### PR TITLE
docs: toFQDNs intro example collects DNS data

### DIFF
--- a/examples/policies/l3/fqdn/fqdn.json
+++ b/examples/policies/l3/fqdn/fqdn.json
@@ -13,6 +13,21 @@
               "app-type": "dns"
             }
           }
+        ],
+        "toPorts": [
+          {
+            "ports": [
+              {
+                "port": "53",
+                "protocol": "ANY"
+              }
+            ],
+            "rules": {
+              "dns": [
+                { "matchPattern": "*" }
+              ]
+            }
+          }
         ]
       },
       {

--- a/examples/policies/l3/fqdn/fqdn.yaml
+++ b/examples/policies/l3/fqdn/fqdn.yaml
@@ -11,5 +11,12 @@ spec:
       - matchLabels:
           "k8s:io.kubernetes.pod.namespace": kube-system
           "k8s:k8s-app": kube-dns
+      toPorts:
+        - ports:
+           - port: "53"
+             protocol: ANY
+          rules:
+            dns:
+              - matchPattern: "*"
     - toFQDNs:
         - matchName: "my-remote-service.com"

--- a/examples/policies/l7/dns/dns-visibility.yaml
+++ b/examples/policies/l7/dns/dns-visibility.yaml
@@ -18,7 +18,6 @@ spec:
         rules:
           dns:
             - matchPattern: "*"
-
   - toFQDNs:
       - matchName: "cilium.io"
       - matchName: "sub.cilium.io"


### PR DESCRIPTION
The first toFQDNs policy seen in the docs doesn't include any section to
capture DNS data. Since the poller is off my default, this will likely
be confusing. We now include the needed L7 allow-all rule.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6620)
<!-- Reviewable:end -->
