### PR TITLE
fqdn: Remove *domain.com special case

### DIFF
--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -482,9 +482,6 @@ IPs to be allowed are selected via:
     ``.`` separator. ``*.cilium.io`` will match ``sub.cilium.io`` but not
     ``cilium.io``. ``part*ial.com`` will match ``partial.com`` and
     ``part-extra-ial.com``.
-  * ``*`` at the start of a pattern, with no trailing ``.``, matches a domain
-    and all subdomains. For example, ``*cilium.io`` matches ``sub.cilium.io``
-    and ``cilium.io`` but not ``another.sub.cilium.io``.
   * ``*`` alone matches all names, and inserts all cached DNS IPs into this
     rule.
 
@@ -992,9 +989,6 @@ DNS policy may be applied via:
     ``.`` separator. ``*.cilium.io`` will match ``sub.cilium.io`` but not
     ``cilium.io``. ``part*ial.com`` will match ``partial.com`` and
     ``part-extra-ial.com``.
-  * ``*`` at the start of a pattern, with no trailing ``.``, matches a domain
-    and all subdomains. For example, ``*cilium.io`` matches ``sub.cilium.io``
-    and ``cilium.io`` but not ``another.sub.cilium.io``.
   * ``*`` alone matches all names, and inserts all IPs in DNS responses into
     the cilium-agent DNS cache.
 

--- a/pkg/fqdn/matchpattern/matchpattern.go
+++ b/pkg/fqdn/matchpattern/matchpattern.go
@@ -38,10 +38,6 @@ func Validate(pattern string) error {
 	return err
 }
 
-// isSubAndDomainSpecial checks that the first two characters are * followed by
-// a valid DNS character that isn't a .
-var isSubAndDomainSpecial = regexp.MustCompile("^[*]" + allowedDNSCharsREGroup)
-
 // Sanitize canonicalized the pattern for use by ToRegexp
 func Sanitize(pattern string) string {
 	if pattern == "*" {
@@ -55,7 +51,6 @@ func Sanitize(pattern string) string {
 // validate the pattern.
 // It supports:
 // * to select 0 or more DNS valid characters
-// *domain.com to select the domain and it's subdomains
 func ToRegexp(pattern string) string {
 	pattern = strings.TrimSpace(pattern)
 	pattern = strings.ToLower(pattern)
@@ -63,13 +58,6 @@ func ToRegexp(pattern string) string {
 	// handle the * match-all case. This will filter down to the end.
 	if pattern == "*" {
 		pattern = "(" + allowedDNSCharsREGroup + "+.)+"
-	}
-
-	// handle *domain.com case
-	if isSubAndDomainSpecial.MatchString(pattern) {
-		// the + at the start of the string affect the allowed chars
-		// the . will be turned into [.] in the base case below
-		pattern = "(" + allowedDNSCharsREGroup + "+.)?" + pattern[1:]
 	}
 
 	// base case. * becomes .*, but only for DNS valid characters

--- a/pkg/fqdn/matchpattern/matchpattern_test.go
+++ b/pkg/fqdn/matchpattern/matchpattern_test.go
@@ -42,7 +42,6 @@ func (ts *MatchPatternTestSuite) TestMatchPatternREConversion(c *C) {
 	for source, target := range map[string]string{
 		"cilium.io.":   "^cilium[.]io[.]$",
 		"*.cilium.io.": "^" + allowedDNSCharsREGroup + "*[.]cilium[.]io[.]$",
-		"*cilium.io.":  "^(" + allowedDNSCharsREGroup + "+[.])?cilium[.]io[.]$",
 		"*":            "^(" + allowedDNSCharsREGroup + "+[.])+$",
 	} {
 		reStr := ToRegexp(source)
@@ -74,11 +73,6 @@ func (ts *MatchPatternTestSuite) TestMatchPatternMatching(c *C) {
 			reject:  []string{"", "cilium.io.", "anysub.ci.io.", "anysub.ciliumandmore.io."},
 		},
 		{
-			pattern: "*cilium.io.",
-			accept:  []string{"anysub.cilium.io.", "cilium.io."},
-			reject:  []string{"", "anysub.ci.io.", "anysub.ciliumandmore.io."},
-		},
-		{
 			pattern: "*.ci*.io.",
 			accept:  []string{"anysub.cilium.io.", "anysub.ci.io.", "anysub.ciliumandmore.io."},
 			reject:  []string{"", "cilium.io."},
@@ -104,10 +98,9 @@ func (ts *MatchPatternTestSuite) TestMatchPatternMatching(c *C) {
 // TestMatchPatternSanitize tests that Sanitize handles any special cases
 func (ts *MatchPatternTestSuite) TestMatchPatternSanitize(c *C) {
 	for source, target := range map[string]string{
-		"*":          "*",
-		"*.":         "*.",
-		"*cilium.io": "*cilium.io.",
-		"*.com":      "*.com.",
+		"*":     "*",
+		"*.":    "*.",
+		"*.com": "*.com.",
 	} {
 		sanitized := Sanitize(source)
 		c.Assert(sanitized, Equals, target, Commentf("matchPattern: %s not sanitized correctly", source))


### PR DESCRIPTION
We handled *domain.com as a special case, internally transforming it
into domain.com and *.domain.com. While convenient, the same effect is
possible with two separate but adjacent matchName or matchPattern rules.
On the other hand, the special casing disallows matching a prefix on the
left-most subdomain or domain. Given how easy it is to get the same
outcomes otherwise, it seems safer to remove the special case until it
is clear we need it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6622)
<!-- Reviewable:end -->
