### PR TITLE
fqdn: DNSPoller emits lookups as accesslog/monitor events

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -93,6 +93,7 @@ cilium-agent [flags]
       --state-dir string                            Directory path to store runtime state (default "/var/run/cilium")
       --tofqdns-dns-reject-response-code string     DNS response code for rejecting DNS requests, available options are '[nameError refused]' (default "refused")
       --tofqdns-enable-poller                       Enable proactive polling of DNS names in toFQDNs.matchName rules.
+      --tofqdns-enable-poller-events                Emit DNS responses seen by the DNS poller as Monitor events, if the poller is enabled. (default true)
       --tofqdns-min-ttl int                         The minimum time, in seconds, to use DNS data for toFQDNs policies. (default 3600 when --tofqdns-enable-poller, 604800 otherwise)
       --tofqdns-proxy-port int                      Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port.
       --trace-payloadlen int                        Length of payload to capture when tracing (default 128)

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -614,6 +614,9 @@ func init() {
 	flags.Bool(option.ToFQDNsEnablePoller, false, "Enable proactive polling of DNS names in toFQDNs.matchName rules.")
 	option.BindEnv(option.ToFQDNsEnablePoller)
 
+	flags.Bool(option.ToFQDNsEnablePollerEvents, true, "Emit DNS responses seen by the DNS poller as Monitor events, if the poller is enabled.")
+	option.BindEnv(option.ToFQDNsEnablePollerEvents)
+
 	flags.StringVar(&option.Config.FQDNRejectResponse, option.FQDNRejectResponseCode, option.FQDNProxyDenyWithRefused, fmt.Sprintf("DNS response code for rejecting DNS requests, available options are '%v'", option.FQDNRejectOptions))
 	viper.BindEnv(option.FQDNRejectResponseCode, option.FQDNRejectResponseCodeEnv)
 

--- a/pkg/fqdn/config.go
+++ b/pkg/fqdn/config.go
@@ -15,6 +15,8 @@
 package fqdn
 
 import (
+	"time"
+
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/miekg/dns"
 )
@@ -43,4 +45,10 @@ type Config struct {
 	// AddGeneratedRules is a callback  to emit generated rules.
 	// When set to nil, it is a no-op.
 	AddGeneratedRules func([]*api.Rule) error
+
+	// PollerResponseNotify is used when the poller recieves DNS data in response
+	// to a successful poll.
+	// Note: This function doesn't do much, as the poller is still wired to
+	// RuleGen directly right now.
+	PollerResponseNotify func(lookupTime time.Time, qname string, response *DNSIPRecords)
 }

--- a/pkg/monitor/logrecord.go
+++ b/pkg/monitor/logrecord.go
@@ -85,7 +85,11 @@ func (l *LogRecordNotify) DumpInfo() {
 			fmt.Printf(" DNS Query: %s", l.DNS.Query)
 
 		case l.Type == accesslog.TypeResponse:
-			fmt.Printf(" DNS Query: %s", l.DNS.Query)
+			sourceType := "Query"
+			if l.DNS.ObservationSource == accesslog.DNSSourceAgentPoller {
+				sourceType = "Poll"
+			}
+			fmt.Printf(" DNS %s: %s", sourceType, l.DNS.Query)
 
 			ips := make([]string, 0, len(l.DNS.IPs))
 			for _, ip := range l.DNS.IPs {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -239,6 +239,9 @@ const (
 	// ToFQDNsEnablePoller enables proactive polling of DNS names in toFQDNs.matchName rules.
 	ToFQDNsEnablePoller = "tofqdns-enable-poller"
 
+	// ToFQDNsEmitPollerEvents controls if poller lookups are sent as monitor events
+	ToFQDNsEnablePollerEvents = "tofqdns-enable-poller-events"
+
 	// AutoIPv6NodeRoutesName is the name of the AutoIPv6NodeRoutes option
 	AutoIPv6NodeRoutesName = "auto-ipv6-node-routes"
 
@@ -660,8 +663,14 @@ type DaemonConfig struct {
 	// by the DNS Proxy. Both UDP and TCP are handled on the same port. When it
 	// is 0 a random port will be assigned, and can be obtained from
 	// DefaultDNSProxy below.
-	ToFQDNsProxyPort    int
+	ToFQDNsProxyPort int
+
+	// ToFQDNsEnablePoller enables the DNS poller that polls toFQDNs.matchName
 	ToFQDNsEnablePoller bool
+
+	// ToFQDNsEnablePollerEvents controls sending a monitor event for each DNS
+	// response the DNS poller sees
+	ToFQDNsEnablePollerEvents bool
 
 	// FQDNRejectResponse is the dns-proxy response for invalid dns-proxy request
 	FQDNRejectResponse string
@@ -877,6 +886,7 @@ func (c *DaemonConfig) Populate() {
 	// every 5s). Without the poller, a longer default is better because it
 	// avoids confusion about dropped connections.
 	c.ToFQDNsEnablePoller = viper.GetBool(ToFQDNsEnablePoller)
+	c.ToFQDNsEnablePollerEvents = viper.GetBool(ToFQDNsEnablePollerEvents)
 	userSetMinTTL := viper.GetInt(ToFQDNsMinTTL)
 	switch {
 	case userSetMinTTL != 0: // set by user

--- a/pkg/proxy/accesslog/record.go
+++ b/pkg/proxy/accesslog/record.go
@@ -248,6 +248,18 @@ type LogRecordKafka struct {
 	Topic KafkaTopic
 }
 
+type DNSDataSource string
+
+const (
+	// DNSSourceAgentPoller indicates that the DNS record was created by a poll
+	// from cilium-agent.
+	DNSSourceAgentPoller DNSDataSource = "agent-poller"
+
+	// DNSSourceProxy indicates that the DNS record was created by a proxy
+	// intercepting a DNS request/response.
+	DNSSourceProxy DNSDataSource = "proxy"
+)
+
 // LogRecordDNS contains the DNS specific portion of a log record
 type LogRecordDNS struct {
 	// Query is the name in the original query
@@ -265,6 +277,11 @@ type LogRecordDNS struct {
 	// to the IPs.
 	// This field is filled only for DNS responses with CNAMEs to IP data.
 	CNAMEs []string `json:"CNAMEs,omitempty"`
+
+	// ObservationSource represents the source of the data in this LogRecordDNS.
+	// Empty or undefined may indicate older cilium versions, as it is expected
+	// to be filled in.
+	ObservationSource DNSDataSource `json:"ObservationSource,omitempty"`
 }
 
 // LogRecordL7 contains the generic L7 portion of a log record


### PR DESCRIPTION
_This is a jankier PR than I would like. There is a bunch of refactoring needed to normalise how DNSPoller, RuleGen and DNSProxy interact with daemon. I didn't want to squeeze that into 1.4._

When relying on monitor events to correlate DNS data to later
connections, information discovered by the poller was lost. These
lookups are now emitted.

```
<- Response dns from 0 ([]) to 0 ([]), identity 0->0, verdict Forwarded DNS Query: google.com. TTL: 273 Answer: '216.58.215.238,2a00:1450:400a:800::200e'
<- Response dns from 0 ([]) to 0 ([]), identity 0->0, verdict Forwarded DNS Query: google.com. TTL: 237 Answer: '216.58.215.238,2a00:1450:400a:800::200e'
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6623)
<!-- Reviewable:end -->
