### PR TITLE
agent: Fix endpoint restore with unmounted BPF filesystem

### DIFF
--- a/pkg/maps/lxcmap/lxcmap.go
+++ b/pkg/maps/lxcmap/lxcmap.go
@@ -220,7 +220,7 @@ func DumpToMap() (map[string]*EndpointInfo, error) {
 	}
 
 	if err := LXCMap.DumpWithCallback(callback); err != nil {
-		return m, fmt.Errorf("unable to read BPF endpoint list: %s", err)
+		return nil, fmt.Errorf("unable to read BPF endpoint list: %s", err)
 	}
 
 	return m, nil


### PR DESCRIPTION
The function Daemon.restoreOldEndpoints() had errored out when the endpoint BPF
map could not be opened. This would prevent restoring of endpoints when the BPF
filesystem was not mounted. The error does not matter if we can't open the map
as the map will be initialized from scratch and no cleaning up of old
potentially stale entries is necessary.

Fixes: 4ecf111c35f ("agent: Fix temporary corruption of BPF endpoint map on restart")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6624)
<!-- Reviewable:end -->
