### PR TITLE
client: Fix a possible NULL pointer dereference of localNode

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -269,10 +269,12 @@ func FormatStatusResponse(w io.Writer, sr *models.StatusResponse, allAddresses, 
 	}
 
 	if sr.IPAM != nil {
-		var v4CIDR, v6CIDR string
-		v4AllocRange := localNode.PrimaryAddress.IPV4.AllocRange
-		v6AllocRange := localNode.PrimaryAddress.IPV6.AllocRange
+		var v4CIDR, v6CIDR, v4AllocRangeFmt, v6AllocRangeFmt string
 		if localNode != nil {
+			v4AllocRange := localNode.PrimaryAddress.IPV4.AllocRange
+			v6AllocRange := localNode.PrimaryAddress.IPV6.AllocRange
+			v4AllocRangeFmt = fmt.Sprintf(" allocated from %s", v4AllocRange)
+			v6AllocRangeFmt = fmt.Sprintf(" allocated from %s", v6AllocRange)
 			if nIPs := ip.CountIPsInCIDR(v4AllocRange); nIPs > 0 {
 				v4CIDR = fmt.Sprintf("/%d", nIPs)
 			}
@@ -280,13 +282,13 @@ func FormatStatusResponse(w io.Writer, sr *models.StatusResponse, allAddresses, 
 				v6CIDR = fmt.Sprintf("/%d", nIPs)
 			}
 		}
-		fmt.Fprintf(w, "IPv4 address pool:\t%d%s allocated from %s\n", len(sr.IPAM.IPV4), v4CIDR, v4AllocRange)
+		fmt.Fprintf(w, "IPv4 address pool:\t%d%s%s\n", len(sr.IPAM.IPV4), v4CIDR, v4AllocRangeFmt)
 		if allAddresses {
 			for _, ipv4 := range sr.IPAM.IPV4 {
 				fmt.Fprintf(w, "  %s\n", ipv4)
 			}
 		}
-		fmt.Fprintf(w, "IPv6 address pool:\t%d%s allocated from %s\n", len(sr.IPAM.IPV6), v6CIDR, v6AllocRange)
+		fmt.Fprintf(w, "IPv6 address pool:\t%d%s%s\n", len(sr.IPAM.IPV6), v6CIDR, v6AllocRangeFmt)
 		if allAddresses {
 			for _, ipv6 := range sr.IPAM.IPV6 {
 				fmt.Fprintf(w, "  %s\n", ipv6)


### PR DESCRIPTION
Also, do not print `v{4,6}AllocRange` in a status report if it's missing.

Caught by CI (https://jenkins.cilium.io/job/cilium-ginkgo/job/cilium/job/master/2129/testReport/junit/k8s-1/8/K8sChaosTest_Connectivity_demo_application_Endpoint_can_still_connect_while_Cilium_is_not_running/):

```
panic: runtime error: invalid memory address or nil pointer dereference
<..>
github.com/cilium/cilium/pkg/client.FormatStatusResponse(0x2ed1fe0, 0xc0004306e0, 0xc000444fc0, 0x10000)
    /go/src/github.com/cilium/cilium/pkg/client/client.go:273
```

Fixes: e84db5e ("client: Print IPAM range in cilium status")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6628)
<!-- Reviewable:end -->
