### PR TITLE
kubernetes: Fix terminationGracePeriodSeconds for minikube example YAMLs

### DIFF
--- a/examples/kubernetes/1.10/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-minikube-ds.yaml
@@ -218,7 +218,7 @@ spec:
       restartPolicy: Always
       serviceAccount: cilium
       serviceAccountName: cilium
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 1
       tolerations:
       - operator: Exists
       volumes:

--- a/examples/kubernetes/1.10/cilium-minikube.yaml
+++ b/examples/kubernetes/1.10/cilium-minikube.yaml
@@ -325,7 +325,7 @@ spec:
       restartPolicy: Always
       serviceAccount: cilium
       serviceAccountName: cilium
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 1
       tolerations:
       - operator: Exists
       volumes:

--- a/examples/kubernetes/1.11/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-minikube-ds.yaml
@@ -219,7 +219,7 @@ spec:
       restartPolicy: Always
       serviceAccount: cilium
       serviceAccountName: cilium
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 1
       tolerations:
       - operator: Exists
       volumes:

--- a/examples/kubernetes/1.11/cilium-minikube.yaml
+++ b/examples/kubernetes/1.11/cilium-minikube.yaml
@@ -326,7 +326,7 @@ spec:
       restartPolicy: Always
       serviceAccount: cilium
       serviceAccountName: cilium
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 1
       tolerations:
       - operator: Exists
       volumes:

--- a/examples/kubernetes/1.12/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-minikube-ds.yaml
@@ -219,7 +219,7 @@ spec:
       restartPolicy: Always
       serviceAccount: cilium
       serviceAccountName: cilium
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 1
       tolerations:
       - operator: Exists
       volumes:

--- a/examples/kubernetes/1.12/cilium-minikube.yaml
+++ b/examples/kubernetes/1.12/cilium-minikube.yaml
@@ -326,7 +326,7 @@ spec:
       restartPolicy: Always
       serviceAccount: cilium
       serviceAccountName: cilium
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 1
       tolerations:
       - operator: Exists
       volumes:

--- a/examples/kubernetes/1.13/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-minikube-ds.yaml
@@ -219,7 +219,7 @@ spec:
       restartPolicy: Always
       serviceAccount: cilium
       serviceAccountName: cilium
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 1
       tolerations:
       - operator: Exists
       volumes:

--- a/examples/kubernetes/1.13/cilium-minikube.yaml
+++ b/examples/kubernetes/1.13/cilium-minikube.yaml
@@ -326,7 +326,7 @@ spec:
       restartPolicy: Always
       serviceAccount: cilium
       serviceAccountName: cilium
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 1
       tolerations:
       - operator: Exists
       volumes:

--- a/examples/kubernetes/1.8/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-minikube-ds.yaml
@@ -218,7 +218,7 @@ spec:
       restartPolicy: Always
       serviceAccount: cilium
       serviceAccountName: cilium
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 1
       tolerations:
       - operator: Exists
       volumes:

--- a/examples/kubernetes/1.8/cilium-minikube.yaml
+++ b/examples/kubernetes/1.8/cilium-minikube.yaml
@@ -325,7 +325,7 @@ spec:
       restartPolicy: Always
       serviceAccount: cilium
       serviceAccountName: cilium
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 1
       tolerations:
       - operator: Exists
       volumes:

--- a/examples/kubernetes/1.9/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-minikube-ds.yaml
@@ -218,7 +218,7 @@ spec:
       restartPolicy: Always
       serviceAccount: cilium
       serviceAccountName: cilium
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 1
       tolerations:
       - operator: Exists
       volumes:

--- a/examples/kubernetes/1.9/cilium-minikube.yaml
+++ b/examples/kubernetes/1.9/cilium-minikube.yaml
@@ -325,7 +325,7 @@ spec:
       restartPolicy: Always
       serviceAccount: cilium
       serviceAccountName: cilium
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 1
       tolerations:
       - operator: Exists
       volumes:

--- a/examples/kubernetes/templates/v1/cilium-minikube-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-minikube-ds.yaml.sed
@@ -218,7 +218,7 @@ spec:
       restartPolicy: Always
       serviceAccount: cilium
       serviceAccountName: cilium
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 1
       tolerations:
       - operator: Exists
       volumes:


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6635)
<!-- Reviewable:end -->
