### PR TITLE
daemon: fix legacy-host-allows-world option

### DIFF
--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -465,8 +465,9 @@ func init() {
 	flags.String(option.K8sKubeConfigPath, "", "Absolute path of the kubernetes kubeconfig file")
 	option.BindEnv(option.K8sKubeConfigPath)
 
-	// This needs to be set manually for backward compatibility
 	option.BindEnv(option.K8sLegacyHostAllowsWorld)
+	// This needs to be set manually for backward compatibility
+	viper.BindEnv(option.K8sLegacyHostAllowsWorld, "CILIUM_LEGACY_HOST_ALLOWS_WORLD")
 
 	flags.String(option.K8sNamespaceName, "", "Name of the Kubernetes namespace in which Cilium is deployed in")
 	flags.MarkHidden(option.K8sNamespaceName)


### PR DESCRIPTION
Fixes: 13bb9be3d042 ("{daemon,pkg}: make usage of the option package for CLI options")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6645)
<!-- Reviewable:end -->
