### PR TITLE
Kubernetes: Deprecate ConfigMap option "legacy-host-allows-world"

### DIFF
--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -816,13 +816,13 @@ Furthermore, to allow Kubernetes agents to perform health checks over IP into
 the endpoints, the host is allowed by default. This means that all traffic from
 the outside world is also allowed by default, regardless of security policy.
 
+This behaviour was disabled in Cilium 1.1 or later.
+
 Affected versions
 ~~~~~~~~~~~~~~~~~
 
 * Cilium 1.0 or earlier deployed using the DaemonSet and ConfigMap YAMLs
-  provided with that release, or
-* Later versions of Cilium deployed using the YAMLs provided with Cilium 1.0 or
-  earlier.
+  provided with that release.
 
 Affected environments will see no output for one or more of the below commands:
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -915,9 +915,11 @@ func NewDaemon() (*Daemon, *endpointRestoreState, error) {
 		// from the outside world on ingress was treated as though it
 		// was from the host for policy purposes. In order to not break
 		// existing policies, this option retains the behavior.
-		if option.Config.K8sLegacyHostAllowsWorld != "false" {
+		if option.Config.K8sLegacyHostAllowsWorld == "true" {
+			log.Warn("k8s mode: Configuring ingress policy for host to also allow from world. This option will be removed in Cilium 1.5. For more information, see https://cilium.link/host-vs-world")
 			option.Config.HostAllowsWorld = true
-			log.Warn("k8s mode: Configuring ingress policy for host to also allow from world. For more information, see https://cilium.link/host-vs-world")
+		} else {
+			option.Config.HostAllowsWorld = false
 		}
 	}
 

--- a/examples/kubernetes/1.10/cilium-cm.yaml
+++ b/examples/kubernetes/1.10/cilium-cm.yaml
@@ -49,7 +49,23 @@ data:
   # backend after restart.
   clean-cilium-bpf-state: "false"
 
-  legacy-host-allows-world: "false"
+  # In Cilium 1.0, all traffic from the host, including from local processes
+  # and traffic that is masqueraded from the outside world to the host IP,
+  # would be classified as from the host entity (reserved:host label).
+  # Furthermore, to allow Kubernetes agents to perform health checks over IP
+  # into the endpoints, the host is allowed by default. This means that all
+  # traffic from the outside world is also allowed by default, regardless of
+  # security policy.
+  #
+  # This option was introduced in Cilium 1.1 to disable this behaviour. It must
+  # be explicitly set to "false" to take effect on Cilium 1.3 or earlier.
+  # Cilium 1.4 sets this to "false" by default if it is not specified in the
+  # ConfigMap.
+  #
+  # This option has been deprecated, it will be removed in Cilium 1.5 or later.
+  #
+  # For more information, see https://cilium.link/host-vs-world
+  #legacy-host-allows-world: "false"
 
   # If you want cilium monitor to aggregate tracing for packets, set this level
   # to "low", "medium", or "maximum". The higher the level, the less packets

--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -49,7 +49,23 @@ data:
   # backend after restart.
   clean-cilium-bpf-state: "false"
 
-  legacy-host-allows-world: "false"
+  # In Cilium 1.0, all traffic from the host, including from local processes
+  # and traffic that is masqueraded from the outside world to the host IP,
+  # would be classified as from the host entity (reserved:host label).
+  # Furthermore, to allow Kubernetes agents to perform health checks over IP
+  # into the endpoints, the host is allowed by default. This means that all
+  # traffic from the outside world is also allowed by default, regardless of
+  # security policy.
+  #
+  # This option was introduced in Cilium 1.1 to disable this behaviour. It must
+  # be explicitly set to "false" to take effect on Cilium 1.3 or earlier.
+  # Cilium 1.4 sets this to "false" by default if it is not specified in the
+  # ConfigMap.
+  #
+  # This option has been deprecated, it will be removed in Cilium 1.5 or later.
+  #
+  # For more information, see https://cilium.link/host-vs-world
+  #legacy-host-allows-world: "false"
 
   # If you want cilium monitor to aggregate tracing for packets, set this level
   # to "low", "medium", or "maximum". The higher the level, the less packets

--- a/examples/kubernetes/1.10/cilium-minikube.yaml
+++ b/examples/kubernetes/1.10/cilium-minikube.yaml
@@ -49,7 +49,23 @@ data:
   # backend after restart.
   clean-cilium-bpf-state: "false"
 
-  legacy-host-allows-world: "false"
+  # In Cilium 1.0, all traffic from the host, including from local processes
+  # and traffic that is masqueraded from the outside world to the host IP,
+  # would be classified as from the host entity (reserved:host label).
+  # Furthermore, to allow Kubernetes agents to perform health checks over IP
+  # into the endpoints, the host is allowed by default. This means that all
+  # traffic from the outside world is also allowed by default, regardless of
+  # security policy.
+  #
+  # This option was introduced in Cilium 1.1 to disable this behaviour. It must
+  # be explicitly set to "false" to take effect on Cilium 1.3 or earlier.
+  # Cilium 1.4 sets this to "false" by default if it is not specified in the
+  # ConfigMap.
+  #
+  # This option has been deprecated, it will be removed in Cilium 1.5 or later.
+  #
+  # For more information, see https://cilium.link/host-vs-world
+  #legacy-host-allows-world: "false"
 
   # If you want cilium monitor to aggregate tracing for packets, set this level
   # to "low", "medium", or "maximum". The higher the level, the less packets

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -49,7 +49,23 @@ data:
   # backend after restart.
   clean-cilium-bpf-state: "false"
 
-  legacy-host-allows-world: "false"
+  # In Cilium 1.0, all traffic from the host, including from local processes
+  # and traffic that is masqueraded from the outside world to the host IP,
+  # would be classified as from the host entity (reserved:host label).
+  # Furthermore, to allow Kubernetes agents to perform health checks over IP
+  # into the endpoints, the host is allowed by default. This means that all
+  # traffic from the outside world is also allowed by default, regardless of
+  # security policy.
+  #
+  # This option was introduced in Cilium 1.1 to disable this behaviour. It must
+  # be explicitly set to "false" to take effect on Cilium 1.3 or earlier.
+  # Cilium 1.4 sets this to "false" by default if it is not specified in the
+  # ConfigMap.
+  #
+  # This option has been deprecated, it will be removed in Cilium 1.5 or later.
+  #
+  # For more information, see https://cilium.link/host-vs-world
+  #legacy-host-allows-world: "false"
 
   # If you want cilium monitor to aggregate tracing for packets, set this level
   # to "low", "medium", or "maximum". The higher the level, the less packets

--- a/examples/kubernetes/1.11/cilium-cm.yaml
+++ b/examples/kubernetes/1.11/cilium-cm.yaml
@@ -49,7 +49,23 @@ data:
   # backend after restart.
   clean-cilium-bpf-state: "false"
 
-  legacy-host-allows-world: "false"
+  # In Cilium 1.0, all traffic from the host, including from local processes
+  # and traffic that is masqueraded from the outside world to the host IP,
+  # would be classified as from the host entity (reserved:host label).
+  # Furthermore, to allow Kubernetes agents to perform health checks over IP
+  # into the endpoints, the host is allowed by default. This means that all
+  # traffic from the outside world is also allowed by default, regardless of
+  # security policy.
+  #
+  # This option was introduced in Cilium 1.1 to disable this behaviour. It must
+  # be explicitly set to "false" to take effect on Cilium 1.3 or earlier.
+  # Cilium 1.4 sets this to "false" by default if it is not specified in the
+  # ConfigMap.
+  #
+  # This option has been deprecated, it will be removed in Cilium 1.5 or later.
+  #
+  # For more information, see https://cilium.link/host-vs-world
+  #legacy-host-allows-world: "false"
 
   # If you want cilium monitor to aggregate tracing for packets, set this level
   # to "low", "medium", or "maximum". The higher the level, the less packets

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -49,7 +49,23 @@ data:
   # backend after restart.
   clean-cilium-bpf-state: "false"
 
-  legacy-host-allows-world: "false"
+  # In Cilium 1.0, all traffic from the host, including from local processes
+  # and traffic that is masqueraded from the outside world to the host IP,
+  # would be classified as from the host entity (reserved:host label).
+  # Furthermore, to allow Kubernetes agents to perform health checks over IP
+  # into the endpoints, the host is allowed by default. This means that all
+  # traffic from the outside world is also allowed by default, regardless of
+  # security policy.
+  #
+  # This option was introduced in Cilium 1.1 to disable this behaviour. It must
+  # be explicitly set to "false" to take effect on Cilium 1.3 or earlier.
+  # Cilium 1.4 sets this to "false" by default if it is not specified in the
+  # ConfigMap.
+  #
+  # This option has been deprecated, it will be removed in Cilium 1.5 or later.
+  #
+  # For more information, see https://cilium.link/host-vs-world
+  #legacy-host-allows-world: "false"
 
   # If you want cilium monitor to aggregate tracing for packets, set this level
   # to "low", "medium", or "maximum". The higher the level, the less packets

--- a/examples/kubernetes/1.11/cilium-minikube.yaml
+++ b/examples/kubernetes/1.11/cilium-minikube.yaml
@@ -49,7 +49,23 @@ data:
   # backend after restart.
   clean-cilium-bpf-state: "false"
 
-  legacy-host-allows-world: "false"
+  # In Cilium 1.0, all traffic from the host, including from local processes
+  # and traffic that is masqueraded from the outside world to the host IP,
+  # would be classified as from the host entity (reserved:host label).
+  # Furthermore, to allow Kubernetes agents to perform health checks over IP
+  # into the endpoints, the host is allowed by default. This means that all
+  # traffic from the outside world is also allowed by default, regardless of
+  # security policy.
+  #
+  # This option was introduced in Cilium 1.1 to disable this behaviour. It must
+  # be explicitly set to "false" to take effect on Cilium 1.3 or earlier.
+  # Cilium 1.4 sets this to "false" by default if it is not specified in the
+  # ConfigMap.
+  #
+  # This option has been deprecated, it will be removed in Cilium 1.5 or later.
+  #
+  # For more information, see https://cilium.link/host-vs-world
+  #legacy-host-allows-world: "false"
 
   # If you want cilium monitor to aggregate tracing for packets, set this level
   # to "low", "medium", or "maximum". The higher the level, the less packets

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -49,7 +49,23 @@ data:
   # backend after restart.
   clean-cilium-bpf-state: "false"
 
-  legacy-host-allows-world: "false"
+  # In Cilium 1.0, all traffic from the host, including from local processes
+  # and traffic that is masqueraded from the outside world to the host IP,
+  # would be classified as from the host entity (reserved:host label).
+  # Furthermore, to allow Kubernetes agents to perform health checks over IP
+  # into the endpoints, the host is allowed by default. This means that all
+  # traffic from the outside world is also allowed by default, regardless of
+  # security policy.
+  #
+  # This option was introduced in Cilium 1.1 to disable this behaviour. It must
+  # be explicitly set to "false" to take effect on Cilium 1.3 or earlier.
+  # Cilium 1.4 sets this to "false" by default if it is not specified in the
+  # ConfigMap.
+  #
+  # This option has been deprecated, it will be removed in Cilium 1.5 or later.
+  #
+  # For more information, see https://cilium.link/host-vs-world
+  #legacy-host-allows-world: "false"
 
   # If you want cilium monitor to aggregate tracing for packets, set this level
   # to "low", "medium", or "maximum". The higher the level, the less packets

--- a/examples/kubernetes/1.12/cilium-cm.yaml
+++ b/examples/kubernetes/1.12/cilium-cm.yaml
@@ -49,7 +49,23 @@ data:
   # backend after restart.
   clean-cilium-bpf-state: "false"
 
-  legacy-host-allows-world: "false"
+  # In Cilium 1.0, all traffic from the host, including from local processes
+  # and traffic that is masqueraded from the outside world to the host IP,
+  # would be classified as from the host entity (reserved:host label).
+  # Furthermore, to allow Kubernetes agents to perform health checks over IP
+  # into the endpoints, the host is allowed by default. This means that all
+  # traffic from the outside world is also allowed by default, regardless of
+  # security policy.
+  #
+  # This option was introduced in Cilium 1.1 to disable this behaviour. It must
+  # be explicitly set to "false" to take effect on Cilium 1.3 or earlier.
+  # Cilium 1.4 sets this to "false" by default if it is not specified in the
+  # ConfigMap.
+  #
+  # This option has been deprecated, it will be removed in Cilium 1.5 or later.
+  #
+  # For more information, see https://cilium.link/host-vs-world
+  #legacy-host-allows-world: "false"
 
   # If you want cilium monitor to aggregate tracing for packets, set this level
   # to "low", "medium", or "maximum". The higher the level, the less packets

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -49,7 +49,23 @@ data:
   # backend after restart.
   clean-cilium-bpf-state: "false"
 
-  legacy-host-allows-world: "false"
+  # In Cilium 1.0, all traffic from the host, including from local processes
+  # and traffic that is masqueraded from the outside world to the host IP,
+  # would be classified as from the host entity (reserved:host label).
+  # Furthermore, to allow Kubernetes agents to perform health checks over IP
+  # into the endpoints, the host is allowed by default. This means that all
+  # traffic from the outside world is also allowed by default, regardless of
+  # security policy.
+  #
+  # This option was introduced in Cilium 1.1 to disable this behaviour. It must
+  # be explicitly set to "false" to take effect on Cilium 1.3 or earlier.
+  # Cilium 1.4 sets this to "false" by default if it is not specified in the
+  # ConfigMap.
+  #
+  # This option has been deprecated, it will be removed in Cilium 1.5 or later.
+  #
+  # For more information, see https://cilium.link/host-vs-world
+  #legacy-host-allows-world: "false"
 
   # If you want cilium monitor to aggregate tracing for packets, set this level
   # to "low", "medium", or "maximum". The higher the level, the less packets

--- a/examples/kubernetes/1.12/cilium-minikube.yaml
+++ b/examples/kubernetes/1.12/cilium-minikube.yaml
@@ -49,7 +49,23 @@ data:
   # backend after restart.
   clean-cilium-bpf-state: "false"
 
-  legacy-host-allows-world: "false"
+  # In Cilium 1.0, all traffic from the host, including from local processes
+  # and traffic that is masqueraded from the outside world to the host IP,
+  # would be classified as from the host entity (reserved:host label).
+  # Furthermore, to allow Kubernetes agents to perform health checks over IP
+  # into the endpoints, the host is allowed by default. This means that all
+  # traffic from the outside world is also allowed by default, regardless of
+  # security policy.
+  #
+  # This option was introduced in Cilium 1.1 to disable this behaviour. It must
+  # be explicitly set to "false" to take effect on Cilium 1.3 or earlier.
+  # Cilium 1.4 sets this to "false" by default if it is not specified in the
+  # ConfigMap.
+  #
+  # This option has been deprecated, it will be removed in Cilium 1.5 or later.
+  #
+  # For more information, see https://cilium.link/host-vs-world
+  #legacy-host-allows-world: "false"
 
   # If you want cilium monitor to aggregate tracing for packets, set this level
   # to "low", "medium", or "maximum". The higher the level, the less packets

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -49,7 +49,23 @@ data:
   # backend after restart.
   clean-cilium-bpf-state: "false"
 
-  legacy-host-allows-world: "false"
+  # In Cilium 1.0, all traffic from the host, including from local processes
+  # and traffic that is masqueraded from the outside world to the host IP,
+  # would be classified as from the host entity (reserved:host label).
+  # Furthermore, to allow Kubernetes agents to perform health checks over IP
+  # into the endpoints, the host is allowed by default. This means that all
+  # traffic from the outside world is also allowed by default, regardless of
+  # security policy.
+  #
+  # This option was introduced in Cilium 1.1 to disable this behaviour. It must
+  # be explicitly set to "false" to take effect on Cilium 1.3 or earlier.
+  # Cilium 1.4 sets this to "false" by default if it is not specified in the
+  # ConfigMap.
+  #
+  # This option has been deprecated, it will be removed in Cilium 1.5 or later.
+  #
+  # For more information, see https://cilium.link/host-vs-world
+  #legacy-host-allows-world: "false"
 
   # If you want cilium monitor to aggregate tracing for packets, set this level
   # to "low", "medium", or "maximum". The higher the level, the less packets

--- a/examples/kubernetes/1.13/cilium-cm.yaml
+++ b/examples/kubernetes/1.13/cilium-cm.yaml
@@ -49,7 +49,23 @@ data:
   # backend after restart.
   clean-cilium-bpf-state: "false"
 
-  legacy-host-allows-world: "false"
+  # In Cilium 1.0, all traffic from the host, including from local processes
+  # and traffic that is masqueraded from the outside world to the host IP,
+  # would be classified as from the host entity (reserved:host label).
+  # Furthermore, to allow Kubernetes agents to perform health checks over IP
+  # into the endpoints, the host is allowed by default. This means that all
+  # traffic from the outside world is also allowed by default, regardless of
+  # security policy.
+  #
+  # This option was introduced in Cilium 1.1 to disable this behaviour. It must
+  # be explicitly set to "false" to take effect on Cilium 1.3 or earlier.
+  # Cilium 1.4 sets this to "false" by default if it is not specified in the
+  # ConfigMap.
+  #
+  # This option has been deprecated, it will be removed in Cilium 1.5 or later.
+  #
+  # For more information, see https://cilium.link/host-vs-world
+  #legacy-host-allows-world: "false"
 
   # If you want cilium monitor to aggregate tracing for packets, set this level
   # to "low", "medium", or "maximum". The higher the level, the less packets

--- a/examples/kubernetes/1.13/cilium-crio.yaml
+++ b/examples/kubernetes/1.13/cilium-crio.yaml
@@ -49,7 +49,23 @@ data:
   # backend after restart.
   clean-cilium-bpf-state: "false"
 
-  legacy-host-allows-world: "false"
+  # In Cilium 1.0, all traffic from the host, including from local processes
+  # and traffic that is masqueraded from the outside world to the host IP,
+  # would be classified as from the host entity (reserved:host label).
+  # Furthermore, to allow Kubernetes agents to perform health checks over IP
+  # into the endpoints, the host is allowed by default. This means that all
+  # traffic from the outside world is also allowed by default, regardless of
+  # security policy.
+  #
+  # This option was introduced in Cilium 1.1 to disable this behaviour. It must
+  # be explicitly set to "false" to take effect on Cilium 1.3 or earlier.
+  # Cilium 1.4 sets this to "false" by default if it is not specified in the
+  # ConfigMap.
+  #
+  # This option has been deprecated, it will be removed in Cilium 1.5 or later.
+  #
+  # For more information, see https://cilium.link/host-vs-world
+  #legacy-host-allows-world: "false"
 
   # If you want cilium monitor to aggregate tracing for packets, set this level
   # to "low", "medium", or "maximum". The higher the level, the less packets

--- a/examples/kubernetes/1.13/cilium-minikube.yaml
+++ b/examples/kubernetes/1.13/cilium-minikube.yaml
@@ -49,7 +49,23 @@ data:
   # backend after restart.
   clean-cilium-bpf-state: "false"
 
-  legacy-host-allows-world: "false"
+  # In Cilium 1.0, all traffic from the host, including from local processes
+  # and traffic that is masqueraded from the outside world to the host IP,
+  # would be classified as from the host entity (reserved:host label).
+  # Furthermore, to allow Kubernetes agents to perform health checks over IP
+  # into the endpoints, the host is allowed by default. This means that all
+  # traffic from the outside world is also allowed by default, regardless of
+  # security policy.
+  #
+  # This option was introduced in Cilium 1.1 to disable this behaviour. It must
+  # be explicitly set to "false" to take effect on Cilium 1.3 or earlier.
+  # Cilium 1.4 sets this to "false" by default if it is not specified in the
+  # ConfigMap.
+  #
+  # This option has been deprecated, it will be removed in Cilium 1.5 or later.
+  #
+  # For more information, see https://cilium.link/host-vs-world
+  #legacy-host-allows-world: "false"
 
   # If you want cilium monitor to aggregate tracing for packets, set this level
   # to "low", "medium", or "maximum". The higher the level, the less packets

--- a/examples/kubernetes/1.13/cilium.yaml
+++ b/examples/kubernetes/1.13/cilium.yaml
@@ -49,7 +49,23 @@ data:
   # backend after restart.
   clean-cilium-bpf-state: "false"
 
-  legacy-host-allows-world: "false"
+  # In Cilium 1.0, all traffic from the host, including from local processes
+  # and traffic that is masqueraded from the outside world to the host IP,
+  # would be classified as from the host entity (reserved:host label).
+  # Furthermore, to allow Kubernetes agents to perform health checks over IP
+  # into the endpoints, the host is allowed by default. This means that all
+  # traffic from the outside world is also allowed by default, regardless of
+  # security policy.
+  #
+  # This option was introduced in Cilium 1.1 to disable this behaviour. It must
+  # be explicitly set to "false" to take effect on Cilium 1.3 or earlier.
+  # Cilium 1.4 sets this to "false" by default if it is not specified in the
+  # ConfigMap.
+  #
+  # This option has been deprecated, it will be removed in Cilium 1.5 or later.
+  #
+  # For more information, see https://cilium.link/host-vs-world
+  #legacy-host-allows-world: "false"
 
   # If you want cilium monitor to aggregate tracing for packets, set this level
   # to "low", "medium", or "maximum". The higher the level, the less packets

--- a/examples/kubernetes/1.8/cilium-cm.yaml
+++ b/examples/kubernetes/1.8/cilium-cm.yaml
@@ -49,7 +49,23 @@ data:
   # backend after restart.
   clean-cilium-bpf-state: "false"
 
-  legacy-host-allows-world: "false"
+  # In Cilium 1.0, all traffic from the host, including from local processes
+  # and traffic that is masqueraded from the outside world to the host IP,
+  # would be classified as from the host entity (reserved:host label).
+  # Furthermore, to allow Kubernetes agents to perform health checks over IP
+  # into the endpoints, the host is allowed by default. This means that all
+  # traffic from the outside world is also allowed by default, regardless of
+  # security policy.
+  #
+  # This option was introduced in Cilium 1.1 to disable this behaviour. It must
+  # be explicitly set to "false" to take effect on Cilium 1.3 or earlier.
+  # Cilium 1.4 sets this to "false" by default if it is not specified in the
+  # ConfigMap.
+  #
+  # This option has been deprecated, it will be removed in Cilium 1.5 or later.
+  #
+  # For more information, see https://cilium.link/host-vs-world
+  #legacy-host-allows-world: "false"
 
   # If you want cilium monitor to aggregate tracing for packets, set this level
   # to "low", "medium", or "maximum". The higher the level, the less packets

--- a/examples/kubernetes/1.8/cilium-crio.yaml
+++ b/examples/kubernetes/1.8/cilium-crio.yaml
@@ -49,7 +49,23 @@ data:
   # backend after restart.
   clean-cilium-bpf-state: "false"
 
-  legacy-host-allows-world: "false"
+  # In Cilium 1.0, all traffic from the host, including from local processes
+  # and traffic that is masqueraded from the outside world to the host IP,
+  # would be classified as from the host entity (reserved:host label).
+  # Furthermore, to allow Kubernetes agents to perform health checks over IP
+  # into the endpoints, the host is allowed by default. This means that all
+  # traffic from the outside world is also allowed by default, regardless of
+  # security policy.
+  #
+  # This option was introduced in Cilium 1.1 to disable this behaviour. It must
+  # be explicitly set to "false" to take effect on Cilium 1.3 or earlier.
+  # Cilium 1.4 sets this to "false" by default if it is not specified in the
+  # ConfigMap.
+  #
+  # This option has been deprecated, it will be removed in Cilium 1.5 or later.
+  #
+  # For more information, see https://cilium.link/host-vs-world
+  #legacy-host-allows-world: "false"
 
   # If you want cilium monitor to aggregate tracing for packets, set this level
   # to "low", "medium", or "maximum". The higher the level, the less packets

--- a/examples/kubernetes/1.8/cilium-minikube.yaml
+++ b/examples/kubernetes/1.8/cilium-minikube.yaml
@@ -49,7 +49,23 @@ data:
   # backend after restart.
   clean-cilium-bpf-state: "false"
 
-  legacy-host-allows-world: "false"
+  # In Cilium 1.0, all traffic from the host, including from local processes
+  # and traffic that is masqueraded from the outside world to the host IP,
+  # would be classified as from the host entity (reserved:host label).
+  # Furthermore, to allow Kubernetes agents to perform health checks over IP
+  # into the endpoints, the host is allowed by default. This means that all
+  # traffic from the outside world is also allowed by default, regardless of
+  # security policy.
+  #
+  # This option was introduced in Cilium 1.1 to disable this behaviour. It must
+  # be explicitly set to "false" to take effect on Cilium 1.3 or earlier.
+  # Cilium 1.4 sets this to "false" by default if it is not specified in the
+  # ConfigMap.
+  #
+  # This option has been deprecated, it will be removed in Cilium 1.5 or later.
+  #
+  # For more information, see https://cilium.link/host-vs-world
+  #legacy-host-allows-world: "false"
 
   # If you want cilium monitor to aggregate tracing for packets, set this level
   # to "low", "medium", or "maximum". The higher the level, the less packets

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -49,7 +49,23 @@ data:
   # backend after restart.
   clean-cilium-bpf-state: "false"
 
-  legacy-host-allows-world: "false"
+  # In Cilium 1.0, all traffic from the host, including from local processes
+  # and traffic that is masqueraded from the outside world to the host IP,
+  # would be classified as from the host entity (reserved:host label).
+  # Furthermore, to allow Kubernetes agents to perform health checks over IP
+  # into the endpoints, the host is allowed by default. This means that all
+  # traffic from the outside world is also allowed by default, regardless of
+  # security policy.
+  #
+  # This option was introduced in Cilium 1.1 to disable this behaviour. It must
+  # be explicitly set to "false" to take effect on Cilium 1.3 or earlier.
+  # Cilium 1.4 sets this to "false" by default if it is not specified in the
+  # ConfigMap.
+  #
+  # This option has been deprecated, it will be removed in Cilium 1.5 or later.
+  #
+  # For more information, see https://cilium.link/host-vs-world
+  #legacy-host-allows-world: "false"
 
   # If you want cilium monitor to aggregate tracing for packets, set this level
   # to "low", "medium", or "maximum". The higher the level, the less packets

--- a/examples/kubernetes/1.9/cilium-cm.yaml
+++ b/examples/kubernetes/1.9/cilium-cm.yaml
@@ -49,7 +49,23 @@ data:
   # backend after restart.
   clean-cilium-bpf-state: "false"
 
-  legacy-host-allows-world: "false"
+  # In Cilium 1.0, all traffic from the host, including from local processes
+  # and traffic that is masqueraded from the outside world to the host IP,
+  # would be classified as from the host entity (reserved:host label).
+  # Furthermore, to allow Kubernetes agents to perform health checks over IP
+  # into the endpoints, the host is allowed by default. This means that all
+  # traffic from the outside world is also allowed by default, regardless of
+  # security policy.
+  #
+  # This option was introduced in Cilium 1.1 to disable this behaviour. It must
+  # be explicitly set to "false" to take effect on Cilium 1.3 or earlier.
+  # Cilium 1.4 sets this to "false" by default if it is not specified in the
+  # ConfigMap.
+  #
+  # This option has been deprecated, it will be removed in Cilium 1.5 or later.
+  #
+  # For more information, see https://cilium.link/host-vs-world
+  #legacy-host-allows-world: "false"
 
   # If you want cilium monitor to aggregate tracing for packets, set this level
   # to "low", "medium", or "maximum". The higher the level, the less packets

--- a/examples/kubernetes/1.9/cilium-crio.yaml
+++ b/examples/kubernetes/1.9/cilium-crio.yaml
@@ -49,7 +49,23 @@ data:
   # backend after restart.
   clean-cilium-bpf-state: "false"
 
-  legacy-host-allows-world: "false"
+  # In Cilium 1.0, all traffic from the host, including from local processes
+  # and traffic that is masqueraded from the outside world to the host IP,
+  # would be classified as from the host entity (reserved:host label).
+  # Furthermore, to allow Kubernetes agents to perform health checks over IP
+  # into the endpoints, the host is allowed by default. This means that all
+  # traffic from the outside world is also allowed by default, regardless of
+  # security policy.
+  #
+  # This option was introduced in Cilium 1.1 to disable this behaviour. It must
+  # be explicitly set to "false" to take effect on Cilium 1.3 or earlier.
+  # Cilium 1.4 sets this to "false" by default if it is not specified in the
+  # ConfigMap.
+  #
+  # This option has been deprecated, it will be removed in Cilium 1.5 or later.
+  #
+  # For more information, see https://cilium.link/host-vs-world
+  #legacy-host-allows-world: "false"
 
   # If you want cilium monitor to aggregate tracing for packets, set this level
   # to "low", "medium", or "maximum". The higher the level, the less packets

--- a/examples/kubernetes/1.9/cilium-minikube.yaml
+++ b/examples/kubernetes/1.9/cilium-minikube.yaml
@@ -49,7 +49,23 @@ data:
   # backend after restart.
   clean-cilium-bpf-state: "false"
 
-  legacy-host-allows-world: "false"
+  # In Cilium 1.0, all traffic from the host, including from local processes
+  # and traffic that is masqueraded from the outside world to the host IP,
+  # would be classified as from the host entity (reserved:host label).
+  # Furthermore, to allow Kubernetes agents to perform health checks over IP
+  # into the endpoints, the host is allowed by default. This means that all
+  # traffic from the outside world is also allowed by default, regardless of
+  # security policy.
+  #
+  # This option was introduced in Cilium 1.1 to disable this behaviour. It must
+  # be explicitly set to "false" to take effect on Cilium 1.3 or earlier.
+  # Cilium 1.4 sets this to "false" by default if it is not specified in the
+  # ConfigMap.
+  #
+  # This option has been deprecated, it will be removed in Cilium 1.5 or later.
+  #
+  # For more information, see https://cilium.link/host-vs-world
+  #legacy-host-allows-world: "false"
 
   # If you want cilium monitor to aggregate tracing for packets, set this level
   # to "low", "medium", or "maximum". The higher the level, the less packets

--- a/examples/kubernetes/1.9/cilium.yaml
+++ b/examples/kubernetes/1.9/cilium.yaml
@@ -49,7 +49,23 @@ data:
   # backend after restart.
   clean-cilium-bpf-state: "false"
 
-  legacy-host-allows-world: "false"
+  # In Cilium 1.0, all traffic from the host, including from local processes
+  # and traffic that is masqueraded from the outside world to the host IP,
+  # would be classified as from the host entity (reserved:host label).
+  # Furthermore, to allow Kubernetes agents to perform health checks over IP
+  # into the endpoints, the host is allowed by default. This means that all
+  # traffic from the outside world is also allowed by default, regardless of
+  # security policy.
+  #
+  # This option was introduced in Cilium 1.1 to disable this behaviour. It must
+  # be explicitly set to "false" to take effect on Cilium 1.3 or earlier.
+  # Cilium 1.4 sets this to "false" by default if it is not specified in the
+  # ConfigMap.
+  #
+  # This option has been deprecated, it will be removed in Cilium 1.5 or later.
+  #
+  # For more information, see https://cilium.link/host-vs-world
+  #legacy-host-allows-world: "false"
 
   # If you want cilium monitor to aggregate tracing for packets, set this level
   # to "low", "medium", or "maximum". The higher the level, the less packets

--- a/examples/kubernetes/templates/v1/cilium-cm.yaml
+++ b/examples/kubernetes/templates/v1/cilium-cm.yaml
@@ -49,7 +49,23 @@ data:
   # backend after restart.
   clean-cilium-bpf-state: "false"
 
-  legacy-host-allows-world: "false"
+  # In Cilium 1.0, all traffic from the host, including from local processes
+  # and traffic that is masqueraded from the outside world to the host IP,
+  # would be classified as from the host entity (reserved:host label).
+  # Furthermore, to allow Kubernetes agents to perform health checks over IP
+  # into the endpoints, the host is allowed by default. This means that all
+  # traffic from the outside world is also allowed by default, regardless of
+  # security policy.
+  #
+  # This option was introduced in Cilium 1.1 to disable this behaviour. It must
+  # be explicitly set to "false" to take effect on Cilium 1.3 or earlier.
+  # Cilium 1.4 sets this to "false" by default if it is not specified in the
+  # ConfigMap.
+  #
+  # This option has been deprecated, it will be removed in Cilium 1.5 or later.
+  #
+  # For more information, see https://cilium.link/host-vs-world
+  #legacy-host-allows-world: "false"
 
   # If you want cilium monitor to aggregate tracing for packets, set this level
   # to "low", "medium", or "maximum". The higher the level, the less packets


### PR DESCRIPTION
The option to configure policy such that allowing connectivity to/from
"reserved:host" would also allow "reserved:world" traffic has been
configured to "false" by default in Cilium versions 1.1 and later.

In preparation to remove this option, set the default daemon evaluation
of this setting to false, which allows k8s ConfigMap to stop specifying the
option. Users who are explicitly enabling this will now see warnings in
the logs indicating that this option will be deprecated in an upcoming
release and that they should update their policies if they wish to
retain this behaviour.

This PR only removes the option from the configmap, as the default
setting was changed from the previous release; the next release should
be safe to remove entirely from both configmap and daemonset YAMLs
(as well as the daemon code).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6655)
<!-- Reviewable:end -->
