### PR TITLE
daemon: Do not mention ipvlan in --device flag usage

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -34,7 +34,7 @@ cilium-agent [flags]
       --datapath-mode string                        Datapath mode name (default "veth")
   -D, --debug                                       Enable debugging mode
       --debug-verbose strings                       List of enabled verbose debug groups
-  -d, --device string                               Device facing cluster/external network for direct L3 (non-overlay mode or ipvlan) (default "undefined")
+  -d, --device string                               Device facing cluster/external network for direct L3 (non-overlay mode) (default "undefined")
       --disable-conntrack                           Disable connection tracking
       --disable-endpoint-crd                        Disable use of CiliumEndpoint CRD
       --disable-k8s-services                        Disable east-west K8s load balancing by cilium

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -368,7 +368,7 @@ func init() {
 	flags.StringSlice(option.DebugVerbose, []string{}, "List of enabled verbose debug groups")
 	option.BindEnv(option.DebugVerbose)
 
-	flags.StringP(option.Device, "d", "undefined", "Device facing cluster/external network for direct L3 (non-overlay mode or ipvlan)")
+	flags.StringP(option.Device, "d", "undefined", "Device facing cluster/external network for direct L3 (non-overlay mode)")
 	option.BindEnv(option.Device)
 
 	flags.String(option.DatapathMode, defaults.DatapathMode, "Datapath mode name")


### PR DESCRIPTION
An ipvlan master device can be specified only via the `--ipvlan-master-device` flag.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6656)
<!-- Reviewable:end -->
