### PR TITLE
pkg/identity: add well known identity for cilium-etcd-operator

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1263,7 +1263,7 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 
 	// This needs to be done after the node addressing has been configured
 	// as the node address is required as suffix.
-	cache.InitIdentityAllocator(&d)
+	go cache.InitIdentityAllocator(&d)
 
 	if path := option.Config.ClusterMeshConfig; path != "" {
 		if option.Config.ClusterID == 0 {

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -894,15 +894,17 @@ func initEnv(cmd *cobra.Command) {
 	if !option.Config.EnableIPv4 && !option.Config.EnableIPv6 {
 		log.Fatal("Either IPv4 or IPv6 addressing must be enabled")
 	}
-	if err := kvstore.Setup(option.Config.KVStore, option.Config.KVStoreOpt); err != nil {
-		addrkey := fmt.Sprintf("%s.address", option.Config.KVStore)
-		addr := option.Config.KVStoreOpt[addrkey]
+	go func() {
+		if err := kvstore.Setup(option.Config.KVStore, option.Config.KVStoreOpt); err != nil {
+			addrkey := fmt.Sprintf("%s.address", option.Config.KVStore)
+			addr := option.Config.KVStoreOpt[addrkey]
 
-		log.WithError(err).WithFields(logrus.Fields{
-			"kvstore": option.Config.KVStore,
-			"address": addr,
-		}).Fatal("Unable to setup kvstore")
-	}
+			log.WithError(err).WithFields(logrus.Fields{
+				"kvstore": option.Config.KVStore,
+				"address": addr,
+			}).Fatal("Unable to setup kvstore")
+		}
+	}()
 
 	if err := labels.ParseLabelPrefixCfg(option.Config.Labels, option.Config.LabelPrefixFile); err != nil {
 		log.WithError(err).Fatal("Unable to parse Label prefix configuration")

--- a/pkg/identity/numericidentity.go
+++ b/pkg/identity/numericidentity.go
@@ -99,6 +99,9 @@ const (
 
 	// ReservedEKSCoreDNS is the reserved identity used for CoreDNS on EKS
 	ReservedEKSCoreDNS NumericIdentity = 106
+
+	// ReservedCiliumEtcdOperator is the reserved identity used for the Cilium etcd operator
+	ReservedCiliumEtcdOperator NumericIdentity = 107
 )
 
 type wellKnownIdentities map[NumericIdentity]wellKnownIdentity
@@ -239,6 +242,20 @@ func InitWellKnownIdentities() {
 		"k8s:io.cilium/app=operator",
 		fmt.Sprintf("k8s:%s=%s", api.PodNamespaceLabel, namespace),
 		fmt.Sprintf("k8s:%s=cilium-operator", api.PolicyLabelServiceAccount),
+		fmt.Sprintf("k8s:%s=%s", api.PolicyLabelCluster, option.Config.ClusterName),
+	})
+
+	// cilium-etcd-operator labels
+	//   k8s:io.cilium.k8s.policy.cluster=default
+	//   k8s:io.cilium.k8s.policy.serviceaccount=cilium-etcd-operator
+	//   k8s:io.cilium/app=etcd-operator
+	//   k8s:io.kubernetes.pod.namespace=<NAMESPACE>
+	//   k8s:name=cilium-etcd-operator
+	WellKnown.add(ReservedCiliumEtcdOperator, []string{
+		"k8s:name=cilium-etcd-operator",
+		"k8s:io.cilium/app=etcd-operator",
+		fmt.Sprintf("k8s:%s=%s", api.PodNamespaceLabel, namespace),
+		fmt.Sprintf("k8s:%s=cilium-etcd-operator", api.PolicyLabelServiceAccount),
 		fmt.Sprintf("k8s:%s=%s", api.PolicyLabelCluster, option.Config.ClusterName),
 	})
 }

--- a/pkg/ipcache/kvstore.go
+++ b/pkg/ipcache/kvstore.go
@@ -367,8 +367,10 @@ func (iw *IPIdentityWatcher) Close() {
 func InitIPIdentityWatcher() {
 	setupIPIdentityWatcher.Do(func() {
 		globalMap = newKVReferenceCounter(kvstoreImplementation{})
-		log.Info("Starting IP identity watcher")
-		watch := NewIPIdentityWatcher(kvstore.Client())
-		go watch.Watch()
+		go func() {
+			log.Info("Starting IP identity watcher")
+			watch := NewIPIdentityWatcher(kvstore.Client())
+			watch.Watch()
+		}()
 	})
 }


### PR DESCRIPTION
This allows users to run cilium-etcd-operator without `hostNetwork: true`

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6660)
<!-- Reviewable:end -->
