### PR TITLE
examples/kubernetes: set enable-[ipv4|ipv6] as optional envVar

### DIFF
--- a/examples/kubernetes/1.10/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-crio-ds.yaml
@@ -56,11 +56,13 @@ spec:
             configMapKeyRef:
               key: enable-ipv4
               name: cilium-config
+              optional: true
         - name: CILIUM_ENABLE_IPV6
           valueFrom:
             configMapKeyRef:
               key: enable-ipv6
               name: cilium-config
+              optional: true
           # Note: this variable is a no-op if not defined, and is used in the
           # prometheus examples.
         - name: CILIUM_PROMETHEUS_SERVE_ADDR

--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -179,11 +179,13 @@ spec:
             configMapKeyRef:
               key: enable-ipv4
               name: cilium-config
+              optional: true
         - name: CILIUM_ENABLE_IPV6
           valueFrom:
             configMapKeyRef:
               key: enable-ipv6
               name: cilium-config
+              optional: true
           # Note: this variable is a no-op if not defined, and is used in the
           # prometheus examples.
         - name: CILIUM_PROMETHEUS_SERVE_ADDR

--- a/examples/kubernetes/1.10/cilium-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-ds.yaml
@@ -55,11 +55,13 @@ spec:
             configMapKeyRef:
               key: enable-ipv4
               name: cilium-config
+              optional: true
         - name: CILIUM_ENABLE_IPV6
           valueFrom:
             configMapKeyRef:
               key: enable-ipv6
               name: cilium-config
+              optional: true
           # Note: this variable is a no-op if not defined, and is used in the
           # prometheus examples.
         - name: CILIUM_PROMETHEUS_SERVE_ADDR

--- a/examples/kubernetes/1.10/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-minikube-ds.yaml
@@ -55,11 +55,13 @@ spec:
             configMapKeyRef:
               key: enable-ipv4
               name: cilium-config
+              optional: true
         - name: CILIUM_ENABLE_IPV6
           valueFrom:
             configMapKeyRef:
               key: enable-ipv6
               name: cilium-config
+              optional: true
           # Note: this variable is a no-op if not defined, and is used in the
           # prometheus examples.
         - name: CILIUM_PROMETHEUS_SERVE_ADDR

--- a/examples/kubernetes/1.10/cilium-minikube.yaml
+++ b/examples/kubernetes/1.10/cilium-minikube.yaml
@@ -178,11 +178,13 @@ spec:
             configMapKeyRef:
               key: enable-ipv4
               name: cilium-config
+              optional: true
         - name: CILIUM_ENABLE_IPV6
           valueFrom:
             configMapKeyRef:
               key: enable-ipv6
               name: cilium-config
+              optional: true
           # Note: this variable is a no-op if not defined, and is used in the
           # prometheus examples.
         - name: CILIUM_PROMETHEUS_SERVE_ADDR

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -178,11 +178,13 @@ spec:
             configMapKeyRef:
               key: enable-ipv4
               name: cilium-config
+              optional: true
         - name: CILIUM_ENABLE_IPV6
           valueFrom:
             configMapKeyRef:
               key: enable-ipv6
               name: cilium-config
+              optional: true
           # Note: this variable is a no-op if not defined, and is used in the
           # prometheus examples.
         - name: CILIUM_PROMETHEUS_SERVE_ADDR

--- a/examples/kubernetes/1.11/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-crio-ds.yaml
@@ -56,11 +56,13 @@ spec:
             configMapKeyRef:
               key: enable-ipv4
               name: cilium-config
+              optional: true
         - name: CILIUM_ENABLE_IPV6
           valueFrom:
             configMapKeyRef:
               key: enable-ipv6
               name: cilium-config
+              optional: true
           # Note: this variable is a no-op if not defined, and is used in the
           # prometheus examples.
         - name: CILIUM_PROMETHEUS_SERVE_ADDR

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -179,11 +179,13 @@ spec:
             configMapKeyRef:
               key: enable-ipv4
               name: cilium-config
+              optional: true
         - name: CILIUM_ENABLE_IPV6
           valueFrom:
             configMapKeyRef:
               key: enable-ipv6
               name: cilium-config
+              optional: true
           # Note: this variable is a no-op if not defined, and is used in the
           # prometheus examples.
         - name: CILIUM_PROMETHEUS_SERVE_ADDR

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -55,11 +55,13 @@ spec:
             configMapKeyRef:
               key: enable-ipv4
               name: cilium-config
+              optional: true
         - name: CILIUM_ENABLE_IPV6
           valueFrom:
             configMapKeyRef:
               key: enable-ipv6
               name: cilium-config
+              optional: true
           # Note: this variable is a no-op if not defined, and is used in the
           # prometheus examples.
         - name: CILIUM_PROMETHEUS_SERVE_ADDR

--- a/examples/kubernetes/1.11/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-minikube-ds.yaml
@@ -55,11 +55,13 @@ spec:
             configMapKeyRef:
               key: enable-ipv4
               name: cilium-config
+              optional: true
         - name: CILIUM_ENABLE_IPV6
           valueFrom:
             configMapKeyRef:
               key: enable-ipv6
               name: cilium-config
+              optional: true
           # Note: this variable is a no-op if not defined, and is used in the
           # prometheus examples.
         - name: CILIUM_PROMETHEUS_SERVE_ADDR

--- a/examples/kubernetes/1.11/cilium-minikube.yaml
+++ b/examples/kubernetes/1.11/cilium-minikube.yaml
@@ -178,11 +178,13 @@ spec:
             configMapKeyRef:
               key: enable-ipv4
               name: cilium-config
+              optional: true
         - name: CILIUM_ENABLE_IPV6
           valueFrom:
             configMapKeyRef:
               key: enable-ipv6
               name: cilium-config
+              optional: true
           # Note: this variable is a no-op if not defined, and is used in the
           # prometheus examples.
         - name: CILIUM_PROMETHEUS_SERVE_ADDR

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -178,11 +178,13 @@ spec:
             configMapKeyRef:
               key: enable-ipv4
               name: cilium-config
+              optional: true
         - name: CILIUM_ENABLE_IPV6
           valueFrom:
             configMapKeyRef:
               key: enable-ipv6
               name: cilium-config
+              optional: true
           # Note: this variable is a no-op if not defined, and is used in the
           # prometheus examples.
         - name: CILIUM_PROMETHEUS_SERVE_ADDR

--- a/examples/kubernetes/1.12/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-crio-ds.yaml
@@ -56,11 +56,13 @@ spec:
             configMapKeyRef:
               key: enable-ipv4
               name: cilium-config
+              optional: true
         - name: CILIUM_ENABLE_IPV6
           valueFrom:
             configMapKeyRef:
               key: enable-ipv6
               name: cilium-config
+              optional: true
           # Note: this variable is a no-op if not defined, and is used in the
           # prometheus examples.
         - name: CILIUM_PROMETHEUS_SERVE_ADDR

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -179,11 +179,13 @@ spec:
             configMapKeyRef:
               key: enable-ipv4
               name: cilium-config
+              optional: true
         - name: CILIUM_ENABLE_IPV6
           valueFrom:
             configMapKeyRef:
               key: enable-ipv6
               name: cilium-config
+              optional: true
           # Note: this variable is a no-op if not defined, and is used in the
           # prometheus examples.
         - name: CILIUM_PROMETHEUS_SERVE_ADDR

--- a/examples/kubernetes/1.12/cilium-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-ds.yaml
@@ -55,11 +55,13 @@ spec:
             configMapKeyRef:
               key: enable-ipv4
               name: cilium-config
+              optional: true
         - name: CILIUM_ENABLE_IPV6
           valueFrom:
             configMapKeyRef:
               key: enable-ipv6
               name: cilium-config
+              optional: true
           # Note: this variable is a no-op if not defined, and is used in the
           # prometheus examples.
         - name: CILIUM_PROMETHEUS_SERVE_ADDR

--- a/examples/kubernetes/1.12/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-minikube-ds.yaml
@@ -55,11 +55,13 @@ spec:
             configMapKeyRef:
               key: enable-ipv4
               name: cilium-config
+              optional: true
         - name: CILIUM_ENABLE_IPV6
           valueFrom:
             configMapKeyRef:
               key: enable-ipv6
               name: cilium-config
+              optional: true
           # Note: this variable is a no-op if not defined, and is used in the
           # prometheus examples.
         - name: CILIUM_PROMETHEUS_SERVE_ADDR

--- a/examples/kubernetes/1.12/cilium-minikube.yaml
+++ b/examples/kubernetes/1.12/cilium-minikube.yaml
@@ -178,11 +178,13 @@ spec:
             configMapKeyRef:
               key: enable-ipv4
               name: cilium-config
+              optional: true
         - name: CILIUM_ENABLE_IPV6
           valueFrom:
             configMapKeyRef:
               key: enable-ipv6
               name: cilium-config
+              optional: true
           # Note: this variable is a no-op if not defined, and is used in the
           # prometheus examples.
         - name: CILIUM_PROMETHEUS_SERVE_ADDR

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -178,11 +178,13 @@ spec:
             configMapKeyRef:
               key: enable-ipv4
               name: cilium-config
+              optional: true
         - name: CILIUM_ENABLE_IPV6
           valueFrom:
             configMapKeyRef:
               key: enable-ipv6
               name: cilium-config
+              optional: true
           # Note: this variable is a no-op if not defined, and is used in the
           # prometheus examples.
         - name: CILIUM_PROMETHEUS_SERVE_ADDR

--- a/examples/kubernetes/1.13/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-crio-ds.yaml
@@ -56,11 +56,13 @@ spec:
             configMapKeyRef:
               key: enable-ipv4
               name: cilium-config
+              optional: true
         - name: CILIUM_ENABLE_IPV6
           valueFrom:
             configMapKeyRef:
               key: enable-ipv6
               name: cilium-config
+              optional: true
           # Note: this variable is a no-op if not defined, and is used in the
           # prometheus examples.
         - name: CILIUM_PROMETHEUS_SERVE_ADDR

--- a/examples/kubernetes/1.13/cilium-crio.yaml
+++ b/examples/kubernetes/1.13/cilium-crio.yaml
@@ -179,11 +179,13 @@ spec:
             configMapKeyRef:
               key: enable-ipv4
               name: cilium-config
+              optional: true
         - name: CILIUM_ENABLE_IPV6
           valueFrom:
             configMapKeyRef:
               key: enable-ipv6
               name: cilium-config
+              optional: true
           # Note: this variable is a no-op if not defined, and is used in the
           # prometheus examples.
         - name: CILIUM_PROMETHEUS_SERVE_ADDR

--- a/examples/kubernetes/1.13/cilium-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-ds.yaml
@@ -55,11 +55,13 @@ spec:
             configMapKeyRef:
               key: enable-ipv4
               name: cilium-config
+              optional: true
         - name: CILIUM_ENABLE_IPV6
           valueFrom:
             configMapKeyRef:
               key: enable-ipv6
               name: cilium-config
+              optional: true
           # Note: this variable is a no-op if not defined, and is used in the
           # prometheus examples.
         - name: CILIUM_PROMETHEUS_SERVE_ADDR

--- a/examples/kubernetes/1.13/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-minikube-ds.yaml
@@ -55,11 +55,13 @@ spec:
             configMapKeyRef:
               key: enable-ipv4
               name: cilium-config
+              optional: true
         - name: CILIUM_ENABLE_IPV6
           valueFrom:
             configMapKeyRef:
               key: enable-ipv6
               name: cilium-config
+              optional: true
           # Note: this variable is a no-op if not defined, and is used in the
           # prometheus examples.
         - name: CILIUM_PROMETHEUS_SERVE_ADDR

--- a/examples/kubernetes/1.13/cilium-minikube.yaml
+++ b/examples/kubernetes/1.13/cilium-minikube.yaml
@@ -178,11 +178,13 @@ spec:
             configMapKeyRef:
               key: enable-ipv4
               name: cilium-config
+              optional: true
         - name: CILIUM_ENABLE_IPV6
           valueFrom:
             configMapKeyRef:
               key: enable-ipv6
               name: cilium-config
+              optional: true
           # Note: this variable is a no-op if not defined, and is used in the
           # prometheus examples.
         - name: CILIUM_PROMETHEUS_SERVE_ADDR

--- a/examples/kubernetes/1.13/cilium.yaml
+++ b/examples/kubernetes/1.13/cilium.yaml
@@ -178,11 +178,13 @@ spec:
             configMapKeyRef:
               key: enable-ipv4
               name: cilium-config
+              optional: true
         - name: CILIUM_ENABLE_IPV6
           valueFrom:
             configMapKeyRef:
               key: enable-ipv6
               name: cilium-config
+              optional: true
           # Note: this variable is a no-op if not defined, and is used in the
           # prometheus examples.
         - name: CILIUM_PROMETHEUS_SERVE_ADDR

--- a/examples/kubernetes/1.8/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-crio-ds.yaml
@@ -56,11 +56,13 @@ spec:
             configMapKeyRef:
               key: enable-ipv4
               name: cilium-config
+              optional: true
         - name: CILIUM_ENABLE_IPV6
           valueFrom:
             configMapKeyRef:
               key: enable-ipv6
               name: cilium-config
+              optional: true
           # Note: this variable is a no-op if not defined, and is used in the
           # prometheus examples.
         - name: CILIUM_PROMETHEUS_SERVE_ADDR

--- a/examples/kubernetes/1.8/cilium-crio.yaml
+++ b/examples/kubernetes/1.8/cilium-crio.yaml
@@ -179,11 +179,13 @@ spec:
             configMapKeyRef:
               key: enable-ipv4
               name: cilium-config
+              optional: true
         - name: CILIUM_ENABLE_IPV6
           valueFrom:
             configMapKeyRef:
               key: enable-ipv6
               name: cilium-config
+              optional: true
           # Note: this variable is a no-op if not defined, and is used in the
           # prometheus examples.
         - name: CILIUM_PROMETHEUS_SERVE_ADDR

--- a/examples/kubernetes/1.8/cilium-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-ds.yaml
@@ -55,11 +55,13 @@ spec:
             configMapKeyRef:
               key: enable-ipv4
               name: cilium-config
+              optional: true
         - name: CILIUM_ENABLE_IPV6
           valueFrom:
             configMapKeyRef:
               key: enable-ipv6
               name: cilium-config
+              optional: true
           # Note: this variable is a no-op if not defined, and is used in the
           # prometheus examples.
         - name: CILIUM_PROMETHEUS_SERVE_ADDR

--- a/examples/kubernetes/1.8/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-minikube-ds.yaml
@@ -55,11 +55,13 @@ spec:
             configMapKeyRef:
               key: enable-ipv4
               name: cilium-config
+              optional: true
         - name: CILIUM_ENABLE_IPV6
           valueFrom:
             configMapKeyRef:
               key: enable-ipv6
               name: cilium-config
+              optional: true
           # Note: this variable is a no-op if not defined, and is used in the
           # prometheus examples.
         - name: CILIUM_PROMETHEUS_SERVE_ADDR

--- a/examples/kubernetes/1.8/cilium-minikube.yaml
+++ b/examples/kubernetes/1.8/cilium-minikube.yaml
@@ -178,11 +178,13 @@ spec:
             configMapKeyRef:
               key: enable-ipv4
               name: cilium-config
+              optional: true
         - name: CILIUM_ENABLE_IPV6
           valueFrom:
             configMapKeyRef:
               key: enable-ipv6
               name: cilium-config
+              optional: true
           # Note: this variable is a no-op if not defined, and is used in the
           # prometheus examples.
         - name: CILIUM_PROMETHEUS_SERVE_ADDR

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -178,11 +178,13 @@ spec:
             configMapKeyRef:
               key: enable-ipv4
               name: cilium-config
+              optional: true
         - name: CILIUM_ENABLE_IPV6
           valueFrom:
             configMapKeyRef:
               key: enable-ipv6
               name: cilium-config
+              optional: true
           # Note: this variable is a no-op if not defined, and is used in the
           # prometheus examples.
         - name: CILIUM_PROMETHEUS_SERVE_ADDR

--- a/examples/kubernetes/1.9/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-crio-ds.yaml
@@ -56,11 +56,13 @@ spec:
             configMapKeyRef:
               key: enable-ipv4
               name: cilium-config
+              optional: true
         - name: CILIUM_ENABLE_IPV6
           valueFrom:
             configMapKeyRef:
               key: enable-ipv6
               name: cilium-config
+              optional: true
           # Note: this variable is a no-op if not defined, and is used in the
           # prometheus examples.
         - name: CILIUM_PROMETHEUS_SERVE_ADDR

--- a/examples/kubernetes/1.9/cilium-crio.yaml
+++ b/examples/kubernetes/1.9/cilium-crio.yaml
@@ -179,11 +179,13 @@ spec:
             configMapKeyRef:
               key: enable-ipv4
               name: cilium-config
+              optional: true
         - name: CILIUM_ENABLE_IPV6
           valueFrom:
             configMapKeyRef:
               key: enable-ipv6
               name: cilium-config
+              optional: true
           # Note: this variable is a no-op if not defined, and is used in the
           # prometheus examples.
         - name: CILIUM_PROMETHEUS_SERVE_ADDR

--- a/examples/kubernetes/1.9/cilium-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-ds.yaml
@@ -55,11 +55,13 @@ spec:
             configMapKeyRef:
               key: enable-ipv4
               name: cilium-config
+              optional: true
         - name: CILIUM_ENABLE_IPV6
           valueFrom:
             configMapKeyRef:
               key: enable-ipv6
               name: cilium-config
+              optional: true
           # Note: this variable is a no-op if not defined, and is used in the
           # prometheus examples.
         - name: CILIUM_PROMETHEUS_SERVE_ADDR

--- a/examples/kubernetes/1.9/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-minikube-ds.yaml
@@ -55,11 +55,13 @@ spec:
             configMapKeyRef:
               key: enable-ipv4
               name: cilium-config
+              optional: true
         - name: CILIUM_ENABLE_IPV6
           valueFrom:
             configMapKeyRef:
               key: enable-ipv6
               name: cilium-config
+              optional: true
           # Note: this variable is a no-op if not defined, and is used in the
           # prometheus examples.
         - name: CILIUM_PROMETHEUS_SERVE_ADDR

--- a/examples/kubernetes/1.9/cilium-minikube.yaml
+++ b/examples/kubernetes/1.9/cilium-minikube.yaml
@@ -178,11 +178,13 @@ spec:
             configMapKeyRef:
               key: enable-ipv4
               name: cilium-config
+              optional: true
         - name: CILIUM_ENABLE_IPV6
           valueFrom:
             configMapKeyRef:
               key: enable-ipv6
               name: cilium-config
+              optional: true
           # Note: this variable is a no-op if not defined, and is used in the
           # prometheus examples.
         - name: CILIUM_PROMETHEUS_SERVE_ADDR

--- a/examples/kubernetes/1.9/cilium.yaml
+++ b/examples/kubernetes/1.9/cilium.yaml
@@ -178,11 +178,13 @@ spec:
             configMapKeyRef:
               key: enable-ipv4
               name: cilium-config
+              optional: true
         - name: CILIUM_ENABLE_IPV6
           valueFrom:
             configMapKeyRef:
               key: enable-ipv6
               name: cilium-config
+              optional: true
           # Note: this variable is a no-op if not defined, and is used in the
           # prometheus examples.
         - name: CILIUM_PROMETHEUS_SERVE_ADDR

--- a/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
@@ -56,11 +56,13 @@ spec:
             configMapKeyRef:
               key: enable-ipv4
               name: cilium-config
+              optional: true
         - name: CILIUM_ENABLE_IPV6
           valueFrom:
             configMapKeyRef:
               key: enable-ipv6
               name: cilium-config
+              optional: true
           # Note: this variable is a no-op if not defined, and is used in the
           # prometheus examples.
         - name: CILIUM_PROMETHEUS_SERVE_ADDR

--- a/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
@@ -55,11 +55,13 @@ spec:
             configMapKeyRef:
               key: enable-ipv4
               name: cilium-config
+              optional: true
         - name: CILIUM_ENABLE_IPV6
           valueFrom:
             configMapKeyRef:
               key: enable-ipv6
               name: cilium-config
+              optional: true
           # Note: this variable is a no-op if not defined, and is used in the
           # prometheus examples.
         - name: CILIUM_PROMETHEUS_SERVE_ADDR

--- a/examples/kubernetes/templates/v1/cilium-minikube-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-minikube-ds.yaml.sed
@@ -55,11 +55,13 @@ spec:
             configMapKeyRef:
               key: enable-ipv4
               name: cilium-config
+              optional: true
         - name: CILIUM_ENABLE_IPV6
           valueFrom:
             configMapKeyRef:
               key: enable-ipv6
               name: cilium-config
+              optional: true
           # Note: this variable is a no-op if not defined, and is used in the
           # prometheus examples.
         - name: CILIUM_PROMETHEUS_SERVE_ADDR


### PR DESCRIPTION
As users might upgrade by only applying the DaemonSet file they might
not have the enable-ipv4 nor enable-ipv6 options set in the ConfigMap,
this will cause upgrade disruptions in those environments as Cilium will
not start as that field does not exist in the ConfigMap.

Fixes: 6f2218f42513 ("agent: Universal --enable-ipv4 and --enable-ipv6 option")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6661)
<!-- Reviewable:end -->
