### PR TITLE
maps/tunnel: Retire code for removal of tunnel_endpoint_map

### DIFF
--- a/pkg/maps/tunnel/tunnel.go
+++ b/pkg/maps/tunnel/tunnel.go
@@ -16,23 +16,15 @@ package tunnel
 
 import (
 	"net"
-	"os"
-	"path/filepath"
 	"unsafe"
 
 	"github.com/cilium/cilium/pkg/bpf"
-	"github.com/cilium/cilium/pkg/defaults"
 
 	"github.com/sirupsen/logrus"
 )
 
 const (
 	MapName = "cilium_tunnel_map"
-
-	// Cilium versions < 1.0 used this tunnel map name, we remove it when
-	// we open the new tunnel map. In a future release, we should remove
-	// this downgrade handling code
-	oldMapName = "tunnel_endpoint_map"
 
 	// MaxEntries is the maximum entries in the tunnel endpoint map
 	MaxEntries = 65536
@@ -65,12 +57,6 @@ type Map struct {
 
 func init() {
 	TunnelMap.NonPersistent = true
-
-	// Remove old map and ignore errors; this is the "normal" case.
-	// BPFFS map root in older versions of Cilium wasn't dynamic, so the
-	// path of this old map will be always
-	// /sys/fs/bpf/tc/globals/tunnel_endpoint_map
-	os.Remove(filepath.Join(defaults.DefaultMapRoot, defaults.DefaultMapPrefix, oldMapName))
 }
 
 type tunnelEndpoint struct {


### PR DESCRIPTION
Cilium 1.0 stopped using tunnel_endpoint_map and versions 1.0-1.3 remove
this map on start up. Release 1.4 no longer needs the cleanup code and
there are no plans for supporting upgrades straight from <1.0 to 1.4.

Fixes: #3866

Signed-off-by: Michal Rostecki <mrostecki@suse.de>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6663)
<!-- Reviewable:end -->
