### PR TITLE
examples/kubernetes: fix crio k8s descriptors

### DIFF
--- a/examples/kubernetes/1.11/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-crio-ds.yaml
@@ -165,8 +165,6 @@ spec:
             - NET_ADMIN
           privileged: true
         volumeMounts:
-        - mountPath: /sys/fs/bpf
-          name: bpf-maps
         - mountPath: /var/run/cilium
           name: cilium-run
         - mountPath: /host/opt/cni/bin
@@ -212,8 +210,6 @@ spec:
             - NET_ADMIN
           privileged: true
         volumeMounts:
-        - mountPath: /sys/fs/bpf
-          name: bpf-maps
         - mountPath: /var/run/cilium
           name: cilium-run
       priorityClassName: system-node-critical

--- a/examples/kubernetes/1.11/cilium-crio-transforms2sed.sed
+++ b/examples/kubernetes/1.11/cilium-crio-transforms2sed.sed
@@ -1,4 +1,4 @@
 # delete mounts
-/            - name: bpf-maps/,+1 d
+/        - mountPath: \/sys\/fs\/bpf/,+1 d
 # delete volumes
 /        # To keep state between restarts \/ upgrades for bpf maps/,+4 d

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -288,8 +288,6 @@ spec:
             - NET_ADMIN
           privileged: true
         volumeMounts:
-        - mountPath: /sys/fs/bpf
-          name: bpf-maps
         - mountPath: /var/run/cilium
           name: cilium-run
         - mountPath: /host/opt/cni/bin
@@ -335,8 +333,6 @@ spec:
             - NET_ADMIN
           privileged: true
         volumeMounts:
-        - mountPath: /sys/fs/bpf
-          name: bpf-maps
         - mountPath: /var/run/cilium
           name: cilium-run
       priorityClassName: system-node-critical

--- a/examples/kubernetes/1.12/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-crio-ds.yaml
@@ -165,8 +165,6 @@ spec:
             - NET_ADMIN
           privileged: true
         volumeMounts:
-        - mountPath: /sys/fs/bpf
-          name: bpf-maps
         - mountPath: /var/run/cilium
           name: cilium-run
         - mountPath: /host/opt/cni/bin
@@ -212,8 +210,6 @@ spec:
             - NET_ADMIN
           privileged: true
         volumeMounts:
-        - mountPath: /sys/fs/bpf
-          name: bpf-maps
         - mountPath: /var/run/cilium
           name: cilium-run
       priorityClassName: system-node-critical

--- a/examples/kubernetes/1.12/cilium-crio-transforms2sed.sed
+++ b/examples/kubernetes/1.12/cilium-crio-transforms2sed.sed
@@ -1,4 +1,4 @@
 # delete mounts
-/            - name: bpf-maps/,+1 d
+/        - mountPath: \/sys\/fs\/bpf/,+1 d
 # delete volumes
 /        # To keep state between restarts \/ upgrades for bpf maps/,+4 d

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -288,8 +288,6 @@ spec:
             - NET_ADMIN
           privileged: true
         volumeMounts:
-        - mountPath: /sys/fs/bpf
-          name: bpf-maps
         - mountPath: /var/run/cilium
           name: cilium-run
         - mountPath: /host/opt/cni/bin
@@ -335,8 +333,6 @@ spec:
             - NET_ADMIN
           privileged: true
         volumeMounts:
-        - mountPath: /sys/fs/bpf
-          name: bpf-maps
         - mountPath: /var/run/cilium
           name: cilium-run
       priorityClassName: system-node-critical

--- a/examples/kubernetes/1.13/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-crio-ds.yaml
@@ -165,8 +165,6 @@ spec:
             - NET_ADMIN
           privileged: true
         volumeMounts:
-        - mountPath: /sys/fs/bpf
-          name: bpf-maps
         - mountPath: /var/run/cilium
           name: cilium-run
         - mountPath: /host/opt/cni/bin
@@ -212,8 +210,6 @@ spec:
             - NET_ADMIN
           privileged: true
         volumeMounts:
-        - mountPath: /sys/fs/bpf
-          name: bpf-maps
         - mountPath: /var/run/cilium
           name: cilium-run
       priorityClassName: system-node-critical

--- a/examples/kubernetes/1.13/cilium-crio-transforms2sed.sed
+++ b/examples/kubernetes/1.13/cilium-crio-transforms2sed.sed
@@ -1,4 +1,4 @@
 # delete mounts
-/            - name: bpf-maps/,+1 d
+/        - mountPath: \/sys\/fs\/bpf/,+1 d
 # delete volumes
 /        # To keep state between restarts \/ upgrades for bpf maps/,+4 d

--- a/examples/kubernetes/1.13/cilium-crio.yaml
+++ b/examples/kubernetes/1.13/cilium-crio.yaml
@@ -288,8 +288,6 @@ spec:
             - NET_ADMIN
           privileged: true
         volumeMounts:
-        - mountPath: /sys/fs/bpf
-          name: bpf-maps
         - mountPath: /var/run/cilium
           name: cilium-run
         - mountPath: /host/opt/cni/bin
@@ -335,8 +333,6 @@ spec:
             - NET_ADMIN
           privileged: true
         volumeMounts:
-        - mountPath: /sys/fs/bpf
-          name: bpf-maps
         - mountPath: /var/run/cilium
           name: cilium-run
       priorityClassName: system-node-critical


### PR DESCRIPTION
Since crio already mounts the bpf since version 1.11 we don't need to
mount paths inside the cilium container.

Fixes: b1116e0c09b3 ("order files by the same order kubernetes output")
Reported-by: António Meireles <antonio.meireles@reformi.st>
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6666)
<!-- Reviewable:end -->
