### PR TITLE
Documentation: add "behaviour" to spelling wordlist

### DIFF
--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -30,6 +30,7 @@ battlestation
 bazel
 bcc
 Bertin
+behaviour
 bgpd
 bindata
 Blanco


### PR DESCRIPTION
Fixes: 4fa2a23029 ("daemon: Disable host-allows-world by default")

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6668)
<!-- Reviewable:end -->
