### PR TITLE
v1.3: disable microscope in CI

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -54,6 +54,9 @@ const (
 	// The kubedns resyncPeriod is defined at
 	// https://github.com/kubernetes/dns/blob/80fdd88276adba36a87c4f424b66fdf37cd7c9a8/pkg/dns/dns.go#L53
 	DNSHelperTimeout int64 = 420
+
+	// EnableMicroscope is true when microscope should be enabled
+	EnableMicroscope = false
 )
 
 // GetCurrentK8SEnv returns the value of K8S_VERSION from the OS environment.
@@ -349,6 +352,9 @@ func (kub *Kubectl) Logs(namespace string, pod string) *CmdRes {
 // a timeout. Also it returns a callback function to stop the monitor and save
 // the output to `helpers.monitorLogFileName` file.
 func (kub *Kubectl) MicroscopeStart() (error, func() error) {
+	if !EnableMicroscope {
+		return nil, func() error { return nil }
+	}
 	microscope := "microscope"
 	var microscopeCmd = microscope + "| ts '[%Y-%m-%d %H:%M:%S]'"
 	var cb = func() error { return nil }

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -386,7 +386,7 @@ func (kub *Kubectl) MicroscopeStart() (error, func() error) {
 			log.WithError(err).Errorf("cannot create monitor log file")
 			return err
 		}
-		res := kub.Exec(fmt.Sprintf("%s -n %s delete pod microscope", KubectlCmd, KubeSystemNamespace))
+		res := kub.Exec(fmt.Sprintf("%s -n %s delete pod --grace-period=0 --force microscope", KubectlCmd, KubeSystemNamespace))
 		if !res.WasSuccessful() {
 			return fmt.Errorf("error deleting microscope pod: %s", res.OutputPrettyPrint())
 		}

--- a/test/k8sT/microscope.go
+++ b/test/k8sT/microscope.go
@@ -52,6 +52,10 @@ var _ = Describe("K8sMicroscope", func() {
 	})
 
 	It("Runs microscope", func() {
+		if !helpers.EnableMicroscope {
+			Skip("Microscope is disabled")
+		}
+
 		microscopeErr, microscopeCancel := kubectl.MicroscopeStart()
 		Expect(microscopeErr).To(BeNil(), "Microscope cannot be started")
 


### PR DESCRIPTION
Microscope is disabled in v1.4 and master CI due to concerns around performance / stability in the Cilium CI. Disable it in v1.3 as well.

This is a partial backport of #6110.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6669)
<!-- Reviewable:end -->
