### PR TITLE
v1.2 backport : endpoint: do not regenerate health endpoint after identity change

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2497,11 +2497,28 @@ func (e *Endpoint) identityLabelsChanged(owner Owner, myChangeRev int) error {
 
 	e.SetIdentity(identity)
 
-	readyToRegenerate := e.SetStateLocked(StateWaitingToRegenerate, "Triggering regeneration due to new identity")
-
 	// Unconditionally force policy recomputation after a new identity has been
 	// assigned.
 	e.ForcePolicyCompute()
+
+	/* This is a workaround to ensure that the health endpoint is not regenerated
+	before it is added into the endpointmanager, as the health endpoint is
+	treated differently than all other endpoints in how it is added. If
+	we try to regenerate upon identity change (which occurs whenever the
+	health endpoint is started), then there is a possibility that the endpoint
+	will be regenerating while it is being added into the endpoint manager,
+	which results in subsequent state changes failing in
+	cilium-health/launch/endpoint.go:LaunchAsEndpoint . So, we leave regeneration
+	of the health endpoint to be the responsibility of that function instead of
+	this function, since the health endpoint's identity should never change.
+	*/
+	if e.SecurityIdentity.ID == identityPkg.ReservedIdentityHealth {
+		e.getLogger().Debug("skipping health endpoint regeneration after identity change")
+		e.Unlock()
+		return nil
+	}
+
+	readyToRegenerate := e.SetStateLocked(StateWaitingToRegenerate, "Triggering regeneration due to new identity")
 
 	e.Unlock()
 


### PR DESCRIPTION
The health endpoint's identity never changes after initial bootstrapping, and
the initial regeneration is handled specially when the health endpoint is
launched, so skip regeneration of the health endpoint when its identity is set.

Signed-off by: Ian Vernon <ian@cilium.io>

This fix was required in v1.3 because the code in `UpdateLabels` changed in master and required special changes to function in v1.3. It is entirely based around timing around what an endpoint's state is. So, in v1.3, the issue may present itself more frequently, but it could present itself in v1.2. So, I chose to backport the commit from v1.3 to v1.2.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6670)
<!-- Reviewable:end -->
