### PR TITLE
Add DNS Proxy upstream time histogram metric

### DIFF
--- a/Documentation/configuration/metrics.rst
+++ b/Documentation/configuration/metrics.rst
@@ -88,10 +88,12 @@ Policy L7 (HTTP/Kafka)
 ----------------------
 
 * ``proxy_redirects``: Number of redirects installed for endpoints, labeled by protocol
+* ``proxy_upstream_reply_seconds``: Seconds waited for upstream server to reply to a request
 * ``policy_l7_parse_errors_total``: Number of total L7 parse errors
 * ``policy_l7_forwarded_total``: Number of total L7 forwarded requests/responses
 * ``policy_l7_denied_total``: Number of total L7 denied requests/responses due to policy
 * ``policy_l7_received_total``: Number of total L7 received requests/responses
+
 
 Events external to Cilium
 -------------------------

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1937,7 +1937,7 @@ func (e *Endpoint) UpdateLabels(owner Owner, identityLabels, infoLabels pkgLabel
 	}).Debug("Refreshing labels of endpoint")
 
 	if err := e.LockAlive(); err != nil {
-		e.LogDisconnectedMutexAction(err, "when trying to refresh endpint labels")
+		e.LogDisconnectedMutexAction(err, "when trying to refresh endpoint labels")
 		return
 	}
 

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -84,7 +84,7 @@ func (s *DNSProxyTestSuite) SetUpSuite(c *C) {
 		func(ip net.IP) (endpointID string, err error) {
 			return "endpoint1", nil
 		},
-		func(lookupTime time.Time, srcAddr, dstAddr string, msg *dns.Msg, protocol string, allowed bool, proxyErr error) error {
+		func(lookupTime time.Time, srcAddr, dstAddr string, msg *dns.Msg, protocol string, allowed bool, stat ProxyRequestContext) error {
 			return nil
 		})
 	c.Assert(err, IsNil, Commentf("error starting DNS Proxy"))

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -81,6 +81,9 @@ const (
 	// DNSName is a FQDN or not fully qualified name intended for DNS lookups
 	DNSName = "dnsName"
 
+	// DNSRequestID is the DNS request id used by dns-proxy
+	DNSRequestID = "DNSRequestID"
+
 	// IPAddr is an IPV4 or IPv6 address
 	IPAddr = "ipAddr"
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -305,12 +305,13 @@ var (
 		Help:      "Number of total L7 received requests/responses",
 	})
 
-	// ProxyUpstreamTime is how long the upstream server took to reply
+	// ProxyUpstreamTime is how long the upstream server took to reply labeled
+	// by error, protocol and span time
 	ProxyUpstreamTime = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: Namespace,
 		Name:      "proxy_upstream_reply_seconds",
-		Help:      "Seconds waited for upstream server to reply to a request",
-	}, []string{"error", LabelProtocolL7})
+		Help:      "Seconds waited to get a reply from a upstream server",
+	}, []string{"error", LabelProtocolL7, LabelScope})
 
 	// L3-L4 statistics
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -45,6 +45,15 @@ const (
 	// BuildStateRunning is the value of LabelBuildState to describe
 	// the number of builds currently running
 	BuildStateRunning = "running"
+
+	// ErrorTimeout is the value used to notify timeout errors.
+	ErrorTimeout = "timeout"
+
+	// ErrorProxy is the value used to notify errors on Proxy.
+	ErrorProxy = "proxy"
+
+	//L7DNS is the value used to report DNS label on metrics
+	L7DNS = "dns"
 )
 
 var (
@@ -296,6 +305,13 @@ var (
 		Help:      "Number of total L7 received requests/responses",
 	})
 
+	// ProxyUpstreamTime is how long the upstream server took to reply
+	ProxyUpstreamTime = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: Namespace,
+		Name:      "proxy_upstream_reply_seconds",
+		Help:      "Seconds waited for upstream server to reply to a request",
+	}, []string{"error", LabelProtocolL7})
+
 	// L3-L4 statistics
 
 	// DropCount is the total drop requests,
@@ -469,6 +485,7 @@ func init() {
 	MustRegister(ProxyForwarded)
 	MustRegister(ProxyDenied)
 	MustRegister(ProxyReceived)
+	MustRegister(ProxyUpstreamTime)
 
 	MustRegister(DropCount)
 	MustRegister(ForwardCount)


### PR DESCRIPTION
Hi, 

1) One commit that add a upstream proxy duration to track how is slow in a dns response. 
2) Typo fix. 
3) Added a request.ID in the log so it's easy to track issues. 

Regards.

PS: Not sure if you want to backport this to 1.4.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6672)
<!-- Reviewable:end -->
