### PR TITLE
cilium, ipvlan: fix tail call map fd leakage

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2232,10 +2232,6 @@ func (e *Endpoint) MapPin() error {
 	}
 
 	err = bpf.ObjPin(mapFd, e.BPFIpvlanMapPath())
-	if err != nil {
-		unix.Close(mapFd)
-		return err
-	}
-
-	return nil
+	unix.Close(mapFd)
+	return err
 }


### PR DESCRIPTION
After pinning we must close the fd we got before in success *and*
in error case.

Fixes: 7bfe015f3000 ("cilium, ipvlan: add initial endpoint ipvlan support")
Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6673)
<!-- Reviewable:end -->
