### PR TITLE
ipvlan support for libnetwork

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -900,7 +900,10 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 
 	ctmap.InitMapInfo(option.Config.CTMapEntriesGlobalTCP, option.Config.CTMapEntriesGlobalAny)
 
-	if err := workloads.Setup(option.Config.Workloads, map[string]string{}); err != nil {
+	wOpts := map[string]string{
+		workloads.DatapathModeOpt: option.Config.DatapathMode,
+	}
+	if err := workloads.Setup(option.Config.Workloads, wOpts); err != nil {
 		return nil, nil, fmt.Errorf("unable to setup workload: %s", err)
 	}
 

--- a/pkg/endpoint/connector/add.go
+++ b/pkg/endpoint/connector/add.go
@@ -17,7 +17,6 @@ package connector
 import (
 	"crypto/sha256"
 	"fmt"
-	"math/rand"
 	"net"
 	"os"
 
@@ -54,21 +53,6 @@ func Endpoint2TempIfName(endpointID string) string {
 }
 
 var ifChars = []rune("abcdefghijklmnopqrstuvwxyz")
-
-func randIfStr(num int) string {
-	str := make([]rune, num)
-	for i := range str {
-		str[i] = ifChars[rand.Intn(len(ifChars))]
-	}
-	return string(str)
-}
-
-// Endpoint2TempRandIfName returns a random, temporary interface name for the
-// given endpointID. This is similar to Endpoint2TempIfName() but uses a
-// random string instead of endpoint ID.
-func Endpoint2TempRandIfName() string {
-	return temporaryInterfacePrefix + "_" + randIfStr(5)
-}
 
 func truncateString(epID string, maxLen uint) string {
 	if maxLen <= uint(len(epID)) {

--- a/pkg/endpoint/connector/ipvlan.go
+++ b/pkg/endpoint/connector/ipvlan.go
@@ -237,7 +237,7 @@ func SetupIpvlan(id string, mtu, masterDev int, mode string, ep *models.Endpoint
 		return nil, nil, "", fmt.Errorf("invalid or unsupported ipvlan operation mode: %s", mode)
 	}
 
-	tmpIfName := Endpoint2TempRandIfName()
+	tmpIfName := Endpoint2TempIfName(id)
 	ipvlan, link, err := setupIpvlanWithNames(tmpIfName, mtu, masterDev, ipvlanMode, ep)
 
 	return ipvlan, link, tmpIfName, err

--- a/pkg/endpoint/connector/ipvlan.go
+++ b/pkg/endpoint/connector/ipvlan.go
@@ -156,9 +156,11 @@ func SetupIpvlanRemoteNs(netNs ns.NetNS, srcIfName, dstIfName string) (int, int,
 	err = netNs.Do(func(_ ns.NetNS) error {
 		var err error
 
-		err = link.Rename(srcIfName, dstIfName)
-		if err != nil {
-			return fmt.Errorf("failed to rename ipvlan from %q to %q: %s", srcIfName, dstIfName, err)
+		if srcIfName != dstIfName {
+			err = link.Rename(srcIfName, dstIfName)
+			if err != nil {
+				return fmt.Errorf("failed to rename ipvlan from %q to %q: %s", srcIfName, dstIfName, err)
+			}
 		}
 
 		ipvlan, err := netlink.LinkByName(dstIfName)

--- a/pkg/endpoint/connector/ipvlan.go
+++ b/pkg/endpoint/connector/ipvlan.go
@@ -244,7 +244,10 @@ func SetupIpvlan(id string, mtu, masterDev int, mode string, ep *models.Endpoint
 }
 
 func setupIpvlanWithNames(lxcIfName string, mtu, masterDev int, mode netlink.IPVlanMode, ep *models.EndpointChangeRequest) (*netlink.IPVlan, *netlink.Link, error) {
-	var err error
+	var (
+		link netlink.Link
+		err  error
+	)
 
 	ipvlan := &netlink.IPVlan{
 		LinkAttrs: netlink.LinkAttrs{
@@ -279,7 +282,7 @@ func setupIpvlanWithNames(lxcIfName string, mtu, masterDev int, mode netlink.IPV
 		return nil, nil, fmt.Errorf("unable to disable %s: %s", rpFilterPath, err)
 	}
 
-	link, err := netlink.LinkByName(lxcIfName)
+	link, err = netlink.LinkByName(lxcIfName)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to lookup ipvlan slave just created: %s", err)
 	}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -144,6 +144,9 @@ type Endpoint struct {
 	// Corresponding BPF map identifier for tail call map of ipvlan datapath
 	dataPathMapID int
 
+	// isDatapathMapPinned denotes whether the datapath map has been pinned.
+	isDatapathMapPinned bool
+
 	// IfName is the name of the host facing interface (veth pair) which
 	// connects into the endpoint
 	IfName string
@@ -2232,6 +2235,11 @@ func (e *Endpoint) MapPin() error {
 	}
 
 	err = bpf.ObjPin(mapFd, e.BPFIpvlanMapPath())
-	unix.Close(mapFd)
+	defer unix.Close(mapFd)
+
+	if err != nil {
+		e.isDatapathMapPinned = true
+	}
+
 	return err
 }

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1591,7 +1591,7 @@ func (e *Endpoint) GetDockerNetworkID() string {
 // SetDatapathMapIDAndPinMapLocked modifies the endpoint's datapath map ID
 func (e *Endpoint) SetDatapathMapIDAndPinMapLocked(id int) error {
 	e.dataPathMapID = id
-	return e.MapPin()
+	return e.MapPinLocked()
 }
 
 // IsDatapathMapPinnedLocked returns whether the endpoint's datapath map has been pinned
@@ -2235,7 +2235,7 @@ func (e *Endpoint) IsDisconnecting() bool {
 
 // MapPinLocked retrieves a file descriptor from the map ID from the API call
 // and pins the corresponding map into the BPF file system.
-func (e *Endpoint) MapPin() error {
+func (e *Endpoint) MapPinLocked() error {
 	if e.dataPathMapID == 0 {
 		return nil
 	}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1588,6 +1588,17 @@ func (e *Endpoint) GetDockerNetworkID() string {
 	return e.DockerNetworkID
 }
 
+// SetDatapathMapIDAndPinMapLocked modifies the endpoint's datapath map ID
+func (e *Endpoint) SetDatapathMapIDAndPinMapLocked(id int) error {
+	e.dataPathMapID = id
+	return e.MapPin()
+}
+
+// IsDatapathMapPinnedLocked returns whether the endpoint's datapath map has been pinned
+func (e *Endpoint) IsDatapathMapPinnedLocked() bool {
+	return e.isDatapathMapPinned
+}
+
 // GetState returns the endpoint's state
 // endpoint.Mutex may only be.RLockAlive()ed
 func (e *Endpoint) GetStateLocked() string {
@@ -2222,7 +2233,7 @@ func (e *Endpoint) IsDisconnecting() bool {
 	return e.state == StateDisconnected || e.state == StateDisconnecting
 }
 
-// MapPin retrieves a file descriptor from the map ID from the API call
+// MapPinLocked retrieves a file descriptor from the map ID from the API call
 // and pins the corresponding map into the BPF file system.
 func (e *Endpoint) MapPin() error {
 	if e.dataPathMapID == 0 {
@@ -2237,7 +2248,7 @@ func (e *Endpoint) MapPin() error {
 	err = bpf.ObjPin(mapFd, e.BPFIpvlanMapPath())
 	defer unix.Close(mapFd)
 
-	if err != nil {
+	if err == nil {
 		e.isDatapathMapPinned = true
 	}
 

--- a/pkg/workloads/runtimes.go
+++ b/pkg/workloads/runtimes.go
@@ -53,6 +53,8 @@ const (
 
 const (
 	epOpt = "endpoint"
+	// DatapathModeOpt is the option name for datapath mode
+	DatapathModeOpt = "datapath-mode"
 )
 
 type workloadRuntimeOpt struct {
@@ -188,8 +190,14 @@ func GetRuntimeOptions() string {
 
 	for _, cr := range crs {
 		rb := registeredWorkloads[workloadRuntimeType(cr)]
-		for k, v := range rb.getConfig() {
-			crtStr = append(crtStr, fmt.Sprintf("%s=%s", k, v))
+		cfg := rb.getConfig()
+		keys := make([]string, 0, len(cfg))
+		for k := range cfg {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			crtStr = append(crtStr, fmt.Sprintf("%s=%s", k, cfg[k]))
 		}
 	}
 	return strings.Join(crtStr, ",")

--- a/pkg/workloads/runtimes_test.go
+++ b/pkg/workloads/runtimes_test.go
@@ -46,7 +46,8 @@ func (s *WorkloadsTestSuite) TestParseConfigEndpoint(c *C) {
 		epOpt: "unix:///foo.sock",
 	}
 	dockerOpts := map[string]string{
-		epOpt: "unix:///docker.sock",
+		epOpt:           "unix:///docker.sock",
+		DatapathModeOpt: "veth",
 	}
 
 	type args struct {
@@ -270,6 +271,7 @@ func (s *WorkloadsTestSuite) TestGetRuntimeOptions(c *C) {
 			name: "default options",
 			want: epOpt + "=" + containerDInstance.opts[epOpt].value + "," +
 				epOpt + "=" + criOInstance.opts[epOpt].value + "," +
+				DatapathModeOpt + "=" + dockerInstance.opts[DatapathModeOpt].value + "," +
 				epOpt + "=" + dockerInstance.opts[epOpt].value,
 		},
 	}

--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -421,20 +421,10 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 			return err
 		}
 	case option.DatapathModeIpvlan:
-		var mode netlink.IPVlanMode
-
 		ipvlanConf := *conf.IpvlanConfiguration
 		index := int(ipvlanConf.MasterDeviceIndex)
-		switch ipvlanConf.OperationMode {
-		case option.OperationModeL3:
-			mode = netlink.IPVLAN_MODE_L3
-		case option.OperationModeL3S:
-			mode = netlink.IPVLAN_MODE_L3S
-		default:
-			return fmt.Errorf("invalid or unsupported ipvlan operation mode: %s", ipvlanConf.OperationMode)
-		}
 
-		ipvlan, link, tmpIfName, err := connector.SetupIpvlan(ep.ContainerID, int(conf.DeviceMTU), index, mode, ep)
+		ipvlan, link, tmpIfName, err := connector.SetupIpvlan(ep.ContainerID, int(conf.DeviceMTU), index, ipvlanConf.OperationMode, ep)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
- [x] Fix `level=warning msg="Unable to setup ipvlan slave" containerID=d3209e6eaf error="failed to create clsact qdisc on \"cilium0\": file exists" maxRetry=20 retry=1 subsys=workload-watcher willRetry=false`.
- [ ] Fix restoration of endpoint after cilium-agent has restarted.
- [ ] Integration tests.
- [ ] Update guides.

EDIT: ^^ will be done in separate PRs.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6674)
<!-- Reviewable:end -->
