### PR TITLE
examples/kubernetes: add missing host mount for bpf-maps

### DIFF
--- a/examples/kubernetes/1.13/cilium-crio.yaml
+++ b/examples/kubernetes/1.13/cilium-crio.yaml
@@ -352,6 +352,11 @@ spec:
           path: /var/run/cilium
           type: DirectoryOrCreate
         name: cilium-run
+        # To keep state between restarts / upgrades for bpf maps
+      - hostPath:
+          path: /sys/fs/bpf
+          type: DirectoryOrCreate
+        name: bpf-maps
         # To read labels from CRI-O containers running in the host
       - hostPath:
           path: /var/run/crio/crio.sock


### PR DESCRIPTION
Signed-off-by: Nirmoy Das <ndas@suse.de>

Error before this PR:
kubectl apply -f examples/kubernetes/1.13/cilium-crio.yaml
configmap "cilium-config" unchanged
deployment.apps "cilium-operator" unchanged
serviceaccount "cilium-operator" unchanged
clusterrole.rbac.authorization.k8s.io "cilium-operator" configured
clusterrolebinding.rbac.authorization.k8s.io "cilium-operator" configured
clusterrole.rbac.authorization.k8s.io "cilium-etcd-operator" configured
clusterrolebinding.rbac.authorization.k8s.io "cilium-etcd-operator" configured
clusterrole.rbac.authorization.k8s.io "etcd-operator" configured
clusterrolebinding.rbac.authorization.k8s.io "etcd-operator" configured
serviceaccount "cilium-etcd-operator" unchanged
serviceaccount "cilium-etcd-sa" unchanged
deployment.apps "cilium-etcd-operator" unchanged
clusterrolebinding.rbac.authorization.k8s.io "cilium" configured
clusterrole.rbac.authorization.k8s.io "cilium" configured
serviceaccount "cilium" unchanged
The DaemonSet "cilium" is invalid:
* spec.template.spec.containers[0].volumeMounts[0].name: Not found: "bpf-maps"
* spec.template.spec.initContainers[0].volumeMounts[0].name: Not found: "bpf-maps"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6675)
<!-- Reviewable:end -->
