### PR TITLE
v1.3 backports 19-01-18

### DIFF
--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -321,7 +321,7 @@ func (h *putEndpointID) Handle(params PutEndpointIDParams) middleware.Responder 
 				hasSidecarProxy := e.HasSidecarProxy()
 				e.RUnlock()
 
-				if hasSidecarProxy {
+				if hasSidecarProxy && e.HasBPFProgram() {
 					// If the endpoint is determined to have a sidecar proxy,
 					// return immediately to let the sidecar container start,
 					// in case it is required to enforce L7 rules.
@@ -521,6 +521,13 @@ func (d *Daemon) deleteEndpointQuiet(ep *endpoint.Endpoint, releaseIP bool) []er
 
 	// Wait for existing builds to complete and prevent further builds
 	ep.BuildMutex.Lock()
+
+	// Given that we are deleting the endpoint and that no more builds are
+	// going to occur for this endpoint, close the channel which signals whether
+	// the endpoint has its BPF program compiled or not to avoid it persisting
+	// if anything is blocking on it. If a delete request has already been
+	// enqueued for this endpoint, this is a no-op.
+	ep.CloseBPFProgramChannel()
 
 	// Lock out any other writers to the endpoint
 	ep.UnconditionalLock()

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -770,7 +770,16 @@ func (e *Endpoint) regenerateBPF(owner Owner, currentDir, nextDir string, regenC
 			Debug("BPF header file unchanged, skipping BPF compilation and installation")
 	}
 
+	// Hook the endpoint into the endpoint table and expose it
+	stats.mapSync.Start()
+	err = lxcmap.WriteEndpoint(epInfoCache)
+	stats.mapSync.End(err == nil)
+	if err != nil {
+		return 0, compilationExecuted, fmt.Errorf("Exposing new BPF failed: %s", err)
+	}
+
 	// Signal that BPF program has been generated.
+	// The endpoint has at least L3/L4 connectivity at this point.
 	e.CloseBPFProgramChannel()
 
 	// Allow another builder to start while we wait for the proxy
@@ -806,17 +815,10 @@ func (e *Endpoint) regenerateBPF(owner Owner, currentDir, nextDir string, regenC
 	// policy map with the new proxy ports.
 	stats.mapSync.Start()
 	err = e.syncPolicyMap()
+	stats.mapSync.End(err == nil)
 	if err != nil {
-		stats.mapSync.End(false)
 		return 0, compilationExecuted, fmt.Errorf("unable to regenerate policy because PolicyMap synchronization failed: %s", err)
 	}
-
-	// The last operation hooks the endpoint into the endpoint table and exposes it
-	err = lxcmap.WriteEndpoint(epInfoCache)
-	if err != nil {
-		log.WithField(logfields.EndpointID, e.ID).WithError(err).Error("Exposing new bpf failed")
-	}
-	stats.mapSync.End(true)
 
 	return epInfoCache.revision, compilationExecuted, err
 }

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -770,6 +770,9 @@ func (e *Endpoint) regenerateBPF(owner Owner, currentDir, nextDir string, regenC
 			Debug("BPF header file unchanged, skipping BPF compilation and installation")
 	}
 
+	// Signal that BPF program has been generated.
+	e.CloseBPFProgramChannel()
+
 	// Allow another builder to start while we wait for the proxy
 	if regenContext.DoneFunc != nil {
 		regenContext.DoneFunc()

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -485,6 +485,8 @@ type Endpoint struct {
 	// is enabled for this endpoint.
 	egressPolicyEnabled bool
 
+	hasBPFProgram chan struct{}
+
 	///////////////////////
 	// DEPRECATED FIELDS //
 	///////////////////////
@@ -494,6 +496,28 @@ type Endpoint struct {
 	//
 	// Deprecated: Use Options instead.
 	DeprecatedOpts deprecatedOptions `json:"Opts"`
+}
+
+// CloseBPFProgramChannel closes the channel that signals whether the endpoint
+// has had its BPF program compiled. If the channel is already closed, this is
+// a no-op.
+func (e *Endpoint) CloseBPFProgramChannel() {
+	select {
+	case <-e.hasBPFProgram:
+	default:
+		close(e.hasBPFProgram)
+	}
+}
+
+// HasBPFProgram returns whether a BPF program has been generated for this
+// endpoint.
+func (e *Endpoint) HasBPFProgram() bool {
+	select {
+	case <-e.hasBPFProgram:
+		return true
+	default:
+		return false
+	}
 }
 
 // GetIngressPolicyEnabledLocked returns whether ingress policy enforcement is
@@ -731,10 +755,11 @@ func (e *Endpoint) RunK8sCiliumEndpointSync() {
 // NewEndpointWithState creates a new endpoint useful for testing purposes
 func NewEndpointWithState(ID uint16, state string) *Endpoint {
 	ep := &Endpoint{
-		ID:      ID,
-		Options: option.NewIntOptions(&EndpointMutableOptionLibrary),
-		Status:  NewEndpointStatus(),
-		state:   state,
+		ID:            ID,
+		Options:       option.NewIntOptions(&EndpointMutableOptionLibrary),
+		Status:        NewEndpointStatus(),
+		state:         state,
+		hasBPFProgram: make(chan struct{}, 0),
 	}
 	ep.UpdateLogger(nil)
 	return ep
@@ -762,8 +787,9 @@ func NewEndpointFromChangeModel(base *models.EndpointChangeRequest) (*Endpoint, 
 			OrchestrationIdentity: pkgLabels.Labels{},
 			OrchestrationInfo:     pkgLabels.Labels{},
 		},
-		state:  "",
-		Status: NewEndpointStatus(),
+		state:         "",
+		Status:        NewEndpointStatus(),
+		hasBPFProgram: make(chan struct{}, 0),
 	}
 
 	ep.UpdateLogger(nil)
@@ -1494,6 +1520,9 @@ func ParseEndpoint(strEp string) (*Endpoint, error) {
 	if err := parseBase64ToEndpoint(strEpSlice[1], &ep); err != nil {
 		return nil, fmt.Errorf("failed to parse base64toendpoint: %s", err)
 	}
+
+	// Initialize fields to values which are non-nil that are not serialized.
+	ep.hasBPFProgram = make(chan struct{}, 0)
 
 	// We need to check for nil in Status, CurrentStatuses and Log, since in
 	// some use cases, status will be not nil and Cilium will eventually

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2446,8 +2446,14 @@ func (e *Endpoint) runLabelsResolver(owner Owner, myChangeRev int, blocking bool
 	if blocking || identityPkg.IdentityAllocationIsLocal(newLabels) {
 		scopedLog.Debug("Endpoint has reserved identity, changing synchronously")
 		err := e.identityLabelsChanged(owner, myChangeRev)
-		if err != nil {
-			scopedLog.WithError(err).Warn("Error changing endpoint identity")
+		switch err {
+		case ErrNotAlive:
+			scopedLog.Debug("not changing endpoint identity because endpoint is in process of being removed")
+			return
+		default:
+			if err != nil {
+				scopedLog.WithError(err).Warn("Error changing endpoint identity")
+			}
 		}
 	}
 
@@ -2455,7 +2461,14 @@ func (e *Endpoint) runLabelsResolver(owner Owner, myChangeRev int, blocking bool
 	e.controllers.UpdateController(ctrlName,
 		controller.ControllerParams{
 			DoFunc: func() error {
-				return e.identityLabelsChanged(owner, myChangeRev)
+				err := e.identityLabelsChanged(owner, myChangeRev)
+				switch err {
+				case ErrNotAlive:
+					e.getLogger().Debug("not changing endpoint identity because endpoint is in process of being removed")
+					return nil
+				default:
+					return err
+				}
 			},
 			RunInterval: 5 * time.Minute,
 		},
@@ -2464,7 +2477,7 @@ func (e *Endpoint) runLabelsResolver(owner Owner, myChangeRev int, blocking bool
 
 func (e *Endpoint) identityLabelsChanged(owner Owner, myChangeRev int) error {
 	if err := e.RLockAlive(); err != nil {
-		return err
+		return ErrNotAlive
 	}
 	newLabels := e.OpLabels.IdentityLabels()
 	elog := e.getLogger().WithFields(logrus.Fields{

--- a/pkg/endpoint/errors.go
+++ b/pkg/endpoint/errors.go
@@ -1,0 +1,23 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endpoint
+
+import "errors"
+
+var (
+	// ErrNotAlive is an error which indicates that the endpoint should not be
+	// rlocked because it is currently being removed.
+	ErrNotAlive = errors.New("rlock failed: endpoint is in the process of being removed")
+)

--- a/pkg/endpoint/lock.go
+++ b/pkg/endpoint/lock.go
@@ -36,7 +36,7 @@ func (e *Endpoint) RLockAlive() error {
 	e.mutex.RLock()
 	if e.IsDisconnecting() {
 		e.mutex.RUnlock()
-		return fmt.Errorf("rlock failed: endpoint is in the process of being removed")
+		return ErrNotAlive
 	}
 	return nil
 }

--- a/pkg/ipam/allocator.go
+++ b/pkg/ipam/allocator.go
@@ -100,6 +100,9 @@ func AllocateNext(family string) (net.IP, net.IP, error) {
 	if (family == "ipv4" || family == "") && ipamConf.IPv4Allocator != nil {
 		ipConf, err := ipamConf.IPv4Allocator.AllocateNext()
 		if err != nil {
+			if ipv6 != nil {
+				ipamConf.IPv6Allocator.Release(ipv6)
+			}
 			return nil, nil, err
 		}
 

--- a/pkg/kvstore/lock.go
+++ b/pkg/kvstore/lock.go
@@ -59,10 +59,15 @@ func (pl *pathLocks) lock(path string) {
 		}
 
 		if time.Since(started) > lockTimeout {
-			log.WithField("path", path).Warning("WARNING: Timeout while waiting for lock, ignoring lock")
-			pl.lockPaths[path] = 1
+			log.WithField("path", path).Warning("Timeout while waiting for lock, forcefully unlocking...")
+			pl.lockPaths[path] = 0
 			pl.mutex.Unlock()
-			return
+
+			// The lock was forcefully released, restart a new
+			// timeout period as we will attempt to acquire the
+			// local lock again
+			started = time.Now()
+			continue
 		}
 
 		pl.mutex.Unlock()


### PR DESCRIPTION
Backported PRs

* PR: 5869 -- endpoint: signal when BPF program is compiled for the first time (@ianvernon) -- #5869
This is needed for the Istio integration to work in v1.3.
* PR: 6699 -- Fix stale kvstore lock timeout behavior (@tgraf) -- https://github.com/cilium/cilium/pull/6699
 * PR: 6719 -- ipam: Release IPv6 IP when AllocateNext() is requested to allocate both and fails (@tgraf) -- https://github.com/cilium/cilium/pull/6719
* PR: 6750 -- endpoint: do not return error if endpoint RLock fails due to endpoint being removed (@ianvernon) -- https://github.com/cilium/cilium/pull/6750
 
PRs not backported due to merge conflicts:

PR: 6671 -- Fix route lookup and add workaround for kernel race condition (@tgraf) -- #6671
cc: @tgraf

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6688)
<!-- Reviewable:end -->
