### PR TITLE
workloads/crio: do not print StatusResponse struct

### DIFF
--- a/pkg/workloads/cri.go
+++ b/pkg/workloads/cri.go
@@ -116,8 +116,13 @@ func (c *criClient) Status() *models.Status {
 	if err != nil {
 		return &models.Status{State: models.StatusStateFailure, Msg: err.Error()}
 	}
+	for _, runtimeCondition := range sresp.Status.Conditions {
+		if !runtimeCondition.Status {
+			return &models.Status{State: models.StatusStateFailure, Msg: runtimeCondition.Message}
+		}
 
-	return &models.Status{State: models.StatusStateOk, Msg: sresp.String()}
+	}
+	return &models.Status{State: models.StatusStateOk, Msg: "cri daemon: Ok"}
 }
 
 // EnableEventListener watches for containerD events. Performs the plumbing for the

--- a/pkg/workloads/crio.go
+++ b/pkg/workloads/crio.go
@@ -101,8 +101,8 @@ func (c *criOClient) Status() *models.Status {
 	criStatusMsg := fmt.Sprintf("cri-o client: %s - %s", criStatus.State, criStatus.Msg)
 
 	return &models.Status{
-		State: models.StatusStateOk,
-		Msg:   fmt.Sprintf(criStatusMsg, models.StatusStateOk),
+		State: criStatus.State,
+		Msg:   criStatusMsg,
 	}
 }
 


### PR DESCRIPTION
workloads/crio: do not print StatusResponse struct
    
    StatusResponse.String() spit out raw struct
    ./daemon/cilium status
    KVStore:                Ok         Consul: 172.17.0.2:8300
    ContainerRuntime:       Ok         cri-o client: Ok - &StatusResponse{Status:&RuntimeStatus{Conditions:[&RuntimeCondition{Type:RuntimeReady,Status:true,Reason:,Message:,} &RuntimeCondition{Type:NetworkReady,Status:false,Reason:NetworkPluginNotReady,Message:Network plugin returns error: cni config uninitialized,}],},Info:map[string]string{},}%!(EXTRA string=Ok)
    Kubernetes:             Disabled
    
    With this PR:
    sudo ./daemon/cilium status
    KVStore:             Ok         Consul: 172.17.0.2:8300
    ContainerRuntime:    Failure    cri-o client: Failure - Network plugin returns error: cni config uninitialized
    Kubernetes:          Disabled
    Cilium:              Failure    Container runtime is not ready
    NodeMonitor:         Disabled
    
    Signed-off-by: Nirmoy Das <ndas@suse.de>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6691)
<!-- Reviewable:end -->
