### PR TITLE
daemon: Create BPF maps before restoring service IDs

### DIFF
--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -961,17 +961,6 @@ func initEnv(cmd *cobra.Command) {
 		}
 	}
 
-	// Read the service IDs of existing services from the BPF map and
-	// reserve them. This must be done *before* connecting to the
-	// Kubernetes apiserver and serving the API to ensure service IDs are
-	// not changing across restarts or that a new service could accidentally
-	// use an existing service ID.
-	if option.Config.RestoreState {
-		restoreServiceIDs()
-	}
-
-	k8s.Configure(option.Config.K8sAPIServer, option.Config.K8sKubeConfigPath)
-
 	if option.Config.WorkloadsEnabled() {
 		// workaround for to use the values of the deprecated dockerEndpoint
 		// variable if it is set with a different value than defaults.


### PR DESCRIPTION
Restoring service IDs is an operation which includes reading from a BPF
map, but it was done before any BFP map was created. It was always
failing with error on the first run of Cilium.

This change ensures that daemon initialization keeps the following steps
in the following order:

1. Creating BPF maps.
2. Restoring service IDs.
3. Configuring Kubernetes client and any operation on Kubernetes API.
4. IPAM initialization.
5. Compilation of base BPF programs.

Before this change, creating BPF maps and compilation of base BPF
programs were done in one step as the last operation of daemon
initialization.

Fixes: 3b5133ad5476 ("service: Restore service IDs before connecting to
Kubernetes apiserver")
Fixes: #6642

Signed-off-by: Michal Rostecki <mrostecki@suse.de>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6694)
<!-- Reviewable:end -->
