### PR TITLE
plugins/cilium-cni: do not error if variable unset

### DIFF
--- a/plugins/cilium-cni/cni-install.sh
+++ b/plugins/cilium-cni/cni-install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -eu
+set -e
 
 HOST_PREFIX=${HOST_PREFIX:-/host}
 if [ -z "${CILIUM_FLANNEL_MASTER_DEVICE}" ]; then

--- a/plugins/cilium-cni/cni-uninstall.sh
+++ b/plugins/cilium-cni/cni-uninstall.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -eu
+set -e
 
 HOST_PREFIX=${HOST_PREFIX:-/host}
 if [ -z "${CILIUM_FLANNEL_MASTER_DEVICE}" ]; then


### PR DESCRIPTION
As some users will not have the CILIUM_FLANNEL_MASTER_DEVICE nor
CILIUM_FLANNEL_UNINSTALL_ON_EXIT environment labels set in their
environments, the cni installation scripts will fail to run preventing
cilium from starting.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6695)
<!-- Reviewable:end -->
