### PR TITLE
k8s: Restructure and optimize CEP

### DIFF
--- a/pkg/controller/manager.go
+++ b/pkg/controller/manager.go
@@ -231,3 +231,29 @@ func (m *Manager) GetStatusModel() models.ControllerStatuses {
 
 	return statuses
 }
+
+// FakeManager returns a fake controller manager with the specified number of
+// failing controllers. The returned manager is identical in any regard except
+// for internal pointers.
+func FakeManager(failingControllers int) Manager {
+	m := Manager{
+		controllers: controllerMap{},
+	}
+
+	for i := 0; i < failingControllers; i++ {
+		ctrl := &Controller{
+			name:              fmt.Sprintf("controller-%d", i),
+			uuid:              fmt.Sprintf("%d", i),
+			stop:              make(chan struct{}, 0),
+			update:            make(chan struct{}, 1),
+			terminated:        make(chan struct{}, 0),
+			lastError:         fmt.Errorf("controller failed"),
+			failureCount:      1,
+			consecutiveErrors: 1,
+		}
+
+		m.controllers[ctrl.name] = ctrl
+	}
+
+	return m
+}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -516,7 +516,10 @@ func (e *Endpoint) GetModelRLocked() *models.Endpoint {
 
 	spec := &models.EndpointConfigurationSpec{
 		LabelConfiguration: lblMdl.Realized,
-		Options:            *e.Options.GetMutableModel(),
+	}
+
+	if e.Options != nil {
+		spec.Options = *e.Options.GetMutableModel()
 	}
 
 	mdl := &models.Endpoint{

--- a/pkg/endpoint/endpoint_status.go
+++ b/pkg/endpoint/endpoint_status.go
@@ -1,0 +1,235 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endpoint
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/identity"
+	identitycache "github.com/cilium/cilium/pkg/identity/cache"
+	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/policy/trafficdirection"
+)
+
+func getEndpointStatusControllers(status *models.EndpointStatus) (controllers cilium_v2.ControllerList) {
+	for _, c := range status.Controllers {
+		if c.Status == nil {
+			continue
+		}
+
+		if c.Status.ConsecutiveFailureCount > 0 {
+			s := cilium_v2.ControllerStatus{
+				Configuration: c.Configuration,
+				Name:          c.Name,
+				UUID:          string(c.UUID),
+				Status: cilium_v2.ControllerStatusStatus{
+					ConsecutiveFailureCount: c.Status.ConsecutiveFailureCount,
+					FailureCount:            c.Status.FailureCount,
+					LastFailureMsg:          c.Status.LastFailureMsg,
+					LastFailureTimestamp:    c.Status.LastFailureTimestamp.String(),
+					LastSuccessTimestamp:    c.Status.LastSuccessTimestamp.String(),
+					SuccessCount:            c.Status.SuccessCount,
+				},
+			}
+			if controllers == nil {
+				controllers = cilium_v2.ControllerList{s}
+			} else {
+				controllers = append(controllers, s)
+			}
+		}
+	}
+
+	if controllers != nil {
+		controllers.Sort()
+	}
+
+	return
+}
+
+func (e *Endpoint) getEndpointStatusLog() (log []*models.EndpointStatusChange) {
+	added := 0
+
+	if s := e.Status; s != nil {
+		s.indexMU.RLock()
+		defer s.indexMU.RUnlock()
+
+		for i := s.lastIndex(); ; i-- {
+			if i < 0 {
+				i = maxLogs - 1
+			}
+			if i < len(s.Log) && s.Log[i] != nil {
+				l := &models.EndpointStatusChange{
+					Timestamp: s.Log[i].Timestamp.Format(time.RFC3339),
+					Code:      s.Log[i].Status.Code.String(),
+					Message:   s.Log[i].Status.Msg,
+					State:     models.EndpointState(s.Log[i].Status.State),
+				}
+
+				if strings.ToLower(l.Code) != models.EndpointStatusChangeCodeOk {
+					if log == nil {
+						log = []*models.EndpointStatusChange{l}
+					} else {
+						log = append(log, l)
+					}
+
+					// Limit the number of endpoint log
+					// entries to keep the size of the
+					// EndpointStatus low.
+					added++
+					if added >= cilium_v2.EndpointStatusLogEntries {
+						break
+					}
+				}
+			}
+			if i == s.Index {
+				break
+			}
+		}
+	}
+	return
+}
+
+func getEndpointIdentity(status *models.EndpointStatus) (identity *cilium_v2.EndpointIdentity) {
+	if status.Identity != nil {
+		identity = &cilium_v2.EndpointIdentity{
+			ID: status.Identity.ID,
+		}
+
+		identity.Labels = make([]string, len(status.Identity.Labels))
+		copy(identity.Labels, status.Identity.Labels)
+		sort.Strings(identity.Labels)
+	}
+	return
+}
+
+func getEndpointNetworking(status *models.EndpointStatus) (networking *cilium_v2.EndpointNetworking) {
+	if status.Networking != nil {
+		networking = &cilium_v2.EndpointNetworking{
+			Addressing: make(cilium_v2.AddressPairList, len(status.Networking.Addressing)),
+		}
+		i := 0
+		for _, pair := range status.Networking.Addressing {
+			networking.Addressing[i] = &cilium_v2.AddressPair{
+				IPV4: pair.IPV4,
+				IPV6: pair.IPV6,
+			}
+			i++
+		}
+
+		networking.Addressing.Sort()
+	}
+	return
+}
+
+func (e *Endpoint) getEndpointPolicy() (policy *cilium_v2.EndpointPolicy) {
+	if e.desiredPolicy != nil {
+		policy = &cilium_v2.EndpointPolicy{
+			Ingress: &cilium_v2.EndpointPolicyDirection{
+				Enforcing: e.desiredPolicy.IngressPolicyEnabled,
+			},
+			Egress: &cilium_v2.EndpointPolicyDirection{
+				Enforcing: e.desiredPolicy.EgressPolicyEnabled,
+			},
+		}
+
+		for policyKey := range e.desiredPolicy.PolicyMapState {
+			allowedIdentityTuple := cilium_v2.AllowedIdentityTuple{
+				DestPort: policyKey.DestPort,
+				Protocol: policyKey.Nexthdr,
+				Identity: uint64(policyKey.Identity),
+			}
+
+			identity := identitycache.LookupIdentityByID(identity.NumericIdentity(policyKey.Identity))
+			if identity != nil {
+				var l labels.Labels
+				if identity.CIDRLabel != nil {
+					l = identity.CIDRLabel
+				} else {
+					l = identity.Labels
+				}
+
+				allowedIdentityTuple.IdentityLabels = l.StringMap()
+			}
+
+			switch policyKey.TrafficDirection {
+			case trafficdirection.Ingress.Uint8():
+				if policy.Ingress.Allowed == nil {
+					policy.Ingress.Allowed = cilium_v2.AllowedIdentityList{allowedIdentityTuple}
+				} else {
+					policy.Ingress.Allowed = append(policy.Ingress.Allowed, allowedIdentityTuple)
+				}
+			case trafficdirection.Egress.Uint8():
+				if policy.Egress.Allowed == nil {
+					policy.Egress.Allowed = cilium_v2.AllowedIdentityList{allowedIdentityTuple}
+				} else {
+					policy.Egress.Allowed = append(policy.Egress.Allowed, allowedIdentityTuple)
+				}
+			}
+		}
+
+		if policy.Ingress.Allowed != nil {
+			policy.Ingress.Allowed.Sort()
+		}
+
+		if policy.Egress.Allowed != nil {
+			policy.Egress.Allowed.Sort()
+		}
+	}
+
+	return
+}
+
+// GetCiliumEndpointStatus creates a cilium_v2.EndpointStatus of an endpoint.
+// See cilium_v2.EndpointStatus for a detailed explanation of each field.
+func (e *Endpoint) GetCiliumEndpointStatus() *cilium_v2.EndpointStatus {
+	e.mutex.RLock()
+	defer e.mutex.RUnlock()
+
+	model := e.GetModelRLocked()
+	modelStatus := model.Status
+
+	controllers := getEndpointStatusControllers(modelStatus)
+	identity := getEndpointIdentity(modelStatus)
+	log := e.getEndpointStatusLog()
+	networking := getEndpointNetworking(modelStatus)
+
+	return &cilium_v2.EndpointStatus{
+		ID:                  int64(e.ID),
+		ExternalIdentifiers: modelStatus.ExternalIdentifiers,
+		Controllers:         controllers,
+		Identity:            identity,
+		Log:                 log,
+		Networking:          networking,
+		Health:              modelStatus.Health,
+		State:               string(modelStatus.State),
+		Policy:              e.getEndpointPolicy(),
+
+		// Scheduled for deprecation in 1.5
+		//
+		// Status is deprecated but we have some users depending on
+		// these fields so they continue to be populated until version
+		// 1.5
+		Status: &cilium_v2.DeprecatedEndpointStatus{
+			Controllers: controllers,
+			Identity:    identity,
+			Log:         log,
+			Networking:  networking,
+		},
+	}
+}

--- a/pkg/endpoint/endpoint_status_test.go
+++ b/pkg/endpoint/endpoint_status_test.go
@@ -1,0 +1,251 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package endpoint
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/checker"
+	"github.com/cilium/cilium/pkg/controller"
+	"github.com/cilium/cilium/pkg/identity"
+	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/trafficdirection"
+
+	"gopkg.in/check.v1"
+)
+
+type endpointGeneratorSpec struct {
+	failingControllers       int
+	logErrors                int
+	allowedIngressIdentities int
+	allowedEgressIdentities  int
+	numPortsPerIdentity      int
+	fakeControllerManager    bool
+}
+
+func newEndpoint(c *check.C, spec endpointGeneratorSpec) *Endpoint {
+	e, err := NewEndpointFromChangeModel(&models.EndpointChangeRequest{
+		Addressing: &models.AddressPair{},
+		ID:         200,
+		Labels: models.Labels{
+			"k8s:io.cilium.k8s.policy.cluster=default",
+			"k8s:io.cilium.k8s.policy.serviceaccount=default",
+			"k8s:io.kubernetes.pod.namespace=default",
+			"k8s:name=probe",
+		},
+		State: models.EndpointState("waiting-for-identity"),
+	})
+	c.Assert(err, check.IsNil)
+
+	e.SecurityIdentity = &identity.Identity{
+		ID: 100,
+		Labels: labels.NewLabelsFromModel([]string{
+			"k8s:io.cilium.k8s.policy.cluster=default",
+			"k8s:io.cilium.k8s.policy.serviceaccount=default",
+			"k8s:io.kubernetes.pod.namespace=default",
+			"k8s:name=probe",
+		}),
+	}
+
+	if spec.fakeControllerManager {
+		e.controllers = controller.FakeManager(spec.failingControllers)
+	}
+
+	for i := 0; i < spec.logErrors; i++ {
+		e.Status.addStatusLog(&statusLogMsg{
+			Status: Status{Code: Failure, Msg: "Failure", Type: BPF},
+		})
+	}
+
+	e.desiredPolicy.PolicyMapState = policy.MapState{}
+
+	if spec.numPortsPerIdentity == 0 {
+		spec.numPortsPerIdentity = 1
+	}
+
+	for i := 0; i < spec.allowedIngressIdentities; i++ {
+		for n := 0; n < spec.numPortsPerIdentity; n++ {
+			key := policy.Key{
+				Identity:         uint32(i),
+				DestPort:         uint16(80 + n),
+				TrafficDirection: trafficdirection.Ingress.Uint8(),
+			}
+			e.desiredPolicy.PolicyMapState[key] = policy.MapStateEntry{}
+		}
+	}
+
+	for i := 0; i < spec.allowedIngressIdentities; i++ {
+		for n := 0; n < spec.numPortsPerIdentity; n++ {
+			key := policy.Key{
+				Identity:         uint32(i + 30000),
+				DestPort:         uint16(80 + n),
+				TrafficDirection: trafficdirection.Egress.Uint8(),
+			}
+			e.desiredPolicy.PolicyMapState[key] = policy.MapStateEntry{}
+		}
+	}
+
+	return e
+}
+
+func (s *EndpointSuite) TestGetCiliumEndpointStatusSuccessfulControllers(c *check.C) {
+	e := newEndpoint(c, endpointGeneratorSpec{})
+	cepA := e.GetCiliumEndpointStatus()
+
+	// Run successful controllers in the background
+	for i := 0; i < 50; i++ {
+		e.controllers.UpdateController(fmt.Sprintf("controller-%d", i),
+			controller.ControllerParams{
+				DoFunc:      func() error { return nil },
+				RunInterval: 10 * time.Millisecond,
+			},
+		)
+	}
+	defer e.controllers.RemoveAll()
+
+	// Generate EndpointStatus in quick interval while controllers are
+	// succeeding in the background
+	timeout := time.After(1 * time.Second)
+	tick := time.Tick(10 * time.Millisecond)
+	for {
+		select {
+		case <-timeout:
+			return
+		case <-tick:
+			cepB := e.GetCiliumEndpointStatus()
+			c.Assert(cepA, checker.DeepEquals, cepB)
+		}
+	}
+}
+
+func (s *EndpointSuite) TestGetCiliumEndpointStatusSuccessfulLog(c *check.C) {
+	e := newEndpoint(c, endpointGeneratorSpec{})
+	cepA := e.GetCiliumEndpointStatus()
+
+	go func() {
+		for i := 0; i < 1000; i++ {
+			e.Status.addStatusLog(&statusLogMsg{
+				Status: Status{Code: OK, Msg: "Success", Type: BPF},
+			})
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	// Generate EndpointStatus in quick interval while state transitions
+	// are succeeding in the background
+	timeout := time.After(1 * time.Second)
+	tick := time.Tick(10 * time.Millisecond)
+	for {
+		select {
+		case <-timeout:
+			return
+		case <-tick:
+			cepB := e.GetCiliumEndpointStatus()
+			c.Assert(cepA, checker.DeepEquals, cepB)
+		}
+	}
+}
+
+func (s *EndpointSuite) TestGetCiliumEndpointStatusDeepEqual(c *check.C) {
+	a := newEndpoint(c, endpointGeneratorSpec{
+		fakeControllerManager:    true,
+		failingControllers:       10,
+		logErrors:                maxLogs,
+		allowedIngressIdentities: 100,
+		allowedEgressIdentities:  100,
+		numPortsPerIdentity:      10,
+	})
+
+	b := newEndpoint(c, endpointGeneratorSpec{
+		fakeControllerManager:    true,
+		failingControllers:       10,
+		logErrors:                maxLogs,
+		allowedIngressIdentities: 100,
+		allowedEgressIdentities:  100,
+		numPortsPerIdentity:      10,
+	})
+
+	cepA := a.GetCiliumEndpointStatus()
+	cepB := b.GetCiliumEndpointStatus()
+
+	c.Assert(cepA, checker.DeepEquals, cepB)
+}
+
+func (s *EndpointSuite) TestGetCiliumEndpointStatusCorrectnes(c *check.C) {
+	e := newEndpoint(c, endpointGeneratorSpec{
+		fakeControllerManager:    true,
+		failingControllers:       10,
+		logErrors:                maxLogs,
+		allowedIngressIdentities: 100,
+		allowedEgressIdentities:  100,
+		numPortsPerIdentity:      10,
+	})
+
+	cep := e.GetCiliumEndpointStatus()
+
+	c.Assert(len(cep.Status.Log), check.Equals, cilium_v2.EndpointStatusLogEntries)
+}
+
+func (s *EndpointSuite) BenchmarkGetCiliumEndpointStatusDeepEqual(c *check.C) {
+	a := newEndpoint(c, endpointGeneratorSpec{
+		fakeControllerManager:    true,
+		failingControllers:       10,
+		logErrors:                maxLogs,
+		allowedIngressIdentities: 100,
+		allowedEgressIdentities:  100,
+		numPortsPerIdentity:      10,
+	})
+
+	b := newEndpoint(c, endpointGeneratorSpec{
+		fakeControllerManager:    true,
+		failingControllers:       10,
+		logErrors:                maxLogs,
+		allowedIngressIdentities: 100,
+		allowedEgressIdentities:  100,
+		numPortsPerIdentity:      10,
+	})
+
+	c.ResetTimer()
+	for i := 0; i < c.N; i++ {
+		if !reflect.DeepEqual(a, b) {
+			c.Errorf("DeepEqual failed")
+		}
+	}
+	c.StopTimer()
+}
+
+func (s *EndpointSuite) BenchmarkGetCiliumEndpointStatus(c *check.C) {
+	e := newEndpoint(c, endpointGeneratorSpec{
+		failingControllers:       10,
+		logErrors:                maxLogs,
+		allowedIngressIdentities: 100,
+		allowedEgressIdentities:  100,
+		numPortsPerIdentity:      10,
+	})
+
+	c.ResetTimer()
+	for i := 0; i < c.N; i++ {
+		status := e.GetCiliumEndpointStatus()
+		c.Assert(status, check.Not(check.IsNil))
+	}
+	c.StopTimer()
+}

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -36,6 +36,17 @@ type Identity struct {
 	// for faster lookup.
 	LabelArray labels.LabelArray `json:"-"`
 
+	// CIDRLabel is the primary identity label when the identity represents
+	// a CIDR. The Labels field will consist of all matching prefixes, e.g.
+	// 10.0.0.0/8
+	// 10.0.0.0/7
+	// 10.0.0.0/6
+	// [...]
+	// reserverd:world
+	//
+	// The CIDRLabel field will only contain 10.0.0.0/8
+	CIDRLabel labels.Labels `json:"-"`
+
 	// ReferenceCount counts the number of references pointing to this
 	// identity. This field is used by the owning cache of the identity.
 	ReferenceCount int

--- a/pkg/ipcache/cidr.go
+++ b/pkg/ipcache/cidr.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/labels/cidr"
 )
 
@@ -49,6 +50,8 @@ func AllocateCIDRs(impl Implementation, prefixes []*net.IPNet) error {
 			cache.ReleaseSlice(usedIdentities)
 			return fmt.Errorf("failed to allocate identity for cidr %s: %s", prefix.String(), err)
 		}
+
+		id.CIDRLabel = labels.NewLabelsFromModel([]string{labels.LabelSourceCIDR + ":" + prefix.String()})
 
 		usedIdentities = append(usedIdentities, id)
 		if isNew {

--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -41,7 +41,7 @@ const (
 
 	// CustomResourceDefinitionSchemaVersion is semver-conformant version of CRD schema
 	// Used to determine if CRD needs to be updated in cluster
-	CustomResourceDefinitionSchemaVersion = "1.12"
+	CustomResourceDefinitionSchemaVersion = "1.13"
 
 	// CustomResourceDefinitionSchemaVersionKey is key to label which holds the CRD schema version
 	CustomResourceDefinitionSchemaVersionKey = "io.cilium.k8s.crd.schema.version"

--- a/pkg/k8s/apis/cilium.io/v2/types.go
+++ b/pkg/k8s/apis/cilium.io/v2/types.go
@@ -17,6 +17,7 @@ package v2
 import (
 	"fmt"
 	"reflect"
+	"sort"
 	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -28,6 +29,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/policy/api"
 
+	"github.com/go-openapi/swag"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -274,31 +276,251 @@ type CiliumEndpoint struct {
 	// +k8s:openapi-gen=false
 	metav1.ObjectMeta `json:"metadata"`
 
-	Status CiliumEndpointDetail `json:"status"`
+	Status EndpointStatus `json:"status"`
 }
 
-// CiliumEndpointDetail is the status of a Cilium policy rule
+// EndpointStatus is the status of a Cilium endpoint
 // The custom deepcopy function below is a workaround. We can generate a
-// deepcopy for CiliumEndpointDetail but not for the various models.* types it
+// deepcopy for EndpointStatus but not for the various models.* types it
 // includes. We can't generate functions for classes in other packages, nor can
 // we change the models.Endpoint type to use proxy types we define here.
 // +k8s:deepcopy-gen=false
-type CiliumEndpointDetail models.Endpoint
+type EndpointStatus struct {
+	// The cilium-agent-local ID of the endpoint
+	ID int64 `json:"id,omitempty"`
+
+	// Controllers is the list of failing controllers for this endpoint
+	Controllers ControllerList `json:"controllers,omitempty"`
+
+	// ExternalIdentifiers is a set of identifiers to identify the endpoint
+	// apart from the pod name. This includes container runtime IDs.
+	ExternalIdentifiers *models.EndpointIdentifiers `json:"external-identifiers,omitempty"`
+
+	// Summary overall endpoint & subcomponent health
+	Health *models.EndpointHealth `json:"health,omitempty"`
+
+	// Identity is the security identity associated with the endpoint
+	Identity *EndpointIdentity `json:"identity,omitempty"`
+
+	// Log is the list of the last few warning and error log entries
+	Log []*models.EndpointStatusChange `json:"log,omitempty"`
+
+	// Networking properties of the endpoint
+	Networking *EndpointNetworking `json:"networking,omitempty"`
+
+	Policy *EndpointPolicy `json:"policy,omitempty"`
+
+	// State is the state of the endpoint
+	//
+	// States are:
+	// - creating
+	// - waiting-for-identity
+	// - not-ready
+	// - waiting-to-regenerate
+	// - regenerating
+	// - restoring
+	// - ready
+	// - disconnecting
+	// - disconnected
+	State string `json:"state,omitempty"`
+
+	// Deprecated fields
+	Spec   *deprecatedEndpointConfigurationSpec `json:"spec,omitempty"`
+	Status *DeprecatedEndpointStatus            `json:"status,omitempty"`
+}
+
+// EndpointStatusLogEntries is the maximum number of log entries in EndpointStatus.Log
+const EndpointStatusLogEntries = 5
+
+// ControllerList is a list of ControllerStatus
+type ControllerList []ControllerStatus
+
+// Sort sorts the ControllerList by controller name
+func (c ControllerList) Sort() {
+	sort.Slice(c, func(i, j int) bool { return c[i].Name < c[j].Name })
+}
+
+// ControllerStatus is the status of a failing controller
+type ControllerStatus struct {
+	// Name is the name of the controller
+	Name string `json:"name,omitempty"`
+
+	// Configuration is the controller configuration
+	Configuration *models.ControllerStatusConfiguration `json:"configuration,omitempty"`
+
+	// Status is the status of the controller
+	Status ControllerStatusStatus `json:"status,omitempty"`
+
+	// UUID is the UUID of the controller
+	UUID string `json:"uuid,omitempty"`
+}
+
+// ControllerStatusStatus is the detailed status section of a controller
+type ControllerStatusStatus struct {
+	ConsecutiveFailureCount int64  `json:"consecutive-failure-count,omitempty"`
+	FailureCount            int64  `json:"failure-count,omitempty"`
+	LastFailureMsg          string `json:"last-failure-msg,omitempty"`
+	LastFailureTimestamp    string `json:"last-failure-timestamp,omitempty"`
+	LastSuccessTimestamp    string `json:"last-success-timestamp,omitempty"`
+	SuccessCount            int64  `json:"success-count,omitempty"`
+}
+
+// EndpointPolicy represents the endpoint's policy by listing all allowed
+// ingress and egress identities in combination with L4 port and protocol
+type EndpointPolicy struct {
+	Ingress *EndpointPolicyDirection `json:"ingress,omitempty"`
+	Egress  *EndpointPolicyDirection `json:"egress,omitempty"`
+}
+
+// EndpointPolicyDirection is the list of allowed identities per direction
+type EndpointPolicyDirection struct {
+	Enforcing bool                `json:"enforcing,omitempty"`
+	Allowed   AllowedIdentityList `json:"allowed,omitempty"`
+	Removing  AllowedIdentityList `json:"removing,omitempty"`
+	Adding    AllowedIdentityList `json:"adding,omitempty"`
+}
+
+// AllowedIdentityTuple specifies an allowed peer by identity, destination port
+// and protocol
+type AllowedIdentityTuple struct {
+	Identity       uint64            `json:"identity,omitempty"`
+	IdentityLabels map[string]string `json:"identity-labels,omitempty"`
+	DestPort       uint16            `json:"dest-port,omitempty"`
+	Protocol       uint8             `json:"protocol,omitempty"`
+}
+
+// AllowedIdentityList is a list of AllowedIdentityTuple
+type AllowedIdentityList []AllowedIdentityTuple
+
+// Sort sorts a list AllowedIdentityTuple by numeric identity, port and protocol
+func (a AllowedIdentityList) Sort() {
+	sort.Slice(a, func(i, j int) bool {
+		if a[i].Identity < a[j].Identity {
+			return true
+		} else if a[i].Identity == a[j].Identity {
+			if a[i].DestPort < a[j].DestPort {
+				return true
+			} else if a[i].DestPort == a[j].DestPort {
+				return a[i].Protocol < a[j].Protocol
+			}
+		}
+		return false
+	})
+}
+
+type deprecatedEndpointConfigurationSpec struct {
+	LabelConfiguration *deprecatedLabelConfigurationSpec `json:"label-configuration,omitempty"`
+	Options            map[string]string                 `json:"options,omitempty"`
+}
+
+type deprecatedLabelConfigurationSpec struct {
+	User []string `json:"user"`
+}
+
+// DeprecatedEndpointStatus is the original endpoint status provided for
+// backwards compatibility.
+//
+// See EndpointStatus for descriptions of fields
+type DeprecatedEndpointStatus struct {
+	Controllers ControllerList                 `json:"controllers,omitempty"`
+	Identity    *EndpointIdentity              `json:"identity,omitempty"`
+	Log         []*models.EndpointStatusChange `json:"log,omitempty"`
+	Networking  *EndpointNetworking            `json:"networking,omitempty"`
+	State       string                         `json:"state,omitempty"`
+
+	// These fields are no longer populated
+	Realized            *deprecatedEndpointConfigurationSpec `json:"realized,omitempty"`
+	Labels              *deprecatedLabelConfigurationStatus  `json:"labels,omitempty"`
+	Policy              *models.EndpointPolicyStatus         `json:"policy,omitempty"`
+	ExternalIdentifiers *models.EndpointIdentifiers          `json:"external-identifiers,omitempty"`
+	Health              *models.EndpointHealth               `json:"health,omitempty"`
+}
+
+// EndpointIdentity is the identity information of an endpoint
+type EndpointIdentity struct {
+	// ID is the numeric identity of the endpoint
+	ID int64 `json:"id,omitempty"`
+
+	// Labels is the list of labels associated with the identity
+	Labels []string `json:"labels,omitempty"`
+
+	// Deprecated fields
+	LabelsSHA256 string `json:"labelsSHA256,omitempty"`
+}
+
+// AddressPair is is a par of IPv4 and/or IPv6 address
+type AddressPair struct {
+	IPV4 string `json:"ipv4,omitempty"`
+	IPV6 string `json:"ipv6,omitempty"`
+}
+
+// AddressPairList is a list of address pairs
+type AddressPairList []*AddressPair
+
+// Sort sorts an AddressPairList by IPv4 and IPv6 address
+func (a AddressPairList) Sort() {
+	sort.Slice(a, func(i, j int) bool {
+		if a[i].IPV4 < a[j].IPV4 {
+			return true
+		} else if a[i].IPV4 == a[j].IPV4 {
+			return a[i].IPV6 < a[j].IPV6
+		}
+		return false
+	})
+}
+
+// EndpointNetworking is the addressing information of an endpoint
+type EndpointNetworking struct {
+	// IP4/6 addresses assigned to this Endpoint
+	Addressing AddressPairList `json:"addressing"`
+
+	// Deprecated fields
+	HostAddressing *models.NodeAddressing `json:"host-addressing,omitempty"`
+	HostMac        string                 `json:"host-mac,omitempty"`
+	InterfaceIndex int64                  `json:"interface-index,omitempty"`
+	InterfaceName  string                 `json:"interface-name,omitempty"`
+	Mac            string                 `json:"mac,omitempty"`
+}
+
+type deprecatedLabelConfigurationStatus struct {
+	Derived          []string                         `json:"derived"`
+	Disabled         []string                         `json:"disabled"`
+	Realized         deprecatedLabelConfigurationSpec `json:"realized,omitempty"`
+	SecurityRelevant []string                         `json:"security-relevant"`
+}
 
 // DeepCopyInto is an inefficient hack to allow reusing models.Endpoint in the
 // CiliumEndpoint CRD.
-func (in *CiliumEndpointDetail) DeepCopyInto(out *CiliumEndpointDetail) {
-	*out = *in
-	b, err := (*models.Endpoint)(in).MarshalBinary()
+func (m *EndpointStatus) DeepCopyInto(out *EndpointStatus) {
+	*out = *m
+	b, err := (*EndpointStatus)(m).MarshalBinary()
 	if err != nil {
-		log.WithError(err).Error("Cannot marshal models.Endpoint during CiliumEndpoitnDetail deepcopy")
+		log.WithError(err).Error("Cannot marshal EndpointStatus during EndpointStatus deepcopy")
 		return
 	}
-	err = (*models.Endpoint)(out).UnmarshalBinary(b)
+	err = (*EndpointStatus)(out).UnmarshalBinary(b)
 	if err != nil {
-		log.WithError(err).Error("Cannot unmarshal models.Endpoint during CiliumEndpoitnDetail deepcopy")
+		log.WithError(err).Error("Cannot unmarshal EndpointStatus during EndpointStatus deepcopy")
 		return
 	}
+}
+
+// MarshalBinary interface implementation
+func (m *EndpointStatus) MarshalBinary() ([]byte, error) {
+	if m == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(m)
+}
+
+// UnmarshalBinary interface implementation
+func (m *EndpointStatus) UnmarshalBinary(b []byte) error {
+	var res EndpointStatus
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*m = res
+	return nil
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -358,6 +358,15 @@ func Map2Labels(m map[string]string, source string) Labels {
 	return o
 }
 
+// StringMap converts Labels into map[string]string
+func (l Labels) StringMap() map[string]string {
+	o := map[string]string{}
+	for _, v := range l {
+		o[v.Source+":"+v.Key] = v.Value
+	}
+	return o
+}
+
 // NewLabelsFromModel creates labels from string array.
 func NewLabelsFromModel(base []string) Labels {
 	lbls := make(Labels, len(base))

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -110,7 +110,7 @@ func CreateKubectl(vmName string, log *logrus.Entry) *Kubectl {
 
 // CepGet returns the endpoint model for the given pod name in the specified
 // namespaces. If the pod is not present it returns nil
-func (kub *Kubectl) CepGet(namespace string, pod string) *models.Endpoint {
+func (kub *Kubectl) CepGet(namespace string, pod string) *cnpv2.EndpointStatus {
 	log := kub.logger.WithFields(logrus.Fields{
 		"cep":       pod,
 		"namespace": namespace})
@@ -122,7 +122,7 @@ func (kub *Kubectl) CepGet(namespace string, pod string) *models.Endpoint {
 		return nil
 	}
 
-	var data *models.Endpoint
+	var data *cnpv2.EndpointStatus
 	err := res.Unmarshal(&data)
 	if err != nil {
 		log.WithError(err).Error("cannot Unmarshal json")
@@ -140,76 +140,6 @@ func (kub *Kubectl) GetNumNodes() int {
 	}
 
 	return len(strings.Split(res.SingleOut(), " "))
-}
-
-// WaitCEPReady waits until all Cilium endpoints are sync in Kubernetes resource.
-// WaitCEPReady waits until a CEP exists for all currently existing endpoints
-// except for the health endpoint and ensures that the policy-revision reported
-// by the CEP is greater or equal than the policy revision reported in the
-// endpoint itself.
-func (kub *Kubectl) WaitCEPReady() error {
-	pods, err := kub.GetCiliumPods(KubeSystemNamespace)
-	if err != nil {
-		return err
-	}
-
-	// Created a map of .id and IPv4 because endpoint id can be the same in different nodes.
-	// Note: endpointFilter ignores the health endpoint because we don't create
-	// CEPs for them (via `?(@.status.identity.id != 4)`).
-	endpointFilter := `{range [?(@.status.identity.id != 4)]}{@.id}{"_"}{@.status.networking.addressing[0].ipv4}{"="}{@.status.policy.spec.policy-revision}{"\n"}{end}`
-	cepFilter := `{range .items[*]}{@.status.id}{"_"}{@.status.status.networking.addressing[0].ipv4}{"="}{@.status.status.policy.spec.policy-revision}{"\n"}{end}`
-	endpoints := map[string]int{}
-	for _, ciliumPod := range pods {
-		res := kub.ExecPodCmd(
-			KubeSystemNamespace,
-			ciliumPod,
-			fmt.Sprintf("cilium endpoint list -o jsonpath='%s'", endpointFilter))
-		if !res.WasSuccessful() {
-			return fmt.Errorf("unable to run '%s': %s", res.GetCmd(), res.OutputPrettyPrint())
-		}
-
-		for k, v := range res.KVOutput() {
-			policyRevision, err := strconv.Atoi(v)
-			if err != nil {
-				return fmt.Errorf("unable to parse policy revision '%s': %s", v, err)
-			}
-
-			endpoints[k] = policyRevision
-		}
-	}
-
-	// Wait for the CEPs to implement the desired policy revision for each endpoint
-	body := func() bool {
-		cepCMD := fmt.Sprintf("%s get cep --all-namespaces -o jsonpath='%s'", KubectlCmd, cepFilter)
-		res := kub.Exec(cepCMD)
-		if !res.WasSuccessful() {
-			return false
-		}
-		cepValues := res.KVOutput()
-		for k, requiredRevision := range endpoints {
-			cepRevisionString, ok := cepValues[k]
-			if !ok {
-				kub.logger.Infof("Endpoint '%s' is not present in cep", k)
-				return false
-			}
-
-			if requiredRevision > 0 {
-				cepRevision, err := strconv.Atoi(cepRevisionString)
-				if err != nil {
-					kub.logger.Infof("unable to parse policy revision '%s': %s", cepRevisionString, err)
-					return false
-				}
-
-				if cepRevision < requiredRevision {
-					kub.logger.Infof("Endpoint '%s' revision not met yet: '%d'<'%d'", k, cepRevision, requiredRevision)
-					return false
-				}
-			}
-		}
-		return true
-	}
-
-	return WithTimeout(body, "CEP don't implement required policy revisions after timeout", &TimeoutConfig{Timeout: HelperTimeout})
 }
 
 // ExecKafkaPodCmd executes shell command with arguments arg in the specified pod residing in the specified
@@ -1487,7 +1417,7 @@ func (kub *Kubectl) CiliumCheckReport() {
 		KubectlCmd, policiesFilter))
 	fmt.Fprintf(CheckLogs, "CiliumNetworkPolicies loaded: %v\n", cnp.Output())
 
-	cepFilter := `{range .items[*]}{.metadata.name}{"="}{.status.status.policy.realized.policy-enabled}{"\n"}{end}`
+	cepFilter := `{range .items[*]}{.metadata.name}{"=ingress:"}{.status.policy.ingress.enforcing}{"/egress:"}{.status.policy.egress.enforcing}{"\n"}{end}`
 	cepStatus := kub.Exec(fmt.Sprintf(
 		"%s get cep -o jsonpath='%s' --all-namespaces",
 		KubectlCmd, cepFilter))
@@ -2015,7 +1945,7 @@ func (kub *Kubectl) KubeDNSPreFlightCheck() error {
 
 //ServicePreFlightCheck makes sure that k8s service with given name and namespace is properly plumbed in Cilium
 func (kub *Kubectl) ServicePreFlightCheck(serviceName, serviceNamespace string) error {
-	ginkgoext.By("Checking that the kubernetes service is correctly plumbed by Cilium")
+	ginkgoext.By("Checking that the %s/%s service is correctly plumbed by Cilium", serviceNamespace, serviceName)
 	var service *v1.Service
 	for _, s := range kub.serviceCache.services.Items {
 		if s.Name == serviceName && s.Namespace == serviceNamespace {

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -263,7 +263,6 @@ var _ = Describe("K8sServicesTest", func() {
 
 		validateEgress := func() {
 			By("Checking that toServices CIDR is plumbed into CEP")
-			ExpectWithOffset(1, kubectl.WaitCEPReady()).To(BeNil(), "Cep is not ready after timeout")
 			Eventually(func() string {
 				res := kubectl.Exec(fmt.Sprintf(
 					"%s -n %s get cep %s -o json",
@@ -271,7 +270,7 @@ var _ = Describe("K8sServicesTest", func() {
 					helpers.DefaultNamespace,
 					podName))
 				ExpectWithOffset(1, res).Should(helpers.CMDSuccess(), "cannot get Cilium endpoint")
-				data, err := res.Filter(`{.status.status.policy.realized.cidr-policy.egress}`)
+				data, err := res.Filter(`{.status.policy.egress}`)
 				ExpectWithOffset(1, err).To(BeNil(), "unable to get endpoint %s metadata", podName)
 				return data.String()
 			}, 2*time.Minute, 2*time.Second).Should(ContainSubstring(expectedCIDR))
@@ -279,7 +278,6 @@ var _ = Describe("K8sServicesTest", func() {
 
 		validateEgressAfterDeletion := func() {
 			By("Checking that toServices CIDR is no longer plumbed into CEP")
-			ExpectWithOffset(1, kubectl.WaitCEPReady()).To(BeNil(), "Cep is not ready after timeout")
 			Eventually(func() string {
 				res := kubectl.Exec(fmt.Sprintf(
 					"%s -n %s get cep %s -o json",
@@ -287,7 +285,7 @@ var _ = Describe("K8sServicesTest", func() {
 					helpers.DefaultNamespace,
 					podName))
 				ExpectWithOffset(1, res).Should(helpers.CMDSuccess(), "cannot get Cilium endpoint")
-				data, err := res.Filter(`{.status.status.policy.realized.cidr-policy.egress}`)
+				data, err := res.Filter(`{.status.policy.egress}`)
 				ExpectWithOffset(1, err).To(BeNil(), "unable to get endpoint %s metadata", podName)
 				return data.String()
 			}, 2*time.Minute, 2*time.Second).ShouldNot(ContainSubstring(expectedCIDR))

--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -60,13 +60,6 @@ func ExpectAllPodsTerminated(vm *helpers.Kubectl) {
 	ExpectWithOffset(1, err).To(BeNil(), "terminating containers are not deleted after timeout")
 }
 
-// ExpectCEPUpdates is a wrapper around helpers/WaitCEPReady.
-// It asserts that the error returned by that function is nil.
-func ExpectCEPUpdates(vm *helpers.Kubectl) {
-	err := vm.WaitCEPReady()
-	ExpectWithOffset(1, err).To(BeNil(), "CEP does not updated correctly")
-}
-
 // ExpectETCDOperatorReady is a wrapper around helpers/WaitForNPods. It asserts
 // the error returned by that function is nil.
 func ExpectETCDOperatorReady(vm *helpers.Kubectl) {


### PR DESCRIPTION
This commit creates a native type for the CiliumEndpoint CRD. It still uses a
couple of structures from api/v1/models but the majority of the types are
native. The primary purpose of this commit is to make CEP as stable as possible to avoid frequent updates.

In scope for this PR:
 - Fix structure and sorting of the CEP

Out of scope for this PR:
 - Selective inclusion of certain information based on agent flags or pod annotations.
 - Introduce trigger to update CEP on certain endpoint changes
 - Avoid CEP GET operation for each update interval
 - Avoid k8s version validation for each update interval

## Summary of changes

* CiliumEndpoint.Status.Spec is deprecated and no longer populated. The labe
  configuration is typically available in the pod. The endpoint configuration
  is almost never changed and if performed, it is done via CLI which means the
  CLI can also be used to query it.

* CiliumEndpoint.Status.Status is deprecated but some fields which we know have
  users are preserved. All fields are mirrored to CiliumEndpoint.Status and new
  fields should only be added there.

* The endpoint log is limited to the last 5 errors or warnings. Successful
  transitions are no longer included.

* The list of controllers is limited to failing controllers and the list is
  sorted by controller name.

* The endpoint networking field is reduced and the list of addressess is sorted.

* The policy field is completely restructured and now contains a list of
  identities + L4 port + protocol for ingress and egress.

* As the CEP no longer carries the policy revision, the CI tests are adjusted to solely rely on the CNP status. The CNP status will scale to any number of pods and is what should be the mechanism to determine policy enforcement state. The logic in the Kafka test is kept to validate the policy enforcement state in the CEP.

## Example CEP

```
apiVersion: cilium.io/v2
kind: CiliumEndpoint
metadata:
  creationTimestamp: "2019-01-21T12:20:19Z"
  generation: 1
  name: echo-79b5fcd4d9-2jbxq
  namespace: default
  resourceVersion: "1669965"
  selfLink: /apis/cilium.io/v2/namespaces/default/ciliumendpoints/echo-79b5fcd4d9-2jbxq
  uid: eae1ac79-1d76-11e9-8790-080027d2d952
status:
  external-identifiers:
    container-id: 9241bd4e0b600b46b095376a5120766c726cc7d916e956b6705a89b25cf53dd8
    container-name: k8s_POD_echo-79b5fcd4d9-2jbxq_default_cd4126b4-1d72-11e9-8790-080027d2d952_0
    pod-name: default/echo-79b5fcd4d9-2jbxq
  health:
    bpf: OK
    connected: true
    overallHealth: OK
    policy: OK
  id: 2686
  identity:
    id: 45252
    labels:
    - k8s:io.cilium.k8s.policy.cluster=default
    - k8s:io.cilium.k8s.policy.serviceaccount=default
    - k8s:io.kubernetes.pod.namespace=default
    - k8s:name=echo
  log:
  - code: Warning
    message: 'Skipped invalid state transition to waiting-to-regenerate due to: Triggering
      endpoint regeneration due to '
    state: waiting-to-regenerate
    timestamp: "2019-01-21T12:20:17Z"
  - code: Warning
    message: 'Skipped invalid state transition to ready due to: Completed endpoint
      regeneration with no pending regeneration requests'
    state: waiting-to-regenerate
    timestamp: "2019-01-21T12:20:17Z"
  networking:
    addressing:
    - ipv4: 10.16.195.88
  policy:
    egress:
      allowed:
      - identity: 16777218
        identity-labels:
          cidr:20.1.1.1/32: ""
      - identity: 16777219
        identity-labels:
          cidr:10.128.0.0/9: ""
      - identity: 16777220
        identity-labels:
          cidr:10.0.0.0/10: ""
      - identity: 16777221
        identity-labels:
          cidr:10.64.0.0/11: ""
      - identity: 16777222
        identity-labels:
          cidr:10.112.0.0/12: ""
      enforcing: true
    ingress:
      allowed:
      - identity: 1
        identity-labels:
          reserved:host: ""
      - identity: 2
        identity-labels:
          reserved:world: ""
      - identity: 3
        identity-labels:
          reserved:unmanaged: ""
      - identity: 4
        identity-labels:
          reserved:health: ""
      - identity: 5
        identity-labels:
          reserved:init: ""
      - identity: 100
        identity-labels:
          k8s:io.cilium.k8s.policy.cluster: default
          k8s:io.cilium.k8s.policy.serviceaccount: cilium-etcd-sa
          k8s:io.cilium/app: etcd-operator
          k8s:io.kubernetes.pod.namespace: ""
      - identity: 101
        identity-labels:
          k8s:app: etcd
          k8s:etcd_cluster: cilium-etcd
          k8s:io.cilium.k8s.policy.cluster: default
          k8s:io.cilium.k8s.policy.serviceaccount: default
          k8s:io.cilium/app: etcd-operator
          k8s:io.kubernetes.pod.namespace: ""
      - identity: 102
        identity-labels:
          k8s:io.cilium.k8s.policy.cluster: default
          k8s:io.cilium.k8s.policy.serviceaccount: kube-dns
          k8s:io.kubernetes.pod.namespace: kube-system
          k8s:k8s-app: kube-dns
      - identity: 103
        identity-labels:
          k8s:eks.amazonaws.com/component: kube-dns
          k8s:io.cilium.k8s.policy.cluster: default
          k8s:io.cilium.k8s.policy.serviceaccount: kube-dns
          k8s:io.kubernetes.pod.namespace: kube-system
          k8s:k8s-app: kube-dns
      - identity: 104
        identity-labels:
          k8s:io.cilium.k8s.policy.cluster: default
          k8s:io.cilium.k8s.policy.serviceaccount: coredns
          k8s:io.kubernetes.pod.namespace: kube-system
          k8s:k8s-app: kube-dns
      - identity: 105
        identity-labels:
          k8s:io.cilium.k8s.policy.cluster: default
          k8s:io.cilium.k8s.policy.serviceaccount: cilium-operator
          k8s:io.cilium/app: operator
          k8s:io.kubernetes.pod.namespace: ""
          k8s:name: cilium-operator
      - identity: 106
        identity-labels:
          k8s:eks.amazonaws.com/component: coredns
          k8s:io.cilium.k8s.policy.cluster: default
          k8s:io.cilium.k8s.policy.serviceaccount: coredns
          k8s:io.kubernetes.pod.namespace: kube-system
          k8s:k8s-app: kube-dns
      - identity: 45252
        identity-labels:
          k8s:io.cilium.k8s.policy.cluster: default
          k8s:io.cilium.k8s.policy.serviceaccount: default
          k8s:io.kubernetes.pod.namespace: default
          k8s:name: echo
      - identity: 46156
        identity-labels:
          k8s:io.cilium.k8s.policy.cluster: default
          k8s:io.cilium.k8s.policy.serviceaccount: default
          k8s:io.kubernetes.pod.namespace: default
          k8s:name: probe
      - identity: 16777218
        identity-labels:
          cidr:20.1.1.1/32: ""
      - identity: 16777219
        identity-labels:
          cidr:10.128.0.0/9: ""
      - identity: 16777220
        identity-labels:
          cidr:10.0.0.0/10: ""
      - identity: 16777221
        identity-labels:
          cidr:10.64.0.0/11: ""
      - identity: 16777222
        identity-labels:
          cidr:10.112.0.0/12: ""
  spec: {}
  state: ready
  status:
    identity:
      id: 45252
      labels:
      - k8s:io.cilium.k8s.policy.cluster=default
      - k8s:io.cilium.k8s.policy.serviceaccount=default
      - k8s:io.kubernetes.pod.namespace=default
      - k8s:name=echo
    log:
    - code: Warning
      message: 'Skipped invalid state transition to waiting-to-regenerate due to:
        Triggering endpoint regeneration due to '
      state: waiting-to-regenerate
      timestamp: "2019-01-21T12:20:17Z"
    - code: Warning
      message: 'Skipped invalid state transition to ready due to: Completed endpoint
        regeneration with no pending regeneration requests'
      state: waiting-to-regenerate
      timestamp: "2019-01-21T12:20:17Z"
    networking:
      addressing:
      - ipv4: 10.16.195.88
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6697)
<!-- Reviewable:end -->
