### PR TITLE
cilium: bugtool cmdref update

### DIFF
--- a/Documentation/cmdref/cilium-bugtool.md
+++ b/Documentation/cmdref/cilium-bugtool.md
@@ -6,10 +6,11 @@ Collects agent & system information useful for bug reporting
 
 ### Synopsis
 
+
 Collects agent & system information useful for bug reporting
 
 ```
-cilium-bugtool [OPTIONS] [flags]
+cilium-bugtool [OPTIONS]
 ```
 
 ### Examples
@@ -38,7 +39,6 @@ cilium-bugtool [OPTIONS] [flags]
       --dry-run                 Create configuration file of all commands that would have been executed
       --enable-markdown         Dump output of commands in markdown format
       --exec-timeout duration   The default timeout for any cmd execution in seconds (default 30s)
-  -h, --help                    help for cilium-bugtool
   -H, --host string             URI to server-side API
       --k8s-label string        Kubernetes label for Cilium pod (default "k8s-app=cilium")
       --k8s-mode                Require Kubernetes pods to be found or fail


### PR DESCRIPTION
Run `make -C Documentation cmdref` missing cmdref update fix by
running cmdref update.

Signed-off-by: John Fastabend <john.fastabend@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6700)
<!-- Reviewable:end -->
