### PR TITLE
Provide better error message on endpoint operation timeouts

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -33,6 +33,7 @@ import (
 
 	runtime_client "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+	"golang.org/x/net/context"
 )
 
 type Client struct {
@@ -132,6 +133,11 @@ func Hint(err error) error {
 	if err == nil {
 		return err
 	}
+
+	if err == context.DeadlineExceeded {
+		return fmt.Errorf("Cilium API client timeout exceeded")
+	}
+
 	e, _ := url.PathUnescape(err.Error())
 	if strings.Contains(err.Error(), defaults.SockPath) {
 		return fmt.Errorf("%s\nIs the agent running?", e)

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -1,0 +1,62 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package client
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"golang.org/x/net/context"
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+type ClientTestSuite struct{}
+
+var _ = Suite(&ClientTestSuite{})
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+func (cs *ClientTestSuite) TestHint(c *C) {
+	var err error
+
+	err = nil
+	c.Assert(Hint(err), IsNil)
+
+	err = errors.New("foo bar")
+	c.Assert(Hint(err), ErrorMatches, "foo bar")
+
+	err = fmt.Errorf("ayy lmao")
+	c.Assert(Hint(err), ErrorMatches, "ayy lmao")
+
+	err = context.DeadlineExceeded
+	c.Assert(Hint(err), ErrorMatches, "Cilium API client timeout exceeded")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer cancel()
+
+	select {
+	case <-ctx.Done():
+		err = ctx.Err()
+	}
+
+	c.Assert(Hint(err), ErrorMatches, "Cilium API client timeout exceeded")
+}


### PR DESCRIPTION
Currently both API and kvstore (etcd) are returning a not descriptive `context deadline exceeded` error (`DeadlineExceeded` from golang.org/x/net/context), which doesn't show which component has connectivity problems. This PR aims to extend `DeadlineExceeded` errors by using `Hint` functions in all possible places where golang.org/x/net/context is used for endpoint operations.

Fixes: #6458

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6704)
<!-- Reviewable:end -->
