### PR TITLE
Linux kernel minimum requirement

### DIFF
--- a/Documentation/gettingstarted/cilium_install.rst
+++ b/Documentation/gettingstarted/cilium_install.rst
@@ -7,6 +7,8 @@
 Step 1: Install Cilium
 ======================
 
+Before installing Cilium, make sure that the Linux kernel version >= 4.8
+
 The next step is to install Cilium into your Kubernetes cluster.
 Cilium installation leverages the `Kubernetes Daemon Set
 <https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/>`_


### PR DESCRIPTION
In order to install Cilium properly, the Linux kernel version >= 4.8

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6712)
<!-- Reviewable:end -->
