### PR TITLE
fqdn: Do not report stats on nil Endpoint

### DIFF
--- a/daemon/fqdn.go
+++ b/daemon/fqdn.go
@@ -191,7 +191,6 @@ func (d *Daemon) bootstrapFQDN(restoredEndpoints *endpointRestoreState) (err err
 				// dns.RcodeSuccess below).
 				err := fmt.Errorf("Cannot find matching endpoint for IPs %s or %s", srcAddr, dstAddr)
 				log.WithError(err).Error("cannot find matching endpoint")
-				ep.UpdateProxyStatistics("dns", uint16(serverPort), ingress, !ingress, accesslog.VerdictError)
 				return err
 			}
 


### PR DESCRIPTION
This was a bug. We cannot update statistics on an endpoint when it is
nil. Now we don't.

Signed-off-by: Ray Bejjani <ray@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6717)
<!-- Reviewable:end -->
