### PR TITLE
kubernetes: Mark cilium-etcd-secret secret required

### DIFF
--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -248,7 +248,7 @@ latest ``1.1.y`` release before subsequently upgrading to ``1.2.z``.
 +-----------------------+-----------------------+-----------------------+-------------------------+---------------------------+
 | ``1.2.x``             | ``1.3.y``             | Required              | Minimal to None         | Clients must reconnect[1] |
 +-----------------------+-----------------------+-----------------------+-------------------------+---------------------------+
-| ``>=1.2.5``           | ``1.4.y``             | Required              | Minimal to None         | Clients must reconnect[1] |
+| ``>=1.2.5``           | ``1.4.y``             | Action Required       | Minimal to None         | Clients must reconnect[1] |
 +-----------------------+-----------------------+-----------------------+-------------------------+---------------------------+
 
 Annotations:
@@ -267,6 +267,23 @@ Annotations:
 
 Upgrading from >=1.2.5 to 1.4.y
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+#. **Action required:** With Cilium 1.4.0 the ``cilium-etcd-secrets`` secrets
+   are marked as required in the DaemonSet. This is done to simplify the
+   default installation with the etcd-operator. If you are already using the
+   ``cilium-etcd-secrets`` to access etcd using TLS, no action is required. If
+   you have not been using TLS yet or if you are not sure whether you are using
+   TLS to access etcd, run the following command:
+
+   .. parsed-literal::
+
+      kubectl create -f \ |SCM_WEB|\/examples/kubernetes/1.11/etcd-secrets.yaml
+
+   It will either succeed and create an empty secrets or it will fail with:
+
+   .. parsed-literal::
+
+      Error from server (AlreadyExists): error when creating
 
 #. Follow the standard procedures to perform the upgrade as described in :ref:`upgrade_minor`.
 

--- a/examples/kubernetes/1.10/cilium-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-ds.yaml
@@ -279,7 +279,7 @@ spec:
       - name: etcd-secrets
         secret:
           defaultMode: 420
-          optional: true
+          optional: false
           secretName: cilium-etcd-secrets
         # To read the clustermesh configuration
       - name: clustermesh-secrets

--- a/examples/kubernetes/1.10/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.10/cilium-external-etcd.yaml
@@ -10,18 +10,18 @@ data:
   etcd-config: |-
     ---
     endpoints:
-      - https://cilium-etcd-client.kube-system.svc:2379
+      - http://EDIT-ME-ETCD-ADDRESS:2379
     #
     # In case you want to use TLS in etcd, uncomment the 'ca-file' line
     # and create a kubernetes secret by following the tutorial in
     # https://cilium.link/etcd-config
-    ca-file: '/var/lib/etcd-secrets/etcd-client-ca.crt'
+    # ca-file: '/var/lib/etcd-secrets/etcd-client-ca.crt'
     #
     # In case you want client to server authentication, uncomment the following
     # lines and create a kubernetes secret by following the tutorial in
     # https://cilium.link/etcd-config
-    key-file: '/var/lib/etcd-secrets/etcd-client.key'
-    cert-file: '/var/lib/etcd-secrets/etcd-client.crt'
+    # key-file: '/var/lib/etcd-secrets/etcd-client.key'
+    # cert-file: '/var/lib/etcd-secrets/etcd-client.crt'
 
   # If you want to run cilium in debug mode change this value to true
   debug: "false"
@@ -131,6 +131,21 @@ data:
   # a container. When the Cilium DaemonSet is removed, the BPF programs will
   # be kept in the interfaces unless this option is set to "true".
   flannel-uninstall-on-exit: "false"
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: cilium-etcd-secrets
+  namespace: kube-system
+data:
+  # To enable TLS with etcd, populate the secret with the key information from
+  # etcd:
+  #
+  # kubectl create secret generic -n kube-system cilium-etcd-secrets \
+  #    --from-file=etcd-ca=ca.crt \
+  #    --from-file=etcd-client-key=client.key \
+  #    --from-file=etcd-client-crt=client.crt
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -588,229 +603,6 @@ subjects:
 - kind: ServiceAccount
   name: cilium-operator
   namespace: kube-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: cilium-etcd-operator
-  namespace: kube-system
-rules:
-- apiGroups:
-  - etcd.database.coreos.com
-  resources:
-  - etcdclusters
-  verbs:
-  - get
-  - delete
-  - create
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - delete
-  - get
-  - create
-- apiGroups:
-  - ""
-  resources:
-  - deployments
-  verbs:
-  - delete
-  - create
-  - get
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - list
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - delete
-  - create
-  - get
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - componentstatuses
-  verbs:
-  - get
-- apiGroups:
-  - extensions
-  resources:
-  - deployments
-  verbs:
-  - delete
-  - create
-  - get
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - create
-  - delete
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: cilium-etcd-operator
-  namespace: kube-system
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cilium-etcd-operator
-subjects:
-- kind: ServiceAccount
-  name: cilium-etcd-operator
-  namespace: kube-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: etcd-operator
-  namespace: kube-system
-rules:
-- apiGroups:
-  - etcd.database.coreos.com
-  resources:
-  - etcdclusters
-  - etcdbackups
-  - etcdrestores
-  verbs:
-  - '*'
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - '*'
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - services
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - deployments
-  verbs:
-  - '*'
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - '*'
-- apiGroups:
-  - extensions
-  resources:
-  - deployments
-  verbs:
-  - create
-  - get
-  - list
-  - patch
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: etcd-operator
-  namespace: kube-system
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: etcd-operator
-subjects:
-- kind: ServiceAccount
-  name: cilium-etcd-sa
-  namespace: kube-system
----
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: cilium-etcd-operator
-  namespace: kube-system
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: cilium-etcd-sa
-  namespace: kube-system
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    io.cilium/app: etcd-operator
-    name: cilium-etcd-operator
-  name: cilium-etcd-operator
-  namespace: kube-system
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      io.cilium/app: etcd-operator
-      name: cilium-etcd-operator
-  strategy:
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 1
-    type: RollingUpdate
-  template:
-    metadata:
-      labels:
-        io.cilium/app: etcd-operator
-        name: cilium-etcd-operator
-    spec:
-      containers:
-      - command:
-        - /usr/bin/cilium-etcd-operator
-        env:
-        - name: CILIUM_ETCD_OPERATOR_CLUSTER_DOMAIN
-          value: cluster.local
-        - name: CILIUM_ETCD_OPERATOR_ETCD_CLUSTER_SIZE
-          value: "3"
-        - name: CILIUM_ETCD_OPERATOR_NAMESPACE
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.namespace
-        - name: CILIUM_ETCD_OPERATOR_POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        - name: CILIUM_ETCD_OPERATOR_POD_UID
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.uid
-        image: docker.io/cilium/cilium-etcd-operator:v2.0.4
-        imagePullPolicy: IfNotPresent
-        name: cilium-etcd-operator
-      dnsPolicy: ClusterFirst
-      hostNetwork: true
-      restartPolicy: Always
-      serviceAccount: cilium-etcd-operator
-      serviceAccountName: cilium-etcd-operator
-      tolerations:
-      - operator: Exists
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/examples/kubernetes/1.10/etcd-secrets.yaml
+++ b/examples/kubernetes/1.10/etcd-secrets.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: cilium-etcd-secrets
+  namespace: kube-system
+data:
+  # To enable TLS with etcd, populate the secret with the key information from
+  # etcd:
+  #
+  # kubectl create secret generic -n kube-system cilium-etcd-secrets \
+  #    --from-file=etcd-ca=ca.crt \
+  #    --from-file=etcd-client-key=client.key \
+  #    --from-file=etcd-client-crt=client.crt

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -280,7 +280,7 @@ spec:
       - name: etcd-secrets
         secret:
           defaultMode: 420
-          optional: true
+          optional: false
           secretName: cilium-etcd-secrets
         # To read the clustermesh configuration
       - name: clustermesh-secrets

--- a/examples/kubernetes/1.11/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.11/cilium-external-etcd.yaml
@@ -10,18 +10,18 @@ data:
   etcd-config: |-
     ---
     endpoints:
-      - https://cilium-etcd-client.kube-system.svc:2379
+      - http://EDIT-ME-ETCD-ADDRESS:2379
     #
     # In case you want to use TLS in etcd, uncomment the 'ca-file' line
     # and create a kubernetes secret by following the tutorial in
     # https://cilium.link/etcd-config
-    ca-file: '/var/lib/etcd-secrets/etcd-client-ca.crt'
+    # ca-file: '/var/lib/etcd-secrets/etcd-client-ca.crt'
     #
     # In case you want client to server authentication, uncomment the following
     # lines and create a kubernetes secret by following the tutorial in
     # https://cilium.link/etcd-config
-    key-file: '/var/lib/etcd-secrets/etcd-client.key'
-    cert-file: '/var/lib/etcd-secrets/etcd-client.crt'
+    # key-file: '/var/lib/etcd-secrets/etcd-client.key'
+    # cert-file: '/var/lib/etcd-secrets/etcd-client.crt'
 
   # If you want to run cilium in debug mode change this value to true
   debug: "false"
@@ -131,6 +131,21 @@ data:
   # a container. When the Cilium DaemonSet is removed, the BPF programs will
   # be kept in the interfaces unless this option is set to "true".
   flannel-uninstall-on-exit: "false"
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: cilium-etcd-secrets
+  namespace: kube-system
+data:
+  # To enable TLS with etcd, populate the secret with the key information from
+  # etcd:
+  #
+  # kubectl create secret generic -n kube-system cilium-etcd-secrets \
+  #    --from-file=etcd-ca=ca.crt \
+  #    --from-file=etcd-client-key=client.key \
+  #    --from-file=etcd-client-crt=client.crt
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -368,6 +383,7 @@ spec:
           name: bpf-maps
         - mountPath: /var/run/cilium
           name: cilium-run
+      priorityClassName: system-node-critical
       restartPolicy: Always
       serviceAccount: cilium
       serviceAccountName: cilium
@@ -516,6 +532,7 @@ spec:
           name: etcd-secrets
           readOnly: true
       dnsPolicy: ClusterFirst
+      priorityClassName: system-node-critical
       restartPolicy: Always
       serviceAccount: cilium-operator
       serviceAccountName: cilium-operator
@@ -588,229 +605,6 @@ subjects:
 - kind: ServiceAccount
   name: cilium-operator
   namespace: kube-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: cilium-etcd-operator
-  namespace: kube-system
-rules:
-- apiGroups:
-  - etcd.database.coreos.com
-  resources:
-  - etcdclusters
-  verbs:
-  - get
-  - delete
-  - create
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - delete
-  - get
-  - create
-- apiGroups:
-  - ""
-  resources:
-  - deployments
-  verbs:
-  - delete
-  - create
-  - get
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - list
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - delete
-  - create
-  - get
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - componentstatuses
-  verbs:
-  - get
-- apiGroups:
-  - extensions
-  resources:
-  - deployments
-  verbs:
-  - delete
-  - create
-  - get
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - create
-  - delete
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: cilium-etcd-operator
-  namespace: kube-system
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cilium-etcd-operator
-subjects:
-- kind: ServiceAccount
-  name: cilium-etcd-operator
-  namespace: kube-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: etcd-operator
-  namespace: kube-system
-rules:
-- apiGroups:
-  - etcd.database.coreos.com
-  resources:
-  - etcdclusters
-  - etcdbackups
-  - etcdrestores
-  verbs:
-  - '*'
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - '*'
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - services
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - deployments
-  verbs:
-  - '*'
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - '*'
-- apiGroups:
-  - extensions
-  resources:
-  - deployments
-  verbs:
-  - create
-  - get
-  - list
-  - patch
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: etcd-operator
-  namespace: kube-system
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: etcd-operator
-subjects:
-- kind: ServiceAccount
-  name: cilium-etcd-sa
-  namespace: kube-system
----
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: cilium-etcd-operator
-  namespace: kube-system
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: cilium-etcd-sa
-  namespace: kube-system
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    io.cilium/app: etcd-operator
-    name: cilium-etcd-operator
-  name: cilium-etcd-operator
-  namespace: kube-system
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      io.cilium/app: etcd-operator
-      name: cilium-etcd-operator
-  strategy:
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 1
-    type: RollingUpdate
-  template:
-    metadata:
-      labels:
-        io.cilium/app: etcd-operator
-        name: cilium-etcd-operator
-    spec:
-      containers:
-      - command:
-        - /usr/bin/cilium-etcd-operator
-        env:
-        - name: CILIUM_ETCD_OPERATOR_CLUSTER_DOMAIN
-          value: cluster.local
-        - name: CILIUM_ETCD_OPERATOR_ETCD_CLUSTER_SIZE
-          value: "3"
-        - name: CILIUM_ETCD_OPERATOR_NAMESPACE
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.namespace
-        - name: CILIUM_ETCD_OPERATOR_POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        - name: CILIUM_ETCD_OPERATOR_POD_UID
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.uid
-        image: docker.io/cilium/cilium-etcd-operator:v2.0.4
-        imagePullPolicy: IfNotPresent
-        name: cilium-etcd-operator
-      dnsPolicy: ClusterFirst
-      hostNetwork: true
-      restartPolicy: Always
-      serviceAccount: cilium-etcd-operator
-      serviceAccountName: cilium-etcd-operator
-      tolerations:
-      - operator: Exists
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -413,7 +413,7 @@ spec:
       - name: etcd-secrets
         secret:
           defaultMode: 420
-          optional: true
+          optional: false
           secretName: cilium-etcd-secrets
         # To read the clustermesh configuration
       - name: clustermesh-secrets

--- a/examples/kubernetes/1.11/etcd-secrets.yaml
+++ b/examples/kubernetes/1.11/etcd-secrets.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: cilium-etcd-secrets
+  namespace: kube-system
+data:
+  # To enable TLS with etcd, populate the secret with the key information from
+  # etcd:
+  #
+  # kubectl create secret generic -n kube-system cilium-etcd-secrets \
+  #    --from-file=etcd-ca=ca.crt \
+  #    --from-file=etcd-client-key=client.key \
+  #    --from-file=etcd-client-crt=client.crt

--- a/examples/kubernetes/1.12/cilium-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-ds.yaml
@@ -280,7 +280,7 @@ spec:
       - name: etcd-secrets
         secret:
           defaultMode: 420
-          optional: true
+          optional: false
           secretName: cilium-etcd-secrets
         # To read the clustermesh configuration
       - name: clustermesh-secrets

--- a/examples/kubernetes/1.12/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.12/cilium-external-etcd.yaml
@@ -10,18 +10,18 @@ data:
   etcd-config: |-
     ---
     endpoints:
-      - https://cilium-etcd-client.kube-system.svc:2379
+      - http://EDIT-ME-ETCD-ADDRESS:2379
     #
     # In case you want to use TLS in etcd, uncomment the 'ca-file' line
     # and create a kubernetes secret by following the tutorial in
     # https://cilium.link/etcd-config
-    ca-file: '/var/lib/etcd-secrets/etcd-client-ca.crt'
+    # ca-file: '/var/lib/etcd-secrets/etcd-client-ca.crt'
     #
     # In case you want client to server authentication, uncomment the following
     # lines and create a kubernetes secret by following the tutorial in
     # https://cilium.link/etcd-config
-    key-file: '/var/lib/etcd-secrets/etcd-client.key'
-    cert-file: '/var/lib/etcd-secrets/etcd-client.crt'
+    # key-file: '/var/lib/etcd-secrets/etcd-client.key'
+    # cert-file: '/var/lib/etcd-secrets/etcd-client.crt'
 
   # If you want to run cilium in debug mode change this value to true
   debug: "false"
@@ -131,6 +131,21 @@ data:
   # a container. When the Cilium DaemonSet is removed, the BPF programs will
   # be kept in the interfaces unless this option is set to "true".
   flannel-uninstall-on-exit: "false"
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: cilium-etcd-secrets
+  namespace: kube-system
+data:
+  # To enable TLS with etcd, populate the secret with the key information from
+  # etcd:
+  #
+  # kubectl create secret generic -n kube-system cilium-etcd-secrets \
+  #    --from-file=etcd-ca=ca.crt \
+  #    --from-file=etcd-client-key=client.key \
+  #    --from-file=etcd-client-crt=client.crt
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -368,6 +383,7 @@ spec:
           name: bpf-maps
         - mountPath: /var/run/cilium
           name: cilium-run
+      priorityClassName: system-node-critical
       restartPolicy: Always
       serviceAccount: cilium
       serviceAccountName: cilium
@@ -516,6 +532,7 @@ spec:
           name: etcd-secrets
           readOnly: true
       dnsPolicy: ClusterFirst
+      priorityClassName: system-node-critical
       restartPolicy: Always
       serviceAccount: cilium-operator
       serviceAccountName: cilium-operator
@@ -588,229 +605,6 @@ subjects:
 - kind: ServiceAccount
   name: cilium-operator
   namespace: kube-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: cilium-etcd-operator
-  namespace: kube-system
-rules:
-- apiGroups:
-  - etcd.database.coreos.com
-  resources:
-  - etcdclusters
-  verbs:
-  - get
-  - delete
-  - create
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - delete
-  - get
-  - create
-- apiGroups:
-  - ""
-  resources:
-  - deployments
-  verbs:
-  - delete
-  - create
-  - get
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - list
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - delete
-  - create
-  - get
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - componentstatuses
-  verbs:
-  - get
-- apiGroups:
-  - extensions
-  resources:
-  - deployments
-  verbs:
-  - delete
-  - create
-  - get
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - create
-  - delete
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: cilium-etcd-operator
-  namespace: kube-system
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cilium-etcd-operator
-subjects:
-- kind: ServiceAccount
-  name: cilium-etcd-operator
-  namespace: kube-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: etcd-operator
-  namespace: kube-system
-rules:
-- apiGroups:
-  - etcd.database.coreos.com
-  resources:
-  - etcdclusters
-  - etcdbackups
-  - etcdrestores
-  verbs:
-  - '*'
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - '*'
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - services
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - deployments
-  verbs:
-  - '*'
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - '*'
-- apiGroups:
-  - extensions
-  resources:
-  - deployments
-  verbs:
-  - create
-  - get
-  - list
-  - patch
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: etcd-operator
-  namespace: kube-system
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: etcd-operator
-subjects:
-- kind: ServiceAccount
-  name: cilium-etcd-sa
-  namespace: kube-system
----
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: cilium-etcd-operator
-  namespace: kube-system
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: cilium-etcd-sa
-  namespace: kube-system
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    io.cilium/app: etcd-operator
-    name: cilium-etcd-operator
-  name: cilium-etcd-operator
-  namespace: kube-system
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      io.cilium/app: etcd-operator
-      name: cilium-etcd-operator
-  strategy:
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 1
-    type: RollingUpdate
-  template:
-    metadata:
-      labels:
-        io.cilium/app: etcd-operator
-        name: cilium-etcd-operator
-    spec:
-      containers:
-      - command:
-        - /usr/bin/cilium-etcd-operator
-        env:
-        - name: CILIUM_ETCD_OPERATOR_CLUSTER_DOMAIN
-          value: cluster.local
-        - name: CILIUM_ETCD_OPERATOR_ETCD_CLUSTER_SIZE
-          value: "3"
-        - name: CILIUM_ETCD_OPERATOR_NAMESPACE
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.namespace
-        - name: CILIUM_ETCD_OPERATOR_POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        - name: CILIUM_ETCD_OPERATOR_POD_UID
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.uid
-        image: docker.io/cilium/cilium-etcd-operator:v2.0.4
-        imagePullPolicy: IfNotPresent
-        name: cilium-etcd-operator
-      dnsPolicy: ClusterFirst
-      hostNetwork: true
-      restartPolicy: Always
-      serviceAccount: cilium-etcd-operator
-      serviceAccountName: cilium-etcd-operator
-      tolerations:
-      - operator: Exists
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -413,7 +413,7 @@ spec:
       - name: etcd-secrets
         secret:
           defaultMode: 420
-          optional: true
+          optional: false
           secretName: cilium-etcd-secrets
         # To read the clustermesh configuration
       - name: clustermesh-secrets

--- a/examples/kubernetes/1.12/etcd-secrets.yaml
+++ b/examples/kubernetes/1.12/etcd-secrets.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: cilium-etcd-secrets
+  namespace: kube-system
+data:
+  # To enable TLS with etcd, populate the secret with the key information from
+  # etcd:
+  #
+  # kubectl create secret generic -n kube-system cilium-etcd-secrets \
+  #    --from-file=etcd-ca=ca.crt \
+  #    --from-file=etcd-client-key=client.key \
+  #    --from-file=etcd-client-crt=client.crt

--- a/examples/kubernetes/1.13/cilium-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-ds.yaml
@@ -280,7 +280,7 @@ spec:
       - name: etcd-secrets
         secret:
           defaultMode: 420
-          optional: true
+          optional: false
           secretName: cilium-etcd-secrets
         # To read the clustermesh configuration
       - name: clustermesh-secrets

--- a/examples/kubernetes/1.13/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.13/cilium-external-etcd.yaml
@@ -10,18 +10,18 @@ data:
   etcd-config: |-
     ---
     endpoints:
-      - https://cilium-etcd-client.kube-system.svc:2379
+      - http://EDIT-ME-ETCD-ADDRESS:2379
     #
     # In case you want to use TLS in etcd, uncomment the 'ca-file' line
     # and create a kubernetes secret by following the tutorial in
     # https://cilium.link/etcd-config
-    ca-file: '/var/lib/etcd-secrets/etcd-client-ca.crt'
+    # ca-file: '/var/lib/etcd-secrets/etcd-client-ca.crt'
     #
     # In case you want client to server authentication, uncomment the following
     # lines and create a kubernetes secret by following the tutorial in
     # https://cilium.link/etcd-config
-    key-file: '/var/lib/etcd-secrets/etcd-client.key'
-    cert-file: '/var/lib/etcd-secrets/etcd-client.crt'
+    # key-file: '/var/lib/etcd-secrets/etcd-client.key'
+    # cert-file: '/var/lib/etcd-secrets/etcd-client.crt'
 
   # If you want to run cilium in debug mode change this value to true
   debug: "false"
@@ -131,6 +131,21 @@ data:
   # a container. When the Cilium DaemonSet is removed, the BPF programs will
   # be kept in the interfaces unless this option is set to "true".
   flannel-uninstall-on-exit: "false"
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: cilium-etcd-secrets
+  namespace: kube-system
+data:
+  # To enable TLS with etcd, populate the secret with the key information from
+  # etcd:
+  #
+  # kubectl create secret generic -n kube-system cilium-etcd-secrets \
+  #    --from-file=etcd-ca=ca.crt \
+  #    --from-file=etcd-client-key=client.key \
+  #    --from-file=etcd-client-crt=client.crt
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -368,6 +383,7 @@ spec:
           name: bpf-maps
         - mountPath: /var/run/cilium
           name: cilium-run
+      priorityClassName: system-node-critical
       restartPolicy: Always
       serviceAccount: cilium
       serviceAccountName: cilium
@@ -516,6 +532,7 @@ spec:
           name: etcd-secrets
           readOnly: true
       dnsPolicy: ClusterFirst
+      priorityClassName: system-node-critical
       restartPolicy: Always
       serviceAccount: cilium-operator
       serviceAccountName: cilium-operator
@@ -588,229 +605,6 @@ subjects:
 - kind: ServiceAccount
   name: cilium-operator
   namespace: kube-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: cilium-etcd-operator
-  namespace: kube-system
-rules:
-- apiGroups:
-  - etcd.database.coreos.com
-  resources:
-  - etcdclusters
-  verbs:
-  - get
-  - delete
-  - create
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - delete
-  - get
-  - create
-- apiGroups:
-  - ""
-  resources:
-  - deployments
-  verbs:
-  - delete
-  - create
-  - get
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - list
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - delete
-  - create
-  - get
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - componentstatuses
-  verbs:
-  - get
-- apiGroups:
-  - extensions
-  resources:
-  - deployments
-  verbs:
-  - delete
-  - create
-  - get
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - create
-  - delete
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: cilium-etcd-operator
-  namespace: kube-system
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cilium-etcd-operator
-subjects:
-- kind: ServiceAccount
-  name: cilium-etcd-operator
-  namespace: kube-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: etcd-operator
-  namespace: kube-system
-rules:
-- apiGroups:
-  - etcd.database.coreos.com
-  resources:
-  - etcdclusters
-  - etcdbackups
-  - etcdrestores
-  verbs:
-  - '*'
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - '*'
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - services
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - deployments
-  verbs:
-  - '*'
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - '*'
-- apiGroups:
-  - extensions
-  resources:
-  - deployments
-  verbs:
-  - create
-  - get
-  - list
-  - patch
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: etcd-operator
-  namespace: kube-system
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: etcd-operator
-subjects:
-- kind: ServiceAccount
-  name: cilium-etcd-sa
-  namespace: kube-system
----
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: cilium-etcd-operator
-  namespace: kube-system
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: cilium-etcd-sa
-  namespace: kube-system
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    io.cilium/app: etcd-operator
-    name: cilium-etcd-operator
-  name: cilium-etcd-operator
-  namespace: kube-system
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      io.cilium/app: etcd-operator
-      name: cilium-etcd-operator
-  strategy:
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 1
-    type: RollingUpdate
-  template:
-    metadata:
-      labels:
-        io.cilium/app: etcd-operator
-        name: cilium-etcd-operator
-    spec:
-      containers:
-      - command:
-        - /usr/bin/cilium-etcd-operator
-        env:
-        - name: CILIUM_ETCD_OPERATOR_CLUSTER_DOMAIN
-          value: cluster.local
-        - name: CILIUM_ETCD_OPERATOR_ETCD_CLUSTER_SIZE
-          value: "3"
-        - name: CILIUM_ETCD_OPERATOR_NAMESPACE
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.namespace
-        - name: CILIUM_ETCD_OPERATOR_POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        - name: CILIUM_ETCD_OPERATOR_POD_UID
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.uid
-        image: docker.io/cilium/cilium-etcd-operator:v2.0.4
-        imagePullPolicy: IfNotPresent
-        name: cilium-etcd-operator
-      dnsPolicy: ClusterFirst
-      hostNetwork: true
-      restartPolicy: Always
-      serviceAccount: cilium-etcd-operator
-      serviceAccountName: cilium-etcd-operator
-      tolerations:
-      - operator: Exists
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/examples/kubernetes/1.13/cilium.yaml
+++ b/examples/kubernetes/1.13/cilium.yaml
@@ -413,7 +413,7 @@ spec:
       - name: etcd-secrets
         secret:
           defaultMode: 420
-          optional: true
+          optional: false
           secretName: cilium-etcd-secrets
         # To read the clustermesh configuration
       - name: clustermesh-secrets

--- a/examples/kubernetes/1.13/etcd-secrets.yaml
+++ b/examples/kubernetes/1.13/etcd-secrets.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: cilium-etcd-secrets
+  namespace: kube-system
+data:
+  # To enable TLS with etcd, populate the secret with the key information from
+  # etcd:
+  #
+  # kubectl create secret generic -n kube-system cilium-etcd-secrets \
+  #    --from-file=etcd-ca=ca.crt \
+  #    --from-file=etcd-client-key=client.key \
+  #    --from-file=etcd-client-crt=client.crt

--- a/examples/kubernetes/1.8/cilium-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-ds.yaml
@@ -279,7 +279,7 @@ spec:
       - name: etcd-secrets
         secret:
           defaultMode: 420
-          optional: true
+          optional: false
           secretName: cilium-etcd-secrets
         # To read the clustermesh configuration
       - name: clustermesh-secrets

--- a/examples/kubernetes/1.8/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.8/cilium-external-etcd.yaml
@@ -10,18 +10,18 @@ data:
   etcd-config: |-
     ---
     endpoints:
-      - https://cilium-etcd-client.kube-system.svc:2379
+      - http://EDIT-ME-ETCD-ADDRESS:2379
     #
     # In case you want to use TLS in etcd, uncomment the 'ca-file' line
     # and create a kubernetes secret by following the tutorial in
     # https://cilium.link/etcd-config
-    ca-file: '/var/lib/etcd-secrets/etcd-client-ca.crt'
+    # ca-file: '/var/lib/etcd-secrets/etcd-client-ca.crt'
     #
     # In case you want client to server authentication, uncomment the following
     # lines and create a kubernetes secret by following the tutorial in
     # https://cilium.link/etcd-config
-    key-file: '/var/lib/etcd-secrets/etcd-client.key'
-    cert-file: '/var/lib/etcd-secrets/etcd-client.crt'
+    # key-file: '/var/lib/etcd-secrets/etcd-client.key'
+    # cert-file: '/var/lib/etcd-secrets/etcd-client.crt'
 
   # If you want to run cilium in debug mode change this value to true
   debug: "false"
@@ -132,7 +132,22 @@ data:
   # be kept in the interfaces unless this option is set to "true".
   flannel-uninstall-on-exit: "false"
 ---
-apiVersion: apps/v1
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: cilium-etcd-secrets
+  namespace: kube-system
+data:
+  # To enable TLS with etcd, populate the secret with the key information from
+  # etcd:
+  #
+  # kubectl create secret generic -n kube-system cilium-etcd-secrets \
+  #    --from-file=etcd-ca=ca.crt \
+  #    --from-file=etcd-client-key=client.key \
+  #    --from-file=etcd-client-crt=client.crt
+---
+apiVersion: apps/v1beta2
 kind: DaemonSet
 metadata:
   labels:
@@ -426,7 +441,7 @@ spec:
       maxUnavailable: 2
     type: RollingUpdate
 ---
-apiVersion: apps/v1
+apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   labels:
@@ -589,230 +604,7 @@ subjects:
   name: cilium-operator
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: cilium-etcd-operator
-  namespace: kube-system
-rules:
-- apiGroups:
-  - etcd.database.coreos.com
-  resources:
-  - etcdclusters
-  verbs:
-  - get
-  - delete
-  - create
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - delete
-  - get
-  - create
-- apiGroups:
-  - ""
-  resources:
-  - deployments
-  verbs:
-  - delete
-  - create
-  - get
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - list
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - delete
-  - create
-  - get
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - componentstatuses
-  verbs:
-  - get
-- apiGroups:
-  - extensions
-  resources:
-  - deployments
-  verbs:
-  - delete
-  - create
-  - get
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - create
-  - delete
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: cilium-etcd-operator
-  namespace: kube-system
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cilium-etcd-operator
-subjects:
-- kind: ServiceAccount
-  name: cilium-etcd-operator
-  namespace: kube-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: etcd-operator
-  namespace: kube-system
-rules:
-- apiGroups:
-  - etcd.database.coreos.com
-  resources:
-  - etcdclusters
-  - etcdbackups
-  - etcdrestores
-  verbs:
-  - '*'
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - '*'
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - services
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - deployments
-  verbs:
-  - '*'
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - '*'
-- apiGroups:
-  - extensions
-  resources:
-  - deployments
-  verbs:
-  - create
-  - get
-  - list
-  - patch
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: etcd-operator
-  namespace: kube-system
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: etcd-operator
-subjects:
-- kind: ServiceAccount
-  name: cilium-etcd-sa
-  namespace: kube-system
----
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: cilium-etcd-operator
-  namespace: kube-system
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: cilium-etcd-sa
-  namespace: kube-system
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    io.cilium/app: etcd-operator
-    name: cilium-etcd-operator
-  name: cilium-etcd-operator
-  namespace: kube-system
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      io.cilium/app: etcd-operator
-      name: cilium-etcd-operator
-  strategy:
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 1
-    type: RollingUpdate
-  template:
-    metadata:
-      labels:
-        io.cilium/app: etcd-operator
-        name: cilium-etcd-operator
-    spec:
-      containers:
-      - command:
-        - /usr/bin/cilium-etcd-operator
-        env:
-        - name: CILIUM_ETCD_OPERATOR_CLUSTER_DOMAIN
-          value: cluster.local
-        - name: CILIUM_ETCD_OPERATOR_ETCD_CLUSTER_SIZE
-          value: "3"
-        - name: CILIUM_ETCD_OPERATOR_NAMESPACE
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.namespace
-        - name: CILIUM_ETCD_OPERATOR_POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        - name: CILIUM_ETCD_OPERATOR_POD_UID
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.uid
-        image: docker.io/cilium/cilium-etcd-operator:v2.0.4
-        imagePullPolicy: IfNotPresent
-        name: cilium-etcd-operator
-      dnsPolicy: ClusterFirst
-      hostNetwork: true
-      restartPolicy: Always
-      serviceAccount: cilium-etcd-operator
-      serviceAccountName: cilium-etcd-operator
-      tolerations:
-      - operator: Exists
----
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: cilium
@@ -828,7 +620,7 @@ subjects:
   kind: Group
   name: system:nodes
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: cilium

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -412,7 +412,7 @@ spec:
       - name: etcd-secrets
         secret:
           defaultMode: 420
-          optional: true
+          optional: false
           secretName: cilium-etcd-secrets
         # To read the clustermesh configuration
       - name: clustermesh-secrets

--- a/examples/kubernetes/1.8/etcd-secrets.yaml
+++ b/examples/kubernetes/1.8/etcd-secrets.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: cilium-etcd-secrets
+  namespace: kube-system
+data:
+  # To enable TLS with etcd, populate the secret with the key information from
+  # etcd:
+  #
+  # kubectl create secret generic -n kube-system cilium-etcd-secrets \
+  #    --from-file=etcd-ca=ca.crt \
+  #    --from-file=etcd-client-key=client.key \
+  #    --from-file=etcd-client-crt=client.crt

--- a/examples/kubernetes/1.9/cilium-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-ds.yaml
@@ -279,7 +279,7 @@ spec:
       - name: etcd-secrets
         secret:
           defaultMode: 420
-          optional: true
+          optional: false
           secretName: cilium-etcd-secrets
         # To read the clustermesh configuration
       - name: clustermesh-secrets

--- a/examples/kubernetes/1.9/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.9/cilium-external-etcd.yaml
@@ -10,18 +10,18 @@ data:
   etcd-config: |-
     ---
     endpoints:
-      - https://cilium-etcd-client.kube-system.svc:2379
+      - http://EDIT-ME-ETCD-ADDRESS:2379
     #
     # In case you want to use TLS in etcd, uncomment the 'ca-file' line
     # and create a kubernetes secret by following the tutorial in
     # https://cilium.link/etcd-config
-    ca-file: '/var/lib/etcd-secrets/etcd-client-ca.crt'
+    # ca-file: '/var/lib/etcd-secrets/etcd-client-ca.crt'
     #
     # In case you want client to server authentication, uncomment the following
     # lines and create a kubernetes secret by following the tutorial in
     # https://cilium.link/etcd-config
-    key-file: '/var/lib/etcd-secrets/etcd-client.key'
-    cert-file: '/var/lib/etcd-secrets/etcd-client.crt'
+    # key-file: '/var/lib/etcd-secrets/etcd-client.key'
+    # cert-file: '/var/lib/etcd-secrets/etcd-client.crt'
 
   # If you want to run cilium in debug mode change this value to true
   debug: "false"
@@ -131,6 +131,21 @@ data:
   # a container. When the Cilium DaemonSet is removed, the BPF programs will
   # be kept in the interfaces unless this option is set to "true".
   flannel-uninstall-on-exit: "false"
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: cilium-etcd-secrets
+  namespace: kube-system
+data:
+  # To enable TLS with etcd, populate the secret with the key information from
+  # etcd:
+  #
+  # kubectl create secret generic -n kube-system cilium-etcd-secrets \
+  #    --from-file=etcd-ca=ca.crt \
+  #    --from-file=etcd-client-key=client.key \
+  #    --from-file=etcd-client-crt=client.crt
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -588,229 +603,6 @@ subjects:
 - kind: ServiceAccount
   name: cilium-operator
   namespace: kube-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: cilium-etcd-operator
-  namespace: kube-system
-rules:
-- apiGroups:
-  - etcd.database.coreos.com
-  resources:
-  - etcdclusters
-  verbs:
-  - get
-  - delete
-  - create
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - delete
-  - get
-  - create
-- apiGroups:
-  - ""
-  resources:
-  - deployments
-  verbs:
-  - delete
-  - create
-  - get
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - list
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - delete
-  - create
-  - get
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - componentstatuses
-  verbs:
-  - get
-- apiGroups:
-  - extensions
-  resources:
-  - deployments
-  verbs:
-  - delete
-  - create
-  - get
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - create
-  - delete
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: cilium-etcd-operator
-  namespace: kube-system
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cilium-etcd-operator
-subjects:
-- kind: ServiceAccount
-  name: cilium-etcd-operator
-  namespace: kube-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: etcd-operator
-  namespace: kube-system
-rules:
-- apiGroups:
-  - etcd.database.coreos.com
-  resources:
-  - etcdclusters
-  - etcdbackups
-  - etcdrestores
-  verbs:
-  - '*'
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - '*'
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - services
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - deployments
-  verbs:
-  - '*'
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - '*'
-- apiGroups:
-  - extensions
-  resources:
-  - deployments
-  verbs:
-  - create
-  - get
-  - list
-  - patch
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: etcd-operator
-  namespace: kube-system
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: etcd-operator
-subjects:
-- kind: ServiceAccount
-  name: cilium-etcd-sa
-  namespace: kube-system
----
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: cilium-etcd-operator
-  namespace: kube-system
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: cilium-etcd-sa
-  namespace: kube-system
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    io.cilium/app: etcd-operator
-    name: cilium-etcd-operator
-  name: cilium-etcd-operator
-  namespace: kube-system
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      io.cilium/app: etcd-operator
-      name: cilium-etcd-operator
-  strategy:
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 1
-    type: RollingUpdate
-  template:
-    metadata:
-      labels:
-        io.cilium/app: etcd-operator
-        name: cilium-etcd-operator
-    spec:
-      containers:
-      - command:
-        - /usr/bin/cilium-etcd-operator
-        env:
-        - name: CILIUM_ETCD_OPERATOR_CLUSTER_DOMAIN
-          value: cluster.local
-        - name: CILIUM_ETCD_OPERATOR_ETCD_CLUSTER_SIZE
-          value: "3"
-        - name: CILIUM_ETCD_OPERATOR_NAMESPACE
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.namespace
-        - name: CILIUM_ETCD_OPERATOR_POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        - name: CILIUM_ETCD_OPERATOR_POD_UID
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.uid
-        image: docker.io/cilium/cilium-etcd-operator:v2.0.4
-        imagePullPolicy: IfNotPresent
-        name: cilium-etcd-operator
-      dnsPolicy: ClusterFirst
-      hostNetwork: true
-      restartPolicy: Always
-      serviceAccount: cilium-etcd-operator
-      serviceAccountName: cilium-etcd-operator
-      tolerations:
-      - operator: Exists
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/examples/kubernetes/1.9/cilium.yaml
+++ b/examples/kubernetes/1.9/cilium.yaml
@@ -412,7 +412,7 @@ spec:
       - name: etcd-secrets
         secret:
           defaultMode: 420
-          optional: true
+          optional: false
           secretName: cilium-etcd-secrets
         # To read the clustermesh configuration
       - name: clustermesh-secrets

--- a/examples/kubernetes/1.9/etcd-secrets.yaml
+++ b/examples/kubernetes/1.9/etcd-secrets.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: cilium-etcd-secrets
+  namespace: kube-system
+data:
+  # To enable TLS with etcd, populate the secret with the key information from
+  # etcd:
+  #
+  # kubectl create secret generic -n kube-system cilium-etcd-secrets \
+  #    --from-file=etcd-ca=ca.crt \
+  #    --from-file=etcd-client-key=client.key \
+  #    --from-file=etcd-client-crt=client.crt

--- a/examples/kubernetes/Makefile
+++ b/examples/kubernetes/Makefile
@@ -20,6 +20,13 @@ CILIUM_DEFAULT= \
   $(ETCD_OPERATOR) \
   cilium-rbac.yaml
 
+CILIUM_EXTERNAL_ETCD= \
+  cilium-cm.yaml \
+  etcd-secrets.yaml \
+  cilium-ds.yaml \
+  cilium-operator.yaml \
+  cilium-rbac.yaml
+
 CILIUM_MINIKUBE= \
   cilium-cm.yaml \
   cilium-minikube-ds.yaml \
@@ -32,7 +39,7 @@ CILIUM_CRIO= \
   $(ETCD_OPERATOR) \
   cilium-rbac.yaml
 
-all: transform cilium.yaml cilium-crio.yaml cilium-minikube.yaml
+all: transform cilium.yaml cilium-crio.yaml cilium-minikube.yaml cilium-external-etcd.yaml
 
 %.sed:
 	for k8s_version in $(K8S_VERSIONS); do \
@@ -74,6 +81,18 @@ cilium.yaml:
         (cd $$k8s_version && \
             rm -f ./$@ && \
             for f in $(CILIUM_DEFAULT); do (cat "$${f}") >> $@; done); \
+	done
+
+cilium-external-etcd.yaml:
+	export __CILIUM_CONTAINER_RUNTIME__=auto
+	for k8s_version in $(K8S_VERSIONS); do \
+        (cd $$k8s_version && \
+            rm -f ./$@ && \
+            for f in $(CILIUM_EXTERNAL_ETCD); do (cat "$${f}") >> $@; done; \
+	sed -i 's+https://cilium-etcd-client.kube-system.svc:2379+http://EDIT-ME-ETCD-ADDRESS:2379+' cilium-external-etcd.yaml; \
+	sed -i "s+ca-file: '/var/lib/etcd-secrets/etcd-client-ca.crt'+# ca-file: '/var/lib/etcd-secrets/etcd-client-ca.crt'+" cilium-external-etcd.yaml; \
+	sed -i "s+key-file: '/var/lib/etcd-secrets/etcd-client.key'+# key-file: '/var/lib/etcd-secrets/etcd-client.key'+" cilium-external-etcd.yaml; \
+	sed -i "s+cert-file: '/var/lib/etcd-secrets/etcd-client.crt'+# cert-file: '/var/lib/etcd-secrets/etcd-client.crt'+" cilium-external-etcd.yaml); \
 	done
 
 cilium-crio.yaml:

--- a/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
@@ -279,7 +279,7 @@ spec:
       - name: etcd-secrets
         secret:
           defaultMode: 420
-          optional: true
+          optional: false
           secretName: cilium-etcd-secrets
         # To read the clustermesh configuration
       - name: clustermesh-secrets

--- a/examples/kubernetes/templates/v1/etcd-secrets.yaml
+++ b/examples/kubernetes/templates/v1/etcd-secrets.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: cilium-etcd-secrets
+  namespace: kube-system
+data:
+  # To enable TLS with etcd, populate the secret with the key information from
+  # etcd:
+  #
+  # kubectl create secret generic -n kube-system cilium-etcd-secrets --dry-run -o yaml \
+  #    --from-file=etcd-ca=ca.crt \
+  #    --from-file=etcd-client-key=client.key \
+  #    --from-file=etcd-client-crt=client.crt


### PR DESCRIPTION
With the etcd-operator becoming the standard, marking the cilium-etcd-secrets as optional is inefficient as it requires a Cilium pod restart to mount the secret after it has been created.

Instaead, mark the secret as required an provide a new `cilium-external-etcd.yaml` which contains an empty secret. For users upgrading, document the requirement to create an empty secret before the upgrade.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6718)
<!-- Reviewable:end -->
