### PR TITLE
Refactor datapath header generation

### DIFF
--- a/cilium/cmd/bpf_config_get.go
+++ b/cilium/cmd/bpf_config_get.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -62,7 +62,7 @@ func listEndpointConfigMap(args []string) {
 	}
 	defer bpf.ObjClose(fd)
 
-	m, _, err := configmap.OpenMapWithName(file, configmap.MapNamePrefix+lbl)
+	m, _, err := configmap.OpenMapWithName(file)
 	if err != nil {
 		fmt.Printf("error opening map %s: %s\n", file, err)
 		os.Exit(1)

--- a/common/utils.go
+++ b/common/utils.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,23 +25,6 @@ import (
 	"strings"
 )
 
-// goArray2C transforms a byte slice into its hexadecimal string representation.
-// Example:
-// array := []byte{0x12, 0xFF, 0x0, 0x01}
-// fmt.Print(GoArray2C(array)) // "{ 0x12, 0xff, 0x0, 0x1 }"
-func goArray2C(array []byte) string {
-	ret := ""
-
-	for i, e := range array {
-		if i == 0 {
-			ret = ret + fmt.Sprintf("%#x", e)
-		} else {
-			ret = ret + fmt.Sprintf(", %#x", e)
-		}
-	}
-	return ret
-}
-
 // C2GoArray transforms an hexadecimal string representation into a byte slice.
 // Example:
 // str := "0x12, 0xff, 0x0, 0x1"
@@ -63,24 +46,6 @@ func C2GoArray(str string) []byte {
 		ret = append(ret, byte(digit))
 	}
 	return ret
-}
-
-func FmtDefineComma(name string, addr []byte) string {
-	return fmt.Sprintf("#define %s %s\n", name, goArray2C(addr))
-}
-
-// FmtDefineAddress returns the a define string from the given name and addr.
-// Example:
-// fmt.Print(FmtDefineAddress("foo", []byte{1, 2, 3})) // "#define foo { .addr = { 0x1, 0x2, 0x3 } }\n"
-func FmtDefineAddress(name string, addr []byte) string {
-	return fmt.Sprintf("#define %s { .addr = { %s } }\n", name, goArray2C(addr))
-}
-
-// FmtDefineArray returns the a define string from the given name and array.
-// Example:
-// fmt.Print(FmtDefineArray("foo", []byte{1, 2, 3})) // "#define foo { 0x1, 0x2, 0x3 }\n"
-func FmtDefineArray(name string, array []byte) string {
-	return fmt.Sprintf("#define %s { %s }\n", name, goArray2C(array))
 }
 
 // FindEPConfigCHeader returns the full path of the file that is the CHeaderFileName from

--- a/common/utils_test.go
+++ b/common/utils_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,35 +36,12 @@ type CommonSuite struct{}
 
 var _ = check.Suite(&CommonSuite{})
 
-func (s *CommonSuite) TestGoArray2C(c *check.C) {
-	c.Assert(goArray2C([]byte{0, 0x01, 0x02, 0x03}), check.Equals, "0x0, 0x1, 0x2, 0x3")
-	c.Assert(goArray2C([]byte{0, 0xFF, 0xFF, 0xFF}), check.Equals, "0x0, 0xff, 0xff, 0xff")
-	c.Assert(goArray2C([]byte{0xa, 0xbc, 0xde, 0xf1}), check.Equals, "0xa, 0xbc, 0xde, 0xf1")
-	c.Assert(goArray2C([]byte{0}), check.Equals, "0x0")
-	c.Assert(goArray2C([]byte{}), check.Equals, "")
-}
-
 func (s *CommonSuite) TestC2GoArray(c *check.C) {
 	c.Assert(C2GoArray("0x0, 0x1, 0x2, 0x3"), checker.DeepEquals, []byte{0, 0x01, 0x02, 0x03})
 	c.Assert(C2GoArray("0x0, 0xff, 0xff, 0xff"), checker.DeepEquals, []byte{0, 0xFF, 0xFF, 0xFF})
 	c.Assert(C2GoArray("0xa, 0xbc, 0xde, 0xf1"), checker.DeepEquals, []byte{0xa, 0xbc, 0xde, 0xf1})
 	c.Assert(C2GoArray("0x0"), checker.DeepEquals, []byte{0})
 	c.Assert(C2GoArray(""), checker.DeepEquals, []byte{})
-}
-
-func (s *CommonSuite) TestFmtDefineComma(c *check.C) {
-	c.Assert(FmtDefineComma("foo", []byte{1, 2, 3}), check.Equals, "#define foo 0x1, 0x2, 0x3\n")
-	c.Assert(FmtDefineComma("foo", []byte{}), check.Equals, "#define foo \n")
-}
-
-func (s *CommonSuite) TestFmtDefineAddress(c *check.C) {
-	c.Assert(FmtDefineAddress("foo", []byte{1, 2, 3}), check.Equals, "#define foo { .addr = { 0x1, 0x2, 0x3 } }\n")
-	c.Assert(FmtDefineAddress("foo", []byte{}), check.Equals, "#define foo { .addr = {  } }\n")
-}
-
-func (s *CommonSuite) TestFmtDefineArray(c *check.C) {
-	c.Assert(FmtDefineArray("foo", []byte{1, 2, 3}), check.Equals, "#define foo { 0x1, 0x2, 0x3 }\n")
-	c.Assert(FmtDefineArray("foo", []byte{}), check.Equals, "#define foo {  }\n")
 }
 
 func (s *CommonSuite) TestMoveNewFilesTo(c *check.C) {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -21,7 +21,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"reflect"
 	"runtime"
 	"strings"
 	"sync"
@@ -34,7 +33,6 @@ import (
 	monitorLaunch "github.com/cilium/cilium/monitor/launch"
 	"github.com/cilium/cilium/pkg/api"
 	"github.com/cilium/cilium/pkg/bpf"
-	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/clustermesh"
 	"github.com/cilium/cilium/pkg/command/exec"
@@ -59,7 +57,6 @@ import (
 	"github.com/cilium/cilium/pkg/ipam"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s"
-	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
@@ -70,8 +67,6 @@ import (
 	"github.com/cilium/cilium/pkg/maps/lbmap"
 	"github.com/cilium/cilium/pkg/maps/lxcmap"
 	"github.com/cilium/cilium/pkg/maps/metricsmap"
-	"github.com/cilium/cilium/pkg/maps/policymap"
-	"github.com/cilium/cilium/pkg/maps/proxymap"
 	"github.com/cilium/cilium/pkg/maps/sockmap"
 	"github.com/cilium/cilium/pkg/maps/tunnel"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
@@ -694,98 +689,13 @@ func (d *Daemon) createNodeConfigHeaderfile() error {
 	if err != nil {
 		log.WithError(err).WithField(logfields.Path, nodeConfigPath).Fatal("Failed to create node configuration file")
 		return err
-
 	}
-	fw := bufio.NewWriter(f)
+	defer f.Close()
 
-	routerIP := node.GetIPv6Router()
-	hostIP := node.GetIPv6()
-
-	fmt.Fprintf(fw, ""+
-		"/*\n"+
-		" * Node-IPv6: %s\n"+
-		" * Router-IPv6: %s\n"+
-		" * Host-IPv4: %s\n"+
-		" */\n\n",
-		hostIP.String(), routerIP.String(),
-		node.GetInternalIPv4().String())
-
-	if option.Config.EnableIPv6 {
-		fw.WriteString(common.FmtDefineComma("ROUTER_IP", routerIP))
+	if err = d.datapath.WriteNodeConfig(f, &d.nodeDiscovery.localConfig); err != nil {
+		log.WithError(err).WithField(logfields.Path, nodeConfigPath).Fatal("Failed to write node configuration file")
+		return err
 	}
-
-	if option.Config.EnableIPv4 {
-		ipv4GW := node.GetInternalIPv4()
-		loopbackIPv4 := node.GetIPv4Loopback()
-		ipv4Range := node.GetIPv4AllocRange()
-		fmt.Fprintf(fw, "#define IPV4_GATEWAY %#x\n", byteorder.HostSliceToNetwork(ipv4GW, reflect.Uint32).(uint32))
-		fmt.Fprintf(fw, "#define IPV4_LOOPBACK %#x\n", byteorder.HostSliceToNetwork(loopbackIPv4, reflect.Uint32).(uint32))
-		fmt.Fprintf(fw, "#define IPV4_MASK %#x\n", byteorder.HostSliceToNetwork(ipv4Range.Mask, reflect.Uint32).(uint32))
-	}
-
-	if nat46Range := option.Config.NAT46Prefix; nat46Range != nil {
-		fw.WriteString(common.FmtDefineAddress("NAT46_PREFIX", nat46Range.IP))
-	}
-
-	fw.WriteString(common.FmtDefineComma("HOST_IP", hostIP))
-	fmt.Fprintf(fw, "#define HOST_ID %d\n", identity.GetReservedID(labels.IDNameHost))
-	fmt.Fprintf(fw, "#define WORLD_ID %d\n", identity.GetReservedID(labels.IDNameWorld))
-	fmt.Fprintf(fw, "#define HEALTH_ID %d\n", identity.GetReservedID(labels.IDNameHealth))
-	fmt.Fprintf(fw, "#define UNMANAGED_ID %d\n", identity.GetReservedID(labels.IDNameUnmanaged))
-	fmt.Fprintf(fw, "#define INIT_ID %d\n", identity.GetReservedID(labels.IDNameInit))
-	fmt.Fprintf(fw, "#define LB_RR_MAX_SEQ %d\n", lbmap.MaxSeq)
-	fmt.Fprintf(fw, "#define CILIUM_LB_MAP_MAX_ENTRIES %d\n", lbmap.MaxEntries)
-	fmt.Fprintf(fw, "#define TUNNEL_MAP %s\n", tunnel.MapName)
-	fmt.Fprintf(fw, "#define TUNNEL_ENDPOINT_MAP_SIZE %d\n", tunnel.MaxEntries)
-	fmt.Fprintf(fw, "#define PROXY_MAP_SIZE %d\n", proxymap.MaxEntries)
-	fmt.Fprintf(fw, "#define ENDPOINTS_MAP %s\n", lxcmap.MapName)
-	fmt.Fprintf(fw, "#define ENDPOINTS_MAP_SIZE %d\n", lxcmap.MaxEntries)
-	fmt.Fprintf(fw, "#define METRICS_MAP %s\n", metricsmap.MapName)
-	fmt.Fprintf(fw, "#define METRICS_MAP_SIZE %d\n", metricsmap.MaxEntries)
-	fmt.Fprintf(fw, "#define POLICY_MAP_SIZE %d\n", policymap.MaxEntries)
-	fmt.Fprintf(fw, "#define IPCACHE_MAP %s\n", ipcachemap.Name)
-	fmt.Fprintf(fw, "#define IPCACHE_MAP_SIZE %d\n", ipcachemap.MaxEntries)
-	fmt.Fprintf(fw, "#define POLICY_PROG_MAP_SIZE %d\n", policymap.ProgArrayMaxEntries)
-	fmt.Fprintf(fw, "#define SOCKOPS_MAP_SIZE %d\n", sockmap.MaxEntries)
-
-	if option.Config.DatapathMode == option.DatapathModeIpvlan {
-		fmt.Fprintf(fw, "#define ENABLE_SECCTX_FROM_IPCACHE 1\n")
-	}
-
-	if option.Config.PreAllocateMaps {
-		fmt.Fprintf(fw, "#define PREALLOCATE_MAPS 1\n")
-	}
-
-	fmt.Fprintf(fw, "#define EVENTS_MAP %s\n", "cilium_events")
-	fmt.Fprintf(fw, "#define POLICY_CALL_MAP %s\n", policymap.CallMapName)
-	fmt.Fprintf(fw, "#define PROXY4_MAP cilium_proxy4\n")
-	fmt.Fprintf(fw, "#define PROXY6_MAP cilium_proxy6\n")
-	fmt.Fprintf(fw, "#define EP_POLICY_MAP %s\n", eppolicymap.MapName)
-	fmt.Fprintf(fw, "#define LB6_REVERSE_NAT_MAP cilium_lb6_reverse_nat\n")
-	fmt.Fprintf(fw, "#define LB6_SERVICES_MAP cilium_lb6_services\n")
-	fmt.Fprintf(fw, "#define LB6_RR_SEQ_MAP cilium_lb6_rr_seq\n")
-	fmt.Fprintf(fw, "#define LB4_REVERSE_NAT_MAP cilium_lb4_reverse_nat\n")
-	fmt.Fprintf(fw, "#define LB4_SERVICES_MAP cilium_lb4_services\n")
-	fmt.Fprintf(fw, "#define LB4_RR_SEQ_MAP cilium_lb4_rr_seq\n")
-
-	fmt.Fprintf(fw, "#define TRACE_PAYLOAD_LEN %dULL\n", option.Config.TracePayloadlen)
-	fmt.Fprintf(fw, "#define MTU %d\n", d.mtuConfig.GetDeviceMTU())
-
-	if option.Config.EnableIPv4 {
-		fmt.Fprintf(fw, "#define ENABLE_IPV4 1\n")
-	}
-
-	if option.Config.EnableIPv6 {
-		fmt.Fprintf(fw, "#define ENABLE_IPV6 1\n")
-	}
-
-	if option.Config.EnableIPSec {
-		fmt.Fprintf(fw, "#define ENABLE_IPSEC 1\n")
-	}
-
-	fw.Flush()
-	f.Close()
-
 	return nil
 }
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -659,10 +659,6 @@ func (d *Daemon) init() error {
 		log.WithError(err).WithField(logfields.Path, option.Config.StateDir).Fatal("Could not change to runtime directory")
 	}
 
-	if err := d.createNodeConfigHeaderfile(); err != nil {
-		return err
-	}
-
 	// Remove any old sockops and re-enable with _new_ programs if flag is set
 	sockops.SockmapDisable()
 	sockops.SkmsgDisable()
@@ -675,6 +671,10 @@ func (d *Daemon) init() error {
 	}
 
 	if !option.Config.DryMode {
+		if err := d.createNodeConfigHeaderfile(); err != nil {
+			return err
+		}
+
 		if err := d.compileBase(); err != nil {
 			return err
 		}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -323,30 +323,12 @@ func (d *Daemon) writeNetdevHeader(dir string) error {
 
 	fw := bufio.NewWriter(f)
 	fw.WriteString(option.Config.Opts.GetFmtList())
-	fw.WriteString(d.fmtPolicyEnforcementIngress())
-	fw.WriteString(d.fmtPolicyEnforcementEgress())
 	if option.Config.IsFlannelMasterDeviceSet() {
 		fw.WriteString("#define HOST_REDIRECT_TO_INGRESS 1\n")
 	}
 	endpoint.WriteIPCachePrefixes(fw, d.prefixLengths.ToBPFData)
 
 	return fw.Flush()
-}
-
-// returns #define for PolicyIngress based on the configuration of the daemon.
-func (d *Daemon) fmtPolicyEnforcementIngress() string {
-	if policy.GetPolicyEnabled() == option.AlwaysEnforce {
-		return fmt.Sprintf("#define %s 1\n", option.IngressSpecPolicy.Define)
-	}
-	return fmt.Sprintf("#undef %s\n", option.IngressSpecPolicy.Define)
-}
-
-// returns #define for PolicyEgress based on the configuration of the daemon.
-func (d *Daemon) fmtPolicyEnforcementEgress() string {
-	if policy.GetPolicyEnabled() == option.AlwaysEnforce {
-		return fmt.Sprintf("#define %s 1\n", option.EgressSpecPolicy.Define)
-	}
-	return fmt.Sprintf("#undef %s\n", option.EgressSpecPolicy.Define)
 }
 
 // Must be called with option.Config.EnablePolicyMU locked.

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -326,9 +326,15 @@ func (d *Daemon) writeNetdevHeader(dir string) error {
 	if option.Config.IsFlannelMasterDeviceSet() {
 		fw.WriteString("#define HOST_REDIRECT_TO_INGRESS 1\n")
 	}
-	endpoint.WriteIPCachePrefixes(fw, d.prefixLengths.ToBPFData)
+	endpoint.WriteIPCachePrefixes(fw, d)
 
 	return fw.Flush()
+}
+
+// GetCIDRPrefixLengths returns the sorted list of unique prefix lengths used
+// by CIDR policies.
+func (d *Daemon) GetCIDRPrefixLengths() (s6, s4 []int) {
+	return d.prefixLengths.ToBPFData()
 }
 
 // Must be called with option.Config.EnablePolicyMU locked.
@@ -348,6 +354,11 @@ func (d *Daemon) writePreFilterHeader(dir string) error {
 	fmt.Fprint(fw, " */\n\n")
 	d.preFilter.WriteConfig(fw)
 	return fw.Flush()
+}
+
+// GetOptions returns the datapath configuration options of the daemon.
+func (d *Daemon) GetOptions() *option.IntOptions {
+	return option.Config.Opts
 }
 
 func (d *Daemon) setHostAddresses() error {

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import (
 
 	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/pkg/completion"
+	"github.com/cilium/cilium/pkg/datapath"
 	fakedatapath "github.com/cilium/cilium/pkg/datapath/fake"
 	e "github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpointmanager"
@@ -274,4 +275,8 @@ func (ds *DaemonSuite) NewProxyLogRecord(l *accesslog.LogRecord) error {
 		return ds.OnNewProxyLogRecord(l)
 	}
 	panic("NewProxyLogRecord should not have been called")
+}
+
+func (ds *DaemonSuite) Datapath() datapath.Datapath {
+	return ds.d.datapath
 }

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -469,8 +469,8 @@ func (h *patchEndpointID) Handle(params PatchEndpointIDParams) middleware.Respon
 		changed = true
 	}
 
-	if epTemplate.HostMac != "" && bytes.Compare(ep.NodeMAC, newEp.NodeMAC) != 0 {
-		ep.NodeMAC = newEp.NodeMAC
+	if epTemplate.HostMac != "" && bytes.Compare(ep.GetNodeMAC(), newEp.NodeMAC) != 0 {
+		ep.SetNodeMACLocked(newEp.NodeMAC)
 		changed = true
 	}
 

--- a/daemon/policy_test.go
+++ b/daemon/policy_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -154,7 +154,7 @@ func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
 	e.IPv6 = QAIPv6Addr
 	e.IPv4 = QAIPv4Addr
 	e.LXCMAC = QAHardAddr
-	e.NodeMAC = QAHardAddr
+	e.SetNodeMACLocked(QAHardAddr)
 
 	err2 := os.Mkdir("1", 755)
 	c.Assert(err2, IsNil)
@@ -181,7 +181,7 @@ func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
 	e.IPv6 = ProdIPv6Addr
 	e.IPv4 = ProdIPv4Addr
 	e.LXCMAC = ProdHardAddr
-	e.NodeMAC = ProdHardAddr
+	e.SetNodeMACLocked(ProdHardAddr)
 	e.SetIdentity(prodBarSecLblsCtx)
 	e.UnconditionalLock()
 	ready = e.SetStateLocked(endpoint.StateWaitingToRegenerate, "test")
@@ -455,7 +455,7 @@ func (ds *DaemonSuite) TestRemovePolicy(c *C) {
 	e.IPv6 = QAIPv6Addr
 	e.IPv4 = QAIPv4Addr
 	e.LXCMAC = QAHardAddr
-	e.NodeMAC = QAHardAddr
+	e.SetNodeMACLocked(QAHardAddr)
 	err2 := os.Mkdir("1", 755)
 	c.Assert(err2, IsNil)
 	defer func() {

--- a/daemon/state_test.go
+++ b/daemon/state_test.go
@@ -76,7 +76,7 @@ func endpointCreator(id uint16, secID identity.NumericIdentity) *e.Endpoint {
 	ep.IPv4 = addressing.DeriveCiliumIPv4(net.IP{0xc0, 0xa8, b[0], b[1]})
 	ep.IPv6 = addressing.DeriveCiliumIPv6(net.IP{0xbe, 0xef, 0xbe, 0xef, 0xbe, 0xef, 0xbe, 0xef, 0xaa, 0xaa, 0xaa, 0xaa, 0x00, 0x00, b[0], b[1]})
 	ep.IfIndex = 1
-	ep.NodeMAC = mac.MAC([]byte{0x02, 0xff, 0xf2, 0x12, 0x0, 0x0})
+	ep.SetNodeMACLocked(mac.MAC([]byte{0x02, 0xff, 0xf2, 0x12, 0x0, 0x0}))
 	ep.SecurityIdentity = &identity.Identity{
 		ID: secID,
 		Labels: labels.Labels{
@@ -171,7 +171,7 @@ func (ds *DaemonSuite) generateEPs(baseDir string, epsWanted []*e.Endpoint, epsM
 				ep.UnconditionalLock()
 				// Change endpoint a little bit so we know which endpoint is in
 				// "256_next_fail" and with one is in the "256" directory.
-				ep.NodeMAC = mac.MAC([]byte{0x02, 0xff, 0xf2, 0x12, 0xc1, 0xc1})
+				ep.SetNodeMACLocked(mac.MAC([]byte{0x02, 0xff, 0xf2, 0x12, 0xc1, 0xc1}))
 				ready := ep.SetStateLocked(e.StateWaitingToRegenerate, "test")
 				ep.Unlock()
 				if ready {

--- a/pkg/bpf/bpffs_linux.go
+++ b/pkg/bpf/bpffs_linux.go
@@ -104,6 +104,16 @@ func MapPath(name string) string {
 	return mapPathFromMountInfo(name)
 }
 
+// LocalMapName returns the name for a BPF map that is local to the specified ID.
+func LocalMapName(name string, id uint16) string {
+	return fmt.Sprintf("%s%d", name, id)
+}
+
+// LocalMapPath returns the path for a BPF map that is local to the specified ID.
+func LocalMapPath(name string, id uint16) string {
+	return MapPath(LocalMapName(name, id))
+}
+
 // Environment returns a list of environment variables which are needed to make
 // BPF programs and tc aware of the actual BPFFS mount path.
 func Environment() []string {

--- a/pkg/datapath/config.go
+++ b/pkg/datapath/config.go
@@ -15,6 +15,9 @@
 package datapath
 
 import (
+	"github.com/cilium/cilium/common/addressing"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/mac"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -30,4 +33,25 @@ type DeviceConfiguration interface {
 
 	// GetOptions fetches the configurable datapath options from the owner.
 	GetOptions() *option.IntOptions
+}
+
+// EndpointConfiguration provides datapath implementations a clean interface
+// to access endpoint-specific configuration when configuring the datapath.
+type EndpointConfiguration interface {
+	DeviceConfiguration
+
+	// GetID returns a locally-significant endpoint identification number.
+	GetID() uint64
+	// StringID returns the string-formatted version of the ID from GetID().
+	StringID() string
+	// GetIdentity returns a globally-significant numeric security identity.
+	GetIdentity() identity.NumericIdentity
+
+	IPv4Address() addressing.CiliumIPv4
+	IPv6Address() addressing.CiliumIPv6
+	GetNodeMAC() mac.MAC
+
+	// TODO: Move this detail into the datapath
+	HasIpvlanDataPath() bool
+	ConntrackLocalLocked() bool
 }

--- a/pkg/datapath/config.go
+++ b/pkg/datapath/config.go
@@ -1,0 +1,33 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datapath
+
+import (
+	"github.com/cilium/cilium/pkg/option"
+)
+
+// DeviceConfiguration is an interface for injecting configuration of datapath
+// options that affect lookups and logic applied at a per-device level, whether
+// those are devices associated with the endpoint or associated with the host.
+type DeviceConfiguration interface {
+	// GetCIDRPrefixLengths fetches the lists of unique IPv6 and IPv4
+	// prefix lengths used for datapath lookups, each of which is sorted
+	// from longest prefix to shortest prefix. It must return more than
+	// one element in each returned array.
+	GetCIDRPrefixLengths() (s6, s4 []int)
+
+	// GetOptions fetches the configurable datapath options from the owner.
+	GetOptions() *option.IntOptions
+}

--- a/pkg/datapath/datapath.go
+++ b/pkg/datapath/datapath.go
@@ -14,6 +14,10 @@
 
 package datapath
 
+import (
+	"io"
+)
+
 // Datapath is the interface to abstract all datapath interactions. The
 // abstraction allows to implement the datapath requirements with multiple
 // implementations
@@ -24,4 +28,8 @@ type Datapath interface {
 	// LocalNodeAddressing must return the node addressing implementation
 	// of the local node
 	LocalNodeAddressing() NodeAddressing
+
+	// WriteNodeConfig writes the implementation-specific configuration of
+	// node-wide options into the specified writer.
+	WriteNodeConfig(io.Writer, *LocalNodeConfiguration) error
 }

--- a/pkg/datapath/datapath.go
+++ b/pkg/datapath/datapath.go
@@ -38,4 +38,8 @@ type Datapath interface {
 	// here will apply to base programs and not to endpoints, though
 	// endpoints may have equivalent configurable options.
 	WriteNetdevConfig(io.Writer, DeviceConfiguration) error
+
+	// WriteEndpointConfig writes the implementation-specific configuration
+	// of configurable options to the specified writer.
+	WriteEndpointConfig(io.Writer, EndpointConfiguration) error
 }

--- a/pkg/datapath/datapath.go
+++ b/pkg/datapath/datapath.go
@@ -32,4 +32,10 @@ type Datapath interface {
 	// WriteNodeConfig writes the implementation-specific configuration of
 	// node-wide options into the specified writer.
 	WriteNodeConfig(io.Writer, *LocalNodeConfiguration) error
+
+	// WriteNetdevConfig writes the implementation-specific configuration
+	// of configurable options to the specified writer. Options specified
+	// here will apply to base programs and not to endpoints, though
+	// endpoints may have equivalent configurable options.
+	WriteNetdevConfig(io.Writer, DeviceConfiguration) error
 }

--- a/pkg/datapath/fake/datapath.go
+++ b/pkg/datapath/fake/datapath.go
@@ -15,6 +15,8 @@
 package fake
 
 import (
+	"io"
+
 	"github.com/cilium/cilium/pkg/datapath"
 )
 
@@ -40,4 +42,9 @@ func (f *fakeDatapath) Node() datapath.NodeHandler {
 // local node
 func (f *fakeDatapath) LocalNodeAddressing() datapath.NodeAddressing {
 	return f.nodeAddressing
+}
+
+// WriteNodeConfig pretends to write the datapath configuration to the writer.
+func (f *fakeDatapath) WriteNodeConfig(io.Writer, *datapath.LocalNodeConfiguration) error {
+	return nil
 }

--- a/pkg/datapath/fake/datapath.go
+++ b/pkg/datapath/fake/datapath.go
@@ -48,3 +48,8 @@ func (f *fakeDatapath) LocalNodeAddressing() datapath.NodeAddressing {
 func (f *fakeDatapath) WriteNodeConfig(io.Writer, *datapath.LocalNodeConfiguration) error {
 	return nil
 }
+
+// WriteNetdevConfig pretends to write the netdev configuration to a writer.
+func (f *fakeDatapath) WriteNetdevConfig(io.Writer, datapath.DeviceConfiguration) error {
+	return nil
+}

--- a/pkg/datapath/fake/datapath.go
+++ b/pkg/datapath/fake/datapath.go
@@ -53,3 +53,8 @@ func (f *fakeDatapath) WriteNodeConfig(io.Writer, *datapath.LocalNodeConfigurati
 func (f *fakeDatapath) WriteNetdevConfig(io.Writer, datapath.DeviceConfiguration) error {
 	return nil
 }
+
+// WriteEndpointConfig pretends to write the endpoint configuration to a writer.
+func (f *fakeDatapath) WriteEndpointConfig(io.Writer, datapath.EndpointConfiguration) error {
+	return nil
+}

--- a/pkg/datapath/linux/config.go
+++ b/pkg/datapath/linux/config.go
@@ -1,0 +1,129 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package linux
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"reflect"
+
+	"github.com/cilium/cilium/common"
+	"github.com/cilium/cilium/pkg/byteorder"
+	"github.com/cilium/cilium/pkg/datapath"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/maps/eppolicymap"
+	ipcachemap "github.com/cilium/cilium/pkg/maps/ipcache"
+	"github.com/cilium/cilium/pkg/maps/lbmap"
+	"github.com/cilium/cilium/pkg/maps/lxcmap"
+	"github.com/cilium/cilium/pkg/maps/metricsmap"
+	"github.com/cilium/cilium/pkg/maps/policymap"
+	"github.com/cilium/cilium/pkg/maps/proxymap"
+	"github.com/cilium/cilium/pkg/maps/sockmap"
+	"github.com/cilium/cilium/pkg/maps/tunnel"
+	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+// WriteNodeConfig writes the local node configuration to the specified writer.
+func (l *linuxDatapath) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeConfiguration) error {
+	fw := bufio.NewWriter(w)
+
+	routerIP := node.GetIPv6Router()
+	hostIP := node.GetIPv6()
+
+	fmt.Fprintf(fw, ""+
+		"/*\n"+
+		" * Node-IPv6: %s\n"+
+		" * Router-IPv6: %s\n"+
+		" * Host-IPv4: %s\n"+
+		" */\n\n",
+		hostIP.String(), routerIP.String(),
+		node.GetInternalIPv4().String())
+
+	if option.Config.EnableIPv6 {
+		fw.WriteString(common.FmtDefineComma("ROUTER_IP", routerIP))
+	}
+
+	if option.Config.EnableIPv4 {
+		ipv4GW := node.GetInternalIPv4()
+		loopbackIPv4 := node.GetIPv4Loopback()
+		ipv4Range := node.GetIPv4AllocRange()
+		fmt.Fprintf(fw, "#define IPV4_GATEWAY %#x\n", byteorder.HostSliceToNetwork(ipv4GW, reflect.Uint32).(uint32))
+		fmt.Fprintf(fw, "#define IPV4_LOOPBACK %#x\n", byteorder.HostSliceToNetwork(loopbackIPv4, reflect.Uint32).(uint32))
+		fmt.Fprintf(fw, "#define IPV4_MASK %#x\n", byteorder.HostSliceToNetwork(ipv4Range.Mask, reflect.Uint32).(uint32))
+	}
+
+	if nat46Range := option.Config.NAT46Prefix; nat46Range != nil {
+		fw.WriteString(common.FmtDefineAddress("NAT46_PREFIX", nat46Range.IP))
+	}
+
+	fw.WriteString(common.FmtDefineComma("HOST_IP", hostIP))
+	fmt.Fprintf(fw, "#define HOST_ID %d\n", identity.GetReservedID(labels.IDNameHost))
+	fmt.Fprintf(fw, "#define WORLD_ID %d\n", identity.GetReservedID(labels.IDNameWorld))
+	fmt.Fprintf(fw, "#define HEALTH_ID %d\n", identity.GetReservedID(labels.IDNameHealth))
+	fmt.Fprintf(fw, "#define UNMANAGED_ID %d\n", identity.GetReservedID(labels.IDNameUnmanaged))
+	fmt.Fprintf(fw, "#define INIT_ID %d\n", identity.GetReservedID(labels.IDNameInit))
+	fmt.Fprintf(fw, "#define LB_RR_MAX_SEQ %d\n", lbmap.MaxSeq)
+	fmt.Fprintf(fw, "#define CILIUM_LB_MAP_MAX_ENTRIES %d\n", lbmap.MaxEntries)
+	fmt.Fprintf(fw, "#define TUNNEL_MAP %s\n", tunnel.MapName)
+	fmt.Fprintf(fw, "#define TUNNEL_ENDPOINT_MAP_SIZE %d\n", tunnel.MaxEntries)
+	fmt.Fprintf(fw, "#define PROXY_MAP_SIZE %d\n", proxymap.MaxEntries)
+	fmt.Fprintf(fw, "#define ENDPOINTS_MAP %s\n", lxcmap.MapName)
+	fmt.Fprintf(fw, "#define ENDPOINTS_MAP_SIZE %d\n", lxcmap.MaxEntries)
+	fmt.Fprintf(fw, "#define METRICS_MAP %s\n", metricsmap.MapName)
+	fmt.Fprintf(fw, "#define METRICS_MAP_SIZE %d\n", metricsmap.MaxEntries)
+	fmt.Fprintf(fw, "#define POLICY_MAP_SIZE %d\n", policymap.MaxEntries)
+	fmt.Fprintf(fw, "#define IPCACHE_MAP %s\n", ipcachemap.Name)
+	fmt.Fprintf(fw, "#define IPCACHE_MAP_SIZE %d\n", ipcachemap.MaxEntries)
+	fmt.Fprintf(fw, "#define POLICY_PROG_MAP_SIZE %d\n", policymap.ProgArrayMaxEntries)
+	fmt.Fprintf(fw, "#define SOCKOPS_MAP_SIZE %d\n", sockmap.MaxEntries)
+
+	if option.Config.DatapathMode == option.DatapathModeIpvlan {
+		fmt.Fprintf(fw, "#define ENABLE_SECCTX_FROM_IPCACHE 1\n")
+	}
+
+	if option.Config.PreAllocateMaps {
+		fmt.Fprintf(fw, "#define PREALLOCATE_MAPS 1\n")
+	}
+
+	fmt.Fprintf(fw, "#define EVENTS_MAP %s\n", "cilium_events")
+	fmt.Fprintf(fw, "#define POLICY_CALL_MAP %s\n", policymap.CallMapName)
+	fmt.Fprintf(fw, "#define PROXY4_MAP cilium_proxy4\n")
+	fmt.Fprintf(fw, "#define PROXY6_MAP cilium_proxy6\n")
+	fmt.Fprintf(fw, "#define EP_POLICY_MAP %s\n", eppolicymap.MapName)
+	fmt.Fprintf(fw, "#define LB6_REVERSE_NAT_MAP cilium_lb6_reverse_nat\n")
+	fmt.Fprintf(fw, "#define LB6_SERVICES_MAP cilium_lb6_services\n")
+	fmt.Fprintf(fw, "#define LB6_RR_SEQ_MAP cilium_lb6_rr_seq\n")
+	fmt.Fprintf(fw, "#define LB4_REVERSE_NAT_MAP cilium_lb4_reverse_nat\n")
+	fmt.Fprintf(fw, "#define LB4_SERVICES_MAP cilium_lb4_services\n")
+	fmt.Fprintf(fw, "#define LB4_RR_SEQ_MAP cilium_lb4_rr_seq\n")
+
+	fmt.Fprintf(fw, "#define TRACE_PAYLOAD_LEN %dULL\n", option.Config.TracePayloadlen)
+	fmt.Fprintf(fw, "#define MTU %d\n", cfg.MtuConfig.GetDeviceMTU())
+
+	if option.Config.EnableIPv4 {
+		fmt.Fprintf(fw, "#define ENABLE_IPV4 1\n")
+	}
+	if option.Config.EnableIPv6 {
+		fmt.Fprintf(fw, "#define ENABLE_IPV6 1\n")
+	}
+	if option.Config.EnableIPSec {
+		fmt.Fprintf(fw, "#define ENABLE_IPSEC 1\n")
+	}
+
+	return fw.Flush()
+}

--- a/pkg/datapath/linux/config_test.go
+++ b/pkg/datapath/linux/config_test.go
@@ -1,0 +1,101 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build privileged_tests
+
+package linux
+
+import (
+	"bytes"
+	"errors"
+	"io"
+
+	"github.com/cilium/cilium/pkg/datapath"
+	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/testutils"
+
+	. "gopkg.in/check.v1"
+)
+
+type DatapathSuite struct{}
+
+var (
+	_ = Suite(&DatapathSuite{})
+
+	dummyNodeCfg  = datapath.LocalNodeConfiguration{}
+	dummyDevCfg   = testutils.NewTestEndpoint()
+	dummyEPCfg    = testutils.NewTestEndpoint()
+	ipv4DummyAddr = []byte{192, 0, 2, 3}
+)
+
+func (s *DatapathSuite) SetUpTest(c *C) {
+	node.InitDefaultPrefix("")
+	node.SetInternalIPv4(ipv4DummyAddr)
+	node.SetIPv4Loopback(ipv4DummyAddr)
+}
+
+func (s *DatapathSuite) TearDownTest(c *C) {
+	node.SetInternalIPv4(nil)
+	node.SetIPv4Loopback(nil)
+}
+
+type badWriter struct{}
+
+func (b *badWriter) Write(p []byte) (int, error) {
+	return 0, errors.New("bad write :(")
+}
+
+type writeFn func(io.Writer, datapath.Datapath) error
+
+func writeConfig(c *C, header string, write writeFn) {
+	tests := []struct {
+		description string
+		output      io.Writer
+		expResult   Checker
+	}{
+		{
+			description: "successful write to an in-memory buffer",
+			output:      &bytes.Buffer{},
+			expResult:   IsNil,
+		},
+		{
+			description: "write to a failing writer",
+			output:      &badWriter{},
+			expResult:   NotNil,
+		},
+	}
+	for _, test := range tests {
+		c.Logf("  Testing %s configuration: %s", header, test.description)
+		dp := NewDatapath(DatapathConfiguration{})
+		c.Assert(write(test.output, dp), test.expResult)
+	}
+}
+
+func (s *DatapathSuite) TestWriteNodeConfig(c *C) {
+	writeConfig(c, "node", func(w io.Writer, dp datapath.Datapath) error {
+		return dp.WriteNodeConfig(w, &dummyNodeCfg)
+	})
+}
+
+func (s *DatapathSuite) TestWriteNetdevConfig(c *C) {
+	writeConfig(c, "netdev", func(w io.Writer, dp datapath.Datapath) error {
+		return dp.WriteNetdevConfig(w, &dummyDevCfg)
+	})
+}
+
+func (s *DatapathSuite) TestWriteEndpointConfig(c *C) {
+	writeConfig(c, "endpoint", func(w io.Writer, dp datapath.Datapath) error {
+		return dp.WriteEndpointConfig(w, &dummyEPCfg)
+	})
+}

--- a/pkg/datapath/linux/utils_test.go
+++ b/pkg/datapath/linux/utils_test.go
@@ -1,0 +1,83 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package linux
+
+import (
+	. "gopkg.in/check.v1"
+)
+
+type DatapathSuite struct{}
+
+var (
+	_ = Suite(&DatapathSuite{})
+)
+
+type formatTestCase struct {
+	input  []byte
+	output string
+}
+
+func (s *DatapathSuite) TestGoArray2C(c *C) {
+	tests := []formatTestCase{
+		{
+			input:  []byte{0, 0x01, 0x02, 0x03},
+			output: "0x0, 0x1, 0x2, 0x3",
+		},
+		{
+			input:  []byte{0, 0xFF, 0xFF, 0xFF},
+			output: "0x0, 0xff, 0xff, 0xff",
+		},
+		{
+			input:  []byte{0xa, 0xbc, 0xde, 0xf1},
+			output: "0xa, 0xbc, 0xde, 0xf1",
+		},
+		{
+			input:  []byte{0},
+			output: "0x0",
+		},
+		{
+			input:  []byte{},
+			output: "",
+		},
+	}
+
+	for _, test := range tests {
+		c.Assert(goArray2C(test.input), Equals, test.output)
+	}
+}
+
+func (s *DatapathSuite) TestdefineIPv6(c *C) {
+	input := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	expOut := "#define foo 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf, 0x10\n"
+	c.Assert(defineIPv6("foo", input), Equals, expOut)
+}
+
+func (s *DatapathSuite) TestdefineMAC(c *C) {
+	tests := []formatTestCase{
+		{
+			input:  []byte{1, 2, 3},
+			output: "#define foo { .addr = { 0x1, 0x2, 0x3 } }\n",
+		},
+		{
+			input:  []byte{},
+			output: "#define foo { .addr = {  } }\n",
+		},
+	}
+	for _, test := range tests {
+		c.Assert(defineMAC("foo", test.input), Equals, test.output)
+	}
+}

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -25,7 +25,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"strconv"
 	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -55,39 +54,24 @@ const (
 	EndpointGenerationTimeout = 330 * time.Second
 )
 
-// mapPath returns the path to a map for endpoint ID.
-func (e *Endpoint) mapPath(mapname string) string {
-	return bpf.MapPath(mapname + strconv.Itoa(int(e.ID)))
-}
-
 // PolicyMapPathLocked returns the path to the policy map of endpoint.
 func (e *Endpoint) PolicyMapPathLocked() string {
-	return e.mapPath(policymap.MapName)
+	return bpf.LocalMapPath(policymap.MapName, e.ID)
 }
 
 // CallsMapPathLocked returns the path to cilium tail calls map of an endpoint.
 func (e *Endpoint) CallsMapPathLocked() string {
-	return bpf.MapPath(CallsMapName + strconv.Itoa(int(e.ID)))
+	return bpf.LocalMapPath(CallsMapName, e.ID)
 }
 
 // BPFConfigMapPath returns the path to the BPF config map of endpoint.
 func (e *Endpoint) BPFConfigMapPath() string {
-	return bpf.MapPath(e.BPFConfigMapName())
-}
-
-// BPFConfigMapName returns the name of the config map for endpoint.
-func (e *Endpoint) BPFConfigMapName() string {
-	return bpfconfig.MapNamePrefix + strconv.Itoa(int(e.ID))
+	return bpf.LocalMapPath(bpfconfig.MapNamePrefix, e.ID)
 }
 
 // BPFIpvlanMapPath returns the path to the ipvlan tail call map of an endpoint.
 func (e *Endpoint) BPFIpvlanMapPath() string {
-	return bpf.MapPath(e.BPFIpvlanMapName())
-}
-
-// BPFIpvlanMapName returns the name of the ipvlan tail call map of an endpoint.
-func (e *Endpoint) BPFIpvlanMapName() string {
-	return IpvlanMapName + strconv.Itoa(int(e.ID))
+	return bpf.LocalMapPath(IpvlanMapName, e.ID)
 }
 
 // writeInformationalComments writes annotations to the specified writer,
@@ -671,7 +655,7 @@ func (e *Endpoint) runPreCompilationSteps(owner Owner, regenContext *regeneratio
 	}
 
 	if e.bpfConfigMap == nil {
-		e.bpfConfigMap, _, err = bpfconfig.OpenMapWithName(e.BPFConfigMapPath(), e.BPFConfigMapName())
+		e.bpfConfigMap, _, err = bpfconfig.OpenMapWithName(e.BPFConfigMapPath())
 		if err != nil {
 			return err
 		}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -861,6 +861,16 @@ func (e *Endpoint) GetIPv6Address() string {
 	return e.IPv6.String()
 }
 
+// GetNodeMAC returns the MAC address of the node from this endpoint's perspective.
+func (e *Endpoint) GetNodeMAC() mac.MAC {
+	return e.NodeMAC
+}
+
+// SetNodeMACLocked updates the node MAC inside the endpoint.
+func (e *Endpoint) SetNodeMACLocked(m mac.MAC) {
+	e.NodeMAC = m
+}
+
 func (e *Endpoint) HasSidecarProxy() bool {
 	return e.hasSidecarProxy
 }

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -851,14 +851,24 @@ func (e *Endpoint) GetOptions() *option.IntOptions {
 	return e.Options
 }
 
-// GetIPv4Address returns the IPv4 address of the endpoint
+// GetIPv4Address returns the IPv4 address of the endpoint as a string
 func (e *Endpoint) GetIPv4Address() string {
 	return e.IPv4.String()
 }
 
-// GetIPv6Address returns the IPv6 address of the endpoint
+// GetIPv6Address returns the IPv6 address of the endpoint as a string
 func (e *Endpoint) GetIPv6Address() string {
 	return e.IPv6.String()
+}
+
+// IPv4Address returns the IPv4 address of the endpoint
+func (e *Endpoint) IPv4Address() addressing.CiliumIPv4 {
+	return e.IPv4
+}
+
+// IPv6Address returns the IPv6 address of the endpoint
+func (e *Endpoint) IPv6Address() addressing.CiliumIPv6 {
+	return e.IPv6
 }
 
 // GetNodeMAC returns the MAC address of the node from this endpoint's perspective.

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -846,6 +846,11 @@ func (e *Endpoint) GetOpLabels() []string {
 	return e.OpLabels.IdentityLabels().GetModel()
 }
 
+// GetOptions returns the datapath configuration options of the endpoint.
+func (e *Endpoint) GetOptions() *option.IntOptions {
+	return e.Options
+}
+
 // GetIPv4Address returns the IPv4 address of the endpoint
 func (e *Endpoint) GetIPv4Address() string {
 	return e.IPv4.String()

--- a/pkg/endpoint/owner.go
+++ b/pkg/endpoint/owner.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@ package endpoint
 
 import (
 	"github.com/cilium/cilium/pkg/completion"
+	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/lock"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
@@ -56,4 +57,7 @@ type Owner interface {
 
 	// SendNotification is called to emit an agent notification
 	SendNotification(typ monitorAPI.AgentNotification, text string) error
+
+	// Datapath returns a reference to the datapath implementation.
+	Datapath() datapath.Datapath
 }

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -553,3 +553,12 @@ func (e *Endpoint) SetIdentity(identity *identityPkg.Identity) {
 		logfields.Identity: identity.StringID(),
 	})
 }
+
+// GetCIDRPrefixLengths returns the sorted list of unique prefix lengths used
+// for CIDR policy or IPcache lookup from this endpoint.
+func (e *Endpoint) GetCIDRPrefixLengths() (s6, s4 []int) {
+	if e.desiredPolicy == nil || e.desiredPolicy.CIDRPolicy == nil {
+		return policy.GetDefaultPrefixLengths()
+	}
+	return e.desiredPolicy.CIDRPolicy.ToBPFData()
+}

--- a/pkg/maps/configmap/configmap.go
+++ b/pkg/maps/configmap/configmap.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -165,9 +165,9 @@ func (m *EndpointConfigMap) Update(value *EndpointConfig) error {
 // path with the specified name.
 // On success, it returns a map and whether the map was newly created, or
 // otherwise an error.
-func OpenMapWithName(path, name string) (*EndpointConfigMap, bool, error) {
+func OpenMapWithName(path string) (*EndpointConfigMap, bool, error) {
 
-	newMap := bpf.NewMap(name,
+	newMap := bpf.NewMap(path,
 		bpf.BPF_MAP_TYPE_ARRAY,
 		int(unsafe.Sizeof(uint32(0))),
 		int(unsafe.Sizeof(EndpointConfig{})),

--- a/pkg/option/runtime_options.go
+++ b/pkg/option/runtime_options.go
@@ -103,14 +103,4 @@ var (
 			return nil
 		},
 	}
-
-	IngressSpecPolicy = Option{
-		Define:      "POLICY_INGRESS",
-		Description: "Enable ingress policy enforcement",
-	}
-
-	EgressSpecPolicy = Option{
-		Define:      "POLICY_EGRESS",
-		Description: "Enable egress policy enforcement",
-	}
 )

--- a/test/bpf/unit-test.c
+++ b/test/bpf/unit-test.c
@@ -10,7 +10,6 @@
 #include "lib/common.h"
 #include "lib/ipv6.h"
 
-#define POLICY_EGRESS
 #define SKIP_UNDEF_LPM_LOOKUP_FN
 #include "lib/maps.h"
 


### PR DESCRIPTION
Commits are prepared for commit-by-commit review.

Refactor header datapath configuration to expose interfaces that take `io.Writer`, which should allow future commits to pass `Hash` objects in for hashing the datapath configuration options that are typically written to the files.

Write some unit tests for the header file writes too, to validate that if there's an io.Writer failure then it will be properly return by these new functions.

There's one or two minor extra endpoint-related refactors here too which I've split out from the main templating PR.

To do:
* [x] Decide whether to leave the bufio on the datapath side or daemon side
  * Bigger comment below, but leaving as-is for now.
* [x] Fix up MapPath() dependency in unit tests
* [x] Fix policy map runtime test
* [x] ~~Replace `HasIpvlanDataPath()` with `MustGraftDatapathMap()`~~
* [x] Fold in header write unit tests, fixes for those
* [x] Fold in `common/` BPF macro move commits
* [x] Rebase

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6722)
<!-- Reviewable:end -->
