### PR TITLE
fqdn: Monitor events fill in Endpoint data and use ipcache

### DIFF
--- a/daemon/fqdn.go
+++ b/daemon/fqdn.go
@@ -30,6 +30,8 @@ import (
 	"github.com/cilium/cilium/pkg/fqdn"
 	"github.com/cilium/cilium/pkg/fqdn/dnsproxy"
 	"github.com/cilium/cilium/pkg/fqdn/matchpattern"
+	secIDCache "github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/node"
@@ -186,7 +188,7 @@ func (d *Daemon) bootstrapFQDN(restoredEndpoints *endpointRestoreState) (err err
 			}
 
 			var serverPort int
-			_, serverPortStr, err := net.SplitHostPort(serverAddr)
+			serverIP, serverPortStr, err := net.SplitHostPort(serverAddr)
 			if err != nil {
 				log.WithError(err).Error("cannot extract endpoint IP from DNS request")
 			} else {
@@ -229,10 +231,43 @@ func (d *Daemon) bootstrapFQDN(restoredEndpoints *endpointRestoreState) (err err
 				func(lr *logger.LogRecord) { lr.LogRecord.TransportProtocol = accesslog.TransportProtocol(protoID) },
 				logger.LogTags.Verdict(verdict, reason),
 				logger.LogTags.Addressing(logger.AddressingInfo{
-					SrcIPPort:   srcAddr,
-					DstIPPort:   dstAddr,
-					SrcIdentity: 0, // 0 more correctly finds src and dst EP data
+					SrcIPPort:   epAddr,
+					DstIPPort:   serverAddr,
+					SrcIdentity: ep.GetIdentity().Uint32(),
 				}),
+				func(lr *logger.LogRecord) {
+					lr.LogRecord.SourceEndpoint = accesslog.EndpointInfo{
+						ID:           ep.GetID(),
+						IPv4:         ep.GetIPv4Address(),
+						IPv6:         ep.GetIPv6Address(),
+						Labels:       ep.GetLabels(),
+						LabelsSHA256: ep.GetLabelsSHA(),
+						Identity:     uint64(ep.GetIdentity()),
+					}
+
+					// When the server is an endpoint, get all the data for it.
+					// When external, use the ipcache to fill in the SecID
+					if serverEP := endpointmanager.LookupIPv4(serverIP); serverEP != nil {
+						lr.LogRecord.DestinationEndpoint = accesslog.EndpointInfo{
+							ID:           serverEP.GetID(),
+							IPv4:         serverEP.GetIPv4Address(),
+							IPv6:         serverEP.GetIPv6Address(),
+							Labels:       serverEP.GetLabels(),
+							LabelsSHA256: serverEP.GetLabelsSHA(),
+							Identity:     uint64(serverEP.GetIdentity()),
+						}
+					} else if serverSecID, exists := ipcache.IPIdentityCache.LookupByIP(serverIP); exists {
+						secID := secIDCache.LookupIdentityByID(serverSecID.ID)
+						// TODO: handle IPv6
+						lr.LogRecord.DestinationEndpoint = accesslog.EndpointInfo{
+							IPv4: serverIP,
+							// IPv6:         serverEP.GetIPv6Address(),
+							Labels:       secID.Labels.GetModel(),
+							LabelsSHA256: secID.GetLabelsSHA256(),
+							Identity:     uint64(serverSecID.ID.Uint32()),
+						}
+					}
+				},
 				logger.LogTags.DNS(&accesslog.LogRecordDNS{
 					Query:             qname,
 					IPs:               responseIPs,

--- a/daemon/fqdn.go
+++ b/daemon/fqdn.go
@@ -149,9 +149,9 @@ func (d *Daemon) bootstrapFQDN(restoredEndpoints *endpointRestoreState) (err err
 		// - Report the verdict in a monitor event and emit proxy metrics
 		// - Insert the DNS data into the cache when msg is a DNS response and we
 		//   can lookup the endpoint related to it
-		// srcAddr and dstAddr should match the packet reported on (i.e. the
-		// endpoint is srcAddr for requests, and dstAddr for responses).
-		func(lookupTime time.Time, srcAddr, dstAddr string, msg *dns.Msg, protocol string, allowed bool, stat dnsproxy.ProxyRequestContext) error {
+		// epAddr and serverAddr should match the original request, where epAddr is
+		// the source for egress (the only case current).
+		func(lookupTime time.Time, epAddr, serverAddr string, msg *dns.Msg, protocol string, allowed bool, stat dnsproxy.ProxyRequestContext) error {
 			var protoID = u8proto.ProtoIDs[strings.ToLower(protocol)]
 
 			var verdict accesslog.FlowVerdict
@@ -185,20 +185,6 @@ func (d *Daemon) bootstrapFQDN(restoredEndpoints *endpointRestoreState) (err err
 				reason = "Denied by policy"
 			}
 
-			var epAddr string     // the address of the endpoint that originated the request
-			var serverAddr string // the address of the DNS target
-			var ingress = msg.Response
-			var flowType accesslog.FlowType
-			if ingress {
-				flowType = accesslog.TypeResponse
-				epAddr = dstAddr
-				serverAddr = srcAddr
-			} else {
-				flowType = accesslog.TypeRequest
-				epAddr = srcAddr
-				serverAddr = dstAddr
-			}
-
 			var serverPort int
 			_, serverPortStr, err := net.SplitHostPort(serverAddr)
 			if err != nil {
@@ -213,7 +199,8 @@ func (d *Daemon) bootstrapFQDN(restoredEndpoints *endpointRestoreState) (err err
 			epIP, _, err := net.SplitHostPort(epAddr)
 			if err != nil {
 				log.WithError(err).Error("cannot extract endpoint IP from DNS request")
-				ep.UpdateProxyStatistics("dns", uint16(serverPort), ingress, !ingress, accesslog.VerdictError)
+				// We are always egress
+				ep.UpdateProxyStatistics("dns", uint16(serverPort), false, !msg.Response, accesslog.VerdictError)
 				endMetric()
 				return err
 			}
@@ -224,7 +211,7 @@ func (d *Daemon) bootstrapFQDN(restoredEndpoints *endpointRestoreState) (err err
 				// cache if we don't know that an endpoint asked for it (this is
 				// asserted via ep != nil here and msg.Response && msg.Rcode ==
 				// dns.RcodeSuccess below).
-				err := fmt.Errorf("Cannot find matching endpoint for IPs %s or %s", srcAddr, dstAddr)
+				err := fmt.Errorf("Cannot find matching endpoint for IP %s", epAddr)
 				log.WithError(err).Error("cannot find matching endpoint")
 				endMetric()
 				return err
@@ -236,8 +223,9 @@ func (d *Daemon) bootstrapFQDN(restoredEndpoints *endpointRestoreState) (err err
 				log.WithError(err).Error("cannot extract DNS message details")
 			}
 
-			ep.UpdateProxyStatistics("dns", uint16(serverPort), ingress, !ingress, verdict)
-			record := logger.NewLogRecord(proxy.DefaultEndpointInfoRegistry, ep, flowType, ingress,
+			// We are always egress
+			ep.UpdateProxyStatistics("dns", uint16(serverPort), false, !msg.Response, verdict)
+			record := logger.NewLogRecord(proxy.DefaultEndpointInfoRegistry, ep, accesslog.TypeRequest, false,
 				func(lr *logger.LogRecord) { lr.LogRecord.TransportProtocol = accesslog.TransportProtocol(protoID) },
 				logger.LogTags.Verdict(verdict, reason),
 				logger.LogTags.Addressing(logger.AddressingInfo{

--- a/pkg/monitor/logrecord.go
+++ b/pkg/monitor/logrecord.go
@@ -60,11 +60,21 @@ func (l *LogRecordNotify) l7Proto() string {
 
 // DumpInfo dumps an access log notification
 func (l *LogRecordNotify) DumpInfo() {
-	fmt.Printf("%s %s %s from %d (%s) to %d (%s), identity %d->%d, verdict %s",
-		l.direction(), l.Type, l.l7Proto(), l.SourceEndpoint.ID, l.SourceEndpoint.Labels,
-		l.DestinationEndpoint.ID, l.DestinationEndpoint.Labels,
-		l.SourceEndpoint.Identity, l.DestinationEndpoint.Identity,
-		l.Verdict)
+	switch l.Type {
+	case accesslog.TypeRequest:
+		fmt.Printf("%s %s %s from %d (%s) to %d (%s), identity %d->%d, verdict %s",
+			l.direction(), l.Type, l.l7Proto(), l.SourceEndpoint.ID, l.SourceEndpoint.Labels,
+			l.DestinationEndpoint.ID, l.DestinationEndpoint.Labels,
+			l.SourceEndpoint.Identity, l.DestinationEndpoint.Identity,
+			l.Verdict)
+
+	case accesslog.TypeResponse:
+		fmt.Printf("%s %s %s to %d (%s) from %d (%s), identity %d->%d, verdict %s",
+			l.direction(), l.Type, l.l7Proto(), l.SourceEndpoint.ID, l.SourceEndpoint.Labels,
+			l.DestinationEndpoint.ID, l.DestinationEndpoint.Labels,
+			l.SourceEndpoint.Identity, l.DestinationEndpoint.Identity,
+			l.Verdict)
+	}
 
 	if http := l.HTTP; http != nil {
 		url := ""


### PR DESCRIPTION
Perhaps this will work better, perhaps not!
The utility functions in `pkg/logger` and `pkg/accesslog` didn't seem to work well when we forced the source/destination IPs in the response event to be like the request (i.e. the source endpoint is always the source IP). This might be related to a bunch of conditionals around `ingress==true` and `ObservationPoint`. Furthermore, we use the ipcache to set some identities but we reported 0 (world) for those instead.
The code now:
- Sets the src/dst info unconditionally from the data we already have
- Falls back on the ipcache to get a dst SecID when we don't have the info (so when it is a non-endpoint).
- The human-readable monitor printout is now also human-understandable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6724)
<!-- Reviewable:end -->
