### PR TITLE
proxylib: Add SONAME, create .so* files and symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.o
 *.a
 *.so
+*.so.*
 
 # LLVM IR files
 *.ll

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -14,6 +14,7 @@ endif
 INSTALL = $(QUIET)install
 
 VERSION = $(shell cat $(dir $(lastword $(MAKEFILE_LIST)))/VERSION)
+VERSION_MAJOR = $(shell cat $(dir $(lastword $(MAKEFILE_LIST)))/VERSION | cut -d. -f1)
 # Use git only if in a Git repo
 ifneq ($(wildcard $(dir $(lastword $(MAKEFILE_LIST)))/.git),)
 	GIT_VERSION = $(shell git show -s --format='format:%h %aI')

--- a/proxylib/Makefile
+++ b/proxylib/Makefile
@@ -1,11 +1,15 @@
 include ../Makefile.quiet
 include ../Makefile.defs
 
+PROXYLIB_GOLDFLAGS=$(GOLDFLAGS) -extldflags -Wl,-soname,libcilium.so.$(VERSION_MAJOR)
+PROXYLIB_GOBUILD=-ldflags '$(PROXYLIB_GOLDFLAGS)'
+
 TARGET=libcilium.so
 DEPS := $(shell find ../pkg accesslog npds test . \( -name '*.go' ! -name '*_test.go' \))
 $(TARGET): $(DEPS)
 	@$(ECHO_GO)
-	$(QUIET)$(GO) build $(GOBUILD) -o $@ -buildmode=c-shared
+	$(QUIET)$(GO) build $(PROXYLIB_GOBUILD) -o $@.$(VERSION_MAJOR) -buildmode=c-shared
+	$(QUIET)ln -sf $@.$(VERSION_MAJOR) $@
 
 all: $(TARGET)
 
@@ -16,4 +20,5 @@ clean:
 
 install:
 	$(INSTALL) -m 0755 -d $(DESTDIR)$(LIBDIR)
-	$(INSTALL) -m 0755 $(TARGET) $(DESTDIR)$(LIBDIR)
+	$(INSTALL) -m 0755 $(TARGET).$(VERSION_MAJOR) $(DESTDIR)$(LIBDIR)
+	ln -sf $(TARGET).$(VERSION_MAJOR) $(DESTDIR)$(LIBDIR)/$(TARGET)


### PR DESCRIPTION
The common pattern in the most of Linux distributions is to have SONAME
field in shared object files and to keep the library version as its
suffix. The name of shared object file should be the same as SONAME and
.so file without suffix should be a symlink to the versioned file.

In this case, SONAME contains only the major version as a suffix, which
is acceptable by the most of projects and Linux distributions.

After this change, executing `make` and `make install` produces the
following results:

```
$ make
[...]
$ ls -la proxylib/ | grep libcilium.so
lrwxrwxrwx  1 mrostecki users       14 Jan 23 14:04 libcilium.so -> libcilium.so.1
-rw-r--r--  1 mrostecki users 21362336 Jan 23 14:04 libcilium.so.1
$ readelf -a proxylib/libcilium.so | grep SONAME
 0x000000000000000e (SONAME)             Library soname: [libcilium.so.1]
$ make install PREFIX=~/.local LIBDIR=~/.local/lib64
[...]
$ ls -la ~/.local/lib64/
total 20988
drwxr-xr-x 3 mrostecki users      188 Jan 23 14:57 .
drwx------ 9 mrostecki users       91 Jan 23 14:40 ..
lrwxrwxrwx 1 mrostecki users       14 Jan 23 14:57 libcilium.so -> libcilium.so.1
-rwxr-xr-x 1 mrostecki users 21362336 Jan 23 14:57 libcilium.so.1
```

Signed-off-by: Michal Rostecki <mrostecki@suse.de>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6725)
<!-- Reviewable:end -->
