### PR TITLE
endpoint: fix logic to finalize proxy state in dry mode

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -542,7 +542,7 @@ func (e *Endpoint) regenerateBPF(owner Owner, regenContext *regenerationContext)
 	// reverted, and execute it in case of regeneration success.
 	defer func() {
 		// Ignore finalizing of proxy state in dry mode.
-		if option.Config.DryMode {
+		if !option.Config.DryMode {
 			e.finalizeProxyState(regenContext, reterr)
 		}
 	}()


### PR DESCRIPTION
The logic was inverted for checking whether proxy state should be finalized
or not.

Fixes: 4045887122c11827977956abda8c7c28684538f8

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6732)
<!-- Reviewable:end -->
