### PR TITLE
iptables: Do not remove & re-create all iptables on startup

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -534,13 +534,9 @@ func (d *Daemon) compileBase() error {
 		return err
 	}
 
-	if option.Config.EnableIPv4 {
-		// Always remove masquerade rule and then re-add it if required
-		iptables.RemoveRules()
-		if option.Config.InstallIptRules {
-			if err := iptables.InstallRules(d.datapath.LocalNodeAddressing(), option.Config.HostDevice); err != nil {
-				return err
-			}
+	if option.Config.EnableIPv4 && option.Config.InstallIptRules {
+		if err := iptables.ReplaceRules(d.datapath.LocalNodeAddressing(), option.Config.HostDevice); err != nil {
+			return err
 		}
 	}
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -538,7 +538,7 @@ func (d *Daemon) compileBase() error {
 		// Always remove masquerade rule and then re-add it if required
 		iptables.RemoveRules()
 		if option.Config.InstallIptRules {
-			if err := iptables.InstallRules(option.Config.HostDevice); err != nil {
+			if err := iptables.InstallRules(d.datapath.LocalNodeAddressing(), option.Config.HostDevice); err != nil {
 				return err
 			}
 		}

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -18,207 +18,343 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/cilium/cilium/pkg/command/exec"
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/defaults"
-	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/proxy"
 
 	"github.com/mattn/go-shellwords"
+	"github.com/sirupsen/logrus"
 )
 
 const (
-	ciliumOutputChain     = "CILIUM_OUTPUT"
-	ciliumPostNatChain    = "CILIUM_POST"
-	ciliumPostMangleChain = "CILIUM_POST_mangle"
-	ciliumForwardChain    = "CILIUM_FORWARD"
-	feederDescription     = "cilium-feeder:"
+	tableNat    tableName = "nat"
+	tableMangle tableName = "mangle"
+	tableRaw    tableName = "raw"
+	tableFilter tableName = "filter"
 )
 
-type customChain struct {
-	name       string
-	table      string
-	hook       string
-	feederArgs []string
-}
+var (
+	tables = []tableName{tableNat, tableMangle, tableRaw, tableFilter}
+)
+
+// custom chain names
+const (
+	ciliumOutputChain     chainName = "CILIUM_OUTPUT"
+	ciliumPostNatChain    chainName = "CILIUM_POST"
+	ciliumPostMangleChain chainName = "CILIUM_POST_mangle"
+	ciliumForwardChain    chainName = "CILIUM_FORWARD"
+)
 
 func runProg(prog string, args []string, quiet bool) error {
+	log.Debugf("Executing %s %s", prog, strings.Join(args, " "))
 	_, err := exec.WithTimeout(defaults.ExecTimeout, prog, args...).CombinedOutput(log, !quiet)
+	if err != nil {
+		log.WithError(err).Warningf("Error while executing %s %sv", prog, strings.Join(args, " "))
+	}
 	return err
 }
 
-func getFeedRule(name, args string) []string {
-	ruleTail := []string{"-m", "comment", "--comment", feederDescription + " " + name, "-j", name}
-	if args == "" {
-		return ruleTail
-	}
-	argsList, err := shellwords.Parse(args)
-	if err != nil {
-		log.WithError(err).WithField(logfields.Object, args).Fatal("Unable to parse rule into argument slice")
-	}
-	return append(argsList, ruleTail...)
+func getFeedRule(name chainName) []string {
+	return []string{"-m", "comment", "--comment", "cilium-feeder: " + string(name), "-j", string(name)}
 }
 
-func (c *customChain) add() error {
-	return runProg("iptables", []string{"-t", c.table, "-N", c.name}, false)
+// rule is an iptables rule minus the table and chain name
+type rule []string
+
+// Equal returns true if two rules are identical
+//
+// NOTE: The rule must be described in the same way as `iptables-save` prints it
+func (r rule) Equal(o rule) bool {
+	return reflect.DeepEqual(r, o)
 }
 
-func reverseRule(rule string) ([]string, error) {
-	if strings.HasPrefix(rule, "-A") {
-		// From: -A POSTROUTING -m comment [...]
-		// To:   -D POSTROUTING -m comment [...]
-		return shellwords.Parse(strings.Replace(rule, "-A", "-D", 1))
+// rules is a list of rules
+type rules []rule
+
+type chainName string
+
+// chains is a map of chains with given rules, indexed by chain name
+type chains map[chainName]rules
+
+// add adds a rule to a given chain
+func (c chains) add(chain chainName, rule rule) {
+	if _, ok := c[chain]; !ok {
+		c[chain] = rules{}
 	}
 
-	if strings.HasPrefix(rule, "-I") {
-		// From: -I POSTROUTING -m comment [...]
-		// To:   -D POSTROUTING -m comment [...]
-		return shellwords.Parse(strings.Replace(rule, "-I", "-D", 1))
-	}
-
-	return []string{}, nil
+	c[chain] = append(c[chain], rule)
 }
 
-func removeCiliumRules(table string) {
+// equalChain returns true if the chain references by name has identical rules
+// as the rules provided
+func (c chains) equalChain(chain chainName, rules rules) bool {
+	if _, ok := c[chain]; !ok {
+		return false
+	}
+
+	return reflect.DeepEqual(c[chain], rules)
+}
+
+type tableName string
+
+//ruleSet is a set of chains with rules indexed by table name
+type ruleSet map[tableName]chains
+
+func newRuleSet() ruleSet {
+	return ruleSet{}
+}
+
+// add adds a rule to a chain in a given table
+func (r ruleSet) add(table tableName, chain chainName, rule rule) {
+	if _, ok := r[table]; !ok {
+		r[table] = chains{}
+	}
+
+	r[table].add(chain, rule)
+}
+
+// removeChain removes an entire chain from a ruleset
+func (r ruleSet) removeChain(table tableName, chain chainName) bool {
+	if _, ok := r[table]; ok {
+		if _, ok := r[table][chain]; ok {
+			delete(r[table], chain)
+			if len(r[table]) == 0 {
+				delete(r, table)
+			}
+			return true
+		}
+	}
+
+	return false
+}
+
+// replaceChain replaces a chain with an entire set of rules
+func (r ruleSet) replaceChain(table tableName, chain chainName, rules rules) {
+	if _, ok := r[table]; !ok {
+		r[table] = chains{}
+	}
+
+	r[table][chain] = rules
+}
+
+// equalChain returns true if the rules for a given chain in a table are
+// identical
+func (r ruleSet) equalChain(table tableName, chain chainName, rules rules) bool {
+	if _, ok := r[table]; !ok {
+		return false
+	}
+
+	return r[table].equalChain(chain, rules)
+}
+
+// diff generates the difference between an old an new rule set and returns all
+// chains that were removed and lists all chains that have at least one
+// modification. The rules reported in the modified ruleset are *all* rules as
+// per new ruleset, not exclusively the changed rules
+func (r ruleSet) diff(o ruleSet) (removed ruleSet, modified ruleSet) {
+	removed = newRuleSet()
+	modified = newRuleSet()
+
+	for table, chains := range r {
+		for chain, rules := range chains {
+			for _, rule := range rules {
+				removed.add(table, chain, rule)
+			}
+		}
+	}
+
+	for table, chains := range o {
+		for chain, rules := range chains {
+			removed.removeChain(table, chain)
+			if !r.equalChain(table, chain, rules) {
+				modified.replaceChain(table, chain, rules)
+			}
+		}
+	}
+
+	return
+}
+
+// listCiliumRules creates a ruleset of all currently install Cilium rules
+func listCiliumRules() (ruleset ruleSet, err error) {
+	ruleset = newRuleSet()
+	for _, t := range tables {
+		ruleset[t], err = listCiliumTableRules(t)
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+func listCiliumTableRules(table tableName) (chains, error) {
+	c := chains{}
+
 	prog := "iptables"
-	args := []string{"-t", table, "-S"}
+	args := []string{"-t", string(table), "-S"}
 
 	out, err := exec.WithTimeout(defaults.ExecTimeout, prog, args...).CombinedOutput(log, true)
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	scanner := bufio.NewScanner(bytes.NewReader(out))
 	for scanner.Scan() {
 		rule := scanner.Text()
-		log.WithField(logfields.Object, logfields.Repr(rule)).Debug("Considering removing iptables rule")
 
 		// All rules installed by cilium either belong to a chain with
 		// the name CILIUM_ or call a chain with the name CILIUM_:
 		// -A CILIUM_FORWARD -o cilium_host -m comment --comment "cilium: any->cluster on cilium_host forward accept" -j ACCEPT
-		// -A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST" -j CILIUM_POST
 		if strings.Contains(rule, "CILIUM_") {
-			reversedRule, err := reverseRule(rule)
+			argsList, err := shellwords.Parse(rule)
 			if err != nil {
-				log.WithError(err).WithField(logfields.Object, rule).Warn("Unable to parse iptables rule into slice. Leaving rule behind.")
+				return nil, err
+			}
+
+			if len(argsList) < 3 {
 				continue
 			}
 
-			if len(reversedRule) > 0 {
-				deleteRule := append([]string{"-t", table}, reversedRule...)
-				log.WithField(logfields.Object, logfields.Repr(deleteRule)).Debug("Removing iptables rule")
-				err = runProg("iptables", deleteRule, true)
-				if err != nil {
-					log.WithError(err).WithField(logfields.Object, rule).Warn("Unable to delete Cilium iptables rule")
-				}
+			if argsList[0] != "-I" && argsList[0] != "-A" {
+				continue
 			}
+
+			// ignore the feeder rules
+			if strings.Contains(rule, "-j CILIUM_") {
+				continue
+			}
+
+			c.add(chainName(argsList[1]), argsList[2:])
 		}
 	}
+
+	return c, nil
 }
 
-func (c *customChain) remove() {
-	runProg("iptables", []string{
-		"-t", c.table,
-		"-F", c.name}, true)
+func removeCustomChain(table tableName, chain chainName) {
+	tablePart := []string{}
+	if table != tableFilter {
+		tablePart = []string{"-t", string(table)}
+	}
 
-	runProg("iptables", []string{
-		"-t", c.table,
-		"-X", c.name}, true)
+	if hook, ok := hookMapping[chain]; ok {
+		prefix := append(tablePart, []string{"-D", hook}...)
+		runProg("iptables", append(prefix, getFeedRule(chain)...), false)
+	} else {
+		log.WithFields(logrus.Fields{"table": table, "chain": chain}).Error("Unable to map custom chain to hook")
+	}
+
+	runProg("iptables", append(tablePart, []string{"-F", string(chain)}...), true)
+	runProg("iptables", append(tablePart, []string{"-X", string(chain)}...), true)
 }
 
-func (c *customChain) installFeeder() error {
+var hookMapping = map[chainName]string{
+	ciliumOutputChain:     "OUTPUT",
+	ciliumPostNatChain:    "POSTROUTING",
+	ciliumPostMangleChain: "POSTROUTING",
+	ciliumForwardChain:    "FORWARD",
+}
+
+// ReplaceRules installs iptables rules for Cilium in specific use-cases
+// (most specifically, interaction with kube-proxy).
+func ReplaceRules(nodeAddressing datapath.NodeAddressing, ifName string) error {
+	existingRules, err := listCiliumRules()
+	if err != nil {
+		return err
+	}
+
+	for table, chains := range existingRules {
+		for chain, rules := range chains {
+			log.WithFields(logrus.Fields{"table": table, "chain": chain}).Debugf("Existing iptables rule: %#v", rules)
+		}
+	}
+
 	installMode := "-A"
 	if option.Config.PrependIptablesChains {
 		installMode = "-I"
 	}
 
-	for _, feedArgs := range c.feederArgs {
-		err := runProg("iptables", append([]string{"-t", c.table, installMode, c.hook}, getFeedRule(c.name, feedArgs)...), true)
-		if err != nil {
-			return err
+	newRuleSet := generateRules(nodeAddressing, ifName)
+	for table, chains := range newRuleSet {
+		for chain, rules := range chains {
+			log.WithFields(logrus.Fields{"table": table, "chain": chain}).Debugf("New iptables rule: %#v", rules)
 		}
 	}
+
+	removed, modified := existingRules.diff(newRuleSet)
+
+	for table, chains := range modified {
+		for chain, rules := range chains {
+			log.WithFields(logrus.Fields{"table": table, "chain": chain}).Info("Detected changes in chain, re-recreating...")
+
+			removeCustomChain(table, chain)
+
+			tablePart := []string{}
+			if table != tableFilter {
+				tablePart = []string{"-t", string(table)}
+			}
+
+			runProg("iptables", append(tablePart, []string{"-N", string(chain)}...), false)
+
+			for _, rule := range rules {
+				prefix := append(tablePart, []string{"-A", string(chain)}...)
+				runProg("iptables", append(prefix, rule...), false)
+			}
+
+			if hook, ok := hookMapping[chain]; ok {
+				prefix := append(tablePart, []string{installMode, hook}...)
+				runProg("iptables", append(prefix, getFeedRule(chain)...), false)
+			} else {
+				log.WithFields(logrus.Fields{"table": table, "chain": chain}).Error("Unable to map custom chain to hook")
+			}
+		}
+	}
+
+	// remove chains that are no longer needed
+	for table, chains := range removed {
+		for chain := range chains {
+			log.WithFields(logrus.Fields{"table": table, "chain": chain}).Info("Removing unused iptables chain")
+			removeCustomChain(table, chain)
+		}
+	}
+
 	return nil
 }
 
-// ciliumChains is the list of custom iptables chain used by Cilium. Custom
-// chains are used to allow for simple replacements of all rules.
+// generateRules generates the entire Cilium ruleset
 //
-// WARNING: If you change or remove any of the feeder rules you have to ensure
-// that the old feeder rules is also removed on agent start, otherwise,
-// flushing and removing the custom chains will fail.
-var ciliumChains = []customChain{
-	{
-		name:       ciliumOutputChain,
-		table:      "filter",
-		hook:       "OUTPUT",
-		feederArgs: []string{""},
-	},
-	{
-		name:       ciliumPostNatChain,
-		table:      "nat",
-		hook:       "POSTROUTING",
-		feederArgs: []string{""},
-	},
-	{
-		name:       ciliumPostMangleChain,
-		table:      "mangle",
-		hook:       "POSTROUTING",
-		feederArgs: []string{""},
-	},
-	{
-		name:       ciliumForwardChain,
-		table:      "filter",
-		hook:       "FORWARD",
-		feederArgs: []string{""},
-	},
-}
-
-// RemoveRules removes iptables rules installed by Cilium.
-func RemoveRules() {
-	tables := []string{"nat", "mangle", "raw", "filter"}
-	for _, t := range tables {
-		removeCiliumRules(t)
-	}
-
-	for _, c := range ciliumChains {
-		c.remove()
-	}
-}
-
-// InstallRules installs iptables rules for Cilium in specific use-cases
-// (most specifically, interaction with kube-proxy).
-func InstallRules(nodeAddressing datapath.NodeAddressing, ifName string) error {
-	for _, c := range ciliumChains {
-		if err := c.add(); err != nil {
-			return fmt.Errorf("cannot add custom chain %s: %s", c.name, err)
-		}
-	}
-
-	matchFromIPSecEncrypt := fmt.Sprintf("%#08x/%#08x", linux_defaults.RouteMarkDecrypt, linux_defaults.RouteMarkMask)
-	matchFromIPSecDecrypt := fmt.Sprintf("%#08x/%#08x", linux_defaults.RouteMarkEncrypt, linux_defaults.RouteMarkMask)
+// WARNING: All rules specified in the function must be specified in the same
+// way as `iptables-save` emits them again to ensure that rule changes can be
+// detected properly. To verify this, run the agent in debug mode with the new
+// rules applied and then restart the agent again. Check for the message:
+// "Detected changes in chain, re-recreating...". If it appears enable
+// debugging mode and compare the "Existing iptables rule: [...]" message with
+// the "New iptables rule: [...] message to identify what is missing.
+//
+func generateRules(nodeAddressing datapath.NodeAddressing, ifName string) ruleSet {
+	rules := newRuleSet()
+	matchFromIPSecEncrypt := fmt.Sprintf("%#x/%#x", linux_defaults.RouteMarkDecrypt, linux_defaults.RouteMarkMask)
+	matchFromIPSecDecrypt := fmt.Sprintf("%#x/%#x", linux_defaults.RouteMarkEncrypt, linux_defaults.RouteMarkMask)
 
 	// Clear the Kubernetes masquerading mark bit to skip source PAT
 	// performed by kube-proxy for all packets destined for Cilium. Cilium
 	// installs a dedicated rule which does the source PAT to the right
 	// source IP.
-	clearMasqBit := fmt.Sprintf("%#08x/%#08x", 0, proxy.MagicMarkK8sMasq)
-	if err := runProg("iptables", []string{
-		"-t", "mangle",
-		"-A", ciliumPostMangleChain,
+	clearMasqBit := fmt.Sprintf("%#x/%#x", 0, proxy.MagicMarkK8sMasq)
+	rules.add(tableMangle, ciliumPostMangleChain, []string{
+		"!", "-s", "127.0.0.1/32",
 		"-o", ifName,
 		"-m", "mark", "!", "--mark", matchFromIPSecDecrypt, // Don't match ipsec traffic
 		"-m", "mark", "!", "--mark", matchFromIPSecEncrypt, // Don't match ipsec traffic
-		"!", "-s", "127.0.0.1",
 		"-m", "comment", "--comment", "cilium: clear masq bit for pkts to " + ifName,
-		"-j", "MARK", "--set-xmark", clearMasqBit}, false); err != nil {
-		return err
-	}
+		"-j", "MARK", "--set-xmark", clearMasqBit})
 
 	// kube-proxy does not change the default policy of the FORWARD chain
 	// which means that while packets to services are properly DNAT'ed,
@@ -230,24 +366,18 @@ func InstallRules(nodeAddressing datapath.NodeAddressing, ifName string) error {
 	// It is safe to ignore the destination IP here as the pre-requisite
 	// for a packet being routed to ifName is that a route exists
 	// which is only installed for known node IP CIDR ranges.
-	if err := runProg("iptables", []string{
-		"-A", ciliumForwardChain,
+	rules.add(tableFilter, ciliumForwardChain, []string{
 		"-o", ifName,
 		"-m", "comment", "--comment", "cilium: any->cluster on " + ifName + " forward accept",
-		"-j", "ACCEPT"}, false); err != nil {
-		return err
-	}
+		"-j", "ACCEPT"})
 
 	// Accept all packets in the FORWARD chain that are coming from the
 	// ifName interface with a source IP in the local node
 	// allocation range.
-	if err := runProg("iptables", []string{
-		"-A", ciliumForwardChain,
+	rules.add(tableFilter, ciliumForwardChain, []string{
 		"-s", nodeAddressing.IPv4().AllocationCIDR().String(),
 		"-m", "comment", "--comment", "cilium: cluster->any forward accept",
-		"-j", "ACCEPT"}, false); err != nil {
-		return err
-	}
+		"-j", "ACCEPT"})
 
 	// Mark all packets sourced from processes running on the host with a
 	// special marker so that we can differentiate traffic sourced locally
@@ -265,21 +395,17 @@ func InstallRules(nodeAddressing datapath.NodeAddressing, ifName string) error {
 	// mark, then when the service implementation proxies it back into
 	// Cilium the BPF will see this mark and understand that the packet
 	// originated from the host.
-	matchFromProxy := fmt.Sprintf("%#08x/%#08x", proxy.MagicMarkIsProxy, proxy.MagicMarkProxyMask)
-	markAsFromHost := fmt.Sprintf("%#08x/%#08x", proxy.MagicMarkHost, proxy.MagicMarkHostMask)
-	if err := runProg("iptables", []string{
-		"-t", "filter",
-		"-A", ciliumOutputChain,
+	matchFromProxy := fmt.Sprintf("%#x/%#x", proxy.MagicMarkIsProxy, proxy.MagicMarkProxyMask)
+	markAsFromHost := fmt.Sprintf("%#x/%#x", proxy.MagicMarkHost, proxy.MagicMarkHostMask)
+	rules.add(tableFilter, ciliumOutputChain, []string{
 		"-m", "mark", "!", "--mark", matchFromIPSecDecrypt, // Don't match ipsec traffic
 		"-m", "mark", "!", "--mark", matchFromIPSecEncrypt, // Don't match ipsec traffic
 		"-m", "mark", "!", "--mark", matchFromProxy, // Don't match proxy traffic
 		"-m", "comment", "--comment", "cilium: host->any mark as from host",
-		"-j", "MARK", "--set-xmark", markAsFromHost}, false); err != nil {
-		return err
-	}
+		"-j", "MARK", "--set-xmark", markAsFromHost})
 
 	if option.Config.Masquerade {
-		ingressSnatSrcAddrExclusion := node.GetHostMasqueradeIPv4().String()
+		ingressSnatSrcAddrExclusion := node.GetHostMasqueradeIPv4().String() + "/32"
 		if option.Config.Tunnel == option.TunnelDisabled {
 			ingressSnatSrcAddrExclusion = node.GetIPv4ClusterRange().String()
 		}
@@ -294,34 +420,25 @@ func InstallRules(nodeAddressing datapath.NodeAddressing, ifName string) error {
 		//   * May not already be originating from the masquerade IP
 		// * Non-tunnel mode:
 		//   * May not orignate from any IP inside of the cluster range
-		if err := runProg("iptables", []string{
-			"-t", "nat",
-			"-A", ciliumPostNatChain,
+		rules.add(tableNat, ciliumPostNatChain, []string{
 			"!", "-s", ingressSnatSrcAddrExclusion,
-			"!", "-d", node.GetIPv4AllocRange().String(),
 			"!", "-d", nodeAddressing.IPv4().AllocationCIDR().String(),
+			"-o", ifName,
 			"-m", "mark", "!", "--mark", matchFromIPSecDecrypt, // Don't match ipsec traffic
 			"-m", "mark", "!", "--mark", matchFromIPSecEncrypt, // Don't match ipsec traffic
-			"-o", ifName,
 			"-m", "comment", "--comment", "cilium host->cluster masquerade",
-			"-j", "SNAT", "--to-source", node.GetHostMasqueradeIPv4().String()}, false); err != nil {
-			return err
-		}
+			"-j", "SNAT", "--to-source", node.GetHostMasqueradeIPv4().String()})
 
 		// Masquerade all traffic from a local endpoint that is routed
 		// back to an endpoint on the same node. This happens if a
 		// local endpoint talks to a Kubernetes NodePort or HostPort.
-		if err := runProg("iptables", []string{
-			"-t", "nat",
-			"-A", ciliumPostNatChain,
+		rules.add(tableNat, ciliumPostNatChain, []string{
 			"-s", nodeAddressing.IPv4().AllocationCIDR().String(),
+			"-o", ifName,
 			"-m", "mark", "!", "--mark", matchFromIPSecDecrypt, // Don't match ipsec traffic
 			"-m", "mark", "!", "--mark", matchFromIPSecEncrypt, // Don't match ipsec traffic
-			"-o", ifName,
 			"-m", "comment", "--comment", "cilium hostport loopback masquerade",
-			"-j", "SNAT", "--to-source", node.GetHostMasqueradeIPv4().String()}, false); err != nil {
-			return err
-		}
+			"-j", "SNAT", "--to-source", node.GetHostMasqueradeIPv4().String()})
 
 		egressSnatDstAddrExclusion := nodeAddressing.IPv4().AllocationCIDR().String()
 		if option.Config.Tunnel == option.TunnelDisabled {
@@ -339,23 +456,13 @@ func InstallRules(nodeAddressing datapath.NodeAddressing, ifName string) error {
 		//     range
 		// * Non-tunnel mode:
 		//   * May not be targeted to an IP in the cluster range
-		if err := runProg("iptables", []string{
-			"-t", "nat",
-			"-A", "CILIUM_POST",
+		rules.add(tableNat, ciliumPostNatChain, []string{
 			"-s", nodeAddressing.IPv4().AllocationCIDR().String(),
 			"!", "-d", egressSnatDstAddrExclusion,
 			"!", "-o", "cilium_+",
 			"-m", "comment", "--comment", "cilium masquerade non-cluster",
-			"-j", "MASQUERADE"}, false); err != nil {
-			return err
-		}
+			"-j", "MASQUERADE"})
 	}
 
-	for _, c := range ciliumChains {
-		if err := c.installFeeder(); err != nil {
-			return fmt.Errorf("cannot install feeder rule %s: %s", c.feederArgs, err)
-		}
-	}
-
-	return nil
+	return rules
 }

--- a/pkg/datapath/iptables/iptables_test.go
+++ b/pkg/datapath/iptables/iptables_test.go
@@ -1,0 +1,58 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package iptables
+
+import (
+	"testing"
+
+	"github.com/cilium/cilium/pkg/checker"
+
+	"gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	check.TestingT(t)
+}
+
+type iptablesTestSuite struct{}
+
+var _ = check.Suite(&iptablesTestSuite{})
+
+func (s *iptablesTestSuite) TestRulesetDiff(c *check.C) {
+	r1 := rule{"foo", "bar"}
+	r2 := rule{"foo2", "bar2"}
+	r3 := rule{"foo3", "bar3"}
+
+	a := newRuleSet()
+	a.add(tableNat, ciliumOutputChain, r1)
+	a.add(tableNat, ciliumOutputChain, r2)
+	a.add(tableFilter, ciliumOutputChain, r1)
+
+	b := newRuleSet()
+	b.add(tableNat, ciliumOutputChain, r1)
+	b.add(tableNat, ciliumOutputChain, r2)
+
+	removed, modified := a.diff(b)
+	c.Assert(len(removed), check.Equals, 1)
+	c.Assert(len(modified), check.Equals, 0)
+
+	b.add(tableNat, ciliumOutputChain, r3)
+	removed, modified = a.diff(b)
+	c.Assert(len(removed), check.Equals, 1)
+	c.Assert(len(modified), check.Equals, 1)
+	c.Assert(modified[tableNat][ciliumOutputChain], checker.DeepEquals, rules{r1, r2, r3})
+}


### PR DESCRIPTION
The current brute-force approach can cause disruption on startup. Instead of removing and re-creating all rules, calculate the difference between the old and new ruleset and only flush and re-create the chain if changes were detected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6735)
<!-- Reviewable:end -->
