### PR TITLE
DNSCache: TTL cleanup implementation.

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -102,6 +102,7 @@ cilium-agent [flags]
       --tofqdns-dns-reject-response-code string     DNS response code for rejecting DNS requests, available options are '[nameError refused]' (default "refused")
       --tofqdns-enable-poller                       Enable proactive polling of DNS names in toFQDNs.matchName rules.
       --tofqdns-enable-poller-events                Emit DNS responses seen by the DNS poller as Monitor events, if the poller is enabled. (default true)
+      --tofqdns-endpoint-max-ip-per-hostname int    Maximum number of IPs to maintain per FQDN name for each endpoint (default 50)
       --tofqdns-min-ttl int                         The minimum time, in seconds, to use DNS data for toFQDNs policies. (default 3600 when --tofqdns-enable-poller, 604800 otherwise)
       --tofqdns-proxy-port int                      Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port.
       --trace-payloadlen int                        Length of payload to capture when tracing (default 128)

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -667,6 +667,9 @@ func init() {
 	flags.StringVar(&option.Config.FQDNRejectResponse, option.FQDNRejectResponseCode, option.FQDNProxyDenyWithRefused, fmt.Sprintf("DNS response code for rejecting DNS requests, available options are '%v'", option.FQDNRejectOptions))
 	option.BindEnv(option.FQDNRejectResponseCode)
 
+	flags.Int(option.ToFQDNsMaxIPsPerHost, defaults.ToFQDNsMaxIPsPerHost, "Maximum number of IPs to maintain per FQDN name for each endpoint")
+	option.BindEnv(option.ToFQDNsMaxIPsPerHost)
+
 	viper.BindPFlags(flags)
 }
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -94,6 +94,10 @@ const (
 	// This or ToFQDNsMinTTL is used in DaemonConfig.Populate
 	ToFQDNsMinTTLPoller = 3600 // 1 hour in seconds
 
+	// ToFQDNsMaxIPsPerHost defines the maximum number of IPs to maintain
+	// for each FQDN name in an endpoint's FQDN cache
+	ToFQDNsMaxIPsPerHost = 50
+
 	// IdentityChangeGracePeriod is the grace period that needs to pass
 	// before an endpoint that has changed its identity will start using
 	// that new identity. During the grace period, the new identity has

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -415,7 +415,7 @@ func NewEndpointWithState(ID uint16, state string) *Endpoint {
 		Options:       option.NewIntOptions(&EndpointMutableOptionLibrary),
 		OpLabels:      pkgLabels.NewOpLabels(),
 		Status:        NewEndpointStatus(),
-		DNSHistory:    fqdn.NewDNSCache(),
+		DNSHistory:    fqdn.NewDNSCacheWithLimit(option.Config.ToFQDNsMaxIPsPerHost),
 		state:         state,
 		hasBPFProgram: make(chan struct{}, 0),
 		controllers:   controller.NewManager(),
@@ -442,7 +442,7 @@ func NewEndpointFromChangeModel(base *models.EndpointChangeRequest) (*Endpoint, 
 		DatapathMapID:    int(base.DatapathMapID),
 		IfIndex:          int(base.InterfaceIndex),
 		OpLabels:         pkgLabels.NewOpLabels(),
-		DNSHistory:       fqdn.NewDNSCache(),
+		DNSHistory:       fqdn.NewDNSCacheWithLimit(option.Config.ToFQDNsMaxIPsPerHost),
 		state:            "",
 		Status:           NewEndpointStatus(),
 		hasBPFProgram:    make(chan struct{}, 0),
@@ -1191,7 +1191,10 @@ func ParseEndpoint(strEp string) (*Endpoint, error) {
 	if len(strEpSlice) != 2 {
 		return nil, fmt.Errorf("invalid format %q. Should contain a single ':'", strEp)
 	}
-	ep := Endpoint{OpLabels: pkgLabels.NewOpLabels(), DNSHistory: fqdn.NewDNSCache()}
+	ep := Endpoint{
+		OpLabels:   pkgLabels.NewOpLabels(),
+		DNSHistory: fqdn.NewDNSCacheWithLimit(option.Config.ToFQDNsMaxIPsPerHost),
+	}
 	if err := parseBase64ToEndpoint(strEpSlice[1], &ep); err != nil {
 		return nil, fmt.Errorf("failed to parse base64toendpoint: %s", err)
 	}

--- a/pkg/fqdn/cache_test.go
+++ b/pkg/fqdn/cache_test.go
@@ -464,3 +464,13 @@ func benchmarkUnmarshalJSON(c *C, numDNSEntries int) {
 		c.Assert(err, IsNil)
 	}
 }
+
+func (ds *DNSCacheTestSuite) TestCleanupEntries(c *C) {
+	cache := NewDNSCache()
+	cache.Update(now, "test.com", []net.IP{net.ParseIP("1.2.3.4")}, 3)
+	c.Assert(len(cache.cleanup), Equals, 1)
+	entries, _ := cache.CleanupExpiredEntries(time.Now().Add(5 * time.Second))
+	c.Assert(len(entries), Equals, 1)
+	c.Assert(len(cache.cleanup), Equals, 0)
+	c.Assert(len(cache.forward["test.com"]), Equals, 0)
+}

--- a/pkg/fqdn/helpers.go
+++ b/pkg/fqdn/helpers.go
@@ -165,3 +165,19 @@ func sortedIPsAreEqual(a, b []net.IP) bool {
 func prepareMatchName(matchName string) string {
 	return strings.ToLower(dns.Fqdn(matchName))
 }
+
+// KeepUniqueNames it gets a array of strings and return a new array of strings
+// with the unique names.
+func KeepUniqueNames(names []string) []string {
+	result := []string{}
+	entries := map[string]bool{}
+
+	for _, item := range names {
+		if _, ok := entries[item]; ok {
+			continue
+		}
+		entries[item] = true
+		result = append(result, item)
+	}
+	return result
+}

--- a/pkg/fqdn/helpers_test.go
+++ b/pkg/fqdn/helpers_test.go
@@ -1,0 +1,39 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package fqdn
+
+import (
+	"github.com/cilium/cilium/pkg/checker"
+	. "gopkg.in/check.v1"
+)
+
+func (ds *DNSCacheTestSuite) TestKeepUniqueNames(c *C) {
+	testData := []struct {
+		argument []string
+		expected []string
+	}{
+		{[]string{"a", "b", "c"}, []string{"a", "b", "c"}},
+		{[]string{"a", "b", "a", "c"}, []string{"a", "b", "c"}},
+		{[]string{""}, []string{""}},
+		{[]string{}, []string{}},
+	}
+
+	for _, item := range testData {
+		val := KeepUniqueNames(item.argument)
+		c.Assert(val, checker.DeepEquals, item.expected)
+	}
+}

--- a/pkg/fqdn/rulegen.go
+++ b/pkg/fqdn/rulegen.go
@@ -526,5 +526,9 @@ func (gen *RuleGen) updateIPsForName(lookupTime time.Time, dnsName string, newIP
 
 	gen.cache.Update(lookupTime, dnsName, newIPs, ttl)
 	sortedNewIPs := gen.cache.Lookup(dnsName) // DNSCache returns IPs sorted
-	return !sortedIPsAreEqual(sortedNewIPs, cacheIPs)
+
+	// The 0 checks below account for an unlike race condition where this
+	// function is called with already expired data and if other cache data
+	// from before also expired.
+	return (len(cacheIPs) == 0 && len(sortedNewIPs) == 0) || !sortedIPsAreEqual(sortedNewIPs, cacheIPs)
 }

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -50,6 +50,9 @@ const (
 	// Labels are any label, they may not be relevant to the security identity.
 	Labels = "labels"
 
+	// Controller is the name of the controller to log it.
+	Controller = "controller"
+
 	// Identity is the identifier of a security identity
 	Identity = "identity"
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -260,6 +260,10 @@ const (
 	// ToFQDNsEmitPollerEvents controls if poller lookups are sent as monitor events
 	ToFQDNsEnablePollerEvents = "tofqdns-enable-poller-events"
 
+	// ToFQDNsMaxIPsPerHost defines the maximum number of IPs to maintain
+	// for each FQDN name in an endpoint's FQDN cache
+	ToFQDNsMaxIPsPerHost = "tofqdns-endpoint-max-ip-per-hostname"
+
 	// AutoIPv6NodeRoutesName is the name of the AutoIPv6NodeRoutes option
 	AutoIPv6NodeRoutesName = "auto-ipv6-node-routes"
 
@@ -735,6 +739,10 @@ type DaemonConfig struct {
 	// response the DNS poller sees
 	ToFQDNsEnablePollerEvents bool
 
+	// ToFQDNsMaxIPsPerHost defines the maximum number of IPs to maintain
+	// for each FQDN name in an endpoint's FQDN cache
+	ToFQDNsMaxIPsPerHost int
+
 	// FQDNRejectResponse is the dns-proxy response for invalid dns-proxy request
 	FQDNRejectResponse string
 
@@ -774,6 +782,7 @@ var (
 		EnableHealthChecking:     defaults.EnableHealthChecking,
 		EnableIPv4:               defaults.EnableIPv4,
 		EnableIPv6:               defaults.EnableIPv6,
+		ToFQDNsMaxIPsPerHost:     defaults.ToFQDNsMaxIPsPerHost,
 		ContainerRuntimeEndpoint: make(map[string]string),
 		FixedIdentityMapping:     make(map[string]string),
 		KVStoreOpt:               make(map[string]string),
@@ -997,6 +1006,7 @@ func (c *DaemonConfig) Populate() {
 	// avoids confusion about dropped connections.
 	c.ToFQDNsEnablePoller = viper.GetBool(ToFQDNsEnablePoller)
 	c.ToFQDNsEnablePollerEvents = viper.GetBool(ToFQDNsEnablePollerEvents)
+	c.ToFQDNsMaxIPsPerHost = viper.GetInt(ToFQDNsMaxIPsPerHost)
 	userSetMinTTL := viper.GetInt(ToFQDNsMinTTL)
 	switch {
 	case userSetMinTTL != 0: // set by user


### PR DESCRIPTION
The reason for this commit is to avoid large list of identities on fqdn policy
and implement the cleanup process to clean expires IPS and avoid large times on
policyCalculation.

The reason to use a cleanup map in dnsCache is to avoid to loop all the DNS
cache entries, so each second we have a map and a controller will clean the
entries that has some ips expired at that point of time.

The reason to use the controller, is to avoid to have a goroutine with a
timer.Tick each second, and have all in the same goroutine. To avoid leaks,
instead the passing time.Now() use the cache.lastCleanup to get all the entries
from the last run, policy regeneration can take more than 40 seconds in some
huge policies and with this method leak seconds entries int he cleanup map will
not happen.

Tried also with a callback function, but that can block the cache in case of the
long policyCalculation times and DNS proxy will not resolve/response correctly.
Also tried with the channel, but need to have a buffer and the Cilium way is
more related to use a controller.

This PR will not work if https://github.com/cilium/cilium/pull/6692 is not merged. 

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6740)
<!-- Reviewable:end -->
