### PR TITLE
Test: retrieve docker logs by name.

### DIFF
--- a/test/helpers/docker.go
+++ b/test/helpers/docker.go
@@ -170,7 +170,7 @@ func (s *SSHMeta) SampleContainersActions(mode string, networkName string, creat
 // GatherDockerLogs dumps docker containers logs output to the directory
 // testResultsPath
 func (s *SSHMeta) GatherDockerLogs() {
-	res := s.Exec("docker ps -aq")
+	res := s.Exec("docker ps -a --format {{.Names}}")
 	if !res.WasSuccessful() {
 		log.WithField("error", res.CombineOutput()).Errorf("cannot get docker logs")
 		return


### PR DESCRIPTION
To make it easier to debug, retrieve logs based on names instead of ids
to make it easier to find it.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6741)
<!-- Reviewable:end -->
