### PR TITLE
Test: Increase curl timeout

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -150,7 +150,7 @@ const (
 
 	// CurlConnectTimeout is the timeout for the connect() call that curl
 	// invokes
-	CurlConnectTimeout = 3
+	CurlConnectTimeout = 5
 
 	// CurlMaxTimeout is the hard timeout. It starts when curl is invoked
 	// and interrupts curl regardless of whether curl is currently


### PR DESCRIPTION
Due DNS proxy each time that a DNS request happens creates a new
regeneration happens, so conenct timeout of 3 seconds was not enough in
the CI because of the CI load.

Fix #6727

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6742)
<!-- Reviewable:end -->
