### PR TITLE
Fix restoration of ipvlan-based endpoints

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -142,7 +142,7 @@ type Endpoint struct {
 	DockerEndpointID string
 
 	// Corresponding BPF map identifier for tail call map of ipvlan datapath
-	dataPathMapID int
+	DataPathMapID int
 
 	// isDatapathMapPinned denotes whether the datapath map has been pinned.
 	isDatapathMapPinned bool
@@ -331,7 +331,7 @@ func (e *Endpoint) HasBPFProgram() bool {
 
 // HasIpvlanDataPath returns whether the daemon is running in ipvlan mode.
 func (e *Endpoint) HasIpvlanDataPath() bool {
-	if e.dataPathMapID > 0 {
+	if e.DataPathMapID > 0 {
 		return true
 	}
 	return false
@@ -432,7 +432,7 @@ func NewEndpointFromChangeModel(base *models.EndpointChangeRequest) (*Endpoint, 
 		IfName:           base.InterfaceName,
 		K8sPodName:       base.K8sPodName,
 		K8sNamespace:     base.K8sNamespace,
-		dataPathMapID:    int(base.DataPathMapID),
+		DataPathMapID:    int(base.DataPathMapID),
 		IfIndex:          int(base.InterfaceIndex),
 		OpLabels:         pkgLabels.NewOpLabels(),
 		DNSHistory:       fqdn.NewDNSCache(),
@@ -1590,7 +1590,7 @@ func (e *Endpoint) GetDockerNetworkID() string {
 
 // SetDatapathMapIDAndPinMapLocked modifies the endpoint's datapath map ID
 func (e *Endpoint) SetDatapathMapIDAndPinMapLocked(id int) error {
-	e.dataPathMapID = id
+	e.DataPathMapID = id
 	return e.MapPinLocked()
 }
 
@@ -2236,11 +2236,11 @@ func (e *Endpoint) IsDisconnecting() bool {
 // MapPinLocked retrieves a file descriptor from the map ID from the API call
 // and pins the corresponding map into the BPF file system.
 func (e *Endpoint) MapPinLocked() error {
-	if e.dataPathMapID == 0 {
+	if e.DataPathMapID == 0 {
 		return nil
 	}
 
-	mapFd, err := bpf.MapFdFromID(e.dataPathMapID)
+	mapFd, err := bpf.MapFdFromID(e.DataPathMapID)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Previously, restoring of an ipvlan-based endpoint was not working due to missing datapath tail call map id in `lxc_config.h` which was due to JSON marshaller not encoding private fields.

This PR makes the field public and replaces the check for ipvlan slave netdev existence in the restoring function with the check for datapath tail call map existence.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6743)
<!-- Reviewable:end -->
