### PR TITLE
endpoint: do not return error if endpoint RLock fails due to endpoint being removed

### DIFF
--- a/pkg/endpoint/errors.go
+++ b/pkg/endpoint/errors.go
@@ -1,0 +1,23 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endpoint
+
+import "errors"
+
+var (
+	// ErrNotAlive is an error which indicates that the endpoint should not be
+	// rlocked because it is currently being removed.
+	ErrNotAlive = errors.New("rlock failed: endpoint is in the process of being removed")
+)

--- a/pkg/endpoint/lock.go
+++ b/pkg/endpoint/lock.go
@@ -36,7 +36,7 @@ func (e *Endpoint) RLockAlive() error {
 	e.mutex.RLock()
 	if e.IsDisconnecting() {
 		e.mutex.RUnlock()
-		return fmt.Errorf("rlock failed: endpoint is in the process of being removed")
+		return ErrNotAlive
 	}
 	return nil
 }


### PR DESCRIPTION
The Cilium CI has failed recently on multiple occasions due to errors appearing
for controllers for endpoints which resolve the identity for said endpoints.
The errors were "rlock failed: endpoint is in the process of being removed".
If an endpoint is being removed, its identity no longer needs to be resolved, so
we do not need to return an error in this case within `identityLabelsChanged`.

Fixes: #6721

Signed-off by: Ian Vernon <ian@cilium.io>

Nominating for 1.3 backport since this is affecting the v1.3 CI as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6750)
<!-- Reviewable:end -->
