### PR TITLE
k8s: Don't list identities in CEP for default-allow

### DIFF
--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -54,6 +54,16 @@ type Key struct {
 	TrafficDirection uint8
 }
 
+// IsIngress returns true if the key refers to an ingress policy key
+func (k Key) IsIngress() bool {
+	return k.TrafficDirection == trafficdirection.Ingress.Uint8()
+}
+
+// IsEgress returns true if the key refers to an egress policy key
+func (k Key) IsEgress() bool {
+	return k.TrafficDirection == trafficdirection.Egress.Uint8()
+}
+
 // MapStateEntry is the configuration associated with a Key in a
 // MapState. This is a minimized version of policymap.PolicyEntry.
 type MapStateEntry struct {

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -1,0 +1,33 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package policy
+
+import (
+	"github.com/cilium/cilium/pkg/policy/trafficdirection"
+
+	"gopkg.in/check.v1"
+)
+
+func (ds *PolicyTestSuite) TestPolicyKeyTrafficDirection(c *check.C) {
+	k := Key{TrafficDirection: trafficdirection.Ingress.Uint8()}
+	c.Assert(k.IsIngress(), check.Equals, true)
+	c.Assert(k.IsEgress(), check.Equals, false)
+
+	k = Key{TrafficDirection: trafficdirection.Egress.Uint8()}
+	c.Assert(k.IsIngress(), check.Equals, false)
+	c.Assert(k.IsEgress(), check.Equals, true)
+}


### PR DESCRIPTION
This lowers the size of the CEP and reduces the number of updates required for
pods that are running in default-allow policy enforcement mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6758)
<!-- Reviewable:end -->
