### PR TITLE
daemon: sockops: delay sockops init till node_config.h gets generated

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -579,17 +579,6 @@ func (d *Daemon) initMaps() error {
 		log.WithError(err).Fatal("Unable to open service maps")
 	}
 
-	// Remove any old sockops and re-enable with _new_ programs if flag is set
-	sockops.SockmapDisable()
-	sockops.SkmsgDisable()
-
-	if option.Config.SockopsEnable {
-		eppolicymap.CreateEPPolicyMap()
-		sockops.SockmapEnable()
-		sockops.SkmsgEnable()
-		sockmap.SockmapCreate()
-	}
-
 	// Set up the list of IPCache listeners in the daemon, to be
 	// used by syncLXCMap().
 	ipcache.IPIdentityCache.SetListeners([]ipcache.IPIdentityMappingListener{
@@ -669,6 +658,17 @@ func (d *Daemon) init() error {
 
 	if err := d.createNodeConfigHeaderfile(); err != nil {
 		return err
+	}
+
+	// Remove any old sockops and re-enable with _new_ programs if flag is set
+	sockops.SockmapDisable()
+	sockops.SkmsgDisable()
+
+	if option.Config.SockopsEnable {
+		eppolicymap.CreateEPPolicyMap()
+		sockops.SockmapEnable()
+		sockops.SkmsgEnable()
+		sockmap.SockmapCreate()
 	}
 
 	if !option.Config.DryMode {


### PR DESCRIPTION
SockmapEnable and SkmsgEnable require node_config.h which generated
in Daemon.init().

level=error msg="Failed to compile bpf_sockops.o: exit status 1" compiler-pid=23550 linker-pid=23551 subsys=datapath-loader
level=warning msg="/var/lib/cilium/bpf/sockops/bpf_sockops.c:21:10: fatal error: 'node_config.h' file not found" subsys=datapath-loader
level=warning msg="#include <node_config.h>" subsys=datapath-loader
level=warning msg="         ^~~~~~~~~~~~~~~" subsys=datapath-loader
level=warning msg="1 error generated." subsys=datapath-loader
level=error msg="failed compile sockops/bpf_sockops.c: Failed to compile bpf_sockops.o: exit status 1" subsys=sockops
level=error msg="Failed to compile bpf_redir.o: exit status 1" compiler-pid=23553 linker-pid=23554 subsys=datapath-loader
level=warning msg="/var/lib/cilium/bpf/sockops/bpf_redir.c:21:10: fatal error: 'node_config.h' file not found" subsys=datapath-loader
level=warning msg="#include <node_config.h>" subsys=datapath-loader
level=warning msg="         ^~~~~~~~~~~~~~~" subsys=datapath-loader

Fixes: ac55c6a435 (daemon: Create BPF maps before restoring service IDs)

Signed-off-by: Nirmoy Das <ndas@suse.de>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6763)
<!-- Reviewable:end -->
