### PR TITLE
Kubernetes: CEP fixes.

### DIFF
--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -41,7 +41,7 @@ const (
 
 	// CustomResourceDefinitionSchemaVersion is semver-conformant version of CRD schema
 	// Used to determine if CRD needs to be updated in cluster
-	CustomResourceDefinitionSchemaVersion = "1.13"
+	CustomResourceDefinitionSchemaVersion = "1.14"
 
 	// CustomResourceDefinitionSchemaVersionKey is key to label which holds the CRD schema version
 	CustomResourceDefinitionSchemaVersionKey = "io.cilium.k8s.crd.schema.version"
@@ -211,31 +211,37 @@ func createCEPCRD(clientset apiextensionsclient.Interface) error {
 					Name:        "Identity ID",
 					Type:        "integer",
 					Description: "Cilium identity id",
-					JSONPath:    ".status.status.identity.id",
+					JSONPath:    ".status.identity.id",
 				},
 				{
-					Name:        "Policy Enforcement",
-					Type:        "string",
-					Description: "Policy enforcement in the endpoint",
-					JSONPath:    ".status.status.policy.realized.policy-enabled",
+					Name:        "Ingress Enforcement",
+					Type:        "boolean",
+					Description: "Ingress enforcement in the endpoint",
+					JSONPath:    ".status.policy.ingress.enforcing",
+				},
+				{
+					Name:        "Egress Enforcement",
+					Type:        "boolean",
+					Description: "Egress enforcement in the endpoint",
+					JSONPath:    ".status.policy.egress.enforcing",
 				},
 				{
 					Name:        "Endpoint State",
 					Type:        "string",
 					Description: "Endpoint current state",
-					JSONPath:    ".status.status.state",
+					JSONPath:    ".status.state",
 				},
 				{
 					Name:        "IPv4",
 					Type:        "string",
 					Description: "Endpoint IPv4 address",
-					JSONPath:    ".status.status.networking.addressing[0].ipv4",
+					JSONPath:    ".status.networking.addressing[0].ipv4",
 				},
 				{
 					Name:        "IPv6",
 					Type:        "string",
 					Description: "Endpoint IPv6 address",
-					JSONPath:    ".status.status.networking.addressing[0].ipv6",
+					JSONPath:    ".status.networking.addressing[0].ipv6",
 				},
 			},
 			Subresources: &apiextensionsv1beta1.CustomResourceSubresources{

--- a/pkg/k8s/apis/cilium.io/v2/types.go
+++ b/pkg/k8s/apis/cilium.io/v2/types.go
@@ -374,7 +374,7 @@ type EndpointPolicy struct {
 
 // EndpointPolicyDirection is the list of allowed identities per direction
 type EndpointPolicyDirection struct {
-	Enforcing bool                `json:"enforcing,omitempty"`
+	Enforcing bool                `json:"enforcing"`
 	Allowed   AllowedIdentityList `json:"allowed,omitempty"`
 	Removing  AllowedIdentityList `json:"removing,omitempty"`
 	Adding    AllowedIdentityList `json:"adding,omitempty"`


### PR DESCRIPTION
Due the changes on commit `c5e50eb57be837b6b90c601c990fb6834d96d33b` the
get cep list is not reporting correctly.

With this change the list is reporting correctly:

```
NAME               ENDPOINT ID   IDENTITY ID   INGRESS ENFORCEMENT   EGRESS ENFORCEMENT   ENDPOINT STATE   IPV4          IPV6
testclient-m894b   3216          4397          false                 false                ready            10.10.0.218   f00d::a0a:0:0:f
testds-2p4hq       3644          645           false                 false                ready            10.10.0.120   f00d::a0a:0:0:f521
```

Also, make ingress/egress enforcement value in the json as non-empty,
due is good to report that the value is false for jsonpath utilities.

Due the changes, I also changed the CI report to make it easy to
understand if the test failed, the new behaviour looks like this:

```
<Checks>
Number of 'context deadline exceeded' in logs: 0
Number of 'level=error' in logs: 0
Number of 'level=warning' in logs: 0
Number of 'Cilium API handler panicked' in logs: 0
Number of 'Goroutine took lock for more than' in logs: 0
Cilium pods: [cilium-rmcw9]
Netpols loaded:
CiliumNetworkPolicies loaded:
Endpoint Policy Enforcement:
Pod                              Ingress   Egress
coredns-fff89c9b9-cfkvb          false     false
etcd-operator-5cf67779fd-hmkcv   false     false
testclient-m894b                 false     false
testds-2p4hq                     false     false
cilium-etcd-8nwlbq9cvq           false     false
cilium-etcd-wgptgl2gt5           false     false
cilium-etcd-xxh29gps5m           false     false
```

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6764)
<!-- Reviewable:end -->
