### PR TITLE
workloads: Pass options per runtime

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1061,8 +1061,10 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 
 	// Workloads must be initialized after IPAM has started as it requires
 	// to allocate IPs.
-	wOpts := map[string]string{
-		workloads.DatapathModeOpt: option.Config.DatapathMode,
+	wOpts := map[workloads.WorkloadRuntimeType]map[string]string{
+		workloads.Docker:     {workloads.DatapathModeOpt: option.Config.DatapathMode},
+		workloads.ContainerD: make(map[string]string),
+		workloads.CRIO:       make(map[string]string),
 	}
 	if err := workloads.Setup(d.ipam, option.Config.Workloads, wOpts); err != nil {
 		return nil, nil, fmt.Errorf("unable to setup workload: %s", err)

--- a/pkg/workloads/config.go
+++ b/pkg/workloads/config.go
@@ -78,7 +78,7 @@ var (
 	allocator allocatorInterface
 )
 
-func setup(workloadRuntime workloadRuntimeType, opts map[string]string) error {
+func setup(workloadRuntime WorkloadRuntimeType, opts map[string]string) error {
 	workloadMod := getWorkload(workloadRuntime)
 	if workloadMod == nil {
 		return fmt.Errorf("unknown workloadRuntime runtime type %s", workloadRuntime)
@@ -104,7 +104,7 @@ func Setup(a allocatorInterface, workloadRuntimes []string, opts map[string]stri
 		func() {
 			allocator = a
 
-			var crt workloadRuntimeType
+			var crt WorkloadRuntimeType
 			for _, runtime := range workloadRuntimes {
 				crt, err = parseRuntimeType(runtime)
 				if err != nil {

--- a/pkg/workloads/config.go
+++ b/pkg/workloads/config.go
@@ -97,7 +97,7 @@ type allocatorInterface interface {
 
 // Setup sets up the workload runtime specified in workloadRuntime and configures it
 // with the options provided in opts
-func Setup(a allocatorInterface, workloadRuntimes []string, opts map[string]string) error {
+func Setup(a allocatorInterface, workloadRuntimes []string, opts map[WorkloadRuntimeType]map[string]string) error {
 	var err error
 
 	setupOnce.Do(
@@ -124,17 +124,17 @@ func Setup(a allocatorInterface, workloadRuntimes []string, opts map[string]stri
 				}
 				switch crt {
 				case Auto:
-					err1 := setup(Docker, opts)
+					err1 := setup(Docker, opts[Docker])
 					st := Status()
 					if err1 == nil && st.State == models.StatusStateOk {
 						return
 					}
-					err2 := setup(ContainerD, opts)
+					err2 := setup(ContainerD, opts[ContainerD])
 					st = Status()
 					if err2 == nil && st.State == models.StatusStateOk {
 						return
 					}
-					err3 := setup(CRIO, opts)
+					err3 := setup(CRIO, opts[CRIO])
 					st = Status()
 					if err3 == nil && st.State == models.StatusStateOk {
 						return
@@ -142,7 +142,7 @@ func Setup(a allocatorInterface, workloadRuntimes []string, opts map[string]stri
 					err = err1
 					return
 				default:
-					err = setup(crt, opts)
+					err = setup(crt, opts[crt])
 					return
 				}
 			}

--- a/pkg/workloads/containerd.go
+++ b/pkg/workloads/containerd.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	ContainerD workloadRuntimeType = "containerd"
+	ContainerD WorkloadRuntimeType = "containerd"
 
 	// criContainerdPrefix is common prefix for cri-containerd
 	criContainerdPrefix = "io.cri-containerd"

--- a/pkg/workloads/crio.go
+++ b/pkg/workloads/crio.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	CRIO workloadRuntimeType = "crio"
+	CRIO WorkloadRuntimeType = "crio"
 
 	// criOEndpoint is the default value for the crio socket
 	criOEndpoint = "/var/run/crio.sock"

--- a/pkg/workloads/docker.go
+++ b/pkg/workloads/docker.go
@@ -56,7 +56,7 @@ import (
 )
 
 const (
-	Docker workloadRuntimeType = "docker"
+	Docker WorkloadRuntimeType = "docker"
 )
 
 var (

--- a/pkg/workloads/runtimes.go
+++ b/pkg/workloads/runtimes.go
@@ -47,8 +47,8 @@ func Init(o WorkloadOwner) {
 }
 
 const (
-	None workloadRuntimeType = "none"
-	Auto workloadRuntimeType = "auto"
+	None WorkloadRuntimeType = "none"
+	Auto WorkloadRuntimeType = "auto"
 )
 
 const (
@@ -91,16 +91,17 @@ type workloadModule interface {
 	newClient() (WorkloadRuntime, error)
 }
 
-type workloadRuntimeType string
+// WorkloadRuntimeType is the type of a container runtime
+type WorkloadRuntimeType string
 
 var (
 	// registeredWorkloads is a slice of all workloads that have registered
 	// itself via registerWorkload()
-	registeredWorkloads = map[workloadRuntimeType]workloadModule{}
+	registeredWorkloads = map[WorkloadRuntimeType]workloadModule{}
 )
 
 func unregisterWorkloads() {
-	registeredWorkloads = map[workloadRuntimeType]workloadModule{}
+	registeredWorkloads = map[WorkloadRuntimeType]workloadModule{}
 }
 
 // ParseConfigEndpoint parses the containerRuntimes and the containerRuntime
@@ -136,8 +137,8 @@ func ParseConfigEndpoint(containerRuntimes []string, containerRuntimesEPOpts map
 	return nil
 }
 
-func parseRuntimeType(str string) (workloadRuntimeType, error) {
-	switch crt := workloadRuntimeType(strings.ToLower(str)); crt {
+func parseRuntimeType(str string) (WorkloadRuntimeType, error) {
+	switch crt := WorkloadRuntimeType(strings.ToLower(str)); crt {
 	case None, Auto:
 		return crt, nil
 	default:
@@ -150,7 +151,7 @@ func parseRuntimeType(str string) (workloadRuntimeType, error) {
 }
 
 // registerWorkload must be called by container runtimes to register themselves
-func registerWorkload(name workloadRuntimeType, module workloadModule) {
+func registerWorkload(name WorkloadRuntimeType, module workloadModule) {
 	if _, ok := registeredWorkloads[name]; ok {
 		log.Panicf("workload with name '%s' already registered", name)
 	}
@@ -159,7 +160,7 @@ func registerWorkload(name workloadRuntimeType, module workloadModule) {
 }
 
 // getWorkload finds a registered workload by name
-func getWorkload(name workloadRuntimeType) workloadModule {
+func getWorkload(name WorkloadRuntimeType) workloadModule {
 	if workload, ok := registeredWorkloads[name]; ok {
 		return workload
 	}
@@ -169,7 +170,7 @@ func getWorkload(name workloadRuntimeType) workloadModule {
 
 // GetRuntimeDefaultOpt returns the default options for the given container
 // runtime.
-func GetRuntimeDefaultOpt(crt workloadRuntimeType, opt string) string {
+func GetRuntimeDefaultOpt(crt WorkloadRuntimeType, opt string) string {
 	opts, ok := registeredWorkloads[crt]
 	if !ok {
 		return ""
@@ -189,7 +190,7 @@ func GetRuntimeOptions() string {
 	sort.Strings(crs)
 
 	for _, cr := range crs {
-		rb := registeredWorkloads[workloadRuntimeType(cr)]
+		rb := registeredWorkloads[WorkloadRuntimeType(cr)]
 		cfg := rb.getConfig()
 		keys := make([]string, 0, len(cfg))
 		for k := range cfg {
@@ -215,7 +216,7 @@ func GetDefaultEPOptsStringWithPrefix(prefix string) string {
 	sort.Strings(crs)
 
 	for _, cr := range crs {
-		v := registeredWorkloads[workloadRuntimeType(cr)].getConfig()
+		v := registeredWorkloads[WorkloadRuntimeType(cr)].getConfig()
 		strs = append(strs, fmt.Sprintf("%s%s=%s", prefix, cr, v[epOpt]))
 	}
 

--- a/pkg/workloads/runtimes_test.go
+++ b/pkg/workloads/runtimes_test.go
@@ -34,7 +34,7 @@ var _ = Suite(&WorkloadsTestSuite{})
 
 func (s *WorkloadsTestSuite) TestParseConfigEndpoint(c *C) {
 	// backup registered workload since None will unregister them all
-	bakRegisteredWorkloads := map[workloadRuntimeType]workloadModule{}
+	bakRegisteredWorkloads := map[WorkloadRuntimeType]workloadModule{}
 	for k, v := range registeredWorkloads {
 		bakRegisteredWorkloads[k] = v
 	}
@@ -123,7 +123,7 @@ func (s *WorkloadsTestSuite) Test_parseRuntimeType(c *C) {
 	tests := []struct {
 		name    string
 		args    args
-		want    workloadRuntimeType
+		want    WorkloadRuntimeType
 		wantErr bool
 	}{
 		{
@@ -189,7 +189,7 @@ func (s *WorkloadsTestSuite) Test_parseRuntimeType(c *C) {
 
 func (s *WorkloadsTestSuite) Test_unregisterWorkloads(c *C) {
 	// backup registered workloads since they will unregistered
-	bakRegisteredWorkloads := map[workloadRuntimeType]workloadModule{}
+	bakRegisteredWorkloads := map[WorkloadRuntimeType]workloadModule{}
 	for k, v := range registeredWorkloads {
 		bakRegisteredWorkloads[k] = v
 	}
@@ -208,7 +208,7 @@ func (s *WorkloadsTestSuite) Test_unregisterWorkloads(c *C) {
 
 func (s *WorkloadsTestSuite) Test_getWorkload(c *C) {
 	type args struct {
-		name workloadRuntimeType
+		name WorkloadRuntimeType
 	}
 	tests := []struct {
 		name string
@@ -232,7 +232,7 @@ func (s *WorkloadsTestSuite) Test_getWorkload(c *C) {
 
 func (s *WorkloadsTestSuite) TestGetRuntimeDefaultOpt(c *C) {
 	type args struct {
-		crt workloadRuntimeType
+		crt WorkloadRuntimeType
 		opt string
 	}
 	tests := []struct {


### PR DESCRIPTION
Previously, all workloads runtime options passed to `workloads.Setup/2` were passed to each individual runtime implementation. This led to some runtimes returning an error during the setup step, because not all options were supported by them (e.g. `datapath-mode` is not supported by the containerd workloads runtime).

This PR changes the runtime options in a way that they are defined per runtime.

I was thinking to add unit tests for `workloads.Setup`, but this would involve mocking workloads clients (a lot of effort). Instead, maybe it would make sense to add integration tests for a non-Docker container runtime?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6766)
<!-- Reviewable:end -->
