### PR TITLE
daemon: Sanitize fqdn/cache API matchpattern parameter

### DIFF
--- a/daemon/fqdn.go
+++ b/daemon/fqdn.go
@@ -339,7 +339,7 @@ func extractDNSLookups(endpoints []*endpoint.Endpoint, CIDRStr, matchPatternStr 
 
 	nameMatcher := func(name string) bool { return true }
 	if matchPatternStr != "" {
-		matcher, err := matchpattern.Validate(matchPatternStr)
+		matcher, err := matchpattern.Validate(matchpattern.Sanitize(matchPatternStr))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
When parsing policy .Sanitize ensures a name or pattern is a FQDN. The
FQDN API code now also does this, allow the same patterns in policies to
match in-cache names.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6767)
<!-- Reviewable:end -->
