### PR TITLE
Jenkins: delete docker-compose networks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,11 @@ $(SUBDIRS): force
 jenkins-precheck:
 	docker-compose -f test/docker-compose.yml -p $(JOB_BASE_NAME)-$$BUILD_NUMBER run --rm precheck
 
+clean-jenkins-precheck:
+	docker-compose -f test/docker-compose.yml -p $(JOB_BASE_NAME)-$$BUILD_NUMBER rm
+	# remove the networks
+	docker-compose -f test/docker-compose.yml -p $(JOB_BASE_NAME)-$$BUILD_NUMBER down
+
 TEST_LDFLAGS=-ldflags "-X github.com/cilium/cilium/pkg/kvstore.consulDummyAddress=https://consul:8443 -X github.com/cilium/cilium/pkg/kvstore.etcdDummyAddress=http://etcd:4002"
 
 PRIV_TEST_PKGS = $(shell grep --include='*.go' -ril '+build privileged_tests' | xargs dirname | sort | uniq)

--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -50,7 +50,7 @@ pipeline {
             }
             post {
                always {
-                   sh "cd ${TESTDIR}; make clean-ginkgo-tests || true"
+                   sh "cd ${TESTDIR}; make clean-jenkins-precheck || true"
                }
             }
         }
@@ -82,7 +82,7 @@ pipeline {
                 script {
                     parallel(
                         "Runtime":{
-                            sh 'cd ${TESTDIR}; vagrant provision runtime' 
+                            sh 'cd ${TESTDIR}; vagrant provision runtime'
                             sh 'cd ${TESTDIR}; ginkgo --focus=" Runtime*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
                         },
                         "K8s-1.8":{


### PR DESCRIPTION
On commit `eb3b298849bc72b283034e13ab32e57130260758` target
clean-ginkgo-test was deleted, but the jenkins-precheck is still using
the docker-compose, so the docker networks never got deleted and Jenkins
failed after a while

With this change, after each build a delete will happens.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

Backport is only to 1.4 due is when the change was made. 
Please ensure your pull request adheres to the following guidelines:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6768)
<!-- Reviewable:end -->
