### PR TITLE
kvstore: Fix panic in `cilium kvstore` CLI

### DIFF
--- a/pkg/kvstore/client.go
+++ b/pkg/kvstore/client.go
@@ -23,6 +23,10 @@ var (
 
 func initClient(module backendModule) error {
 	c, errChan := module.newClient()
+	if c == nil {
+		err := <-errChan
+		log.WithError(err).Fatalf("Unable to connect to kvstore")
+	}
 
 	defaultClient = c
 
@@ -31,7 +35,6 @@ func initClient(module backendModule) error {
 		if isErr {
 			log.WithError(err).Fatalf("Unable to connect to kvstore")
 		}
-
 		deleteLegacyPrefixes()
 	}()
 


### PR DESCRIPTION
Fix the following panic when the kvstore client cannot be created via the CLI:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x50 pc=0x1a306d0]

goroutine 1 [running]:
github.com/cilium/cilium/pkg/kvstore.Get(0x0, 0x0, 0x8, 0x8, 0x8, 0x7, 0x7)
	/home/vagrant/go/src/github.com/cilium/cilium/pkg/kvstore/kvstore.go:40 +0x40
github.com/cilium/cilium/cilium/cmd.glob..func32(0x44e3c80, 0x4ada920, 0x0, 0x0)
	/home/vagrant/go/src/github.com/cilium/cilium/cilium/cmd/kvstore_get.go:55 +0x2e7
github.com/cilium/cilium/vendor/github.com/spf13/cobra.(*Command).execute(0x44e3c80, 0x4ada920, 0x0, 0x0, 0x44e3c80, 0x4ada920)
	/home/vagrant/go/src/github.com/cilium/cilium/vendor/github.com/spf13/cobra/command.go:766 +0x2cc
github.com/cilium/cilium/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0x44e7f00, 0x2f, 0xffffffffffffffff, 0xc0004c2f30)
	/home/vagrant/go/src/github.com/cilium/cilium/vendor/github.com/spf13/cobra/command.go:852 +0x2fd
github.com/cilium/cilium/vendor/github.com/spf13/cobra.(*Command).Execute(0x44e7f00, 0xc0007a7f58, 0x1164e30)
	/home/vagrant/go/src/github.com/cilium/cilium/vendor/github.com/spf13/cobra/command.go:800 +0x2b
github.com/cilium/cilium/cilium/cmd.Execute()
	/home/vagrant/go/src/github.com/cilium/cilium/cilium/cmd/root.go:46 +0x2d
main.main()
	/home/vagrant/go/src/github.com/cilium/cilium/daemon/main.go:32 +0xd0
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6769)
<!-- Reviewable:end -->
