### PR TITLE
Fix bug where cilium-health endpoint controller would fail on startup

### DIFF
--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 Authors of Cilium
+// Copyright 2017-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
-	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/endpoint"
@@ -174,13 +173,6 @@ func CleanupEndpoint() {
 	} else {
 		scopedLog.WithError(err).Debug("Didn't find existing device")
 	}
-}
-
-// Annotator is an interface which describes anything which annotates a node
-// with cilium-health metadata.
-type Annotator interface {
-	AnnotateNode(nodeName string, v4CIDR, v6CIDR *cidr.CIDR, v4HealthIP, v6HealthIP, v4CiliumHostIP net.IP) error
-	AnnotatePod(k8sNamespace, k8sPodName, annotationKey, annotationValue string) error
 }
 
 // LaunchAsEndpoint launches the cilium-health agent in a nested network

--- a/daemon/status.go
+++ b/daemon/status.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -68,13 +68,11 @@ func checkLocks(d *Daemon) {
 }
 
 func (d *Daemon) getNodeStatus() *models.ClusterStatus {
-	ipv4 := option.Config.EnableIPv4
-
 	clusterStatus := models.ClusterStatus{
 		Self: d.nodeDiscovery.localNode.Fullname(),
 	}
 	for _, node := range d.nodeDiscovery.manager.GetNodes() {
-		clusterStatus.Nodes = append(clusterStatus.Nodes, node.GetModel(ipv4))
+		clusterStatus.Nodes = append(clusterStatus.Nodes, node.GetModel())
 	}
 	return &clusterStatus
 }


### PR DESCRIPTION
Previously, due to a static global definition of the client object in                                                                                                                                                                   
the health launch package, the daemon had no way to determine whether           
the client is already initialized, and would always fail to start the           
endpoint the first time the controller runs, then succeed afterwards.           
                                                                                
Fix this by pushing the client out to the daemon package, where we can          
then switch on whether the client exists to create it the first time            
without treating that case as an error, then only if the client already         
exists, attempt to ping it and treat failure to ping as an error worthy         
of failing the controller and restarting the endpoint.                          
                      
This PR also does a couple of other minor cleanups in files that are touched by the fix.
                                                          
Fixes: #6754

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6773)
<!-- Reviewable:end -->
