### PR TITLE
node: Do not require ipv6AllocRange in ipv4-only mode

### DIFF
--- a/pkg/node/node_address.go
+++ b/pkg/node/node_address.go
@@ -230,7 +230,7 @@ func AutoComplete() error {
 		InitDefaultPrefix("")
 	}
 
-	if ipv6AllocRange == nil {
+	if option.Config.EnableIPv6 && ipv6AllocRange == nil {
 		return fmt.Errorf("IPv6 per node allocation prefix is not configured. Please specificy --ipv6-range")
 	}
 


### PR DESCRIPTION
Otherwise, cilium-agent cannot start when running in the ipv4-only mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6774)
<!-- Reviewable:end -->
