### PR TITLE
endpoint: Properly cache ipvlan option

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -335,6 +335,11 @@ func (e *Endpoint) HasIpvlanDataPath() bool {
 		return true
 	}
 	return false
+}
+
+// MustGraft returns whether we need full replacement or grafting of object file.
+func (e *Endpoint) MustGraft() bool {
+	return e.HasIpvlanDataPath()
 }
 
 // GetIngressPolicyEnabledLocked returns whether ingress policy enforcement is


### PR DESCRIPTION
This option was being dereferenced while the endpoint was unlocked and
could (in theory) disappear. Cache it instead.

I'm hoping that in future if we make datapath regeneration approach 0 cost (via templated configuration), we can just hold the endpoint across that time and get rid of this whole cache object stuff. In the mean time, we should ensure it is used properly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6785)
<!-- Reviewable:end -->
