### PR TITLE
Avoid deleting ipcache map on startup on older kernels

### DIFF
--- a/pkg/bpf/map.go
+++ b/pkg/bpf/map.go
@@ -220,3 +220,19 @@ func GetLRUMapType() MapType {
 	}
 	return MapTypeHash
 }
+
+// GetMapType determines whether the specified map type is supported by the
+// kernel (as determined by ReadFeatureProbes()), and if the map type is not
+// supported, returns a more primitive map type that may be used to implement
+// the map on older implementations. Otherwise, returns the specified map type.
+func GetMapType(t MapType) MapType {
+	switch t {
+	case MapTypeLPMTrie:
+		fallthrough
+	case MapTypeLRUHash:
+		if !supportedMapTypes[t] {
+			return MapTypeHash
+		}
+	}
+	return t
+}

--- a/pkg/bpf/map.go
+++ b/pkg/bpf/map.go
@@ -209,18 +209,6 @@ func ReadFeatureProbes(filename string) {
 	}
 }
 
-// GetLRUMapType determines whether the kernel supports LRU hash maps, and if
-// so returns the LRU map type, otherwise returns the hash map type.
-//
-// Must only be used when the datapath also performs best-effort attempts at
-// defining a map's type to be LRU via HAVE_LRU_MAP_TYPE.
-func GetLRUMapType() MapType {
-	if supportedMapTypes[MapTypeLRUHash] {
-		return MapTypeLRUHash
-	}
-	return MapTypeHash
-}
-
 // GetMapType determines whether the specified map type is supported by the
 // kernel (as determined by ReadFeatureProbes()), and if the map type is not
 // supported, returns a more primitive map type that may be used to implement

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -222,7 +222,7 @@ func ct6DumpParser(key []byte, value []byte) (bpf.MapKey, bpf.MapValue, error) {
 func NewMap(mapName string, mapType MapType) *Map {
 	result := &Map{
 		Map: *bpf.NewMap(mapName,
-			bpf.GetLRUMapType(),
+			bpf.MapTypeLRUHash,
 			mapInfo[mapType].keySize,
 			int(unsafe.Sizeof(CtEntry{})),
 			mapInfo[mapType].maxEntries,


### PR DESCRIPTION
Use the BPF probes of the LPM support in the kernel and set the map type
of the IPCacheMap appropriately before attempting to OpenOrCreate() the
map. This should avoid situations on older kernels where a previous
Cilium instance creates the ipcache map as a hash map, then Cilium is
re-run and on startup it first sees the wrong map type and attempts to
delete it because the type is wrong (hash, not LPM), then attempts to
create the LPM map, fails, and falls back to hash map. This would create
unnecessary churn and recreation of IPCache maps, potentially leading to
some amount of network connectivity downtime.

Fixes: #6775

TODO:
* [x] Test on an older kernel
* [x] Test on a newer kernel

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6787)
<!-- Reviewable:end -->
