### PR TITLE
fqdn: Introduce upper cap of IPs per FQDN name per endpoint

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -98,6 +98,7 @@ cilium-agent [flags]
       --socket-path string                          Sets daemon's socket path to listen for connections (default "/var/run/cilium/cilium.sock")
       --sockops-enable                              Enable sockops when kernel supported
       --state-dir string                            Directory path to store runtime state (default "/var/run/cilium")
+      --tofqdn-max-ip-per-hostname int              Maximum number of IPs to maintain per FQDN name for each endpoint (default 50)
       --tofqdns-dns-reject-response-code string     DNS response code for rejecting DNS requests, available options are '[nameError refused]' (default "refused")
       --tofqdns-enable-poller                       Enable proactive polling of DNS names in toFQDNs.matchName rules.
       --tofqdns-enable-poller-events                Emit DNS responses seen by the DNS poller as Monitor events, if the poller is enabled. (default true)

--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -534,6 +534,19 @@ obtain DNS data. In such cases a shorter minimum TTL is recommended, as
 .. note:: It is recommended that ``--tofqdns-min-ttl`` be set to the minimum
           time a connection must be maintained.
 
+Managing Short-Lived Connections & Maximum IPs per FQDN/endpoint
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The minimal TTL for DNS entries in the cache is deliberately long with 1 week
+per default. This is done to accommodate long-lived, persistent connections.
+On the other end of the spectrum are workloads which perform short-lived
+connections in repetition to FQDNs which are backed by a large number of IP
+addresses (e.g. AWS S3). Such workloads can grow the number of IPs mapping to
+an FQDN quickly. In order to limit the number of IP addresses that map a
+particular FQDN, each FQDN per endpoint has a max capacity of IPs that are
+being maintained (default: 50). Once the capacity is exceeded, the oldest
+entries are automatically expired from the cache. This capacity can be changed
+using the ``--tofqdn-max-ip-per-hostname`` option.
 
 Obtaining DNS Data
 ~~~~~~~~~~~~~~~~~~

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -652,6 +652,9 @@ func init() {
 	flags.Bool(option.ToFQDNsEnablePollerEvents, true, "Emit DNS responses seen by the DNS poller as Monitor events, if the poller is enabled.")
 	option.BindEnv(option.ToFQDNsEnablePollerEvents)
 
+	flags.Int(option.ToFQDNsMaxIPsPerHost, defaults.ToFQDNsMaxIPsPerHost, "Maximum number of IPs to maintain per FQDN name for each endpoint")
+	option.BindEnv(option.ToFQDNsMaxIPsPerHost)
+
 	flags.StringVar(&option.Config.FQDNRejectResponse, option.FQDNRejectResponseCode, option.FQDNProxyDenyWithRefused, fmt.Sprintf("DNS response code for rejecting DNS requests, available options are '%v'", option.FQDNRejectOptions))
 	option.BindEnv(option.FQDNRejectResponseCode)
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -94,6 +94,10 @@ const (
 	// This or ToFQDNsMinTTL is used in DaemonConfig.Populate
 	ToFQDNsMinTTLPoller = 3600 // 1 hour in seconds
 
+	// ToFQDNsMaxIPsPerHost defines the maximum number of IPs to maintain
+	// for each FQDN name in an endpoint's FQDN cache
+	ToFQDNsMaxIPsPerHost = 50
+
 	// IdentityChangeGracePeriod is the grace period that needs to pass
 	// before an endpoint that has changed its identity will start using
 	// that new identity. During the grace period, the new identity has

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -255,6 +255,10 @@ const (
 	// ToFQDNsEmitPollerEvents controls if poller lookups are sent as monitor events
 	ToFQDNsEnablePollerEvents = "tofqdns-enable-poller-events"
 
+	// ToFQDNsMaxIPsPerHost defines the maximum number of IPs to maintain
+	// for each FQDN name in an endpoint's FQDN cache
+	ToFQDNsMaxIPsPerHost = "tofqdn-max-ip-per-hostname"
+
 	// AutoIPv6NodeRoutesName is the name of the AutoIPv6NodeRoutes option
 	AutoIPv6NodeRoutesName = "auto-ipv6-node-routes"
 
@@ -727,6 +731,10 @@ type DaemonConfig struct {
 	// response the DNS poller sees
 	ToFQDNsEnablePollerEvents bool
 
+	// ToFQDNsMaxIPsPerHost defines the maximum number of IPs to maintain
+	// for each FQDN name in an endpoint's FQDN cache
+	ToFQDNsMaxIPsPerHost int
+
 	// FQDNRejectResponse is the dns-proxy response for invalid dns-proxy request
 	FQDNRejectResponse string
 
@@ -759,6 +767,7 @@ var (
 		IPv6ClusterAllocCIDRBase: defaults.IPv6ClusterAllocCIDRBase,
 		EnableHostIPRestore:      defaults.EnableHostIPRestore,
 		EnableHealthChecking:     defaults.EnableHealthChecking,
+		ToFQDNsMaxIPsPerHost:     defaults.ToFQDNsMaxIPsPerHost,
 		ContainerRuntimeEndpoint: make(map[string]string),
 		FixedIdentityMapping:     make(map[string]string),
 		KVStoreOpt:               make(map[string]string),
@@ -991,6 +1000,7 @@ func (c *DaemonConfig) Populate() {
 		c.ToFQDNsMinTTL = defaults.ToFQDNsMinTTL
 	}
 	c.ToFQDNsProxyPort = viper.GetInt(ToFQDNsProxyPort)
+	c.ToFQDNsMaxIPsPerHost = viper.GetInt(ToFQDNsMaxIPsPerHost)
 
 	// Map options
 	if m := viper.GetStringMapString(ContainerRuntimeEndpoint); len(m) != 0 {


### PR DESCRIPTION
The minimal TTL for DNS entries in the cache is deliberately long with 1 week
per default. This is done to accommodate long-lived, persistent connections.
On the other end of the spectrum are workloads which perform short-lived
connections in repetition to FQDNs which are backed by a large number of IP
addresses (e.g. AWS S3). Such workloads can grow the number of IPs mapping to
an FQDN quickly. In order to limit the number of IP addresses that map a
particular FQDN, each FQDN per endpoint has a max capacity of IPs that are
being maintained (default: 50). Once the capacity is exceeded, the oldest
entries are automatically expired from the cache. This capacity can be changed
using the `--tofqdn-max-ip-per-hostname` option.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6788)
<!-- Reviewable:end -->
