### PR TITLE
daemon: syncLBMapsWithK8s - delete k8s service once if not found

### DIFF
--- a/daemon/loadbalancer.go
+++ b/daemon/loadbalancer.go
@@ -230,20 +230,20 @@ func (d *Daemon) svcDeleteByFrontend(frontend *loadbalancer.L3n4Addr) error {
 }
 
 func (d *Daemon) svcDelete(svc *loadbalancer.LBSVC) error {
-	if err := d.svcDeleteBPF(svc); err != nil {
+	if err := d.svcDeleteBPF(svc.FE); err != nil {
 		return err
 	}
 	d.loadBalancer.DeleteService(svc)
 	return nil
 }
 
-func (d *Daemon) svcDeleteBPF(svc *loadbalancer.LBSVC) error {
-	log.WithField(logfields.ServiceName, svc.FE.String()).Debug("deleting service from BPF maps")
+func (d *Daemon) svcDeleteBPF(svc loadbalancer.L3n4AddrID) error {
+	log.WithField(logfields.ServiceName, svc.String()).Debug("deleting service from BPF maps")
 	var svcKey lbmap.ServiceKey
-	if !svc.FE.IsIPv6() {
-		svcKey = lbmap.NewService4Key(svc.FE.IP, svc.FE.Port, 0)
+	if !svc.IsIPv6() {
+		svcKey = lbmap.NewService4Key(svc.IP, svc.Port, 0)
 	} else {
-		svcKey = lbmap.NewService6Key(svc.FE.IP, svc.FE.Port, 0)
+		svcKey = lbmap.NewService6Key(svc.IP, svc.Port, 0)
 	}
 
 	svcKey.SetBackend(0)
@@ -260,10 +260,10 @@ func (d *Daemon) svcDeleteBPF(svc *loadbalancer.LBSVC) error {
 	// ServiceKeys are unique by their slave number, which corresponds to the number of backends. Delete each of these.
 	for i := numBackends; i > 0; i-- {
 		var slaveKey lbmap.ServiceKey
-		if !svc.FE.IsIPv6() {
-			slaveKey = lbmap.NewService4Key(svc.FE.IP, svc.FE.Port, i)
+		if !svc.IsIPv6() {
+			slaveKey = lbmap.NewService4Key(svc.IP, svc.Port, i)
 		} else {
-			slaveKey = lbmap.NewService6Key(svc.FE.IP, svc.FE.Port, i)
+			slaveKey = lbmap.NewService6Key(svc.IP, svc.Port, i)
 		}
 		log.WithFields(logrus.Fields{
 			"idx.backend": i,
@@ -275,7 +275,7 @@ func (d *Daemon) svcDeleteBPF(svc *loadbalancer.LBSVC) error {
 		}
 	}
 
-	log.WithField(logfields.ServiceID, svc.FE.ID).Debug("done deleting service slaves, now deleting master service")
+	log.WithField(logfields.ServiceID, svc.ID).Debug("done deleting service slaves, now deleting master service")
 	if err := lbmap.DeleteService(svcKey); err != nil {
 		return fmt.Errorf("deleting service failed for %s: %s", svcKey, err)
 	}
@@ -632,7 +632,7 @@ func (d *Daemon) SyncLBMap() error {
 	// Clean services and rev nats from BPF maps that failed to be restored.
 	for _, svc := range failedSyncSVC {
 		log.WithField(logfields.Object, logfields.Repr(svc.FE)).Debug("Unable to restore, so removing service")
-		if err := d.svcDeleteBPF(&svc); err != nil {
+		if err := d.svcDeleteBPF(svc.FE); err != nil {
 			log.WithError(err).WithField(logfields.Object, logfields.Repr(svc.FE)).Warn("Unable to clean service from BPF map")
 		}
 	}
@@ -672,7 +672,7 @@ func (d *Daemon) SyncLBMap() error {
 // elsewhere it needed. Returns an error if any issues occur dumping BPF maps
 // or deleting entries from BPF maps.
 func (d *Daemon) syncLBMapsWithK8s() error {
-	k8sDeletedServices := []loadbalancer.LBSVC{}
+	k8sDeletedServices := map[string]loadbalancer.L3n4AddrID{}
 
 	// Maps service IDs to whether they are IPv6 (true) or IPv4 (false).
 	k8sDeletedRevNATS := make(map[loadbalancer.ServiceID]bool)
@@ -711,7 +711,7 @@ func (d *Daemon) syncLBMapsWithK8s() error {
 		frontendAddress := svc.FE.L3n4Addr.StringWithProtocol()
 		if _, ok := k8sServicesFrontendAddresses[frontendAddress]; !ok {
 			scopedLog.Debug("service in BPF maps is not managed by K8s; will delete it from BPF maps")
-			k8sDeletedServices = append(k8sDeletedServices, *svc)
+			k8sDeletedServices[frontendAddress] = svc.FE
 			continue
 		}
 		scopedLog.Debug("service from BPF maps is managed by K8s; will not delete it from BPF maps")
@@ -736,9 +736,9 @@ func (d *Daemon) syncLBMapsWithK8s() error {
 	// Delete map entries from BPF which don't exist in list of Kubernetes
 	// services.
 	for _, svc := range k8sDeletedServices {
-		svcLogger := log.WithField(logfields.Object, logfields.Repr(svc.FE))
+		svcLogger := log.WithField(logfields.Object, logfields.Repr(svc))
 		svcLogger.Debug("removing service because it was not synced from Kubernetes")
-		if err := d.svcDeleteBPF(&svc); err != nil {
+		if err := d.svcDeleteBPF(svc); err != nil {
 			bpfDeleteErrors = append(bpfDeleteErrors, err)
 		}
 	}


### PR DESCRIPTION
As lbmap.DumpServiceMapsToUserspace returns a list of backend services,
this list of backend services can contain duplicated entries as BPF lb
map can contain multiple entries for the same service as showned from the
following log messages:

```
level=debug msg="parsing service mapping" bpfMapKey="10.98.234.114:9125" bpfMapValue="0.0.0.0:0 (0)" subsys=map-lb
level=debug msg="converting ServiceKey and ServiceValue to frontend and backend" obj="0.0.0.0:0 (0)" serviceID="10.98.234.114:9125" subsys=map-lb
level=debug msg="creating L3n4Addr for ServiceKey" serviceID="10.98.234.114:9125" subsys=map-lb
level=debug msg="adding frontend and backend to SVCMap" backend="0.0.0.0:0, weight: 0" backendIndex=0 frontend="10.98.234.114:9125" subsys=loadbalancer
level=debug msg="parsing service mapping" bpfMapKey="10.98.234.114:9125" bpfMapValue="10.10.1.222:9125 (29)" subsys=map-lb
level=debug msg="converting ServiceKey and ServiceValue to frontend and backend" obj="10.10.1.222:9125 (29)" serviceID="10.98.234.114:9125" subsys=map-lb
```

In order to correctly remove this list of services that are no longer
being managed by k8s one should use a Set to avoid trying to delete
multiple times the same LB service which results in controller errors
such as:

```
msg="Controller run failed" consecutiveErrors=2 error="Errors deleting BPF map entries: key 10.98.234.114:42275 is not in lbmap...
```

Fixes: cc4be8e37107 ("daemon: sync BPF maps with in-memory K8s service maps")
Signed-off-by: André Martins <andre@cilium.io>

Fixes https://github.com/cilium/cilium/issues/6779

```release-note
On cilium-agent initialization correctly delete kubernetes services from BPF if those services are no longer being managed by kubernetes.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6794)
<!-- Reviewable:end -->
