### PR TITLE
Fix panic in node datapath when IPv4 allocation CIDR is nil

### DIFF
--- a/pkg/datapath/fake/node_addressing.go
+++ b/pkg/datapath/fake/node_addressing.go
@@ -26,6 +26,32 @@ type fakeNodeAddressing struct {
 	ipv4 addressFamily
 }
 
+// NewIPv6OnlyNodeAddressing returns a new fake node addressing where IPv4 is
+// disabled
+func NewIPv6OnlyNodeAddressing() datapath.NodeAddressing {
+	return &fakeNodeAddressing{
+		ipv4: addressFamily{},
+		ipv6: addressFamily{
+			router:          net.ParseIP("cafe::2"),
+			primaryExternal: net.ParseIP("cafe::1"),
+			allocCIDR:       cidr.MustParseCIDR("cafe::/96"),
+		},
+	}
+}
+
+// NewIPv4OnlyNodeAddressing returns a new fake node addressing where IPv6 is
+// disabled
+func NewIPv4OnlyNodeAddressing() datapath.NodeAddressing {
+	return &fakeNodeAddressing{
+		ipv4: addressFamily{
+			router:          net.ParseIP("1.1.1.2"),
+			primaryExternal: net.ParseIP("1.1.1.1"),
+			allocCIDR:       cidr.MustParseCIDR("1.1.1.0/24"),
+		},
+		ipv6: addressFamily{},
+	}
+}
+
 // NewNodeAddressing returns a new fake node addressing
 func NewNodeAddressing() datapath.NodeAddressing {
 	return &fakeNodeAddressing{

--- a/pkg/datapath/linux/node_test.go
+++ b/pkg/datapath/linux/node_test.go
@@ -62,14 +62,16 @@ func (s *linuxTestSuite) TestCreateNodeRoute(c *check.C) {
 	nodeHandler := NewNodeHandler(dpConfig, fakeNodeAddressing)
 
 	c1 := cidr.MustParseCIDR("10.10.0.0/16")
-	generatedRoute := nodeHandler.(*linuxNodeHandler).createNodeRoute(c1)
+	generatedRoute, err := nodeHandler.(*linuxNodeHandler).createNodeRoute(c1)
+	c.Assert(err, check.IsNil)
 	c.Assert(generatedRoute.Prefix, checker.DeepEquals, *c1.IPNet)
 	c.Assert(generatedRoute.Device, check.Equals, dpConfig.HostDevice)
 	c.Assert(*generatedRoute.Nexthop, checker.DeepEquals, fakeNodeAddressing.IPv4().Router())
 	c.Assert(generatedRoute.Local, checker.DeepEquals, fakeNodeAddressing.IPv4().Router())
 
 	c1 = cidr.MustParseCIDR("beef:beef::/48")
-	generatedRoute = nodeHandler.(*linuxNodeHandler).createNodeRoute(c1)
+	generatedRoute, err = nodeHandler.(*linuxNodeHandler).createNodeRoute(c1)
+	c.Assert(err, check.IsNil)
 	c.Assert(generatedRoute.Prefix, checker.DeepEquals, *c1.IPNet)
 	c.Assert(generatedRoute.Device, check.Equals, dpConfig.HostDevice)
 	c.Assert(*generatedRoute.Nexthop, checker.DeepEquals, fakeNodeAddressing.IPv6().Router())


### PR DESCRIPTION
This is a bug in master, no backports beyond 1.4 are needed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6798)
<!-- Reviewable:end -->
