### PR TITLE
pkg/endpoint: restore endpoints that were being regenerated

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1171,7 +1171,7 @@ func FilterEPDir(dirFiles []os.FileInfo) []string {
 	for _, file := range dirFiles {
 		if file.IsDir() {
 			_, err := strconv.ParseUint(file.Name(), 10, 16)
-			if err == nil || strings.HasSuffix(file.Name(), "_next_fail") {
+			if err == nil || strings.HasSuffix(file.Name(), "_next") || strings.HasSuffix(file.Name(), "_next_fail") {
 				eptsID = append(eptsID, file.Name())
 			}
 		}


### PR DESCRIPTION
If cilium-agent got terminated while an endpoint was being created for
the first time, Cilium could not restore that endpoint from previous
life as the endpoint was never considered "alive" in the first place.

Signed-off-by: André Martins <andre@cilium.io>


Do we need to backport to 1.3?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6799)
<!-- Reviewable:end -->
