### PR TITLE
endpoint: Fix old endpoint identity release

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2077,16 +2077,8 @@ func (e *Endpoint) identityLabelsChanged(owner Owner, myChangeRev int) error {
 
 	// If endpoint has an old identity, defer release of it to the end of
 	// the function after the endpoint structured has been unlocked again
-	if e.SecurityIdentity != nil {
-		oldIdentity := e.SecurityIdentity
-		defer func() {
-			_, err := cache.Release(oldIdentity)
-			if err != nil {
-				elog.WithFields(logrus.Fields{logfields.Identity: oldIdentity.ID}).
-					WithError(err).Warn("BUG: Unable to release old endpoint identity")
-			}
-		}()
-
+	oldIdentity := e.SecurityIdentity
+	if oldIdentity != nil {
 		// The identity of the endpoint is changing, delay the use of
 		// the identity by a grace period to give all other cluster
 		// nodes a chance to adjust their policies first. This requires
@@ -2119,6 +2111,14 @@ func (e *Endpoint) identityLabelsChanged(owner Owner, myChangeRev int) error {
 		Debug("Assigned new identity to endpoint")
 
 	e.SetIdentity(identity)
+
+	if oldIdentity != nil {
+		_, err := cache.Release(oldIdentity)
+		if err != nil {
+			elog.WithFields(logrus.Fields{logfields.Identity: oldIdentity.ID}).
+				WithError(err).Warn("Unable to release old endpoint identity")
+		}
+	}
 
 	readyToRegenerate := false
 


### PR DESCRIPTION
The old identity release logic mistakenly released the identity in some of the
error paths which could lead to an endpoint identity no longer being reference
counted.

Fixes: #6308

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6808)
<!-- Reviewable:end -->
