### PR TITLE
Fix panic in idpool and remove suspicious cache refresh

### DIFF
--- a/pkg/idpool/idpool.go
+++ b/pkg/idpool/idpool.go
@@ -15,7 +15,6 @@
 package idpool
 
 import (
-	"fmt"
 	"math/rand"
 	"strconv"
 	"time"
@@ -92,11 +91,6 @@ func NewIDPool(minID ID, maxID ID) *IDPool {
 	p.FinishRefresh()
 
 	return p
-}
-
-// Dump returns the IDPool as formatted structure for debugging
-func (p *IDPool) Dump() string {
-	return fmt.Sprintf("pool: %+v, cache: %+v", p, p.nextIDCache)
 }
 
 // StartRefresh creates a new cache backing the pool.

--- a/pkg/idpool/idpool_test.go
+++ b/pkg/idpool/idpool_test.go
@@ -99,51 +99,6 @@ func (s *IDPoolTestSuite) TestInsertRemoveIDs(c *C) {
 	c.Assert(actualIDs, checker.DeepEquals, evenIDs)
 }
 
-func (s *IDPoolTestSuite) TestRefresh(c *C) {
-	minID, maxID := 1, 5
-	p := NewIDPool(ID(minID), ID(maxID))
-
-	p.StartRefresh()
-
-	// Lease all ids from the current cache.
-	for i := minID; i <= maxID; i++ {
-		id := p.LeaseAvailableID()
-		c.Assert(id, Not(Equals), NoID)
-	}
-
-	// Delete even-numbered ids from the next cache.
-	for i := minID; i <= maxID; i++ {
-		if i%2 == 0 {
-			c.Assert(p.Remove(ID(i)), Equals, true)
-		}
-	}
-
-	// We should be out of IDs until we finish the refresh.
-	id := p.LeaseAvailableID()
-	c.Assert(id, Equals, NoID)
-
-	p.FinishRefresh()
-
-	// Check we can only lease the remaining
-	// odd-numbered ids from the current cache.
-	expected := make([]int, 0)
-	actual := make([]int, 0)
-	for i := minID; i <= maxID; i++ {
-		if i%2 != 0 {
-			id := p.LeaseAvailableID()
-			c.Assert(id, Not(Equals), NoID)
-			actual = append(actual, int(id))
-			expected = append(expected, int(i))
-		}
-	}
-	// We should be out of IDs.
-	id = p.LeaseAvailableID()
-	c.Assert(id, Equals, NoID)
-
-	sort.Ints(actual)
-	c.Assert(actual, checker.DeepEquals, expected)
-}
-
 func (s *IDPoolTestSuite) TestReleaseID(c *C) {
 	minID, maxID := 1, 5
 	p := NewIDPool(ID(minID), ID(maxID))

--- a/pkg/kvstore/allocator/cache.go
+++ b/pkg/kvstore/allocator/cache.go
@@ -93,11 +93,6 @@ func (c *cache) getLogger() *logrus.Entry {
 	})
 }
 
-func (c *cache) restart(a *Allocator) error {
-	c.stop()
-	return c.startAndWait(a)
-}
-
 func (c *cache) keyToID(key string, deleteInvalid bool) idpool.ID {
 	if !strings.HasPrefix(key, c.prefix) {
 		invalidKey(key, c.prefix, deleteInvalid)
@@ -132,7 +127,6 @@ func (c *cache) start(a *Allocator) waitChan {
 	c.nextCache = idMap{}
 	c.nextKeyCache = keyMap{}
 	c.mutex.Unlock()
-	a.idPool.StartRefresh()
 
 	c.stopWatchWg.Add(1)
 
@@ -151,7 +145,6 @@ func (c *cache) start(a *Allocator) waitChan {
 					c.cache = c.nextCache
 					c.keyCache = c.nextKeyCache
 					c.mutex.Unlock()
-					a.idPool.FinishRefresh()
 
 					// report that the list operation has
 					// been completed and the allocator is


### PR DESCRIPTION
This PR fixes #6632

It does so by removing erroneous index logic which can get out of sync on removal.

It also removes the cache refresh logic which is likely buggy as well. We never found evidence in logfiles that the allocator failure watermark was reached so the refresh only adds complexity to the code without having proven itself.

Fixes: #6632

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6811)
<!-- Reviewable:end -->
