### PR TITLE
Test: Services wait until all endpoints are ready.

### DIFF
--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -246,6 +246,9 @@ var _ = Describe("K8sServicesTest", func() {
 
 			err := kubectl.WaitforPods(helpers.DefaultNamespace, "", helpers.HelperTimeout)
 			Expect(err).To(BeNil(), "Pods are not ready after timeout")
+
+			err = kubectl.CiliumEndpointWaitReady()
+			Expect(err).To(BeNil(), "Endpoints are not ready after timeout")
 		})
 
 		AfterAll(func() {


### PR DESCRIPTION
Wait until all endpoints are ready in the beforeAll to do not get
invalid CEP resources in the Eventually clause.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6813)
<!-- Reviewable:end -->
