### PR TITLE
Test: Assertion helper change order.

### DIFF
--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -118,7 +118,8 @@ func ProvisionInfraPods(vm *helpers.Kubectl) {
 	default:
 	}
 
-	ExpectCiliumReady(vm)
 	ExpectETCDOperatorReady(vm)
+	Expect(vm.WaitKubeDNS()).To(BeNil(), "KubeDNS is not ready after timeout")
+	ExpectCiliumReady(vm)
 	ExpectKubeDNSReady(vm)
 }


### PR DESCRIPTION
At the moment, Cilium is validated that all is ok before etcd pods and
the dns pods are ready. So Cilium can be restarted due timeoUt on etcd
connection and pre-flight checks does not happens afterwards.

With this change we make sure that Cilium is installed correctly after
etcd-operator and the pre-flight errors are ok before doing any test.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

Please ensure your pull request adheres to the following guidelines:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6814)
<!-- Reviewable:end -->
