### PR TITLE
cilium: auto-detect when kernel has ipv6 compiled out and set enable-ipv6 to false

### DIFF
--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -223,6 +223,12 @@ func checkMinRequirements() {
 			"version is %s; kernel version that is running is: %s", minKernelVer, kernelVersion)
 	}
 
+	if option.Config.EnableIPv6 {
+		if _, err := os.Stat("/proc/net/if_inet6"); os.IsNotExist(err) {
+			log.Fatalf("kernel: ipv6 is enabled in agent but ipv6 is either disabled or not compiled in the kernel")
+		}
+	}
+
 	if filePath, err := exec.LookPath("clang"); err != nil {
 		log.WithError(err).Fatal("clang: NOT OK")
 	} else {


### PR DESCRIPTION

Fixes: #6815

Signed-off-by: Nirmoy Das <ndas@suse.de>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6816)
<!-- Reviewable:end -->
