### PR TITLE
client: Use one err variable in client with timeout

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -92,7 +92,7 @@ func NewDefaultClientWithTimeout(timeout time.Duration) (*Client, error) {
 
 		c, err = NewDefaultClient()
 		if err == nil {
-			_, err := c.Daemon.GetConfig(nil)
+			_, err = c.Daemon.GetConfig(nil)
 			if err == nil {
 				break
 			}


### PR DESCRIPTION
Before this change, `GetConfig` call in `NewDefaultClientWithTimeout`
was using its own `err` variable, which was never returned and nil error
was returned instead.

Fixes: d48af6ab5c28 ("pkg/client: wait until the client has connectivity
with daemon")
Fixes: #6801

Signed-off-by: Michal Rostecki <mrostecki@suse.de>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6817)
<!-- Reviewable:end -->
