### PR TITLE
Vagrantfiles: disable VirtualBox audio

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -119,6 +119,9 @@ Vagrant.configure(2) do |config|
         vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
         vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
 
+        # Prevent VirtualBox from interfering with host audio stack
+        vb.customize ["modifyvm", :id, "--audio", "none"]
+
         config.vm.box = "cilium/ubuntu-dev"
         config.vm.box_version = "126"
         vb.memory = ENV['VM_MEMORY'].to_i

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -34,6 +34,9 @@ Vagrant.configure("2") do |config|
             vb.cpus = $CPU
             vb.memory= $MEMORY
             vb.linked_clone = true
+
+            # Prevent VirtualBox from interfering with host audio stack
+            vb.customize ["modifyvm", :id, "--audio", "none"]
         end
 
         server.vm.box =  "#{$SERVER_BOX}"
@@ -63,6 +66,9 @@ Vagrant.configure("2") do |config|
                 vb.cpus = $CPU
                 vb.memory= $MEMORY
                 vb.linked_clone = true
+
+                # Prevent VirtualBox from interfering with host audio stack
+                vb.customize ["modifyvm", :id, "--audio", "none"]
             end
 
             server.vm.box =  "#{$SERVER_BOX}"


### PR DESCRIPTION
With recent versions of macOS, when Vagrant is used to launch VirtualBox VMs, as
the VM is being provisioned, the microphone is activated. This degrades audio
quality when certain headphones are in use while the VMs are being launched,
which degrades the music-listening while developing Cilium. Given that audio is
not needed in the testing / development environments for Cilium, disable audio
support in VirtualBox accordingly.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6828)
<!-- Reviewable:end -->
