### PR TITLE
backporting: Accept multiple commits in 'cherry-pick'

### DIFF
--- a/contrib/backporting/cherry-pick
+++ b/contrib/backporting/cherry-pick
@@ -1,22 +1,34 @@
 #!/bin/sh
 set -e
-if [ $# -ne 1 ]; then
-  echo "Usage: $0 <commit-id>"
+
+cherry_pick () {
+  CID=$1
+  REM=`git remote -v | grep "github.com.cilium/cilium" | head -n1 | cut -f1`
+  BRANCHES=`git branch -q -r --contains $CID $REM/master 2> /dev/null`
+  if ! echo ${BRANCHES} | grep -q ".*$REM/master.*"; then
+    echo "Commit $CID not in $REM/master!"
+    exit 1
+  fi
+  TMPF=`mktemp cp.XXXXXX`
+  FROM=`git show --pretty=email $CID | head -n 2 | grep "From: "`
+  FULL_ID=`git show $CID | head -n 1 | cut -f 2 -d ' '`
+  git format-patch -1 $FULL_ID --stdout | sed '/^$/Q' > $TMPF
+  echo "" >> $TMPF
+  echo "[ upstream commit $FULL_ID ]" >> $TMPF
+  git format-patch -1 $FULL_ID --stdout | sed -n '/^$/,/$a/p' >> $TMPF
+  git am -3 --signoff $TMPF
+  rm $TMPF
+}
+
+main () {
+  for CID in "$@"; do
+    cherry_pick "$CID"
+  done
+}
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <commit-id> [commit-id ...]"
   exit 1
 fi
-CID=$1
-REM=`git remote -v | grep "github.com.cilium/cilium" | head -n1 | cut -f1`
-BRANCHES=`git branch -q -r --contains $CID $REM/master 2> /dev/null`
-if ! echo ${BRANCHES} | grep -q ".*$REM/master.*"; then
-  echo "Commit $CID not in $REM/master!"
-  exit 1
-fi
-TMPF=`mktemp cp.XXXXXX`
-FROM=`git show --pretty=email $CID | head -n 2 | grep "From: "`
-FULL_ID=`git show $CID | head -n 1 | cut -f 2 -d ' '`
-git format-patch -1 $FULL_ID --stdout | sed '/^$/Q' > $TMPF
-echo "" >> $TMPF
-echo "[ upstream commit $FULL_ID ]" >> $TMPF
-git format-patch -1 $FULL_ID --stdout | sed -n '/^$/,/$a/p' >> $TMPF
-git am -3 --signoff $TMPF
-rm $TMPF
+
+main "$@"


### PR DESCRIPTION
Update the 'cherry-pick' commit to accept multiple commits, which it
will attempt to apply one-by-one until either they all apply or a patch
fails to apply. When a patch fails to apply, it will terminate and stop
applying the rest of the commits in the list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6834)
<!-- Reviewable:end -->
