### PR TITLE
Don't put empty node ips into special identities

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -790,41 +790,57 @@ func (d *Daemon) syncLXCMap() error {
 	specialIdentities := []identity.IPIdentityPair{}
 
 	if option.Config.EnableIPv4 {
+		ip := node.GetInternalIPv4()
+		if len(ip) > 0 {
+			specialIdentities = append(specialIdentities,
+				identity.IPIdentityPair{
+					IP: ip,
+					ID: identity.ReservedIdentityHost,
+				})
+		}
+
+		ip = node.GetExternalIPv4()
+		if len(ip) > 0 {
+			specialIdentities = append(specialIdentities,
+				identity.IPIdentityPair{
+					IP: ip,
+					ID: identity.ReservedIdentityHost,
+				})
+		}
+
 		specialIdentities = append(specialIdentities,
-			[]identity.IPIdentityPair{
-				{
-					IP: node.GetInternalIPv4(),
-					ID: identity.ReservedIdentityHost,
-				},
-				{
-					IP: node.GetExternalIPv4(),
-					ID: identity.ReservedIdentityHost,
-				},
-				{
-					IP:   net.IPv4zero,
-					Mask: net.CIDRMask(0, net.IPv4len*8),
-					ID:   identity.ReservedIdentityWorld,
-				},
-			}...)
+			identity.IPIdentityPair{
+				IP:   net.IPv4zero,
+				Mask: net.CIDRMask(0, net.IPv4len*8),
+				ID:   identity.ReservedIdentityWorld,
+			})
 	}
 
 	if option.Config.EnableIPv6 {
+		ip := node.GetIPv6()
+		if len(ip) > 0 {
+			specialIdentities = append(specialIdentities,
+				identity.IPIdentityPair{
+					IP: ip,
+					ID: identity.ReservedIdentityHost,
+				})
+		}
+
+		ip = node.GetIPv6Router()
+		if len(ip) > 0 {
+			specialIdentities = append(specialIdentities,
+				identity.IPIdentityPair{
+					IP: ip,
+					ID: identity.ReservedIdentityHost,
+				})
+		}
+
 		specialIdentities = append(specialIdentities,
-			[]identity.IPIdentityPair{
-				{
-					IP: node.GetIPv6(),
-					ID: identity.ReservedIdentityHost,
-				},
-				{
-					IP: node.GetIPv6Router(),
-					ID: identity.ReservedIdentityHost,
-				},
-				{
-					IP:   net.IPv6zero,
-					Mask: net.CIDRMask(0, net.IPv6len*8),
-					ID:   identity.ReservedIdentityWorld,
-				},
-			}...)
+			identity.IPIdentityPair{
+				IP:   net.IPv6zero,
+				Mask: net.CIDRMask(0, net.IPv6len*8),
+				ID:   identity.ReservedIdentityWorld,
+			})
 	}
 
 	existingEndpoints, err := lxcmap.DumpToMap()


### PR DESCRIPTION
This change causes `lxcmap-bpf-host-sync` controller to not sync
internal ips until they are set by AllocateInternalIPs in daemon

Fixes: #6737

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6843)
<!-- Reviewable:end -->
