### PR TITLE
datapath/linux: fix updateTunnelMapping when old and new CIDR are nil

### DIFF
--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -97,6 +97,10 @@ func updateTunnelMapping(oldCIDR, newCIDR *cidr.CIDR, oldIP, newIP net.IP, first
 // CIDR and node IP to a new node CIDR and node IP requires to insert/update
 // the new node CIDR.
 func cidrNodeMappingUpdateRequired(oldCIDR, newCIDR *cidr.CIDR, oldIP, newIP net.IP) bool {
+	// node with single IP stack could have nil old and new CIDR
+	if oldCIDR == nil && newCIDR == nil {
+		return false
+	}
 	// Newly announced CIDR
 	if newCIDR != nil && oldCIDR == nil {
 		return true


### PR DESCRIPTION
node with single IP stack can cause below segfault

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x265d554]

goroutine 1 [running]:
github.com/cilium/cilium/pkg/datapath/linux.updateTunnelMapping(0x0, 0x0, 0x0, 0x0, 0x0, 0xc000190b20, 0x10, 0x10, 0xc000cc0101)
	/home/nirmoy/go/src/github.com/cilium/cilium/pkg/datapath/linux/node.go:76 +0x454
github.com/cilium/cilium/pkg/datapath/linux.(*linuxNodeHandler).nodeUpdate(0xc0001d5dc0, 0x0, 0xc000ad8420, 0x0, 0x0)
	/home/nirmoy/go/src/github.com/cilium/cilium/pkg/datapath/linux/node.go:480 +0x68a
github.com/cilium/cilium/pkg/datapath/linux.(*linuxNodeHandler).NodeConfigurationChanged(0xc0001d5dc0, 0x5dc, 0x5aa, 0x1, 0x49ac080, 0x0, 0x0, 0x10001000101, 0x0, 0x0)
	/home/nirmoy/go/src/github.com/cilium/cilium/pkg/datapath/linux/node.go:660 +0x1e1
main.(*Daemon).compileBase(0xc000528c40, 0x0, 0x0)
	/home/nirmoy/go/src/github.com/cilium/cilium/daemon/daemon.go:533 +0x7a9
main.(*Daemon).init(0xc000528c40, 0xc000528c40, 0x20)
	/home/nirmoy/go/src/github.com/cilium/cilium/daemon/daemon.go:675 +0x126
main.NewDaemon(0x300c6a0, 0xc00094c810, 0x1, 0x1, 0xc000827928, 0x11fd242)
	/home/nirmoy/go/src/github.com/cilium/cilium/daemon/daemon.go:1191 +0x1177
main.runDaemon()
	/home/nirmoy/go/src/github.com/cilium/cilium/daemon/daemon_main.go:1062 +0x214
main.glob..func1(0x43bb060, 0xc000948000, 0x0, 0x9)
	/home/nirmoy/go/src/github.com/cilium/cilium/daemon/daemon_main.go:108 +0x30
github.com/cilium/cilium/vendor/github.com/spf13/cobra.(*Command).execute(0x43bb060, 0xc00004c0b0, 0x9, 0x9, 0x43bb060, 0xc00004c0b0)
	/home/nirmoy/go/src/github.com/cilium/cilium/vendor/github.com/spf13/cobra/command.go:766 +0x2cc
github.com/cilium/cilium/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0x43bb060, 0x2fef610, 0x3016ee0, 0x2fef630)
	/home/nirmoy/go/src/github.com/cilium/cilium/vendor/github.com/spf13/cobra/command.go:852 +0x2fd
github.com/cilium/cilium/vendor/github.com/spf13/cobra.(*Command).Execute(0x43bb060, 0x0, 0x0)
	/home/nirmoy/go/src/github.com/cilium/cilium/vendor/github.com/spf13/cobra/command.go:800 +0x2b
main.daemonMain()
	/home/nirmoy/go/src/github.com/cilium/cilium/daemon/daemon_main.go:126 +0x14c
main.main()
	/home/nirmoy/go/src/github.com/cilium/cilium/daemon/main.go:30 +0xc9
nirmoy@chapman:~/go/src/github.com/cilium/cilium> fg
vim /home/nirmoy/go/src/github.com/cilium/cilium/pkg/datapath/linux/node.go
```

Fixes: #6842

Signed-off-by: Nirmoy Das <ndas@suse.de>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6844)
<!-- Reviewable:end -->
