### PR TITLE
cilium: return formatted error on ipsec-key-file open failure

### DIFF
--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -421,7 +421,7 @@ func init() {
 	flags.Bool(option.EnableIPSecName, defaults.EnableIPSec, "Enable IPSec support")
 	option.BindEnv(option.EnableIPSecName)
 
-	flags.StringVar(&option.Config.IPSecKeyFile, "ipsec-key-file", "", "Path to IPSec key file")
+	flags.StringVar(&option.Config.IPSecKeyFile, option.IPSecKeyFileName, "", "Path to IPSec key file")
 
 	flags.String(option.HTTP403Message, "", "Message returned in proxy L7 403 body")
 	flags.MarkHidden(option.HTTP403Message)

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -252,7 +252,7 @@ func DeleteIPSecEndpoint(src, local net.IP) error {
 func LoadIPSecKeysFile(path string) error {
 	file, err := os.Open(path)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to load IPSec Keys File %s: %v", path, err)
 	}
 	defer file.Close()
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -381,6 +381,9 @@ const (
 
 	// EnableIPSecName is the name of the option to enable IPSec
 	EnableIPSecName = "enable-ipsec"
+
+	// IPSecKeyFileName is the name of the option for ipsec key file
+	IPSecKeyFileName = "ipsec-key-file"
 )
 
 // FQDNS variables


### PR DESCRIPTION
Fixes: a7beef597d (cilium: ipsec, import keys via certs file)

Signed-off-by: Nirmoy Das <ndas@suse.de>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6846)
<!-- Reviewable:end -->
