### PR TITLE
Revert "fqdn: Make Rule UUIDs random instead of depending on the labels"

### DIFF
--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -204,7 +204,6 @@ func (d *Daemon) policyAdd(rules policyAPI.Rules, opts *AddOptions, prefixes []*
 			for _, r := range rules {
 				tmp := d.policy.SearchRLocked(r.Labels)
 				if len(tmp) > 0 {
-					d.dnsPoller.StopPollForDNSName(tmp)
 					d.policy.DeleteByLabelsLocked(r.Labels)
 				}
 			}
@@ -212,7 +211,6 @@ func (d *Daemon) policyAdd(rules policyAPI.Rules, opts *AddOptions, prefixes []*
 		if len(opts.ReplaceWithLabels) > 0 {
 			tmp := d.policy.SearchRLocked(opts.ReplaceWithLabels)
 			if len(tmp) > 0 {
-				d.dnsPoller.StopPollForDNSName(tmp)
 				d.policy.DeleteByLabelsLocked(opts.ReplaceWithLabels)
 			}
 		}

--- a/pkg/fqdn/dnspoller_test.go
+++ b/pkg/fqdn/dnspoller_test.go
@@ -32,11 +32,9 @@ func makeRule(key string, dnsNames ...string) *api.Rule {
 			fmt.Sprintf(`{"matchName": "%s"}`, name))
 	}
 
-	rule := `{`
-	if key != "" {
-		rule += fmt.Sprintf(`"labels": [{ "key": "%s" }],`, key)
-	}
-	rule += fmt.Sprintf(`"endpointSelector": {
+	rule := fmt.Sprintf(`{
+	"labels": [{ "key": "%s" }],
+  "endpointSelector": {
     "matchLabels": {
       "class": "xwing"
     }
@@ -48,7 +46,7 @@ func makeRule(key string, dnsNames ...string) *api.Rule {
       ]
     }
   ]
-}`, strings.Join(matchNames, ",\n"))
+}`, key, strings.Join(matchNames, ",\n"))
 	//fmt.Print(rule)
 	return mustParseRule(rule)
 }
@@ -74,11 +72,11 @@ func mustParseRule(rule string) (parsedRule *api.Rule) {
 }
 
 var (
-	// cilium.io dns target, no rule name => no rule labels
-	rule1 = makeRule("", "cilium.io")
+	// cilium.io dns target
+	rule1 = makeRule("rule1", "cilium.io")
 
-	// cilium.io dns target, no rule name => no rule labels
-	rule2 = makeRule("", "cilium.io")
+	// cilium.io dns target
+	rule2 = makeRule("rule2", "cilium.io")
 
 	// cilium.io, github.com dns targets
 	rule3 = makeRule("rule3", "cilium.io", "github.com")
@@ -247,26 +245,15 @@ func (ds *FQDNTestSuite) TestDNSPollerRuleHandling(c *C) {
 		}
 		rulesToDelete := []*api.Rule{}
 		for _, rule := range testCase.rulesToDelete {
-			// Copy the pointer to an added rule if any
-			for i := range testCase.rulesToAdd {
-				if rule == testCase.rulesToAdd[i] {
-					rulesToDelete = append(rulesToDelete, rulesToAdd[i])
-				}
-			}
+			rulesToDelete = append(rulesToDelete, rule.DeepCopy())
 		}
 
 		// add rules and run basic checks
 		poller.MarkToFQDNRules(rulesToAdd)
-		for i, rule := range rulesToAdd {
-			c.Assert(len(getRuleUUIDLabel(rule)), Not(Equals), 0, Commentf("Added a FQDN label to each marked rule"))
-			if i > 0 {
-				c.Assert(getRuleUUIDLabel(rule), Not(Equals), getRuleUUIDLabel(rulesToAdd[0]), Commentf("Each rule must have a unique UUID"))
-			}
+		poller.MarkToFQDNRules(rulesToDelete)
+		for _, rule := range rulesToAdd {
+			c.Assert(len(getUUIDFromRuleLabels(rule)), Not(Equals), 0, Commentf("Added a FQDN label to each marked rule"))
 		}
-		for _, rule := range rulesToDelete {
-			c.Assert(len(getRuleUUIDLabel(rule)), Not(Equals), 0, Commentf("Added a FQDN label to each marked rule"))
-		}
-
 		poller.StartPollForDNSName(rulesToAdd)
 		for i := testCase.lookupIterationsAfterAdd; i > 0; i-- {
 			err := poller.LookupUpdateDNS()
@@ -321,7 +308,7 @@ func (ds *FQDNTestSuite) TestDNSPollerCIDRGeneration(c *C) {
 	poller.StartPollForDNSName(rulesToAdd)
 
 	// store original UUID
-	uuidOrig := getRuleUUIDLabel(rulesToAdd[0])
+	uuidOrig := getUUIDFromRuleLabels(rulesToAdd[0])
 	c.Assert(uuidOrig, Not(Equals), "", Commentf("UUID label not set on rule, or not recovered correctly"))
 
 	// poll DNS once, check that we only generate 1 rule (for 1 IP) and that we
@@ -336,7 +323,7 @@ func (ds *FQDNTestSuite) TestDNSPollerCIDRGeneration(c *C) {
 	c.Assert(generatedRules[0].Egress[0].ToCIDRSet[0].Cidr, Equals, api.CIDR("1.1.1.1/32"), Commentf("Incorrect IP CIDR generated"))
 
 	// Check that the UUID has not changed
-	uuid1 := getRuleUUIDLabel(generatedRules[0])
+	uuid1 := getUUIDFromRuleLabels(generatedRules[0])
 	c.Assert(uuid1, Equals, uuidOrig, Commentf("UUID label has changed on rule since original insert"))
 
 	// poll DNS once, check that we only generate 1 rule (for 1 IP) and that we
@@ -351,7 +338,7 @@ func (ds *FQDNTestSuite) TestDNSPollerCIDRGeneration(c *C) {
 	c.Assert(generatedRules[0].Egress[0].ToCIDRSet[0].Cidr, Equals, api.CIDR("2.2.2.2/32"), Commentf("Incorrect IP CIDR generated"))
 
 	// check that the UUID has not changed
-	uuid2 := getRuleUUIDLabel(generatedRules[0])
+	uuid2 := getUUIDFromRuleLabels(generatedRules[0])
 	c.Assert(uuid2, Equals, uuidOrig, Commentf("UUID label has changed on rule since original insert"))
 	c.Assert(uuid2, Equals, uuid1, Commentf("UUID label has changed on rule since previous generation"))
 }
@@ -377,9 +364,13 @@ func (ds *FQDNTestSuite) TestDNSPollerDropCIDROnReinsert(c *C) {
 		})
 	)
 
-	// Add a fake "generated" CIDR entry, it should not come back later when generated
+	// ensure we strip on MarkToFQDNRules
 	rulesToAdd := []*api.Rule{rule1.DeepCopy()}
+	rulesToAdd[0].Egress[0].ToCIDRSet = append(rulesToAdd[0].Egress[0].ToCIDRSet, api.CIDRRule{Cidr: api.CIDR("2.2.2.2/32")})
 	poller.MarkToFQDNRules(rulesToAdd)
+	c.Assert(len(rulesToAdd[0].Egress[0].ToCIDRSet), Equals, 0, Commentf("existing toCIDRSet section not stripped by MarkToFQDNRules"))
+
+	// Add a fake "generated" CIDR entry, it should not come back later when generated
 	rulesToAdd[0].Egress[0].ToCIDRSet = append(rulesToAdd[0].Egress[0].ToCIDRSet, api.CIDRRule{Cidr: api.CIDR("2.2.2.2/32")})
 	poller.StartPollForDNSName(rulesToAdd)
 	err := poller.LookupUpdateDNS()
@@ -494,9 +485,9 @@ func (ds *FQDNTestSuite) TestDNSPollerUpdatesOnReplace(c *C) {
 	poller.StartPollForDNSName(rules)
 	poller.LookupUpdateDNS()
 
-	// Add another rule with the same FQDN. We should see IPs in-place BEFORE StartPollForDNSName.
+	// re-add. We should see IPs in-place BEFORE StartPollForDNSName.
 	// MarkToFQDNRules adds the IP from the cache
-	rules = []*api.Rule{makeRule("testRule2", "cilium.io")}
+	rules = []*api.Rule{makeRule("testRule", "cilium.io")}
 	poller.MarkToFQDNRules(rules)
 	c.Assert(len(rules[0].Egress), Equals, 1, Commentf("Incorrect number of generated egress rules for testCase with single ToFQDNs entry"))
 	c.Assert(len(rules[0].Egress[0].ToCIDRSet), Equals, 1, Commentf("Generated CIDR count is not the same as ToFQDNs"))
@@ -506,14 +497,14 @@ func (ds *FQDNTestSuite) TestDNSPollerUpdatesOnReplace(c *C) {
 	poller.LookupUpdateDNS()
 
 	// Add 2 rules and poll
-	rules = []*api.Rule{makeRule("testRule3", "cilium.io", "github.com")}
+	rules = []*api.Rule{makeRule("testRule", "cilium.io", "github.com")}
 	poller.MarkToFQDNRules(rules)
 	poller.StartPollForDNSName(rules)
 	poller.LookupUpdateDNS()
 
-	// Add a 2 matchnames, only one overlaps
+	// Add a 2 matchnames without deleting, only one overlaps
 	// MarkToFQDNRules should add only 1 entry
-	rules = []*api.Rule{makeRule("testRule4", "cilium.io", "anotherdomain.com")}
+	rules = []*api.Rule{makeRule("testRule", "cilium.io", "anotherdomain.com")}
 	poller.MarkToFQDNRules(rules)
 	c.Assert(len(rules[0].Egress), Equals, 1, Commentf("Incorrect number of generated egress rules for testCase with single cached ToFQDNs DNS entry"))
 	c.Assert(len(rules[0].Egress[0].ToCIDRSet), Equals, 1, Commentf("Generated CIDR count is not the same as ToFQDNs DNS entries in cache"))
@@ -524,20 +515,20 @@ func (ds *FQDNTestSuite) TestDNSPollerUpdatesOnReplace(c *C) {
 
 	fmt.Printf("%#v\n", poller.IPs)
 	// Add the original 2 matchnames without deleting
-	// MarkToFQDNRules should add 2 entries, as those should be in the poller cache
-	rules = []*api.Rule{makeRule("testRule5", "cilium.io", "github.com")}
+	// MarkToFQDNRules should add only 1 entry
+	rules = []*api.Rule{makeRule("testRule", "cilium.io", "github.com")}
 	poller.MarkToFQDNRules(rules)
 	c.Assert(len(rules[0].Egress), Equals, 1, Commentf("Incorrect number of generated egress rules for testCase with single cached ToFQDNs DNS entry"))
-	c.Assert(len(rules[0].Egress[0].ToCIDRSet), Equals, 2, Commentf("Generated CIDR count is not the same as ToFQDNs DNS entries in cache"))
+	c.Assert(len(rules[0].Egress[0].ToCIDRSet), Equals, 1, Commentf("Generated CIDR count is not the same as ToFQDNs DNS entries in cache"))
 	c.Assert(rules[0].Egress[0].ToCIDRSet[0].Cidr, Equals, api.CIDR("1.1.1.1/32"), Commentf("Incorrect first IP CIDR generated from cache"))
 
 	poller.StartPollForDNSName(rules)
 	poller.LookupUpdateDNS()
 
-	// Add a rule with 1 old matchname
-	// MarkToFQDNRules should add one entry
-	rules = []*api.Rule{makeRule("testRule6", "anotherdomain.com")}
+	// Replace with 1 old matchname without deleting
+	// MarkToFQDNRules should not add an entry
+	rules = []*api.Rule{makeRule("testRule", "anotherdomain.com")}
 	poller.MarkToFQDNRules(rules)
 	c.Assert(len(rules[0].Egress), Equals, 1, Commentf("Incorrect number of generated egress rules for testCase with single cached ToFQDNs DNS entry"))
-	c.Assert(len(rules[0].Egress[0].ToCIDRSet), Equals, 1, Commentf("Generated CIDR count is not the same as ToFQDNs DNS entries in cache"))
+	c.Assert(len(rules[0].Egress[0].ToCIDRSet), Equals, 0, Commentf("Generated CIDR count is not the same as ToFQDNs DNS entries in cache"))
 }

--- a/pkg/fqdn/helpers.go
+++ b/pkg/fqdn/helpers.go
@@ -15,11 +15,14 @@
 package fqdn
 
 import (
+	"crypto/sha512"
+	"fmt"
 	"net"
+	"sort"
+	"strings"
 
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy/api"
-	"github.com/cilium/cilium/pkg/uuid"
 )
 
 // DNSLookupDefaultResolver runs a DNS lookup for every name in dnsNames
@@ -45,16 +48,29 @@ func DNSLookupDefaultResolver(dnsNames []string) (DNSIPs map[string][]net.IP, DN
 }
 
 // getUUIDFromRuleLabels returns the value of the UUID label
-func getRuleUUIDLabel(rule *api.Rule) (uuid string) {
+func getUUIDFromRuleLabels(rule *api.Rule) (uuid string) {
 	return rule.Labels.Get(uuidLabelSearchKey)
 }
 
-// generateUUIDLabel builds a random UUID label that can be used to uniquely identify
-// rules augmented with a "toCIDRSet" based on "toFQDNs".
-func generateUUIDLabel() (id *labels.Label) {
+// generateUUIDLabel builds a UUID label to unique a rule on PolicyAdd, it is
+// consistent over the labels passed in.
+// It sorts a copy of the lbls array, and returns a hash
+// TODO: this function is a frankenstein mix of labels.Labels.SortedList and
+// SHA256Sum, neither of this exist on labels.LabelArray and there is no
+// conversion function that won't be even less efficient. fix
+func generateUUIDLabel(lbls labels.LabelArray) (id *labels.Label) {
+	sorted := make([]string, len(lbls)) // copy uses len(dst) not cap!
+	for _, lbl := range lbls {
+		sorted = append(sorted, lbl.String())
+	}
+	sort.Strings(sorted)
+
+	data := []byte(strings.Join(sorted, ""))
+	uuid := fmt.Sprintf("%x", sha512.Sum512_256(data))
+
 	return &labels.Label{
 		Key:    generatedLabelNameUUID,
-		Value:  uuid.NewUUID().String(),
+		Value:  uuid,
 		Source: labels.LabelSourceCiliumGenerated,
 	}
 }


### PR DESCRIPTION
_Please don't merge this unless we decide we specifically want to. I've put this PR up to run CI so it is quicker to merge_

This reverts commit bb849d602cb497ee712dc82acbca32451d5b9d5f.
The bug this fixed was were rules in a specs field used the same labels and
overwrote each other (last one wins). The backport accidentally included a
different fix related to removing names from the poller when a rule was updated
(which also happens when the poller updates IPs). This fix caused DNS names to
be removed before being re-added on replace, causing the internal copy of the
IPs to be removed and the new updated IPs to be treated as new (even when they
are not). This then triggered policy regenerations on every poller update,
using up CPU.
The revert re-introduces two bugs:
- CNP specs fields are handled incorrectly, and will cause rules to dissapear.
- A minor leak will exist in the agent for DNS names being polled, where the
IPs seen will never be removed. This is 4 or 16 bytes per IP, and will likely
never be more than a few kilobytes in size.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6848)
<!-- Reviewable:end -->
