### PR TITLE
doc: Update ClusterMesh documentation for 1.4

### DIFF
--- a/Documentation/concepts.rst
+++ b/Documentation/concepts.rst
@@ -610,6 +610,15 @@ This is typically achieved using two methods:
 There are two possible approaches to performing network forwarding for
 container-to-container traffic:
 
+Cluster Mesh
+============
+
+Cluster mesh extends the networking datapath across multiple clusters. It
+allows endpoints in all connected clusters to communicate while providing full
+policy enforcement. Load-balancing is available via Kubernetes annotations.
+
+See :ref:`gs_clustermesh` for instructions on how to set up cluster mesh.
+
 Container Communication with External Hosts
 ===========================================
 

--- a/Documentation/gettingstarted/clustermesh.rst
+++ b/Documentation/gettingstarted/clustermesh.rst
@@ -2,115 +2,252 @@
 
 .. _gs_clustermesh:
 
-****************************
-Setting up the Cluster Mesh
-****************************
+***********************
+Setting up Cluster Mesh
+***********************
 
 This is a step-by-step guide on how to build a mesh of Kubernetes clusters by
-connecting them together and enabling pod-to-pod connectivity across all
-clusters while providing label-based security policies.
-
-.. note::
-
-    This is a beta feature introduced in Cilium 1.2.
+connecting them together, enabling pod-to-pod connectivity across all clusters,
+define global services to load-balance between clusters and enforce security
+policies to restrict access.
 
 Prerequisites
 #############
 
-* All nodes in all clusters must have IP connectivity. This requirement is
-  typically met by establishing peering between the networks of the machines
-  forming each cluster.
+* PodCIDR ranges in all clusters must be non-conflicting.
 
-* No encryption is performed by Cilium for the connectivity between nodes.
-  The feature is on the roadmap (`details
-  <https://github.com/cilium/cilium/issues/504>`_) but not implemented yet.  It
-  is however possible to set up IPSec-based encryption between all nodes using
-  a standard guide. It is also possible and common to establish VPNs between
-  networks if clusters are connected across untrusted networks.
+* This guide and the referenced scripts assume that Cilium was installed using
+  the :ref:`k8s_install_etcd_operator` instructions which leads to etcd being
+  managed by Cilium using etcd-operator. You can use any way to manage etcd but
+  you will have to adjust some of the scripts to account for different secret
+  names and adjust the LoadBalancer to expose the etcd pods.
 
-* All worker nodes must have connectivity to the etcd clusters of all remote
-  clusters. Security is implemented by connecting to etcd using TLS/SSL
-  certificates.
+* Nodes in all clusters must have IP connectivity between each other. This
+  requirement is typically met by establishing peering or VPN tunnels between
+  the networks of the nodes of each cluster.
+
+* All nodes must have a unique IP address assigned them. Node IPs of clusters
+  being connected together may not conflict with each other.
 
 * Cilium must be configured to use etcd as the kvstore. Consul is not supported
-  by cluster mesh.
+  by cluster mesh at this point.
 
-Getting Started
-###############
+* It is highly recommended to use a TLS protected etcd cluster with Cilium. The
+  server certificate of etcd must whitelist the host name ``*.mesh.cilium.io``.
+  If you are using the ``cilium-etcd-operator`` as set up in the
+  :ref:`k8s_install_etcd_operator` instructions then this is automatically
+  taken care of.
 
-Step 1: Prepare the individual clusters
-=======================================
+* The network between clusters must allow the inter-cluster communication. The
+  exact ports are documented in the :ref:`firewall_requirements` section.
 
-Setting the cluster name and ID
--------------------------------
+
+Prepare the clusters
+####################
+
+Specify the cluster name and ID
+===============================
 
 Each cluster must be assigned a unique human-readable name. The name will be
-used to group nodes of a cluster. The cluster name is specified with the
-``--cluster-name=NAME`` argument or ``cluster-name`` ConfigMap option.
+used to group nodes of a cluster together. The cluster name is specified with
+the ``--cluster-name=NAME`` argument or ``cluster-name`` ConfigMap option.
 
 To ensure scalability of identity allocation and policy enforcement, each
-cluster continues to manage its own identity allocation. In order to guarantee
-compatibility with identities across clusters, each cluster is configured with
-a unique cluster ID configured with the ``--cluster-id=ID`` argument or
-``cluster-id`` ConfigMap option.
+cluster continues to manage its own security identity allocation. In order to
+guarantee compatibility with identities across clusters, each cluster is
+configured with a unique cluster ID configured with the ``--cluster-id=ID``
+argument or ``cluster-id`` ConfigMap option. The value must be between 1 and
+255.
 
 .. code:: bash
 
-   $ kubectl -n kube-system edit cm cilium-config
-   [ add/edit ]
-   cluster-name: default
-   cluster-id: 1
+   kubectl -n kube-system edit cm cilium-config
+   [ ... add/edit ... ]
+   cluster-name: cluster1
+   cluster-id: "1"
 
-Provide unique values for the cluster name and ID for each cluster.
+Repeat this step for each cluster.
 
-Step 2: Create Secret to provide access to remote etcd
-------------------------------------------------------
+Expose the Cilium etcd to other clusters
+========================================
 
-Clusters are connected together by providing connectivity information to the
-etcd key-value store to each individual cluster. This allows Cilium to
-synchronize state between clusters and provide cross-cluster connectivity and
-policy enforcement.
+The Cilium etcd must be exposed to other clusters. There are many ways to
+achieve this. The method documented in this guide will work with cloud
+providers that implement the Kubernetes ``LoadBalancer`` service type:
 
-The connectivity details of a remote etcd typically includes certificates to
-enable use of TLS which is why the entire ClusterMesh configuration is stored
-in a Kubernetes Secret.
+.. tabs::
+  .. group-tab:: GCP
 
-1. Create an etcd configuration file for each remote cluster you want to
-   connect to. The syntax is that the official etcd configuration file and
-   identical to the syntax used in the ``cilium-config`` ConfigMap.
+    .. parsed-literal::
 
-2. Create a secret ``cilium-clustermesh`` from all configuration files you have
-   created:
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: cilium-etcd-external
+        annotations:
+          cloud.google.com/load-balancer-type: "Internal"
+      spec:
+        type: LoadBalancer
+        ports:
+        - port: 2379
+        selector:
+          app: etcd
+          etcd_cluster: cilium-etcd
+          io.cilium/app: etcd-operator
+
+  .. group-tab:: AWS
+
+    .. parsed-literal::
+
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: cilium-etcd-external
+        annotations:
+          service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
+      spec:
+        type: LoadBalancer
+        ports:
+        - port: 2379
+        selector:
+          app: etcd
+          etcd_cluster: cilium-etcd
+          io.cilium/app: etcd-operator
+
+The example used here exposes the etcd cluster as managed by
+``cilium-etcd-operator`` installed by the standard installation instructions as
+an internal service which means that it is only exposed inside of a VPC and not
+publicly accessible outside of the VPC. It is recommended to use a static IP
+for the ServiceIP to avoid requiring to update the IP mapping as done in one of
+the later steps.
+
+If you are running the cilium-etcd-operator you can simply apply the following
+service to expose etcd:
+
+.. tabs::
+  .. group-tab:: GCP
+
+    .. parsed-literal::
+
+       kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/clustermesh/cilium-etcd-external-service/cilium-etcd-external-gke.yaml
+
+  .. group-tab:: AWS
+
+    .. parsed-literal::
+
+       kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/clustermesh/cilium-etcd-external-service/cilium-etcd-external-eks.yaml
+
+
+.. note::
+
+   Make sure that you create the service in namespace in which cilium and/or
+   etcd is running. Depending on which installation method you chose, this
+   could be ``kube-system`` or ``cilium``.
+
+Extract the TLS keys and generate the etcd configuration
+========================================================
+
+The cluster mesh control plane performs TLS based authentication and encryption.
+For this purpose, the TLS keys and certificates of each etcd need to be made
+available to all clusters that wish to connect.
+
+1. Clone the ``cilium/clustermesh-tools`` repository. It contains scripts to
+   extracts the secrets and generate a Kubernetes secret in form of a YAML
+   file:
+
+   .. code:: bash
+   
+        git clone https://github.com/cilium/clustermesh-tools.git
+        cd clustermesh-tools
+
+2. Ensure that the kubectl context is pointing to the cluster you want to
+   extract the secret from.
+
+3. Extract the TLS certificate, key and root CA authority.
 
    .. code:: bash
 
-       $ ks create secret generic cilium-clustermesh --from-file=./cluster5 --from-file=./cluster7
+        ./extract-etcd-secrets.sh
 
-   Cilium will automatically ignore any configuration referring to its own
-   cluster so you can create a single secret and import it into all your
-   clusters to establish connectivity between all clusters.
+   This will extract the keys that Cilium is using to connect to the etcd in
+   the local cluster. The key files are written to
+   ``config/<cluster-name>.*.{key|crt|-ca.crt}``
+
+4. Repeat this step for all clusters you want to connect with each other.
+
+5. Generate a single Kubernetes secret from all the keys and certificates
+   extracted. The secret will contain the etcd configuration with the service
+   IP or host name of the etcd including the keys and certificates to access
+   it.
 
    .. code:: bash
 
-       cluster 1:
-       $ kubectl -n kube-system get secret cilium-clustermesh -o yaml > clustermesh.yaml
+        ./generate-secret-yaml.sh > clustermesh.yaml
 
-       cluster 2:
-       $ kubectl apply -f clustermesh.yaml
+.. note::
 
-Step 3: Restart the cilium agent
---------------------------------
+   The key files in ``config/`` and the secret represented as YAML are
+   sensitive. Anyone gaining access to these files is able to connect to the
+   etcd instances in the local cluster. Delete the files after the you are done
+   setting up the cluster mesh.
 
-Restart Cilium in each cluster to pick up the new cluster name, cluster id and
-clustermesh secret configuration. Cilium will automatically establish
-connectivity between the clusters.
+Ensure that the etcd service names can be resolved
+==================================================
+
+For TLS authentication to work properly, agents will connect to etcd in remote
+clusters using a pre-defined naming schema ``{clustername}.mesh.cilium.io``. In
+order for DNS resolution to work on these virtual host name, the names are
+statically mapped to the service IP via the ``/etc/hosts`` file.
+
+1. The following script will generate the required segment which has to be
+   inserted into the ``cilium`` DaemonSet:
+
+    .. code:: bash
+
+       ./generate-name-mapping.sh > ds.patch
+
+    The ``ds.patch`` will look something like this:
+
+    .. code:: bash
+
+        spec:
+          template:
+            spec:
+              hostAliases:
+              - ip: "10.138.0.18"
+                hostnames:
+                - cluster1.mesh.cilium.io
+              - ip: "10.138.0.19"
+                hostnames:
+                - cluster2.mesh.cilium.io
+
+2. Apply the patch to all DaemonSets in all clusters:
+
+   .. code:: bash
+
+      kubectl -n kube-system patch ds cilium -p "$(cat ds.patch)"
+
+Establish connections between clusters
+######################################
+
+1. Import the ``cilium-clustermesh`` secret that you generated in the last
+chapter into all of your clusters:
 
 .. code:: bash
 
-    $ kubectl -n kube-system delete -l k8s-app=cilium
+    kubectl apply -f clustermesh.yaml
 
-Step 4: Test the connectivity between clusters
-----------------------------------------------
+2. Restart the cilium-agent in all clusters so it picks up the new cluster
+   name, cluster id and mounts the ``cilium-clustermesh`` secret. Cilium will
+   automatically establish connectivity between the clusters.
+
+.. code:: bash
+
+    kubectl -n kube-system delete -l k8s-app=cilium
+
+Test pod connectivity between clusters
+======================================
+
 
 Run ``cilium node list`` to see the full list of nodes discovered. You can run
 this command inside any Cilium pod in any cluster:
@@ -132,3 +269,106 @@ this command inside any Cilium pod in any cluster:
 
     $ kubectl exec -ti pod-cluster5-xxx curl <pod-ip-cluster7>
     [...]
+
+Load-balancing with Global Services
+###################################
+
+Establishing load-balancing between clusters is achieved by defining a
+Kubernetes service with identical name and namespace in each cluster and adding
+the annotation ``io.cilium/global-service: "true"``` to declare it global.
+Cilium will automatically perform load-balancing to pods in both clusters.
+
+.. code:: bash
+
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: rebel-base
+      annotations:
+        io.cilium/global-service: "true"
+    spec:
+      type: ClusterIP
+      ports:
+      - port: 80
+      selector:
+        name: rebel-base
+
+Deploying a simple example service
+==================================
+
+1. In cluster 1, deploy:
+
+   .. code:: bash
+
+       kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/clustermesh/global-service-example/cluster1.yaml
+
+2. In cluster 2, deploy:
+
+   .. code:: bash
+
+       kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/clustermesh/global-service-example/cluster2.yaml
+
+3. From either cluster, access the global service:
+
+   .. code:: bash
+
+      kubectl exec -ti xwing-xxx -- curl rebel-base
+
+   You will see replies from pods in both clusters
+
+
+Security Policies
+#################
+
+As addressing and network security is decoupled, network security enforcement
+automatically spans across clusters. Note that Kubernetes security policies are
+not automatically distributed across clusters, it is your responsibility to
+apply ``CiliumNetworkPolicy`` or ``NetworkPolicy`` in all clusters.
+
+Allowing specific communication between clusters
+================================================
+
+The following policy illustrates how to allow particular pods to allow
+communicate between two clusters. The cluster name refers to the name given via
+the ``--cluster-name`` agent option or ``cluster-name`` ConfigMap option.
+
+::
+
+    apiVersion: "cilium.io/v2"
+    kind: CiliumNetworkPolicy
+    metadata:
+      name: "allow-cross-cluster"
+      description: "Allow x-wing in cluster1 to contact rebel-base in cluster2"
+    spec:
+      endpointSelector:
+        matchLabels:
+          name: x-wing
+          io.cilium.k8s.policy.cluster: cluster1
+      egress:
+      - toEndpoints:
+        - matchLabels:
+            name: rebel-base
+            io.cilium.k8s.policy.cluster: cluster2
+
+Limitations
+###########
+
+ * L7 security policies currently only work across multiple clusters if worker
+   nodes have routes installed allowing to route pod IPs of all clusters. This
+   is given when running in direct routing mode by running a routing daemon or
+   ``--auto-direct-node-routes`` but won't work automatically when using
+   tunnel/encapsulation mode.
+
+ * The number of clusters that can be connected together is currently limited
+   to 255. This limitation will be lifted in the future when running in direct
+   routing mode or when running in encapsulation mode with encryption enabled.
+
+Roadmap Ahead
+#############
+
+ * Future versions will put an API server before etcd to provide better
+   scalability and simplify the installation to support any etcd support
+
+ * Introduction of IPSec and use of ESP or utilization of the traffic class
+   field in the IPv6 header will allow to use more than 8 bits for the
+   cluster-id and thus support more than 256 clusters.

--- a/Documentation/install/system_requirements.rst
+++ b/Documentation/install/system_requirements.rst
@@ -150,6 +150,8 @@ The minimum version of iproute2_ must be >= 4.8.0. Please see
 https://www.kernel.org/pub/linux/utils/net/iproute2/ for documentation on how
 to install iproute2.
 
+.. _firewall_requirements:
+
 Firewall Rules
 ==============
 
@@ -159,7 +161,7 @@ It is recommended but optional that all nodes running Cilium in a given cluster 
 
 If you are using VXLAN overlay network mode, Cilium uses Linux's default VXLAN port 8472 over UDP, unless Linux has been configured otherwise. In this case, UDP 8472 must be open among all nodes to enable VXLAN overlay mode. The same applies to Geneve overlay network mode, except the port is UDP 6081.
 
-If you are running in direct routing mode, you effectively need to allow all traffic among nodes. Since there's no distinction between the pods' network and the underlying network, all nodes must be able to freely talk to each other.
+If you are running in direct routing mode, your network must allow routing of pod IPs.
 
 As an example, if you are running on AWS with VXLAN overlay networking, here is a minimum set of AWS Security Group (SG) rules. It assumes a separation between the SG on the master nodes, ``master-sg``, and the worker nodes, ``worker-sg``. It also assumes ``etcd`` is running on the master nodes.
 

--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -1191,6 +1191,24 @@ resources.
 
         .. literalinclude:: ../../examples/policies/kubernetes/serviceaccount/serviceaccount-policy.json
 
+Multi-Cluster
+-------------
+
+When operating multiple cluster with cluster mesh, the cluster name is exposed
+via the label ``io.cilium.k8s.policy.cluster`` and can be used to restrict
+policies to a particular cluster.
+
+.. only:: html
+
+   .. tabs::
+     .. group-tab:: k8s YAML
+
+        .. literalinclude:: ../../examples/policies/kubernetes/clustermesh/cross-cluster-policy.yaml
+
+.. only:: epub or latex
+
+        .. literalinclude:: ../../examples/policies/kubernetes/clustermesh/cross-cluster-policy.yaml
+
 Well-known Identities
 ---------------------
 

--- a/examples/kubernetes/clustermesh/cilium-etcd-external-service/cilium-etcd-external-eks.yaml
+++ b/examples/kubernetes/clustermesh/cilium-etcd-external-service/cilium-etcd-external-eks.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cilium-etcd-external
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 2379
+  selector:
+    app: etcd
+    etcd_cluster: cilium-etcd
+    io.cilium/app: etcd-operator

--- a/examples/kubernetes/clustermesh/cilium-etcd-external-service/cilium-etcd-external-gke.yaml
+++ b/examples/kubernetes/clustermesh/cilium-etcd-external-service/cilium-etcd-external-gke.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cilium-etcd-external
+  annotations:
+    cloud.google.com/load-balancer-type: "Internal"
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 2379
+  selector:
+    app: etcd
+    etcd_cluster: cilium-etcd
+    io.cilium/app: etcd-operator

--- a/examples/kubernetes/clustermesh/global-service-example/cluster1.yaml
+++ b/examples/kubernetes/clustermesh/global-service-example/cluster1.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rebel-base
+  annotations:
+    io.cilium/global-service: "true"
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+  selector:
+    name: rebel-base
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: rebel-base
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        name: rebel-base
+    spec:
+      containers:
+      - name: rebel-base
+        image: docker.io/nginx:1.15.8
+        volumeMounts:
+          - name: html
+            mountPath: /usr/share/nginx/html/
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 80
+          periodSeconds: 1
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
+      volumes:
+        - name: html
+          configMap:
+            name: rebel-base-response
+            items:
+              - key: message
+                path: index.html
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rebel-base-response
+data:
+  message: "{\"Galaxy\": \"Alderaan\", \"Cluster\": \"Cluster-1\"}\n"
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: x-wing
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        name: x-wing
+    spec:
+      containers:
+      - name: x-wing-container
+        image: docker.io/cilium/json-mock:1.0
+        livenessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - -o
+            - /dev/null
+            - localhost
+        readinessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - -o
+            - /dev/null
+            - localhost

--- a/examples/kubernetes/clustermesh/global-service-example/cluster2.yaml
+++ b/examples/kubernetes/clustermesh/global-service-example/cluster2.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rebel-base
+  annotations:
+    io.cilium/global-service: "true"
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+  selector:
+    name: rebel-base
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: rebel-base
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        name: rebel-base
+    spec:
+      containers:
+      - name: rebel-base
+        image: docker.io/nginx:1.15.8
+        volumeMounts:
+          - name: html
+            mountPath: /usr/share/nginx/html/
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 80
+          periodSeconds: 1
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
+      volumes:
+        - name: html
+          configMap:
+            name: rebel-base-response
+            items:
+              - key: message
+                path: index.html
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rebel-base-response
+data:
+  message: "{\"Galaxy\": \"Alderaan\", \"Cluster\": \"Cluster-2\"}\n"
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: x-wing
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        name: x-wing
+    spec:
+      containers:
+      - name: x-wing-container
+        image: docker.io/cilium/json-mock:1.0
+        livenessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - -o
+            - /dev/null
+            - localhost
+        readinessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - -o
+            - /dev/null
+            - localhost

--- a/examples/policies/kubernetes/clustermesh/cross-cluster-policy.yaml
+++ b/examples/policies/kubernetes/clustermesh/cross-cluster-policy.yaml
@@ -1,0 +1,15 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "allow-cross-cluster"
+  description: "Allow x-wing in cluster1 to contact rebel-base in cluster2"
+spec:
+  endpointSelector:
+    matchLabels:
+      name: x-wing
+      io.cilium.k8s.policy.cluster: cluster1
+  egress:
+  - toEndpoints:
+    - matchLabels:
+        name: rebel-base
+        io.cilium.k8s.policy.cluster: cluster2


### PR DESCRIPTION
Provide a getting-started guide to set up cluster mesh using SSL certificates
generated by cilium-etcd-operator. Provide examples for global services and
policy enforcement.

Provide a cross cluster policy example

Depends on https://github.com/cilium/cilium-etcd-operator/pull/35

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6853)
<!-- Reviewable:end -->
