### PR TITLE
Streamline backporting and improve backporting docs

### DIFF
--- a/Documentation/contributing.rst
+++ b/Documentation/contributing.rst
@@ -2029,10 +2029,10 @@ the process for backporting these PRs.
    to configure git to have your name and email address to be used in
    the commit messages:
 
-.. code-block:: bash
+   .. code-block:: bash
 
-        $ git config --global user.name "John Doe"
-        $ git config --global user.email johndoe@example.com
+      $ git config --global user.name "John Doe"
+      $ git config --global user.email johndoe@example.com
 
 3. Make sure you have your a GitHub developer access token
    available. For details, see `contrib/backporting/README.md
@@ -2044,9 +2044,9 @@ the process for backporting these PRs.
    token, this will list the commits that need backporting, from the
    newest to oldest:
 
-.. code-block:: bash
+   .. code-block:: bash
 
-        $ GITHUB_TOKEN=xxx contrib/backporting/check-stable 1.0
+      $ GITHUB_TOKEN=xxx contrib/backporting/check-stable 1.0
 
    .. note::
       ``contrib/backporting/check-stable`` accepts a second argument to
@@ -2065,11 +2065,11 @@ the process for backporting these PRs.
    specified on the command line until one cherry pick fails or every
    commit is cherry-picked.
 
-.. code-block:: bash
+   .. code-block:: bash
 
-        $ contrib/backporting/cherry-pick <oldest-commit-sha>
-        ...
-        $ contrib/backporting/cherry-pick <newest-commit-sha>
+      $ contrib/backporting/cherry-pick <oldest-commit-sha>
+      ...
+      $ contrib/backporting/cherry-pick <newest-commit-sha>
 
 8. Push your backports branch to cilium repo, e.g., ``git push -u origin pr/v1.0-backports-YY-MM-DD``
 9. In Github, create a new PR from your branch towards the feature

--- a/Documentation/contributing.rst
+++ b/Documentation/contributing.rst
@@ -1311,7 +1311,7 @@ Alternatively you can use a Docker container to build the pages:
 This builds the docs in a container and builds and starts a web server with
 your document changes.
 
-Now the documentation page should be browsable on http://localhost:8080.
+Now the documentation page should be browsable on http://localhost:9080.
 
 .. _ci_jenkins:
 

--- a/Documentation/contributing.rst
+++ b/Documentation/contributing.rst
@@ -2048,11 +2048,22 @@ the process for backporting these PRs.
 
         $ GITHUB_TOKEN=xxx contrib/backporting/check-stable 1.0
 
+   .. note::
+      ``contrib/backporting/check-stable`` accepts a second argument to
+      specify a path to write a nicely-formatted pull request message to.
+      This can be used alongside
+      `Github command-line tools <https://github.com/node-gh/gh>`__ to
+      send the pull request from the command line in steps 9-10 via
+      ``gh pull-request -b vX.Y -l backport/vX.Y -F <path>``.
+
 7. Cherry-pick the commits using the master git SHAs listed, starting
    from the oldest (bottom), working your way up and fixing any merge
    conflicts as they appear. Note that for PRs that have multiple
    commits you will want to check that you are cherry-picking oldest
-   commits first.
+   commits first. The ``cherry-pick`` script accepts multiple arguments,
+   in which case it will attempt to apply each commit in the order
+   specified on the command line until one cherry pick fails or every
+   commit is cherry-picked.
 
 .. code-block:: bash
 

--- a/Makefile
+++ b/Makefile
@@ -300,8 +300,8 @@ docs-container:
 	  (ret=$$?; rm -r ./Documentation/_api && exit $$ret)
 
 render-docs: test-docs
-	$(DOCKER) container run --rm -dit --name docs-cilium -p 8080:80 -v $$(pwd)/Documentation/_build/html/:/usr/local/apache2/htdocs/ httpd:2.4
-	@echo "$$(tput setaf 2)Running at http://localhost:8080$$(tput sgr0)"
+	$(DOCKER) container run --rm -dit --name docs-cilium -p 9080:80 -v $$(pwd)/Documentation/_build/html/:/usr/local/apache2/htdocs/ httpd:2.4
+	@echo "$$(tput setaf 2)Running at http://localhost:9080$$(tput sgr0)"
 
 test-docs: docs-container
 	-$(DOCKER) container rm -f docs-cilium >/dev/null 2>&1 || true

--- a/contrib/backporting/check-stable
+++ b/contrib/backporting/check-stable
@@ -188,4 +188,12 @@ if [[ ${#stable_prs[@]} > 0 ]]; then
     generate_commit_list_for_pr $pr
     echo ""
   done
+  echo "When you have backported the above commits, you can update the PR labels via this command:"
+  echo "$ for pr in ${stable_prs[@]}; do contrib/backporting/set-labels.py \$pr pending ${STABLE_BRANCH}; done"
+  if [[ ! -z $SUMMARY_LOG ]]; then
+    echo -e "\nOnce this PR is merged, you can update the PR labels via:" >> $SUMMARY_LOG
+    echo "\`\`\`" >> $SUMMARY_LOG
+    echo "$ for pr in ${stable_prs[@]}; do contrib/backporting/set-labels.py \$pr done ${STABLE_BRANCH}; done" >> $SUMMARY_LOG
+    echo "\`\`\`" >> $SUMMARY_LOG
+  fi
 fi

--- a/contrib/backporting/check-stable
+++ b/contrib/backporting/check-stable
@@ -1,6 +1,7 @@
 #!/bin/bash
 #
 # Copyright 2016 The Kubernetes Authors All rights reserved.
+# Copyright 2019 Authors of Cilium
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,14 +17,19 @@
 #
 # Set PROGram name
 PROG=${0##*/}
-STABLE_BRANCH=${1:-1.0}
-echo "Checking for backports on branch '${STABLE_BRANCH}'"
+STABLE_BRANCH=${1:-}
+SUMMARY_LOG=${2:-}
 
 source $(dirname $(readlink -ne $BASH_SOURCE))/../release/lib/common.sh
 source $TOOL_LIB_PATH/gitlib.sh
 
 # Validate command-line
-common::argc_validate 1
+common::argc_validate 2
+
+if [[ -z $STABLE_BRANCH ]]; then
+  logecho "usage: $0 <branch> [summary-file]" >&2
+  common::exit 1
+fi
 
 ###############################################################################
 # FUNCTIONS
@@ -167,12 +173,18 @@ MYLOG=/tmp/$PROG.log
 # Check token
 gitlib::github_api_token
 
+echo "Checking for backports on branch '${STABLE_BRANCH}'"
+
 stable_prs=($(get_prs "needs-backport/${STABLE_BRANCH}" "backport-done/${STABLE_BRANCH}"))
+echo -e "v$STABLE_BRANCH backports $(date +%Y-%m-%d)\n" | tee $SUMMARY_LOG
 echo -e "PRs for stable backporting: ${#stable_prs[@]}\n"
 if [[ ${#stable_prs[@]} > 0 ]]; then
   for pr in "${stable_prs[@]}"; do
     title=$(extract_pr_title "$pr")
     echo " * PR: $pr -- $title -- https://github.com/cilium/cilium/pull/$pr"
+    if [[ ! -z $SUMMARY_LOG ]]; then
+      echo " * #$pr -- $title" >> $SUMMARY_LOG
+    fi
     generate_commit_list_for_pr $pr
     echo ""
   done


### PR DESCRIPTION
Please review commit-by-commit.

Main functionality added in this PR is:

    backporting: Add summary log option to check-stable

    Allow writing a nicely-formatted PR message to a file:

    ```
        $ check-stable 1.4 my-pr.txt
        $ cat my-pr.txt
        v1.4 backports 2019-01-30

         * #xxxx -- commit title (@author)
         ...
    ```

See #6858 for an example. This file can be passed to [Github command-line tools](https://github.com/node-gh/gh) directly to open the backport PR from the commandline (shout out to @nebril for the suggestion!)

Also, serve `make render-docs` on `localhost:9080` as port `8080` conflicts with microk8s default ports, and document the new feature, as well as the feature in #6834.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6859)
<!-- Reviewable:end -->
