### PR TITLE
Test: Report a kubernetes summary to a single file.

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1648,6 +1648,7 @@ func (kub *Kubectl) GatherLogs() {
 		"kubectl describe pods --all-namespaces":                     "pods_status.txt",
 		"kubectl get replicationcontroller --all-namespaces -o json": "replicationcontroller.txt",
 		"kubectl get deployment --all-namespaces -o json":            "deployment.txt",
+		"kubectl get all,cnp,cep --all-namespaces -o wide":           "kubernetes_summary.txt",
 	}
 
 	kub.GeneratePodLogGatheringCommands(reportCmds)


### PR DESCRIPTION
To make it faster to debug print all resources in a single file in a
human friendly format.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6864)
<!-- Reviewable:end -->
