### PR TITLE
endpoint: Skip finalization only in dry mode.

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -521,7 +521,7 @@ func (e *Endpoint) regenerateBPF(owner Owner, regenContext *regenerationContext)
 	// reverted, and execute it in case of regeneration success.
 	defer func() {
 		// Ignore finalizing of proxy state in dry mode.
-		if option.Config.DryMode {
+		if !option.Config.DryMode {
 			e.finalizeProxyState(regenContext, reterr)
 		}
 	}()


### PR DESCRIPTION
Logic that skips proxy finalization in dry mode got inverted.

Fixes: 4045887122
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6866)
<!-- Reviewable:end -->
