### PR TITLE
pkg/k8s: consider 2 CNPs different if they have different annotations

### DIFF
--- a/pkg/k8s/factory_functions.go
+++ b/pkg/k8s/factory_functions.go
@@ -502,6 +502,7 @@ func equalV2CNP(o1, o2 interface{}) bool {
 	}
 	return cnp1.Name == cnp2.Name &&
 		cnp1.Namespace == cnp2.Namespace &&
+		comparator.MapStringEquals(cnp1.GetAnnotations(), cnp2.GetAnnotations()) &&
 		reflect.DeepEqual(cnp1.Spec, cnp2.Spec) &&
 		reflect.DeepEqual(cnp1.Specs, cnp2.Specs)
 }


### PR DESCRIPTION
Fixes: 7e96576f0ffd ("k8s: create Equalness and Missing Functions for CNP and NP")
Signed-off-by: André Martins <andre@cilium.io>

```release-note
Consider 2 cilium network policies different if they have different annotations
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6867)
<!-- Reviewable:end -->
