### PR TITLE
endpoint: Avoid harmless controller failures when endpoint disappears

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -15,6 +15,7 @@
 package controller
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -39,11 +40,16 @@ type ControllerFunc func() error
 // ExitReason is a returnable type from DoFunc that causes the
 // controller to exit. This reason is recorded in the controller's status. The
 // controller is not removed from any manager.
-// Construct one with ExitReason{errors.New("a reason")}
+// Construct one with NewExitReason("a reason")
 type ExitReason struct {
 	// This is constucted in this odd way because the type assertion in
 	// runController didn't work otherwise.
 	error
+}
+
+// NewExitReason returns a new ExitReason
+func NewExitReason(reason string) ExitReason {
+	return ExitReason{errors.New(reason)}
 }
 
 // ControllerParams contains all parameters of a controller

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -17,7 +17,6 @@
 package controller
 
 import (
-	"errors"
 	"fmt"
 	"sync/atomic"
 	"testing"
@@ -76,7 +75,7 @@ func (b *ControllerSuite) TestSelfExit(c *C) {
 		RunInterval: 100 * time.Millisecond,
 		DoFunc: func() error {
 			atomic.AddUint32(&iterations, 1)
-			return ExitReason{errors.New("test exit")}
+			return NewExitReason("test exit")
 		},
 		StopFunc: func() error {
 			close(waitChan)

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1158,8 +1158,8 @@ func (e *Endpoint) syncPolicyMapController() {
 				// Failure to lock is not an error, it means
 				// that the endpoint was disconnected and we
 				// should exit gracefully.
-				if err := e.LockAlive(); err != nil {
-					return nil
+				if err := e.RLockAlive(); err != nil {
+					return controller.NewExitReason("Endpoint disappeared")
 				}
 				defer e.Unlock()
 				return e.syncPolicyMap()

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2004,7 +2004,7 @@ func (e *Endpoint) runLabelsResolver(owner Owner, myChangeRev int, blocking bool
 				switch err {
 				case ErrNotAlive:
 					e.getLogger().Debug("not changing endpoint identity because endpoint is in process of being removed")
-					return nil
+					return controller.NewExitReason("Endpoint disappeared")
 				default:
 					return err
 				}


### PR DESCRIPTION
When the endpoint is no longer alive during a controller run, stop the
controller gracefully and wait for it to be deleted.

Avoids a spam of controller failures when pods are restarted or endpoints
disappear for another reason.

Example:
```
msg="Controller run failed" consecutiveErrors=1 error="rlock failed: endpoint is in the process of being removed" name="sync-identity-to-k8s-pod (3558)" subsys=controller uuid=0ea5b9e4-25d6-11e9-8745-080027d2d952
msg="Controller run failed" consecutiveErrors=2 error="rlock failed: endpoint is in the process of being removed" name="sync-identity-to-k8s-pod (3558)" subsys=controller uuid=0ea5b9e4-25d6-11e9-8745-080027d2d952
msg="Controller run failed" consecutiveErrors=3 error="rlock failed: endpoint is in the process of being removed" name="sync-identity-to-k8s-pod (3558)" subsys=controller uuid=0ea5b9e4-25d6-11e9-8745-080027d2d952
msg="Controller run failed" consecutiveErrors=4 error="rlock failed: endpoint is in the process of being removed" name="sync-identity-to-k8s-pod (3558)" subsys=controller uuid=0ea5b9e4-25d6-11e9-8745-080027d2d952
msg="Controller run failed" consecutiveErrors=1 error="rlock failed: endpoint is in the process of being removed" name="sync-identity-to-k8s-pod (1507)" subsys=controller uuid=0ec539f5-25d6-11e9-8745-080027d2d952
msg="Controller run failed" consecutiveErrors=2 error="rlock failed: endpoint is in the process of being removed" name="sync-identity-to-k8s-pod (1507)" subsys=controller uuid=0ec539f5-25d6-11e9-8745-080027d2d952
msg="Controller run failed" consecutiveErrors=3 error="rlock failed: endpoint is in the process of being removed" name="sync-identity-to-k8s-pod (1507)" subsys=controller uuid=0ec539f5-25d6-11e9-8745-080027d2d952
msg="Controller run failed" consecutiveErrors=4 error="rlock failed: endpoint is in the process of being removed" name="sync-identity-to-k8s-pod (1507)" subsys=controller uuid=0ec539f5-25d6-11e9-8745-080027d2d952
msg="Controller run failed" consecutiveErrors=1 error="rlock failed: endpoint is in the process of being removed" name="sync-identity-to-k8s-pod (2287)" subsys=controller uuid=6ada57c4-25d6-11e9-8745-080027d2d952
msg="Controller run failed" consecutiveErrors=2 error="rlock failed: endpoint is in the process of being removed" name="sync-identity-to-k8s-pod (2287)" subsys=controller uuid=6ada57c4-25d6-11e9-8745-080027d2d952
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6872)
<!-- Reviewable:end -->
