### PR TITLE
Add unit tests for Linux Datapath Encrypt APIs and Route Rules

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net"
 	"os"
@@ -291,11 +292,14 @@ func decodeIPSecKey(keyRaw string) ([]byte, error) {
 func LoadIPSecKeysFile(path string) error {
 	file, err := os.Open(path)
 	if err != nil {
-		return fmt.Errorf("failed to load IPSec Keys File %s: %v", path, err)
+		return err
 	}
 	defer file.Close()
+	return loadIPSecKeys(file)
+}
 
-	scanner := bufio.NewScanner(file)
+func loadIPSecKeys(r io.Reader) error {
+	scanner := bufio.NewScanner(r)
 	scanner.Split(bufio.ScanLines)
 	for scanner.Scan() {
 		ipSecKey := &ipSecKey{

--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -1,0 +1,141 @@
+// Copyright 2018 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build privileged_tests
+
+package ipsec
+
+import (
+	"bytes"
+	"net"
+	"os"
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/vishvananda/netlink"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) { TestingT(t) }
+
+type IPSecSuitePrivileged struct{}
+
+var _ = Suite(&IPSecSuitePrivileged{})
+
+var (
+	path           = "ipsec_keys_test"
+	keysDat        = []byte("hmac(sha256) 0123456789abcdef0123456789abcdef cbc(aes) 0123456789abcdef0123456789abcdef\nhmac(sha256) 0123456789abcdef0123456789abcdef cbc(aes) 0123456789abcdef0123456789abcdef foobar\n")
+	invalidKeysDat = []byte("test abcdefghijklmnopqrstuvwzyzABCDEF test abcdefghijklmnopqrstuvwzyzABCDEF\n")
+)
+
+func (p *IPSecSuitePrivileged) TestLoadKeysNoFile(c *C) {
+	err := LoadIPSecKeysFile(path)
+	c.Assert(os.IsNotExist(err), Equals, true)
+}
+
+func (p *IPSecSuitePrivileged) TestInvalidLoadKeys(c *C) {
+	keys := bytes.NewReader(invalidKeysDat)
+	err := loadIPSecKeys(keys)
+	spi := 1
+	c.Assert(err, NotNil)
+
+	_, local, err := net.ParseCIDR("1.1.3.4/16")
+	c.Assert(err, IsNil)
+	_, remote, err := net.ParseCIDR("1.2.3.4/16")
+	c.Assert(err, IsNil)
+
+	err = UpsertIPSecEndpoint(local, remote, spi, IPSecDirBoth)
+	c.Assert(err, NotNil)
+}
+
+func (p *IPSecSuitePrivileged) TestLoadKeys(c *C) {
+	keys := bytes.NewReader(keysDat)
+	err := loadIPSecKeys(keys)
+	c.Assert(err, IsNil)
+}
+
+func (p *IPSecSuitePrivileged) TestUpsertIPSecEquals(c *C) {
+	spi := 1
+
+	_, local, err := net.ParseCIDR("1.2.3.4/16")
+	c.Assert(err, IsNil)
+	_, remote, err := net.ParseCIDR("1.2.3.4/16")
+	c.Assert(err, IsNil)
+
+	key := &ipSecKey{
+		Spi:   1,
+		ReqID: 1,
+		Auth:  &netlink.XfrmStateAlgo{Name: "hmac(sha256)", Key: []byte("0123456789abcdef0123456789abcdef")},
+		Crypt: &netlink.XfrmStateAlgo{Name: "cbc(aes)", Key: []byte("0123456789abcdef0123456789abcdef")},
+	}
+
+	ipSecKeysGlobal["1.2.3.4"] = key
+	ipSecKeysGlobal[""] = key
+
+	err = UpsertIPSecEndpoint(local, remote, spi, IPSecDirBoth)
+	c.Assert(err, IsNil)
+
+	err = DeleteIPSecEndpoint(remote.IP, local.IP)
+	c.Assert(err, IsNil)
+
+	ipSecKeysGlobal["1.2.3.4"] = nil
+	ipSecKeysGlobal[""] = nil
+
+}
+
+func (p *IPSecSuitePrivileged) TestUpsertIPSecEndpoint(c *C) {
+	spi := 1
+
+	_, local, err := net.ParseCIDR("1.1.3.4/16")
+	c.Assert(err, IsNil)
+	_, remote, err := net.ParseCIDR("1.2.3.4/16")
+	c.Assert(err, IsNil)
+
+	key := &ipSecKey{
+		Spi:   1,
+		ReqID: 1,
+		Auth:  &netlink.XfrmStateAlgo{Name: "hmac(sha256)", Key: []byte("0123456789abcdef0123456789abcdef")},
+		Crypt: &netlink.XfrmStateAlgo{Name: "cbc(aes)", Key: []byte("0123456789abcdef0123456789abcdef")},
+	}
+
+	ipSecKeysGlobal["1.1.3.4"] = key
+	ipSecKeysGlobal["1.2.3.4"] = key
+	ipSecKeysGlobal[""] = key
+
+	err = UpsertIPSecEndpoint(local, remote, spi, IPSecDirBoth)
+	c.Assert(err, IsNil)
+
+	err = DeleteIPSecEndpoint(remote.IP, local.IP)
+	c.Assert(err, IsNil)
+
+	ipSecKeysGlobal["1.1.3.4"] = nil
+	ipSecKeysGlobal["1.2.3.4"] = nil
+	ipSecKeysGlobal[""] = nil
+}
+
+func (p *IPSecSuitePrivileged) TestUpsertIPSecKeyMissing(c *C) {
+	spi := 1
+
+	_, local, err := net.ParseCIDR("1.1.3.4/16")
+	c.Assert(err, IsNil)
+	_, remote, err := net.ParseCIDR("1.2.3.4/16")
+	c.Assert(err, IsNil)
+
+	err = UpsertIPSecEndpoint(local, remote, spi, IPSecDirBoth)
+	c.Assert(err, ErrorMatches, "unable to replace local state: IPSec key missing")
+
+	err = DeleteIPSecEndpoint(remote.IP, local.IP)
+	c.Assert(err, IsNil)
+}

--- a/pkg/datapath/linux/route/route_linux.go
+++ b/pkg/datapath/linux/route/route_linux.go
@@ -357,6 +357,17 @@ func replaceRule(fwmark, table, family int) error {
 func DeleteRule(fwmark int, table int) error {
 	rule := netlink.NewRule()
 	rule.Mark = fwmark
+	rule.Mask = linux_defaults.RouteMarkMask
 	rule.Table = table
+	rule.Family = netlink.FAMILY_V4
+	return netlink.RuleDel(rule)
+}
+
+// DeleteRuleIPv6 delete a mark based IPv6 rule from the routing table.
+func DeleteRuleIPv6(fwmark int, table int) error {
+	rule := netlink.NewRule()
+	rule.Mark = fwmark
+	rule.Table = table
+	rule.Family = netlink.FAMILY_V6
 	return netlink.RuleDel(rule)
 }

--- a/pkg/datapath/linux/route/route_linux_test.go
+++ b/pkg/datapath/linux/route/route_linux_test.go
@@ -119,3 +119,36 @@ func (p *RouteSuitePrivileged) TestReplaceRoute(c *C) {
 	// lookup test broken for IPv6 as long as use lo as device
 	testReplaceRoute(c, "f00d::a02:200:0:0/96", "f00d::a02:100:0:815b", false)
 }
+
+func testReplaceRule(c *C, mark, table int) {
+	// delete rule in case it exists from a previous failed run
+	DeleteRule(mark, table)
+	err := ReplaceRule(mark, table)
+	c.Assert(err, IsNil)
+	exists, err := lookupRule(mark, table, netlink.FAMILY_V4)
+	c.Assert(err, IsNil)
+	c.Assert(exists, Equals, true)
+	err = DeleteRule(mark, table)
+	c.Assert(err, IsNil)
+	exists, err = lookupRule(mark, table, netlink.FAMILY_V4)
+	c.Assert(err, IsNil)
+	c.Assert(exists, Equals, false)
+}
+
+func testReplaceRuleIPv6(c *C, mark, table int) {
+	// delete rule in case it exists from a previous failed run
+	DeleteRuleIPv6(mark, table)
+	err := ReplaceRuleIPv6(mark, table)
+	c.Assert(err, IsNil)
+	exists, err := lookupRule(mark, table, netlink.FAMILY_V6)
+	c.Assert(err, IsNil)
+	c.Assert(exists, Equals, true)
+	err = DeleteRuleIPv6(mark, table)
+	c.Assert(err, IsNil)
+	exists, err = lookupRule(mark, table, netlink.FAMILY_V6)
+	c.Assert(err, IsNil)
+	c.Assert(exists, Equals, false)
+}
+func (p *RouteSuitePrivileged) TestReplaceRule(c *C) {
+	testReplaceRule(c, 0xf00, 123)
+}


### PR DESCRIPTION
Add additional unit tests for new route rule functionality and ipsec_linux.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6873)
<!-- Reviewable:end -->
