### PR TITLE
Improve CIDR allocation change resolution

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -55,6 +55,7 @@ import (
 	"github.com/cilium/cilium/pkg/fqdn"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/ipam"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s"
@@ -916,6 +917,59 @@ func createPrefixLengthCounter() *counter.PrefixLengthCounter {
 	return counter
 }
 
+func (d *Daemon) prepareAllocationCIDR(family datapath.NodeAddressingFamily) (routerIP net.IP, err error) {
+	// Reserve the IPv4 external node IP within the allocation range if
+	// required.
+	allocRange := family.AllocationCIDR()
+	nodeIP := family.PrimaryExternal()
+	if allocRange.Contains(nodeIP) {
+		err = d.ipam.AllocateIP(nodeIP)
+		if err != nil {
+			err = fmt.Errorf("Unable to allocate external IPv4 node IP %s from allocation range %s: %s",
+				nodeIP, allocRange, err)
+			return
+		}
+	}
+
+	routerIP = family.Router()
+	if routerIP != nil && !allocRange.Contains(routerIP) {
+		log.Warningf("Detected allocation CIDR change to %s, previous router IP %s", allocRange, routerIP)
+
+		// The restored router IP is not part of the allocation range.
+		// This indicates that the allocation range has changed.
+		if !option.Config.IsFlannelMasterDeviceSet() {
+			// Remove the old host device and
+			var link netlink.Link
+			link, err = netlink.LinkByName(option.Config.HostDevice)
+			if err != nil {
+				err = fmt.Errorf("unable to lookup host device %s: %s", option.Config.HostDevice, err)
+				return
+			}
+			if err = netlink.LinkDel(link); err != nil {
+				err = fmt.Errorf("unable to delete host device %s to change allocation CIDR: %s",
+					option.Config.HostDevice, err)
+				return
+			}
+		}
+
+		// force re-allocation of the router IP
+		routerIP = nil
+	}
+
+	if routerIP == nil {
+		routerIP = ip.GetNextIP(family.AllocationCIDR().IP)
+	}
+
+	err = d.ipam.AllocateIP(routerIP)
+	if err != nil {
+		err = fmt.Errorf("Unable to allocate IPv4 router IP %s from allocation range %s: %s",
+			routerIP, allocRange, err)
+		return
+	}
+
+	return
+}
+
 // NewDaemon creates and returns a new Daemon with the parameters set in c.
 func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 	// Validate the daemon-specific global options.
@@ -1094,27 +1148,24 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 		log.WithError(err).Error("Unable to restore existing endpoints")
 	}
 
-	switch err := d.ipam.AllocateInternalIPs(); err.(type) {
-	case ipam.ErrAllocation:
-		if option.Config.IPv4Range == AutoCIDR || option.Config.IPv6ServiceRange == AutoCIDR {
-			log.WithError(err).Fatalf(
-				"The allocation CIDR is different from the previous cilium instance. " +
-					"This error is most likely caused by a temporary network disruption to the kube-apiserver " +
-					"that prevent Cilium from retrieve the node's IPv4/IPv6 allocation range. " +
-					"If you believe the allocation range is supposed to be different you need to clean " +
-					"up all Cilium state with the `cilium cleanup` command on this node. Be aware " +
-					"this will cause network disruption for all existing containers managed by Cilium " +
-					"running on this node and you will have to restart them.")
-		} else {
-			log.WithError(err).Fatalf(
-				"The allocation CIDR is different from the previous cilium instance. " +
-					"If you believe the allocation range is supposed to be different you need to clean " +
-					"up all Cilium state with the `cilium cleanup` command on this node. Be aware " +
-					"this will cause network disruption for all existing containers managed by Cilium " +
-					"running on this node and you will have to restart them.")
+	if option.Config.EnableIPv4 {
+		routerIP, err := d.prepareAllocationCIDR(dp.LocalNodeAddressing().IPv4())
+		if err != nil {
+			return nil, nil, err
 		}
-	case error:
-		log.WithError(err).Fatal("IPAM init failed")
+		if routerIP != nil {
+			node.SetInternalIPv4(routerIP)
+		}
+	}
+
+	if option.Config.EnableIPv6 {
+		routerIP, err := d.prepareAllocationCIDR(dp.LocalNodeAddressing().IPv6())
+		if err != nil {
+			return nil, nil, err
+		}
+		if routerIP != nil {
+			node.SetIPv6Router(routerIP)
+		}
 	}
 
 	log.Info("Addressing information:")

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -143,7 +143,7 @@ func (ipam *IPAM) AllocateInternalIPs() error {
 		if allocRange.Contains(nodeIP) {
 			err := ipam.IPv4Allocator.Allocate(nodeIP)
 			if err != nil {
-				log.WithError(err).WithField(logfields.IPAddr, nodeIP).Debug("Unable to reserve IPv4 router address")
+				return fmt.Errorf("Unable to allocate external IPv4 node IP %s from allocation range %s: %s", nodeIP, allocRange, err)
 			}
 		}
 
@@ -179,7 +179,7 @@ func (ipam *IPAM) AllocateInternalIPs() error {
 			if allocRange.Contains(ip6) {
 				err := ipam.IPv6Allocator.Allocate(ip6)
 				if err != nil {
-					log.WithError(err).WithField(logfields.IPAddr, ip6).Debug("Unable to reserve IPv6 address")
+					return fmt.Errorf("Unable to allocate external IPv6 node IP %s from allocation range %s: %s", ip6, allocRange, err)
 				}
 			}
 

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -37,9 +37,6 @@ func (s *IPAMSuite) TestLock(c *C) {
 	fakeAddressing := fake.NewNodeAddressing()
 	ipam := NewIPAM(fakeAddressing, Configuration{EnableIPv4: true, EnableIPv6: true})
 
-	err := ipam.AllocateInternalIPs()
-	c.Assert(err, IsNil)
-
 	// Since the IPs we have allocated to the endpoints might or might not
 	// be in the allocrange specified in cilium, we need to specify them
 	// manually on the endpoint based on the alloc range.

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/node"
-	"github.com/cilium/cilium/pkg/option"
 
 	. "gopkg.in/check.v1"
 	"k8s.io/api/core/v1"
@@ -35,9 +34,6 @@ import (
 )
 
 func (s *K8sSuite) TestUseNodeCIDR(c *C) {
-	option.Config.EnableIPv4 = true
-	option.Config.EnableIPv6 = true
-
 	// Test IPv4
 	node1 := v1.Node{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/node/node_address.go
+++ b/pkg/node/node_address.go
@@ -243,7 +243,11 @@ func AutoComplete() error {
 	}
 
 	if option.Config.EnableIPv6 && ipv6AllocRange == nil {
-		return fmt.Errorf("IPv6 per node allocation prefix is not configured. Please specificy --ipv6-range")
+		return fmt.Errorf("IPv6 allocation CIDR is not configured. Please specificy --ipv6-range")
+	}
+
+	if option.Config.EnableIPv4 && ipv4AllocRange == nil {
+		return fmt.Errorf("IPv4 allocation CIDR is not configured. Please specificy --ipv4-range")
 	}
 
 	return nil

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -21,9 +21,7 @@ import (
 	"testing"
 
 	"github.com/cilium/cilium/pkg/cidr"
-	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/node/addressing"
-	"github.com/cilium/cilium/pkg/option"
 
 	. "gopkg.in/check.v1"
 )
@@ -36,11 +34,6 @@ func Test(t *testing.T) {
 type NodeSuite struct{}
 
 var _ = Suite(&NodeSuite{})
-
-func (s *NodeSuite) SetUpTest(c *C) {
-	option.Config.Populate()
-	option.Config.EnableIPv4 = defaults.EnableIPv4
-}
 
 func (s *NodeSuite) TestGetNodeIP(c *C) {
 	n := Node{

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -772,6 +772,8 @@ var (
 		IPv6ClusterAllocCIDRBase: defaults.IPv6ClusterAllocCIDRBase,
 		EnableHostIPRestore:      defaults.EnableHostIPRestore,
 		EnableHealthChecking:     defaults.EnableHealthChecking,
+		EnableIPv4:               defaults.EnableIPv4,
+		EnableIPv6:               defaults.EnableIPv6,
 		ContainerRuntimeEndpoint: make(map[string]string),
 		FixedIdentityMapping:     make(map[string]string),
 		KVStoreOpt:               make(map[string]string),


### PR DESCRIPTION
When the allocation CIDR changes, the existing code errored out. When that
happened on the first agent restart, all existing endpoints failed to restore
due to failure to allocate the existing endpoint's IP address. The failure to
restore would then in turn get all existing endpoints deleted.

This is bad in two ways:

1. It causes all endpoints to be removed, causing the pods to restart
2. It does not allow the agent to ever come up again without intervention from
the user.

This commit solves problem #2 to allow nodes to recover automatically. It does
not solve problem #1 yet and requires pods to restart.

Solving problem #2 only makes sense once we have isolated all datapath aspects
such as the DNS proxy and L7 proxies out of the agent as endpoint connetivity
cannot be guaranteed if the agent cannot come up within a reasonable amount of
time.

Fixes: #6215

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6874)
<!-- Reviewable:end -->
