### PR TITLE
Misc ipvlan-related refactoring

### DIFF
--- a/api/v1/models/endpoint_change_request.go
+++ b/api/v1/models/endpoint_change_request.go
@@ -28,7 +28,7 @@ type EndpointChangeRequest struct {
 	ContainerName string `json:"container-name,omitempty"`
 
 	// ID of datapath tail call map
-	DataPathMapID int64 `json:"data-path-map-id,omitempty"`
+	DatapathMapID int64 `json:"datapath-map-id,omitempty"`
 
 	// Docker endpoint ID
 	DockerEndpointID string `json:"docker-endpoint-id,omitempty"`
@@ -81,7 +81,7 @@ type EndpointChangeRequest struct {
 
 /* polymorph EndpointChangeRequest container-name false */
 
-/* polymorph EndpointChangeRequest data-path-map-id false */
+/* polymorph EndpointChangeRequest datapath-map-id false */
 
 /* polymorph EndpointChangeRequest docker-endpoint-id false */
 

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -913,7 +913,7 @@ definitions:
       k8s-namespace:
         description: Kubernetes namespace name
         type: string
-      data-path-map-id:
+      datapath-map-id:
         description: ID of datapath tail call map
         type: integer
       policy-enabled:

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -1551,7 +1551,7 @@ func init() {
           "description": "Name assigned to container",
           "type": "string"
         },
-        "data-path-map-id": {
+        "datapath-map-id": {
           "description": "ID of datapath tail call map",
           "type": "integer"
         },

--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -303,7 +303,7 @@ func LaunchAsEndpoint(owner endpoint.Owner, n *node.Node, mtuConfig mtu.Configur
 		ep.Unlock()
 		return nil, fmt.Errorf("unable to transition health endpoint to WaitingToRegenerate state")
 	}
-	ep.MapPinLocked()
+	ep.PinDatapathMap()
 	ep.Unlock()
 
 	buildSuccessful := <-ep.Regenerate(owner, &endpoint.ExternalRegenerationMetadata{

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -912,7 +912,7 @@ func initEnv(cmd *cobra.Command) {
 	switch option.Config.DatapathMode {
 	case option.DatapathModeVeth:
 		if name := viper.GetString(option.IpvlanMasterDevice); name != "undefined" {
-			log.WithField(logfields.Device, name).
+			log.WithField(logfields.IpvlanMasterDevice, name).
 				Fatal("ipvlan master device cannot be set in the 'veth' datapath mode")
 		}
 		if option.Config.Tunnel == "" {
@@ -942,12 +942,12 @@ func initEnv(cmd *cobra.Command) {
 		// ipvlan it is desired to have a separate one, see PR #6608.
 		option.Config.Device = viper.GetString(option.IpvlanMasterDevice)
 		if option.Config.Device == "undefined" {
-			log.WithField(logfields.Device, option.Config.Device).
+			log.WithField(logfields.IpvlanMasterDevice, option.Config.Device).
 				Fatal("ipvlan master device must be specified in the 'ipvlan' datapath mode")
 		}
 		link, err := netlink.LinkByName(option.Config.Device)
 		if err != nil {
-			log.WithError(err).WithField(logfields.Device, option.Config.Device).
+			log.WithError(err).WithField(logfields.IpvlanMasterDevice, option.Config.Device).
 				Fatal("Cannot find device interface")
 		}
 		option.Config.Ipvlan.MasterDeviceIndex = link.Attrs().Index

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -257,7 +257,7 @@ func (d *Daemon) createEndpoint(ctx context.Context, epTemplate *models.Endpoint
 
 	// Now that we have ep.ID we can pin the map from this point. This
 	// also has to happen before the first build took place.
-	if err = ep.MapPinLocked(); err != nil {
+	if err = ep.PinDatapathMap(); err != nil {
 		d.deleteEndpoint(ep)
 		log.WithError(err).Warn("Aborting endpoint tail call map pin")
 		return nil, err

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -41,7 +41,7 @@ type endpoint interface {
 	Logger(subsystem string) *logrus.Entry
 	StateDir() string
 	MapPath() string
-	MustGraft() bool
+	MustGraftDatapathMap() bool
 }
 
 // compileDatapath invokes the compiler and linker to create all state files for
@@ -85,7 +85,7 @@ func compileDatapath(ctx context.Context, ep endpoint, dirs *directoryInfo, debu
 func reloadDatapath(ctx context.Context, ep endpoint, dirs *directoryInfo) error {
 	// Replace the current program
 	objPath := path.Join(dirs.Output, endpointObj)
-	if ep.MustGraft() {
+	if ep.MustGraftDatapathMap() {
 		if err := graftDatapath(ctx, ep.MapPath(), objPath, symbolFromEndpoint); err != nil {
 			scopedLog := ep.Logger(Subsystem).WithFields(logrus.Fields{
 				logfields.Path: objPath,

--- a/pkg/datapath/loader/loader_test.go
+++ b/pkg/datapath/loader/loader_test.go
@@ -120,7 +120,7 @@ func (ep *testEP) MapPath() string {
 	return "map_path"
 }
 
-func (ep *testEP) MustGraft() bool {
+func (ep *testEP) MustGraftDatapathMap() bool {
 	return false
 }
 

--- a/pkg/endpoint/cache.go
+++ b/pkg/endpoint/cache.go
@@ -58,7 +58,7 @@ func (e *Endpoint) createEpInfoCache(epdir string) *epInfoCache {
 		id:          e.StringID(),
 		ifName:      e.IfName,
 		keys:        e.GetBPFKeys(),
-		graftToLoad: e.MustGraft(),
+		graftToLoad: e.MustGraftDatapathMap(),
 	}
 
 	var err error
@@ -91,8 +91,8 @@ func (ep *epInfoCache) Logger(subsystem string) *logrus.Entry {
 	return ep.endpoint.Logger(subsystem)
 }
 
-// MustGraft returns whether we need full replacement or grafting of object file.
-func (ep *epInfoCache) MustGraft() bool {
+// MustGraftDatapathMap returns whether we need full replacement or grafting of object file.
+func (ep *epInfoCache) MustGraftDatapathMap() bool {
 	return ep.graftToLoad
 }
 

--- a/pkg/endpoint/connector/ipvlan.go
+++ b/pkg/endpoint/connector/ipvlan.go
@@ -324,7 +324,7 @@ func CreateAndSetupIpvlanSlave(id string, slaveIfName string, netNs ns.NetNS, mt
 		return 0, fmt.Errorf("unable to setup ipvlan slave in remote netns: %s", err)
 	}
 
-	ep.DataPathMapID = int64(mapID)
+	ep.DatapathMapID = int64(mapID)
 
 	return mapFD, nil
 }

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -337,8 +337,9 @@ func (e *Endpoint) HasIpvlanDataPath() bool {
 	return false
 }
 
-// MustGraft returns whether we need full replacement or grafting of object file.
-func (e *Endpoint) MustGraft() bool {
+// MustGraftDatapathMap returns whether we need full replacement or grafting of
+// object file.
+func (e *Endpoint) MustGraftDatapathMap() bool {
 	return e.HasIpvlanDataPath()
 }
 
@@ -1599,7 +1600,7 @@ func (e *Endpoint) GetDockerNetworkID() string {
 // SetDatapathMapIDAndPinMapLocked modifies the endpoint's datapath map ID
 func (e *Endpoint) SetDatapathMapIDAndPinMapLocked(id int) error {
 	e.DataPathMapID = id
-	return e.MapPinLocked()
+	return e.PinDatapathMap()
 }
 
 // IsDatapathMapPinnedLocked returns whether the endpoint's datapath map has been pinned
@@ -2254,9 +2255,9 @@ func (e *Endpoint) IsDisconnecting() bool {
 	return e.state == StateDisconnected || e.state == StateDisconnecting
 }
 
-// MapPinLocked retrieves a file descriptor from the map ID from the API call
+// PinDatapathMap retrieves a file descriptor from the map ID from the API call
 // and pins the corresponding map into the BPF file system.
-func (e *Endpoint) MapPinLocked() error {
+func (e *Endpoint) PinDatapathMap() error {
 	if e.DataPathMapID == 0 {
 		return nil
 	}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -142,7 +142,7 @@ type Endpoint struct {
 	DockerEndpointID string
 
 	// Corresponding BPF map identifier for tail call map of ipvlan datapath
-	DataPathMapID int
+	DatapathMapID int
 
 	// isDatapathMapPinned denotes whether the datapath map has been pinned.
 	isDatapathMapPinned bool
@@ -331,7 +331,7 @@ func (e *Endpoint) HasBPFProgram() bool {
 
 // HasIpvlanDataPath returns whether the daemon is running in ipvlan mode.
 func (e *Endpoint) HasIpvlanDataPath() bool {
-	if e.DataPathMapID > 0 {
+	if e.DatapathMapID > 0 {
 		return true
 	}
 	return false
@@ -438,7 +438,7 @@ func NewEndpointFromChangeModel(base *models.EndpointChangeRequest) (*Endpoint, 
 		IfName:           base.InterfaceName,
 		K8sPodName:       base.K8sPodName,
 		K8sNamespace:     base.K8sNamespace,
-		DataPathMapID:    int(base.DataPathMapID),
+		DatapathMapID:    int(base.DatapathMapID),
 		IfIndex:          int(base.InterfaceIndex),
 		OpLabels:         pkgLabels.NewOpLabels(),
 		DNSHistory:       fqdn.NewDNSCache(),
@@ -1599,7 +1599,7 @@ func (e *Endpoint) GetDockerNetworkID() string {
 
 // SetDatapathMapIDAndPinMapLocked modifies the endpoint's datapath map ID
 func (e *Endpoint) SetDatapathMapIDAndPinMapLocked(id int) error {
-	e.DataPathMapID = id
+	e.DatapathMapID = id
 	return e.PinDatapathMap()
 }
 
@@ -2258,11 +2258,11 @@ func (e *Endpoint) IsDisconnecting() bool {
 // PinDatapathMap retrieves a file descriptor from the map ID from the API call
 // and pins the corresponding map into the BPF file system.
 func (e *Endpoint) PinDatapathMap() error {
-	if e.DataPathMapID == 0 {
+	if e.DatapathMapID == 0 {
 		return nil
 	}
 
-	mapFd, err := bpf.MapFdFromID(e.DataPathMapID)
+	mapFd, err := bpf.MapFdFromID(e.DatapathMapID)
 	if err != nil {
 		return err
 	}

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -195,6 +195,9 @@ const (
 	// Device is the device name
 	Device = "device"
 
+	// IpvlanMasterDevice is the ipvlan master device name
+	IpvlanMasterDevice = "ipvlanMasterDevice"
+
 	// DatapathMode is the datapath mode name
 	DatapathMode = "datapathMode"
 


### PR DESCRIPTION
This PR:

- (Hopefully) improves naming of some ipvlan-related endpoint methods.
- Fixes `logfields.Device` usage.
- Renames `DataPathMapID` to `DatapathMapID`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6881)
<!-- Reviewable:end -->
