### PR TITLE
daemon: only fatal if err != nil

### DIFF
--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -1191,9 +1191,13 @@ func runDaemon() {
 
 	select {
 	case err := <-metricsErrs:
-		log.WithError(err).Fatal("Cannot start metrics server")
+		if err != nil {
+			log.WithError(err).Fatal("Cannot start metrics server")
+		}
 	case err := <-errs:
-		log.WithError(err).Fatal("Error returned from non-returning Serve() call")
+		if err != nil {
+			log.WithError(err).Fatal("Error returned from non-returning Serve() call")
+		}
 	}
 }
 


### PR DESCRIPTION
This commit avoids cilium-agent from fatal itself on an expected exit
signal such as:

```
cilium-agent[11272]: level=info msg="Stopped serving cilium at unix:///var/run/cilium/cilium.sock" subsys=daemon
cilium-agent[11272]: level=fatal msg="Error returned from non-returning Serve() call" error="<nil>" subsys=daemon
```

Fixes: 894365fc6b0e ("daemon: Handle listen/serve errors with channels")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6887)
<!-- Reviewable:end -->
