### PR TITLE
examples/kubernetes: clean k8s descriptors

### DIFF
--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -548,19 +548,17 @@ spec:
           defaultMode: 420
           optional: true
           secretName: cilium-etcd-secrets
-
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-operator
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - ""
@@ -589,11 +587,10 @@ rules:
   verbs:
   - '*'
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -607,7 +604,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-etcd-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -677,7 +673,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-etcd-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -691,7 +686,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: etcd-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -745,7 +739,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: etcd-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -755,8 +748,8 @@ subjects:
   name: cilium-etcd-sa
   namespace: kube-system
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-etcd-operator
   namespace: kube-system

--- a/examples/kubernetes/1.10/cilium-etcd-operator-rbac.yaml
+++ b/examples/kubernetes/1.10/cilium-etcd-operator-rbac.yaml
@@ -3,7 +3,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-etcd-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -73,7 +72,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-etcd-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -87,7 +85,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: etcd-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -141,7 +138,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: etcd-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/examples/kubernetes/1.10/cilium-etcd-operator-sa.yaml
+++ b/examples/kubernetes/1.10/cilium-etcd-operator-sa.yaml
@@ -1,6 +1,6 @@
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-etcd-operator
   namespace: kube-system

--- a/examples/kubernetes/1.10/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.10/cilium-external-etcd.yaml
@@ -547,19 +547,17 @@ spec:
           defaultMode: 420
           optional: true
           secretName: cilium-etcd-secrets
-
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-operator
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - ""
@@ -588,11 +586,10 @@ rules:
   verbs:
   - '*'
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/examples/kubernetes/1.10/cilium-operator.yaml
+++ b/examples/kubernetes/1.10/cilium-operator.yaml
@@ -107,19 +107,17 @@ spec:
           defaultMode: 420
           optional: true
           secretName: cilium-etcd-secrets
-
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-operator
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - ""
@@ -148,11 +146,10 @@ rules:
   verbs:
   - '*'
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/examples/kubernetes/1.10/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.10/cilium-with-node-init.yaml
@@ -547,19 +547,17 @@ spec:
           defaultMode: 420
           optional: true
           secretName: cilium-etcd-secrets
-
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-operator
   namespace: cilium
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-operator
-  namespace: cilium
 rules:
 - apiGroups:
   - ""
@@ -588,11 +586,10 @@ rules:
   verbs:
   - '*'
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-operator
-  namespace: cilium
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -606,7 +603,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-etcd-operator
-  namespace: cilium
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -676,7 +672,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-etcd-operator
-  namespace: cilium
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -690,7 +685,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: etcd-operator
-  namespace: cilium
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -744,7 +738,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: etcd-operator
-  namespace: cilium
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -754,8 +747,8 @@ subjects:
   name: cilium-etcd-sa
   namespace: cilium
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-etcd-operator
   namespace: cilium

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -547,19 +547,17 @@ spec:
           defaultMode: 420
           optional: true
           secretName: cilium-etcd-secrets
-
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-operator
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - ""
@@ -588,11 +586,10 @@ rules:
   verbs:
   - '*'
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -606,7 +603,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-etcd-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -676,7 +672,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-etcd-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -690,7 +685,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: etcd-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -744,7 +738,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: etcd-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -754,8 +747,8 @@ subjects:
   name: cilium-etcd-sa
   namespace: kube-system
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-etcd-operator
   namespace: kube-system

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -541,19 +541,17 @@ spec:
           defaultMode: 420
           optional: true
           secretName: cilium-etcd-secrets
-
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-operator
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - ""
@@ -582,11 +580,10 @@ rules:
   verbs:
   - '*'
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -600,7 +597,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-etcd-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -670,7 +666,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-etcd-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -684,7 +679,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: etcd-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -738,7 +732,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: etcd-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -748,8 +741,8 @@ subjects:
   name: cilium-etcd-sa
   namespace: kube-system
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-etcd-operator
   namespace: kube-system

--- a/examples/kubernetes/1.11/cilium-etcd-operator-rbac.yaml
+++ b/examples/kubernetes/1.11/cilium-etcd-operator-rbac.yaml
@@ -3,7 +3,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-etcd-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -73,7 +72,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-etcd-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -87,7 +85,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: etcd-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -141,7 +138,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: etcd-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/examples/kubernetes/1.11/cilium-etcd-operator-sa.yaml
+++ b/examples/kubernetes/1.11/cilium-etcd-operator-sa.yaml
@@ -1,6 +1,6 @@
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-etcd-operator
   namespace: kube-system

--- a/examples/kubernetes/1.11/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.11/cilium-external-etcd.yaml
@@ -549,19 +549,17 @@ spec:
           defaultMode: 420
           optional: true
           secretName: cilium-etcd-secrets
-
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-operator
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - ""
@@ -590,11 +588,10 @@ rules:
   verbs:
   - '*'
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/examples/kubernetes/1.11/cilium-operator.yaml
+++ b/examples/kubernetes/1.11/cilium-operator.yaml
@@ -108,19 +108,17 @@ spec:
           defaultMode: 420
           optional: true
           secretName: cilium-etcd-secrets
-
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-operator
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - ""
@@ -149,11 +147,10 @@ rules:
   verbs:
   - '*'
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/examples/kubernetes/1.11/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.11/cilium-with-node-init.yaml
@@ -547,19 +547,17 @@ spec:
           defaultMode: 420
           optional: true
           secretName: cilium-etcd-secrets
-
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-operator
   namespace: cilium
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-operator
-  namespace: cilium
 rules:
 - apiGroups:
   - ""
@@ -588,11 +586,10 @@ rules:
   verbs:
   - '*'
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-operator
-  namespace: cilium
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -606,7 +603,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-etcd-operator
-  namespace: cilium
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -676,7 +672,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-etcd-operator
-  namespace: cilium
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -690,7 +685,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: etcd-operator
-  namespace: cilium
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -744,7 +738,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: etcd-operator
-  namespace: cilium
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -754,8 +747,8 @@ subjects:
   name: cilium-etcd-sa
   namespace: cilium
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-etcd-operator
   namespace: cilium

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -549,19 +549,17 @@ spec:
           defaultMode: 420
           optional: true
           secretName: cilium-etcd-secrets
-
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-operator
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - ""
@@ -590,11 +588,10 @@ rules:
   verbs:
   - '*'
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -608,7 +605,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-etcd-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -678,7 +674,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-etcd-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -692,7 +687,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: etcd-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -746,7 +740,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: etcd-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -756,8 +749,8 @@ subjects:
   name: cilium-etcd-sa
   namespace: kube-system
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-etcd-operator
   namespace: kube-system

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -541,19 +541,17 @@ spec:
           defaultMode: 420
           optional: true
           secretName: cilium-etcd-secrets
-
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-operator
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - ""
@@ -582,11 +580,10 @@ rules:
   verbs:
   - '*'
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -600,7 +597,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-etcd-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -670,7 +666,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-etcd-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -684,7 +679,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: etcd-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -738,7 +732,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: etcd-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -748,8 +741,8 @@ subjects:
   name: cilium-etcd-sa
   namespace: kube-system
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-etcd-operator
   namespace: kube-system

--- a/examples/kubernetes/1.12/cilium-etcd-operator-rbac.yaml
+++ b/examples/kubernetes/1.12/cilium-etcd-operator-rbac.yaml
@@ -3,7 +3,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-etcd-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -73,7 +72,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-etcd-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -87,7 +85,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: etcd-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -141,7 +138,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: etcd-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/examples/kubernetes/1.12/cilium-etcd-operator-sa.yaml
+++ b/examples/kubernetes/1.12/cilium-etcd-operator-sa.yaml
@@ -1,6 +1,6 @@
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-etcd-operator
   namespace: kube-system

--- a/examples/kubernetes/1.12/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.12/cilium-external-etcd.yaml
@@ -549,19 +549,17 @@ spec:
           defaultMode: 420
           optional: true
           secretName: cilium-etcd-secrets
-
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-operator
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - ""
@@ -590,11 +588,10 @@ rules:
   verbs:
   - '*'
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/examples/kubernetes/1.12/cilium-operator.yaml
+++ b/examples/kubernetes/1.12/cilium-operator.yaml
@@ -108,19 +108,17 @@ spec:
           defaultMode: 420
           optional: true
           secretName: cilium-etcd-secrets
-
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-operator
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - ""
@@ -149,11 +147,10 @@ rules:
   verbs:
   - '*'
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/examples/kubernetes/1.12/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.12/cilium-with-node-init.yaml
@@ -547,19 +547,17 @@ spec:
           defaultMode: 420
           optional: true
           secretName: cilium-etcd-secrets
-
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-operator
   namespace: cilium
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-operator
-  namespace: cilium
 rules:
 - apiGroups:
   - ""
@@ -588,11 +586,10 @@ rules:
   verbs:
   - '*'
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-operator
-  namespace: cilium
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -606,7 +603,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-etcd-operator
-  namespace: cilium
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -676,7 +672,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-etcd-operator
-  namespace: cilium
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -690,7 +685,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: etcd-operator
-  namespace: cilium
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -744,7 +738,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: etcd-operator
-  namespace: cilium
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -754,8 +747,8 @@ subjects:
   name: cilium-etcd-sa
   namespace: cilium
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-etcd-operator
   namespace: cilium

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -549,19 +549,17 @@ spec:
           defaultMode: 420
           optional: true
           secretName: cilium-etcd-secrets
-
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-operator
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - ""
@@ -590,11 +588,10 @@ rules:
   verbs:
   - '*'
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -608,7 +605,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-etcd-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -678,7 +674,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-etcd-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -692,7 +687,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: etcd-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -746,7 +740,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: etcd-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -756,8 +749,8 @@ subjects:
   name: cilium-etcd-sa
   namespace: kube-system
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-etcd-operator
   namespace: kube-system

--- a/examples/kubernetes/1.13/cilium-crio.yaml
+++ b/examples/kubernetes/1.13/cilium-crio.yaml
@@ -541,19 +541,17 @@ spec:
           defaultMode: 420
           optional: true
           secretName: cilium-etcd-secrets
-
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-operator
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - ""
@@ -582,11 +580,10 @@ rules:
   verbs:
   - '*'
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -600,7 +597,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-etcd-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -670,7 +666,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-etcd-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -684,7 +679,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: etcd-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -738,7 +732,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: etcd-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -748,8 +741,8 @@ subjects:
   name: cilium-etcd-sa
   namespace: kube-system
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-etcd-operator
   namespace: kube-system

--- a/examples/kubernetes/1.13/cilium-etcd-operator-rbac.yaml
+++ b/examples/kubernetes/1.13/cilium-etcd-operator-rbac.yaml
@@ -3,7 +3,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-etcd-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -73,7 +72,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-etcd-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -87,7 +85,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: etcd-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -141,7 +138,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: etcd-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/examples/kubernetes/1.13/cilium-etcd-operator-sa.yaml
+++ b/examples/kubernetes/1.13/cilium-etcd-operator-sa.yaml
@@ -1,6 +1,6 @@
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-etcd-operator
   namespace: kube-system

--- a/examples/kubernetes/1.13/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.13/cilium-external-etcd.yaml
@@ -549,19 +549,17 @@ spec:
           defaultMode: 420
           optional: true
           secretName: cilium-etcd-secrets
-
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-operator
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - ""
@@ -590,11 +588,10 @@ rules:
   verbs:
   - '*'
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/examples/kubernetes/1.13/cilium-operator.yaml
+++ b/examples/kubernetes/1.13/cilium-operator.yaml
@@ -108,19 +108,17 @@ spec:
           defaultMode: 420
           optional: true
           secretName: cilium-etcd-secrets
-
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-operator
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - ""
@@ -149,11 +147,10 @@ rules:
   verbs:
   - '*'
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/examples/kubernetes/1.13/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.13/cilium-with-node-init.yaml
@@ -547,19 +547,17 @@ spec:
           defaultMode: 420
           optional: true
           secretName: cilium-etcd-secrets
-
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-operator
   namespace: cilium
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-operator
-  namespace: cilium
 rules:
 - apiGroups:
   - ""
@@ -588,11 +586,10 @@ rules:
   verbs:
   - '*'
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-operator
-  namespace: cilium
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -606,7 +603,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-etcd-operator
-  namespace: cilium
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -676,7 +672,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-etcd-operator
-  namespace: cilium
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -690,7 +685,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: etcd-operator
-  namespace: cilium
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -744,7 +738,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: etcd-operator
-  namespace: cilium
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -754,8 +747,8 @@ subjects:
   name: cilium-etcd-sa
   namespace: cilium
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-etcd-operator
   namespace: cilium

--- a/examples/kubernetes/1.13/cilium.yaml
+++ b/examples/kubernetes/1.13/cilium.yaml
@@ -549,19 +549,17 @@ spec:
           defaultMode: 420
           optional: true
           secretName: cilium-etcd-secrets
-
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-operator
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - ""
@@ -590,11 +588,10 @@ rules:
   verbs:
   - '*'
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -608,7 +605,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-etcd-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -678,7 +674,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-etcd-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -692,7 +687,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: etcd-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -746,7 +740,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: etcd-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -756,8 +749,8 @@ subjects:
   name: cilium-etcd-sa
   namespace: kube-system
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-etcd-operator
   namespace: kube-system

--- a/examples/kubernetes/1.8/cilium-crio.yaml
+++ b/examples/kubernetes/1.8/cilium-crio.yaml
@@ -548,10 +548,9 @@ spec:
           defaultMode: 420
           optional: true
           secretName: cilium-etcd-secrets
-
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-operator
   namespace: kube-system
@@ -560,7 +559,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: cilium-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - ""
@@ -593,7 +591,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -607,7 +604,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: cilium-etcd-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -677,7 +673,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-etcd-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -691,7 +686,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: etcd-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -745,7 +739,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: etcd-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -755,8 +748,8 @@ subjects:
   name: cilium-etcd-sa
   namespace: kube-system
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-etcd-operator
   namespace: kube-system

--- a/examples/kubernetes/1.8/cilium-etcd-operator-rbac.yaml
+++ b/examples/kubernetes/1.8/cilium-etcd-operator-rbac.yaml
@@ -3,7 +3,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: cilium-etcd-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -73,7 +72,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-etcd-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -87,7 +85,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: etcd-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -141,7 +138,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: etcd-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/examples/kubernetes/1.8/cilium-etcd-operator-sa.yaml
+++ b/examples/kubernetes/1.8/cilium-etcd-operator-sa.yaml
@@ -1,6 +1,6 @@
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-etcd-operator
   namespace: kube-system

--- a/examples/kubernetes/1.8/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.8/cilium-external-etcd.yaml
@@ -547,10 +547,9 @@ spec:
           defaultMode: 420
           optional: true
           secretName: cilium-etcd-secrets
-
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-operator
   namespace: kube-system
@@ -559,7 +558,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: cilium-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - ""
@@ -592,7 +590,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/examples/kubernetes/1.8/cilium-operator.yaml
+++ b/examples/kubernetes/1.8/cilium-operator.yaml
@@ -107,10 +107,9 @@ spec:
           defaultMode: 420
           optional: true
           secretName: cilium-etcd-secrets
-
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-operator
   namespace: kube-system
@@ -119,7 +118,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: cilium-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - ""
@@ -152,7 +150,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/examples/kubernetes/1.8/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.8/cilium-with-node-init.yaml
@@ -547,10 +547,9 @@ spec:
           defaultMode: 420
           optional: true
           secretName: cilium-etcd-secrets
-
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-operator
   namespace: cilium
@@ -559,7 +558,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: cilium-operator
-  namespace: cilium
 rules:
 - apiGroups:
   - ""
@@ -592,7 +590,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-operator
-  namespace: cilium
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -606,7 +603,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: cilium-etcd-operator
-  namespace: cilium
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -676,7 +672,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-etcd-operator
-  namespace: cilium
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -690,7 +685,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: etcd-operator
-  namespace: cilium
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -744,7 +738,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: etcd-operator
-  namespace: cilium
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -754,8 +747,8 @@ subjects:
   name: cilium-etcd-sa
   namespace: cilium
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-etcd-operator
   namespace: cilium

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -547,10 +547,9 @@ spec:
           defaultMode: 420
           optional: true
           secretName: cilium-etcd-secrets
-
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-operator
   namespace: kube-system
@@ -559,7 +558,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: cilium-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - ""
@@ -592,7 +590,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -606,7 +603,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: cilium-etcd-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -676,7 +672,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-etcd-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -690,7 +685,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: etcd-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -744,7 +738,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: etcd-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -754,8 +747,8 @@ subjects:
   name: cilium-etcd-sa
   namespace: kube-system
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-etcd-operator
   namespace: kube-system

--- a/examples/kubernetes/1.9/cilium-crio.yaml
+++ b/examples/kubernetes/1.9/cilium-crio.yaml
@@ -548,19 +548,17 @@ spec:
           defaultMode: 420
           optional: true
           secretName: cilium-etcd-secrets
-
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-operator
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - ""
@@ -589,11 +587,10 @@ rules:
   verbs:
   - '*'
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -607,7 +604,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-etcd-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -677,7 +673,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-etcd-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -691,7 +686,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: etcd-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -745,7 +739,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: etcd-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -755,8 +748,8 @@ subjects:
   name: cilium-etcd-sa
   namespace: kube-system
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-etcd-operator
   namespace: kube-system

--- a/examples/kubernetes/1.9/cilium-etcd-operator-rbac.yaml
+++ b/examples/kubernetes/1.9/cilium-etcd-operator-rbac.yaml
@@ -3,7 +3,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-etcd-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -73,7 +72,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-etcd-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -87,7 +85,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: etcd-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -141,7 +138,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: etcd-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/examples/kubernetes/1.9/cilium-etcd-operator-sa.yaml
+++ b/examples/kubernetes/1.9/cilium-etcd-operator-sa.yaml
@@ -1,6 +1,6 @@
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-etcd-operator
   namespace: kube-system

--- a/examples/kubernetes/1.9/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.9/cilium-external-etcd.yaml
@@ -547,19 +547,17 @@ spec:
           defaultMode: 420
           optional: true
           secretName: cilium-etcd-secrets
-
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-operator
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - ""
@@ -588,11 +586,10 @@ rules:
   verbs:
   - '*'
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/examples/kubernetes/1.9/cilium-operator.yaml
+++ b/examples/kubernetes/1.9/cilium-operator.yaml
@@ -107,19 +107,17 @@ spec:
           defaultMode: 420
           optional: true
           secretName: cilium-etcd-secrets
-
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-operator
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - ""
@@ -148,11 +146,10 @@ rules:
   verbs:
   - '*'
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/examples/kubernetes/1.9/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.9/cilium-with-node-init.yaml
@@ -547,19 +547,17 @@ spec:
           defaultMode: 420
           optional: true
           secretName: cilium-etcd-secrets
-
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-operator
   namespace: cilium
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-operator
-  namespace: cilium
 rules:
 - apiGroups:
   - ""
@@ -588,11 +586,10 @@ rules:
   verbs:
   - '*'
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-operator
-  namespace: cilium
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -606,7 +603,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-etcd-operator
-  namespace: cilium
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -676,7 +672,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-etcd-operator
-  namespace: cilium
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -690,7 +685,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: etcd-operator
-  namespace: cilium
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -744,7 +738,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: etcd-operator
-  namespace: cilium
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -754,8 +747,8 @@ subjects:
   name: cilium-etcd-sa
   namespace: cilium
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-etcd-operator
   namespace: cilium

--- a/examples/kubernetes/1.9/cilium.yaml
+++ b/examples/kubernetes/1.9/cilium.yaml
@@ -547,19 +547,17 @@ spec:
           defaultMode: 420
           optional: true
           secretName: cilium-etcd-secrets
-
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-operator
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - ""
@@ -588,11 +586,10 @@ rules:
   verbs:
   - '*'
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -606,7 +603,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-etcd-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -676,7 +672,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-etcd-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -690,7 +685,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: etcd-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -744,7 +738,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: etcd-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -754,8 +747,8 @@ subjects:
   name: cilium-etcd-sa
   namespace: kube-system
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-etcd-operator
   namespace: kube-system

--- a/examples/kubernetes/templates/v1/cilium-etcd-operator-rbac.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-etcd-operator-rbac.yaml.sed
@@ -3,7 +3,6 @@ apiVersion: __RBAC_API_VERSION__
 kind: ClusterRole
 metadata:
   name: cilium-etcd-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -73,7 +72,6 @@ apiVersion: __RBAC_API_VERSION__
 kind: ClusterRoleBinding
 metadata:
   name: cilium-etcd-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -87,7 +85,6 @@ apiVersion: __RBAC_API_VERSION__
 kind: ClusterRole
 metadata:
   name: etcd-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - etcd.database.coreos.com
@@ -141,7 +138,6 @@ apiVersion: __RBAC_API_VERSION__
 kind: ClusterRoleBinding
 metadata:
   name: etcd-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/examples/kubernetes/templates/v1/cilium-etcd-operator-sa.yaml
+++ b/examples/kubernetes/templates/v1/cilium-etcd-operator-sa.yaml
@@ -1,6 +1,6 @@
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-etcd-operator
   namespace: kube-system

--- a/examples/kubernetes/templates/v1/cilium-operator.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-operator.yaml.sed
@@ -107,19 +107,17 @@ spec:
           defaultMode: 420
           optional: true
           secretName: cilium-etcd-secrets
-
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: cilium-operator
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: __RBAC_API_VERSION__
 kind: ClusterRole
 metadata:
   name: cilium-operator
-  namespace: kube-system
 rules:
 - apiGroups:
   - ""
@@ -148,11 +146,10 @@ rules:
   verbs:
   - '*'
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: __RBAC_API_VERSION__
 kind: ClusterRoleBinding
 metadata:
   name: cilium-operator
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
Clean up the k8s descriptors in particular removing non-existing fields
(namespace) for non-namespaced objects and setting the right API
Version.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6889)
<!-- Reviewable:end -->
