### PR TITLE
cilium: fix fd leak from ObjClose being omitted on ConfigMap

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1447,6 +1447,12 @@ func (e *Endpoint) LeaveLocked(owner Owner, proxyWaitGroup *completion.WaitGroup
 		}
 	}
 
+	if e.bpfConfigMap != nil {
+		if err := e.bpfConfigMap.Close(); err != nil {
+			errors = append(errors, fmt.Errorf("unable to close configmap %s: %s", e.BPFConfigMapPath(), err))
+		}
+	}
+
 	if e.SecurityIdentity != nil {
 		_, err := cache.Release(e.SecurityIdentity)
 		if err != nil {

--- a/pkg/maps/configmap/configmap.go
+++ b/pkg/maps/configmap/configmap.go
@@ -135,7 +135,7 @@ type endpoint interface {
 
 // EndpointConfigMap is a map type for interfacing with endpoint BPF config.
 type EndpointConfigMap struct {
-	Map  *bpf.Map
+	*bpf.Map
 	path string
 	Fd   int
 }


### PR DESCRIPTION
Watching bpftool maps via 'bpftool show map' shows the ConfigMap is
not being removed when an endpoint is deleted. This results in the
number of active fd's growing until eventually fd space is exhausted.

This fix copies the policymap approach and similarly adds the Close
hook to ConfigMap and calls it from LeaveLocked()

Fixes: #6803

Signed-off-by: John Fastabend <john.fastabend@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6890)
<!-- Reviewable:end -->
