### PR TITLE
node: fix unused import

### DIFF
--- a/pkg/node/node_address_darwin.go
+++ b/pkg/node/node_address_darwin.go
@@ -18,8 +18,6 @@ package node
 
 import (
 	"net"
-
-	"github.com/vishvananda/netlink"
 )
 
 func firstGlobalV4Addr(intf string) (net.IP, error) {


### PR DESCRIPTION
The netlink import wasn't being used, which caused compilation errors when
running unit tests on macOS setups.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6892)
<!-- Reviewable:end -->
