### PR TITLE
v1.2 backports 2019-02-01

### DIFF
--- a/Documentation/contributing.rst
+++ b/Documentation/contributing.rst
@@ -1997,11 +1997,22 @@ the process for backporting these PRs.
 
         $ GITHUB_TOKEN=xxx contrib/backporting/check-stable 1.0
 
+   .. note::
+      ``contrib/backporting/check-stable`` accepts a second argument to
+      specify a path to write a nicely-formatted pull request message to.
+      This can be used alongside
+      `Github command-line tools <https://github.com/node-gh/gh>`__ to
+      send the pull request from the command line in steps 9-10 via
+      ``gh pull-request -b vX.Y -l backport/vX.Y -F <path>``.
+
 7. Cherry-pick the commits using the master git SHAs listed, starting
    from the oldest (bottom), working your way up and fixing any merge
    conflicts as they appear. Note that for PRs that have multiple
    commits you will want to check that you are cherry-picking oldest
-   commits first.
+   commits first. The ``cherry-pick`` script accepts multiple arguments,
+   in which case it will attempt to apply each commit in the order
+   specified on the command line until one cherry pick fails or every
+   commit is cherry-picked.
 
 .. code-block:: bash
 

--- a/Documentation/contributing.rst
+++ b/Documentation/contributing.rst
@@ -1269,7 +1269,7 @@ Alternatively you can use a Docker container to build the pages:
 This builds the docs in a container and builds and starts a web server with
 your document changes.
 
-Now the documentation page should be browsable on http://localhost:8080.
+Now the documentation page should be browsable on http://localhost:9080.
 
 .. _ci_jenkins:
 

--- a/Documentation/contributing.rst
+++ b/Documentation/contributing.rst
@@ -1978,10 +1978,10 @@ the process for backporting these PRs.
    to configure git to have your name and email address to be used in
    the commit messages:
 
-.. code-block:: bash
+   .. code-block:: bash
 
-        $ git config --global user.name "John Doe"
-        $ git config --global user.email johndoe@example.com
+      $ git config --global user.name "John Doe"
+      $ git config --global user.email johndoe@example.com
 
 3. Make sure you have your a GitHub developer access token
    available. For details, see `contrib/backporting/README.md
@@ -1993,9 +1993,9 @@ the process for backporting these PRs.
    token, this will list the commits that need backporting, from the
    newest to oldest:
 
-.. code-block:: bash
+   .. code-block:: bash
 
-        $ GITHUB_TOKEN=xxx contrib/backporting/check-stable 1.0
+      $ GITHUB_TOKEN=xxx contrib/backporting/check-stable 1.0
 
    .. note::
       ``contrib/backporting/check-stable`` accepts a second argument to
@@ -2014,11 +2014,11 @@ the process for backporting these PRs.
    specified on the command line until one cherry pick fails or every
    commit is cherry-picked.
 
-.. code-block:: bash
+   .. code-block:: bash
 
-        $ contrib/backporting/cherry-pick <oldest-commit-sha>
-        ...
-        $ contrib/backporting/cherry-pick <newest-commit-sha>
+      $ contrib/backporting/cherry-pick <oldest-commit-sha>
+      ...
+      $ contrib/backporting/cherry-pick <newest-commit-sha>
 
 8. Push your backports branch to cilium repo, e.g., ``git push -u origin pr/v1.0-backports-YY-MM-DD``
 9. In Github, create a new PR from your branch towards the feature

--- a/Documentation/contributing.rst
+++ b/Documentation/contributing.rst
@@ -1963,17 +1963,16 @@ For the final release
 Backporting process
 ~~~~~~~~~~~~~~~~~~~
 
-Cilium PRs that are marked with label ``stable/needs-backport`` need to be backported to the stable branch(es), listed below. Following steps summarize the process.
+Cilium PRs that are marked with the label ``needs-backport/X.Y`` need to be
+backported to the stable branch ``X.Y``. The following steps summarize
+the process for backporting these PRs.
 
 1. Make sure the Github labels are up-to-date, as this process will
-   deal with all commits from PRs that have the
-   ``stable/needs-backport`` set.  Especially, clear
-   ``stable/backport-triage``, ``stable/backport-pending`` and
-   ``stable/needs-backport`` labels from PRs that have already been
-   backported as indicated by ``stable/backport-done`` label.
-   Generally, if a PR has multiple ``backport`` labels set you will
-   need to figure out the status of that PR's backport to clean up the
-   labels before proceeding.
+   deal with all commits from PRs that have the ``needs-backport/X.Y`` label
+   set (for a stable release version X.Y). If any PRs contain labels such as
+   ``backport-pending/X.Y``, ensure that the backport for that PR have been
+   merged and if so, change the label to ``backport-done/X.Y``.
+
 2. The scripts referred to below need to be run in Linux, they do not
    work on OSX.  You can use the cilium dev VM for this, but you need
    to configure git to have your name and email address to be used in
@@ -1988,22 +1987,17 @@ Cilium PRs that are marked with label ``stable/needs-backport`` need to be backp
    available. For details, see `contrib/backporting/README.md
    <https://github.com/cilium/cilium/blob/master/contrib/backporting/README.md>`_
 4. Fetch the repo, e.g., ``git fetch``
-5. Check out the stable branch you are backporting to, e.g., ``git
-   checkout v1.0``
-6. Create a new branch for your backports, e.g., ``git branch
-   v1.0-backports-YY-MM-DD``
-7. Check out your backports branch, e.g., ``git checkout v1.0-backports-YY-MM-DD``
-8. Run the ``check-stable`` script, referring to your Github access
+5. Check a new branch for your backports based on the stable branch for that
+   version, e.g., ``git checkout -b pr/v1.0-backport-YY-MM-DD origin/v1.0``
+6. Run the ``check-stable`` script, referring to your Github access
    token, this will list the commits that need backporting, from the
    newest to oldest:
-9. ``check-stable`` has a optional argument that it's the target version to
-   backport.
 
 .. code-block:: bash
 
         $ GITHUB_TOKEN=xxx contrib/backporting/check-stable 1.0
 
-9. Cherry-pick the commits using the master git SHAs listed, starting
+7. Cherry-pick the commits using the master git SHAs listed, starting
    from the oldest (bottom), working your way up and fixing any merge
    conflicts as they appear. Note that for PRs that have multiple
    commits you will want to check that you are cherry-picking oldest
@@ -2015,24 +2009,33 @@ Cilium PRs that are marked with label ``stable/needs-backport`` need to be backp
         ...
         $ contrib/backporting/cherry-pick <newest-commit-sha>
 
-10. Push your backports branch to cilium repo, e.g., ``git push -u
-    origin v1.0-backports-YY-MM-DD``
-11. In Github, create a new PR from you branch towards the feature
-    branch you are backporting to. Note that by default Github creates
-    PRs against the master branch, so you will need to change it.
-12. Label the new backport PR as ``stable/backport`` so that it is
-    easy to find backport PRs later.
-13. Mark all PRs you backported with ``stable/backport-pending`` label
-    and clear the ``stable/needs-backport`` label.  Note that using
-    the GitHub web interface it is better to add new labels first so
-    that you can still find the PRs using either the new or old label!
-    You can also do this with
-    ``contrib/backporting/set-labels.py <original PR ID> pending <version(defaults to 1.0)>``.
-14. After the backport PR is merged, mark all backported PRs with
-    ``stable/backport-done`` label and clear the
-    ``stable/backport-pending`` label.
-    This can be achieved by
-    ``contrib/backporting/set-labels.py <original PR ID> done <version(defaults to 1.0)>``.
+8. Push your backports branch to cilium repo, e.g., ``git push -u origin pr/v1.0-backports-YY-MM-DD``
+9. In Github, create a new PR from your branch towards the feature
+   branch you are backporting to. Note that by default Github creates
+   PRs against the master branch, so you will need to change it.
+10. Label the new backport PR with the backport label for the stable branch
+    such as ``backport/X.Y`` so that it is easy to find backport PRs later.
+11. Mark all PRs you backported with the backport pending label ``backport-pending/X.Y``
+    and clear the ``needs-backport/vX.Y`` label. This can be via the GitHub
+    interface, or using the backport script ``contrib/backporting/set-labels.py``, e.g.:
+
+    .. code-block:: bash
+
+        # Set PR 1234's v1.0 backporting labels to pending
+        $ contrib/backporting/set-labels.py 1234 pending 1.0
+
+    .. note::
+
+        ``contrib/backporting/set-labels.py`` requires Python 3 and
+        `PyGithub <https://pypi.org/project/PyGithub/>`_ installed.
+
+12. After the backport PR is merged, mark all backported PRs with
+    ``backport-done/X.Y`` label and clear the ``backport-pending/X.Y`` label(s).
+
+    .. code-block:: bash
+
+        # Set PR 1234's v1.0 backporting labels to done
+        contrib/backporting/set-labels.py 1234 done 1.0.
 
 Update cilium-builder and cilium-runtime images
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Makefile
+++ b/Makefile
@@ -271,8 +271,8 @@ docs-container:
 render-docs: docs-container
 	-docker container rm -f docs-cilium >/dev/null
 	docker container run -ti -v $$(pwd):/srv/ cilium/docs-builder /bin/bash -c 'make html' && \
-	docker container run -dit --name docs-cilium -p 8080:80 -v $$(pwd)/Documentation/_build/html/:/usr/local/apache2/htdocs/ httpd:2.4
-	@echo "$$(tput setaf 2)Running at http://localhost:8080$$(tput sgr0)"
+	docker container run -dit --name docs-cilium -p 9080:80 -v $$(pwd)/Documentation/_build/html/:/usr/local/apache2/htdocs/ httpd:2.4
+	@echo "$$(tput setaf 2)Running at http://localhost:9080$$(tput sgr0)"
 
 test-docs: docs-container
 	-docker container rm -f docs-cilium >/dev/null

--- a/contrib/backporting/check-stable
+++ b/contrib/backporting/check-stable
@@ -188,4 +188,12 @@ if [[ ${#stable_prs[@]} > 0 ]]; then
     generate_commit_list_for_pr $pr
     echo ""
   done
+  echo "When you have backported the above commits, you can update the PR labels via this command:"
+  echo "$ for pr in ${stable_prs[@]}; do contrib/backporting/set-labels.py \$pr pending ${STABLE_BRANCH}; done"
+  if [[ ! -z $SUMMARY_LOG ]]; then
+    echo -e "\nOnce this PR is merged, you can update the PR labels via:" >> $SUMMARY_LOG
+    echo "\`\`\`" >> $SUMMARY_LOG
+    echo "$ for pr in ${stable_prs[@]}; do contrib/backporting/set-labels.py \$pr done ${STABLE_BRANCH}; done" >> $SUMMARY_LOG
+    echo "\`\`\`" >> $SUMMARY_LOG
+  fi
 fi

--- a/contrib/backporting/check-stable
+++ b/contrib/backporting/check-stable
@@ -1,6 +1,7 @@
 #!/bin/bash
 #
 # Copyright 2016 The Kubernetes Authors All rights reserved.
+# Copyright 2019 Authors of Cilium
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,14 +17,19 @@
 #
 # Set PROGram name
 PROG=${0##*/}
-STABLE_BRANCH=${1:-1.0}
-echo "Checking for backports on branch '${STABLE_BRANCH}'"
+STABLE_BRANCH=${1:-}
+SUMMARY_LOG=${2:-}
 
 source $(dirname $(readlink -ne $BASH_SOURCE))/../release/lib/common.sh
 source $TOOL_LIB_PATH/gitlib.sh
 
 # Validate command-line
-common::argc_validate 1
+common::argc_validate 2
+
+if [[ -z $STABLE_BRANCH ]]; then
+  logecho "usage: $0 <branch> [summary-file]" >&2
+  common::exit 1
+fi
 
 ###############################################################################
 # FUNCTIONS
@@ -167,12 +173,18 @@ MYLOG=/tmp/$PROG.log
 # Check token
 gitlib::github_api_token
 
+echo "Checking for backports on branch '${STABLE_BRANCH}'"
+
 stable_prs=($(get_prs "needs-backport/${STABLE_BRANCH}" "backport-done/${STABLE_BRANCH}"))
+echo -e "v$STABLE_BRANCH backports $(date +%Y-%m-%d)\n" | tee $SUMMARY_LOG
 echo -e "PRs for stable backporting: ${#stable_prs[@]}\n"
 if [[ ${#stable_prs[@]} > 0 ]]; then
   for pr in "${stable_prs[@]}"; do
     title=$(extract_pr_title "$pr")
     echo " * PR: $pr -- $title -- https://github.com/cilium/cilium/pull/$pr"
+    if [[ ! -z $SUMMARY_LOG ]]; then
+      echo " * #$pr -- $title" >> $SUMMARY_LOG
+    fi
     generate_commit_list_for_pr $pr
     echo ""
   done

--- a/contrib/backporting/cherry-pick
+++ b/contrib/backporting/cherry-pick
@@ -1,22 +1,34 @@
 #!/bin/sh
 set -e
-if [ $# -ne 1 ]; then
-  echo "Usage: $0 <commit-id>"
+
+cherry_pick () {
+  CID=$1
+  REM=`git remote -v | grep "github.com.cilium/cilium" | head -n1 | cut -f1`
+  BRANCHES=`git branch -q -r --contains $CID $REM/master 2> /dev/null`
+  if ! echo ${BRANCHES} | grep -q ".*$REM/master.*"; then
+    echo "Commit $CID not in $REM/master!"
+    exit 1
+  fi
+  TMPF=`mktemp cp.XXXXXX`
+  FROM=`git show --pretty=email $CID | head -n 2 | grep "From: "`
+  FULL_ID=`git show $CID | head -n 1 | cut -f 2 -d ' '`
+  git format-patch -1 $FULL_ID --stdout | sed '/^$/Q' > $TMPF
+  echo "" >> $TMPF
+  echo "[ upstream commit $FULL_ID ]" >> $TMPF
+  git format-patch -1 $FULL_ID --stdout | sed -n '/^$/,/$a/p' >> $TMPF
+  git am -3 --signoff $TMPF
+  rm $TMPF
+}
+
+main () {
+  for CID in "$@"; do
+    cherry_pick "$CID"
+  done
+}
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <commit-id> [commit-id ...]"
   exit 1
 fi
-CID=$1
-REM=`git remote -v | grep "github.com.cilium/cilium" | head -n1 | cut -f1`
-BRANCHES=`git branch -q -r --contains $CID $REM/master 2> /dev/null`
-if ! echo ${BRANCHES} | grep -q ".*$REM/master.*"; then
-  echo "Commit $CID not in $REM/master!"
-  exit 1
-fi
-TMPF=`mktemp cp.XXXXXX`
-FROM=`git show --pretty=email $CID | head -n 2 | grep "From: "`
-FULL_ID=`git show $CID | head -n 1 | cut -f 2 -d ' '`
-git format-patch -1 $FULL_ID --stdout | sed '/^$/Q' > $TMPF
-echo "" >> $TMPF
-echo "[ upstream commit $FULL_ID ]" >> $TMPF
-git format-patch -1 $FULL_ID --stdout | sed -n '/^$/,/$a/p' >> $TMPF
-git am -3 --signoff $TMPF
-rm $TMPF
+
+main "$@"


### PR DESCRIPTION
* #6859 -- Streamline backporting and improve backporting docs (@joestringer)
   * Needed e7e3e72a7db64 to backport cleanly
   * Minor fixup in the Makefile changes for render-docs on port 9080.
 * #6834 -- backporting: Accept multiple commits in 'cherry-pick' (@joestringer)

Once this PR is merged, you can update the PR labels via:
```
$ for pr in 6859 6834; do contrib/backporting/set-labels.py $pr done 1.2; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6895)
<!-- Reviewable:end -->
