### PR TITLE
v1.3 backports 2019-02-01

### DIFF
--- a/Documentation/contributing.rst
+++ b/Documentation/contributing.rst
@@ -1273,7 +1273,7 @@ Alternatively you can use a Docker container to build the pages:
 This builds the docs in a container and builds and starts a web server with
 your document changes.
 
-Now the documentation page should be browsable on http://localhost:8080.
+Now the documentation page should be browsable on http://localhost:9080.
 
 .. _ci_jenkins:
 

--- a/Documentation/contributing.rst
+++ b/Documentation/contributing.rst
@@ -2009,11 +2009,22 @@ the process for backporting these PRs.
 
         $ GITHUB_TOKEN=xxx contrib/backporting/check-stable 1.0
 
+   .. note::
+      ``contrib/backporting/check-stable`` accepts a second argument to
+      specify a path to write a nicely-formatted pull request message to.
+      This can be used alongside
+      `Github command-line tools <https://github.com/node-gh/gh>`__ to
+      send the pull request from the command line in steps 9-10 via
+      ``gh pull-request -b vX.Y -l backport/vX.Y -F <path>``.
+
 7. Cherry-pick the commits using the master git SHAs listed, starting
    from the oldest (bottom), working your way up and fixing any merge
    conflicts as they appear. Note that for PRs that have multiple
    commits you will want to check that you are cherry-picking oldest
-   commits first.
+   commits first. The ``cherry-pick`` script accepts multiple arguments,
+   in which case it will attempt to apply each commit in the order
+   specified on the command line until one cherry pick fails or every
+   commit is cherry-picked.
 
 .. code-block:: bash
 

--- a/Documentation/contributing.rst
+++ b/Documentation/contributing.rst
@@ -1990,10 +1990,10 @@ the process for backporting these PRs.
    to configure git to have your name and email address to be used in
    the commit messages:
 
-.. code-block:: bash
+   .. code-block:: bash
 
-        $ git config --global user.name "John Doe"
-        $ git config --global user.email johndoe@example.com
+      $ git config --global user.name "John Doe"
+      $ git config --global user.email johndoe@example.com
 
 3. Make sure you have your a GitHub developer access token
    available. For details, see `contrib/backporting/README.md
@@ -2005,9 +2005,9 @@ the process for backporting these PRs.
    token, this will list the commits that need backporting, from the
    newest to oldest:
 
-.. code-block:: bash
+   .. code-block:: bash
 
-        $ GITHUB_TOKEN=xxx contrib/backporting/check-stable 1.0
+      $ GITHUB_TOKEN=xxx contrib/backporting/check-stable 1.0
 
    .. note::
       ``contrib/backporting/check-stable`` accepts a second argument to
@@ -2026,11 +2026,11 @@ the process for backporting these PRs.
    specified on the command line until one cherry pick fails or every
    commit is cherry-picked.
 
-.. code-block:: bash
+   .. code-block:: bash
 
-        $ contrib/backporting/cherry-pick <oldest-commit-sha>
-        ...
-        $ contrib/backporting/cherry-pick <newest-commit-sha>
+      $ contrib/backporting/cherry-pick <oldest-commit-sha>
+      ...
+      $ contrib/backporting/cherry-pick <newest-commit-sha>
 
 8. Push your backports branch to cilium repo, e.g., ``git push -u origin pr/v1.0-backports-YY-MM-DD``
 9. In Github, create a new PR from your branch towards the feature

--- a/Makefile
+++ b/Makefile
@@ -284,8 +284,8 @@ docs-container:
 render-docs: docs-container
 	-$(DOCKER) container rm -f docs-cilium >/dev/null 2>&1 || true
 	$(DOCKER) container run --rm -ti -v $$(pwd):/srv/ cilium/docs-builder /bin/bash -c 'make html'
-	$(DOCKER) container run --rm -dit --name docs-cilium -p 8080:80 -v $$(pwd)/Documentation/_build/html/:/usr/local/apache2/htdocs/ httpd:2.4
-	@echo "$$(tput setaf 2)Running at http://localhost:8080$$(tput sgr0)"
+	$(DOCKER) container run --rm -dit --name docs-cilium -p 9080:80 -v $$(pwd)/Documentation/_build/html/:/usr/local/apache2/htdocs/ httpd:2.4
+	@echo "$$(tput setaf 2)Running at http://localhost:9080$$(tput sgr0)"
 
 test-docs: docs-container
 	-$(DOCKER) container rm -f docs-cilium >/dev/null

--- a/contrib/backporting/check-stable
+++ b/contrib/backporting/check-stable
@@ -188,4 +188,12 @@ if [[ ${#stable_prs[@]} > 0 ]]; then
     generate_commit_list_for_pr $pr
     echo ""
   done
+  echo "When you have backported the above commits, you can update the PR labels via this command:"
+  echo "$ for pr in ${stable_prs[@]}; do contrib/backporting/set-labels.py \$pr pending ${STABLE_BRANCH}; done"
+  if [[ ! -z $SUMMARY_LOG ]]; then
+    echo -e "\nOnce this PR is merged, you can update the PR labels via:" >> $SUMMARY_LOG
+    echo "\`\`\`" >> $SUMMARY_LOG
+    echo "$ for pr in ${stable_prs[@]}; do contrib/backporting/set-labels.py \$pr done ${STABLE_BRANCH}; done" >> $SUMMARY_LOG
+    echo "\`\`\`" >> $SUMMARY_LOG
+  fi
 fi

--- a/contrib/backporting/check-stable
+++ b/contrib/backporting/check-stable
@@ -1,6 +1,7 @@
 #!/bin/bash
 #
 # Copyright 2016 The Kubernetes Authors All rights reserved.
+# Copyright 2019 Authors of Cilium
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,14 +17,19 @@
 #
 # Set PROGram name
 PROG=${0##*/}
-STABLE_BRANCH=${1:-1.0}
-echo "Checking for backports on branch '${STABLE_BRANCH}'"
+STABLE_BRANCH=${1:-}
+SUMMARY_LOG=${2:-}
 
 source $(dirname $(readlink -ne $BASH_SOURCE))/../release/lib/common.sh
 source $TOOL_LIB_PATH/gitlib.sh
 
 # Validate command-line
-common::argc_validate 1
+common::argc_validate 2
+
+if [[ -z $STABLE_BRANCH ]]; then
+  logecho "usage: $0 <branch> [summary-file]" >&2
+  common::exit 1
+fi
 
 ###############################################################################
 # FUNCTIONS
@@ -167,12 +173,18 @@ MYLOG=/tmp/$PROG.log
 # Check token
 gitlib::github_api_token
 
+echo "Checking for backports on branch '${STABLE_BRANCH}'"
+
 stable_prs=($(get_prs "needs-backport/${STABLE_BRANCH}" "backport-done/${STABLE_BRANCH}"))
+echo -e "v$STABLE_BRANCH backports $(date +%Y-%m-%d)\n" | tee $SUMMARY_LOG
 echo -e "PRs for stable backporting: ${#stable_prs[@]}\n"
 if [[ ${#stable_prs[@]} > 0 ]]; then
   for pr in "${stable_prs[@]}"; do
     title=$(extract_pr_title "$pr")
     echo " * PR: $pr -- $title -- https://github.com/cilium/cilium/pull/$pr"
+    if [[ ! -z $SUMMARY_LOG ]]; then
+      echo " * #$pr -- $title" >> $SUMMARY_LOG
+    fi
     generate_commit_list_for_pr $pr
     echo ""
   done

--- a/contrib/backporting/cherry-pick
+++ b/contrib/backporting/cherry-pick
@@ -1,22 +1,34 @@
 #!/bin/sh
 set -e
-if [ $# -ne 1 ]; then
-  echo "Usage: $0 <commit-id>"
+
+cherry_pick () {
+  CID=$1
+  REM=`git remote -v | grep "github.com.cilium/cilium" | head -n1 | cut -f1`
+  BRANCHES=`git branch -q -r --contains $CID $REM/master 2> /dev/null`
+  if ! echo ${BRANCHES} | grep -q ".*$REM/master.*"; then
+    echo "Commit $CID not in $REM/master!"
+    exit 1
+  fi
+  TMPF=`mktemp cp.XXXXXX`
+  FROM=`git show --pretty=email $CID | head -n 2 | grep "From: "`
+  FULL_ID=`git show $CID | head -n 1 | cut -f 2 -d ' '`
+  git format-patch -1 $FULL_ID --stdout | sed '/^$/Q' > $TMPF
+  echo "" >> $TMPF
+  echo "[ upstream commit $FULL_ID ]" >> $TMPF
+  git format-patch -1 $FULL_ID --stdout | sed -n '/^$/,/$a/p' >> $TMPF
+  git am -3 --signoff $TMPF
+  rm $TMPF
+}
+
+main () {
+  for CID in "$@"; do
+    cherry_pick "$CID"
+  done
+}
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <commit-id> [commit-id ...]"
   exit 1
 fi
-CID=$1
-REM=`git remote -v | grep "github.com.cilium/cilium" | head -n1 | cut -f1`
-BRANCHES=`git branch -q -r --contains $CID $REM/master 2> /dev/null`
-if ! echo ${BRANCHES} | grep -q ".*$REM/master.*"; then
-  echo "Commit $CID not in $REM/master!"
-  exit 1
-fi
-TMPF=`mktemp cp.XXXXXX`
-FROM=`git show --pretty=email $CID | head -n 2 | grep "From: "`
-FULL_ID=`git show $CID | head -n 1 | cut -f 2 -d ' '`
-git format-patch -1 $FULL_ID --stdout | sed '/^$/Q' > $TMPF
-echo "" >> $TMPF
-echo "[ upstream commit $FULL_ID ]" >> $TMPF
-git format-patch -1 $FULL_ID --stdout | sed -n '/^$/,/$a/p' >> $TMPF
-git am -3 --signoff $TMPF
-rm $TMPF
+
+main "$@"

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1884,6 +1884,12 @@ func (e *Endpoint) LeaveLocked(owner Owner, proxyWaitGroup *completion.WaitGroup
 		}
 	}
 
+	if e.bpfConfigMap != nil {
+		if err := e.bpfConfigMap.Close(); err != nil {
+			errors = append(errors, fmt.Errorf("unable to close configmap %s: %s", e.BPFConfigMapPath(), err))
+		}
+	}
+
 	if e.SecurityIdentity != nil {
 		err := e.SecurityIdentity.Release()
 		if err != nil {

--- a/pkg/k8s/factory_functions.go
+++ b/pkg/k8s/factory_functions.go
@@ -498,6 +498,7 @@ func equalV2CNP(o1, o2 interface{}) bool {
 	}
 	return cnp1.Name == cnp2.Name &&
 		cnp1.Namespace == cnp2.Namespace &&
+		comparator.MapStringEquals(cnp1.GetAnnotations(), cnp2.GetAnnotations()) &&
 		reflect.DeepEqual(cnp1.Spec, cnp2.Spec) &&
 		reflect.DeepEqual(cnp1.Specs, cnp2.Specs)
 }

--- a/pkg/maps/configmap/configmap.go
+++ b/pkg/maps/configmap/configmap.go
@@ -135,7 +135,7 @@ type endpoint interface {
 
 // EndpointConfigMap is a map type for interfacing with endpoint BPF config.
 type EndpointConfigMap struct {
-	Map  *bpf.Map
+	*bpf.Map
 	path string
 	Fd   int
 }


### PR DESCRIPTION
These backports do *not* supersede the outstanding backport from 01-29 (https://github.com/cilium/cilium/pull/6849). Running
this PR to reduce backlog while we wait for issues on other v1.3 backport branch
to be resolved.

 * #6890 -- cilium: fix fd leak from ObjClose being omitted on ConfigMap (@jrfastab)
 * #6869 -- iptables: Fix 127.0.0.1:NodePort to remote pods (@tgraf)
   * Had to manually intervene here - No IPSec marks in v1.3, and the files
     where the logic lives is different on master vs v1.3. Please look closely.
 * #6867 -- pkg/k8s: consider 2 CNPs different if they have different annotations (@aanm)
 * #6859 -- Streamline backporting and improve backporting docs (@joestringer)
   * Minor fixup in the Makefile changes for render-docs on port 9080.
 * #6834 -- backporting: Accept multiple commits in 'cherry-pick' (@joestringer)
   * Manual cherry-pick from v1.4

Once this PR is merged, you can update the PR labels via:
```
$ for pr in 6890 6869 6867 6859 6857 6834 6809; do contrib/backporting/set-labels.py $pr done 1.3; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6897)
<!-- Reviewable:end -->
