### PR TITLE
endpoint: Embed a *controller.Manager

### DIFF
--- a/pkg/controller/manager.go
+++ b/pkg/controller/manager.go
@@ -235,8 +235,8 @@ func (m *Manager) GetStatusModel() models.ControllerStatuses {
 // FakeManager returns a fake controller manager with the specified number of
 // failing controllers. The returned manager is identical in any regard except
 // for internal pointers.
-func FakeManager(failingControllers int) Manager {
-	m := Manager{
+func FakeManager(failingControllers int) *Manager {
+	m := &Manager{
 		controllers: controllerMap{},
 	}
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -263,7 +263,7 @@ type Endpoint struct {
 
 	// controllers is the list of async controllers syncing the endpoint to
 	// other resources
-	controllers controller.Manager
+	controllers *controller.Manager
 
 	// realizedRedirects maps the ID of each proxy redirect that has been
 	// successfully added into a proxy for this endpoint, to the redirect's
@@ -418,6 +418,7 @@ func NewEndpointWithState(ID uint16, state string) *Endpoint {
 		DNSHistory:    fqdn.NewDNSCache(),
 		state:         state,
 		hasBPFProgram: make(chan struct{}, 0),
+		controllers:   controller.NewManager(),
 	}
 	ep.UpdateLogger(nil)
 	return ep
@@ -447,6 +448,7 @@ func NewEndpointFromChangeModel(base *models.EndpointChangeRequest) (*Endpoint, 
 		hasBPFProgram:    make(chan struct{}, 0),
 		desiredPolicy:    &policy.EndpointPolicy{},
 		realizedPolicy:   &policy.EndpointPolicy{},
+		controllers:      controller.NewManager(),
 	}
 	ep.UpdateLogger(nil)
 
@@ -1198,6 +1200,7 @@ func ParseEndpoint(strEp string) (*Endpoint, error) {
 	ep.hasBPFProgram = make(chan struct{}, 0)
 	ep.desiredPolicy = &policy.EndpointPolicy{}
 	ep.realizedPolicy = &policy.EndpointPolicy{}
+	ep.controllers = controller.NewManager()
 
 	// We need to check for nil in Status, CurrentStatuses and Log, since in
 	// some use cases, status will be not nil and Cilium will eventually


### PR DESCRIPTION
Allows to use NewManager() and thus FakeManager() isntead of doing a copy by
value.

Fixes: #6896

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6898)
<!-- Reviewable:end -->
