### PR TITLE
endpoint: fix incorrect RLock usage in controller

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1158,7 +1158,7 @@ func (e *Endpoint) syncPolicyMapController() {
 				// Failure to lock is not an error, it means
 				// that the endpoint was disconnected and we
 				// should exit gracefully.
-				if err := e.RLockAlive(); err != nil {
+				if err := e.LockAlive(); err != nil {
 					return controller.NewExitReason("Endpoint disappeared")
 				}
 				defer e.Unlock()


### PR DESCRIPTION
The below commit accidentally replaced a call to `LockAlive` with `RLockAlive`.
This resulted in the endpoint mutex having `Unlock` called when the endpoint
mutex was `RLocked`, which caused the following error:

```
fatal error: sync: Unlock of unlocked RWMutex

goroutine 996 [running]:
runtime.throw(0x2d25cea, 0x20)
    /usr/local/go/src/runtime/panic.go:608 +0x72 fp=0xc000cdcd30 sp=0xc000cdcd00 pc=0x108fd72
sync.throw(0x2d25cea, 0x20)
    /usr/local/go/src/runtime/panic.go:594 +0x35 fp=0xc000cdcd50 sp=0xc000cdcd30 pc=0x108fcf5
sync.(*RWMutex).Unlock(0xc000f62004)
    /usr/local/go/src/sync/rwmutex.go:124 +0xa1 fp=0xc000cdcd80 sp=0xc000cdcd50 pc=0x10c98e1
github.com/cilium/cilium/pkg/endpoint.(*Endpoint).Unlock(0xc000f62000)
```

Fixes: 8eb1698b2 ("endpoint: Avoid harmless controller failures when endpoint disappears")

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6901)
<!-- Reviewable:end -->
