### PR TITLE
make: Allow to use custom container engine

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -43,3 +43,7 @@ GOBUILD = -ldflags '$(GOLDFLAGS)'
 ifneq ($(LOCKDEBUG),)
     GOBUILD += -tags lockdebug
 endif
+
+# Container engine
+CONTAINER_ENGINE?=docker
+CONTAINER_ENGINE_FULL=$(QUIET)$(CONTAINER_ENGINE)


### PR DESCRIPTION
Before this change, Cilum buildsystem required Docker. This change
allows to specify a custom container engine which allows to use Podman
as an alternative. Docker is still the default container engine.

Example of using podman to run kvstore containers for unit tests:

```
make unit-tests CONTAINER_ENGINE=podman
```

Examples for more paranoid people who don't like to have paswordless
sudo on their machines:

```
make unit-tests CONTAINER_ENGINE="sudo podman"
make unit-tests CONTAINER_ENGINE="sudo docker"
```

Ref: #6908

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6909)
<!-- Reviewable:end -->
