### PR TITLE
Fix operator crash on invalid CNP

### DIFF
--- a/cilium-operator.Dockerfile
+++ b/cilium-operator.Dockerfile
@@ -11,4 +11,4 @@ FROM scratch
 LABEL maintainer="maintainer@cilium.io"
 COPY --from=builder /go/src/github.com/cilium/cilium/operator/cilium-operator /usr/bin/cilium-operator
 WORKDIR /
-CMD ["/usr/bin/cilium-etcd-operator"]
+CMD ["/usr/bin/cilium-operator"]

--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"strings"
 	"sync"
 	"time"
 
@@ -62,8 +61,6 @@ import (
 )
 
 const (
-	k8sErrLogTimeout = time.Minute
-
 	k8sAPIGroupCRD              = "CustomResourceDefinition"
 	k8sAPIGroupNodeV1Core       = "core/v1::Node"
 	k8sAPIGroupNamespaceV1Core  = "core/v1::Namespace"
@@ -89,10 +86,6 @@ const (
 )
 
 var (
-	// k8sErrMsgMU guards additions and removals to k8sErrMsg, which stores a
-	// time after which a repeat error message can be printed
-	k8sErrMsgMU  lock.Mutex
-	k8sErrMsg    = map[string]time.Time{}
 	k8sServerVer *go_version.Version
 
 	ciliumNPClient clientset.Interface
@@ -239,74 +232,7 @@ func (m *k8sAPIGroupsUsed) getGroups() []string {
 func init() {
 	// Replace error handler with our own
 	runtime.ErrorHandlers = []func(error){
-		k8sErrorHandler,
-	}
-}
-
-// k8sErrorUpdateCheckUnmuteTime returns a boolean indicating whether we should
-// log errmsg or not. It manages once-per-k8sErrLogTimeout entry in k8sErrMsg.
-// When errmsg is new or more than k8sErrLogTimeout has passed since the last
-// invocation that returned true, it returns true.
-func k8sErrorUpdateCheckUnmuteTime(errstr string, now time.Time) bool {
-	k8sErrMsgMU.Lock()
-	defer k8sErrMsgMU.Unlock()
-
-	if unmuteDeadline, ok := k8sErrMsg[errstr]; !ok || now.After(unmuteDeadline) {
-		k8sErrMsg[errstr] = now.Add(k8sErrLogTimeout)
-		return true
-	}
-
-	return false
-}
-
-// k8sErrorHandler handles the error messages in a non verbose way by omitting
-// repeated instances of the same error message for a timeout defined with
-// k8sErrLogTimeout.
-func k8sErrorHandler(e error) {
-	if e == nil {
-		return
-	}
-
-	// We rate-limit certain categories of error message. These are matched
-	// below, with a default behaviour to print everything else without
-	// rate-limiting.
-	// Note: We also have side-effects in some of the special cases.
-	now := time.Now()
-	errstr := e.Error()
-	switch {
-	// This can occur when cilium comes up before the k8s API server, and keeps
-	// trying to connect.
-	case strings.Contains(errstr, "connection refused"):
-		if k8sErrorUpdateCheckUnmuteTime(errstr, now) {
-			log.WithError(e).Error("k8sError")
-		}
-
-	// k8s does not allow us to watch both ThirdPartyResource and
-	// CustomResourceDefinition. This would occur when a user mixes these within
-	// the k8s cluster, and might occur when upgrading from versions of cilium
-	// that used ThirdPartyResource to define CiliumNetworkPolicy.
-	case strings.Contains(errstr, "Failed to list *v2.CiliumNetworkPolicy: the server could not find the requested resource"):
-		if k8sErrorUpdateCheckUnmuteTime(errstr, now) {
-			log.WithError(e).Error("Conflicting TPR and CRD resources")
-			log.Warn("Detected conflicting TPR and CRD, please migrate all ThirdPartyResource to CustomResourceDefinition! More info: https://cilium.link/migrate-tpr")
-			log.Warn("Due to conflicting TPR and CRD rules, CiliumNetworkPolicy enforcement can't be guaranteed!")
-		}
-
-	// fromCIDR and toCIDR used to expect an "ip" subfield (so, they were a YAML
-	// map with one field) but common usage and expectation would simply list the
-	// CIDR ranges and IPs desired as a YAML list. In these cases we would see
-	// this decode error. We have since changed the definition to be a simple
-	// list of strings.
-	case strings.Contains(errstr, "Unable to decode an event from the watch stream: unable to decode watch event"),
-		strings.Contains(errstr, "Failed to list *v1.CiliumNetworkPolicy: only encoded map or array can be decoded into a struct"),
-		strings.Contains(errstr, "Failed to list *v2.CiliumNetworkPolicy: only encoded map or array can be decoded into a struct"),
-		strings.Contains(errstr, "Failed to list *v2.CiliumNetworkPolicy: v2.CiliumNetworkPolicyList:"):
-		if k8sErrorUpdateCheckUnmuteTime(errstr, now) {
-			log.WithError(e).Error("Unable to decode k8s watch event")
-		}
-
-	default:
-		log.WithError(e).Error("k8sError")
+		k8s.K8sErrorHandler,
 	}
 }
 

--- a/daemon/k8s_watcher_test.go
+++ b/daemon/k8s_watcher_test.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"net"
-	"time"
 
 	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/checker"
@@ -43,27 +42,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 )
-
-func (ds *DaemonSuite) TestK8sErrorLogTimeout(c *C) {
-	errstr := "I am an error string"
-
-	// ensure k8sErrMsg is empty for tests that use it
-	k8sErrMsgMU.Lock()
-	k8sErrMsg = map[string]time.Time{}
-	k8sErrMsgMU.Unlock()
-
-	// Returns true because it's the first time we see this message
-	startTime := time.Now()
-	c.Assert(k8sErrorUpdateCheckUnmuteTime(errstr, startTime), Equals, true)
-
-	// Returns false because <= k8sErrLogTimeout time has passed
-	noLogTime := startTime.Add(k8sErrLogTimeout)
-	c.Assert(k8sErrorUpdateCheckUnmuteTime(errstr, noLogTime), Equals, false)
-
-	// Returns true because k8sErrLogTimeout has passed
-	shouldLogTime := startTime.Add(k8sErrLogTimeout).Add(time.Nanosecond)
-	c.Assert(k8sErrorUpdateCheckUnmuteTime(errstr, shouldLogTime), Equals, true)
-}
 
 func (ds *DaemonSuite) Test_missingK8sNetworkPolicyV1(c *C) {
 	type args struct {

--- a/pkg/k8s/error_helpers.go
+++ b/pkg/k8s/error_helpers.go
@@ -1,0 +1,98 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"strings"
+	"time"
+
+	"github.com/cilium/cilium/pkg/lock"
+)
+
+var (
+
+	// k8sErrMsgMU guards additions and removals to k8sErrMsg, which stores a
+	// time after which a repeat error message can be printed
+	k8sErrMsgMU      lock.Mutex
+	k8sErrMsg        = map[string]time.Time{}
+	k8sErrLogTimeout = time.Minute
+)
+
+// k8sErrorUpdateCheckUnmuteTime returns a boolean indicating whether we should
+// log errmsg or not. It manages once-per-k8sErrLogTimeout entry in k8sErrMsg.
+// When errmsg is new or more than k8sErrLogTimeout has passed since the last
+// invocation that returned true, it returns true.
+func k8sErrorUpdateCheckUnmuteTime(errstr string, now time.Time) bool {
+	k8sErrMsgMU.Lock()
+	defer k8sErrMsgMU.Unlock()
+
+	if unmuteDeadline, ok := k8sErrMsg[errstr]; !ok || now.After(unmuteDeadline) {
+		k8sErrMsg[errstr] = now.Add(k8sErrLogTimeout)
+		return true
+	}
+
+	return false
+}
+
+// K8sErrorHandler handles the error messages in a non verbose way by omitting
+// repeated instances of the same error message for a timeout defined with
+// k8sErrLogTimeout.
+func K8sErrorHandler(e error) {
+	if e == nil {
+		return
+	}
+
+	// We rate-limit certain categories of error message. These are matched
+	// below, with a default behaviour to print everything else without
+	// rate-limiting.
+	// Note: We also have side-effects in some of the special cases.
+	now := time.Now()
+	errstr := e.Error()
+	switch {
+	// This can occur when cilium comes up before the k8s API server, and keeps
+	// trying to connect.
+	case strings.Contains(errstr, "connection refused"):
+		if k8sErrorUpdateCheckUnmuteTime(errstr, now) {
+			log.WithError(e).Error("k8sError")
+		}
+
+	// k8s does not allow us to watch both ThirdPartyResource and
+	// CustomResourceDefinition. This would occur when a user mixes these within
+	// the k8s cluster, and might occur when upgrading from versions of cilium
+	// that used ThirdPartyResource to define CiliumNetworkPolicy.
+	case strings.Contains(errstr, "Failed to list *v2.CiliumNetworkPolicy: the server could not find the requested resource"):
+		if k8sErrorUpdateCheckUnmuteTime(errstr, now) {
+			log.WithError(e).Error("Conflicting TPR and CRD resources")
+			log.Warn("Detected conflicting TPR and CRD, please migrate all ThirdPartyResource to CustomResourceDefinition! More info: https://cilium.link/migrate-tpr")
+			log.Warn("Due to conflicting TPR and CRD rules, CiliumNetworkPolicy enforcement can't be guaranteed!")
+		}
+
+	// fromCIDR and toCIDR used to expect an "ip" subfield (so, they were a YAML
+	// map with one field) but common usage and expectation would simply list the
+	// CIDR ranges and IPs desired as a YAML list. In these cases we would see
+	// this decode error. We have since changed the definition to be a simple
+	// list of strings.
+	case strings.Contains(errstr, "Unable to decode an event from the watch stream: unable to decode watch event"),
+		strings.Contains(errstr, "Failed to list *v1.CiliumNetworkPolicy: only encoded map or array can be decoded into a struct"),
+		strings.Contains(errstr, "Failed to list *v2.CiliumNetworkPolicy: only encoded map or array can be decoded into a struct"),
+		strings.Contains(errstr, "Failed to list *v2.CiliumNetworkPolicy: v2.CiliumNetworkPolicyList:"):
+		if k8sErrorUpdateCheckUnmuteTime(errstr, now) {
+			log.WithError(e).Error("Unable to decode k8s watch event")
+		}
+
+	default:
+		log.WithError(e).Error("k8sError")
+	}
+}

--- a/pkg/k8s/error_helpers_test.go
+++ b/pkg/k8s/error_helpers_test.go
@@ -1,0 +1,44 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package k8s
+
+import (
+	"time"
+
+	. "gopkg.in/check.v1"
+)
+
+func (s *K8sSuite) TestK8sErrorLogTimeout(c *C) {
+	errstr := "I am an error string"
+
+	// ensure k8sErrMsg is empty for tests that use it
+	k8sErrMsgMU.Lock()
+	k8sErrMsg = map[string]time.Time{}
+	k8sErrMsgMU.Unlock()
+
+	// Returns true because it's the first time we see this message
+	startTime := time.Now()
+	c.Assert(k8sErrorUpdateCheckUnmuteTime(errstr, startTime), Equals, true)
+
+	// Returns false because <= k8sErrLogTimeout time has passed
+	noLogTime := startTime.Add(k8sErrLogTimeout)
+	c.Assert(k8sErrorUpdateCheckUnmuteTime(errstr, noLogTime), Equals, false)
+
+	// Returns true because k8sErrLogTimeout has passed
+	shouldLogTime := startTime.Add(k8sErrLogTimeout).Add(time.Nanosecond)
+	c.Assert(k8sErrorUpdateCheckUnmuteTime(errstr, shouldLogTime), Equals, true)
+}


### PR DESCRIPTION
1) Fix crash in operator, handle errors in a common package. 
2) Fix typo on operator dockerfile.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6913)
<!-- Reviewable:end -->
