### PR TITLE
cilium, docker: allow for v4 only config

### DIFF
--- a/plugins/cilium-docker/driver/driver.go
+++ b/plugins/cilium-docker/driver/driver.go
@@ -105,7 +105,7 @@ func NewDriver(url string) (Driver, error) {
 			}
 			time.Sleep(time.Duration(tries) * time.Second)
 		} else {
-			if res.Status.Addressing == nil || res.Status.Addressing.IPV6 == nil {
+			if res.Status.Addressing == nil || (res.Status.Addressing.IPV4 == nil && res.Status.Addressing.IPV6 == nil) {
 				scopedLog.Fatal("Invalid addressing information from daemon")
 			}
 


### PR DESCRIPTION
GetNodeAddressing() does not set up the v6 config when in v4 only.

Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6917)
<!-- Reviewable:end -->
