### PR TITLE
workloads: Setup options in single function

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1129,15 +1129,35 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 		EnableIPv6: option.Config.EnableIPv6,
 	})
 
-	// Workloads must be initialized after IPAM has started as it requires
-	// to allocate IPs.
-	wOpts := map[workloads.WorkloadRuntimeType]map[string]string{
-		workloads.Docker:     {workloads.DatapathModeOpt: option.Config.DatapathMode},
-		workloads.ContainerD: make(map[string]string),
-		workloads.CRIO:       make(map[string]string),
-	}
-	if err := workloads.Setup(d.ipam, option.Config.Workloads, wOpts); err != nil {
-		return nil, nil, fmt.Errorf("unable to setup workload: %s", err)
+	if option.Config.WorkloadsEnabled() {
+		// workaround for to use the values of the deprecated dockerEndpoint
+		// variable if it is set with a different value than defaults.
+		defaultDockerEndpoint := workloads.GetRuntimeDefaultOpt(workloads.Docker, "endpoint")
+		if defaultDockerEndpoint != option.Config.DockerEndpoint {
+			option.Config.ContainerRuntimeEndpoint[string(workloads.Docker)] = option.Config.DockerEndpoint
+			log.Warn(`"docker" flag is deprecated.` +
+				`Please use "--container-runtime-endpoint=docker=` + defaultDockerEndpoint + `" instead`)
+		}
+
+		opts := make(map[workloads.WorkloadRuntimeType]map[string]string)
+		for _, rt := range option.Config.Workloads {
+			opts[workloads.WorkloadRuntimeType(rt)] = make(map[string]string)
+		}
+		for rt, ep := range option.Config.ContainerRuntimeEndpoint {
+			opts[workloads.WorkloadRuntimeType(rt)][workloads.EpOpt] = ep
+		}
+		if opts[workloads.Docker] == nil {
+			opts[workloads.Docker] = make(map[string]string)
+		}
+		opts[workloads.Docker][workloads.DatapathModeOpt] = option.Config.DatapathMode
+
+		// Workloads must be initialized after IPAM has started as it requires
+		// to allocate IPs.
+		if err := workloads.Setup(d.ipam, option.Config.Workloads, opts); err != nil {
+			return nil, nil, fmt.Errorf("unable to setup workload: %s", err)
+		}
+
+		log.Infof("Container runtime options set: %s", workloads.GetRuntimeOptions())
 	}
 	log.Infof("Container runtime options set: %s", workloads.GetRuntimeOptions())
 

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -986,23 +986,6 @@ func initEnv(cmd *cobra.Command) {
 		}
 	}
 
-	if option.Config.WorkloadsEnabled() {
-		// workaround for to use the values of the deprecated dockerEndpoint
-		// variable if it is set with a different value than defaults.
-		defaultDockerEndpoint := workloads.GetRuntimeDefaultOpt(workloads.Docker, "endpoint")
-		if defaultDockerEndpoint != option.Config.DockerEndpoint {
-			option.Config.ContainerRuntimeEndpoint[string(workloads.Docker)] = option.Config.DockerEndpoint
-			log.Warn(`"docker" flag is deprecated.` +
-				`Please use "--container-runtime-endpoint=docker=` + defaultDockerEndpoint + `" instead`)
-		}
-
-		err = workloads.ParseConfigEndpoint(option.Config.Workloads, option.Config.ContainerRuntimeEndpoint)
-		if err != nil {
-			log.WithError(err).Fatal("Unable to initialize policy container runtimes")
-			return
-		}
-	}
-
 	if option.Config.SidecarHTTPProxy {
 		log.Warn(`"sidecar-http-proxy" flag is deprecated and has no effect`)
 	}

--- a/pkg/workloads/containerd.go
+++ b/pkg/workloads/containerd.go
@@ -54,7 +54,7 @@ const (
 var (
 	containerDInstance = &containerDModule{
 		opts: workloadRuntimeOpts{
-			epOpt: &workloadRuntimeOpt{
+			EpOpt: &workloadRuntimeOpt{
 				description: "Address of containerD endpoint",
 				value:       containerDEndpoint,
 			},
@@ -95,7 +95,7 @@ type containerDClient struct {
 }
 
 func newContainerDClient(opts workloadRuntimeOpts) (WorkloadRuntime, error) {
-	ep := string(opts[epOpt].value)
+	ep := string(opts[EpOpt].value)
 	c, err := containerd.New(ep)
 	if err != nil {
 		return nil, err
@@ -107,7 +107,7 @@ func newContainerDClient(opts workloadRuntimeOpts) (WorkloadRuntime, error) {
 	if p.Scheme == "" {
 		ep = "unix://" + ep
 	}
-	rsc, err := newCRIClient(context.WithValue(context.Background(), epOpt, ep))
+	rsc, err := newCRIClient(context.WithValue(context.Background(), EpOpt, ep))
 	return &containerDClient{c, rsc}, err
 }
 

--- a/pkg/workloads/cri.go
+++ b/pkg/workloads/cri.go
@@ -40,7 +40,7 @@ import (
 )
 
 func getGRPCCLient(ctx context.Context) (*grpc.ClientConn, error) {
-	ep, ok := ctx.Value(epOpt).(string)
+	ep, ok := ctx.Value(EpOpt).(string)
 	if !ok {
 		return nil, fmt.Errorf("unknown runtime endpoint")
 	}

--- a/pkg/workloads/crio.go
+++ b/pkg/workloads/crio.go
@@ -33,7 +33,7 @@ const (
 var (
 	criOInstance = &criOModule{
 		opts: workloadRuntimeOpts{
-			epOpt: &workloadRuntimeOpt{
+			EpOpt: &workloadRuntimeOpt{
 				description: "Address of cri-o endpoint",
 				value:       criOEndpoint,
 			},
@@ -73,7 +73,7 @@ type criOClient struct {
 }
 
 func newCRIOClient(opts workloadRuntimeOpts) (WorkloadRuntime, error) {
-	ep := string(opts[epOpt].value)
+	ep := string(opts[EpOpt].value)
 	p, err := url.Parse(ep)
 	if err != nil {
 		return nil, err
@@ -81,7 +81,7 @@ func newCRIOClient(opts workloadRuntimeOpts) (WorkloadRuntime, error) {
 	if p.Scheme == "" {
 		ep = "unix://" + ep
 	}
-	rsc, err := newCRIClient(context.WithValue(context.Background(), epOpt, ep))
+	rsc, err := newCRIClient(context.WithValue(context.Background(), EpOpt, ep))
 	return &criOClient{rsc}, err
 }
 

--- a/pkg/workloads/docker.go
+++ b/pkg/workloads/docker.go
@@ -62,7 +62,7 @@ const (
 var (
 	dockerInstance = &dockerModule{
 		opts: workloadRuntimeOpts{
-			epOpt: &workloadRuntimeOpt{
+			EpOpt: &workloadRuntimeOpt{
 				description: "Addresses of docker endpoint",
 				value:       "unix:///var/run/docker.sock",
 			},
@@ -108,7 +108,7 @@ type dockerClient struct {
 
 func newDockerClient(opts workloadRuntimeOpts) (WorkloadRuntime, error) {
 	defaultHeaders := map[string]string{"User-Agent": "cilium"}
-	ep := opts[epOpt]
+	ep := opts[EpOpt]
 	c, err := client.NewClient(ep.value, "v1.21", nil, defaultHeaders)
 	if err != nil {
 		return nil, err

--- a/pkg/workloads/runtimes.go
+++ b/pkg/workloads/runtimes.go
@@ -52,7 +52,8 @@ const (
 )
 
 const (
-	epOpt = "endpoint"
+	// EpOpt is the option name for path to endpoint
+	EpOpt = "endpoint"
 	// DatapathModeOpt is the option name for datapath mode
 	DatapathModeOpt = "datapath-mode"
 )
@@ -102,39 +103,6 @@ var (
 
 func unregisterWorkloads() {
 	registeredWorkloads = map[WorkloadRuntimeType]workloadModule{}
-}
-
-// ParseConfigEndpoint parses the containerRuntimes and the containerRuntime
-// options and adds them to the internal containerRuntime maps.
-// In case any containeRuntime does not exist an error is returned.
-// If `auto` is set in containerRuntimes, the default options of each container
-// runtime will be set. The user defined options of each particular runtime
-// will overwrite defaults.
-// If `none` is set, all containerRuntimes will be ignored.
-func ParseConfigEndpoint(containerRuntimes []string, containerRuntimesEPOpts map[string]string) error {
-	for _, runtime := range containerRuntimes {
-		crt, err := parseRuntimeType(runtime)
-		if err != nil {
-			return err
-		}
-		switch crt {
-		case None:
-			unregisterWorkloads()
-			return nil
-		}
-	}
-
-	for runtime, epOpts := range containerRuntimesEPOpts {
-		crt, _ := parseRuntimeType(runtime)
-		switch crt {
-		case None, Auto:
-		default:
-			registeredWorkloads[crt].setConfig(map[string]string{
-				epOpt: epOpts,
-			})
-		}
-	}
-	return nil
 }
 
 func parseRuntimeType(str string) (WorkloadRuntimeType, error) {
@@ -217,7 +185,7 @@ func GetDefaultEPOptsStringWithPrefix(prefix string) string {
 
 	for _, cr := range crs {
 		v := registeredWorkloads[WorkloadRuntimeType(cr)].getConfig()
-		strs = append(strs, fmt.Sprintf("%s%s=%s", prefix, cr, v[epOpt]))
+		strs = append(strs, fmt.Sprintf("%s%s=%s", prefix, cr, v[EpOpt]))
 	}
 
 	return strings.Join(strs, ", ")


### PR DESCRIPTION
Previously, workloads runtime options can be set from two different functions, namely `ParseConfigEndpoint` and `Setup`, which made code difficult to follow. One possible result of it was that logging of runtime options was happening at the wrong place.

This commit gets rid of the former function by moving all workloads init steps to the latter function.

To make unit testing of `Setup` possible without mocking runtime clients, we introduce `bypassStatusCheck` flag which should be set to `true` only when testing.

Note, that I removed the containerd runtime from the tests, as it internally tries to call its endpoint during initialization.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6919)
<!-- Reviewable:end -->
