### PR TITLE
daemon: Log workloads runtime options after final setup

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1085,6 +1085,7 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 	if err := workloads.Setup(d.ipam, option.Config.Workloads, wOpts); err != nil {
 		return nil, nil, fmt.Errorf("unable to setup workload: %s", err)
 	}
+	log.Infof("Container runtime options set: %s", workloads.GetRuntimeOptions())
 
 	// restore endpoints before any IPs are allocated to avoid eventual IP
 	// conflicts later on, otherwise any IP conflict will result in the

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -1001,8 +1001,6 @@ func initEnv(cmd *cobra.Command) {
 			log.WithError(err).Fatal("Unable to initialize policy container runtimes")
 			return
 		}
-
-		log.Infof("Container runtime options set: %s", workloads.GetRuntimeOptions())
 	}
 
 	if option.Config.SidecarHTTPProxy {


### PR DESCRIPTION
This commit fixes the problem, when default workloads runtime options are logged instead of actual ones due to logging happening after the first (out of two) workloads initialization step.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6920)
<!-- Reviewable:end -->
