### PR TITLE
v1.4: backports 19-02-04

### DIFF
--- a/Documentation/concepts.rst
+++ b/Documentation/concepts.rst
@@ -610,6 +610,15 @@ This is typically achieved using two methods:
 There are two possible approaches to performing network forwarding for
 container-to-container traffic:
 
+Cluster Mesh
+============
+
+Cluster mesh extends the networking datapath across multiple clusters. It
+allows endpoints in all connected clusters to communicate while providing full
+policy enforcement. Load-balancing is available via Kubernetes annotations.
+
+See :ref:`gs_clustermesh` for instructions on how to set up cluster mesh.
+
 Container Communication with External Hosts
 ===========================================
 

--- a/Documentation/gettingstarted/clustermesh.rst
+++ b/Documentation/gettingstarted/clustermesh.rst
@@ -2,115 +2,252 @@
 
 .. _gs_clustermesh:
 
-****************************
-Setting up the Cluster Mesh
-****************************
+***********************
+Setting up Cluster Mesh
+***********************
 
 This is a step-by-step guide on how to build a mesh of Kubernetes clusters by
-connecting them together and enabling pod-to-pod connectivity across all
-clusters while providing label-based security policies.
-
-.. note::
-
-    This is a beta feature introduced in Cilium 1.2.
+connecting them together, enabling pod-to-pod connectivity across all clusters,
+define global services to load-balance between clusters and enforce security
+policies to restrict access.
 
 Prerequisites
 #############
 
-* All nodes in all clusters must have IP connectivity. This requirement is
-  typically met by establishing peering between the networks of the machines
-  forming each cluster.
+* PodCIDR ranges in all clusters must be non-conflicting.
 
-* No encryption is performed by Cilium for the connectivity between nodes.
-  The feature is on the roadmap (`details
-  <https://github.com/cilium/cilium/issues/504>`_) but not implemented yet.  It
-  is however possible to set up IPSec-based encryption between all nodes using
-  a standard guide. It is also possible and common to establish VPNs between
-  networks if clusters are connected across untrusted networks.
+* This guide and the referenced scripts assume that Cilium was installed using
+  the :ref:`k8s_install_etcd_operator` instructions which leads to etcd being
+  managed by Cilium using etcd-operator. You can use any way to manage etcd but
+  you will have to adjust some of the scripts to account for different secret
+  names and adjust the LoadBalancer to expose the etcd pods.
 
-* All worker nodes must have connectivity to the etcd clusters of all remote
-  clusters. Security is implemented by connecting to etcd using TLS/SSL
-  certificates.
+* Nodes in all clusters must have IP connectivity between each other. This
+  requirement is typically met by establishing peering or VPN tunnels between
+  the networks of the nodes of each cluster.
+
+* All nodes must have a unique IP address assigned them. Node IPs of clusters
+  being connected together may not conflict with each other.
 
 * Cilium must be configured to use etcd as the kvstore. Consul is not supported
-  by cluster mesh.
+  by cluster mesh at this point.
 
-Getting Started
-###############
+* It is highly recommended to use a TLS protected etcd cluster with Cilium. The
+  server certificate of etcd must whitelist the host name ``*.mesh.cilium.io``.
+  If you are using the ``cilium-etcd-operator`` as set up in the
+  :ref:`k8s_install_etcd_operator` instructions then this is automatically
+  taken care of.
 
-Step 1: Prepare the individual clusters
-=======================================
+* The network between clusters must allow the inter-cluster communication. The
+  exact ports are documented in the :ref:`firewall_requirements` section.
 
-Setting the cluster name and ID
--------------------------------
+
+Prepare the clusters
+####################
+
+Specify the cluster name and ID
+===============================
 
 Each cluster must be assigned a unique human-readable name. The name will be
-used to group nodes of a cluster. The cluster name is specified with the
-``--cluster-name=NAME`` argument or ``cluster-name`` ConfigMap option.
+used to group nodes of a cluster together. The cluster name is specified with
+the ``--cluster-name=NAME`` argument or ``cluster-name`` ConfigMap option.
 
 To ensure scalability of identity allocation and policy enforcement, each
-cluster continues to manage its own identity allocation. In order to guarantee
-compatibility with identities across clusters, each cluster is configured with
-a unique cluster ID configured with the ``--cluster-id=ID`` argument or
-``cluster-id`` ConfigMap option.
+cluster continues to manage its own security identity allocation. In order to
+guarantee compatibility with identities across clusters, each cluster is
+configured with a unique cluster ID configured with the ``--cluster-id=ID``
+argument or ``cluster-id`` ConfigMap option. The value must be between 1 and
+255.
 
 .. code:: bash
 
-   $ kubectl -n kube-system edit cm cilium-config
-   [ add/edit ]
-   cluster-name: default
-   cluster-id: 1
+   kubectl -n kube-system edit cm cilium-config
+   [ ... add/edit ... ]
+   cluster-name: cluster1
+   cluster-id: "1"
 
-Provide unique values for the cluster name and ID for each cluster.
+Repeat this step for each cluster.
 
-Step 2: Create Secret to provide access to remote etcd
-------------------------------------------------------
+Expose the Cilium etcd to other clusters
+========================================
 
-Clusters are connected together by providing connectivity information to the
-etcd key-value store to each individual cluster. This allows Cilium to
-synchronize state between clusters and provide cross-cluster connectivity and
-policy enforcement.
+The Cilium etcd must be exposed to other clusters. There are many ways to
+achieve this. The method documented in this guide will work with cloud
+providers that implement the Kubernetes ``LoadBalancer`` service type:
 
-The connectivity details of a remote etcd typically includes certificates to
-enable use of TLS which is why the entire ClusterMesh configuration is stored
-in a Kubernetes Secret.
+.. tabs::
+  .. group-tab:: GCP
 
-1. Create an etcd configuration file for each remote cluster you want to
-   connect to. The syntax is that the official etcd configuration file and
-   identical to the syntax used in the ``cilium-config`` ConfigMap.
+    .. parsed-literal::
 
-2. Create a secret ``cilium-clustermesh`` from all configuration files you have
-   created:
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: cilium-etcd-external
+        annotations:
+          cloud.google.com/load-balancer-type: "Internal"
+      spec:
+        type: LoadBalancer
+        ports:
+        - port: 2379
+        selector:
+          app: etcd
+          etcd_cluster: cilium-etcd
+          io.cilium/app: etcd-operator
+
+  .. group-tab:: AWS
+
+    .. parsed-literal::
+
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: cilium-etcd-external
+        annotations:
+          service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
+      spec:
+        type: LoadBalancer
+        ports:
+        - port: 2379
+        selector:
+          app: etcd
+          etcd_cluster: cilium-etcd
+          io.cilium/app: etcd-operator
+
+The example used here exposes the etcd cluster as managed by
+``cilium-etcd-operator`` installed by the standard installation instructions as
+an internal service which means that it is only exposed inside of a VPC and not
+publicly accessible outside of the VPC. It is recommended to use a static IP
+for the ServiceIP to avoid requiring to update the IP mapping as done in one of
+the later steps.
+
+If you are running the cilium-etcd-operator you can simply apply the following
+service to expose etcd:
+
+.. tabs::
+  .. group-tab:: GCP
+
+    .. parsed-literal::
+
+       kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/clustermesh/cilium-etcd-external-service/cilium-etcd-external-gke.yaml
+
+  .. group-tab:: AWS
+
+    .. parsed-literal::
+
+       kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/clustermesh/cilium-etcd-external-service/cilium-etcd-external-eks.yaml
+
+
+.. note::
+
+   Make sure that you create the service in namespace in which cilium and/or
+   etcd is running. Depending on which installation method you chose, this
+   could be ``kube-system`` or ``cilium``.
+
+Extract the TLS keys and generate the etcd configuration
+========================================================
+
+The cluster mesh control plane performs TLS based authentication and encryption.
+For this purpose, the TLS keys and certificates of each etcd need to be made
+available to all clusters that wish to connect.
+
+1. Clone the ``cilium/clustermesh-tools`` repository. It contains scripts to
+   extracts the secrets and generate a Kubernetes secret in form of a YAML
+   file:
+
+   .. code:: bash
+   
+        git clone https://github.com/cilium/clustermesh-tools.git
+        cd clustermesh-tools
+
+2. Ensure that the kubectl context is pointing to the cluster you want to
+   extract the secret from.
+
+3. Extract the TLS certificate, key and root CA authority.
 
    .. code:: bash
 
-       $ ks create secret generic cilium-clustermesh --from-file=./cluster5 --from-file=./cluster7
+        ./extract-etcd-secrets.sh
 
-   Cilium will automatically ignore any configuration referring to its own
-   cluster so you can create a single secret and import it into all your
-   clusters to establish connectivity between all clusters.
+   This will extract the keys that Cilium is using to connect to the etcd in
+   the local cluster. The key files are written to
+   ``config/<cluster-name>.*.{key|crt|-ca.crt}``
+
+4. Repeat this step for all clusters you want to connect with each other.
+
+5. Generate a single Kubernetes secret from all the keys and certificates
+   extracted. The secret will contain the etcd configuration with the service
+   IP or host name of the etcd including the keys and certificates to access
+   it.
 
    .. code:: bash
 
-       cluster 1:
-       $ kubectl -n kube-system get secret cilium-clustermesh -o yaml > clustermesh.yaml
+        ./generate-secret-yaml.sh > clustermesh.yaml
 
-       cluster 2:
-       $ kubectl apply -f clustermesh.yaml
+.. note::
 
-Step 3: Restart the cilium agent
---------------------------------
+   The key files in ``config/`` and the secret represented as YAML are
+   sensitive. Anyone gaining access to these files is able to connect to the
+   etcd instances in the local cluster. Delete the files after the you are done
+   setting up the cluster mesh.
 
-Restart Cilium in each cluster to pick up the new cluster name, cluster id and
-clustermesh secret configuration. Cilium will automatically establish
-connectivity between the clusters.
+Ensure that the etcd service names can be resolved
+==================================================
+
+For TLS authentication to work properly, agents will connect to etcd in remote
+clusters using a pre-defined naming schema ``{clustername}.mesh.cilium.io``. In
+order for DNS resolution to work on these virtual host name, the names are
+statically mapped to the service IP via the ``/etc/hosts`` file.
+
+1. The following script will generate the required segment which has to be
+   inserted into the ``cilium`` DaemonSet:
+
+    .. code:: bash
+
+       ./generate-name-mapping.sh > ds.patch
+
+    The ``ds.patch`` will look something like this:
+
+    .. code:: bash
+
+        spec:
+          template:
+            spec:
+              hostAliases:
+              - ip: "10.138.0.18"
+                hostnames:
+                - cluster1.mesh.cilium.io
+              - ip: "10.138.0.19"
+                hostnames:
+                - cluster2.mesh.cilium.io
+
+2. Apply the patch to all DaemonSets in all clusters:
+
+   .. code:: bash
+
+      kubectl -n kube-system patch ds cilium -p "$(cat ds.patch)"
+
+Establish connections between clusters
+######################################
+
+1. Import the ``cilium-clustermesh`` secret that you generated in the last
+chapter into all of your clusters:
 
 .. code:: bash
 
-    $ kubectl -n kube-system delete -l k8s-app=cilium
+    kubectl apply -f clustermesh.yaml
 
-Step 4: Test the connectivity between clusters
-----------------------------------------------
+2. Restart the cilium-agent in all clusters so it picks up the new cluster
+   name, cluster id and mounts the ``cilium-clustermesh`` secret. Cilium will
+   automatically establish connectivity between the clusters.
+
+.. code:: bash
+
+    kubectl -n kube-system delete -l k8s-app=cilium
+
+Test pod connectivity between clusters
+======================================
+
 
 Run ``cilium node list`` to see the full list of nodes discovered. You can run
 this command inside any Cilium pod in any cluster:
@@ -132,3 +269,106 @@ this command inside any Cilium pod in any cluster:
 
     $ kubectl exec -ti pod-cluster5-xxx curl <pod-ip-cluster7>
     [...]
+
+Load-balancing with Global Services
+###################################
+
+Establishing load-balancing between clusters is achieved by defining a
+Kubernetes service with identical name and namespace in each cluster and adding
+the annotation ``io.cilium/global-service: "true"``` to declare it global.
+Cilium will automatically perform load-balancing to pods in both clusters.
+
+.. code:: bash
+
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: rebel-base
+      annotations:
+        io.cilium/global-service: "true"
+    spec:
+      type: ClusterIP
+      ports:
+      - port: 80
+      selector:
+        name: rebel-base
+
+Deploying a simple example service
+==================================
+
+1. In cluster 1, deploy:
+
+   .. code:: bash
+
+       kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/clustermesh/global-service-example/cluster1.yaml
+
+2. In cluster 2, deploy:
+
+   .. code:: bash
+
+       kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/clustermesh/global-service-example/cluster2.yaml
+
+3. From either cluster, access the global service:
+
+   .. code:: bash
+
+      kubectl exec -ti xwing-xxx -- curl rebel-base
+
+   You will see replies from pods in both clusters
+
+
+Security Policies
+#################
+
+As addressing and network security is decoupled, network security enforcement
+automatically spans across clusters. Note that Kubernetes security policies are
+not automatically distributed across clusters, it is your responsibility to
+apply ``CiliumNetworkPolicy`` or ``NetworkPolicy`` in all clusters.
+
+Allowing specific communication between clusters
+================================================
+
+The following policy illustrates how to allow particular pods to allow
+communicate between two clusters. The cluster name refers to the name given via
+the ``--cluster-name`` agent option or ``cluster-name`` ConfigMap option.
+
+::
+
+    apiVersion: "cilium.io/v2"
+    kind: CiliumNetworkPolicy
+    metadata:
+      name: "allow-cross-cluster"
+      description: "Allow x-wing in cluster1 to contact rebel-base in cluster2"
+    spec:
+      endpointSelector:
+        matchLabels:
+          name: x-wing
+          io.cilium.k8s.policy.cluster: cluster1
+      egress:
+      - toEndpoints:
+        - matchLabels:
+            name: rebel-base
+            io.cilium.k8s.policy.cluster: cluster2
+
+Limitations
+###########
+
+ * L7 security policies currently only work across multiple clusters if worker
+   nodes have routes installed allowing to route pod IPs of all clusters. This
+   is given when running in direct routing mode by running a routing daemon or
+   ``--auto-direct-node-routes`` but won't work automatically when using
+   tunnel/encapsulation mode.
+
+ * The number of clusters that can be connected together is currently limited
+   to 255. This limitation will be lifted in the future when running in direct
+   routing mode or when running in encapsulation mode with encryption enabled.
+
+Roadmap Ahead
+#############
+
+ * Future versions will put an API server before etcd to provide better
+   scalability and simplify the installation to support any etcd support
+
+ * Introduction of IPSec and use of ESP or utilization of the traffic class
+   field in the IPv6 header will allow to use more than 8 bits for the
+   cluster-id and thus support more than 256 clusters.

--- a/Documentation/gettingstarted/k8s-install-external-etcd.rst
+++ b/Documentation/gettingstarted/k8s-install-external-etcd.rst
@@ -93,13 +93,13 @@ Kubernetes you are using:
     # In case you want to use TLS in etcd, uncomment the 'ca-file' line
     # and create a kubernetes secret by following the tutorial in
     # https://cilium.link/etcd-config
-    #ca-file: '/var/lib/etcd-secrets/etcd-client-ca.crt'
+    #ca-file: '/var/lib/etcd-secrets/etcd-ca'
     #
     # In case you want client to server authentication, uncomment the following
     # lines and create a kubernetes secret by following the tutorial in
     # https://cilium.link/etcd-config
-    #key-file: '/var/lib/etcd-secrets/etcd-client.key'
-    #cert-file: '/var/lib/etcd-secrets/etcd-client.crt'
+    #key-file: '/var/lib/etcd-secrets/etcd-client-key'
+    #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
 
 Deploy Cilium
 =============
@@ -111,7 +111,7 @@ Deploy Cilium
 Validate the Installation
 =========================
 
-Verify that a cilium pod was started on each of your worker nodes
+Verify that Cilium pods were started on each of your worker nodes
 
 .. code:: bash
 
@@ -119,3 +119,6 @@ Verify that a cilium pod was started on each of your worker nodes
     NAME            DESIRED   CURRENT   READY     NODE-SELECTOR   AGE
     cilium          4         4         4         <none>          2m
 
+    kubectl -n kube-system get deployments cilium-operator
+    NAME              READY   UP-TO-DATE   AVAILABLE   AGE
+    cilium-operator   1/1     1            1           5m25s

--- a/Documentation/install/system_requirements.rst
+++ b/Documentation/install/system_requirements.rst
@@ -150,6 +150,8 @@ The minimum version of iproute2_ must be >= 4.8.0. Please see
 https://www.kernel.org/pub/linux/utils/net/iproute2/ for documentation on how
 to install iproute2.
 
+.. _firewall_requirements:
+
 Firewall Rules
 ==============
 
@@ -159,7 +161,7 @@ It is recommended but optional that all nodes running Cilium in a given cluster 
 
 If you are using VXLAN overlay network mode, Cilium uses Linux's default VXLAN port 8472 over UDP, unless Linux has been configured otherwise. In this case, UDP 8472 must be open among all nodes to enable VXLAN overlay mode. The same applies to Geneve overlay network mode, except the port is UDP 6081.
 
-If you are running in direct routing mode, you effectively need to allow all traffic among nodes. Since there's no distinction between the pods' network and the underlying network, all nodes must be able to freely talk to each other.
+If you are running in direct routing mode, your network must allow routing of pod IPs.
 
 As an example, if you are running on AWS with VXLAN overlay networking, here is a minimum set of AWS Security Group (SG) rules. It assumes a separation between the SG on the master nodes, ``master-sg``, and the worker nodes, ``worker-sg``. It also assumes ``etcd`` is running on the master nodes.
 

--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -1191,6 +1191,24 @@ resources.
 
         .. literalinclude:: ../../examples/policies/kubernetes/serviceaccount/serviceaccount-policy.json
 
+Multi-Cluster
+-------------
+
+When operating multiple cluster with cluster mesh, the cluster name is exposed
+via the label ``io.cilium.k8s.policy.cluster`` and can be used to restrict
+policies to a particular cluster.
+
+.. only:: html
+
+   .. tabs::
+     .. group-tab:: k8s YAML
+
+        .. literalinclude:: ../../examples/policies/kubernetes/clustermesh/cross-cluster-policy.yaml
+
+.. only:: epub or latex
+
+        .. literalinclude:: ../../examples/policies/kubernetes/clustermesh/cross-cluster-policy.yaml
+
 Well-known Identities
 ---------------------
 

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1200,7 +1200,7 @@
     "storage/v1beta1"
   ]
   pruneopts = "NUT"
-  revision = "kubernetes-1.13.2"
+  revision = "kubernetes-1.13.3"
 
 [[projects]]
   name = "k8s.io/apiextensions-apiserver"
@@ -1213,7 +1213,7 @@
     "pkg/features"
   ]
   pruneopts = "NUT"
-  revision = "kubernetes-1.13.2"
+  revision = "kubernetes-1.13.3"
 
 [[projects]]
   name = "k8s.io/apimachinery"
@@ -1263,7 +1263,7 @@
     "third_party/forked/golang/reflect"
   ]
   pruneopts = "NUT"
-  revision = "kubernetes-1.13.2"
+  revision = "kubernetes-1.13.3"
 
 [[projects]]
   name = "k8s.io/apiserver"
@@ -1272,11 +1272,9 @@
     "pkg/util/feature"
   ]
   pruneopts = "NUT"
-  revision = "kubernetes-1.13.2"
+  revision = "kubernetes-1.13.3"
 
 [[projects]]
-  digest = "1:e00a2f6e9516b21e01cf2878e2926fee4cf8ec1be1b4b36f201d7c31ccc1ce4d"
->>>>>>> vendor: bump k8s version to v1.13.2
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -1377,7 +1375,7 @@
     "util/retry"
   ]
   pruneopts = "NUT"
-  revision = "kubernetes-1.13.2"
+  revision = "kubernetes-1.13.3"
 
 [[projects]]
   name = "k8s.io/code-generator"
@@ -1393,7 +1391,7 @@
     "pkg/util"
   ]
   pruneopts = "T"
-  revision = "kubernetes-1.13.2"
+  revision = "kubernetes-1.13.3"
 
 [[projects]]
   name = "k8s.io/gengo"
@@ -1435,7 +1433,7 @@
     "pkg/registry/core/service/ipallocator"
   ]
   pruneopts = "NUT"
-  revision = "v1.13.2"
+  revision = "v1.13.3"
 
 [[projects]]
   name = "sigs.k8s.io/yaml"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -467,42 +467,42 @@ required = [
 
 [[constraint]]
   name = "k8s.io/api"
-  revision = "kubernetes-1.13.2"
+  revision = "kubernetes-1.13.3"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
 
 [[constraint]]
   name = "k8s.io/apiextensions-apiserver"
-  revision = "kubernetes-1.13.2"
+  revision = "kubernetes-1.13.3"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
 
 [[override]]
   name = "k8s.io/apiserver"
-  revision = "kubernetes-1.13.2"
+  revision = "kubernetes-1.13.3"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
 
 [[constraint]]
   name = "k8s.io/apimachinery"
-  revision = "kubernetes-1.13.2"
+  revision = "kubernetes-1.13.3"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
 
 [[constraint]]
   name = "k8s.io/client-go"
-  revision = "kubernetes-1.13.2"
+  revision = "kubernetes-1.13.3"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
 
 [[constraint]]
   name = "k8s.io/code-generator"
-  revision = "kubernetes-1.13.2"
+  revision = "kubernetes-1.13.3"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
@@ -516,7 +516,7 @@ required = [
 
 [[constraint]]
   name = "k8s.io/kubernetes"
-  revision = "v1.13.2"
+  revision = "v1.13.3"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""

--- a/cilium-operator.Dockerfile
+++ b/cilium-operator.Dockerfile
@@ -11,4 +11,4 @@ FROM scratch
 LABEL maintainer="maintainer@cilium.io"
 COPY --from=builder /go/src/github.com/cilium/cilium/operator/cilium-operator /usr/bin/cilium-operator
 WORKDIR /
-CMD ["/usr/bin/cilium-etcd-operator"]
+CMD ["/usr/bin/cilium-operator"]

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -55,6 +55,7 @@ import (
 	"github.com/cilium/cilium/pkg/fqdn"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/ipam"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s"
@@ -916,6 +917,59 @@ func createPrefixLengthCounter() *counter.PrefixLengthCounter {
 	return counter
 }
 
+func (d *Daemon) prepareAllocationCIDR(family datapath.NodeAddressingFamily) (routerIP net.IP, err error) {
+	// Reserve the IPv4 external node IP within the allocation range if
+	// required.
+	allocRange := family.AllocationCIDR()
+	nodeIP := family.PrimaryExternal()
+	if allocRange.Contains(nodeIP) {
+		err = d.ipam.AllocateIP(nodeIP)
+		if err != nil {
+			err = fmt.Errorf("Unable to allocate external IPv4 node IP %s from allocation range %s: %s",
+				nodeIP, allocRange, err)
+			return
+		}
+	}
+
+	routerIP = family.Router()
+	if routerIP != nil && !allocRange.Contains(routerIP) {
+		log.Warningf("Detected allocation CIDR change to %s, previous router IP %s", allocRange, routerIP)
+
+		// The restored router IP is not part of the allocation range.
+		// This indicates that the allocation range has changed.
+		if !option.Config.IsFlannelMasterDeviceSet() {
+			// Remove the old host device and
+			var link netlink.Link
+			link, err = netlink.LinkByName(option.Config.HostDevice)
+			if err != nil {
+				err = fmt.Errorf("unable to lookup host device %s: %s", option.Config.HostDevice, err)
+				return
+			}
+			if err = netlink.LinkDel(link); err != nil {
+				err = fmt.Errorf("unable to delete host device %s to change allocation CIDR: %s",
+					option.Config.HostDevice, err)
+				return
+			}
+		}
+
+		// force re-allocation of the router IP
+		routerIP = nil
+	}
+
+	if routerIP == nil {
+		routerIP = ip.GetNextIP(family.AllocationCIDR().IP)
+	}
+
+	err = d.ipam.AllocateIP(routerIP)
+	if err != nil {
+		err = fmt.Errorf("Unable to allocate IPv4 router IP %s from allocation range %s: %s",
+			routerIP, allocRange, err)
+		return
+	}
+
+	return
+}
+
 // NewDaemon creates and returns a new Daemon with the parameters set in c.
 func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 	// Validate the daemon-specific global options.
@@ -1094,27 +1148,24 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 		log.WithError(err).Error("Unable to restore existing endpoints")
 	}
 
-	switch err := d.ipam.AllocateInternalIPs(); err.(type) {
-	case ipam.ErrAllocation:
-		if option.Config.IPv4Range == AutoCIDR || option.Config.IPv6ServiceRange == AutoCIDR {
-			log.WithError(err).Fatalf(
-				"The allocation CIDR is different from the previous cilium instance. " +
-					"This error is most likely caused by a temporary network disruption to the kube-apiserver " +
-					"that prevent Cilium from retrieve the node's IPv4/IPv6 allocation range. " +
-					"If you believe the allocation range is supposed to be different you need to clean " +
-					"up all Cilium state with the `cilium cleanup` command on this node. Be aware " +
-					"this will cause network disruption for all existing containers managed by Cilium " +
-					"running on this node and you will have to restart them.")
-		} else {
-			log.WithError(err).Fatalf(
-				"The allocation CIDR is different from the previous cilium instance. " +
-					"If you believe the allocation range is supposed to be different you need to clean " +
-					"up all Cilium state with the `cilium cleanup` command on this node. Be aware " +
-					"this will cause network disruption for all existing containers managed by Cilium " +
-					"running on this node and you will have to restart them.")
+	if option.Config.EnableIPv4 {
+		routerIP, err := d.prepareAllocationCIDR(dp.LocalNodeAddressing().IPv4())
+		if err != nil {
+			return nil, nil, err
 		}
-	case error:
-		log.WithError(err).Fatal("IPAM init failed")
+		if routerIP != nil {
+			node.SetInternalIPv4(routerIP)
+		}
+	}
+
+	if option.Config.EnableIPv6 {
+		routerIP, err := d.prepareAllocationCIDR(dp.LocalNodeAddressing().IPv6())
+		if err != nil {
+			return nil, nil, err
+		}
+		if routerIP != nil {
+			node.SetIPv6Router(routerIP)
+		}
 	}
 
 	log.Info("Addressing information:")

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1139,6 +1139,7 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 	if err := workloads.Setup(d.ipam, option.Config.Workloads, wOpts); err != nil {
 		return nil, nil, fmt.Errorf("unable to setup workload: %s", err)
 	}
+	log.Infof("Container runtime options set: %s", workloads.GetRuntimeOptions())
 
 	// restore endpoints before any IPs are allocated to avoid eventual IP
 	// conflicts later on, otherwise any IP conflict will result in the

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -1001,8 +1001,6 @@ func initEnv(cmd *cobra.Command) {
 			log.WithError(err).Fatal("Unable to initialize policy container runtimes")
 			return
 		}
-
-		log.Infof("Container runtime options set: %s", workloads.GetRuntimeOptions())
 	}
 
 	if option.Config.SidecarHTTPProxy {

--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"strings"
 	"sync"
 	"time"
 
@@ -62,8 +61,6 @@ import (
 )
 
 const (
-	k8sErrLogTimeout = time.Minute
-
 	k8sAPIGroupCRD              = "CustomResourceDefinition"
 	k8sAPIGroupNodeV1Core       = "core/v1::Node"
 	k8sAPIGroupNamespaceV1Core  = "core/v1::Namespace"
@@ -89,10 +86,6 @@ const (
 )
 
 var (
-	// k8sErrMsgMU guards additions and removals to k8sErrMsg, which stores a
-	// time after which a repeat error message can be printed
-	k8sErrMsgMU  lock.Mutex
-	k8sErrMsg    = map[string]time.Time{}
 	k8sServerVer *go_version.Version
 
 	ciliumNPClient clientset.Interface
@@ -239,74 +232,7 @@ func (m *k8sAPIGroupsUsed) getGroups() []string {
 func init() {
 	// Replace error handler with our own
 	runtime.ErrorHandlers = []func(error){
-		k8sErrorHandler,
-	}
-}
-
-// k8sErrorUpdateCheckUnmuteTime returns a boolean indicating whether we should
-// log errmsg or not. It manages once-per-k8sErrLogTimeout entry in k8sErrMsg.
-// When errmsg is new or more than k8sErrLogTimeout has passed since the last
-// invocation that returned true, it returns true.
-func k8sErrorUpdateCheckUnmuteTime(errstr string, now time.Time) bool {
-	k8sErrMsgMU.Lock()
-	defer k8sErrMsgMU.Unlock()
-
-	if unmuteDeadline, ok := k8sErrMsg[errstr]; !ok || now.After(unmuteDeadline) {
-		k8sErrMsg[errstr] = now.Add(k8sErrLogTimeout)
-		return true
-	}
-
-	return false
-}
-
-// k8sErrorHandler handles the error messages in a non verbose way by omitting
-// repeated instances of the same error message for a timeout defined with
-// k8sErrLogTimeout.
-func k8sErrorHandler(e error) {
-	if e == nil {
-		return
-	}
-
-	// We rate-limit certain categories of error message. These are matched
-	// below, with a default behaviour to print everything else without
-	// rate-limiting.
-	// Note: We also have side-effects in some of the special cases.
-	now := time.Now()
-	errstr := e.Error()
-	switch {
-	// This can occur when cilium comes up before the k8s API server, and keeps
-	// trying to connect.
-	case strings.Contains(errstr, "connection refused"):
-		if k8sErrorUpdateCheckUnmuteTime(errstr, now) {
-			log.WithError(e).Error("k8sError")
-		}
-
-	// k8s does not allow us to watch both ThirdPartyResource and
-	// CustomResourceDefinition. This would occur when a user mixes these within
-	// the k8s cluster, and might occur when upgrading from versions of cilium
-	// that used ThirdPartyResource to define CiliumNetworkPolicy.
-	case strings.Contains(errstr, "Failed to list *v2.CiliumNetworkPolicy: the server could not find the requested resource"):
-		if k8sErrorUpdateCheckUnmuteTime(errstr, now) {
-			log.WithError(e).Error("Conflicting TPR and CRD resources")
-			log.Warn("Detected conflicting TPR and CRD, please migrate all ThirdPartyResource to CustomResourceDefinition! More info: https://cilium.link/migrate-tpr")
-			log.Warn("Due to conflicting TPR and CRD rules, CiliumNetworkPolicy enforcement can't be guaranteed!")
-		}
-
-	// fromCIDR and toCIDR used to expect an "ip" subfield (so, they were a YAML
-	// map with one field) but common usage and expectation would simply list the
-	// CIDR ranges and IPs desired as a YAML list. In these cases we would see
-	// this decode error. We have since changed the definition to be a simple
-	// list of strings.
-	case strings.Contains(errstr, "Unable to decode an event from the watch stream: unable to decode watch event"),
-		strings.Contains(errstr, "Failed to list *v1.CiliumNetworkPolicy: only encoded map or array can be decoded into a struct"),
-		strings.Contains(errstr, "Failed to list *v2.CiliumNetworkPolicy: only encoded map or array can be decoded into a struct"),
-		strings.Contains(errstr, "Failed to list *v2.CiliumNetworkPolicy: v2.CiliumNetworkPolicyList:"):
-		if k8sErrorUpdateCheckUnmuteTime(errstr, now) {
-			log.WithError(e).Error("Unable to decode k8s watch event")
-		}
-
-	default:
-		log.WithError(e).Error("k8sError")
+		k8s.K8sErrorHandler,
 	}
 }
 

--- a/daemon/k8s_watcher_test.go
+++ b/daemon/k8s_watcher_test.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"net"
-	"time"
 
 	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/endpointmanager"
@@ -42,27 +41,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 )
-
-func (ds *DaemonSuite) TestK8sErrorLogTimeout(c *C) {
-	errstr := "I am an error string"
-
-	// ensure k8sErrMsg is empty for tests that use it
-	k8sErrMsgMU.Lock()
-	k8sErrMsg = map[string]time.Time{}
-	k8sErrMsgMU.Unlock()
-
-	// Returns true because it's the first time we see this message
-	startTime := time.Now()
-	c.Assert(k8sErrorUpdateCheckUnmuteTime(errstr, startTime), Equals, true)
-
-	// Returns false because <= k8sErrLogTimeout time has passed
-	noLogTime := startTime.Add(k8sErrLogTimeout)
-	c.Assert(k8sErrorUpdateCheckUnmuteTime(errstr, noLogTime), Equals, false)
-
-	// Returns true because k8sErrLogTimeout has passed
-	shouldLogTime := startTime.Add(k8sErrLogTimeout).Add(time.Nanosecond)
-	c.Assert(k8sErrorUpdateCheckUnmuteTime(errstr, shouldLogTime), Equals, true)
-}
 
 func (ds *DaemonSuite) Test_missingK8sNetworkPolicyV1(c *C) {
 	type args struct {

--- a/examples/kubernetes-ingress/scripts/helpers.bash
+++ b/examples/kubernetes-ingress/scripts/helpers.bash
@@ -73,7 +73,7 @@ cluster_api_server_ip=${K8S_CLUSTER_API_SERVER_IP:-"172.20.0.1"}
 #cluster_dns_ip=${K8S_CLUSTER_DNS_IP:-"FD03::A"}
 #cluster_api_server_ip=${K8S_CLUSTER_API_SERVER_IP:-"FD03::1"}
 
-k8s_version="v1.13.0"
+k8s_version="v1.13.3"
 etcd_version="v3.3.10"
 
 function restore_flag {

--- a/examples/kubernetes/clustermesh/cilium-etcd-external-service/cilium-etcd-external-eks.yaml
+++ b/examples/kubernetes/clustermesh/cilium-etcd-external-service/cilium-etcd-external-eks.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cilium-etcd-external
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 2379
+  selector:
+    app: etcd
+    etcd_cluster: cilium-etcd
+    io.cilium/app: etcd-operator

--- a/examples/kubernetes/clustermesh/cilium-etcd-external-service/cilium-etcd-external-gke.yaml
+++ b/examples/kubernetes/clustermesh/cilium-etcd-external-service/cilium-etcd-external-gke.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cilium-etcd-external
+  annotations:
+    cloud.google.com/load-balancer-type: "Internal"
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 2379
+  selector:
+    app: etcd
+    etcd_cluster: cilium-etcd
+    io.cilium/app: etcd-operator

--- a/examples/kubernetes/clustermesh/global-service-example/cluster1.yaml
+++ b/examples/kubernetes/clustermesh/global-service-example/cluster1.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rebel-base
+  annotations:
+    io.cilium/global-service: "true"
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+  selector:
+    name: rebel-base
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: rebel-base
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        name: rebel-base
+    spec:
+      containers:
+      - name: rebel-base
+        image: docker.io/nginx:1.15.8
+        volumeMounts:
+          - name: html
+            mountPath: /usr/share/nginx/html/
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 80
+          periodSeconds: 1
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
+      volumes:
+        - name: html
+          configMap:
+            name: rebel-base-response
+            items:
+              - key: message
+                path: index.html
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rebel-base-response
+data:
+  message: "{\"Galaxy\": \"Alderaan\", \"Cluster\": \"Cluster-1\"}\n"
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: x-wing
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        name: x-wing
+    spec:
+      containers:
+      - name: x-wing-container
+        image: docker.io/cilium/json-mock:1.0
+        livenessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - -o
+            - /dev/null
+            - localhost
+        readinessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - -o
+            - /dev/null
+            - localhost

--- a/examples/kubernetes/clustermesh/global-service-example/cluster2.yaml
+++ b/examples/kubernetes/clustermesh/global-service-example/cluster2.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rebel-base
+  annotations:
+    io.cilium/global-service: "true"
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+  selector:
+    name: rebel-base
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: rebel-base
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        name: rebel-base
+    spec:
+      containers:
+      - name: rebel-base
+        image: docker.io/nginx:1.15.8
+        volumeMounts:
+          - name: html
+            mountPath: /usr/share/nginx/html/
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 80
+          periodSeconds: 1
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
+      volumes:
+        - name: html
+          configMap:
+            name: rebel-base-response
+            items:
+              - key: message
+                path: index.html
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rebel-base-response
+data:
+  message: "{\"Galaxy\": \"Alderaan\", \"Cluster\": \"Cluster-2\"}\n"
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: x-wing
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        name: x-wing
+    spec:
+      containers:
+      - name: x-wing-container
+        image: docker.io/cilium/json-mock:1.0
+        livenessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - -o
+            - /dev/null
+            - localhost
+        readinessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - -o
+            - /dev/null
+            - localhost

--- a/examples/policies/kubernetes/clustermesh/cross-cluster-policy.yaml
+++ b/examples/policies/kubernetes/clustermesh/cross-cluster-policy.yaml
@@ -1,0 +1,15 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "allow-cross-cluster"
+  description: "Allow x-wing in cluster1 to contact rebel-base in cluster2"
+spec:
+  endpointSelector:
+    matchLabels:
+      name: x-wing
+      io.cilium.k8s.policy.cluster: cluster1
+  egress:
+  - toEndpoints:
+    - matchLabels:
+        name: rebel-base
+        io.cilium.k8s.policy.cluster: cluster2

--- a/pkg/controller/manager.go
+++ b/pkg/controller/manager.go
@@ -235,8 +235,8 @@ func (m *Manager) GetStatusModel() models.ControllerStatuses {
 // FakeManager returns a fake controller manager with the specified number of
 // failing controllers. The returned manager is identical in any regard except
 // for internal pointers.
-func FakeManager(failingControllers int) Manager {
-	m := Manager{
+func FakeManager(failingControllers int) *Manager {
+	m := &Manager{
 		controllers: controllerMap{},
 	}
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -263,7 +263,7 @@ type Endpoint struct {
 
 	// controllers is the list of async controllers syncing the endpoint to
 	// other resources
-	controllers controller.Manager
+	controllers *controller.Manager
 
 	// realizedRedirects maps the ID of each proxy redirect that has been
 	// successfully added into a proxy for this endpoint, to the redirect's
@@ -418,6 +418,7 @@ func NewEndpointWithState(ID uint16, state string) *Endpoint {
 		DNSHistory:    fqdn.NewDNSCache(),
 		state:         state,
 		hasBPFProgram: make(chan struct{}, 0),
+		controllers:   controller.NewManager(),
 	}
 	ep.UpdateLogger(nil)
 	return ep
@@ -447,6 +448,7 @@ func NewEndpointFromChangeModel(base *models.EndpointChangeRequest) (*Endpoint, 
 		hasBPFProgram:    make(chan struct{}, 0),
 		desiredPolicy:    &policy.EndpointPolicy{},
 		realizedPolicy:   &policy.EndpointPolicy{},
+		controllers:      controller.NewManager(),
 	}
 	ep.UpdateLogger(nil)
 
@@ -1198,6 +1200,7 @@ func ParseEndpoint(strEp string) (*Endpoint, error) {
 	ep.hasBPFProgram = make(chan struct{}, 0)
 	ep.desiredPolicy = &policy.EndpointPolicy{}
 	ep.realizedPolicy = &policy.EndpointPolicy{}
+	ep.controllers = controller.NewManager()
 
 	// We need to check for nil in Status, CurrentStatuses and Log, since in
 	// some use cases, status will be not nil and Cilium will eventually

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -143,7 +143,7 @@ func (ipam *IPAM) AllocateInternalIPs() error {
 		if allocRange.Contains(nodeIP) {
 			err := ipam.IPv4Allocator.Allocate(nodeIP)
 			if err != nil {
-				log.WithError(err).WithField(logfields.IPAddr, nodeIP).Debug("Unable to reserve IPv4 router address")
+				return fmt.Errorf("Unable to allocate external IPv4 node IP %s from allocation range %s: %s", nodeIP, allocRange, err)
 			}
 		}
 
@@ -179,7 +179,7 @@ func (ipam *IPAM) AllocateInternalIPs() error {
 			if allocRange.Contains(ip6) {
 				err := ipam.IPv6Allocator.Allocate(ip6)
 				if err != nil {
-					log.WithError(err).WithField(logfields.IPAddr, ip6).Debug("Unable to reserve IPv6 address")
+					return fmt.Errorf("Unable to allocate external IPv6 node IP %s from allocation range %s: %s", ip6, allocRange, err)
 				}
 			}
 

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -37,9 +37,6 @@ func (s *IPAMSuite) TestLock(c *C) {
 	fakeAddressing := fake.NewNodeAddressing()
 	ipam := NewIPAM(fakeAddressing, Configuration{EnableIPv4: true, EnableIPv6: true})
 
-	err := ipam.AllocateInternalIPs()
-	c.Assert(err, IsNil)
-
 	// Since the IPs we have allocated to the endpoints might or might not
 	// be in the allocrange specified in cilium, we need to specify them
 	// manually on the endpoint based on the alloc range.

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/node"
-	"github.com/cilium/cilium/pkg/option"
 
 	. "gopkg.in/check.v1"
 	"k8s.io/api/core/v1"
@@ -35,9 +34,6 @@ import (
 )
 
 func (s *K8sSuite) TestUseNodeCIDR(c *C) {
-	option.Config.EnableIPv4 = true
-	option.Config.EnableIPv6 = true
-
 	// Test IPv4
 	node1 := v1.Node{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/k8s/error_helpers.go
+++ b/pkg/k8s/error_helpers.go
@@ -1,0 +1,98 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"strings"
+	"time"
+
+	"github.com/cilium/cilium/pkg/lock"
+)
+
+var (
+
+	// k8sErrMsgMU guards additions and removals to k8sErrMsg, which stores a
+	// time after which a repeat error message can be printed
+	k8sErrMsgMU      lock.Mutex
+	k8sErrMsg        = map[string]time.Time{}
+	k8sErrLogTimeout = time.Minute
+)
+
+// k8sErrorUpdateCheckUnmuteTime returns a boolean indicating whether we should
+// log errmsg or not. It manages once-per-k8sErrLogTimeout entry in k8sErrMsg.
+// When errmsg is new or more than k8sErrLogTimeout has passed since the last
+// invocation that returned true, it returns true.
+func k8sErrorUpdateCheckUnmuteTime(errstr string, now time.Time) bool {
+	k8sErrMsgMU.Lock()
+	defer k8sErrMsgMU.Unlock()
+
+	if unmuteDeadline, ok := k8sErrMsg[errstr]; !ok || now.After(unmuteDeadline) {
+		k8sErrMsg[errstr] = now.Add(k8sErrLogTimeout)
+		return true
+	}
+
+	return false
+}
+
+// K8sErrorHandler handles the error messages in a non verbose way by omitting
+// repeated instances of the same error message for a timeout defined with
+// k8sErrLogTimeout.
+func K8sErrorHandler(e error) {
+	if e == nil {
+		return
+	}
+
+	// We rate-limit certain categories of error message. These are matched
+	// below, with a default behaviour to print everything else without
+	// rate-limiting.
+	// Note: We also have side-effects in some of the special cases.
+	now := time.Now()
+	errstr := e.Error()
+	switch {
+	// This can occur when cilium comes up before the k8s API server, and keeps
+	// trying to connect.
+	case strings.Contains(errstr, "connection refused"):
+		if k8sErrorUpdateCheckUnmuteTime(errstr, now) {
+			log.WithError(e).Error("k8sError")
+		}
+
+	// k8s does not allow us to watch both ThirdPartyResource and
+	// CustomResourceDefinition. This would occur when a user mixes these within
+	// the k8s cluster, and might occur when upgrading from versions of cilium
+	// that used ThirdPartyResource to define CiliumNetworkPolicy.
+	case strings.Contains(errstr, "Failed to list *v2.CiliumNetworkPolicy: the server could not find the requested resource"):
+		if k8sErrorUpdateCheckUnmuteTime(errstr, now) {
+			log.WithError(e).Error("Conflicting TPR and CRD resources")
+			log.Warn("Detected conflicting TPR and CRD, please migrate all ThirdPartyResource to CustomResourceDefinition! More info: https://cilium.link/migrate-tpr")
+			log.Warn("Due to conflicting TPR and CRD rules, CiliumNetworkPolicy enforcement can't be guaranteed!")
+		}
+
+	// fromCIDR and toCIDR used to expect an "ip" subfield (so, they were a YAML
+	// map with one field) but common usage and expectation would simply list the
+	// CIDR ranges and IPs desired as a YAML list. In these cases we would see
+	// this decode error. We have since changed the definition to be a simple
+	// list of strings.
+	case strings.Contains(errstr, "Unable to decode an event from the watch stream: unable to decode watch event"),
+		strings.Contains(errstr, "Failed to list *v1.CiliumNetworkPolicy: only encoded map or array can be decoded into a struct"),
+		strings.Contains(errstr, "Failed to list *v2.CiliumNetworkPolicy: only encoded map or array can be decoded into a struct"),
+		strings.Contains(errstr, "Failed to list *v2.CiliumNetworkPolicy: v2.CiliumNetworkPolicyList:"):
+		if k8sErrorUpdateCheckUnmuteTime(errstr, now) {
+			log.WithError(e).Error("Unable to decode k8s watch event")
+		}
+
+	default:
+		log.WithError(e).Error("k8sError")
+	}
+}

--- a/pkg/k8s/error_helpers_test.go
+++ b/pkg/k8s/error_helpers_test.go
@@ -1,0 +1,44 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package k8s
+
+import (
+	"time"
+
+	. "gopkg.in/check.v1"
+)
+
+func (s *K8sSuite) TestK8sErrorLogTimeout(c *C) {
+	errstr := "I am an error string"
+
+	// ensure k8sErrMsg is empty for tests that use it
+	k8sErrMsgMU.Lock()
+	k8sErrMsg = map[string]time.Time{}
+	k8sErrMsgMU.Unlock()
+
+	// Returns true because it's the first time we see this message
+	startTime := time.Now()
+	c.Assert(k8sErrorUpdateCheckUnmuteTime(errstr, startTime), Equals, true)
+
+	// Returns false because <= k8sErrLogTimeout time has passed
+	noLogTime := startTime.Add(k8sErrLogTimeout)
+	c.Assert(k8sErrorUpdateCheckUnmuteTime(errstr, noLogTime), Equals, false)
+
+	// Returns true because k8sErrLogTimeout has passed
+	shouldLogTime := startTime.Add(k8sErrLogTimeout).Add(time.Nanosecond)
+	c.Assert(k8sErrorUpdateCheckUnmuteTime(errstr, shouldLogTime), Equals, true)
+}

--- a/pkg/node/node_address.go
+++ b/pkg/node/node_address.go
@@ -243,7 +243,11 @@ func AutoComplete() error {
 	}
 
 	if option.Config.EnableIPv6 && ipv6AllocRange == nil {
-		return fmt.Errorf("IPv6 per node allocation prefix is not configured. Please specificy --ipv6-range")
+		return fmt.Errorf("IPv6 allocation CIDR is not configured. Please specificy --ipv6-range")
+	}
+
+	if option.Config.EnableIPv4 && ipv4AllocRange == nil {
+		return fmt.Errorf("IPv4 allocation CIDR is not configured. Please specificy --ipv4-range")
 	}
 
 	return nil

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -21,9 +21,7 @@ import (
 	"testing"
 
 	"github.com/cilium/cilium/pkg/cidr"
-	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/node/addressing"
-	"github.com/cilium/cilium/pkg/option"
 
 	. "gopkg.in/check.v1"
 )
@@ -36,11 +34,6 @@ func Test(t *testing.T) {
 type NodeSuite struct{}
 
 var _ = Suite(&NodeSuite{})
-
-func (s *NodeSuite) SetUpTest(c *C) {
-	option.Config.Populate()
-	option.Config.EnableIPv4 = defaults.EnableIPv4
-}
 
 func (s *NodeSuite) TestGetNodeIP(c *C) {
 	n := Node{

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -772,6 +772,8 @@ var (
 		IPv6ClusterAllocCIDRBase: defaults.IPv6ClusterAllocCIDRBase,
 		EnableHostIPRestore:      defaults.EnableHostIPRestore,
 		EnableHealthChecking:     defaults.EnableHealthChecking,
+		EnableIPv4:               defaults.EnableIPv4,
+		EnableIPv6:               defaults.EnableIPv6,
 		ContainerRuntimeEndpoint: make(map[string]string),
 		FixedIdentityMapping:     make(map[string]string),
 		KVStoreOpt:               make(map[string]string),

--- a/plugins/cilium-docker/driver/driver.go
+++ b/plugins/cilium-docker/driver/driver.go
@@ -105,7 +105,7 @@ func NewDriver(url string) (Driver, error) {
 			}
 			time.Sleep(time.Duration(tries) * time.Second)
 		} else {
-			if res.Status.Addressing == nil || res.Status.Addressing.IPV6 == nil {
+			if res.Status.Addressing == nil || (res.Status.Addressing.IPV4 == nil && res.Status.Addressing.IPV6 == nil) {
 				scopedLog.Fatal("Invalid addressing information from daemon")
 			}
 

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -166,7 +166,7 @@ case $K8S_VERSION in
         ;;
     "1.11")
         KUBERNETES_CNI_VERSION="0.6.0"
-        K8S_FULL_VERSION="1.11.5"
+        K8S_FULL_VERSION="1.11.7"
         KUBEADM_OPTIONS="--ignore-preflight-errors=cri,FileExisting-crictl,SystemVerification"
         KUBEADM_SLAVE_OPTIONS="--discovery-token-unsafe-skip-ca-verification --ignore-preflight-errors=cri,FileExisting-crictl,SystemVerification"
         sudo ln -sf $COREDNS_DEPLOYMENT $DNS_DEPLOYMENT
@@ -181,7 +181,7 @@ case $K8S_VERSION in
         ;;
     "1.13")
         KUBERNETES_CNI_VERSION="0.6.0"
-        K8S_FULL_VERSION="1.13.2"
+        K8S_FULL_VERSION="1.13.3"
         KUBEADM_OPTIONS="--ignore-preflight-errors=cri"
         KUBEADM_SLAVE_OPTIONS="--discovery-token-unsafe-skip-ca-verification --ignore-preflight-errors=cri,SystemVerification"
         sudo ln -sf $COREDNS_DEPLOYMENT $DNS_DEPLOYMENT

--- a/vendor/k8s.io/apimachinery/pkg/runtime/serializer/streaming/streaming.go
+++ b/vendor/k8s.io/apimachinery/pkg/runtime/serializer/streaming/streaming.go
@@ -64,7 +64,7 @@ func NewDecoder(r io.ReadCloser, d runtime.Decoder) Decoder {
 		reader:   r,
 		decoder:  d,
 		buf:      make([]byte, 1024),
-		maxBytes: 1024 * 1024,
+		maxBytes: 16 * 1024 * 1024,
 	}
 }
 


### PR DESCRIPTION
 * #6920 -- daemon: Log workloads runtime options after final setup (@brb)
 * #6918 -- Update k8s test and dependency versions to v1.13.3 (@aanm)
 * #6917 -- cilium, docker: allow for v4 only config (@borkmann)
 * #6913 -- Fix operator crash on invalid CNP (@eloycoto)
 * #6898 -- endpoint: Embed a *controller.Manager (@tgraf)
 * #6885 -- Docs/GSG: Fix some paths on etcd keys (@eloycoto)
 * #6874 -- Improve CIDR allocation change resolution (@tgraf)
 * #6853 -- doc: Update ClusterMesh documentation for 1.4 (@tgraf)

Once this PR is merged, you can update the PR labels via:
```
$ for pr in 6920 6918 6917 6913 6898 6885 6874 6853; do contrib/backporting/set-labels.py $pr done 1.4; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6922)
<!-- Reviewable:end -->
