### PR TITLE
Docs: Trivial fixes on k8s-install-etcd-operator.rst

### DIFF
--- a/Documentation/gettingstarted/k8s-install-etcd-operator.rst
+++ b/Documentation/gettingstarted/k8s-install-etcd-operator.rst
@@ -13,7 +13,7 @@ Standard Installation
 This guides takes you through the steps required to set up Cilium on Kubernetes
 using the cilium-etcd-operator. The cilium-etcd-operator replaces the
 requirement for an external kvstore. You can learn more about it in the section
-:ref:`k8s_what_is_the_cilium_etcd_operator`. It is suitable for small and
+:ref:`k8s_what_is_the_cilium_etcd_operator` It is suitable for small and
 medium scale deployments where etcd performance is not absolutely essential.
 Please refer to the  :ref:`k8s_etcd_operator_limitations` section below to
 learn about the exact limitations of this deployment method.
@@ -60,8 +60,8 @@ should be healthy and ready:
 What is the cilium-etcd-operator?
 =================================
 
-The cilium-etcd-operator uses and extend the etcd-operator to guarantee quorum,
-auto-create certificates and manage compaction:
+The cilium-etcd-operator uses and extends the etcd-operator to guarantee quorum,
+auto-create certificates, and manage compaction:
 
  * Automatic re-creation of the etcd cluster when the cluster loses quorum. The
    standard etcd-operator will refuse to bring up new etcd nodes and the etcd
@@ -89,7 +89,7 @@ disadvantages which can become of relevance as you scale up your clusters:
   re-created by the cilium-etcd-operator. Cilium will automatically recover and
   re-create all state in etcd. This operation can take can couple of seconds
   and may cause minor disruptions as ongoing distributed locks are invalidated
-  and security identities have have to be re-allocated.
+  and security identities have to be re-allocated.
 
 * etcd is very sensitive to disk IO latency and requires fast disk access at a
   certain scale. The cilium-etcd-operator will not take any measures to provide


### PR DESCRIPTION
Simple language fixes only.

Tested `k8s-install-etcd-operator.rst` on minikube, which eventually worked with the standard 4GB of memory recommended in the minikube GSG. Cilium restarted twice, though:

```
$ kubectl -n kube-system get pods
NAME                                   READY     STATUS    RESTARTS   AGE
cilium-etcd-65xx978rkc                 1/1       Running   0          11m
cilium-etcd-bcdjnxt46k                 1/1       Running   0          15m
cilium-etcd-operator-d6cb86868-667d2   1/1       Running   0          21m
cilium-etcd-vq97pt5c42                 1/1       Running   0          11m
cilium-operator-cb4578bc5-66nsl        1/1       Running   1          21m
cilium-wm492                           1/1       Running   2          21m
coredns-86c58d9df4-mlb96               1/1       Running   0          30m
coredns-86c58d9df4-s6xlv               1/1       Running   0          30m
etcd-minikube                          1/1       Running   0          29m
etcd-operator-5cf67779fd-d76wm         1/1       Running   0          16m
kube-addon-manager-minikube            1/1       Running   0          30m
kube-apiserver-minikube                1/1       Running   0          29m
kube-controller-manager-minikube       1/1       Running   0          29m
kube-proxy-6wwcb                       1/1       Running   0          30m
kube-scheduler-minikube                1/1       Running   0          29m
storage-provisioner                    1/1       Running   0          30m
```

Fixes: #6875
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6925)
<!-- Reviewable:end -->
