### PR TITLE
clustermesh: Fix panic in clustermesh initialization

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1250,6 +1250,7 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 				ConfigDirectory: path,
 				NodeKeyCreator:  nodeStore.KeyCreator,
 				ServiceMerger:   &d.k8sSvcCache,
+				NodeManager:     nodeMngr,
 			})
 			if err != nil {
 				log.WithError(err).Fatal("Unable to initialize ClusterMesh")

--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/lock"
+	nodemanager "github.com/cilium/cilium/pkg/node/manager"
 	nodeStore "github.com/cilium/cilium/pkg/node/store"
 	"github.com/cilium/cilium/pkg/option"
 )
@@ -49,6 +50,10 @@ type Configuration struct {
 	// endpoints into an existing cache
 	ServiceMerger ServiceMerger
 
+	// NodeManager is the node manager to manage all discovered remote
+	// nodes
+	NodeManager *nodemanager.Manager
+
 	nodeObserver store.Observer
 }
 
@@ -58,7 +63,7 @@ func (c *Configuration) NodeObserver() store.Observer {
 		return c.nodeObserver
 	}
 
-	return &nodeStore.NodeObserver{}
+	return nodeStore.NewNodeObserver(c.NodeManager)
 }
 
 // ClusterMesh is a cache of multiple remote clusters

--- a/pkg/node/store/store.go
+++ b/pkg/node/store/store.go
@@ -43,6 +43,12 @@ type NodeObserver struct {
 	manager NodeManager
 }
 
+// NewNodeObserver returns a new NodeObserver associated with the specified
+// node manager
+func NewNodeObserver(manager NodeManager) *NodeObserver {
+	return &NodeObserver{manager: manager}
+}
+
 func (o *NodeObserver) OnUpdate(k store.Key) {
 	if n, ok := k.(*node.Node); ok {
 		nodeCopy := n.DeepCopy()
@@ -82,7 +88,7 @@ func (nr *NodeRegistrar) RegisterNode(n *node.Node, manager NodeManager) error {
 		Prefix:                  NodeStorePrefix,
 		KeyCreator:              KeyCreator,
 		SynchronizationInterval: time.Minute,
-		Observer:                &NodeObserver{manager: manager},
+		Observer:                NewNodeObserver(manager),
 	})
 
 	if err != nil {


### PR DESCRIPTION
The NodeManager must be passed into the ClusterMesh so it can be passed on to
the NodeObserver.

Fixes: #6927

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6928)
<!-- Reviewable:end -->
