### PR TITLE
operator: set right environment variable for 'cluster-name' in operator

### DIFF
--- a/operator/main.go
+++ b/operator/main.go
@@ -88,7 +88,7 @@ func init() {
 	flags.Int(option.ClusterIDName, 0, "Unique identifier of the cluster")
 	option.BindEnv(option.ClusterIDName)
 	flags.String(option.ClusterName, defaults.ClusterName, "Name of the cluster")
-	option.BindEnv(option.ClusterNameEnv)
+	option.BindEnv(option.ClusterName)
 	flags.BoolP("debug", "D", false, "Enable debugging mode")
 	flags.StringVar(&k8sAPIServer, "k8s-api-server", "", "Kubernetes api address server (for https use --k8s-kubeconfig-path instead)")
 	flags.StringVar(&k8sKubeConfigPath, "k8s-kubeconfig-path", "", "Absolute path of the kubernetes kubeconfig file")

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -296,10 +296,6 @@ const (
 	// ClusterName is the name of the ClusterName option
 	ClusterName = "cluster-name"
 
-	// ClusterNameEnv is the name of the environment variable of the
-	// ClusterName option
-	ClusterNameEnv = "CILIUM_CLUSTER_NAME"
-
 	// ClusterIDName is the name of the ClusterID option
 	ClusterIDName = "cluster-id"
 


### PR DESCRIPTION
Fixes: 7e636567e698 ("use constants for cilium-agent flags")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6935)
<!-- Reviewable:end -->
