### PR TITLE
endpoint: Clean up state transition logging.

### DIFF
--- a/daemon/state.go
+++ b/daemon/state.go
@@ -301,6 +301,12 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) {
 			}
 			ep.SetIdentity(identity)
 
+			if ep.GetStateLocked() == endpoint.StateWaitingToRegenerate {
+				ep.Unlock()
+				// EP is already waiting to regenerate. This is no error so no logging.
+				epRegenerated <- false
+				return
+			}
 			ready := ep.SetStateLocked(endpoint.StateWaitingToRegenerate, "Triggering synchronous endpoint regeneration while syncing state to host")
 			ep.Unlock()
 

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -299,6 +299,9 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) {
 					time.Sleep(defaults.IdentityChangeGracePeriod)
 				}
 			}
+			// The identity of a freshly restored endpoint is incomplete due to some
+			// parts of the identity not being marshaled to JSON. Hence we must set
+			// the identity even if has not changed.
 			ep.SetIdentity(identity)
 
 			if ep.GetStateLocked() == endpoint.StateWaitingToRegenerate {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1747,6 +1747,12 @@ func (e *Endpoint) BuilderSetStateLocked(toState, reason string) bool {
 		// state.
 		case StateRegenerating:
 			goto OKState
+		// Transition to ReadyState is not supported, but is
+		// attempted when a regeneration is competed, and another
+		// regeneration has been queued in the meanwhile. So this
+		// is expected and will not be logged as an error or warning.
+		case StateReady:
+			return false
 		}
 	case StateRegenerating:
 		switch toState {
@@ -1758,7 +1764,8 @@ func (e *Endpoint) BuilderSetStateLocked(toState, reason string) bool {
 		// queued. In this case the endpoint has been
 		// transitioned to waiting-to-regenerate state
 		// already, and the transition to ready state is
-		// skipped.
+		// skipped (but not worth logging for, as this is
+		// normal, see above).
 		case StateReady:
 			goto OKState
 		}

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -543,12 +543,13 @@ func (e *Endpoint) SetIdentity(identity *identityPkg.Identity) {
 	e.runIPIdentitySync(e.IPv4)
 	e.runIPIdentitySync(e.IPv6)
 
-	e.getLogger().WithFields(logrus.Fields{
-		logfields.Identity:       identity.StringID(),
-		logfields.OldIdentity:    oldIdentity,
-		logfields.IdentityLabels: identity.Labels.String(),
-	}).Info("Identity of endpoint changed")
-
+	if oldIdentity != identity.StringID() {
+		e.getLogger().WithFields(logrus.Fields{
+			logfields.Identity:       identity.StringID(),
+			logfields.OldIdentity:    oldIdentity,
+			logfields.IdentityLabels: identity.Labels.String(),
+		}).Info("Identity of endpoint changed")
+	}
 	e.UpdateLogger(map[string]interface{}{
 		logfields.Identity: identity.StringID(),
 	})


### PR DESCRIPTION
Skipping transition to Ready when another regeneration is queued is
normal, but currently logged as a warning. Dont.

State transition to waiting-to-regenerate fails if the endpoint is
already in that state. Notice this and avoid any error or warning
logging also in this case.

Fixes: #6793
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6937)
<!-- Reviewable:end -->
