### PR TITLE
gke: Clear cbr0 bridge in node-init DaemonSet

### DIFF
--- a/examples/kubernetes/node-init/node-init.yaml
+++ b/examples/kubernetes/node-init/node-init.yaml
@@ -70,5 +70,16 @@ spec:
                   "type": "cilium-cni"
               }
               EOF
+
+              if ip link show cbr0; then
+                      echo "Detected cbr0 bridge. Deleting interface..."
+                      ip link del cbr0
+              fi
+
+              echo "Link information:"
+              ip link
+
+              echo "Routing table:"
+              ip route
               
               echo "Node initialization complete"


### PR DESCRIPTION
A default GKE cluster comes with a cbr0 bridge set up with a PodCIDR route
pointing to it. The PodCIDR route conflicts with the route that Cilium wants to
install. Cilium sees the route and considers the entire PodCIDR address space
as reserved and will fail to allocate any IP addresses. The routing layer
replaces the route later on but at the time, the IPAM layer has already
reserved the IP range so a pod restart is required before Cilium comes up
correctly.

This commit removes the cbr0 interface in the node-init DaemonSet to prepare
GKE cluster nodes before deployment of Cilium. It also extends the startup
script to print the link and routing information for later reference.

Fixes: #6807

Tested manually as we have no GKE integration into the CI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6942)
<!-- Reviewable:end -->
