### PR TITLE
policy: only regenerate endpoints which changes in policy select

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -46,6 +46,7 @@ cilium-agent [flags]
       --enable-ipv6                                 Enable IPv6 support (default true)
       --enable-policy string                        Enable policy enforcement (default "default")
       --enable-tracing                              Enable tracing while determining policy (debugging)
+      --endpoint-queue-size int                     size of EventQueue per-endpoint (default 25)
       --envoy-log string                            Path to a separate Envoy log file, if any
       --fixed-identity-mapping map                  Key-value for the fixed identity mapping which allows to use reserved label for fixed identities (default map[])
       --flannel-manage-existing-containers          Installs a BPF program to allow for policy enforcement in already running containers managed by Flannel. Require Cilium to be running in the hostPID.

--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -268,7 +268,7 @@ func LaunchAsEndpoint(owner endpoint.Owner, n *node.Node, mtuConfig mtu.Configur
 		return nil, err
 	}
 	if !ep.SetStateLocked(endpoint.StateWaitingToRegenerate, "initial build of health endpoint") {
-		endpointmanager.Remove(ep)
+		endpointmanager.Remove(ep, owner)
 		ep.Unlock()
 		return nil, fmt.Errorf("unable to transition health endpoint to WaitingToRegenerate state")
 	}
@@ -279,7 +279,7 @@ func LaunchAsEndpoint(owner endpoint.Owner, n *node.Node, mtuConfig mtu.Configur
 		Reason: "health daemon bootstrap",
 	})
 	if !buildSuccessful {
-		endpointmanager.Remove(ep)
+		endpointmanager.Remove(ep, owner)
 		return nil, fmt.Errorf("unable to build health endpoint")
 	}
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1593,3 +1593,7 @@ func (d *Daemon) GetNodeSuffix() string {
 
 	return ip.String()
 }
+
+func (d *Daemon) ClearPolicyConsumers(id uint16) *sync.WaitGroup {
+	return &sync.WaitGroup{}
+}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1594,6 +1594,8 @@ func (d *Daemon) GetNodeSuffix() string {
 	return ip.String()
 }
 
+// ClearPolicyConsumers removes references to the specified id from the rules in
+// the daemon's policy repository.
 func (d *Daemon) ClearPolicyConsumers(id uint16) *sync.WaitGroup {
-	return &sync.WaitGroup{}
+	return d.policy.RemoveEndpointIDFromRuleCaches(id)
 }

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -702,6 +702,10 @@ func init() {
 
 	flags.Int(option.PolicyQueueSize, defaults.PolicyQueueSize, "size of queues for policy-related events")
 	option.BindEnv(option.PolicyQueueSize)
+
+	flags.Int(option.EndpointQueueSize, defaults.EndpointQueueSize, "size of EventQueue per-endpoint")
+	option.BindEnv(option.EndpointQueueSize)
+
 	viper.BindPFlags(flags)
 }
 

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"testing"
 	"time"
 
@@ -71,6 +72,7 @@ type DaemonSuite struct {
 	OnGetCompilationLock      func() *lock.RWMutex
 	OnSendNotification        func(typ monitorAPI.AgentNotification, text string) error
 	OnNewProxyLogRecord       func(l *accesslog.LogRecord) error
+	OnClearPolicyConsumers    func(id uint16) *sync.WaitGroup
 }
 
 func (ds *DaemonSuite) SetUpTest(c *C) {
@@ -125,6 +127,7 @@ func (ds *DaemonSuite) SetUpTest(c *C) {
 	ds.OnGetCompilationLock = nil
 	ds.OnSendNotification = nil
 	ds.OnNewProxyLogRecord = nil
+	ds.OnClearPolicyConsumers = nil
 }
 
 func (ds *DaemonSuite) TearDownTest(c *C) {
@@ -279,4 +282,11 @@ func (ds *DaemonSuite) NewProxyLogRecord(l *accesslog.LogRecord) error {
 
 func (ds *DaemonSuite) Datapath() datapath.Datapath {
 	return ds.d.datapath
+}
+
+func (ds *DaemonSuite) ClearPolicyConsumers(id uint16) *sync.WaitGroup {
+	if ds.OnClearPolicyConsumers != nil {
+		return ds.OnClearPolicyConsumers(id)
+	}
+	panic("ClearPolicyConsumers should not have been called")
 }

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -585,6 +585,10 @@ func (d *Daemon) deleteEndpointQuiet(ep *endpoint.Endpoint, releaseIP bool) []er
 	}
 	ep.SetStateLocked(endpoint.StateDisconnecting, "Deleting endpoint")
 
+	// Since the endpoint is being deleted, we no longer need to run events
+	// in its event queue.
+	ep.EventQueue.Stop()
+
 	// Remove the endpoint before we clean up. This ensures it is no longer
 	// listed or queued for rebuilds.
 	endpointmanager.Remove(ep)

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -591,7 +591,7 @@ func (d *Daemon) deleteEndpointQuiet(ep *endpoint.Endpoint, releaseIP bool) []er
 
 	// Remove the endpoint before we clean up. This ensures it is no longer
 	// listed or queued for rebuilds.
-	endpointmanager.Remove(ep)
+	endpointmanager.Remove(ep, d)
 
 	// If dry mode is enabled, no changes to BPF maps are performed
 	if !option.Config.DryMode {

--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -296,7 +296,7 @@ func (d *Daemon) policyAdd(rules policyAPI.Rules, opts *AddOptions, resChan chan
 				removedPrefixes = append(removedPrefixes, policy.GetCIDRPrefixes(oldRules)...)
 				if len(oldRules) > 0 {
 					d.dnsRuleGen.StopManageDNSName(oldRules)
-					_, _ = d.policy.DeleteByLabelsLocked(r.Labels)
+					_, _, _ = d.policy.DeleteByLabelsLocked(r.Labels)
 				}
 			}
 		}
@@ -305,11 +305,11 @@ func (d *Daemon) policyAdd(rules policyAPI.Rules, opts *AddOptions, resChan chan
 			removedPrefixes = append(removedPrefixes, policy.GetCIDRPrefixes(oldRules)...)
 			if len(oldRules) > 0 {
 				d.dnsRuleGen.StopManageDNSName(oldRules)
-				_, _ = d.policy.DeleteByLabelsLocked(opts.ReplaceWithLabels)
+				_, _, _ = d.policy.DeleteByLabelsLocked(opts.ReplaceWithLabels)
 			}
 		}
 	}
-	newRev := d.policy.AddListLocked(rules)
+	_, newRev := d.policy.AddListLocked(rules)
 
 	// The information needed by the caller is available at this point, signal
 	// accordingly.
@@ -434,7 +434,7 @@ func (d *Daemon) policyDelete(labels labels.LabelArray, res chan interface{}) {
 		return
 	}
 
-	rev, deleted := d.policy.DeleteByLabelsLocked(labels)
+	_, rev, deleted := d.policy.DeleteByLabelsLocked(labels)
 
 	res <- &PolicyDeleteResult{
 		newRev: rev,

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -334,12 +334,17 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) (resto
 			// the identity even if has not changed.
 			ep.SetIdentity(identity)
 
+			// We don't need to hold the policy repository mutex here because
+			// the content of the rules themselves are not being changed.
+			d.policy.UpdateLocalConsumers([]policy.Endpoint{ep}).Wait()
+
 			if ep.GetStateLocked() == endpoint.StateWaitingToRegenerate {
 				ep.Unlock()
 				// EP is already waiting to regenerate. This is no error so no logging.
 				epRegenerated <- false
 				return
 			}
+
 			ready := ep.SetStateLocked(endpoint.StateWaitingToRegenerate, "Triggering synchronous endpoint regeneration while syncing state to host")
 			ep.Unlock()
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -170,4 +170,7 @@ const (
 
 	// KVstoreQPS is default rate limit for kv store operations
 	KVstoreQPS = 20
+
+	// EndpointQueueSize is the default queue size for an endpoint.
+	EndpointQueueSize = 25
 )

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -414,7 +414,7 @@ func NewEndpointWithState(ID uint16, state string) *Endpoint {
 		state:         state,
 		hasBPFProgram: make(chan struct{}, 0),
 		controllers:   controller.NewManager(),
-		EventQueue:    eventqueue.NewEventQueueBuffered(25),
+		EventQueue:    eventqueue.NewEventQueueBuffered(option.Config.EndpointQueueSize),
 	}
 	ep.SetDefaultOpts(option.Config.Opts)
 	ep.UpdateLogger(nil)
@@ -448,7 +448,7 @@ func NewEndpointFromChangeModel(base *models.EndpointChangeRequest) (*Endpoint, 
 		desiredPolicy:    &policy.EndpointPolicy{},
 		realizedPolicy:   &policy.EndpointPolicy{},
 		controllers:      controller.NewManager(),
-		EventQueue:       eventqueue.NewEventQueueBuffered(25),
+		EventQueue:       eventqueue.NewEventQueueBuffered(option.Config.EndpointQueueSize),
 	}
 	ep.UpdateLogger(nil)
 
@@ -1055,7 +1055,7 @@ func ParseEndpoint(strEp string) (*Endpoint, error) {
 	ep.desiredPolicy = &policy.EndpointPolicy{}
 	ep.realizedPolicy = &policy.EndpointPolicy{}
 	ep.controllers = controller.NewManager()
-	ep.EventQueue = eventqueue.NewEventQueueBuffered(25)
+	ep.EventQueue = eventqueue.NewEventQueueBuffered(option.Config.EndpointQueueSize)
 
 	// We need to check for nil in Status, CurrentStatuses and Log, since in
 	// some use cases, status will be not nil and Cilium will eventually

--- a/pkg/endpoint/events.go
+++ b/pkg/endpoint/events.go
@@ -15,8 +15,6 @@
 package endpoint
 
 import (
-	"sync"
-
 	"github.com/cilium/cilium/pkg/eventqueue"
 )
 
@@ -96,9 +94,8 @@ func (ev *EndpointRevisionBumpEvent) Handle(res chan interface{}) {
 // realized policy revision to rev. This may block depending on if events have
 // been queued up for the given endpoint. It blocks until the event has
 // succeeded, or if the event has been cancelled.
-func (e *Endpoint) PolicyRevisionBumpEvent(rev uint64, wg *sync.WaitGroup) {
+func (e *Endpoint) PolicyRevisionBumpEvent(rev uint64) {
 	epBumpEvent := eventqueue.NewEvent(&EndpointRevisionBumpEvent{Rev: rev, ep: e})
 	// Don't care about policy revision event results - it is best effort.
 	_ = e.EventQueue.Enqueue(epBumpEvent)
-	wg.Done()
 }

--- a/pkg/endpoint/events.go
+++ b/pkg/endpoint/events.go
@@ -1,0 +1,104 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endpoint
+
+import (
+	"sync"
+
+	"github.com/cilium/cilium/pkg/eventqueue"
+)
+
+// EndpointRegenerationEvent contains all fields necessary to regenerate an endpoint.
+type EndpointRegenerationEvent struct {
+	owner        Owner
+	regenContext *regenerationContext
+	ep           *Endpoint
+}
+
+// Handle handles the regeneration event for the endpoint.
+func (ev *EndpointRegenerationEvent) Handle(res chan interface{}) {
+	e := ev.ep
+	owner := ev.owner
+	regenContext := ev.regenContext
+
+	err := e.RLockAlive()
+	if err != nil {
+		e.LogDisconnectedMutexAction(err, "before regeneration")
+		res <- &EndpointRegenerationResult{
+			err: err,
+		}
+
+		return
+	}
+	e.RUnlock()
+
+	// We should only queue the request after we use all the endpoint's
+	// lock/unlock. Otherwise this can get a deadlock if the endpoint is
+	// being deleted at the same time. More info PR-1777.
+	doneFunc := owner.QueueEndpointBuild(uint64(e.ID))
+	if doneFunc != nil {
+		e.getLogger().Debug("Dequeued endpoint from build queue")
+
+		regenContext.DoneFunc = doneFunc
+
+		err = ev.ep.regenerate(ev.owner, ev.regenContext)
+
+		doneFunc()
+		e.notifyEndpointRegeneration(owner, err)
+	} else {
+		e.getLogger().Debug("My request was cancelled because I'm already in line")
+	}
+
+	res <- &EndpointRegenerationResult{
+		err: err,
+	}
+	return
+}
+
+// EndpointRegenerationResult contains the results of an endpoint regeneration.
+type EndpointRegenerationResult struct {
+	err error
+}
+
+// EndpointRevisionBumpEvent contains all fields necessary to bump the policy
+// revision of a given endpoint.
+type EndpointRevisionBumpEvent struct {
+	Rev uint64
+	ep  *Endpoint
+}
+
+// Handle handles the revision bump event for the Endpoint.
+func (ev *EndpointRevisionBumpEvent) Handle(res chan interface{}) {
+	// TODO: if the endpoint is not in a 'ready' state that means that
+	// we cannot set the policy revision, as something else has
+	// changed endpoint state which necessitates regeneration,
+	// *or* the endpoint is in a not-ready state (i.e., a prior
+	// regeneration failed, so there is no way that we can
+	// realize the policy revision yet. Should this be signaled
+	// to the routine waiting for the result of this event?
+	ev.ep.SetPolicyRevision(ev.Rev)
+	res <- struct{}{}
+}
+
+// PolicyRevisionBumpEvent queues an event for the given endpoint to set its
+// realized policy revision to rev. This may block depending on if events have
+// been queued up for the given endpoint. It blocks until the event has
+// succeeded, or if the event has been cancelled.
+func (e *Endpoint) PolicyRevisionBumpEvent(rev uint64, wg *sync.WaitGroup) {
+	epBumpEvent := eventqueue.NewEvent(&EndpointRevisionBumpEvent{Rev: rev, ep: e})
+	// Don't care about policy revision event results - it is best effort.
+	_ = e.EventQueue.Enqueue(epBumpEvent)
+	wg.Done()
+}

--- a/pkg/endpoint/owner.go
+++ b/pkg/endpoint/owner.go
@@ -15,6 +15,8 @@
 package endpoint
 
 import (
+	"sync"
+
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/identity/cache"
@@ -60,4 +62,8 @@ type Owner interface {
 
 	// Datapath returns a reference to the datapath implementation.
 	Datapath() datapath.Datapath
+
+	// ClearPolicyConsumers removes references to the specified id from the
+	// policy rules managed by Owner.
+	ClearPolicyConsumers(id uint16) *sync.WaitGroup
 }

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -446,8 +446,6 @@ func (e *Endpoint) Regenerate(owner Owner, regenMetadata *ExternalRegenerationMe
 			if ok {
 				regenResult := result.(*EndpointRegenerationResult)
 				regenError = regenResult.err
-
-				// Build was successful whether regeneration errored out of not.
 				buildSuccess = regenError == nil
 			} else {
 				// This may be unnecessary(?) since 'closing' of the results

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -158,7 +158,7 @@ func (e *Endpoint) regeneratePolicy(owner Owner) (retErr error) {
 	e.prevIdentityCache = labelsMap
 
 	stats.policyCalculation.Start()
-	calculatedPolicy, err := repo.ResolvePolicy(e.ID, e.SecurityIdentity.LabelArray, e, *labelsMap)
+	calculatedPolicy, err := repo.ResolvePolicy(e.ID, e.SecurityIdentity, e, *labelsMap)
 	if err != nil {
 		return err
 	}

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -431,7 +431,9 @@ func (e *Endpoint) Regenerate(owner Owner, regenMetadata *ExternalRegenerationMe
 		ep:           e,
 	})
 
-	// This may block if the Endpoint's EventQueue is full.
+	// This may block if the Endpoint's EventQueue is full. This has to be done
+	// synchronously as some callers depend on the fact that the event is
+	// synchronously enqueued.
 	resChan := e.EventQueue.Enqueue(epEvent)
 
 	go func() {

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -397,7 +397,7 @@ func parseAndAddRules(c *C, p *networkingv1.NetworkPolicy) *policy.Repository {
 	rules, err := ParseNetworkPolicy(p)
 	c.Assert(err, IsNil)
 	rev := repo.GetRevision()
-	id := repo.AddList(rules)
+	_, id := repo.AddList(rules)
 	c.Assert(id, Equals, rev+1)
 
 	return repo

--- a/pkg/k8s/rule_translate_test.go
+++ b/pkg/k8s/rule_translate_test.go
@@ -67,7 +67,7 @@ func (s *K8sSuite) TestTranslatorDirect(c *C) {
 
 	translator := NewK8sTranslator(serviceInfo, endpointInfo, false, map[string]string{}, nil)
 
-	_, err := repo.Add(rule1)
+	_, _, err := repo.Add(rule1, []policy.Endpoint{})
 	c.Assert(err, IsNil)
 
 	result, err := repo.TranslateRules(translator)
@@ -166,7 +166,7 @@ func (s *K8sSuite) TestTranslatorLabels(c *C) {
 
 	translator := NewK8sTranslator(serviceInfo, endpointInfo, false, svcLabels, nil)
 
-	_, err := repo.Add(rule1)
+	_, _, err := repo.Add(rule1, []policy.Endpoint{})
 	c.Assert(err, IsNil)
 
 	result, err := repo.TranslateRules(translator)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -419,6 +419,9 @@ const (
 	// PolicyQueueSize is the size of the queues utilized by the policy
 	// repository.
 	PolicyQueueSize = "policy-queue-size"
+
+	// EndpointQueueSize is the size of the EventQueue per-endpoint.
+	EndpointQueueSize = "endpoint-queue-size"
 )
 
 // FQDNS variables
@@ -826,6 +829,12 @@ type DaemonConfig struct {
 	// PolicyQueueSize is the size of the queues for the policy repository.
 	// A larger queue means that more events related to policy can be buffered.
 	PolicyQueueSize int
+
+	// EndpointQueueSize is the size of the EventQueue per-endpoint. A larger
+	// queue means that more events can be buffered per-endpoint. This is useful
+	// in the case where a cluster might be under high load for endpoint-related
+	// events, specifically those which cause many regenerations.
+	EndpointQueueSize int
 }
 
 var (
@@ -1178,6 +1187,7 @@ func (c *DaemonConfig) Populate() {
 	c.SidecarHTTPProxy = viper.GetBool(SidecarHTTPProxy)
 	c.CMDRefDir = viper.GetString(CMDRef)
 	c.PolicyQueueSize = sanitizeIntParam(PolicyQueueSize, defaults.PolicyQueueSize)
+	c.EndpointQueueSize = sanitizeIntParam(EndpointQueueSize, defaults.EndpointQueueSize)
 }
 
 func sanitizeIntParam(paramName string, paramDefault int) int {

--- a/pkg/policy/identifier.go
+++ b/pkg/policy/identifier.go
@@ -15,8 +15,6 @@
 package policy
 
 import (
-	"sync"
-
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/lock"
 )
@@ -42,5 +40,5 @@ func NewIDSet() *IDSet {
 type Endpoint interface {
 	GetID16() uint16
 	GetSecurityIdentity() *identity.Identity
-	PolicyRevisionBumpEvent(rev uint64, wg *sync.WaitGroup)
+	PolicyRevisionBumpEvent(rev uint64)
 }

--- a/pkg/policy/identifier.go
+++ b/pkg/policy/identifier.go
@@ -1,0 +1,46 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	"sync"
+
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/lock"
+)
+
+// IDSet is a wrapper type around a set of unsigned 16-bit integers, with
+// a mutex for protecting access.
+type IDSet struct {
+	Mutex lock.RWMutex
+	IDs   map[uint16]struct{}
+}
+
+// NewIDSet returns a new instance of an IDSet.
+func NewIDSet() *IDSet {
+	return &IDSet{
+		IDs: map[uint16]struct{}{},
+	}
+}
+
+// Endpoint refers to any structure which has the following properties:
+// * a node-local ID stored as a uint16
+// * a security identity
+// * a means of incrementing its policy revision
+type Endpoint interface {
+	GetID16() uint16
+	GetSecurityIdentity() *identity.Identity
+	PolicyRevisionBumpEvent(rev uint64, wg *sync.WaitGroup)
+}

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -16,9 +16,11 @@ package policy
 
 import (
 	"encoding/json"
+	"sync"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/eventqueue"
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
@@ -368,23 +370,25 @@ nextLabel:
 // This is just a helper function for unit testing.
 // TODO: this should be in a test_helpers.go file or something similar
 // so we can clearly delineate what helpers are for testing.
-func (p *Repository) Add(r api.Rule) (uint64, error) {
+func (p *Repository) Add(r api.Rule, localRuleConsumers []Endpoint) (uint64, map[uint16]struct{}, error) {
 	p.Mutex.Lock()
 	defer p.Mutex.Unlock()
 
 	if err := r.Sanitize(); err != nil {
-		return p.revision, err
+		return p.revision, nil, err
 	}
 
 	newList := make([]*api.Rule, 1)
 	newList[0] = &r
-	return p.AddListLocked(newList), nil
+	_, rev := p.AddListLocked(newList)
+	return rev, map[uint16]struct{}{}, nil
 }
 
 // AddListLocked inserts a rule into the policy repository with the repository already locked
 // Expects that the entire rule list has already been sanitized.
-func (p *Repository) AddListLocked(rules api.Rules) uint64 {
-	newList := make([]*rule, len(rules))
+func (p *Repository) AddListLocked(rules api.Rules) (ruleSlice, uint64) {
+
+	newList := make(ruleSlice, len(rules))
 	for i := range rules {
 		newRule := &rule{
 			Rule:     *rules[i],
@@ -392,31 +396,80 @@ func (p *Repository) AddListLocked(rules api.Rules) uint64 {
 		}
 		newList[i] = newRule
 	}
+
 	p.rules = append(p.rules, newList...)
 	p.revision++
 	metrics.PolicyCount.Add(float64(len(newList)))
 	metrics.PolicyRevision.Inc()
 
-	return p.revision
+	return newList, p.revision
 }
 
-// AddList inserts a rule into the policy repository.
-func (p *Repository) AddList(rules api.Rules) uint64 {
+// UpdateLocalConsumers updates the cache within each rule in the given repository
+// which specifies whether said rule selects said identity. Returns a wait group
+// which can be used to wait until all rules have had said caches updated.
+func (p *Repository) UpdateLocalConsumers(identifiers []Endpoint) *sync.WaitGroup {
+	var policySelectionWG sync.WaitGroup
+	for _, identityConsumer := range identifiers {
+		policySelectionWG.Add(1)
+		go p.rules.updateEndpointsCaches(identityConsumer, NewIDSet(), &policySelectionWG)
+	}
+	return &policySelectionWG
+}
+
+// RemoveEndpointIDFromRuleCaches removes identifier from the processedConsumers
+// and localRuleConsumers sets in each rule within the repository. Returns a
+// sync.WaitGroup which can be waited on once all rules have been processed in
+// relation to the identifier.
+func (p *Repository) RemoveEndpointIDFromRuleCaches(endpointID uint16) *sync.WaitGroup {
+	p.Mutex.RLock()
+	defer p.Mutex.RUnlock()
+	var wg sync.WaitGroup
+	wg.Add(len(p.rules))
+	for _, r := range p.rules {
+		go func(rr *rule, wgg *sync.WaitGroup) {
+			rr.metadata.deleteID(endpointID)
+			wgg.Done()
+		}(r, &wg)
+	}
+	return &wg
+}
+
+// AddList inserts a rule into the policy repository. It is used for
+// unit-testing purposes only.
+func (p *Repository) AddList(rules api.Rules) (ruleSlice, uint64) {
 	p.Mutex.Lock()
 	defer p.Mutex.Unlock()
 	return p.AddListLocked(rules)
 }
 
+// UpdateRulesEndpointsCaches updates the caches within each rule in r that
+// specify whether the rule selects the endpoints in eps. If any rule matches
+// the endpoints, it is added to the provided IDSet. The provided WaitGroup is
+// signaled for a given endpoint which it has been analyzed against all rules
+// in the slice.
+func (r ruleSlice) UpdateRulesEndpointsCaches(eps []Endpoint, epsIDs *IDSet, policySelectionWG *sync.WaitGroup) {
+	policySelectionWG.Add(len(eps))
+	for _, identityConsumer := range eps {
+		// Update each rule in parallel.
+		go r.updateEndpointsCaches(identityConsumer, epsIDs, policySelectionWG)
+	}
+}
+
 // DeleteByLabelsLocked deletes all rules in the policy repository which
-// contain the specified labels
-func (p *Repository) DeleteByLabelsLocked(labels labels.LabelArray) (uint64, int) {
+// contain the specified labels. Returns the revision of the policy repository
+// after deleting the rules, as well as now many rules were deleted.
+func (p *Repository) DeleteByLabelsLocked(labels labels.LabelArray) (ruleSlice, uint64, int) {
+
 	deleted := 0
 	new := p.rules[:0]
+	deletedRules := ruleSlice{}
 
 	for _, r := range p.rules {
 		if !r.Labels.Contains(labels) {
 			new = append(new, r)
 		} else {
+			deletedRules = append(deletedRules, r)
 			deleted++
 		}
 	}
@@ -428,7 +481,7 @@ func (p *Repository) DeleteByLabelsLocked(labels labels.LabelArray) (uint64, int
 		metrics.PolicyRevision.Inc()
 	}
 
-	return p.revision, deleted
+	return deletedRules, p.revision, deleted
 }
 
 // DeleteByLabels deletes all rules in the policy repository which contain the
@@ -436,7 +489,8 @@ func (p *Repository) DeleteByLabelsLocked(labels labels.LabelArray) (uint64, int
 func (p *Repository) DeleteByLabels(labels labels.LabelArray) (uint64, int) {
 	p.Mutex.Lock()
 	defer p.Mutex.Unlock()
-	return p.DeleteByLabelsLocked(labels)
+	_, rev, numDeleted := p.DeleteByLabelsLocked(labels)
+	return rev, numDeleted
 }
 
 // JSONMarshalRules returns a slice of policy rules as string in JSON
@@ -493,17 +547,19 @@ func (p *Repository) GetRulesMatching(labels labels.LabelArray) (ingressMatch bo
 // a slice of all rules which match.
 //
 // Must be called with p.Mutex held
-func (p *Repository) getMatchingRules(labels labels.LabelArray) (ingressMatch bool, egressMatch bool, matchingRules []*rule) {
+func (p *Repository) getMatchingRules(id uint16, securityIdentity *identity.Identity) (ingressMatch bool, egressMatch bool, matchingRules ruleSlice) {
 	matchingRules = []*rule{}
 	ingressMatch = false
 	egressMatch = false
 	for _, r := range p.rules {
-		rulesMatch := r.EndpointSelector.Matches(labels)
-		if rulesMatch {
-			if len(r.Ingress) > 0 {
+		if ruleMatches := r.matches(id, securityIdentity); ruleMatches {
+			// Don't need to update whether ingressMatch is true if it already
+			// has been determined to be true - allows us to not have to check
+			// lenth of slice.
+			if !ingressMatch && len(r.Ingress) > 0 {
 				ingressMatch = true
 			}
-			if len(r.Egress) > 0 {
+			if !egressMatch && len(r.Egress) > 0 {
 				egressMatch = true
 			}
 			matchingRules = append(matchingRules, r)
@@ -581,7 +637,9 @@ func (p *Repository) GetRulesList() *models.Policy {
 // set of rules in the repository, and the provided set of identities.
 // If the policy cannot be generated due to conflicts at L4 or L7, returns an
 // error.
-func (p *Repository) ResolvePolicy(id uint16, labels labels.LabelArray, policyOwner PolicyOwner, identityCache cache.IdentityCache) (*EndpointPolicy, error) {
+func (p *Repository) ResolvePolicy(id uint16, securityIdentity *identity.Identity, policyOwner PolicyOwner, identityCache cache.IdentityCache) (*EndpointPolicy, error) {
+
+	labels := securityIdentity.LabelArray
 
 	calculatedPolicy := &EndpointPolicy{
 		ID:                      id,
@@ -598,7 +656,7 @@ func (p *Repository) ResolvePolicy(id uint16, labels labels.LabelArray, policyOw
 	// to not have to iterate through the entire rule list multiple times and
 	// perform the matching decision again when computing policy for each
 	// protocol layer, which is quite costly in terms of performance.
-	ingressEnabled, egressEnabled, matchingRules := p.computePolicyEnforcementAndRules(labels)
+	ingressEnabled, egressEnabled, matchingRules := p.computePolicyEnforcementAndRules(id, securityIdentity)
 	calculatedPolicy.IngressPolicyEnabled = ingressEnabled
 	calculatedPolicy.EgressPolicyEnabled = egressEnabled
 
@@ -697,16 +755,18 @@ func (p *Repository) ResolvePolicy(id uint16, labels labels.LabelArray, policyOw
 // the set of labels.
 //
 // Must be called with repo mutex held for reading.
-func (p *Repository) computePolicyEnforcementAndRules(lbls labels.LabelArray) (ingress bool, egress bool, matchingRules ruleSlice) {
+func (p *Repository) computePolicyEnforcementAndRules(id uint16, securityIdentity *identity.Identity) (ingress bool, egress bool, matchingRules ruleSlice) {
+
+	lbls := securityIdentity.LabelArray
 	// Check if policy enforcement should be enabled at the daemon level.
 	switch GetPolicyEnabled() {
 	case option.AlwaysEnforce:
-		_, _, matchingRules = p.getMatchingRules(lbls)
+		_, _, matchingRules = p.getMatchingRules(id, securityIdentity)
 		// If policy enforcement is enabled for the daemon, then it has to be
 		// enabled for the endpoint.
 		return true, true, matchingRules
 	case option.DefaultEnforcement:
-		ingress, egress, matchingRules = p.getMatchingRules(lbls)
+		ingress, egress, matchingRules = p.getMatchingRules(id, securityIdentity)
 		// If the endpoint has the reserved:init label, i.e. if it has not yet
 		// received any labels, always enforce policy (default deny).
 		if lbls.Has(labels.IDNameInit) {

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -386,7 +386,11 @@ func (p *Repository) Add(r api.Rule) (uint64, error) {
 func (p *Repository) AddListLocked(rules api.Rules) uint64 {
 	newList := make([]*rule, len(rules))
 	for i := range rules {
-		newList[i] = &rule{Rule: *rules[i]}
+		newRule := &rule{
+			Rule:     *rules[i],
+			metadata: newRuleMetadata(),
+		}
+		newList[i] = newRule
 	}
 	p.rules = append(p.rules, newList...)
 	p.revision++

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -23,8 +23,10 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/checker"
+	"github.com/cilium/cilium/pkg/identity"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
 
@@ -132,11 +134,36 @@ func (ds *PolicyTestSuite) TestComputePolicyEnforcementAndRules(c *C) {
 		},
 	}
 
-	convertedFooIngressRule1 := &rule{Rule: fooIngressRule1}
-	convertedFooIngressRule2 := &rule{Rule: fooIngressRule2}
-	convertedFooEgressRule1 := &rule{Rule: fooEgressRule1}
-	convertedFooEgressRule2 := &rule{Rule: fooEgressRule2}
-	convertedCombinedRule := &rule{Rule: combinedRule}
+	convertedFooIngressRule1 := &rule{Rule: fooIngressRule1,
+		metadata: &ruleMetadata{
+			Mutex:             lock.RWMutex{},
+			EndpointsSelected: map[uint16]*identity.Identity{},
+			AllEndpoints:      map[uint16]struct{}{},
+		}}
+	convertedFooIngressRule2 := &rule{Rule: fooIngressRule2,
+		metadata: &ruleMetadata{
+			Mutex:             lock.RWMutex{},
+			EndpointsSelected: map[uint16]*identity.Identity{},
+			AllEndpoints:      map[uint16]struct{}{},
+		}}
+	convertedFooEgressRule1 := &rule{Rule: fooEgressRule1,
+		metadata: &ruleMetadata{
+			Mutex:             lock.RWMutex{},
+			EndpointsSelected: map[uint16]*identity.Identity{},
+			AllEndpoints:      map[uint16]struct{}{},
+		}}
+	convertedFooEgressRule2 := &rule{Rule: fooEgressRule2,
+		metadata: &ruleMetadata{
+			Mutex:             lock.RWMutex{},
+			EndpointsSelected: map[uint16]*identity.Identity{},
+			AllEndpoints:      map[uint16]struct{}{},
+		}}
+	convertedCombinedRule := &rule{Rule: combinedRule,
+		metadata: &ruleMetadata{
+			Mutex:             lock.RWMutex{},
+			EndpointsSelected: map[uint16]*identity.Identity{},
+			AllEndpoints:      map[uint16]struct{}{},
+		}}
 
 	ing, egr, matchingRules := repo.computePolicyEnforcementAndRules(fooLabelArray)
 	c.Assert(ing, Equals, false, Commentf("ingress policy enforcement should not apply since no rules are in repository"))

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -59,7 +59,7 @@ func (d *dummyEndpoint) GetSecurityIdentity() *identity.Identity {
 	return d.SecurityIdentity
 }
 
-func (d *dummyEndpoint) PolicyRevisionBumpEvent(rev uint64, wg *sync.WaitGroup) {
+func (d *dummyEndpoint) PolicyRevisionBumpEvent(rev uint64) {
 	return
 }
 

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -1592,7 +1592,7 @@ func checkEgress(c *C, repo *Repository, ctx *SearchContext, verdict api.Decisio
 
 func parseAndAddRules(c *C, rules api.Rules) *Repository {
 	repo := NewPolicyRepository()
-	_ = repo.AddList(rules)
+	_, _ = repo.AddList(rules)
 	return repo
 }
 

--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -16,7 +16,6 @@ package policy
 
 import (
 	"strconv"
-	"sync"
 
 	"github.com/cilium/cilium/pkg/policy/api"
 
@@ -257,12 +256,9 @@ egressLoop:
 // updateEndpointsCaches iterates over a given list of rules to update the cache
 // within the rule which determines whether or not the given identity is
 // selected by that rule. If a rule in the list does select said identity, it is
-// added to epIDSet. Signals to the given WaitGroup that all rules have been
-// parsed in relation to said identity. Note that epIDSet can be shared across
-// goroutines!
-func (rules ruleSlice) updateEndpointsCaches(ep Endpoint, epIDSet *IDSet, wg *sync.WaitGroup) {
+// added to epIDSet. Note that epIDSet can be shared across goroutines!
+func (rules ruleSlice) updateEndpointsCaches(ep Endpoint, epIDSet *IDSet) {
 	if ep == nil {
-		wg.Done()
 		return
 	}
 	id := ep.GetID16()
@@ -275,7 +271,4 @@ func (rules ruleSlice) updateEndpointsCaches(ep Endpoint, epIDSet *IDSet, wg *sy
 			epIDSet.Mutex.Unlock()
 		}
 	}
-	// Work done for calculating change for this endpoint in relation to list of
-	// rules.
-	wg.Done()
 }


### PR DESCRIPTION
Previously, when policy updates occurred, all endpoints were regenerated, regardless of whether or not the rules which were updated, added, or deleted actually selected all endpoints. This commit removes this kitchen-sink approach to policy calculation when the repository is modified, and instead regenerates only the endpoints that are selected by the rules that are updated, added, or deleted. To do this, a cache per-rule is added, which contains the set of endpoints that are selected by said rule. This cache is updated upon identity change for an endpoint, deletion of an endpoint, and when the state of the policy repository changes. Within each rule, a set of all endpoint IDs that have been processed (i.e., whether or not that rule selects the endpoint) is present as well, so that it is not incorrectly assumed that a rule does not select an endpoint, when in fact the rule's caches have not been updated yet for said endpoint. The policy calculation algorithm makes use of this cache when all rules which select an endpoint are aggregated. If the endpoint has not been processed for a given rule, it falls back to using the `Matches` operation for its LabelSelector. Once this operation is performed for the endpoint, the cache for the rule is updated accordingly. This ensures that policy will correctly be calculated for a given endpoint without reliance upon the cache within the rules being up-to-date.

When the state of the policy repository changes, a set of endpoints which the rules that were updated, added, or deleted, select, is updated. These endpoints are regenerated. All other endpoints have their policy revision incremented, as they technically do realize the latest revision of the policy repository, but do not have to be regenerated to state they realize it. To ensure correctness, the EventQueue type is utilized for all endpoints to ensure that the policy revision done for these endpoints which are not selected by the rules that were updated, added, or deleted, do not have their revisions bumped while they are currently being regenerated, as that would incorrectly state that said endpoints realize a policy revision which they have not yet implemented.

Another consequence of not always regenerating endpoints upon every change in policy, is that the "reacting" to policy changes (e.g., triggering regenerations for endpoints which a policy selects vs. bumping policy revision for endpoints which policy does not select) needs to be serialized *between* subsequent API calls which change policy. For instance, take the following case:

1.  Policy imported selecting endpoint A
2. Policy imported not selecting endpoint A

The regeneration event for endpoint A (from 1.)  *must* be scheduled and enqueued for endpoint A *before* the revision bump event (from 2.)  is scheduled for the endpoint, otherwise the revision being incremented first would say that endpoint A realizes the policy in the repository, when in fact it does not.

This correctness is ensured by the serialization of policy repository-related changes that is now in master.

Signed-off by: Ian Vernon <ian@cilium.io>

I'd like feedback on the overall design here at this point in time as opposed to issues like missing comments, etc. 

Misc. notes about changes:

* I tried to make sure that the caches within rules were not out of date. This is something that needs to be closely analyzed, as the events causing the cache to go out of date are difficult to test. 
* Endpoint identity change may occur at any time - I've added safeguards against this by mapping identity to id within the cache of rules, so we ensure that we are never incorrectly assuming a rule selects a given endpoint with a given ID if its identity differs.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6943)
<!-- Reviewable:end -->