### PR TITLE
doc: Document requirement to restart kube-dns for GKE

### DIFF
--- a/Documentation/gettingstarted/k8s-install-gke.rst
+++ b/Documentation/gettingstarted/k8s-install-gke.rst
@@ -52,6 +52,16 @@ DaemonSet will:
      kubectl create namespace cilium
      kubectl -n cilium apply -f \ |SCM_WEB|\/examples/kubernetes/node-init/node-init.yaml
 
+Restart kube-dns
+================
+
+kube-dns is already running but is still managed by the original GKE network
+plugin. Restart kube-dns to ensure it is managed by Cilium.
+
+.. code:: bash
+
+     kubectl -n kube-system delete pod -l k8s-app: kube-dns
+
 
 Deploy Cilium + cilium-etcd-operator
 ====================================


### PR DESCRIPTION
Relying on the operator can take a long time as the kube-dns pod has to be in
running state while the operator checks for unmanaged pods during the interval.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6945)
<!-- Reviewable:end -->
