### PR TITLE
Added couple of notes for minikube

### DIFF
--- a/Documentation/gettingstarted/minikube.rst
+++ b/Documentation/gettingstarted/minikube.rst
@@ -33,6 +33,10 @@ Install kubectl & minikube
 
      minikube start --network-plugin=cni --memory=4096
 
+.. note:: The minikube node may have a taint set for ``NoSchedule``. Please run ``kubectl describe node minikube | grep Taints``. If you find a ``NoSchedule`` taint, you can remove using the command ``kubectl taint nodes minikube  node.kubernetes.io/not-ready:NoSchedule-``
+
+.. note:: The ``core-dns`` pods will not be completely initialized since they are waiting for the CNI to be installed. They will be in ``Running`` state after Cilium is installed in the next section.
+
 Install Cilium
 ==============
 


### PR DESCRIPTION
-Taints prevent core-dns pods from getting scheduled
-core-dns pods are in Initializing state and get to
Running state after Cilium is installed

Signed-off-by: Arvind Soni <arvindsoni@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6948)
<!-- Reviewable:end -->
