### PR TITLE
make: Add optional distribution of cilium-docker to cilium image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,11 +19,13 @@ WORKDIR /go/src/github.com/cilium/cilium
 COPY . ./
 ARG LOCKDEBUG
 ARG V
+ARG LIBNETWORK_PLUGIN
 #
 # Please do not add any dependency updates before the 'make install' here,
 # as that will mess with caching for incremental builds!
 #
-RUN make LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 V=$V SKIP_DOCS=true DESTDIR=/tmp/install clean-container build-container install-container
+RUN make LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 V=$V LIBNETWORK_PLUGIN=$LIBNETWORK_PLUGIN \
+    SKIP_DOCS=true DESTDIR=/tmp/install clean-container build-container install-container
 
 #
 # Cilium runtime install.

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@ include Makefile.defs
 include daemon/bpf.sha
 
 SUBDIRS_CILIUM_CONTAINER = proxylib envoy plugins/cilium-cni bpf daemon cilium-health bugtool
+ifdef LIBNETWORK_PLUGIN
+SUBDIRS_CILIUM_CONTAINER += plugins/cilium-docker
+endif
 SUBDIRS = $(SUBDIRS_CILIUM_CONTAINER) operator plugins tools
 GOFILES ?= $(subst _$(ROOT_DIR)/,,$(shell $(GO) list ./... | grep -v -e /vendor/ -e /contrib/))
 TESTPKGS ?= $(subst _$(ROOT_DIR)/,,$(shell $(GO) list ./... | grep -v -e /api/v1 -e /vendor/ -e /contrib/ -e test))
@@ -138,12 +141,20 @@ GIT_VERSION: .git
 docker-image: clean docker-image-no-clean
 
 docker-image-no-clean: GIT_VERSION
-	$(CONTAINER_ENGINE_FULL) build --build-arg LOCKDEBUG=${LOCKDEBUG} --build-arg V=${V} -t "cilium/cilium:$(DOCKER_IMAGE_TAG)" .
+	$(CONTAINER_ENGINE_FULL) build \
+		--build-arg LOCKDEBUG=${LOCKDEBUG} \
+		--build-arg V=${V} \
+		--build-arg LIBNETWORK_PLUGIN=${LIBNETWORK_PLUGIN} \
+		-t "cilium/cilium:$(DOCKER_IMAGE_TAG)" .
 	$(QUIET)echo "Push like this when ready:"
 	$(QUIET)echo "${CONTAINER_ENGINE_FULL} push cilium/cilium:$(DOCKER_IMAGE_TAG)"
 
 dev-docker-image: GIT_VERSION
-	$(CONTAINER_ENGINE_FULL) build --build-arg LOCKDEBUG=${LOCKDEBUG} --build-arg V=${V} -t "cilium/cilium-dev:$(DOCKER_IMAGE_TAG)" .
+	$(CONTAINER_ENGINE_FULL) build \
+		--build-arg LOCKDEBUG=${LOCKDEBUG} \
+		--build-arg V=${V} \
+		--build-arg LIBNETWORK_PLUGIN=${LIBNETWORK_PLUGIN} \
+		-t "cilium/cilium-dev:$(DOCKER_IMAGE_TAG)" .
 	$(QUIET)echo "Push like this when ready:"
 	$(QUIET)echo "${CONTAINER_ENGINE_FULL} push cilium/cilium-dev:$(DOCKER_IMAGE_TAG)"
 


### PR DESCRIPTION
This commit introduces `LIBNETWORK_PLUGIN` make param which, when set, includes `cilium-docker` (aka libnetwork plugin) to the cilium container image.

Usage example:

```
$ LIBNETWORK_PLUGIN=1 make docker-image-no-clean
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6952)
<!-- Reviewable:end -->
