### PR TITLE
Makefile enhancements

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -32,7 +32,7 @@ ifeq ($(DOCKER_IMAGE_TAG),)
     DOCKER_IMAGE_TAG="latest"
 endif
 
-GOBUILD = -ldflags '$(GOLDFLAGS)'
+GOBUILD = -ldflags '$(GOLDFLAGS)' $(EXTRA_GOBUILD_FLAGS)
 
 # Uncomment to enable race detection
 #GOBUILD += -race

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -4,6 +4,8 @@ include $(ROOT_DIR)/Makefile.quiet
 
 PREFIX?=/usr
 BINDIR?=$(PREFIX)/bin
+CNIBINDIR?=/opt/cni/bin
+CNICONFDIR?=/etc/cni/net.d
 LIBDIR?=$(PREFIX)/lib
 RUNDIR?=/var/run
 CONFDIR?=/etc

--- a/plugins/cilium-cni/Makefile
+++ b/plugins/cilium-cni/Makefile
@@ -17,7 +17,7 @@ $(TARGET): $(SOURCES)
 	$(QUIET)CGO_ENABLED=0 $(GO) build $(GOBUILD) -o $(TARGET) ./cilium-cni.go
 
 install:
-	$(INSTALL) -m 0755 -d $(DESTDIR)/etc/cni/net.d
-	$(INSTALL) -m 0644 05-cilium-cni.conf $(DESTDIR)/etc/cni/net.d
-	$(INSTALL) -m 0755 -d $(DESTDIR)/opt/cni/bin
-	$(INSTALL) -m 0755 $(TARGET) $(DESTDIR)/opt/cni/bin
+	$(INSTALL) -m 0755 -d $(DESTDIR)$(CNICONFDIR)
+	$(INSTALL) -m 0644 05-cilium-cni.conf $(DESTDIR)$(CNICONFDIR)
+	$(INSTALL) -m 0755 -d $(DESTDIR)$(CNIBINDIR)
+	$(INSTALL) -m 0755 $(TARGET) $(DESTDIR)$(CNIBINDIR)


### PR DESCRIPTION
Two enhancements for the buildsystem:

- allow to add extra `go build` flags (with the `EXTRA_GOBUILD_FLAGS` variable); example:
```
make EXTRA_GOBUILD_FLAGS="-linkshared -buildmode=pie"
```
- allow to specify install directories for CNI binary and config file (with `CNIBINDIR` and `CNICONFDIF` variables); example:
```
make install CNIBINDIR=/usr/libexec/cni CNICONFDIR=/etc/cni/net.d
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6955)
<!-- Reviewable:end -->
