### PR TITLE
daemon: initialize workloads map based on option.Config.ContainerRunt…

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1147,10 +1147,8 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 		}
 
 		opts := make(map[workloads.WorkloadRuntimeType]map[string]string)
-		for _, rt := range option.Config.Workloads {
-			opts[workloads.WorkloadRuntimeType(rt)] = make(map[string]string)
-		}
 		for rt, ep := range option.Config.ContainerRuntimeEndpoint {
+			opts[workloads.WorkloadRuntimeType(rt)] = make(map[string]string)
 			opts[workloads.WorkloadRuntimeType(rt)][workloads.EpOpt] = ep
 		}
 		if opts[workloads.Docker] == nil {


### PR DESCRIPTION
…imeEndpoint

This avoids nil pointer exception when setting up Cilium with
containerD.

Fixes: d49267940840 ("workloads: Setup options in single function")
Signed-off-by: André Martins <andre@cilium.io>


Fixes https://github.com/cilium/cilium/issues/6963

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6964)
<!-- Reviewable:end -->
