### PR TITLE
examples: Do not use SSL for etcd in minikube for k8s <= 1.9

### DIFF
--- a/examples/kubernetes/1.8/cilium-minikube.yaml
+++ b/examples/kubernetes/1.8/cilium-minikube.yaml
@@ -10,18 +10,18 @@ data:
   etcd-config: |-
     ---
     endpoints:
-      - https://127.0.0.1:2379
+      - http://127.0.0.1:2379
     #
     # In case you want to use TLS in etcd, uncomment the 'ca-file' line
     # and create a kubernetes secret by following the tutorial in
     # https://cilium.link/etcd-config
-    ca-file: '/var/lib/etcd-secrets/etcd/ca.crt'
+    # ca-file: '/var/lib/etcd-secrets/etcd-client-ca.crt'
     #
     # In case you want client to server authentication, uncomment the following
     # lines and create a kubernetes secret by following the tutorial in
     # https://cilium.link/etcd-config
-    key-file: '/var/lib/etcd-secrets/apiserver-etcd-client.key'
-    cert-file: '/var/lib/etcd-secrets/apiserver-etcd-client.crt'
+    # key-file: '/var/lib/etcd-secrets/etcd-client.key'
+    # cert-file: '/var/lib/etcd-secrets/etcd-client.crt'
 
   # If you want to run cilium in debug mode change this value to true
   debug: "false"

--- a/examples/kubernetes/1.9/cilium-minikube.yaml
+++ b/examples/kubernetes/1.9/cilium-minikube.yaml
@@ -10,18 +10,18 @@ data:
   etcd-config: |-
     ---
     endpoints:
-      - https://127.0.0.1:2379
+      - http://127.0.0.1:2379
     #
     # In case you want to use TLS in etcd, uncomment the 'ca-file' line
     # and create a kubernetes secret by following the tutorial in
     # https://cilium.link/etcd-config
-    ca-file: '/var/lib/etcd-secrets/etcd/ca.crt'
+    # ca-file: '/var/lib/etcd-secrets/etcd-client-ca.crt'
     #
     # In case you want client to server authentication, uncomment the following
     # lines and create a kubernetes secret by following the tutorial in
     # https://cilium.link/etcd-config
-    key-file: '/var/lib/etcd-secrets/apiserver-etcd-client.key'
-    cert-file: '/var/lib/etcd-secrets/apiserver-etcd-client.crt'
+    # key-file: '/var/lib/etcd-secrets/etcd-client.key'
+    # cert-file: '/var/lib/etcd-secrets/etcd-client.crt'
 
   # If you want to run cilium in debug mode change this value to true
   debug: "false"

--- a/examples/kubernetes/Makefile
+++ b/examples/kubernetes/Makefile
@@ -126,11 +126,18 @@ cilium-minikube.yaml:
         (cd $$k8s_version && \
             rm -f ./$@ && \
             for f in $(CILIUM_MINIKUBE); do (cat "$${f}") >> $@; done; \
-	sed -i 's+https://cilium-etcd-client.kube-system.svc:2379+https://127.0.0.1:2379+' cilium-minikube.yaml; \
-	sed -i 's+/var/lib/etcd-secrets/etcd-client-ca.crt+/var/lib/etcd-secrets/etcd/ca.crt+' cilium-minikube.yaml; \
-	sed -i 's+/var/lib/etcd-secrets/etcd-client.key+/var/lib/etcd-secrets/apiserver-etcd-client.key+' cilium-minikube.yaml; \
-	sed -i 's+/var/lib/etcd-secrets/etcd-client.crt+/var/lib/etcd-secrets/apiserver-etcd-client.crt+' cilium-minikube.yaml); \
-	done
+            if [[ "$$k8s_version" == "1.8" || "$$k8s_version" == "1.9" ]]; then \
+            sed -i 's+https://cilium-etcd-client.kube-system.svc:2379+http://127.0.0.1:2379+' cilium-minikube.yaml; \
+            sed -i 's+ca-file:+# ca-file:+' cilium-minikube.yaml; \
+            sed -i 's+key-file:+# key-file:+' cilium-minikube.yaml; \
+            sed -i 's+cert-file:+# cert-file:+' cilium-minikube.yaml; \
+            else \
+            sed -i 's+https://cilium-etcd-client.kube-system.svc:2379+https://127.0.0.1:2379+' cilium-minikube.yaml; \
+            sed -i 's+/var/lib/etcd-secrets/etcd-client-ca.crt+/var/lib/etcd-secrets/etcd/ca.crt+' cilium-minikube.yaml; \
+            sed -i 's+/var/lib/etcd-secrets/etcd-client.key+/var/lib/etcd-secrets/apiserver-etcd-client.key+' cilium-minikube.yaml; \
+            sed -i 's+/var/lib/etcd-secrets/etcd-client.crt+/var/lib/etcd-secrets/apiserver-etcd-client.crt+' cilium-minikube.yaml; \
+            fi); \
+            done
 
 clean:
 	for k8s_version in $(K8S_VERSIONS); do \


### PR DESCRIPTION
Minikube does not provide SSL certificates for etcd and configures
apiserver to use HTTP when the Kubernetes version is lower than 1.9.

Fixes: #6940

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6973)
<!-- Reviewable:end -->
