### PR TITLE
daemon: release endpoint lock if PinDatapathMap fails

### DIFF
--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -258,6 +258,7 @@ func (d *Daemon) createEndpoint(ctx context.Context, epTemplate *models.Endpoint
 	// Now that we have ep.ID we can pin the map from this point. This
 	// also has to happen before the first build took place.
 	if err = ep.PinDatapathMap(); err != nil {
+		ep.Unlock()
 		d.deleteEndpoint(ep)
 		log.WithError(err).Warn("Aborting endpoint tail call map pin")
 		return nil, err


### PR DESCRIPTION
\`daemon.deleteEndpoint\` assumes the endpoint lock is not held when
it is called.

Fixes: b277ab4d56 ("endpoint: Refactor ipvlan related method names")

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6977)
<!-- Reviewable:end -->
