### PR TITLE
daemon: Add tofqdns-pre-cache DNS data preload

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -104,6 +104,7 @@ cilium-agent [flags]
       --tofqdns-enable-poller-events                Emit DNS responses seen by the DNS poller as Monitor events, if the poller is enabled. (default true)
       --tofqdns-endpoint-max-ip-per-hostname int    Maximum number of IPs to maintain per FQDN name for each endpoint (default 50)
       --tofqdns-min-ttl int                         The minimum time, in seconds, to use DNS data for toFQDNs policies. (default 3600 when --tofqdns-enable-poller, 604800 otherwise)
+      --tofqdns-pre-cache string                    DNS cache data at this path is preloaded on agent startup
       --tofqdns-proxy-port int                      Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port.
       --trace-payloadlen int                        Length of payload to capture when tracing (default 128)
   -t, --tunnel string                               Tunnel mode {vxlan, geneve, disabled} (default "vxlan" for the "veth" datapath mode)

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1304,7 +1304,7 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 		return nil, nil, err
 	}
 
-	err = d.bootstrapFQDN(restoredEndpoints)
+	err = d.bootstrapFQDN(restoredEndpoints, option.Config.ToFQDNsPreCache)
 	if err != nil {
 		return nil, restoredEndpoints, err
 	}

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -670,6 +670,9 @@ func init() {
 	flags.Int(option.ToFQDNsMaxIPsPerHost, defaults.ToFQDNsMaxIPsPerHost, "Maximum number of IPs to maintain per FQDN name for each endpoint")
 	option.BindEnv(option.ToFQDNsMaxIPsPerHost)
 
+	flags.String(option.ToFQDNsPreCache, defaults.ToFQDNsPreCache, "DNS cache data at this path is preloaded on agent startup")
+	option.BindEnv(option.ToFQDNsPreCache)
+
 	viper.BindPFlags(flags)
 }
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -98,6 +98,11 @@ const (
 	// for each FQDN name in an endpoint's FQDN cache
 	ToFQDNsMaxIPsPerHost = 50
 
+	// ToFQDNsPreCache is a path to a file with DNS cache data to insert into the
+	// global cache on startup.
+	// The file is not re-read after agent start.
+	ToFQDNsPreCache = ""
+
 	// IdentityChangeGracePeriod is the grace period that needs to pass
 	// before an endpoint that has changed its identity will start using
 	// that new identity. During the grace period, the new identity has

--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -36,16 +36,20 @@ var DefaultDNSCache = NewDNSCache()
 // returned.
 // cacheEntry objects are immutable once created; the address of an instance is
 // a unique identifier.
+// Note: the JSON names are intended to correlate to field names from
+// api/v1/models.DNSLookup to allow dumping the json from
+// `cilium fqdn cache list` to a file that can be unmarshalled via
+// `--tofqdns-per-cache`
 type cacheEntry struct {
 	// Name is a DNS name, it my be not fully qualified (e.g. myservice.namespace)
-	Name string `json:"name,omitempty"`
+	Name string `json:"fqdn,omitempty"`
 
 	// LookupTime is when the data begins being valid
-	LookupTime time.Time `json:"lookuptime,omitempty"`
+	LookupTime time.Time `json:"lookup-time,omitempty"`
 
 	// ExpirationTime is a calcutated time when the DNS data stops being valid.
 	// It is simply LookupTime + TTL
-	ExpirationTime time.Time `json:"expirationtime,omitempty"`
+	ExpirationTime time.Time `json:"expiration-time,omitempty"`
 
 	// TTL represents the number of seconds past LookupTime that this data is
 	// valid.

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -264,6 +264,11 @@ const (
 	// for each FQDN name in an endpoint's FQDN cache
 	ToFQDNsMaxIPsPerHost = "tofqdns-endpoint-max-ip-per-hostname"
 
+	// ToFQDNsPreCache is a path to a file with DNS cache data to insert into the
+	// global cache on startup.
+	// The file is not re-read after agent start.
+	ToFQDNsPreCache = "tofqdns-pre-cache"
+
 	// AutoIPv6NodeRoutesName is the name of the AutoIPv6NodeRoutes option
 	AutoIPv6NodeRoutesName = "auto-ipv6-node-routes"
 
@@ -742,6 +747,9 @@ type DaemonConfig struct {
 	// FQDNRejectResponse is the dns-proxy response for invalid dns-proxy request
 	FQDNRejectResponse string
 
+	// Path to a file with DNS cache data to preload on startup
+	ToFQDNsPreCache string
+
 	// HostDevice will be device used by Cilium to connect to the outside world.
 	HostDevice string
 
@@ -1013,6 +1021,7 @@ func (c *DaemonConfig) Populate() {
 		c.ToFQDNsMinTTL = defaults.ToFQDNsMinTTL
 	}
 	c.ToFQDNsProxyPort = viper.GetInt(ToFQDNsProxyPort)
+	c.ToFQDNsPreCache = viper.GetString(ToFQDNsPreCache)
 
 	// Map options
 	if m := viper.GetStringMapString(ContainerRuntimeEndpoint); len(m) != 0 {


### PR DESCRIPTION
When restarting cilium-agent, DNS data may be lost, particularly when
upgrading from earlier cilium versions without a DNS restore feature. We now allow preloading the DNS cache data for use by L3 toFQDN rules in cilium-agent.
Separately, it may also be useful to always ensure some IPs are
available as a minimum set for a DNS name. This is redundant with
toCIDR, however, so it is mostly a convenience for toFQDNs situations.

This can be folded into https://github.com/cilium/cilium/pull/6886 instead, if that's preferred. I'll post a similar message there. This option removes some of the complexity around the plan proposed in https://github.com/cilium/cilium/pull/6886. From a user perspective, it side-steps determining when to remove the generated bridge-CNP as the IPs behave like they would in the normal cache (and better accounts for upgrades from 1.3 which did have a cache). From my perspective, it allows me to avoid developing a script/tool that needs to exec on each cilium pod and then create a global CNP (or print it). This proved a little more involved than I expected. Instead, a preflight container can do the work (see below).


The upgrade plan with this option would be:
- the cilium preflight image is updated to run a new script. It runs on all nodes, adjacent to cilium-agent.
  - mount /var/run/cilium
  - Use the cilium API to `cilium policy get` directly with cilium.sock
  - Create a json file of pretend DNS lookups in a file under `/var/run/cilium/dns-precache-upgrade-1.4.json`. The expiration time is absolute, and it will expire out like any other DNS data.
  - The pod posts an error if this fails, making it clear the upgrade cannot proceed
- User updates the cilium configmap/daemonset to add `--tofqdns-pre-cache /var/run/cilium/dns-precache-upgrade-1.4.json` (or the env var equivalent).
- Switch to the cilium 1.4 image. Cilium 1.4 preloads this data into the cache at the same stage where it restores the endpoint caches. Policies received from K8s will be filled in with this data.
- The file can be deleted or not. The cache will expire the pre-cache data normally (in fact, it will be replaced by more recent lookups from the poller or DNS proxy).

An open question is whether we want to switch the DNSCache json format to match the one in the `cilium fqdn cache list` format. The fields values are the same, but they are named differently. This would break restore from other 1.4-RC images and master, but not from other versions because this feature hasn't been released. I've not included this here in case we treat the RCs are releases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6979)
<!-- Reviewable:end -->
