### PR TITLE
endpoint: make "Regenerating endpoint" log Debug level

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -225,7 +225,7 @@ func (e *Endpoint) regenerate(owner Owner, context *regenerationContext) (retErr
 	e.getLogger().WithFields(logrus.Fields{
 		logfields.StartTime: time.Now(),
 		logfields.Reason:    context.Reason,
-	}).Info("Regenerating endpoint")
+	}).Debug("Regenerating endpoint")
 
 	defer func() {
 		e.updateRegenerationStatistics(context, retErr)


### PR DESCRIPTION
If frequent regenerations occur for a lot of endpoints, a lot of logs are
generated, which is not suitable for production environments. Reduce the log
level accordingly to Debug level.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6980)
<!-- Reviewable:end -->
