### PR TITLE
1.4 backports 2019-02-08

### DIFF
--- a/Documentation/gettingstarted/ipvlan.rst
+++ b/Documentation/gettingstarted/ipvlan.rst
@@ -73,6 +73,10 @@ The ipvlan datapath only supports direct routing mode right now,
 therefore tunneling must be disabled through setting ``tunnel`` to
 ``"disabled"``.
 
+To make ipvlan work between hosts, routes on each host have to be installed
+either manually or automatically by Cilium. The latter can be enabled
+through setting ``auto-direct-node-routes`` to ``"true"``.
+
 The ``--install-iptables-rules`` parameter is optional and if set to
 ``"false"`` then Cilium will not install any iptables rules which are
 mainly for interaction with kube-proxy, and additionally it will trigger
@@ -94,6 +98,7 @@ Example ConfigMap extract for ipvlan in pure L3 mode:
   ipvlan-master-device: "bond0"
   tunnel: "disabled"
   install-iptables-rules: "false"
+  auto-direct-node-routes: "true"
 
 Example ConfigMap extract for ipvlan in L3S mode with masquerading
 all traffic leaving the node:
@@ -104,6 +109,7 @@ all traffic leaving the node:
   ipvlan-master-device: "bond0"
   tunnel: "disabled"
   masquerade: "true"
+  auto-direct-node-routes: "true"
 
 Apply the DaemonSet file to deploy Cilium and verify that it has
 come up correctly:

--- a/api/v1/models/frontend_address.go
+++ b/api/v1/models/frontend_address.go
@@ -15,7 +15,10 @@ import (
 	"github.com/go-openapi/validate"
 )
 
-// FrontendAddress Layer 4 address
+// FrontendAddress Layer 4 address. The protocol is currently ignored, all services will
+// behave as if protocol any is specified. To restrict to a particular
+// protocol, use policy.
+//
 // swagger:model FrontendAddress
 
 type FrontendAddress struct {

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -1659,7 +1659,10 @@ definitions:
           "$ref": "#/definitions/Port"
 
   FrontendAddress:
-    description: Layer 4 address
+    description: |
+      Layer 4 address. The protocol is currently ignored, all services will
+      behave as if protocol any is specified. To restrict to a particular
+      protocol, use policy.
     type: object
     properties:
       ip:

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -1911,7 +1911,7 @@ func init() {
       "type": "string"
     },
     "FrontendAddress": {
-      "description": "Layer 4 address",
+      "description": "Layer 4 address. The protocol is currently ignored, all services will\nbehave as if protocol any is specified. To restrict to a particular\nprotocol, use policy.\n",
       "type": "object",
       "properties": {
         "ip": {

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -258,6 +258,7 @@ func (d *Daemon) createEndpoint(ctx context.Context, epTemplate *models.Endpoint
 	// Now that we have ep.ID we can pin the map from this point. This
 	// also has to happen before the first build took place.
 	if err = ep.PinDatapathMap(); err != nil {
+		ep.Unlock()
 		d.deleteEndpoint(ep)
 		log.WithError(err).Warn("Aborting endpoint tail call map pin")
 		return nil, err

--- a/examples/kubernetes/1.10/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-crio-ds.yaml
@@ -169,6 +169,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -308,6 +308,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/examples/kubernetes/1.10/cilium-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-ds.yaml
@@ -168,6 +168,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/examples/kubernetes/1.10/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.10/cilium-external-etcd.yaml
@@ -307,6 +307,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/examples/kubernetes/1.10/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-minikube-ds.yaml
@@ -156,6 +156,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: Always
         lifecycle:

--- a/examples/kubernetes/1.10/cilium-minikube.yaml
+++ b/examples/kubernetes/1.10/cilium-minikube.yaml
@@ -295,6 +295,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: Always
         lifecycle:

--- a/examples/kubernetes/1.10/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.10/cilium-with-node-init.yaml
@@ -307,6 +307,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -307,6 +307,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/examples/kubernetes/1.11/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-crio-ds.yaml
@@ -169,6 +169,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -308,6 +308,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -168,6 +168,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/examples/kubernetes/1.11/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.11/cilium-external-etcd.yaml
@@ -307,6 +307,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/examples/kubernetes/1.11/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-minikube-ds.yaml
@@ -156,6 +156,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: Always
         lifecycle:

--- a/examples/kubernetes/1.11/cilium-minikube.yaml
+++ b/examples/kubernetes/1.11/cilium-minikube.yaml
@@ -295,6 +295,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: Always
         lifecycle:

--- a/examples/kubernetes/1.11/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.11/cilium-with-node-init.yaml
@@ -307,6 +307,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -307,6 +307,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/examples/kubernetes/1.12/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-crio-ds.yaml
@@ -169,6 +169,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -308,6 +308,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/examples/kubernetes/1.12/cilium-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-ds.yaml
@@ -168,6 +168,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/examples/kubernetes/1.12/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.12/cilium-external-etcd.yaml
@@ -307,6 +307,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/examples/kubernetes/1.12/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-minikube-ds.yaml
@@ -156,6 +156,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: Always
         lifecycle:

--- a/examples/kubernetes/1.12/cilium-minikube.yaml
+++ b/examples/kubernetes/1.12/cilium-minikube.yaml
@@ -295,6 +295,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: Always
         lifecycle:

--- a/examples/kubernetes/1.12/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.12/cilium-with-node-init.yaml
@@ -307,6 +307,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -307,6 +307,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/examples/kubernetes/1.13/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-crio-ds.yaml
@@ -169,6 +169,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/examples/kubernetes/1.13/cilium-crio.yaml
+++ b/examples/kubernetes/1.13/cilium-crio.yaml
@@ -308,6 +308,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/examples/kubernetes/1.13/cilium-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-ds.yaml
@@ -168,6 +168,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/examples/kubernetes/1.13/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.13/cilium-external-etcd.yaml
@@ -307,6 +307,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/examples/kubernetes/1.13/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-minikube-ds.yaml
@@ -156,6 +156,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: Always
         lifecycle:

--- a/examples/kubernetes/1.13/cilium-minikube.yaml
+++ b/examples/kubernetes/1.13/cilium-minikube.yaml
@@ -295,6 +295,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: Always
         lifecycle:

--- a/examples/kubernetes/1.13/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.13/cilium-with-node-init.yaml
@@ -307,6 +307,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/examples/kubernetes/1.13/cilium.yaml
+++ b/examples/kubernetes/1.13/cilium.yaml
@@ -307,6 +307,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/examples/kubernetes/1.8/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-crio-ds.yaml
@@ -169,6 +169,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/examples/kubernetes/1.8/cilium-crio.yaml
+++ b/examples/kubernetes/1.8/cilium-crio.yaml
@@ -308,6 +308,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/examples/kubernetes/1.8/cilium-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-ds.yaml
@@ -168,6 +168,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/examples/kubernetes/1.8/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-minikube-ds.yaml
@@ -156,6 +156,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: Always
         lifecycle:

--- a/examples/kubernetes/1.8/cilium-minikube.yaml
+++ b/examples/kubernetes/1.8/cilium-minikube.yaml
@@ -295,6 +295,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: Always
         lifecycle:

--- a/examples/kubernetes/1.8/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.8/cilium-with-node-init.yaml
@@ -307,6 +307,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -307,6 +307,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/examples/kubernetes/1.9/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-crio-ds.yaml
@@ -169,6 +169,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/examples/kubernetes/1.9/cilium-crio.yaml
+++ b/examples/kubernetes/1.9/cilium-crio.yaml
@@ -308,6 +308,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/examples/kubernetes/1.9/cilium-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-ds.yaml
@@ -168,6 +168,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/examples/kubernetes/1.9/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.9/cilium-external-etcd.yaml
@@ -307,6 +307,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/examples/kubernetes/1.9/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-minikube-ds.yaml
@@ -156,6 +156,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: Always
         lifecycle:

--- a/examples/kubernetes/1.9/cilium-minikube.yaml
+++ b/examples/kubernetes/1.9/cilium-minikube.yaml
@@ -295,6 +295,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: Always
         lifecycle:

--- a/examples/kubernetes/1.9/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.9/cilium-with-node-init.yaml
@@ -307,6 +307,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/examples/kubernetes/1.9/cilium.yaml
+++ b/examples/kubernetes/1.9/cilium.yaml
@@ -307,6 +307,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:v1.4.0-rc7
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/examples/kubernetes/connectivity-check/echo-policy.yaml
+++ b/examples/kubernetes/connectivity-check/echo-policy.yaml
@@ -1,0 +1,12 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "curl-to-echo-stream"
+spec:
+  endpointSelector:
+    matchLabels:
+      name: echo-stream
+  ingress:
+  - fromEndpoints:
+    - matchLabels:
+        name: curl

--- a/examples/kubernetes/connectivity-check/echo.yaml
+++ b/examples/kubernetes/connectivity-check/echo.yaml
@@ -1,0 +1,42 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: echo-stream
+spec:
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        name: echo-stream
+    spec:
+      containers:
+      - name: echo-stream
+        image: docker.io/tgraf/echo-server
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo-stream
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    name: echo-stream
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: curl
+spec:
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        name: curl
+    spec:
+      containers:
+      - name: echo-container
+        image: docker.io/cilium/json-mock

--- a/examples/kubernetes/node-init/cilium-with-node-init.yaml
+++ b/examples/kubernetes/node-init/cilium-with-node-init.yaml
@@ -3,25 +3,25 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: cilium-config
-  namespace: kube-system
+  namespace: cilium
 data:
   # This etcd-config contains the etcd endpoints of your cluster. If you use
   # TLS please make sure you follow the tutorial in https://cilium.link/etcd-config
   etcd-config: |-
     ---
     endpoints:
-      - http://EDIT-ME-ETCD-ADDRESS:2379
+      - https://cilium-etcd-client.cilium.svc:2379
     #
     # In case you want to use TLS in etcd, uncomment the 'ca-file' line
     # and create a kubernetes secret by following the tutorial in
     # https://cilium.link/etcd-config
-    # ca-file: '/var/lib/etcd-secrets/etcd-client-ca.crt'
+    ca-file: '/var/lib/etcd-secrets/etcd-client-ca.crt'
     #
     # In case you want client to server authentication, uncomment the following
     # lines and create a kubernetes secret by following the tutorial in
     # https://cilium.link/etcd-config
-    # key-file: '/var/lib/etcd-secrets/etcd-client.key'
-    # cert-file: '/var/lib/etcd-secrets/etcd-client.crt'
+    key-file: '/var/lib/etcd-secrets/etcd-client.key'
+    cert-file: '/var/lib/etcd-secrets/etcd-client.crt'
 
   # If you want to run cilium in debug mode change this value to true
   debug: "false"
@@ -138,14 +138,14 @@ data:
   # false to true. Can be found under the path `spec.spec.hostPID`
   flannel-manage-existing-containers: "false"
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
     k8s-app: cilium
     kubernetes.io/cluster-service: "true"
   name: cilium
-  namespace: kube-system
+  namespace: cilium
 spec:
   selector:
     matchLabels:
@@ -283,38 +283,8 @@ spec:
               key: flannel-manage-existing-containers
               name: cilium-config
               optional: true
-        - name: CILIUM_DATAPATH_MODE
-          valueFrom:
-            configMapKeyRef:
-              key: datapath-mode
-              name: cilium-config
-              optional: true
-        - name: CILIUM_IPVLAN_MASTER_DEVICE
-          valueFrom:
-            configMapKeyRef:
-              key: ipvlan-master-device
-              name: cilium-config
-              optional: true
-        - name: CILIUM_INSTALL_IPTABLES_RULES
-          valueFrom:
-            configMapKeyRef:
-              key: install-iptables-rules
-              name: cilium-config
-              optional: true
-        - name: CILIUM_MASQUERADE
-          valueFrom:
-            configMapKeyRef:
-              key: masquerade
-              name: cilium-config
-              optional: true
-        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
-          valueFrom:
-            configMapKeyRef:
-              key: auto-direct-node-routes
-              name: cilium-config
-              optional: true
-        image: docker.io/cilium/cilium:v1.4.0-rc7
-        imagePullPolicy: IfNotPresent
+        image: docker.io/cilium/cilium:latest
+        imagePullPolicy: Always
         lifecycle:
           postStart:
             exec:
@@ -435,7 +405,7 @@ spec:
         name: docker-socket
         # To install cilium cni plugin in the host
       - hostPath:
-          path: /opt/cni/bin
+          path: /home/kubernetes/bin
           type: DirectoryOrCreate
         name: cni-path
         # To install cilium cni configuration in the host
@@ -469,14 +439,14 @@ spec:
       maxUnavailable: 2
     type: RollingUpdate
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
     io.cilium/app: operator
     name: cilium-operator
   name: cilium-operator
-  namespace: kube-system
+  namespace: cilium
 spec:
   replicas: 1
   selector:
@@ -554,8 +524,8 @@ spec:
               key: AWS_DEFAULT_REGION
               name: cilium-aws
               optional: true
-        image: docker.io/cilium/operator:v1.4.0-rc7
-        imagePullPolicy: IfNotPresent
+        image: docker.io/tgraf/operator:init-fix
+        imagePullPolicy: Always
         name: cilium-operator
         volumeMounts:
         - mountPath: /var/lib/etcd-config
@@ -588,9 +558,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: cilium-operator
-  namespace: kube-system
+  namespace: cilium
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium-operator
@@ -622,7 +592,7 @@ rules:
   verbs:
   - '*'
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium-operator
@@ -633,9 +603,228 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: cilium-operator
-  namespace: kube-system
+  namespace: cilium
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cilium-etcd-operator
+rules:
+- apiGroups:
+  - etcd.database.coreos.com
+  resources:
+  - etcdclusters
+  verbs:
+  - get
+  - delete
+  - create
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - delete
+  - get
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - deployments
+  verbs:
+  - delete
+  - create
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - delete
+  - create
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - componentstatuses
+  verbs:
+  - get
+- apiGroups:
+  - extensions
+  resources:
+  - deployments
+  verbs:
+  - delete
+  - create
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - create
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cilium-etcd-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium-etcd-operator
+subjects:
+- kind: ServiceAccount
+  name: cilium-etcd-operator
+  namespace: cilium
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: etcd-operator
+rules:
+- apiGroups:
+  - etcd.database.coreos.com
+  resources:
+  - etcdclusters
+  - etcdbackups
+  - etcdrestores
+  verbs:
+  - '*'
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - deployments
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - '*'
+- apiGroups:
+  - extensions
+  resources:
+  - deployments
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: etcd-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: etcd-operator
+subjects:
+- kind: ServiceAccount
+  name: cilium-etcd-sa
+  namespace: cilium
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cilium-etcd-operator
+  namespace: cilium
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cilium-etcd-sa
+  namespace: cilium
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    io.cilium/app: etcd-operator
+    name: cilium-etcd-operator
+  name: cilium-etcd-operator
+  namespace: cilium
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.cilium/app: etcd-operator
+      name: cilium-etcd-operator
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        io.cilium/app: etcd-operator
+        name: cilium-etcd-operator
+    spec:
+      containers:
+      - command:
+        - /usr/bin/cilium-etcd-operator
+        env:
+        - name: CILIUM_ETCD_OPERATOR_CLUSTER_DOMAIN
+          value: cluster.local
+        - name: CILIUM_ETCD_OPERATOR_ETCD_CLUSTER_SIZE
+          value: "3"
+        - name: CILIUM_ETCD_OPERATOR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: CILIUM_ETCD_OPERATOR_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: CILIUM_ETCD_OPERATOR_POD_UID
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.uid
+        image: docker.io/cilium/cilium-etcd-operator:v2.0.5
+        imagePullPolicy: IfNotPresent
+        name: cilium-etcd-operator
+      dnsPolicy: ClusterFirst
+      hostNetwork: true
+      restartPolicy: Always
+      serviceAccount: cilium-etcd-operator
+      serviceAccountName: cilium-etcd-operator
+      tolerations:
+      - operator: Exists
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cilium
@@ -646,12 +835,12 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: cilium
-  namespace: kube-system
+  namespace: cilium
 - apiGroup: rbac.authorization.k8s.io
   kind: Group
   name: system:nodes
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cilium
@@ -719,4 +908,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: cilium
-  namespace: kube-system
+  namespace: cilium

--- a/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
@@ -169,6 +169,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:__CILIUM_VERSION__
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
@@ -168,6 +168,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:__CILIUM_VERSION__
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/examples/kubernetes/templates/v1/cilium-minikube-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-minikube-ds.yaml.sed
@@ -156,6 +156,12 @@ spec:
               key: masquerade
               name: cilium-config
               optional: true
+        - name: CILIUM_AUTO_DIRECT_NODE_ROUTES
+          valueFrom:
+            configMapKeyRef:
+              key: auto-direct-node-routes
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:__CILIUM_VERSION__
         imagePullPolicy: Always
         lifecycle:

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -45,6 +45,11 @@ const (
 	UDP = L4Type("UDP")
 )
 
+var (
+	// AllProtocols is the list of all supported L4 protocols
+	AllProtocols = []L4Type{TCP, UDP}
+)
+
 // L4Type name.
 type L4Type string
 

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -262,9 +262,13 @@ func NewL3n4AddrFromModel(base *models.FrontendAddress) (*L3n4Addr, error) {
 		return nil, fmt.Errorf("Missing IP address")
 	}
 
-	proto, err := NewL4Type(base.Protocol)
-	if err != nil {
-		return nil, err
+	proto := NONE
+	if base.Protocol != "" {
+		p, err := NewL4Type(base.Protocol)
+		if err != nil {
+			return nil, err
+		}
+		proto = p
 	}
 
 	l4addr := NewL4Addr(proto, base.Port)
@@ -325,9 +329,8 @@ func (a *L3n4Addr) GetModel() *models.FrontendAddress {
 	}
 
 	return &models.FrontendAddress{
-		IP:       a.IP.String(),
-		Protocol: string(a.Protocol),
-		Port:     a.Port,
+		IP:   a.IP.String(),
+		Port: a.Port,
 	}
 }
 

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -497,7 +497,7 @@ func serviceKey2L3n4Addr(svcKey ServiceKey) *loadbalancer.L3n4Addr {
 		feIP = svc4Key.Address.IP()
 		fePort = svc4Key.Port
 	}
-	return loadbalancer.NewL3n4Addr(loadbalancer.TCP, feIP, fePort)
+	return loadbalancer.NewL3n4Addr(loadbalancer.NONE, feIP, fePort)
 }
 
 // serviceKeynValue2FEnBE converts the given svcKey and svcValue to a frontend in the
@@ -530,7 +530,7 @@ func serviceKeynValue2FEnBE(svcKey ServiceKey, svcValue ServiceValue) (*loadbala
 	}
 
 	feL3n4Addr := serviceKey2L3n4Addr(svcKey)
-	beLBBackEnd := loadbalancer.NewLBBackEnd(loadbalancer.TCP, beIP, bePort, beWeight)
+	beLBBackEnd := loadbalancer.NewLBBackEnd(loadbalancer.NONE, beIP, bePort, beWeight)
 
 	feL3n4AddrID := &loadbalancer.L3n4AddrID{
 		L3n4Addr: *feL3n4Addr,
@@ -542,12 +542,12 @@ func serviceKeynValue2FEnBE(svcKey ServiceKey, svcValue ServiceValue) (*loadbala
 
 // RevNat6Value2L3n4Addr converts the given RevNat6Value to a L3n4Addr.
 func revNat6Value2L3n4Addr(revNATV *RevNat6Value) *loadbalancer.L3n4Addr {
-	return loadbalancer.NewL3n4Addr(loadbalancer.TCP, revNATV.Address.IP(), revNATV.Port)
+	return loadbalancer.NewL3n4Addr(loadbalancer.NONE, revNATV.Address.IP(), revNATV.Port)
 }
 
 // revNat4Value2L3n4Addr converts the given RevNat4Value to a L3n4Addr.
 func revNat4Value2L3n4Addr(revNATV *RevNat4Value) *loadbalancer.L3n4Addr {
-	return loadbalancer.NewL3n4Addr(loadbalancer.TCP, revNATV.Address.IP(), revNATV.Port)
+	return loadbalancer.NewL3n4Addr(loadbalancer.NONE, revNATV.Address.IP(), revNATV.Port)
 }
 
 // revNatValue2L3n4AddrID converts the given RevNatKey and RevNatValue to a L3n4AddrID.


### PR DESCRIPTION
 * PR: 6977 -- daemon: release endpoint lock if PinDatapathMap fails (@ianvernon) -- https://github.com/cilium/cilium/pull/6977
 * PR: 6976 -- datapath: Fix accidental external route deletion (@tgraf) -- https://github.com/cilium/cilium/pull/6976
 * PR: 6971 -- Add auto-direct-node-routes for ipvlan (@brb) -- https://github.com/cilium/cilium/pull/6971
 * PR: 6970 -- Fix restore of k8s UDP services (@tgraf) -- https://github.com/cilium/cilium/pull/6970

When you have backported the above commits, you can update the PR labels via this command:
```
$ for pr in 6977 6976 6971 6970; do contrib/backporting/set-labels.py $pr done 1.4; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6982)
<!-- Reviewable:end -->
