### PR TITLE
v1.4: backports 19-02-08

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -104,6 +104,7 @@ cilium-agent [flags]
       --tofqdns-enable-poller-events                Emit DNS responses seen by the DNS poller as Monitor events, if the poller is enabled. (default true)
       --tofqdns-endpoint-max-ip-per-hostname int    Maximum number of IPs to maintain per FQDN name for each endpoint (default 50)
       --tofqdns-min-ttl int                         The minimum time, in seconds, to use DNS data for toFQDNs policies. (default 3600 when --tofqdns-enable-poller, 604800 otherwise)
+      --tofqdns-pre-cache string                    DNS cache data at this path is preloaded on agent startup
       --tofqdns-proxy-port int                      Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port.
       --trace-payloadlen int                        Length of payload to capture when tracing (default 128)
   -t, --tunnel string                               Tunnel mode {vxlan, geneve, disabled} (default "vxlan" for the "veth" datapath mode)

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1286,7 +1286,7 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 		return nil, nil, err
 	}
 
-	err = d.bootstrapFQDN(restoredEndpoints)
+	err = d.bootstrapFQDN(restoredEndpoints, option.Config.ToFQDNsPreCache)
 	if err != nil {
 		return nil, restoredEndpoints, err
 	}

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -670,6 +670,9 @@ func init() {
 	flags.Int(option.ToFQDNsMaxIPsPerHost, defaults.ToFQDNsMaxIPsPerHost, "Maximum number of IPs to maintain per FQDN name for each endpoint")
 	option.BindEnv(option.ToFQDNsMaxIPsPerHost)
 
+	flags.String(option.ToFQDNsPreCache, defaults.ToFQDNsPreCache, "DNS cache data at this path is preloaded on agent startup")
+	option.BindEnv(option.ToFQDNsPreCache)
+
 	viper.BindPFlags(flags)
 }
 

--- a/daemon/fqdn.go
+++ b/daemon/fqdn.go
@@ -343,7 +343,11 @@ func (d *Daemon) bootstrapFQDN(restoredEndpoints *endpointRestoreState, preCache
 				if effectiveTTL < option.Config.ToFQDNsMinTTL {
 					effectiveTTL = option.Config.ToFQDNsMinTTL
 				}
-				ep.DNSHistory.Update(lookupTime, qname, responseIPs, effectiveTTL)
+
+				if ep.DNSHistory.Update(lookupTime, qname, responseIPs, effectiveTTL) {
+					ep.SyncEndpointHeaderFile(d)
+				}
+
 				log.Debug("Updating DNS name in cache from response to to query")
 				err = d.dnsRuleGen.UpdateGenerateDNS(lookupTime, map[string]*fqdn.DNSIPRecords{
 					qname: {

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -98,6 +98,11 @@ const (
 	// for each FQDN name in an endpoint's FQDN cache
 	ToFQDNsMaxIPsPerHost = 50
 
+	// ToFQDNsPreCache is a path to a file with DNS cache data to insert into the
+	// global cache on startup.
+	// The file is not re-read after agent start.
+	ToFQDNsPreCache = ""
+
 	// IdentityChangeGracePeriod is the grace period that needs to pass
 	// before an endpoint that has changed its identity will start using
 	// that new identity. During the grace period, the new identity has

--- a/pkg/endpoint/directory.go
+++ b/pkg/endpoint/directory.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
+
 	"github.com/sirupsen/logrus"
 )
 
@@ -33,6 +35,11 @@ func (e *Endpoint) DirectoryPath() string {
 // failed builds.
 func (e *Endpoint) FailedDirectoryPath() string {
 	return filepath.Join(".", fmt.Sprintf("%d%s", e.ID, "_next_fail"))
+}
+
+// StateDirectoryPath returns the directory name for this endpoint bpf program.
+func (e *Endpoint) StateDirectoryPath() string {
+	return filepath.Join(option.Config.StateDir, e.StringID())
 }
 
 // NextDirectoryPath returns the directory name for this endpoint bpf program

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"math"
 	"os"
-	"path/filepath"
 	"reflect"
 	"strconv"
 	"strings"
@@ -257,7 +256,7 @@ func (e *Endpoint) regenerate(owner Owner, context *regenerationContext) (retErr
 	e.Unlock()
 
 	stats.prepareBuild.Start()
-	origDir := filepath.Join(option.Config.StateDir, e.StringID())
+	origDir := e.StateDirectoryPath()
 	context.datapathRegenerationContext.currentDir = origDir
 
 	// This is the temporary directory to store the generated headers,

--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -36,16 +36,20 @@ var DefaultDNSCache = NewDNSCache()
 // returned.
 // cacheEntry objects are immutable once created; the address of an instance is
 // a unique identifier.
+// Note: the JSON names are intended to correlate to field names from
+// api/v1/models.DNSLookup to allow dumping the json from
+// `cilium fqdn cache list` to a file that can be unmarshalled via
+// `--tofqdns-per-cache`
 type cacheEntry struct {
 	// Name is a DNS name, it my be not fully qualified (e.g. myservice.namespace)
-	Name string `json:"name,omitempty"`
+	Name string `json:"fqdn,omitempty"`
 
 	// LookupTime is when the data begins being valid
-	LookupTime time.Time `json:"lookuptime,omitempty"`
+	LookupTime time.Time `json:"lookup-time,omitempty"`
 
 	// ExpirationTime is a calcutated time when the DNS data stops being valid.
 	// It is simply LookupTime + TTL
-	ExpirationTime time.Time `json:"expirationtime,omitempty"`
+	ExpirationTime time.Time `json:"expiration-time,omitempty"`
 
 	// TTL represents the number of seconds past LookupTime that this data is
 	// valid.

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -264,6 +264,11 @@ const (
 	// for each FQDN name in an endpoint's FQDN cache
 	ToFQDNsMaxIPsPerHost = "tofqdns-endpoint-max-ip-per-hostname"
 
+	// ToFQDNsPreCache is a path to a file with DNS cache data to insert into the
+	// global cache on startup.
+	// The file is not re-read after agent start.
+	ToFQDNsPreCache = "tofqdns-pre-cache"
+
 	// AutoIPv6NodeRoutesName is the name of the AutoIPv6NodeRoutes option
 	AutoIPv6NodeRoutesName = "auto-ipv6-node-routes"
 
@@ -742,6 +747,9 @@ type DaemonConfig struct {
 	// FQDNRejectResponse is the dns-proxy response for invalid dns-proxy request
 	FQDNRejectResponse string
 
+	// Path to a file with DNS cache data to preload on startup
+	ToFQDNsPreCache string
+
 	// HostDevice will be device used by Cilium to connect to the outside world.
 	HostDevice string
 
@@ -1013,6 +1021,7 @@ func (c *DaemonConfig) Populate() {
 		c.ToFQDNsMinTTL = defaults.ToFQDNsMinTTL
 	}
 	c.ToFQDNsProxyPort = viper.GetInt(ToFQDNsProxyPort)
+	c.ToFQDNsPreCache = viper.GetString(ToFQDNsPreCache)
 
 	// Map options
 	if m := viper.GetStringMapString(ContainerRuntimeEndpoint); len(m) != 0 {


### PR DESCRIPTION
 * #6981 -- FQDN proxy keep dnscache sync (@tgraf)
 * #6979 -- daemon: Add tofqdns-pre-cache DNS data preload (@raybejjani)

Once this PR is merged, you can update the PR labels via:
```
$ for pr in 6981 6979; do contrib/backporting/set-labels.py $pr done 1.4; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6983)
<!-- Reviewable:end -->
