### PR TITLE
FQDN: Add metrics for Garbage collector cleanup.

### DIFF
--- a/Documentation/configuration/metrics.rst
+++ b/Documentation/configuration/metrics.rst
@@ -136,7 +136,6 @@ IPAM
 * ``ipam_events_total``: Number of IPAM events received labeled by action and
   datapath family type
 
-
 KVstore
 -------
 
@@ -149,6 +148,13 @@ Agent
 
 * ``agent_bootstrap_seconds``: Duration of various bootstrap phases
   * Labels: ``scope``, ``outcome``
+
+FQDN
+-----
+
+* ``fqdn_gc_deletions_total``: Number of FQDNs that have been cleaned on FQDN
+  Garbage collector job
+
 
 Cilium as a Kubernetes pod
 ==========================

--- a/daemon/fqdn.go
+++ b/daemon/fqdn.go
@@ -150,6 +150,8 @@ func (d *Daemon) bootstrapFQDN(restoredEndpoints *endpointRestoreState, preCache
 			for _, ep := range endpoints {
 				cfg.Cache.UpdateFromCache(ep.DNSHistory, namesToClean)
 			}
+
+			metrics.FQDNGarbageCollectorCleanedTotal.Add(float64(len(namesToClean)))
 			log.WithField(logfields.Controller, dnsGCJobName).Infof(
 				"FQDN garbage collector work deleted %d name entries", len(namesToClean))
 			return d.dnsRuleGen.ForceGenerateDNS(namesToClean)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -487,6 +487,13 @@ var (
 		Name:      "operations_duration_seconds",
 		Help:      "Duration in seconds of kvstore operations",
 	}, []string{LabelScope, LabelKind, LabelAction, LabelOutcome})
+
+	// FQDNGarbageCollectorCleanedTotal is the number of domains cleaned by the
+	// GC job.
+	FQDNGarbageCollectorCleanedTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "fqdn_gc_deletions_total",
+		Help: "Number of FQDNs that have been cleaned on FQDN Garbage collector job",
+	})
 )
 
 func init() {
@@ -550,6 +557,8 @@ func init() {
 
 	MustRegister(KVStoreOperationsTotal)
 	MustRegister(KVStoreOperationsDuration)
+
+	MustRegister(FQDNGarbageCollectorCleanedTotal)
 }
 
 // MustRegister adds the collector to the registry, exposing this metric to


### PR DESCRIPTION
This commit add the option to get the number of names that has been
cleaned on a GC job.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

Please ensure your pull request adheres to the following guidelines:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6985)
<!-- Reviewable:end -->
