### PR TITLE
cilium-docker: Add version subcommand

### DIFF
--- a/plugins/cilium-docker/main.go
+++ b/plugins/cilium-docker/main.go
@@ -50,6 +50,10 @@ connected to a Docker network of type "cilium".`,
   docker run --net my_network hello-world
 `,
 	Run: func(cmd *cobra.Command, args []string) {
+		common.RequireRootPrivilege("cilium-docker")
+
+		createPluginSock()
+
 		if d, err := driver.NewDriver(ciliumAPI); err != nil {
 			log.WithError(err).Fatal("Unable to create cilium-net driver")
 		} else {
@@ -83,9 +87,9 @@ func initConfig() {
 	} else {
 		log.Logger.SetLevel(logrus.InfoLevel)
 	}
+}
 
-	common.RequireRootPrivilege("cilium-docker")
-
+func createPluginSock() {
 	driverSock = filepath.Join(pluginPath, "cilium.sock")
 
 	if err := os.MkdirAll(pluginPath, 0755); err != nil && !os.IsExist(err) {

--- a/plugins/cilium-docker/version.go
+++ b/plugins/cilium-docker/version.go
@@ -1,0 +1,39 @@
+// Copyright 2016-2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/cilium/cilium/pkg/version"
+
+	"github.com/spf13/cobra"
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print version information",
+	Run: func(cmd *cobra.Command, args []string) {
+		getVersion(cmd, args)
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(versionCmd)
+}
+
+func getVersion(cmd *cobra.Command, args []string) {
+	fmt.Printf("%s\n", version.Version)
+}


### PR DESCRIPTION
This PR refactors cilium-docker cmd in a way that some steps are executed only when starting the plugin, and adds `version` sub cmd.

Usage example:

```
$ ./plugins/cilium-docker/cilium-docker version
1.4.90 de4cec1a6 2019-02-07T16:37:23+01:00 go version go1.11.3 linux/amd64
```

Fixes: #6744 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6986)
<!-- Reviewable:end -->
