### PR TITLE
status: Declare probe as stale only after FailureThreshold

### DIFF
--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -344,4 +344,7 @@ const (
 
 	// PIDFile is a string value for the path to a file containing a PID.
 	PIDFile = "pidfile"
+
+	// Probe is the name of a status probe.
+	Probe = "probe"
 )


### PR DESCRIPTION
Previously, if a probe didn't return after `WarningThreshold` (=15s), it would have been considered as stale, which resulted in `cilium status` to exit with 1 and thus, marking a cilium node as `NotReady`. This was the case for heavily loaded nodes on which 15s was not enough.

This commit changes the way we declare a probe as stale: after `WarningThreshold` we log a warning and only after `FailureThreshold` we mark the probe as stale.

Also, this change is more compatible with the previous cilium status subsystem which had a timeout for staleness of 60s.

(Probably) Fixes #6954

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6992)
<!-- Reviewable:end -->
