### PR TITLE
v1.3: Stop annotating Cilium security identity in kubernetes pods

### DIFF
--- a/Documentation/cmdref/cilium_policy_trace.md
+++ b/Documentation/cmdref/cilium_policy_trace.md
@@ -11,7 +11,8 @@ Verifies if the source is allowed to consume
 destination. Source / destination can be provided as endpoint ID, security ID, Kubernetes Pod, YAML file, set of LABELs. LABEL is represented as
 SOURCE:KEY[=VALUE].
 dports can be can be for example: 80/tcp, 53 or 23/udp.
-If multiple sources and / or destinations are provided, each source is tested whether there is a policy allowing traffic between it and each destination
+If multiple sources and / or destinations are provided, each source is tested whether there is a policy allowing traffic between it and each destination.
+--src-k8s-pod and --dst-k8s-pod requires cilium-agent to be running with disable-endpoint-crd option set to "false".
 
 ```
 cilium policy trace ( -s <label context> | --src-identity <security identity> | --src-endpoint <endpoint ID> | --src-k8s-pod <namespace:pod-name> | --src-k8s-yaml <path to YAML file> ) ( -d <label context> | --dst-identity <security identity> | --dst-endpoint <endpoint ID> | --dst-k8s-pod <namespace:pod-name> | --dst-k8s-yaml <path to YAML file>) [--dport <port>[/<protocol>]

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -97,6 +97,7 @@ cpumap
 cqlsh
 createtopic
 CreationDate
+crd
 cri
 crio
 daemonset
@@ -133,6 +134,7 @@ doesn
 DoorManager
 dports
 dryRun
+dst
 DTrace
 DWARF
 dwarfris
@@ -464,6 +466,7 @@ SIG
 Sith
 skb
 Spectre
+src
 Stacktrace
 stacktrace
 stap

--- a/cilium/cmd/policy_trace.go
+++ b/cilium/cmd/policy_trace.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Authors of Cilium
+// Copyright 2017-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import (
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/k8s"
-	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
+	clientset "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned"
 	"github.com/cilium/cilium/pkg/policy/trace"
 
 	"github.com/spf13/cobra"
@@ -52,7 +52,8 @@ var policyTraceCmd = &cobra.Command{
 destination. Source / destination can be provided as endpoint ID, security ID, Kubernetes Pod, YAML file, set of LABELs. LABEL is represented as
 SOURCE:KEY[=VALUE].
 dports can be can be for example: 80/tcp, 53 or 23/udp.
-If multiple sources and / or destinations are provided, each source is tested whether there is a policy allowing traffic between it and each destination`,
+If multiple sources and / or destinations are provided, each source is tested whether there is a policy allowing traffic between it and each destination.
+--src-k8s-pod and --dst-k8s-pod requires cilium-agent to be running with disable-endpoint-crd option set to "false".`,
 	Run: func(cmd *cobra.Command, args []string) {
 
 		srcSlices := [][]string{}
@@ -256,22 +257,22 @@ func getSecIDFromK8s(podName string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("unable to create rest configuration: %s", err)
 	}
-	k8sClient, err := k8s.CreateClient(restConfig)
+	ciliumK8sClient, err := clientset.NewForConfig(restConfig)
 	if err != nil {
 		return "", fmt.Errorf("unable to create k8s client: %s", err)
 	}
 
-	p, err := k8sClient.CoreV1().Pods(namespace).Get(pod, meta_v1.GetOptions{})
+	ep, err := ciliumK8sClient.CiliumV2().CiliumEndpoints(namespace).Get(pod, meta_v1.GetOptions{})
 	if err != nil {
 		return "", fmt.Errorf("unable to get pod %s in namespace %s", pod, namespace)
 	}
 
-	secID := p.GetAnnotations()[k8sConst.CiliumIdentityAnnotation]
-	if secID == "" {
-		return "", fmt.Errorf("cilium-identity annotation not set for pod %s in namespace %s", pod, namespace)
+	if ep.Status.Status == nil || ep.Status.Status.Identity == nil {
+		return "", fmt.Errorf("cilium security identity"+
+			" not set for pod %s in namespace %s", pod, namespace)
 	}
 
-	return secID, nil
+	return strconv.Itoa(int(ep.Status.Status.Identity.ID)), nil
 }
 
 // parseL4PortsSlice parses a given `slice` of strings. Each string should be in

--- a/pkg/k8s/apis/cilium.io/const.go
+++ b/pkg/k8s/apis/cilium.io/const.go
@@ -52,9 +52,6 @@ const (
 
 	// CiliumK8sAnnotationPrefix is the prefix key for the annotations used in kubernetes.
 	CiliumK8sAnnotationPrefix = "cilium.io/"
-
-	// CiliumIdentityAnnotation is the annotation key used to map to an endpoint's security identity.
-	CiliumIdentityAnnotation = CiliumK8sAnnotationPrefix + "identity"
 	// CiliumIdentityAnnotationDeprecated is the previous annotation key used to map to an endpoint's security identity.
 	CiliumIdentityAnnotationDeprecated = "cilium-identity"
 )

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -17,7 +17,6 @@ package k8sTest
 import (
 	"context"
 	"fmt"
-
 	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
@@ -257,6 +256,11 @@ var _ = Describe("K8sPolicyTest", func() {
 				helpers.KubeSystemNamespace, l3Policy, helpers.KubectlApply, 300)
 			Expect(err).Should(BeNil())
 
+			for _, appName := range []string{helpers.App1, helpers.App2, helpers.App3} {
+				err = kubectl.WaitForCEPIdentity(helpers.DefaultNamespace, appPods[appName])
+				Expect(err).Should(BeNil())
+			}
+
 			validatePolicyStatus()
 
 			trace := kubectl.CiliumExec(ciliumPod, fmt.Sprintf(
@@ -352,6 +356,11 @@ var _ = Describe("K8sPolicyTest", func() {
 			_, err := kubectl.CiliumPolicyAction(
 				helpers.KubeSystemNamespace, serviceAccountPolicy, helpers.KubectlApply, 300)
 			Expect(err).Should(BeNil())
+
+			for _, appName := range []string{helpers.App1, helpers.App2, helpers.App3} {
+				err = kubectl.WaitForCEPIdentity(helpers.DefaultNamespace, appPods[appName])
+				Expect(err).Should(BeNil())
+			}
 
 			trace := kubectl.CiliumExec(ciliumPod, fmt.Sprintf(
 				"cilium policy trace --src-k8s-pod default:%s --dst-k8s-pod default:%s --dport 80",


### PR DESCRIPTION
Backport of https://github.com/cilium/cilium/pull/6888

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6993)
<!-- Reviewable:end -->
