### PR TITLE
Test: Fix Containerd installation.

### DIFF
--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -210,7 +210,7 @@ case $CONTAINER_RUNTIME in
     "docker")
         ;;
     "containerd")
-        KUBEADM_CRI_SOCKET="unix:///var/run/cri-containerd.sock"
+        KUBEADM_CRI_SOCKET="unix:///run/containerd/containerd.sock"
         ;;
     *)
         echo "Invalid container runtime '${CONTAINER_RUNTIME}'"


### PR DESCRIPTION
Due docker is enabled, the containerd is not working correctly on test
vagrant servers.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6996)
<!-- Reviewable:end -->
