### PR TITLE
fqdn: Avoid regenerations on each poller update

### DIFF
--- a/pkg/fqdn/dnspoller.go
+++ b/pkg/fqdn/dnspoller.go
@@ -97,7 +97,7 @@ type DNSPoller struct {
 	// The data here is map[dnsName][rule uuid]struct{} where the inner map acts
 	// as a refcount of rules that depend on this dnsName.
 	// The UUID -> rule mapping is allRules below.
-	sourceRules map[string]map[string]struct{}
+	sourceRules map[string]map[string]int
 
 	// allRules is the global source of truth for rules we are managing. It maps
 	// UUID to the rule copy.
@@ -105,6 +105,10 @@ type DNSPoller struct {
 
 	// cache is a private copy of the pointer from config.
 	cache *DNSCache
+
+	// allRulesRefCnt is the refcount for each uuid key in allRules. This is used
+	// to guard against different order Start/StopPollDNSName in daemon.PolicyAdd
+	allRulesRefCnt map[string]int
 }
 
 // DNSPollerConfig is a simple configuration structure to set how DNSPoller
@@ -151,11 +155,12 @@ func NewDNSPoller(config DNSPollerConfig) *DNSPoller {
 	}
 
 	return &DNSPoller{
-		config:      config,
-		IPs:         make(map[string][]net.IP),
-		sourceRules: make(map[string]map[string]struct{}),
-		allRules:    make(map[string]*api.Rule),
-		cache:       config.Cache,
+		config:         config,
+		IPs:            make(map[string][]net.IP),
+		sourceRules:    make(map[string]map[string]int),
+		allRules:       make(map[string]*api.Rule),
+		allRulesRefCnt: make(map[string]int),
+		cache:          config.Cache,
 	}
 }
 
@@ -428,6 +433,7 @@ func (poller *DNSPoller) addRule(uuid string, sourceRule *api.Rule) (newDNSNames
 
 	// Always add to allRules
 	poller.allRules[uuid] = sourceRule
+	poller.allRulesRefCnt[uuid] += 1
 
 	// Add a dnsname -> rule reference
 	for _, egressRule := range sourceRule.Egress {
@@ -441,9 +447,9 @@ func (poller *DNSPoller) addRule(uuid string, sourceRule *api.Rule) (newDNSNames
 				oldDNSNames = append(oldDNSNames, dnsName)
 			} else {
 				newDNSNames = append(newDNSNames, dnsName)
-				// Add this egress rule as a dependent on dnsName.
-				poller.sourceRules[dnsName][uuid] = struct{}{}
 			}
+			// Add this egress rule as a dependent on dnsName.
+			poller.sourceRules[dnsName][uuid] += 1
 		}
 	}
 
@@ -466,7 +472,11 @@ func (poller *DNSPoller) addRule(uuid string, sourceRule *api.Rule) (newDNSNames
 // noLongerPolled indicates that no more rules rely on this DNS target
 func (poller *DNSPoller) removeRule(uuid string, sourceRule *api.Rule) (noLongerPolled []string) {
 	// Always delete from allRules
-	delete(poller.allRules, uuid)
+	poller.allRulesRefCnt[uuid] -= 1
+	if poller.allRulesRefCnt[uuid] <= 0 {
+		delete(poller.allRulesRefCnt, uuid)
+		delete(poller.allRules, uuid)
+	}
 
 	// Delete dnsname -> rule references
 	for _, egressRule := range sourceRule.Egress {
@@ -491,8 +501,10 @@ func (poller *DNSPoller) removeFromDNSName(dnsName, uuid string) (shouldStopPoll
 	// remove the rule from the set of rules that rely on dnsName.
 	// Note: this isn't removing dnsName from poller.sourceRules, that is just
 	// below.
-	delete(poller.sourceRules[dnsName], uuid)
-
+	poller.sourceRules[dnsName][uuid] -= 1
+	if poller.sourceRules[dnsName][uuid] <= 0 {
+		delete(poller.sourceRules[dnsName], uuid)
+	}
 	// Check if any rules remain that rely on this dnsName by checking
 	// if the inner map[rule uuid]struct{} set is empty. If none do we
 	// can delete it so we no longer poll it.
@@ -511,7 +523,7 @@ func (poller *DNSPoller) ensureExists(dnsName string) (exists bool) {
 	_, exists = poller.IPs[dnsName]
 	if !exists {
 		poller.IPs[dnsName] = make([]net.IP, 0)
-		poller.sourceRules[dnsName] = make(map[string]struct{})
+		poller.sourceRules[dnsName] = make(map[string]int)
 	}
 
 	return exists


### PR DESCRIPTION
This is the v1.3 forwardport version of https://github.com/cilium/cilium/pull/6850. Since this has come up in both 1.2 and 1.3, I prefer to not have this be another hotfix. The 1.3 code is different enough from 1.4 that backports will be difficult and this PR will make it worse, but it will be consistent. I've picked reviewers that are familiar with the 1.3 user that prompted this PR. Others are free to also chime in.

When the DNS Poller would update DNS info we called StopPollDNSName
before calling StartPollDNSName. In cases where a new rule was added or
one removed, this was ok. In cases where we replaced an existing rule we
would remove a rule-uuid -> DNS name association, deleting the IPs for
that DNS name, and then add it again. This caused the update logic to
treat the IP update as new always, instead of only when the IPs had
changed (since it had no copy of the IP to compare to). This ultimately
resulted in a regeneration with every poller update.
The solution is to call StopPollDNSName on rules only after we have
called StartPollDNSName, and more aggresively reference count UUID-based
associations. This is especially important because we now randomize
UUIDs given to rules, and it was possible to not clean the UUID of an
old rule and regenerate it back into existence.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/6997)
<!-- Reviewable:end -->
