### PR TITLE
make: Ensure that bash is used as a shell

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -1,3 +1,6 @@
+SHELL := /bin/bash
+.SHELLFLAGS := -eu -o pipefail -c
+
 ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 RELATIVE_DIR := $(shell echo $(realpath .) | sed "s;$(ROOT_DIR)[/]*;;")
 include $(ROOT_DIR)/Makefile.quiet


### PR DESCRIPTION
Makefile for Kubernetes examples contains bash specific code. GNU Make
may use sh as a shell if the `SHELL` variable is not defined.

Fixes: ad6a29a9e420 ("examples: Do not use SSL for etcd in minikube for k8s <= 1.9")
Reported-by: Thomas Graf <thomas@cilium.io>
Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7000)
<!-- Reviewable:end -->
