### PR TITLE
pkg/workloads,examples,Documentation: change default crio.sock path to /var/run/crio/crio.sock

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -30,7 +30,7 @@ cilium-agent [flags]
       --config string                               Configuration file (default "$HOME/ciliumd.yaml")
       --conntrack-garbage-collector-interval uint   Garbage collection interval for the connection tracking table (in seconds) (default 60)
       --container-runtime strings                   Sets the container runtime(s) used by Cilium { containerd | crio | docker | none | auto } ( "auto" uses the container runtime found in the order: "docker", "containerd", "crio" ) (default [auto])
-      --container-runtime-endpoint map              Container runtime(s) endpoint(s). (default: --container-runtime-endpoint=containerd=/var/run/containerd/containerd.sock, --container-runtime-endpoint=crio=/var/run/crio.sock, --container-runtime-endpoint=docker=unix:///var/run/docker.sock) (default map[])
+      --container-runtime-endpoint map              Container runtime(s) endpoint(s). (default: --container-runtime-endpoint=containerd=/var/run/containerd/containerd.sock, --container-runtime-endpoint=crio=/var/run/crio/crio.sock, --container-runtime-endpoint=docker=unix:///var/run/docker.sock) (default map[])
       --datapath-mode string                        Datapath mode name (default "veth")
   -D, --debug                                       Enable debugging mode
       --debug-verbose strings                       List of enabled verbose debug groups

--- a/Documentation/kubernetes/configuration.rst
+++ b/Documentation/kubernetes/configuration.rst
@@ -365,7 +365,7 @@ After that you can restart CRI-O:
     minikube ssh -- sudo systemctl restart crio
 
 Finally, you need to restart the Cilium pod so it can re-mount
-``/var/run/crio.sock`` which was recreated by CRI-O
+``/var/run/crio/crio.sock`` which was recreated by CRI-O
 
 ::
 

--- a/examples/kubernetes/1.10/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-crio-ds.yaml
@@ -229,7 +229,7 @@ spec:
           name: cni-path
         - mountPath: /host/etc/cni/net.d
           name: etc-cni-netd
-        - mountPath: /var/run/crio.sock
+        - mountPath: /var/run/crio/crio.sock
           name: crio-socket
           readOnly: true
         - mountPath: /var/lib/etcd-config

--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -368,7 +368,7 @@ spec:
           name: cni-path
         - mountPath: /host/etc/cni/net.d
           name: etc-cni-netd
-        - mountPath: /var/run/crio.sock
+        - mountPath: /var/run/crio/crio.sock
           name: crio-socket
           readOnly: true
         - mountPath: /var/lib/etcd-config

--- a/examples/kubernetes/1.11/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-crio-ds.yaml
@@ -227,7 +227,7 @@ spec:
           name: cni-path
         - mountPath: /host/etc/cni/net.d
           name: etc-cni-netd
-        - mountPath: /var/run/crio.sock
+        - mountPath: /var/run/crio/crio.sock
           name: crio-socket
           readOnly: true
         - mountPath: /var/lib/etcd-config

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -366,7 +366,7 @@ spec:
           name: cni-path
         - mountPath: /host/etc/cni/net.d
           name: etc-cni-netd
-        - mountPath: /var/run/crio.sock
+        - mountPath: /var/run/crio/crio.sock
           name: crio-socket
           readOnly: true
         - mountPath: /var/lib/etcd-config

--- a/examples/kubernetes/1.12/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-crio-ds.yaml
@@ -227,7 +227,7 @@ spec:
           name: cni-path
         - mountPath: /host/etc/cni/net.d
           name: etc-cni-netd
-        - mountPath: /var/run/crio.sock
+        - mountPath: /var/run/crio/crio.sock
           name: crio-socket
           readOnly: true
         - mountPath: /var/lib/etcd-config

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -366,7 +366,7 @@ spec:
           name: cni-path
         - mountPath: /host/etc/cni/net.d
           name: etc-cni-netd
-        - mountPath: /var/run/crio.sock
+        - mountPath: /var/run/crio/crio.sock
           name: crio-socket
           readOnly: true
         - mountPath: /var/lib/etcd-config

--- a/examples/kubernetes/1.13/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-crio-ds.yaml
@@ -227,7 +227,7 @@ spec:
           name: cni-path
         - mountPath: /host/etc/cni/net.d
           name: etc-cni-netd
-        - mountPath: /var/run/crio.sock
+        - mountPath: /var/run/crio/crio.sock
           name: crio-socket
           readOnly: true
         - mountPath: /var/lib/etcd-config

--- a/examples/kubernetes/1.13/cilium-crio.yaml
+++ b/examples/kubernetes/1.13/cilium-crio.yaml
@@ -366,7 +366,7 @@ spec:
           name: cni-path
         - mountPath: /host/etc/cni/net.d
           name: etc-cni-netd
-        - mountPath: /var/run/crio.sock
+        - mountPath: /var/run/crio/crio.sock
           name: crio-socket
           readOnly: true
         - mountPath: /var/lib/etcd-config

--- a/examples/kubernetes/1.8/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-crio-ds.yaml
@@ -229,7 +229,7 @@ spec:
           name: cni-path
         - mountPath: /host/etc/cni/net.d
           name: etc-cni-netd
-        - mountPath: /var/run/crio.sock
+        - mountPath: /var/run/crio/crio.sock
           name: crio-socket
           readOnly: true
         - mountPath: /var/lib/etcd-config

--- a/examples/kubernetes/1.8/cilium-crio.yaml
+++ b/examples/kubernetes/1.8/cilium-crio.yaml
@@ -368,7 +368,7 @@ spec:
           name: cni-path
         - mountPath: /host/etc/cni/net.d
           name: etc-cni-netd
-        - mountPath: /var/run/crio.sock
+        - mountPath: /var/run/crio/crio.sock
           name: crio-socket
           readOnly: true
         - mountPath: /var/lib/etcd-config

--- a/examples/kubernetes/1.9/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-crio-ds.yaml
@@ -229,7 +229,7 @@ spec:
           name: cni-path
         - mountPath: /host/etc/cni/net.d
           name: etc-cni-netd
-        - mountPath: /var/run/crio.sock
+        - mountPath: /var/run/crio/crio.sock
           name: crio-socket
           readOnly: true
         - mountPath: /var/lib/etcd-config

--- a/examples/kubernetes/1.9/cilium-crio.yaml
+++ b/examples/kubernetes/1.9/cilium-crio.yaml
@@ -368,7 +368,7 @@ spec:
           name: cni-path
         - mountPath: /host/etc/cni/net.d
           name: etc-cni-netd
-        - mountPath: /var/run/crio.sock
+        - mountPath: /var/run/crio/crio.sock
           name: crio-socket
           readOnly: true
         - mountPath: /var/lib/etcd-config

--- a/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
@@ -229,7 +229,7 @@ spec:
           name: cni-path
         - mountPath: /host/etc/cni/net.d
           name: etc-cni-netd
-        - mountPath: /var/run/crio.sock
+        - mountPath: /var/run/crio/crio.sock
           name: crio-socket
           readOnly: true
         - mountPath: /var/lib/etcd-config

--- a/pkg/workloads/crio.go
+++ b/pkg/workloads/crio.go
@@ -27,7 +27,7 @@ const (
 	CRIO WorkloadRuntimeType = "crio"
 
 	// criOEndpoint is the default value for the crio socket
-	criOEndpoint = "/var/run/crio.sock"
+	criOEndpoint = "/var/run/crio/crio.sock"
 )
 
 var (


### PR DESCRIPTION
<!-- Description of change -->

`/var/run/crio/crio.sock` has been the canonical default path for the CRI-O socket for a while now, so update the default path Cilium looks at (including in the Kubernetes volume mount). This makes things more consistent in the manifests, especially if you're templating the Cilium manifest to support a choice between container runtimes dynamically. The path can still be overridden using the cli args as before; this change is for convenience rather than behavior change.

This change was done via a straight find-and-replace for `/var/run/crio.sock` --> `/var/run/crio/crio.sock`. I may have missed some locations.

Signed-off-by: Anit Gandhi <anitgandhi@gmail.com>

```release-note
The default crio socket path is now /var/run/crio/crio.sock
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7001)
<!-- Reviewable:end -->
