### PR TITLE
Vagrantfiles: update developer, CI VM version to 128

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -123,7 +123,7 @@ Vagrant.configure(2) do |config|
         vb.customize ["modifyvm", :id, "--audio", "none"]
 
         config.vm.box = "cilium/ubuntu-dev"
-        config.vm.box_version = "126"
+        config.vm.box_version = "128"
         vb.memory = ENV['VM_MEMORY'].to_i
         vb.cpus = ENV['VM_CPUS'].to_i
         if ENV["NFS"] then

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -8,7 +8,7 @@ $K8S_VERSION = ENV['K8S_VERSION'] || "1.13"
 $K8S_NODES = (ENV['K8S_NODES'] || "2").to_i
 $NFS = ENV['NFS']=="1"? true : false
 $SERVER_BOX = (ENV['SERVER_BOX'] || "cilium/ubuntu-dev")
-$SERVER_VERSION= "126"
+$SERVER_VERSION= "128"
 $NETNEXT_SERVER_BOX= "cilium/ubuntu-next"
 $NETNEXT_SERVER_VERSION= "6"
 $IPv6=(ENV['IPv6'] || "0")


### PR DESCRIPTION
Changes from the prior VM version include:

* Include kTLS support in packer builds
* Pull Spotify Kafka proxy image
* Fix golang envtpl installation
* install python3-sphinx and add ~/.local/bin to PATH
* Pull FQDN images
* Pull Istio images
* Allow to specify packer binary name
* fix permissions for packages installed via pip3

Fixes: #6638

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7004)
<!-- Reviewable:end -->
