### PR TITLE
operator: always set "logtostderr" flag to true

### DIFF
--- a/operator/main.go
+++ b/operator/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"os/signal"
@@ -128,6 +129,11 @@ func initConfig() {
 
 func runOperator(cmd *cobra.Command) {
 	logging.SetupLogging([]string{}, map[string]string{}, "cilium-operator", viper.GetBool("debug"))
+
+	// Make sure glog (used by the client-go dependency) logs to stderr, as it
+	// will try to log to directories that may not exist in the cilium-operator
+	// container and cause the cilium-operator to exit.
+	flag.Set("logtostderr", "true")
 
 	log.Infof("Cilium Operator %s", version.Version)
 


### PR DESCRIPTION
Make sure glog (used by the client-go dependency) logs to stderr, as it will try
to log to directories that may not exist in the cilium-operator container and
cause the cilium-operator to exit.

Signed-off by: Ian Vernon <ian@cilium.io>

I haven't tried to force glog to log to a location within a locally-built cilium-operator pod to reproduce the issue hit in #7006 yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7007)
<!-- Reviewable:end -->
