### PR TITLE
kubernetes: Add missing pod delete RBAC permissions

### DIFF
--- a/examples/kubernetes/1.10/cilium-containerd.yaml
+++ b/examples/kubernetes/1.10/cilium-containerd.yaml
@@ -672,6 +672,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -672,6 +672,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.10/cilium-etcd-operator-rbac.yaml
+++ b/examples/kubernetes/1.10/cilium-etcd-operator-rbac.yaml
@@ -35,6 +35,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.10/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.10/cilium-with-node-init.yaml
@@ -671,6 +671,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -671,6 +671,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.11/cilium-containerd.yaml
+++ b/examples/kubernetes/1.11/cilium-containerd.yaml
@@ -674,6 +674,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -665,6 +665,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.11/cilium-etcd-operator-rbac.yaml
+++ b/examples/kubernetes/1.11/cilium-etcd-operator-rbac.yaml
@@ -35,6 +35,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.11/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.11/cilium-with-node-init.yaml
@@ -671,6 +671,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -673,6 +673,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.12/cilium-containerd.yaml
+++ b/examples/kubernetes/1.12/cilium-containerd.yaml
@@ -674,6 +674,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -665,6 +665,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.12/cilium-etcd-operator-rbac.yaml
+++ b/examples/kubernetes/1.12/cilium-etcd-operator-rbac.yaml
@@ -35,6 +35,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.12/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.12/cilium-with-node-init.yaml
@@ -671,6 +671,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -673,6 +673,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.13/cilium-containerd.yaml
+++ b/examples/kubernetes/1.13/cilium-containerd.yaml
@@ -674,6 +674,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.13/cilium-crio.yaml
+++ b/examples/kubernetes/1.13/cilium-crio.yaml
@@ -665,6 +665,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.13/cilium-etcd-operator-rbac.yaml
+++ b/examples/kubernetes/1.13/cilium-etcd-operator-rbac.yaml
@@ -35,6 +35,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.13/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.13/cilium-with-node-init.yaml
@@ -671,6 +671,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.13/cilium.yaml
+++ b/examples/kubernetes/1.13/cilium.yaml
@@ -673,6 +673,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.8/cilium-containerd.yaml
+++ b/examples/kubernetes/1.8/cilium-containerd.yaml
@@ -672,6 +672,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.8/cilium-crio.yaml
+++ b/examples/kubernetes/1.8/cilium-crio.yaml
@@ -672,6 +672,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.8/cilium-etcd-operator-rbac.yaml
+++ b/examples/kubernetes/1.8/cilium-etcd-operator-rbac.yaml
@@ -35,6 +35,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.8/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.8/cilium-with-node-init.yaml
@@ -671,6 +671,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -671,6 +671,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.9/cilium-containerd.yaml
+++ b/examples/kubernetes/1.9/cilium-containerd.yaml
@@ -672,6 +672,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.9/cilium-crio.yaml
+++ b/examples/kubernetes/1.9/cilium-crio.yaml
@@ -672,6 +672,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.9/cilium-etcd-operator-rbac.yaml
+++ b/examples/kubernetes/1.9/cilium-etcd-operator-rbac.yaml
@@ -35,6 +35,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.9/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.9/cilium-with-node-init.yaml
@@ -671,6 +671,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.9/cilium.yaml
+++ b/examples/kubernetes/1.9/cilium.yaml
@@ -671,6 +671,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/templates/v1/cilium-etcd-operator-rbac.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-etcd-operator-rbac.yaml.sed
@@ -35,6 +35,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:


### PR DESCRIPTION
Fixes:
```
level=error msg="pods \"cilium-etcd-r2kk6rfd5c\" is forbidden: User \"system:serviceaccount:kube-system:cilium-etcd-operator\" cannot delete resource \"pods\" in API group \"\" in the namespace \"kube-system\""
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7010)
<!-- Reviewable:end -->
