### PR TITLE
1.4 Backports 2019-02-09

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -30,7 +30,7 @@ cilium-agent [flags]
       --config string                               Configuration file (default "$HOME/ciliumd.yaml")
       --conntrack-garbage-collector-interval uint   Garbage collection interval for the connection tracking table (in seconds) (default 60)
       --container-runtime strings                   Sets the container runtime(s) used by Cilium { containerd | crio | docker | none | auto } ( "auto" uses the container runtime found in the order: "docker", "containerd", "crio" ) (default [auto])
-      --container-runtime-endpoint map              Container runtime(s) endpoint(s). (default: --container-runtime-endpoint=containerd=/var/run/containerd/containerd.sock, --container-runtime-endpoint=crio=/var/run/crio.sock, --container-runtime-endpoint=docker=unix:///var/run/docker.sock) (default map[])
+      --container-runtime-endpoint map              Container runtime(s) endpoint(s). (default: --container-runtime-endpoint=containerd=/var/run/containerd/containerd.sock, --container-runtime-endpoint=crio=/var/run/crio/crio.sock, --container-runtime-endpoint=docker=unix:///var/run/docker.sock) (default map[])
       --datapath-mode string                        Datapath mode name (default "veth")
   -D, --debug                                       Enable debugging mode
       --debug-verbose strings                       List of enabled verbose debug groups

--- a/Documentation/kubernetes/configuration.rst
+++ b/Documentation/kubernetes/configuration.rst
@@ -365,7 +365,7 @@ After that you can restart CRI-O:
     minikube ssh -- sudo systemctl restart crio
 
 Finally, you need to restart the Cilium pod so it can re-mount
-``/var/run/crio.sock`` which was recreated by CRI-O
+``/var/run/crio/crio.sock`` which was recreated by CRI-O
 
 ::
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1147,7 +1147,6 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 	if err := workloads.Setup(d.ipam, option.Config.Workloads, wOpts); err != nil {
 		return nil, nil, fmt.Errorf("unable to setup workload: %s", err)
 	}
-	log.Infof("Container runtime options set: %s", workloads.GetRuntimeOptions())
 
 	// restore endpoints before any IPs are allocated to avoid eventual IP
 	// conflicts later on, otherwise any IP conflict will result in the

--- a/examples/kubernetes/1.10/cilium-containerd.yaml
+++ b/examples/kubernetes/1.10/cilium-containerd.yaml
@@ -673,6 +673,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.10/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-crio-ds.yaml
@@ -229,7 +229,7 @@ spec:
           name: cni-path
         - mountPath: /host/etc/cni/net.d
           name: etc-cni-netd
-        - mountPath: /var/run/crio.sock
+        - mountPath: /var/run/crio/crio.sock
           name: crio-socket
           readOnly: true
         - mountPath: /var/lib/etcd-config

--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -368,7 +368,7 @@ spec:
           name: cni-path
         - mountPath: /host/etc/cni/net.d
           name: etc-cni-netd
-        - mountPath: /var/run/crio.sock
+        - mountPath: /var/run/crio/crio.sock
           name: crio-socket
           readOnly: true
         - mountPath: /var/lib/etcd-config

--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -672,6 +672,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.10/cilium-etcd-operator-rbac.yaml
+++ b/examples/kubernetes/1.10/cilium-etcd-operator-rbac.yaml
@@ -35,6 +35,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.10/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.10/cilium-with-node-init.yaml
@@ -671,6 +671,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -671,6 +671,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.11/cilium-containerd.yaml
+++ b/examples/kubernetes/1.11/cilium-containerd.yaml
@@ -675,6 +675,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.11/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-crio-ds.yaml
@@ -227,7 +227,7 @@ spec:
           name: cni-path
         - mountPath: /host/etc/cni/net.d
           name: etc-cni-netd
-        - mountPath: /var/run/crio.sock
+        - mountPath: /var/run/crio/crio.sock
           name: crio-socket
           readOnly: true
         - mountPath: /var/lib/etcd-config

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -665,6 +665,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -366,7 +366,7 @@ spec:
           name: cni-path
         - mountPath: /host/etc/cni/net.d
           name: etc-cni-netd
-        - mountPath: /var/run/crio.sock
+        - mountPath: /var/run/crio/crio.sock
           name: crio-socket
           readOnly: true
         - mountPath: /var/lib/etcd-config

--- a/examples/kubernetes/1.11/cilium-etcd-operator-rbac.yaml
+++ b/examples/kubernetes/1.11/cilium-etcd-operator-rbac.yaml
@@ -35,6 +35,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.11/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.11/cilium-with-node-init.yaml
@@ -671,6 +671,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -673,6 +673,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.12/cilium-containerd.yaml
+++ b/examples/kubernetes/1.12/cilium-containerd.yaml
@@ -675,6 +675,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.12/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-crio-ds.yaml
@@ -227,7 +227,7 @@ spec:
           name: cni-path
         - mountPath: /host/etc/cni/net.d
           name: etc-cni-netd
-        - mountPath: /var/run/crio.sock
+        - mountPath: /var/run/crio/crio.sock
           name: crio-socket
           readOnly: true
         - mountPath: /var/lib/etcd-config

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -665,6 +665,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -366,7 +366,7 @@ spec:
           name: cni-path
         - mountPath: /host/etc/cni/net.d
           name: etc-cni-netd
-        - mountPath: /var/run/crio.sock
+        - mountPath: /var/run/crio/crio.sock
           name: crio-socket
           readOnly: true
         - mountPath: /var/lib/etcd-config

--- a/examples/kubernetes/1.12/cilium-etcd-operator-rbac.yaml
+++ b/examples/kubernetes/1.12/cilium-etcd-operator-rbac.yaml
@@ -35,6 +35,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.12/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.12/cilium-with-node-init.yaml
@@ -671,6 +671,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -673,6 +673,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.13/cilium-containerd.yaml
+++ b/examples/kubernetes/1.13/cilium-containerd.yaml
@@ -675,6 +675,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.13/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-crio-ds.yaml
@@ -227,7 +227,7 @@ spec:
           name: cni-path
         - mountPath: /host/etc/cni/net.d
           name: etc-cni-netd
-        - mountPath: /var/run/crio.sock
+        - mountPath: /var/run/crio/crio.sock
           name: crio-socket
           readOnly: true
         - mountPath: /var/lib/etcd-config

--- a/examples/kubernetes/1.13/cilium-crio.yaml
+++ b/examples/kubernetes/1.13/cilium-crio.yaml
@@ -665,6 +665,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.13/cilium-crio.yaml
+++ b/examples/kubernetes/1.13/cilium-crio.yaml
@@ -366,7 +366,7 @@ spec:
           name: cni-path
         - mountPath: /host/etc/cni/net.d
           name: etc-cni-netd
-        - mountPath: /var/run/crio.sock
+        - mountPath: /var/run/crio/crio.sock
           name: crio-socket
           readOnly: true
         - mountPath: /var/lib/etcd-config

--- a/examples/kubernetes/1.13/cilium-etcd-operator-rbac.yaml
+++ b/examples/kubernetes/1.13/cilium-etcd-operator-rbac.yaml
@@ -35,6 +35,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.13/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.13/cilium-with-node-init.yaml
@@ -671,6 +671,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.13/cilium.yaml
+++ b/examples/kubernetes/1.13/cilium.yaml
@@ -673,6 +673,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.8/cilium-containerd.yaml
+++ b/examples/kubernetes/1.8/cilium-containerd.yaml
@@ -673,6 +673,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.8/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-crio-ds.yaml
@@ -229,7 +229,7 @@ spec:
           name: cni-path
         - mountPath: /host/etc/cni/net.d
           name: etc-cni-netd
-        - mountPath: /var/run/crio.sock
+        - mountPath: /var/run/crio/crio.sock
           name: crio-socket
           readOnly: true
         - mountPath: /var/lib/etcd-config

--- a/examples/kubernetes/1.8/cilium-crio.yaml
+++ b/examples/kubernetes/1.8/cilium-crio.yaml
@@ -368,7 +368,7 @@ spec:
           name: cni-path
         - mountPath: /host/etc/cni/net.d
           name: etc-cni-netd
-        - mountPath: /var/run/crio.sock
+        - mountPath: /var/run/crio/crio.sock
           name: crio-socket
           readOnly: true
         - mountPath: /var/lib/etcd-config

--- a/examples/kubernetes/1.8/cilium-crio.yaml
+++ b/examples/kubernetes/1.8/cilium-crio.yaml
@@ -672,6 +672,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.8/cilium-etcd-operator-rbac.yaml
+++ b/examples/kubernetes/1.8/cilium-etcd-operator-rbac.yaml
@@ -35,6 +35,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.8/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.8/cilium-with-node-init.yaml
@@ -671,6 +671,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -671,6 +671,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.9/cilium-containerd.yaml
+++ b/examples/kubernetes/1.9/cilium-containerd.yaml
@@ -673,6 +673,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.9/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-crio-ds.yaml
@@ -229,7 +229,7 @@ spec:
           name: cni-path
         - mountPath: /host/etc/cni/net.d
           name: etc-cni-netd
-        - mountPath: /var/run/crio.sock
+        - mountPath: /var/run/crio/crio.sock
           name: crio-socket
           readOnly: true
         - mountPath: /var/lib/etcd-config

--- a/examples/kubernetes/1.9/cilium-crio.yaml
+++ b/examples/kubernetes/1.9/cilium-crio.yaml
@@ -368,7 +368,7 @@ spec:
           name: cni-path
         - mountPath: /host/etc/cni/net.d
           name: etc-cni-netd
-        - mountPath: /var/run/crio.sock
+        - mountPath: /var/run/crio/crio.sock
           name: crio-socket
           readOnly: true
         - mountPath: /var/lib/etcd-config

--- a/examples/kubernetes/1.9/cilium-crio.yaml
+++ b/examples/kubernetes/1.9/cilium-crio.yaml
@@ -672,6 +672,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.9/cilium-etcd-operator-rbac.yaml
+++ b/examples/kubernetes/1.9/cilium-etcd-operator-rbac.yaml
@@ -35,6 +35,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.9/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.9/cilium-with-node-init.yaml
@@ -671,6 +671,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/1.9/cilium.yaml
+++ b/examples/kubernetes/1.9/cilium.yaml
@@ -671,6 +671,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
@@ -229,7 +229,7 @@ spec:
           name: cni-path
         - mountPath: /host/etc/cni/net.d
           name: etc-cni-netd
-        - mountPath: /var/run/crio.sock
+        - mountPath: /var/run/crio/crio.sock
           name: crio-socket
           readOnly: true
         - mountPath: /var/lib/etcd-config

--- a/examples/kubernetes/templates/v1/cilium-etcd-operator-rbac.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-etcd-operator-rbac.yaml.sed
@@ -35,6 +35,8 @@ rules:
   - pods
   verbs:
   - list
+  - delete
+  - get
 - apiGroups:
   - apps
   resources:

--- a/operator/main.go
+++ b/operator/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"os/signal"
@@ -128,6 +129,11 @@ func initConfig() {
 
 func runOperator(cmd *cobra.Command) {
 	logging.SetupLogging([]string{}, map[string]string{}, "cilium-operator", viper.GetBool("debug"))
+
+	// Make sure glog (used by the client-go dependency) logs to stderr, as it
+	// will try to log to directories that may not exist in the cilium-operator
+	// container and cause the cilium-operator to exit.
+	flag.Set("logtostderr", "true")
 
 	log.Infof("Cilium Operator %s", version.Version)
 

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -344,4 +344,7 @@ const (
 
 	// PIDFile is a string value for the path to a file containing a PID.
 	PIDFile = "pidfile"
+
+	// Probe is the name of a status probe.
+	Probe = "probe"
 )

--- a/pkg/workloads/crio.go
+++ b/pkg/workloads/crio.go
@@ -27,7 +27,7 @@ const (
 	CRIO WorkloadRuntimeType = "crio"
 
 	// criOEndpoint is the default value for the crio socket
-	criOEndpoint = "/var/run/crio.sock"
+	criOEndpoint = "/var/run/crio/crio.sock"
 )
 
 var (


### PR DESCRIPTION
 * PR: 7001 -- pkg/workloads,examples,Documentation: change default crio.sock path to /var/run/crio/crio.sock (@anitgandhi) -- https://github.com/cilium/cilium/pull/7001
 * PR: 7007 -- operator: always set "logtostderr" flag to true (@ianvernon) -- https://github.com/cilium/cilium/pull/7007
 * PR: 7003 -- daemon: remove duplicated Container runtime options set info message (@aanm) -- https://github.com/cilium/cilium/pull/7003
 * PR: 6992 -- status: Declare probe as stale only after FailureThreshold (@brb) -- https://github.com/cilium/cilium/pull/6992

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7011)
<!-- Reviewable:end -->
