### PR TITLE
metrics: Add bytes counter for forwards and drops

### DIFF
--- a/Documentation/configuration/metrics.rst
+++ b/Documentation/configuration/metrics.rst
@@ -71,7 +71,9 @@ Drops/Forwards (L3/L4)
 ----------------------
 
 * ``drop_count_total``: Total dropped packets, tagged by drop reason and ingress/egress direction
+* ``drop_bytes_total``: Total dropped bytes, tagged by drop reason and ingress/egress direction
 * ``forward_count_total``: Total forwarded packets, tagged by ingress/egress direction
+* ``forward_bytes_total``: Total forwarded bytes, tagged by ingress/egress direction
 
 Policy
 ------

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -324,12 +324,30 @@ var (
 	},
 		[]string{"reason", "direction"})
 
-	// ForwardCount is the total forward requests,
+	// DropBytes is the total dropped bytes,
+	// tagged by drop reason and direction(ingress/egress)
+	DropBytes = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Name:      "drop_bytes_total",
+		Help:      "Total dropped bytes, tagged by drop reason and ingress/egress direction",
+	},
+		[]string{"reason", "direction"})
+
+	// ForwardCount is the total forwarded packets,
 	// tagged by ingress/egress direction
 	ForwardCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: Namespace,
 		Name:      "forward_count_total",
 		Help:      "Total forwarded packets, tagged by ingress/egress direction",
+	},
+		[]string{"direction"})
+
+	// ForwardBytes is the total forwarded bytes,
+	// tagged by ingress/egress direction
+	ForwardBytes = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Name:      "forward_bytes_total",
+		Help:      "Total forwarded bytes, tagged by ingress/egress direction",
 	},
 		[]string{"direction"})
 
@@ -489,7 +507,9 @@ func init() {
 	MustRegister(ProxyUpstreamTime)
 
 	MustRegister(DropCount)
+	MustRegister(DropBytes)
 	MustRegister(ForwardCount)
+	MustRegister(ForwardBytes)
 
 	MustRegister(newStatusCollector())
 


### PR DESCRIPTION
Example:
```
cilium_drop_bytes_total                               direction="EGRESS" reason="CT: Unknown L4 protocol"        390.000000
cilium_drop_bytes_total                               direction="EGRESS" reason="Invalid source ip"              423830.000000
cilium_drop_bytes_total                               direction="EGRESS" reason="Missed tail call"               467472.000000
cilium_drop_bytes_total                               direction="EGRESS" reason="Service backend not found"      13416.000000
cilium_drop_bytes_total                               direction="EGRESS" reason="Unknown L3 target address"      78.000000
cilium_drop_bytes_total                               direction="INGRESS" reason="Not a local target address"    14823596.000000
cilium_drop_bytes_total                               direction="INGRESS" reason="Policy denied (L3)"            2310.000000
cilium_forward_bytes_total                            direction="EGRESS"                                         427268531.000000
cilium_forward_bytes_total                            direction="INGRESS"                                        520828105.000000
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7012)
<!-- Reviewable:end -->
