### PR TITLE
api/v1: remove requirements of labels in endpoints API

### DIFF
--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -176,7 +176,13 @@ paths:
       tags:
       - endpoint
       parameters:
-      - "$ref": "#/parameters/labels"
+      - name: labels
+        description: |
+          List of labels
+        in: body
+        required: false
+        schema:
+          "$ref": "#/definitions/Labels"
       responses:
         '200':
           description: Success

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -112,7 +112,12 @@ func init() {
         "summary": "Retrieves a list of endpoints that have metadata matching the provided parameters.",
         "parameters": [
           {
-            "$ref": "#/parameters/labels"
+            "description": "List of labels\n",
+            "name": "labels",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/Labels"
+            }
           }
         ],
         "responses": {

--- a/api/v1/server/restapi/endpoint/get_endpoint_parameters.go
+++ b/api/v1/server/restapi/endpoint/get_endpoint_parameters.go
@@ -6,7 +6,6 @@ package endpoint
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	"io"
 	"net/http"
 
 	"github.com/go-openapi/errors"
@@ -34,7 +33,6 @@ type GetEndpointParams struct {
 
 	/*List of labels
 
-	  Required: true
 	  In: body
 	*/
 	Labels models.Labels
@@ -50,12 +48,7 @@ func (o *GetEndpointParams) BindRequest(r *http.Request, route *middleware.Match
 		defer r.Body.Close()
 		var body models.Labels
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
-			if err == io.EOF {
-				res = append(res, errors.Required("labels", "body"))
-			} else {
-				res = append(res, errors.NewParseError("labels", "body", "", err))
-			}
-
+			res = append(res, errors.NewParseError("labels", "body", "", err))
 		} else {
 
 			if len(res) == 0 {
@@ -63,8 +56,6 @@ func (o *GetEndpointParams) BindRequest(r *http.Request, route *middleware.Match
 			}
 		}
 
-	} else {
-		res = append(res, errors.Required("labels", "body"))
 	}
 
 	if len(res) > 0 {


### PR DESCRIPTION
Labels are not really required in this API endpoint and so they should
be marked as optional in `GET: v1/endpoint`

Fixes: 48abb62084ac ("api: add pod / container name, labels for GET ep")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7029)
<!-- Reviewable:end -->
