### PR TITLE
datapath: Fix IPsec with IPv4 or IPv6 disabled

### DIFF
--- a/Documentation/gettingstarted/encryption.rst
+++ b/Documentation/gettingstarted/encryption.rst
@@ -153,6 +153,107 @@ Finally, apply the file,
 At this point the Cilium managed nodes will be using IPSec for all traffic. For further
 information on Cilium's transparent encryption, see :ref:`arch_guide`.
 
+Validate the Setup
+==================
+
+Run a ``bash`` shell in one of the Cilium pods with ``kubectl -n kube-system
+exec -ti cilium-7cpsm -- bash`` and execute the following commands:
+
+1. Install tcpdump
+
+.. code:: bash
+
+    apt-get update
+    apt-get -y install tcpdump
+
+2. Check that traffic is encrypted:
+
+.. code:: bash
+
+    tcpdump -n -i cilium_vxlan
+    tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
+    listening on cilium_vxlan, link-type EN10MB (Ethernet), capture size 262144 bytes
+    15:16:21.626416 IP 10.60.1.1 > 10.60.0.1: ESP(spi=0x00000001,seq=0x57e2), length 180
+    15:16:21.626473 IP 10.60.1.1 > 10.60.0.1: ESP(spi=0x00000001,seq=0x57e3), length 180
+    15:16:21.627167 IP 10.60.0.1 > 10.60.1.1: ESP(spi=0x00000001,seq=0x579d), length 100
+    15:16:21.627296 IP 10.60.0.1 > 10.60.1.1: ESP(spi=0x00000001,seq=0x579e), length 100
+    15:16:21.627523 IP 10.60.0.1 > 10.60.1.1: ESP(spi=0x00000001,seq=0x579f), length 180
+    15:16:21.627699 IP 10.60.1.1 > 10.60.0.1: ESP(spi=0x00000001,seq=0x57e4), length 100
+    15:16:21.628408 IP 10.60.1.1 > 10.60.0.1: ESP(spi=0x00000001,seq=0x57e5), length 100
+
+
+Troubleshooting
+===============
+
+ * Make sure that the Cilium pods have kvstore connectivity:
+   
+   .. code:: bash
+
+      cilium status
+      KVStore:                Ok   etcd: 1/1 connected: http://127.0.0.1:31079 - 3.3.2 (Leader)
+      [...]
+
+ * Check for ``level=warning`` and ``level=error`` messages in the Cilium log files
+ * Run a ``bash`` in a Cilium and validate the following:
+ 
+   * Routing rules matching on fwmark:
+
+     .. code:: bash
+        
+        ip rule list
+        1:	from all fwmark 0xd00/0xf00 lookup 200
+        1:	from all fwmark 0xe00/0xf00 lookup 200
+        [...]
+
+   * Content of routing table 200
+   
+     .. code:: bash
+
+        ip route list table 200
+        local 10.60.0.0/24 dev cilium_vxlan proto 50 scope host
+        10.60.1.0/24 via 10.60.0.1 dev cilium_host
+
+   * XFRM policy:
+
+     .. code:: bash
+
+        ip xfrm p
+        src 10.60.1.1/24 dst 10.60.0.1/24
+                dir fwd priority 0
+                mark 0xd00/0xf00
+                tmpl src 10.60.1.1 dst 10.60.0.1
+                        proto esp spi 0x00000001 reqid 1 mode tunnel
+        src 10.60.1.1/24 dst 10.60.0.1/24
+                dir in priority 0
+                mark 0xd00/0xf00
+                tmpl src 10.60.1.1 dst 10.60.0.1
+                        proto esp spi 0x00000001 reqid 1 mode tunnel
+        src 10.60.0.1/24 dst 10.60.1.1/24
+                dir out priority 0
+                mark 0xe00/0xf00
+                tmpl src 10.60.0.1 dst 10.60.1.1
+                        proto esp spi 0x00000001 reqid 1 mode tunnel
+
+   * XFRM state:
+
+     .. code:: bash
+
+        ip xfrm s
+        src 10.60.0.1 dst 10.60.1.1
+                proto esp spi 0x00000001 reqid 1 mode tunnel
+                replay-window 0
+                auth-trunc hmac(sha256) 0x6162636465666768696a6b6c6d6e6f70717273747576777a797a414243444546 96
+                enc cbc(aes) 0x6162636465666768696a6b6c6d6e6f70717273747576777a797a414243444546
+                anti-replay context: seq 0x0, oseq 0xe0c0, bitmap 0x00000000
+                sel src 0.0.0.0/0 dst 0.0.0.0/0
+        src 10.60.1.1 dst 10.60.0.1
+                proto esp spi 0x00000001 reqid 1 mode tunnel
+                replay-window 0
+                auth-trunc hmac(sha256) 0x6162636465666768696a6b6c6d6e6f70717273747576777a797a414243444546 96
+                enc cbc(aes) 0x6162636465666768696a6b6c6d6e6f70717273747576777a797a414243444546
+                anti-replay context: seq 0x0, oseq 0x0, bitmap 0x00000000
+                sel src 0.0.0.0/0 dst 0.0.0.0/0
+
 Disabling Encryption
 ====================
 

--- a/Documentation/gettingstarted/encryption.rst
+++ b/Documentation/gettingstarted/encryption.rst
@@ -51,8 +51,8 @@ AES-CBC with HMAC-256 (hash based authentication code), but any of the supported
 Linux algorithms may be used. To generate use the following
 
 .. parsed-literal::
-  KEY1=0x`dd if=/dev/urandom count=32 bs=1 2> /dev/null| xxd -p -c 64`
-  KEY2=0x`dd if=/dev/urandom count=32 bs=1 2> /dev/null| xxd -p -c 64`
+  KEY1=0x`dd if=/dev/urandom count=16 bs=1 2> /dev/null| xxd -p -c 64`
+  KEY2=0x`dd if=/dev/urandom count=16 bs=1 2> /dev/null| xxd -p -c 64`
   echo "  keys: \\"hmac(sha256) $KEY1 cbc(aes) $KEY2\\"" >> cilium-ipsec-keys.yaml
 
 .. parsed-literal::

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -178,6 +178,7 @@ fromCIDRSet
 fromEndpoints
 frontend
 fs
+fwmark
 Gartrell
 gcc
 Geneve

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -434,7 +434,13 @@ func (n *linuxNodeHandler) enableIPsec(newNode *node.Node) {
 				ipsecLocal := &net.IPNet{IP: n.nodeAddressing.IPv4().Router(), Mask: n.nodeAddressing.IPv4().AllocationCIDR().Mask}
 				ipsecRemote := &net.IPNet{IP: ciliumInternalIPv4, Mask: newNode.IPv4AllocCIDR.Mask}
 				n.replaceNodeIPSecOutRoute(new4Net)
-				ipsec.UpsertIPSecEndpoint(ipsecLocal, ipsecRemote, linux_defaults.IPSecEndpointSPI)
+				err := ipsec.UpsertIPSecEndpoint(ipsecLocal, ipsecRemote, linux_defaults.IPSecEndpointSPI)
+				if err != nil {
+					log.WithError(err).Errorf("Upsert local %s remote %s", ipsecLocal, ipsecRemote)
+				} else {
+					log.Debugf("Upsert (success) local %s remote %s", ipsecLocal, ipsecRemote)
+				}
+
 			}
 		}
 	}


### PR DESCRIPTION
Fixes:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x25e10b2]

goroutine 1 [running]:
github.com/cilium/cilium/pkg/datapath/linux.(*linuxNodeHandler).nodeUpdate(0xc0001a8620, 0x0, 0xc000477830, 0x1, 0x4b5c160, 0x0)
	/go/src/github.com/cilium/cilium/pkg/datapath/linux/node.go:440 +0x1d2
github.com/cilium/cilium/pkg/datapath/linux.(*linuxNodeHandler).NodeConfigurationChanged(0xc0001a8620, 0x5b4, 0x582, 0x1, 0x4b5c160, 0x0, 0x0, 0x1010001000001, 0x0, 0x0)
	/go/src/github.com/cilium/cilium/pkg/datapath/linux/node.go:676 +0x1e6
main.(*Daemon).compileBase(0xc000426540, 0x0, 0x0)
	/go/src/github.com/cilium/cilium/daemon/daemon.go:541 +0x7dc
main.(*Daemon).init(0xc000426540, 0xc0011a7200, 0x1)
	/go/src/github.com/cilium/cilium/daemon/daemon.go:683 +0x126
main.NewDaemon(0x2fa09c0, 0xc00107db60, 0x1, 0x1, 0xc0008f3928, 0x1156212)
	/go/src/github.com/cilium/cilium/daemon/daemon.go:1288 +0x1557
main.runDaemon()
	/go/src/github.com/cilium/cilium/daemon/daemon_main.go:1052 +0x214
main.glob..func1(0x456a520, 0xc0007ec280, 0x0, 0x5)
	/go/src/github.com/cilium/cilium/daemon/daemon_main.go:108 +0x30
github.com/cilium/cilium/vendor/github.com/spf13/cobra.(*Command).execute(0x456a520, 0xc00004c1f0, 0x5, 0x5, 0x456a520, 0xc00004c1f0)
	/go/src/github.com/cilium/cilium/vendor/github.com/spf13/cobra/command.go:766 +0x2cc
github.com/cilium/cilium/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0x456a520, 0x2f83568, 0x2fab440, 0x2f83588)
	/go/src/github.com/cilium/cilium/vendor/github.com/spf13/cobra/command.go:852 +0x2fd
github.com/cilium/cilium/vendor/github.com/spf13/cobra.(*Command).Execute(0x456a520, 0x0, 0x0)
	/go/src/github.com/cilium/cilium/vendor/github.com/spf13/cobra/command.go:800 +0x2b
main.daemonMain()
	/go/src/github.com/cilium/cilium/daemon/daemon_main.go:126 +0x14c
main.main()
	/go/src/github.com/cilium/cilium/daemon/main.go:30 +0xc9
```

Fixes: 48961ade2cc ("cilium: ipsec, insert 'ip rules' for ipsec")

Tested on GKE with IPv6 disabled

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7040)
<!-- Reviewable:end -->
