### PR TITLE
cilium-docker-plugin: set default CMD to /usr/bin/cilium-docker

### DIFF
--- a/cilium-docker-plugin.Dockerfile
+++ b/cilium-docker-plugin.Dockerfile
@@ -9,6 +9,6 @@ RUN strip cilium-docker
 
 FROM scratch
 LABEL maintainer="maintainer@cilium.io"
-COPY --from=builder /go/src/github.com/cilium/cilium/plugins/cilium-docker /usr/bin/cilium-docker
+COPY --from=builder /go/src/github.com/cilium/cilium/plugins/cilium-docker/cilium-docker /usr/bin/cilium-docker
 WORKDIR /
-CMD ["/usr/bin/cilium-etcd-operator"]
+CMD ["/usr/bin/cilium-docker"]


### PR DESCRIPTION
Fixes: 18eb98aaac16 ("add cilium-docker-plugin Dockerfile")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7043)
<!-- Reviewable:end -->
