### PR TITLE
examples: Update docker-compose examples

### DIFF
--- a/examples/getting-started/Vagrantfile
+++ b/examples/getting-started/Vagrantfile
@@ -3,9 +3,9 @@
 
 Vagrant.require_version ">= 2.0.0"
 
-cilium_version = (ENV['CILIUM_VERSION'] || "v1.3.1")
+cilium_version = (ENV['CILIUM_VERSION'] || "v1.4.0")
 cilium_opts = (ENV['CILIUM_OPTS'] || "--kvstore consul --kvstore-opt consul.address=127.0.0.1:8500 -t vxlan")
-cilium_tag = (ENV['CILIUM_TAG'] || "v1.3.1")
+cilium_tag = (ENV['CILIUM_TAG'] || "v1.4.0")
 
 # This runs only once when vagrant box is provisioned for the first time
 $bootstrap = <<SCRIPT

--- a/examples/getting-started/docker-compose.yml
+++ b/examples/getting-started/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - /var/run/cilium:/var/run/cilium
       - /run/docker/plugins:/run/docker/plugins
       - /sys/fs/bpf:/sys/fs/bpf
+      - /var/run/docker/netns:/var/run/docker/netns:rshared
     network_mode: "host"
     cap_add:
       - "NET_ADMIN"
@@ -18,7 +19,7 @@ services:
 
   cilium_docker:
     container_name: cilium-docker-plugin
-    image: docker.io/cilium/cilium:${CILIUM_TAG}
+    image: docker.io/cilium/docker-plugin:${CILIUM_TAG}
     command: cilium-docker
     volumes:
       - /var/run/cilium:/var/run/cilium


### PR DESCRIPTION
- Bump cilium to v1.4.0.
- Use cilium/docker-plugin image for the libnetwork plugin, as we no longer ship the plugin within the cilium/cilium image.
- Add the new bind mount required for the ipvlan mode to work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7045)
<!-- Reviewable:end -->
