### PR TITLE
docs: Add ipvlan-based datapath limitations and requirements

### DIFF
--- a/Documentation/gettingstarted/ipvlan.rst
+++ b/Documentation/gettingstarted/ipvlan.rst
@@ -18,6 +18,20 @@ datapath instead of the default veth-based one.
     This is a beta feature. Please provide feedback and file a GitHub issue if
     you experience any problems.
 
+    The feature lacks support of the following, which will be resolved in
+    upcoming Cilium releases:
+
+    - IPVLAN L2 mode
+    - L7 policy enforcement
+    - NAT64
+    - IPVLAN with tunneling
+
+.. note::
+
+   The ipvlan-based datapath in L3 mode requires v4.12 or more recent Linux
+   kernel, while L3S mode, in addition, requires a stable kernel with the fix
+   mentioned in this document (see below).
+
 First step is to download the Cilium Kubernetes descriptor:
 
 .. tabs::


### PR DESCRIPTION
The >= v4.12 requirement is due to the `BPF_MAP_GET_FD_BY_ID` feature.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7047)
<!-- Reviewable:end -->
