### PR TITLE
cilium-docker-plugin: set default CMD to /usr/bin/cilium-docker

### DIFF
--- a/cilium-docker-plugin.Dockerfile
+++ b/cilium-docker-plugin.Dockerfile
@@ -9,6 +9,6 @@ RUN strip cilium-docker
 
 FROM scratch
 LABEL maintainer="maintainer@cilium.io"
-COPY --from=builder /go/src/github.com/cilium/cilium/plugins/cilium-docker /usr/bin/cilium-docker
+COPY --from=builder /go/src/github.com/cilium/cilium/plugins/cilium-docker/cilium-docker /usr/bin/cilium-docker
 WORKDIR /
-CMD ["/usr/bin/cilium-etcd-operator"]
+CMD ["/usr/bin/cilium-docker"]


### PR DESCRIPTION
[ upstream commit 084674e4cd84a7c76f28fba404ee340b8bc74d95 ]

Fixes: 18eb98aaac16 ("add cilium-docker-plugin Dockerfile")
Reported-by: Chanwit Kaewkasi <chanwit@gmail.com>
Signed-off-by: André Martins <andre@cilium.io>
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7049)
<!-- Reviewable:end -->
