### PR TITLE
cilium-operator.Dockerfile: set `klog` logging values from cilium-operator

### DIFF
--- a/operator/main.go
+++ b/operator/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"k8s.io/klog"
 )
 
 var (
@@ -110,6 +111,15 @@ func init() {
 	option.BindEnv(option.DisableCiliumEndpointCRDName)
 
 	viper.BindPFlags(flags)
+
+	// Make sure that klog logging variables are initialized so that we can
+	// update them from this file.
+	klog.InitFlags(nil)
+
+	// Make sure klog (used by the client-go dependency) logs to stderr, as it
+	// will try to log to directories that may not exist in the cilium-operator
+	// container (/tmp) and cause the cilium-operator to exit.
+	flag.Set("logtostderr", "true")
 }
 
 // initConfig reads in config file and ENV variables if set.
@@ -129,11 +139,6 @@ func initConfig() {
 
 func runOperator(cmd *cobra.Command) {
 	logging.SetupLogging([]string{}, map[string]string{}, "cilium-operator", viper.GetBool("debug"))
-
-	// Make sure glog (used by the client-go dependency) logs to stderr, as it
-	// will try to log to directories that may not exist in the cilium-operator
-	// container and cause the cilium-operator to exit.
-	flag.Set("logtostderr", "true")
 
 	log.Infof("Cilium Operator %s", version.Version)
 


### PR DESCRIPTION
`klog`, which is used by the Kubernetes libraries consumed by `cilium-operator`,
always tries to log to a file in `/tmp`. Since the `cilium-operator` container
image is built off of `scratch`, such a directory does not exist. If the
directory does not exist, `klog` exits and causes `cilium-operator` to crash.
To not crash, do not log to any directories, and instead set the `logtostderr`
value within `klog` to `true` so that it does not log to a directory.

Fixes: #7006

Signed-off by: Ian Vernon <ian@cilium.io>

I've deployed an image with this fix on a cluster which was hitting this problem frequently, so I am waiting until that image does not crash after some time to establish whether this hack really works.

I manually tested that this behavior does not cause crashes if the directory being logged to does not exist here: 
https://github.com/cilium/cilium/pull/7050#issuecomment-463324944 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7050)
<!-- Reviewable:end -->
