### PR TITLE
Fix bug where stale endpoint config maps would not be cleared

### DIFF
--- a/pkg/datapath/maps/map.go
+++ b/pkg/datapath/maps/map.go
@@ -92,7 +92,10 @@ func staleMapWalker(path string) error {
 
 	mapPrefix := []string{
 		policymap.MapName,
-		ctmap.MapNamePrefix,
+		ctmap.MapNameTCP6,
+		ctmap.MapNameTCP4,
+		ctmap.MapNameAny6,
+		ctmap.MapNameAny4,
 		endpoint.CallsMapName,
 		bpfconfig.MapNamePrefix,
 	}

--- a/pkg/datapath/maps/map.go
+++ b/pkg/datapath/maps/map.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	bpfconfig "github.com/cilium/cilium/pkg/maps/configmap"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/option"
@@ -93,6 +94,7 @@ func staleMapWalker(path string) error {
 		policymap.MapName,
 		ctmap.MapNamePrefix,
 		endpoint.CallsMapName,
+		bpfconfig.MapNamePrefix,
 	}
 
 	checkStaleGlobalMap(path, filename)


### PR DESCRIPTION
When we walk the maps pinned to the filesystem to remove maps
corresponding to endpoints that no longer exist, also walk the config
maps.

For local CT maps, ensure they are properly walked too (less likely).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7054)
<!-- Reviewable:end -->
