### PR TITLE
FQDN: Set always a empty ToCIDRSet in case of no entries in cache.

### DIFF
--- a/pkg/fqdn/helpers.go
+++ b/pkg/fqdn/helpers.go
@@ -105,12 +105,12 @@ func injectToCIDRSetRules(rule *api.Rule, cache *DNSCache, reMap *regexpmap.Rege
 					allIPs = append(allIPs, ips...)
 				}
 			}
-		}
 
-		// Only overwrite ToCIDRSet for rules with FQDN elements
-		if len(allIPs) > 0 {
+			// Always set the ToCIDRSet, in case that there are no IPs will be
+			// empty to clean old entries in case of TTL expires.
 			egressRule.ToCIDRSet = api.IPsToCIDRRules(ip.KeepUniqueIPs(allIPs))
 		}
+
 	}
 
 	for dnsName := range missing {

--- a/pkg/fqdn/helpers_test.go
+++ b/pkg/fqdn/helpers_test.go
@@ -17,7 +17,11 @@
 package fqdn
 
 import (
+	"net"
+
 	"github.com/cilium/cilium/pkg/checker"
+	"github.com/cilium/cilium/pkg/fqdn/regexpmap"
+	"github.com/cilium/cilium/pkg/policy/api"
 	. "gopkg.in/check.v1"
 )
 
@@ -36,4 +40,64 @@ func (ds *DNSCacheTestSuite) TestKeepUniqueNames(c *C) {
 		val := KeepUniqueNames(item.argument)
 		c.Assert(val, checker.DeepEquals, item.expected)
 	}
+}
+
+func (ds *DNSCacheTestSuite) TestInjectCIDRSetRulesWithOtherCIDRSet(c *C) {
+	// Validate that if empty cache the ToCidrRule is always empty
+	rule := makeRule("cilium.io", "cilium.io")
+	cache := NewDNSCache()
+	cache.Update(now, "cilium.io.", []net.IP{net.ParseIP("1.1.1.1")}, 1)
+	rule.Egress = append(rule.Egress, api.EgressRule{
+		ToCIDRSet: api.IPsToCIDRRules([]net.IP{net.ParseIP("4.4.4.4")})})
+
+	injectToCIDRSetRules(rule, cache, nil)
+	c.Assert(rule.Egress[0].ToCIDRSet, HasLen, 1)
+	c.Assert(rule.Egress[1].ToCIDRSet, HasLen, 1)
+}
+
+func (ds *DNSCacheTestSuite) TestInjectCIDRSetRulesInvalidCache(c *C) {
+	// Validate that if empty cache the ToCidrRule is always empty
+	rule := makeRule("cilium.io", "cilium.io")
+	EmptyCache := NewDNSCache()
+	injectToCIDRSetRules(rule, EmptyCache, nil)
+	c.Assert(rule.Egress[0].ToCIDRSet, HasLen, 0)
+
+	// Validate that if empty cache the ToCidrRule is cleared correctly
+	rule.Egress[0].ToCIDRSet = api.IPsToCIDRRules([]net.IP{net.ParseIP("1.1.1.1")})
+	c.Assert(rule.Egress[0].ToCIDRSet, HasLen, 1)
+	injectToCIDRSetRules(rule, EmptyCache, nil)
+	c.Assert(rule.Egress[0].ToCIDRSet, HasLen, 0)
+}
+
+func (ds *DNSCacheTestSuite) TestInjectCIDRSetRulesByMatchName(c *C) {
+	rule := makeRule("cilium.io", "cilium.io")
+	cache := NewDNSCache()
+	cache.Update(now, "cilium.io.", []net.IP{net.ParseIP("1.1.1.1")}, 1)
+
+	injectToCIDRSetRules(rule, cache, nil)
+	c.Assert(rule.Egress[0].ToCIDRSet, HasLen, 1)
+}
+
+func (ds *DNSCacheTestSuite) TestInjectCIDRSetRulesByMatchPattern(c *C) {
+
+	rule := makeRule("cilium.io")
+	rule.Egress[0].ToFQDNs = api.FQDNSelectorSlice{
+		{MatchPattern: "cilium.io"},
+	}
+	cache := NewDNSCache()
+	cache.Update(now, "cilium.io.", []net.IP{net.ParseIP("1.1.1.1")}, 1)
+	reg := regexpmap.NewRegexpMap()
+	reg.Add("cilium.io", "cilium.io")
+
+	injectToCIDRSetRules(rule, cache, reg)
+	c.Assert(rule.Egress[0].ToCIDRSet, HasLen, 1)
+
+	rule = makeRule("cilium.io")
+	rule.Egress[0].ToFQDNs = api.FQDNSelectorSlice{
+		{MatchPattern: "ciliumtest.io"},
+	}
+
+	injectToCIDRSetRules(rule, cache, reg)
+	c.Assert(rule.Egress[0].ToCIDRSet, HasLen, 0)
+
 }


### PR DESCRIPTION
If the cache is empty due TTL expiration, the ToCIDR keeps with the same
data as before and invalid policies can be in place.

This commits make sure that all ToCIDRS are reset if no IPs returned.
Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7065)
<!-- Reviewable:end -->
