### PR TITLE
Clean up stale ipvlan maps

### DIFF
--- a/pkg/datapath/maps/map.go
+++ b/pkg/datapath/maps/map.go
@@ -90,6 +90,7 @@ func staleMapWalker(path string) error {
 		ctmap.MapNameAny4,
 		endpoint.CallsMapName,
 		bpfconfig.MapNamePrefix,
+		endpoint.IpvlanMapName,
 	}
 
 	checkStaleGlobalMap(path, filename)


### PR DESCRIPTION
When endpoints are not restored, we need to sweep the maps dir for
ipvlan maps and remove them.

Fixes: #7066
Fixes: 3144e8e1e557 ("cilium, ipvlan: prefix entry tail call map with cilium")

Similar to #7054 , but for ipvlan maps.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7067)
<!-- Reviewable:end -->
