### PR TITLE
test: Bump ubuntu-next to v9

### DIFF
--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -10,7 +10,7 @@ $NFS = ENV['NFS']=="1"? true : false
 $SERVER_BOX = (ENV['SERVER_BOX'] || "cilium/ubuntu-dev")
 $SERVER_VERSION= "126"
 $NETNEXT_SERVER_BOX= "cilium/ubuntu-next"
-$NETNEXT_SERVER_VERSION= "6"
+$NETNEXT_SERVER_VERSION= "10"
 $IPv6=(ENV['IPv6'] || "0")
 $CONTAINER_RUNTIME=(ENV['CONTAINER_RUNTIME'] || "docker")
 $CNI_INTEGRATION=(ENV['CNI_INTEGRATION'] || "")


### PR DESCRIPTION
The ubuntu-next was built a day ago: https://app.vagrantup.com/cilium/boxes/ubuntu-next/versions/9.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7075)
<!-- Reviewable:end -->
