### PR TITLE
[fixup] fqdn: No warning when toFQDNs are missing IPs when generating

### DIFF
--- a/pkg/fqdn/rulegen.go
+++ b/pkg/fqdn/rulegen.go
@@ -248,7 +248,7 @@ func (gen *RuleGen) UpdateGenerateDNS(lookupTime time.Time, updatedDNSIPs map[st
 	generatedRules, namesMissingIPs := gen.GenerateRulesFromSources(rulesToUpdate)
 	if len(namesMissingIPs) != 0 {
 		log.WithField(logfields.DNSName, strings.Join(namesMissingIPs, ",")).
-			Warn("Missing IPs for ToFQDN rule")
+			Debug("No IPs to insert when generating DNS name selected by ToFQDN rule")
 	}
 
 	// no new rules to add, do not call AddGeneratedRules below


### PR DESCRIPTION
This was missing from https://github.com/cilium/cilium/pull/6827 and the
code-path fixed in this commit is the more common one.

With the DNS poller a matchName without IP data was a sign that polling
had failed for that name (the regeneration was triggered after the
poll). As we switch to the DNS proxy this makes less sense since as each
DNS lookup will trigger a regeneration and some matchName entries may
not match. A debug print is useful but anything more is unnecessary.

Fixes 3775d8d357bc2ce673089639cad677c796a9027b

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7078)
<!-- Reviewable:end -->
