### PR TITLE
FQDN: Add expired by name function.

### DIFF
--- a/daemon/fqdn.go
+++ b/daemon/fqdn.go
@@ -140,11 +140,7 @@ func (d *Daemon) bootstrapFQDN(restoredEndpoints *endpointRestoreState, preCache
 
 			//Before doing the loop the DNS names to clean will be removed from
 			//cfg.Cache, to make sure that data is persistant across cache.
-			namesRegex, err := regexp.Compile("^" + strings.Join(namesToClean, ".?|") + "$")
-			if err != nil {
-				return err
-			}
-			cfg.Cache.ForceExpire(time.Now(), namesRegex)
+			cfg.Cache.ForceExpireByNames(time.Now(), namesToClean)
 
 			// A second loop is needed to update the global cache from the
 			// endpoints cache. Looping this way is generally safe despite not


### PR DESCRIPTION
Added a new function to avoid the use of regexp in the FQDN garbage
controller.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7079)
<!-- Reviewable:end -->
