### PR TITLE
godep: add klog to gopkg.lock

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1861,6 +1861,7 @@
     "k8s.io/code-generator/cmd/client-gen",
     "k8s.io/gengo/examples/deepcopy-gen/generators",
     "k8s.io/gengo/examples/defaulter-gen/generators",
+    "k8s.io/klog",
     "k8s.io/kubernetes/pkg/apis/core",
     "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2",
     "k8s.io/kubernetes/pkg/kubelet/types",


### PR DESCRIPTION
Fixes: eee2e8da8503 ("cilium-operator.Dockerfile: set `klog` logging values from cilium-operator")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7081)
<!-- Reviewable:end -->
