### PR TITLE
examples: Fix docker-compose mount points

### DIFF
--- a/examples/getting-started/docker-compose.yml
+++ b/examples/getting-started/docker-compose.yml
@@ -7,9 +7,11 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /var/run/cilium:/var/run/cilium
-      - /run/docker/plugins:/run/docker/plugins
       - /sys/fs/bpf:/sys/fs/bpf
+      # To access Docker container netns:
       - /var/run/docker/netns:/var/run/docker/netns:rshared
+      # To create named netns for cilium-health endpoint:
+      - /var/run/netns:/var/run/netns:rshared
     network_mode: "host"
     cap_add:
       - "NET_ADMIN"


### PR DESCRIPTION
- Add `/var/run/netns` which is needed for named netns of cilium-health ep.
- Document netns related mounts.
- Remove unnecessary `/run/docker/plugins` mount from cilium-agent container, as cilium agent does not need to access any plugin socket.

NOTE: we use `rshared` mount propagation for netns related mounts to prevent from possibly leaking netns. See for more details: https://github.com/moby/moby/issues/32090.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7082)
<!-- Reviewable:end -->
