### PR TITLE
Misc loader benchmark improvements

### DIFF
--- a/pkg/datapath/loader/loader_test.go
+++ b/pkg/datapath/loader/loader_test.go
@@ -37,6 +37,7 @@ type LoaderTestSuite struct{}
 var (
 	_              = Suite(&LoaderTestSuite{})
 	contextTimeout = 10 * time.Second
+	benchTimeout   = 5*time.Minute + 5*time.Second
 
 	dirInfo *directoryInfo
 	ep      = testutils.NewTestEndpoint()
@@ -190,7 +191,7 @@ func (s *LoaderTestSuite) TestCompileFailure(c *C) {
 
 // BenchmarkCompileOnly benchmarks the just the entire compilation process.
 func BenchmarkCompileOnly(b *testing.B) {
-	ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), benchTimeout)
 	defer cancel()
 
 	b.ResetTimer()
@@ -204,7 +205,7 @@ func BenchmarkCompileOnly(b *testing.B) {
 
 // BenchmarkCompileAndLoad benchmarks the entire compilation + loading process.
 func BenchmarkCompileAndLoad(b *testing.B) {
-	ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), benchTimeout)
 	defer cancel()
 
 	b.ResetTimer()
@@ -218,7 +219,7 @@ func BenchmarkCompileAndLoad(b *testing.B) {
 // BenchmarkReplaceDatapath compiles the datapath program, then benchmarks only
 // the loading of the program into the kernel.
 func BenchmarkReplaceDatapath(b *testing.B) {
-	ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), benchTimeout)
 	defer cancel()
 
 	if err := compileDatapath(ctx, &ep, dirInfo, false); err != nil {

--- a/pkg/datapath/loader/loader_test.go
+++ b/pkg/datapath/loader/loader_test.go
@@ -188,6 +188,20 @@ func (s *LoaderTestSuite) TestCompileFailure(c *C) {
 	c.Assert(err, NotNil)
 }
 
+// BenchmarkCompileOnly benchmarks the just the entire compilation process.
+func BenchmarkCompileOnly(b *testing.B) {
+	ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
+	defer cancel()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		debug := false // Otherwise we compile lots more.
+		if err := compileDatapath(ctx, &ep, dirInfo, debug); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 // BenchmarkCompileAndLoad benchmarks the entire compilation + loading process.
 func BenchmarkCompileAndLoad(b *testing.B) {
 	ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)


### PR DESCRIPTION
* Add a benchmark for only compiling
* Update the benchmark context timeout to allow longer benchmark runs

These changes only affect benchmarks, so I haven't run CI. I manually tested them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7090)
<!-- Reviewable:end -->
