### PR TITLE
Makefile improvements for benchmarking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ clean-jenkins-precheck:
 
 TEST_LDFLAGS=-ldflags "-X github.com/cilium/cilium/pkg/kvstore.consulDummyAddress=https://consul:8443 -X github.com/cilium/cilium/pkg/kvstore.etcdDummyAddress=http://etcd:4002"
 
-PRIV_TEST_PKGS = $(shell grep --include='*.go' -ril '+build privileged_tests' | xargs dirname | sort | uniq)
+PRIV_TEST_PKGS ?= $(shell grep --include='*.go' -ril '+build privileged_tests' | xargs dirname | sort | uniq)
 tests-privileged:
 	# cilium-map-migrate is a dependency of some unit tests.
 	$(MAKE) -C bpf cilium-map-migrate

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ SUBDIRS_CILIUM_CONTAINER += plugins/cilium-docker
 endif
 SUBDIRS = $(SUBDIRS_CILIUM_CONTAINER) operator plugins tools
 GOFILES ?= $(subst _$(ROOT_DIR)/,,$(shell $(GO) list ./... | grep -v -e /vendor/ -e /contrib/))
-TESTPKGS ?= $(subst _$(ROOT_DIR)/,,$(shell $(GO) list ./... | grep -v -e /api/v1 -e /vendor/ -e /contrib/ -e test))
+TESTPKGS ?= $(subst github.com/cilium/cilium/,,$(shell $(GO) list ./... | grep -v -e /api/v1 -e /vendor/ -e /contrib/ -e test))
 GOLANGVERSION = $(shell $(GO) version 2>/dev/null | grep -Eo '(go[0-9].[0-9])')
 GOLANG_SRCFILES=$(shell for pkg in $(subst github.com/cilium/cilium/,,$(GOFILES)); do find $$pkg -name *.go -print; done | grep -v vendor)
 BPF_FILES ?= $(shell git ls-files ../bpf/ | tr "\n" ' ')
@@ -105,7 +105,7 @@ unit-tests: start-kvstores
 	$(QUIET) $(MAKE) -C daemon/ check-bindata
 	$(QUIET) echo "mode: count" > coverage-all-tmp.out
 	$(QUIET) echo "mode: count" > coverage.out
-	$(QUIET)$(foreach pkg,$(TESTPKGS),\
+	$(QUIET)$(foreach pkg,$(patsubst %,github.com/cilium/cilium/%,$(TESTPKGS)),\
 		$(GO) test $(TEST_UNITTEST_LDFLAGS) $(pkg) $(GOTEST_BASE) $(GOTEST_COVER_OPTS) || exit 1; \
 		tail -n +2 coverage.out >> coverage-all-tmp.out;)
 	$(MAKE) generate-cov

--- a/contrib/shell/test.sh
+++ b/contrib/shell/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2017 Authors of Cilium
+# Copyright 2017-2019 Authors of Cilium
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -59,7 +59,7 @@ function watchtest
         echo "Cannot find 'inotifywait'. Please install inotify-tools."
         exit 1
     elif [ $# -eq 1 ]; then
-        TESTPKGS="github.com/cilium/cilium/$1" watchtest_
+        TESTPKGS="$1" watchtest_
     else
         watchtest_
     fi


### PR DESCRIPTION
* Tidy up a few things around running tests in the makefile
* Add new 'bench', 'bench-privileged' targets:

```
      $ make bench TESTPKGS=pkg/policy
      $ make bench TESTPKGS=pkg/policy BENCH=ParseLabel
      $ sudo make bench-privileged TESTPKGS=pkg/datapath/loader
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7091)
<!-- Reviewable:end -->
