### PR TITLE
agent: Add bootstrap duration metric

### DIFF
--- a/Documentation/configuration/metrics.rst
+++ b/Documentation/configuration/metrics.rst
@@ -143,6 +143,13 @@ KVstore
 * ``kvstore_operations_duration_seconds``: Duration of kvstore operation
   * Labels: ``action``, ``kind``, ``outcome``, ``scope``
 
+
+Agent
+-----
+
+* ``agent_bootstrap_seconds``: Duration of various bootstrap phases
+  * Labels: ``scope``, ``outcome``
+
 Cilium as a Kubernetes pod
 ==========================
 The Cilium Prometheus reference configuration configures jobs that automatically

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -980,6 +980,7 @@ func (d *Daemon) prepareAllocationCIDR(family datapath.NodeAddressingFamily) (ro
 
 // NewDaemon creates and returns a new Daemon with the parameters set in c.
 func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
+	bootstrapStats.daemonInit.Start()
 	// Validate the daemon-specific global options.
 	if err := option.Config.Validate(); err != nil {
 		return nil, nil, fmt.Errorf("invalid daemon configuration: %s", err)
@@ -1017,9 +1018,13 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 		datapath:         dp,
 		nodeDiscovery:    newNodeDiscovery(nodeMngr, mtuConfig),
 	}
+	bootstrapStats.daemonInit.End(true)
 
 	// Open or create BPF maps.
-	if err := d.initMaps(); err != nil {
+	bootstrapStats.mapsInit.Start()
+	err = d.initMaps()
+	bootstrapStats.mapsInit.EndError(err)
+	if err != nil {
 		log.WithError(err).Error("Error while opening/creating BPF maps")
 		return nil, nil, err
 	}
@@ -1030,7 +1035,9 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 	// not changing across restarts or that a new service could accidentally
 	// use an existing service ID.
 	if option.Config.RestoreState {
+		bootstrapStats.restore.Start()
 		restoreServiceIDs()
+		bootstrapStats.restore.End(true)
 	}
 
 	t, err := trigger.NewTrigger(trigger.Parameters{
@@ -1046,20 +1053,27 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 
 	debug.RegisterStatusObject("k8s-service-cache", &d.k8sSvcCache)
 
+	bootstrapStats.k8sInit.Start()
 	k8s.Configure(option.Config.K8sAPIServer, option.Config.K8sKubeConfigPath)
+	bootstrapStats.k8sInit.End(true)
 	d.runK8sServiceHandler()
 	policyApi.InitEntities(option.Config.ClusterName)
 
+	bootstrapStats.workloadsInit.Start()
 	workloads.Init(&d)
+	bootstrapStats.workloadsInit.End(true)
 
+	bootstrapStats.cleanup.Start()
 	// Clear previous leftovers before listening for new requests
 	log.Info("Clearing leftover Cilium veths")
 	err = d.clearCiliumVeths()
+	bootstrapStats.cleanup.EndError(err)
 	if err != nil {
 		log.WithError(err).Debug("Unable to clean leftover veths")
 	}
 
 	if k8s.IsEnabled() {
+		bootstrapStats.k8sInit.Start()
 		if err := k8s.Init(); err != nil {
 			log.WithError(err).Fatal("Unable to initialize Kubernetes subsystem")
 		}
@@ -1089,6 +1103,7 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 
 		// Inject K8s dependency into packages which need to annotate K8s resources.
 		endpoint.EpAnnotator = k8s.Client()
+		bootstrapStats.k8sInit.End(true)
 	}
 
 	// If the device has been specified, the IPv4AllocPrefix and the
@@ -1103,6 +1118,7 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 	//
 	// Then, we will calculate the IPv4 or IPv6 alloc prefix based on the IPv6
 	// or IPv4 alloc prefix, respectively, retrieved by k8s node annotations.
+	bootstrapStats.ipam.Start()
 	log.Info("Initializing node addressing")
 
 	if err := node.AutoComplete(); err != nil {
@@ -1136,8 +1152,10 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 		EnableIPv4: option.Config.EnableIPv4,
 		EnableIPv6: option.Config.EnableIPv6,
 	})
+	bootstrapStats.ipam.End(true)
 
 	if option.Config.WorkloadsEnabled() {
+		bootstrapStats.workloadsInit.Start()
 		// workaround for to use the values of the deprecated dockerEndpoint
 		// variable if it is set with a different value than defaults.
 		defaultDockerEndpoint := workloads.GetRuntimeDefaultOpt(workloads.Docker, "endpoint")
@@ -1164,8 +1182,10 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 		}
 
 		log.Infof("Container runtime options set: %s", workloads.GetRuntimeOptions())
+		bootstrapStats.workloadsInit.End(true)
 	}
 
+	bootstrapStats.restore.Start()
 	// restore endpoints before any IPs are allocated to avoid eventual IP
 	// conflicts later on, otherwise any IP conflict will result in the
 	// endpoint not being able to be restored.
@@ -1173,7 +1193,9 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 	if err != nil {
 		log.WithError(err).Error("Unable to restore existing endpoints")
 	}
+	bootstrapStats.restore.End(true)
 
+	bootstrapStats.ipam.Start()
 	if option.Config.EnableIPv4 {
 		routerIP, err := d.prepareAllocationCIDR(dp.LocalNodeAddressing().IPv4())
 		if err != nil {
@@ -1220,7 +1242,9 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 		node.SetIPv4Loopback(loopbackIPv4)
 		log.Infof("  Loopback IPv4: %s", node.GetIPv4Loopback().String())
 	}
+	bootstrapStats.ipam.End(true)
 
+	bootstrapStats.healthCheck.Start()
 	if option.Config.EnableHealthChecking {
 		if option.Config.EnableIPv4 {
 			health4, err := d.ipam.AllocateNextFamily(ipam.IPv4)
@@ -1245,10 +1269,12 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 			log.Debugf("IPv6 health endpoint address: %s", health6)
 		}
 	}
+	bootstrapStats.healthCheck.End(true)
 
 	// Annotation of the k8s node must happen after discovery of the
 	// PodCIDR range and allocation of the health IPs.
 	if k8s.IsEnabled() {
+		bootstrapStats.k8sInit.Start()
 		log.Info("Annotating k8s node with CIDR ranges")
 		err := k8s.Client().AnnotateNode(node.GetName(),
 			node.GetIPv4AllocRange(), node.GetIPv6NodeRange(),
@@ -1257,6 +1283,7 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 		if err != nil {
 			log.WithError(err).Warning("Cannot annotate k8s node with CIDR range")
 		}
+		bootstrapStats.k8sInit.End(true)
 	}
 
 	d.nodeDiscovery.startDiscovery()
@@ -1265,6 +1292,7 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 	// as the node address is required as suffix.
 	cache.InitIdentityAllocator(&d)
 
+	bootstrapStats.clusterMeshInit.Start()
 	if path := option.Config.ClusterMeshConfig; path != "" {
 		if option.Config.ClusterID == 0 {
 			log.Info("Cluster-ID is not specified, skipping ClusterMesh initialization")
@@ -1284,8 +1312,12 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 			d.clustermesh = clustermesh
 		}
 	}
+	bootstrapStats.clusterMeshInit.End(true)
 
-	if err = d.init(); err != nil {
+	bootstrapStats.bpfBase.Start()
+	err = d.init()
+	bootstrapStats.bpfBase.EndError(err)
+	if err != nil {
 		log.WithError(err).Error("Error while initializing daemon")
 		return nil, restoredEndpoints, err
 	}
@@ -1295,18 +1327,24 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 	// we populate the IPCache with the host's IP(s).
 	ipcache.InitIPIdentityWatcher()
 
+	bootstrapStats.proxyStart.Start()
 	// FIXME: Make the port range configurable.
 	d.l7Proxy = proxy.StartProxySupport(10000, 20000, option.Config.RunDir,
 		option.Config.AccessLog, &d, option.Config.AgentLabels)
+	bootstrapStats.proxyStart.End(true)
 
+	bootstrapStats.fqdn.Start()
 	if err := fqdn.ConfigFromResolvConf(); err != nil {
+		bootstrapStats.fqdn.EndError(err)
 		return nil, nil, err
 	}
 
 	err = d.bootstrapFQDN(restoredEndpoints, option.Config.ToFQDNsPreCache)
 	if err != nil {
+		bootstrapStats.fqdn.EndError(err)
 		return nil, restoredEndpoints, err
 	}
+	bootstrapStats.fqdn.End(true)
 
 	return &d, restoredEndpoints, nil
 }

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -104,10 +104,14 @@ var (
 		Use:   "cilium-agent",
 		Short: "Run the cilium agent",
 		Run: func(cmd *cobra.Command, args []string) {
+			bootstrapStats.earlyInit.Start()
 			initEnv(cmd)
+			bootstrapStats.earlyInit.End(true)
 			runDaemon()
 		},
 	}
+
+	bootstrapStats = bootstrapStatistics{}
 )
 
 func init() {
@@ -115,6 +119,7 @@ func init() {
 }
 
 func daemonMain() {
+	bootstrapStats.overall.Start()
 
 	// Open socket for using gops to get stacktraces of the agent.
 	if err := gops.Listen(gops.Options{}); err != nil {
@@ -1087,18 +1092,23 @@ func runDaemon() {
 		})
 	}
 
+	bootstrapStats.enableConntrack.Start()
 	log.Info("Starting connection tracking garbage collector")
 	endpointmanager.EnableConntrackGC(option.Config.EnableIPv4, option.Config.EnableIPv6,
 		option.Config.ConntrackGarbageCollectorInterval,
 		restoredEndpoints.restored)
+	bootstrapStats.enableConntrack.End(true)
 
 	endpointmanager.EndpointSynchronizer = &endpointsynchronizer.EndpointSynchronizer{}
 
 	log.Info("Launching node monitor daemon")
 	go d.nodeMonitor.Run(path.Join(defaults.RuntimePath, defaults.EventsPipe), bpf.GetMapRoot())
 
+	bootstrapStats.k8sInit.Start()
 	d.initK8sSubsystem()
+	bootstrapStats.k8sInit.End(true)
 
+	bootstrapStats.restore.Start()
 	if option.Config.RestoreState {
 		// When we regenerate restored endpoints, it is guaranteed tha we have
 		// received the full list of policies present at the time the daemon
@@ -1133,6 +1143,7 @@ func runDaemon() {
 		// these containers from reading.
 		workloads.IgnoreRunningWorkloads()
 	}
+	bootstrapStats.restore.End(true)
 
 	if option.Config.IsFlannelMasterDeviceSet() {
 		// health checking is not supported by flannel
@@ -1148,8 +1159,10 @@ func runDaemon() {
 		}
 	}
 
+	bootstrapStats.cleanup.Start()
 	maps.CollectStaleMapGarbage()
 	maps.RemoveDisabledMaps()
+	bootstrapStats.cleanup.End(true)
 
 	// The workload event listener *must* be enabled *after* restored endpoints
 	// are added into the endpoint manager; otherwise, updates to important
@@ -1162,14 +1175,17 @@ func runDaemon() {
 		d.workloadsEventsCh = eventsCh
 	}
 
+	bootstrapStats.healthCheck.Start()
 	if option.Config.EnableHealthChecking {
 		d.initHealth()
 	}
+	bootstrapStats.healthCheck.End(true)
 
 	d.startStatusCollector()
 
 	metricsErrs := initMetrics()
 
+	bootstrapStats.initAPI.Start()
 	api := d.instantiateAPI()
 
 	server := server.NewServer(api)
@@ -1180,6 +1196,7 @@ func runDaemon() {
 	defer server.Shutdown()
 
 	server.ConfigureAPI()
+	bootstrapStats.initAPI.End(true)
 
 	repr, err := monitorAPI.TimeRepr(time.Now())
 	if err != nil {
@@ -1196,6 +1213,9 @@ func runDaemon() {
 	go func() {
 		errs <- server.Serve()
 	}()
+
+	bootstrapStats.overall.End(true)
+	bootstrapStats.updateMetrics()
 
 	select {
 	case err := <-metricsErrs:

--- a/daemon/metrics.go
+++ b/daemon/metrics.go
@@ -16,13 +16,16 @@ package main
 
 import (
 	"fmt"
+	"time"
 
 	restapi "github.com/cilium/cilium/api/v1/server/restapi/metrics"
 	"github.com/cilium/cilium/pkg/api"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/spanstat"
 
 	"github.com/go-openapi/runtime/middleware"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 type getMetrics struct {
@@ -54,4 +57,80 @@ func initMetrics() <-chan error {
 	}
 
 	return errs
+}
+
+type bootstrapStatistics struct {
+	overall         spanstat.SpanStat
+	earlyInit       spanstat.SpanStat
+	k8sInit         spanstat.SpanStat
+	restore         spanstat.SpanStat
+	healthCheck     spanstat.SpanStat
+	initAPI         spanstat.SpanStat
+	initDaemon      spanstat.SpanStat
+	cleanup         spanstat.SpanStat
+	bpfBase         spanstat.SpanStat
+	clusterMeshInit spanstat.SpanStat
+	ipam            spanstat.SpanStat
+	daemonInit      spanstat.SpanStat
+	mapsInit        spanstat.SpanStat
+	workloadsInit   spanstat.SpanStat
+	proxyStart      spanstat.SpanStat
+	fqdn            spanstat.SpanStat
+	enableConntrack spanstat.SpanStat
+}
+
+func (b *bootstrapStatistics) updateMetrics() {
+	for scope, stat := range b.getMap() {
+		if stat.SuccessTotal() != time.Duration(0) {
+			metricBootstrapTimes.WithLabelValues(scope, metrics.LabelValueOutcomeSuccess).Observe(stat.SuccessTotal().Seconds())
+		}
+		if stat.FailureTotal() != time.Duration(0) {
+			metricBootstrapTimes.WithLabelValues(scope, metrics.LabelValueOutcomeFail).Observe(stat.FailureTotal().Seconds())
+		}
+	}
+}
+
+func (b *bootstrapStatistics) getMap() map[string]*spanstat.SpanStat {
+	return map[string]*spanstat.SpanStat{
+		"overall":         &b.overall,
+		"earlyInit":       &b.earlyInit,
+		"k8sInit":         &b.k8sInit,
+		"restore":         &b.restore,
+		"healthCheck":     &b.healthCheck,
+		"initAPI":         &b.initAPI,
+		"initDaemon":      &b.initDaemon,
+		"cleanup":         &b.cleanup,
+		"bpfBase":         &b.bpfBase,
+		"clusterMeshInit": &b.clusterMeshInit,
+		"ipam":            &b.ipam,
+		"daemonInit":      &b.daemonInit,
+		"mapsInit":        &b.mapsInit,
+		"workloadsInit":   &b.workloadsInit,
+		"proxyStart":      &b.proxyStart,
+		"fqdn":            &b.fqdn,
+		"enableConntrack": &b.enableConntrack,
+	}
+}
+
+const (
+	metricSubsystem = "agent"
+
+	metricBootstrapOverall = "overall"
+)
+
+var (
+	metricBootstrapTimes *prometheus.HistogramVec
+)
+
+func init() {
+	metricBootstrapTimes = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: metrics.Namespace,
+		Subsystem: metricSubsystem,
+		Name:      "bootstrap_seconds",
+		Help:      "Duration of bootstrap sequence",
+	}, []string{metrics.LabelScope, metrics.LabelOutcome})
+
+	if err := metrics.Register(metricBootstrapTimes); err != nil {
+		log.WithError(err).Fatal("unable to register prometheus metric")
+	}
 }


### PR DESCRIPTION
This metric helps evaluate how long it takes for an agent to start serving the
API and where the time is being spent during the bootstrap phase.

Example:
```
cilium_agent_bootstrap_seconds                        outcome="success" scope="bpfBase"                                            1.451699
cilium_agent_bootstrap_seconds                        outcome="success" scope="cleanup"                                            0.001206
cilium_agent_bootstrap_seconds                        outcome="success" scope="clusterMeshInit"                                    0.000001
cilium_agent_bootstrap_seconds                        outcome="success" scope="daemonInit"                                         0.000423
cilium_agent_bootstrap_seconds                        outcome="success" scope="earlyInit"                                          1.100657
cilium_agent_bootstrap_seconds                        outcome="success" scope="enableConntrack"                                    0.021765
cilium_agent_bootstrap_seconds                        outcome="success" scope="fqdn"                                               0.000462
cilium_agent_bootstrap_seconds                        outcome="success" scope="healthCheck"                                        0.001528
cilium_agent_bootstrap_seconds                        outcome="success" scope="initAPI"                                            0.514106
cilium_agent_bootstrap_seconds                        outcome="success" scope="ipam"                                               0.001434
cilium_agent_bootstrap_seconds                        outcome="success" scope="k8sInit"                                            1.731391
cilium_agent_bootstrap_seconds                        outcome="success" scope="mapsInit"                                           0.039221
cilium_agent_bootstrap_seconds                        outcome="success" scope="overall"                                            6.491492
cilium_agent_bootstrap_seconds                        outcome="success" scope="proxyStart"                                         0.000173
cilium_agent_bootstrap_seconds                        outcome="success" scope="restore"                                            1.570109
cilium_agent_bootstrap_seconds                        scope="workloadsInit" outcome="success"                                      0.000041
```

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7093)
<!-- Reviewable:end -->
