### PR TITLE
Fix running the linux datapath node test locally

### DIFF
--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -180,6 +180,16 @@ func (m *Map) Path() (string, error) {
 	return m.path, nil
 }
 
+// Unpin attempts to unpin (remove) the map from the filesystem.
+func (m *Map) Unpin() error {
+	path, err := m.Path()
+	if err != nil {
+		return err
+	}
+
+	return os.RemoveAll(path)
+}
+
 // DeepEquals compares the current map against another map to see that the
 // attributes of the two maps are the same.
 func (m *Map) DeepEquals(other *Map) bool {

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -92,6 +92,9 @@ func (s *linuxPrivilegedBaseTestSuite) SetUpTest(c *check.C, addressing datapath
 		err = setupDummyDevice(dummyHostDeviceName)
 	}
 	c.Assert(err, check.IsNil)
+
+	_, err = tunnel.TunnelMap.OpenOrCreate()
+	c.Assert(err, check.IsNil)
 }
 
 func (s *linuxPrivilegedIPv6OnlyTestSuite) SetUpTest(c *check.C) {
@@ -112,6 +115,8 @@ func (s *linuxPrivilegedIPv4AndIPv6TestSuite) SetUpTest(c *check.C) {
 func tearDownTest(c *check.C) {
 	removeDevice(dummyHostDeviceName)
 	removeDevice(dummyExternalDeviceName)
+	err := tunnel.TunnelMap.Unpin()
+	c.Assert(err, check.IsNil)
 }
 
 func (s *linuxPrivilegedIPv6OnlyTestSuite) TearDownTest(c *check.C) {

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -93,6 +93,7 @@ func (s *linuxPrivilegedBaseTestSuite) SetUpTest(c *check.C, addressing datapath
 	}
 	c.Assert(err, check.IsNil)
 
+	tunnel.TunnelMap = tunnel.NewTunnelMap("test_cilium_tunnel_map")
 	_, err = tunnel.TunnelMap.OpenOrCreate()
 	c.Assert(err, check.IsNil)
 }

--- a/pkg/maps/tunnel/tunnel.go
+++ b/pkg/maps/tunnel/tunnel.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -32,7 +32,17 @@ const (
 
 var (
 	// TunnelMap represents the BPF map for tunnels
-	TunnelMap = &Map{Map: bpf.NewMap(MapName,
+	TunnelMap = NewTunnelMap(MapName)
+)
+
+// Map implements tunnel connectivity configuration in the BPF datapath.
+type Map struct {
+	*bpf.Map
+}
+
+// NewTunnelMap returns a new tunnel map with the specified name.
+func NewTunnelMap(name string) *Map {
+	return &Map{Map: bpf.NewMap(MapName,
 		bpf.MapTypeHash,
 		int(unsafe.Sizeof(tunnelEndpoint{})),
 		int(unsafe.Sizeof(tunnelEndpoint{})),
@@ -48,11 +58,6 @@ var (
 			return &k, &v, nil
 		}).WithCache(),
 	}
-)
-
-// Map implements tunnel connectivity configuration in the BPF datapath.
-type Map struct {
-	*bpf.Map
 }
 
 func init() {


### PR DESCRIPTION
Fix privileged testsuite failures when running the linux datapath node tests locally by creating a tunnel map with a unique name during test setup, and cleaning it up afterwards.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7094)
<!-- Reviewable:end -->
