### PR TITLE
Ginkgo: Do not return test names with *

### DIFF
--- a/test/ginkgo-ext/scopes.go
+++ b/test/ginkgo-ext/scopes.go
@@ -137,6 +137,7 @@ func GinkgoPrint(message string, optionalValues ...interface{}) {
 func GetTestName() string {
 	testDesc := ginkgo.CurrentGinkgoTestDescription()
 	name := strings.Replace(testDesc.FullTestText, " ", "_", -1)
+	name = strings.Trim(name, "*")
 	return strings.Replace(name, "/", "-", -1)
 }
 


### PR DESCRIPTION
To avoid issues on creating test reports and folders, delete the * from
the test names to avoid issues on gather logs

Current issue:
```
Time="2019-02-14T14:22:30Z" level=error msg="Error running bugtool: Failed to create debug directory stat /home/vagrant/go/src/github.com/cilium/cilium/test/test_results/RuntimeFQDNPolicies_Implements_matchPattern:_*: no such file or directory\n
```

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7104)
<!-- Reviewable:end -->
