### PR TITLE
[ignore] try longer curl timeouts

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -142,14 +142,14 @@ const (
 
 	// CurlConnectTimeout is the timeout for the connect() call that curl
 	// invokes
-	CurlConnectTimeout = 5
+	CurlConnectTimeout = 10
 
 	// CurlMaxTimeout is the hard timeout. It starts when curl is invoked
 	// and interrupts curl regardless of whether curl is currently
 	// connecting or transferring data. CurlMaxTimeout should be at least 5
 	// seconds longer than CurlConnectTimeout to provide some time to
 	// actually transfer data.
-	CurlMaxTimeout = 8
+	CurlMaxTimeout = CurlConnectTimeout + 3
 
 	DefaultNamespace    = "default"
 	KubeSystemNamespace = "kube-system"


### PR DESCRIPTION
I'm trying this out to see how often we flake. I'll run tests over and over. The timeout that fails in `runtime.RuntimeFQDNPolicies Implements matchPattern: "*"` has been doubled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7107)
<!-- Reviewable:end -->
