### PR TITLE
api/v1: add metrics for each API call made to the cilium-agent

### DIFF
--- a/Documentation/configuration/metrics.rst
+++ b/Documentation/configuration/metrics.rst
@@ -149,6 +149,8 @@ Agent
 
 * ``agent_bootstrap_seconds``: Duration of various bootstrap phases
   * Labels: ``scope``, ``outcome``
+* ``api_process_time_seconds``: Processing time of all the API calls made to the
+  cilium-agent, labeled by API method, API path and returned HTTP code.
 
 Cilium as a Kubernetes pod
 ==========================

--- a/api/v1/server/configure_cilium.go
+++ b/api/v1/server/configure_cilium.go
@@ -61,8 +61,9 @@ func setupMiddlewares(handler http.Handler) http.Handler {
 // So this is a good place to plug in a panic handling middleware, logging and metrics
 func setupGlobalMiddleware(handler http.Handler) http.Handler {
 	eventsHelper := &metrics.APIEventTSHelper{
-		Next:    handler,
-		TSGauge: metrics.EventTSAPI,
+		Next:      handler,
+		TSGauge:   metrics.EventTSAPI,
+		Histogram: metrics.APIInteractions,
 	}
 
 	return &api.APIPanicHandler{

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -67,6 +67,9 @@ var (
 	// the datapath. It is prepended to metric names and separated with a '_'.
 	Datapath = "datapath"
 
+	// Agent is the subsystem to cope metrics related to the cilium agent itself.
+	Agent = "agent"
+
 	// LabelOutcome indicates whether the outcome of the operation was successful or not
 	LabelOutcome = "outcome"
 
@@ -130,6 +133,26 @@ var (
 
 	// LabelKind is the kind a label
 	LabelKind = "kind"
+
+	// LabelPath is the label for the API path
+	LabelPath = "path"
+
+	// LabelMethod is the label for the HTTP method
+	LabelMethod = "method"
+
+	// LabelAPIReturnCode is the HTTP code returned for that API path
+	LabelAPIReturnCode = "return_code"
+
+	// API interactions
+
+	// APIInteractions is the total time taken to process an API call made
+	// to the cilium-agent
+	APIInteractions = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: Namespace,
+		Subsystem: Agent,
+		Name:      "api_process_time_seconds",
+		Help:      "Duration of processed API calls labeled by path, method and return code.",
+	}, []string{LabelPath, LabelMethod, LabelAPIReturnCode})
 
 	// Endpoint
 
@@ -493,6 +516,7 @@ func init() {
 	MustRegister(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{Namespace: Namespace}))
 	// TODO: Figure out how to put this into a Namespace
 	//MustRegister(prometheus.NewGoCollector())
+	MustRegister(APIInteractions)
 
 	MustRegister(EndpointCountRegenerating)
 	MustRegister(EndpointRegenerationCount)

--- a/pkg/metrics/middleware.go
+++ b/pkg/metrics/middleware.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Authors of Cilium
+// Copyright 2017-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,10 @@ package metrics
 
 import (
 	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/cilium/cilium/pkg/spanstat"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -24,13 +28,48 @@ import (
 // around API calls.
 // It records the timestamp of an API call in the provided gauge.
 type APIEventTSHelper struct {
-	Next    http.Handler
-	TSGauge prometheus.Gauge
+	Next      http.Handler
+	TSGauge   prometheus.Gauge
+	Histogram *prometheus.HistogramVec
+}
+
+type responderWrapper struct {
+	http.ResponseWriter
+	code int
+}
+
+func (rw *responderWrapper) WriteHeader(code int) {
+	rw.code = code
+	rw.ResponseWriter.WriteHeader(code)
+}
+
+// getShortPath returns the API path trimmed after the 3rd slash.
+// examples:
+//  "/v1/config" -> "/v1/config"
+//  "/v1/endpoint/cilium-local:0" -> "/v1/endpoint"
+//  "/v1/endpoint/container-id:597.." -> "/v1/endpoint"
+func getShortPath(s string) string {
+	var idxSum int
+	for nThSlash := 0; nThSlash < 3; nThSlash++ {
+		idx := strings.IndexByte(s[idxSum:], '/')
+		if idx == -1 {
+			return s
+		}
+		idxSum += idx + 1
+	}
+	return s[:idxSum-1]
 }
 
 // ServeHTTP implements the http.Handler interface. It records the timestamp
 // this API call began at, then chains to the next handler.
 func (m *APIEventTSHelper) ServeHTTP(r http.ResponseWriter, req *http.Request) {
 	m.TSGauge.SetToCurrentTime()
-	m.Next.ServeHTTP(r, req)
+	duration := spanstat.Start()
+	rw := &responderWrapper{ResponseWriter: r}
+	m.Next.ServeHTTP(rw, req)
+	if req != nil && req.URL != nil && req.URL.Path != "" {
+		path := getShortPath(req.URL.Path)
+		took := float64(duration.End(true).Total().Seconds())
+		m.Histogram.WithLabelValues(path, req.Method, strconv.Itoa(rw.code)).Observe(took)
+	}
 }

--- a/pkg/metrics/middleware_test.go
+++ b/pkg/metrics/middleware_test.go
@@ -1,0 +1,144 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package metrics
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type MetricsSuite struct{}
+
+var _ = Suite(&MetricsSuite{})
+
+func (s *MetricsSuite) Test_getShortPath(c *C) {
+	tests := []struct {
+		args string
+		want string
+	}{
+		{
+			args: "/v1/config",
+			want: "/v1/config",
+		},
+		{
+			args: "/v1/endpoint/cilium-local:0",
+			want: "/v1/endpoint",
+		},
+		{
+			args: "/v1/endpoint/container-id:597b3583727d51206d0a08df82b484925b458ff1fc04d1a98637435b73b9b47d",
+			want: "/v1/endpoint",
+		},
+		{
+			args: "/v1/endpoint/container-id:6813916d21c3311e62078a232942504937f1b4a8b2e32e40044f188da986fe41",
+			want: "/v1/endpoint",
+		},
+		{
+			args: "/v1/endpoint/container-id:cf2c692f24933fc12d51dc0b42d92708a3c73e8f3a0f517c3ed2e7628ba57d92",
+			want: "/v1/endpoint",
+		},
+		{
+			args: "/v1/healthz",
+			want: "/v1/healthz",
+		},
+		{
+			args: "/v1/ipam",
+			want: "/v1/ipam",
+		},
+		{
+			args: "/v1/ipam/10.16.11.109",
+			want: "/v1/ipam",
+		},
+		{
+			args: "/v1/ipam/10.16.169.230",
+			want: "/v1/ipam",
+		},
+		{
+			args: "/v1/ipam/10.16.69.17",
+			want: "/v1/ipam",
+		},
+		{
+			args: "/v1/ipam/f00d::a10:0:0:2f5f",
+			want: "/v1/ipam",
+		},
+		{
+			args: "/v1/ipam/f00d::a10:0:0:9dec",
+			want: "/v1/ipam",
+		},
+		{
+			args: "/v1/ipam/f00d::a10:0:0:d5c7",
+			want: "/v1/ipam",
+		},
+		{
+			args: "/v1/ipam/f00d::a10:0:0:d5c7/hello",
+			want: "/v1/ipam",
+		},
+		{
+			args: "/v1",
+			want: "/v1",
+		},
+		{
+			args: "/////",
+			want: "//",
+		},
+		{
+			args: "//",
+			want: "//",
+		},
+		{
+			args: "/",
+			want: "/",
+		},
+		{
+			args: "hello/foo/bar/",
+			want: "hello/foo/bar",
+		},
+		{
+			args: "hello/foo//",
+			want: "hello/foo/",
+		},
+		{
+			args: "hello/foo/",
+			want: "hello/foo/",
+		},
+		{
+			args: "hello/foo",
+			want: "hello/foo",
+		},
+		{
+			args: "hello/",
+			want: "hello/",
+		},
+		{
+			args: "hello",
+			want: "hello",
+		},
+		{
+			args: "",
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		got := getShortPath(tt.args)
+		c.Assert(got, Equals, tt.want)
+	}
+}


### PR DESCRIPTION
The metrics added are in the form of an histogram vec which are scoped
by API path and returned status code.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7112)
<!-- Reviewable:end -->
