### PR TITLE
Dockerfile.runtime: Pull in custom iproute2 changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN make LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 V=$V LIBNETWORK_PLUGIN=$LIBNETWORK_PLU
 # built while allowing the new versions to make changes that are not
 # backwards compatible.
 #
-FROM quay.io/cilium/cilium-runtime:2018-11-29
+FROM cilium/cilium-runtime:2019-01-25
 LABEL maintainer="maintainer@cilium.io"
 COPY --from=builder /tmp/install /
 COPY --from=cilium-envoy / /

--- a/contrib/packaging/docker/Dockerfile.runtime
+++ b/contrib/packaging/docker/Dockerfile.runtime
@@ -47,7 +47,7 @@ strip /usr/local/clang+llvm/bin/* && \
 #
 # iproute2
 #
-git clone --depth 1 -b master git://git.kernel.org/pub/scm/network/iproute2/iproute2-next.git iproute2 && \
+git clone --depth 1 -b 4.20.0-1ubuntu0bjn2 https://github.com/joestringer/iproute2.git iproute2 && \
 cd iproute2 && \
 ./configure && \
 make -j `getconf _NPROCESSORS_ONLN` && \


### PR DESCRIPTION
Pull iproute2 from https://github.com/joestringer/iproute2/releases/tag/4.20.0-1ubuntu0bjn2 .

This facilitates #6618 by allowing static data loads from the code in #7095 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7113)
<!-- Reviewable:end -->
