### PR TITLE
Dockerfile.runtime: Pull in custom iproute2 changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN make LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 V=$V LIBNETWORK_PLUGIN=$LIBNETWORK_PLU
 # built while allowing the new versions to make changes that are not
 # backwards compatible.
 #
-FROM quay.io/cilium/cilium-runtime:2018-11-29
+FROM quay.io/cilium/cilium-runtime:2019-02-15
 LABEL maintainer="maintainer@cilium.io"
 COPY --from=builder /tmp/install /
 COPY --from=cilium-envoy / /

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -123,7 +123,7 @@ Vagrant.configure(2) do |config|
         vb.customize ["modifyvm", :id, "--audio", "none"]
 
         config.vm.box = "cilium/ubuntu-dev"
-        config.vm.box_version = "131"
+        config.vm.box_version = "132"
         vb.memory = ENV['VM_MEMORY'].to_i
         vb.cpus = ENV['VM_CPUS'].to_i
         if ENV["NFS"] then

--- a/contrib/packaging/docker/Dockerfile.runtime
+++ b/contrib/packaging/docker/Dockerfile.runtime
@@ -47,7 +47,7 @@ strip /usr/local/clang+llvm/bin/* && \
 #
 # iproute2
 #
-git clone --depth 1 -b master git://git.kernel.org/pub/scm/network/iproute2/iproute2-next.git iproute2 && \
+git clone --depth 1 -b 4.20.0-1ubuntu0bjn2 https://github.com/joestringer/iproute2.git iproute2 && \
 cd iproute2 && \
 ./configure && \
 make -j `getconf _NPROCESSORS_ONLN` && \

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -8,7 +8,7 @@ $K8S_VERSION = ENV['K8S_VERSION'] || "1.13"
 $K8S_NODES = (ENV['K8S_NODES'] || "2").to_i
 $NFS = ENV['NFS']=="1"? true : false
 $SERVER_BOX = (ENV['SERVER_BOX'] || "cilium/ubuntu-dev")
-$SERVER_VERSION= "131"
+$SERVER_VERSION= "132"
 $NETNEXT_SERVER_BOX= "cilium/ubuntu-next"
 $NETNEXT_SERVER_VERSION= "6"
 $IPv6=(ENV['IPv6'] || "0")


### PR DESCRIPTION
Pull iproute2 from https://github.com/joestringer/iproute2/releases/tag/4.20.0-1ubuntu0bjn2 .

This facilitates #6618 by allowing static data loads from the code in #7095 .

This PR pairs with https://github.com/cilium/packer-ci-build/pull/119.

To do:
* [x] Build and update references for new cilium-runtime image
* [x] Pull in `SERVER_VERSION` from the new VM image

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7114)
<!-- Reviewable:end -->
