### PR TITLE
add yaml config name to policy intro examples

### DIFF
--- a/Documentation/policy/intro.rst
+++ b/Documentation/policy/intro.rst
@@ -52,6 +52,11 @@ daemon:
 
 Similarly, you can enable the policy enforcement mode across a Kubernetes cluster by including the parameter above in the Cilium DaemonSet.
 
+.. code:: yaml
+
+    - name: CILIUM_ENABLE_POLICY
+      value: always
+
 
 .. _policy_rule:
 

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -299,6 +299,7 @@ kubernetes
 Kubespray
 kubespray
 KV
+KVstore
 kvstore
 Lando
 Leblond


### PR DESCRIPTION
Added the relevant k8s yaml config name example for `enable-policy` agent configuration in DaemonSet

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7115)
<!-- Reviewable:end -->
