### PR TITLE
policy: Fix ipcache synchronization on startup

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -558,7 +558,17 @@ func (d *Daemon) initMaps() error {
 		return err
 	}
 
-	if _, err := ipcachemap.IPCache.OpenOrCreate(); err != nil {
+	// The ipcache is shared between endpoints. Parallel mode needs to be
+	// used to allow existing endpoints that have not been regenerated yet
+	// to continue using the existing ipcache until the endpoint is
+	// regenerated for the first time. Existing endpoints are using a
+	// policy map which is potentially out of sync as local identities are
+	// re-allocated on startup. Parallel mode allows to continue using the
+	// old version until regeneration. Note that the old version is not
+	// updated with new identities. This is fine as any new identity
+	// appearing would require a regeneration of the endpoint anyway in
+	// order for the endpoint to gain the privilege of communication.
+	if _, err := ipcachemap.IPCache.OpenParallel(); err != nil {
 		return err
 	}
 

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -181,7 +181,9 @@ func (d *Daemon) restoreOldEndpoints(dir string, clean bool) (*endpointRestoreSt
 	return state, nil
 }
 
-func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) {
+func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) (restoreComplete chan struct{}) {
+	restoreComplete = make(chan struct{}, 0)
+
 	log.Infof("Regenerating %d restored endpoints", len(state.restored))
 
 	// Before regenerating, check whether the CT map has properties that
@@ -356,7 +358,10 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) {
 			"regenerated": regenerated,
 			"total":       total,
 		}).Info("Finished regenerating restored endpoints")
+		close(restoreComplete)
 	}()
+
+	return
 }
 
 func (d *Daemon) allocateIPsLocked(ep *endpoint.Endpoint) error {


### PR DESCRIPTION
The ipcache is shared between endpoints. Parallel mode needs to be used to
allow existing endpoints that have not been regenerated yet to continue using
the existing ipcache until the endpoint is regenerated for the first time.
Existing endpoints are using a policy map which is potentially out of sync as
local identities are re-allocated on startup. Parallel mode allows to continue
using the old version until regeneration. Note that the old version is not
updated with new identities. This is fine as any new identity appearing would
require a regeneration of the endpoint anyway in order for the endpoint to gain
the privilege of communication.

Fixes: #7120

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7139)
<!-- Reviewable:end -->
