### PR TITLE
Factor nodediscovery out of daemon

### DIFF
--- a/daemon/health.go
+++ b/daemon/health.go
@@ -67,7 +67,7 @@ func (d *Daemon) initHealth() {
 				// error, restart the health EP.
 				if client == nil || err != nil {
 					d.cleanupHealthEndpoint()
-					client, err = health.LaunchAsEndpoint(d, &d.nodeDiscovery.localNode, d.mtuConfig)
+					client, err = health.LaunchAsEndpoint(d, &d.nodeDiscovery.LocalNode, d.mtuConfig)
 				}
 				return err
 			},
@@ -83,7 +83,7 @@ func (d *Daemon) initHealth() {
 }
 
 func (d *Daemon) cleanupHealthEndpoint() {
-	localNode := d.nodeDiscovery.localNode
+	localNode := d.nodeDiscovery.LocalNode
 
 	// Delete the process
 	health.KillEndpoint()

--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -1714,7 +1714,7 @@ func (d *Daemon) updateK8sNodeTunneling(k8sNodeOld, k8sNodeNew *v1.Node) error {
 		return fmt.Errorf("ipcache entry owned by kvstore or agent")
 	}
 
-	d.nodeDiscovery.manager.NodeUpdated(*nodeNew)
+	d.nodeDiscovery.Manager.NodeUpdated(*nodeNew)
 
 	return nil
 }
@@ -1749,7 +1749,7 @@ func (d *Daemon) deleteK8sNodeV1(k8sNode *v1.Node) error {
 		logfields.IPAddr: ip,
 	})
 
-	d.nodeDiscovery.manager.NodeDeleted(*oldNode)
+	d.nodeDiscovery.Manager.NodeDeleted(*oldNode)
 
 	id, exists := ipcache.IPIdentityCache.LookupByIP(ip)
 	if !exists {
@@ -1791,7 +1791,7 @@ func updateK8sEventMetric(scope string, action string, status bool) {
 // associated with the right node.
 func (d *Daemon) missingK8sNodeV1(m versioned.Map) versioned.Map {
 	missing := versioned.NewMap()
-	nodes := d.nodeDiscovery.manager.GetNodes()
+	nodes := d.nodeDiscovery.Manager.GetNodes()
 	for k, v := range m {
 		n := v.Data.(*v1.Node)
 		ciliumHostIPStr := n.GetAnnotations()[annotation.CiliumHostIP]

--- a/daemon/k8s_watcher_test.go
+++ b/daemon/k8s_watcher_test.go
@@ -504,7 +504,7 @@ func (ds *DaemonSuite) Test_missingK8sPodV1(c *C) {
 }
 
 func (ds *DaemonSuite) Test_missingK8sNodeV1(c *C) {
-	defer ds.d.nodeDiscovery.manager.DeleteAllNodes()
+	defer ds.d.nodeDiscovery.Manager.DeleteAllNodes()
 	prevClusterName := option.Config.ClusterName
 	option.Config.ClusterName = "default"
 	defer func() {
@@ -569,13 +569,13 @@ func (ds *DaemonSuite) Test_missingK8sNodeV1(c *C) {
 		{
 			name: "ipcache and the node package contains the node. Should be no-op",
 			setupArgs: func() args {
-				ds.d.nodeDiscovery.manager.DeleteAllNodes()
+				ds.d.nodeDiscovery.Manager.DeleteAllNodes()
 				cache := ipcache.NewIPCache()
 				cache.Upsert("172.20.0.1", net.ParseIP("172.20.0.2"), ipcache.Identity{
 					ID:     identity.ReservedIdentityInit,
 					Source: ipcache.FromKubernetes,
 				})
-				ds.d.nodeDiscovery.manager.NodeUpdated(node.Node{
+				ds.d.nodeDiscovery.Manager.NodeUpdated(node.Node{
 					Name:    "foo",
 					Cluster: "default",
 					Source:  node.FromKubernetes,
@@ -611,7 +611,7 @@ func (ds *DaemonSuite) Test_missingK8sNodeV1(c *C) {
 		{
 			name: "node doesn't contain any cilium host IP. should be no-op",
 			setupArgs: func() args {
-				ds.d.nodeDiscovery.manager.DeleteAllNodes()
+				ds.d.nodeDiscovery.Manager.DeleteAllNodes()
 				cache := ipcache.NewIPCache()
 				cache.Upsert("127.0.0.1", net.ParseIP("127.0.0.2"), ipcache.Identity{
 					ID:     identity.ReservedIdentityInit,
@@ -641,13 +641,13 @@ func (ds *DaemonSuite) Test_missingK8sNodeV1(c *C) {
 		{
 			name: "ipcache contains the node but the CiliumHostIP is not the right one for the given nodeIP",
 			setupArgs: func() args {
-				ds.d.nodeDiscovery.manager.DeleteAllNodes()
+				ds.d.nodeDiscovery.Manager.DeleteAllNodes()
 				cache := ipcache.NewIPCache()
 				cache.Upsert("172.20.9.1", net.ParseIP("172.20.1.1"), ipcache.Identity{
 					ID:     identity.ReservedIdentityInit,
 					Source: ipcache.FromKubernetes,
 				})
-				ds.d.nodeDiscovery.manager.NodeUpdated(node.Node{
+				ds.d.nodeDiscovery.Manager.NodeUpdated(node.Node{
 					Name:    "bar",
 					Source:  node.FromAgentLocal,
 					Cluster: "default",

--- a/daemon/status.go
+++ b/daemon/status.go
@@ -69,9 +69,9 @@ func checkLocks(d *Daemon) {
 
 func (d *Daemon) getNodeStatus() *models.ClusterStatus {
 	clusterStatus := models.ClusterStatus{
-		Self: d.nodeDiscovery.localNode.Fullname(),
+		Self: d.nodeDiscovery.LocalNode.Fullname(),
 	}
-	for _, node := range d.nodeDiscovery.manager.GetNodes() {
+	for _, node := range d.nodeDiscovery.Manager.GetNodes() {
 		clusterStatus.Nodes = append(clusterStatus.Nodes, node.GetModel())
 	}
 	return &clusterStatus


### PR DESCRIPTION
This is done so https://github.com/cilium/node-discovery-perf works.

Also, it's always nice to have less stuff in `daemon`


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7141)
<!-- Reviewable:end -->
