### PR TITLE
Wait for for k8s objects until are synced and processed before initializing cilium daemon

### DIFF
--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -522,7 +522,11 @@ func (d *Daemon) EnableK8sWatcher(reSyncPeriod time.Duration) error {
 			reSyncPeriod,
 			metrics.EventTSK8s,
 		)
-		blockWaitGroupToSyncResources(&d.k8sResourceSyncWaitGroup, ciliumV2Controller, "CiliumNetworkPolicy")
+
+		// Wrap the controller from Kubernetes so we can actually know when all
+		// objects were synchronized and processed from kubernetes.
+		cs := &k8sUtils.ControllerSyncer{Controller: ciliumV2Controller, ResourceEventHandler: rehf}
+		blockWaitGroupToSyncResources(&d.k8sResourceSyncWaitGroup, cs, "CiliumNetworkPolicy")
 
 		ciliumV2Controller.AddEventHandler(rehf)
 	}

--- a/pkg/k8s/utils/factory.go
+++ b/pkg/k8s/utils/factory.go
@@ -58,25 +58,25 @@ type lister func(client interface{}) func() (versioned.Map, error)
 // the HasSynced method with the help of our own ResourceEventHandler
 // implementation.
 type ControllerSyncer struct {
-	c   cache.Controller
-	reh ResourceEventHandler
+	Controller           cache.Controller
+	ResourceEventHandler ResourceEventHandler
 }
 
 // Run starts the controller, which will be stopped when stopCh is closed.
 func (c *ControllerSyncer) Run(stopCh <-chan struct{}) {
-	c.c.Run(stopCh)
+	c.Controller.Run(stopCh)
 }
 
 // HasSynced returns true if the controller has synced and the resource event
 // handler has handled all requests.
 func (c *ControllerSyncer) HasSynced() bool {
-	return c.reh.HasSynced()
+	return c.ResourceEventHandler.HasSynced()
 }
 
 // LastSyncResourceVersion is the resource version observed when last synced
 // with the underlying store.
 func (c *ControllerSyncer) LastSyncResourceVersion() string {
-	return c.c.LastSyncResourceVersion()
+	return c.Controller.LastSyncResourceVersion()
 }
 
 // ResourceEventHandler is a wrapper for the cache.ResourceEventHandler

--- a/pkg/k8s/utils/factory.go
+++ b/pkg/k8s/utils/factory.go
@@ -196,7 +196,9 @@ func ControllerFactory(
 		rehf,
 	)
 
-	return s, c
+	// Wrap the controller from Kubernetes so we can actually know when all
+	// objects were synchronized and processed from kubernetes.
+	return s, &ControllerSyncer{Controller: c, ResourceEventHandler: rehf}
 }
 
 // ResourceEventHandlerFactory returns a ResourceEventHandlerSyncer,


### PR DESCRIPTION
Read per commit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7144)
<!-- Reviewable:end -->
