### PR TITLE
Fix policy drops on restart due to lack of kvstore sync

### DIFF
--- a/daemon/state.go
+++ b/daemon/state.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -247,11 +248,13 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) (resto
 				epRegenerated <- false
 			}
 
-			// Wait for initial identities from the kvstore before
-			// doing any policy calculation for endpoints that don't have
-			// a fixed identity or are not well known.
+			// Wait for initial identities and ipcache from the
+			// kvstore before doing any policy calculation for
+			// endpoints that don't have a fixed identity or are
+			// not well known.
 			if !identity.IsFixed() && !identity.IsWellKnown() {
 				cache.WaitForInitialIdentities()
+				ipcache.WaitForInitialSync()
 			}
 
 			if err := ep.LockAlive(); err != nil {

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -246,6 +246,7 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) (resto
 				scopedLog.WithError(err).Warn("Unable to restore endpoint")
 				epRegenerated <- false
 			}
+
 			// Wait for initial identities from the kvstore before
 			// doing any policy calculation for endpoints that don't have
 			// a fixed identity or are not well known.


### PR DESCRIPTION
In the process of endpoints being restored from disk, all programs are
regenerated. This bases the programs on the latest snapshots of all local
caches for identities, ipcache, services, and so on. In order to not
destabilize existing endpoint, it must be ensured that local caches have been
synchronized to a valid state. This was done for services as well as identities
if the endpoint was not assigned a fixed or well-known identity. The first
part of the fix is to also require the ipcache to be synchronized to avoid
egress policy drops for endpoints subject to egress policy.

The second part of the fix is to make all endpoints subject to these
synchronization requirements.

Example:
coredns is assigned a well-known identity. When coredns is restored from disk
and regenerated, premature regeneration without the full list of identities
being available will result in the allowed policy map to be stripped of all
global identities. This can result in temporary policy drops.

The risk of avoiding regeneration on restore is that restarting the agent no
longer guarantees to fix an eventual program with the BPF program. It is thus
required for the orchestrator to eventually restart the pod/container on
failure. This will happen in a timely manner with Kubernetes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7148)
<!-- Reviewable:end -->
