### PR TITLE
link to stable docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # How to Contribute
 
 See the [Developer / Contributor
-Guide](http://docs.cilium.io/en/v1.0/contributing/) for detailed information on
+Guide](http://docs.cilium.io/en/stable/contributing/) for detailed information on
 how to contribute, get started and find good first issues.


### PR DESCRIPTION
Change `CONTRIBUTING.md` link to point to stable docs.

Signed-off-by: Stephen Martin <lockwood@opperline.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7149)
<!-- Reviewable:end -->
