### PR TITLE
fqdn-poller: Ensure monitor events contain all data

### DIFF
--- a/pkg/monitor/logrecord.go
+++ b/pkg/monitor/logrecord.go
@@ -91,10 +91,15 @@ func (l *LogRecordNotify) DumpInfo() {
 	}
 
 	if l.DNS != nil {
-		t, _ := dns.TypeToString[l.DNS.QTypes[0]]
+		types := []string{}
+		for _, t := range l.DNS.QTypes {
+			types = append(types, dns.TypeToString[t])
+		}
+		qTypeStr := strings.Join(types, ",")
+
 		switch {
 		case l.Type == accesslog.TypeRequest:
-			fmt.Printf(" DNS Query: %s %s", l.DNS.Query, t)
+			fmt.Printf(" DNS Query: %s %s", l.DNS.Query, qTypeStr)
 
 		case l.Type == accesslog.TypeResponse:
 			sourceType := "Query"
@@ -102,7 +107,7 @@ func (l *LogRecordNotify) DumpInfo() {
 				sourceType = "Poll"
 			}
 
-			fmt.Printf(" DNS %s: %s %s", sourceType, l.DNS.Query, t)
+			fmt.Printf(" DNS %s: %s %s", sourceType, l.DNS.Query, qTypeStr)
 
 			ips := make([]string, 0, len(l.DNS.IPs))
 			for _, ip := range l.DNS.IPs {

--- a/pkg/proxy/accesslog/record.go
+++ b/pkg/proxy/accesslog/record.go
@@ -286,17 +286,17 @@ type LogRecordDNS struct {
 	// RCode is the response code
 	// defined as per https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-6
 	// Use 	github.com/miekg/dns.RcodeToString map to retrieve string representation
-	RCode int
+	RCode int `json:"RCode,omitempty"`
 
 	// QTypes are question types in DNS message
 	// https://www.ietf.org/rfc/rfc1035.txt
 	// Use github.com/miekg/dns.TypeToString map to retrieve string representation
-	QTypes []uint16
+	QTypes []uint16 `json:"QTypes,omitempty"`
 
 	// AnswerTypes are record types in the answer section
 	// https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4
 	// Use github.com/miekg/dns.TypeToString map to retrieve string representation
-	AnswerTypes []uint16
+	AnswerTypes []uint16 `json:"AnswerTypes,omitempty"`
 }
 
 // LogRecordL7 contains the generic L7 portion of a log record


### PR DESCRIPTION
The poller-generated monitor events for DNS lookups were missing some
newer fields. This caused the monitor CLI pretty-printer to panic as it
assumed these field were always populated. We now better guard against
that scenario and also populate these fields for poller events.

@nebril you totally said we should account for this :) 1 point to you! 0 point for me!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7157)
<!-- Reviewable:end -->
