### PR TITLE
ctmap: Fix order of CtKey{4,6} struct fields

### DIFF
--- a/pkg/maps/ctmap/ipv4.go
+++ b/pkg/maps/ctmap/ipv4.go
@@ -29,8 +29,8 @@ import (
 type CtKey4 struct {
 	DestAddr   types.IPv4
 	SourceAddr types.IPv4
-	SourcePort uint16
 	DestPort   uint16
+	SourcePort uint16
 	NextHeader u8proto.U8proto
 	Flags      uint8
 }

--- a/pkg/maps/ctmap/ipv6.go
+++ b/pkg/maps/ctmap/ipv6.go
@@ -29,8 +29,8 @@ import (
 type CtKey6 struct {
 	DestAddr   types.IPv6
 	SourceAddr types.IPv6
-	SourcePort uint16
 	DestPort   uint16
+	SourcePort uint16
 	NextHeader u8proto.U8proto
 	Flags      uint8
 }


### PR DESCRIPTION
(Spotted while working on #6559)

`CtKey{4,6}` have to correspond to `ipv{4,6}_ct_tuple` structs in C, respectively. From `bpf/lib/common.h`:

```
struct ipv4_ct_tuple {
	__be32		daddr;
	__be32		saddr;
	/* The order of dport+sport must not be changed */
	__be16		dport;
	__be16		sport;
	__u8		nexthdr;
	__u8		flags;
} __attribute__((packed));

struct ipv6_ct_tuple {
	union v6addr	daddr;
	union v6addr	saddr;
	/* The order of dport+sport must not be changed */
	__be16		dport;
	__be16		sport;
	__u8		nexthdr;
	__u8		flags;
} __attribute__((packed));
```

Previously, the order of `DestPort` and `SourcePort` in the Go structs was mixed. Luckily, we do not do any GC based on ports and the fields are used only (from the first glance) for dumping.

Fixes: 9cf0ee258ba95 ("Add global, local ctmaps with different key sizes.")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7159)
<!-- Reviewable:end -->
