### PR TITLE
policy: Add missing import error metric calls

### DIFF
--- a/pkg/policy/api/selector.go
+++ b/pkg/policy/api/selector.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/metrics"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	k8sLbls "k8s.io/apimachinery/pkg/labels"
@@ -158,6 +159,7 @@ func (n EndpointSelector) GetMatch(key string) ([]string, bool) {
 func labelSelectorToRequirements(labelSelector *metav1.LabelSelector) *k8sLbls.Requirements {
 	selector, err := metav1.LabelSelectorAsSelector(labelSelector)
 	if err != nil {
+		metrics.PolicyImportErrors.Inc()
 		log.WithError(err).WithField(logfields.EndpointLabelSelector,
 			logfields.Repr(labelSelector)).Error("unable to construct selector in label selector")
 		return nil

--- a/pkg/policy/groups/actions.go
+++ b/pkg/policy/groups/actions.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cilium/cilium/pkg/controller"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -112,6 +113,7 @@ func DeleteDerivativeCNP(cnp *cilium_v2.CiliumNetworkPolicy) error {
 
 	k8sClient, err := getK8sClient()
 	if err != nil {
+		metrics.PolicyImportErrors.Inc()
 		scopedLog.WithError(err).Error("Cannot get Kubernetes client")
 	}
 
@@ -150,6 +152,7 @@ func addDerivativeCNP(cnp *cilium_v2.CiliumNetworkPolicy) error {
 		if derivativeErr == nil {
 			break
 		}
+		metrics.PolicyImportErrors.Inc()
 		scopedLog.WithError(derivativeErr).Error("Cannot create derivative rule. Installing deny-all rule.")
 		statusErr := updateDerivativeStatus(cnp, derivativeCNP.ObjectMeta.Name, derivativeErr)
 		if statusErr != nil {
@@ -162,6 +165,7 @@ func addDerivativeCNP(cnp *cilium_v2.CiliumNetworkPolicy) error {
 	if err != nil {
 		statusErr := updateDerivativeStatus(cnp, derivativeCNP.ObjectMeta.Name, err)
 		if statusErr != nil {
+			metrics.PolicyImportErrors.Inc()
 			scopedLog.WithError(err).Error("Cannot update CNP status for derivative policy")
 		}
 		return statusErr


### PR DESCRIPTION
After this change, policy import error metric is increased after every
logged error in the whole pkg/policy package in functions/methods which
are called when policies are imported.

Fixes #7022

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7161)
<!-- Reviewable:end -->
