### PR TITLE
backport/v1.3 2019 02 19

### DIFF
--- a/Documentation/contributing.rst
+++ b/Documentation/contributing.rst
@@ -1386,7 +1386,8 @@ illustrating which subset of tests the job runs.
 There are some feature flags based on Pull Requests labels, the list of labels
 are the following:
 
-- area/containerd: Enable containerd runtime on all Kubernetes test.
+- ``area/containerd``: Enable containerd runtime on all Kubernetes test.
+- ``ci/next-next``: Run tests on net-next kernel.
 
 
 Using Jenkins for testing

--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -585,7 +585,11 @@ func (d *Daemon) EnableK8sWatcher(reSyncPeriod time.Duration) error {
 			reSyncPeriod,
 			metrics.EventTSK8s,
 		)
-		blockWaitGroupToSyncResources(&d.k8sResourceSyncWaitGroup, ciliumV2Controller, "CiliumNetworkPolicy")
+
+		// Wrap the controller from Kubernetes so we can actually know when all
+		// objects were synchronized and processed from kubernetes.
+		cs := &k8sUtils.ControllerSyncer{Controller: ciliumV2Controller, ResourceEventHandler: rehf}
+		blockWaitGroupToSyncResources(&d.k8sResourceSyncWaitGroup, cs, "CiliumNetworkPolicy")
 
 		ciliumV2Controller.AddEventHandler(rehf)
 	}

--- a/pkg/k8s/utils/factory.go
+++ b/pkg/k8s/utils/factory.go
@@ -196,7 +196,9 @@ func ControllerFactory(
 		rehf,
 	)
 
-	return c
+	// Wrap the controller from Kubernetes so we can actually know when all
+	// objects were synchronized and processed from kubernetes.
+	return &ControllerSyncer{Controller: c, ResourceEventHandler: rehf}
 }
 
 // ResourceEventHandlerFactory returns a ResourceEventHandlerSyncer,

--- a/pkg/k8s/utils/factory.go
+++ b/pkg/k8s/utils/factory.go
@@ -58,25 +58,25 @@ type lister func(client interface{}) func() (versioned.Map, error)
 // the HasSynced method with the help of our own ResourceEventHandler
 // implementation.
 type ControllerSyncer struct {
-	c   cache.Controller
-	reh ResourceEventHandler
+	Controller           cache.Controller
+	ResourceEventHandler ResourceEventHandler
 }
 
 // Run starts the controller, which will be stopped when stopCh is closed.
 func (c *ControllerSyncer) Run(stopCh <-chan struct{}) {
-	c.c.Run(stopCh)
+	c.Controller.Run(stopCh)
 }
 
 // HasSynced returns true if the controller has synced and the resource event
 // handler has handled all requests.
 func (c *ControllerSyncer) HasSynced() bool {
-	return c.reh.HasSynced()
+	return c.ResourceEventHandler.HasSynced()
 }
 
 // LastSyncResourceVersion is the resource version observed when last synced
 // with the underlying store.
 func (c *ControllerSyncer) LastSyncResourceVersion() string {
-	return c.c.LastSyncResourceVersion()
+	return c.Controller.LastSyncResourceVersion()
 }
 
 // ResourceEventHandler is a wrapper for the cache.ResourceEventHandler

--- a/pkg/maps/ctmap/ipv4.go
+++ b/pkg/maps/ctmap/ipv4.go
@@ -29,8 +29,8 @@ import (
 type CtKey4 struct {
 	DestAddr   types.IPv4
 	SourceAddr types.IPv4
-	SourcePort uint16
 	DestPort   uint16
+	SourcePort uint16
 	NextHeader u8proto.U8proto
 	Flags      uint8
 }

--- a/pkg/maps/ctmap/ipv6.go
+++ b/pkg/maps/ctmap/ipv6.go
@@ -29,8 +29,8 @@ import (
 type CtKey6 struct {
 	DestAddr   types.IPv6
 	SourceAddr types.IPv6
-	SourcePort uint16
 	DestPort   uint16
+	SourcePort uint16
 	NextHeader u8proto.U8proto
 	Flags      uint8
 }


### PR DESCRIPTION
Backported
------------

 * PR: 7144 -- Wait for for k8s objects until are synced and processed before initializing cilium daemon (@aanm) -- https://github.com/cilium/cilium/pull/7144
@aanm This had a minor conflict. I think I did it correctly.

 * PR: 7103 -- Change endpoint policy status map to regular map (@nebril) -- https://github.com/cilium/cilium/pull/7103

 * PR: 7076 -- docs: Add note about triggering builds with net-next (@brb) -- https://github.com/cilium/cilium/pull/7076


Skipped
--------
 * PR: 7147 -- .travis: as coverall is not working we will disable it (@aanm) -- https://github.com/cilium/cilium/pull/7147
@aanm this file doesn't exist in 1.3 and I couldn't find another one

 * PR: 7139 -- policy: Fix ipcache synchronization on startup (@tgraf) -- https://github.com/cilium/cilium/pull/7139
@tgraf This had a conflict and it complains that the map is already open on startup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7165)
<!-- Reviewable:end -->
