### PR TITLE
release: fix uploadrev script to work with changes made after 1.3

### DIFF
--- a/contrib/release/uploadrev
+++ b/contrib/release/uploadrev
@@ -59,27 +59,47 @@ function copy_source() {
   git archive --format=tar.gz -o $TARGET_DIR/$TARBALL --prefix=$PREPEND $REV
 }
 
-function copy_binaries() {
+function copy_binaries_cilium_docker() {
+  echo "target_dir: $TARGET_DIR"
   mkdir -p $TARGET_DIR
-  SHA=$(docker create docker.io/cilium/cilium:$REV)
-  docker cp $SHA:/usr/bin/cilium $TARGET_DIR/cilium-$ARCH
-  docker cp $SHA:/usr/bin/cilium-agent $TARGET_DIR/cilium-agent-$ARCH
-  docker cp $SHA:/usr/bin/cilium-bugtool $TARGET_DIR/cilium-bugtool-$ARCH
-  docker cp $SHA:/usr/bin/cilium-node-monitor $TARGET_DIR/cilium-node-monitor-$ARCH
-  docker cp $SHA:/usr/bin/cilium-health $TARGET_DIR/cilium-health-$ARCH
-  docker cp $SHA:/usr/bin/cilium-envoy $TARGET_DIR/cilium-envoy-$ARCH
-  docker cp $SHA:/usr/bin/cilium-docker $TARGET_DIR/cilium-docker-$ARCH
-  docker cp $SHA:/opt/cni/bin/cilium-cni $TARGET_DIR/cilium-cni-$ARCH
-  cp contrib/k8s/k8s-cilium-exec.sh $TARGET_DIR/tools/ || true
-  cp contrib/k8s/k8s-get-cilium-pod.sh $TARGET_DIR/tools/ || true
-  cp contrib/k8s/k8s-unmanaged.sh $TARGET_DIR/tools/ || true
+  SHA=$(docker create docker.io/cilium/docker-plugin:$REV)
+  docker cp $SHA:/usr/bin/cilium-docker/cilium-docker $TARGET_DIR/cilium-docker-$ARCH
   docker rm -f $SHA
+}
 
+function copy_binaries_cilium_operator() {
+  mkdir -p $TARGET_DIR
+  SHA=$(docker create docker.io/cilium/operator:$REV)
+  docker cp $SHA:/usr/bin/cilium-operator $TARGET_DIR/cilium-operator-$ARCH
+  docker rm -f $SHA
+}
+
+function generate_sha_digest_for_binaries() {
+  mkdir -p $TARGET_DIR
   # Generate  SHA256 digest
   cd $TARGET_DIR
   for f in *; do
     [ ! -d "$f" ] && sha256sum $f > $f.sha256sum
   done
+}
+
+function copy_binaries() {
+  mkdir -p $TARGET_DIR
+  SHA=$(docker create docker.io/cilium/cilium:$REV)
+  docker cp $SHA:/usr/bin/cilium-agent $TARGET_DIR/cilium-$ARCH
+  docker cp $SHA:/usr/bin/cilium-agent $TARGET_DIR/cilium-agent-$ARCH
+  docker cp $SHA:/usr/bin/cilium-agent $TARGET_DIR/cilium-node-monitor-$ARCH
+  docker cp $SHA:/usr/bin/cilium-bugtool $TARGET_DIR/cilium-bugtool-$ARCH
+  docker cp $SHA:/usr/bin/cilium-health $TARGET_DIR/cilium-health-$ARCH
+  docker cp $SHA:/usr/bin/cilium-envoy $TARGET_DIR/cilium-envoy-$ARCH
+  docker cp $SHA:/opt/cni/bin/cilium-cni $TARGET_DIR/cilium-cni-$ARCH
+  cp contrib/k8s/k8s-cilium-exec.sh $TARGET_DIR/tools/ || true
+  cp contrib/k8s/k8s-get-cilium-pod.sh $TARGET_DIR/tools/ || true
+  cp contrib/k8s/k8s-unmanaged.sh $TARGET_DIR/tools/ || true
+  docker rm -f $SHA
+  copy_binaries_cilium_operator
+  copy_binaries_cilium_docker
+  generate_sha_digest_for_binaries
 }
 
 


### PR DESCRIPTION
Various changes were needed to make the uploadrev script function correctly:

* Pull the `cilium-docker` binary from the new `docker-plugin` image, as the
`cilium-docker` plugin is no longer installed in the `cilium` image.
* Copy the `cilium-agent` binary to represent the `cilium` and
`cilium-node-monitor` binaries. This is because there are no longer separate
binaries for these components; instead, in the `cilium` image,
`cilium-node-monitor` and `cilium` are just symlinks to `cilium-agent`. This
change was introduced in 8ac4ed8488 .

This also copies the `cilium-operator` binary from the `cilium/operator` image,
and factors out generation of SHAs for each binary into a separate function,
`generate_sha_digest_for_binaries` for easier code readability.

Output from running uploadrev now works for `v1.4.0`, for instance:

```
$ SKIP_UPLOAD=1 DOMAIN=releases.cilium.io ./contrib/release/uploadrev v1.4.0
/usr/bin/aws
mkdir: created directory '/home/vagrant/go/src/github.com/cilium/cilium/contrib/release/../../_build/v1.4.0'
mkdir: created directory '/home/vagrant/go/src/github.com/cilium/cilium/contrib/release/../../_build/v1.4.0/tools'
ac2f4b990fa05dd7c24bdd374099dca60d80b092ffff565718cfa7f51b2f28bf
33541bf7371659a82b04d0c0a8faed7fc33184f95b4c426e2f196be1f289a968
target_dir: /home/vagrant/go/src/github.com/cilium/cilium/contrib/release/../../_build/v1.4.0
c23067126aa3e7d0cd45e673ca0166021c205336781f3333abca09cbb9fae09d
Skipping upload
--- markdown snippet for NEWS.rst  ---
Release binaries
----------------

* [cilium-agent-x86_64](http://releases.cilium.io/v1.4.0/cilium-agent-x86_64) ([c6314d3cce4ced94a51f](http://releases.cilium.io/v1.4.0/cilium-agent-x86_64.sha256sum))
* [cilium-bugtool-x86_64](http://releases.cilium.io/v1.4.0/cilium-bugtool-x86_64) ([41786219a2f1fdfba446](http://releases.cilium.io/v1.4.0/cilium-bugtool-x86_64.sha256sum))
* [cilium-cni-x86_64](http://releases.cilium.io/v1.4.0/cilium-cni-x86_64) ([95697b1dbd144aff6df1](http://releases.cilium.io/v1.4.0/cilium-cni-x86_64.sha256sum))
* [cilium-docker-x86_64](http://releases.cilium.io/v1.4.0/cilium-docker-x86_64) ([58787d1d5fcb76c9ae99](http://releases.cilium.io/v1.4.0/cilium-docker-x86_64.sha256sum))
* [cilium-envoy-x86_64](http://releases.cilium.io/v1.4.0/cilium-envoy-x86_64) ([8189908dd72e7b3cbb74](http://releases.cilium.io/v1.4.0/cilium-envoy-x86_64.sha256sum))
* [cilium-health-x86_64](http://releases.cilium.io/v1.4.0/cilium-health-x86_64) ([9ed77c3397ebb3302289](http://releases.cilium.io/v1.4.0/cilium-health-x86_64.sha256sum))
* [cilium-node-monitor-x86_64](http://releases.cilium.io/v1.4.0/cilium-node-monitor-x86_64) ([c6314d3cce4ced94a51f](http://releases.cilium.io/v1.4.0/cilium-node-monitor-x86_64.sha256sum))
* [cilium-operator-x86_64](http://releases.cilium.io/v1.4.0/cilium-operator-x86_64) ([7cd4fda7a0a7c06c8962](http://releases.cilium.io/v1.4.0/cilium-operator-x86_64.sha256sum))
* [cilium-x86_64](http://releases.cilium.io/v1.4.0/cilium-x86_64) ([c6314d3cce4ced94a51f](http://releases.cilium.io/v1.4.0/cilium-x86_64.sha256sum))
* [v1.4.0.tar.gz](http://releases.cilium.io/v1.4.0/v1.4.0.tar.gz) ([5fb9741ff93b59dc2d53](http://releases.cilium.io/v1.4.0/v1.4.0.tar.gz.sha256sum))
* [v1.4.0.zip](http://releases.cilium.io/v1.4.0/v1.4.0.zip) ([9212ff62fe6335dc83e9](http://releases.cilium.io/v1.4.0/v1.4.0.zip.sha256sum))
--- end ---
```

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #7154

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7168)
<!-- Reviewable:end -->
