### PR TITLE
loader: Fix nil dereference in logging statement

### DIFF
--- a/pkg/datapath/loader/compile.go
+++ b/pkg/datapath/loader/compile.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 Authors of Cilium
+// Copyright 2017-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
 	"path"
 	"runtime"
 
@@ -128,6 +129,14 @@ func prepareCmdPipes(cmd *exec.Cmd) (io.ReadCloser, io.ReadCloser, error) {
 	return stdout, stderr, nil
 }
 
+func pidFromProcess(proc *os.Process) string {
+	result := "not-started"
+	if proc != nil {
+		result = fmt.Sprintf("%d", proc.Pid)
+	}
+	return result
+}
+
 // compileAndLink links the specified program from the specified path to the
 // intermediate representation, to the output specified in the prog's info.
 func compileAndLink(ctx context.Context, prog *progInfo, dir *directoryInfo, debug bool, compileArgs ...string) error {
@@ -163,8 +172,8 @@ func compileAndLink(ctx context.Context, prog *progInfo, dir *directoryInfo, deb
 	if err != nil {
 		err = fmt.Errorf("Failed to compile %s: %s", prog.Output, err)
 		log.WithFields(logrus.Fields{
-			"compiler-pid": compileCmd.Process.Pid,
-			"linker-pid":   linkCmd.Process.Pid,
+			"compiler-pid": pidFromProcess(compileCmd.Process),
+			"linker-pid":   pidFromProcess(linkCmd.Process),
 		}).Error(err)
 		if compileOut != nil {
 			scopedLog := log.Warn


### PR DESCRIPTION
If the command context is cancelled at just the wrong time, then it's
possible for the compiler to have run but the linker not yet run, which
means that the process in the *Cmd is nil. In this case, we would
attempt to dereference the process to get its pid but the process
pointer is nil, leading to a crash.

Fix this by checking that the pointer is non-nil before dereferencing.

Found via the unit test failure:

```
  ... Panic: runtime error: invalid memory address or nil pointer dereference (PC=0x45BA7A)

  /usr/local/go/src/runtime/panic.go:513
    in gopanic
  /usr/local/go/src/runtime/panic.go:82
    in panicmem
  /usr/local/go/src/runtime/signal_unix.go:390
    in sigpanic
  compile.go:167
    in compileAndLink
  compile.go:230
    in compile
  loader.go:73
    in compileDatapath
  loader.go:112
    in compileAndLoad
  loader_test.go:187
    in LoaderTestSuite.TestCompileFailure
  /usr/local/go/src/reflect/value.go:308
    in Value.Call
  /usr/local/go/src/runtime/asm_amd64.s:1333
    in goexit
  PANIC: loader_test.go:169: LoaderTestSuite.TestCompileFailure
```

Fixes: d9a9f240d83d ("loader: Log PIDs of compiler/linker on error")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7170)
<!-- Reviewable:end -->
