### PR TITLE
cilium: Transparent encryption datapath CI K8sT tests

### DIFF
--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -29,10 +29,12 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 	var kubectl *helpers.Kubectl
 	var demoDSPath string
+	var ipsecDSPath string
 
 	BeforeAll(func() {
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 		demoDSPath = helpers.ManifestGet("demo_ds.yaml")
+		ipsecDSPath = helpers.ManifestGet("ipsec_ds.yaml")
 
 		kubectl.Exec("kubectl -n kube-system delete ds cilium")
 
@@ -41,11 +43,13 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 	BeforeEach(func() {
 		kubectl.Apply(demoDSPath).ExpectSuccess("cannot install Demo application")
+		kubectl.Apply(ipsecDSPath).ExpectSuccess("cannot install IPsec keys")
 		kubectl.NodeCleanMetadata()
 	})
 
 	AfterEach(func() {
 		kubectl.Delete(demoDSPath)
+		kubectl.Delete(ipsecDSPath)
 		ExpectAllPodsTerminated(kubectl)
 
 		// Do not assert on success in AfterEach intentionally to avoid
@@ -104,6 +108,20 @@ var _ = Describe("K8sDatapathConfig", func() {
 			Expect(status.IntOutput()).Should(Equal(3), "Did not find expected number of entries in BPF tunnel map")
 		}
 
+		It("Check connectivity with transparent encryption and VXLAN encapsulation", func() {
+			switch helpers.GetCurrentIntegration() {
+			case helpers.CIIntegrationFlannel:
+				Skip(fmt.Sprintf(
+					"Cilium in %q mode is not supported with transparent encryption and VxLAN. Skipping test.",
+					helpers.CIIntegrationFlannel))
+				return
+			}
+			deployCilium("cilium-ds-patch-vxlan-ipsec.yaml")
+			validateBPFTunnelMap()
+			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test with IPsec between nodes failed")
+			cleanService()
+		}, 600)
+
 		It("Check connectivity with VXLAN encapsulation", func() {
 			switch helpers.GetCurrentIntegration() {
 			case helpers.CIIntegrationFlannel:
@@ -146,6 +164,14 @@ var _ = Describe("K8sDatapathConfig", func() {
 			}
 
 			deployCilium("cilium-ds-patch-auto-node-routes.yaml")
+			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
+			cleanService()
+		})
+	})
+
+	Context("Transparent encryption with IPv4Only", func() {
+		It("Check connectivity with transparent encryption enabled and IPv6 disabled", func() {
+			deployCilium("cilium-ds-patch-ipv4-only-ipsec.yaml")
 			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
 			cleanService()
 		})

--- a/test/k8sT/manifests/cilium-ds-patch-ipv4-only-ipsec.yaml
+++ b/test/k8sT/manifests/cilium-ds-patch-ipv4-only-ipsec.yaml
@@ -1,0 +1,32 @@
+---
+metadata:
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+      - image: k8s1:5000/cilium/cilium-dev:latest
+        imagePullPolicy: Always
+        name: cilium-agent
+        args:
+        - "--kvstore=etcd"
+        - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
+        - "--k8s-require-ipv4-pod-cidr"
+        - "--pprof=true"
+        - "--log-system-load"
+        - "--enable-ipv4=true"
+        - "--enable-ipv6=false"
+        - "--config-dir=/tmp/cilium/config-map"
+        - "--enable-ipsec"
+        - "--ipsec-key-file=/etc/ipsec/keys"
+        volumeMounts:
+          - name: cilium-ipsec-secrets
+            mountPath: /etc/ipsec
+      volumes:
+      - name: cilium-ipsec-secrets
+        secret:
+          secretName: cilium-ipsec-keys
+      - name: etcd-secrets
+        secret:
+          secretName: cilium-etcd-client-tls
+      dnsPolicy: ClusterFirstWithHostNet

--- a/test/k8sT/manifests/cilium-ds-patch-vxlan-ipsec.yaml
+++ b/test/k8sT/manifests/cilium-ds-patch-vxlan-ipsec.yaml
@@ -1,0 +1,31 @@
+---
+metadata:
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+      - image: k8s1:5000/cilium/cilium-dev:latest
+        imagePullPolicy: Always
+        name: cilium-agent
+        args:
+        - "--tunnel=vxlan"
+        - "--kvstore=etcd"
+        - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
+        - "--k8s-require-ipv4-pod-cidr"
+        - "--pprof=true"
+        - "--log-system-load"
+        - "--config-dir=/tmp/cilium/config-map"
+        - "--enable-ipsec"
+        - "--ipsec-key-file=/etc/ipsec/keys"
+        volumeMounts:
+          - name: cilium-ipsec-secrets
+            mountPath: /etc/ipsec
+      volumes:
+      - name: cilium-ipsec-secrets
+        secret:
+          secretName: cilium-ipsec-keys
+      - name: etcd-secrets
+        secret:
+          secretName: cilium-etcd-client-tls
+      dnsPolicy: ClusterFirstWithHostNet

--- a/test/k8sT/manifests/ipsec_ds.yaml
+++ b/test/k8sT/manifests/ipsec_ds.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cilium-ipsec-keys
+  namespace: kube-system
+type: Opaque
+stringData:
+  keys: "hmac(sha256) 0123456789abcdef0123456789abcdef cbc(aes) 0123456789abcdef0123456789abcdef"


### PR DESCRIPTION
Adds initial tests to K8sT CI to test datapath with vxlan and IPv4 only modes. There will be some improvements in the future but I think it makes sense to get this base case in now. Next we will add some more introspection options from cilium CLI and use these to verify traffic is being encrypted and alert if unencrypted traffic is seen. We can then verify these from the CI side. However, for now lets get some test coverage.

I verified these are encrypted and setting up transparent traffic by inspecting the VM manually. Also I intentionally broke the datapath encryption side add the test failed as expected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7175)
<!-- Reviewable:end -->
