### PR TITLE
cilium: fix Error -> Errorf errors

### DIFF
--- a/test/helpers/ssh_command.go
+++ b/test/helpers/ssh_command.go
@@ -213,7 +213,7 @@ func (client *SSHClient) RunCommandInBackground(ctx context.Context, cmd *SSHCom
 
 	stdin, err := session.StdinPipe()
 	if err != nil {
-		log.Errorf("Could not get stdin", err)
+		log.Errorf("Could not get stdin: %s", err)
 	}
 
 	go func() {

--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -59,7 +59,7 @@ var _ = Describe("NightlyEpsMeasurement", func() {
 
 		select {
 		case <-ctx.Done():
-			logger.Error("DeleteAll: delete all pods,services failed after %s", helpers.HelperTimeout)
+			logger.Errorf("DeleteAll: delete all pods,services failed after %s", helpers.HelperTimeout)
 		}
 	}
 	AfterAll(func() {


### PR DESCRIPTION
Fix a couple missing Error(f) in ginkgo. Found by running older version of golang, its not clear to me why go is getting more permissive with higher versions but fix anyways.

Fixes: 92f83a5fb927 ("helpers: Use proper time types")
Fixes: 6220ff2692cb ("Terminate microscope in CI properly")
Signed-off-by: John Fastabend <john.fastabend@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7177)
<!-- Reviewable:end -->
