### PR TITLE
FQDN: Refactor on Rulegen.

### DIFF
--- a/daemon/fqdn.go
+++ b/daemon/fqdn.go
@@ -362,6 +362,7 @@ func (d *Daemon) bootstrapFQDN(restoredEndpoints *endpointRestoreState, preCache
 				// Note: We need to fixup minTTL to be consistent with how we insert it
 				// elsewhere i.e. we don't want to lose the lower bound for DNS data
 				// TTL if we reboot twice.
+
 				log.WithField(logfields.EndpointID, ep.ID).Debug("Recording DNS lookup in endpoint specific cache")
 				effectiveTTL := int(TTL)
 				if effectiveTTL < option.Config.ToFQDNsMinTTL {
@@ -372,14 +373,13 @@ func (d *Daemon) bootstrapFQDN(restoredEndpoints *endpointRestoreState, preCache
 					ep.SyncEndpointHeaderFile(d)
 				}
 
-				log.Debug("Updating DNS name in cache from response to to query")
 				err = d.dnsRuleGen.UpdateGenerateDNS(lookupTime, map[string]*fqdn.DNSIPRecords{
 					qname: {
 						IPs: responseIPs,
 						TTL: int(effectiveTTL),
 					}})
 				if err != nil {
-					log.WithError(err).Error("error updating internal DNS cache for rule generation")
+					log.WithError(err).Error("Error updating internal DNS cache for rule generation")
 				}
 				endMetric()
 			}

--- a/pkg/fqdn/helpers.go
+++ b/pkg/fqdn/helpers.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cilium/cilium/pkg/fqdn/matchpattern"
 	"github.com/cilium/cilium/pkg/fqdn/regexpmap"
 	"github.com/cilium/cilium/pkg/ip"
+	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/uuid"
@@ -31,7 +32,12 @@ import (
 
 // getUUIDFromRuleLabels returns the value of the UUID label
 func getRuleUUIDLabel(rule *api.Rule) (uuid string) {
-	return rule.Labels.Get(uuidLabelSearchKey)
+	keyb := labels.NewLabel(k8sConst.PolicyLabelUID, "", labels.LabelSourceK8s)
+	key := keyb.GetExtendedKey()
+	if !rule.Labels.Has(key) {
+		return rule.Labels.Get(uuidLabelSearchKey)
+	}
+	return rule.Labels.Get(key)
 }
 
 // generateUUIDLabel builds a random UUID label that can be used to uniquely identify


### PR DESCRIPTION
At the moment the fqdn rulegen is a bit complicated. It creates the
policy, will stop managing and start managing in the same policy add.
That makes difficult to debug issues, and hard to figure it races found
in issue #7105

With this change a new behaviour is added:

- The submitted  policy is marked with FQDN result and a new rule DeepCopy is returned.
- All operations in policyAdd are made using the new Copy of the policy.
- If all goes well, the copy of the rules will be pushed to FQDN rule
gen to keep in the storage a new recent version.

Also this PR uses kubernetes policies UUID  if are present, so it's easy
to debug in logs and correlate between then.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>


Pending things: 

- [ ] Fix unittests
  - [ ] Add unittest for remove UUID that are clean correctly. 
  - [ ] Add a unittest for multiple CNP specs. 
- [ ]  Add a e2e test with multiple specs in a CNP. 
- [ ] Add comments in the code  
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7183)
<!-- Reviewable:end -->
