### PR TITLE
test: Test upgrade from v1.3 to master

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -213,7 +213,7 @@ const (
 )
 
 // NightlyStableUpgradesFrom the cilium images to update from in Nightly test.
-var NightlyStableUpgradesFrom = []string{"v1.2"}
+var NightlyStableUpgradesFrom = []string{"v1.3"}
 
 var (
 	CiliumV1_0 = versioncheck.MustCompile(">=v1.0,<v1.1")


### PR DESCRIPTION
Test upgrades from v1.3 to master, instead of from v1.2 to master, as we no longer support upgrade from v1.2.

Fixes #7187

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7189)
<!-- Reviewable:end -->
