### PR TITLE
pkg/kvstore: do not use default instance to create new instance module

### DIFF
--- a/pkg/kvstore/consul.go
+++ b/pkg/kvstore/consul.go
@@ -54,7 +54,16 @@ var (
 	//consulDummyConfigFile can be overwritten from test invokers using ldflags
 	consulDummyConfigFile = "/tmp/cilium-consul-certs/cilium-consul.yaml"
 
-	module = &consulModule{
+	module = newConsulModule()
+)
+
+func init() {
+	// register consul module for use
+	registerBackend(consulName, module)
+}
+
+func newConsulModule() backendModule {
+	return &consulModule{
 		opts: backendOptions{
 			optAddress: &backendOption{
 				description: "Addresses of consul cluster",
@@ -64,16 +73,10 @@ var (
 			},
 		},
 	}
-)
-
-func init() {
-	// register consul module for use
-	registerBackend(consulName, module)
 }
 
 func (c *consulModule) createInstance() backendModule {
-	cpy := *module
-	return &cpy
+	return newConsulModule()
 }
 
 func (c *consulModule) getName() string {

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -68,7 +68,15 @@ var (
 	// etcdDummyAddress can be overwritten from test invokers using ldflags
 	etcdDummyAddress = "http://127.0.0.1:4002"
 
-	etcdInstance = &etcdModule{
+	etcdInstance = newEtcdModule()
+)
+
+func EtcdDummyAddress() string {
+	return etcdDummyAddress
+}
+
+func newEtcdModule() backendModule {
+	return &etcdModule{
 		opts: backendOptions{
 			addrOption: &backendOption{
 				description: "Addresses of etcd cluster",
@@ -78,15 +86,10 @@ var (
 			},
 		},
 	}
-)
-
-func EtcdDummyAddress() string {
-	return etcdDummyAddress
 }
 
 func (e *etcdModule) createInstance() backendModule {
-	cpy := *etcdInstance
-	return &cpy
+	return newEtcdModule()
 }
 
 func (e *etcdModule) getName() string {


### PR DESCRIPTION
By returning the same instance module for every client created this
can create race conditions if 2 or more clients are being setup at the
same time. For this reason we should really create a new instance
instead of using a copy of an existing instance.

Fixes: 96895f9d35cf ("kvstore: Support creation of multiple clients")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7191)
<!-- Reviewable:end -->
