### PR TITLE
vendor: fix vendor/golang.org/x/net

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1244,7 +1244,7 @@
   revision = "56440b844dfe139a8ac053f4ecac0b20b79058f4"
 
 [[projects]]
-  digest = "1:77f0df0a744220ea2d96c636686811a7888c1297ff4ecce5cc97b30df4e3a78f"
+  digest = "1:e10b2fc351acc7685b214f37d683594eef61a74f8f8d178168a37298aaf136da"
   name = "golang.org/x/net"
   packages = [
     "bpf",

--- a/vendor/golang.org/x/net/netutil/listen.go
+++ b/vendor/golang.org/x/net/netutil/listen.go
@@ -14,25 +14,51 @@ import (
 // LimitListener returns a Listener that accepts at most n simultaneous
 // connections from the provided Listener.
 func LimitListener(l net.Listener, n int) net.Listener {
-	return &limitListener{l, make(chan struct{}, n)}
+	return &limitListener{
+		Listener: l,
+		sem:      make(chan struct{}, n),
+		done:     make(chan struct{}),
+	}
 }
 
 type limitListener struct {
 	net.Listener
-	sem chan struct{}
+	sem       chan struct{}
+	closeOnce sync.Once     // ensures the done chan is only closed once
+	done      chan struct{} // no values sent; closed when Close is called
 }
 
-func (l *limitListener) acquire() { l.sem <- struct{}{} }
+// acquire acquires the limiting semaphore. Returns true if successfully
+// accquired, false if the listener is closed and the semaphore is not
+// acquired.
+func (l *limitListener) acquire() bool {
+	select {
+	case <-l.done:
+		return false
+	case l.sem <- struct{}{}:
+		return true
+	}
+}
 func (l *limitListener) release() { <-l.sem }
 
 func (l *limitListener) Accept() (net.Conn, error) {
-	l.acquire()
+	acquired := l.acquire()
+	// If the semaphore isn't acquired because the listener was closed, expect
+	// that this call to accept won't block, but immediately return an error.
 	c, err := l.Listener.Accept()
 	if err != nil {
-		l.release()
+		if acquired {
+			l.release()
+		}
 		return nil, err
 	}
 	return &limitListenerConn{Conn: c, release: l.release}, nil
+}
+
+func (l *limitListener) Close() error {
+	err := l.Listener.Close()
+	l.closeOnce.Do(func() { close(l.done) })
+	return err
 }
 
 type limitListenerConn struct {


### PR DESCRIPTION
It seems the vendor directory got out of sync as this is the output of
`dep ensure` of the current master branch.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7192)
<!-- Reviewable:end -->
