### PR TITLE
metrics for k8s client-go library

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1898,6 +1898,7 @@
     "k8s.io/client-go/testing",
     "k8s.io/client-go/tools/cache",
     "k8s.io/client-go/tools/clientcmd",
+    "k8s.io/client-go/tools/metrics",
     "k8s.io/client-go/util/flowcontrol",
     "k8s.io/client-go/util/jsonpath",
     "k8s.io/code-generator/cmd/client-gen",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1588,7 +1588,7 @@
   revision = "kubernetes-1.13.3"
 
 [[projects]]
-  digest = "1:e00a2f6e9516b21e01cf2878e2926fee4cf8ec1be1b4b36f201d7c31ccc1ce4d"
+  digest = "1:1dd09943a44ac236806aaae16aa521cf43727eaa48b1bd409e5d7da884d8466a"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -1689,7 +1689,8 @@
     "util/retry",
   ]
   pruneopts = "NUT"
-  revision = "kubernetes-1.13.3"
+  revision = "b5836377ae6c61ca4e81982fc253d1ef21a1ca87"
+  source = "https://github.com/cilium/client-go"
 
 [[projects]]
   digest = "1:dc1ae99dcab96913d81ae970b1f7a7411a54199b14bfb17a7e86f9a56979c720"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -521,10 +521,11 @@ required = [
 
 [[constraint]]
   name = "k8s.io/client-go"
-  revision = "kubernetes-1.13.3"
+  source = "https://github.com/cilium/client-go"
+  revision = "b5836377ae6c61ca4e81982fc253d1ef21a1ca87"
 
   # main-usage = "pkg/k8s"
-  # on-revision = ""
+  # on-revision = "TODO @aanm is on b5836377ae6c61ca4e81982fc253d1ef21a1ca87 as it contains the hotfix for the metrics path"
 
 [[constraint]]
   name = "k8s.io/code-generator"

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -70,6 +70,9 @@ var (
 	// Agent is the subsystem to cope metrics related to the cilium agent itself.
 	Agent = "agent"
 
+	// K8sClient is the subsystem to scope metrics related to the kubernetes client.
+	K8sClient = "k8s_client"
+
 	// LabelOutcome indicates whether the outcome of the operation was successful or not
 	LabelOutcome = "outcome"
 
@@ -481,6 +484,26 @@ var (
 		Help:      "Number of Kubernetes events received labeled by scope, action and execution result",
 	}, []string{LabelScope, LabelAction, LabelStatus})
 
+	// Kubernetes interactions
+
+	// KubernetesAPIInteractions is the total time taken to process an API call made
+	// to the kube-apiserver
+	KubernetesAPIInteractions = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: Namespace,
+		Subsystem: K8sClient,
+		Name:      "api_latency_time_seconds",
+		Help:      "Duration of processed API calls labeled by path and method.",
+	}, []string{LabelPath, LabelMethod})
+
+	// KubernetesAPICalls is the counter for all API calls made to
+	// kube-apiserver.
+	KubernetesAPICalls = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Subsystem: K8sClient,
+		Name:      "api_calls_counter",
+		Help:      "Number of API calls made to kube-apiserver labeled by host, method and return code.",
+	}, []string{"host", LabelMethod, LabelAPIReturnCode})
+
 	// IPAM events
 
 	// IpamEvent is the number of IPAM events received labeled by action and
@@ -524,6 +547,8 @@ func init() {
 	// TODO: Figure out how to put this into a Namespace
 	//MustRegister(prometheus.NewGoCollector())
 	MustRegister(APIInteractions)
+	MustRegister(KubernetesAPIInteractions)
+	MustRegister(KubernetesAPICalls)
 
 	MustRegister(EndpointCountRegenerating)
 	MustRegister(EndpointRegenerationCount)

--- a/vendor/k8s.io/client-go/rest/request.go
+++ b/vendor/k8s.io/client-go/rest/request.go
@@ -469,7 +469,13 @@ func (r Request) finalURLTemplate() url.URL {
 	groupIndex := 0
 	index := 0
 	if r.URL() != nil && r.baseURL != nil && strings.Contains(r.URL().Path, r.baseURL.Path) {
-		groupIndex += len(strings.Split(r.baseURL.Path, "/"))
+		// only add baseURL path length if it is different than `/`
+		// as strings.Split("/", "/") returns length of 2
+		if r.baseURL.Path != "/" {
+			groupIndex += len(strings.Split(r.baseURL.Path, "/"))
+		} else {
+			groupIndex += 1
+		}
 	}
 	if groupIndex >= len(segments) {
 		return *url


### PR DESCRIPTION
Depends on https://github.com/cilium/cilium/pull/7192

I can drop the last commit if we are happy by having the "{prefix}" until the upstream PR made to k8s is merged.

Read per commit.

```release-note
add metrics for k8s api-server interactions
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7193)
<!-- Reviewable:end -->
