### PR TITLE
Ignore preflight errors for unsupported kernel

### DIFF
--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -145,6 +145,9 @@ fi
 # Around the `--ignore-preflight-errors=cri` is used because
 # /var/run/dockershim.sock is not present (because base image has containerd)
 # so with that option kubeadm fallback to /var/run/docker.sock
+#
+# SystemVerification errors are ignored as net-next VM often triggers them, eg:
+#     [ERROR SystemVerification]: unsupported kernel release: 5.0.0-rc6+
 case $K8S_VERSION in
     "1.8")
         KUBERNETES_CNI_VERSION="0.5.1"
@@ -182,7 +185,7 @@ case $K8S_VERSION in
     "1.13")
         KUBERNETES_CNI_VERSION="0.6.0"
         K8S_FULL_VERSION="1.13.3"
-        KUBEADM_OPTIONS="--ignore-preflight-errors=cri"
+        KUBEADM_OPTIONS="--ignore-preflight-errors=cri,SystemVerification"
         KUBEADM_SLAVE_OPTIONS="--discovery-token-unsafe-skip-ca-verification --ignore-preflight-errors=cri,SystemVerification"
         sudo ln -sf $COREDNS_DEPLOYMENT $DNS_DEPLOYMENT
         KUBEADM_CONFIG="${KUBEADM_CONFIG_ALPHA3}"


### PR DESCRIPTION
This works around the following error in preflight checks on k8s1-1.13:

    [ERROR SystemVerification]: unsupported kernel release: 5.0.0-rc6+

We could consider alternatively using the environment variable `NETNEXT` to determine whether to ignore these errors, but I don't know if there's other reasons we're ignoring this class of preflight errors for the various k8s versions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7194)
<!-- Reviewable:end -->
