### PR TITLE
Fix up MAC,IPv6 addresses in testutils endpoint

### DIFF
--- a/pkg/testutils/endpoint.go
+++ b/pkg/testutils/endpoint.go
@@ -26,6 +26,7 @@ import (
 type TestEndpoint struct {
 	Id   uint64
 	Opts *option.IntOptions
+	MAC  mac.MAC
 }
 
 func NewTestEndpoint() TestEndpoint {
@@ -33,6 +34,7 @@ func NewTestEndpoint() TestEndpoint {
 	opts.SetBool("TEST_OPTION", true)
 	return TestEndpoint{
 		Id:   42,
+		MAC:  mac.MAC([]byte{0x02, 0x00, 0x60, 0x0D, 0xF0, 0x0D}),
 		Opts: opts,
 	}
 }
@@ -43,7 +45,7 @@ func (e *TestEndpoint) GetCIDRPrefixLengths() ([]int, []int)  { return nil, nil 
 func (e *TestEndpoint) GetID() uint64                         { return e.Id }
 func (e *TestEndpoint) StringID() string                      { return "42" }
 func (e *TestEndpoint) GetIdentity() identity.NumericIdentity { return 42 }
-func (e *TestEndpoint) GetNodeMAC() mac.MAC                   { return nil }
+func (e *TestEndpoint) GetNodeMAC() mac.MAC                   { return e.MAC }
 func (e *TestEndpoint) GetOptions() *option.IntOptions        { return e.Opts }
 
 func (e *TestEndpoint) IPv4Address() addressing.CiliumIPv4 {

--- a/pkg/testutils/endpoint.go
+++ b/pkg/testutils/endpoint.go
@@ -53,7 +53,7 @@ func (e *TestEndpoint) IPv4Address() addressing.CiliumIPv4 {
 	return addr
 }
 func (e *TestEndpoint) IPv6Address() addressing.CiliumIPv6 {
-	addr, _ := addressing.NewCiliumIPv6("::ffff:192.0.2.3")
+	addr, _ := addressing.NewCiliumIPv6("2001:db08:0bad:cafe:600d:bee2:0bad:cafe")
 	return addr
 }
 


### PR DESCRIPTION
These implementations were providing broken MAC/IPv6 addresses which would cause any unit tests built on top of this to fail. Fix them up.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7197)
<!-- Reviewable:end -->
