### PR TITLE
ctmap: Print source addresses in ctmap cli

### DIFF
--- a/pkg/maps/ctmap/ipv4.go
+++ b/pkg/maps/ctmap/ipv4.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -103,6 +103,26 @@ type CtKey4Global struct {
 
 func (k *CtKey4Global) String() string {
 	return fmt.Sprintf("%s:%d --> %s:%d, %d, %d", k.SourceAddr, k.SourcePort, k.DestAddr, k.DestPort, k.NextHeader, k.Flags)
+}
+
+// ToNetwork converts ports to network byte order.
+//
+// This is necessary to prevent callers from implicitly converting the
+// CtKey4Global type here into a local key type in the nested CtKey4 field.
+func (k *CtKey4Global) ToNetwork() CtKey {
+	return &CtKey4Global{
+		CtKey4: *k.CtKey4.ToNetwork().(*CtKey4),
+	}
+}
+
+// ToHost converts CtKey4 ports to host byte order.
+//
+// This is necessary to prevent callers from implicitly converting the
+// CtKey4Global type here into a local key type in the nested CtKey4 field.
+func (k *CtKey4Global) ToHost() CtKey {
+	return &CtKey4Global{
+		CtKey4: *k.CtKey4.ToHost().(*CtKey4),
+	}
 }
 
 // Dump writes the contents of key to buffer and returns true if the value for

--- a/pkg/maps/ctmap/ipv6.go
+++ b/pkg/maps/ctmap/ipv6.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -102,6 +102,26 @@ type CtKey6Global struct {
 
 func (k *CtKey6Global) String() string {
 	return fmt.Sprintf("[%s]:%d --> [%s]:%d, %d, %d", k.SourceAddr, k.SourcePort, k.DestAddr, k.DestPort, k.NextHeader, k.Flags)
+}
+
+// ToNetwork converts ports to network byte order.
+//
+// This is necessary to prevent callers from implicitly converting the
+// CtKey6Global type here into a local key type in the nested CtKey6 field.
+func (k *CtKey6Global) ToNetwork() CtKey {
+	return &CtKey6Global{
+		CtKey6: *k.CtKey6.ToNetwork().(*CtKey6),
+	}
+}
+
+// ToHost converts CtKey6 ports to host byte order.
+//
+// This is necessary to prevent callers from implicitly converting the
+// CtKey6Global type here into a local key type in the nested CtKey6 field.
+func (k *CtKey6Global) ToHost() CtKey {
+	return &CtKey6Global{
+		CtKey6: *k.CtKey6.ToHost().(*CtKey6),
+	}
 }
 
 // Dump writes the contents of key to buffer and returns true if the value for


### PR DESCRIPTION
Fix an issue where ctmap entries dumped from global maps would be
printed in the form used for local conntrack entries, missing the
source address information.

Fixes: 803bf0a1ae98 ("cilium: Refactor ct list to use new APIs")
Fixes: #7064

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7200)
<!-- Reviewable:end -->
