### PR TITLE
Get rid of JoinEP flakes

### DIFF
--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -656,12 +656,7 @@ func (s *SSHMeta) ValidateNoErrorsInLogs(duration time.Duration) {
 		}
 	}()
 
-	for _, message := range checkLogsMessages {
-		if strings.Contains(logs, message) {
-			fmt.Fprintf(CheckLogs, "⚠️  Found a %q in logs\n", message)
-			ginkgoext.Fail(fmt.Sprintf("Found a %q in Cilium Logs", message))
-		}
-	}
+	failIfContainsBadLogMsg(logs)
 
 	// Count part
 	for _, message := range countLogsMessages {

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -236,7 +236,16 @@ const CiliumDefaultPreFlight = "cilium-pre-flight.yaml"
 // CiliumConfigMapPatch is the default Cilium ConfigMap patch to be used in all tests.
 const CiliumConfigMapPatch = "cilium-cm-patch.yaml"
 
-var checkLogsMessages = []string{panicMessage, deadLockHeader, segmentationFault, NACKreceived, RunInitFailed}
+// badLogMessages is a map which key is a part of a log message which indicates
+// a failure if the message does not contain any part from value list.
+var badLogMessages = map[string][]string{
+	panicMessage:      nil,
+	deadLockHeader:    nil,
+	segmentationFault: nil,
+	NACKreceived:      nil,
+	RunInitFailed:     {"signal: terminated", "signal: killed"},
+}
+
 var countLogsMessages = []string{contextDeadlineExceeded, ErrorLogs, WarningLogs, APIPanicked, selfishThresholdMsg}
 
 var ciliumCLICommands = map[string]string{

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1524,12 +1524,8 @@ func (kub *Kubectl) ValidateNoErrorsInLogs(duration time.Duration) {
 		}
 	}()
 
-	for _, message := range checkLogsMessages {
-		if strings.Contains(logs, message) {
-			fmt.Fprintf(CheckLogs, "⚠️  Found a '%s' in logs\n", message)
-			ginkgoext.Fail(fmt.Sprintf("Found a '%s' in Cilium Logs", message))
-		}
-	}
+	failIfContainsBadLogMsg(logs)
+
 	// Count part
 	for _, message := range countLogsMessages {
 		var prefix = ""

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -393,3 +393,26 @@ func CanRunK8sVersion(ciliumVersion, k8sVersionStr string) (bool, error) {
 	}
 	return constraint.Check(k8sVersion), nil
 }
+
+// failIfContainsBadLogMsg makes a test case to fail if any message from
+// given log messages contains an entry from badLogMessages (map key) AND
+// does not contain ignore messages (map value).
+func failIfContainsBadLogMsg(logs string) {
+	for _, msg := range strings.Split(logs, "\n") {
+		for fail, ignoreMessages := range badLogMessages {
+			if strings.Contains(msg, fail) {
+				ok := false
+				for _, ignore := range ignoreMessages {
+					if strings.Contains(msg, ignore) {
+						ok = true
+						break
+					}
+				}
+				if !ok {
+					fmt.Fprintf(CheckLogs, "⚠️  Found a %q in logs\n", fail)
+					ginkgoext.Fail(fmt.Sprintf("Found a %q in Cilium Logs", fail))
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Previously, if a log of a test run contained any "bad" message from the predefined list, such test was marked as failing one. This introduced many flakes for the `JoinEP:` "bad" message, as due to terminating cilium-agent any subprocess of loader was stopped with either SIGTERM or SIGKILL which resulted in a "bad" message with `JoinEP:` being logged.

This commit relaxes the "bad" messages check by introducing a sublist containing a list of values which indicate whether the "bad" message has to be ignored if the "bad" log message contains any of the values.

The relaxed check is more computationally intense due to the string splitting and the iteration of each log message. However, when measured, the time (sum of all test cases per CI build run) it takes to perform the check is not really noticeable:

    67.443 ms (old check) vs  112.486 ms (relaxed check)

Fixes #6786 #6059 

---

An alternative approach would have been to ignore the `JoinEP` "bad" messages after cilium-agent has terminated, but that would complicate the check.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7203)
<!-- Reviewable:end -->
