### PR TITLE
endpoint: Fix and quieten endpoint revert logs

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -791,14 +791,14 @@ func (e *Endpoint) finalizeProxyState(regenContext *regenerationContext, err err
 		e.Unlock()
 	} else {
 		if err := e.LockAlive(); err != nil {
-			e.getLogger().WithError(err).Debug("Skipping unnecessary restoring endpoint state")
+			e.getLogger().WithError(err).Debug("Skipping unnecessary reverting of endpoint regeneration changes")
 			return
 		}
-		e.getLogger().Error("Restoring endpoint state after BPF regeneration failed")
+		e.getLogger().Debug("Reverting endpoint changes after BPF regeneration failed")
 		if err := datapathRegenCtx.revertStack.Revert(); err != nil {
-			e.getLogger().WithError(err).Error("Restoring endpoint state failed")
+			e.getLogger().WithError(err).Error("Reverting endpoint regeneration changes failed")
 		}
-		e.getLogger().Error("Finished restoring endpoint state after BPF regeneration failed")
+		e.getLogger().Debug("Finished reverting endpoint changes after BPF regeneration failed")
 		e.Unlock()
 	}
 }


### PR DESCRIPTION
These logs are overly verbose (they don't tell you anything you don't
already know), and they also use the terms "endpoint restore" which have
a well-known meaning that applies to reconstruction of endpoint state
during restart. Avoid using those terms so we don't mix them up.

Noticed in a v1.3 deployment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7207)
<!-- Reviewable:end -->
