### PR TITLE
endpoint: Fix ENABLE_NAT46 endpoint config validation

### DIFF
--- a/pkg/option/runtime_options.go
+++ b/pkg/option/runtime_options.go
@@ -91,14 +91,20 @@ var (
 		Description: "Enable automatic NAT46 translation",
 		Requires:    []string{Conntrack},
 		Verify: func(key string, val string) error {
-			if !Config.EnableIPv4 {
-				return ErrNAT46ReqIPv4
+			opt, err := NormalizeBool(val)
+			if err != nil {
+				return err
 			}
-			if !Config.EnableIPv6 {
-				return ErrNAT46ReqIPv6
-			}
-			if Config.DatapathMode == DatapathModeIpvlan {
-				return ErrNAT46ReqVeth
+			if opt == OptionEnabled {
+				if !Config.EnableIPv4 {
+					return ErrNAT46ReqIPv4
+				}
+				if !Config.EnableIPv6 {
+					return ErrNAT46ReqIPv6
+				}
+				if Config.DatapathMode == DatapathModeIpvlan {
+					return ErrNAT46ReqVeth
+				}
 			}
 			return nil
 		},


### PR DESCRIPTION
Previously, the validation function of the `ENABLE_NAT46` field did not check a given value and it assumed that the function is called whenever a caller wants to enable NAT46.

This was not always the case. E.g. `cilium endpoint config 1923 ConntrackLocal Enabled` did not specify the field, but the request handler was anyway calling the validation function for the field with value "Disabled" which resulted in a response with the 400 error code:

    Error: Cannot update endpoint 1923: [PATCH /endpoint/{id}/config][400]
    patchEndpointIdConfigInvalid

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7213)
<!-- Reviewable:end -->
