### PR TITLE
pkg/kvstore: add 15 min TTL for the first session lease

### DIFF
--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -287,7 +287,7 @@ func connectEtcdClient(config *client.Config, cfgPath string, errChan chan error
 
 	// create session in parallel as this is a blocking operation
 	go func() {
-		session, err := concurrency.NewSession(c)
+		session, err := concurrency.NewSession(c, concurrency.WithTTL(int(LeaseTTL.Seconds())))
 		errorChan <- err
 		sessionChan <- session
 		close(sessionChan)


### PR DESCRIPTION
As etcd deletes the paths for which the leases have expired this causes
the some keys to be deleted if cilium is not running on a particular node
for more than 60 seconds, which is the default lease TTL.

Signed-off-by: André Martins <andre@cilium.io>

This will stop node delete events, that we have been seeing in the testing cluster during restarts, only **after** this patch is in place.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7214)
<!-- Reviewable:end -->
