### PR TITLE
workloads: Synchronous handling of container events

### DIFF
--- a/pkg/workloads/containerd.go
+++ b/pkg/workloads/containerd.go
@@ -144,7 +144,7 @@ func (c *containerDClient) Status() *models.Status {
 }
 
 const (
-	syncRateContainerD = 30 * time.Second
+	syncRateContainerD = 5 * time.Minute
 )
 
 // EnableEventListener watches for containerD events. Performs the plumbing for

--- a/pkg/workloads/docker.go
+++ b/pkg/workloads/docker.go
@@ -268,7 +268,7 @@ func (d *dockerClient) Status() *models.Status {
 }
 
 const (
-	syncRateDocker = 30 * time.Second
+	syncRateDocker = 5 * time.Minute
 
 	eventQueueBufferSize = 100
 )

--- a/pkg/workloads/watcher_state.go
+++ b/pkg/workloads/watcher_state.go
@@ -129,7 +129,6 @@ func (ws *watcherState) syncWithRuntime() {
 			wg.Add(1)
 			go func(wg *sync.WaitGroup, id string) {
 				defer wg.Done()
-				ws.enqueueByContainerID(id, nil) // ensure a handler is running for future events
 				Client().handleCreateWorkload(id, false)
 			}(&wg, contID)
 		}

--- a/pkg/workloads/watcher_state.go
+++ b/pkg/workloads/watcher_state.go
@@ -130,7 +130,7 @@ func (ws *watcherState) syncWithRuntime() {
 			go func(wg *sync.WaitGroup, id string) {
 				defer wg.Done()
 				ws.enqueueByContainerID(id, nil) // ensure a handler is running for future events
-				go Client().handleCreateWorkload(id, false)
+				Client().handleCreateWorkload(id, false)
 			}(&wg, contID)
 		}
 	}


### PR DESCRIPTION
The periodic container runtime watcher has been scheduling go routines into the background for each container to allow for parallel handling. However, the existing waitgroup did not wait for the events to be handled completely. This could cause for a pile up of go routines which continue to interact with the container runtime and the apiserver.

Fixes: #7209

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7217)
<!-- Reviewable:end -->
