### PR TITLE
Make map names static-length

### DIFF
--- a/pkg/bpf/bpffs_linux.go
+++ b/pkg/bpf/bpffs_linux.go
@@ -107,7 +107,7 @@ func MapPath(name string) string {
 
 // LocalMapName returns the name for a BPF map that is local to the specified ID.
 func LocalMapName(name string, id uint16) string {
-	return fmt.Sprintf("%s%d", name, id)
+	return fmt.Sprintf("%s%05d", name, id)
 }
 
 // LocalMapPath returns the path for a BPF map that is local to the specified ID.

--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -190,6 +190,11 @@ func (m *Map) GetFd() int {
 	return m.fd
 }
 
+// Name returns the basename of this map.
+func (m *Map) Name() string {
+	return m.name
+}
+
 // Path returns the path to this map on the filesystem.
 func (m *Map) Path() (string, error) {
 	if err := m.setPathIfUnset(); err != nil {

--- a/pkg/datapath/maps/map.go
+++ b/pkg/datapath/maps/map.go
@@ -95,9 +95,14 @@ func newMapSweeper(g endpointManager) *mapSweeper {
 // deleteMapIfStale uses the endpointManager implementation to determine for
 // the given path whether it should be deleted, and if so deletes the path.
 func (ms *mapSweeper) deleteMapIfStale(path string, filename string, endpointID string) {
-	if tmp, err := strconv.ParseUint(endpointID, 0, 16); err == nil {
+	if tmp, err := strconv.ParseUint(endpointID, 10, 16); err == nil {
 		epID := uint16(tmp)
-		if !ms.endpointExists(epID) {
+		if ms.endpointExists(epID) {
+			prefix := strings.TrimSuffix(filename, endpointID)
+			if filename != bpf.LocalMapName(prefix, uint16(tmp)) {
+				ms.removeMapPath(path)
+			}
+		} else {
 			err2 := ms.removeDatapathMapping(epID)
 			if err2 != nil {
 				log.WithError(err2).Debugf("Failed to remove ID %d from global policy map", tmp)

--- a/pkg/datapath/maps/map_test.go
+++ b/pkg/datapath/maps/map_test.go
@@ -82,13 +82,14 @@ func (s *MapTestSuite) TestCollectStaleMapGarbage(c *C) {
 				42,
 			},
 			paths: []string{
-				"cilium_policy_1",
-				"cilium_policy_42",
-				"cilium_ct6_1",
-				"cilium_ct4_1",
-				"cilium_ct_any6_1",
-				"cilium_ct_any4_1",
-				"cilium_ep_config_1",
+				"cilium_policy_00001",
+				"cilium_policy_00001",
+				"cilium_policy_00042",
+				"cilium_ct6_00001",
+				"cilium_ct4_00001",
+				"cilium_ct_any6_00001",
+				"cilium_ct_any4_00001",
+				"cilium_ep_config_00001",
 			},
 			removedPaths:    []string{},
 			removedMappings: []int{},
@@ -96,19 +97,45 @@ func (s *MapTestSuite) TestCollectStaleMapGarbage(c *C) {
 		{
 			name: "Delete some endpoints",
 			endpoints: []uint16{
+				42,
+			},
+			paths: []string{
+				"cilium_policy_00001",
+				"cilium_policy_00042",
+				"cilium_ct6_00001",
+				"cilium_ct4_00001",
+				"cilium_ct_any6_00001",
+				"cilium_ct_any4_00001",
+				"cilium_ep_config_00001",
+			},
+			removedPaths: []string{
+				"cilium_policy_00001",
+				"cilium_ct6_00001",
+				"cilium_ct4_00001",
+				"cilium_ct_any6_00001",
+				"cilium_ct_any4_00001",
+				"cilium_ep_config_00001",
+			},
+			removedMappings: []int{
+				1,
+			},
+		},
+		{
+			name: "Delete some endpoints",
+			endpoints: []uint16{
 				1,
 			},
 			paths: []string{
-				"cilium_policy_1",
-				"cilium_policy_42",
-				"cilium_ct6_1",
-				"cilium_ct4_1",
-				"cilium_ct_any6_1",
-				"cilium_ct_any4_1",
-				"cilium_ep_config_1",
+				"cilium_policy_00001",
+				"cilium_policy_00042",
+				"cilium_ct6_00001",
+				"cilium_ct4_00001",
+				"cilium_ct_any6_00001",
+				"cilium_ct_any4_00001",
+				"cilium_ep_config_00001",
 			},
 			removedPaths: []string{
-				"cilium_policy_42",
+				"cilium_policy_00042",
 			},
 			removedMappings: []int{
 				42,
@@ -118,6 +145,35 @@ func (s *MapTestSuite) TestCollectStaleMapGarbage(c *C) {
 			name:      "Delete every map",
 			endpoints: []uint16{},
 			paths: []string{
+				"cilium_policy_00001",
+				"cilium_policy_00042",
+				"cilium_ct6_00001",
+				"cilium_ct4_00001",
+				"cilium_ct_any6_00001",
+				"cilium_ct_any4_00001",
+				"cilium_ep_config_00001",
+			},
+			removedPaths: []string{
+				"cilium_policy_00001",
+				"cilium_policy_00042",
+				"cilium_ct6_00001",
+				"cilium_ct4_00001",
+				"cilium_ct_any6_00001",
+				"cilium_ct_any4_00001",
+				"cilium_ep_config_00001",
+			},
+			removedMappings: []int{
+				1,
+				42,
+			},
+		},
+		{
+			name: "Delete maps with old path format",
+			endpoints: []uint16{
+				1,
+				42,
+			},
+			paths: []string{
 				"cilium_policy_1",
 				"cilium_policy_42",
 				"cilium_ct6_1",
@@ -125,6 +181,13 @@ func (s *MapTestSuite) TestCollectStaleMapGarbage(c *C) {
 				"cilium_ct_any6_1",
 				"cilium_ct_any4_1",
 				"cilium_ep_config_1",
+				"cilium_policy_00001",
+				"cilium_policy_00042",
+				"cilium_ct6_00001",
+				"cilium_ct4_00001",
+				"cilium_ct_any6_00001",
+				"cilium_ct_any4_00001",
+				"cilium_ep_config_00001",
 			},
 			removedPaths: []string{
 				"cilium_policy_1",
@@ -135,14 +198,12 @@ func (s *MapTestSuite) TestCollectStaleMapGarbage(c *C) {
 				"cilium_ct_any4_1",
 				"cilium_ep_config_1",
 			},
-			removedMappings: []int{
-				1,
-				42,
-			},
+			removedMappings: []int{},
 		},
 	}
 
 	for _, tt := range testCases {
+		c.Log(tt.name)
 		testEPManager := newTestEPManager()
 		sweeper := newMapSweeper(testEPManager)
 

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -21,7 +21,6 @@ import (
 	"math"
 	"net"
 	"os"
-	"path"
 	"unsafe"
 
 	"github.com/cilium/cilium/pkg/bpf"
@@ -459,12 +458,7 @@ func NameIsGlobal(filename string) bool {
 func WriteBPFMacros(fw io.Writer, e CtEndpoint) {
 	var mapEntriesTCP, mapEntriesAny int
 	for _, m := range maps(e, true, true) {
-		filepath, err := m.Path()
-		if err != nil {
-			log.WithError(err).Warningf("Cannot define BPF macro for %s", m.define)
-			continue
-		}
-		fmt.Fprintf(fw, "#define %s %s\n", m.define, path.Base(filepath))
+		fmt.Fprintf(fw, "#define %s %s\n", m.define, m.Name())
 		if m.mapType.isTCP() {
 			mapEntriesTCP = mapInfo[m.mapType].maxEntries
 		} else {

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 Authors of Cilium
+// Copyright 2017-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -1831,8 +1832,9 @@ var _ = Describe("RuntimePolicyImportTests", func() {
 		Expect(err).Should(BeNil(), "Unable to get endpoint IDs")
 
 		for _, endpointID := range endpointIDMap {
+			epID, _ := strconv.Atoi(endpointID)
 			By("Checking that endpoint policy map exists for endpoint %s", endpointID)
-			epPolicyMap := fmt.Sprintf("/sys/fs/bpf/tc/globals/cilium_policy_%s", endpointID)
+			epPolicyMap := fmt.Sprintf("/sys/fs/bpf/tc/globals/cilium_policy_%05d", epID)
 			vm.Exec(fmt.Sprintf("test -f %s", epPolicyMap)).ExpectSuccess(fmt.Sprintf("Endpoint policy map %s does not exist", epPolicyMap))
 		}
 


### PR DESCRIPTION
Tidy up some map name usage, and adjust the map name format such that the length of map names are always of fixed-length. This is important for the upcoming templating work, to simplify rewrite of map names inside ELF files (#7095).

We also update the map cleanup logic, so that upon upgrade Cilium will delete maps that have shorter names, ie which apply to endpoints from a previous run.

Review commit-by-commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7218)
<!-- Reviewable:end -->
