### PR TITLE
Refactor and simplify some datapath compile/configuration code

### DIFF
--- a/pkg/datapath/loader/compile.go
+++ b/pkg/datapath/loader/compile.go
@@ -26,6 +26,8 @@ import (
 	"runtime"
 
 	"github.com/cilium/cilium/pkg/command/exec"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
 
 	"github.com/sirupsen/logrus"
 )
@@ -245,4 +247,59 @@ func compile(ctx context.Context, prog *progInfo, dir *directoryInfo, debug bool
 	}
 
 	return err
+}
+
+// compileDatapath invokes the compiler and linker to create all state files for
+// the BPF datapath, with the primary target being the BPF ELF binary.
+//
+// If debug is enabled, create also the following output files:
+// * Preprocessed C
+// * Assembly
+// * Object compiled with debug symbols
+func compileDatapath(ctx context.Context, ep endpoint, dirs *directoryInfo, debug bool) error {
+	// TODO: Consider logging kernel/clang versions here too
+	epLog := ep.Logger(Subsystem)
+
+	// Write out assembly and preprocessing files for debugging purposes
+	if debug {
+		for _, p := range debugProgs {
+			if err := compile(ctx, p, dirs, debug); err != nil {
+				scopedLog := epLog.WithFields(logrus.Fields{
+					logfields.Params: logfields.Repr(p),
+					logfields.Debug:  debug,
+				})
+				scopedLog.WithError(err).Debug("JoinEP: Failed to compile")
+				return err
+			}
+		}
+	}
+
+	// Compile the new program
+	if err := compile(ctx, datapathProg, dirs, debug); err != nil {
+		scopedLog := epLog.WithFields(logrus.Fields{
+			logfields.Params: logfields.Repr(datapathProg),
+			logfields.Debug:  false,
+		})
+		scopedLog.WithError(err).Warn("JoinEP: Failed to compile")
+		return err
+	}
+
+	return nil
+}
+
+// Compile compiles a BPF program generating an object file.
+func Compile(ctx context.Context, src string, out string) error {
+	debug := option.Config.BPFCompilationDebug
+	prog := progInfo{
+		Source:     src,
+		Output:     out,
+		OutputType: outputObject,
+	}
+	dirs := directoryInfo{
+		Library: option.Config.BpfDir,
+		Runtime: option.Config.StateDir,
+		Output:  option.Config.StateDir,
+		State:   option.Config.StateDir,
+	}
+	return compile(ctx, &prog, &dirs, debug)
 }

--- a/pkg/datapath/loader/compile.go
+++ b/pkg/datapath/loader/compile.go
@@ -79,7 +79,7 @@ var (
 
 	// testIncludes allows the unit tests to inject additional include
 	// paths into the compile command at test time. It is usually nil.
-	testIncludes string
+	testIncludes []string
 
 	debugProgs = []*progInfo{
 		{
@@ -202,14 +202,13 @@ func progCFlags(prog *progInfo, dir *directoryInfo) []string {
 		output = "-" // stdout
 	}
 
-	return []string{
-		testIncludes,
+	return append(testIncludes,
 		fmt.Sprintf("-I%s", path.Join(dir.Runtime, "globals")),
 		fmt.Sprintf("-I%s", dir.State),
 		fmt.Sprintf("-I%s", path.Join(dir.Library, "include")),
 		"-c", path.Join(dir.Library, prog.Source),
 		"-o", output,
-	}
+	)
 }
 
 // compile and link a program.

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -41,13 +41,13 @@ type endpoint interface {
 	Logger(subsystem string) *logrus.Entry
 	StateDir() string
 	MapPath() string
-	MustGraftDatapathMap() bool
+	HasIpvlanDataPath() bool
 }
 
 func reloadDatapath(ctx context.Context, ep endpoint, dirs *directoryInfo) error {
 	// Replace the current program
 	objPath := path.Join(dirs.Output, endpointObj)
-	if ep.MustGraftDatapathMap() {
+	if ep.HasIpvlanDataPath() {
 		if err := graftDatapath(ctx, ep.MapPath(), objPath, symbolFromEndpoint); err != nil {
 			scopedLog := ep.Logger(Subsystem).WithFields(logrus.Fields{
 				logfields.Path: objPath,

--- a/pkg/datapath/loader/loader_test.go
+++ b/pkg/datapath/loader/loader_test.go
@@ -43,6 +43,11 @@ var (
 	ep      = testutils.NewTestEndpoint()
 )
 
+// SetTestIncludes allows test files to configure additional include flags.
+func SetTestIncludes(includes []string) {
+	testIncludes = includes
+}
+
 func Test(t *testing.T) {
 	TestingT(t)
 }
@@ -71,7 +76,8 @@ func (s *LoaderTestSuite) TearDownTest(c *C) {
 // cleanups and pass the exit code of the test run to the caller which can run
 // os.Exit() with the result.
 func runTests(m *testing.M) (int, error) {
-	testIncludes = "-I/usr/include/x86_64-linux-gnu/"
+	SetTestIncludes([]string{"-I/usr/include/x86_64-linux-gnu/"})
+	defer SetTestIncludes(nil)
 
 	tmpDir, err := ioutil.TempDir("/tmp/", "cilium_")
 	if err != nil {

--- a/pkg/endpoint/cache.go
+++ b/pkg/endpoint/cache.go
@@ -35,10 +35,10 @@ type epInfoCache struct {
 	value *lxcmap.EndpointInfo
 
 	// For datapath.loader.endpoint
-	epdir       string
-	id          string
-	ifName      string
-	graftToLoad bool
+	epdir  string
+	id     string
+	ifName string
+	ipvlan bool
 
 	// endpoint is used to get the endpoint's logger.
 	//
@@ -52,13 +52,13 @@ type epInfoCache struct {
 // Must be called when endpoint is still locked.
 func (e *Endpoint) createEpInfoCache(epdir string) *epInfoCache {
 	ep := &epInfoCache{
-		revision:    e.nextPolicyRevision,
-		endpoint:    e,
-		epdir:       epdir,
-		id:          e.StringID(),
-		ifName:      e.IfName,
-		keys:        e.GetBPFKeys(),
-		graftToLoad: e.MustGraftDatapathMap(),
+		revision: e.nextPolicyRevision,
+		endpoint: e,
+		epdir:    epdir,
+		id:       e.StringID(),
+		ifName:   e.IfName,
+		keys:     e.GetBPFKeys(),
+		ipvlan:   e.HasIpvlanDataPath(),
 	}
 
 	var err error
@@ -91,9 +91,9 @@ func (ep *epInfoCache) Logger(subsystem string) *logrus.Entry {
 	return ep.endpoint.Logger(subsystem)
 }
 
-// MustGraftDatapathMap returns whether we need full replacement or grafting of object file.
-func (ep *epInfoCache) MustGraftDatapathMap() bool {
-	return ep.graftToLoad
+// HasIpvlanDataPath returns whether the endpoint's datapath is implemented via ipvlan.
+func (ep *epInfoCache) HasIpvlanDataPath() bool {
+	return ep.ipvlan
 }
 
 // StateDir returns the directory for the endpoint's (next) state.

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -339,12 +339,6 @@ func (e *Endpoint) HasIpvlanDataPath() bool {
 	return false
 }
 
-// MustGraftDatapathMap returns whether we need full replacement or grafting of
-// object file.
-func (e *Endpoint) MustGraftDatapathMap() bool {
-	return e.HasIpvlanDataPath()
-}
-
 // GetIngressPolicyEnabledLocked returns whether ingress policy enforcement is
 // enabled for endpoint or not. The endpoint's mutex must be held.
 func (e *Endpoint) GetIngressPolicyEnabledLocked() bool {

--- a/pkg/testutils/endpoint.go
+++ b/pkg/testutils/endpoint.go
@@ -72,7 +72,3 @@ func (e *TestEndpoint) StateDir() string {
 func (e *TestEndpoint) MapPath() string {
 	return "map_path"
 }
-
-func (e *TestEndpoint) MustGraftDatapathMap() bool {
-	return false
-}


### PR DESCRIPTION
This PR includes a few minor refactors in `pkg/datapath/loader` necessary for #7095 . The main change which should not be functional is to change the endpoint to only report `HasIpvlanDataPath()`, rather than the detail of grafting the map. This simplifies some code later on, and I think that detail is probably a bit more appropriate to keep in `pkg/datapath/` rather than `pkg/endpoint`.

Review commit-by-commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7219)
<!-- Reviewable:end -->
