### PR TITLE
Daemon: Feed policyAdd using a channel.

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -182,6 +182,9 @@ type Daemon struct {
 
 	// ipam is the IP address manager of the agent
 	ipam *ipam.IPAM
+
+	// policyAddQueueRequests is a channel that feeds the PolicyAdd synchronously
+	policyAddQueueRequests chan policyAddQueueOptions
 }
 
 // Datapath returns a reference to the datapath implementation.

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -1087,6 +1087,11 @@ func runDaemon() {
 		return
 	}
 
+	// Start the policy queue channel and add worker to make sure that the
+	// restore of new policies or CNP are updated correctly and we wait with
+	// the worker started.
+	go d.PolicyQueueRequestInitilize(context.Background())
+
 	// This validation needs to be done outside of the agent until
 	// datapath.NodeAddressing is used consistently across the code base.
 	log.Info("Validating configured node address ranges")

--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -258,6 +258,14 @@ func (d *Daemon) PolicyAdd(rules policyAPI.Rules, opts *AddOptions) (newRev uint
 		}
 	}
 	newRev = d.policy.AddListLocked(rules)
+
+	// The rules are added, we can begin ToFQDN DNS polling for them
+	// Note: api.FQDNSelector.sanitize checks that the matchName entries are
+	// valid. This error should never happen (of course).
+	if err := d.dnsRuleGen.StartManageDNSName(rules); err != nil {
+		logger.WithError(err).Warn("Error trying to manage rules during PolicyAdd")
+	}
+
 	d.policy.Mutex.Unlock()
 
 	// Begin tracking the time taken to deploy newRev to the datapath. The start
@@ -281,13 +289,6 @@ func (d *Daemon) PolicyAdd(rules policyAPI.Rules, opts *AddOptions) (newRev uint
 		logger.WithField("prefixes", removedPrefixes).Debug("Decrementing replaced CIDR refcounts when adding rules")
 		ipcache.ReleaseCIDRs(removedPrefixes)
 		d.prefixLengths.Delete(removedPrefixes)
-	}
-
-	// The rules are added, we can begin ToFQDN DNS polling for them
-	// Note: api.FQDNSelector.sanitize checks that the matchName entries are
-	// valid. This error should never happen (of course).
-	if err := d.dnsRuleGen.StartManageDNSName(rules); err != nil {
-		logger.WithError(err).Warn("Error trying to manage rules during PolicyAdd")
 	}
 
 	logger.WithField(logfields.PolicyRevision, newRev).Info("Policy imported via API, recalculating...")

--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -230,7 +230,10 @@ func (d *Daemon) PolicyAdd(rules policyAPI.Rules, opts *AddOptions) (newRev uint
 		metrics.PolicyImportErrors.Inc()
 		logger.WithError(err).WithField("prefixes", prefixes).Warn(
 			"Failed to allocate identities for CIDRs during policy add")
-		return d.policy.GetRevision(), err
+		d.policy.Mutex.Lock()
+		rev := d.policy.GetRevision()
+		d.policy.Mutex.Unlock()
+		return rev, err
 	}
 
 	d.policy.Mutex.Lock()


### PR DESCRIPTION
To avoid races[1] from DNSProxy keep the policyAdd with a channel and
fetch the latest rules from policy repository and feed the policyAdd
using a channel to avoid weird cases. Also keep the CNP/KNP as the valid
source of truth and push always the rules without fetching it.

[1] Race condition diagram:

```
@startuml

participant K8s
participant DNS1
participant DNS2
participant PolicyAdd
participant policyRepo

-[#blue]> K8s: New CNP
K8s -[#blue]> PolicyAdd: Send rules to PolicyAdd
PolicyAdd -[#blue]> PolicyAdd: MarkToFQDNsRules
PolicyAdd -[#blue]> PolicyAdd: Populate local/in-function rule copy IPs from DNS Cache
PolicyAdd -[#blue]> PolicyAdd: Allocate IPs
PolicyAdd -[#blue]> policyRepo: lock
PolicyAdd -[#blue]> policyRepo: Delete old rules from repo
PolicyAdd -[#blue]> PolicyAdd: StopManageDNSName
PolicyAdd -[#blue]> PolicyAdd: Remove references to old rules
PolicyAdd -[#blue]> policyRepo: Add new rules
PolicyAdd -[#blue]> PolicyAdd: StartManageDNSName
PolicyAdd -[#blue]> policyRepo: unlock

== With multiple request ==

-[#gold]> K8s: New CNP
K8s -[#gold]> PolicyAdd: Send rules to PolicyAdd
DNS1 -[#green]> PolicyAdd: Send rules to PolicyAdd
PolicyAdd -[#gold]> PolicyAdd: MarkToFQDNsRules
PolicyAdd -[#gold]> PolicyAdd: Populate local/in-function rule copy IPs from DNS Cache
PolicyAdd -[#gold]> PolicyAdd: Allocate IPs
PolicyAdd -[#green]> PolicyAdd: MarkToFQDNsRules
PolicyAdd -[#green]> PolicyAdd: Populate local/in-function rule copy IPs from DNS Cache
PolicyAdd -[#green]> PolicyAdd: Allocate IPs
PolicyAdd -[#gold]> policyRepo: lock
PolicyAdd -[#gold]> policyRepo: Delete old rules from repo
PolicyAdd -[#gold]> PolicyAdd: StopManageDNSName
PolicyAdd -[#gold]> PolicyAdd: Remove references to old rules
PolicyAdd -[#gold]> policyRepo: Add new rules
PolicyAdd -[#gold]> PolicyAdd: StartManageDNSName
PolicyAdd -[#gold]> policyRepo: unlock
PolicyAdd -[#green]> policyRepo: lock
PolicyAdd -[#green]> policyRepo: Delete old rules from repo
PolicyAdd -[#green]> PolicyAdd: StopManageDNSName
PolicyAdd -[#green]> PolicyAdd: Remove references to old rules
PolicyAdd -[#green]> policyRepo: Add new rules
PolicyAdd -[#green]> PolicyAdd: StartManageDNSName
hnote over PolicyAdd #FFAAAA: **OLD Policy has been added and CNP is not working correctly something is lost**.
PolicyAdd -[#green]> policyRepo: unlock
@enduml
```

Related to #7105

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

Pending things: 

- [x] add unittest. 
- [x] Manual scale testing
- [x] DNStester validation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7220)
<!-- Reviewable:end -->
