### PR TITLE
cilium: fix bailing out on auto-complete when v4/v6 ranges are specified

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1059,10 +1059,6 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 	bootstrapStats.ipam.Start()
 	log.Info("Initializing node addressing")
 
-	if err := node.AutoComplete(); err != nil {
-		log.WithError(err).Fatal("Cannot autocomplete node addresses")
-	}
-
 	node.SetIPv4ClusterCidrMaskSize(option.Config.IPv4ClusterCIDRMaskSize)
 
 	if option.Config.IPv4Range != AutoCIDR {
@@ -1082,6 +1078,10 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 		if err := node.SetIPv6NodeRange(net); err != nil {
 			log.WithError(err).WithField(logfields.V6Prefix, net).Fatal("Invalid per node IPv6 allocation prefix")
 		}
+	}
+
+	if err := node.AutoComplete(); err != nil {
+		log.WithError(err).Fatal("Cannot autocomplete node addresses")
 	}
 
 	// Set up ipam conf after init() because we might be running d.conf.KVStoreIPv4Registration


### PR DESCRIPTION
The node.AutoComplete() checks for ipv{4,6}AllocRange being set even
though in case of != AutoCIDR we set this after node.AutoComplete(),
meaning --ipv{4,6}-range is ignored and daemon bails out nevertheless.

Fixes: 90eed3a04bd8 ("pkg: allocate first IP in IPv4 allocation range")
Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7227)
<!-- Reviewable:end -->
