### PR TITLE
v1.3 backports 2019-02-27

### DIFF
--- a/daemon/state.go
+++ b/daemon/state.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	identityPkg "github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipam"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
@@ -211,11 +212,13 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) {
 				epRegenerated <- false
 			}
 
-			// Wait for initial identities from the kvstore before
-			// doing any policy calculation for endpoints that don't have
-			// a fixed identity or are not well known.
+			// Wait for initial identities and ipcache from the
+			// kvstore before doing any policy calculation for
+			// endpoints that don't have a fixed identity or are
+			// not well known.
 			if !identity.IsFixed() && !identity.IsWellKnown() {
 				identityPkg.WaitForInitialIdentities()
+				ipcache.WaitForInitialSync()
 			}
 
 			if err := ep.LockAlive(); err != nil {

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -210,6 +210,7 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) {
 				scopedLog.WithError(err).Warn("Unable to restore endpoint")
 				epRegenerated <- false
 			}
+
 			// Wait for initial identities from the kvstore before
 			// doing any policy calculation for endpoints that don't have
 			// a fixed identity or are not well known.

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -280,7 +280,7 @@ func connectEtcdClient(config *client.Config, cfgPath string, errChan chan error
 
 	// create session in parallel as this is a blocking operation
 	go func() {
-		session, err := concurrency.NewSession(c)
+		session, err := concurrency.NewSession(c, concurrency.WithTTL(int(LeaseTTL.Seconds())))
 		errorChan <- err
 		sessionChan <- session
 		close(sessionChan)

--- a/pkg/option/runtime_options.go
+++ b/pkg/option/runtime_options.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -90,8 +90,14 @@ var (
 		Description: "Enable automatic NAT46 translation",
 		Requires:    []string{Conntrack},
 		Verify: func(key string, val string) error {
-			if IPv4Disabled {
-				return ErrNAT46ReqIPv4
+			opt, err := NormalizeBool(val)
+			if err != nil {
+				return err
+			}
+			if opt == OptionEnabled {
+				if IPv4Disabled {
+					return ErrNAT46ReqIPv4
+				}
 			}
 			return nil
 		},

--- a/pkg/workloads/containerd.go
+++ b/pkg/workloads/containerd.go
@@ -143,7 +143,7 @@ func (c *containerDClient) Status() *models.Status {
 }
 
 const (
-	syncRateContainerD = 30 * time.Second
+	syncRateContainerD = 5 * time.Minute
 )
 
 // EnableEventListener watches for containerD events. Performs the plumbing for

--- a/pkg/workloads/docker.go
+++ b/pkg/workloads/docker.go
@@ -254,7 +254,7 @@ func (d *dockerClient) Status() *models.Status {
 }
 
 const (
-	syncRateDocker = 30 * time.Second
+	syncRateDocker = 5 * time.Minute
 
 	eventQueueBufferSize = 100
 )

--- a/pkg/workloads/watcher_state.go
+++ b/pkg/workloads/watcher_state.go
@@ -129,7 +129,6 @@ func (ws *watcherState) syncWithRuntime() {
 			wg.Add(1)
 			go func(wg *sync.WaitGroup, id string) {
 				defer wg.Done()
-				ws.enqueueByContainerID(id, nil) // ensure a handler is running for future events
 				Client().handleCreateWorkload(id, false)
 			}(&wg, contID)
 		}

--- a/pkg/workloads/watcher_state.go
+++ b/pkg/workloads/watcher_state.go
@@ -130,7 +130,7 @@ func (ws *watcherState) syncWithRuntime() {
 			go func(wg *sync.WaitGroup, id string) {
 				defer wg.Done()
 				ws.enqueueByContainerID(id, nil) // ensure a handler is running for future events
-				go Client().handleCreateWorkload(id, false)
+				Client().handleCreateWorkload(id, false)
 			}(&wg, contID)
 		}
 	}


### PR DESCRIPTION
* #7213 -- endpoint: Fix ENABLE_NAT46 endpoint config validation (@brb)
   * I had to rebase this as we previously could only disable ipv4, minor conflict.
 * #7214 -- pkg/kvstore: add 15 min TTL for the first session lease (@aanm)
 * #7148 -- Fix policy drops on restart due to lack of kvstore sync (@tgraf)
   * @tgraf, please look closely at these commits as they had quite a few conflicts
 * #7217 -- workloads: Synchronous handling of container events (@tgraf)

Once this PR is merged, you can update the PR labels via:
```
$ for pr in 7213 7214 7148 7217; do contrib/backporting/set-labels.py $pr done 1.3; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7234)
<!-- Reviewable:end -->
