### PR TITLE
Improve backport workflow (sort PRs by merge date!)

### DIFF
--- a/contrib/backporting/check-stable
+++ b/contrib/backporting/check-stable
@@ -62,6 +62,8 @@ extract_pr_title () {
 
 ###############################################################################
 # Get merged PRs that match a specified label and exclude a specified label
+#
+# Each returned array entry is in the form "$merged_at#$prnumber"
 get_prs () {
   local label=$1
   local label_exclude=$2
@@ -83,7 +85,23 @@ get_prs () {
   num_pages=$(((total + prs_per_page - 1) / prs_per_page ))
 
   for current_page in `seq 1 $num_pages`; do
-    prs+=($($GHCURL "${CILIUM_GITHUB_SEARCHAPI}$label_opt$label_exclude_opt&page=$current_page" | jq -r '.items[] | (.number | tostring)'))
+    local page_json
+    local merged_at
+    local pr_url
+    local pr_list
+
+    page_json=$($GHCURL "$url&page=$current_page")
+    pr_list=$(echo -n $page_json | jq -r '.items[] | (.number | tostring)')
+    for pr in $pr_list; do
+      pr_url="https://api.github.com/repos/cilium/cilium/pulls/$pr"
+      merged_at=$($GHCURL "$pr_url" | jq -r '.merged_at')
+
+      # Never merged ...
+      if [[ "$merged_at" = "null" ]]; then
+        continue
+      fi
+      prs+=("$merged_at#$pr ")
+    done
   done
 
   echo "${prs[@]}"
@@ -93,10 +111,10 @@ get_prs () {
 # Generates the release notes for one particular PR
 generate_commit_list_for_pr () {
   local pr=$1
+  local merged_at=$2
   local url
   local pr_json
   local merge_sha
-  local merge_at
   local commits
   local remote
   local branch
@@ -112,22 +130,9 @@ generate_commit_list_for_pr () {
 
   remote=`git remote -v | grep "github.com.cilium/cilium" | head -n1 | cut -f1`
 
-  url="https://api.github.com/repos/cilium/cilium/pulls/$pr"
-  pr_json="$($GHCURL $url)"
-  merge_sha="$(echo -n $pr_json | jq -r '.merge_commit_sha')"
-  merged_at="$(echo -n $pr_json | jq -r '.merged_at')"
-
   url="https://api.github.com/repos/cilium/cilium/pulls/$pr/commits"
   pr_json="$($GHCURL $url)"
   commits="$(echo -n $pr_json | jq -r '.[] | (.sha | tostring)')"
-
-  if [[ "$merge_sha" = "null" ]]; then
-    return
-  fi
-  # Never merged ...
-  if [[ "$merged_at" = "null" ]]; then
-    return
-  fi
 
   SAVEIFS=$IFS
   IFS=$'\n'
@@ -178,14 +183,22 @@ echo "Checking for backports on branch '${STABLE_BRANCH}'"
 stable_prs=($(get_prs "needs-backport/${STABLE_BRANCH}" "backport-done/${STABLE_BRANCH}"))
 echo -e "v$STABLE_BRANCH backports $(date +%Y-%m-%d)\n" | tee $SUMMARY_LOG
 echo -e "PRs for stable backporting: ${#stable_prs[@]}\n"
+
 if [[ ${#stable_prs[@]} > 0 ]]; then
-  for pr in "${stable_prs[@]}"; do
+  SAVEIFS=$IFS
+  IFS=$'\n' sorted_prs=($(sort <<<"${stable_prs[*]}"))
+  IFS=$'\n' stable_prs=($(cut -d'#' -f 2 <<<"${sorted_prs[*]}"))
+  IFS=$SAVEIFS
+
+  for dated_pr in "${sorted_prs[@]}"; do
+    merged_at=$(echo "$dated_pr" | cut -d'#' -f 1)
+    pr=$(echo "$dated_pr" | cut -d'#' -f 2)
     title=$(extract_pr_title "$pr")
     echo " * PR: $pr -- $title -- https://github.com/cilium/cilium/pull/$pr"
     if [[ ! -z $SUMMARY_LOG ]]; then
       echo " * #$pr -- $title" >> $SUMMARY_LOG
     fi
-    generate_commit_list_for_pr $pr
+    generate_commit_list_for_pr $pr $merged_at
     echo ""
   done
   echo "When you have backported the above commits, you can update the PR labels via this command:"

--- a/contrib/backporting/cherry-pick
+++ b/contrib/backporting/cherry-pick
@@ -16,7 +16,8 @@ cherry_pick () {
   echo "" >> $TMPF
   echo "[ upstream commit $FULL_ID ]" >> $TMPF
   git format-patch -1 $FULL_ID --stdout | sed -n '/^$/,/$a/p' >> $TMPF
-  git am -3 --signoff $TMPF
+  echo "Applying: $(git log -1 --oneline $FULL_ID)"
+  git am --quiet -3 --signoff $TMPF
   rm $TMPF
 }
 

--- a/contrib/scripts/fix-sha.sh
+++ b/contrib/scripts/fix-sha.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+SHA_PATH="daemon/bpf.sha"
+MAKE=${MAKE:-"make"}
+if [ ! -e "$SHA_PATH" ]; then
+	echo "Could not locate bpf.sha. Are you in the right directory?" >&2
+	exit 1
+fi
+
+echo "GO_BINDATA_SHA1SUM=01234567890abcdef78901234567890abcdef789" > "$SHA_PATH"
+echo "BPF_FILES=../bpf/.gitignore" >> "$SHA_PATH"
+${MAKE} -C daemon apply-bindata

--- a/contrib/shell/util.sh
+++ b/contrib/shell/util.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Copyright 2016 The Kubernetes Authors All rights reserved.
-# Copyright 2018 Authors of Cilium
+# Copyright 2018-2019 Authors of Cilium
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -93,13 +93,11 @@ function relative() {
 function rebase-bindata
 {
     (
+        local dir
         set -x
         while ! git rebase --continue ; do
-            grep -A 5 "=====" daemon/bpf.sha >daemon/bpf.sha.new
-            sed -i '/^[<=>][<=>]*.*$/d' daemon/bpf.sha.new
-            sed -i '/^$/d' daemon/bpf.sha.new
-            mv -f daemon/bpf.sha.new daemon/bpf.sha
-            make -C daemon apply-bindata
+            dir=$(cd $(dirname ${BASH_SOURCE})/../.. && pwd)
+            $dir/contrib/scripts/fix-sha.sh
             git add daemon/bpf.sha
             if [ $(git diff --diff-filter=U | wc -l) -ne 0 ]; then
                 echo "Files that need manual merge:"


### PR DESCRIPTION
A few more script improvements to make a backporter's life easier:

* Sort the output of the "check-stable" PR by merge date, oldest to newest. This should ease backporting as sorting by PR number was inaccurate and would sometimes reorder PRs, leading to more conflicts than necessary.
* Print the sha of patches being applied when applying the patch. Means when running `contrib/backporting/cherry-pick a b c`, if 'b' fails to apply, it's easier to tell which patch to continue with.
* Add `contrib/scripts/fix-sha.sh` which idempotently restores the `daemon/bpf.sha` into the state it should be if you were to recreate it with the current commits.
* Change the `rebase-bindata` shell util to use `fix-sha.sh`.

No changes to code affected by CI, so I didn't bother running it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7235)
<!-- Reviewable:end -->
