### PR TITLE
contrib: Script for running locally modified Cilium on minikube

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -360,5 +360,8 @@ postcheck: build
 	$(QUIET) contrib/scripts/lock-check.sh
 	@$(SKIP_DOCS) || $(MAKE) check-docs
 
+minikube:
+	$(QUIET) contrib/scripts/minikube.sh
+
 .PHONY: force generate-api generate-health-api
 force :;

--- a/contrib/scripts/minikube.sh
+++ b/contrib/scripts/minikube.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -eux
+
+KUBERNETES_VERSION=${KUBERNETES_VERSION:-v1.13.2}
+
+export MINIKUBE_NETWORK_PLUGIN="cni"
+export MINIKUBE_EXTRA_CONFIG="kubelet.network-plugin=cni"
+export MINIKUBE_MEMORY=5120
+export MINIKUBE_KUBERNETES_VERSION="${KUBERNETES_VERSION}"
+unset CONTAINER_ENGINE
+
+minikube start
+# TODO(mrostecki): Support cri-o and buildah.
+eval $(minikube docker-env)
+
+make docker-image DOCKER_IMAGE_TAG=dev
+
+version="${KUBERNETES_VERSION:1}"
+version_minor="${version%.*}"
+cp "examples/kubernetes/${version_minor}/cilium-minikube.yaml" /tmp/cilium-minikube.yaml
+
+sed -i 's|latest|dev|g' /tmp/cilium-minikube.yaml
+sed -i 's|docker.io/||g' /tmp/cilium-minikube.yaml
+sed -i 's|imagePullPolicy: Always|imagePullPolicy: Never|g' /tmp/cilium-minikube.yaml
+
+kubectl create -f /tmp/cilium-minikube.yaml


### PR DESCRIPTION
This change provides a small script for running locally modified Cilium
sources on Minikube. The limitation of Vagrant development VMs is that
Cilium is running as a systemd service. The only way to check whether
Cilium as a DeamonSet is working was to run Ginkgo test. This utility
provides a possibility to test Cilium as a DS quickier on Minikube.

The script is added as a make target, so the easiest way to invoke it
is:

```
make minikube
make minikube KUBERNETES_VERSION="v1.12.6"
```

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7236)
<!-- Reviewable:end -->
