### PR TITLE
contrib: fix extraction of cilium-docker binary

### DIFF
--- a/contrib/release/uploadrev
+++ b/contrib/release/uploadrev
@@ -63,7 +63,7 @@ function copy_binaries_cilium_docker() {
   echo "target_dir: $TARGET_DIR"
   mkdir -p $TARGET_DIR
   SHA=$(docker create docker.io/cilium/docker-plugin:$REV)
-  docker cp $SHA:/usr/bin/cilium-docker/cilium-docker $TARGET_DIR/cilium-docker-$ARCH
+  docker cp $SHA:/usr/bin/cilium-docker $TARGET_DIR/cilium-docker-$ARCH
   docker rm -f $SHA
 }
 


### PR DESCRIPTION
Commit 084674e4cd84a7c76f28fba404ee340b8bc74d95 changed the location of the
`cilium-docker` binary to be at `/usr/bin/cilium-docker` instead of
`/user/bin/cilium-docker/cilium-docker`, so the uploadrev script needs to be
updated accordingly to extract the binary from its new location in the image.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #7233 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7241)
<!-- Reviewable:end -->
