### PR TITLE
Generate sockops bpf code after node config header is created

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -696,16 +696,16 @@ func (d *Daemon) init() error {
 	sockops.SockmapDisable()
 	sockops.SkmsgDisable()
 
-	if option.Config.SockopsEnable {
-		eppolicymap.CreateEPPolicyMap()
-		sockops.SockmapEnable()
-		sockops.SkmsgEnable()
-		sockmap.SockmapCreate()
-	}
-
 	if !option.Config.DryMode {
 		if err := d.createNodeConfigHeaderfile(); err != nil {
 			return err
+		}
+
+		if option.Config.SockopsEnable {
+			eppolicymap.CreateEPPolicyMap()
+			sockops.SockmapEnable()
+			sockops.SkmsgEnable()
+			sockmap.SockmapCreate()
 		}
 
 		if err := d.compileBase(); err != nil {


### PR DESCRIPTION
The sockops bpf map and code depends on the node config file.
So do this after node_config.h has been generated.

Also, the sockops bpf code is now generated only if dry mode is
not set.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7243)
<!-- Reviewable:end -->
