### PR TITLE
test: Wait for cilium to start in runtime provision

### DIFF
--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -356,26 +356,7 @@ if [ -n "\${K8S}" ]; then
 fi
 
 service cilium restart
-
-cilium_started=false
-
-for ((i = 0 ; i < 24; i++)); do
-    if cilium status > /dev/null 2>&1; then
-        cilium_started=true
-        break
-    fi
-    sleep 5s
-    echo "Waiting for Cilium daemon to come up..."
-done
-
-if [ "\$cilium_started" = true ] ; then
-    echo 'Cilium successfully started!'
-else
-    >&2 echo 'Timeout waiting for Cilium to start...'
-    journalctl -u cilium.service --since \$(systemctl show -p ActiveEnterTimestamp cilium.service | awk '{print \$2 \$3}')
-    >&2 echo 'Cilium failed to start'
-    exit 1
-fi
+/home/vagrant/go/src/github.com/cilium/cilium/test/provision/wait-cilium.sh
 EOF
 }
 

--- a/test/provision/runtime_install.sh
+++ b/test/provision/runtime_install.sh
@@ -13,3 +13,4 @@ sudo systemctl restart ssh
 
 "${PROVISIONSRC}"/dns.sh
 "${PROVISIONSRC}"/compile.sh
+"${PROVISIONSRC}"/wait-cilium.sh

--- a/test/provision/wait-cilium.sh
+++ b/test/provision/wait-cilium.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+main() {
+    local cilium_started
+    cilium_started=false
+
+    for ((i = 0 ; i < 24; i++)); do
+        if cilium status --brief > /dev/null 2>&1; then
+            cilium_started=true
+            break
+        fi
+        sleep 5s
+        echo "Waiting for Cilium daemon to come up..."
+    done
+
+    if [ "$cilium_started" = true ] ; then
+        echo 'Cilium successfully started!'
+    else
+        >&2 echo 'Timeout waiting for Cilium to start...'
+        journalctl -u cilium.service --since $(systemctl show -p ActiveEnterTimestamp cilium.service | awk '{print $2 $3}')
+        >&2 echo 'Cilium failed to start'
+        exit 1
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
Refactor the code used to ensure that the dev VM's cilium has
successfully started into a script and reuse it from the ginkgo
provision scripts. This should ensure that if Cilium crashes shortly
after startup, the CI provision step will fail with a useful error
message in the logs.

This should fix issues like the one seen with the following build
where the logs show no obvious reason why it failed, even though
cilium startup fails with a `Fatal()` call:

https://jenkins.cilium.io/job/Cilium-PR-Ginkgo-Tests-Validated/10306/flowGraphTable/

Example failure where I just caused the daemon to `Fatal()` on startup:
https://jenkins.cilium.io/job/Cilium-PR-Ginkgo-Tests-Validated/10317/execution/node/75/log/

We might consider backporting this to detect such failures more easily in older branches too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7244)
<!-- Reviewable:end -->
