### PR TITLE
policy: cache aggregated list of selectors in rule

### DIFF
--- a/pkg/fqdn/helpers.go
+++ b/pkg/fqdn/helpers.go
@@ -110,6 +110,7 @@ func injectToCIDRSetRules(rule *api.Rule, cache *DNSCache, reMap *regexpmap.Rege
 			// empty to clean old entries in case of TTL expires.
 			egressRule.ToCIDRSet = api.IPsToCIDRRules(ip.KeepUniqueIPs(allIPs))
 		}
+		egressRule.SetAggregatedSelectors()
 
 	}
 

--- a/pkg/fqdn/rulegen.go
+++ b/pkg/fqdn/rulegen.go
@@ -377,7 +377,6 @@ func (gen *RuleGen) GenerateRulesFromSources(sourceRules []*api.Rule) (generated
 		for _, missing := range namesMissingIPs {
 			namesMissingMap[missing] = struct{}{}
 		}
-
 		generatedRules = append(generatedRules, newRule)
 	}
 

--- a/pkg/k8s/apis/cilium.io/utils/utils.go
+++ b/pkg/k8s/apis/cilium.io/utils/utils.go
@@ -124,6 +124,8 @@ func parseToCiliumIngressRule(namespace string, inRule, retRule *api.Rule) {
 				retRule.Ingress[i].FromEntities = make([]api.Entity, len(ing.FromEntities))
 				copy(retRule.Ingress[i].FromEntities, ing.FromEntities)
 			}
+
+			retRule.Ingress[i].SetAggregatedSelectors()
 		}
 	}
 }
@@ -182,6 +184,8 @@ func parseToCiliumEgressRule(namespace string, inRule, retRule *api.Rule) {
 				retRule.Egress[i].ToGroups = make([]api.ToGroups, len(egr.ToGroups))
 				copy(retRule.Egress[i].ToGroups, egr.ToGroups)
 			}
+
+			retRule.Egress[i].SetAggregatedSelectors()
 		}
 	}
 }

--- a/pkg/k8s/apis/cilium.io/utils/utils_test.go
+++ b/pkg/k8s/apis/cilium.io/utils/utils_test.go
@@ -285,6 +285,9 @@ func Test_ParseToCiliumRule(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := ParseToCiliumRule(tt.args.namespace, tt.name, tt.args.uid, tt.args.rule)
+
+			// Sanitize to set aggregatedSelectors field.
+			tt.want.Sanitize()
 			args := []interface{}{got, tt.want}
 			names := []string{"obtained", "expected"}
 			if equal, err := checker.DeepEquals.Check(args, names); !equal {

--- a/pkg/k8s/apis/cilium.io/v2/types_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/types_test.go
@@ -304,6 +304,9 @@ func (s *CiliumV2Suite) TestParseSpec(c *C) {
 	)
 	expectedSpecRule.EndpointSelector = expectedES
 
+	// Sanitize rule to populate aggregated selectors.
+	expectedSpecRule.Sanitize()
+
 	rules, err := expectedPolicyRule.Parse()
 	c.Assert(err, IsNil)
 	c.Assert(len(rules), Equals, 1)
@@ -314,6 +317,7 @@ func (s *CiliumV2Suite) TestParseSpec(c *C) {
 	var expectedPolicyRuleUnmarshalled CiliumNetworkPolicy
 	err = json.Unmarshal(b, &expectedPolicyRuleUnmarshalled)
 	c.Assert(err, IsNil)
+	expectedPolicyRuleUnmarshalled.Parse()
 	c.Assert(expectedPolicyRuleUnmarshalled, checker.DeepEquals, *expectedPolicyRule)
 
 	cnpl := CiliumNetworkPolicy{}
@@ -367,6 +371,10 @@ func (s *CiliumV2Suite) TestParseRules(c *C) {
 	)
 	expectedSpecRule.EndpointSelector = expectedES
 	expectedSpecRules := api.Rules{&expectedSpecRule, &expectedSpecRule}
+	expectedSpecRule.Sanitize()
+	for i := range expectedSpecRules {
+		expectedSpecRules[i].Sanitize()
+	}
 
 	rules, err := expectedPolicyRuleList.Parse()
 	c.Assert(err, IsNil)
@@ -380,6 +388,7 @@ func (s *CiliumV2Suite) TestParseRules(c *C) {
 	var expectedPolicyRuleUnmarshalled CiliumNetworkPolicy
 	err = json.Unmarshal(b, &expectedPolicyRuleUnmarshalled)
 	c.Assert(err, IsNil)
+	expectedPolicyRuleUnmarshalled.Parse()
 	c.Assert(expectedPolicyRuleUnmarshalled, checker.DeepEquals, *expectedPolicyRuleList)
 
 	cnpl := CiliumNetworkPolicy{}

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -250,29 +250,33 @@ func (s *K8sSuite) TestParseNetworkPolicyNoSelectors(c *C) {
 	err := json.Unmarshal(ex1, &np)
 	c.Assert(err, IsNil)
 
-	expectedRules := api.Rules{
-		&api.Rule{
-			EndpointSelector: epSelector,
-			Ingress: []api.IngressRule{
-				{
-					FromCIDRSet: []api.CIDRRule{
-						{
-							Cidr: api.CIDR("10.0.0.0/8"),
-							ExceptCIDRs: []api.CIDR{
-								"10.96.0.0/12",
-							},
+	expectedRule := &api.Rule{
+		EndpointSelector: epSelector,
+		Ingress: []api.IngressRule{
+			{
+				FromCIDRSet: []api.CIDRRule{
+					{
+						Cidr: api.CIDR("10.0.0.0/8"),
+						ExceptCIDRs: []api.CIDR{
+							"10.96.0.0/12",
 						},
 					},
 				},
 			},
-			Egress: []api.EgressRule{},
-			Labels: labels.ParseLabelArray(
-				"k8s:"+k8sConst.PolicyLabelName+"=ingress-cidr-test",
-				"k8s:"+k8sConst.PolicyLabelUID+"=11bba160-ddca-11e8-b697-0800273b04ff",
-				"k8s:"+k8sConst.PolicyLabelNamespace+"=myns",
-				"k8s:"+k8sConst.PolicyLabelDerivedFrom+"="+resourceTypeNetworkPolicy,
-			),
 		},
+		Egress: []api.EgressRule{},
+		Labels: labels.ParseLabelArray(
+			"k8s:"+k8sConst.PolicyLabelName+"=ingress-cidr-test",
+			"k8s:"+k8sConst.PolicyLabelUID+"=11bba160-ddca-11e8-b697-0800273b04ff",
+			"k8s:"+k8sConst.PolicyLabelNamespace+"=myns",
+			"k8s:"+k8sConst.PolicyLabelDerivedFrom+"="+resourceTypeNetworkPolicy,
+		),
+	}
+
+	expectedRule.Sanitize()
+
+	expectedRules := api.Rules{
+		expectedRule,
 	}
 
 	rules, err := ParseNetworkPolicy(&np)

--- a/pkg/k8s/rule_translate.go
+++ b/pkg/k8s/rule_translate.go
@@ -52,6 +52,8 @@ func (k RuleTranslator) Translate(r *api.Rule, result *policy.TranslationResult)
 // TranslateEgress populates/depopulates egress rules with ToCIDR entries based
 // on toService entries
 func (k RuleTranslator) TranslateEgress(r *api.EgressRule, result *policy.TranslationResult) error {
+
+	defer r.SetAggregatedSelectors()
 	err := k.depopulateEgress(r, result)
 	if err != nil {
 		return err

--- a/pkg/policy/api/ingress.go
+++ b/pkg/policy/api/ingress.go
@@ -104,14 +104,34 @@ type IngressRule struct {
 	//
 	// +optional
 	FromEntities EntitySlice `json:"fromEntities,omitempty"`
+
+	aggregatedSelectors EndpointSelectorSlice
+}
+
+// SetAggregatedSelectors creates a single slice containing all of the following
+// fields within the IngressRule, converted to EndpointSelector, to be stored
+// within the IngressRule for easy lookup while performing policy evaluation
+// for the rule:
+// * FromEndpoints
+// * FromEntities
+// * FromCIDR
+// * FromCIDRSet
+func (i *IngressRule) SetAggregatedSelectors() {
+	res := make(EndpointSelectorSlice, 0, len(i.FromEndpoints)+len(i.FromEntities)+len(i.FromCIDRSet)+len(i.FromCIDR))
+	res = append(res, i.FromEndpoints...)
+	res = append(res, i.FromEntities.GetAsEndpointSelectors()...)
+	res = append(res, i.FromCIDR.GetAsEndpointSelectors()...)
+	res = append(res, i.FromCIDRSet.GetAsEndpointSelectors()...)
+	i.aggregatedSelectors = res
 }
 
 // GetSourceEndpointSelectors returns a slice of endpoints selectors covering
 // all L3 source selectors of the ingress rule
 func (i *IngressRule) GetSourceEndpointSelectors() EndpointSelectorSlice {
-	res := append(i.FromEndpoints, i.FromEntities.GetAsEndpointSelectors()...)
-	res = append(res, i.FromCIDR.GetAsEndpointSelectors()...)
-	return append(res, i.FromCIDRSet.GetAsEndpointSelectors()...)
+	if i.aggregatedSelectors == nil {
+		i.SetAggregatedSelectors()
+	}
+	return i.aggregatedSelectors
 }
 
 // IsLabelBased returns true whether the L3 source endpoints are selected based

--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -143,6 +143,8 @@ func (i *IngressRule) sanitize() error {
 		return fmt.Errorf("too many ingress CIDR prefix lengths %d/%d", l, MaxCIDRPrefixLengths)
 	}
 
+	i.SetAggregatedSelectors()
+
 	return nil
 }
 
@@ -231,6 +233,8 @@ func (e *EgressRule) sanitize() error {
 	if l := len(prefixLengths); l > MaxCIDRPrefixLengths {
 		return fmt.Errorf("too many egress CIDR prefix lengths %d/%d", l, MaxCIDRPrefixLengths)
 	}
+
+	e.SetAggregatedSelectors()
 
 	return nil
 }

--- a/pkg/policy/api/zz_generated.deepcopy.go
+++ b/pkg/policy/api/zz_generated.deepcopy.go
@@ -179,6 +179,13 @@ func (in *EgressRule) DeepCopyInto(out *EgressRule) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.aggregatedSelectors != nil {
+		in, out := &in.aggregatedSelectors, &out.aggregatedSelectors
+		*out = make(EndpointSelectorSlice, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 
@@ -342,6 +349,13 @@ func (in *IngressRule) DeepCopyInto(out *IngressRule) {
 		in, out := &in.FromEntities, &out.FromEntities
 		*out = make(EntitySlice, len(*in))
 		copy(*out, *in)
+	}
+	if in.aggregatedSelectors != nil {
+		in, out := &in.aggregatedSelectors, &out.aggregatedSelectors
+		*out = make(EndpointSelectorSlice, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 	return
 }

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -107,7 +107,7 @@ func GenerateNumRules(numRules int) api.Rules {
 			EndpointSelector: fooSelector,
 			Ingress:          []api.IngressRule{ingRule},
 		}
-
+		rule.Sanitize()
 		rules = append(rules, &rule)
 	}
 	return rules

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -269,6 +269,7 @@ func (r *rule) resolveL4IngressPolicy(ctx *SearchContext, state *traceState, res
 				ruleCopy.FromEndpoints[idx].MatchExpressions = append(ruleCopy.FromEndpoints[idx].MatchExpressions, requirements...)
 				ruleCopy.FromEndpoints[idx].SyncRequirementsWithLabelSelector()
 			}
+			ruleCopy.SetAggregatedSelectors()
 		}
 
 		cnt, err := mergeL4Ingress(ctx, ruleCopy, r.Rule.Labels.DeepCopy(), result.Ingress)
@@ -571,6 +572,7 @@ func (r *rule) resolveL4EgressPolicy(ctx *SearchContext, state *traceState, resu
 				ruleCopy.ToEndpoints[idx].MatchExpressions = append(ruleCopy.ToEndpoints[idx].MatchExpressions, requirements...)
 				ruleCopy.ToEndpoints[idx].SyncRequirementsWithLabelSelector()
 			}
+			ruleCopy.SetAggregatedSelectors()
 		}
 		cnt, err := mergeL4Egress(ctx, ruleCopy, r.Rule.Labels.DeepCopy(), result.Egress)
 		if err != nil {


### PR DESCRIPTION
Add a new, unexported field to the `IngressRule` and `EgressRule` types in the
API called `aggregatedSelectors`.

For `IngressRule`, it is an aggregation of the following fields within the type,
all converted to `EndpointSelector`:

* `FromEndpoints`
* `FromEntities`
* `FromCIDR`
* `FromCIDRSet`

For `EgressRule`, it is an aggregation of the following fields within the type,
all converted to `EndpointSelector`:

* `ToEndpoints`
* `ToEntities`
* `ToCIDR`
* `ToCIDRSet`
* `ToFQDNs`

Previously, upon each policy calculation, for each rule, this aggregate list of
rule fields as `EndpointSelector` was created in an ad-hoc manner, and was not
performant, as it allocated many different slices of `EndpointSelector` in calls
to `GetSourceEndpointSelectors` and `GetDestinationEndpointSelectors`. This new
field caches the aggregated list only once, upon rule sanitization, or in calls
to the two aforementioned functions if the field has not been initialized yet.

The performance gains by making this change are significant. With 1000 rules and
3000 identities from before making this change:

```
PASS: resolve_test.go:122: PolicyTestSuite.BenchmarkRegeneratePolicyRules	       1	1289445773 ns/op
```

And after:

```
PASS: resolve_test.go:122: PolicyTestSuite.BenchmarkRegeneratePolicyRules	       1	1053485143 ns/op
```

This is a 19 % performance improvement in policy calculation for the policy
benchmark.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #7057 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7250)
<!-- Reviewable:end -->
