### PR TITLE
daemon: Make alignment check optional

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -526,30 +526,34 @@ func (d *Daemon) compileBase() error {
 		return err
 	}
 
-	// Validate alignments of C and Go equivalent structs
-	toCheck := map[string]reflect.Type{
-		"ipv4_ct_tuple":        reflect.TypeOf(ctmap.CtKey4{}),
-		"ipv6_ct_tuple":        reflect.TypeOf(ctmap.CtKey6{}),
-		"ct_entry":             reflect.TypeOf(ctmap.CtEntry{}),
-		"ipcache_key":          reflect.TypeOf(ipcachemap.Key{}),
-		"remote_endpoint_info": reflect.TypeOf(ipcachemap.RemoteEndpointInfo{}),
-		"lb4_key":              reflect.TypeOf(lbmap.Service4Key{}),
-		"lb4_service":          reflect.TypeOf(lbmap.Service4Value{}),
-		"lb6_key":              reflect.TypeOf(lbmap.Service6Key{}),
-		"lb6_service":          reflect.TypeOf(lbmap.Service6Value{}),
-		"endpoint_key":         reflect.TypeOf(bpf.EndpointKey{}),
-		"endpoint_info":        reflect.TypeOf(lxcmap.EndpointInfo{}),
-		"metrics_key":          reflect.TypeOf(metricsmap.Key{}),
-		"metrics_value":        reflect.TypeOf(metricsmap.Value{}),
-		"proxy4_tbl_key":       reflect.TypeOf(proxymap.Proxy4Key{}),
-		"proxy4_tbl_value":     reflect.TypeOf(proxymap.Proxy4Value{}),
-		"proxy6_tbl_key":       reflect.TypeOf(proxymap.Proxy6Key{}),
-		"proxy6_tbl_value":     reflect.TypeOf(proxymap.Proxy6Value{}),
-		"sock_key":             reflect.TypeOf(sockmap.SockmapKey{}),
-		"ep_config":            reflect.TypeOf(configmap.EndpointConfig{}),
-	}
-	if err := alignchecker.CheckStructAlignments("bpf_alignchecker.o", toCheck); err != nil {
-		log.WithError(err).Fatal("C and Go structs alignment check failed")
+	if canDisableDwarfRelocations {
+		// Validate alignments of C and Go equivalent structs
+		toCheck := map[string]reflect.Type{
+			"ipv4_ct_tuple":        reflect.TypeOf(ctmap.CtKey4{}),
+			"ipv6_ct_tuple":        reflect.TypeOf(ctmap.CtKey6{}),
+			"ct_entry":             reflect.TypeOf(ctmap.CtEntry{}),
+			"ipcache_key":          reflect.TypeOf(ipcachemap.Key{}),
+			"remote_endpoint_info": reflect.TypeOf(ipcachemap.RemoteEndpointInfo{}),
+			"lb4_key":              reflect.TypeOf(lbmap.Service4Key{}),
+			"lb4_service":          reflect.TypeOf(lbmap.Service4Value{}),
+			"lb6_key":              reflect.TypeOf(lbmap.Service6Key{}),
+			"lb6_service":          reflect.TypeOf(lbmap.Service6Value{}),
+			"endpoint_key":         reflect.TypeOf(bpf.EndpointKey{}),
+			"endpoint_info":        reflect.TypeOf(lxcmap.EndpointInfo{}),
+			"metrics_key":          reflect.TypeOf(metricsmap.Key{}),
+			"metrics_value":        reflect.TypeOf(metricsmap.Value{}),
+			"proxy4_tbl_key":       reflect.TypeOf(proxymap.Proxy4Key{}),
+			"proxy4_tbl_value":     reflect.TypeOf(proxymap.Proxy4Value{}),
+			"proxy6_tbl_key":       reflect.TypeOf(proxymap.Proxy6Key{}),
+			"proxy6_tbl_value":     reflect.TypeOf(proxymap.Proxy6Value{}),
+			"sock_key":             reflect.TypeOf(sockmap.SockmapKey{}),
+			"ep_config":            reflect.TypeOf(configmap.EndpointConfig{}),
+		}
+		if err := alignchecker.CheckStructAlignments("bpf_alignchecker.o", toCheck); err != nil {
+			log.WithError(err).Fatal("C and Go structs alignment check failed")
+		}
+	} else {
+		log.Warning("Cannot check matching of C and Go common struct alignments due to old LLVM/clang version")
 	}
 
 	if !option.Config.IsFlannelMasterDeviceSet() {

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -83,6 +83,10 @@ var (
 
 	recKernelVer = versioncheck.MustCompile(">= 4.9.0")
 	recClangVer  = versioncheck.MustCompile(">= 3.9.0")
+
+	// LLVM/clang version which supports `-mattr=dwarfris`
+	dwarfrisClangVer           = versioncheck.MustCompile(">= 7.0.0")
+	canDisableDwarfRelocations bool
 )
 
 const (
@@ -252,6 +256,7 @@ func checkMinRequirements() {
 				"your kernel version to at least %s",
 				clangVersion, kernelVersion, recKernelVer)
 		}
+		canDisableDwarfRelocations = dwarfrisClangVer.Check(clangVersion)
 		log.Infof("clang (%s) and kernel (%s) versions: OK!", clangVersion, kernelVersion)
 	}
 


### PR DESCRIPTION
Prior to LLVM/clang v7.0.0, `.debug_symbol` could contain Dwarf
cross-section relocations which are not supported by Go's Dwarf
parsing library (and elfutils). The outcome of this was that
struct names used by the alignment checker could not be extracted
which lead to the alignment checker reporting a failure that
a struct is not found.

LLVM/clang 7.0.0 introduced the `-mattr=dwarfris` option which
disables the relocations ( https://reviews.llvm.org/rL326505
).

To make possible to run Cilium with LLVM/clang < 7.0.0 we
(hopefully temporarily) disable the alignment checker
if < 7.0.0 version of the compiler suite is detected.

We could base the decision making on whether `llc` fails if
the `-mattr=dwarfris` option is passed, but unfortunately `llc`
silently ignores invalid options.

---

The long term fix is to extend Go's `debug/dwarf` to support the cross-relocations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7253)
<!-- Reviewable:end -->
