### PR TITLE
v1.4 backports 2019-03-01

### DIFF
--- a/contrib/release/uploadrev
+++ b/contrib/release/uploadrev
@@ -63,7 +63,7 @@ function copy_binaries_cilium_docker() {
   echo "target_dir: $TARGET_DIR"
   mkdir -p $TARGET_DIR
   SHA=$(docker create docker.io/cilium/docker-plugin:$REV)
-  docker cp $SHA:/usr/bin/cilium-docker/cilium-docker $TARGET_DIR/cilium-docker-$ARCH
+  docker cp $SHA:/usr/bin/cilium-docker $TARGET_DIR/cilium-docker-$ARCH
   docker rm -f $SHA
 }
 

--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -353,26 +353,7 @@ if [ -n "\${K8S}" ]; then
 fi
 
 service cilium restart
-
-cilium_started=false
-
-for ((i = 0 ; i < 24; i++)); do
-    if cilium status > /dev/null 2>&1; then
-        cilium_started=true
-        break
-    fi
-    sleep 5s
-    echo "Waiting for Cilium daemon to come up..."
-done
-
-if [ "\$cilium_started" = true ] ; then
-    echo 'Cilium successfully started!'
-else
-    >&2 echo 'Timeout waiting for Cilium to start...'
-    journalctl -u cilium.service --since \$(systemctl show -p ActiveEnterTimestamp cilium.service | awk '{print \$2 \$3}')
-    >&2 echo 'Cilium failed to start'
-    exit 1
-fi
+/home/vagrant/go/src/github.com/cilium/cilium/test/provision/wait-cilium.sh
 EOF
 }
 

--- a/test/provision/runtime_install.sh
+++ b/test/provision/runtime_install.sh
@@ -13,3 +13,4 @@ sudo systemctl restart ssh
 
 "${PROVISIONSRC}"/dns.sh
 "${PROVISIONSRC}"/compile.sh
+"${PROVISIONSRC}"/wait-cilium.sh

--- a/test/provision/wait-cilium.sh
+++ b/test/provision/wait-cilium.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+main() {
+    local cilium_started
+    cilium_started=false
+
+    for ((i = 0 ; i < 24; i++)); do
+        if cilium status --brief > /dev/null 2>&1; then
+            cilium_started=true
+            break
+        fi
+        sleep 5s
+        echo "Waiting for Cilium daemon to come up..."
+    done
+
+    if [ "$cilium_started" = true ] ; then
+        echo 'Cilium successfully started!'
+    else
+        >&2 echo 'Timeout waiting for Cilium to start...'
+        journalctl -u cilium.service --since $(systemctl show -p ActiveEnterTimestamp cilium.service | awk '{print $2 $3}')
+        >&2 echo 'Cilium failed to start'
+        exit 1
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
## Backported:

 * #7244 -- test: Wait for cilium to start in runtime provision (@joestringer)
 * #7241 -- contrib: fix extraction of cilium-docker binary (@ianvernon)

## Skipped:

 * #7210 -- bpf: Replace inline asm with call to BPF helper function (@brb)

## Post-merge
Once this PR is merged, you can update the PR labels via:

```
$ for pr in 7244 7241; do contrib/backporting/set-labels.py $pr done 1.4; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7254)
<!-- Reviewable:end -->
