### PR TITLE
test: Do not install Vbox Guest Additions

### DIFF
--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -14,6 +14,7 @@ $NETNEXT_SERVER_VERSION= "15"
 $IPv6=(ENV['IPv6'] || "0")
 $CONTAINER_RUNTIME=(ENV['CONTAINER_RUNTIME'] || "docker")
 $CNI_INTEGRATION=(ENV['CNI_INTEGRATION'] || "")
+$CHECK_GUEST_ADDITIONS = true
 
 # RAM and CPU settings
 $MEMORY = (ENV['MEMORY'] || "4096").to_i
@@ -22,11 +23,16 @@ $CPU = (ENV['CPUS'] || "2").to_i
 if ENV['NETNEXT'] == "true"
     $SERVER_BOX = $NETNEXT_SERVER_BOX
     $SERVER_VERSION = $NETNEXT_SERVER_VERSION
+    $CHECK_GUEST_ADDITIONS = false
     puts "Vagrant to use net-next version"
 end
 
 ENV["VAGRANT_DEFAULT_PROVIDER"] = "virtualbox"
 Vagrant.configure("2") do |config|
+
+    if Vagrant.has_plugin?("vagrant-vbguest") then
+        config.vbguest.auto_update = $CHECK_GUEST_ADDITIONS
+    end
 
     config.vm.define "runtime" do |server|
         server.vm.provider "virtualbox" do |vb|
@@ -34,6 +40,7 @@ Vagrant.configure("2") do |config|
             vb.cpus = $CPU
             vb.memory= $MEMORY
             vb.linked_clone = true
+            vb.check_guest_additions = $CHECK_GUEST_ADDITIONS
 
             # Prevent VirtualBox from interfering with host audio stack
             vb.customize ["modifyvm", :id, "--audio", "none"]
@@ -66,6 +73,7 @@ Vagrant.configure("2") do |config|
                 vb.cpus = $CPU
                 vb.memory= $MEMORY
                 vb.linked_clone = true
+                vb.check_guest_additions = $CHECK_GUEST_ADDITIONS
 
                 # Prevent VirtualBox from interfering with host audio stack
                 vb.customize ["modifyvm", :id, "--audio", "none"]


### PR DESCRIPTION
Currently, Virtualbox Guest Additions are installed to a test VM
image when it gets build by packer-ci. However, when we start a VM
on a Virtualbox which version does not match with the version
of the additions (i.e. != 5.2.0), either Vagrant or Vagrant's plugin
`vbguest` re-installs the additions which includes `mount.vboxsf`.

The latter is not compatible with the custom vboxsf version we use
in ubuntu-next and makes the following command to fail:

    mount -t vboxsf -o uid=1000,gid=1000 vagrant /vagrant

Removing the `mount.vboxsf` fixes the problem. However, I couldn't
find an easy way to remove the binary before Vagrant starts
syncing shared folders, thus I chose not to install the additions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7255)
<!-- Reviewable:end -->
