### PR TITLE
grafana: clean grafana descriptors

### DIFF
--- a/examples/kubernetes/addons/prometheus/monitoring-example.yaml
+++ b/examples/kubernetes/addons/prometheus/monitoring-example.yaml
@@ -24,7 +24,8 @@ kind: ClusterRole
 metadata:
   name: kube-state-metrics
 rules:
-- apiGroups: [""]
+- apiGroups:
+  - ""
   resources:
   - configmaps
   - secrets
@@ -38,69 +39,122 @@ rules:
   - persistentvolumes
   - namespaces
   - endpoints
-  verbs: ["list", "watch"]
-- apiGroups: ["extensions"]
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - extensions
   resources:
   - daemonsets
   - deployments
   - replicasets
-  verbs: ["list", "watch"]
-- apiGroups: ["apps"]
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - apps
   resources:
   - statefulsets
-  verbs: ["list", "watch"]
-- apiGroups: ["batch"]
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - batch
   resources:
   - cronjobs
   - jobs
-  verbs: ["list", "watch"]
-- apiGroups: ["autoscaling"]
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - autoscaling
   resources:
   - horizontalpodautoscalers
-  verbs: ["list", "watch"]
-- apiGroups: ["policy"]
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - policy
   resources:
   - poddisruptionbudgets
-  verbs: ["list", "watch"]
+  verbs:
+  - list
+  - watch
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1beta1
 # Kubernetes versions after 1.9.0 should use apps/v1
 # Kubernetes versions before 1.8.0 should use apps/v1beta1 or extensions/v1beta1
 kind: Deployment
 metadata:
+  labels:
+    k8s-app: kube-state-metrics
   name: kube-state-metrics
   namespace: kube-system
 spec:
   selector:
     matchLabels:
       k8s-app: kube-state-metrics
-  replicas: 1
   template:
     metadata:
+      annotations:
+        prometheus.io/port: "8080"
+        prometheus.io/scrape: "true"
+        prometheus.io/target: metrics
       labels:
         k8s-app: kube-state-metrics
-      annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "8080"
-        prometheus.io/target: "metrics"
     spec:
-      serviceAccountName: kube-state-metrics
       containers:
-      - name: kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.5.0
+      - image: quay.io/coreos/kube-state-metrics:v1.5.0
+        imagePullPolicy: IfNotPresent
+        name: kube-state-metrics
         ports:
-        - name: prometheus
-          containerPort: 8080
-        - name: telemetry
-          containerPort: 8081
+        - containerPort: 8080
+          name: prometheus
+          protocol: TCP
+        - containerPort: 8081
+          name: telemetry
+          protocol: TCP
         readinessProbe:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
           timeoutSeconds: 5
-      - name: addon-resizer
+        resources:
+          limits:
+            cpu: 102m
+            memory: 104Mi
+          requests:
+            cpu: 102m
+            memory: 104Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      - command:
+        - /pod_nanny
+        - --container=kube-state-metrics
+        - --cpu=100m
+        - --extra-cpu=1m
+        - --memory=100Mi
+        - --extra-memory=2Mi
+        - --threshold=5
+        - --deployment=kube-state-metrics
+        env:
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: MY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
         image: k8s.gcr.io/addon-resizer:1.8.3
+        imagePullPolicy: IfNotPresent
+        name: addon-resizer
         resources:
           limits:
             cpu: 150m
@@ -108,24 +162,9 @@ spec:
           requests:
             cpu: 150m
             memory: 50Mi
-        env:
-          - name: MY_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: MY_POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-        command:
-          - /pod_nanny
-          - --container=kube-state-metrics
-          - --cpu=100m
-          - --extra-cpu=1m
-          - --memory=100Mi
-          - --extra-memory=2Mi
-          - --threshold=5
-          - --deployment=kube-state-metrics
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      serviceAccount: kube-state-metrics
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 # kubernetes versions before 1.8.0 should use rbac.authorization.k8s.io/v1beta1
@@ -146,18 +185,24 @@ apiVersion: rbac.authorization.k8s.io/v1
 # kubernetes versions before 1.8.0 should use rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
-  namespace: kube-system
   name: kube-state-metrics-resizer
+  namespace: kube-system
 rules:
-- apiGroups: [""]
+- apiGroups:
+  - ""
   resources:
   - pods
-  verbs: ["get"]
-- apiGroups: ["extensions"]
+  verbs:
+  - get
+- apiGroups:
+  - extensions
+  resourceNames:
+  - kube-state-metrics
   resources:
   - deployments
-  resourceNames: ["kube-state-metrics"]
-  verbs: ["get", "update"]
+  verbs:
+  - get
+  - update
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -168,29 +213,29 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: kube-state-metrics
-  namespace: kube-system
+  annotations:
+    prometheus.io/port: "8080"
+    prometheus.io/probe: "true"
   labels:
     k8s-app: kube-state-metrics
-  annotations:
-    prometheus.io/probe: "true"
-    prometheus.io/port: "8080"
+  name: kube-state-metrics
+  namespace: kube-system
 spec:
   ports:
   - name: http-metrics
     port: 8080
-    targetPort: prometheus
     protocol: TCP
+    targetPort: prometheus
   - name: telemetry
     port: 8081
-    targetPort: telemetry
     protocol: TCP
+    targetPort: telemetry
   selector:
     k8s-app: kube-state-metrics
+  type: ClusterIP
 ---
 kind: ConfigMap
 metadata:
-  creationTimestamp: null
   name: prometheus
   namespace: cilium-monitoring
 apiVersion: v1
@@ -317,78 +362,87 @@ data:
             regex: (.+)
             target_label: __metrics_path__
             replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
-
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: prometheus
-  namespace: cilium-monitoring
   labels:
     app: prometheus
+  name: prometheus
+  namespace: cilium-monitoring
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
   template:
     metadata:
-      name: prometheus-main
       labels:
         app: prometheus
+      name: prometheus-main
     spec:
-      serviceAccountName: prometheus-k8s
-      terminationGracePeriodSeconds: 0
       containers:
-      - name: prometheus
+      - args:
+        - --config.file=/etc/prometheus/prometheus.yaml
+        - --storage.tsdb.path=/prometheus/
+        - --log.level=debug
         image: docker.io/prom/prometheus:v2.6.1
-        args:
-          - "--config.file=/etc/prometheus/prometheus.yaml"
-          - "--storage.tsdb.path=/prometheus/"
-          - "--log.level=debug"
+        imagePullPolicy: IfNotPresent
+        name: prometheus
         ports:
-        - name: webui
-          containerPort: 9090
+        - containerPort: 9090
+          name: webui
+          protocol: TCP
         volumeMounts:
-        - name: config-volume
-          mountPath: /etc/prometheus
-        - name: storage
-          mountPath: /prometheus/
+        - mountPath: /etc/prometheus
+          name: config-volume
+          readOnly: true
+        - mountPath: /prometheus/
+          name: storage
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      serviceAccount: prometheus-k8s
       volumes:
-      - name: config-volume
-        configMap:
-          defaultMode: 0777
+      - configMap:
           name: prometheus
-      - name: storage
-        emptyDir: {}
+        name: config-volume
+      - emptyDir: {}
+        name: storage
 ---
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    app: prometheus
   name: prometheus
   namespace: cilium-monitoring
-  labels:
-    app: prometheus
 spec:
   ports:
-    - port: 9090
-      protocol: TCP
-      name: webui
+  - name: webui
+    port: 9090
+    protocol: TCP
+    targetPort: 9090
   selector:
     app: prometheus
+  type: ClusterIP
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: prometheus-open
-  namespace: cilium-monitoring
   labels:
     app: prometheus
+  name: prometheus-open
+  namespace: cilium-monitoring
 spec:
-  type: NodePort
   ports:
-  - port: 9090
+  - name: open
     nodePort: 31001
-    name: open
+    port: 9090
+    protocol: TCP
+    targetPort: 9090
   selector:
     app: prometheus
+  type: NodePort
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -408,20 +462,28 @@ kind: ClusterRole
 metadata:
   name: prometheus
 rules:
-- apiGroups: [""]
+- apiGroups:
+  - ""
   resources:
   - nodes
   - nodes/proxy
   - services
   - endpoints
   - pods
-  verbs: ["get", "list", "watch"]
-- apiGroups: [""]
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
   resources:
   - configmaps
-  verbs: ["get"]
-- nonResourceURLs: ["/metrics"]
-  verbs: ["get"]
+  verbs:
+  - get
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -429,70 +491,402 @@ metadata:
   name: prometheus-k8s
   namespace: cilium-monitoring
 ---
-kind: ConfigMap
-metadata:
-  creationTimestamp: null
-  name: grafana-config
-  namespace: cilium-monitoring
-  labels:
-    app: grafana
-apiVersion: v1
-data:
-  GF_AUTH_BASIC_ENABLED: "false"
-  GF_AUTH_ANONYMOUS_ORG_ROLE: "Admin"
-  GF_AUTH_ANONYMOUS_ENABLED: "true"
----
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: grafana
-  namespace: cilium-monitoring
   labels:
     app: grafana
     component: core
+  name: grafana
+  namespace: cilium-monitoring
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: grafana
   template:
     metadata:
       labels:
         app: grafana
     spec:
-      terminationGracePeriodSeconds: 0
       containers:
-      - image: docker.io/grafana/grafana:5.4.3
-        name: grafana-core
+      - env:
+        - name: GF_PATHS_CONFIG
+          value: /configmap/grafana/grafana-config.ini
+        - name: GF_PATHS_PROVISIONING
+          value: /configmap/grafana/provisioning
+        image: docker.io/grafana/grafana:6.0.0
         imagePullPolicy: IfNotPresent
-        envFrom:
-          - configMapRef:
-              name: grafana-config
+        name: grafana-core
         readinessProbe:
+          failureThreshold: 3
           httpGet:
             path: /login
             port: 3000
+            scheme: HTTP
+        volumeMounts:
+        - mountPath: /configmap/grafana
+          name: grafana-config
+          readOnly: true
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      volumes:
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: grafana-config
+            path: grafana-config.ini
+          - key: prometheus-datasource
+            path: provisioning/datasources/prometheus.yaml
+          - key: cilium-dashboard
+            path: provisioning/cilium/cilium-dashboard.json
+          - key: dashboard-config
+            path: provisioning/dashboards/config.yaml
+          name: grafana-config
+        name: grafana-config
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: grafana
-  namespace: cilium-monitoring
   labels:
     app: grafana
+  name: grafana
+  namespace: cilium-monitoring
 spec:
-  type: NodePort
   ports:
-    - port: 3000
-      nodePort: 31000
+  - nodePort: 31000
+    port: 3000
+    protocol: TCP
+    targetPort: 3000
   selector:
     app: grafana
+  type: NodePort
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  creationTimestamp: null
+  labels:
+    app: grafana
+  name: grafana-config
   namespace: cilium-monitoring
-  name: grafana-dashboards
 data:
-  cilium-dashboard.json: |
+  dashboard-config: |
+    apiVersion: 1
+    providers:
+    - name: 'cilium-dashboard-config'
+      orgId: 1
+      folder: ''
+      type: file
+      disableDeletion: true
+      options:
+        path: '/configmap/grafana/provisioning/cilium'
+  grafana-config: |
+    app_mode = production
+    [paths]
+    # Path to where grafana can store temp files, sessions, and the sqlite3 db (if that is used)
+    data = data
+    # Temporary files in `data` directory older than given duration will be removed
+    temp_data_lifetime = 24h
+    # Directory where grafana can store logs
+    logs = data/log
+    # Directory where grafana will automatically scan and look for plugins
+    plugins = data/plugins
+    # folder that contains provisioning config files that grafana will apply on startup and while running.
+    provisioning = /configmap/grafana/provisioning
+    #################################### Server ##############################
+    [server]
+    # Protocol (http, https, socket)
+    protocol = http
+    # The http port to use
+    http_port = 3000
+    # enable gzip
+    enable_gzip = false
+    #################################### Session #############################
+    [session]
+    # Either "memory", "file", "redis", "mysql", "postgres", "memcache", default is "file"
+    provider = file
+
+    provider_config = sessions
+
+    # Session cookie name
+    cookie_name = grafana_sess
+
+    # If you use session in https only, default is false
+    cookie_secure = true
+
+    # Session life time, default is 86400
+    session_life_time = 86400
+    gc_interval_time = 86400
+
+    # Connection Max Lifetime default is 14400 (means 14400 seconds or 4 hours)
+    conn_max_lifetime = 14400
+
+    #################################### Data proxy ###########################
+    [dataproxy]
+
+    # This enables data proxy logging, default is false
+    logging = false
+
+    # How long the data proxy should wait before timing out default is 30 (seconds)
+    timeout = 30
+
+    #################################### Analytics ###########################
+    [analytics]
+    # Server reporting, sends usage counters to stats.grafana.org every 24 hours.
+    # No ip addresses are being tracked, only simple counters to track
+    # running instances, dashboard and error counts. It is very helpful to us.
+    # Change this option to false to disable reporting.
+    reporting_enabled = false
+
+    # Set to false to disable all checks to https://grafana.com
+    # for new versions (grafana itself and plugins), check is used
+    # in some UI views to notify that grafana or plugin update exists
+    # This option does not cause any auto updates, nor send any information
+    # only a GET request to https://grafana.com to get latest versions
+    check_for_updates = false
+
+    #################################### Security ############################
+    [security]
+    # default admin user, created on startup
+    admin_user = admin
+
+    # default admin password, can be changed before first start of grafana, or in profile settings
+    admin_password = admin
+
+    # used for signing
+    secret_key = SW2YcwTIb9zpOOhoPsMm
+
+    # disable gravatar profile images
+    disable_gravatar = true
+
+    # disable protection against brute force login attempts
+    disable_brute_force_login_protection = false
+
+    # set to true if you host Grafana behind HTTPS. default is false.
+    cookie_secure = true
+
+    # set cookie SameSite attribute. defaults to `lax`. can be set to "lax", "strict" and "none"
+    cookie_samesite = lax
+
+    #################################### Dashboards ##################
+
+    [dashboards]
+    # Number dashboard versions to keep (per dashboard). Default: 20, Minimum: 1
+    versions_to_keep = 20
+
+    #################################### Users ###############################
+    [users]
+    # disable user signup / registration
+    allow_sign_up = false
+
+    # Allow non admin users to create organizations
+    allow_org_create = false
+
+    # Set to true to automatically assign new users to the default organization (id 1)
+    auto_assign_org = true
+
+    # Set this value to automatically add new users to the provided organization (if auto_assign_org above is set to true)
+    auto_assign_org_id = 1
+
+    # Default role new users will be automatically assigned (if auto_assign_org above is set to true)
+    auto_assign_org_role = Viewer
+
+    # Require email validation before sign up completes
+    verify_email_enabled = false
+
+    # Background text for the user field on the login page
+    login_hint = email or username
+
+    # Default UI theme ("dark" or "light")
+    default_theme = dark
+
+    # External user management
+    external_manage_link_url =
+    external_manage_link_name =
+    external_manage_info =
+
+    # Viewers can edit/inspect dashboard settings in the browser. But not save the dashboard.
+    viewers_can_edit = false
+
+    [auth]
+    # Login cookie name
+    login_cookie_name = grafana_session
+
+    # The lifetime (days) an authenticated user can be inactive before being required to login at next visit. Default is 7 days.
+    login_maximum_inactive_lifetime_days = 7
+
+    # The maximum lifetime (days) an authenticated user can be logged in since login time before being required to login. Default is 30 days.
+    login_maximum_lifetime_days = 30
+
+    # How often should auth tokens be rotated for authenticated users when being active. The default is each 10 minutes.
+    token_rotation_interval_minutes = 10
+
+    # Set to true to disable (hide) the login form, useful if you use OAuth
+    disable_login_form = false
+
+    # Set to true to disable the signout link in the side menu. useful if you use auth.proxy
+    disable_signout_menu = false
+
+    # URL to redirect the user to after sign out
+    signout_redirect_url =
+
+    # Set to true to attempt login with OAuth automatically, skipping the login screen.
+    # This setting is ignored if multiple OAuth providers are configured.
+    oauth_auto_login = false
+
+    #################################### Anonymous Auth ######################
+    [auth.anonymous]
+    # enable anonymous access
+    enabled = true
+
+    # specify organization name that should be used for unauthenticated users
+    org_name = Main Org.
+
+    # specify role for unauthenticated users
+    org_role = Admin
+
+
+    #################################### Basic Auth ##########################
+    [auth.basic]
+    enabled = false
+
+    #################################### Logging ##########################
+    [log]
+    # Either "console", "file", "syslog". Default is console and file
+    # Use space to separate multiple modes, e.g. "console file"
+    mode = console file
+
+    # Either "debug", "info", "warn", "error", "critical", default is "info"
+    level = info
+
+    # optional settings to set different levels for specific loggers. Ex filters = sqlstore:debug
+    filters =
+
+    # For "console" mode only
+    [log.console]
+    level =
+
+    # log line format, valid options are text, console and json
+    format = console
+
+    # For "file" mode only
+    [log.file]
+    level =
+
+    # log line format, valid options are text, console and json
+    format = text
+
+    # This enables automated log rotate(switch of following options), default is true
+    log_rotate = true
+
+    # Max line number of single file, default is 1000000
+    max_lines = 1000000
+
+    # Max size shift of single file, default is 28 means 1 << 28, 256MB
+    max_size_shift = 28
+
+    # Segment log daily, default is true
+    daily_rotate = true
+
+    # Expired days of log file(delete after max days), default is 7
+    max_days = 7
+
+    [log.syslog]
+    level =
+
+    # log line format, valid options are text, console and json
+    format = text
+
+    # Syslog network type and address. This can be udp, tcp, or unix. If left blank, the default unix endpoints will be used.
+    network =
+    address =
+
+    # Syslog facility. user, daemon and local0 through local7 are valid.
+    facility =
+
+    # Syslog tag. By default, the process' argv[0] is used.
+    tag =
+
+    #################################### Usage Quotas ########################
+    [quota]
+    enabled = false
+
+    #### set quotas to -1 to make unlimited. ####
+    # limit number of users per Org.
+    org_user = 10
+
+    # limit number of dashboards per Org.
+    org_dashboard = 100
+
+    # limit number of data_sources per Org.
+    org_data_source = 10
+
+    # limit number of api_keys per Org.
+    org_api_key = 10
+
+    # limit number of orgs a user can create.
+    user_org = 10
+
+    # Global limit of users.
+    global_user = -1
+
+    # global limit of orgs.
+    global_org = -1
+
+    # global limit of dashboards
+    global_dashboard = -1
+
+    # global limit of api_keys
+    global_api_key = -1
+
+    # global limit on number of logged in users.
+    global_session = -1
+
+    #################################### Alerting ############################
+    [alerting]
+    # Disable alerting engine & UI features
+    enabled = true
+    # Makes it possible to turn off alert rule execution but alerting UI is visible
+    execute_alerts = true
+
+    # Default setting for new alert rules. Defaults to categorize error and timeouts as alerting. (alerting, keep_state)
+    error_or_timeout = alerting
+
+    # Default setting for how Grafana handles nodata or null values in alerting. (alerting, no_data, keep_state, ok)
+    nodata_or_nullvalues = no_data
+
+    # Alert notifications can include images, but rendering many images at the same time can overload the server
+    # This limit will protect the server from render overloading and make sure notifications are sent out quickly
+    concurrent_render_limit = 5
+
+    #################################### Explore #############################
+    [explore]
+    # Enable the Explore section
+    enabled = true
+
+    #################################### Internal Grafana Metrics ############
+    # Metrics available at HTTP API Url /metrics
+    [metrics]
+    enabled           = true
+    interval_seconds  = 10
+
+    #If both are set, basic auth will be required for the metrics endpoint.
+    basic_auth_username =
+    basic_auth_password =
+  prometheus-datasource: |
+    apiVersion: 1
+    deleteDatasources:
+      - name: prometheus
+        orgId: 1
+    datasources:
+    - name: prometheus
+      type: prometheus
+      access: proxy
+      orgId: 1
+      url: http://prometheus:9090
+      basicAuth: false
+      editable: true
+  cilium-dashboard: |
     {
       "annotations": {
         "list": [
@@ -7172,82 +7566,3 @@ data:
       "uid": "vtuWtdumz",
       "version": 43
     }
-  prometheus-datasource.json: |
-    {
-      "name": "prometheus",
-      "type": "prometheus",
-      "url": "http://prometheus:9090",
-      "access": "proxy",
-      "basicAuth": false
-    }
----
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: grafana-dashboards-import
-  namespace: cilium-monitoring
-spec:
-  template:
-    metadata:
-      name: grafana-import-dashboards
-      labels:
-        app: grafana
-        component: import-dashboards
-    spec:
-      # serviceAccountName: prometheus-k8s
-      initContainers:
-      - name: wait-for-grafana
-        image: docker.io/giantswarm/tiny-tools
-        args:
-        - /bin/sh
-        - -c
-        - >
-          set -x;
-          while [ $(curl -sw '%{http_code}' "http://grafana:3000" -o /dev/null) -ne 200]; do
-            echo '.'
-            sleep 15;
-          done
-      restartPolicy: Never
-      containers:
-      - name: grafana-import-dashboards
-        image: giantswarm/tiny-tools
-        command: ["/bin/sh", "-c"]
-        workingDir: /opt/grafana-dashboards
-        args:
-          - >
-            for file in *-datasource.json ; do
-              if [ -e "$file" ] ; then
-                echo "importing $file" &&
-                curl --silent --fail --show-error \
-                  --request POST http://grafana:3000/api/datasources \
-                  --header "Content-Type: application/json" \
-                  --data-binary "@$file" ;
-                echo "" ;
-              fi
-            done ;
-            for file in *-dashboard.json ; do
-              if [ -e "$file" ] ; then
-                echo "importing $file" &&
-                ( echo '{"dashboard":'; \
-                  cat "$file"; \
-                  echo ',"overwrite":true,"inputs":[{"name":"DS_PROMETHEUS","type":"datasource","pluginId":"prometheus","value":"prometheus"}]}' ) \
-                | jq -c '.' \
-                | curl --silent --fail --show-error \
-                  --request POST http://grafana:3000/api/dashboards/import \
-                  --header "Content-Type: application/json" \
-                  --data-binary "@-" ;
-                echo "" ;
-              fi
-            done
-
-        envFrom:
-          - configMapRef:
-              name: grafana-config
-        volumeMounts:
-        - name: dashboards
-          mountPath: /opt/grafana-dashboards
-      restartPolicy: Never
-      volumes:
-      - name: dashboards
-        configMap:
-          name: grafana-dashboards

--- a/examples/kubernetes/addons/prometheus/templates/03-kube-metrics.yaml
+++ b/examples/kubernetes/addons/prometheus/templates/03-kube-metrics.yaml
@@ -19,7 +19,8 @@ kind: ClusterRole
 metadata:
   name: kube-state-metrics
 rules:
-- apiGroups: [""]
+- apiGroups:
+  - ""
   resources:
   - configmaps
   - secrets
@@ -33,69 +34,122 @@ rules:
   - persistentvolumes
   - namespaces
   - endpoints
-  verbs: ["list", "watch"]
-- apiGroups: ["extensions"]
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - extensions
   resources:
   - daemonsets
   - deployments
   - replicasets
-  verbs: ["list", "watch"]
-- apiGroups: ["apps"]
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - apps
   resources:
   - statefulsets
-  verbs: ["list", "watch"]
-- apiGroups: ["batch"]
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - batch
   resources:
   - cronjobs
   - jobs
-  verbs: ["list", "watch"]
-- apiGroups: ["autoscaling"]
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - autoscaling
   resources:
   - horizontalpodautoscalers
-  verbs: ["list", "watch"]
-- apiGroups: ["policy"]
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - policy
   resources:
   - poddisruptionbudgets
-  verbs: ["list", "watch"]
+  verbs:
+  - list
+  - watch
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1beta1
 # Kubernetes versions after 1.9.0 should use apps/v1
 # Kubernetes versions before 1.8.0 should use apps/v1beta1 or extensions/v1beta1
 kind: Deployment
 metadata:
+  labels:
+    k8s-app: kube-state-metrics
   name: kube-state-metrics
   namespace: kube-system
 spec:
   selector:
     matchLabels:
       k8s-app: kube-state-metrics
-  replicas: 1
   template:
     metadata:
+      annotations:
+        prometheus.io/port: "8080"
+        prometheus.io/scrape: "true"
+        prometheus.io/target: metrics
       labels:
         k8s-app: kube-state-metrics
-      annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "8080"
-        prometheus.io/target: "metrics"
     spec:
-      serviceAccountName: kube-state-metrics
       containers:
-      - name: kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.5.0
+      - image: quay.io/coreos/kube-state-metrics:v1.5.0
+        imagePullPolicy: IfNotPresent
+        name: kube-state-metrics
         ports:
-        - name: prometheus
-          containerPort: 8080
-        - name: telemetry
-          containerPort: 8081
+        - containerPort: 8080
+          name: prometheus
+          protocol: TCP
+        - containerPort: 8081
+          name: telemetry
+          protocol: TCP
         readinessProbe:
           httpGet:
             path: /healthz
             port: 8080
+            scheme: HTTP
           initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
           timeoutSeconds: 5
-      - name: addon-resizer
+        resources:
+          limits:
+            cpu: 102m
+            memory: 104Mi
+          requests:
+            cpu: 102m
+            memory: 104Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      - command:
+        - /pod_nanny
+        - --container=kube-state-metrics
+        - --cpu=100m
+        - --extra-cpu=1m
+        - --memory=100Mi
+        - --extra-memory=2Mi
+        - --threshold=5
+        - --deployment=kube-state-metrics
+        env:
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: MY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
         image: k8s.gcr.io/addon-resizer:1.8.3
+        imagePullPolicy: IfNotPresent
+        name: addon-resizer
         resources:
           limits:
             cpu: 150m
@@ -103,24 +157,9 @@ spec:
           requests:
             cpu: 150m
             memory: 50Mi
-        env:
-          - name: MY_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: MY_POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-        command:
-          - /pod_nanny
-          - --container=kube-state-metrics
-          - --cpu=100m
-          - --extra-cpu=1m
-          - --memory=100Mi
-          - --extra-memory=2Mi
-          - --threshold=5
-          - --deployment=kube-state-metrics
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      serviceAccount: kube-state-metrics
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 # kubernetes versions before 1.8.0 should use rbac.authorization.k8s.io/v1beta1
@@ -141,18 +180,24 @@ apiVersion: rbac.authorization.k8s.io/v1
 # kubernetes versions before 1.8.0 should use rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
-  namespace: kube-system
   name: kube-state-metrics-resizer
+  namespace: kube-system
 rules:
-- apiGroups: [""]
+- apiGroups:
+  - ""
   resources:
   - pods
-  verbs: ["get"]
-- apiGroups: ["extensions"]
+  verbs:
+  - get
+- apiGroups:
+  - extensions
+  resourceNames:
+  - kube-state-metrics
   resources:
   - deployments
-  resourceNames: ["kube-state-metrics"]
-  verbs: ["get", "update"]
+  verbs:
+  - get
+  - update
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -163,22 +208,23 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: kube-state-metrics
-  namespace: kube-system
+  annotations:
+    prometheus.io/port: "8080"
+    prometheus.io/probe: "true"
   labels:
     k8s-app: kube-state-metrics
-  annotations:
-    prometheus.io/probe: "true"
-    prometheus.io/port: "8080"
+  name: kube-state-metrics
+  namespace: kube-system
 spec:
   ports:
   - name: http-metrics
     port: 8080
-    targetPort: prometheus
     protocol: TCP
+    targetPort: prometheus
   - name: telemetry
     port: 8081
-    targetPort: telemetry
     protocol: TCP
+    targetPort: telemetry
   selector:
     k8s-app: kube-state-metrics
+  type: ClusterIP

--- a/examples/kubernetes/addons/prometheus/templates/04-prometheus.yaml
+++ b/examples/kubernetes/addons/prometheus/templates/04-prometheus.yaml
@@ -1,7 +1,6 @@
 ---
 kind: ConfigMap
 metadata:
-  creationTimestamp: null
   name: prometheus
   namespace: cilium-monitoring
 apiVersion: v1
@@ -128,78 +127,87 @@ data:
             regex: (.+)
             target_label: __metrics_path__
             replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
-
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: prometheus
-  namespace: cilium-monitoring
   labels:
     app: prometheus
+  name: prometheus
+  namespace: cilium-monitoring
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
   template:
     metadata:
-      name: prometheus-main
       labels:
         app: prometheus
+      name: prometheus-main
     spec:
-      serviceAccountName: prometheus-k8s
-      terminationGracePeriodSeconds: 0
       containers:
-      - name: prometheus
+      - args:
+        - --config.file=/etc/prometheus/prometheus.yaml
+        - --storage.tsdb.path=/prometheus/
+        - --log.level=debug
         image: docker.io/prom/prometheus:v2.6.1
-        args:
-          - "--config.file=/etc/prometheus/prometheus.yaml"
-          - "--storage.tsdb.path=/prometheus/"
-          - "--log.level=debug"
+        imagePullPolicy: IfNotPresent
+        name: prometheus
         ports:
-        - name: webui
-          containerPort: 9090
+        - containerPort: 9090
+          name: webui
+          protocol: TCP
         volumeMounts:
-        - name: config-volume
-          mountPath: /etc/prometheus
-        - name: storage
-          mountPath: /prometheus/
+        - mountPath: /etc/prometheus
+          name: config-volume
+          readOnly: true
+        - mountPath: /prometheus/
+          name: storage
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      serviceAccount: prometheus-k8s
       volumes:
-      - name: config-volume
-        configMap:
-          defaultMode: 0777
+      - configMap:
           name: prometheus
-      - name: storage
-        emptyDir: {}
+        name: config-volume
+      - emptyDir: {}
+        name: storage
 ---
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    app: prometheus
   name: prometheus
   namespace: cilium-monitoring
-  labels:
-    app: prometheus
 spec:
   ports:
-    - port: 9090
-      protocol: TCP
-      name: webui
+  - name: webui
+    port: 9090
+    protocol: TCP
+    targetPort: 9090
   selector:
     app: prometheus
+  type: ClusterIP
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: prometheus-open
-  namespace: cilium-monitoring
   labels:
     app: prometheus
+  name: prometheus-open
+  namespace: cilium-monitoring
 spec:
-  type: NodePort
   ports:
-  - port: 9090
+  - name: open
     nodePort: 31001
-    name: open
+    port: 9090
+    protocol: TCP
+    targetPort: 9090
   selector:
     app: prometheus
+  type: NodePort
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -219,20 +227,28 @@ kind: ClusterRole
 metadata:
   name: prometheus
 rules:
-- apiGroups: [""]
+- apiGroups:
+  - ""
   resources:
   - nodes
   - nodes/proxy
   - services
   - endpoints
   - pods
-  verbs: ["get", "list", "watch"]
-- apiGroups: [""]
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
   resources:
   - configmaps
-  verbs: ["get"]
-- nonResourceURLs: ["/metrics"]
-  verbs: ["get"]
+  verbs:
+  - get
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/examples/kubernetes/addons/prometheus/templates/05-grafana.yaml
+++ b/examples/kubernetes/addons/prometheus/templates/05-grafana.yaml
@@ -1,56 +1,71 @@
 ---
-kind: ConfigMap
-metadata:
-  creationTimestamp: null
-  name: grafana-config
-  namespace: cilium-monitoring
-  labels:
-    app: grafana
-apiVersion: v1
-data:
-  GF_AUTH_BASIC_ENABLED: "false"
-  GF_AUTH_ANONYMOUS_ORG_ROLE: "Admin"
-  GF_AUTH_ANONYMOUS_ENABLED: "true"
----
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: grafana
-  namespace: cilium-monitoring
   labels:
     app: grafana
     component: core
+  name: grafana
+  namespace: cilium-monitoring
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: grafana
   template:
     metadata:
       labels:
         app: grafana
     spec:
-      terminationGracePeriodSeconds: 0
       containers:
-      - image: docker.io/grafana/grafana:5.4.3
-        name: grafana-core
+      - env:
+        - name: GF_PATHS_CONFIG
+          value: /configmap/grafana/grafana-config.ini
+        - name: GF_PATHS_PROVISIONING
+          value: /configmap/grafana/provisioning
+        image: docker.io/grafana/grafana:6.0.0
         imagePullPolicy: IfNotPresent
-        envFrom:
-          - configMapRef:
-              name: grafana-config
+        name: grafana-core
         readinessProbe:
+          failureThreshold: 3
           httpGet:
             path: /login
             port: 3000
+            scheme: HTTP
+        volumeMounts:
+        - mountPath: /configmap/grafana
+          name: grafana-config
+          readOnly: true
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      volumes:
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: grafana-config
+            path: grafana-config.ini
+          - key: prometheus-datasource
+            path: provisioning/datasources/prometheus.yaml
+          - key: cilium-dashboard
+            path: provisioning/cilium/cilium-dashboard.json
+          - key: dashboard-config
+            path: provisioning/dashboards/config.yaml
+          name: grafana-config
+        name: grafana-config
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: grafana
-  namespace: cilium-monitoring
   labels:
     app: grafana
+  name: grafana
+  namespace: cilium-monitoring
 spec:
-  type: NodePort
   ports:
-    - port: 3000
-      nodePort: 31000
+  - nodePort: 31000
+    port: 3000
+    protocol: TCP
+    targetPort: 3000
   selector:
     app: grafana
+  type: NodePort

--- a/examples/kubernetes/addons/prometheus/templates/06-grafana-config.yaml
+++ b/examples/kubernetes/addons/prometheus/templates/06-grafana-config.yaml
@@ -2,11 +2,328 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  creationTimestamp: null
+  labels:
+    app: grafana
+  name: grafana-config
   namespace: cilium-monitoring
-  name: grafana-dashboards
 data:
-  cilium-dashboard.json: |
+  dashboard-config: |
+    apiVersion: 1
+    providers:
+    - name: 'cilium-dashboard-config'
+      orgId: 1
+      folder: ''
+      type: file
+      disableDeletion: true
+      options:
+        path: '/configmap/grafana/provisioning/cilium'
+  grafana-config: |
+    app_mode = production
+    [paths]
+    # Path to where grafana can store temp files, sessions, and the sqlite3 db (if that is used)
+    data = data
+    # Temporary files in `data` directory older than given duration will be removed
+    temp_data_lifetime = 24h
+    # Directory where grafana can store logs
+    logs = data/log
+    # Directory where grafana will automatically scan and look for plugins
+    plugins = data/plugins
+    # folder that contains provisioning config files that grafana will apply on startup and while running.
+    provisioning = /configmap/grafana/provisioning
+    #################################### Server ##############################
+    [server]
+    # Protocol (http, https, socket)
+    protocol = http
+    # The http port to use
+    http_port = 3000
+    # enable gzip
+    enable_gzip = false
+    #################################### Session #############################
+    [session]
+    # Either "memory", "file", "redis", "mysql", "postgres", "memcache", default is "file"
+    provider = file
+
+    provider_config = sessions
+
+    # Session cookie name
+    cookie_name = grafana_sess
+
+    # If you use session in https only, default is false
+    cookie_secure = true
+
+    # Session life time, default is 86400
+    session_life_time = 86400
+    gc_interval_time = 86400
+
+    # Connection Max Lifetime default is 14400 (means 14400 seconds or 4 hours)
+    conn_max_lifetime = 14400
+
+    #################################### Data proxy ###########################
+    [dataproxy]
+
+    # This enables data proxy logging, default is false
+    logging = false
+
+    # How long the data proxy should wait before timing out default is 30 (seconds)
+    timeout = 30
+
+    #################################### Analytics ###########################
+    [analytics]
+    # Server reporting, sends usage counters to stats.grafana.org every 24 hours.
+    # No ip addresses are being tracked, only simple counters to track
+    # running instances, dashboard and error counts. It is very helpful to us.
+    # Change this option to false to disable reporting.
+    reporting_enabled = false
+
+    # Set to false to disable all checks to https://grafana.com
+    # for new versions (grafana itself and plugins), check is used
+    # in some UI views to notify that grafana or plugin update exists
+    # This option does not cause any auto updates, nor send any information
+    # only a GET request to https://grafana.com to get latest versions
+    check_for_updates = false
+
+    #################################### Security ############################
+    [security]
+    # default admin user, created on startup
+    admin_user = admin
+
+    # default admin password, can be changed before first start of grafana, or in profile settings
+    admin_password = admin
+
+    # used for signing
+    secret_key = SW2YcwTIb9zpOOhoPsMm
+
+    # disable gravatar profile images
+    disable_gravatar = true
+
+    # disable protection against brute force login attempts
+    disable_brute_force_login_protection = false
+
+    # set to true if you host Grafana behind HTTPS. default is false.
+    cookie_secure = true
+
+    # set cookie SameSite attribute. defaults to `lax`. can be set to "lax", "strict" and "none"
+    cookie_samesite = lax
+
+    #################################### Dashboards ##################
+
+    [dashboards]
+    # Number dashboard versions to keep (per dashboard). Default: 20, Minimum: 1
+    versions_to_keep = 20
+
+    #################################### Users ###############################
+    [users]
+    # disable user signup / registration
+    allow_sign_up = false
+
+    # Allow non admin users to create organizations
+    allow_org_create = false
+
+    # Set to true to automatically assign new users to the default organization (id 1)
+    auto_assign_org = true
+
+    # Set this value to automatically add new users to the provided organization (if auto_assign_org above is set to true)
+    auto_assign_org_id = 1
+
+    # Default role new users will be automatically assigned (if auto_assign_org above is set to true)
+    auto_assign_org_role = Viewer
+
+    # Require email validation before sign up completes
+    verify_email_enabled = false
+
+    # Background text for the user field on the login page
+    login_hint = email or username
+
+    # Default UI theme ("dark" or "light")
+    default_theme = dark
+
+    # External user management
+    external_manage_link_url =
+    external_manage_link_name =
+    external_manage_info =
+
+    # Viewers can edit/inspect dashboard settings in the browser. But not save the dashboard.
+    viewers_can_edit = false
+
+    [auth]
+    # Login cookie name
+    login_cookie_name = grafana_session
+
+    # The lifetime (days) an authenticated user can be inactive before being required to login at next visit. Default is 7 days.
+    login_maximum_inactive_lifetime_days = 7
+
+    # The maximum lifetime (days) an authenticated user can be logged in since login time before being required to login. Default is 30 days.
+    login_maximum_lifetime_days = 30
+
+    # How often should auth tokens be rotated for authenticated users when being active. The default is each 10 minutes.
+    token_rotation_interval_minutes = 10
+
+    # Set to true to disable (hide) the login form, useful if you use OAuth
+    disable_login_form = false
+
+    # Set to true to disable the signout link in the side menu. useful if you use auth.proxy
+    disable_signout_menu = false
+
+    # URL to redirect the user to after sign out
+    signout_redirect_url =
+
+    # Set to true to attempt login with OAuth automatically, skipping the login screen.
+    # This setting is ignored if multiple OAuth providers are configured.
+    oauth_auto_login = false
+
+    #################################### Anonymous Auth ######################
+    [auth.anonymous]
+    # enable anonymous access
+    enabled = true
+
+    # specify organization name that should be used for unauthenticated users
+    org_name = Main Org.
+
+    # specify role for unauthenticated users
+    org_role = Admin
+
+
+    #################################### Basic Auth ##########################
+    [auth.basic]
+    enabled = false
+
+    #################################### Logging ##########################
+    [log]
+    # Either "console", "file", "syslog". Default is console and file
+    # Use space to separate multiple modes, e.g. "console file"
+    mode = console file
+
+    # Either "debug", "info", "warn", "error", "critical", default is "info"
+    level = info
+
+    # optional settings to set different levels for specific loggers. Ex filters = sqlstore:debug
+    filters =
+
+    # For "console" mode only
+    [log.console]
+    level =
+
+    # log line format, valid options are text, console and json
+    format = console
+
+    # For "file" mode only
+    [log.file]
+    level =
+
+    # log line format, valid options are text, console and json
+    format = text
+
+    # This enables automated log rotate(switch of following options), default is true
+    log_rotate = true
+
+    # Max line number of single file, default is 1000000
+    max_lines = 1000000
+
+    # Max size shift of single file, default is 28 means 1 << 28, 256MB
+    max_size_shift = 28
+
+    # Segment log daily, default is true
+    daily_rotate = true
+
+    # Expired days of log file(delete after max days), default is 7
+    max_days = 7
+
+    [log.syslog]
+    level =
+
+    # log line format, valid options are text, console and json
+    format = text
+
+    # Syslog network type and address. This can be udp, tcp, or unix. If left blank, the default unix endpoints will be used.
+    network =
+    address =
+
+    # Syslog facility. user, daemon and local0 through local7 are valid.
+    facility =
+
+    # Syslog tag. By default, the process' argv[0] is used.
+    tag =
+
+    #################################### Usage Quotas ########################
+    [quota]
+    enabled = false
+
+    #### set quotas to -1 to make unlimited. ####
+    # limit number of users per Org.
+    org_user = 10
+
+    # limit number of dashboards per Org.
+    org_dashboard = 100
+
+    # limit number of data_sources per Org.
+    org_data_source = 10
+
+    # limit number of api_keys per Org.
+    org_api_key = 10
+
+    # limit number of orgs a user can create.
+    user_org = 10
+
+    # Global limit of users.
+    global_user = -1
+
+    # global limit of orgs.
+    global_org = -1
+
+    # global limit of dashboards
+    global_dashboard = -1
+
+    # global limit of api_keys
+    global_api_key = -1
+
+    # global limit on number of logged in users.
+    global_session = -1
+
+    #################################### Alerting ############################
+    [alerting]
+    # Disable alerting engine & UI features
+    enabled = true
+    # Makes it possible to turn off alert rule execution but alerting UI is visible
+    execute_alerts = true
+
+    # Default setting for new alert rules. Defaults to categorize error and timeouts as alerting. (alerting, keep_state)
+    error_or_timeout = alerting
+
+    # Default setting for how Grafana handles nodata or null values in alerting. (alerting, no_data, keep_state, ok)
+    nodata_or_nullvalues = no_data
+
+    # Alert notifications can include images, but rendering many images at the same time can overload the server
+    # This limit will protect the server from render overloading and make sure notifications are sent out quickly
+    concurrent_render_limit = 5
+
+    #################################### Explore #############################
+    [explore]
+    # Enable the Explore section
+    enabled = true
+
+    #################################### Internal Grafana Metrics ############
+    # Metrics available at HTTP API Url /metrics
+    [metrics]
+    enabled           = true
+    interval_seconds  = 10
+
+    #If both are set, basic auth will be required for the metrics endpoint.
+    basic_auth_username =
+    basic_auth_password =
+  prometheus-datasource: |
+    apiVersion: 1
+    deleteDatasources:
+      - name: prometheus
+        orgId: 1
+    datasources:
+    - name: prometheus
+      type: prometheus
+      access: proxy
+      orgId: 1
+      url: http://prometheus:9090
+      basicAuth: false
+      editable: true
+  cilium-dashboard: |
     {
       "annotations": {
         "list": [
@@ -6686,82 +7003,3 @@ data:
       "uid": "vtuWtdumz",
       "version": 43
     }
-  prometheus-datasource.json: |
-    {
-      "name": "prometheus",
-      "type": "prometheus",
-      "url": "http://prometheus:9090",
-      "access": "proxy",
-      "basicAuth": false
-    }
----
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: grafana-dashboards-import
-  namespace: cilium-monitoring
-spec:
-  template:
-    metadata:
-      name: grafana-import-dashboards
-      labels:
-        app: grafana
-        component: import-dashboards
-    spec:
-      # serviceAccountName: prometheus-k8s
-      initContainers:
-      - name: wait-for-grafana
-        image: docker.io/giantswarm/tiny-tools
-        args:
-        - /bin/sh
-        - -c
-        - >
-          set -x;
-          while [ $(curl -sw '%{http_code}' "http://grafana:3000" -o /dev/null) -ne 200]; do
-            echo '.'
-            sleep 15;
-          done
-      restartPolicy: Never
-      containers:
-      - name: grafana-import-dashboards
-        image: giantswarm/tiny-tools
-        command: ["/bin/sh", "-c"]
-        workingDir: /opt/grafana-dashboards
-        args:
-          - >
-            for file in *-datasource.json ; do
-              if [ -e "$file" ] ; then
-                echo "importing $file" &&
-                curl --silent --fail --show-error \
-                  --request POST http://grafana:3000/api/datasources \
-                  --header "Content-Type: application/json" \
-                  --data-binary "@$file" ;
-                echo "" ;
-              fi
-            done ;
-            for file in *-dashboard.json ; do
-              if [ -e "$file" ] ; then
-                echo "importing $file" &&
-                ( echo '{"dashboard":'; \
-                  cat "$file"; \
-                  echo ',"overwrite":true,"inputs":[{"name":"DS_PROMETHEUS","type":"datasource","pluginId":"prometheus","value":"prometheus"}]}' ) \
-                | jq -c '.' \
-                | curl --silent --fail --show-error \
-                  --request POST http://grafana:3000/api/dashboards/import \
-                  --header "Content-Type: application/json" \
-                  --data-binary "@-" ;
-                echo "" ;
-              fi
-            done
-
-        envFrom:
-          - configMapRef:
-              name: grafana-config
-        volumeMounts:
-        - name: dashboards
-          mountPath: /opt/grafana-dashboards
-      restartPolicy: Never
-      volumes:
-      - name: dashboards
-        configMap:
-          name: grafana-dashboards


### PR DESCRIPTION
- Update grafana to 6.0.0
- Remove batch job to insert dashboard and datasources
- Store descriptors as they are printed by `kubectl get -o yaml` for
easy comparison between version

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7256)
<!-- Reviewable:end -->
