### PR TITLE
contrib: `$a` corrupted patch in cherry-pick

### DIFF
--- a/contrib/backporting/cherry-pick
+++ b/contrib/backporting/cherry-pick
@@ -15,7 +15,7 @@ cherry_pick () {
   git format-patch -1 $FULL_ID --stdout | sed '/^$/Q' > $TMPF
   echo "" >> $TMPF
   echo "[ upstream commit $FULL_ID ]" >> $TMPF
-  git format-patch -1 $FULL_ID --stdout | sed -n '/^$/,/$a/p' >> $TMPF
+  git format-patch -1 $FULL_ID --stdout | sed -n '/^$/,/$ a/p' >> $TMPF
   echo "Applying: $(git log -1 --oneline $FULL_ID)"
   git am --quiet -3 --signoff $TMPF
   rm $TMPF


### PR DESCRIPTION
`$a` in cherry-pick expanded in sed command and caused
only half of patch to be put into `$TMPF`, which caused patch
corruption.

Added space should take care of that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7258)
<!-- Reviewable:end -->
