### PR TITLE
Improve scalability of workloads layer in Kubernetes mode

### DIFF
--- a/pkg/workloads/containerd.go
+++ b/pkg/workloads/containerd.go
@@ -143,10 +143,6 @@ func (c *containerDClient) Status() *models.Status {
 	}
 }
 
-const (
-	syncRateContainerD = 5 * time.Minute
-)
-
 // EnableEventListener watches for containerD events. Performs the plumbing for
 // the containers started or dead.
 func (c *containerDClient) EnableEventListener() (eventsCh chan<- *EventMessage, err error) {
@@ -156,19 +152,7 @@ func (c *containerDClient) EnableEventListener() (eventsCh chan<- *EventMessage,
 	}
 	log.Info("Enabling containerD event listener")
 
-	ws := newWatcherState(eventQueueBufferSize)
-	// start a go routine which periodically synchronizes containers
-	// managed by the local container runtime and checks if any of them
-	// need to be managed by Cilium. This is a fall back mechanism in case
-	// an event notification has been lost.
-	// Note: We do the sync before the first sleep
-	go func(state *watcherState) {
-		for {
-			state.reapEmpty()
-			ws.syncWithRuntime()
-			time.Sleep(syncRateContainerD)
-		}
-	}(ws)
+	ws := newWatcherState()
 
 	// Note: We do the sync before the first sleep
 	go func(state *watcherState) {

--- a/pkg/workloads/cri.go
+++ b/pkg/workloads/cri.go
@@ -133,19 +133,7 @@ func (c *criClient) EnableEventListener() (chan<- *EventMessage, error) {
 	}
 	log.Info("Enabling CRI event listener")
 
-	ws := newWatcherState(eventQueueBufferSize)
-	// start a go routine which periodically synchronizes containers
-	// managed by the local container runtime and checks if any of them
-	// need to be managed by Cilium. This is a fall back mechanism in case
-	// an event notification has been lost.
-	// Note: We do the sync before the first sleep
-	go func(state *watcherState) {
-		for {
-			state.reapEmpty()
-			ws.syncWithRuntime()
-			time.Sleep(syncRateContainerD)
-		}
-	}(ws)
+	ws := newWatcherState()
 
 	eventsCh := make(chan *EventMessage, 100)
 	go func(state *watcherState, eventsCh <-chan *EventMessage) {

--- a/pkg/workloads/defaults.go
+++ b/pkg/workloads/defaults.go
@@ -62,7 +62,7 @@ func processCreateWorkload(ep *endpoint.Endpoint, containerID string, allLabels 
 	ep.SetContainerID(containerID)
 
 	// FIXME: Remove this in 2019-06: GH-6526
-	if k8s.IsEnabled() {
+	if k8s.IsEnabled() && ep.GetK8sPodName() == "" {
 		ep.SetK8sNamespace(k8sLbls.GetPodNamespace(allLabels))
 		ep.SetK8sPodName(k8sLbls.GetPodName(allLabels))
 	}


### PR DESCRIPTION
This resolves some major scalability bottlenecks in the workloads layer when operating in Kuberentes mode:

 - Disable periodic runtime sync, it is not required in Kubernetes mode
 - Avoid fetching labels and thus causing a apiserver interaction for all 20 retries of trying to associate a container with an endpoint
 - Avoid overwriting pod/namespace name when already set

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7260)
<!-- Reviewable:end -->
