### PR TITLE
api: Return 500 "Internal Error" when API handlers panic

### DIFF
--- a/pkg/api/apipanic.go
+++ b/pkg/api/apipanic.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ type APIPanicHandler struct {
 
 // ServeHTTP implements the http.Handler interface.
 // It recovers from panics of all next handlers and logs them
-func (h *APIPanicHandler) ServeHTTP(r http.ResponseWriter, req *http.Request) {
+func (h *APIPanicHandler) ServeHTTP(wr http.ResponseWriter, req *http.Request) {
 	defer func() {
 		if r := recover(); r != nil {
 			fields := logrus.Fields{
@@ -39,7 +39,11 @@ func (h *APIPanicHandler) ServeHTTP(r http.ResponseWriter, req *http.Request) {
 			}
 			log.WithFields(fields).Warn("Cilium API handler panicked")
 			log.Debugf("%s", debug.Stack())
+			wr.WriteHeader(http.StatusInternalServerError)
+			if _, err := wr.Write([]byte("Internal error occurred, check Cilium logs for details.")); err != nil {
+				log.WithError(err).Debug("Failed to write API response")
+			}
 		}
 	}()
-	h.Next.ServeHTTP(r, req)
+	h.Next.ServeHTTP(wr, req)
 }


### PR DESCRIPTION
Previously, when an API handler panicked, the resulting return code for
the request would be 200 OK, implying that the API request was satisfied
despite the fact that the handler panicked while handling the request.
Fix this by writing the header code for internal server error with a
message asking the user to check the cilium logs for details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7265)
<!-- Reviewable:end -->
