### PR TITLE
Fix API internal errors due to requests for endpoints that do not exist

### DIFF
--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -676,6 +676,8 @@ func (d *Daemon) EndpointUpdate(id string, cfg *models.EndpointConfigurationSpec
 	ep, err := endpointmanager.Lookup(id)
 	if err != nil {
 		return api.Error(PatchEndpointIDInvalidCode, err)
+	} else if ep == nil {
+		return api.New(PatchEndpointIDNotFoundCode, "endpoint %s not found", id)
 	}
 	if err = endpoint.APICanModify(ep); err != nil {
 		return api.Error(PatchEndpointIDInvalidCode, err)

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -902,6 +902,8 @@ func (h *putEndpointIDLabels) Handle(params PatchEndpointIDLabelsParams) middlew
 
 	ep, err := endpointmanager.Lookup(params.ID)
 	if err != nil {
+		return api.Error(PutEndpointIDInvalidCode, err)
+	} else if ep == nil {
 		return NewPatchEndpointIDLabelsNotFound()
 	}
 


### PR DESCRIPTION
Previously, with these APIs, if an API request was made relating to an endpoint ID that has no corresponding endpoint, then the API handler would attempt to dereference the endpoint before checking whether it exists or not. Due to the apipanic library, this would not cause a full Cilium crash, but it could lead to some weird error responses on the commandline such as:

```
$ cilium endpoint regenerate 1
Error: Cannot regenerate endpoint 1: [PATCH /endpoint/{id}/config][500] patchEndpointIdConfigFailed  Internal error occurred. Check Cilium logs for details.
```

Fix this by checking whether the endpoint is non-nil first, and form a proper API response:
```
$ cilium endpoint regenerate 1   
Error: Cannot regenerate endpoint 1: [PATCH /endpoint/{id}/config][404] patchEndpointIdConfigNotFound
```

If you feel strongly that this _should_ be backported, please comment on the issue and/or add the labels and we can discuss.

Related: #7264

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7278)
<!-- Reviewable:end -->
