### PR TITLE
Improve apipanic stack trace log output

### DIFF
--- a/pkg/api/apipanic.go
+++ b/pkg/api/apipanic.go
@@ -16,7 +16,10 @@ package api
 
 import (
 	"net/http"
+	"os"
 	"runtime/debug"
+
+	"github.com/cilium/cilium/pkg/logging"
 
 	"github.com/sirupsen/logrus"
 )
@@ -38,7 +41,9 @@ func (h *APIPanicHandler) ServeHTTP(wr http.ResponseWriter, req *http.Request) {
 				"client":        req.RemoteAddr,
 			}
 			log.WithFields(fields).Warn("Cilium API handler panicked")
-			log.Debugf("%s", debug.Stack())
+			if logging.DefaultLogger.IsLevelEnabled(logrus.DebugLevel) {
+				os.Stdout.Write(debug.Stack())
+			}
 			wr.WriteHeader(http.StatusInternalServerError)
 			if _, err := wr.Write([]byte("Internal error occurred, check Cilium logs for details.")); err != nil {
 				log.WithError(err).Debug("Failed to write API response")


### PR DESCRIPTION
This properly formats the output in the log instead of one giant log
line with embedded '\n' strings. We do similar in the lockdebug library,
so follow that example.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7279)
<!-- Reviewable:end -->
