### PR TITLE
kvstore: Make kvstore periodic sync interval configurable

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -75,6 +75,7 @@ cilium-agent [flags]
       --keep-config                                 When restoring state, keeps containers' configuration in place
       --kvstore string                              Key-value store type
       --kvstore-opt map                             Key-value store options (default map[])
+      --kvstore-periodic-sync duration              Periodic KVstore synchronization interval (default 5m0s)
       --label-prefix-file string                    Valid label prefixes file path
       --labels strings                              List of label prefixes used to determine identity of an endpoint
       --lb string                                   Enables load balancer mode where load balancer bpf program is attached to the given interface

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -519,6 +519,9 @@ func init() {
 	flags.String(option.KVStore, "", "Key-value store type")
 	option.BindEnv(option.KVStore)
 
+	flags.Duration(option.KVstorePeriodicSync, defaults.KVstorePeriodicSync, "Periodic KVstore synchronization interval")
+	option.BindEnv(option.KVstorePeriodicSync)
+
 	flags.Var(option.NewNamedMapOptions(option.KVStoreOpt, &option.Config.KVStoreOpt, nil),
 		option.KVStoreOpt, "Key-value store options")
 	option.BindEnv(option.KVStoreOpt)

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -158,4 +158,7 @@ const (
 
 	// AlignCheckerName is the BPF object name for the alignchecker.
 	AlignCheckerName = "bpf_alignchecker.o"
+
+	// KVstorePeriodicSync is the default kvstore periodic sync interval
+	KVstorePeriodicSync = 5 * time.Minute
 )

--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/uuid"
 
 	"github.com/sirupsen/logrus"
@@ -45,10 +46,6 @@ const (
 	// listTimeout is the time to wait for the initial list operation to
 	// succeed when creating a new allocator
 	listTimeout = 3 * time.Minute
-
-	// localKeySyncInterval is the interval in which local keys are being
-	// synced to the kvstore in case master keys get lost
-	localKeySyncInterval = 1 * time.Minute
 )
 
 // Allocator is a distributed ID allocator backed by a KVstore. It maps
@@ -736,7 +733,7 @@ func (a *Allocator) startLocalKeySync() {
 				log.WithFields(logrus.Fields{fieldPrefix: a.idPrefix}).
 					Debug("Stopped master key sync routine")
 				return
-			case <-time.After(localKeySyncInterval):
+			case <-time.After(option.Config.KVstorePeriodicSync):
 			}
 		}
 	}(a)

--- a/pkg/kvstore/store/store.go
+++ b/pkg/kvstore/store/store.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
 
 	"github.com/sirupsen/logrus"
 )
@@ -33,10 +34,6 @@ const (
 	// listTimeoutDefault is the default timeout to wait while performing
 	// the initial list operation of objects from the kvstore
 	listTimeoutDefault = 3 * time.Minute
-
-	// synchronizationIntervalDefault is the default interval to
-	// synchronize keys with the kvstore
-	synchronizationIntervalDefault = time.Minute
 
 	// watcherChanSize is the size of the channel to buffer kvstore events
 	watcherChanSize = 100
@@ -90,7 +87,7 @@ func (c *Configuration) validate() error {
 	}
 
 	if c.SynchronizationInterval == 0 {
-		c.SynchronizationInterval = synchronizationIntervalDefault
+		c.SynchronizationInterval = option.Config.KVstorePeriodicSync
 	}
 
 	if c.Backend == nil {

--- a/pkg/kvstore/store/store_test.go
+++ b/pkg/kvstore/store/store_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/testutils"
 
 	. "gopkg.in/check.v1"
@@ -146,14 +147,14 @@ func (s *StoreSuite) TestStoreCreation(c *C) {
 	store, err = JoinSharedStore(Configuration{Prefix: testutils.RandomRune(), KeyCreator: newTestType})
 	c.Assert(err, IsNil)
 	c.Assert(store, Not(IsNil))
-	c.Assert(store.conf.SynchronizationInterval, Equals, synchronizationIntervalDefault)
+	c.Assert(store.conf.SynchronizationInterval, Equals, option.Config.KVstorePeriodicSync)
 	store.Close()
 
 	// Test with kvstore client specified
 	store, err = JoinSharedStore(Configuration{Prefix: testutils.RandomRune(), KeyCreator: newTestType, Backend: kvstore.Client()})
 	c.Assert(err, IsNil)
 	c.Assert(store, Not(IsNil))
-	c.Assert(store.conf.SynchronizationInterval, Equals, synchronizationIntervalDefault)
+	c.Assert(store.conf.SynchronizationInterval, Equals, option.Config.KVstorePeriodicSync)
 	store.Close()
 }
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -24,6 +24,7 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/common"
@@ -396,6 +397,10 @@ const (
 
 	// IPSecKeyFileName is the name of the option for ipsec key file
 	IPSecKeyFileName = "ipsec-key-file"
+
+	// KVstorePeriodicSync is the time interval in which periodic
+	// synchronization with the kvstore occurs
+	KVstorePeriodicSync = "kvstore-periodic-sync"
 )
 
 // FQDNS variables
@@ -780,6 +785,10 @@ type DaemonConfig struct {
 	// EnableHealthChecking enables health checking between nodes and
 	// health endpoints
 	EnableHealthChecking bool
+
+	// KVstorePeriodicSync is the time interval in which periodic
+	// synchronization with the kvstore occurs
+	KVstorePeriodicSync time.Duration
 }
 
 var (
@@ -794,6 +803,7 @@ var (
 		EnableIPv4:               defaults.EnableIPv4,
 		EnableIPv6:               defaults.EnableIPv6,
 		ToFQDNsMaxIPsPerHost:     defaults.ToFQDNsMaxIPsPerHost,
+		KVstorePeriodicSync:      defaults.KVstorePeriodicSync,
 		ContainerRuntimeEndpoint: make(map[string]string),
 		FixedIdentityMapping:     make(map[string]string),
 		KVStoreOpt:               make(map[string]string),
@@ -1045,6 +1055,7 @@ func (c *DaemonConfig) Populate() {
 	c.KeepTemplates = viper.GetBool(KeepBPFTemplates)
 	c.KeepConfig = viper.GetBool(KeepConfig)
 	c.KVStore = viper.GetString(KVStore)
+	c.KVstorePeriodicSync = viper.GetDuration(KVstorePeriodicSync)
 	c.LabelPrefixFile = viper.GetString(LabelPrefixFile)
 	c.Labels = viper.GetStringSlice(Labels)
 	c.LBInterface = viper.GetString(LB)


### PR DESCRIPTION
Changes the default to 5 minutes as a saner default for mid-scale environments
and make the interval configurable if needed.

Fixes: #7223

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7280)
<!-- Reviewable:end -->
