### PR TITLE
allocator: Move allocator garbage collector into operator

### DIFF
--- a/operator/identity_gc.go
+++ b/operator/identity_gc.go
@@ -1,0 +1,43 @@
+// Copyright 2018-2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"time"
+
+	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/kvstore/allocator"
+)
+
+var (
+	// identityGCInterval is the interval in which allocator identities are
+	// attempted to be expired from the kvstore
+	identityGCInterval time.Duration
+)
+
+func startIdentityGC() {
+	log.Infof("Starting security identity garbage collector with %s interval...", identityGCInterval)
+	a := allocator.NewAllocatorForGC(cache.IdentitiesPath)
+
+	go func() {
+		for {
+			if err := a.RunGC(); err != nil {
+				log.WithError(err).Warning("Unable to run security identity garbage collector")
+			}
+
+			<-time.After(identityGCInterval)
+		}
+	}()
+}

--- a/operator/main.go
+++ b/operator/main.go
@@ -99,6 +99,7 @@ func init() {
 
 	flags.BoolVar(&synchronizeServices, "synchronize-k8s-services", true, "Synchronize Kubernetes services to kvstore")
 	flags.BoolVar(&enableCepGC, "cilium-endpoint-gc", true, "Enable CiliumEndpoint garbage collector")
+	flags.DurationVar(&identityGCInterval, "identity-gc-interval", time.Minute*10, "GC interval for security identities")
 
 	flags.IntVar(&unmanagedKubeDnsWatcherInterval, "unmanaged-pod-watcher-interval", 15, "Interval to check for unmanaged kube-dns pods (0 to disable)")
 
@@ -170,6 +171,10 @@ func runOperator(cmd *cobra.Command) {
 
 	if enableCepGC {
 		enableCiliumEndpointSyncGC()
+	}
+
+	if identityGCInterval != time.Duration(0) {
+		startIdentityGC()
 	}
 
 	if option.Config.DisableCiliumEndpointCRD {

--- a/pkg/kvstore/allocator/allocator_test.go
+++ b/pkg/kvstore/allocator/allocator_test.go
@@ -219,7 +219,7 @@ func testAllocator(c *C, maxID idpool.ID, allocatorName string, suffix string) {
 	}
 
 	// running the GC should not evict any entries
-	allocator.runGC()
+	allocator.RunGC()
 
 	v, err := kvstore.ListPrefix(allocator.idPrefix)
 	c.Assert(err, IsNil)
@@ -236,7 +236,7 @@ func testAllocator(c *C, maxID idpool.ID, allocatorName string, suffix string) {
 	}
 
 	// running the GC should evict all entries
-	allocator.runGC()
+	allocator.RunGC()
 
 	v, err = kvstore.ListPrefix(allocator.idPrefix)
 	c.Assert(err, IsNil)
@@ -369,7 +369,7 @@ func (s *AllocatorSuite) TestRemoteCache(c *C) {
 //	}
 //
 //	// running the GC should evict all entries
-//	allocator.runGC()
+//	allocator.RunGC()
 //
 //	v, err := kvstore.ListPrefix(allocator.idPrefix)
 //	c.Assert(err, IsNil)


### PR DESCRIPTION
In order to assist with scale, move the security identity garbage colletor into
the operator instead of running on on each node every 10 minutes.

Fixes: #7238

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7281)
<!-- Reviewable:end -->
