### PR TITLE
contrib: Fix cherry-pick to avoid omitting parts of patch

### DIFF
--- a/contrib/backporting/cherry-pick
+++ b/contrib/backporting/cherry-pick
@@ -15,7 +15,7 @@ cherry_pick () {
   git format-patch -1 $FULL_ID --stdout | sed '/^$/Q' > $TMPF
   echo "" >> $TMPF
   echo "[ upstream commit $FULL_ID ]" >> $TMPF
-  git format-patch -1 $FULL_ID --stdout | sed -n '/^$/,/$ a/p' >> $TMPF
+  git format-patch -1 $FULL_ID --stdout | sed -n '/^$/,$p' >> $TMPF
   echo "Applying: $(git log -1 --oneline $FULL_ID)"
   git am --quiet -3 --signoff $TMPF
   rm $TMPF


### PR DESCRIPTION
The cherry-pick script inserts "[ upstream commit $ID ]" into
a commit message after its title. This is done by splitting the
original commit message into two parts with sed - one before
the first empty line and everything else.

Sometimes, extracting the later part did not properly work -
some parts of commit message were omitted, and I haven't spent
much time trying to understand why sed decided to omit.

This commit changes the sed pattern to print everything
after the first empty line.

I have tested it with the 7ba1142f60 ("contrib: `$a` corrupted patch in
cherry-pick") commit which previously was not properly handled
by sed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7286)
<!-- Reviewable:end -->
