### PR TITLE
v1.3 backports 2019-03-05

### DIFF
--- a/pkg/api/apipanic.go
+++ b/pkg/api/apipanic.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ type APIPanicHandler struct {
 
 // ServeHTTP implements the http.Handler interface.
 // It recovers from panics of all next handlers and logs them
-func (h *APIPanicHandler) ServeHTTP(r http.ResponseWriter, req *http.Request) {
+func (h *APIPanicHandler) ServeHTTP(wr http.ResponseWriter, req *http.Request) {
 	defer func() {
 		if r := recover(); r != nil {
 			fields := logrus.Fields{
@@ -39,7 +39,11 @@ func (h *APIPanicHandler) ServeHTTP(r http.ResponseWriter, req *http.Request) {
 			}
 			log.WithFields(fields).Warn("Cilium API handler panicked")
 			log.Debugf("%s", debug.Stack())
+			wr.WriteHeader(http.StatusInternalServerError)
+			if _, err := wr.Write([]byte("Internal error occurred, check Cilium logs for details.")); err != nil {
+				log.WithError(err).Debug("Failed to write API response")
+			}
 		}
 	}()
-	h.Next.ServeHTTP(r, req)
+	h.Next.ServeHTTP(wr, req)
 }


### PR DESCRIPTION
v1.3 backports 2019-03-05

## Included

 * #7265 -- api: Return 500 "Internal Error" when API handlers panic (@joestringer)

## Not included

 * #7246 -- Protect remaining local keys from kvstore delete events (@tgraf)
 * #7249 -- daemon: Remove old health EP state dirs in restore (@joestringer)

## Dropped

*  #7258 -- contrib: `$a` corrupted patch in cherry-pick (@nebril)

Once this PR is merged, you can update the PR labels via:
```
$ for pr in 7265; do contrib/backporting/set-labels.py $pr done 1.3; done
```
---
- @joestringer #7249 depends on e1b6ebb2500608620fad58fba4234974e81a3b7e (`ep.StateDirectoryPath()`). Maybe we can define the method separately and include into the backport?
- @tgraf 234b257166ad5ca6dfbc5981c2ef31130c0bfad7 of #7246 depends on a5f8515478065477a9bf83da9eb494bd8646ae1d (`Configuration.Observer`) for testing. Maybe we can define the field separately?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7287)
<!-- Reviewable:end -->
