### PR TITLE
contrib: Update backporting README

### DIFF
--- a/contrib/backporting/README.md
+++ b/contrib/backporting/README.md
@@ -1,12 +1,12 @@
 Cilium Backporting Scripts
 ==========================
 
-# check-stable - List commits that need stable backporting
+# check-stable - List commits that need backporting
 
-`GITHUB_TOKEN=xxx check-stable`
+`GITHUB_TOKEN=xxx check-stable X.Y`
 
 The `check-stable` script is derived from `relnotes` and scans for PRs which
-have been merged and marked with the label `stable/needs-backport`. The
+have been merged and marked with the label `needs-backport/X.Y`. The
 script will list those PRs and all non-merge commit ids that were part of the
 merge. There are three columns: first one is the correlated sha of the commit
 from the master branch, second one is the sha of the commit from the pull
@@ -25,7 +25,7 @@ branch is then needed for backporting into downstream with the help of the
 
 2. Run the script to generate the list of current backporting TODOs:
 
-   `GITHUB_TOKEN=xxx `./check-stable`
+   `GITHUB_TOKEN=xxx `./check-stable 1.0`
 
    The list will be dumped to stdout.
 


### PR DESCRIPTION
The previous version of README mentioned the non-existing label and it didn't mention the version param to `check-stable`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7288)
<!-- Reviewable:end -->
