### PR TITLE
Optimize apiserver interactions for health check

### DIFF
--- a/pkg/k8s/metrics/metrics.go
+++ b/pkg/k8s/metrics/metrics.go
@@ -1,0 +1,47 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"time"
+
+	"github.com/cilium/cilium/pkg/lock"
+)
+
+var (
+	// LastInteraction is the time at which the last apiserver interaction
+	// occured
+	LastInteraction eventTimestamper
+)
+
+type eventTimestamper struct {
+	timestamp time.Time
+	lock      lock.RWMutex
+}
+
+// Reset sets the timestamp to the current time
+func (e *eventTimestamper) Reset() {
+	e.lock.Lock()
+	e.timestamp = time.Now()
+	e.lock.Unlock()
+}
+
+// Time returns the timestamp as set per Reset()
+func (e *eventTimestamper) Time() time.Time {
+	e.lock.RLock()
+	t := e.timestamp
+	e.lock.RUnlock()
+	return t
+}

--- a/pkg/k8s/metrics/metrics_test.go
+++ b/pkg/k8s/metrics/metrics_test.go
@@ -1,0 +1,37 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type MetricsSuite struct{}
+
+var _ = Suite(&MetricsSuite{})
+
+func (s *MetricsSuite) TestLastInteraction(c *C) {
+	LastInteraction.Reset()
+	c.Assert(time.Since(LastInteraction.Time()) < time.Second, Equals, true)
+}

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -315,7 +315,7 @@ func (s *managerTestSuite) BenchmarkUpdateAndDeleteCycle(c *check.C) {
 	c.StopTimer()
 }
 
-func (s *managerTestSuite) TestBackgroundSyncInterval(c *check.C) {
+func (s *managerTestSuite) TestClusterSizeDependantInterval(c *check.C) {
 	mngr, err := NewManager("test", fake.NewNodeHandler())
 	c.Assert(err, check.IsNil)
 	defer mngr.Close()
@@ -325,7 +325,7 @@ func (s *managerTestSuite) TestBackgroundSyncInterval(c *check.C) {
 	for i := 0; i < 1000; i++ {
 		n := node.Node{Name: fmt.Sprintf("%d", i), Source: node.FromAgentLocal}
 		mngr.NodeUpdated(n)
-		newInterval := mngr.backgroundSyncInterval()
+		newInterval := mngr.ClusterSizeDependantInterval(time.Minute)
 		c.Assert(newInterval > prevInterval, check.Equals, true)
 	}
 }
@@ -336,7 +336,7 @@ func (s *managerTestSuite) TestBackgroundSync(c *check.C) {
 	// set the base background sync interval to a very low value so the
 	// background sync runs aggressively
 	baseBackgroundSyncIntervalBackup := baseBackgroundSyncInterval
-	baseBackgroundSyncInterval = float64((10 * time.Millisecond).Nanoseconds())
+	baseBackgroundSyncInterval = 10 * time.Millisecond
 	defer func() { baseBackgroundSyncInterval = baseBackgroundSyncIntervalBackup }()
 
 	signalNodeHandler := newSignalNodeHandler()

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -57,6 +57,16 @@ type Probe struct {
 
 	// OnStatusUpdate is called whenever the status of the probe changes
 	OnStatusUpdate func(status Status)
+
+	// Interval allows to specify a probe specific interval that can be
+	// mutated based on whether the probe is failing or based on external
+	// factors such as current cluster size
+	Interval func(failures int) time.Duration
+
+	// consecutiveFailures is the number of consecutive failures in the
+	// probe becoming stale or failing. It is managed by
+	// updateProbeStatus()
+	consecutiveFailures int
 }
 
 // Collector concurrently runs probes used to check status of various subsystems
@@ -134,11 +144,16 @@ func (c *Collector) spawnProbe(p *Probe) {
 		for {
 			c.runProbe(p)
 
+			interval := c.config.Interval
+			if p.Interval != nil {
+				interval = p.Interval(p.consecutiveFailures)
+			}
+
 			select {
 			case <-c.stop:
 				// collector is closed, stop looping
 				return
-			case <-time.After(c.config.Interval):
+			case <-time.After(interval):
 				// keep looping
 			}
 		}
@@ -224,8 +239,14 @@ func (c *Collector) updateProbeStatus(p *Probe, data interface{}, stale bool, er
 	startTime := c.probeStartTime[p.Name]
 	if stale {
 		c.staleProbes[p.Name] = struct{}{}
+		p.consecutiveFailures++
 	} else {
 		delete(c.staleProbes, p.Name)
+		if err == nil {
+			p.consecutiveFailures = 0
+		} else {
+			p.consecutiveFailures++
+		}
 	}
 	c.Unlock()
 


### PR DESCRIPTION
The status checker was triggering a version call to the apiserver every 5 seconds. Optimize this using the following approach:

 * Use a cluster size dependent interval
 * Increase the interval while failing to ensure fast recovery
 * Consider the timestamp of the last event received to avoid unnecessary calls to the apiserver
 * Enforce an interval in which version checks are performed to ensure that we catch apiserver ugprades


![screen shot 2019-03-05 at 3 09 14 pm](https://user-images.githubusercontent.com/1417913/53811257-37a96b80-3f59-11e9-87c9-8c58c149439e.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7292)
<!-- Reviewable:end -->
