### PR TITLE
Test: Validate that cilium is ready after upgrade.

### DIFF
--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -268,6 +268,7 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldVersion, newV
 		ExpectWithOffset(1, err).Should(BeNil(), "Cilium is not ready after timeout")
 
 		validatedImage(newVersion)
+		ExpectCiliumReady(kubectl)
 
 		validateEndpointsConnection()
 


### PR DESCRIPTION
To make sure that Cilium is already connected and all is healty make an
assertion to fail in case that something went wrong.

Related to builds:

- https://jenkins.cilium.io/job/cilium-ginkgo/job/cilium/job/master/2478/execution/node/91/log/
Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7295)
<!-- Reviewable:end -->
