### PR TITLE
Fix the getting-started-guide Vagrantfile

### DIFF
--- a/examples/getting-started/Vagrantfile
+++ b/examples/getting-started/Vagrantfile
@@ -3,9 +3,9 @@
 
 Vagrant.require_version ">= 2.0.0"
 
-cilium_version = (ENV['CILIUM_VERSION'] || "v1.4.0")
+cilium_version = (ENV['CILIUM_VERSION'] || "v1.4.1")
 cilium_opts = (ENV['CILIUM_OPTS'] || "--kvstore consul --kvstore-opt consul.address=127.0.0.1:8500 -t vxlan")
-cilium_tag = (ENV['CILIUM_TAG'] || "v1.4.0")
+cilium_tag = (ENV['CILIUM_TAG'] || "v1.4.1")
 
 # This runs only once when vagrant box is provisioned for the first time
 $bootstrap = <<SCRIPT


### PR DESCRIPTION
The Vagrantfile previously pointed to a broken version of the
cilium-docker image, which caused the VM start to fail. Fix this.

Fixes: #7251

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7298)
<!-- Reviewable:end -->
