### PR TITLE
cilium: Datapath transparent encryption CI test

### DIFF
--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -29,10 +29,12 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 	var kubectl *helpers.Kubectl
 	var demoDSPath string
+	var ipsecKeysPath string
 
 	BeforeAll(func() {
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 		demoDSPath = helpers.ManifestGet("demo_ds.yaml")
+		ipsecKeysPath = helpers.ManifestGet("ipsec_keys.yaml")
 
 		kubectl.Exec("kubectl -n kube-system delete ds cilium")
 
@@ -41,11 +43,13 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 	BeforeEach(func() {
 		kubectl.Apply(demoDSPath).ExpectSuccess("cannot install Demo application")
+		kubectl.Apply(ipsecKeysPath).ExpectSuccess("cannot install IPsec keys")
 		kubectl.NodeCleanMetadata()
 	})
 
 	AfterEach(func() {
 		kubectl.Delete(demoDSPath)
+		kubectl.Delete(ipsecKeysPath)
 		ExpectAllPodsTerminated(kubectl)
 
 		// Do not assert on success in AfterEach intentionally to avoid
@@ -103,6 +107,14 @@ var _ = Describe("K8sDatapathConfig", func() {
 			status.ExpectSuccess()
 			Expect(status.IntOutput()).Should(Equal(3), "Did not find expected number of entries in BPF tunnel map")
 		}
+
+		It("Check connectivity with transparent encryption and VXLAN encapsulation", func() {
+			SkipIfFlannel()
+			deployCilium("cilium-ds-patch-vxlan-ipsec.yaml")
+			validateBPFTunnelMap()
+			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test with IPsec between nodes failed")
+			cleanService()
+		}, 600)
 
 		It("Check connectivity with VXLAN encapsulation", func() {
 			SkipIfFlannel()

--- a/test/k8sT/manifests/cilium-ds-patch-ipv4-only-ipsec.yaml
+++ b/test/k8sT/manifests/cilium-ds-patch-ipv4-only-ipsec.yaml
@@ -1,0 +1,32 @@
+---
+metadata:
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+      - image: k8s1:5000/cilium/cilium-dev:latest
+        imagePullPolicy: Always
+        name: cilium-agent
+        args:
+        - "--kvstore=etcd"
+        - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
+        - "--k8s-require-ipv4-pod-cidr"
+        - "--pprof=true"
+        - "--log-system-load"
+        - "--enable-ipv4=true"
+        - "--enable-ipv6=false"
+        - "--config-dir=/tmp/cilium/config-map"
+        - "--enable-ipsec"
+        - "--ipsec-key-file=/etc/ipsec/keys"
+        volumeMounts:
+          - name: cilium-ipsec-secrets
+            mountPath: /etc/ipsec
+      volumes:
+      - name: cilium-ipsec-secrets
+        secret:
+          secretName: cilium-ipsec-keys
+      - name: etcd-secrets
+        secret:
+          secretName: cilium-etcd-client-tls
+      dnsPolicy: ClusterFirstWithHostNet

--- a/test/k8sT/manifests/cilium-ds-patch-vxlan-ipsec.yaml
+++ b/test/k8sT/manifests/cilium-ds-patch-vxlan-ipsec.yaml
@@ -1,0 +1,31 @@
+---
+metadata:
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+      - image: k8s1:5000/cilium/cilium-dev:latest
+        imagePullPolicy: Always
+        name: cilium-agent
+        args:
+        - "--tunnel=vxlan"
+        - "--kvstore=etcd"
+        - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
+        - "--k8s-require-ipv4-pod-cidr"
+        - "--pprof=true"
+        - "--log-system-load"
+        - "--config-dir=/tmp/cilium/config-map"
+        - "--enable-ipsec"
+        - "--ipsec-key-file=/etc/ipsec/keys"
+        volumeMounts:
+          - name: cilium-ipsec-secrets
+            mountPath: /etc/ipsec
+      volumes:
+      - name: cilium-ipsec-secrets
+        secret:
+          secretName: cilium-ipsec-keys
+      - name: etcd-secrets
+        secret:
+          secretName: cilium-etcd-client-tls
+      dnsPolicy: ClusterFirstWithHostNet

--- a/test/k8sT/manifests/ipsec_keys.yaml
+++ b/test/k8sT/manifests/ipsec_keys.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cilium-ipsec-keys
+  namespace: kube-system
+type: Opaque
+stringData:
+  keys: "hmac(sha256) 0123456789abcdef0123456789abcdef cbc(aes) 0123456789abcdef0123456789abcdef"


### PR DESCRIPTION
Add initial baseline tests to DatapathConfiguration so that all CI
runs now do some enabled-ipsec tests.

Signed-off-by: John Fastabend <john.fastabend@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7303)
<!-- Reviewable:end -->
