### PR TITLE
Makefile: Add microk8s make target

### DIFF
--- a/contrib/k8s/microk8s-prepull.yaml
+++ b/contrib/k8s/microk8s-prepull.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1beta2
+kind: DaemonSet
+metadata:
+  name: prepull
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      name: prepull
+  template:
+    metadata:
+      labels:
+        name: prepull
+    spec:
+      initContainers:
+      - name: prepull
+        image: docker
+        command: ["docker", "pull", "localhost:32000/cilium/cilium:local"]
+        volumeMounts:
+        - name: docker
+          mountPath: /var/run
+      volumes:
+      - name: docker
+        hostPath:
+          path: /var/snap/microk8s/current/
+      containers:
+      - name: pause
+        image: gcr.io/google_containers/pause


### PR DESCRIPTION
This will build and push a new image tag based on the code that is
currently checked out, ready for you to update your cilium image in your
microk8s setup:

  $ make microk8s

There's no official documentation for setting up microk8s to work with
Cilium just yet, but here's the preliminary notes:

https://gist.github.com/joestringer/60a5f53d59e57274ed4c2a1736a7b101

(I plan on streamlining the above docs, tidying them up, and submitting at some point but for now I was just working through the issues with it.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7311)
<!-- Reviewable:end -->
