### PR TITLE
Test: Kubectl helper print stdout instead of write a new step.

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1793,7 +1793,7 @@ func (kub *Kubectl) CiliumPreFlightCheck() error {
 		if err := kub.ciliumPreFlightCheck(); err != nil {
 			newError := err.Error()
 			if lastError != newError || consecutiveFailures >= 5 {
-				ginkgoext.By("Cilium is not ready yet: %s", newError)
+				ginkgoext.GinkgoPrint("Cilium is not ready yet: %s", newError)
 				lastError = newError
 				consecutiveFailures = 0
 			} else {


### PR DESCRIPTION
When use BY a new `STEP` header is written, to debug make it difficult
to understand in what status the test is. If we use GinkgoPrint will
print the output, but no with the STEP header.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7319)
<!-- Reviewable:end -->
