### PR TITLE
Abort identity allocation when endpoint creation is aborted

### DIFF
--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -15,6 +15,7 @@
 package launch
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"os"
@@ -238,7 +239,7 @@ func LaunchAsEndpoint(owner endpoint.Owner, n *node.Node, mtuConfig mtu.Configur
 	}
 
 	// Give the endpoint a security identity
-	ep.UpdateLabels(owner, labels.LabelHealth, nil, true)
+	ep.UpdateLabels(context.Background(), owner, labels.LabelHealth, nil, true)
 
 	// Wait until the cilium-health endpoint is running before setting up routes
 	deadline := time.Now().Add(1 * time.Minute)

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -240,7 +240,7 @@ func (d *Daemon) createEndpoint(ctx context.Context, epTemplate *models.Endpoint
 		return nil, err
 	}
 
-	ep.UpdateLabels(d, addLabels, infoLabels, true)
+	ep.UpdateLabels(ctx, d, addLabels, infoLabels, true)
 
 	select {
 	case <-ctx.Done():

--- a/daemon/policy_test.go
+++ b/daemon/policy_test.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"context"
 	"os"
 	"sort"
 	"time"
@@ -125,29 +126,29 @@ func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
 	c.Assert(err3, Equals, nil)
 
 	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}
-	qaBarSecLblsCtx, _, err := cache.AllocateIdentity(qaBarLbls)
+	qaBarSecLblsCtx, _, err := cache.AllocateIdentity(context.Background(), qaBarLbls)
 	c.Assert(err, Equals, nil)
-	defer cache.Release(qaBarSecLblsCtx)
+	defer cache.Release(context.Background(), qaBarSecLblsCtx)
 
 	prodBarLbls := labels.Labels{lblBar.Key: lblBar, lblProd.Key: lblProd}
-	prodBarSecLblsCtx, _, err := cache.AllocateIdentity(prodBarLbls)
+	prodBarSecLblsCtx, _, err := cache.AllocateIdentity(context.Background(), prodBarLbls)
 	c.Assert(err, Equals, nil)
-	defer cache.Release(prodBarSecLblsCtx)
+	defer cache.Release(context.Background(), prodBarSecLblsCtx)
 
 	qaFooLbls := labels.Labels{lblFoo.Key: lblFoo, lblQA.Key: lblQA}
-	qaFooSecLblsCtx, _, err := cache.AllocateIdentity(qaFooLbls)
+	qaFooSecLblsCtx, _, err := cache.AllocateIdentity(context.Background(), qaFooLbls)
 	c.Assert(err, Equals, nil)
-	defer cache.Release(qaFooSecLblsCtx)
+	defer cache.Release(context.Background(), qaFooSecLblsCtx)
 
 	prodFooLbls := labels.Labels{lblFoo.Key: lblFoo, lblProd.Key: lblProd}
-	prodFooSecLblsCtx, _, err := cache.AllocateIdentity(prodFooLbls)
+	prodFooSecLblsCtx, _, err := cache.AllocateIdentity(context.Background(), prodFooLbls)
 	c.Assert(err, Equals, nil)
-	defer cache.Release(prodFooSecLblsCtx)
+	defer cache.Release(context.Background(), prodFooSecLblsCtx)
 
 	prodFooJoeLbls := labels.Labels{lblFoo.Key: lblFoo, lblProd.Key: lblProd, lblJoe.Key: lblJoe}
-	prodFooJoeSecLblsCtx, _, err := cache.AllocateIdentity(prodFooJoeLbls)
+	prodFooJoeSecLblsCtx, _, err := cache.AllocateIdentity(context.Background(), prodFooJoeLbls)
 	c.Assert(err, Equals, nil)
-	defer cache.Release(prodFooJoeSecLblsCtx)
+	defer cache.Release(context.Background(), prodFooJoeSecLblsCtx)
 
 	e := endpoint.NewEndpointWithState(1, endpoint.StateWaitingForIdentity)
 	e.IfName = "dummy1"
@@ -445,9 +446,9 @@ func (ds *DaemonSuite) TestRemovePolicy(c *C) {
 	c.Assert(err3, Equals, nil)
 
 	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}
-	qaBarSecLblsCtx, _, err := cache.AllocateIdentity(qaBarLbls)
+	qaBarSecLblsCtx, _, err := cache.AllocateIdentity(context.Background(), qaBarLbls)
 	c.Assert(err, Equals, nil)
-	defer cache.Release(qaBarSecLblsCtx)
+	defer cache.Release(context.Background(), qaBarSecLblsCtx)
 
 	// Create the endpoint and generate its policy.
 	e := endpoint.NewEndpointWithState(1, endpoint.StateWaitingForIdentity)

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -252,7 +253,7 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) (resto
 			l, _ := labels.FilterLabels(ep.OpLabels.IdentityLabels())
 			ep.RUnlock()
 
-			identity, _, err := cache.AllocateIdentity(l)
+			identity, _, err := cache.AllocateIdentity(context.Background(), l)
 			if err != nil {
 				scopedLog.WithError(err).Warn("Unable to restore endpoint")
 				epRegenerated <- false

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -264,7 +264,7 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) (resto
 			// endpoints that don't have a fixed identity or are
 			// not well known.
 			if !identity.IsFixed() && !identity.IsWellKnown() {
-				cache.WaitForInitialIdentities()
+				cache.WaitForInitialIdentities(context.Background())
 				ipcache.WaitForInitialSync()
 			}
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1282,7 +1282,7 @@ func (e *Endpoint) LeaveLocked(owner Owner, proxyWaitGroup *completion.WaitGroup
 	}
 
 	if e.SecurityIdentity != nil {
-		_, err := cache.Release(e.SecurityIdentity)
+		_, err := cache.Release(context.Background(), e.SecurityIdentity)
 		if err != nil {
 			errors = append(errors, fmt.Errorf("unable to release identity: %s", err))
 		}
@@ -1892,15 +1892,23 @@ func (e *Endpoint) identityLabelsChanged(ctx context.Context, owner Owner, myCha
 	e.RUnlock()
 	elog.Debug("Resolving identity for labels")
 
-	identity, _, err := cache.AllocateIdentity(newLabels)
+	identity, _, err := cache.AllocateIdentity(ctx, newLabels)
 	if err != nil {
 		err = fmt.Errorf("unable to resolve identity: %s", err)
 		e.LogStatus(Other, Warning, fmt.Sprintf("%s (will retry)", err.Error()))
 		return err
 	}
 
+	// When releasing identities after allocation due to either failure of
+	// allocation or due a no longer used identity we want to operation to
+	// continue even if the parent has given up. Enforce a timeout of two
+	// minutes to avoid blocking forever but give plenty of time to release
+	// the identity.
+	releaseCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
 	releaseNewlyAllocatedIdentity := func() {
-		_, err := cache.Release(identity)
+		_, err := cache.Release(releaseCtx, identity)
 		if err != nil {
 			// non fatal error as keys will expire after lease expires but log it
 			elog.WithFields(logrus.Fields{logfields.Identity: identity.ID}).
@@ -1960,7 +1968,7 @@ func (e *Endpoint) identityLabelsChanged(ctx context.Context, owner Owner, myCha
 	e.SetIdentity(identity)
 
 	if oldIdentity != nil {
-		_, err := cache.Release(oldIdentity)
+		_, err := cache.Release(releaseCtx, oldIdentity)
 		if err != nil {
 			elog.WithFields(logrus.Fields{logfields.Identity: oldIdentity.ID}).
 				WithError(err).Warn("Unable to release old endpoint identity")

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1755,7 +1755,7 @@ func (e *Endpoint) ModifyIdentityLabels(owner Owner, addLabels, delLabels pkgLab
 	e.Unlock()
 
 	if changed {
-		e.runLabelsResolver(owner, rev, false)
+		e.runLabelsResolver(context.Background(), owner, rev, false)
 	}
 	return nil
 }
@@ -1792,7 +1792,7 @@ func (e *Endpoint) UpdateLabels(ctx context.Context, owner Owner, identityLabels
 	rev := e.replaceIdentityLabels(identityLabels)
 	e.Unlock()
 	if rev != 0 {
-		e.runLabelsResolver(owner, rev, blocking)
+		e.runLabelsResolver(ctx, owner, rev, blocking)
 	}
 }
 
@@ -1813,7 +1813,7 @@ func (e *Endpoint) identityResolutionIsObsolete(myChangeRev int) bool {
 }
 
 // Must be called with e.Mutex NOT held.
-func (e *Endpoint) runLabelsResolver(owner Owner, myChangeRev int, blocking bool) {
+func (e *Endpoint) runLabelsResolver(ctx context.Context, owner Owner, myChangeRev int, blocking bool) {
 	if err := e.RLockAlive(); err != nil {
 		// If a labels update and an endpoint delete API request arrive
 		// in quick succession, this could occur; in that case, there's
@@ -1830,7 +1830,7 @@ func (e *Endpoint) runLabelsResolver(owner Owner, myChangeRev int, blocking bool
 	// of regenerations for the endpoint during its initialization.
 	if blocking || cache.IdentityAllocationIsLocal(newLabels) {
 		scopedLog.Debug("Endpoint has reserved identity, changing synchronously")
-		err := e.identityLabelsChanged(owner, myChangeRev)
+		err := e.identityLabelsChanged(ctx, owner, myChangeRev)
 		switch err {
 		case ErrNotAlive:
 			scopedLog.Debug("not changing endpoint identity because endpoint is in process of being removed")
@@ -1846,7 +1846,8 @@ func (e *Endpoint) runLabelsResolver(owner Owner, myChangeRev int, blocking bool
 	e.controllers.UpdateController(ctrlName,
 		controller.ControllerParams{
 			DoFunc: func() error {
-				err := e.identityLabelsChanged(owner, myChangeRev)
+				// FIXME GH-7320: Pass in context from controller once provided
+				err := e.identityLabelsChanged(context.Background(), owner, myChangeRev)
 				switch err {
 				case ErrNotAlive:
 					e.getLogger().Debug("not changing endpoint identity because endpoint is in process of being removed")
@@ -1860,7 +1861,7 @@ func (e *Endpoint) runLabelsResolver(owner Owner, myChangeRev int, blocking bool
 	)
 }
 
-func (e *Endpoint) identityLabelsChanged(owner Owner, myChangeRev int) error {
+func (e *Endpoint) identityLabelsChanged(ctx context.Context, owner Owner, myChangeRev int) error {
 	if err := e.RLockAlive(); err != nil {
 		return ErrNotAlive
 	}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1774,7 +1774,7 @@ func (e *Endpoint) IsInit() bool {
 // If a net label changed was performed, the endpoint will receive a new
 // identity and will be regenerated. Both of these operations will happen in
 // the background.
-func (e *Endpoint) UpdateLabels(owner Owner, identityLabels, infoLabels pkgLabels.Labels, blocking bool) {
+func (e *Endpoint) UpdateLabels(ctx context.Context, owner Owner, identityLabels, infoLabels pkgLabels.Labels, blocking bool) {
 	log.WithFields(logrus.Fields{
 		logfields.ContainerID:    e.GetShortContainerID(),
 		logfields.EndpointID:     e.StringID(),

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -199,7 +199,7 @@ func AllocateIdentity(ctx context.Context, lbls labels.Labels) (*identity.Identi
 		return nil, false, fmt.Errorf("allocator not initialized")
 	}
 
-	id, isNew, err := IdentityAllocator.Allocate(globalIdentity{lbls})
+	id, isNew, err := IdentityAllocator.Allocate(ctx, globalIdentity{lbls})
 	if err != nil {
 		return nil, false, err
 	}
@@ -235,7 +235,7 @@ func Release(ctx context.Context, id *identity.Identity) (bool, error) {
 		return false, fmt.Errorf("allocator not initialized")
 	}
 
-	return IdentityAllocator.Release(globalIdentity{id.Labels})
+	return IdentityAllocator.Release(ctx, globalIdentity{id.Labels})
 }
 
 // ReleaseSlice attempts to release a set of identities. It is a helper

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -152,8 +152,7 @@ func WaitForInitialIdentities(ctx context.Context) error {
 		return fmt.Errorf("initial identity sync was cancelled: %s", ctx.Err())
 	}
 
-	IdentityAllocator.WaitForInitialSync()
-	return nil
+	return IdentityAllocator.WaitForInitialSync(ctx)
 }
 
 // IdentityAllocationIsLocal returns true if a call to AllocateIdentity with

--- a/pkg/ipcache/cidr.go
+++ b/pkg/ipcache/cidr.go
@@ -15,6 +15,7 @@
 package ipcache
 
 import (
+	"context"
 	"fmt"
 	"net"
 
@@ -45,9 +46,9 @@ func AllocateCIDRs(impl Implementation, prefixes []*net.IPNet) error {
 			continue
 		}
 
-		id, isNew, err := cache.AllocateIdentity(cidr.GetCIDRLabels(prefix))
+		id, isNew, err := cache.AllocateIdentity(context.Background(), cidr.GetCIDRLabels(prefix))
 		if err != nil {
-			cache.ReleaseSlice(usedIdentities)
+			cache.ReleaseSlice(context.Background(), usedIdentities)
 			return fmt.Errorf("failed to allocate identity for cidr %s: %s", prefix.String(), err)
 		}
 
@@ -78,7 +79,7 @@ func ReleaseCIDRs(prefixes []*net.IPNet) {
 		}
 
 		if id := cache.LookupIdentity(cidr.GetCIDRLabels(prefix)); id != nil {
-			released, err := cache.Release(id)
+			released, err := cache.Release(context.Background(), id)
 			if err != nil {
 				log.WithError(err).Warningf("Unable to release identity for CIDR %s. Ignoring error. Identity may be leaked", prefix.String())
 			}

--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -530,7 +530,7 @@ func (a *Allocator) lockedAllocate(key AllocatorKey) (idpool.ID, bool, error) {
 //
 // Returns the ID allocated to the key, if the ID had to be allocated, then
 // true is returned. An error is returned in case of failure.
-func (a *Allocator) Allocate(key AllocatorKey) (idpool.ID, bool, error) {
+func (a *Allocator) Allocate(ctx context.Context, key AllocatorKey) (idpool.ID, bool, error) {
 	var (
 		err   error
 		value idpool.ID
@@ -616,7 +616,7 @@ func (a *Allocator) GetByID(id idpool.ID) (AllocatorKey, error) {
 // Release releases the use of an ID associated with the provided key. After
 // the last user has released the ID, the key is removed in the KVstore and
 // the returned lastUse value is true.
-func (a *Allocator) Release(key AllocatorKey) (lastUse bool, err error) {
+func (a *Allocator) Release(ctx context.Context, key AllocatorKey) (lastUse bool, err error) {
 	k := key.GetKey()
 	// release the key locally, if it was the last use, remove the node
 	// specific value key to remove the global reference mark

--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -15,6 +15,7 @@
 package allocator
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"path"
@@ -341,8 +342,14 @@ func (a *Allocator) Delete() {
 }
 
 // WaitForInitialSync waits until the initial sync is complete
-func (a *Allocator) WaitForInitialSync() {
-	<-a.initialListDone
+func (a *Allocator) WaitForInitialSync(ctx context.Context) error {
+	select {
+	case <-a.initialListDone:
+	case <-ctx.Done():
+		return fmt.Errorf("identity sync with kvstore was cancelled: %s", ctx.Err())
+	}
+
+	return nil
 }
 
 // lockPath locks a key in the scope of an allocator

--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -355,7 +355,7 @@ func (a *Allocator) WaitForInitialSync(ctx context.Context) error {
 // lockPath locks a key in the scope of an allocator
 func (a *Allocator) lockPath(ctx context.Context, key string) (*kvstore.Lock, error) {
 	suffix := strings.TrimPrefix(key, a.basePrefix)
-	return kvstore.LockPath(path.Join(a.lockPrefix, suffix))
+	return kvstore.LockPath(ctx, path.Join(a.lockPrefix, suffix))
 }
 
 // DeleteAllKeys will delete all keys

--- a/pkg/kvstore/backend.go
+++ b/pkg/kvstore/backend.go
@@ -15,6 +15,8 @@
 package kvstore
 
 import (
+	"context"
+
 	"google.golang.org/grpc"
 )
 
@@ -104,7 +106,7 @@ type BackendOperations interface {
 	Status() (string, error)
 
 	// LockPath locks the provided path
-	LockPath(path string) (kvLocker, error)
+	LockPath(ctx context.Context, path string) (kvLocker, error)
 
 	// Get returns value of key
 	Get(key string) ([]byte, error)

--- a/pkg/kvstore/base_test.go
+++ b/pkg/kvstore/base_test.go
@@ -17,6 +17,7 @@
 package kvstore
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -37,7 +38,7 @@ func (s *BaseTests) TestLock(c *C) {
 	defer DeletePrefix(prefix)
 
 	for i := 0; i < 10; i++ {
-		lock, err := LockPath(fmt.Sprintf("%sfoo/%d", prefix, i))
+		lock, err := LockPath(context.Background(), fmt.Sprintf("%sfoo/%d", prefix, i))
 		c.Assert(err, IsNil)
 		c.Assert(lock, Not(IsNil))
 		lock.Unlock()

--- a/pkg/kvstore/consul.go
+++ b/pkg/kvstore/consul.go
@@ -15,6 +15,7 @@
 package kvstore
 
 import (
+	"context"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -235,7 +236,7 @@ func newConsulClient(config *consulAPI.Config) (BackendOperations, error) {
 	return client, nil
 }
 
-func (c *consulClient) LockPath(path string) (kvLocker, error) {
+func (c *consulClient) LockPath(ctx context.Context, path string) (kvLocker, error) {
 	lockKey, err := c.LockOpts(&consulAPI.LockOptions{Key: getLockPath(path)})
 	if err != nil {
 		return nil, err
@@ -250,6 +251,12 @@ func (c *consulClient) LockPath(path string) (kvLocker, error) {
 			Trace("Acquiring lock timed out, retrying", nil, logrus.Fields{fieldKey: path, logfields.Attempt: retries})
 		default:
 			return lockKey, err
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("lock cancelled via context: %s", ctx.Err())
+		default:
 		}
 	}
 
@@ -451,7 +458,7 @@ func (c *consulClient) createIfExists(condKey, key string, value []byte, lease b
 	//
 	// Lock the conditional key to serialize all CreateIfExists() calls
 
-	l, err := LockPath(condKey)
+	l, err := LockPath(context.Background(), condKey)
 	if err != nil {
 		return fmt.Errorf("unable to lock condKey for CreateIfExists: %s", err)
 	}

--- a/pkg/kvstore/lock.go
+++ b/pkg/kvstore/lock.go
@@ -15,6 +15,7 @@
 package kvstore
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -101,10 +102,10 @@ type Lock struct {
 // returned also contains a patch specific local Mutex which will be held.
 //
 // It is required to call Unlock() on the returned Lock to unlock
-func LockPath(path string) (l *Lock, err error) {
+func LockPath(ctx context.Context, path string) (l *Lock, err error) {
 	kvstoreLocks.lock(path)
 
-	lock, err := Client().LockPath(path)
+	lock, err := Client().LockPath(ctx, path)
 	if err != nil {
 		kvstoreLocks.unlock(path)
 		Trace("Failed to lock", err, logrus.Fields{fieldKey: path})

--- a/pkg/service/id_kvstore.go
+++ b/pkg/service/id_kvstore.go
@@ -15,6 +15,7 @@
 package service
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"path"
@@ -38,7 +39,7 @@ func updateL3n4AddrIDRef(id loadbalancer.ServiceID, l3n4AddrID loadbalancer.L3n4
 func initializeFreeID(path string, firstID uint32) error {
 
 	client := kvstore.Client()
-	kvLocker, err := client.LockPath(path)
+	kvLocker, err := client.LockPath(context.Background(), path)
 	if err != nil {
 		return err
 	}
@@ -157,7 +158,7 @@ func gasNewL3n4AddrID(l3n4AddrID *loadbalancer.L3n4AddrID, baseID uint32) error 
 	acquireFreeID := func(firstID uint32, incID *uint32) (bool, error) {
 		keyPath := path.Join(ServiceIDKeyPath, strconv.FormatUint(uint64(*incID), 10))
 
-		locker, err := client.LockPath(keyPath)
+		locker, err := client.LockPath(context.Background(), keyPath)
 		if err != nil {
 			return false, err
 		}
@@ -210,7 +211,7 @@ func acquireGlobalID(l3n4Addr loadbalancer.L3n4Addr, baseID uint32) (*loadbalanc
 	svcPath := path.Join(common.ServicesKeyPath, sha256Sum)
 
 	// Lock that sha256Sum
-	lockKey, err := kvstore.LockPath(svcPath)
+	lockKey, err := kvstore.LockPath(context.Background(), svcPath)
 	if err != nil {
 		return nil, err
 	}
@@ -293,7 +294,7 @@ func deleteL3n4AddrIDBySHA256(sha256Sum string) error {
 	}
 	svcPath := path.Join(common.ServicesKeyPath, sha256Sum)
 	// Lock that sha256Sum
-	lockKey, err := kvstore.LockPath(svcPath)
+	lockKey, err := kvstore.LockPath(context.Background(), svcPath)
 	if err != nil {
 		return err
 	}

--- a/pkg/workloads/defaults.go
+++ b/pkg/workloads/defaults.go
@@ -15,6 +15,7 @@
 package workloads
 
 import (
+	"context"
 	"time"
 
 	"github.com/cilium/cilium/pkg/endpoint"
@@ -72,5 +73,5 @@ func processCreateWorkload(ep *endpoint.Endpoint, containerID string, allLabels 
 	endpointmanager.UpdateReferences(ep)
 
 	identityLabels, informationLabels := getFilteredLabels(containerID, allLabels)
-	ep.UpdateLabels(Owner(), identityLabels, informationLabels, false)
+	ep.UpdateLabels(context.Background(), Owner(), identityLabels, informationLabels, false)
 }


### PR DESCRIPTION
In #7128 it was observed that:
 * kvstore operations can continue to block even when etcd connectivity is given. This is due to lack of quorum
 * The identity allocation will thus be attempted aggressively. The operation will retry many times. Each of the attempts can then block on the local or distributed lock for a long time.
 * In the meantime, the endpoint creation will time out due to the API caller giving up.
 * The identity allocation is not aborted in this case so all remaining attempts will be executed which will continue to add contention to the lock. In particular if the local lock has been acquired already.

Resolution:
Abort identity allocation based on context provided from API caller.

This is likely a fix for #7128 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7322)
<!-- Reviewable:end -->
