### PR TITLE
v1.3 backports 2019-03-06

### DIFF
--- a/contrib/backporting/README.md
+++ b/contrib/backporting/README.md
@@ -1,12 +1,12 @@
 Cilium Backporting Scripts
 ==========================
 
-# check-stable - List commits that need stable backporting
+# check-stable - List commits that need backporting
 
-`GITHUB_TOKEN=xxx check-stable`
+`GITHUB_TOKEN=xxx check-stable X.Y`
 
 The `check-stable` script is derived from `relnotes` and scans for PRs which
-have been merged and marked with the label `stable/needs-backport`. The
+have been merged and marked with the label `needs-backport/X.Y`. The
 script will list those PRs and all non-merge commit ids that were part of the
 merge. There are three columns: first one is the correlated sha of the commit
 from the master branch, second one is the sha of the commit from the pull
@@ -25,7 +25,7 @@ branch is then needed for backporting into downstream with the help of the
 
 2. Run the script to generate the list of current backporting TODOs:
 
-   `GITHUB_TOKEN=xxx `./check-stable`
+   `GITHUB_TOKEN=xxx `./check-stable 1.0`
 
    The list will be dumped to stdout.
 

--- a/contrib/backporting/cherry-pick
+++ b/contrib/backporting/cherry-pick
@@ -15,7 +15,7 @@ cherry_pick () {
   git format-patch -1 $FULL_ID --stdout | sed '/^$/Q' > $TMPF
   echo "" >> $TMPF
   echo "[ upstream commit $FULL_ID ]" >> $TMPF
-  git format-patch -1 $FULL_ID --stdout | sed -n '/^$/,/$a/p' >> $TMPF
+  git format-patch -1 $FULL_ID --stdout | sed -n '/^$/,$p' >> $TMPF
   echo "Applying: $(git log -1 --oneline $FULL_ID)"
   git am --quiet -3 --signoff $TMPF
   rm $TMPF


### PR DESCRIPTION
v1.3 backports 2019-03-06

## Not Included

 * #7246 -- Protect remaining local keys from kvstore delete events (@tgraf)
 * #7249 -- daemon: Remove old health EP state dirs in restore (@joestringer)

## Included 

 * #7286 -- contrib: Fix cherry-pick to avoid omitting parts of patch (@brb)
 * #7288 -- contrib: Update backporting README (@brb)

Once this PR is merged, you can update the PR labels via:
```
$ for pr in 7286 7288; do contrib/backporting/set-labels.py $pr done 1.3; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7323)
<!-- Reviewable:end -->
