### PR TITLE
cilium: bugtool add xfrm details

### DIFF
--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -73,6 +73,11 @@ func defaultCommands(confDir string, cmdDir string, k8sPods []string) []string {
 		"ip rule",
 		"ip -4 route show table 2005",
 		"ip -6 route show table 2005",
+		"ip -4 route show table 200",
+		"ip -6 route show table 200",
+		// xfrm
+		"ip xfrm policy",
+		"ip -s xfrm state",
 		// gops
 		fmt.Sprintf("gops memstats $(pidof %s)", components.CiliumAgentName),
 		fmt.Sprintf("gops stack $(pidof %s)", components.CiliumAgentName),
@@ -125,6 +130,7 @@ func loadConfigFile(path string) (*BugtoolConfiguration, error) {
 
 func catCommands() []string {
 	files := []string{
+		"/proc/net/xfrm_stat",
 		"/proc/sys/net/core/bpf_jit_enable",
 		"/proc/kallsyms",
 		"/etc/resolv.conf",


### PR DESCRIPTION
Add xfrm output to bugtool so we can debug transparent encryption (--enable-ipsec)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7324)
<!-- Reviewable:end -->
