### PR TITLE
endpointmanager: fix IPv6 lookup

### DIFF
--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -144,7 +144,7 @@ func Lookup(id string) (*endpoint.Endpoint, error) {
 		return lookupIPv4(eid), nil
 
 	case endpointid.IPv6Prefix:
-		return lookupIPv4(eid), nil
+		return lookupIPv6(eid), nil
 
 	default:
 		return nil, ErrInvalidPrefix{InvalidPrefix: prefix.String()}


### PR DESCRIPTION
Fix IPv6 lookups in the endpointmanager.

Fixes: 022f196da22
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7328)
<!-- Reviewable:end -->
