### PR TITLE
Makefile: Fix duplicates in cscope output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ SUBDIRS = $(SUBDIRS_CILIUM_CONTAINER) operator plugins tools
 GOFILES ?= $(subst _$(ROOT_DIR)/,,$(shell $(GO) list ./... | grep -v -e /vendor/ -e /contrib/))
 TESTPKGS ?= $(subst github.com/cilium/cilium/,,$(shell $(GO) list ./... | grep -v -e /api/v1 -e /vendor/ -e /contrib/ -e test))
 GOLANGVERSION = $(shell $(GO) version 2>/dev/null | grep -Eo '(go[0-9].[0-9])')
-GOLANG_SRCFILES=$(shell for pkg in $(subst github.com/cilium/cilium/,,$(GOFILES)); do find $$pkg -name *.go -print; done | grep -v vendor)
+GOLANG_SRCFILES=$(shell for pkg in $(subst github.com/cilium/cilium/,,$(GOFILES)); do find $$pkg -name *.go -print; done | grep -v vendor | sort | uniq)
 BPF_FILES ?= $(shell git ls-files ../bpf/ | grep -v .gitignore | tr "\n" ' ')
 BPF_SRCFILES=$(subst ../,,$(BPF_FILES))
 
@@ -135,7 +135,7 @@ clean-tags:
 	@$(ECHO_CLEAN) tags
 	@-rm -f cscope.out cscope.in.out cscope.po.out cscope.files tags
 
-tags: $(GOLANG_SRCFILES) $(BPF_SRCFILES)
+tags: $(GOLANG_SRCFILES) $(BPF_SRCFILES) cscope.files
 	ctags $(GOLANG_SRCFILES) $(BPF_SRCFILES)
 	@ echo $(GOLANG_SRCFILES) $(BPF_SRCFILES) | sed 's/ /\n/g' | sort > cscope.files
 	cscope -R -b -q


### PR DESCRIPTION
For some reason, some files would show up multiple times in the
GOLANG_SRCFILES variable, which would cause cscope to create duplicate
references to symbols across the codebase. Pass the list through sort
and uniq to ensure each file is only scanned once.

Fixes a bug I found in regular usage of cscope for indexing golang files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7329)
<!-- Reviewable:end -->
