### PR TITLE
Support cancellation of various kvstore operations via context

### DIFF
--- a/pkg/identity/cache/cache.go
+++ b/pkg/identity/cache/cache.go
@@ -15,6 +15,7 @@
 package cache
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -147,7 +148,7 @@ func LookupIdentity(lbls labels.Labels) *identity.Identity {
 		return nil
 	}
 
-	id, err := IdentityAllocator.Get(globalIdentity{lbls})
+	id, err := IdentityAllocator.Get(context.TODO(), globalIdentity{lbls})
 	if err != nil {
 		return nil
 	}

--- a/pkg/ipcache/kvstore.go
+++ b/pkg/ipcache/kvstore.go
@@ -15,6 +15,7 @@
 package ipcache
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -70,7 +71,7 @@ type kvstoreImplementation struct{}
 // upsert places the mapping of {key, value} into the kvstore, optionally with
 // a lease.
 func (k kvstoreImplementation) upsert(key string, value []byte, lease bool) error {
-	return kvstore.Update(key, value, lease)
+	return kvstore.Update(context.TODO(), key, value, lease)
 }
 
 // release removes the specified key from the kvstore.

--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -501,7 +501,7 @@ func (a *Allocator) lockedAllocate(ctx context.Context, key AllocatorKey) (idpoo
 
 	// create /id/<ID> and fail if it already exists
 	keyPath := path.Join(a.idPrefix, strID)
-	err = kvstore.CreateOnly(keyPath, []byte(k), false)
+	err = kvstore.CreateOnly(ctx, keyPath, []byte(k), false)
 	if err != nil {
 		// Creation failed. Another agent most likely beat us to allocting this
 		// ID, retry.
@@ -701,7 +701,7 @@ func (a *Allocator) recreateMasterKey(id idpool.ID, value string, reliablyMissin
 
 	// Use of CreateOnly() ensures that any existing potentially
 	// conflicting key is never overwritten.
-	err := kvstore.CreateOnly(keyPath, []byte(value), false)
+	err := kvstore.CreateOnly(context.TODO(), keyPath, []byte(value), false)
 	if reliablyMissing || err == nil {
 		log.WithError(err).WithField(fieldKey, keyPath).Warning("Re-created potentially missing master key")
 	}
@@ -710,7 +710,7 @@ func (a *Allocator) recreateMasterKey(id idpool.ID, value string, reliablyMissin
 	// ensure that the next garbage collection cycle of any participating
 	// node does not remove the master key again.
 	valueKey := path.Join(a.valuePrefix, value, a.suffix)
-	err = kvstore.CreateOnly(valueKey, []byte(id.String()), true)
+	err = kvstore.CreateOnly(context.TODO(), valueKey, []byte(id.String()), true)
 	if reliablyMissing || err == nil {
 		log.WithError(err).WithField(fieldKey, valueKey).Warning("Re-created potentially missing slave key")
 	}

--- a/pkg/kvstore/backend.go
+++ b/pkg/kvstore/backend.go
@@ -112,7 +112,7 @@ type BackendOperations interface {
 	Get(key string) ([]byte, error)
 
 	// GetPrefix returns the first key which matches the prefix
-	GetPrefix(prefix string) ([]byte, error)
+	GetPrefix(ctx context.Context, prefix string) ([]byte, error)
 
 	// Set sets value of key
 	Set(key string, value []byte) error

--- a/pkg/kvstore/backend.go
+++ b/pkg/kvstore/backend.go
@@ -126,7 +126,7 @@ type BackendOperations interface {
 	Update(key string, value []byte, lease bool) error
 
 	// CreateOnly atomically creates a key or fails if it already exists
-	CreateOnly(key string, value []byte, lease bool) error
+	CreateOnly(ctx context.Context, key string, value []byte, lease bool) error
 
 	// CreateIfExists creates a key with the value only if key condKey exists
 	CreateIfExists(condKey, key string, value []byte, lease bool) error

--- a/pkg/kvstore/backend.go
+++ b/pkg/kvstore/backend.go
@@ -123,7 +123,7 @@ type BackendOperations interface {
 	DeletePrefix(path string) error
 
 	// Update atomically creates a key or fails if it already exists
-	Update(key string, value []byte, lease bool) error
+	Update(ctx context.Context, key string, value []byte, lease bool) error
 
 	// CreateOnly atomically creates a key or fails if it already exists
 	CreateOnly(ctx context.Context, key string, value []byte, lease bool) error

--- a/pkg/kvstore/base_test.go
+++ b/pkg/kvstore/base_test.go
@@ -162,13 +162,13 @@ func (s *BaseTests) TestCreateOnly(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(val, IsNil)
 
-	c.Assert(CreateOnly(testKey(prefix, 0), testValue(0), false), IsNil)
+	c.Assert(CreateOnly(context.Background(), testKey(prefix, 0), testValue(0), false), IsNil)
 
 	val, err = Get(testKey(prefix, 0))
 	c.Assert(err, IsNil)
 	c.Assert(val, checker.DeepEquals, testValue(0))
 
-	c.Assert(CreateOnly(testKey(prefix, 0), testValue(1), false), Not(IsNil))
+	c.Assert(CreateOnly(context.Background(), testKey(prefix, 0), testValue(1), false), Not(IsNil))
 
 	val, err = Get(testKey(prefix, 0))
 	c.Assert(err, IsNil)
@@ -220,7 +220,7 @@ func (s *BaseTests) TestListAndWatch(c *C) {
 	DeletePrefix("foo2/")
 	defer DeletePrefix("foo2/")
 
-	err := CreateOnly(key1, val1, false)
+	err := CreateOnly(context.Background(), key1, val1, false)
 	c.Assert(err, IsNil)
 
 	w := ListAndWatch("testWatcher2", "foo2/", 100)
@@ -229,7 +229,7 @@ func (s *BaseTests) TestListAndWatch(c *C) {
 	expectEvent(c, w, EventTypeCreate, key1, val1)
 	expectEvent(c, w, EventTypeListDone, "", []byte{})
 
-	err = CreateOnly(key2, val2, false)
+	err = CreateOnly(context.Background(), key2, val2, false)
 	c.Assert(err, IsNil)
 	expectEvent(c, w, EventTypeCreate, key2, val2)
 
@@ -237,7 +237,7 @@ func (s *BaseTests) TestListAndWatch(c *C) {
 	c.Assert(err, IsNil)
 	expectEvent(c, w, EventTypeDelete, key1, val1)
 
-	err = CreateOnly(key1, val1, false)
+	err = CreateOnly(context.Background(), key1, val1, false)
 	c.Assert(err, IsNil)
 	expectEvent(c, w, EventTypeCreate, key1, val1)
 

--- a/pkg/kvstore/base_test.go
+++ b/pkg/kvstore/base_test.go
@@ -138,14 +138,14 @@ func (s *BaseTests) TestUpdate(c *C) {
 	c.Assert(val, IsNil)
 
 	// create
-	c.Assert(Update(testKey(prefix, 0), testValue(0), true), IsNil)
+	c.Assert(Update(context.Background(), testKey(prefix, 0), testValue(0), true), IsNil)
 
 	val, err = Get(testKey(prefix, 0))
 	c.Assert(err, IsNil)
 	c.Assert(val, checker.DeepEquals, testValue(0))
 
 	// update
-	c.Assert(Update(testKey(prefix, 0), testValue(0), true), IsNil)
+	c.Assert(Update(context.Background(), testKey(prefix, 0), testValue(0), true), IsNil)
 
 	val, err = Get(testKey(prefix, 0))
 	c.Assert(err, IsNil)

--- a/pkg/kvstore/base_test.go
+++ b/pkg/kvstore/base_test.go
@@ -60,7 +60,7 @@ func (s *BaseTests) TestGetSet(c *C) {
 	DeletePrefix(prefix)
 	defer DeletePrefix(prefix)
 
-	val, err := GetPrefix(prefix)
+	val, err := GetPrefix(context.Background(), prefix)
 	c.Assert(err, IsNil)
 	c.Assert(val, IsNil)
 
@@ -69,7 +69,7 @@ func (s *BaseTests) TestGetSet(c *C) {
 		c.Assert(err, IsNil)
 		c.Assert(val, IsNil)
 
-		val, err = GetPrefix(testKey(prefix, i))
+		val, err = GetPrefix(context.Background(), testKey(prefix, i))
 		c.Assert(err, IsNil)
 		c.Assert(val, IsNil)
 
@@ -91,12 +91,12 @@ func (s *BaseTests) TestGetSet(c *C) {
 		c.Assert(err, IsNil)
 		c.Assert(val, IsNil)
 
-		val, err = GetPrefix(testKey(prefix, i))
+		val, err = GetPrefix(context.Background(), testKey(prefix, i))
 		c.Assert(err, IsNil)
 		c.Assert(val, IsNil)
 	}
 
-	val, err = GetPrefix(prefix)
+	val, err = GetPrefix(context.Background(), prefix)
 	c.Assert(err, IsNil)
 	c.Assert(val, IsNil)
 }
@@ -133,7 +133,7 @@ func (s *BaseTests) TestUpdate(c *C) {
 	DeletePrefix(prefix)
 	defer DeletePrefix(prefix)
 
-	val, err := GetPrefix(prefix)
+	val, err := GetPrefix(context.Background(), prefix)
 	c.Assert(err, IsNil)
 	c.Assert(val, IsNil)
 
@@ -158,7 +158,7 @@ func (s *BaseTests) TestCreateOnly(c *C) {
 	DeletePrefix(prefix)
 	defer DeletePrefix(prefix)
 
-	val, err := GetPrefix(prefix)
+	val, err := GetPrefix(context.Background(), prefix)
 	c.Assert(err, IsNil)
 	c.Assert(val, IsNil)
 

--- a/pkg/kvstore/consul.go
+++ b/pkg/kvstore/consul.go
@@ -396,9 +396,10 @@ func (c *consulClient) Get(key string) ([]byte, error) {
 }
 
 // GetPrefix returns the first key which matches the prefix
-func (c *consulClient) GetPrefix(prefix string) ([]byte, error) {
+func (c *consulClient) GetPrefix(ctx context.Context, prefix string) ([]byte, error) {
 	duration := spanstat.Start()
-	pairs, _, err := c.KV().List(prefix, nil)
+	opts := &consulAPI.QueryOptions{}
+	pairs, _, err := c.KV().List(prefix, opts.WithContext(ctx))
 	increaseMetric(prefix, metricRead, "GetPrefix", duration.EndError(err).Total(), err)
 	if err != nil {
 		return nil, err

--- a/pkg/kvstore/consul.go
+++ b/pkg/kvstore/consul.go
@@ -413,15 +413,17 @@ func (c *consulClient) GetPrefix(ctx context.Context, prefix string) ([]byte, er
 }
 
 // Update creates or updates a key with the value
-func (c *consulClient) Update(key string, value []byte, lease bool) error {
+func (c *consulClient) Update(ctx context.Context, key string, value []byte, lease bool) error {
 	k := &consulAPI.KVPair{Key: key, Value: value}
 
 	if lease {
 		k.Session = c.lease
 	}
 
+	opts := &consulAPI.WriteOptions{}
+
 	duration := spanstat.Start()
-	_, err := c.KV().Put(k, nil)
+	_, err := c.KV().Put(k, opts.WithContext(ctx))
 	increaseMetric(key, metricSet, "Update", duration.EndError(err).Total(), err)
 	return err
 }

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -642,9 +642,9 @@ func (e *etcdClient) Get(key string) ([]byte, error) {
 }
 
 // GetPrefix returns the first key which matches the prefix
-func (e *etcdClient) GetPrefix(prefix string) ([]byte, error) {
+func (e *etcdClient) GetPrefix(ctx context.Context, prefix string) ([]byte, error) {
 	duration := spanstat.Start()
-	getR, err := e.client.Get(ctx.Background(), prefix, client.WithPrefix())
+	getR, err := e.client.Get(ctx, prefix, client.WithPrefix())
 	increaseMetric(prefix, metricRead, "GetPrefix", duration.EndError(err).Total(), err)
 	if err != nil {
 		return nil, Hint(err)

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -699,11 +699,11 @@ func (e *etcdClient) Update(key string, value []byte, lease bool) error {
 }
 
 // CreateOnly creates a key with the value and will fail if the key already exists
-func (e *etcdClient) CreateOnly(key string, value []byte, lease bool) error {
+func (e *etcdClient) CreateOnly(ctx context.Context, key string, value []byte, lease bool) error {
 	duration := spanstat.Start()
 	req := e.createOpPut(key, value, lease)
 	cond := client.Compare(client.Version(key), "=", 0)
-	txnresp, err := e.client.Txn(ctx.TODO()).If(cond).Then(*req).Commit()
+	txnresp, err := e.client.Txn(ctx).If(cond).Then(*req).Commit()
 	increaseMetric(key, metricSet, "CreateOnly", duration.EndError(err).Total(), err)
 	if err != nil {
 		return Hint(err)

--- a/pkg/kvstore/kvstore.go
+++ b/pkg/kvstore/kvstore.go
@@ -45,8 +45,8 @@ func Get(key string) ([]byte, error) {
 }
 
 // GetPrefix returns the first key which matches the prefix
-func GetPrefix(prefix string) ([]byte, error) {
-	v, err := Client().GetPrefix(prefix)
+func GetPrefix(ctx context.Context, prefix string) ([]byte, error) {
+	v, err := Client().GetPrefix(ctx, prefix)
 	Trace("GetPrefix", err, logrus.Fields{fieldPrefix: prefix, fieldValue: string(v)})
 	return v, err
 }

--- a/pkg/kvstore/kvstore.go
+++ b/pkg/kvstore/kvstore.go
@@ -15,6 +15,8 @@
 package kvstore
 
 import (
+	"context"
+
 	"github.com/sirupsen/logrus"
 )
 
@@ -57,8 +59,8 @@ func ListPrefix(prefix string) (KeyValuePairs, error) {
 }
 
 // CreateOnly atomically creates a key or fails if it already exists
-func CreateOnly(key string, value []byte, lease bool) error {
-	err := Client().CreateOnly(key, value, lease)
+func CreateOnly(ctx context.Context, key string, value []byte, lease bool) error {
+	err := Client().CreateOnly(ctx, key, value, lease)
 	Trace("CreateOnly", err, logrus.Fields{fieldKey: key, fieldValue: string(value), fieldAttachLease: lease})
 	return err
 }

--- a/pkg/kvstore/kvstore.go
+++ b/pkg/kvstore/kvstore.go
@@ -66,8 +66,8 @@ func CreateOnly(ctx context.Context, key string, value []byte, lease bool) error
 }
 
 // Update creates or updates a key value pair
-func Update(key string, value []byte, lease bool) error {
-	err := Client().Update(key, value, lease)
+func Update(ctx context.Context, key string, value []byte, lease bool) error {
+	err := Client().Update(ctx, key, value, lease)
 	Trace("Update", err, logrus.Fields{fieldKey: key, fieldValue: string(value), fieldAttachLease: lease})
 	return err
 }

--- a/pkg/kvstore/store/store.go
+++ b/pkg/kvstore/store/store.go
@@ -15,6 +15,7 @@
 package store
 
 import (
+	"context"
 	"fmt"
 	"path"
 	"strings"
@@ -263,7 +264,7 @@ func (s *SharedStore) syncLocalKey(key LocalKey) error {
 
 	// Update key in kvstore, overwrite an eventual existing key, attach
 	// lease to expire entry when agent dies and never comes back up.
-	if err := s.backend.Update(s.keyPath(key), jsonValue, true); err != nil {
+	if err := s.backend.Update(context.TODO(), s.keyPath(key), jsonValue, true); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Support context based cancellation for the majority of kvstore operations, namely:
 * CreateOnly()
 * GetPrefix()
 * Update()

The main beneficiary is the kvstore based identity allocator. Most other kvstore operations are controller based and blocking is fine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7334)
<!-- Reviewable:end -->
