### PR TITLE
test,docs: Vagrant misc updates for net-next.

### DIFF
--- a/Documentation/contributing.rst
+++ b/Documentation/contributing.rst
@@ -661,6 +661,30 @@ supported version of Kubernetes, run the test suite with the following format:
 
     K8S_VERSION=<version> ginkgo --focus="K8s*" -noColor
 
+.. note::
+
+   When provisioning VMs with the net-next kernel (``NETNEXT=true``) on
+   VirtualBox which version does not match a version of the VM image
+   VirtualBox Guest Additions, Vagrant will install a new version of
+   the Additions with ``mount.vboxsf``. The latter is not compatible with
+   ``vboxsf.ko`` shipped within the VM image, and thus syncing of shared
+   folders will not work.
+
+   To avoid this, one can prevent Vagrant from installing the Additions by
+   putting the following into ``$HOME/.vagrant.d/Vagrantfile``:
+
+   .. code:: ruby
+
+      Vagrant.configure('2') do |config|
+	if Vagrant.has_plugin?("vagrant-vbguest") then
+	  config.vbguest.auto_update = false
+	end
+
+	config.vm.provider :virtualbox do |vbox|
+	  vbox.check_guest_additions = false
+	end
+      end
+
 Running Nightly Tests
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -584,6 +584,8 @@ vader
 Vagrantcloud
 Vagrantfile
 validator
+vbguest
+vbox
 vCPUs
 ve
 Verifier
@@ -597,6 +599,7 @@ virtio
 virtualbox
 vlan
 VM
+vm
 vmlinux
 vX
 vxlan

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -22,7 +22,6 @@ $CPU = (ENV['CPUS'] || "2").to_i
 if ENV['NETNEXT'] == "true"
     $SERVER_BOX = $NETNEXT_SERVER_BOX
     $SERVER_VERSION = $NETNEXT_SERVER_VERSION
-    puts "Vagrant to use net-next version"
 end
 
 ENV["VAGRANT_DEFAULT_PROVIDER"] = "virtualbox"


### PR DESCRIPTION
This PR:

- Prevents Vagrant from printing to stdout about running on net-next.
- Adds a note about running `ubuntu-next` on vbox which vsn != 5.2.0.

After merging this PR, we can close #7255 without merging it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7338)
<!-- Reviewable:end -->
