### PR TITLE
endpoint: Fix cached IntOptions copy

### DIFF
--- a/pkg/endpoint/cache.go
+++ b/pkg/endpoint/cache.go
@@ -53,7 +53,7 @@ type epInfoCache struct {
 	ipv6                                   addressing.CiliumIPv6
 	conntrackLocal                         bool
 	cidr4PrefixLengths, cidr6PrefixLengths []int
-	options                                option.IntOptions
+	options                                *option.IntOptions
 
 	// endpoint is used to get the endpoint's logger.
 	//
@@ -84,7 +84,7 @@ func (e *Endpoint) createEpInfoCache(epdir string) *epInfoCache {
 		conntrackLocal:     e.ConntrackLocalLocked(),
 		cidr4PrefixLengths: cidr4,
 		cidr6PrefixLengths: cidr6,
-		options:            *e.Options,
+		options:            e.Options.DeepCopy(),
 
 		endpoint: e,
 	}
@@ -170,5 +170,5 @@ func (ep *epInfoCache) GetCIDRPrefixLengths() ([]int, []int) {
 }
 
 func (ep *epInfoCache) GetOptions() *option.IntOptions {
-	return &ep.options
+	return ep.options
 }


### PR DESCRIPTION
Previously this was just taking a direct-dereference copy of the
endpoint options, complete with lock in its current state. Instead, make
a deepcopy. Fixes the following govet complaint:

```
  pkg/endpoint/cache.go:87:23: literal copies lock value from
  *e.Options: github.com/cilium/cilium/pkg/option.IntOptions contains
  github.com/cilium/cilium/pkg/lock.RWMutex
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7339)
<!-- Reviewable:end -->
