### PR TITLE
Minor followup fixes to BPF templating

### DIFF
--- a/pkg/datapath/loader/cache.go
+++ b/pkg/datapath/loader/cache.go
@@ -80,7 +80,7 @@ func RestoreTemplates(stateDir string) error {
 	// In future we should make this smarter.
 	path := filepath.Join(stateDir, defaults.TemplatesDir)
 	err := os.RemoveAll(path)
-	if os.IsNotExist(err) {
+	if err == nil || os.IsNotExist(err) {
 		return nil
 	}
 	return &os.PathError{


### PR DESCRIPTION
Fix up a couple of issues with the final merge of the BPF templating work:
* Error always printed on startup `level=error msg="Unable to restore previous BPF templates" error="%!v(PANIC=runtime error: invalid memory address or nil pointer dereference)" subsys=daemon`
* Occasional test failure of the `pkg/datapath/loader/cache_test.go` privileged unit tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7347)
<!-- Reviewable:end -->
