### PR TITLE
k8s: add hidden option to use JSONPatch to update CNP and CEP status

### DIFF
--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -511,6 +511,10 @@ func init() {
 	flags.Bool(option.K8sRequireIPv6PodCIDRName, false, "Require IPv6 PodCIDR to be specified in node resource")
 	option.BindEnv(option.K8sRequireIPv6PodCIDRName)
 
+	flags.Bool(option.K8sForceJSONPatch, false, "When set uses JSON Patch to update CNP and CEP status in kube-apiserver")
+	option.BindEnv(option.K8sForceJSONPatch)
+	flags.MarkHidden(option.K8sForceJSONPatch)
+
 	flags.Bool(option.KeepConfig, false, "When restoring state, keeps containers' configuration in place")
 	option.BindEnv(option.KeepConfig)
 

--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -637,7 +637,7 @@ func (d *Daemon) EnableK8sWatcher(queueSize uint) error {
 		ciliumV2Controller := si.Cilium().V2().CiliumNetworkPolicies().Informer()
 		var cnpStore cache.Store
 		switch {
-		case ciliumPatchStatusVerConstr.Check(k8sServerVer):
+		case ciliumPatchStatusVerConstr.Check(k8sServerVer) || option.Config.K8sForceJSONPatch:
 			// k8s >= 1.13 does not require a store
 		default:
 			cnpStore = ciliumV2Controller.GetStore()

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -151,6 +151,10 @@ const (
 	// K8sRequireIPv6PodCIDRName is the name of the K8sRequireIPv6PodCIDR option
 	K8sRequireIPv6PodCIDRName = "k8s-require-ipv6-pod-cidr"
 
+	// K8sForceJSONPatch when set, uses JSON Patch to update CNP and CEP
+	// status in kube-apiserver.
+	K8sForceJSONPatch = "k8s-force-json-patch"
+
 	// K8sAPIServer is the kubernetes api address server (for https use --k8s-kubeconfig-path instead)
 	K8sAPIServer = "k8s-api-server"
 
@@ -591,6 +595,10 @@ type DaemonConfig struct {
 	// IPv6 PodCIDR. Cilium will block bootstrapping until the information
 	// is available.
 	K8sRequireIPv6PodCIDR bool
+
+	// K8sForceJSONPatch when set, uses JSON Patch to update CNP and CEP
+	// status in kube-apiserver.
+	K8sForceJSONPatch bool
 
 	// K8sWatcherQueueSize is the queue size used to serialize each k8s event
 	// type.
@@ -1059,6 +1067,7 @@ func (c *DaemonConfig) Populate() {
 	c.K8sKubeConfigPath = viper.GetString(K8sKubeConfigPath)
 	c.K8sRequireIPv4PodCIDR = viper.GetBool(K8sRequireIPv4PodCIDRName)
 	c.K8sRequireIPv6PodCIDR = viper.GetBool(K8sRequireIPv6PodCIDRName)
+	c.K8sForceJSONPatch = viper.GetBool(K8sForceJSONPatch)
 	c.K8sWatcherQueueSize = uint(viper.GetInt(K8sWatcherQueueSize))
 	c.KeepTemplates = viper.GetBool(KeepBPFTemplates)
 	c.KeepConfig = viper.GetBool(KeepConfig)


### PR DESCRIPTION
As this option can be used in certain k8s version we should make
optional as JSON Patch might work for some k8s versions. By default,
this flag will have no effect for k8s versions >= 1.13.

Signed-off-by: André Martins <andre@cilium.dev>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7351)
<!-- Reviewable:end -->
