### PR TITLE
[v1.4] flannel: forcefully disabling IPv6 mode on flannel

### DIFF
--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -930,9 +930,15 @@ func initEnv(cmd *cobra.Command) {
 		if option.Config.Tunnel == "" {
 			option.Config.Tunnel = option.TunnelVXLAN
 		}
-		if option.Config.IsFlannelMasterDeviceSet() && option.Config.Tunnel != option.TunnelDisabled {
-			log.Warnf("Running Cilium in flannel mode requires tunnel mode be '%s'. Changing tunnel mode to: %s", option.TunnelDisabled, option.TunnelDisabled)
-			option.Config.Tunnel = option.TunnelDisabled
+		if option.Config.IsFlannelMasterDeviceSet() {
+			if option.Config.Tunnel != option.TunnelDisabled {
+				log.Warnf("Running Cilium in flannel mode requires tunnel mode be '%s'. Changing tunnel mode to: %s", option.TunnelDisabled, option.TunnelDisabled)
+				option.Config.Tunnel = option.TunnelDisabled
+			}
+			if option.Config.EnableIPv6 {
+				log.Warn("Running Cilium in flannel mode requires IPv6 mode be 'false'. Disabling IPv6 mode")
+				option.Config.EnableIPv6 = false
+			}
 		}
 	case option.DatapathModeIpvlan:
 		if option.Config.Tunnel != "" && option.Config.Tunnel != option.TunnelDisabled {


### PR DESCRIPTION
[ upstream commit 05b4d2b32f1440abdc0e279265db7543ce501147 ]

Signed-off-by: André Martins <andre@cilium.dev>

Backport of https://github.com/cilium/cilium/pull/7331

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7354)
<!-- Reviewable:end -->
