### PR TITLE
cilium: scrub keys from bugtool xfrm

### DIFF
--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -77,7 +77,7 @@ func defaultCommands(confDir string, cmdDir string, k8sPods []string) []string {
 		"ip -6 route show table 200",
 		// xfrm
 		"ip xfrm policy",
-		"ip -s xfrm state",
+		"ip -s xfrm state | awk '!/auth|enc/'",
 		// gops
 		fmt.Sprintf("gops memstats $(pidof %s)", components.CiliumAgentName),
 		fmt.Sprintf("gops stack $(pidof %s)", components.CiliumAgentName),


### PR DESCRIPTION
Remove keys from xfrm debug output. We want the state output to
identify any issues with xfrm setup, the output has the stats.
We don't however want to record any keys.

Fixes: 53b310438ee53 ("cilium: bugtool add xfrm details")
Reported-by: Signed-off-by: Martynas Pumputis <m@lambda.lt>
Signed-off-by: John Fastabend <john.fastabend@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7355)
<!-- Reviewable:end -->
