### PR TITLE
k8s: ignore kubectl.kubernetes.io/last-applied-configuration annotation

### DIFF
--- a/pkg/k8s/factory_functions_test.go
+++ b/pkg/k8s/factory_functions_test.go
@@ -93,6 +93,30 @@ func (s *K8sSuite) Test_EqualV2CNP(c *C) {
 			},
 			want: true,
 		},
+		{
+			name: "CNP with different last applied annotations. The are ignored so they should be equal",
+			args: args{
+				o1: &v2.CiliumNetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "rule1",
+						Annotations: map[string]string{
+							core_v1.LastAppliedConfigAnnotation: "foo",
+						},
+					},
+					Spec: &api.Rule{},
+				},
+				o2: &v2.CiliumNetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "rule1",
+						Annotations: map[string]string{
+							core_v1.LastAppliedConfigAnnotation: "bar",
+						},
+					},
+					Spec: &api.Rule{},
+				},
+			},
+			want: true,
+		},
 	}
 	for _, tt := range tests {
 		got := EqualV2CNP(tt.args.o1, tt.args.o2)


### PR DESCRIPTION
This annotation does not give any real usability for CNP Status and it
might even increase the CNP status for a big policy with a small-medium
cluster (50 nodes).

Signed-off-by: André Martins <andre@cilium.dev>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7356)
<!-- Reviewable:end -->
