### PR TITLE
1.4: doc: Fix etcd key paths for external etcd installation

### DIFF
--- a/Documentation/gettingstarted/k8s-install-external-etcd.rst
+++ b/Documentation/gettingstarted/k8s-install-external-etcd.rst
@@ -81,9 +81,9 @@ Kubernetes you are using:
 .. code:: bash
 
    kubectl create secret generic -n kube-system cilium-etcd-secrets \
-        --from-file=etcd-ca=ca.crt \
-        --from-file=etcd-client-key=client.key \
-        --from-file=etcd-client-crt=client.crt
+        --from-file=etcd-client-ca.crt=ca.crt \
+        --from-file=etcd-client.key=client.key \
+        --from-file=etcd-client.crt=client.crt
 
 3. In case you are not using a TLS-enabled etcd, comment out the configuration
    options in the ConfigMap referring to the key locations like this:
@@ -93,13 +93,13 @@ Kubernetes you are using:
     # In case you want to use TLS in etcd, uncomment the 'ca-file' line
     # and create a kubernetes secret by following the tutorial in
     # https://cilium.link/etcd-config
-    #ca-file: '/var/lib/etcd-secrets/etcd-ca'
+    #ca-file: '/var/lib/etcd-secrets/etcd-client-ca.crt'
     #
     # In case you want client to server authentication, uncomment the following
     # lines and create a kubernetes secret by following the tutorial in
     # https://cilium.link/etcd-config
-    #key-file: '/var/lib/etcd-secrets/etcd-client-key'
-    #cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
+    #key-file: '/var/lib/etcd-secrets/etcd-client.key'
+    #cert-file: '/var/lib/etcd-secrets/etcd-client.crt'
 
 Deploy Cilium
 =============

--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -694,12 +694,12 @@ Export the current ConfigMap
             # In case you want to use TLS in etcd, uncomment the 'ca-file' line
             # and create a kubernetes secret by following the tutorial in
             # https://cilium.link/etcd-config
-            ca-file: '/var/lib/etcd-secrets/etcd-ca'
+            ca-file: '/var/lib/etcd-secrets/etcd-client-ca.crt'
             #
             # In case you want client to server authentication, uncomment the following
             # lines and add the certificate and key in cilium-etcd-secrets below
-            key-file: '/var/lib/etcd-secrets/etcd-client-key'
-            cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
+            key-file: '/var/lib/etcd-secrets/etcd-client.key'
+            cert-file: '/var/lib/etcd-secrets/etcd-client.crt'
         kind: ConfigMap
         metadata:
           creationTimestamp: null
@@ -787,12 +787,12 @@ new options while keeping the configuration that we wanted:
             # In case you want to use TLS in etcd, uncomment the 'ca-file' line
             # and create a kubernetes secret by following the tutorial in
             # https://cilium.link/etcd-config
-            ca-file: '/var/lib/etcd-secrets/etcd-ca'
+            ca-file: '/var/lib/etcd-secrets/etcd-client-ca.crt'
             #
             # In case you want client to server authentication, uncomment the following
             # lines and add the certificate and key in cilium-etcd-secrets below
-            key-file: '/var/lib/etcd-secrets/etcd-client-key'
-            cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
+            key-file: '/var/lib/etcd-secrets/etcd-client.key'
+            cert-file: '/var/lib/etcd-secrets/etcd-client.crt'
         kind: ConfigMap
         metadata:
           creationTimestamp: null

--- a/Documentation/kubernetes/configuration.rst
+++ b/Documentation/kubernetes/configuration.rst
@@ -56,13 +56,13 @@ enabled.
         # In case you want to use TLS in etcd, uncomment the 'ca-file' line
         # and create a kubernetes secret by following the tutorial in
         # https://cilium.link/etcd-config
-        ca-file: '/var/lib/etcd-secrets/etcd-ca'
+        ca-file: '/var/lib/etcd-secrets/etcd-client-ca.crt'
         #
         # In case you want client to server authentication, uncomment the following
         # lines and create a kubernetes secret by following the tutorial in
         # https://cilium.link/etcd-config
-        key-file: '/var/lib/etcd-secrets/etcd-client-key'
-        cert-file: '/var/lib/etcd-secrets/etcd-client-crt'
+        key-file: '/var/lib/etcd-secrets/etcd-client.key'
+        cert-file: '/var/lib/etcd-secrets/etcd-client.crt'
 
       # If you want to run cilium in debug mode change this value to true
       debug: "false"


### PR DESCRIPTION
[ upstream commit 29ef87aa4e24a9d6058e070ba96ad0cbce04de4e ]

The paths in the standard installation YAML:
    # ca-file: '/var/lib/etcd-secrets/etcd-client-ca.crt'
    # key-file: '/var/lib/etcd-secrets/etcd-client.key'
    # cert-file: '/var/lib/etcd-secrets/etcd-client.crt'

was not aligned with the paths used in the key creation instructions:

    kubectl create secret generic -n kube-system cilium-etcd-secrets \
         --from-file=etcd-ca=ca.crt \
         --from-file=etcd-client-key=client.key \
         --from-file=etcd-client-crt=client.crt

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7359)
<!-- Reviewable:end -->
