### PR TITLE
proxy: Break GC loop between Redirect and RedirectImplementation

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -311,6 +311,9 @@ func (p *Proxy) removeRedirect(id string, wg *completion.WaitGroup) (err error, 
 	// FinalizeFunc.
 	proxyPort := r.ProxyPort
 	finalizeFunc = func() {
+		// break GC loop (implementation may point back to 'r')
+		r.implementation = nil
+
 		if implFinalizeFunc != nil {
 			implFinalizeFunc()
 		}


### PR DESCRIPTION
A RedirectImplemenation may point back to the Redirect, so we must nil
the 'implementation' pointer in Redirect to allow Go garbage
collection to clean them up once a Redirect is removed.

As of now Kafka and DNS redirect implementations point back to the
Redirect.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7360)
<!-- Reviewable:end -->
