### PR TITLE
datapath: Add template substitutions for local conntrack maps.

### DIFF
--- a/cilium/cmd/bpf_ct_flush.go
+++ b/cilium/cmd/bpf_ct_flush.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
@@ -40,11 +41,11 @@ func init() {
 }
 
 type dummyEndpoint struct {
-	ID string
+	ID int
 }
 
-func (d dummyEndpoint) StringID() string {
-	return d.ID
+func (d dummyEndpoint) GetID() uint64 {
+	return uint64(d.ID)
 }
 
 func flushCt(eID string) {
@@ -52,7 +53,8 @@ func flushCt(eID string) {
 	if eID == "global" {
 		maps = ctmap.GlobalMaps(true, true)
 	} else {
-		maps = ctmap.LocalMaps(&dummyEndpoint{ID: eID}, true, true)
+		id, _ := strconv.Atoi(eID)
+		maps = ctmap.LocalMaps(&dummyEndpoint{ID: id}, true, true)
 	}
 	for _, m := range maps {
 		path, err := m.Path()

--- a/cilium/cmd/bpf_ct_list.go
+++ b/cilium/cmd/bpf_ct_list.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/pkg/command"
@@ -47,7 +48,8 @@ func dumpCt(eID string) {
 	if eID == "global" {
 		maps = ctmap.GlobalMaps(true, true)
 	} else {
-		maps = ctmap.LocalMaps(&dummyEndpoint{ID: eID}, true, true)
+		id, _ := strconv.Atoi(eID)
+		maps = ctmap.LocalMaps(&dummyEndpoint{ID: id}, true, true)
 	}
 
 	for _, m := range maps {

--- a/pkg/datapath/loader/template.go
+++ b/pkg/datapath/loader/template.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/mac"
 	bpfconfig "github.com/cilium/cilium/pkg/maps/configmap"
+	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/maps/policymap"
 )
 
@@ -40,6 +41,12 @@ var (
 		policymap.MapName,
 		CallsMapName,
 		bpfconfig.MapNamePrefix,
+	}
+	elfCtMapPrefixes = []string{
+		ctmap.MapNameTCP4,
+		ctmap.MapNameAny4,
+		ctmap.MapNameTCP6,
+		ctmap.MapNameAny6,
 	}
 )
 
@@ -132,6 +139,14 @@ func elfMapSubstitutions(ep endpoint) map[string]string {
 		desiredStr := bpf.LocalMapName(name, epID)
 		result[templateStr] = desiredStr
 	}
+	if ep.ConntrackLocalLocked() {
+		for _, name := range elfCtMapPrefixes {
+			templateStr := bpf.LocalMapName(name, TemplateLxcID)
+			desiredStr := bpf.LocalMapName(name, epID)
+			result[templateStr] = desiredStr
+		}
+	}
+
 	result[policymap.CallString(TemplateLxcID)] = policymap.CallString(epID)
 	return result
 }

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -133,7 +133,7 @@ func init() {
 // CtEndpoint represents an endpoint for the functions required to manage
 // conntrack maps for the endpoint.
 type CtEndpoint interface {
-	StringID() string
+	GetID() uint64
 }
 
 // Map represents an instance of a BPF connection tracking map.
@@ -413,12 +413,16 @@ func maps(e CtEndpoint, ipv4, ipv6 bool) []*Map {
 		}
 	} else {
 		if ipv4 {
-			result = append(result, NewMap(MapNameTCP4+e.StringID(), MapTypeIPv4TCPLocal))
-			result = append(result, NewMap(MapNameAny4+e.StringID(), MapTypeIPv4AnyLocal))
+			result = append(result, NewMap(bpf.LocalMapName(MapNameTCP4, uint16(e.GetID())),
+				MapTypeIPv4TCPLocal))
+			result = append(result, NewMap(bpf.LocalMapName(MapNameAny4, uint16(e.GetID())),
+				MapTypeIPv4AnyLocal))
 		}
 		if ipv6 {
-			result = append(result, NewMap(MapNameTCP6+e.StringID(), MapTypeIPv6TCPLocal))
-			result = append(result, NewMap(MapNameAny6+e.StringID(), MapTypeIPv6AnyLocal))
+			result = append(result, NewMap(bpf.LocalMapName(MapNameTCP6, uint16(e.GetID())),
+				MapTypeIPv6TCPLocal))
+			result = append(result, NewMap(bpf.LocalMapName(MapNameAny6, uint16(e.GetID())),
+				MapTypeIPv6AnyLocal))
 		}
 	}
 	return result


### PR DESCRIPTION
When endpoint is configured with local conntrack maps, the dummy map
names in the template need to be substituted.

Fixes: d192b4c1f1b00ea0979e2f9282ab42d82d2f4e81
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7361)
<!-- Reviewable:end -->
