### PR TITLE
kvstore: Add metric to count received kvstore events

### DIFF
--- a/Documentation/configuration/metrics.rst
+++ b/Documentation/configuration/metrics.rst
@@ -144,8 +144,12 @@ KVstore
 -------
 
 * ``kvstore_operations_duration_seconds``: Duration of kvstore operation
+
   * Labels: ``action``, ``kind``, ``outcome``, ``scope``
 
+* ``kvstore_events_queue_seconds``: Duration of seconds of time received event was blocked before it could be queued
+
+  * Labels: ``action``, ``scope``
 
 Agent
 -----

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -467,11 +467,13 @@ reList:
 				localCache.MarkInUse(key.Key)
 				scopedLog.Debugf("Emitting list result as %v event for %s=%v", t, key.Key, key.Value)
 
+				queueStart := spanstat.Start()
 				w.Events <- KeyValueEvent{
 					Key:   string(key.Key),
 					Value: key.Value,
 					Typ:   t,
 				}
+				trackEventQueued(string(key.Key), t, queueStart.End(true).Total())
 			}
 		}
 
@@ -490,7 +492,9 @@ reList:
 			}
 
 			scopedLog.Debugf("Emitting EventTypeDelete event for %s", k)
+			queueStart := spanstat.Start()
 			w.Events <- event
+			trackEventQueued(k, EventTypeDelete, queueStart.End(true).Total())
 		})
 
 		// Only send the list signal once
@@ -558,7 +562,9 @@ reList:
 
 					scopedLog.Debugf("Emitting %v event for %s=%v", event.Typ, event.Key, event.Value)
 
+					queueStart := spanstat.Start()
 					w.Events <- event
+					trackEventQueued(string(ev.Kv.Key), event.Typ, queueStart.End(true).Total())
 				}
 			}
 		}

--- a/pkg/kvstore/metrics.go
+++ b/pkg/kvstore/metrics.go
@@ -47,3 +47,7 @@ func increaseMetric(key, kind, action string, duration time.Duration, err error)
 	metrics.KVStoreOperationsDuration.
 		WithLabelValues(namespace, kind, action, outcome).Observe(duration.Seconds())
 }
+
+func trackEventQueued(key string, typ EventType, duration time.Duration) {
+	metrics.KVStoreEventsQueueDuration.WithLabelValues(getScopeFromKey(key), typ.String()).Observe(duration.Seconds())
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -565,6 +565,16 @@ var (
 		Help:      "Duration in seconds of kvstore operations",
 	}, []string{LabelScope, LabelKind, LabelAction, LabelOutcome})
 
+	// KVStoreEventsQueueDuration records the duration in seconds of time
+	// received event was blocked before it could be queued
+	KVStoreEventsQueueDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: Namespace,
+		Subsystem: "kvstore",
+		Name:      "events_queue_seconds",
+		Help:      "Duration in seconds of time received event was blocked before it could be queued",
+		Buckets:   []float64{.002, .005, .01, .015, .025, .05, .1, .25, .5, .75, 1},
+	}, []string{LabelScope, LabelAction})
+
 	// FQDNGarbageCollectorCleanedTotal is the number of domains cleaned by the
 	// GC job.
 	FQDNGarbageCollectorCleanedTotal = prometheus.NewCounter(prometheus.CounterOpts{
@@ -639,6 +649,7 @@ func init() {
 
 	MustRegister(KVStoreOperationsTotal)
 	MustRegister(KVStoreOperationsDuration)
+	MustRegister(KVStoreEventsQueueDuration)
 
 	MustRegister(FQDNGarbageCollectorCleanedTotal)
 }


### PR DESCRIPTION
Count the number of kvstore events received, labelled by scope and action. Also
measure the duration until the event could be queued to allow alerting on event
processing backlog.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7364)
<!-- Reviewable:end -->
