### PR TITLE
Fix API ToCIDRSet wording typo

### DIFF
--- a/pkg/policy/api/egress.go
+++ b/pkg/policy/api/egress.go
@@ -77,7 +77,7 @@ type EgressRule struct {
 
 	// ToCIDRSet is a list of IP blocks which the endpoint subject to the rule
 	// is allowed to initiate connections to in addition to connections
-	// which are allowed via FromEndpoints, along with a list of subnets contained
+	// which are allowed via ToEndpoints, along with a list of subnets contained
 	// within their corresponding IP block to which traffic should not be
 	// allowed. This will match on the destination IP address of outgoing
 	// connections. Adding a prefix into ToCIDR or into ToCIDRSet with no


### PR DESCRIPTION
This referred to FromEndpoints, but in egress rules it's ToEndpoints.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7366)
<!-- Reviewable:end -->
