### PR TITLE
policy: Add UUIDs to rules

### DIFF
--- a/Documentation/policy/intro.rst
+++ b/Documentation/policy/intro.rst
@@ -112,6 +112,18 @@ provided. If both ingress and egress are omitted, the rule has no effect.
                 //
                 // +optional
                 Description string `json:"description,omitempty"`
+
+                // UUID is an identifier for the rule, in the form of an RFC4122 UUID.
+                //
+                // As of Cilium 1.5, when a set of rules are added, Cilium will
+                // generate an RFC4122 Version 4 UUID for the set of rules and
+                // configure the same UUID in each rule that is imported at the same
+                // time, overriding any user-provided UUIDs.
+                //
+                // Introduced in Cilium 1.5.
+                //
+                // +optional
+                UUID types.UID `json:"UUID,omitempty"`
         }
 
 ----
@@ -139,6 +151,10 @@ labels
 description
   Description is a string which is not interpreted by Cilium. It can be used to
   describe the intent and scope of the rule in a human readable form.
+
+uuid
+  UUID is an identifier for a rule or set of rules which Cilium generates. It
+  can be used to correlate policy API requests with imported rules.
 
 .. _label_selector:
 .. _LabelSelector:

--- a/daemon/k8s_watcher_test.go
+++ b/daemon/k8s_watcher_test.go
@@ -78,7 +78,7 @@ func (ds *DaemonSuite) Test_addCiliumNetworkPolicyV2(c *C) {
 			setupWanted: func() wanted {
 				r := policy.NewPolicyRepository()
 				r.AddList(api.Rules{
-					api.NewRule(types.UID("")).
+					api.NewRule(uuid).
 						WithEndpointSelector(api.EndpointSelector{
 							LabelSelector: &metav1.LabelSelector{
 								MatchLabels: map[string]string{
@@ -148,7 +148,7 @@ func (ds *DaemonSuite) Test_addCiliumNetworkPolicyV2(c *C) {
 			setupWanted: func() wanted {
 				r := policy.NewPolicyRepository()
 				r.AddList(api.Rules{
-					api.NewRule(types.UID("")).
+					api.NewRule(uuid).
 						WithEndpointSelector(api.EndpointSelector{
 							LabelSelector: &metav1.LabelSelector{
 								MatchLabels: map[string]string{
@@ -219,7 +219,7 @@ func (ds *DaemonSuite) Test_addCiliumNetworkPolicyV2(c *C) {
 				lbls := utils.GetPolicyLabels("production", "db", uuid, utils.ResourceTypeCiliumNetworkPolicy)
 				lbls = append(lbls, labels.ParseLabelArray("foo=bar")...)
 				r.AddList(api.Rules{
-					api.NewRule(types.UID("")).
+					api.NewRule(uuid).
 						WithEndpointSelector(api.EndpointSelector{
 							LabelSelector: &metav1.LabelSelector{
 								MatchLabels: map[string]string{

--- a/daemon/k8s_watcher_test.go
+++ b/daemon/k8s_watcher_test.go
@@ -78,20 +78,23 @@ func (ds *DaemonSuite) Test_addCiliumNetworkPolicyV2(c *C) {
 			setupWanted: func() wanted {
 				r := policy.NewPolicyRepository()
 				r.AddList(api.Rules{
-					{
-						EndpointSelector: api.EndpointSelector{
+					api.NewRule(types.UID("")).
+						WithEndpointSelector(api.EndpointSelector{
 							LabelSelector: &metav1.LabelSelector{
 								MatchLabels: map[string]string{
 									"env": "cluster-1",
 									labels.LabelSourceK8s + "." + k8sConst.PodNamespaceLabel: "production",
 								},
 							},
-						},
-						Ingress:     nil,
-						Egress:      nil,
-						Labels:      utils.GetPolicyLabels("production", "db", uuid, utils.ResourceTypeCiliumNetworkPolicy),
-						Description: "",
-					},
+						}).
+						WithIngressRules(nil).
+						WithEgressRules(nil).
+						WithLabels(utils.GetPolicyLabels(
+							"production",
+							"db",
+							uuid,
+							utils.ResourceTypeCiliumNetworkPolicy),
+						),
 				})
 				return wanted{
 					err:  nil,
@@ -145,20 +148,23 @@ func (ds *DaemonSuite) Test_addCiliumNetworkPolicyV2(c *C) {
 			setupWanted: func() wanted {
 				r := policy.NewPolicyRepository()
 				r.AddList(api.Rules{
-					{
-						EndpointSelector: api.EndpointSelector{
+					api.NewRule(types.UID("")).
+						WithEndpointSelector(api.EndpointSelector{
 							LabelSelector: &metav1.LabelSelector{
 								MatchLabels: map[string]string{
 									"env": "cluster-1",
 									labels.LabelSourceK8s + "." + k8sConst.PodNamespaceLabel: "production",
 								},
 							},
-						},
-						Ingress:     nil,
-						Egress:      nil,
-						Labels:      utils.GetPolicyLabels("production", "db", uuid, utils.ResourceTypeCiliumNetworkPolicy),
-						Description: "",
-					},
+						}).
+						WithIngressRules(nil).
+						WithEgressRules(nil).
+						WithLabels(utils.GetPolicyLabels(
+							"production",
+							"db",
+							uuid,
+							utils.ResourceTypeCiliumNetworkPolicy,
+						)),
 				})
 				return wanted{
 					err:  nil,
@@ -213,20 +219,18 @@ func (ds *DaemonSuite) Test_addCiliumNetworkPolicyV2(c *C) {
 				lbls := utils.GetPolicyLabels("production", "db", uuid, utils.ResourceTypeCiliumNetworkPolicy)
 				lbls = append(lbls, labels.ParseLabelArray("foo=bar")...)
 				r.AddList(api.Rules{
-					{
-						EndpointSelector: api.EndpointSelector{
+					api.NewRule(types.UID("")).
+						WithEndpointSelector(api.EndpointSelector{
 							LabelSelector: &metav1.LabelSelector{
 								MatchLabels: map[string]string{
 									"env": "cluster-1",
 									labels.LabelSourceK8s + "." + k8sConst.PodNamespaceLabel: "production",
 								},
 							},
-						},
-						Ingress:     nil,
-						Egress:      nil,
-						Labels:      lbls,
-						Description: "",
-					},
+						}).
+						WithIngressRules(nil).
+						WithEgressRules(nil).
+						WithLabels(lbls),
 				})
 				return wanted{
 					err:  nil,

--- a/daemon/policy_test.go
+++ b/daemon/policy_test.go
@@ -122,7 +122,7 @@ func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
 
 	ds.d.l7Proxy.RemoveAllNetworkPolicies()
 
-	_, err3 := ds.d.PolicyAdd(rules, nil)
+	_, err3 := ds.d.PolicyAdd(rules, &AddOptions{})
 	c.Assert(err3, Equals, nil)
 
 	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}
@@ -357,7 +357,7 @@ func (ds *DaemonSuite) TestReplacePolicy(c *C) {
 		},
 	}
 
-	_, err := ds.d.PolicyAdd(rules, nil)
+	_, err := ds.d.PolicyAdd(rules, &AddOptions{})
 	c.Assert(err, IsNil)
 	ds.d.policy.Mutex.RLock()
 	c.Assert(len(ds.d.policy.SearchRLocked(lbls)), Equals, 2)
@@ -442,7 +442,7 @@ func (ds *DaemonSuite) TestRemovePolicy(c *C) {
 
 	ds.d.l7Proxy.RemoveAllNetworkPolicies()
 
-	_, err3 := ds.d.PolicyAdd(rules, nil)
+	_, err3 := ds.d.PolicyAdd(rules, &AddOptions{})
 	c.Assert(err3, Equals, nil)
 
 	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}

--- a/pkg/fqdn/config.go
+++ b/pkg/fqdn/config.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -44,7 +44,10 @@ type Config struct {
 
 	// AddGeneratedRules is a callback  to emit generated rules.
 	// When set to nil, it is a no-op.
-	AddGeneratedRules func([]*api.Rule) error
+	//
+	// uuidsToUpdate are used just for logging purposes to identify UUIDs
+	// associated with policy add requests.
+	AddGeneratedRules func(rules []*api.Rule, uuidsToUpdate []string) error
 
 	// PollerResponseNotify is used when the poller recieves DNS data in response
 	// to a successful poll.

--- a/pkg/fqdn/dnspoller_test.go
+++ b/pkg/fqdn/dnspoller_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -151,7 +151,7 @@ func (ds *FQDNTestSuite) TestRuleGenRuleHandling(c *C) {
 					return lookupDNSNames(ipLookups, lookups, dnsNames), nil
 				},
 
-				AddGeneratedRules: func(rules []*api.Rule) error {
+				AddGeneratedRules: func(rules []*api.Rule, uuids []string) error {
 					generatedRules = append(generatedRules, rules...)
 					return nil
 				},

--- a/pkg/fqdn/rulegen.go
+++ b/pkg/fqdn/rulegen.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -90,7 +90,7 @@ func NewRuleGen(config Config) *RuleGen {
 	}
 
 	if config.AddGeneratedRules == nil {
-		config.AddGeneratedRules = func(generatedRules []*api.Rule) error { return nil }
+		config.AddGeneratedRules = func([]*api.Rule, []string) error { return nil }
 	}
 
 	return &RuleGen{
@@ -257,7 +257,7 @@ func (gen *RuleGen) UpdateGenerateDNS(lookupTime time.Time, updatedDNSIPs map[st
 	}
 
 	// emit the new rules
-	return gen.config.AddGeneratedRules(generatedRules)
+	return gen.config.AddGeneratedRules(generatedRules, uuidsToUpdate)
 }
 
 // ForceGenerateDNS unconditionally regenerates all rules that refer to DNS
@@ -295,7 +295,7 @@ func (gen *RuleGen) ForceGenerateDNS(namesToRegen []string) error {
 	}
 
 	// emit the new rules
-	return gen.config.AddGeneratedRules(generatedRules)
+	return gen.config.AddGeneratedRules(generatedRules, uuidsToUpdate)
 }
 
 // UpdateDNSIPs updates the IPs for each DNS name in updatedDNSIPs.

--- a/pkg/fqdn/rulegen_test.go
+++ b/pkg/fqdn/rulegen_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ func (ds *FQDNTestSuite) TestRuleGenCIDRGeneration(c *C) {
 				return lookupFail(c, dnsNames)
 			},
 
-			AddGeneratedRules: func(rules []*api.Rule) error {
+			AddGeneratedRules: func(rules []*api.Rule, uuids []string) error {
 				generatedRules = append(generatedRules, rules...)
 				return nil
 			},
@@ -111,7 +111,7 @@ func (ds *FQDNTestSuite) TestRuleGenDropCIDROnReinsert(c *C) {
 				return lookupFail(c, dnsNames)
 			},
 
-			AddGeneratedRules: func(rules []*api.Rule) error {
+			AddGeneratedRules: func(rules []*api.Rule, uuids []string) error {
 				generatedRules = append(generatedRules, rules...)
 				return nil
 			},
@@ -143,7 +143,7 @@ func (ds *FQDNTestSuite) TestRuleGenMultiIPUpdate(c *C) {
 				return lookupFail(c, dnsNames)
 			},
 
-			AddGeneratedRules: func(rules []*api.Rule) error {
+			AddGeneratedRules: func(rules []*api.Rule, uuids []string) error {
 				generatedRules = append(generatedRules, rules...)
 				return nil
 			},
@@ -214,7 +214,7 @@ func (ds *FQDNTestSuite) TestRuleGenUpdatesOnReplace(c *C) {
 				return lookupFail(c, dnsNames)
 			},
 
-			AddGeneratedRules: func(rules []*api.Rule) error {
+			AddGeneratedRules: func(rules []*api.Rule, uuids []string) error {
 				return nil
 			},
 		})

--- a/pkg/k8s/apis/cilium.io/utils/utils.go
+++ b/pkg/k8s/apis/cilium.io/utils/utils.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 Authors of Cilium
+// Copyright 2017-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -201,7 +201,7 @@ func namespacesAreValid(namespace string, userNamespaces []string) bool {
 // ParseToCiliumRule returns an api.Rule with all the labels parsed into cilium
 // labels.
 func ParseToCiliumRule(namespace, name string, uid types.UID, r *api.Rule) *api.Rule {
-	retRule := &api.Rule{}
+	retRule := api.NewRule(uid)
 	if r.EndpointSelector.LabelSelector != nil {
 		retRule.EndpointSelector = api.NewESFromK8sLabelSelector("", r.EndpointSelector.LabelSelector)
 		// The PodSelector should only reflect to the same namespace

--- a/pkg/k8s/apis/cilium.io/utils/utils_test.go
+++ b/pkg/k8s/apis/cilium.io/utils/utils_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -77,15 +77,16 @@ func Test_ParseToCiliumRule(t *testing.T) {
 					),
 				},
 			},
-			want: &api.Rule{
-				EndpointSelector: api.NewESFromMatchRequirements(
+			want: api.NewRule(uuid).WithEndpointSelector(
+				api.NewESFromMatchRequirements(
 					map[string]string{
 						role:      "backend",
 						namespace: "default",
 					},
 					nil,
 				),
-				Labels: labels.LabelArray{
+			).WithLabels(
+				labels.LabelArray{
 					{
 						Key:    "io.cilium.k8s.policy.name",
 						Value:  "parse-in-namespace",
@@ -107,7 +108,7 @@ func Test_ParseToCiliumRule(t *testing.T) {
 						Source: labels.LabelSourceK8s,
 					},
 				},
-			},
+			),
 		},
 		{
 			// When the rule specifies a namespace, it is overridden
@@ -126,15 +127,16 @@ func Test_ParseToCiliumRule(t *testing.T) {
 					),
 				},
 			},
-			want: &api.Rule{
-				EndpointSelector: api.NewESFromMatchRequirements(
+			want: api.NewRule(uuid).WithEndpointSelector(
+				api.NewESFromMatchRequirements(
 					map[string]string{
 						role:      "backend",
 						namespace: "default",
 					},
 					nil,
 				),
-				Labels: labels.LabelArray{
+			).WithLabels(
+				labels.LabelArray{
 					{
 						Key:    "io.cilium.k8s.policy.name",
 						Value:  "parse-in-namespace-with-ns-selector",
@@ -156,7 +158,7 @@ func Test_ParseToCiliumRule(t *testing.T) {
 						Source: labels.LabelSourceK8s,
 					},
 				},
-			},
+			),
 		},
 		{
 			// Don't insert a namespace selection when the rule
@@ -175,8 +177,8 @@ func Test_ParseToCiliumRule(t *testing.T) {
 					),
 				},
 			},
-			want: &api.Rule{
-				EndpointSelector: api.NewESFromMatchRequirements(
+			want: api.NewRule(uuid).WithEndpointSelector(
+				api.NewESFromMatchRequirements(
 					map[string]string{
 						role:       "backend",
 						podInitLbl: "",
@@ -185,7 +187,8 @@ func Test_ParseToCiliumRule(t *testing.T) {
 					},
 					nil,
 				),
-				Labels: labels.LabelArray{
+			).WithLabels(
+				labels.LabelArray{
 					{
 						Key:    "io.cilium.k8s.policy.name",
 						Value:  "parse-init-policy",
@@ -207,7 +210,7 @@ func Test_ParseToCiliumRule(t *testing.T) {
 						Source: labels.LabelSourceK8s,
 					},
 				},
-			},
+			),
 		},
 		{
 			name: "set-any-source-for-namespace",
@@ -236,15 +239,16 @@ func Test_ParseToCiliumRule(t *testing.T) {
 					},
 				},
 			},
-			want: &api.Rule{
-				EndpointSelector: api.NewESFromMatchRequirements(
+			want: api.NewRule(uuid).WithEndpointSelector(
+				api.NewESFromMatchRequirements(
 					map[string]string{
 						role:      "backend",
 						namespace: "default",
 					},
 					nil,
 				),
-				Ingress: []api.IngressRule{
+			).WithIngressRules(
+				[]api.IngressRule{
 					{
 						FromEndpoints: []api.EndpointSelector{
 							api.NewESFromK8sLabelSelector(
@@ -257,7 +261,8 @@ func Test_ParseToCiliumRule(t *testing.T) {
 						},
 					},
 				},
-				Labels: labels.LabelArray{
+			).WithLabels(
+				labels.LabelArray{
 					{
 						Key:    "io.cilium.k8s.policy.name",
 						Value:  "set-any-source-for-namespace",
@@ -279,7 +284,7 @@ func Test_ParseToCiliumRule(t *testing.T) {
 						Source: labels.LabelSourceK8s,
 					},
 				},
-			},
+			),
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/k8s/apis/cilium.io/v2/types_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/types_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -113,8 +113,8 @@ var (
 		Labels: labels.LabelArray{{Key: "uuid", Value: "98678-9868976-78687678887678", Source: ""}},
 	}
 	uuidRule         = types.UID("98678-9868976-78687678887678")
-	expectedSpecRule = api.Rule{
-		Ingress: []api.IngressRule{
+	expectedSpecRule = api.NewRule(uuidRule).
+				WithIngressRules([]api.IngressRule{
 			{
 				FromEndpoints: []api.EndpointSelector{
 					api.NewESFromLabels(
@@ -132,8 +132,8 @@ var (
 					},
 				},
 			},
-		},
-		Egress: []api.EgressRule{
+		}).
+		WithEgressRules([]api.EgressRule{
 			{
 				ToPorts: []api.PortRule{
 					{
@@ -147,9 +147,8 @@ var (
 			}, {
 				ToCIDRSet: []api.CIDRRule{{Cidr: api.CIDR("10.0.0.0/8"), ExceptCIDRs: []api.CIDR{"10.96.0.0/12"}}},
 			},
-		},
-		Labels: k8sUtils.GetPolicyLabels("default", "rule1", uuidRule, "CiliumNetworkPolicy"),
-	}
+		}).
+		WithLabels(k8sUtils.GetPolicyLabels("default", "rule1", uuidRule, "CiliumNetworkPolicy"))
 
 	rawRule = []byte(`{
         "endpointSelector": {
@@ -310,7 +309,7 @@ func (s *CiliumV2Suite) TestParseSpec(c *C) {
 	rules, err := expectedPolicyRule.Parse()
 	c.Assert(err, IsNil)
 	c.Assert(len(rules), Equals, 1)
-	c.Assert(*rules[0], checker.DeepEquals, expectedSpecRule)
+	c.Assert(*rules[0], checker.DeepEquals, *expectedSpecRule)
 
 	b, err := json.Marshal(expectedPolicyRule)
 	c.Assert(err, IsNil)
@@ -370,7 +369,7 @@ func (s *CiliumV2Suite) TestParseRules(c *C) {
 		}},
 	)
 	expectedSpecRule.EndpointSelector = expectedES
-	expectedSpecRules := api.Rules{&expectedSpecRule, &expectedSpecRule}
+	expectedSpecRules := api.Rules{expectedSpecRule, expectedSpecRule}
 	expectedSpecRule.Sanitize()
 	for i := range expectedSpecRules {
 		expectedSpecRules[i].Sanitize()

--- a/pkg/k8s/network_policy.go
+++ b/pkg/k8s/network_policy.go
@@ -28,7 +28,6 @@ import (
 
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 const (
@@ -241,8 +240,7 @@ func ParseNetworkPolicy(np *networkingv1.NetworkPolicy) (api.Rules, error) {
 	}
 	np.Spec.PodSelector.MatchLabels[k8sConst.PodNamespaceLabel] = namespace
 
-	// The next patch will pass the UID.
-	rule := api.NewRule(types.UID("")).
+	rule := api.NewRule(np.ObjectMeta.UID).
 		WithEndpointSelector(api.NewESFromK8sLabelSelector(labels.LabelSourceK8sKeyPrefix, &np.Spec.PodSelector)).
 		WithLabels(GetPolicyLabelsv1(np)).
 		WithIngressRules(ingresses).

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -250,9 +250,9 @@ func (s *K8sSuite) TestParseNetworkPolicyNoSelectors(c *C) {
 	err := json.Unmarshal(ex1, &np)
 	c.Assert(err, IsNil)
 
-	expectedRule := &api.Rule{
-		EndpointSelector: epSelector,
-		Ingress: []api.IngressRule{
+	expectedRule := api.NewRule(types.UID("")).
+		WithEndpointSelector(epSelector).
+		WithIngressRules([]api.IngressRule{
 			{
 				FromCIDRSet: []api.CIDRRule{
 					{
@@ -263,15 +263,14 @@ func (s *K8sSuite) TestParseNetworkPolicyNoSelectors(c *C) {
 					},
 				},
 			},
-		},
-		Egress: []api.EgressRule{},
-		Labels: labels.ParseLabelArray(
+		}).
+		WithEgressRules([]api.EgressRule{}).
+		WithLabels(labels.ParseLabelArray(
 			"k8s:"+k8sConst.PolicyLabelName+"=ingress-cidr-test",
 			"k8s:"+k8sConst.PolicyLabelUID+"=11bba160-ddca-11e8-b697-0800273b04ff",
 			"k8s:"+k8sConst.PolicyLabelNamespace+"=myns",
 			"k8s:"+k8sConst.PolicyLabelDerivedFrom+"="+resourceTypeNetworkPolicy,
-		),
-	}
+		))
 
 	expectedRule.Sanitize()
 

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -208,14 +208,15 @@ func (s *K8sSuite) TestParseNetworkPolicyIngress(c *C) {
 
 func (s *K8sSuite) TestParseNetworkPolicyNoSelectors(c *C) {
 
-	// Ingress with neither pod nor namespace selector set.
+	// Ingress with neither pod nor namespace selector set
+	uuid := "11bba160-ddca-11e8-b697-0800273b04ff"
 	ex1 := []byte(`{
 "kind": "NetworkPolicy",
 "apiVersion": "extensions/networkingv1",
 "metadata": {
   "name": "ingress-cidr-test",
   "namespace": "myns",
-  "uid": "11bba160-ddca-11e8-b697-0800273b04ff"
+  "uid": "` + uuid + `"
 },
 "spec": {
   "podSelector": {
@@ -250,7 +251,7 @@ func (s *K8sSuite) TestParseNetworkPolicyNoSelectors(c *C) {
 	err := json.Unmarshal(ex1, &np)
 	c.Assert(err, IsNil)
 
-	expectedRule := api.NewRule(types.UID("")).
+	expectedRule := api.NewRule(types.UID(uuid)).
 		WithEndpointSelector(epSelector).
 		WithIngressRules([]api.IngressRule{
 			{
@@ -267,7 +268,7 @@ func (s *K8sSuite) TestParseNetworkPolicyNoSelectors(c *C) {
 		WithEgressRules([]api.EgressRule{}).
 		WithLabels(labels.ParseLabelArray(
 			"k8s:"+k8sConst.PolicyLabelName+"=ingress-cidr-test",
-			"k8s:"+k8sConst.PolicyLabelUID+"=11bba160-ddca-11e8-b697-0800273b04ff",
+			"k8s:"+k8sConst.PolicyLabelUID+"="+uuid,
 			"k8s:"+k8sConst.PolicyLabelNamespace+"=myns",
 			"k8s:"+k8sConst.PolicyLabelDerivedFrom+"="+resourceTypeNetworkPolicy,
 		))

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 Authors of Cilium
+// Copyright 2017-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -37,6 +37,9 @@ const (
 
 	// EventUUID is an event unique identifier
 	EventUUID = "eventID"
+
+	// PolicyUUID is a policy unique identifier
+	PolicyUUID = "policyUUID"
 
 	// ContainerID is the container identifier
 	ContainerID = "containerID"

--- a/pkg/policy/api/rule.go
+++ b/pkg/policy/api/rule.go
@@ -120,6 +120,11 @@ func (r *Rule) WithUUID(uuid types.UID) *Rule {
 	return r
 }
 
+// SetUUID changes the unique identifier for the rule to the specified UUID.
+func (r *Rule) SetUUID(uuid types.UID) {
+	r.UUID = uuid
+}
+
 // RequiresDerivative it return true if the rule has a derivative rule.
 func (r *Rule) RequiresDerivative() bool {
 	for _, rule := range r.Egress {

--- a/pkg/policy/api/rule.go
+++ b/pkg/policy/api/rule.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@ package api
 
 import (
 	"github.com/cilium/cilium/pkg/labels"
+
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // Rule is a policy rule which must be applied to all endpoints which match the
@@ -60,6 +62,26 @@ type Rule struct {
 	//
 	// +optional
 	Description string `json:"description,omitempty"`
+
+	// UUID is an identifier for the rule, in the form of an RFC4122 UUID.
+	//
+	// As of Cilium 1.5, when a set of rules are added, Cilium will
+	// generate an RFC4122 Version 4 UUID for the set of rules and
+	// configure the same UUID in each rule that is imported at the same
+	// time, overriding any user-provided UUIDs.
+	//
+	// Introduced in Cilium 1.5.
+	//
+	// +optional
+	UUID types.UID `json:"UUID,omitempty"`
+}
+
+// NewRule builds a new rule with the UUID prepopulated. By convention, the
+// same UID may be shared with other rules that are parts of the same policy.
+func NewRule(uuid types.UID) *Rule {
+	return &Rule{
+		UUID: uuid,
+	}
 }
 
 // RequiresDerivative it return true if the rule has a derivative rule.

--- a/pkg/policy/api/rule.go
+++ b/pkg/policy/api/rule.go
@@ -84,6 +84,42 @@ func NewRule(uuid types.UID) *Rule {
 	}
 }
 
+// WithEndpointSelector configures the Rule with the specified selector.
+func (r *Rule) WithEndpointSelector(es EndpointSelector) *Rule {
+	r.EndpointSelector = es
+	return r
+}
+
+// WithIngressRules configures the Rule with the specified rules.
+func (r *Rule) WithIngressRules(rules []IngressRule) *Rule {
+	r.Ingress = rules
+	return r
+}
+
+// WithEgressRules configures the Rule with the specified rules.
+func (r *Rule) WithEgressRules(rules []EgressRule) *Rule {
+	r.Egress = rules
+	return r
+}
+
+// WithLabels configures the Rule with the specified labels metadata.
+func (r *Rule) WithLabels(labels labels.LabelArray) *Rule {
+	r.Labels = labels
+	return r
+}
+
+// WithDescription configures the Rule with the specified description metadata.
+func (r *Rule) WithDescription(desc string) *Rule {
+	r.Description = desc
+	return r
+}
+
+// WithUUID configures the Rule with the specified unique identifier.
+func (r *Rule) WithUUID(uuid types.UID) *Rule {
+	r.UUID = uuid
+	return r
+}
+
 // RequiresDerivative it return true if the rule has a derivative rule.
 func (r *Rule) RequiresDerivative() bool {
 	for _, rule := range r.Egress {

--- a/pkg/uuid/uuid.go
+++ b/pkg/uuid/uuid.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2019 Authors of Cilium
-Copyright 2014 The Kubernetes Authors.
+Copyright 2014-2019 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -38,9 +38,14 @@ func (u UUID) ToUID() types.UID {
 	return types.UID(u.String())
 }
 
+// Parse decodes the specified uuid into a UUID or returns nil.
+func Parse(uid string) UUID {
+	return UUID{uuid.Parse(uid)}
+}
+
 // ParseUID decodes uid into a UUID or returns nil.
 func ParseUID(uid types.UID) UUID {
-	return UUID{uuid.Parse(string(uid))}
+	return Parse(string(uid))
 }
 
 // NewUUID returns a new UUID

--- a/pkg/uuid/uuid.go
+++ b/pkg/uuid/uuid.go
@@ -1,4 +1,5 @@
 /*
+Copyright 2019 Authors of Cilium
 Copyright 2014 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,13 +21,30 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 
 	"github.com/pborman/uuid"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 var uuidLock lock.Mutex
 var lastUUID uuid.UUID
 
+// A UUID is a 128 bit (16 byte) Universal Unique IDentifier as defined in RFC
+// 4122.
+type UUID struct {
+	uuid.UUID
+}
+
+// ToUID converts the UUID into a k8s UID.
+func (u UUID) ToUID() types.UID {
+	return types.UID(u.String())
+}
+
+// ParseUID decodes uid into a UUID or returns nil.
+func ParseUID(uid types.UID) UUID {
+	return UUID{uuid.Parse(string(uid))}
+}
+
 // NewUUID returns a new UUID
-func NewUUID() uuid.UUID {
+func NewUUID() UUID {
 	uuidLock.Lock()
 	defer uuidLock.Unlock()
 	result := uuid.NewUUID()
@@ -38,5 +56,5 @@ func NewUUID() uuid.UUID {
 		result = uuid.NewUUID()
 	}
 	lastUUID = result
-	return result
+	return UUID{result}
 }


### PR DESCRIPTION
### **Main question**:
* Is `api.Rule{}` the right abstraction level to put the UUID, or should it be in each individual `api.IngressRule` / `api.EgressRule`?

### Summary

Add a UUID for every api.Rule, based on the policy add request (which implies that all rules in the same policy will have the same UUID):
* In the k8s case, this is derived from the NP/CNP `ObjectMeta.UID`, so the same for every rule that's part of the same k8s policy object.
* In the direct Cilium API case, this is autogenerated server-side as an RFC4122 version 4 UUID when the policy add request is received, ie there is one UUID for all rules that are added at the same time.
* In the FQDN case, the FQDN poller will end up updating the same rule as the FQDN rule so the UUID will be the same there. However, for logging purposes in the `PolicyAdd()`, we pass down the slice of UUIDs so we can correlate those logs with other FQDN logs. This is not the cleanest solution, but it works for now and I expect that FQDN will change considerably over the coming months so I don't want to spend lots of times making this tidy just for us to go and rip it all up and do it a different way.

In the API, I reused the k8s UID type (basically a string), but I figured we may want a more fleshed out uuid internally and we use `pkg/uuid` in other places so in the daemon-level code I ensure we're dealing with `pkg/uuid.UUID` rather than `k8s.io/apimachinery/pkg/types.UID`.

Please review commit-by-commit.

### Example

```
$ cilium_logs | grep UID
Mar 11 20:56:44 runtime1 cilium-agent[31396]: level=info msg="Policy Add Request" PolicyAddRequest="[ 2da16134-4440-11e9-a94f-0800271bbcb9]" ciliumNetworkPolicy="[&{EndpointSelector:{\"matchLabels\":{\"any:role\":\"victim\"}} Ingress:[{FromEndpoints:[{}] FromRequires:[] ToPorts:[] FromCIDR:[] FromCIDRSet:[] FromEntities:[] aggregatedSelectors:[{LabelSelector:0xc0006fb160 requirements:0xc0006fb1a0}]}] Egress:[] Labels:[:name=allow-all-to-victim] Description: UUID:2da16134-4440-11e9-a94f-0800271bbcb9}]" subsys=daemon
$ cilium policy get
[
  {
    "endpointSelector": {
      "matchLabels": {
        "any:role": "victim"
      }
    },
    "ingress": [
      {
        "fromEndpoints": [
          {}
        ]
      }
    ],
    "labels": [
      {
        "key": "name",
        "value": "allow-all-to-victim",
        "source": ""
      }
    ],
    "UUID": "2da16134-4440-11e9-a94f-0800271bbcb9"
  }
]
Revision: 2
```

### Out of scope / other future work

* Rearrange `policy.Repository` to reduce iteration.
* Policy delete by UUID
* Improve usage from FQDNs subsystem
  * Eg, have a global map by fqdn-UUID to allow direct lookup during DNS resolution

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7368)
<!-- Reviewable:end -->
