### PR TITLE
docs: Fix sphinx warnings

### DIFF
--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -295,7 +295,7 @@ Deprecated Options
   * ``ct-global-max-entries-other``: Superseded by ``bpf-ct-global-any-max``.
 
   * ``prometheus-serve-addr`` from the ``cilium-metrics-config`` ConfigMap is
-   superseded by ``prometheus-serve-addr``from the ``cilium-config` ConfigMap.
+    superseded by ``prometheus-serve-addr`` from the ``cilium-config`` ConfigMap.
 
   * ``--auto-ipv6-node-routes`` was removed as planned. Use
     ``--auto-direct-node-routes`` instead.


### PR DESCRIPTION
Sphinx complains:

     /srv/Documentation/install/upgrade.rst:298: WARNING: Bullet list ends
    without a blank line; unexpected unindent.
     /srv/Documentation/install/upgrade.rst:298: WARNING: Inline literal
    start-string without end-string.
     /srv/Documentation/install/upgrade.rst:298: WARNING: Inline literal
    start-string without end-string.

Fix it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7369)
<!-- Reviewable:end -->
