### PR TITLE
loader: Add more detailed datapath load metrics

### DIFF
--- a/pkg/datapath/loader/metrics.go
+++ b/pkg/datapath/loader/metrics.go
@@ -22,11 +22,17 @@ import (
 // load operations.
 type SpanStat struct {
 	bpfCompilation spanstat.SpanStat
+	bpfWaitForELF  spanstat.SpanStat
+	bpfWriteELF    spanstat.SpanStat
+	bpfLoadProg    spanstat.SpanStat
 }
 
 // GetMap returns a map of statistic names to stats
 func (s *SpanStat) GetMap() map[string]*spanstat.SpanStat {
 	return map[string]*spanstat.SpanStat{
 		"bpfCompilation": &s.bpfCompilation,
+		"bpfWaitForELF":  &s.bpfWaitForELF,
+		"bpfWriteELF":    &s.bpfWriteELF,
+		"bpfLoadProg":    &s.bpfLoadProg,
 	}
 }

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -489,7 +489,7 @@ func (e *Endpoint) realizeBPFState(regenContext *regenerationContext) (compilati
 			e.getLogger().WithError(err).Info("Rewrote endpoint BPF program")
 			compilationExecuted = true
 		} else { // RegenerateWithDatapathLoad
-			err = loader.ReloadDatapath(datapathRegenCtxt.completionCtx, datapathRegenCtxt.epInfoCache)
+			err = loader.ReloadDatapath(datapathRegenCtxt.completionCtx, datapathRegenCtxt.epInfoCache, &stats.datapathRealization)
 			e.getLogger().WithError(err).Info("Reloaded endpoint BPF program")
 		}
 		close(closeChan)


### PR DESCRIPTION
Count time spent on a few new loader cases:
* bpfWaitForELF - Time waiting for a template to be built
* bpfWriteELF   - Time to rewrite endpoint ELF from template
* bpfLoadProg   - Time to load program into kernel

Open to opinions on whether these are all necessary. `bpfWaitForELF` could tell when everyone is blocking on a template build. `bpfWriteELF` could highlight disk failure. `bpfLoadProg` informs us how long we spend loading programs into the kernel and how long the kernel verifier takes to validate the program (plus things like attach qdisc to the device).

Examples:

```
$ cilium metrics list | grep bpf | grep regen
cilium_endpoint_regeneration_time_stats_seconds scope="bpfCompilation" status="success" 0.872061
cilium_endpoint_regeneration_time_stats_seconds scope="bpfLoadProg" status="success"    0.199416
cilium_endpoint_regeneration_time_stats_seconds scope="bpfWaitForELF" status="success"  0.872430
cilium_endpoint_regeneration_time_stats_seconds scope="bpfWriteELF" status="success"    0.000533
```

In this case, Cilium was just started up with one endpoint so the
`bpfWaitForELF` is similar to `bpfCompilation`, because that endpoint
was waiting for the template to be compiled. Subsequent regenerations
would expect `bpfWaitForELF` to approach zero cost as the template is
cached.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7372)
<!-- Reviewable:end -->
