### PR TITLE
k8s: use force JSON patch for CNP status

### DIFF
--- a/pkg/k8s/cnp.go
+++ b/pkg/k8s/cnp.go
@@ -314,7 +314,7 @@ func (c *CNPStatusUpdateContext) update(cnp *cilium_v2.CiliumNetworkPolicy, enfo
 	ns := k8sUtils.ExtractNamespace(&cnp.ObjectMeta)
 
 	switch {
-	case ciliumPatchStatusVerConstr.Check(c.K8sServerVer):
+	case ciliumPatchStatusVerConstr.Check(c.K8sServerVer) || option.Config.K8sForceJSONPatch:
 		// This is a JSON Patch [RFC 6902] used to create the `/status/nodes`
 		// field in the CNP. If we don't create, replacing the status for this
 		// node will fail as the path does not exist.


### PR DESCRIPTION
Fixes: c24a6a5b25f6 ("k8s: add hidden option to use JSONPatch to update CNP and CEP status")
Signed-off-by: André Martins <andre@cilium.dev>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7378)
<!-- Reviewable:end -->
