### PR TITLE
endpoint: metrics: Add policy regeneration time stats

### DIFF
--- a/Documentation/configuration/metrics.rst
+++ b/Documentation/configuration/metrics.rst
@@ -88,6 +88,7 @@ Policy
 * ``policy_regeneration_total``: Total number of policies regenerated successfully
 * ``policy_regeneration_seconds_total``: Total sum of successful policy regeneration times
 * ``policy_regeneration_square_seconds_total``: Total sum of squares of successful policy regeneration times
+* ``policy_regeneration_time_stats_seconds``: Policy regeneration time stats labeled by the scope.
 * ``policy_max_revision``: Highest policy revision number in the agent
 * ``policy_import_errors``: Number of times a policy import has failed
 * ``policy_endpoint_enforcement_status``: Number of endpoints labeled by policy enforcement status.

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -225,20 +225,29 @@ var (
 		Help:      "Total number of successful policy regenerations",
 	})
 
+	// Deprecated: this metric will be removed in Cilium 1.6
 	// PolicyRegenerationTime is the total time taken to generate policies
 	PolicyRegenerationTime = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: Namespace,
 		Name:      "policy_regeneration_seconds_total",
-		Help:      "Total sum of successful policy regeneration times",
+		Help:      "Total sum of successful policy regeneration times (Deprecated)",
 	})
 
+	// Deprecated: this metric will be removed in Cilium 1.6
 	// PolicyRegenerationTimeSquare is the sum of squares of total time taken
 	// to generate policies
 	PolicyRegenerationTimeSquare = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: Namespace,
 		Name:      "policy_regeneration_square_seconds_total",
-		Help:      "Total sum of squares of successful policy regeneration times",
+		Help:      "Total sum of squares of successful policy regeneration times (Deprecated)",
 	})
+
+	// PolicyRegenerationTimeStats is the total time taken to generate policies
+	PolicyRegenerationTimeStats = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: Namespace,
+		Name:      "policy_regeneration_time_stats_seconds",
+		Help:      "Policy regeneration time stats labeled by the scope",
+	}, []string{LabelScope, LabelStatus})
 
 	// PolicyRevision is the current policy revision number for this agent
 	PolicyRevision = prometheus.NewGauge(prometheus.GaugeOpts{
@@ -592,6 +601,7 @@ func init() {
 	MustRegister(PolicyRegenerationCount)
 	MustRegister(PolicyRegenerationTime)
 	MustRegister(PolicyRegenerationTimeSquare)
+	MustRegister(PolicyRegenerationTimeStats)
 	MustRegister(PolicyRevision)
 	MustRegister(PolicyImportErrors)
 	MustRegister(PolicyEndpointStatus)


### PR DESCRIPTION
This change deprecates the following metrics (which are going to be
removed in Cilium 1.6):
- `policy_regeneration_seconds_total`
- `policy_regeneration_square_seconds_total`

And introduces the new metric, `policy_regeneration_time_stats_seconds`,
which is a labeled histogram with duration of each step of policy
regeneration.

Ref: #7229
Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7379)
<!-- Reviewable:end -->
