### PR TITLE
add checks for DryMode in unit tests

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -970,7 +970,7 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 	// Kubernetes apiserver and serving the API to ensure service IDs are
 	// not changing across restarts or that a new service could accidentally
 	// use an existing service ID.
-	if option.Config.RestoreState {
+	if option.Config.RestoreState && !option.Config.DryMode {
 		bootstrapStats.restore.Start()
 		restoreServiceIDs()
 		bootstrapStats.restore.End(true)
@@ -1561,6 +1561,9 @@ func (d *Daemon) GetServiceList() []*models.Service {
 
 // SendNotification sends an agent notification to the monitor
 func (d *Daemon) SendNotification(typ monitorAPI.AgentNotification, text string) error {
+	if option.Config.DryMode {
+		return nil
+	}
 	event := monitorAPI.AgentNotify{Type: typ, Text: text}
 	return d.nodeMonitor.SendEvent(monitorAPI.MessageTypeAgent, event)
 }

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -73,9 +73,16 @@ func (d *Daemon) restoreOldEndpoints(dir string, clean bool) (*endpointRestoreSt
 
 	log.Info("Restoring endpoints...")
 
-	existingEndpoints, err := lxcmap.DumpToMap()
-	if err != nil {
-		log.WithError(err).Warning("Unable to open endpoint map while restoring. Skipping cleanup of endpoint map on startup")
+	var (
+		existingEndpoints map[string]*lxcmap.EndpointInfo
+		err               error
+	)
+
+	if !option.Config.DryMode {
+		existingEndpoints, err = lxcmap.DumpToMap()
+		if err != nil {
+			log.WithError(err).Warning("Unable to open endpoint map while restoring. Skipping cleanup of endpoint map on startup")
+		}
 	}
 
 	dirFiles, err := ioutil.ReadDir(dir)

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -530,14 +530,16 @@ func (e *Endpoint) runPreCompilationSteps(owner Owner, regenContext *regeneratio
 	// pre-existing connections using that IP are now invalid.
 	if !e.ctCleaned {
 		go func() {
-			ipv4 := option.Config.EnableIPv4
-			ipv6 := option.Config.EnableIPv6
-			created := ctmap.Exists(nil, ipv4, ipv6)
-			if e.ConntrackLocal() {
-				created = ctmap.Exists(e, ipv4, ipv6)
-			}
-			if created {
-				e.scrubIPsInConntrackTable()
+			if !option.Config.DryMode {
+				ipv4 := option.Config.EnableIPv4
+				ipv6 := option.Config.EnableIPv6
+				created := ctmap.Exists(nil, ipv4, ipv6)
+				if e.ConntrackLocal() {
+					created = ctmap.Exists(e, ipv4, ipv6)
+				}
+				if created {
+					e.scrubIPsInConntrackTable()
+				}
 			}
 			close(datapathRegenCtxt.ctCleaned)
 		}()

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1299,7 +1299,7 @@ func (e *Endpoint) LeaveLocked(owner Owner, proxyWaitGroup *completion.WaitGroup
 		e.dnsHistoryTrigger.Shutdown()
 	}
 
-	if !e.ConntrackLocalLocked() {
+	if !e.ConntrackLocalLocked() && !option.Config.DryMode {
 		e.scrubIPsInConntrackTableLocked()
 	}
 

--- a/pkg/kvstore/store/store.go
+++ b/pkg/kvstore/store/store.go
@@ -460,6 +460,7 @@ func (s *SharedStore) watcher(listDone chan bool) {
 			case kvstore.EventTypeDelete:
 				if localKey := s.lookupLocalKey(keyName); localKey != nil {
 					logger.Warning("Received delete event for local key. Re-creating the key in the kvstore")
+
 					s.syncLocalKey(localKey)
 				} else {
 					s.deleteKey(keyName)


### PR DESCRIPTION
Wrap certain conditions / operations around `DryMode` being enabled to reduce
the amount of warnings during the unit tests for operations revolving around
filesystem interactions, BPF filesystem being mounted, etc.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7384)
<!-- Reviewable:end -->
