### PR TITLE
kvstore: Make status check interval cluster size dependant

### DIFF
--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -1127,15 +1127,17 @@ func runDaemon() {
 	// synced unless we setup the kvstore at the same time.
 	k8sCachesSynced := d.initK8sSubsystem()
 
+	goopts := &kvstore.ExtraOptions{
+		ClusterSizeDependantInterval: d.nodeDiscovery.Manager.ClusterSizeDependantInterval,
+	}
+
 	// If K8s is enabled we can do the service translation automagically by
 	// looking at services from k8s and retrieve the service IP from that.
 	// This makes cilium to not depend on kube dns to interact with etcd
-	var goopts *kvstore.ExtraOptions
 	if k8s.IsEnabled() && kvstore.IsEtcdOperator(option.Config.KVStore, option.Config.KVStoreOpt, option.Config.K8sNamespace) {
 		// Wait services and endpoints cache are synced with k8s before setting
 		// up etcd.
 		d.waitForCacheSync(k8sAPIGroupServiceV1Core, k8sAPIGroupEndpointV1Core)
-		goopts = &kvstore.ExtraOptions{}
 		log := log.WithField(logfields.LogSubsys, "etcd")
 		goopts.DialOption = []grpc.DialOption{
 			grpc.WithDialer(func(s string, duration time.Duration) (conn net.Conn, e error) {

--- a/pkg/kvstore/client.go
+++ b/pkg/kvstore/client.go
@@ -28,8 +28,8 @@ var (
 	defaultClientSet = make(chan struct{})
 )
 
-func initClient(module backendModule) error {
-	c, errChan := module.newClient()
+func initClient(module backendModule, opts *ExtraOptions) error {
+	c, errChan := module.newClient(opts)
 	if c == nil {
 		err := <-errChan
 		log.WithError(err).Fatalf("Unable to create etcd client")
@@ -85,5 +85,5 @@ func NewClient(selectedBackend string, opts map[string]string, options *ExtraOpt
 		return nil, errChan
 	}
 
-	return module.newClient()
+	return module.newClient(options)
 }

--- a/pkg/kvstore/config.go
+++ b/pkg/kvstore/config.go
@@ -95,7 +95,7 @@ func setup(selectedBackend string, opts map[string]string, goOpts *ExtraOptions)
 
 	selectedModule = module.getName()
 
-	return initClient(module)
+	return initClient(module, goOpts)
 }
 
 // Setup sets up the key-value store specified in kvStore and configures it

--- a/pkg/kvstore/consul_test.go
+++ b/pkg/kvstore/consul_test.go
@@ -78,7 +78,7 @@ func TestConsulClientOk(t *testing.T) {
 
 	_, err := newConsulClient(&consulAPI.Config{
 		Address: ":8000",
-	})
+	}, nil)
 
 	select {
 	case <-doneC:

--- a/pkg/kvstore/dummy.go
+++ b/pkg/kvstore/dummy.go
@@ -23,7 +23,7 @@ func SetupDummy(dummyBackend string) {
 
 	module.setConfigDummy()
 
-	if err := initClient(module); err != nil {
+	if err := initClient(module, nil); err != nil {
 		log.WithError(err).Panic("Unable to initialize kvstore client")
 	}
 }


### PR DESCRIPTION
The current interval of 5 seconds can result in considerable load on etcd for
very large clusters. Make the interval dependent on the cluster size but
continue to stick to a shorter interval during times of connectivity issues to
keep the delay for establishing or regaining connectivity  short.

Fixes: #7377

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7389)
<!-- Reviewable:end -->
