### PR TITLE
Daemon/PolicyAdd lock policyRepo to avoid fqdn races.

### DIFF
--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -192,6 +192,7 @@ func (d *Daemon) PolicyAdd(rules policyAPI.Rules, opts *AddOptions) (newRev uint
 	} else {
 		log.WithField(logfields.CiliumNetworkPolicy, rules.String()).Info("Policy Add Request")
 	}
+
 	// These must be marked before actually adding them to the repository since a
 	// copy may be made and we won't be able to add the ToFQDN tracking labels
 	d.dnsRuleGen.MarkToFQDNRules(rules)
@@ -224,7 +225,7 @@ func (d *Daemon) PolicyAdd(rules policyAPI.Rules, opts *AddOptions) (newRev uint
 		metrics.PolicyImportErrors.Inc()
 		log.WithError(err).WithField("prefixes", prefixes).Warn(
 			"Failed to allocate identities for CIDRs during policy add")
-		return d.policy.GetRevision(), err
+		return 0, err
 	}
 
 	d.policy.Mutex.Lock()
@@ -252,6 +253,14 @@ func (d *Daemon) PolicyAdd(rules policyAPI.Rules, opts *AddOptions) (newRev uint
 		}
 	}
 	newRev = d.policy.AddListLocked(rules)
+
+	// The rules are added, we can begin ToFQDN DNS polling for them
+	// Note: api.FQDNSelector.sanitize checks that the matchName entries are
+	// valid. This error should never happen (of course).
+	if err := d.dnsRuleGen.StartManageDNSName(rules); err != nil {
+		log.WithError(err).Warn("Error trying to manage rules during PolicyAdd")
+	}
+
 	d.policy.Mutex.Unlock()
 
 	// Begin tracking the time taken to deploy newRev to the datapath. The start
@@ -275,13 +284,6 @@ func (d *Daemon) PolicyAdd(rules policyAPI.Rules, opts *AddOptions) (newRev uint
 		log.WithField("prefixes", removedPrefixes).Debug("Decrementing replaced CIDR refcounts when adding rules")
 		ipcache.ReleaseCIDRs(removedPrefixes)
 		d.prefixLengths.Delete(removedPrefixes)
-	}
-
-	// The rules are added, we can begin ToFQDN DNS polling for them
-	// Note: api.FQDNSelector.sanitize checks that the matchName entries are
-	// valid. This error should never happen (of course).
-	if err := d.dnsRuleGen.StartManageDNSName(rules); err != nil {
-		log.WithError(err).Warn("Error trying to manage rules during PolicyAdd")
 	}
 
 	logger.WithField(logfields.PolicyRevision, newRev).Info("Policy imported via API, recalculating...")


### PR DESCRIPTION
This is an small backport to fix the FQDN race found in the issue #7105
and largely discussed in PR #7220. Due in master a new behaviour will be
used that cannot be backported to 1.4, fix the issue in 1.4 with a
specific commit.

This commit will lock PolicyRepo in the start, so rules are never going
to be overwritted by Fqdn GeneratedRule callback.

PR: https://github.com/cilium/cilium/pull/7220

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7390)
<!-- Reviewable:end -->
