### PR TITLE
node: Use default kvstore synchronization interval

### DIFF
--- a/pkg/node/store/store.go
+++ b/pkg/node/store/store.go
@@ -16,7 +16,6 @@ package store
 
 import (
 	"path"
-	"time"
 
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
@@ -85,10 +84,9 @@ func (nr *NodeRegistrar) RegisterNode(n *node.Node, manager NodeManager) error {
 
 	// Join the shared store holding node information of entire cluster
 	store, err := store.JoinSharedStore(store.Configuration{
-		Prefix:                  NodeStorePrefix,
-		KeyCreator:              KeyCreator,
-		SynchronizationInterval: time.Minute,
-		Observer:                NewNodeObserver(manager),
+		Prefix:     NodeStorePrefix,
+		KeyCreator: KeyCreator,
+		Observer:   NewNodeObserver(manager),
 	})
 
 	if err != nil {


### PR DESCRIPTION
Use the default 5 minute interval that can be changed with the
`--kvstore-periodic-sync` option.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7391)
<!-- Reviewable:end -->
