### PR TITLE
kvstore: forcefully close etcd session on error

### DIFF
--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -243,6 +243,24 @@ func (e *etcdClient) GetLeaseID() client.LeaseID {
 	return l
 }
 
+// checkSession verifies if the lease is still valid from the return error of
+// an etcd API call. If the error explicitly states that a lease was not found
+// we mark the session has an orphan for this etcd client. If we would not mark
+// it as an Orphan() the session would be considered expired after the leaseTTL
+// By make it orphan we guarantee the session will be marked to be renewed.
+func (e *etcdClient) checkSession(err error) {
+	if err == v3rpcErrors.ErrLeaseNotFound {
+		e.closeSession()
+	}
+}
+
+// closeSession closes the current session.
+func (e *etcdClient) closeSession() {
+	e.RWMutex.RLock()
+	e.session.Orphan()
+	e.RWMutex.RUnlock()
+}
+
 func (e *etcdClient) renewSession() error {
 	<-e.firstSession
 	<-e.session.Done()
@@ -701,6 +719,7 @@ func (e *etcdClient) Update(ctx context.Context, key string, value []byte, lease
 	if lease {
 		duration := spanstat.Start()
 		_, err := e.client.Put(ctx, key, string(value), client.WithLease(e.GetLeaseID()))
+		e.checkSession(err)
 		increaseMetric(key, metricSet, "Update", duration.EndError(err).Total(), err)
 		return Hint(err)
 	}
@@ -719,6 +738,7 @@ func (e *etcdClient) CreateOnly(ctx context.Context, key string, value []byte, l
 	txnresp, err := e.client.Txn(ctx).If(cond).Then(*req).Commit()
 	increaseMetric(key, metricSet, "CreateOnly", duration.EndError(err).Total(), err)
 	if err != nil {
+		e.checkSession(err)
 		return Hint(err)
 	}
 
@@ -737,6 +757,7 @@ func (e *etcdClient) CreateIfExists(condKey, key string, value []byte, lease boo
 	txnresp, err := e.client.Txn(ctx.TODO()).If(cond).Then(*req).Commit()
 	increaseMetric(key, metricSet, "CreateIfExists", duration.EndError(err).Total(), err)
 	if err != nil {
+		e.checkSession(err)
 		return Hint(err)
 	}
 


### PR DESCRIPTION
If etcd returns an error of lease not found we need to close the session
so it gets renewed automatically.

Signed-off-by: André Martins <andre@cilium.dev>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7394)
<!-- Reviewable:end -->
