### PR TITLE
pkg/kvstore: attempt to stop giving LeaseIDs for a closed session

### DIFF
--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -246,15 +246,20 @@ func (e *etcdClient) GetLeaseID() client.LeaseID {
 func (e *etcdClient) renewSession() error {
 	<-e.firstSession
 	<-e.session.Done()
+	// This is an attempt to avoid concurrent access of a session that was
+	// already expired. It's not perfect as there is still a period between the
+	// e.session.Done() is closed and the e.Lock() is held where parallel go
+	// routines can get a lease ID of an already expired lease.
+	e.Lock()
 
 	newSession, err := concurrency.NewSession(e.client, concurrency.WithTTL(int(LeaseTTL.Seconds())))
 	if err != nil {
+		e.UnlockIgnoreTime()
 		return fmt.Errorf("Unable to renew etcd session: %s", err)
 	}
 
-	e.Lock()
 	e.session = newSession
-	e.Unlock()
+	e.UnlockIgnoreTime()
 
 	e.getLogger().WithField(fieldSession, newSession).Debug("Renewing etcd session")
 


### PR DESCRIPTION
There is a race between the `e.Session.Done` when is closed and the
time a new session is assigned to `e.session` which can cause new
requests to etcd to use an already expired lease. Although this change
does not fix the issue completly it helps by making the race window to
be smaller.

Signed-off-by: André Martins <andre@cilium.dev>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7398)
<!-- Reviewable:end -->
