### PR TITLE
fix: enable auto-compaction of etcd by default

### DIFF
--- a/examples/kubernetes/1.10/cilium-containerd.yaml
+++ b/examples/kubernetes/1.10/cilium-containerd.yaml
@@ -730,6 +730,10 @@ spec:
       - command:
         - /usr/bin/cilium-etcd-operator
         env:
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_MODE
+          value: "revision"
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_RETENTION
+          value: "25000"
         - name: CILIUM_ETCD_OPERATOR_CLUSTER_DOMAIN
           value: cluster.local
         - name: CILIUM_ETCD_OPERATOR_ETCD_CLUSTER_SIZE

--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -738,6 +738,10 @@ spec:
       - command:
         - /usr/bin/cilium-etcd-operator
         env:
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_MODE
+          value: "revision"
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_RETENTION
+          value: "25000"
         - name: CILIUM_ETCD_OPERATOR_CLUSTER_DOMAIN
           value: cluster.local
         - name: CILIUM_ETCD_OPERATOR_ETCD_CLUSTER_SIZE

--- a/examples/kubernetes/1.10/cilium-etcd-operator.yaml
+++ b/examples/kubernetes/1.10/cilium-etcd-operator.yaml
@@ -28,6 +28,10 @@ spec:
       - command:
         - /usr/bin/cilium-etcd-operator
         env:
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_MODE
+          value: "revision"
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_RETENTION
+          value: "25000"
         - name: CILIUM_ETCD_OPERATOR_CLUSTER_DOMAIN
           value: cluster.local
         - name: CILIUM_ETCD_OPERATOR_ETCD_CLUSTER_SIZE

--- a/examples/kubernetes/1.10/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.10/cilium-with-node-init.yaml
@@ -737,6 +737,10 @@ spec:
       - command:
         - /usr/bin/cilium-etcd-operator
         env:
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_MODE
+          value: "revision"
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_RETENTION
+          value: "25000"
         - name: CILIUM_ETCD_OPERATOR_CLUSTER_DOMAIN
           value: cluster.local
         - name: CILIUM_ETCD_OPERATOR_ETCD_CLUSTER_SIZE

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -737,6 +737,10 @@ spec:
       - command:
         - /usr/bin/cilium-etcd-operator
         env:
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_MODE
+          value: "revision"
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_RETENTION
+          value: "25000"
         - name: CILIUM_ETCD_OPERATOR_CLUSTER_DOMAIN
           value: cluster.local
         - name: CILIUM_ETCD_OPERATOR_ETCD_CLUSTER_SIZE

--- a/examples/kubernetes/1.11/cilium-containerd.yaml
+++ b/examples/kubernetes/1.11/cilium-containerd.yaml
@@ -732,6 +732,10 @@ spec:
       - command:
         - /usr/bin/cilium-etcd-operator
         env:
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_MODE
+          value: "revision"
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_RETENTION
+          value: "25000"
         - name: CILIUM_ETCD_OPERATOR_CLUSTER_DOMAIN
           value: cluster.local
         - name: CILIUM_ETCD_OPERATOR_ETCD_CLUSTER_SIZE

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -731,6 +731,10 @@ spec:
       - command:
         - /usr/bin/cilium-etcd-operator
         env:
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_MODE
+          value: "revision"
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_RETENTION
+          value: "25000"
         - name: CILIUM_ETCD_OPERATOR_CLUSTER_DOMAIN
           value: cluster.local
         - name: CILIUM_ETCD_OPERATOR_ETCD_CLUSTER_SIZE

--- a/examples/kubernetes/1.11/cilium-etcd-operator.yaml
+++ b/examples/kubernetes/1.11/cilium-etcd-operator.yaml
@@ -28,6 +28,10 @@ spec:
       - command:
         - /usr/bin/cilium-etcd-operator
         env:
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_MODE
+          value: "revision"
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_RETENTION
+          value: "25000"
         - name: CILIUM_ETCD_OPERATOR_CLUSTER_DOMAIN
           value: cluster.local
         - name: CILIUM_ETCD_OPERATOR_ETCD_CLUSTER_SIZE

--- a/examples/kubernetes/1.11/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.11/cilium-with-node-init.yaml
@@ -737,6 +737,10 @@ spec:
       - command:
         - /usr/bin/cilium-etcd-operator
         env:
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_MODE
+          value: "revision"
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_RETENTION
+          value: "25000"
         - name: CILIUM_ETCD_OPERATOR_CLUSTER_DOMAIN
           value: cluster.local
         - name: CILIUM_ETCD_OPERATOR_ETCD_CLUSTER_SIZE

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -739,6 +739,10 @@ spec:
       - command:
         - /usr/bin/cilium-etcd-operator
         env:
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_MODE
+          value: "revision"
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_RETENTION
+          value: "25000"
         - name: CILIUM_ETCD_OPERATOR_CLUSTER_DOMAIN
           value: cluster.local
         - name: CILIUM_ETCD_OPERATOR_ETCD_CLUSTER_SIZE

--- a/examples/kubernetes/1.12/cilium-containerd.yaml
+++ b/examples/kubernetes/1.12/cilium-containerd.yaml
@@ -732,6 +732,10 @@ spec:
       - command:
         - /usr/bin/cilium-etcd-operator
         env:
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_MODE
+          value: "revision"
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_RETENTION
+          value: "25000"
         - name: CILIUM_ETCD_OPERATOR_CLUSTER_DOMAIN
           value: cluster.local
         - name: CILIUM_ETCD_OPERATOR_ETCD_CLUSTER_SIZE

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -731,6 +731,10 @@ spec:
       - command:
         - /usr/bin/cilium-etcd-operator
         env:
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_MODE
+          value: "revision"
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_RETENTION
+          value: "25000"
         - name: CILIUM_ETCD_OPERATOR_CLUSTER_DOMAIN
           value: cluster.local
         - name: CILIUM_ETCD_OPERATOR_ETCD_CLUSTER_SIZE

--- a/examples/kubernetes/1.12/cilium-etcd-operator.yaml
+++ b/examples/kubernetes/1.12/cilium-etcd-operator.yaml
@@ -28,6 +28,10 @@ spec:
       - command:
         - /usr/bin/cilium-etcd-operator
         env:
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_MODE
+          value: "revision"
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_RETENTION
+          value: "25000"
         - name: CILIUM_ETCD_OPERATOR_CLUSTER_DOMAIN
           value: cluster.local
         - name: CILIUM_ETCD_OPERATOR_ETCD_CLUSTER_SIZE

--- a/examples/kubernetes/1.12/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.12/cilium-with-node-init.yaml
@@ -737,6 +737,10 @@ spec:
       - command:
         - /usr/bin/cilium-etcd-operator
         env:
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_MODE
+          value: "revision"
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_RETENTION
+          value: "25000"
         - name: CILIUM_ETCD_OPERATOR_CLUSTER_DOMAIN
           value: cluster.local
         - name: CILIUM_ETCD_OPERATOR_ETCD_CLUSTER_SIZE

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -739,6 +739,10 @@ spec:
       - command:
         - /usr/bin/cilium-etcd-operator
         env:
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_MODE
+          value: "revision"
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_RETENTION
+          value: "25000"
         - name: CILIUM_ETCD_OPERATOR_CLUSTER_DOMAIN
           value: cluster.local
         - name: CILIUM_ETCD_OPERATOR_ETCD_CLUSTER_SIZE

--- a/examples/kubernetes/1.13/cilium-containerd.yaml
+++ b/examples/kubernetes/1.13/cilium-containerd.yaml
@@ -732,6 +732,10 @@ spec:
       - command:
         - /usr/bin/cilium-etcd-operator
         env:
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_MODE
+          value: "revision"
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_RETENTION
+          value: "25000"
         - name: CILIUM_ETCD_OPERATOR_CLUSTER_DOMAIN
           value: cluster.local
         - name: CILIUM_ETCD_OPERATOR_ETCD_CLUSTER_SIZE

--- a/examples/kubernetes/1.13/cilium-crio.yaml
+++ b/examples/kubernetes/1.13/cilium-crio.yaml
@@ -731,6 +731,10 @@ spec:
       - command:
         - /usr/bin/cilium-etcd-operator
         env:
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_MODE
+          value: "revision"
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_RETENTION
+          value: "25000"
         - name: CILIUM_ETCD_OPERATOR_CLUSTER_DOMAIN
           value: cluster.local
         - name: CILIUM_ETCD_OPERATOR_ETCD_CLUSTER_SIZE

--- a/examples/kubernetes/1.13/cilium-etcd-operator.yaml
+++ b/examples/kubernetes/1.13/cilium-etcd-operator.yaml
@@ -28,6 +28,10 @@ spec:
       - command:
         - /usr/bin/cilium-etcd-operator
         env:
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_MODE
+          value: "revision"
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_RETENTION
+          value: "25000"
         - name: CILIUM_ETCD_OPERATOR_CLUSTER_DOMAIN
           value: cluster.local
         - name: CILIUM_ETCD_OPERATOR_ETCD_CLUSTER_SIZE

--- a/examples/kubernetes/1.13/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.13/cilium-with-node-init.yaml
@@ -737,6 +737,10 @@ spec:
       - command:
         - /usr/bin/cilium-etcd-operator
         env:
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_MODE
+          value: "revision"
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_RETENTION
+          value: "25000"
         - name: CILIUM_ETCD_OPERATOR_CLUSTER_DOMAIN
           value: cluster.local
         - name: CILIUM_ETCD_OPERATOR_ETCD_CLUSTER_SIZE

--- a/examples/kubernetes/1.13/cilium.yaml
+++ b/examples/kubernetes/1.13/cilium.yaml
@@ -739,6 +739,10 @@ spec:
       - command:
         - /usr/bin/cilium-etcd-operator
         env:
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_MODE
+          value: "revision"
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_RETENTION
+          value: "25000"
         - name: CILIUM_ETCD_OPERATOR_CLUSTER_DOMAIN
           value: cluster.local
         - name: CILIUM_ETCD_OPERATOR_ETCD_CLUSTER_SIZE

--- a/examples/kubernetes/1.8/cilium-containerd.yaml
+++ b/examples/kubernetes/1.8/cilium-containerd.yaml
@@ -730,6 +730,10 @@ spec:
       - command:
         - /usr/bin/cilium-etcd-operator
         env:
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_MODE
+          value: "revision"
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_RETENTION
+          value: "25000"
         - name: CILIUM_ETCD_OPERATOR_CLUSTER_DOMAIN
           value: cluster.local
         - name: CILIUM_ETCD_OPERATOR_ETCD_CLUSTER_SIZE

--- a/examples/kubernetes/1.8/cilium-crio.yaml
+++ b/examples/kubernetes/1.8/cilium-crio.yaml
@@ -738,6 +738,10 @@ spec:
       - command:
         - /usr/bin/cilium-etcd-operator
         env:
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_MODE
+          value: "revision"
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_RETENTION
+          value: "25000"
         - name: CILIUM_ETCD_OPERATOR_CLUSTER_DOMAIN
           value: cluster.local
         - name: CILIUM_ETCD_OPERATOR_ETCD_CLUSTER_SIZE

--- a/examples/kubernetes/1.8/cilium-etcd-operator.yaml
+++ b/examples/kubernetes/1.8/cilium-etcd-operator.yaml
@@ -28,6 +28,10 @@ spec:
       - command:
         - /usr/bin/cilium-etcd-operator
         env:
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_MODE
+          value: "revision"
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_RETENTION
+          value: "25000"
         - name: CILIUM_ETCD_OPERATOR_CLUSTER_DOMAIN
           value: cluster.local
         - name: CILIUM_ETCD_OPERATOR_ETCD_CLUSTER_SIZE

--- a/examples/kubernetes/1.8/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.8/cilium-with-node-init.yaml
@@ -737,6 +737,10 @@ spec:
       - command:
         - /usr/bin/cilium-etcd-operator
         env:
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_MODE
+          value: "revision"
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_RETENTION
+          value: "25000"
         - name: CILIUM_ETCD_OPERATOR_CLUSTER_DOMAIN
           value: cluster.local
         - name: CILIUM_ETCD_OPERATOR_ETCD_CLUSTER_SIZE

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -737,6 +737,10 @@ spec:
       - command:
         - /usr/bin/cilium-etcd-operator
         env:
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_MODE
+          value: "revision"
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_RETENTION
+          value: "25000"
         - name: CILIUM_ETCD_OPERATOR_CLUSTER_DOMAIN
           value: cluster.local
         - name: CILIUM_ETCD_OPERATOR_ETCD_CLUSTER_SIZE

--- a/examples/kubernetes/1.9/cilium-containerd.yaml
+++ b/examples/kubernetes/1.9/cilium-containerd.yaml
@@ -730,6 +730,10 @@ spec:
       - command:
         - /usr/bin/cilium-etcd-operator
         env:
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_MODE
+          value: "revision"
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_RETENTION
+          value: "25000"
         - name: CILIUM_ETCD_OPERATOR_CLUSTER_DOMAIN
           value: cluster.local
         - name: CILIUM_ETCD_OPERATOR_ETCD_CLUSTER_SIZE

--- a/examples/kubernetes/1.9/cilium-crio.yaml
+++ b/examples/kubernetes/1.9/cilium-crio.yaml
@@ -738,6 +738,10 @@ spec:
       - command:
         - /usr/bin/cilium-etcd-operator
         env:
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_MODE
+          value: "revision"
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_RETENTION
+          value: "25000"
         - name: CILIUM_ETCD_OPERATOR_CLUSTER_DOMAIN
           value: cluster.local
         - name: CILIUM_ETCD_OPERATOR_ETCD_CLUSTER_SIZE

--- a/examples/kubernetes/1.9/cilium-etcd-operator.yaml
+++ b/examples/kubernetes/1.9/cilium-etcd-operator.yaml
@@ -28,6 +28,10 @@ spec:
       - command:
         - /usr/bin/cilium-etcd-operator
         env:
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_MODE
+          value: "revision"
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_RETENTION
+          value: "25000"
         - name: CILIUM_ETCD_OPERATOR_CLUSTER_DOMAIN
           value: cluster.local
         - name: CILIUM_ETCD_OPERATOR_ETCD_CLUSTER_SIZE

--- a/examples/kubernetes/1.9/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.9/cilium-with-node-init.yaml
@@ -737,6 +737,10 @@ spec:
       - command:
         - /usr/bin/cilium-etcd-operator
         env:
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_MODE
+          value: "revision"
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_RETENTION
+          value: "25000"
         - name: CILIUM_ETCD_OPERATOR_CLUSTER_DOMAIN
           value: cluster.local
         - name: CILIUM_ETCD_OPERATOR_ETCD_CLUSTER_SIZE

--- a/examples/kubernetes/1.9/cilium.yaml
+++ b/examples/kubernetes/1.9/cilium.yaml
@@ -737,6 +737,10 @@ spec:
       - command:
         - /usr/bin/cilium-etcd-operator
         env:
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_MODE
+          value: "revision"
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_RETENTION
+          value: "25000"
         - name: CILIUM_ETCD_OPERATOR_CLUSTER_DOMAIN
           value: cluster.local
         - name: CILIUM_ETCD_OPERATOR_ETCD_CLUSTER_SIZE

--- a/examples/kubernetes/README.rst
+++ b/examples/kubernetes/README.rst
@@ -4,7 +4,7 @@ Kubernetes Deployment
 This directory contains all Cilium deployment files that can be used in
 Kubernetes.
 
-Each directory represents a Kubernetes version, from :code:`1.8` to :code:`1.12`,
+Each directory represents a Kubernetes version, from :code:`1.8` to :code:`1.13`,
 and inside each version there is a list of files to deploy Cilium.
 
 The structure directory will be :code:`${k8s_major_version}.${k8s_minor_version}/*.yaml`.
@@ -24,6 +24,8 @@ There are templates for each component to be installed in Kubernetes inside
 the directory :code:`templates`. The components ending with :code:`.sed` will be
 automatically generated based on the template itself and the specific
 :code:`transforms2sed.sed` inside each directory for each Kubernetes version.
+
+To make a change to a template and all versions of Kubernetes run: :code:`CILIUM_VERSION=latest make -C examples/kubernetes clean all`
 
 Files
 -----

--- a/examples/kubernetes/templates/v1/cilium-etcd-operator.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-etcd-operator.yaml.sed
@@ -28,6 +28,10 @@ spec:
       - command:
         - /usr/bin/cilium-etcd-operator
         env:
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_MODE
+          value: "revision"
+        - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_RETENTION
+          value: "25000"
         - name: CILIUM_ETCD_OPERATOR_CLUSTER_DOMAIN
           value: cluster.local
         - name: CILIUM_ETCD_OPERATOR_ETCD_CLUSTER_SIZE


### PR DESCRIPTION
Enable auto-compaction of etcd to prevent mvcc: database space exceeded errors

```release-note
cilium-etcd-operator: enable auto-compaction by default
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7399)
<!-- Reviewable:end -->
