### PR TITLE
[v1.4] backports 2019 03 14

### DIFF
--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1261,11 +1261,25 @@ func cnpNodeStatusController(ciliumV2Store cache.Store, cnp *cilium_v2.CiliumNet
 	return overallErr
 }
 
-func updateCNPNodeStatus(cnp *cilium_v2.CiliumNetworkPolicy, enforcing, ok bool, err error, rev uint64, annotations map[string]string) error {
+func updateCNPNodeStatus(cnp *cilium_v2.CiliumNetworkPolicy, enforcing, ok bool, err error, rev uint64, cnpAnnotations map[string]string) error {
 	var (
-		cnpns cilium_v2.CiliumNetworkPolicyNodeStatus
-		err2  error
+		cnpns       cilium_v2.CiliumNetworkPolicyNodeStatus
+		err2        error
+		annotations map[string]string
 	)
+
+	switch {
+	case cnpAnnotations == nil:
+		// don't bother doing anything if cnpAnnotations is nil.
+	default:
+		// for all other k8s versions, since the CNP is sent with the
+		// annotations we need to make a deepcopy.
+		m := make(map[string]string, len(cnpAnnotations))
+		for k, v := range cnpAnnotations {
+			m[k] = v
+		}
+		annotations = m
+	}
 
 	if err != nil {
 		cnpns = cilium_v2.CiliumNetworkPolicyNodeStatus{

--- a/operator/k8s_pod_controller.go
+++ b/operator/k8s_pod_controller.go
@@ -55,7 +55,7 @@ func enableUnmanagedKubeDNSController() {
 				}
 
 				for _, pod := range pods.Items {
-					if !pod.Spec.HostNetwork {
+					if pod.Spec.HostNetwork {
 						continue
 					}
 					cep, err := ciliumK8sClient.CiliumV2().CiliumEndpoints(pod.Namespace).Get(pod.Name, metav1.GetOptions{})

--- a/pkg/k8s/factory_functions_test.go
+++ b/pkg/k8s/factory_functions_test.go
@@ -168,6 +168,30 @@ func (s *K8sSuite) Test_equalV2CNP(c *C) {
 			},
 			want: true,
 		},
+		{
+			name: "CNP with different last applied annotations. The are ignored so they should be equal",
+			args: args{
+				o1: &v2.CiliumNetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "rule1",
+						Annotations: map[string]string{
+							core_v1.LastAppliedConfigAnnotation: "foo",
+						},
+					},
+					Spec: &api.Rule{},
+				},
+				o2: &v2.CiliumNetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "rule1",
+						Annotations: map[string]string{
+							core_v1.LastAppliedConfigAnnotation: "bar",
+						},
+					},
+					Spec: &api.Rule{},
+				},
+			},
+			want: true,
+		},
 	}
 	for _, tt := range tests {
 		got := equalV2CNP(tt.args.o1, tt.args.o2)


### PR DESCRIPTION
Backport of 

* PR: 7356 -- k8s: ignore kubectl.kubernetes.io/last-applied-configuration annotation (@aanm) -- https://github.com/cilium/cilium/pull/7356
* PR: 7385 -- operator: do not restart unmanaged hostNetwork pods (@aanm) -- https://github.com/cilium/cilium/pull/7385

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7400)
<!-- Reviewable:end -->
