### PR TITLE
[v1.3] backports 2019 03 14

### DIFF
--- a/pkg/ipcache/kvstore.go
+++ b/pkg/ipcache/kvstore.go
@@ -397,6 +397,9 @@ restart:
 						log.WithError(err).WithField("ip", ip).Warning("Unable to re-create alive ipcache entry")
 					}
 					globalMap.Unlock()
+				} else if _, ok := globalMap.keys[path.Join(IPIdentitiesPath, AddressSpace, ip)]; ok {
+					log.WithField("ip", ip).Warning("Received kvstore delete notification with mismatching key but alive IP. Ignoring")
+					globalMap.Unlock()
 				} else {
 					globalMap.Unlock()
 

--- a/pkg/kvstore/store/store.go
+++ b/pkg/kvstore/store/store.go
@@ -270,6 +270,19 @@ func (s *SharedStore) syncLocalKeys() error {
 	return nil
 }
 
+func (s *SharedStore) lookupLocalKey(name string) LocalKey {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	for _, key := range s.localKeys {
+		if key.GetKeyName() == name {
+			return key
+		}
+	}
+
+	return nil
+}
+
 // UpdateLocalKey adds a key to be synchronized with the kvstore
 func (s *SharedStore) UpdateLocalKey(key LocalKey) {
 	s.mutex.Lock()
@@ -293,13 +306,14 @@ func (s *SharedStore) UpdateLocalKeySync(key LocalKey) error {
 
 // DeleteLocalKey removes a key from being synchronized with the kvstore
 func (s *SharedStore) DeleteLocalKey(key LocalKey) {
-	err := s.backend.Delete(s.keyPath(key))
 	name := key.GetKeyName()
 
 	s.mutex.Lock()
 	_, ok := s.localKeys[name]
 	delete(s.localKeys, name)
 	s.mutex.Unlock()
+
+	err := s.backend.Delete(s.keyPath(key))
 
 	if ok {
 		if err != nil {
@@ -434,7 +448,12 @@ func (s *SharedStore) watcher(listDone chan bool) {
 				}
 
 			case kvstore.EventTypeDelete:
-				s.deleteKey(keyName)
+				if localKey := s.lookupLocalKey(keyName); localKey != nil {
+					logger.Warning("Received delete event for local key. Re-creating the key in the kvstore")
+					s.syncLocalKey(localKey)
+				} else {
+					s.deleteKey(keyName)
+				}
 			}
 		}
 	}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -302,6 +302,9 @@ func (p *Proxy) removeRedirect(id string, wg *completion.WaitGroup) (err error, 
 	// FinalizeFunc.
 	proxyPort := r.ProxyPort
 	finalizeFunc = func() {
+		// break GC loop (implementation may point back to 'r')
+		r.implementation = nil
+
 		if implFinalizeFunc != nil {
 			implFinalizeFunc()
 		}

--- a/proxylib/proxylib_test.go
+++ b/proxylib/proxylib_test.go
@@ -119,8 +119,10 @@ func TestOnNewConnection(t *testing.T) {
 func checkAccessLogs(t *testing.T, logServer *test.AccessLogServer, expPasses, expDrops int) {
 	t.Helper()
 	passes, drops := 0, 0
-	empty := false
-	for !empty {
+	nWaits := 0
+	done := false
+	// Loop until done or when the timeout has ticked 100 times without any logs being received
+	for !done && nWaits < 100 {
 		select {
 		case pblog := <-logServer.Logs:
 			if pblog.EntryType == cilium.EntryType_Denied {
@@ -128,8 +130,16 @@ func checkAccessLogs(t *testing.T, logServer *test.AccessLogServer, expPasses, e
 			} else {
 				passes++
 			}
-		case <-time.After(10 * time.Millisecond):
-			empty = true
+			// Start the timeout again (for upto 5 seconds)
+			nWaits = 0
+		case <-time.After(50 * time.Millisecond):
+			// Count the number of times we have waited since the last log was received
+			nWaits++
+			// Finish when expected number of passes and drops have been collected
+			// and there are no more logs in the channel for 50 milliseconds
+			if passes == expPasses && drops == expDrops {
+				done = true
+			}
 		}
 	}
 


### PR DESCRIPTION
Backport PRs:

 * PR: 7246 -- Protect remaining local keys from kvstore delete events (@tgraf) -- https://github.com/cilium/cilium/pull/7246
 * PR: 7352 -- proxylib: Fix unit test flake when counting access log entries (@jrajahalme) -- https://github.com/cilium/cilium/pull/7352
 * PR: 7360 -- proxy: Break GC loop between Redirect and RedirectImplementation (@jrajahalme) -- https://github.com/cilium/cilium/pull/7360

**Not** backported PRs:

 * PR: 7338 -- test,docs: Vagrant misc updates for net-next. (@brb) -- https://github.com/cilium/cilium/pull/7338
 * PR: 7328 -- endpointmanager: fix IPv6 lookup (@jrajahalme) -- https://github.com/cilium/cilium/pull/7328

@brb we usually don't backport vagrant changes related with dev VM. Please consider removing the needs/backport label from #7338

@jrajahalme #7328 attempts to fix a code path that does not exist. Please consider removing the needs/backport label from #7328 and adding a "Fixes" in the commit message for which a fix is being made to, for example in the commit f55435dc2b6e41e3e1e8e6cb89f7a6436904acd7 which contains a "Fixes" we can see if the commit that introduced the bug exists in the v1.3 branch or not and if needs to be backported to that branch.

@tgraf @jrajahalme please verify if your changes are properly backported.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7401)
<!-- Reviewable:end -->
