### PR TITLE
k8s: Bump k8s version check interval to 15 minutes

### DIFF
--- a/daemon/status.go
+++ b/daemon/status.go
@@ -39,7 +39,7 @@ import (
 const (
 	// k8sVersionCheckInterval is the interval in which the Kubernetes
 	// version is verified even if connectivity is given
-	k8sVersionCheckInterval = 5 * time.Minute
+	k8sVersionCheckInterval = 15 * time.Minute
 
 	// k8sMinimumEventHearbeat is the time interval in which any received
 	// event will be considered proof that the apiserver connectivity is


### PR DESCRIPTION
At 1k nodes, a 5 minute interval still leads to 3.33 apiserver interactions per
second. The health is primarily determined when the last event has been received
so we can be more conservative in forcing a full version check.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7408)
<!-- Reviewable:end -->
