### PR TITLE
k8s: Use node resource from Update() when annotating

### DIFF
--- a/pkg/k8s/annotate.go
+++ b/pkg/k8s/annotate.go
@@ -100,12 +100,15 @@ func (k8sCli K8sClient) AnnotateNode(nodeName string, v4CIDR, v6CIDR *cidr.CIDR,
 		var err error
 
 		for n := 1; n <= maxUpdateRetries; n++ {
-			node, err = GetNode(c, nodeName)
-			switch {
-			case err == nil:
-				_, err = updateNodeAnnotation(c, node, v4CIDR, v6CIDR, v4HealthIP, v6HealthIP, v4CiliumHostIP, v6CiliumHostIP)
-			case errors.IsNotFound(err):
-				err = ErrNilNode
+			if node == nil {
+				node, err = GetNode(c, nodeName)
+				if errors.IsNotFound(err) {
+					err = ErrNilNode
+				}
+			}
+
+			if err == nil && node != nil {
+				node, err = updateNodeAnnotation(c, node, v4CIDR, v6CIDR, v4HealthIP, v6HealthIP, v4CiliumHostIP, v6CiliumHostIP)
 			}
 
 			switch {


### PR DESCRIPTION
Instead of fetching the latest node information from the apiserver on each
retry, use the node resource as returned by Update().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7410)
<!-- Reviewable:end -->
