### PR TITLE
Add table-driven policy rule merge & resolve tests

### DIFF
--- a/daemon/k8s_watcher_test.go
+++ b/daemon/k8s_watcher_test.go
@@ -81,20 +81,23 @@ func (ds *DaemonSuite) Test_addCiliumNetworkPolicyV2(c *C) {
 			setupWanted: func() wanted {
 				r := policy.NewPolicyRepository()
 				r.AddList(api.Rules{
-					{
-						EndpointSelector: api.EndpointSelector{
+					api.NewRule().
+						WithEndpointSelector(api.EndpointSelector{
 							LabelSelector: &metav1.LabelSelector{
 								MatchLabels: map[string]string{
 									"env": "cluster-1",
 									labels.LabelSourceK8s + "." + k8sConst.PodNamespaceLabel: "production",
 								},
 							},
-						},
-						Ingress:     nil,
-						Egress:      nil,
-						Labels:      utils.GetPolicyLabels("production", "db", uuid, utils.ResourceTypeCiliumNetworkPolicy),
-						Description: "",
-					},
+						}).
+						WithIngressRules(nil).
+						WithEgressRules(nil).
+						WithLabels(utils.GetPolicyLabels(
+							"production",
+							"db",
+							uuid,
+							utils.ResourceTypeCiliumNetworkPolicy),
+						),
 				})
 				return wanted{
 					err:  nil,
@@ -150,20 +153,23 @@ func (ds *DaemonSuite) Test_addCiliumNetworkPolicyV2(c *C) {
 			setupWanted: func() wanted {
 				r := policy.NewPolicyRepository()
 				r.AddList(api.Rules{
-					{
-						EndpointSelector: api.EndpointSelector{
+					api.NewRule().
+						WithEndpointSelector(api.EndpointSelector{
 							LabelSelector: &metav1.LabelSelector{
 								MatchLabels: map[string]string{
 									"env": "cluster-1",
 									labels.LabelSourceK8s + "." + k8sConst.PodNamespaceLabel: "production",
 								},
 							},
-						},
-						Ingress:     nil,
-						Egress:      nil,
-						Labels:      utils.GetPolicyLabels("production", "db", uuid, utils.ResourceTypeCiliumNetworkPolicy),
-						Description: "",
-					},
+						}).
+						WithIngressRules(nil).
+						WithEgressRules(nil).
+						WithLabels(utils.GetPolicyLabels(
+							"production",
+							"db",
+							uuid,
+							utils.ResourceTypeCiliumNetworkPolicy,
+						)),
 				})
 				return wanted{
 					err:  nil,
@@ -220,20 +226,18 @@ func (ds *DaemonSuite) Test_addCiliumNetworkPolicyV2(c *C) {
 				lbls := utils.GetPolicyLabels("production", "db", uuid, utils.ResourceTypeCiliumNetworkPolicy)
 				lbls = append(lbls, labels.ParseLabelArray("foo=bar")...)
 				r.AddList(api.Rules{
-					{
-						EndpointSelector: api.EndpointSelector{
+					api.NewRule().
+						WithEndpointSelector(api.EndpointSelector{
 							LabelSelector: &metav1.LabelSelector{
 								MatchLabels: map[string]string{
 									"env": "cluster-1",
 									labels.LabelSourceK8s + "." + k8sConst.PodNamespaceLabel: "production",
 								},
 							},
-						},
-						Ingress:     nil,
-						Egress:      nil,
-						Labels:      lbls,
-						Description: "",
-					},
+						}).
+						WithIngressRules(nil).
+						WithEgressRules(nil).
+						WithLabels(lbls),
 				})
 				return wanted{
 					err:  nil,

--- a/pkg/checker/checker.go
+++ b/pkg/checker/checker.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,9 +29,12 @@ type diffChecker struct {
 // DeepEquals is a GoCheck checker that does a diff between two objects and
 // pretty-prints any difference between the two. It can act as a substitute
 // for DeepEquals.
-var DeepEquals check.Checker = &diffChecker{
-	&check.CheckerInfo{Name: "Diff", Params: []string{"obtained", "expected"}},
-}
+var (
+	defaultParams               = []string{"obtained", "expected"}
+	DeepEquals    check.Checker = &diffChecker{
+		&check.CheckerInfo{Name: "Diff", Params: defaultParams},
+	}
+)
 
 // Check performs a diff between two objects provided as parameters, and
 // returns either true if the objects are identical, or false otherwise. If
@@ -47,4 +50,11 @@ func (checker *diffChecker) Check(params []interface{}, names []string) (result 
 	}
 
 	return false, comparator.CompareWithNames(params[0], params[1], names[0], names[1])
+}
+
+// DeepEqual tests whether two parameters are deeply equal, and returns true if
+// they are. If the objects are not deeply equal, then the second return value
+// includes a json representation of the difference between the parameters.
+func DeepEqual(params ...interface{}) (bool, string) {
+	return DeepEquals.Check(params, defaultParams)
 }

--- a/pkg/k8s/apis/cilium.io/utils/utils_test.go
+++ b/pkg/k8s/apis/cilium.io/utils/utils_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -77,15 +77,16 @@ func Test_ParseToCiliumRule(t *testing.T) {
 					),
 				},
 			},
-			want: &api.Rule{
-				EndpointSelector: api.NewESFromMatchRequirements(
+			want: api.NewRule().WithEndpointSelector(
+				api.NewESFromMatchRequirements(
 					map[string]string{
 						role:      "backend",
 						namespace: "default",
 					},
 					nil,
 				),
-				Labels: labels.LabelArray{
+			).WithLabels(
+				labels.LabelArray{
 					{
 						Key:    "io.cilium.k8s.policy.name",
 						Value:  "parse-in-namespace",
@@ -107,7 +108,7 @@ func Test_ParseToCiliumRule(t *testing.T) {
 						Source: labels.LabelSourceK8s,
 					},
 				},
-			},
+			),
 		},
 		{
 			// When the rule specifies a namespace, it is overridden
@@ -126,15 +127,16 @@ func Test_ParseToCiliumRule(t *testing.T) {
 					),
 				},
 			},
-			want: &api.Rule{
-				EndpointSelector: api.NewESFromMatchRequirements(
+			want: api.NewRule().WithEndpointSelector(
+				api.NewESFromMatchRequirements(
 					map[string]string{
 						role:      "backend",
 						namespace: "default",
 					},
 					nil,
 				),
-				Labels: labels.LabelArray{
+			).WithLabels(
+				labels.LabelArray{
 					{
 						Key:    "io.cilium.k8s.policy.name",
 						Value:  "parse-in-namespace-with-ns-selector",
@@ -156,7 +158,7 @@ func Test_ParseToCiliumRule(t *testing.T) {
 						Source: labels.LabelSourceK8s,
 					},
 				},
-			},
+			),
 		},
 		{
 			// Don't insert a namespace selection when the rule
@@ -175,8 +177,8 @@ func Test_ParseToCiliumRule(t *testing.T) {
 					),
 				},
 			},
-			want: &api.Rule{
-				EndpointSelector: api.NewESFromMatchRequirements(
+			want: api.NewRule().WithEndpointSelector(
+				api.NewESFromMatchRequirements(
 					map[string]string{
 						role:       "backend",
 						podInitLbl: "",
@@ -185,7 +187,8 @@ func Test_ParseToCiliumRule(t *testing.T) {
 					},
 					nil,
 				),
-				Labels: labels.LabelArray{
+			).WithLabels(
+				labels.LabelArray{
 					{
 						Key:    "io.cilium.k8s.policy.name",
 						Value:  "parse-init-policy",
@@ -207,7 +210,7 @@ func Test_ParseToCiliumRule(t *testing.T) {
 						Source: labels.LabelSourceK8s,
 					},
 				},
-			},
+			),
 		},
 		{
 			name: "set-any-source-for-namespace",
@@ -236,15 +239,16 @@ func Test_ParseToCiliumRule(t *testing.T) {
 					},
 				},
 			},
-			want: &api.Rule{
-				EndpointSelector: api.NewESFromMatchRequirements(
+			want: api.NewRule().WithEndpointSelector(
+				api.NewESFromMatchRequirements(
 					map[string]string{
 						role:      "backend",
 						namespace: "default",
 					},
 					nil,
 				),
-				Ingress: []api.IngressRule{
+			).WithIngressRules(
+				[]api.IngressRule{
 					{
 						FromEndpoints: []api.EndpointSelector{
 							api.NewESFromK8sLabelSelector(
@@ -257,7 +261,8 @@ func Test_ParseToCiliumRule(t *testing.T) {
 						},
 					},
 				},
-				Labels: labels.LabelArray{
+			).WithLabels(
+				labels.LabelArray{
 					{
 						Key:    "io.cilium.k8s.policy.name",
 						Value:  "set-any-source-for-namespace",
@@ -279,7 +284,7 @@ func Test_ParseToCiliumRule(t *testing.T) {
 						Source: labels.LabelSourceK8s,
 					},
 				},
-			},
+			),
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/k8s/apis/cilium.io/v2/types_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/types_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -113,8 +113,8 @@ var (
 		Labels: labels.LabelArray{{Key: "uuid", Value: "98678-9868976-78687678887678", Source: ""}},
 	}
 	uuidRule         = types.UID("98678-9868976-78687678887678")
-	expectedSpecRule = api.Rule{
-		Ingress: []api.IngressRule{
+	expectedSpecRule = api.NewRule().
+				WithIngressRules([]api.IngressRule{
 			{
 				FromEndpoints: []api.EndpointSelector{
 					api.NewESFromLabels(
@@ -132,8 +132,8 @@ var (
 					},
 				},
 			},
-		},
-		Egress: []api.EgressRule{
+		}).
+		WithEgressRules([]api.EgressRule{
 			{
 				ToPorts: []api.PortRule{
 					{
@@ -147,9 +147,8 @@ var (
 			}, {
 				ToCIDRSet: []api.CIDRRule{{Cidr: api.CIDR("10.0.0.0/8"), ExceptCIDRs: []api.CIDR{"10.96.0.0/12"}}},
 			},
-		},
-		Labels: k8sUtils.GetPolicyLabels("default", "rule1", uuidRule, "CiliumNetworkPolicy"),
-	}
+		}).
+		WithLabels(k8sUtils.GetPolicyLabels("default", "rule1", uuidRule, "CiliumNetworkPolicy"))
 
 	rawRule = []byte(`{
         "endpointSelector": {
@@ -310,7 +309,7 @@ func (s *CiliumV2Suite) TestParseSpec(c *C) {
 	rules, err := expectedPolicyRule.Parse()
 	c.Assert(err, IsNil)
 	c.Assert(len(rules), Equals, 1)
-	c.Assert(*rules[0], checker.DeepEquals, expectedSpecRule)
+	c.Assert(*rules[0], checker.DeepEquals, *expectedSpecRule)
 
 	b, err := json.Marshal(expectedPolicyRule)
 	c.Assert(err, IsNil)
@@ -370,7 +369,7 @@ func (s *CiliumV2Suite) TestParseRules(c *C) {
 		}},
 	)
 	expectedSpecRule.EndpointSelector = expectedES
-	expectedSpecRules := api.Rules{&expectedSpecRule, &expectedSpecRule}
+	expectedSpecRules := api.Rules{expectedSpecRule, expectedSpecRule}
 	expectedSpecRule.Sanitize()
 	for i := range expectedSpecRules {
 		expectedSpecRules[i].Sanitize()

--- a/pkg/k8s/network_policy.go
+++ b/pkg/k8s/network_policy.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
+
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -239,12 +240,12 @@ func ParseNetworkPolicy(np *networkingv1.NetworkPolicy) (api.Rules, error) {
 	}
 	np.Spec.PodSelector.MatchLabels[k8sConst.PodNamespaceLabel] = namespace
 
-	rule := &api.Rule{
-		EndpointSelector: api.NewESFromK8sLabelSelector(labels.LabelSourceK8sKeyPrefix, &np.Spec.PodSelector),
-		Labels:           GetPolicyLabelsv1(np),
-		Ingress:          ingresses,
-		Egress:           egresses,
-	}
+	// The next patch will pass the UID.
+	rule := api.NewRule().
+		WithEndpointSelector(api.NewESFromK8sLabelSelector(labels.LabelSourceK8sKeyPrefix, &np.Spec.PodSelector)).
+		WithLabels(GetPolicyLabelsv1(np)).
+		WithIngressRules(ingresses).
+		WithEgressRules(egresses)
 
 	if err := rule.Sanitize(); err != nil {
 		return nil, err

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -250,9 +250,9 @@ func (s *K8sSuite) TestParseNetworkPolicyNoSelectors(c *C) {
 	err := json.Unmarshal(ex1, &np)
 	c.Assert(err, IsNil)
 
-	expectedRule := &api.Rule{
-		EndpointSelector: epSelector,
-		Ingress: []api.IngressRule{
+	expectedRule := api.NewRule().
+		WithEndpointSelector(epSelector).
+		WithIngressRules([]api.IngressRule{
 			{
 				FromCIDRSet: []api.CIDRRule{
 					{
@@ -263,15 +263,14 @@ func (s *K8sSuite) TestParseNetworkPolicyNoSelectors(c *C) {
 					},
 				},
 			},
-		},
-		Egress: []api.EgressRule{},
-		Labels: labels.ParseLabelArray(
+		}).
+		WithEgressRules([]api.EgressRule{}).
+		WithLabels(labels.ParseLabelArray(
 			"k8s:"+k8sConst.PolicyLabelName+"=ingress-cidr-test",
 			"k8s:"+k8sConst.PolicyLabelUID+"=11bba160-ddca-11e8-b697-0800273b04ff",
 			"k8s:"+k8sConst.PolicyLabelNamespace+"=myns",
 			"k8s:"+k8sConst.PolicyLabelDerivedFrom+"="+resourceTypeNetworkPolicy,
-		),
-	}
+		))
 
 	expectedRule.Sanitize()
 

--- a/pkg/policy/api/rule.go
+++ b/pkg/policy/api/rule.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -60,6 +60,41 @@ type Rule struct {
 	//
 	// +optional
 	Description string `json:"description,omitempty"`
+}
+
+// NewRule builds a new rule with no selector and no policy.
+func NewRule() *Rule {
+	return &Rule{}
+}
+
+// WithEndpointSelector configures the Rule with the specified selector.
+func (r *Rule) WithEndpointSelector(es EndpointSelector) *Rule {
+	r.EndpointSelector = es
+	return r
+}
+
+// WithIngressRules configures the Rule with the specified rules.
+func (r *Rule) WithIngressRules(rules []IngressRule) *Rule {
+	r.Ingress = rules
+	return r
+}
+
+// WithEgressRules configures the Rule with the specified rules.
+func (r *Rule) WithEgressRules(rules []EgressRule) *Rule {
+	r.Egress = rules
+	return r
+}
+
+// WithLabels configures the Rule with the specified labels metadata.
+func (r *Rule) WithLabels(labels labels.LabelArray) *Rule {
+	r.Labels = labels
+	return r
+}
+
+// WithDescription configures the Rule with the specified description metadata.
+func (r *Rule) WithDescription(desc string) *Rule {
+	r.Description = desc
+	return r
 }
 
 // RequiresDerivative it return true if the rule has a derivative rule.

--- a/pkg/policy/api/rules.go
+++ b/pkg/policy/api/rules.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,5 +33,5 @@ func (rs Rules) String() string {
 		strRules = append(strRules, fmt.Sprintf("%+v", r))
 	}
 
-	return "[" + strings.Join(strRules, ",") + "]"
+	return "[" + strings.Join(strRules, ",\n") + "]"
 }

--- a/pkg/policy/api/selector.go
+++ b/pkg/policy/api/selector.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -44,6 +44,9 @@ type EndpointSelector struct {
 // LabelSelectorString returns a user-friendly string representation of
 // EndpointSelector.
 func (n *EndpointSelector) LabelSelectorString() string {
+	if n != nil && n.LabelSelector == nil {
+		return "<all>"
+	}
 	return metav1.FormatLabelSelector(n.LabelSelector)
 }
 

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -1,0 +1,308 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package policy
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/cilium/cilium/pkg/checker"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/policy/trafficdirection"
+
+	"github.com/op/go-logging"
+)
+
+var (
+	// Identity, labels, selectors for an endpoint named "foo"
+	identityFoo = uint32(100)
+	labelsFoo   = labels.ParseSelectLabelArray("foo", "red")
+	selectFoo_  = api.NewESFromLabels(labels.ParseSelectLabel("foo"))
+	allowFooL3_ = selectFoo_
+
+	// API rule sections for composability
+	// L4 rule sections
+	allowAllL4_ []api.PortRule
+	allowPort80 = []api.PortRule{{
+		Ports: []api.PortProtocol{
+			{Port: "80", Protocol: api.ProtoTCP},
+		},
+	}}
+	// L7 rule sections
+	allowAllL7___ *api.L7Rules
+	allowHTTPRoot = &api.L7Rules{
+		HTTP: []api.PortRuleHTTP{
+			{Method: "GET", Path: "/"},
+		},
+		L7Proto: ParserTypeHTTP.String(),
+	}
+	// API rule definitions for default-deny, L3, L3L4, L3L4L7, L4, L4L7
+	rule____NoAllow = api.NewRule().
+			WithIngressRules([]api.IngressRule{api.IngressRule{}})
+	ruleL3____Allow = api.NewRule().
+			WithIngressRules([]api.IngressRule{{
+			FromEndpoints: []api.EndpointSelector{allowFooL3_},
+			ToPorts:       allowAllL4_,
+		}})
+	ruleL3L4__Allow = api.NewRule().
+			WithIngressRules([]api.IngressRule{{
+			FromEndpoints: []api.EndpointSelector{allowFooL3_},
+			ToPorts:       allowPort80,
+		}})
+	ruleL3L4L7Allow = api.NewRule().
+			WithIngressRules([]api.IngressRule{{
+			FromEndpoints: []api.EndpointSelector{allowFooL3_},
+			ToPorts:       combineL4L7(allowPort80, allowHTTPRoot),
+		}})
+	rule__L4__Allow = api.NewRule().
+			WithIngressRules([]api.IngressRule{{
+			ToPorts: allowPort80,
+		}})
+	rule__L4L7Allow = api.NewRule().
+			WithIngressRules([]api.IngressRule{{
+			ToPorts: combineL4L7(allowPort80, allowHTTPRoot),
+		}})
+
+	// Misc other bpf key fields for convenience / readability.
+	l7RedirectNone_ = uint16(0)
+	l7RedirectProxy = uint16(1)
+	dirIngress      = trafficdirection.Ingress.Uint8()
+	// Desired map keys for L3, L3-dependent L4, L4
+	mapKeyAllowFoo__ = Key{identityFoo, 0, 0, dirIngress}
+	mapKeyAllowFooL4 = Key{identityFoo, 80, 6, dirIngress}
+	mapKeyAllow___L4 = Key{0, 80, 6, dirIngress}
+	// Desired map entries for no L7 redirect / redirect to Proxy
+	mapEntryL7None_ = MapStateEntry{l7RedirectNone_}
+	mapEntryL7Proxy = MapStateEntry{l7RedirectProxy}
+)
+
+// combineL4L7 returns a new PortRule that refers to the specified l4 ports and
+// l7 rules.
+func combineL4L7(l4 []api.PortRule, l7 *api.L7Rules) []api.PortRule {
+	result := make([]api.PortRule, len(l4))
+	for _, pr := range l4 {
+		result = append(result, api.PortRule{
+			Ports: pr.Ports,
+			Rules: l7,
+		})
+	}
+	return result
+}
+
+// policyDistillery is a convenience wrapper around the existing policy engine,
+// allowing simple direct evaluation of L3 and L4 state into "MapState".
+type policyDistillery struct {
+	*Repository
+	identityCache cache.IdentityCache
+	log           io.Writer
+}
+
+func newPolicyDistillery(identities cache.IdentityCache) *policyDistillery {
+	return &policyDistillery{
+		Repository:    NewPolicyRepository(),
+		identityCache: identities,
+	}
+}
+
+func (d *policyDistillery) WithLogBuffer(w io.Writer) *policyDistillery {
+	return &policyDistillery{
+		Repository:    d.Repository,
+		identityCache: d.identityCache,
+		log:           w,
+	}
+}
+
+// distillPolicy distills the policy repository into a set of bpf map state
+// entries for an endpoint with the specified labels.
+func (d *policyDistillery) distillPolicy(epLabels labels.LabelArray) (MapState, error) {
+	result := make(MapState)
+
+	endpointSelected, _ := d.Repository.GetRulesMatching(epLabels)
+	io.WriteString(d.log, fmt.Sprintf("[distill] Endpoint selected by policy: %t\n", endpointSelected))
+
+	// Prepare the L4 policy so we know whether L4 policy may apply
+	ingressL4 := SearchContext{
+		To:    epLabels,
+		Trace: TRACE_VERBOSE,
+	}
+	ingressL4.Logging = logging.NewLogBackend(d.log, "", 0)
+	io.WriteString(d.log, fmt.Sprintf("[distill] Evaluating L4 -> %s", epLabels))
+	l4IngressPolicy, err := d.Repository.ResolveL4IngressPolicy(&ingressL4)
+	if err != nil {
+		return nil, err
+	}
+
+	// Handle L3 ingress from each identity in the cache to the endpoint.
+	// Build a cache of requirements that are used for l4 policy resolution.
+	deniedPeers := make(cache.IdentityCache)
+	for id, lbls := range d.identityCache {
+		io.WriteString(d.log, fmt.Sprintf("[distill] Evaluating %s -> %s\n", lbls, epLabels))
+		ingressL3 := &SearchContext{
+			From:  lbls,
+			To:    epLabels,
+			Trace: TRACE_VERBOSE,
+		}
+		ingressL3.Logging = logging.NewLogBackend(d.log, "", 0)
+
+		switch d.Repository.CanReachIngressRLocked(ingressL3) {
+		case api.Allowed:
+			io.WriteString(d.log, "[distill] L3 ingress allow\n")
+			key := Key{uint32(id), 0, 0, dirIngress}
+			result[key] = MapStateEntry{l7RedirectNone_}
+		case api.Undecided:
+			io.WriteString(d.log, "[distill] L3 ingress undecided\n")
+			// If there's no L4 policy, undecided becomes allow.
+			if len(*l4IngressPolicy) == 0 && !endpointSelected {
+				key := Key{uint32(id), 0, 0, dirIngress}
+				result[key] = MapStateEntry{l7RedirectNone_}
+				io.WriteString(d.log, "[distill] Endpoint not selected; allowing\n")
+			}
+			// Otherwise this will be handled in L4 resolution below.
+		case api.Denied:
+			io.WriteString(d.log, "[distill] L3 ingress denied\n")
+			deniedPeers[id] = lbls
+		}
+	}
+
+	// Handle L4 ingress from each identity in the cache to the endpoint.
+	io.WriteString(d.log, "[distill] Producing L4 filter keys\n")
+	for _, l4 := range *l4IngressPolicy {
+		io.WriteString(d.log, fmt.Sprintf("[distill] Processing L4Filter (l7: %+v)\n", l4.L7RulesPerEp))
+		for _, key := range l4.ToKeys(0, d.identityCache, deniedPeers) {
+			io.WriteString(d.log, fmt.Sprintf("[distill] L4 ingress allow %+v (parser=%s, redirect=%t)\n", key, l4.L7Parser, l4.IsRedirect()))
+			if l4.IsRedirect() {
+				result[key] = MapStateEntry{l7RedirectProxy}
+			} else {
+				result[key] = MapStateEntry{l7RedirectNone_}
+			}
+		}
+	}
+
+	// Handle L3-wildcard of L7 destinations
+	// Eg, when you have L4+L7 "allow /public on 80" with L3 "allow all from foo"
+	// Initially, three keys would be generated: L4+L7, L3+L4+L7, and L3.
+	// Here, we remove the L3+L4+L7 key if it overlaps with the L4+L7,
+	// but only if they have the same L7 redirect.
+	//
+	// For these the BPF policy order of attempting L3+L4 lookup, L4 lookup,
+	// then L3 lookup means that three keys are not strictly necessary; the
+	// correct behaviour can be encoded with two keys - an L4 key and L3 key.
+	nKeys := 0
+	l3l4keys := make([]Key, len(result))
+	for k := range result {
+		if k.Identity > 0 && k.DestPort > 0 {
+			l3l4keys[nKeys] = k
+			nKeys++
+		}
+	}
+	for i := 0; i < nKeys; i++ {
+		k := l3l4keys[i]
+		io.WriteString(d.log, fmt.Sprintf("[distill] Squashing L3-dependent L4 key %+v\n", k))
+		wildcardL3 := Key{DestPort: k.DestPort, Nexthdr: k.Nexthdr, TrafficDirection: k.TrafficDirection}
+		wildcardL4 := Key{Identity: k.Identity, TrafficDirection: k.TrafficDirection}
+		if _, ok := result[wildcardL4]; ok {
+			io.WriteString(d.log, fmt.Sprintf("[distill] -> Found L3 overlap %+v\n", wildcardL4))
+			if entry, ok := result[wildcardL3]; ok {
+				io.WriteString(d.log, fmt.Sprintf("[distill] -> Found L4 overlap %+v:%+v\n", wildcardL3, entry))
+				if entry.ProxyPort == result[k].ProxyPort {
+					io.WriteString(d.log, fmt.Sprintf("[distill] -> Removing L3-dependent L4 %+v\n", k))
+					delete(result, k)
+				}
+			}
+		}
+	}
+
+	return result, nil
+}
+
+func Test_MergeRules(t *testing.T) {
+	identityCache := cache.IdentityCache{
+		identity.NumericIdentity(identityFoo): labelsFoo,
+	}
+
+	tests := []struct {
+		test   int
+		rules  api.Rules
+		result MapState
+	}{
+		// The following table is derived from the Google Doc here:
+		// https://docs.google.com/spreadsheets/d/1WANIoZGB48nryylQjjOw6lKjI80eVgPShrdMTMalLEw/edit?usp=sharing
+		//
+		//  Rule 0                   | Rule 1         | Rule 2         | Rule 3         | Rule 4         | Desired BPF map state
+		{0, api.Rules{rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, MapState{}},
+		{1, api.Rules{rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, MapState{mapKeyAllowFoo__: mapEntryL7None_}},
+		{2, api.Rules{rule____NoAllow, rule____NoAllow, rule____NoAllow, rule__L4__Allow, rule____NoAllow}, MapState{mapKeyAllow___L4: mapEntryL7None_}},
+		{3, api.Rules{rule____NoAllow, rule____NoAllow, rule____NoAllow, rule__L4__Allow, ruleL3____Allow}, MapState{mapKeyAllow___L4: mapEntryL7None_, mapKeyAllowFoo__: mapEntryL7None_}},
+		{4, api.Rules{rule____NoAllow, rule____NoAllow, ruleL3L4__Allow, rule____NoAllow, rule____NoAllow}, MapState{mapKeyAllowFooL4: mapEntryL7None_}},
+		{5, api.Rules{rule____NoAllow, rule____NoAllow, ruleL3L4__Allow, rule____NoAllow, ruleL3____Allow}, MapState{mapKeyAllowFooL4: mapEntryL7None_, mapKeyAllowFoo__: mapEntryL7None_}},
+		{6, api.Rules{rule____NoAllow, rule____NoAllow, ruleL3L4__Allow, rule__L4__Allow, rule____NoAllow}, MapState{mapKeyAllow___L4: mapEntryL7None_}},                                    // Differs from spreadsheet(!)
+		{7, api.Rules{rule____NoAllow, rule____NoAllow, ruleL3L4__Allow, rule__L4__Allow, ruleL3____Allow}, MapState{mapKeyAllow___L4: mapEntryL7None_, mapKeyAllowFoo__: mapEntryL7None_}}, // Differs from spreadsheet(!)
+		{8, api.Rules{rule____NoAllow, rule__L4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, MapState{mapKeyAllow___L4: mapEntryL7Proxy}},
+		{9, api.Rules{rule____NoAllow, rule__L4L7Allow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, MapState{mapKeyAllow___L4: mapEntryL7Proxy, mapKeyAllowFoo__: mapEntryL7None_}},
+		{10, api.Rules{rule____NoAllow, rule__L4L7Allow, rule____NoAllow, rule__L4__Allow, rule____NoAllow}, MapState{mapKeyAllow___L4: mapEntryL7Proxy}},
+		{11, api.Rules{rule____NoAllow, rule__L4L7Allow, rule____NoAllow, rule__L4__Allow, ruleL3____Allow}, MapState{mapKeyAllow___L4: mapEntryL7Proxy, mapKeyAllowFoo__: mapEntryL7None_}},
+		{12, api.Rules{rule____NoAllow, rule__L4L7Allow, ruleL3L4__Allow, rule____NoAllow, rule____NoAllow}, MapState{mapKeyAllowFooL4: mapEntryL7Proxy, mapKeyAllow___L4: mapEntryL7Proxy}},
+		{13, api.Rules{rule____NoAllow, rule__L4L7Allow, ruleL3L4__Allow, rule____NoAllow, ruleL3____Allow}, MapState{mapKeyAllow___L4: mapEntryL7Proxy, mapKeyAllowFoo__: mapEntryL7None_}}, // Differs from spreadsheet(!)
+		{14, api.Rules{rule____NoAllow, rule__L4L7Allow, ruleL3L4__Allow, rule__L4__Allow, rule____NoAllow}, MapState{mapKeyAllowFooL4: mapEntryL7Proxy, mapKeyAllow___L4: mapEntryL7Proxy}},
+		{15, api.Rules{rule____NoAllow, rule__L4L7Allow, ruleL3L4__Allow, rule__L4__Allow, ruleL3____Allow}, MapState{mapKeyAllow___L4: mapEntryL7Proxy, mapKeyAllowFoo__: mapEntryL7None_}}, // Differs from spreadsheet(!)
+		{16, api.Rules{ruleL3L4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, MapState{mapKeyAllowFooL4: mapEntryL7Proxy}},
+		{17, api.Rules{ruleL3L4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, MapState{mapKeyAllowFooL4: mapEntryL7Proxy, mapKeyAllowFoo__: mapEntryL7None_}},
+		// TODO: Tests 22-23 reveal a bug in the redirect logic (GH-7438).
+		//{18, api.Rules{ruleL3L4L7Allow, rule____NoAllow, rule____NoAllow, rule__L4__Allow, rule____NoAllow}, MapState{mapKeyAllowFooL4: mapEntryL7Proxy, mapKeyAllow___L4: mapEntryL7None_}},
+		//{19, api.Rules{ruleL3L4L7Allow, rule____NoAllow, rule____NoAllow, rule__L4__Allow, ruleL3____Allow}, MapState{mapKeyAllowFooL4: mapEntryL7Proxy, mapKeyAllow___L4: mapEntryL7None_, mapKeyAllowFoo__: mapEntryL7None_}},
+		{20, api.Rules{ruleL3L4L7Allow, rule____NoAllow, ruleL3L4__Allow, rule____NoAllow, rule____NoAllow}, MapState{mapKeyAllowFooL4: mapEntryL7Proxy}},
+		{21, api.Rules{ruleL3L4L7Allow, rule____NoAllow, ruleL3L4__Allow, rule____NoAllow, ruleL3____Allow}, MapState{mapKeyAllowFooL4: mapEntryL7Proxy, mapKeyAllowFoo__: mapEntryL7None_}},
+		// TODO: Tests 22-23 reveal a bug in the redirect logic (GH-7438).
+		//{22, api.Rules{ruleL3L4L7Allow, rule____NoAllow, ruleL3L4__Allow, rule__L4__Allow, rule____NoAllow}, MapState{mapKeyAllowFooL4: mapEntryL7Proxy, mapKeyAllow___L4: mapEntryL7None_}},
+		//{23, api.Rules{ruleL3L4L7Allow, rule____NoAllow, ruleL3L4__Allow, rule__L4__Allow, ruleL3____Allow}, MapState{mapKeyAllowFooL4: mapEntryL7Proxy, mapKeyAllow___L4: mapEntryL7None_, mapKeyAllowFoo__: mapEntryL7None_}},
+		{24, api.Rules{ruleL3L4L7Allow, rule__L4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, MapState{mapKeyAllowFooL4: mapEntryL7Proxy, mapKeyAllow___L4: mapEntryL7Proxy}},
+		{25, api.Rules{ruleL3L4L7Allow, rule__L4L7Allow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, MapState{mapKeyAllow___L4: mapEntryL7Proxy, mapKeyAllowFoo__: mapEntryL7None_}}, // Differs from spreadsheet(!)
+		{26, api.Rules{ruleL3L4L7Allow, rule__L4L7Allow, rule____NoAllow, rule__L4__Allow, rule____NoAllow}, MapState{mapKeyAllowFooL4: mapEntryL7Proxy, mapKeyAllow___L4: mapEntryL7Proxy}},
+		{27, api.Rules{ruleL3L4L7Allow, rule__L4L7Allow, rule____NoAllow, rule__L4__Allow, ruleL3____Allow}, MapState{mapKeyAllow___L4: mapEntryL7Proxy, mapKeyAllowFoo__: mapEntryL7None_}}, // Differs from spreadsheet(!)
+		{28, api.Rules{ruleL3L4L7Allow, rule__L4L7Allow, ruleL3L4__Allow, rule____NoAllow, rule____NoAllow}, MapState{mapKeyAllowFooL4: mapEntryL7Proxy, mapKeyAllow___L4: mapEntryL7Proxy}},
+		{29, api.Rules{ruleL3L4L7Allow, rule__L4L7Allow, ruleL3L4__Allow, rule____NoAllow, ruleL3____Allow}, MapState{mapKeyAllow___L4: mapEntryL7Proxy, mapKeyAllowFoo__: mapEntryL7None_}}, // Differs from spreadsheet(!)
+		{30, api.Rules{ruleL3L4L7Allow, rule__L4L7Allow, ruleL3L4__Allow, rule__L4__Allow, rule____NoAllow}, MapState{mapKeyAllowFooL4: mapEntryL7Proxy, mapKeyAllow___L4: mapEntryL7Proxy}},
+		{31, api.Rules{ruleL3L4L7Allow, rule__L4L7Allow, ruleL3L4__Allow, rule__L4__Allow, ruleL3____Allow}, MapState{mapKeyAllow___L4: mapEntryL7Proxy, mapKeyAllowFoo__: mapEntryL7None_}}, // Differs from spreadsheet(!)
+	}
+	for _, tt := range tests {
+		repo := newPolicyDistillery(identityCache)
+		for _, r := range tt.rules {
+			if r != nil {
+				rule := r.WithEndpointSelector(selectFoo_)
+				_, _ = repo.AddList(api.Rules{rule})
+			}
+		}
+		t.Run(fmt.Sprintf("permutation_%d", tt.test), func(t *testing.T) {
+			logBuffer := new(bytes.Buffer)
+			repo = repo.WithLogBuffer(logBuffer)
+			mapstate, err := repo.distillPolicy(labelsFoo)
+			if err != nil {
+				t.Errorf("Policy resolution failure: %s", err)
+			}
+			if equal, err := checker.DeepEqual(mapstate, tt.result); !equal {
+				t.Logf("Rules:\n%s\n\n", tt.rules.String())
+				t.Logf("Policy Trace: \n%s\n", logBuffer.String())
+				t.Errorf("Policy obtained didn't match expected for endpoint %s:\n%s", labelsFoo, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This the beginnings of a table-driven approach for ensuring that high-level policy `api.Rule` lists generate the correct underlying datapath keys for applying the policy.

The first few commits can likely be split out into a separate PR and merged for general use if desired.

The final commit has the main test functionality like this:

```
  //  Rule 0                   | Rule 1         | Rule 2         | Rule 3         | Rule 4         | Desired BPF map state
  {0, api.Rules{rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, MapState{}},
...
  {5, api.Rules{rule____NoAllow, rule____NoAllow, ruleL3L4__Allow, rule____NoAllow, ruleL3____Allow}, MapState{mapKeyAllowFooL4: mapEntryL7None_, mapKeyAllowFoo__: mapEntryL7None_}},
...
```

This starts with a definiton of some rules, then follows with the desired BPF map state for the endpoint "foo". These test numbers correlate to the first column in a [Google doc](https://docs.google.com/spreadsheets/d/1WANIoZGB48nryylQjjOw6lKjI80eVgPShrdMTMalLEw/edit?usp=sharing). This doc summarises the set of tests that are important to validate merging of overlapping rules. There are currently some minor divergences between the doc and the testsuite code here, however these should be addressed when #7439 and #7438 are resolved/merged.

Example test failure for debugging:

```
$ git diff                                                 
diff --git a/pkg/policy/distillery_test.go b/pkg/policy/distillery_test.go
index 3123e8e8b0c5..a5de6460b183 100644
--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go                                    
@@ -252,7 +252,7 @@ func Test_MergeRules(t *testing.T) {   
        }{                                                 
                //  Rule 0                   | Rule 1         | Rule 2         | Rule 3         | Rule 4         | Desired BPF map state
                {0, api.Rules{rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, MapState{}},
-               {1, api.Rules{rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, MapState{mapKeyAllowFoo__: mapEntryL7None_}},
+               {1, api.Rules{rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, MapState{}},
                {2, api.Rules{rule____NoAllow, rule____NoAllow, rule____NoAllow, rule__L4__Allow, rule____NoAllow}, MapState{mapKeyAllowFooL4: mapEntryL7None_}},                                    // Differs from spreadsheet(!)
                {3, api.Rules{rule____NoAllow, rule____NoAllow, rule____NoAllow, rule__L4__Allow, ruleL3____Allow}, MapState{mapKeyAllowFooL4: mapEntryL7None_, mapKeyAllowFoo__: mapEntryL7None_}}, // Differs from spreadsheet(!)
                {4, api.Rules{rule____NoAllow, rule____NoAllow, ruleL3L4__Allow, rule____NoAllow, rule____NoAllow}, MapState{mapKeyAllowFooL4: mapEntryL7None_}},
$ make unit-tests TESTPKGS=pkg/policy
...
--- FAIL: Test_MergeRules (0.02s)                                                                                                                                                                                                                                                         
    --- PASS: Test_MergeRules/permutation_0 (0.00s)                                                                                                                                                                                                                                       
    --- FAIL: Test_MergeRules/permutation_1 (0.00s)                                                                                                                                                                                                                                       
        distillery_test.go:305: Rules:                                                                                                                                                                                                                                                    
            [&{EndpointSelector:{"matchLabels":{"any:foo":""}} Ingress:[{FromEndpoints:[] FromRequires:[] ToPorts:[] FromCIDR:[] FromCIDRSet:[] FromEntities:[] aggregatedSelectors:[]}] Egress:[] Labels:[] Description:},                                                               
            &{EndpointSelector:{"matchLabels":{"any:foo":""}} Ingress:[{FromEndpoints:[] FromRequires:[] ToPorts:[] FromCIDR:[] FromCIDRSet:[] FromEntities:[] aggregatedSelectors:[]}] Egress:[] Labels:[] Description:},                                                                
            &{EndpointSelector:{"matchLabels":{"any:foo":""}} Ingress:[{FromEndpoints:[] FromRequires:[] ToPorts:[] FromCIDR:[] FromCIDRSet:[] FromEntities:[] aggregatedSelectors:[]}] Egress:[] Labels:[] Description:},                                                               
            &{EndpointSelector:{"matchLabels":{"any:foo":""}} Ingress:[{FromEndpoints:[] FromRequires:[] ToPorts:[] FromCIDR:[] FromCIDRSet:[] FromEntities:[] aggregatedSelectors:[]}] Egress:[] Labels:[] Description:},                                                               
            &{EndpointSelector:{"matchLabels":{"any:foo":""}} Ingress:[{FromEndpoints:[{"matchLabels":{"any:foo":""}}] FromRequires:[] ToPorts:[] FromCIDR:[] FromCIDRSet:[] FromEntities:[] aggregatedSelectors:[]}] Egress:[] Labels:[] Description:}]                                 

        distillery_test.go:306: Policy Trace:
            [distill] Endpoint selected by policy: true
            [distill] Evaluating L4 -> [any:foo any:red]
            Resolving ingress port policy for [any:foo any:red]
            * Rule {"matchLabels":{"any:foo":""}}: selected
                No L4 Ingress rules
            * Rule {"matchLabels":{"any:foo":""}}: selected
                No L4 Ingress rules
            * Rule {"matchLabels":{"any:foo":""}}: selected
                No L4 Ingress rules
            * Rule {"matchLabels":{"any:foo":""}}: selected
                No L4 Ingress rules
            * Rule {"matchLabels":{"any:foo":""}}: selected
                No L4 Ingress rules
            5/5 rules selected
            Found no allow rule
            [distill] Evaluating [any:foo any:red] -> [any:foo any:red]
            * Rule {"matchLabels":{"any:foo":""}}: selected
            * Rule {"matchLabels":{"any:foo":""}}: selected
            * Rule {"matchLabels":{"any:foo":""}}: selected
            * Rule {"matchLabels":{"any:foo":""}}: selected
            * Rule {"matchLabels":{"any:foo":""}}: selected
                Allows from labels {"matchLabels":{"any:foo":""}}
                  Found all required labels
            +       No L4 restrictions
            5/5 rules selected
            Found allow rule
            [distill] L3 ingress allow
            [distill] Producing L4 filter keys

        distillery_test.go:307: Policy obtained didn't match expected for endpoint [any:foo any:red]:
            Unified diff:
            --- obtained
            +++ expected
            @@ -1,3 +1,2 @@
             policy.MapState{
            -    {Identity:0x64, DestPort:0x0, Nexthdr:0x0, TrafficDirection:0x0}: {},
             }
...
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7411)
<!-- Reviewable:end -->
