### PR TITLE
pkg/k8s: remove duplicated JSONPatch struct

### DIFF
--- a/pkg/k8s/cnp.go
+++ b/pkg/k8s/cnp.go
@@ -252,12 +252,6 @@ retryLoop:
 	return err
 }
 
-type jsonPatch struct {
-	OP    string      `json:"op,omitempty"`
-	Path  string      `json:"path,omitempty"`
-	Value interface{} `json:"value"`
-}
-
 func (c *CNPStatusUpdateContext) update(cnp *cilium_v2.CiliumNetworkPolicy, enforcing, ok bool, cnpError error, rev uint64, cnpAnnotations map[string]string) error {
 	var (
 		cnpns       cilium_v2.CiliumNetworkPolicyNodeStatus
@@ -326,7 +320,7 @@ func (c *CNPStatusUpdateContext) update(cnp *cilium_v2.CiliumNetworkPolicy, enfo
 		// one of the nodes would "create" the `/status` path before all other
 		// nodes tried to replace their own status resulted in a gain of 3 %.
 		// This gain is less notable once the number of nodes increases.
-		createStatusAndNodePatch := []jsonPatch{
+		createStatusAndNodePatch := []JSONPatch{
 			{
 				OP:    "test",
 				Path:  "/status",
@@ -353,7 +347,7 @@ func (c *CNPStatusUpdateContext) update(cnp *cilium_v2.CiliumNetworkPolicy, enfo
 		if err != nil {
 			// If it fails it means the test from the previous patch failed
 			// so we can safely replace this node in the CNP status.
-			createStatusAndNodePatch := []jsonPatch{
+			createStatusAndNodePatch := []JSONPatch{
 				{
 					OP:    "replace",
 					Path:  "/status/nodes/" + c.NodeName,

--- a/pkg/k8s/cnp_test.go
+++ b/pkg/k8s/cnp_test.go
@@ -162,7 +162,7 @@ func testUpdateCNPNodeStatusK8s(integrationTest bool, k8sVersion string, c *C) {
 			func(action k8sTesting.Action) (bool, runtime.Object, error) {
 				pa := action.(k8sTesting.PatchAction)
 				time.Sleep(1 * time.Millisecond)
-				var receivedJsonPatch []jsonPatch
+				var receivedJsonPatch []JSONPatch
 				err := json.Unmarshal(pa.GetPatch(), &receivedJsonPatch)
 				c.Assert(err, IsNil)
 
@@ -198,7 +198,7 @@ func testUpdateCNPNodeStatusK8s(integrationTest bool, k8sVersion string, c *C) {
 						// Remove k8s2 from the nodes status.
 						cnpsK8s1 := wantedCNPS.DeepCopy()
 						delete(cnpsK8s1.Nodes, "k8s2")
-						createStatusAndNodePatch := []jsonPatch{
+						createStatusAndNodePatch := []JSONPatch{
 							{
 								OP:    "test",
 								Path:  "/status",
@@ -212,7 +212,7 @@ func testUpdateCNPNodeStatusK8s(integrationTest bool, k8sVersion string, c *C) {
 						}
 						expectedJSONPatchBytes, err := json.Marshal(createStatusAndNodePatch)
 						c.Assert(err, IsNil)
-						var expectedJSONPatch []jsonPatch
+						var expectedJSONPatch []JSONPatch
 						err = json.Unmarshal(expectedJSONPatchBytes, &expectedJSONPatch)
 						c.Assert(err, IsNil)
 
@@ -255,7 +255,7 @@ func testUpdateCNPNodeStatusK8s(integrationTest bool, k8sVersion string, c *C) {
 						cnpsK8s2 := wantedCNPS.DeepCopy()
 						delete(cnpsK8s2.Nodes, "k8s1")
 
-						createStatusAndNodePatch := []jsonPatch{
+						createStatusAndNodePatch := []JSONPatch{
 							{
 								OP:    receivedJsonPatch[0].OP,
 								Path:  "/status/nodes/k8s2",
@@ -264,7 +264,7 @@ func testUpdateCNPNodeStatusK8s(integrationTest bool, k8sVersion string, c *C) {
 						}
 						expectedJSONPatchBytes, err := json.Marshal(createStatusAndNodePatch)
 						c.Assert(err, IsNil)
-						var expectedJSONPatch []jsonPatch
+						var expectedJSONPatch []JSONPatch
 						err = json.Unmarshal(expectedJSONPatchBytes, &expectedJSONPatch)
 						c.Assert(err, IsNil)
 
@@ -286,7 +286,7 @@ func testUpdateCNPNodeStatusK8s(integrationTest bool, k8sVersion string, c *C) {
 					nWanted.Enforcing = false
 					cnpsK8s1.Nodes["k8s1"] = nWanted
 
-					createStatusAndNodePatch := []jsonPatch{
+					createStatusAndNodePatch := []JSONPatch{
 						{
 							OP:    receivedJsonPatch[0].OP,
 							Path:  "/status/nodes/k8s1",
@@ -295,7 +295,7 @@ func testUpdateCNPNodeStatusK8s(integrationTest bool, k8sVersion string, c *C) {
 					}
 					expectedJSONPatchBytes, err := json.Marshal(createStatusAndNodePatch)
 					c.Assert(err, IsNil)
-					var expectedJSONPatch []jsonPatch
+					var expectedJSONPatch []JSONPatch
 					err = json.Unmarshal(expectedJSONPatchBytes, &expectedJSONPatch)
 					c.Assert(err, IsNil)
 


### PR DESCRIPTION
Fixes: 30aa6ca2796f ("pkg/k8s: refactor json_patch to its own file")
Signed-off-by: André Martins <andre@cilium.dev>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7415)
<!-- Reviewable:end -->
