### PR TITLE
endpoint: metrics: Remove deprecated metrics

### DIFF
--- a/Documentation/configuration/metrics.rst
+++ b/Documentation/configuration/metrics.rst
@@ -34,8 +34,6 @@ Endpoint
 * ``endpoint_count``: Number of endpoints managed by this agent
 * ``endpoint_regenerating``: Number of endpoints currently regenerating. Deprecated. Use endpoint_state with proper labels instead
 * ``endpoint_regenerations``: Count of all endpoint regenerations that have completed, tagged by outcome
-* ``endpoint_regeneration_seconds_total``: Total sum of successful endpoint regeneration times (Deprecated)
-* ``endpoint_regeneration_square_seconds_total``: Total sum of squares of successful endpoint regeneration times (Deprecated)
 * ``endpoint_regeneration_time_stats_seconds``: Endpoint regeneration time stats labeled by scope.
 * ``endpoint_state``: Count of all endpoints, tagged by different endpoint states
 

--- a/pkg/endpoint/metrics.go
+++ b/pkg/endpoint/metrics.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/spanstat"
 
-	"math"
 	"time"
 )
 
@@ -61,9 +60,6 @@ func (s *regenerationStatistics) SendMetrics() {
 	}
 
 	metrics.EndpointRegenerationCount.WithLabelValues(metrics.LabelValueOutcomeSuccess).Inc()
-	regenerateTimeSec := s.totalTime.Total().Seconds()
-	metrics.EndpointRegenerationTime.Add(regenerateTimeSec)
-	metrics.EndpointRegenerationTimeSquare.Add(math.Pow(regenerateTimeSec, 2))
 
 	for scope, stat := range s.GetMap() {
 		// Skip scopes that have not been hit (zero duration), so the count in

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -190,23 +190,6 @@ var (
 	},
 		[]string{"outcome"})
 
-	// Deprecated: this metric will be removed in Cilium 1.4
-	// EndpointRegenerationTime is the total time taken to regenerate endpoint
-	EndpointRegenerationTime = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Name:      "endpoint_regeneration_seconds_total",
-		Help:      "Total sum of successful endpoint regeneration times (Deprecated)",
-	})
-
-	// Deprecated: this metric will be removed in Cilium 1.4
-	// EndpointRegenerationTimeSquare is the sum of squares of total time taken
-	// to regenerate endpoint.
-	EndpointRegenerationTimeSquare = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Name:      "endpoint_regeneration_square_seconds_total",
-		Help:      "Total sum of squares of successful endpoint regeneration times (Deprecated)",
-	})
-
 	// EndpointStateCount is the total count of the endpoints in various states.
 	EndpointStateCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -594,8 +577,6 @@ func init() {
 
 	MustRegister(EndpointCountRegenerating)
 	MustRegister(EndpointRegenerationCount)
-	MustRegister(EndpointRegenerationTime)
-	MustRegister(EndpointRegenerationTimeSquare)
 	MustRegister(EndpointStateCount)
 	MustRegister(EndpointRegenerationTimeStats)
 


### PR DESCRIPTION
The following metrics were previously deprecated and they can be removed
now:
- `endpoint_regeneration_seconds_total`
- `endpoint_regeneration_square_seconds_total`

They were replaced by the `endpoint_regeneration_time_stats_seconds`
histogram.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7417)
<!-- Reviewable:end -->
