### PR TITLE
Add liveness probe to cilium operator

### DIFF
--- a/examples/kubernetes/1.10/cilium-containerd.yaml
+++ b/examples/kubernetes/1.10/cilium-containerd.yaml
@@ -461,6 +461,14 @@ spec:
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
         name: cilium-operator
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9234
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/etcd-config
           name: etcd-config-path

--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -469,6 +469,14 @@ spec:
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
         name: cilium-operator
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9234
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/etcd-config
           name: etcd-config-path

--- a/examples/kubernetes/1.10/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.10/cilium-external-etcd.yaml
@@ -468,6 +468,14 @@ spec:
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
         name: cilium-operator
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9234
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/etcd-config
           name: etcd-config-path

--- a/examples/kubernetes/1.10/cilium-operator.yaml
+++ b/examples/kubernetes/1.10/cilium-operator.yaml
@@ -87,6 +87,14 @@ spec:
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
         name: cilium-operator
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9234
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/etcd-config
           name: etcd-config-path

--- a/examples/kubernetes/1.10/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.10/cilium-with-node-init.yaml
@@ -468,6 +468,14 @@ spec:
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
         name: cilium-operator
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9234
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/etcd-config
           name: etcd-config-path

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -468,6 +468,14 @@ spec:
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
         name: cilium-operator
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9234
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/etcd-config
           name: etcd-config-path

--- a/examples/kubernetes/1.11/cilium-containerd.yaml
+++ b/examples/kubernetes/1.11/cilium-containerd.yaml
@@ -462,6 +462,14 @@ spec:
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
         name: cilium-operator
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9234
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/etcd-config
           name: etcd-config-path

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -461,6 +461,14 @@ spec:
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
         name: cilium-operator
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9234
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/etcd-config
           name: etcd-config-path

--- a/examples/kubernetes/1.11/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.11/cilium-external-etcd.yaml
@@ -469,6 +469,14 @@ spec:
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
         name: cilium-operator
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9234
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/etcd-config
           name: etcd-config-path

--- a/examples/kubernetes/1.11/cilium-operator.yaml
+++ b/examples/kubernetes/1.11/cilium-operator.yaml
@@ -87,6 +87,14 @@ spec:
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
         name: cilium-operator
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9234
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/etcd-config
           name: etcd-config-path

--- a/examples/kubernetes/1.11/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.11/cilium-with-node-init.yaml
@@ -468,6 +468,14 @@ spec:
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
         name: cilium-operator
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9234
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/etcd-config
           name: etcd-config-path

--- a/examples/kubernetes/1.12/cilium-containerd.yaml
+++ b/examples/kubernetes/1.12/cilium-containerd.yaml
@@ -462,6 +462,14 @@ spec:
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
         name: cilium-operator
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9234
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/etcd-config
           name: etcd-config-path

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -461,6 +461,14 @@ spec:
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
         name: cilium-operator
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9234
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/etcd-config
           name: etcd-config-path

--- a/examples/kubernetes/1.12/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.12/cilium-external-etcd.yaml
@@ -469,6 +469,14 @@ spec:
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
         name: cilium-operator
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9234
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/etcd-config
           name: etcd-config-path

--- a/examples/kubernetes/1.12/cilium-operator.yaml
+++ b/examples/kubernetes/1.12/cilium-operator.yaml
@@ -87,6 +87,14 @@ spec:
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
         name: cilium-operator
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9234
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/etcd-config
           name: etcd-config-path

--- a/examples/kubernetes/1.12/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.12/cilium-with-node-init.yaml
@@ -468,6 +468,14 @@ spec:
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
         name: cilium-operator
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9234
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/etcd-config
           name: etcd-config-path

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -469,6 +469,14 @@ spec:
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
         name: cilium-operator
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9234
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/etcd-config
           name: etcd-config-path

--- a/examples/kubernetes/1.13/cilium-containerd.yaml
+++ b/examples/kubernetes/1.13/cilium-containerd.yaml
@@ -462,6 +462,14 @@ spec:
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
         name: cilium-operator
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9234
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/etcd-config
           name: etcd-config-path

--- a/examples/kubernetes/1.13/cilium-crio.yaml
+++ b/examples/kubernetes/1.13/cilium-crio.yaml
@@ -461,6 +461,14 @@ spec:
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
         name: cilium-operator
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9234
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/etcd-config
           name: etcd-config-path

--- a/examples/kubernetes/1.13/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.13/cilium-external-etcd.yaml
@@ -469,6 +469,14 @@ spec:
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
         name: cilium-operator
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9234
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/etcd-config
           name: etcd-config-path

--- a/examples/kubernetes/1.13/cilium-operator.yaml
+++ b/examples/kubernetes/1.13/cilium-operator.yaml
@@ -87,6 +87,14 @@ spec:
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
         name: cilium-operator
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9234
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/etcd-config
           name: etcd-config-path

--- a/examples/kubernetes/1.13/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.13/cilium-with-node-init.yaml
@@ -468,6 +468,14 @@ spec:
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
         name: cilium-operator
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9234
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/etcd-config
           name: etcd-config-path

--- a/examples/kubernetes/1.13/cilium.yaml
+++ b/examples/kubernetes/1.13/cilium.yaml
@@ -469,6 +469,14 @@ spec:
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
         name: cilium-operator
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9234
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/etcd-config
           name: etcd-config-path

--- a/examples/kubernetes/1.8/cilium-containerd.yaml
+++ b/examples/kubernetes/1.8/cilium-containerd.yaml
@@ -461,6 +461,14 @@ spec:
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
         name: cilium-operator
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9234
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/etcd-config
           name: etcd-config-path

--- a/examples/kubernetes/1.8/cilium-crio.yaml
+++ b/examples/kubernetes/1.8/cilium-crio.yaml
@@ -469,6 +469,14 @@ spec:
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
         name: cilium-operator
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9234
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/etcd-config
           name: etcd-config-path

--- a/examples/kubernetes/1.8/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.8/cilium-external-etcd.yaml
@@ -468,6 +468,14 @@ spec:
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
         name: cilium-operator
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9234
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/etcd-config
           name: etcd-config-path

--- a/examples/kubernetes/1.8/cilium-operator.yaml
+++ b/examples/kubernetes/1.8/cilium-operator.yaml
@@ -87,6 +87,14 @@ spec:
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
         name: cilium-operator
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9234
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/etcd-config
           name: etcd-config-path

--- a/examples/kubernetes/1.8/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.8/cilium-with-node-init.yaml
@@ -468,6 +468,14 @@ spec:
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
         name: cilium-operator
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9234
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/etcd-config
           name: etcd-config-path

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -468,6 +468,14 @@ spec:
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
         name: cilium-operator
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9234
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/etcd-config
           name: etcd-config-path

--- a/examples/kubernetes/1.9/cilium-containerd.yaml
+++ b/examples/kubernetes/1.9/cilium-containerd.yaml
@@ -461,6 +461,14 @@ spec:
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
         name: cilium-operator
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9234
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/etcd-config
           name: etcd-config-path

--- a/examples/kubernetes/1.9/cilium-crio.yaml
+++ b/examples/kubernetes/1.9/cilium-crio.yaml
@@ -469,6 +469,14 @@ spec:
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
         name: cilium-operator
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9234
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/etcd-config
           name: etcd-config-path

--- a/examples/kubernetes/1.9/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.9/cilium-external-etcd.yaml
@@ -468,6 +468,14 @@ spec:
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
         name: cilium-operator
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9234
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/etcd-config
           name: etcd-config-path

--- a/examples/kubernetes/1.9/cilium-operator.yaml
+++ b/examples/kubernetes/1.9/cilium-operator.yaml
@@ -87,6 +87,14 @@ spec:
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
         name: cilium-operator
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9234
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/etcd-config
           name: etcd-config-path

--- a/examples/kubernetes/1.9/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.9/cilium-with-node-init.yaml
@@ -468,6 +468,14 @@ spec:
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
         name: cilium-operator
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9234
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/etcd-config
           name: etcd-config-path

--- a/examples/kubernetes/1.9/cilium.yaml
+++ b/examples/kubernetes/1.9/cilium.yaml
@@ -468,6 +468,14 @@ spec:
         image: docker.io/cilium/operator:latest
         imagePullPolicy: Always
         name: cilium-operator
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9234
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/etcd-config
           name: etcd-config-path

--- a/examples/kubernetes/README.rst
+++ b/examples/kubernetes/README.rst
@@ -4,7 +4,7 @@ Kubernetes Deployment
 This directory contains all Cilium deployment files that can be used in
 Kubernetes.
 
-Each directory represents a Kubernetes version, from :code:`1.8` to :code:`1.12`,
+Each directory represents a Kubernetes version, from :code:`1.8` to :code:`1.13`,
 and inside each version there is a list of files to deploy Cilium.
 
 The structure directory will be :code:`${k8s_major_version}.${k8s_minor_version}/*.yaml`.

--- a/examples/kubernetes/templates/v1/cilium-operator.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-operator.yaml.sed
@@ -87,6 +87,14 @@ spec:
         image: docker.io/cilium/operator:__CILIUM_VERSION__
         imagePullPolicy: Always
         name: cilium-operator
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9234
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/etcd-config
           name: etcd-config-path

--- a/operator/api.go
+++ b/operator/api.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/cilium/cilium/pkg/k8s"
+	"github.com/cilium/cilium/pkg/kvstore"
+)
+
+// StartServer starts an api server listening on the given address.
+func StartServer(addr string, shutdownSignal <-chan struct{}) {
+	log.Infof("Starting apiserver on address %s", addr)
+
+	http.HandleFunc("/healthz", healthHandler)
+
+	srv := &http.Server{Addr: addr}
+
+	go func() {
+		<-shutdownSignal
+		if err := srv.Shutdown(context.Background()); err != nil {
+			log.WithError(err).Error("apiserver shutdown")
+		}
+	}()
+
+	if err := srv.ListenAndServe(); err != nil {
+		log.WithError(err).Error("apiserver listen")
+	}
+}
+
+func healthHandler(w http.ResponseWriter, r *http.Request) {
+	statusCode := http.StatusOK
+	reply := "ok"
+
+	if err := checkStatus(); err != nil {
+		statusCode = http.StatusInternalServerError
+		reply = err.Error()
+	}
+
+	w.WriteHeader(statusCode)
+	if _, err := w.Write([]byte(reply)); err != nil {
+		log.WithError(err).Error("Failed to write liveness-probe response")
+	}
+}
+
+// checkStatus checks the connection status to the kvstore and
+// k8s apiserver and returns an error if any of them is unhealthy
+func checkStatus() error {
+
+	if client := kvstore.Client(); client == nil {
+		return fmt.Errorf("kvstore client not configured")
+	} else if _, err := client.Status(); err != nil {
+		return err
+	} else if _, err := k8s.Client().Discovery().ServerVersion(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/kvstore/backend.go
+++ b/pkg/kvstore/backend.go
@@ -132,7 +132,7 @@ func getBackend(name string) backendModule {
 // tracing layer.
 type BackendOperations interface {
 
-	// Status returns the status of he kvstore client including an
+	// Status returns the status of the kvstore client including an
 	// eventual error
 	Status() (string, error)
 


### PR DESCRIPTION
* Adds /healthz endpoint that returns HTTP 200 if
  etcd and k8s api status are healthy and HTTP 500
  otherwise.
* Adds `--api-server-port` cmd flag to the cilium-operator
  application to allow to configure the listening server's
  port (with default 9234).
* Adds liveness probe `HTTP GET /healthz` to the
  cilium-operator deployment in the example yaml files.
* Minor typo fixes.

Fixes #6217

Happy to make any suggested improvements!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7419)
<!-- Reviewable:end -->
