### PR TITLE
cilium: ipsec, support kernel without ipv6 support

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -929,8 +929,10 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 		if err := ipsec.LoadIPSecKeysFile(option.Config.IPSecKeyFile); err != nil {
 			return nil, nil, err
 		}
-		if err := ipsec.EnableIPv6Forwarding(); err != nil {
-			return nil, nil, err
+		if option.Config.EnableIPv6 {
+			if err := ipsec.EnableIPv6Forwarding(); err != nil {
+				return nil, nil, err
+			}
 		}
 	}
 


### PR DESCRIPTION
If ipv6 support is disabled do not try to write to ipv6 files. This resolves an issue where kernels without ipv6 support throw an error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7420)
<!-- Reviewable:end -->
