### PR TITLE
[1.4] cilium: ipsec, support kernel without ipv6 support

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1003,8 +1003,10 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 		if err := ipsec.LoadIPSecKeysFile(option.Config.IPSecKeyFile); err != nil {
 			return nil, nil, err
 		}
-		if err := ipsec.EnableIPv6Forwarding(); err != nil {
-			return nil, nil, err
+		if option.Config.EnableIPv6 {
+			if err := ipsec.EnableIPv6Forwarding(); err != nil {
+				return nil, nil, err
+			}
 		}
 	}
 


### PR DESCRIPTION
[ upstream commit a7b09677ac94f4f5fdf07c81adcc0f6ce97e92b3 ]

If kernel does not have ipv6 support forwarding file will not exist
so do not try to set the file if ipv6 is disabled.

Signed-off-by: John Fastabend <john.fastabend@gmail.com>
Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7421)
<!-- Reviewable:end -->
