### PR TITLE
go: bump golang to 1.12.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: trusty
 sudo: required
 
 go:
- - 1.12
+ - 1.12.1
 
 # This will travis to build on branch updates only for the master branch
 branches:
@@ -20,6 +20,6 @@ before_install: ./.travis/prepare.sh
 
 before_script:
   - export PATH=/usr/local/clang/bin:$PATH
-  - export GO=/home/travis/.gimme/versions/go1.12.linux.amd64/bin/go
+  - export GO=/home/travis/.gimme/versions/go1.12.1.linux.amd64/bin/go
 
 script: ./.travis/build.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ FROM quay.io/cilium/cilium-envoy:84ee839e1d78ef858a39e390288ad417d35bb1d4 as cil
 # versions to be built while allowing the new versions to make changes
 # that are not backwards compatible.
 #
-FROM quay.io/cilium/cilium-builder:2019-02-26 as builder
+FROM quay.io/cilium/cilium-builder:2019-03-16 as builder
 LABEL maintainer="maintainer@cilium.io"
 WORKDIR /go/src/github.com/cilium/cilium
 COPY . ./
@@ -37,7 +37,7 @@ RUN make LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 V=$V LIBNETWORK_PLUGIN=$LIBNETWORK_PLU
 # built while allowing the new versions to make changes that are not
 # backwards compatible.
 #
-FROM quay.io/cilium/cilium-runtime:2019-02-26
+FROM quay.io/cilium/cilium-runtime:2019-03-16
 LABEL maintainer="maintainer@cilium.io"
 COPY --from=builder /tmp/install /
 COPY --from=cilium-envoy / /

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -14,7 +14,7 @@ WORKDIR /go/src/github.com/cilium/cilium
 ENV GOROOT /usr/local/go
 ENV GOPATH /go
 ENV PATH "$GOROOT/bin:$GOPATH/bin:$PATH"
-ENV GO_VERSION 1.12
+ENV GO_VERSION 1.12.1
 
 #
 # Build dependencies

--- a/cilium-docker-plugin.Dockerfile
+++ b/cilium-docker-plugin.Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.12.0 as builder
+FROM docker.io/library/golang:1.12.1 as builder
 LABEL maintainer="maintainer@cilium.io"
 ADD . /go/src/github.com/cilium/cilium
 WORKDIR /go/src/github.com/cilium/cilium/plugins/cilium-docker

--- a/cilium-operator.Dockerfile
+++ b/cilium-operator.Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.12.0 as builder
+FROM docker.io/library/golang:1.12.1 as builder
 LABEL maintainer="maintainer@cilium.io"
 ADD . /go/src/github.com/cilium/cilium
 WORKDIR /go/src/github.com/cilium/cilium/operator

--- a/contrib/packaging/docker/Dockerfile.runtime
+++ b/contrib/packaging/docker/Dockerfile.runtime
@@ -78,7 +78,7 @@ apt-get clean
 #
 # Go-based tools we need at runtime
 #
-FROM golang:1.12.0 as runtime-gobuild
+FROM golang:1.12.1 as runtime-gobuild
 WORKDIR /tmp
 RUN go get -u github.com/cilium/go-bindata/... && \
 go get -u github.com/google/gops && \

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     command: "etcd -name etcd0 -advertise-client-urls http://0.0.0.0:4002 -listen-client-urls http://0.0.0.0:4002 -initial-cluster-token etcd-cluster-1 -initial-cluster-state new"
     privileged: true
   base_image:
-    image: "quay.io/cilium/cilium-builder:2019-02-26"
+    image: "quay.io/cilium/cilium-builder:2019-03-16"
     volumes:
       - "./../:/go/src/github.com/cilium/cilium/"
     privileged: true


### PR DESCRIPTION
Signed-off-by: André Martins <andre@cilium.dev>

```release-note
update to golang to 1.12.1
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7423)
<!-- Reviewable:end -->
