### PR TITLE
daemon: fix conntrack map dump wrt addresses

### DIFF
--- a/pkg/maps/ctmap/ipv4.go
+++ b/pkg/maps/ctmap/ipv4.go
@@ -71,14 +71,16 @@ func (k CtKey4) Dump(buffer *bytes.Buffer) bool {
 	if k.Flags&TUPLE_F_IN != 0 {
 		buffer.WriteString(fmt.Sprintf("%s IN %s %d:%d ",
 			k.NextHeader.String(),
-			k.DestAddr.IP().String(),
+			// Address swapped, see issue #5848
+			k.SourceAddr.IP().String(),
 			k.SourcePort, k.DestPort),
 		)
 
 	} else {
 		buffer.WriteString(fmt.Sprintf("%s OUT %s %d:%d ",
 			k.NextHeader.String(),
-			k.DestAddr.IP().String(),
+			// Address swapped, see issue #5848
+			k.SourceAddr.IP().String(),
 			k.DestPort,
 			k.SourcePort),
 		)
@@ -135,15 +137,17 @@ func (k CtKey4Global) Dump(buffer *bytes.Buffer) bool {
 	if k.Flags&TUPLE_F_IN != 0 {
 		buffer.WriteString(fmt.Sprintf("%s IN %s:%d -> %s:%d ",
 			k.NextHeader.String(),
-			k.SourceAddr.IP().String(), k.SourcePort,
-			k.DestAddr.IP().String(), k.DestPort),
+			// Addresses swapped, see issue #5848
+			k.DestAddr.IP().String(), k.SourcePort,
+			k.SourceAddr.IP().String(), k.DestPort),
 		)
 
 	} else {
 		buffer.WriteString(fmt.Sprintf("%s OUT %s:%d -> %s:%d ",
 			k.NextHeader.String(),
-			k.SourceAddr.IP().String(), k.SourcePort,
-			k.DestAddr.IP().String(), k.DestPort),
+			// Addresses swapped, see issue #5848
+			k.DestAddr.IP().String(), k.SourcePort,
+			k.SourceAddr.IP().String(), k.DestPort),
 		)
 	}
 

--- a/pkg/maps/ctmap/ipv6.go
+++ b/pkg/maps/ctmap/ipv6.go
@@ -71,14 +71,16 @@ func (k CtKey6) Dump(buffer *bytes.Buffer) bool {
 	if k.Flags&TUPLE_F_IN != 0 {
 		buffer.WriteString(fmt.Sprintf("%s IN %s %d:%d ",
 			k.NextHeader.String(),
-			k.DestAddr.IP().String(),
+			// Address swapped, see issue #5848
+			k.SourceAddr.IP().String(),
 			k.SourcePort, k.DestPort),
 		)
 
 	} else {
 		buffer.WriteString(fmt.Sprintf("%s OUT %s %d:%d ",
 			k.NextHeader.String(),
-			k.DestAddr.IP().String(),
+			// Address swapped, see issue #5848
+			k.SourceAddr.IP().String(),
 			k.DestPort,
 			k.SourcePort),
 		)
@@ -134,15 +136,17 @@ func (k CtKey6Global) Dump(buffer *bytes.Buffer) bool {
 	if k.Flags&TUPLE_F_IN != 0 {
 		buffer.WriteString(fmt.Sprintf("%s IN [%s]:%d -> [%s]:%d ",
 			k.NextHeader.String(),
-			k.SourceAddr.IP().String(), k.SourcePort,
-			k.DestAddr.IP().String(), k.DestPort),
+			// Addresses swapped, see issue #5848
+			k.DestAddr.IP().String(), k.SourcePort,
+			k.SourceAddr.IP().String(), k.DestPort),
 		)
 
 	} else {
 		buffer.WriteString(fmt.Sprintf("%s OUT [%s]:%d -> [%s]:%d ",
 			k.NextHeader.String(),
-			k.SourceAddr.IP().String(), k.SourcePort,
-			k.DestAddr.IP().String(), k.DestPort),
+			// Addresses swapped, see issue #5848
+			k.DestAddr.IP().String(), k.SourcePort,
+			k.SourceAddr.IP().String(), k.DestPort),
 		)
 	}
 


### PR DESCRIPTION
The CT dump currently shows swapped src/dst address entries even
though it's correctly using src address resp. dst address as data.

Issue is that 7afe903203c3 ("bpf: Global 5 tuple conntrack.") did
not swap the initial tuple for the lookup when converting from
local to global table, and all the current code right now is doing
workarounds in order to not break CT table during version upgrade.

Thus same needs to be done here for the dump. Issue became more
apparent after aaf6ba39ad4e ("ctmap: Fix order of CtKey{4,6} struct
fields"), which might have had been swapped on purpose but without
further comments in the code on why it was swapped on daemon side.

In this case, reverting aaf6ba39ad4e doesn't fully fix it either
since then direction also needs to be swapped. Instead, make it
less confusing and only swap what needs to be swapped, that is, the
address parts since in the datapath this is the only thing that
should have been done but was missed back then. For next major
version upgrade (aka 2.0), this will be properly fixed (at the
cost of disruptive upgrade).

Fixes: 7afe903203c3 ("bpf: Global 5 tuple conntrack.")
Fixes: aaf6ba39ad4e ("ctmap: Fix order of CtKey{4,6} struct fields")
Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7428)
<!-- Reviewable:end -->
