### PR TITLE
Add dockerignore file.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,6 @@
 *.o
 *.a
 *.so
-*.so.*
 
 # LLVM IR files
 *.ll
@@ -11,9 +10,8 @@
 # Folders
 _obj
 _test
-tests/cilium-files
-test/test_results
 _build/
+hack/
 
 # Architecture specific extensions/prefixes
 *.cgo1.go
@@ -30,7 +28,7 @@ _testmain.go
 
 *.swn
 *.swp
-.vagrant
+.vagrant/
 vagrant.kubeconfig
 coverage.out
 coverage-all.out
@@ -52,19 +50,27 @@ outgoing
 
 man/
 
+# Test files
 test/tmp.yaml
 test/*_service_manifest.json
 test/*_manifest.yaml
 test/*_policy.json
 test/*.xml
+tests/cilium-files
+test/test_results
+test/*.json
+test/.vagrant/
 
 # Emacs backup files
 *~
 
+# Automatically generated when needed
+.dockerignore
+
 # Temporary files that allow build containers/VMs work without git
-GIT_VERSION
 
 test/bpf/_results
 
 # generated from make targets
 *.ok
+.*


### PR DESCRIPTION
On CI has been seen the following error on building operator[0] to avoid
that kind of issues do not include test/*.json files because can be
added/deleted in any time in runtime and things start to fail randomly.

[0] CI error
```
00:37:26.858      k8s1-1.13: e45cfbc98a50: Pushed
00:37:26.858      k8s1-1.13: d60e01b37e74: Pushed
00:37:37.746      k8s1-1.13: e8dbf417700a: Pushed
00:37:38.878      k8s1-1.13: 762d8e1a6054: Pushed
00:37:40.622      k8s1-1.13: can't load package: package ./test/bpf: C source files not allowed when not using cgo or SWIG: bpf-event-test.c elf-demo.c unit-test.c
00:37:41.355      k8s1-1.13: docker build --build-arg LOCKDEBUG=1 -f cilium-operator.Dockerfile -t "cilium/operator:"latest"" .
00:37:43.069      k8s1-1.13: error checking context: 'file ('/home/vagrant/go/src/github.com/cilium/cilium/test/policy_ace3612d.json') not found or excluded by .dockerignore'.
00:37:43.069      k8s1-1.13: Makefile:187: recipe for target 'docker-operator-image' failed
00:37:43.069      k8s1-1.13: make: *** [docker-operator-image] Error 1
00:37:52.144      k8s1-1.13: bde303456f0c: Pushed
00:37:52.144      k8s1-1.13: latest: digest: sha256:d0d55c183ac79bd9611e259ab33105900e8f53ba7e8e3eed59f50f544e415300 size: 3665
```

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7429)
<!-- Reviewable:end -->
