### PR TITLE
k8s: Add metric to count number of raw Kubernetes events received

### DIFF
--- a/Documentation/configuration/metrics.rst
+++ b/Documentation/configuration/metrics.rst
@@ -125,7 +125,10 @@ SubProcess
 Kubernetes
 -----------
 
-* ``kubernetes_events_total``: Number of Kubernetes events received labeled by
+* ``kubernetes_events_received_total``: Number of Kubernetes events received labeled by
+  scope, action, validity and equality
+
+* ``kubernetes_events_total``: Number of Kubernetes events processed labeled by
   scope, action and the execution result
 
 * ``k8s_cnp_status_completion_seconds``: Duration in seconds in how long it

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -481,13 +481,21 @@ var (
 
 	// Kubernetes Events
 
-	// KubernetesEvent is the number of Kubernetes events received labeled by
-	// scope, action and execution result
-	KubernetesEvent = prometheus.NewCounterVec(prometheus.CounterOpts{
+	// KubernetesEventProcessed is the number of Kubernetes events
+	// processed labeled by scope, action and execution result
+	KubernetesEventProcessed = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: Namespace,
 		Name:      "kubernetes_events_total",
-		Help:      "Number of Kubernetes events received labeled by scope, action and execution result",
+		Help:      "Number of Kubernetes events processed labeled by scope, action and execution result",
 	}, []string{LabelScope, LabelAction, LabelStatus})
+
+	// KubernetesEventReceived is the number of Kubernetes events received
+	// labeled by scope, action, valid data and equalness.
+	KubernetesEventReceived = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Name:      "kubernetes_events_received_total",
+		Help:      "Number of Kubernetes events processed labeled by scope, action and execution result",
+	}, []string{LabelScope, LabelAction, "valid", "equal"})
 
 	// Kubernetes interactions
 
@@ -624,7 +632,8 @@ func init() {
 
 	MustRegister(SubprocessStart)
 
-	MustRegister(KubernetesEvent)
+	MustRegister(KubernetesEventProcessed)
+	MustRegister(KubernetesEventReceived)
 
 	MustRegister(IpamEvent)
 


### PR DESCRIPTION
Counting the processed events is insufficient as it may hide the majority of
events being received. Also count the number of events received in order to
gain visibility into how many events the apiserver is sending out.

```
cilium_kubernetes_events_received_total               action="create" equal="false" scope="CiliumNetworkPolicy" valid="true"                                1.000000
cilium_kubernetes_events_received_total               valid="true" action="create" equal="false" scope="Endpoint"                                           7.000000
cilium_kubernetes_events_received_total               action="create" equal="false" scope="Node" valid="true"                                               1.000000
cilium_kubernetes_events_received_total               scope="Pod" valid="true" action="create" equal="false"                                                6.000000
cilium_kubernetes_events_received_total               action="create" equal="false" scope="Service" valid="true"                                            7.000000
cilium_kubernetes_events_received_total               action="update" equal="true" scope="CiliumNetworkPolicy" valid="true"                                 1.000000
cilium_kubernetes_events_received_total               equal="true" scope="Node" valid="true" action="update"                                                5.000000
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7430)
<!-- Reviewable:end -->
