### PR TITLE
FQDN: Only regenerate rule if dns response has IPs.

### DIFF
--- a/daemon/fqdn.go
+++ b/daemon/fqdn.go
@@ -357,7 +357,7 @@ func (d *Daemon) bootstrapFQDN(restoredEndpoints *endpointRestoreState, preCache
 			)
 			record.Log()
 
-			if msg.Response && msg.Rcode == dns.RcodeSuccess {
+			if msg.Response && msg.Rcode == dns.RcodeSuccess && len(responseIPs) > 0 {
 				// This must happen before the ruleGen update below, to ensure that
 				// this data is included in the serialized Endpoint object.
 				// Note: We need to fixup minTTL to be consistent with how we insert it


### PR DESCRIPTION
There are cases where a DNS response return a Nonerror but there are no
IPS in the response. In that case Cilium  regenerates the policy because
it's a legit response.

With this change, regeneration will not happens if it is a empty
response.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7431)
<!-- Reviewable:end -->
