### PR TITLE
k8s: Use cilium status --brief in liveness/readiness probe

### DIFF
--- a/examples/kubernetes/1.10/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-containerd-ds.yaml
@@ -76,6 +76,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -95,6 +96,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.10/cilium-containerd.yaml
+++ b/examples/kubernetes/1.10/cilium-containerd.yaml
@@ -226,6 +226,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -245,6 +246,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.10/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-crio-ds.yaml
@@ -84,6 +84,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -103,6 +104,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -234,6 +234,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -253,6 +254,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.10/cilium-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-ds.yaml
@@ -83,6 +83,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -102,6 +103,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.10/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.10/cilium-external-etcd.yaml
@@ -233,6 +233,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -252,6 +253,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.10/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-minikube-ds.yaml
@@ -83,6 +83,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -102,6 +103,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.10/cilium-minikube.yaml
+++ b/examples/kubernetes/1.10/cilium-minikube.yaml
@@ -233,6 +233,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -252,6 +253,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.10/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.10/cilium-with-node-init.yaml
@@ -233,6 +233,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -252,6 +253,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -233,6 +233,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -252,6 +253,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.11/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-containerd-ds.yaml
@@ -76,6 +76,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -95,6 +96,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.11/cilium-containerd.yaml
+++ b/examples/kubernetes/1.11/cilium-containerd.yaml
@@ -226,6 +226,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -245,6 +246,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.11/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-crio-ds.yaml
@@ -84,6 +84,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -103,6 +104,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -234,6 +234,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -253,6 +254,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -83,6 +83,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -102,6 +103,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.11/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.11/cilium-external-etcd.yaml
@@ -233,6 +233,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -252,6 +253,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.11/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-minikube-ds.yaml
@@ -83,6 +83,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -102,6 +103,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.11/cilium-minikube.yaml
+++ b/examples/kubernetes/1.11/cilium-minikube.yaml
@@ -233,6 +233,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -252,6 +253,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.11/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.11/cilium-with-node-init.yaml
@@ -233,6 +233,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -252,6 +253,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -233,6 +233,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -252,6 +253,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.12/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-containerd-ds.yaml
@@ -76,6 +76,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -95,6 +96,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.12/cilium-containerd.yaml
+++ b/examples/kubernetes/1.12/cilium-containerd.yaml
@@ -226,6 +226,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -245,6 +246,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.12/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-crio-ds.yaml
@@ -84,6 +84,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -103,6 +104,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -234,6 +234,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -253,6 +254,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.12/cilium-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-ds.yaml
@@ -83,6 +83,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -102,6 +103,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.12/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.12/cilium-external-etcd.yaml
@@ -233,6 +233,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -252,6 +253,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.12/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-minikube-ds.yaml
@@ -83,6 +83,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -102,6 +103,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.12/cilium-minikube.yaml
+++ b/examples/kubernetes/1.12/cilium-minikube.yaml
@@ -233,6 +233,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -252,6 +253,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.12/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.12/cilium-with-node-init.yaml
@@ -233,6 +233,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -252,6 +253,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -233,6 +233,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -252,6 +253,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.13/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-containerd-ds.yaml
@@ -76,6 +76,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -95,6 +96,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.13/cilium-containerd.yaml
+++ b/examples/kubernetes/1.13/cilium-containerd.yaml
@@ -226,6 +226,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -245,6 +246,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.13/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-crio-ds.yaml
@@ -84,6 +84,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -103,6 +104,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.13/cilium-crio.yaml
+++ b/examples/kubernetes/1.13/cilium-crio.yaml
@@ -234,6 +234,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -253,6 +254,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.13/cilium-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-ds.yaml
@@ -83,6 +83,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -102,6 +103,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.13/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.13/cilium-external-etcd.yaml
@@ -233,6 +233,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -252,6 +253,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.13/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-minikube-ds.yaml
@@ -83,6 +83,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -102,6 +103,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.13/cilium-minikube.yaml
+++ b/examples/kubernetes/1.13/cilium-minikube.yaml
@@ -233,6 +233,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -252,6 +253,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.13/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.13/cilium-with-node-init.yaml
@@ -233,6 +233,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -252,6 +253,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.13/cilium.yaml
+++ b/examples/kubernetes/1.13/cilium.yaml
@@ -233,6 +233,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -252,6 +253,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.8/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-containerd-ds.yaml
@@ -76,6 +76,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -95,6 +96,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.8/cilium-containerd.yaml
+++ b/examples/kubernetes/1.8/cilium-containerd.yaml
@@ -226,6 +226,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -245,6 +246,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.8/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-crio-ds.yaml
@@ -84,6 +84,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -103,6 +104,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.8/cilium-crio.yaml
+++ b/examples/kubernetes/1.8/cilium-crio.yaml
@@ -234,6 +234,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -253,6 +254,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.8/cilium-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-ds.yaml
@@ -83,6 +83,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -102,6 +103,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.8/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.8/cilium-external-etcd.yaml
@@ -233,6 +233,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -252,6 +253,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.8/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.8/cilium-minikube-ds.yaml
@@ -83,6 +83,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -102,6 +103,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.8/cilium-minikube.yaml
+++ b/examples/kubernetes/1.8/cilium-minikube.yaml
@@ -233,6 +233,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -252,6 +253,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.8/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.8/cilium-with-node-init.yaml
@@ -233,6 +233,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -252,6 +253,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.8/cilium.yaml
+++ b/examples/kubernetes/1.8/cilium.yaml
@@ -233,6 +233,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -252,6 +253,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.9/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-containerd-ds.yaml
@@ -76,6 +76,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -95,6 +96,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.9/cilium-containerd.yaml
+++ b/examples/kubernetes/1.9/cilium-containerd.yaml
@@ -226,6 +226,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -245,6 +246,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.9/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-crio-ds.yaml
@@ -84,6 +84,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -103,6 +104,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.9/cilium-crio.yaml
+++ b/examples/kubernetes/1.9/cilium-crio.yaml
@@ -234,6 +234,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -253,6 +254,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.9/cilium-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-ds.yaml
@@ -83,6 +83,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -102,6 +103,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.9/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.9/cilium-external-etcd.yaml
@@ -233,6 +233,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -252,6 +253,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.9/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.9/cilium-minikube-ds.yaml
@@ -83,6 +83,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -102,6 +103,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.9/cilium-minikube.yaml
+++ b/examples/kubernetes/1.9/cilium-minikube.yaml
@@ -233,6 +233,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -252,6 +253,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.9/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.9/cilium-with-node-init.yaml
@@ -233,6 +233,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -252,6 +253,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/1.9/cilium.yaml
+++ b/examples/kubernetes/1.9/cilium.yaml
@@ -233,6 +233,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -252,6 +253,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/templates/v1/cilium-containerd-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-containerd-ds.yaml.sed
@@ -76,6 +76,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -95,6 +96,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
@@ -84,6 +84,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -103,6 +104,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
@@ -83,6 +83,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -102,6 +103,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/examples/kubernetes/templates/v1/cilium-minikube-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-minikube-ds.yaml.sed
@@ -83,6 +83,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -102,6 +103,7 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -191,14 +191,14 @@ func FormatStatusResponseBrief(w io.Writer, sr *models.StatusResponse) {
 	msg := ""
 
 	switch {
-	case statusUnhealthy(sr.Cilium):
-		msg = fmt.Sprintf("cilium: %s", sr.Cilium.Msg)
-	case statusUnhealthy(sr.ContainerRuntime):
-		msg = fmt.Sprintf("container runtime: %s", sr.ContainerRuntime.Msg)
 	case statusUnhealthy(sr.Kvstore):
 		msg = fmt.Sprintf("kvstore: %s", sr.Kvstore.Msg)
+	case statusUnhealthy(sr.ContainerRuntime):
+		msg = fmt.Sprintf("container runtime: %s", sr.ContainerRuntime.Msg)
 	case sr.Kubernetes != nil && stateUnhealthy(sr.Kubernetes.State):
 		msg = fmt.Sprintf("kubernetes: %s", sr.Kubernetes.Msg)
+	case statusUnhealthy(sr.Cilium):
+		msg = fmt.Sprintf("cilium: %s", sr.Cilium.Msg)
 	case sr.Cluster != nil && statusUnhealthy(sr.Cluster.CiliumHealth):
 		msg = fmt.Sprintf("cilium-health: %s", sr.Cluster.CiliumHealth.Msg)
 	}


### PR DESCRIPTION
* Make sure the output of `--brief` selects specific sub-component
  errors (like kvstore) to print over generic ones (like cilium).
* Terminate `cilium status --brief` with non-zero exit code if
  cilium status is unhealthy, similar to `cilium status`.
* Update yaml files to use the `--brief` flag in liveness/readiness
  probes.

Fixes #6574

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7432)
<!-- Reviewable:end -->
