### PR TITLE
Makefile: fix grep command for getting directories to run unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ SUBDIRS_CILIUM_CONTAINER += plugins/cilium-docker
 endif
 SUBDIRS = $(SUBDIRS_CILIUM_CONTAINER) operator plugins tools
 GOFILES ?= $(subst _$(ROOT_DIR)/,,$(shell $(GO) list ./... | grep -v -e /vendor/ -e /contrib/))
-TESTPKGS ?= $(subst github.com/cilium/cilium/,,$(shell $(GO) list ./... | grep -P -v -e /api/v1 -e /vendor/ -e /contrib/ -e 'test(?!/helpers/logutils)'))
+TESTPKGS ?= $(subst github.com/cilium/cilium/,,$(shell $(GO) list ./... | grep -v '/api/v1\|/vendor\|/contrib' | grep -v -P 'test(?!/helpers/logutils)'))
 GOLANGVERSION = $(shell $(GO) version 2>/dev/null | grep -Eo '(go[0-9].[0-9])')
 GOLANG_SRCFILES=$(shell for pkg in $(subst github.com/cilium/cilium/,,$(GOFILES)); do find $$pkg -name *.go -print; done | grep -v vendor | sort | uniq)
 BPF_FILES ?= $(shell git ls-files ../bpf/ | grep -v .gitignore | tr "\n" ' ')

--- a/cilium/cmd/bpf_ipcache_get_test.go
+++ b/cilium/cmd/bpf_ipcache_get_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !privileged_tests
+// +build privileged_tests
 
 package cmd
 

--- a/cilium/cmd/helpers_test.go
+++ b/cilium/cmd/helpers_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !privileged_tests
+// +build privileged_tests
 
 package cmd
 


### PR DESCRIPTION
This fixes an issue where no unit tests are ran when \`make unit tests\`
is invoked, as the parameters provided to grep to acquire the list of
directories for which tests should be ran was broken. When ran, it would
produce the following error:

```
grep: the -P option only supports a single pattern
```

A consequence of the above is that no unit tests were ran since 4dbb8fdfc5
was merged. This only affected the master branch.

Fixes: `4dbb8fdfc5`: Create testable logutils package in test helpers

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7437)
<!-- Reviewable:end -->
