### PR TITLE
test: Fix skipping of ipvlan test suite

### DIFF
--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -13,8 +13,15 @@ import (
 	"github.com/onsi/gomega/types"
 )
 
+func runOnNetNextOnly(f func()) func() {
+	if helpers.RunsOnNetNext() {
+		return f
+	}
+	return func() {}
+}
+
 var _ = Describe("RuntimeConnectivityInVethModeTest", runtimeConnectivityTest("veth"))
-var _ = Describe("RuntimeConnectivityInIpvlanModeTest", runtimeConnectivityTest("ipvlan"))
+var _ = Describe("RuntimeConnectivityInIpvlanModeTest", runOnNetNextOnly(runtimeConnectivityTest("ipvlan")))
 
 // TODO(brb) Either create a dummy netdev or determine the master device at runtime
 const ipvlanMasterDevice = "enp0s8"
@@ -30,9 +37,6 @@ var runtimeConnectivityTest = func(datapathMode string) func() {
 			vm = helpers.InitRuntimeHelper(helpers.Runtime, logger)
 
 			if datapathMode == "ipvlan" {
-				if !helpers.RunsOnNetNext() {
-					Skip("ipvlan tests can be run only on >= 4.12 Linux kernel")
-				}
 				vm.SetUpCiliumInIpvlanMode(ipvlanMasterDevice)
 				// cilium-docker has to be restarted because the datapath mode
 				// has changed
@@ -320,7 +324,7 @@ var runtimeConnectivityTest = func(datapathMode string) func() {
 }
 
 var _ = Describe("RuntimeConntrackInVethModeTest", runtimeConntrackTest("veth"))
-var _ = Describe("RuntimeConntrackInIpvlanModeTest", runtimeConntrackTest("ipvlan"))
+var _ = Describe("RuntimeConntrackInIpvlanModeTest", runOnNetNextOnly(runtimeConntrackTest("ipvlan")))
 
 var runtimeConntrackTest = func(datapathMode string) func() {
 	return func() {
@@ -344,9 +348,6 @@ var runtimeConntrackTest = func(datapathMode string) func() {
 			vm = helpers.InitRuntimeHelper(helpers.Runtime, logger)
 
 			if datapathMode == "ipvlan" {
-				if !helpers.RunsOnNetNext() {
-					Skip("ipvlan tests can be run only on >= 4.12 Linux kernel")
-				}
 				vm.SetUpCiliumInIpvlanMode(ipvlanMasterDevice)
 				// cilium-docker has to be restarted because the datapath mode
 				// has changed


### PR DESCRIPTION
Previously, `AfterEach` statements were executed regardless whether the ipvlan suites were skipped (due to running on ubuntu-next) which made the whole suite to fail.

Fix: #7443 

Fixes: 314a6d3fd6 ("test: Extend runtime connectivity tests to include ipvlan")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7444)
<!-- Reviewable:end -->
