### PR TITLE
serialize policy repository update events

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -91,6 +91,7 @@ cilium-agent [flags]
       --monitor-queue-size int                      Size of the event queue when reading monitor events (default 32768)
       --mtu int                                     Overwrite auto-detected MTU of underlying network
       --nat46-range string                          IPv6 prefix to map IPv4 addresses to (default "0:0:0:0:0:FFFF::/96")
+      --policy-queue-size int                       size of queues for policy-related events (default 100)
       --pprof                                       Enable serving the pprof debugging API
       --preallocate-bpf-maps                        Enable BPF map pre-allocation (default true)
       --prefilter-device string                     Device facing external network for XDP prefiltering (default "undefined")

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -700,6 +700,8 @@ func init() {
 	flags.String(option.ToFQDNsPreCache, defaults.ToFQDNsPreCache, "DNS cache data at this path is preloaded on agent startup")
 	option.BindEnv(option.ToFQDNsPreCache)
 
+	flags.Int(option.PolicyQueueSize, defaults.PolicyQueueSize, "size of queues for policy-related events")
+	option.BindEnv(option.PolicyQueueSize)
 	viper.BindPFlags(flags)
 }
 

--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -199,6 +199,11 @@ type PolicyAddResult struct {
 	err    error
 }
 
+// PolicyAdd adds a slice of rules to the policy repository owned by the
+// daemon. Eventual changes in policy rules are propagated to all locally
+// managed endpoints. Returns the policy revision number of the repository after
+// adding the rules into the repository, or an error if the updated policy
+// was not able to be imported.
 func (d *Daemon) PolicyAdd(rules policyAPI.Rules, opts *AddOptions) (newRev uint64, err error) {
 	p := &PolicyAddEvent{
 		rules: rules,

--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -213,14 +213,12 @@ func (d *Daemon) PolicyAdd(rules policyAPI.Rules, opts *AddOptions) (newRev uint
 	polAddEvent := eventqueue.NewEvent(p)
 	resChan := d.policy.RepositoryChangeQueue.Enqueue(polAddEvent)
 
-	select {
-	case res, ok := <-resChan:
-		if ok {
-			pRes := res.(*PolicyAddResult)
-			return pRes.newRev, pRes.err
-		}
-		return 0, fmt.Errorf("policy addition event was cancelled")
+	res, ok := <-resChan
+	if ok {
+		pRes := res.(*PolicyAddResult)
+		return pRes.newRev, pRes.err
 	}
+	return 0, fmt.Errorf("policy addition event was cancelled")
 }
 
 // policyAdd adds a slice of rules to the policy repository owned by the
@@ -405,14 +403,12 @@ func (d *Daemon) PolicyDelete(labels labels.LabelArray) (newRev uint64, err erro
 	policyDeleteEvent := eventqueue.NewEvent(p)
 	resChan := d.policy.RepositoryChangeQueue.Enqueue(policyDeleteEvent)
 
-	select {
-	case res, ok := <-resChan:
-		if ok {
-			ress := res.(*PolicyDeleteResult)
-			return ress.newRev, ress.err
-		}
-		return 0, fmt.Errorf("policy deletion event cancelled")
+	res, ok := <-resChan
+	if ok {
+		ress := res.(*PolicyDeleteResult)
+		return ress.newRev, ress.err
 	}
+	return 0, fmt.Errorf("policy deletion event cancelled")
 }
 
 func (d *Daemon) policyDelete(labels labels.LabelArray, res chan interface{}) {

--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -283,8 +283,6 @@ func (d *Daemon) policyAdd(rules policyAPI.Rules, opts *AddOptions, resChan chan
 		return
 	}
 
-	// No errors past this point!
-
 	d.policy.Mutex.Lock()
 
 	// removedPrefixes tracks prefixes that we replace in the rules. It is used

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -164,4 +164,7 @@ const (
 
 	// KVstorePeriodicSync is the default kvstore periodic sync interval
 	KVstorePeriodicSync = 5 * time.Minute
+
+	// PolicyQueueSize is the default queue size for policy-related events.
+	PolicyQueueSize = 100
 )

--- a/pkg/eventqueue/doc.go
+++ b/pkg/eventqueue/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package eventqueue implements a queue-based system for event processing in a
+// generic fashion in a first-in, first-out manner.
+package eventqueue

--- a/pkg/eventqueue/eventqueue.go
+++ b/pkg/eventqueue/eventqueue.go
@@ -1,0 +1,263 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eventqueue
+
+import (
+	"reflect"
+	"sync"
+
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/spanstat"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "eventqueue")
+)
+
+// EventQueue is a structure which is utilized to handle Events in a first-in,
+// first-out order. An EventQueue may be closed, in which case all events which
+// are queued up, but have not been processed yet, will be cancelled (i.e., not
+// ran). It is guaranteed that no events will be scheduled onto an EventQueue
+// after it has been closed; if any event is attempted to be scheduled onto an
+// EventQueue after it has been closed, it will be cancelled immediately. For
+// any event to be processed by the EventQueue, it must implement the
+// `EventHandler` interface. This allows for different types of events to be
+// processed by anything which chooses to utilize an `EventQueue`.
+type EventQueue struct {
+	// This should always be a buffered channel.
+	events chan *Event
+
+	// close is closed once the EventQueue has been closed.
+	close chan struct{}
+
+	// drain is closed when the EventQueue is stopped. Any Event which is
+	// Enqueued after this channel is closed will be cancelled / not processed
+	// by the queue. If an Event has been Enqueued, but has not been processed
+	// before this channel is closed, it will be cancelled and not processed
+	// as well.
+	drain chan struct{}
+
+	// eventQueueOnce is used to ensure that the EventQueue business logic can
+	// only be ran once.
+	eventQueueOnce sync.Once
+
+	// closeOnce is used to ensure that the EventQueue can only be closed once.
+	closeOnce sync.Once
+
+	// closeWaitGroup ensures that the events channel is not closed before all
+	// events have been consumed off of it.
+	closeWaitGroup sync.WaitGroup
+}
+
+// NewEventQueue returns an EventQueue with a capacity for only one event at
+// a time.
+func NewEventQueue() *EventQueue {
+	return NewEventQueueBuffered(1)
+
+}
+
+// NewEventQueueBuffered returns an EventQueue with a capacity of,
+// numBufferedEvents at a time, and all other needed fields initialized.
+func NewEventQueueBuffered(numBufferedEvents int) *EventQueue {
+	return &EventQueue{
+		// Up to numBufferedEvents can be Enqueued until Enqueueing blocks.
+		events: make(chan *Event, numBufferedEvents),
+		close:  make(chan struct{}),
+		drain:  make(chan struct{}),
+	}
+
+}
+
+// Event is an event that can be enqueued onto an EventQueue.
+type Event struct {
+	// Metadata is the information about the event which is sent
+	// by its queuer. Metadata must implement the EventHandler interface in
+	// order for the Event to be successfully processed by the EventQueue.
+	Metadata EventHandler
+
+	// EventResults is a channel on which the results of the event are sent.
+	// It is populated by the EventQueue itself, not by the queuer. This channel
+	// is closed if the event is cancelled.
+	eventResults chan interface{}
+
+	// cancelled signals that the given Event was not ran. This can happen
+	// if the EventQueue processing this Event was closed before the Event was
+	// Enqueued onto the Event queue, or if the Event was Enqueued onto an
+	// EventQueue, and the EventQueue on which the Event was scheduled was
+	// closed.
+	cancelled chan struct{}
+
+	// stats is a field which contains information about when this event is
+	// enqueued, dequeued, etc.
+	stats eventStatistics
+}
+
+type eventStatistics struct {
+
+	// waitEnqueue shows how long a given event was waiting on the queue before
+	// it was actually processed.
+	waitEnqueue spanstat.SpanStat
+
+	// durationStat shows how long the actual processing of the event took. This
+	// is the time for how long Handle() takes for the event.
+	durationStat spanstat.SpanStat
+
+	// waitConsumeOffQueue shows how long it took for the event to be consumed
+	// off of the queue.
+	waitConsumeOffQueue spanstat.SpanStat
+}
+
+// NewEvent returns an Event with all fields initialized.
+func NewEvent(meta EventHandler) *Event {
+	return &Event{
+		Metadata:     meta,
+		eventResults: make(chan interface{}, 1),
+		cancelled:    make(chan struct{}),
+		stats:        eventStatistics{},
+	}
+}
+
+// WasCancelled returns whether the cancelled channel for the given Event has
+// been closed or not. Cancellation occurs if the event was not processed yet
+// by an EventQueue onto which this Event was Enqueued, and the queue is closed,
+// or if the event was attempted to be scheduled onto an EventQueue which has
+// already been closed.
+func (ev *Event) WasCancelled() bool {
+	select {
+	case <-ev.cancelled:
+		return true
+	default:
+		return false
+	}
+}
+
+// Enqueue pushes the given event onto the EventQueue. If the queue has been
+// stopped, the Event will not be enqueued, and its cancel channel will be
+// closed, indicating that the Event was not ran. This function may block if
+// the queue is at its capacity for events.
+func (q *EventQueue) Enqueue(ev *Event) <-chan interface{} {
+
+	if ev == nil {
+		return nil
+	}
+
+	// Track that event has been Enqueued.
+	q.closeWaitGroup.Add(1)
+	defer q.closeWaitGroup.Done()
+
+	select {
+	// The event should be drained from the queue (e.g., it should not be
+	// processed).
+	case <-q.drain:
+		// Closed eventResults channel signifies cancellation.
+		close(ev.cancelled)
+		close(ev.eventResults)
+
+		return ev.eventResults
+	default:
+		// The events channel may be closed even if an event has been pushed
+		// onto the events channel, as events are consumed off of the events
+		// channel asynchronously! If the EventQueue is closed before this
+		// event is processed, then it will be cancelled.
+
+		ev.stats.waitEnqueue.Start()
+		q.events <- ev
+		ev.stats.waitEnqueue.End(true)
+		ev.stats.waitConsumeOffQueue.Start()
+		return ev.eventResults
+	}
+}
+
+func (ev *Event) printStats() {
+	log.WithFields(logrus.Fields{
+		"eventType":                    reflect.TypeOf(ev.Metadata).String(),
+		"eventHandlingDuration":        ev.stats.durationStat.Total(),
+		"eventEnqueueWaitTime":         ev.stats.waitEnqueue.Total(),
+		"eventConsumeOffQueueWaitTime": ev.stats.waitConsumeOffQueue.Total(),
+	}).Debug("EventQueue event processing statistics")
+}
+
+// Run consumes events that have been queued for this EventQueue. It
+// is presumed that the eventQueue is a buffered channel with a length of one
+// (i.e., only one event can be processed at a time). All business logic for
+// handling queued events is contained within this function. The events in the
+// queue must implement the EventHandler interface. If the event queue is
+// closed, then all events which were queued up, but not processed, are
+// cancelled; any event which is currently being processed will not be
+// cancelled.
+func (q *EventQueue) Run() {
+	go q.eventQueueOnce.Do(func() {
+		for ev := range q.events {
+			select {
+			case <-q.drain:
+				ev.stats.waitConsumeOffQueue.End(false)
+				close(ev.cancelled)
+				close(ev.eventResults)
+				ev.printStats()
+			default:
+				ev.stats.waitConsumeOffQueue.End(true)
+				ev.stats.durationStat.Start()
+				ev.Metadata.Handle(ev.eventResults)
+				// Always indicate success for now.
+				ev.stats.durationStat.End(true)
+				// Ensures that no more results can be sent as the event has
+				// already been processed.
+				ev.printStats()
+				close(ev.eventResults)
+			}
+		}
+	})
+}
+
+// Stop stops any further events from being processed by the EventQueue. Any
+// event which is currently being processed by the EventQueue will continue to
+// run. All other events waiting to be processed, and all events that may be
+// enqueued will not be processed by the event queue; they will be cancelled.
+// If the queue has already been stopped, this is a no-op.
+func (q *EventQueue) Stop() {
+	q.closeOnce.Do(func() {
+		// Any event that is sent to the queue at this point will be cancelled
+		// immediately in Enqueue().
+		close(q.drain)
+
+		// Wait for all events which have been queued to be processed. If
+		// a large amount of events are continuously enqueued at this point,
+		// then this may block. But, in most scenarios, this should exit
+		// fairly quickly.
+		q.closeWaitGroup.Wait()
+
+		// Signal that the queue has been drained.
+		close(q.close)
+
+		// This will cause Run() to receive a nil event.
+		close(q.events)
+	})
+}
+
+// IsDrained returns the channel which waits for the EventQueue to have been
+// stopped. This allows for queuers to ensure that all events in the queue have
+// been processed or cancelled.
+func (q *EventQueue) IsDrained() <-chan struct{} {
+	return q.close
+}
+
+// EventHandler is an interface for allowing an EventQueue to handle events
+// in a generic way. To be processed by the EventQueue, all event types must
+// implement any function specified in this interface.
+type EventHandler interface {
+	Handle(chan interface{})
+}

--- a/pkg/eventqueue/eventqueue.go
+++ b/pkg/eventqueue/eventqueue.go
@@ -89,7 +89,7 @@ type Event struct {
 	// order for the Event to be successfully processed by the EventQueue.
 	Metadata EventHandler
 
-	// EventResults is a channel on which the results of the event are sent.
+	// eventResults is a channel on which the results of the event are sent.
 	// It is populated by the EventQueue itself, not by the queuer. This channel
 	// is closed if the event is cancelled.
 	eventResults chan interface{}

--- a/pkg/eventqueue/eventqueue_test.go
+++ b/pkg/eventqueue/eventqueue_test.go
@@ -1,0 +1,169 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package eventqueue
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) { TestingT(t) }
+
+type EventQueueSuite struct{}
+
+var _ = Suite(&EventQueueSuite{})
+
+func (s *EventQueueSuite) TestNewEventQueue(c *C) {
+	q := NewEventQueue()
+	c.Assert(q.close, Not(IsNil))
+	c.Assert(q.events, Not(IsNil))
+	c.Assert(q.drain, Not(IsNil))
+	c.Assert(cap(q.events), Equals, 1)
+}
+
+func (s *EventQueueSuite) TestCloseEventQueueMultipleTimes(c *C) {
+	q := NewEventQueue()
+	q.Stop()
+	// Closing event queue twice should not cause panic.
+	q.Stop()
+}
+
+func (s *EventQueueSuite) TestDrained(c *C) {
+	q := NewEventQueue()
+	q.Run()
+
+	// Stopping queue should drain it as well.
+	q.Stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*500)
+	defer cancel()
+
+	select {
+	case <-q.IsDrained():
+	case <-ctx.Done():
+		c.Log("timed out waiting for queue to be drained")
+		c.Fail()
+	}
+}
+
+func (s *EventQueueSuite) TestNewEvent(c *C) {
+	e := NewEvent(&DummyEvent{})
+	c.Assert(e.Metadata, Not(IsNil))
+	c.Assert(e.eventResults, Not(IsNil))
+	c.Assert(e.cancelled, Not(IsNil))
+}
+
+type DummyEvent struct{}
+
+func (d *DummyEvent) Handle(ifc chan interface{}) {
+	ifc <- struct{}{}
+}
+
+func (s *EventQueueSuite) TestEventCancelAfterQueueClosed(c *C) {
+	q := NewEventQueue()
+	q.Run()
+	ev := NewEvent(&DummyEvent{})
+	q.Enqueue(ev)
+
+	// Event should not have been cancelled since queue was not closed.
+	c.Assert(ev.WasCancelled(), Equals, false)
+	q.Stop()
+
+	ev = NewEvent(&DummyEvent{})
+	q.Enqueue(ev)
+	c.Assert(ev.WasCancelled(), Equals, true)
+}
+
+type NewHangEvent struct {
+	Channel   chan struct{}
+	processed bool
+}
+
+func (n *NewHangEvent) Handle(ifc chan interface{}) {
+	<-n.Channel
+	n.processed = true
+	ifc <- struct{}{}
+}
+
+func CreateHangEvent() *NewHangEvent {
+	return &NewHangEvent{
+		Channel: make(chan struct{}),
+	}
+}
+
+func (s *EventQueueSuite) TestDrain(c *C) {
+	q := NewEventQueue()
+	q.Run()
+
+	nh1 := CreateHangEvent()
+	nh2 := CreateHangEvent()
+	nh3 := CreateHangEvent()
+
+	ev := NewEvent(nh1)
+	q.Enqueue(ev)
+
+	ev2 := NewEvent(nh2)
+	ev3 := NewEvent(nh3)
+
+	q.Enqueue(ev2)
+
+	var rcvChan <-chan interface{}
+
+	enq := make(chan struct{})
+
+	go func() {
+		rcvChan = q.Enqueue(ev3)
+		enq <- struct{}{}
+	}()
+
+	close(nh1.Channel)
+
+	// Ensure that the event is enqueued. Because nh2.Channel hasn't been closed
+	// We know that the event hasn't been handled yet.
+	select {
+	case <-enq:
+		break
+	}
+
+	// Stop queue in goroutine so we don't block on all events being processed
+	// (because nh2 nor nh3 haven't had their channels closed yet).
+	go q.Stop()
+
+	// Ensure channel has began to drain after stopping.
+	select {
+	case <-q.drain:
+	}
+
+	// Allow nh2 handling to unblock so we can wait for ev3 to be cancelled.
+	close(nh2.Channel)
+
+	// Event was drained, so it should have been cancelled.
+	select {
+	case _, ok := <-rcvChan:
+		c.Assert(ok, Equals, false)
+		c.Assert(ev3.WasCancelled(), Equals, true)
+
+		// Event wasn't processed because it was drained. See Handle() for
+		// NewHangEvent.
+		c.Assert(nh3.processed, Equals, false)
+	}
+
+}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -415,6 +415,10 @@ const (
 
 	// EnableHealthChecking is the name of the EnableHealthChecking option
 	EnableHealthChecking = "enable-health-checking"
+
+	// PolicyQueueSize is the size of the queues utilized by the policy
+	// repository.
+	PolicyQueueSize = "policy-queue-size"
 )
 
 // FQDNS variables
@@ -818,6 +822,10 @@ type DaemonConfig struct {
 	// already been allocated and other nodes in the cluster have a chance
 	// to whitelist the new upcoming identity of the endpoint.
 	IdentityChangeGracePeriod time.Duration
+
+	// PolicyQueueSize is the size of the queues for the policy repository.
+	// A larger queue means that more events related to policy can be buffered.
+	PolicyQueueSize int
 }
 
 var (
@@ -1169,6 +1177,20 @@ func (c *DaemonConfig) Populate() {
 	c.MaxControllerInterval = viper.GetInt(MaxCtrlIntervalName)
 	c.SidecarHTTPProxy = viper.GetBool(SidecarHTTPProxy)
 	c.CMDRefDir = viper.GetString(CMDRef)
+	c.PolicyQueueSize = sanitizeIntParam(PolicyQueueSize, defaults.PolicyQueueSize)
+}
+
+func sanitizeIntParam(paramName string, paramDefault int) int {
+	intParam := viper.GetInt(paramName)
+	if intParam <= 0 {
+		log.WithFields(
+			logrus.Fields{
+				"parameter":    paramName,
+				"defaultValue": paramDefault,
+			}).Warning("user-provided parameter had value <= 0 , which is invalid ; setting to default")
+		return paramDefault
+	}
+	return intParam
 }
 
 func getIPv4Enabled() bool {

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -53,8 +53,8 @@ type Repository struct {
 
 // NewPolicyRepository allocates a new policy repository
 func NewPolicyRepository() *Repository {
-	repoChangeQueue := eventqueue.NewEventQueueBuffered(100)
-	ruleReactionQueue := eventqueue.NewEventQueueBuffered(100)
+	repoChangeQueue := eventqueue.NewEventQueueBuffered(option.Config.PolicyQueueSize)
+	ruleReactionQueue := eventqueue.NewEventQueueBuffered(option.Config.PolicyQueueSize)
 	repoChangeQueue.Run()
 	ruleReactionQueue.Run()
 	return &Repository{


### PR DESCRIPTION
This originally was part of 
https://github.com/cilium/cilium/pull/6943 .

This PR serves to serialize the various types of events which change the state of the policy repository to avoid race-y behavior from occurring (from FQDN policy updates, for instance). It does this via using a new structure, the EventQueue.


The EventQueue package implements a queue-based system for event processing in a generic fashion in a first-in, first-out manner. An EventQueue may be closed, in which case all events which are queued up, but have not been processed, will be cancelled (i.e., not ran). It is guaranteed that no events will be scheduled onto an EventQueue after it has been closed; if any event is attempted to be scheduled onto an EventQueue after it has been closed, it will be cancelled immediately. For any event to be processed by the EventQueue, it must implement the EventHandler interface. This allows for different types of events to be processed by anything which chooses to utilize an EventQueue.

To ensure correctness in ordering these events, and for future work, two EventQueues are added to the Repository type:

* RepositoryChangeQueue: this serializes policy repository changes (update, delete, insert). This ensures that the operations associated with updating the policy repository are serialized, without the entirety of the operations holding the repository lock.
* RuleReactionQueue : this serializes the 'reacting' to events based on policy changes without blocking the policy API. This is not used currently, and will be utilized in future work (#6943).

Both of these queues are buffered up to 100 events each. After this point, the API will block. Their length is configurable via the configuration option `policy-queue-size`. 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7445)
<!-- Reviewable:end -->