### PR TITLE
Offload node events to cilium-operator and decrease number pod events received in cilium

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -158,15 +158,6 @@ type Daemon struct {
 
 	clustermesh *clustermesh.ClusterMesh
 
-	// k8sResourceSyncWaitGroup is used to block the starting of the daemon,
-	// including regenerating restored endpoints (if specified) until all
-	// policies, services, ingresses, and endpoints stored in Kubernetes at the
-	// time of bootstrapping of the agent are consumed by Cilium.
-	// This prevents regeneration of endpoints, restoring of loadbalancer BPF
-	// maps, etc. being performed without crucial information in securing said
-	// components. See GH-5038 and GH-4457.
-	k8sResourceSyncWaitGroup sync.WaitGroup
-
 	// k8sResourceSyncedMu protects the k8sResourceSynced map.
 	k8sResourceSyncedMu lock.RWMutex
 

--- a/examples/kubernetes/1.10/cilium-containerd.yaml
+++ b/examples/kubernetes/1.10/cilium-containerd.yaml
@@ -512,17 +512,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.10/cilium-containerd.yaml
+++ b/examples/kubernetes/1.10/cilium-containerd.yaml
@@ -522,6 +522,7 @@ rules:
   resources:
   - services
   - endpoints
+  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -520,17 +520,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -530,6 +530,7 @@ rules:
   resources:
   - services
   - endpoints
+  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.10/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.10/cilium-external-etcd.yaml
@@ -519,17 +519,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.10/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.10/cilium-external-etcd.yaml
@@ -529,6 +529,7 @@ rules:
   resources:
   - services
   - endpoints
+  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.10/cilium-operator-sa.yaml
+++ b/examples/kubernetes/1.10/cilium-operator-sa.yaml
@@ -13,17 +13,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.10/cilium-operator-sa.yaml
+++ b/examples/kubernetes/1.10/cilium-operator-sa.yaml
@@ -23,6 +23,7 @@ rules:
   resources:
   - services
   - endpoints
+  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.10/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.10/cilium-with-node-init.yaml
@@ -519,17 +519,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.10/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.10/cilium-with-node-init.yaml
@@ -529,6 +529,7 @@ rules:
   resources:
   - services
   - endpoints
+  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -519,17 +519,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -529,6 +529,7 @@ rules:
   resources:
   - services
   - endpoints
+  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.11/cilium-containerd.yaml
+++ b/examples/kubernetes/1.11/cilium-containerd.yaml
@@ -524,6 +524,7 @@ rules:
   resources:
   - services
   - endpoints
+  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.11/cilium-containerd.yaml
+++ b/examples/kubernetes/1.11/cilium-containerd.yaml
@@ -514,17 +514,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -523,6 +523,7 @@ rules:
   resources:
   - services
   - endpoints
+  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -513,17 +513,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.11/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.11/cilium-external-etcd.yaml
@@ -521,17 +521,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.11/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.11/cilium-external-etcd.yaml
@@ -531,6 +531,7 @@ rules:
   resources:
   - services
   - endpoints
+  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.11/cilium-operator-sa.yaml
+++ b/examples/kubernetes/1.11/cilium-operator-sa.yaml
@@ -13,17 +13,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.11/cilium-operator-sa.yaml
+++ b/examples/kubernetes/1.11/cilium-operator-sa.yaml
@@ -23,6 +23,7 @@ rules:
   resources:
   - services
   - endpoints
+  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.11/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.11/cilium-with-node-init.yaml
@@ -519,17 +519,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.11/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.11/cilium-with-node-init.yaml
@@ -529,6 +529,7 @@ rules:
   resources:
   - services
   - endpoints
+  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -521,17 +521,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -531,6 +531,7 @@ rules:
   resources:
   - services
   - endpoints
+  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.12/cilium-containerd.yaml
+++ b/examples/kubernetes/1.12/cilium-containerd.yaml
@@ -524,6 +524,7 @@ rules:
   resources:
   - services
   - endpoints
+  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.12/cilium-containerd.yaml
+++ b/examples/kubernetes/1.12/cilium-containerd.yaml
@@ -514,17 +514,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -523,6 +523,7 @@ rules:
   resources:
   - services
   - endpoints
+  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -513,17 +513,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.12/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.12/cilium-external-etcd.yaml
@@ -521,17 +521,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.12/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.12/cilium-external-etcd.yaml
@@ -531,6 +531,7 @@ rules:
   resources:
   - services
   - endpoints
+  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.12/cilium-operator-sa.yaml
+++ b/examples/kubernetes/1.12/cilium-operator-sa.yaml
@@ -13,17 +13,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.12/cilium-operator-sa.yaml
+++ b/examples/kubernetes/1.12/cilium-operator-sa.yaml
@@ -23,6 +23,7 @@ rules:
   resources:
   - services
   - endpoints
+  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.12/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.12/cilium-with-node-init.yaml
@@ -519,17 +519,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.12/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.12/cilium-with-node-init.yaml
@@ -529,6 +529,7 @@ rules:
   resources:
   - services
   - endpoints
+  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -521,17 +521,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -531,6 +531,7 @@ rules:
   resources:
   - services
   - endpoints
+  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.13/cilium-containerd.yaml
+++ b/examples/kubernetes/1.13/cilium-containerd.yaml
@@ -524,6 +524,7 @@ rules:
   resources:
   - services
   - endpoints
+  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.13/cilium-containerd.yaml
+++ b/examples/kubernetes/1.13/cilium-containerd.yaml
@@ -514,17 +514,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.13/cilium-crio.yaml
+++ b/examples/kubernetes/1.13/cilium-crio.yaml
@@ -523,6 +523,7 @@ rules:
   resources:
   - services
   - endpoints
+  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.13/cilium-crio.yaml
+++ b/examples/kubernetes/1.13/cilium-crio.yaml
@@ -513,17 +513,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.13/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.13/cilium-external-etcd.yaml
@@ -521,17 +521,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.13/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.13/cilium-external-etcd.yaml
@@ -531,6 +531,7 @@ rules:
   resources:
   - services
   - endpoints
+  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.13/cilium-operator-sa.yaml
+++ b/examples/kubernetes/1.13/cilium-operator-sa.yaml
@@ -13,17 +13,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.13/cilium-operator-sa.yaml
+++ b/examples/kubernetes/1.13/cilium-operator-sa.yaml
@@ -23,6 +23,7 @@ rules:
   resources:
   - services
   - endpoints
+  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.13/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.13/cilium-with-node-init.yaml
@@ -519,17 +519,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.13/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.13/cilium-with-node-init.yaml
@@ -529,6 +529,7 @@ rules:
   resources:
   - services
   - endpoints
+  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.13/cilium.yaml
+++ b/examples/kubernetes/1.13/cilium.yaml
@@ -521,17 +521,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.13/cilium.yaml
+++ b/examples/kubernetes/1.13/cilium.yaml
@@ -531,6 +531,7 @@ rules:
   resources:
   - services
   - endpoints
+  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.14/cilium-containerd.yaml
+++ b/examples/kubernetes/1.14/cilium-containerd.yaml
@@ -524,6 +524,7 @@ rules:
   resources:
   - services
   - endpoints
+  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.14/cilium-containerd.yaml
+++ b/examples/kubernetes/1.14/cilium-containerd.yaml
@@ -514,17 +514,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.14/cilium-crio.yaml
+++ b/examples/kubernetes/1.14/cilium-crio.yaml
@@ -523,6 +523,7 @@ rules:
   resources:
   - services
   - endpoints
+  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.14/cilium-crio.yaml
+++ b/examples/kubernetes/1.14/cilium-crio.yaml
@@ -513,17 +513,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.14/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.14/cilium-external-etcd.yaml
@@ -521,17 +521,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.14/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.14/cilium-external-etcd.yaml
@@ -531,6 +531,7 @@ rules:
   resources:
   - services
   - endpoints
+  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.14/cilium-operator-sa.yaml
+++ b/examples/kubernetes/1.14/cilium-operator-sa.yaml
@@ -13,17 +13,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.14/cilium-operator-sa.yaml
+++ b/examples/kubernetes/1.14/cilium-operator-sa.yaml
@@ -23,6 +23,7 @@ rules:
   resources:
   - services
   - endpoints
+  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.14/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.14/cilium-with-node-init.yaml
@@ -519,17 +519,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.14/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.14/cilium-with-node-init.yaml
@@ -529,6 +529,7 @@ rules:
   resources:
   - services
   - endpoints
+  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.14/cilium.yaml
+++ b/examples/kubernetes/1.14/cilium.yaml
@@ -521,17 +521,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.14/cilium.yaml
+++ b/examples/kubernetes/1.14/cilium.yaml
@@ -531,6 +531,7 @@ rules:
   resources:
   - services
   - endpoints
+  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/templates/v1/cilium-operator-sa.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-operator-sa.yaml.sed
@@ -13,17 +13,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/templates/v1/cilium-operator-sa.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-operator-sa.yaml.sed
@@ -23,6 +23,7 @@ rules:
   resources:
   - services
   - endpoints
+  - nodes
   verbs:
   - get
   - list

--- a/operator/k8s_node.go
+++ b/operator/k8s_node.go
@@ -1,0 +1,97 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/cilium/cilium/pkg/k8s"
+	"github.com/cilium/cilium/pkg/kvstore/store"
+	"github.com/cilium/cilium/pkg/node"
+	nodeStore "github.com/cilium/cilium/pkg/node/store"
+	"github.com/cilium/cilium/pkg/serializer"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+)
+
+func runNodeWatcher() error {
+	serNodes := serializer.NewFunctionQueue(1024)
+
+	ciliumStore, err := store.JoinSharedStore(store.Configuration{
+		Prefix:     nodeStore.NodeStorePrefix,
+		KeyCreator: nodeStore.KeyCreator,
+	})
+	if err != nil {
+		return err
+	}
+
+	_, nodeController := k8s.NewInformer(
+		cache.NewListWatchFromClient(k8s.Client().CoreV1().RESTClient(),
+			"nodes", v1.NamespaceAll, fields.Everything()),
+		&v1.Node{},
+		0,
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				if n := k8s.CopyObjToV1Node(obj); n != nil {
+					serNodes.Enqueue(func() error {
+						nodeNew := k8s.ParseNode(n, node.FromKubernetes)
+						ciliumStore.UpdateKeySync(nodeNew)
+						return nil
+					}, serializer.NoRetry)
+				}
+			},
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				if oldNode := k8s.CopyObjToV1Node(oldObj); oldNode != nil {
+					if newNode := k8s.CopyObjToV1Node(newObj); newNode != nil {
+						if k8s.EqualV1Node(oldNode, newNode) {
+							return
+						}
+
+						serNodes.Enqueue(func() error {
+							newNode := k8s.ParseNode(newNode, node.FromKubernetes)
+							ciliumStore.UpdateKeySync(newNode)
+							return nil
+						}, serializer.NoRetry)
+					}
+				}
+			},
+			DeleteFunc: func(obj interface{}) {
+				n := k8s.CopyObjToV1Node(obj)
+				if n == nil {
+					deletedObj, ok := obj.(cache.DeletedFinalStateUnknown)
+					if !ok {
+						return
+					}
+					// Delete was not observed by the watcher but is
+					// removed from kube-apiserver. This is the last
+					// known state and the object no longer exists.
+					n = k8s.CopyObjToV1Node(deletedObj.Obj)
+					if n == nil {
+						return
+					}
+				}
+				serNodes.Enqueue(func() error {
+					deletedNode := k8s.ParseNode(n, node.FromKubernetes)
+					ciliumStore.DeleteLocalKey(deletedNode)
+					return nil
+				}, serializer.NoRetry)
+			},
+		},
+		k8s.ConvertToNode,
+	)
+	go nodeController.Run(wait.NeverStop)
+	return nil
+}

--- a/operator/main.go
+++ b/operator/main.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -171,6 +171,10 @@ func runOperator(cmd *cobra.Command) {
 
 	if enableCepGC {
 		enableCiliumEndpointSyncGC()
+	}
+
+	if err := runNodeWatcher(); err != nil {
+		log.WithError(err).Error("Unable to setup node watcher")
 	}
 
 	if identityGCInterval != time.Duration(0) {

--- a/pkg/kvstore/backend.go
+++ b/pkg/kvstore/backend.go
@@ -131,6 +131,13 @@ func getBackend(name string) backendModule {
 // must implement. Direct use of this interface is possible but will bypass the
 // tracing layer.
 type BackendOperations interface {
+	// Connected returns a channel which is closed whenever the kvstore client
+	// is connected to the kvstore server. (Only implemented for etcd)
+	Connected() <-chan struct{}
+
+	// Disconnected returns a channel which is closed whenever the kvstore
+	// client is not connected to the kvstore server. (Only implemented for etcd)
+	Disconnected() <-chan struct{}
 
 	// Status returns the status of the kvstore client including an
 	// eventual error

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -539,6 +539,7 @@ func (e *etcdClient) Watch(w *Watcher) {
 		fieldWatcher: w,
 		fieldPrefix:  w.prefix,
 	})
+	<-e.Connected()
 
 reList:
 	for {

--- a/pkg/kvstore/store/store.go
+++ b/pkg/kvstore/store/store.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -323,6 +323,17 @@ func (s *SharedStore) UpdateLocalKeySync(key LocalKey) error {
 	}
 
 	return nil
+}
+
+// UpdateKeySync synchronously synchronizes a key with the kvstore.
+func (s *SharedStore) UpdateKeySync(key LocalKey) error {
+	err := s.syncLocalKey(key)
+	if err != nil {
+		s.DeleteLocalKey(key)
+		return err
+	}
+
+	return err
 }
 
 // DeleteLocalKey removes a key from being synchronized with the kvstore


### PR DESCRIPTION
Once cilium is connected to the kvstore we can stop listenning for node
events from k8s and start listening for node events in the kvstore
instead.

A similar case goes to pod events where we can stop listening for all pod
events from k8s once we have connectivity with the kvstore and start listening
for pod events for pods running in the node where cilium is running.

~!!!! **BUG** !!!!: There's still a bug that I haven't figure out, the ip routes are not removed, 
from remaining nodes, once other nodes are deleted, it seems the cilium agents are ignoring
delete events from the kvstore.~

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7447)
<!-- Reviewable:end -->
