### PR TITLE
WIP: Debug SIGBUS

### DIFF
--- a/contrib/scripts/check-cmdref.sh
+++ b/contrib/scripts/check-cmdref.sh
@@ -8,7 +8,7 @@ OLD_DIR=${DOCS_DIR}/cmdref
 TMP_DIR=`mktemp -d`
 trap 'rm -rf $TMP_DIR' EXIT INT TERM
 
-${MAKE} CMDREFDIR=${TMP_DIR} -C ${DOCS_DIR} cmdref
+${MAKE} CMDREFDIR=${TMP_DIR} -C ${DOCS_DIR} cmdref || dmesg
 
 if ! diff -x '*.rst' -r ${OLD_DIR} ${TMP_DIR}; then
   # echo is used here intentional to avoid the splat when running from top


### PR DESCRIPTION
This PR is just for debugging purpose to figure out why Cilium's `cmdref` sometimes (observed two times on the 5.0 kernel) causes SIGBUS:

```
[2019-03-19T12:41:41.918Z]     runtime: make[1]: Entering directory '/home/vagrant/go/src/github.com/cilium/cilium/Documentation'
[2019-03-19T12:41:41.918Z]     runtime: # We don't know what changed so recreate the directory
[2019-03-19T12:41:41.918Z]     runtime: rm -rvf /tmp/tmp.UlIDPZcEGB/cilium*
[2019-03-19T12:41:41.918Z]     runtime: ../daemon/cilium cmdref -d /tmp/tmp.UlIDPZcEGB
[2019-03-19T12:41:41.918Z]     runtime: fatal error: 
[2019-03-19T12:41:41.918Z]     runtime: unexpected signal during runtime execution
[2019-03-19T12:41:41.918Z]     runtime: [signal 
[2019-03-19T12:41:41.918Z]     runtime: SIGBUS: bus error
[2019-03-19T12:41:41.918Z]     runtime:  code=
[2019-03-19T12:41:41.918Z]     runtime: 0x2
[2019-03-19T12:41:41.918Z]     runtime:  addr=
[2019-03-19T12:41:41.918Z]     runtime: 0x3ad76cc
[2019-03-19T12:41:41.918Z]     runtime:  pc=
[2019-03-19T12:41:41.918Z]     runtime: 0x10ef7fa
[2019-03-19T12:41:41.918Z]     runtime: ]
[2019-03-19T12:41:41.918Z]     runtime: 
[2019-03-19T12:41:41.918Z]     runtime: runtime stack:
[2019-03-19T12:41:41.918Z]     runtime: runtime.throw
[2019-03-19T12:41:41.918Z]     runtime: (
[2019-03-19T12:41:41.918Z]     runtime: 0x2f7d67e
[2019-03-19T12:41:41.918Z]     runtime: , 
[2019-03-19T12:41:41.918Z]     runtime: 0x2a
[2019-03-19T12:41:41.918Z]     runtime: )
[2019-03-19T12:41:41.918Z]     runtime: 	
[2019-03-19T12:41:41.918Z]     runtime: /usr/local/go/src/runtime/panic.go
[2019-03-19T12:41:41.918Z]     runtime: :
[2019-03-19T12:41:41.918Z]     runtime: 617
[2019-03-19T12:41:41.918Z]     runtime:  +
[2019-03-19T12:41:41.918Z]     runtime: 0x72
[2019-03-19T12:41:41.918Z]     runtime: runtime.sigpanic
[2019-03-19T12:41:41.918Z]     runtime: (
[2019-03-19T12:41:41.918Z]     runtime: )
[2019-03-19T12:41:41.918Z]     runtime: 	
[2019-03-19T12:41:41.918Z]     runtime: /usr/local/go/src/runtime/signal_unix.go
[2019-03-19T12:41:41.918Z]     runtime: :
[2019-03-19T12:41:41.918Z]     runtime: 374
[2019-03-19T12:41:41.918Z]     runtime:  +
[2019-03-19T12:41:41.918Z]     runtime: 0x4a9
[2019-03-19T12:41:41.918Z]     runtime: runtime.isSystemGoroutine
[2019-03-19T12:41:41.918Z]     runtime: (
[2019-03-19T12:41:41.918Z]     runtime: 0xc000482f00
[2019-03-19T12:41:41.918Z]     runtime: , 
[2019-03-19T12:41:41.918Z]     runtime: 0x0
[2019-03-19T12:41:41.918Z]     runtime: , 
[2019-03-19T12:41:41.918Z]     runtime: 0x10
[2019-03-19T12:41:41.918Z]     runtime: )
[2019-03-19T12:41:41.918Z]     runtime: 	
[2019-03-19T12:41:41.918Z]     runtime: /usr/local/go/src/runtime/traceback.go
[2019-03-19T12:41:41.918Z]     runtime: :
[2019-03-19T12:41:41.918Z]     runtime: 1036
[2019-03-19T12:41:41.918Z]     runtime:  +
[2019-03-19T12:41:41.918Z]     runtime: 0x4a
[2019-03-19T12:41:41.918Z]     runtime: runtime.newproc1
[2019-03-19T12:41:41.918Z]     runtime: (
[2019-03-19T12:41:41.918Z]     runtime: 0x303d298
[2019-03-19T12:41:41.918Z]     runtime: , 
[2019-03-19T12:41:41.918Z]     runtime: 0xc00064dcc0
[2019-03-19T12:41:41.918Z]     runtime: , 
[2019-03-19T12:41:41.918Z]     runtime: 0x7fff00000010
[2019-03-19T12:41:41.918Z]     runtime: , 
[2019-03-19T12:41:41.918Z]     runtime: 0xc000000180
[2019-03-19T12:41:41.918Z]     runtime: , 
[2019-03-19T12:41:41.918Z]     runtime: 0x18035ef
[2019-03-19T12:41:41.918Z]     runtime: )
[2019-03-19T12:41:41.918Z]     runtime: 	
[2019-03-19T12:41:41.918Z]     runtime: /usr/local/go/src/runtime/proc.go
[2019-03-19T12:41:41.918Z]     runtime: :
[2019-03-19T12:41:41.918Z]     runtime: 3326
[2019-03-19T12:41:41.918Z]     runtime:  +
[2019-03-19T12:41:41.918Z]     runtime: 0x1d7
[2019-03-19T12:41:41.918Z]     runtime: runtime.newproc.func1
[2019-03-19T12:41:41.918Z]     runtime: (
[2019-03-19T12:41:41.918Z]     runtime: )
[2019-03-19T12:41:41.918Z]     runtime: 	
[2019-03-19T12:41:41.918Z]     runtime: /usr/local/go/src/runtime/proc.go
[2019-03-19T12:41:41.918Z]     runtime: :
[2019-03-19T12:41:41.918Z]     runtime: 3244
[2019-03-19T12:41:41.918Z]     runtime:  +
[2019-03-19T12:41:41.918Z]     runtime: 0x4f
[2019-03-19T12:41:41.918Z]     runtime: runtime.systemstack
[2019-03-19T12:41:41.918Z]     runtime: (
[2019-03-19T12:41:41.918Z]     runtime: 0x10f6879
[2019-03-19T12:41:41.918Z]     runtime: )
[2019-03-19T12:41:41.918Z]     runtime: 	
[2019-03-19T12:41:41.918Z]     runtime: /usr/local/go/src/runtime/asm_amd64.s
[2019-03-19T12:41:41.918Z]     runtime: :
[2019-03-19T12:41:41.918Z]     runtime: 351
[2019-03-19T12:41:41.918Z]     runtime:  +
[2019-03-19T12:41:41.918Z]     runtime: 0x66
[2019-03-19T12:41:41.918Z]     runtime: runtime.mstart
[2019-03-19T12:41:41.918Z]     runtime: (
[2019-03-19T12:41:41.918Z]     runtime: )
[2019-03-19T12:41:41.918Z]     runtime: 	
[2019-03-19T12:41:41.918Z]     runtime: /usr/local/go/src/runtime/proc.go
[2019-03-19T12:41:41.918Z]     runtime: :
[2019-03-19T12:41:41.918Z]     runtime: 1153
[2019-03-19T12:41:41.918Z]     runtime: goroutine 
[2019-03-19T12:41:41.918Z]     runtime: 1
[2019-03-19T12:41:41.918Z]     runtime:  [
[2019-03-19T12:41:41.918Z]     runtime: running
[2019-03-19T12:41:41.918Z]     runtime: , locked to thread
[2019-03-19T12:41:41.918Z]     runtime: ]:
[2019-03-19T12:41:41.918Z]     runtime: runtime.systemstack_switch
[2019-03-19T12:41:41.919Z]     runtime: (
[2019-03-19T12:41:41.919Z]     runtime: )
[2019-03-19T12:41:41.919Z]     runtime: 	
[2019-03-19T12:41:41.919Z]     runtime: /usr/local/go/src/runtime/asm_amd64.s
[2019-03-19T12:41:41.919Z]     runtime: :
[2019-03-19T12:41:41.919Z]     runtime: 311
[2019-03-19T12:41:41.919Z]     runtime:  fp=
[2019-03-19T12:41:41.919Z]     runtime: 0xc00064dc68
[2019-03-19T12:41:41.919Z]     runtime:  sp=
[2019-03-19T12:41:41.919Z]     runtime: 0xc00064dc60
[2019-03-19T12:41:41.919Z]     runtime:  pc=
[2019-03-19T12:41:41.919Z]     runtime: 0x10f6970
[2019-03-19T12:41:41.919Z]     runtime: runtime.newproc
[2019-03-19T12:41:41.919Z]     runtime: (
[2019-03-19T12:41:41.919Z]     runtime: 0x10
[2019-03-19T12:41:41.919Z]     runtime: , 
[2019-03-19T12:41:41.919Z]     runtime: 0x303d298
[2019-03-19T12:41:41.919Z]     runtime: )
[2019-03-19T12:41:41.919Z]     runtime: 	
[2019-03-19T12:41:41.919Z]     runtime: /usr/local/go/src/runtime/proc.go
[2019-03-19T12:41:41.919Z]     runtime: :
[2019-03-19T12:41:41.919Z]     runtime: 3243
[2019-03-19T12:41:41.919Z]     runtime:  +
[2019-03-19T12:41:41.919Z]     runtime: 0x6f
[2019-03-19T12:41:41.919Z]     runtime:  fp=
[2019-03-19T12:41:41.919Z]     runtime: 0xc00064dcb0
[2019-03-19T12:41:41.919Z]     runtime:  sp=
[2019-03-19T12:41:41.919Z]     runtime: 0xc00064dc68
[2019-03-19T12:41:41.919Z]     runtime:  pc=
[2019-03-19T12:41:41.919Z]     runtime: 0x10d267f
[2019-03-19T12:41:41.919Z]     runtime: os/exec.(*Cmd).Start
[2019-03-19T12:41:41.919Z]     runtime: (
[2019-03-19T12:41:41.919Z]     runtime: 0xc0003838c0
[2019-03-19T12:41:41.919Z]     runtime: , 
[2019-03-19T12:41:41.919Z]     runtime: 0xc0004d5ef0
[2019-03-19T12:41:41.919Z]     runtime: , 
[2019-03-19T12:41:41.919Z]     runtime: 0xc00019fe40
[2019-03-19T12:41:41.919Z]     runtime: )
[2019-03-19T12:41:41.919Z]     runtime: 	
[2019-03-19T12:41:41.919Z]     runtime: /usr/local/go/src/os/exec/exec.go
[2019-03-19T12:41:41.919Z]     runtime: :
[2019-03-19T12:41:41.919Z]     runtime: 408
[2019-03-19T12:41:41.919Z]     runtime:  +
[2019-03-19T12:41:41.919Z]     runtime: 0x58f
[2019-03-19T12:41:41.919Z]     runtime:  fp=
[2019-03-19T12:41:41.919Z]     runtime: 0xc00064dde8
[2019-03-19T12:41:41.919Z]     runtime:  sp=
[2019-03-19T12:41:41.919Z]     runtime: 0xc00064dcb0
[2019-03-19T12:41:41.919Z]     runtime:  pc=
[2019-03-19T12:41:41.919Z]     runtime: 0x18035ef
[2019-03-19T12:41:41.919Z]     runtime: github.com/cilium/cilium/vendor/github.com/shirou/gopsutil/internal/common.Invoke.CommandWithContext
[2019-03-19T12:41:41.919Z]     runtime: (
[2019-03-19T12:41:41.919Z]     runtime: 0x337e400
[2019-03-19T12:41:41.919Z]     runtime: , 
[2019-03-19T12:41:41.919Z]     runtime: 0xc000052118
[2019-03-19T12:41:41.919Z]     runtime: , 
[2019-03-19T12:41:41.919Z]     runtime: 0x2f36a24
[2019-03-19T12:41:41.919Z]     runtime: , 
[2019-03-19T12:41:41.919Z]     runtime: 0x10
[2019-03-19T12:41:41.919Z]     runtime: , 
[2019-03-19T12:41:41.919Z]     runtime: 0xc00019fe40
[2019-03-19T12:41:41.919Z]     runtime: , 
[2019-03-19T12:41:41.919Z]     runtime: 0x1
[2019-03-19T12:41:41.919Z]     runtime: , 
[2019-03-19T12:41:41.919Z]     runtime: 0x1
[2019-03-19T12:41:41.919Z]     runtime: , 
[2019-03-19T12:41:41.919Z]     runtime: 0x10a7d88
[2019-03-19T12:41:41.919Z]     runtime: , 
[2019-03-19T12:41:41.919Z]     runtime: 0x10
[2019-03-19T12:41:41.919Z]     runtime: , 
[2019-03-19T12:41:41.919Z]     runtime: 0x2b474e0
[2019-03-19T12:41:41.919Z]     runtime: , ...
[2019-03-19T12:41:41.919Z]     runtime: )
[2019-03-19T12:41:41.919Z]     runtime: 	
[2019-03-19T12:41:41.919Z]     runtime: /home/vagrant/go/src/github.com/cilium/cilium/vendor/github.com/shirou/gopsutil/internal/common/common.go
[2019-03-19T12:41:41.919Z]     runtime: :
[2019-03-19T12:41:41.919Z]     runtime: 53
[2019-03-19T12:41:41.919Z]     runtime:  +
[2019-03-19T12:41:41.919Z]     runtime: 0xf1
[2019-03-19T12:41:41.919Z]     runtime:  fp=
[2019-03-19T12:41:41.919Z]     runtime: 0xc00064de38
[2019-03-19T12:41:41.919Z]     runtime:  sp=
[2019-03-19T12:41:41.919Z]     runtime: 0xc00064dde8
[2019-03-19T12:41:41.919Z]     runtime:  pc=
[2019-03-19T12:41:41.919Z]     runtime: 0x2326a41
[2019-03-19T12:41:41.919Z]     runtime: github.com/cilium/cilium/vendor/github.com/shirou/gopsutil/internal/common.(*Invoke).CommandWithContext
[2019-03-19T12:41:41.919Z]     runtime: (
[2019-03-19T12:41:41.919Z]     runtime: 0x50fce60
[2019-03-19T12:41:41.919Z]     runtime: , 
[2019-03-19T12:41:41.919Z]     runtime: 0x337e400
[2019-03-19T12:41:41.919Z]     runtime: , 
[2019-03-19T12:41:41.919Z]     runtime: 0xc000052118
[2019-03-19T12:41:41.919Z]     runtime: , 
[2019-03-19T12:41:41.919Z]     runtime: 0x2f36a24
[2019-03-19T12:41:41.919Z]     runtime: , 
[2019-03-19T12:41:41.919Z]     runtime: 0x10
[2019-03-19T12:41:41.919Z]     runtime: , 
[2019-03-19T12:41:41.919Z]     runtime: 0xc00019fe40
[2019-03-19T12:41:41.919Z]     runtime: , 
[2019-03-19T12:41:41.919Z]     runtime: 0x1
[2019-03-19T12:41:41.919Z]     runtime: , 
[2019-03-19T12:41:41.919Z]     runtime: 0x1
[2019-03-19T12:41:41.919Z]     runtime: , 
[2019-03-19T12:41:41.919Z]     runtime: 0x4bb4360
[2019-03-19T12:41:41.919Z]     runtime: , 
[2019-03-19T12:41:41.919Z]     runtime: 0xc000052118
[2019-03-19T12:41:41.919Z]     runtime: , ...
[2019-03-19T12:41:41.919Z]     runtime: )
[2019-03-19T12:41:41.919Z]     runtime: 	
[2019-03-19T12:41:41.919Z]     runtime: <autogenerated>
[2019-03-19T12:41:41.919Z]     runtime: :
[2019-03-19T12:41:41.919Z]     runtime: 1
[2019-03-19T12:41:41.919Z]     runtime:  +
[2019-03-19T12:41:41.919Z]     runtime: 0x96
[2019-03-19T12:41:41.919Z]     runtime:  fp=
[2019-03-19T12:41:41.919Z]     runtime: 0xc00064dea8
[2019-03-19T12:41:41.919Z]     runtime:  sp=
[2019-03-19T12:41:41.919Z]     runtime: 0xc00064de38
[2019-03-19T12:41:41.919Z]     runtime:  pc=
[2019-03-19T12:41:41.919Z]     runtime: 0x2327b66
[2019-03-19T12:41:41.919Z]     runtime: github.com/cilium/cilium/vendor/github.com/shirou/gopsutil/cpu.init.1
[2019-03-19T12:41:41.919Z]     runtime: (
[2019-03-19T12:41:41.919Z]     runtime: )
[2019-03-19T12:41:41.919Z]     runtime: 	
[2019-03-19T12:41:41.919Z]     runtime: /home/vagrant/go/src/github.com/cilium/cilium/vendor/github.com/shirou/gopsutil/cpu/cpu_linux.go
[2019-03-19T12:41:41.919Z]     runtime: :
[2019-03-19T12:41:41.919Z]     runtime: 23
[2019-03-19T12:41:41.919Z]     runtime:  +
[2019-03-19T12:41:41.919Z]     runtime: 0x105
[2019-03-19T12:41:41.919Z]     runtime:  fp=
[2019-03-19T12:41:41.919Z]     runtime: 0xc00064df38
[2019-03-19T12:41:41.919Z]     runtime:  sp=
[2019-03-19T12:41:41.919Z]     runtime: 0xc00064dea8
[2019-03-19T12:41:41.919Z]     runtime:  pc=
[2019-03-19T12:41:41.919Z]     runtime: 0x232aa55
[2019-03-19T12:41:41.919Z]     runtime: github.com/cilium/cilium/vendor/github.com/shirou/gopsutil/cpu.init
[2019-03-19T12:41:41.919Z]     runtime: (
[2019-03-19T12:41:41.919Z]     runtime: )
[2019-03-19T12:41:41.919Z]     runtime: 	
[2019-03-19T12:41:41.919Z]     runtime: <autogenerated>
[2019-03-19T12:41:41.919Z]     runtime: :
[2019-03-19T12:41:41.919Z]     runtime: 1
[2019-03-19T12:41:41.919Z]     runtime:  +
[2019-03-19T12:41:41.919Z]     runtime: 0x7c
[2019-03-19T12:41:41.919Z]     runtime:  fp=
[2019-03-19T12:41:41.919Z]     runtime: 0xc00064df48
[2019-03-19T12:41:41.919Z]     runtime:  sp=
[2019-03-19T12:41:41.919Z]     runtime: 0xc00064df38
[2019-03-19T12:41:41.919Z]     runtime:  pc=
[2019-03-19T12:41:41.919Z]     runtime: 0x232b95c
[2019-03-19T12:41:41.919Z]     runtime: github.com/cilium/cilium/vendor/github.com/shirou/gopsutil/process.init
[2019-03-19T12:41:41.919Z]     runtime: (
[2019-03-19T12:41:41.919Z]     runtime: )
[2019-03-19T12:41:41.919Z]     runtime: 	
[2019-03-19T12:41:41.919Z]     runtime: <autogenerated>
[2019-03-19T12:41:41.919Z]     runtime: :
[2019-03-19T12:41:41.919Z]     runtime: 1
[2019-03-19T12:41:41.919Z]     runtime:  +
[2019-03-19T12:41:41.919Z]     runtime: 0x5c
[2019-03-19T12:41:41.919Z]     runtime:  fp=
[2019-03-19T12:41:41.919Z]     runtime: 0xc00064df58
[2019-03-19T12:41:41.919Z]     runtime:  sp=
[2019-03-19T12:41:41.919Z]     runtime: 0xc00064df48
[2019-03-19T12:41:41.919Z]     runtime:  pc=
[2019-03-19T12:41:41.919Z]     runtime: 0x234062c
[2019-03-19T12:41:41.919Z]     runtime: github.com/cilium/cilium/pkg/loadinfo.init
[2019-03-19T12:41:41.919Z]     runtime: (
[2019-03-19T12:41:41.919Z]     runtime: )
[2019-03-19T12:41:41.919Z]     runtime: 	
[2019-03-19T12:41:41.919Z]     runtime: <autogenerated>
[2019-03-19T12:41:41.919Z]     runtime: :
[2019-03-19T12:41:41.919Z]     runtime: 1
[2019-03-19T12:41:41.919Z]     runtime:  +
[2019-03-19T12:41:41.919Z]     runtime: 0x63
[2019-03-19T12:41:41.919Z]     runtime:  fp=
[2019-03-19T12:41:41.919Z]     runtime: 0xc00064df68
[2019-03-19T12:41:41.919Z]     runtime:  sp=
[2019-03-19T12:41:41.919Z]     runtime: 0xc00064df58
[2019-03-19T12:41:41.919Z]     runtime:  pc=
[2019-03-19T12:41:41.919Z]     runtime: 0x2342483
[2019-03-19T12:41:41.919Z]     runtime: github.com/cilium/cilium/pkg/endpoint.init
[2019-03-19T12:41:41.919Z]     runtime: (
[2019-03-19T12:41:41.919Z]     runtime: )
[2019-03-19T12:41:41.919Z]     runtime: 	
[2019-03-19T12:41:41.919Z]     runtime: <autogenerated>
[2019-03-19T12:41:41.919Z]     runtime: :
[2019-03-19T12:41:41.919Z]     runtime: 1
[2019-03-19T12:41:41.919Z]     runtime:  +
[2019-03-19T12:41:41.919Z]     runtime: 0x8e
[2019-03-19T12:41:41.919Z]     runtime:  fp=
[2019-03-19T12:41:41.919Z]     runtime: 0xc00064df78
[2019-03-19T12:41:41.919Z]     runtime:  sp=
[2019-03-19T12:41:41.919Z]     runtime: 0xc00064df68
[2019-03-19T12:41:41.919Z]     runtime:  pc=
[2019-03-19T12:41:41.919Z]     runtime: 0x237d36e
[2019-03-19T12:41:41.919Z]     runtime: github.com/cilium/cilium/pkg/endpointmanager.init
[2019-03-19T12:41:41.919Z]     runtime: (
[2019-03-19T12:41:41.919Z]     runtime: )
[2019-03-19T12:41:41.919Z]     runtime: 	
[2019-03-19T12:41:41.919Z]     runtime: <autogenerated>
[2019-03-19T12:41:41.919Z]     runtime: :
[2019-03-19T12:41:41.919Z]     runtime: 1
[2019-03-19T12:41:41.919Z]     runtime:  +
[2019-03-19T12:41:41.919Z]     runtime: 0x57
[2019-03-19T12:41:41.919Z]     runtime:  fp=
[2019-03-19T12:41:41.919Z]     runtime: 0xc00064df88
[2019-03-19T12:41:41.919Z]     runtime:  sp=
[2019-03-19T12:41:41.919Z]     runtime: 0xc00064df78
[2019-03-19T12:41:41.919Z]     runtime:  pc=
[2019-03-19T12:41:41.919Z]     runtime: 0x23823b7
[2019-03-19T12:41:41.919Z]     runtime: main.init
[2019-03-19T12:41:41.919Z]     runtime: (
[2019-03-19T12:41:41.919Z]     runtime: )
[2019-03-19T12:41:41.919Z]     runtime: 	
[2019-03-19T12:41:41.919Z]     runtime: <autogenerated>
[2019-03-19T12:41:41.919Z]     runtime: :
[2019-03-19T12:41:41.919Z]     runtime: 1
[2019-03-19T12:41:41.919Z]     runtime:  +
[2019-03-19T12:41:41.919Z]     runtime: 0x84
[2019-03-19T12:41:41.919Z]     runtime:  fp=
[2019-03-19T12:41:41.919Z]     runtime: 0xc00064df98
[2019-03-19T12:41:41.919Z]     runtime:  sp=
[2019-03-19T12:41:41.919Z]     runtime: 0xc00064df88
[2019-03-19T12:41:41.919Z]     runtime:  pc=
[2019-03-19T12:41:41.919Z]     runtime: 0x291ed04
[2019-03-19T12:41:41.919Z]     runtime: runtime.main
[2019-03-19T12:41:41.919Z]     runtime: (
[2019-03-19T12:41:41.919Z]     runtime: )
[2019-03-19T12:41:41.919Z]     runtime: 	
[2019-03-19T12:41:41.919Z]     runtime: /usr/local/go/src/runtime/proc.go
[2019-03-19T12:41:41.919Z]     runtime: :
[2019-03-19T12:41:41.919Z]     runtime: 188
[2019-03-19T12:41:41.919Z]     runtime:  +
[2019-03-19T12:41:41.919Z]     runtime: 0x1c8
[2019-03-19T12:41:41.919Z]     runtime:  fp=
[2019-03-19T12:41:41.919Z]     runtime: 0xc00064dfe0
[2019-03-19T12:41:41.919Z]     runtime:  sp=
[2019-03-19T12:41:41.919Z]     runtime: 0xc00064df98
[2019-03-19T12:41:41.919Z]     runtime:  pc=
[2019-03-19T12:41:41.919Z]     runtime: 0x10cab28
[2019-03-19T12:41:41.919Z]     runtime: runtime.goexit()
[2019-03-19T12:41:41.919Z]     runtime: 	/usr/local/go/src/runtime/asm_amd64.s:1337 +0x1 fp=0xc00064dfe8 sp=0xc00064dfe0 pc=0x10f8a41
[2019-03-19T12:41:41.919Z]     runtime: 
[2019-03-19T12:41:41.919Z]     runtime: goroutine 4 [syscall]:
[2019-03-19T12:41:41.919Z]     runtime: os/signal.signal_recv(0x0)
[2019-03-19T12:41:41.919Z]     runtime: 	/usr/local/go/src/runtime/sigqueue.go:139 +0x9c
[2019-03-19T12:41:41.919Z]     runtime: os/signal.loop
[2019-03-19T12:41:41.919Z]     runtime: (
[2019-03-19T12:41:41.919Z]     runtime: )
[2019-03-19T12:41:41.919Z]     runtime: 	/usr/local/go/src/os/signal/signal_unix.go:23 +0x22
[2019-03-19T12:41:41.919Z]     runtime: created by os/signal.init.0
[2019-03-19T12:41:41.919Z]     runtime: 	/usr/local/go/src/os/signal/signal_unix.go:29 +0x41
[2019-03-19T12:41:41.919Z]     runtime: 
[2019-03-19T12:41:41.919Z]     runtime: goroutine 7 [chan receive]:
[2019-03-19T12:41:41.919Z]     runtime: github.com/cilium/cilium/vendor/k8s.io/klog.(*loggingT).flushDaemon
[2019-03-19T12:41:41.919Z]     runtime: (
[2019-03-19T12:41:41.919Z]     runtime: 0x4bb4e00)
[2019-03-19T12:41:41.919Z]     runtime: 	/home/vagrant/go/src/github.com/cilium/cilium/vendor/k8s.io/klog/klog.go:941 +0x8b
[2019-03-19T12:41:41.919Z]     runtime: created by 
[2019-03-19T12:41:41.919Z]     runtime: github.com/cilium/cilium/vendor/k8s.io/klog.init.0
[2019-03-19T12:41:41.919Z]     runtime: 
[2019-03-19T12:41:41.919Z]     runtime: 	/home/vagrant/go/src/github.com/cilium/cilium/vendor/k8s.io/klog/klog.go:403 +0x6c
[2019-03-19T12:41:41.919Z]     runtime: Makefile:36: recipe for target 'cmdref' failed
[2019-03-19T12:41:41.919Z]     runtime: make[1]: Leaving directory '/home/vagrant/go/src/github.com/cilium/cilium/Documentation'
[2019-03-19T12:41:41.919Z]     runtime: make[1]: *** [cmdref] Error 2
[2019-03-19T12:41:41.919Z]     runtime: Makefile:406: recipe for target 'postcheck' failed
[2019-03-19T12:41:41.919Z]     runtime: make: *** [postcheck] Error 2
```

https://jenkins.cilium.io/job/Cilium-PR-Ginkgo-Tests-Validated/10852/consoleText

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7449)
<!-- Reviewable:end -->
