### PR TITLE
k8s: decrease the log level of some messages

### DIFF
--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -1686,7 +1686,7 @@ func (d *Daemon) updateK8sNodeTunneling(k8sNodeOld, k8sNodeNew *v1.Node) error {
 			// Don't return an error here, as the node may not have been
 			// annotated yet by the Cilium agent on it. If the node is annotated
 			// later, we will receive an event via the K8s watcher.
-			log.Infof("not updating ipcache entry for node %s because it does not have the CiliumHostIP annotation yet", k8sNode.Name)
+			log.Debugf("not updating ipcache entry for node %s because it does not have the CiliumHostIP annotation yet", k8sNode.Name)
 			return "", nil, nil
 		}
 		ciliumIP := net.ParseIP(ciliumIPStr)
@@ -1773,7 +1773,7 @@ func (d *Daemon) deleteK8sNodeV1(k8sNode *v1.Node) error {
 
 	id, exists := ipcache.IPIdentityCache.LookupByIP(ip)
 	if !exists {
-		logger.Warning("identity for Cilium IP not found")
+		logger.Debug("identity for Cilium IP not found")
 		return nil
 	}
 


### PR DESCRIPTION
Some messages are not usefull in production environments so we can
downgrade those to debug level.

Signed-off-by: André Martins <andre@cilium.dev>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7454)
<!-- Reviewable:end -->
