### PR TITLE
Fix cilium-health endpoint probing with either IPv4 or IPv6 disabled

### DIFF
--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/k8s/factory_functions.go
+++ b/pkg/k8s/factory_functions.go
@@ -204,10 +204,24 @@ func EqualV1Pod(pod1, pod2 *v1.Pod) bool {
 }
 
 func EqualV1Node(node1, node2 *v1.Node) bool {
-	// The only information we care about the node is it's annotations, in
-	// particularly the CiliumHostIP annotation.
-	return node1.GetObjectMeta().GetName() == node2.GetObjectMeta().GetName() &&
-		node1.GetAnnotations()[annotation.CiliumHostIP] == node2.GetAnnotations()[annotation.CiliumHostIP]
+	if node1.GetObjectMeta().GetName() != node2.GetObjectMeta().GetName() {
+		return false
+	}
+
+	anno1 := node1.GetAnnotations()
+	anno2 := node2.GetAnnotations()
+	annotationsWeCareAbout := []string{
+		annotation.CiliumHostIP,
+		annotation.CiliumHostIPv6,
+		annotation.V4HealthName,
+		annotation.V6HealthName,
+	}
+	for _, an := range annotationsWeCareAbout {
+		if anno1[an] != anno2[an] {
+			return false
+		}
+	}
+	return true
 }
 
 func EqualV1Namespace(ns1, ns2 *v1.Namespace) bool {

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -221,7 +221,7 @@ func (n *Node) getSecondaryAddresses() []*models.NodeAddressingElement {
 }
 
 func (n *Node) getHealthAddresses() *models.NodeAddressing {
-	if n.IPv4HealthIP == nil || n.IPv6HealthIP == nil {
+	if n.IPv4HealthIP == nil && n.IPv6HealthIP == nil {
 		return nil
 	}
 	return &models.NodeAddressing{

--- a/test/k8sT/Health.go
+++ b/test/k8sT/Health.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -97,10 +97,15 @@ var _ = Describe("K8sHealthTest", func() {
 			status := kubectl.CiliumExec(cilium1, healthCmd)
 			status.ExpectSuccess("Cannot retrieve health status")
 			for _, path := range apiPaths {
-				filter := fmt.Sprintf("{.nodes[%d].%s.status}", node, path)
+				filter := fmt.Sprintf("{.nodes[%d].%s}", node, path)
 				By("checking API response for %q", filter)
 				data, err := status.Filter(filter)
 				Expect(err).To(BeNil(), "cannot retrieve filter %q from health output", filter)
+				Expect(data.String()).Should(Not((BeEmpty())))
+				statusFilter := fmt.Sprintf("{.nodes[%d].%s.status}", node, path)
+				By("checking API status response for %q", statusFilter)
+				data, err = status.Filter(statusFilter)
+				Expect(err).To(BeNil(), "cannot retrieve filter %q from health output", statusFilter)
 				Expect(data.String()).Should(BeEmpty())
 			}
 		}


### PR DESCRIPTION
Previously, if either IPv4 or IPv6 was disabled, then we would fail out of attempting to probe health endpoint IPs. Change this to allow probing of IPs which are being used.

Fixes: #7456

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7457)
<!-- Reviewable:end -->
