### PR TITLE
Fixes: #7440 - remove deprecated metrics

### DIFF
--- a/Documentation/configuration/metrics.rst
+++ b/Documentation/configuration/metrics.rst
@@ -86,8 +86,6 @@ Policy
 
 * ``policy_count``: Number of policies currently loaded
 * ``policy_regeneration_total``: Total number of policies regenerated successfully
-* ``policy_regeneration_seconds_total``: Total sum of successful policy regeneration times
-* ``policy_regeneration_square_seconds_total``: Total sum of squares of successful policy regeneration times
 * ``policy_regeneration_time_stats_seconds``: Policy regeneration time stats labeled by the scope.
 * ``policy_max_revision``: Highest policy revision number in the agent
 * ``policy_import_errors``: Number of times a policy import has failed

--- a/pkg/endpoint/metrics.go
+++ b/pkg/endpoint/metrics.go
@@ -15,7 +15,6 @@
 package endpoint
 
 import (
-	"math"
 	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -114,10 +113,6 @@ type policyRegenerationStatistics struct {
 
 func (ps *policyRegenerationStatistics) SendMetrics() {
 	metrics.PolicyRegenerationCount.Inc()
-
-	regenerateTimeSec := ps.totalTime.Total().Seconds()
-	metrics.PolicyRegenerationTime.Add(regenerateTimeSec)
-	metrics.PolicyRegenerationTimeSquare.Add(math.Pow(regenerateTimeSec, 2))
 
 	sendMetrics(ps, metrics.PolicyRegenerationTimeStats)
 }

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -105,9 +105,6 @@ const (
 	// BPFCompilationTime is the time elapsed to build a BPF endpoint program
 	BPFCompilationTime = "BPFCompilationTime"
 
-	// PolicyRegenerationTime is the time elapsed to generate a policy
-	PolicyRegenerationTime = "policyRegenerationTime"
-
 	// EndpointRegenerationTime is the time elapsed to generate an endpoint
 	EndpointRegenerationTime = "endpointRegenerationTime"
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -225,23 +225,6 @@ var (
 		Help:      "Total number of successful policy regenerations",
 	})
 
-	// Deprecated: this metric will be removed in Cilium 1.6
-	// PolicyRegenerationTime is the total time taken to generate policies
-	PolicyRegenerationTime = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Name:      "policy_regeneration_seconds_total",
-		Help:      "Total sum of successful policy regeneration times (Deprecated)",
-	})
-
-	// Deprecated: this metric will be removed in Cilium 1.6
-	// PolicyRegenerationTimeSquare is the sum of squares of total time taken
-	// to generate policies
-	PolicyRegenerationTimeSquare = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Name:      "policy_regeneration_square_seconds_total",
-		Help:      "Total sum of squares of successful policy regeneration times (Deprecated)",
-	})
-
 	// PolicyRegenerationTimeStats is the total time taken to generate policies
 	PolicyRegenerationTimeStats = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: Namespace,
@@ -599,8 +582,6 @@ func init() {
 
 	MustRegister(PolicyCount)
 	MustRegister(PolicyRegenerationCount)
-	MustRegister(PolicyRegenerationTime)
-	MustRegister(PolicyRegenerationTimeSquare)
 	MustRegister(PolicyRegenerationTimeStats)
 	MustRegister(PolicyRevision)
 	MustRegister(PolicyImportErrors)


### PR DESCRIPTION
Removes PolicyRegenerationTimeSquare and PolicyRegenerationTime metrics

Fixes: #7440 
Signed-off-by: Mark deVilliers <markdevilliers@gmail.com>

```release-note
Removed PolicyRegenerationTimeSquare and PolicyRegenerationTime metrics
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7458)
<!-- Reviewable:end -->
