### PR TITLE
FQDN: Avoid a data race on FQDN policyAdd

### DIFF
--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -226,19 +227,32 @@ func (d *Daemon) PolicyAdd(rules policyAPI.Rules, opts *AddOptions) (newRev uint
 // managed endpoints. Returns the policy revision number of the repository after
 // adding the rules into the repository, or an error if the updated policy
 // was not able to be imported.
-func (d *Daemon) policyAdd(rules policyAPI.Rules, opts *AddOptions, resChan chan interface{}) {
+func (d *Daemon) policyAdd(sourceRules policyAPI.Rules, opts *AddOptions, resChan chan interface{}) {
 	policyAddStartTime := time.Now()
 	logger := log.WithField("policyAddRequest", uuid.NewUUID().String())
 
 	if opts != nil && opts.Generated {
-		logger.WithField(logfields.CiliumNetworkPolicy, rules.String()).Debug("Policy Add Request")
+		logger.WithField(logfields.CiliumNetworkPolicy, sourceRules.String()).Debug("Policy Add Request")
 	} else {
-		logger.WithField(logfields.CiliumNetworkPolicy, rules.String()).Info("Policy Add Request")
+		logger.WithField(logfields.CiliumNetworkPolicy, sourceRules.String()).Info("Policy Add Request")
 	}
 
-	// These must be marked before actually adding them to the repository since a
-	// copy may be made and we won't be able to add the ToFQDN tracking labels
-	d.dnsRuleGen.MarkToFQDNRules(rules)
+	// These must be marked before actually adding them to the repository since
+	// a copy may be made and we won't be able to add the ToFQDN tracking
+	// labels.
+	// CAUTION, there is a small race between this PrepareFQDNRules invocation and
+	// taking the policy lock. As long as policyAdd is fed by a single-threaded
+	// queue this should never be an issue.
+	rules := d.dnsRuleGen.PrepareFQDNRules(sourceRules)
+	if len(rules) == 0 && len(sourceRules) > 0 {
+		// All rules being added have ToFQDNs UUIDs that have been removed and
+		// will not be re-inserted to avoid a race.
+		err := errors.New("PrepareFQDNRules delete all sourceRules due invalid UUIDs")
+		resChan <- &PolicyAddResult{
+			newRev: 0,
+			err:    api.Error(PutPolicyFailureCode, err),
+		}
+	}
 
 	prefixes := policy.GetCIDRPrefixes(rules)
 	logger.WithField("prefixes", prefixes).Debug("Policy imported via API, found CIDR prefixes...")

--- a/pkg/fqdn/dnspoller_test.go
+++ b/pkg/fqdn/dnspoller_test.go
@@ -176,7 +176,7 @@ func (ds *FQDNTestSuite) TestRuleGenRuleHandling(c *C) {
 		}
 
 		// add rules and run basic checks
-		gen.MarkToFQDNRules(rulesToAdd)
+		gen.PrepareFQDNRules(rulesToAdd)
 		for i, rule := range rulesToAdd {
 			c.Assert(len(getRuleUUIDLabel(rule)), Not(Equals), 0, Commentf("Added a FQDN label to each marked rule"))
 			if i > 0 {


### PR DESCRIPTION
This commit change a little bit how policyAdd handles the case of FQDN
rules. This code checks that the FQDN rule UUID is still present on the
fqdn.RuleGen, if it is not present means that the `daemon.policyAdd`
already updated the rule, so the rule is no longer valid.

Checking the RuleGen.allRules is O(1) due is a map, hopefully this will
be replaced in the future when policyRepo has a key-value and things can
be retrieved without looping over it.

This is a new commit,and this will close the PR#7220 where issue was
discussed more on deep.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7459)
<!-- Reviewable:end -->
