### PR TITLE
linux/route: use RouteListFiltered to filter routes and RouteUpdate to update routes

### DIFF
--- a/pkg/datapath/linux/route/route_linux_test.go
+++ b/pkg/datapath/linux/route/route_linux_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -51,9 +51,10 @@ func testReplaceNexthopRoute(c *C, link netlink.Link, routerNet *net.IPNet) {
 	c.Assert(err, IsNil)
 	c.Assert(replaced, Equals, true)
 
+	// We expect routes to always be replaced
 	replaced, err = replaceNexthopRoute(link, routerNet)
 	c.Assert(err, IsNil)
-	c.Assert(replaced, Equals, false)
+	c.Assert(replaced, Equals, true)
 
 	err = deleteNexthopRoute(link, routerNet)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
The first commit makes use of a netlink library helper for cilium to perform a route lookup by using filters without cilium needing to perform the filtering itself.

The second commit uses route update instead of performing the lookup every time we want to verify if a route exists. We could store the routes in a cache, but there's no real advantage in duplicating the information that exists in the system if we there's no real performance gain if we use route update directly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7460)
<!-- Reviewable:end -->
