### PR TITLE
datapath/iptables: Check iptables kernel modules

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -555,10 +555,12 @@ func (d *Daemon) compileBase() error {
 	}
 
 	if option.Config.EnableIPv4 {
+		iptablesManager := iptables.IptablesManager{}
+		iptablesManager.Init()
 		// Always remove masquerade rule and then re-add it if required
-		iptables.RemoveRules()
+		iptablesManager.RemoveRules()
 		if option.Config.InstallIptRules {
-			if err := iptables.InstallRules(option.Config.HostDevice); err != nil {
+			if err := iptablesManager.InstallRules(option.Config.HostDevice); err != nil {
 				return err
 			}
 		}

--- a/pkg/modules/doc.go
+++ b/pkg/modules/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package modules contains a manager of loaded modules which supports search
+// operation.
+package modules

--- a/pkg/modules/modules.go
+++ b/pkg/modules/modules.go
@@ -1,0 +1,63 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package modules
+
+import (
+	"fmt"
+
+	"github.com/cilium/cilium/pkg/command/exec"
+	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/set"
+)
+
+// ModulesManager is a manager which stores information about loaded modules
+// and provides a search operation.
+type ModulesManager struct {
+	modulesList []string
+}
+
+// Init initializes the internal modules information store of modules manager.
+func (m *ModulesManager) Init() error {
+	modulesList, err := listModules()
+	if err != nil {
+		return err
+	}
+	m.modulesList = modulesList
+	return nil
+}
+
+// findModules checks whether the given kernel modules are loaded and also
+// returns a slice with names of modules which are not loaded.
+func (m *ModulesManager) findModules(expectedNames ...string) (bool, []string) {
+	return set.SliceSubsetOf(expectedNames, m.modulesList)
+}
+
+// FindOrLoadModules checks whether the given kernel modules are loaded and
+// tries to load those which are not.
+func (m *ModulesManager) FindOrLoadModules(expectedNames ...string) error {
+	found, diff := m.findModules(expectedNames...)
+	if found {
+		return nil
+	}
+	for _, unloadedModule := range diff {
+		if _, err := exec.WithTimeout(
+			defaults.ExecTimeout, moduleLoader(), unloadedModule).CombinedOutput(
+			nil, false); err != nil {
+			return fmt.Errorf("could not load module %s: %s",
+				unloadedModule, err)
+		}
+	}
+	return nil
+}

--- a/pkg/modules/modules_linux.go
+++ b/pkg/modules/modules_linux.go
@@ -1,0 +1,66 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package modules
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+const (
+	modulesFilepath = "/proc/modules"
+)
+
+func moduleLoader() string {
+	return "modprobe"
+}
+
+// parseModulesFile returns the list of loaded kernel modules names.
+func parseModulesFile(r io.Reader) ([]string, error) {
+	var result []string
+
+	scanner := bufio.NewScanner(r)
+	scanner.Split(bufio.ScanLines)
+
+	for scanner.Scan() {
+		moduleInfoRaw := scanner.Text()
+		moduleInfoSeparated := strings.Split(moduleInfoRaw, " ")
+		if len(moduleInfoSeparated) < 6 {
+			return nil, fmt.Errorf(
+				"invalid module info - it has %d fields (less than 6): %s",
+				len(moduleInfoSeparated), moduleInfoRaw)
+		}
+
+		result = append(result, moduleInfoSeparated[0])
+	}
+
+	return result, nil
+}
+
+// listModules returns the list of loaded kernel modules names parsed from
+// /proc/modules.
+func listModules() ([]string, error) {
+	fModules, err := os.Open(modulesFilepath)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to open modules information at %s: %s",
+			modulesFilepath, err)
+	}
+	defer fModules.Close()
+	return parseModulesFile(fModules)
+}

--- a/pkg/modules/modules_linux_privileged_test.go
+++ b/pkg/modules/modules_linux_privileged_test.go
@@ -1,0 +1,61 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux,privileged_tests
+
+package modules
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type ModulesPrivilegedTestSuite struct{}
+
+var _ = Suite(&ModulesPrivilegedTestSuite{})
+
+func (s *ModulesPrivilegedTestSuite) TestFindOrLoadModules(c *C) {
+	testCases := []struct {
+		modulesToFind []string
+		expectedErr   bool
+	}{
+		{
+			modulesToFind: []string{"bridge"},
+			expectedErr:   false,
+		},
+		{
+			modulesToFind: []string{"foo", "bar"},
+			expectedErr:   true,
+		},
+	}
+
+	manager := &ModulesManager{}
+	err := manager.Init()
+	c.Assert(err, IsNil)
+
+	for _, tc := range testCases {
+		err = manager.FindOrLoadModules(tc.modulesToFind...)
+		if tc.expectedErr {
+			c.Assert(err, NotNil)
+		} else {
+			c.Assert(err, IsNil)
+		}
+	}
+}

--- a/pkg/modules/modules_test.go
+++ b/pkg/modules/modules_test.go
@@ -1,0 +1,166 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package modules
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/cilium/cilium/pkg/checker"
+
+	. "gopkg.in/check.v1"
+)
+
+const (
+	modulesContent = `ebtable_nat 16384 1 - Live 0x0000000000000000
+ebtable_broute 16384 1 - Live 0x0000000000000000
+bridge 172032 1 ebtable_broute, Live 0x0000000000000000
+ip6table_nat 16384 1 - Live 0x0000000000000000
+nf_nat_ipv6 16384 1 ip6table_nat, Live 0x0000000000000000
+ip6table_mangle 16384 1 - Live 0x0000000000000000
+ip6table_raw 16384 1 - Live 0x0000000000000000
+ip6table_security 16384 1 - Live 0x0000000000000000
+iptable_nat 16384 1 - Live 0x0000000000000000
+nf_nat_ipv4 16384 1 iptable_nat, Live 0x0000000000000000
+iptable_mangle 16384 1 - Live 0x0000000000000000
+iptable_raw 16384 1 - Live 0x0000000000000000
+iptable_security 16384 1 - Live 0x0000000000000000
+ebtable_filter 16384 1 - Live 0x0000000000000000
+ebtables 36864 3 ebtable_nat,ebtable_broute,ebtable_filter, Live 0x0000000000000000
+ip6table_filter 16384 1 - Live 0x0000000000000000
+ip6_tables 28672 5 ip6table_nat,ip6table_mangle,ip6table_raw,ip6table_security,ip6table_filter, Live 0x0000000000000000
+iptable_filter 16384 1 - Live 0x0000000000000000
+ip_tables 28672 5 iptable_nat,iptable_mangle,iptable_raw,iptable_security,iptable_filter, Live 0x0000000000000000
+x_tables 40960 23 xt_multiport,xt_nat,xt_addrtype,xt_mark,xt_comment,xt_CHECKSUM,ipt_MASQUERADE,xt_tcpudp,ip6t_rpfilter,ip6t_REJECT,ipt_REJECT,xt_conntrack,ip6table_mangle,ip6table_raw,ip6table_security,iptable_mangle,iptable_raw,iptable_security,ebtables,ip6table_filter,ip6_tables,iptable_filter,ip_tables, Live 0x0000000000000000`
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type ModulesTestSuite struct{}
+
+var _ = Suite(&ModulesTestSuite{})
+
+func (s *ModulesTestSuite) TestInit(c *C) {
+	manager := &ModulesManager{}
+	c.Assert(manager.modulesList, IsNil)
+	err := manager.Init()
+	c.Assert(err, IsNil)
+	c.Assert(manager.modulesList, NotNil)
+}
+
+func (s *ModulesTestSuite) TestFindModules(c *C) {
+	manager := &ModulesManager{
+		modulesList: []string{
+			"ip6_tables",
+			"ip6table_mangle",
+			"ip6table_filter",
+			"ip6table_security",
+			"ip6table_raw",
+			"ip6table_nat",
+		},
+	}
+	testCases := []struct {
+		modulesToFind []string
+		isSubset      bool
+		expectedDiff  []string
+	}{
+		{
+			modulesToFind: []string{
+				"ip6_tables",
+				"ip6table_mangle",
+				"ip6table_filter",
+				"ip6table_security",
+				"ip6table_raw",
+				"ip6table_nat",
+			},
+			isSubset:     true,
+			expectedDiff: nil,
+		},
+		{
+			modulesToFind: []string{
+				"ip6_tables",
+				"ip6table_mangle",
+				"ip6table_raw",
+			},
+			isSubset:     true,
+			expectedDiff: nil,
+		},
+		{
+			modulesToFind: []string{
+				"ip6_tables",
+				"ip6table_mangle",
+				"ip6table_raw",
+				"foo_module",
+			},
+			isSubset:     false,
+			expectedDiff: []string{"foo_module"},
+		},
+		{
+			modulesToFind: []string{
+				"foo_module",
+				"bar_module",
+			},
+			isSubset:     false,
+			expectedDiff: []string{"foo_module", "bar_module"},
+		},
+	}
+	for _, tc := range testCases {
+		found, diff := manager.findModules(tc.modulesToFind...)
+		c.Assert(found, Equals, tc.isSubset)
+		c.Assert(diff, checker.DeepEquals, tc.expectedDiff)
+	}
+}
+
+func (s *ModulesTestSuite) TestParseModuleFile(c *C) {
+	expectedLength := 20
+	expectedModules := []string{
+		"ebtable_nat",
+		"ebtable_broute",
+		"bridge",
+		"ip6table_nat",
+		"nf_nat_ipv6",
+		"ip6table_mangle",
+		"ip6table_raw",
+		"ip6table_security",
+		"iptable_nat",
+		"nf_nat_ipv4",
+		"iptable_mangle",
+		"iptable_raw",
+		"iptable_security",
+		"ebtable_filter",
+		"ebtables",
+		"ip6table_filter",
+		"ip6_tables",
+		"iptable_filter",
+		"ip_tables",
+		"x_tables",
+	}
+
+	r := bytes.NewBuffer([]byte(modulesContent))
+	moduleInfos, err := parseModulesFile(r)
+	c.Assert(err, IsNil)
+	c.Assert(moduleInfos, HasLen, expectedLength)
+	c.Assert(moduleInfos, checker.DeepEquals, expectedModules)
+}
+
+func (s *ModulesTestSuite) TestListModules(c *C) {
+	_, err := listModules()
+	c.Assert(err, IsNil)
+}

--- a/pkg/set/doc.go
+++ b/pkg/set/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package set contains a function for performing a subset check for slices.
+package set

--- a/pkg/set/set.go
+++ b/pkg/set/set.go
@@ -1,0 +1,41 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package set
+
+// SliceSubsetOf checks whether the first slice is a subset of the second slice. If
+// not, it also returns slice of elements which are the difference of both
+// input slices.
+func SliceSubsetOf(sub, main []string) (bool, []string) {
+	var diff []string
+	occurences := make(map[string]int, len(main))
+	result := true
+	for _, element := range main {
+		occurences[element]++
+	}
+	for _, element := range sub {
+		if count, ok := occurences[element]; !ok {
+			// Element was not found in the main slice.
+			result = false
+			diff = append(diff, element)
+		} else if count < 1 {
+			// The element is in both slices, but the sub slice
+			// has more duplicates.
+			result = false
+		} else {
+			occurences[element]--
+		}
+	}
+	return result, diff
+}

--- a/pkg/set/set_test.go
+++ b/pkg/set/set_test.go
@@ -1,0 +1,91 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package set
+
+import (
+	"testing"
+
+	"github.com/cilium/cilium/pkg/checker"
+
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type SetTestSuite struct{}
+
+var _ = Suite(&SetTestSuite{})
+
+func (s *SetTestSuite) TestSliceSubsetOf(c *C) {
+	testCases := []struct {
+		sub          []string
+		main         []string
+		isSubset     bool
+		expectedDiff []string
+	}{
+		{
+			sub:          []string{"foo", "bar"},
+			main:         []string{"foo", "bar", "baz"},
+			isSubset:     true,
+			expectedDiff: nil,
+		},
+		{
+			sub:          []string{"foo", "bar"},
+			main:         []string{"foo", "bar"},
+			isSubset:     true,
+			expectedDiff: nil,
+		},
+		{
+			sub:          []string{"foo", "bar"},
+			main:         []string{"foo", "baz"},
+			isSubset:     false,
+			expectedDiff: []string{"bar"},
+		},
+		{
+			sub:          []string{"baz"},
+			main:         []string{"foo", "bar"},
+			isSubset:     false,
+			expectedDiff: []string{"baz"},
+		},
+		{
+			sub:          []string{"foo", "bar", "fizz"},
+			main:         []string{"fizz", "buzz"},
+			isSubset:     false,
+			expectedDiff: []string{"foo", "bar"},
+		},
+		{
+			sub:          []string{"foo", "foo", "bar"},
+			main:         []string{"foo", "bar"},
+			isSubset:     false,
+			expectedDiff: nil,
+		},
+		{
+			sub:          []string{"foo", "foo", "foo", "bar", "bar"},
+			main:         []string{"foo", "foo", "bar"},
+			isSubset:     false,
+			expectedDiff: nil,
+		},
+	}
+	for _, tc := range testCases {
+		isSubset, diff := SliceSubsetOf(tc.sub, tc.main)
+		c.Assert(isSubset, Equals, tc.isSubset)
+		c.Assert(diff, checker.DeepEquals, tc.expectedDiff)
+	}
+}


### PR DESCRIPTION
Before this change, ip6tables was called for rules removal even if
ip6tables modules were not loaded.

After this change, iptables module is going to:
- fail if iptables modules are not loaded
- fail if ip6tables modules are not loaded, but IPv6 is enabled
- not use ip6tables if its modules are not loaded and IPv6 is disabled

Fixes: #7453
Fixes: 65cfe4a ("iptables: Add support for IPv6, make IPv4 optional.")
Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7464)
<!-- Reviewable:end -->
