### PR TITLE
optimize processing of endpoints when reacting to rule updates

### DIFF
--- a/pkg/policy/identifier_test.go
+++ b/pkg/policy/identifier_test.go
@@ -1,0 +1,72 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package policy
+
+import (
+	"sync"
+
+	"github.com/cilium/cilium/pkg/identity"
+
+	. "gopkg.in/check.v1"
+)
+
+type DummyEndpoint struct {
+	rev uint64
+}
+
+func (d *DummyEndpoint) GetID16() uint16 {
+	return 0
+}
+
+func (d *DummyEndpoint) GetSecurityIdentity() *identity.Identity {
+	return nil
+}
+
+func (d *DummyEndpoint) PolicyRevisionBumpEvent(rev uint64) {
+	d.rev = rev
+	return
+}
+
+func (ds *PolicyTestSuite) TestNewEndpointSet(c *C) {
+	epSet := NewEndpointSet(20)
+	c.Assert(epSet.Len(), Equals, 0)
+
+	d := &DummyEndpoint{}
+	epSet.Insert(d)
+	c.Assert(epSet.Len(), Equals, 1)
+	epSet.Delete(d)
+	c.Assert(epSet.Len(), Equals, 0)
+}
+
+func (ds *PolicyTestSuite) TestForEach(c *C) {
+	var wg sync.WaitGroup
+
+	d0 := &DummyEndpoint{}
+	d1 := &DummyEndpoint{}
+
+	epSet := NewEndpointSet(20)
+	epSet.Insert(d0)
+	epSet.Insert(d1)
+	epSet.ForEach(&wg, func(e Endpoint) {
+		e.PolicyRevisionBumpEvent(100)
+	})
+
+	wg.Wait()
+
+	c.Assert(d0.rev, Equals, uint64(100))
+	c.Assert(d1.rev, Equals, uint64(100))
+}

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -68,11 +68,19 @@ func (ds *PolicyTestSuite) SetUpSuite(c *C) {
 	SetPolicyEnabled(option.DefaultEnforcement)
 	GenerateNumIdentities(3000)
 	rulez, _ := repo.AddList(GenerateNumRules(1000))
-	rulez.UpdateRulesEndpointsCaches([]Endpoint{&dummyEndpoint{
+
+	epSet := NewEndpointSet(5)
+
+	epSet.Insert(&dummyEndpoint{
 		ID:               9001,
 		SecurityIdentity: fooIdentity,
-	}}, NewIDSet(), &wg)
+	})
+	idSet := NewIDSet()
+	rulez.UpdateRulesEndpointsCaches(epSet, idSet, &wg)
 	wg.Wait()
+
+	c.Assert(epSet.Len(), Equals, 0)
+	c.Assert(len(idSet.IDs), Equals, 1)
 }
 
 func (ds *PolicyTestSuite) TearDownSuite(c *C) {


### PR DESCRIPTION
The sets of endpoints which need to be regenerated by a given policy update vs.
those which need to have their revision bumped directly are always disjoint.
Furthermore, when evaluating whether a set of rules select a given endpoint, the
set of endpoints which needs to be regenerated can be updated, and no more rules
need to be evaluated, as the set of endpoints to be regenerated has already been
updated for said endpoint. This means that said endpoint can be removed from the
original set containing all endpoints. The current flow when reacting to rule
updates is as follows:

* Add all endpoints to the set of endpoints which need to have their revision
bumped
* If an endpoint needs to be regenerated because rules which were added,
deleted, or updated which select the endpoint, then remove the endpoint from the
set of all endpoints and add it to the set of endpoints which need to be
regenerated. No further processing needs to be performed for this endpoint apart
from regenerating it later.
* After all endpoints are processed in relation to all rule changes, the set of
endpoints which formerly contained all endpoints will eventually contain only
the endpoints whose revision needs to be bumped.

This makes the reacting to rule updates more performant, as the iteration of
rules for a given endpoint is no longer always `O(n)`, but at best case may be
`O(1)`.

Furthermore, an endpoint is never evaluated again for rule matching (which is
costly) as part of the reacting after it is determined to be needed to be
regenerated.

A side-effect of this is that the updating of whether rules select the endpoint
is deferred to occur when the endpoint is being regenerated, but this will only
happen once per-rule per-endpoint. This is OK because the caches within the
rules are lazily updated.

Signed-off by: Ian Vernon <ian@cilium.io>

Related-to: #7466 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7465)
<!-- Reviewable:end -->
