### PR TITLE
make selective regeneration of endpoints configurable

### DIFF
--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -706,6 +706,10 @@ func init() {
 	flags.Int(option.EndpointQueueSize, defaults.EndpointQueueSize, "size of EventQueue per-endpoint")
 	option.BindEnv(option.EndpointQueueSize)
 
+	flags.Bool(option.SelectiveRegeneration, true, "only regenerate endpoints which need to be regenerated upon policy changes")
+	flags.MarkHidden(option.SelectiveRegeneration)
+	option.BindEnv(option.SelectiveRegeneration)
+
 	viper.BindPFlags(flags)
 }
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -173,4 +173,8 @@ const (
 
 	// EndpointQueueSize is the default queue size for an endpoint.
 	EndpointQueueSize = 25
+
+	// SelectiveRegeneration specifies whether regeneration of endpoints will be
+	// invoked only for endpoints which are selected by policy changes.
+	SelectiveRegeneration = true
 )

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -422,6 +422,10 @@ const (
 
 	// EndpointQueueSize is the size of the EventQueue per-endpoint.
 	EndpointQueueSize = "endpoint-queue-size"
+
+	// SelectiveRegeneration specifies whether only the endpoints which policy
+	// changes select should be regenerated upon policy changes.
+	SelectiveRegeneration = "enable-selective-regeneration"
 )
 
 // FQDNS variables
@@ -835,6 +839,13 @@ type DaemonConfig struct {
 	// in the case where a cluster might be under high load for endpoint-related
 	// events, specifically those which cause many regenerations.
 	EndpointQueueSize int
+
+	// SelectiveRegeneration, when true, enables the functionality to only
+	// regenerate endpoints which are selected by the policy rules that have
+	// been changed (added, deleted, or updated). If false, then all endpoints
+	// are regenerated upon every policy change regardless of the scope of the
+	// policy change.
+	SelectiveRegeneration bool
 }
 
 var (
@@ -855,6 +866,7 @@ var (
 		FixedIdentityMapping:      make(map[string]string),
 		KVStoreOpt:                make(map[string]string),
 		LogOpt:                    make(map[string]string),
+		SelectiveRegeneration:     defaults.SelectiveRegeneration,
 	}
 )
 
@@ -1188,6 +1200,7 @@ func (c *DaemonConfig) Populate() {
 	c.CMDRefDir = viper.GetString(CMDRef)
 	c.PolicyQueueSize = sanitizeIntParam(PolicyQueueSize, defaults.PolicyQueueSize)
 	c.EndpointQueueSize = sanitizeIntParam(EndpointQueueSize, defaults.EndpointQueueSize)
+	c.SelectiveRegeneration = viper.GetBool(SelectiveRegeneration)
 }
 
 func sanitizeIntParam(paramName string, paramDefault int) int {

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -452,6 +452,12 @@ func (p *Repository) AddList(rules api.Rules) (ruleSlice, uint64) {
 // signaled for a given endpoint which it has been analyzed against all rules
 // in the slice.
 func (r ruleSlice) UpdateRulesEndpointsCaches(eps []Endpoint, epsIDs *IDSet, policySelectionWG *sync.WaitGroup) {
+	// No need to check whether endpoints need to be regenerated here since we
+	// will unconditionally regenerate all endpoints later.
+	if !option.Config.SelectiveRegeneration {
+		return
+	}
+
 	policySelectionWG.Add(len(eps))
 	for _, ep := range eps {
 		// Update each rule in parallel.


### PR DESCRIPTION
Provide an option to end-users of Cilium to always regenerate all endpoints upon policy changes instead of selectively regenerating endpoints based on the content of the policy change. The option is called "enable-selective-regeneration", and is hidden by default. This option can be enabled in case the selective regeneration logic becomes overwhelmed and blocks the policy API. This is not expected; this is a fallback, just in case :) 

Signed-off by: Ian Vernon <ian@cilium.io>

Related-to: #7466 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7467)
<!-- Reviewable:end -->
