### PR TITLE
eventqueue: add name field, additional unit test coverage

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -414,10 +414,11 @@ func NewEndpointWithState(ID uint16, state string) *Endpoint {
 		state:         state,
 		hasBPFProgram: make(chan struct{}, 0),
 		controllers:   controller.NewManager(),
-		EventQueue:    eventqueue.NewEventQueueBuffered(option.Config.EndpointQueueSize),
+		EventQueue:    eventqueue.NewEventQueueBuffered(fmt.Sprintf("endpoint-%d", ID), option.Config.EndpointQueueSize),
 	}
 	ep.SetDefaultOpts(option.Config.Opts)
 	ep.UpdateLogger(nil)
+
 	ep.EventQueue.Run()
 
 	return ep
@@ -448,7 +449,6 @@ func NewEndpointFromChangeModel(base *models.EndpointChangeRequest) (*Endpoint, 
 		desiredPolicy:    &policy.EndpointPolicy{},
 		realizedPolicy:   &policy.EndpointPolicy{},
 		controllers:      controller.NewManager(),
-		EventQueue:       eventqueue.NewEventQueueBuffered(option.Config.EndpointQueueSize),
 	}
 	ep.UpdateLogger(nil)
 
@@ -1054,7 +1054,6 @@ func ParseEndpoint(strEp string) (*Endpoint, error) {
 	ep.desiredPolicy = &policy.EndpointPolicy{}
 	ep.realizedPolicy = &policy.EndpointPolicy{}
 	ep.controllers = controller.NewManager()
-	ep.EventQueue = eventqueue.NewEventQueueBuffered(option.Config.EndpointQueueSize)
 
 	// We need to check for nil in Status, CurrentStatuses and Log, since in
 	// some use cases, status will be not nil and Cilium will eventually

--- a/pkg/eventqueue/eventqueue_test.go
+++ b/pkg/eventqueue/eventqueue_test.go
@@ -64,6 +64,12 @@ func (s *EventQueueSuite) TestDrained(c *C) {
 	}
 }
 
+func (s *EventQueueSuite) TestNilEvent(c *C) {
+	q := NewEventQueue()
+	res := q.Enqueue(nil)
+	c.Assert(res, IsNil)
+}
+
 func (s *EventQueueSuite) TestNewEvent(c *C) {
 	e := NewEvent(&DummyEvent{})
 	c.Assert(e.Metadata, Not(IsNil))

--- a/pkg/eventqueue/eventqueue_test.go
+++ b/pkg/eventqueue/eventqueue_test.go
@@ -36,7 +36,14 @@ func (s *EventQueueSuite) TestNewEventQueue(c *C) {
 	c.Assert(q.close, Not(IsNil))
 	c.Assert(q.events, Not(IsNil))
 	c.Assert(q.drain, Not(IsNil))
+	c.Assert(q.name, Equals, "")
 	c.Assert(cap(q.events), Equals, 1)
+}
+
+func (s *EventQueueSuite) TestNewEventQueueBuffered(c *C) {
+	q := NewEventQueueBuffered("foo", 25)
+	c.Assert(q.name, Equals, "foo")
+	c.Assert(cap(q.events), Equals, 25)
 }
 
 func (s *EventQueueSuite) TestCloseEventQueueMultipleTimes(c *C) {

--- a/pkg/eventqueue/eventqueue_test.go
+++ b/pkg/eventqueue/eventqueue_test.go
@@ -46,6 +46,17 @@ func (s *EventQueueSuite) TestNewEventQueueBuffered(c *C) {
 	c.Assert(cap(q.events), Equals, 25)
 }
 
+func (s *EventQueue) TestNilEventQueueOperations(c *C) {
+	var qq *EventQueue
+	qq.Stop()
+	c.Assert(qq, IsNil)
+}
+
+func (s *EventQueueSuite) TestStopWithoutRun(c *C) {
+	q := NewEventQueue()
+	q.Stop()
+}
+
 func (s *EventQueueSuite) TestCloseEventQueueMultipleTimes(c *C) {
 	q := NewEventQueue()
 	q.Stop()

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -56,8 +56,8 @@ type Repository struct {
 
 // NewPolicyRepository allocates a new policy repository
 func NewPolicyRepository() *Repository {
-	repoChangeQueue := eventqueue.NewEventQueueBuffered(option.Config.PolicyQueueSize)
-	ruleReactionQueue := eventqueue.NewEventQueueBuffered(option.Config.PolicyQueueSize)
+	repoChangeQueue := eventqueue.NewEventQueueBuffered("repository-change-queue", option.Config.PolicyQueueSize)
+	ruleReactionQueue := eventqueue.NewEventQueueBuffered("repository-reaction-queue", option.Config.PolicyQueueSize)
 	repoChangeQueue.Run()
 	ruleReactionQueue.Run()
 	return &Repository{


### PR DESCRIPTION
 Provide a means of differentiating logs for different `EventQueues` by allowing creators of  `EventQueue` to provide a name. Update the printing of statistics for a given event being processed to reference the name of the queue that is processing / has processed the event. This field will make it easier to track event processing in relation to a given owner of a queue (policy, endpoint, etc.). 

Also add additional unit tests; the package now has 100 % code coverage.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7469)
<!-- Reviewable:end -->