### PR TITLE
Fix proxy redirect for traffic matching L4-only policy

### DIFF
--- a/daemon/policy_test.go
+++ b/daemon/policy_test.go
@@ -236,16 +236,6 @@ func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
 						L7: &cilium.PortNetworkPolicyRule_HttpRules{
 							HttpRules: &cilium.HttpNetworkPolicyRules{
 								HttpRules: []*cilium.HttpNetworkPolicyRule{
-									{},
-								},
-							},
-						},
-					},
-					{
-						RemotePolicies: expectedRemotePolicies,
-						L7: &cilium.PortNetworkPolicyRule_HttpRules{
-							HttpRules: &cilium.HttpNetworkPolicyRules{
-								HttpRules: []*cilium.HttpNetworkPolicyRule{
 									{
 										Headers: []*envoy_api_v2_route.HeaderMatcher{
 											{
@@ -299,26 +289,6 @@ func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
 				Port:     80,
 				Protocol: envoy_api_v2_core.SocketAddress_TCP,
 				Rules: []*cilium.PortNetworkPolicyRule{
-					{
-						RemotePolicies: expectedRemotePolicies2,
-						L7: &cilium.PortNetworkPolicyRule_HttpRules{
-							HttpRules: &cilium.HttpNetworkPolicyRules{
-								HttpRules: []*cilium.HttpNetworkPolicyRule{
-									{},
-								},
-							},
-						},
-					},
-					{
-						RemotePolicies: expectedRemotePolicies,
-						L7: &cilium.PortNetworkPolicyRule_HttpRules{
-							HttpRules: &cilium.HttpNetworkPolicyRules{
-								HttpRules: []*cilium.HttpNetworkPolicyRule{
-									{},
-								},
-							},
-						},
-					},
 					{
 						RemotePolicies: expectedRemotePolicies,
 						L7: &cilium.PortNetworkPolicyRule_HttpRules{

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -158,7 +158,9 @@ func (e *Endpoint) addNewRedirectsFromMap(owner Owner, m policy.L4PolicyMap, des
 	updatedDesiredMapState := make(policy.MapState)
 
 	for _, l4 := range m {
-		if l4.IsRedirect() {
+		// If this has no redirect, then the key generation was already
+		// handled by computeDirectionL4PolicyMapEntries().
+		if l4.HasRedirect() {
 			var redirectPort uint16
 			var err error
 			// Only create a redirect if the proxy is NOT running in a sidecar

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -54,7 +54,7 @@ func (e *Endpoint) ProxyID(l4 *policy.L4Filter) string {
 // filter doesn't require a redirect.
 // Must be called with Endpoint.Mutex held.
 func (e *Endpoint) LookupRedirectPort(l4Filter *policy.L4Filter) uint16 {
-	if !l4Filter.IsRedirect() {
+	if !l4Filter.HasRedirect() {
 		return 0
 	}
 	proxyID := e.ProxyID(l4Filter)

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -339,8 +339,9 @@ func CreateL4EgressFilter(toEndpoints api.EndpointSelectorSlice, rule api.PortRu
 	return CreateL4Filter(toEndpoints, rule, port, protocol, ruleLabels, false)
 }
 
-// IsRedirect returns true if the L4 filter contains a port redirection
-func (l4 *L4Filter) IsRedirect() bool {
+// HasRedirect returns true if the L4 filter contains a port redirection for
+// some L3 peers (sources in the case of ingress filter, destinations otherwise).
+func (l4 *L4Filter) HasRedirect() bool {
 	return l4.L7Parser != ParserTypeNone
 }
 
@@ -386,7 +387,7 @@ type L4PolicyMap map[string]L4Filter
 // redirection
 func (l4 L4PolicyMap) HasRedirect() bool {
 	for _, f := range l4 {
-		if f.IsRedirect() {
+		if f.HasRedirect() {
 			return true
 		}
 	}

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -209,8 +209,11 @@ func (ds *PolicyTestSuite) TestMergeAllowAllL3AndShadowedL7(c *C) {
 		Protocol:      api.ProtoTCP,
 		U8Proto:       6,
 		allowsAllAtL3: true,
-		Endpoints:     api.EndpointSelectorSlice{api.WildcardEndpointSelector},
-		L7Parser:      "http",
+		Endpoints: api.EndpointSelectorSlice{
+			api.WildcardEndpointSelector,
+			api.WildcardEndpointSelector,
+		},
+		L7Parser: "http",
 		L7RulesPerEp: L7DataMap{
 			api.WildcardEndpointSelector: api.L7Rules{
 				HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
@@ -315,8 +318,11 @@ func (ds *PolicyTestSuite) TestMergeIdenticalAllowAllL3AndRestrictedL7HTTP(c *C)
 		Protocol:      api.ProtoTCP,
 		U8Proto:       6,
 		allowsAllAtL3: true,
-		Endpoints:     api.EndpointSelectorSlice{api.WildcardEndpointSelector},
-		L7Parser:      ParserTypeHTTP,
+		Endpoints: api.EndpointSelectorSlice{
+			api.WildcardEndpointSelector,
+			api.WildcardEndpointSelector,
+		},
+		L7Parser: ParserTypeHTTP,
 		L7RulesPerEp: L7DataMap{
 			api.WildcardEndpointSelector: api.L7Rules{
 				HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
@@ -394,8 +400,11 @@ func (ds *PolicyTestSuite) TestMergeIdenticalAllowAllL3AndRestrictedL7Kafka(c *C
 		Protocol:      api.ProtoTCP,
 		U8Proto:       6,
 		allowsAllAtL3: true,
-		Endpoints:     api.EndpointSelectorSlice{api.WildcardEndpointSelector},
-		L7Parser:      ParserTypeKafka,
+		Endpoints: api.EndpointSelectorSlice{
+			api.WildcardEndpointSelector,
+			api.WildcardEndpointSelector,
+		},
+		L7Parser: ParserTypeKafka,
 		L7RulesPerEp: L7DataMap{
 			api.WildcardEndpointSelector: api.L7Rules{
 				Kafka: []api.PortRuleKafka{{Topic: "foo"}},
@@ -644,11 +653,14 @@ func (ds *PolicyTestSuite) TestL3RuleShadowedByL3AllowAll(c *C) {
 
 	expected := NewL4Policy()
 	expected.Ingress["80/TCP"] = L4Filter{
-		Port:             80,
-		Protocol:         api.ProtoTCP,
-		U8Proto:          6,
-		allowsAllAtL3:    true,
-		Endpoints:        api.EndpointSelectorSlice{api.WildcardEndpointSelector},
+		Port:          80,
+		Protocol:      api.ProtoTCP,
+		U8Proto:       6,
+		allowsAllAtL3: true,
+		Endpoints: api.EndpointSelectorSlice{
+			endpointSelectorA,
+			api.WildcardEndpointSelector,
+		},
 		L7Parser:         ParserTypeNone,
 		L7RulesPerEp:     L7DataMap{},
 		Ingress:          true,
@@ -701,11 +713,14 @@ func (ds *PolicyTestSuite) TestL3RuleShadowedByL3AllowAll(c *C) {
 
 	expected = NewL4Policy()
 	expected.Ingress["80/TCP"] = L4Filter{
-		Port:             80,
-		Protocol:         api.ProtoTCP,
-		U8Proto:          6,
-		allowsAllAtL3:    true,
-		Endpoints:        api.EndpointSelectorSlice{api.WildcardEndpointSelector},
+		Port:          80,
+		Protocol:      api.ProtoTCP,
+		U8Proto:       6,
+		allowsAllAtL3: true,
+		Endpoints: api.EndpointSelectorSlice{
+			api.WildcardEndpointSelector,
+			endpointSelectorA,
+		},
 		L7Parser:         ParserTypeNone,
 		L7RulesPerEp:     L7DataMap{},
 		Ingress:          true,
@@ -775,8 +790,11 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RulePartiallyShadowedByL3AllowAll(c *
 		Protocol:      api.ProtoTCP,
 		U8Proto:       6,
 		allowsAllAtL3: true,
-		Endpoints:     api.EndpointSelectorSlice{api.WildcardEndpointSelector},
-		L7Parser:      ParserTypeHTTP,
+		Endpoints: api.EndpointSelectorSlice{
+			endpointSelectorA,
+			api.WildcardEndpointSelector,
+		},
+		L7Parser: ParserTypeHTTP,
 		L7RulesPerEp: L7DataMap{
 			endpointSelectorA: api.L7Rules{
 				HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
@@ -843,8 +861,11 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RulePartiallyShadowedByL3AllowAll(c *
 		Protocol:      api.ProtoTCP,
 		U8Proto:       6,
 		allowsAllAtL3: true,
-		Endpoints:     api.EndpointSelectorSlice{api.WildcardEndpointSelector},
-		L7Parser:      ParserTypeHTTP,
+		Endpoints: api.EndpointSelectorSlice{
+			api.WildcardEndpointSelector,
+			endpointSelectorA,
+		},
+		L7Parser: ParserTypeHTTP,
 		L7RulesPerEp: L7DataMap{
 			endpointSelectorA: api.L7Rules{
 				HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
@@ -924,8 +945,11 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RuleShadowedByL3AllowAll(c *C) {
 		Protocol:      api.ProtoTCP,
 		U8Proto:       6,
 		allowsAllAtL3: true,
-		Endpoints:     api.EndpointSelectorSlice{api.WildcardEndpointSelector},
-		L7Parser:      ParserTypeHTTP,
+		Endpoints: api.EndpointSelectorSlice{
+			endpointSelectorA,
+			api.WildcardEndpointSelector,
+		},
+		L7Parser: ParserTypeHTTP,
 		L7RulesPerEp: L7DataMap{
 			api.WildcardEndpointSelector: api.L7Rules{
 				HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
@@ -1001,8 +1025,11 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RuleShadowedByL3AllowAll(c *C) {
 		Protocol:      api.ProtoTCP,
 		U8Proto:       6,
 		allowsAllAtL3: true,
-		Endpoints:     api.EndpointSelectorSlice{api.WildcardEndpointSelector},
-		L7Parser:      ParserTypeHTTP,
+		Endpoints: api.EndpointSelectorSlice{
+			api.WildcardEndpointSelector,
+			endpointSelectorA,
+		},
+		L7Parser: ParserTypeHTTP,
 		L7RulesPerEp: L7DataMap{
 			api.WildcardEndpointSelector: api.L7Rules{
 				HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -165,7 +165,6 @@ func wildcardL3L4Rule(proto api.L4Proto, port int, endpoints api.EndpointSelecto
 				}
 			}
 		}
-		filter.Endpoints = append(filter.Endpoints, endpoints...)
 		filter.DerivedFromRules = append(filter.DerivedFromRules, ruleLabels)
 		l4Policy[k] = filter
 	}

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -797,9 +797,6 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngress(c *C) {
 				selBar2: api.L7Rules{
 					Kafka: []api.PortRuleKafka{kafkaRule.Ingress[0].ToPorts[0].Rules.Kafka[0]},
 				},
-				selBar1: api.L7Rules{
-					Kafka: []api.PortRuleKafka{{}},
-				},
 			},
 			DerivedFromRules: labels.LabelArrayList{labelsKafka, labelsL3},
 		},
@@ -813,9 +810,6 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngress(c *C) {
 			L7RulesPerEp: L7DataMap{
 				selBar2: api.L7Rules{
 					HTTP: []api.PortRuleHTTP{httpRule.Ingress[0].ToPorts[0].Rules.HTTP[0]},
-				},
-				selBar1: api.L7Rules{
-					HTTP: []api.PortRuleHTTP{{}},
 				},
 			},
 			DerivedFromRules: labels.LabelArrayList{labelsHTTP, labelsL3},
@@ -831,10 +825,6 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngress(c *C) {
 				selBar2: api.L7Rules{
 					L7Proto: "tester",
 					L7:      []api.PortRuleL7{l7Rule.Ingress[0].ToPorts[0].Rules.L7[0]},
-				},
-				selBar1: api.L7Rules{
-					L7Proto: "tester",
-					L7:      []api.PortRuleL7{},
 				},
 			},
 			DerivedFromRules: labels.LabelArrayList{labelsL7, labelsL3},
@@ -954,9 +944,6 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesIngress(c *C) {
 			L7Parser:  ParserTypeHTTP,
 			Ingress:   true,
 			L7RulesPerEp: L7DataMap{
-				selBar1: api.L7Rules{
-					HTTP: []api.PortRuleHTTP{{}},
-				},
 				selBar2: api.L7Rules{
 					HTTP: []api.PortRuleHTTP{httpRule.Ingress[0].ToPorts[0].Rules.HTTP[0]},
 				},
@@ -971,9 +958,6 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesIngress(c *C) {
 			L7Parser:  ParserTypeKafka,
 			Ingress:   true,
 			L7RulesPerEp: L7DataMap{
-				selBar1: api.L7Rules{
-					Kafka: []api.PortRuleKafka{{}},
-				},
 				selBar2: api.L7Rules{
 					Kafka: []api.PortRuleKafka{kafkaRule.Ingress[0].ToPorts[0].Rules.Kafka[0]},
 				},
@@ -1197,9 +1181,6 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgress(c *C) {
 			L7Parser:  ParserTypeKafka,
 			Ingress:   false,
 			L7RulesPerEp: L7DataMap{
-				selBar1: api.L7Rules{
-					Kafka: []api.PortRuleKafka{{}},
-				},
 				selBar2: api.L7Rules{
 					Kafka: []api.PortRuleKafka{kafkaRule.Egress[0].ToPorts[0].Rules.Kafka[0]},
 				},
@@ -1214,9 +1195,6 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgress(c *C) {
 			L7Parser:  ParserTypeHTTP,
 			Ingress:   false,
 			L7RulesPerEp: L7DataMap{
-				selBar1: api.L7Rules{
-					HTTP: []api.PortRuleHTTP{{}},
-				},
 				selBar2: api.L7Rules{
 					HTTP: []api.PortRuleHTTP{httpRule.Egress[0].ToPorts[0].Rules.HTTP[0]},
 				},
@@ -1338,9 +1316,6 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesEgress(c *C) {
 			L7Parser:  ParserTypeHTTP,
 			Ingress:   false,
 			L7RulesPerEp: L7DataMap{
-				selBar1: api.L7Rules{
-					HTTP: []api.PortRuleHTTP{{}},
-				},
 				selBar2: api.L7Rules{
 					HTTP: []api.PortRuleHTTP{httpRule.Egress[0].ToPorts[0].Rules.HTTP[0]},
 				},
@@ -1355,9 +1330,6 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesEgress(c *C) {
 			L7Parser:  ParserTypeKafka,
 			Ingress:   false,
 			L7RulesPerEp: L7DataMap{
-				selBar1: api.L7Rules{
-					Kafka: []api.PortRuleKafka{{}},
-				},
 				selBar2: api.L7Rules{
 					Kafka: []api.PortRuleKafka{kafkaRule.Egress[0].ToPorts[0].Rules.Kafka[0]},
 				},
@@ -1450,7 +1422,6 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngressFromEntities(c *C) {
 	c.Assert(len(filter.Endpoints), Equals, 1)
 	c.Assert(filter.Endpoints[0], checker.DeepEquals, selBar2)
 
-	selWorld := api.EntitySelectorMapping[api.EntityWorld][0]
 	expectedPolicy := L4PolicyMap{
 		"9092/TCP": {
 			Port:      9092,
@@ -1460,9 +1431,6 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngressFromEntities(c *C) {
 			L7Parser:  ParserTypeKafka,
 			Ingress:   true,
 			L7RulesPerEp: L7DataMap{
-				selWorld: api.L7Rules{
-					Kafka: []api.PortRuleKafka{{}},
-				},
 				selBar2: api.L7Rules{
 					Kafka: []api.PortRuleKafka{kafkaRule.Ingress[0].ToPorts[0].Rules.Kafka[0]},
 				},
@@ -1477,9 +1445,6 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngressFromEntities(c *C) {
 			L7Parser:  ParserTypeHTTP,
 			Ingress:   true,
 			L7RulesPerEp: L7DataMap{
-				selWorld: api.L7Rules{
-					HTTP: []api.PortRuleHTTP{{}},
-				},
 				selBar2: api.L7Rules{
 					HTTP: []api.PortRuleHTTP{httpRule.Ingress[0].ToPorts[0].Rules.HTTP[0]},
 				},
@@ -1573,7 +1538,6 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgressToEntities(c *C) {
 	c.Assert(len(filter.Endpoints), Equals, 1)
 	c.Assert(filter.Endpoints[0], checker.DeepEquals, selBar2)
 
-	selWorld := api.EntitySelectorMapping[api.EntityWorld][0]
 	expectedPolicy := L4PolicyMap{
 		"9092/TCP": {
 			Port:      9092,
@@ -1583,9 +1547,6 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgressToEntities(c *C) {
 			L7Parser:  ParserTypeKafka,
 			Ingress:   false,
 			L7RulesPerEp: L7DataMap{
-				selWorld: api.L7Rules{
-					Kafka: []api.PortRuleKafka{{}},
-				},
 				selBar2: api.L7Rules{
 					Kafka: []api.PortRuleKafka{kafkaRule.Egress[0].ToPorts[0].Rules.Kafka[0]},
 				},
@@ -1600,9 +1561,6 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgressToEntities(c *C) {
 			L7Parser:  ParserTypeHTTP,
 			Ingress:   false,
 			L7RulesPerEp: L7DataMap{
-				selWorld: api.L7Rules{
-					HTTP: []api.PortRuleHTTP{{}},
-				},
 				selBar2: api.L7Rules{
 					HTTP: []api.PortRuleHTTP{httpRule.Egress[0].ToPorts[0].Rules.HTTP[0]},
 				},

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -790,7 +790,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngress(c *C) {
 			Port:      9092,
 			Protocol:  api.ProtoTCP,
 			U8Proto:   0x6,
-			Endpoints: []api.EndpointSelector{selBar2, selBar1},
+			Endpoints: []api.EndpointSelector{selBar2},
 			L7Parser:  ParserTypeKafka,
 			Ingress:   true,
 			L7RulesPerEp: L7DataMap{
@@ -807,7 +807,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngress(c *C) {
 			Port:      80,
 			Protocol:  api.ProtoTCP,
 			U8Proto:   0x6,
-			Endpoints: []api.EndpointSelector{selBar2, selBar1},
+			Endpoints: []api.EndpointSelector{selBar2},
 			L7Parser:  ParserTypeHTTP,
 			Ingress:   true,
 			L7RulesPerEp: L7DataMap{
@@ -824,7 +824,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngress(c *C) {
 			Port:      9090,
 			Protocol:  api.ProtoTCP,
 			U8Proto:   0x6,
-			Endpoints: []api.EndpointSelector{selBar2, selBar1},
+			Endpoints: []api.EndpointSelector{selBar2},
 			L7Parser:  L7ParserType("tester"),
 			Ingress:   true,
 			L7RulesPerEp: L7DataMap{
@@ -950,7 +950,7 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesIngress(c *C) {
 			Port:      80,
 			Protocol:  api.ProtoTCP,
 			U8Proto:   0x6,
-			Endpoints: []api.EndpointSelector{selBar1, selBar2, selBar1},
+			Endpoints: []api.EndpointSelector{selBar1, selBar2},
 			L7Parser:  ParserTypeHTTP,
 			Ingress:   true,
 			L7RulesPerEp: L7DataMap{
@@ -967,7 +967,7 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesIngress(c *C) {
 			Port:      9092,
 			Protocol:  api.ProtoTCP,
 			U8Proto:   0x6,
-			Endpoints: []api.EndpointSelector{selBar1, selBar2, selBar1},
+			Endpoints: []api.EndpointSelector{selBar1, selBar2},
 			L7Parser:  ParserTypeKafka,
 			Ingress:   true,
 			L7RulesPerEp: L7DataMap{
@@ -1193,7 +1193,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgress(c *C) {
 			Port:      9092,
 			Protocol:  api.ProtoTCP,
 			U8Proto:   0x6,
-			Endpoints: []api.EndpointSelector{selBar2, selBar1},
+			Endpoints: []api.EndpointSelector{selBar2},
 			L7Parser:  ParserTypeKafka,
 			Ingress:   false,
 			L7RulesPerEp: L7DataMap{
@@ -1210,7 +1210,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgress(c *C) {
 			Port:      80,
 			Protocol:  api.ProtoTCP,
 			U8Proto:   0x6,
-			Endpoints: []api.EndpointSelector{selBar2, selBar1},
+			Endpoints: []api.EndpointSelector{selBar2},
 			L7Parser:  ParserTypeHTTP,
 			Ingress:   false,
 			L7RulesPerEp: L7DataMap{
@@ -1334,7 +1334,7 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesEgress(c *C) {
 			Port:      80,
 			Protocol:  api.ProtoTCP,
 			U8Proto:   0x6,
-			Endpoints: []api.EndpointSelector{selBar1, selBar2, selBar1},
+			Endpoints: []api.EndpointSelector{selBar1, selBar2},
 			L7Parser:  ParserTypeHTTP,
 			Ingress:   false,
 			L7RulesPerEp: L7DataMap{
@@ -1351,7 +1351,7 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesEgress(c *C) {
 			Port:      9092,
 			Protocol:  api.ProtoTCP,
 			U8Proto:   0x6,
-			Endpoints: []api.EndpointSelector{selBar1, selBar2, selBar1},
+			Endpoints: []api.EndpointSelector{selBar1, selBar2},
 			L7Parser:  ParserTypeKafka,
 			Ingress:   false,
 			L7RulesPerEp: L7DataMap{
@@ -1446,16 +1446,17 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngressFromEntities(c *C) {
 	policy, err := repo.ResolveL4IngressPolicy(ctx)
 	c.Assert(err, IsNil)
 	c.Assert(len(*policy), Equals, 2)
-	c.Assert(len((*policy)["80/TCP"].Endpoints), Equals, 2)
-	selWorld := (*policy)["80/TCP"].Endpoints[1]
-	c.Assert(api.EndpointSelectorSlice{selWorld}, checker.DeepEquals, api.EntitySelectorMapping[api.EntityWorld])
+	filter := (*policy)["80/TCP"]
+	c.Assert(len(filter.Endpoints), Equals, 1)
+	c.Assert(filter.Endpoints[0], checker.DeepEquals, selBar2)
 
+	selWorld := api.EntitySelectorMapping[api.EntityWorld][0]
 	expectedPolicy := L4PolicyMap{
 		"9092/TCP": {
 			Port:      9092,
 			Protocol:  api.ProtoTCP,
 			U8Proto:   0x6,
-			Endpoints: []api.EndpointSelector{selBar2, selWorld},
+			Endpoints: []api.EndpointSelector{selBar2},
 			L7Parser:  ParserTypeKafka,
 			Ingress:   true,
 			L7RulesPerEp: L7DataMap{
@@ -1472,7 +1473,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngressFromEntities(c *C) {
 			Port:      80,
 			Protocol:  api.ProtoTCP,
 			U8Proto:   0x6,
-			Endpoints: []api.EndpointSelector{selBar2, selWorld},
+			Endpoints: []api.EndpointSelector{selBar2},
 			L7Parser:  ParserTypeHTTP,
 			Ingress:   true,
 			L7RulesPerEp: L7DataMap{
@@ -1568,16 +1569,17 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgressToEntities(c *C) {
 	policy, err := repo.ResolveL4EgressPolicy(ctx)
 	c.Assert(err, IsNil)
 	c.Assert(len(*policy), Equals, 2)
-	c.Assert(len((*policy)["80/TCP"].Endpoints), Equals, 2)
-	selWorld := (*policy)["80/TCP"].Endpoints[1]
-	c.Assert(api.EndpointSelectorSlice{selWorld}, checker.DeepEquals, api.EntitySelectorMapping[api.EntityWorld])
+	filter := (*policy)["80/TCP"]
+	c.Assert(len(filter.Endpoints), Equals, 1)
+	c.Assert(filter.Endpoints[0], checker.DeepEquals, selBar2)
 
+	selWorld := api.EntitySelectorMapping[api.EntityWorld][0]
 	expectedPolicy := L4PolicyMap{
 		"9092/TCP": {
 			Port:      9092,
 			Protocol:  api.ProtoTCP,
 			U8Proto:   0x6,
-			Endpoints: []api.EndpointSelector{selBar2, selWorld},
+			Endpoints: []api.EndpointSelector{selBar2},
 			L7Parser:  ParserTypeKafka,
 			Ingress:   false,
 			L7RulesPerEp: L7DataMap{
@@ -1594,7 +1596,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgressToEntities(c *C) {
 			Port:      80,
 			Protocol:  api.ProtoTCP,
 			U8Proto:   0x6,
-			Endpoints: []api.EndpointSelector{selBar2, selWorld},
+			Endpoints: []api.EndpointSelector{selBar2},
 			L7Parser:  ParserTypeHTTP,
 			Ingress:   false,
 			L7RulesPerEp: L7DataMap{
@@ -1713,9 +1715,6 @@ func (ds *PolicyTestSuite) TestMinikubeGettingStarted(c *C) {
 	// instances of the EndpointSelector. We duplicate them in the expected
 	// output here just to get the tests passing.
 	selectorFromApp2DupList := []api.EndpointSelector{
-		api.NewESFromLabels(
-			labels.ParseSelectLabel("id=app2"),
-		),
 		api.NewESFromLabels(
 			labels.ParseSelectLabel("id=app2"),
 		),

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -100,8 +100,8 @@ func (p *EndpointPolicy) computeDesiredL4PolicyMapEntries(identityCache cache.Id
 func (p *EndpointPolicy) computeDirectionL4PolicyMapEntries(identityCache cache.IdentityCache, l4PolicyMap L4PolicyMap, deniedIdentities cache.IdentityCache) {
 	for _, filter := range l4PolicyMap {
 		filter.ForEachDatapathEntry(p.PolicyOwner, identityCache, deniedIdentities,
-			func(k Key, v MapStateEntry) {
-				if filter.IsRedirect() && v.ProxyPort == 0 {
+			func(k Key, v MapStateEntry, isProxy bool) {
+				if isProxy && v.ProxyPort == 0 {
 					// If the currently allocated proxy port is 0, this is a new
 					// redirect, for which no port has been allocated yet. Ignore
 					// it for now. This will be configured by

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -86,7 +86,8 @@ func mergeL4Port(ctx *SearchContext, existingFilter, filterToMerge *L4Filter) er
 	// L3 selectors are held in 'l4.Endpoints') and L3-dependent L7 rules
 	// on the same L4 destination (where the L3 selectors are held in
 	// l4.RulesPerEP), the 'l4.Endpoints' should become a superset or equal
-	// to the 'l4.L7RulesPerEP' selectors.
+	// to the 'l4.L7RulesPerEP' selectors, to allow l3-dependent L7 datapath
+	// entries to be correctly generated in l4.ForEachDatapathEntry().
 	existingFilter.Endpoints = append(existingFilter.Endpoints, filterToMerge.Endpoints...)
 
 	// Merge the L7-related data from the arguments provided to this function

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -2145,7 +2145,8 @@ func (ds *PolicyTestSuite) TestL4WildcardMerge(c *C) {
 	c.Assert(filter.Ingress, Equals, true)
 	c.Assert(len(filter.Endpoints), Equals, 2)
 	c.Assert(filter.L7Parser, Equals, ParserTypeHTTP)
-	c.Assert(len(filter.L7RulesPerEp), Equals, 2)
+	c.Assert(len(filter.L7RulesPerEp), Equals, 1)
+	c.Assert(filter.L7RulesPerEp[endpointSelectorC], Not(IsNil))
 
 	// Test the reverse order as well; ensure that we check both conditions
 	// for if L4-only policy is in the L4Filter for the same port-protocol tuple,
@@ -2195,7 +2196,8 @@ func (ds *PolicyTestSuite) TestL4WildcardMerge(c *C) {
 	c.Assert(len(filter.Endpoints), Equals, 2)
 
 	c.Assert(filter.L7Parser, Equals, ParserTypeHTTP)
-	c.Assert(len(filter.L7RulesPerEp), Equals, 2)
+	c.Assert(len(filter.L7RulesPerEp), Equals, 1)
+	c.Assert(filter.L7RulesPerEp[endpointSelectorC], Not(IsNil))
 }
 
 func (ds *PolicyTestSuite) TestL3L4L7Merge(c *C) {
@@ -2249,7 +2251,8 @@ func (ds *PolicyTestSuite) TestL3L4L7Merge(c *C) {
 	c.Assert(filter.Endpoints[1], Equals, endpointSelectorC)
 
 	c.Assert(filter.L7Parser, Equals, ParserTypeHTTP)
-	c.Assert(len(filter.L7RulesPerEp), Equals, 2)
+	c.Assert(len(filter.L7RulesPerEp), Equals, 1)
+	c.Assert(filter.L7RulesPerEp[api.WildcardEndpointSelector], Not(IsNil))
 
 	repo = parseAndAddRules(c, api.Rules{&api.Rule{
 		EndpointSelector: endpointSelectorA,
@@ -2296,7 +2299,8 @@ func (ds *PolicyTestSuite) TestL3L4L7Merge(c *C) {
 	c.Assert(filter.Endpoints[1], Equals, api.WildcardEndpointSelector)
 
 	c.Assert(filter.L7Parser, Equals, ParserTypeHTTP)
-	c.Assert(len(filter.L7RulesPerEp), Equals, 2)
+	c.Assert(len(filter.L7RulesPerEp), Equals, 1)
+	c.Assert(filter.L7RulesPerEp[api.WildcardEndpointSelector], Not(IsNil))
 }
 
 func (ds *PolicyTestSuite) TestMatches(c *C) {

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -671,31 +671,17 @@ var _ = Describe("RuntimePolicies", func() {
 
 		connectivityTest(httpRequestsPublic, helpers.App3, helpers.Httpd2, true)
 
-		// Since policy allows connectivity on L3 from app3 to httpd2, we expect:
-		// * two more requests to get received by the proxy because even though
-		// only L3 policy applies for connectivity from app3 to httpd2, because
-		// app3 has L7 policy applied to it, all traffic goes through the proxy.
-		// * two more requests to get forwarded by the proxy because policy allows
-		// app3 to talk to httpd2.
-		// * no increase in requests denied by the proxy.
-		// * two more corresponding responses forwarded / received to the aforementioned requests due to policy
-		// allowing connectivity via http / http6.
-		checkProxyStatistics(app3EndpointID, 4, 6, 2, 4, 4)
+		// While the policy allows connectivity on L3 from app3 to httpd2,
+		// the rule which does so does not have any L7 rules, so we expect
+		// no increase in requests forwarded by or denied by the proxy.
+		checkProxyStatistics(app3EndpointID, 2, 4, 2, 2, 2)
 
 		connectivityTest(httpRequestsPrivate, helpers.App3, helpers.Httpd2, true)
 
-		// Since policy allows connectivity on L3 from app3 to httpd2, we expect:
-		// * two more requests to get received by the proxy because even though
-		// only L3 policy applies for connectivity from app3 to httpd2, because
-		// app3 has L7 policy applied to it, all traffic goes through the proxy.
-		// * two more requests to get forwarded by the proxy because policy allows
-		// app3 to talk to httpd2, even though it's restricted on L7 for connectivity
-		// to httpd1 from app3. This is what tests L3-dependent L7 policy is applied
-		// correctly.
-		// * no increase in requests denied by the proxy.
-		// * two more corresponding responses forwarded / received to the aforementioned requests due to policy
-		// allowing connectivity via http / http6.
-		checkProxyStatistics(app3EndpointID, 6, 8, 2, 6, 6)
+		// While the policy allows connectivity on L3 from app3 to httpd2,
+		// the rule which does so does not have any L7 rules, so we expect
+		// no increase in requests forwarded by or denied by the proxy.
+		checkProxyStatistics(app3EndpointID, 2, 4, 2, 2, 2)
 	})
 
 	It("Checks CIDR L3 Policy", func() {


### PR DESCRIPTION
Conflicts with #7411.

Previously, if an L4-only rule overlapped with an L3-dependent L7 rule,
then all traffic that matched that L4 port/proto would always be sent to
the proxy, regardless of whether the L3 matched the L7 rule's
dependency. This currently denies traffic that migh totherwise be
allowed by policy, and furthermore adds unnecessary latency and
complication to the forwarding path.
    
This PR reworks the wildcarding of L7 rules so that if there exists
an L7 rule for a particular L3 destination and a broader rule wildcards
all traffic at L7, then the traffic will be redirected to the proxy but
all traffic will be reliably allowed; whereas if the L3 does *not*
match, then don't populate the L7 rules for those L3 peers; the traffic
can be forwarded purely at L3/L4 via BPF without involving the proxy at
all.
    
Related: #7438

This was validated against a variation of #7411 (which I'll update,
depending on which PRs go in first).

#7476 is a smaller fix which generates the correct L7 rules to the
proxy without avoiding the redirect, which fixes #7438. We can
evaluate whether such a fix would be appropriate for backport to the
1.4 and/or earlier branches.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7471)
<!-- Reviewable:end -->
