### PR TITLE
Fix issue where traffic matching L4-only rule would be redirected to the proxy then dropped

### DIFF
--- a/daemon/policy_test.go
+++ b/daemon/policy_test.go
@@ -48,6 +48,13 @@ var (
 	ProdIPv6Addr, _ = addressing.NewCiliumIPv6("cafe:cafe:cafe:cafe:aaaa:aaaa:1111:1112")
 	ProdIPv4Addr, _ = addressing.NewCiliumIPv4("10.11.12.14")
 
+	lblProd = labels.ParseLabel("Prod")
+	lblQA   = labels.ParseLabel("QA")
+	lblFoo  = labels.ParseLabel("foo")
+	lblBar  = labels.ParseLabel("bar")
+	lblJoe  = labels.ParseLabel("user=joe")
+	lblPete = labels.ParseLabel("user=pete")
+
 	testEndpointID = uint16(1)
 
 	regenerationMetadata = &endpoint.ExternalRegenerationMetadata{
@@ -147,13 +154,6 @@ func (ds *DaemonSuite) prepareEndpoint(c *C, identity *identity.Identity, qa boo
 }
 
 func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
-	lblProd := labels.ParseLabel("Prod")
-	lblQA := labels.ParseLabel("QA")
-	lblFoo := labels.ParseLabel("foo")
-	lblBar := labels.ParseLabel("bar")
-	lblJoe := labels.ParseLabel("user=joe")
-	lblPete := labels.ParseLabel("user=pete")
-
 	rules := api.Rules{
 		{
 			EndpointSelector: api.NewESFromLabels(lblBar),
@@ -338,7 +338,6 @@ func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
 }
 
 func (ds *DaemonSuite) TestReplacePolicy(c *C) {
-	lblBar := labels.ParseLabel("bar")
 	lbls := labels.ParseLabelArray("foo", "bar")
 	rules := api.Rules{
 		{
@@ -386,13 +385,6 @@ func (ds *DaemonSuite) TestReplacePolicy(c *C) {
 }
 
 func (ds *DaemonSuite) TestRemovePolicy(c *C) {
-	lblProd := labels.ParseLabel("Prod")
-	lblQA := labels.ParseLabel("QA")
-	lblFoo := labels.ParseLabel("foo")
-	lblBar := labels.ParseLabel("bar")
-	lblJoe := labels.ParseLabel("user=joe")
-	lblPete := labels.ParseLabel("user=pete")
-
 	rules := api.Rules{
 		{
 			EndpointSelector: api.NewESFromLabels(lblBar),

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -128,6 +128,11 @@ func wildcardL3L4Rule(proto api.L4Proto, port int, endpoints api.EndpointSelecto
 		if proto != filter.Protocol || (port != 0 && port != filter.Port) {
 			continue
 		}
+
+		if endpoints.SelectsAllEndpoints() {
+			endpoints = api.EndpointSelectorSlice{api.WildcardEndpointSelector}
+		}
+
 		switch filter.L7Parser {
 		case ParserTypeNone:
 			continue

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -2020,11 +2020,12 @@ func (ds *PolicyTestSuite) TestL4WildcardMerge(c *C) {
 	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, true)
 
-	c.Assert(len(filter.Endpoints), Equals, 1)
+	c.Assert(len(filter.Endpoints), Equals, 2)
 	c.Assert(filter.Endpoints[0], Equals, api.WildcardEndpointSelector)
+	c.Assert(filter.Endpoints[1], Equals, api.WildcardEndpointSelector)
 
 	c.Assert(filter.L7Parser, Equals, ParserTypeHTTP)
-	c.Assert(len(filter.L7RulesPerEp), Equals, 1)
+	c.Assert(len(filter.L7RulesPerEp), Equals, 2)
 
 	// Test the reverse order as well; ensure that we check both conditions
 	// for if L4-only policy is in the L4Filter for the same port-protocol tuple,
@@ -2070,10 +2071,10 @@ func (ds *PolicyTestSuite) TestL4WildcardMerge(c *C) {
 	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, true)
 
-	c.Assert(len(filter.Endpoints), Equals, 1)
+	c.Assert(len(filter.Endpoints), Equals, 2)
 
 	c.Assert(filter.L7Parser, Equals, ParserTypeHTTP)
-	c.Assert(len(filter.L7RulesPerEp), Equals, 1)
+	c.Assert(len(filter.L7RulesPerEp), Equals, 2)
 
 	// Second, test the explicit allow at L3.
 	repo = parseAndAddRules(c, api.Rules{&api.Rule{
@@ -2116,7 +2117,9 @@ func (ds *PolicyTestSuite) TestL4WildcardMerge(c *C) {
 	c.Assert(ok, Equals, true)
 	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, true)
-	c.Assert(len(filter.Endpoints), Equals, 2)
+
+	// 3 -> One for each rule, plus one from the l4-only rule (l7 scan).
+	c.Assert(len(filter.Endpoints), Equals, 3)
 	c.Assert(filter.L7Parser, Equals, ParserTypeHTTP)
 	c.Assert(len(filter.L7RulesPerEp), Equals, 2)
 
@@ -2165,7 +2168,8 @@ func (ds *PolicyTestSuite) TestL4WildcardMerge(c *C) {
 	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, true)
 
-	c.Assert(len(filter.Endpoints), Equals, 2)
+	// 3 -> One for each rule, plus one from the l4-only rule (l7 scan).
+	c.Assert(len(filter.Endpoints), Equals, 3)
 
 	c.Assert(filter.L7Parser, Equals, ParserTypeHTTP)
 	c.Assert(len(filter.L7RulesPerEp), Equals, 2)

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -2118,8 +2118,7 @@ func (ds *PolicyTestSuite) TestL4WildcardMerge(c *C) {
 	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, true)
 
-	// 3 -> One for each rule, plus one from the l4-only rule (l7 scan).
-	c.Assert(len(filter.Endpoints), Equals, 3)
+	c.Assert(len(filter.Endpoints), Equals, 2)
 	c.Assert(filter.L7Parser, Equals, ParserTypeHTTP)
 	c.Assert(len(filter.L7RulesPerEp), Equals, 2)
 
@@ -2168,8 +2167,7 @@ func (ds *PolicyTestSuite) TestL4WildcardMerge(c *C) {
 	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, true)
 
-	// 3 -> One for each rule, plus one from the l4-only rule (l7 scan).
-	c.Assert(len(filter.Endpoints), Equals, 3)
+	c.Assert(len(filter.Endpoints), Equals, 2)
 
 	c.Assert(filter.L7Parser, Equals, ParserTypeHTTP)
 	c.Assert(len(filter.L7RulesPerEp), Equals, 2)

--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -76,6 +76,9 @@ func (rules ruleSlice) wildcardL3L4Rules(ctx *SearchContext, ingress bool, l4Pol
 					wildcardL3L4Rule(api.ProtoTCP, 0, fromEndpoints, ruleLabels, l4Policy)
 					wildcardL3L4Rule(api.ProtoUDP, 0, fromEndpoints, ruleLabels, l4Policy)
 				} else {
+					if fromEndpoints.SelectsAllEndpoints() {
+						fromEndpoints = append(fromEndpoints, api.WildcardEndpointSelector)
+					}
 					for _, toPort := range rule.ToPorts {
 						// L3/L4-only rule
 						if toPort.Rules.IsEmpty() {
@@ -108,6 +111,9 @@ func (rules ruleSlice) wildcardL3L4Rules(ctx *SearchContext, ingress bool, l4Pol
 					wildcardL3L4Rule(api.ProtoTCP, 0, toEndpoints, ruleLabels, l4Policy)
 					wildcardL3L4Rule(api.ProtoUDP, 0, toEndpoints, ruleLabels, l4Policy)
 				} else {
+					if toEndpoints.SelectsAllEndpoints() {
+						toEndpoints = append(toEndpoints, api.WildcardEndpointSelector)
+					}
 					for _, toPort := range rule.ToPorts {
 						// L3/L4-only rule
 						if toPort.Rules.IsEmpty() {

--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -76,9 +76,6 @@ func (rules ruleSlice) wildcardL3L4Rules(ctx *SearchContext, ingress bool, l4Pol
 					wildcardL3L4Rule(api.ProtoTCP, 0, fromEndpoints, ruleLabels, l4Policy)
 					wildcardL3L4Rule(api.ProtoUDP, 0, fromEndpoints, ruleLabels, l4Policy)
 				} else {
-					if fromEndpoints.SelectsAllEndpoints() {
-						fromEndpoints = append(fromEndpoints, api.WildcardEndpointSelector)
-					}
 					for _, toPort := range rule.ToPorts {
 						// L3/L4-only rule
 						if toPort.Rules.IsEmpty() {
@@ -111,9 +108,6 @@ func (rules ruleSlice) wildcardL3L4Rules(ctx *SearchContext, ingress bool, l4Pol
 					wildcardL3L4Rule(api.ProtoTCP, 0, toEndpoints, ruleLabels, l4Policy)
 					wildcardL3L4Rule(api.ProtoUDP, 0, toEndpoints, ruleLabels, l4Policy)
 				} else {
-					if toEndpoints.SelectsAllEndpoints() {
-						toEndpoints = append(toEndpoints, api.WildcardEndpointSelector)
-					}
 					for _, toPort := range rule.ToPorts {
 						// L3/L4-only rule
 						if toPort.Rules.IsEmpty() {


### PR DESCRIPTION
Previously, if an L4-only rule shadowed an L7 rule on the same
port/protocol, we would redirect the traffic to the proxy, but we would
*not* generate xDS filters to allow that traffic. This would result in
unexpectedly dropping traffic that should otherwise be allowed.
    
The included test previously failed, with the functional change in this
commit it now passes.

I included a few test refactors here just because otherwise these tests
became unwieldy to understand and reuse. The top commit is the only
functional change (with accompanying test).

Related: #7438

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7476)
<!-- Reviewable:end -->
