### PR TITLE
endpoint: only start EventQueue once endpoint is exposed via endpointmanager

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -488,7 +488,6 @@ func NewEndpointFromChangeModel(base *models.EndpointChangeRequest) (*Endpoint, 
 	}
 
 	ep.SetDefaultOpts(option.Config.Opts)
-	ep.EventQueue.Run()
 
 	return ep, nil
 }
@@ -1068,7 +1067,6 @@ func ParseEndpoint(strEp string) (*Endpoint, error) {
 	ep.UpdateLogger(nil)
 
 	ep.SetStateLocked(StateRestoring, "Endpoint restoring")
-	ep.EventQueue.Run()
 
 	return &ep, nil
 }

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -92,6 +92,11 @@ func Insert(ep *endpoint.Endpoint) error {
 	ep.UnconditionalRLock()
 	mutex.Lock()
 
+	// The endpoint's eventqueue can be safely started. Ensure that it is only
+	// started once it is exposed to the endpointmanager so that it will be
+	// stopped when the endpoint is removed from the endpointmanager.
+	ep.EventQueue.Run()
+
 	endpoints[ep.ID] = ep
 	updateReferences(ep)
 
@@ -479,7 +484,6 @@ func AddEndpoint(owner endpoint.Owner, ep *endpoint.Endpoint, reason string) (er
 	if ep.ID != 0 {
 		return fmt.Errorf("Endpoint ID is already set to %d", ep.ID)
 	}
-
 	return Insert(ep)
 }
 


### PR DESCRIPTION
This ensures that goroutines are not leaked for endpoints which cannot be
inserted into the endpointmanager / are not inserted into the endpointmanager
due to some error before insertion.

Fixes: 04a49b0898ed008f6f332ae55ba4acfcc396a40f ("endpoint: add EventQueue field")

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7477)
<!-- Reviewable:end -->
