### PR TITLE
k8s: Merge init-container.sh with cilium cleanup

### DIFF
--- a/Documentation/cmdref/cilium_cleanup.md
+++ b/Documentation/cmdref/cilium_cleanup.md
@@ -15,8 +15,10 @@ cilium cleanup [flags]
 ### Options
 
 ```
-  -f, --force   Skip confirmation
-  -h, --help    help for cleanup
+      --all-state   Remove all cilium state
+      --bpf-state   Remove BPF state
+  -f, --force       Skip confirmation
+  -h, --help        help for cleanup
 ```
 
 ### Options inherited from parent commands

--- a/contrib/packaging/docker/Dockerfile.init
+++ b/contrib/packaging/docker/Dockerfile.init
@@ -2,9 +2,9 @@
 # Cilium init container.
 #
 # cilium-init is used in kubernetes environments to run miscellaneous
-# logic for cleaning up containers in between pod restarts.
+# logic for setting up containers in between pod restarts.
 #
-FROM docker.io/library/busybox:1.28.4
+FROM docker.io/cilium/cilium:latest
 LABEL maintainer="maintainer@cilium.io"
 COPY init-container.sh /init-container.sh
 CMD ["/init-container.sh"]

--- a/contrib/packaging/docker/init-container.sh
+++ b/contrib/packaging/docker/init-container.sh
@@ -1,15 +1,7 @@
 #!/bin/sh
 
-if [ "${CLEAN_CILIUM_STATE}" = "true" ]; then
-    echo "Removing Cilium state..."
-    rm -rf /var/run/cilium/state;
-fi;
-if [ "${CLEAN_CILIUM_STATE}" = "true" ] \
-   || [ "${CLEAN_CILIUM_BPF_STATE}" = "true" ]; then
-    echo "Removing BPF state..."
-    rm -rf /sys/fs/bpf/tc/globals/cilium_* \
-           /var/run/cilium/bpffs/tc/globals/cilium_*;
-fi
+cilium cleanup -f
+
 if [ "${CILIUM_WAIT_BPF_MOUNT}" = "true" ]; then
 	until mount | grep bpf; do echo "BPF filesystem is not mounted yet"; sleep 1; done
 fi;

--- a/examples/kubernetes/1.10/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-containerd-ds.yaml
@@ -147,13 +147,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.10/cilium-containerd.yaml
+++ b/examples/kubernetes/1.10/cilium-containerd.yaml
@@ -300,13 +300,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.10/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-crio-ds.yaml
@@ -155,13 +155,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -308,13 +308,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.10/cilium-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-ds.yaml
@@ -154,13 +154,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.10/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.10/cilium-external-etcd.yaml
@@ -307,13 +307,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.10/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-minikube-ds.yaml
@@ -154,13 +154,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.10/cilium-minikube.yaml
+++ b/examples/kubernetes/1.10/cilium-minikube.yaml
@@ -307,13 +307,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.10/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.10/cilium-with-node-init.yaml
@@ -307,13 +307,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -307,13 +307,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.11/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-containerd-ds.yaml
@@ -147,13 +147,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.11/cilium-containerd.yaml
+++ b/examples/kubernetes/1.11/cilium-containerd.yaml
@@ -300,13 +300,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.11/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-crio-ds.yaml
@@ -153,13 +153,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -306,13 +306,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -154,13 +154,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.11/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.11/cilium-external-etcd.yaml
@@ -307,13 +307,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.11/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-minikube-ds.yaml
@@ -154,13 +154,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.11/cilium-minikube.yaml
+++ b/examples/kubernetes/1.11/cilium-minikube.yaml
@@ -307,13 +307,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.11/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.11/cilium-with-node-init.yaml
@@ -307,13 +307,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -307,13 +307,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.12/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-containerd-ds.yaml
@@ -147,13 +147,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.12/cilium-containerd.yaml
+++ b/examples/kubernetes/1.12/cilium-containerd.yaml
@@ -300,13 +300,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.12/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-crio-ds.yaml
@@ -153,13 +153,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -306,13 +306,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.12/cilium-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-ds.yaml
@@ -154,13 +154,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.12/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.12/cilium-external-etcd.yaml
@@ -307,13 +307,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.12/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-minikube-ds.yaml
@@ -154,13 +154,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.12/cilium-minikube.yaml
+++ b/examples/kubernetes/1.12/cilium-minikube.yaml
@@ -307,13 +307,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.12/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.12/cilium-with-node-init.yaml
@@ -307,13 +307,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -307,13 +307,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.13/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-containerd-ds.yaml
@@ -147,13 +147,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.13/cilium-containerd.yaml
+++ b/examples/kubernetes/1.13/cilium-containerd.yaml
@@ -300,13 +300,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.13/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-crio-ds.yaml
@@ -153,13 +153,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.13/cilium-crio.yaml
+++ b/examples/kubernetes/1.13/cilium-crio.yaml
@@ -306,13 +306,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.13/cilium-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-ds.yaml
@@ -154,13 +154,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.13/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.13/cilium-external-etcd.yaml
@@ -307,13 +307,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.13/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-minikube-ds.yaml
@@ -154,13 +154,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.13/cilium-minikube.yaml
+++ b/examples/kubernetes/1.13/cilium-minikube.yaml
@@ -307,13 +307,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.13/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.13/cilium-with-node-init.yaml
@@ -307,13 +307,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.13/cilium.yaml
+++ b/examples/kubernetes/1.13/cilium.yaml
@@ -307,13 +307,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.14/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.14/cilium-containerd-ds.yaml
@@ -147,13 +147,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.14/cilium-containerd.yaml
+++ b/examples/kubernetes/1.14/cilium-containerd.yaml
@@ -300,13 +300,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.14/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.14/cilium-crio-ds.yaml
@@ -153,13 +153,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.14/cilium-crio.yaml
+++ b/examples/kubernetes/1.14/cilium-crio.yaml
@@ -306,13 +306,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.14/cilium-ds.yaml
+++ b/examples/kubernetes/1.14/cilium-ds.yaml
@@ -154,13 +154,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.14/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.14/cilium-external-etcd.yaml
@@ -307,13 +307,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.14/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.14/cilium-minikube-ds.yaml
@@ -154,13 +154,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.14/cilium-minikube.yaml
+++ b/examples/kubernetes/1.14/cilium-minikube.yaml
@@ -307,13 +307,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.14/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.14/cilium-with-node-init.yaml
@@ -307,13 +307,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/1.14/cilium.yaml
+++ b/examples/kubernetes/1.14/cilium.yaml
@@ -307,13 +307,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/templates/v1/cilium-containerd-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-containerd-ds.yaml.sed
@@ -147,13 +147,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
@@ -155,13 +155,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
@@ -154,13 +154,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state

--- a/examples/kubernetes/templates/v1/cilium-minikube-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-minikube-ds.yaml.sed
@@ -154,13 +154,13 @@ spec:
       - command:
         - /init-container.sh
         env:
-        - name: CLEAN_CILIUM_STATE
+        - name: CILIUM_ALL_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-state
               name: cilium-config
               optional: true
-        - name: CLEAN_CILIUM_BPF_STATE
+        - name: CILIUM_BPF_STATE
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state


### PR DESCRIPTION
This commit provides the option to only remove BPF
state by passing the flag `--bpf-state-only` to the
`cilium cleanup` command. The idea is to be able to
honor both `clean-cilium-state` and `clean-cilium-bpf-state`
options and replace `init-container.sh` script in the k8s YAMLs.

Fixes #6478

I'm not so sure whether this is the best approach to do this so I'm happy to make suggested changes!
I've skipped updating all the YAML files for now until the PR looks good to merge.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7478)
<!-- Reviewable:end -->
