### PR TITLE
eventqueue: signal when queue is started, hide running of queue

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -418,7 +418,6 @@ func NewEndpointWithState(ID uint16, state string) *Endpoint {
 	}
 	ep.SetDefaultOpts(option.Config.Opts)
 	ep.UpdateLogger(nil)
-	ep.EventQueue.Run()
 
 	return ep
 }
@@ -488,7 +487,6 @@ func NewEndpointFromChangeModel(base *models.EndpointChangeRequest) (*Endpoint, 
 	}
 
 	ep.SetDefaultOpts(option.Config.Opts)
-	ep.EventQueue.Run()
 
 	return ep, nil
 }
@@ -1068,7 +1066,6 @@ func ParseEndpoint(strEp string) (*Endpoint, error) {
 	ep.UpdateLogger(nil)
 
 	ep.SetStateLocked(StateRestoring, "Endpoint restoring")
-	ep.EventQueue.Run()
 
 	return &ep, nil
 }

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -57,8 +57,6 @@ type Repository struct {
 func NewPolicyRepository() *Repository {
 	repoChangeQueue := eventqueue.NewEventQueueBuffered(option.Config.PolicyQueueSize)
 	ruleReactionQueue := eventqueue.NewEventQueueBuffered(option.Config.PolicyQueueSize)
-	repoChangeQueue.Run()
-	ruleReactionQueue.Run()
 	return &Repository{
 		revision:              1,
 		RepositoryChangeQueue: repoChangeQueue,


### PR DESCRIPTION
Do not export the functionality for starting the queue anymore. This functionality is now performed
on every Enqueue. If the queue has already been started, then it will not be started again. Also
add a channel which signifies whether the EventQueue is running or not for visibility.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7479)
<!-- Reviewable:end -->
