### PR TITLE
daemon: fix namespace controller to watch for correct object type

### DIFF
--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -878,7 +878,7 @@ func (d *Daemon) EnableK8sWatcher(queueSize uint) error {
 	_, namespaceController := k8s.NewInformer(
 		cache.NewListWatchFromClient(k8s.Client().CoreV1().RESTClient(),
 			"namespaces", v1.NamespaceAll, fields.Everything()),
-		&v1.Node{},
+		&v1.Namespace{},
 		0,
 		cache.ResourceEventHandlerFuncs{
 			// AddFunc does not matter since the endpoint will fetch


### PR DESCRIPTION
This should be `v1.Namespace`, not `v1.Node`.

Fixes: a71dfb49bb55e879dc7449c95f47c527fbea70a8 ("pkg/k8s: use official k8s library to watch events from kube-apiserver")

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7480)
<!-- Reviewable:end -->
