### PR TITLE
stop watching for k8s infrastructure endpoints as a CLI option

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -74,6 +74,7 @@ cilium-agent [flags]
       --k8s-kubeconfig-path string                  Absolute path of the kubernetes kubeconfig file
       --k8s-require-ipv4-pod-cidr                   Require IPv4 PodCIDR to be specified in node resource
       --k8s-require-ipv6-pod-cidr                   Require IPv6 PodCIDR to be specified in node resource
+      --k8s-watcher-endpoint-selector string        K8s endpoint watcher will watch for these k8s endpoints (default "metadata.name!=kube-scheduler,metadata.name!=kube-controller-manager")
       --k8s-watcher-queue-size uint                 Queue size used to serialize each k8s event type (default 1024)
       --keep-bpf-templates                          Do not restore BPF template files from binary
       --keep-config                                 When restoring state, keeps containers' configuration in place

--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -74,7 +74,7 @@ cilium-agent [flags]
       --k8s-kubeconfig-path string                  Absolute path of the kubernetes kubeconfig file
       --k8s-require-ipv4-pod-cidr                   Require IPv4 PodCIDR to be specified in node resource
       --k8s-require-ipv6-pod-cidr                   Require IPv6 PodCIDR to be specified in node resource
-      --k8s-watcher-endpoint-selector string        K8s endpoint watcher will watch for these k8s endpoints (default "metadata.name!=kube-scheduler,metadata.name!=kube-controller-manager")
+      --k8s-watcher-endpoint-selector string        K8s endpoint watcher will watch for these k8s endpoints (default "metadata.name!=kube-scheduler,metadata.name!=kube-controller-manager,metadata.name!=etcd-operator,metadata.name!=gcp-controller-manager")
       --k8s-watcher-queue-size uint                 Queue size used to serialize each k8s event type (default 1024)
       --keep-bpf-templates                          Do not restore BPF template files from binary
       --keep-config                                 When restoring state, keeps containers' configuration in place

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -521,6 +521,9 @@ func init() {
 	option.BindEnv(option.K8sForceJSONPatch)
 	flags.MarkHidden(option.K8sForceJSONPatch)
 
+	flags.String(option.K8sWatcherEndpointSelector, defaults.K8sWatcherEndpointSelector, "K8s endpoint watcher will watch for these k8s endpoints")
+	option.BindEnv(option.K8sWatcherEndpointSelector)
+
 	flags.Bool(option.KeepConfig, false, "When restoring state, keeps containers' configuration in place")
 	option.BindEnv(option.KeepConfig)
 

--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -522,8 +522,7 @@ func (d *Daemon) EnableK8sWatcher(queueSize uint) error {
 	_, endpointController := k8s.NewInformer(
 		cache.NewListWatchFromClient(k8s.Client().CoreV1().RESTClient(),
 			"endpoints", v1.NamespaceAll,
-			// Don't get any events from kubernetes endpoints.
-			fields.ParseSelectorOrDie("metadata.name!=kube-scheduler,metadata.name!=kube-controller-manager"),
+			fields.ParseSelectorOrDie(option.Config.K8sWatcherEndpointSelector),
 		),
 		&v1.Endpoints{},
 		0,

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -180,5 +180,5 @@ const (
 
 	// K8sWatcherEndpointSelector specifies the k8s endpoints that Cilium
 	// should watch for.
-	K8sWatcherEndpointSelector = "metadata.name!=kube-scheduler,metadata.name!=kube-controller-manager"
+	K8sWatcherEndpointSelector = "metadata.name!=kube-scheduler,metadata.name!=kube-controller-manager,metadata.name!=etcd-operator,metadata.name!=gcp-controller-manager"
 )

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -177,4 +177,8 @@ const (
 	// SelectiveRegeneration specifies whether regeneration of endpoints will be
 	// invoked only for endpoints which are selected by policy changes.
 	SelectiveRegeneration = true
+
+	// K8sWatcherEndpointSelector specifies the k8s endpoints that Cilium
+	// should watch for.
+	K8sWatcherEndpointSelector = "metadata.name!=kube-scheduler,metadata.name!=kube-controller-manager"
 )

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -155,6 +155,10 @@ const (
 	// status in kube-apiserver.
 	K8sForceJSONPatch = "k8s-force-json-patch"
 
+	// K8sWatcherEndpointSelector specifies the k8s endpoints that Cilium
+	// should watch for.
+	K8sWatcherEndpointSelector = "k8s-watcher-endpoint-selector"
+
 	// K8sAPIServer is the kubernetes api address server (for https use --k8s-kubeconfig-path instead)
 	K8sAPIServer = "k8s-api-server"
 
@@ -744,6 +748,7 @@ type DaemonConfig struct {
 	K8sAPIServer                      string
 	K8sKubeConfigPath                 string
 	K8sLegacyHostAllowsWorld          string
+	K8sWatcherEndpointSelector        string
 	KVStore                           string
 	KVStoreOpt                        map[string]string
 	LabelPrefixFile                   string


### PR DESCRIPTION
etcd-operator and gcp-controller-manager endpoints are only used for leaderelection which makes those endpoints to have frequent endpoint updates. As those endpoints are not used in a k8s service we can safely ignore them by default.


```release-note
Do not watch for events of k8s endpoints "gcp-controller-manager" and "etcd-operator"
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7483)
<!-- Reviewable:end -->
