### PR TITLE
pkg/kvstore: start watchers only when etcd is connected

### DIFF
--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -537,6 +537,7 @@ func (e *etcdClient) Watch(w *Watcher) {
 		fieldWatcher: w,
 		fieldPrefix:  w.prefix,
 	})
+	<-e.Connected()
 
 reList:
 	for {


### PR DESCRIPTION
There's no point in trying to watch for a resource is etcd is not
connected so we should start watching for a resource when cilium has
etcd connectivity.

Signed-off-by: André Martins <andre@cilium.io>

Depends on #7447 

**NOTE**: Even with this patch I've noticed `"Starting to watch allocation changes"` message always shows that etcd is not connected, I think we should also wait until we have connectivity with the kvstore before reporting any status for etcd.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7484)
<!-- Reviewable:end -->
