### PR TITLE
examples/kubernetes: fix cilium-operator RBAC

### DIFF
--- a/examples/kubernetes/1.10/cilium-containerd.yaml
+++ b/examples/kubernetes/1.10/cilium-containerd.yaml
@@ -512,17 +512,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -520,17 +520,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.10/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.10/cilium-external-etcd.yaml
@@ -519,17 +519,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.10/cilium-operator-sa.yaml
+++ b/examples/kubernetes/1.10/cilium-operator-sa.yaml
@@ -13,17 +13,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.10/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.10/cilium-with-node-init.yaml
@@ -519,17 +519,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -519,17 +519,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.11/cilium-containerd.yaml
+++ b/examples/kubernetes/1.11/cilium-containerd.yaml
@@ -514,17 +514,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -513,17 +513,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.11/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.11/cilium-external-etcd.yaml
@@ -521,17 +521,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.11/cilium-operator-sa.yaml
+++ b/examples/kubernetes/1.11/cilium-operator-sa.yaml
@@ -13,17 +13,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.11/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.11/cilium-with-node-init.yaml
@@ -519,17 +519,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -521,17 +521,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.12/cilium-containerd.yaml
+++ b/examples/kubernetes/1.12/cilium-containerd.yaml
@@ -514,17 +514,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -513,17 +513,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.12/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.12/cilium-external-etcd.yaml
@@ -521,17 +521,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.12/cilium-operator-sa.yaml
+++ b/examples/kubernetes/1.12/cilium-operator-sa.yaml
@@ -13,17 +13,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.12/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.12/cilium-with-node-init.yaml
@@ -519,17 +519,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -521,17 +521,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.13/cilium-containerd.yaml
+++ b/examples/kubernetes/1.13/cilium-containerd.yaml
@@ -514,17 +514,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.13/cilium-crio.yaml
+++ b/examples/kubernetes/1.13/cilium-crio.yaml
@@ -513,17 +513,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.13/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.13/cilium-external-etcd.yaml
@@ -521,17 +521,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.13/cilium-operator-sa.yaml
+++ b/examples/kubernetes/1.13/cilium-operator-sa.yaml
@@ -13,17 +13,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.13/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.13/cilium-with-node-init.yaml
@@ -519,17 +519,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.13/cilium.yaml
+++ b/examples/kubernetes/1.13/cilium.yaml
@@ -521,17 +521,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.14/cilium-containerd.yaml
+++ b/examples/kubernetes/1.14/cilium-containerd.yaml
@@ -514,17 +514,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.14/cilium-crio.yaml
+++ b/examples/kubernetes/1.14/cilium-crio.yaml
@@ -513,17 +513,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.14/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.14/cilium-external-etcd.yaml
@@ -521,17 +521,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.14/cilium-operator-sa.yaml
+++ b/examples/kubernetes/1.14/cilium-operator-sa.yaml
@@ -13,17 +13,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.14/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.14/cilium-with-node-init.yaml
@@ -519,17 +519,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/1.14/cilium.yaml
+++ b/examples/kubernetes/1.14/cilium.yaml
@@ -521,17 +521,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list

--- a/examples/kubernetes/templates/v1/cilium-operator-sa.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-operator-sa.yaml.sed
@@ -13,17 +13,31 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  - deployments
+  # to get k8s version and status
   - componentstatuses
   verbs:
-  - '*'
+  - get
 - apiGroups:
   - ""
   resources:
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  # to automatically read from k8s and import the node's pod CIDR to cilium's
+  # etcd so all nodes know how to reach another pod running in in a different
+  # node.
+  - nodes
+  # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  - nodes
   verbs:
   - get
   - list


### PR DESCRIPTION
cilium-operator has more permissions than the ones that actually need.
Re-wrote the RBAC for cilium-operator and add comments explaining the
reason it needs those permissions to access k8s API.

Signed-off-by: André Martins <andre@cilium.io>

Depends on #7447

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7485)
<!-- Reviewable:end -->
