### PR TITLE
k8s/node-init: add node-init script to automatically restart pods managed by kubenet on GKE

### DIFF
--- a/examples/kubernetes/node-init/README.rst
+++ b/examples/kubernetes/node-init/README.rst
@@ -13,6 +13,16 @@ The node-init DaemonSet prepares a node to run Cilium, it will:
 
  * Write a Cilium CNI configuration file to `/etc/cni/net.d/04-cilium-cni.conf`
 
+Recommended node-init DaemonSet
+===============================
+
+There is a more aggressive DaemonSet that will remove all running containers
+managed by kubenet. It is extremely recommended to run the `node-init-with-kill-pods.yaml`
+instead of `node-init.yaml` to avoid pods potentially being managed by kubenet
+during scale up and scale down. Be aware this might delete k8s jobs and pods
+that are managed by kubenet, this will force kubelet to reschedule the pod to
+have its network managed by Cilium.
+
 Requirements
 ------------
 

--- a/examples/kubernetes/node-init/node-init-with-kill-pods.yaml
+++ b/examples/kubernetes/node-init/node-init-with-kill-pods.yaml
@@ -1,0 +1,101 @@
+kind: DaemonSet
+apiVersion: extensions/v1beta1
+metadata:
+  name: cilium-node-init
+  labels:
+    app: cilium-node-init
+spec:
+  template:
+    metadata:
+      labels:
+        app: cilium-node-init
+    spec:
+      tolerations:
+      - operator: Exists
+      hostPID: true
+      hostNetwork: true
+      containers:
+        - name: node-init
+          image: gcr.io/google-containers/startup-script:v1
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+          env:
+          - name: STARTUP_SCRIPT
+            value: |
+              #!/bin/bash
+
+              set -o errexit
+              set -o pipefail
+              set -o nounset
+
+              if [[ ! -f /tmp/cilium-installed-v1 ]]; then
+                echo "Installing BPF filesystem mount"
+
+                cat >/tmp/sys-fs-bpf.mount <<EOF
+              [Unit]
+              Description=Mount BPF filesystem (Cilium)
+              Documentation=http://docs.cilium.io/
+              DefaultDependencies=no
+              Before=local-fs.target umount.target
+              After=swap.target
+
+              [Mount]
+              What=bpffs
+              Where=/sys/fs/bpf
+              Type=bpf
+
+              [Install]
+              WantedBy=multi-user.target
+              EOF
+
+                if [ -d "/etc/systemd/system/" ]; then
+                  mv /tmp/sys-fs-bpf.mount /etc/systemd/system/
+                  echo "Installed sys-fs-bpf.mount to /etc/systemd/system/"
+                elif [ -d "/lib/systemd/system/" ]; then
+                  mv /tmp/sys-fs-bpf.mount /lib/systemd/system/
+                  echo "Installed sys-fs-bpf.mount to /lib/systemd/system/"
+                fi
+
+                systemctl enable sys-fs-bpf.mount
+                systemctl start sys-fs-bpf.mount
+
+                echo "Installing /etc/cni/net.d/04-cilium-cni.conf"
+                mkdir -p /etc/cni/net.d/
+                cat >/etc/cni/net.d/04-cilium-cni.conf <<EOF
+              {
+                "name": "cilium",
+                "type": "cilium-cni"
+              }
+              EOF
+
+                echo "Changing kubelet configuration to --network-plugin=cni --cni-bin-dir=/home/kubernetes/bin"
+                mkdir -p /home/kubernetes/bin
+                sed -i "s:--network-plugin=kubenet:--network-plugin=cni\ --cni-bin-dir=/home/kubernetes/bin:g" /etc/default/kubelet
+                echo "Restarting kubelet..."
+                systemctl restart kubelet
+
+                echo "Restarting kubenet managed pods"
+                if grep -q 'docker' /etc/crictl.yaml; then
+                  # Works for COS, ubuntu
+                  for f in `find /var/lib/cni/networks/ -type f ! -name lock ! -name last_reserved_ip.0`; do docker rm -f $(cat $f) || true; done
+                else
+                  # COS-beta (with containerd)
+                  for f in `find /var/lib/cni/networks/ -type f ! -name lock ! -name last_reserved_ip.0`; do crictl stopp $(cat $f) || true; done
+                fi
+
+                if ip link show cbr0; then
+                  echo "Detected cbr0 bridge. Deleting interface..."
+                  ip link del cbr0
+                fi
+
+                echo "Link information:"
+                ip link
+
+                echo "Routing table:"
+                ip route
+
+                echo "Node initialization complete"
+
+                touch /tmp/cilium-installed-v1
+              fi

--- a/examples/kubernetes/node-init/node-init-with-kill-pods.yaml
+++ b/examples/kubernetes/node-init/node-init-with-kill-pods.yaml
@@ -89,6 +89,21 @@ spec:
                   ip link del cbr0
                 fi
 
+                # We still need to delete Cilium in case it started before
+                # we have changed kubelet configuration. This prevents Cilium
+                # from pre-allocating all IP addresses managed by cbr0.
+                echo "Restarting possible cilium instances"
+                if grep -q 'docker' /etc/crictl.yaml; then
+                  # Works for COS, ubuntu
+                  docker rm -f $(docker ps -q --filter=label=k8s-app=cilium) || true
+                else
+                  # COS-beta (with containerd)
+                  # currently cilium doesn't work with cos-beta so once it does
+                  # we need to figure out a why to delete cilium pods
+                  echo "Not implemented for cos-beta, please restart cilium pods"
+                  echo "manually!"
+                fi
+
                 echo "Link information:"
                 ip link
 

--- a/examples/kubernetes/node-init/node-init.yaml
+++ b/examples/kubernetes/node-init/node-init.yaml
@@ -10,6 +10,8 @@ spec:
       labels:
         app: cilium-node-init
     spec:
+      tolerations:
+      - operator: Exists
       hostPID: true
       containers:
         - name: node-init
@@ -81,5 +83,5 @@ spec:
 
               echo "Routing table:"
               ip route
-              
+
               echo "Node initialization complete"

--- a/examples/kubernetes/node-init/node-init.yaml
+++ b/examples/kubernetes/node-init/node-init.yaml
@@ -23,15 +23,16 @@ spec:
           env:
           - name: STARTUP_SCRIPT
             value: |
-              #! /bin/bash
+              #!/bin/bash
 
               set -o errexit
               set -o pipefail
               set -o nounset
 
-              echo "Installing BPF filesystem mount"
+              if [[ ! -f /tmp/cilium-installed-v1 ]]; then
+                echo "Installing BPF filesystem mount"
 
-              cat >/tmp/sys-fs-bpf.mount <<EOF
+                cat >/tmp/sys-fs-bpf.mount <<EOF
               [Unit]
               Description=Mount BPF filesystem (Cilium)
               Documentation=http://docs.cilium.io/
@@ -48,41 +49,44 @@ spec:
               WantedBy=multi-user.target
               EOF
 
-              if [ -d "/etc/systemd/system/" ]; then
-                mv /tmp/sys-fs-bpf.mount /etc/systemd/system/
-                echo "Installed sys-fs-bpf.mount to /etc/systemd/system/"
-              elif [ -d "/lib/systemd/system/" ]; then
-                mv /tmp/sys-fs-bpf.mount /lib/systemd/system/
-                echo "Installed sys-fs-bpf.mount to /lib/systemd/system/"
-              fi
+                if [ -d "/etc/systemd/system/" ]; then
+                  mv /tmp/sys-fs-bpf.mount /etc/systemd/system/
+                  echo "Installed sys-fs-bpf.mount to /etc/systemd/system/"
+                elif [ -d "/lib/systemd/system/" ]; then
+                  mv /tmp/sys-fs-bpf.mount /lib/systemd/system/
+                  echo "Installed sys-fs-bpf.mount to /lib/systemd/system/"
+                fi
 
-              systemctl enable sys-fs-bpf.mount
-              systemctl start sys-fs-bpf.mount
+                systemctl enable sys-fs-bpf.mount
+                systemctl start sys-fs-bpf.mount
 
-              echo "Changing kubelet configuration to --network-plugin=cni --cni-bin-dir=/home/kubernetes/bin"
-              mkdir -p /home/kubernetes/bin
-              sed -i "s:--network-plugin=kubenet:--network-plugin=cni\ --cni-bin-dir=/home/kubernetes/bin:g" /etc/default/kubelet
-              echo "Restarting kubelet..."
-              systemctl restart kubelet
+                echo "Changing kubelet configuration to --network-plugin=cni --cni-bin-dir=/home/kubernetes/bin"
+                mkdir -p /home/kubernetes/bin
+                sed -i "s:--network-plugin=kubenet:--network-plugin=cni\ --cni-bin-dir=/home/kubernetes/bin:g" /etc/default/kubelet
+                echo "Restarting kubelet..."
+                systemctl restart kubelet
 
-              echo "Installing /etc/cni/net.d/04-cilium-cni.conf"
-              mkdir -p /etc/cni/net.d/
-              cat >/etc/cni/net.d/04-cilium-cni.conf <<EOF
+                echo "Installing /etc/cni/net.d/04-cilium-cni.conf"
+                mkdir -p /etc/cni/net.d/
+                cat >/etc/cni/net.d/04-cilium-cni.conf <<EOF
               {
-                  "name": "cilium",
-                  "type": "cilium-cni"
+                "name": "cilium",
+                "type": "cilium-cni"
               }
               EOF
 
-              if ip link show cbr0; then
-                      echo "Detected cbr0 bridge. Deleting interface..."
-                      ip link del cbr0
+                if ip link show cbr0; then
+                  echo "Detected cbr0 bridge. Deleting interface..."
+                  ip link del cbr0
+                fi
+
+                echo "Link information:"
+                ip link
+
+                echo "Routing table:"
+                ip route
+
+                echo "Node initialization complete"
+
+                touch /tmp/cilium-installed-v1
               fi
-
-              echo "Link information:"
-              ip link
-
-              echo "Routing table:"
-              ip route
-
-              echo "Node initialization complete"

--- a/examples/kubernetes/node-init/node-init.yaml
+++ b/examples/kubernetes/node-init/node-init.yaml
@@ -80,6 +80,21 @@ spec:
                   ip link del cbr0
                 fi
 
+                # We still need to delete Cilium in case it started before
+                # we have changed kubelet configuration. This prevents Cilium
+                # from pre-allocating all IP addresses managed by cbr0.
+                echo "Restarting possible cilium instances"
+                if grep -q 'docker' /etc/crictl.yaml; then
+                  # Works for COS, ubuntu
+                  docker rm -f $(docker ps -q --filter=label=k8s-app=cilium) || true
+                else
+                  # COS-beta (with containerd)
+                  # currently cilium doesn't work with cos-beta so once it does
+                  # we need to figure out a why to delete cilium pods
+                  echo "Not implemented for cos-beta, please restart cilium pods"
+                  echo "manually!"
+                fi
+
                 echo "Link information:"
                 ip link
 

--- a/examples/kubernetes/node-init/node-init.yaml
+++ b/examples/kubernetes/node-init/node-init.yaml
@@ -13,6 +13,7 @@ spec:
       tolerations:
       - operator: Exists
       hostPID: true
+      hostNetwork: true
       containers:
         - name: node-init
           image: gcr.io/google-containers/startup-script:v1

--- a/examples/kubernetes/node-init/node-init.yaml
+++ b/examples/kubernetes/node-init/node-init.yaml
@@ -60,12 +60,6 @@ spec:
                 systemctl enable sys-fs-bpf.mount
                 systemctl start sys-fs-bpf.mount
 
-                echo "Changing kubelet configuration to --network-plugin=cni --cni-bin-dir=/home/kubernetes/bin"
-                mkdir -p /home/kubernetes/bin
-                sed -i "s:--network-plugin=kubenet:--network-plugin=cni\ --cni-bin-dir=/home/kubernetes/bin:g" /etc/default/kubelet
-                echo "Restarting kubelet..."
-                systemctl restart kubelet
-
                 echo "Installing /etc/cni/net.d/04-cilium-cni.conf"
                 mkdir -p /etc/cni/net.d/
                 cat >/etc/cni/net.d/04-cilium-cni.conf <<EOF
@@ -74,6 +68,12 @@ spec:
                 "type": "cilium-cni"
               }
               EOF
+
+                echo "Changing kubelet configuration to --network-plugin=cni --cni-bin-dir=/home/kubernetes/bin"
+                mkdir -p /home/kubernetes/bin
+                sed -i "s:--network-plugin=kubenet:--network-plugin=cni\ --cni-bin-dir=/home/kubernetes/bin:g" /etc/default/kubelet
+                echo "Restarting kubelet..."
+                systemctl restart kubelet
 
                 if ip link show cbr0; then
                   echo "Detected cbr0 bridge. Deleting interface..."


### PR DESCRIPTION
Please read per commit basis, I couldn't find a better solution than having 2 node-init scripts.

```release-note
k8s/node-init: add node-init script to automatically restart pods managed by kubenet on GKE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7486)
<!-- Reviewable:end -->
