### PR TITLE
WIP: Test datapathconfig flakiness

### DIFF
--- a/daemon/policy_test.go
+++ b/daemon/policy_test.go
@@ -48,6 +48,13 @@ var (
 	ProdIPv6Addr, _ = addressing.NewCiliumIPv6("cafe:cafe:cafe:cafe:aaaa:aaaa:1111:1112")
 	ProdIPv4Addr, _ = addressing.NewCiliumIPv4("10.11.12.14")
 
+	lblProd = labels.ParseLabel("Prod")
+	lblQA   = labels.ParseLabel("QA")
+	lblFoo  = labels.ParseLabel("foo")
+	lblBar  = labels.ParseLabel("bar")
+	lblJoe  = labels.ParseLabel("user=joe")
+	lblPete = labels.ParseLabel("user=pete")
+
 	testEndpointID = uint16(1)
 
 	regenerationMetadata = &endpoint.ExternalRegenerationMetadata{
@@ -147,13 +154,6 @@ func (ds *DaemonSuite) prepareEndpoint(c *C, identity *identity.Identity, qa boo
 }
 
 func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
-	lblProd := labels.ParseLabel("Prod")
-	lblQA := labels.ParseLabel("QA")
-	lblFoo := labels.ParseLabel("foo")
-	lblBar := labels.ParseLabel("bar")
-	lblJoe := labels.ParseLabel("user=joe")
-	lblPete := labels.ParseLabel("user=pete")
-
 	rules := api.Rules{
 		{
 			EndpointSelector: api.NewESFromLabels(lblBar),
@@ -338,7 +338,6 @@ func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
 }
 
 func (ds *DaemonSuite) TestReplacePolicy(c *C) {
-	lblBar := labels.ParseLabel("bar")
 	lbls := labels.ParseLabelArray("foo", "bar")
 	rules := api.Rules{
 		{
@@ -386,13 +385,6 @@ func (ds *DaemonSuite) TestReplacePolicy(c *C) {
 }
 
 func (ds *DaemonSuite) TestRemovePolicy(c *C) {
-	lblProd := labels.ParseLabel("Prod")
-	lblQA := labels.ParseLabel("QA")
-	lblFoo := labels.ParseLabel("foo")
-	lblBar := labels.ParseLabel("bar")
-	lblJoe := labels.ParseLabel("user=joe")
-	lblPete := labels.ParseLabel("user=pete")
-
 	rules := api.Rules{
 		{
 			EndpointSelector: api.NewESFromLabels(lblBar),

--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -46,7 +46,8 @@ pipeline {
                 TESTDIR="${WORKSPACE}/${PROJ_PATH}/"
             }
             steps {
-               sh "cd ${TESTDIR}; make jenkins-precheck"
+               //sh "cd ${TESTDIR}; make jenkins-precheck"
+	       sh 'echo "SKIPPING"'
             }
             post {
                always {
@@ -82,16 +83,17 @@ pipeline {
                 script {
                     parallel(
                         "Runtime":{
-                            sh 'cd ${TESTDIR}; vagrant provision runtime'
-                            sh 'cd ${TESTDIR}; ginkgo --focus=" Runtime*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
+                            //sh 'cd ${TESTDIR}; vagrant provision runtime'
+                            //sh 'cd ${TESTDIR}; ginkgo --focus=" Runtime*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
+			    sh 'echo "SKIPPING"'
                         },
                         "K8s-1.11":{
                             sh 'cd ${TESTDIR}; K8S_VERSION=1.10 vagrant provision k8s1-1.10; K8S_VERSION=1.10 vagrant provision k8s2-1.10'
-                            sh 'cd ${TESTDIR}; K8S_VERSION=1.10 ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
+                            sh 'cd ${TESTDIR}; K8S_VERSION=1.10 ginkgo --focus=" K8sXXX*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
                         },
                         "K8s-1.14":{
                             sh 'cd ${TESTDIR}; K8S_VERSION=1.14 vagrant provision k8s1-1.14; K8S_VERSION=1.14 vagrant provision k8s2-1.14'
-                            sh 'cd ${TESTDIR}; K8S_VERSION=1.14 ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
+                            sh 'cd ${TESTDIR}; K8S_VERSION=1.14 ginkgo --focus=" K8sXXX*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
                         },
                         failFast: "${FAILFAST}".toBoolean()
                     )

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -2020,11 +2020,12 @@ func (ds *PolicyTestSuite) TestL4WildcardMerge(c *C) {
 	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, true)
 
-	c.Assert(len(filter.Endpoints), Equals, 1)
+	c.Assert(len(filter.Endpoints), Equals, 2)
 	c.Assert(filter.Endpoints[0], Equals, api.WildcardEndpointSelector)
+	c.Assert(filter.Endpoints[1], Equals, api.WildcardEndpointSelector)
 
 	c.Assert(filter.L7Parser, Equals, ParserTypeHTTP)
-	c.Assert(len(filter.L7RulesPerEp), Equals, 1)
+	c.Assert(len(filter.L7RulesPerEp), Equals, 2)
 
 	// Test the reverse order as well; ensure that we check both conditions
 	// for if L4-only policy is in the L4Filter for the same port-protocol tuple,
@@ -2070,10 +2071,10 @@ func (ds *PolicyTestSuite) TestL4WildcardMerge(c *C) {
 	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, true)
 
-	c.Assert(len(filter.Endpoints), Equals, 1)
+	c.Assert(len(filter.Endpoints), Equals, 2)
 
 	c.Assert(filter.L7Parser, Equals, ParserTypeHTTP)
-	c.Assert(len(filter.L7RulesPerEp), Equals, 1)
+	c.Assert(len(filter.L7RulesPerEp), Equals, 2)
 
 	// Second, test the explicit allow at L3.
 	repo = parseAndAddRules(c, api.Rules{&api.Rule{
@@ -2116,7 +2117,9 @@ func (ds *PolicyTestSuite) TestL4WildcardMerge(c *C) {
 	c.Assert(ok, Equals, true)
 	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, true)
-	c.Assert(len(filter.Endpoints), Equals, 2)
+
+	// 3 -> One for each rule, plus one from the l4-only rule (l7 scan).
+	c.Assert(len(filter.Endpoints), Equals, 3)
 	c.Assert(filter.L7Parser, Equals, ParserTypeHTTP)
 	c.Assert(len(filter.L7RulesPerEp), Equals, 2)
 
@@ -2165,7 +2168,8 @@ func (ds *PolicyTestSuite) TestL4WildcardMerge(c *C) {
 	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, true)
 
-	c.Assert(len(filter.Endpoints), Equals, 2)
+	// 3 -> One for each rule, plus one from the l4-only rule (l7 scan).
+	c.Assert(len(filter.Endpoints), Equals, 3)
 
 	c.Assert(filter.L7Parser, Equals, ParserTypeHTTP)
 	c.Assert(len(filter.L7RulesPerEp), Equals, 2)

--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -76,6 +76,9 @@ func (rules ruleSlice) wildcardL3L4Rules(ctx *SearchContext, ingress bool, l4Pol
 					wildcardL3L4Rule(api.ProtoTCP, 0, fromEndpoints, ruleLabels, l4Policy)
 					wildcardL3L4Rule(api.ProtoUDP, 0, fromEndpoints, ruleLabels, l4Policy)
 				} else {
+					if fromEndpoints.SelectsAllEndpoints() {
+						fromEndpoints = append(fromEndpoints, api.WildcardEndpointSelector)
+					}
 					for _, toPort := range rule.ToPorts {
 						// L3/L4-only rule
 						if toPort.Rules.IsEmpty() {
@@ -108,6 +111,9 @@ func (rules ruleSlice) wildcardL3L4Rules(ctx *SearchContext, ingress bool, l4Pol
 					wildcardL3L4Rule(api.ProtoTCP, 0, toEndpoints, ruleLabels, l4Policy)
 					wildcardL3L4Rule(api.ProtoUDP, 0, toEndpoints, ruleLabels, l4Policy)
 				} else {
+					if toEndpoints.SelectsAllEndpoints() {
+						toEndpoints = append(toEndpoints, api.WildcardEndpointSelector)
+					}
 					for _, toPort := range rule.ToPorts {
 						// L3/L4-only rule
 						if toPort.Rules.IsEmpty() {

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -27,37 +27,6 @@ end
 ENV["VAGRANT_DEFAULT_PROVIDER"] = "virtualbox"
 Vagrant.configure("2") do |config|
 
-    config.vm.define "runtime" do |server|
-        server.vm.provider "virtualbox" do |vb|
-            vb.customize ["modifyvm", :id, "--hwvirtex", "on"]
-            vb.cpus = $CPU
-            vb.memory= $MEMORY
-            vb.linked_clone = true
-            vb.default_nic_type = "virtio"
-            # Prevent VirtualBox from interfering with host audio stack
-            vb.customize ["modifyvm", :id, "--audio", "none"]
-        end
-
-        server.vm.box =  "#{$SERVER_BOX}"
-        server.vm.box_version = $SERVER_VERSION
-        server.vm.boot_timeout = 600
-        server.vm.hostname = "runtime"
-
-        # This network is only used by NFS
-        server.vm.network "private_network", type: "dhcp"
-        server.vm.synced_folder "../", "/home/vagrant/go/src/github.com/cilium/cilium",
-            nfs: $NFS
-
-        # Provision section
-        server.vm.provision :shell,
-            :inline => "sed -i 's/^mesg n$/tty -s \\&\\& mesg n/g' /root/.profile"
-        server.vm.provision "file", source: "provision/", destination: "/tmp/"
-        server.vm.provision "shell" do |sh|
-            sh.path = "./provision/runtime_install.sh"
-            sh.env = {}
-        end
-    end
-
     (1..$K8S_NODES).each do |i|
         config.vm.define "k8s#{i}-#{$K8S_VERSION}" do |server|
             server.vm.provider "virtualbox" do |vb|

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -104,7 +104,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 			Expect(status.IntOutput()).Should(Equal(3), "Did not find expected number of entries in BPF tunnel map")
 		}
 
-		It("Check connectivity with VXLAN encapsulation", func() {
+		FIt("K8sXXXCheck connectivity with VXLAN encapsulation", func() {
 			SkipIfFlannel()
 
 			deployCilium("cilium-ds-patch-vxlan.yaml")
@@ -113,7 +113,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 			cleanService()
 		}, 600)
 
-		It("Check connectivity with Geneve encapsulation", func() {
+		FIt("K8sXXXCheck connectivity with Geneve encapsulation", func() {
 			SkipIfFlannel()
 
 			deployCilium("cilium-ds-patch-geneve.yaml")
@@ -124,7 +124,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 	})
 
 	Context("DirectRouting", func() {
-		It("Check connectivity with automatic direct nodes routes", func() {
+		FIt("K8sXXXCheck connectivity with automatic direct nodes routes", func() {
 			SkipIfFlannel()
 
 			deployCilium("cilium-ds-patch-auto-node-routes.yaml")
@@ -134,7 +134,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 	})
 
 	Context("IPv4Only", func() {
-		It("Check connectivity with IPv6 disabled", func() {
+		FIt("K8sXXXCheck connectivity with IPv6 disabled", func() {
 			deployCilium("cilium-ds-patch-ipv4-only.yaml")
 			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
 			cleanService()


### PR DESCRIPTION
Just run the datapathconfig tests against #7476 to attempt to determine flakiness of the tests.

I noticed that there's some discrepancies between the cilium infra provision for most tests, done by `ProvisionInfraPods()` vs. the provisioning done in the "DatapathConfig" and the "Updates" tests. The latter tests have been somewhat flaky recently and I'm wondering if the discrepancies are related to the failures..


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7499)
<!-- Reviewable:end -->
