### PR TITLE
api, labels: pair hash with EndpointSelector, LabelArray

### DIFF
--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -95,8 +95,8 @@ func (h *getPolicyResolve) Handle(params GetPolicyResolveParams) middleware.Resp
 		// the API request, that means that policy enforcement is not enabled
 		// for the endpoints corresponding to said sets of labels; thus, we allow
 		// traffic between these sets of labels, and do not enforce policy between them.
-		fromIngress, fromEgress := d.policy.GetRulesMatching(labels.NewSelectLabelArrayFromModel(params.TraceSelector.From.Labels))
-		toIngress, toEgress := d.policy.GetRulesMatching(labels.NewSelectLabelArrayFromModel(params.TraceSelector.To.Labels))
+		fromIngress, fromEgress := d.policy.GetRulesMatching(labels.NewSelectLabelArrayWithHashFromModel(params.TraceSelector.From.Labels))
+		toIngress, toEgress := d.policy.GetRulesMatching(labels.NewSelectLabelArrayWithHashFromModel(params.TraceSelector.To.Labels))
 		if !fromIngress && !fromEgress && !toIngress && !toEgress {
 			policyEnforcementMsg = "Policy enforcement is disabled because " +
 				"no rules in the policy repository match any endpoint selector " +
@@ -112,9 +112,9 @@ func (h *getPolicyResolve) Handle(params GetPolicyResolveParams) middleware.Resp
 		buffer := new(bytes.Buffer)
 		ctx := params.TraceSelector
 		searchCtx := policy.SearchContext{
-			From:    labels.NewSelectLabelArrayFromModel(ctx.From.Labels),
+			From:    labels.NewSelectLabelArrayWithHashFromModel(ctx.From.Labels),
 			Trace:   policy.TRACE_ENABLED,
-			To:      labels.NewSelectLabelArrayFromModel(ctx.To.Labels),
+			To:      labels.NewSelectLabelArrayWithHashFromModel(ctx.To.Labels),
 			DPorts:  ctx.To.Dports,
 			Logging: logging.NewLogBackend(buffer, "", 0),
 		}
@@ -139,8 +139,8 @@ func (h *getPolicyResolve) Handle(params GetPolicyResolveParams) middleware.Resp
 	ingressSearchCtx := policy.SearchContext{
 		Trace:   policy.TRACE_ENABLED,
 		Logging: logging.NewLogBackend(ingressBuffer, "", 0),
-		From:    labels.NewSelectLabelArrayFromModel(ctx.From.Labels),
-		To:      labels.NewSelectLabelArrayFromModel(ctx.To.Labels),
+		From:    labels.NewSelectLabelArrayWithHashFromModel(ctx.From.Labels),
+		To:      labels.NewSelectLabelArrayWithHashFromModel(ctx.To.Labels),
 		DPorts:  ctx.To.Dports,
 	}
 	if ctx.Verbose {

--- a/pkg/envoy/server_test.go
+++ b/pkg/envoy/server_test.go
@@ -113,23 +113,22 @@ var L7Rules1 = api.L7Rules{HTTP: []api.PortRuleHTTP{*PortRuleHTTP1, *PortRuleHTT
 var L7Rules2 = api.L7Rules{HTTP: []api.PortRuleHTTP{*PortRuleHTTP1}}
 
 var IdentityCache = cache.IdentityCache{
-	1001: labels.LabelArray{
-		labels.NewLabel("app", "etcd", labels.LabelSourceK8s),
-		labels.NewLabel("version", "v1", labels.LabelSourceK8s),
+	1001: &labels.LabelArrayWithHash{
+		LabelArray: labels.LabelArray{labels.NewLabel("app", "etcd", labels.LabelSourceK8s),
+			labels.NewLabel("version", "v1", labels.LabelSourceK8s)},
 	},
-	1002: labels.LabelArray{
-		labels.NewLabel("app", "etcd", labels.LabelSourceK8s),
-		labels.NewLabel("version", "v2", labels.LabelSourceK8s),
+	1002: &labels.LabelArrayWithHash{
+		LabelArray: labels.LabelArray{labels.NewLabel("app", "etcd", labels.LabelSourceK8s),
+			labels.NewLabel("version", "v2", labels.LabelSourceK8s)},
 	},
-	1003: labels.LabelArray{
-		labels.NewLabel("app", "cassandra", labels.LabelSourceK8s),
-		labels.NewLabel("version", "v1", labels.LabelSourceK8s),
+	1003: &labels.LabelArrayWithHash{
+		LabelArray: labels.LabelArray{labels.NewLabel("app", "cassandra", labels.LabelSourceK8s), labels.NewLabel("version", "v1", labels.LabelSourceK8s)},
 	},
 }
 
 var DeniedIdentitiesNone = make(cache.IdentityCache)
 
-var DeniedIdentities1001 = cache.IdentityCache{1001: labels.LabelArray{}}
+var DeniedIdentities1001 = cache.IdentityCache{1001: &labels.LabelArrayWithHash{}}
 
 var ExpectedPortNetworkPolicyRule1 = &cilium.PortNetworkPolicyRule{
 	RemotePolicies: []uint64{1001, 1002},

--- a/pkg/identity/cache/cache.go
+++ b/pkg/identity/cache/cache.go
@@ -33,7 +33,7 @@ var (
 )
 
 // IdentityCache is a cache of identity to labels mapping
-type IdentityCache map[identity.NumericIdentity]labels.LabelArray
+type IdentityCache map[identity.NumericIdentity]*labels.LabelArrayWithHash
 
 // IdentitiesModel is a wrapper so that we can implement the sort.Interface
 // to sort the slice by ID
@@ -54,7 +54,7 @@ func GetIdentityCache() IdentityCache {
 		IdentityAllocator.ForeachCache(func(id idpool.ID, val allocator.AllocatorKey) {
 			if val != nil {
 				if gi, ok := val.(globalIdentity); ok {
-					cache[identity.NumericIdentity(id)] = gi.LabelArray()
+					cache[identity.NumericIdentity(id)] = gi.LabelArrayWithHash()
 				} else {
 					log.Warningf("Ignoring unknown identity type '%s': %+v",
 						reflect.TypeOf(val), val)
@@ -64,12 +64,12 @@ func GetIdentityCache() IdentityCache {
 	}
 
 	for key, identity := range identity.ReservedIdentityCache {
-		cache[key] = identity.Labels.LabelArray()
+		cache[key] = identity.Labels.LabelArrayWithHash()
 	}
 
 	if localIdentities != nil {
 		for _, identity := range localIdentities.GetIdentities() {
-			cache[identity.ID] = identity.Labels.LabelArray()
+			cache[identity.ID] = identity.Labels.LabelArrayWithHash()
 		}
 	}
 

--- a/pkg/identity/cache/local.go
+++ b/pkg/identity/cache/local.go
@@ -94,7 +94,7 @@ func (l *localIdentityCache) lookupOrCreate(lbls labels.Labels) (*identity.Ident
 	id := &identity.Identity{
 		ID:             numericIdentity,
 		Labels:         lbls,
-		LabelArray:     lbls.LabelArray(),
+		LabelArray:     lbls.LabelArrayWithHash(),
 		ReferenceCount: 1,
 	}
 

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -34,7 +34,7 @@ type Identity struct {
 
 	// LabelArray contains the same labels as Labels in a form of a list, used
 	// for faster lookup.
-	LabelArray labels.LabelArray `json:"-"`
+	LabelArray *labels.LabelArrayWithHash `json:"-"`
 
 	// CIDRLabel is the primary identity label when the identity represents
 	// a CIDR. The Labels field will consist of all matching prefixes, e.g.
@@ -83,7 +83,7 @@ func NewIdentityFromModel(base *models.Identity) *Identity {
 	}
 
 	if id.Labels != nil {
-		id.LabelArray = id.Labels.LabelArray()
+		id.LabelArray = id.Labels.LabelArrayWithHash()
 	}
 
 	return id
@@ -142,12 +142,16 @@ func (id *Identity) IsWellKnown() bool {
 
 // NewIdentity creates a new identity
 func NewIdentity(id NumericIdentity, lbls labels.Labels) *Identity {
-	var lblArray labels.LabelArray
+	var lblArray *labels.LabelArrayWithHash
 
 	if lbls != nil {
-		lblArray = lbls.LabelArray()
+		lblArray = lbls.LabelArrayWithHash()
 	}
-	return &Identity{ID: id, Labels: lbls, LabelArray: lblArray}
+	return &Identity{ID: id,
+		Labels:       lbls,
+		LabelArray:   lblArray,
+		LabelsSHA256: lbls.SHA256Sum(),
+	}
 }
 
 // IsHost determines whether the IP in the pair represents a host (true) or a

--- a/pkg/kvstore/store/store.go
+++ b/pkg/kvstore/store/store.go
@@ -459,8 +459,9 @@ func (s *SharedStore) watcher(listDone chan bool) {
 
 			case kvstore.EventTypeDelete:
 				if localKey := s.lookupLocalKey(keyName); localKey != nil {
-					logger.Warning("Received delete event for local key. Re-creating the key in the kvstore")
-
+					if !option.Config.DryMode {
+						logger.Warning("Received delete event for local key. Re-creating the key in the kvstore")
+					}
 					s.syncLocalKey(localKey)
 				} else {
 					s.deleteKey(keyName)

--- a/pkg/labels/array.go
+++ b/pkg/labels/array.go
@@ -14,6 +14,25 @@
 
 package labels
 
+import (
+	k8sLbls "k8s.io/apimachinery/pkg/labels"
+)
+
+type LabelArrayWithHash struct {
+	LabelArray
+	hash string
+}
+
+type LabelsWithHash interface {
+	k8sLbls.Labels
+
+	Hash() string
+}
+
+func (ls LabelArrayWithHash) Hash() string {
+	return ls.hash
+}
+
 // LabelArray is an array of labels forming a set
 type LabelArray []Label
 
@@ -26,6 +45,26 @@ func ParseLabelArray(labels ...string) LabelArray {
 	return array
 }
 
+// ParseLabelArrayWithHash parses a list of labels and returns a LabelArray
+func ParseLabelArrayWithHash(labels ...string) *LabelArrayWithHash {
+	array := make([]Label, len(labels))
+	for i := range labels {
+		array[i] = ParseLabel(labels[i])
+	}
+
+	arrayAsLabels := Labels{}
+
+	// TODO ianvernon fix this
+	for _, lbl := range array {
+		arrayAsLabels[lbl.Key] = lbl
+	}
+
+	return &LabelArrayWithHash{
+		LabelArray: array,
+		hash:       arrayAsLabels.SHA256Sum(),
+	}
+}
+
 // ParseSelectLabelArray parses a list of select labels and returns a LabelArray
 func ParseSelectLabelArray(labels ...string) LabelArray {
 	array := make([]Label, len(labels))
@@ -33,6 +72,26 @@ func ParseSelectLabelArray(labels ...string) LabelArray {
 		array[i] = ParseSelectLabel(labels[i])
 	}
 	return array
+}
+
+// ParseSelectLabelArray parses a list of select labels and returns a LabelArray
+func ParseSelectLabelArrayWithHash(labels ...string) *LabelArrayWithHash {
+	array := make([]Label, len(labels))
+	for i := range labels {
+		array[i] = ParseSelectLabel(labels[i])
+	}
+
+	arrayAsLabels := Labels{}
+
+	// TODO ianvernon fix this
+	for _, lbl := range array {
+		arrayAsLabels[lbl.Key] = lbl
+	}
+
+	return &LabelArrayWithHash{
+		LabelArray: array,
+		hash:       arrayAsLabels.SHA256Sum(),
+	}
 }
 
 // ParseLabelArrayFromArray converts an array of strings as labels and returns a LabelArray

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -395,6 +395,17 @@ func NewSelectLabelArrayFromModel(base []string) LabelArray {
 	return lbls
 }
 
+// NewSelectLabelArrayWithHashFromModel parses a slice of strings and converts them
+// into an array of selecting labels.
+func NewSelectLabelArrayWithHashFromModel(base []string) *LabelArrayWithHash {
+	lbls := make(LabelArray, 0, len(base))
+	for i := range base {
+		lbls = append(lbls, ParseSelectLabel(base[i]))
+	}
+
+	return &LabelArrayWithHash{LabelArray: lbls}
+}
+
 // GetModel returns model with all the values of the labels.
 func (l Labels) GetModel() []string {
 	res := make([]string, 0, len(l))
@@ -461,6 +472,16 @@ func (l Labels) LabelArray() LabelArray {
 		labels = append(labels, v)
 	}
 	return labels
+}
+
+// LabelArray returns the labels as label array with hash
+func (l Labels) LabelArrayWithHash() *LabelArrayWithHash {
+	labels := []Label{}
+	for _, v := range l {
+		labels = append(labels, v)
+	}
+
+	return &LabelArrayWithHash{LabelArray: labels, hash: l.SHA256Sum()}
 }
 
 // FindReserved locates all labels with reserved source in the labels and

--- a/pkg/policy/api/cidr_test.go
+++ b/pkg/policy/api/cidr_test.go
@@ -38,7 +38,7 @@ func (s *PolicyAPITestSuite) TestCIDRMatchesAll(c *C) {
 }
 
 func (s *PolicyAPITestSuite) TestGetAsEndpointSelectors(c *C) {
-	world := labels.ParseLabelArray("reserved:world")
+	world := labels.ParseLabelArrayWithHash("reserved:world")
 
 	labelWorld := labels.ParseSelectLabel("reserved:world")
 	esWorld := NewESFromLabels(labelWorld)

--- a/pkg/policy/api/entity.go
+++ b/pkg/policy/api/entity.go
@@ -82,7 +82,7 @@ var (
 type EntitySlice []Entity
 
 // Matches returns true if the entity matches the labels
-func (e Entity) Matches(ctx labels.LabelArray) bool {
+func (e Entity) Matches(ctx *labels.LabelArrayWithHash) bool {
 	if selectors, ok := EntitySelectorMapping[e]; ok {
 		return selectors.Matches(ctx)
 	}
@@ -91,7 +91,7 @@ func (e Entity) Matches(ctx labels.LabelArray) bool {
 }
 
 // Matches returns true if any of the entities in the slice match the labels
-func (s EntitySlice) Matches(ctx labels.LabelArray) bool {
+func (s EntitySlice) Matches(ctx *labels.LabelArrayWithHash) bool {
 	for _, entity := range s {
 		if entity.Matches(ctx) {
 			return true

--- a/pkg/policy/api/entity_test.go
+++ b/pkg/policy/api/entity_test.go
@@ -28,38 +28,38 @@ import (
 func (s *PolicyAPITestSuite) TestEntityMatches(c *C) {
 	InitEntities("cluster1")
 
-	c.Assert(EntityHost.Matches(labels.ParseLabelArray("reserved:host")), Equals, true)
-	c.Assert(EntityHost.Matches(labels.ParseLabelArray("reserved:host", "id:foo")), Equals, true)
-	c.Assert(EntityHost.Matches(labels.ParseLabelArray("reserved:world")), Equals, false)
-	c.Assert(EntityHost.Matches(labels.ParseLabelArray("reserved:none")), Equals, false)
-	c.Assert(EntityHost.Matches(labels.ParseLabelArray("id=foo")), Equals, false)
+	c.Assert(EntityHost.Matches(labels.ParseLabelArrayWithHash("reserved:host")), Equals, true)
+	c.Assert(EntityHost.Matches(labels.ParseLabelArrayWithHash("reserved:host", "id:foo")), Equals, true)
+	c.Assert(EntityHost.Matches(labels.ParseLabelArrayWithHash("reserved:world")), Equals, false)
+	c.Assert(EntityHost.Matches(labels.ParseLabelArrayWithHash("reserved:none")), Equals, false)
+	c.Assert(EntityHost.Matches(labels.ParseLabelArrayWithHash("id=foo")), Equals, false)
 
-	c.Assert(EntityAll.Matches(labels.ParseLabelArray("reserved:host")), Equals, true)
-	c.Assert(EntityAll.Matches(labels.ParseLabelArray("reserved:world")), Equals, true)
-	c.Assert(EntityAll.Matches(labels.ParseLabelArray("reserved:none")), Equals, true) // in a white-list model, All trumps None
-	c.Assert(EntityAll.Matches(labels.ParseLabelArray("id=foo")), Equals, true)
+	c.Assert(EntityAll.Matches(labels.ParseLabelArrayWithHash("reserved:host")), Equals, true)
+	c.Assert(EntityAll.Matches(labels.ParseLabelArrayWithHash("reserved:world")), Equals, true)
+	c.Assert(EntityAll.Matches(labels.ParseLabelArrayWithHash("reserved:none")), Equals, true) // in a white-list model, All trumps None
+	c.Assert(EntityAll.Matches(labels.ParseLabelArrayWithHash("id=foo")), Equals, true)
 
-	c.Assert(EntityCluster.Matches(labels.ParseLabelArray("reserved:host")), Equals, true)
-	c.Assert(EntityCluster.Matches(labels.ParseLabelArray("reserved:init")), Equals, true)
-	c.Assert(EntityCluster.Matches(labels.ParseLabelArray("reserved:world")), Equals, false)
-	c.Assert(EntityCluster.Matches(labels.ParseLabelArray("reserved:none")), Equals, false)
+	c.Assert(EntityCluster.Matches(labels.ParseLabelArrayWithHash("reserved:host")), Equals, true)
+	c.Assert(EntityCluster.Matches(labels.ParseLabelArrayWithHash("reserved:init")), Equals, true)
+	c.Assert(EntityCluster.Matches(labels.ParseLabelArrayWithHash("reserved:world")), Equals, false)
+	c.Assert(EntityCluster.Matches(labels.ParseLabelArrayWithHash("reserved:none")), Equals, false)
 
 	clusterLabel := fmt.Sprintf("k8s:%s=%s", k8sapi.PolicyLabelCluster, "cluster1")
-	c.Assert(EntityCluster.Matches(labels.ParseLabelArray(clusterLabel, "id=foo")), Equals, true)
-	c.Assert(EntityCluster.Matches(labels.ParseLabelArray(clusterLabel, "id=foo", "id=bar")), Equals, true)
-	c.Assert(EntityCluster.Matches(labels.ParseLabelArray("id=foo")), Equals, false)
+	c.Assert(EntityCluster.Matches(labels.ParseLabelArrayWithHash(clusterLabel, "id=foo")), Equals, true)
+	c.Assert(EntityCluster.Matches(labels.ParseLabelArrayWithHash(clusterLabel, "id=foo", "id=bar")), Equals, true)
+	c.Assert(EntityCluster.Matches(labels.ParseLabelArrayWithHash("id=foo")), Equals, false)
 
-	c.Assert(EntityWorld.Matches(labels.ParseLabelArray("reserved:host")), Equals, false)
-	c.Assert(EntityWorld.Matches(labels.ParseLabelArray("reserved:world")), Equals, true)
-	c.Assert(EntityWorld.Matches(labels.ParseLabelArray("reserved:none")), Equals, false)
-	c.Assert(EntityWorld.Matches(labels.ParseLabelArray("id=foo")), Equals, false)
-	c.Assert(EntityWorld.Matches(labels.ParseLabelArray("id=foo", "id=bar")), Equals, false)
+	c.Assert(EntityWorld.Matches(labels.ParseLabelArrayWithHash("reserved:host")), Equals, false)
+	c.Assert(EntityWorld.Matches(labels.ParseLabelArrayWithHash("reserved:world")), Equals, true)
+	c.Assert(EntityWorld.Matches(labels.ParseLabelArrayWithHash("reserved:none")), Equals, false)
+	c.Assert(EntityWorld.Matches(labels.ParseLabelArrayWithHash("id=foo")), Equals, false)
+	c.Assert(EntityWorld.Matches(labels.ParseLabelArrayWithHash("id=foo", "id=bar")), Equals, false)
 
-	c.Assert(EntityNone.Matches(labels.ParseLabelArray("reserved:host")), Equals, false)
-	c.Assert(EntityNone.Matches(labels.ParseLabelArray("reserved:world")), Equals, false)
-	c.Assert(EntityNone.Matches(labels.ParseLabelArray("reserved:init")), Equals, false)
-	c.Assert(EntityNone.Matches(labels.ParseLabelArray("id=foo")), Equals, false)
-	c.Assert(EntityNone.Matches(labels.ParseLabelArray(clusterLabel, "id=foo", "id=bar")), Equals, false)
+	c.Assert(EntityNone.Matches(labels.ParseLabelArrayWithHash("reserved:host")), Equals, false)
+	c.Assert(EntityNone.Matches(labels.ParseLabelArrayWithHash("reserved:world")), Equals, false)
+	c.Assert(EntityNone.Matches(labels.ParseLabelArrayWithHash("reserved:init")), Equals, false)
+	c.Assert(EntityNone.Matches(labels.ParseLabelArrayWithHash("id=foo")), Equals, false)
+	c.Assert(EntityNone.Matches(labels.ParseLabelArrayWithHash(clusterLabel, "id=foo", "id=bar")), Equals, false)
 
 }
 
@@ -67,15 +67,15 @@ func (s *PolicyAPITestSuite) TestEntitySliceMatches(c *C) {
 	InitEntities("cluster1")
 
 	slice := EntitySlice{EntityHost, EntityWorld}
-	c.Assert(slice.Matches(labels.ParseLabelArray("reserved:host")), Equals, true)
-	c.Assert(slice.Matches(labels.ParseLabelArray("reserved:world")), Equals, true)
-	c.Assert(slice.Matches(labels.ParseLabelArray("reserved:none")), Equals, false)
-	c.Assert(slice.Matches(labels.ParseLabelArray("id=foo")), Equals, false)
+	c.Assert(slice.Matches(labels.ParseLabelArrayWithHash("reserved:host")), Equals, true)
+	c.Assert(slice.Matches(labels.ParseLabelArrayWithHash("reserved:world")), Equals, true)
+	c.Assert(slice.Matches(labels.ParseLabelArrayWithHash("reserved:none")), Equals, false)
+	c.Assert(slice.Matches(labels.ParseLabelArrayWithHash("id=foo")), Equals, false)
 
 	// result must be identical if matched via endpoint selector
 	selector := slice.GetAsEndpointSelectors()
-	c.Assert(selector.Matches(labels.ParseLabelArray("reserved:host")), Equals, true)
-	c.Assert(selector.Matches(labels.ParseLabelArray("reserved:world")), Equals, true)
-	c.Assert(selector.Matches(labels.ParseLabelArray("reserved:none")), Equals, false)
-	c.Assert(selector.Matches(labels.ParseLabelArray("id=foo")), Equals, false)
+	c.Assert(selector.Matches(labels.ParseLabelArrayWithHash("reserved:host")), Equals, true)
+	c.Assert(selector.Matches(labels.ParseLabelArrayWithHash("reserved:world")), Equals, true)
+	c.Assert(selector.Matches(labels.ParseLabelArrayWithHash("reserved:none")), Equals, false)
+	c.Assert(selector.Matches(labels.ParseLabelArrayWithHash("id=foo")), Equals, false)
 }

--- a/pkg/policy/api/selector_test.go
+++ b/pkg/policy/api/selector_test.go
@@ -77,13 +77,13 @@ func (s *PolicyAPITestSuite) TestLabelSelectorToRequirements(c *C) {
 	c.Assert(labelSelectorToRequirements(labelSelector), checker.DeepEquals, &expRequirements)
 }
 
-func benchmarkMatchesSetup(match string, count int) (EndpointSelector, labels.LabelArray) {
+func benchmarkMatchesSetup(match string, count int) (EndpointSelector, *labels.LabelArrayWithHash) {
 	stringLabels := []string{}
 	for i := 0; i < count; i++ {
 		stringLabels = append(stringLabels, fmt.Sprintf("%d", i))
 	}
 	lbls := labels.NewLabelsFromModel(stringLabels)
-	return NewESFromLabels(lbls.ToSlice()...), labels.ParseLabelArray(match)
+	return NewESFromLabels(lbls.ToSlice()...), labels.ParseLabelArrayWithHash(match)
 }
 
 func BenchmarkMatchesValid1000(b *testing.B) {

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -184,7 +184,7 @@ func (l7 L7DataMap) GetRelevantRules(identity *identity.Identity) api.L7Rules {
 
 	if identity != nil {
 		for selector, endpointRules := range l7 {
-			if selector.Matches(identity.Labels.LabelArray()) {
+			if selector.Matches(identity.Labels.LabelArrayWithHash()) {
 				rules.HTTP = append(rules.HTTP, endpointRules.HTTP...)
 				rules.Kafka = append(rules.Kafka, endpointRules.Kafka...)
 				rules.DNS = append(rules.DNS, endpointRules.DNS...)
@@ -330,10 +330,10 @@ func (l4 L4Filter) String() string {
 	return string(b)
 }
 
-func (l4 L4Filter) matchesLabels(labels labels.LabelArray) bool {
+func (l4 L4Filter) matchesLabels(labels *labels.LabelArrayWithHash) bool {
 	if l4.AllowsAllAtL3() {
 		return true
-	} else if len(labels) == 0 {
+	} else if len(labels.LabelArray) == 0 {
 		return false
 	}
 
@@ -372,7 +372,7 @@ func (l4 L4PolicyMap) HasRedirect() bool {
 // * If a port is present in the `L4PolicyMap`, but it applies ToEndpoints or
 // FromEndpoints constraints that require labels not present in `labels`.
 // Otherwise, returns api.Allowed.
-func (l4 L4PolicyMap) containsAllL3L4(labels labels.LabelArray, ports []*models.Port) api.Decision {
+func (l4 L4PolicyMap) containsAllL3L4(labels *labels.LabelArrayWithHash, ports []*models.Port) api.Decision {
 	if len(l4) == 0 {
 		return api.Allowed
 	}

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -31,7 +31,7 @@ import (
 var (
 	barSelector  = api.NewESFromLabels(labels.ParseSelectLabel("bar"))
 	hostSelector = api.ReservedEndpointSelectors[labels.IDNameHost]
-	toFoo        = &SearchContext{To: labels.ParseSelectLabelArray("foo")}
+	toFoo        = &SearchContext{To: labels.ParseSelectLabelArrayWithHash("foo")}
 )
 
 // Tests in this file:

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -65,8 +65,8 @@ type SearchContext struct {
 	Trace   Tracing
 	Depth   int
 	Logging *logging.LogBackend
-	From    labels.LabelArray
-	To      labels.LabelArray
+	From    *labels.LabelArrayWithHash
+	To      *labels.LabelArrayWithHash
 	DPorts  []*models.Port
 	// rulesSelect specifies whether or not to check whether a rule which is
 	// being analyzed using this SearchContext matches either From or To.
@@ -85,10 +85,10 @@ func (s *SearchContext) String() string {
 	from := []string{}
 	to := []string{}
 	dports := []string{}
-	for _, fromLabel := range s.From {
+	for _, fromLabel := range s.From.LabelArray {
 		from = append(from, fromLabel.String())
 	}
-	for _, toLabel := range s.To {
+	for _, toLabel := range s.To.LabelArray {
 		to = append(to, toLabel.String())
 	}
 	for _, dport := range s.DPorts {

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -530,7 +530,7 @@ func (p *Repository) GetJSON() string {
 // rule with labels matching the labels in the provided LabelArray.
 //
 // Must be called with p.Mutex held
-func (p *Repository) GetRulesMatching(labels labels.LabelArray) (ingressMatch bool, egressMatch bool) {
+func (p *Repository) GetRulesMatching(labels *labels.LabelArrayWithHash) (ingressMatch bool, egressMatch bool) {
 	ingressMatch = false
 	egressMatch = false
 	for _, r := range p.rules {
@@ -767,6 +767,9 @@ func (p *Repository) ResolvePolicy(id uint16, securityIdentity *identity.Identit
 func (p *Repository) computePolicyEnforcementAndRules(id uint16, securityIdentity *identity.Identity) (ingress bool, egress bool, matchingRules ruleSlice) {
 
 	lbls := securityIdentity.LabelArray
+	if lbls == nil {
+		return true, true, ruleSlice{}
+	}
 	// Check if policy enforcement should be enabled at the daemon level.
 	switch GetPolicyEnabled() {
 	case option.AlwaysEnforce:

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -496,8 +496,8 @@ func (ds *PolicyTestSuite) TestCanReachIngress(c *C) {
 	repo := NewPolicyRepository()
 
 	fooToBar := &SearchContext{
-		From: labels.ParseSelectLabelArray("foo"),
-		To:   labels.ParseSelectLabelArray("bar"),
+		From: labels.ParseSelectLabelArrayWithHash("foo"),
+		To:   labels.ParseSelectLabelArrayWithHash("bar"),
 	}
 
 	repo.Mutex.RLock()
@@ -557,32 +557,32 @@ func (ds *PolicyTestSuite) TestCanReachIngress(c *C) {
 
 	// foo=>bar2 is OK
 	c.Assert(repo.AllowsIngressRLocked(&SearchContext{
-		From: labels.ParseSelectLabelArray("foo"),
-		To:   labels.ParseSelectLabelArray("bar2"),
+		From: labels.ParseSelectLabelArrayWithHash("foo"),
+		To:   labels.ParseSelectLabelArrayWithHash("bar2"),
 	}), Equals, api.Allowed)
 
 	// foo=>bar inside groupA is OK
 	c.Assert(repo.AllowsIngressRLocked(&SearchContext{
-		From: labels.ParseSelectLabelArray("foo", "groupA"),
-		To:   labels.ParseSelectLabelArray("bar", "groupA"),
+		From: labels.ParseSelectLabelArrayWithHash("foo", "groupA"),
+		To:   labels.ParseSelectLabelArrayWithHash("bar", "groupA"),
 	}), Equals, api.Allowed)
 
 	// groupB can't talk to groupA => Denied
 	c.Assert(repo.AllowsIngressRLocked(&SearchContext{
-		From: labels.ParseSelectLabelArray("foo", "groupB"),
-		To:   labels.ParseSelectLabelArray("bar", "groupA"),
+		From: labels.ParseSelectLabelArrayWithHash("foo", "groupB"),
+		To:   labels.ParseSelectLabelArrayWithHash("bar", "groupA"),
 	}), Equals, api.Denied)
 
 	// no restriction on groupB, unused label => OK
 	c.Assert(repo.AllowsIngressRLocked(&SearchContext{
-		From: labels.ParseSelectLabelArray("foo", "groupB"),
-		To:   labels.ParseSelectLabelArray("bar", "groupB"),
+		From: labels.ParseSelectLabelArrayWithHash("foo", "groupB"),
+		To:   labels.ParseSelectLabelArrayWithHash("bar", "groupB"),
 	}), Equals, api.Allowed)
 
 	// foo=>bar3, no rule => Denied
 	c.Assert(repo.AllowsIngressRLocked(&SearchContext{
-		From: labels.ParseSelectLabelArray("foo"),
-		To:   labels.ParseSelectLabelArray("bar3"),
+		From: labels.ParseSelectLabelArrayWithHash("foo"),
+		To:   labels.ParseSelectLabelArrayWithHash("bar3"),
 	}), Equals, api.Denied)
 }
 
@@ -590,8 +590,8 @@ func (ds *PolicyTestSuite) TestCanReachEgress(c *C) {
 	repo := NewPolicyRepository()
 
 	fooToBar := &SearchContext{
-		From: labels.ParseSelectLabelArray("foo"),
-		To:   labels.ParseSelectLabelArray("bar"),
+		From: labels.ParseSelectLabelArrayWithHash("foo"),
+		To:   labels.ParseSelectLabelArrayWithHash("bar"),
 	}
 
 	repo.Mutex.RLock()
@@ -650,21 +650,21 @@ func (ds *PolicyTestSuite) TestCanReachEgress(c *C) {
 
 	// foo=>bar2 is OK
 	c.Assert(repo.AllowsEgressRLocked(&SearchContext{
-		From: labels.ParseSelectLabelArray("foo"),
-		To:   labels.ParseSelectLabelArray("bar2"),
+		From: labels.ParseSelectLabelArrayWithHash("foo"),
+		To:   labels.ParseSelectLabelArrayWithHash("bar2"),
 	}), Equals, api.Allowed)
 
 	// foo=>bar inside groupA is OK
 	c.Assert(repo.AllowsEgressRLocked(&SearchContext{
-		From: labels.ParseSelectLabelArray("foo", "groupA"),
-		To:   labels.ParseSelectLabelArray("bar", "groupA"),
+		From: labels.ParseSelectLabelArrayWithHash("foo", "groupA"),
+		To:   labels.ParseSelectLabelArrayWithHash("bar", "groupA"),
 	}), Equals, api.Allowed)
 
 	buffer := new(bytes.Buffer)
 	// groupB can't talk to groupA => Denied
 	ctx := &SearchContext{
-		To:      labels.ParseSelectLabelArray("foo", "groupB"),
-		From:    labels.ParseSelectLabelArray("bar", "groupA"),
+		To:      labels.ParseSelectLabelArrayWithHash("foo", "groupB"),
+		From:    labels.ParseSelectLabelArrayWithHash("bar", "groupA"),
 		Logging: logging.NewLogBackend(buffer, "", 0),
 		Trace:   TRACE_VERBOSE,
 	}
@@ -673,14 +673,14 @@ func (ds *PolicyTestSuite) TestCanReachEgress(c *C) {
 
 	// no restriction on groupB, unused label => OK
 	c.Assert(repo.AllowsEgressRLocked(&SearchContext{
-		From: labels.ParseSelectLabelArray("foo", "groupB"),
-		To:   labels.ParseSelectLabelArray("bar", "groupB"),
+		From: labels.ParseSelectLabelArrayWithHash("foo", "groupB"),
+		To:   labels.ParseSelectLabelArrayWithHash("bar", "groupB"),
 	}), Equals, api.Allowed)
 
 	// foo=>bar3, no rule => Denied
 	c.Assert(repo.AllowsEgressRLocked(&SearchContext{
-		From: labels.ParseSelectLabelArray("foo"),
-		To:   labels.ParseSelectLabelArray("bar3"),
+		From: labels.ParseSelectLabelArrayWithHash("foo"),
+		To:   labels.ParseSelectLabelArrayWithHash("bar3"),
 	}), Equals, api.Denied)
 }
 
@@ -776,7 +776,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngress(c *C) {
 	c.Assert(err, IsNil)
 
 	ctx := &SearchContext{
-		To: labels.ParseSelectLabelArray("id=foo"),
+		To: labels.ParseSelectLabelArrayWithHash("id=foo"),
 	}
 
 	repo.Mutex.RLock()
@@ -936,7 +936,7 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesIngress(c *C) {
 	c.Assert(err, IsNil)
 
 	ctx := &SearchContext{
-		To: labels.ParseSelectLabelArray("id=foo"),
+		To: labels.ParseSelectLabelArrayWithHash("id=foo"),
 	}
 
 	repo.Mutex.RLock()
@@ -1014,7 +1014,7 @@ func (ds *PolicyTestSuite) TestL3DependentL4IngressFromRequires(c *C) {
 	c.Assert(err, IsNil)
 
 	ctx := &SearchContext{
-		To: labels.ParseSelectLabelArray("id=foo"),
+		To: labels.ParseSelectLabelArrayWithHash("id=foo"),
 	}
 
 	repo.Mutex.RLock()
@@ -1077,7 +1077,7 @@ func (ds *PolicyTestSuite) TestL3DependentL4EgressFromRequires(c *C) {
 	c.Assert(err, IsNil)
 
 	ctx := &SearchContext{
-		From: labels.ParseSelectLabelArray("id=foo"),
+		From: labels.ParseSelectLabelArrayWithHash("id=foo"),
 	}
 
 	repo.Mutex.RLock()
@@ -1179,7 +1179,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgress(c *C) {
 	c.Assert(err, IsNil)
 
 	ctx := &SearchContext{
-		From: labels.ParseSelectLabelArray("id=foo"),
+		From: labels.ParseSelectLabelArrayWithHash("id=foo"),
 	}
 
 	repo.Mutex.RLock()
@@ -1320,7 +1320,7 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesEgress(c *C) {
 	c.Assert(err, IsNil)
 
 	ctx := &SearchContext{
-		From: labels.ParseSelectLabelArray("id=foo"),
+		From: labels.ParseSelectLabelArrayWithHash("id=foo"),
 	}
 
 	repo.Mutex.RLock()
@@ -1437,7 +1437,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngressFromEntities(c *C) {
 	c.Assert(err, IsNil)
 
 	ctx := &SearchContext{
-		To: labels.ParseSelectLabelArray("id=foo"),
+		To: labels.ParseSelectLabelArrayWithHash("id=foo"),
 	}
 
 	repo.Mutex.RLock()
@@ -1559,7 +1559,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgressToEntities(c *C) {
 	c.Assert(err, IsNil)
 
 	ctx := &SearchContext{
-		From: labels.ParseSelectLabelArray("id=foo"),
+		From: labels.ParseSelectLabelArrayWithHash("id=foo"),
 	}
 
 	repo.Mutex.RLock()
@@ -1615,17 +1615,17 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgressToEntities(c *C) {
 func (ds *PolicyTestSuite) TestMinikubeGettingStarted(c *C) {
 	repo := NewPolicyRepository()
 
-	app2Selector := labels.ParseSelectLabelArray("id=app2")
+	app2Selector := labels.ParseSelectLabelArrayWithHash("id=app2")
 
 	fromApp2 := &SearchContext{
 		From:  app2Selector,
-		To:    labels.ParseSelectLabelArray("id=app1"),
+		To:    labels.ParseSelectLabelArrayWithHash("id=app1"),
 		Trace: TRACE_VERBOSE,
 	}
 
 	fromApp3 := &SearchContext{
-		From: labels.ParseSelectLabelArray("id=app3"),
-		To:   labels.ParseSelectLabelArray("id=app1"),
+		From: labels.ParseSelectLabelArrayWithHash("id=app3"),
+		To:   labels.ParseSelectLabelArrayWithHash("id=app1"),
 	}
 
 	repo.Mutex.RLock()
@@ -1760,8 +1760,8 @@ func buildSearchCtx(from, to string, port uint16) *SearchContext {
 		ports = []*models.Port{{Port: port}}
 	}
 	return &SearchContext{
-		From:   labels.ParseSelectLabelArray(from),
-		To:     labels.ParseSelectLabelArray(to),
+		From:   labels.ParseSelectLabelArrayWithHash(from),
+		To:     labels.ParseSelectLabelArrayWithHash(to),
 		DPorts: ports,
 		Trace:  TRACE_ENABLED,
 	}

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -35,14 +35,14 @@ var (
 	lbls     = labels.Labels{
 		"foo": fooLabel,
 	}
-	lblsArray   = lbls.LabelArray()
-	repo        = &Repository{}
-	fooIdentity = &identity.Identity{
+	lblsArrayWithHash = lbls.LabelArrayWithHash()
+	repo              = &Repository{}
+	fooIdentity       = &identity.Identity{
 		ID:         303,
 		Labels:     lbls,
-		LabelArray: lbls.LabelArray(),
+		LabelArray: lblsArrayWithHash,
 	}
-	identityCache = cache.IdentityCache{303: lblsArray}
+	identityCache = cache.IdentityCache{303: lblsArrayWithHash}
 	fooEndpointId = 9001
 )
 
@@ -107,7 +107,7 @@ func GenerateNumIdentities(numIdentities int) {
 		bumpedIdentity := i + 1000
 		numericIdentity := identity.NumericIdentity(bumpedIdentity)
 
-		identityCache[numericIdentity] = identityLabels.LabelArray()
+		identityCache[numericIdentity] = identityLabels.LabelArrayWithHash()
 	}
 }
 

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -265,7 +265,7 @@ func (state *traceState) selectRule(ctx *SearchContext, r *rule) {
 	state.selectedRules++
 }
 
-func (state *traceState) unSelectRule(ctx *SearchContext, labels labels.LabelArray, r *rule) {
+func (state *traceState) unSelectRule(ctx *SearchContext, labels *labels.LabelArrayWithHash, r *rule) {
 	ctx.PolicyTraceVerbose("  Rule %s: did not select %+v\n", r, labels)
 }
 
@@ -345,7 +345,7 @@ func mergeCIDR(ctx *SearchContext, dir string, ipRules []api.CIDR, ruleLabels la
 func (r *rule) resolveCIDRPolicy(ctx *SearchContext, state *traceState, result *CIDRPolicy) *CIDRPolicy {
 	// Don't select rule if it doesn't apply to the given context.
 	if !ctx.rulesSelect {
-		if !r.EndpointSelector.Matches(ctx.To) {
+		if ctx.To != nil && !r.EndpointSelector.Matches(ctx.To) {
 			state.unSelectRule(ctx, ctx.To, r)
 			return nil
 		}

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -41,12 +41,12 @@ var (
 
 func (ds *PolicyTestSuite) TestRuleCanReach(c *C) {
 	fooFoo2ToBar := &SearchContext{
-		From: labels.ParseSelectLabelArray("foo", "foo2"),
-		To:   labels.ParseSelectLabelArray("bar"),
+		From: labels.ParseSelectLabelArrayWithHash("foo", "foo2"),
+		To:   labels.ParseSelectLabelArrayWithHash("bar"),
 	}
 	fooToBar := &SearchContext{
-		From: labels.ParseSelectLabelArray("foo"),
-		To:   labels.ParseSelectLabelArray("bar"),
+		From: labels.ParseSelectLabelArrayWithHash("foo"),
+		To:   labels.ParseSelectLabelArrayWithHash("bar"),
 	}
 
 	rule1 := rule{
@@ -94,12 +94,12 @@ func (ds *PolicyTestSuite) TestRuleCanReach(c *C) {
 	}
 
 	fooBazToBar := &SearchContext{
-		From: labels.ParseSelectLabelArray("foo", "baz"),
-		To:   labels.ParseSelectLabelArray("bar"),
+		From: labels.ParseSelectLabelArrayWithHash("foo", "baz"),
+		To:   labels.ParseSelectLabelArrayWithHash("bar"),
 	}
 	bazToBar := &SearchContext{
-		From: labels.ParseSelectLabelArray("baz"),
-		To:   labels.ParseSelectLabelArray("bar"),
+		From: labels.ParseSelectLabelArrayWithHash("baz"),
+		To:   labels.ParseSelectLabelArrayWithHash("bar"),
 	}
 
 	state = traceState{}
@@ -119,10 +119,10 @@ func (ds *PolicyTestSuite) TestRuleCanReach(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestL4Policy(c *C) {
-	toBar := &SearchContext{To: labels.ParseSelectLabelArray("bar")}
-	fromBar := &SearchContext{From: labels.ParseSelectLabelArray("bar")}
-	toFoo := &SearchContext{To: labels.ParseSelectLabelArray("foo")}
-	fromFoo := &SearchContext{From: labels.ParseSelectLabelArray("foo")}
+	toBar := &SearchContext{To: labels.ParseSelectLabelArrayWithHash("bar")}
+	fromBar := &SearchContext{From: labels.ParseSelectLabelArrayWithHash("bar")}
+	toFoo := &SearchContext{To: labels.ParseSelectLabelArrayWithHash("foo")}
+	fromFoo := &SearchContext{From: labels.ParseSelectLabelArrayWithHash("foo")}
 
 	rule1 := &rule{
 		Rule: api.Rule{
@@ -335,7 +335,7 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestMergeL4PolicyIngress(c *C) {
-	toBar := &SearchContext{To: labels.ParseSelectLabelArray("bar")}
+	toBar := &SearchContext{To: labels.ParseSelectLabelArrayWithHash("bar")}
 	//toFoo := &SearchContext{To: labels.ParseSelectLabelArray("foo")}
 
 	fooSelector := api.NewESFromLabels(labels.ParseSelectLabel("foo"))
@@ -385,7 +385,7 @@ func (ds *PolicyTestSuite) TestMergeL4PolicyEgress(c *C) {
 
 	buffer := new(bytes.Buffer)
 	fromBar := &SearchContext{
-		From:    labels.ParseSelectLabelArray("bar"),
+		From:    labels.ParseSelectLabelArrayWithHash("bar"),
 		Logging: logging.NewLogBackend(buffer, "", 0),
 		Trace:   TRACE_VERBOSE,
 	}
@@ -436,8 +436,8 @@ func (ds *PolicyTestSuite) TestMergeL4PolicyEgress(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
-	toBar := &SearchContext{To: labels.ParseSelectLabelArray("bar")}
-	toFoo := &SearchContext{To: labels.ParseSelectLabelArray("foo")}
+	toBar := &SearchContext{To: labels.ParseSelectLabelArrayWithHash("bar")}
+	toFoo := &SearchContext{To: labels.ParseSelectLabelArrayWithHash("foo")}
 
 	fooSelector := api.NewESFromLabels(labels.ParseSelectLabel("foo"))
 
@@ -663,8 +663,8 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
-	fromBar := &SearchContext{From: labels.ParseSelectLabelArray("bar")}
-	fromFoo := &SearchContext{From: labels.ParseSelectLabelArray("foo")}
+	fromBar := &SearchContext{From: labels.ParseSelectLabelArrayWithHash("bar")}
+	fromFoo := &SearchContext{From: labels.ParseSelectLabelArrayWithHash("foo")}
 
 	fooSelector := []api.EndpointSelector{
 		api.NewESFromLabels(labels.ParseSelectLabel("foo")),
@@ -972,7 +972,7 @@ func (ds *PolicyTestSuite) TestL3Policy(c *C) {
 	expected.Egress.Map["2001:dbf::/64"] = &CIDRPolicyMapRule{Prefix: net.IPNet{IP: []byte{0x20, 1, 0xd, 0xbf, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, Mask: []byte{255, 255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 0, 0, 0, 0, 0}}, DerivedFromRules: labels.LabelArrayList{nil}}
 	expected.Egress.IPv6PrefixCount[64] = 1
 
-	toBar := &SearchContext{To: labels.ParseSelectLabelArray("bar")}
+	toBar := &SearchContext{To: labels.ParseSelectLabelArrayWithHash("bar")}
 	state := traceState{}
 	res := rule1.resolveCIDRPolicy(toBar, &state, NewCIDRPolicy())
 	c.Assert(res, Not(IsNil))
@@ -1097,18 +1097,18 @@ func (ds *PolicyTestSuite) TestEgressRuleRestrictions(c *C) {
 
 func (ds *PolicyTestSuite) TestRuleCanReachFromEntity(c *C) {
 	fromWorld := &SearchContext{
-		From: labels.ParseSelectLabelArray("reserved:world"),
-		To:   labels.ParseSelectLabelArray("bar"),
+		From: labels.ParseSelectLabelArrayWithHash("reserved:world"),
+		To:   labels.ParseSelectLabelArrayWithHash("bar"),
 	}
 
 	fromCluster := &SearchContext{
-		From: labels.ParseSelectLabelArray("foo", localClusterLabel),
-		To:   labels.ParseSelectLabelArray("bar"),
+		From: labels.ParseSelectLabelArrayWithHash("foo", localClusterLabel),
+		To:   labels.ParseSelectLabelArrayWithHash("bar"),
 	}
 
 	fromOtherCluster := &SearchContext{
-		From: labels.ParseSelectLabelArray("foo", otherClusterLabel),
-		To:   labels.ParseSelectLabelArray("bar"),
+		From: labels.ParseSelectLabelArrayWithHash("foo", otherClusterLabel),
+		To:   labels.ParseSelectLabelArrayWithHash("bar"),
 	}
 
 	rule1 := rule{
@@ -1145,18 +1145,18 @@ func (ds *PolicyTestSuite) TestRuleCanReachEntity(c *C) {
 	api.InitEntities(option.Config.ClusterName)
 
 	toWorld := &SearchContext{
-		From: labels.ParseSelectLabelArray("bar"),
-		To:   labels.ParseSelectLabelArray("reserved:world"),
+		From: labels.ParseSelectLabelArrayWithHash("bar"),
+		To:   labels.ParseSelectLabelArrayWithHash("reserved:world"),
 	}
 
 	toCluster := &SearchContext{
-		From: labels.ParseSelectLabelArray("bar"),
-		To:   labels.ParseSelectLabelArray("foo", localClusterLabel),
+		From: labels.ParseSelectLabelArrayWithHash("bar"),
+		To:   labels.ParseSelectLabelArrayWithHash("foo", localClusterLabel),
 	}
 
 	toOtherCluster := &SearchContext{
-		From: labels.ParseSelectLabelArray("bar"),
-		To:   labels.ParseSelectLabelArray("foo", otherClusterLabel),
+		From: labels.ParseSelectLabelArrayWithHash("bar"),
+		To:   labels.ParseSelectLabelArrayWithHash("foo", otherClusterLabel),
 	}
 
 	rule1 := rule{
@@ -1193,16 +1193,16 @@ func BenchmarkRuleCanReachEntity(b *testing.B) {
 	api.InitEntities(option.Config.ClusterName)
 
 	toOtherCluster := &SearchContext{
-		From: labels.ParseSelectLabelArray("bar"),
-		To:   labels.ParseSelectLabelArray("foo", otherClusterLabel),
+		From: labels.ParseSelectLabelArrayWithHash("bar"),
+		To:   labels.ParseSelectLabelArrayWithHash("foo", otherClusterLabel),
 	}
 	toFooBar := &SearchContext{
-		From: labels.ParseSelectLabelArray("k8s:app=bar", "k8s:namespace=default"),
-		To:   labels.ParseSelectLabelArray("k8s:app=FooBar", "k8s:namespace=default"),
+		From: labels.ParseSelectLabelArrayWithHash("k8s:app=bar", "k8s:namespace=default"),
+		To:   labels.ParseSelectLabelArrayWithHash("k8s:app=FooBar", "k8s:namespace=default"),
 	}
 	toFooBar2 := &SearchContext{
-		From: labels.ParseSelectLabelArray("k8s:app=bar", "k8s:namespace=default"),
-		To:   labels.ParseSelectLabelArray("k8s:app=FooBar2", "k8s:namespace=default2"),
+		From: labels.ParseSelectLabelArrayWithHash("k8s:app=bar", "k8s:namespace=default"),
+		To:   labels.ParseSelectLabelArrayWithHash("k8s:app=FooBar2", "k8s:namespace=default2"),
 	}
 
 	rule1 := rule{
@@ -1393,7 +1393,7 @@ func (ds *PolicyTestSuite) TestL3RuleLabels(c *C) {
 		}}
 
 	// endpoint selector for all tests
-	toBar := &SearchContext{To: labels.ParseSelectLabelArray("bar")}
+	toBar := &SearchContext{To: labels.ParseSelectLabelArrayWithHash("bar")}
 
 	for _, test := range testCases {
 		finalPolicy := NewCIDRPolicy()
@@ -1506,8 +1506,8 @@ func (ds *PolicyTestSuite) TestL4RuleLabels(c *C) {
 		}}
 
 	// endpoint selector for all tests
-	toBar := &SearchContext{To: labels.ParseSelectLabelArray("bar")}
-	fromBar := &SearchContext{From: labels.ParseSelectLabelArray("bar")}
+	toBar := &SearchContext{To: labels.ParseSelectLabelArrayWithHash("bar")}
+	fromBar := &SearchContext{From: labels.ParseSelectLabelArrayWithHash("bar")}
 
 	for _, test := range testCases {
 		finalPolicy := NewL4Policy()
@@ -1542,19 +1542,19 @@ func (ds *PolicyTestSuite) TestL4RuleLabels(c *C) {
 }
 
 var (
-	labelsA = labels.LabelArray{
-		labels.NewLabel("id", "a", labels.LabelSourceK8s),
+	labelsA = &labels.LabelArrayWithHash{
+		LabelArray: labels.LabelArray{labels.NewLabel("id", "a", labels.LabelSourceK8s)},
 	}
 
 	endpointSelectorA = api.NewESFromLabels(labels.ParseSelectLabel("id=a"))
 
-	labelsB = labels.LabelArray{
-		labels.NewLabel("id1", "b", labels.LabelSourceK8s),
-		labels.NewLabel("id2", "c", labels.LabelSourceK8s),
+	labelsB = &labels.LabelArrayWithHash{
+		LabelArray: labels.LabelArray{labels.NewLabel("id1", "b", labels.LabelSourceK8s),
+			labels.NewLabel("id2", "c", labels.LabelSourceK8s)},
 	}
 
-	labelsC = labels.LabelArray{
-		labels.NewLabel("id", "c", labels.LabelSourceK8s),
+	labelsC = &labels.LabelArrayWithHash{
+		LabelArray: labels.LabelArray{labels.NewLabel("id", "c", labels.LabelSourceK8s)},
 	}
 
 	endpointSelectorC = api.NewESFromLabels(labels.ParseSelectLabel("id=c"))
@@ -1778,7 +1778,7 @@ func (ds *PolicyTestSuite) TestEgressL4AllowWorld(c *C) {
 		},
 	})
 
-	worldLabel := labels.ParseSelectLabelArray("reserved:world")
+	worldLabel := labels.ParseSelectLabelArrayWithHash("reserved:world")
 	ctxAToWorld80 := SearchContext{From: labelsA, To: worldLabel, Trace: TRACE_VERBOSE}
 	ctxAToWorld80.DPorts = []*models.Port{{Port: 80, Protocol: models.PortProtocolTCP}}
 	checkEgress(c, repo, &ctxAToWorld80, api.Allowed)
@@ -1788,7 +1788,7 @@ func (ds *PolicyTestSuite) TestEgressL4AllowWorld(c *C) {
 	checkEgress(c, repo, &ctxAToWorld90, api.Denied)
 
 	// Pod to pod must be denied on port 80 and 90, only world was whitelisted
-	fooLabel := labels.ParseSelectLabelArray("k8s:app=foo")
+	fooLabel := labels.ParseSelectLabelArrayWithHash("k8s:app=foo")
 	ctxAToFoo := SearchContext{From: labelsA, To: fooLabel, Trace: TRACE_VERBOSE,
 		DPorts: []*models.Port{{Port: 80, Protocol: models.PortProtocolTCP}}}
 	checkEgress(c, repo, &ctxAToFoo, api.Denied)
@@ -1839,7 +1839,7 @@ func (ds *PolicyTestSuite) TestEgressL4AllowAllEntity(c *C) {
 		},
 	})
 
-	worldLabel := labels.ParseSelectLabelArray("reserved:world")
+	worldLabel := labels.ParseSelectLabelArrayWithHash("reserved:world")
 	ctxAToWorld80 := SearchContext{From: labelsA, To: worldLabel, Trace: TRACE_VERBOSE}
 	ctxAToWorld80.DPorts = []*models.Port{{Port: 80, Protocol: models.PortProtocolTCP}}
 	checkEgress(c, repo, &ctxAToWorld80, api.Allowed)
@@ -1849,7 +1849,7 @@ func (ds *PolicyTestSuite) TestEgressL4AllowAllEntity(c *C) {
 	checkEgress(c, repo, &ctxAToWorld90, api.Denied)
 
 	// Pod to pod must be allowed on port 80, denied on port 90 (all identity)
-	fooLabel := labels.ParseSelectLabelArray("k8s:app=foo")
+	fooLabel := labels.ParseSelectLabelArrayWithHash("k8s:app=foo")
 	ctxAToFoo := SearchContext{From: labelsA, To: fooLabel, Trace: TRACE_VERBOSE,
 		DPorts: []*models.Port{{Port: 80, Protocol: models.PortProtocolTCP}}}
 	checkEgress(c, repo, &ctxAToFoo, api.Allowed)
@@ -1895,7 +1895,7 @@ func (ds *PolicyTestSuite) TestEgressL3AllowWorld(c *C) {
 		},
 	})
 
-	worldLabel := labels.ParseSelectLabelArray("reserved:world")
+	worldLabel := labels.ParseSelectLabelArrayWithHash("reserved:world")
 	ctxAToWorld80 := SearchContext{From: labelsA, To: worldLabel, Trace: TRACE_VERBOSE}
 	ctxAToWorld80.DPorts = []*models.Port{{Port: 80, Protocol: models.PortProtocolTCP}}
 	checkEgress(c, repo, &ctxAToWorld80, api.Allowed)
@@ -1905,7 +1905,7 @@ func (ds *PolicyTestSuite) TestEgressL3AllowWorld(c *C) {
 	checkEgress(c, repo, &ctxAToWorld90, api.Allowed)
 
 	// Pod to pod must be denied on port 80 and 90, only world was whitelisted
-	fooLabel := labels.ParseSelectLabelArray("k8s:app=foo")
+	fooLabel := labels.ParseSelectLabelArrayWithHash("k8s:app=foo")
 	ctxAToFoo := SearchContext{From: labelsA, To: fooLabel, Trace: TRACE_VERBOSE,
 		DPorts: []*models.Port{{Port: 80, Protocol: models.PortProtocolTCP}}}
 	checkEgress(c, repo, &ctxAToFoo, api.Denied)
@@ -1939,7 +1939,7 @@ func (ds *PolicyTestSuite) TestEgressL3AllowAllEntity(c *C) {
 		},
 	})
 
-	worldLabel := labels.ParseSelectLabelArray("reserved:world")
+	worldLabel := labels.ParseSelectLabelArrayWithHash("reserved:world")
 	ctxAToWorld80 := SearchContext{From: labelsA, To: worldLabel, Trace: TRACE_VERBOSE}
 	ctxAToWorld80.DPorts = []*models.Port{{Port: 80, Protocol: models.PortProtocolTCP}}
 	checkEgress(c, repo, &ctxAToWorld80, api.Allowed)
@@ -1949,7 +1949,7 @@ func (ds *PolicyTestSuite) TestEgressL3AllowAllEntity(c *C) {
 	checkEgress(c, repo, &ctxAToWorld90, api.Allowed)
 
 	// Pod to pod must be allowed on both port 80 and 90 (L3 only rule)
-	fooLabel := labels.ParseSelectLabelArray("k8s:app=foo")
+	fooLabel := labels.ParseSelectLabelArrayWithHash("k8s:app=foo")
 	ctxAToFoo := SearchContext{From: labelsA, To: fooLabel, Trace: TRACE_VERBOSE,
 		DPorts: []*models.Port{{Port: 80, Protocol: models.PortProtocolTCP}}}
 	checkEgress(c, repo, &ctxAToFoo, api.Allowed)


### PR DESCRIPTION
Upon creation of a `LabelArray`, store the hash of the contents of the
`LabelArray` within a new type, `LabelArrayWithHash`. This hash is based off
of the `SHA256Sum` of the sorted labels in the `LabelArray`. Simillarly, add a
new field, hash, to `EndpointSelector`. This hash is currently based on the
`String()` function within the `LabelSelector`. This function sorts the
`Labels` within the `LabelSelector`, but does not sort the
`MatchExpressions` field, which means that there is a case where two
instances of the equivalent `LabelSelector`, but with different ordering of
their\`MatchExpressions` are hashed, the hash will be different.

Adding a hash to `EndpointSelector` is performed upon its creation. This
allows for caching of information about multiple `EndpointSelector` with the
same labels for aggregating information related to policy, e.g., what identities
are selected by a given `EndpointSelector`.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7500)
<!-- Reviewable:end -->
