### PR TITLE
Test: Wait endpoints to be deleted.

### DIFF
--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -159,6 +159,7 @@ var _ = Describe("K8sServicesTest", func() {
 			// Explicitly ignore result of deletion of resources to avoid incomplete
 			// teardown if any step fails.
 			_ = kubectl.Delete(demoYAML)
+			ExpectAllPodsTerminated(kubectl)
 		})
 
 		It("Checks ClusterIP Connectivity", func() {


### PR DESCRIPTION
In the following CI fail, toServices fail due pods were schedulled to be
deleted. This PR addressed that all pods are deleted when reach the
BeforeAll.

Link: https://jenkins.cilium.io/job/cilium-ginkgo/job/cilium/job/master/2605/testReport/junit/k8s-1/14/K8sServicesTest_External_services_To_Services_first_endpoint_creation/
Error:
```
/home/jenkins/workspace/cilium-ginkgo_cilium_master/src/github.com/cilium/cilium/test/ginkgo-ext/scopes.go:366
Pods are not ready after timeout
Expected
    <*errors.errorString | 0xc4200c3a20>: {
        s: "There are some pods with filter  that are marked to be deleted",
    }
to be nil
/home/jenkins/workspace/cilium-ginkgo_cilium_master/src/github.com/cilium/cilium/test/k8sT/Services.go:248
```

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7505)
<!-- Reviewable:end -->
