### PR TITLE
Update CNI plugins to v0.7.5 and CNI libraries to v0.7.0-rc2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN make LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 V=$V LIBNETWORK_PLUGIN=$LIBNETWORK_PLU
 # built while allowing the new versions to make changes that are not
 # backwards compatible.
 #
-FROM quay.io/cilium/cilium-runtime:2019-03-16
+FROM quay.io/cilium/cilium-runtime:2019-03-26
 LABEL maintainer="maintainer@cilium.io"
 COPY --from=builder /tmp/install /
 COPY --from=cilium-envoy / /

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -219,7 +219,7 @@
   revision = "461401dc8f19d80baa4b70178935e4501286c00b"
 
 [[projects]]
-  digest = "1:95312968b2ba23adbf770086f402cb74c8c0b6a373c6056178e446386a4a7e0c"
+  digest = "1:217f54a01004e15731471f4b3d420c16b99ade200d9872d7c1f0d2684df60f14"
   name = "github.com/containernetworking/cni"
   packages = [
     "pkg/skel",
@@ -229,7 +229,7 @@
     "pkg/version",
   ]
   pruneopts = "NUT"
-  revision = "d2836a7b59485b780f49c64c07e8c41c06bde6ab"
+  revision = "v0.7.0-rc2"
 
 [[projects]]
   digest = "1:c76a35a17c17bc067b506dc24afb353ecb207087c079ef62a73febefbb20ed0b"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -236,7 +236,7 @@
   name = "github.com/containernetworking/plugins"
   packages = ["pkg/ns"]
   pruneopts = "NUT"
-  revision = "v0.7.4"
+  revision = "v0.7.5"
 
 [[projects]]
   digest = "1:d37f9e5bed67b56e4f1431c47ae2cd4b995369a5a23c52c0997dcbd8301e78bd"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -95,7 +95,7 @@ required = [
 
 [[constraint]]
   name = "github.com/containernetworking/plugins"
-  revision = "v0.7.4"
+  revision = "v0.7.5"
 
   # main-usage = "pkg/ipam and plugins/cilium-cni"
   # on-revision = ""

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -88,10 +88,10 @@ required = [
 
 [[constraint]]
   name = "github.com/containernetworking/cni"
-  revision = "d2836a7b59485b780f49c64c07e8c41c06bde6ab"
+  revision = "v0.7.0-rc2"
 
   # main-usage = "plugins/cni"
-  # on-revision = "a stable realease was not released for the CNI chaining that Cilium needs"
+  # on-revision = "latest stable release"
 
 [[constraint]]
   name = "github.com/containernetworking/plugins"

--- a/contrib/packaging/docker/Dockerfile.runtime
+++ b/contrib/packaging/docker/Dockerfile.runtime
@@ -66,7 +66,7 @@ strip bpf-map && \
 #
 # cni/loopback
 #
-curl -sS -L https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz -o cni.tar.gz && \
+curl -sS -L https://github.com/containernetworking/plugins/releases/download/v0.7.5/cni-plugins-amd64-v0.7.5.tgz -o cni.tar.gz && \
 tar -xvf cni.tar.gz ./loopback && \
 strip -s ./loopback && \
 #

--- a/vendor/github.com/containernetworking/cni/pkg/skel/skel.go
+++ b/vendor/github.com/containernetworking/cni/pkg/skel/skel.go
@@ -74,54 +74,54 @@ func (t *dispatcher) getCmdArgsFromEnv() (string, *CmdArgs, error) {
 			"CNI_COMMAND",
 			&cmd,
 			reqForCmdEntry{
-				"ADD": true,
-				"GET": true,
-				"DEL": true,
+				"ADD":   true,
+				"CHECK": true,
+				"DEL":   true,
 			},
 		},
 		{
 			"CNI_CONTAINERID",
 			&contID,
 			reqForCmdEntry{
-				"ADD": true,
-				"GET": true,
-				"DEL": true,
+				"ADD":   true,
+				"CHECK": true,
+				"DEL":   true,
 			},
 		},
 		{
 			"CNI_NETNS",
 			&netns,
 			reqForCmdEntry{
-				"ADD": true,
-				"GET": true,
-				"DEL": false,
+				"ADD":   true,
+				"CHECK": true,
+				"DEL":   false,
 			},
 		},
 		{
 			"CNI_IFNAME",
 			&ifName,
 			reqForCmdEntry{
-				"ADD": true,
-				"GET": true,
-				"DEL": true,
+				"ADD":   true,
+				"CHECK": true,
+				"DEL":   true,
 			},
 		},
 		{
 			"CNI_ARGS",
 			&args,
 			reqForCmdEntry{
-				"ADD": false,
-				"GET": false,
-				"DEL": false,
+				"ADD":   false,
+				"CHECK": false,
+				"DEL":   false,
 			},
 		},
 		{
 			"CNI_PATH",
 			&path,
 			reqForCmdEntry{
-				"ADD": true,
-				"GET": true,
-				"DEL": true,
+				"ADD":   true,
+				"CHECK": true,
+				"DEL":   true,
 			},
 		},
 	}
@@ -198,7 +198,7 @@ func validateConfig(jsonBytes []byte) error {
 	return nil
 }
 
-func (t *dispatcher) pluginMain(cmdAdd, cmdGet, cmdDel func(_ *CmdArgs) error, versionInfo version.PluginInfo, about string) *types.Error {
+func (t *dispatcher) pluginMain(cmdAdd, cmdCheck, cmdDel func(_ *CmdArgs) error, versionInfo version.PluginInfo, about string) *types.Error {
 	cmd, cmdArgs, err := t.getCmdArgsFromEnv()
 	if err != nil {
 		// Print the about string to stderr when no command is set
@@ -219,7 +219,7 @@ func (t *dispatcher) pluginMain(cmdAdd, cmdGet, cmdDel func(_ *CmdArgs) error, v
 	switch cmd {
 	case "ADD":
 		err = t.checkVersionAndCall(cmdArgs, versionInfo, cmdAdd)
-	case "GET":
+	case "CHECK":
 		configVersion, err := t.ConfVersionDecoder.Decode(cmdArgs.StdinData)
 		if err != nil {
 			return createTypedError(err.Error())
@@ -229,7 +229,7 @@ func (t *dispatcher) pluginMain(cmdAdd, cmdGet, cmdDel func(_ *CmdArgs) error, v
 		} else if !gtet {
 			return &types.Error{
 				Code: types.ErrIncompatibleCNIVersion,
-				Msg:  "config version does not allow GET",
+				Msg:  "config version does not allow CHECK",
 			}
 		}
 		for _, pluginVersion := range versionInfo.SupportedVersions() {
@@ -237,7 +237,7 @@ func (t *dispatcher) pluginMain(cmdAdd, cmdGet, cmdDel func(_ *CmdArgs) error, v
 			if err != nil {
 				return createTypedError(err.Error())
 			} else if gtet {
-				if err := t.checkVersionAndCall(cmdArgs, versionInfo, cmdGet); err != nil {
+				if err := t.checkVersionAndCall(cmdArgs, versionInfo, cmdCheck); err != nil {
 					return createTypedError(err.Error())
 				}
 				return nil
@@ -245,7 +245,7 @@ func (t *dispatcher) pluginMain(cmdAdd, cmdGet, cmdDel func(_ *CmdArgs) error, v
 		}
 		return &types.Error{
 			Code: types.ErrIncompatibleCNIVersion,
-			Msg:  "plugin version does not allow GET",
+			Msg:  "plugin version does not allow CHECK",
 		}
 	case "DEL":
 		err = t.checkVersionAndCall(cmdArgs, versionInfo, cmdDel)
@@ -266,7 +266,7 @@ func (t *dispatcher) pluginMain(cmdAdd, cmdGet, cmdDel func(_ *CmdArgs) error, v
 }
 
 // PluginMainWithError is the core "main" for a plugin. It accepts
-// callback functions for add, get, and del CNI commands and returns an error.
+// callback functions for add, check, and del CNI commands and returns an error.
 //
 // The caller must also specify what CNI spec versions the plugin supports.
 //
@@ -277,13 +277,13 @@ func (t *dispatcher) pluginMain(cmdAdd, cmdGet, cmdDel func(_ *CmdArgs) error, v
 //
 // To let this package automatically handle errors and call os.Exit(1) for you,
 // use PluginMain() instead.
-func PluginMainWithError(cmdAdd, cmdGet, cmdDel func(_ *CmdArgs) error, versionInfo version.PluginInfo, about string) *types.Error {
+func PluginMainWithError(cmdAdd, cmdCheck, cmdDel func(_ *CmdArgs) error, versionInfo version.PluginInfo, about string) *types.Error {
 	return (&dispatcher{
 		Getenv: os.Getenv,
 		Stdin:  os.Stdin,
 		Stdout: os.Stdout,
 		Stderr: os.Stderr,
-	}).pluginMain(cmdAdd, cmdGet, cmdDel, versionInfo, about)
+	}).pluginMain(cmdAdd, cmdCheck, cmdDel, versionInfo, about)
 }
 
 // PluginMain is the core "main" for a plugin which includes automatic error handling.
@@ -291,14 +291,14 @@ func PluginMainWithError(cmdAdd, cmdGet, cmdDel func(_ *CmdArgs) error, versionI
 // The caller must also specify what CNI spec versions the plugin supports.
 //
 // The caller can specify an "about" string, which is printed on stderr
-// when no CNI_COMMAND is specified. The reccomended output is "CNI plugin <foo> v<version>"
+// when no CNI_COMMAND is specified. The recommended output is "CNI plugin <foo> v<version>"
 //
-// When an error occurs in either cmdAdd, cmdGet, or cmdDel, PluginMain will print the error
+// When an error occurs in either cmdAdd, cmdCheck, or cmdDel, PluginMain will print the error
 // as JSON to stdout and call os.Exit(1).
 //
 // To have more control over error handling, use PluginMainWithError() instead.
-func PluginMain(cmdAdd, cmdGet, cmdDel func(_ *CmdArgs) error, versionInfo version.PluginInfo, about string) {
-	if e := PluginMainWithError(cmdAdd, cmdGet, cmdDel, versionInfo, about); e != nil {
+func PluginMain(cmdAdd, cmdCheck, cmdDel func(_ *CmdArgs) error, versionInfo version.PluginInfo, about string) {
+	if e := PluginMainWithError(cmdAdd, cmdCheck, cmdDel, versionInfo, about); e != nil {
 		if err := e.Print(); err != nil {
 			log.Print("Error writing error JSON to stdout: ", err)
 		}

--- a/vendor/github.com/containernetworking/cni/pkg/types/020/types.go
+++ b/vendor/github.com/containernetworking/cni/pkg/types/020/types.go
@@ -17,6 +17,7 @@ package types020
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"os"
 
@@ -73,11 +74,15 @@ func (r *Result) GetAsVersion(version string) (types.Result, error) {
 }
 
 func (r *Result) Print() error {
+	return r.PrintTo(os.Stdout)
+}
+
+func (r *Result) PrintTo(writer io.Writer) error {
 	data, err := json.MarshalIndent(r, "", "    ")
 	if err != nil {
 		return err
 	}
-	_, err = os.Stdout.Write(data)
+	_, err = writer.Write(data)
 	return err
 }
 

--- a/vendor/github.com/containernetworking/cni/pkg/types/current/types.go
+++ b/vendor/github.com/containernetworking/cni/pkg/types/current/types.go
@@ -17,6 +17,7 @@ package current
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"os"
 
@@ -75,13 +76,9 @@ func convertFrom020(result types.Result) (*Result, error) {
 			Gateway: oldResult.IP4.Gateway,
 		})
 		for _, route := range oldResult.IP4.Routes {
-			gw := route.GW
-			if gw == nil {
-				gw = oldResult.IP4.Gateway
-			}
 			newResult.Routes = append(newResult.Routes, &types.Route{
 				Dst: route.Dst,
-				GW:  gw,
+				GW:  route.GW,
 			})
 		}
 	}
@@ -93,19 +90,11 @@ func convertFrom020(result types.Result) (*Result, error) {
 			Gateway: oldResult.IP6.Gateway,
 		})
 		for _, route := range oldResult.IP6.Routes {
-			gw := route.GW
-			if gw == nil {
-				gw = oldResult.IP6.Gateway
-			}
 			newResult.Routes = append(newResult.Routes, &types.Route{
 				Dst: route.Dst,
-				GW:  gw,
+				GW:  route.GW,
 			})
 		}
-	}
-
-	if len(newResult.IPs) == 0 {
-		return nil, fmt.Errorf("cannot convert: no valid IP addresses")
 	}
 
 	return newResult, nil
@@ -206,11 +195,15 @@ func (r *Result) GetAsVersion(version string) (types.Result, error) {
 }
 
 func (r *Result) Print() error {
+	return r.PrintTo(os.Stdout)
+}
+
+func (r *Result) PrintTo(writer io.Writer) error {
 	data, err := json.MarshalIndent(r, "", "    ")
 	if err != nil {
 		return err
 	}
-	_, err = os.Stdout.Write(data)
+	_, err = writer.Write(data)
 	return err
 }
 

--- a/vendor/github.com/containernetworking/cni/pkg/types/types.go
+++ b/vendor/github.com/containernetworking/cni/pkg/types/types.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"os"
 )
@@ -78,15 +79,16 @@ type IPAM struct {
 type NetConfList struct {
 	CNIVersion string `json:"cniVersion,omitempty"`
 
-	Name    string     `json:"name,omitempty"`
-	Plugins []*NetConf `json:"plugins,omitempty"`
+	Name         string     `json:"name,omitempty"`
+	DisableCheck bool       `json:"disableCheck,omitempty"`
+	Plugins      []*NetConf `json:"plugins,omitempty"`
 }
 
 type ResultFactoryFunc func([]byte) (Result, error)
 
 // Result is an interface that provides the result of plugin execution
 type Result interface {
-	// The highest CNI specification result verison the result supports
+	// The highest CNI specification result version the result supports
 	// without having to convert
 	Version() string
 
@@ -96,6 +98,9 @@ type Result interface {
 
 	// Prints the result in JSON format to stdout
 	Print() error
+
+	// Prints the result in JSON format to provided writer
+	PrintTo(writer io.Writer) error
 
 	// Returns a JSON string representation of the result
 	String() string

--- a/vendor/github.com/containernetworking/cni/pkg/version/plugin.go
+++ b/vendor/github.com/containernetworking/cni/pkg/version/plugin.go
@@ -86,9 +86,13 @@ func (*PluginDecoder) Decode(jsonBytes []byte) (PluginInfo, error) {
 // minor, and micro numbers or returns an error
 func ParseVersion(version string) (int, int, int, error) {
 	var major, minor, micro int
+	if version == "" {
+		return -1, -1, -1, fmt.Errorf("invalid version %q: the version is empty", version)
+	}
+
 	parts := strings.Split(version, ".")
-	if len(parts) == 0 || len(parts) >= 4 {
-		return -1, -1, -1, fmt.Errorf("invalid version %q: too many or too few parts", version)
+	if len(parts) >= 4 {
+		return -1, -1, -1, fmt.Errorf("invalid version %q: too many parts", version)
 	}
 
 	major, err := strconv.Atoi(parts[0])
@@ -114,7 +118,7 @@ func ParseVersion(version string) (int, int, int, error) {
 }
 
 // GreaterThanOrEqualTo takes two string versions, parses them into major/minor/micro
-// nubmers, and compares them to determine whether the first version is greater
+// numbers, and compares them to determine whether the first version is greater
 // than or equal to the second
 func GreaterThanOrEqualTo(version, otherVersion string) (bool, error) {
 	firstMajor, firstMinor, firstMicro, err := ParseVersion(version)


### PR DESCRIPTION
K8s has bumped the minimal version of the CNI plugins to v0.7.5. We should update it as well for the loopback plugin that we have so we can test it for all k8s versions that we support.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7514)
<!-- Reviewable:end -->
