### PR TITLE
Fix regression in L7 policy

### DIFF
--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 Authors of Cilium
+// Copyright 2016-2017 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -128,11 +128,6 @@ func wildcardL3L4Rule(proto api.L4Proto, port int, endpoints api.EndpointSelecto
 		if proto != filter.Protocol || (port != 0 && port != filter.Port) {
 			continue
 		}
-
-		if endpoints.SelectsAllEndpoints() {
-			endpoints = api.EndpointSelectorSlice{api.WildcardEndpointSelector}
-		}
-
 		switch filter.L7Parser {
 		case ParserTypeNone:
 			continue

--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -76,6 +76,13 @@ func (rules ruleSlice) wildcardL3L4Rules(ctx *SearchContext, ingress bool, l4Pol
 					wildcardL3L4Rule(api.ProtoTCP, 0, fromEndpoints, ruleLabels, l4Policy)
 					wildcardL3L4Rule(api.ProtoUDP, 0, fromEndpoints, ruleLabels, l4Policy)
 				} else {
+					// L4-only or L3-dependent L4 rule.
+					//
+					// "fromEndpoints" may be empty here, which indicates that all L3 peers should
+					// be selected. If so, add the wildcard selector.
+					if len(fromEndpoints) == 0 {
+						fromEndpoints = append(fromEndpoints, api.WildcardEndpointSelector)
+					}
 					for _, toPort := range rule.ToPorts {
 						// L3/L4-only rule
 						if toPort.Rules.IsEmpty() {
@@ -108,6 +115,13 @@ func (rules ruleSlice) wildcardL3L4Rules(ctx *SearchContext, ingress bool, l4Pol
 					wildcardL3L4Rule(api.ProtoTCP, 0, toEndpoints, ruleLabels, l4Policy)
 					wildcardL3L4Rule(api.ProtoUDP, 0, toEndpoints, ruleLabels, l4Policy)
 				} else {
+					// L4-only or L3-dependent L4 rule.
+					//
+					// "toEndpoints" may be empty here, which indicates that all L3 peers should
+					// be selected. If so, add the wildcard selector.
+					if len(toEndpoints) == 0 {
+						toEndpoints = append(toEndpoints, api.WildcardEndpointSelector)
+					}
 					for _, toPort := range rule.ToPorts {
 						// L3/L4-only rule
 						if toPort.Rules.IsEmpty() {


### PR DESCRIPTION
This reverts commit 13c705070d71e44b11a1c0f57b8de89a89c93e6b.

The `wildcardL3L4Rules()` function is used from L3-only rules as well as
L3-dependent L4 and L4-only rules, so in these cases the empty endpoint
set has different meaning: In L3-only, it means "select nothing at all";
in any L4 type of rule, it means "select all endpoints with this port" -
ie a wildcard. Shift this code back to where it used to be, and add a
comment to describe why it's there.

Fixes: #7476

Marked as needing backport to match #7476's tags.

(I'm working on a followup change in this area which adds comments to the
function, so I can add a comment above it there to reflect this information)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7520)
<!-- Reviewable:end -->
