### PR TITLE
remove .* from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -73,4 +73,3 @@ test/bpf/_results
 
 # generated from make targets
 *.ok
-.*


### PR DESCRIPTION
Ignoring the .* makes the git directory to be ignored and thefore it's
not possible to derive the commit ID when building docker images.

Fixes: f332375063be ("Add dockerignore file.")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7525)
<!-- Reviewable:end -->
