### PR TITLE
pkg/option: set option used for k8s endpoint field selector

### DIFF
--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1120,6 +1120,7 @@ func (c *DaemonConfig) Populate() {
 	c.K8sRequireIPv6PodCIDR = viper.GetBool(K8sRequireIPv6PodCIDRName)
 	c.K8sForceJSONPatch = viper.GetBool(K8sForceJSONPatch)
 	c.K8sWatcherQueueSize = uint(viper.GetInt(K8sWatcherQueueSize))
+	c.K8sWatcherEndpointSelector = viper.GetString(K8sWatcherEndpointSelector)
 	c.KeepTemplates = viper.GetBool(KeepBPFTemplates)
 	c.KeepConfig = viper.GetBool(KeepConfig)
 	c.KVStore = viper.GetString(KVStore)


### PR DESCRIPTION
Fixes: ada4e28df2ab ("k8s: set endpoint watcher selector as a CLI option")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7528)
<!-- Reviewable:end -->
