### PR TITLE
policy: include L3-only policy in L4Filter

### DIFF
--- a/pkg/policy/api/selector.go
+++ b/pkg/policy/api/selector.go
@@ -362,19 +362,9 @@ func (s EndpointSelectorSlice) Matches(ctx labels.LabelArray) bool {
 }
 
 // SelectsAllEndpoints returns whether the EndpointSelectorSlice selects all
-// endpoints. Depending on what "layer" of policy is being computed for this
-// EndpointSelectorSlice (L3, or L4), an empty slice represents different
-// behavior: at L3, an empty slice does not allow traffic, while at L4, it does.
-// If a slice contains the WildcardEndpointSelector, it of course selects all
-// endpoints.
-func (s EndpointSelectorSlice) SelectsAllEndpoints(isL3Only bool) bool {
-
-	if len(s) == 0 {
-		if !isL3Only {
-			return true
-		}
-	}
-
+// endpoints, which is true if the wildcard endpoint selector is present in the
+// slice.
+func (s EndpointSelectorSlice) SelectsAllEndpoints() bool {
 	for _, selector := range s {
 		if selector.IsWildcard() {
 			return true

--- a/pkg/policy/api/selector.go
+++ b/pkg/policy/api/selector.go
@@ -362,11 +362,17 @@ func (s EndpointSelectorSlice) Matches(ctx labels.LabelArray) bool {
 }
 
 // SelectsAllEndpoints returns whether the EndpointSelectorSlice selects all
-// endpoints (if it contains the WildcardEndpointSelector, or if it is empty).
-func (s EndpointSelectorSlice) SelectsAllEndpoints() bool {
+// endpoints. Depending on what "layer" of policy is being computed for this
+// EndpointSelectorSlice (L3, or L4), an empty slice represents different
+// behavior: at L3, an empty slice does not allow traffic, while at L4, it does.
+// If a slice contains the WildcardEndpointSelector, it of course selects all
+// endpoints.
+func (s EndpointSelectorSlice) SelectsAllEndpoints(isL3Only bool) bool {
 
 	if len(s) == 0 {
-		return true
+		if !isL3Only {
+			return true
+		}
 	}
 
 	for _, selector := range s {

--- a/pkg/policy/api/selector_test.go
+++ b/pkg/policy/api/selector_test.go
@@ -35,17 +35,17 @@ func (s *PolicyAPITestSuite) TestSelectsAllEndpoints(c *C) {
 
 	// Empty endpoint selector slice equates to a wildcard.
 	selectorSlice := EndpointSelectorSlice{}
-	c.Assert(selectorSlice.SelectsAllEndpoints(false), Equals, true)
+	c.Assert(selectorSlice.SelectsAllEndpoints(), Equals, false)
 
 	selectorSlice = EndpointSelectorSlice{WildcardEndpointSelector}
-	c.Assert(selectorSlice.SelectsAllEndpoints(false), Equals, true)
+	c.Assert(selectorSlice.SelectsAllEndpoints(), Equals, true)
 
 	// Slice that contains wildcard and other selectors still selects all endpoints.
 	selectorSlice = EndpointSelectorSlice{WildcardEndpointSelector, NewESFromLabels(labels.ParseSelectLabel("bar"))}
-	c.Assert(selectorSlice.SelectsAllEndpoints(false), Equals, true)
+	c.Assert(selectorSlice.SelectsAllEndpoints(), Equals, true)
 
 	selectorSlice = EndpointSelectorSlice{NewESFromLabels(labels.ParseSelectLabel("bar")), NewESFromLabels(labels.ParseSelectLabel("foo"))}
-	c.Assert(selectorSlice.SelectsAllEndpoints(false), Equals, false)
+	c.Assert(selectorSlice.SelectsAllEndpoints(), Equals, false)
 }
 
 func (s *PolicyAPITestSuite) TestLabelSelectorToRequirements(c *C) {

--- a/pkg/policy/api/selector_test.go
+++ b/pkg/policy/api/selector_test.go
@@ -35,17 +35,17 @@ func (s *PolicyAPITestSuite) TestSelectsAllEndpoints(c *C) {
 
 	// Empty endpoint selector slice equates to a wildcard.
 	selectorSlice := EndpointSelectorSlice{}
-	c.Assert(selectorSlice.SelectsAllEndpoints(), Equals, true)
+	c.Assert(selectorSlice.SelectsAllEndpoints(false), Equals, true)
 
 	selectorSlice = EndpointSelectorSlice{WildcardEndpointSelector}
-	c.Assert(selectorSlice.SelectsAllEndpoints(), Equals, true)
+	c.Assert(selectorSlice.SelectsAllEndpoints(false), Equals, true)
 
 	// Slice that contains wildcard and other selectors still selects all endpoints.
 	selectorSlice = EndpointSelectorSlice{WildcardEndpointSelector, NewESFromLabels(labels.ParseSelectLabel("bar"))}
-	c.Assert(selectorSlice.SelectsAllEndpoints(), Equals, true)
+	c.Assert(selectorSlice.SelectsAllEndpoints(false), Equals, true)
 
 	selectorSlice = EndpointSelectorSlice{NewESFromLabels(labels.ParseSelectLabel("bar")), NewESFromLabels(labels.ParseSelectLabel("foo"))}
-	c.Assert(selectorSlice.SelectsAllEndpoints(), Equals, false)
+	c.Assert(selectorSlice.SelectsAllEndpoints(false), Equals, false)
 }
 
 func (s *PolicyAPITestSuite) TestLabelSelectorToRequirements(c *C) {

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -39,6 +39,12 @@ var (
 	selectFoo_  = api.NewESFromLabels(labels.ParseSelectLabel("foo"))
 	allowFooL3_ = selectFoo_
 
+	// Identity, labels, selectors for an endpoint named "bar"
+	identityBar = uint32(200)
+	labelsBar   = labels.ParseSelectLabelArray("bar", "blue")
+	selectBar_  = api.NewESFromLabels(labels.ParseSelectLabel("bar"))
+	allowBarL3_ = selectBar_
+
 	// API rule sections for composability
 	// L4 rule sections
 	allowAllL4_ []api.PortRule
@@ -82,12 +88,23 @@ var (
 			ToPorts: combineL4L7(allowPort80, allowHTTPRoot),
 		}})
 
+	rule__L3AllowFoo = api.NewRule().
+				WithIngressRules([]api.IngressRule{{
+			FromEndpoints: []api.EndpointSelector{allowFooL3_},
+		}})
+
+	rule__L3AllowBar = api.NewRule().
+				WithIngressRules([]api.IngressRule{{
+			FromEndpoints: []api.EndpointSelector{allowBarL3_},
+		}})
+
 	// Misc other bpf key fields for convenience / readability.
 	l7RedirectNone_ = uint16(0)
 	l7RedirectProxy = uint16(1)
 	dirIngress      = trafficdirection.Ingress.Uint8()
 	// Desired map keys for L3, L3-dependent L4, L4
 	mapKeyAllowFoo__ = Key{identityFoo, 0, 0, dirIngress}
+	mapKeyAllowBar__ = Key{identityBar, 0, 0, dirIngress}
 	mapKeyAllowFooL4 = Key{identityFoo, 80, 6, dirIngress}
 	mapKeyAllow___L4 = Key{0, 80, 6, dirIngress}
 	// Desired map entries for no L7 redirect / redirect to Proxy
@@ -186,7 +203,7 @@ func (d *policyDistillery) distillPolicy(epLabels labels.LabelArray) (MapState, 
 	// Handle L4 ingress from each identity in the cache to the endpoint.
 	io.WriteString(d.log, "[distill] Producing L4 filter keys\n")
 	for _, l4 := range *l4IngressPolicy {
-		io.WriteString(d.log, fmt.Sprintf("[distill] Processing L4Filter (l7: %+v)\n", l4.L7RulesPerEp))
+		io.WriteString(d.log, fmt.Sprintf("[distill] Processing L4Filter (l3: %+v), (l4: %d/%s), (l7: %+v)\n", l4.Endpoints, l4.Port, l4.Protocol, l4.L7RulesPerEp))
 		for _, key := range l4.ToKeys(0, d.identityCache, deniedPeers) {
 			io.WriteString(d.log, fmt.Sprintf("[distill] L4 ingress allow %+v (parser=%s, redirect=%t)\n", key, l4.L7Parser, l4.IsRedirect()))
 			if l4.IsRedirect() {
@@ -232,6 +249,45 @@ func (d *policyDistillery) distillPolicy(epLabels labels.LabelArray) (MapState, 
 	}
 
 	return result, nil
+}
+
+func Test_MergeL3(t *testing.T) {
+	identityCache := cache.IdentityCache{
+		identity.NumericIdentity(identityFoo): labelsFoo,
+		identity.NumericIdentity(identityBar): labelsBar,
+	}
+
+	tests := []struct {
+		test   int
+		rules  api.Rules
+		result MapState
+	}{
+		{0, api.Rules{rule__L3AllowFoo, rule__L3AllowBar}, MapState{mapKeyAllowFoo__: mapEntryL7None_, mapKeyAllowBar__: mapEntryL7None_}},
+		{1, api.Rules{rule__L3AllowFoo, ruleL3L4__Allow}, MapState{mapKeyAllowFoo__: mapEntryL7None_, mapKeyAllowFooL4: mapEntryL7None_}},
+	}
+
+	for _, tt := range tests {
+		repo := newPolicyDistillery(identityCache)
+		for _, r := range tt.rules {
+			if r != nil {
+				rule := r.WithEndpointSelector(selectFoo_)
+				_, _ = repo.AddList(api.Rules{rule})
+			}
+		}
+		t.Run(fmt.Sprintf("permutation_%d", tt.test), func(t *testing.T) {
+			logBuffer := new(bytes.Buffer)
+			repo = repo.WithLogBuffer(logBuffer)
+			mapstate, err := repo.distillPolicy(labelsFoo)
+			if err != nil {
+				t.Errorf("Policy resolution failure: %s", err)
+			}
+			if equal, err := checker.DeepEqual(mapstate, tt.result); !equal {
+				t.Logf("Rules:\n%s\n\n", tt.rules.String())
+				t.Logf("Policy Trace: \n%s\n", logBuffer.String())
+				t.Errorf("Policy obtained didn't match expected for endpoint %s:\n%s", labelsFoo, err)
+			}
+		})
+	}
 }
 
 func Test_MergeRules(t *testing.T) {

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -144,7 +144,7 @@ func (l4 *L4Filter) ToKeys(direction trafficdirection.TrafficDirection, identity
 	port := uint16(l4.Port)
 	proto := uint8(l4.U8Proto)
 
-	if l4.AllowsAllAtL3() {
+	if l4.AllowsAllAtL3() && l4.Port != 0 {
 		keyToAdd := Key{
 			Identity: 0,
 			// NOTE: Port is in host byte-order!

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -227,7 +227,7 @@ func (l7 L7DataMap) addRulesForEndpoints(rules api.L7Rules, endpoints []api.Endp
 // filter is derived from. This filter may be associated with a series of L7
 // rules via the `rule` parameter.
 func CreateL4Filter(peerEndpoints api.EndpointSelectorSlice, rule api.PortRule, port api.PortProtocol,
-	protocol api.L4Proto, ruleLabels labels.LabelArray, ingress bool, l3Only bool) L4Filter {
+	protocol api.L4Proto, ruleLabels labels.LabelArray, ingress bool) L4Filter {
 
 	// already validated via PortRule.Validate()
 	p, _ := strconv.ParseUint(port.Port, 0, 16)
@@ -236,7 +236,7 @@ func CreateL4Filter(peerEndpoints api.EndpointSelectorSlice, rule api.PortRule, 
 
 	filterEndpoints := peerEndpoints
 	allowsAllL3 := false
-	if peerEndpoints.SelectsAllEndpoints(l3Only) {
+	if peerEndpoints.SelectsAllEndpoints() {
 		filterEndpoints = api.EndpointSelectorSlice{api.WildcardEndpointSelector}
 		allowsAllL3 = true
 	}
@@ -283,9 +283,9 @@ func CreateL4Filter(peerEndpoints api.EndpointSelectorSlice, rule api.PortRule, 
 // endpointsWithL3Override determines selectors for which L7 rules should be
 // wildcarded (eg, host / world in the relevant daemon modes).
 func CreateL4IngressFilter(fromEndpoints api.EndpointSelectorSlice, endpointsWithL3Override []api.EndpointSelector, rule api.PortRule, port api.PortProtocol,
-	protocol api.L4Proto, ruleLabels labels.LabelArray, isL3Only bool) L4Filter {
+	protocol api.L4Proto, ruleLabels labels.LabelArray) L4Filter {
 
-	filter := CreateL4Filter(fromEndpoints, rule, port, protocol, ruleLabels, true, isL3Only)
+	filter := CreateL4Filter(fromEndpoints, rule, port, protocol, ruleLabels, true)
 
 	// If the filter would apply L7 rules for endpointsWithL3Override,
 	// then wildcard those specific endpoints at L7.
@@ -303,9 +303,9 @@ func CreateL4IngressFilter(fromEndpoints api.EndpointSelectorSlice, endpointsWit
 // to the original rules that the filter is derived from. This filter may be
 // associated with a series of L7 rules via the `rule` parameter.
 func CreateL4EgressFilter(toEndpoints api.EndpointSelectorSlice, rule api.PortRule, port api.PortProtocol,
-	protocol api.L4Proto, ruleLabels labels.LabelArray, isL3Only bool) L4Filter {
+	protocol api.L4Proto, ruleLabels labels.LabelArray) L4Filter {
 
-	return CreateL4Filter(toEndpoints, rule, port, protocol, ruleLabels, false, isL3Only)
+	return CreateL4Filter(toEndpoints, rule, port, protocol, ruleLabels, false)
 }
 
 // IsRedirect returns true if the L4 filter contains a port redirection

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -144,6 +144,11 @@ func (l4 *L4Filter) ToKeys(direction trafficdirection.TrafficDirection, identity
 	port := uint16(l4.Port)
 	proto := uint8(l4.U8Proto)
 
+	// The BPF datapath only supports a value of '0' for identity (wildcarding
+	// at L3) if there is a corresponding port (i.e., a non-zero port).
+	// Wildcarding at L3 and L4 at the same time is not understood by the
+	// datapath at this time. So, if we have L3-only policy (e.g., port == 0),
+	// we need to explicitly allow each identity at port 0.
 	if l4.AllowsAllAtL3() && l4.Port != 0 {
 		keyToAdd := Key{
 			Identity: 0,

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -106,7 +106,7 @@ func (ds *PolicyTestSuite) TestMergeAllowAllL3AndAllowAllL7(c *C) {
 	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, true)
 
-	c.Assert(filter.Endpoints.SelectsAllEndpoints(), Equals, true)
+	c.Assert(filter.Endpoints.SelectsAllEndpoints(false), Equals, true)
 
 	c.Assert(filter.L7Parser, Equals, ParserTypeNone)
 	c.Assert(len(filter.L7RulesPerEp), Equals, 0)
@@ -148,7 +148,7 @@ func (ds *PolicyTestSuite) TestMergeAllowAllL3AndAllowAllL7(c *C) {
 	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, true)
 
-	c.Assert(filter.Endpoints.SelectsAllEndpoints(), Equals, true)
+	c.Assert(filter.Endpoints.SelectsAllEndpoints(false), Equals, true)
 
 	c.Assert(filter.L7Parser, Equals, ParserTypeNone)
 	c.Assert(len(filter.L7RulesPerEp), Equals, 0)
@@ -267,7 +267,7 @@ func (ds *PolicyTestSuite) TestMergeAllowAllL3AndShadowedL7(c *C) {
 	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, true)
 
-	c.Assert(filter.Endpoints.SelectsAllEndpoints(), Equals, true)
+	c.Assert(filter.Endpoints.SelectsAllEndpoints(false), Equals, true)
 
 	c.Assert(filter.L7Parser, Equals, ParserTypeHTTP)
 	c.Assert(len(filter.L7RulesPerEp), Equals, 1)

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -106,7 +106,7 @@ func (ds *PolicyTestSuite) TestMergeAllowAllL3AndAllowAllL7(c *C) {
 	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, true)
 
-	c.Assert(filter.Endpoints.SelectsAllEndpoints(false), Equals, true)
+	c.Assert(filter.Endpoints.SelectsAllEndpoints(), Equals, true)
 
 	c.Assert(filter.L7Parser, Equals, ParserTypeNone)
 	c.Assert(len(filter.L7RulesPerEp), Equals, 0)
@@ -148,7 +148,7 @@ func (ds *PolicyTestSuite) TestMergeAllowAllL3AndAllowAllL7(c *C) {
 	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, true)
 
-	c.Assert(filter.Endpoints.SelectsAllEndpoints(false), Equals, true)
+	c.Assert(filter.Endpoints.SelectsAllEndpoints(), Equals, true)
 
 	c.Assert(filter.L7Parser, Equals, ParserTypeNone)
 	c.Assert(len(filter.L7RulesPerEp), Equals, 0)
@@ -267,7 +267,7 @@ func (ds *PolicyTestSuite) TestMergeAllowAllL3AndShadowedL7(c *C) {
 	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, true)
 
-	c.Assert(filter.Endpoints.SelectsAllEndpoints(false), Equals, true)
+	c.Assert(filter.Endpoints.SelectsAllEndpoints(), Equals, true)
 
 	c.Assert(filter.L7Parser, Equals, ParserTypeHTTP)
 	c.Assert(len(filter.L7RulesPerEp), Equals, 1)

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -192,7 +192,7 @@ func (ds *PolicyTestSuite) TestMergeAllowAllL3AndShadowedL7(c *C) {
 	ctx.Logging = logging.NewLogBackend(buffer, "", 0)
 
 	ingressState := traceState{}
-	res, err := rule1.resolveL4IngressPolicy(&ctx, &ingressState, NewL4Policy(), nil)
+	res, err := rule1.resolveIngressPolicy(&ctx, &ingressState, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 
@@ -332,7 +332,7 @@ func (ds *PolicyTestSuite) TestMergeIdenticalAllowAllL3AndRestrictedL7HTTP(c *C)
 	c.Log(buffer)
 
 	state := traceState{}
-	res, err := identicalHTTPRule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
+	res, err := identicalHTTPRule.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, checker.DeepEquals, *expected)
@@ -340,7 +340,7 @@ func (ds *PolicyTestSuite) TestMergeIdenticalAllowAllL3AndRestrictedL7HTTP(c *C)
 	c.Assert(state.matchedRules, Equals, 0)
 
 	state = traceState{}
-	res, err = identicalHTTPRule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy(), nil)
+	res, err = identicalHTTPRule.resolveIngressPolicy(toFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -406,7 +406,7 @@ func (ds *PolicyTestSuite) TestMergeIdenticalAllowAllL3AndRestrictedL7Kafka(c *C
 	}
 
 	state := traceState{}
-	res, err := identicalKafkaRule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
+	res, err := identicalKafkaRule.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, checker.DeepEquals, *expected)
@@ -414,7 +414,7 @@ func (ds *PolicyTestSuite) TestMergeIdenticalAllowAllL3AndRestrictedL7Kafka(c *C
 	c.Assert(state.matchedRules, Equals, 0)
 
 	state = traceState{}
-	res, err = identicalKafkaRule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy(), nil)
+	res, err = identicalKafkaRule.resolveIngressPolicy(toFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -466,7 +466,7 @@ func (ds *PolicyTestSuite) TestMergeIdenticalAllowAllL3AndMismatchingParsers(c *
 	c.Log(buffer)
 
 	state := traceState{}
-	res, err := conflictingParsersRule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
+	res, err := conflictingParsersRule.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
 	c.Assert(err, Not(IsNil))
 	c.Assert(res, IsNil)
 
@@ -510,7 +510,7 @@ func (ds *PolicyTestSuite) TestMergeIdenticalAllowAllL3AndMismatchingParsers(c *
 	c.Log(buffer)
 
 	state = traceState{}
-	res, err = conflictingParsersRule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
+	res, err = conflictingParsersRule.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
 	c.Assert(err, Not(IsNil))
 	c.Assert(res, IsNil)
 
@@ -558,7 +558,7 @@ func (ds *PolicyTestSuite) TestMergeIdenticalAllowAllL3AndMismatchingParsers(c *
 	c.Assert(err, IsNil)
 
 	state = traceState{}
-	res, err = conflictingParsersIngressRule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
+	res, err = conflictingParsersIngressRule.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
 	c.Assert(err, Not(IsNil))
 	c.Assert(res, IsNil)
 
@@ -603,7 +603,7 @@ func (ds *PolicyTestSuite) TestMergeIdenticalAllowAllL3AndMismatchingParsers(c *
 	c.Assert(err, IsNil)
 
 	state = traceState{}
-	res, err = conflictingParsersEgressRule.resolveL4EgressPolicy(&ctxAToC, &state, NewL4Policy(), nil)
+	res, err = conflictingParsersEgressRule.resolveEgressPolicy(&ctxAToC, &state, NewL4Policy(), nil)
 	c.Log(buffer)
 	c.Assert(err, Not(IsNil))
 	c.Assert(res, IsNil)
@@ -656,7 +656,7 @@ func (ds *PolicyTestSuite) TestL3RuleShadowedByL3AllowAll(c *C) {
 	}
 
 	state := traceState{}
-	res, err := shadowRule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
+	res, err := shadowRule.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, checker.DeepEquals, *expected)
@@ -664,7 +664,7 @@ func (ds *PolicyTestSuite) TestL3RuleShadowedByL3AllowAll(c *C) {
 	c.Assert(state.matchedRules, Equals, 0)
 
 	state = traceState{}
-	res, err = shadowRule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy(), nil)
+	res, err = shadowRule.resolveIngressPolicy(toFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -713,7 +713,7 @@ func (ds *PolicyTestSuite) TestL3RuleShadowedByL3AllowAll(c *C) {
 	}
 
 	state = traceState{}
-	res, err = shadowRule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
+	res, err = shadowRule.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, checker.DeepEquals, *expected)
@@ -721,7 +721,7 @@ func (ds *PolicyTestSuite) TestL3RuleShadowedByL3AllowAll(c *C) {
 	c.Assert(state.matchedRules, Equals, 0)
 
 	state = traceState{}
-	res, err = shadowRule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy(), nil)
+	res, err = shadowRule.resolveIngressPolicy(toFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -787,7 +787,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RulePartiallyShadowedByL3AllowAll(c *
 	}
 
 	state := traceState{}
-	res, err := shadowRule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
+	res, err := shadowRule.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, checker.DeepEquals, *expected)
@@ -795,7 +795,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RulePartiallyShadowedByL3AllowAll(c *
 	c.Assert(state.matchedRules, Equals, 0)
 
 	state = traceState{}
-	res, err = shadowRule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy(), nil)
+	res, err = shadowRule.resolveIngressPolicy(toFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -855,7 +855,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RulePartiallyShadowedByL3AllowAll(c *
 	}
 
 	state = traceState{}
-	res, err = shadowRule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
+	res, err = shadowRule.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, checker.DeepEquals, *expected)
@@ -863,7 +863,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RulePartiallyShadowedByL3AllowAll(c *
 	c.Assert(state.matchedRules, Equals, 0)
 
 	state = traceState{}
-	res, err = shadowRule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy(), nil)
+	res, err = shadowRule.resolveIngressPolicy(toFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -939,7 +939,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RuleShadowedByL3AllowAll(c *C) {
 	}
 
 	state := traceState{}
-	res, err := case8Rule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
+	res, err := case8Rule.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, checker.DeepEquals, *expected)
@@ -947,7 +947,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RuleShadowedByL3AllowAll(c *C) {
 	c.Assert(state.matchedRules, Equals, 0)
 
 	state = traceState{}
-	res, err = case8Rule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy(), nil)
+	res, err = case8Rule.resolveIngressPolicy(toFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -1016,7 +1016,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RuleShadowedByL3AllowAll(c *C) {
 	}
 
 	state = traceState{}
-	res, err = case8Rule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
+	res, err = case8Rule.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, checker.DeepEquals, *expected)
@@ -1024,7 +1024,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RuleShadowedByL3AllowAll(c *C) {
 	c.Assert(state.matchedRules, Equals, 0)
 
 	state = traceState{}
-	res, err = case8Rule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy(), nil)
+	res, err = case8Rule.resolveIngressPolicy(toFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -1076,12 +1076,12 @@ func (ds *PolicyTestSuite) TestL3SelectingEndpointAndL3AllowAllMergeConflictingL
 	c.Log(buffer)
 
 	state := traceState{}
-	res, err := conflictingL7Rule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
+	res, err := conflictingL7Rule.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
 	c.Assert(err, Not(IsNil))
 	c.Assert(res, IsNil)
 
 	state = traceState{}
-	res, err = conflictingL7Rule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy(), nil)
+	res, err = conflictingL7Rule.resolveIngressPolicy(toFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -1127,12 +1127,12 @@ func (ds *PolicyTestSuite) TestL3SelectingEndpointAndL3AllowAllMergeConflictingL
 	c.Log(buffer)
 
 	state = traceState{}
-	res, err = conflictingL7Rule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
+	res, err = conflictingL7Rule.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
 	c.Assert(err, Not(IsNil))
 	c.Assert(res, IsNil)
 
 	state = traceState{}
-	res, err = conflictingL7Rule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy(), nil)
+	res, err = conflictingL7Rule.resolveIngressPolicy(toFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -1201,7 +1201,7 @@ func (ds *PolicyTestSuite) TestMergingWithDifferentEndpointsSelectedAllowSameL7(
 	}
 
 	state := traceState{}
-	res, err := selectDifferentEndpointsRestrictL7.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
+	res, err := selectDifferentEndpointsRestrictL7.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, checker.DeepEquals, *expected)
@@ -1214,7 +1214,7 @@ func (ds *PolicyTestSuite) TestMergingWithDifferentEndpointsSelectedAllowSameL7(
 	c.Log(buffer)
 
 	state = traceState{}
-	res, err = selectDifferentEndpointsRestrictL7.resolveL4IngressPolicy(toFoo, &state, NewL4Policy(), nil)
+	res, err = selectDifferentEndpointsRestrictL7.resolveIngressPolicy(toFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -1265,7 +1265,7 @@ func (ds *PolicyTestSuite) TestMergingWithDifferentEndpointSelectedAllowAllL7(c 
 	}
 
 	state := traceState{}
-	res, err := selectDifferentEndpointsAllowAllL7.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
+	res, err := selectDifferentEndpointsAllowAllL7.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, checker.DeepEquals, *expected)
@@ -1278,7 +1278,7 @@ func (ds *PolicyTestSuite) TestMergingWithDifferentEndpointSelectedAllowAllL7(c 
 	c.Log(buffer)
 
 	state = traceState{}
-	res, err = selectDifferentEndpointsAllowAllL7.resolveL4IngressPolicy(toFoo, &state, NewL4Policy(), nil)
+	res, err = selectDifferentEndpointsAllowAllL7.resolveIngressPolicy(toFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -1342,7 +1342,7 @@ func (ds *PolicyTestSuite) TestAllowingLocalhostShadowsL7(c *C) {
 	}
 
 	state := traceState{}
-	res, err := rule.resolveL4IngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
+	res, err := rule.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, checker.DeepEquals, *expected)
@@ -1356,7 +1356,7 @@ func (ds *PolicyTestSuite) TestAllowingLocalhostShadowsL7(c *C) {
 	c.Log(buffer)
 
 	state = traceState{}
-	res, err = rule.resolveL4IngressPolicy(toFoo, &state, NewL4Policy(), nil)
+	res, err = rule.resolveIngressPolicy(toFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -1394,7 +1394,7 @@ func (ds *PolicyTestSuite) TestEntitiesL3(c *C) {
 	}
 
 	state := traceState{}
-	res, err := allowWorldRule.resolveL4EgressPolicy(&ctxFromA, &state, NewL4Policy(), nil)
+	res, err := allowWorldRule.resolveEgressPolicy(&ctxFromA, &state, NewL4Policy(), nil)
 
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))

--- a/pkg/policy/l4_test.go
+++ b/pkg/policy/l4_test.go
@@ -75,12 +75,12 @@ func (s *PolicyTestSuite) TestCreateL4Filter(c *C) {
 	for _, selector := range selectors {
 		eps := []api.EndpointSelector{selector}
 		// Regardless of ingress/egress, we should end up with
-		// a single L7 rule whether the selector is wildcarded
+		// a single L7 rule whether the selector is wildcardeds
 		// or if it is based on specific labels.
-		filter := CreateL4IngressFilter(eps, nil, portrule, tuple, tuple.Protocol, nil)
+		filter := CreateL4IngressFilter(eps, nil, portrule, tuple, tuple.Protocol, nil, false)
 		c.Assert(len(filter.L7RulesPerEp), Equals, 1)
 
-		filter = CreateL4EgressFilter(eps, portrule, tuple, tuple.Protocol, nil)
+		filter = CreateL4EgressFilter(eps, portrule, tuple, tuple.Protocol, nil, false)
 		c.Assert(len(filter.L7RulesPerEp), Equals, 1)
 	}
 }

--- a/pkg/policy/l4_test.go
+++ b/pkg/policy/l4_test.go
@@ -75,7 +75,7 @@ func (s *PolicyTestSuite) TestCreateL4Filter(c *C) {
 	for _, selector := range selectors {
 		eps := []api.EndpointSelector{selector}
 		// Regardless of ingress/egress, we should end up with
-		// a single L7 rule whether the selector is wildcardeds
+		// a single L7 rule whether the selector is wildcarded
 		// or if it is based on specific labels.
 		filter := CreateL4IngressFilter(eps, nil, portrule, tuple, tuple.Protocol, nil)
 		c.Assert(len(filter.L7RulesPerEp), Equals, 1)

--- a/pkg/policy/l4_test.go
+++ b/pkg/policy/l4_test.go
@@ -77,10 +77,10 @@ func (s *PolicyTestSuite) TestCreateL4Filter(c *C) {
 		// Regardless of ingress/egress, we should end up with
 		// a single L7 rule whether the selector is wildcardeds
 		// or if it is based on specific labels.
-		filter := CreateL4IngressFilter(eps, nil, portrule, tuple, tuple.Protocol, nil, false)
+		filter := CreateL4IngressFilter(eps, nil, portrule, tuple, tuple.Protocol, nil)
 		c.Assert(len(filter.L7RulesPerEp), Equals, 1)
 
-		filter = CreateL4EgressFilter(eps, portrule, tuple, tuple.Protocol, nil, false)
+		filter = CreateL4EgressFilter(eps, portrule, tuple, tuple.Protocol, nil)
 		c.Assert(len(filter.L7RulesPerEp), Equals, 1)
 	}
 }

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -671,13 +671,13 @@ func (p *Repository) ResolvePolicy(id uint16, securityIdentity *identity.Identit
 	ingressCtx := SearchContext{
 		To:                            labels,
 		rulesSelect:                   true,
-		skipL4RequirementsAggregation: true,
+		skipL4RequirementsAggregation: false,
 	}
 
 	egressCtx := SearchContext{
 		From:                          labels,
 		rulesSelect:                   true,
-		skipL4RequirementsAggregation: true,
+		skipL4RequirementsAggregation: false,
 	}
 
 	if option.Config.TracingEnabled() {
@@ -704,16 +704,11 @@ func (p *Repository) ResolvePolicy(id uint16, securityIdentity *identity.Identit
 			egressCtx.To = labels
 
 			ingressAccess := matchingRules.canReachIngressRLocked(&ingressCtx)
-			if ingressAccess == api.Allowed {
-				keyToAdd := Key{
-					Identity:         identity.Uint32(),
-					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}
-				calculatedPolicy.PolicyMapState[keyToAdd] = MapStateEntry{}
-			} else if ingressAccess == api.Denied {
+			if ingressAccess == api.Denied {
 				calculatedPolicy.DeniedIngressIdentities[identity] = labels
 			}
 		}
+
 	} else {
 		calculatedPolicy.PolicyMapState.AllowAllIdentities(identityCache, trafficdirection.Ingress)
 	}

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -729,14 +729,7 @@ func (p *Repository) ResolvePolicy(id uint16, securityIdentity *identity.Identit
 		for identity, labels := range identityCache {
 			egressCtx.To = labels
 
-			egressAccess := matchingRules.canReachEgressRLocked(&egressCtx)
-			if egressAccess == api.Allowed {
-				keyToAdd := Key{
-					Identity:         identity.Uint32(),
-					TrafficDirection: trafficdirection.Egress.Uint8(),
-				}
-				calculatedPolicy.PolicyMapState[keyToAdd] = MapStateEntry{}
-			} else if egressAccess == api.Denied {
+			if matchingRules.analyzeEgressRequirements(&egressCtx) == api.Denied {
 				calculatedPolicy.DeniedEgressIdentities[identity] = labels
 			}
 		}

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -703,8 +703,7 @@ func (p *Repository) ResolvePolicy(id uint16, securityIdentity *identity.Identit
 			ingressCtx.From = labels
 			egressCtx.To = labels
 
-			ingressAccess := matchingRules.canReachIngressRLocked(&ingressCtx)
-			if ingressAccess == api.Denied {
+			if matchingRules.analyzeIngressRequirements(&ingressCtx) == api.Denied {
 				calculatedPolicy.DeniedIngressIdentities[identity] = labels
 			}
 		}

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -786,6 +786,15 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngress(c *C) {
 	c.Assert(err, IsNil)
 
 	expectedPolicy := L4PolicyMap{
+		"0/ANY": {
+			Port:             0,
+			Protocol:         api.ProtoAny,
+			U8Proto:          0x0,
+			Endpoints:        []api.EndpointSelector{selBar1},
+			L7RulesPerEp:     L7DataMap{},
+			Ingress:          true,
+			DerivedFromRules: labels.LabelArrayList{labelsL3},
+		},
 		"9092/TCP": {
 			Port:      9092,
 			Protocol:  api.ProtoTCP,
@@ -1223,6 +1232,17 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgress(c *C) {
 			},
 			DerivedFromRules: labels.LabelArrayList{labelsHTTP, labelsL4},
 		},
+		"0/ANY": {
+			Port:             0,
+			Protocol:         "ANY",
+			U8Proto:          0x0,
+			allowsAllAtL3:    false,
+			Endpoints:        api.EndpointSelectorSlice{selBar1},
+			L7Parser:         "",
+			L7RulesPerEp:     L7DataMap{},
+			Ingress:          false,
+			DerivedFromRules: labels.LabelArrayList{labelsL4},
+		},
 	}
 	c.Assert((*policy), checker.DeepEquals, expectedPolicy)
 }
@@ -1445,12 +1465,23 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngressFromEntities(c *C) {
 
 	policy, err := repo.ResolveL4IngressPolicy(ctx)
 	c.Assert(err, IsNil)
-	c.Assert(len(*policy), Equals, 2)
+	c.Assert(len(*policy), Equals, 3)
 	c.Assert(len((*policy)["80/TCP"].Endpoints), Equals, 2)
 	selWorld := (*policy)["80/TCP"].Endpoints[1]
 	c.Assert(api.EndpointSelectorSlice{selWorld}, checker.DeepEquals, api.EntitySelectorMapping[api.EntityWorld])
 
 	expectedPolicy := L4PolicyMap{
+		"0/ANY": {
+			Port:             0,
+			Protocol:         "ANY",
+			U8Proto:          0x0,
+			allowsAllAtL3:    false,
+			Endpoints:        []api.EndpointSelector{selWorld},
+			L7Parser:         "",
+			L7RulesPerEp:     L7DataMap{},
+			Ingress:          true,
+			DerivedFromRules: labels.LabelArrayList{labelsL3},
+		},
 		"9092/TCP": {
 			Port:      9092,
 			Protocol:  api.ProtoTCP,
@@ -1567,12 +1598,23 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgressToEntities(c *C) {
 
 	policy, err := repo.ResolveL4EgressPolicy(ctx)
 	c.Assert(err, IsNil)
-	c.Assert(len(*policy), Equals, 2)
+	c.Assert(len(*policy), Equals, 3)
 	c.Assert(len((*policy)["80/TCP"].Endpoints), Equals, 2)
 	selWorld := (*policy)["80/TCP"].Endpoints[1]
 	c.Assert(api.EndpointSelectorSlice{selWorld}, checker.DeepEquals, api.EntitySelectorMapping[api.EntityWorld])
 
 	expectedPolicy := L4PolicyMap{
+		"0/ANY": {
+			Port:             0,
+			Protocol:         "ANY",
+			U8Proto:          0x0,
+			allowsAllAtL3:    false,
+			Endpoints:        api.EndpointSelectorSlice{selWorld},
+			L7Parser:         "",
+			L7RulesPerEp:     L7DataMap{},
+			Ingress:          false,
+			DerivedFromRules: labels.LabelArrayList{labelsL3},
+		},
 		"9092/TCP": {
 			Port:      9092,
 			Protocol:  api.ProtoTCP,
@@ -1879,7 +1921,7 @@ Label verdict: undecided
 
 Resolving ingress port policy for [any:bar]
 * Rule {"matchLabels":{"any:bar":""}}: selected
-    No L4 Ingress rules
+    Labels [any:baz] not found
 * Rule {"matchLabels":{"any:bar":""}}: selected
     Found all required labels
     Allows Ingress port [{80 ANY}] from endpoints [{"matchLabels":{"reserved:host":""}} {"matchLabels":{"any:baz":""}}]
@@ -1908,7 +1950,7 @@ Label verdict: undecided
 
 Resolving ingress port policy for [any:bar]
 * Rule {"matchLabels":{"any:bar":""}}: selected
-    No L4 Ingress rules
+    Labels [any:bar] not found
 * Rule {"matchLabels":{"any:bar":""}}: selected
     Labels [any:bar] not found
 2/2 rules selected

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
-
 	. "gopkg.in/check.v1"
 )
 
@@ -151,7 +150,6 @@ type DummyOwner struct{}
 func (d DummyOwner) LookupRedirectPort(l4 *L4Filter) uint16 {
 	return 0
 }
-
 func (ds *PolicyTestSuite) BenchmarkRegeneratePolicyRules(c *C) {
 	c.ResetTimer()
 	for i := 0; i < c.N; i++ {

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -165,18 +165,18 @@ func mergeL4Port(ctx *SearchContext, endpoints []api.EndpointSelector, existingF
 // into L7 wildcards (ie, traffic will be forwarded to the proxy for endpoints
 // matching those labels, but the proxy will allow all such traffic).
 func mergeL4IngressPort(ctx *SearchContext, endpoints []api.EndpointSelector, endpointsWithL3Override []api.EndpointSelector, r api.PortRule, p api.PortProtocol,
-	proto api.L4Proto, ruleLabels labels.LabelArray, resMap L4PolicyMap, isL3Only bool) (int, error) {
+	proto api.L4Proto, ruleLabels labels.LabelArray, resMap L4PolicyMap) (int, error) {
 
 	key := p.Port + "/" + string(proto)
 	existingFilter, ok := resMap[key]
 	if !ok {
-		resMap[key] = CreateL4IngressFilter(endpoints, endpointsWithL3Override, r, p, proto, ruleLabels, isL3Only)
+		resMap[key] = CreateL4IngressFilter(endpoints, endpointsWithL3Override, r, p, proto, ruleLabels)
 		return 1, nil
 	}
 
 	// Create a new L4Filter based off of the arguments provided to this function
 	// for merging with the filter which is already in the policy map.
-	filterToMerge := CreateL4IngressFilter(endpoints, endpointsWithL3Override, r, p, proto, ruleLabels, isL3Only)
+	filterToMerge := CreateL4IngressFilter(endpoints, endpointsWithL3Override, r, p, proto, ruleLabels)
 
 	if err := mergeL4Port(ctx, endpoints, &existingFilter, &filterToMerge); err != nil {
 		return 0, err
@@ -221,7 +221,7 @@ func mergeL4Ingress(ctx *SearchContext, rule api.IngressRule, ruleLabels labels.
 
 	// L3-only rule without requirements.
 	if len(rule.ToPorts) == 0 && len(rule.FromRequires) == 0 {
-		cnt, err = mergeL4IngressPort(ctx, fromEndpoints, endpointsWithL3Override, api.PortRule{}, api.PortProtocol{Port: "0", Protocol: api.ProtoAny}, api.ProtoAny, ruleLabels, resMap, true)
+		cnt, err = mergeL4IngressPort(ctx, fromEndpoints, endpointsWithL3Override, api.PortRule{}, api.PortProtocol{Port: "0", Protocol: api.ProtoAny}, api.ProtoAny, ruleLabels, resMap)
 		if err != nil {
 			return found, err
 		}
@@ -230,6 +230,12 @@ func mergeL4Ingress(ctx *SearchContext, rule api.IngressRule, ruleLabels labels.
 	found += cnt
 
 	for _, r := range rule.ToPorts {
+		// For L4 Policy, an empty slice of EndpointSelector indicates that the
+		// rule allows all at L3 - explicitly specify this by creating a slice
+		// with the WildcardEndpointSelector.
+		if len(fromEndpoints) == 0 {
+			fromEndpoints = api.EndpointSelectorSlice{api.WildcardEndpointSelector}
+		}
 		ctx.PolicyTrace("    Allows %s port %v from endpoints %v\n", trafficdirection.Ingress, r.Ports, fromEndpoints)
 		if r.Rules != nil && r.Rules.L7Proto != "" {
 			ctx.PolicyTrace("      l7proto: \"%s\"\n", r.Rules.L7Proto)
@@ -248,19 +254,19 @@ func mergeL4Ingress(ctx *SearchContext, rule api.IngressRule, ruleLabels labels.
 
 		for _, p := range r.Ports {
 			if p.Protocol != api.ProtoAny {
-				cnt, err := mergeL4IngressPort(ctx, fromEndpoints, endpointsWithL3Override, r, p, p.Protocol, ruleLabels, resMap, false)
+				cnt, err := mergeL4IngressPort(ctx, fromEndpoints, endpointsWithL3Override, r, p, p.Protocol, ruleLabels, resMap)
 				if err != nil {
 					return found, err
 				}
 				found += cnt
 			} else {
-				cnt, err := mergeL4IngressPort(ctx, fromEndpoints, endpointsWithL3Override, r, p, api.ProtoTCP, ruleLabels, resMap, false)
+				cnt, err := mergeL4IngressPort(ctx, fromEndpoints, endpointsWithL3Override, r, p, api.ProtoTCP, ruleLabels, resMap)
 				if err != nil {
 					return found, err
 				}
 				found += cnt
 
-				cnt, err = mergeL4IngressPort(ctx, fromEndpoints, endpointsWithL3Override, r, p, api.ProtoUDP, ruleLabels, resMap, false)
+				cnt, err = mergeL4IngressPort(ctx, fromEndpoints, endpointsWithL3Override, r, p, api.ProtoUDP, ruleLabels, resMap)
 				if err != nil {
 					return found, err
 				}
@@ -616,7 +622,7 @@ func mergeL4Egress(ctx *SearchContext, rule api.EgressRule, ruleLabels labels.La
 
 	// L3-only rule
 	if len(rule.ToPorts) == 0 && len(rule.ToRequires) == 0 {
-		cnt, err = mergeL4EgressPort(ctx, toEndpoints, api.PortRule{}, api.PortProtocol{Port: "0", Protocol: api.ProtoAny}, api.ProtoAny, ruleLabels, resMap, true)
+		cnt, err = mergeL4EgressPort(ctx, toEndpoints, api.PortRule{}, api.PortProtocol{Port: "0", Protocol: api.ProtoAny}, api.ProtoAny, ruleLabels, resMap)
 		if err != nil {
 			return found, err
 		}
@@ -625,6 +631,12 @@ func mergeL4Egress(ctx *SearchContext, rule api.EgressRule, ruleLabels labels.La
 	found += cnt
 
 	for _, r := range rule.ToPorts {
+		// For L4 Policy, an empty slice of EndpointSelector indicates that the
+		// rule allows all at L3 - explicitly specify this by creating a slice
+		// with the WildcardEndpointSelector.
+		if len(toEndpoints) == 0 {
+			toEndpoints = api.EndpointSelectorSlice{api.WildcardEndpointSelector}
+		}
 		ctx.PolicyTrace("    Allows %s port %v to endpoints %v\n", trafficdirection.Egress, r.Ports, toEndpoints)
 		if r.Rules != nil && r.Rules.L7Proto != "" {
 			ctx.PolicyTrace("      l7proto: \"%s\"\n", r.Rules.L7Proto)
@@ -643,19 +655,19 @@ func mergeL4Egress(ctx *SearchContext, rule api.EgressRule, ruleLabels labels.La
 
 		for _, p := range r.Ports {
 			if p.Protocol != api.ProtoAny {
-				cnt, err := mergeL4EgressPort(ctx, toEndpoints, r, p, p.Protocol, ruleLabels, resMap, false)
+				cnt, err := mergeL4EgressPort(ctx, toEndpoints, r, p, p.Protocol, ruleLabels, resMap)
 				if err != nil {
 					return found, err
 				}
 				found += cnt
 			} else {
-				cnt, err := mergeL4EgressPort(ctx, toEndpoints, r, p, api.ProtoTCP, ruleLabels, resMap, false)
+				cnt, err := mergeL4EgressPort(ctx, toEndpoints, r, p, api.ProtoTCP, ruleLabels, resMap)
 				if err != nil {
 					return found, err
 				}
 				found += cnt
 
-				cnt, err = mergeL4EgressPort(ctx, toEndpoints, r, p, api.ProtoUDP, ruleLabels, resMap, false)
+				cnt, err = mergeL4EgressPort(ctx, toEndpoints, r, p, api.ProtoUDP, ruleLabels, resMap)
 				if err != nil {
 					return found, err
 				}
@@ -673,18 +685,18 @@ func mergeL4Egress(ctx *SearchContext, rule api.EgressRule, ruleLabels labels.La
 // being merged has conflicting L7 rules with those already in the provided
 // L4PolicyMap for the specified port-protocol tuple, it returns an error.
 func mergeL4EgressPort(ctx *SearchContext, endpoints []api.EndpointSelector, r api.PortRule, p api.PortProtocol,
-	proto api.L4Proto, ruleLabels labels.LabelArray, resMap L4PolicyMap, isL3Only bool) (int, error) {
+	proto api.L4Proto, ruleLabels labels.LabelArray, resMap L4PolicyMap) (int, error) {
 
 	key := p.Port + "/" + string(proto)
 	existingFilter, ok := resMap[key]
 	if !ok {
-		resMap[key] = CreateL4EgressFilter(endpoints, r, p, proto, ruleLabels, isL3Only)
+		resMap[key] = CreateL4EgressFilter(endpoints, r, p, proto, ruleLabels)
 		return 1, nil
 	}
 
 	// Create a new L4Filter based off of the arguments provided to this function
 	// for merging with the filter which is already in the policy map.
-	filterToMerge := CreateL4EgressFilter(endpoints, r, p, proto, ruleLabels, isL3Only)
+	filterToMerge := CreateL4EgressFilter(endpoints, r, p, proto, ruleLabels)
 
 	if err := mergeL4Port(ctx, endpoints, &existingFilter, &filterToMerge); err != nil {
 		return 0, err

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -508,8 +508,6 @@ func (r *rule) canReachEgressV2(ctx *SearchContext, state *traceState) api.Decis
 // requirements in the rule, that does not mean that the rule allows traffic
 // from the labels in ctx.From, merely that the rule does not deny it.
 func (r *rule) meetsRequirementsIngress(ctx *SearchContext, state *traceState) api.Decision {
-
-	state.selectRule(ctx, r)
 	for _, r := range r.Ingress {
 		for _, sel := range r.FromRequires {
 			ctx.PolicyTrace("    Requires from labels %+v", sel)
@@ -616,8 +614,6 @@ func (r *rule) canReachEgress(ctx *SearchContext, state *traceState) api.Decisio
 // requirements in the rule, that does not mean that the rule allows traffic
 // from the labels in ctx.To, merely that the rule does not deny it.
 func (r *rule) meetsRequirementsEgress(ctx *SearchContext, state *traceState) api.Decision {
-
-	state.selectRule(ctx, r)
 	for _, r := range r.Egress {
 		for _, sel := range r.ToRequires {
 			ctx.PolicyTrace("    Requires from labels %+v", sel)

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -503,9 +503,10 @@ func (r *rule) canReachEgressV2(ctx *SearchContext, state *traceState) api.Decis
 	return api.Undecided
 }
 
-// canReachIngress returns the decision as to whether the set of labels specified
-// in ctx.From match with the label selectors specified in the ingress rules
-// contained within r.
+// meetsRequirementsIngress returns whether the labels in ctx.From do not
+// meet the requirements in the provided rule. If a rule does meet the
+// requirements in the rule, that does not mean that the rule allows traffic
+// from the labels in ctx.From, merely that the rule does not deny it.
 func (r *rule) meetsRequirementsIngress(ctx *SearchContext, state *traceState) api.Decision {
 
 	state.selectRule(ctx, r)

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -433,21 +433,6 @@ func (r *rule) canReachIngress(ctx *SearchContext, state *traceState) api.Decisi
 		return api.Denied
 	}
 
-	// At this point we only know whether anything is not denied by requirements.
-	// Now we need to determine whether rule allows traffic based off of
-	// SearchContext.
-	for _, r := range r.Ingress {
-		for _, sel := range r.FromRequires {
-			ctx.PolicyTrace("    Requires from labels %+v", sel)
-			if !sel.Matches(ctx.From) {
-				ctx.PolicyTrace("-     Labels %v not found\n", ctx.From)
-				state.constrainedRules++
-				return api.Denied
-			}
-			ctx.PolicyTrace("+     Found all required labels\n")
-		}
-	}
-
 	return r.canReachFromEndpoints(ctx, state)
 }
 

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -461,7 +461,7 @@ func (r *rule) canReachIngress(ctx *SearchContext, state *traceState) api.Decisi
 	return api.Undecided
 }
 
-func (r *rule) canReachIngressV2(ctx *SearchContext, state *traceState) api.Decision {
+func (r *rule) canReachFromEndpoints(ctx *SearchContext, state *traceState) api.Decision {
 	// assume requirements have already been analyzed.
 	for _, r := range r.Ingress {
 		for _, sel := range r.GetSourceEndpointSelectors() {
@@ -482,7 +482,7 @@ func (r *rule) canReachIngressV2(ctx *SearchContext, state *traceState) api.Deci
 	return api.Undecided
 }
 
-func (r *rule) canReachEgressV2(ctx *SearchContext, state *traceState) api.Decision {
+func (r *rule) canReachToEndpoints(ctx *SearchContext, state *traceState) api.Decision {
 	// assume requirements have already been analyzed.
 	for _, r := range r.Egress {
 		for _, sel := range r.GetDestinationEndpointSelectors() {

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -456,7 +456,6 @@ func (r *rule) canReachIngress(ctx *SearchContext, state *traceState) api.Decisi
 }
 
 func (r *rule) canReachIngressV2(ctx *SearchContext, state *traceState) api.Decision {
-
 	// assume requirements have already been analyzed.
 	for _, r := range r.Ingress {
 		for _, sel := range r.GetSourceEndpointSelectors() {
@@ -471,6 +470,27 @@ func (r *rule) canReachIngressV2(ctx *SearchContext, state *traceState) api.Deci
 				ctx.PolicyTrace("        Rule restricts traffic to specific L4 destinations; deferring policy decision to L4 policy stage\n")
 			} else {
 				ctx.PolicyTrace("      Labels %v not found\n", ctx.From)
+			}
+		}
+	}
+	return api.Undecided
+}
+
+func (r *rule) canReachEgressV2(ctx *SearchContext, state *traceState) api.Decision {
+	// assume requirements have already been analyzed.
+	for _, r := range r.Egress {
+		for _, sel := range r.GetDestinationEndpointSelectors() {
+			ctx.PolicyTrace("    Allows to labels %+v", sel)
+			if sel.Matches(ctx.To) {
+				ctx.PolicyTrace("      Found all required labels")
+				if len(r.ToPorts) == 0 {
+					ctx.PolicyTrace("+       No L4 restrictions\n")
+					state.matchedRules++
+					return api.Allowed
+				}
+				ctx.PolicyTrace("        Rule restricts traffic from specific L4 destinations; deferring policy decision to L4 policy stage\n")
+			} else {
+				ctx.PolicyTrace("      Labels %v not found\n", ctx.To)
 			}
 		}
 	}

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -66,7 +66,7 @@ func (r *rule) String() string {
 	return fmt.Sprintf("%v", r.EndpointSelector)
 }
 
-func mergeL4Port(ctx *SearchContext, endpoints []api.EndpointSelector, existingFilter, filterToMerge *L4Filter) error {
+func mergePortProto(ctx *SearchContext, endpoints []api.EndpointSelector, existingFilter, filterToMerge *L4Filter) error {
 	// Handle cases where filter we are merging new rule with, new rule itself
 	// allows all traffic on L3, or both rules allow all traffic on L3.
 	//
@@ -154,7 +154,7 @@ func mergeL4Port(ctx *SearchContext, endpoints []api.EndpointSelector, existingF
 	return nil
 }
 
-// mergeL4IngressPort merges all rules which share the same port & protocol that
+// mergeIngressPortProto merges all rules which share the same port & protocol that
 // select a given set of endpoints. It updates the L4Filter mapped to by the specified
 // port and protocol with the contents of the provided PortRule. If the rule
 // being merged has conflicting L7 rules with those already in the provided
@@ -164,7 +164,7 @@ func mergeL4Port(ctx *SearchContext, endpoints []api.EndpointSelector, existingF
 // then for the endpoints with L3 override, the L7 rules will be translated
 // into L7 wildcards (ie, traffic will be forwarded to the proxy for endpoints
 // matching those labels, but the proxy will allow all such traffic).
-func mergeL4IngressPort(ctx *SearchContext, endpoints []api.EndpointSelector, endpointsWithL3Override []api.EndpointSelector, r api.PortRule, p api.PortProtocol,
+func mergeIngressPortProto(ctx *SearchContext, endpoints []api.EndpointSelector, endpointsWithL3Override []api.EndpointSelector, r api.PortRule, p api.PortProtocol,
 	proto api.L4Proto, ruleLabels labels.LabelArray, resMap L4PolicyMap) (int, error) {
 
 	key := p.Port + "/" + string(proto)
@@ -178,7 +178,7 @@ func mergeL4IngressPort(ctx *SearchContext, endpoints []api.EndpointSelector, en
 	// for merging with the filter which is already in the policy map.
 	filterToMerge := CreateL4IngressFilter(endpoints, endpointsWithL3Override, r, p, proto, ruleLabels)
 
-	if err := mergeL4Port(ctx, endpoints, &existingFilter, &filterToMerge); err != nil {
+	if err := mergePortProto(ctx, endpoints, &existingFilter, &filterToMerge); err != nil {
 		return 0, err
 	}
 	existingFilter.DerivedFromRules = append(existingFilter.DerivedFromRules, ruleLabels)
@@ -187,7 +187,7 @@ func mergeL4IngressPort(ctx *SearchContext, endpoints []api.EndpointSelector, en
 	return 1, nil
 }
 
-func mergeL4Ingress(ctx *SearchContext, rule api.IngressRule, ruleLabels labels.LabelArray, resMap L4PolicyMap) (int, error) {
+func mergeIngress(ctx *SearchContext, rule api.IngressRule, ruleLabels labels.LabelArray, resMap L4PolicyMap) (int, error) {
 
 	fromEndpoints := rule.GetSourceEndpointSelectors()
 	found := 0
@@ -221,7 +221,7 @@ func mergeL4Ingress(ctx *SearchContext, rule api.IngressRule, ruleLabels labels.
 
 	// L3-only rule without requirements.
 	if len(rule.ToPorts) == 0 && len(rule.FromRequires) == 0 {
-		cnt, err = mergeL4IngressPort(ctx, fromEndpoints, endpointsWithL3Override, api.PortRule{}, api.PortProtocol{Port: "0", Protocol: api.ProtoAny}, api.ProtoAny, ruleLabels, resMap)
+		cnt, err = mergeIngressPortProto(ctx, fromEndpoints, endpointsWithL3Override, api.PortRule{}, api.PortProtocol{Port: "0", Protocol: api.ProtoAny}, api.ProtoAny, ruleLabels, resMap)
 		if err != nil {
 			return found, err
 		}
@@ -254,19 +254,19 @@ func mergeL4Ingress(ctx *SearchContext, rule api.IngressRule, ruleLabels labels.
 
 		for _, p := range r.Ports {
 			if p.Protocol != api.ProtoAny {
-				cnt, err := mergeL4IngressPort(ctx, fromEndpoints, endpointsWithL3Override, r, p, p.Protocol, ruleLabels, resMap)
+				cnt, err := mergeIngressPortProto(ctx, fromEndpoints, endpointsWithL3Override, r, p, p.Protocol, ruleLabels, resMap)
 				if err != nil {
 					return found, err
 				}
 				found += cnt
 			} else {
-				cnt, err := mergeL4IngressPort(ctx, fromEndpoints, endpointsWithL3Override, r, p, api.ProtoTCP, ruleLabels, resMap)
+				cnt, err := mergeIngressPortProto(ctx, fromEndpoints, endpointsWithL3Override, r, p, api.ProtoTCP, ruleLabels, resMap)
 				if err != nil {
 					return found, err
 				}
 				found += cnt
 
-				cnt, err = mergeL4IngressPort(ctx, fromEndpoints, endpointsWithL3Override, r, p, api.ProtoUDP, ruleLabels, resMap)
+				cnt, err = mergeIngressPortProto(ctx, fromEndpoints, endpointsWithL3Override, r, p, api.ProtoUDP, ruleLabels, resMap)
 				if err != nil {
 					return found, err
 				}
@@ -287,8 +287,13 @@ func (state *traceState) unSelectRule(ctx *SearchContext, labels labels.LabelArr
 	ctx.PolicyTraceVerbose("  Rule %s: did not select %+v\n", r, labels)
 }
 
-// resolveL4IngressPolicy determines whether (TODO ianvernon)
-func (r *rule) resolveL4IngressPolicy(ctx *SearchContext, state *traceState, result *L4Policy, requirements []v1.LabelSelectorRequirement) (*L4Policy, error) {
+// resolveIngressPolicy analyzes the rule against the given SearchContext, and
+// merges it with any prior-generated policy within the provided L4Policy.
+// Requirements based off of all Ingress requirements (set in FromRequires) in
+// other rules are stored in the specified slice of LabelSelectorRequirement.
+// These requirements are dynamically inserted into a copy of the receiver rule,
+// as requirements form conjunctions across all rules.
+func (r *rule) resolveIngressPolicy(ctx *SearchContext, state *traceState, result *L4Policy, requirements []v1.LabelSelectorRequirement) (*L4Policy, error) {
 	if !ctx.rulesSelect {
 		if !r.EndpointSelector.Matches(ctx.To) {
 			state.unSelectRule(ctx, ctx.To, r)
@@ -322,7 +327,7 @@ func (r *rule) resolveL4IngressPolicy(ctx *SearchContext, state *traceState, res
 			}
 			ruleCopy.SetAggregatedSelectors()
 		}
-		cnt, err := mergeL4Ingress(ctx, ruleCopy, r.Rule.Labels.DeepCopy(), result.Ingress)
+		cnt, err := mergeIngress(ctx, ruleCopy, r.Rule.Labels.DeepCopy(), result.Ingress)
 		if err != nil {
 			return nil, err
 		}
@@ -377,7 +382,7 @@ func (r *rule) resolveCIDRPolicy(ctx *SearchContext, state *traceState, result *
 		allCIDRs = append(allCIDRs, ingressRule.FromCIDR...)
 		allCIDRs = append(allCIDRs, api.ComputeResultantCIDRSet(ingressRule.FromCIDRSet)...)
 
-		// CIDR + L4 rules are handled via mergeL4Ingress(),
+		// CIDR + L4 rules are handled via mergeIngress(),
 		// skip them here.
 		if len(allCIDRs) > 0 && len(ingressRule.ToPorts) > 0 {
 			continue
@@ -576,7 +581,7 @@ func (r *rule) meetsRequirementsEgress(ctx *SearchContext, state *traceState) ap
 	return api.Undecided
 }
 
-func mergeL4Egress(ctx *SearchContext, rule api.EgressRule, ruleLabels labels.LabelArray, resMap L4PolicyMap) (int, error) {
+func mergeEgress(ctx *SearchContext, rule api.EgressRule, ruleLabels labels.LabelArray, resMap L4PolicyMap) (int, error) {
 
 	toEndpoints := rule.GetDestinationEndpointSelectors()
 	found := 0
@@ -588,7 +593,7 @@ func mergeL4Egress(ctx *SearchContext, rule api.EgressRule, ruleLabels labels.La
 
 	// L3-only rule
 	if len(rule.ToPorts) == 0 && len(rule.ToRequires) == 0 {
-		cnt, err = mergeL4EgressPort(ctx, toEndpoints, api.PortRule{}, api.PortProtocol{Port: "0", Protocol: api.ProtoAny}, api.ProtoAny, ruleLabels, resMap)
+		cnt, err = mergeEgressPortProto(ctx, toEndpoints, api.PortRule{}, api.PortProtocol{Port: "0", Protocol: api.ProtoAny}, api.ProtoAny, ruleLabels, resMap)
 		if err != nil {
 			return found, err
 		}
@@ -621,19 +626,19 @@ func mergeL4Egress(ctx *SearchContext, rule api.EgressRule, ruleLabels labels.La
 
 		for _, p := range r.Ports {
 			if p.Protocol != api.ProtoAny {
-				cnt, err := mergeL4EgressPort(ctx, toEndpoints, r, p, p.Protocol, ruleLabels, resMap)
+				cnt, err := mergeEgressPortProto(ctx, toEndpoints, r, p, p.Protocol, ruleLabels, resMap)
 				if err != nil {
 					return found, err
 				}
 				found += cnt
 			} else {
-				cnt, err := mergeL4EgressPort(ctx, toEndpoints, r, p, api.ProtoTCP, ruleLabels, resMap)
+				cnt, err := mergeEgressPortProto(ctx, toEndpoints, r, p, api.ProtoTCP, ruleLabels, resMap)
 				if err != nil {
 					return found, err
 				}
 				found += cnt
 
-				cnt, err = mergeL4EgressPort(ctx, toEndpoints, r, p, api.ProtoUDP, ruleLabels, resMap)
+				cnt, err = mergeEgressPortProto(ctx, toEndpoints, r, p, api.ProtoUDP, ruleLabels, resMap)
 				if err != nil {
 					return found, err
 				}
@@ -645,12 +650,12 @@ func mergeL4Egress(ctx *SearchContext, rule api.EgressRule, ruleLabels labels.La
 	return found, nil
 }
 
-// mergeL4EgressPort merges all rules which share the same port & protocol that
+// mergeEgressPortProto merges all rules which share the same port & protocol that
 // select a given set of endpoints. It updates the L4Filter mapped to by the specified
 // port and protocol with the contents of the provided PortRule. If the rule
 // being merged has conflicting L7 rules with those already in the provided
 // L4PolicyMap for the specified port-protocol tuple, it returns an error.
-func mergeL4EgressPort(ctx *SearchContext, endpoints []api.EndpointSelector, r api.PortRule, p api.PortProtocol,
+func mergeEgressPortProto(ctx *SearchContext, endpoints []api.EndpointSelector, r api.PortRule, p api.PortProtocol,
 	proto api.L4Proto, ruleLabels labels.LabelArray, resMap L4PolicyMap) (int, error) {
 
 	key := p.Port + "/" + string(proto)
@@ -664,7 +669,7 @@ func mergeL4EgressPort(ctx *SearchContext, endpoints []api.EndpointSelector, r a
 	// for merging with the filter which is already in the policy map.
 	filterToMerge := CreateL4EgressFilter(endpoints, r, p, proto, ruleLabels)
 
-	if err := mergeL4Port(ctx, endpoints, &existingFilter, &filterToMerge); err != nil {
+	if err := mergePortProto(ctx, endpoints, &existingFilter, &filterToMerge); err != nil {
 		return 0, err
 	}
 	existingFilter.DerivedFromRules = append(existingFilter.DerivedFromRules, ruleLabels)
@@ -672,7 +677,7 @@ func mergeL4EgressPort(ctx *SearchContext, endpoints []api.EndpointSelector, r a
 	return 1, nil
 }
 
-func (r *rule) resolveL4EgressPolicy(ctx *SearchContext, state *traceState, result *L4Policy, requirements []v1.LabelSelectorRequirement) (*L4Policy, error) {
+func (r *rule) resolveEgressPolicy(ctx *SearchContext, state *traceState, result *L4Policy, requirements []v1.LabelSelectorRequirement) (*L4Policy, error) {
 	if !ctx.rulesSelect {
 		if !r.EndpointSelector.Matches(ctx.From) {
 			state.unSelectRule(ctx, ctx.From, r)
@@ -706,7 +711,7 @@ func (r *rule) resolveL4EgressPolicy(ctx *SearchContext, state *traceState, resu
 			}
 			ruleCopy.SetAggregatedSelectors()
 		}
-		cnt, err := mergeL4Egress(ctx, ruleCopy, r.Rule.Labels.DeepCopy(), result.Egress)
+		cnt, err := mergeEgress(ctx, ruleCopy, r.Rule.Labels.DeepCopy(), result.Egress)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -611,6 +611,27 @@ func (r *rule) canReachEgress(ctx *SearchContext, state *traceState) api.Decisio
 	return api.Undecided
 }
 
+// meetsRequirementsEgress returns whether the labels in ctx.To do not
+// meet the requirements in the provided rule. If a rule does meet the
+// requirements in the rule, that does not mean that the rule allows traffic
+// from the labels in ctx.To, merely that the rule does not deny it.
+func (r *rule) meetsRequirementsEgress(ctx *SearchContext, state *traceState) api.Decision {
+
+	state.selectRule(ctx, r)
+	for _, r := range r.Egress {
+		for _, sel := range r.ToRequires {
+			ctx.PolicyTrace("    Requires from labels %+v", sel)
+			if !sel.Matches(ctx.To) {
+				ctx.PolicyTrace("-     Labels %v not found\n", ctx.To)
+				state.constrainedRules++
+				return api.Denied
+			}
+			ctx.PolicyTrace("+     Found all required labels\n")
+		}
+	}
+	return api.Undecided
+}
+
 func mergeL4Egress(ctx *SearchContext, rule api.EgressRule, ruleLabels labels.LabelArray, resMap L4PolicyMap) (int, error) {
 
 	toEndpoints := rule.GetDestinationEndpointSelectors()

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -455,6 +455,48 @@ func (r *rule) canReachIngress(ctx *SearchContext, state *traceState) api.Decisi
 	return api.Undecided
 }
 
+func (r *rule) canReachIngressV2(ctx *SearchContext, state *traceState) api.Decision {
+
+	// assume requirements have already been analyzed.
+	for _, r := range r.Ingress {
+		for _, sel := range r.GetSourceEndpointSelectors() {
+			ctx.PolicyTrace("    Allows from labels %+v", sel)
+			if sel.Matches(ctx.From) {
+				ctx.PolicyTrace("      Found all required labels")
+				if len(r.ToPorts) == 0 {
+					ctx.PolicyTrace("+       No L4 restrictions\n")
+					state.matchedRules++
+					return api.Allowed
+				}
+				ctx.PolicyTrace("        Rule restricts traffic to specific L4 destinations; deferring policy decision to L4 policy stage\n")
+			} else {
+				ctx.PolicyTrace("      Labels %v not found\n", ctx.From)
+			}
+		}
+	}
+	return api.Undecided
+}
+
+// canReachIngress returns the decision as to whether the set of labels specified
+// in ctx.From match with the label selectors specified in the ingress rules
+// contained within r.
+func (r *rule) meetsRequirementsIngress(ctx *SearchContext, state *traceState) api.Decision {
+
+	state.selectRule(ctx, r)
+	for _, r := range r.Ingress {
+		for _, sel := range r.FromRequires {
+			ctx.PolicyTrace("    Requires from labels %+v", sel)
+			if !sel.Matches(ctx.From) {
+				ctx.PolicyTrace("-     Labels %v not found\n", ctx.From)
+				state.constrainedRules++
+				return api.Denied
+			}
+			ctx.PolicyTrace("+     Found all required labels\n")
+		}
+	}
+	return api.Undecided
+}
+
 func (r *rule) matches(id uint16, securityIdentity *identity.Identity) bool {
 	r.metadata.Mutex.Lock()
 	defer r.metadata.Mutex.Unlock()

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -194,11 +194,11 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 
 	ingressState := traceState{}
 	egressState := traceState{}
-	res, err := rule1.resolveL4IngressPolicy(toBar, &ingressState, NewL4Policy(), nil)
+	res, err := rule1.resolveIngressPolicy(toBar, &ingressState, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 
-	res2, err := rule1.resolveL4EgressPolicy(fromBar, &egressState, NewL4Policy(), nil)
+	res2, err := rule1.resolveEgressPolicy(fromBar, &egressState, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res2, Not(IsNil))
 
@@ -215,9 +215,9 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 	ingressState = traceState{}
 	egressState = traceState{}
 
-	res, err = rule1.resolveL4IngressPolicy(toFoo, &ingressState, NewL4Policy(), nil)
+	res, err = rule1.resolveIngressPolicy(toFoo, &ingressState, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
-	res2, err = rule1.resolveL4EgressPolicy(fromFoo, &ingressState, NewL4Policy(), nil)
+	res2, err = rule1.resolveEgressPolicy(fromFoo, &ingressState, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 
 	c.Assert(res, IsNil)
@@ -298,11 +298,11 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 
 	ingressState = traceState{}
 	egressState = traceState{}
-	res, err = rule2.resolveL4IngressPolicy(toBar, &ingressState, NewL4Policy(), nil)
+	res, err = rule2.resolveIngressPolicy(toBar, &ingressState, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 
-	res2, err = rule2.resolveL4EgressPolicy(fromBar, &egressState, NewL4Policy(), nil)
+	res2, err = rule2.resolveEgressPolicy(fromBar, &egressState, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res2, Not(IsNil))
 
@@ -319,11 +319,11 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 	ingressState = traceState{}
 	egressState = traceState{}
 
-	res, err = rule2.resolveL4IngressPolicy(toFoo, &ingressState, NewL4Policy(), nil)
+	res, err = rule2.resolveIngressPolicy(toFoo, &ingressState, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 
-	res2, err = rule2.resolveL4EgressPolicy(fromFoo, &egressState, NewL4Policy(), nil)
+	res2, err = rule2.resolveEgressPolicy(fromFoo, &egressState, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 
@@ -373,7 +373,7 @@ func (ds *PolicyTestSuite) TestMergeL4PolicyIngress(c *C) {
 	}
 
 	state := traceState{}
-	res, err := rule1.resolveL4IngressPolicy(toBar, &state, NewL4Policy(), nil)
+	res, err := rule1.resolveIngressPolicy(toBar, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, checker.DeepEquals, *expected)
@@ -427,7 +427,7 @@ func (ds *PolicyTestSuite) TestMergeL4PolicyEgress(c *C) {
 	}
 
 	state := traceState{}
-	res, err := rule1.resolveL4EgressPolicy(fromBar, &state, NewL4Policy(), nil)
+	res, err := rule1.resolveEgressPolicy(fromBar, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, checker.DeepEquals, *expected)
@@ -505,7 +505,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
 	}
 
 	state := traceState{}
-	res, err := rule1.resolveL4IngressPolicy(toBar, &state, NewL4Policy(), nil)
+	res, err := rule1.resolveIngressPolicy(toBar, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, checker.DeepEquals, *expected)
@@ -513,7 +513,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
 	c.Assert(state.matchedRules, Equals, 0)
 
 	state = traceState{}
-	res, err = rule1.resolveL4IngressPolicy(toFoo, &state, NewL4Policy(), nil)
+	res, err = rule1.resolveIngressPolicy(toFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -570,7 +570,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
 	}
 
 	state = traceState{}
-	res, err = rule2.resolveL4IngressPolicy(toBar, &state, NewL4Policy(), nil)
+	res, err = rule2.resolveIngressPolicy(toBar, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, checker.DeepEquals, *expected)
@@ -578,19 +578,19 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
 	c.Assert(state.matchedRules, Equals, 0)
 
 	state = traceState{}
-	res, err = rule2.resolveL4IngressPolicy(toFoo, &state, NewL4Policy(), nil)
+	res, err = rule2.resolveIngressPolicy(toFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
 	c.Assert(state.matchedRules, Equals, 0)
 
 	// Resolve rule1's policy, then try to add rule2.
-	res, err = rule1.resolveL4IngressPolicy(toBar, &state, NewL4Policy(), nil)
+	res, err = rule1.resolveIngressPolicy(toBar, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 
 	state = traceState{}
-	_, err = rule2.resolveL4IngressPolicy(toBar, &state, res, nil)
+	_, err = rule2.resolveIngressPolicy(toBar, &state, res, nil)
 
 	c.Assert(err, Not(IsNil))
 
@@ -654,7 +654,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
 	}
 
 	state = traceState{}
-	res, err = rule3.resolveL4IngressPolicy(toBar, &state, NewL4Policy(), nil)
+	res, err = rule3.resolveIngressPolicy(toBar, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, checker.DeepEquals, *expected)
@@ -729,7 +729,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 	}
 
 	state := traceState{}
-	res, err := rule1.resolveL4EgressPolicy(fromBar, &state, NewL4Policy(), nil)
+	res, err := rule1.resolveEgressPolicy(fromBar, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, checker.DeepEquals, *expected)
@@ -737,7 +737,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 	c.Assert(state.matchedRules, Equals, 0)
 
 	state = traceState{}
-	res, err = rule1.resolveL4EgressPolicy(fromFoo, &state, NewL4Policy(), nil)
+	res, err = rule1.resolveEgressPolicy(fromFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -802,7 +802,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 	}
 
 	state = traceState{}
-	res, err = rule2.resolveL4EgressPolicy(fromBar, &state, NewL4Policy(), nil)
+	res, err = rule2.resolveEgressPolicy(fromBar, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, checker.DeepEquals, *expected)
@@ -810,14 +810,14 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 	c.Assert(state.matchedRules, Equals, 0)
 
 	state = traceState{}
-	res, err = rule2.resolveL4EgressPolicy(fromFoo, &state, NewL4Policy(), nil)
+	res, err = rule2.resolveEgressPolicy(fromFoo, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
 	c.Assert(state.matchedRules, Equals, 0)
 
 	// Resolve rule1's policy, then try to add rule2.
-	res, err = rule1.resolveL4EgressPolicy(fromBar, &state, NewL4Policy(), nil)
+	res, err = rule1.resolveEgressPolicy(fromBar, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 
@@ -878,7 +878,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 	}
 
 	state = traceState{}
-	res, err = rule3.resolveL4EgressPolicy(fromBar, &state, NewL4Policy(), nil)
+	res, err = rule3.resolveEgressPolicy(fromBar, &state, NewL4Policy(), nil)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, checker.DeepEquals, *expected)
@@ -1518,8 +1518,8 @@ func (ds *PolicyTestSuite) TestL4RuleLabels(c *C) {
 
 			rule := &rule{Rule: apiRule}
 
-			rule.resolveL4IngressPolicy(toBar, &traceState{}, finalPolicy, nil)
-			rule.resolveL4EgressPolicy(fromBar, &traceState{}, finalPolicy, nil)
+			rule.resolveIngressPolicy(toBar, &traceState{}, finalPolicy, nil)
+			rule.resolveEgressPolicy(fromBar, &traceState{}, finalPolicy, nil)
 		}
 
 		c.Assert(len(finalPolicy.Ingress), Equals, len(test.expectedIngressLabels), Commentf(test.description))

--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -43,6 +43,8 @@ loop:
 			}
 		}
 
+		state.selectRule(ctx, r)
+
 		switch r.meetsRequirementsIngress(ctx, &state) {
 		// The rule contained a constraint which was not met; this
 		// connection is not allowed.
@@ -80,6 +82,8 @@ loop:
 				continue
 			}
 		}
+
+		state.selectRule(ctx, r)
 
 		if r.meetsRequirementsIngress(ctx, &state) == api.Denied {
 			decision = api.Denied
@@ -296,6 +300,8 @@ egressLoop:
 			}
 		}
 
+		egressState.selectRule(egressCtx, r)
+
 		switch r.meetsRequirementsEgress(egressCtx, &egressState) {
 		// The rule contained a constraint which was not met; this
 		// connection is not allowed.
@@ -333,6 +339,8 @@ loop:
 				return api.Undecided
 			}
 		}
+
+		state.selectRule(ctx, r)
 
 		if r.meetsRequirementsEgress(ctx, &state) == api.Denied {
 			decision = api.Denied

--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -345,9 +345,10 @@ loop:
 	return decision
 }
 
-// canReachIngress returns the decision as to whether the set of labels specified
-// in ctx.From match with the label selectors specified in the ingress rules
-// contained within r.
+// meetsRequirementsEgress returns whether the labels in ctx.To do not
+// meet the requirements in the provided rule. If a rule does meet the
+// requirements in the rule, that does not mean that the rule allows traffic
+// from the labels in ctx.To, merely that the rule does not deny it.
 func (r *rule) meetsRequirementsEgress(ctx *SearchContext, state *traceState) api.Decision {
 
 	state.selectRule(ctx, r)

--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -345,27 +345,6 @@ loop:
 	return decision
 }
 
-// meetsRequirementsEgress returns whether the labels in ctx.To do not
-// meet the requirements in the provided rule. If a rule does meet the
-// requirements in the rule, that does not mean that the rule allows traffic
-// from the labels in ctx.To, merely that the rule does not deny it.
-func (r *rule) meetsRequirementsEgress(ctx *SearchContext, state *traceState) api.Decision {
-
-	state.selectRule(ctx, r)
-	for _, r := range r.Egress {
-		for _, sel := range r.ToRequires {
-			ctx.PolicyTrace("    Requires from labels %+v", sel)
-			if !sel.Matches(ctx.To) {
-				ctx.PolicyTrace("-     Labels %v not found\n", ctx.To)
-				state.constrainedRules++
-				return api.Denied
-			}
-			ctx.PolicyTrace("+     Found all required labels\n")
-		}
-	}
-	return api.Undecided
-}
-
 // updateEndpointsCaches iterates over a given list of rules to update the cache
 // within the rule which determines whether or not the given identity is
 // selected by that rule. If a rule in the list does select said identity, it is

--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -207,7 +207,7 @@ func (rules ruleSlice) resolveL4IngressPolicy(ctx *SearchContext, revision uint6
 	}
 
 	for _, r := range rules {
-		found, err := r.resolveL4IngressPolicy(ctx, &state, result, requirements)
+		found, err := r.resolveIngressPolicy(ctx, &state, result, requirements)
 		if err != nil {
 			return nil, err
 		}
@@ -251,7 +251,7 @@ func (rules ruleSlice) resolveL4EgressPolicy(ctx *SearchContext, revision uint64
 	state := traceState{}
 	for i, r := range rules {
 		state.ruleID = i
-		found, err := r.resolveL4EgressPolicy(ctx, &state, result, requirements)
+		found, err := r.resolveEgressPolicy(ctx, &state, result, requirements)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -57,7 +57,7 @@ loop:
 			// Do not overwrite 'allowed' verdict with 'undecided' verdict yet.
 			// Can't break here because requirements in rule which was not
 			// analyzed may actually deny traffic.
-			if r.canReachIngressV2(ctx, &state) == api.Allowed {
+			if r.canReachFromEndpoints(ctx, &state) == api.Allowed {
 				decision = api.Allowed
 			}
 		}
@@ -314,7 +314,7 @@ egressLoop:
 			// Do not overwrite 'allowed' verdict with 'undecided' verdict yet.
 			// Can't break here because requirements in rule which was not
 			// analyzed may actually deny traffic.
-			if r.canReachEgressV2(egressCtx, &egressState) == api.Allowed {
+			if r.canReachToEndpoints(egressCtx, &egressState) == api.Allowed {
 				egressDecision = api.Allowed
 			}
 		}

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -1028,7 +1028,7 @@ var _ = Describe("RuntimePolicies", func() {
 			ExpectWithOffset(2, res).ShouldNot(helpers.CMDSuccess(),
 				"unexpectedly able to ping %q", helpers.App2)
 
-			By("Testing egress access to the world")
+			By("Testing egress access to the world from %s", helpers.App1)
 			pingFailures := 0
 			curlFailures := 0
 


### PR DESCRIPTION
This allows for all policy at L3 to be stored in a single construct, and means that all resolved policy is now specified in terms of selectors.
    
Resolution to identities is now done in the translation to PolicyMap keys and in the xDS layer, apart from when requirements are analyzed. Because L3-only policy is computed as part of L4Filter, and we still need to calculate the sets of denied identities for xDS policy, we only need to calculate whether requirements deny specific identities now in `ResolvePolicy`. Do just that, and factor out the code which calculates requirements, as well as analysis of `ToEndpoints` and `FromEndpoints` into separate functions to be reused elsewhere, specifically the policy tracing logic.

This allows us to potentially change how tracing works, since we store computed policy in the L4Filter for L3 as well now, but I've kept it the same for now to reduce the amount of changes in a single PR.

Fixes: #7516 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7536)
<!-- Reviewable:end -->
