### PR TITLE
Minor improvements around bpf map use and testing

### DIFF
--- a/cilium/cmd/helpers.go
+++ b/cilium/cmd/helpers.go
@@ -325,7 +325,10 @@ func parsePolicyUpdateArgsHelper(args []string) (*PolicyUpdateArgs, error) {
 // Adds the entry to the PolicyMap if add is true, otherwise the entry is
 // deleted.
 func updatePolicyKey(pa *PolicyUpdateArgs, add bool) {
-	policyMap, _, err := policymap.OpenOrCreate(pa.path)
+	// The map needs not to be transparently initialized here even if
+	// it's not present for some reason. Triggering map recreation with
+	// OpenOrCreate when some map attribute had changed would be much worse.
+	policyMap, err := policymap.Open(pa.path)
 	if err != nil {
 		Fatalf("Cannot open policymap %q : %s", pa.path, err)
 	}

--- a/pkg/bpf/bpf.go
+++ b/pkg/bpf/bpf.go
@@ -96,9 +96,18 @@ const (
 )
 
 // EnableMapPreAllocation enables BPF map pre-allocation on map types that
-// support it.
+// support it. This does not take effect on existing map although some map
+// types could be recreated later when objCheck() runs.
 func EnableMapPreAllocation() {
 	atomic.StoreUint32(&preAllocateMapSetting, 0)
+}
+
+// DisableMapPreAllocation disables BPF map pre-allocation as a default
+// setting. Some map types enforces pre-alloc strategy so this does not
+// take effect in that case. Also note that this does not take effect on
+// existing map although could be recreated later when objCheck() runs.
+func DisableMapPreAllocation() {
+	atomic.StoreUint32(&preAllocateMapSetting, 1)
 }
 
 // GetPreAllocateMapFlags returns the map flags for map which use conditional

--- a/pkg/bpf/map_linux_test.go
+++ b/pkg/bpf/map_linux_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"unsafe"
 
 	. "gopkg.in/check.v1"
 
@@ -31,19 +32,42 @@ func Test(t *testing.T) { TestingT(t) }
 
 type BPFPrivilegedTestSuite struct{}
 
+type TestKey struct {
+	Key uint32
+}
+type TestValue struct {
+	Value uint32
+}
+
+func (k *TestKey) String() string            { return fmt.Sprintf("key=%d", k.Key) }
+func (k *TestKey) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(k) }
+func (k *TestKey) NewValue() MapValue        { return &TestValue{} }
+
+func (v *TestValue) String() string              { return fmt.Sprintf("value=%d", v.Value) }
+func (v *TestValue) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(v) }
+
+func DumpParserFunc(key []byte, value []byte) (MapKey, MapValue, error) {
+	k, v := TestKey{}, TestValue{}
+
+	if err := ConvertKeyValue(key, value, &k, &v); err != nil {
+		return nil, nil, err
+	}
+	return &k, &v, nil
+}
+
 var _ = Suite(&BPFPrivilegedTestSuite{})
 
 var (
-	maxEntries = 2
+	maxEntries = 16
 
 	testMap = NewMap("cilium_test",
 		MapTypeHash,
-		4,
-		4,
+		int(unsafe.Sizeof(TestKey{})),
+		int(unsafe.Sizeof(TestValue{})),
 		maxEntries,
 		BPF_F_NO_PREALLOC,
 		0,
-		nil)
+		DumpParserFunc).WithCache()
 )
 
 func runTests(m *testing.M) (int, error) {
@@ -71,7 +95,7 @@ func TestMain(m *testing.M) {
 }
 
 func (s *BPFPrivilegedTestSuite) TestGetMapInfo(c *C) {
-	mi, err := GetMapInfo(os.Getpid(), testMap.fd)
+	mi, err := GetMapInfo(os.Getpid(), testMap.GetFd())
 	c.Assert(err, IsNil)
 	c.Assert(&testMap.MapInfo, checker.DeepEquals, mi)
 }
@@ -87,16 +111,262 @@ func (s *BPFPrivilegedTestSuite) TestOpen(c *C) {
 	// existingMap is the same as testMap. Opening should succeed.
 	existingMap := NewMap("cilium_test",
 		MapTypeHash,
-		4,
-		4,
+		int(unsafe.Sizeof(TestKey{})),
+		int(unsafe.Sizeof(TestValue{})),
 		maxEntries,
 		BPF_F_NO_PREALLOC,
 		0,
-		nil)
+		DumpParserFunc).WithCache()
 	err = existingMap.Open()
 	c.Check(err, IsNil)      // Avoid assert to ensure Close() is called below.
 	err = existingMap.Open() // Reopen should be no-op.
 	c.Check(err, IsNil)
 	err = existingMap.Close()
 	c.Assert(err, IsNil)
+}
+
+func (s *BPFPrivilegedTestSuite) TestOpenMap(c *C) {
+	openedMap, err := OpenMap("cilium_test_no_exist")
+	c.Assert(err, Not(IsNil))
+	c.Assert(openedMap, IsNil)
+
+	openedMap, err = OpenMap("cilium_test")
+	noDiff := openedMap.DeepEquals(testMap)
+	c.Assert(noDiff, Equals, true)
+	c.Assert(err, IsNil)
+}
+
+func (s *BPFPrivilegedTestSuite) TestOpenOrCreate(c *C) {
+	// existingMap is the same as testMap. OpenOrCreate should skip recreation.
+	existingMap := NewMap("cilium_test",
+		MapTypeHash,
+		int(unsafe.Sizeof(TestKey{})),
+		int(unsafe.Sizeof(TestValue{})),
+		maxEntries,
+		BPF_F_NO_PREALLOC,
+		0,
+		DumpParserFunc).WithCache()
+	isNew, err := existingMap.OpenOrCreate()
+	c.Assert(err, IsNil)
+	c.Assert(isNew, Equals, false)
+
+	// preallocMap unsets BPF_F_NO_PREALLOC. OpenOrCreate should recreate map.
+	EnableMapPreAllocation() // prealloc on/off is controllable in HASH map case.
+	preallocMap := NewMap("cilium_test",
+		MapTypeHash,
+		int(unsafe.Sizeof(TestKey{})),
+		int(unsafe.Sizeof(TestValue{})),
+		maxEntries,
+		0,
+		0,
+		DumpParserFunc).WithCache()
+	isNew, err = preallocMap.OpenOrCreate()
+	defer preallocMap.Close()
+	c.Assert(err, IsNil)
+	c.Assert(isNew, Equals, true)
+	DisableMapPreAllocation()
+
+	// preallocMap is already open. OpenOrCreate does nothing.
+	isNew, err = preallocMap.OpenOrCreate()
+	c.Assert(err, IsNil)
+	c.Assert(isNew, Equals, false)
+}
+
+func (s *BPFPrivilegedTestSuite) TestOpenParallel(c *C) {
+	parallelMap := NewMap("cilium_test",
+		MapTypeHash,
+		int(unsafe.Sizeof(TestKey{})),
+		int(unsafe.Sizeof(TestValue{})),
+		maxEntries,
+		BPF_F_NO_PREALLOC,
+		0,
+		DumpParserFunc).WithCache()
+	isNew, err := parallelMap.OpenParallel()
+	defer parallelMap.Close()
+	c.Assert(err, IsNil)
+	c.Assert(isNew, Equals, true)
+
+	isNew, err = parallelMap.OpenParallel()
+	c.Assert(isNew, Equals, false)
+	c.Assert(err, Not(IsNil))
+
+	noDiff := parallelMap.DeepEquals(testMap)
+	c.Assert(noDiff, Equals, true)
+
+	key1 := &TestKey{Key: 101}
+	value1 := &TestValue{Value: 201}
+	key2 := &TestKey{Key: 102}
+	value2 := &TestValue{Value: 202}
+
+	err = testMap.Update(key1, value1)
+	c.Assert(err, IsNil)
+	err = parallelMap.Update(key2, value2)
+	c.Assert(err, IsNil)
+
+	value, err := testMap.Lookup(key1)
+	c.Assert(err, IsNil)
+	c.Assert(value, checker.DeepEquals, value1)
+	value, err = testMap.Lookup(key2)
+	c.Assert(err, Not(IsNil))
+	c.Assert(value, IsNil)
+
+	value, err = parallelMap.Lookup(key1)
+	c.Assert(err, Not(IsNil))
+	c.Assert(value, IsNil)
+	value, err = parallelMap.Lookup(key2)
+	c.Assert(err, IsNil)
+	c.Assert(value, checker.DeepEquals, value2)
+
+	err = parallelMap.EndParallelMode()
+	c.Assert(err, IsNil)
+	err = parallelMap.EndParallelMode()
+	c.Assert(err, Not(IsNil))
+}
+
+func (s *BPFPrivilegedTestSuite) TestBasicManipulation(c *C) {
+	// existingMap is the same as testMap. Opening should succeed.
+	existingMap := NewMap("cilium_test",
+		MapTypeHash,
+		int(unsafe.Sizeof(TestKey{})),
+		int(unsafe.Sizeof(TestValue{})),
+		maxEntries,
+		BPF_F_NO_PREALLOC,
+		0,
+		DumpParserFunc).WithCache()
+	err := existingMap.Open()
+	defer existingMap.Close()
+	c.Assert(err, IsNil)
+
+	key1 := &TestKey{Key: 103}
+	value1 := &TestValue{Value: 203}
+	key2 := &TestKey{Key: 104}
+	value2 := &TestValue{Value: 204}
+
+	err = existingMap.Update(key1, value1)
+	c.Assert(err, IsNil)
+	// key    val
+	// 103    203
+	value, err := existingMap.Lookup(key1)
+	c.Assert(err, IsNil)
+	c.Assert(value, checker.DeepEquals, value1)
+	value, err = existingMap.Lookup(key2)
+	c.Assert(err, Not(IsNil))
+	c.Assert(value, Equals, nil)
+
+	err = existingMap.Update(key1, value2)
+	c.Assert(err, IsNil)
+	// key    val
+	// 103    204
+	value, err = existingMap.Lookup(key1)
+	c.Assert(err, IsNil)
+	c.Assert(value, checker.DeepEquals, value2)
+
+	err = existingMap.Update(key2, value2)
+	c.Assert(err, IsNil)
+	// key    val
+	// 103    204
+	// 104    204
+	value, err = existingMap.Lookup(key1)
+	c.Assert(err, IsNil)
+	c.Assert(value, checker.DeepEquals, value2)
+	value, err = existingMap.Lookup(key2)
+	c.Assert(err, IsNil)
+	c.Assert(value, checker.DeepEquals, value2)
+
+	err = existingMap.Delete(key1)
+	c.Assert(err, IsNil)
+	// key    val
+	// 104    204
+	value, err = existingMap.Lookup(key1)
+	c.Assert(err, Not(IsNil))
+	c.Assert(value, Equals, nil)
+
+	err = existingMap.DeleteAll()
+	c.Assert(err, IsNil)
+	value, err = existingMap.Lookup(key1)
+	c.Assert(err, Not(IsNil))
+	c.Assert(value, Equals, nil)
+	err = existingMap.DeleteAll()
+	c.Assert(err, IsNil)
+}
+
+func (s *BPFPrivilegedTestSuite) TestDump(c *C) {
+	key1 := &TestKey{Key: 105}
+	value1 := &TestValue{Value: 205}
+	key2 := &TestKey{Key: 106}
+	value2 := &TestValue{Value: 206}
+
+	err := testMap.Update(key1, value1)
+	c.Assert(err, IsNil)
+	err = testMap.Update(key2, value1)
+	c.Assert(err, IsNil)
+	err = testMap.Update(key2, value2)
+	c.Assert(err, IsNil)
+
+	dump1 := map[string][]string{}
+	testMap.Dump(dump1)
+	c.Assert(dump1, checker.DeepEquals, map[string][]string{
+		"key=105": []string{"value=205"},
+		"key=106": []string{"value=206"},
+	})
+
+	dump2 := map[string][]string{}
+	customCb := func(key MapKey, value MapValue) {
+		dump2[key.String()] = append(dump2[key.String()], "custom-"+value.String())
+	}
+	testMap.DumpWithCallback(customCb)
+	c.Assert(dump2, checker.DeepEquals, map[string][]string{
+		"key=105": []string{"custom-value=205"},
+		"key=106": []string{"custom-value=206"},
+	})
+
+	dump3 := map[string][]string{}
+	noSuchMap := NewMap("cilium_test_no_exist",
+		MapTypeHash, 4, 4, maxEntries, 0, 0, nil)
+	err = noSuchMap.DumpIfExists(dump3)
+	c.Assert(err, IsNil)
+	c.Assert(len(dump3), Equals, 0)
+}
+
+func (s *BPFPrivilegedTestSuite) TestGetModel(c *C) {
+	model := testMap.GetModel()
+	c.Assert(model, Not(IsNil))
+}
+
+func (s *BPFPrivilegedTestSuite) TestCheckAndUpgrade(c *C) {
+	// CheckAndUpgrade removes map file if upgrade is needed
+	// so we setup and use another map.
+	upgradeMap := NewMap("cilium_test_upgrade",
+		MapTypeHash,
+		int(unsafe.Sizeof(TestKey{})),
+		int(unsafe.Sizeof(TestValue{})),
+		maxEntries,
+		BPF_F_NO_PREALLOC,
+		0,
+		DumpParserFunc).WithCache()
+	_, err := upgradeMap.OpenOrCreate()
+	c.Assert(err, IsNil)
+	defer func() {
+		path, _ := upgradeMap.Path()
+		os.Remove(path)
+	}()
+	defer upgradeMap.Close()
+
+	// Exactly the same MapInfo so it won't be upgraded.
+	upgrade := upgradeMap.CheckAndUpgrade(&upgradeMap.MapInfo)
+	c.Assert(upgrade, Equals, false)
+
+	// preallocMap unsets BPF_F_NO_PREALLOC so upgrade is needed.
+	EnableMapPreAllocation()
+	preallocMap := NewMap("cilium_test_upgrade",
+		MapTypeHash,
+		int(unsafe.Sizeof(TestKey{})),
+		int(unsafe.Sizeof(TestValue{})),
+		maxEntries,
+		0,
+		0,
+		DumpParserFunc).WithCache()
+	upgrade = upgradeMap.CheckAndUpgrade(&preallocMap.MapInfo)
+	c.Assert(upgrade, Equals, true)
+	DisableMapPreAllocation()
 }


### PR DESCRIPTION
This PR prevents unexpected map regeneration triggered by user command and increases test coverage as well. Without this patch, the documentation for ConfigMap ``preallocate-bpf-maps`` option would have to be edited (see: https://github.com/cilium/cilium/blame/1d6f46b74074e40d61e8a09fcc3b09ad3445349a/Documentation/install/upgrade.rst#L338). Test coverage for map_linux increases 2% -> 61.3%.

Fixes: #7386 

```release-note
Fix possible map deletion via `cilium bpf policy { add | delete }`
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7538)
<!-- Reviewable:end -->
