### PR TITLE
policy: Add selector cache

### DIFF
--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/eventqueue"
+	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -66,6 +67,13 @@ func (d *Daemon) TriggerPolicyUpdates(force bool, reason string) {
 	}
 
 	d.policyTrigger.TriggerWithReason(reason)
+}
+
+// UpdateIdentities informs the policy package of all identity changes
+// and also triggers policy updates.
+func (d *Daemon) UpdateIdentities(added, deleted cache.IdentityCache) {
+	policy.UpdateIdentities(added, deleted)
+	d.TriggerPolicyUpdates(true, "one or more identities created or deleted")
 }
 
 type getPolicyResolve struct {

--- a/pkg/clustermesh/clustermesh_test.go
+++ b/pkg/clustermesh/clustermesh_test.go
@@ -99,8 +99,7 @@ func (o *testObserver) OnDelete(k store.NamedKey) {
 
 type identityAllocatorOwnerMock struct{}
 
-func (i *identityAllocatorOwnerMock) TriggerPolicyUpdates(force bool, reason string) {
-}
+func (i *identityAllocatorOwnerMock) UpdateIdentities(added, deleted cache.IdentityCache) {}
 
 func (i *identityAllocatorOwnerMock) GetNodeSuffix() string {
 	return "foo"

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -47,7 +47,7 @@ var _ = Suite(&EndpointSuite{})
 
 type testIdentityAllocator struct{}
 
-func (t *testIdentityAllocator) TriggerPolicyUpdates(bool, string) {}
+func (t *testIdentityAllocator) UpdateIdentities(added, deleted cache.IdentityCache) {}
 
 func (t *testIdentityAllocator) GetNodeSuffix() string { return "foo" }
 

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -78,9 +78,8 @@ var (
 // IdentityAllocatorOwner is the interface the owner of an identity allocator
 // must implement
 type IdentityAllocatorOwner interface {
-	// TriggerPolicyUpdates will be called whenever a policy recalculation
-	// must be triggered
-	TriggerPolicyUpdates(force bool, reason string)
+	// UpdateIdentities will be called when identities have changed
+	UpdateIdentities(added, deleted IdentityCache)
 
 	// GetSuffix must return the node specific suffix to use
 	GetNodeSuffix() string

--- a/pkg/identity/cache/cache.go
+++ b/pkg/identity/cache/cache.go
@@ -103,26 +103,92 @@ type identityWatcher struct {
 	stopChan chan bool
 }
 
+func collectEvent(event allocator.AllocatorEvent, added, deleted IdentityCache) bool {
+	id := identity.NumericIdentity(event.ID)
+	// Only create events have the key
+	if event.Typ == kvstore.EventTypeCreate {
+		if gi, ok := event.Key.(globalIdentity); ok {
+			// Un-delete the added ID if previously
+			// 'deleted' so that collected events can be
+			// processed in any order.
+			if _, exists := deleted[id]; exists {
+				delete(deleted, id)
+			}
+			added[id] = gi.LabelArray
+			return true
+		}
+		log.Warningf("collectEvent: Ignoring unknown identity type '%s': %+v",
+			reflect.TypeOf(event.Key), event.Key)
+		return false
+	}
+	// Reverse an add when subsequently deleted
+	if _, exists := added[id]; exists {
+		delete(added, id)
+	}
+	// record the id deleted even if an add was reversed, as the
+	// id may also have previously existed, in which case the
+	// result is not no-op!
+	deleted[id] = labels.LabelArray{}
+
+	return true
+}
+
 // watch starts the identity watcher
 func (w *identityWatcher) watch(owner IdentityAllocatorOwner, events allocator.AllocatorEventChan) {
 	w.stopChan = make(chan bool)
 
 	go func() {
 		for {
-			select {
-			case event := <-events:
+			added := IdentityCache{}
+			deleted := IdentityCache{}
 
-				switch event.Typ {
-				case kvstore.EventTypeCreate, kvstore.EventTypeDelete:
-					owner.TriggerPolicyUpdates(true, "one or more identities created or deleted")
-
-				case kvstore.EventTypeModify:
-					// Ignore modify events
+		First:
+			for {
+				// Wait for one identity add or delete or stop
+				select {
+				case event, ok := <-events:
+					if !ok {
+						// 'events' was closed
+						return
+					}
+					// Collect first added and deleted labels
+					switch event.Typ {
+					case kvstore.EventTypeCreate, kvstore.EventTypeDelete:
+						if collectEvent(event, added, deleted) {
+							// First event collected
+							break First
+						}
+					default:
+						// Ignore modify events
+					}
+				case <-w.stopChan:
+					return
 				}
-
-			case <-w.stopChan:
-				return
 			}
+
+		More:
+			for {
+				// see if there is more, but do not wait nor stop
+				select {
+				case event, ok := <-events:
+					if !ok {
+						// 'events' was closed
+						break More
+					}
+					// Collect more added and deleted labels
+					switch event.Typ {
+					case kvstore.EventTypeCreate, kvstore.EventTypeDelete:
+						collectEvent(event, added, deleted)
+					default:
+						// Ignore modify events
+					}
+				default:
+					// No more events available without blocking
+					break More
+				}
+			}
+			// Issue collected updates
+			owner.UpdateIdentities(added, deleted)
 		}
 	}()
 }

--- a/pkg/identity/cache/local.go
+++ b/pkg/identity/cache/local.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/idpool"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/allocator"
 	"github.com/cilium/cilium/pkg/labels"
@@ -104,6 +105,8 @@ func (l *localIdentityCache) lookupOrCreate(lbls labels.Labels) (*identity.Ident
 	if l.events != nil {
 		l.events <- allocator.AllocatorEvent{
 			Typ: kvstore.EventTypeCreate,
+			ID:  idpool.ID(id.ID),
+			Key: globalIdentity{id.LabelArray},
 		}
 	}
 
@@ -134,6 +137,7 @@ func (l *localIdentityCache) release(id *identity.Identity) bool {
 			if l.events != nil {
 				l.events <- allocator.AllocatorEvent{
 					Typ: kvstore.EventTypeDelete,
+					ID:  idpool.ID(id.ID),
 				}
 			}
 

--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -1,0 +1,341 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	"sort"
+	"sync/atomic"
+	"unsafe"
+
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/policy/api"
+
+	"github.com/sirupsen/logrus"
+)
+
+// CachedSelector represents an identity selector owned by the selector cache
+type CachedSelector interface {
+	// GetSelections returns the cached set of numeric identities
+	// selected by the CachedSelector.  The retuned slice must NOT
+	// be modified, as it is shared among multiple users.
+	GetSelections() []identity.NumericIdentity
+
+	// String returns the string representation of this selector.
+	// Used as a map key.
+	String() string
+}
+
+// CachedSelectionUser inserts selectors into the cache and gets update
+// callbacks whenever the set of selected numeric identities change for
+// the CachedSelectors pushed by it.
+type CachedSelectionUser interface {
+	// IdentitySelectionUpdated implementations MUST NOT call back
+	// to selector cache while executing this function!
+	IdentitySelectionUpdated(selector CachedSelector, selections, added, deleted []identity.NumericIdentity)
+}
+
+// identitySelector is the internal interface for all selectors in the
+// selector cache.
+//
+// identitySelector represents the mapping of an EndpointSelector
+// to a slice of identities. These mappings are updated via two
+// different processes:
+//
+// 1. When policy rules are changed these are added and/or deleted
+// depending on what selectors the rules contain. Cached selections of
+// new identitySelectors are pre-populated from the set of currently
+// known identities.
+//
+// 2. When reachacble identities appear or disappear, either via local
+// allocation (CIDRs), or via the KV-store (remote endpoints). In this
+// case all existing identitySelectors are walked through and their
+// cached selections are updated as necessary.
+//
+// In both of the above cases the set of existing identitySelectors is
+// write locked.
+//
+// To minimize the upkeep the identity selectors are shared accross
+// all IdentityPolicies, so that only one copy exists for each
+// identitySelector. Users of the SelectorCache take care of creating
+// identitySelectors as needed by identity policies. The set of
+// identitySelectors is read locked during an IdentityPolicy update so
+// that the the policy is always updated using a coherent set of
+// cached selections.
+//
+// identitySelector is used as a map key, so it must not be implemented by a
+// map, slice, or a func, or a runtime panic will be triggered. In all
+// cases below identitySelector is being implemented by structs.
+type identitySelector interface {
+	CachedSelector
+	addUser(CachedSelectionUser) (added bool)
+	removeUser(CachedSelectionUser) (last bool)
+	notifyUsers(added, deleted []identity.NumericIdentity)
+}
+
+// SelectorCache caches identities, identity selectors, and the
+// subsets of identities each selector selects.
+type SelectorCache struct {
+	mutex lock.RWMutex
+
+	// idCache contains all known identities as informed by the
+	// kv-store and the local identity facility via our
+	// UpdateIdentities() function.
+	idCache cache.IdentityCache
+
+	// map key is the string representation of the selector being cached.
+	selectors map[string]identitySelector
+}
+
+// newSelectorCache creates a new SelectorCache.
+func newSelectorCache() *SelectorCache {
+	return &SelectorCache{
+		idCache:   cache.GetIdentityCache(),
+		selectors: make(map[string]identitySelector),
+	}
+}
+
+var (
+	// selectorCache is the global selector cache. Additional ones
+	// are only created for testing.
+	selectorCache = newSelectorCache()
+	// Empty slice of numeric identities used for all selectors that select nothing
+	emptySelection []identity.NumericIdentity
+)
+
+type labelIdentitySelector struct {
+	selector         api.EndpointSelector
+	key              string
+	users            map[CachedSelectionUser]struct{}
+	selections       unsafe.Pointer // *[]identity.NumericIdentity
+	cachedSelections map[identity.NumericIdentity]struct{}
+}
+
+//
+// CachedSelector implementation (== Public API)
+//
+// No locking needed.
+//
+
+// GetSelections returns the set of numeric identities currently
+// selected.  The cached selections can be concurrently updated. In
+// that case GetSelections() will return either the old or new version
+// of the selections. If the old version is returned, the user is
+// guaranteed to receive a notification including the update.
+func (l *labelIdentitySelector) GetSelections() []identity.NumericIdentity {
+	return *(*[]identity.NumericIdentity)(atomic.LoadPointer(&l.selections))
+}
+
+// String returns the map key for this selector
+func (l *labelIdentitySelector) String() string {
+	return l.key
+}
+
+//
+// identitySelector implemenentation (== internal API)
+//
+
+// lock must be held
+func (l *labelIdentitySelector) addUser(user CachedSelectionUser) (added bool) {
+	if _, exists := l.users[user]; exists {
+		return false
+	}
+	l.users[user] = struct{}{}
+	return true
+}
+
+// lock must be held
+func (l *labelIdentitySelector) removeUser(user CachedSelectionUser) (last bool) {
+	delete(l.users, user)
+	return len(l.users) == 0
+}
+
+// lock must be held
+func (l *labelIdentitySelector) notifyUsers(added, deleted []identity.NumericIdentity) {
+	for user := range l.users {
+		user.IdentitySelectionUpdated(l, l.GetSelections(), added, deleted)
+	}
+}
+
+func (l *labelIdentitySelector) setSelections(selections *[]identity.NumericIdentity) {
+	if len(*selections) > 0 {
+		atomic.StorePointer(&l.selections, unsafe.Pointer(selections))
+	} else {
+		atomic.StorePointer(&l.selections, unsafe.Pointer(&emptySelection))
+	}
+}
+
+// updateSelections updates the immutable slice representation of the
+// cached selections after the cached selections have been changed.
+//
+// lock must be held
+func (l *labelIdentitySelector) updateSelections() {
+	selections := make([]identity.NumericIdentity, len(l.cachedSelections))
+	i := 0
+	for nid := range l.cachedSelections {
+		selections[i] = nid
+		i++
+	}
+	// Sort the numeric identities so that the map iteration order
+	// does not matter. This makes testing easier, but may help
+	// identifying changes easier also otherwise.
+	sort.Slice(selections, func(i, j int) bool {
+		return selections[i] < selections[j]
+	})
+	l.setSelections(&selections)
+}
+
+type fqdnSelector struct {
+	labelIdentitySelector
+	// fqdnSelections map[string]identity.NumericIdentity // identity.String(): "cidr:1.1.1.1" -> identity of 1.1.1.1
+}
+
+// AddIdentitySelector adds the given api.EndpointSelector in to the
+// selector cache. If an identical EndpointSelector has already been
+// cached, the corresponding CachedSelector is returned, otherwise one
+// is created and added to the cache.
+func (sc *SelectorCache) AddIdentitySelector(user CachedSelectionUser, selector api.EndpointSelector) (cachedSelector CachedSelector, added bool) {
+	// The key returned here may be different for equivalent
+	// labelselectors, if the selector's requirements are stored
+	// in different orders. When this happens we'll be tracking
+	// essentially two copies of the same selector.
+	key := selector.LabelSelector.String()
+	sc.mutex.Lock()
+	defer sc.mutex.Unlock()
+	idSel, exists := sc.selectors[key]
+	if exists {
+		return idSel, idSel.addUser(user)
+	}
+
+	// Selectors are never modified once a rule is placed in the policy repository,
+	// so no need to copy.
+
+	// TODO: FQDNSelector
+
+	newIDSel := &labelIdentitySelector{
+		key:              key,
+		users:            make(map[CachedSelectionUser]struct{}),
+		selector:         selector,
+		cachedSelections: make(map[identity.NumericIdentity]struct{}),
+	}
+
+	// Add the initial user
+	newIDSel.users[user] = struct{}{}
+
+	// Find all matching identities from the identity cache.
+	for numericID, lbls := range sc.idCache {
+		if selector.Matches(lbls) {
+			newIDSel.cachedSelections[numericID] = struct{}{}
+		}
+	}
+	// Create the immutable slice representation of the selected
+	// numeric identities
+	newIDSel.updateSelections()
+
+	// Note: No notifications are sent for the existing
+	// identities. Caller must use GetSelections() to get the
+	// current selections after adding a selector. This way the
+	// behavior is the same between the two cases here (selector
+	// is already cached, or is a new one).
+
+	sc.selectors[key] = newIDSel
+	return newIDSel, true
+}
+
+// RemoveIdentitySelector removes CachedSelector for the user.
+func (sc *SelectorCache) RemoveIdentitySelector(user CachedSelectionUser, selector CachedSelector) {
+	key := selector.String()
+	sc.mutex.Lock()
+	defer sc.mutex.Unlock()
+	idSel, exists := sc.selectors[key]
+	if exists {
+		if idSel.removeUser(user) {
+			delete(sc.selectors, key)
+		}
+	}
+}
+
+// UpdateIdentities propagates identity updates to selectors
+func (sc *SelectorCache) UpdateIdentities(added, deleted cache.IdentityCache) {
+	sc.mutex.Lock()
+	defer sc.mutex.Unlock()
+
+	// Update idCache so that newly added selectors get
+	// prepopulated with all matching numeric identities.
+	for numericID := range deleted {
+		if _, exists := sc.idCache[numericID]; exists {
+			delete(sc.idCache, numericID)
+		} else {
+			log.WithFields(logrus.Fields{logfields.Identity: numericID}).Warning("UpdateIdentities: Deleting a non-existing identity")
+		}
+	}
+	for numericID, lbls := range added {
+		if _, exists := sc.idCache[numericID]; exists {
+			log.WithFields(logrus.Fields{logfields.Identity: numericID}).Warning("UpdateIdentities: Adding an existing identity")
+		}
+		sc.idCache[numericID] = lbls
+	}
+
+	// Iterate through all locally used identity selectors and
+	// update the cached numeric identities as required.
+	for _, sel := range sc.selectors {
+		var adds, dels []identity.NumericIdentity
+		switch idSel := sel.(type) {
+		case *labelIdentitySelector:
+			for numericID := range deleted {
+				if _, exists := idSel.cachedSelections[numericID]; exists {
+					dels = append(dels, numericID)
+					delete(idSel.cachedSelections, numericID)
+				}
+			}
+			for numericID, lbls := range added {
+				if _, exists := idSel.cachedSelections[numericID]; !exists {
+					if idSel.selector.Matches(lbls) {
+						adds = append(adds, numericID)
+						idSel.cachedSelections[numericID] = struct{}{}
+					}
+				}
+			}
+			if len(dels)+len(adds) > 0 {
+				idSel.updateSelections()
+				idSel.notifyUsers(adds, dels)
+			}
+		case *fqdnSelector:
+			// TODO
+		}
+	}
+}
+
+// Export global functions to interface with the global selector cache
+
+// AddIdentitySelector adds the given api.EndpointSelector in to the
+// selector cache. If an identical EndpointSelector has already been
+// cached, the corresponding CachedSelector is returned, otherwise one
+// is created and added to the cache.
+func AddIdentitySelector(user CachedSelectionUser, selector api.EndpointSelector) (cachedSelector CachedSelector, added bool) {
+	return selectorCache.AddIdentitySelector(user, selector)
+}
+
+// RemoveIdentitySelector removes CachedSelector for the user.
+func RemoveIdentitySelector(user CachedSelectionUser, selector CachedSelector) {
+	selectorCache.RemoveIdentitySelector(user, selector)
+}
+
+// UpdateIdentities propagates identity updates to selectors
+func UpdateIdentities(added, deleted cache.IdentityCache) {
+	selectorCache.UpdateIdentities(added, deleted)
+}

--- a/pkg/policy/selectorcache_test.go
+++ b/pkg/policy/selectorcache_test.go
@@ -1,0 +1,310 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package policy
+
+import (
+	"github.com/cilium/cilium/pkg/checker"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/policy/api"
+
+	. "gopkg.in/check.v1"
+)
+
+type SelectorCacheTestSuite struct{}
+
+var _ = Suite(&SelectorCacheTestSuite{})
+
+type cachedSelectionUser struct {
+	c             *C
+	sc            *SelectorCache
+	name          string
+	selections    map[CachedSelector][]identity.NumericIdentity
+	notifications int
+	adds          int
+	deletes       int
+}
+
+func newUser(c *C, name string, sc *SelectorCache) *cachedSelectionUser {
+	return &cachedSelectionUser{
+		c:          c,
+		sc:         sc,
+		name:       name,
+		selections: make(map[CachedSelector][]identity.NumericIdentity),
+	}
+}
+
+func haveNid(nid identity.NumericIdentity, selections []identity.NumericIdentity) bool {
+	for i := range selections {
+		if selections[i] == nid {
+			return true
+		}
+	}
+	return false
+}
+
+func (csu *cachedSelectionUser) AddIdentitySelector(sel api.EndpointSelector) CachedSelector {
+	notifications := csu.notifications
+	cached, added := csu.sc.AddIdentitySelector(csu, sel)
+	csu.c.Assert(cached, Not(Equals), nil)
+
+	_, exists := csu.selections[cached]
+	// Not added if already exists for this user
+	csu.c.Assert(added, Equals, !exists)
+	csu.selections[cached] = cached.GetSelections()
+
+	// Pre-existing selections are not notified as updates
+	csu.c.Assert(csu.notifications, Equals, notifications)
+
+	return cached
+}
+
+func (csu *cachedSelectionUser) RemoveIdentitySelector(sel CachedSelector) {
+	notifications := csu.notifications
+	csu.sc.RemoveIdentitySelector(csu, sel)
+	delete(csu.selections, sel)
+
+	// No notifications for a removed selector
+	csu.c.Assert(csu.notifications, Equals, notifications)
+}
+
+func (csu *cachedSelectionUser) IdentitySelectionUpdated(selector CachedSelector, selections, added, deleted []identity.NumericIdentity) {
+	csu.notifications++
+	csu.adds += len(added)
+	csu.deletes += len(deleted)
+
+	// Validate added & deleted against the selections
+	for _, add := range added {
+		csu.c.Assert(haveNid(add, selections), Equals, true)
+	}
+	for _, del := range deleted {
+		csu.c.Assert(haveNid(del, selections), Equals, false)
+	}
+
+	// update selections
+	csu.selections[selector] = selections
+}
+
+func (ds *SelectorCacheTestSuite) SetUpTest(c *C) {
+}
+
+func (ds *SelectorCacheTestSuite) TearDownTest(c *C) {
+}
+
+func (ds *SelectorCacheTestSuite) TestAddRemoveIdentitySelector(c *C) {
+	sc := newSelectorCache()
+	// Add some identities to the identity cache
+	sc.UpdateIdentities(cache.IdentityCache{
+		1234: labels.Labels{"app": labels.NewLabel("app", "test", labels.LabelSourceK8s)}.LabelArray(),
+		2345: labels.Labels{"app": labels.NewLabel("app", "test2", labels.LabelSourceK8s)}.LabelArray(),
+	}, nil)
+
+	testSelector := api.NewESFromLabels(labels.NewLabel("app", "test", labels.LabelSourceK8s))
+
+	user1 := newUser(c, "user1", sc)
+	cached := user1.AddIdentitySelector(testSelector)
+
+	// Current selections contain the numeric identities of existing identities that match
+	selections := cached.GetSelections()
+	c.Assert(len(selections), Equals, 1)
+	c.Assert(selections[0], Equals, identity.NumericIdentity(1234))
+
+	// Try add the same selector from the same user the second time
+	testSelector = api.NewESFromLabels(labels.NewLabel("app", "test", labels.LabelSourceK8s))
+	cached2 := user1.AddIdentitySelector(testSelector)
+	c.Assert(cached2, Equals, cached)
+
+	// Add the same selector from a different user
+	testSelector = api.NewESFromLabels(labels.NewLabel("app", "test", labels.LabelSourceK8s))
+	user2 := newUser(c, "user2", sc)
+	cached3 := user2.AddIdentitySelector(testSelector)
+
+	// Same old CachedSelector is returned, nothing new is cached
+	c.Assert(cached3, Equals, cached)
+
+	// Removing the first user does not remove the cached selector
+	user1.RemoveIdentitySelector(cached)
+	// Remove is idempotent
+	user1.RemoveIdentitySelector(cached)
+
+	// Removing the last user removes the cached selector
+	user2.RemoveIdentitySelector(cached3)
+	// Remove is idempotent
+	user2.RemoveIdentitySelector(cached3)
+
+	// All identities removed
+	c.Assert(len(sc.selectors), Equals, 0)
+}
+
+func (ds *SelectorCacheTestSuite) TestMultipleIdentitySelectors(c *C) {
+	sc := newSelectorCache()
+	// Add some identities to the identity cache
+	sc.UpdateIdentities(cache.IdentityCache{
+		1234: labels.Labels{"app": labels.NewLabel("app", "test", labels.LabelSourceK8s)}.LabelArray(),
+		2345: labels.Labels{"app": labels.NewLabel("app", "test2", labels.LabelSourceK8s)}.LabelArray(),
+	}, nil)
+
+	testSelector := api.NewESFromLabels(labels.NewLabel("app", "test", labels.LabelSourceK8s))
+	test2Selector := api.NewESFromLabels(labels.NewLabel("app", "test2", labels.LabelSourceK8s))
+
+	user1 := newUser(c, "user1", sc)
+	cached := user1.AddIdentitySelector(testSelector)
+
+	// Current selections contain the numeric identities of existing identities that match
+	selections := cached.GetSelections()
+	c.Assert(len(selections), Equals, 1)
+	c.Assert(selections[0], Equals, identity.NumericIdentity(1234))
+
+	// Add another selector from the same user
+	cached2 := user1.AddIdentitySelector(test2Selector)
+	c.Assert(cached2, Not(Equals), cached)
+
+	// Current selections contain the numeric identities of existing identities that match
+	selections2 := cached2.GetSelections()
+	c.Assert(len(selections2), Equals, 1)
+	c.Assert(selections2[0], Equals, identity.NumericIdentity(2345))
+
+	user1.RemoveIdentitySelector(cached)
+	user1.RemoveIdentitySelector(cached2)
+
+	// All identities removed
+	c.Assert(len(sc.selectors), Equals, 0)
+}
+
+func (ds *SelectorCacheTestSuite) TestIdentityUpdates(c *C) {
+	sc := newSelectorCache()
+	// Add some identities to the identity cache
+	sc.UpdateIdentities(cache.IdentityCache{
+		1234: labels.Labels{"app": labels.NewLabel("app", "test", labels.LabelSourceK8s)}.LabelArray(),
+		2345: labels.Labels{"app": labels.NewLabel("app", "test2", labels.LabelSourceK8s)}.LabelArray(),
+	}, nil)
+
+	testSelector := api.NewESFromLabels(labels.NewLabel("app", "test", labels.LabelSourceK8s))
+	test2Selector := api.NewESFromLabels(labels.NewLabel("app", "test2", labels.LabelSourceK8s))
+
+	user1 := newUser(c, "user1", sc)
+	cached := user1.AddIdentitySelector(testSelector)
+
+	// Current selections contain the numeric identities of existing identities that match
+	selections := cached.GetSelections()
+	c.Assert(len(selections), Equals, 1)
+	c.Assert(selections[0], Equals, identity.NumericIdentity(1234))
+
+	// Add another selector from the same user
+	cached2 := user1.AddIdentitySelector(test2Selector)
+	c.Assert(cached2, Not(Equals), cached)
+
+	// Current selections contain the numeric identities of existing identities that match
+	selections2 := cached2.GetSelections()
+	c.Assert(len(selections2), Equals, 1)
+	c.Assert(selections2[0], Equals, identity.NumericIdentity(2345))
+
+	// Add some identities to the identity cache
+	sc.UpdateIdentities(cache.IdentityCache{
+		12345: labels.Labels{"app": labels.NewLabel("app", "test", labels.LabelSourceK8s)}.LabelArray(),
+	}, nil)
+	c.Assert(user1.adds, Equals, 1)
+	c.Assert(user1.deletes, Equals, 0)
+
+	// Current selections contain the numeric identities of existing identities that match
+	selections = cached.GetSelections()
+	c.Assert(len(selections), Equals, 2)
+	c.Assert(selections[0], Equals, identity.NumericIdentity(1234))
+	c.Assert(selections[1], Equals, identity.NumericIdentity(12345))
+
+	// Remove some identities from the identity cache
+	sc.UpdateIdentities(nil, cache.IdentityCache{
+		12345: labels.Labels{"app": labels.NewLabel("app", "test", labels.LabelSourceK8s)}.LabelArray(),
+	})
+	c.Assert(user1.adds, Equals, 1)
+	c.Assert(user1.deletes, Equals, 1)
+
+	// Current selections contain the numeric identities of existing identities that match
+	selections = cached.GetSelections()
+	c.Assert(len(selections), Equals, 1)
+	c.Assert(selections[0], Equals, identity.NumericIdentity(1234))
+
+	user1.RemoveIdentitySelector(cached)
+	user1.RemoveIdentitySelector(cached2)
+
+	// All identities removed
+	c.Assert(len(sc.selectors), Equals, 0)
+}
+
+func (ds *SelectorCacheTestSuite) TestIdentityUpdatesMultipleUsers(c *C) {
+	sc := newSelectorCache()
+	// Add some identities to the identity cache
+	sc.UpdateIdentities(cache.IdentityCache{
+		1234: labels.Labels{"app": labels.NewLabel("app", "test", labels.LabelSourceK8s)}.LabelArray(),
+		2345: labels.Labels{"app": labels.NewLabel("app", "test2", labels.LabelSourceK8s)}.LabelArray(),
+	}, nil)
+
+	testSelector := api.NewESFromLabels(labels.NewLabel("app", "test", labels.LabelSourceK8s))
+
+	user1 := newUser(c, "user1", sc)
+	cached := user1.AddIdentitySelector(testSelector)
+
+	// Add same selector from a different user
+	user2 := newUser(c, "user2", sc)
+	cached2 := user2.AddIdentitySelector(testSelector)
+	c.Assert(cached2, Equals, cached)
+
+	// Add some identities to the identity cache
+	sc.UpdateIdentities(cache.IdentityCache{
+		123: labels.Labels{"app": labels.NewLabel("app", "test", labels.LabelSourceK8s)}.LabelArray(),
+		234: labels.Labels{"app": labels.NewLabel("app", "test2", labels.LabelSourceK8s)}.LabelArray(),
+		345: labels.Labels{"app": labels.NewLabel("app", "test", labels.LabelSourceK8s)}.LabelArray(),
+	}, nil)
+	c.Assert(user1.adds, Equals, 2)
+	c.Assert(user1.deletes, Equals, 0)
+	c.Assert(user2.adds, Equals, 2)
+	c.Assert(user2.deletes, Equals, 0)
+
+	// Current selections contain the numeric identities of existing identities that match
+	selections := cached.GetSelections()
+	c.Assert(len(selections), Equals, 3)
+	c.Assert(selections[0], Equals, identity.NumericIdentity(123))
+	c.Assert(selections[1], Equals, identity.NumericIdentity(345))
+	c.Assert(selections[2], Equals, identity.NumericIdentity(1234))
+
+	c.Assert(cached.GetSelections(), checker.DeepEquals, cached2.GetSelections())
+
+	// Remove some identities from the identity cache
+	sc.UpdateIdentities(nil, cache.IdentityCache{
+		123: labels.Labels{"app": labels.NewLabel("app", "test", labels.LabelSourceK8s)}.LabelArray(),
+		234: labels.Labels{"app": labels.NewLabel("app", "test2", labels.LabelSourceK8s)}.LabelArray(),
+	})
+	c.Assert(user1.adds, Equals, 2)
+	c.Assert(user1.deletes, Equals, 1)
+	c.Assert(user2.adds, Equals, 2)
+	c.Assert(user2.deletes, Equals, 1)
+
+	// Current selections contain the numeric identities of existing identities that match
+	selections = cached.GetSelections()
+	c.Assert(len(selections), Equals, 2)
+	c.Assert(selections[0], Equals, identity.NumericIdentity(345))
+	c.Assert(selections[1], Equals, identity.NumericIdentity(1234))
+
+	c.Assert(cached.GetSelections(), checker.DeepEquals, cached2.GetSelections())
+
+	user1.RemoveIdentitySelector(cached)
+	user2.RemoveIdentitySelector(cached2)
+
+	// All identities removed
+	c.Assert(len(sc.selectors), Equals, 0)
+}


### PR DESCRIPTION
Add an identity selector cache that does all the selector matching
necessary and caches the results.

This cache also gets updates from the kvstore on added and deleted
identities, and updates the selections accordingly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7539)
<!-- Reviewable:end -->
