### PR TITLE
Decouple identity policy from endpoint policy

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -55,6 +55,7 @@ import (
 	"github.com/cilium/cilium/pkg/fqdn"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/ipam"
 	"github.com/cilium/cilium/pkg/ipcache"
@@ -1274,6 +1275,7 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 	// this needs to be done *after* init() for the daemon in that function,
 	// we populate the IPCache with the host's IP(s).
 	ipcache.InitIPIdentityWatcher()
+	identitymanager.Subscribe(d.policy)
 
 	bootstrapStats.proxyStart.Start()
 	// FIXME: Make the port range configurable.
@@ -1594,10 +1596,4 @@ func (d *Daemon) GetNodeSuffix() string {
 	}
 
 	return ip.String()
-}
-
-// ClearPolicyConsumers removes references to the specified id from the rules in
-// the daemon's policy repository.
-func (d *Daemon) ClearPolicyConsumers(id uint16) *sync.WaitGroup {
-	return d.policy.RemoveEndpointIDFromRuleCaches(id)
 }

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -562,7 +562,7 @@ func (d *Daemon) deleteEndpointQuiet(ep *endpoint.Endpoint, conf endpoint.Delete
 
 	// Remove the endpoint before we clean up. This ensures it is no longer
 	// listed or queued for rebuilds.
-	endpointmanager.Remove(ep, d)
+	endpointmanager.Remove(ep)
 
 	// If dry mode is enabled, no changes to BPF maps are performed
 	if !option.Config.DryMode {

--- a/daemon/policy_test.go
+++ b/daemon/policy_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/mac"
-	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/testutils"
 
@@ -144,8 +143,6 @@ func (ds *DaemonSuite) prepareEndpoint(c *C, identity *identity.Identity, qa boo
 	identityChangedWG.Wait()
 	e.SetIdentity(identity)
 
-	wg := ds.d.policy.UpdateLocalConsumers([]policy.Endpoint{e})
-	wg.Wait()
 	e.UnconditionalLock()
 	ready := e.SetStateLocked(endpoint.StateWaitingToRegenerate, "test")
 	e.Unlock()

--- a/daemon/policy_test.go
+++ b/daemon/policy_test.go
@@ -139,8 +139,6 @@ func (ds *DaemonSuite) prepareEndpoint(c *C, identity *identity.Identity, qa boo
 		e.LXCMAC = ProdHardAddr
 		e.SetNodeMACLocked(ProdHardAddr)
 	}
-	identityChangedWG := ds.d.ClearPolicyConsumers(e.ID)
-	identityChangedWG.Wait()
 	e.SetIdentity(identity)
 
 	e.UnconditionalLock()

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -338,10 +338,6 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) (resto
 			// the identity even if has not changed.
 			ep.SetIdentity(identity)
 
-			// We don't need to hold the policy repository mutex here because
-			// the content of the rules themselves are not being changed.
-			d.policy.UpdateLocalConsumers([]policy.Endpoint{ep}).Wait()
-
 			if ep.GetStateLocked() == endpoint.StateWaitingToRegenerate {
 				ep.Unlock()
 				// EP is already waiting to regenerate. This is no error so no logging.

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2014,8 +2014,6 @@ func (e *Endpoint) identityLabelsChanged(ctx context.Context, owner Owner, myCha
 	elog.WithFields(logrus.Fields{logfields.Identity: identity.StringID()}).
 		Debug("Assigned new identity to endpoint")
 
-	owner.ClearPolicyConsumers(e.ID).Wait()
-
 	e.SetIdentity(identity)
 
 	if oldIdentity != nil {

--- a/pkg/endpoint/endpoint_status_test.go
+++ b/pkg/endpoint/endpoint_status_test.go
@@ -249,8 +249,10 @@ func (s *EndpointSuite) TestgetEndpointPolicyMapState(c *check.C) {
 				Nexthdr:  6,
 			}: {},
 		},
-		IngressPolicyEnabled: true,
-		EgressPolicyEnabled:  true,
+		SelectorPolicy: &policy.SelectorPolicy{
+			IngressPolicyEnabled: true,
+			EgressPolicyEnabled:  true,
+		},
 	}
 
 	apiPolicy = e.getEndpointPolicy()

--- a/pkg/endpoint/owner.go
+++ b/pkg/endpoint/owner.go
@@ -16,7 +16,6 @@ package endpoint
 
 import (
 	"context"
-	"sync"
 
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/datapath"
@@ -63,8 +62,4 @@ type Owner interface {
 
 	// Datapath returns a reference to the datapath implementation.
 	Datapath() datapath.Datapath
-
-	// ClearPolicyConsumers removes references to the specified id from the
-	// policy rules managed by Owner.
-	ClearPolicyConsumers(id uint16) *sync.WaitGroup
 }

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -160,7 +160,7 @@ func (e *Endpoint) regeneratePolicy(owner Owner) (retErr error) {
 	e.prevIdentityCache = labelsMap
 
 	stats.policyCalculation.Start()
-	identityPolicy, err := repo.ResolvePolicyLocked(e.ID, e.SecurityIdentity)
+	identityPolicy, err := repo.ResolvePolicyLocked(e.SecurityIdentity)
 	if err != nil {
 		return err
 	}

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -160,10 +160,11 @@ func (e *Endpoint) regeneratePolicy(owner Owner) (retErr error) {
 	e.prevIdentityCache = labelsMap
 
 	stats.policyCalculation.Start()
-	calculatedPolicy, err := repo.ResolvePolicy(e.ID, e.SecurityIdentity, e, *labelsMap)
+	identityPolicy, err := repo.ResolvePolicyLocked(e.ID, e.SecurityIdentity)
 	if err != nil {
 		return err
 	}
+	calculatedPolicy := identityPolicy.DistillPolicy(e, *labelsMap)
 	stats.policyCalculation.End(true)
 
 	e.desiredPolicy = calculatedPolicy

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -43,8 +43,6 @@ type DummyRuleCacheOwner struct{}
 func (d *DummyRuleCacheOwner) ClearPolicyConsumers(id uint16) *sync.WaitGroup {
 	return &sync.WaitGroup{}
 }
-
-var ruleCacheOwner *DummyRuleCacheOwner
 
 func (s *EndpointManagerSuite) TestLookup(c *C) {
 	ep := endpoint.NewEndpointWithState(10, endpoint.StateReady)
@@ -100,7 +98,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 				}
 			},
 			postTestRun: func() {
-				WaitEndpointRemoved(ep, ruleCacheOwner)
+				WaitEndpointRemoved(ep)
 				ep.ID = 0
 			},
 		},
@@ -122,7 +120,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 				}
 			},
 			postTestRun: func() {
-				WaitEndpointRemoved(ep, ruleCacheOwner)
+				WaitEndpointRemoved(ep)
 				ep.ID = 0
 			},
 		},
@@ -145,7 +143,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 				}
 			},
 			postTestRun: func() {
-				WaitEndpointRemoved(ep, ruleCacheOwner)
+				WaitEndpointRemoved(ep)
 				ep.ContainerID = ""
 			},
 		},
@@ -168,7 +166,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 				}
 			},
 			postTestRun: func() {
-				WaitEndpointRemoved(ep, ruleCacheOwner)
+				WaitEndpointRemoved(ep)
 				ep.DockerEndpointID = ""
 			},
 		},
@@ -191,7 +189,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 				}
 			},
 			postTestRun: func() {
-				WaitEndpointRemoved(ep, ruleCacheOwner)
+				WaitEndpointRemoved(ep)
 				ep.ContainerName = ""
 			},
 		},
@@ -215,7 +213,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 				}
 			},
 			postTestRun: func() {
-				WaitEndpointRemoved(ep, ruleCacheOwner)
+				WaitEndpointRemoved(ep)
 				ep.SetK8sPodName("")
 			},
 		},
@@ -240,7 +238,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 				}
 			},
 			postTestRun: func() {
-				WaitEndpointRemoved(ep, ruleCacheOwner)
+				WaitEndpointRemoved(ep)
 				ep.IPv4 = nil
 			},
 		},
@@ -327,7 +325,7 @@ func (s *EndpointManagerSuite) TestLookupCiliumID(c *C) {
 				}
 			},
 			postTestRun: func() {
-				WaitEndpointRemoved(ep, ruleCacheOwner)
+				WaitEndpointRemoved(ep)
 				ep.ID = 0
 			},
 		},
@@ -394,7 +392,7 @@ func (s *EndpointManagerSuite) TestLookupContainerID(c *C) {
 				}
 			},
 			postTestRun: func() {
-				WaitEndpointRemoved(ep, ruleCacheOwner)
+				WaitEndpointRemoved(ep)
 				ep.SetContainerID("")
 			},
 		},
@@ -463,7 +461,7 @@ func (s *EndpointManagerSuite) TestLookupIPv4(c *C) {
 				}
 			},
 			postTestRun: func() {
-				WaitEndpointRemoved(ep, ruleCacheOwner)
+				WaitEndpointRemoved(ep)
 				ep.IPv4 = nil
 			},
 		},
@@ -531,7 +529,7 @@ func (s *EndpointManagerSuite) TestLookupPodName(c *C) {
 				}
 			},
 			postTestRun: func() {
-				WaitEndpointRemoved(ep, ruleCacheOwner)
+				WaitEndpointRemoved(ep)
 				ep.IPv4 = nil
 			},
 		},
@@ -607,7 +605,7 @@ func (s *EndpointManagerSuite) TestUpdateReferences(c *C) {
 				}
 			},
 			postTestRun: func() {
-				WaitEndpointRemoved(ep, ruleCacheOwner)
+				WaitEndpointRemoved(ep)
 				ep.SetK8sNamespace("")
 				ep.SetK8sPodName("")
 				ep.SetContainerID("")
@@ -712,7 +710,7 @@ func (s *EndpointManagerSuite) TestHasGlobalCT(c *C) {
 				}
 			},
 			postTestRun: func() {
-				WaitEndpointRemoved(ep, ruleCacheOwner)
+				WaitEndpointRemoved(ep)
 				ep.ID = 0
 				ep.Options = nil
 			},
@@ -731,7 +729,7 @@ func (s *EndpointManagerSuite) TestHasGlobalCT(c *C) {
 				}
 			},
 			postTestRun: func() {
-				WaitEndpointRemoved(ep, ruleCacheOwner)
+				WaitEndpointRemoved(ep)
 				ep.ID = 0
 				ep.Options = nil
 			},
@@ -785,7 +783,7 @@ func (s *EndpointManagerSuite) TestWaitForEndpointsAtPolicyRev(c *C) {
 				}
 			},
 			postTestRun: func() {
-				WaitEndpointRemoved(ep, ruleCacheOwner)
+				WaitEndpointRemoved(ep)
 				ep = endpoint.NewEndpointWithState(1, endpoint.StateReady)
 			},
 		},
@@ -811,7 +809,7 @@ func (s *EndpointManagerSuite) TestWaitForEndpointsAtPolicyRev(c *C) {
 				}
 			},
 			postTestRun: func() {
-				WaitEndpointRemoved(ep, ruleCacheOwner)
+				WaitEndpointRemoved(ep)
 				ep = endpoint.NewEndpointWithState(1, endpoint.StateReady)
 			},
 		},
@@ -837,7 +835,7 @@ func (s *EndpointManagerSuite) TestWaitForEndpointsAtPolicyRev(c *C) {
 				}
 			},
 			postTestRun: func() {
-				WaitEndpointRemoved(ep, ruleCacheOwner)
+				WaitEndpointRemoved(ep)
 				ep = endpoint.NewEndpointWithState(1, endpoint.StateReady)
 			},
 		},

--- a/pkg/identity/identitymanager/manager_test.go
+++ b/pkg/identity/identitymanager/manager_test.go
@@ -31,25 +31,16 @@ func Test(t *testing.T) {
 
 type IdentityManagerTestSuite struct{}
 
-var _ = Suite(&IdentityManagerTestSuite{})
+var (
+	_ = Suite(&IdentityManagerTestSuite{})
+
+	idFooSelectLabels = labels.NewLabelsFromModel([]string{"id=foo"})
+	idBarSelectLabels = labels.NewLabelsFromModel([]string{"id=bar"})
+	fooIdentity       = identity.NewIdentity(identity.NumericIdentity(12345), idFooSelectLabels)
+	barIdentity       = identity.NewIdentity(identity.NumericIdentity(54321), idBarSelectLabels)
+)
 
 func (s *IdentityManagerTestSuite) TestIdentityManagerLifecycle(c *C) {
-
-	idFooSelectLabelArray := labels.ParseSelectLabelArray("id=foo")
-	idFooSelectLabels := labels.Labels{}
-	for _, lbl := range idFooSelectLabelArray {
-		idFooSelectLabels[lbl.Key] = lbl
-	}
-
-	idBarSelectLabelArray := labels.ParseSelectLabelArray("id=bar")
-	idBarSelectLabels := labels.Labels{}
-	for _, lbl := range idBarSelectLabelArray {
-		idBarSelectLabels[lbl.Key] = lbl
-	}
-
-	fooIdentity := identity.NewIdentity(identity.NumericIdentity(12345), idFooSelectLabels)
-	barIdentity := identity.NewIdentity(identity.NumericIdentity(54321), idBarSelectLabels)
-
 	idm := NewIdentityManager()
 	c.Assert(idm.identities, Not(IsNil))
 

--- a/pkg/identity/identitymanager/observer.go
+++ b/pkg/identity/identitymanager/observer.go
@@ -1,0 +1,27 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package identitymanager
+
+import (
+	"github.com/cilium/cilium/pkg/identity"
+)
+
+// Observer can sign up to receive events whenever local identities are removed.
+type Observer interface {
+	// LocalEndpointIdentityRemoved is called when an identity is no longer
+	// in use on the node. Implementations must ensure that the callback
+	// returns within a reasonable period.
+	LocalEndpointIdentityRemoved(*identity.Identity)
+}

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -405,21 +405,6 @@ func (p *Repository) AddListLocked(rules api.Rules) (ruleSlice, uint64) {
 	return newList, p.GetRevision()
 }
 
-// UpdateLocalConsumers updates the cache within each rule in the given repository
-// which specifies whether said rule selects said identity. Returns a wait group
-// which can be used to wait until all rules have had said caches updated.
-func (p *Repository) UpdateLocalConsumers(eps []Endpoint) *sync.WaitGroup {
-	var policySelectionWG sync.WaitGroup
-	for _, ep := range eps {
-		policySelectionWG.Add(1)
-		go func(epp Endpoint) {
-			p.rules.refreshRulesForEndpoint(epp)
-			policySelectionWG.Done()
-		}(ep)
-	}
-	return &policySelectionWG
-}
-
 // RemoveEndpointIDFromRuleCaches removes identifier from the processedConsumers
 // and localRuleConsumers sets in each rule within the repository. Returns a
 // sync.WaitGroup which can be waited on once all rules have been processed in

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -29,9 +29,6 @@ import (
 // particular Identity across all layers (L3, L4, and L7), with the policy
 // still determined in terms of EndpointSelectors.
 type SelectorPolicy struct {
-	// ID is the node-local identifier of this EndpointPolicy.
-	ID uint16
-
 	// L4Policy contains the computed L4 and L7 policy.
 	L4Policy *L4Policy
 

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,14 +18,17 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
+
 	"github.com/sirupsen/logrus"
 )
 
-// EndpointPolicy is a structure which contains the resolved policy across all layers
-// (L3, L4, and L7).
-type EndpointPolicy struct {
+// SelectorPolicy is a structure which contains the resolved policy for a
+// particular Identity across all layers (L3, L4, and L7), with the policy
+// still determined in terms of EndpointSelectors.
+type SelectorPolicy struct {
 	// ID is the node-local identifier of this EndpointPolicy.
 	ID uint16
 
@@ -42,6 +45,19 @@ type EndpointPolicy struct {
 	// EgressPolicyEnabled specifies whether this policy contains any policy
 	// at egress.
 	EgressPolicyEnabled bool
+
+	// matchingRules is the set of rules in the repository that were
+	// matched during policy resolution. These refer directly into the
+	// policy repository and must not be modified.
+	//
+	// GH-7516 tracks removal of this field.
+	matchingRules ruleSlice
+}
+
+// EndpointPolicy is a structure which contains the resolved policy across all
+// layers (L3, L4, and L7), distilled against a set of identities.
+type EndpointPolicy struct {
+	*SelectorPolicy
 
 	// PolicyMapState contains the state of this policy as it relates to the
 	// datapath. In the future, this will be factored out of this object to
@@ -69,6 +85,7 @@ type EndpointPolicy struct {
 // PolicyOwner is anything which consumes a EndpointPolicy.
 type PolicyOwner interface {
 	LookupRedirectPort(l4 *L4Filter) uint16
+	GetSecurityIdentity() *identity.Identity
 }
 
 func getSecurityIdentities(labelsMap cache.IdentityCache, selector *api.EndpointSelector) []identity.NumericIdentity {
@@ -84,6 +101,84 @@ func getSecurityIdentities(labelsMap cache.IdentityCache, selector *api.Endpoint
 	}
 
 	return identities
+}
+
+// DistillPolicy filters down the specified SelectorPolicy (which acts upon
+// selectors) into a set of concrete map entries based on the specified
+// identityCache. These can subsequently be plumbed into the datapath.
+//
+// Must be performed while holding the Repository lock.
+func (p *SelectorPolicy) DistillPolicy(policyOwner PolicyOwner, identityCache cache.IdentityCache) *EndpointPolicy {
+
+	calculatedPolicy := &EndpointPolicy{
+		SelectorPolicy:          p,
+		PolicyMapState:          make(MapState),
+		PolicyOwner:             policyOwner,
+		DeniedIngressIdentities: cache.IdentityCache{},
+		DeniedEgressIdentities:  cache.IdentityCache{},
+	}
+
+	labels := policyOwner.GetSecurityIdentity().LabelArray
+	ingressCtx := SearchContext{
+		To:                            labels,
+		rulesSelect:                   true,
+		skipL4RequirementsAggregation: true,
+	}
+
+	egressCtx := SearchContext{
+		From:                          labels,
+		rulesSelect:                   true,
+		skipL4RequirementsAggregation: true,
+	}
+
+	if option.Config.TracingEnabled() {
+		ingressCtx.Trace = TRACE_ENABLED
+		egressCtx.Trace = TRACE_ENABLED
+	}
+
+	if p.IngressPolicyEnabled {
+		for identity, labels := range identityCache {
+			ingressCtx.From = labels
+			egressCtx.To = labels
+
+			ingressAccess := p.matchingRules.canReachIngressRLocked(&ingressCtx)
+			if ingressAccess == api.Allowed {
+				keyToAdd := Key{
+					Identity:         identity.Uint32(),
+					TrafficDirection: trafficdirection.Ingress.Uint8(),
+				}
+				calculatedPolicy.PolicyMapState[keyToAdd] = MapStateEntry{}
+			} else if ingressAccess == api.Denied {
+				calculatedPolicy.DeniedIngressIdentities[identity] = labels
+			}
+		}
+	} else {
+		calculatedPolicy.PolicyMapState.AllowAllIdentities(identityCache, trafficdirection.Ingress)
+	}
+
+	if p.EgressPolicyEnabled {
+		for identity, labels := range identityCache {
+			egressCtx.To = labels
+
+			egressAccess := p.matchingRules.canReachEgressRLocked(&egressCtx)
+			if egressAccess == api.Allowed {
+				keyToAdd := Key{
+					Identity:         identity.Uint32(),
+					TrafficDirection: trafficdirection.Egress.Uint8(),
+				}
+				calculatedPolicy.PolicyMapState[keyToAdd] = MapStateEntry{}
+			} else if egressAccess == api.Denied {
+				calculatedPolicy.DeniedEgressIdentities[identity] = labels
+			}
+		}
+	} else {
+		calculatedPolicy.PolicyMapState.AllowAllIdentities(identityCache, trafficdirection.Egress)
+	}
+
+	calculatedPolicy.computeDesiredL4PolicyMapEntries(identityCache)
+	calculatedPolicy.PolicyMapState.DetermineAllowLocalhost(p.L4Policy)
+
+	return calculatedPolicy
 }
 
 // computeDesiredL4PolicyMapEntries transforms the EndpointPolicy.L4Policy into
@@ -120,17 +215,33 @@ func (p *EndpointPolicy) computeDirectionL4PolicyMapEntries(identityCache cache.
 	}
 }
 
+// NewEndpointPolicy returns an empty EndpointPolicy stub.
+func NewEndpointPolicy() *EndpointPolicy {
+	return &EndpointPolicy{
+		SelectorPolicy: &SelectorPolicy{},
+	}
+}
+
 // Realizes copies the fields from desired into p. It assumes that the fields in
 // desired are not modified after this function is called.
-func (p *EndpointPolicy) Realizes(desired *EndpointPolicy) {
+func (p *SelectorPolicy) Realizes(desired *SelectorPolicy) {
 	if p == nil {
-		p = &EndpointPolicy{}
+		p = &SelectorPolicy{}
 	}
-
 	p.IngressPolicyEnabled = desired.IngressPolicyEnabled
 	p.EgressPolicyEnabled = desired.EgressPolicyEnabled
 	p.L4Policy = desired.L4Policy
 	p.CIDRPolicy = desired.CIDRPolicy
+}
+
+// Realizes copies the fields from desired into p. It assumes that the fields in
+// desired are not modified after this function is called.
+func (p *EndpointPolicy) Realizes(desired *EndpointPolicy) {
+	if p == nil {
+		p = NewEndpointPolicy()
+	}
+
+	p.SelectorPolicy.Realizes(desired.SelectorPolicy)
 	p.DeniedEgressIdentities = desired.DeniedEgressIdentities
 	p.DeniedIngressIdentities = desired.DeniedIngressIdentities
 }

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -158,7 +158,7 @@ func (d DummyOwner) GetSecurityIdentity() *identity.Identity {
 func (ds *PolicyTestSuite) BenchmarkRegeneratePolicyRules(c *C) {
 	c.ResetTimer()
 	for i := 0; i < c.N; i++ {
-		ip, _ := repo.ResolvePolicyLocked(9001, fooIdentity)
+		ip, _ := repo.ResolvePolicyLocked(fooIdentity)
 		_ = ip.DistillPolicy(DummyOwner{}, identityCache)
 	}
 }
@@ -200,13 +200,12 @@ func (ds *PolicyTestSuite) TestL7WithIngressWildcard(c *C) {
 	repo.Mutex.RLock()
 	defer repo.Mutex.RUnlock()
 	identityCache = cache.GetIdentityCache()
-	identityPolicy, err := repo.ResolvePolicyLocked(10, fooIdentity)
+	identityPolicy, err := repo.ResolvePolicyLocked(fooIdentity)
 	c.Assert(err, IsNil)
 	policy := identityPolicy.DistillPolicy(DummyOwner{}, identityCache)
 
 	expectedEndpointPolicy := EndpointPolicy{
 		SelectorPolicy: &SelectorPolicy{
-			ID: 10,
 			L4Policy: &L4Policy{
 				Ingress: L4PolicyMap{
 					"80/TCP": {
@@ -290,13 +289,12 @@ func (ds *PolicyTestSuite) TestL7WithLocalHostWildcardd(c *C) {
 	defer repo.Mutex.RUnlock()
 
 	identityCache = cache.GetIdentityCache()
-	identityPolicy, err := repo.ResolvePolicyLocked(10, fooIdentity)
+	identityPolicy, err := repo.ResolvePolicyLocked(fooIdentity)
 	c.Assert(err, IsNil)
 	policy := identityPolicy.DistillPolicy(DummyOwner{}, identityCache)
 
 	expectedEndpointPolicy := EndpointPolicy{
 		SelectorPolicy: &SelectorPolicy{
-			ID: 10,
 			L4Policy: &L4Policy{
 				Ingress: L4PolicyMap{
 					"80/TCP": {

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/checker"
+	"github.com/cilium/cilium/pkg/identity"
 	identity2 "github.com/cilium/cilium/pkg/identity"
 	k8sapi "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/labels"
@@ -2286,35 +2287,29 @@ func (ds *PolicyTestSuite) TestMatches(c *C) {
 
 	addedRule := repo.rules[0]
 
-	selectedEndpointID := uint16(12345)
 	selectedEpLabels := labels.ParseSelectLabel("id=a")
-	selectedEndpointIdentity := identity2.NewIdentity(54321, labels.Labels{selectedEpLabels.Key: selectedEpLabels})
+	selectedIdentity := identity2.NewIdentity(54321, labels.Labels{selectedEpLabels.Key: selectedEpLabels})
 
-	notSelectedEndpointID := uint16(6789)
 	notSelectedEpLabels := labels.ParseSelectLabel("id=b")
-	notSelectedEndpointIdentity := identity2.NewIdentity(9876, labels.Labels{notSelectedEpLabels.Key: notSelectedEpLabels})
+	notSelectedIdentity := identity2.NewIdentity(9876, labels.Labels{notSelectedEpLabels.Key: notSelectedEpLabels})
 
 	// notSelectedEndpoint is not selected by rule, so we it shouldn't be added
 	// to EndpointsSelected.
-	c.Assert(addedRule.matches(notSelectedEndpointID, notSelectedEndpointIdentity), Equals, false)
-	c.Assert(addedRule.metadata.AllEndpoints, checker.DeepEquals, map[uint16]struct{}{notSelectedEndpointID: {}})
-	c.Assert(addedRule.metadata.EndpointsSelected, checker.DeepEquals, map[uint16]*identity2.Identity{})
+	c.Assert(addedRule.matches(notSelectedIdentity), Equals, false)
+	c.Assert(addedRule.metadata.IdentitySelected, checker.DeepEquals, map[*identity.Identity]bool{notSelectedIdentity: false})
 
 	// selectedEndpoint is selected by rule, so we it should be added to
 	// EndpointsSelected.
-	c.Assert(addedRule.matches(selectedEndpointID, selectedEndpointIdentity), Equals, true)
-	c.Assert(addedRule.metadata.AllEndpoints, checker.DeepEquals, map[uint16]struct{}{selectedEndpointID: {}, notSelectedEndpointID: {}})
-	c.Assert(addedRule.metadata.EndpointsSelected, checker.DeepEquals, map[uint16]*identity2.Identity{selectedEndpointID: selectedEndpointIdentity})
+	c.Assert(addedRule.matches(selectedIdentity), Equals, true)
+	c.Assert(addedRule.metadata.IdentitySelected, checker.DeepEquals, map[*identity.Identity]bool{selectedIdentity: true, notSelectedIdentity: false})
 
 	// Test again to check for caching working correctly.
-	c.Assert(addedRule.matches(selectedEndpointID, selectedEndpointIdentity), Equals, true)
-	c.Assert(addedRule.metadata.AllEndpoints, checker.DeepEquals, map[uint16]struct{}{selectedEndpointID: {}, notSelectedEndpointID: {}})
-	c.Assert(addedRule.metadata.EndpointsSelected, checker.DeepEquals, map[uint16]*identity2.Identity{selectedEndpointID: selectedEndpointIdentity})
+	c.Assert(addedRule.matches(selectedIdentity), Equals, true)
+	c.Assert(addedRule.metadata.IdentitySelected, checker.DeepEquals, map[*identity.Identity]bool{selectedIdentity: true, notSelectedIdentity: false})
 
 	// Possible scenario where an endpoint is deleted, and soon after another
 	// endpoint is added with the same ID, but with a different identity. Matching
 	// needs to handle this case correctly.
-	c.Assert(addedRule.matches(selectedEndpointID, notSelectedEndpointIdentity), Equals, false)
-	c.Assert(addedRule.metadata.AllEndpoints, checker.DeepEquals, map[uint16]struct{}{selectedEndpointID: {}, notSelectedEndpointID: {}})
-	c.Assert(addedRule.metadata.EndpointsSelected, checker.DeepEquals, map[uint16]*identity2.Identity{})
+	c.Assert(addedRule.matches(notSelectedIdentity), Equals, false)
+	c.Assert(addedRule.metadata.IdentitySelected, checker.DeepEquals, map[*identity.Identity]bool{selectedIdentity: true, notSelectedIdentity: false})
 }

--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -367,7 +367,7 @@ func (rules ruleSlice) updateEndpointsCaches(ep Endpoint, epIDSet *IDSet) bool {
 	securityIdentity := ep.GetSecurityIdentity()
 
 	for _, r := range rules {
-		if ruleMatches := r.matches(id, securityIdentity); ruleMatches {
+		if ruleMatches := r.matches(securityIdentity); ruleMatches {
 			epIDSet.Mutex.Lock()
 			epIDSet.IDs[id] = struct{}{}
 			epIDSet.Mutex.Unlock()
@@ -381,16 +381,14 @@ func (rules ruleSlice) updateEndpointsCaches(ep Endpoint, epIDSet *IDSet) bool {
 	return false
 }
 
-func (rules ruleSlice) refreshRulesForEndpoint(ep Endpoint) {
+func (rules ruleSlice) refreshRulesCache(ep Endpoint) {
 	if ep == nil {
 		return
 	}
 
-	id := ep.GetID16()
 	securityIdentity := ep.GetSecurityIdentity()
-
 	for _, r := range rules {
 		// matches updates the caches within the rules
-		r.matches(id, securityIdentity)
+		r.matches(securityIdentity)
 	}
 }


### PR DESCRIPTION
Decouple the resolving of policy for a particular identity from the endpoint-specific distillation of that policy. The `SelectorPolicy` deals with all rule selectors that apply to a particular identity (of an endpoint), and this performs merging of the policy. The `EndpointPolicy` applies that partially-resolved `SelectorPolicy` to a specific set of identity peers in context of generating the endpoint BPF policy map contents.

As part of this, rework the rule selector cache to be based upon identities rather than endpoints. This makes use of the recently-added identitymanager (#7616) to determine when an identity can be safely flushed from the cache.

Related: #7515 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7542)
<!-- Reviewable:end -->
