### PR TITLE
endpoint: remove controller which synchronizes PolicyMap state

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/completion"
-	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/datapath/loader"
 	"github.com/cilium/cilium/pkg/loadinfo"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -998,23 +997,4 @@ func (e *Endpoint) syncPolicyMap() error {
 	}
 
 	return nil
-}
-
-func (e *Endpoint) syncPolicyMapController() {
-	ctrlName := fmt.Sprintf("sync-policymap-%d", e.ID)
-	e.controllers.UpdateController(ctrlName,
-		controller.ControllerParams{
-			DoFunc: func(ctx context.Context) (reterr error) {
-				// Failure to lock is not an error, it means
-				// that the endpoint was disconnected and we
-				// should exit gracefully.
-				if err := e.LockAlive(); err != nil {
-					return controller.NewExitReason("Endpoint disappeared")
-				}
-				defer e.Unlock()
-				return e.syncPolicyMap()
-			},
-			RunInterval: 1 * time.Minute,
-		},
-	)
 }

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -360,11 +360,6 @@ func (e *Endpoint) updateRealizedState(stats *regenerationStatistics, origDir st
 		return fmt.Errorf("error synchronizing endpoint BPF program directories: %s", err)
 	}
 
-	// Keep PolicyMap for this endpoint in sync with desired / realized state.
-	if !option.Config.DryMode {
-		e.syncPolicyMapController()
-	}
-
 	e.realizedBPFConfig = e.desiredBPFConfig
 
 	// Set realized state to desired state fields.


### PR DESCRIPTION
This controller runs every minute, and has to dump all the contents of the map
to userspace to do introspection as to whether there is a mismatch between the
desired state, and the state in the datapath. For an endpoint with a lot of
PolicyMap entries, this is a large number of syscalls. We also already have
functionality to keep an in-memory cache of all maps already in `pkg/maps`,
so this specialized controller is duplicating existing functionality. We also
have not seen a mismatch between the desired policy / realized policy in the
datapath which has caused drops, so this should be safe to remove.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7543)
<!-- Reviewable:end -->
