### PR TITLE
v1.4 backports 2019-03-29

### DIFF
--- a/daemon/policy_test.go
+++ b/daemon/policy_test.go
@@ -46,6 +46,13 @@ var (
 	ProdIPv6Addr, _ = addressing.NewCiliumIPv6("cafe:cafe:cafe:cafe:aaaa:aaaa:1111:1112")
 	ProdIPv4Addr, _ = addressing.NewCiliumIPv4("10.11.12.14")
 
+	lblProd = labels.ParseLabel("Prod")
+	lblQA   = labels.ParseLabel("QA")
+	lblFoo  = labels.ParseLabel("foo")
+	lblBar  = labels.ParseLabel("bar")
+	lblJoe  = labels.ParseLabel("user=joe")
+	lblPete = labels.ParseLabel("user=pete")
+
 	testEndpointID = uint16(1)
 
 	regenerationMetadata = &endpoint.ExternalRegenerationMetadata{
@@ -101,13 +108,6 @@ func (ds *DaemonSuite) prepareEndpoint(c *C, identity *identity.Identity, qa boo
 }
 
 func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
-	lblProd := labels.ParseLabel("Prod")
-	lblQA := labels.ParseLabel("QA")
-	lblFoo := labels.ParseLabel("foo")
-	lblBar := labels.ParseLabel("bar")
-	lblJoe := labels.ParseLabel("user=joe")
-	lblPete := labels.ParseLabel("user=pete")
-
 	rules := api.Rules{
 		{
 			EndpointSelector: api.NewESFromLabels(lblBar),
@@ -355,7 +355,6 @@ func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
 }
 
 func (ds *DaemonSuite) TestReplacePolicy(c *C) {
-	lblBar := labels.ParseLabel("bar")
 	lbls := labels.ParseLabelArray("foo", "bar")
 	rules := api.Rules{
 		{
@@ -390,13 +389,6 @@ func (ds *DaemonSuite) TestReplacePolicy(c *C) {
 }
 
 func (ds *DaemonSuite) TestRemovePolicy(c *C) {
-	lblProd := labels.ParseLabel("Prod")
-	lblQA := labels.ParseLabel("QA")
-	lblFoo := labels.ParseLabel("foo")
-	lblBar := labels.ParseLabel("bar")
-	lblJoe := labels.ParseLabel("user=joe")
-	lblPete := labels.ParseLabel("user=pete")
-
 	rules := api.Rules{
 		{
 			EndpointSelector: api.NewESFromLabels(lblBar),

--- a/daemon/policy_test.go
+++ b/daemon/policy_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"sort"
 	"time"
@@ -25,6 +26,7 @@ import (
 	"github.com/cilium/cilium/common/addressing"
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/mac"
@@ -44,6 +46,8 @@ var (
 	ProdIPv6Addr, _ = addressing.NewCiliumIPv6("cafe:cafe:cafe:cafe:aaaa:aaaa:1111:1112")
 	ProdIPv4Addr, _ = addressing.NewCiliumIPv4("10.11.12.14")
 
+	testEndpointID = uint16(1)
+
 	regenerationMetadata = &endpoint.ExternalRegenerationMetadata{
 		Reason: "test",
 	}
@@ -55,6 +59,45 @@ func (ds *DaemonSuite) getXDSNetworkPolicies(c *C, resourceNames []string) map[s
 	networkPolicies, err := ds.d.l7Proxy.GetNetworkPolicies(resourceNames)
 	c.Assert(err, IsNil)
 	return networkPolicies
+}
+
+func prepareEndpointDirs() (cleanup func(), err error) {
+	testEPDir := fmt.Sprintf("%d", testEndpointID)
+	if err = os.Mkdir(testEPDir, 755); err != nil {
+		return func() {}, err
+	}
+	return func() {
+		os.RemoveAll(fmt.Sprintf("%s/lxc_config.h", testEPDir))
+		time.Sleep(1 * time.Second)
+		os.RemoveAll(testEPDir)
+		os.RemoveAll(fmt.Sprintf("%s_backup", testEPDir))
+	}, nil
+}
+
+func (ds *DaemonSuite) prepareEndpoint(c *C, identity *identity.Identity, qa bool) *endpoint.Endpoint {
+	e := endpoint.NewEndpointWithState(testEndpointID, endpoint.StateWaitingForIdentity)
+	e.IfName = "dummy1"
+	if qa {
+		e.IPv6 = QAIPv6Addr
+		e.IPv4 = QAIPv4Addr
+		e.LXCMAC = QAHardAddr
+		e.SetNodeMACLocked(QAHardAddr)
+	} else {
+		e.IPv6 = ProdIPv6Addr
+		e.IPv4 = ProdIPv4Addr
+		e.LXCMAC = ProdHardAddr
+		e.SetNodeMACLocked(ProdHardAddr)
+	}
+	e.SetIdentity(identity)
+
+	e.UnconditionalLock()
+	ready := e.SetStateLocked(endpoint.StateWaitingToRegenerate, "test")
+	e.Unlock()
+	c.Assert(ready, Equals, true)
+	buildSuccess := <-e.Regenerate(ds.d, regenerationMetadata)
+	c.Assert(buildSuccess, Equals, true)
+
+	return e
 }
 
 func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
@@ -125,71 +168,40 @@ func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
 	_, err3 := ds.d.PolicyAdd(rules, nil)
 	c.Assert(err3, Equals, nil)
 
+	// Prepare the identities necessary for testing
 	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}
 	qaBarSecLblsCtx, _, err := cache.AllocateIdentity(context.Background(), qaBarLbls)
 	c.Assert(err, Equals, nil)
 	defer cache.Release(context.Background(), qaBarSecLblsCtx)
-
 	prodBarLbls := labels.Labels{lblBar.Key: lblBar, lblProd.Key: lblProd}
 	prodBarSecLblsCtx, _, err := cache.AllocateIdentity(context.Background(), prodBarLbls)
 	c.Assert(err, Equals, nil)
 	defer cache.Release(context.Background(), prodBarSecLblsCtx)
-
 	qaFooLbls := labels.Labels{lblFoo.Key: lblFoo, lblQA.Key: lblQA}
 	qaFooSecLblsCtx, _, err := cache.AllocateIdentity(context.Background(), qaFooLbls)
 	c.Assert(err, Equals, nil)
 	defer cache.Release(context.Background(), qaFooSecLblsCtx)
-
 	prodFooLbls := labels.Labels{lblFoo.Key: lblFoo, lblProd.Key: lblProd}
 	prodFooSecLblsCtx, _, err := cache.AllocateIdentity(context.Background(), prodFooLbls)
 	c.Assert(err, Equals, nil)
 	defer cache.Release(context.Background(), prodFooSecLblsCtx)
-
 	prodFooJoeLbls := labels.Labels{lblFoo.Key: lblFoo, lblProd.Key: lblProd, lblJoe.Key: lblJoe}
 	prodFooJoeSecLblsCtx, _, err := cache.AllocateIdentity(context.Background(), prodFooJoeLbls)
 	c.Assert(err, Equals, nil)
 	defer cache.Release(context.Background(), prodFooJoeSecLblsCtx)
 
-	e := endpoint.NewEndpointWithState(1, endpoint.StateWaitingForIdentity)
-	e.IfName = "dummy1"
-	e.IPv6 = QAIPv6Addr
-	e.IPv4 = QAIPv4Addr
-	e.LXCMAC = QAHardAddr
-	e.NodeMAC = QAHardAddr
+	// Prepare endpoints
+	cleanup, err2 := prepareEndpointDirs()
+	c.Assert(err2, Equals, nil)
+	defer cleanup()
 
-	err2 := os.Mkdir("1", 755)
-	c.Assert(err2, IsNil)
-	defer func() {
-		os.RemoveAll("1/lxc_config.h")
-		time.Sleep(1 * time.Second)
-		os.RemoveAll("1")
-		os.RemoveAll("1_backup")
-	}()
-	e.SetIdentity(qaBarSecLblsCtx)
-	e.UnconditionalLock()
-	ready := e.SetStateLocked(endpoint.StateWaitingToRegenerate, "test")
-	e.Unlock()
-	c.Assert(ready, Equals, true)
-	buildSuccess := <-e.Regenerate(ds.d, regenerationMetadata)
-	c.Assert(buildSuccess, Equals, true)
+	e := ds.prepareEndpoint(c, qaBarSecLblsCtx, true)
 	c.Assert(e.Allows(qaBarSecLblsCtx.ID), Equals, false)
 	c.Assert(e.Allows(prodBarSecLblsCtx.ID), Equals, false)
 	c.Assert(e.Allows(qaFooSecLblsCtx.ID), Equals, true)
 	c.Assert(e.Allows(prodFooSecLblsCtx.ID), Equals, false)
 
-	e = endpoint.NewEndpointWithState(1, endpoint.StateWaitingForIdentity)
-	e.IfName = "dummy1"
-	e.IPv6 = ProdIPv6Addr
-	e.IPv4 = ProdIPv4Addr
-	e.LXCMAC = ProdHardAddr
-	e.NodeMAC = ProdHardAddr
-	e.SetIdentity(prodBarSecLblsCtx)
-	e.UnconditionalLock()
-	ready = e.SetStateLocked(endpoint.StateWaitingToRegenerate, "test")
-	e.Unlock()
-	c.Assert(ready, Equals, true)
-	buildSuccess = <-e.Regenerate(ds.d, regenerationMetadata)
-	c.Assert(buildSuccess, Equals, true)
+	e = ds.prepareEndpoint(c, prodBarSecLblsCtx, false)
 	c.Assert(e.Allows(0), Equals, false)
 	c.Assert(e.Allows(qaBarSecLblsCtx.ID), Equals, false)
 	c.Assert(e.Allows(prodBarSecLblsCtx.ID), Equals, false)
@@ -450,28 +462,12 @@ func (ds *DaemonSuite) TestRemovePolicy(c *C) {
 	c.Assert(err, Equals, nil)
 	defer cache.Release(context.Background(), qaBarSecLblsCtx)
 
+	cleanup, err2 := prepareEndpointDirs()
+	c.Assert(err2, Equals, nil)
+	defer cleanup()
+
 	// Create the endpoint and generate its policy.
-	e := endpoint.NewEndpointWithState(1, endpoint.StateWaitingForIdentity)
-	e.IfName = "dummy1"
-	e.IPv6 = QAIPv6Addr
-	e.IPv4 = QAIPv4Addr
-	e.LXCMAC = QAHardAddr
-	e.NodeMAC = QAHardAddr
-	err2 := os.Mkdir("1", 755)
-	c.Assert(err2, IsNil)
-	defer func() {
-		os.RemoveAll("1/lxc_config.h")
-		time.Sleep(1 * time.Second)
-		os.RemoveAll("1")
-		os.RemoveAll("1_backup")
-	}()
-	e.SetIdentity(qaBarSecLblsCtx)
-	e.UnconditionalLock()
-	ready := e.SetStateLocked(endpoint.StateWaitingToRegenerate, "test")
-	e.Unlock()
-	c.Assert(ready, Equals, true)
-	buildSuccess := <-e.Regenerate(ds.d, regenerationMetadata)
-	c.Assert(buildSuccess, Equals, true)
+	e := ds.prepareEndpoint(c, qaBarSecLblsCtx, true)
 
 	// Check that the policy has been updated in the xDS cache for the L7
 	// proxies.

--- a/daemon/policy_test.go
+++ b/daemon/policy_test.go
@@ -131,12 +131,12 @@ func (ds *DaemonSuite) prepareEndpoint(c *C, identity *identity.Identity, qa boo
 		e.IPv6 = QAIPv6Addr
 		e.IPv4 = QAIPv4Addr
 		e.LXCMAC = QAHardAddr
-		e.SetNodeMACLocked(QAHardAddr)
+		e.NodeMAC = QAHardAddr
 	} else {
 		e.IPv6 = ProdIPv6Addr
 		e.IPv4 = ProdIPv4Addr
 		e.LXCMAC = ProdHardAddr
-		e.SetNodeMACLocked(ProdHardAddr)
+		e.NodeMAC = ProdHardAddr
 	}
 	e.SetIdentity(identity)
 

--- a/daemon/policy_test.go
+++ b/daemon/policy_test.go
@@ -58,6 +58,46 @@ var (
 	regenerationMetadata = &endpoint.ExternalRegenerationMetadata{
 		Reason: "test",
 	}
+
+	CNPAllowGETbar = api.PortRule{
+		Ports: []api.PortProtocol{
+			{Port: "80", Protocol: api.ProtoTCP},
+		},
+		Rules: &api.L7Rules{
+			HTTP: []api.PortRuleHTTP{
+				{
+					Path:   "/bar",
+					Method: "GET",
+				},
+			},
+		},
+	}
+
+	PNPAllowAll = cilium.PortNetworkPolicyRule_HttpRules{
+		HttpRules: &cilium.HttpNetworkPolicyRules{
+			HttpRules: []*cilium.HttpNetworkPolicyRule{
+				{},
+			},
+		},
+	}
+	PNPAllowGETbar = cilium.PortNetworkPolicyRule_HttpRules{
+		HttpRules: &cilium.HttpNetworkPolicyRules{
+			HttpRules: []*cilium.HttpNetworkPolicyRule{
+				{
+					Headers: []*envoy_api_v2_route.HeaderMatcher{
+						{
+							Name:                 ":method",
+							HeaderMatchSpecifier: &envoy_api_v2_route.HeaderMatcher_RegexMatch{RegexMatch: "GET"},
+						},
+						{
+							Name:                 ":path",
+							HeaderMatchSpecifier: &envoy_api_v2_route.HeaderMatcher_RegexMatch{RegexMatch: "/bar"},
+						},
+					},
+				},
+			},
+		},
+	}
 )
 
 // getXDSNetworkPolicies returns the representation of the xDS network policies
@@ -124,19 +164,8 @@ func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
 						api.NewESFromLabels(lblFoo),
 					},
 					ToPorts: []api.PortRule{
-						{
-							Ports: []api.PortProtocol{
-								{Port: "80", Protocol: api.ProtoTCP},
-							},
-							Rules: &api.L7Rules{
-								HTTP: []api.PortRuleHTTP{
-									{
-										Path:   "/bar",
-										Method: "GET",
-									},
-								},
-							},
-						},
+						// Allow Port 80 GET /bar
+						CNPAllowGETbar,
 					},
 				},
 			},
@@ -236,34 +265,11 @@ func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
 				Rules: []*cilium.PortNetworkPolicyRule{
 					{
 						RemotePolicies: expectedRemotePolicies,
-						L7: &cilium.PortNetworkPolicyRule_HttpRules{
-							HttpRules: &cilium.HttpNetworkPolicyRules{
-								HttpRules: []*cilium.HttpNetworkPolicyRule{
-									{},
-								},
-							},
-						},
+						L7:             &PNPAllowAll,
 					},
 					{
 						RemotePolicies: expectedRemotePolicies,
-						L7: &cilium.PortNetworkPolicyRule_HttpRules{
-							HttpRules: &cilium.HttpNetworkPolicyRules{
-								HttpRules: []*cilium.HttpNetworkPolicyRule{
-									{
-										Headers: []*envoy_api_v2_route.HeaderMatcher{
-											{
-												Name:                 ":method",
-												HeaderMatchSpecifier: &envoy_api_v2_route.HeaderMatcher_RegexMatch{RegexMatch: "GET"},
-											},
-											{
-												Name:                 ":path",
-												HeaderMatchSpecifier: &envoy_api_v2_route.HeaderMatcher_RegexMatch{RegexMatch: "/bar"},
-											},
-										},
-									},
-								},
-							},
-						},
+						L7:             &PNPAllowGETbar,
 					},
 				},
 			},
@@ -304,44 +310,15 @@ func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
 				Rules: []*cilium.PortNetworkPolicyRule{
 					{
 						RemotePolicies: expectedRemotePolicies2,
-						L7: &cilium.PortNetworkPolicyRule_HttpRules{
-							HttpRules: &cilium.HttpNetworkPolicyRules{
-								HttpRules: []*cilium.HttpNetworkPolicyRule{
-									{},
-								},
-							},
-						},
+						L7:             &PNPAllowAll,
 					},
 					{
 						RemotePolicies: expectedRemotePolicies,
-						L7: &cilium.PortNetworkPolicyRule_HttpRules{
-							HttpRules: &cilium.HttpNetworkPolicyRules{
-								HttpRules: []*cilium.HttpNetworkPolicyRule{
-									{},
-								},
-							},
-						},
+						L7:             &PNPAllowAll,
 					},
 					{
 						RemotePolicies: expectedRemotePolicies,
-						L7: &cilium.PortNetworkPolicyRule_HttpRules{
-							HttpRules: &cilium.HttpNetworkPolicyRules{
-								HttpRules: []*cilium.HttpNetworkPolicyRule{
-									{
-										Headers: []*envoy_api_v2_route.HeaderMatcher{
-											{
-												Name:                 ":method",
-												HeaderMatchSpecifier: &envoy_api_v2_route.HeaderMatcher_RegexMatch{RegexMatch: "GET"},
-											},
-											{
-												Name:                 ":path",
-												HeaderMatchSpecifier: &envoy_api_v2_route.HeaderMatcher_RegexMatch{RegexMatch: "/bar"},
-											},
-										},
-									},
-								},
-							},
-						},
+						L7:             &PNPAllowGETbar,
 					},
 				},
 			},
@@ -405,19 +382,8 @@ func (ds *DaemonSuite) TestRemovePolicy(c *C) {
 						api.NewESFromLabels(lblFoo),
 					},
 					ToPorts: []api.PortRule{
-						{
-							Ports: []api.PortProtocol{
-								{Port: "80", Protocol: api.ProtoTCP},
-							},
-							Rules: &api.L7Rules{
-								HTTP: []api.PortRuleHTTP{
-									{
-										Path:   "/bar",
-										Method: "GET",
-									},
-								},
-							},
-						},
+						// Allow Port 80 GET /bar
+						CNPAllowGETbar,
 					},
 				},
 			},

--- a/daemon/policy_test.go
+++ b/daemon/policy_test.go
@@ -59,10 +59,13 @@ var (
 		Reason: "test",
 	}
 
-	CNPAllowGETbar = api.PortRule{
+	CNPAllowTCP80 = api.PortRule{
 		Ports: []api.PortProtocol{
 			{Port: "80", Protocol: api.ProtoTCP},
 		},
+	}
+	CNPAllowGETbar = api.PortRule{
+		Ports: CNPAllowTCP80.Ports,
 		Rules: &api.L7Rules{
 			HTTP: []api.PortRuleHTTP{
 				{
@@ -329,6 +332,87 @@ func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
 		},
 	}
 	c.Assert(prodBarNetworkPolicy, checker.DeepEquals, expectedNetworkPolicy)
+}
+
+func (ds *DaemonSuite) TestL4_L7_Shadowing(c *C) {
+	rules := api.Rules{
+		{
+			EndpointSelector: api.NewESFromLabels(lblBar),
+			Ingress: []api.IngressRule{
+				{
+					ToPorts: []api.PortRule{
+						// Allow all on port 80 (no proxy)
+						CNPAllowTCP80,
+					},
+				},
+				{
+					FromEndpoints: []api.EndpointSelector{
+						api.NewESFromLabels(lblFoo),
+					},
+					ToPorts: []api.PortRule{
+						// Allow Port 80 GET /bar
+						CNPAllowGETbar,
+					},
+				},
+			},
+		},
+	}
+
+	ds.d.l7Proxy.RemoveAllNetworkPolicies()
+
+	_, err := ds.d.PolicyAdd(rules, nil)
+	c.Assert(err, Equals, nil)
+
+	// Prepare the identities necessary for testing
+	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}
+	qaBarSecLblsCtx, _, err := cache.AllocateIdentity(context.Background(), qaBarLbls)
+	c.Assert(err, Equals, nil)
+	defer cache.Release(context.Background(), qaBarSecLblsCtx)
+	qaFooLbls := labels.Labels{lblFoo.Key: lblFoo, lblQA.Key: lblQA}
+	qaFooSecLblsCtx, _, err := cache.AllocateIdentity(context.Background(), qaFooLbls)
+	c.Assert(err, Equals, nil)
+	defer cache.Release(context.Background(), qaFooSecLblsCtx)
+
+	// Prepare endpoints
+	cleanup, err := prepareEndpointDirs()
+	c.Assert(err, Equals, nil)
+	defer cleanup()
+
+	e := ds.prepareEndpoint(c, qaBarSecLblsCtx, true)
+	c.Assert(e.Allows(qaBarSecLblsCtx.ID), Equals, false)
+	c.Assert(e.Allows(qaFooSecLblsCtx.ID), Equals, false)
+
+	// Check that both policies have been updated in the xDS cache for the L7
+	// proxies.
+	networkPolicies := ds.getXDSNetworkPolicies(c, nil)
+	c.Assert(networkPolicies, HasLen, 2)
+
+	qaBarNetworkPolicy := networkPolicies[QAIPv4Addr.String()]
+	expectedNetworkPolicy := &cilium.NetworkPolicy{
+		Name:   QAIPv4Addr.String(),
+		Policy: uint64(qaBarSecLblsCtx.ID),
+		IngressPerPortPolicies: []*cilium.PortNetworkPolicy{
+			{
+				Port:     80,
+				Protocol: envoy_api_v2_core.SocketAddress_TCP,
+				Rules: []*cilium.PortNetworkPolicyRule{
+					{
+						RemotePolicies: nil,
+						L7:             &PNPAllowAll,
+					},
+					{
+						RemotePolicies: []uint64{uint64(qaFooSecLblsCtx.ID)},
+						L7:             &PNPAllowGETbar,
+					},
+				},
+			},
+		},
+		EgressPerPortPolicies: []*cilium.PortNetworkPolicy{ // Allow-all policy.
+			{Protocol: envoy_api_v2_core.SocketAddress_TCP},
+			{Protocol: envoy_api_v2_core.SocketAddress_UDP},
+		},
+	}
+	c.Assert(qaBarNetworkPolicy, checker.DeepEquals, expectedNetworkPolicy)
 }
 
 func (ds *DaemonSuite) TestReplacePolicy(c *C) {

--- a/pkg/identity/cache/allocation_test.go
+++ b/pkg/identity/cache/allocation_test.go
@@ -19,7 +19,6 @@ package cache
 import (
 	"context"
 
-	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/labels"

--- a/pkg/node/node_address_test.go
+++ b/pkg/node/node_address_test.go
@@ -23,7 +23,6 @@ import (
 	"path/filepath"
 	"reflect"
 
-	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/cidr"
 
 	. "gopkg.in/check.v1"

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 Authors of Cilium
+// Copyright 2016-2017 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -109,11 +109,6 @@ func wildcardL3L4Rule(proto api.L4Proto, port int, endpoints api.EndpointSelecto
 		if proto != filter.Protocol || (port != 0 && port != filter.Port) {
 			continue
 		}
-
-		if endpoints.SelectsAllEndpoints() {
-			endpoints = api.EndpointSelectorSlice{api.WildcardEndpointSelector}
-		}
-
 		switch filter.L7Parser {
 		case ParserTypeNone:
 			continue

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -109,6 +109,11 @@ func wildcardL3L4Rule(proto api.L4Proto, port int, endpoints api.EndpointSelecto
 		if proto != filter.Protocol || (port != 0 && port != filter.Port) {
 			continue
 		}
+
+		if endpoints.SelectsAllEndpoints() {
+			endpoints = api.EndpointSelectorSlice{api.WildcardEndpointSelector}
+		}
+
 		switch filter.L7Parser {
 		case ParserTypeNone:
 			continue

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -2117,8 +2117,7 @@ func (ds *PolicyTestSuite) TestL4WildcardMerge(c *C) {
 	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, true)
 
-	// 3 -> One for each rule, plus one from the l4-only rule (l7 scan).
-	c.Assert(len(filter.Endpoints), Equals, 3)
+	c.Assert(len(filter.Endpoints), Equals, 2)
 	c.Assert(filter.L7Parser, Equals, ParserTypeHTTP)
 	c.Assert(len(filter.L7RulesPerEp), Equals, 2)
 

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -2166,8 +2166,8 @@ func (ds *PolicyTestSuite) TestL4WildcardMerge(c *C) {
 	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, true)
 
-	// 3 -> One for each rule, plus one from the l4-only rule (l7 scan).
-	c.Assert(len(filter.Endpoints), Equals, 3)
+	// 2 -> One for each rule.
+	c.Assert(len(filter.Endpoints), Equals, 2)
 
 	c.Assert(filter.L7Parser, Equals, ParserTypeHTTP)
 	c.Assert(len(filter.L7RulesPerEp), Equals, 2)

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -2019,11 +2019,12 @@ func (ds *PolicyTestSuite) TestL4WildcardMerge(c *C) {
 	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, true)
 
-	c.Assert(len(filter.Endpoints), Equals, 1)
+	c.Assert(len(filter.Endpoints), Equals, 2)
 	c.Assert(filter.Endpoints[0], Equals, api.WildcardEndpointSelector)
+	c.Assert(filter.Endpoints[1], Equals, api.WildcardEndpointSelector)
 
 	c.Assert(filter.L7Parser, Equals, ParserTypeHTTP)
-	c.Assert(len(filter.L7RulesPerEp), Equals, 1)
+	c.Assert(len(filter.L7RulesPerEp), Equals, 2)
 
 	// Test the reverse order as well; ensure that we check both conditions
 	// for if L4-only policy is in the L4Filter for the same port-protocol tuple,
@@ -2069,10 +2070,10 @@ func (ds *PolicyTestSuite) TestL4WildcardMerge(c *C) {
 	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, true)
 
-	c.Assert(len(filter.Endpoints), Equals, 1)
+	c.Assert(len(filter.Endpoints), Equals, 2)
 
 	c.Assert(filter.L7Parser, Equals, ParserTypeHTTP)
-	c.Assert(len(filter.L7RulesPerEp), Equals, 1)
+	c.Assert(len(filter.L7RulesPerEp), Equals, 2)
 
 	// Second, test the explicit allow at L3.
 	repo = parseAndAddRules(c, api.Rules{&api.Rule{
@@ -2115,7 +2116,9 @@ func (ds *PolicyTestSuite) TestL4WildcardMerge(c *C) {
 	c.Assert(ok, Equals, true)
 	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, true)
-	c.Assert(len(filter.Endpoints), Equals, 2)
+
+	// 3 -> One for each rule, plus one from the l4-only rule (l7 scan).
+	c.Assert(len(filter.Endpoints), Equals, 3)
 	c.Assert(filter.L7Parser, Equals, ParserTypeHTTP)
 	c.Assert(len(filter.L7RulesPerEp), Equals, 2)
 
@@ -2164,7 +2167,8 @@ func (ds *PolicyTestSuite) TestL4WildcardMerge(c *C) {
 	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, true)
 
-	c.Assert(len(filter.Endpoints), Equals, 2)
+	// 3 -> One for each rule, plus one from the l4-only rule (l7 scan).
+	c.Assert(len(filter.Endpoints), Equals, 3)
 
 	c.Assert(filter.L7Parser, Equals, ParserTypeHTTP)
 	c.Assert(len(filter.L7RulesPerEp), Equals, 2)

--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -76,6 +76,9 @@ func (rules ruleSlice) wildcardL3L4Rules(ctx *SearchContext, ingress bool, l4Pol
 					wildcardL3L4Rule(api.ProtoTCP, 0, fromEndpoints, ruleLabels, l4Policy)
 					wildcardL3L4Rule(api.ProtoUDP, 0, fromEndpoints, ruleLabels, l4Policy)
 				} else {
+					if fromEndpoints.SelectsAllEndpoints() {
+						fromEndpoints = append(fromEndpoints, api.WildcardEndpointSelector)
+					}
 					for _, toPort := range rule.ToPorts {
 						// L3/L4-only rule
 						if toPort.Rules.IsEmpty() {
@@ -108,6 +111,9 @@ func (rules ruleSlice) wildcardL3L4Rules(ctx *SearchContext, ingress bool, l4Pol
 					wildcardL3L4Rule(api.ProtoTCP, 0, toEndpoints, ruleLabels, l4Policy)
 					wildcardL3L4Rule(api.ProtoUDP, 0, toEndpoints, ruleLabels, l4Policy)
 				} else {
+					if toEndpoints.SelectsAllEndpoints() {
+						toEndpoints = append(toEndpoints, api.WildcardEndpointSelector)
+					}
 					for _, toPort := range rule.ToPorts {
 						// L3/L4-only rule
 						if toPort.Rules.IsEmpty() {

--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -76,9 +76,6 @@ func (rules ruleSlice) wildcardL3L4Rules(ctx *SearchContext, ingress bool, l4Pol
 					wildcardL3L4Rule(api.ProtoTCP, 0, fromEndpoints, ruleLabels, l4Policy)
 					wildcardL3L4Rule(api.ProtoUDP, 0, fromEndpoints, ruleLabels, l4Policy)
 				} else {
-					if fromEndpoints.SelectsAllEndpoints() {
-						fromEndpoints = append(fromEndpoints, api.WildcardEndpointSelector)
-					}
 					for _, toPort := range rule.ToPorts {
 						// L3/L4-only rule
 						if toPort.Rules.IsEmpty() {
@@ -111,9 +108,6 @@ func (rules ruleSlice) wildcardL3L4Rules(ctx *SearchContext, ingress bool, l4Pol
 					wildcardL3L4Rule(api.ProtoTCP, 0, toEndpoints, ruleLabels, l4Policy)
 					wildcardL3L4Rule(api.ProtoUDP, 0, toEndpoints, ruleLabels, l4Policy)
 				} else {
-					if toEndpoints.SelectsAllEndpoints() {
-						toEndpoints = append(toEndpoints, api.WildcardEndpointSelector)
-					}
 					for _, toPort := range rule.ToPorts {
 						// L3/L4-only rule
 						if toPort.Rules.IsEmpty() {

--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -76,6 +76,13 @@ func (rules ruleSlice) wildcardL3L4Rules(ctx *SearchContext, ingress bool, l4Pol
 					wildcardL3L4Rule(api.ProtoTCP, 0, fromEndpoints, ruleLabels, l4Policy)
 					wildcardL3L4Rule(api.ProtoUDP, 0, fromEndpoints, ruleLabels, l4Policy)
 				} else {
+					// L4-only or L3-dependent L4 rule.
+					//
+					// "fromEndpoints" may be empty here, which indicates that all L3 peers should
+					// be selected. If so, add the wildcard selector.
+					if len(fromEndpoints) == 0 {
+						fromEndpoints = append(fromEndpoints, api.WildcardEndpointSelector)
+					}
 					for _, toPort := range rule.ToPorts {
 						// L3/L4-only rule
 						if toPort.Rules.IsEmpty() {
@@ -108,6 +115,13 @@ func (rules ruleSlice) wildcardL3L4Rules(ctx *SearchContext, ingress bool, l4Pol
 					wildcardL3L4Rule(api.ProtoTCP, 0, toEndpoints, ruleLabels, l4Policy)
 					wildcardL3L4Rule(api.ProtoUDP, 0, toEndpoints, ruleLabels, l4Policy)
 				} else {
+					// L4-only or L3-dependent L4 rule.
+					//
+					// "toEndpoints" may be empty here, which indicates that all L3 peers should
+					// be selected. If so, add the wildcard selector.
+					if len(toEndpoints) == 0 {
+						toEndpoints = append(toEndpoints, api.WildcardEndpointSelector)
+					}
 					for _, toPort := range rule.ToPorts {
 						// L3/L4-only rule
 						if toPort.Rules.IsEmpty() {

--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -76,13 +76,6 @@ func (rules ruleSlice) wildcardL3L4Rules(ctx *SearchContext, ingress bool, l4Pol
 					wildcardL3L4Rule(api.ProtoTCP, 0, fromEndpoints, ruleLabels, l4Policy)
 					wildcardL3L4Rule(api.ProtoUDP, 0, fromEndpoints, ruleLabels, l4Policy)
 				} else {
-					// L4-only or L3-dependent L4 rule.
-					//
-					// "fromEndpoints" may be empty here, which indicates that all L3 peers should
-					// be selected. If so, add the wildcard selector.
-					if len(fromEndpoints) == 0 {
-						fromEndpoints = append(fromEndpoints, api.WildcardEndpointSelector)
-					}
 					for _, toPort := range rule.ToPorts {
 						// L3/L4-only rule
 						if toPort.Rules.IsEmpty() {
@@ -115,13 +108,6 @@ func (rules ruleSlice) wildcardL3L4Rules(ctx *SearchContext, ingress bool, l4Pol
 					wildcardL3L4Rule(api.ProtoTCP, 0, toEndpoints, ruleLabels, l4Policy)
 					wildcardL3L4Rule(api.ProtoUDP, 0, toEndpoints, ruleLabels, l4Policy)
 				} else {
-					// L4-only or L3-dependent L4 rule.
-					//
-					// "toEndpoints" may be empty here, which indicates that all L3 peers should
-					// be selected. If so, add the wildcard selector.
-					if len(toEndpoints) == 0 {
-						toEndpoints = append(toEndpoints, api.WildcardEndpointSelector)
-					}
 					for _, toPort := range rule.ToPorts {
 						// L3/L4-only rule
 						if toPort.Rules.IsEmpty() {


### PR DESCRIPTION
* #7476 -- Fix issue where traffic matching L4-only rule would be redirected to the proxy then dropped (@joestringer)
   * Had to rebase to remove the changes in commit 55b0fd3d22a9. Minor fixup.
* Re-backport of #7520 -- This was previously backported, but it reverts part of #7476. The commit was only partly the same as the original PR, so I undid the revert, backported #7476, then re-backported #7520 again.

Once this PR is merged, you can update the PR labels via:
```
$ for pr in 7476; do contrib/backporting/set-labels.py $pr done 1.4; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7544)
<!-- Reviewable:end -->
