### PR TITLE
Fix commit order in check-stable backporting script

### DIFF
--- a/contrib/backporting/check-stable
+++ b/contrib/backporting/check-stable
@@ -132,23 +132,20 @@ generate_commit_list_for_pr () {
 
   url="https://api.github.com/repos/cilium/cilium/pulls/$pr/commits"
   pr_json="$($GHCURL $url)"
-  commits="$(echo -n $pr_json | jq -r '.[] | (.sha | tostring)')"
-
-  SAVEIFS=$IFS
-  IFS=$'\n'
-  commits=($commits)
-  IFS=$SAVEIFS
+  n_commits="$(echo -n $pr_json | jq -r '. | length')"
 
   tmp_file=`mktemp pr-correlation.XXXXXX`
   branch="check-for-stable-$pr"
   git fetch -q $remote pull/$pr/head:$branch
-  for commit in "${commits[@]}"; do
+  # Use GitHub to determine the number of commits to list, but then query
+  # the branch directly to determine the canonical order of the commits.
+  for commit in $(git rev-list --reverse -$n_commits $branch); do
     patchid="$(git show $commit | git patch-id)"
     subject="$(git show -s --pretty="%s" $commit)"
     echo "$patchid $subject" >> $tmp_file
   done
   git branch -q -D $branch
-  echo "   Merge with ${#commits[@]} commit(s) merged at: `date -R -d "$(echo $merged_at | sed 's/T/ /')"`!"
+  echo "   Merge with $n_commits commit(s) merged at: `date -R -d "$(echo $merged_at | sed 's/T/ /')"`!"
   echo "     Branch:     master (!)                          refs/pull/$pr/head"
   echo "                 ----------                          -------------------"
   echo "     v (start)"


### PR DESCRIPTION
For particular PRs, for example #7476, the chronoligcal ordering of
commits based upon `AuthorDate` is not the same as the revision list
ordering in git, which caused the list of commits to be out-of-order
when printing on the commandline. This could cause problems during
backporting where backporters would inadvertently attempt to backport
later commits before earlier commits that they depend on, leading to
more conflicts than necessary during the backport process.

Fix this up by using the canonical commit ordering in the branch that
was merged, and only use GitHub's PR commit list as a way to determine
the total number of commits being merged in the PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7545)
<!-- Reviewable:end -->
