### PR TITLE
v1.3 backports 2019-03-29

### DIFF
--- a/contrib/backporting/check-stable
+++ b/contrib/backporting/check-stable
@@ -132,23 +132,20 @@ generate_commit_list_for_pr () {
 
   url="https://api.github.com/repos/cilium/cilium/pulls/$pr/commits"
   pr_json="$($GHCURL $url)"
-  commits="$(echo -n $pr_json | jq -r '.[] | (.sha | tostring)')"
-
-  SAVEIFS=$IFS
-  IFS=$'\n'
-  commits=($commits)
-  IFS=$SAVEIFS
+  n_commits="$(echo -n $pr_json | jq -r '. | length')"
 
   tmp_file=`mktemp pr-correlation.XXXXXX`
   branch="check-for-stable-$pr"
   git fetch -q $remote pull/$pr/head:$branch
-  for commit in "${commits[@]}"; do
+  # Use GitHub to determine the number of commits to list, but then query
+  # the branch directly to determine the canonical order of the commits.
+  for commit in $(git rev-list --reverse -$n_commits $branch); do
     patchid="$(git show $commit | git patch-id)"
     subject="$(git show -s --pretty="%s" $commit)"
     echo "$patchid $subject" >> $tmp_file
   done
   git branch -q -D $branch
-  echo "   Merge with ${#commits[@]} commit(s) merged at: `date -R -d "$(echo $merged_at | sed 's/T/ /')"`!"
+  echo "   Merge with $n_commits commit(s) merged at: `date -R -d "$(echo $merged_at | sed 's/T/ /')"`!"
   echo "     Branch:     master (!)                          refs/pull/$pr/head"
   echo "                 ----------                          -------------------"
   echo "     v (start)"

--- a/daemon/policy_test.go
+++ b/daemon/policy_test.go
@@ -44,6 +44,12 @@ var (
 	ProdIPv6Addr, _ = addressing.NewCiliumIPv6("cafe:cafe:cafe:cafe:aaaa:aaaa:1111:1112")
 	ProdIPv4Addr, _ = addressing.NewCiliumIPv4("10.11.12.14")
 
+	lblProd      = labels.ParseLabel("Prod")
+	lblQA        = labels.ParseLabel("QA")
+	lblFoo       = labels.ParseLabel("foo")
+	lblBar       = labels.ParseLabel("bar")
+	lblJoe       = labels.ParseLabel("user=joe")
+	lblPete      = labels.ParseLabel("user=pete")
 	regenContext = endpoint.NewRegenerationContext("test")
 
 	CNPAllowGETbar = api.PortRule{
@@ -137,13 +143,6 @@ func (ds *DaemonSuite) prepareEndpoint(c *C, identity *identity.Identity, qa boo
 }
 
 func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
-	lblProd := labels.ParseLabel("Prod")
-	lblQA := labels.ParseLabel("QA")
-	lblFoo := labels.ParseLabel("foo")
-	lblBar := labels.ParseLabel("bar")
-	lblJoe := labels.ParseLabel("user=joe")
-	lblPete := labels.ParseLabel("user=pete")
-
 	rules := api.Rules{
 		{
 			EndpointSelector: api.NewESFromLabels(lblBar),
@@ -322,7 +321,6 @@ func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
 }
 
 func (ds *DaemonSuite) TestReplacePolicy(c *C) {
-	lblBar := labels.ParseLabel("bar")
 	lbls := labels.ParseLabelArray("foo", "bar")
 	rules := api.Rules{
 		{
@@ -357,13 +355,6 @@ func (ds *DaemonSuite) TestReplacePolicy(c *C) {
 }
 
 func (ds *DaemonSuite) TestRemovePolicy(c *C) {
-	lblProd := labels.ParseLabel("Prod")
-	lblQA := labels.ParseLabel("QA")
-	lblFoo := labels.ParseLabel("foo")
-	lblBar := labels.ParseLabel("bar")
-	lblJoe := labels.ParseLabel("user=joe")
-	lblPete := labels.ParseLabel("user=pete")
-
 	rules := api.Rules{
 		{
 			EndpointSelector: api.NewESFromLabels(lblBar),

--- a/daemon/policy_test.go
+++ b/daemon/policy_test.go
@@ -27,7 +27,6 @@ import (
 	envoy_api_v2_core "github.com/cilium/cilium/pkg/envoy/envoy/api/v2/core"
 	envoy_api_v2_route "github.com/cilium/cilium/pkg/envoy/envoy/api/v2/route"
 	"github.com/cilium/cilium/pkg/identity"
-	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/mac"
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -52,10 +51,13 @@ var (
 	lblPete      = labels.ParseLabel("user=pete")
 	regenContext = endpoint.NewRegenerationContext("test")
 
-	CNPAllowGETbar = api.PortRule{
+	CNPAllowTCP80 = api.PortRule{
 		Ports: []api.PortProtocol{
 			{Port: "80", Protocol: api.ProtoTCP},
 		},
+	}
+	CNPAllowGETbar = api.PortRule{
+		Ports: CNPAllowTCP80.Ports,
 		Rules: &api.L7Rules{
 			HTTP: []api.PortRuleHTTP{
 				{
@@ -318,6 +320,87 @@ func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
 		},
 	}
 	c.Assert(prodBarNetworkPolicy, checker.DeepEquals, expectedNetworkPolicy)
+}
+
+func (ds *DaemonSuite) TestL4_L7_Shadowing(c *C) {
+	rules := api.Rules{
+		{
+			EndpointSelector: api.NewESFromLabels(lblBar),
+			Ingress: []api.IngressRule{
+				{
+					ToPorts: []api.PortRule{
+						// Allow all on port 80 (no proxy)
+						CNPAllowTCP80,
+					},
+				},
+				{
+					FromEndpoints: []api.EndpointSelector{
+						api.NewESFromLabels(lblFoo),
+					},
+					ToPorts: []api.PortRule{
+						// Allow Port 80 GET /bar
+						CNPAllowGETbar,
+					},
+				},
+			},
+		},
+	}
+
+	ds.d.l7Proxy.RemoveAllNetworkPolicies()
+
+	_, err := ds.d.PolicyAdd(rules, nil)
+	c.Assert(err, Equals, nil)
+
+	// Prepare the identities necessary for testing
+	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}
+	qaBarSecLblsCtx, _, err := identity.AllocateIdentity(qaBarLbls)
+	c.Assert(err, Equals, nil)
+	defer qaBarSecLblsCtx.Release()
+	qaFooLbls := labels.Labels{lblFoo.Key: lblFoo, lblQA.Key: lblQA}
+	qaFooSecLblsCtx, _, err := identity.AllocateIdentity(qaFooLbls)
+	c.Assert(err, Equals, nil)
+	defer qaFooSecLblsCtx.Release()
+
+	// Prepare endpoints
+	cleanup, err := prepareEndpointDirs()
+	c.Assert(err, Equals, nil)
+	defer cleanup()
+
+	e := ds.prepareEndpoint(c, qaBarSecLblsCtx, true)
+	c.Assert(e.Allows(qaBarSecLblsCtx.ID), Equals, false)
+	c.Assert(e.Allows(qaFooSecLblsCtx.ID), Equals, false)
+
+	// Check that both policies have been updated in the xDS cache for the L7
+	// proxies.
+	networkPolicies := ds.getXDSNetworkPolicies(c, nil)
+	c.Assert(networkPolicies, HasLen, 2)
+
+	qaBarNetworkPolicy := networkPolicies[QAIPv4Addr.String()]
+	expectedNetworkPolicy := &cilium.NetworkPolicy{
+		Name:   QAIPv4Addr.String(),
+		Policy: uint64(qaBarSecLblsCtx.ID),
+		IngressPerPortPolicies: []*cilium.PortNetworkPolicy{
+			{
+				Port:     80,
+				Protocol: envoy_api_v2_core.SocketAddress_TCP,
+				Rules: []*cilium.PortNetworkPolicyRule{
+					{
+						RemotePolicies: nil,
+						L7:             &PNPAllowAll,
+					},
+					{
+						RemotePolicies: []uint64{uint64(qaFooSecLblsCtx.ID)},
+						L7:             &PNPAllowGETbar,
+					},
+				},
+			},
+		},
+		EgressPerPortPolicies: []*cilium.PortNetworkPolicy{ // Allow-all policy.
+			{Protocol: envoy_api_v2_core.SocketAddress_TCP},
+			{Protocol: envoy_api_v2_core.SocketAddress_UDP},
+		},
+	}
+	c.Assert(qaBarNetworkPolicy, checker.DeepEquals, expectedNetworkPolicy)
 }
 
 func (ds *DaemonSuite) TestReplacePolicy(c *C) {

--- a/daemon/policy_test.go
+++ b/daemon/policy_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -43,6 +43,46 @@ var (
 	ProdIPv4Addr, _ = addressing.NewCiliumIPv4("10.11.12.14")
 
 	regenContext = endpoint.NewRegenerationContext("test")
+
+	CNPAllowGETbar = api.PortRule{
+		Ports: []api.PortProtocol{
+			{Port: "80", Protocol: api.ProtoTCP},
+		},
+		Rules: &api.L7Rules{
+			HTTP: []api.PortRuleHTTP{
+				{
+					Path:   "/bar",
+					Method: "GET",
+				},
+			},
+		},
+	}
+
+	PNPAllowAll = cilium.PortNetworkPolicyRule_HttpRules{
+		HttpRules: &cilium.HttpNetworkPolicyRules{
+			HttpRules: []*cilium.HttpNetworkPolicyRule{
+				{},
+			},
+		},
+	}
+	PNPAllowGETbar = cilium.PortNetworkPolicyRule_HttpRules{
+		HttpRules: &cilium.HttpNetworkPolicyRules{
+			HttpRules: []*cilium.HttpNetworkPolicyRule{
+				{
+					Headers: []*envoy_api_v2_route.HeaderMatcher{
+						{
+							Name:                 ":method",
+							HeaderMatchSpecifier: &envoy_api_v2_route.HeaderMatcher_RegexMatch{RegexMatch: "GET"},
+						},
+						{
+							Name:                 ":path",
+							HeaderMatchSpecifier: &envoy_api_v2_route.HeaderMatcher_RegexMatch{RegexMatch: "/bar"},
+						},
+					},
+				},
+			},
+		},
+	}
 )
 
 // getXDSNetworkPolicies returns the representation of the xDS network policies
@@ -77,19 +117,8 @@ func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
 						api.NewESFromLabels(lblFoo),
 					},
 					ToPorts: []api.PortRule{
-						{
-							Ports: []api.PortProtocol{
-								{Port: "80", Protocol: api.ProtoTCP},
-							},
-							Rules: &api.L7Rules{
-								HTTP: []api.PortRuleHTTP{
-									{
-										Path:   "/bar",
-										Method: "GET",
-									},
-								},
-							},
-						},
+						// Allow Port 80 GET /bar
+						CNPAllowGETbar,
 					},
 				},
 			},
@@ -218,34 +247,11 @@ func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
 				Rules: []*cilium.PortNetworkPolicyRule{
 					{
 						RemotePolicies: expectedRemotePolicies,
-						L7: &cilium.PortNetworkPolicyRule_HttpRules{
-							HttpRules: &cilium.HttpNetworkPolicyRules{
-								HttpRules: []*cilium.HttpNetworkPolicyRule{
-									{},
-								},
-							},
-						},
+						L7:             &PNPAllowAll,
 					},
 					{
 						RemotePolicies: expectedRemotePolicies,
-						L7: &cilium.PortNetworkPolicyRule_HttpRules{
-							HttpRules: &cilium.HttpNetworkPolicyRules{
-								HttpRules: []*cilium.HttpNetworkPolicyRule{
-									{
-										Headers: []*envoy_api_v2_route.HeaderMatcher{
-											{
-												Name:                 ":method",
-												HeaderMatchSpecifier: &envoy_api_v2_route.HeaderMatcher_RegexMatch{RegexMatch: "GET"},
-											},
-											{
-												Name:                 ":path",
-												HeaderMatchSpecifier: &envoy_api_v2_route.HeaderMatcher_RegexMatch{RegexMatch: "/bar"},
-											},
-										},
-									},
-								},
-							},
-						},
+						L7:             &PNPAllowGETbar,
 					},
 				},
 			},
@@ -282,44 +288,15 @@ func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
 				Rules: []*cilium.PortNetworkPolicyRule{
 					{
 						RemotePolicies: expectedRemotePolicies2,
-						L7: &cilium.PortNetworkPolicyRule_HttpRules{
-							HttpRules: &cilium.HttpNetworkPolicyRules{
-								HttpRules: []*cilium.HttpNetworkPolicyRule{
-									{},
-								},
-							},
-						},
+						L7:             &PNPAllowAll,
 					},
 					{
 						RemotePolicies: expectedRemotePolicies,
-						L7: &cilium.PortNetworkPolicyRule_HttpRules{
-							HttpRules: &cilium.HttpNetworkPolicyRules{
-								HttpRules: []*cilium.HttpNetworkPolicyRule{
-									{},
-								},
-							},
-						},
+						L7:             &PNPAllowAll,
 					},
 					{
 						RemotePolicies: expectedRemotePolicies,
-						L7: &cilium.PortNetworkPolicyRule_HttpRules{
-							HttpRules: &cilium.HttpNetworkPolicyRules{
-								HttpRules: []*cilium.HttpNetworkPolicyRule{
-									{
-										Headers: []*envoy_api_v2_route.HeaderMatcher{
-											{
-												Name:                 ":method",
-												HeaderMatchSpecifier: &envoy_api_v2_route.HeaderMatcher_RegexMatch{RegexMatch: "GET"},
-											},
-											{
-												Name:                 ":path",
-												HeaderMatchSpecifier: &envoy_api_v2_route.HeaderMatcher_RegexMatch{RegexMatch: "/bar"},
-											},
-										},
-									},
-								},
-							},
-						},
+						L7:             &PNPAllowGETbar,
 					},
 				},
 			},
@@ -391,19 +368,8 @@ func (ds *DaemonSuite) TestRemovePolicy(c *C) {
 						api.NewESFromLabels(lblFoo),
 					},
 					ToPorts: []api.PortRule{
-						{
-							Ports: []api.PortProtocol{
-								{Port: "80", Protocol: api.ProtoTCP},
-							},
-							Rules: &api.L7Rules{
-								HTTP: []api.PortRuleHTTP{
-									{
-										Path:   "/bar",
-										Method: "GET",
-									},
-								},
-							},
-						},
+						// Allow Port 80 GET /bar
+						CNPAllowGETbar,
 					},
 				},
 			},

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -188,6 +188,13 @@ func (p *Repository) wildcardL3L4Rules(ctx *SearchContext, ingress bool, l4Polic
 					wildcardL3L4Rule(api.ProtoTCP, 0, fromEndpoints, ruleLabels, l4Policy)
 					wildcardL3L4Rule(api.ProtoUDP, 0, fromEndpoints, ruleLabels, l4Policy)
 				} else {
+					// L4-only or L3-dependent L4 rule.
+					//
+					// "fromEndpoints" may be empty here, which indicates that all L3 peers should
+					// be selected. If so, add the wildcard selector.
+					if len(fromEndpoints) == 0 {
+						fromEndpoints = append(fromEndpoints, api.WildcardEndpointSelector)
+					}
 					for _, toPort := range rule.ToPorts {
 						// L3/L4-only rule
 						if toPort.Rules.IsEmpty() {
@@ -218,6 +225,13 @@ func (p *Repository) wildcardL3L4Rules(ctx *SearchContext, ingress bool, l4Polic
 					wildcardL3L4Rule(api.ProtoTCP, 0, toEndpoints, ruleLabels, l4Policy)
 					wildcardL3L4Rule(api.ProtoUDP, 0, toEndpoints, ruleLabels, l4Policy)
 				} else {
+					// L4-only or L3-dependent L4 rule.
+					//
+					// "toEndpoints" may be empty here, which indicates that all L3 peers should
+					// be selected. If so, add the wildcard selector.
+					if len(toEndpoints) == 0 {
+						toEndpoints = append(toEndpoints, api.WildcardEndpointSelector)
+					}
 					for _, toPort := range rule.ToPorts {
 						// L3/L4-only rule
 						if toPort.Rules.IsEmpty() {

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1925,11 +1925,12 @@ func (ds *PolicyTestSuite) TestL4WildcardMerge(c *C) {
 	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, true)
 
-	c.Assert(len(filter.Endpoints), Equals, 1)
+	c.Assert(len(filter.Endpoints), Equals, 2)
 	c.Assert(filter.Endpoints[0], Equals, api.WildcardEndpointSelector)
+	c.Assert(filter.Endpoints[1], Equals, api.WildcardEndpointSelector)
 
 	c.Assert(filter.L7Parser, Equals, ParserTypeHTTP)
-	c.Assert(len(filter.L7RulesPerEp), Equals, 1)
+	c.Assert(len(filter.L7RulesPerEp), Equals, 2)
 
 	// Test the reverse order as well; ensure that we check both conditions
 	// for if L4-only policy is in the L4Filter for the same port-protocol tuple,
@@ -1975,10 +1976,10 @@ func (ds *PolicyTestSuite) TestL4WildcardMerge(c *C) {
 	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, true)
 
-	c.Assert(len(filter.Endpoints), Equals, 1)
+	c.Assert(len(filter.Endpoints), Equals, 2)
 
 	c.Assert(filter.L7Parser, Equals, ParserTypeHTTP)
-	c.Assert(len(filter.L7RulesPerEp), Equals, 1)
+	c.Assert(len(filter.L7RulesPerEp), Equals, 2)
 
 	// Second, test the explicit allow at L3.
 	repo = parseAndAddRules(c, api.Rules{&api.Rule{
@@ -2021,6 +2022,7 @@ func (ds *PolicyTestSuite) TestL4WildcardMerge(c *C) {
 	c.Assert(ok, Equals, true)
 	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, true)
+
 	c.Assert(len(filter.Endpoints), Equals, 2)
 	c.Assert(filter.L7Parser, Equals, ParserTypeHTTP)
 	c.Assert(len(filter.L7RulesPerEp), Equals, 2)


### PR DESCRIPTION
* #7476 -- Fix issue where traffic matching L4-only rule would be redirected to the proxy then dropped (@joestringer)
* #7520 -- Fix regression in L7 policy (@joestringer)
* #7545 -- Fix commit order in check-stable backporting script (@joestringer)

I folded the top three commits between these two PRs together, as the second
to last commit broke something then the top commit reverted it and added some
minor additional comments to the code. There was some minor rebasing, in
particular the policy unit tests changed a bit and the L7 wildcard logic is
in `pkg/policy/repository.go` instead of `pkg/policy/rules.go`. Furthermore, the
identity cache logic was directly under the identity package in v1.3, so there's
minor test rebases there too.

Once this PR is merged, you can update the PR labels via:
```
$ for pr in 7476 7520 7545; do contrib/backporting/set-labels.py $pr done 1.3; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7547)
<!-- Reviewable:end -->
