### PR TITLE
operator: Add missing copyright header

### DIFF
--- a/examples/kubernetes/README.rst
+++ b/examples/kubernetes/README.rst
@@ -4,7 +4,7 @@ Kubernetes Deployment
 This directory contains all Cilium deployment files that can be used in
 Kubernetes.
 
-Each directory represents a Kubernetes version, from :code:`1.8` to :code:`1.13`,
+Each directory represents a Kubernetes version, from :code:`1.10` to :code:`1.14`,
 and inside each version there is a list of files to deploy Cilium.
 
 The structure directory will be :code:`${k8s_major_version}.${k8s_minor_version}/*.yaml`.

--- a/operator/api.go
+++ b/operator/api.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -57,7 +57,7 @@ var (
 	}
 	// API rule definitions for default-deny, L3, L3L4, L3L4L7, L4, L4L7
 	rule____NoAllow = api.NewRule().
-			WithIngressRules([]api.IngressRule{api.IngressRule{}})
+			WithIngressRules([]api.IngressRule{{}})
 	ruleL3____Allow = api.NewRule().
 			WithIngressRules([]api.IngressRule{{
 			FromEndpoints: []api.EndpointSelector{allowFooL3_},


### PR DESCRIPTION
* Adds copyright header to `operator/api.go`.
* Updates k8s examples README with updated k8s versions.
* Removes redundant type in `distillery_test.go`
  check-fmt failed otherwise for me when building locally.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7548)
<!-- Reviewable:end -->
