### PR TITLE
k8s: Cache server version and capabilities

### DIFF
--- a/daemon/k8s_watcher_test.go
+++ b/daemon/k8s_watcher_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
 
-	go_version "github.com/hashicorp/go-version"
 	. "gopkg.in/check.v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sTypes "k8s.io/apimachinery/pkg/types"
@@ -302,9 +301,6 @@ func (ds *DaemonSuite) Test_addCiliumNetworkPolicyV2(c *C) {
 			},
 		},
 	}
-	var err error
-	k8sServerVer, err = go_version.NewVersion("1.13")
-	c.Assert(err, IsNil)
 	for _, tt := range tests {
 		args := tt.setupArgs()
 		want := tt.setupWanted()

--- a/operator/k8s_cep_gc.go
+++ b/operator/k8s_cep_gc.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/versioncheck"
 
 	"github.com/sirupsen/logrus"
 	core_v1 "k8s.io/api/core/v1"
@@ -34,12 +33,6 @@ import (
 // Note that only one node per cluster should run this, and most iterations
 // will simply return.
 const ciliumEndpointGCInterval = 30 * time.Minute
-
-var (
-	// ciliumEPControllerLimit is the range of k8s versions with which we are
-	// willing to run the EndpointCRD controllers
-	ciliumEPControllerLimit = versioncheck.MustCompile("> 1.6")
-)
 
 // enableCiliumEndpointSyncGC starts the node-singleton sweeper for
 // CiliumEndpoint objects where the managing node is no longer running. These
@@ -57,19 +50,6 @@ func enableCiliumEndpointSyncGC() {
 		controllerName = "to-k8s-ciliumendpoint-gc"
 		scopedLog      = log.WithField("controller", controllerName)
 	)
-
-	sv, err := k8s.GetServerVersion()
-	if err != nil {
-		scopedLog.WithError(err).Error("unable to retrieve kubernetes serverversion")
-		return
-	}
-	if !ciliumEPControllerLimit.Check(sv) {
-		scopedLog.WithFields(logrus.Fields{
-			"expected": sv,
-			"found":    ciliumEPControllerLimit,
-		}).Warn("cannot run with this k8s version")
-		return
-	}
 
 	ciliumClient := ciliumK8sClient.CiliumV2()
 

--- a/operator/main.go
+++ b/operator/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/k8s"
 	clientset "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned"
+	k8sversion "github.com/cilium/cilium/pkg/k8s/version"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -158,6 +159,11 @@ func runOperator(cmd *cobra.Command) {
 	}
 
 	ciliumK8sClient = k8s.CiliumClient()
+	k8sversion.Update(k8s.Client())
+	if !k8sversion.Capabilities().MinimalVersionMet {
+		log.Fatalf("Minimal kubernetes version not met: %s < %s",
+			k8sversion.Version(), k8sversion.MinimalVersionConstraint)
+	}
 
 	if synchronizeServices {
 		startSynchronizingServices()

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -24,7 +24,6 @@ import (
 	clientset "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 
-	go_version "github.com/hashicorp/go-version"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -101,35 +100,6 @@ func CreateClient(config *rest.Config) (*kubernetes.Clientset, error) {
 		log.Info("Connected to apiserver")
 	}
 	return cs, err
-}
-
-// GetServerVersion returns the kubernetes api-server version.
-func GetServerVersion() (ver *go_version.Version, err error) {
-	sv, err := Client().Discovery().ServerVersion()
-	if err != nil {
-		return nil, err
-	}
-
-	// Try GitVersion first. In case of error fallback to MajorMinor
-	if sv.GitVersion != "" {
-		// This is a string like "v1.9.0"
-		ver, err = go_version.NewVersion(sv.GitVersion)
-		if err == nil {
-			return ver, err
-		}
-	}
-
-	if sv.Major != "" && sv.Minor != "" {
-		ver, err = go_version.NewVersion(fmt.Sprintf("%s.%s", sv.Major, sv.Minor))
-		if err == nil {
-			return ver, nil
-		}
-	}
-
-	if err != nil {
-		return nil, fmt.Errorf("cannot parse k8s server version from %+v: %s", sv, err)
-	}
-	return nil, fmt.Errorf("cannot parse k8s server version from %+v", sv)
 }
 
 // isConnReady returns the err for the controller-manager status

--- a/pkg/k8s/const.go
+++ b/pkg/k8s/const.go
@@ -30,9 +30,4 @@ const (
 	// EnvNodeNameSpec is the environment label used by Kubernetes to
 	// specify the node's name.
 	EnvNodeNameSpec = "K8S_NODE_NAME"
-
-	// compatibleK8sVersions is the range of k8s versions this cilium is able to
-	// work with. It will change as we add new support or deprecate older k8s
-	// versions.
-	compatibleK8sVersions = "> 1.6"
 )

--- a/pkg/k8s/json_patch.go
+++ b/pkg/k8s/json_patch.go
@@ -14,15 +14,6 @@
 
 package k8s
 
-import (
-	"github.com/cilium/cilium/pkg/versioncheck"
-)
-
-var (
-	// JSONPatchVerConstr is the minimal k8s version supported for JSON Patch
-	JSONPatchVerConstr = versioncheck.MustCompile(">= 1.13.0")
-)
-
 // JSONPatch structure based on the RFC 6902
 type JSONPatch struct {
 	OP    string      `json:"op,omitempty"`

--- a/pkg/k8s/version/version.go
+++ b/pkg/k8s/version/version.go
@@ -1,0 +1,129 @@
+// Copyright 2016-2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package version keeps track of the Kubernetes version the client is
+// connected to
+package version
+
+import (
+	"fmt"
+
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/versioncheck"
+
+	go_version "github.com/hashicorp/go-version"
+	"k8s.io/client-go/kubernetes"
+)
+
+// ServerCapabilities is a list of server capabilities derived based on version
+type ServerCapabilities struct {
+	// Patch is the ability to use PATCH to modify a resource
+	Patch bool
+
+	// UpdateStatus is the ability to update the status separately as a
+	// sub-resource
+	UpdateStatus bool
+
+	// MinimalVersionMet is true when the minimal version of Kubernetes
+	// required to run Cilium has been met
+	MinimalVersionMet bool
+}
+
+type cachedVersion struct {
+	mutex        lock.RWMutex
+	capabilities ServerCapabilities
+	version      *go_version.Version
+}
+
+var (
+	cached = cachedVersion{}
+
+	patchConstraint        = versioncheck.MustCompile(">= 1.13.0")
+	updateStatusConstraint = versioncheck.MustCompile(">= 1.11.0")
+
+	// MinimalVersionConstraint is the minimal version required to run
+	// Cilium
+	MinimalVersionConstraint = versioncheck.MustCompile(">= 1.8.0")
+)
+
+// Version returns the version of the Kubernetes apiserver
+func Version() *go_version.Version {
+	cached.mutex.RLock()
+	c := cached.version
+	cached.mutex.RUnlock()
+	return c
+}
+
+// Capabilities returns the capabilities of the Kubernetes apiserver
+func Capabilities() ServerCapabilities {
+	cached.mutex.RLock()
+	c := cached.capabilities
+	cached.mutex.RUnlock()
+	return c
+}
+
+func updateVersion(version *go_version.Version) {
+	cached.mutex.Lock()
+	defer cached.mutex.Unlock()
+
+	cached.version = version
+
+	cached.capabilities.Patch = patchConstraint.Check(version) || option.Config.K8sForceJSONPatch
+	cached.capabilities.UpdateStatus = updateStatusConstraint.Check(version)
+	cached.capabilities.MinimalVersionMet = MinimalVersionConstraint.Check(version)
+}
+
+// Force forces the use of a specific version
+func Force(version string) error {
+	ver, err := go_version.NewVersion(version)
+	if err != nil {
+		return err
+	}
+	updateVersion(ver)
+	return nil
+}
+
+// Update retrieves the version of the Kubernetes apiserver and derives the
+// capabilities. This function must be called after connectivity to the
+// apiserver has been established.
+func Update(client kubernetes.Interface) error {
+	sv, err := client.Discovery().ServerVersion()
+	if err != nil {
+		return err
+	}
+
+	// Try GitVersion first. In case of error fallback to MajorMinor
+	if sv.GitVersion != "" {
+		// This is a string like "v1.9.0"
+		ver, err := go_version.NewVersion(sv.GitVersion)
+		if err == nil {
+			updateVersion(ver)
+			return nil
+		}
+	}
+
+	if sv.Major != "" && sv.Minor != "" {
+		ver, err := go_version.NewVersion(fmt.Sprintf("%s.%s", sv.Major, sv.Minor))
+		if err == nil {
+			updateVersion(ver)
+			return nil
+		}
+	}
+
+	if err != nil {
+		return fmt.Errorf("cannot parse k8s server version from %+v: %s", sv, err)
+	}
+	return fmt.Errorf("cannot parse k8s server version from %+v", sv)
+}


### PR DESCRIPTION
This reduces the number of Discovery() calls made to the apiserver and no
longer requires to import pkg/k8s to determine capabilities.

Several outdated version checks are removed:
 - Check for >= 1.6 is no longer required as we exit on < 1.8
 - Check for >= 1.8 to use CNP is no longer required as we exit on < 1.8

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7550)
<!-- Reviewable:end -->
