### PR TITLE
Lock endpoint before getting security id

### DIFF
--- a/pkg/policy/identifier.go
+++ b/pkg/policy/identifier.go
@@ -43,6 +43,12 @@ type Endpoint interface {
 	GetID16() uint16
 	GetSecurityIdentity() *identity.Identity
 	PolicyRevisionBumpEvent(rev uint64)
+	LockAlive() error
+	Unlock()
+	RLockAlive() error
+	RUnlock()
+	UnconditionalLock()
+	UnconditionalRLock()
 }
 
 // EndpointSet is used to be able to group together a given set of Endpoints

--- a/pkg/policy/identifier_test.go
+++ b/pkg/policy/identifier_test.go
@@ -36,6 +36,30 @@ func (d *DummyEndpoint) GetSecurityIdentity() *identity.Identity {
 	return nil
 }
 
+func (d *DummyEndpoint) LockAlive() error {
+	return nil
+}
+
+func (d *DummyEndpoint) Unlock() {
+	return
+}
+
+func (d *DummyEndpoint) RLockAlive() error {
+	return nil
+}
+
+func (d *DummyEndpoint) RUnlock() {
+	return
+}
+
+func (d *DummyEndpoint) UnconditionalLock() {
+	return
+}
+
+func (d *DummyEndpoint) UnconditionalRLock() {
+	return
+}
+
 func (d *DummyEndpoint) PolicyRevisionBumpEvent(rev uint64) {
 	d.rev = rev
 	return

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -59,6 +59,30 @@ func (d *dummyEndpoint) GetSecurityIdentity() *identity.Identity {
 	return d.SecurityIdentity
 }
 
+func (d *dummyEndpoint) LockAlive() error {
+	return nil
+}
+
+func (d *dummyEndpoint) Unlock() {
+	return
+}
+
+func (d *dummyEndpoint) RLockAlive() error {
+	return nil
+}
+
+func (d *dummyEndpoint) RUnlock() {
+	return
+}
+
+func (d *dummyEndpoint) UnconditionalLock() {
+	return
+}
+
+func (d *dummyEndpoint) UnconditionalRLock() {
+	return
+}
+
 func (d *dummyEndpoint) PolicyRevisionBumpEvent(rev uint64) {
 	return
 }

--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -278,7 +278,9 @@ func (rules ruleSlice) updateEndpointsCaches(ep Endpoint, epIDSet *IDSet) bool {
 		return true
 	}
 	id := ep.GetID16()
+	ep.UnconditionalRLock()
 	securityIdentity := ep.GetSecurityIdentity()
+	ep.RUnlock()
 
 	for _, r := range rules {
 		if ruleMatches := r.matches(id, securityIdentity); ruleMatches {
@@ -301,7 +303,9 @@ func (rules ruleSlice) refreshRulesForEndpoint(ep Endpoint) {
 	}
 
 	id := ep.GetID16()
+	ep.UnconditionalRLock()
 	securityIdentity := ep.GetSecurityIdentity()
+	ep.RUnlock()
 
 	for _, r := range rules {
 		// matches updates the caches within the rules


### PR DESCRIPTION
`Endpoint.GetSecurityIdentity` is supposed to be protected by endpoint mutex, but this was not the case.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7551)
<!-- Reviewable:end -->
