### PR TITLE
[to v1.4] Revert DNS order-of-operations changes from #7475

### DIFF
--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -367,6 +367,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 
 	scopedLog.WithField(logfields.Response, response).Debug("Received DNS response to proxied lookup")
 	stat.Success = true
+	p.NotifyOnDNSMsg(time.Now(), endpointAddr, targetServerAddr, response, protocol, true, stat)
 
 	scopedLog.Debug("Responding to original DNS query")
 	// restore the ID to the one in the inital request so it matches what the requester expects.
@@ -377,11 +378,6 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		stat.Err = fmt.Errorf("Cannot forward proxied DNS response: %s", err)
 		p.NotifyOnDNSMsg(time.Now(), endpointAddr, targetServerAddr, response, protocol, true, stat)
 	}
-
-	// Note: This may block and it is safer to do it after we have written out
-	// the DNS response to the pod.
-	scopedLog.Debug("Notifying with DNS response to original DNS query")
-	p.NotifyOnDNSMsg(time.Now(), endpointAddr, targetServerAddr, response, protocol, true, stat)
 }
 
 // sendRefused creates and sends a REFUSED response for request to w


### PR DESCRIPTION
After discussion in the community meeting we decided to revert https://github.com/cilium/cilium/pull/. Although small it may have unexpected side-effects and constitute an unexpected change for a minor release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7552)
<!-- Reviewable:end -->
