### PR TITLE
Transparent encryption: improve dynamic key management

### DIFF
--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -1818,6 +1818,7 @@ func (d *Daemon) updateK8sNodeTunneling(k8sNodeOld, k8sNodeNew *types.Node) erro
 		return fmt.Errorf("ipcache entry owned by kvstore or agent")
 	}
 
+	nodeNew.EncryptionKey = hostKey
 	d.nodeDiscovery.Manager.NodeUpdated(*nodeNew)
 
 	return nil

--- a/pkg/datapath/linux/node_test.go
+++ b/pkg/datapath/linux/node_test.go
@@ -32,24 +32,28 @@ func (s *linuxTestSuite) TestTunnelCIDRUpdateRequired(c *check.C) {
 	ip1 := net.ParseIP("1.1.1.1")
 	ip2 := net.ParseIP("2.2.2.2")
 
-	c.Assert(cidrNodeMappingUpdateRequired(nil, nil, ip1, ip1), check.Equals, false) // disabled -> disabled
-	c.Assert(cidrNodeMappingUpdateRequired(nil, c1, ip1, ip1), check.Equals, true)   // disabled -> c1
-	c.Assert(cidrNodeMappingUpdateRequired(c1, c1, ip1, ip1), check.Equals, false)   // c1 -> c1
-	c.Assert(cidrNodeMappingUpdateRequired(c1, c1, ip1, ip2), check.Equals, true)    // c1 -> c1 (changed host IP)
-	c.Assert(cidrNodeMappingUpdateRequired(c1, c2, ip2, ip2), check.Equals, true)    // c1 -> c2
-	c.Assert(cidrNodeMappingUpdateRequired(c2, nil, ip2, ip2), check.Equals, false)  // c2 -> disabled
+	c.Assert(cidrNodeMappingUpdateRequired(nil, nil, ip1, ip1, 0, 0), check.Equals, false) // disabled -> disabled
+	c.Assert(cidrNodeMappingUpdateRequired(nil, c1, ip1, ip1, 0, 0), check.Equals, true)   // disabled -> c1
+	c.Assert(cidrNodeMappingUpdateRequired(c1, c1, ip1, ip1, 0, 0), check.Equals, false)   // c1 -> c1
+	c.Assert(cidrNodeMappingUpdateRequired(c1, c1, ip1, ip2, 0, 0), check.Equals, true)    // c1 -> c1 (changed host IP)
+	c.Assert(cidrNodeMappingUpdateRequired(c1, c2, ip2, ip2, 0, 0), check.Equals, true)    // c1 -> c2
+	c.Assert(cidrNodeMappingUpdateRequired(c2, nil, ip2, ip2, 0, 0), check.Equals, false)  // c2 -> disabled
+	c.Assert(cidrNodeMappingUpdateRequired(c1, c1, ip1, ip1, 0, 1), check.Equals, true)    // key upgrade 0 -> 1
+	c.Assert(cidrNodeMappingUpdateRequired(c1, c1, ip1, ip1, 1, 0), check.Equals, true)    // key downgrade 1 -> 0
 
 	c1 = cidr.MustParseCIDR("f00d::a0a:0:0:0/96")
 	c2 = cidr.MustParseCIDR("f00d::b0b:0:0:0/96")
 	ip1 = net.ParseIP("cafe::1")
 	ip2 = net.ParseIP("cafe::2")
 
-	c.Assert(cidrNodeMappingUpdateRequired(nil, nil, ip1, ip1), check.Equals, false) // disabled -> disabled
-	c.Assert(cidrNodeMappingUpdateRequired(nil, c1, ip1, ip1), check.Equals, true)   // disabled -> c1
-	c.Assert(cidrNodeMappingUpdateRequired(c1, c1, ip1, ip1), check.Equals, false)   // c1 -> c1
-	c.Assert(cidrNodeMappingUpdateRequired(c1, c1, ip1, ip2), check.Equals, true)    // c1 -> c1 (changed host IP)
-	c.Assert(cidrNodeMappingUpdateRequired(c1, c2, ip2, ip2), check.Equals, true)    // c1 -> c2
-	c.Assert(cidrNodeMappingUpdateRequired(c2, nil, ip2, ip2), check.Equals, false)  // c2 -> disabled
+	c.Assert(cidrNodeMappingUpdateRequired(nil, nil, ip1, ip1, 0, 0), check.Equals, false) // disabled -> disabled
+	c.Assert(cidrNodeMappingUpdateRequired(nil, c1, ip1, ip1, 0, 0), check.Equals, true)   // disabled -> c1
+	c.Assert(cidrNodeMappingUpdateRequired(c1, c1, ip1, ip1, 0, 0), check.Equals, false)   // c1 -> c1
+	c.Assert(cidrNodeMappingUpdateRequired(c1, c1, ip1, ip2, 0, 0), check.Equals, true)    // c1 -> c1 (changed host IP)
+	c.Assert(cidrNodeMappingUpdateRequired(c1, c2, ip2, ip2, 0, 0), check.Equals, true)    // c1 -> c2
+	c.Assert(cidrNodeMappingUpdateRequired(c2, nil, ip2, ip2, 0, 0), check.Equals, false)  // c2 -> disabled
+	c.Assert(cidrNodeMappingUpdateRequired(c1, c1, ip1, ip1, 0, 1), check.Equals, true)    // key upgrade 0 -> 1
+	c.Assert(cidrNodeMappingUpdateRequired(c1, c1, ip1, ip1, 1, 0), check.Equals, true)    // key downgrade 1 -> 0
 }
 
 func (s *linuxTestSuite) TestCreateNodeRoute(c *check.C) {

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -91,6 +91,9 @@ type Node struct {
 
 	// Source is the source where the node configuration was generated / created.
 	Source Source
+
+	// Key index used for transparent encryption or 0 for no encryption
+	EncryptionKey uint8
 }
 
 // Fullname returns the node's full name including the cluster name if a

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -110,6 +110,7 @@ func (n *NodeDiscovery) StartDiscovery(nodeName string) {
 	n.LocalNode.IPv4AllocCIDR = node.GetIPv4AllocRange()
 	n.LocalNode.IPv6AllocCIDR = node.GetIPv6AllocRange()
 	n.LocalNode.ClusterID = option.Config.ClusterID
+	n.LocalNode.EncryptionKey = node.GetIPsecKeyIdentity()
 
 	if node.GetExternalIPv4() != nil {
 		n.LocalNode.IPAddresses = append(n.LocalNode.IPAddresses, node.Address{

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -29,10 +29,12 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 	var kubectl *helpers.Kubectl
 	var demoDSPath string
+	var ipsecDSPath string
 
 	BeforeAll(func() {
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 		demoDSPath = helpers.ManifestGet("demo_ds.yaml")
+		ipsecDSPath = helpers.ManifestGet("ipsec_ds.yaml")
 
 		kubectl.Exec("kubectl -n kube-system delete ds cilium")
 
@@ -41,11 +43,13 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 	BeforeEach(func() {
 		kubectl.Apply(demoDSPath).ExpectSuccess("cannot install Demo application")
+		kubectl.Apply(ipsecDSPath).ExpectSuccess("cannot install IPsec keys")
 		kubectl.NodeCleanMetadata()
 	})
 
 	AfterEach(func() {
 		kubectl.Delete(demoDSPath)
+		kubectl.Delete(ipsecDSPath)
 		ExpectAllPodsTerminated(kubectl)
 
 		// Do not assert on success in AfterEach intentionally to avoid
@@ -103,6 +107,21 @@ var _ = Describe("K8sDatapathConfig", func() {
 			status.ExpectSuccess()
 			Expect(status.IntOutput()).Should(Equal(3), "Did not find expected number of entries in BPF tunnel map")
 		}
+
+		It("Check connectivity with transparent encryption and VXLAN encapsulation", func() {
+			switch helpers.GetCurrentIntegration() {
+			case helpers.CIIntegrationFlannel:
+				Skip(fmt.Sprintf(
+					"Cilium in %q mode is not supported with transparent encryption and VxLAN. Skipping test.",
+					helpers.CIIntegrationFlannel))
+				return
+			}
+
+			deployCilium("cilium-ds-patch-vxlan-ipsec.yaml")
+			validateBPFTunnelMap()
+			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test with IPsec between nodes failed")
+			cleanService()
+		}, 600)
 
 		It("Check connectivity with VXLAN encapsulation", func() {
 			SkipIfFlannel()

--- a/test/k8sT/manifests/cilium-ds-patch-ipv4-only-ipsec.yaml
+++ b/test/k8sT/manifests/cilium-ds-patch-ipv4-only-ipsec.yaml
@@ -1,0 +1,32 @@
+---
+metadata:
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+      - image: k8s1:5000/cilium/cilium-dev:latest
+        imagePullPolicy: Always
+        name: cilium-agent
+        args:
+        - "--kvstore=etcd"
+        - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
+        - "--k8s-require-ipv4-pod-cidr"
+        - "--pprof=true"
+        - "--log-system-load"
+        - "--enable-ipv4=true"
+        - "--enable-ipv6=false"
+        - "--config-dir=/tmp/cilium/config-map"
+        - "--enable-ipsec"
+        - "--ipsec-key-file=/etc/ipsec/keys"
+        volumeMounts:
+          - name: cilium-ipsec-secrets
+            mountPath: /etc/ipsec
+      volumes:
+      - name: cilium-ipsec-secrets
+        secret:
+          secretName: cilium-ipsec-keys
+      - name: etcd-secrets
+        secret:
+          secretName: cilium-etcd-client-tls
+      dnsPolicy: ClusterFirstWithHostNet

--- a/test/k8sT/manifests/cilium-ds-patch-vxlan-ipsec.yaml
+++ b/test/k8sT/manifests/cilium-ds-patch-vxlan-ipsec.yaml
@@ -1,0 +1,31 @@
+---
+metadata:
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+      - image: k8s1:5000/cilium/cilium-dev:latest
+        imagePullPolicy: Always
+        name: cilium-agent
+        args:
+        - "--tunnel=vxlan"
+        - "--kvstore=etcd"
+        - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
+        - "--k8s-require-ipv4-pod-cidr"
+        - "--pprof=true"
+        - "--log-system-load"
+        - "--config-dir=/tmp/cilium/config-map"
+        - "--enable-ipsec"
+        - "--ipsec-key-file=/etc/ipsec/keys"
+        volumeMounts:
+          - name: cilium-ipsec-secrets
+            mountPath: /etc/ipsec
+      volumes:
+      - name: cilium-ipsec-secrets
+        secret:
+          secretName: cilium-ipsec-keys
+      - name: etcd-secrets
+        secret:
+          secretName: cilium-etcd-client-tls
+      dnsPolicy: ClusterFirstWithHostNet

--- a/test/k8sT/manifests/ipsec_ds.yaml
+++ b/test/k8sT/manifests/ipsec_ds.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cilium-ipsec-keys
+  namespace: kube-system
+type: Opaque
+stringData:
+  keys: "5 hmac(sha256) 0123456789abcdef0123456789abcdef cbc(aes) 0123456789abcdef0123456789abcdef"


### PR DESCRIPTION
This improves the handling of rolling updates solving two outstanding issues. First tunnel keys were not being updated causing traffic that had a miss in the ipcache but had a node destination to use the old keys. Fix by ensuring tunnel updates also push updates into datapath when keys change, previously keys were ignored when comparing if old and new configs were the same.

Next add a watcher to the key secret file to allow avoiding Cilium restart in this case. Now the new keys will be consumed on secret update.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7555)
<!-- Reviewable:end -->
