### PR TITLE
kvstore: Fix identity override with labels prefix

### DIFF
--- a/pkg/kvstore/backend.go
+++ b/pkg/kvstore/backend.go
@@ -142,8 +142,8 @@ type BackendOperations interface {
 	// Get returns value of key
 	Get(key string) ([]byte, error)
 
-	// GetPrefix returns the first key which matches the prefix
-	GetPrefix(ctx context.Context, prefix string) ([]byte, error)
+	// GetPrefix returns the first key which matches the prefix and its value
+	GetPrefix(ctx context.Context, prefix string) (string, []byte, error)
 
 	// Set sets value of key
 	Set(key string, value []byte) error

--- a/pkg/kvstore/base_test.go
+++ b/pkg/kvstore/base_test.go
@@ -105,6 +105,40 @@ func (s *BaseTests) TestGetSet(c *C) {
 	c.Assert(key, Equals, "")
 }
 
+func (s *BaseTests) TestGetPrefix(c *C) {
+	prefix := "unit-test/"
+
+	DeletePrefix(prefix)
+	defer DeletePrefix(prefix)
+
+	key, val, err := GetPrefix(context.Background(), prefix)
+	c.Assert(err, IsNil)
+	c.Assert(val, IsNil)
+	c.Assert(key, Equals, "")
+
+	// create
+	labelsLong := "foo;/;bar;"
+	labelsShort := "foo;/"
+	testKey := fmt.Sprintf("%s%s/%010d", prefix, labelsLong, 0)
+	c.Assert(Update(context.Background(), testKey, testValue(0), true), IsNil)
+
+	val, err = Get(testKey)
+	c.Assert(err, IsNil)
+	c.Assert(val, checker.DeepEquals, testValue(0))
+
+	prefixes := []string{
+		prefix,
+		fmt.Sprintf("%s%s", prefix, labelsLong),
+		fmt.Sprintf("%s%s", prefix, labelsShort),
+	}
+	for _, p := range prefixes {
+		key, val, err = GetPrefix(context.Background(), p)
+		c.Assert(err, IsNil)
+		c.Assert(val, checker.DeepEquals, testValue(0))
+		c.Assert(key, Equals, testKey)
+	}
+}
+
 func (s *BaseTests) BenchmarkGet(c *C) {
 	prefix := "unit-test/"
 	DeletePrefix(prefix)

--- a/pkg/kvstore/base_test.go
+++ b/pkg/kvstore/base_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -60,18 +60,20 @@ func (s *BaseTests) TestGetSet(c *C) {
 	DeletePrefix(prefix)
 	defer DeletePrefix(prefix)
 
-	val, err := GetPrefix(context.Background(), prefix)
+	key, val, err := GetPrefix(context.Background(), prefix)
 	c.Assert(err, IsNil)
 	c.Assert(val, IsNil)
+	c.Assert(key, Equals, "")
 
 	for i := 0; i < maxID; i++ {
 		val, err = Get(testKey(prefix, i))
 		c.Assert(err, IsNil)
 		c.Assert(val, IsNil)
 
-		val, err = GetPrefix(context.Background(), testKey(prefix, i))
+		key, val, err = GetPrefix(context.Background(), testKey(prefix, i))
 		c.Assert(err, IsNil)
 		c.Assert(val, IsNil)
+		c.Assert(key, Equals, "")
 
 		c.Assert(Set(testKey(prefix, i), testValue(i)), IsNil)
 
@@ -91,14 +93,16 @@ func (s *BaseTests) TestGetSet(c *C) {
 		c.Assert(err, IsNil)
 		c.Assert(val, IsNil)
 
-		val, err = GetPrefix(context.Background(), testKey(prefix, i))
+		key, val, err = GetPrefix(context.Background(), testKey(prefix, i))
 		c.Assert(err, IsNil)
 		c.Assert(val, IsNil)
+		c.Assert(key, Equals, "")
 	}
 
-	val, err = GetPrefix(context.Background(), prefix)
+	key, val, err = GetPrefix(context.Background(), prefix)
 	c.Assert(err, IsNil)
 	c.Assert(val, IsNil)
+	c.Assert(key, Equals, "")
 }
 
 func (s *BaseTests) BenchmarkGet(c *C) {
@@ -133,9 +137,10 @@ func (s *BaseTests) TestUpdate(c *C) {
 	DeletePrefix(prefix)
 	defer DeletePrefix(prefix)
 
-	val, err := GetPrefix(context.Background(), prefix)
+	key, val, err := GetPrefix(context.Background(), prefix)
 	c.Assert(err, IsNil)
 	c.Assert(val, IsNil)
+	c.Assert(key, Equals, "")
 
 	// create
 	c.Assert(Update(context.Background(), testKey(prefix, 0), testValue(0), true), IsNil)
@@ -158,9 +163,10 @@ func (s *BaseTests) TestCreateOnly(c *C) {
 	DeletePrefix(prefix)
 	defer DeletePrefix(prefix)
 
-	val, err := GetPrefix(context.Background(), prefix)
+	key, val, err := GetPrefix(context.Background(), prefix)
 	c.Assert(err, IsNil)
 	c.Assert(val, IsNil)
+	c.Assert(key, Equals, "")
 
 	c.Assert(CreateOnly(context.Background(), testKey(prefix, 0), testValue(0), false), IsNil)
 

--- a/pkg/kvstore/consul.go
+++ b/pkg/kvstore/consul.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -403,21 +403,21 @@ func (c *consulClient) Get(key string) ([]byte, error) {
 	return pair.Value, nil
 }
 
-// GetPrefix returns the first key which matches the prefix
-func (c *consulClient) GetPrefix(ctx context.Context, prefix string) ([]byte, error) {
+// GetPrefix returns the first key which matches the prefix and its value
+func (c *consulClient) GetPrefix(ctx context.Context, prefix string) (string, []byte, error) {
 	duration := spanstat.Start()
 	opts := &consulAPI.QueryOptions{}
 	pairs, _, err := c.KV().List(prefix, opts.WithContext(ctx))
 	increaseMetric(prefix, metricRead, "GetPrefix", duration.EndError(err).Total(), err)
 	if err != nil {
-		return nil, err
+		return "", nil, err
 	}
 
 	if len(pairs) == 0 {
-		return nil, nil
+		return "", nil, nil
 	}
 
-	return pairs[0].Value, nil
+	return pairs[0].Key, pairs[0].Value, nil
 }
 
 // Update creates or updates a key with the value

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -706,20 +706,20 @@ func (e *etcdClient) Get(key string) ([]byte, error) {
 	return getR.Kvs[0].Value, nil
 }
 
-// GetPrefix returns the first key which matches the prefix
-func (e *etcdClient) GetPrefix(ctx context.Context, prefix string) ([]byte, error) {
+// GetPrefix returns the first key which matches the prefix and its value
+func (e *etcdClient) GetPrefix(ctx context.Context, prefix string) (string, []byte, error) {
 	duration := spanstat.Start()
 	e.limiter.Wait(ctx)
 	getR, err := e.client.Get(ctx, prefix, client.WithPrefix())
 	increaseMetric(prefix, metricRead, "GetPrefix", duration.EndError(err).Total(), err)
 	if err != nil {
-		return nil, Hint(err)
+		return "", nil, Hint(err)
 	}
 
 	if getR.Count == 0 {
-		return nil, nil
+		return "", nil, nil
 	}
-	return getR.Kvs[0].Value, nil
+	return string(getR.Kvs[0].Key), getR.Kvs[0].Value, nil
 }
 
 // Set sets value of key

--- a/pkg/kvstore/kvstore.go
+++ b/pkg/kvstore/kvstore.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -44,11 +44,11 @@ func Get(key string) ([]byte, error) {
 	return v, err
 }
 
-// GetPrefix returns the first key which matches the prefix
-func GetPrefix(ctx context.Context, prefix string) ([]byte, error) {
-	v, err := Client().GetPrefix(ctx, prefix)
-	Trace("GetPrefix", err, logrus.Fields{fieldPrefix: prefix, fieldValue: string(v)})
-	return v, err
+// GetPrefix returns the first key which matches the prefix and its value.
+func GetPrefix(ctx context.Context, prefix string) (k string, v []byte, err error) {
+	k, v, err = Client().GetPrefix(ctx, prefix)
+	Trace("GetPrefix", err, logrus.Fields{fieldPrefix: prefix, fieldKey: k, fieldValue: string(v)})
+	return
 }
 
 // ListPrefix returns the list of keys matching the prefix

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -439,6 +439,10 @@ func (l Labels) SortedList() []byte {
 	for _, k := range keys {
 		// We don't care if the values already have a '=' since this method is
 		// only used to calculate a SHA256Sum
+		//
+		// We absolutely care that the final character is a semi-colon.
+		// Identity allocation in the kvstore depends on this (see
+		// kvstore.prefixMatchesKey())
 		result += fmt.Sprintf(`%s:%s=%s;`, l[k].Source, k, l[k].Value)
 	}
 


### PR DESCRIPTION
```release-note
Fix bug where creating a pod with no labels could cause drops for other pods within the same namespace.
```

Previously, when attempting to determine whether an identity exists for
a set of labels, we would perform a prefix lookup with the desired
labels and if an identity is found, unconditionally use that identity,
without checking that the set of specified labels matches the labels of
the identity that was found. This could lead to a situation where if an
endpoint is deployed on a node with a labels subset of another
endpoint's labels, the local node would override the labels for that
identity with the shorter set of labels. As a result, policy which
selects the longer set of labels may potentially not apply, which
assuming a "deny-all" ingress security posture, would lead to packet
drops when the policy would appear to allow traffic to the endpoint with
the longer set of labels.

This patch fixes the issue by returning the key that was found, then
trimming the suffix (which represents the node IP), then comparing the
length of this key against the labels that were used to perform the
lookup. If the length is the same, then the labels are the same and the
identity can be reused. Otherwise, it cannot be reused and we will back
out and attempt to allocate a new numeric identity for this set of
labels.

Note this still leaves one possibility open: The kvstore GetPrefix()
interface does not guarantee which key will be found if two keys with
the same prefix are in the kvstore and a prefix lookup is performed for
the shorter key. In this case, GetNoCache() may return that no key is
found when there is in fact an identity for the shorter prefix. This
could potentially lead to an increase in the number of identities for
the shorter prefix, however this will not affect existing identities.
This situation is deemed unlikely enough that cleaning up this case is
deferred for now.

Fixes: #7559

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7565)
<!-- Reviewable:end -->
