### PR TITLE
policy: Allow DNS proxy only on port 53.

### DIFF
--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -990,6 +990,11 @@ DNS Proxy (preferred)
   DNS requests. It allows L3 connections to ``cilium.io``, ``sub.cilium.io``
   and any subdomains of ``sub.cilium.io``.
 
+.. note:: The port number 53 shown in the examples is currently the
+          only supported port number on which DNS requests can be
+          proxied. This is the standard DNS port number, so it should
+          work for most uses.
+
 .. only:: html
 
    .. tabs::


### PR DESCRIPTION
Forthcoming TPROXY PR limits the DNS Proxy support to port 53. Make
policy validation fail if no port, or other than port 53 is specified
for a toPorts rule with a DNS policy. Add this limit also to the docs.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7566)
<!-- Reviewable:end -->
