### PR TITLE
v1.4: backports 19-04-02

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,7 @@ sudo: required
 go:
  - 1.11.1
 
-# This will travis to build on branch updates only for the master branch
-branches:
-  only:
-  - master
+if: branch = master OR type = pull_request
 
 addons:
   apt:

--- a/contrib/backporting/check-stable
+++ b/contrib/backporting/check-stable
@@ -132,23 +132,20 @@ generate_commit_list_for_pr () {
 
   url="https://api.github.com/repos/cilium/cilium/pulls/$pr/commits"
   pr_json="$($GHCURL $url)"
-  commits="$(echo -n $pr_json | jq -r '.[] | (.sha | tostring)')"
-
-  SAVEIFS=$IFS
-  IFS=$'\n'
-  commits=($commits)
-  IFS=$SAVEIFS
+  n_commits="$(echo -n $pr_json | jq -r '. | length')"
 
   tmp_file=`mktemp pr-correlation.XXXXXX`
   branch="check-for-stable-$pr"
   git fetch -q $remote pull/$pr/head:$branch
-  for commit in "${commits[@]}"; do
+  # Use GitHub to determine the number of commits to list, but then query
+  # the branch directly to determine the canonical order of the commits.
+  for commit in $(git rev-list --reverse -$n_commits $branch); do
     patchid="$(git show $commit | git patch-id)"
     subject="$(git show -s --pretty="%s" $commit)"
     echo "$patchid $subject" >> $tmp_file
   done
   git branch -q -D $branch
-  echo "   Merge with ${#commits[@]} commit(s) merged at: `date -R -d "$(echo $merged_at | sed 's/T/ /')"`!"
+  echo "   Merge with $n_commits commit(s) merged at: `date -R -d "$(echo $merged_at | sed 's/T/ /')"`!"
   echo "     Branch:     master (!)                          refs/pull/$pr/head"
   echo "                 ----------                          -------------------"
   echo "     v (start)"


### PR DESCRIPTION
Backported PRs:

* PR: 7545 -- Fix commit order in check-stable backporting script (@joestringer) -- https://github.com/cilium/cilium/pull/7545
 * PR: 7570 -- .travis: run travis on all PRs (@aanm) -- https://github.com/cilium/cilium/pull/7570

When merged, run:

```
for pr in 7545 7570; do contrib/backporting/set-labels.py $pr done 1.4; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7575)
<!-- Reviewable:end -->