### PR TITLE
cilium: encryption needs to use string reference

### DIFF
--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -1109,7 +1109,8 @@ func endParallelMapMode() {
 
 func runDaemon() {
 	datapathConfig := linuxdatapath.DatapathConfiguration{
-		HostDevice: option.Config.HostDevice,
+		HostDevice:       option.Config.HostDevice,
+		EncryptInterface: option.Config.EncryptInterface,
 	}
 
 	log.Info("Initializing daemon")

--- a/pkg/datapath/linux/datapath.go
+++ b/pkg/datapath/linux/datapath.go
@@ -23,6 +23,8 @@ import (
 type DatapathConfiguration struct {
 	// HostDevice is the name of the device to be used to access the host.
 	HostDevice string
+	// EncryptInterface is the name of the device to be used for direct ruoting encryption
+	EncryptInterface string
 }
 
 type linuxDatapath struct {

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -640,7 +640,7 @@ func (n *linuxNodeHandler) createNodeIPSecInRoute(ip *net.IPNet) route.Route {
 	var device string
 
 	if option.Config.Tunnel == option.TunnelDisabled {
-		device = option.EncryptInterface
+		device = n.datapathConfig.EncryptInterface
 	} else {
 		device = linux_defaults.TunnelDeviceName
 	}


### PR DESCRIPTION
Fix the EncryptInterface name to report the string correctly.

Signed-off-by: John Fastabend <john.fastabend@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7577)
<!-- Reviewable:end -->
