### PR TITLE
v1.4: backports 19-04-02

### DIFF
--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -587,18 +587,31 @@ func (a *Allocator) Get(key AllocatorKey) (idpool.ID, error) {
 	return a.GetNoCache(key)
 }
 
+func prefixMatchesKey(prefix, key string) bool {
+	// cilium/state/identities/v1/value/label;foo;bar;/172.0.124.60
+	lastSlash := strings.LastIndex(key, "/")
+	return len(prefix) == lastSlash
+}
+
 // Get returns the ID which is allocated to a key in the kvstore
 func (a *Allocator) GetNoCache(key AllocatorKey) (idpool.ID, error) {
+	// GetPrefix() will choose any "first" key with the same prefix as the
+	// specified key. In the worst case this may alternate between
+	// returning the prefix that is specified and returning a key with a
+	// longer prefix (even if this exact prefix already exists in the
+	// kvstore). In that case, we will potentially allocate duplicate
+	// identities for the same set of labels. This is not efficient, but
+	// should have the correct identity properties.
 	prefix := path.Join(a.valuePrefix, key.GetKey())
-	value, err := kvstore.GetPrefix(prefix)
-	kvstore.Trace("AllocateGet", err, logrus.Fields{fieldPrefix: prefix, fieldValue: value})
-	if err != nil || value == nil {
+	k, v, err := kvstore.GetPrefix(prefix)
+	kvstore.Trace("AllocateGet", err, logrus.Fields{fieldPrefix: prefix, fieldKey: k, fieldValue: v})
+	if err != nil || v == nil || !prefixMatchesKey(prefix, k) {
 		return 0, err
 	}
 
-	id, err := strconv.ParseUint(string(value), 10, 64)
+	id, err := strconv.ParseUint(string(v), 10, 64)
 	if err != nil {
-		return idpool.NoID, fmt.Errorf("unable to parse value '%s': %s", value, err)
+		return idpool.NoID, fmt.Errorf("unable to parse value '%s': %s", v, err)
 	}
 
 	return idpool.ID(id), nil

--- a/pkg/kvstore/allocator/allocator_test.go
+++ b/pkg/kvstore/allocator/allocator_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -261,6 +261,91 @@ func (s *AllocatorSuite) TestKeyToID(c *C) {
 	c.Assert(a.mainCache.keyToID(path.Join(allocatorName, "invalid"), false), Equals, idpool.NoID)
 	c.Assert(a.mainCache.keyToID(path.Join(a.idPrefix, "invalid"), false), Equals, idpool.NoID)
 	c.Assert(a.mainCache.keyToID(path.Join(a.idPrefix, "10"), false), Equals, idpool.ID(10))
+}
+
+func testGetNoCache(c *C, maxID idpool.ID, testName string, suffix string) {
+	allocator, err := NewAllocator(testName, TestType(""), WithMax(maxID),
+		WithSuffix(suffix), WithoutGC())
+	c.Assert(err, IsNil)
+	c.Assert(allocator, Not(IsNil))
+
+	// remove any keys which might be leftover
+	allocator.DeleteAllKeys()
+	defer allocator.DeleteAllKeys()
+
+	labelsLong := "foo;/;bar;"
+	key := TestType(fmt.Sprintf("%s%010d", labelsLong, 0))
+	longID, new, err := allocator.Allocate(context.Background(), key)
+	c.Assert(err, IsNil)
+	c.Assert(longID, Not(Equals), 0)
+	c.Assert(new, Equals, true)
+
+	observedID, err := allocator.GetNoCache(key)
+	c.Assert(err, IsNil)
+	c.Assert(observedID, Not(Equals), 0)
+
+	labelsShort := "foo;/;"
+	shortKey := TestType(labelsShort)
+	observedID, err = allocator.GetNoCache(shortKey)
+	c.Assert(err, IsNil)
+	c.Assert(observedID, Equals, idpool.NoID)
+
+	// Limitation: If we now insert the key for the short labels because
+	// it's not found, then we will have two keys with the same "foo;/;"
+	// prefix. At that point it's not deterministic whether we will find
+	// the key or not, because GetNoCache() only checks the first key that
+	// matches a given prefix.
+	shortID, new, err := allocator.Allocate(context.Background(), shortKey)
+	c.Assert(err, IsNil)
+	c.Assert(shortID, Not(Equals), 0)
+	c.Assert(new, Equals, true)
+
+	// So, if we look this up, the only thing we can be sure of is that it
+	// must not find the longID. It will either be idpool.NoID or shortID.
+	observedID, err = allocator.GetNoCache(shortKey)
+	c.Assert(err, IsNil)
+	c.Assert(observedID, Not(Equals), longID)
+}
+
+func (s *AllocatorSuite) TestprefixMatchesKey(c *C) {
+	// cilium/state/identities/v1/value/label;foo;bar;/172.0.124.60
+
+	tests := []struct {
+		prefix   string
+		key      string
+		expected bool
+	}{
+		{
+			prefix:   "foo",
+			key:      "foo/bar",
+			expected: true,
+		},
+		{
+			prefix:   "foo/;bar;baz;/;a;",
+			key:      "foo/;bar;baz;/;a;/alice",
+			expected: true,
+		},
+		{
+			prefix:   "foo/;bar;baz;",
+			key:      "foo/;bar;baz;/;a;/alice",
+			expected: false,
+		},
+		{
+			prefix:   "foo/;bar;baz;/;a;/baz",
+			key:      "foo/;bar;baz;/;a;/alice",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Logf("prefixMatchesKey(%q, %q) expected to be %t", tt.prefix, tt.key, tt.expected)
+		result := prefixMatchesKey(tt.prefix, tt.key)
+		c.Assert(result, Equals, tt.expected)
+	}
+}
+
+func (s *AllocatorSuite) TestGetNoCache(c *C) {
+	testGetNoCache(c, idpool.ID(256), randomTestName(), "a") // enable use of local cache
 }
 
 func (s *AllocatorSuite) TestRemoteCache(c *C) {

--- a/pkg/kvstore/backend.go
+++ b/pkg/kvstore/backend.go
@@ -99,8 +99,8 @@ type BackendOperations interface {
 	// Get returns value of key
 	Get(key string) ([]byte, error)
 
-	// GetPrefix returns the first key which matches the prefix
-	GetPrefix(prefix string) ([]byte, error)
+	// GetPrefix returns the first key which matches the prefix and its value
+	GetPrefix(prefix string) (string, []byte, error)
 
 	// Set sets value of key
 	Set(key string, value []byte) error

--- a/pkg/kvstore/base_test.go
+++ b/pkg/kvstore/base_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -60,18 +60,20 @@ func (s *BaseTests) TestGetSet(c *C) {
 	DeletePrefix(prefix)
 	defer DeletePrefix(prefix)
 
-	val, err := GetPrefix(prefix)
+	key, val, err := GetPrefix(prefix)
 	c.Assert(err, IsNil)
 	c.Assert(val, IsNil)
+	c.Assert(key, Equals, "")
 
 	for i := 0; i < maxID; i++ {
 		val, err = Get(testKey(prefix, i))
 		c.Assert(err, IsNil)
 		c.Assert(val, IsNil)
 
-		val, err = GetPrefix(testKey(prefix, i))
+		key, val, err = GetPrefix(testKey(prefix, i))
 		c.Assert(err, IsNil)
 		c.Assert(val, IsNil)
+		c.Assert(key, Equals, "")
 
 		c.Assert(Set(testKey(prefix, i), testValue(i)), IsNil)
 
@@ -91,14 +93,16 @@ func (s *BaseTests) TestGetSet(c *C) {
 		c.Assert(err, IsNil)
 		c.Assert(val, IsNil)
 
-		val, err = GetPrefix(testKey(prefix, i))
+		key, val, err = GetPrefix(testKey(prefix, i))
 		c.Assert(err, IsNil)
 		c.Assert(val, IsNil)
+		c.Assert(key, Equals, "")
 	}
 
-	val, err = GetPrefix(prefix)
+	key, val, err = GetPrefix(prefix)
 	c.Assert(err, IsNil)
 	c.Assert(val, IsNil)
+	c.Assert(key, Equals, "")
 }
 
 func (s *BaseTests) BenchmarkGet(c *C) {
@@ -133,9 +137,10 @@ func (s *BaseTests) TestUpdate(c *C) {
 	DeletePrefix(prefix)
 	defer DeletePrefix(prefix)
 
-	val, err := GetPrefix(prefix)
+	key, val, err := GetPrefix(prefix)
 	c.Assert(err, IsNil)
 	c.Assert(val, IsNil)
+	c.Assert(key, Equals, "")
 
 	// create
 	c.Assert(Update(testKey(prefix, 0), testValue(0), true), IsNil)
@@ -158,9 +163,10 @@ func (s *BaseTests) TestCreateOnly(c *C) {
 	DeletePrefix(prefix)
 	defer DeletePrefix(prefix)
 
-	val, err := GetPrefix(prefix)
+	key, val, err := GetPrefix(prefix)
 	c.Assert(err, IsNil)
 	c.Assert(val, IsNil)
+	c.Assert(key, Equals, "")
 
 	c.Assert(CreateOnly(testKey(prefix, 0), testValue(0), false), IsNil)
 

--- a/pkg/kvstore/base_test.go
+++ b/pkg/kvstore/base_test.go
@@ -105,6 +105,40 @@ func (s *BaseTests) TestGetSet(c *C) {
 	c.Assert(key, Equals, "")
 }
 
+func (s *BaseTests) TestGetPrefix(c *C) {
+	prefix := "unit-test/"
+
+	DeletePrefix(prefix)
+	defer DeletePrefix(prefix)
+
+	key, val, err := GetPrefix(prefix)
+	c.Assert(err, IsNil)
+	c.Assert(val, IsNil)
+	c.Assert(key, Equals, "")
+
+	// create
+	labelsLong := "foo;/;bar;"
+	labelsShort := "foo;/"
+	testKey := fmt.Sprintf("%s%s/%010d", prefix, labelsLong, 0)
+	c.Assert(Update(testKey, testValue(0), true), IsNil)
+
+	val, err = Get(testKey)
+	c.Assert(err, IsNil)
+	c.Assert(val, checker.DeepEquals, testValue(0))
+
+	prefixes := []string{
+		prefix,
+		fmt.Sprintf("%s%s", prefix, labelsLong),
+		fmt.Sprintf("%s%s", prefix, labelsShort),
+	}
+	for _, p := range prefixes {
+		key, val, err = GetPrefix(p)
+		c.Assert(err, IsNil)
+		c.Assert(val, checker.DeepEquals, testValue(0))
+		c.Assert(key, Equals, testKey)
+	}
+}
+
 func (s *BaseTests) BenchmarkGet(c *C) {
 	prefix := "unit-test/"
 	DeletePrefix(prefix)

--- a/pkg/kvstore/consul.go
+++ b/pkg/kvstore/consul.go
@@ -386,19 +386,19 @@ func (c *consulClient) Get(key string) ([]byte, error) {
 	return pair.Value, nil
 }
 
-// GetPrefix returns the first key which matches the prefix
-func (c *consulClient) GetPrefix(prefix string) ([]byte, error) {
+// GetPrefix returns the first key which matches the prefix and its value
+func (c *consulClient) GetPrefix(prefix string) (string, []byte, error) {
 	increaseMetric(prefix, metricRead, "GetPrefix")
 	pairs, _, err := c.KV().List(prefix, nil)
 	if err != nil {
-		return nil, err
+		return "", nil, err
 	}
 
 	if len(pairs) == 0 {
-		return nil, nil
+		return "", nil, nil
 	}
 
-	return pairs[0].Value, nil
+	return pairs[0].Key, pairs[0].Value, nil
 }
 
 // Update creates or updates a key with the value

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -656,18 +656,18 @@ func (e *etcdClient) Get(key string) ([]byte, error) {
 	return getR.Kvs[0].Value, nil
 }
 
-// GetPrefix returns the first key which matches the prefix
-func (e *etcdClient) GetPrefix(prefix string) ([]byte, error) {
+// GetPrefix returns the first key which matches the prefix and its value
+func (e *etcdClient) GetPrefix(prefix string) (string, []byte, error) {
 	increaseMetric(prefix, metricRead, "GetPrefix")
 	getR, err := e.client.Get(ctx.Background(), prefix, client.WithPrefix())
 	if err != nil {
-		return nil, Hint(err)
+		return "", nil, Hint(err)
 	}
 
 	if getR.Count == 0 {
-		return nil, nil
+		return "", nil, nil
 	}
-	return getR.Kvs[0].Value, nil
+	return string(getR.Kvs[0].Key), getR.Kvs[0].Value, nil
 }
 
 // Set sets value of key

--- a/pkg/kvstore/kvstore.go
+++ b/pkg/kvstore/kvstore.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -42,11 +42,11 @@ func Get(key string) ([]byte, error) {
 	return v, err
 }
 
-// GetPrefix returns the first key which matches the prefix
-func GetPrefix(prefix string) ([]byte, error) {
-	v, err := Client().GetPrefix(prefix)
-	Trace("GetPrefix", err, logrus.Fields{fieldPrefix: prefix, fieldValue: string(v)})
-	return v, err
+// GetPrefix returns the first key which matches the prefix and its value
+func GetPrefix(prefix string) (k string, v []byte, err error) {
+	k, v, err = Client().GetPrefix(prefix)
+	Trace("GetPrefix", err, logrus.Fields{fieldPrefix: prefix, fieldKey: k, fieldValue: string(v)})
+	return
 }
 
 // ListPrefix returns the list of keys matching the prefix

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -439,6 +439,10 @@ func (l Labels) SortedList() []byte {
 	for _, k := range keys {
 		// We don't care if the values already have a '=' since this method is
 		// only used to calculate a SHA256Sum
+		//
+		// We absolutely care that the final character is a semi-colon.
+		// Identity allocation in the kvstore depends on this (see
+		// kvstore.prefixMatchesKey())
 		result += fmt.Sprintf(`%s:%s=%s;`, l[k].Source, k, l[k].Value)
 	}
 


### PR DESCRIPTION
Backported PRs:

* PR: 7565 -- kvstore: Fix identity override with labels prefix (@joestringer) -- https://github.com/cilium/cilium/pull/7565
    - Had conflicts due to function signatures not containing `context.Context` - was easy to fix / resolve, but did introduce conflicts nonetheless.

When you have backported the above commits, you can update the PR labels via this command:

```
$ for pr in 7565; do contrib/backporting/set-labels.py $pr done 1.4; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7579)
<!-- Reviewable:end -->
