### PR TITLE
Reduce triggered kvstore events

### DIFF
--- a/pkg/ipcache/kvstore.go
+++ b/pkg/ipcache/kvstore.go
@@ -71,7 +71,8 @@ type kvstoreImplementation struct{}
 // upsert places the mapping of {key, value} into the kvstore, optionally with
 // a lease.
 func (k kvstoreImplementation) upsert(ctx context.Context, key string, value []byte, lease bool) error {
-	return kvstore.Update(ctx, key, value, lease)
+	_, err := kvstore.UpdateIfDifferent(ctx, key, value, lease)
+	return err
 }
 
 // release removes the specified key from the kvstore.

--- a/pkg/kvstore/backend.go
+++ b/pkg/kvstore/backend.go
@@ -163,6 +163,9 @@ type BackendOperations interface {
 	// Update atomically creates a key or fails if it already exists
 	Update(ctx context.Context, key string, value []byte, lease bool) error
 
+	// UpdateIfDifferent updates a key if the value is different
+	UpdateIfDifferent(ctx context.Context, key string, value []byte, lease bool) (bool, error)
+
 	// CreateOnly atomically creates a key or fails if it already exists
 	CreateOnly(ctx context.Context, key string, value []byte, lease bool) (bool, error)
 

--- a/pkg/kvstore/kvstore.go
+++ b/pkg/kvstore/kvstore.go
@@ -76,6 +76,18 @@ func Update(ctx context.Context, key string, value []byte, lease bool) error {
 	return err
 }
 
+// UpdateIfDifferent updates a key if the value is different
+func UpdateIfDifferent(ctx context.Context, key string, value []byte, lease bool) (bool, error) {
+	recreated, err := Client().UpdateIfDifferent(ctx, key, value, lease)
+	Trace("Update", err, logrus.Fields{
+		fieldKey:         key,
+		fieldValue:       string(value),
+		fieldAttachLease: lease,
+		"recreated":      recreated,
+	})
+	return recreated, err
+}
+
 // CreateIfExists creates a key with the value only if key condKey exists
 func CreateIfExists(condKey, key string, value []byte, lease bool) error {
 	err := Client().CreateIfExists(condKey, key, value, lease)

--- a/pkg/kvstore/store/store.go
+++ b/pkg/kvstore/store/store.go
@@ -264,7 +264,7 @@ func (s *SharedStore) syncLocalKey(key LocalKey) error {
 
 	// Update key in kvstore, overwrite an eventual existing key, attach
 	// lease to expire entry when agent dies and never comes back up.
-	if err := s.backend.Update(context.TODO(), s.keyPath(key), jsonValue, true); err != nil {
+	if _, err := s.backend.UpdateIfDifferent(context.TODO(), s.keyPath(key), jsonValue, true); err != nil {
 		return err
 	}
 

--- a/pkg/kvstore/store/store_test.go
+++ b/pkg/kvstore/store/store_test.go
@@ -230,10 +230,8 @@ func (s *StoreSuite) TestStorePeriodicSync(c *C) {
 	err = store.UpdateLocalKeySync(&localKey2)
 	c.Assert(err, IsNil)
 
-	// the sync interval occurs every 10 millisecond, wait until 3 updates
-	// have occurred
-	c.Assert(expect(func() bool { return localKey1.updated() >= 3 }), IsNil)
-	c.Assert(expect(func() bool { return localKey2.updated() >= 3 }), IsNil)
+	c.Assert(expect(func() bool { return localKey1.updated() >= 1 }), IsNil)
+	c.Assert(expect(func() bool { return localKey2.updated() >= 1 }), IsNil)
 
 	store.DeleteLocalKey(&localKey1)
 	store.DeleteLocalKey(&localKey2)
@@ -286,8 +284,8 @@ func setupStoreCollaboration(c *C, storePrefix, keyPrefix string) *SharedStore {
 	c.Assert(err, IsNil)
 
 	// wait until local keys was inserted and until the kvstore has confirmed the
-	c.Assert(expect(func() bool { return localKey1.updated() >= 2 }), IsNil)
-	c.Assert(expect(func() bool { return localKey2.updated() >= 2 }), IsNil)
+	c.Assert(expect(func() bool { return localKey1.updated() >= 1 }), IsNil)
+	c.Assert(expect(func() bool { return localKey2.updated() >= 1 }), IsNil)
 
 	c.Assert(len(store.getLocalKeys()), Equals, 2)
 


### PR DESCRIPTION
Several regular synchronization routines ensuring resiliency had a side-effect of causing unnecessary kvstore events which can result in significant load in large-scale clusters. Optimize interactions to keep the resilience property while minimizing the resulting events.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7580)
<!-- Reviewable:end -->
