### PR TITLE
k8s: Add SYS_MODULE capability, module paths

### DIFF
--- a/examples/kubernetes/1.10/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-containerd-ds.yaml
@@ -106,6 +106,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf
@@ -130,6 +131,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -195,6 +204,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.10/cilium-containerd.yaml
+++ b/examples/kubernetes/1.10/cilium-containerd.yaml
@@ -256,6 +256,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf
@@ -280,6 +281,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -345,6 +354,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.10/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-crio-ds.yaml
@@ -114,6 +114,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf
@@ -138,6 +139,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -203,6 +212,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -264,6 +264,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf
@@ -288,6 +289,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -353,6 +362,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.10/cilium-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-ds.yaml
@@ -113,6 +113,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf
@@ -137,6 +138,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -202,6 +211,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.10/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.10/cilium-external-etcd.yaml
@@ -263,6 +263,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf
@@ -287,6 +288,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -352,6 +361,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.10/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-minikube-ds.yaml
@@ -113,6 +113,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf
@@ -137,6 +138,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -202,6 +211,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.10/cilium-minikube.yaml
+++ b/examples/kubernetes/1.10/cilium-minikube.yaml
@@ -263,6 +263,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf
@@ -287,6 +288,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -352,6 +361,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.10/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.10/cilium-with-node-init.yaml
@@ -263,6 +263,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf
@@ -287,6 +288,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -352,6 +361,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -263,6 +263,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf
@@ -287,6 +288,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -352,6 +361,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.11/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-containerd-ds.yaml
@@ -106,6 +106,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf
@@ -130,6 +131,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -196,6 +205,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.11/cilium-containerd.yaml
+++ b/examples/kubernetes/1.11/cilium-containerd.yaml
@@ -256,6 +256,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf
@@ -280,6 +281,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -346,6 +355,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.11/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-crio-ds.yaml
@@ -114,6 +114,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /var/run/cilium
@@ -136,6 +137,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -195,6 +204,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -264,6 +264,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /var/run/cilium
@@ -286,6 +287,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -345,6 +354,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -113,6 +113,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf
@@ -137,6 +138,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -203,6 +212,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.11/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.11/cilium-external-etcd.yaml
@@ -263,6 +263,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf
@@ -287,6 +288,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -353,6 +362,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.11/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-minikube-ds.yaml
@@ -113,6 +113,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf
@@ -137,6 +138,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -203,6 +212,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.11/cilium-minikube.yaml
+++ b/examples/kubernetes/1.11/cilium-minikube.yaml
@@ -263,6 +263,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf
@@ -287,6 +288,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -353,6 +362,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.11/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.11/cilium-with-node-init.yaml
@@ -263,6 +263,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf
@@ -287,6 +288,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -352,6 +361,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -263,6 +263,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf
@@ -287,6 +288,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -353,6 +362,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.12/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-containerd-ds.yaml
@@ -106,6 +106,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf
@@ -130,6 +131,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -196,6 +205,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.12/cilium-containerd.yaml
+++ b/examples/kubernetes/1.12/cilium-containerd.yaml
@@ -256,6 +256,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf
@@ -280,6 +281,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -346,6 +355,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.12/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-crio-ds.yaml
@@ -114,6 +114,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /var/run/cilium
@@ -136,6 +137,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -195,6 +204,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -264,6 +264,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /var/run/cilium
@@ -286,6 +287,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -345,6 +354,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.12/cilium-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-ds.yaml
@@ -113,6 +113,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf
@@ -137,6 +138,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -203,6 +212,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.12/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.12/cilium-external-etcd.yaml
@@ -263,6 +263,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf
@@ -287,6 +288,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -353,6 +362,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.12/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-minikube-ds.yaml
@@ -113,6 +113,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf
@@ -137,6 +138,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -203,6 +212,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.12/cilium-minikube.yaml
+++ b/examples/kubernetes/1.12/cilium-minikube.yaml
@@ -263,6 +263,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf
@@ -287,6 +288,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -353,6 +362,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.12/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.12/cilium-with-node-init.yaml
@@ -263,6 +263,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf
@@ -287,6 +288,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -352,6 +361,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -263,6 +263,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf
@@ -287,6 +288,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -353,6 +362,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.13/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-containerd-ds.yaml
@@ -106,6 +106,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf
@@ -130,6 +131,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -196,6 +205,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.13/cilium-containerd.yaml
+++ b/examples/kubernetes/1.13/cilium-containerd.yaml
@@ -256,6 +256,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf
@@ -280,6 +281,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -346,6 +355,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.13/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-crio-ds.yaml
@@ -114,6 +114,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /var/run/cilium
@@ -136,6 +137,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -195,6 +204,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.13/cilium-crio.yaml
+++ b/examples/kubernetes/1.13/cilium-crio.yaml
@@ -264,6 +264,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /var/run/cilium
@@ -286,6 +287,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -345,6 +354,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.13/cilium-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-ds.yaml
@@ -113,6 +113,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf
@@ -137,6 +138,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -203,6 +212,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.13/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.13/cilium-external-etcd.yaml
@@ -263,6 +263,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf
@@ -287,6 +288,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -353,6 +362,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.13/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-minikube-ds.yaml
@@ -113,6 +113,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf
@@ -137,6 +138,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -203,6 +212,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.13/cilium-minikube.yaml
+++ b/examples/kubernetes/1.13/cilium-minikube.yaml
@@ -263,6 +263,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf
@@ -287,6 +288,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -353,6 +362,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.13/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.13/cilium-with-node-init.yaml
@@ -263,6 +263,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf
@@ -287,6 +288,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -352,6 +361,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.13/cilium.yaml
+++ b/examples/kubernetes/1.13/cilium.yaml
@@ -263,6 +263,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf
@@ -287,6 +288,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -353,6 +362,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.14/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.14/cilium-containerd-ds.yaml
@@ -106,6 +106,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf
@@ -130,6 +131,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -196,6 +205,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.14/cilium-containerd.yaml
+++ b/examples/kubernetes/1.14/cilium-containerd.yaml
@@ -256,6 +256,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf
@@ -280,6 +281,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -346,6 +355,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.14/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.14/cilium-crio-ds.yaml
@@ -114,6 +114,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /var/run/cilium
@@ -136,6 +137,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -195,6 +204,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.14/cilium-crio.yaml
+++ b/examples/kubernetes/1.14/cilium-crio.yaml
@@ -264,6 +264,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /var/run/cilium
@@ -286,6 +287,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -345,6 +354,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.14/cilium-ds.yaml
+++ b/examples/kubernetes/1.14/cilium-ds.yaml
@@ -113,6 +113,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf
@@ -137,6 +138,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -203,6 +212,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.14/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.14/cilium-external-etcd.yaml
@@ -263,6 +263,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf
@@ -287,6 +288,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -353,6 +362,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.14/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.14/cilium-minikube-ds.yaml
@@ -113,6 +113,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf
@@ -137,6 +138,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -203,6 +212,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.14/cilium-minikube.yaml
+++ b/examples/kubernetes/1.14/cilium-minikube.yaml
@@ -263,6 +263,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf
@@ -287,6 +288,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -353,6 +362,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.14/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.14/cilium-with-node-init.yaml
@@ -263,6 +263,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf
@@ -287,6 +288,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -352,6 +361,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.14/cilium.yaml
+++ b/examples/kubernetes/1.14/cilium.yaml
@@ -263,6 +263,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf
@@ -287,6 +288,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -353,6 +362,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/templates/v1/cilium-containerd-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-containerd-ds.yaml.sed
@@ -106,6 +106,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf
@@ -130,6 +131,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -195,6 +204,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
@@ -114,6 +114,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf
@@ -138,6 +139,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -203,6 +212,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
@@ -113,6 +113,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf
@@ -137,6 +138,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -202,6 +211,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/templates/v1/cilium-minikube-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-minikube-ds.yaml.sed
@@ -113,6 +113,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - SYS_MODULE
           privileged: true
         volumeMounts:
         - mountPath: /sys/fs/bpf
@@ -137,6 +138,14 @@ spec:
           readOnly: true
         - mountPath: /tmp/cilium/config-map
           name: cilium-config-path
+          readOnly: true
+          # Needed to be able to load kernel modules
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+          # Needed by ip[6]tables when loading kernel modules
+        - mountPath: /sbin/modprobe
+          name: sbin-modprobe
           readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -202,6 +211,16 @@ spec:
           path: /etc/cni/net.d
           type: DirectoryOrCreate
         name: etc-cni-netd
+        # To be able to load kernel modules
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: lib-modules
+        # To be able to load ip[6]tables kernel modules
+      - hostPath:
+          path: /sbin/modprobe
+          type: File
+        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420


### PR DESCRIPTION
Add kernel module autoload capability, needed for IPv6 IPsec and
TPROXY in cases where the tables are not yet loaded when cilium-agent
starts.

Also add volume mounts for /lib/modules and /sbin/modprobe, as
'ip[6]tables' command depends on these when a kernel module is not
already loaded.

Fixes: #7453
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7581)
<!-- Reviewable:end -->
