### PR TITLE
eventqueue: check if queue is nil before checking if drained

### DIFF
--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -260,12 +260,12 @@ func Remove(ep *endpoint.Endpoint, owner RuleCacheOwner) <-chan struct{} {
 
 		// The endpoint's EventQueue may not be stopped yet (depending on whether
 		// the caller of the EventQueue has stopped it or not). Call it here
-		// to be safe so that ep.IsDrained() does not hang forever.
+		// to be safe so that ep.WaitToBeDrained() does not hang forever.
 		ep.EventQueue.Stop()
 
 		// Wait for no more events (primarily regenerations) to be occurring for
 		// this endpoint.
-		<-ep.EventQueue.IsDrained()
+		ep.EventQueue.WaitToBeDrained()
 
 		// Now that queue is drained, no more regenerations are occurring for
 		// this endpoint. Safe to remove references to it from the policy

--- a/pkg/eventqueue/eventqueue.go
+++ b/pkg/eventqueue/eventqueue.go
@@ -280,11 +280,18 @@ func (q *EventQueue) Stop() {
 	})
 }
 
-// IsDrained returns the channel which waits for the EventQueue to have been
+// WaitToBeDrained returns the channel which waits for the EventQueue to have been
 // stopped. This allows for queuers to ensure that all events in the queue have
-// been processed or cancelled.
-func (q *EventQueue) IsDrained() <-chan struct{} {
-	return q.close
+// been processed or cancelled. If the queue is nil, returns immediately.
+func (q *EventQueue) WaitToBeDrained() {
+	if q == nil {
+		return
+	}
+
+	select {
+	case <-q.close:
+		return
+	}
 }
 
 // EventHandler is an interface for allowing an EventQueue to handle events

--- a/pkg/eventqueue/eventqueue_test.go
+++ b/pkg/eventqueue/eventqueue_test.go
@@ -75,7 +75,7 @@ func (s *EventQueueSuite) TestDrained(c *C) {
 	defer cancel()
 
 	select {
-	case <-q.IsDrained():
+	case <-q.close:
 	case <-ctx.Done():
 		c.Log("timed out waiting for queue to be drained")
 		c.Fail()


### PR DESCRIPTION
Waiting for a nil queue to be drained can cause a panic:

```
2019-04-02T20:23:21.301728563Z panic: runtime error: invalid memory address or nil pointer dereference
2019-04-02T20:23:21.302031359Z [signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x2400493]
2019-04-02T20:23:21.302075439Z
2019-04-02T20:23:21.302209479Z goroutine 2332 [running]:
2019-04-02T20:23:21.302271748Z github.com/cilium/cilium/pkg/eventqueue.(*EventQueue).IsDrained(...)
2019-04-02T20:23:21.302396789Z /go/src/github.com/cilium/cilium/pkg/eventqueue/eventqueue.go:287
2019-04-02T20:23:21.302712171Z github.com/cilium/cilium/pkg/endpointmanager.Remove.func1(0x33aa820, 0xc0003ac6c0, 0xc001072cc0, 0xc000461600)
2019-04-02T20:23:21.302894563Z /go/src/github.com/cilium/cilium/pkg/endpointmanager/manager.go:268 +0x43
2019-04-02T20:23:21.302977887Z created by github.com/cilium/cilium/pkg/endpointmanager.Remove
2019-04-02T20:23:21.303152028Z /go/src/github.com/cilium/cilium/pkg/endpointmanager/manager.go:259 +0x117
```

Instead of returning the channel which the caller waits to return, check if the
EventQueue is nil before waiting for the `close` channel within the EventQueue
to be closed.

This can occur if the endpoint is deleted before it is added to the endpointmanager,
as its eventqueue is not initialized yet.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7582)
<!-- Reviewable:end -->
