### PR TITLE
endpoint: Use IsSet() to check if endpoint IP is set

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -855,11 +855,11 @@ func (e *Endpoint) SkipStateClean() {
 // endpoints map
 func (e *Endpoint) GetBPFKeys() []*lxcmap.EndpointKey {
 	keys := []*lxcmap.EndpointKey{}
-	if e.IPv6 != nil {
+	if e.IPv6.IsSet() {
 		keys = append(keys, lxcmap.NewEndpointKey(e.IPv6.IP()))
 	}
 
-	if e.IPv4 != nil {
+	if e.IPv4.IsSet() {
 		keys = append(keys, lxcmap.NewEndpointKey(e.IPv4.IP()))
 	}
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2117,10 +2117,10 @@ func (e *Endpoint) WaitForPolicyRevision(ctx context.Context, rev uint64, done f
 // IPs returns the slice of valid IPs for this endpoint.
 func (e *Endpoint) IPs() []net.IP {
 	ips := []net.IP{}
-	if e.IPv4 != nil {
+	if e.IPv4.IsSet() {
 		ips = append(ips, e.IPv4.IP())
 	}
-	if e.IPv6 != nil {
+	if e.IPv6.IsSet() {
 		ips = append(ips, e.IPv6.IP())
 	}
 	return ips

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -490,7 +490,7 @@ func (e *Endpoint) FormatGlobalEndpointID() string {
 // with the numerical ID representing its security identity.
 func (e *Endpoint) runIPIdentitySync(endpointIP addressing.CiliumIP) {
 
-	if endpointIP == nil {
+	if !endpointIP.IsSet() {
 		return
 	}
 


### PR DESCRIPTION
When restored from JSON, the endpoint.IPv[46] field can become an empty slice
instead of being nil.  Use IsSet() to check whether the address is available.

This resulted in unnecessary work being performed. In particular running an
additional controller to synchronize the inexisting IP address to the ipcache
was expensive.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7585)
<!-- Reviewable:end -->
