### PR TITLE
docs: Add a page with link to the kubeadm guide

### DIFF
--- a/Documentation/gettingstarted/k8s-install-kubeadm.rst
+++ b/Documentation/gettingstarted/k8s-install-kubeadm.rst
@@ -1,0 +1,11 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+    http://docs.cilium.io
+
+Installation using kubeadm
+==========================
+
+Instructions about installing Cilium on Kubernetes cluster deployed by kubeadm
+are available in the `official Kubernetes documentation <https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/#pod-network>`__.

--- a/Documentation/gettingstarted/k8s-install-self-managed.rst
+++ b/Documentation/gettingstarted/k8s-install-self-managed.rst
@@ -11,5 +11,6 @@ Self-Managed Kubernetes
    :maxdepth: 1
    :glob:
 
+   k8s-install-kubeadm
    k8s-install-etcd-operator
    k8s-install-external-etcd


### PR DESCRIPTION
Instructions about installing Cilium on kubeadm-managed clusters are
available on the official Kubernetes website[0], but there was no
information in Cilium documentation, where many people were looking for
that kind of guide. This change provides a page with a link to k8s docs.

[0] https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/#pod-network

Fixes #654

Reported-by: Panos Georgiadis <drpaneas@gmail.com>
Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7586)
<!-- Reviewable:end -->
