### PR TITLE
cmd: Warn if bpf ipcache list cmd comes up empty

### DIFF
--- a/Documentation/cmdref/cilium_bpf_ipcache_list.md
+++ b/Documentation/cmdref/cilium_bpf_ipcache_list.md
@@ -11,7 +11,8 @@ List endpoint IPs (local and remote) and their corresponding security identities
 Note that for Linux kernel versions between 4.11 and 4.15 inclusive, the native
 LPM map type used for implementing the IPCache does not provide the ability to
 walk / dump the entries, so on these kernel versions this tool will never
-return any entries, even if entries exist in the map.
+return any entries, even if entries exist in the map. You may instead run:
+    cilium map get cilium_ipcache
 
 
 ```

--- a/cilium/cmd/bpf_ipcache_list.go
+++ b/cilium/cmd/bpf_ipcache_list.go
@@ -26,14 +26,15 @@ import (
 )
 
 const (
-	ipAddrTitle      = "IP PREFIX/ADDRESS"
-	identityTitle    = "IDENTITY"
-	ipCacheListUsage = `List endpoint IPs (local and remote) and their corresponding security identities.
-
+	ipAddrTitle          = "IP PREFIX/ADDRESS"
+	identityTitle        = "IDENTITY"
+	ipCacheListUsage     = "List endpoint IPs (local and remote) and their corresponding security identities.\n" + kernelVersionWarning
+	kernelVersionWarning = `
 Note that for Linux kernel versions between 4.11 and 4.15 inclusive, the native
 LPM map type used for implementing the IPCache does not provide the ability to
 walk / dump the entries, so on these kernel versions this tool will never
-return any entries, even if entries exist in the map.
+return any entries, even if entries exist in the map. You may instead run:
+    cilium map get cilium_ipcache
 `
 )
 
@@ -60,7 +61,7 @@ var bpfIPCacheListCmd = &cobra.Command{
 		}
 
 		if len(bpfIPCacheList) == 0 {
-			fmt.Fprintf(os.Stderr, "No entries found.\n")
+			fmt.Fprintf(os.Stderr, "No entries found.\n%v\n", kernelVersionWarning)
 		} else {
 			TablePrinter(ipAddrTitle, identityTitle, bpfIPCacheList)
 		}


### PR DESCRIPTION
This command is unavailable for Linux kernel versions >= 4.11 through
<= 4.15 and comes up empty as a result.
Notify the user that this behavior is expected and recommend they use
`cilium map get cilium_ipcache` as an alternative.

Example

```
~$ sudo cilium bpf ipcache list
No entries found.

Note that for Linux kernel versions between 4.11 and 4.15 inclusive, the native
LPM map type used for implementing the IPCache does not provide the ability to
walk / dump the entries, so on these kernel versions this tool will never
return any entries, even if entries exist in the map. You may instead run
cilium map get cilium_ipcache

```

Fixes #7576

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7587)
<!-- Reviewable:end -->
