### PR TITLE
add cilium-operator restart to cluster mesh getting started guide

### DIFF
--- a/Documentation/gettingstarted/clustermesh.rst
+++ b/Documentation/gettingstarted/clustermesh.rst
@@ -245,6 +245,12 @@ chapter into all of your clusters:
 
     kubectl -n kube-system delete pod -l k8s-app=cilium
 
+3. For global services to work (see below), also restart the cilium-operator:
+
+.. code:: bash
+
+    kubectl -n kube-system delete pod -l name=cilium-operator
+
 Test pod connectivity between clusters
 ======================================
 


### PR DESCRIPTION
discussed here: https://cilium.slack.com/messages/C1MATJ5U5/

Note: something to consider for a subsequent PR: automating the whole cluster mesh getting started guide with a script, such as https://github.com/admiraltyio/multicluster-scheduler/blob/master/test/e2e/cilium.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7589)
<!-- Reviewable:end -->
