### PR TITLE
allocator: Fix warnings on master & slave key re-creation

### DIFF
--- a/pkg/kvstore/backend.go
+++ b/pkg/kvstore/backend.go
@@ -164,7 +164,7 @@ type BackendOperations interface {
 	Update(ctx context.Context, key string, value []byte, lease bool) error
 
 	// CreateOnly atomically creates a key or fails if it already exists
-	CreateOnly(ctx context.Context, key string, value []byte, lease bool) error
+	CreateOnly(ctx context.Context, key string, value []byte, lease bool) (bool, error)
 
 	// CreateIfExists creates a key with the value only if key condKey exists
 	CreateIfExists(condKey, key string, value []byte, lease bool) error

--- a/pkg/kvstore/base_test.go
+++ b/pkg/kvstore/base_test.go
@@ -202,13 +202,17 @@ func (s *BaseTests) TestCreateOnly(c *C) {
 	c.Assert(val, IsNil)
 	c.Assert(key, Equals, "")
 
-	c.Assert(CreateOnly(context.Background(), testKey(prefix, 0), testValue(0), false), IsNil)
+	success, err := CreateOnly(context.Background(), testKey(prefix, 0), testValue(0), false)
+	c.Assert(err, IsNil)
+	c.Assert(success, Equals, true)
 
 	val, err = Get(testKey(prefix, 0))
 	c.Assert(err, IsNil)
 	c.Assert(val, checker.DeepEquals, testValue(0))
 
-	c.Assert(CreateOnly(context.Background(), testKey(prefix, 0), testValue(1), false), Not(IsNil))
+	success, err = CreateOnly(context.Background(), testKey(prefix, 0), testValue(1), false)
+	c.Assert(err, IsNil)
+	c.Assert(success, Equals, false)
 
 	val, err = Get(testKey(prefix, 0))
 	c.Assert(err, IsNil)
@@ -260,8 +264,9 @@ func (s *BaseTests) TestListAndWatch(c *C) {
 	DeletePrefix("foo2/")
 	defer DeletePrefix("foo2/")
 
-	err := CreateOnly(context.Background(), key1, val1, false)
+	success, err := CreateOnly(context.Background(), key1, val1, false)
 	c.Assert(err, IsNil)
+	c.Assert(success, Equals, true)
 
 	w := ListAndWatch("testWatcher2", "foo2/", 100)
 	c.Assert(c, Not(IsNil))
@@ -269,16 +274,18 @@ func (s *BaseTests) TestListAndWatch(c *C) {
 	expectEvent(c, w, EventTypeCreate, key1, val1)
 	expectEvent(c, w, EventTypeListDone, "", []byte{})
 
-	err = CreateOnly(context.Background(), key2, val2, false)
+	success, err = CreateOnly(context.Background(), key2, val2, false)
 	c.Assert(err, IsNil)
+	c.Assert(success, Equals, true)
 	expectEvent(c, w, EventTypeCreate, key2, val2)
 
 	err = Delete(key1)
 	c.Assert(err, IsNil)
 	expectEvent(c, w, EventTypeDelete, key1, val1)
 
-	err = CreateOnly(context.Background(), key1, val1, false)
+	success, err = CreateOnly(context.Background(), key1, val1, false)
 	c.Assert(err, IsNil)
+	c.Assert(success, Equals, true)
 	expectEvent(c, w, EventTypeCreate, key1, val1)
 
 	err = Delete(key1)

--- a/pkg/kvstore/kvstore.go
+++ b/pkg/kvstore/kvstore.go
@@ -59,10 +59,14 @@ func ListPrefix(prefix string) (KeyValuePairs, error) {
 }
 
 // CreateOnly atomically creates a key or fails if it already exists
-func CreateOnly(ctx context.Context, key string, value []byte, lease bool) error {
-	err := Client().CreateOnly(ctx, key, value, lease)
-	Trace("CreateOnly", err, logrus.Fields{fieldKey: key, fieldValue: string(value), fieldAttachLease: lease})
-	return err
+func CreateOnly(ctx context.Context, key string, value []byte, lease bool) (bool, error) {
+	success, err := Client().CreateOnly(ctx, key, value, lease)
+	Trace("CreateOnly", err, logrus.Fields{
+		fieldKey: key, fieldValue: string(value),
+		fieldAttachLease: lease,
+		"success":        success,
+	})
+	return success, err
 }
 
 // Update creates or updates a key value pair


### PR DESCRIPTION
Modify CreateOnly() to return whether the create attempt failed or whether the
key already existed and use this to provide useful warnings:
 - Warn if create operation failed for reasons other than the key existed
 - Warn if a key was successfully re-created to give an indication that the kvstore state was incorrect

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7592)
<!-- Reviewable:end -->
