### PR TITLE
Kubernetes CNP status on invalid policies. 

### DIFF
--- a/pkg/k8s/cnp.go
+++ b/pkg/k8s/cnp.go
@@ -124,6 +124,7 @@ func (c *CNPStatusUpdateContext) prepareUpdate(cnp *types.SlimCNP, scopedLog *lo
 		serverRule = localCopy.DeepCopy()
 		_, err = serverRule.Parse()
 		if err != nil {
+			err = ErrParse{err.Error()}
 			scopedLog.WithError(err).WithField(logfields.Object, logfields.Repr(serverRule)).
 				Warn("Error parsing new CiliumNetworkPolicy rule")
 		} else {
@@ -196,7 +197,6 @@ func (c *CNPStatusUpdateContext) UpdateStatus(ctx context.Context, cnp *types.Sl
 			logfields.K8sNamespace:            cnp.ObjectMeta.Namespace,
 		})
 	)
-
 	ctxEndpointWait, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 

--- a/test/helpers/policygen/models.go
+++ b/test/helpers/policygen/models.go
@@ -715,7 +715,7 @@ func (t *TestSpec) InvalidNetworkPolicyApply() (*cnpv2.CiliumNetworkPolicy, erro
 	err = helpers.WithTimeout(
 		body,
 		fmt.Sprintf("CNP %q is not ready after timeout", t.Prefix),
-		&helpers.TimeoutConfig{Timeout: 100})
+		&helpers.TimeoutConfig{Timeout: 100 * time.Second})
 	if err != nil {
 		return nil, err
 	}

--- a/test/k8sT/manifests/invalid_cnp.yaml
+++ b/test/k8sT/manifests/invalid_cnp.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: foo
+  namespace: default
+specs:
+- endpointSelector:
+    matchLabels:
+      any:id: foo
+  ingress:
+  - fromEndpoints:
+    - {}
+    toPorts:
+    - ports:
+      - port: "80"
+        protocol: UDP
+      rules:
+        http:
+        - method: GET
+          path: /private


### PR DESCRIPTION
Read per commit: 

1) Fix for old Kubernetes versions, make sure that always return a ParseError.
2) Fix a timeout on Nightly, that makes thing a bit difficult to debug. 
3) Add a e2e test to validate that everything works as expected in all kubernetes versions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7595)
<!-- Reviewable:end -->
