### PR TITLE
endpoint: add optional way of propagating context.Context into regeneration

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -279,7 +279,7 @@ func (d *Daemon) QueueEndpointBuild(epID uint64) func() {
 	}
 
 	// Acquire succeeded, but the context was canceled after?
-	if ctx.Err() == context.Canceled {
+	if ctx.Err() != nil {
 		d.buildEndpointSem.Release(1)
 		return nil
 	}

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -66,7 +67,7 @@ type DaemonSuite struct {
 	OnRemoveProxyRedirect     func(e *e.Endpoint, id string, proxyWaitGroup *completion.WaitGroup) (error, revert.FinalizeFunc, revert.RevertFunc)
 	OnUpdateNetworkPolicy     func(e *e.Endpoint, policy *policy.L4Policy, labelsMap, deniedIngressIdentities, deniedEgressIdentities cache.IdentityCache, proxyWaitGroup *completion.WaitGroup) (error, revert.RevertFunc)
 	OnRemoveNetworkPolicy     func(e *e.Endpoint)
-	OnQueueEndpointBuild      func(epID uint64) func()
+	OnQueueEndpointBuild      func(ctx context.Context, epID uint64) (func(), error)
 	OnRemoveFromEndpointQueue func(epID uint64)
 	OnDebugEnabled            func() bool
 	OnGetCompilationLock      func() *lock.RWMutex
@@ -237,9 +238,9 @@ func (ds *DaemonSuite) RemoveNetworkPolicy(e *e.Endpoint) {
 	panic("RemoveNetworkPolicy should not have been called")
 }
 
-func (ds *DaemonSuite) QueueEndpointBuild(epID uint64) func() {
+func (ds *DaemonSuite) QueueEndpointBuild(ctx context.Context, epID uint64) (func(), error) {
 	if ds.OnQueueEndpointBuild != nil {
-		return ds.OnQueueEndpointBuild(epID)
+		return ds.OnQueueEndpointBuild(ctx, epID)
 	}
 	panic("QueueEndpointBuild should not have been called")
 }

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -267,7 +267,8 @@ func (d *Daemon) createEndpoint(ctx context.Context, epTemplate *models.Endpoint
 		// proxy configuration, this code would effectively deadlock addition
 		// of endpoints.
 		ep.Regenerate(d, &endpoint.ExternalRegenerationMetadata{
-			Reason: "Initial build on endpoint creation",
+			Reason:        "Initial build on endpoint creation",
+			ParentContext: ctx,
 		})
 	}
 

--- a/daemon/state_test.go
+++ b/daemon/state_test.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"context"
 	"encoding/binary"
 	"fmt"
 	"io/ioutil"
@@ -108,14 +109,15 @@ func (ds *DaemonSuite) generateEPs(baseDir string, epsWanted []*e.Endpoint, epsM
 		}
 	}()
 
-	ds.OnQueueEndpointBuild = func(epID uint64) func() {
+	ds.OnQueueEndpointBuild = func(ctx context.Context, epID uint64) (func(), error) {
 		builders++
 		var once sync.Once
-		return func() {
+		doneFunc := func() {
 			once.Do(func() {
 				builders--
 			})
 		}
+		return doneFunc, nil
 	}
 
 	ds.OnTracingEnabled = func() bool {

--- a/pkg/command/exec/exec.go
+++ b/pkg/command/exec/exec.go
@@ -30,9 +30,9 @@ import (
 // options and logging errors, with an optional set of filtered outputs.
 func combinedOutput(ctx context.Context, cmd *exec.Cmd, filters []string, scopedLog *logrus.Entry, verbose bool) ([]byte, error) {
 	out, err := cmd.CombinedOutput()
-	if ctx.Err() == context.DeadlineExceeded {
-		scopedLog.WithField("cmd", cmd.Args).Error("Command execution failed: Timeout")
-		return nil, fmt.Errorf("Command execution failed: Timeout for %s", cmd.Args)
+	if ctx.Err() != nil {
+		scopedLog.WithError(err).WithField("cmd", cmd.Args).Error("Command execution failed")
+		return nil, fmt.Errorf("Command execution failed for %s: %s", cmd.Args, ctx.Err())
 	}
 	if err != nil {
 		if verbose {

--- a/pkg/datapath/loader/compile.go
+++ b/pkg/datapath/loader/compile.go
@@ -268,7 +268,12 @@ func compileDatapath(ctx context.Context, ep endpoint, dirs *directoryInfo, debu
 					logfields.Params: logfields.Repr(p),
 					logfields.Debug:  debug,
 				})
-				scopedLog.WithError(err).Debug("JoinEP: Failed to compile")
+				// Only log an error here if the context was not canceled or not
+				// timed out; this log message should only represent failures
+				// with respect to compiling the program.
+				if ctx.Err() == nil {
+					scopedLog.WithError(err).Debug("JoinEP: Failed to compile")
+				}
 				return err
 			}
 		}
@@ -280,7 +285,12 @@ func compileDatapath(ctx context.Context, ep endpoint, dirs *directoryInfo, debu
 			logfields.Params: logfields.Repr(datapathProg),
 			logfields.Debug:  false,
 		})
-		scopedLog.WithError(err).Warn("JoinEP: Failed to compile")
+		// Only log an error here if the context was not canceled or not timed
+		// out; this log message should only represent failures with respect to
+		// compiling the program.
+		if ctx.Err() == nil {
+			scopedLog.WithError(err).Warn("JoinEP: Failed to compile")
+		}
 		return err
 	}
 

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -57,7 +57,12 @@ func reloadDatapath(ctx context.Context, ep endpoint, dirs *directoryInfo) error
 			scopedLog := ep.Logger(Subsystem).WithFields(logrus.Fields{
 				logfields.Path: objPath,
 			})
-			scopedLog.WithError(err).Warn("JoinEP: Failed to load program")
+			// Don't log an error here if the context was canceled or timed out;
+			// this log message should only represent failures with respect to
+			// loading the program.
+			if ctx.Err() == nil {
+				scopedLog.WithError(err).Warn("JoinEP: Failed to load program")
+			}
 			return err
 		}
 	} else {
@@ -66,7 +71,12 @@ func reloadDatapath(ctx context.Context, ep endpoint, dirs *directoryInfo) error
 				logfields.Path: objPath,
 				logfields.Veth: ep.InterfaceName(),
 			})
-			scopedLog.WithError(err).Warn("JoinEP: Failed to load program")
+			// Don't log an error here if the context was canceled or timed out;
+			// this log message should only represent failures with respect to
+			// loading the program.
+			if ctx.Err() == nil {
+				scopedLog.WithError(err).Warn("JoinEP: Failed to load program")
+			}
 			return err
 		}
 	}

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -380,7 +380,7 @@ func (e *Endpoint) regenerateBPF(owner Owner, regenContext *regenerationContext)
 	stats.waitingForLock.End(true)
 	defer owner.GetCompilationLock().RUnlock()
 
-	datapathRegenCtxt.prepareForProxyUpdates()
+	datapathRegenCtxt.prepareForProxyUpdates(regenContext.parentContext)
 	defer datapathRegenCtxt.completionCancel()
 
 	err = e.runPreCompilationSteps(owner, regenContext)

--- a/pkg/endpoint/owner.go
+++ b/pkg/endpoint/owner.go
@@ -15,6 +15,7 @@
 package endpoint
 
 import (
+	"context"
 	"sync"
 
 	"github.com/cilium/cilium/pkg/completion"
@@ -48,7 +49,7 @@ type Owner interface {
 	RemoveNetworkPolicy(e *Endpoint)
 
 	// QueueEndpointBuild puts the given endpoint in the processing queue
-	QueueEndpointBuild(epID uint64) func()
+	QueueEndpointBuild(ctx context.Context, epID uint64) (func(), error)
 
 	// RemoveFromEndpointQueue removes an endpoint from the working queue
 	RemoveFromEndpointQueue(epID uint64)

--- a/pkg/endpoint/regenerationcontext.go
+++ b/pkg/endpoint/regenerationcontext.go
@@ -119,9 +119,8 @@ type datapathRegenerationContext struct {
 	revertStack  revert.RevertStack
 }
 
-func (ctx *datapathRegenerationContext) prepareForProxyUpdates() {
-	// Set up a context to wait for proxy completions.
-	completionCtx, completionCancel := context.WithTimeout(context.Background(), EndpointGenerationTimeout)
+func (ctx *datapathRegenerationContext) prepareForProxyUpdates(parentCtx context.Context) {
+	completionCtx, completionCancel := context.WithTimeout(parentCtx, EndpointGenerationTimeout)
 	ctx.proxyWaitGroup = completion.NewWaitGroup(completionCtx)
 	ctx.completionCtx = completionCtx
 	ctx.completionCancel = completionCancel

--- a/pkg/endpoint/regenerationcontext.go
+++ b/pkg/endpoint/regenerationcontext.go
@@ -52,13 +52,16 @@ func (r DatapathRegenerationLevel) String() string {
 	return "BUG: Unknown DatapathRegenerationLevel"
 }
 
-func (e *ExternalRegenerationMetadata) toRegenerationContext() *regenerationContext {
+func (e *ExternalRegenerationMetadata) toRegenerationContext(ctx context.Context, c context.CancelFunc) *regenerationContext {
+
 	return &regenerationContext{
 		Reason: e.Reason,
 		datapathRegenerationContext: &datapathRegenerationContext{
 			regenerationLevel: e.RegenerationLevel,
 			ctCleaned:         make(chan struct{}),
 		},
+		parentContext: ctx,
+		cancelFunc:    c,
 	}
 }
 
@@ -72,6 +75,8 @@ type ExternalRegenerationMetadata struct {
 	// RegenerationLevel forces datapath regeneration according to the
 	// levels defined in the DatapathRegenerationLevel description.
 	RegenerationLevel DatapathRegenerationLevel
+
+	ParentContext context.Context
 }
 
 // RegenerationContext provides context to regenerate() calls to determine
@@ -91,6 +96,10 @@ type regenerationContext struct {
 	DoneFunc func()
 
 	datapathRegenerationContext *datapathRegenerationContext
+
+	parentContext context.Context
+
+	cancelFunc context.CancelFunc
 }
 
 // datapathRegenerationContext contains information related to regenerating the


### PR DESCRIPTION
All API calls made to the cilium-agent from clients are passed a `context.Context`, which is canceled whenever an API request times out.

When the Cilium CNI plugin is invoked, it performs an API call to the cilium-agent after creating the network device, links, etc. for the pod. This request goes into the `createEndpoint` function. This function initializes an endpoint with the information provided in the API request, and regenerates the endpoint. This includes compiling the program for the endpoint, and interacting with the network device, links, etc. for the pod. If this API request times out, the Cilium CNI plugin will immediately delete the endpoint and all associated network devices, links, etc. for the pod. 

Before this change, the cilium-agent did not stop regeneration if the API request timed out. As a result, the CNI plugin would delete the interfaces for the pod / endpoint while the regeneration was still ongoing. This would cause the datapath / loader interactions to fail for the endpoint, as the devices would no longer exist. This has caused a strain on our CI, as when such interactions with the datapath fail, the datapath packges log an error with the string `JoinEP`, which is searched for in the logs, and fails the CI if found ( https://github.com/cilium/cilium/issues/7513 ). 

To avoid such problems, Cilium needs to be able to know when the context passed in via the API request was canceled. This PR enhances the endpoint regeneration framework to be able to contain a context passed down in the regeneration request types. This context is only populated with the context provided to `createEndpoint` at this time. This context is used as a parent context for the proxy configuration Completion context, as well as the context passed due to the datapath / loader packages. If the context is canceled, we will return the error that the context itself was canceled instead of having `JoinEP` errors in the logs, which will fail the CI. The endpoint regeneration will then fail. This is OK, because it is assumed that the endpoint will be deleted if the context associated with `createEndpoint` is canceled. 

Another nice part of adding context to the endpoint regeneration request, is that this can be passed into the function which acquires the build semaphore for regenerations. If the context is canceled, the semaphore acquisition will be stopped as well. 

Fixes: #7513 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7600)
<!-- Reviewable:end -->
