### PR TITLE
Optimize kvstore interactions using transactions

### DIFF
--- a/pkg/ipcache/kvstore.go
+++ b/pkg/ipcache/kvstore.go
@@ -71,7 +71,7 @@ type kvstoreImplementation struct{}
 // upsert places the mapping of {key, value} into the kvstore, optionally with
 // a lease.
 func (k kvstoreImplementation) upsert(ctx context.Context, key string, value []byte, lease bool) error {
-	return kvstore.Update(ctx, key, value, lease)
+	return kvstore.UpdateIfDifferent(ctx, key, value, lease)
 }
 
 // release removes the specified key from the kvstore.

--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -403,7 +403,7 @@ func (a *Allocator) createValueNodeKey(ctx context.Context, key string, newID id
 	// add a new key /value/<key>/<node> to account for the reference
 	// The key is protected with a TTL/lease and will expire after LeaseTTL
 	valueKey := path.Join(a.valuePrefix, key, a.suffix)
-	if err := kvstore.Update(ctx, valueKey, []byte(newID.String()), true); err != nil {
+	if err := kvstore.UpdateIfDifferent(ctx, valueKey, []byte(newID.String()), true); err != nil {
 		return fmt.Errorf("unable to create value-node key '%s': %s", valueKey, err)
 	}
 
@@ -712,11 +712,20 @@ func (a *Allocator) RunGC() error {
 }
 
 func (a *Allocator) recreateMasterKey(id idpool.ID, value string, reliablyMissing bool) {
-	keyPath := path.Join(a.idPrefix, id.String())
+	var (
+		err      error
+		success  bool
+		keyPath  = path.Join(a.idPrefix, id.String())
+		valueKey = path.Join(a.valuePrefix, value, a.suffix)
+	)
 
 	// Use of CreateOnly() ensures that any existing potentially
 	// conflicting key is never overwritten.
-	success, err := kvstore.CreateOnly(context.TODO(), keyPath, []byte(value), false)
+	if reliablyMissing {
+		success, err = kvstore.CreateOnly(context.TODO(), keyPath, []byte(value), false)
+	} else {
+		err = kvstore.UpdateIfDifferent(context.TODO(), keyPath, []byte(value), false)
+	}
 	switch {
 	case err != nil:
 		log.WithError(err).WithField(fieldKey, keyPath).Warning("Unable to re-create missing master key")
@@ -727,8 +736,12 @@ func (a *Allocator) recreateMasterKey(id idpool.ID, value string, reliablyMissin
 	// Also re-create the slave key in case it has been deleted. This will
 	// ensure that the next garbage collection cycle of any participating
 	// node does not remove the master key again.
-	valueKey := path.Join(a.valuePrefix, value, a.suffix)
-	success, err = kvstore.CreateOnly(context.TODO(), valueKey, []byte(id.String()), true)
+	success = true
+	if reliablyMissing {
+		success, err = kvstore.CreateOnly(context.TODO(), valueKey, []byte(id.String()), true)
+	} else {
+		err = kvstore.UpdateIfDifferent(context.TODO(), valueKey, []byte(id.String()), true)
+	}
 	switch {
 	case err != nil:
 		log.WithError(err).WithField(fieldKey, valueKey).Warning("Unable to re-create missing slave key")

--- a/pkg/kvstore/backend.go
+++ b/pkg/kvstore/backend.go
@@ -163,6 +163,10 @@ type BackendOperations interface {
 	// Update atomically creates a key or fails if it already exists
 	Update(ctx context.Context, key string, value []byte, lease bool) error
 
+	// UpdateIfDifferent atomically updates a key but only if the value is
+	// different
+	UpdateIfDifferent(ctx context.Context, key string, value []byte, lease bool) error
+
 	// CreateOnly atomically creates a key or fails if it already exists
 	CreateOnly(ctx context.Context, key string, value []byte, lease bool) (bool, error)
 

--- a/pkg/kvstore/consul.go
+++ b/pkg/kvstore/consul.go
@@ -15,6 +15,7 @@
 package kvstore
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"errors"
@@ -471,6 +472,19 @@ func (c *consulClient) Update(ctx context.Context, key string, value []byte, lea
 	_, err := c.KV().Put(k, opts.WithContext(ctx))
 	increaseMetric(key, metricSet, "Update", duration.EndError(err).Total(), err)
 	return err
+}
+
+func (c *consulClient) UpdateIfDifferent(ctx context.Context, key string, value []byte, lease bool) error {
+	existingValue, err := c.Get(key)
+	// On error, attempt update blindly
+	if err == nil {
+		// Value already exists, do not update
+		if bytes.Equal(existingValue, value) {
+			return nil
+		}
+	}
+
+	return c.Update(ctx, key, value, lease)
 }
 
 // CreateOnly creates a key with the value and will fail if the key already exists

--- a/pkg/kvstore/kvstore.go
+++ b/pkg/kvstore/kvstore.go
@@ -76,6 +76,14 @@ func Update(ctx context.Context, key string, value []byte, lease bool) error {
 	return err
 }
 
+// UpdateIfDifferent atomically updates a key but only if the value is
+// different
+func UpdateIfDifferent(ctx context.Context, key string, value []byte, lease bool) error {
+	err := Client().UpdateIfDifferent(ctx, key, value, lease)
+	Trace("Update", err, logrus.Fields{fieldKey: key, fieldValue: string(value), fieldAttachLease: lease})
+	return err
+}
+
 // CreateIfExists creates a key with the value only if key condKey exists
 func CreateIfExists(condKey, key string, value []byte, lease bool) error {
 	err := Client().CreateIfExists(condKey, key, value, lease)

--- a/pkg/kvstore/store/store.go
+++ b/pkg/kvstore/store/store.go
@@ -264,7 +264,7 @@ func (s *SharedStore) syncLocalKey(key LocalKey) error {
 
 	// Update key in kvstore, overwrite an eventual existing key, attach
 	// lease to expire entry when agent dies and never comes back up.
-	if err := s.backend.Update(context.TODO(), s.keyPath(key), jsonValue, true); err != nil {
+	if err := s.backend.UpdateIfDifferent(context.TODO(), s.keyPath(key), jsonValue, true); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This is a version of #7580 using etcd transactions.

Several regular synchronization routines ensuring resiliency had a side-effect of causing unnecessary kvstore events which can result in significant load in large-scale clusters. Optimize interactions to keep the resilience property while minimizing the resulting events.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7607)
<!-- Reviewable:end -->
