### PR TITLE
Add bpf mount check to Cilium init container

### DIFF
--- a/contrib/packaging/docker/init-container.sh
+++ b/contrib/packaging/docker/init-container.sh
@@ -10,3 +10,6 @@ if [ "${CLEAN_CILIUM_STATE}" = "true" ] \
     rm -rf /sys/fs/bpf/tc/globals/cilium_* \
            /var/run/cilium/bpffs/tc/globals/cilium_*;
 fi
+if [ "${CILIUM_WAIT_BPF_MOUNT}" = "true" ]; then
+	until mount | grep bpf; do echo "BPF filesystem is not mounted yet"; sleep 1; done
+fi;

--- a/examples/kubernetes/1.10/cilium-cm.yaml
+++ b/examples/kubernetes/1.10/cilium-cm.yaml
@@ -148,3 +148,6 @@ data:
   # [0] http://docs.cilium.io/en/stable/policy/language/#dns-based
   # [1] http://docs.cilium.io/en/stable/install/upgrade/#changes-that-may-require-action
   tofqdns-enable-poller: "false"
+
+  # wait-bpf-mount makes init container wait until bpf filesystem is mounted
+  wait-bpf-mount: "false"

--- a/examples/kubernetes/1.10/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-containerd-ds.yaml
@@ -159,7 +159,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.10/cilium-containerd.yaml
+++ b/examples/kubernetes/1.10/cilium-containerd.yaml
@@ -148,6 +148,9 @@ data:
   # [0] http://docs.cilium.io/en/stable/policy/language/#dns-based
   # [1] http://docs.cilium.io/en/stable/install/upgrade/#changes-that-may-require-action
   tofqdns-enable-poller: "false"
+
+  # wait-bpf-mount makes init container wait until bpf filesystem is mounted
+  wait-bpf-mount: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/examples/kubernetes/1.10/cilium-containerd.yaml
+++ b/examples/kubernetes/1.10/cilium-containerd.yaml
@@ -312,7 +312,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.10/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-crio-ds.yaml
@@ -167,7 +167,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -320,7 +320,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -148,6 +148,9 @@ data:
   # [0] http://docs.cilium.io/en/stable/policy/language/#dns-based
   # [1] http://docs.cilium.io/en/stable/install/upgrade/#changes-that-may-require-action
   tofqdns-enable-poller: "false"
+
+  # wait-bpf-mount makes init container wait until bpf filesystem is mounted
+  wait-bpf-mount: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/examples/kubernetes/1.10/cilium-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-ds.yaml
@@ -166,6 +166,12 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium-init:2018-10-16
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state

--- a/examples/kubernetes/1.10/cilium-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-ds.yaml
@@ -172,7 +172,7 @@ spec:
               key: wait-bpf-mount
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.10/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.10/cilium-external-etcd.yaml
@@ -148,6 +148,9 @@ data:
   # [0] http://docs.cilium.io/en/stable/policy/language/#dns-based
   # [1] http://docs.cilium.io/en/stable/install/upgrade/#changes-that-may-require-action
   tofqdns-enable-poller: "false"
+
+  # wait-bpf-mount makes init container wait until bpf filesystem is mounted
+  wait-bpf-mount: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -314,6 +317,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:2018-10-16

--- a/examples/kubernetes/1.10/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.10/cilium-external-etcd.yaml
@@ -325,7 +325,7 @@ spec:
               key: wait-bpf-mount
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.10/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-minikube-ds.yaml
@@ -166,7 +166,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.10/cilium-minikube.yaml
+++ b/examples/kubernetes/1.10/cilium-minikube.yaml
@@ -319,7 +319,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.10/cilium-minikube.yaml
+++ b/examples/kubernetes/1.10/cilium-minikube.yaml
@@ -148,6 +148,9 @@ data:
   # [0] http://docs.cilium.io/en/stable/policy/language/#dns-based
   # [1] http://docs.cilium.io/en/stable/install/upgrade/#changes-that-may-require-action
   tofqdns-enable-poller: "false"
+
+  # wait-bpf-mount makes init container wait until bpf filesystem is mounted
+  wait-bpf-mount: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/examples/kubernetes/1.10/cilium-pre-flight.yaml
+++ b/examples/kubernetes/1.10/cilium-pre-flight.yaml
@@ -27,7 +27,7 @@ spec:
             topologyKey: "kubernetes.io/hostname"
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-16
+          image: docker.io/cilium/cilium-init:2019-04-05
           imagePullPolicy: IfNotPresent
           command: ["/bin/echo"]
           args:

--- a/examples/kubernetes/1.10/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.10/cilium-with-node-init.yaml
@@ -148,6 +148,9 @@ data:
   # [0] http://docs.cilium.io/en/stable/policy/language/#dns-based
   # [1] http://docs.cilium.io/en/stable/install/upgrade/#changes-that-may-require-action
   tofqdns-enable-poller: "false"
+
+  # wait-bpf-mount makes init container wait until bpf filesystem is mounted
+  wait-bpf-mount: "true"
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -314,6 +317,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:2018-10-16

--- a/examples/kubernetes/1.10/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.10/cilium-with-node-init.yaml
@@ -325,7 +325,7 @@ spec:
               key: wait-bpf-mount
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -148,6 +148,9 @@ data:
   # [0] http://docs.cilium.io/en/stable/policy/language/#dns-based
   # [1] http://docs.cilium.io/en/stable/install/upgrade/#changes-that-may-require-action
   tofqdns-enable-poller: "false"
+
+  # wait-bpf-mount makes init container wait until bpf filesystem is mounted
+  wait-bpf-mount: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -314,6 +317,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:2018-10-16

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -325,7 +325,7 @@ spec:
               key: wait-bpf-mount
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.11/cilium-cm.yaml
+++ b/examples/kubernetes/1.11/cilium-cm.yaml
@@ -148,3 +148,6 @@ data:
   # [0] http://docs.cilium.io/en/stable/policy/language/#dns-based
   # [1] http://docs.cilium.io/en/stable/install/upgrade/#changes-that-may-require-action
   tofqdns-enable-poller: "false"
+
+  # wait-bpf-mount makes init container wait until bpf filesystem is mounted
+  wait-bpf-mount: "false"

--- a/examples/kubernetes/1.11/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-containerd-ds.yaml
@@ -159,7 +159,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.11/cilium-containerd.yaml
+++ b/examples/kubernetes/1.11/cilium-containerd.yaml
@@ -148,6 +148,9 @@ data:
   # [0] http://docs.cilium.io/en/stable/policy/language/#dns-based
   # [1] http://docs.cilium.io/en/stable/install/upgrade/#changes-that-may-require-action
   tofqdns-enable-poller: "false"
+
+  # wait-bpf-mount makes init container wait until bpf filesystem is mounted
+  wait-bpf-mount: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/examples/kubernetes/1.11/cilium-containerd.yaml
+++ b/examples/kubernetes/1.11/cilium-containerd.yaml
@@ -312,7 +312,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.11/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-crio-ds.yaml
@@ -165,7 +165,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -318,7 +318,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -148,6 +148,9 @@ data:
   # [0] http://docs.cilium.io/en/stable/policy/language/#dns-based
   # [1] http://docs.cilium.io/en/stable/install/upgrade/#changes-that-may-require-action
   tofqdns-enable-poller: "false"
+
+  # wait-bpf-mount makes init container wait until bpf filesystem is mounted
+  wait-bpf-mount: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -166,6 +166,12 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium-init:2018-10-16
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -172,7 +172,7 @@ spec:
               key: wait-bpf-mount
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.11/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.11/cilium-external-etcd.yaml
@@ -148,6 +148,9 @@ data:
   # [0] http://docs.cilium.io/en/stable/policy/language/#dns-based
   # [1] http://docs.cilium.io/en/stable/install/upgrade/#changes-that-may-require-action
   tofqdns-enable-poller: "false"
+
+  # wait-bpf-mount makes init container wait until bpf filesystem is mounted
+  wait-bpf-mount: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -314,6 +317,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:2018-10-16

--- a/examples/kubernetes/1.11/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.11/cilium-external-etcd.yaml
@@ -325,7 +325,7 @@ spec:
               key: wait-bpf-mount
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.11/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-minikube-ds.yaml
@@ -166,7 +166,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.11/cilium-minikube.yaml
+++ b/examples/kubernetes/1.11/cilium-minikube.yaml
@@ -319,7 +319,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.11/cilium-minikube.yaml
+++ b/examples/kubernetes/1.11/cilium-minikube.yaml
@@ -148,6 +148,9 @@ data:
   # [0] http://docs.cilium.io/en/stable/policy/language/#dns-based
   # [1] http://docs.cilium.io/en/stable/install/upgrade/#changes-that-may-require-action
   tofqdns-enable-poller: "false"
+
+  # wait-bpf-mount makes init container wait until bpf filesystem is mounted
+  wait-bpf-mount: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/examples/kubernetes/1.11/cilium-pre-flight.yaml
+++ b/examples/kubernetes/1.11/cilium-pre-flight.yaml
@@ -27,7 +27,7 @@ spec:
             topologyKey: "kubernetes.io/hostname"
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-16
+          image: docker.io/cilium/cilium-init:2019-04-05
           imagePullPolicy: IfNotPresent
           command: ["/bin/echo"]
           args:

--- a/examples/kubernetes/1.11/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.11/cilium-with-node-init.yaml
@@ -148,6 +148,9 @@ data:
   # [0] http://docs.cilium.io/en/stable/policy/language/#dns-based
   # [1] http://docs.cilium.io/en/stable/install/upgrade/#changes-that-may-require-action
   tofqdns-enable-poller: "false"
+
+  # wait-bpf-mount makes init container wait until bpf filesystem is mounted
+  wait-bpf-mount: "true"
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -314,6 +317,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:2018-10-16

--- a/examples/kubernetes/1.11/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.11/cilium-with-node-init.yaml
@@ -325,7 +325,7 @@ spec:
               key: wait-bpf-mount
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -148,6 +148,9 @@ data:
   # [0] http://docs.cilium.io/en/stable/policy/language/#dns-based
   # [1] http://docs.cilium.io/en/stable/install/upgrade/#changes-that-may-require-action
   tofqdns-enable-poller: "false"
+
+  # wait-bpf-mount makes init container wait until bpf filesystem is mounted
+  wait-bpf-mount: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -314,6 +317,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:2018-10-16

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -325,7 +325,7 @@ spec:
               key: wait-bpf-mount
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.12/cilium-cm.yaml
+++ b/examples/kubernetes/1.12/cilium-cm.yaml
@@ -148,3 +148,6 @@ data:
   # [0] http://docs.cilium.io/en/stable/policy/language/#dns-based
   # [1] http://docs.cilium.io/en/stable/install/upgrade/#changes-that-may-require-action
   tofqdns-enable-poller: "false"
+
+  # wait-bpf-mount makes init container wait until bpf filesystem is mounted
+  wait-bpf-mount: "false"

--- a/examples/kubernetes/1.12/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-containerd-ds.yaml
@@ -159,7 +159,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.12/cilium-containerd.yaml
+++ b/examples/kubernetes/1.12/cilium-containerd.yaml
@@ -148,6 +148,9 @@ data:
   # [0] http://docs.cilium.io/en/stable/policy/language/#dns-based
   # [1] http://docs.cilium.io/en/stable/install/upgrade/#changes-that-may-require-action
   tofqdns-enable-poller: "false"
+
+  # wait-bpf-mount makes init container wait until bpf filesystem is mounted
+  wait-bpf-mount: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/examples/kubernetes/1.12/cilium-containerd.yaml
+++ b/examples/kubernetes/1.12/cilium-containerd.yaml
@@ -312,7 +312,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.12/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-crio-ds.yaml
@@ -165,7 +165,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -318,7 +318,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -148,6 +148,9 @@ data:
   # [0] http://docs.cilium.io/en/stable/policy/language/#dns-based
   # [1] http://docs.cilium.io/en/stable/install/upgrade/#changes-that-may-require-action
   tofqdns-enable-poller: "false"
+
+  # wait-bpf-mount makes init container wait until bpf filesystem is mounted
+  wait-bpf-mount: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/examples/kubernetes/1.12/cilium-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-ds.yaml
@@ -166,6 +166,12 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium-init:2018-10-16
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state

--- a/examples/kubernetes/1.12/cilium-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-ds.yaml
@@ -172,7 +172,7 @@ spec:
               key: wait-bpf-mount
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.12/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.12/cilium-external-etcd.yaml
@@ -148,6 +148,9 @@ data:
   # [0] http://docs.cilium.io/en/stable/policy/language/#dns-based
   # [1] http://docs.cilium.io/en/stable/install/upgrade/#changes-that-may-require-action
   tofqdns-enable-poller: "false"
+
+  # wait-bpf-mount makes init container wait until bpf filesystem is mounted
+  wait-bpf-mount: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -314,6 +317,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:2018-10-16

--- a/examples/kubernetes/1.12/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.12/cilium-external-etcd.yaml
@@ -325,7 +325,7 @@ spec:
               key: wait-bpf-mount
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.12/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-minikube-ds.yaml
@@ -166,7 +166,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.12/cilium-minikube.yaml
+++ b/examples/kubernetes/1.12/cilium-minikube.yaml
@@ -319,7 +319,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.12/cilium-minikube.yaml
+++ b/examples/kubernetes/1.12/cilium-minikube.yaml
@@ -148,6 +148,9 @@ data:
   # [0] http://docs.cilium.io/en/stable/policy/language/#dns-based
   # [1] http://docs.cilium.io/en/stable/install/upgrade/#changes-that-may-require-action
   tofqdns-enable-poller: "false"
+
+  # wait-bpf-mount makes init container wait until bpf filesystem is mounted
+  wait-bpf-mount: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/examples/kubernetes/1.12/cilium-pre-flight.yaml
+++ b/examples/kubernetes/1.12/cilium-pre-flight.yaml
@@ -27,7 +27,7 @@ spec:
             topologyKey: "kubernetes.io/hostname"
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-16
+          image: docker.io/cilium/cilium-init:2019-04-05
           imagePullPolicy: IfNotPresent
           command: ["/bin/echo"]
           args:

--- a/examples/kubernetes/1.12/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.12/cilium-with-node-init.yaml
@@ -148,6 +148,9 @@ data:
   # [0] http://docs.cilium.io/en/stable/policy/language/#dns-based
   # [1] http://docs.cilium.io/en/stable/install/upgrade/#changes-that-may-require-action
   tofqdns-enable-poller: "false"
+
+  # wait-bpf-mount makes init container wait until bpf filesystem is mounted
+  wait-bpf-mount: "true"
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -314,6 +317,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:2018-10-16

--- a/examples/kubernetes/1.12/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.12/cilium-with-node-init.yaml
@@ -325,7 +325,7 @@ spec:
               key: wait-bpf-mount
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -148,6 +148,9 @@ data:
   # [0] http://docs.cilium.io/en/stable/policy/language/#dns-based
   # [1] http://docs.cilium.io/en/stable/install/upgrade/#changes-that-may-require-action
   tofqdns-enable-poller: "false"
+
+  # wait-bpf-mount makes init container wait until bpf filesystem is mounted
+  wait-bpf-mount: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -314,6 +317,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:2018-10-16

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -325,7 +325,7 @@ spec:
               key: wait-bpf-mount
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.13/cilium-cm.yaml
+++ b/examples/kubernetes/1.13/cilium-cm.yaml
@@ -148,3 +148,6 @@ data:
   # [0] http://docs.cilium.io/en/stable/policy/language/#dns-based
   # [1] http://docs.cilium.io/en/stable/install/upgrade/#changes-that-may-require-action
   tofqdns-enable-poller: "false"
+
+  # wait-bpf-mount makes init container wait until bpf filesystem is mounted
+  wait-bpf-mount: "false"

--- a/examples/kubernetes/1.13/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-containerd-ds.yaml
@@ -159,7 +159,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.13/cilium-containerd.yaml
+++ b/examples/kubernetes/1.13/cilium-containerd.yaml
@@ -148,6 +148,9 @@ data:
   # [0] http://docs.cilium.io/en/stable/policy/language/#dns-based
   # [1] http://docs.cilium.io/en/stable/install/upgrade/#changes-that-may-require-action
   tofqdns-enable-poller: "false"
+
+  # wait-bpf-mount makes init container wait until bpf filesystem is mounted
+  wait-bpf-mount: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/examples/kubernetes/1.13/cilium-containerd.yaml
+++ b/examples/kubernetes/1.13/cilium-containerd.yaml
@@ -312,7 +312,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.13/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-crio-ds.yaml
@@ -165,7 +165,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.13/cilium-crio.yaml
+++ b/examples/kubernetes/1.13/cilium-crio.yaml
@@ -318,7 +318,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.13/cilium-crio.yaml
+++ b/examples/kubernetes/1.13/cilium-crio.yaml
@@ -148,6 +148,9 @@ data:
   # [0] http://docs.cilium.io/en/stable/policy/language/#dns-based
   # [1] http://docs.cilium.io/en/stable/install/upgrade/#changes-that-may-require-action
   tofqdns-enable-poller: "false"
+
+  # wait-bpf-mount makes init container wait until bpf filesystem is mounted
+  wait-bpf-mount: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/examples/kubernetes/1.13/cilium-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-ds.yaml
@@ -166,6 +166,12 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium-init:2018-10-16
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state

--- a/examples/kubernetes/1.13/cilium-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-ds.yaml
@@ -172,7 +172,7 @@ spec:
               key: wait-bpf-mount
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.13/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.13/cilium-external-etcd.yaml
@@ -148,6 +148,9 @@ data:
   # [0] http://docs.cilium.io/en/stable/policy/language/#dns-based
   # [1] http://docs.cilium.io/en/stable/install/upgrade/#changes-that-may-require-action
   tofqdns-enable-poller: "false"
+
+  # wait-bpf-mount makes init container wait until bpf filesystem is mounted
+  wait-bpf-mount: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -314,6 +317,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:2018-10-16

--- a/examples/kubernetes/1.13/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.13/cilium-external-etcd.yaml
@@ -325,7 +325,7 @@ spec:
               key: wait-bpf-mount
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.13/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-minikube-ds.yaml
@@ -166,7 +166,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.13/cilium-minikube.yaml
+++ b/examples/kubernetes/1.13/cilium-minikube.yaml
@@ -319,7 +319,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.13/cilium-minikube.yaml
+++ b/examples/kubernetes/1.13/cilium-minikube.yaml
@@ -148,6 +148,9 @@ data:
   # [0] http://docs.cilium.io/en/stable/policy/language/#dns-based
   # [1] http://docs.cilium.io/en/stable/install/upgrade/#changes-that-may-require-action
   tofqdns-enable-poller: "false"
+
+  # wait-bpf-mount makes init container wait until bpf filesystem is mounted
+  wait-bpf-mount: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/examples/kubernetes/1.13/cilium-pre-flight.yaml
+++ b/examples/kubernetes/1.13/cilium-pre-flight.yaml
@@ -27,7 +27,7 @@ spec:
             topologyKey: "kubernetes.io/hostname"
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-16
+          image: docker.io/cilium/cilium-init:2019-04-05
           imagePullPolicy: IfNotPresent
           command: ["/bin/echo"]
           args:

--- a/examples/kubernetes/1.13/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.13/cilium-with-node-init.yaml
@@ -148,6 +148,9 @@ data:
   # [0] http://docs.cilium.io/en/stable/policy/language/#dns-based
   # [1] http://docs.cilium.io/en/stable/install/upgrade/#changes-that-may-require-action
   tofqdns-enable-poller: "false"
+
+  # wait-bpf-mount makes init container wait until bpf filesystem is mounted
+  wait-bpf-mount: "true"
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -314,6 +317,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:2018-10-16

--- a/examples/kubernetes/1.13/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.13/cilium-with-node-init.yaml
@@ -325,7 +325,7 @@ spec:
               key: wait-bpf-mount
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.13/cilium.yaml
+++ b/examples/kubernetes/1.13/cilium.yaml
@@ -148,6 +148,9 @@ data:
   # [0] http://docs.cilium.io/en/stable/policy/language/#dns-based
   # [1] http://docs.cilium.io/en/stable/install/upgrade/#changes-that-may-require-action
   tofqdns-enable-poller: "false"
+
+  # wait-bpf-mount makes init container wait until bpf filesystem is mounted
+  wait-bpf-mount: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -314,6 +317,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:2018-10-16

--- a/examples/kubernetes/1.13/cilium.yaml
+++ b/examples/kubernetes/1.13/cilium.yaml
@@ -325,7 +325,7 @@ spec:
               key: wait-bpf-mount
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.14/cilium-cm.yaml
+++ b/examples/kubernetes/1.14/cilium-cm.yaml
@@ -148,3 +148,6 @@ data:
   # [0] http://docs.cilium.io/en/stable/policy/language/#dns-based
   # [1] http://docs.cilium.io/en/stable/install/upgrade/#changes-that-may-require-action
   tofqdns-enable-poller: "false"
+
+  # wait-bpf-mount makes init container wait until bpf filesystem is mounted
+  wait-bpf-mount: "false"

--- a/examples/kubernetes/1.14/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.14/cilium-containerd-ds.yaml
@@ -159,7 +159,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.14/cilium-containerd.yaml
+++ b/examples/kubernetes/1.14/cilium-containerd.yaml
@@ -148,6 +148,9 @@ data:
   # [0] http://docs.cilium.io/en/stable/policy/language/#dns-based
   # [1] http://docs.cilium.io/en/stable/install/upgrade/#changes-that-may-require-action
   tofqdns-enable-poller: "false"
+
+  # wait-bpf-mount makes init container wait until bpf filesystem is mounted
+  wait-bpf-mount: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/examples/kubernetes/1.14/cilium-containerd.yaml
+++ b/examples/kubernetes/1.14/cilium-containerd.yaml
@@ -312,7 +312,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.14/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.14/cilium-crio-ds.yaml
@@ -165,7 +165,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.14/cilium-crio.yaml
+++ b/examples/kubernetes/1.14/cilium-crio.yaml
@@ -318,7 +318,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.14/cilium-crio.yaml
+++ b/examples/kubernetes/1.14/cilium-crio.yaml
@@ -148,6 +148,9 @@ data:
   # [0] http://docs.cilium.io/en/stable/policy/language/#dns-based
   # [1] http://docs.cilium.io/en/stable/install/upgrade/#changes-that-may-require-action
   tofqdns-enable-poller: "false"
+
+  # wait-bpf-mount makes init container wait until bpf filesystem is mounted
+  wait-bpf-mount: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/examples/kubernetes/1.14/cilium-ds.yaml
+++ b/examples/kubernetes/1.14/cilium-ds.yaml
@@ -166,6 +166,12 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium-init:2018-10-16
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state

--- a/examples/kubernetes/1.14/cilium-ds.yaml
+++ b/examples/kubernetes/1.14/cilium-ds.yaml
@@ -172,7 +172,7 @@ spec:
               key: wait-bpf-mount
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.14/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.14/cilium-external-etcd.yaml
@@ -148,6 +148,9 @@ data:
   # [0] http://docs.cilium.io/en/stable/policy/language/#dns-based
   # [1] http://docs.cilium.io/en/stable/install/upgrade/#changes-that-may-require-action
   tofqdns-enable-poller: "false"
+
+  # wait-bpf-mount makes init container wait until bpf filesystem is mounted
+  wait-bpf-mount: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -314,6 +317,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:2018-10-16

--- a/examples/kubernetes/1.14/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.14/cilium-external-etcd.yaml
@@ -325,7 +325,7 @@ spec:
               key: wait-bpf-mount
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.14/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.14/cilium-minikube-ds.yaml
@@ -166,7 +166,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.14/cilium-minikube.yaml
+++ b/examples/kubernetes/1.14/cilium-minikube.yaml
@@ -319,7 +319,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.14/cilium-minikube.yaml
+++ b/examples/kubernetes/1.14/cilium-minikube.yaml
@@ -148,6 +148,9 @@ data:
   # [0] http://docs.cilium.io/en/stable/policy/language/#dns-based
   # [1] http://docs.cilium.io/en/stable/install/upgrade/#changes-that-may-require-action
   tofqdns-enable-poller: "false"
+
+  # wait-bpf-mount makes init container wait until bpf filesystem is mounted
+  wait-bpf-mount: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/examples/kubernetes/1.14/cilium-pre-flight.yaml
+++ b/examples/kubernetes/1.14/cilium-pre-flight.yaml
@@ -27,7 +27,7 @@ spec:
             topologyKey: "kubernetes.io/hostname"
       initContainers:
         - name: clean-cilium-state
-          image: docker.io/cilium/cilium-init:2018-10-16
+          image: docker.io/cilium/cilium-init:2019-04-05
           imagePullPolicy: IfNotPresent
           command: ["/bin/echo"]
           args:

--- a/examples/kubernetes/1.14/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.14/cilium-with-node-init.yaml
@@ -148,6 +148,9 @@ data:
   # [0] http://docs.cilium.io/en/stable/policy/language/#dns-based
   # [1] http://docs.cilium.io/en/stable/install/upgrade/#changes-that-may-require-action
   tofqdns-enable-poller: "false"
+
+  # wait-bpf-mount makes init container wait until bpf filesystem is mounted
+  wait-bpf-mount: "true"
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -314,6 +317,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:2018-10-16

--- a/examples/kubernetes/1.14/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.14/cilium-with-node-init.yaml
@@ -325,7 +325,7 @@ spec:
               key: wait-bpf-mount
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/1.14/cilium.yaml
+++ b/examples/kubernetes/1.14/cilium.yaml
@@ -148,6 +148,9 @@ data:
   # [0] http://docs.cilium.io/en/stable/policy/language/#dns-based
   # [1] http://docs.cilium.io/en/stable/install/upgrade/#changes-that-may-require-action
   tofqdns-enable-poller: "false"
+
+  # wait-bpf-mount makes init container wait until bpf filesystem is mounted
+  wait-bpf-mount: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -314,6 +317,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:2018-10-16

--- a/examples/kubernetes/1.14/cilium.yaml
+++ b/examples/kubernetes/1.14/cilium.yaml
@@ -325,7 +325,7 @@ spec:
               key: wait-bpf-mount
               name: cilium-config
               optional: true
-        image: docker.io/cilium/cilium-init:2018-10-16
+        image: docker.io/cilium/cilium-init:2019-04-05
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         securityContext:

--- a/examples/kubernetes/Makefile
+++ b/examples/kubernetes/Makefile
@@ -4,7 +4,7 @@ ifeq ($(CILIUM_VERSION),)
     CILIUM_VERSION = "v$(shell cat ../../VERSION)"
 endif
 
-CILIUM_INIT_VERSION = "2018-10-16"
+CILIUM_INIT_VERSION = "2019-04-05"
 CILIUM_ETCD_OPERATOR_VERSION = "v2.0.6"
 K8S_VERSIONS = 1.10 1.11 1.12 1.13 1.14
 
@@ -121,7 +121,8 @@ cilium-with-node-init.yaml:
 	    sed -i 's+namespace: kube-system+namespace: cilium+' cilium-with-node-init.yaml; \
 	    sed -i '/priorityClassName: system-node-critical/d' cilium-with-node-init.yaml; \
 	    sed -i 's+path: /opt/cni/bin+path: /home/kubernetes/bin+' cilium-with-node-init.yaml; \
-	    sed -i 's+https://cilium-etcd-client.kube-system.svc:2379+https://cilium-etcd-client.cilium.svc:2379+' cilium-with-node-init.yaml); \
+	    sed -i 's+https://cilium-etcd-client.kube-system.svc:2379+https://cilium-etcd-client.cilium.svc:2379+' cilium-with-node-init.yaml; \
+        sed -i 's+wait-bpf-mount: "false"+wait-bpf-mount: "true"+' cilium-with-node-init.yaml); \
 	done
 
 cilium-external-etcd.yaml:

--- a/examples/kubernetes/templates/v1/cilium-cm.yaml
+++ b/examples/kubernetes/templates/v1/cilium-cm.yaml
@@ -148,3 +148,6 @@ data:
   # [0] http://docs.cilium.io/en/stable/policy/language/#dns-based
   # [1] http://docs.cilium.io/en/stable/install/upgrade/#changes-that-may-require-action
   tofqdns-enable-poller: "false"
+
+  # wait-bpf-mount makes init container wait until bpf filesystem is mounted
+  wait-bpf-mount: "false"

--- a/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
@@ -166,6 +166,12 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium-init:__CILIUM_INIT_VERSION__
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state


### PR DESCRIPTION
Above check is default for cilium-with-node-init.yaml manifests, but can be enabled on any deployment.

This check will be useful on huge clusters where node-init daemonset is also deployed and Cilium may be scheduled before node-init pod.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7609)
<!-- Reviewable:end -->
