### PR TITLE
daemon: remove host-allows-world option

### DIFF
--- a/Documentation/kubernetes/configuration.rst
+++ b/Documentation/kubernetes/configuration.rst
@@ -26,13 +26,6 @@ accordingly with your changes.
 * ``clean-cilium-state`` - Removes any Cilium state, e.g. BPF policy maps,
   before starting the Cilium agent;
 
-* ``legacy-host-allows-world`` - If true, the policy with the entity
-  ``reserved:host`` allows traffic from ``world``. If false, the policy needs
-  to explicitly have the entity ``reserved:world`` to allow traffic from
-  ``world``. It is recommended to set it to false. This option provides
-  compatibility with Cilium 1.0 which was not able to differentiate between
-  NodePort traffic and traffic from the host.
-
 Any changes that you perform in the Cilium `ConfigMap` and in
 ``cilium-etcd-secrets`` ``Secret`` will require you to restart any existing
 Cilium pods in order for them to pick the latest configuration.
@@ -69,8 +62,6 @@ enabled.
       enable-ipv4: "true"
       # If you want to clean cilium state; change this value to true
       clean-cilium-state: "false"
-      legacy-host-allows-world: "false"
-
 
 CNI
 ===

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1030,17 +1030,6 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 			log.Info("k8s mode: Allowing localhost to reach local endpoints")
 		}
 
-		// In Cilium 1.0, due to limitations on the data path, traffic
-		// from the outside world on ingress was treated as though it
-		// was from the host for policy purposes. In order to not break
-		// existing policies, this option retains the behavior.
-		if option.Config.K8sLegacyHostAllowsWorld == "true" {
-			log.Warn("k8s mode: Configuring ingress policy for host to also allow from world. This option will be removed in Cilium 1.5. For more information, see https://cilium.link/host-vs-world")
-			option.Config.HostAllowsWorld = true
-		} else {
-			option.Config.HostAllowsWorld = false
-		}
-
 		bootstrapStats.k8sInit.End(true)
 	}
 

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -510,10 +510,6 @@ func init() {
 	flags.String(option.K8sKubeConfigPath, "", "Absolute path of the kubernetes kubeconfig file")
 	option.BindEnv(option.K8sKubeConfigPath)
 
-	option.BindEnv(option.K8sLegacyHostAllowsWorld)
-	// This needs to be set manually for backward compatibility
-	viper.BindEnv(option.K8sLegacyHostAllowsWorld, "CILIUM_LEGACY_HOST_ALLOWS_WORLD")
-
 	flags.String(option.K8sNamespaceName, "", "Name of the Kubernetes namespace in which Cilium is deployed in")
 	flags.MarkHidden(option.K8sNamespaceName)
 	option.BindEnv(option.K8sNamespaceName)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -180,9 +180,6 @@ const (
 	// KeepBPFTemplates do not restore BPF template files from binary
 	KeepBPFTemplates = "keep-bpf-templates"
 
-	// K8sLegacyHostAllowsWorld is the legacy option to that allows policy host to talk with world
-	K8sLegacyHostAllowsWorld = "k8s-legacy-host-allows-world"
-
 	// KVStore key-value store type
 	KVStore = "kvstore"
 
@@ -582,10 +579,6 @@ type DaemonConfig struct {
 	// values: { auto | always | policy }
 	AllowLocalhost string
 
-	// HostAllowsWorld applies the same policy to world-sourced traffic as
-	// host-sourced traffic, to provide compatibility with Cilium 1.0.
-	HostAllowsWorld bool
-
 	// StateDir is the directory where runtime state of endpoints is stored
 	StateDir string
 
@@ -753,7 +746,6 @@ type DaemonConfig struct {
 	IPv6ServiceRange              string
 	K8sAPIServer                  string
 	K8sKubeConfigPath             string
-	K8sLegacyHostAllowsWorld      string
 	K8sWatcherEndpointSelector    string
 	KVStore                       string
 	KVStoreOpt                    map[string]string
@@ -1067,7 +1059,6 @@ func ReplaceDeprecatedFields(m map[string]interface{}) {
 		"monitor-aggregation-level":   MonitorAggregationName,
 		"ct-global-max-entries-tcp":   CTMapEntriesGlobalTCPName,
 		"ct-global-max-entries-other": CTMapEntriesGlobalAnyName,
-		"legacy-host-allows-world":    K8sLegacyHostAllowsWorld,
 	}
 	for deprecatedOption, newOption := range deprecatedFields {
 		if deprecatedValue, ok := m[deprecatedOption]; ok {
@@ -1217,7 +1208,6 @@ func (c *DaemonConfig) Populate() {
 	c.HTTP403Message = viper.GetString(HTTP403Message)
 	c.DisableEnvoyVersionCheck = viper.GetBool(DisableEnvoyVersionCheck)
 	c.K8sNamespace = viper.GetString(K8sNamespaceName)
-	c.K8sLegacyHostAllowsWorld = viper.GetString(K8sLegacyHostAllowsWorld)
 	c.MaxControllerInterval = viper.GetInt(MaxCtrlIntervalName)
 	c.SidecarHTTPProxy = viper.GetBool(SidecarHTTPProxy)
 	c.CMDRefDir = viper.GetString(CMDRef)

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -73,22 +73,6 @@ type MapStateEntry struct {
 	ProxyPort uint16
 }
 
-// DetermineAllowFromWorld determines whether world should be allowed to
-// communicate with the endpoint, based on legacy Cilium 1.0 behaviour. It
-// inserts the Key corresponding to the world in the desiredPolicyKeys
-// if the legacy mode is enabled.
-//
-// This must be run after DetermineAllowLocalhost().
-//
-// For more information, see https://cilium.link/host-vs-world
-func (keys MapState) DetermineAllowFromWorld() {
-
-	_, localHostAllowed := keys[localHostKey]
-	if option.Config.HostAllowsWorld && localHostAllowed {
-		keys[worldKey] = MapStateEntry{}
-	}
-}
-
 // DetermineAllowLocalhost determines whether communication should be allowed to
 // the localhost. It inserts the Key corresponding to the localhost in
 // the desiredPolicyKeys if the endpoint is allowed to communicate with the

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -753,7 +753,6 @@ func (p *Repository) ResolvePolicy(id uint16, securityIdentity *identity.Identit
 
 	calculatedPolicy.computeDesiredL4PolicyMapEntries(identityCache)
 	calculatedPolicy.PolicyMapState.DetermineAllowLocalhost(calculatedPolicy.L4Policy)
-	calculatedPolicy.PolicyMapState.DetermineAllowFromWorld()
 
 	return calculatedPolicy, nil
 }

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -212,9 +212,6 @@ func mergeL4Ingress(ctx *SearchContext, rule api.IngressRule, ruleLabels labels.
 	endpointsWithL3Override := []api.EndpointSelector{}
 	if option.Config.AlwaysAllowLocalhost() {
 		endpointsWithL3Override = append(endpointsWithL3Override, api.ReservedEndpointSelectors[labels.IDNameHost])
-		if option.Config.HostAllowsWorld {
-			endpointsWithL3Override = append(endpointsWithL3Override, api.ReservedEndpointSelectors[labels.IDNameWorld])
-		}
 	}
 
 	for _, r := range rule.ToPorts {


### PR DESCRIPTION
This is scheduled to be removed in v1.5, so remove it.

Fixes: #6319

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7614)
<!-- Reviewable:end -->
