### PR TITLE
Add Identity policy cache

### DIFF
--- a/pkg/policy/distillery/distillery.go
+++ b/pkg/policy/distillery/distillery.go
@@ -1,0 +1,155 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package distillery
+
+import (
+	"fmt"
+
+	identityPkg "github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/policy"
+)
+
+var (
+	globalPolicyCache = newPolicyCache()
+)
+
+// SelectorPolicy represents a cached SelectorPolicy, previously resolved from
+// the policy repository and ready to be distilled against a set of identities
+// to compute datapath-level policy configuration.
+type SelectorPolicy interface {
+	// Consume returns the policy in terms of connectivity to peer
+	// Identities. The callee MUST NOT modify the returned pointer.
+	Consume(owner policy.PolicyOwner, cache cache.IdentityCache) *policy.EndpointPolicy
+}
+
+// policyCache represents a cache of resolved policies for identities.
+type policyCache struct {
+	lock.Mutex
+	policies map[*identityPkg.Identity]*cachedSelectorPolicy
+}
+
+// newPolicyCache creates a new cache of SelectorPolicy.
+func newPolicyCache() *policyCache {
+	return &policyCache{
+		policies: make(map[*identityPkg.Identity]*cachedSelectorPolicy),
+	}
+}
+
+// upsert adds the specified Identity to the policy cache, with a reference
+// from the specified Endpoint, then returns the threadsafe copy of the policy
+// and whether policy has been computed for this identity.
+func (cache *policyCache) upsert(identity *identityPkg.Identity, ep Endpoint) SelectorPolicy {
+	cache.Lock()
+	defer cache.Unlock()
+	cip, ok := cache.policies[identity]
+	if !ok {
+		cip = newCachedSelectorPolicy()
+		cache.policies[identity] = cip
+	}
+	cip.users[ep] = struct{}{}
+
+	return cip
+}
+
+// remove forgets about any cached SelectorPolicy that this endpoint uses.
+//
+// Returns true if the SelectorPolicy was removed from the cache.
+func (cache *policyCache) remove(ep Endpoint) (bool, error) {
+	identity := ep.GetSecurityIdentity()
+
+	cache.Lock()
+	defer cache.Unlock()
+	cip, ok := cache.policies[identity]
+	if !ok {
+		return false, fmt.Errorf("no cached SelectorPolicy for identity %d", identity.ID)
+	}
+
+	changed := false
+	delete(cip.users, ep)
+	if len(cip.users) == 0 {
+		// TODO: Add deferred removal window in case the SelectorPolicy
+		//       may be re-used some time soon?
+		delete(cache.policies, identity)
+		changed = true
+	}
+	return changed, nil
+}
+
+// updateSelectorPolicy resolves the policy for the security identity of the
+// specified endpoint and stores it internally.
+//
+// Returns whether the cache was updated, or an error.
+//
+// Must be called with repo.Mutex held for reading.
+func (cache *policyCache) updateSelectorPolicy(repo PolicyRepository, ep Endpoint) (bool, error) {
+	identity := ep.GetSecurityIdentity()
+
+	cache.Lock()
+	cip, ok := cache.policies[identity]
+	cache.Unlock()
+	if !ok {
+		return false, fmt.Errorf("SelectorPolicy not found in cache for ID %d", identity.ID)
+	}
+
+	// Resolve the policies, which could fail
+	identityPolicy, err := repo.ResolvePolicyLocked(identity)
+	if err != nil {
+		return false, err
+	}
+
+	cache.Lock()
+	defer cache.Unlock()
+	cip.setPolicyLocked(identityPolicy)
+	return true, nil
+}
+
+// Upsert notifies the global policy cache that the specified endpoint requires
+// a reference to an identity policy, and returns the cached identity policy
+// for that identity.
+func Upsert(ep Endpoint) SelectorPolicy {
+	identity := ep.GetSecurityIdentity()
+	cip := globalPolicyCache.upsert(identity, ep)
+	return cip
+}
+
+// Remove a cached SelectorPolicy reference for the specified endpoint.
+func Remove(ep Endpoint) error {
+	_, err := globalPolicyCache.remove(ep)
+	return err
+}
+
+// PolicyRepository is an interface which generates an SelectorPolicy for a
+// particular Identity.
+type PolicyRepository interface {
+	ResolvePolicyLocked(*identityPkg.Identity) (*policy.SelectorPolicy, error)
+}
+
+// Endpoint represents a user of an SelectorPolicy. It is used for managing
+// the lifetime of the cached policy.
+type Endpoint interface {
+	policy.PolicyOwner
+}
+
+// UpdatePolicy resolves the policy for the security identity of the specified
+// endpoint and caches it for future use.
+//
+// The caller must provide threadsafety for iteration over the provided policy
+// repository.
+func UpdatePolicy(repo PolicyRepository, ep Endpoint) error {
+	_, err := globalPolicyCache.updateSelectorPolicy(repo, ep)
+	return err
+}

--- a/pkg/policy/distillery/distillery_test.go
+++ b/pkg/policy/distillery/distillery_test.go
@@ -1,0 +1,155 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package distillery
+
+import (
+	"fmt"
+	"testing"
+
+	identityPkg "github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/testutils"
+
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type DistilleryTestSuite struct{}
+
+var (
+	_ = Suite(&DistilleryTestSuite{})
+
+	ep1 = newTestEP()
+	ep2 = newTestEP()
+)
+
+// testEP wraps the testutils endpoint implementation to provide
+// LookupRedirectPort() until tproxy support makes this redundant.
+// This avoids import cycles when adding policy to the imports in testutils.
+type testEP struct {
+	testutils.TestEndpoint
+}
+
+func newTestEP() *testEP {
+	return &testEP{
+		testutils.NewTestEndpoint(),
+	}
+}
+
+func (ep *testEP) WithIdentity(id int64) *testEP {
+	ep.SetIdentity(id)
+	return ep
+}
+
+func (ep *testEP) LookupRedirectPort(l4 *policy.L4Filter) uint16 {
+	return 42
+}
+
+type testPolicyRepo struct {
+	err error
+}
+
+func (repo *testPolicyRepo) ResolvePolicyLocked(*identityPkg.Identity) (*policy.SelectorPolicy, error) {
+	return policy.NewSelectorPolicy(), repo.err
+}
+
+func (s *DistilleryTestSuite) TestCacheManagement(c *C) {
+	cache := newPolicyCache()
+
+	identity := ep1.GetSecurityIdentity()
+	c.Assert(ep2.GetSecurityIdentity(), Equals, identity)
+	_, err := cache.remove(ep1)
+	c.Assert(err, NotNil)
+
+	// Upsert ep1 once, ep2 twice.
+	policy1 := cache.upsert(identity, ep1)
+	policy2 := cache.upsert(identity, ep2)
+	c.Assert(policy1, Equals, policy2)
+
+	// Despite three upsert calls, there should only be one reference from
+	// each endpoint; removing both should clear the cache.
+	cacheCleared, err := cache.remove(ep1)
+	c.Assert(err, IsNil)
+	c.Assert(cacheCleared, Equals, false)
+	cacheCleared, err = cache.remove(ep1)
+	c.Assert(err, IsNil)
+	c.Assert(cacheCleared, Equals, false)
+	cacheCleared, err = cache.remove(ep2)
+	c.Assert(err, IsNil)
+	c.Assert(cacheCleared, Equals, true)
+	_, err = cache.remove(ep2)
+	c.Assert(err, NotNil)
+
+	// TODO: If we implement deferred SelectorPolicy expiry, then
+	// re-inserting ep1 would reuse the same policy.
+}
+
+func (s *DistilleryTestSuite) TestCachePopulation(c *C) {
+	cache := newPolicyCache()
+	repo := &testPolicyRepo{}
+
+	identity1 := ep1.GetSecurityIdentity()
+	c.Assert(ep2.GetSecurityIdentity(), Equals, identity1)
+
+	// Upsert ep1, ep2
+	policy1 := cache.upsert(identity1, ep1)
+	policy2 := cache.upsert(identity1, ep2)
+	c.Assert(policy1, Equals, policy2)
+
+	// Calculate the policy and observe that it's cached
+	updated, err := cache.updateSelectorPolicy(repo, ep1)
+	c.Assert(err, IsNil)
+	c.Assert(updated, Equals, true)
+	updated, err = cache.updateSelectorPolicy(repo, ep1)
+	c.Assert(err, IsNil)
+	updated, err = cache.updateSelectorPolicy(repo, ep2)
+	c.Assert(err, IsNil)
+	idp1 := policy1.(*cachedSelectorPolicy).getPolicy()
+	idp2 := policy2.(*cachedSelectorPolicy).getPolicy()
+	c.Assert(idp1, Equals, idp2)
+
+	// Remove ep1 and observe that ep2 still has access to the policy
+	cacheCleared, err := cache.remove(ep1)
+	c.Assert(err, IsNil)
+	c.Assert(cacheCleared, Equals, false)
+	updated, err = cache.updateSelectorPolicy(repo, ep2)
+	c.Assert(err, IsNil)
+
+	// Attempt to update policy for non-cached endpoint and observe failure
+	ep3 := newTestEP().WithIdentity(1234)
+	updated, err = cache.updateSelectorPolicy(repo, ep3)
+	c.Assert(err, NotNil)
+
+	// Insert endpoint with different identity and observe that the cache
+	// is different from ep1, ep2
+	identity3 := ep3.GetSecurityIdentity()
+	policy3 := cache.upsert(identity3, ep3)
+	c.Assert(policy3, Not(Equals), policy1)
+	updated, err = cache.updateSelectorPolicy(repo, ep3)
+	c.Assert(err, IsNil)
+	c.Assert(updated, Equals, true)
+	idp3 := policy3.(*cachedSelectorPolicy).getPolicy()
+	c.Assert(idp3, Not(Equals), idp1)
+
+	// If there's an error during policy resolution, update should fail
+	repo.err = fmt.Errorf("not implemented!")
+	_, err = cache.updateSelectorPolicy(repo, ep3)
+	c.Assert(err, NotNil)
+}

--- a/pkg/policy/distillery/distillery_test.go
+++ b/pkg/policy/distillery/distillery_test.go
@@ -72,7 +72,7 @@ func (repo *testPolicyRepo) GetRevision() uint64 {
 }
 
 func (repo *testPolicyRepo) ResolvePolicyLocked(*identityPkg.Identity) (*policy.SelectorPolicy, error) {
-	return policy.NewSelectorPolicy(), repo.err
+	return policy.NewSelectorPolicy(repo.revision), repo.err
 }
 
 func (s *DistilleryTestSuite) TestCacheManagement(c *C) {

--- a/pkg/policy/distillery/doc.go
+++ b/pkg/policy/distillery/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package distillery provides caching of SelectorPolicy for consumption by
+// endpoint policy generation.
+package distillery

--- a/pkg/policy/distillery/policy.go
+++ b/pkg/policy/distillery/policy.go
@@ -1,0 +1,65 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package distillery
+
+import (
+	"sync/atomic"
+	"unsafe"
+
+	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/policy"
+)
+
+// cachedSelectorPolicy is a wrapper around a SelectorPolicy (stored in the
+// 'policy' field). It is always nested directly in the owning policyCache,
+// and is protected against concurrent writes via the policyCache mutex.
+type cachedSelectorPolicy struct {
+	users  map[Endpoint]struct{}
+	policy unsafe.Pointer
+}
+
+func newCachedSelectorPolicy() *cachedSelectorPolicy {
+	cip := &cachedSelectorPolicy{
+		users: make(map[Endpoint]struct{}),
+	}
+	cip.setPolicyLocked(policy.NewSelectorPolicy())
+	return cip
+}
+
+// getPolicy returns a reference to the SelectorPolicy that is cached.
+//
+// Users should treat the result as immutable state that MUST NOT be modified.
+func (cip *cachedSelectorPolicy) getPolicy() *policy.SelectorPolicy {
+	return (*policy.SelectorPolicy)(atomic.LoadPointer(&cip.policy))
+}
+
+// setPolicyLocked updates the reference to the SelectorPolicy that is cached.
+func (cip *cachedSelectorPolicy) setPolicyLocked(policy *policy.SelectorPolicy) {
+	atomic.StorePointer(&cip.policy, unsafe.Pointer(policy))
+}
+
+// Consume returns the EndpointPolicy that defines connectivity policy to
+// Identities in the specified cache.
+//
+// This denotes that a particular endpoint is 'consuming' the policy from the
+// selector policy cache.
+func (cip *cachedSelectorPolicy) Consume(owner policy.PolicyOwner, cache cache.IdentityCache) *policy.EndpointPolicy {
+	// TODO: This currently computes the EndpointPolicy from SelectorPolicy
+	// on-demand, however in future the cip is intended to cache the
+	// EndpointPolicy for this Identity and emit datapath deltas instead.
+	// Changing this requires shifting IdentityCache management
+	// responsibilities from the caller into this package.
+	return cip.getPolicy().DistillPolicy(owner, cache)
+}

--- a/pkg/policy/distillery/policy.go
+++ b/pkg/policy/distillery/policy.go
@@ -18,6 +18,7 @@ import (
 	"sync/atomic"
 	"unsafe"
 
+	identityPkg "github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/policy"
 )
@@ -28,7 +29,8 @@ import (
 //
 // 'policy' and 'revesion' are only consistent if queried while holding a lock.
 type cachedSelectorPolicy struct {
-	users map[Endpoint]struct{}
+	users    map[Endpoint]struct{}
+	identity *identityPkg.Identity
 
 	// policy is managed via getPolicy() / setPolicyLocked() to ensure that
 	// writes are performed atomically and reads can be entirely lockless
@@ -37,9 +39,10 @@ type cachedSelectorPolicy struct {
 	revision uint64
 }
 
-func newCachedSelectorPolicy() *cachedSelectorPolicy {
+func newCachedSelectorPolicy(identity *identityPkg.Identity) *cachedSelectorPolicy {
 	cip := &cachedSelectorPolicy{
-		users: make(map[Endpoint]struct{}),
+		users:    make(map[Endpoint]struct{}),
+		identity: identity,
 	}
 	cip.setPolicyLocked(policy.NewSelectorPolicy(), 0)
 	return cip

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -652,6 +652,7 @@ func (p *Repository) ResolvePolicyLocked(securityIdentity *identity.Identity) (*
 	ingressEnabled, egressEnabled, matchingRules := p.computePolicyEnforcementAndRules(securityIdentity)
 
 	calculatedPolicy := &SelectorPolicy{
+		Revision:             p.GetRevision(),
 		L4Policy:             NewL4Policy(),
 		CIDRPolicy:           NewCIDRPolicy(),
 		matchingRules:        matchingRules,

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -29,6 +29,10 @@ import (
 // particular Identity across all layers (L3, L4, and L7), with the policy
 // still determined in terms of EndpointSelectors.
 type SelectorPolicy struct {
+	// Revision is the revision of the policy repository used to generate
+	// this SelectorPolicy.
+	Revision uint64
+
 	// L4Policy contains the computed L4 and L7 policy.
 	L4Policy *L4Policy
 
@@ -101,8 +105,8 @@ func getSecurityIdentities(labelsMap cache.IdentityCache, selector *api.Endpoint
 }
 
 // NewSelectorPolicy returns an empty SelectorPolicy stub.
-func NewSelectorPolicy() *SelectorPolicy {
-	return &SelectorPolicy{}
+func NewSelectorPolicy(revision uint64) *SelectorPolicy {
+	return &SelectorPolicy{Revision: revision}
 }
 
 // DistillPolicy filters down the specified SelectorPolicy (which acts upon
@@ -220,7 +224,7 @@ func (p *EndpointPolicy) computeDirectionL4PolicyMapEntries(identityCache cache.
 // NewEndpointPolicy returns an empty EndpointPolicy stub.
 func NewEndpointPolicy() *EndpointPolicy {
 	return &EndpointPolicy{
-		SelectorPolicy: NewSelectorPolicy(),
+		SelectorPolicy: NewSelectorPolicy(0),
 	}
 }
 
@@ -228,8 +232,9 @@ func NewEndpointPolicy() *EndpointPolicy {
 // desired are not modified after this function is called.
 func (p *SelectorPolicy) Realizes(desired *SelectorPolicy) {
 	if p == nil {
-		p = &SelectorPolicy{}
+		p = NewSelectorPolicy(desired.Revision)
 	}
+	p.Revision = desired.Revision
 	p.IngressPolicyEnabled = desired.IngressPolicyEnabled
 	p.EgressPolicyEnabled = desired.EgressPolicyEnabled
 	p.L4Policy = desired.L4Policy

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -100,6 +100,11 @@ func getSecurityIdentities(labelsMap cache.IdentityCache, selector *api.Endpoint
 	return identities
 }
 
+// NewSelectorPolicy returns an empty SelectorPolicy stub.
+func NewSelectorPolicy() *SelectorPolicy {
+	return &SelectorPolicy{}
+}
+
 // DistillPolicy filters down the specified SelectorPolicy (which acts upon
 // selectors) into a set of concrete map entries based on the specified
 // identityCache. These can subsequently be plumbed into the datapath.
@@ -215,7 +220,7 @@ func (p *EndpointPolicy) computeDirectionL4PolicyMapEntries(identityCache cache.
 // NewEndpointPolicy returns an empty EndpointPolicy stub.
 func NewEndpointPolicy() *EndpointPolicy {
 	return &EndpointPolicy{
-		SelectorPolicy: &SelectorPolicy{},
+		SelectorPolicy: NewSelectorPolicy(),
 	}
 }
 

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -206,6 +206,7 @@ func (ds *PolicyTestSuite) TestL7WithIngressWildcard(c *C) {
 
 	expectedEndpointPolicy := EndpointPolicy{
 		SelectorPolicy: &SelectorPolicy{
+			Revision: repo.GetRevision(),
 			L4Policy: &L4Policy{
 				Ingress: L4PolicyMap{
 					"80/TCP": {
@@ -295,6 +296,7 @@ func (ds *PolicyTestSuite) TestL7WithLocalHostWildcardd(c *C) {
 
 	expectedEndpointPolicy := EndpointPolicy{
 		SelectorPolicy: &SelectorPolicy{
+			Revision: repo.GetRevision(),
 			L4Policy: &L4Policy{
 				Ingress: L4PolicyMap{
 					"80/TCP": {


### PR DESCRIPTION
Based on #7542. See the last four commits for the changes proposed in this PR.

This PR adds a new package to manage the caching and lifecycle of
policies for identities. Long term this is intended to compute policy
for specific identities, handle policy or identity change events to
update the memoized form of these policies, and emit events to endpoints
to consume the newly computed policies.

The intended usage is that when we determine that an Identity is used
locally (hereafter Local Endpoint Identity, LEI [See #7616]), that LEI is inserted
into the distillery to notify it that SelectorPolicy should be resolved and
cached for that LEI. Policy changes should trigger a call to Update() the
policy for LEIs.

For the moment to keep the changes incremental, the endpoint triggers
the Update() from policy recalculation logic. Future work will look to
refactor the model around resolution and management of SelectorPolicy
away from the endpoint, but that is out-of-scope for this PR.

To incrementally introduce this model, the implementation currently only
handles generating SelectorPolicy objects and caching
them, then defers the generation of the EndpointPolicy (via Distill())
to users of the cache. Future commits are expected to extend this to
cache EndpointPolicy objects and track changes to global identities for
calculating differences in connectivity policy for peers via other
upcoming work (https://github.com/cilium/cilium/pull/7539).

This PR also adds some naive sharing logic within this identity policy cache
which uses the policy repository revision number to avoid recalculating
SelectorPolicy for an endpoint if it was already calculated for another
endpoint. As described in the comment, this is an optimistic attempt that
will work best in scenarios where new endpoints are created for an
existing Identity, but may potentially not work if regeneration for two
endpoints with the same Identity are triggered concurrently. No attempt is
made to keep SelectorPolicy alive beyond the lifetime of endpoints for now,
future work should configure a grace period to allow SelectorPolicy to be
reused if an endpoint is deleted and immediately readded on the same
node.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7617)
<!-- Reviewable:end -->
