### PR TITLE
Simplify operator shutdown

### DIFF
--- a/operator/main.go
+++ b/operator/main.go
@@ -195,13 +195,8 @@ func runOperator(cmd *cobra.Command) {
 
 	go StartServer(fmt.Sprintf(":%d", apiServerPort), shutdownSignal)
 
-	for {
-		select {
-		case <-shutdownSignal:
-			// graceful exit
-			log.Info("Received termination signal. Shutting down")
-			return
-		case <-time.After(time.Second):
-		}
-	}
+	<-shutdownSignal
+	// graceful exit
+	log.Info("Received termination signal. Shutting down")
+	return
 }


### PR DESCRIPTION
main function waits for shutdown signal to be closed instead of
doing so in a loop

@tgraf was the timeout in a loop necessary? We can add a 1 second wait after the shutdown channel is closed, but I didn't find any reason to do it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7627)
<!-- Reviewable:end -->
