### PR TITLE
FQDN Cache and DNSPoller

### DIFF
--- a/cilium/cmd/preflight.go
+++ b/cilium/cmd/preflight.go
@@ -83,7 +83,7 @@ func preflightPoller() {
 	}
 
 	// Build a cache from this data to be serialized
-	cache := fqdn.NewDNSCache()
+	cache := fqdn.NewDNSCache(0)
 	for name, IPs := range DNSData {
 		cache.Update(lookupTime, name, IPs, toFQDNsPreCacheTTL)
 	}

--- a/daemon/fqdn_test.go
+++ b/daemon/fqdn_test.go
@@ -45,7 +45,7 @@ func (ds *DaemonSuite) BenchmarkFqdnCache(c *C) {
 	for i := 0; i < c.N; i++ {
 		lookupTime := time.Now()
 		ep := &endpoint.Endpoint{} // only works because we only touch .DNSHistory
-		ep.DNSHistory = fqdn.NewDNSCache()
+		ep.DNSHistory = fqdn.NewDNSCache(0)
 
 		for i := 0; i < 1000; i++ {
 			ep.DNSHistory.Update(lookupTime, fmt.Sprintf("domain-%d.com.", i), makeIPs(10), 1000)

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -410,7 +410,7 @@ func NewEndpointWithState(ID uint16, state string) *Endpoint {
 		ID:            ID,
 		OpLabels:      pkgLabels.NewOpLabels(),
 		Status:        NewEndpointStatus(),
-		DNSHistory:    fqdn.NewDNSCacheWithLimit(option.Config.ToFQDNsMaxIPsPerHost),
+		DNSHistory:    fqdn.NewDNSCacheWithLimit(option.Config.ToFQDNsMinTTL, option.Config.ToFQDNsMaxIPsPerHost),
 		state:         state,
 		hasBPFProgram: make(chan struct{}, 0),
 		controllers:   controller.NewManager(),
@@ -442,7 +442,7 @@ func NewEndpointFromChangeModel(base *models.EndpointChangeRequest) (*Endpoint, 
 		DatapathMapID:    int(base.DatapathMapID),
 		IfIndex:          int(base.InterfaceIndex),
 		OpLabels:         pkgLabels.NewOpLabels(),
-		DNSHistory:       fqdn.NewDNSCacheWithLimit(option.Config.ToFQDNsMaxIPsPerHost),
+		DNSHistory:       fqdn.NewDNSCacheWithLimit(option.Config.ToFQDNsMinTTL, option.Config.ToFQDNsMaxIPsPerHost),
 		state:            "",
 		Status:           NewEndpointStatus(),
 		hasBPFProgram:    make(chan struct{}, 0),
@@ -1041,7 +1041,7 @@ func ParseEndpoint(strEp string) (*Endpoint, error) {
 	}
 	ep := Endpoint{
 		OpLabels:   pkgLabels.NewOpLabels(),
-		DNSHistory: fqdn.NewDNSCacheWithLimit(option.Config.ToFQDNsMaxIPsPerHost),
+		DNSHistory: fqdn.NewDNSCacheWithLimit(option.Config.ToFQDNsMinTTL, option.Config.ToFQDNsMaxIPsPerHost),
 	}
 	if err := parseBase64ToEndpoint(strEpSlice[1], &ep); err != nil {
 		return nil, fmt.Errorf("failed to parse base64toendpoint: %s", err)

--- a/pkg/fqdn/config.go
+++ b/pkg/fqdn/config.go
@@ -30,6 +30,9 @@ type Config struct {
 	// When set to 0, 2*DNSPollerInterval is used.
 	MinTTL int
 
+	// OverLimit is the number of max entries that a host can have in the DNS cache.
+	OverLimit int
+
 	// Cache is where the poller stores DNS data used to generate rules.
 	// When set to nil, it uses fqdn.DefaultDNSCache, a global cache instance.
 	Cache *DNSCache

--- a/pkg/fqdn/dnspoller_test.go
+++ b/pkg/fqdn/dnspoller_test.go
@@ -158,7 +158,7 @@ func (ds *FQDNTestSuite) TestRuleGenRuleHandling(c *C) {
 			}
 
 			gen    = NewRuleGen(cfg)
-			poller = NewDNSPoller(cfg, gen, NewDNSCache(0))
+			poller = NewDNSPoller(cfg, gen)
 		)
 
 		rulesToAdd := []*api.Rule{}

--- a/pkg/fqdn/dnspoller_test.go
+++ b/pkg/fqdn/dnspoller_test.go
@@ -145,7 +145,7 @@ func (ds *FQDNTestSuite) TestRuleGenRuleHandling(c *C) {
 
 			cfg = Config{
 				MinTTL: 1,
-				Cache:  NewDNSCache(),
+				Cache:  NewDNSCache(0),
 
 				LookupDNSNames: func(dnsNames []string) (DNSIPs map[string]*DNSIPRecords, errorDNSNames map[string]error) {
 					return lookupDNSNames(ipLookups, lookups, dnsNames), nil
@@ -158,7 +158,7 @@ func (ds *FQDNTestSuite) TestRuleGenRuleHandling(c *C) {
 			}
 
 			gen    = NewRuleGen(cfg)
-			poller = NewDNSPoller(cfg, gen)
+			poller = NewDNSPoller(cfg, gen, NewDNSCache(0))
 		)
 
 		rulesToAdd := []*api.Rule{}

--- a/pkg/fqdn/helpers_test.go
+++ b/pkg/fqdn/helpers_test.go
@@ -45,7 +45,7 @@ func (ds *DNSCacheTestSuite) TestKeepUniqueNames(c *C) {
 func (ds *DNSCacheTestSuite) TestInjectCIDRSetRulesWithOtherCIDRSet(c *C) {
 	// Validate that if empty cache the ToCidrRule is always empty
 	rule := makeRule("cilium.io", "cilium.io")
-	cache := NewDNSCache()
+	cache := NewDNSCache(0)
 	cache.Update(now, "cilium.io.", []net.IP{net.ParseIP("1.1.1.1")}, 1)
 	rule.Egress = append(rule.Egress, api.EgressRule{
 		ToCIDRSet: api.IPsToCIDRRules([]net.IP{net.ParseIP("4.4.4.4")})})
@@ -58,7 +58,7 @@ func (ds *DNSCacheTestSuite) TestInjectCIDRSetRulesWithOtherCIDRSet(c *C) {
 func (ds *DNSCacheTestSuite) TestInjectCIDRSetRulesInvalidCache(c *C) {
 	// Validate that if empty cache the ToCidrRule is always empty
 	rule := makeRule("cilium.io", "cilium.io")
-	EmptyCache := NewDNSCache()
+	EmptyCache := NewDNSCache(0)
 	injectToCIDRSetRules(rule, EmptyCache, nil)
 	c.Assert(rule.Egress[0].ToCIDRSet, HasLen, 0)
 
@@ -71,7 +71,7 @@ func (ds *DNSCacheTestSuite) TestInjectCIDRSetRulesInvalidCache(c *C) {
 
 func (ds *DNSCacheTestSuite) TestInjectCIDRSetRulesByMatchName(c *C) {
 	rule := makeRule("cilium.io", "cilium.io")
-	cache := NewDNSCache()
+	cache := NewDNSCache(0)
 	cache.Update(now, "cilium.io.", []net.IP{net.ParseIP("1.1.1.1")}, 1)
 
 	injectToCIDRSetRules(rule, cache, nil)
@@ -84,7 +84,7 @@ func (ds *DNSCacheTestSuite) TestInjectCIDRSetRulesByMatchPattern(c *C) {
 	rule.Egress[0].ToFQDNs = api.FQDNSelectorSlice{
 		{MatchPattern: "cilium.io"},
 	}
-	cache := NewDNSCache()
+	cache := NewDNSCache(0)
 	cache.Update(now, "cilium.io.", []net.IP{net.ParseIP("1.1.1.1")}, 1)
 	reg := regexpmap.NewRegexpMap()
 	reg.Add("cilium.io", "cilium.io")

--- a/pkg/fqdn/rulegen.go
+++ b/pkg/fqdn/rulegen.go
@@ -86,7 +86,7 @@ type RuleGen struct {
 func NewRuleGen(config Config) *RuleGen {
 
 	if config.Cache == nil {
-		config.Cache = DefaultDNSCache
+		config.Cache = NewDNSCache(0)
 	}
 
 	if config.AddGeneratedRules == nil {
@@ -101,6 +101,11 @@ func NewRuleGen(config Config) *RuleGen {
 		cache:       config.Cache,
 	}
 
+}
+
+// GetDNSCache returns the DNSCache used by the RuleGen
+func (gen *RuleGen) GetDNSCache() *DNSCache {
+	return gen.cache
 }
 
 // PrepareFQDNRules adds a tracking label to rules that contain ToFQDN sections.

--- a/pkg/fqdn/rulegen_test.go
+++ b/pkg/fqdn/rulegen_test.go
@@ -43,7 +43,7 @@ func (ds *FQDNTestSuite) TestRuleGenCIDRGeneration(c *C) {
 
 		gen = NewRuleGen(Config{
 			MinTTL: 1,
-			Cache:  NewDNSCache(),
+			Cache:  NewDNSCache(0),
 
 			LookupDNSNames: func(dnsNames []string) (DNSIPs map[string]*DNSIPRecords, errorDNSNames map[string]error) {
 				return lookupFail(c, dnsNames)
@@ -107,6 +107,7 @@ func (ds *FQDNTestSuite) TestRuleGenDropCIDROnReinsert(c *C) {
 		generatedRules = make([]*api.Rule, 0)
 
 		gen = NewRuleGen(Config{
+			Cache: NewDNSCache(0),
 			LookupDNSNames: func(dnsNames []string) (DNSIPs map[string]*DNSIPRecords, errorDNSNames map[string]error) {
 				return lookupFail(c, dnsNames)
 			},
@@ -137,7 +138,7 @@ func (ds *FQDNTestSuite) TestRuleGenMultiIPUpdate(c *C) {
 
 		gen = NewRuleGen(Config{
 			MinTTL: 1,
-			Cache:  NewDNSCache(),
+			Cache:  NewDNSCache(0),
 
 			LookupDNSNames: func(dnsNames []string) (DNSIPs map[string]*DNSIPRecords, errorDNSNames map[string]error) {
 				return lookupFail(c, dnsNames)
@@ -208,7 +209,7 @@ func (ds *FQDNTestSuite) TestRuleGenUpdatesOnReplace(c *C) {
 
 		gen = NewRuleGen(Config{
 			MinTTL: 1,
-			Cache:  NewDNSCache(),
+			Cache:  NewDNSCache(0),
 
 			LookupDNSNames: func(dnsNames []string) (DNSIPs map[string]*DNSIPRecords, errorDNSNames map[string]error) {
 				return lookupFail(c, dnsNames)
@@ -284,7 +285,7 @@ func (ds *FQDNTestSuite) TestPrepareFQDNRules(c *C) {
 
 		gen = NewRuleGen(Config{
 			MinTTL: 1,
-			Cache:  NewDNSCache(),
+			Cache:  NewDNSCache(0),
 
 			LookupDNSNames: func(dnsNames []string) (DNSIPs map[string]*DNSIPRecords, errorDNSNames map[string]error) {
 				return lookupFail(c, dnsNames)


### PR DESCRIPTION
Read per commit: 

1) Usage of min TTL on dnsCache, so it's handle in one place. 
2) Use a dnsHistory in poller, so can be restored in the DNS cache GC operations. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7629)
<!-- Reviewable:end -->
