### PR TITLE
cilium: support aead state keys

### DIFF
--- a/Documentation/gettingstarted/encryption.rst
+++ b/Documentation/gettingstarted/encryption.rst
@@ -28,14 +28,12 @@ Generate & import the PSK
 First create a Kubernetes secret for the IPSec keys to be stored.
 This will generate the necessary IPSec keys which will be distributed as a
 Kubernetes secret called ``cilium-ipsec-keys``. In this example we use
-AES-CBC with HMAC-256 (hash based authentication code), but any of the supported
+GMC-128-AES, but any of the supported
 Linux algorithms may be used. To generate use the following
 
 .. parsed-literal::
-
-    kubectl create -n kube-system secret generic cilium-ipsec-keys \\
-       --from-literal=keys="hmac(sha256) $(echo \`dd if=/dev/urandom count=32 bs=1 2> /dev/null| xxd -p -c 64\`) cbc(aes) $(echo \`dd if=/dev/urandom count=32 bs=1 2> /dev/null| xxd -p -c 64\`)"
-
+    $ kubectl create -n kube-system secret generic cilium-ipsec-keys \
+        --from-literal=keys="3 rfc4106(gcm(aes)) $(echo `dd if=/dev/urandom count=20 bs=1 2> /dev/null| xxd -p -c 64`) 128"
 
 The secret can be displayed with 'kubectl -n kube-system get secret' and will be
 listed as 'cilium-ipsec-keys'.

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -30,7 +30,6 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
-	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/vishvananda/netlink"
 
 	"github.com/sirupsen/logrus"
@@ -169,28 +168,6 @@ func ipSecReplacePolicyOut(src, dst *net.IPNet, dir IPSecDir) error {
 	return netlink.XfrmPolicyUpdate(policy)
 }
 
-func ipSecDeleteStateOut(src, local net.IP) error {
-	state := ipSecNewState()
-
-	state.Src = src
-	state.Dst = local
-	err := netlink.XfrmStateDel(state)
-	return err
-}
-
-func ipSecDeleteStateIn(src, local net.IP) error {
-	state := ipSecNewState()
-
-	state.Src = src
-	state.Dst = local
-	err := netlink.XfrmStateDel(state)
-	return err
-}
-
-func ipSecDeletePolicy(src, local net.IP) error {
-	return nil
-}
-
 func ipsecDeleteXfrmSpi(spi uint8) {
 	var err error
 	scopedLog := log.WithFields(logrus.Fields{
@@ -310,27 +287,6 @@ func UpsertIPsecEndpoint(local, remote *net.IPNet, dir IPSecDir) (uint8, error) 
 		}
 	}
 	return spi, nil
-}
-
-// DeleteIPSecEndpoint deletes the endpoint from IPSec SPD and SAD
-func DeleteIPSecEndpoint(src, local net.IP) error {
-	scopedLog := log.WithFields(logrus.Fields{
-		logfields.IPAddr: src,
-	})
-
-	err := ipSecDeleteStateIn(src, local)
-	if err != nil {
-		scopedLog.WithError(err).Warning("unable to delete IPSec (stateIn) context\n")
-	}
-	err = ipSecDeleteStateOut(src, local)
-	if err != nil {
-		scopedLog.WithError(err).Warning("unable to delete IPSec (stateOut) context\n")
-	}
-	err = ipSecDeletePolicy(src, local)
-	if err != nil {
-		scopedLog.WithError(err).Warning("unable to delete IPSec (policy) context\n")
-	}
-	return nil
 }
 
 func decodeIPSecKey(keyRaw string) ([]byte, error) {

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -118,30 +118,18 @@ func ipSecReplacePolicyIn(src, dst *net.IPNet) error {
 }
 
 func ipSecReplacePolicyInFwd(src, dst *net.IPNet, dir netlink.Dir) error {
-	var spiWide uint32
-	var mask uint32
-
 	key := getIPSecKeys(dst.IP)
 	if key == nil {
 		return fmt.Errorf("IPSec key missing")
 	}
-	spiWide = uint32(key.Spi)
 
 	policy := ipSecNewPolicy()
 	policy.Dir = dir
 	policy.Src = src
 	policy.Dst = dst
-	// On ingress we use SPI to detremine key to use for decryption on
-	// egress however we need to select the key using the endpoint ID. To
-	// indicate this to the stack we use an extra byte and need a wider mask.
-	if dir == netlink.XFRM_DIR_OUT {
-		mask = linux_defaults.IPsecMarkMask
-	} else {
-		mask = linux_defaults.IPsecMarkMaskIn
-	}
 	policy.Mark = &netlink.XfrmMark{
-		Value: ((spiWide << 12) | linux_defaults.RouteMarkDecrypt),
-		Mask:  mask,
+		Value: linux_defaults.RouteMarkDecrypt,
+		Mask:  linux_defaults.IPsecMarkMaskIn,
 	}
 	ipSecAttachPolicyTempl(policy, key, src.IP, dst.IP)
 	return netlink.XfrmPolicyUpdate(policy)

--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -37,6 +37,7 @@ var _ = Suite(&IPSecSuitePrivileged{})
 var (
 	path           = "ipsec_keys_test"
 	keysDat        = []byte("1 hmac(sha256) 0123456789abcdef0123456789abcdef cbc(aes) 0123456789abcdef0123456789abcdef\n1 hmac(sha256) 0123456789abcdef0123456789abcdef cbc(aes) 0123456789abcdef0123456789abcdef foobar\n")
+	keysAeadDat    = []byte("6 rfc4106(gcm(aes)) 44434241343332312423222114131211f4f3f2f1 128\n")
 	invalidKeysDat = []byte("1 test abcdefghijklmnopqrstuvwzyzABCDEF test abcdefghijklmnopqrstuvwzyzABCDEF\n")
 )
 
@@ -63,6 +64,9 @@ func (p *IPSecSuitePrivileged) TestLoadKeys(c *C) {
 	keys := bytes.NewReader(keysDat)
 	_, err := loadIPSecKeys(keys)
 	c.Assert(err, IsNil)
+	keys = bytes.NewReader(keysAeadDat)
+	_, err = loadIPSecKeys(keys)
+	c.Assert(err, IsNil)
 }
 
 func (p *IPSecSuitePrivileged) TestUpsertIPSecEquals(c *C) {
@@ -80,6 +84,24 @@ func (p *IPSecSuitePrivileged) TestUpsertIPSecEquals(c *C) {
 		ReqID: 1,
 		Auth:  &netlink.XfrmStateAlgo{Name: "hmac(sha256)", Key: authKey},
 		Crypt: &netlink.XfrmStateAlgo{Name: "cbc(aes)", Key: cryptKey},
+	}
+
+	ipSecKeysGlobal["1.2.3.4"] = key
+	ipSecKeysGlobal[""] = key
+
+	_, err = UpsertIPsecEndpoint(local, remote, IPSecDirBoth)
+	c.Assert(err, IsNil)
+
+	ipsecDeleteXfrmSpi(0)
+
+	aeadKey, err := decodeIPSecKey("44434241343332312423222114131211f4f3f2f1")
+	c.Assert(err, IsNil)
+	key = &ipSecKey{
+		Spi:   1,
+		ReqID: 1,
+		Aead:  &netlink.XfrmStateAlgo{Name: "rfc4106(gcm(aes))", Key: aeadKey, ICVLen: 128},
+		Crypt: nil,
+		Auth:  nil,
 	}
 
 	ipSecKeysGlobal["1.2.3.4"] = key
@@ -108,6 +130,25 @@ func (p *IPSecSuitePrivileged) TestUpsertIPSecEndpoint(c *C) {
 		ReqID: 1,
 		Auth:  &netlink.XfrmStateAlgo{Name: "hmac(sha256)", Key: authKey},
 		Crypt: &netlink.XfrmStateAlgo{Name: "cbc(aes)", Key: cryptKey},
+	}
+
+	ipSecKeysGlobal["1.1.3.4"] = key
+	ipSecKeysGlobal["1.2.3.4"] = key
+	ipSecKeysGlobal[""] = key
+
+	_, err = UpsertIPsecEndpoint(local, remote, IPSecDirBoth)
+	c.Assert(err, IsNil)
+
+	ipsecDeleteXfrmSpi(0)
+
+	aeadKey, err := decodeIPSecKey("44434241343332312423222114131211f4f3f2f1")
+	c.Assert(err, IsNil)
+	key = &ipSecKey{
+		Spi:   1,
+		ReqID: 1,
+		Aead:  &netlink.XfrmStateAlgo{Name: "rfc4106(gcm(aes))", Key: aeadKey, ICVLen: 128},
+		Crypt: nil,
+		Auth:  nil,
 	}
 
 	ipSecKeysGlobal["1.1.3.4"] = key

--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -84,12 +84,9 @@ func (p *IPSecSuitePrivileged) TestUpsertIPSecEquals(c *C) {
 	_, err = UpsertIPsecEndpoint(local, remote, IPSecDirBoth)
 	c.Assert(err, IsNil)
 
-	err = DeleteIPSecEndpoint(remote.IP, local.IP)
-	c.Assert(err, IsNil)
-
+	ipsecDeleteXfrmSpi(0)
 	ipSecKeysGlobal["1.2.3.4"] = nil
 	ipSecKeysGlobal[""] = nil
-
 }
 
 func (p *IPSecSuitePrivileged) TestUpsertIPSecEndpoint(c *C) {
@@ -112,9 +109,7 @@ func (p *IPSecSuitePrivileged) TestUpsertIPSecEndpoint(c *C) {
 	_, err = UpsertIPsecEndpoint(local, remote, IPSecDirBoth)
 	c.Assert(err, IsNil)
 
-	err = DeleteIPSecEndpoint(remote.IP, local.IP)
-	c.Assert(err, IsNil)
-
+	ipsecDeleteXfrmSpi(0)
 	ipSecKeysGlobal["1.1.3.4"] = nil
 	ipSecKeysGlobal["1.2.3.4"] = nil
 	ipSecKeysGlobal[""] = nil
@@ -129,6 +124,5 @@ func (p *IPSecSuitePrivileged) TestUpsertIPSecKeyMissing(c *C) {
 	_, err = UpsertIPsecEndpoint(local, remote, IPSecDirBoth)
 	c.Assert(err, ErrorMatches, "unable to replace local state: IPSec key missing")
 
-	err = DeleteIPSecEndpoint(remote.IP, local.IP)
-	c.Assert(err, IsNil)
+	ipsecDeleteXfrmSpi(0)
 }

--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -71,11 +71,15 @@ func (p *IPSecSuitePrivileged) TestUpsertIPSecEquals(c *C) {
 	_, remote, err := net.ParseCIDR("1.2.3.4/16")
 	c.Assert(err, IsNil)
 
+	authKey, err := decodeIPSecKey("0123456789abcdef0123456789abcdef")
+	c.Assert(err, IsNil)
+	cryptKey, err := decodeIPSecKey("0123456789abcdef0123456789abcdef")
+	c.Assert(err, IsNil)
 	key := &ipSecKey{
 		Spi:   1,
 		ReqID: 1,
-		Auth:  &netlink.XfrmStateAlgo{Name: "hmac(sha256)", Key: []byte("0123456789abcdef0123456789abcdef")},
-		Crypt: &netlink.XfrmStateAlgo{Name: "cbc(aes)", Key: []byte("0123456789abcdef0123456789abcdef")},
+		Auth:  &netlink.XfrmStateAlgo{Name: "hmac(sha256)", Key: authKey},
+		Crypt: &netlink.XfrmStateAlgo{Name: "cbc(aes)", Key: cryptKey},
 	}
 
 	ipSecKeysGlobal["1.2.3.4"] = key
@@ -95,11 +99,15 @@ func (p *IPSecSuitePrivileged) TestUpsertIPSecEndpoint(c *C) {
 	_, remote, err := net.ParseCIDR("1.2.3.4/16")
 	c.Assert(err, IsNil)
 
+	authKey, err := decodeIPSecKey("0123456789abcdef0123456789abcdef")
+	c.Assert(err, IsNil)
+	cryptKey, err := decodeIPSecKey("0123456789abcdef0123456789abcdef")
+	c.Assert(err, IsNil)
 	key := &ipSecKey{
 		Spi:   1,
 		ReqID: 1,
-		Auth:  &netlink.XfrmStateAlgo{Name: "hmac(sha256)", Key: []byte("0123456789abcdef0123456789abcdef")},
-		Crypt: &netlink.XfrmStateAlgo{Name: "cbc(aes)", Key: []byte("0123456789abcdef0123456789abcdef")},
+		Auth:  &netlink.XfrmStateAlgo{Name: "hmac(sha256)", Key: authKey},
+		Crypt: &netlink.XfrmStateAlgo{Name: "cbc(aes)", Key: cryptKey},
 	}
 
 	ipSecKeysGlobal["1.1.3.4"] = key

--- a/test/k8sT/manifests/ipsec_ds.yaml
+++ b/test/k8sT/manifests/ipsec_ds.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: kube-system
 type: Opaque
 stringData:
-  keys: "5 hmac(sha256) 0123456789abcdef0123456789abcdef cbc(aes) 0123456789abcdef0123456789abcdef"
+  keys: "6 rfc4106(gcm(aes)) 44434241343332312423222114131211f4f3f2f1 128"


### PR DESCRIPTION
Add support aead keys.

Signed-off-by: John Fastabend <john.fastabend@gmail.com

```release-note
Transparent Encryption support for Authenticated Encryption with Associated Data algorithms
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7635)
<!-- Reviewable:end -->
