### PR TITLE
kubernetes: Relax readiness and liveness probe interval

### DIFF
--- a/examples/kubernetes/1.10/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-containerd-ds.yaml
@@ -82,9 +82,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -99,9 +99,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.10/cilium-containerd.yaml
+++ b/examples/kubernetes/1.10/cilium-containerd.yaml
@@ -235,9 +235,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -252,9 +252,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.10/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-crio-ds.yaml
@@ -90,9 +90,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -107,9 +107,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -243,9 +243,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -260,9 +260,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.10/cilium-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-ds.yaml
@@ -89,9 +89,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -106,9 +106,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.10/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.10/cilium-external-etcd.yaml
@@ -242,9 +242,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -259,9 +259,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.10/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-minikube-ds.yaml
@@ -89,9 +89,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -106,9 +106,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.10/cilium-minikube.yaml
+++ b/examples/kubernetes/1.10/cilium-minikube.yaml
@@ -242,9 +242,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -259,9 +259,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.10/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.10/cilium-with-node-init.yaml
@@ -242,9 +242,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -259,9 +259,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -242,9 +242,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -259,9 +259,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.11/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-containerd-ds.yaml
@@ -82,9 +82,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -99,9 +99,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.11/cilium-containerd.yaml
+++ b/examples/kubernetes/1.11/cilium-containerd.yaml
@@ -235,9 +235,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -252,9 +252,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.11/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-crio-ds.yaml
@@ -90,9 +90,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -107,9 +107,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -243,9 +243,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -260,9 +260,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -89,9 +89,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -106,9 +106,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.11/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.11/cilium-external-etcd.yaml
@@ -242,9 +242,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -259,9 +259,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.11/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-minikube-ds.yaml
@@ -89,9 +89,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -106,9 +106,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.11/cilium-minikube.yaml
+++ b/examples/kubernetes/1.11/cilium-minikube.yaml
@@ -242,9 +242,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -259,9 +259,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.11/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.11/cilium-with-node-init.yaml
@@ -242,9 +242,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -259,9 +259,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -242,9 +242,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -259,9 +259,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.12/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-containerd-ds.yaml
@@ -82,9 +82,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -99,9 +99,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.12/cilium-containerd.yaml
+++ b/examples/kubernetes/1.12/cilium-containerd.yaml
@@ -235,9 +235,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -252,9 +252,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.12/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-crio-ds.yaml
@@ -90,9 +90,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -107,9 +107,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -243,9 +243,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -260,9 +260,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.12/cilium-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-ds.yaml
@@ -89,9 +89,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -106,9 +106,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.12/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.12/cilium-external-etcd.yaml
@@ -242,9 +242,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -259,9 +259,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.12/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-minikube-ds.yaml
@@ -89,9 +89,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -106,9 +106,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.12/cilium-minikube.yaml
+++ b/examples/kubernetes/1.12/cilium-minikube.yaml
@@ -242,9 +242,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -259,9 +259,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.12/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.12/cilium-with-node-init.yaml
@@ -242,9 +242,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -259,9 +259,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -242,9 +242,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -259,9 +259,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.13/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-containerd-ds.yaml
@@ -82,9 +82,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -99,9 +99,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.13/cilium-containerd.yaml
+++ b/examples/kubernetes/1.13/cilium-containerd.yaml
@@ -235,9 +235,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -252,9 +252,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.13/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-crio-ds.yaml
@@ -90,9 +90,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -107,9 +107,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.13/cilium-crio.yaml
+++ b/examples/kubernetes/1.13/cilium-crio.yaml
@@ -243,9 +243,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -260,9 +260,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.13/cilium-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-ds.yaml
@@ -89,9 +89,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -106,9 +106,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.13/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.13/cilium-external-etcd.yaml
@@ -242,9 +242,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -259,9 +259,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.13/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-minikube-ds.yaml
@@ -89,9 +89,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -106,9 +106,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.13/cilium-minikube.yaml
+++ b/examples/kubernetes/1.13/cilium-minikube.yaml
@@ -242,9 +242,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -259,9 +259,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.13/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.13/cilium-with-node-init.yaml
@@ -242,9 +242,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -259,9 +259,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.13/cilium.yaml
+++ b/examples/kubernetes/1.13/cilium.yaml
@@ -242,9 +242,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -259,9 +259,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.14/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.14/cilium-containerd-ds.yaml
@@ -82,9 +82,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -99,9 +99,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.14/cilium-containerd.yaml
+++ b/examples/kubernetes/1.14/cilium-containerd.yaml
@@ -235,9 +235,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -252,9 +252,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.14/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.14/cilium-crio-ds.yaml
@@ -90,9 +90,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -107,9 +107,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.14/cilium-crio.yaml
+++ b/examples/kubernetes/1.14/cilium-crio.yaml
@@ -243,9 +243,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -260,9 +260,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.14/cilium-ds.yaml
+++ b/examples/kubernetes/1.14/cilium-ds.yaml
@@ -89,9 +89,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -106,9 +106,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.14/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.14/cilium-external-etcd.yaml
@@ -242,9 +242,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -259,9 +259,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.14/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.14/cilium-minikube-ds.yaml
@@ -89,9 +89,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -106,9 +106,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.14/cilium-minikube.yaml
+++ b/examples/kubernetes/1.14/cilium-minikube.yaml
@@ -242,9 +242,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -259,9 +259,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.14/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.14/cilium-with-node-init.yaml
@@ -242,9 +242,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -259,9 +259,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.14/cilium.yaml
+++ b/examples/kubernetes/1.14/cilium.yaml
@@ -242,9 +242,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -259,9 +259,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/templates/v1/cilium-containerd-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-containerd-ds.yaml.sed
@@ -82,9 +82,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -99,9 +99,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
@@ -90,9 +90,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -107,9 +107,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
@@ -89,9 +89,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -106,9 +106,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/templates/v1/cilium-minikube-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-minikube-ds.yaml.sed
@@ -89,9 +89,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -106,9 +106,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:


### PR DESCRIPTION
A considerable amount of idle CPU time is used for the high frequency of
liveness and readiness probes. Relax the interval to not burn unnecessary CPU.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7638)
<!-- Reviewable:end -->
