### PR TITLE
datapath: Fix panic when updating tunnel mapping

### DIFF
--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -103,12 +103,12 @@ func updateTunnelMapping(oldCIDR, newCIDR *cidr.CIDR, oldIP, newIP net.IP, first
 // CIDR and node IP to a new node CIDR and node IP requires to insert/update
 // the new node CIDR.
 func cidrNodeMappingUpdateRequired(oldCIDR, newCIDR *cidr.CIDR, oldIP, newIP net.IP, oldKey, newKey uint8) bool {
-	// node with single IP stack could have nil old and new CIDR
-	if oldCIDR == nil && newCIDR == nil {
+	// No CIDR provided
+	if newCIDR == nil {
 		return false
 	}
 	// Newly announced CIDR
-	if newCIDR != nil && oldCIDR == nil {
+	if oldCIDR == nil {
 		return true
 	}
 
@@ -122,7 +122,7 @@ func cidrNodeMappingUpdateRequired(oldCIDR, newCIDR *cidr.CIDR, oldIP, newIP net
 	}
 
 	// CIDR changed
-	return oldCIDR != nil && newCIDR != nil && !oldCIDR.IP.Equal(newCIDR.IP)
+	return !oldCIDR.IP.Equal(newCIDR.IP)
 }
 
 func deleteTunnelMapping(oldCIDR *cidr.CIDR, quietMode bool) {


### PR DESCRIPTION
Don't attempt to update the tunnel mapping when no node CIDR is provided

Fixes the following panic:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x28186be]

goroutine 5776 [running]:
github.com/cilium/cilium/pkg/datapath/linux.updateTunnelMapping(0xc000bc4bc8, 0x0, 0xc000c8abd0, 0x10, 0x10, 0xc0007c51a0, 0x10, 0x10, 0xc000050100)
	/go/src/github.com/cilium/cilium/pkg/datapath/linux/node.go:82 +0x37e
github.com/cilium/cilium/pkg/datapath/linux.(*linuxNodeHandler).nodeUpdate(0xc000a88be0, 0xc000c9f2d8, 0xc000ec54a0, 0xc0009b0300, 0xc00056b830, 0x13e9151c0)
	/go/src/github.com/cilium/cilium/pkg/datapath/linux/node.go:542 +0x4a3
github.com/cilium/cilium/pkg/datapath/linux.(*linuxNodeHandler).NodeUpdate(0xc000a88be0, 0xc000c5bbac, 0x4, 0xc0002fb798, 0x7, 0xc000c58fa0, 0x3, 0x4, 0xc000bc4bc0, 0xc000bc4bc8, ...)
	/go/src/github.com/cilium/cilium/pkg/datapath/linux/node.go:427 +0x14b
github.com/cilium/cilium/pkg/node/manager.(*Manager).NodeUpdated(0xc00056b830, 0xc0007c50d8, 0x4, 0xc0007c50f0, 0x7, 0xc0005070e0, 0x2, 0x2, 0xc0000103f0, 0x0, ...)
	/go/src/github.com/cilium/cilium/pkg/node/manager/manager.go:279 +0x484
github.com/cilium/cilium/pkg/node/store.(*NodeObserver).OnUpdate(0xc0007d3000, 0x33e82a0, 0xc000ec5180)
	/go/src/github.com/cilium/cilium/pkg/node/store/store.go:55 +0xfa
github.com/cilium/cilium/pkg/kvstore/store.(*SharedStore).onUpdate(...)
	/go/src/github.com/cilium/cilium/pkg/kvstore/store/store.go:223
github.com/cilium/cilium/pkg/kvstore/store.(*SharedStore).updateKey(0xc000cd98c0, 0xc000c00e26, 0xc, 0xc000a38500, 0x139, 0x140, 0x1, 0x0)
	/go/src/github.com/cilium/cilium/pkg/kvstore/store/store.go:405 +0x13f
github.com/cilium/cilium/pkg/kvstore/store.(*SharedStore).watcher(0xc000cd98c0, 0xc001057020)
	/go/src/github.com/cilium/cilium/pkg/kvstore/store/store.go:467 +0x826
created by github.com/cilium/cilium/pkg/kvstore/store.(*SharedStore).listAndStartWatcher
	/go/src/github.com/cilium/cilium/pkg/kvstore/store/store.go:426 +0x7c
```

Related: #7615

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7643)
<!-- Reviewable:end -->
