### PR TITLE
bpf: Avoid unnecessary error when ending parallel map mode

### DIFF
--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -1106,9 +1106,7 @@ func waitForHostDeviceWhenReady(ifaceName string) error {
 }
 
 func endParallelMapMode() {
-	if err := ipcachemap.IPCache.EndParallelMode(); err != nil {
-		log.WithError(err).Error("Unable to end parallel mode of ipcache map")
-	}
+	ipcachemap.IPCache.EndParallelMode()
 }
 
 func runDaemon() {

--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -315,18 +315,14 @@ func (m *Map) setPathIfUnset() error {
 }
 
 // EndParallelMode ends the parallel mode of a map
-func (m *Map) EndParallelMode() error {
+func (m *Map) EndParallelMode() {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
-	if !m.inParallelMode {
-		return fmt.Errorf("map is not in parallel mode")
+	if m.inParallelMode {
+		m.inParallelMode = false
+		m.scopedLogger().Debug("End of parallel mode")
 	}
-
-	m.inParallelMode = false
-	m.scopedLogger().Debug("End of parallel mode")
-
-	return nil
 }
 
 // OpenParallel is similar to OpenOrCreate() but prepares the existing map to

--- a/pkg/bpf/map_linux_test.go
+++ b/pkg/bpf/map_linux_test.go
@@ -217,10 +217,7 @@ func (s *BPFPrivilegedTestSuite) TestOpenParallel(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(value, checker.DeepEquals, value2)
 
-	err = parallelMap.EndParallelMode()
-	c.Assert(err, IsNil)
-	err = parallelMap.EndParallelMode()
-	c.Assert(err, Not(IsNil))
+	parallelMap.EndParallelMode()
 }
 
 func (s *BPFPrivilegedTestSuite) TestBasicManipulation(c *C) {


### PR DESCRIPTION
The error was printed when the ipcache map did not previously exist. Inability
to enter parallel mode is already logged as an error when the map is opened,
there is no need to attempt printing another warning or error when closing the
map.

Fixes: #7622

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7644)
<!-- Reviewable:end -->
