### PR TITLE
agent: Fix --contrack-gc-interval option

### DIFF
--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1205,9 +1205,8 @@ func (c *DaemonConfig) Populate() {
 		c.LogOpt = m
 	}
 
-	if viper.IsSet(ConntrackGarbageCollectorIntervalDeprecated) {
-		val := time.Duration(viper.GetInt(ConntrackGarbageCollectorIntervalDeprecated))
-		c.ConntrackGCInterval = val * time.Second
+	if val := viper.GetInt(ConntrackGarbageCollectorIntervalDeprecated); val != 0 {
+		c.ConntrackGCInterval = time.Duration(val) * time.Second
 	} else {
 		c.ConntrackGCInterval = viper.GetDuration(ConntrackGCInterval)
 	}


### PR DESCRIPTION
The option was always ignored

Fixes: #7649
Fixes: df8582d16e5 ("datapath: Optimize connection-tracking GC interval")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7650)
<!-- Reviewable:end -->
