### PR TITLE
Pr/v1.5 backports 2019 04 09

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -15,108 +15,108 @@ cilium-agent [flags]
 ### Options
 
 ```
-      --access-log string                           Path to access log of supported L7 requests observed
-      --agent-labels strings                        Additional labels to identify this agent
-      --allow-localhost string                      Policy when to allow local stack to reach local endpoints { auto | always | policy } (default "auto")
-      --auto-direct-node-routes                     Enable automatic L2 routing between nodes
-      --bpf-compile-debug                           Enable debugging of the BPF compilation process
-      --bpf-ct-global-any-max int                   Maximum number of entries in non-TCP CT table (default 262144)
-      --bpf-ct-global-tcp-max int                   Maximum number of entries in TCP CT table (default 1000000)
-      --bpf-root string                             Path to BPF filesystem
-      --cgroup-root string                          Path to Cgroup2 filesystem
-      --cluster-id int                              Unique identifier of the cluster
-      --cluster-name string                         Name of the cluster (default "default")
-      --clustermesh-config string                   Path to the ClusterMesh configuration directory
-      --config string                               Configuration file (default "$HOME/ciliumd.yaml")
-      --config-dir string                           Configuration directory that contains a file for each option
-      --conntrack-garbage-collector-interval uint   Garbage collection interval for the connection tracking table (in seconds) (default 60)
-      --container-runtime strings                   Sets the container runtime(s) used by Cilium { containerd | crio | docker | none | auto } ( "auto" uses the container runtime found in the order: "docker", "containerd", "crio" ) (default [auto])
-      --container-runtime-endpoint map              Container runtime(s) endpoint(s). (default: --container-runtime-endpoint=containerd=/var/run/containerd/containerd.sock, --container-runtime-endpoint=crio=/var/run/crio/crio.sock, --container-runtime-endpoint=docker=unix:///var/run/docker.sock) (default map[])
-      --datapath-mode string                        Datapath mode name (default "veth")
-  -D, --debug                                       Enable debugging mode
-      --debug-verbose strings                       List of enabled verbose debug groups
-  -d, --device string                               Device facing cluster/external network for direct L3 (non-overlay mode) (default "undefined")
-      --disable-conntrack                           Disable connection tracking
-      --disable-endpoint-crd                        Disable use of CiliumEndpoint CRD
-      --disable-k8s-services                        Disable east-west K8s load balancing by cilium
-  -e, --docker string                               Path to docker runtime socket (DEPRECATED: use container-runtime-endpoint instead) (default "unix:///var/run/docker.sock")
-      --enable-health-checking                      Enable connectivity health checking (default true)
-      --enable-ipsec                                Enable IPSec support
-      --enable-ipv4                                 Enable IPv4 support (default true)
-      --enable-ipv6                                 Enable IPv6 support (default true)
-      --enable-policy string                        Enable policy enforcement (default "default")
-      --enable-tracing                              Enable tracing while determining policy (debugging)
-      --encrypt-interface string                    Transparent encryption interface
-      --endpoint-queue-size int                     size of EventQueue per-endpoint (default 25)
-      --envoy-log string                            Path to a separate Envoy log file, if any
-      --fixed-identity-mapping map                  Key-value for the fixed identity mapping which allows to use reserved label for fixed identities (default map[])
-      --flannel-manage-existing-containers          Installs a BPF program to allow for policy enforcement in already running containers managed by Flannel. Require Cilium to be running in the hostPID.
-      --flannel-master-device string                Installs a BPF program to allow for policy enforcement in the given network interface. Allows to run Cilium on top of other CNI plugins that provide networking, e.g. flannel, where for flannel, this value should be set with 'cni0'. [EXPERIMENTAL]
-      --flannel-uninstall-on-exit                   When used along the flannel-master-device flag, it cleans up all BPF programs installed when Cilium agent is terminated.
-  -h, --help                                        help for cilium-agent
-      --http-idle-timeout uint                      Time after which a non-gRPC HTTP stream is considered failed unless traffic in the stream has been processed (in seconds); defaults to 0 (unlimited)
-      --http-max-grpc-timeout uint                  Time after which a forwarded gRPC request is considered failed unless completed (in seconds). A "grpc-timeout" header may override this with a shorter value; defaults to 0 (unlimited)
-      --http-request-timeout uint                   Time after which a forwarded HTTP request is considered failed unless completed (in seconds); Use 0 for unlimited (default 3600)
-      --http-retry-count uint                       Number of retries performed after a forwarded request attempt fails (default 3)
-      --http-retry-timeout uint                     Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
-      --identity-change-grace-period duration       Time to wait before using new identity on endpoint identity change (default 5s)
-      --install-iptables-rules                      Install base iptables rules for cilium to mainly interact with kube-proxy (and masquerading) (default true)
-      --ipsec-key-file string                       Path to IPSec key file
-      --ipv4-cluster-cidr-mask-size int             Mask size for the cluster wide CIDR (default 8)
-      --ipv4-node string                            IPv4 address of node (default "auto")
-      --ipv4-range string                           Per-node IPv4 endpoint prefix, e.g. 10.16.0.0/16 (default "auto")
-      --ipv4-service-range string                   Kubernetes IPv4 services CIDR if not inside cluster prefix (default "auto")
-      --ipv6-cluster-alloc-cidr string              IPv6 /64 CIDR used to allocate per node endpoint /96 CIDR (default "f00d::/64")
-      --ipv6-node string                            IPv6 address of node (default "auto")
-      --ipv6-range string                           Per-node IPv6 endpoint prefix, must be /96, e.g. fd02:1:1::/96 (default "auto")
-      --ipv6-service-range string                   Kubernetes IPv6 services CIDR if not inside cluster prefix (default "auto")
-      --ipvlan-master-device string                 Device facing external network acting as ipvlan master (default "undefined")
-      --k8s-api-server string                       Kubernetes api address server (for https use --k8s-kubeconfig-path instead)
-      --k8s-kubeconfig-path string                  Absolute path of the kubernetes kubeconfig file
-      --k8s-require-ipv4-pod-cidr                   Require IPv4 PodCIDR to be specified in node resource
-      --k8s-require-ipv6-pod-cidr                   Require IPv6 PodCIDR to be specified in node resource
-      --k8s-watcher-endpoint-selector string        K8s endpoint watcher will watch for these k8s endpoints (default "metadata.name!=kube-scheduler,metadata.name!=kube-controller-manager,metadata.name!=etcd-operator,metadata.name!=gcp-controller-manager")
-      --k8s-watcher-queue-size uint                 Queue size used to serialize each k8s event type (default 1024)
-      --keep-bpf-templates                          Do not restore BPF template files from binary
-      --keep-config                                 When restoring state, keeps containers' configuration in place
-      --kvstore string                              Key-value store type
-      --kvstore-opt map                             Key-value store options (default map[])
-      --kvstore-periodic-sync duration              Periodic KVstore synchronization interval (default 5m0s)
-      --label-prefix-file string                    Valid label prefixes file path
-      --labels strings                              List of label prefixes used to determine identity of an endpoint
-      --lb string                                   Enables load balancer mode where load balancer bpf program is attached to the given interface
-      --lib-dir string                              Directory path to store runtime build environment (default "/var/lib/cilium")
-      --log-driver strings                          Logging endpoints to use for example syslog
-      --log-opt map                                 Log driver options for cilium (default map[])
-      --log-system-load                             Enable periodic logging of system load
-      --masquerade                                  Masquerade packets from endpoints leaving the host (default true)
-      --monitor-aggregation string                  Level of monitor aggregation for traces from the datapath (default "None")
-      --monitor-queue-size int                      Size of the event queue when reading monitor events (default 32768)
-      --mtu int                                     Overwrite auto-detected MTU of underlying network
-      --nat46-range string                          IPv6 prefix to map IPv4 addresses to (default "0:0:0:0:0:FFFF::/96")
-      --policy-queue-size int                       size of queues for policy-related events (default 100)
-      --pprof                                       Enable serving the pprof debugging API
-      --preallocate-bpf-maps                        Enable BPF map pre-allocation (default true)
-      --prefilter-device string                     Device facing external network for XDP prefiltering (default "undefined")
-      --prefilter-mode string                       Prefilter mode { native | generic } (default: native) (default "native")
-      --prepend-iptables-chains                     Prepend custom iptables chains instead of appending (default true)
-      --prometheus-serve-addr string                IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
-      --proxy-connect-timeout uint                  Time after which a TCP connect attempt is considered failed unless completed (in seconds) (default 1)
-      --restore                                     Restores state, if possible, from previous daemon (default true)
-      --sidecar-istio-proxy-image string            Regular expression matching compatible Istio sidecar istio-proxy container image names (default "cilium/istio_proxy")
-      --single-cluster-route                        Use a single cluster route instead of per node routes
-      --socket-path string                          Sets daemon's socket path to listen for connections (default "/var/run/cilium/cilium.sock")
-      --sockops-enable                              Enable sockops when kernel supported
-      --state-dir string                            Directory path to store runtime state (default "/var/run/cilium")
-      --tofqdns-dns-reject-response-code string     DNS response code for rejecting DNS requests, available options are '[nameError refused]' (default "refused")
-      --tofqdns-enable-poller                       Enable proactive polling of DNS names in toFQDNs.matchName rules.
-      --tofqdns-enable-poller-events                Emit DNS responses seen by the DNS poller as Monitor events, if the poller is enabled. (default true)
-      --tofqdns-endpoint-max-ip-per-hostname int    Maximum number of IPs to maintain per FQDN name for each endpoint (default 50)
-      --tofqdns-min-ttl int                         The minimum time, in seconds, to use DNS data for toFQDNs policies. (default 3600 when --tofqdns-enable-poller, 604800 otherwise)
-      --tofqdns-pre-cache string                    DNS cache data at this path is preloaded on agent startup
-      --tofqdns-proxy-port int                      Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port.
-      --trace-payloadlen int                        Length of payload to capture when tracing (default 128)
-  -t, --tunnel string                               Tunnel mode {vxlan, geneve, disabled} (default "vxlan" for the "veth" datapath mode)
-      --version                                     Print version information
+      --access-log string                          Path to access log of supported L7 requests observed
+      --agent-labels strings                       Additional labels to identify this agent
+      --allow-localhost string                     Policy when to allow local stack to reach local endpoints { auto | always | policy } (default "auto")
+      --auto-direct-node-routes                    Enable automatic L2 routing between nodes
+      --bpf-compile-debug                          Enable debugging of the BPF compilation process
+      --bpf-ct-global-any-max int                  Maximum number of entries in non-TCP CT table (default 262144)
+      --bpf-ct-global-tcp-max int                  Maximum number of entries in TCP CT table (default 1000000)
+      --bpf-root string                            Path to BPF filesystem
+      --cgroup-root string                         Path to Cgroup2 filesystem
+      --cluster-id int                             Unique identifier of the cluster
+      --cluster-name string                        Name of the cluster (default "default")
+      --clustermesh-config string                  Path to the ClusterMesh configuration directory
+      --config string                              Configuration file (default "$HOME/ciliumd.yaml")
+      --config-dir string                          Configuration directory that contains a file for each option
+      --conntrack-gc-interval duration             Overwrite the connection-tracking garbage collection interval
+      --container-runtime strings                  Sets the container runtime(s) used by Cilium { containerd | crio | docker | none | auto } ( "auto" uses the container runtime found in the order: "docker", "containerd", "crio" ) (default [auto])
+      --container-runtime-endpoint map             Container runtime(s) endpoint(s). (default: --container-runtime-endpoint=containerd=/var/run/containerd/containerd.sock, --container-runtime-endpoint=crio=/var/run/crio/crio.sock, --container-runtime-endpoint=docker=unix:///var/run/docker.sock) (default map[])
+      --datapath-mode string                       Datapath mode name (default "veth")
+  -D, --debug                                      Enable debugging mode
+      --debug-verbose strings                      List of enabled verbose debug groups
+  -d, --device string                              Device facing cluster/external network for direct L3 (non-overlay mode) (default "undefined")
+      --disable-conntrack                          Disable connection tracking
+      --disable-endpoint-crd                       Disable use of CiliumEndpoint CRD
+      --disable-k8s-services                       Disable east-west K8s load balancing by cilium
+  -e, --docker string                              Path to docker runtime socket (DEPRECATED: use container-runtime-endpoint instead) (default "unix:///var/run/docker.sock")
+      --enable-health-checking                     Enable connectivity health checking (default true)
+      --enable-ipsec                               Enable IPSec support
+      --enable-ipv4                                Enable IPv4 support (default true)
+      --enable-ipv6                                Enable IPv6 support (default true)
+      --enable-policy string                       Enable policy enforcement (default "default")
+      --enable-tracing                             Enable tracing while determining policy (debugging)
+      --encrypt-interface string                   Transparent encryption interface
+      --endpoint-queue-size int                    size of EventQueue per-endpoint (default 25)
+      --envoy-log string                           Path to a separate Envoy log file, if any
+      --fixed-identity-mapping map                 Key-value for the fixed identity mapping which allows to use reserved label for fixed identities (default map[])
+      --flannel-manage-existing-containers         Installs a BPF program to allow for policy enforcement in already running containers managed by Flannel. Require Cilium to be running in the hostPID.
+      --flannel-master-device string               Installs a BPF program to allow for policy enforcement in the given network interface. Allows to run Cilium on top of other CNI plugins that provide networking, e.g. flannel, where for flannel, this value should be set with 'cni0'. [EXPERIMENTAL]
+      --flannel-uninstall-on-exit                  When used along the flannel-master-device flag, it cleans up all BPF programs installed when Cilium agent is terminated.
+  -h, --help                                       help for cilium-agent
+      --http-idle-timeout uint                     Time after which a non-gRPC HTTP stream is considered failed unless traffic in the stream has been processed (in seconds); defaults to 0 (unlimited)
+      --http-max-grpc-timeout uint                 Time after which a forwarded gRPC request is considered failed unless completed (in seconds). A "grpc-timeout" header may override this with a shorter value; defaults to 0 (unlimited)
+      --http-request-timeout uint                  Time after which a forwarded HTTP request is considered failed unless completed (in seconds); Use 0 for unlimited (default 3600)
+      --http-retry-count uint                      Number of retries performed after a forwarded request attempt fails (default 3)
+      --http-retry-timeout uint                    Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
+      --identity-change-grace-period duration      Time to wait before using new identity on endpoint identity change (default 5s)
+      --install-iptables-rules                     Install base iptables rules for cilium to mainly interact with kube-proxy (and masquerading) (default true)
+      --ipsec-key-file string                      Path to IPSec key file
+      --ipv4-cluster-cidr-mask-size int            Mask size for the cluster wide CIDR (default 8)
+      --ipv4-node string                           IPv4 address of node (default "auto")
+      --ipv4-range string                          Per-node IPv4 endpoint prefix, e.g. 10.16.0.0/16 (default "auto")
+      --ipv4-service-range string                  Kubernetes IPv4 services CIDR if not inside cluster prefix (default "auto")
+      --ipv6-cluster-alloc-cidr string             IPv6 /64 CIDR used to allocate per node endpoint /96 CIDR (default "f00d::/64")
+      --ipv6-node string                           IPv6 address of node (default "auto")
+      --ipv6-range string                          Per-node IPv6 endpoint prefix, must be /96, e.g. fd02:1:1::/96 (default "auto")
+      --ipv6-service-range string                  Kubernetes IPv6 services CIDR if not inside cluster prefix (default "auto")
+      --ipvlan-master-device string                Device facing external network acting as ipvlan master (default "undefined")
+      --k8s-api-server string                      Kubernetes api address server (for https use --k8s-kubeconfig-path instead)
+      --k8s-kubeconfig-path string                 Absolute path of the kubernetes kubeconfig file
+      --k8s-require-ipv4-pod-cidr                  Require IPv4 PodCIDR to be specified in node resource
+      --k8s-require-ipv6-pod-cidr                  Require IPv6 PodCIDR to be specified in node resource
+      --k8s-watcher-endpoint-selector string       K8s endpoint watcher will watch for these k8s endpoints (default "metadata.name!=kube-scheduler,metadata.name!=kube-controller-manager,metadata.name!=etcd-operator,metadata.name!=gcp-controller-manager")
+      --k8s-watcher-queue-size uint                Queue size used to serialize each k8s event type (default 1024)
+      --keep-bpf-templates                         Do not restore BPF template files from binary
+      --keep-config                                When restoring state, keeps containers' configuration in place
+      --kvstore string                             Key-value store type
+      --kvstore-opt map                            Key-value store options (default map[])
+      --kvstore-periodic-sync duration             Periodic KVstore synchronization interval (default 5m0s)
+      --label-prefix-file string                   Valid label prefixes file path
+      --labels strings                             List of label prefixes used to determine identity of an endpoint
+      --lb string                                  Enables load balancer mode where load balancer bpf program is attached to the given interface
+      --lib-dir string                             Directory path to store runtime build environment (default "/var/lib/cilium")
+      --log-driver strings                         Logging endpoints to use for example syslog
+      --log-opt map                                Log driver options for cilium (default map[])
+      --log-system-load                            Enable periodic logging of system load
+      --masquerade                                 Masquerade packets from endpoints leaving the host (default true)
+      --monitor-aggregation string                 Level of monitor aggregation for traces from the datapath (default "None")
+      --monitor-queue-size int                     Size of the event queue when reading monitor events (default 32768)
+      --mtu int                                    Overwrite auto-detected MTU of underlying network
+      --nat46-range string                         IPv6 prefix to map IPv4 addresses to (default "0:0:0:0:0:FFFF::/96")
+      --policy-queue-size int                      size of queues for policy-related events (default 100)
+      --pprof                                      Enable serving the pprof debugging API
+      --preallocate-bpf-maps                       Enable BPF map pre-allocation (default true)
+      --prefilter-device string                    Device facing external network for XDP prefiltering (default "undefined")
+      --prefilter-mode string                      Prefilter mode { native | generic } (default: native) (default "native")
+      --prepend-iptables-chains                    Prepend custom iptables chains instead of appending (default true)
+      --prometheus-serve-addr string               IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
+      --proxy-connect-timeout uint                 Time after which a TCP connect attempt is considered failed unless completed (in seconds) (default 1)
+      --restore                                    Restores state, if possible, from previous daemon (default true)
+      --sidecar-istio-proxy-image string           Regular expression matching compatible Istio sidecar istio-proxy container image names (default "cilium/istio_proxy")
+      --single-cluster-route                       Use a single cluster route instead of per node routes
+      --socket-path string                         Sets daemon's socket path to listen for connections (default "/var/run/cilium/cilium.sock")
+      --sockops-enable                             Enable sockops when kernel supported
+      --state-dir string                           Directory path to store runtime state (default "/var/run/cilium")
+      --tofqdns-dns-reject-response-code string    DNS response code for rejecting DNS requests, available options are '[nameError refused]' (default "refused")
+      --tofqdns-enable-poller                      Enable proactive polling of DNS names in toFQDNs.matchName rules.
+      --tofqdns-enable-poller-events               Emit DNS responses seen by the DNS poller as Monitor events, if the poller is enabled. (default true)
+      --tofqdns-endpoint-max-ip-per-hostname int   Maximum number of IPs to maintain per FQDN name for each endpoint (default 50)
+      --tofqdns-min-ttl int                        The minimum time, in seconds, to use DNS data for toFQDNs policies. (default 3600 when --tofqdns-enable-poller, 604800 otherwise)
+      --tofqdns-pre-cache string                   DNS cache data at this path is preloaded on agent startup
+      --tofqdns-proxy-port int                     Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port.
+      --trace-payloadlen int                       Length of payload to capture when tracing (default 128)
+  -t, --tunnel string                              Tunnel mode {vxlan, geneve, disabled} (default "vxlan" for the "veth" datapath mode)
+      --version                                    Print version information
 ```
 

--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -265,6 +265,13 @@ Annotations:
 1.5 Upgrade Notes
 -----------------
 
+New Default Values
+~~~~~~~~~~~~~~~~~~
+
+ * The connection-tracking garbage collector intervals is now 12 hours when
+   using LRU maps (newer kernels) and 15 minutes an all older kernels. The
+   interval can be overwritten with the option ``--conntrack-gc-interval``.
+
 .. _1.5_new_options:
 
 New ConfigMap Options
@@ -276,6 +283,11 @@ New ConfigMap Options
 
 Deprecated Options
 ~~~~~~~~~~~~~~~~~~
+
+  * ``--conntrack-garbage-collector-interval`` has been deprecated. Please
+    use the option ``--conntrack-gc-interval`` which parses a duration as
+    string instead of a integer in seconds. Support for the deprecated option
+    will be removed in 1.6.
 
   * ``legacy-host-allows-world`` option is now removed as planned.
 

--- a/Documentation/kubernetes/configuration.rst
+++ b/Documentation/kubernetes/configuration.rst
@@ -26,13 +26,6 @@ accordingly with your changes.
 * ``clean-cilium-state`` - Removes any Cilium state, e.g. BPF policy maps,
   before starting the Cilium agent;
 
-* ``legacy-host-allows-world`` - If true, the policy with the entity
-  ``reserved:host`` allows traffic from ``world``. If false, the policy needs
-  to explicitly have the entity ``reserved:world`` to allow traffic from
-  ``world``. It is recommended to set it to false. This option provides
-  compatibility with Cilium 1.0 which was not able to differentiate between
-  NodePort traffic and traffic from the host.
-
 Any changes that you perform in the Cilium `ConfigMap` and in
 ``cilium-etcd-secrets`` ``Secret`` will require you to restart any existing
 Cilium pods in order for them to pick the latest configuration.
@@ -69,8 +62,6 @@ enabled.
       enable-ipv4: "true"
       # If you want to clean cilium state; change this value to true
       clean-cilium-state: "false"
-      legacy-host-allows-world: "false"
-
 
 CNI
 ===

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1030,17 +1030,6 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 			log.Info("k8s mode: Allowing localhost to reach local endpoints")
 		}
 
-		// In Cilium 1.0, due to limitations on the data path, traffic
-		// from the outside world on ingress was treated as though it
-		// was from the host for policy purposes. In order to not break
-		// existing policies, this option retains the behavior.
-		if option.Config.K8sLegacyHostAllowsWorld == "true" {
-			log.Warn("k8s mode: Configuring ingress policy for host to also allow from world. This option will be removed in Cilium 1.5. For more information, see https://cilium.link/host-vs-world")
-			option.Config.HostAllowsWorld = true
-		} else {
-			option.Config.HostAllowsWorld = false
-		}
-
 		bootstrapStats.k8sInit.End(true)
 	}
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1325,7 +1325,7 @@ func (d *Daemon) attachExistingInfraContainers() {
 			continue
 		}
 		log.Debugf("Adding endpoint %+v", epModel)
-		ep, err := d.createEndpoint(context.Background(), epModel)
+		ep, _, err := d.createEndpoint(context.Background(), epModel)
 		if err != nil {
 			log.WithError(err).WithField(logfields.ContainerID, containerID).
 				Warning("Unable to attach existing infra container")

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -1106,9 +1106,7 @@ func waitForHostDeviceWhenReady(ifaceName string) error {
 }
 
 func endParallelMapMode() {
-	if err := ipcachemap.IPCache.EndParallelMode(); err != nil {
-		log.WithError(err).Error("Unable to end parallel mode of ipcache map")
-	}
+	ipcachemap.IPCache.EndParallelMode()
 }
 
 func runDaemon() {

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -510,10 +510,6 @@ func init() {
 	flags.String(option.K8sKubeConfigPath, "", "Absolute path of the kubernetes kubeconfig file")
 	option.BindEnv(option.K8sKubeConfigPath)
 
-	option.BindEnv(option.K8sLegacyHostAllowsWorld)
-	// This needs to be set manually for backward compatibility
-	viper.BindEnv(option.K8sLegacyHostAllowsWorld, "CILIUM_LEGACY_HOST_ALLOWS_WORLD")
-
 	flags.String(option.K8sNamespaceName, "", "Name of the Kubernetes namespace in which Cilium is deployed in")
 	flags.MarkHidden(option.K8sNamespaceName)
 	option.BindEnv(option.K8sNamespaceName)

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -376,8 +376,12 @@ func init() {
 	flags.String(option.ConfigDir, "", `Configuration directory that contains a file for each option`)
 	option.BindEnv(option.ConfigDir)
 
-	flags.Uint(option.ConntrackGarbageCollectorInterval, 60, "Garbage collection interval for the connection tracking table (in seconds)")
-	option.BindEnv(option.ConntrackGarbageCollectorInterval)
+	flags.Uint(option.ConntrackGarbageCollectorIntervalDeprecated, 0, "Garbage collection interval for the connection tracking table (in seconds)")
+	flags.MarkDeprecated(option.ConntrackGarbageCollectorIntervalDeprecated, fmt.Sprintf("please use --%s", option.ConntrackGCInterval))
+	option.BindEnv(option.ConntrackGarbageCollectorIntervalDeprecated)
+
+	flags.Duration(option.ConntrackGCInterval, time.Duration(0), "Overwrite the connection-tracking garbage collection interval")
+	option.BindEnv(option.ConntrackGCInterval)
 
 	flags.StringSlice(option.ContainerRuntime, []string{"auto"}, `Sets the container runtime(s) used by Cilium { containerd | crio | docker | none | auto } ( "auto" uses the container runtime found in the order: "docker", "containerd", "crio" )`)
 	option.BindEnv(option.ContainerRuntime)
@@ -1153,7 +1157,6 @@ func runDaemon() {
 	bootstrapStats.enableConntrack.Start()
 	log.Info("Starting connection tracking garbage collector")
 	endpointmanager.EnableConntrackGC(option.Config.EnableIPv4, option.Config.EnableIPv6,
-		option.Config.ConntrackGarbageCollectorInterval,
 		restoredEndpoints.restored)
 	bootstrapStats.enableConntrack.End(true)
 

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -192,8 +192,8 @@ func (d *Daemon) createEndpoint(ctx context.Context, epTemplate *models.Endpoint
 	infoLabels := labels.NewLabelsFromModel([]string{})
 
 	if len(addLabels) > 0 {
-		addLabels, _, ok := checkLabels(addLabels, nil)
-		if !ok {
+		addLabels, _, _ = checkLabels(addLabels, nil)
+		if len(addLabels) == 0 {
 			return invalidDataError(ep, fmt.Errorf("no valid labels provided"))
 		}
 		if lbls := addLabels.FindReserved(); lbls != nil {

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -284,7 +284,7 @@ func (d *Daemon) createEndpoint(ctx context.Context, epTemplate *models.Endpoint
 		return ep, 0, nil
 	}
 
-	logger.Debug("Synchronously waiting for endpoint to regenerate")
+	logger.Info("Waiting for endpoint to be generated")
 
 	// Default timeout for PUT /endpoint/{id} is 60 seconds, so put timeout
 	// in this function a bit below that timeout. If the timeout for clients

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -192,12 +192,13 @@ func (d *Daemon) createEndpoint(ctx context.Context, epTemplate *models.Endpoint
 	infoLabels := labels.NewLabelsFromModel([]string{})
 
 	if len(addLabels) > 0 {
+		if lbls := addLabels.FindReserved(); lbls != nil {
+			return invalidDataError(ep, fmt.Errorf("not allowed to add reserved labels: %s", lbls))
+		}
+
 		addLabels, _, _ = checkLabels(addLabels, nil)
 		if len(addLabels) == 0 {
 			return invalidDataError(ep, fmt.Errorf("no valid labels provided"))
-		}
-		if lbls := addLabels.FindReserved(); lbls != nil {
-			return invalidDataError(ep, fmt.Errorf("not allowed to add reserved labels: %s", lbls))
 		}
 	}
 

--- a/daemon/endpoint_test.go
+++ b/daemon/endpoint_test.go
@@ -51,21 +51,23 @@ func getEPTemplate(c *C, d *Daemon) *models.EndpointChangeRequest {
 func (ds *DaemonSuite) TestEndpointAddReservedLabel(c *C) {
 	epTemplate := getEPTemplate(c, ds.d)
 	epTemplate.Labels = []string{"reserved:world"}
-	_, err := ds.d.createEndpoint(context.TODO(), epTemplate)
+	_, code, err := ds.d.createEndpoint(context.TODO(), epTemplate)
 	c.Assert(err, Not(IsNil))
+	c.Assert(code, Equals, apiEndpoint.PutEndpointIDInvalidCode)
 }
 
 func (ds *DaemonSuite) TestEndpointAddInvalidLabel(c *C) {
 	epTemplate := getEPTemplate(c, ds.d)
 	epTemplate.Labels = []string{"reserved:foo"}
-	_, err := ds.d.createEndpoint(context.TODO(), epTemplate)
+	_, code, err := ds.d.createEndpoint(context.TODO(), epTemplate)
 	c.Assert(err, Not(IsNil))
+	c.Assert(code, Equals, apiEndpoint.PutEndpointIDInvalidCode)
 }
 
 func (ds *DaemonSuite) TestEndpointAddNoLabels(c *C) {
 	// Create the endpoint without any labels.
 	epTemplate := getEPTemplate(c, ds.d)
-	_, err := ds.d.createEndpoint(context.TODO(), epTemplate)
+	_, _, err := ds.d.createEndpoint(context.TODO(), epTemplate)
 	c.Assert(err, IsNil)
 
 	expectedLabels := labels.Labels{

--- a/examples/kubernetes/1.10/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-containerd-ds.yaml
@@ -82,9 +82,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -99,9 +99,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.10/cilium-containerd.yaml
+++ b/examples/kubernetes/1.10/cilium-containerd.yaml
@@ -235,9 +235,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -252,9 +252,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.10/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-crio-ds.yaml
@@ -90,9 +90,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -107,9 +107,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -243,9 +243,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -260,9 +260,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.10/cilium-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-ds.yaml
@@ -89,9 +89,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -106,9 +106,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.10/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.10/cilium-external-etcd.yaml
@@ -242,9 +242,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -259,9 +259,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.10/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-minikube-ds.yaml
@@ -89,9 +89,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -106,9 +106,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.10/cilium-minikube.yaml
+++ b/examples/kubernetes/1.10/cilium-minikube.yaml
@@ -242,9 +242,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -259,9 +259,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.10/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.10/cilium-with-node-init.yaml
@@ -242,9 +242,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -259,9 +259,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -242,9 +242,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -259,9 +259,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.11/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-containerd-ds.yaml
@@ -82,9 +82,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -99,9 +99,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.11/cilium-containerd.yaml
+++ b/examples/kubernetes/1.11/cilium-containerd.yaml
@@ -235,9 +235,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -252,9 +252,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.11/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-crio-ds.yaml
@@ -90,9 +90,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -107,9 +107,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -243,9 +243,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -260,9 +260,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -89,9 +89,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -106,9 +106,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.11/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.11/cilium-external-etcd.yaml
@@ -242,9 +242,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -259,9 +259,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.11/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-minikube-ds.yaml
@@ -89,9 +89,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -106,9 +106,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.11/cilium-minikube.yaml
+++ b/examples/kubernetes/1.11/cilium-minikube.yaml
@@ -242,9 +242,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -259,9 +259,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.11/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.11/cilium-with-node-init.yaml
@@ -242,9 +242,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -259,9 +259,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -242,9 +242,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -259,9 +259,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.12/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-containerd-ds.yaml
@@ -82,9 +82,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -99,9 +99,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.12/cilium-containerd.yaml
+++ b/examples/kubernetes/1.12/cilium-containerd.yaml
@@ -235,9 +235,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -252,9 +252,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.12/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-crio-ds.yaml
@@ -90,9 +90,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -107,9 +107,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -243,9 +243,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -260,9 +260,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.12/cilium-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-ds.yaml
@@ -89,9 +89,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -106,9 +106,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.12/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.12/cilium-external-etcd.yaml
@@ -242,9 +242,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -259,9 +259,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.12/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-minikube-ds.yaml
@@ -89,9 +89,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -106,9 +106,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.12/cilium-minikube.yaml
+++ b/examples/kubernetes/1.12/cilium-minikube.yaml
@@ -242,9 +242,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -259,9 +259,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.12/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.12/cilium-with-node-init.yaml
@@ -242,9 +242,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -259,9 +259,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -242,9 +242,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -259,9 +259,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.13/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-containerd-ds.yaml
@@ -82,9 +82,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -99,9 +99,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.13/cilium-containerd.yaml
+++ b/examples/kubernetes/1.13/cilium-containerd.yaml
@@ -235,9 +235,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -252,9 +252,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.13/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-crio-ds.yaml
@@ -90,9 +90,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -107,9 +107,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.13/cilium-crio.yaml
+++ b/examples/kubernetes/1.13/cilium-crio.yaml
@@ -243,9 +243,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -260,9 +260,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.13/cilium-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-ds.yaml
@@ -89,9 +89,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -106,9 +106,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.13/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.13/cilium-external-etcd.yaml
@@ -242,9 +242,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -259,9 +259,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.13/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-minikube-ds.yaml
@@ -89,9 +89,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -106,9 +106,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.13/cilium-minikube.yaml
+++ b/examples/kubernetes/1.13/cilium-minikube.yaml
@@ -242,9 +242,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -259,9 +259,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.13/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.13/cilium-with-node-init.yaml
@@ -242,9 +242,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -259,9 +259,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.13/cilium.yaml
+++ b/examples/kubernetes/1.13/cilium.yaml
@@ -242,9 +242,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -259,9 +259,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.14/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.14/cilium-containerd-ds.yaml
@@ -82,9 +82,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -99,9 +99,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.14/cilium-containerd.yaml
+++ b/examples/kubernetes/1.14/cilium-containerd.yaml
@@ -235,9 +235,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -252,9 +252,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.14/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.14/cilium-crio-ds.yaml
@@ -90,9 +90,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -107,9 +107,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.14/cilium-crio.yaml
+++ b/examples/kubernetes/1.14/cilium-crio.yaml
@@ -243,9 +243,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -260,9 +260,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.14/cilium-ds.yaml
+++ b/examples/kubernetes/1.14/cilium-ds.yaml
@@ -89,9 +89,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -106,9 +106,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.14/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.14/cilium-external-etcd.yaml
@@ -242,9 +242,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -259,9 +259,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.14/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.14/cilium-minikube-ds.yaml
@@ -89,9 +89,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -106,9 +106,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.14/cilium-minikube.yaml
+++ b/examples/kubernetes/1.14/cilium-minikube.yaml
@@ -242,9 +242,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -259,9 +259,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.14/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.14/cilium-with-node-init.yaml
@@ -242,9 +242,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -259,9 +259,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/1.14/cilium.yaml
+++ b/examples/kubernetes/1.14/cilium.yaml
@@ -242,9 +242,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -259,9 +259,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/templates/v1/cilium-containerd-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-containerd-ds.yaml.sed
@@ -82,9 +82,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -99,9 +99,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
@@ -90,9 +90,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -107,9 +107,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
@@ -89,9 +89,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -106,9 +106,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/examples/kubernetes/templates/v1/cilium-minikube-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-minikube-ds.yaml.sed
@@ -89,9 +89,9 @@ spec:
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
-          periodSeconds: 10
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         name: cilium-agent
         ports:
         - containerPort: 9090
@@ -106,9 +106,9 @@ spec:
             - --brief
           failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         securityContext:
           capabilities:
             add:

--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -315,18 +315,14 @@ func (m *Map) setPathIfUnset() error {
 }
 
 // EndParallelMode ends the parallel mode of a map
-func (m *Map) EndParallelMode() error {
+func (m *Map) EndParallelMode() {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
-	if !m.inParallelMode {
-		return fmt.Errorf("map is not in parallel mode")
+	if m.inParallelMode {
+		m.inParallelMode = false
+		m.scopedLogger().Debug("End of parallel mode")
 	}
-
-	m.inParallelMode = false
-	m.scopedLogger().Debug("End of parallel mode")
-
-	return nil
 }
 
 // OpenParallel is similar to OpenOrCreate() but prepares the existing map to

--- a/pkg/bpf/map_linux_test.go
+++ b/pkg/bpf/map_linux_test.go
@@ -217,10 +217,7 @@ func (s *BPFPrivilegedTestSuite) TestOpenParallel(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(value, checker.DeepEquals, value2)
 
-	err = parallelMap.EndParallelMode()
-	c.Assert(err, IsNil)
-	err = parallelMap.EndParallelMode()
-	c.Assert(err, Not(IsNil))
+	parallelMap.EndParallelMode()
 }
 
 func (s *BPFPrivilegedTestSuite) TestBasicManipulation(c *C) {

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -424,7 +424,6 @@ func loadIPSecKeys(r io.Reader) (uint8, error) {
 			ipSecKeysGlobal[""] = ipSecKey
 		}
 
-		scopedLog.WithError(err).Warning("newtimer: oldSPI %u new spi %u", oldSpi, ipSecKey.Spi)
 		// Detect a version change and call cleanup routine to remove old
 		// keys after a timeout period. We also want to ensure on restart
 		// we remove any stale keys for example when a restart changes keys.

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -103,12 +103,12 @@ func updateTunnelMapping(oldCIDR, newCIDR *cidr.CIDR, oldIP, newIP net.IP, first
 // CIDR and node IP to a new node CIDR and node IP requires to insert/update
 // the new node CIDR.
 func cidrNodeMappingUpdateRequired(oldCIDR, newCIDR *cidr.CIDR, oldIP, newIP net.IP, oldKey, newKey uint8) bool {
-	// node with single IP stack could have nil old and new CIDR
-	if oldCIDR == nil && newCIDR == nil {
+	// No CIDR provided
+	if newCIDR == nil {
 		return false
 	}
 	// Newly announced CIDR
-	if newCIDR != nil && oldCIDR == nil {
+	if oldCIDR == nil {
 		return true
 	}
 
@@ -122,7 +122,7 @@ func cidrNodeMappingUpdateRequired(oldCIDR, newCIDR *cidr.CIDR, oldIP, newIP net
 	}
 
 	// CIDR changed
-	return oldCIDR != nil && newCIDR != nil && !oldCIDR.IP.Equal(newCIDR.IP)
+	return !oldCIDR.IP.Equal(newCIDR.IP)
 }
 
 func deleteTunnelMapping(oldCIDR *cidr.CIDR, quietMode bool) {

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -181,4 +181,12 @@ const (
 	// K8sWatcherEndpointSelector specifies the k8s endpoints that Cilium
 	// should watch for.
 	K8sWatcherEndpointSelector = "metadata.name!=kube-scheduler,metadata.name!=kube-controller-manager,metadata.name!=etcd-operator,metadata.name!=gcp-controller-manager"
+
+	// ConntrackGCIntervalLRU is the default connection tracking interval
+	// when using LRU maps
+	ConntrackGCIntervalLRU = 12 * time.Hour
+
+	// ConntrackGCIntervalNonLRU is the default connection tracking
+	// interval when using non-LRU maps
+	ConntrackGCIntervalNonLRU = 15 * time.Minute
 )

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1722,7 +1722,7 @@ func APICanModify(e *Endpoint) error {
 		return nil
 	}
 	if e.OpLabels.OrchestrationIdentity.IsReserved() {
-		return fmt.Errorf("Endpoint cannot be modified by API call")
+		return fmt.Errorf("endpoint may not be associated reserved labels")
 	}
 	return nil
 }

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1847,7 +1847,8 @@ func (e *Endpoint) runLabelsResolver(ctx context.Context, owner Owner, myChangeR
 	// store, do it first synchronously right now. This can reduce the number
 	// of regenerations for the endpoint during its initialization.
 	if blocking || cache.IdentityAllocationIsLocal(newLabels) {
-		scopedLog.Debug("Endpoint has reserved identity, changing synchronously")
+		scopedLog.Info("Resolving identity labels (blocking)")
+
 		err := e.identityLabelsChanged(ctx, owner, myChangeRev)
 		switch err {
 		case ErrNotAlive:
@@ -1858,6 +1859,8 @@ func (e *Endpoint) runLabelsResolver(ctx context.Context, owner Owner, myChangeR
 				scopedLog.WithError(err).Warn("Error changing endpoint identity")
 			}
 		}
+	} else {
+		scopedLog.Info("Resolving identity labels (non-blocking)")
 	}
 
 	ctrlName := fmt.Sprintf("resolve-identity-%d", e.ID)

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -450,9 +450,7 @@ func NewEndpointFromChangeModel(base *models.EndpointChangeRequest) (*Endpoint, 
 		realizedPolicy:   &policy.EndpointPolicy{},
 		controllers:      controller.NewManager(),
 	}
-	ep.UpdateLogger(nil)
 
-	ep.SetStateLocked(string(base.State), "Endpoint creation")
 	if base.Mac != "" {
 		m, err := mac.ParseMAC(base.Mac)
 		if err != nil {
@@ -488,6 +486,9 @@ func NewEndpointFromChangeModel(base *models.EndpointChangeRequest) (*Endpoint, 
 	}
 
 	ep.SetDefaultOpts(option.Config.Opts)
+
+	ep.UpdateLogger(nil)
+	ep.SetStateLocked(string(base.State), "Endpoint creation")
 
 	return ep, nil
 }

--- a/pkg/endpoint/log.go
+++ b/pkg/endpoint/log.go
@@ -44,6 +44,10 @@ func (e *Endpoint) getLogger() *logrus.Entry {
 // Logger returns a logrus object with EndpointID, ContainerID and the Endpoint
 // revision fields. The caller must specify their subsystem.
 func (e *Endpoint) Logger(subsystem string) *logrus.Entry {
+	if e == nil {
+		return log.WithField(logfields.LogSubsys, subsystem)
+	}
+
 	return e.getLogger().WithField(logfields.LogSubsys, subsystem)
 }
 

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -367,11 +367,6 @@ func doGC(m *Map, filter *GCFilter) int {
 // It returns how many items were deleted from m.
 func GC(m *Map, filter *GCFilter) int {
 	if filter.RemoveExpired {
-		// If LRUHashtable, no need to garbage collect as LRUHashtable cleans itself up.
-		// FIXME: GH-3239 LRU logic is not handling timeouts gracefully enough
-		// if m.MapInfo.MapType == bpf.MapTypeLRUHash {
-		// 	return 0
-		// }
 		t, _ := bpf.GetMtime()
 		tsec := t / 1000000000
 		filter.Time = uint32(tsec)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -180,9 +180,6 @@ const (
 	// KeepBPFTemplates do not restore BPF template files from binary
 	KeepBPFTemplates = "keep-bpf-templates"
 
-	// K8sLegacyHostAllowsWorld is the legacy option to that allows policy host to talk with world
-	K8sLegacyHostAllowsWorld = "k8s-legacy-host-allows-world"
-
 	// KVStore key-value store type
 	KVStore = "kvstore"
 
@@ -582,10 +579,6 @@ type DaemonConfig struct {
 	// values: { auto | always | policy }
 	AllowLocalhost string
 
-	// HostAllowsWorld applies the same policy to world-sourced traffic as
-	// host-sourced traffic, to provide compatibility with Cilium 1.0.
-	HostAllowsWorld bool
-
 	// StateDir is the directory where runtime state of endpoints is stored
 	StateDir string
 
@@ -753,7 +746,6 @@ type DaemonConfig struct {
 	IPv6ServiceRange              string
 	K8sAPIServer                  string
 	K8sKubeConfigPath             string
-	K8sLegacyHostAllowsWorld      string
 	K8sWatcherEndpointSelector    string
 	KVStore                       string
 	KVStoreOpt                    map[string]string
@@ -1067,7 +1059,6 @@ func ReplaceDeprecatedFields(m map[string]interface{}) {
 		"monitor-aggregation-level":   MonitorAggregationName,
 		"ct-global-max-entries-tcp":   CTMapEntriesGlobalTCPName,
 		"ct-global-max-entries-other": CTMapEntriesGlobalAnyName,
-		"legacy-host-allows-world":    K8sLegacyHostAllowsWorld,
 	}
 	for deprecatedOption, newOption := range deprecatedFields {
 		if deprecatedValue, ok := m[deprecatedOption]; ok {
@@ -1216,7 +1207,6 @@ func (c *DaemonConfig) Populate() {
 	c.HTTP403Message = viper.GetString(HTTP403Message)
 	c.DisableEnvoyVersionCheck = viper.GetBool(DisableEnvoyVersionCheck)
 	c.K8sNamespace = viper.GetString(K8sNamespaceName)
-	c.K8sLegacyHostAllowsWorld = viper.GetString(K8sLegacyHostAllowsWorld)
 	c.MaxControllerInterval = viper.GetInt(MaxCtrlIntervalName)
 	c.SidecarHTTPProxy = viper.GetBool(SidecarHTTPProxy)
 	c.CMDRefDir = viper.GetString(CMDRef)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1205,9 +1205,8 @@ func (c *DaemonConfig) Populate() {
 		c.LogOpt = m
 	}
 
-	if viper.IsSet(ConntrackGarbageCollectorIntervalDeprecated) {
-		val := time.Duration(viper.GetInt(ConntrackGarbageCollectorIntervalDeprecated))
-		c.ConntrackGCInterval = val * time.Second
+	if val := viper.GetInt(ConntrackGarbageCollectorIntervalDeprecated); val != 0 {
+		c.ConntrackGCInterval = time.Duration(val) * time.Second
 	} else {
 		c.ConntrackGCInterval = viper.GetDuration(ConntrackGCInterval)
 	}

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -73,22 +73,6 @@ type MapStateEntry struct {
 	ProxyPort uint16
 }
 
-// DetermineAllowFromWorld determines whether world should be allowed to
-// communicate with the endpoint, based on legacy Cilium 1.0 behaviour. It
-// inserts the Key corresponding to the world in the desiredPolicyKeys
-// if the legacy mode is enabled.
-//
-// This must be run after DetermineAllowLocalhost().
-//
-// For more information, see https://cilium.link/host-vs-world
-func (keys MapState) DetermineAllowFromWorld() {
-
-	_, localHostAllowed := keys[localHostKey]
-	if option.Config.HostAllowsWorld && localHostAllowed {
-		keys[worldKey] = MapStateEntry{}
-	}
-}
-
 // DetermineAllowLocalhost determines whether communication should be allowed to
 // the localhost. It inserts the Key corresponding to the localhost in
 // the desiredPolicyKeys if the endpoint is allowed to communicate with the

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -753,7 +753,6 @@ func (p *Repository) ResolvePolicy(id uint16, securityIdentity *identity.Identit
 
 	calculatedPolicy.computeDesiredL4PolicyMapEntries(identityCache)
 	calculatedPolicy.PolicyMapState.DetermineAllowLocalhost(calculatedPolicy.L4Policy)
-	calculatedPolicy.PolicyMapState.DetermineAllowFromWorld()
 
 	return calculatedPolicy, nil
 }

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -212,9 +212,6 @@ func mergeL4Ingress(ctx *SearchContext, rule api.IngressRule, ruleLabels labels.
 	endpointsWithL3Override := []api.EndpointSelector{}
 	if option.Config.AlwaysAllowLocalhost() {
 		endpointsWithL3Override = append(endpointsWithL3Override, api.ReservedEndpointSelectors[labels.IDNameHost])
-		if option.Config.HostAllowsWorld {
-			endpointsWithL3Override = append(endpointsWithL3Override, api.ReservedEndpointSelectors[labels.IDNameWorld])
-		}
 	}
 
 	for _, r := range rule.ToPorts {

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -109,6 +109,8 @@ var _ = Describe("K8sDatapathConfig", func() {
 		}
 
 		It("Check connectivity with transparent encryption and VXLAN encapsulation", func() {
+			Skip("Encryption test is currently disabled")
+
 			switch helpers.GetCurrentIntegration() {
 			case helpers.CIIntegrationFlannel:
 				Skip(fmt.Sprintf(


### PR DESCRIPTION
Applied cherry-picks:
```
vagrant@runtime1:~/go/src/github.com/cilium/cilium/contrib/backporting$ ./cherry-pick df8582d16e51792e62ef1a512a1c13a4fd6a8057
Applying: df8582d16e datapath: Optimize connection-tracking GC interval
vagrant@runtime1:~/go/src/github.com/cilium/cilium/contrib/backporting$ ./cherry-pick 789937dd8deb714b0ca07340e7280490e6999e24
Applying: 789937dd8d node/store: delete ipcache entries for node events
vagrant@runtime1:~/go/src/github.com/cilium/cilium/contrib/backporting$ ./cherry-pick 88861c3a3fe799b0d94c2c122ac04952bed25b0a
Applying: 88861c3a3f ipsec: Remove leftover warning message used for debugging
vagrant@runtime1:~/go/src/github.com/cilium/cilium/contrib/backporting$ ./cherry-pick bc47a41df190a78b4b24862bab77d0c62649e769
Applying: bc47a41df1 endpoint: Update the logger after endpoint initialization
vagrant@runtime1:~/go/src/github.com/cilium/cilium/contrib/backporting$ ./cherry-pick 6c566883af8c98b7c239b07c97bc9950d73c542e
Applying: 6c566883af endpoint: Provide clear error messages to PUT /endpoint/{id}
vagrant@runtime1:~/go/src/github.com/cilium/cilium/contrib/backporting$ ./cherry-pick 08a69803b59151f18af0ced45643f0d97bc103ba
Applying: 08a69803b5 endpoint: Correctly filter labels on endpoint creation
vagrant@runtime1:~/go/src/github.com/cilium/cilium/contrib/backporting$ ./cherry-pick 26045203f5b65b4cd6cabd689d657efef2111f39
Applying: 26045203f5 endpoint: Guarantee to reject endpoint creation with reserved labels
vagrant@runtime1:~/go/src/github.com/cilium/cilium/contrib/backporting$ ./cherry-pick 96cdb6c4a4f13ea26774c98c14040a82ac689409
Applying: 96cdb6c4a4 endpoint: Provide additional info messages while creating endpoint
vagrant@runtime1:~/go/src/github.com/cilium/cilium/contrib/backporting$ ./cherry-pick 017ce85c3af22f71d6e8380a8be7a34636723730
Applying: 017ce85c3a kubernetes: Relax readiness and liveness probe interval
vagrant@runtime1:~/go/src/github.com/cilium/cilium/contrib/backporting$ ./cherry-pick 8e74b85d72c10f3b19f4ee577f22b55703bb9978
Applying: 8e74b85d72 datapath: Fix panic when updating tunnel mapping
vagrant@runtime1:~/go/src/github.com/cilium/cilium/contrib/backporting$ ./cherry-pick 08e4dde73a327bf693422df76a67e99f5d5a8655
Applying: 08e4dde73a test: Disable flaky encapsulation encryption test
vagrant@runtime1:~/go/src/github.com/cilium/cilium/contrib/backporting$ ./cherry-pick 1591aaa74f0332af12b0eecadfeef46cc23f5643
Applying: 1591aaa74f bpf: Avoid unnecessary error when ending parallel map mode
vagrant@runtime1:~/go/src/github.com/cilium/cilium/contrib/backporting$ ./cherry-pick c054352c0b1590a4ce5ecefe49999046e7ce7595
Applying: c054352c0b agent: Fix --contrack-gc-interval option
vagrant@runtime1:~/go/src/github.com/cilium/cilium/contrib/backporting$ ./cherry-pick aacd71ef7209de51d4b04502c59ea3fd65c66548
Applying: aacd71ef72 daemon: remove host-allows-world option
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7653)
<!-- Reviewable:end -->
