### PR TITLE
kvstore: Simplify Client() blocking behavior

### DIFF
--- a/pkg/kvstore/client.go
+++ b/pkg/kvstore/client.go
@@ -16,13 +16,11 @@ package kvstore
 
 import (
 	"fmt"
-	"sync"
 )
 
 var (
 	// defaultClient is the default client initialized by initClient
 	defaultClient BackendOperations
-	once          sync.Once
 	// defaultClientSet is a channel that is closed whenever the defaultClient
 	// is set.
 	defaultClientSet = make(chan struct{})
@@ -56,9 +54,7 @@ func initClient(module backendModule, opts *ExtraOptions) error {
 
 // Client returns the global kvstore client or nil if the client is not configured yet
 func Client() BackendOperations {
-	once.Do(func() {
-		<-defaultClientSet
-	})
+	<-defaultClientSet
 	return defaultClient
 }
 


### PR DESCRIPTION
We can simply block on the channel. No need for additional sync.Once logic.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7656)
<!-- Reviewable:end -->
