### PR TITLE
Don't use local remote in check-stable script

### DIFF
--- a/contrib/backporting/check-stable
+++ b/contrib/backporting/check-stable
@@ -128,7 +128,7 @@ generate_commit_list_for_pr () {
   local entry_sub
   local upstream
 
-  remote=`git remote -v | grep "github.com.cilium/cilium" | head -n1 | cut -f1`
+  remote=`git remote -v | grep "github.com.cilium/cilium.git" | head -n1 | cut -f1`
 
   url="https://api.github.com/repos/cilium/cilium/pulls/$pr/commits"
   pr_json="$($GHCURL $url)"

--- a/contrib/backporting/cherry-pick
+++ b/contrib/backporting/cherry-pick
@@ -3,7 +3,7 @@ set -e
 
 cherry_pick () {
   CID=$1
-  REM=`git remote -v | grep "github.com.cilium/cilium" | head -n1 | cut -f1`
+  REM=`git remote -v | grep "github.com.cilium/cilium.git" | head -n1 | cut -f1`
   BRANCHES=`git branch -q -r --contains $CID $REM/master 2> /dev/null`
   if ! echo ${BRANCHES} | grep -q ".*$REM/master.*"; then
     echo "Commit $CID not in $REM/master!"


### PR DESCRIPTION
I have several local remotes set up on my machine, which helps in
parallel development of features.

When backporting, check-stable script took my local remotes instead of
github origin because path to local remote contained `github.com/cilium/cilium`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7657)
<!-- Reviewable:end -->
