### PR TITLE
allocator: Relax number of iterations in unit testing

### DIFF
--- a/pkg/kvstore/allocator/allocator_test.go
+++ b/pkg/kvstore/allocator/allocator_test.go
@@ -249,7 +249,7 @@ func testAllocator(c *C, maxID idpool.ID, allocatorName string, suffix string) {
 }
 
 func (s *AllocatorSuite) TestAllocateCached(c *C) {
-	testAllocator(c, idpool.ID(256), randomTestName(), "a") // enable use of local cache
+	testAllocator(c, idpool.ID(32), randomTestName(), "a") // enable use of local cache
 }
 
 func (s *AllocatorSuite) TestKeyToID(c *C) {


### PR DESCRIPTION
There is no functional or coverage gain by allocating 256 keys instead of 32.
It only causes the test to take longer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7660)
<!-- Reviewable:end -->
