### PR TITLE
Test: Runtime run with --device option.

### DIFF
--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -878,7 +878,7 @@ func (s *SSHMeta) ServiceDelAll() *CmdRes {
 func (s *SSHMeta) SetUpCilium() error {
 	template := `
 PATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
-CILIUM_OPTS=--kvstore consul --kvstore-opt consul.address=127.0.0.1:8500 --debug --pprof=true --log-system-load --tofqdns-enable-poller=true
+CILIUM_OPTS=--kvstore consul --kvstore-opt consul.address=127.0.0.1:8500 --debug --pprof=true --log-system-load --tofqdns-enable-poller=true --device=enp0s3
 INITSYSTEM=SYSTEMD`
 	return s.SetUpCiliumWithOptions(template)
 }
@@ -906,7 +906,7 @@ func (s *SSHMeta) SetUpCiliumWithOptions(template string) error {
 func (s *SSHMeta) SetUpCiliumWithSockops() error {
 	var config = `
 +PATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
-+CILIUM_OPTS=--sockops-enable --kvstore consul --kvstore-opt consul.address=127.0.0.1:8500 --debug --pprof=true --log-system-load --tofqdns-enable-poller=true
++CILIUM_OPTS=--sockops-enable --kvstore consul --kvstore-opt consul.address=127.0.0.1:8500 --debug --pprof=true --log-system-load --tofqdns-enable-poller=true --device=enp0s3
 +INITSYSTEM=SYSTEMD`
 
 	return s.SetUpCiliumWithOptions(config)

--- a/test/runtime/fqdn.go
+++ b/test/runtime/fqdn.go
@@ -868,7 +868,7 @@ var _ = Describe("RuntimeFQDNPolicies", func() {
 	Context("toFQDNs populates toCIDRSet when poller is disabled (data from proxy)", func() {
 		var config = `
 PATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
-CILIUM_OPTS=--kvstore consul --kvstore-opt consul.address=127.0.0.1:8500 --debug --pprof=true --log-system-load --tofqdns-enable-poller=false
+CILIUM_OPTS=--kvstore consul --kvstore-opt consul.address=127.0.0.1:8500 --debug --pprof=true --log-system-load --tofqdns-enable-poller=false --device=enp0s3
 INITSYSTEM=SYSTEMD`
 		BeforeAll(func() {
 			vm.SetUpCiliumWithOptions(config)


### PR DESCRIPTION
Due to some issues on Cilium restart, this commit changes how we setup
Cilium, and set the default device to avoid issues on startup and node
address and CIDR

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7665)
<!-- Reviewable:end -->
