### PR TITLE
agent: Delete endpoints which failed to restore synchronously

### DIFF
--- a/daemon/health.go
+++ b/daemon/health.go
@@ -98,7 +98,9 @@ func (d *Daemon) cleanupHealthEndpoint() {
 		log.Debug("Didn't find existing cilium-health endpoint to delete")
 	} else {
 		log.Debug("Removing existing cilium-health endpoint")
-		errs := d.deleteEndpointQuiet(ep, false)
+		errs := d.deleteEndpointQuiet(ep, endpoint.DeleteConfig{
+			NoIPRelease: true,
+		})
 		for _, err := range errs {
 			log.WithError(err).Debug("Error occurred while deleting cilium-health endpoint")
 		}

--- a/daemon/policy_test.go
+++ b/daemon/policy_test.go
@@ -539,7 +539,7 @@ func (ds *DaemonSuite) TestRemovePolicy(c *C) {
 
 	// Delete the endpoint.
 	e.UnconditionalLock()
-	e.LeaveLocked(ds.d, nil)
+	e.LeaveLocked(ds.d, nil, endpoint.DeleteConfig{})
 	e.Unlock()
 
 	// Check that the policy has been removed from the xDS cache.


### PR DESCRIPTION
Endpoints which fail to restore have been deleted in the background so far.
This has potentially overlapped with new endpoints being created which could
then cause the release of resources such as IP addresses which are used by new
endpoints.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7667)
<!-- Reviewable:end -->
