### PR TITLE
 Fix Junit attachment in runtime test. 

### DIFF
--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -99,7 +99,8 @@ func TestTest(t *testing.T) {
 	junitReporter := ginkgoext.NewJUnitReporter(fmt.Sprintf(
 		"%s.xml", helpers.GetScopeWithVersion()))
 	RunSpecsWithDefaultAndCustomReporters(
-		t, helpers.GetScopeWithVersion(), []ginkgo.Reporter{junitReporter})
+		t, fmt.Sprintf("Suite-%s", helpers.GetScopeWithVersion()),
+		[]ginkgo.Reporter{junitReporter})
 }
 
 func goReportVagrantStatus() chan bool {


### PR DESCRIPTION
Change suiteName to not match test folders names.

To avoid issues in Junit Attachment Jenkins plugin that the className is
the same as a folder and attachment fails:

```
00:59:24.653  Recording test results
00:59:38.788  Attachment fe200965_RuntimeFQDNPolicies_Implements_matchPattern:_"*".zip was referenced from the test 'runtime' but it doe$
00:59:38.938  Attachment a923df9d_RuntimeFQDNPolicies_toFQDNs_populates_toCIDRSet_when_poller_is_disabled_(data_from_proxy)_Policy_addit$
```

From here:
https://github.com/jenkinsci/junit-attachments-plugin/blob/b68f75080535d3f264a2408958a88f8b733d30d4/src/main/java/hudson/plugins/junitat$

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7674)
<!-- Reviewable:end -->
