### PR TITLE
GC Nodes stored in the KVstore

### DIFF
--- a/operator/main.go
+++ b/operator/main.go
@@ -103,6 +103,7 @@ func init() {
 	flags.BoolVar(&synchronizeServices, "synchronize-k8s-services", true, "Synchronize Kubernetes services to kvstore")
 	flags.BoolVar(&enableCepGC, "cilium-endpoint-gc", true, "Enable CiliumEndpoint garbage collector")
 	flags.DurationVar(&identityGCInterval, "identity-gc-interval", time.Minute*10, "GC interval for security identities")
+	flags.DurationVar(&kvNodeGCInterval, "nodes-gc-interval", time.Minute*2, "GC interval for nodes store in the kvstore")
 
 	flags.IntVar(&unmanagedKubeDnsWatcherInterval, "unmanaged-pod-watcher-interval", 15, "Interval to check for unmanaged kube-dns pods (0 to disable)")
 

--- a/pkg/clustermesh/clustermesh_test.go
+++ b/pkg/clustermesh/clustermesh_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -90,7 +90,7 @@ func (o *testObserver) OnUpdate(k store.Key) {
 	nodesMutex.Unlock()
 }
 
-func (o *testObserver) OnDelete(k store.Key) {
+func (o *testObserver) OnDelete(k store.NamedKey) {
 	n := k.(*testNode)
 	nodesMutex.Lock()
 	delete(nodes, n.GetKeyName())

--- a/pkg/clustermesh/services.go
+++ b/pkg/clustermesh/services.go
@@ -145,7 +145,7 @@ func (r *remoteServiceObserver) OnUpdate(key store.Key) {
 }
 
 // OnDelete is called when a service in a remote cluster is deleted
-func (r *remoteServiceObserver) OnDelete(key store.Key) {
+func (r *remoteServiceObserver) OnDelete(key store.NamedKey) {
 	if svc, ok := key.(*service.ClusterService); ok {
 		scopedLog := log.WithFields(logrus.Fields{logfields.ServiceName: svc.String()})
 		scopedLog.Debugf("Update event of remote service %#v", svc)

--- a/pkg/kvstore/store/store.go
+++ b/pkg/kvstore/store/store.go
@@ -310,6 +310,20 @@ func (s *SharedStore) lookupLocalKey(name string) LocalKey {
 	return nil
 }
 
+// SharedKeysMap returns a copy of the SharedKeysMap, the returned map can
+// be safely modified but the values of the map represent the actual data
+// stored in the internal SharedStore SharedKeys map.
+func (s *SharedStore) SharedKeysMap() map[string]Key {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	sharedKeysCopy := make(map[string]Key, len(s.sharedKeys))
+
+	for k, v := range s.sharedKeys {
+		sharedKeysCopy[k] = v
+	}
+	return sharedKeysCopy
+}
+
 // UpdateLocalKey adds a key to be synchronized with the kvstore
 func (s *SharedStore) UpdateLocalKey(key LocalKey) {
 	s.mutex.Lock()

--- a/pkg/kvstore/store/store_test.go
+++ b/pkg/kvstore/store/store_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -121,7 +121,7 @@ func (o *observer) OnUpdate(k Key) {
 	}
 	counterLock.Unlock()
 }
-func (o *observer) OnDelete(k Key) {
+func (o *observer) OnDelete(k NamedKey) {
 	counterLock.Lock()
 	counter[k.(*TestType).Name].deleted++
 	counterLock.Unlock()

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -308,11 +308,16 @@ func (n *Node) PublicAttrEquals(o *Node) bool {
 	return false
 }
 
-// GetKeyName returns the kvstore key to be used for the node
-func (n *Node) GetKeyName() string {
+// GetKeyNodeName constructs the API name for the given cluster and node name.
+func GetKeyNodeName(cluster, node string) string {
 	// WARNING - STABLE API: Changing the structure of the key may break
 	// backwards compatibility
-	return path.Join(n.Cluster, n.Name)
+	return path.Join(cluster, node)
+}
+
+// GetKeyName returns the kvstore key to be used for the node
+func (n *Node) GetKeyName() string {
+	return GetKeyNodeName(n.Cluster, n.Name)
 }
 
 // DeepKeyCopy creates a deep copy of the LocalKey

--- a/pkg/node/store/store.go
+++ b/pkg/node/store/store.go
@@ -77,7 +77,7 @@ func (o *NodeObserver) OnUpdate(k store.Key) {
 	}
 }
 
-func (o *NodeObserver) OnDelete(k store.Key) {
+func (o *NodeObserver) OnDelete(k store.NamedKey) {
 	if n, ok := k.(*node.Node); ok {
 		nodeCopy := n.DeepCopy()
 		nodeCopy.Source = node.FromKVStore


### PR DESCRIPTION
If the operator stops running and at the same time nodes are evicted
the cluster, those nodes will never be removed from the kvstore as the operator
the entity that handles the synchronization of nodes from k8s to the
kvstore.
    
With this change the operator will remove the nodes from the KVStore that
are no longer running in a k8s cluster.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7675)
<!-- Reviewable:end -->
