### PR TITLE
Sanitize endpoint security identity upon restore

### DIFF
--- a/daemon/state.go
+++ b/daemon/state.go
@@ -281,7 +281,7 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) (resto
 				return
 			}
 
-			ep.LogStatusOKLocked(endpoint.Other, "Synchronizing endpoint labels with KVStore")
+			ep.SetStateLocked(endpoint.StateRestoring, "Synchronizing endpoint labels with KVStore")
 
 			if ep.SecurityIdentity != nil {
 				if oldSecID := ep.SecurityIdentity.ID; identity.ID != oldSecID {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1064,6 +1064,11 @@ func ParseEndpoint(strEp string) (*Endpoint, error) {
 		ep.Status = NewEndpointStatus()
 	}
 
+	if ep.SecurityIdentity == nil {
+		ep.SetIdentity(identityPkg.LookupReservedIdentity(identityPkg.ReservedIdentityInit))
+	} else {
+		ep.SecurityIdentity.Sanitize()
+	}
 	ep.UpdateLogger(nil)
 
 	ep.SetStateLocked(StateRestoring, "Endpoint restoring")

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -81,12 +81,17 @@ func NewIdentityFromModel(base *models.Identity) *Identity {
 		lbl := labels.ParseLabel(v)
 		id.Labels[lbl.Key] = lbl
 	}
+	id.Sanitize()
 
+	return id
+}
+
+// Sanitize takes a partially initialized Identity (for example, deserialized
+// from json) and reconstitutes the full object from what has been restored.
+func (id *Identity) Sanitize() {
 	if id.Labels != nil {
 		id.LabelArray = id.Labels.LabelArray()
 	}
-
-	return id
 }
 
 // GetLabelsSHA256 returns the SHA256 of the labels associated with the


### PR DESCRIPTION
Supersedes #7672.

Previously, we would deserialize endpoints from json, then add these
partially unvalidated objects into the endpointmanager, exposing them to
other subsystems, then only after some time change the identity of the
endpoint and ensure that the security identity is correct.

As a result, the `pkg/endpoint` code could not rely upon the
`e.SecurityIdentity` being fully initialized (specifically, with the
`LabelArray` of the security identity being non-nil). This leads to
calculation of `L4Policy` using security labels `[]`.

This PR ensures that during restore, the endpoint's SecurityIdentity is
properly restored by sanitizing the `e.SecurityIdentity` to ensure that its
corresponding `LabelArray` is populated with labels that reflect the identity.

Additionally, this PR prevents identity updates triggering regeneration for
 endpoints that are currently being restored or waiting to regenerate. This
should avoid the entire situation in future where endpoints that are exposed
via the endpointmanager (to provide visibility to users) are regenerated prior
to the restore logic completely finishing.

A side effect of the change to how regeneration is triggered is that if the
identity of an endpoint is changed during Cilium startup, that endpoint will
now appear as `Restoring` for about 20 seconds during Cilium startup. I
believe that this is a more accurate reflection of how Cilium is handling this
endpoint for that period, so this is an improvement above the current setup
where the endpoint is represented as `ready`, even though the newly
launched Cilium hasn't yet regenerated that endpoint, so it is only applying
whatever policy was determined during a previous Cilium run.

```release-note
Fix issue where if there are many identities changing during Cilium restart, some endpoints may enforce policy only using policy that selects all labels, rather than the policy that selects that endpoint's labels.
```

Fixes: #7358

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7682)
<!-- Reviewable:end -->
