### PR TITLE
Pr/v1.5 backports 2019 04 11

### DIFF
--- a/Documentation/gettingstarted/encryption.rst
+++ b/Documentation/gettingstarted/encryption.rst
@@ -28,14 +28,12 @@ Generate & import the PSK
 First create a Kubernetes secret for the IPSec keys to be stored.
 This will generate the necessary IPSec keys which will be distributed as a
 Kubernetes secret called ``cilium-ipsec-keys``. In this example we use
-AES-CBC with HMAC-256 (hash based authentication code), but any of the supported
+GMC-128-AES, but any of the supported
 Linux algorithms may be used. To generate use the following
 
 .. parsed-literal::
-
-    kubectl create -n kube-system secret generic cilium-ipsec-keys \\
-       --from-literal=keys="hmac(sha256) $(echo \`dd if=/dev/urandom count=32 bs=1 2> /dev/null| xxd -p -c 64\`) cbc(aes) $(echo \`dd if=/dev/urandom count=32 bs=1 2> /dev/null| xxd -p -c 64\`)"
-
+    $ kubectl create -n kube-system secret generic cilium-ipsec-keys \
+        --from-literal=keys="3 rfc4106(gcm(aes)) $(echo `dd if=/dev/urandom count=20 bs=1 2> /dev/null| xxd -p -c 64`) 128"
 
 The secret can be displayed with 'kubectl -n kube-system get secret' and will be
 listed as 'cilium-ipsec-keys'.

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1477,7 +1477,7 @@
     "storage/v1beta1",
   ]
   pruneopts = "NUT"
-  revision = "kubernetes-1.14.0"
+  revision = "kubernetes-1.14.1"
 
 [[projects]]
   digest = "1:47ddb5be73e959bd73931c04911cd05e3f45d7f7c978a45eb817e1fb85e21da4"
@@ -1491,7 +1491,7 @@
     "pkg/features",
   ]
   pruneopts = "NUT"
-  revision = "kubernetes-1.14.0"
+  revision = "kubernetes-1.14.1"
 
 [[projects]]
   digest = "1:062b06c1ccb71c956f40a8627cc93dba1dc7713a21876572ccd0e314c5362884"
@@ -1542,7 +1542,7 @@
     "third_party/forked/golang/reflect",
   ]
   pruneopts = "NUT"
-  revision = "kubernetes-1.14.0"
+  revision = "kubernetes-1.14.1"
 
 [[projects]]
   digest = "1:fe60b6d8b8208ecb0e70e97963fef38ce27443c6934ec00a37f80a3f9372f42b"
@@ -1552,7 +1552,7 @@
     "pkg/util/feature",
   ]
   pruneopts = "NUT"
-  revision = "kubernetes-1.14.0"
+  revision = "kubernetes-1.14.1"
 
 [[projects]]
   digest = "1:8342528e1275c10c0db434bd9e4853bacd901835366a1734fe112c731a2deda3"
@@ -1663,7 +1663,7 @@
     "util/retry",
   ]
   pruneopts = "NUT"
-  revision = "173e5d72ee987b4e748b8609ed2959d385ac6370"
+  revision = "0435e1d065b132cd4915ab080c12c8f762c9df68"
   source = "https://github.com/cilium/client-go"
 
 [[projects]]
@@ -1690,7 +1690,7 @@
     "pkg/util",
   ]
   pruneopts = "T"
-  revision = "kubernetes-1.14.0"
+  revision = "kubernetes-1.14.1"
 
 [[projects]]
   digest = "1:da31d8be5af84b69ef83b212d833d8e10930cd9e8a876780a20099ea306c4c13"
@@ -1738,7 +1738,7 @@
     "pkg/registry/core/service/ipallocator",
   ]
   pruneopts = "NUT"
-  revision = "v1.14.0"
+  revision = "v1.14.1"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -497,28 +497,28 @@ required = [
 
 [[constraint]]
   name = "k8s.io/api"
-  revision = "kubernetes-1.14.0"
+  revision = "kubernetes-1.14.1"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
 
 [[constraint]]
   name = "k8s.io/apiextensions-apiserver"
-  revision = "kubernetes-1.14.0"
+  revision = "kubernetes-1.14.1"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
 
 [[override]]
   name = "k8s.io/apiserver"
-  revision = "kubernetes-1.14.0"
+  revision = "kubernetes-1.14.1"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
 
 [[constraint]]
   name = "k8s.io/apimachinery"
-  revision = "kubernetes-1.14.0"
+  revision = "kubernetes-1.14.1"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
@@ -526,14 +526,14 @@ required = [
 [[constraint]]
   name = "k8s.io/client-go"
   source = "https://github.com/cilium/client-go"
-  revision = "173e5d72ee987b4e748b8609ed2959d385ac6370"
+  revision = "0435e1d065b132cd4915ab080c12c8f762c9df68"
 
   # main-usage = "pkg/k8s"
-  # on-revision = "TODO @aanm is on 173e5d72ee987b4e748b8609ed2959d385ac6370 as it contains the hotfix for the metrics path"
+  # on-revision = "TODO @aanm is on 0435e1d065b132cd4915ab080c12c8f762c9df68 as it contains the hotfix for the metrics path"
 
 [[constraint]]
   name = "k8s.io/code-generator"
-  revision = "kubernetes-1.14.0"
+  revision = "kubernetes-1.14.1"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
@@ -547,7 +547,7 @@ required = [
 
 [[constraint]]
   name = "k8s.io/kubernetes"
-  revision = "v1.14.0"
+  revision = "v1.14.1"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -279,7 +279,7 @@ func (d *Daemon) QueueEndpointBuild(epID uint64) func() {
 	}
 
 	// Acquire succeeded, but the context was canceled after?
-	if ctx.Err() == context.Canceled {
+	if ctx.Err() != nil {
 		d.buildEndpointSem.Release(1)
 		return nil
 	}

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -66,7 +67,7 @@ type DaemonSuite struct {
 	OnRemoveProxyRedirect     func(e *e.Endpoint, id string, proxyWaitGroup *completion.WaitGroup) (error, revert.FinalizeFunc, revert.RevertFunc)
 	OnUpdateNetworkPolicy     func(e *e.Endpoint, policy *policy.L4Policy, labelsMap, deniedIngressIdentities, deniedEgressIdentities cache.IdentityCache, proxyWaitGroup *completion.WaitGroup) (error, revert.RevertFunc)
 	OnRemoveNetworkPolicy     func(e *e.Endpoint)
-	OnQueueEndpointBuild      func(epID uint64) func()
+	OnQueueEndpointBuild      func(ctx context.Context, epID uint64) (func(), error)
 	OnRemoveFromEndpointQueue func(epID uint64)
 	OnDebugEnabled            func() bool
 	OnGetCompilationLock      func() *lock.RWMutex
@@ -237,9 +238,9 @@ func (ds *DaemonSuite) RemoveNetworkPolicy(e *e.Endpoint) {
 	panic("RemoveNetworkPolicy should not have been called")
 }
 
-func (ds *DaemonSuite) QueueEndpointBuild(epID uint64) func() {
+func (ds *DaemonSuite) QueueEndpointBuild(ctx context.Context, epID uint64) (func(), error) {
 	if ds.OnQueueEndpointBuild != nil {
-		return ds.OnQueueEndpointBuild(epID)
+		return ds.OnQueueEndpointBuild(ctx, epID)
 	}
 	panic("QueueEndpointBuild should not have been called")
 }

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -267,7 +267,8 @@ func (d *Daemon) createEndpoint(ctx context.Context, epTemplate *models.Endpoint
 		// proxy configuration, this code would effectively deadlock addition
 		// of endpoints.
 		ep.Regenerate(d, &endpoint.ExternalRegenerationMetadata{
-			Reason: "Initial build on endpoint creation",
+			Reason:        "Initial build on endpoint creation",
+			ParentContext: ctx,
 		})
 	}
 

--- a/daemon/health.go
+++ b/daemon/health.go
@@ -98,7 +98,9 @@ func (d *Daemon) cleanupHealthEndpoint() {
 		log.Debug("Didn't find existing cilium-health endpoint to delete")
 	} else {
 		log.Debug("Removing existing cilium-health endpoint")
-		errs := d.deleteEndpointQuiet(ep, false)
+		errs := d.deleteEndpointQuiet(ep, endpoint.DeleteConfig{
+			NoIPRelease: true,
+		})
 		for _, err := range errs {
 			log.WithError(err).Debug("Error occurred while deleting cilium-health endpoint")
 		}

--- a/daemon/policy_test.go
+++ b/daemon/policy_test.go
@@ -539,7 +539,7 @@ func (ds *DaemonSuite) TestRemovePolicy(c *C) {
 
 	// Delete the endpoint.
 	e.UnconditionalLock()
-	e.LeaveLocked(ds.d, nil)
+	e.LeaveLocked(ds.d, nil, endpoint.DeleteConfig{})
 	e.Unlock()
 
 	// Check that the policy has been removed from the xDS cache.

--- a/daemon/state_test.go
+++ b/daemon/state_test.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"context"
 	"encoding/binary"
 	"fmt"
 	"io/ioutil"
@@ -108,14 +109,15 @@ func (ds *DaemonSuite) generateEPs(baseDir string, epsWanted []*e.Endpoint, epsM
 		}
 	}()
 
-	ds.OnQueueEndpointBuild = func(epID uint64) func() {
+	ds.OnQueueEndpointBuild = func(ctx context.Context, epID uint64) (func(), error) {
 		builders++
 		var once sync.Once
-		return func() {
+		doneFunc := func() {
 			once.Do(func() {
 				builders--
 			})
 		}
+		return doneFunc, nil
 	}
 
 	ds.OnTracingEnabled = func() bool {

--- a/pkg/command/exec/exec.go
+++ b/pkg/command/exec/exec.go
@@ -30,9 +30,9 @@ import (
 // options and logging errors, with an optional set of filtered outputs.
 func combinedOutput(ctx context.Context, cmd *exec.Cmd, filters []string, scopedLog *logrus.Entry, verbose bool) ([]byte, error) {
 	out, err := cmd.CombinedOutput()
-	if ctx.Err() == context.DeadlineExceeded {
-		scopedLog.WithField("cmd", cmd.Args).Error("Command execution failed: Timeout")
-		return nil, fmt.Errorf("Command execution failed: Timeout for %s", cmd.Args)
+	if ctx.Err() != nil {
+		scopedLog.WithError(err).WithField("cmd", cmd.Args).Error("Command execution failed")
+		return nil, fmt.Errorf("Command execution failed for %s: %s", cmd.Args, ctx.Err())
 	}
 	if err != nil {
 		if verbose {

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -30,7 +30,6 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
-	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/vishvananda/netlink"
 
 	"github.com/sirupsen/logrus"
@@ -169,28 +168,6 @@ func ipSecReplacePolicyOut(src, dst *net.IPNet, dir IPSecDir) error {
 	return netlink.XfrmPolicyUpdate(policy)
 }
 
-func ipSecDeleteStateOut(src, local net.IP) error {
-	state := ipSecNewState()
-
-	state.Src = src
-	state.Dst = local
-	err := netlink.XfrmStateDel(state)
-	return err
-}
-
-func ipSecDeleteStateIn(src, local net.IP) error {
-	state := ipSecNewState()
-
-	state.Src = src
-	state.Dst = local
-	err := netlink.XfrmStateDel(state)
-	return err
-}
-
-func ipSecDeletePolicy(src, local net.IP) error {
-	return nil
-}
-
 func ipsecDeleteXfrmSpi(spi uint8) {
 	var err error
 	scopedLog := log.WithFields(logrus.Fields{
@@ -310,27 +287,6 @@ func UpsertIPsecEndpoint(local, remote *net.IPNet, dir IPSecDir) (uint8, error) 
 		}
 	}
 	return spi, nil
-}
-
-// DeleteIPSecEndpoint deletes the endpoint from IPSec SPD and SAD
-func DeleteIPSecEndpoint(src, local net.IP) error {
-	scopedLog := log.WithFields(logrus.Fields{
-		logfields.IPAddr: src,
-	})
-
-	err := ipSecDeleteStateIn(src, local)
-	if err != nil {
-		scopedLog.WithError(err).Warning("unable to delete IPSec (stateIn) context\n")
-	}
-	err = ipSecDeleteStateOut(src, local)
-	if err != nil {
-		scopedLog.WithError(err).Warning("unable to delete IPSec (stateOut) context\n")
-	}
-	err = ipSecDeletePolicy(src, local)
-	if err != nil {
-		scopedLog.WithError(err).Warning("unable to delete IPSec (policy) context\n")
-	}
-	return nil
 }
 
 func decodeIPSecKey(keyRaw string) ([]byte, error) {

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -118,30 +118,18 @@ func ipSecReplacePolicyIn(src, dst *net.IPNet) error {
 }
 
 func ipSecReplacePolicyInFwd(src, dst *net.IPNet, dir netlink.Dir) error {
-	var spiWide uint32
-	var mask uint32
-
 	key := getIPSecKeys(dst.IP)
 	if key == nil {
 		return fmt.Errorf("IPSec key missing")
 	}
-	spiWide = uint32(key.Spi)
 
 	policy := ipSecNewPolicy()
 	policy.Dir = dir
 	policy.Src = src
 	policy.Dst = dst
-	// On ingress we use SPI to detremine key to use for decryption on
-	// egress however we need to select the key using the endpoint ID. To
-	// indicate this to the stack we use an extra byte and need a wider mask.
-	if dir == netlink.XFRM_DIR_OUT {
-		mask = linux_defaults.IPsecMarkMask
-	} else {
-		mask = linux_defaults.IPsecMarkMaskIn
-	}
 	policy.Mark = &netlink.XfrmMark{
-		Value: ((spiWide << 12) | linux_defaults.RouteMarkDecrypt),
-		Mask:  mask,
+		Value: linux_defaults.RouteMarkDecrypt,
+		Mask:  linux_defaults.IPsecMarkMaskIn,
 	}
 	ipSecAttachPolicyTempl(policy, key, src.IP, dst.IP)
 	return netlink.XfrmPolicyUpdate(policy)

--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -37,6 +37,7 @@ var _ = Suite(&IPSecSuitePrivileged{})
 var (
 	path           = "ipsec_keys_test"
 	keysDat        = []byte("1 hmac(sha256) 0123456789abcdef0123456789abcdef cbc(aes) 0123456789abcdef0123456789abcdef\n1 hmac(sha256) 0123456789abcdef0123456789abcdef cbc(aes) 0123456789abcdef0123456789abcdef foobar\n")
+	keysAeadDat    = []byte("6 rfc4106(gcm(aes)) 44434241343332312423222114131211f4f3f2f1 128\n")
 	invalidKeysDat = []byte("1 test abcdefghijklmnopqrstuvwzyzABCDEF test abcdefghijklmnopqrstuvwzyzABCDEF\n")
 )
 
@@ -63,6 +64,9 @@ func (p *IPSecSuitePrivileged) TestLoadKeys(c *C) {
 	keys := bytes.NewReader(keysDat)
 	_, err := loadIPSecKeys(keys)
 	c.Assert(err, IsNil)
+	keys = bytes.NewReader(keysAeadDat)
+	_, err = loadIPSecKeys(keys)
+	c.Assert(err, IsNil)
 }
 
 func (p *IPSecSuitePrivileged) TestUpsertIPSecEquals(c *C) {
@@ -80,6 +84,24 @@ func (p *IPSecSuitePrivileged) TestUpsertIPSecEquals(c *C) {
 		ReqID: 1,
 		Auth:  &netlink.XfrmStateAlgo{Name: "hmac(sha256)", Key: authKey},
 		Crypt: &netlink.XfrmStateAlgo{Name: "cbc(aes)", Key: cryptKey},
+	}
+
+	ipSecKeysGlobal["1.2.3.4"] = key
+	ipSecKeysGlobal[""] = key
+
+	_, err = UpsertIPsecEndpoint(local, remote, IPSecDirBoth)
+	c.Assert(err, IsNil)
+
+	ipsecDeleteXfrmSpi(0)
+
+	aeadKey, err := decodeIPSecKey("44434241343332312423222114131211f4f3f2f1")
+	c.Assert(err, IsNil)
+	key = &ipSecKey{
+		Spi:   1,
+		ReqID: 1,
+		Aead:  &netlink.XfrmStateAlgo{Name: "rfc4106(gcm(aes))", Key: aeadKey, ICVLen: 128},
+		Crypt: nil,
+		Auth:  nil,
 	}
 
 	ipSecKeysGlobal["1.2.3.4"] = key
@@ -108,6 +130,25 @@ func (p *IPSecSuitePrivileged) TestUpsertIPSecEndpoint(c *C) {
 		ReqID: 1,
 		Auth:  &netlink.XfrmStateAlgo{Name: "hmac(sha256)", Key: authKey},
 		Crypt: &netlink.XfrmStateAlgo{Name: "cbc(aes)", Key: cryptKey},
+	}
+
+	ipSecKeysGlobal["1.1.3.4"] = key
+	ipSecKeysGlobal["1.2.3.4"] = key
+	ipSecKeysGlobal[""] = key
+
+	_, err = UpsertIPsecEndpoint(local, remote, IPSecDirBoth)
+	c.Assert(err, IsNil)
+
+	ipsecDeleteXfrmSpi(0)
+
+	aeadKey, err := decodeIPSecKey("44434241343332312423222114131211f4f3f2f1")
+	c.Assert(err, IsNil)
+	key = &ipSecKey{
+		Spi:   1,
+		ReqID: 1,
+		Aead:  &netlink.XfrmStateAlgo{Name: "rfc4106(gcm(aes))", Key: aeadKey, ICVLen: 128},
+		Crypt: nil,
+		Auth:  nil,
 	}
 
 	ipSecKeysGlobal["1.1.3.4"] = key

--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -84,12 +84,9 @@ func (p *IPSecSuitePrivileged) TestUpsertIPSecEquals(c *C) {
 	_, err = UpsertIPsecEndpoint(local, remote, IPSecDirBoth)
 	c.Assert(err, IsNil)
 
-	err = DeleteIPSecEndpoint(remote.IP, local.IP)
-	c.Assert(err, IsNil)
-
+	ipsecDeleteXfrmSpi(0)
 	ipSecKeysGlobal["1.2.3.4"] = nil
 	ipSecKeysGlobal[""] = nil
-
 }
 
 func (p *IPSecSuitePrivileged) TestUpsertIPSecEndpoint(c *C) {
@@ -112,9 +109,7 @@ func (p *IPSecSuitePrivileged) TestUpsertIPSecEndpoint(c *C) {
 	_, err = UpsertIPsecEndpoint(local, remote, IPSecDirBoth)
 	c.Assert(err, IsNil)
 
-	err = DeleteIPSecEndpoint(remote.IP, local.IP)
-	c.Assert(err, IsNil)
-
+	ipsecDeleteXfrmSpi(0)
 	ipSecKeysGlobal["1.1.3.4"] = nil
 	ipSecKeysGlobal["1.2.3.4"] = nil
 	ipSecKeysGlobal[""] = nil
@@ -129,6 +124,5 @@ func (p *IPSecSuitePrivileged) TestUpsertIPSecKeyMissing(c *C) {
 	_, err = UpsertIPsecEndpoint(local, remote, IPSecDirBoth)
 	c.Assert(err, ErrorMatches, "unable to replace local state: IPSec key missing")
 
-	err = DeleteIPSecEndpoint(remote.IP, local.IP)
-	c.Assert(err, IsNil)
+	ipsecDeleteXfrmSpi(0)
 }

--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -71,11 +71,15 @@ func (p *IPSecSuitePrivileged) TestUpsertIPSecEquals(c *C) {
 	_, remote, err := net.ParseCIDR("1.2.3.4/16")
 	c.Assert(err, IsNil)
 
+	authKey, err := decodeIPSecKey("0123456789abcdef0123456789abcdef")
+	c.Assert(err, IsNil)
+	cryptKey, err := decodeIPSecKey("0123456789abcdef0123456789abcdef")
+	c.Assert(err, IsNil)
 	key := &ipSecKey{
 		Spi:   1,
 		ReqID: 1,
-		Auth:  &netlink.XfrmStateAlgo{Name: "hmac(sha256)", Key: []byte("0123456789abcdef0123456789abcdef")},
-		Crypt: &netlink.XfrmStateAlgo{Name: "cbc(aes)", Key: []byte("0123456789abcdef0123456789abcdef")},
+		Auth:  &netlink.XfrmStateAlgo{Name: "hmac(sha256)", Key: authKey},
+		Crypt: &netlink.XfrmStateAlgo{Name: "cbc(aes)", Key: cryptKey},
 	}
 
 	ipSecKeysGlobal["1.2.3.4"] = key
@@ -95,11 +99,15 @@ func (p *IPSecSuitePrivileged) TestUpsertIPSecEndpoint(c *C) {
 	_, remote, err := net.ParseCIDR("1.2.3.4/16")
 	c.Assert(err, IsNil)
 
+	authKey, err := decodeIPSecKey("0123456789abcdef0123456789abcdef")
+	c.Assert(err, IsNil)
+	cryptKey, err := decodeIPSecKey("0123456789abcdef0123456789abcdef")
+	c.Assert(err, IsNil)
 	key := &ipSecKey{
 		Spi:   1,
 		ReqID: 1,
-		Auth:  &netlink.XfrmStateAlgo{Name: "hmac(sha256)", Key: []byte("0123456789abcdef0123456789abcdef")},
-		Crypt: &netlink.XfrmStateAlgo{Name: "cbc(aes)", Key: []byte("0123456789abcdef0123456789abcdef")},
+		Auth:  &netlink.XfrmStateAlgo{Name: "hmac(sha256)", Key: authKey},
+		Crypt: &netlink.XfrmStateAlgo{Name: "cbc(aes)", Key: cryptKey},
 	}
 
 	ipSecKeysGlobal["1.1.3.4"] = key

--- a/pkg/datapath/loader/compile.go
+++ b/pkg/datapath/loader/compile.go
@@ -268,7 +268,12 @@ func compileDatapath(ctx context.Context, ep endpoint, dirs *directoryInfo, debu
 					logfields.Params: logfields.Repr(p),
 					logfields.Debug:  debug,
 				})
-				scopedLog.WithError(err).Debug("JoinEP: Failed to compile")
+				// Only log an error here if the context was not canceled or not
+				// timed out; this log message should only represent failures
+				// with respect to compiling the program.
+				if ctx.Err() == nil {
+					scopedLog.WithError(err).Debug("JoinEP: Failed to compile")
+				}
 				return err
 			}
 		}
@@ -280,7 +285,12 @@ func compileDatapath(ctx context.Context, ep endpoint, dirs *directoryInfo, debu
 			logfields.Params: logfields.Repr(datapathProg),
 			logfields.Debug:  false,
 		})
-		scopedLog.WithError(err).Warn("JoinEP: Failed to compile")
+		// Only log an error here if the context was not canceled or not timed
+		// out; this log message should only represent failures with respect to
+		// compiling the program.
+		if ctx.Err() == nil {
+			scopedLog.WithError(err).Warn("JoinEP: Failed to compile")
+		}
 		return err
 	}
 

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -57,7 +57,12 @@ func reloadDatapath(ctx context.Context, ep endpoint, dirs *directoryInfo) error
 			scopedLog := ep.Logger(Subsystem).WithFields(logrus.Fields{
 				logfields.Path: objPath,
 			})
-			scopedLog.WithError(err).Warn("JoinEP: Failed to load program")
+			// Don't log an error here if the context was canceled or timed out;
+			// this log message should only represent failures with respect to
+			// loading the program.
+			if ctx.Err() == nil {
+				scopedLog.WithError(err).Warn("JoinEP: Failed to load program")
+			}
 			return err
 		}
 	} else {
@@ -66,7 +71,12 @@ func reloadDatapath(ctx context.Context, ep endpoint, dirs *directoryInfo) error
 				logfields.Path: objPath,
 				logfields.Veth: ep.InterfaceName(),
 			})
-			scopedLog.WithError(err).Warn("JoinEP: Failed to load program")
+			// Don't log an error here if the context was canceled or timed out;
+			// this log message should only represent failures with respect to
+			// loading the program.
+			if ctx.Err() == nil {
+				scopedLog.WithError(err).Warn("JoinEP: Failed to load program")
+			}
 			return err
 		}
 	}

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -380,7 +380,7 @@ func (e *Endpoint) regenerateBPF(owner Owner, regenContext *regenerationContext)
 	stats.waitingForLock.End(true)
 	defer owner.GetCompilationLock().RUnlock()
 
-	datapathRegenCtxt.prepareForProxyUpdates()
+	datapathRegenCtxt.prepareForProxyUpdates(regenContext.parentContext)
 	defer datapathRegenCtxt.completionCancel()
 
 	err = e.runPreCompilationSteps(owner, regenContext)

--- a/pkg/endpoint/owner.go
+++ b/pkg/endpoint/owner.go
@@ -15,6 +15,7 @@
 package endpoint
 
 import (
+	"context"
 	"sync"
 
 	"github.com/cilium/cilium/pkg/completion"
@@ -48,7 +49,7 @@ type Owner interface {
 	RemoveNetworkPolicy(e *Endpoint)
 
 	// QueueEndpointBuild puts the given endpoint in the processing queue
-	QueueEndpointBuild(epID uint64) func()
+	QueueEndpointBuild(ctx context.Context, epID uint64) (func(), error)
 
 	// RemoveFromEndpointQueue removes an endpoint from the working queue
 	RemoveFromEndpointQueue(epID uint64)

--- a/pkg/endpoint/regenerationcontext.go
+++ b/pkg/endpoint/regenerationcontext.go
@@ -119,9 +119,8 @@ type datapathRegenerationContext struct {
 	revertStack  revert.RevertStack
 }
 
-func (ctx *datapathRegenerationContext) prepareForProxyUpdates() {
-	// Set up a context to wait for proxy completions.
-	completionCtx, completionCancel := context.WithTimeout(context.Background(), EndpointGenerationTimeout)
+func (ctx *datapathRegenerationContext) prepareForProxyUpdates(parentCtx context.Context) {
+	completionCtx, completionCancel := context.WithTimeout(parentCtx, EndpointGenerationTimeout)
 	ctx.proxyWaitGroup = completion.NewWaitGroup(completionCtx)
 	ctx.completionCtx = completionCtx
 	ctx.completionCancel = completionCancel

--- a/pkg/endpoint/regenerationcontext.go
+++ b/pkg/endpoint/regenerationcontext.go
@@ -52,13 +52,16 @@ func (r DatapathRegenerationLevel) String() string {
 	return "BUG: Unknown DatapathRegenerationLevel"
 }
 
-func (e *ExternalRegenerationMetadata) toRegenerationContext() *regenerationContext {
+func (e *ExternalRegenerationMetadata) toRegenerationContext(ctx context.Context, c context.CancelFunc) *regenerationContext {
+
 	return &regenerationContext{
 		Reason: e.Reason,
 		datapathRegenerationContext: &datapathRegenerationContext{
 			regenerationLevel: e.RegenerationLevel,
 			ctCleaned:         make(chan struct{}),
 		},
+		parentContext: ctx,
+		cancelFunc:    c,
 	}
 }
 
@@ -72,6 +75,8 @@ type ExternalRegenerationMetadata struct {
 	// RegenerationLevel forces datapath regeneration according to the
 	// levels defined in the DatapathRegenerationLevel description.
 	RegenerationLevel DatapathRegenerationLevel
+
+	ParentContext context.Context
 }
 
 // RegenerationContext provides context to regenerate() calls to determine
@@ -91,6 +96,10 @@ type regenerationContext struct {
 	DoneFunc func()
 
 	datapathRegenerationContext *datapathRegenerationContext
+
+	parentContext context.Context
+
+	cancelFunc context.CancelFunc
 }
 
 // datapathRegenerationContext contains information related to regenerating the

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ type Identity struct {
 
 	// ReferenceCount counts the number of references pointing to this
 	// identity. This field is used by the owning cache of the identity.
-	ReferenceCount int
+	ReferenceCount int `json:"-"`
 }
 
 // IPIdentityPair is a pairing of an IP and the security identity to which that

--- a/pkg/kvstore/lock_test.go
+++ b/pkg/kvstore/lock_test.go
@@ -1,0 +1,55 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package kvstore
+
+import (
+	"context"
+	"time"
+
+	"github.com/pborman/uuid"
+	. "gopkg.in/check.v1"
+)
+
+func (s *independentSuite) TestLocalLock(c *C) {
+	prefix := "locktest/"
+	path := prefix + "foo"
+
+	backup := staleLockTimeout
+	defer func() { staleLockTimeout = backup }()
+	staleLockTimeout = 5 * time.Millisecond
+
+	locks := pathLocks{lockPaths: map[string]uuid.UUID{}}
+
+	// Acquie lock1
+	id1 := locks.lock(context.Background(), path)
+
+	// Ensure that staleLockTimeout has passed
+	time.Sleep(staleLockTimeout)
+
+	// Acquire lock on same path, must unlock local use
+	id2 := locks.lock(context.Background(), path)
+
+	// Unlock lock1, this should be a no-op
+	locks.unlock(path, id1)
+
+	l, ok := locks.lockPaths[path]
+	c.Assert(ok, Equals, true)
+	c.Assert(uuid.Equal(l, id2), Equals, true)
+
+	// Unlock lock2, this should be a no-op
+	locks.unlock(path, id2)
+}

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -401,7 +401,6 @@ func (p *Repository) AddListLocked(rules api.Rules) (ruleSlice, uint64) {
 	p.rules = append(p.rules, newList...)
 	p.BumpRevision()
 	metrics.PolicyCount.Add(float64(len(newList)))
-	metrics.PolicyRevision.Inc()
 
 	return newList, p.GetRevision()
 }
@@ -488,7 +487,6 @@ func (p *Repository) DeleteByLabelsLocked(labels labels.LabelArray) (ruleSlice, 
 		p.BumpRevision()
 		p.rules = new
 		metrics.PolicyCount.Sub(float64(deleted))
-		metrics.PolicyRevision.Inc()
 	}
 
 	return deletedRules, p.GetRevision(), deleted

--- a/test/k8sT/manifests/ipsec_ds.yaml
+++ b/test/k8sT/manifests/ipsec_ds.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: kube-system
 type: Opaque
 stringData:
-  keys: "5 hmac(sha256) 0123456789abcdef0123456789abcdef cbc(aes) 0123456789abcdef0123456789abcdef"
+  keys: "6 rfc4106(gcm(aes)) 44434241343332312423222114131211f4f3f2f1 128"

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -192,7 +192,7 @@ case $K8S_VERSION in
         ;;
     "1.14")
         KUBERNETES_CNI_VERSION="0.7.5"
-        K8S_FULL_VERSION="1.14.0"
+        K8S_FULL_VERSION="1.14.1"
         KUBEADM_OPTIONS="--ignore-preflight-errors=cri"
         KUBEADM_SLAVE_OPTIONS="--discovery-token-unsafe-skip-ca-verification --ignore-preflight-errors=cri,SystemVerification"
         sudo ln -sf $COREDNS_DEPLOYMENT $DNS_DEPLOYMENT

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -99,7 +99,8 @@ func TestTest(t *testing.T) {
 	junitReporter := ginkgoext.NewJUnitReporter(fmt.Sprintf(
 		"%s.xml", helpers.GetScopeWithVersion()))
 	RunSpecsWithDefaultAndCustomReporters(
-		t, helpers.GetScopeWithVersion(), []ginkgo.Reporter{junitReporter})
+		t, fmt.Sprintf("Suite-%s", helpers.GetScopeWithVersion()),
+		[]ginkgo.Reporter{junitReporter})
 }
 
 func goReportVagrantStatus() chan bool {

--- a/vendor/github.com/golang/protobuf/proto/deprecated.go
+++ b/vendor/github.com/golang/protobuf/proto/deprecated.go
@@ -1,0 +1,63 @@
+// Go support for Protocol Buffers - Google's data interchange format
+//
+// Copyright 2018 The Go Authors.  All rights reserved.
+// https://github.com/golang/protobuf
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package proto
+
+import "errors"
+
+// Deprecated: do not use.
+type Stats struct{ Emalloc, Dmalloc, Encode, Decode, Chit, Cmiss, Size uint64 }
+
+// Deprecated: do not use.
+func GetStats() Stats { return Stats{} }
+
+// Deprecated: do not use.
+func MarshalMessageSet(interface{}) ([]byte, error) {
+	return nil, errors.New("proto: not implemented")
+}
+
+// Deprecated: do not use.
+func UnmarshalMessageSet([]byte, interface{}) error {
+	return errors.New("proto: not implemented")
+}
+
+// Deprecated: do not use.
+func MarshalMessageSetJSON(interface{}) ([]byte, error) {
+	return nil, errors.New("proto: not implemented")
+}
+
+// Deprecated: do not use.
+func UnmarshalMessageSetJSON([]byte, interface{}) error {
+	return errors.New("proto: not implemented")
+}
+
+// Deprecated: do not use.
+func RegisterMessageSetType(Message, int32, string) {}


### PR DESCRIPTION
Backport of PR #7657 NOT done, as it broke the cherry-pick script for the later backports.

Following backports applied against v1.5:
```
vagrant@runtime1:~/go/src/github.com/cilium/cilium$ contrib/backporting/cherry-pick ce889ce39084e8be9a199d155ce41ac3e8169003
Applying: ce889ce390 allocator: Block Allocate() and Release() until key list is initialized
vagrant@runtime1:~/go/src/github.com/cilium/cilium$ contrib/backporting/cherry-pick 8091d2441f38f1fe763783ea4b23ed19c45f048b
Applying: 8091d2441f allocator: Provide info and warning messages around key allocation
vagrant@runtime1:~/go/src/github.com/cilium/cilium$ contrib/backporting/cherry-pick 7bc3528336f4496763fffe4d23b69b50b49ec933
Applying: 7bc3528336 kvstore: Protect Unlock() from timeout overwrite
vagrant@runtime1:~/go/src/github.com/cilium/cilium$ contrib/backporting/cherry-pick 341274337e5dc928b6ed4326776651fa26e23fc0
Applying: 341274337e kvstore: Return from LockPath() when local locking is cancelled
vagrant@runtime1:~/go/src/github.com/cilium/cilium$ contrib/backporting/cherry-pick 6202595c7230b8f957ba4214a21e50d64e907e4a
Applying: 6202595c72 cilium: ipsec_linux, remote DeleteIPSecEndpint and use SPI version
vagrant@runtime1:~/go/src/github.com/cilium/cilium$ contrib/backporting/cherry-pick 9fea830dcc8db7d293f3cede4fae0a40ab714aaa
Applying: 9fea830dcc cilium: ipsec_linux only set spi bit in xfrm mark on egress
vagrant@runtime1:~/go/src/github.com/cilium/cilium$ contrib/backporting/cherry-pick 74c656bb9e53d6228abfe203cac55719102fdc28
Applying: 74c656bb9e cilium: Policy rules are no longer unique for key
vagrant@runtime1:~/go/src/github.com/cilium/cilium$ contrib/backporting/cherry-pick 913a2cdb4f03e16a98af3b182ffa86f7a681f27d
Applying: 913a2cdb4f cilium: ipsec tests should use decodeIPSecKey for strings to hex
vagrant@runtime1:~/go/src/github.com/cilium/cilium$ contrib/backporting/cherry-pick 074cb88ad91605c7b7d0c09905b4d627f0036a23
Applying: 074cb88ad9 cilium: support aead state keys
vagrant@runtime1:~/go/src/github.com/cilium/cilium$ contrib/backporting/cherry-pick 7972c7f00c7f379ed35cf3f84295430454d18703
Applying: 7972c7f00c cilium: docs update encryption algo example to use GCM
vagrant@runtime1:~/go/src/github.com/cilium/cilium$ contrib/backporting/cherry-pick 7e389f35911db69615226b9429e5502091eafffa
Applying: 7e389f3591 vendor: update k8s dependencies to 1.14.1
vagrant@runtime1:~/go/src/github.com/cilium/cilium$ contrib/backporting/cherry-pick da45c47b11f97c84ed996589477d27fc48bfe19e
Applying: da45c47b11 test: update k8s test versions to v1.14.1
vagrant@runtime1:~/go/src/github.com/cilium/cilium$ contrib/backporting/cherry-pick 9195a107b1d3a54b4b0fd28b23f53f937f899692
Applying: 9195a107b1 policy: Fix metrics for policy revision
vagrant@runtime1:~/go/src/github.com/cilium/cilium$ contrib/backporting/cherry-pick a078bb313112a801a39234f9fafa610475d77359
Applying: a078bb3131 identity: Don't serialize reference counts
vagrant@runtime1:~/go/src/github.com/cilium/cilium$ contrib/backporting/cherry-pick 127800d273e41d4ab52792109ba01ef794d3631b 
Applying: 127800d273 Documentation: clean up upgrade instructions
vagrant@runtime1:~/go/src/github.com/cilium/cilium$ contrib/backporting/cherry-pick 25cb8f0d501eed1832059e1b31ebf8bdeb3bfcaf
Applying: 25cb8f0d50 Change suiteName to not match test folders names.
vagrant@runtime1:~/go/src/github.com/cilium/cilium$ contrib/backporting/cherry-pick 1a370790e4f9341e4fafde5140d712b1b5d90149
Applying: 1a370790e4 agent: Delete endpoints which failed to restore synchronously
vagrant@runtime1:~/go/src/github.com/cilium/cilium$ contrib/backporting/cherry-pick 21b156fbb55c12fbf734be3b892d27d95c85a287
Applying: 21b156fbb5 exec: return for any error from context
vagrant@runtime1:~/go/src/github.com/cilium/cilium$ contrib/backporting/cherry-pick 7c40dedd4624b03973b17b8bf7aa910f0b26174b
Applying: 7c40dedd46 endpoint: add Context field to regenerationContext
vagrant@runtime1:~/go/src/github.com/cilium/cilium$ contrib/backporting/cherry-pick 7c588a70a3eed245067bca595305edc9a2be30da
Applying: 7c588a70a3 endpoint: use parent context with prepareForProxyUpdates
vagrant@runtime1:~/go/src/github.com/cilium/cilium$ contrib/backporting/cherry-pick bb1f2e1dc561b99a0b83a15be08c0fb15b8e9b10
Applying: bb1f2e1dc5 daemon: pass down context on endpoint creation into regeneration functionality
vagrant@runtime1:~/go/src/github.com/cilium/cilium$ contrib/backporting/cherry-pick 1f602bb2f0992560c2fb577acaa0cd6ed92ab31b
Applying: 1f602bb2f0 loader: check whether context is cancelled
vagrant@runtime1:~/go/src/github.com/cilium/cilium$ contrib/backporting/cherry-pick 7a352e08365b9c5bdcb099600d42f666541f8809
Applying: 7a352e0836 daemon: pass context down into QueueEndpointBuild
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7684)
<!-- Reviewable:end -->
