### PR TITLE
Improve logging around endpoint headerfile writes

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -130,6 +130,9 @@ func (e *Endpoint) writeInformationalComments(w io.Writer, owner Owner) error {
 
 func (e *Endpoint) writeHeaderfile(prefix string, owner Owner) error {
 	headerPath := filepath.Join(prefix, common.CHeaderFileName)
+	e.getLogger().WithFields(logrus.Fields{
+		logfields.Path: headerPath,
+	}).Debug("writing header file")
 	f, err := os.Create(headerPath)
 	if err != nil {
 		return fmt.Errorf("failed to open file %s for writing: %s", headerPath, err)

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2180,7 +2180,7 @@ func (e *Endpoint) PinDatapathMap() error {
 	return err
 }
 
-func (e *Endpoint) syncEndpointHeaderFile(owner Owner) {
+func (e *Endpoint) syncEndpointHeaderFile(owner Owner, reasons []string) {
 	e.BuildMutex.Lock()
 	defer e.BuildMutex.Unlock()
 
@@ -2190,7 +2190,11 @@ func (e *Endpoint) syncEndpointHeaderFile(owner Owner) {
 	}
 	defer e.Unlock()
 
-	e.writeHeaderfile(e.StateDirectoryPath(), owner)
+	if err := e.writeHeaderfile(e.StateDirectoryPath(), owner); err != nil {
+		e.getLogger().WithFields(logrus.Fields{
+			logfields.Reason: reasons,
+		}).WithError(err).Warning("could not sync header file")
+	}
 }
 
 // SyncEndpointHeaderFile it bumps the current DNS History information for the
@@ -2207,7 +2211,7 @@ func (e *Endpoint) SyncEndpointHeaderFile(owner Owner) error {
 			Name:              "sync_endpoint_header_file",
 			PrometheusMetrics: false,
 			MinInterval:       5 * time.Second,
-			TriggerFunc:       func(reasons []string) { e.syncEndpointHeaderFile(owner) },
+			TriggerFunc:       func(reasons []string) { e.syncEndpointHeaderFile(owner, reasons) },
 		})
 		if err != nil {
 			return fmt.Errorf(


### PR DESCRIPTION
We haven't been performing any logging around header file writes,
even when errors occur during filesystem interaction. Add a debug log
before writing, and log any errors that may occur at debug level.

I'll nominate this for v1.5, just because if any errors occur here then we'd have no way to tell. Feel free to push back if you're concerned about it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7685)
<!-- Reviewable:end -->
