### PR TITLE
Vagrantfiles: bump version to 144

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -124,7 +124,7 @@ Vagrant.configure(2) do |config|
         vb.customize ["modifyvm", :id, "--audio", "none"]
 
         config.vm.box = "cilium/ubuntu-dev"
-        config.vm.box_version = "143"
+        config.vm.box_version = "144"
         vb.memory = ENV['VM_MEMORY'].to_i
         vb.cpus = ENV['VM_CPUS'].to_i
         if ENV["NFS"] then

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -8,7 +8,7 @@ $K8S_VERSION = ENV['K8S_VERSION'] || "1.14"
 $K8S_NODES = (ENV['K8S_NODES'] || "2").to_i
 $NFS = ENV['NFS']=="1"? true : false
 $SERVER_BOX = (ENV['SERVER_BOX'] || "cilium/ubuntu-dev")
-$SERVER_VERSION= "143"
+$SERVER_VERSION= "144"
 $NETNEXT_SERVER_BOX= "cilium/ubuntu-next"
 $NETNEXT_SERVER_VERSION= "21"
 $IPv6=(ENV['IPv6'] || "0")


### PR DESCRIPTION
This new VM caches the following image docker.io/cilium/istio_proxy_debug:1.0.0

Caching this image will reduce the amount of time the Istio CI tests take.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7689)
<!-- Reviewable:end -->
