### PR TITLE
Node: Try to prioritize the InternalIPv[46] from restore.

### DIFF
--- a/pkg/node/node_address.go
+++ b/pkg/node/node_address.go
@@ -66,7 +66,7 @@ func SetIPv4ClusterCidrMaskSize(size int) {
 // scope will be regarded as the system's node address.
 func InitDefaultPrefix(device string) {
 	if option.Config.EnableIPv4 {
-		ip, err := firstGlobalV4Addr(device)
+		ip, err := firstGlobalV4Addr(device, GetInternalIPv4())
 		if err != nil {
 			return
 		}
@@ -101,7 +101,7 @@ func InitDefaultPrefix(device string) {
 	if option.Config.EnableIPv6 {
 		if ipv6Address == nil {
 			// Find a IPv6 node address first
-			ipv6Address = findIPv6NodeAddr()
+			ipv6Address = findIPv6NodeAddr(GetIPv6Router())
 			if ipv6Address == nil {
 				ipv6Address = makeIPv6HostIP()
 			}

--- a/pkg/node/node_address_darwin.go
+++ b/pkg/node/node_address_darwin.go
@@ -20,11 +20,11 @@ import (
 	"net"
 )
 
-func firstGlobalV4Addr(intf string) (net.IP, error) {
+func firstGlobalV4Addr(intf string, preferredIP net.IP) (net.IP, error) {
 	return net.IP{}, nil
 }
 
-func findIPv6NodeAddr() net.IP {
+func findIPv6NodeAddr(preferredIP net.IP) net.IP {
 	return net.IP{}
 }
 


### PR DESCRIPTION
On case of Cilium restore can choose different Node CIDR, and the
endpoints will no restore correctly due to the IP CIDR mismatch.

This change will list all IPS, and if the IP that it is on
`node_config.h` is present in the list of the IPs will be selected, in
case that it is not present (new installation) will list all the address
with the RT_SCOPE_UNIVERSE  and sort that to try to return always the
same results.

Fix #7637

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7690)
<!-- Reviewable:end -->
