### PR TITLE
v1.4 backports 2019-04-12

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1534,11 +1534,7 @@
   revision = "kubernetes-1.14.0"
 
 [[projects]]
-<<<<<<< HEAD
-  digest = "1:e00a2f6e9516b21e01cf2878e2926fee4cf8ec1be1b4b36f201d7c31ccc1ce4d"
-=======
   digest = "1:8342528e1275c10c0db434bd9e4853bacd901835366a1734fe112c731a2deda3"
->>>>>>> vendor: update dependencies to k8s 1.14.0-rc.1
   name = "k8s.io/client-go"
   packages = [
     "discovery",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -596,17 +596,6 @@
   revision = "26a6070f849969ba72b72256e9f14cf519751690"
 
 [[projects]]
-  branch = "master"
-  digest = "1:7fdf3223c7372d1ced0b98bf53457c5e89d89aecbad9a77ba9fcc6e01f9e5621"
-  name = "github.com/gregjones/httpcache"
-  packages = [
-    ".",
-    "diskcache",
-  ]
-  pruneopts = "NUT"
-  revision = "9cad4c3443a7200dd6400aef47183728de563a38"
-
-[[projects]]
   digest = "1:a6870429d5083ea442fc6df86fa846dbe19f6f2a27607213594dd86debb10a52"
   name = "github.com/hashicorp/consul"
   packages = ["api"]
@@ -1456,7 +1445,7 @@
     "storage/v1beta1",
   ]
   pruneopts = "NUT"
-  revision = "kubernetes-1.14.0"
+  revision = "kubernetes-1.14.1"
 
 [[projects]]
   digest = "1:47ddb5be73e959bd73931c04911cd05e3f45d7f7c978a45eb817e1fb85e21da4"
@@ -1470,7 +1459,7 @@
     "pkg/features",
   ]
   pruneopts = "NUT"
-  revision = "kubernetes-1.14.0"
+  revision = "kubernetes-1.14.1"
 
 [[projects]]
   digest = "1:062b06c1ccb71c956f40a8627cc93dba1dc7713a21876572ccd0e314c5362884"
@@ -1521,7 +1510,7 @@
     "third_party/forked/golang/reflect",
   ]
   pruneopts = "NUT"
-  revision = "kubernetes-1.14.0"
+  revision = "kubernetes-1.14.1"
 
 [[projects]]
   digest = "1:fe60b6d8b8208ecb0e70e97963fef38ce27443c6934ec00a37f80a3f9372f42b"
@@ -1531,7 +1520,7 @@
     "pkg/util/feature",
   ]
   pruneopts = "NUT"
-  revision = "kubernetes-1.14.0"
+  revision = "kubernetes-1.14.1"
 
 [[projects]]
   digest = "1:8342528e1275c10c0db434bd9e4853bacd901835366a1734fe112c731a2deda3"
@@ -1642,7 +1631,7 @@
     "util/retry",
   ]
   pruneopts = "NUT"
-  revision = "173e5d72ee987b4e748b8609ed2959d385ac6370"
+  revision = "0435e1d065b132cd4915ab080c12c8f762c9df68"
   source = "https://github.com/cilium/client-go"
 
 [[projects]]
@@ -1669,7 +1658,7 @@
     "pkg/util",
   ]
   pruneopts = "T"
-  revision = "kubernetes-1.14.0"
+  revision = "kubernetes-1.14.1"
 
 [[projects]]
   digest = "1:da31d8be5af84b69ef83b212d833d8e10930cd9e8a876780a20099ea306c4c13"
@@ -1717,7 +1706,7 @@
     "pkg/registry/core/service/ipallocator",
   ]
   pruneopts = "NUT"
-  revision = "v1.14.0"
+  revision = "v1.14.1"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -467,28 +467,28 @@ required = [
 
 [[constraint]]
   name = "k8s.io/api"
-  revision = "kubernetes-1.14.0"
+  revision = "kubernetes-1.14.1"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
 
 [[constraint]]
   name = "k8s.io/apiextensions-apiserver"
-  revision = "kubernetes-1.14.0"
+  revision = "kubernetes-1.14.1"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
 
 [[override]]
   name = "k8s.io/apiserver"
-  revision = "kubernetes-1.14.0"
+  revision = "kubernetes-1.14.1"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
 
 [[constraint]]
   name = "k8s.io/apimachinery"
-  revision = "kubernetes-1.14.0"
+  revision = "kubernetes-1.14.1"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
@@ -496,14 +496,14 @@ required = [
 [[constraint]]
   name = "k8s.io/client-go"
   source = "https://github.com/cilium/client-go"
-  revision = "173e5d72ee987b4e748b8609ed2959d385ac6370"
+  revision = "0435e1d065b132cd4915ab080c12c8f762c9df68"
 
   # main-usage = "pkg/k8s"
-  # on-revision = "TODO @aanm is on 173e5d72ee987b4e748b8609ed2959d385ac6370 as it contains the hotfix for the metrics path"
+  # on-revision = "TODO @aanm is on 0435e1d065b132cd4915ab080c12c8f762c9df68 as it contains the hotfix for the metrics path"
 
 [[constraint]]
   name = "k8s.io/code-generator"
-  revision = "kubernetes-1.14.0"
+  revision = "kubernetes-1.14.1"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
@@ -517,7 +517,7 @@ required = [
 
 [[constraint]]
   name = "k8s.io/kubernetes"
-  revision = "v1.14.0"
+  revision = "v1.14.1"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""

--- a/contrib/backporting/check-stable
+++ b/contrib/backporting/check-stable
@@ -128,7 +128,7 @@ generate_commit_list_for_pr () {
   local entry_sub
   local upstream
 
-  remote=`git remote -v | grep "github.com.cilium/cilium" | head -n1 | cut -f1`
+  remote=`git remote -v | grep "github.com.cilium/cilium.git" | head -n1 | cut -f1`
 
   url="https://api.github.com/repos/cilium/cilium/pulls/$pr/commits"
   pr_json="$($GHCURL $url)"

--- a/contrib/backporting/cherry-pick
+++ b/contrib/backporting/cherry-pick
@@ -3,7 +3,7 @@ set -e
 
 cherry_pick () {
   CID=$1
-  REM=`git remote -v | grep "github.com.cilium/cilium" | head -n1 | cut -f1`
+  REM=`git remote -v | grep "github.com.cilium/cilium.git" | head -n1 | cut -f1`
   BRANCHES=`git branch -q -r --contains $CID $REM/master 2> /dev/null`
   if ! echo ${BRANCHES} | grep -q ".*$REM/master.*"; then
     echo "Commit $CID not in $REM/master!"

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -161,6 +161,19 @@ func fetchK8sLabels(ep *endpoint.Endpoint) (labels.Labels, labels.Labels, error)
 	return identityLabels, infoLabels, nil
 }
 
+func invalidDataError(ep *endpoint.Endpoint, err error) (*endpoint.Endpoint, int, error) {
+	ep.Logger(daemonSubsys).WithError(err).Warning("Creation of endpoint failed due to invalid data")
+	return nil, PutEndpointIDInvalidCode, err
+}
+
+func (d *Daemon) errorDuringCreation(ep *endpoint.Endpoint, err error) (*endpoint.Endpoint, int, error) {
+	// The IP has been provided by the caller and must be released
+	// by the caller
+	d.deleteEndpointQuiet(ep, true)
+	ep.Logger(daemonSubsys).WithError(err).Warning("Creation of endpoint failed")
+	return nil, PutEndpointIDFailedCode, err
+}
+
 // createEndpoint attempts to create the endpoint corresponding to the change
 // request that was specified. Returns the following errors types:
 //  * errEndpointInvalidParams - If the parameters are not valid

--- a/daemon/health.go
+++ b/daemon/health.go
@@ -100,7 +100,9 @@ func (d *Daemon) cleanupHealthEndpoint() {
 		log.Debug("Didn't find existing cilium-health endpoint to delete")
 	} else {
 		log.Debug("Removing existing cilium-health endpoint")
-		errs := d.deleteEndpointQuiet(ep, false)
+		errs := d.deleteEndpointQuiet(ep, endpoint.DeleteConfig{
+			NoIPRelease: true,
+		})
 		for _, err := range errs {
 			log.WithError(err).Debug("Error occurred while deleting cilium-health endpoint")
 		}

--- a/daemon/policy_test.go
+++ b/daemon/policy_test.go
@@ -520,7 +520,7 @@ func (ds *DaemonSuite) TestRemovePolicy(c *C) {
 
 	// Delete the endpoint.
 	e.UnconditionalLock()
-	e.LeaveLocked(ds.d, nil)
+	e.LeaveLocked(ds.d, nil, endpoint.DeleteConfig{})
 	e.Unlock()
 
 	// Check that the policy has been removed from the xDS cache.

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -269,7 +269,7 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) (resto
 				return
 			}
 
-			ep.LogStatusOKLocked(endpoint.Other, "Synchronizing endpoint labels with KVStore")
+			ep.SetStateLocked(endpoint.StateRestoring, "Synchronizing endpoint labels with KVStore")
 
 			if ep.SecurityIdentity != nil {
 				if oldSecID := ep.SecurityIdentity.ID; identity.ID != oldSecID {

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/cilium/cilium/common"
@@ -354,9 +355,23 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) (resto
 		}(ep, epRegenerated)
 	}
 
+	var endpointCleanupCompleted sync.WaitGroup
 	for _, ep := range state.toClean {
-		go d.deleteEndpointQuiet(ep, true)
+		endpointCleanupCompleted.Add(1)
+		go func(ep *endpoint.Endpoint) {
+			// The IP was not allocated yet so does not need to be free.
+			// The identity may be allocated in the kvstore but we can't
+			// release it easily as it will require to block on kvstore
+			// connectivity which we can't do at this point. Let the lease
+			// expire to release the identity.
+			d.deleteEndpointQuiet(ep, endpoint.DeleteConfig{
+				NoIdentityRelease: true,
+				NoIPRelease:       true,
+			})
+			endpointCleanupCompleted.Done()
+		}(ep)
 	}
+	endpointCleanupCompleted.Wait()
 
 	go func() {
 		regenerated, total := 0, 0

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -143,6 +143,30 @@ func NewClient(host string) (*Client, error) {
 	return &Client{*clientapi.New(clientTrans, strfmt.Default)}, nil
 }
 
+// ClientError is the error returned by all client functions which use Hint()
+type ClientError struct {
+	msg         string
+	recoverable bool
+}
+
+// Recoverable returns true if the error is likely to be recoverable
+func (c ClientError) Recoverable() bool {
+	return c.recoverable
+}
+
+// Error returns the error message representing the error
+func (c ClientError) Error() string {
+	return c.msg
+}
+
+func newRecoverableError(msg string, args ...interface{}) ClientError {
+	return ClientError{recoverable: true, msg: fmt.Sprintf(msg, args...)}
+}
+
+func newUnrecoverableError(msg string, args ...interface{}) ClientError {
+	return ClientError{recoverable: false, msg: fmt.Sprintf(msg, args...)}
+}
+
 // Hint tries to improve the error message displayed to the user.
 func Hint(err error) error {
 	if err == nil {
@@ -150,14 +174,14 @@ func Hint(err error) error {
 	}
 
 	if err == context.DeadlineExceeded {
-		return fmt.Errorf("Cilium API client timeout exceeded")
+		return newRecoverableError("Cilium API client timeout exceeded")
 	}
 
 	e, _ := url.PathUnescape(err.Error())
 	if strings.Contains(err.Error(), defaults.SockPath) {
-		return fmt.Errorf("%s\nIs the agent running?", e)
+		return newRecoverableError("%s\nIs the agent running?", e)
 	}
-	return fmt.Errorf("%s", e)
+	return newUnrecoverableError("%s", e)
 }
 
 func timeSince(since time.Time) string {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1446,9 +1446,20 @@ func (e *Endpoint) replaceIdentityLabels(l pkgLabels.Labels) int {
 	return rev
 }
 
+// DeleteConfig is the endpoint deletion configuration
+type DeleteConfig struct {
+	NoIPRelease       bool
+	NoIdentityRelease bool
+}
+
 // LeaveLocked removes the endpoint's directory from the system. Must be called
 // with Endpoint's mutex AND BuildMutex locked.
-func (e *Endpoint) LeaveLocked(owner Owner, proxyWaitGroup *completion.WaitGroup) []error {
+//
+// Note: LeaveLocked() is called indirectly from endpoint restore logic for
+// endpoints which failed to be restored. Any cleanup routine of LeaveLocked()
+// which depends on kvstore connectivity must be protected by a flag in
+// DeleteConfig and the restore logic must opt-out of it.
+func (e *Endpoint) LeaveLocked(owner Owner, proxyWaitGroup *completion.WaitGroup, conf DeleteConfig) []error {
 	errors := []error{}
 
 	owner.RemoveFromEndpointQueue(uint64(e.ID))
@@ -1469,7 +1480,7 @@ func (e *Endpoint) LeaveLocked(owner Owner, proxyWaitGroup *completion.WaitGroup
 		}
 	}
 
-	if e.SecurityIdentity != nil {
+	if !conf.NoIdentityRelease && e.SecurityIdentity != nil {
 		_, err := cache.Release(context.Background(), e.SecurityIdentity)
 		if err != nil {
 			errors = append(errors, fmt.Errorf("unable to release identity: %s", err))

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1218,6 +1218,11 @@ func ParseEndpoint(strEp string) (*Endpoint, error) {
 		ep.Status = NewEndpointStatus()
 	}
 
+	if ep.SecurityIdentity == nil {
+		ep.SetIdentity(identityPkg.LookupReservedIdentity(identityPkg.ReservedIdentityInit))
+	} else {
+		ep.SecurityIdentity.Sanitize()
+	}
 	ep.UpdateLogger(nil)
 
 	ep.SetStateLocked(StateRestoring, "Endpoint restoring")

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -80,12 +80,17 @@ func NewIdentityFromModel(base *models.Identity) *Identity {
 		lbl := labels.ParseLabel(v)
 		id.Labels[lbl.Key] = lbl
 	}
+	id.Sanitize()
 
+	return id
+}
+
+// Sanitize takes a partially initialized Identity (for example, deserialized
+// from json) and reconstitutes the full object from what has been restored.
+func (id *Identity) Sanitize() {
 	if id.Labels != nil {
 		id.LabelArray = id.Labels.LabelArray()
 	}
-
-	return id
 }
 
 // GetLabelsSHA256 returns the SHA256 of the labels associated with the

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -189,7 +189,7 @@ case $K8S_VERSION in
         ;;
     "1.14")
         KUBERNETES_CNI_VERSION="0.7.5"
-        K8S_FULL_VERSION="1.14.0"
+        K8S_FULL_VERSION="1.14.1"
         KUBEADM_OPTIONS="--ignore-preflight-errors=cri"
         KUBEADM_SLAVE_OPTIONS="--discovery-token-unsafe-skip-ca-verification --ignore-preflight-errors=cri,SystemVerification"
         sudo ln -sf $COREDNS_DEPLOYMENT $DNS_DEPLOYMENT

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -99,7 +99,8 @@ func TestTest(t *testing.T) {
 	junitReporter := ginkgoext.NewJUnitReporter(fmt.Sprintf(
 		"%s.xml", helpers.GetScopeWithVersion()))
 	RunSpecsWithDefaultAndCustomReporters(
-		t, helpers.GetScopeWithVersion(), []ginkgo.Reporter{junitReporter})
+		t, fmt.Sprintf("Suite-%s", helpers.GetScopeWithVersion()),
+		[]ginkgo.Reporter{junitReporter})
 }
 
 func goReportVagrantStatus() chan bool {

--- a/vendor/k8s.io/client-go/rest/request.go
+++ b/vendor/k8s.io/client-go/rest/request.go
@@ -469,7 +469,16 @@ func (r Request) finalURLTemplate() url.URL {
 	groupIndex := 0
 	index := 0
 	if r.URL() != nil && r.baseURL != nil && strings.Contains(r.URL().Path, r.baseURL.Path) {
-		groupIndex += len(strings.Split(r.baseURL.Path, "/"))
+		// only add baseURL path length if it is different than `/`
+		// as strings.Split("/", "/") returns length of 2
+		if r.baseURL.Path != "/" {
+			// We need to perform a `path.Join` as path.Join appends `/` to a
+			// path that does not contain `/` and removes duplicate `/` if they
+			// exist.
+			groupIndex += len(strings.Split(path.Join("/", r.baseURL.Path), "/"))
+		} else {
+			groupIndex += 1
+		}
 	}
 	if groupIndex >= len(segments) {
 		return *url
@@ -477,14 +486,20 @@ func (r Request) finalURLTemplate() url.URL {
 
 	const CoreGroupPrefix = "api"
 	const NamedGroupPrefix = "apis"
+	const Version = "version"
 	isCoreGroup := segments[groupIndex] == CoreGroupPrefix
 	isNamedGroup := segments[groupIndex] == NamedGroupPrefix
+	isVersion := segments[groupIndex] == Version
 	if isCoreGroup {
 		// checking the case of core group with /api/v1/... format
 		index = groupIndex + 2
 	} else if isNamedGroup {
 		// checking the case of named group with /apis/apps/v1/... format
 		index = groupIndex + 3
+	} else if isVersion {
+		url.Path = "/version"
+		url.RawQuery = ""
+		return *url
 	} else {
 		// this should not happen that the only two possibilities are /api... and /apis..., just want to put an
 		// outlet here in case more API groups are added in future if ever possible:
@@ -517,7 +532,7 @@ func (r Request) finalURLTemplate() url.URL {
 			segments[index+3] = "{name}"
 		}
 	}
-	url.Path = path.Join(segments...)
+	url.Path = strings.Join(segments, "/")
 	return *url
 }
 


### PR DESCRIPTION
includes a fix in `Gopkg.lock` file (leftover from merge conflict in previous backports)

* #7657 -- Don't use local remote in check-stable script (@nebril)
 * #7664 -- update k8s libraries and CI to 1.14.1 (@aanm)
 * #7674 -- Fix Junit attachment in runtime test.  (@eloycoto)
 * #7667 -- agent: Delete endpoints which failed to restore synchronously (@tgraf)
 * #7682 -- Sanitize endpoint security identity upon restore (@joestringer)
 * #7670 -- Fix various CNI add/delete handling bugs (@tgraf)

Once this PR is merged, you can update the PR labels via:
```
$ for pr in 7657 7664 7674 7667 7682 7670; do contrib/backporting/set-labels.py $pr done 1.4; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7695)
<!-- Reviewable:end -->
