### PR TITLE
v1.3 backports 2019-04-12

### DIFF
--- a/contrib/backporting/check-stable
+++ b/contrib/backporting/check-stable
@@ -128,7 +128,7 @@ generate_commit_list_for_pr () {
   local entry_sub
   local upstream
 
-  remote=`git remote -v | grep "github.com.cilium/cilium" | head -n1 | cut -f1`
+  remote=`git remote -v | grep "github.com.cilium/cilium.git" | head -n1 | cut -f1`
 
   url="https://api.github.com/repos/cilium/cilium/pulls/$pr/commits"
   pr_json="$($GHCURL $url)"

--- a/contrib/backporting/cherry-pick
+++ b/contrib/backporting/cherry-pick
@@ -3,7 +3,7 @@ set -e
 
 cherry_pick () {
   CID=$1
-  REM=`git remote -v | grep "github.com.cilium/cilium" | head -n1 | cut -f1`
+  REM=`git remote -v | grep "github.com.cilium/cilium.git" | head -n1 | cut -f1`
   BRANCHES=`git branch -q -r --contains $CID $REM/master 2> /dev/null`
   if ! echo ${BRANCHES} | grep -q ".*$REM/master.*"; then
     echo "Commit $CID not in $REM/master!"


### PR DESCRIPTION
* #7657 -- Don't use local remote in check-stable script (@nebril)

Once this PR is merged, you can update the PR labels via:
```
$ for pr in 7657; do contrib/backporting/set-labels.py $pr done 1.3; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7696)
<!-- Reviewable:end -->
