### PR TITLE
test: decrease HelperTimeout to 4 minutes

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -28,7 +28,7 @@ import (
 
 var (
 	// HelperTimeout is a predefined timeout value for commands.
-	HelperTimeout = 5 * time.Minute
+	HelperTimeout = 4 * time.Minute
 
 	// CiliumStartTimeout is a predefined timeout value for Cilium startup.
 	CiliumStartTimeout = 100 * time.Second


### PR DESCRIPTION
See whether the CI can handle lower timeouts for letting resources get ready to reduce the amount of time failed test runs take.

Signed-off by: Ian Vernon <ian@cilium.io>

I think we should ideally tune the CI so that we can have lean enough timeouts to not have false-negatives, but not allow for bad performance in certain cases. The current timeout of 5 minutes for things like importing policy, waiting for pods to be ready, etc., is too generous. It allows for things to get swept under the rug. Ideally, over time, we should try to guarantee certain timeouts for specific operations (policy import, etc.).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7705)
<!-- Reviewable:end -->
