### PR TITLE
misc. logging cleanups

### DIFF
--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -1406,7 +1406,7 @@ func (d *Daemon) updateCiliumNetworkPolicyV2AnnotationsOnly(ciliumNPClient clien
 		logfields.K8sNamespace:            cnp.ObjectMeta.Namespace,
 	})
 
-	scopedLog.Infof("updating node status due to annotations-only change to CiliumNetworkPolicy")
+	scopedLog.Info("updating node status due to annotations-only change to CiliumNetworkPolicy")
 
 	ctrlName := cnp.GetControllerName()
 

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -212,7 +212,7 @@ func (d *Daemon) restoreOldEndpoints(dir string, clean bool) (*endpointRestoreSt
 func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) (restoreComplete chan struct{}) {
 	restoreComplete = make(chan struct{}, 0)
 
-	log.Infof("Regenerating %d restored endpoints", len(state.restored))
+	log.WithField("numRestored", len(state.restored)).Info("Regenerating restored endpoints")
 
 	// Before regenerating, check whether the CT map has properties that
 	// match this Cilium userspace instance. If not, it must be removed

--- a/pkg/datapath/loader/loader_test.go
+++ b/pkg/datapath/loader/loader_test.go
@@ -114,7 +114,7 @@ func runTests(m *testing.M) (int, error) {
 	}
 	defer func() {
 		if err := cleanup(); err != nil {
-			log.Errorf(err.Error())
+			log.Error(err.Error())
 		}
 	}()
 

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -489,11 +489,19 @@ func (e *Endpoint) realizeBPFState(regenContext *regenerationContext) (compilati
 		// Compile and install BPF programs for this endpoint
 		if datapathRegenCtxt.regenerationLevel == RegenerateWithDatapathRebuild {
 			err = loader.CompileOrLoad(datapathRegenCtxt.completionCtx, datapathRegenCtxt.epInfoCache, &stats.datapathRealization)
-			e.getLogger().WithError(err).Info("Rewrote endpoint BPF program")
+			if err == nil {
+				e.getLogger().Info("Rewrote endpoint BPF program")
+			} else {
+				e.getLogger().WithError(err).Error("Error while rewriting endpoint BPF program")
+			}
 			compilationExecuted = true
 		} else { // RegenerateWithDatapathLoad
 			err = loader.ReloadDatapath(datapathRegenCtxt.completionCtx, datapathRegenCtxt.epInfoCache, &stats.datapathRealization)
-			e.getLogger().WithError(err).Info("Reloaded endpoint BPF program")
+			if err == nil {
+				e.getLogger().Info("Reloaded endpoint BPF program")
+			} else {
+				e.getLogger().WithError(err).Error("Error while reloading endpoint BPF program")
+			}
 		}
 		close(closeChan)
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1208,7 +1208,7 @@ func (e *Endpoint) Update(owner Owner, cfg *models.EndpointConfigurationSpec) er
 				}
 				e.Unlock()
 			case <-timeout:
-				e.getLogger().Warningf("timed out waiting for endpoint state to change")
+				e.getLogger().Warning("timed out waiting for endpoint state to change")
 				return UpdateStateChangeError{fmt.Sprintf("unable to regenerate endpoint program because state transition to %s was unsuccessful; check `cilium endpoint log %d` for more information", StateWaitingToRegenerate, e.ID)}
 			}
 		}

--- a/pkg/kvstore/config.go
+++ b/pkg/kvstore/config.go
@@ -17,6 +17,8 @@ package kvstore
 import (
 	"fmt"
 	"sync"
+
+	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
 var (
@@ -33,7 +35,7 @@ func setOpts(opts map[string]string, supportedOpts backendOptions) error {
 		opt, ok := supportedOpts[key]
 		if !ok {
 			errors++
-			log.Errorf("unknown kvstore configuration key %q", key)
+			log.WithField(logfields.Key, key).Error("unknown kvstore configuration key")
 			continue
 		}
 

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -267,7 +267,7 @@ func doGC6(m *Map, filter *GCFilter) gcStats {
 		case deleteEntry:
 			err := purgeCtEntry6(m, currentKey, natMap)
 			if err != nil {
-				log.WithError(err).Errorf("Unable to delete CT entry %s", currentKey.String())
+				log.WithError(err).WithField(logfields.Key, currentKey.String()).Error("Unable to delete CT entry")
 			} else {
 				stats.deleted++
 			}
@@ -316,7 +316,7 @@ func doGC4(m *Map, filter *GCFilter) gcStats {
 		case deleteEntry:
 			err := purgeCtEntry4(m, currentKey, natMap)
 			if err != nil {
-				log.WithError(err).Errorf("Unable to delete CT entry %s", currentKey.String())
+				log.WithError(err).WithField(logfields.Key, currentKey.String()).Error("Unable to delete CT entry")
 			} else {
 				stats.deleted++
 			}

--- a/pkg/maps/nat/nat.go
+++ b/pkg/maps/nat/nat.go
@@ -160,7 +160,7 @@ func doFlush4(m *Map) gcStats {
 		currentKey := key.(*tuple.TupleKey4Global)
 		err := m.Delete(currentKey)
 		if err != nil {
-			log.WithError(err).Errorf("Unable to delete CT entry %s", currentKey.String())
+			log.WithError(err).WithField(logfields.Key, currentKey.String()).Error("Unable to delete CT entry")
 		} else {
 			stats.deleted++
 		}
@@ -175,7 +175,7 @@ func doFlush6(m *Map) gcStats {
 		currentKey := key.(*tuple.TupleKey6Global)
 		err := m.Delete(currentKey)
 		if err != nil {
-			log.WithError(err).Errorf("Unable to delete CT entry %s", currentKey.String())
+			log.WithError(err).WithField(logfields.Key, currentKey.String()).Error("Unable to delete CT entry")
 		} else {
 			stats.deleted++
 		}

--- a/pkg/workloads/containerd.go
+++ b/pkg/workloads/containerd.go
@@ -159,7 +159,7 @@ func (c *containerDClient) EnableEventListener() (eventsCh chan<- *EventMessage,
 		for {
 			eventsCh, errCh := c.Client.Subscribe(context.Background(), `topic~="/containers/create"`, `topic~="/containers/delete"`)
 			err := c.listenForContainerDEvents(ws, eventsCh, errCh)
-			log.WithError(err).Errorf("failed to listen events")
+			log.WithError(err).Error("failed to listen events")
 		}
 	}(ws)
 	return nil, nil

--- a/pkg/workloads/cri.go
+++ b/pkg/workloads/cri.go
@@ -278,7 +278,7 @@ func (c *criClient) IgnoreRunningWorkloads() {
 
 	resp, err := c.RuntimeServiceClient.ListPodSandbox(context.Background(), req)
 	if err != nil {
-		log.WithError(err).Errorf("unable to get list of pods running")
+		log.WithError(err).Error("unable to get list of pods running")
 		return
 	}
 	for _, pod := range resp.GetItems() {

--- a/pkg/workloads/docker.go
+++ b/pkg/workloads/docker.go
@@ -359,7 +359,7 @@ func (d *dockerClient) getEndpointByIP(cont *dTypes.ContainerJSON) *endpoint.End
 		if contNetwork.GlobalIPv6Address != "" {
 			id := endpointid.NewID(endpointid.IPv6Prefix, contNetwork.GlobalIPv6Address)
 			if ep, err := endpointmanager.Lookup(id); err != nil {
-				log.WithError(err).Warningf("Unable to lookup endpoint by IP prefix %s", id)
+				log.WithError(err).WithField(logfields.V6Prefix, id).Warning("Unable to lookup endpoint by IP prefix")
 			} else if ep != nil {
 				return ep
 			}
@@ -368,7 +368,7 @@ func (d *dockerClient) getEndpointByIP(cont *dTypes.ContainerJSON) *endpoint.End
 		if contNetwork.IPAddress != "" {
 			id := endpointid.NewID(endpointid.IPv4Prefix, contNetwork.IPAddress)
 			if ep, err := endpointmanager.Lookup(id); err != nil {
-				log.WithError(err).Warningf("Unable to lookup endpoint by IP prefix %s", id)
+				log.WithError(err).WithField(logfields.V4Prefix, id).Warning("Unable to lookup endpoint by IP prefix")
 			} else if ep != nil {
 				return ep
 			}


### PR DESCRIPTION
* Change some log messages to use \`WithField\` so logged errors are more generic.
* Remove unnecessary \`Infof\`, \`Warningf\`, and \`Errorf\` invocations.
* change how endpoint BPF reloading / writing logs are emitted. The log messages for rewriting / reloading endpoint BPF programs always said that the endpoint's program was rewritten or reloaded, even if said operations had an error. If the operation occurred without error, log at Debug level to reduce the amount of these logs, as they scale to the number of endpoints on the node. If there is an error, log it at Warning level instead of Info level as was done before.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7706)
<!-- Reviewable:end -->
