### PR TITLE
operator: GC nodes from existing CNPs

### DIFF
--- a/pkg/k8s/json_patch.go
+++ b/pkg/k8s/json_patch.go
@@ -14,6 +14,12 @@
 
 package k8s
 
+const(
+	// maximum number of operations a single json patch may contain.
+	// See https://github.com/kubernetes/kubernetes/pull/74000
+	MaxJSONPatchOperations = 10000
+)
+
 // JSONPatch structure based on the RFC 6902
 type JSONPatch struct {
 	OP    string      `json:"op,omitempty"`


### PR DESCRIPTION
~~:rotating_light:  :warning:  :warning: :rotating_light:  **this PR is going to be merge against https://github.com/cilium/cilium/pull/7675 and not master.** :rotating_light:  :warning:  :warning: :rotating_light:~~
 
As nodes can be removed from the cluster their status in the CNP can be
left behind. The operator will be checking if nodes are still running
and if not, they will be removed from the CNP Node Status.

Signed-off-by: André Martins <andre@cilium.io>

Should we backport this to v1.4 and v1.3?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7707)
<!-- Reviewable:end -->
