### PR TITLE
Support forcing full regeneration of an endpoint

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -487,7 +487,11 @@ func (e *Endpoint) realizeBPFState(regenContext *regenerationContext) (compilati
 		closeChan := loadinfo.LogPeriodicSystemLoad(log.WithFields(logrus.Fields{logfields.EndpointID: e.StringID()}).Debugf, time.Second)
 
 		// Compile and install BPF programs for this endpoint
-		if datapathRegenCtxt.regenerationLevel == RegenerateWithDatapathRewrite {
+		if datapathRegenCtxt.regenerationLevel == RegenerateWithDatapathRebuild {
+			err = loader.CompileAndLoad(datapathRegenCtxt.completionCtx, datapathRegenCtxt.epInfoCache, &stats.datapathRealization)
+			e.getLogger().WithError(err).Info("Regenerated endpoint BPF program")
+			compilationExecuted = true
+		} else if datapathRegenCtxt.regenerationLevel == RegenerateWithDatapathRewrite {
 			err = loader.CompileOrLoad(datapathRegenCtxt.completionCtx, datapathRegenCtxt.epInfoCache, &stats.datapathRealization)
 			e.getLogger().WithError(err).Info("Rewrote endpoint BPF program")
 			compilationExecuted = true

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -487,7 +487,7 @@ func (e *Endpoint) realizeBPFState(regenContext *regenerationContext) (compilati
 		closeChan := loadinfo.LogPeriodicSystemLoad(log.WithFields(logrus.Fields{logfields.EndpointID: e.StringID()}).Debugf, time.Second)
 
 		// Compile and install BPF programs for this endpoint
-		if datapathRegenCtxt.regenerationLevel == RegenerateWithDatapathRebuild {
+		if datapathRegenCtxt.regenerationLevel == RegenerateWithDatapathRewrite {
 			err = loader.CompileOrLoad(datapathRegenCtxt.completionCtx, datapathRegenCtxt.epInfoCache, &stats.datapathRealization)
 			e.getLogger().WithError(err).Info("Rewrote endpoint BPF program")
 			compilationExecuted = true
@@ -701,18 +701,18 @@ func (e *Endpoint) runPreCompilationSteps(owner Owner, regenContext *regeneratio
 	if err != nil {
 		e.getLogger().WithError(err).Warn("Unable to hash header file")
 		datapathRegenCtxt.bpfHeaderfilesHash = ""
-		datapathRegenCtxt.regenerationLevel = RegenerateWithDatapathRebuild
+		datapathRegenCtxt.regenerationLevel = RegenerateWithDatapathRewrite
 	} else {
 		changed := (datapathRegenCtxt.bpfHeaderfilesHash != e.bpfHeaderfileHash)
 		if changed {
-			datapathRegenCtxt.regenerationLevel = RegenerateWithDatapathRebuild
+			datapathRegenCtxt.regenerationLevel = RegenerateWithDatapathRewrite
 		}
 		e.getLogger().WithField(logfields.BPFHeaderfileHash, datapathRegenCtxt.bpfHeaderfilesHash).
 			Debugf("BPF header file hashed (was: %q)", e.bpfHeaderfileHash)
 	}
 
 	// Cache endpoint information so that we can release the endpoint lock.
-	if datapathRegenCtxt.regenerationLevel >= RegenerateWithDatapathRebuild {
+	if datapathRegenCtxt.regenerationLevel >= RegenerateWithDatapathRewrite {
 		datapathRegenCtxt.epInfoCache = e.createEpInfoCache(nextDir)
 	} else {
 		datapathRegenCtxt.epInfoCache = e.createEpInfoCache(currentDir)

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1168,10 +1168,10 @@ func (e *Endpoint) Update(owner Owner, cfg *models.EndpointConfigurationSpec) er
 	// If configuration options are provided, we only regenerate if necessary.
 	// Otherwise always regenerate.
 	if cfg.Options == nil {
-		regenCtx.RegenerationLevel = RegenerateWithDatapathRebuild
+		regenCtx.RegenerationLevel = RegenerateWithDatapathRewrite
 		regenCtx.Reason = "endpoint was manually regenerated via API"
 	} else if e.updateAndOverrideEndpointOptions(om) || e.Status.CurrentStatus() != OK {
-		regenCtx.RegenerationLevel = RegenerateWithDatapathRebuild
+		regenCtx.RegenerationLevel = RegenerateWithDatapathRewrite
 	}
 
 	if regenCtx.RegenerationLevel > RegenerateWithoutDatapath {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1168,7 +1168,7 @@ func (e *Endpoint) Update(owner Owner, cfg *models.EndpointConfigurationSpec) er
 	// If configuration options are provided, we only regenerate if necessary.
 	// Otherwise always regenerate.
 	if cfg.Options == nil {
-		regenCtx.RegenerationLevel = RegenerateWithDatapathRewrite
+		regenCtx.RegenerationLevel = RegenerateWithDatapathRebuild
 		regenCtx.Reason = "endpoint was manually regenerated via API"
 	} else if e.updateAndOverrideEndpointOptions(om) || e.Status.CurrentStatus() != OK {
 		regenCtx.RegenerationLevel = RegenerateWithDatapathRewrite

--- a/pkg/endpoint/regenerationcontext.go
+++ b/pkg/endpoint/regenerationcontext.go
@@ -35,6 +35,9 @@ const (
 	// RegenerateWithDatapathRewrite indicates that the datapath must be
 	// recompiled and reloaded to implement this regeneration.
 	RegenerateWithDatapathRewrite
+	// RegenerateWithDatapathRebuild indicates that the datapath must be
+	// fully recompiled and reloaded without using any cached templates.
+	RegenerateWithDatapathRebuild
 )
 
 // String converts a DatapathRegenerationLevel into a human-readable string.
@@ -46,6 +49,8 @@ func (r DatapathRegenerationLevel) String() string {
 		return "reload"
 	case RegenerateWithDatapathRewrite:
 		return "rewrite+load"
+	case RegenerateWithDatapathRebuild:
+		return "compile+load"
 	default:
 		break
 	}

--- a/pkg/endpoint/regenerationcontext.go
+++ b/pkg/endpoint/regenerationcontext.go
@@ -32,9 +32,9 @@ const (
 	// RegenerateWithDatapathLoad indicates that the datapath must be
 	// reloaded but not recompiled to implement this regeneration.
 	RegenerateWithDatapathLoad
-	// RegenerateWithDatapathRebuild indicates the the datapath must be
+	// RegenerateWithDatapathRewrite indicates that the datapath must be
 	// recompiled and reloaded to implement this regeneration.
-	RegenerateWithDatapathRebuild
+	RegenerateWithDatapathRewrite
 )
 
 // String converts a DatapathRegenerationLevel into a human-readable string.
@@ -44,8 +44,8 @@ func (r DatapathRegenerationLevel) String() string {
 		return "no-rebuild"
 	case RegenerateWithDatapathLoad:
 		return "reload"
-	case RegenerateWithDatapathRebuild:
-		return "compile+load"
+	case RegenerateWithDatapathRewrite:
+		return "rewrite+load"
 	default:
 		break
 	}


### PR DESCRIPTION
Plumb the endpoint regeneration CLI command through to actually fully
rebuild the endpoint. This provides an ultimate backstop for kicking an
endpoint if all else fails (or if a developer wants to test something).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7711)
<!-- Reviewable:end -->
