### PR TITLE
CI: Enforce sensible timeouts.

### DIFF
--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -115,8 +115,13 @@ type TimeoutConfig struct {
 // the timeout in config is reached. Returns an error if the timeout is
 // exceeded for body to execute successfully.
 func WithTimeout(body func() bool, msg string, config *TimeoutConfig) error {
+	if config.Timeout < 10 * time.Second {
+		return fmt.Errorf("Timeout too short (must be at least 10 seconds): %v", config.Timeout)
+	}
 	if config.Ticker == 0 {
-		config.Ticker = 5
+		config.Ticker = 5 * time.Second
+	} else if config.Ticker < time.Second {
+		return fmt.Errorf("Timeout config Ticker interval too short (must be at least 1 second): %v", config.Ticker)
 	}
 
 	done := time.After(config.Timeout)

--- a/test/k8sT/KafkaPolicies.go
+++ b/test/k8sT/KafkaPolicies.go
@@ -17,6 +17,7 @@ package k8sTest
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/test/ginkgo-ext"
@@ -94,7 +95,7 @@ var _ = Describe("K8sKafkaPolicyTest", func() {
 				}
 				return true
 			}
-			err := helpers.WithTimeout(body, fmt.Sprintf("unable to resolve DNS for service %s in pod %s", service, pod), &helpers.TimeoutConfig{Timeout: 30})
+			err := helpers.WithTimeout(body, fmt.Sprintf("unable to resolve DNS for service %s in pod %s", service, pod), &helpers.TimeoutConfig{Timeout: 30 * time.Second})
 			return err
 		}
 

--- a/test/k8sT/microscope.go
+++ b/test/k8sT/microscope.go
@@ -15,6 +15,8 @@
 package k8sTest
 
 import (
+	"time"
+
 	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
 
@@ -53,8 +55,8 @@ var _ = Describe("K8sMicroscope", func() {
 			return res.WasSuccessful()
 		}, "running microscope processes not found",
 			&helpers.TimeoutConfig{
-				Ticker:  5,
-				Timeout: 120,
+				Ticker:  5 * time.Second,
+				Timeout: 120 * time.Second,
 			})
 
 		Expect(err).To(BeNil())
@@ -67,8 +69,8 @@ var _ = Describe("K8sMicroscope", func() {
 			return !res.WasSuccessful()
 		}, "found running microscope processes; no microscope processes should be running",
 			&helpers.TimeoutConfig{
-				Ticker:  5,
-				Timeout: 120,
+				Ticker:  5 * time.Second,
+				Timeout: 120 * time.Second,
 			})
 		Expect(err).To(BeNil())
 	})

--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
@@ -90,7 +91,7 @@ var runtimeConnectivityTest = func(datapathMode string) func() {
 						return false
 					}
 					return true
-				}, "Endpoints are not ready", &helpers.TimeoutConfig{Timeout: 150})
+				}, "Endpoints are not ready", &helpers.TimeoutConfig{Timeout: 150 * time.Second})
 				Expect(err).Should(BeNil())
 			}, 150)
 
@@ -132,7 +133,7 @@ var runtimeConnectivityTest = func(datapathMode string) func() {
 
 			It("Test connectivity between containers with policy imported", func() {
 				policyID, err := vm.PolicyImportAndWait(
-					fmt.Sprintf("%s/test.policy", vm.ManifestsPath()), 150)
+					fmt.Sprintf("%s/test.policy", vm.ManifestsPath()), 150 * time.Second)
 				Expect(err).Should(BeNil())
 				logger.Debugf("New policy created with id '%d'", policyID)
 

--- a/test/runtime/fqdn.go
+++ b/test/runtime/fqdn.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/fqdn"
@@ -322,7 +323,7 @@ var _ = Describe("RuntimeFQDNPolicies", func() {
 			return vm.PolicyWait(preImportPolicyRevision + 2).WasSuccessful()
 		}
 		err = helpers.WithTimeout(dnsWaitBody, "DNSPoller did not update IPs",
-			&helpers.TimeoutConfig{Ticker: 1, Timeout: timeout})
+			&helpers.TimeoutConfig{Ticker: 1 * time.Second, Timeout: timeout})
 		ExpectWithOffset(1, err).To(BeNil(), "Unable to update IPs")
 		ExpectWithOffset(1, vm.WaitEndpointsReady()).Should(BeTrue(),
 			"Endpoints are not ready after ToFQDNs DNS poll triggered a regenerate")


### PR DESCRIPTION
Default timeout/duration unit is nanoseconds, so specify time.Second
where the unit was missing, and enforce minimum timeout of 10 seconds
and minimum ticker interval of 1 second in WithTimeout().

The default Ticker duration in WithTimeout was 5 nanoseconds, which
may have caused busy looping on the provided `body()` if the first call to
body() was not successful.

Istio test may have been failing due to this.

Microscope test also had both timeouts and ticker durations without
units (defaulting to nanoseconds), which may have contributed to the
fact that microscope test had to be disabled.

Ginkgo functions have optional timeouts (that we usually do not use),
expressed in seconds. These should not be mixed up!

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7720)
<!-- Reviewable:end -->
