### PR TITLE
cilium: enable encrypt + vxlan test again

### DIFF
--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -109,8 +109,6 @@ var _ = Describe("K8sDatapathConfig", func() {
 		}
 
 		It("Check connectivity with transparent encryption and VXLAN encapsulation", func() {
-			Skip("Encryption test is currently disabled")
-
 			switch helpers.GetCurrentIntegration() {
 			case helpers.CIIntegrationFlannel:
 				Skip(fmt.Sprintf(


### PR DESCRIPTION
Initially we introduced the encryption + vxlan tests resulting in increased CI failures. I have now ran this PR successfully 5/5 times. We should consider re-enabling. It is however still unclear the cause of the original failures.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7724)
<!-- Reviewable:end -->
