### PR TITLE
contrib: Exit early if no git remote is found

### DIFF
--- a/contrib/backporting/check-stable
+++ b/contrib/backporting/check-stable
@@ -22,6 +22,7 @@ SUMMARY_LOG=${2:-}
 
 source $(dirname $(readlink -ne $BASH_SOURCE))/../release/lib/common.sh
 source $TOOL_LIB_PATH/gitlib.sh
+source $(dirname $(readlink -ne $BASH_SOURCE))/common.sh
 
 # Validate command-line
 common::argc_validate 2
@@ -116,7 +117,6 @@ generate_commit_list_for_pr () {
   local pr_json
   local merge_sha
   local commits
-  local remote
   local branch
   local tmp_file
   local patchid
@@ -128,15 +128,13 @@ generate_commit_list_for_pr () {
   local entry_sub
   local upstream
 
-  remote=`git remote -v | grep "git@github.com:cilium/cilium.git\|https://github.com/cilium/cilium" | head -n1 | cut -f1`
-
   url="https://api.github.com/repos/cilium/cilium/pulls/$pr/commits"
   pr_json="$($GHCURL $url)"
   n_commits="$(echo -n $pr_json | jq -r '. | length')"
 
   tmp_file=`mktemp pr-correlation.XXXXXX`
   branch="check-for-stable-$pr"
-  git fetch -q $remote pull/$pr/head:$branch
+  git fetch -q $REMOTE pull/$pr/head:$branch
   # Use GitHub to determine the number of commits to list, but then query
   # the branch directly to determine the canonical order of the commits.
   for commit in $(git rev-list --reverse -$n_commits $branch); do
@@ -154,7 +152,7 @@ generate_commit_list_for_pr () {
     entry_id=${entry_array[0]}
     entry_sha=${entry_array[1]}
     entry_sub=${entry_array[@]:2}
-    upstream="$(git log --since="1year" --pretty="%H" --no-merges --grep "$entry_sub" $remote/master)"
+    upstream="$(git log --since="1year" --pretty="%H" --no-merges --grep "$entry_sub" $REMOTE/master)"
     upstream="$(git show $upstream | git patch-id)"
     upstream=($upstream)
     if [ "$entry_id" == "${upstream[0]}" ]; then
@@ -172,6 +170,7 @@ generate_commit_list_for_pr () {
 ###############################################################################
 # Initialize and save up to 10 (rotated logs)
 MYLOG=/tmp/$PROG.log
+REMOTE="$(get_remote)"
 # Check token
 gitlib::github_api_token
 

--- a/contrib/backporting/cherry-pick
+++ b/contrib/backporting/cherry-pick
@@ -1,9 +1,10 @@
 #!/bin/sh
 set -e
 
+source $(dirname $(readlink -ne $BASH_SOURCE))/common.sh
+
 cherry_pick () {
   CID=$1
-  REM=`git remote -v | grep "git@github.com:cilium/cilium.git\|https://github.com/cilium/cilium" | head -n1 | cut -f1`
   BRANCHES=`git branch -q -r --contains $CID $REM/master 2> /dev/null`
   if ! echo ${BRANCHES} | grep -q ".*$REM/master.*"; then
     echo "Commit $CID not in $REM/master!"
@@ -22,6 +23,7 @@ cherry_pick () {
 }
 
 main () {
+  REM="$(get_remote)"
   for CID in "$@"; do
     cherry_pick "$CID"
   done

--- a/contrib/backporting/common.sh
+++ b/contrib/backporting/common.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# Copyright 2019 Authors of Cilium
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+get_remote () {
+  local remote
+  remote=$(git remote -v | \
+    grep "git@github.com:cilium/cilium.git\|https://github.com/cilium/cilium" | \
+    head -n1 | cut -f1)
+  if [ -z "$remote" ]; then
+      echo "No remote git@github:cilium/cilium.git or https://github.com/cilium/cilium found" 1>&2
+      return 1
+  fi
+  echo "$remote"
+}


### PR DESCRIPTION
Previously, if no git remote pointing to `git@github.com:cilium/cilium.git` or `https://github.com/cilium/cilium` was found, the `check-stable` and `cherry-pick` scripts continued to execute nevertheless which lead to cryptic errors.

This commit makes both scripts to exit early and also to print an error to stderr that the git remote could not have been found.

Also, factor out the common code into the `get_remote` function which can be shared by sourcing common.sh.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7727)
<!-- Reviewable:end -->
