### PR TITLE
Fix cilium configfile CLI

### DIFF
--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -796,11 +796,13 @@ func initConfig() {
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {
-		log.Infof("Using config file: %s", viper.ConfigFileUsed())
+		log.WithField(logfields.Path, viper.ConfigFileUsed()).
+			Info("Using config from file")
 	} else if option.Config.ConfigFile != "" {
-		log.Fatalf("Error reading config file %s: %s", option.Config.ConfigFile, err)
+		log.WithField(logfields.Path, option.Config.ConfigFile).
+			Fatal("Error reading config file")
 	} else {
-		log.Warnf("Error reading default config: %s", err)
+		log.WithField(logfields.Reason, err).Info("Skipped reading configuration file")
 	}
 }
 

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -304,7 +304,21 @@ func checkMinRequirements() {
 	bpf.ReadFeatureProbes(featuresFilePath)
 }
 
+func skipInit(basePath string) bool {
+	switch basePath {
+	case components.CiliumAgentName, components.CiliumDaemonTestName:
+		return false
+	default:
+		return true
+	}
+}
+
 func init() {
+	if skipInit(path.Base(os.Args[0])) {
+		log.Debug("Skipping preparation of cilium-agent environment")
+		return
+	}
+
 	cobra.OnInitialize(initConfig)
 
 	// Reset the help function to also exit, as we block elsewhere in interrupts


### PR DESCRIPTION
PR https://github.com/cilium/cilium/pull/7703 introduced a regression into the CLI, where every single Cilium commandline invocation would lead to the following error message being printed:

```
level=warning msg="Error reading default config: Config File \"ciliumd\" Not Found in \"[/home/vagrant]\"" subsys=daemon
```

This PR fixes it by:
1. Skipping the init() logic for the daemon if the command being run isn't `cilium-agent` (eg, `cilium` cli which shares the same base binary).
1. Rewording the log so that it appears like an innocuous informational message, rather than a warning that the user did something wrong.
   * On the way here, it also improves logging library usage style to use `WithField()`.

Fixes: #7732

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7733)
<!-- Reviewable:end -->
