### PR TITLE
cilium: Encryption overhead MTU accounting

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -42,13 +42,13 @@ var (
 )
 
 func (p *IPSecSuitePrivileged) TestLoadKeysNoFile(c *C) {
-	_, err := LoadIPSecKeysFile(path)
+	_, _, err := LoadIPSecKeysFile(path)
 	c.Assert(os.IsNotExist(err), Equals, true)
 }
 
 func (p *IPSecSuitePrivileged) TestInvalidLoadKeys(c *C) {
 	keys := bytes.NewReader(invalidKeysDat)
-	_, err := loadIPSecKeys(keys)
+	_, _, err := loadIPSecKeys(keys)
 	c.Assert(err, NotNil)
 
 	_, local, err := net.ParseCIDR("1.1.3.4/16")
@@ -62,10 +62,10 @@ func (p *IPSecSuitePrivileged) TestInvalidLoadKeys(c *C) {
 
 func (p *IPSecSuitePrivileged) TestLoadKeys(c *C) {
 	keys := bytes.NewReader(keysDat)
-	_, err := loadIPSecKeys(keys)
+	_, _, err := loadIPSecKeys(keys)
 	c.Assert(err, IsNil)
 	keys = bytes.NewReader(keysAeadDat)
-	_, err = loadIPSecKeys(keys)
+	_, _, err = loadIPSecKeys(keys)
 	c.Assert(err, IsNil)
 }
 
@@ -75,9 +75,9 @@ func (p *IPSecSuitePrivileged) TestUpsertIPSecEquals(c *C) {
 	_, remote, err := net.ParseCIDR("1.2.3.4/16")
 	c.Assert(err, IsNil)
 
-	authKey, err := decodeIPSecKey("0123456789abcdef0123456789abcdef")
+	_, authKey, err := decodeIPSecKey("0123456789abcdef0123456789abcdef")
 	c.Assert(err, IsNil)
-	cryptKey, err := decodeIPSecKey("0123456789abcdef0123456789abcdef")
+	_, cryptKey, err := decodeIPSecKey("0123456789abcdef0123456789abcdef")
 	c.Assert(err, IsNil)
 	key := &ipSecKey{
 		Spi:   1,
@@ -94,7 +94,7 @@ func (p *IPSecSuitePrivileged) TestUpsertIPSecEquals(c *C) {
 
 	ipsecDeleteXfrmSpi(0)
 
-	aeadKey, err := decodeIPSecKey("44434241343332312423222114131211f4f3f2f1")
+	_, aeadKey, err := decodeIPSecKey("44434241343332312423222114131211f4f3f2f1")
 	c.Assert(err, IsNil)
 	key = &ipSecKey{
 		Spi:   1,
@@ -121,9 +121,9 @@ func (p *IPSecSuitePrivileged) TestUpsertIPSecEndpoint(c *C) {
 	_, remote, err := net.ParseCIDR("1.2.3.4/16")
 	c.Assert(err, IsNil)
 
-	authKey, err := decodeIPSecKey("0123456789abcdef0123456789abcdef")
+	_, authKey, err := decodeIPSecKey("0123456789abcdef0123456789abcdef")
 	c.Assert(err, IsNil)
-	cryptKey, err := decodeIPSecKey("0123456789abcdef0123456789abcdef")
+	_, cryptKey, err := decodeIPSecKey("0123456789abcdef0123456789abcdef")
 	c.Assert(err, IsNil)
 	key := &ipSecKey{
 		Spi:   1,
@@ -141,7 +141,7 @@ func (p *IPSecSuitePrivileged) TestUpsertIPSecEndpoint(c *C) {
 
 	ipsecDeleteXfrmSpi(0)
 
-	aeadKey, err := decodeIPSecKey("44434241343332312423222114131211f4f3f2f1")
+	_, aeadKey, err := decodeIPSecKey("44434241343332312423222114131211f4f3f2f1")
 	c.Assert(err, IsNil)
 	key = &ipSecKey{
 		Spi:   1,

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -69,7 +69,7 @@ const (
 
 func (s *linuxPrivilegedBaseTestSuite) SetUpTest(c *check.C, addressing datapath.NodeAddressing, enableIPv6, enableIPv4 bool) {
 	s.nodeAddressing = addressing
-	s.mtuConfig = mtu.NewConfiguration(false, 1500)
+	s.mtuConfig = mtu.NewConfiguration(0, false, false, 1500)
 	s.enableIPv6 = enableIPv6
 	s.enableIPv4 = enableIPv4
 

--- a/pkg/datapath/linux/route/route_linux_test.go
+++ b/pkg/datapath/linux/route/route_linux_test.go
@@ -98,7 +98,7 @@ func testReplaceRoute(c *C, prefixStr, nexthopStr string, lookupTest bool) {
 		Scope:  netlink.SCOPE_LINK,
 	})
 
-	_, err = Upsert(rt, mtu.NewConfiguration(false, 0))
+	_, err = Upsert(rt, mtu.NewConfiguration(0, false, false, 0))
 	c.Assert(err, IsNil)
 
 	if lookupTest {

--- a/pkg/mtu/mtu_test.go
+++ b/pkg/mtu/mtu_test.go
@@ -29,15 +29,49 @@ type MTUSuite struct{}
 var _ = Suite(&MTUSuite{})
 
 func (m *MTUSuite) TestNewConfiguration(c *C) {
-	conf := NewConfiguration(false, 0)
+	// Add routes with no encryption or tunnel
+	conf := NewConfiguration(0, false, false, 0)
 	c.Assert(conf.GetDeviceMTU(), Not(Equals), 0)
 	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU())
 
-	conf = NewConfiguration(false, 1400)
+	// Add routes with no encryption or tunnel and set MTU
+	conf = NewConfiguration(0, false, false, 1400)
 	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
 	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU())
 
-	conf = NewConfiguration(true, 1400)
+	// Add routes with tunnel
+	conf = NewConfiguration(0, false, true, 1400)
 	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
 	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU()-TunnelOverhead)
+
+	// Add routes with tunnel and set MTU
+	conf = NewConfiguration(0, false, true, 1400)
+	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
+	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU()-TunnelOverhead)
+
+	// Add routes with encryption and set MTU using standard 128bit, larger 256bit and smaller 96bit ICVlen keys
+	conf = NewConfiguration(16, true, false, 1400)
+	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
+	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU()-EncryptionIPsecOverhead)
+
+	conf = NewConfiguration(32, true, false, 1400)
+	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
+	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU()-(EncryptionIPsecOverhead+16))
+
+	conf = NewConfiguration(12, true, false, 1400)
+	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
+	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU()-(EncryptionIPsecOverhead-4))
+
+	// Add routes with encryption and tunnels using standard 128bit, larger 256bit and smaller 96bit ICVlen keys
+	conf = NewConfiguration(16, true, true, 1400)
+	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
+	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU()-(TunnelOverhead+EncryptionIPsecOverhead))
+
+	conf = NewConfiguration(32, true, true, 1400)
+	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
+	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU()-(TunnelOverhead+EncryptionIPsecOverhead+16))
+
+	conf = NewConfiguration(32, true, true, 1400)
+	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
+	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU()-(TunnelOverhead+EncryptionIPsecOverhead+16))
 }


### PR DESCRIPTION
When encryption is used we consume some bytes for encryption and need to account for these when calculating MTU, similar to how tunnel mode is calculated. Complicating things slightly though is that different encryption schemes will use slightly different byte counts so we account for this by doing MTU initialization after reading the encryption keys which will inform the byte usage.

There is one gap however where if a user transitions to a "new" key format dynamically (e.g. without a agent restart which is not support now but will be shortly) then routes will continue to use the old route MTU values. For now I'm ignoring this corner case and we can polish that bit later if needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7734)
<!-- Reviewable:end -->
