### PR TITLE
test: Fix gofmt reported miss-formats in runtime tests

### DIFF
--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -115,7 +115,7 @@ type TimeoutConfig struct {
 // the timeout in config is reached. Returns an error if the timeout is
 // exceeded for body to execute successfully.
 func WithTimeout(body func() bool, msg string, config *TimeoutConfig) error {
-	if config.Timeout < 10 * time.Second {
+	if config.Timeout < 10*time.Second {
 		return fmt.Errorf("Timeout too short (must be at least 10 seconds): %v", config.Timeout)
 	}
 	if config.Ticker == 0 {

--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -133,7 +133,7 @@ var runtimeConnectivityTest = func(datapathMode string) func() {
 
 			It("Test connectivity between containers with policy imported", func() {
 				policyID, err := vm.PolicyImportAndWait(
-					fmt.Sprintf("%s/test.policy", vm.ManifestsPath()), 150 * time.Second)
+					fmt.Sprintf("%s/test.policy", vm.ManifestsPath()), 150*time.Second)
 				Expect(err).Should(BeNil())
 				logger.Debugf("New policy created with id '%d'", policyID)
 


### PR DESCRIPTION
This PR fixes the following miss-formats:

```
<..>
    runtime: Unformatted Go source code:
    runtime: ./test/runtime/connectivity.go
    runtime: diff -u ./test/runtime/connectivity.go.orig ./test/runtime/connectivity.go
    runtime: --- ./test/runtime/connectivity.go.orig    2019-04-16 07:01:51.281708216 +0000
    runtime: +++ ./test/runtime/connectivity.go 2019-04-16 07:01:51.281708216 +0000
    runtime: @@ -133,7 +133,7 @@
    runtime:
    runtime:                    It("Test connectivity between containers with policy imported", func() {
    runtime:                            policyID, err := vm.PolicyImportAndWait(
    runtime: -                                  fmt.Sprintf("%s/test.policy", vm.ManifestsPath()), 150 * time.Second)
    runtime: +                                  fmt.Sprintf("%s/test.policy", vm.ManifestsPath()), 150*time.Second)
    runtime:                            Expect(err).Should(BeNil())
    runtime:                            logger.Debugf("New policy created with id '%d'", policyID)
    runtime:
    runtime: ./test/helpers/utils.go
    runtime: diff -u ./test/helpers/utils.go.orig ./test/helpers/utils.go
    runtime: --- ./test/helpers/utils.go.orig   2019-04-16 07:01:51.401709430 +0000
    runtime: +++ ./test/helpers/utils.go        2019-04-16 07:01:51.401709430 +0000
    runtime: @@ -115,7 +115,7 @@
    runtime:  // the timeout in config is reached. Returns an error if the timeout is
    runtime:  // exceeded for body to execute successfully.
    runtime:  func WithTimeout(body func() bool, msg string, config *TimeoutConfig) error {
    runtime: -  if config.Timeout < 10 * time.Second {
    runtime: +  if config.Timeout < 10*time.Second {
    runtime:            return fmt.Errorf("Timeout too short (must be at least 10 seconds): %v", config.Timeout)
    runtime:    }
    runtime:    if config.Ticker == 0 {
    runtime: Makefile:342: recipe for target 'precheck' failed
    runtime: make: *** [precheck] Error 1
```

Observed with `go version go1.12 linux/amd64`.

Added the `needs-backporting/1.{3,4}` labels, as https://github.com/cilium/cilium/pull/7720 currently has them set, although the PR is not easily backportable and might be dropped. So, we might need to adjust the labels of this PR accordingly.

Fixes: 3b9c1e6f ("CI: Enforce sensible timeouts.")
Signed-off-by: Martynas Pumputis <m@lambda.lt>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7738)
<!-- Reviewable:end -->
