### PR TITLE
daemon: Set backend IDs in daemon's LB cache

### DIFF
--- a/pkg/service/id.go
+++ b/pkg/service/id.go
@@ -113,6 +113,13 @@ func DeleteBackendID(id loadbalancer.BackendID) {
 	backendIDAlloc.deleteLocalID(uint32(id))
 }
 
+// LookupBackendID looks up already allocated backend ID for the given backend
+// addr. If such cannot be found, returns an error.
+func LookupBackendID(l3n4Addr loadbalancer.L3n4Addr) (loadbalancer.BackendID, error) {
+	id, err := backendIDAlloc.lookupLocalID(l3n4Addr)
+	return loadbalancer.BackendID(id), err
+}
+
 func restoreBackendID(l3n4Addr loadbalancer.L3n4Addr, id loadbalancer.BackendID) (loadbalancer.BackendID, error) {
 	l3n4AddrID, err := backendIDAlloc.acquireLocalID(l3n4Addr, uint32(id))
 	if err != nil {

--- a/pkg/service/id_local.go
+++ b/pkg/service/id_local.go
@@ -131,6 +131,17 @@ func (alloc *IDAllocator) deleteLocalID(id uint32) error {
 	return nil
 }
 
+func (alloc *IDAllocator) lookupLocalID(svc loadbalancer.L3n4Addr) (uint32, error) {
+	alloc.RLock()
+	defer alloc.RUnlock()
+
+	if svcID, ok := alloc.entities[svc.StringID()]; ok {
+		return svcID, nil
+	}
+
+	return 0, fmt.Errorf("ID not found")
+}
+
 func (alloc *IDAllocator) setLocalIDSpace(next, max uint32) error {
 	alloc.Lock()
 	alloc.nextID = next

--- a/pkg/service/id_test.go
+++ b/pkg/service/id_test.go
@@ -152,6 +152,26 @@ func (ds *ServiceTestSuite) TestGetMaxServiceID(c *C) {
 	c.Assert(id, Equals, (MaxSetOfServiceID - 1))
 }
 
+func (ds *ServiceTestSuite) TestBackendID(c *C) {
+	firstBackendID := loadbalancer.BackendID(FirstFreeBackendID)
+
+	id1, err := AcquireBackendID(l3n4Addr1)
+	c.Assert(err, Equals, nil)
+	c.Assert(id1, Equals, firstBackendID)
+
+	id1, err = AcquireBackendID(l3n4Addr1)
+	c.Assert(err, Equals, nil)
+	c.Assert(id1, Equals, firstBackendID)
+
+	id2, err := AcquireBackendID(l3n4Addr2)
+	c.Assert(err, Equals, nil)
+	c.Assert(id2, Equals, firstBackendID+1)
+
+	existingID1, err := LookupBackendID(l3n4Addr1)
+	c.Assert(err, Equals, nil)
+	c.Assert(existingID1, Equals, id1)
+}
+
 func (ds *ServiceTestSuite) BenchmarkAllocation(c *C) {
 	addr := loadbalancer.L3n4Addr{
 		IP:     net.IPv6loopback,


### PR DESCRIPTION
Currently, the allocation of backend IDs is triggered inside `lbmap` methods. This is far from ideal, as this breaks a separation of concerns between different layers (i.e. the allocation should be really controlled by `daemon`; this is going to be changed in the nearest future).

One bug which slipped unnoticed was that we didn't populate the daemon's local LB cache with the acquired backend IDs which lead to non-consistent ordering of service endpoints reported by `cilium service list`, and, as a consequence, this made some CI tests flaky which were expecting some exact service endpoint ordering. E.g.: https://github.com/cilium/cilium/pull/7733#issuecomment-483452050.

This PR fixes the issue by populating the backend IDs which are retrieved from the service ID allocator.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7739)
<!-- Reviewable:end -->
