### PR TITLE
examples: Add --enable-legacy-service=false to ConfigMap

### DIFF
--- a/examples/kubernetes/1.10/cilium-cm.yaml
+++ b/examples/kubernetes/1.10/cilium-cm.yaml
@@ -151,3 +151,7 @@ data:
 
   # wait-bpf-mount makes init container wait until bpf filesystem is mounted
   wait-bpf-mount: "false"
+
+  # Enable legacy services (prior v1.5) to prevent from terminating existing
+  # connections with services when upgrading Cilium from < v1.5 to v1.5.
+  enable-legacy-services: "false"

--- a/examples/kubernetes/1.10/cilium-containerd.yaml
+++ b/examples/kubernetes/1.10/cilium-containerd.yaml
@@ -151,6 +151,10 @@ data:
 
   # wait-bpf-mount makes init container wait until bpf filesystem is mounted
   wait-bpf-mount: "false"
+
+  # Enable legacy services (prior v1.5) to prevent from terminating existing
+  # connections with services when upgrading Cilium from < v1.5 to v1.5.
+  enable-legacy-services: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -151,6 +151,10 @@ data:
 
   # wait-bpf-mount makes init container wait until bpf filesystem is mounted
   wait-bpf-mount: "false"
+
+  # Enable legacy services (prior v1.5) to prevent from terminating existing
+  # connections with services when upgrading Cilium from < v1.5 to v1.5.
+  enable-legacy-services: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/examples/kubernetes/1.10/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.10/cilium-external-etcd.yaml
@@ -151,6 +151,10 @@ data:
 
   # wait-bpf-mount makes init container wait until bpf filesystem is mounted
   wait-bpf-mount: "false"
+
+  # Enable legacy services (prior v1.5) to prevent from terminating existing
+  # connections with services when upgrading Cilium from < v1.5 to v1.5.
+  enable-legacy-services: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/examples/kubernetes/1.10/cilium-minikube.yaml
+++ b/examples/kubernetes/1.10/cilium-minikube.yaml
@@ -151,6 +151,10 @@ data:
 
   # wait-bpf-mount makes init container wait until bpf filesystem is mounted
   wait-bpf-mount: "false"
+
+  # Enable legacy services (prior v1.5) to prevent from terminating existing
+  # connections with services when upgrading Cilium from < v1.5 to v1.5.
+  enable-legacy-services: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/examples/kubernetes/1.10/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.10/cilium-with-node-init.yaml
@@ -151,6 +151,10 @@ data:
 
   # wait-bpf-mount makes init container wait until bpf filesystem is mounted
   wait-bpf-mount: "true"
+
+  # Enable legacy services (prior v1.5) to prevent from terminating existing
+  # connections with services when upgrading Cilium from < v1.5 to v1.5.
+  enable-legacy-services: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -151,6 +151,10 @@ data:
 
   # wait-bpf-mount makes init container wait until bpf filesystem is mounted
   wait-bpf-mount: "false"
+
+  # Enable legacy services (prior v1.5) to prevent from terminating existing
+  # connections with services when upgrading Cilium from < v1.5 to v1.5.
+  enable-legacy-services: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/examples/kubernetes/1.11/cilium-cm.yaml
+++ b/examples/kubernetes/1.11/cilium-cm.yaml
@@ -151,3 +151,7 @@ data:
 
   # wait-bpf-mount makes init container wait until bpf filesystem is mounted
   wait-bpf-mount: "false"
+
+  # Enable legacy services (prior v1.5) to prevent from terminating existing
+  # connections with services when upgrading Cilium from < v1.5 to v1.5.
+  enable-legacy-services: "false"

--- a/examples/kubernetes/1.11/cilium-containerd.yaml
+++ b/examples/kubernetes/1.11/cilium-containerd.yaml
@@ -151,6 +151,10 @@ data:
 
   # wait-bpf-mount makes init container wait until bpf filesystem is mounted
   wait-bpf-mount: "false"
+
+  # Enable legacy services (prior v1.5) to prevent from terminating existing
+  # connections with services when upgrading Cilium from < v1.5 to v1.5.
+  enable-legacy-services: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -151,6 +151,10 @@ data:
 
   # wait-bpf-mount makes init container wait until bpf filesystem is mounted
   wait-bpf-mount: "false"
+
+  # Enable legacy services (prior v1.5) to prevent from terminating existing
+  # connections with services when upgrading Cilium from < v1.5 to v1.5.
+  enable-legacy-services: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/examples/kubernetes/1.11/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.11/cilium-external-etcd.yaml
@@ -151,6 +151,10 @@ data:
 
   # wait-bpf-mount makes init container wait until bpf filesystem is mounted
   wait-bpf-mount: "false"
+
+  # Enable legacy services (prior v1.5) to prevent from terminating existing
+  # connections with services when upgrading Cilium from < v1.5 to v1.5.
+  enable-legacy-services: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/examples/kubernetes/1.11/cilium-minikube.yaml
+++ b/examples/kubernetes/1.11/cilium-minikube.yaml
@@ -151,6 +151,10 @@ data:
 
   # wait-bpf-mount makes init container wait until bpf filesystem is mounted
   wait-bpf-mount: "false"
+
+  # Enable legacy services (prior v1.5) to prevent from terminating existing
+  # connections with services when upgrading Cilium from < v1.5 to v1.5.
+  enable-legacy-services: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/examples/kubernetes/1.11/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.11/cilium-with-node-init.yaml
@@ -151,6 +151,10 @@ data:
 
   # wait-bpf-mount makes init container wait until bpf filesystem is mounted
   wait-bpf-mount: "true"
+
+  # Enable legacy services (prior v1.5) to prevent from terminating existing
+  # connections with services when upgrading Cilium from < v1.5 to v1.5.
+  enable-legacy-services: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -151,6 +151,10 @@ data:
 
   # wait-bpf-mount makes init container wait until bpf filesystem is mounted
   wait-bpf-mount: "false"
+
+  # Enable legacy services (prior v1.5) to prevent from terminating existing
+  # connections with services when upgrading Cilium from < v1.5 to v1.5.
+  enable-legacy-services: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/examples/kubernetes/1.12/cilium-cm.yaml
+++ b/examples/kubernetes/1.12/cilium-cm.yaml
@@ -151,3 +151,7 @@ data:
 
   # wait-bpf-mount makes init container wait until bpf filesystem is mounted
   wait-bpf-mount: "false"
+
+  # Enable legacy services (prior v1.5) to prevent from terminating existing
+  # connections with services when upgrading Cilium from < v1.5 to v1.5.
+  enable-legacy-services: "false"

--- a/examples/kubernetes/1.12/cilium-containerd.yaml
+++ b/examples/kubernetes/1.12/cilium-containerd.yaml
@@ -151,6 +151,10 @@ data:
 
   # wait-bpf-mount makes init container wait until bpf filesystem is mounted
   wait-bpf-mount: "false"
+
+  # Enable legacy services (prior v1.5) to prevent from terminating existing
+  # connections with services when upgrading Cilium from < v1.5 to v1.5.
+  enable-legacy-services: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -151,6 +151,10 @@ data:
 
   # wait-bpf-mount makes init container wait until bpf filesystem is mounted
   wait-bpf-mount: "false"
+
+  # Enable legacy services (prior v1.5) to prevent from terminating existing
+  # connections with services when upgrading Cilium from < v1.5 to v1.5.
+  enable-legacy-services: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/examples/kubernetes/1.12/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.12/cilium-external-etcd.yaml
@@ -151,6 +151,10 @@ data:
 
   # wait-bpf-mount makes init container wait until bpf filesystem is mounted
   wait-bpf-mount: "false"
+
+  # Enable legacy services (prior v1.5) to prevent from terminating existing
+  # connections with services when upgrading Cilium from < v1.5 to v1.5.
+  enable-legacy-services: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/examples/kubernetes/1.12/cilium-minikube.yaml
+++ b/examples/kubernetes/1.12/cilium-minikube.yaml
@@ -151,6 +151,10 @@ data:
 
   # wait-bpf-mount makes init container wait until bpf filesystem is mounted
   wait-bpf-mount: "false"
+
+  # Enable legacy services (prior v1.5) to prevent from terminating existing
+  # connections with services when upgrading Cilium from < v1.5 to v1.5.
+  enable-legacy-services: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/examples/kubernetes/1.12/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.12/cilium-with-node-init.yaml
@@ -151,6 +151,10 @@ data:
 
   # wait-bpf-mount makes init container wait until bpf filesystem is mounted
   wait-bpf-mount: "true"
+
+  # Enable legacy services (prior v1.5) to prevent from terminating existing
+  # connections with services when upgrading Cilium from < v1.5 to v1.5.
+  enable-legacy-services: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -151,6 +151,10 @@ data:
 
   # wait-bpf-mount makes init container wait until bpf filesystem is mounted
   wait-bpf-mount: "false"
+
+  # Enable legacy services (prior v1.5) to prevent from terminating existing
+  # connections with services when upgrading Cilium from < v1.5 to v1.5.
+  enable-legacy-services: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/examples/kubernetes/1.13/cilium-cm.yaml
+++ b/examples/kubernetes/1.13/cilium-cm.yaml
@@ -151,3 +151,7 @@ data:
 
   # wait-bpf-mount makes init container wait until bpf filesystem is mounted
   wait-bpf-mount: "false"
+
+  # Enable legacy services (prior v1.5) to prevent from terminating existing
+  # connections with services when upgrading Cilium from < v1.5 to v1.5.
+  enable-legacy-services: "false"

--- a/examples/kubernetes/1.13/cilium-containerd.yaml
+++ b/examples/kubernetes/1.13/cilium-containerd.yaml
@@ -151,6 +151,10 @@ data:
 
   # wait-bpf-mount makes init container wait until bpf filesystem is mounted
   wait-bpf-mount: "false"
+
+  # Enable legacy services (prior v1.5) to prevent from terminating existing
+  # connections with services when upgrading Cilium from < v1.5 to v1.5.
+  enable-legacy-services: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/examples/kubernetes/1.13/cilium-crio.yaml
+++ b/examples/kubernetes/1.13/cilium-crio.yaml
@@ -151,6 +151,10 @@ data:
 
   # wait-bpf-mount makes init container wait until bpf filesystem is mounted
   wait-bpf-mount: "false"
+
+  # Enable legacy services (prior v1.5) to prevent from terminating existing
+  # connections with services when upgrading Cilium from < v1.5 to v1.5.
+  enable-legacy-services: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/examples/kubernetes/1.13/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.13/cilium-external-etcd.yaml
@@ -151,6 +151,10 @@ data:
 
   # wait-bpf-mount makes init container wait until bpf filesystem is mounted
   wait-bpf-mount: "false"
+
+  # Enable legacy services (prior v1.5) to prevent from terminating existing
+  # connections with services when upgrading Cilium from < v1.5 to v1.5.
+  enable-legacy-services: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/examples/kubernetes/1.13/cilium-minikube.yaml
+++ b/examples/kubernetes/1.13/cilium-minikube.yaml
@@ -151,6 +151,10 @@ data:
 
   # wait-bpf-mount makes init container wait until bpf filesystem is mounted
   wait-bpf-mount: "false"
+
+  # Enable legacy services (prior v1.5) to prevent from terminating existing
+  # connections with services when upgrading Cilium from < v1.5 to v1.5.
+  enable-legacy-services: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/examples/kubernetes/1.13/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.13/cilium-with-node-init.yaml
@@ -151,6 +151,10 @@ data:
 
   # wait-bpf-mount makes init container wait until bpf filesystem is mounted
   wait-bpf-mount: "true"
+
+  # Enable legacy services (prior v1.5) to prevent from terminating existing
+  # connections with services when upgrading Cilium from < v1.5 to v1.5.
+  enable-legacy-services: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/examples/kubernetes/1.13/cilium.yaml
+++ b/examples/kubernetes/1.13/cilium.yaml
@@ -151,6 +151,10 @@ data:
 
   # wait-bpf-mount makes init container wait until bpf filesystem is mounted
   wait-bpf-mount: "false"
+
+  # Enable legacy services (prior v1.5) to prevent from terminating existing
+  # connections with services when upgrading Cilium from < v1.5 to v1.5.
+  enable-legacy-services: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/examples/kubernetes/1.14/cilium-cm.yaml
+++ b/examples/kubernetes/1.14/cilium-cm.yaml
@@ -151,3 +151,7 @@ data:
 
   # wait-bpf-mount makes init container wait until bpf filesystem is mounted
   wait-bpf-mount: "false"
+
+  # Enable legacy services (prior v1.5) to prevent from terminating existing
+  # connections with services when upgrading Cilium from < v1.5 to v1.5.
+  enable-legacy-services: "false"

--- a/examples/kubernetes/1.14/cilium-containerd.yaml
+++ b/examples/kubernetes/1.14/cilium-containerd.yaml
@@ -151,6 +151,10 @@ data:
 
   # wait-bpf-mount makes init container wait until bpf filesystem is mounted
   wait-bpf-mount: "false"
+
+  # Enable legacy services (prior v1.5) to prevent from terminating existing
+  # connections with services when upgrading Cilium from < v1.5 to v1.5.
+  enable-legacy-services: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/examples/kubernetes/1.14/cilium-crio.yaml
+++ b/examples/kubernetes/1.14/cilium-crio.yaml
@@ -151,6 +151,10 @@ data:
 
   # wait-bpf-mount makes init container wait until bpf filesystem is mounted
   wait-bpf-mount: "false"
+
+  # Enable legacy services (prior v1.5) to prevent from terminating existing
+  # connections with services when upgrading Cilium from < v1.5 to v1.5.
+  enable-legacy-services: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/examples/kubernetes/1.14/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.14/cilium-external-etcd.yaml
@@ -151,6 +151,10 @@ data:
 
   # wait-bpf-mount makes init container wait until bpf filesystem is mounted
   wait-bpf-mount: "false"
+
+  # Enable legacy services (prior v1.5) to prevent from terminating existing
+  # connections with services when upgrading Cilium from < v1.5 to v1.5.
+  enable-legacy-services: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/examples/kubernetes/1.14/cilium-minikube.yaml
+++ b/examples/kubernetes/1.14/cilium-minikube.yaml
@@ -151,6 +151,10 @@ data:
 
   # wait-bpf-mount makes init container wait until bpf filesystem is mounted
   wait-bpf-mount: "false"
+
+  # Enable legacy services (prior v1.5) to prevent from terminating existing
+  # connections with services when upgrading Cilium from < v1.5 to v1.5.
+  enable-legacy-services: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/examples/kubernetes/1.14/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.14/cilium-with-node-init.yaml
@@ -151,6 +151,10 @@ data:
 
   # wait-bpf-mount makes init container wait until bpf filesystem is mounted
   wait-bpf-mount: "true"
+
+  # Enable legacy services (prior v1.5) to prevent from terminating existing
+  # connections with services when upgrading Cilium from < v1.5 to v1.5.
+  enable-legacy-services: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/examples/kubernetes/1.14/cilium.yaml
+++ b/examples/kubernetes/1.14/cilium.yaml
@@ -151,6 +151,10 @@ data:
 
   # wait-bpf-mount makes init container wait until bpf filesystem is mounted
   wait-bpf-mount: "false"
+
+  # Enable legacy services (prior v1.5) to prevent from terminating existing
+  # connections with services when upgrading Cilium from < v1.5 to v1.5.
+  enable-legacy-services: "false"
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/examples/kubernetes/templates/v1/cilium-cm.yaml
+++ b/examples/kubernetes/templates/v1/cilium-cm.yaml
@@ -151,3 +151,7 @@ data:
 
   # wait-bpf-mount makes init container wait until bpf filesystem is mounted
   wait-bpf-mount: "false"
+
+  # Enable legacy services (prior v1.5) to prevent from terminating existing
+  # connections with services when upgrading Cilium from < v1.5 to v1.5.
+  enable-legacy-services: "false"


### PR DESCRIPTION
This PR adds the `enable-legacy-services` flag to the ConfigMap and sets it to false, so that new users won't need to maintain unnecessary legacy services.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7741)
<!-- Reviewable:end -->
