### PR TITLE
cli: Add flag to list legacy service BPF maps

### DIFF
--- a/Documentation/cmdref/cilium_bpf_lb_list.md
+++ b/Documentation/cmdref/cilium_bpf_lb_list.md
@@ -16,6 +16,7 @@ cilium bpf lb list [flags]
 
 ```
   -h, --help            help for list
+      --legacy          List legacy service entries
   -o, --output string   json| jsonpath='{}'
       --revnat          List reverse NAT entries
 ```

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -817,6 +818,52 @@ func (s *SSHMeta) ServiceAdd(id int, frontend string, backends []string) *CmdRes
 		"service update --frontend '%s' --backends '%s' --id '%d' --rev",
 		frontend, strings.Join(backends, ","), id)
 	return s.ExecCilium(cmd)
+}
+
+// BpfLBMapsAreSynced checks whether the v2 and legacy BPF maps contain the same
+// endpoints.
+func (s *SSHMeta) BpfLBMapsAreSynced() error {
+	bpfLB, err := s.BpfLBList(false, false)
+	if err != nil {
+		return err
+	}
+	bpfLegacyLB, err := s.BpfLBList(true, true)
+	if err != nil {
+		return err
+	}
+
+	if len(bpfLB) != len(bpfLegacyLB) {
+		return fmt.Errorf("Number of services do not match: %d (v2) vs %d (legacy)",
+			len(bpfLB), len(bpfLegacyLB))
+	}
+
+	for svc, entries := range bpfLB {
+		legacyEntries, found := bpfLegacyLB[svc]
+		if !found {
+			return fmt.Errorf("%s service not found in the legacy BPF map", svc)
+		}
+
+		sort.Strings(legacyEntries)
+		sort.Strings(entries)
+		if len(entries) != len(legacyEntries) {
+			return fmt.Errorf("Number of %s endpoints do not match: %d (v2) vs %d (legacy)",
+				svc, len(entries), len(legacyEntries))
+		}
+
+		for i, entry := range entries {
+			if i == 0 {
+				// Ignore master services, as they do not match due to revNATID
+				// being set in v2
+				continue
+			}
+			if entry != legacyEntries[i] {
+				return fmt.Errorf("%d-th sorted entries do not match: %s (v2) vs %s (legacy)",
+					i, entry, legacyEntries[i])
+			}
+		}
+	}
+
+	return nil
 }
 
 // ServiceIsSynced checks that the Cilium service with the specified id has its

--- a/test/runtime/lb.go
+++ b/test/runtime/lb.go
@@ -57,6 +57,9 @@ var _ = Describe("RuntimeLB", func() {
 	})
 
 	AfterEach(func() {
+		err := vm.BpfLBMapsAreSynced()
+		Expect(err).Should(BeNil(), "v2 and legacy bpf lb are not in sync")
+
 		cleanupLBDevice(vm)
 	}, 500)
 

--- a/test/runtime/lb.go
+++ b/test/runtime/lb.go
@@ -301,7 +301,7 @@ var _ = Describe("RuntimeLB", func() {
 
 			oldSvcIds, err := vm.ServiceGetIds()
 			Expect(err).Should(BeNil())
-			oldBpfLB, err := vm.BpfLBList()
+			oldBpfLB, err := vm.BpfLBList(false, false)
 			Expect(err).Should(BeNil())
 
 			err = vm.RestartCilium()
@@ -319,7 +319,7 @@ var _ = Describe("RuntimeLB", func() {
 
 			By("Checking that BPF LB maps match the service")
 
-			newBpfLB, err := vm.BpfLBList()
+			newBpfLB, err := vm.BpfLBList(false, false)
 			Expect(err).Should(BeNil(), "Cannot retrieve bpf lb list after restart")
 			Expect(oldBpfLB).Should(Equal(newBpfLB))
 			svcSync, err := vm.ServiceIsSynced(svcID)


### PR DESCRIPTION
This PR:

* Adds the `--legacy` flag which can be passed to the `cilium bpf lb list` command in order to dump the legacy service BPF maps (addresses https://github.com/cilium/cilium/pull/7639#discussion_r274989402).
* Extends the LB runtime tests to check whether the svc legacy and v2 BPF maps are in sync.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7742)
<!-- Reviewable:end -->
