### PR TITLE
Improve debuggability of toEntities test failures with DNS

### DIFF
--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -128,7 +128,7 @@ var _ = Describe("K8sPolicyTest", func() {
 				By("DNS lookup of google.com")
 				res = kubectl.ExecPodCmd(
 					helpers.DefaultNamespace, pod,
-					"host www.google.com")
+					"host -v www.google.com")
 
 				// kube-dns is always whitelisted so this should always work
 				ExpectWithOffset(1, res).To(getMatcher(expectWorldSuccess || expectClusterSuccess),


### PR DESCRIPTION
In the toEntities connectivity validation, add verbose output for the
"host" command to get more information what's happening during the DNS
lookup.

Seems like it's just timing out after 10 seconds, but I'm curious to see if we
can get any more information from `host` during that period.

Related: #7721

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7744)
<!-- Reviewable:end -->
