### PR TITLE
refine CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -37,12 +37,15 @@ contrib/packaging/docker/ @aanm @ianvernon
 contrib/vagrant @cilium/vagrant
 daemon/ @cilium/agent
 daemon/bpf.sha @cilium/bpf
-daemon/endpoint.go @cilium/endpoint
-daemon/k8s_watcher.go @cilium/kubernetes
+daemon/endpoint.* @cilium/endpoint
+daemon/health.* @cilium/health
+daemon/k8s_watcher.* @cilium/kubernetes
 daemon/loadbalancer.* @cilium/loadbalancer
-daemon/policy.go @cilium/policy
+daemon/metrics.* @cilium/metrics
+daemon/policy.* @cilium/policy
 daemon/prefilter.go @cilium/bpf
 daemon/services.* @cilium/loadbalancer
+daemon/state.go @cilium/endpoint
 Documentation/ @cilium/docs
 Documentation/bpf.rst @scanf @borkmann
 Documentation/contributing.rst @cilium/contributing


### PR DESCRIPTION
* Use regexes so test files for endpoint, policy, and K8s are owned by their
respective codeowners as well instead of needing review from the cilium/agent
team.
* Add daemon/health.* to be owend by cilium/health.
* Add daemon/metrics.* to be owned by cilium/metrics.
* Add daemon/state.* to be owned by cilium/endpoint.

Signed-off by: Ian Vernon <ian@cilium.dev>

I added the codeowners that are affected as reviewers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7745)
<!-- Reviewable:end -->
