### PR TITLE
move readEPsFromDirNames to pkg/endpoint

### DIFF
--- a/daemon/state.go
+++ b/daemon/state.go
@@ -20,12 +20,9 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
-	"path/filepath"
-	"strings"
 	"sync"
 	"time"
 
-	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpointmanager"
@@ -92,7 +89,7 @@ func (d *Daemon) restoreOldEndpoints(dir string, clean bool) (*endpointRestoreSt
 	}
 	eptsID := endpoint.FilterEPDir(dirFiles)
 
-	possibleEPs := readEPsFromDirNames(dir, eptsID)
+	possibleEPs := endpoint.ReadEPsFromDirNames(dir, eptsID)
 
 	if len(possibleEPs) == 0 {
 		log.Info("No old endpoints found.")
@@ -437,68 +434,4 @@ func (d *Daemon) allocateIPsLocked(ep *endpoint.Endpoint) error {
 	}
 
 	return nil
-}
-
-// readEPsFromDirNames returns a mapping of endpoint ID to endpoint of endpoints
-// from a list of directory names that can possible contain an endpoint.
-func readEPsFromDirNames(basePath string, eptsDirNames []string) map[uint16]*endpoint.Endpoint {
-	possibleEPs := map[uint16]*endpoint.Endpoint{}
-	for _, epDirName := range eptsDirNames {
-		epDir := filepath.Join(basePath, epDirName)
-		readDir := func() string {
-			scopedLog := log.WithFields(logrus.Fields{
-				logfields.EndpointID: epDirName,
-				logfields.Path:       filepath.Join(epDir, common.CHeaderFileName),
-			})
-			scopedLog.Debug("Reading directory")
-			epFiles, err := ioutil.ReadDir(epDir)
-			if err != nil {
-				scopedLog.WithError(err).Warn("Error while reading directory. Ignoring it...")
-				return ""
-			}
-			cHeaderFile := common.FindEPConfigCHeader(epDir, epFiles)
-			if cHeaderFile == "" {
-				return ""
-			}
-			return cHeaderFile
-		}
-		// There's an odd issue where the first read dir doesn't work.
-		cHeaderFile := readDir()
-		if cHeaderFile == "" {
-			cHeaderFile = readDir()
-		}
-
-		scopedLog := log.WithFields(logrus.Fields{
-			logfields.EndpointID: epDirName,
-			logfields.Path:       cHeaderFile,
-		})
-
-		if cHeaderFile == "" {
-			scopedLog.Warning("C header file not found. Ignoring endpoint")
-			continue
-		}
-
-		scopedLog.Debug("Found endpoint C header file")
-
-		strEp, err := common.GetCiliumVersionString(cHeaderFile)
-		if err != nil {
-			scopedLog.WithError(err).Warn("Unable to read the C header file")
-			continue
-		}
-		ep, err := endpoint.ParseEndpoint(strEp)
-		if err != nil {
-			scopedLog.WithError(err).Warn("Unable to parse the C header file")
-			continue
-		}
-		if _, ok := possibleEPs[ep.ID]; ok {
-			// If the endpoint already exists then give priority to the directory
-			// that contains an endpoint that didn't fail to be build.
-			if strings.HasSuffix(ep.DirectoryPath(), epDirName) {
-				possibleEPs[ep.ID] = ep
-			}
-		} else {
-			possibleEPs[ep.ID] = ep
-		}
-	}
-	return possibleEPs
 }

--- a/daemon/state_test.go
+++ b/daemon/state_test.go
@@ -215,7 +215,7 @@ func (ds *DaemonSuite) TestReadEPsFromDirNames(c *C) {
 	c.Assert(err, IsNil)
 	epsNames, err := ds.generateEPs(tmpDir, epsWanted, epsMap)
 	c.Assert(err, IsNil)
-	eps := readEPsFromDirNames(tmpDir, epsNames)
+	eps := e.ReadEPsFromDirNames(tmpDir, epsNames)
 	c.Assert(len(eps), Equals, len(epsWanted))
 
 	e.OrderEndpointAsc(epsWanted)


### PR DESCRIPTION
This function was in the `daemon` package, but it does not depend on the daemon in any way. As part of the effort to move functionality out of the daemon package, move it to the endpoint package, where it makes more logical sense to store such code.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7746)
<!-- Reviewable:end -->
