### PR TITLE
k8s: Disable k8s event handover to kvstore by default

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -44,6 +44,7 @@ cilium-agent [flags]
       --enable-ipsec                               Enable IPSec support
       --enable-ipv4                                Enable IPv4 support (default true)
       --enable-ipv6                                Enable IPv6 support (default true)
+      --enable-k8s-event-handover                  Enable k8s event handover to kvstore for improved scalability
       --enable-legacy-services                     Enable legacy (prior-v1.5) services (default true)
       --enable-policy string                       Enable policy enforcement (default "default")
       --enable-tracing                             Enable tracing while determining policy (debugging)

--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -282,6 +282,9 @@ New ConfigMap Options
   All options available in the cilium-agent can now be specified in the Cilium
   ConfigMap without requiring to set an environment variable in the DaemonSet.
 
+  * ``enable-k8s-event-handover``: enables use of the kvstore to optimize
+    Kubernetes event handling by listening for k8s events in the operator and
+    mirroring it into the kvstore for reduced overhead in large clusters.
 
 Deprecated Options
 ~~~~~~~~~~~~~~~~~~

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -521,6 +521,9 @@ func init() {
 	flags.String(option.IPv6ServiceRange, AutoCIDR, "Kubernetes IPv6 services CIDR if not inside cluster prefix")
 	option.BindEnv(option.IPv6ServiceRange)
 
+	flags.Bool(option.K8sEventHandover, defaults.K8sEventHandover, "Enable k8s event handover to kvstore for improved scalability")
+	option.BindEnv(option.K8sEventHandover)
+
 	flags.String(option.K8sAPIServer, "", "Kubernetes api address server (for https use --k8s-kubeconfig-path instead)")
 	option.BindEnv(option.K8sAPIServer)
 

--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -846,6 +846,7 @@ func (d *Daemon) EnableK8sWatcher(queueSize uint) error {
 			// Create a new pod controller when we are disconnected with the
 			// kvstore
 			<-kvstore.Client().Disconnected()
+			close(isConnected)
 			log.Info("Disconnected from KVStore, watching for pod events all nodes")
 		}
 	}()
@@ -946,6 +947,7 @@ func (d *Daemon) EnableK8sWatcher(queueSize uint) error {
 			// Create a new node controller when we are disconnected with the
 			// kvstore
 			<-kvstore.Client().Disconnected()
+			close(isConnected)
 
 			log.Info("Disconnected from KVStore, restarting k8s node watcher")
 		}

--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -827,8 +827,13 @@ func (d *Daemon) EnableK8sWatcher(queueSize uint) error {
 			})
 			go podController.Run(isConnected)
 
+			if !option.Config.K8sEventHandover {
+				return
+			}
+
 			// Replace pod controller by only receiving events from our own
 			// node once we are connected to the kvstore.
+
 			<-kvstore.Client().Connected()
 			close(isConnected)
 
@@ -927,6 +932,11 @@ func (d *Daemon) EnableK8sWatcher(queueSize uint) error {
 			go nodeController.Run(isConnected)
 			// TODO: do we really need to wait until etcd watcher signalizes
 			// "listDone" or connected to it is sufficient?
+
+			if !option.Config.K8sEventHandover {
+				return
+			}
+
 			<-kvstore.Client().Connected()
 			close(isConnected)
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -189,4 +189,10 @@ const (
 	// ConntrackGCIntervalNonLRU is the default connection tracking
 	// interval when using non-LRU maps
 	ConntrackGCIntervalNonLRU = 15 * time.Minute
+
+	// K8sEventHandover enables use of the kvstore to optimize Kubernetes
+	// event handling by listening for k8s events in the operator and
+	// mirroring it into the kvstore for reduced overhead in large
+	// clusters.
+	K8sEventHandover = false
 )

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -436,6 +436,9 @@ const (
 	// SelectiveRegeneration specifies whether only the endpoints which policy
 	// changes select should be regenerated upon policy changes.
 	SelectiveRegeneration = "enable-selective-regeneration"
+
+	// K8sEventHandover is the name of the K8sEventHandover option
+	K8sEventHandover = "enable-k8s-event-handover"
 )
 
 // FQDNS variables
@@ -857,6 +860,12 @@ type DaemonConfig struct {
 	// ConntrackGCInterval is the connection tracking garbage collection
 	// interval
 	ConntrackGCInterval time.Duration
+
+	// K8sEventHandover enables use of the kvstore to optimize Kubernetes
+	// event handling by listening for k8s events in the operator and
+	// mirroring it into the kvstore for reduced overhead in large
+	// clusters.
+	K8sEventHandover bool
 }
 
 var (
@@ -1125,6 +1134,7 @@ func (c *DaemonConfig) Populate() {
 	c.K8sRequireIPv4PodCIDR = viper.GetBool(K8sRequireIPv4PodCIDRName)
 	c.K8sRequireIPv6PodCIDR = viper.GetBool(K8sRequireIPv6PodCIDRName)
 	c.K8sForceJSONPatch = viper.GetBool(K8sForceJSONPatch)
+	c.K8sEventHandover = viper.GetBool(K8sEventHandover)
 	c.K8sWatcherQueueSize = uint(viper.GetInt(K8sWatcherQueueSize))
 	c.K8sWatcherEndpointSelector = viper.GetString(K8sWatcherEndpointSelector)
 	c.KeepTemplates = viper.GetBool(KeepBPFTemplates)


### PR DESCRIPTION
This is a new feature and primiarly targeted at larger scale. It requires the
operator to be functional. This adds complexity which is only required once k8s
apiserver event handling at scale becomes a concern. Require users to opt-in.

Fixes: #7722

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7755)
<!-- Reviewable:end -->
