### PR TITLE
CI: Check Cilium Operator only when supported

### DIFF
--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -161,11 +161,13 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldVersion, newV
 		ExpectCiliumReady(kubectl)
 
 		By("Installing Cilium-Operator")
-		err = kubectl.CiliumOperatorInstall(oldVersion)
+		operatorIsInstalled, err := kubectl.CiliumOperatorInstall(oldVersion)
 		Expect(err).To(BeNil(), "Cannot install Cilium Operator")
 
 		ExpectETCDOperatorReady(kubectl)
-		ExpectCiliumOperatorReady(kubectl)
+		if operatorIsInstalled {
+			ExpectCiliumOperatorReady(kubectl)
+		}
 
 		By("Installing Microscope")
 		microscopeErr, microscopeCancel := kubectl.MicroscopeStart()
@@ -216,7 +218,7 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldVersion, newV
 		res := kubectl.Apply(demoPath)
 		ExpectWithOffset(1, res).To(helpers.CMDSuccess(), "cannot apply dempo application")
 
-		err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=testapp", timeout)
+		err = kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=testapp", timeout)
 		Expect(err).Should(BeNil(), "Test pods are not ready after timeout")
 
 		ExpectKubeDNSReady(kubectl)
@@ -265,7 +267,7 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldVersion, newV
 		ExpectWithOffset(1, err).To(BeNil(), "Cilium %q was not able to be deployed", newVersion)
 
 		By("Installing Cilium-Operator")
-		err = kubectl.CiliumOperatorInstall("head")
+		operatorIsInstalled, err = kubectl.CiliumOperatorInstall("head")
 		Expect(err).To(BeNil(), "Cannot install Cilium Operator")
 
 		err = helpers.WithTimeout(
@@ -281,7 +283,9 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldVersion, newV
 		validatedImage(newVersion)
 		ExpectCiliumReady(kubectl)
 
-		ExpectCiliumOperatorReady(kubectl)
+		if operatorIsInstalled {
+			ExpectCiliumOperatorReady(kubectl)
+		}
 
 		validateEndpointsConnection()
 
@@ -295,7 +299,7 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldVersion, newV
 		ExpectWithOffset(1, err).To(BeNil(), "Cilium %q was not able to be deployed", oldVersion)
 
 		By("Installing Cilium-Operator")
-		err = kubectl.CiliumOperatorInstall(oldVersion)
+		operatorIsInstalled, err = kubectl.CiliumOperatorInstall(oldVersion)
 		Expect(err).To(BeNil(), "Cannot install Cilium Operator")
 
 		err = helpers.WithTimeout(
@@ -309,7 +313,9 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldVersion, newV
 		ExpectWithOffset(1, err).Should(BeNil(), "Cilium is not ready after timeout")
 
 		validatedImage(oldVersion)
-		ExpectCiliumOperatorReady(kubectl)
+		if operatorIsInstalled {
+			ExpectCiliumOperatorReady(kubectl)
+		}
 
 		validateEndpointsConnection()
 

--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -119,7 +119,7 @@ func ProvisionInfraPods(vm *helpers.Kubectl) {
 	Expect(err).To(BeNil(), "Cilium cannot be installed")
 
 	By("Installing Cilium-Operator")
-	err = vm.CiliumOperatorInstall("head")
+	operatorIsInstalled, err := vm.CiliumOperatorInstall("head")
 	Expect(err).To(BeNil(), "Cannot install Cilium Operator")
 
 	switch helpers.GetCurrentIntegration() {
@@ -132,7 +132,9 @@ func ProvisionInfraPods(vm *helpers.Kubectl) {
 	ExpectETCDOperatorReady(vm)
 	Expect(vm.WaitKubeDNS()).To(BeNil(), "KubeDNS is not ready after timeout")
 	ExpectCiliumReady(vm)
-	ExpectCiliumOperatorReady(vm)
+	if operatorIsInstalled {
+		ExpectCiliumOperatorReady(vm)
+	}
 	ExpectKubeDNSReady(vm)
 }
 


### PR DESCRIPTION
cilium <v1.4 did not support/require Cilium operator but most CI code is
not directly aware of this. This is most pronounced in upgrade tests
that check different version combinations.
The structure of the install/assert code makes it difficult to include
whether the operator should be running inside
ExpectCiliumOperatorReady so we skip calling it at all callsites based
on whether CiliumOperatorInstall installed Cilium operator.

This fixes one of the persistent failures in Nightly tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7757)
<!-- Reviewable:end -->
