### PR TITLE
cilium: enable sockops connectivity test with k8sT

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -698,10 +698,18 @@ func (d *Daemon) init() error {
 		}
 
 		if option.Config.SockopsEnable {
+			disableSockops := func(err error) {
+				option.Config.SockopsEnable = false
+				log.WithError(err).Warn("Disabled '--sockops-enable' due to missing BPF kernel support")
+			}
 			eppolicymap.CreateEPPolicyMap()
-			sockops.SockmapEnable()
-			sockops.SkmsgEnable()
-			sockmap.SockmapCreate()
+			if err := sockops.SockmapEnable(); err != nil {
+				disableSockops(err)
+			} else if err := sockops.SkmsgEnable(); err != nil {
+				disableSockops(err)
+			} else {
+				sockmap.SockmapCreate()
+			}
 		}
 
 		if err := d.compileBase(); err != nil {

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -125,6 +125,14 @@ var _ = Describe("K8sDatapathConfig", func() {
 			cleanService()
 		}, 600)
 
+		It("Check connectivity with sockops and VXLAN encapsulation", func() {
+			// Note if run on kernel without sockops feature is ignored
+			deployCilium("cilium-ds-patch-vxlan-sockops.yaml")
+			validateBPFTunnelMap()
+			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
+			cleanService()
+		}, 600)
+
 		It("Check connectivity with VXLAN encapsulation", func() {
 			SkipIfFlannel()
 

--- a/test/k8sT/manifests/cilium-ds-patch-vxlan-sockops.yaml
+++ b/test/k8sT/manifests/cilium-ds-patch-vxlan-sockops.yaml
@@ -1,0 +1,24 @@
+---
+metadata:
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+      - image: k8s1:5000/cilium/cilium-dev:latest
+        imagePullPolicy: Always
+        name: cilium-agent
+        args:
+        - "--tunnel=vxlan"
+        - "--kvstore=etcd"
+        - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
+        - "--k8s-require-ipv4-pod-cidr"
+        - "--pprof=true"
+        - "--log-system-load"
+        - "--config-dir=/tmp/cilium/config-map"
+        - "--sockops-enable"
+      volumes:
+      - name: etcd-secrets
+        secret:
+          secretName: cilium-etcd-client-tls
+      dnsPolicy: ClusterFirstWithHostNet


### PR DESCRIPTION
Add a sockops test. Adding to k8sT to test both local traffic and that
VM to VM traffic is properly handled.

Signed-off-by: John Fastabend <john.fastabend@gmail.com>

---
Now sockops can be enabled on any kernel version and will be disabled with a warning on kernels without sockmap/sockops support, but the cilium-agent will continue to work as expected. Previously it would continue to run but the map-sync controller would throw errors because the sockmap would not be in a good state.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7759)
<!-- Reviewable:end -->
