### PR TITLE
docs: Add containerd to self-managed installation section

### DIFF
--- a/Documentation/gettingstarted/k8s-install-etcd-operator-steps.rst
+++ b/Documentation/gettingstarted/k8s-install-etcd-operator-steps.rst
@@ -120,3 +120,37 @@ For CRI-O as container runtime:
     .. parsed-literal::
 
       kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.10/cilium-crio.yaml
+
+For containerd as container runtime:
+-------------------------------
+
+.. tabs::
+  .. group-tab:: K8s 1.14
+
+    .. parsed-literal::
+
+      kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.14/cilium-containerd.yaml
+
+  .. group-tab:: K8s 1.13
+
+    .. parsed-literal::
+
+      kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.13/cilium-containerd.yaml
+
+  .. group-tab:: K8s 1.12
+
+    .. parsed-literal::
+
+      kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.12/cilium-containerd.yaml
+
+  .. group-tab:: K8s 1.11
+
+    .. parsed-literal::
+
+      kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.11/cilium-containerd.yaml
+
+  .. group-tab:: K8s 1.10
+
+    .. parsed-literal::
+
+      kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.10/cilium-containerd.yaml


### PR DESCRIPTION
Adds a tabbed section for containerd to the self-managed installation section, next to Docker and CRI-O.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7761)
<!-- Reviewable:end -->
