### PR TITLE
daemon: Panic if executable name does not match cilium{-agent,-node-monitor,}

### DIFF
--- a/daemon/main.go
+++ b/daemon/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path"
 
@@ -32,5 +33,8 @@ func main() {
 		cmd.Execute()
 	case "cilium-node-monitor":
 		monitor.Execute()
+	default:
+		panic(fmt.Sprintf("Invalid executable name: %s. Only \"cilium-agent\", "+
+			"\"cilium\" or \"cilium-node-monitor\" is supported.", base))
 	}
 }


### PR DESCRIPTION
Previously, if the executable name of cilium didn't match neither from the above, the executable exited with 0 and didn't log anything to stdout/stderr.

This could have confused users who downloaded the released cilium executables which were suffixed with `-x86_64` (e.g. `cilium-agent-x86_64`) and due to the suffix were failing silently.

---

A user = me who spent 15 minutes stracing the cilium executable while thinking that my environment is broken.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7763)
<!-- Reviewable:end -->
