### PR TITLE
cilium: sockmap logging is a bit redundant clean it up

### DIFF
--- a/pkg/sockops/sockops.go
+++ b/pkg/sockops/sockops.go
@@ -403,7 +403,6 @@ func SkmsgEnable() error {
 // the file associated with the program.
 func SkmsgDisable() {
 	bpftoolUnload(eIPC)
-	log.Info("Sockmsg Disabled.")
 }
 
 // First user of sockops root is sockops load programs so we ensure the sockops
@@ -461,5 +460,4 @@ func SockmapDisable() {
 	bpftoolDetach(eSockops)
 	bpftoolUnload(eSockops)
 	bpftoolUnload(mapName)
-	log.Info("Sockmap disabled.")
 }


### PR DESCRIPTION
Because we cleanup the sockmap state at daemon init time the logs
will have these two messges near eachother,

  Sockmap Disabled
  Sockmsg Disabled

Really this is just telling the user that sockmap is being flushed
and is ready to reinit. If sockmap is enabled this is followed by
yet another message,

  Sockmap Enabled: ...

This patch removes the *Disabled messages instead we only print
output now if there is an error during the reinit and will print
a single "Sockmap Enabled..." message if sockmap is enabled. The
absense of the enabled message means sockmap is disabled plus the
top of the logs have the init args which can also be checked.

We don't change any error messages so if there is an error that
will continue to be printed.

Signed-off-by: John Fastabend <john.fastabend@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7764)
<!-- Reviewable:end -->
