### PR TITLE
daemon: Use controller context for health endpoint

### DIFF
--- a/daemon/health.go
+++ b/daemon/health.go
@@ -65,7 +65,7 @@ func (d *Daemon) initHealth() {
 				// error, restart the health EP.
 				if client == nil || err != nil {
 					d.cleanupHealthEndpoint()
-					client, err = health.LaunchAsEndpoint(d, &d.nodeDiscovery.LocalNode, d.mtuConfig)
+					client, err = health.LaunchAsEndpoint(ctx, d, &d.nodeDiscovery.LocalNode, d.mtuConfig)
 				}
 				return err
 			},


### PR DESCRIPTION
Pass the health endpoint controller context down to the health endpoint
launch function and derive a timeout-based context from it, to ensure
that the health endpoint is launched within a reasonable period of time.

Related: #7760

I don't think that this necessarily fixes #7760, but it probably helps in the
worst case. The lack of context here has been present for several
versions of Cilium so I'm not considering this a regression.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7771)
<!-- Reviewable:end -->
