### PR TITLE
cni: Stop removing CNI_CONF_NAME on preStop

### DIFF
--- a/plugins/cilium-cni/cni-uninstall.sh
+++ b/plugins/cilium-cni/cni-uninstall.sh
@@ -27,28 +27,14 @@ function get_list_of_veth_from_bridge() {
 }
 
 HOST_PREFIX=${HOST_PREFIX:-/host}
-if [[ -z "${CILIUM_FLANNEL_MASTER_DEVICE}" ]]; then
-    CNI_CONF_NAME=${CNI_CONF_NAME:-05-cilium.conf}
-else
-    CNI_CONF_NAME=${CNI_CONF_NAME:-04-flannel-cilium-cni.conflist}
-fi
-
 BIN_NAME=cilium-cni
 CNI_DIR=${CNI_DIR:-${HOST_PREFIX}/opt/cni}
-CILIUM_CNI_CONF=${CILIUM_CNI_CONF:-${HOST_PREFIX}/etc/cni/net.d/${CNI_CONF_NAME}}
 
 echo "Removing ${CNI_DIR}/bin/cilium-cni..."
 rm -f ${CNI_DIR}/bin/${BIN_NAME}
 rm -f ${CNI_DIR}/bin/${BIN_NAME}.old
 
-
-if [[ -z "${CILIUM_FLANNEL_MASTER_DEVICE}" ]]; then
-    echo "Removing ${CILIUM_CNI_CONF} ..."
-    rm -f ${CILIUM_CNI_CONF}
-elif [[ "${CILIUM_FLANNEL_UNINSTALL_ON_EXIT}" == "true" ]]; then
-    echo "Removing ${CILIUM_CNI_CONF} ..."
-    rm -f ${CILIUM_CNI_CONF}
-
+if [[ "${CILIUM_FLANNEL_UNINSTALL_ON_EXIT}" == "true" ]]; then
     echo "Removing BPF programs from all containers and from ${CILIUM_FLANNEL_MASTER_DEVICE}"
     echo "Uninstalling cilium from ${CILIUM_FLANNEL_MASTER_DEVICE}"
     uninstall_cilium_from_flannel_master "${CILIUM_FLANNEL_MASTER_DEVICE}"


### PR DESCRIPTION
The idea behind removing the CNI_CONF_NAME on preStop has been to leave no
trace behind when the DaemonSet is removed. This strategy has caused two
reocurring problems:

 * When Cilium is restarted, kubelet may fall-back to a different CNI
   configuration during a short race window, this may cause pods to be managed
   by a CNI which does not provide network security policy enforcement which
   then leads to unexpected protection loss.

 * When users provide a manual CNI configuration, the manual file is kept
   untouched on start but then removed when the agent restarts.

Stop removing the CNI configuration

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7772)
<!-- Reviewable:end -->
