### PR TITLE
cilium, template: add cilium_encrypt_state to ignored prefixes

### DIFF
--- a/pkg/datapath/loader/cache.go
+++ b/pkg/datapath/loader/cache.go
@@ -43,21 +43,22 @@ var (
 	templateWatcherQueueSize = 10
 
 	ignoredELFPrefixes = []string{
-		"2/",                 // Calls within the endpoint
-		"HOST_IP",            // Global
-		"ROUTER_IP",          // Global
-		"SNAT_IPV6_EXTERNAL", // Global
-		"cilium_ct",          // All CT maps, including local
-		"cilium_snat",        // All SNAT maps
-		"cilium_events",      // Global
-		"cilium_ipcache",     // Global
-		"cilium_lb",          // Global
-		"cilium_lxc",         // Global
-		"cilium_metrics",     // Global
-		"cilium_proxy",       // Global
-		"cilium_tunnel",      // Global
-		"cilium_policy",      // Global
-		"from-container",     // Prog name
+		"2/",                   // Calls within the endpoint
+		"HOST_IP",              // Global
+		"ROUTER_IP",            // Global
+		"SNAT_IPV6_EXTERNAL",   // Global
+		"cilium_ct",            // All CT maps, including local
+		"cilium_encrypt_state", // Global
+		"cilium_events",        // Global
+		"cilium_ipcache",       // Global
+		"cilium_lb",            // Global
+		"cilium_lxc",           // Global
+		"cilium_metrics",       // Global
+		"cilium_policy",        // Global
+		"cilium_proxy",         // Global
+		"cilium_snat",          // All SNAT maps
+		"cilium_tunnel",        // Global
+		"from-container",       // Prog name
 	}
 )
 


### PR DESCRIPTION
Seen several warnings in the cilium agent log files as the following:

  2019-04-17T20:11:25.804796408Z level=warning msg="Skipping symbol substitution" subsys=elf symbol=cilium_encrypt_state

The map is a global one, therefore add it to ignored prefixes to
silence the warning.

Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7773)
<!-- Reviewable:end -->
