### PR TITLE
Cilium: Remove encryption state on NodeDelete events

### DIFF
--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -773,13 +773,19 @@ func (n *linuxNodeHandler) replaceNodeIPSecInRoute(ip *net.IPNet) {
 
 func (n *linuxNodeHandler) deleteIPsec(oldNode *node.Node) {
 	if n.nodeConfig.EnableIPv4 && oldNode.IPv4AllocCIDR != nil {
+		ciliumInternalIPv4 := oldNode.GetCiliumInternalIP(false)
+		old4Net := &net.IPNet{IP: ciliumInternalIPv4, Mask: oldNode.IPv4AllocCIDR.Mask}
 		old4RouteNet := &net.IPNet{IP: oldNode.IPv4AllocCIDR.IP, Mask: oldNode.IPv4AllocCIDR.Mask}
 		n.deleteNodeIPSecOutRoute(old4RouteNet)
+		ipsec.DeleteIPsecEndpoint(old4Net)
 	}
 
 	if n.nodeConfig.EnableIPv6 && oldNode.IPv6AllocCIDR != nil {
+		ciliumInternalIPv6 := oldNode.GetCiliumInternalIP(true)
+		old6Net := &net.IPNet{IP: ciliumInternalIPv6, Mask: oldNode.IPv6AllocCIDR.Mask}
 		old6RouteNet := &net.IPNet{IP: oldNode.IPv6AllocCIDR.IP, Mask: oldNode.IPv6AllocCIDR.Mask}
 		n.deleteNodeIPSecOutRoute(old6RouteNet)
+		ipsec.DeleteIPsecEndpoint(old6Net)
 	}
 }
 

--- a/pkg/datapath/linux/route/route_linux.go
+++ b/pkg/datapath/linux/route/route_linux.go
@@ -377,6 +377,7 @@ func DeleteRule(fwmark int, table int) error {
 func DeleteRuleIPv6(fwmark int, table int) error {
 	rule := netlink.NewRule()
 	rule.Mark = fwmark
+	rule.Mask = linux_defaults.RouteMarkMask
 	rule.Table = table
 	rule.Family = netlink.FAMILY_V6
 	return netlink.RuleDel(rule)


### PR DESCRIPTION
Delete encryption state when nodes are deleted otherwise the datapath will contain state for every node that existed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7776)
<!-- Reviewable:end -->
