### PR TITLE
test: Allow Cilium 1.4 to be run with K8s 1.14

### DIFF
--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -377,7 +377,7 @@ func getK8sSupportedConstraints(ciliumVersion string) (go_version.Constraints, e
 	case CiliumV1_3.Check(cst):
 		return versioncheck.MustCompile(">= 1.8, <1.13"), nil
 	case CiliumV1_4.Check(cst):
-		return versioncheck.MustCompile(">= 1.8, <1.14"), nil
+		return versioncheck.MustCompile(">= 1.8, <1.15"), nil
 	case CiliumV1_5.Check(cst):
 		return versioncheck.MustCompile(">= 1.8, <1.15"), nil
 	default:


### PR DESCRIPTION
This PR makes it possible to run upgrade tests on k8s 1.14 with Cilium 1.4.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7779)
<!-- Reviewable:end -->
