### PR TITLE
Find/Fix Nightly flakes

### DIFF
--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -492,6 +492,10 @@ func (r *rule) meetsRequirementsIngress(ctx *SearchContext, state *traceState) a
 }
 
 func (r *rule) matches(securityIdentity *identity.Identity) bool {
+	if securityIdentity == nil {
+		return false
+	}
+
 	r.metadata.Mutex.Lock()
 	defer r.metadata.Mutex.Unlock()
 	var ruleMatches bool

--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -366,6 +366,11 @@ func (rules ruleSlice) updateEndpointsCaches(ep Endpoint, epIDSet *IDSet) bool {
 	id := ep.GetID16()
 	securityIdentity := ep.GetSecurityIdentity()
 
+	// The endpoint isn't initialized yet, and we can't update anything here.
+	if securityIdentity == nil {
+		return true
+	}
+
 	for _, r := range rules {
 		if ruleMatches := r.matches(securityIdentity); ruleMatches {
 			epIDSet.Mutex.Lock()


### PR DESCRIPTION
Testing
- Fix a nil in this panic (probably a nil pointer on the security identity)
```
2019-04-14T00:29:20.734695714Z level=debug msg="EventQueue event processing statistics" eventConsumeOffQueueWaitTime=678ns eventEnqueueWaitTime=773ns eventHandlingDuration="474.899µs" eventType="*main.PolicyDeleteEvent" name=repository-change-queue subsys=eventqueue
2019-04-14T00:29:20.738211783Z panic: runtime error: invalid memory address or nil pointer dereference
2019-04-14T00:29:20.738236307Z [signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x231b390]
2019-04-14T00:29:20.738251405Z 
2019-04-14T00:29:20.738255152Z goroutine 28050 [running]:
2019-04-14T00:29:20.738258311Z github.com/cilium/cilium/pkg/policy.(*rule).matches(0xc0015e8690, 0x80c, 0x0, 0x1114200)
2019-04-14T00:29:20.73826143Z 	/go/src/github.com/cilium/cilium/pkg/policy/rule.go:469 +0xb0
2019-04-14T00:29:20.738264831Z github.com/cilium/cilium/pkg/policy.ruleSlice.updateEndpointsCaches(0xc00119ca30, 0x2, 0x2, 0x33ef980, 0xc001bc62c0, 0xc000a7d600, 0x0)
2019-04-14T00:29:20.738268813Z 	/go/src/github.com/cilium/cilium/pkg/policy/rules.go:284 +0xac
2019-04-14T00:29:20.738271967Z github.com/cilium/cilium/pkg/policy.ruleSlice.UpdateRulesEndpointsCaches.func1(0x33ef980, 0xc001bc62c0)
2019-04-14T00:29:20.738274979Z 	/go/src/github.com/cilium/cilium/pkg/policy/repository.go:462 +0x66
2019-04-14T00:29:20.738278027Z github.com/cilium/cilium/pkg/policy.(*EndpointSet).ForEach.func1(0xc00090dc80, 0xc000a2c0b0, 0x33ef980, 0xc001bc62c0)
2019-04-14T00:29:20.738280977Z 	/go/src/github.com/cilium/cilium/pkg/policy/identifier.go:75 +0x3a
2019-04-14T00:29:20.738284152Z created by github.com/cilium/cilium/pkg/policy.(*EndpointSet).ForEach
2019-04-14T00:29:20.738287776Z 	/go/src/github.com/cilium/cilium/pkg/policy/identifier.go:74 +0x12c
2019-04-14T00:29:20.758414296Z level=fatal msg="Agent pipe unexpectedly closed, shutting down" subsys=cilium-node-monitor
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7780)
<!-- Reviewable:end -->
