### PR TITLE
v1.5 backport 19-04-18

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -7,6 +7,7 @@ llc --version
 export CFLAGS="-Werror"
 export CGO_CFLAGS="-DCI_BUILD"
 
+dep check
 make unit-tests
 
 $HOME/gopath/bin/goveralls -coverprofile=coverage-all.out -service=travis-ci || true

--- a/.travis/prepare.sh
+++ b/.travis/prepare.sh
@@ -17,3 +17,4 @@ export PATH="$NEWPATH:$PATH"
 go get -u github.com/jteeuwen/go-bindata/...
 go get golang.org/x/tools/cmd/cover
 go get github.com/mattn/goveralls
+curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh

--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -44,6 +44,7 @@ cilium-agent [flags]
       --enable-ipsec                               Enable IPSec support
       --enable-ipv4                                Enable IPv4 support (default true)
       --enable-ipv6                                Enable IPv6 support (default true)
+      --enable-k8s-event-handover                  Enable k8s event handover to kvstore for improved scalability
       --enable-legacy-services                     Enable legacy (prior-v1.5) services (default true)
       --enable-policy string                       Enable policy enforcement (default "default")
       --enable-tracing                             Enable tracing while determining policy (debugging)

--- a/Documentation/gettingstarted/k8s-install-etcd-operator-steps.rst
+++ b/Documentation/gettingstarted/k8s-install-etcd-operator-steps.rst
@@ -120,3 +120,37 @@ For CRI-O as container runtime:
     .. parsed-literal::
 
       kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.10/cilium-crio.yaml
+
+For containerd as container runtime:
+-------------------------------
+
+.. tabs::
+  .. group-tab:: K8s 1.14
+
+    .. parsed-literal::
+
+      kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.14/cilium-containerd.yaml
+
+  .. group-tab:: K8s 1.13
+
+    .. parsed-literal::
+
+      kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.13/cilium-containerd.yaml
+
+  .. group-tab:: K8s 1.12
+
+    .. parsed-literal::
+
+      kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.12/cilium-containerd.yaml
+
+  .. group-tab:: K8s 1.11
+
+    .. parsed-literal::
+
+      kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.11/cilium-containerd.yaml
+
+  .. group-tab:: K8s 1.10
+
+    .. parsed-literal::
+
+      kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.10/cilium-containerd.yaml

--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -282,6 +282,9 @@ New ConfigMap Options
   All options available in the cilium-agent can now be specified in the Cilium
   ConfigMap without requiring to set an environment variable in the DaemonSet.
 
+  * ``enable-k8s-event-handover``: enables use of the kvstore to optimize
+    Kubernetes event handling by listening for k8s events in the operator and
+    mirroring it into the kvstore for reduced overhead in large clusters.
 
 Deprecated Options
 ~~~~~~~~~~~~~~~~~~

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -555,10 +555,12 @@ func (d *Daemon) compileBase() error {
 	}
 
 	if option.Config.EnableIPv4 {
+		iptablesManager := iptables.IptablesManager{}
+		iptablesManager.Init()
 		// Always remove masquerade rule and then re-add it if required
-		iptables.RemoveRules()
+		iptablesManager.RemoveRules()
 		if option.Config.InstallIptRules {
-			if err := iptables.InstallRules(option.Config.HostDevice); err != nil {
+			if err := iptablesManager.InstallRules(option.Config.HostDevice); err != nil {
 				return err
 			}
 		}

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -521,6 +521,9 @@ func init() {
 	flags.String(option.IPv6ServiceRange, AutoCIDR, "Kubernetes IPv6 services CIDR if not inside cluster prefix")
 	option.BindEnv(option.IPv6ServiceRange)
 
+	flags.Bool(option.K8sEventHandover, defaults.K8sEventHandover, "Enable k8s event handover to kvstore for improved scalability")
+	option.BindEnv(option.K8sEventHandover)
+
 	flags.String(option.K8sAPIServer, "", "Kubernetes api address server (for https use --k8s-kubeconfig-path instead)")
 	option.BindEnv(option.K8sAPIServer)
 

--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -846,6 +846,7 @@ func (d *Daemon) EnableK8sWatcher(queueSize uint) error {
 			// Create a new pod controller when we are disconnected with the
 			// kvstore
 			<-kvstore.Client().Disconnected()
+			close(isConnected)
 			log.Info("Disconnected from KVStore, watching for pod events all nodes")
 		}
 	}()
@@ -946,6 +947,7 @@ func (d *Daemon) EnableK8sWatcher(queueSize uint) error {
 			// Create a new node controller when we are disconnected with the
 			// kvstore
 			<-kvstore.Client().Disconnected()
+			close(isConnected)
 
 			log.Info("Disconnected from KVStore, restarting k8s node watcher")
 		}

--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -827,8 +827,13 @@ func (d *Daemon) EnableK8sWatcher(queueSize uint) error {
 			})
 			go podController.Run(isConnected)
 
+			if !option.Config.K8sEventHandover {
+				return
+			}
+
 			// Replace pod controller by only receiving events from our own
 			// node once we are connected to the kvstore.
+
 			<-kvstore.Client().Connected()
 			close(isConnected)
 
@@ -927,6 +932,11 @@ func (d *Daemon) EnableK8sWatcher(queueSize uint) error {
 			go nodeController.Run(isConnected)
 			// TODO: do we really need to wait until etcd watcher signalizes
 			// "listDone" or connected to it is sufficient?
+
+			if !option.Config.K8sEventHandover {
+				return
+			}
+
 			<-kvstore.Client().Connected()
 			close(isConnected)
 

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path"
 
@@ -32,5 +33,8 @@ func main() {
 		cmd.Execute()
 	case "cilium-node-monitor":
 		monitor.Execute()
+	default:
+		panic(fmt.Sprintf("Invalid executable name: %s. Only \"cilium-agent\", "+
+			"\"cilium\" or \"cilium-node-monitor\" is supported.", base))
 	}
 }

--- a/pkg/datapath/loader/cache.go
+++ b/pkg/datapath/loader/cache.go
@@ -43,21 +43,22 @@ var (
 	templateWatcherQueueSize = 10
 
 	ignoredELFPrefixes = []string{
-		"2/",                 // Calls within the endpoint
-		"HOST_IP",            // Global
-		"ROUTER_IP",          // Global
-		"SNAT_IPV6_EXTERNAL", // Global
-		"cilium_ct",          // All CT maps, including local
-		"cilium_snat",        // All SNAT maps
-		"cilium_events",      // Global
-		"cilium_ipcache",     // Global
-		"cilium_lb",          // Global
-		"cilium_lxc",         // Global
-		"cilium_metrics",     // Global
-		"cilium_proxy",       // Global
-		"cilium_tunnel",      // Global
-		"cilium_policy",      // Global
-		"from-container",     // Prog name
+		"2/",                   // Calls within the endpoint
+		"HOST_IP",              // Global
+		"ROUTER_IP",            // Global
+		"SNAT_IPV6_EXTERNAL",   // Global
+		"cilium_ct",            // All CT maps, including local
+		"cilium_encrypt_state", // Global
+		"cilium_events",        // Global
+		"cilium_ipcache",       // Global
+		"cilium_lb",            // Global
+		"cilium_lxc",           // Global
+		"cilium_metrics",       // Global
+		"cilium_policy",        // Global
+		"cilium_proxy",         // Global
+		"cilium_snat",          // All SNAT maps
+		"cilium_tunnel",        // Global
+		"from-container",       // Prog name
 	}
 )
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -189,4 +189,10 @@ const (
 	// ConntrackGCIntervalNonLRU is the default connection tracking
 	// interval when using non-LRU maps
 	ConntrackGCIntervalNonLRU = 15 * time.Minute
+
+	// K8sEventHandover enables use of the kvstore to optimize Kubernetes
+	// event handling by listening for k8s events in the operator and
+	// mirroring it into the kvstore for reduced overhead in large
+	// clusters.
+	K8sEventHandover = false
 )

--- a/pkg/modules/doc.go
+++ b/pkg/modules/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package modules contains a manager of loaded modules which supports search
+// operation.
+package modules

--- a/pkg/modules/modules.go
+++ b/pkg/modules/modules.go
@@ -1,0 +1,63 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package modules
+
+import (
+	"fmt"
+
+	"github.com/cilium/cilium/pkg/command/exec"
+	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/set"
+)
+
+// ModulesManager is a manager which stores information about loaded modules
+// and provides a search operation.
+type ModulesManager struct {
+	modulesList []string
+}
+
+// Init initializes the internal modules information store of modules manager.
+func (m *ModulesManager) Init() error {
+	modulesList, err := listModules()
+	if err != nil {
+		return err
+	}
+	m.modulesList = modulesList
+	return nil
+}
+
+// findModules checks whether the given kernel modules are loaded and also
+// returns a slice with names of modules which are not loaded.
+func (m *ModulesManager) findModules(expectedNames ...string) (bool, []string) {
+	return set.SliceSubsetOf(expectedNames, m.modulesList)
+}
+
+// FindOrLoadModules checks whether the given kernel modules are loaded and
+// tries to load those which are not.
+func (m *ModulesManager) FindOrLoadModules(expectedNames ...string) error {
+	found, diff := m.findModules(expectedNames...)
+	if found {
+		return nil
+	}
+	for _, unloadedModule := range diff {
+		if _, err := exec.WithTimeout(
+			defaults.ExecTimeout, moduleLoader(), unloadedModule).CombinedOutput(
+			nil, false); err != nil {
+			return fmt.Errorf("could not load module %s: %s",
+				unloadedModule, err)
+		}
+	}
+	return nil
+}

--- a/pkg/modules/modules_linux.go
+++ b/pkg/modules/modules_linux.go
@@ -1,0 +1,66 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package modules
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+const (
+	modulesFilepath = "/proc/modules"
+)
+
+func moduleLoader() string {
+	return "modprobe"
+}
+
+// parseModulesFile returns the list of loaded kernel modules names.
+func parseModulesFile(r io.Reader) ([]string, error) {
+	var result []string
+
+	scanner := bufio.NewScanner(r)
+	scanner.Split(bufio.ScanLines)
+
+	for scanner.Scan() {
+		moduleInfoRaw := scanner.Text()
+		moduleInfoSeparated := strings.Split(moduleInfoRaw, " ")
+		if len(moduleInfoSeparated) < 6 {
+			return nil, fmt.Errorf(
+				"invalid module info - it has %d fields (less than 6): %s",
+				len(moduleInfoSeparated), moduleInfoRaw)
+		}
+
+		result = append(result, moduleInfoSeparated[0])
+	}
+
+	return result, nil
+}
+
+// listModules returns the list of loaded kernel modules names parsed from
+// /proc/modules.
+func listModules() ([]string, error) {
+	fModules, err := os.Open(modulesFilepath)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to open modules information at %s: %s",
+			modulesFilepath, err)
+	}
+	defer fModules.Close()
+	return parseModulesFile(fModules)
+}

--- a/pkg/modules/modules_linux_privileged_test.go
+++ b/pkg/modules/modules_linux_privileged_test.go
@@ -1,0 +1,61 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux,privileged_tests
+
+package modules
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type ModulesPrivilegedTestSuite struct{}
+
+var _ = Suite(&ModulesPrivilegedTestSuite{})
+
+func (s *ModulesPrivilegedTestSuite) TestFindOrLoadModules(c *C) {
+	testCases := []struct {
+		modulesToFind []string
+		expectedErr   bool
+	}{
+		{
+			modulesToFind: []string{"bridge"},
+			expectedErr:   false,
+		},
+		{
+			modulesToFind: []string{"foo", "bar"},
+			expectedErr:   true,
+		},
+	}
+
+	manager := &ModulesManager{}
+	err := manager.Init()
+	c.Assert(err, IsNil)
+
+	for _, tc := range testCases {
+		err = manager.FindOrLoadModules(tc.modulesToFind...)
+		if tc.expectedErr {
+			c.Assert(err, NotNil)
+		} else {
+			c.Assert(err, IsNil)
+		}
+	}
+}

--- a/pkg/modules/modules_test.go
+++ b/pkg/modules/modules_test.go
@@ -1,0 +1,166 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package modules
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/cilium/cilium/pkg/checker"
+
+	. "gopkg.in/check.v1"
+)
+
+const (
+	modulesContent = `ebtable_nat 16384 1 - Live 0x0000000000000000
+ebtable_broute 16384 1 - Live 0x0000000000000000
+bridge 172032 1 ebtable_broute, Live 0x0000000000000000
+ip6table_nat 16384 1 - Live 0x0000000000000000
+nf_nat_ipv6 16384 1 ip6table_nat, Live 0x0000000000000000
+ip6table_mangle 16384 1 - Live 0x0000000000000000
+ip6table_raw 16384 1 - Live 0x0000000000000000
+ip6table_security 16384 1 - Live 0x0000000000000000
+iptable_nat 16384 1 - Live 0x0000000000000000
+nf_nat_ipv4 16384 1 iptable_nat, Live 0x0000000000000000
+iptable_mangle 16384 1 - Live 0x0000000000000000
+iptable_raw 16384 1 - Live 0x0000000000000000
+iptable_security 16384 1 - Live 0x0000000000000000
+ebtable_filter 16384 1 - Live 0x0000000000000000
+ebtables 36864 3 ebtable_nat,ebtable_broute,ebtable_filter, Live 0x0000000000000000
+ip6table_filter 16384 1 - Live 0x0000000000000000
+ip6_tables 28672 5 ip6table_nat,ip6table_mangle,ip6table_raw,ip6table_security,ip6table_filter, Live 0x0000000000000000
+iptable_filter 16384 1 - Live 0x0000000000000000
+ip_tables 28672 5 iptable_nat,iptable_mangle,iptable_raw,iptable_security,iptable_filter, Live 0x0000000000000000
+x_tables 40960 23 xt_multiport,xt_nat,xt_addrtype,xt_mark,xt_comment,xt_CHECKSUM,ipt_MASQUERADE,xt_tcpudp,ip6t_rpfilter,ip6t_REJECT,ipt_REJECT,xt_conntrack,ip6table_mangle,ip6table_raw,ip6table_security,iptable_mangle,iptable_raw,iptable_security,ebtables,ip6table_filter,ip6_tables,iptable_filter,ip_tables, Live 0x0000000000000000`
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type ModulesTestSuite struct{}
+
+var _ = Suite(&ModulesTestSuite{})
+
+func (s *ModulesTestSuite) TestInit(c *C) {
+	manager := &ModulesManager{}
+	c.Assert(manager.modulesList, IsNil)
+	err := manager.Init()
+	c.Assert(err, IsNil)
+	c.Assert(manager.modulesList, NotNil)
+}
+
+func (s *ModulesTestSuite) TestFindModules(c *C) {
+	manager := &ModulesManager{
+		modulesList: []string{
+			"ip6_tables",
+			"ip6table_mangle",
+			"ip6table_filter",
+			"ip6table_security",
+			"ip6table_raw",
+			"ip6table_nat",
+		},
+	}
+	testCases := []struct {
+		modulesToFind []string
+		isSubset      bool
+		expectedDiff  []string
+	}{
+		{
+			modulesToFind: []string{
+				"ip6_tables",
+				"ip6table_mangle",
+				"ip6table_filter",
+				"ip6table_security",
+				"ip6table_raw",
+				"ip6table_nat",
+			},
+			isSubset:     true,
+			expectedDiff: nil,
+		},
+		{
+			modulesToFind: []string{
+				"ip6_tables",
+				"ip6table_mangle",
+				"ip6table_raw",
+			},
+			isSubset:     true,
+			expectedDiff: nil,
+		},
+		{
+			modulesToFind: []string{
+				"ip6_tables",
+				"ip6table_mangle",
+				"ip6table_raw",
+				"foo_module",
+			},
+			isSubset:     false,
+			expectedDiff: []string{"foo_module"},
+		},
+		{
+			modulesToFind: []string{
+				"foo_module",
+				"bar_module",
+			},
+			isSubset:     false,
+			expectedDiff: []string{"foo_module", "bar_module"},
+		},
+	}
+	for _, tc := range testCases {
+		found, diff := manager.findModules(tc.modulesToFind...)
+		c.Assert(found, Equals, tc.isSubset)
+		c.Assert(diff, checker.DeepEquals, tc.expectedDiff)
+	}
+}
+
+func (s *ModulesTestSuite) TestParseModuleFile(c *C) {
+	expectedLength := 20
+	expectedModules := []string{
+		"ebtable_nat",
+		"ebtable_broute",
+		"bridge",
+		"ip6table_nat",
+		"nf_nat_ipv6",
+		"ip6table_mangle",
+		"ip6table_raw",
+		"ip6table_security",
+		"iptable_nat",
+		"nf_nat_ipv4",
+		"iptable_mangle",
+		"iptable_raw",
+		"iptable_security",
+		"ebtable_filter",
+		"ebtables",
+		"ip6table_filter",
+		"ip6_tables",
+		"iptable_filter",
+		"ip_tables",
+		"x_tables",
+	}
+
+	r := bytes.NewBuffer([]byte(modulesContent))
+	moduleInfos, err := parseModulesFile(r)
+	c.Assert(err, IsNil)
+	c.Assert(moduleInfos, HasLen, expectedLength)
+	c.Assert(moduleInfos, checker.DeepEquals, expectedModules)
+}
+
+func (s *ModulesTestSuite) TestListModules(c *C) {
+	_, err := listModules()
+	c.Assert(err, IsNil)
+}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -436,6 +436,9 @@ const (
 	// SelectiveRegeneration specifies whether only the endpoints which policy
 	// changes select should be regenerated upon policy changes.
 	SelectiveRegeneration = "enable-selective-regeneration"
+
+	// K8sEventHandover is the name of the K8sEventHandover option
+	K8sEventHandover = "enable-k8s-event-handover"
 )
 
 // FQDNS variables
@@ -857,6 +860,12 @@ type DaemonConfig struct {
 	// ConntrackGCInterval is the connection tracking garbage collection
 	// interval
 	ConntrackGCInterval time.Duration
+
+	// K8sEventHandover enables use of the kvstore to optimize Kubernetes
+	// event handling by listening for k8s events in the operator and
+	// mirroring it into the kvstore for reduced overhead in large
+	// clusters.
+	K8sEventHandover bool
 }
 
 var (
@@ -1125,6 +1134,7 @@ func (c *DaemonConfig) Populate() {
 	c.K8sRequireIPv4PodCIDR = viper.GetBool(K8sRequireIPv4PodCIDRName)
 	c.K8sRequireIPv6PodCIDR = viper.GetBool(K8sRequireIPv6PodCIDRName)
 	c.K8sForceJSONPatch = viper.GetBool(K8sForceJSONPatch)
+	c.K8sEventHandover = viper.GetBool(K8sEventHandover)
 	c.K8sWatcherQueueSize = uint(viper.GetInt(K8sWatcherQueueSize))
 	c.K8sWatcherEndpointSelector = viper.GetString(K8sWatcherEndpointSelector)
 	c.KeepTemplates = viper.GetBool(KeepBPFTemplates)

--- a/pkg/set/doc.go
+++ b/pkg/set/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package set contains a function for performing a subset check for slices.
+package set

--- a/pkg/set/set.go
+++ b/pkg/set/set.go
@@ -1,0 +1,41 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package set
+
+// SliceSubsetOf checks whether the first slice is a subset of the second slice. If
+// not, it also returns slice of elements which are the difference of both
+// input slices.
+func SliceSubsetOf(sub, main []string) (bool, []string) {
+	var diff []string
+	occurences := make(map[string]int, len(main))
+	result := true
+	for _, element := range main {
+		occurences[element]++
+	}
+	for _, element := range sub {
+		if count, ok := occurences[element]; !ok {
+			// Element was not found in the main slice.
+			result = false
+			diff = append(diff, element)
+		} else if count < 1 {
+			// The element is in both slices, but the sub slice
+			// has more duplicates.
+			result = false
+		} else {
+			occurences[element]--
+		}
+	}
+	return result, diff
+}

--- a/pkg/set/set_test.go
+++ b/pkg/set/set_test.go
@@ -1,0 +1,91 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package set
+
+import (
+	"testing"
+
+	"github.com/cilium/cilium/pkg/checker"
+
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type SetTestSuite struct{}
+
+var _ = Suite(&SetTestSuite{})
+
+func (s *SetTestSuite) TestSliceSubsetOf(c *C) {
+	testCases := []struct {
+		sub          []string
+		main         []string
+		isSubset     bool
+		expectedDiff []string
+	}{
+		{
+			sub:          []string{"foo", "bar"},
+			main:         []string{"foo", "bar", "baz"},
+			isSubset:     true,
+			expectedDiff: nil,
+		},
+		{
+			sub:          []string{"foo", "bar"},
+			main:         []string{"foo", "bar"},
+			isSubset:     true,
+			expectedDiff: nil,
+		},
+		{
+			sub:          []string{"foo", "bar"},
+			main:         []string{"foo", "baz"},
+			isSubset:     false,
+			expectedDiff: []string{"bar"},
+		},
+		{
+			sub:          []string{"baz"},
+			main:         []string{"foo", "bar"},
+			isSubset:     false,
+			expectedDiff: []string{"baz"},
+		},
+		{
+			sub:          []string{"foo", "bar", "fizz"},
+			main:         []string{"fizz", "buzz"},
+			isSubset:     false,
+			expectedDiff: []string{"foo", "bar"},
+		},
+		{
+			sub:          []string{"foo", "foo", "bar"},
+			main:         []string{"foo", "bar"},
+			isSubset:     false,
+			expectedDiff: nil,
+		},
+		{
+			sub:          []string{"foo", "foo", "foo", "bar", "bar"},
+			main:         []string{"foo", "foo", "bar"},
+			isSubset:     false,
+			expectedDiff: nil,
+		},
+	}
+	for _, tc := range testCases {
+		isSubset, diff := SliceSubsetOf(tc.sub, tc.main)
+		c.Assert(isSubset, Equals, tc.isSubset)
+		c.Assert(diff, checker.DeepEquals, tc.expectedDiff)
+	}
+}

--- a/plugins/cilium-cni/cni-uninstall.sh
+++ b/plugins/cilium-cni/cni-uninstall.sh
@@ -27,28 +27,14 @@ function get_list_of_veth_from_bridge() {
 }
 
 HOST_PREFIX=${HOST_PREFIX:-/host}
-if [[ -z "${CILIUM_FLANNEL_MASTER_DEVICE}" ]]; then
-    CNI_CONF_NAME=${CNI_CONF_NAME:-05-cilium.conf}
-else
-    CNI_CONF_NAME=${CNI_CONF_NAME:-04-flannel-cilium-cni.conflist}
-fi
-
 BIN_NAME=cilium-cni
 CNI_DIR=${CNI_DIR:-${HOST_PREFIX}/opt/cni}
-CILIUM_CNI_CONF=${CILIUM_CNI_CONF:-${HOST_PREFIX}/etc/cni/net.d/${CNI_CONF_NAME}}
 
 echo "Removing ${CNI_DIR}/bin/cilium-cni..."
 rm -f ${CNI_DIR}/bin/${BIN_NAME}
 rm -f ${CNI_DIR}/bin/${BIN_NAME}.old
 
-
-if [[ -z "${CILIUM_FLANNEL_MASTER_DEVICE}" ]]; then
-    echo "Removing ${CILIUM_CNI_CONF} ..."
-    rm -f ${CILIUM_CNI_CONF}
-elif [[ "${CILIUM_FLANNEL_UNINSTALL_ON_EXIT}" == "true" ]]; then
-    echo "Removing ${CILIUM_CNI_CONF} ..."
-    rm -f ${CILIUM_CNI_CONF}
-
+if [[ "${CILIUM_FLANNEL_UNINSTALL_ON_EXIT}" == "true" ]]; then
     echo "Removing BPF programs from all containers and from ${CILIUM_FLANNEL_MASTER_DEVICE}"
     echo "Uninstalling cilium from ${CILIUM_FLANNEL_MASTER_DEVICE}"
     uninstall_cilium_from_flannel_master "${CILIUM_FLANNEL_MASTER_DEVICE}"

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -377,7 +377,7 @@ func getK8sSupportedConstraints(ciliumVersion string) (go_version.Constraints, e
 	case CiliumV1_3.Check(cst):
 		return versioncheck.MustCompile(">= 1.8, <1.13"), nil
 	case CiliumV1_4.Check(cst):
-		return versioncheck.MustCompile(">= 1.8, <1.14"), nil
+		return versioncheck.MustCompile(">= 1.8, <1.15"), nil
 	case CiliumV1_5.Check(cst):
 		return versioncheck.MustCompile(">= 1.8, <1.15"), nil
 	default:

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -109,8 +109,6 @@ var _ = Describe("K8sDatapathConfig", func() {
 		}
 
 		It("Check connectivity with transparent encryption and VXLAN encapsulation", func() {
-			Skip("Encryption test is currently disabled")
-
 			switch helpers.GetCurrentIntegration() {
 			case helpers.CIIntegrationFlannel:
 				Skip(fmt.Sprintf(


### PR DESCRIPTION
v1.5 backports 2019-04-18

 * #7761 -- docs: Add containerd to self-managed installation section (@dbirks)
 * #7700 -- Add `dep check` to travis build (@nebril)
 * #7763 -- daemon: Panic if executable name does not match cilium{-agent,-node-monitor,} (@brb)
 * #7755 -- k8s: Disable k8s event handover to kvstore by default (@tgraf)
 * #7464 -- datapath/iptables: Check iptables kernel modules (@mrostecki)
 * #7724 -- cilium: enable encrypt + vxlan test again (@jrfastab)
 * #7772 -- cni: Stop removing CNI_CONF_NAME on preStop (@tgraf)
 * #7773 -- cilium, template: add cilium_encrypt_state to ignored prefixes (@borkmann)
 * #7779 -- test: Allow Cilium 1.4 to be run with K8s 1.14 (@brb)

Once this PR is merged, you can update the PR labels via:
```
$ for pr in 7761 7700 7763 7755 7464 7724 7772 7773 7779; do contrib/backporting/set-labels.py $pr done 1.5; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7783)
<!-- Reviewable:end -->
