### PR TITLE
Jenkinsfile: run K8s tests with seed=1555643481

### DIFF
--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -87,11 +87,11 @@ pipeline {
                         },
                         "K8s-1.10":{
                             sh 'cd ${TESTDIR}; K8S_VERSION=1.10 vagrant provision k8s1-1.10; K8S_VERSION=1.10 vagrant provision k8s2-1.10'
-                            sh 'cd ${TESTDIR}; K8S_VERSION=1.10 ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
+                            sh 'cd ${TESTDIR}; K8S_VERSION=1.10 ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} --seed=1555643481 -- -cilium.provision=false'
                         },
                         "K8s-1.14":{
                             sh 'cd ${TESTDIR}; K8S_VERSION=1.14 vagrant provision k8s1-1.14; K8S_VERSION=1.14 vagrant provision k8s2-1.14'
-                            sh 'cd ${TESTDIR}; K8S_VERSION=1.14 ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
+                            sh 'cd ${TESTDIR}; K8S_VERSION=1.14 ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} --seed=1555643481 -- -cilium.provision=false'
                         },
                         failFast: "${FAILFAST}".toBoolean()
                     )


### PR DESCRIPTION
See if the VXLAN + encryption test fails consistently when the
seed for the CI is set to a value from a build in which said
test has failed.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7793)
<!-- Reviewable:end -->
