### PR TITLE
examples: do not specify "type: Directory" for mounting `/lib/modules`

### DIFF
--- a/examples/kubernetes/1.10/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-containerd-ds.yaml
@@ -207,7 +207,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.10/cilium-containerd.yaml
+++ b/examples/kubernetes/1.10/cilium-containerd.yaml
@@ -364,7 +364,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.10/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-crio-ds.yaml
@@ -215,7 +215,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -372,7 +372,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.10/cilium-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-ds.yaml
@@ -220,7 +220,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.10/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.10/cilium-external-etcd.yaml
@@ -377,7 +377,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.10/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-minikube-ds.yaml
@@ -214,7 +214,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.10/cilium-minikube.yaml
+++ b/examples/kubernetes/1.10/cilium-minikube.yaml
@@ -371,7 +371,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.10/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.10/cilium-with-node-init.yaml
@@ -377,7 +377,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -377,7 +377,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.11/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-containerd-ds.yaml
@@ -208,7 +208,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.11/cilium-containerd.yaml
+++ b/examples/kubernetes/1.11/cilium-containerd.yaml
@@ -365,7 +365,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.11/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-crio-ds.yaml
@@ -207,7 +207,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -364,7 +364,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -221,7 +221,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.11/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.11/cilium-external-etcd.yaml
@@ -378,7 +378,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.11/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-minikube-ds.yaml
@@ -215,7 +215,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.11/cilium-minikube.yaml
+++ b/examples/kubernetes/1.11/cilium-minikube.yaml
@@ -372,7 +372,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.11/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.11/cilium-with-node-init.yaml
@@ -377,7 +377,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -378,7 +378,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.12/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-containerd-ds.yaml
@@ -208,7 +208,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.12/cilium-containerd.yaml
+++ b/examples/kubernetes/1.12/cilium-containerd.yaml
@@ -365,7 +365,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.12/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-crio-ds.yaml
@@ -207,7 +207,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -364,7 +364,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.12/cilium-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-ds.yaml
@@ -221,7 +221,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.12/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.12/cilium-external-etcd.yaml
@@ -378,7 +378,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.12/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-minikube-ds.yaml
@@ -215,7 +215,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.12/cilium-minikube.yaml
+++ b/examples/kubernetes/1.12/cilium-minikube.yaml
@@ -372,7 +372,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.12/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.12/cilium-with-node-init.yaml
@@ -377,7 +377,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -378,7 +378,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.13/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-containerd-ds.yaml
@@ -208,7 +208,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.13/cilium-containerd.yaml
+++ b/examples/kubernetes/1.13/cilium-containerd.yaml
@@ -365,7 +365,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.13/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-crio-ds.yaml
@@ -207,7 +207,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.13/cilium-crio.yaml
+++ b/examples/kubernetes/1.13/cilium-crio.yaml
@@ -364,7 +364,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.13/cilium-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-ds.yaml
@@ -221,7 +221,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.13/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.13/cilium-external-etcd.yaml
@@ -378,7 +378,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.13/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-minikube-ds.yaml
@@ -215,7 +215,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.13/cilium-minikube.yaml
+++ b/examples/kubernetes/1.13/cilium-minikube.yaml
@@ -372,7 +372,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.13/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.13/cilium-with-node-init.yaml
@@ -377,7 +377,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.13/cilium.yaml
+++ b/examples/kubernetes/1.13/cilium.yaml
@@ -378,7 +378,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.14/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.14/cilium-containerd-ds.yaml
@@ -208,7 +208,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.14/cilium-containerd.yaml
+++ b/examples/kubernetes/1.14/cilium-containerd.yaml
@@ -365,7 +365,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.14/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.14/cilium-crio-ds.yaml
@@ -207,7 +207,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.14/cilium-crio.yaml
+++ b/examples/kubernetes/1.14/cilium-crio.yaml
@@ -364,7 +364,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.14/cilium-ds.yaml
+++ b/examples/kubernetes/1.14/cilium-ds.yaml
@@ -221,7 +221,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.14/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.14/cilium-external-etcd.yaml
@@ -378,7 +378,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.14/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.14/cilium-minikube-ds.yaml
@@ -215,7 +215,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.14/cilium-minikube.yaml
+++ b/examples/kubernetes/1.14/cilium-minikube.yaml
@@ -372,7 +372,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.14/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.14/cilium-with-node-init.yaml
@@ -377,7 +377,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/1.14/cilium.yaml
+++ b/examples/kubernetes/1.14/cilium.yaml
@@ -378,7 +378,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/templates/v1/cilium-containerd-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-containerd-ds.yaml.sed
@@ -207,7 +207,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
@@ -215,7 +215,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
@@ -220,7 +220,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:

--- a/examples/kubernetes/templates/v1/cilium-minikube-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-minikube-ds.yaml.sed
@@ -214,7 +214,6 @@ spec:
         # To be able to load kernel modules
       - hostPath:
           path: /lib/modules
-          type: Directory
         name: lib-modules
         # To be able to load ip[6]tables kernel modules
       - hostPath:


### PR DESCRIPTION
On some distributions, the path to `/lib/modules` is a symlink, not a directory.
In such cases, deploying the Cilium DaemonSet with "type: Directory" for the
volumeMount for mounting `/lib/modules` will fail because a symlink is not a
directory. Such cases will result in the following errors when deploying the
Cilium DaemonSet:

```
Warning  FailedMount            1m (x9 over 3m)  kubelet,<IP redacted>  MountVolume.SetUp failed for volume "lib-modules" : hostPath type check failed: /lib/modules is not a directory
```

To resolve this issue, do not specify the type of the volumeMount. If
`/lib/modules` is a symlink, the actual path will be resolved and the volume
will be mounted correctly. This was tested manually.

Fixes: #7785

Signed-off by: Ian Vernon <ian@cilium.io>

I believe I have updated every template file that is required to be updated. I checked this by doing the following:

```
$ pwd
/Users/ianvernon/go/src/github.com/cilium/cilium/examples/kubernetes/templates/v1
$ grep -C3 "lib/modules" *.sed | grep "type: Directory"
$
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7794)
<!-- Reviewable:end -->
