### PR TITLE
test: only run VXLAN + Encryption test on net-next kernels

### DIFF
--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -117,6 +117,11 @@ var _ = Describe("K8sDatapathConfig", func() {
 				return
 			}
 
+			if !helpers.RunsOnNetNext() {
+				Skip("Skipping test because it is not running with the net-next kernel")
+				return
+			}
+
 			deployCilium("cilium-ds-patch-vxlan-ipsec.yaml")
 			validateBPFTunnelMap()
 			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test with IPsec between nodes failed")


### PR DESCRIPTION
This will disable the test in normal CI runs for now.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7798)
<!-- Reviewable:end -->
