### PR TITLE
docs: Update urllib3 dependency to address CVE-2019-11324

### DIFF
--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -20,7 +20,7 @@ sphinxcontrib-httpdomain==1.7.0
 sphinxcontrib-openapi==0.3.2
 sphinxcontrib-websupport==1.1.0
 typing==3.6.6
-urllib3==1.24
+urllib3==1.24.2
 sphinx-tabs==1.1.7
 recommonmark==0.4.0
 sphinxcontrib-spelling==4.2.0


### PR DESCRIPTION
Update urllib3 dependency to 1.24.2 to address CVE-2019-11324
(https://nvd.nist.gov/vuln/detail/CVE-2019-11324).

Note that this only affects the documentation build process, which
requires the manual steps for installing the required Python
dependencies as documented in Documentation/contributing.rst. We do
not depend on urllib3 otherwise.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7799)
<!-- Reviewable:end -->
