### PR TITLE
daemon: Log duration of service restoration and migration

### DIFF
--- a/daemon/loadbalancer.go
+++ b/daemon/loadbalancer.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+	"time"
 
 	. "github.com/cilium/cilium/api/v1/server/restapi/service"
 	"github.com/cilium/cilium/pkg/api"
@@ -840,6 +841,8 @@ func restoreBackendIDs() (map[lbmap.BackendAddrID]loadbalancer.BackendID, error)
 }
 
 func restoreServices() {
+	before := time.Now()
+
 	// Restore Backend IDs first, otherwise they can get taken by subsequent
 	// calls to UpdateService
 	restoredBackendIDs, err := restoreBackendIDs()
@@ -962,9 +965,10 @@ func restoreServices() {
 	}
 
 	log.WithFields(logrus.Fields{
-		"restored": restored,
-		"failed":   failed,
-		"skipped":  skipped,
-		"removed":  removed,
+		logfields.Duration: time.Now().Sub(before),
+		"restored":         restored,
+		"failed":           failed,
+		"skipped":          skipped,
+		"removed":          removed,
 	}).Info("Restore service IDs from BPF maps")
 }


### PR DESCRIPTION
This PR adds logging of time spent restoring and migrating services (from legacy to svc).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7806)
<!-- Reviewable:end -->
