### PR TITLE
contrib: Fix cherry-pick script

### DIFF
--- a/contrib/backporting/cherry-pick
+++ b/contrib/backporting/cherry-pick
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 source $(dirname $(readlink -ne $BASH_SOURCE))/common.sh


### PR DESCRIPTION
This script doesn't work currently because it invokes bash-only features
(BASH_SOURCE) when the top of the script states it's supposed to be a
generic 'sh' script. Fix it by relying on bash.

Fixes: 65b001f43779 ("contrib: Exit early if no git remote is found")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7808)
<!-- Reviewable:end -->
