### PR TITLE
v1.4 backports 2019-04-22

### DIFF
--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -20,7 +20,7 @@ sphinxcontrib-httpdomain==1.7.0
 sphinxcontrib-openapi==0.3.2
 sphinxcontrib-websupport==1.1.0
 typing==3.6.6
-urllib3==1.24
+urllib3==1.24.2
 sphinx-tabs==1.1.7
 recommonmark==0.4.0
 sphinxcontrib-spelling==4.2.0

--- a/contrib/backporting/cherry-pick
+++ b/contrib/backporting/cherry-pick
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 source $(dirname $(readlink -ne $BASH_SOURCE))/common.sh


### PR DESCRIPTION
* #7799 -- docs: Update urllib3 dependency to address CVE-2019-11324 (@jrajahalme)
 * #7808 -- contrib: Fix cherry-pick script (@joestringer)

Once this PR is merged, you can update the PR labels via:
```
$ for pr in 7799 7808; do contrib/backporting/set-labels.py $pr done 1.4; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7810)
<!-- Reviewable:end -->
