### PR TITLE
v1.5: backports 19-04-22

### DIFF
--- a/contrib/backporting/cherry-pick
+++ b/contrib/backporting/cherry-pick
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 source $(dirname $(readlink -ne $BASH_SOURCE))/common.sh

--- a/daemon/loadbalancer.go
+++ b/daemon/loadbalancer.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+	"time"
 
 	. "github.com/cilium/cilium/api/v1/server/restapi/service"
 	"github.com/cilium/cilium/pkg/api"
@@ -847,6 +848,8 @@ func restoreBackendIDs() (map[lbmap.BackendAddrID]loadbalancer.BackendID, error)
 }
 
 func restoreServices() {
+	before := time.Now()
+
 	// Restore Backend IDs first, otherwise they can get taken by subsequent
 	// calls to UpdateService
 	restoredBackendIDs, err := restoreBackendIDs()
@@ -969,9 +972,10 @@ func restoreServices() {
 	}
 
 	log.WithFields(logrus.Fields{
-		"restored": restored,
-		"failed":   failed,
-		"skipped":  skipped,
-		"removed":  removed,
+		logfields.Duration: time.Now().Sub(before),
+		"restored":         restored,
+		"failed":           failed,
+		"skipped":          skipped,
+		"removed":          removed,
 	}).Info("Restore service IDs from BPF maps")
 }

--- a/operator/main.go
+++ b/operator/main.go
@@ -103,6 +103,7 @@ func init() {
 	flags.BoolVar(&synchronizeServices, "synchronize-k8s-services", true, "Synchronize Kubernetes services to kvstore")
 	flags.BoolVar(&enableCepGC, "cilium-endpoint-gc", true, "Enable CiliumEndpoint garbage collector")
 	flags.DurationVar(&identityGCInterval, "identity-gc-interval", time.Minute*10, "GC interval for security identities")
+	flags.DurationVar(&kvNodeGCInterval, "nodes-gc-interval", time.Minute*2, "GC interval for nodes store in the kvstore")
 
 	flags.IntVar(&unmanagedKubeDnsWatcherInterval, "unmanaged-pod-watcher-interval", 15, "Interval to check for unmanaged kube-dns pods (0 to disable)")
 

--- a/pkg/clustermesh/clustermesh_test.go
+++ b/pkg/clustermesh/clustermesh_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -90,7 +90,7 @@ func (o *testObserver) OnUpdate(k store.Key) {
 	nodesMutex.Unlock()
 }
 
-func (o *testObserver) OnDelete(k store.Key) {
+func (o *testObserver) OnDelete(k store.NamedKey) {
 	n := k.(*testNode)
 	nodesMutex.Lock()
 	delete(nodes, n.GetKeyName())

--- a/pkg/clustermesh/services.go
+++ b/pkg/clustermesh/services.go
@@ -145,7 +145,7 @@ func (r *remoteServiceObserver) OnUpdate(key store.Key) {
 }
 
 // OnDelete is called when a service in a remote cluster is deleted
-func (r *remoteServiceObserver) OnDelete(key store.Key) {
+func (r *remoteServiceObserver) OnDelete(key store.NamedKey) {
 	if svc, ok := key.(*service.ClusterService); ok {
 		scopedLog := log.WithFields(logrus.Fields{logfields.ServiceName: svc.String()})
 		scopedLog.Debugf("Update event of remote service %#v", svc)

--- a/pkg/k8s/json_patch.go
+++ b/pkg/k8s/json_patch.go
@@ -14,6 +14,12 @@
 
 package k8s
 
+const(
+	// maximum number of operations a single json patch may contain.
+	// See https://github.com/kubernetes/kubernetes/pull/74000
+	MaxJSONPatchOperations = 10000
+)
+
 // JSONPatch structure based on the RFC 6902
 type JSONPatch struct {
 	OP    string      `json:"op,omitempty"`

--- a/pkg/kvstore/store/store.go
+++ b/pkg/kvstore/store/store.go
@@ -310,6 +310,20 @@ func (s *SharedStore) lookupLocalKey(name string) LocalKey {
 	return nil
 }
 
+// SharedKeysMap returns a copy of the SharedKeysMap, the returned map can
+// be safely modified but the values of the map represent the actual data
+// stored in the internal SharedStore SharedKeys map.
+func (s *SharedStore) SharedKeysMap() map[string]Key {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	sharedKeysCopy := make(map[string]Key, len(s.sharedKeys))
+
+	for k, v := range s.sharedKeys {
+		sharedKeysCopy[k] = v
+	}
+	return sharedKeysCopy
+}
+
 // UpdateLocalKey adds a key to be synchronized with the kvstore
 func (s *SharedStore) UpdateLocalKey(key LocalKey) {
 	s.mutex.Lock()

--- a/pkg/kvstore/store/store_test.go
+++ b/pkg/kvstore/store/store_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -121,7 +121,7 @@ func (o *observer) OnUpdate(k Key) {
 	}
 	counterLock.Unlock()
 }
-func (o *observer) OnDelete(k Key) {
+func (o *observer) OnDelete(k NamedKey) {
 	counterLock.Lock()
 	counter[k.(*TestType).Name].deleted++
 	counterLock.Unlock()

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -308,11 +308,16 @@ func (n *Node) PublicAttrEquals(o *Node) bool {
 	return false
 }
 
-// GetKeyName returns the kvstore key to be used for the node
-func (n *Node) GetKeyName() string {
+// GetKeyNodeName constructs the API name for the given cluster and node name.
+func GetKeyNodeName(cluster, node string) string {
 	// WARNING - STABLE API: Changing the structure of the key may break
 	// backwards compatibility
-	return path.Join(n.Cluster, n.Name)
+	return path.Join(cluster, node)
+}
+
+// GetKeyName returns the kvstore key to be used for the node
+func (n *Node) GetKeyName() string {
+	return GetKeyNodeName(n.Cluster, n.Name)
 }
 
 // DeepKeyCopy creates a deep copy of the LocalKey

--- a/pkg/node/store/store.go
+++ b/pkg/node/store/store.go
@@ -77,7 +77,7 @@ func (o *NodeObserver) OnUpdate(k store.Key) {
 	}
 }
 
-func (o *NodeObserver) OnDelete(k store.Key) {
+func (o *NodeObserver) OnDelete(k store.NamedKey) {
 	if n, ok := k.(*node.Node); ok {
 		nodeCopy := n.DeepCopy()
 		nodeCopy.Source = node.FromKVStore

--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -2,6 +2,7 @@ package k8sTest
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	. "github.com/cilium/cilium/test/ginkgo-ext"
@@ -14,11 +15,11 @@ var _ = Describe("K8sUpdates", func() {
 	// This test runs 8 steps as following:
 	// 1 - delete all pods. Clean cilium, this can be, and should be achieved by
 	// `clean-cilium-state: "true"` option that we have in configmap
-	// 2 - install cilium `cilium:v1.1.4`
+	// 2 - install cilium `cilium:v1.4`
 	// 3 - make endpoints talk with each other with policy
 	// 4 - upgrade cilium to `k8s1:5000/cilium/cilium-dev:latest`
 	// 5 - make endpoints talk with each other with policy
-	// 6 - downgrade cilium to `cilium:v1.1.4`
+	// 6 - downgrade cilium to `cilium:v1.4`
 	// 7 - make endpoints talk with each other with policy
 	// 8 - delete all pods. Clean cilium, this can be, and should be achieved by
 	// `clean-cilium-state: "true"` option that we have in configmap.
@@ -96,10 +97,14 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldVersion, newV
 
 	demoPath := helpers.ManifestGet("demo.yaml")
 	l7Policy := helpers.ManifestGet("l7-policy.yaml")
+	migrateSVCClient := helpers.ManifestGet("migrate-svc-client.yaml")
+	migrateSVCServer := helpers.ManifestGet("migrate-svc-server.yaml")
 	apps := []string{helpers.App1, helpers.App2, helpers.App3}
 	app1Service := "app1-service"
 
 	cleanupCallback := func() {
+		kubectl.Delete(migrateSVCClient)
+		kubectl.Delete(migrateSVCServer)
 		kubectl.Delete(l7Policy)
 		kubectl.Delete(demoPath)
 
@@ -212,7 +217,39 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldVersion, newV
 			ExpectWithOffset(1, res).ShouldNot(helpers.CMDSuccess(), "Expect a 403 from app1-service")
 		}
 
+		// checkNoInteruptsInMigratedSVCFlows checks whether there are no
+		// interrupts in established connections to the migrate-svc service
+		// after Cilium has been upgraded / downgraded. This is needed to check
+		// that migration legacy <-> v2 services does not cause any interruptions.
+		//
+		// The check is based on restart count of the Pods. We can do it so, because
+		// any interrupt in the flow makes a client to panic which makes the Pod
+		// to restart.
+		lastCount := -1
+		checkNoInteruptsInMigratedSVCFlows := func() {
+			By("No interrupts in migrated svc flows")
+
+			filter := `{.items[*].status.containerStatuses[0].restartCount}`
+			restartCount, err := kubectl.GetPods(helpers.DefaultNamespace,
+				"-l zgroup=migrate-svc").Filter(filter)
+			ExpectWithOffset(1, err).To(BeNil(), "Failed to query \"migrate-svc-server\" Pod")
+
+			currentCount := 0
+			for _, c := range strings.Split(restartCount.String(), " ") {
+				count, err := strconv.Atoi(c)
+				ExpectWithOffset(1, err).To(BeNil(), "Failed to convert count value")
+				currentCount += count
+			}
+			// The check is invoked for the first time
+			if lastCount == -1 {
+				lastCount = currentCount
+			}
+			Expect(lastCount).Should(BeIdenticalTo(currentCount),
+				"migrate-svc restart count values do not match")
+		}
+
 		By("Creating some endpoints and L7 policy")
+
 		res := kubectl.Apply(demoPath)
 		ExpectWithOffset(1, res).To(helpers.CMDSuccess(), "cannot apply dempo application")
 
@@ -225,9 +262,20 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldVersion, newV
 			helpers.KubeSystemNamespace, l7Policy, helpers.KubectlApply, timeout)
 		Expect(err).Should(BeNil(), "cannot import l7 policy: %v", l7Policy)
 
-		validateEndpointsConnection()
+		By("Creating service and clients for migration")
 
-		By("Updating cilium to master image")
+		res = kubectl.Apply(migrateSVCServer)
+		ExpectWithOffset(1, res).To(helpers.CMDSuccess(), "cannot apply migrate-svc-server")
+		err = kubectl.WaitforPods(helpers.DefaultNamespace, "-l app=migrate-svc-server", timeout)
+		Expect(err).Should(BeNil(), "migrate-svc-server pods are not ready after timeout")
+
+		res = kubectl.Apply(migrateSVCClient)
+		ExpectWithOffset(1, res).To(helpers.CMDSuccess(), "cannot apply migrate-svc-client")
+		err = kubectl.WaitforPods(helpers.DefaultNamespace, "-l app=migrate-svc-client", timeout)
+		Expect(err).Should(BeNil(), "migrate-svc-client pods are not ready after timeout")
+
+		validateEndpointsConnection()
+		checkNoInteruptsInMigratedSVCFlows()
 
 		waitForUpdateImage := func(image string) func() bool {
 			return func() bool {
@@ -284,6 +332,7 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldVersion, newV
 		ExpectCiliumOperatorReady(kubectl)
 
 		validateEndpointsConnection()
+		checkNoInteruptsInMigratedSVCFlows()
 
 		By("Downgrading cilium to %s image", oldVersion)
 
@@ -312,7 +361,7 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldVersion, newV
 		ExpectCiliumOperatorReady(kubectl)
 
 		validateEndpointsConnection()
-
+		checkNoInteruptsInMigratedSVCFlows()
 	}
 	return testfunc, cleanupCallback
 }

--- a/test/k8sT/manifests/cilium-cm-patch-clean-cilium-state.yaml
+++ b/test/k8sT/manifests/cilium-cm-patch-clean-cilium-state.yaml
@@ -23,3 +23,5 @@ data:
 
   enable-ipv4: "true"
   enable-ipv6: "true"
+
+  preallocate-bpf-maps: "true"

--- a/test/k8sT/manifests/cilium-cm-patch.yaml
+++ b/test/k8sT/manifests/cilium-cm-patch.yaml
@@ -24,3 +24,5 @@ data:
   enable-ipv4: "true"
   enable-ipv6: "true"
   preallocate-bpf-maps: "true"
+  enable-legacy-services: "true"
+  bpf-ct-global-tcp-max: "1000000"

--- a/test/k8sT/manifests/migrate-svc-client.yaml
+++ b/test/k8sT/manifests/migrate-svc-client.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: migrate-svc-client
+spec:
+  replicas: 5
+  selector:
+    matchLabels:
+      app: migrate-svc-client
+  template:
+    metadata:
+      labels:
+        app: migrate-svc-client
+        zgroup: migrate-svc
+    spec:
+      containers:
+      - name: server
+        image: docker.io/cilium/migrate-svc-test:v0.0.1
+        imagePullPolicy: IfNotPresent
+        command: [ "/client", "migrate-svc.default.svc.cluster.local.:8000" ]

--- a/test/k8sT/manifests/migrate-svc-server.yaml
+++ b/test/k8sT/manifests/migrate-svc-server.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: migrate-svc
+spec:
+  ports:
+  - port: 8000
+  selector:
+    app: migrate-svc-server
+---
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: migrate-svc-server
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: migrate-svc-server
+  template:
+    metadata:
+      labels:
+        app: migrate-svc-server
+        zgroup: migrate-svc
+    spec:
+      containers:
+      - name: server
+        image: docker.io/cilium/migrate-svc-test:v0.0.1
+        imagePullPolicy: IfNotPresent
+        command: [ "/server", "8000" ]

--- a/test/k8sT/manifests/v1.4/cilium-cm-patch-clean-cilium-state.yaml
+++ b/test/k8sT/manifests/v1.4/cilium-cm-patch-clean-cilium-state.yaml
@@ -23,3 +23,5 @@ data:
 
   enable-ipv4: "true"
   enable-ipv6: "true"
+
+  preallocate-bpf-maps: "true"

--- a/test/k8sT/manifests/v1.4/cilium-cm-patch.yaml
+++ b/test/k8sT/manifests/v1.4/cilium-cm-patch.yaml
@@ -24,3 +24,5 @@ data:
   enable-ipv4: "true"
   enable-ipv6: "true"
   preallocate-bpf-maps: "true"
+  enable-legacy-services: "true"
+  bpf-ct-global-tcp-max: "1000000"


### PR DESCRIPTION
* PR: 7778 -- Test service migrations of legacy -> v2 -> legacy (@brb) -- https://github.com/cilium/cilium/pull/7778
* PR: 7675 -- GC Nodes stored in the KVstore (@aanm) -- https://github.com/cilium/cilium/pull/7675
* PR: 7806 -- daemon: Log duration of service restoration and migration (@brb) -- https://github.com/cilium/cilium/pull/7806
* PR: 7808 -- contrib: Fix cherry-pick script (@joestringer) -- https://github.com/cilium/cilium/pull/7808
* PR: 7707 -- operator: GC nodes from existing CNPs (@aanm) -- https://github.com/cilium/cilium/pull/7707

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7813)
<!-- Reviewable:end -->
