### PR TITLE
Fix compile complaint in k8s package

### DIFF
--- a/pkg/k8s/json_patch.go
+++ b/pkg/k8s/json_patch.go
@@ -14,7 +14,7 @@
 
 package k8s
 
-const(
+const (
 	// maximum number of operations a single json patch may contain.
 	// See https://github.com/kubernetes/kubernetes/pull/74000
 	MaxJSONPatchOperations = 10000


### PR DESCRIPTION
We weren't previously running `make` at all in the CI, which leads to regressions like this:

```
$ make
...
Unformatted Go source code:
./pkg/k8s/json_patch.go
diff -u ./pkg/k8s/json_patch.go.orig ./pkg/k8s/json_patch.go
--- ./pkg/k8s/json_patch.go.orig        2019-04-22 16:48:14.987138041 -0700
+++ ./pkg/k8s/json_patch.go     2019-04-22 16:48:14.987138041 -0700
@@ -14,7 +14,7 @@

 package k8s

-const(
+const (
        // maximum number of operations a single json patch may contain.
        // See kubernetes/kubernetes#74000
        MaxJSONPatchOperations = 10000
```

Fix up the issue, and add a "make" to the CI in a way that will cause a failure in the PR before it gets committed to master.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7814)
<!-- Reviewable:end -->
