### PR TITLE
labels: Keep LabelArrays sorted

### DIFF
--- a/daemon/k8s_watcher_test.go
+++ b/daemon/k8s_watcher_test.go
@@ -109,7 +109,7 @@ func (ds *DaemonSuite) Test_addCiliumNetworkPolicyV2(c *C) {
 			setupArgs: func() args {
 				r := policy.NewPolicyRepository()
 				lbls := utils.GetPolicyLabels("production", "db", uuid, utils.ResourceTypeCiliumNetworkPolicy)
-				lbls = append(lbls, labels.ParseLabelArray("foo=bar")...)
+				lbls = append(lbls, labels.ParseLabelArray("foo=bar")...).Sort()
 				r.AddList(api.Rules{
 					{
 						EndpointSelector: api.EndpointSelector{
@@ -223,7 +223,7 @@ func (ds *DaemonSuite) Test_addCiliumNetworkPolicyV2(c *C) {
 			setupWanted: func() wanted {
 				r := policy.NewPolicyRepository()
 				lbls := utils.GetPolicyLabels("production", "db", uuid, utils.ResourceTypeCiliumNetworkPolicy)
-				lbls = append(lbls, labels.ParseLabelArray("foo=bar")...)
+				lbls = append(lbls, labels.ParseLabelArray("foo=bar")...).Sort()
 				r.AddList(api.Rules{
 					api.NewRule().
 						WithEndpointSelector(api.EndpointSelector{

--- a/pkg/identity/cache/cache.go
+++ b/pkg/identity/cache/cache.go
@@ -54,7 +54,7 @@ func GetIdentityCache() IdentityCache {
 		IdentityAllocator.ForeachCache(func(id idpool.ID, val allocator.AllocatorKey) {
 			if val != nil {
 				if gi, ok := val.(globalIdentity); ok {
-					cache[identity.NumericIdentity(id)] = gi.LabelArray()
+					cache[identity.NumericIdentity(id)] = gi.LabelArray
 				} else {
 					log.Warningf("Ignoring unknown identity type '%s': %+v",
 						reflect.TypeOf(val), val)
@@ -82,7 +82,7 @@ func GetIdentities() IdentitiesModel {
 
 	IdentityAllocator.ForeachCache(func(id idpool.ID, val allocator.AllocatorKey) {
 		if gi, ok := val.(globalIdentity); ok {
-			identity := identity.NewIdentity(identity.NumericIdentity(id), gi.Labels)
+			identity := identity.NewIdentityFromLabelArray(identity.NumericIdentity(id), gi.LabelArray)
 			identities = append(identities, identity.GetModel())
 		}
 
@@ -148,7 +148,8 @@ func LookupIdentity(lbls labels.Labels) *identity.Identity {
 		return nil
 	}
 
-	id, err := IdentityAllocator.Get(context.TODO(), globalIdentity{lbls})
+	lblArray := lbls.LabelArray()
+	id, err := IdentityAllocator.Get(context.TODO(), globalIdentity{lblArray})
 	if err != nil {
 		return nil
 	}
@@ -157,7 +158,7 @@ func LookupIdentity(lbls labels.Labels) *identity.Identity {
 		return nil
 	}
 
-	return identity.NewIdentity(identity.NumericIdentity(id), lbls)
+	return identity.NewIdentityFromLabelArray(identity.NumericIdentity(id), lblArray)
 }
 
 // LookupReservedIdentityByLabels looks up a reserved identity by its labels and
@@ -223,7 +224,7 @@ func LookupIdentityByID(id identity.NumericIdentity) *identity.Identity {
 	}
 
 	if gi, ok := allocatorKey.(globalIdentity); ok {
-		return identity.NewIdentity(id, gi.Labels)
+		return identity.NewIdentityFromLabelArray(id, gi.LabelArray)
 	}
 
 	return nil

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -145,6 +145,16 @@ func (id *Identity) IsWellKnown() bool {
 	return WellKnown.lookupByNumericIdentity(id.ID) != nil
 }
 
+// NewIdentityFromLabelArray creates a new identity
+func NewIdentityFromLabelArray(id NumericIdentity, lblArray labels.LabelArray) *Identity {
+	var lbls labels.Labels
+
+	if lblArray != nil {
+		lbls = lblArray.Labels()
+	}
+	return &Identity{ID: id, Labels: lbls, LabelArray: lblArray}
+}
+
 // NewIdentity creates a new identity
 func NewIdentity(id NumericIdentity, lbls labels.Labels) *Identity {
 	var lblArray labels.LabelArray

--- a/pkg/identity/identity_test.go
+++ b/pkg/identity/identity_test.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"testing"
 
+	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/labels/cidr"
 
@@ -86,4 +87,18 @@ func (s *IdentityTestSuite) TestRequiresGlobalIdentity(c *C) {
 	c.Assert(RequiresGlobalIdentity(cidr.GetCIDRLabels(ipnet)), Equals, false)
 
 	c.Assert(RequiresGlobalIdentity(labels.NewLabelsFromModel([]string{"k8s:foo=bar"})), Equals, true)
+}
+
+func (s *IdentityTestSuite) TestNewIdentityFromLabelArray(c *C) {
+	id := NewIdentityFromLabelArray(NumericIdentity(1001),
+		labels.NewLabelArrayFromSortedList("unspec:a=;unspec:b;unspec:c=d"))
+
+	lbls := labels.Labels{
+		"a": labels.ParseLabel("a"),
+		"c": labels.ParseLabel("c=d"),
+		"b": labels.ParseLabel("b"),
+	}
+	c.Assert(id.ID, Equals, NumericIdentity(1001))
+	c.Assert(id.Labels, checker.DeepEquals, lbls)
+	c.Assert(id.LabelArray, checker.DeepEquals, lbls.LabelArray())
 }

--- a/pkg/k8s/apis/cilium.io/utils/utils.go
+++ b/pkg/k8s/apis/cilium.io/utils/utils.go
@@ -53,11 +53,12 @@ var (
 
 // GetPolicyLabels returns a LabelArray for the given namespace and name.
 func GetPolicyLabels(ns, name string, uid types.UID, derivedFrom string) labels.LabelArray {
+	// Keep labels sorted by the key.
 	return labels.LabelArray{
-		labels.NewLabel(k8sConst.PolicyLabelName, name, labels.LabelSourceK8s),
-		labels.NewLabel(k8sConst.PolicyLabelUID, string(uid), labels.LabelSourceK8s),
-		labels.NewLabel(k8sConst.PolicyLabelNamespace, ns, labels.LabelSourceK8s),
 		labels.NewLabel(k8sConst.PolicyLabelDerivedFrom, derivedFrom, labels.LabelSourceK8s),
+		labels.NewLabel(k8sConst.PolicyLabelName, name, labels.LabelSourceK8s),
+		labels.NewLabel(k8sConst.PolicyLabelNamespace, ns, labels.LabelSourceK8s),
+		labels.NewLabel(k8sConst.PolicyLabelUID, string(uid), labels.LabelSourceK8s),
 	}
 }
 
@@ -241,5 +242,5 @@ func ParseToCiliumRule(namespace, name string, uid types.UID, r *api.Rule) *api.
 // these labels were derived from a CiliumNetworkPolicy.
 func ParseToCiliumLabels(namespace, name string, uid types.UID, ruleLbs labels.LabelArray) labels.LabelArray {
 	policyLbls := GetPolicyLabels(namespace, name, uid, ResourceTypeCiliumNetworkPolicy)
-	return append(policyLbls, ruleLbs...)
+	return append(policyLbls, ruleLbs...).Sort()
 }

--- a/pkg/k8s/apis/cilium.io/utils/utils_test.go
+++ b/pkg/k8s/apis/cilium.io/utils/utils_test.go
@@ -88,13 +88,13 @@ func Test_ParseToCiliumRule(t *testing.T) {
 			).WithLabels(
 				labels.LabelArray{
 					{
-						Key:    "io.cilium.k8s.policy.name",
-						Value:  "parse-in-namespace",
+						Key:    "io.cilium.k8s.policy.derived-from",
+						Value:  "CiliumNetworkPolicy",
 						Source: labels.LabelSourceK8s,
 					},
 					{
-						Key:    "io.cilium.k8s.policy.uid",
-						Value:  string(uuid),
+						Key:    "io.cilium.k8s.policy.name",
+						Value:  "parse-in-namespace",
 						Source: labels.LabelSourceK8s,
 					},
 					{
@@ -103,8 +103,8 @@ func Test_ParseToCiliumRule(t *testing.T) {
 						Source: labels.LabelSourceK8s,
 					},
 					{
-						Key:    "io.cilium.k8s.policy.derived-from",
-						Value:  "CiliumNetworkPolicy",
+						Key:    "io.cilium.k8s.policy.uid",
+						Value:  string(uuid),
 						Source: labels.LabelSourceK8s,
 					},
 				},
@@ -138,13 +138,13 @@ func Test_ParseToCiliumRule(t *testing.T) {
 			).WithLabels(
 				labels.LabelArray{
 					{
-						Key:    "io.cilium.k8s.policy.name",
-						Value:  "parse-in-namespace-with-ns-selector",
+						Key:    "io.cilium.k8s.policy.derived-from",
+						Value:  "CiliumNetworkPolicy",
 						Source: labels.LabelSourceK8s,
 					},
 					{
-						Key:    "io.cilium.k8s.policy.uid",
-						Value:  string(uuid),
+						Key:    "io.cilium.k8s.policy.name",
+						Value:  "parse-in-namespace-with-ns-selector",
 						Source: labels.LabelSourceK8s,
 					},
 					{
@@ -153,8 +153,8 @@ func Test_ParseToCiliumRule(t *testing.T) {
 						Source: labels.LabelSourceK8s,
 					},
 					{
-						Key:    "io.cilium.k8s.policy.derived-from",
-						Value:  "CiliumNetworkPolicy",
+						Key:    "io.cilium.k8s.policy.uid",
+						Value:  string(uuid),
 						Source: labels.LabelSourceK8s,
 					},
 				},
@@ -190,13 +190,13 @@ func Test_ParseToCiliumRule(t *testing.T) {
 			).WithLabels(
 				labels.LabelArray{
 					{
-						Key:    "io.cilium.k8s.policy.name",
-						Value:  "parse-init-policy",
+						Key:    "io.cilium.k8s.policy.derived-from",
+						Value:  "CiliumNetworkPolicy",
 						Source: labels.LabelSourceK8s,
 					},
 					{
-						Key:    "io.cilium.k8s.policy.uid",
-						Value:  string(uuid),
+						Key:    "io.cilium.k8s.policy.name",
+						Value:  "parse-init-policy",
 						Source: labels.LabelSourceK8s,
 					},
 					{
@@ -205,8 +205,8 @@ func Test_ParseToCiliumRule(t *testing.T) {
 						Source: labels.LabelSourceK8s,
 					},
 					{
-						Key:    "io.cilium.k8s.policy.derived-from",
-						Value:  "CiliumNetworkPolicy",
+						Key:    "io.cilium.k8s.policy.uid",
+						Value:  string(uuid),
 						Source: labels.LabelSourceK8s,
 					},
 				},
@@ -264,13 +264,13 @@ func Test_ParseToCiliumRule(t *testing.T) {
 			).WithLabels(
 				labels.LabelArray{
 					{
-						Key:    "io.cilium.k8s.policy.name",
-						Value:  "set-any-source-for-namespace",
+						Key:    "io.cilium.k8s.policy.derived-from",
+						Value:  "CiliumNetworkPolicy",
 						Source: labels.LabelSourceK8s,
 					},
 					{
-						Key:    "io.cilium.k8s.policy.uid",
-						Value:  string(uuid),
+						Key:    "io.cilium.k8s.policy.name",
+						Value:  "set-any-source-for-namespace",
 						Source: labels.LabelSourceK8s,
 					},
 					{
@@ -279,8 +279,8 @@ func Test_ParseToCiliumRule(t *testing.T) {
 						Source: labels.LabelSourceK8s,
 					},
 					{
-						Key:    "io.cilium.k8s.policy.derived-from",
-						Value:  "CiliumNetworkPolicy",
+						Key:    "io.cilium.k8s.policy.uid",
+						Value:  string(uuid),
 						Source: labels.LabelSourceK8s,
 					},
 				},
@@ -332,18 +332,8 @@ func (s *CiliumUtilsSuite) TestParseToCiliumLabels(c *C) {
 			},
 			want: labels.LabelArray{
 				{
-					Key:    "io.cilium.k8s.policy.name",
-					Value:  "foo",
-					Source: labels.LabelSourceK8s,
-				},
-				{
-					Key:    "io.cilium.k8s.policy.uid",
-					Value:  string(uuid),
-					Source: labels.LabelSourceK8s,
-				},
-				{
-					Key:    "io.cilium.k8s.policy.namespace",
-					Value:  "bar",
+					Key:    "hello",
+					Value:  "world",
 					Source: labels.LabelSourceK8s,
 				},
 				{
@@ -352,8 +342,18 @@ func (s *CiliumUtilsSuite) TestParseToCiliumLabels(c *C) {
 					Source: labels.LabelSourceK8s,
 				},
 				{
-					Key:    "hello",
-					Value:  "world",
+					Key:    "io.cilium.k8s.policy.name",
+					Value:  "foo",
+					Source: labels.LabelSourceK8s,
+				},
+				{
+					Key:    "io.cilium.k8s.policy.namespace",
+					Value:  "bar",
+					Source: labels.LabelSourceK8s,
+				},
+				{
+					Key:    "io.cilium.k8s.policy.uid",
+					Value:  string(uuid),
 					Source: labels.LabelSourceK8s,
 				},
 			},

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -1639,11 +1639,11 @@ func (s *K8sSuite) TestGetPolicyLabelsv1(c *C) {
 
 		c.Assert(lbls, NotNil)
 		c.Assert(len(lbls), Equals, 4, Commentf(
-			"Incorrect number of labels: Expected Name, UID, Namespace and DerivedFrom labels."))
-		assertLabel(lbls[0], k8sConst.PolicyLabelName, tt.name)
-		assertLabel(lbls[1], k8sConst.PolicyLabelUID, tt.uuid)
-		assertLabel(lbls[2], k8sConst.PolicyLabelNamespace, tt.namespace)
-		assertLabel(lbls[3], k8sConst.PolicyLabelDerivedFrom, tt.derivedFrom)
+			"Incorrect number of labels: Expected DerivedFrom, Name, Namespace and UID labels."))
+		assertLabel(lbls[0], "io.cilium.k8s.policy.derived-from", tt.derivedFrom)
+		assertLabel(lbls[1], "io.cilium.k8s.policy.name", tt.name)
+		assertLabel(lbls[2], "io.cilium.k8s.policy.namespace", tt.namespace)
+		assertLabel(lbls[3], "io.cilium.k8s.policy.uid", tt.uuid)
 	}
 }
 

--- a/pkg/labels/array.go
+++ b/pkg/labels/array.go
@@ -16,6 +16,7 @@ package labels
 
 import (
 	"sort"
+	"strings"
 )
 
 // LabelArray is an array of labels forming a set
@@ -58,6 +59,19 @@ func ParseLabelArrayFromArray(base []string) LabelArray {
 	return array.Sort()
 }
 
+// NewLabelArrayFromSortedList returns labels based on the output of SortedList()
+// Trailing ';' will result in an empty key that must be filtered out.
+func NewLabelArrayFromSortedList(list string) LabelArray {
+	base := strings.Split(list, ";")
+	array := make(LabelArray, 0, len(base))
+	for _, v := range base {
+		if lbl := ParseLabel(v); lbl.Key != "" {
+			array = append(array, lbl)
+		}
+	}
+	return array
+}
+
 // ParseSelectLabelArrayFromArray converts an array of strings as select labels and returns a LabelArray
 func ParseSelectLabelArrayFromArray(base []string) LabelArray {
 	array := make(LabelArray, len(base))
@@ -65,6 +79,15 @@ func ParseSelectLabelArrayFromArray(base []string) LabelArray {
 		array[i] = ParseSelectLabel(base[i])
 	}
 	return array.Sort()
+}
+
+// Labels returns the LabelArray as Labels
+func (ls LabelArray) Labels() Labels {
+	lbls := Labels{}
+	for _, l := range ls {
+		lbls[l.Key] = l
+	}
+	return lbls
 }
 
 // Contains returns true if all ls contains all the labels in needed. If

--- a/pkg/labels/array.go
+++ b/pkg/labels/array.go
@@ -14,43 +14,57 @@
 
 package labels
 
+import (
+	"sort"
+)
+
 // LabelArray is an array of labels forming a set
 type LabelArray []Label
 
+// Sort is an internal utility to return all LabelArrays in sorted
+// order, when the source material may be unsorted.  'ls' is sorted
+// in-place, but also returns the sorted array for convenience.
+func (ls LabelArray) Sort() LabelArray {
+	sort.Slice(ls, func(i, j int) bool {
+		return ls[i].Key < ls[j].Key
+	})
+	return ls
+}
+
 // ParseLabelArray parses a list of labels and returns a LabelArray
 func ParseLabelArray(labels ...string) LabelArray {
-	array := make([]Label, len(labels))
+	array := make(LabelArray, len(labels))
 	for i := range labels {
 		array[i] = ParseLabel(labels[i])
 	}
-	return array
+	return array.Sort()
 }
 
 // ParseSelectLabelArray parses a list of select labels and returns a LabelArray
 func ParseSelectLabelArray(labels ...string) LabelArray {
-	array := make([]Label, len(labels))
+	array := make(LabelArray, len(labels))
 	for i := range labels {
 		array[i] = ParseSelectLabel(labels[i])
 	}
-	return array
+	return array.Sort()
 }
 
 // ParseLabelArrayFromArray converts an array of strings as labels and returns a LabelArray
 func ParseLabelArrayFromArray(base []string) LabelArray {
-	array := make([]Label, len(base))
+	array := make(LabelArray, len(base))
 	for i := range base {
 		array[i] = ParseLabel(base[i])
 	}
-	return array
+	return array.Sort()
 }
 
 // ParseSelectLabelArrayFromArray converts an array of strings as select labels and returns a LabelArray
 func ParseSelectLabelArrayFromArray(base []string) LabelArray {
-	array := make([]Label, len(base))
+	array := make(LabelArray, len(base))
 	for i := range base {
 		array[i] = ParseSelectLabel(base[i])
 	}
-	return array
+	return array.Sort()
 }
 
 // Contains returns true if all ls contains all the labels in needed. If

--- a/pkg/labels/array_test.go
+++ b/pkg/labels/array_test.go
@@ -46,8 +46,12 @@ func (s *LabelsSuite) TestMatches(c *C) {
 func (s *LabelsSuite) TestParse(c *C) {
 	c.Assert(ParseLabelArray(), checker.DeepEquals, LabelArray{})
 	c.Assert(ParseLabelArray("magic"), checker.DeepEquals, LabelArray{ParseLabel("magic")})
-	c.Assert(ParseLabelArray("a", "b", "c"), checker.DeepEquals,
+	// LabelArray is sorted
+	c.Assert(ParseLabelArray("a", "c", "b"), checker.DeepEquals,
 		LabelArray{ParseLabel("a"), ParseLabel("b"), ParseLabel("c")})
+	// NewLabelArrayFromSortedList
+	c.Assert(NewLabelArrayFromSortedList("unspec:a=;unspec:b;unspec:c=d"), checker.DeepEquals,
+		LabelArray{ParseLabel("a"), ParseLabel("b"), ParseLabel("c=d")})
 }
 
 func (s *LabelsSuite) TestHas(c *C) {

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -385,14 +385,14 @@ func NewLabelsFromSortedList(list string) Labels {
 }
 
 // NewSelectLabelArrayFromModel parses a slice of strings and converts them
-// into an array of selecting labels.
+// into an array of selecting labels, sorted by the key.
 func NewSelectLabelArrayFromModel(base []string) LabelArray {
 	lbls := make(LabelArray, 0, len(base))
 	for i := range base {
 		lbls = append(lbls, ParseSelectLabel(base[i]))
 	}
 
-	return lbls
+	return lbls.Sort()
 }
 
 // GetModel returns model with all the values of the labels.
@@ -449,22 +449,19 @@ func (l Labels) SortedList() []byte {
 	return []byte(result)
 }
 
-// ToSlice returns a slice of label with the values of the given Labels' map.
+// ToSlice returns a slice of label with the values of the given
+// Labels' map, sorted by the key.
 func (l Labels) ToSlice() []Label {
-	labels := []Label{}
-	for _, v := range l {
-		labels = append(labels, v)
-	}
-	return labels
+	return l.LabelArray()
 }
 
-// LabelArray returns the labels as label array
+// LabelArray returns the labels as label array, sorted by the key.
 func (l Labels) LabelArray() LabelArray {
-	labels := []Label{}
+	labels := make(LabelArray, 0, len(l))
 	for _, v := range l {
 		labels = append(labels, v)
 	}
-	return labels
+	return labels.Sort()
 }
 
 // FindReserved locates all labels with reserved source in the labels and

--- a/pkg/labels/labels_test.go
+++ b/pkg/labels/labels_test.go
@@ -18,6 +18,7 @@ package labels
 
 import (
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -36,6 +37,7 @@ type LabelsSuite struct{}
 var _ = Suite(&LabelsSuite{})
 
 var (
+	// Elements are sorted by the key
 	lblsArray = []string{`unspec:%=%ed`, `unspec://=/=`, `unspec:foo=bar`, `unspec:foo2==bar2`, `unspec:foo=====`, `unspec:foo\\==\=`, `unspec:key=`}
 	lbls      = Labels{
 		"foo":    NewLabel("foo", "bar", LabelSourceUnspec),
@@ -60,6 +62,16 @@ func (s *LabelsSuite) TestSortMap(c *C) {
 	lblsString += ";"
 	sortedMap := lbls.SortedList()
 	c.Assert(sortedMap, checker.DeepEquals, []byte(lblsString))
+}
+
+func (s *LabelsSuite) TestLabelArraySorted(c *C) {
+	lblsString := strings.Join(lblsArray, ";")
+	lblsString += ";"
+	str := ""
+	for _, l := range lbls.LabelArray() {
+		str += fmt.Sprintf(`%s:%s=%s;`, l.Source, l.Key, l.Value)
+	}
+	c.Assert(str, checker.DeepEquals, lblsString)
 }
 
 type lblTest struct {


### PR DESCRIPTION
Create `labels.LabelArray` in sorted order which allows interacting with KV-store without worrying about label order. To be safe, all other uses of LabelArrays are also changed to sorted order, which affects e.g., rule labels. Arguably this is better than the somewhat arbitrary order they were in before.

This PR makes the follow-up work on `policy.SelectorCache` (#7539) easier. This also allows use of faster matching algorithms on LabelArrays in future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7815)
<!-- Reviewable:end -->
