### PR TITLE
test: Set CT map sizes

### DIFF
--- a/test/k8sT/manifests/cilium-cm-patch.yaml
+++ b/test/k8sT/manifests/cilium-cm-patch.yaml
@@ -25,4 +25,3 @@ data:
   enable-ipv6: "true"
   preallocate-bpf-maps: "true"
   enable-legacy-services: "true"
-  bpf-ct-global-tcp-max: "1000000"

--- a/test/k8sT/manifests/v1.3/cilium-cm-patch-clean-cilium-state.yaml
+++ b/test/k8sT/manifests/v1.3/cilium-cm-patch-clean-cilium-state.yaml
@@ -20,3 +20,6 @@ data:
 
   debug: "true"
   clean-cilium-state: "true"
+
+  bpf-ct-global-tcp-max: "524288"
+  bpf-ct-global-any-max: "262144"

--- a/test/k8sT/manifests/v1.3/cilium-cm-patch-clean-cilium-state.yaml
+++ b/test/k8sT/manifests/v1.3/cilium-cm-patch-clean-cilium-state.yaml
@@ -22,4 +22,3 @@ data:
   clean-cilium-state: "true"
 
   bpf-ct-global-tcp-max: "524288"
-  bpf-ct-global-any-max: "262144"

--- a/test/k8sT/manifests/v1.3/cilium-cm-patch.yaml
+++ b/test/k8sT/manifests/v1.3/cilium-cm-patch.yaml
@@ -20,3 +20,6 @@ data:
 
   # If you want to run cilium in debug mode change this value to true
   debug: "true"
+
+  bpf-ct-global-tcp-max: "524288"
+  bpf-ct-global-any-max: "262144"

--- a/test/k8sT/manifests/v1.3/cilium-cm-patch.yaml
+++ b/test/k8sT/manifests/v1.3/cilium-cm-patch.yaml
@@ -22,4 +22,3 @@ data:
   debug: "true"
 
   bpf-ct-global-tcp-max: "524288"
-  bpf-ct-global-any-max: "262144"

--- a/test/k8sT/manifests/v1.4/cilium-cm-patch-clean-cilium-state.yaml
+++ b/test/k8sT/manifests/v1.4/cilium-cm-patch-clean-cilium-state.yaml
@@ -26,4 +26,3 @@ data:
 
   preallocate-bpf-maps: "true"
   bpf-ct-global-tcp-max: "524288"
-  bpf-ct-global-any-max: "262144"

--- a/test/k8sT/manifests/v1.4/cilium-cm-patch-clean-cilium-state.yaml
+++ b/test/k8sT/manifests/v1.4/cilium-cm-patch-clean-cilium-state.yaml
@@ -25,3 +25,5 @@ data:
   enable-ipv6: "true"
 
   preallocate-bpf-maps: "true"
+  bpf-ct-global-tcp-max: "524288"
+  bpf-ct-global-any-max: "262144"

--- a/test/k8sT/manifests/v1.4/cilium-cm-patch.yaml
+++ b/test/k8sT/manifests/v1.4/cilium-cm-patch.yaml
@@ -24,5 +24,5 @@ data:
   enable-ipv4: "true"
   enable-ipv6: "true"
   preallocate-bpf-maps: "true"
-  enable-legacy-services: "true"
-  bpf-ct-global-tcp-max: "1000000"
+  bpf-ct-global-tcp-max: "524288"
+  bpf-ct-global-any-max: "262144"

--- a/test/k8sT/manifests/v1.4/cilium-cm-patch.yaml
+++ b/test/k8sT/manifests/v1.4/cilium-cm-patch.yaml
@@ -25,4 +25,3 @@ data:
   enable-ipv6: "true"
   preallocate-bpf-maps: "true"
   bpf-ct-global-tcp-max: "524288"
-  bpf-ct-global-any-max: "262144"


### PR DESCRIPTION
Previously, some ConfigMaps used by Cilium in testing didn't have the CT map sizes specified which defaulted to `1000000`, or they were explicitly set to `1000000`. At the same time, ConfigMaps from `examples/`, which were used by tests as well, have the CT map sizes set to `< 1000000`.

This made the CT maps being recreated due to the property change which lead to existing connections to be broken during Cilium upgrades, thus the SVC migration tests were failing. As an example, `Nightly` tests were failing due to this.

This PR sets the CT map sizes to the ones from `examples/`. Also, it removes `--enable-legacy-services` from the `v1.4` yamls, as the v1.4 does not support the param.

Fix #7641 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7817)
<!-- Reviewable:end -->
