### PR TITLE
k8s: fix panic of closed channel

### DIFF
--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -947,7 +947,6 @@ func (d *Daemon) EnableK8sWatcher(queueSize uint) error {
 			// Create a new node controller when we are disconnected with the
 			// kvstore
 			<-kvstore.Client().Disconnected()
-			close(isConnected)
 
 			log.Info("Disconnected from KVStore, restarting k8s node watcher")
 		}


### PR DESCRIPTION
The channel was previously closed and it does not need to be re-closed
again.

Fixes: a63342e75944 ("k8s: Fix leak of k8s controller on kvstore connect & disconnect")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7818)
<!-- Reviewable:end -->
