### PR TITLE
pkg/k8s: fix golang formatting

### DIFF
--- a/pkg/k8s/json_patch.go
+++ b/pkg/k8s/json_patch.go
@@ -14,7 +14,7 @@
 
 package k8s
 
-const(
+const (
 	// maximum number of operations a single json patch may contain.
 	// See https://github.com/kubernetes/kubernetes/pull/74000
 	MaxJSONPatchOperations = 10000


### PR DESCRIPTION
Fixes: 0cd1be0e64dc ("operator: GC nodes from existing CNPs")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7819)
<!-- Reviewable:end -->
