### PR TITLE
v1.5 backports 2019-04-23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN make LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 V=$V LIBNETWORK_PLUGIN=$LIBNETWORK_PLU
 # built while allowing the new versions to make changes that are not
 # backwards compatible.
 #
-FROM quay.io/cilium/cilium-runtime:2019-03-26
+FROM quay.io/cilium/cilium-runtime:2019-04-23
 LABEL maintainer="maintainer@cilium.io"
 COPY --from=builder /tmp/install /
 COPY --from=cilium-envoy / /

--- a/contrib/packaging/docker/Dockerfile.runtime
+++ b/contrib/packaging/docker/Dockerfile.runtime
@@ -9,7 +9,7 @@ apt-get upgrade -y && \
 #
 apt-get install -y --no-install-recommends \
     gpg gpg-agent libelf-dev libmnl-dev libc6-dev-i386 iptables libgcc-5-dev \
-    bash-completion binutils binutils-dev ca-certificates clang-7 llvm-7 && \
+    bash-completion binutils binutils-dev ca-certificates clang-7 llvm-7 kmod && \
 apt-get purge --auto-remove && \
 apt-get clean && \
 #

--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -947,7 +947,6 @@ func (d *Daemon) EnableK8sWatcher(queueSize uint) error {
 			// Create a new node controller when we are disconnected with the
 			// kvstore
 			<-kvstore.Client().Disconnected()
-			close(isConnected)
 
 			log.Info("Disconnected from KVStore, restarting k8s node watcher")
 		}

--- a/examples/kubernetes/1.10/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-containerd-ds.yaml
@@ -136,10 +136,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -208,11 +204,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.10/cilium-containerd.yaml
+++ b/examples/kubernetes/1.10/cilium-containerd.yaml
@@ -293,10 +293,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -365,11 +361,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.10/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-crio-ds.yaml
@@ -144,10 +144,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -216,11 +212,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -301,10 +301,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -373,11 +369,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.10/cilium-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-ds.yaml
@@ -143,10 +143,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -221,11 +217,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.10/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.10/cilium-external-etcd.yaml
@@ -300,10 +300,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -378,11 +374,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.10/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-minikube-ds.yaml
@@ -143,10 +143,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -215,11 +211,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.10/cilium-minikube.yaml
+++ b/examples/kubernetes/1.10/cilium-minikube.yaml
@@ -300,10 +300,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -372,11 +368,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.10/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.10/cilium-with-node-init.yaml
@@ -300,10 +300,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -378,11 +374,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -300,10 +300,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -378,11 +374,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.11/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-containerd-ds.yaml
@@ -136,10 +136,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -209,11 +205,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.11/cilium-containerd.yaml
+++ b/examples/kubernetes/1.11/cilium-containerd.yaml
@@ -293,10 +293,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -366,11 +362,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.11/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-crio-ds.yaml
@@ -142,10 +142,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -208,11 +204,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -299,10 +299,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -365,11 +361,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -143,10 +143,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -222,11 +218,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.11/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.11/cilium-external-etcd.yaml
@@ -300,10 +300,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -379,11 +375,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.11/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-minikube-ds.yaml
@@ -143,10 +143,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -216,11 +212,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.11/cilium-minikube.yaml
+++ b/examples/kubernetes/1.11/cilium-minikube.yaml
@@ -300,10 +300,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -373,11 +369,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.11/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.11/cilium-with-node-init.yaml
@@ -300,10 +300,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -378,11 +374,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -300,10 +300,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -379,11 +375,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.12/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-containerd-ds.yaml
@@ -136,10 +136,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -209,11 +205,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.12/cilium-containerd.yaml
+++ b/examples/kubernetes/1.12/cilium-containerd.yaml
@@ -293,10 +293,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -366,11 +362,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.12/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-crio-ds.yaml
@@ -142,10 +142,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -208,11 +204,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -299,10 +299,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -365,11 +361,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.12/cilium-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-ds.yaml
@@ -143,10 +143,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -222,11 +218,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.12/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.12/cilium-external-etcd.yaml
@@ -300,10 +300,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -379,11 +375,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.12/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-minikube-ds.yaml
@@ -143,10 +143,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -216,11 +212,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.12/cilium-minikube.yaml
+++ b/examples/kubernetes/1.12/cilium-minikube.yaml
@@ -300,10 +300,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -373,11 +369,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.12/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.12/cilium-with-node-init.yaml
@@ -300,10 +300,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -378,11 +374,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -300,10 +300,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -379,11 +375,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.13/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-containerd-ds.yaml
@@ -136,10 +136,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -209,11 +205,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.13/cilium-containerd.yaml
+++ b/examples/kubernetes/1.13/cilium-containerd.yaml
@@ -293,10 +293,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -366,11 +362,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.13/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-crio-ds.yaml
@@ -142,10 +142,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -208,11 +204,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.13/cilium-crio.yaml
+++ b/examples/kubernetes/1.13/cilium-crio.yaml
@@ -299,10 +299,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -365,11 +361,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.13/cilium-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-ds.yaml
@@ -143,10 +143,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -222,11 +218,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.13/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.13/cilium-external-etcd.yaml
@@ -300,10 +300,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -379,11 +375,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.13/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-minikube-ds.yaml
@@ -143,10 +143,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -216,11 +212,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.13/cilium-minikube.yaml
+++ b/examples/kubernetes/1.13/cilium-minikube.yaml
@@ -300,10 +300,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -373,11 +369,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.13/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.13/cilium-with-node-init.yaml
@@ -300,10 +300,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -378,11 +374,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.13/cilium.yaml
+++ b/examples/kubernetes/1.13/cilium.yaml
@@ -300,10 +300,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -379,11 +375,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.14/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.14/cilium-containerd-ds.yaml
@@ -136,10 +136,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -209,11 +205,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.14/cilium-containerd.yaml
+++ b/examples/kubernetes/1.14/cilium-containerd.yaml
@@ -293,10 +293,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -366,11 +362,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.14/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.14/cilium-crio-ds.yaml
@@ -142,10 +142,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -208,11 +204,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.14/cilium-crio.yaml
+++ b/examples/kubernetes/1.14/cilium-crio.yaml
@@ -299,10 +299,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -365,11 +361,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.14/cilium-ds.yaml
+++ b/examples/kubernetes/1.14/cilium-ds.yaml
@@ -143,10 +143,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -222,11 +218,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.14/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.14/cilium-external-etcd.yaml
@@ -300,10 +300,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -379,11 +375,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.14/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.14/cilium-minikube-ds.yaml
@@ -143,10 +143,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -216,11 +212,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.14/cilium-minikube.yaml
+++ b/examples/kubernetes/1.14/cilium-minikube.yaml
@@ -300,10 +300,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -373,11 +369,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.14/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.14/cilium-with-node-init.yaml
@@ -300,10 +300,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -378,11 +374,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/1.14/cilium.yaml
+++ b/examples/kubernetes/1.14/cilium.yaml
@@ -300,10 +300,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -379,11 +375,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/templates/v1/cilium-containerd-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-containerd-ds.yaml.sed
@@ -136,10 +136,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -208,11 +204,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
@@ -144,10 +144,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -216,11 +212,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
@@ -143,10 +143,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -221,11 +217,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/examples/kubernetes/templates/v1/cilium-minikube-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-minikube-ds.yaml.sed
@@ -143,10 +143,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-          # Needed by ip[6]tables when loading kernel modules
-        - mountPath: /sbin/modprobe
-          name: sbin-modprobe
-          readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: false
@@ -215,11 +211,6 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
-        # To be able to load ip[6]tables kernel modules
-      - hostPath:
-          path: /sbin/modprobe
-          type: File
-        name: sbin-modprobe
         # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -261,10 +261,10 @@ func (m *IptablesManager) RemoveRules() {
 		for _, t := range tables6 {
 			removeCiliumRules(t, "ip6tables")
 		}
+	}
 
-		for _, c := range ciliumChains {
-			c.remove()
-		}
+	for _, c := range ciliumChains {
+		c.remove()
 	}
 }
 

--- a/pkg/k8s/json_patch.go
+++ b/pkg/k8s/json_patch.go
@@ -14,7 +14,7 @@
 
 package k8s
 
-const(
+const (
 	// maximum number of operations a single json patch may contain.
 	// See https://github.com/kubernetes/kubernetes/pull/74000
 	MaxJSONPatchOperations = 10000


### PR DESCRIPTION
* #7818 -- k8s: fix panic of closed channel (@aanm)
* #7820 -- contrib: Install modprobe to cilium-runtime image (@brb)
* #7814 -- Fix compile complaint in k8s package (@joestringer)
* #7828 -- iptables: Correctly remove Cilium chains when IPv6 is disabled (@tgraf)

Once this PR is merged, you can update the PR labels via:
```
$ for pr in 7818 7820 7814 7828; do contrib/backporting/set-labels.py $pr done 1.5; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7827)
<!-- Reviewable:end -->
