### PR TITLE
iptables: Correctly remove Cilium chains when IPv6 is disabled

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -278,10 +278,10 @@ func (m *IptablesManager) RemoveRules() {
 		for _, t := range tables6 {
 			removeCiliumRules(t, "ip6tables")
 		}
+	}
 
-		for _, c := range ciliumChains {
-			c.remove()
-		}
+	for _, c := range ciliumChains {
+		c.remove()
 	}
 }
 


### PR DESCRIPTION
The Cilium chain removal in RemoveRules() was made dependent on IPv6 being
enabled, this is incorrect and leads to the following error when Ipv6 is
disabled:

```
level=warning msg="iptables: Chain already exists." subsys=iptables
level=error msg="Error while initializing daemon" error="cannot add custom chain CILIUM_OUTPUT: exit status 1" subsys=daemon
```

Fixes: 5b17c993e57 ("datapath/iptables: Check iptables kernel modules")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7828)
<!-- Reviewable:end -->
