### PR TITLE
contrib: ensure check-fmt.sh runs correctly, and fails if it does not

### DIFF
--- a/contrib/scripts/check-fmt.sh
+++ b/contrib/scripts/check-fmt.sh
@@ -1,13 +1,14 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 set -e
+set -o pipefail
+
 diff="$(find . ! \( -path './contrib' -prune \) \
         ! \( -path './vendor' -prune \) \
         ! \( -path './.git' -prune \) \
         ! \( -path '*.validate.go' -prune \) \
-        ! -samefile ./daemon/bindata.go \
-        -type f -name '*.go' -print0 \
-                | xargs -0 gofmt -d -l -s )"
+        -type f -name '*.go' | grep -v "daemon/bindata.go" | \
+        xargs gofmt -d -l -s )"
 
 if [ -n "$diff" ]; then
 	echo "Unformatted Go source code:"


### PR DESCRIPTION
* Set the pipefail option so that the script fails when a piped command fails.
This fixes the issue where `gofmt` was not actually run in the
`make jenkins-precheck` target, as the commad to get all files to run `gofmt`
failed when `./daemon/bindata.go` was not found, but the script itself did not
exit with a non-zero return code. Said file was not able to be found in said
target because `make` had not been ran yet. As a result, the `find` command
silently failed, which resulted in the contents of the `diff` variable being
empty, which the script assumed meant that there were no violations of `gofmt`.
* Use bash as the shell for the script to be able to use the pipefail option.

With these changes, the `jenkins-precheck` target should correctly catch `gofmt`
violations on Jenkins.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7829)
<!-- Reviewable:end -->
