### PR TITLE
policy: Use NumericIdentity for rule selector cache

### DIFF
--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -1991,18 +1991,18 @@ func (ds *PolicyTestSuite) TestremoveIdentityFromRuleCaches(c *C) {
 	// selectedEndpoint is selected by rule, so we it should be added to
 	// EndpointsSelected.
 	c.Assert(addedRule.matches(selectedIdentity), Equals, true)
-	c.Assert(addedRule.metadata.IdentitySelected, checker.DeepEquals, map[*identity.Identity]bool{selectedIdentity: true})
+	c.Assert(addedRule.metadata.IdentitySelected, checker.DeepEquals, map[identity.NumericIdentity]bool{selectedIdentity.ID: true})
 
 	wg := testRepo.removeIdentityFromRuleCaches(selectedIdentity)
 	wg.Wait()
 
-	c.Assert(addedRule.metadata.IdentitySelected, checker.DeepEquals, map[*identity.Identity]bool{})
+	c.Assert(addedRule.metadata.IdentitySelected, checker.DeepEquals, map[identity.NumericIdentity]bool{})
 
 	c.Assert(addedRule.matches(notSelectedIdentity), Equals, false)
-	c.Assert(addedRule.metadata.IdentitySelected, checker.DeepEquals, map[*identity.Identity]bool{notSelectedIdentity: false})
+	c.Assert(addedRule.metadata.IdentitySelected, checker.DeepEquals, map[identity.NumericIdentity]bool{notSelectedIdentity.ID: false})
 
 	wg = testRepo.removeIdentityFromRuleCaches(notSelectedIdentity)
 	wg.Wait()
 
-	c.Assert(addedRule.metadata.IdentitySelected, checker.DeepEquals, map[*identity.Identity]bool{})
+	c.Assert(addedRule.metadata.IdentitySelected, checker.DeepEquals, map[identity.NumericIdentity]bool{})
 }

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -39,19 +39,19 @@ type ruleMetadata struct {
 
 	// IdentitySelected is a cache that maps from an identity to whether
 	// this rule selects that identity.
-	IdentitySelected map[*identity.Identity]bool
+	IdentitySelected map[identity.NumericIdentity]bool
 }
 
 func newRuleMetadata() *ruleMetadata {
 	return &ruleMetadata{
-		IdentitySelected: make(map[*identity.Identity]bool),
+		IdentitySelected: make(map[identity.NumericIdentity]bool),
 	}
 }
 
 func (m *ruleMetadata) delete(identity *identity.Identity) {
 	m.Mutex.Lock()
 	defer m.Mutex.Unlock()
-	delete(m.IdentitySelected, identity)
+	delete(m.IdentitySelected, identity.ID)
 }
 
 func (r *rule) String() string {
@@ -496,15 +496,15 @@ func (r *rule) matches(securityIdentity *identity.Identity) bool {
 	defer r.metadata.Mutex.Unlock()
 	var ruleMatches bool
 
-	if ruleMatches, cached := r.metadata.IdentitySelected[securityIdentity]; cached {
+	if ruleMatches, cached := r.metadata.IdentitySelected[securityIdentity.ID]; cached {
 		return ruleMatches
 	}
 	// Fall back to costly matching.
 	if ruleMatches = r.EndpointSelector.Matches(securityIdentity.LabelArray); ruleMatches {
 		// Update cache so we don't have to do costly matching again.
-		r.metadata.IdentitySelected[securityIdentity] = true
+		r.metadata.IdentitySelected[securityIdentity.ID] = true
 	} else {
-		r.metadata.IdentitySelected[securityIdentity] = false
+		r.metadata.IdentitySelected[securityIdentity.ID] = false
 	}
 
 	return ruleMatches

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -2296,20 +2296,20 @@ func (ds *PolicyTestSuite) TestMatches(c *C) {
 	// notSelectedEndpoint is not selected by rule, so we it shouldn't be added
 	// to EndpointsSelected.
 	c.Assert(addedRule.matches(notSelectedIdentity), Equals, false)
-	c.Assert(addedRule.metadata.IdentitySelected, checker.DeepEquals, map[*identity.Identity]bool{notSelectedIdentity: false})
+	c.Assert(addedRule.metadata.IdentitySelected, checker.DeepEquals, map[identity.NumericIdentity]bool{notSelectedIdentity.ID: false})
 
 	// selectedEndpoint is selected by rule, so we it should be added to
 	// EndpointsSelected.
 	c.Assert(addedRule.matches(selectedIdentity), Equals, true)
-	c.Assert(addedRule.metadata.IdentitySelected, checker.DeepEquals, map[*identity.Identity]bool{selectedIdentity: true, notSelectedIdentity: false})
+	c.Assert(addedRule.metadata.IdentitySelected, checker.DeepEquals, map[identity.NumericIdentity]bool{selectedIdentity.ID: true, notSelectedIdentity.ID: false})
 
 	// Test again to check for caching working correctly.
 	c.Assert(addedRule.matches(selectedIdentity), Equals, true)
-	c.Assert(addedRule.metadata.IdentitySelected, checker.DeepEquals, map[*identity.Identity]bool{selectedIdentity: true, notSelectedIdentity: false})
+	c.Assert(addedRule.metadata.IdentitySelected, checker.DeepEquals, map[identity.NumericIdentity]bool{selectedIdentity.ID: true, notSelectedIdentity.ID: false})
 
 	// Possible scenario where an endpoint is deleted, and soon after another
 	// endpoint is added with the same ID, but with a different identity. Matching
 	// needs to handle this case correctly.
 	c.Assert(addedRule.matches(notSelectedIdentity), Equals, false)
-	c.Assert(addedRule.metadata.IdentitySelected, checker.DeepEquals, map[*identity.Identity]bool{selectedIdentity: true, notSelectedIdentity: false})
+	c.Assert(addedRule.metadata.IdentitySelected, checker.DeepEquals, map[identity.NumericIdentity]bool{selectedIdentity.ID: true, notSelectedIdentity.ID: false})
 }


### PR DESCRIPTION
Feedback on #7542 was that the rule selector cache indexing based upon
the identity pointer may have unintended impact, as there is no
guarantee that an identity pointer for the same numeric identity is the
same. Fix it up by keying based upon NumericIdentity instead.

Feedback link: https://github.com/cilium/cilium/pull/7542#discussion_r277402254

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7831)
<!-- Reviewable:end -->
