### PR TITLE
doc: fix up Ubuntu apt-get install command

### DIFF
--- a/Documentation/bpf.rst
+++ b/Documentation/bpf.rst
@@ -790,7 +790,7 @@ The following applies to Ubuntu 17.04 or later:
 ::
 
     $ sudo apt-get install -y make gcc libssl-dev bc libelf-dev libcap-dev \
-      clang gcc-multilib llvm libncurses5-dev git pkg-config libmnl bison flex \
+      clang gcc-multilib llvm libncurses5-dev git pkg-config libmnl-dev bison flex \
       graphviz
 
 openSUSE Tumbleweed


### PR DESCRIPTION
The libmnl package in Ubuntu/Debian packaging system is named as `libmnl0`, not `libmnl`.
```
$ sudo apt install libmnl
Reading package lists... Done
Building dependency tree       
Reading state information... Done
E: Unable to locate package libmnl
```
We should install `libmnl-dev` or `libmnl0` instead:
```
$ sudo apt install libmnl-dev libmnl0
Reading package lists... Done
Building dependency tree       
Reading state information... Done
libmnl0 is already the newest version (1.0.3-5).
The following NEW packages will be installed:
  libmnl-dev
0 upgraded, 1 newly installed, 0 to remove and 68 not upgraded.
Need to get 11.0 kB of archives.
After this operation, 88.1 kB of additional disk space will be used.
Do you want to continue? [Y/n]
```

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](http://docs.cilium.io/en/stable/contributing/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue. 
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](http://docs.cilium.io/en/stable/contributing/#dev-coo).
- [ ] Provide a title or release-note blurb suitable for the release notes.

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed -->
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7834)
<!-- Reviewable:end -->
