### PR TITLE
operator: add ca-certificates to operator

### DIFF
--- a/cilium-operator.Dockerfile
+++ b/cilium-operator.Dockerfile
@@ -7,8 +7,12 @@ ARG V
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o cilium-operator
 RUN strip cilium-operator
 
+FROM docker.io/library/alpine:3.9.3 as certs
+RUN apk --update add ca-certificates
+
 FROM scratch
 LABEL maintainer="maintainer@cilium.io"
 COPY --from=builder /go/src/github.com/cilium/cilium/operator/cilium-operator /usr/bin/cilium-operator
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 WORKDIR /
 CMD ["/usr/bin/cilium-operator"]


### PR DESCRIPTION
As the operator is running based on a scratch image it does not contain
any ca-certificates installed which prevents cilium-operator from
verifying if a TLS connection is secure.

We will use the ca-certificates available from the alpine:3.9.3 and use
those ones in production.

Signed-off-by: André Martins <andre@cilium.io>

Fixes: #7833 

```release-note
add ca-certificates to cilium-operator
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7835)
<!-- Reviewable:end -->
