### PR TITLE
policy: Avoid panic on nil SecurityIdentity in updateEndpointCaches

### DIFF
--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -492,6 +492,10 @@ func (r *rule) meetsRequirementsIngress(ctx *SearchContext, state *traceState) a
 }
 
 func (r *rule) matches(securityIdentity *identity.Identity) bool {
+	if securityIdentity == nil {
+		return false
+	}
+
 	r.metadata.Mutex.Lock()
 	defer r.metadata.Mutex.Unlock()
 	var ruleMatches bool

--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -364,7 +364,12 @@ func (rules ruleSlice) updateEndpointsCaches(ep Endpoint, epIDSet *IDSet) bool {
 		return true
 	}
 	id := ep.GetID16()
+
+	// If the endpoint isn't initialized yet, we can't update anything here.
 	securityIdentity := ep.GetSecurityIdentity()
+	if securityIdentity == nil {
+		return true
+	}
 
 	for _, r := range rules {
 		if ruleMatches := r.matches(securityIdentity); ruleMatches {


### PR DESCRIPTION
When handling policy updates we need to update selector caches. This
relies on iterating over existing endpoints. In cases where an endpoint
is being deleted or has not finished initializing,
Endpoint.GetSecurityIdentity() returns nil. We do some basic checks to
avoid panicking.

Fixes (probably) https://github.com/cilium/cilium/issues/7782. I haven't seen the crash in a few runs of Nightly so I'm hopeful that this is an improvement. It seems mostly harmless anyway (yeah, right).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7836)
<!-- Reviewable:end -->
