### PR TITLE
policy: Lock endpoint in GetSecurityIdentity

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -810,9 +810,12 @@ func (e *Endpoint) GetLabels() []string {
 	return e.SecurityIdentity.Labels.GetModel()
 }
 
-// GetSecurityIdentity returns the security identity of the endpoint. It assumes
-// the endpoint's mutex.
+// GetSecurityIdentity returns the security identity of the endpoint. The
+// endpoint's mutex must NOT be held.
 func (e *Endpoint) GetSecurityIdentity() *identityPkg.Identity {
+	e.UnconditionalRLock()
+	defer e.RUnlock()
+
 	return e.SecurityIdentity
 }
 

--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -380,15 +380,3 @@ func (rules ruleSlice) updateEndpointsCaches(ep Endpoint, epIDSet *IDSet) bool {
 
 	return false
 }
-
-func (rules ruleSlice) refreshRulesCache(ep Endpoint) {
-	if ep == nil {
-		return
-	}
-
-	securityIdentity := ep.GetSecurityIdentity()
-	for _, r := range rules {
-		// matches updates the caches within the rules
-		r.matches(securityIdentity)
-	}
-}


### PR DESCRIPTION
The policy.Endpoint interface is used without holding a
endpoint.Endpoint's lock. endpoint.Endpoint.SecurityIdentity needs to be
guarded by endpoint.Endpoint.mutex and this is now part of the
endpoint.Endpoint.GetSecurityIdentity function. This should avoid a race
on the security identity but there is now a risk of deadlocking if we
are not careful.

This fixes https://github.com/cilium/cilium/pull/7551, I think. One thing I'm surprised about is that, last week, I saw calls to refreshRulesCache but now I don't. This simplified things because that function held the endpoint lock when it was called. I might be very wrong (but the code compiles, at least).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7837)
<!-- Reviewable:end -->
