### PR TITLE
endpoint: do not serialize JSON for EventQueue field

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -292,7 +292,7 @@ type Endpoint struct {
 
 	realizedPolicy *policy.EndpointPolicy
 
-	EventQueue *eventqueue.EventQueue
+	EventQueue *eventqueue.EventQueue `json:"-"`
 
 	///////////////////////
 	// DEPRECATED FIELDS //


### PR DESCRIPTION
This field's lifecycle should be managed by the agent, and should not persist
across cilium-agent restarts.

Signed-off by: Ian Vernon <ian@cilium.io>:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7840)
<!-- Reviewable:end -->
