### PR TITLE
Manage the identities for cached selector policies via identitymanager

### DIFF
--- a/daemon/state_test.go
+++ b/daemon/state_test.go
@@ -33,6 +33,7 @@ import (
 	e "github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/mac"
@@ -151,6 +152,11 @@ func (ds *DaemonSuite) generateEPs(baseDir string, epsWanted []*e.Endpoint, epsM
 		fullDirName := filepath.Join(baseDir, ep.DirectoryPath())
 		os.MkdirAll(fullDirName, 777)
 		ep.UnconditionalLock()
+
+		// The identities must be tracked in identitymanager to
+		// regenerate the policy for them.
+		identitymanager.Add(ep.SecurityIdentity)
+		defer identitymanager.Remove(ep.SecurityIdentity)
 
 		ready := ep.SetStateLocked(e.StateWaitingToRegenerate, "test")
 		ep.Unlock()

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1335,12 +1335,6 @@ func (e *Endpoint) LeaveLocked(owner Owner, proxyWaitGroup *completion.WaitGroup
 		}
 	}
 
-	if e.selectorPolicy != nil {
-		if err := distillery.Remove(e); err != nil {
-			errors = append(errors, fmt.Errorf("unable to release SelectorPolicy reference: %s", err))
-		}
-	}
-
 	if !conf.NoIdentityRelease && e.SecurityIdentity != nil {
 		identitymanager.Remove(e.SecurityIdentity)
 		_, err := cache.Release(context.Background(), e.SecurityIdentity)

--- a/pkg/identity/identitymanager/manager.go
+++ b/pkg/identity/identitymanager/manager.go
@@ -80,6 +80,9 @@ func (idm *IdentityManager) add(identity *identity.Identity) {
 			identity: identity,
 			refCount: 1,
 		}
+		for o := range idm.observers {
+			o.LocalEndpointIdentityAdded(identity)
+		}
 	} else {
 		idMeta.refCount++
 	}

--- a/pkg/identity/identitymanager/manager_test.go
+++ b/pkg/identity/identitymanager/manager_test.go
@@ -110,6 +110,9 @@ func (s *IdentityManagerTestSuite) TestLocalEndpointIdentityAdded(c *C) {
 	observer := newIdentityManagerObserver([]identity.NumericIdentity{}, nil)
 	idm.subscribe(observer)
 
+	// No-op: nil Identity.
+	idm.Add(nil)
+
 	// First add triggers an "IdentityAdded" event.
 	idm.Add(fooIdentity)
 	expectedObserver := newIdentityManagerObserver([]identity.NumericIdentity{fooIdentity.ID}, nil)
@@ -137,6 +140,12 @@ func (s *IdentityManagerTestSuite) TestLocalEndpointIdentityRemoved(c *C) {
 	c.Assert(idm.identities, NotNil)
 	observer := newIdentityManagerObserver(nil, []identity.NumericIdentity{})
 	idm.subscribe(observer)
+
+	// No-ops:
+	// - nil Identity.
+	// - Identity that isn't managed
+	idm.Remove(nil)
+	idm.Remove(fooIdentity)
 
 	// Basic remove
 	idm.Add(fooIdentity)

--- a/pkg/identity/identitymanager/observer.go
+++ b/pkg/identity/identitymanager/observer.go
@@ -20,6 +20,11 @@ import (
 
 // Observer can sign up to receive events whenever local identities are removed.
 type Observer interface {
+	// LocalEndpointIdentityAdded is called when an identity first becomes
+	// used on the node. Implementations must ensure that the callback
+	// returns within a reasonable period.
+	LocalEndpointIdentityAdded(*identity.Identity)
+
 	// LocalEndpointIdentityRemoved is called when an identity is no longer
 	// in use on the node. Implementations must ensure that the callback
 	// returns within a reasonable period.

--- a/pkg/policy/distillery/policy.go
+++ b/pkg/policy/distillery/policy.go
@@ -27,14 +27,12 @@ import (
 // 'policy' field). It is always nested directly in the owning policyCache,
 // and is protected against concurrent writes via the policyCache mutex.
 type cachedSelectorPolicy struct {
-	users    map[Endpoint]struct{}
 	identity *identityPkg.Identity
 	policy   unsafe.Pointer
 }
 
 func newCachedSelectorPolicy(identity *identityPkg.Identity) *cachedSelectorPolicy {
 	cip := &cachedSelectorPolicy{
-		users:    make(map[Endpoint]struct{}),
 		identity: identity,
 	}
 	cip.setPolicy(policy.NewSelectorPolicy(0))

--- a/pkg/policy/distillery/policy.go
+++ b/pkg/policy/distillery/policy.go
@@ -26,8 +26,6 @@ import (
 // cachedSelectorPolicy is a wrapper around a SelectorPolicy (stored in the
 // 'policy' field). It is always nested directly in the owning policyCache,
 // and is protected against concurrent writes via the policyCache mutex.
-//
-// 'policy' and 'revesion' are only consistent if queried while holding a lock.
 type cachedSelectorPolicy struct {
 	users    map[Endpoint]struct{}
 	identity *identityPkg.Identity

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -421,6 +421,11 @@ func (p *Repository) removeIdentityFromRuleCaches(identity *identity.Identity) *
 	return &wg
 }
 
+// LocalEndpointIdentityAdded handles local identity add events.
+func (p *Repository) LocalEndpointIdentityAdded(*identity.Identity) {
+	// no-op for now.
+}
+
 // LocalEndpointIdentityRemoved handles local identity removal events to
 // remove references from rules in the repository to the specified identity.
 func (p *Repository) LocalEndpointIdentityRemoved(identity *identity.Identity) {


### PR DESCRIPTION
Previous incremental PRs have required the policy distillery to reference-count the users of an identity policy, and tie the adds/removes of identities for which we cache selector policy to the endpoint (by, for instance, inserting when the selectorpolicy is found to be nil inside the endpoint, and removing when the endpoint leaves). This PR replaces that with instead triggering the caching of selector policy based upon the identitymanager lifecycle. This is a bit cleaner, requiring less management, and reducing interdependency between the distillery and endpoint packages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7843)
<!-- Reviewable:end -->
