### PR TITLE
policy: ensure Endpoint lock held while accessing identity

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -816,7 +816,7 @@ func (e *Endpoint) GetLabels() []string {
 }
 
 // GetSecurityIdentity returns the security identity of the endpoint. It assumes
-// the endpoint's mutex.
+// the endpoint's mutex is held.
 func (e *Endpoint) GetSecurityIdentity() *identityPkg.Identity {
 	return e.SecurityIdentity
 }

--- a/pkg/policy/identifier.go
+++ b/pkg/policy/identifier.go
@@ -41,6 +41,8 @@ func NewIDSet() *IDSet {
 // * a means of incrementing its policy revision
 type Endpoint interface {
 	GetID16() uint16
+	RLockAlive() error
+	RUnlock()
 	GetSecurityIdentity() *identity.Identity
 	PolicyRevisionBumpEvent(rev uint64)
 }

--- a/pkg/policy/identifier_test.go
+++ b/pkg/policy/identifier_test.go
@@ -41,6 +41,14 @@ func (d *DummyEndpoint) PolicyRevisionBumpEvent(rev uint64) {
 	return
 }
 
+func (d *DummyEndpoint) RLockAlive() error {
+	return nil
+}
+
+func (d *DummyEndpoint) RUnlock() {
+	return
+}
+
 func (ds *PolicyTestSuite) TestNewEndpointSet(c *C) {
 	epSet := NewEndpointSet(20)
 	c.Assert(epSet.Len(), Equals, 0)

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -466,6 +466,9 @@ func (r ruleSlice) UpdateRulesEndpointsCaches(endpointsToBumpRevision *EndpointS
 		// endpoint). This is usually the case when the endpoint is no longer
 		// alive (i.e., it has been marked to be deleted).
 		if endpointSelected || err != nil {
+			if err != nil {
+				log.WithError(err).Debug("could not determine whether endpoint was selected by rule")
+			}
 			endpointsToBumpRevision.Delete(epp)
 		}
 	})

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -456,7 +456,16 @@ func (r ruleSlice) UpdateRulesEndpointsCaches(endpointsToBumpRevision *EndpointS
 	}
 
 	endpointsToBumpRevision.ForEach(policySelectionWG, func(epp Endpoint) {
-		if endpointSelected := r.updateEndpointsCaches(epp, endpointsToRegenerate); endpointSelected {
+		endpointSelected, err := r.updateEndpointsCaches(epp, endpointsToRegenerate)
+
+		// If we could not evaluate the rules against the current endpoint, or
+		// the endpoint is not selected by the rules, remove it from the set
+		// of endpoints to bump the revision. If the error is non-nil, the
+		// endpoint is no longer in either set (endpointsToBumpRevision or
+		// endpointsToRegenerate, as we could not determine what to do for the
+		// endpoint). This is usually the case when the endpoint is no longer
+		// alive (i.e., it has been marked to be deleted).
+		if endpointSelected || err != nil {
 			endpointsToBumpRevision.Delete(epp)
 		}
 	})

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -62,6 +62,14 @@ func (d *dummyEndpoint) PolicyRevisionBumpEvent(rev uint64) {
 	return
 }
 
+func (d *dummyEndpoint) RLockAlive() error {
+	return nil
+}
+
+func (d *dummyEndpoint) RUnlock() {
+	return
+}
+
 func (ds *PolicyTestSuite) SetUpSuite(c *C) {
 	var wg sync.WaitGroup
 	SetPolicyEnabled(option.DefaultEnforcement)

--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -15,6 +15,7 @@
 package policy
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -359,12 +360,20 @@ loop:
 // added to epIDSet. Note that epIDSet can be shared across goroutines!
 // Returns whether the endpoint was selected by one of the rules, or if the
 // endpoint is nil.
-func (rules ruleSlice) updateEndpointsCaches(ep Endpoint, epIDSet *IDSet) bool {
+func (rules ruleSlice) updateEndpointsCaches(ep Endpoint, epIDSet *IDSet) (bool, error) {
 	if ep == nil {
-		return true
+		return false, fmt.Errorf("cannot update caches in rules because endpoint is nil")
 	}
 	id := ep.GetID16()
+	if err := ep.RLockAlive(); err != nil {
+		return false, fmt.Errorf("cannnot update caches in rules for endpoint %d because it is being deleted: %s", id, err)
+	}
+	defer ep.RUnlock()
 	securityIdentity := ep.GetSecurityIdentity()
+
+	if securityIdentity == nil {
+		return false, fmt.Errorf("cannot update caches in rules for endpoint %d because it has a nil identity", id)
+	}
 
 	for _, r := range rules {
 		if ruleMatches := r.matches(securityIdentity); ruleMatches {
@@ -374,21 +383,9 @@ func (rules ruleSlice) updateEndpointsCaches(ep Endpoint, epIDSet *IDSet) bool {
 
 			// If epIDSet is updated, we can exit since updating it again if
 			// another rule selects the Endpoint is a no-op.
-			return true
+			return true, nil
 		}
 	}
 
-	return false
-}
-
-func (rules ruleSlice) refreshRulesCache(ep Endpoint) {
-	if ep == nil {
-		return
-	}
-
-	securityIdentity := ep.GetSecurityIdentity()
-	for _, r := range rules {
-		// matches updates the caches within the rules
-		r.matches(securityIdentity)
-	}
+	return false, nil
 }


### PR DESCRIPTION
Because the endpoint identity is mutable, we need to hold the lock for the endpoint while we are updating the caches in the rules which specify what identities are selected by that rule. The endpoint's identity may change while we are updating the caches, which could result in an identity being left behind in said caches. Also, the endpoint's identity may be set to a nil value, which would result in a panic, since fields within the identity are dereferenced to access the identity's labels when the caches within the rules are updated.

The locks which check liveness with the endpoint are used here because if the endpoint is being deleted, we don't need to update the caches within the rules anymore for it. Also, when an endpoint is deleted, its security identity is set to `nil` in `pkg/endpoint.go:LeaveLocked`. Read-locking is needed because no updating of the security identity is performed here.

There is still a possibility that the endpoint's identity could be nil while itis 'alive', as the endpoint is inserted into the endpointmanager before its identity is allocated in `daemon/endpoint.go:createEndpoint`. This is OK, as once an endpoint's identity is changed, another regeneration will occur for it, which will populate the caches within the rules with its new identity. This case, while possible, is not probable.
    
Signed-off by: Ian Vernon <ian@cilium.io>

Related: #7837

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7844)
<!-- Reviewable:end -->
