### PR TITLE
test: Suffix K8s-1.10 with net-next

### DIFF
--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -85,7 +85,7 @@ pipeline {
                             sh 'cd ${TESTDIR}; vagrant provision runtime'
                             sh 'cd ${TESTDIR}; ginkgo --focus=" Runtime*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
                         },
-                        "K8s-1.10":{
+                        "K8s-1.10-net-next":{
                             sh 'cd ${TESTDIR}; NETNEXT=true K8S_VERSION=1.10 vagrant provision k8s1-1.10; K8S_VERSION=1.10 vagrant provision k8s2-1.10'
                             sh 'cd ${TESTDIR}; NETNEXT=true K8S_VERSION=1.10 ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
                         },


### PR DESCRIPTION
As we started running integration tests with k8s 1.10 on net-next, add the `net-next` suffix to the step description to raise awareness that tests are running on the net-next kernel.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7845)
<!-- Reviewable:end -->
