### PR TITLE
CI execs time out more reliably

### DIFF
--- a/test/helpers/node.go
+++ b/test/helpers/node.go
@@ -135,13 +135,7 @@ func (s *SSHMeta) ExecuteContext(ctx context.Context, cmd string, stdout io.Writ
 		Stdout: stdout,
 		Stderr: stderr,
 	}
-	err := s.sshClient.RunCommandContext(ctx, command)
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	default:
-		return err
-	}
+	return s.sshClient.RunCommandContext(ctx, command)
 }
 
 // ExecWithSudo returns the result of executing the provided cmd via SSH using

--- a/test/helpers/ssh_command.go
+++ b/test/helpers/ssh_command.go
@@ -143,7 +143,7 @@ func ImportSSHconfig(config []byte) (SSHConfigs, error) {
 // Note: io.Copy stops when it sees an EOF error, but does not treat it as an
 // error.
 func copyWait(dst io.Writer, src io.Reader) chan error {
-	c := make(chan error)
+	c := make(chan error, 1)
 	go func() {
 		_, err := io.Copy(dst, src)
 		c <- err

--- a/test/runtime/helpers.go
+++ b/test/runtime/helpers.go
@@ -39,28 +39,29 @@ var _ = Describe("RuntimeTestExecTimeout", func() {
 		start := time.Now()
 		timeout := 10 * time.Second
 		sleepSeconds := 20 + (timeout+helpers.CMDGracePeriod)/time.Second
+		deadline := start.Add((timeout + helpers.CMDGracePeriod))
 
 		ctx, cancel := context.WithTimeout(context.TODO(), timeout)
 		defer cancel()
 
 		res := vm.ExecContext(ctx, fmt.Sprintf("sleep %d", sleepSeconds))
-		fmt.Printf("FML: %v WTF: %v\n", time.Since(start), time.Since(start) < timeout)
-		Expect(time.Since(start) < timeout).Should(BeTrue(), "Did not interrupt a timed-out exec within timeout")
+		fmt.Printf("FML: %v WTF: %v\n", time.Since(start), time.Now().Before(deadline))
+		Expect(time.Now().Before(deadline)).Should(BeTrue(), "Did not interrupt a timed-out exec within timeout")
 		Expect(res.GetExitCode()).Should(Not(Equal(0)), "Did not interrupt a timed-out exec based on exit code")
 		Expect(!res.WasSuccessful(), "Did not interrupt a timed-out exec based on returned error")
 	})
 
 	It("Returns from execs on cancel", func() {
 		start := time.Now()
-		timeout := 1 * time.Second
 		sleepSeconds := 20 + helpers.CMDGracePeriod/time.Second
+		deadline := start.Add((helpers.CMDGracePeriod))
 
 		ctx, cancel := context.WithCancel(context.TODO())
 		cancel()
 
 		res := vm.ExecContext(ctx, fmt.Sprintf("sleep %d", sleepSeconds))
-		fmt.Printf("FML: %v WTF: %v\n", time.Since(start), time.Since(start) < timeout)
-		Expect(time.Since(start) < timeout).Should(BeTrue(), "Did not interrupt a cancelled exec")
+		fmt.Printf("FML: %v WTF: %v\n", time.Since(start), time.Now().Before(deadline))
+		Expect(time.Now().Before(deadline)).Should(BeTrue(), "Did not interrupt a cancelled exec")
 		Expect(res.GetExitCode()).Should(Not(Equal(0)), "Did not interrupt a cancelled out exec based on exit code")
 		Expect(!res.WasSuccessful(), "Did not interrupt a cancelled exec based on returned error")
 	})

--- a/test/runtime/helpers.go
+++ b/test/runtime/helpers.go
@@ -44,6 +44,7 @@ var _ = Describe("RuntimeTestExecTimeout", func() {
 		defer cancel()
 
 		res := vm.ExecContext(ctx, fmt.Sprintf("sleep %d", sleepSeconds))
+		fmt.Printf("FML: %v WTF: %v\n", time.Since(start), time.Since(start) < timeout)
 		Expect(time.Since(start) < timeout).Should(BeTrue(), "Did not interrupt a timed-out exec within timeout")
 		Expect(res.GetExitCode()).Should(Not(Equal(0)), "Did not interrupt a timed-out exec based on exit code")
 		Expect(!res.WasSuccessful(), "Did not interrupt a timed-out exec based on returned error")
@@ -58,6 +59,7 @@ var _ = Describe("RuntimeTestExecTimeout", func() {
 		cancel()
 
 		res := vm.ExecContext(ctx, fmt.Sprintf("sleep %d", sleepSeconds))
+		fmt.Printf("FML: %v WTF: %v\n", time.Since(start), time.Since(start) < timeout)
 		Expect(time.Since(start) < timeout).Should(BeTrue(), "Did not interrupt a cancelled exec")
 		Expect(res.GetExitCode()).Should(Not(Equal(0)), "Did not interrupt a cancelled out exec based on exit code")
 		Expect(!res.WasSuccessful(), "Did not interrupt a cancelled exec based on returned error")

--- a/test/runtime/helpers.go
+++ b/test/runtime/helpers.go
@@ -1,0 +1,64 @@
+// Copyright 2018-2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package RuntimeTest
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/cilium/cilium/test/ginkgo-ext"
+	"github.com/cilium/cilium/test/helpers"
+
+	. "github.com/onsi/gomega"
+)
+
+// TestExecTimeout checks that our SSH execs are able to cancel in-flight
+// commands. This is important to avoid blocking CI indefinitely when things
+// misbehave.
+var _ = Describe("RuntimeTestExecTimeout", func() {
+	var vm *helpers.SSHMeta
+	BeforeAll(func() {
+		vm = helpers.InitRuntimeHelper(helpers.Runtime, logger)
+		ExpectCiliumReady(vm)
+	})
+
+	It("Returns from execs on timeout", func() {
+		timeout := 10 * time.Second
+		sleepSeconds := 20 + (timeout+helpers.CMDGracePeriod)/time.Second
+		deadline := time.Now().Add(sleepSeconds * time.Second)
+
+		ctx, cancel := context.WithTimeout(context.TODO(), timeout)
+		defer cancel()
+
+		res := vm.ExecContext(ctx, fmt.Sprintf("sleep %d", sleepSeconds))
+		Expect(res.GetExitCode()).Should(Not(Equal(0)), "Did not interrupt a timed-out exec")
+		Expect(!res.WasSuccessful(), "Did not interrupt a timed-out exec")
+		Expect(time.Now().Before(deadline), "Did not interrupt a timed-out exec")
+	})
+
+	It("Returns from execs on cancel", func() {
+		sleepSeconds := 20 + helpers.CMDGracePeriod/time.Second
+		deadline := time.Now().Add(1 * time.Second)
+
+		ctx, cancel := context.WithCancel(context.TODO())
+		cancel()
+
+		res := vm.ExecContext(ctx, fmt.Sprintf("sleep %d", sleepSeconds))
+		Expect(!res.WasSuccessful(), "Did not interrupt a cancelled out exec")
+		Expect(res.GetExitCode()).Should(Not(Equal(0)), "Did not interrupt a cancelled out exec")
+		Expect(time.Now().Before(deadline), "Did not interrupt a cancelled out exec")
+	})
+})

--- a/test/test_test.go
+++ b/test/test_test.go
@@ -16,6 +16,7 @@ package ciliumTest
 
 import (
 	// test sources
+
 	_ "github.com/cilium/cilium/test/k8sT"
 	_ "github.com/cilium/cilium/test/runtime"
 )


### PR DESCRIPTION
CI: Ensure k8s execs cancel contexts
We make many calls that end up in SSHMeta.Exec. It would pass
context.Background to SSHMeta.ExecContext. Unfortunately, the way
ExecContext is written relies on the context expiring eventually,
otherwise it will leak goroutines (and also leave the session open,
potentially). We now pass in a cancellable context and cancel it when we
exit Exec. There is still no direct timeout in this case.


CI: SSH exec wrappers cleanup on timeout
In cases where non-expiring contexts were used, we did not clean up watcher
goroutines and they would leak. In cases where the command returned
before the context expired, we would return without waiting for the
session to be torn down.
When a context did expire, the code used SIGINT to terminate it. This
could cause our code to block until the command reacted to SIGINT,
possibly waiting indefinitely (when cilium is deadlocked, for example).

The code now:
- Sends a SIGKILL after a grace period, if the command did not exit.
- Ensures non-timeout/context based wrappers use a cancelled context
internally, allowing for cleanups.
- Always waits for the command to terminate and relies on SIGKILL to
ensure that we exit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7847)
<!-- Reviewable:end -->
