### PR TITLE
Improve operator bootstrap sequence

### DIFF
--- a/operator/cnp_event.go
+++ b/operator/cnp_event.go
@@ -38,6 +38,7 @@ func init() {
 }
 
 func enableCNPWatcher() error {
+	log.Info("Starting to garbage collect stale CiliumNetworkPolicy status field entries...")
 
 	_, ciliumV2Controller := k8s.NewInformer(
 		cache.NewListWatchFromClient(k8s.CiliumClient().CiliumV2().RESTClient(),

--- a/operator/k8s_cep_gc.go
+++ b/operator/k8s_cep_gc.go
@@ -51,6 +51,8 @@ func enableCiliumEndpointSyncGC() {
 		scopedLog      = log.WithField("controller", controllerName)
 	)
 
+	log.Info("Starting to garbage collect stale CiliumEndpoint custom resources...")
+
 	ciliumClient := ciliumK8sClient.CiliumV2()
 
 	// this dummy manager is needed only to add this controller to the global list

--- a/operator/k8s_node.go
+++ b/operator/k8s_node.go
@@ -48,6 +48,8 @@ var (
 )
 
 func runNodeWatcher() error {
+	log.Info("Starting to synchronize k8s nodes to kvstore...")
+
 	serNodes := serializer.NewFunctionQueue(1024)
 
 	ciliumNodeStore, err := store.JoinSharedStore(store.Configuration{

--- a/operator/k8s_service_sync.go
+++ b/operator/k8s_service_sync.go
@@ -72,6 +72,8 @@ func k8sServiceHandler() {
 }
 
 func startSynchronizingServices() {
+	log.Info("Starting to synchronize k8s services to kvstore...")
+
 	readyChan := make(chan struct{}, 0)
 
 	go func() {

--- a/operator/main.go
+++ b/operator/main.go
@@ -146,6 +146,7 @@ func runOperator(cmd *cobra.Command) {
 	logging.SetupLogging([]string{}, map[string]string{}, "cilium-operator", viper.GetBool("debug"))
 
 	log.Infof("Cilium Operator %s", version.Version)
+	go StartServer(fmt.Sprintf(":%d", apiServerPort), shutdownSignal)
 
 	if err := kvstore.Setup(kvStore, kvStoreOpts, nil); err != nil {
 		log.WithError(err).WithFields(logrus.Fields{
@@ -193,8 +194,6 @@ func runOperator(cmd *cobra.Command) {
 		log.WithError(err).WithField("subsys", "CNPWatcher").Fatal(
 			"Cannot connect to Kubernetes apiserver ")
 	}
-
-	go StartServer(fmt.Sprintf(":%d", apiServerPort), shutdownSignal)
 
 	<-shutdownSignal
 	// graceful exit

--- a/operator/main.go
+++ b/operator/main.go
@@ -195,6 +195,8 @@ func runOperator(cmd *cobra.Command) {
 			"Cannot connect to Kubernetes apiserver ")
 	}
 
+	log.Info("Initialization complete")
+
 	<-shutdownSignal
 	// graceful exit
 	log.Info("Received termination signal. Shutting down")


### PR DESCRIPTION
* Start the health port earlier to avoid liveness probes failing when kvstore or k8s apiserver are not yet reachable
* Provide additional logging on startup to indicate at what stage the operator is currently at

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7848)
<!-- Reviewable:end -->
