### PR TITLE
v1.3 backports 2019-04-25

### DIFF
--- a/Documentation/bpf.rst
+++ b/Documentation/bpf.rst
@@ -765,7 +765,7 @@ The following applies to Ubuntu 17.04 or later:
 ::
 
     $ sudo apt-get install -y make gcc libssl-dev bc libelf-dev libcap-dev \
-      clang gcc-multilib llvm libncurses5-dev git pkg-config libmnl bison flex \
+      clang gcc-multilib llvm libncurses5-dev git pkg-config libmnl-dev bison flex \
       graphviz
 
 Compiling the Kernel

--- a/contrib/scripts/check-fmt.sh
+++ b/contrib/scripts/check-fmt.sh
@@ -1,13 +1,14 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 set -e
+set -o pipefail
+
 diff="$(find . ! \( -path './contrib' -prune \) \
         ! \( -path './vendor' -prune \) \
         ! \( -path './.git' -prune \) \
         ! \( -path '*.validate.go' -prune \) \
-        ! -samefile ./daemon/bindata.go \
-        -type f -name '*.go' -print0 \
-                | xargs -0 gofmt -d -l -s )"
+        -type f -name '*.go' | grep -v "daemon/bindata.go" | \
+        xargs gofmt -d -l -s )"
 
 if [ -n "$diff" ]; then
 	echo "Unformatted Go source code:"


### PR DESCRIPTION
* #7829 -- contrib: ensure check-fmt.sh runs correctly, and fails if it does not (@ianvernon)
 * #7834 -- doc: fix up Ubuntu apt-get install command (@liuqun)

Once this PR is merged, you can update the PR labels via:
```
$ for pr in 7829 7834; do contrib/backporting/set-labels.py $pr done 1.3; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7849)
<!-- Reviewable:end -->
