### PR TITLE
Test: Add size mismatch log entry to failed ones.

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -197,6 +197,7 @@ const (
 	segmentationFault = "segmentation fault"        // from https://github.com/cilium/cilium/issues/3233
 	NACKreceived      = "NACK received for version" // from https://github.com/cilium/cilium/issues/4003
 	RunInitFailed     = "JoinEP: "                  // from https://github.com/cilium/cilium/pull/5052
+	sizeMismatch      = "size mismatch for BPF map" // from https://github.com/cilium/cilium/issues/7851
 )
 
 // Re-definitions of stable constants in the API. The re-definition is on
@@ -238,6 +239,7 @@ var badLogMessages = map[string][]string{
 	segmentationFault: nil,
 	NACKreceived:      nil,
 	RunInitFailed:     {"signal: terminated", "signal: killed"},
+	sizeMismatch:      nil,
 }
 
 var ciliumCLICommands = map[string]string{


### PR DESCRIPTION
Fail if size mismatch is found in the logs after executing the test.

Fix #7851

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7852)
<!-- Reviewable:end -->
