### PR TITLE
daemon,option: Work around the viper.BindEnv limitation of multiple binds

### DIFF
--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -491,10 +491,8 @@ func init() {
 
 	flags.Bool(option.DisableEnvoyVersionCheck, false, "Do not perform Envoy binary version check on startup")
 	flags.MarkHidden(option.DisableEnvoyVersionCheck)
-	option.BindEnv(option.DisableEnvoyVersionCheck)
 	// Disable version check if Envoy build is disabled
-	// This needs to be set manually for backward compatibility
-	viper.BindEnv(option.DisableEnvoyVersionCheck, "CILIUM_DISABLE_ENVOY_BUILD")
+	option.BindEnvWithLegacyEnvFallback(option.DisableEnvoyVersionCheck, "CILIUM_DISABLE_ENVOY_BUILD")
 
 	flags.Var(option.NewNamedMapOptions(option.FixedIdentityMapping, &option.Config.FixedIdentityMapping, option.Config.FixedIdentityMappingValidator),
 		option.FixedIdentityMapping, "Key-value for the fixed identity mapping which allows to use reserved label for fixed identities")
@@ -603,9 +601,7 @@ func init() {
 
 	flags.String(option.MonitorAggregationName, "None",
 		"Level of monitor aggregation for traces from the datapath")
-	option.BindEnv(option.MonitorAggregationName)
-	// Leave for backwards compatibility
-	viper.BindEnv(option.MonitorAggregationName, "CILIUM_MONITOR_AGGREGATION_LEVEL")
+	option.BindEnvWithLegacyEnvFallback(option.MonitorAggregationName, "CILIUM_MONITOR_AGGREGATION_LEVEL")
 
 	flags.Int(option.MonitorQueueSizeName, defaults.MonitorQueueSize,
 		"Size of the event queue when reading monitor events")
@@ -615,9 +611,7 @@ func init() {
 	option.BindEnv(option.MTUName)
 
 	flags.Bool(option.PrependIptablesChainsName, true, "Prepend custom iptables chains instead of appending")
-	// Leave for backwards compatibility
-	viper.BindEnv(option.PrependIptablesChainsName, "CILIUM_PREPEND_IPTABLES_CHAIN")
-	option.BindEnv(option.PrependIptablesChainsName)
+	option.BindEnvWithLegacyEnvFallback(option.PrependIptablesChainsName, "CILIUM_PREPEND_IPTABLES_CHAIN")
 
 	flags.String(option.IPv6NodeAddr, "auto", "IPv6 address of node")
 	option.BindEnv(option.IPv6NodeAddr)
@@ -688,18 +682,13 @@ func init() {
 	// handle the case where someone uses a new image with an older spec, and the
 	// older spec used the older variable name.
 	flags.String(option.PrometheusServeAddr, "", "IP:Port on which to serve prometheus metrics (pass \":Port\" to bind on all interfaces, \"\" is off)")
-	viper.BindEnv(option.PrometheusServeAddrDeprecated, "PROMETHEUS_SERVE_ADDR")
-	option.BindEnv(option.PrometheusServeAddr)
+	option.BindEnvWithLegacyEnvFallback(option.PrometheusServeAddr, "PROMETHEUS_SERVE_ADDR")
 
 	flags.Int(option.CTMapEntriesGlobalTCPName, option.CTMapEntriesGlobalTCPDefault, "Maximum number of entries in TCP CT table")
-	// Leave for backwards compatibility
-	viper.BindEnv(option.CTMapEntriesGlobalTCPName, "CILIUM_GLOBAL_CT_MAX_TCP")
-	option.BindEnv(option.CTMapEntriesGlobalTCPName)
+	option.BindEnvWithLegacyEnvFallback(option.CTMapEntriesGlobalTCPName, "CILIUM_GLOBAL_CT_MAX_TCP")
 
 	flags.Int(option.CTMapEntriesGlobalAnyName, option.CTMapEntriesGlobalAnyDefault, "Maximum number of entries in non-TCP CT table")
-	// Leave for backwards compatibility
-	viper.BindEnv(option.CTMapEntriesGlobalAnyName, "CILIUM_GLOBAL_CT_MAX_ANY")
-	option.BindEnv(option.CTMapEntriesGlobalAnyName)
+	option.BindEnvWithLegacyEnvFallback(option.CTMapEntriesGlobalAnyName, "CILIUM_GLOBAL_CT_MAX_ANY")
 
 	flags.String(option.CMDRef, "", "Path to cmdref output directory")
 	flags.MarkHidden(option.CMDRef)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -523,12 +523,33 @@ var RegisteredOptions = map[string]struct{}{}
 // variable which s based on the given optName. If the same optName is bind
 // more than 1 time, this function panics.
 func BindEnv(optName string) {
+	registerOpt(optName)
+	viper.BindEnv(optName, getEnvName(optName))
+}
+
+// BindEnvWithLegacyEnvFallback binds the given option name with either the same
+// environment variable as BindEnv, if it's set, or with the given legacyEnvName.
+//
+// The function is used to work around the viper.BindEnv limitation that only
+// one environment variable can be bound for an option, and we need multiple
+// environment variables due to backward compatibility reasons.
+func BindEnvWithLegacyEnvFallback(optName, legacyEnvName string) {
+	registerOpt(optName)
+
+	envName := getEnvName(optName)
+	if os.Getenv(envName) == "" {
+		envName = legacyEnvName
+	}
+
+	viper.BindEnv(optName, envName)
+}
+
+func registerOpt(optName string) {
 	_, ok := RegisteredOptions[optName]
 	if ok || optName == "" {
 		panic(fmt.Errorf("option already registered: %s", optName))
 	}
 	RegisteredOptions[optName] = struct{}{}
-	viper.BindEnv(optName, getEnvName(optName))
 }
 
 // LogRegisteredOptions logs all options that where bind to viper.

--- a/pkg/option/config_test.go
+++ b/pkg/option/config_test.go
@@ -223,3 +223,17 @@ func (s *OptionSuite) TestWorkloadsEnabled(c *C) {
 		}
 	}
 }
+
+func (s *OptionSuite) TestBindEnv(c *C) {
+	optName1 := "foo-bar"
+	os.Setenv("LEGACY_FOO_BAR", "legacy")
+	os.Setenv(getEnvName(optName1), "new")
+	BindEnvWithLegacyEnvFallback(optName1, "LEGACY_FOO_BAR")
+	c.Assert(viper.GetString(optName1), Equals, "new")
+
+	optName2 := "bar-foo"
+	BindEnvWithLegacyEnvFallback(optName2, "LEGACY_FOO_BAR")
+	c.Assert(viper.GetString(optName2), Equals, "legacy")
+
+	viper.Reset()
+}


### PR DESCRIPTION
Firstly, this PR introduces `BindEnvWithLegacyEnvFallback` function which is used to work around the `viper.BindEnv` limitation: only one ENV param can be bound for a given option.

This limitation prevents from some ENV params introduced for the backward compatibility in `daemon/deamon_main.go` being usable. E.g. A value of `CILIUM_GLOBAL_CT_MAX_TCP` is actually never used.

The ENV binding order is the following:

1. Bind the ENV param derived from the option name if it's non-empty.
2. Bind the legacy ENV param otherwise.

Secondly, we replace the usage of multiple `viper.BindEnv` calls for the same param with the newly introduced function in `daemon/daemon_main.go`, so that the legacy ENV param can be used.

As the backward compatible ENV params were never been used, this PR will have an upgrade impact on v1.4 users: if a user didn't specify the CT TCP maps size via a command line parameter to `cilium-agent`, then it was using the default values for the maps even if `CILIUM_GLOBAL_CT_MAX_TCP` was set. After the user has upgraded to a version which includes this fix, the CT TCP maps size will be taken from the `CILIUM_GLOBAL_CT_MAX_TCP`, which in many cases have a different value than the default one (e.g. https://github.com/cilium/cilium/blob/v1.4.4/examples/kubernetes/1.14/cilium-cm.yaml#L86). Due to the difference in the sizes, the CT TCP maps will be removed and recreated which means that all established TCP connections will be broken.

IMHO, we should mention in the upgrade docs that the user needs to change the `CILIUM_GLOBAL_CT_MAX_TCP` value in ConfigMap before doing the upgrade. Happy to create a PR for the docs if you agree on the suggestion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7859)
<!-- Reviewable:end -->
