### PR TITLE
docs: Add upgrade guide from >=1.4.0 to 1.5

### DIFF
--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -267,6 +267,18 @@ Annotations:
 1.5 Upgrade Notes
 -----------------
 
+Upgrading from >=1.4.0 to 1.5.y
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+#. In v1.4, the TCP conntrack table size ``ct-global-max-entries-tcp``
+   ConfigMap parameter was ineffective due to a bug and thus, the default
+   value (``1000000``) was used instead. To prevent from breaking established
+   TCP connections, ``bpf-ct-global-tcp-max`` must be set to ``1000000`` in
+   the ConfigMap before upgrading. Refer to the section :ref:`upgrade_configmap`
+   on how to upgrade the `ConfigMap`.
+
+#. Follow the standard procedures to perform the upgrade as described in :ref:`upgrade_minor`.
+
 New Default Values
 ~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Mention about possible breakage of established connections due to the change in the CT TCP maps (CT any map is not affected, as the default size value = the value used in the ConfigMaps) set and how to avoid it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7861)
<!-- Reviewable:end -->
