### PR TITLE
AWS CNI chaining support

### DIFF
--- a/Documentation/gettingstarted/cni-chaining-aws-cni.rst
+++ b/Documentation/gettingstarted/cni-chaining-aws-cni.rst
@@ -1,0 +1,134 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+    http://docs.cilium.io
+
+*******
+AWS-CNI
+*******
+
+This guide explains how to set up Cilium in combination with aws-cni. In this
+hybrid mode, the aws-cni plugin is responsible for setting up the virtual
+network devices as well as address allocation (IPAM) via ENI. After the initial
+networking is setup, the Cilium CNI plugin is called to attach BPF programs to
+the network devices set up by aws-cni to enforce network policies, perform
+load-balancing, and encryption.
+
+.. image:: aws-cni-architecture.png
+
+
+Setup Cluster on AWS
+====================
+
+Follow the instructions in the :ref:`k8s_install_eks` guide to set up an EKS
+cluster or use any other method of your preference to set up a Kubernetes
+cluster.
+
+Ensure that the `aws-vpc-cni-k8s <https://github.com/aws/amazon-vpc-cni-k8s>`__
+plugin is installed. If you have set up an EKS cluster, this is automatically
+done.
+
+Prepare Cilium to use AWS-CNI chaining
+======================================
+
+Download the Cilium deployment yaml:
+
+.. tabs::
+  .. group-tab:: K8s 1.14
+
+    .. parsed-literal::
+
+      curl -sLO \ |SCM_WEB|\/examples/kubernetes/1.14/cilium.yaml
+
+  .. group-tab:: K8s 1.13
+
+    .. parsed-literal::
+
+      curl -sLO \ |SCM_WEB|\/examples/kubernetes/1.13/cilium.yaml
+
+  .. group-tab:: K8s 1.12
+
+    .. parsed-literal::
+
+      curl -sLO \ |SCM_WEB|\/examples/kubernetes/1.12/cilium.yaml
+
+  .. group-tab:: K8s 1.11
+
+    .. parsed-literal::
+
+      curl -sLO \ |SCM_WEB|\/examples/kubernetes/1.11/cilium.yaml
+
+  .. group-tab:: K8s 1.10
+
+    .. parsed-literal::
+
+      curl -sLO \ |SCM_WEB|\/examples/kubernetes/1.10/cilium.yaml
+
+Edit ``cilium.yaml and add the following configuration to the ConfigMap:
+
+.. code:: bash
+
+      cni-chaining-mode: aws-cni
+      masquerade: "false"
+      tunnel: disabled
+
+This will enable chaining with the aws-cni plugin. It will also disable
+tunneling. Tunneling is not required as ENI IP addresses can be directly routed
+in your VPC. You can also disable masquerading for the same reason.
+
+Validate your Security Groups
+=============================
+
+Validate your AWS security groups rules and ensure that ENI IP addresses as
+allocated and used by the aws-cni plugin are allowed. See the documentation of
+the `aws-vpc-cni-k8s <https://github.com/aws/amazon-vpc-cni-k8s>`__ plugin for
+more details.
+
+Deploy Cilium
+=============
+
+.. code:: bash
+
+       kubectl apply -f cilium.yaml
+
+As Cilium is deployed as a DaemonSet, it will write a new CNI configuration
+``05-cilium.conflist`` which will take precedence over the standard
+``10-aws.conflist``. Any new pod scheduled, will use the chaining configuration
+which will not also invoke Cilium.
+
+Restart existing pods
+=====================
+
+The new CNI chaining configuration will *not* apply to any pod that is already
+running in the cluster. Existing pods will be reachable and Cilium will
+load-balance to them but policy enforcement will not apply to them and
+load-balancing is not performed for traffic originating from existing pods.
+You must restart these pods in order to invoke the chaining configuration on
+them.
+
+If you are unsure if a pod is managed by Cilium or not, run ``kubectl get cep``
+in the respective namespace and see if the pod is listed.
+
+Validate the Setup
+==================
+
+Start some pods, and then run ``kubectl get cep`` in the namespace of the pods.
+You should see an entry for each pod in ``ready`` state with an ENI IP
+addresses assigned to each pod:
+
+.. code:: bash
+
+        NAME                     ENDPOINT ID   IDENTITY ID   INGRESS ENFORCEMENT   EGRESS ENFORCEMENT   ENDPOINT STATE   IPV4             IPV6
+        echo-775d85cfd4-7qrd4    1561          31650         false                 false                ready            192.168.61.190
+        echo-775d85cfd4-9rvfd    424           31650         false                 false                ready            192.168.43.185
+        echo-775d85cfd4-d9nfq    2197          31650         false                 false                ready            192.168.84.131
+        echo-775d85cfd4-h8qrv    352           31650         false                 false                ready            192.168.78.253
+        echo-775d85cfd4-lkq5g    1308          31650         false                 false                ready            192.168.69.202
+        probe-67cdb8c986-hpn7b   2838          13243         false                 false                ready            192.168.90.115
+        probe-67cdb8c986-mrfgf   2879          13243         false                 false                ready            192.168.35.144
+        probe-67cdb8c986-sj4j7   2673          13243         false                 false                ready            192.168.57.56
+        probe-67cdb8c986-td8qb   553           13243         false                 false                ready            192.168.67.25
+        probe-67cdb8c986-wqqzj   789           13243         false                 false                ready            192.168.52.109
+
+

--- a/Documentation/gettingstarted/cni-chaining.rst
+++ b/Documentation/gettingstarted/cni-chaining.rst
@@ -16,4 +16,5 @@ CNI chaining allows to use Cilium in combination with other CNI plugins.
    :maxdepth: 1
    :glob:
 
+   cni-chaining-aws-cni
    cni-chaining-portmap

--- a/examples/kubernetes/1.10/cilium-cm.yaml
+++ b/examples/kubernetes/1.10/cilium-cm.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none

--- a/examples/kubernetes/1.10/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-containerd-ds.yaml
@@ -52,6 +52,12 @@ spec:
               key: flannel-master-device
               name: cilium-config
               optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
+              name: cilium-config
+              optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT
           valueFrom:
             configMapKeyRef:

--- a/examples/kubernetes/1.10/cilium-containerd.yaml
+++ b/examples/kubernetes/1.10/cilium-containerd.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none
@@ -218,6 +219,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: flannel-master-device
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
               name: cilium-config
               optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT

--- a/examples/kubernetes/1.10/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-crio-ds.yaml
@@ -52,6 +52,12 @@ spec:
               key: flannel-master-device
               name: cilium-config
               optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
+              name: cilium-config
+              optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT
           valueFrom:
             configMapKeyRef:

--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none
@@ -218,6 +219,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: flannel-master-device
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
               name: cilium-config
               optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT

--- a/examples/kubernetes/1.10/cilium-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-ds.yaml
@@ -51,6 +51,12 @@ spec:
               key: flannel-master-device
               name: cilium-config
               optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
+              name: cilium-config
+              optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT
           valueFrom:
             configMapKeyRef:

--- a/examples/kubernetes/1.10/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.10/cilium-external-etcd.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none
@@ -217,6 +218,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: flannel-master-device
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
               name: cilium-config
               optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT

--- a/examples/kubernetes/1.10/cilium-microk8s.yaml
+++ b/examples/kubernetes/1.10/cilium-microk8s.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none
@@ -218,6 +219,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: flannel-master-device
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
               name: cilium-config
               optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT

--- a/examples/kubernetes/1.10/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-minikube-ds.yaml
@@ -51,6 +51,12 @@ spec:
               key: flannel-master-device
               name: cilium-config
               optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
+              name: cilium-config
+              optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT
           valueFrom:
             configMapKeyRef:

--- a/examples/kubernetes/1.10/cilium-minikube.yaml
+++ b/examples/kubernetes/1.10/cilium-minikube.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none
@@ -217,6 +218,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: flannel-master-device
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
               name: cilium-config
               optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT

--- a/examples/kubernetes/1.10/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.10/cilium-with-node-init.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none
@@ -217,6 +218,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: flannel-master-device
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
               name: cilium-config
               optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none
@@ -217,6 +218,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: flannel-master-device
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
               name: cilium-config
               optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT

--- a/examples/kubernetes/1.11/cilium-cm.yaml
+++ b/examples/kubernetes/1.11/cilium-cm.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none

--- a/examples/kubernetes/1.11/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-containerd-ds.yaml
@@ -52,6 +52,12 @@ spec:
               key: flannel-master-device
               name: cilium-config
               optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
+              name: cilium-config
+              optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT
           valueFrom:
             configMapKeyRef:

--- a/examples/kubernetes/1.11/cilium-containerd.yaml
+++ b/examples/kubernetes/1.11/cilium-containerd.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none
@@ -218,6 +219,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: flannel-master-device
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
               name: cilium-config
               optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT

--- a/examples/kubernetes/1.11/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-crio-ds.yaml
@@ -52,6 +52,12 @@ spec:
               key: flannel-master-device
               name: cilium-config
               optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
+              name: cilium-config
+              optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT
           valueFrom:
             configMapKeyRef:

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none
@@ -218,6 +219,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: flannel-master-device
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
               name: cilium-config
               optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -51,6 +51,12 @@ spec:
               key: flannel-master-device
               name: cilium-config
               optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
+              name: cilium-config
+              optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT
           valueFrom:
             configMapKeyRef:

--- a/examples/kubernetes/1.11/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.11/cilium-external-etcd.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none
@@ -217,6 +218,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: flannel-master-device
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
               name: cilium-config
               optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT

--- a/examples/kubernetes/1.11/cilium-microk8s.yaml
+++ b/examples/kubernetes/1.11/cilium-microk8s.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none
@@ -218,6 +219,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: flannel-master-device
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
               name: cilium-config
               optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT

--- a/examples/kubernetes/1.11/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-minikube-ds.yaml
@@ -51,6 +51,12 @@ spec:
               key: flannel-master-device
               name: cilium-config
               optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
+              name: cilium-config
+              optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT
           valueFrom:
             configMapKeyRef:

--- a/examples/kubernetes/1.11/cilium-minikube.yaml
+++ b/examples/kubernetes/1.11/cilium-minikube.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none
@@ -217,6 +218,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: flannel-master-device
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
               name: cilium-config
               optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT

--- a/examples/kubernetes/1.11/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.11/cilium-with-node-init.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none
@@ -217,6 +218,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: flannel-master-device
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
               name: cilium-config
               optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none
@@ -217,6 +218,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: flannel-master-device
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
               name: cilium-config
               optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT

--- a/examples/kubernetes/1.12/cilium-cm.yaml
+++ b/examples/kubernetes/1.12/cilium-cm.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none

--- a/examples/kubernetes/1.12/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-containerd-ds.yaml
@@ -52,6 +52,12 @@ spec:
               key: flannel-master-device
               name: cilium-config
               optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
+              name: cilium-config
+              optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT
           valueFrom:
             configMapKeyRef:

--- a/examples/kubernetes/1.12/cilium-containerd.yaml
+++ b/examples/kubernetes/1.12/cilium-containerd.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none
@@ -218,6 +219,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: flannel-master-device
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
               name: cilium-config
               optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT

--- a/examples/kubernetes/1.12/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-crio-ds.yaml
@@ -52,6 +52,12 @@ spec:
               key: flannel-master-device
               name: cilium-config
               optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
+              name: cilium-config
+              optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT
           valueFrom:
             configMapKeyRef:

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none
@@ -218,6 +219,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: flannel-master-device
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
               name: cilium-config
               optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT

--- a/examples/kubernetes/1.12/cilium-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-ds.yaml
@@ -51,6 +51,12 @@ spec:
               key: flannel-master-device
               name: cilium-config
               optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
+              name: cilium-config
+              optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT
           valueFrom:
             configMapKeyRef:

--- a/examples/kubernetes/1.12/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.12/cilium-external-etcd.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none
@@ -217,6 +218,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: flannel-master-device
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
               name: cilium-config
               optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT

--- a/examples/kubernetes/1.12/cilium-microk8s.yaml
+++ b/examples/kubernetes/1.12/cilium-microk8s.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none
@@ -218,6 +219,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: flannel-master-device
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
               name: cilium-config
               optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT

--- a/examples/kubernetes/1.12/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-minikube-ds.yaml
@@ -51,6 +51,12 @@ spec:
               key: flannel-master-device
               name: cilium-config
               optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
+              name: cilium-config
+              optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT
           valueFrom:
             configMapKeyRef:

--- a/examples/kubernetes/1.12/cilium-minikube.yaml
+++ b/examples/kubernetes/1.12/cilium-minikube.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none
@@ -217,6 +218,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: flannel-master-device
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
               name: cilium-config
               optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT

--- a/examples/kubernetes/1.12/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.12/cilium-with-node-init.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none
@@ -217,6 +218,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: flannel-master-device
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
               name: cilium-config
               optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none
@@ -217,6 +218,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: flannel-master-device
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
               name: cilium-config
               optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT

--- a/examples/kubernetes/1.13/cilium-cm.yaml
+++ b/examples/kubernetes/1.13/cilium-cm.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none

--- a/examples/kubernetes/1.13/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-containerd-ds.yaml
@@ -52,6 +52,12 @@ spec:
               key: flannel-master-device
               name: cilium-config
               optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
+              name: cilium-config
+              optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT
           valueFrom:
             configMapKeyRef:

--- a/examples/kubernetes/1.13/cilium-containerd.yaml
+++ b/examples/kubernetes/1.13/cilium-containerd.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none
@@ -218,6 +219,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: flannel-master-device
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
               name: cilium-config
               optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT

--- a/examples/kubernetes/1.13/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-crio-ds.yaml
@@ -52,6 +52,12 @@ spec:
               key: flannel-master-device
               name: cilium-config
               optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
+              name: cilium-config
+              optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT
           valueFrom:
             configMapKeyRef:

--- a/examples/kubernetes/1.13/cilium-crio.yaml
+++ b/examples/kubernetes/1.13/cilium-crio.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none
@@ -218,6 +219,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: flannel-master-device
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
               name: cilium-config
               optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT

--- a/examples/kubernetes/1.13/cilium-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-ds.yaml
@@ -51,6 +51,12 @@ spec:
               key: flannel-master-device
               name: cilium-config
               optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
+              name: cilium-config
+              optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT
           valueFrom:
             configMapKeyRef:

--- a/examples/kubernetes/1.13/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.13/cilium-external-etcd.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none
@@ -217,6 +218,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: flannel-master-device
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
               name: cilium-config
               optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT

--- a/examples/kubernetes/1.13/cilium-microk8s.yaml
+++ b/examples/kubernetes/1.13/cilium-microk8s.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none
@@ -218,6 +219,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: flannel-master-device
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
               name: cilium-config
               optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT

--- a/examples/kubernetes/1.13/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-minikube-ds.yaml
@@ -51,6 +51,12 @@ spec:
               key: flannel-master-device
               name: cilium-config
               optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
+              name: cilium-config
+              optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT
           valueFrom:
             configMapKeyRef:

--- a/examples/kubernetes/1.13/cilium-minikube.yaml
+++ b/examples/kubernetes/1.13/cilium-minikube.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none
@@ -217,6 +218,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: flannel-master-device
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
               name: cilium-config
               optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT

--- a/examples/kubernetes/1.13/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.13/cilium-with-node-init.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none
@@ -217,6 +218,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: flannel-master-device
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
               name: cilium-config
               optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT

--- a/examples/kubernetes/1.13/cilium.yaml
+++ b/examples/kubernetes/1.13/cilium.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none
@@ -217,6 +218,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: flannel-master-device
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
               name: cilium-config
               optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT

--- a/examples/kubernetes/1.14/cilium-cm.yaml
+++ b/examples/kubernetes/1.14/cilium-cm.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none

--- a/examples/kubernetes/1.14/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.14/cilium-containerd-ds.yaml
@@ -52,6 +52,12 @@ spec:
               key: flannel-master-device
               name: cilium-config
               optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
+              name: cilium-config
+              optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT
           valueFrom:
             configMapKeyRef:

--- a/examples/kubernetes/1.14/cilium-containerd.yaml
+++ b/examples/kubernetes/1.14/cilium-containerd.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none
@@ -218,6 +219,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: flannel-master-device
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
               name: cilium-config
               optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT

--- a/examples/kubernetes/1.14/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.14/cilium-crio-ds.yaml
@@ -52,6 +52,12 @@ spec:
               key: flannel-master-device
               name: cilium-config
               optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
+              name: cilium-config
+              optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT
           valueFrom:
             configMapKeyRef:

--- a/examples/kubernetes/1.14/cilium-crio.yaml
+++ b/examples/kubernetes/1.14/cilium-crio.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none
@@ -218,6 +219,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: flannel-master-device
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
               name: cilium-config
               optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT

--- a/examples/kubernetes/1.14/cilium-ds.yaml
+++ b/examples/kubernetes/1.14/cilium-ds.yaml
@@ -51,6 +51,12 @@ spec:
               key: flannel-master-device
               name: cilium-config
               optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
+              name: cilium-config
+              optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT
           valueFrom:
             configMapKeyRef:

--- a/examples/kubernetes/1.14/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.14/cilium-external-etcd.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none
@@ -217,6 +218,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: flannel-master-device
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
               name: cilium-config
               optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT

--- a/examples/kubernetes/1.14/cilium-microk8s.yaml
+++ b/examples/kubernetes/1.14/cilium-microk8s.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none
@@ -218,6 +219,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: flannel-master-device
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
               name: cilium-config
               optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT

--- a/examples/kubernetes/1.14/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.14/cilium-minikube-ds.yaml
@@ -51,6 +51,12 @@ spec:
               key: flannel-master-device
               name: cilium-config
               optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
+              name: cilium-config
+              optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT
           valueFrom:
             configMapKeyRef:

--- a/examples/kubernetes/1.14/cilium-minikube.yaml
+++ b/examples/kubernetes/1.14/cilium-minikube.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none
@@ -217,6 +218,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: flannel-master-device
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
               name: cilium-config
               optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT

--- a/examples/kubernetes/1.14/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.14/cilium-with-node-init.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none
@@ -217,6 +218,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: flannel-master-device
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
               name: cilium-config
               optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT

--- a/examples/kubernetes/1.14/cilium.yaml
+++ b/examples/kubernetes/1.14/cilium.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none
@@ -217,6 +218,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: flannel-master-device
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
               name: cilium-config
               optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT

--- a/examples/kubernetes/templates/v1/cilium-cm.yaml
+++ b/examples/kubernetes/templates/v1/cilium-cm.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none

--- a/examples/kubernetes/templates/v1/cilium-containerd-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-containerd-ds.yaml.sed
@@ -52,6 +52,12 @@ spec:
               key: flannel-master-device
               name: cilium-config
               optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
+              name: cilium-config
+              optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT
           valueFrom:
             configMapKeyRef:

--- a/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
@@ -52,6 +52,12 @@ spec:
               key: flannel-master-device
               name: cilium-config
               optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
+              name: cilium-config
+              optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT
           valueFrom:
             configMapKeyRef:

--- a/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
@@ -51,6 +51,12 @@ spec:
               key: flannel-master-device
               name: cilium-config
               optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
+              name: cilium-config
+              optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT
           valueFrom:
             configMapKeyRef:

--- a/examples/kubernetes/templates/v1/cilium-minikube-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-minikube-ds.yaml.sed
@@ -51,6 +51,12 @@ spec:
               key: flannel-master-device
               name: cilium-config
               optional: true
+        - name: CILIUM_CNI_CHAINING_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: cni-chaining-mode
+              name: cilium-config
+              optional: true
         - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT
           valueFrom:
             configMapKeyRef:

--- a/plugins/cilium-cni/chaining/api/api.go
+++ b/plugins/cilium-cni/chaining/api/api.go
@@ -51,6 +51,14 @@ type ChainingPlugin interface {
 	// ImplementsAdd returns true if the chaining plugin implements its own
 	// add logic
 	ImplementsAdd() bool
+
+	// Delete is called on CNI DELETE. It is given the plugin context from
+	// the previous plugin.
+	Delete(ctx context.Context, pluginContext PluginContext) (err error)
+
+	// ImplementsDelete returns true if the chaining plugin implements its
+	// own delete logic
+	ImplementsDelete() bool
 }
 
 // Register is called by chaining plugins to register themselves. After

--- a/plugins/cilium-cni/chaining/api/api.go
+++ b/plugins/cilium-cni/chaining/api/api.go
@@ -34,12 +34,11 @@ var (
 
 // PluginContext is the context given to chaining plugins
 type PluginContext struct {
-	Logger     *logrus.Entry
-	Args       *skel.CmdArgs
-	CniArgs    types.ArgsSpec
-	NetConf    *types.NetConf
-	CniVersion string
-	Client     *client.Client
+	Logger  *logrus.Entry
+	Args    *skel.CmdArgs
+	CniArgs types.ArgsSpec
+	NetConf *types.NetConf
+	Client  *client.Client
 }
 
 // ChainingPlugin is the interface each chaining plugin must implement

--- a/plugins/cilium-cni/chaining/api/api_test.go
+++ b/plugins/cilium-cni/chaining/api/api_test.go
@@ -42,6 +42,14 @@ func (p *pluginTest) ImplementsAdd() bool {
 	return true
 }
 
+func (p *pluginTest) Delete(ctx context.Context, pluginContext PluginContext) (err error) {
+	return nil
+}
+
+func (p *pluginTest) ImplementsDelete() bool {
+	return true
+}
+
 func (a *APISuite) TestRegistration(c *check.C) {
 	err := Register("foo", &pluginTest{})
 	c.Assert(err, check.IsNil)

--- a/plugins/cilium-cni/chaining/awscni/aws-cni.go
+++ b/plugins/cilium-cni/chaining/awscni/aws-cni.go
@@ -1,0 +1,24 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package awscni
+
+import (
+	chainingapi "github.com/cilium/cilium/plugins/cilium-cni/chaining/api"
+	"github.com/cilium/cilium/plugins/cilium-cni/chaining/generic-veth"
+)
+
+func init() {
+	chainingapi.Register("aws-cni", &genericveth.GenericVethChainer{})
+}

--- a/plugins/cilium-cni/chaining/flannel/flannel.go
+++ b/plugins/cilium-cni/chaining/flannel/flannel.go
@@ -141,6 +141,14 @@ func (f *flannelChainer) Add(ctx context.Context, pluginCtx chainingapi.PluginCo
 	return &cniTypesVer.Result{}, nil
 }
 
+func (f *flannelChainer) ImplementsDelete() bool {
+	return false
+}
+
+func (f *flannelChainer) Delete(ctx context.Context, pluginCtx chainingapi.PluginContext) (err error) {
+	return nil
+}
+
 func init() {
 	chainingapi.Register("cbr0", &flannelChainer{})
 }

--- a/plugins/cilium-cni/chaining/generic-veth/generic-veth.go
+++ b/plugins/cilium-cni/chaining/generic-veth/generic-veth.go
@@ -1,0 +1,225 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package genericveth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/client"
+	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	chainingapi "github.com/cilium/cilium/plugins/cilium-cni/chaining/api"
+
+	cniTypesVer "github.com/containernetworking/cni/pkg/types/current"
+	cniVersion "github.com/containernetworking/cni/pkg/version"
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/sirupsen/logrus"
+	"github.com/vishvananda/netlink"
+)
+
+var (
+	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "generic-veth")
+)
+
+type genericVethChainer struct{}
+
+func (f *genericVethChainer) ImplementsAdd() bool {
+	return true
+}
+
+func (f *genericVethChainer) Add(ctx context.Context, pluginCtx chainingapi.PluginContext) (res *cniTypesVer.Result, err error) {
+	err = cniVersion.ParsePrevResult(&pluginCtx.NetConf.NetConf)
+	if err != nil {
+		err = fmt.Errorf("unable to understand network config: %s", err)
+		return
+	}
+
+	var prevRes *cniTypesVer.Result
+	prevRes, err = cniTypesVer.NewResultFromResult(pluginCtx.NetConf.PrevResult)
+	if err != nil {
+		err = fmt.Errorf("unable to get previous network result: %s", err)
+		return
+	}
+
+	defer func() {
+		if err != nil {
+			pluginCtx.Logger.WithError(err).
+				WithFields(logrus.Fields{"cni-pre-result": pluginCtx.NetConf.PrevResult.String()}).
+				Errorf("Unable to create endpoint")
+		}
+	}()
+	var (
+		hostMac, vethHostName, vethLXCMac, vethIP string
+		vethHostIdx, peerIndex                    int
+		peer                                      netlink.Link
+		netNs                                     ns.NetNS
+	)
+
+	netNs, err = ns.GetNS(pluginCtx.Args.Netns)
+	if err != nil {
+		err = fmt.Errorf("failed to open netns %q: %s", pluginCtx.Args.Netns, err)
+		return
+	}
+	defer netNs.Close()
+
+	if err = netNs.Do(func(_ ns.NetNS) error {
+		links, err := netlink.LinkList()
+		if err != nil {
+			return err
+		}
+
+		for _, link := range links {
+			log.Debugf("Found interface in container %+v", link.Attrs())
+
+			if link.Type() != "veth" {
+				continue
+			}
+
+			vethLXCMac = link.Attrs().HardwareAddr.String()
+
+			veth, ok := link.(*netlink.Veth)
+			if !ok {
+				return fmt.Errorf("link %s is not a veth interface", vethHostName)
+			}
+
+			peerIndex, err = netlink.VethPeerIndex(veth)
+			if err != nil {
+				return fmt.Errorf("unable to retrieve index of veth peer %s: %s", vethHostName, err)
+			}
+
+			addrs, err := netlink.AddrList(link, netlink.FAMILY_V4)
+			if err != nil {
+				return fmt.Errorf("unable to list addresses for link %s: %s", link.Attrs().Name, err)
+			}
+
+			if len(addrs) < 1 {
+				return fmt.Errorf("no address configured inside container")
+			}
+
+			vethIP = addrs[0].IPNet.IP.String()
+			return nil
+		}
+
+		return fmt.Errorf("no link found inside container")
+	}); err != nil {
+		return
+	}
+
+	peer, err = netlink.LinkByIndex(peerIndex)
+	if err != nil {
+		err = fmt.Errorf("unable to lookup link %d: %s", peerIndex, err)
+		return
+	}
+
+	hostMac = peer.Attrs().HardwareAddr.String()
+	vethHostName = peer.Attrs().Name
+	vethHostIdx = peer.Attrs().Index
+
+	switch {
+	case vethHostName == "":
+		err = errors.New("unable to determine name of veth pair on the host side")
+		return
+	case vethLXCMac == "":
+		err = errors.New("unable to determine MAC address of veth pair on the container side")
+		return
+	case vethIP == "":
+		err = errors.New("unable to determine IP address of the container")
+		return
+	case vethHostIdx == 0:
+		err = errors.New("unable to determine index interface of veth pair on the host side")
+		return
+	}
+
+	var enabled = true
+	ep := &models.EndpointChangeRequest{
+		Addressing: &models.AddressPair{
+			IPV4: vethIP,
+		},
+		ContainerID:       pluginCtx.Args.ContainerID,
+		State:             models.EndpointStateWaitingForIdentity,
+		HostMac:           hostMac,
+		InterfaceIndex:    int64(vethHostIdx),
+		Mac:               vethLXCMac,
+		InterfaceName:     vethHostName,
+		K8sPodName:        string(pluginCtx.CniArgs.K8S_POD_NAME),
+		K8sNamespace:      string(pluginCtx.CniArgs.K8S_POD_NAMESPACE),
+		SyncBuildEndpoint: true,
+		DatapathConfiguration: &models.EndpointDatapathConfiguration{
+			// aws-cni requires ARP passthrough between Linux and
+			// the pod
+			RequireArpPassthrough: true,
+
+			// The route is pointing directly into the veth of the
+			// pod, install a host-facing egress program to
+			// implement ingress policy and to provide reverse NAT
+			RequireEgressProg: true,
+
+			// The IP is managed by the aws-cni plugin, no need for
+			// Cilium to manage any aspect of addressing
+			ExternalIPAM: true,
+
+			// All routing is performed by the Linux stack
+			RequireRouting: &enabled,
+		},
+	}
+
+	err = pluginCtx.Client.EndpointCreate(ep)
+	if err != nil {
+		pluginCtx.Logger.WithError(err).WithFields(logrus.Fields{
+			logfields.ContainerID: ep.ContainerID}).Warn("Unable to create endpoint")
+		err = fmt.Errorf("unable to create endpoint: %s", err)
+		return
+	}
+
+	pluginCtx.Logger.WithFields(logrus.Fields{
+		logfields.ContainerID: ep.ContainerID}).Debug("Endpoint successfully created")
+
+	res = prevRes
+
+	return
+}
+
+func (f *genericVethChainer) ImplementsDelete() bool {
+	return true
+}
+
+func (f *genericVethChainer) Delete(ctx context.Context, pluginCtx chainingapi.PluginContext) (err error) {
+	id := endpointid.NewID(endpointid.ContainerIdPrefix, pluginCtx.Args.ContainerID)
+	if err := pluginCtx.Client.EndpointDelete(id); err != nil {
+		// EndpointDelete returns an error in the following scenarios:
+		// DeleteEndpointIDInvalid: Invalid delete parameters, no need to retry
+		// DeleteEndpointIDNotFound: No need to retry
+		// DeleteEndpointIDErrors: Errors encountered while deleting,
+		//                         the endpoint is always deleted though, no
+		//                         need to retry
+		// ClientError: Various reasons, type will be ClientError and
+		//              Recoverable() will return true if error can be
+		//              retried
+		if clientError, ok := err.(client.ClientError); ok {
+			if clientError.Recoverable() {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func init() {
+	chainingapi.Register("generic-veth", &genericVethChainer{})
+}

--- a/plugins/cilium-cni/chaining/generic-veth/generic-veth.go
+++ b/plugins/cilium-cni/chaining/generic-veth/generic-veth.go
@@ -37,13 +37,13 @@ var (
 	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "generic-veth")
 )
 
-type genericVethChainer struct{}
+type GenericVethChainer struct{}
 
-func (f *genericVethChainer) ImplementsAdd() bool {
+func (f *GenericVethChainer) ImplementsAdd() bool {
 	return true
 }
 
-func (f *genericVethChainer) Add(ctx context.Context, pluginCtx chainingapi.PluginContext) (res *cniTypesVer.Result, err error) {
+func (f *GenericVethChainer) Add(ctx context.Context, pluginCtx chainingapi.PluginContext) (res *cniTypesVer.Result, err error) {
 	err = cniVersion.ParsePrevResult(&pluginCtx.NetConf.NetConf)
 	if err != nil {
 		err = fmt.Errorf("unable to understand network config: %s", err)
@@ -195,11 +195,11 @@ func (f *genericVethChainer) Add(ctx context.Context, pluginCtx chainingapi.Plug
 	return
 }
 
-func (f *genericVethChainer) ImplementsDelete() bool {
+func (f *GenericVethChainer) ImplementsDelete() bool {
 	return true
 }
 
-func (f *genericVethChainer) Delete(ctx context.Context, pluginCtx chainingapi.PluginContext) (err error) {
+func (f *GenericVethChainer) Delete(ctx context.Context, pluginCtx chainingapi.PluginContext) (err error) {
 	id := endpointid.NewID(endpointid.ContainerIdPrefix, pluginCtx.Args.ContainerID)
 	if err := pluginCtx.Client.EndpointDelete(id); err != nil {
 		// EndpointDelete returns an error in the following scenarios:
@@ -221,5 +221,5 @@ func (f *genericVethChainer) Delete(ctx context.Context, pluginCtx chainingapi.P
 }
 
 func init() {
-	chainingapi.Register("generic-veth", &genericVethChainer{})
+	chainingapi.Register("generic-veth", &GenericVethChainer{})
 }

--- a/plugins/cilium-cni/chaining/portmap/portmap.go
+++ b/plugins/cilium-cni/chaining/portmap/portmap.go
@@ -32,6 +32,14 @@ func (p *portmapChainer) Add(ctx context.Context, pluginCtx chainingapi.PluginCo
 	return nil, nil
 }
 
+func (p *portmapChainer) ImplementsDelete() bool {
+	return false
+}
+
+func (p *portmapChainer) Delete(ctx context.Context, pluginCtx chainingapi.PluginContext) (err error) {
+	return nil
+}
+
 func init() {
 	chainingapi.Register("portmap", &portmapChainer{})
 }

--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cilium/cilium/pkg/version"
 	chainingapi "github.com/cilium/cilium/plugins/cilium-cni/chaining/api"
 	_ "github.com/cilium/cilium/plugins/cilium-cni/chaining/flannel"
+	_ "github.com/cilium/cilium/plugins/cilium-cni/chaining/generic-veth"
 	_ "github.com/cilium/cilium/plugins/cilium-cni/chaining/portmap"
 	"github.com/cilium/cilium/plugins/cilium-cni/types"
 

--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cilium/cilium/pkg/uuid"
 	"github.com/cilium/cilium/pkg/version"
 	chainingapi "github.com/cilium/cilium/plugins/cilium-cni/chaining/api"
+	_ "github.com/cilium/cilium/plugins/cilium-cni/chaining/awscni"
 	_ "github.com/cilium/cilium/plugins/cilium-cni/chaining/flannel"
 	_ "github.com/cilium/cilium/plugins/cilium-cni/chaining/generic-veth"
 	_ "github.com/cilium/cilium/plugins/cilium-cni/chaining/portmap"

--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -265,18 +265,21 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 		routes   []*cniTypes.Route
 		ipam     *models.IPAMResponse
 		n        *types.NetConf
-		cniVer   string
 		c        *client.Client
 		netNs    ns.NetNS
 	)
 
 	logger := log.WithField("eventUUID", uuid.NewUUID())
-	logger.WithField("args", args).Debug("Processing CNI ADD request")
+	logger.Debugf("Processing CNI ADD request %#v", args)
 
-	n, cniVer, err = types.LoadNetConf(args.StdinData)
+	n, err = types.LoadNetConf(args.StdinData)
 	if err != nil {
 		err = fmt.Errorf("unable to parse CNI configuration \"%s\": %s", args.StdinData, err)
 		return
+	}
+	logger.Debugf("CNI NetConf: %#v", n)
+	if n.PrevResult != nil {
+		logger.Debugf("CNI Previous result: %#v", n.PrevResult)
 	}
 
 	cniArgs := types.ArgsSpec{}
@@ -284,6 +287,7 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 		err = fmt.Errorf("unable to extract CNI arguments: %s", err)
 		return
 	}
+	logger.Debugf("CNI Args: %#v", cniArgs)
 
 	c, err = client.NewDefaultClientWithTimeout(defaults.ClientConnectTimeout)
 	if err != nil {
@@ -296,12 +300,11 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 			var (
 				res *cniTypesVer.Result
 				ctx = chainingapi.PluginContext{
-					Logger:     logger,
-					Args:       args,
-					CniArgs:    cniArgs,
-					NetConf:    n,
-					CniVersion: cniVer,
-					Client:     c,
+					Logger:  logger,
+					Args:    args,
+					CniArgs: cniArgs,
+					NetConf: n,
+					Client:  c,
 				}
 			)
 
@@ -310,7 +313,9 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 				if err != nil {
 					return
 				}
-				return cniTypes.PrintResult(res, cniVer)
+				logger.Debugf("Returning result %#v", res)
+				err = cniTypes.PrintResult(res, n.CNIVersion)
+				return
 			}
 		} else {
 			logger.Warnf("Unknown CNI chaining configuration name '%s'", n.Name)
@@ -496,7 +501,7 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 
 	logger.WithFields(logrus.Fields{
 		logfields.ContainerID: ep.ContainerID}).Debug("Endpoint successfully created")
-	return cniTypes.PrintResult(res, cniVer)
+	return cniTypes.PrintResult(res, n.CNIVersion)
 }
 
 func cmdDel(args *skel.CmdArgs) error {
@@ -505,17 +510,19 @@ func cmdDel(args *skel.CmdArgs) error {
 	// are guaranteed to be recoverable.
 
 	logger := log.WithField("eventUUID", uuid.NewUUID())
-	logger.WithField("args", args).Debug("Processing CNI DEL request")
+	logger.Debugf("Processing CNI DEL request %#v", args)
 
-	n, cniVer, err := types.LoadNetConf(args.StdinData)
+	n, err := types.LoadNetConf(args.StdinData)
 	if err != nil {
 		return err
 	}
+	logger.Debugf("CNI NetConf: %#v", n)
 
 	cniArgs := types.ArgsSpec{}
 	if err = cniTypes.LoadArgs(args.Args, &cniArgs); err != nil {
 		return fmt.Errorf("unable to extract CNI arguments: %s", err)
 	}
+	logger.Debugf("CNI Args: %#v", cniArgs)
 
 	c, err := client.NewDefaultClientWithTimeout(defaults.ClientConnectTimeout)
 	if err != nil {
@@ -526,12 +533,11 @@ func cmdDel(args *skel.CmdArgs) error {
 	if chainAction := chainingapi.Lookup(n.Name); chainAction != nil {
 		var (
 			ctx = chainingapi.PluginContext{
-				Logger:     logger,
-				Args:       args,
-				CniArgs:    cniArgs,
-				NetConf:    n,
-				CniVersion: cniVer,
-				Client:     c,
+				Logger:  logger,
+				Args:    args,
+				CniArgs: cniArgs,
+				NetConf: n,
+				Client:  c,
 			}
 		)
 

--- a/plugins/cilium-cni/cni-install.sh
+++ b/plugins/cilium-cni/cni-install.sh
@@ -23,6 +23,9 @@ case "$CILIUM_CNI_CHAINING_MODE" in
 "portmap")
 	CNI_CONF_NAME=${CNI_CONF_NAME:-05-cilium.conflist}
 	;;
+"aws-cni")
+	CNI_CONF_NAME=${CNI_CONF_NAME:-05-cilium.conflist}
+	;;
 *)
 	CNI_CONF_NAME=${CNI_CONF_NAME:-05-cilium.conf}
 	;;
@@ -102,6 +105,30 @@ EOF
     {
       "type": "portmap",
       "capabilities": {"portMappings": true},
+    }
+  ]
+}
+EOF
+	;;
+
+"aws-cni")
+	cat > ${CNI_CONF_NAME} <<EOF
+{
+  "name": "aws-cni",
+  "plugins": [
+    {
+      "name": "aws-cni",
+      "type": "aws-cni",
+      "vethPrefix": "eni"
+    },
+    {
+      "type": "portmap",
+      "capabilities": {"portMappings": true},
+      "snat": true
+    },
+    {
+       "name": "cilium",
+       "type": "cilium-cni"
     }
   ]
 }

--- a/plugins/cilium-cni/cni-install.sh
+++ b/plugins/cilium-cni/cni-install.sh
@@ -17,6 +17,9 @@ case "$CILIUM_CNI_CHAINING_MODE" in
 	done
 	CNI_CONF_NAME=${CNI_CONF_NAME:-04-flannel-cilium-cni.conflist}
 	;;
+"generic-veth")
+	CNI_CONF_NAME=${CNI_CONF_NAME:-05-cilium.conflist}
+	;;
 "portmap")
 	CNI_CONF_NAME=${CNI_CONF_NAME:-05-cilium.conflist}
 	;;


### PR DESCRIPTION
This PR introduces two new aspecs:

**Generic veth CNI plugin:**

This generic plugin identifies a veth peer in the container namespace and
extracts all relevant information from it, creates a Cilium endpoint and
instructs Cilium to install ingress and egress programs.

It can be used to build chaining with any veth-based CNI plugin.

**AWS CNI chaining mode:**

Building on top of the generic veth CNI plugin, an AWS CNI specific mode is introduced which written the appropriate CNI configuration file to chain aws-cni .+ portmap + Cilium.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7862)
<!-- Reviewable:end -->
