### PR TITLE
ginko: adjust timeout to something more appropriate

### DIFF
--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -75,7 +75,7 @@ pipeline {
             }
 
             options {
-                timeout(time: 75, unit: 'MINUTES')
+                timeout(time: 110, unit: 'MINUTES')
             }
 
             steps {


### PR DESCRIPTION
Looking at the Cilium 1.5 main CI runs under ...

  https://jenkins.cilium.io/view/Cilium-v1.5/job/cilium-v1.5-standard/

... the timeout of 1h 15 min is way too short. Runs did finish successfully
in the range of 1h 10min, 1h 13min, for example, but others got aborted
at 1h 16min. Increase it to 110 min so that we hit aborts less frequent,
only if something is really off.

Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7863)
<!-- Reviewable:end -->
