### PR TITLE
bpf: Set BPF_F_NO_PREALLOC before comparing maps

### DIFF
--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -979,6 +979,8 @@ func (m *Map) resolveErrors(ctx context.Context) error {
 // Returns true if the map was upgraded.
 func (m *Map) CheckAndUpgrade(desired *MapInfo) bool {
 	desiredMapType := GetMapType(desired.MapType)
+	desired.Flags |= GetPreAllocateMapFlags(desired.MapType)
+
 	return objCheck(
 		m.fd,
 		m.path,


### PR DESCRIPTION
Previously, the `bpf.Map.CheckAndUpgrade` method didn't take into consideration the `--preallocate-bpf-maps` flag of the cilium-agent. Therefore, in the case of the map with `type=BPF_MAP_TYPE_HASH` and
`flags=BPF_F_NO_PREALLOC(0x1)`, it was wrongly detecting that the map needs to be updated (= removed and recreated).

This lead to the CT maps w/o prealloc on older kernels to be destroyed each time cilium-agent has restarted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7866)
<!-- Reviewable:end -->
