### PR TITLE
pkg/health: Fix IPv6 URL format in HTTP probe

### DIFF
--- a/pkg/health/server/prober.go
+++ b/pkg/health/server/prober.go
@@ -15,8 +15,8 @@
 package server
 
 import (
-	"fmt"
 	"net"
+	"strconv"
 	"strings"
 	"time"
 
@@ -229,7 +229,7 @@ func (p *prober) setNodes(nodes nodeMap) {
 func (p *prober) httpProbe(node string, ip string, port int) *models.ConnectivityStatus {
 	result := &models.ConnectivityStatus{}
 
-	host := fmt.Sprintf("http://%s:%d", ip, port)
+	host := "http://" + net.JoinHostPort(ip, strconv.Itoa(port))
 	scopedLog := log.WithFields(logrus.Fields{
 		logfields.NodeName: node,
 		logfields.IPAddr:   ip,
@@ -249,7 +249,7 @@ func (p *prober) httpProbe(node string, ip string, port int) *models.Connectivit
 			result.Latency = rtt.Nanoseconds()
 		} else {
 			scopedLog.WithError(err).Debug("Greeting snubbed")
-			result.Status = "Connection timed out"
+			result.Status = err.Error()
 		}
 	} else {
 		scopedLog.WithError(err).Info("Failed to express greeting to host")


### PR DESCRIPTION
The current URL address formatting for HTTP probes does not support
IPv6 literal addresses very well. Since an IPv6 address itself
contains ':' it should be enclosed within '[' and ']' to be able to
properly parse the port from the address.

E.g for an endpoint `f00d::a10:0:0:a26e`, we will make an HTTP request:
`http://f00d::a10:0:0:a26e:4240/v1beta/hello` which throws an error:
`Get http://f00d::a10:0:0:a26e:4240/v1beta/hello: invalid URL port ":a10:0:0:a26e:4240"`.

Instead, the request could be something like:
`http://[f00d::a10:0:0:a26e]:4240/v1beta/hello`

* Enclose health endpoint addresses within brackets during HTTP probe.
  This doesn't affect the behavior for IPv4 literal addresses.
* In case of an error, set the probe result `status` to the error
  message instead of the generic 'Connection timed out' message.
  If there aren't already reasons for having the generic message, then
  it might help the user debug probe issues.

Fixes #7804

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7869)
<!-- Reviewable:end -->
