### PR TITLE
CI: Log at INFO and above for all unit tests

### DIFF
--- a/pkg/clustermesh/clustermesh_test.go
+++ b/pkg/clustermesh/clustermesh_test.go
@@ -29,10 +29,8 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/lock"
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/testutils"
 
-	"github.com/sirupsen/logrus"
 	. "gopkg.in/check.v1"
 )
 
@@ -108,8 +106,6 @@ func (i *identityAllocatorOwnerMock) GetNodeSuffix() string {
 func (s *ClusterMeshTestSuite) TestClusterMesh(c *C) {
 	kvstore.SetupDummy("etcd")
 	defer kvstore.Close()
-
-	logging.DefaultLogger.SetLevel(logrus.DebugLevel)
 
 	cache.InitIdentityAllocator(&identityAllocatorOwnerMock{})
 	defer cache.Close()

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -28,10 +28,8 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/types"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/loadbalancer"
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/testutils"
 
-	"github.com/sirupsen/logrus"
 	. "gopkg.in/check.v1"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -63,7 +61,6 @@ func (s *ClusterMeshServicesTestSuite) SetUpTest(c *C) {
 
 	kvstore.DeletePrefix("cilium/state/services/v1/" + s.randomName)
 	s.svcCache = k8s.NewServiceCache()
-	logging.DefaultLogger.SetLevel(logrus.DebugLevel)
 	cache.InitIdentityAllocator(&identityAllocatorOwnerMock{})
 	dir, err := ioutil.TempDir("", "multicluster")
 	s.testDir = dir

--- a/pkg/envoy/envoy_test.go
+++ b/pkg/envoy/envoy_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 
-	"github.com/sirupsen/logrus"
 	. "gopkg.in/check.v1"
 )
 
@@ -69,7 +68,6 @@ func (s *EnvoySuite) TestEnvoy(c *C) {
 	option.Config.Populate()
 	option.Config.ProxyConnectTimeout = 1
 	c.Assert(option.Config.ProxyConnectTimeout, Not(Equals), 0)
-	log.Logger.SetLevel(logrus.DebugLevel)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -142,7 +140,6 @@ func (s *EnvoySuite) TestEnvoy(c *C) {
 }
 
 func (s *EnvoySuite) TestEnvoyNACK(c *C) {
-	log.Logger.SetLevel(logrus.DebugLevel)
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Second)
 	defer cancel()
 

--- a/pkg/proxy/kafka_test.go
+++ b/pkg/proxy/kafka_test.go
@@ -172,12 +172,6 @@ func (m *metadataTester) Handler() RequestHandler {
 }
 
 func (k *proxyTestSuite) TestKafkaRedirect(c *C) {
-	// this isn't thread safe but there is no function to get it
-	// SetLevel is atomic, however.
-	oldLevel := log.Level
-	defer log.Logger.SetLevel(oldLevel)
-	log.Logger.SetLevel(logrus.DebugLevel)
-
 	server := NewServer()
 	server.Start()
 	defer server.Close()

--- a/proxylib/npds/client_test.go
+++ b/proxylib/npds/client_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/envoy"
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/proxylib/test"
 
 	"github.com/cilium/proxy/go/cilium/api"
@@ -34,7 +33,6 @@ import (
 
 // Hook up gocheck into the "go test" runner.
 func Test(t *testing.T) {
-	logging.ToggleDebugLogs(true)
 	TestingT(t)
 }
 

--- a/proxylib/proxylib/input_test.go
+++ b/proxylib/proxylib/input_test.go
@@ -19,14 +19,11 @@ package proxylib
 import (
 	"testing"
 
-	"github.com/cilium/cilium/pkg/logging"
-
 	. "gopkg.in/check.v1"
 )
 
 // Hook up gocheck into the "go test" runner.
 func Test(t *testing.T) {
-	logging.ToggleDebugLogs(true)
 	TestingT(t)
 }
 

--- a/proxylib/proxylib_memcached_test.go
+++ b/proxylib/proxylib_memcached_test.go
@@ -126,7 +126,7 @@ func TestMemcache(t *testing.T) {
 			logServer := test.StartAccessLogServer("access_log.sock", 10)
 			defer logServer.Close()
 
-			mod := OpenModule([][2]string{{"access-log-path", logServer.Path}}, true)
+			mod := OpenModule([][2]string{{"access-log-path", logServer.Path}}, false)
 			if mod == 0 {
 				t.Errorf("OpenModule() with access log path %s failed", logServer.Path)
 			} else {

--- a/proxylib/proxylib_test.go
+++ b/proxylib/proxylib_test.go
@@ -31,14 +31,16 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const debug = false
+
 func TestOpenModule(t *testing.T) {
-	mod1 := OpenModule([][2]string{}, true)
+	mod1 := OpenModule([][2]string{}, debug)
 	if mod1 == 0 {
 		t.Error("OpenModule() with empty params failed")
 	} else {
 		defer CloseModule(mod1)
 	}
-	mod2 := OpenModule([][2]string{}, true)
+	mod2 := OpenModule([][2]string{}, debug)
 	if mod2 == 0 {
 		t.Error("OpenModule() with empty params failed")
 	} else {
@@ -48,7 +50,7 @@ func TestOpenModule(t *testing.T) {
 		t.Error("OpenModule() with empty params called again opened a new module")
 	}
 
-	mod3 := OpenModule([][2]string{{"dummy-key", "dummy-value"}, {"key2", "value2"}}, true)
+	mod3 := OpenModule([][2]string{{"dummy-key", "dummy-value"}, {"key2", "value2"}}, debug)
 	if mod3 != 0 {
 		t.Error("OpenModule() with unknown params accepted")
 		defer CloseModule(mod3)
@@ -57,7 +59,7 @@ func TestOpenModule(t *testing.T) {
 	logServer := test.StartAccessLogServer("access_log.sock", 10)
 	defer logServer.Close()
 
-	mod4 := OpenModule([][2]string{{"access-log-path", logServer.Path}}, true)
+	mod4 := OpenModule([][2]string{{"access-log-path", logServer.Path}}, debug)
 	if mod4 == 0 {
 		t.Errorf("OpenModule() with access log path %s failed", logServer.Path)
 	} else {
@@ -67,7 +69,7 @@ func TestOpenModule(t *testing.T) {
 		t.Error("OpenModule() should have returned a different module")
 	}
 
-	mod5 := OpenModule([][2]string{{"access-log-path", logServer.Path}, {"node-id", "host~127.0.0.1~libcilium~localdomain"}}, true)
+	mod5 := OpenModule([][2]string{{"access-log-path", logServer.Path}, {"node-id", "host~127.0.0.1~libcilium~localdomain"}}, debug)
 	if mod5 == 0 {
 		t.Errorf("OpenModule() with access log path %s failed", logServer.Path)
 	} else {
@@ -79,7 +81,7 @@ func TestOpenModule(t *testing.T) {
 }
 
 func TestOnNewConnection(t *testing.T) {
-	mod := OpenModule([][2]string{}, true)
+	mod := OpenModule([][2]string{}, debug)
 	if mod == 0 {
 		t.Error("OpenModule() with empty params failed")
 	} else {
@@ -154,7 +156,7 @@ func TestOnDataNoPolicy(t *testing.T) {
 	logServer := test.StartAccessLogServer("access_log.sock", 10)
 	defer logServer.Close()
 
-	mod := OpenModule([][2]string{{"access-log-path", logServer.Path}}, true)
+	mod := OpenModule([][2]string{{"access-log-path", logServer.Path}}, debug)
 	if mod == 0 {
 		t.Errorf("OpenModule() with access log path %s failed", logServer.Path)
 	} else {
@@ -214,7 +216,7 @@ func TestOnDataPanic(t *testing.T) {
 	logServer := test.StartAccessLogServer("access_log.sock", 10)
 	defer logServer.Close()
 
-	mod := OpenModule([][2]string{{"access-log-path", logServer.Path}}, true)
+	mod := OpenModule([][2]string{{"access-log-path", logServer.Path}}, debug)
 	if mod == 0 {
 		t.Errorf("OpenModule() with access log path %s failed", logServer.Path)
 	} else {
@@ -255,7 +257,7 @@ func TestUnsupportedL7Drops(t *testing.T) {
 	logServer := test.StartAccessLogServer("access_log.sock", 10)
 	defer logServer.Close()
 
-	mod := OpenModule([][2]string{{"access-log-path", logServer.Path}}, true)
+	mod := OpenModule([][2]string{{"access-log-path", logServer.Path}}, debug)
 	if mod == 0 {
 		t.Errorf("OpenModule() with access log path %s failed", logServer.Path)
 	} else {
@@ -304,7 +306,7 @@ func TestUnsupportedL7DropsGeneric(t *testing.T) {
 	logServer := test.StartAccessLogServer("access_log.sock", 10)
 	defer logServer.Close()
 
-	mod := OpenModule([][2]string{{"access-log-path", logServer.Path}}, true)
+	mod := OpenModule([][2]string{{"access-log-path", logServer.Path}}, debug)
 	if mod == 0 {
 		t.Errorf("OpenModule() with access log path %s failed", logServer.Path)
 	} else {
@@ -357,7 +359,7 @@ func TestTwoRulesOnSamePortFirstNoL7(t *testing.T) {
 	logServer := test.StartAccessLogServer("access_log.sock", 10)
 	defer logServer.Close()
 
-	mod := OpenModule([][2]string{{"access-log-path", logServer.Path}}, true)
+	mod := OpenModule([][2]string{{"access-log-path", logServer.Path}}, debug)
 	if mod == 0 {
 		t.Errorf("OpenModule() with access log path %s failed", logServer.Path)
 	} else {
@@ -391,7 +393,7 @@ func TestTwoRulesOnSamePortFirstNoL7Generic(t *testing.T) {
 	logServer := test.StartAccessLogServer("access_log.sock", 10)
 	defer logServer.Close()
 
-	mod := OpenModule([][2]string{{"access-log-path", logServer.Path}}, true)
+	mod := OpenModule([][2]string{{"access-log-path", logServer.Path}}, debug)
 	if mod == 0 {
 		t.Errorf("OpenModule() with access log path %s failed", logServer.Path)
 	} else {
@@ -434,7 +436,7 @@ func TestTwoRulesOnSamePortMismatchingL7(t *testing.T) {
 	logServer := test.StartAccessLogServer("access_log.sock", 10)
 	defer logServer.Close()
 
-	mod := OpenModule([][2]string{{"access-log-path", logServer.Path}}, true)
+	mod := OpenModule([][2]string{{"access-log-path", logServer.Path}}, debug)
 	if mod == 0 {
 		t.Errorf("OpenModule() with access log path %s failed", logServer.Path)
 	} else {
@@ -495,7 +497,7 @@ func TestSimplePolicy(t *testing.T) {
 	logServer := test.StartAccessLogServer("access_log.sock", 10)
 	defer logServer.Close()
 
-	mod := OpenModule([][2]string{{"access-log-path", logServer.Path}}, true)
+	mod := OpenModule([][2]string{{"access-log-path", logServer.Path}}, debug)
 	if mod == 0 {
 		t.Errorf("OpenModule() with access log path %s failed", logServer.Path)
 	} else {
@@ -554,7 +556,7 @@ func TestAllowAllPolicy(t *testing.T) {
 	logServer := test.StartAccessLogServer("access_log.sock", 10)
 	defer logServer.Close()
 
-	mod := OpenModule([][2]string{{"access-log-path", logServer.Path}}, true)
+	mod := OpenModule([][2]string{{"access-log-path", logServer.Path}}, debug)
 	if mod == 0 {
 		t.Errorf("OpenModule() with access log path %s failed", logServer.Path)
 	} else {
@@ -599,7 +601,7 @@ func TestAllowEmptyPolicy(t *testing.T) {
 	logServer := test.StartAccessLogServer("access_log.sock", 10)
 	defer logServer.Close()
 
-	mod := OpenModule([][2]string{{"access-log-path", logServer.Path}}, true)
+	mod := OpenModule([][2]string{{"access-log-path", logServer.Path}}, debug)
 	if mod == 0 {
 		t.Errorf("OpenModule() with access log path %s failed", logServer.Path)
 	} else {


### PR DESCRIPTION
By default all unit test suites already log at INFO level.
However, there are currently a few test suites that explicitly
enable DEBUG log levels.
This commit turns DEBUG back off for these tests.

Fixes #7867

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7870)
<!-- Reviewable:end -->
