### PR TITLE
Rebase policy trace to use L3 policy resolve in L4PolicyMap

### DIFF
--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -374,7 +374,7 @@ func (s *K8sSuite) TestParseNetworkPolicyEgress(c *C) {
 	}
 
 	// ctx.From needs to have all labels from the policy in order to be accepted
-	c.Assert(repo.CanReachEgressRLocked(&ctx), Not(Equals), api.Allowed)
+	c.Assert(repo.AllowsEgressRLocked(&ctx), Not(Equals), api.Allowed)
 
 	ctx = policy.SearchContext{
 		To: labels.LabelArray{
@@ -388,7 +388,7 @@ func (s *K8sSuite) TestParseNetworkPolicyEgress(c *C) {
 	}
 
 	// ctx.To also needs to have all labels from the policy in order to be accepted.
-	c.Assert(repo.CanReachEgressRLocked(&ctx), Not(Equals), api.Allowed)
+	c.Assert(repo.AllowsEgressRLocked(&ctx), Not(Equals), api.Allowed)
 }
 
 func parseAndAddRules(c *C, p *networkingv1.NetworkPolicy) *policy.Repository {
@@ -415,7 +415,7 @@ func (s *K8sSuite) TestParseNetworkPolicyEgressAllowAll(c *C) {
 	})
 
 	c.Assert(repo.AllowsEgressRLocked(&ctxAToB), Equals, api.Allowed)
-	c.Assert(repo.CanReachEgressRLocked(&ctxAToC), Equals, api.Allowed)
+	c.Assert(repo.AllowsEgressRLocked(&ctxAToC), Equals, api.Allowed)
 
 	ctxAToC80 := ctxAToC
 	ctxAToC80.DPorts = []*models.Port{{Port: 80, Protocol: models.PortProtocolTCP}}

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -190,7 +190,7 @@ func (s *K8sSuite) TestParseNetworkPolicyIngress(c *C) {
 	}
 
 	// ctx.To needs to have all labels from the policy in order to be accepted
-	c.Assert(repo.CanReachIngressRLocked(&ctx), Not(Equals), api.Allowed)
+	c.Assert(repo.AllowsIngressRLocked(&ctx), Not(Equals), api.Allowed)
 
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
@@ -203,7 +203,7 @@ func (s *K8sSuite) TestParseNetworkPolicyIngress(c *C) {
 		Trace: policy.TRACE_VERBOSE,
 	}
 	// ctx.From also needs to have all labels from the policy in order to be accepted
-	c.Assert(repo.CanReachIngressRLocked(&ctx), Not(Equals), api.Allowed)
+	c.Assert(repo.AllowsIngressRLocked(&ctx), Not(Equals), api.Allowed)
 }
 
 func (s *K8sSuite) TestParseNetworkPolicyNoSelectors(c *C) {
@@ -552,7 +552,7 @@ func (s *K8sSuite) TestParseNetworkPolicyEmptyFrom(c *C) {
 
 	repo := policy.NewPolicyRepository()
 	repo.AddList(rules)
-	c.Assert(repo.CanReachIngressRLocked(&ctx), Equals, api.Allowed)
+	c.Assert(repo.AllowsIngressRLocked(&ctx), Equals, api.Allowed)
 
 	// Empty From rules, all sources should be allowed
 	netPolicy2 := &networkingv1.NetworkPolicy{
@@ -576,7 +576,7 @@ func (s *K8sSuite) TestParseNetworkPolicyEmptyFrom(c *C) {
 	c.Assert(len(rules), Equals, 1)
 	repo = policy.NewPolicyRepository()
 	repo.AddList(rules)
-	c.Assert(repo.CanReachIngressRLocked(&ctx), Equals, api.Allowed)
+	c.Assert(repo.AllowsIngressRLocked(&ctx), Equals, api.Allowed)
 }
 
 func (s *K8sSuite) TestParseNetworkPolicyDenyAll(c *C) {

--- a/pkg/policy/api/l4.go
+++ b/pkg/policy/api/l4.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -37,6 +37,18 @@ type PortProtocol struct {
 	//
 	// +optional
 	Protocol L4Proto `json:"protocol,omitempty"`
+}
+
+// Covers returns true if the ports and protocol specified in the received
+// PortProtocol are equal to or a superset of the ports and protocol in 'other'.
+func (p PortProtocol) Covers(other PortProtocol) bool {
+	if p.Port != other.Port {
+		return false
+	}
+	if p.Protocol != other.Protocol {
+		return p.Protocol == "" || p.Protocol == ProtoAny
+	}
+	return true
 }
 
 // PortRule is a list of ports/protocol combinations with optional Layer 7

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -35,11 +35,15 @@ const (
 	TRACE_VERBOSE
 )
 
+// TraceEnabled returns true if the SearchContext requests tracing.
+func (s *SearchContext) TraceEnabled() bool {
+	return s.Trace != TRACE_DISABLED
+}
+
 // PolicyTrace logs the given message into the SearchContext logger only if
 // TRACE_ENABLED or TRACE_VERBOSE is enabled in the receiver's SearchContext.
 func (s *SearchContext) PolicyTrace(format string, a ...interface{}) {
-	switch s.Trace {
-	case TRACE_ENABLED, TRACE_VERBOSE:
+	if s.TraceEnabled() {
 		log.Debugf(format, a...)
 		if s.Logging != nil {
 			format = "%-" + s.CallDepth() + "s" + format

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@ package policy
 
 import (
 	"fmt"
+	"io"
 	"strconv"
 	"strings"
 
@@ -104,6 +105,17 @@ func (s *SearchContext) String() string {
 
 func (s *SearchContext) CallDepth() string {
 	return strconv.Itoa(s.Depth * 2)
+}
+
+// WithLogger returns a shallow copy of the received SearchContext with the
+// logging set to write to 'log'.
+func (s *SearchContext) WithLogger(log io.Writer) *SearchContext {
+	result := *s
+	result.Logging = logging.NewLogBackend(log, "", 0)
+	if result.Trace == TRACE_DISABLED {
+		result.Trace = TRACE_ENABLED
+	}
+	return &result
 }
 
 // Translator is an interface for altering policy rules

--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -229,7 +229,7 @@ func (rules ruleSlice) resolveL4EgressPolicy(ctx *SearchContext, revision uint64
 	result := NewL4Policy()
 
 	ctx.PolicyTrace("\n")
-	ctx.PolicyTrace("Resolving egress port policy for %+v\n", ctx.To)
+	ctx.PolicyTrace("Resolving egress policy for %+v\n", ctx.From)
 
 	var requirements []v1.LabelSelectorRequirement
 

--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -186,7 +186,7 @@ func (rules ruleSlice) resolveL4IngressPolicy(ctx *SearchContext, revision uint6
 	result := NewL4Policy()
 
 	ctx.PolicyTrace("\n")
-	ctx.PolicyTrace("Resolving ingress port policy for %+v\n", ctx.To)
+	ctx.PolicyTrace("Resolving ingress policy for %+v\n", ctx.To)
 
 	state := traceState{}
 	var requirements []v1.LabelSelectorRequirement

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -201,7 +201,7 @@ var _ = Describe("K8sPolicyTest", func() {
 			}
 
 			trace := kubectl.CiliumExec(ciliumPod, fmt.Sprintf(
-				"cilium policy trace --src-k8s-pod default:%s --dst-k8s-pod default:%s --dport 80",
+				"cilium policy trace --src-k8s-pod default:%s --dst-k8s-pod default:%s --dport 80/TCP",
 				appPods[helpers.App2], appPods[helpers.App1]))
 			trace.ExpectSuccess(trace.CombineOutput().String())
 			trace.ExpectContains("Final verdict: ALLOWED", "Policy trace output mismatch")
@@ -297,7 +297,7 @@ var _ = Describe("K8sPolicyTest", func() {
 			}
 
 			trace := kubectl.CiliumExec(ciliumPod, fmt.Sprintf(
-				"cilium policy trace --src-k8s-pod default:%s --dst-k8s-pod default:%s --dport 80",
+				"cilium policy trace --src-k8s-pod default:%s --dst-k8s-pod default:%s --dport 80/TCP",
 				appPods[helpers.App2], appPods[helpers.App1]))
 			trace.ExpectSuccess(trace.CombineOutput().String())
 			trace.ExpectContains("Final verdict: ALLOWED", "Policy trace output mismatch")

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -1962,7 +1962,7 @@ var _ = Describe("RuntimePolicyImportTests", func() {
 
 		By("Verifying that trace says that %q can reach %q", httpd2Label, httpd1Label)
 
-		res := vm.Exec(fmt.Sprintf(`cilium policy trace -s %s -d %s`, httpd2Label, httpd1Label))
+		res := vm.Exec(fmt.Sprintf(`cilium policy trace -s %s -d %s/TCP`, httpd2Label, httpd1Label))
 		Expect(res.Output().String()).Should(ContainSubstring(allowedVerdict), "Policy trace did not contain %s", allowedVerdict)
 
 		endpointIDS, err := vm.GetEndpointsIds()


### PR DESCRIPTION
Recently, label-based policy was reworked to be implemented via the L4PolicyMap, and resolved as part of the same step as L4 policy resolution. However, the policy tracing remained using the old code paths. This PR seeks to rectify this by reworking the policy trace functions to extend the L4 policy trace to appropriately report messages during policy resolution, and to use this function for the policy trace paths.

The resulting code is a little simpler, which is nice. Most of the changes here are minor test fixups.

Here's an example of the updated text output for a trace where there are three rules:
* Allow from `reserved:host` and `any:foo` at L3
* Allow from `reserved:host` and `any:baz` on port 80
* Require traffic ingressing to `any:bar` to contain the labels `any:baz`.

It's disallowed, because the trace doesn't specify L4 port but the rule only allows port 80.
```
Tracing From: [any:baz] => To: [any:bar] Ports: [0/ANY]

Resolving ingress policy for [any:bar]                                          
* Rule {"matchLabels":{"any:bar":""}}: selected                                 
    Enforcing requirements [{Key:any.baz Operator:In Values:[]}]                
    Allows from labels {"matchLabels":{"reserved:host":""},"matchExpressions":[{"key":"any:baz","operator":"In","values":[""]}]}
    Allows from labels {"matchLabels":{"any:foo":""},"matchExpressions":[{"key":"any:baz","operator":"In","values":[""]}]}
      No label match for [any:baz]                                              
* Rule {"matchLabels":{"any:bar":""}}: selected                                 
    Enforcing requirements [{Key:any.baz Operator:In Values:[]}]                
    Allows from labels {"matchLabels":{"reserved:host":""},"matchExpressions":[{"key":"any:baz","operator":"In","values":[""]}]}
    Allows from labels {"matchLabels":{"any:baz":""},"matchExpressions":[{"key":"any:baz","operator":"In","values":[""]}]}
      Found all required labels                                                 
      Allows port [{80 ANY}]                                                    
        No port match found                                                     
* Rule {"matchLabels":{"any:bar":""}}: selected                                 
    Enforcing requirements [{Key:any.baz Operator:In Values:[]}]                
      Found all required labels                                                 
3/3 rules selected                                                              
Found no allow rule                                                             
Ingress verdict: denied
```

TODO:
* [x] Validate tests pass
* [x] Update documentation examples
  * Prepared additional commit, can open another PR or update this one

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7871)
<!-- Reviewable:end -->
