### PR TITLE
CI: Disable RuntimeMonitorTest With Sample Containers Cilium monitor event types

### DIFF
--- a/test/runtime/monitor.go
+++ b/test/runtime/monitor.go
@@ -113,6 +113,7 @@ var _ = Describe("RuntimeMonitorTest", func() {
 		})
 
 		It("Cilium monitor event types", func() {
+			Skip("Disabled flake: https://github.com/cilium/cilium/issues/7872")
 
 			monitorConfig()
 


### PR DESCRIPTION
This began failing often sometime around April 26. See https://github.com/cilium/cilium/issues/7872

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7874)
<!-- Reviewable:end -->
