### PR TITLE
CI: Stop monitor after all test assertions

### DIFF
--- a/test/runtime/monitor.go
+++ b/test/runtime/monitor.go
@@ -113,8 +113,6 @@ var _ = Describe("RuntimeMonitorTest", func() {
 		})
 
 		It("Cilium monitor event types", func() {
-			Skip("Disabled flake: https://github.com/cilium/cilium/issues/7872")
-
 			monitorConfig()
 
 			_, err := vm.PolicyImportAndWait(vm.GetFullPath(policiesL3JSON), helpers.HelperTimeout)
@@ -139,11 +137,11 @@ var _ = Describe("RuntimeMonitorTest", func() {
 				vm.ContainerExec(helpers.App1, helpers.Ping(helpers.Httpd1))
 				vm.ContainerExec(helpers.App3, helpers.Ping(helpers.Httpd1))
 
-				cancel()
 				Expect(res.WaitUntilMatch(v)).To(BeNil(),
 					"%q is not in the output after timeout", v)
 				Expect(res.CountLines()).Should(BeNumerically(">", 3))
 				Expect(res.Output().String()).Should(ContainSubstring(v))
+				cancel()
 			}
 
 			By("all types together")


### PR DESCRIPTION
It is possible that the cancel call we make before checking the output
from monitor causes it to stop emitting events too soon. This moves the
cancel, thus the close, to after we definitively have passed or failed
that part of the test.


This has failed in a bunch of other exciting ways, but nothing that seemed directly related. I suspect it is benign to merge since we do similar things in other tests here.

Hopefully fixes https://github.com/cilium/cilium/issues/7872

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7875)
<!-- Reviewable:end -->
