### PR TITLE
CI: Check that cilium actually stops when desired

### DIFF
--- a/test/runtime/assertionHelpers.go
+++ b/test/runtime/assertionHelpers.go
@@ -53,6 +53,16 @@ func ExpectCiliumReady(vm *helpers.SSHMeta) {
 	ExpectWithOffset(1, res).To(helpers.CMDSuccess(), "Cannot set policy enforcement default")
 }
 
+// ExpectCiliumNotRunning checks that cilium has stopped with a grace period.
+func ExpectCiliumNotRunning(vm *helpers.SSHMeta) {
+	body := func() bool {
+		res := vm.Exec("systemctl is-active cilium")
+		return !res.WasSuccessful()
+	}
+	err := helpers.WithTimeout(body, "Cilium is still running after timeout", &helpers.TimeoutConfig{Timeout: helpers.CiliumStartTimeout})
+	ExpectWithOffset(1, err).To(BeNil(), "Cilium is still running after timeout")
+}
+
 // ExpectDockerContainersMatchCiliumEndpoints asserts that docker containers in
 // Cilium network match with the endpoint list
 func ExpectDockerContainersMatchCiliumEndpoints(vm *helpers.SSHMeta) {

--- a/test/runtime/fqdn.go
+++ b/test/runtime/fqdn.go
@@ -998,6 +998,7 @@ INITSYSTEM=SYSTEMD`
 
 		res = vm.ExecWithSudo("systemctl stop cilium")
 		res.ExpectSuccess("Failed trying to stop cilium via systemctl")
+		ExpectCiliumNotRunning(vm)
 
 		By("Testing connectivity from %q to the IP %q without DNS request", helpers.App1, targetIP)
 		res = vm.ContainerExec(helpers.App1, helpers.CurlFail("http://%s", targetIP))

--- a/test/runtime/kvstore.go
+++ b/test/runtime/kvstore.go
@@ -47,6 +47,7 @@ var _ = Describe("RuntimeKVStoreTest", func() {
 	BeforeEach(func() {
 		res := vm.ExecWithSudo("systemctl stop cilium")
 		res.ExpectSuccess("Failed trying to stop cilium via systemctl")
+		ExpectCiliumNotRunning(vm)
 	}, 150)
 
 	AfterEach(func() {

--- a/test/runtime/privileged_tests.go
+++ b/test/runtime/privileged_tests.go
@@ -31,6 +31,7 @@ var _ = Describe("RuntimePrivilegedUnitTests", func() {
 		vm = helpers.InitRuntimeHelper(helpers.Runtime, logger)
 		res := vm.ExecWithSudo("systemctl stop cilium")
 		res.ExpectSuccess("Failed trying to stop cilium via systemctl")
+		ExpectCiliumNotRunning(vm)
 	})
 
 	AfterAll(func() {

--- a/test/runtime/verifier.go
+++ b/test/runtime/verifier.go
@@ -38,6 +38,7 @@ var _ = Describe("RuntimeVerifier", func() {
 		By("Stopping Cilium")
 		res := vm.ExecWithSudo("systemctl stop cilium")
 		res.ExpectSuccess()
+		ExpectCiliumNotRunning(vm)
 		res = vm.ExecWithSudo("rm -f /sys/fs/bpf/tc/globals/cilium*")
 		res.ExpectSuccess()
 	})


### PR DESCRIPTION
In a few instances we attempt to shutdown cilium, but don't wait for it
to do so. We now check the systemd status in runtime tests that do this.

I saw this flake when testing https://github.com/cilium/cilium/pull/7847 with the BPF verifier failing. Hopefully this sorts it out in a few other places.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7876)
<!-- Reviewable:end -->
