### PR TITLE
fqdn / policy: plumb mapping of FQDNSelector --> set of IPs into SelectorCache

### DIFF
--- a/daemon/fqdn.go
+++ b/daemon/fqdn.go
@@ -107,13 +107,11 @@ func updateSelectorCache(selectors map[policyApi.FQDNSelector][]*identity.Identi
 	// Selectors which no longer map to IPs (due to TTL expiry, cache being
 	// cleared forcibly via CLI, etc.) still exist in the selector cache
 	// since policy is imported which allows it, but the selector does
-	// not match anything anymore.
-	for k := range selectorsWithoutIPs {
-		log.WithFields(logrus.Fields{
-			"fqdnSelectorString": selectorsWithoutIPs[k],
-		}).Debug("removing all identities from FQDN selector")
-		policy.UpdateFQDNSelector(selectorsWithoutIPs[k], []identity.NumericIdentity{})
-	}
+	// not map to any IPs anymore.
+	log.WithFields(logrus.Fields{
+		"fqdnSelectors": selectorsWithoutIPs,
+	}).Debug("removing all identities from FQDN selectors")
+	policy.RemoveIdentitiesFQDNSelectors(selectorsWithoutIPs)
 }
 
 // bootstrapFQDN initializes the toFQDNs related subsystems: DNSPoller,

--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -294,7 +294,7 @@ func (d *Daemon) policyAdd(sourceRules policyAPI.Rules, opts *AddOptions, resCha
 		}
 	}
 
-	if err := ipcache.AllocateCIDRs(bpfIPCache.IPCache, prefixes); err != nil {
+	if _, err := ipcache.AllocateCIDRs(bpfIPCache.IPCache, prefixes); err != nil {
 		_ = d.prefixLengths.Delete(prefixes)
 		metrics.PolicyImportErrors.Inc()
 		logger.WithError(err).WithField("prefixes", prefixes).Warn(

--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -252,11 +252,15 @@ func (d *Daemon) policyAdd(sourceRules policyAPI.Rules, opts *AddOptions, resCha
 	// CAUTION, there is a small race between this PrepareFQDNRules invocation and
 	// taking the policy lock. As long as policyAdd is fed by a single-threaded
 	// queue this should never be an issue.
-	rules := d.dnsRuleGen.PrepareFQDNRules(sourceRules)
+	// TODO - we do not update the SelectorCache with the mapping of selector to
+	// IPs here. This would allow us to pre-populate the SelectorCache with the
+	// IPs that already have been resolved which correspond to DNS names that
+	// are in the newly added rules.
+	rules, _ := d.dnsRuleGen.PrepareFQDNRules(sourceRules)
 	if len(rules) == 0 && len(sourceRules) > 0 {
 		// All rules being added have ToFQDNs UUIDs that have been removed and
 		// will not be re-inserted to avoid a race.
-		err := errors.New("PrepareFQDNRules delete all sourceRules due invalid UUIDs")
+		err := errors.New("PrepareFQDNRules delete all rules due invalid UUIDs")
 		resChan <- &PolicyAddResult{
 			newRev: 0,
 			err:    api.Error(PutPolicyFailureCode, err),

--- a/pkg/fqdn/config.go
+++ b/pkg/fqdn/config.go
@@ -15,6 +15,7 @@
 package fqdn
 
 import (
+	"net"
 	"time"
 
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -24,7 +25,7 @@ import (
 // Config is a simple configuration structure to set how pkg/fqdn subcomponents
 // behave.
 // DNSPoller relies on LookupDNSNames to control how DNS lookups are done, and
-// AddGeneratedRules to control how generated policy rules are emitted.
+// AddGeneratedRulesAndUpdateSelectors to control how generated policy rules are emitted.
 type Config struct {
 	// MinTTL is the time used by the poller to cache information.
 	// When set to 0, 2*DNSPollerInterval is used.
@@ -45,9 +46,10 @@ type Config struct {
 	// When set to nil, fqdn.DNSLookupDefaultResolver is used.
 	LookupDNSNames func(dnsNames []string) (DNSIPs map[string]*DNSIPRecords, errorDNSNames map[string]error)
 
-	// AddGeneratedRules is a callback  to emit generated rules.
+	// AddGeneratedRulesAndUpdateSelectors is a callback  to emit generated rules,
+	// as well as update the mapping of FQDNSelector to set of IPs.
 	// When set to nil, it is a no-op.
-	AddGeneratedRules func([]*api.Rule) error
+	AddGeneratedRulesAndUpdateSelectors func(generatedRules []*api.Rule, selectorsWithIPs map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) error
 
 	// PollerResponseNotify is used when the poller recieves DNS data in response
 	// to a successful poll.

--- a/pkg/fqdn/dnspoller.go
+++ b/pkg/fqdn/dnspoller.go
@@ -49,7 +49,7 @@ func StartDNSPoller(poller *DNSPoller) {
 // handled directly, but will depend on the resolver's behavior.
 // fqdn.Config can be opitonally used to set how the DNS lookups are
 // executed (via LookupDNSNames) and how generated policy rules are handled
-// (via AddGeneratedRules).
+// (via AddGeneratedRulesAndUpdateSelectors).
 type DNSPoller struct {
 	lock.Mutex // this guards both maps and their contents
 

--- a/pkg/fqdn/dnspoller_test.go
+++ b/pkg/fqdn/dnspoller_test.go
@@ -18,6 +18,7 @@ package fqdn
 
 import (
 	"context"
+	"net"
 
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/miekg/dns"
@@ -151,8 +152,7 @@ func (ds *FQDNTestSuite) TestRuleGenRuleHandling(c *C) {
 					return lookupDNSNames(ipLookups, lookups, dnsNames), nil
 				},
 
-				AddGeneratedRules: func(rules []*api.Rule) error {
-					generatedRules = append(generatedRules, rules...)
+				AddGeneratedRulesAndUpdateSelectors: func([]*api.Rule, map[api.FQDNSelector][]net.IP, []api.FQDNSelector) error {
 					return nil
 				},
 			}

--- a/pkg/fqdn/rulegen_test.go
+++ b/pkg/fqdn/rulegen_test.go
@@ -49,7 +49,7 @@ func (ds *FQDNTestSuite) TestRuleGenCIDRGeneration(c *C) {
 				return lookupFail(c, dnsNames)
 			},
 
-			AddGeneratedRules: func(rules []*api.Rule) error {
+			AddGeneratedRulesAndUpdateSelectors: func(rules []*api.Rule, selectorIPMapping map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) error {
 				generatedRules = append(generatedRules, rules...)
 				return nil
 			},
@@ -112,7 +112,7 @@ func (ds *FQDNTestSuite) TestRuleGenDropCIDROnReinsert(c *C) {
 				return lookupFail(c, dnsNames)
 			},
 
-			AddGeneratedRules: func(rules []*api.Rule) error {
+			AddGeneratedRulesAndUpdateSelectors: func(rules []*api.Rule, selectorIPMapping map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) error {
 				generatedRules = append(generatedRules, rules...)
 				return nil
 			},
@@ -144,7 +144,7 @@ func (ds *FQDNTestSuite) TestRuleGenMultiIPUpdate(c *C) {
 				return lookupFail(c, dnsNames)
 			},
 
-			AddGeneratedRules: func(rules []*api.Rule) error {
+			AddGeneratedRulesAndUpdateSelectors: func(rules []*api.Rule, selectorIPMapping map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) error {
 				generatedRules = append(generatedRules, rules...)
 				return nil
 			},
@@ -215,7 +215,7 @@ func (ds *FQDNTestSuite) TestRuleGenUpdatesOnReplace(c *C) {
 				return lookupFail(c, dnsNames)
 			},
 
-			AddGeneratedRules: func(rules []*api.Rule) error {
+			AddGeneratedRulesAndUpdateSelectors: func(rules []*api.Rule, selectorIPMapping map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) error {
 				return nil
 			},
 		})
@@ -282,8 +282,7 @@ func (ds *FQDNTestSuite) TestPrepareFQDNRules(c *C) {
 
 	var (
 		generatedRules = make([]*api.Rule, 0)
-
-		gen = NewRuleGen(Config{
+		gen            = NewRuleGen(Config{
 			MinTTL: 1,
 			Cache:  NewDNSCache(0),
 
@@ -291,7 +290,7 @@ func (ds *FQDNTestSuite) TestPrepareFQDNRules(c *C) {
 				return lookupFail(c, dnsNames)
 			},
 
-			AddGeneratedRules: func(rules []*api.Rule) error {
+			AddGeneratedRulesAndUpdateSelectors: func(rules []*api.Rule, selectorIPMapping map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) error {
 				generatedRules = append(generatedRules, rules...)
 				return nil
 			},
@@ -301,18 +300,22 @@ func (ds *FQDNTestSuite) TestPrepareFQDNRules(c *C) {
 	rules := []*api.Rule{rule3.DeepCopy()}
 
 	// Validate that no rules in RuleGen return the rule without issues.
-	c.Assert(gen.PrepareFQDNRules(rules), HasLen, 1)
+	rulez, _ := gen.PrepareFQDNRules(rules)
+	c.Assert(rulez, HasLen, 1)
 
 	// Validate that if rules is in RuleGen returns always 1
 	gen.StartManageDNSName(rules)
-	c.Assert(gen.PrepareFQDNRules(rules), HasLen, 1)
+	rulez, _ = gen.PrepareFQDNRules(rules)
+	c.Assert(rulez, HasLen, 1)
 
 	// Validate that an empty rule returns 0 len
 	emptyRules := []*api.Rule{}
-	c.Assert(gen.PrepareFQDNRules(emptyRules), HasLen, 0)
+	rulez, _ = gen.PrepareFQDNRules(emptyRules)
+	c.Assert(rulez, HasLen, 0)
 
 	// Validate if the gen.AllRules are empty should return 0 rules due to UUID
 	// mismatch
 	gen.allRules = map[string]*api.Rule{}
-	c.Assert(gen.PrepareFQDNRules(rules), HasLen, 0)
+	rulez, _ = gen.PrepareFQDNRules(rules)
+	c.Assert(rulez, HasLen, 0)
 }

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -109,6 +109,11 @@ func (id *Identity) StringID() string {
 	return id.ID.StringID()
 }
 
+// StringID returns the identity identifier as string
+func (id *Identity) String() string {
+	return id.ID.StringID()
+}
+
 func (id *Identity) GetModel() *models.Identity {
 	if id == nil {
 		return nil

--- a/pkg/ip/cidr.go
+++ b/pkg/ip/cidr.go
@@ -32,15 +32,7 @@ func ParseCIDRs(cidrs []string) (valid []*net.IPNet, invalid []string) {
 				invalid = append(invalid, cidr)
 				continue
 			} else {
-				bits := net.IPv6len * 8
-				if ip.To4() != nil {
-					ip = ip.To4()
-					bits = net.IPv4len * 8
-				}
-				prefix = &net.IPNet{
-					IP:   ip,
-					Mask: net.CIDRMask(bits, bits),
-				}
+				prefix = IPToPrefix(ip)
 			}
 		}
 		if prefix != nil {

--- a/pkg/ip/ip.go
+++ b/pkg/ip/ip.go
@@ -768,3 +768,29 @@ func IsPublicAddr(ip net.IP) bool {
 	}
 	return true
 }
+
+// GetCIDRPrefixesFromIPs returns all of the ips as a slice of *net.IPNet.
+func GetCIDRPrefixesFromIPs(ips []net.IP) []*net.IPNet {
+	if len(ips) == 0 {
+		return nil
+	}
+	res := make([]*net.IPNet, 0, len(ips))
+	for _, ip := range ips {
+		res = append(res, IPToPrefix(ip))
+	}
+	return res
+}
+
+// IPToPrefix returns the corresponding IPNet for the given IP.
+func IPToPrefix(ip net.IP) *net.IPNet {
+	bits := net.IPv6len * 8
+	if ip.To4() != nil {
+		ip = ip.To4()
+		bits = net.IPv4len * 8
+	}
+	prefix := &net.IPNet{
+		IP:   ip,
+		Mask: net.CIDRMask(bits, bits),
+	}
+	return prefix
+}

--- a/pkg/k8s/rule_translate.go
+++ b/pkg/k8s/rule_translate.go
@@ -127,7 +127,7 @@ func generateToCidrFromEndpoint(
 		if err != nil {
 			return err
 		}
-		if err := ipcache.AllocateCIDRs(impl, prefixes); err != nil {
+		if _, err := ipcache.AllocateCIDRs(impl, prefixes); err != nil {
 			return err
 		}
 	}

--- a/pkg/policy/api/fqdn.go
+++ b/pkg/policy/api/fqdn.go
@@ -54,6 +54,10 @@ type FQDNSelector struct {
 	MatchPattern string `json:"matchPattern,omitempty"`
 }
 
+func (s *FQDNSelector) String() string {
+	return fmt.Sprintf("MatchName: %s, MatchPattern %s", s.MatchName, s.MatchPattern)
+}
+
 // sanitize for FQDNSelector is a little wonky. While we do more processing
 // when using MatchName the basic requirement is that is a valid regexp. We
 // test that it can compile here.

--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -213,10 +213,13 @@ type labelIdentitySelector struct {
 // of the cachedSelections differ from those in the identities slice, all
 // users are notified.
 func (sc *SelectorCache) UpdateFQDNSelector(fqdnSelec api.FQDNSelector, identities []identity.NumericIdentity) {
-
-	fqdnKey := fqdnSelec.String()
 	sc.mutex.Lock()
 	defer sc.mutex.Unlock()
+	sc.updateFQDNSelector(fqdnSelec, identities)
+}
+
+func (sc *SelectorCache) updateFQDNSelector(fqdnSelec api.FQDNSelector, identities []identity.NumericIdentity) {
+	fqdnKey := fqdnSelec.String()
 
 	var fqdnSel *fqdnSelector
 

--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -461,6 +461,19 @@ func (sc *SelectorCache) UpdateIdentities(added, deleted cache.IdentityCache) {
 	}
 }
 
+// RemoveIdentitiesFQDNSelectors removes all identities from being mapped to the
+// set of FQDNSelectors.
+func (sc *SelectorCache) RemoveIdentitiesFQDNSelectors(fqdnSels []api.FQDNSelector) {
+	sc.mutex.Lock()
+	defer sc.mutex.Unlock()
+
+	noIdentities := []identity.NumericIdentity{}
+
+	for i := range fqdnSels {
+		sc.updateFQDNSelector(fqdnSels[i], noIdentities)
+	}
+}
+
 // Export global functions to interface with the global selector cache
 
 // AddIdentitySelector adds the given api.EndpointSelector in to the
@@ -482,6 +495,12 @@ func RemoveIdentitySelector(user CachedSelectionUser, selector CachedSelector) {
 // all users are notified.
 func UpdateFQDNSelector(fqdnSelector api.FQDNSelector, identities []identity.NumericIdentity) {
 	selectorCache.UpdateFQDNSelector(fqdnSelector, identities)
+}
+
+// RemoveIdentitiesFQDNSelectors removes all identities from being mapped to the
+// set of FQDNSelectors in the global SelectorCache.
+func RemoveIdentitiesFQDNSelectors(fqdnSels []api.FQDNSelector) {
+	selectorCache.RemoveIdentitiesFQDNSelectors(fqdnSels)
 }
 
 // AddFQDNSelector adds the given api.EndpointSelector to the selector cache. If


### PR DESCRIPTION
This is the minimally-viable solution to plumb the mapping of FQDNSelector --> set of IPs into the new `SelectorCache` construct, which will be used when computing policy for a given identity being consumed by an Endpoint that is running locally.

DNS policy is still transmitted through Cilium via adding / deleting rules from the policy repository with these changes. However, the mapping of FQDNs --> IPs is plumbed as well. This is done so we can start using the `SelectorCache` for all `*Selector` --> identity lookups while computing policy.

Note that removing of the policy rule update / add / remove logic from the FQDN side is out of scope of this PR. The policy computation layer is insulated from this, so this can be followed-up later. 

I also did not handle the case where we fetch the IPs that may map to the given FQDN that is provided in a new rule with  `toFQDNs` rules (`PrepareToFQDNsRules`). Given that we will plumb upon DNS lookup, I figured this would be OK for now - @raybejjani would be interested in your feedback here, though.  

TODO in follow-up PRs:

- [ ] lifecycle management of Selectors in the SelectorCache - need to iterate through rules that are being deleted from policy and remove `FQDNSelectors` from the `SelectorCache`
- [ ] removal of CIDR rule generation

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7879)
<!-- Reviewable:end -->
