### PR TITLE
policy: Remove denied identities maps

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -225,12 +225,12 @@ func (d *Daemon) RemoveProxyRedirect(e *endpoint.Endpoint, id string, proxyWaitG
 // UpdateNetworkPolicy adds or updates a network policy in the set
 // published to L7 proxies.
 func (d *Daemon) UpdateNetworkPolicy(e *endpoint.Endpoint, policy *policy.L4Policy,
-	labelsMap, deniedIngressIdentities, deniedEgressIdentities cache.IdentityCache, proxyWaitGroup *completion.WaitGroup) (error, revert.RevertFunc) {
+	labelsMap cache.IdentityCache, proxyWaitGroup *completion.WaitGroup) (error, revert.RevertFunc) {
 	if d.l7Proxy == nil {
 		return fmt.Errorf("can't update network policy, proxy disabled"), nil
 	}
-	err, revertFunc := d.l7Proxy.UpdateNetworkPolicy(e, policy, e.GetIngressPolicyEnabledLocked(), e.GetEgressPolicyEnabledLocked(),
-		labelsMap, deniedIngressIdentities, deniedEgressIdentities, proxyWaitGroup)
+	err, revertFunc := d.l7Proxy.UpdateNetworkPolicy(e, policy, e.GetIngressPolicyEnabledLocked(),
+		e.GetEgressPolicyEnabledLocked(), labelsMap, proxyWaitGroup)
 	return err, revert.RevertFunc(revertFunc)
 }
 

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -65,7 +65,7 @@ type DaemonSuite struct {
 	OnGetPolicyRepository     func() *policy.Repository
 	OnUpdateProxyRedirect     func(e *e.Endpoint, l4 *policy.L4Filter, proxyWaitGroup *completion.WaitGroup) (uint16, error, revert.FinalizeFunc, revert.RevertFunc)
 	OnRemoveProxyRedirect     func(e *e.Endpoint, id string, proxyWaitGroup *completion.WaitGroup) (error, revert.FinalizeFunc, revert.RevertFunc)
-	OnUpdateNetworkPolicy     func(e *e.Endpoint, policy *policy.L4Policy, labelsMap, deniedIngressIdentities, deniedEgressIdentities cache.IdentityCache, proxyWaitGroup *completion.WaitGroup) (error, revert.RevertFunc)
+	OnUpdateNetworkPolicy     func(e *e.Endpoint, policy *policy.L4Policy, labelsMap cache.IdentityCache, proxyWaitGroup *completion.WaitGroup) (error, revert.RevertFunc)
 	OnRemoveNetworkPolicy     func(e *e.Endpoint)
 	OnQueueEndpointBuild      func(ctx context.Context, epID uint64) (func(), error)
 	OnRemoveFromEndpointQueue func(epID uint64)
@@ -224,9 +224,9 @@ func (ds *DaemonSuite) RemoveProxyRedirect(e *e.Endpoint, id string, proxyWaitGr
 }
 
 func (ds *DaemonSuite) UpdateNetworkPolicy(e *e.Endpoint, policy *policy.L4Policy,
-	labelsMap, deniedIngressIdentities, deniedEgressIdentities cache.IdentityCache, proxyWaitGroup *completion.WaitGroup) (error, revert.RevertFunc) {
+	labelsMap cache.IdentityCache, proxyWaitGroup *completion.WaitGroup) (error, revert.RevertFunc) {
 	if ds.OnUpdateNetworkPolicy != nil {
-		return ds.OnUpdateNetworkPolicy(e, policy, labelsMap, deniedIngressIdentities, deniedEgressIdentities, proxyWaitGroup)
+		return ds.OnUpdateNetworkPolicy(e, policy, labelsMap, proxyWaitGroup)
 	}
 	panic("UpdateNetworkPolicy should not have been called")
 }

--- a/daemon/state_test.go
+++ b/daemon/state_test.go
@@ -140,7 +140,7 @@ func (ds *DaemonSuite) generateEPs(baseDir string, epsWanted []*e.Endpoint, epsM
 	}
 
 	ds.OnUpdateNetworkPolicy = func(e *e.Endpoint, policy *policy.L4Policy,
-		labelsMap, deniedIngressIdentities, deniedEgressIdentities cache.IdentityCache, proxyWaitGroup *completion.WaitGroup) (error, revert.RevertFunc) {
+		labelsMap cache.IdentityCache, proxyWaitGroup *completion.WaitGroup) (error, revert.RevertFunc) {
 		return nil, nil
 	}
 

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -211,7 +211,7 @@ func (e *Endpoint) addNewRedirectsFromMap(owner Owner, m policy.L4PolicyMap, des
 				direction = trafficdirection.Egress
 			}
 
-			keysFromFilter := l4.ToKeys(direction, *e.prevIdentityCache, e.desiredPolicy.DeniedIngressIdentities)
+			keysFromFilter := l4.ToKeys(direction, *e.prevIdentityCache)
 
 			for _, keyFromFilter := range keysFromFilter {
 				if oldEntry, ok := e.desiredPolicy.PolicyMapState[keyFromFilter]; ok {

--- a/pkg/endpoint/owner.go
+++ b/pkg/endpoint/owner.go
@@ -41,7 +41,7 @@ type Owner interface {
 	// UpdateNetworkPolicy adds or updates a network policy in the set
 	// published to L7 proxies.
 	UpdateNetworkPolicy(e *Endpoint, policy *policy.L4Policy,
-		labelsMap, deniedIngressIdentities, deniedEgressIdentities cache.IdentityCache, proxyWaitGroup *completion.WaitGroup) (error, revert.RevertFunc)
+		labelsMap cache.IdentityCache, proxyWaitGroup *completion.WaitGroup) (error, revert.RevertFunc)
 
 	// RemoveNetworkPolicy removes a network policy from the set published to
 	// L7 proxies.

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -81,7 +81,7 @@ func (e *Endpoint) updateNetworkPolicy(owner Owner, proxyWaitGroup *completion.W
 	if e.desiredPolicy != nil {
 		desiredL4Policy = e.desiredPolicy.L4Policy
 	}
-	return owner.UpdateNetworkPolicy(e, desiredL4Policy, *e.prevIdentityCache, e.desiredPolicy.DeniedIngressIdentities, e.desiredPolicy.DeniedEgressIdentities, proxyWaitGroup)
+	return owner.UpdateNetworkPolicy(e, desiredL4Policy, *e.prevIdentityCache, proxyWaitGroup)
 }
 
 // setNextPolicyRevision updates the desired policy revision field

--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -566,6 +566,7 @@ func (a *Allocator) Allocate(ctx context.Context, key AllocatorKey) (idpool.ID, 
 		value, isNew, err = a.lockedAllocate(ctx, key)
 		if err == nil {
 			a.mainCache.insert(key, value)
+			log.WithField(fieldKey, key).WithField(fieldID, value).Info("Allocated key")
 			return value, isNew, nil
 		}
 

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -168,14 +168,11 @@ func (d *policyDistillery) distillPolicy(epLabels labels.LabelArray) (MapState, 
 		return nil, err
 	}
 
-	// TODO: Test Requirements
-	deniedIdentities := make(cache.IdentityCache)
-
 	// Handle L4 ingress from each identity in the cache to the endpoint.
 	io.WriteString(d.log, "[distill] Producing L4 filter keys\n")
 	for _, l4 := range *l4IngressPolicy {
 		io.WriteString(d.log, fmt.Sprintf("[distill] Processing L4Filter (l3: %+v), (l4: %d/%s), (l7: %+v)\n", l4.Endpoints, l4.Port, l4.Protocol, l4.L7RulesPerEp))
-		for _, key := range l4.ToKeys(0, d.identityCache, deniedIdentities) {
+		for _, key := range l4.ToKeys(0, d.identityCache) {
 			io.WriteString(d.log, fmt.Sprintf("[distill] L4 ingress allow %+v (parser=%s, redirect=%t)\n", key, l4.L7Parser, l4.IsRedirect()))
 			if l4.IsRedirect() {
 				result[key] = MapStateEntry{l7RedirectProxy}

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -139,7 +139,7 @@ func (l4 *L4Filter) HasL3DependentL7Rules() bool {
 }
 
 // ToKeys converts filter into a list of Keys.
-func (l4 *L4Filter) ToKeys(direction trafficdirection.TrafficDirection, identityCache cache.IdentityCache, deniedIdentities cache.IdentityCache) []Key {
+func (l4 *L4Filter) ToKeys(direction trafficdirection.TrafficDirection, identityCache cache.IdentityCache) []Key {
 	keysToAdd := []Key{}
 	port := uint16(l4.Port)
 	proto := uint8(l4.U8Proto)
@@ -166,17 +166,15 @@ func (l4 *L4Filter) ToKeys(direction trafficdirection.TrafficDirection, identity
 	for _, sel := range l4.Endpoints {
 		identities := getSecurityIdentities(identityCache, &sel)
 		for _, id := range identities {
-			if _, identityIsDenied := deniedIdentities[id]; !identityIsDenied {
-				srcID := id.Uint32()
-				keyToAdd := Key{
-					Identity: srcID,
-					// NOTE: Port is in host byte-order!
-					DestPort:         port,
-					Nexthdr:          proto,
-					TrafficDirection: direction.Uint8(),
-				}
-				keysToAdd = append(keysToAdd, keyToAdd)
+			srcID := id.Uint32()
+			keyToAdd := Key{
+				Identity: srcID,
+				// NOTE: Port is in host byte-order!
+				DestPort:         port,
+				Nexthdr:          proto,
+				TrafficDirection: direction.Uint8(),
 			}
+			keysToAdd = append(keysToAdd, keyToAdd)
 		}
 	}
 

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -78,12 +78,6 @@ type SearchContext struct {
 	// This is used to avoid using EndpointSelector.Matches() if possible,
 	// since it is costly in terms of performance.
 	rulesSelect bool
-	// skipL4RequirementsAggregation allows for skipping of aggregation of
-	// requirements in L4 policy parsing, as it is expensive. This is used
-	// when the policy is being calculated for an endpoint (vs. a trace),
-	// and the set of denied identities can be consulted for when the PolicyMap
-	// state is computed for an endpoint.
-	skipL4RequirementsAggregation bool
 }
 
 func (s *SearchContext) String() string {

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -143,12 +143,6 @@ func wildcardL3L4Rule(proto api.L4Proto, port int, endpoints api.EndpointSelecto
 	}
 }
 
-// wildcardL3L4Rules updates each ingress L7 rule to allow at L7 all traffic that
-// is allowed at L3-only or L3/L4.
-func (p *Repository) wildcardL3L4Rules(ctx *SearchContext, ingress bool, l4Policy L4PolicyMap) {
-	p.rules.wildcardL3L4Rules(ctx, ingress, l4Policy)
-}
-
 // ResolveL4IngressPolicy resolves the L4 ingress policy for a set of endpoints
 // by searching the policy repository for `PortRule` rules that are attached to
 // a `Rule` where the EndpointSelector matches `ctx.To`. `ctx.From` takes no effect and
@@ -588,7 +582,6 @@ func (p *Repository) ResolvePolicyLocked(securityIdentity *identity.Identity) (*
 		Revision:             p.GetRevision(),
 		L4Policy:             NewL4Policy(),
 		CIDRPolicy:           NewCIDRPolicy(),
-		matchingRules:        matchingRules,
 		IngressPolicyEnabled: ingressEnabled,
 		EgressPolicyEnabled:  egressEnabled,
 	}
@@ -597,15 +590,13 @@ func (p *Repository) ResolvePolicyLocked(securityIdentity *identity.Identity) (*
 
 	labels := securityIdentity.LabelArray
 	ingressCtx := SearchContext{
-		To:                            labels,
-		rulesSelect:                   true,
-		skipL4RequirementsAggregation: false,
+		To:          labels,
+		rulesSelect: true,
 	}
 
 	egressCtx := SearchContext{
-		From:                          labels,
-		rulesSelect:                   true,
-		skipL4RequirementsAggregation: false,
+		From:        labels,
+		rulesSelect: true,
 	}
 
 	if option.Config.TracingEnabled() {

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -1844,7 +1844,7 @@ Ingress verdict: allowed
 	ctx = buildSearchCtx("bar", "foo", 0)
 	expectedOut = `
 Resolving ingress policy for [any:foo]
-0/1 rules selected
+0/0 rules selected
 Found no allow rule
 Ingress verdict: denied
 `

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -1902,8 +1902,6 @@ Resolving ingress policy for [any:bar]
     Allows from labels {"matchLabels":{"any:baz":""},"matchExpressions":[{"key":"any:baz","operator":"In","values":[""]}]}
       No label match for [any:foo]
 * Rule {"matchLabels":{"any:bar":""}}: selected
-    Enforcing requirements [{Key:any.baz Operator:In Values:[]}]
-      No label match for [any:foo]
 3/3 rules selected
 Found no allow rule
 Ingress verdict: denied
@@ -1927,8 +1925,6 @@ Resolving ingress policy for [any:bar]
       Allows port [{80 ANY}]
         No port match found
 * Rule {"matchLabels":{"any:bar":""}}: selected
-    Enforcing requirements [{Key:any.baz Operator:In Values:[]}]
-      Found all required labels
 3/3 rules selected
 Found no allow rule
 Ingress verdict: denied

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -1022,6 +1022,9 @@ func (ds *PolicyTestSuite) TestL3DependentL4EgressFromRequires(c *C) {
 				}},
 			},
 			{
+				ToEndpoints: []api.EndpointSelector{
+					api.WildcardEndpointSelector,
+				},
 				ToRequires: []api.EndpointSelector{selBar2},
 			},
 		},
@@ -1048,8 +1051,26 @@ func (ds *PolicyTestSuite) TestL3DependentL4EgressFromRequires(c *C) {
 			Values:   []string{"bar2"},
 		},
 	})
+	expectedSelector2 := api.NewESFromMatchRequirements(map[string]string{}, []v1.LabelSelectorRequirement{
+		{
+			Key:      "any.id",
+			Operator: v1.LabelSelectorOpIn,
+			Values:   []string{"bar2"},
+		},
+	})
 
 	expectedPolicy := L4PolicyMap{
+		"0/ANY": L4Filter{
+			Port:          0,
+			Protocol:      "ANY",
+			U8Proto:       0x0,
+			allowsAllAtL3: false,
+			Endpoints: api.EndpointSelectorSlice{
+				expectedSelector2,
+			},
+			L7RulesPerEp:     L7DataMap{},
+			DerivedFromRules: labels.LabelArrayList{nil},
+		},
 		"80/TCP": L4Filter{
 			Port:     80,
 			Protocol: api.ProtoTCP,

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -241,17 +241,12 @@ func (ds *PolicyTestSuite) TestL7WithIngressWildcard(c *C) {
 			IngressPolicyEnabled: true,
 			EgressPolicyEnabled:  false,
 		},
-		PolicyOwner:             DummyOwner{},
-		DeniedIngressIdentities: cache.IdentityCache{},
-		DeniedEgressIdentities:  cache.IdentityCache{},
+		PolicyOwner: DummyOwner{},
 		// inherit this from the result as it is outside of the scope
 		// of this test
 		PolicyMapState: policy.PolicyMapState,
 	}
 
-	// Ignore the matching rules, this is intermediate state during
-	// generation of the EndpointPolicy.
-	policy.matchingRules = nil
 	c.Assert(policy, checker.DeepEquals, &expectedEndpointPolicy)
 }
 
@@ -332,16 +327,11 @@ func (ds *PolicyTestSuite) TestL7WithLocalHostWildcardd(c *C) {
 			IngressPolicyEnabled: true,
 			EgressPolicyEnabled:  false,
 		},
-		PolicyOwner:             DummyOwner{},
-		DeniedIngressIdentities: cache.IdentityCache{},
-		DeniedEgressIdentities:  cache.IdentityCache{},
+		PolicyOwner: DummyOwner{},
 		// inherit this from the result as it is outside of the scope
 		// of this test
 		PolicyMapState: policy.PolicyMapState,
 	}
 
-	// Ignore the matching rules, this is intermediate state during
-	// generation of the EndpointPolicy.
-	policy.matchingRules = nil
 	c.Assert(policy, checker.DeepEquals, &expectedEndpointPolicy)
 }

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -237,9 +237,8 @@ func mergeIngress(ctx *SearchContext, rule api.IngressRule, ruleLabels labels.La
 			ctx.PolicyTrace("      No label match for %s", ctx.From)
 			return 0, nil
 		}
+		ctx.PolicyTrace("      Found all required labels")
 	}
-
-	ctx.PolicyTrace("      Found all required labels")
 
 	// Daemon options may induce L3 allows for host/world. In this case, if
 	// we find any L7 rules matching host/world then we need to turn any L7
@@ -356,17 +355,11 @@ func (r *rule) resolveIngressPolicy(ctx *SearchContext, state *traceState, resul
 		// from rules which select the labels in ctx.To. This ensures that
 		// FromRequires is taken into account even if it isn't part of the current
 		// rule over which we are iterating.
-		if len(requirements) > 0 {
+		if len(requirements) > 0 && len(ingressRule.FromEndpoints) > 0 {
 			// Create a deep copy of the rule, as we are going to modify FromEndpoints
 			// with requirementsSelector. We don't want to modify the rule itself
 			// in the policy repository.
 			ruleCopy = *ingressRule.DeepCopy()
-			// If the rule only consists of a FromRequires statement,
-			// provide an empty selector so that it will be updated
-			// in the next step.
-			if ctx.TraceEnabled() && len(ruleCopy.FromEndpoints) == 0 {
-				ruleCopy.FromEndpoints = []api.EndpointSelector{api.NewESFromLabels()}
-			}
 			// Update each EndpointSelector in FromEndpoints to contain requirements.
 			for idx := range ruleCopy.FromEndpoints {
 				ruleCopy.FromEndpoints[idx].MatchExpressions = append(ruleCopy.FromEndpoints[idx].MatchExpressions, requirements...)
@@ -626,9 +619,8 @@ func mergeEgress(ctx *SearchContext, rule api.EgressRule, ruleLabels labels.Labe
 			ctx.PolicyTrace("      No label match for %s", ctx.To)
 			return 0, nil
 		}
+		ctx.PolicyTrace("      Found all required labels")
 	}
-
-	ctx.PolicyTrace("      Found all required labels")
 
 	var (
 		cnt int
@@ -742,17 +734,11 @@ func (r *rule) resolveEgressPolicy(ctx *SearchContext, state *traceState, result
 		// from rules which select the labels in ctx.From. This ensures that
 		// ToRequires is taken into account even if it isn't part of the current
 		// rule over which we are iterating.
-		if len(requirements) > 0 {
+		if len(requirements) > 0 && len(egressRule.ToEndpoints) > 0 {
 			// Create a deep copy of the rule, as we are going to modify
 			// ToEndpoints with requirements; we don't want to modify the rule
 			// in the repository.
 			ruleCopy = *egressRule.DeepCopy()
-			// If the rule only consists of a ToRequires statement,
-			// provide an empty selector so that it will be updated
-			// in the next step.
-			if ctx.TraceEnabled() && len(ruleCopy.ToEndpoints) == 0 {
-				ruleCopy.ToEndpoints = []api.EndpointSelector{api.NewESFromLabels()}
-			}
 			for idx := range ruleCopy.ToEndpoints {
 				// Update each EndpointSelector in ToEndpoints to contain
 				// requirements.

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -255,8 +255,8 @@ func mergeIngress(ctx *SearchContext, rule api.IngressRule, ruleLabels labels.La
 		err error
 	)
 
-	// L3-only rule without requirements.
-	if len(rule.ToPorts) == 0 && len(rule.FromRequires) == 0 {
+	// L3-only rule (with requirements folded into fromEndpoints).
+	if len(rule.ToPorts) == 0 && len(fromEndpoints) > 0 {
 		cnt, err = mergeIngressPortProto(ctx, fromEndpoints, endpointsWithL3Override, api.PortRule{}, api.PortProtocol{Port: "0", Protocol: api.ProtoAny}, api.ProtoAny, ruleLabels, resMap)
 		if err != nil {
 			return found, err
@@ -627,8 +627,8 @@ func mergeEgress(ctx *SearchContext, rule api.EgressRule, ruleLabels labels.Labe
 		err error
 	)
 
-	// L3-only rule
-	if len(rule.ToPorts) == 0 && len(rule.ToRequires) == 0 {
+	// L3-only rule (with requirements folded into toEndpoints).
+	if len(rule.ToPorts) == 0 && len(toEndpoints) > 0 {
 		cnt, err = mergeEgressPortProto(ctx, toEndpoints, api.PortRule{}, api.PortProtocol{Port: "0", Protocol: api.ProtoAny}, api.ProtoAny, ruleLabels, resMap)
 		if err != nil {
 			return found, err


### PR DESCRIPTION
Now that requirement selectors are folded into the selectors of the
rules in selector policies, we no longer need to keep track of
identities denied at L3 to produce the correct L4 policies. Removal of
DeniedIngressIdentities and DeniedEgressIdentities from the
EndpointPolicy also allows the removal of the matchingRules members
from the SelectorPolicy.

The generation of a SelectorPolicy is made faster by keeping note of
the selected rules on the first pass, and then iterating only over
those rules in subsequent passes. Note that this changes the set of
rules the later passes process and may result in different policy
trace output than before.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7883)
<!-- Reviewable:end -->
