### PR TITLE
k8s: Move NewInformer into separate package

### DIFF
--- a/operator/cnp_event.go
+++ b/operator/cnp_event.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/k8s"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/informer"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/policy/groups"
 
@@ -40,7 +41,7 @@ func init() {
 func enableCNPWatcher() error {
 	log.Info("Starting to garbage collect stale CiliumNetworkPolicy status field entries...")
 
-	_, ciliumV2Controller := k8s.NewInformer(
+	_, ciliumV2Controller := informer.NewInformer(
 		cache.NewListWatchFromClient(k8s.CiliumClient().CiliumV2().RESTClient(),
 			"ciliumnetworkpolicies", v1.NamespaceAll, fields.Everything()),
 		&cilium_v2.CiliumNetworkPolicy{},

--- a/operator/k8s_node.go
+++ b/operator/k8s_node.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/informer"
 	"github.com/cilium/cilium/pkg/k8s/utils"
 	k8sversion "github.com/cilium/cilium/pkg/k8s/version"
 	"github.com/cilium/cilium/pkg/kvstore/store"
@@ -60,7 +61,7 @@ func runNodeWatcher() error {
 		return err
 	}
 
-	k8sNodeStore, nodeController := k8s.NewInformer(
+	k8sNodeStore, nodeController := informer.NewInformer(
 		cache.NewListWatchFromClient(k8s.Client().CoreV1().RESTClient(),
 			"nodes", v1.NamespaceAll, fields.Everything()),
 		&v1.Node{},

--- a/operator/k8s_service_sync.go
+++ b/operator/k8s_service_sync.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/pkg/k8s"
+	"github.com/cilium/cilium/pkg/k8s/informer"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
@@ -94,7 +95,7 @@ func startSynchronizingServices() {
 	}()
 
 	// Watch for v1.Service changes and push changes into ServiceCache
-	_, svcController := k8s.NewInformer(
+	_, svcController := informer.NewInformer(
 		cache.NewListWatchFromClient(k8s.Client().CoreV1().RESTClient(),
 			"services", v1.NamespaceAll, fields.Everything()),
 		&v1.Service{},
@@ -146,7 +147,7 @@ func startSynchronizingServices() {
 	go svcController.Run(wait.NeverStop)
 
 	// Watch for v1.Endpoints changes and push changes into ServiceCache
-	_, endpointController := k8s.NewInformer(
+	_, endpointController := informer.NewInformer(
 		cache.NewListWatchFromClient(k8s.Client().CoreV1().RESTClient(),
 			"endpoints", v1.NamespaceAll,
 			// Don't get any events from kubernetes endpoints.

--- a/pkg/k8s/informer/informer.go
+++ b/pkg/k8s/informer/informer.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package k8s
+package informer
 
 import (
 	"time"


### PR DESCRIPTION
This helps to avoid import cycles for another PR

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7886)
<!-- Reviewable:end -->
