### PR TITLE
CI: Wait on create/delete in helpers.SampleContainersAction

### DIFF
--- a/test/helpers/docker.go
+++ b/test/helpers/docker.go
@@ -167,10 +167,12 @@ func (s *SSHMeta) SampleContainersActions(mode string, networkName string, creat
 		for k, v := range images {
 			s.ContainerCreate(k, v, networkName, fmt.Sprintf("-l id.%s %s", k, createOptionsString))
 		}
+		s.WaitEndpointsReady()
 	case Delete:
 		for k := range images {
 			s.ContainerRm(k)
 		}
+		s.WaitEndpointsDeleted()
 	}
 }
 


### PR DESCRIPTION
We use this utility function in a number of test suites, cleaning up
when they end. We don't wait for the deletes (or creates) to complete
and this may cause a race with later tests. We now enforce a wait when
creating or deleting endpoints.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7889)
<!-- Reviewable:end -->
