### PR TITLE
v1.5: backports 19-04-30

### DIFF
--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -491,10 +491,8 @@ func init() {
 
 	flags.Bool(option.DisableEnvoyVersionCheck, false, "Do not perform Envoy binary version check on startup")
 	flags.MarkHidden(option.DisableEnvoyVersionCheck)
-	option.BindEnv(option.DisableEnvoyVersionCheck)
 	// Disable version check if Envoy build is disabled
-	// This needs to be set manually for backward compatibility
-	viper.BindEnv(option.DisableEnvoyVersionCheck, "CILIUM_DISABLE_ENVOY_BUILD")
+	option.BindEnvWithLegacyEnvFallback(option.DisableEnvoyVersionCheck, "CILIUM_DISABLE_ENVOY_BUILD")
 
 	flags.Var(option.NewNamedMapOptions(option.FixedIdentityMapping, &option.Config.FixedIdentityMapping, option.Config.FixedIdentityMappingValidator),
 		option.FixedIdentityMapping, "Key-value for the fixed identity mapping which allows to use reserved label for fixed identities")
@@ -603,9 +601,7 @@ func init() {
 
 	flags.String(option.MonitorAggregationName, "None",
 		"Level of monitor aggregation for traces from the datapath")
-	option.BindEnv(option.MonitorAggregationName)
-	// Leave for backwards compatibility
-	viper.BindEnv(option.MonitorAggregationName, "CILIUM_MONITOR_AGGREGATION_LEVEL")
+	option.BindEnvWithLegacyEnvFallback(option.MonitorAggregationName, "CILIUM_MONITOR_AGGREGATION_LEVEL")
 
 	flags.Int(option.MonitorQueueSizeName, defaults.MonitorQueueSize,
 		"Size of the event queue when reading monitor events")
@@ -615,9 +611,7 @@ func init() {
 	option.BindEnv(option.MTUName)
 
 	flags.Bool(option.PrependIptablesChainsName, true, "Prepend custom iptables chains instead of appending")
-	// Leave for backwards compatibility
-	viper.BindEnv(option.PrependIptablesChainsName, "CILIUM_PREPEND_IPTABLES_CHAIN")
-	option.BindEnv(option.PrependIptablesChainsName)
+	option.BindEnvWithLegacyEnvFallback(option.PrependIptablesChainsName, "CILIUM_PREPEND_IPTABLES_CHAIN")
 
 	flags.String(option.IPv6NodeAddr, "auto", "IPv6 address of node")
 	option.BindEnv(option.IPv6NodeAddr)
@@ -688,18 +682,13 @@ func init() {
 	// handle the case where someone uses a new image with an older spec, and the
 	// older spec used the older variable name.
 	flags.String(option.PrometheusServeAddr, "", "IP:Port on which to serve prometheus metrics (pass \":Port\" to bind on all interfaces, \"\" is off)")
-	viper.BindEnv(option.PrometheusServeAddrDeprecated, "PROMETHEUS_SERVE_ADDR")
-	option.BindEnv(option.PrometheusServeAddr)
+	option.BindEnvWithLegacyEnvFallback(option.PrometheusServeAddr, "PROMETHEUS_SERVE_ADDR")
 
 	flags.Int(option.CTMapEntriesGlobalTCPName, option.CTMapEntriesGlobalTCPDefault, "Maximum number of entries in TCP CT table")
-	// Leave for backwards compatibility
-	viper.BindEnv(option.CTMapEntriesGlobalTCPName, "CILIUM_GLOBAL_CT_MAX_TCP")
-	option.BindEnv(option.CTMapEntriesGlobalTCPName)
+	option.BindEnvWithLegacyEnvFallback(option.CTMapEntriesGlobalTCPName, "CILIUM_GLOBAL_CT_MAX_TCP")
 
 	flags.Int(option.CTMapEntriesGlobalAnyName, option.CTMapEntriesGlobalAnyDefault, "Maximum number of entries in non-TCP CT table")
-	// Leave for backwards compatibility
-	viper.BindEnv(option.CTMapEntriesGlobalAnyName, "CILIUM_GLOBAL_CT_MAX_ANY")
-	option.BindEnv(option.CTMapEntriesGlobalAnyName)
+	option.BindEnvWithLegacyEnvFallback(option.CTMapEntriesGlobalAnyName, "CILIUM_GLOBAL_CT_MAX_ANY")
 
 	flags.String(option.CMDRef, "", "Path to cmdref output directory")
 	flags.MarkHidden(option.CMDRef)

--- a/examples/kubernetes/node-init/README.rst
+++ b/examples/kubernetes/node-init/README.rst
@@ -13,6 +13,16 @@ The node-init DaemonSet prepares a node to run Cilium, it will:
 
  * Write a Cilium CNI configuration file to `/etc/cni/net.d/04-cilium-cni.conf`
 
+Recommended node-init DaemonSet
+===============================
+
+There is a more aggressive DaemonSet that will remove all running containers
+managed by kubenet. It is extremely recommended to run the `node-init-with-kill-pods.yaml`
+instead of `node-init.yaml` to avoid pods potentially being managed by kubenet
+during scale up and scale down. Be aware this might delete k8s jobs and pods
+that are managed by kubenet, this will force kubelet to reschedule the pod to
+have its network managed by Cilium.
+
 Requirements
 ------------
 

--- a/examples/kubernetes/node-init/node-init-with-kill-pods.yaml
+++ b/examples/kubernetes/node-init/node-init-with-kill-pods.yaml
@@ -1,0 +1,101 @@
+kind: DaemonSet
+apiVersion: extensions/v1beta1
+metadata:
+  name: cilium-node-init
+  labels:
+    app: cilium-node-init
+spec:
+  template:
+    metadata:
+      labels:
+        app: cilium-node-init
+    spec:
+      tolerations:
+      - operator: Exists
+      hostPID: true
+      hostNetwork: true
+      containers:
+        - name: node-init
+          image: gcr.io/google-containers/startup-script:v1
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+          env:
+          - name: STARTUP_SCRIPT
+            value: |
+              #!/bin/bash
+
+              set -o errexit
+              set -o pipefail
+              set -o nounset
+
+              if [[ ! -f /tmp/cilium-installed-v1 ]]; then
+                echo "Installing BPF filesystem mount"
+
+                cat >/tmp/sys-fs-bpf.mount <<EOF
+              [Unit]
+              Description=Mount BPF filesystem (Cilium)
+              Documentation=http://docs.cilium.io/
+              DefaultDependencies=no
+              Before=local-fs.target umount.target
+              After=swap.target
+
+              [Mount]
+              What=bpffs
+              Where=/sys/fs/bpf
+              Type=bpf
+
+              [Install]
+              WantedBy=multi-user.target
+              EOF
+
+                if [ -d "/etc/systemd/system/" ]; then
+                  mv /tmp/sys-fs-bpf.mount /etc/systemd/system/
+                  echo "Installed sys-fs-bpf.mount to /etc/systemd/system/"
+                elif [ -d "/lib/systemd/system/" ]; then
+                  mv /tmp/sys-fs-bpf.mount /lib/systemd/system/
+                  echo "Installed sys-fs-bpf.mount to /lib/systemd/system/"
+                fi
+
+                systemctl enable sys-fs-bpf.mount
+                systemctl start sys-fs-bpf.mount
+
+                echo "Installing /etc/cni/net.d/04-cilium-cni.conf"
+                mkdir -p /etc/cni/net.d/
+                cat >/etc/cni/net.d/04-cilium-cni.conf <<EOF
+              {
+                "name": "cilium",
+                "type": "cilium-cni"
+              }
+              EOF
+
+                echo "Changing kubelet configuration to --network-plugin=cni --cni-bin-dir=/home/kubernetes/bin"
+                mkdir -p /home/kubernetes/bin
+                sed -i "s:--network-plugin=kubenet:--network-plugin=cni\ --cni-bin-dir=/home/kubernetes/bin:g" /etc/default/kubelet
+                echo "Restarting kubelet..."
+                systemctl restart kubelet
+
+                echo "Restarting kubenet managed pods"
+                if grep -q 'docker' /etc/crictl.yaml; then
+                  # Works for COS, ubuntu
+                  for f in `find /var/lib/cni/networks/ -type f ! -name lock ! -name last_reserved_ip.0`; do docker rm -f $(cat $f) || true; done
+                else
+                  # COS-beta (with containerd)
+                  for f in `find /var/lib/cni/networks/ -type f ! -name lock ! -name last_reserved_ip.0`; do crictl stopp $(cat $f) || true; done
+                fi
+
+                if ip link show cbr0; then
+                  echo "Detected cbr0 bridge. Deleting interface..."
+                  ip link del cbr0
+                fi
+
+                echo "Link information:"
+                ip link
+
+                echo "Routing table:"
+                ip route
+
+                echo "Node initialization complete"
+
+                touch /tmp/cilium-installed-v1
+              fi

--- a/examples/kubernetes/node-init/node-init-with-kill-pods.yaml
+++ b/examples/kubernetes/node-init/node-init-with-kill-pods.yaml
@@ -89,6 +89,21 @@ spec:
                   ip link del cbr0
                 fi
 
+                # We still need to delete Cilium in case it started before
+                # we have changed kubelet configuration. This prevents Cilium
+                # from pre-allocating all IP addresses managed by cbr0.
+                echo "Restarting possible cilium instances"
+                if grep -q 'docker' /etc/crictl.yaml; then
+                  # Works for COS, ubuntu
+                  docker rm -f $(docker ps -q --filter=label=k8s-app=cilium) || true
+                else
+                  # COS-beta (with containerd)
+                  # currently cilium doesn't work with cos-beta so once it does
+                  # we need to figure out a why to delete cilium pods
+                  echo "Not implemented for cos-beta, please restart cilium pods"
+                  echo "manually!"
+                fi
+
                 echo "Link information:"
                 ip link
 

--- a/examples/kubernetes/node-init/node-init.yaml
+++ b/examples/kubernetes/node-init/node-init.yaml
@@ -10,6 +10,8 @@ spec:
       labels:
         app: cilium-node-init
     spec:
+      tolerations:
+      - operator: Exists
       hostPID: true
       containers:
         - name: node-init
@@ -81,5 +83,5 @@ spec:
 
               echo "Routing table:"
               ip route
-              
+
               echo "Node initialization complete"

--- a/examples/kubernetes/node-init/node-init.yaml
+++ b/examples/kubernetes/node-init/node-init.yaml
@@ -23,15 +23,16 @@ spec:
           env:
           - name: STARTUP_SCRIPT
             value: |
-              #! /bin/bash
+              #!/bin/bash
 
               set -o errexit
               set -o pipefail
               set -o nounset
 
-              echo "Installing BPF filesystem mount"
+              if [[ ! -f /tmp/cilium-installed-v1 ]]; then
+                echo "Installing BPF filesystem mount"
 
-              cat >/tmp/sys-fs-bpf.mount <<EOF
+                cat >/tmp/sys-fs-bpf.mount <<EOF
               [Unit]
               Description=Mount BPF filesystem (Cilium)
               Documentation=http://docs.cilium.io/
@@ -48,41 +49,44 @@ spec:
               WantedBy=multi-user.target
               EOF
 
-              if [ -d "/etc/systemd/system/" ]; then
-                mv /tmp/sys-fs-bpf.mount /etc/systemd/system/
-                echo "Installed sys-fs-bpf.mount to /etc/systemd/system/"
-              elif [ -d "/lib/systemd/system/" ]; then
-                mv /tmp/sys-fs-bpf.mount /lib/systemd/system/
-                echo "Installed sys-fs-bpf.mount to /lib/systemd/system/"
-              fi
+                if [ -d "/etc/systemd/system/" ]; then
+                  mv /tmp/sys-fs-bpf.mount /etc/systemd/system/
+                  echo "Installed sys-fs-bpf.mount to /etc/systemd/system/"
+                elif [ -d "/lib/systemd/system/" ]; then
+                  mv /tmp/sys-fs-bpf.mount /lib/systemd/system/
+                  echo "Installed sys-fs-bpf.mount to /lib/systemd/system/"
+                fi
 
-              systemctl enable sys-fs-bpf.mount
-              systemctl start sys-fs-bpf.mount
+                systemctl enable sys-fs-bpf.mount
+                systemctl start sys-fs-bpf.mount
 
-              echo "Changing kubelet configuration to --network-plugin=cni --cni-bin-dir=/home/kubernetes/bin"
-              mkdir -p /home/kubernetes/bin
-              sed -i "s:--network-plugin=kubenet:--network-plugin=cni\ --cni-bin-dir=/home/kubernetes/bin:g" /etc/default/kubelet
-              echo "Restarting kubelet..."
-              systemctl restart kubelet
+                echo "Changing kubelet configuration to --network-plugin=cni --cni-bin-dir=/home/kubernetes/bin"
+                mkdir -p /home/kubernetes/bin
+                sed -i "s:--network-plugin=kubenet:--network-plugin=cni\ --cni-bin-dir=/home/kubernetes/bin:g" /etc/default/kubelet
+                echo "Restarting kubelet..."
+                systemctl restart kubelet
 
-              echo "Installing /etc/cni/net.d/04-cilium-cni.conf"
-              mkdir -p /etc/cni/net.d/
-              cat >/etc/cni/net.d/04-cilium-cni.conf <<EOF
+                echo "Installing /etc/cni/net.d/04-cilium-cni.conf"
+                mkdir -p /etc/cni/net.d/
+                cat >/etc/cni/net.d/04-cilium-cni.conf <<EOF
               {
-                  "name": "cilium",
-                  "type": "cilium-cni"
+                "name": "cilium",
+                "type": "cilium-cni"
               }
               EOF
 
-              if ip link show cbr0; then
-                      echo "Detected cbr0 bridge. Deleting interface..."
-                      ip link del cbr0
+                if ip link show cbr0; then
+                  echo "Detected cbr0 bridge. Deleting interface..."
+                  ip link del cbr0
+                fi
+
+                echo "Link information:"
+                ip link
+
+                echo "Routing table:"
+                ip route
+
+                echo "Node initialization complete"
+
+                touch /tmp/cilium-installed-v1
               fi
-
-              echo "Link information:"
-              ip link
-
-              echo "Routing table:"
-              ip route
-
-              echo "Node initialization complete"

--- a/examples/kubernetes/node-init/node-init.yaml
+++ b/examples/kubernetes/node-init/node-init.yaml
@@ -80,6 +80,21 @@ spec:
                   ip link del cbr0
                 fi
 
+                # We still need to delete Cilium in case it started before
+                # we have changed kubelet configuration. This prevents Cilium
+                # from pre-allocating all IP addresses managed by cbr0.
+                echo "Restarting possible cilium instances"
+                if grep -q 'docker' /etc/crictl.yaml; then
+                  # Works for COS, ubuntu
+                  docker rm -f $(docker ps -q --filter=label=k8s-app=cilium) || true
+                else
+                  # COS-beta (with containerd)
+                  # currently cilium doesn't work with cos-beta so once it does
+                  # we need to figure out a why to delete cilium pods
+                  echo "Not implemented for cos-beta, please restart cilium pods"
+                  echo "manually!"
+                fi
+
                 echo "Link information:"
                 ip link
 

--- a/examples/kubernetes/node-init/node-init.yaml
+++ b/examples/kubernetes/node-init/node-init.yaml
@@ -13,6 +13,7 @@ spec:
       tolerations:
       - operator: Exists
       hostPID: true
+      hostNetwork: true
       containers:
         - name: node-init
           image: gcr.io/google-containers/startup-script:v1

--- a/examples/kubernetes/node-init/node-init.yaml
+++ b/examples/kubernetes/node-init/node-init.yaml
@@ -60,12 +60,6 @@ spec:
                 systemctl enable sys-fs-bpf.mount
                 systemctl start sys-fs-bpf.mount
 
-                echo "Changing kubelet configuration to --network-plugin=cni --cni-bin-dir=/home/kubernetes/bin"
-                mkdir -p /home/kubernetes/bin
-                sed -i "s:--network-plugin=kubenet:--network-plugin=cni\ --cni-bin-dir=/home/kubernetes/bin:g" /etc/default/kubelet
-                echo "Restarting kubelet..."
-                systemctl restart kubelet
-
                 echo "Installing /etc/cni/net.d/04-cilium-cni.conf"
                 mkdir -p /etc/cni/net.d/
                 cat >/etc/cni/net.d/04-cilium-cni.conf <<EOF
@@ -74,6 +68,12 @@ spec:
                 "type": "cilium-cni"
               }
               EOF
+
+                echo "Changing kubelet configuration to --network-plugin=cni --cni-bin-dir=/home/kubernetes/bin"
+                mkdir -p /home/kubernetes/bin
+                sed -i "s:--network-plugin=kubenet:--network-plugin=cni\ --cni-bin-dir=/home/kubernetes/bin:g" /etc/default/kubelet
+                echo "Restarting kubelet..."
+                systemctl restart kubelet
 
                 if ip link show cbr0; then
                   echo "Detected cbr0 bridge. Deleting interface..."

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -807,7 +807,7 @@ func (e *Endpoint) GetLabels() []string {
 }
 
 // GetSecurityIdentity returns the security identity of the endpoint. It assumes
-// the endpoint's mutex.
+// the endpoint's mutex is held.
 func (e *Endpoint) GetSecurityIdentity() *identityPkg.Identity {
 	return e.SecurityIdentity
 }

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -523,12 +523,33 @@ var RegisteredOptions = map[string]struct{}{}
 // variable which s based on the given optName. If the same optName is bind
 // more than 1 time, this function panics.
 func BindEnv(optName string) {
+	registerOpt(optName)
+	viper.BindEnv(optName, getEnvName(optName))
+}
+
+// BindEnvWithLegacyEnvFallback binds the given option name with either the same
+// environment variable as BindEnv, if it's set, or with the given legacyEnvName.
+//
+// The function is used to work around the viper.BindEnv limitation that only
+// one environment variable can be bound for an option, and we need multiple
+// environment variables due to backward compatibility reasons.
+func BindEnvWithLegacyEnvFallback(optName, legacyEnvName string) {
+	registerOpt(optName)
+
+	envName := getEnvName(optName)
+	if os.Getenv(envName) == "" {
+		envName = legacyEnvName
+	}
+
+	viper.BindEnv(optName, envName)
+}
+
+func registerOpt(optName string) {
 	_, ok := RegisteredOptions[optName]
 	if ok || optName == "" {
 		panic(fmt.Errorf("option already registered: %s", optName))
 	}
 	RegisteredOptions[optName] = struct{}{}
-	viper.BindEnv(optName, getEnvName(optName))
 }
 
 // LogRegisteredOptions logs all options that where bind to viper.

--- a/pkg/option/config_test.go
+++ b/pkg/option/config_test.go
@@ -223,3 +223,17 @@ func (s *OptionSuite) TestWorkloadsEnabled(c *C) {
 		}
 	}
 }
+
+func (s *OptionSuite) TestBindEnv(c *C) {
+	optName1 := "foo-bar"
+	os.Setenv("LEGACY_FOO_BAR", "legacy")
+	os.Setenv(getEnvName(optName1), "new")
+	BindEnvWithLegacyEnvFallback(optName1, "LEGACY_FOO_BAR")
+	c.Assert(viper.GetString(optName1), Equals, "new")
+
+	optName2 := "bar-foo"
+	BindEnvWithLegacyEnvFallback(optName2, "LEGACY_FOO_BAR")
+	c.Assert(viper.GetString(optName2), Equals, "legacy")
+
+	viper.Reset()
+}

--- a/pkg/policy/identifier.go
+++ b/pkg/policy/identifier.go
@@ -41,6 +41,8 @@ func NewIDSet() *IDSet {
 // * a means of incrementing its policy revision
 type Endpoint interface {
 	GetID16() uint16
+	RLockAlive() error
+	RUnlock()
 	GetSecurityIdentity() *identity.Identity
 	PolicyRevisionBumpEvent(rev uint64)
 }

--- a/pkg/policy/identifier_test.go
+++ b/pkg/policy/identifier_test.go
@@ -41,6 +41,14 @@ func (d *DummyEndpoint) PolicyRevisionBumpEvent(rev uint64) {
 	return
 }
 
+func (d *DummyEndpoint) RLockAlive() error {
+	return nil
+}
+
+func (d *DummyEndpoint) RUnlock() {
+	return
+}
+
 func (ds *PolicyTestSuite) TestNewEndpointSet(c *C) {
 	epSet := NewEndpointSet(20)
 	c.Assert(epSet.Len(), Equals, 0)

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -459,7 +459,16 @@ func (r ruleSlice) UpdateRulesEndpointsCaches(endpointsToBumpRevision *EndpointS
 	}
 
 	endpointsToBumpRevision.ForEach(policySelectionWG, func(epp Endpoint) {
-		if endpointSelected := r.updateEndpointsCaches(epp, endpointsToRegenerate); endpointSelected {
+		endpointSelected, err := r.updateEndpointsCaches(epp, endpointsToRegenerate)
+
+		// If we could not evaluate the rules against the current endpoint, or
+		// the endpoint is not selected by the rules, remove it from the set
+		// of endpoints to bump the revision. If the error is non-nil, the
+		// endpoint is no longer in either set (endpointsToBumpRevision or
+		// endpointsToRegenerate, as we could not determine what to do for the
+		// endpoint). This is usually the case when the endpoint is no longer
+		// alive (i.e., it has been marked to be deleted).
+		if endpointSelected || err != nil {
 			endpointsToBumpRevision.Delete(epp)
 		}
 	})

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -469,6 +469,9 @@ func (r ruleSlice) UpdateRulesEndpointsCaches(endpointsToBumpRevision *EndpointS
 		// endpoint). This is usually the case when the endpoint is no longer
 		// alive (i.e., it has been marked to be deleted).
 		if endpointSelected || err != nil {
+			if err != nil {
+				log.WithError(err).Debug("could not determine whether endpoint was selected by rule")
+			}
 			endpointsToBumpRevision.Delete(epp)
 		}
 	})

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -63,6 +63,14 @@ func (d *dummyEndpoint) PolicyRevisionBumpEvent(rev uint64) {
 	return
 }
 
+func (d *dummyEndpoint) RLockAlive() error {
+	return nil
+}
+
+func (d *dummyEndpoint) RUnlock() {
+	return
+}
+
 func (ds *PolicyTestSuite) SetUpSuite(c *C) {
 	var wg sync.WaitGroup
 	SetPolicyEnabled(option.DefaultEnforcement)


### PR DESCRIPTION
* PR: 7844 -- policy: ensure Endpoint lock held while accessing identity (@ianvernon) -- https://github.com/cilium/cilium/pull/7844
* PR: 7859 -- daemon,option: Work around the viper.BindEnv limitation of multiple binds (@brb) -- https://github.com/cilium/cilium/pull/7859
* PR: 7486 -- k8s/node-init: add node-init script to automatically restart pods managed by kubenet on GKE (@aanm) -- https://github.com/cilium/cilium/pull/7486

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7890)
<!-- Reviewable:end -->
