### PR TITLE
datapath/iptables: Warn when iptables modules are not available

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -249,7 +249,8 @@ func (m *IptablesManager) Init() {
 	if err := modulesManager.FindOrLoadModules(
 		"ip_tables", "iptable_nat", "iptable_mangle", "iptable_raw",
 		"iptable_filter"); err != nil {
-		log.WithError(err).Fatal("iptables modules could not be initialized")
+		log.WithError(err).Warning(
+			"iptables modules could not be initialized. It probably means that iptables is not available on this system")
 	}
 	if err := modulesManager.FindOrLoadModules(
 		"ip6_tables", "ip6table_mangle", "ip6table_raw"); err != nil {


### PR DESCRIPTION
Before this change, lack of iptables modules made Cilium fail with a
fatal error. However, it seems that some Linux distibutions (i.e. CoreOS
Container Linux) do not ship all netfilter modules we look for.

Fixes: 5b17c993e579 ("datapath/iptables: Check iptables kernel modules")
Ref: #7892

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7893)
<!-- Reviewable:end -->
