### PR TITLE
policy: Generate L3-only filter also for rules with requirements.

### DIFF
--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -1902,8 +1902,6 @@ Resolving ingress policy for [any:bar]
     Allows from labels {"matchLabels":{"any:baz":""},"matchExpressions":[{"key":"any:baz","operator":"In","values":[""]}]}
       No label match for [any:foo]
 * Rule {"matchLabels":{"any:bar":""}}: selected
-    Enforcing requirements [{Key:any.baz Operator:In Values:[]}]
-      No label match for [any:foo]
 3/3 rules selected
 Found no allow rule
 Ingress verdict: denied
@@ -1927,8 +1925,6 @@ Resolving ingress policy for [any:bar]
       Allows port [{80 ANY}]
         No port match found
 * Rule {"matchLabels":{"any:bar":""}}: selected
-    Enforcing requirements [{Key:any.baz Operator:In Values:[]}]
-      Found all required labels
 3/3 rules selected
 Found no allow rule
 Ingress verdict: denied

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -1022,6 +1022,9 @@ func (ds *PolicyTestSuite) TestL3DependentL4EgressFromRequires(c *C) {
 				}},
 			},
 			{
+				ToEndpoints: []api.EndpointSelector{
+					api.WildcardEndpointSelector,
+				},
 				ToRequires: []api.EndpointSelector{selBar2},
 			},
 		},
@@ -1048,8 +1051,26 @@ func (ds *PolicyTestSuite) TestL3DependentL4EgressFromRequires(c *C) {
 			Values:   []string{"bar2"},
 		},
 	})
+	expectedSelector2 := api.NewESFromMatchRequirements(map[string]string{}, []v1.LabelSelectorRequirement{
+		{
+			Key:      "any.id",
+			Operator: v1.LabelSelectorOpIn,
+			Values:   []string{"bar2"},
+		},
+	})
 
 	expectedPolicy := L4PolicyMap{
+		"0/ANY": L4Filter{
+			Port:          0,
+			Protocol:      "ANY",
+			U8Proto:       0x0,
+			allowsAllAtL3: false,
+			Endpoints: api.EndpointSelectorSlice{
+				expectedSelector2,
+			},
+			L7RulesPerEp:     L7DataMap{},
+			DerivedFromRules: labels.LabelArrayList{nil},
+		},
 		"80/TCP": L4Filter{
 			Port:     80,
 			Protocol: api.ProtoTCP,

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -237,9 +237,8 @@ func mergeIngress(ctx *SearchContext, rule api.IngressRule, ruleLabels labels.La
 			ctx.PolicyTrace("      No label match for %s", ctx.From)
 			return 0, nil
 		}
+		ctx.PolicyTrace("      Found all required labels")
 	}
-
-	ctx.PolicyTrace("      Found all required labels")
 
 	// Daemon options may induce L3 allows for host/world. In this case, if
 	// we find any L7 rules matching host/world then we need to turn any L7
@@ -356,17 +355,11 @@ func (r *rule) resolveIngressPolicy(ctx *SearchContext, state *traceState, resul
 		// from rules which select the labels in ctx.To. This ensures that
 		// FromRequires is taken into account even if it isn't part of the current
 		// rule over which we are iterating.
-		if len(requirements) > 0 {
+		if len(requirements) > 0 && len(ingressRule.FromEndpoints) > 0 {
 			// Create a deep copy of the rule, as we are going to modify FromEndpoints
 			// with requirementsSelector. We don't want to modify the rule itself
 			// in the policy repository.
 			ruleCopy = *ingressRule.DeepCopy()
-			// If the rule only consists of a FromRequires statement,
-			// provide an empty selector so that it will be updated
-			// in the next step.
-			if ctx.TraceEnabled() && len(ruleCopy.FromEndpoints) == 0 {
-				ruleCopy.FromEndpoints = []api.EndpointSelector{api.NewESFromLabels()}
-			}
 			// Update each EndpointSelector in FromEndpoints to contain requirements.
 			for idx := range ruleCopy.FromEndpoints {
 				ruleCopy.FromEndpoints[idx].MatchExpressions = append(ruleCopy.FromEndpoints[idx].MatchExpressions, requirements...)
@@ -626,9 +619,8 @@ func mergeEgress(ctx *SearchContext, rule api.EgressRule, ruleLabels labels.Labe
 			ctx.PolicyTrace("      No label match for %s", ctx.To)
 			return 0, nil
 		}
+		ctx.PolicyTrace("      Found all required labels")
 	}
-
-	ctx.PolicyTrace("      Found all required labels")
 
 	var (
 		cnt int
@@ -742,17 +734,11 @@ func (r *rule) resolveEgressPolicy(ctx *SearchContext, state *traceState, result
 		// from rules which select the labels in ctx.From. This ensures that
 		// ToRequires is taken into account even if it isn't part of the current
 		// rule over which we are iterating.
-		if len(requirements) > 0 {
+		if len(requirements) > 0 && len(egressRule.ToEndpoints) > 0 {
 			// Create a deep copy of the rule, as we are going to modify
 			// ToEndpoints with requirements; we don't want to modify the rule
 			// in the repository.
 			ruleCopy = *egressRule.DeepCopy()
-			// If the rule only consists of a ToRequires statement,
-			// provide an empty selector so that it will be updated
-			// in the next step.
-			if ctx.TraceEnabled() && len(ruleCopy.ToEndpoints) == 0 {
-				ruleCopy.ToEndpoints = []api.EndpointSelector{api.NewESFromLabels()}
-			}
 			for idx := range ruleCopy.ToEndpoints {
 				// Update each EndpointSelector in ToEndpoints to contain
 				// requirements.

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -255,8 +255,8 @@ func mergeIngress(ctx *SearchContext, rule api.IngressRule, ruleLabels labels.La
 		err error
 	)
 
-	// L3-only rule without requirements.
-	if len(rule.ToPorts) == 0 && len(rule.FromRequires) == 0 {
+	// L3-only rule (with requirements folded into fromEndpoints).
+	if len(rule.ToPorts) == 0 && len(fromEndpoints) > 0 {
 		cnt, err = mergeIngressPortProto(ctx, fromEndpoints, endpointsWithL3Override, api.PortRule{}, api.PortProtocol{Port: "0", Protocol: api.ProtoAny}, api.ProtoAny, ruleLabels, resMap)
 		if err != nil {
 			return found, err
@@ -627,8 +627,8 @@ func mergeEgress(ctx *SearchContext, rule api.EgressRule, ruleLabels labels.Labe
 		err error
 	)
 
-	// L3-only rule
-	if len(rule.ToPorts) == 0 && len(rule.ToRequires) == 0 {
+	// L3-only rule (with requirements folded into toEndpoints).
+	if len(rule.ToPorts) == 0 && len(toEndpoints) > 0 {
 		cnt, err = mergeEgressPortProto(ctx, toEndpoints, api.PortRule{}, api.PortProtocol{Port: "0", Protocol: api.ProtoAny}, api.ProtoAny, ruleLabels, resMap)
 		if err != nil {
 			return found, err


### PR DESCRIPTION
FromRequires can be placed into the same rule as FromEndpoints, and
an L3-only filter needs to be generated also in that case.

Basically, as [From|To]Requires affects all rules selected for a given
identity, the processing of individual rules should not depend on the
(non)precense of [From|To]Requires in the same rule.

Fixes: 7321663ff85 ("policy: store L3-only policy in L4Filter")
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7894)
<!-- Reviewable:end -->
