### PR TITLE
Fix bug where endpoint state metrics get stuck with nonzero endpoints in restoring state

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1600,12 +1600,7 @@ OKState:
 	e.state = toState
 	e.logStatusLocked(Other, OK, reason)
 
-	// Initial state transitions i.e nil --> waiting-for-identity
-	// need to be handled correctly while updating metrics.
-	// Note that if we are transitioning from some state to restoring
-	// state, we cannot decrement the old state counters as they will not
-	// be accounted for in the metrics.
-	if fromState != "" && toState != StateRestoring {
+	if fromState != "" {
 		metrics.EndpointStateCount.
 			WithLabelValues(fromState).Dec()
 	}
@@ -1672,7 +1667,7 @@ OKState:
 	e.state = toState
 	e.logStatusLocked(Other, OK, reason)
 
-	if fromState != "" && toState != StateRestoring {
+	if fromState != "" {
 		metrics.EndpointStateCount.
 			WithLabelValues(fromState).Dec()
 	}


### PR DESCRIPTION
Endpoint 'state' field is not stored/restored from the filesystem across
Cilium restart. However, the metrics decrement/increment code during
`SetStateLocked()` attempted to ensure that the metrics are not
decremented for old states during restore by checking the destination state.

When commit 69b90d33381d ("endpointmanager: Avoid regenerating restoring
endpoints") attempted to provide stronger guarantees about the state of
an endpoint's datapath during restore, it tripped this check because it
transitions from 'Restoring' state to 'Restoring' state. As a result, in
normal operation after a Cilium restart the metrics for endpoints in the
restoring state would get stuck at a value above zero, even after the
endpoint transitions into 'Ready' state.

Fixes: 69b90d33381d ("endpointmanager: Avoid regenerating restoring endpoints")
Reported-by: Luan Guimarães <luang@protonmail.ch>
Signed-off-by: Joe Stringer <joe@cilium.io>

Fixes: #7868

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7895)
<!-- Reviewable:end -->
