### PR TITLE
add option to enable or disable from default metrics

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -93,6 +93,7 @@ cilium-agent [flags]
       --log-opt map                                Log driver options for cilium (default map[])
       --log-system-load                            Enable periodic logging of system load
       --masquerade                                 Masquerade packets from endpoints leaving the host (default true)
+      --metrics strings                            Metrics that should be enabled or disabled from the default metric list. (+metric_foo to enable metric_foo , -metric_bar to disable metric_bar)
       --monitor-aggregation string                 Level of monitor aggregation for traces from the datapath (default "None")
       --monitor-queue-size int                     Size of the event queue when reading monitor events (default 32768)
       --mtu int                                    Overwrite auto-detected MTU of underlying network

--- a/common/utils.go
+++ b/common/utils.go
@@ -114,3 +114,13 @@ func MoveNewFilesTo(oldDir, newDir string) error {
 	}
 	return nil
 }
+
+// MapStringStructToSlice returns a slice with all keys of the given
+// map[string]struct{}
+func MapStringStructToSlice(m map[string]struct{}) []string {
+	s := make([]string, 0, len(m))
+	for k := range m {
+		s = append(s, k)
+	}
+	return s
+}

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -602,6 +602,9 @@ func init() {
 	flags.MarkHidden(option.MaxCtrlIntervalName)
 	option.BindEnv(option.MaxCtrlIntervalName)
 
+	flags.StringSlice(option.Metrics, []string{}, "Metrics that should be enabled or disabled from the default metric list. (+metric_foo to enable metric_foo , -metric_bar to disable metric_bar)")
+	option.BindEnv(option.Metrics)
+
 	flags.String(option.MonitorAggregationName, "None",
 		"Level of monitor aggregation for traces from the datapath")
 	option.BindEnvWithLegacyEnvFallback(option.MonitorAggregationName, "CILIUM_MONITOR_AGGREGATION_LEVEL")

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/metrics"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
@@ -151,6 +152,11 @@ func (ds *DaemonSuite) TearDownTest(c *C) {
 	cache.Close()
 
 	ds.d.Close()
+
+	_, collectors := metrics.CreateConfiguration(common.MapStringStructToSlice(metrics.DefaultMetrics()))
+	for _, collector := range collectors {
+		metrics.Unregister(collector)
+	}
 }
 
 type DaemonEtcdSuite struct {

--- a/daemon/metrics.go
+++ b/daemon/metrics.go
@@ -119,7 +119,7 @@ const (
 )
 
 var (
-	metricBootstrapTimes *prometheus.HistogramVec
+	metricBootstrapTimes prometheus.ObserverVec
 )
 
 func init() {

--- a/daemon/metrics.go
+++ b/daemon/metrics.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -112,12 +112,6 @@ func (b *bootstrapStatistics) getMap() map[string]*spanstat.SpanStat {
 	}
 }
 
-const (
-	metricSubsystem = "agent"
-
-	metricBootstrapOverall = "overall"
-)
-
 var (
 	metricBootstrapTimes prometheus.ObserverVec
 )
@@ -125,7 +119,7 @@ var (
 func init() {
 	metricBootstrapTimes = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: metrics.Namespace,
-		Subsystem: metricSubsystem,
+		Subsystem: metrics.Agent,
 		Name:      "bootstrap_seconds",
 		Help:      "Duration of bootstrap sequence",
 	}, []string{metrics.LabelScope, metrics.LabelOutcome})

--- a/daemon/metrics.go
+++ b/daemon/metrics.go
@@ -119,7 +119,7 @@ var (
 func init() {
 	metricBootstrapTimes = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: metrics.Namespace,
-		Subsystem: metrics.Agent,
+		Subsystem: metrics.SubsystemAgent,
 		Name:      "bootstrap_seconds",
 		Help:      "Duration of bootstrap sequence",
 	}, []string{metrics.LabelScope, metrics.LabelOutcome})

--- a/pkg/bpf/bpf_linux.go
+++ b/pkg/bpf/bpf_linux.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/spanstat"
 
 	"github.com/sirupsen/logrus"
@@ -60,14 +61,19 @@ func CreateMap(mapType int, keySize, valueSize, maxEntries, flags, innerID uint3
 		innerID,
 	}
 
-	duration := spanstat.Start()
+	var duration *spanstat.SpanStat
+	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
+		duration = spanstat.Start()
+	}
 	ret, _, err := unix.Syscall(
 		unix.SYS_BPF,
 		BPF_MAP_CREATE,
 		uintptr(unsafe.Pointer(&uba)),
 		unsafe.Sizeof(uba),
 	)
-	metricSyscallDuration.WithLabelValues(metricOpCreate, metrics.Errno2Outcome(err)).Observe(duration.End(err == 0).Total().Seconds())
+	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
+		metrics.BPFSyscallDuration.WithLabelValues(metricOpCreate, metrics.Errno2Outcome(err)).Observe(duration.End(err == 0).Total().Seconds())
+	}
 
 	if err != 0 {
 		return 0, &os.PathError{
@@ -103,14 +109,19 @@ func UpdateElement(fd int, key, value unsafe.Pointer, flags uint64) error {
 		flags: uint64(flags),
 	}
 
-	duration := spanstat.Start()
+	var duration *spanstat.SpanStat
+	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
+		duration = spanstat.Start()
+	}
 	ret, _, err := unix.Syscall(
 		unix.SYS_BPF,
 		BPF_MAP_UPDATE_ELEM,
 		uintptr(unsafe.Pointer(&uba)),
 		unsafe.Sizeof(uba),
 	)
-	metricSyscallDuration.WithLabelValues(metricOpUpdate, metrics.Errno2Outcome(err)).Observe(duration.End(err == 0).Total().Seconds())
+	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
+		metrics.BPFSyscallDuration.WithLabelValues(metricOpUpdate, metrics.Errno2Outcome(err)).Observe(duration.End(err == 0).Total().Seconds())
+	}
 
 	if ret != 0 || err != 0 {
 		return fmt.Errorf("Unable to update element for map with file descriptor %d: %s", fd, err)
@@ -128,14 +139,19 @@ func LookupElement(fd int, key, value unsafe.Pointer) error {
 		value: uint64(uintptr(value)),
 	}
 
-	duration := spanstat.Start()
+	var duration *spanstat.SpanStat
+	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
+		duration = spanstat.Start()
+	}
 	ret, _, err := unix.Syscall(
 		unix.SYS_BPF,
 		BPF_MAP_LOOKUP_ELEM,
 		uintptr(unsafe.Pointer(&uba)),
 		unsafe.Sizeof(uba),
 	)
-	metricSyscallDuration.WithLabelValues(metricOpLookup, metrics.Errno2Outcome(err)).Observe(duration.End(err == 0).Total().Seconds())
+	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
+		metrics.BPFSyscallDuration.WithLabelValues(metricOpLookup, metrics.Errno2Outcome(err)).Observe(duration.End(err == 0).Total().Seconds())
+	}
 
 	if ret != 0 || err != 0 {
 		return fmt.Errorf("Unable to lookup element in map with file descriptor %d: %s", fd, err)
@@ -149,14 +165,19 @@ func deleteElement(fd int, key unsafe.Pointer) (uintptr, syscall.Errno) {
 		mapFd: uint32(fd),
 		key:   uint64(uintptr(key)),
 	}
-	duration := spanstat.Start()
+	var duration *spanstat.SpanStat
+	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
+		duration = spanstat.Start()
+	}
 	ret, _, err := unix.Syscall(
 		unix.SYS_BPF,
 		BPF_MAP_DELETE_ELEM,
 		uintptr(unsafe.Pointer(&uba)),
 		unsafe.Sizeof(uba),
 	)
-	metricSyscallDuration.WithLabelValues(metricOpDelete, metrics.Errno2Outcome(err)).Observe(duration.End(err == 0).Total().Seconds())
+	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
+		metrics.BPFSyscallDuration.WithLabelValues(metricOpDelete, metrics.Errno2Outcome(err)).Observe(duration.End(err == 0).Total().Seconds())
+	}
 
 	return ret, err
 }
@@ -179,14 +200,20 @@ func GetNextKey(fd int, key, nextKey unsafe.Pointer) error {
 		key:   uint64(uintptr(key)),
 		value: uint64(uintptr(nextKey)),
 	}
-	duration := spanstat.Start()
+
+	var duration *spanstat.SpanStat
+	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
+		duration = spanstat.Start()
+	}
 	ret, _, err := unix.Syscall(
 		unix.SYS_BPF,
 		BPF_MAP_GET_NEXT_KEY,
 		uintptr(unsafe.Pointer(&uba)),
 		unsafe.Sizeof(uba),
 	)
-	metricSyscallDuration.WithLabelValues(metricOpGetNextKey, metrics.Errno2Outcome(err)).Observe(duration.End(err == 0).Total().Seconds())
+	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
+		metrics.BPFSyscallDuration.WithLabelValues(metricOpGetNextKey, metrics.Errno2Outcome(err)).Observe(duration.End(err == 0).Total().Seconds())
+	}
 
 	if ret != 0 || err != 0 {
 		return fmt.Errorf("Unable to get next key from map with file descriptor %d: %s", fd, err)
@@ -212,14 +239,19 @@ func ObjPin(fd int, pathname string) error {
 		fd:       uint32(fd),
 	}
 
-	duration := spanstat.Start()
+	var duration *spanstat.SpanStat
+	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
+		duration = spanstat.Start()
+	}
 	ret, _, err := unix.Syscall(
 		unix.SYS_BPF,
 		BPF_OBJ_PIN,
 		uintptr(unsafe.Pointer(&uba)),
 		unsafe.Sizeof(uba),
 	)
-	metricSyscallDuration.WithLabelValues(metricOpObjPin, metrics.Errno2Outcome(err)).Observe(duration.End(err == 0).Total().Seconds())
+	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
+		metrics.BPFSyscallDuration.WithLabelValues(metricOpObjPin, metrics.Errno2Outcome(err)).Observe(duration.End(err == 0).Total().Seconds())
+	}
 
 	if ret != 0 || err != 0 {
 		return fmt.Errorf("Unable to pin object with file descriptor %d to %s: %s", fd, pathname, err)
@@ -236,14 +268,19 @@ func ObjGet(pathname string) (int, error) {
 		pathname: uint64(uintptr(unsafe.Pointer(pathStr))),
 	}
 
-	duration := spanstat.Start()
+	var duration *spanstat.SpanStat
+	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
+		duration = spanstat.Start()
+	}
 	fd, _, err := unix.Syscall(
 		unix.SYS_BPF,
 		BPF_OBJ_GET,
 		uintptr(unsafe.Pointer(&uba)),
 		unsafe.Sizeof(uba),
 	)
-	metricSyscallDuration.WithLabelValues(metricOpObjGet, metrics.Errno2Outcome(err)).Observe(duration.End(err == 0).Total().Seconds())
+	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
+		metrics.BPFSyscallDuration.WithLabelValues(metricOpObjGet, metrics.Errno2Outcome(err)).Observe(duration.End(err == 0).Total().Seconds())
+	}
 
 	if fd == 0 || err != 0 {
 		return 0, &os.PathError{
@@ -268,14 +305,19 @@ func MapFdFromID(id int) (int, error) {
 		ID: uint32(id),
 	}
 
-	duration := spanstat.Start()
+	var duration *spanstat.SpanStat
+	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
+		duration = spanstat.Start()
+	}
 	fd, _, err := unix.Syscall(
 		unix.SYS_BPF,
 		BPF_MAP_GET_FD_BY_ID,
 		uintptr(unsafe.Pointer(&uba)),
 		unsafe.Sizeof(uba),
 	)
-	metricSyscallDuration.WithLabelValues(metricOpGetFDByID, metrics.Errno2Outcome(err)).Observe(duration.End(err == 0).Total().Seconds())
+	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
+		metrics.BPFSyscallDuration.WithLabelValues(metricOpGetFDByID, metrics.Errno2Outcome(err)).Observe(duration.End(err == 0).Total().Seconds())
+	}
 
 	if fd == 0 || err != 0 {
 		return 0, fmt.Errorf("Unable to get object fd from id %d: %s", id, err)

--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/option"
 
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
@@ -708,7 +709,9 @@ func (m *Map) Update(key MapKey, value MapValue) error {
 	}
 
 	err = UpdateElement(m.fd, key.GetKeyPtr(), value.GetValuePtr(), 0)
-	metricMapOps.WithLabelValues(m.commonName(), metricOpUpdate, metrics.Error2Outcome(err)).Inc()
+	if option.Config.MetricsConfig.BPFMapOps {
+		metrics.BPFMapOps.WithLabelValues(m.commonName(), metricOpUpdate, metrics.Error2Outcome(err)).Inc()
+	}
 	return err
 }
 
@@ -757,7 +760,9 @@ func (m *Map) DeleteWithErrno(key MapKey) (error, syscall.Errno) {
 	}
 
 	_, errno = deleteElement(m.fd, key.GetKeyPtr())
-	metricMapOps.WithLabelValues(m.commonName(), metricOpDelete, metrics.Errno2Outcome(errno)).Inc()
+	if option.Config.MetricsConfig.BPFMapOps {
+		metrics.BPFMapOps.WithLabelValues(m.commonName(), metricOpDelete, metrics.Errno2Outcome(errno)).Inc()
+	}
 	if errno != 0 {
 		err = fmt.Errorf("Unable to delete element from map %s: %s", m.name, errno.Error())
 	}
@@ -838,7 +843,9 @@ func (m *Map) GetNextKey(key MapKey, nextKey MapKey) error {
 	}
 
 	err := GetNextKey(m.fd, key.GetKeyPtr(), nextKey.GetKeyPtr())
-	metricMapOps.WithLabelValues(m.commonName(), metricOpGetNextKey, metrics.Error2Outcome(err)).Inc()
+	if option.Config.MetricsConfig.BPFMapOps {
+		metrics.BPFMapOps.WithLabelValues(m.commonName(), metricOpGetNextKey, metrics.Error2Outcome(err)).Inc()
+	}
 	return err
 }
 
@@ -926,7 +933,9 @@ func (m *Map) resolveErrors(ctx context.Context) error {
 		case OK:
 		case Insert:
 			err := UpdateElement(m.fd, e.Key.GetKeyPtr(), e.Value.GetValuePtr(), 0)
-			metricMapOps.WithLabelValues(m.commonName(), metricOpUpdate, metrics.Error2Outcome(err)).Inc()
+			if option.Config.MetricsConfig.BPFMapOps {
+				metrics.BPFMapOps.WithLabelValues(m.commonName(), metricOpUpdate, metrics.Error2Outcome(err)).Inc()
+			}
 			if err == nil {
 				e.DesiredAction = OK
 				e.LastError = nil
@@ -939,7 +948,9 @@ func (m *Map) resolveErrors(ctx context.Context) error {
 
 		case Delete:
 			_, err := deleteElement(m.fd, e.Key.GetKeyPtr())
-			metricMapOps.WithLabelValues(m.commonName(), metricOpDelete, metrics.Error2Outcome(err)).Inc()
+			if option.Config.MetricsConfig.BPFMapOps {
+				metrics.BPFMapOps.WithLabelValues(m.commonName(), metricOpDelete, metrics.Error2Outcome(err)).Inc()
+			}
 			if err == 0 || err == unix.ENOENT {
 				delete(m.cache, k)
 				resolved++

--- a/pkg/bpf/metrics.go
+++ b/pkg/bpf/metrics.go
@@ -42,8 +42,8 @@ const (
 )
 
 var (
-	metricSyscallDuration *prometheus.HistogramVec
-	metricMapOps          *prometheus.CounterVec
+	metricSyscallDuration prometheus.ObserverVec
+	metricMapOps          metrics.CounterVec
 )
 
 func init() {

--- a/pkg/bpf/metrics.go
+++ b/pkg/bpf/metrics.go
@@ -14,18 +14,7 @@
 
 package bpf
 
-import (
-	"github.com/cilium/cilium/pkg/metrics"
-
-	"github.com/prometheus/client_golang/prometheus"
-)
-
 const (
-	metricSubsystem = "bpf"
-
-	metricLabelOperation = "operation"
-	metricLabelMapName   = "mapName"
-
 	metricOpCreate           = "create"
 	metricOpUpdate           = "update"
 	metricOpLookup           = "lookup"
@@ -40,33 +29,3 @@ const (
 	metricOpPerfEventEnable  = "perfEventEnable"
 	metricOpPerfEventDisable = "perfEventDisable"
 )
-
-var (
-	metricSyscallDuration prometheus.ObserverVec
-	metricMapOps          metrics.CounterVec
-)
-
-func init() {
-	metricSyscallDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: metrics.Namespace,
-		Subsystem: metricSubsystem,
-		Name:      "syscall_duration_seconds",
-		Help:      "Duration of BPF system calls",
-	}, []string{metricLabelOperation, metrics.LabelOutcome})
-
-	if err := metrics.Register(metricSyscallDuration); err != nil {
-		log.WithError(err).Fatal("unable to register prometheus metric")
-	}
-
-	metricMapOps = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: metrics.Namespace,
-		Subsystem: metricSubsystem,
-		Name:      "map_ops_total",
-		Help:      "Total operations on map, tagged by map name",
-	},
-		[]string{metricLabelMapName, metricLabelOperation, metrics.LabelOutcome})
-
-	if err := metrics.Register(metricMapOps); err != nil {
-		log.WithError(err).Fatal("unable to register prometheus metric")
-	}
-}

--- a/pkg/bpf/perf_linux.go
+++ b/pkg/bpf/perf_linux.go
@@ -231,6 +231,7 @@ import (
 	"unsafe"
 
 	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/spanstat"
 
 	"golang.org/x/sys/unix"
@@ -324,7 +325,10 @@ func PerfEventOpen(config *PerfEventConfig, pid int, cpu int, groupFD int, flags
 		unsafe.Pointer(&attr),
 	)
 
-	duration := spanstat.Start()
+	var duration *spanstat.SpanStat
+	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
+		duration = spanstat.Start()
+	}
 	ret, _, err := unix.Syscall6(
 		unix.SYS_PERF_EVENT_OPEN,
 		uintptr(unsafe.Pointer(&attr)),
@@ -332,7 +336,9 @@ func PerfEventOpen(config *PerfEventConfig, pid int, cpu int, groupFD int, flags
 		uintptr(cpu),
 		uintptr(groupFD),
 		uintptr(flags), 0)
-	metricSyscallDuration.WithLabelValues(metricOpPerfEventOpen, metrics.Errno2Outcome(err)).Observe(duration.EndError(err).Total().Seconds())
+	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
+		metrics.BPFSyscallDuration.WithLabelValues(metricOpPerfEventOpen, metrics.Errno2Outcome(err)).Observe(duration.EndError(err).Total().Seconds())
+	}
 
 	if int(ret) > 0 && err == 0 {
 		return &PerfEvent{
@@ -385,9 +391,14 @@ func (e *PerfEvent) freeBuffers() {
 
 func (e *PerfEvent) Enable() error {
 	e.allocateBuffers()
-	duration := spanstat.Start()
+	var duration *spanstat.SpanStat
+	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
+		duration = spanstat.Start()
+	}
 	err := unix.IoctlSetInt(e.Fd, unix.PERF_EVENT_IOC_ENABLE, 0)
-	metricSyscallDuration.WithLabelValues(metricOpPerfEventEnable, metrics.Error2Outcome(err)).Observe(duration.EndError(err).Total().Seconds())
+	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
+		metrics.BPFSyscallDuration.WithLabelValues(metricOpPerfEventEnable, metrics.Error2Outcome(err)).Observe(duration.EndError(err).Total().Seconds())
+	}
 	if err != nil {
 		e.freeBuffers()
 		return fmt.Errorf("Unable to enable perf event: %v", err)
@@ -406,9 +417,14 @@ func (e *PerfEvent) Disable() error {
 	// Does not fail in perf's kernel-side ioctl handler, but even if
 	// there's not much we can do here ...
 	ret = nil
-	duration := spanstat.Start()
+	var duration *spanstat.SpanStat
+	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
+		duration = spanstat.Start()
+	}
 	err := unix.IoctlSetInt(e.Fd, unix.PERF_EVENT_IOC_DISABLE, 0)
-	metricSyscallDuration.WithLabelValues(metricOpPerfEventDisable, metrics.Error2Outcome(err)).Observe(duration.EndError(err).Total().Seconds())
+	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
+		metrics.BPFSyscallDuration.WithLabelValues(metricOpPerfEventDisable, metrics.Error2Outcome(err)).Observe(duration.EndError(err).Total().Seconds())
+	}
 	if err != nil {
 		ret = fmt.Errorf("Unable to disable perf event: %v", err)
 	}

--- a/pkg/bpf/prog_linux.go
+++ b/pkg/bpf/prog_linux.go
@@ -21,6 +21,7 @@ import (
 	"unsafe"
 
 	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/spanstat"
 
 	"golang.org/x/sys/unix"
@@ -72,9 +73,14 @@ func GetProgNextID(current uint32) (uint32, error) {
 		progID: current,
 	}
 
-	duration := spanstat.Start()
+	var duration *spanstat.SpanStat
+	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
+		duration = spanstat.Start()
+	}
 	ret, _, err := unix.Syscall(unix.SYS_BPF, BPF_PROG_GET_NEXT_ID, uintptr(unsafe.Pointer(&attr)), unsafe.Sizeof(attr))
-	metricSyscallDuration.WithLabelValues(metricOpProgGetNextID, metrics.Errno2Outcome(err)).Observe(duration.End(err == 0).Total().Seconds())
+	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
+		metrics.BPFSyscallDuration.WithLabelValues(metricOpProgGetNextID, metrics.Errno2Outcome(err)).Observe(duration.End(err == 0).Total().Seconds())
+	}
 	if ret != 0 || err != 0 {
 		return 0, fmt.Errorf("Unable to get next id: %v", err)
 	}
@@ -111,9 +117,14 @@ func GetProgInfoByFD(fd int) (ProgInfo, error) {
 		info: attrInfo,
 	}
 
-	duration := spanstat.Start()
+	var duration *spanstat.SpanStat
+	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
+		duration = spanstat.Start()
+	}
 	ret, _, err := unix.Syscall(unix.SYS_BPF, BPF_OBJ_GET_INFO_BY_FD, uintptr(unsafe.Pointer(&attr)), unsafe.Sizeof(attr))
-	metricSyscallDuration.WithLabelValues(metricOpObjGetInfoByFD, metrics.Errno2Outcome(err)).Observe(duration.End(err == 0).Total().Seconds())
+	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
+		metrics.BPFSyscallDuration.WithLabelValues(metricOpObjGetInfoByFD, metrics.Errno2Outcome(err)).Observe(duration.End(err == 0).Total().Seconds())
+	}
 	if ret != 0 || err != 0 {
 		return ProgInfo{}, fmt.Errorf("Unable to get object info: %v", err)
 	}

--- a/pkg/endpoint/metrics.go
+++ b/pkg/endpoint/metrics.go
@@ -37,7 +37,7 @@ type statistics interface {
 	GetMap() map[string]*spanstat.SpanStat
 }
 
-func sendMetrics(stats statistics, metric *prometheus.HistogramVec) {
+func sendMetrics(stats statistics, metric prometheus.ObserverVec) {
 	for scope, stat := range stats.GetMap() {
 		// Skip scopes that have not been hit (zero duration), so the count in
 		// the histogram accurately reflects the number of times each scope is

--- a/pkg/kvstore/metrics.go
+++ b/pkg/kvstore/metrics.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 const (
@@ -40,6 +41,9 @@ func getScopeFromKey(key string) string {
 }
 
 func increaseMetric(key, kind, action string, duration time.Duration, err error) {
+	if !option.Config.MetricsConfig.KVStoreOperationsDurationEnabled {
+		return
+	}
 	namespace := getScopeFromKey(key)
 	outcome := metrics.Error2Outcome(err)
 	metrics.KVStoreOperationsDuration.
@@ -47,5 +51,8 @@ func increaseMetric(key, kind, action string, duration time.Duration, err error)
 }
 
 func trackEventQueued(key string, typ EventType, duration time.Duration) {
+	if !option.Config.MetricsConfig.KVStoreEventsQueueDurationEnabled {
+		return
+	}
 	metrics.KVStoreEventsQueueDuration.WithLabelValues(getScopeFromKey(key), typ.String()).Observe(duration.Seconds())
 }

--- a/pkg/metrics/interfaces.go
+++ b/pkg/metrics/interfaces.go
@@ -1,0 +1,31 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type CounterVec interface {
+	WithLabelValues(lvls ...string) prometheus.Counter
+	GetMetricWithLabelValues(lvs ...string) (prometheus.Counter, error)
+	With(labels prometheus.Labels) prometheus.Counter
+	prometheus.Collector
+}
+
+type GaugeVec interface {
+	WithLabelValues(lvls ...string) prometheus.Gauge
+	prometheus.Collector
+}

--- a/pkg/metrics/interfaces.go
+++ b/pkg/metrics/interfaces.go
@@ -16,6 +16,7 @@ package metrics
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 )
 
 type CounterVec interface {
@@ -28,4 +29,107 @@ type CounterVec interface {
 type GaugeVec interface {
 	WithLabelValues(lvls ...string) prometheus.Gauge
 	prometheus.Collector
+}
+
+var (
+	NoOpMetric    prometheus.Metric    = &metric{}
+	NoOpCollector prometheus.Collector = &collector{}
+
+	NoOpCounter     prometheus.Counter     = &counter{NoOpMetric, NoOpCollector}
+	NoOpCounterVec  CounterVec             = &counterVec{NoOpCollector}
+	NoOpObserver    prometheus.Observer    = &observer{}
+	NoOpObserverVec prometheus.ObserverVec = &observerVec{NoOpCollector}
+	NoOpGauge       prometheus.Gauge       = &gauge{NoOpMetric, NoOpCollector}
+	NoOpGaugeVec    GaugeVec               = &gaugeVec{NoOpCollector}
+)
+
+// Metric
+
+type metric struct{}
+
+// *WARNING*: Desc returns nil so do not register this metric into prometheus
+// default register.
+func (m *metric) Desc() *prometheus.Desc  { return nil }
+func (m *metric) Write(*dto.Metric) error { return nil }
+
+// Collector
+
+type collector struct{}
+
+func (c *collector) Describe(chan<- *prometheus.Desc) {}
+func (c *collector) Collect(chan<- prometheus.Metric) {}
+
+// Counter
+
+type counter struct {
+	prometheus.Metric
+	prometheus.Collector
+}
+
+func (cv *counter) Add(float64) {}
+func (cv *counter) Inc()        {}
+
+// CounterVec
+
+type counterVec struct{ prometheus.Collector }
+
+func (cv *counterVec) WithLabelValues(lvls ...string) prometheus.Counter { return NoOpCounter }
+
+func (cv *counterVec) GetMetricWithLabelValues(lvs ...string) (prometheus.Counter, error) {
+	return NoOpCounter, nil
+}
+
+func (cv *counterVec) With(labels prometheus.Labels) prometheus.Counter { return NoOpCounter }
+
+// Observer
+
+type observer struct{}
+
+func (o *observer) Observe(float64) {}
+
+// ObserverVec
+
+type observerVec struct {
+	prometheus.Collector
+}
+
+func (ov *observerVec) GetMetricWith(prometheus.Labels) (prometheus.Observer, error) {
+	return NoOpObserver, nil
+}
+func (ov *observerVec) GetMetricWithLabelValues(lvs ...string) (prometheus.Observer, error) {
+	return NoOpObserver, nil
+}
+
+func (ov *observerVec) With(prometheus.Labels) prometheus.Observer    { return NoOpObserver }
+func (ov *observerVec) WithLabelValues(...string) prometheus.Observer { return NoOpObserver }
+
+func (ov *observerVec) CurryWith(prometheus.Labels) (prometheus.ObserverVec, error) {
+	return NoOpObserverVec, nil
+}
+func (ov *observerVec) MustCurryWith(prometheus.Labels) prometheus.ObserverVec {
+	return NoOpObserverVec
+}
+
+// Gauge
+
+type gauge struct {
+	prometheus.Metric
+	prometheus.Collector
+}
+
+func (g *gauge) Set(float64)       {}
+func (g *gauge) Inc()              {}
+func (g *gauge) Dec()              {}
+func (g *gauge) Add(float64)       {}
+func (g *gauge) Sub(float64)       {}
+func (g *gauge) SetToCurrentTime() {}
+
+// GaugeVec
+
+type gaugeVec struct {
+	prometheus.Collector
+}
+
+func (gv *gaugeVec) WithLabelValues(lvls ...string) prometheus.Gauge {
+	return NoOpGauge
 }

--- a/pkg/metrics/logging_hook.go
+++ b/pkg/metrics/logging_hook.go
@@ -21,14 +21,13 @@ import (
 	"github.com/cilium/cilium/pkg/components"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 )
 
 // LoggingHook is a hook for logrus which counts error and warning messages as a
 // Prometheus metric.
 type LoggingHook struct {
-	metric *prometheus.CounterVec
+	metric CounterVec
 }
 
 // NewLoggingHook returns a new instance of LoggingHook for the given Cilium
@@ -39,7 +38,7 @@ func NewLoggingHook(component string) *LoggingHook {
 	// cilium-health - GH-4268) is planned.
 
 	// Pick a metric for the component.
-	var metric *prometheus.CounterVec
+	var metric CounterVec
 	switch component {
 	case components.CiliumAgentName:
 		metric = ErrorsWarnings

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -529,11 +529,7 @@ var (
 
 	// FQDNGarbageCollectorCleanedTotal is the number of domains cleaned by the
 	// GC job.
-	FQDNGarbageCollectorCleanedTotal = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Name:      "fqdn_gc_deletions_total",
-		Help:      "Number of FQDNs that have been cleaned on FQDN Garbage collector job",
-	})
+	FQDNGarbageCollectorCleanedTotal = NoOpCounter
 )
 
 func init() {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -148,7 +148,7 @@ var (
 
 	// APIInteractions is the total time taken to process an API call made
 	// to the cilium-agent
-	APIInteractions = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	APIInteractions prometheus.ObserverVec = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: Namespace,
 		Subsystem: Agent,
 		Name:      "api_process_time_seconds",
@@ -170,7 +170,7 @@ var (
 
 	// EndpointRegenerationCount is a count of the number of times any endpoint
 	// has been regenerated and success/fail outcome
-	EndpointRegenerationCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+	EndpointRegenerationCount CounterVec = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: Namespace,
 		Name:      "endpoint_regenerations",
 		Help:      "Count of all endpoint regenerations that have completed, tagged by outcome",
@@ -178,7 +178,7 @@ var (
 		[]string{"outcome"})
 
 	// EndpointStateCount is the total count of the endpoints in various states.
-	EndpointStateCount = prometheus.NewGaugeVec(
+	EndpointStateCount GaugeVec = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: Namespace,
 			Name:      "endpoint_state",
@@ -189,7 +189,7 @@ var (
 
 	// EndpointRegenerationTimeStats is the total time taken to regenerate
 	// endpoints, labeled by span name and status ("success" or "failure")
-	EndpointRegenerationTimeStats = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	EndpointRegenerationTimeStats prometheus.ObserverVec = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: Namespace,
 		Name:      "endpoint_regeneration_time_stats_seconds",
 		Help:      "Endpoint regeneration time stats labeled by the scope",
@@ -213,7 +213,7 @@ var (
 	})
 
 	// PolicyRegenerationTimeStats is the total time taken to generate policies
-	PolicyRegenerationTimeStats = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	PolicyRegenerationTimeStats prometheus.ObserverVec = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: Namespace,
 		Name:      "policy_regeneration_time_stats_seconds",
 		Help:      "Policy regeneration time stats labeled by the scope",
@@ -234,7 +234,7 @@ var (
 	})
 
 	// PolicyEndpointStatus is the number of endpoints with policy labeled by enforcement type
-	PolicyEndpointStatus = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	PolicyEndpointStatus GaugeVec = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "policy_endpoint_enforcement_status",
 		Help:      "Number of endpoints labeled by policy enforcement status",
@@ -245,7 +245,7 @@ var (
 	// per Endpoint. This reflects the actual delay percieved by traffic flowing
 	// through the datapath. The longest times will roughly correlate with the
 	// time taken to fully deploy an endpoint.
-	PolicyImplementationDelay = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	PolicyImplementationDelay prometheus.ObserverVec = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: Namespace,
 		Name:      "policy_implementation_delay",
 		Help:      "Time between a policy change and it being fully deployed into the datapath",
@@ -284,7 +284,7 @@ var (
 	// L7 statistics
 
 	// ProxyRedirects is the number of redirects labelled by protocol
-	ProxyRedirects = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	ProxyRedirects GaugeVec = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Name:      "proxy_redirects",
 		Help:      "Number of redirects installed for endpoints, labeled by protocol",
@@ -320,7 +320,7 @@ var (
 
 	// ProxyUpstreamTime is how long the upstream server took to reply labeled
 	// by error, protocol and span time
-	ProxyUpstreamTime = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	ProxyUpstreamTime prometheus.ObserverVec = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: Namespace,
 		Name:      "proxy_upstream_reply_seconds",
 		Help:      "Seconds waited to get a reply from a upstream server",
@@ -330,7 +330,7 @@ var (
 
 	// DropCount is the total drop requests,
 	// tagged by drop reason and direction(ingress/egress)
-	DropCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+	DropCount CounterVec = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: Namespace,
 		Name:      "drop_count_total",
 		Help:      "Total dropped packets, tagged by drop reason and ingress/egress direction",
@@ -339,7 +339,7 @@ var (
 
 	// DropBytes is the total dropped bytes,
 	// tagged by drop reason and direction(ingress/egress)
-	DropBytes = prometheus.NewCounterVec(prometheus.CounterOpts{
+	DropBytes CounterVec = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: Namespace,
 		Name:      "drop_bytes_total",
 		Help:      "Total dropped bytes, tagged by drop reason and ingress/egress direction",
@@ -348,7 +348,7 @@ var (
 
 	// ForwardCount is the total forwarded packets,
 	// tagged by ingress/egress direction
-	ForwardCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+	ForwardCount CounterVec = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: Namespace,
 		Name:      "forward_count_total",
 		Help:      "Total forwarded packets, tagged by ingress/egress direction",
@@ -357,7 +357,7 @@ var (
 
 	// ForwardBytes is the total forwarded bytes,
 	// tagged by ingress/egress direction
-	ForwardBytes = prometheus.NewCounterVec(prometheus.CounterOpts{
+	ForwardBytes CounterVec = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: Namespace,
 		Name:      "forward_bytes_total",
 		Help:      "Total forwarded bytes, tagged by ingress/egress direction",
@@ -368,7 +368,7 @@ var (
 
 	// DatapathErrors is the number of errors managing datapath components
 	// such as BPF maps.
-	DatapathErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
+	DatapathErrors CounterVec = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: Namespace,
 		Subsystem: Datapath,
 		Name:      "errors_total",
@@ -377,7 +377,7 @@ var (
 
 	// ConntrackGCRuns is the number of times that the conntrack GC
 	// process was run.
-	ConntrackGCRuns = prometheus.NewCounterVec(prometheus.CounterOpts{
+	ConntrackGCRuns CounterVec = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: Namespace,
 		Subsystem: Datapath,
 		Name:      "conntrack_gc_runs_total",
@@ -386,7 +386,7 @@ var (
 	}, []string{LabelDatapathFamily, LabelProtocol, LabelStatus})
 
 	// ConntrackGCKeyFallbacks number of times that the conntrack key fallback was invalid.
-	ConntrackGCKeyFallbacks = prometheus.NewCounterVec(prometheus.CounterOpts{
+	ConntrackGCKeyFallbacks CounterVec = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: Namespace,
 		Subsystem: Datapath,
 		Name:      "conntrack_gc_key_fallbacks_total",
@@ -394,7 +394,7 @@ var (
 	}, []string{LabelDatapathFamily, LabelProtocol})
 
 	// ConntrackGCSize the number of entries in the conntrack table
-	ConntrackGCSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	ConntrackGCSize GaugeVec = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: Datapath,
 		Name:      "conntrack_gc_entries",
@@ -403,7 +403,7 @@ var (
 	}, []string{LabelDatapathFamily, LabelProtocol, LabelStatus})
 
 	// ConntrackGCDuration the duration of the conntrack GC process in milliseconds.
-	ConntrackGCDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	ConntrackGCDuration prometheus.ObserverVec = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: Namespace,
 		Subsystem: Datapath,
 		Name:      "conntrack_gc_duration_seconds",
@@ -414,7 +414,7 @@ var (
 	// Services
 
 	// ServicesCount number of services
-	ServicesCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+	ServicesCount CounterVec = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: Namespace,
 		Name:      "services_events_total",
 		Help:      "Number of services events labeled by action type",
@@ -423,28 +423,28 @@ var (
 	// Errors and warnings
 
 	// ErrorsWarnings is the number of errors and warnings in cilium-agent instances
-	ErrorsWarnings = prometheus.NewCounterVec(prometheus.CounterOpts{
+	ErrorsWarnings CounterVec = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: Namespace,
 		Name:      "errors_warnings_total",
 		Help:      "Number of total errors in cilium-agent instances",
 	}, []string{"level", "subsystem"})
 
 	// ControllerRuns is the number of times that a controller process runs.
-	ControllerRuns = prometheus.NewCounterVec(prometheus.CounterOpts{
+	ControllerRuns CounterVec = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: Namespace,
 		Name:      "controllers_runs_total",
 		Help:      "Number of times that a controller process was run labeled by completion status",
 	}, []string{LabelStatus})
 
 	// ControllerRunsDuration the duration of the controller process in seconds
-	ControllerRunsDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	ControllerRunsDuration prometheus.ObserverVec = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: Namespace,
 		Name:      "controllers_runs_duration_seconds",
 		Help:      "Duration in seconds of the controller process labeled by completion status",
 	}, []string{LabelStatus})
 
 	// subprocess, labeled by Subsystem
-	SubprocessStart = prometheus.NewCounterVec(prometheus.CounterOpts{
+	SubprocessStart CounterVec = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: Namespace,
 		Name:      "subprocess_start_total",
 		Help:      "Number of times that Cilium has started a subprocess, labeled by subsystem",
@@ -454,7 +454,7 @@ var (
 
 	// KubernetesEventProcessed is the number of Kubernetes events
 	// processed labeled by scope, action and execution result
-	KubernetesEventProcessed = prometheus.NewCounterVec(prometheus.CounterOpts{
+	KubernetesEventProcessed CounterVec = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: Namespace,
 		Name:      "kubernetes_events_total",
 		Help:      "Number of Kubernetes events processed labeled by scope, action and execution result",
@@ -462,7 +462,7 @@ var (
 
 	// KubernetesEventReceived is the number of Kubernetes events received
 	// labeled by scope, action, valid data and equalness.
-	KubernetesEventReceived = prometheus.NewCounterVec(prometheus.CounterOpts{
+	KubernetesEventReceived CounterVec = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: Namespace,
 		Name:      "kubernetes_events_received_total",
 		Help:      "Number of Kubernetes events processed labeled by scope, action and execution result",
@@ -472,7 +472,7 @@ var (
 
 	// KubernetesAPIInteractions is the total time taken to process an API call made
 	// to the kube-apiserver
-	KubernetesAPIInteractions = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	KubernetesAPIInteractions prometheus.ObserverVec = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: Namespace,
 		Subsystem: K8sClient,
 		Name:      "api_latency_time_seconds",
@@ -481,7 +481,7 @@ var (
 
 	// KubernetesAPICalls is the counter for all API calls made to
 	// kube-apiserver.
-	KubernetesAPICalls = prometheus.NewCounterVec(prometheus.CounterOpts{
+	KubernetesAPICalls CounterVec = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: Namespace,
 		Subsystem: K8sClient,
 		Name:      "api_calls_counter",
@@ -490,7 +490,7 @@ var (
 
 	// KubernetesCNPStatusCompletion is the number of seconds it takes to
 	// complete a CNP status update
-	KubernetesCNPStatusCompletion = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	KubernetesCNPStatusCompletion prometheus.ObserverVec = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: Namespace,
 		Subsystem: K8s,
 		Name:      "cnp_status_completion_seconds",
@@ -501,7 +501,7 @@ var (
 
 	// IpamEvent is the number of IPAM events received labeled by action and
 	// datapath family type
-	IpamEvent = prometheus.NewCounterVec(prometheus.CounterOpts{
+	IpamEvent CounterVec = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: Namespace,
 		Name:      "ipam_events_total",
 		Help:      "Number of IPAM events received labeled by action and datapath family type",
@@ -510,7 +510,7 @@ var (
 	// KVstore events
 
 	// KVStoreOperationsDuration records the duration of kvstore operations
-	KVStoreOperationsDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	KVStoreOperationsDuration prometheus.ObserverVec = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: Namespace,
 		Subsystem: "kvstore",
 		Name:      "operations_duration_seconds",
@@ -519,7 +519,7 @@ var (
 
 	// KVStoreEventsQueueDuration records the duration in seconds of time
 	// received event was blocked before it could be queued
-	KVStoreEventsQueueDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	KVStoreEventsQueueDuration prometheus.ObserverVec = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: Namespace,
 		Subsystem: "kvstore",
 		Name:      "events_queue_seconds",

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -41,27 +41,35 @@ const (
 
 	//L7DNS is the value used to report DNS label on metrics
 	L7DNS = "dns"
-)
 
-var (
-	registry = prometheus.NewPedanticRegistry()
+	// SubsystemBPF is the subsystem to scope metrics related to the bpf syscalls.
+	SubsystemBPF = "bpf"
+
+	// SubsystemDatapath is the subsystem to scope metrics related to management of
+	// the datapath. It is prepended to metric names and separated with a '_'.
+	SubsystemDatapath = "datapath"
+
+	// SubsystemAgent is the subsystem to scope metrics related to the cilium agent itself.
+	SubsystemAgent = "agent"
+
+	// SubsystemK8s is the subsystem to scope metrics related to Kubernetes
+	SubsystemK8s = "k8s"
+
+	// SubsystemK8sClient is the subsystem to scope metrics related to the kubernetes client.
+	SubsystemK8sClient = "k8s_client"
+
+	// SubsystemKVStore is the subsystem to scope metrics related to the kvstore.
+	SubsystemKVStore = "kvstore"
+
+	// SubsystemNodes is the subsystem to scope metrics related to the node manager.
+	SubsystemNodes = "nodes"
+
+	// SubsystemTriggers is the subsystem to scope metrics related to the trigger package.
+	SubsystemTriggers = "triggers"
 
 	// Namespace is used to scope metrics from cilium. It is prepended to metric
 	// names and separated with a '_'
 	Namespace = "cilium"
-
-	// Datapath is the subsystem to scope metrics related to management of
-	// the datapath. It is prepended to metric names and separated with a '_'.
-	Datapath = "datapath"
-
-	// Agent is the subsystem to scope metrics related to the cilium agent itself.
-	Agent = "agent"
-
-	// K8s is the subsystem to scope metrics related to Kubernetes
-	K8s = "k8s"
-
-	// K8sClient is the subsystem to scope metrics related to the kubernetes client.
-	K8sClient = "k8s_client"
 
 	// LabelOutcome indicates whether the outcome of the operation was successful or not
 	LabelOutcome = "outcome"
@@ -105,10 +113,10 @@ var (
 	// LabelStatus the label from completed task
 	LabelStatus = "status"
 
-	//LabelPolicyEnforcement is the label used to see the enforcement status
+	// LabelPolicyEnforcement is the label used to see the enforcement status
 	LabelPolicyEnforcement = "enforcement"
 
-	//LabelPolicySource is the label used to see the enforcement status
+	// LabelPolicySource is the label used to see the enforcement status
 	LabelPolicySource = "source"
 
 	// LabelScope is the label used to defined multiples scopes in the same
@@ -143,6 +151,10 @@ var (
 
 	// LabelAPIReturnCode is the HTTP code returned for that API path
 	LabelAPIReturnCode = "return_code"
+)
+
+var (
+	registry = prometheus.NewPedanticRegistry()
 
 	// API interactions
 
@@ -150,7 +162,7 @@ var (
 	// to the cilium-agent
 	APIInteractions prometheus.ObserverVec = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: Namespace,
-		Subsystem: Agent,
+		Subsystem: SubsystemAgent,
 		Name:      "api_process_time_seconds",
 		Help:      "Duration of processed API calls labeled by path, method and return code.",
 	}, []string{LabelPath, LabelMethod, LabelAPIReturnCode})
@@ -370,7 +382,7 @@ var (
 	// such as BPF maps.
 	DatapathErrors CounterVec = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: Namespace,
-		Subsystem: Datapath,
+		Subsystem: SubsystemDatapath,
 		Name:      "errors_total",
 		Help:      "Number of errors that occurred in the datapath or datapath management",
 	}, []string{LabelDatapathArea, LabelDatapathName, LabelDatapathFamily})
@@ -379,7 +391,7 @@ var (
 	// process was run.
 	ConntrackGCRuns CounterVec = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: Namespace,
-		Subsystem: Datapath,
+		Subsystem: SubsystemDatapath,
 		Name:      "conntrack_gc_runs_total",
 		Help: "Number of times that the conntrack garbage collector process was run " +
 			"labeled by completion status",
@@ -388,7 +400,7 @@ var (
 	// ConntrackGCKeyFallbacks number of times that the conntrack key fallback was invalid.
 	ConntrackGCKeyFallbacks CounterVec = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: Namespace,
-		Subsystem: Datapath,
+		Subsystem: SubsystemDatapath,
 		Name:      "conntrack_gc_key_fallbacks_total",
 		Help:      "Number of times a key fallback was needed when iterating over the BPF map",
 	}, []string{LabelDatapathFamily, LabelProtocol})
@@ -396,7 +408,7 @@ var (
 	// ConntrackGCSize the number of entries in the conntrack table
 	ConntrackGCSize GaugeVec = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
-		Subsystem: Datapath,
+		Subsystem: SubsystemDatapath,
 		Name:      "conntrack_gc_entries",
 		Help: "The number of alive and deleted conntrack entries at the end " +
 			"of a garbage collector run labeled by datapath family.",
@@ -405,7 +417,7 @@ var (
 	// ConntrackGCDuration the duration of the conntrack GC process in milliseconds.
 	ConntrackGCDuration prometheus.ObserverVec = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: Namespace,
-		Subsystem: Datapath,
+		Subsystem: SubsystemDatapath,
 		Name:      "conntrack_gc_duration_seconds",
 		Help: "Duration in seconds of the garbage collector process " +
 			"labeled by datapath family and completion status",
@@ -474,7 +486,7 @@ var (
 	// to the kube-apiserver
 	KubernetesAPIInteractions prometheus.ObserverVec = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: Namespace,
-		Subsystem: K8sClient,
+		Subsystem: SubsystemK8sClient,
 		Name:      "api_latency_time_seconds",
 		Help:      "Duration of processed API calls labeled by path and method.",
 	}, []string{LabelPath, LabelMethod})
@@ -483,7 +495,7 @@ var (
 	// kube-apiserver.
 	KubernetesAPICalls CounterVec = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: Namespace,
-		Subsystem: K8sClient,
+		Subsystem: SubsystemK8sClient,
 		Name:      "api_calls_counter",
 		Help:      "Number of API calls made to kube-apiserver labeled by host, method and return code.",
 	}, []string{"host", LabelMethod, LabelAPIReturnCode})
@@ -492,7 +504,7 @@ var (
 	// complete a CNP status update
 	KubernetesCNPStatusCompletion prometheus.ObserverVec = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: Namespace,
-		Subsystem: K8s,
+		Subsystem: SubsystemK8s,
 		Name:      "cnp_status_completion_seconds",
 		Help:      "Duration in seconds in how long it took to complete a CNP status update",
 	}, []string{LabelAttempts, LabelOutcome})
@@ -512,7 +524,7 @@ var (
 	// KVStoreOperationsDuration records the duration of kvstore operations
 	KVStoreOperationsDuration prometheus.ObserverVec = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: Namespace,
-		Subsystem: "kvstore",
+		Subsystem: SubsystemKVStore,
 		Name:      "operations_duration_seconds",
 		Help:      "Duration in seconds of kvstore operations",
 	}, []string{LabelScope, LabelKind, LabelAction, LabelOutcome})
@@ -521,7 +533,7 @@ var (
 	// received event was blocked before it could be queued
 	KVStoreEventsQueueDuration prometheus.ObserverVec = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: Namespace,
-		Subsystem: "kvstore",
+		Subsystem: SubsystemKVStore,
 		Name:      "events_queue_seconds",
 		Help:      "Duration in seconds of time received event was blocked before it could be queued",
 		Buckets:   []float64{.002, .005, .01, .015, .025, .05, .1, .25, .5, .75, 1},

--- a/pkg/metrics/middleware.go
+++ b/pkg/metrics/middleware.go
@@ -30,7 +30,7 @@ import (
 type APIEventTSHelper struct {
 	Next      http.Handler
 	TSGauge   prometheus.Gauge
-	Histogram *prometheus.HistogramVec
+	Histogram prometheus.ObserverVec
 }
 
 type responderWrapper struct {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1265,7 +1265,7 @@ func (c *DaemonConfig) Populate() {
 	var collectors []prometheus.Collector
 	metricsSlice := common.MapStringStructToSlice(defaultMetrics)
 	c.MetricsConfig, collectors = metrics.CreateConfiguration(metricsSlice)
-	prometheus.MustRegister(collectors...)
+	metrics.MustRegister(collectors...)
 
 	// Hidden options
 	c.ConfigFile = viper.GetString(ConfigFile)

--- a/pkg/trigger/trigger.go
+++ b/pkg/trigger/trigger.go
@@ -89,9 +89,9 @@ type Trigger struct {
 	// closeChan is used to stop the background trigger routine
 	closeChan chan struct{}
 
-	triggerReasons *prometheus.CounterVec
+	triggerReasons metrics.CounterVec
 	triggerFolds   prometheus.Gauge
-	callDurations  *prometheus.HistogramVec
+	callDurations  prometheus.ObserverVec
 
 	// numFolds is the current count of folds that happened into the
 	// currently scheduled trigger


### PR DESCRIPTION
This PR adds metric levels which allows for users to specify which metrics they want to choose. Right now the bpf syscalls metrics will be the only ones not considered the default.

```release-note
Add option to enable or disable from default metrics (`+metric_foo` to enable `metric_foo`, `-metric_bar` to disable `metric_bar`)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7896)
<!-- Reviewable:end -->
