### PR TITLE
test: Add readiness probe to demo deployments

### DIFF
--- a/test/k8sT/manifests/demo.yaml
+++ b/test/k8sT/manifests/demo.yaml
@@ -38,6 +38,10 @@ spec:
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
       nodeSelector:
         "kubernetes.io/hostname": k8s1
 ---

--- a/test/k8sT/manifests/demo_ds.yaml
+++ b/test/k8sT/manifests/demo_ds.yaml
@@ -16,6 +16,10 @@ spec:
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
       terminationGracePeriodSeconds: 0
       tolerations:
       - effect: NoSchedule


### PR DESCRIPTION
The CI code was waiting for the pods to be marked as ready but there was no
readiness probe so it was possible for the connectivity to be checked before
the server pod was up and running properly.

Fixes: #7902

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7903)
<!-- Reviewable:end -->
