### PR TITLE
v1.5: backports 19-05-01

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -232,7 +232,8 @@ func (m *IptablesManager) Init() {
 	if err := modulesManager.FindOrLoadModules(
 		"ip_tables", "iptable_nat", "iptable_mangle", "iptable_raw",
 		"iptable_filter"); err != nil {
-		log.WithError(err).Fatal("iptables modules could not be initialized")
+		log.WithError(err).Warning(
+			"iptables modules could not be initialized. It probably means that iptables is not available on this system")
 	}
 	if err := modulesManager.FindOrLoadModules(
 		"ip6_tables", "ip6table_mangle", "ip6table_raw"); err != nil {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1577,12 +1577,7 @@ OKState:
 	e.state = toState
 	e.logStatusLocked(Other, OK, reason)
 
-	// Initial state transitions i.e nil --> waiting-for-identity
-	// need to be handled correctly while updating metrics.
-	// Note that if we are transitioning from some state to restoring
-	// state, we cannot decrement the old state counters as they will not
-	// be accounted for in the metrics.
-	if fromState != "" && toState != StateRestoring {
+	if fromState != "" {
 		metrics.EndpointStateCount.
 			WithLabelValues(fromState).Dec()
 	}
@@ -1649,7 +1644,7 @@ OKState:
 	e.state = toState
 	e.logStatusLocked(Other, OK, reason)
 
-	if fromState != "" && toState != StateRestoring {
+	if fromState != "" {
 		metrics.EndpointStateCount.
 			WithLabelValues(fromState).Dec()
 	}

--- a/test/helpers/docker.go
+++ b/test/helpers/docker.go
@@ -167,10 +167,12 @@ func (s *SSHMeta) SampleContainersActions(mode string, networkName string, creat
 		for k, v := range images {
 			s.ContainerCreate(k, v, networkName, fmt.Sprintf("-l id.%s %s", k, createOptionsString))
 		}
+		s.WaitEndpointsReady()
 	case Delete:
 		for k := range images {
 			s.ContainerRm(k)
 		}
+		s.WaitEndpointsDeleted()
 	}
 }
 


### PR DESCRIPTION
* PR: 7893 -- datapath/iptables: Warn when iptables modules are not available (@mrostecki) -- https://github.com/cilium/cilium/pull/7893
* PR: 7895 -- Fix bug where endpoint state metrics get stuck with nonzero endpoints in restoring state (@joestringer) -- https://github.com/cilium/cilium/pull/7895
* PR: 7889 -- CI: Wait on create/delete in helpers.SampleContainersAction (@raybejjani) -- https://github.com/cilium/cilium/pull/7889

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7904)
<!-- Reviewable:end -->
