### PR TITLE
test: Bump ubuntu-next version to 23

### DIFF
--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -10,7 +10,7 @@ $NFS = ENV['NFS']=="1"? true : false
 $SERVER_BOX = (ENV['SERVER_BOX'] || "cilium/ubuntu-dev")
 $SERVER_VERSION= "147"
 $NETNEXT_SERVER_BOX= "cilium/ubuntu-next"
-$NETNEXT_SERVER_VERSION= "21"
+$NETNEXT_SERVER_VERSION= "23"
 $IPv6=(ENV['IPv6'] || "0")
 $CONTAINER_RUNTIME=(ENV['CONTAINER_RUNTIME'] || "docker")
 $CNI_INTEGRATION=(ENV['CNI_INTEGRATION'] || "")


### PR DESCRIPTION
Notable changes:

- Get rid of custom kernel patches.
- Update vboxsf to work with VirtualBox v6.
- Cache some container images used by Docker (incl. `cilium-runtime` to include iproute2 changes for the host lb).
- Kernel version `linux-5.1.0-rc5`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7908)
<!-- Reviewable:end -->
