### PR TITLE
CI: Ensure k8s execs cancel contexts

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -311,7 +311,12 @@ func (kub *Kubectl) GetPodNames(namespace string, label string) ([]string, error
 
 	cmd := fmt.Sprintf("%s -n %s get pods -l %s %s", KubectlCmd, namespace, label, filter)
 
-	err := kub.ExecuteContext(context.TODO(), cmd, stdout, nil)
+	// Since we have no timeout, ensure that the context given to ExecuteContext
+	// eventually cancels in case something is blocked on ctx.Done() (something
+	// is).
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	err := kub.ExecuteContext(ctx, cmd, stdout, nil)
 
 	if err != nil {
 		return nil, fmt.Errorf(

--- a/test/helpers/node.go
+++ b/test/helpers/node.go
@@ -158,7 +158,12 @@ type ExecOptions struct {
 
 // Exec returns the results of executing the provided cmd via SSH.
 func (s *SSHMeta) Exec(cmd string, options ...ExecOptions) *CmdRes {
-	return s.ExecContext(context.Background(), cmd, options...)
+	// Since we have no timeout, ensure that the context given to ExecContext
+	// eventually cancels in case something is blocked on ctx.Done() (something
+	// is).
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	return s.ExecContext(ctx, cmd, options...)
 }
 
 // ExecContext returns the results of executing the provided cmd via SSH.


### PR DESCRIPTION
_https://github.com/cilium/cilium/pull/7847 continues to confound so I figured I could get this commit out since it might marginally lower load on our machines (some goroutines wait on the context to end and currently would block forever in these functions)._

We make many calls that end up in SSHMeta.Exec. It would pass
context.Background to SSHMeta.ExecContext. Unfortunately, the way
ExecContext is written relies on the context expiring eventually,
otherwise it will leak goroutines (and also leave the session open,
potentially). We now pass in a cancellable context and cancel it when we
exit Exec. There is still no direct timeout in this case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7911)
<!-- Reviewable:end -->
