### PR TITLE
Improve separation between cilium-agent and cli

### DIFF
--- a/cilium/cmd/root.go
+++ b/cilium/cmd/root.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	clientPkg "github.com/cilium/cilium/pkg/client"
+	"github.com/cilium/cilium/pkg/components"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -50,6 +51,10 @@ func Execute() {
 }
 
 func init() {
+	if components.IsCiliumAgent() {
+		return
+	}
+
 	cobra.OnInitialize(initConfig)
 	flags := rootCmd.PersistentFlags()
 	flags.StringVar(&cfgFile, "config", "", "config file (default is $HOME/.cilium.yaml)")

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -787,6 +787,7 @@ func initConfig() {
 		viper.SetConfigFile(option.Config.ConfigFile)
 	} else {
 		viper.SetConfigName("ciliumd") // name of config file (without extension)
+		viper.AddConfigPath("$HOME")   // adding home directory as first search path
 	}
 
 	// If a config file is found, read it in.

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -29,5 +29,6 @@ const (
 // IsCiliumAgent checks whether the current process is cilium-agent (daemon).
 func IsCiliumAgent() bool {
 	binaryName := os.Args[0]
-	return binaryName == CiliumAgentName || strings.Contains(binaryName, CiliumDaemonTestName)
+	return strings.HasSuffix(binaryName, CiliumAgentName) ||
+		strings.HasSuffix(binaryName, CiliumDaemonTestName)
 }


### PR DESCRIPTION
This PR contains multiple changes to improve separation between `cilium-agent` and `cilium`:

1. Fix `cilium-agent` detection routine.
2. Do not call the CLI initialization function when running as `cilium-agent`.
3. Set `$HOME` as a dir for the default `ciliumd.yaml` config.

Please review each commit separately.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7912)
<!-- Reviewable:end -->
