### PR TITLE
daemon: Do not init config when running with --cmdref

### DIFF
--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -762,6 +762,10 @@ func initConfig() {
 		os.Exit(0)
 	}
 
+	if option.Config.CMDRefDir != "" {
+		return
+	}
+
 	option.Config.ConfigFile = viper.GetString(option.ConfigFile) // enable ability to specify config file via flag
 	option.Config.ConfigDir = viper.GetString(option.ConfigDir)
 	viper.SetEnvPrefix("cilium")


### PR DESCRIPTION
Previously, `cilium-agent --cmdref <..>` was logging to stderr:

    level=info msg="Skipped reading configuration file" reason="Config File \"ciliumd\" Not Found in \"[/home/brb]\"" subsys=daemon

This PR fixes this by not calling the config initialization routines when `cilium-agent` is ran with `--cmdref=<..>`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7913)
<!-- Reviewable:end -->
