### PR TITLE
test: Increase timeout of boot VM stage to 45 minutes

### DIFF
--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -62,7 +62,7 @@ pipeline {
         }
         stage ("Copy code and boot vms"){
             options {
-                timeout(time: 30, unit: 'MINUTES')
+                timeout(time: 45, unit: 'MINUTES')
             }
 
             environment {


### PR DESCRIPTION
We have seen a massive amount of CI builds timing out. Some of them are close
to completing the stage but then fail because the download of the vagrant
images takes longer than usual. Bump the timeout until this is resolved.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7915)
<!-- Reviewable:end -->
