### PR TITLE
test: Do not set enable-legacy-services in v1.4 ConfigMap

### DIFF
--- a/test/k8sT/manifests/v1.4/cilium-cm-patch.yaml
+++ b/test/k8sT/manifests/v1.4/cilium-cm-patch.yaml
@@ -24,5 +24,4 @@ data:
   enable-ipv4: "true"
   enable-ipv6: "true"
   preallocate-bpf-maps: "true"
-  enable-legacy-services: "true"
   bpf-ct-global-tcp-max: "1000000"


### PR DESCRIPTION
v1.4 does not support the `--enable-legacy-services` flag.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7919)
<!-- Reviewable:end -->
