### PR TITLE
pkg/metrics: add Cilium namespace to fqdn_gc_deletions_total

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -551,8 +551,9 @@ var (
 	// FQDNGarbageCollectorCleanedTotal is the number of domains cleaned by the
 	// GC job.
 	FQDNGarbageCollectorCleanedTotal = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "fqdn_gc_deletions_total",
-		Help: "Number of FQDNs that have been cleaned on FQDN Garbage collector job",
+		Namespace: Namespace,
+		Name:      "fqdn_gc_deletions_total",
+		Help:      "Number of FQDNs that have been cleaned on FQDN Garbage collector job",
 	})
 )
 


### PR DESCRIPTION
The fqdn_gc_deletions_total misses the Cilium namespace and it's
currently exporter without it. This commit fixes that omission.

Fixes: 5a68e1f11dc3 ("FQDN: Add metrics for Garbage collector cleanup.")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7922)
<!-- Reviewable:end -->
