### PR TITLE
Fix bug where Cilium would refuse to start if ipv6 netfilter modules are unavailable

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -255,7 +255,7 @@ func (m *IptablesManager) Init() {
 	if err := modulesManager.FindOrLoadModules(
 		"ip6_tables", "ip6table_mangle", "ip6table_raw"); err != nil {
 		if option.Config.EnableIPv6 {
-			log.WithError(err).Fatal(
+			log.WithError(err).Warning(
 				"IPv6 is enabled and ip6tables modules could not be initialized")
 		}
 		log.WithError(err).Debug(


### PR DESCRIPTION
Reduce the severity of this log from Fatal to Warning, so that if a
distribution doesn't provide this functionality or builds it into their
base kernel image, Cilium will complain but still run. This is similar
to the fix a058705f5e9a ("datapath/iptables: Warn when iptables modules
are not available").

Fixes: 5b17c993e579 ("datapath/iptables: Check iptables kernel modules")
Fixes: #7928

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7929)
<!-- Reviewable:end -->
