### PR TITLE
daemon: Use all labels to restore endpoint identity

### DIFF
--- a/daemon/state.go
+++ b/daemon/state.go
@@ -261,7 +261,7 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) (resto
 			}
 			scopedLog := log.WithField(logfields.EndpointID, ep.ID)
 			// Filter the restored labels with the new daemon's filter
-			l, _ := labels.FilterLabels(ep.OpLabels.IdentityLabels())
+			l, _ := labels.FilterLabels(ep.OpLabels.AllLabels())
 			ep.RUnlock()
 
 			identity, _, err := cache.AllocateIdentity(context.Background(), l)

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -589,6 +589,7 @@ func (e *Endpoint) SetIdentity(identity *identityPkg.Identity) {
 	// identity for the endpoint.
 	identitymanager.RemoveOldAddNew(e.SecurityIdentity, identity)
 	e.SecurityIdentity = identity
+	e.replaceIdentityLabels(identity.Labels)
 
 	// Clear selectorPolicy. It will be determined at next regeneration.
 	e.selectorPolicy = nil


### PR DESCRIPTION
It was previously assumed that upon restart, Cilium would attempt to
adjust the labels for existing endpoints based upon the `--labels`
option of the current run of the daemon. The logic was there to resolve
the new identity, wait if necessary, and so on; However, it was only
filtering the previous set of security relevant labels using the new
filter, rather than starting from scratch. As a result, if one only ever
narrowed the set of labels, then the new identity would be calculated
correctly. However, if a user ever removed labels from the filtering
set, thereby expanding the set of labels that would be considered
security-relevant, then the resolution logic would never take this into
account.

Fix it by using the total set of known labels from a previous run to
calculate the new version of security-relevant labels for determining
the identity of an endpoint. While we're at it, ensure that the
endpoint's orchestration labels are updated to reflect the new set of
security-relevant labels.

Fixes: #7914

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7932)
<!-- Reviewable:end -->
