### PR TITLE
docs: Add note about updating external resources after release

### DIFF
--- a/Documentation/contributing.rst
+++ b/Documentation/contributing.rst
@@ -1948,6 +1948,11 @@ If you intent to release a new minor release, see the
    Please reach out on the ``#development`` channel on Slack for assistance with
    this task.
 
+#. Update the external tools and guides to point to the released Cilium version:
+
+    * `kubeadm <https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/>`_
+    * `kops <https://github.com/kubernetes/kops/>`_
+    * `kubespray <https://github.com/kubernetes-sigs/kubespray/>`_
 
 .. _minor_release_process:
 


### PR DESCRIPTION
This PR adds a note to the release docs about updating external tools and guides after releasing a new version of Cilium.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7934)
<!-- Reviewable:end -->
