### PR TITLE
kvstore: Wait for kvstore to reach quorum

### DIFF
--- a/pkg/kvstore/kvstore.go
+++ b/pkg/kvstore/kvstore.go
@@ -35,6 +35,9 @@ const (
 
 	// BaseKeyPrefix is the base prefix that should be used for all keys
 	BaseKeyPrefix = "cilium"
+
+	// InitLockPath is the path to the init lock to test quorum
+	InitLockPath = BaseKeyPrefix + "/.initlock"
 )
 
 // Get returns value of key


### PR DESCRIPTION
So far, the channel returned by the Connected() function of the kvstore client
was closed when the kvstore could be connected to. This did not guarantee that
the kvstore actually had quorum and operations could still block and timeout
afterwards. Wait for a distributed lock to be acquired to identify the moment
quorum has been reached.

Also indicate the quorum status in the kvstore status of `cilium status` for
etcd.

```
KVStore:                Ok   etcd: 1/1 connected, has-quorum=true: https://192.168.33.11:2379 - 3.3.11 (Leader)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7938)
<!-- Reviewable:end -->
