### PR TITLE
Backport v1.4 2019 05 07

### DIFF
--- a/Documentation/contributing.rst
+++ b/Documentation/contributing.rst
@@ -653,6 +653,7 @@ The Kubernetes tests support the following Kubernetes versions:
 * 1.11
 * 1.12
 * 1.13
+* 1.14
 
 By default, the Vagrant VMs are provisioned with Kubernetes 1.13. To run with any other
 supported version of Kubernetes, run the test suite with the following format:

--- a/cilium/cmd/root.go
+++ b/cilium/cmd/root.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	clientPkg "github.com/cilium/cilium/pkg/client"
+	"github.com/cilium/cilium/pkg/components"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -50,6 +51,10 @@ func Execute() {
 }
 
 func init() {
+	if components.IsCiliumAgent() {
+		return
+	}
+
 	cobra.OnInitialize(initConfig)
 	flags := rootCmd.PersistentFlags()
 	flags.StringVar(&cfgFile, "config", "", "config file (default is $HOME/.cilium.yaml)")

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -713,6 +713,8 @@ func initConfig() {
 
 	if option.Config.ConfigFile != "" { // enable ability to specify config file via flag
 		viper.SetConfigFile(option.Config.ConfigFile)
+	} else {
+		viper.AddConfigPath("$HOME") // adding home directory as first search path
 	}
 
 	viper.SetEnvPrefix("cilium")

--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -967,6 +967,8 @@ func (m *Map) resolveErrors() error {
 // Returns true if the map was upgraded.
 func (m *Map) CheckAndUpgrade(desired *MapInfo) bool {
 	desiredMapType := GetMapType(desired.MapType)
+	desired.Flags |= GetPreAllocateMapFlags(desired.MapType)
+
 	return objCheck(
 		m.fd,
 		m.path,

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -29,5 +29,6 @@ const (
 // IsCiliumAgent checks whether the current process is cilium-agent (daemon).
 func IsCiliumAgent() bool {
 	binaryName := os.Args[0]
-	return binaryName == CiliumAgentName || strings.Contains(binaryName, CiliumDaemonTestName)
+	return strings.HasSuffix(binaryName, CiliumAgentName) ||
+		strings.HasSuffix(binaryName, CiliumDaemonTestName)
 }

--- a/test/helpers/policygen/models.go
+++ b/test/helpers/policygen/models.go
@@ -714,7 +714,7 @@ func (t *TestSpec) InvalidNetworkPolicyApply() (*cnpv2.CiliumNetworkPolicy, erro
 	err = helpers.WithTimeout(
 		body,
 		fmt.Sprintf("CNP %q is not ready after timeout", t.Prefix),
-		&helpers.TimeoutConfig{Timeout: 100})
+		&helpers.TimeoutConfig{Timeout: 100 * time.Second})
 	if err != nil {
 		return nil, err
 	}

--- a/test/k8sT/manifests/invalid_cnp.yaml
+++ b/test/k8sT/manifests/invalid_cnp.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: foo
+  namespace: default
+specs:
+- endpointSelector:
+    matchLabels:
+      any:id: foo
+  ingress:
+  - fromEndpoints:
+    - {}
+    toPorts:
+    - ports:
+      - port: "80"
+        protocol: UDP
+      rules:
+        http:
+        - method: GET
+          path: /private


### PR DESCRIPTION
 * PR: 7595 -- Kubernetes CNP status on invalid policies.  (@eloycoto) -- https://github.com/cilium/cilium/pull/7595
 * PR: 7910 -- docs: Add k8s 1.14 to supported versions for testing (@brb) -- https://github.com/cilium/cilium/pull/7910
 * PR: 7912 -- Improve separation between cilium-agent and cli (@brb) -- https://github.com/cilium/cilium/pull/7912
 * PR: 7866 -- bpf: Set BPF_F_NO_PREALLOC before comparing maps (@brb) -- https://github.com/cilium/cilium/pull/7866

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7941)
<!-- Reviewable:end -->
