### PR TITLE
test: Set CT TCP map size in v1.3 ConfigMaps

### DIFF
--- a/test/k8sT/manifests/v1.3/cilium-cm-patch-clean-cilium-state.yaml
+++ b/test/k8sT/manifests/v1.3/cilium-cm-patch-clean-cilium-state.yaml
@@ -20,3 +20,4 @@ data:
 
   debug: "true"
   clean-cilium-state: "true"
+  ct-global-max-entries-tcp: "1000000"

--- a/test/k8sT/manifests/v1.3/cilium-cm-patch.yaml
+++ b/test/k8sT/manifests/v1.3/cilium-cm-patch.yaml
@@ -20,3 +20,5 @@ data:
 
   # If you want to run cilium in debug mode change this value to true
   debug: "true"
+
+  ct-global-max-entries-tcp: "1000000"


### PR DESCRIPTION
_I came to [the conclusion](https://github.com/cilium/cilium/pull/7817#issuecomment-489113534) way too quick._

The upgrade test upgrades Cilium to the latest. The latest version CT TCP map size is 1000000, while v1.3 - 524288. To avoid the removal of the CT TCP maps due to max entries mismatch, we need to set size in the v1.3 ConfigMaps.

Should fix the nightly CI failure: https://jenkins.cilium.io/job/cilium-master-Nightly/173

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7942)
<!-- Reviewable:end -->
