### PR TITLE
iptables: Remove legacy workaround for kube-proxy of k8s < 1.8

### DIFF
--- a/Documentation/install/system_requirements.rst
+++ b/Documentation/install/system_requirements.rst
@@ -162,10 +162,21 @@ Source            `Cilium iproute2 source`_
 .. _`Open Build Service`: https://build.opensuse.org/package/show/security:netfilter/iproute2
 .. _`Cilium iproute2 source`: https://github.com/cilium/iproute2/tree/static-data
 
+Host Firewall Rules
+===================
+
+If you have iptables enabled on your system, the following must be allowed:
+
+========= =======================================
+Chain     Required policy
+========= =======================================
+FORWARD   Accept forwarding to and from PodIPs
+========= =======================================
+
 .. _firewall_requirements:
 
-Firewall Rules
-==============
+Network Firewall Rules
+======================
 
 If you are running Cilium in an environment that requires firewall rules to enable connectivity, you will have to add the following rules to ensure Cilium works properly.
 

--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -103,6 +103,7 @@ ip -6 a a ${vm_ipv6}/16 dev enp0s8
 
 echo '${master_ipv6} ${VM_BASENAME}1' >> /etc/hosts
 sysctl -w net.ipv6.conf.all.forwarding=1
+iptables -P FORWARD ACCEPT
 EOF
 }
 
@@ -377,11 +378,19 @@ service cilium restart
 EOF
 }
 
+function write_iptables_rules(){
+    filename="${1}"
+    cat <<EOF >> "${filename}"
+sudo iptables -P FORWARD ACCEPT
+EOF
+}
+
 function create_master(){
     split_ipv4 ipv4_array "${MASTER_IPV4}"
     get_cilium_node_addr master_cilium_ipv6 "${MASTER_IPV4}"
     output_file="${dir}/node-1.sh"
     write_netcfg_header "${MASTER_IPV6}" "${MASTER_IPV6}" "${output_file}"
+    write_iptables_rules "${output_file}"
 
     if [ -n "${NWORKERS}" ]; then
         write_nodes_routes 1 "${MASTER_IPV4}" "${output_file}"
@@ -405,6 +414,7 @@ function create_workers(){
             ipv6_public_workers_addrs+=(${worker_host_ipv6})
 
             write_netcfg_header "${worker_ipv6}" "${MASTER_IPV6}" "${output_file}"
+            write_iptables_rules "${output_file}"
 
             write_master_route "${master_prefix_ip}" "${master_cilium_ipv6}" \
                 "${MASTER_IPV6}" "${i}" "${worker_ipv6}" "${output_file}"

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -257,7 +257,8 @@ sudo systemctl restart $MOUNT_SYSTEMD
 sudo rm -rfv /var/lib/kubelet
 
 # Allow iptables forwarding so kube-dns can function.
-sudo iptables --policy FORWARD ACCEPT
+sudo iptables -P FORWARD ACCEPT
+sudo ip6tables -P FORWARD ACCEPT
 
 #check hostname to know if is kubernetes or runtime test
 if [[ "${HOST}" == "k8s1" ]]; then

--- a/test/provision/runtime_install.sh
+++ b/test/provision/runtime_install.sh
@@ -11,6 +11,9 @@ source "${PROVISIONSRC}/helpers.bash"
 sudo bash -c "echo MaxSessions 200 >> /etc/ssh/sshd_config"
 sudo systemctl restart ssh
 
+sudo iptables -P FORWARD ACCEPT
+sudo ip6tables -P FORWARD ACCEPT
+
 "${PROVISIONSRC}"/dns.sh
 "${PROVISIONSRC}"/compile.sh
 "${PROVISIONSRC}"/wait-cilium.sh


### PR DESCRIPTION
kube-proxy in Kubernetes versions prior to 1.8 did not set the FORWARD
policy to ACCEPT. The workaround is no longer needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7944)
<!-- Reviewable:end -->
