### PR TITLE
Disable broken CI tests

### DIFF
--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -564,6 +564,8 @@ var _ = Describe("K8sPolicyTest", func() {
 			})
 
 			It("Validate toEntities Cluster", func() {
+				Skip("Test currently broken GH-7947")
+
 				By("Installing toEntities Cluster")
 				importPolicy(cnpToEntitiesCluster, "to-entities-cluster")
 

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -125,6 +125,7 @@ var _ = Describe("K8sServicesTest", func() {
 		})
 
 		It("Checks service on same node", func() {
+			Skip("Broken test GH-7948")
 			err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=testapp", helpers.HelperTimeout)
 			Expect(err).Should(BeNil())
 			clusterIP, _, err := kubectl.GetServiceHostPort(helpers.DefaultNamespace, serviceName)


### PR DESCRIPTION
Both tests are failing very regularly. Any failure is not being considered a breakage so there is no point in keeping these enabled until they are fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7949)
<!-- Reviewable:end -->
