### PR TITLE
pkg/envoy: use proto.Equal instead comparing strings

### DIFF
--- a/pkg/envoy/xds/cache.go
+++ b/pkg/envoy/xds/cache.go
@@ -109,9 +109,7 @@ func (c *Cache) tx(typeURL string, upsertedResources map[string]proto.Message, d
 		// If the value is unchanged, don't update the entry, to preserve its
 		// lastModifiedVersion. This allows minimizing the frequency of
 		// responses in GetResources.
-		// Calling proto.Message.String is not very cheap, but we assume that
-		// the reduced churn between the clients and the server is worth it.
-		if !found || oldV.resource.String() != value.String() {
+		if !found || !proto.Equal(oldV.resource, value) {
 			if found {
 				cacheLog.WithField(logfields.XDSResourceName, name).Debug("updating resource in cache")
 


### PR DESCRIPTION
On medium-large clusters with lots of endpoints, the conversion to
Strings in order to perform a comparison can be expensive. Instead,
we should make use of the protobuf equal function that should have
the same result.

Signed-off-by: André Martins <andre@cilium.io>

@jrajahalme does it make sense? I'll trigger a couple tests to see if something brakes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7953)
<!-- Reviewable:end -->
