### PR TITLE
test: replace guestbook test docker image

### DIFF
--- a/test/k8sT/manifests/guestbook-policy-web.yaml
+++ b/test/k8sT/manifests/guestbook-policy-web.yaml
@@ -5,12 +5,12 @@ metadata:
 spec:
   endpointSelector:
     matchLabels:
-      k8s-app.guestbook: web
+      app: guestbook
   ingress:
   - fromEndpoints:
     - matchLabels:
         "reserved.world": ""
     toPorts:
     - ports:
-      - port: "3000"
+      - port: "80"
         protocol: TCP

--- a/test/k8sT/manifests/guestbook_deployment.json
+++ b/test/k8sT/manifests/guestbook_deployment.json
@@ -126,37 +126,50 @@
     }
 }
 {
-    "kind":"ReplicationController",
-    "apiVersion":"v1",
-    "metadata":{
-        "name":"guestbook",
-        "labels":{
-            "k8s-app.guestbook":"web"
-        }
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": {
+        "name": "frontend"
     },
-    "spec":{
-        "replicas":1,
-        "selector":{
-            "k8s-app.guestbook":"web"
+    "spec": {
+        "selector": {
+            "matchLabels": {
+                "app": "guestbook",
+                "tier": "frontend"
+            }
         },
-        "template":{
-            "metadata":{
-                "labels":{
-                    "k8s-app.guestbook":"web",
-                    "zgroup": "guestbook"
+        "replicas": 1,
+        "template": {
+            "metadata": {
+                "labels": {
+                    "app": "guestbook",
+                    "tier": "frontend"
                 }
             },
-            "spec":{
-                "terminationGracePeriodSeconds": 0,
-                "containers":[{
-                    "name":"guestbook",
-                    "image":"docker.io/kubernetes/guestbook:v2",
-                    "imagePullPolicy": "IfNotPresent",
-                    "ports":[{
-                        "name":"http-server",
-                        "containerPort":3000
-                    }]
-                }],
+            "spec": {
+                "containers": [
+                    {
+                        "name": "php-redis",
+                        "image": "gcr.io/google-samples/gb-frontend:v4",
+                        "resources": {
+                            "requests": {
+                                "cpu": "100m",
+                                "memory": "100Mi"
+                            }
+                        },
+                        "env": [
+                            {
+                                "name": "GET_HOSTS_FROM",
+                                "value": "dns"
+                            }
+                        ],
+                        "ports": [
+                            {
+                                "containerPort": 80
+                            }
+                        ]
+                    }
+                ],
                 "nodeSelector": {
                     "kubernetes.io/hostname": "k8s2"
                 }


### PR DESCRIPTION
The image docker.io/kubernetes/guestbook:v2 no longer exists so we need
to update the guestbook test to make usage of the new guestbook test
version.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7955)
<!-- Reviewable:end -->
