### PR TITLE
metrics: add map_ops_total by default

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -450,6 +450,7 @@ func DefaultMetrics() map[string]struct{} {
 		Namespace + "_" + SubsystemKVStore + "_operations_duration_seconds":       {},
 		Namespace + "_" + SubsystemKVStore + "_events_queue_seconds":              {},
 		Namespace + "_fqdn_gc_deletions_total":                                    {},
+		Namespace + "_" + SubsystemBPF + "_map_ops_total":                         {},
 	}
 }
 


### PR DESCRIPTION
Fixes: 603df325f21b ("pkg/bpf: only account for bpf syscalls if syscall metric is enabled")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7956)
<!-- Reviewable:end -->
