### PR TITLE
ipam: Use static service loopback address

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -68,6 +68,7 @@ cilium-agent [flags]
       --ipv4-cluster-cidr-mask-size int            Mask size for the cluster wide CIDR (default 8)
       --ipv4-node string                           IPv4 address of node (default "auto")
       --ipv4-range string                          Per-node IPv4 endpoint prefix, e.g. 10.16.0.0/16 (default "auto")
+      --ipv4-service-loopback-address string       IPv4 address for service loopback SNAT (default "169.254.42.1")
       --ipv4-service-range string                  Kubernetes IPv4 services CIDR if not inside cluster prefix (default "auto")
       --ipv6-cluster-alloc-cidr string             IPv6 /64 CIDR used to allocate per node endpoint /96 CIDR (default "f00d::/64")
       --ipv6-node string                           IPv6 address of node (default "auto")

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1197,9 +1197,9 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 		log.Infof("  IPv4 allocation prefix: %s", node.GetIPv4AllocRange())
 
 		// Allocate IPv4 service loopback IP
-		loopbackIPv4, err := d.ipam.AllocateNextFamily(ipam.IPv4, "loopback")
-		if err != nil {
-			return nil, restoredEndpoints, fmt.Errorf("Unable to reserve IPv4 loopback address: %s", err)
+		loopbackIPv4 := net.ParseIP(option.Config.LoopbackIPv4)
+		if loopbackIPv4 == nil {
+			return nil, restoredEndpoints, fmt.Errorf("Invalid IPv4 loopback address %s", option.Config.LoopbackIPv4)
 		}
 		node.SetIPv4Loopback(loopbackIPv4)
 		log.Infof("  Loopback IPv4: %s", node.GetIPv4Loopback().String())

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -589,6 +589,9 @@ func init() {
 	flags.Bool(option.LogSystemLoadConfigName, false, "Enable periodic logging of system load")
 	option.BindEnv(option.LogSystemLoadConfigName)
 
+	flags.String(option.LoopbackIPv4, defaults.LoopbackIPv4, "IPv4 address for service loopback SNAT")
+	option.BindEnv(option.LoopbackIPv4)
+
 	flags.String(option.NAT46Range, defaults.DefaultNAT46Prefix, "IPv6 prefix to map IPv4 addresses to")
 	option.BindEnv(option.NAT46Range)
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -195,4 +195,7 @@ const (
 	// mirroring it into the kvstore for reduced overhead in large
 	// clusters.
 	K8sEventHandover = false
+
+	// LoopbackIPv4 is the default address for service loopback
+	LoopbackIPv4 = "169.254.42.1"
 )

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -448,6 +448,9 @@ const (
 	// Metrics represents the metrics subsystem that Cilium should expose
 	// to prometheus.
 	Metrics = "metrics"
+
+	// LoopbackIPv4 is the address to use for service loopback SNAT
+	LoopbackIPv4 = "ipv4-service-loopback-address"
 )
 
 // FQDNS variables
@@ -900,6 +903,9 @@ type DaemonConfig struct {
 
 	// MetricsConfig is the configuration set in metrics
 	MetricsConfig metrics.Configuration
+
+	// LoopbackIPv4 is the address to use for service loopback SNAT
+	LoopbackIPv4 string
 }
 
 var (
@@ -921,6 +927,7 @@ var (
 		KVStoreOpt:                make(map[string]string),
 		LogOpt:                    make(map[string]string),
 		SelectiveRegeneration:     defaults.SelectiveRegeneration,
+		LoopbackIPv4:              defaults.LoopbackIPv4,
 	}
 )
 
@@ -1183,6 +1190,7 @@ func (c *DaemonConfig) Populate() {
 	c.LogDriver = viper.GetStringSlice(LogDriver)
 	c.LogSystemLoadConfig = viper.GetBool(LogSystemLoadConfigName)
 	c.Logstash = viper.GetBool(Logstash)
+	c.LoopbackIPv4 = viper.GetString(LoopbackIPv4)
 	c.Masquerade = viper.GetBool(Masquerade)
 	c.InstallIptRules = viper.GetBool(InstallIptRules)
 	c.ModePreFilter = viper.GetString(PrefilterMode)


### PR DESCRIPTION
Reduce the number of allocations required in preparation for external IPAM and
ENI support. The service loopback address can be arbitrary as long as the
address is unused, default to 169.254.42.1 and allow the user to overwrite it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7957)
<!-- Reviewable:end -->
