### PR TITLE
Return brief status response with brief is passed to the server

### DIFF
--- a/api/v1/client/daemon/get_healthz_parameters.go
+++ b/api/v1/client/daemon/get_healthz_parameters.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	cr "github.com/go-openapi/runtime/client"
+	"github.com/go-openapi/swag"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -20,7 +21,7 @@ import (
 // NewGetHealthzParams creates a new GetHealthzParams object
 // with the default values initialized.
 func NewGetHealthzParams() *GetHealthzParams {
-
+	var ()
 	return &GetHealthzParams{
 
 		timeout: cr.DefaultTimeout,
@@ -30,7 +31,7 @@ func NewGetHealthzParams() *GetHealthzParams {
 // NewGetHealthzParamsWithTimeout creates a new GetHealthzParams object
 // with the default values initialized, and the ability to set a timeout on a request
 func NewGetHealthzParamsWithTimeout(timeout time.Duration) *GetHealthzParams {
-
+	var ()
 	return &GetHealthzParams{
 
 		timeout: timeout,
@@ -40,7 +41,7 @@ func NewGetHealthzParamsWithTimeout(timeout time.Duration) *GetHealthzParams {
 // NewGetHealthzParamsWithContext creates a new GetHealthzParams object
 // with the default values initialized, and the ability to set a context for a request
 func NewGetHealthzParamsWithContext(ctx context.Context) *GetHealthzParams {
-
+	var ()
 	return &GetHealthzParams{
 
 		Context: ctx,
@@ -50,7 +51,7 @@ func NewGetHealthzParamsWithContext(ctx context.Context) *GetHealthzParams {
 // NewGetHealthzParamsWithHTTPClient creates a new GetHealthzParams object
 // with the default values initialized, and the ability to set a custom HTTPClient for a request
 func NewGetHealthzParamsWithHTTPClient(client *http.Client) *GetHealthzParams {
-
+	var ()
 	return &GetHealthzParams{
 		HTTPClient: client,
 	}
@@ -60,6 +61,14 @@ func NewGetHealthzParamsWithHTTPClient(client *http.Client) *GetHealthzParams {
 for the get healthz operation typically these are written to a http.Request
 */
 type GetHealthzParams struct {
+
+	/*Brief
+	  Brief will return a brief representation of the Cilium status.
+
+
+	*/
+	Brief *bool
+
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
@@ -98,6 +107,17 @@ func (o *GetHealthzParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
+// WithBrief adds the brief to the get healthz params
+func (o *GetHealthzParams) WithBrief(brief *bool) *GetHealthzParams {
+	o.SetBrief(brief)
+	return o
+}
+
+// SetBrief adds the brief to the get healthz params
+func (o *GetHealthzParams) SetBrief(brief *bool) {
+	o.Brief = brief
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *GetHealthzParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -105,6 +125,15 @@ func (o *GetHealthzParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Re
 		return err
 	}
 	var res []error
+
+	if o.Brief != nil {
+
+		// header param brief
+		if err := r.SetHeaderParam("brief", swag.FormatBool(*o.Brief)); err != nil {
+			return err
+		}
+
+	}
 
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -21,6 +21,13 @@ paths:
         Kubernetes integration.
       tags:
       - daemon
+      parameters:
+      - name: brief
+        description: |
+          Brief will return a brief representation of the Cilium status.
+        in: header
+        required: false
+        type: boolean
       responses:
         '200':
           description: Success

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -563,6 +563,14 @@ func init() {
           "daemon"
         ],
         "summary": "Get health of Cilium daemon",
+        "parameters": [
+          {
+            "type": "boolean",
+            "description": "Brief will return a brief representation of the Cilium status.\n",
+            "name": "brief",
+            "in": "header"
+          }
+        ],
         "responses": {
           "200": {
             "description": "Success",
@@ -3380,6 +3388,14 @@ func init() {
           "daemon"
         ],
         "summary": "Get health of Cilium daemon",
+        "parameters": [
+          {
+            "type": "boolean",
+            "description": "Brief will return a brief representation of the Cilium status.\n",
+            "name": "brief",
+            "in": "header"
+          }
+        ],
         "responses": {
           "200": {
             "description": "Success",

--- a/api/v1/server/restapi/daemon/get_healthz_parameters.go
+++ b/api/v1/server/restapi/daemon/get_healthz_parameters.go
@@ -10,6 +10,9 @@ import (
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime/middleware"
+	"github.com/go-openapi/swag"
+
+	strfmt "github.com/go-openapi/strfmt"
 )
 
 // NewGetHealthzParams creates a new GetHealthzParams object
@@ -27,6 +30,12 @@ type GetHealthzParams struct {
 
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
+
+	/*Brief will return a brief representation of the Cilium status.
+
+	  In: header
+	*/
+	Brief *bool
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -38,8 +47,34 @@ func (o *GetHealthzParams) BindRequest(r *http.Request, route *middleware.Matche
 
 	o.HTTPRequest = r
 
+	if err := o.bindBrief(r.Header[http.CanonicalHeaderKey("brief")], true, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+// bindBrief binds and validates parameter Brief from header.
+func (o *GetHealthzParams) bindBrief(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+
+	value, err := swag.ConvertBool(raw)
+	if err != nil {
+		return errors.InvalidType("brief", "header", "bool", raw)
+	}
+	o.Brief = &value
+
 	return nil
 }

--- a/cilium/cmd/status.go
+++ b/cilium/cmd/status.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"text/tabwriter"
 
+	"github.com/cilium/cilium/api/v1/client/daemon"
 	"github.com/cilium/cilium/api/v1/models"
 	pkg "github.com/cilium/cilium/pkg/client"
 	"github.com/cilium/cilium/pkg/command"
@@ -77,7 +78,9 @@ func statusDaemon() {
 	if allHealth {
 		healthLines = 0
 	}
-	if resp, err := client.Daemon.GetHealthz(nil); err != nil {
+	params := daemon.NewGetHealthzParams()
+	params.SetBrief(&brief)
+	if resp, err := client.Daemon.GetHealthz(params); err != nil {
 		if brief {
 			fmt.Fprintf(os.Stderr, "%s\n", "cilium: daemon unreachable")
 		} else {

--- a/daemon/debuginfo.go
+++ b/daemon/debuginfo.go
@@ -49,7 +49,7 @@ func (h *getDebugInfo) Handle(params restapi.GetDebuginfoParams) middleware.Resp
 		dr.KernelVersion = fmt.Sprintf("%s", kver)
 	}
 
-	status := d.getStatus()
+	status := d.getStatus(false)
 	dr.CiliumStatus = &status
 
 	var p endpoint.GetEndpointParams


### PR DESCRIPTION
There's no point on doing a deep copy of the agent's status response if the client will not use the full information provided to the client.

Future will be to stop doing `getNodeStatus` on a probe as shown in [0] and only do it based on the cilium status request made to the server. The returned node list is not even used by `cilium status` so there's no point in running this probe.

[0]
https://github.com/cilium/cilium/blob/cb4680e1bd13d0dc7be1945148ceae5655ee5e3d/daemon/status.go#L366-L369

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7959)
<!-- Reviewable:end -->
