### PR TITLE
docs: give better troubleshooting for conntrack-gc-interval

### DIFF
--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -305,6 +305,14 @@ New Default Values
  * The connection-tracking garbage collector intervals is now 12 hours when
    using LRU maps (newer kernels) and 15 minutes an all older kernels. The
    interval can be overwritten with the option ``--conntrack-gc-interval``.
+   If connectivity between pods is faulty and ``cilium monitor --type drop``
+   shows ``xx drop (CT: Map insertion failed)`` it is recommended to set
+   ``--conntrack-gc-interval`` to an interval lower than the default.
+   Alternatively, the value for ``bpf-ct-global-any-max`` and
+   ``bpf-ct-global-tcp-max`` should be increased. Setting both of these options
+   will be a trade-off of CPU for ``conntrack-gc-interval``, and for
+   ``bpf-ct-global-any-max`` and ``bpf-ct-global-tcp-max`` the amount of memory
+   consumed.
 
 .. _1.5_new_options:
 

--- a/Documentation/troubleshooting.rst
+++ b/Documentation/troubleshooting.rst
@@ -200,6 +200,15 @@ examples if running with Kubernetes):
 The above indicates that a packet to endpoint ID ``25729`` has been dropped due
 to violation of the Layer 3 policy.
 
+If connectivity between pods is faulty and ``cilium monitor --type drop``
+shows ``xx drop (CT: Map insertion failed)`` it is recommended to set
+``--conntrack-gc-interval`` to an interval lower than the default.
+Alternatively, the value for ``bpf-ct-global-any-max`` and
+``bpf-ct-global-tcp-max`` should be increased. Setting both of these options
+will be a trade-off of CPU for ``conntrack-gc-interval``, and for
+``bpf-ct-global-any-max`` and ``bpf-ct-global-tcp-max`` the amount of memory
+consumed.
+
 Policy Troubleshooting
 ======================
 


### PR DESCRIPTION
In case the default values of `conntrack-gc-interval` are not good
enough for the end users we should prepare them how to solve the issue.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7961)
<!-- Reviewable:end -->
