### PR TITLE
api: do not allow FQDNSelectors to contain both MatchName and MatchPattern

### DIFF
--- a/pkg/policy/api/fqdn.go
+++ b/pkg/policy/api/fqdn.go
@@ -62,6 +62,9 @@ func (s *FQDNSelector) String() string {
 // when using MatchName the basic requirement is that is a valid regexp. We
 // test that it can compile here.
 func (s *FQDNSelector) sanitize() error {
+	if len(s.MatchName) > 0 && len(s.MatchPattern) > 0 {
+		return fmt.Errorf("only one of MatchName or MatchPattern is allowed in an FQDNSelector")
+	}
 	if len(s.MatchName) > 0 && !allowedMatchNameChars.MatchString(s.MatchName) {
 		return fmt.Errorf("Invalid characters in MatchName: \"%s\". Only 0-9, a-z, A-Z and . and - characters are allowed", s.MatchName)
 	}

--- a/pkg/policy/api/fqdn_test.go
+++ b/pkg/policy/api/fqdn_test.go
@@ -31,7 +31,6 @@ func (s *PolicyAPITestSuite) TestFQDNSelectorSanitize(c *C) {
 		{MatchPattern: "*.cilium.io"},
 		{MatchPattern: "*cilium.io"},
 		{MatchPattern: "cilium.io"},
-		{MatchName: "cilium.io", MatchPattern: "*cilium.io"},
 	} {
 		err := accept.sanitize()
 		c.Assert(err, IsNil, Commentf("FQDNSelector %+v was rejected but it should be valid", accept))
@@ -40,8 +39,7 @@ func (s *PolicyAPITestSuite) TestFQDNSelectorSanitize(c *C) {
 	for _, reject := range []FQDNSelector{
 		{MatchName: "a{1,2}.cilium.io."},
 		{MatchPattern: "[a-z]*.cilium.io."},
-		{MatchName: "a{1,2}.cilium.io.", MatchPattern: "*cilium.io"},
-		{MatchName: "a{1,2}.cilium.io.", MatchPattern: "[a-z]*.cilium.io."},
+		{MatchName: "cilium.io", MatchPattern: "*cilium.io"},
 	} {
 		err := reject.sanitize()
 		c.Assert(err, Not(IsNil), Commentf("FQDNSelector %+v was accepted but it should be invalid", reject))
@@ -59,7 +57,6 @@ func (s *PolicyAPITestSuite) TestPortRuleDNSSanitize(c *C) {
 		{MatchPattern: "*.cilium.io"},
 		{MatchPattern: "*cilium.io"},
 		{MatchPattern: "cilium.io"},
-		{MatchName: "cilium.io", MatchPattern: "*cilium.io"},
 	} {
 		err := accept.Sanitize()
 		c.Assert(err, IsNil, Commentf("PortRuleDNS %+v was rejected but it should be valid", accept))
@@ -68,7 +65,6 @@ func (s *PolicyAPITestSuite) TestPortRuleDNSSanitize(c *C) {
 	for _, reject := range []PortRuleDNS{
 		{MatchName: "a{1,2}.cilium.io."},
 		{MatchPattern: "[a-z]*.cilium.io."},
-		{MatchName: "a{1,2}.cilium.io.", MatchPattern: "*cilium.io"},
 		{MatchName: "a{1,2}.cilium.io.", MatchPattern: "[a-z]*.cilium.io."},
 	} {
 		err := reject.Sanitize()


### PR DESCRIPTION
Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7963)
<!-- Reviewable:end -->
