### PR TITLE
operator: fix concurrent access of variable in cnp garbage collection that could lead to panic in cilium-operator

### DIFF
--- a/operator/k8s_node.go
+++ b/operator/k8s_node.go
@@ -205,8 +205,9 @@ func runNodeWatcher() error {
 							}
 							if needsUpdate {
 								wg.Add(1)
+								cnpCpy := cnp.DeepCopy()
 								removeNodeFromCNP <- func() {
-									updateCNP(ciliumK8sClient.CiliumV2(), &cnp, nodesToDelete, k8sCapabilities)
+									updateCNP(ciliumK8sClient.CiliumV2(), cnpCpy, nodesToDelete, k8sCapabilities)
 									wg.Done()
 								}
 							}


### PR DESCRIPTION
As the cnp variable will be used in a different go routine we need to
deepcopy it.

Fixes: 0cd1be0e64dc ("operator: GC nodes from existing CNPs")
Signed-off-by: André Martins <andre@cilium.io>

fixes https://github.com/cilium/cilium/issues/7974

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7975)
<!-- Reviewable:end -->
