### PR TITLE
fqdn: DNSProxy does not fold similar DNS requests

### DIFF
--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -214,8 +214,10 @@ func StartDNSProxy(address string, port uint16, lookupEPFunc LookupEndpointIDByI
 	}
 
 	// Bind the DNS forwarding clients on UDP and TCP
-	p.UDPClient = &dns.Client{Net: "udp", Timeout: ProxyForwardTimeout, SingleInflight: true}
-	p.TCPClient = &dns.Client{Net: "tcp", Timeout: ProxyForwardTimeout, SingleInflight: true}
+	// Note: SingleInFlight should remain disabled. When enabled it folds DNS
+	// retries into the previous lookup, supressing them.
+	p.UDPClient = &dns.Client{Net: "udp", Timeout: ProxyForwardTimeout, SingleInflight: false}
+	p.TCPClient = &dns.Client{Net: "tcp", Timeout: ProxyForwardTimeout, SingleInflight: false}
 
 	return p, nil
 }


### PR DESCRIPTION
We previously used a feature in the DNS package named SingleInFlight.
This operated by "Suppressing multiple outstanding queries (with the
same question, type and class)" when repeated. This would avoid
multiple pods making multiple requests that would all be passed through
the proxy, making it seem like the proxy's IP was misbehaving.
Unfortunately, it also stopped DNS retries from working. This probably
caused more disruption than any rate limiting on the proxy IP.
We now do not use this feature so that retries operate correctly. Except
for situations where the proxy would have been rate-limited, but was not
due to the collation, this should not cause any change perceived
behaviour of the fqdn subsystem.

There is a small chance that this is the cause of https://github.com/cilium/cilium/issues/7721 We'll find out! (probably not since that shouldn't have the DNS proxy involved)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7979)
<!-- Reviewable:end -->
