### PR TITLE
datapath: Add flag to specify prefix for interface name of endpoints

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -50,6 +50,7 @@ cilium-agent [flags]
       --enable-policy string                       Enable policy enforcement (default "default")
       --enable-tracing                             Enable tracing while determining policy (debugging)
       --encrypt-interface string                   Transparent encryption interface
+      --endpoint-interface-name-prefix string      Prefix of interface name shared by all endpoints (default "lxc+")
       --endpoint-queue-size int                    size of EventQueue per-endpoint (default 25)
       --envoy-log string                           Path to a separate Envoy log file, if any
       --fixed-identity-mapping map                 Key-value for the fixed identity mapping which allows to use reserved label for fixed identities (default map[])

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -438,6 +438,9 @@ func init() {
 	flags.String(option.EncryptInterface, "", "Transparent encryption interface")
 	option.BindEnv(option.EncryptInterface)
 
+	flags.String(option.EndpointInterfaceNamePrefix, defaults.EndpointInterfaceNamePrefix, "Prefix of interface name shared by all endpoints")
+	option.BindEnv(option.EndpointInterfaceNamePrefix)
+
 	flags.Bool(option.DisableCiliumEndpointCRDName, false, "Disable use of CiliumEndpoint CRD")
 	option.BindEnv(option.DisableCiliumEndpointCRDName)
 

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -329,10 +329,10 @@ func egressProxyRule(cmd, l4Match, markMatch, mark, port, name string) []string 
 	return []string{
 		"-t", "mangle",
 		cmd, ciliumPreMangleChain,
-		"-i", "lxc+",
+		"-i", option.Config.EndpointInterfaceNamePrefix,
 		"-p", l4Match,
 		"-m", "mark", "--mark", markMatch,
-		"-m", "comment", "--comment", "cilium: TPROXY to host " + name + " proxy on lxc+",
+		"-m", "comment", "--comment", "cilium: TPROXY to host " + name + " proxy on " + option.Config.EndpointInterfaceNamePrefix,
 		"-j", "TPROXY",
 		"--tproxy-mark", mark,
 		"--on-port", port}

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -198,4 +198,8 @@ const (
 
 	// LoopbackIPv4 is the default address for service loopback
 	LoopbackIPv4 = "169.254.42.1"
+
+	// EndpointInterfaceNamePrefix is the default prefix name of the
+	// interface names shared by all endpoints
+	EndpointInterfaceNamePrefix = "lxc+"
 )

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -451,6 +451,10 @@ const (
 
 	// LoopbackIPv4 is the address to use for service loopback SNAT
 	LoopbackIPv4 = "ipv4-service-loopback-address"
+
+	// EndpointInterfaceNamePrefix is the prefix name of the interface
+	// names shared by all endpoints
+	EndpointInterfaceNamePrefix = "endpoint-interface-name-prefix"
 )
 
 // FQDNS variables
@@ -906,28 +910,33 @@ type DaemonConfig struct {
 
 	// LoopbackIPv4 is the address to use for service loopback SNAT
 	LoopbackIPv4 string
+
+	// EndpointInterfaceNamePrefix is the prefix name of the interface
+	// names shared by all endpoints
+	EndpointInterfaceNamePrefix string
 }
 
 var (
 	// Config represents the daemon configuration
 	Config = &DaemonConfig{
-		Opts:                      NewIntOptions(&DaemonOptionLibrary),
-		Monitor:                   &models.MonitorStatus{Cpus: int64(runtime.NumCPU()), Npages: 64, Pagesize: int64(os.Getpagesize()), Lost: 0, Unknown: 0},
-		IPv6ClusterAllocCIDR:      defaults.IPv6ClusterAllocCIDR,
-		IPv6ClusterAllocCIDRBase:  defaults.IPv6ClusterAllocCIDRBase,
-		EnableHostIPRestore:       defaults.EnableHostIPRestore,
-		EnableHealthChecking:      defaults.EnableHealthChecking,
-		EnableIPv4:                defaults.EnableIPv4,
-		EnableIPv6:                defaults.EnableIPv6,
-		ToFQDNsMaxIPsPerHost:      defaults.ToFQDNsMaxIPsPerHost,
-		KVstorePeriodicSync:       defaults.KVstorePeriodicSync,
-		IdentityChangeGracePeriod: defaults.IdentityChangeGracePeriod,
-		ContainerRuntimeEndpoint:  make(map[string]string),
-		FixedIdentityMapping:      make(map[string]string),
-		KVStoreOpt:                make(map[string]string),
-		LogOpt:                    make(map[string]string),
-		SelectiveRegeneration:     defaults.SelectiveRegeneration,
-		LoopbackIPv4:              defaults.LoopbackIPv4,
+		Opts:                        NewIntOptions(&DaemonOptionLibrary),
+		Monitor:                     &models.MonitorStatus{Cpus: int64(runtime.NumCPU()), Npages: 64, Pagesize: int64(os.Getpagesize()), Lost: 0, Unknown: 0},
+		IPv6ClusterAllocCIDR:        defaults.IPv6ClusterAllocCIDR,
+		IPv6ClusterAllocCIDRBase:    defaults.IPv6ClusterAllocCIDRBase,
+		EnableHostIPRestore:         defaults.EnableHostIPRestore,
+		EnableHealthChecking:        defaults.EnableHealthChecking,
+		EnableIPv4:                  defaults.EnableIPv4,
+		EnableIPv6:                  defaults.EnableIPv6,
+		ToFQDNsMaxIPsPerHost:        defaults.ToFQDNsMaxIPsPerHost,
+		KVstorePeriodicSync:         defaults.KVstorePeriodicSync,
+		IdentityChangeGracePeriod:   defaults.IdentityChangeGracePeriod,
+		ContainerRuntimeEndpoint:    make(map[string]string),
+		FixedIdentityMapping:        make(map[string]string),
+		KVStoreOpt:                  make(map[string]string),
+		LogOpt:                      make(map[string]string),
+		SelectiveRegeneration:       defaults.SelectiveRegeneration,
+		LoopbackIPv4:                defaults.LoopbackIPv4,
+		EndpointInterfaceNamePrefix: defaults.EndpointInterfaceNamePrefix,
 	}
 )
 
@@ -1144,6 +1153,7 @@ func (c *DaemonConfig) Populate() {
 	c.EnableIPv4 = getIPv4Enabled()
 	c.EnableIPv6 = viper.GetBool(EnableIPv6Name)
 	c.EnableIPSec = viper.GetBool(EnableIPSecName)
+	c.EndpointInterfaceNamePrefix = viper.GetString(EndpointInterfaceNamePrefix)
 	c.DevicePreFilter = viper.GetString(PrefilterDevice)
 	c.DisableCiliumEndpointCRD = viper.GetBool(DisableCiliumEndpointCRDName)
 	c.DisableK8sServices = viper.GetBool(DisableK8sServices)


### PR DESCRIPTION
This was hardcoded to lxc+ so far, provide a new option to change this. This
enables to use L7 proxy redirection in combination with chaining where the
interface name is picked by the CNI plugin setting up the interface names.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7980)
<!-- Reviewable:end -->
