### PR TITLE
docs: add missing cilium-operator-sa.yaml for k8s 1.14 upgrade guide

### DIFF
--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -184,6 +184,7 @@ Both files are dedicated to "\ |SCM_BRANCH|" for each Kubernetes version.
 
       kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.14/cilium-rbac.yaml
       kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.14/cilium-ds.yaml
+      kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.14/cilium-operator-sa.yaml
       kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.14/cilium-operator.yaml
 
 


### PR DESCRIPTION
Fixes: 9ab5e64f041e ("Documentation: Add Kubernetes 1.14 support.")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7985)
<!-- Reviewable:end -->
