### PR TITLE
daemon: add option to skip CRD creation

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -113,6 +113,7 @@ cilium-agent [flags]
       --restore                                    Restores state, if possible, from previous daemon (default true)
       --sidecar-istio-proxy-image string           Regular expression matching compatible Istio sidecar istio-proxy container image names (default "cilium/istio_proxy")
       --single-cluster-route                       Use a single cluster route instead of per node routes
+      --skip-crd-creation                          Skip Kubernetes Custom Resource Definitions creations
       --socket-path string                         Sets daemon's socket path to listen for connections (default "/var/run/cilium/cilium.sock")
       --sockops-enable                             Enable sockops when kernel supported
       --state-dir string                           Directory path to store runtime state (default "/var/run/cilium")

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -743,6 +743,9 @@ func init() {
 	flags.MarkHidden(option.SelectiveRegeneration)
 	option.BindEnv(option.SelectiveRegeneration)
 
+	flags.Bool(option.SkipCRDCreation, false, "Skip Kubernetes Custom Resource Definitions creations")
+	option.BindEnv(option.SkipCRDCreation)
+
 	viper.BindPFlags(flags)
 }
 

--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -32,7 +32,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s"
-	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
+	ciliumio "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	clientset "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned"
 	"github.com/cilium/cilium/pkg/k8s/informer"
@@ -55,7 +55,7 @@ import (
 	"github.com/cilium/cilium/pkg/spanstat"
 
 	"github.com/sirupsen/logrus"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	networkingv1 "k8s.io/api/networking/v1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -369,9 +369,11 @@ func (d *Daemon) EnableK8sWatcher(queueSize uint) error {
 		return fmt.Errorf("Unable to create rest configuration for k8s CRD: %s", err)
 	}
 
-	err = cilium_v2.CreateCustomResourceDefinitions(apiextensionsclientset)
-	if err != nil {
-		return fmt.Errorf("Unable to create custom resource definition: %s", err)
+	if !option.Config.SkipCRDCreation {
+		err = cilium_v2.CreateCustomResourceDefinitions(apiextensionsclientset)
+		if err != nil {
+			return fmt.Errorf("Unable to create custom resource definition: %s", err)
+		}
 	}
 	d.k8sAPIGroups.addAPI(k8sAPIGroupCRD)
 

--- a/examples/crds/ciliumendpoints.yaml
+++ b/examples/crds/ciliumendpoints.yaml
@@ -1,0 +1,56 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: ciliumendpoints.cilium.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.id
+    description: Cilium endpoint id
+    name: Endpoint ID
+    type: integer
+  - JSONPath: .status.identity.id
+    description: Cilium identity id
+    name: Identity ID
+    type: integer
+  - JSONPath: .status.policy.ingress.enforcing
+    description: Ingress enforcement in the endpoint
+    name: Ingress Enforcement
+    type: boolean
+  - JSONPath: .status.policy.egress.enforcing
+    description: Egress enforcement in the endpoint
+    name: Egress Enforcement
+    type: boolean
+  - JSONPath: .status.state
+    description: Endpoint current state
+    name: Endpoint State
+    type: string
+  - JSONPath: .status.networking.addressing[0].ipv4
+    description: Endpoint IPv4 address
+    name: IPv4
+    type: string
+  - JSONPath: .status.networking.addressing[0].ipv6
+    description: Endpoint IPv6 address
+    name: IPv6
+    type: string
+  conversion:
+    strategy: None
+  group: cilium.io
+  names:
+    kind: CiliumEndpoint
+    listKind: CiliumEndpointList
+    plural: ciliumendpoints
+    shortNames:
+    - cep
+    - ciliumep
+    singular: ciliumendpoint
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema: {}
+  version: v2
+  versions:
+  - name: v2
+    served: true
+    storage: true
+

--- a/examples/crds/ciliumnetworkpolicies.yaml
+++ b/examples/crds/ciliumnetworkpolicies.yaml
@@ -1,0 +1,4021 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: ciliumnetworkpolicies.cilium.io
+spec:
+  conversion:
+    strategy: None
+  group: cilium.io
+  names:
+    kind: CiliumNetworkPolicy
+    listKind: CiliumNetworkPolicyList
+    plural: ciliumnetworkpolicies
+    shortNames:
+    - cnp
+    - ciliumnp
+    singular: ciliumnetworkpolicy
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        CIDR:
+          description: CIDR is a CIDR prefix / IP Block.
+          oneOf:
+          - pattern: ^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\/([0-9]|[1-2][0-9]|3[0-2])$
+            type: string
+          - pattern: ^s*((([0-9A-Fa-f]{1,4}:){7}(:|([0-9A-Fa-f]{1,4})))|(([0-9A-Fa-f]{1,4}:){6}:([0-9A-Fa-f]{1,4})?)|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){0,1}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){0,2}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){0,3}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){0,4}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){0,5}):([0-9A-Fa-f]{1,4})?))|(:(:|((:[0-9A-Fa-f]{1,4}){1,7}))))(%.+)?s*/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$
+            type: string
+          type: string
+        CIDRRule:
+          description: CIDRRule is a rule that specifies a CIDR prefix to/from which
+            outside communication is allowed, along with an optional list of subnets
+            within that CIDR prefix to/from which outside communication is not allowed.
+          properties:
+            cidr:
+              description: CIDR is a CIDR prefix / IP Block.
+              oneOf:
+              - pattern: ^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\/([0-9]|[1-2][0-9]|3[0-2])$
+                type: string
+              - pattern: ^s*((([0-9A-Fa-f]{1,4}:){7}(:|([0-9A-Fa-f]{1,4})))|(([0-9A-Fa-f]{1,4}:){6}:([0-9A-Fa-f]{1,4})?)|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){0,1}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){0,2}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){0,3}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){0,4}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){0,5}):([0-9A-Fa-f]{1,4})?))|(:(:|((:[0-9A-Fa-f]{1,4}){1,7}))))(%.+)?s*/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$
+                type: string
+              type: string
+            except:
+              description: ExceptCIDRs is a list of IP blocks which the endpoint subject
+                to the rule is not allowed to initiate connections to. These CIDR
+                prefixes should be contained within Cidr. These exceptions are only
+                applied to the Cidr in this CIDRRule, and do not apply to any other
+                CIDR prefixes in any other CIDRRules.
+              items:
+                description: CIDR is a CIDR prefix / IP Block.
+                oneOf:
+                - pattern: ^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\/([0-9]|[1-2][0-9]|3[0-2])$
+                  type: string
+                - pattern: ^s*((([0-9A-Fa-f]{1,4}:){7}(:|([0-9A-Fa-f]{1,4})))|(([0-9A-Fa-f]{1,4}:){6}:([0-9A-Fa-f]{1,4})?)|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){0,1}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){0,2}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){0,3}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){0,4}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){0,5}):([0-9A-Fa-f]{1,4})?))|(:(:|((:[0-9A-Fa-f]{1,4}){1,7}))))(%.+)?s*/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$
+                  type: string
+                type: string
+              type: array
+          required:
+          - cidr
+        EgressRule:
+          description: |-
+            EgressRule contains all rule types which can be applied at egress, i.e. network traffic that originates inside the endpoint and exits the endpoint selected by the endpointSelector.
+
+            - All members of this structure are optional. If omitted or empty, the
+              member will have no effect on the rule.
+
+            - For now, combining ToPorts and ToCIDR in the same rule is not supported
+              and such rules will be rejected. In the future, this will be supported and
+              if if multiple members of the structure are specified, then all members
+              must match in order for the rule to take effect.
+          properties:
+            toCIDR:
+              description: |-
+                ToCIDR is a list of IP blocks which the endpoint subject to the rule is allowed to initiate connections. This will match on the destination IP address of outgoing connections. Adding a prefix into ToCIDR or into ToCIDRSet with no ExcludeCIDRs is equivalent. Overlaps are allowed between ToCIDR and ToCIDRSet.
+
+                Example: Any endpoint with the label "app=database-proxy" is allowed to initiate connections to 10.2.3.0/24
+              items:
+                description: CIDR is a CIDR prefix / IP Block.
+                oneOf:
+                - pattern: ^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\/([0-9]|[1-2][0-9]|3[0-2])$
+                  type: string
+                - pattern: ^s*((([0-9A-Fa-f]{1,4}:){7}(:|([0-9A-Fa-f]{1,4})))|(([0-9A-Fa-f]{1,4}:){6}:([0-9A-Fa-f]{1,4})?)|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){0,1}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){0,2}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){0,3}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){0,4}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){0,5}):([0-9A-Fa-f]{1,4})?))|(:(:|((:[0-9A-Fa-f]{1,4}){1,7}))))(%.+)?s*/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$
+                  type: string
+                type: string
+              type: array
+            toCIDRSet:
+              description: |-
+                ToCIDRSet is a list of IP blocks which the endpoint subject to the rule is allowed to initiate connections to in addition to connections which are allowed via FromEndpoints, along with a list of subnets contained within their corresponding IP block to which traffic should not be allowed. This will match on the destination IP address of outgoing connections. Adding a prefix into ToCIDR or into ToCIDRSet with no ExcludeCIDRs is equivalent. Overlaps are allowed between ToCIDR and ToCIDRSet.
+
+                Example: Any endpoint with the label "app=database-proxy" is allowed to initiate connections to 10.2.3.0/24 except from IPs in subnet 10.2.3.0/28.
+              items:
+                description: CIDRRule is a rule that specifies a CIDR prefix to/from
+                  which outside communication is allowed, along with an optional list
+                  of subnets within that CIDR prefix to/from which outside communication
+                  is not allowed.
+                properties:
+                  cidr:
+                    description: CIDR is a CIDR prefix / IP Block.
+                    oneOf:
+                    - pattern: ^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\/([0-9]|[1-2][0-9]|3[0-2])$
+                      type: string
+                    - pattern: ^s*((([0-9A-Fa-f]{1,4}:){7}(:|([0-9A-Fa-f]{1,4})))|(([0-9A-Fa-f]{1,4}:){6}:([0-9A-Fa-f]{1,4})?)|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){0,1}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){0,2}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){0,3}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){0,4}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){0,5}):([0-9A-Fa-f]{1,4})?))|(:(:|((:[0-9A-Fa-f]{1,4}){1,7}))))(%.+)?s*/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$
+                      type: string
+                    type: string
+                  except:
+                    description: ExceptCIDRs is a list of IP blocks which the endpoint
+                      subject to the rule is not allowed to initiate connections to.
+                      These CIDR prefixes should be contained within Cidr. These exceptions
+                      are only applied to the Cidr in this CIDRRule, and do not apply
+                      to any other CIDR prefixes in any other CIDRRules.
+                    items:
+                      description: CIDR is a CIDR prefix / IP Block.
+                      oneOf:
+                      - pattern: ^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\/([0-9]|[1-2][0-9]|3[0-2])$
+                        type: string
+                      - pattern: ^s*((([0-9A-Fa-f]{1,4}:){7}(:|([0-9A-Fa-f]{1,4})))|(([0-9A-Fa-f]{1,4}:){6}:([0-9A-Fa-f]{1,4})?)|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){0,1}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){0,2}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){0,3}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){0,4}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){0,5}):([0-9A-Fa-f]{1,4})?))|(:(:|((:[0-9A-Fa-f]{1,4}){1,7}))))(%.+)?s*/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$
+                        type: string
+                      type: string
+                    type: array
+                required:
+                - cidr
+              type: array
+            toEndpoints:
+              description: |-
+                ToEndpoints is a list of endpoints identified by an EndpointSelector to which the endpoint subject to the ruleis allowed to communicate.
+
+                Example: Any endpoint with the label "role=frontend" can be consumed by any endpoint carrying the label "role=backend".
+              items:
+                description: EndpointSelector is a wrapper for k8s LabelSelector.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                    type: array
+                  matchLabels:
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+              type: array
+            toEntities:
+              description: ToEntities is a list of special entities to which the endpoint
+                subject to the rule is allowed to initiate connections. Supported
+                entities are `world`, `cluster` and `host`
+              items:
+                type: string
+              type: array
+            toGroups:
+              description: "ToGroups is a list of constraints that will\n\t\t\t\tgather
+                data from third-party providers and create a new\n\t\t\t\tderived
+                policy."
+              properties:
+                AWS:
+                  properties:
+                    Region:
+                      description: "Region is the key that will filter the AWS EC2\n\t\t\t\tinstances
+                        in the given region"
+                      type: string
+                    SecurityGroupsIds:
+                      description: "SecurityGroupsIds is the list of AWS security\n\t\t\t\tgroup
+                        IDs that will filter the instances IPs from the AWS API"
+                      type: array
+                    SecurityGroupsNames:
+                      description: "SecurityGroupsNames is the list of  AWS security\n\t\t\t\tgroup
+                        names that will filter the instances IPs from the AWS API"
+                      type: array
+            toPorts:
+              description: |-
+                ToPorts is a list of destination ports identified by port number and protocol which the endpoint subject to the rule is allowed to connect to.
+
+                Example: Any endpoint with the label "role=frontend" is allowed to initiate connections to destination port 8080/tcp
+              items:
+                description: PortRule is a list of ports/protocol combinations with
+                  optional Layer 7 rules which must be met.
+                properties:
+                  ports:
+                    description: |-
+                      Ports is a list of L4 port/protocol
+
+                      If omitted or empty but RedirectPort is set, then all ports of the endpoint subject to either the ingress or egress rule are being redirected.
+                    items:
+                      description: PortProtocol specifies an L4 port with an optional
+                        transport protocol
+                      properties:
+                        port:
+                          description: Port is an L4 port number. For now the string
+                            will be strictly parsed as a single uint16. In the future,
+                            this field may support ranges in the form "1024-2048
+                          pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})$
+                          type: string
+                        protocol:
+                          description: 'Protocol is the L4 protocol. If omitted or
+                            empty, any protocol matches. Accepted values: "TCP", "UDP",
+                            ""/"ANY"\n\nMatching on ICMP is not supported.'
+                          enum:
+                          - TCP
+                          - UDP
+                          - ANY
+                          type: string
+                      required:
+                      - port
+                    type: array
+                  redirectPort:
+                    description: RedirectPort is the L4 port which, if set, all traffic
+                      matching the Ports is being redirected to. Whatever listener
+                      behind that port becomes responsible to enforce the port rules
+                      and is also responsible to reinject all traffic back and ensure
+                      it reaches its original destination.
+                    format: uint16
+                    type: integer
+                  rules:
+                    description: Rules is a list of additional port level rules which
+                      must be met in order for the PortRule to allow the traffic.
+                      If omitted or empty, no layer 7 rules are enforced.
+                    properties:
+                      http:
+                        description: HTTP specific rules.
+                        items:
+                          description: |-
+                            PortRuleHTTP is a list of HTTP protocol constraints. All fields are optional, if all fields are empty or missing, the rule does not have any effect.
+
+                            All fields of this type are extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows the egrep/unix syntax, not the perl syntax) matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986.
+                          properties:
+                            headers:
+                              description: Headers is a list of HTTP headers which
+                                must be present in the request. If omitted or empty,
+                                requests are allowed regardless of headers present.
+                              items:
+                                type: string
+                              type: array
+                            host:
+                              description: |-
+                                Host is an extended POSIX regex matched against the host header of a request, e.g. "foo.com"
+
+                                If omitted or empty, the value of the host header is ignored.
+                              format: idn-hostname
+                              type: string
+                            method:
+                              description: |-
+                                Method is an extended POSIX regex matched against the method of a request, e.g. "GET", "POST", "PUT", "PATCH", "DELETE", ...
+
+                                If omitted or empty, all methods are allowed.
+                              type: string
+                            path:
+                              description: |-
+                                Path is an extended POSIX regex matched against the path of a request. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986.
+
+                                If omitted or empty, all paths are all allowed.
+                              type: string
+                        type: array
+                      kafka:
+                        description: Kafka-specific rules.
+                        items:
+                          description: PortRuleKafka is a list of Kafka protocol constraints.
+                            All fields are optional, if all fields are empty or missing,
+                            the rule will match all Kafka messages.
+                          properties:
+                            apiKey:
+                              description: |-
+                                APIKey is a case-insensitive string matched against the key of a request, e.g. "produce", "fetch", "createtopic", "deletetopic", et al Reference: https://kafka.apache.org/protocol#protocol_api_keys
+
+                                If omitted or empty, all keys are allowed.
+                              type: string
+                            apiVersion:
+                              description: |-
+                                APIVersion is the version matched against the api version of the Kafka message. If set, it has to be a string representing a positive integer.
+
+                                If omitted or empty, all versions are allowed.
+                              type: string
+                            clientID:
+                              description: |-
+                                ClientID is the client identifier as provided in the request.
+
+                                From Kafka protocol documentation: This is a user supplied identifier for the client application. The user can use any identifier they like and it will be used when logging errors, monitoring aggregates, etc. For example, one might want to monitor not just the requests per second overall, but the number coming from each client application (each of which could reside on multiple servers). This id acts as a logical grouping across all requests from a particular client.
+
+                                If omitted or empty, all client identifiers are allowed.
+                              type: string
+                            role:
+                              description: 'Role is a case-insensitive string and
+                                describes a group of API keysnecessary to perform
+                                certain higher level Kafka operations such as"produce"
+                                or "consume". An APIGroup automatically expands into
+                                all APIKeysrequired to perform the specified higher
+                                level operation.The following values are supported:-
+                                "produce": Allow producing to the topics specified
+                                in the rule- "consume": Allow consuming from the topics
+                                specified in the ruleThis field is incompatible with
+                                the APIKey field, either APIKey or Rolemay be specified.
+                                If omitted or empty, the field has no effect and the
+                                logic of the APIKey field applies.'
+                              enum:
+                              - produce
+                              - consume
+                              type: string
+                            topic:
+                              description: |-
+                                Topic is the topic name contained in the message. If a Kafka request contains multiple topics, then all topics must be allowed or the message will be rejected.
+
+                                This constraint is ignored if the matched request message type doesn't contain any topic. Maximum size of Topic can be 249 characters as per recent Kafka spec and allowed characters are a-z, A-Z, 0-9, -, . and _ Older Kafka versions had longer topic lengths of 255, but in Kafka 0.10 version the length was changed from 255 to 249. For compatibility reasons we are using 255
+
+                                If omitted or empty, all topics are allowed.
+                              maxLength: 255
+                              type: string
+                        type: array
+                      l7:
+                        description: Generic Key-Value pair rules.
+                        items:
+                          description: PortRuleL7 is a map of {key,value} pairs which
+                            is passed to the parser referenced in l7proto. It is up
+                            to the parser to define what to do with the map data.
+                            If omitted or empty, all requests are allowed. Both keys
+                            and values must be strings.
+                        type: array
+                      l7proto:
+                        description: Parser type name that uses Key-Value pair rules.
+                        type: string
+              type: array
+            toRequires:
+              description: |-
+                ToRequires is a list of additional constraints which must be met in order for the selected endpoints to be able to reach other endpoints. These additional constraints do not by themselves grant access privileges and must always be accompanied with at least one matching FromEndpoints.
+
+                Example: Any Endpoint with the label "team=A" requires any endpoint to which it communicates to also carry the label "team=A".
+              items:
+                description: EndpointSelector is a wrapper for k8s LabelSelector.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                    type: array
+                  matchLabels:
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+              type: array
+            toServices:
+              description: |-
+                ToServices is a list of services to which the endpoint subject to the rule is allowed to initiate connections.
+
+                Example: Any endpoint with the label "app=backend-app" is allowed to initiate connections to all cidrs backing the "external-service" service
+              items:
+                description: Service wraps around selectors for services
+                properties:
+                  k8sService:
+                    description: K8sServiceNamespace is an abstraction for the k8s
+                      service + namespace types.
+                    properties:
+                      namespace:
+                        type: string
+                      serviceName:
+                        type: string
+                  k8sServiceSelector:
+                    description: K8sServiceSelector selects services by k8s labels.
+                      Not supported yet
+                    properties:
+                      namespace:
+                        type: string
+                      selector:
+                        description: A label selector is a label query over a set
+                          of resources. The result of matchLabels and matchExpressions
+                          are ANDed. An empty label selector matches all objects.
+                          A null label selector matches no objects.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                            type: array
+                          matchLabels:
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                    required:
+                    - selector
+              type: array
+        EndpointSelector:
+          description: A label selector is a label query over a set of resources.
+            The result of matchLabels and matchExpressions are ANDed. An empty label
+            selector matches all objects. A null label selector matches no objects.
+          properties:
+            matchExpressions:
+              description: matchExpressions is a list of label selector requirements.
+                The requirements are ANDed.
+              items:
+                description: A label selector requirement is a selector that contains
+                  values, a key, and an operator that relates the key and values.
+                properties:
+                  key:
+                    description: key is the label key that the selector applies to.
+                    type: string
+                  operator:
+                    description: operator represents a key's relationship to a set
+                      of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                    enum:
+                    - In
+                    - NotIn
+                    - Exists
+                    - DoesNotExist
+                    type: string
+                  values:
+                    description: values is an array of string values. If the operator
+                      is In or NotIn, the values array must be non-empty. If the operator
+                      is Exists or DoesNotExist, the values array must be empty. This
+                      array is replaced during a strategic merge patch.
+                    items:
+                      type: string
+                    type: array
+                required:
+                - key
+                - operator
+              type: array
+            matchLabels:
+              description: matchLabels is a map of {key,value} pairs. A single {key,value}
+                in the matchLabels map is equivalent to an element of matchExpressions,
+                whose key field is "key", the operator is "In", and the values array
+                contains only "value". The requirements are ANDed.
+              type: object
+        IngressRule:
+          description: |-
+            IngressRule contains all rule types which can be applied at ingress, i.e. network traffic that originates outside of the endpoint and is entering the endpoint selected by the endpointSelector.
+
+            - All members of this structure are optional. If omitted or empty, the
+              member will have no effect on the rule.
+
+            - If multiple members are set, all of them need to match in order for
+              the rule to take effect. The exception to this rule is FromRequires field;
+              the effects of any Requires field in any rule will apply to all other
+              rules as well.
+
+            - For now, combining ToPorts, FromCIDR, and FromEndpoints in the same rule
+              is not supported and any such rules will be rejected. In the future, this
+              will be supported and if multiple members of this structure are specified,
+             then all members must match in order for the rule to take effect. The
+              exception to this rule is the Requires field, the effects of any Requires
+              field in any rule will apply to all other rules as well.
+          properties:
+            fromCIDR:
+              description: |-
+                FromCIDR is a list of IP blocks which the endpoint subject to the rule is allowed to receive connections from. This will match on the source IP address of incoming connections. Adding  a prefix into FromCIDR or into FromCIDRSet with no ExcludeCIDRs is  equivalent. Overlaps are allowed between FromCIDR and FromCIDRSet.
+
+                Example: Any endpoint with the label "app=my-legacy-pet" is allowed to receive connections from 10.3.9.1
+              items:
+                description: CIDR is a CIDR prefix / IP Block.
+                oneOf:
+                - pattern: ^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\/([0-9]|[1-2][0-9]|3[0-2])$
+                  type: string
+                - pattern: ^s*((([0-9A-Fa-f]{1,4}:){7}(:|([0-9A-Fa-f]{1,4})))|(([0-9A-Fa-f]{1,4}:){6}:([0-9A-Fa-f]{1,4})?)|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){0,1}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){0,2}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){0,3}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){0,4}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){0,5}):([0-9A-Fa-f]{1,4})?))|(:(:|((:[0-9A-Fa-f]{1,4}){1,7}))))(%.+)?s*/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$
+                  type: string
+                type: string
+              type: array
+            fromCIDRSet:
+              description: |-
+                FromCIDRSet is a list of IP blocks which the endpoint subject to the rule is allowed to receive connections from in addition to FromEndpoints, along with a list of subnets contained within their corresponding IP block from which traffic should not be allowed. This will match on the source IP address of incoming connections. Adding a prefix into FromCIDR or into FromCIDRSet with no ExcludeCIDRs is equivalent. Overlaps are allowed between FromCIDR and FromCIDRSet.
+
+                Example: Any endpoint with the label "app=my-legacy-pet" is allowed to receive connections from 10.0.0.0/8 except from IPs in subnet 10.96.0.0/12.
+              items:
+                description: CIDRRule is a rule that specifies a CIDR prefix to/from
+                  which outside communication is allowed, along with an optional list
+                  of subnets within that CIDR prefix to/from which outside communication
+                  is not allowed.
+                properties:
+                  cidr:
+                    description: CIDR is a CIDR prefix / IP Block.
+                    oneOf:
+                    - pattern: ^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\/([0-9]|[1-2][0-9]|3[0-2])$
+                      type: string
+                    - pattern: ^s*((([0-9A-Fa-f]{1,4}:){7}(:|([0-9A-Fa-f]{1,4})))|(([0-9A-Fa-f]{1,4}:){6}:([0-9A-Fa-f]{1,4})?)|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){0,1}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){0,2}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){0,3}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){0,4}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){0,5}):([0-9A-Fa-f]{1,4})?))|(:(:|((:[0-9A-Fa-f]{1,4}){1,7}))))(%.+)?s*/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$
+                      type: string
+                    type: string
+                  except:
+                    description: ExceptCIDRs is a list of IP blocks which the endpoint
+                      subject to the rule is not allowed to initiate connections to.
+                      These CIDR prefixes should be contained within Cidr. These exceptions
+                      are only applied to the Cidr in this CIDRRule, and do not apply
+                      to any other CIDR prefixes in any other CIDRRules.
+                    items:
+                      description: CIDR is a CIDR prefix / IP Block.
+                      oneOf:
+                      - pattern: ^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\/([0-9]|[1-2][0-9]|3[0-2])$
+                        type: string
+                      - pattern: ^s*((([0-9A-Fa-f]{1,4}:){7}(:|([0-9A-Fa-f]{1,4})))|(([0-9A-Fa-f]{1,4}:){6}:([0-9A-Fa-f]{1,4})?)|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){0,1}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){0,2}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){0,3}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){0,4}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){0,5}):([0-9A-Fa-f]{1,4})?))|(:(:|((:[0-9A-Fa-f]{1,4}){1,7}))))(%.+)?s*/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$
+                        type: string
+                      type: string
+                    type: array
+                required:
+                - cidr
+              type: array
+            fromEndpoints:
+              description: |-
+                FromEndpoints is a list of endpoints identified by an EndpointSelector which are allowed to communicate with the endpoint subject to the rule.
+
+                Example: Any endpoint with the label "role=backend" can be consumed by any endpoint carrying the label "role=frontend".
+              items:
+                description: EndpointSelector is a wrapper for k8s LabelSelector.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                    type: array
+                  matchLabels:
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+              type: array
+            fromEntities:
+              description: FromEntities is a list of special entities which the endpoint
+                subject to the rule is allowed to receive connections from. Supported
+                entities are `world`, `cluster`, `host`, and `init`
+              items:
+                type: string
+              type: array
+            fromRequires:
+              description: |-
+                FromRequires is a list of additional constraints which must be met in order for the selected endpoints to be reachable. These additional constraints do no by itself grant access privileges and must always be accompanied with at least one matching FromEndpoints.
+
+                Example: Any Endpoint with the label "team=A" requires consuming endpoint to also carry the label "team=A".
+              items:
+                description: EndpointSelector is a wrapper for k8s LabelSelector.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                    type: array
+                  matchLabels:
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+              type: array
+            toPorts:
+              description: |-
+                ToPorts is a list of destination ports identified by port number and protocol which the endpoint subject to the rule is allowed to receive connections on.
+
+                Example: Any endpoint with the label "app=httpd" can only accept incoming connections on port 80/tcp.
+              items:
+                description: PortRule is a list of ports/protocol combinations with
+                  optional Layer 7 rules which must be met.
+                properties:
+                  ports:
+                    description: |-
+                      Ports is a list of L4 port/protocol
+
+                      If omitted or empty but RedirectPort is set, then all ports of the endpoint subject to either the ingress or egress rule are being redirected.
+                    items:
+                      description: PortProtocol specifies an L4 port with an optional
+                        transport protocol
+                      properties:
+                        port:
+                          description: Port is an L4 port number. For now the string
+                            will be strictly parsed as a single uint16. In the future,
+                            this field may support ranges in the form "1024-2048
+                          pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})$
+                          type: string
+                        protocol:
+                          description: 'Protocol is the L4 protocol. If omitted or
+                            empty, any protocol matches. Accepted values: "TCP", "UDP",
+                            ""/"ANY"\n\nMatching on ICMP is not supported.'
+                          enum:
+                          - TCP
+                          - UDP
+                          - ANY
+                          type: string
+                      required:
+                      - port
+                    type: array
+                  redirectPort:
+                    description: RedirectPort is the L4 port which, if set, all traffic
+                      matching the Ports is being redirected to. Whatever listener
+                      behind that port becomes responsible to enforce the port rules
+                      and is also responsible to reinject all traffic back and ensure
+                      it reaches its original destination.
+                    format: uint16
+                    type: integer
+                  rules:
+                    description: Rules is a list of additional port level rules which
+                      must be met in order for the PortRule to allow the traffic.
+                      If omitted or empty, no layer 7 rules are enforced.
+                    properties:
+                      http:
+                        description: HTTP specific rules.
+                        items:
+                          description: |-
+                            PortRuleHTTP is a list of HTTP protocol constraints. All fields are optional, if all fields are empty or missing, the rule does not have any effect.
+
+                            All fields of this type are extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows the egrep/unix syntax, not the perl syntax) matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986.
+                          properties:
+                            headers:
+                              description: Headers is a list of HTTP headers which
+                                must be present in the request. If omitted or empty,
+                                requests are allowed regardless of headers present.
+                              items:
+                                type: string
+                              type: array
+                            host:
+                              description: |-
+                                Host is an extended POSIX regex matched against the host header of a request, e.g. "foo.com"
+
+                                If omitted or empty, the value of the host header is ignored.
+                              format: idn-hostname
+                              type: string
+                            method:
+                              description: |-
+                                Method is an extended POSIX regex matched against the method of a request, e.g. "GET", "POST", "PUT", "PATCH", "DELETE", ...
+
+                                If omitted or empty, all methods are allowed.
+                              type: string
+                            path:
+                              description: |-
+                                Path is an extended POSIX regex matched against the path of a request. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986.
+
+                                If omitted or empty, all paths are all allowed.
+                              type: string
+                        type: array
+                      kafka:
+                        description: Kafka-specific rules.
+                        items:
+                          description: PortRuleKafka is a list of Kafka protocol constraints.
+                            All fields are optional, if all fields are empty or missing,
+                            the rule will match all Kafka messages.
+                          properties:
+                            apiKey:
+                              description: |-
+                                APIKey is a case-insensitive string matched against the key of a request, e.g. "produce", "fetch", "createtopic", "deletetopic", et al Reference: https://kafka.apache.org/protocol#protocol_api_keys
+
+                                If omitted or empty, all keys are allowed.
+                              type: string
+                            apiVersion:
+                              description: |-
+                                APIVersion is the version matched against the api version of the Kafka message. If set, it has to be a string representing a positive integer.
+
+                                If omitted or empty, all versions are allowed.
+                              type: string
+                            clientID:
+                              description: |-
+                                ClientID is the client identifier as provided in the request.
+
+                                From Kafka protocol documentation: This is a user supplied identifier for the client application. The user can use any identifier they like and it will be used when logging errors, monitoring aggregates, etc. For example, one might want to monitor not just the requests per second overall, but the number coming from each client application (each of which could reside on multiple servers). This id acts as a logical grouping across all requests from a particular client.
+
+                                If omitted or empty, all client identifiers are allowed.
+                              type: string
+                            role:
+                              description: 'Role is a case-insensitive string and
+                                describes a group of API keysnecessary to perform
+                                certain higher level Kafka operations such as"produce"
+                                or "consume". An APIGroup automatically expands into
+                                all APIKeysrequired to perform the specified higher
+                                level operation.The following values are supported:-
+                                "produce": Allow producing to the topics specified
+                                in the rule- "consume": Allow consuming from the topics
+                                specified in the ruleThis field is incompatible with
+                                the APIKey field, either APIKey or Rolemay be specified.
+                                If omitted or empty, the field has no effect and the
+                                logic of the APIKey field applies.'
+                              enum:
+                              - produce
+                              - consume
+                              type: string
+                            topic:
+                              description: |-
+                                Topic is the topic name contained in the message. If a Kafka request contains multiple topics, then all topics must be allowed or the message will be rejected.
+
+                                This constraint is ignored if the matched request message type doesn't contain any topic. Maximum size of Topic can be 249 characters as per recent Kafka spec and allowed characters are a-z, A-Z, 0-9, -, . and _ Older Kafka versions had longer topic lengths of 255, but in Kafka 0.10 version the length was changed from 255 to 249. For compatibility reasons we are using 255
+
+                                If omitted or empty, all topics are allowed.
+                              maxLength: 255
+                              type: string
+                        type: array
+                      l7:
+                        description: Generic Key-Value pair rules.
+                        items:
+                          description: PortRuleL7 is a map of {key,value} pairs which
+                            is passed to the parser referenced in l7proto. It is up
+                            to the parser to define what to do with the map data.
+                            If omitted or empty, all requests are allowed. Both keys
+                            and values must be strings.
+                        type: array
+                      l7proto:
+                        description: Parser type name that uses Key-Value pair rules.
+                        type: string
+              type: array
+        K8sServiceNamespace:
+          description: K8sServiceNamespace is an abstraction for the k8s service +
+            namespace types.
+          properties:
+            namespace:
+              type: string
+            serviceName:
+              type: string
+        L7Rules:
+          description: L7Rules is a union of port level rule types. Mixing of different
+            port level rule types is disallowed, so exactly one of the following must
+            be set. If none are specified, then no additional port level rules are
+            applied.
+          properties:
+            http:
+              description: HTTP specific rules.
+              items:
+                description: |-
+                  PortRuleHTTP is a list of HTTP protocol constraints. All fields are optional, if all fields are empty or missing, the rule does not have any effect.
+
+                  All fields of this type are extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows the egrep/unix syntax, not the perl syntax) matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986.
+                properties:
+                  headers:
+                    description: Headers is a list of HTTP headers which must be present
+                      in the request. If omitted or empty, requests are allowed regardless
+                      of headers present.
+                    items:
+                      type: string
+                    type: array
+                  host:
+                    description: |-
+                      Host is an extended POSIX regex matched against the host header of a request, e.g. "foo.com"
+
+                      If omitted or empty, the value of the host header is ignored.
+                    format: idn-hostname
+                    type: string
+                  method:
+                    description: |-
+                      Method is an extended POSIX regex matched against the method of a request, e.g. "GET", "POST", "PUT", "PATCH", "DELETE", ...
+
+                      If omitted or empty, all methods are allowed.
+                    type: string
+                  path:
+                    description: |-
+                      Path is an extended POSIX regex matched against the path of a request. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986.
+
+                      If omitted or empty, all paths are all allowed.
+                    type: string
+              type: array
+            kafka:
+              description: Kafka-specific rules.
+              items:
+                description: PortRuleKafka is a list of Kafka protocol constraints.
+                  All fields are optional, if all fields are empty or missing, the
+                  rule will match all Kafka messages.
+                properties:
+                  apiKey:
+                    description: |-
+                      APIKey is a case-insensitive string matched against the key of a request, e.g. "produce", "fetch", "createtopic", "deletetopic", et al Reference: https://kafka.apache.org/protocol#protocol_api_keys
+
+                      If omitted or empty, all keys are allowed.
+                    type: string
+                  apiVersion:
+                    description: |-
+                      APIVersion is the version matched against the api version of the Kafka message. If set, it has to be a string representing a positive integer.
+
+                      If omitted or empty, all versions are allowed.
+                    type: string
+                  clientID:
+                    description: |-
+                      ClientID is the client identifier as provided in the request.
+
+                      From Kafka protocol documentation: This is a user supplied identifier for the client application. The user can use any identifier they like and it will be used when logging errors, monitoring aggregates, etc. For example, one might want to monitor not just the requests per second overall, but the number coming from each client application (each of which could reside on multiple servers). This id acts as a logical grouping across all requests from a particular client.
+
+                      If omitted or empty, all client identifiers are allowed.
+                    type: string
+                  role:
+                    description: 'Role is a case-insensitive string and describes
+                      a group of API keysnecessary to perform certain higher level
+                      Kafka operations such as"produce" or "consume". An APIGroup
+                      automatically expands into all APIKeysrequired to perform the
+                      specified higher level operation.The following values are supported:-
+                      "produce": Allow producing to the topics specified in the rule-
+                      "consume": Allow consuming from the topics specified in the
+                      ruleThis field is incompatible with the APIKey field, either
+                      APIKey or Rolemay be specified. If omitted or empty, the field
+                      has no effect and the logic of the APIKey field applies.'
+                    enum:
+                    - produce
+                    - consume
+                    type: string
+                  topic:
+                    description: |-
+                      Topic is the topic name contained in the message. If a Kafka request contains multiple topics, then all topics must be allowed or the message will be rejected.
+
+                      This constraint is ignored if the matched request message type doesn't contain any topic. Maximum size of Topic can be 249 characters as per recent Kafka spec and allowed characters are a-z, A-Z, 0-9, -, . and _ Older Kafka versions had longer topic lengths of 255, but in Kafka 0.10 version the length was changed from 255 to 249. For compatibility reasons we are using 255
+
+                      If omitted or empty, all topics are allowed.
+                    maxLength: 255
+                    type: string
+              type: array
+            l7:
+              description: Generic Key-Value pair rules.
+              items:
+                description: PortRuleL7 is a map of {key,value} pairs which is passed
+                  to the parser referenced in l7proto. It is up to the parser to define
+                  what to do with the map data. If omitted or empty, all requests
+                  are allowed. Both keys and values must be strings.
+              type: array
+            l7proto:
+              description: Parser type name that uses Key-Value pair rules.
+              type: string
+        Label:
+          description: Label is the cilium's representation of a container label.
+          properties:
+            key:
+              type: string
+            source:
+              description: 'Source can be one of the values present in const.go (e.g.:
+                LabelSourceContainer)'
+              type: string
+            value:
+              type: string
+          required:
+          - key
+        LabelSelector:
+          description: A label selector is a label query over a set of resources.
+            The result of matchLabels and matchExpressions are ANDed. An empty label
+            selector matches all objects. A null label selector matches no objects.
+          properties:
+            matchExpressions:
+              description: matchExpressions is a list of label selector requirements.
+                The requirements are ANDed.
+              items:
+                description: A label selector requirement is a selector that contains
+                  values, a key, and an operator that relates the key and values.
+                properties:
+                  key:
+                    description: key is the label key that the selector applies to.
+                    type: string
+                  operator:
+                    description: operator represents a key's relationship to a set
+                      of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                    enum:
+                    - In
+                    - NotIn
+                    - Exists
+                    - DoesNotExist
+                    type: string
+                  values:
+                    description: values is an array of string values. If the operator
+                      is In or NotIn, the values array must be non-empty. If the operator
+                      is Exists or DoesNotExist, the values array must be empty. This
+                      array is replaced during a strategic merge patch.
+                    items:
+                      type: string
+                    type: array
+                required:
+                - key
+                - operator
+              type: array
+            matchLabels:
+              description: matchLabels is a map of {key,value} pairs. A single {key,value}
+                in the matchLabels map is equivalent to an element of matchExpressions,
+                whose key field is "key", the operator is "In", and the values array
+                contains only "value". The requirements are ANDed.
+              type: object
+        LabelSelectorRequirement:
+          description: A label selector requirement is a selector that contains values,
+            a key, and an operator that relates the key and values.
+          properties:
+            key:
+              description: key is the label key that the selector applies to.
+              type: string
+            operator:
+              description: operator represents a key's relationship to a set of values.
+                Valid operators are In, NotIn, Exists and DoesNotExist.
+              enum:
+              - In
+              - NotIn
+              - Exists
+              - DoesNotExist
+              type: string
+            values:
+              description: values is an array of string values. If the operator is
+                In or NotIn, the values array must be non-empty. If the operator is
+                Exists or DoesNotExist, the values array must be empty. This array
+                is replaced during a strategic merge patch.
+              items:
+                type: string
+              type: array
+          required:
+          - key
+          - operator
+        PortProtocol:
+          description: PortProtocol specifies an L4 port with an optional transport
+            protocol
+          properties:
+            port:
+              description: Port is an L4 port number. For now the string will be strictly
+                parsed as a single uint16. In the future, this field may support ranges
+                in the form "1024-2048
+              pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})$
+              type: string
+            protocol:
+              description: 'Protocol is the L4 protocol. If omitted or empty, any
+                protocol matches. Accepted values: "TCP", "UDP", ""/"ANY"\n\nMatching
+                on ICMP is not supported.'
+              enum:
+              - TCP
+              - UDP
+              - ANY
+              type: string
+          required:
+          - port
+        PortRule:
+          description: PortRule is a list of ports/protocol combinations with optional
+            Layer 7 rules which must be met.
+          properties:
+            ports:
+              description: |-
+                Ports is a list of L4 port/protocol
+
+                If omitted or empty but RedirectPort is set, then all ports of the endpoint subject to either the ingress or egress rule are being redirected.
+              items:
+                description: PortProtocol specifies an L4 port with an optional transport
+                  protocol
+                properties:
+                  port:
+                    description: Port is an L4 port number. For now the string will
+                      be strictly parsed as a single uint16. In the future, this field
+                      may support ranges in the form "1024-2048
+                    pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})$
+                    type: string
+                  protocol:
+                    description: 'Protocol is the L4 protocol. If omitted or empty,
+                      any protocol matches. Accepted values: "TCP", "UDP", ""/"ANY"\n\nMatching
+                      on ICMP is not supported.'
+                    enum:
+                    - TCP
+                    - UDP
+                    - ANY
+                    type: string
+                required:
+                - port
+              type: array
+            redirectPort:
+              description: RedirectPort is the L4 port which, if set, all traffic
+                matching the Ports is being redirected to. Whatever listener behind
+                that port becomes responsible to enforce the port rules and is also
+                responsible to reinject all traffic back and ensure it reaches its
+                original destination.
+              format: uint16
+              type: integer
+            rules:
+              description: Rules is a list of additional port level rules which must
+                be met in order for the PortRule to allow the traffic. If omitted
+                or empty, no layer 7 rules are enforced.
+              properties:
+                http:
+                  description: HTTP specific rules.
+                  items:
+                    description: |-
+                      PortRuleHTTP is a list of HTTP protocol constraints. All fields are optional, if all fields are empty or missing, the rule does not have any effect.
+
+                      All fields of this type are extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows the egrep/unix syntax, not the perl syntax) matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986.
+                    properties:
+                      headers:
+                        description: Headers is a list of HTTP headers which must
+                          be present in the request. If omitted or empty, requests
+                          are allowed regardless of headers present.
+                        items:
+                          type: string
+                        type: array
+                      host:
+                        description: |-
+                          Host is an extended POSIX regex matched against the host header of a request, e.g. "foo.com"
+
+                          If omitted or empty, the value of the host header is ignored.
+                        format: idn-hostname
+                        type: string
+                      method:
+                        description: |-
+                          Method is an extended POSIX regex matched against the method of a request, e.g. "GET", "POST", "PUT", "PATCH", "DELETE", ...
+
+                          If omitted or empty, all methods are allowed.
+                        type: string
+                      path:
+                        description: |-
+                          Path is an extended POSIX regex matched against the path of a request. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986.
+
+                          If omitted or empty, all paths are all allowed.
+                        type: string
+                  type: array
+                kafka:
+                  description: Kafka-specific rules.
+                  items:
+                    description: PortRuleKafka is a list of Kafka protocol constraints.
+                      All fields are optional, if all fields are empty or missing,
+                      the rule will match all Kafka messages.
+                    properties:
+                      apiKey:
+                        description: |-
+                          APIKey is a case-insensitive string matched against the key of a request, e.g. "produce", "fetch", "createtopic", "deletetopic", et al Reference: https://kafka.apache.org/protocol#protocol_api_keys
+
+                          If omitted or empty, all keys are allowed.
+                        type: string
+                      apiVersion:
+                        description: |-
+                          APIVersion is the version matched against the api version of the Kafka message. If set, it has to be a string representing a positive integer.
+
+                          If omitted or empty, all versions are allowed.
+                        type: string
+                      clientID:
+                        description: |-
+                          ClientID is the client identifier as provided in the request.
+
+                          From Kafka protocol documentation: This is a user supplied identifier for the client application. The user can use any identifier they like and it will be used when logging errors, monitoring aggregates, etc. For example, one might want to monitor not just the requests per second overall, but the number coming from each client application (each of which could reside on multiple servers). This id acts as a logical grouping across all requests from a particular client.
+
+                          If omitted or empty, all client identifiers are allowed.
+                        type: string
+                      role:
+                        description: 'Role is a case-insensitive string and describes
+                          a group of API keysnecessary to perform certain higher level
+                          Kafka operations such as"produce" or "consume". An APIGroup
+                          automatically expands into all APIKeysrequired to perform
+                          the specified higher level operation.The following values
+                          are supported:- "produce": Allow producing to the topics
+                          specified in the rule- "consume": Allow consuming from the
+                          topics specified in the ruleThis field is incompatible with
+                          the APIKey field, either APIKey or Rolemay be specified.
+                          If omitted or empty, the field has no effect and the logic
+                          of the APIKey field applies.'
+                        enum:
+                        - produce
+                        - consume
+                        type: string
+                      topic:
+                        description: |-
+                          Topic is the topic name contained in the message. If a Kafka request contains multiple topics, then all topics must be allowed or the message will be rejected.
+
+                          This constraint is ignored if the matched request message type doesn't contain any topic. Maximum size of Topic can be 249 characters as per recent Kafka spec and allowed characters are a-z, A-Z, 0-9, -, . and _ Older Kafka versions had longer topic lengths of 255, but in Kafka 0.10 version the length was changed from 255 to 249. For compatibility reasons we are using 255
+
+                          If omitted or empty, all topics are allowed.
+                        maxLength: 255
+                        type: string
+                  type: array
+                l7:
+                  description: Generic Key-Value pair rules.
+                  items:
+                    description: PortRuleL7 is a map of {key,value} pairs which is
+                      passed to the parser referenced in l7proto. It is up to the
+                      parser to define what to do with the map data. If omitted or
+                      empty, all requests are allowed. Both keys and values must be
+                      strings.
+                  type: array
+                l7proto:
+                  description: Parser type name that uses Key-Value pair rules.
+                  type: string
+        PortRuleHTTP:
+          description: |-
+            PortRuleHTTP is a list of HTTP protocol constraints. All fields are optional, if all fields are empty or missing, the rule does not have any effect.
+
+            All fields of this type are extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows the egrep/unix syntax, not the perl syntax) matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986.
+          properties:
+            headers:
+              description: Headers is a list of HTTP headers which must be present
+                in the request. If omitted or empty, requests are allowed regardless
+                of headers present.
+              items:
+                type: string
+              type: array
+            host:
+              description: |-
+                Host is an extended POSIX regex matched against the host header of a request, e.g. "foo.com"
+
+                If omitted or empty, the value of the host header is ignored.
+              format: idn-hostname
+              type: string
+            method:
+              description: |-
+                Method is an extended POSIX regex matched against the method of a request, e.g. "GET", "POST", "PUT", "PATCH", "DELETE", ...
+
+                If omitted or empty, all methods are allowed.
+              type: string
+            path:
+              description: |-
+                Path is an extended POSIX regex matched against the path of a request. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986.
+
+                If omitted or empty, all paths are all allowed.
+              type: string
+        PortRuleKafka:
+          description: PortRuleKafka is a list of Kafka protocol constraints. All
+            fields are optional, if all fields are empty or missing, the rule will
+            match all Kafka messages.
+          properties:
+            apiKey:
+              description: |-
+                APIKey is a case-insensitive string matched against the key of a request, e.g. "produce", "fetch", "createtopic", "deletetopic", et al Reference: https://kafka.apache.org/protocol#protocol_api_keys
+
+                If omitted or empty, all keys are allowed.
+              type: string
+            apiVersion:
+              description: |-
+                APIVersion is the version matched against the api version of the Kafka message. If set, it has to be a string representing a positive integer.
+
+                If omitted or empty, all versions are allowed.
+              type: string
+            clientID:
+              description: |-
+                ClientID is the client identifier as provided in the request.
+
+                From Kafka protocol documentation: This is a user supplied identifier for the client application. The user can use any identifier they like and it will be used when logging errors, monitoring aggregates, etc. For example, one might want to monitor not just the requests per second overall, but the number coming from each client application (each of which could reside on multiple servers). This id acts as a logical grouping across all requests from a particular client.
+
+                If omitted or empty, all client identifiers are allowed.
+              type: string
+            role:
+              description: 'Role is a case-insensitive string and describes a group
+                of API keysnecessary to perform certain higher level Kafka operations
+                such as"produce" or "consume". An APIGroup automatically expands into
+                all APIKeysrequired to perform the specified higher level operation.The
+                following values are supported:- "produce": Allow producing to the
+                topics specified in the rule- "consume": Allow consuming from the
+                topics specified in the ruleThis field is incompatible with the APIKey
+                field, either APIKey or Rolemay be specified. If omitted or empty,
+                the field has no effect and the logic of the APIKey field applies.'
+              enum:
+              - produce
+              - consume
+              type: string
+            topic:
+              description: |-
+                Topic is the topic name contained in the message. If a Kafka request contains multiple topics, then all topics must be allowed or the message will be rejected.
+
+                This constraint is ignored if the matched request message type doesn't contain any topic. Maximum size of Topic can be 249 characters as per recent Kafka spec and allowed characters are a-z, A-Z, 0-9, -, . and _ Older Kafka versions had longer topic lengths of 255, but in Kafka 0.10 version the length was changed from 255 to 249. For compatibility reasons we are using 255
+
+                If omitted or empty, all topics are allowed.
+              maxLength: 255
+              type: string
+        PortRuleL7:
+          description: PortRuleL7 is a map of {key,value} pairs which is passed to
+            the parser referenced in l7proto. It is up to the parser to define what
+            to do with the map data. If omitted or empty, all requests are allowed.
+            Both keys and values must be strings.
+        Rule:
+          description: |-
+            Rule is a policy rule which must be applied to all endpoints which match the labels contained in the endpointSelector
+
+            Each rule is split into an ingress section which contains all rules applicable at ingress, and an egress section applicable at egress. For rule types such as `L4Rule` and `CIDR` which can be applied at both ingress and egress, both ingress and egress side have to either specifically allow the connection or one side has to be omitted.
+
+            Either ingress, egress, or both can be provided. If both ingress and egress are omitted, the rule has no effect.
+          properties:
+            Description:
+              description: Description is a free form string, it can be used by the
+                creator of the rule to store human readable explanation of the purpose
+                of this rule. Rules cannot be identified by comment.
+              type: string
+            egress:
+              description: Egress is a list of EgressRule which are enforced at egress.
+                If omitted or empty, this rule does not apply at egress.
+              items:
+                description: |-
+                  EgressRule contains all rule types which can be applied at egress, i.e. network traffic that originates inside the endpoint and exits the endpoint selected by the endpointSelector.
+
+                  - All members of this structure are optional. If omitted or empty, the
+                    member will have no effect on the rule.
+
+                  - For now, combining ToPorts and ToCIDR in the same rule is not supported
+                    and such rules will be rejected. In the future, this will be supported and
+                    if if multiple members of the structure are specified, then all members
+                    must match in order for the rule to take effect.
+                properties:
+                  toCIDR:
+                    description: |-
+                      ToCIDR is a list of IP blocks which the endpoint subject to the rule is allowed to initiate connections. This will match on the destination IP address of outgoing connections. Adding a prefix into ToCIDR or into ToCIDRSet with no ExcludeCIDRs is equivalent. Overlaps are allowed between ToCIDR and ToCIDRSet.
+
+                      Example: Any endpoint with the label "app=database-proxy" is allowed to initiate connections to 10.2.3.0/24
+                    items:
+                      description: CIDR is a CIDR prefix / IP Block.
+                      oneOf:
+                      - pattern: ^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\/([0-9]|[1-2][0-9]|3[0-2])$
+                        type: string
+                      - pattern: ^s*((([0-9A-Fa-f]{1,4}:){7}(:|([0-9A-Fa-f]{1,4})))|(([0-9A-Fa-f]{1,4}:){6}:([0-9A-Fa-f]{1,4})?)|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){0,1}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){0,2}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){0,3}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){0,4}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){0,5}):([0-9A-Fa-f]{1,4})?))|(:(:|((:[0-9A-Fa-f]{1,4}){1,7}))))(%.+)?s*/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$
+                        type: string
+                      type: string
+                    type: array
+                  toCIDRSet:
+                    description: |-
+                      ToCIDRSet is a list of IP blocks which the endpoint subject to the rule is allowed to initiate connections to in addition to connections which are allowed via FromEndpoints, along with a list of subnets contained within their corresponding IP block to which traffic should not be allowed. This will match on the destination IP address of outgoing connections. Adding a prefix into ToCIDR or into ToCIDRSet with no ExcludeCIDRs is equivalent. Overlaps are allowed between ToCIDR and ToCIDRSet.
+
+                      Example: Any endpoint with the label "app=database-proxy" is allowed to initiate connections to 10.2.3.0/24 except from IPs in subnet 10.2.3.0/28.
+                    items:
+                      description: CIDRRule is a rule that specifies a CIDR prefix
+                        to/from which outside communication is allowed, along with
+                        an optional list of subnets within that CIDR prefix to/from
+                        which outside communication is not allowed.
+                      properties:
+                        cidr:
+                          description: CIDR is a CIDR prefix / IP Block.
+                          oneOf:
+                          - pattern: ^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\/([0-9]|[1-2][0-9]|3[0-2])$
+                            type: string
+                          - pattern: ^s*((([0-9A-Fa-f]{1,4}:){7}(:|([0-9A-Fa-f]{1,4})))|(([0-9A-Fa-f]{1,4}:){6}:([0-9A-Fa-f]{1,4})?)|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){0,1}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){0,2}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){0,3}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){0,4}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){0,5}):([0-9A-Fa-f]{1,4})?))|(:(:|((:[0-9A-Fa-f]{1,4}){1,7}))))(%.+)?s*/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$
+                            type: string
+                          type: string
+                        except:
+                          description: ExceptCIDRs is a list of IP blocks which the
+                            endpoint subject to the rule is not allowed to initiate
+                            connections to. These CIDR prefixes should be contained
+                            within Cidr. These exceptions are only applied to the
+                            Cidr in this CIDRRule, and do not apply to any other CIDR
+                            prefixes in any other CIDRRules.
+                          items:
+                            description: CIDR is a CIDR prefix / IP Block.
+                            oneOf:
+                            - pattern: ^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\/([0-9]|[1-2][0-9]|3[0-2])$
+                              type: string
+                            - pattern: ^s*((([0-9A-Fa-f]{1,4}:){7}(:|([0-9A-Fa-f]{1,4})))|(([0-9A-Fa-f]{1,4}:){6}:([0-9A-Fa-f]{1,4})?)|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){0,1}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){0,2}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){0,3}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){0,4}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){0,5}):([0-9A-Fa-f]{1,4})?))|(:(:|((:[0-9A-Fa-f]{1,4}){1,7}))))(%.+)?s*/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$
+                              type: string
+                            type: string
+                          type: array
+                      required:
+                      - cidr
+                    type: array
+                  toEndpoints:
+                    description: |-
+                      ToEndpoints is a list of endpoints identified by an EndpointSelector to which the endpoint subject to the ruleis allowed to communicate.
+
+                      Example: Any endpoint with the label "role=frontend" can be consumed by any endpoint carrying the label "role=backend".
+                    items:
+                      description: EndpointSelector is a wrapper for k8s LabelSelector.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship
+                                  to a set of values. Valid operators are In, NotIn,
+                                  Exists and DoesNotExist.
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                description: values is an array of string values.
+                                  If the operator is In or NotIn, the values array
+                                  must be non-empty. If the operator is Exists or
+                                  DoesNotExist, the values array must be empty. This
+                                  array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                          type: array
+                        matchLabels:
+                          description: matchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.
+                          type: object
+                    type: array
+                  toEntities:
+                    description: ToEntities is a list of special entities to which
+                      the endpoint subject to the rule is allowed to initiate connections.
+                      Supported entities are `world`, `cluster` and `host`
+                    items:
+                      type: string
+                    type: array
+                  toGroups:
+                    description: "ToGroups is a list of constraints that will\n\t\t\t\tgather
+                      data from third-party providers and create a new\n\t\t\t\tderived
+                      policy."
+                    properties:
+                      AWS:
+                        properties:
+                          Region:
+                            description: "Region is the key that will filter the AWS
+                              EC2\n\t\t\t\tinstances in the given region"
+                            type: string
+                          SecurityGroupsIds:
+                            description: "SecurityGroupsIds is the list of AWS security\n\t\t\t\tgroup
+                              IDs that will filter the instances IPs from the AWS
+                              API"
+                            type: array
+                          SecurityGroupsNames:
+                            description: "SecurityGroupsNames is the list of  AWS
+                              security\n\t\t\t\tgroup names that will filter the instances
+                              IPs from the AWS API"
+                            type: array
+                  toPorts:
+                    description: |-
+                      ToPorts is a list of destination ports identified by port number and protocol which the endpoint subject to the rule is allowed to connect to.
+
+                      Example: Any endpoint with the label "role=frontend" is allowed to initiate connections to destination port 8080/tcp
+                    items:
+                      description: PortRule is a list of ports/protocol combinations
+                        with optional Layer 7 rules which must be met.
+                      properties:
+                        ports:
+                          description: |-
+                            Ports is a list of L4 port/protocol
+
+                            If omitted or empty but RedirectPort is set, then all ports of the endpoint subject to either the ingress or egress rule are being redirected.
+                          items:
+                            description: PortProtocol specifies an L4 port with an
+                              optional transport protocol
+                            properties:
+                              port:
+                                description: Port is an L4 port number. For now the
+                                  string will be strictly parsed as a single uint16.
+                                  In the future, this field may support ranges in
+                                  the form "1024-2048
+                                pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})$
+                                type: string
+                              protocol:
+                                description: 'Protocol is the L4 protocol. If omitted
+                                  or empty, any protocol matches. Accepted values:
+                                  "TCP", "UDP", ""/"ANY"\n\nMatching on ICMP is not
+                                  supported.'
+                                enum:
+                                - TCP
+                                - UDP
+                                - ANY
+                                type: string
+                            required:
+                            - port
+                          type: array
+                        redirectPort:
+                          description: RedirectPort is the L4 port which, if set,
+                            all traffic matching the Ports is being redirected to.
+                            Whatever listener behind that port becomes responsible
+                            to enforce the port rules and is also responsible to reinject
+                            all traffic back and ensure it reaches its original destination.
+                          format: uint16
+                          type: integer
+                        rules:
+                          description: Rules is a list of additional port level rules
+                            which must be met in order for the PortRule to allow the
+                            traffic. If omitted or empty, no layer 7 rules are enforced.
+                          properties:
+                            http:
+                              description: HTTP specific rules.
+                              items:
+                                description: |-
+                                  PortRuleHTTP is a list of HTTP protocol constraints. All fields are optional, if all fields are empty or missing, the rule does not have any effect.
+
+                                  All fields of this type are extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows the egrep/unix syntax, not the perl syntax) matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986.
+                                properties:
+                                  headers:
+                                    description: Headers is a list of HTTP headers
+                                      which must be present in the request. If omitted
+                                      or empty, requests are allowed regardless of
+                                      headers present.
+                                    items:
+                                      type: string
+                                    type: array
+                                  host:
+                                    description: |-
+                                      Host is an extended POSIX regex matched against the host header of a request, e.g. "foo.com"
+
+                                      If omitted or empty, the value of the host header is ignored.
+                                    format: idn-hostname
+                                    type: string
+                                  method:
+                                    description: |-
+                                      Method is an extended POSIX regex matched against the method of a request, e.g. "GET", "POST", "PUT", "PATCH", "DELETE", ...
+
+                                      If omitted or empty, all methods are allowed.
+                                    type: string
+                                  path:
+                                    description: |-
+                                      Path is an extended POSIX regex matched against the path of a request. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986.
+
+                                      If omitted or empty, all paths are all allowed.
+                                    type: string
+                              type: array
+                            kafka:
+                              description: Kafka-specific rules.
+                              items:
+                                description: PortRuleKafka is a list of Kafka protocol
+                                  constraints. All fields are optional, if all fields
+                                  are empty or missing, the rule will match all Kafka
+                                  messages.
+                                properties:
+                                  apiKey:
+                                    description: |-
+                                      APIKey is a case-insensitive string matched against the key of a request, e.g. "produce", "fetch", "createtopic", "deletetopic", et al Reference: https://kafka.apache.org/protocol#protocol_api_keys
+
+                                      If omitted or empty, all keys are allowed.
+                                    type: string
+                                  apiVersion:
+                                    description: |-
+                                      APIVersion is the version matched against the api version of the Kafka message. If set, it has to be a string representing a positive integer.
+
+                                      If omitted or empty, all versions are allowed.
+                                    type: string
+                                  clientID:
+                                    description: |-
+                                      ClientID is the client identifier as provided in the request.
+
+                                      From Kafka protocol documentation: This is a user supplied identifier for the client application. The user can use any identifier they like and it will be used when logging errors, monitoring aggregates, etc. For example, one might want to monitor not just the requests per second overall, but the number coming from each client application (each of which could reside on multiple servers). This id acts as a logical grouping across all requests from a particular client.
+
+                                      If omitted or empty, all client identifiers are allowed.
+                                    type: string
+                                  role:
+                                    description: 'Role is a case-insensitive string
+                                      and describes a group of API keysnecessary to
+                                      perform certain higher level Kafka operations
+                                      such as"produce" or "consume". An APIGroup automatically
+                                      expands into all APIKeysrequired to perform
+                                      the specified higher level operation.The following
+                                      values are supported:- "produce": Allow producing
+                                      to the topics specified in the rule- "consume":
+                                      Allow consuming from the topics specified in
+                                      the ruleThis field is incompatible with the
+                                      APIKey field, either APIKey or Rolemay be specified.
+                                      If omitted or empty, the field has no effect
+                                      and the logic of the APIKey field applies.'
+                                    enum:
+                                    - produce
+                                    - consume
+                                    type: string
+                                  topic:
+                                    description: |-
+                                      Topic is the topic name contained in the message. If a Kafka request contains multiple topics, then all topics must be allowed or the message will be rejected.
+
+                                      This constraint is ignored if the matched request message type doesn't contain any topic. Maximum size of Topic can be 249 characters as per recent Kafka spec and allowed characters are a-z, A-Z, 0-9, -, . and _ Older Kafka versions had longer topic lengths of 255, but in Kafka 0.10 version the length was changed from 255 to 249. For compatibility reasons we are using 255
+
+                                      If omitted or empty, all topics are allowed.
+                                    maxLength: 255
+                                    type: string
+                              type: array
+                            l7:
+                              description: Generic Key-Value pair rules.
+                              items:
+                                description: PortRuleL7 is a map of {key,value} pairs
+                                  which is passed to the parser referenced in l7proto.
+                                  It is up to the parser to define what to do with
+                                  the map data. If omitted or empty, all requests
+                                  are allowed. Both keys and values must be strings.
+                              type: array
+                            l7proto:
+                              description: Parser type name that uses Key-Value pair
+                                rules.
+                              type: string
+                    type: array
+                  toRequires:
+                    description: |-
+                      ToRequires is a list of additional constraints which must be met in order for the selected endpoints to be able to reach other endpoints. These additional constraints do not by themselves grant access privileges and must always be accompanied with at least one matching FromEndpoints.
+
+                      Example: Any Endpoint with the label "team=A" requires any endpoint to which it communicates to also carry the label "team=A".
+                    items:
+                      description: EndpointSelector is a wrapper for k8s LabelSelector.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship
+                                  to a set of values. Valid operators are In, NotIn,
+                                  Exists and DoesNotExist.
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                description: values is an array of string values.
+                                  If the operator is In or NotIn, the values array
+                                  must be non-empty. If the operator is Exists or
+                                  DoesNotExist, the values array must be empty. This
+                                  array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                          type: array
+                        matchLabels:
+                          description: matchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.
+                          type: object
+                    type: array
+                  toServices:
+                    description: |-
+                      ToServices is a list of services to which the endpoint subject to the rule is allowed to initiate connections.
+
+                      Example: Any endpoint with the label "app=backend-app" is allowed to initiate connections to all cidrs backing the "external-service" service
+                    items:
+                      description: Service wraps around selectors for services
+                      properties:
+                        k8sService:
+                          description: K8sServiceNamespace is an abstraction for the
+                            k8s service + namespace types.
+                          properties:
+                            namespace:
+                              type: string
+                            serviceName:
+                              type: string
+                        k8sServiceSelector:
+                          description: K8sServiceSelector selects services by k8s
+                            labels. Not supported yet
+                          properties:
+                            namespace:
+                              type: string
+                            selector:
+                              description: A label selector is a label query over
+                                a set of resources. The result of matchLabels and
+                                matchExpressions are ANDed. An empty label selector
+                                matches all objects. A null label selector matches
+                                no objects.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        enum:
+                                        - In
+                                        - NotIn
+                                        - Exists
+                                        - DoesNotExist
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                  type: array
+                                matchLabels:
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                          required:
+                          - selector
+                    type: array
+              type: array
+            endpointSelector:
+              description: EndpointSelector selects all endpoints which should be
+                subject to this rule. Cannot be empty.
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        enum:
+                        - In
+                        - NotIn
+                        - Exists
+                        - DoesNotExist
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                  type: array
+                matchLabels:
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
+                  type: object
+            ingress:
+              description: Ingress is a list of IngressRule which are enforced at
+                ingress. If omitted or empty, this rule does not apply at ingress.
+              items:
+                description: |-
+                  IngressRule contains all rule types which can be applied at ingress, i.e. network traffic that originates outside of the endpoint and is entering the endpoint selected by the endpointSelector.
+
+                  - All members of this structure are optional. If omitted or empty, the
+                    member will have no effect on the rule.
+
+                  - If multiple members are set, all of them need to match in order for
+                    the rule to take effect. The exception to this rule is FromRequires field;
+                    the effects of any Requires field in any rule will apply to all other
+                    rules as well.
+
+                  - For now, combining ToPorts, FromCIDR, and FromEndpoints in the same rule
+                    is not supported and any such rules will be rejected. In the future, this
+                    will be supported and if multiple members of this structure are specified,
+                   then all members must match in order for the rule to take effect. The
+                    exception to this rule is the Requires field, the effects of any Requires
+                    field in any rule will apply to all other rules as well.
+                properties:
+                  fromCIDR:
+                    description: |-
+                      FromCIDR is a list of IP blocks which the endpoint subject to the rule is allowed to receive connections from. This will match on the source IP address of incoming connections. Adding  a prefix into FromCIDR or into FromCIDRSet with no ExcludeCIDRs is  equivalent. Overlaps are allowed between FromCIDR and FromCIDRSet.
+
+                      Example: Any endpoint with the label "app=my-legacy-pet" is allowed to receive connections from 10.3.9.1
+                    items:
+                      description: CIDR is a CIDR prefix / IP Block.
+                      oneOf:
+                      - pattern: ^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\/([0-9]|[1-2][0-9]|3[0-2])$
+                        type: string
+                      - pattern: ^s*((([0-9A-Fa-f]{1,4}:){7}(:|([0-9A-Fa-f]{1,4})))|(([0-9A-Fa-f]{1,4}:){6}:([0-9A-Fa-f]{1,4})?)|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){0,1}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){0,2}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){0,3}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){0,4}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){0,5}):([0-9A-Fa-f]{1,4})?))|(:(:|((:[0-9A-Fa-f]{1,4}){1,7}))))(%.+)?s*/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$
+                        type: string
+                      type: string
+                    type: array
+                  fromCIDRSet:
+                    description: |-
+                      FromCIDRSet is a list of IP blocks which the endpoint subject to the rule is allowed to receive connections from in addition to FromEndpoints, along with a list of subnets contained within their corresponding IP block from which traffic should not be allowed. This will match on the source IP address of incoming connections. Adding a prefix into FromCIDR or into FromCIDRSet with no ExcludeCIDRs is equivalent. Overlaps are allowed between FromCIDR and FromCIDRSet.
+
+                      Example: Any endpoint with the label "app=my-legacy-pet" is allowed to receive connections from 10.0.0.0/8 except from IPs in subnet 10.96.0.0/12.
+                    items:
+                      description: CIDRRule is a rule that specifies a CIDR prefix
+                        to/from which outside communication is allowed, along with
+                        an optional list of subnets within that CIDR prefix to/from
+                        which outside communication is not allowed.
+                      properties:
+                        cidr:
+                          description: CIDR is a CIDR prefix / IP Block.
+                          oneOf:
+                          - pattern: ^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\/([0-9]|[1-2][0-9]|3[0-2])$
+                            type: string
+                          - pattern: ^s*((([0-9A-Fa-f]{1,4}:){7}(:|([0-9A-Fa-f]{1,4})))|(([0-9A-Fa-f]{1,4}:){6}:([0-9A-Fa-f]{1,4})?)|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){0,1}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){0,2}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){0,3}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){0,4}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){0,5}):([0-9A-Fa-f]{1,4})?))|(:(:|((:[0-9A-Fa-f]{1,4}){1,7}))))(%.+)?s*/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$
+                            type: string
+                          type: string
+                        except:
+                          description: ExceptCIDRs is a list of IP blocks which the
+                            endpoint subject to the rule is not allowed to initiate
+                            connections to. These CIDR prefixes should be contained
+                            within Cidr. These exceptions are only applied to the
+                            Cidr in this CIDRRule, and do not apply to any other CIDR
+                            prefixes in any other CIDRRules.
+                          items:
+                            description: CIDR is a CIDR prefix / IP Block.
+                            oneOf:
+                            - pattern: ^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\/([0-9]|[1-2][0-9]|3[0-2])$
+                              type: string
+                            - pattern: ^s*((([0-9A-Fa-f]{1,4}:){7}(:|([0-9A-Fa-f]{1,4})))|(([0-9A-Fa-f]{1,4}:){6}:([0-9A-Fa-f]{1,4})?)|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){0,1}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){0,2}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){0,3}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){0,4}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){0,5}):([0-9A-Fa-f]{1,4})?))|(:(:|((:[0-9A-Fa-f]{1,4}){1,7}))))(%.+)?s*/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$
+                              type: string
+                            type: string
+                          type: array
+                      required:
+                      - cidr
+                    type: array
+                  fromEndpoints:
+                    description: |-
+                      FromEndpoints is a list of endpoints identified by an EndpointSelector which are allowed to communicate with the endpoint subject to the rule.
+
+                      Example: Any endpoint with the label "role=backend" can be consumed by any endpoint carrying the label "role=frontend".
+                    items:
+                      description: EndpointSelector is a wrapper for k8s LabelSelector.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship
+                                  to a set of values. Valid operators are In, NotIn,
+                                  Exists and DoesNotExist.
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                description: values is an array of string values.
+                                  If the operator is In or NotIn, the values array
+                                  must be non-empty. If the operator is Exists or
+                                  DoesNotExist, the values array must be empty. This
+                                  array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                          type: array
+                        matchLabels:
+                          description: matchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.
+                          type: object
+                    type: array
+                  fromEntities:
+                    description: FromEntities is a list of special entities which
+                      the endpoint subject to the rule is allowed to receive connections
+                      from. Supported entities are `world`, `cluster`, `host`, and
+                      `init`
+                    items:
+                      type: string
+                    type: array
+                  fromRequires:
+                    description: |-
+                      FromRequires is a list of additional constraints which must be met in order for the selected endpoints to be reachable. These additional constraints do no by itself grant access privileges and must always be accompanied with at least one matching FromEndpoints.
+
+                      Example: Any Endpoint with the label "team=A" requires consuming endpoint to also carry the label "team=A".
+                    items:
+                      description: EndpointSelector is a wrapper for k8s LabelSelector.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship
+                                  to a set of values. Valid operators are In, NotIn,
+                                  Exists and DoesNotExist.
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                description: values is an array of string values.
+                                  If the operator is In or NotIn, the values array
+                                  must be non-empty. If the operator is Exists or
+                                  DoesNotExist, the values array must be empty. This
+                                  array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                          type: array
+                        matchLabels:
+                          description: matchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.
+                          type: object
+                    type: array
+                  toPorts:
+                    description: |-
+                      ToPorts is a list of destination ports identified by port number and protocol which the endpoint subject to the rule is allowed to receive connections on.
+
+                      Example: Any endpoint with the label "app=httpd" can only accept incoming connections on port 80/tcp.
+                    items:
+                      description: PortRule is a list of ports/protocol combinations
+                        with optional Layer 7 rules which must be met.
+                      properties:
+                        ports:
+                          description: |-
+                            Ports is a list of L4 port/protocol
+
+                            If omitted or empty but RedirectPort is set, then all ports of the endpoint subject to either the ingress or egress rule are being redirected.
+                          items:
+                            description: PortProtocol specifies an L4 port with an
+                              optional transport protocol
+                            properties:
+                              port:
+                                description: Port is an L4 port number. For now the
+                                  string will be strictly parsed as a single uint16.
+                                  In the future, this field may support ranges in
+                                  the form "1024-2048
+                                pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})$
+                                type: string
+                              protocol:
+                                description: 'Protocol is the L4 protocol. If omitted
+                                  or empty, any protocol matches. Accepted values:
+                                  "TCP", "UDP", ""/"ANY"\n\nMatching on ICMP is not
+                                  supported.'
+                                enum:
+                                - TCP
+                                - UDP
+                                - ANY
+                                type: string
+                            required:
+                            - port
+                          type: array
+                        redirectPort:
+                          description: RedirectPort is the L4 port which, if set,
+                            all traffic matching the Ports is being redirected to.
+                            Whatever listener behind that port becomes responsible
+                            to enforce the port rules and is also responsible to reinject
+                            all traffic back and ensure it reaches its original destination.
+                          format: uint16
+                          type: integer
+                        rules:
+                          description: Rules is a list of additional port level rules
+                            which must be met in order for the PortRule to allow the
+                            traffic. If omitted or empty, no layer 7 rules are enforced.
+                          properties:
+                            http:
+                              description: HTTP specific rules.
+                              items:
+                                description: |-
+                                  PortRuleHTTP is a list of HTTP protocol constraints. All fields are optional, if all fields are empty or missing, the rule does not have any effect.
+
+                                  All fields of this type are extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows the egrep/unix syntax, not the perl syntax) matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986.
+                                properties:
+                                  headers:
+                                    description: Headers is a list of HTTP headers
+                                      which must be present in the request. If omitted
+                                      or empty, requests are allowed regardless of
+                                      headers present.
+                                    items:
+                                      type: string
+                                    type: array
+                                  host:
+                                    description: |-
+                                      Host is an extended POSIX regex matched against the host header of a request, e.g. "foo.com"
+
+                                      If omitted or empty, the value of the host header is ignored.
+                                    format: idn-hostname
+                                    type: string
+                                  method:
+                                    description: |-
+                                      Method is an extended POSIX regex matched against the method of a request, e.g. "GET", "POST", "PUT", "PATCH", "DELETE", ...
+
+                                      If omitted or empty, all methods are allowed.
+                                    type: string
+                                  path:
+                                    description: |-
+                                      Path is an extended POSIX regex matched against the path of a request. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986.
+
+                                      If omitted or empty, all paths are all allowed.
+                                    type: string
+                              type: array
+                            kafka:
+                              description: Kafka-specific rules.
+                              items:
+                                description: PortRuleKafka is a list of Kafka protocol
+                                  constraints. All fields are optional, if all fields
+                                  are empty or missing, the rule will match all Kafka
+                                  messages.
+                                properties:
+                                  apiKey:
+                                    description: |-
+                                      APIKey is a case-insensitive string matched against the key of a request, e.g. "produce", "fetch", "createtopic", "deletetopic", et al Reference: https://kafka.apache.org/protocol#protocol_api_keys
+
+                                      If omitted or empty, all keys are allowed.
+                                    type: string
+                                  apiVersion:
+                                    description: |-
+                                      APIVersion is the version matched against the api version of the Kafka message. If set, it has to be a string representing a positive integer.
+
+                                      If omitted or empty, all versions are allowed.
+                                    type: string
+                                  clientID:
+                                    description: |-
+                                      ClientID is the client identifier as provided in the request.
+
+                                      From Kafka protocol documentation: This is a user supplied identifier for the client application. The user can use any identifier they like and it will be used when logging errors, monitoring aggregates, etc. For example, one might want to monitor not just the requests per second overall, but the number coming from each client application (each of which could reside on multiple servers). This id acts as a logical grouping across all requests from a particular client.
+
+                                      If omitted or empty, all client identifiers are allowed.
+                                    type: string
+                                  role:
+                                    description: 'Role is a case-insensitive string
+                                      and describes a group of API keysnecessary to
+                                      perform certain higher level Kafka operations
+                                      such as"produce" or "consume". An APIGroup automatically
+                                      expands into all APIKeysrequired to perform
+                                      the specified higher level operation.The following
+                                      values are supported:- "produce": Allow producing
+                                      to the topics specified in the rule- "consume":
+                                      Allow consuming from the topics specified in
+                                      the ruleThis field is incompatible with the
+                                      APIKey field, either APIKey or Rolemay be specified.
+                                      If omitted or empty, the field has no effect
+                                      and the logic of the APIKey field applies.'
+                                    enum:
+                                    - produce
+                                    - consume
+                                    type: string
+                                  topic:
+                                    description: |-
+                                      Topic is the topic name contained in the message. If a Kafka request contains multiple topics, then all topics must be allowed or the message will be rejected.
+
+                                      This constraint is ignored if the matched request message type doesn't contain any topic. Maximum size of Topic can be 249 characters as per recent Kafka spec and allowed characters are a-z, A-Z, 0-9, -, . and _ Older Kafka versions had longer topic lengths of 255, but in Kafka 0.10 version the length was changed from 255 to 249. For compatibility reasons we are using 255
+
+                                      If omitted or empty, all topics are allowed.
+                                    maxLength: 255
+                                    type: string
+                              type: array
+                            l7:
+                              description: Generic Key-Value pair rules.
+                              items:
+                                description: PortRuleL7 is a map of {key,value} pairs
+                                  which is passed to the parser referenced in l7proto.
+                                  It is up to the parser to define what to do with
+                                  the map data. If omitted or empty, all requests
+                                  are allowed. Both keys and values must be strings.
+                              type: array
+                            l7proto:
+                              description: Parser type name that uses Key-Value pair
+                                rules.
+                              type: string
+                    type: array
+              type: array
+            labels:
+              description: Labels is a list of optional strings which can be used
+                to re-identify the rule or to store metadata. It is possible to lookup
+                or delete strings based on labels. Labels are not required to be unique,
+                multiple rules can have overlapping or identical labels.
+              items:
+                description: Label is the cilium's representation of a container label.
+                properties:
+                  key:
+                    type: string
+                  source:
+                    description: 'Source can be one of the values present in const.go
+                      (e.g.: LabelSourceContainer)'
+                    type: string
+                  value:
+                    type: string
+                required:
+                - key
+              type: array
+          required:
+          - endpointSelector
+        Service:
+          description: Service wraps around selectors for services
+          properties:
+            k8sService:
+              description: K8sServiceNamespace is an abstraction for the k8s service
+                + namespace types.
+              properties:
+                namespace:
+                  type: string
+                serviceName:
+                  type: string
+            k8sServiceSelector:
+              description: K8sServiceSelector selects services by k8s labels. Not
+                supported yet
+              properties:
+                namespace:
+                  type: string
+                selector:
+                  description: A label selector is a label query over a set of resources.
+                    The result of matchLabels and matchExpressions are ANDed. An empty
+                    label selector matches all objects. A null label selector matches
+                    no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            enum:
+                            - In
+                            - NotIn
+                            - Exists
+                            - DoesNotExist
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                      type: array
+                    matchLabels:
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+              required:
+              - selector
+        ServiceSelector:
+          description: ServiceSelector is a label selector for k8s services
+          properties:
+            namespace:
+              type: string
+            selector:
+              description: A label selector is a label query over a set of resources.
+                The result of matchLabels and matchExpressions are ANDed. An empty
+                label selector matches all objects. A null label selector matches
+                no objects.
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        enum:
+                        - In
+                        - NotIn
+                        - Exists
+                        - DoesNotExist
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                  type: array
+                matchLabels:
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
+                  type: object
+          required:
+          - selector
+        spec:
+          description: |-
+            Rule is a policy rule which must be applied to all endpoints which match the labels contained in the endpointSelector
+
+            Each rule is split into an ingress section which contains all rules applicable at ingress, and an egress section applicable at egress. For rule types such as `L4Rule` and `CIDR` which can be applied at both ingress and egress, both ingress and egress side have to either specifically allow the connection or one side has to be omitted.
+
+            Either ingress, egress, or both can be provided. If both ingress and egress are omitted, the rule has no effect.
+          properties:
+            Description:
+              description: Description is a free form string, it can be used by the
+                creator of the rule to store human readable explanation of the purpose
+                of this rule. Rules cannot be identified by comment.
+              type: string
+            egress:
+              description: Egress is a list of EgressRule which are enforced at egress.
+                If omitted or empty, this rule does not apply at egress.
+              items:
+                description: |-
+                  EgressRule contains all rule types which can be applied at egress, i.e. network traffic that originates inside the endpoint and exits the endpoint selected by the endpointSelector.
+
+                  - All members of this structure are optional. If omitted or empty, the
+                    member will have no effect on the rule.
+
+                  - For now, combining ToPorts and ToCIDR in the same rule is not supported
+                    and such rules will be rejected. In the future, this will be supported and
+                    if if multiple members of the structure are specified, then all members
+                    must match in order for the rule to take effect.
+                properties:
+                  toCIDR:
+                    description: |-
+                      ToCIDR is a list of IP blocks which the endpoint subject to the rule is allowed to initiate connections. This will match on the destination IP address of outgoing connections. Adding a prefix into ToCIDR or into ToCIDRSet with no ExcludeCIDRs is equivalent. Overlaps are allowed between ToCIDR and ToCIDRSet.
+
+                      Example: Any endpoint with the label "app=database-proxy" is allowed to initiate connections to 10.2.3.0/24
+                    items:
+                      description: CIDR is a CIDR prefix / IP Block.
+                      oneOf:
+                      - pattern: ^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\/([0-9]|[1-2][0-9]|3[0-2])$
+                        type: string
+                      - pattern: ^s*((([0-9A-Fa-f]{1,4}:){7}(:|([0-9A-Fa-f]{1,4})))|(([0-9A-Fa-f]{1,4}:){6}:([0-9A-Fa-f]{1,4})?)|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){0,1}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){0,2}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){0,3}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){0,4}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){0,5}):([0-9A-Fa-f]{1,4})?))|(:(:|((:[0-9A-Fa-f]{1,4}){1,7}))))(%.+)?s*/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$
+                        type: string
+                      type: string
+                    type: array
+                  toCIDRSet:
+                    description: |-
+                      ToCIDRSet is a list of IP blocks which the endpoint subject to the rule is allowed to initiate connections to in addition to connections which are allowed via FromEndpoints, along with a list of subnets contained within their corresponding IP block to which traffic should not be allowed. This will match on the destination IP address of outgoing connections. Adding a prefix into ToCIDR or into ToCIDRSet with no ExcludeCIDRs is equivalent. Overlaps are allowed between ToCIDR and ToCIDRSet.
+
+                      Example: Any endpoint with the label "app=database-proxy" is allowed to initiate connections to 10.2.3.0/24 except from IPs in subnet 10.2.3.0/28.
+                    items:
+                      description: CIDRRule is a rule that specifies a CIDR prefix
+                        to/from which outside communication is allowed, along with
+                        an optional list of subnets within that CIDR prefix to/from
+                        which outside communication is not allowed.
+                      properties:
+                        cidr:
+                          description: CIDR is a CIDR prefix / IP Block.
+                          oneOf:
+                          - pattern: ^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\/([0-9]|[1-2][0-9]|3[0-2])$
+                            type: string
+                          - pattern: ^s*((([0-9A-Fa-f]{1,4}:){7}(:|([0-9A-Fa-f]{1,4})))|(([0-9A-Fa-f]{1,4}:){6}:([0-9A-Fa-f]{1,4})?)|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){0,1}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){0,2}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){0,3}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){0,4}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){0,5}):([0-9A-Fa-f]{1,4})?))|(:(:|((:[0-9A-Fa-f]{1,4}){1,7}))))(%.+)?s*/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$
+                            type: string
+                          type: string
+                        except:
+                          description: ExceptCIDRs is a list of IP blocks which the
+                            endpoint subject to the rule is not allowed to initiate
+                            connections to. These CIDR prefixes should be contained
+                            within Cidr. These exceptions are only applied to the
+                            Cidr in this CIDRRule, and do not apply to any other CIDR
+                            prefixes in any other CIDRRules.
+                          items:
+                            description: CIDR is a CIDR prefix / IP Block.
+                            oneOf:
+                            - pattern: ^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\/([0-9]|[1-2][0-9]|3[0-2])$
+                              type: string
+                            - pattern: ^s*((([0-9A-Fa-f]{1,4}:){7}(:|([0-9A-Fa-f]{1,4})))|(([0-9A-Fa-f]{1,4}:){6}:([0-9A-Fa-f]{1,4})?)|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){0,1}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){0,2}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){0,3}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){0,4}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){0,5}):([0-9A-Fa-f]{1,4})?))|(:(:|((:[0-9A-Fa-f]{1,4}){1,7}))))(%.+)?s*/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$
+                              type: string
+                            type: string
+                          type: array
+                      required:
+                      - cidr
+                    type: array
+                  toEndpoints:
+                    description: |-
+                      ToEndpoints is a list of endpoints identified by an EndpointSelector to which the endpoint subject to the ruleis allowed to communicate.
+
+                      Example: Any endpoint with the label "role=frontend" can be consumed by any endpoint carrying the label "role=backend".
+                    items:
+                      description: A label selector is a label query over a set of
+                        resources. The result of matchLabels and matchExpressions
+                        are ANDed. An empty label selector matches all objects. A
+                        null label selector matches no objects.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship
+                                  to a set of values. Valid operators are In, NotIn,
+                                  Exists and DoesNotExist.
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                description: values is an array of string values.
+                                  If the operator is In or NotIn, the values array
+                                  must be non-empty. If the operator is Exists or
+                                  DoesNotExist, the values array must be empty. This
+                                  array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                          type: array
+                        matchLabels:
+                          description: matchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.
+                          type: object
+                    type: array
+                  toEntities:
+                    description: ToEntities is a list of special entities to which
+                      the endpoint subject to the rule is allowed to initiate connections.
+                      Supported entities are `world`, `cluster` and `host`
+                    items:
+                      type: string
+                    type: array
+                  toGroups:
+                    description: "ToGroups is a list of constraints that will\n\t\t\t\tgather
+                      data from third-party providers and create a new\n\t\t\t\tderived
+                      policy."
+                    properties:
+                      AWS:
+                        properties:
+                          Region:
+                            description: "Region is the key that will filter the AWS
+                              EC2\n\t\t\t\tinstances in the given region"
+                            type: string
+                          SecurityGroupsIds:
+                            description: "SecurityGroupsIds is the list of AWS security\n\t\t\t\tgroup
+                              IDs that will filter the instances IPs from the AWS
+                              API"
+                            type: array
+                          SecurityGroupsNames:
+                            description: "SecurityGroupsNames is the list of  AWS
+                              security\n\t\t\t\tgroup names that will filter the instances
+                              IPs from the AWS API"
+                            type: array
+                  toPorts:
+                    description: |-
+                      ToPorts is a list of destination ports identified by port number and protocol which the endpoint subject to the rule is allowed to connect to.
+
+                      Example: Any endpoint with the label "role=frontend" is allowed to initiate connections to destination port 8080/tcp
+                    items:
+                      description: PortRule is a list of ports/protocol combinations
+                        with optional Layer 7 rules which must be met.
+                      properties:
+                        ports:
+                          description: |-
+                            Ports is a list of L4 port/protocol
+
+                            If omitted or empty but RedirectPort is set, then all ports of the endpoint subject to either the ingress or egress rule are being redirected.
+                          items:
+                            description: PortProtocol specifies an L4 port with an
+                              optional transport protocol
+                            properties:
+                              port:
+                                description: Port is an L4 port number. For now the
+                                  string will be strictly parsed as a single uint16.
+                                  In the future, this field may support ranges in
+                                  the form "1024-2048
+                                pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})$
+                                type: string
+                              protocol:
+                                description: 'Protocol is the L4 protocol. If omitted
+                                  or empty, any protocol matches. Accepted values:
+                                  "TCP", "UDP", ""/"ANY"\n\nMatching on ICMP is not
+                                  supported.'
+                                enum:
+                                - TCP
+                                - UDP
+                                - ANY
+                                type: string
+                            required:
+                            - port
+                          type: array
+                        redirectPort:
+                          description: RedirectPort is the L4 port which, if set,
+                            all traffic matching the Ports is being redirected to.
+                            Whatever listener behind that port becomes responsible
+                            to enforce the port rules and is also responsible to reinject
+                            all traffic back and ensure it reaches its original destination.
+                          format: uint16
+                          type: integer
+                        rules:
+                          description: L7Rules is a union of port level rule types.
+                            Mixing of different port level rule types is disallowed,
+                            so exactly one of the following must be set. If none are
+                            specified, then no additional port level rules are applied.
+                          properties:
+                            http:
+                              description: HTTP specific rules.
+                              items:
+                                description: |-
+                                  PortRuleHTTP is a list of HTTP protocol constraints. All fields are optional, if all fields are empty or missing, the rule does not have any effect.
+
+                                  All fields of this type are extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows the egrep/unix syntax, not the perl syntax) matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986.
+                                properties:
+                                  headers:
+                                    description: Headers is a list of HTTP headers
+                                      which must be present in the request. If omitted
+                                      or empty, requests are allowed regardless of
+                                      headers present.
+                                    items:
+                                      type: string
+                                    type: array
+                                  host:
+                                    description: |-
+                                      Host is an extended POSIX regex matched against the host header of a request, e.g. "foo.com"
+
+                                      If omitted or empty, the value of the host header is ignored.
+                                    format: idn-hostname
+                                    type: string
+                                  method:
+                                    description: |-
+                                      Method is an extended POSIX regex matched against the method of a request, e.g. "GET", "POST", "PUT", "PATCH", "DELETE", ...
+
+                                      If omitted or empty, all methods are allowed.
+                                    type: string
+                                  path:
+                                    description: |-
+                                      Path is an extended POSIX regex matched against the path of a request. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986.
+
+                                      If omitted or empty, all paths are all allowed.
+                                    type: string
+                              type: array
+                            kafka:
+                              description: Kafka-specific rules.
+                              items:
+                                description: PortRuleKafka is a list of Kafka protocol
+                                  constraints. All fields are optional, if all fields
+                                  are empty or missing, the rule will match all Kafka
+                                  messages.
+                                properties:
+                                  apiKey:
+                                    description: |-
+                                      APIKey is a case-insensitive string matched against the key of a request, e.g. "produce", "fetch", "createtopic", "deletetopic", et al Reference: https://kafka.apache.org/protocol#protocol_api_keys
+
+                                      If omitted or empty, all keys are allowed.
+                                    type: string
+                                  apiVersion:
+                                    description: |-
+                                      APIVersion is the version matched against the api version of the Kafka message. If set, it has to be a string representing a positive integer.
+
+                                      If omitted or empty, all versions are allowed.
+                                    type: string
+                                  clientID:
+                                    description: |-
+                                      ClientID is the client identifier as provided in the request.
+
+                                      From Kafka protocol documentation: This is a user supplied identifier for the client application. The user can use any identifier they like and it will be used when logging errors, monitoring aggregates, etc. For example, one might want to monitor not just the requests per second overall, but the number coming from each client application (each of which could reside on multiple servers). This id acts as a logical grouping across all requests from a particular client.
+
+                                      If omitted or empty, all client identifiers are allowed.
+                                    type: string
+                                  role:
+                                    description: 'Role is a case-insensitive string
+                                      and describes a group of API keysnecessary to
+                                      perform certain higher level Kafka operations
+                                      such as"produce" or "consume". An APIGroup automatically
+                                      expands into all APIKeysrequired to perform
+                                      the specified higher level operation.The following
+                                      values are supported:- "produce": Allow producing
+                                      to the topics specified in the rule- "consume":
+                                      Allow consuming from the topics specified in
+                                      the ruleThis field is incompatible with the
+                                      APIKey field, either APIKey or Rolemay be specified.
+                                      If omitted or empty, the field has no effect
+                                      and the logic of the APIKey field applies.'
+                                    enum:
+                                    - produce
+                                    - consume
+                                    type: string
+                                  topic:
+                                    description: |-
+                                      Topic is the topic name contained in the message. If a Kafka request contains multiple topics, then all topics must be allowed or the message will be rejected.
+
+                                      This constraint is ignored if the matched request message type doesn't contain any topic. Maximum size of Topic can be 249 characters as per recent Kafka spec and allowed characters are a-z, A-Z, 0-9, -, . and _ Older Kafka versions had longer topic lengths of 255, but in Kafka 0.10 version the length was changed from 255 to 249. For compatibility reasons we are using 255
+
+                                      If omitted or empty, all topics are allowed.
+                                    maxLength: 255
+                                    type: string
+                              type: array
+                            l7:
+                              description: Generic Key-Value pair rules.
+                              items:
+                                description: PortRuleL7 is a map of {key,value} pairs
+                                  which is passed to the parser referenced in l7proto.
+                                  It is up to the parser to define what to do with
+                                  the map data. If omitted or empty, all requests
+                                  are allowed. Both keys and values must be strings.
+                              type: array
+                            l7proto:
+                              description: Parser type name that uses Key-Value pair
+                                rules.
+                              type: string
+                    type: array
+                  toRequires:
+                    description: |-
+                      ToRequires is a list of additional constraints which must be met in order for the selected endpoints to be able to reach other endpoints. These additional constraints do not by themselves grant access privileges and must always be accompanied with at least one matching FromEndpoints.
+
+                      Example: Any Endpoint with the label "team=A" requires any endpoint to which it communicates to also carry the label "team=A".
+                    items:
+                      description: A label selector is a label query over a set of
+                        resources. The result of matchLabels and matchExpressions
+                        are ANDed. An empty label selector matches all objects. A
+                        null label selector matches no objects.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship
+                                  to a set of values. Valid operators are In, NotIn,
+                                  Exists and DoesNotExist.
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                description: values is an array of string values.
+                                  If the operator is In or NotIn, the values array
+                                  must be non-empty. If the operator is Exists or
+                                  DoesNotExist, the values array must be empty. This
+                                  array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                          type: array
+                        matchLabels:
+                          description: matchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.
+                          type: object
+                    type: array
+                  toServices:
+                    description: |-
+                      ToServices is a list of services to which the endpoint subject to the rule is allowed to initiate connections.
+
+                      Example: Any endpoint with the label "app=backend-app" is allowed to initiate connections to all cidrs backing the "external-service" service
+                    items:
+                      description: Service wraps around selectors for services
+                      properties:
+                        k8sService:
+                          description: K8sServiceNamespace is an abstraction for the
+                            k8s service + namespace types.
+                          properties:
+                            namespace:
+                              type: string
+                            serviceName:
+                              type: string
+                        k8sServiceSelector:
+                          description: ServiceSelector is a label selector for k8s
+                            services
+                          properties:
+                            namespace:
+                              type: string
+                            selector:
+                              description: A label selector is a label query over
+                                a set of resources. The result of matchLabels and
+                                matchExpressions are ANDed. An empty label selector
+                                matches all objects. A null label selector matches
+                                no objects.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        enum:
+                                        - In
+                                        - NotIn
+                                        - Exists
+                                        - DoesNotExist
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                  type: array
+                                matchLabels:
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                          required:
+                          - selector
+                    type: array
+              type: array
+            endpointSelector:
+              description: A label selector is a label query over a set of resources.
+                The result of matchLabels and matchExpressions are ANDed. An empty
+                label selector matches all objects. A null label selector matches
+                no objects.
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        enum:
+                        - In
+                        - NotIn
+                        - Exists
+                        - DoesNotExist
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                  type: array
+                matchLabels:
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
+                  type: object
+            ingress:
+              description: Ingress is a list of IngressRule which are enforced at
+                ingress. If omitted or empty, this rule does not apply at ingress.
+              items:
+                description: |-
+                  IngressRule contains all rule types which can be applied at ingress, i.e. network traffic that originates outside of the endpoint and is entering the endpoint selected by the endpointSelector.
+
+                  - All members of this structure are optional. If omitted or empty, the
+                    member will have no effect on the rule.
+
+                  - If multiple members are set, all of them need to match in order for
+                    the rule to take effect. The exception to this rule is FromRequires field;
+                    the effects of any Requires field in any rule will apply to all other
+                    rules as well.
+
+                  - For now, combining ToPorts, FromCIDR, and FromEndpoints in the same rule
+                    is not supported and any such rules will be rejected. In the future, this
+                    will be supported and if multiple members of this structure are specified,
+                   then all members must match in order for the rule to take effect. The
+                    exception to this rule is the Requires field, the effects of any Requires
+                    field in any rule will apply to all other rules as well.
+                properties:
+                  fromCIDR:
+                    description: |-
+                      FromCIDR is a list of IP blocks which the endpoint subject to the rule is allowed to receive connections from. This will match on the source IP address of incoming connections. Adding  a prefix into FromCIDR or into FromCIDRSet with no ExcludeCIDRs is  equivalent. Overlaps are allowed between FromCIDR and FromCIDRSet.
+
+                      Example: Any endpoint with the label "app=my-legacy-pet" is allowed to receive connections from 10.3.9.1
+                    items:
+                      description: CIDR is a CIDR prefix / IP Block.
+                      oneOf:
+                      - pattern: ^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\/([0-9]|[1-2][0-9]|3[0-2])$
+                        type: string
+                      - pattern: ^s*((([0-9A-Fa-f]{1,4}:){7}(:|([0-9A-Fa-f]{1,4})))|(([0-9A-Fa-f]{1,4}:){6}:([0-9A-Fa-f]{1,4})?)|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){0,1}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){0,2}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){0,3}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){0,4}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){0,5}):([0-9A-Fa-f]{1,4})?))|(:(:|((:[0-9A-Fa-f]{1,4}){1,7}))))(%.+)?s*/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$
+                        type: string
+                      type: string
+                    type: array
+                  fromCIDRSet:
+                    description: |-
+                      FromCIDRSet is a list of IP blocks which the endpoint subject to the rule is allowed to receive connections from in addition to FromEndpoints, along with a list of subnets contained within their corresponding IP block from which traffic should not be allowed. This will match on the source IP address of incoming connections. Adding a prefix into FromCIDR or into FromCIDRSet with no ExcludeCIDRs is equivalent. Overlaps are allowed between FromCIDR and FromCIDRSet.
+
+                      Example: Any endpoint with the label "app=my-legacy-pet" is allowed to receive connections from 10.0.0.0/8 except from IPs in subnet 10.96.0.0/12.
+                    items:
+                      description: CIDRRule is a rule that specifies a CIDR prefix
+                        to/from which outside communication is allowed, along with
+                        an optional list of subnets within that CIDR prefix to/from
+                        which outside communication is not allowed.
+                      properties:
+                        cidr:
+                          description: CIDR is a CIDR prefix / IP Block.
+                          oneOf:
+                          - pattern: ^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\/([0-9]|[1-2][0-9]|3[0-2])$
+                            type: string
+                          - pattern: ^s*((([0-9A-Fa-f]{1,4}:){7}(:|([0-9A-Fa-f]{1,4})))|(([0-9A-Fa-f]{1,4}:){6}:([0-9A-Fa-f]{1,4})?)|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){0,1}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){0,2}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){0,3}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){0,4}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){0,5}):([0-9A-Fa-f]{1,4})?))|(:(:|((:[0-9A-Fa-f]{1,4}){1,7}))))(%.+)?s*/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$
+                            type: string
+                          type: string
+                        except:
+                          description: ExceptCIDRs is a list of IP blocks which the
+                            endpoint subject to the rule is not allowed to initiate
+                            connections to. These CIDR prefixes should be contained
+                            within Cidr. These exceptions are only applied to the
+                            Cidr in this CIDRRule, and do not apply to any other CIDR
+                            prefixes in any other CIDRRules.
+                          items:
+                            description: CIDR is a CIDR prefix / IP Block.
+                            oneOf:
+                            - pattern: ^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\/([0-9]|[1-2][0-9]|3[0-2])$
+                              type: string
+                            - pattern: ^s*((([0-9A-Fa-f]{1,4}:){7}(:|([0-9A-Fa-f]{1,4})))|(([0-9A-Fa-f]{1,4}:){6}:([0-9A-Fa-f]{1,4})?)|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){0,1}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){0,2}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){0,3}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){0,4}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){0,5}):([0-9A-Fa-f]{1,4})?))|(:(:|((:[0-9A-Fa-f]{1,4}){1,7}))))(%.+)?s*/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$
+                              type: string
+                            type: string
+                          type: array
+                      required:
+                      - cidr
+                    type: array
+                  fromEndpoints:
+                    description: |-
+                      FromEndpoints is a list of endpoints identified by an EndpointSelector which are allowed to communicate with the endpoint subject to the rule.
+
+                      Example: Any endpoint with the label "role=backend" can be consumed by any endpoint carrying the label "role=frontend".
+                    items:
+                      description: A label selector is a label query over a set of
+                        resources. The result of matchLabels and matchExpressions
+                        are ANDed. An empty label selector matches all objects. A
+                        null label selector matches no objects.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship
+                                  to a set of values. Valid operators are In, NotIn,
+                                  Exists and DoesNotExist.
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                description: values is an array of string values.
+                                  If the operator is In or NotIn, the values array
+                                  must be non-empty. If the operator is Exists or
+                                  DoesNotExist, the values array must be empty. This
+                                  array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                          type: array
+                        matchLabels:
+                          description: matchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.
+                          type: object
+                    type: array
+                  fromEntities:
+                    description: FromEntities is a list of special entities which
+                      the endpoint subject to the rule is allowed to receive connections
+                      from. Supported entities are `world`, `cluster`, `host`, and
+                      `init`
+                    items:
+                      type: string
+                    type: array
+                  fromRequires:
+                    description: |-
+                      FromRequires is a list of additional constraints which must be met in order for the selected endpoints to be reachable. These additional constraints do no by itself grant access privileges and must always be accompanied with at least one matching FromEndpoints.
+
+                      Example: Any Endpoint with the label "team=A" requires consuming endpoint to also carry the label "team=A".
+                    items:
+                      description: A label selector is a label query over a set of
+                        resources. The result of matchLabels and matchExpressions
+                        are ANDed. An empty label selector matches all objects. A
+                        null label selector matches no objects.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship
+                                  to a set of values. Valid operators are In, NotIn,
+                                  Exists and DoesNotExist.
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                description: values is an array of string values.
+                                  If the operator is In or NotIn, the values array
+                                  must be non-empty. If the operator is Exists or
+                                  DoesNotExist, the values array must be empty. This
+                                  array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                          type: array
+                        matchLabels:
+                          description: matchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.
+                          type: object
+                    type: array
+                  toPorts:
+                    description: |-
+                      ToPorts is a list of destination ports identified by port number and protocol which the endpoint subject to the rule is allowed to receive connections on.
+
+                      Example: Any endpoint with the label "app=httpd" can only accept incoming connections on port 80/tcp.
+                    items:
+                      description: PortRule is a list of ports/protocol combinations
+                        with optional Layer 7 rules which must be met.
+                      properties:
+                        ports:
+                          description: |-
+                            Ports is a list of L4 port/protocol
+
+                            If omitted or empty but RedirectPort is set, then all ports of the endpoint subject to either the ingress or egress rule are being redirected.
+                          items:
+                            description: PortProtocol specifies an L4 port with an
+                              optional transport protocol
+                            properties:
+                              port:
+                                description: Port is an L4 port number. For now the
+                                  string will be strictly parsed as a single uint16.
+                                  In the future, this field may support ranges in
+                                  the form "1024-2048
+                                pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})$
+                                type: string
+                              protocol:
+                                description: 'Protocol is the L4 protocol. If omitted
+                                  or empty, any protocol matches. Accepted values:
+                                  "TCP", "UDP", ""/"ANY"\n\nMatching on ICMP is not
+                                  supported.'
+                                enum:
+                                - TCP
+                                - UDP
+                                - ANY
+                                type: string
+                            required:
+                            - port
+                          type: array
+                        redirectPort:
+                          description: RedirectPort is the L4 port which, if set,
+                            all traffic matching the Ports is being redirected to.
+                            Whatever listener behind that port becomes responsible
+                            to enforce the port rules and is also responsible to reinject
+                            all traffic back and ensure it reaches its original destination.
+                          format: uint16
+                          type: integer
+                        rules:
+                          description: L7Rules is a union of port level rule types.
+                            Mixing of different port level rule types is disallowed,
+                            so exactly one of the following must be set. If none are
+                            specified, then no additional port level rules are applied.
+                          properties:
+                            http:
+                              description: HTTP specific rules.
+                              items:
+                                description: |-
+                                  PortRuleHTTP is a list of HTTP protocol constraints. All fields are optional, if all fields are empty or missing, the rule does not have any effect.
+
+                                  All fields of this type are extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows the egrep/unix syntax, not the perl syntax) matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986.
+                                properties:
+                                  headers:
+                                    description: Headers is a list of HTTP headers
+                                      which must be present in the request. If omitted
+                                      or empty, requests are allowed regardless of
+                                      headers present.
+                                    items:
+                                      type: string
+                                    type: array
+                                  host:
+                                    description: |-
+                                      Host is an extended POSIX regex matched against the host header of a request, e.g. "foo.com"
+
+                                      If omitted or empty, the value of the host header is ignored.
+                                    format: idn-hostname
+                                    type: string
+                                  method:
+                                    description: |-
+                                      Method is an extended POSIX regex matched against the method of a request, e.g. "GET", "POST", "PUT", "PATCH", "DELETE", ...
+
+                                      If omitted or empty, all methods are allowed.
+                                    type: string
+                                  path:
+                                    description: |-
+                                      Path is an extended POSIX regex matched against the path of a request. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986.
+
+                                      If omitted or empty, all paths are all allowed.
+                                    type: string
+                              type: array
+                            kafka:
+                              description: Kafka-specific rules.
+                              items:
+                                description: PortRuleKafka is a list of Kafka protocol
+                                  constraints. All fields are optional, if all fields
+                                  are empty or missing, the rule will match all Kafka
+                                  messages.
+                                properties:
+                                  apiKey:
+                                    description: |-
+                                      APIKey is a case-insensitive string matched against the key of a request, e.g. "produce", "fetch", "createtopic", "deletetopic", et al Reference: https://kafka.apache.org/protocol#protocol_api_keys
+
+                                      If omitted or empty, all keys are allowed.
+                                    type: string
+                                  apiVersion:
+                                    description: |-
+                                      APIVersion is the version matched against the api version of the Kafka message. If set, it has to be a string representing a positive integer.
+
+                                      If omitted or empty, all versions are allowed.
+                                    type: string
+                                  clientID:
+                                    description: |-
+                                      ClientID is the client identifier as provided in the request.
+
+                                      From Kafka protocol documentation: This is a user supplied identifier for the client application. The user can use any identifier they like and it will be used when logging errors, monitoring aggregates, etc. For example, one might want to monitor not just the requests per second overall, but the number coming from each client application (each of which could reside on multiple servers). This id acts as a logical grouping across all requests from a particular client.
+
+                                      If omitted or empty, all client identifiers are allowed.
+                                    type: string
+                                  role:
+                                    description: 'Role is a case-insensitive string
+                                      and describes a group of API keysnecessary to
+                                      perform certain higher level Kafka operations
+                                      such as"produce" or "consume". An APIGroup automatically
+                                      expands into all APIKeysrequired to perform
+                                      the specified higher level operation.The following
+                                      values are supported:- "produce": Allow producing
+                                      to the topics specified in the rule- "consume":
+                                      Allow consuming from the topics specified in
+                                      the ruleThis field is incompatible with the
+                                      APIKey field, either APIKey or Rolemay be specified.
+                                      If omitted or empty, the field has no effect
+                                      and the logic of the APIKey field applies.'
+                                    enum:
+                                    - produce
+                                    - consume
+                                    type: string
+                                  topic:
+                                    description: |-
+                                      Topic is the topic name contained in the message. If a Kafka request contains multiple topics, then all topics must be allowed or the message will be rejected.
+
+                                      This constraint is ignored if the matched request message type doesn't contain any topic. Maximum size of Topic can be 249 characters as per recent Kafka spec and allowed characters are a-z, A-Z, 0-9, -, . and _ Older Kafka versions had longer topic lengths of 255, but in Kafka 0.10 version the length was changed from 255 to 249. For compatibility reasons we are using 255
+
+                                      If omitted or empty, all topics are allowed.
+                                    maxLength: 255
+                                    type: string
+                              type: array
+                            l7:
+                              description: Generic Key-Value pair rules.
+                              items:
+                                description: PortRuleL7 is a map of {key,value} pairs
+                                  which is passed to the parser referenced in l7proto.
+                                  It is up to the parser to define what to do with
+                                  the map data. If omitted or empty, all requests
+                                  are allowed. Both keys and values must be strings.
+                              type: array
+                            l7proto:
+                              description: Parser type name that uses Key-Value pair
+                                rules.
+                              type: string
+                    type: array
+              type: array
+            labels:
+              description: Labels is a list of optional strings which can be used
+                to re-identify the rule or to store metadata. It is possible to lookup
+                or delete strings based on labels. Labels are not required to be unique,
+                multiple rules can have overlapping or identical labels.
+              items:
+                description: Label is the cilium's representation of a container label.
+                properties:
+                  key:
+                    type: string
+                  source:
+                    description: 'Source can be one of the values present in const.go
+                      (e.g.: LabelSourceContainer)'
+                    type: string
+                  value:
+                    type: string
+                required:
+                - key
+              type: array
+          required:
+          - endpointSelector
+        specs:
+          description: Specs is a list of desired Cilium specific rule specification.
+          items:
+            description: Spec is the desired Cilium specific rule specification.
+            properties:
+              Description:
+                description: Description is a free form string, it can be used by
+                  the creator of the rule to store human readable explanation of the
+                  purpose of this rule. Rules cannot be identified by comment.
+                type: string
+              egress:
+                description: Egress is a list of EgressRule which are enforced at
+                  egress. If omitted or empty, this rule does not apply at egress.
+                items:
+                  description: |-
+                    EgressRule contains all rule types which can be applied at egress, i.e. network traffic that originates inside the endpoint and exits the endpoint selected by the endpointSelector.
+
+                    - All members of this structure are optional. If omitted or empty, the
+                      member will have no effect on the rule.
+
+                    - For now, combining ToPorts and ToCIDR in the same rule is not supported
+                      and such rules will be rejected. In the future, this will be supported and
+                      if if multiple members of the structure are specified, then all members
+                      must match in order for the rule to take effect.
+                  properties:
+                    toCIDR:
+                      description: |-
+                        ToCIDR is a list of IP blocks which the endpoint subject to the rule is allowed to initiate connections. This will match on the destination IP address of outgoing connections. Adding a prefix into ToCIDR or into ToCIDRSet with no ExcludeCIDRs is equivalent. Overlaps are allowed between ToCIDR and ToCIDRSet.
+
+                        Example: Any endpoint with the label "app=database-proxy" is allowed to initiate connections to 10.2.3.0/24
+                      items:
+                        description: CIDR is a CIDR prefix / IP Block.
+                        oneOf:
+                        - pattern: ^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\/([0-9]|[1-2][0-9]|3[0-2])$
+                          type: string
+                        - pattern: ^s*((([0-9A-Fa-f]{1,4}:){7}(:|([0-9A-Fa-f]{1,4})))|(([0-9A-Fa-f]{1,4}:){6}:([0-9A-Fa-f]{1,4})?)|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){0,1}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){0,2}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){0,3}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){0,4}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){0,5}):([0-9A-Fa-f]{1,4})?))|(:(:|((:[0-9A-Fa-f]{1,4}){1,7}))))(%.+)?s*/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$
+                          type: string
+                        type: string
+                      type: array
+                    toCIDRSet:
+                      description: |-
+                        ToCIDRSet is a list of IP blocks which the endpoint subject to the rule is allowed to initiate connections to in addition to connections which are allowed via FromEndpoints, along with a list of subnets contained within their corresponding IP block to which traffic should not be allowed. This will match on the destination IP address of outgoing connections. Adding a prefix into ToCIDR or into ToCIDRSet with no ExcludeCIDRs is equivalent. Overlaps are allowed between ToCIDR and ToCIDRSet.
+
+                        Example: Any endpoint with the label "app=database-proxy" is allowed to initiate connections to 10.2.3.0/24 except from IPs in subnet 10.2.3.0/28.
+                      items:
+                        description: CIDRRule is a rule that specifies a CIDR prefix
+                          to/from which outside communication is allowed, along with
+                          an optional list of subnets within that CIDR prefix to/from
+                          which outside communication is not allowed.
+                        properties:
+                          cidr:
+                            description: CIDR is a CIDR prefix / IP Block.
+                            oneOf:
+                            - pattern: ^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\/([0-9]|[1-2][0-9]|3[0-2])$
+                              type: string
+                            - pattern: ^s*((([0-9A-Fa-f]{1,4}:){7}(:|([0-9A-Fa-f]{1,4})))|(([0-9A-Fa-f]{1,4}:){6}:([0-9A-Fa-f]{1,4})?)|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){0,1}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){0,2}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){0,3}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){0,4}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){0,5}):([0-9A-Fa-f]{1,4})?))|(:(:|((:[0-9A-Fa-f]{1,4}){1,7}))))(%.+)?s*/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$
+                              type: string
+                            type: string
+                          except:
+                            description: ExceptCIDRs is a list of IP blocks which
+                              the endpoint subject to the rule is not allowed to initiate
+                              connections to. These CIDR prefixes should be contained
+                              within Cidr. These exceptions are only applied to the
+                              Cidr in this CIDRRule, and do not apply to any other
+                              CIDR prefixes in any other CIDRRules.
+                            items:
+                              description: CIDR is a CIDR prefix / IP Block.
+                              oneOf:
+                              - pattern: ^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\/([0-9]|[1-2][0-9]|3[0-2])$
+                                type: string
+                              - pattern: ^s*((([0-9A-Fa-f]{1,4}:){7}(:|([0-9A-Fa-f]{1,4})))|(([0-9A-Fa-f]{1,4}:){6}:([0-9A-Fa-f]{1,4})?)|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){0,1}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){0,2}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){0,3}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){0,4}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){0,5}):([0-9A-Fa-f]{1,4})?))|(:(:|((:[0-9A-Fa-f]{1,4}){1,7}))))(%.+)?s*/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$
+                                type: string
+                              type: string
+                            type: array
+                        required:
+                        - cidr
+                      type: array
+                    toEndpoints:
+                      description: |-
+                        ToEndpoints is a list of endpoints identified by an EndpointSelector to which the endpoint subject to the ruleis allowed to communicate.
+
+                        Example: Any endpoint with the label "role=frontend" can be consumed by any endpoint carrying the label "role=backend".
+                      items:
+                        description: A label selector is a label query over a set
+                          of resources. The result of matchLabels and matchExpressions
+                          are ANDed. An empty label selector matches all objects.
+                          A null label selector matches no objects.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                            type: array
+                          matchLabels:
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                      type: array
+                    toEntities:
+                      description: ToEntities is a list of special entities to which
+                        the endpoint subject to the rule is allowed to initiate connections.
+                        Supported entities are `world`, `cluster` and `host`
+                      items:
+                        type: string
+                      type: array
+                    toGroups:
+                      description: "ToGroups is a list of constraints that will\n\t\t\t\tgather
+                        data from third-party providers and create a new\n\t\t\t\tderived
+                        policy."
+                      properties:
+                        AWS:
+                          properties:
+                            Region:
+                              description: "Region is the key that will filter the
+                                AWS EC2\n\t\t\t\tinstances in the given region"
+                              type: string
+                            SecurityGroupsIds:
+                              description: "SecurityGroupsIds is the list of AWS security\n\t\t\t\tgroup
+                                IDs that will filter the instances IPs from the AWS
+                                API"
+                              type: array
+                            SecurityGroupsNames:
+                              description: "SecurityGroupsNames is the list of  AWS
+                                security\n\t\t\t\tgroup names that will filter the
+                                instances IPs from the AWS API"
+                              type: array
+                    toPorts:
+                      description: |-
+                        ToPorts is a list of destination ports identified by port number and protocol which the endpoint subject to the rule is allowed to connect to.
+
+                        Example: Any endpoint with the label "role=frontend" is allowed to initiate connections to destination port 8080/tcp
+                      items:
+                        description: PortRule is a list of ports/protocol combinations
+                          with optional Layer 7 rules which must be met.
+                        properties:
+                          ports:
+                            description: |-
+                              Ports is a list of L4 port/protocol
+
+                              If omitted or empty but RedirectPort is set, then all ports of the endpoint subject to either the ingress or egress rule are being redirected.
+                            items:
+                              description: PortProtocol specifies an L4 port with
+                                an optional transport protocol
+                              properties:
+                                port:
+                                  description: Port is an L4 port number. For now
+                                    the string will be strictly parsed as a single
+                                    uint16. In the future, this field may support
+                                    ranges in the form "1024-2048
+                                  pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})$
+                                  type: string
+                                protocol:
+                                  description: 'Protocol is the L4 protocol. If omitted
+                                    or empty, any protocol matches. Accepted values:
+                                    "TCP", "UDP", ""/"ANY"\n\nMatching on ICMP is
+                                    not supported.'
+                                  enum:
+                                  - TCP
+                                  - UDP
+                                  - ANY
+                                  type: string
+                              required:
+                              - port
+                            type: array
+                          redirectPort:
+                            description: RedirectPort is the L4 port which, if set,
+                              all traffic matching the Ports is being redirected to.
+                              Whatever listener behind that port becomes responsible
+                              to enforce the port rules and is also responsible to
+                              reinject all traffic back and ensure it reaches its
+                              original destination.
+                            format: uint16
+                            type: integer
+                          rules:
+                            description: L7Rules is a union of port level rule types.
+                              Mixing of different port level rule types is disallowed,
+                              so exactly one of the following must be set. If none
+                              are specified, then no additional port level rules are
+                              applied.
+                            properties:
+                              http:
+                                description: HTTP specific rules.
+                                items:
+                                  description: |-
+                                    PortRuleHTTP is a list of HTTP protocol constraints. All fields are optional, if all fields are empty or missing, the rule does not have any effect.
+
+                                    All fields of this type are extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows the egrep/unix syntax, not the perl syntax) matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986.
+                                  properties:
+                                    headers:
+                                      description: Headers is a list of HTTP headers
+                                        which must be present in the request. If omitted
+                                        or empty, requests are allowed regardless
+                                        of headers present.
+                                      items:
+                                        type: string
+                                      type: array
+                                    host:
+                                      description: |-
+                                        Host is an extended POSIX regex matched against the host header of a request, e.g. "foo.com"
+
+                                        If omitted or empty, the value of the host header is ignored.
+                                      format: idn-hostname
+                                      type: string
+                                    method:
+                                      description: |-
+                                        Method is an extended POSIX regex matched against the method of a request, e.g. "GET", "POST", "PUT", "PATCH", "DELETE", ...
+
+                                        If omitted or empty, all methods are allowed.
+                                      type: string
+                                    path:
+                                      description: |-
+                                        Path is an extended POSIX regex matched against the path of a request. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986.
+
+                                        If omitted or empty, all paths are all allowed.
+                                      type: string
+                                type: array
+                              kafka:
+                                description: Kafka-specific rules.
+                                items:
+                                  description: PortRuleKafka is a list of Kafka protocol
+                                    constraints. All fields are optional, if all fields
+                                    are empty or missing, the rule will match all
+                                    Kafka messages.
+                                  properties:
+                                    apiKey:
+                                      description: |-
+                                        APIKey is a case-insensitive string matched against the key of a request, e.g. "produce", "fetch", "createtopic", "deletetopic", et al Reference: https://kafka.apache.org/protocol#protocol_api_keys
+
+                                        If omitted or empty, all keys are allowed.
+                                      type: string
+                                    apiVersion:
+                                      description: |-
+                                        APIVersion is the version matched against the api version of the Kafka message. If set, it has to be a string representing a positive integer.
+
+                                        If omitted or empty, all versions are allowed.
+                                      type: string
+                                    clientID:
+                                      description: |-
+                                        ClientID is the client identifier as provided in the request.
+
+                                        From Kafka protocol documentation: This is a user supplied identifier for the client application. The user can use any identifier they like and it will be used when logging errors, monitoring aggregates, etc. For example, one might want to monitor not just the requests per second overall, but the number coming from each client application (each of which could reside on multiple servers). This id acts as a logical grouping across all requests from a particular client.
+
+                                        If omitted or empty, all client identifiers are allowed.
+                                      type: string
+                                    role:
+                                      description: 'Role is a case-insensitive string
+                                        and describes a group of API keysnecessary
+                                        to perform certain higher level Kafka operations
+                                        such as"produce" or "consume". An APIGroup
+                                        automatically expands into all APIKeysrequired
+                                        to perform the specified higher level operation.The
+                                        following values are supported:- "produce":
+                                        Allow producing to the topics specified in
+                                        the rule- "consume": Allow consuming from
+                                        the topics specified in the ruleThis field
+                                        is incompatible with the APIKey field, either
+                                        APIKey or Rolemay be specified. If omitted
+                                        or empty, the field has no effect and the
+                                        logic of the APIKey field applies.'
+                                      enum:
+                                      - produce
+                                      - consume
+                                      type: string
+                                    topic:
+                                      description: |-
+                                        Topic is the topic name contained in the message. If a Kafka request contains multiple topics, then all topics must be allowed or the message will be rejected.
+
+                                        This constraint is ignored if the matched request message type doesn't contain any topic. Maximum size of Topic can be 249 characters as per recent Kafka spec and allowed characters are a-z, A-Z, 0-9, -, . and _ Older Kafka versions had longer topic lengths of 255, but in Kafka 0.10 version the length was changed from 255 to 249. For compatibility reasons we are using 255
+
+                                        If omitted or empty, all topics are allowed.
+                                      maxLength: 255
+                                      type: string
+                                type: array
+                              l7:
+                                description: Generic Key-Value pair rules.
+                                items:
+                                  description: PortRuleL7 is a map of {key,value}
+                                    pairs which is passed to the parser referenced
+                                    in l7proto. It is up to the parser to define what
+                                    to do with the map data. If omitted or empty,
+                                    all requests are allowed. Both keys and values
+                                    must be strings.
+                                type: array
+                              l7proto:
+                                description: Parser type name that uses Key-Value
+                                  pair rules.
+                                type: string
+                      type: array
+                    toRequires:
+                      description: |-
+                        ToRequires is a list of additional constraints which must be met in order for the selected endpoints to be able to reach other endpoints. These additional constraints do not by themselves grant access privileges and must always be accompanied with at least one matching FromEndpoints.
+
+                        Example: Any Endpoint with the label "team=A" requires any endpoint to which it communicates to also carry the label "team=A".
+                      items:
+                        description: A label selector is a label query over a set
+                          of resources. The result of matchLabels and matchExpressions
+                          are ANDed. An empty label selector matches all objects.
+                          A null label selector matches no objects.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                            type: array
+                          matchLabels:
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                      type: array
+                    toServices:
+                      description: |-
+                        ToServices is a list of services to which the endpoint subject to the rule is allowed to initiate connections.
+
+                        Example: Any endpoint with the label "app=backend-app" is allowed to initiate connections to all cidrs backing the "external-service" service
+                      items:
+                        description: Service wraps around selectors for services
+                        properties:
+                          k8sService:
+                            description: K8sServiceNamespace is an abstraction for
+                              the k8s service + namespace types.
+                            properties:
+                              namespace:
+                                type: string
+                              serviceName:
+                                type: string
+                          k8sServiceSelector:
+                            description: ServiceSelector is a label selector for k8s
+                              services
+                            properties:
+                              namespace:
+                                type: string
+                              selector:
+                                description: A label selector is a label query over
+                                  a set of resources. The result of matchLabels and
+                                  matchExpressions are ANDed. An empty label selector
+                                  matches all objects. A null label selector matches
+                                  no objects.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                    type: array
+                                  matchLabels:
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                            required:
+                            - selector
+                      type: array
+                type: array
+              endpointSelector:
+                description: A label selector is a label query over a set of resources.
+                  The result of matchLabels and matchExpressions are ANDed. An empty
+                  label selector matches all objects. A null label selector matches
+                  no objects.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                    type: array
+                  matchLabels:
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+              ingress:
+                description: Ingress is a list of IngressRule which are enforced at
+                  ingress. If omitted or empty, this rule does not apply at ingress.
+                items:
+                  description: |-
+                    IngressRule contains all rule types which can be applied at ingress, i.e. network traffic that originates outside of the endpoint and is entering the endpoint selected by the endpointSelector.
+
+                    - All members of this structure are optional. If omitted or empty, the
+                      member will have no effect on the rule.
+
+                    - If multiple members are set, all of them need to match in order for
+                      the rule to take effect. The exception to this rule is FromRequires field;
+                      the effects of any Requires field in any rule will apply to all other
+                      rules as well.
+
+                    - For now, combining ToPorts, FromCIDR, and FromEndpoints in the same rule
+                      is not supported and any such rules will be rejected. In the future, this
+                      will be supported and if multiple members of this structure are specified,
+                     then all members must match in order for the rule to take effect. The
+                      exception to this rule is the Requires field, the effects of any Requires
+                      field in any rule will apply to all other rules as well.
+                  properties:
+                    fromCIDR:
+                      description: |-
+                        FromCIDR is a list of IP blocks which the endpoint subject to the rule is allowed to receive connections from. This will match on the source IP address of incoming connections. Adding  a prefix into FromCIDR or into FromCIDRSet with no ExcludeCIDRs is  equivalent. Overlaps are allowed between FromCIDR and FromCIDRSet.
+
+                        Example: Any endpoint with the label "app=my-legacy-pet" is allowed to receive connections from 10.3.9.1
+                      items:
+                        description: CIDR is a CIDR prefix / IP Block.
+                        oneOf:
+                        - pattern: ^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\/([0-9]|[1-2][0-9]|3[0-2])$
+                          type: string
+                        - pattern: ^s*((([0-9A-Fa-f]{1,4}:){7}(:|([0-9A-Fa-f]{1,4})))|(([0-9A-Fa-f]{1,4}:){6}:([0-9A-Fa-f]{1,4})?)|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){0,1}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){0,2}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){0,3}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){0,4}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){0,5}):([0-9A-Fa-f]{1,4})?))|(:(:|((:[0-9A-Fa-f]{1,4}){1,7}))))(%.+)?s*/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$
+                          type: string
+                        type: string
+                      type: array
+                    fromCIDRSet:
+                      description: |-
+                        FromCIDRSet is a list of IP blocks which the endpoint subject to the rule is allowed to receive connections from in addition to FromEndpoints, along with a list of subnets contained within their corresponding IP block from which traffic should not be allowed. This will match on the source IP address of incoming connections. Adding a prefix into FromCIDR or into FromCIDRSet with no ExcludeCIDRs is equivalent. Overlaps are allowed between FromCIDR and FromCIDRSet.
+
+                        Example: Any endpoint with the label "app=my-legacy-pet" is allowed to receive connections from 10.0.0.0/8 except from IPs in subnet 10.96.0.0/12.
+                      items:
+                        description: CIDRRule is a rule that specifies a CIDR prefix
+                          to/from which outside communication is allowed, along with
+                          an optional list of subnets within that CIDR prefix to/from
+                          which outside communication is not allowed.
+                        properties:
+                          cidr:
+                            description: CIDR is a CIDR prefix / IP Block.
+                            oneOf:
+                            - pattern: ^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\/([0-9]|[1-2][0-9]|3[0-2])$
+                              type: string
+                            - pattern: ^s*((([0-9A-Fa-f]{1,4}:){7}(:|([0-9A-Fa-f]{1,4})))|(([0-9A-Fa-f]{1,4}:){6}:([0-9A-Fa-f]{1,4})?)|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){0,1}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){0,2}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){0,3}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){0,4}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){0,5}):([0-9A-Fa-f]{1,4})?))|(:(:|((:[0-9A-Fa-f]{1,4}){1,7}))))(%.+)?s*/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$
+                              type: string
+                            type: string
+                          except:
+                            description: ExceptCIDRs is a list of IP blocks which
+                              the endpoint subject to the rule is not allowed to initiate
+                              connections to. These CIDR prefixes should be contained
+                              within Cidr. These exceptions are only applied to the
+                              Cidr in this CIDRRule, and do not apply to any other
+                              CIDR prefixes in any other CIDRRules.
+                            items:
+                              description: CIDR is a CIDR prefix / IP Block.
+                              oneOf:
+                              - pattern: ^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\/([0-9]|[1-2][0-9]|3[0-2])$
+                                type: string
+                              - pattern: ^s*((([0-9A-Fa-f]{1,4}:){7}(:|([0-9A-Fa-f]{1,4})))|(([0-9A-Fa-f]{1,4}:){6}:([0-9A-Fa-f]{1,4})?)|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){0,1}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){0,2}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){0,3}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){0,4}):([0-9A-Fa-f]{1,4})?))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){0,5}):([0-9A-Fa-f]{1,4})?))|(:(:|((:[0-9A-Fa-f]{1,4}){1,7}))))(%.+)?s*/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$
+                                type: string
+                              type: string
+                            type: array
+                        required:
+                        - cidr
+                      type: array
+                    fromEndpoints:
+                      description: |-
+                        FromEndpoints is a list of endpoints identified by an EndpointSelector which are allowed to communicate with the endpoint subject to the rule.
+
+                        Example: Any endpoint with the label "role=backend" can be consumed by any endpoint carrying the label "role=frontend".
+                      items:
+                        description: A label selector is a label query over a set
+                          of resources. The result of matchLabels and matchExpressions
+                          are ANDed. An empty label selector matches all objects.
+                          A null label selector matches no objects.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                            type: array
+                          matchLabels:
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                      type: array
+                    fromEntities:
+                      description: FromEntities is a list of special entities which
+                        the endpoint subject to the rule is allowed to receive connections
+                        from. Supported entities are `world`, `cluster`, `host`, and
+                        `init`
+                      items:
+                        type: string
+                      type: array
+                    fromRequires:
+                      description: |-
+                        FromRequires is a list of additional constraints which must be met in order for the selected endpoints to be reachable. These additional constraints do no by itself grant access privileges and must always be accompanied with at least one matching FromEndpoints.
+
+                        Example: Any Endpoint with the label "team=A" requires consuming endpoint to also carry the label "team=A".
+                      items:
+                        description: A label selector is a label query over a set
+                          of resources. The result of matchLabels and matchExpressions
+                          are ANDed. An empty label selector matches all objects.
+                          A null label selector matches no objects.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                            type: array
+                          matchLabels:
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                      type: array
+                    toPorts:
+                      description: |-
+                        ToPorts is a list of destination ports identified by port number and protocol which the endpoint subject to the rule is allowed to receive connections on.
+
+                        Example: Any endpoint with the label "app=httpd" can only accept incoming connections on port 80/tcp.
+                      items:
+                        description: PortRule is a list of ports/protocol combinations
+                          with optional Layer 7 rules which must be met.
+                        properties:
+                          ports:
+                            description: |-
+                              Ports is a list of L4 port/protocol
+
+                              If omitted or empty but RedirectPort is set, then all ports of the endpoint subject to either the ingress or egress rule are being redirected.
+                            items:
+                              description: PortProtocol specifies an L4 port with
+                                an optional transport protocol
+                              properties:
+                                port:
+                                  description: Port is an L4 port number. For now
+                                    the string will be strictly parsed as a single
+                                    uint16. In the future, this field may support
+                                    ranges in the form "1024-2048
+                                  pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})$
+                                  type: string
+                                protocol:
+                                  description: 'Protocol is the L4 protocol. If omitted
+                                    or empty, any protocol matches. Accepted values:
+                                    "TCP", "UDP", ""/"ANY"\n\nMatching on ICMP is
+                                    not supported.'
+                                  enum:
+                                  - TCP
+                                  - UDP
+                                  - ANY
+                                  type: string
+                              required:
+                              - port
+                            type: array
+                          redirectPort:
+                            description: RedirectPort is the L4 port which, if set,
+                              all traffic matching the Ports is being redirected to.
+                              Whatever listener behind that port becomes responsible
+                              to enforce the port rules and is also responsible to
+                              reinject all traffic back and ensure it reaches its
+                              original destination.
+                            format: uint16
+                            type: integer
+                          rules:
+                            description: L7Rules is a union of port level rule types.
+                              Mixing of different port level rule types is disallowed,
+                              so exactly one of the following must be set. If none
+                              are specified, then no additional port level rules are
+                              applied.
+                            properties:
+                              http:
+                                description: HTTP specific rules.
+                                items:
+                                  description: |-
+                                    PortRuleHTTP is a list of HTTP protocol constraints. All fields are optional, if all fields are empty or missing, the rule does not have any effect.
+
+                                    All fields of this type are extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows the egrep/unix syntax, not the perl syntax) matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986.
+                                  properties:
+                                    headers:
+                                      description: Headers is a list of HTTP headers
+                                        which must be present in the request. If omitted
+                                        or empty, requests are allowed regardless
+                                        of headers present.
+                                      items:
+                                        type: string
+                                      type: array
+                                    host:
+                                      description: |-
+                                        Host is an extended POSIX regex matched against the host header of a request, e.g. "foo.com"
+
+                                        If omitted or empty, the value of the host header is ignored.
+                                      format: idn-hostname
+                                      type: string
+                                    method:
+                                      description: |-
+                                        Method is an extended POSIX regex matched against the method of a request, e.g. "GET", "POST", "PUT", "PATCH", "DELETE", ...
+
+                                        If omitted or empty, all methods are allowed.
+                                      type: string
+                                    path:
+                                      description: |-
+                                        Path is an extended POSIX regex matched against the path of a request. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986.
+
+                                        If omitted or empty, all paths are all allowed.
+                                      type: string
+                                type: array
+                              kafka:
+                                description: Kafka-specific rules.
+                                items:
+                                  description: PortRuleKafka is a list of Kafka protocol
+                                    constraints. All fields are optional, if all fields
+                                    are empty or missing, the rule will match all
+                                    Kafka messages.
+                                  properties:
+                                    apiKey:
+                                      description: |-
+                                        APIKey is a case-insensitive string matched against the key of a request, e.g. "produce", "fetch", "createtopic", "deletetopic", et al Reference: https://kafka.apache.org/protocol#protocol_api_keys
+
+                                        If omitted or empty, all keys are allowed.
+                                      type: string
+                                    apiVersion:
+                                      description: |-
+                                        APIVersion is the version matched against the api version of the Kafka message. If set, it has to be a string representing a positive integer.
+
+                                        If omitted or empty, all versions are allowed.
+                                      type: string
+                                    clientID:
+                                      description: |-
+                                        ClientID is the client identifier as provided in the request.
+
+                                        From Kafka protocol documentation: This is a user supplied identifier for the client application. The user can use any identifier they like and it will be used when logging errors, monitoring aggregates, etc. For example, one might want to monitor not just the requests per second overall, but the number coming from each client application (each of which could reside on multiple servers). This id acts as a logical grouping across all requests from a particular client.
+
+                                        If omitted or empty, all client identifiers are allowed.
+                                      type: string
+                                    role:
+                                      description: 'Role is a case-insensitive string
+                                        and describes a group of API keysnecessary
+                                        to perform certain higher level Kafka operations
+                                        such as"produce" or "consume". An APIGroup
+                                        automatically expands into all APIKeysrequired
+                                        to perform the specified higher level operation.The
+                                        following values are supported:- "produce":
+                                        Allow producing to the topics specified in
+                                        the rule- "consume": Allow consuming from
+                                        the topics specified in the ruleThis field
+                                        is incompatible with the APIKey field, either
+                                        APIKey or Rolemay be specified. If omitted
+                                        or empty, the field has no effect and the
+                                        logic of the APIKey field applies.'
+                                      enum:
+                                      - produce
+                                      - consume
+                                      type: string
+                                    topic:
+                                      description: |-
+                                        Topic is the topic name contained in the message. If a Kafka request contains multiple topics, then all topics must be allowed or the message will be rejected.
+
+                                        This constraint is ignored if the matched request message type doesn't contain any topic. Maximum size of Topic can be 249 characters as per recent Kafka spec and allowed characters are a-z, A-Z, 0-9, -, . and _ Older Kafka versions had longer topic lengths of 255, but in Kafka 0.10 version the length was changed from 255 to 249. For compatibility reasons we are using 255
+
+                                        If omitted or empty, all topics are allowed.
+                                      maxLength: 255
+                                      type: string
+                                type: array
+                              l7:
+                                description: Generic Key-Value pair rules.
+                                items:
+                                  description: PortRuleL7 is a map of {key,value}
+                                    pairs which is passed to the parser referenced
+                                    in l7proto. It is up to the parser to define what
+                                    to do with the map data. If omitted or empty,
+                                    all requests are allowed. Both keys and values
+                                    must be strings.
+                                type: array
+                              l7proto:
+                                description: Parser type name that uses Key-Value
+                                  pair rules.
+                                type: string
+                      type: array
+                type: array
+              labels:
+                description: Labels is a list of optional strings which can be used
+                  to re-identify the rule or to store metadata. It is possible to
+                  lookup or delete strings based on labels. Labels are not required
+                  to be unique, multiple rules can have overlapping or identical labels.
+                items:
+                  description: Label is the cilium's representation of a container
+                    label.
+                  properties:
+                    key:
+                      type: string
+                    source:
+                      description: 'Source can be one of the values present in const.go
+                        (e.g.: LabelSourceContainer)'
+                      type: string
+                    value:
+                      type: string
+                  required:
+                  - key
+                type: array
+            required:
+            - endpointSelector
+            type: object
+          type: array
+  version: v2
+  versions:
+  - name: v2
+    served: true
+    storage: true
+

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -463,6 +463,10 @@ const (
 	// ForceLocalPolicyEvalAtSource forces a policy decision at the source
 	// endpoint for all local communication
 	ForceLocalPolicyEvalAtSource = "force-local-policy-eval-at-source"
+
+	// SkipCRDCreation specifies whether the CustomResourceDefinition will be
+	// created by the daemon
+	SkipCRDCreation = "skip-crd-creation"
 )
 
 // FQDNS variables
@@ -930,6 +934,10 @@ type DaemonConfig struct {
 	// ForceLocalPolicyEvalAtSource forces a policy decision at the source
 	// endpoint for all local communication
 	ForceLocalPolicyEvalAtSource bool
+
+	// SkipCRDCreation disables creation of the CustomResourceDefinition
+	// on daemon startup
+	SkipCRDCreation bool
 }
 
 var (
@@ -1316,6 +1324,7 @@ func (c *DaemonConfig) Populate() {
 	c.PolicyQueueSize = sanitizeIntParam(PolicyQueueSize, defaults.PolicyQueueSize)
 	c.EndpointQueueSize = sanitizeIntParam(EndpointQueueSize, defaults.EndpointQueueSize)
 	c.SelectiveRegeneration = viper.GetBool(SelectiveRegeneration)
+	c.SkipCRDCreation = viper.GetBool(SkipCRDCreation)
 }
 
 func sanitizeIntParam(paramName string, paramDefault int) int {


### PR DESCRIPTION
We've added a new option called `--skip-crd-creation` that skips automatic CRD creation and let users create it themselves.
We've also added an example of such a creation to help them make it.

Fixes: #7434

Signed-off-by: Pierre-Yves AILLET <pyaillet@gmail.com>
Signed-off-by: Charles-Henri GUERIN <charleshenri.guerin@icloud.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7989)
<!-- Reviewable:end -->
