### PR TITLE
maps: Remove disabled svc v2 maps

### DIFF
--- a/pkg/datapath/maps/map.go
+++ b/pkg/datapath/maps/map.go
@@ -169,6 +169,9 @@ func RemoveDisabledMaps() {
 			"cilium_lb6_reverse_nat",
 			"cilium_lb6_rr_seq",
 			"cilium_lb6_services",
+			"cilium_lb6_services_v2",
+			"cilium_lb6_rr_seq_v2",
+			"cilium_lb6_backends",
 			"cilium_snat_v6_external",
 			"cilium_proxy6"}...)
 	}
@@ -180,6 +183,9 @@ func RemoveDisabledMaps() {
 			"cilium_lb4_reverse_nat",
 			"cilium_lb4_rr_seq",
 			"cilium_lb4_services",
+			"cilium_lb4_services_v2",
+			"cilium_lb4_rr_seq_v2",
+			"cilium_lb4_backends",
 			"cilium_snat_v4_external",
 			"cilium_proxy4"}...)
 	}


### PR DESCRIPTION
Previously, the svc v2 related maps were not removed when ipv4 or ipv6 services were disabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7990)
<!-- Reviewable:end -->
