### PR TITLE
daemon: Improve service restoration

### DIFF
--- a/daemon/loadbalancer.go
+++ b/daemon/loadbalancer.go
@@ -905,6 +905,7 @@ func restoreServices() {
 		if err := lbmap.RestoreService(svc, v2Exists); err != nil {
 			scopedLog.WithError(err).Warning("Unable to restore service in cache")
 			failed++
+			continue
 		}
 
 		if !option.Config.EnableLegacyServices {

--- a/daemon/loadbalancer.go
+++ b/daemon/loadbalancer.go
@@ -903,7 +903,8 @@ func restoreServices() {
 		// Restore the service cache to guarantee backend ordering
 		// across restarts
 		if err := lbmap.RestoreService(svc, v2Exists); err != nil {
-			log.WithError(err).Warning("Unable to restore service in cache")
+			scopedLog.WithError(err).Warning("Unable to restore service in cache")
+			failed++
 		}
 
 		if !option.Config.EnableLegacyServices {
@@ -915,7 +916,7 @@ func restoreServices() {
 			fe, besValues, err := lbmap.LBSVC2ServiceKeynValue(svc)
 			if err != nil {
 				failed++
-				log.WithField(logfields.ServiceID, svc.FE.ID).WithError(err).
+				scopedLog.WithField(logfields.ServiceID, svc.FE.ID).WithError(err).
 					WithError(err).Warning("Unable to convert service key and values v2")
 				continue
 			}
@@ -926,7 +927,7 @@ func restoreServices() {
 				service.AcquireBackendID, service.DeleteBackendID)
 			if err != nil {
 				failed++
-				log.WithField(logfields.ServiceID, svc.FE.ID).WithError(err).
+				scopedLog.WithField(logfields.ServiceID, svc.FE.ID).WithError(err).
 					Warning("Unable to restore service v2")
 			}
 		}


### PR DESCRIPTION
This PR:

- Improves logging of service restoration in the case of failures.
- Prevents from restoring a service if the service cache population fails for it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7996)
<!-- Reviewable:end -->
