### PR TITLE
ctmap: Introduce variable conntrack gc interval

### DIFF
--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -303,17 +303,22 @@ Upgrading from >=1.4.0 to 1.5.y
 New Default Values
 ~~~~~~~~~~~~~~~~~~
 
- * The connection-tracking garbage collector intervals is now 12 hours when
-   using LRU maps (newer kernels) and 15 minutes an all older kernels. The
-   interval can be overwritten with the option ``--conntrack-gc-interval``.
-   If connectivity between pods is faulty and ``cilium monitor --type drop``
-   shows ``xx drop (CT: Map insertion failed)`` it is recommended to set
-   ``--conntrack-gc-interval`` to an interval lower than the default.
-   Alternatively, the value for ``bpf-ct-global-any-max`` and
-   ``bpf-ct-global-tcp-max`` should be increased. Setting both of these options
-   will be a trade-off of CPU for ``conntrack-gc-interval``, and for
-   ``bpf-ct-global-any-max`` and ``bpf-ct-global-tcp-max`` the amount of memory
-   consumed.
+ * The connection-tracking garbage collector interval is now dynamic. It will
+   automatically  adjust based n on the percentage of the connection tracking
+   table that has been cleared in the last run. The interval will vary between
+   10 seconds and 30 minutes or 12 hours for LRU based maps. This should
+   automatically optimize CPU consumption as much as possible while keeping the
+   connection tracking table utilization below 25%. If needed, the interval can
+   be set to a static interval with the option ``--conntrack-gc-interval``. If
+   connectivity fails and ``cilium monitor --type drop`` shows ``xx drop (CT:
+   Map insertion failed)``, then it is likely that the connection tracking
+   table is filling up and the automatic adjustment of the garbage collector
+   interval is insufficient. Set ``--conntrack-gc-interval`` to an interval
+   lower than the default.  Alternatively, the value for
+   ``bpf-ct-global-any-max`` and ``bpf-ct-global-tcp-max`` can be increased.
+   Setting both of these options will be a trade-off of CPU for
+   ``conntrack-gc-interval``, and for ``bpf-ct-global-any-max`` and
+   ``bpf-ct-global-tcp-max`` the amount of memory consumed.
 
 .. _1.5_new_options:
 

--- a/Documentation/troubleshooting.rst
+++ b/Documentation/troubleshooting.rst
@@ -200,12 +200,16 @@ examples if running with Kubernetes):
 The above indicates that a packet to endpoint ID ``25729`` has been dropped due
 to violation of the Layer 3 policy.
 
-If connectivity between pods is faulty and ``cilium monitor --type drop``
-shows ``xx drop (CT: Map insertion failed)`` it is recommended to set
-``--conntrack-gc-interval`` to an interval lower than the default.
-Alternatively, the value for ``bpf-ct-global-any-max`` and
-``bpf-ct-global-tcp-max`` should be increased. Setting both of these options
-will be a trade-off of CPU for ``conntrack-gc-interval``, and for
+Handling drop (CT: Map insertion failed)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If connectivity fails and ``cilium monitor --type drop`` shows ``xx drop (CT:
+Map insertion failed)``, then it is likely that the connection tracking table
+is filling up and the automatic adjustment of the garbage collector interval is
+insufficient. Set ``--conntrack-gc-interval`` to an interval lower than the
+default.  Alternatively, the value for ``bpf-ct-global-any-max`` and
+``bpf-ct-global-tcp-max`` can be increased. Setting both of these options will
+be a trade-off of CPU for ``conntrack-gc-interval``, and for
 ``bpf-ct-global-any-max`` and ``bpf-ct-global-tcp-max`` the amount of memory
 consumed.
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -182,13 +182,18 @@ const (
 	// should watch for.
 	K8sWatcherEndpointSelector = "metadata.name!=kube-scheduler,metadata.name!=kube-controller-manager,metadata.name!=etcd-operator,metadata.name!=gcp-controller-manager"
 
-	// ConntrackGCIntervalLRU is the default connection tracking interval
-	// when using LRU maps
-	ConntrackGCIntervalLRU = 12 * time.Hour
+	// ConntrackGCMaxLRUInterval is the maximum conntrack GC interval when using LRU maps
+	ConntrackGCMaxLRUInterval = 12 * time.Hour
 
-	// ConntrackGCIntervalNonLRU is the default connection tracking
-	// interval when using non-LRU maps
-	ConntrackGCIntervalNonLRU = 15 * time.Minute
+	// ConntrackGCMaxInterval is the maximum conntrack GC interval for non-LRU maps
+	ConntrackGCMaxInterval = 30 * time.Minute
+
+	// ConntrackGCMinInterval is the minimum conntrack GC interval
+	ConntrackGCMinInterval = 10 * time.Second
+
+	// ConntrackGCStartingInterval is the default starting interval for
+	// connection tracking garbage collection
+	ConntrackGCStartingInterval = 5 * time.Minute
 
 	// K8sEventHandover enables use of the kvstore to optimize Kubernetes
 	// event handling by listening for k8s events in the operator and

--- a/pkg/maps/ctmap/ctmap_test.go
+++ b/pkg/maps/ctmap/ctmap_test.go
@@ -19,8 +19,11 @@ package ctmap
 import (
 	"strings"
 	"testing"
+	"time"
 	"unsafe"
 
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/tuple"
 
@@ -64,4 +67,22 @@ func (t *CTMapTestSuite) TestInit(c *C) {
 			}
 		}
 	}
+}
+
+func (t *CTMapTestSuite) TestCalculateInterval(c *C) {
+	c.Assert(calculateInterval(bpf.MapTypeLRUHash, time.Minute, 0.1), Equals, time.Minute)  // no change
+	c.Assert(calculateInterval(bpf.MapTypeLRUHash, time.Minute, 0.2), Equals, time.Minute)  // no change
+	c.Assert(calculateInterval(bpf.MapTypeLRUHash, time.Minute, 0.25), Equals, time.Minute) // no change
+
+	c.Assert(calculateInterval(bpf.MapTypeLRUHash, time.Minute, 0.40), Equals, 36*time.Second)
+	c.Assert(calculateInterval(bpf.MapTypeLRUHash, time.Minute, 0.60), Equals, 24*time.Second)
+
+	c.Assert(calculateInterval(bpf.MapTypeLRUHash, 10*time.Second, 0.01), Equals, 15*time.Second)
+	c.Assert(calculateInterval(bpf.MapTypeLRUHash, 10*time.Second, 0.04), Equals, 15*time.Second)
+
+	c.Assert(calculateInterval(bpf.MapTypeLRUHash, 1*time.Second, 0.9), Equals, defaults.ConntrackGCMinInterval)
+	c.Assert(calculateInterval(bpf.MapTypeHash, 1*time.Second, 0.9), Equals, defaults.ConntrackGCMinInterval)
+
+	c.Assert(calculateInterval(bpf.MapTypeLRUHash, 24*time.Hour, 0.01), Equals, defaults.ConntrackGCMaxLRUInterval)
+	c.Assert(calculateInterval(bpf.MapTypeHash, 24*time.Hour, 0.01), Equals, defaults.ConntrackGCMaxInterval)
 }


### PR DESCRIPTION
Commit df8582d16e5 ("datapath: Optimize connection-tracking GC interval") has
introduced a regression by changing the default interval for LRU map based
conntrack to 12h on the basis that the tables will automatically expire the
oldest entries when filling up.

Unfortunately, walking the table to clean the conntrack stale podIPs on pod
removal taints all entries. This causes to random conntrack entries being
evicted while the table is full.

Resolve this by adjusting the conntrack gc interval automatically based on the
number of entries deleted in the table with the most deletions.

Fixes: #7997

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/7999)
<!-- Reviewable:end -->
