### PR TITLE
Encryption fixes for route/rule management

### DIFF
--- a/pkg/datapath/linux/route/route_linux.go
+++ b/pkg/datapath/linux/route/route_linux.go
@@ -300,6 +300,7 @@ func Delete(route Route) error {
 	routeSpec := netlink.Route{
 		Dst:       &route.Prefix,
 		LinkIndex: link.Attrs().Index,
+		Table:     route.Table,
 	}
 
 	// Scope can only be specified for IPv4


### PR DESCRIPTION
Include table in route specifier so deleting IPsec routes in the encryption routing table will work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8000)
<!-- Reviewable:end -->
