### PR TITLE
test: Trim trailing newline in ByLines method

### DIFF
--- a/test/helpers/cmd.go
+++ b/test/helpers/cmd.go
@@ -197,6 +197,7 @@ func (res *CmdRes) ByLines() []string {
 	if strings.Contains(stdoutStr, "\r\n") {
 		sep = "\r\n"
 	}
+	stdoutStr = strings.TrimRight(stdoutStr, sep)
 	return strings.Split(stdoutStr, sep)
 }
 


### PR DESCRIPTION
It was observed, that sometimes `SSHMeta.Exec` output includes a trailing newline which might break some test assertions.

For example, `ValidateEndpointsAreCorrect` retrieves a list of Docker containers attached to the `cilium-net` network. If the list (a string `res`) contains a trailing newline, then the last `containerID` retrieved from `res.Bylines()` will be empty. It will make the test assertion to fail, as the `endpoints` does not have an entry with the empty key:

```
for _, containerID := range res.ByLines() {
    _, exists := endpoints[containerID]
    if !exists {
        // FAIL
    }
}
```

The assertion from above will fail with the `ContainerID  is not present in the endpoint list` error.

---

I didn't set any `needs-backport` label, as I haven't seen the failure in v1.5 or v1.4 CI runs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8001)
<!-- Reviewable:end -->
