### PR TITLE
[CI] Don't overwrite minRequired in WaitforNPods

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -546,7 +546,8 @@ func (kub *Kubectl) WaitforPods(namespace string, filter string, timeout time.Du
 // Returns no error if minRequired pods achieve the aforementioned desired
 // state within timeout seconds. Returns an error if the command failed or the
 // timeout was exceeded.
-// When minRequired is 0 the current count of pods are used. This is unreliable.
+// When minRequired is 0, the function will derive required pod count from number
+// of pods in the cluster for every iteration.
 func (kub *Kubectl) WaitforNPods(namespace string, filter string, minRequired int, timeout time.Duration) error {
 	body := func() bool {
 		podList := &v1.PodList{}
@@ -556,11 +557,15 @@ func (kub *Kubectl) WaitforNPods(namespace string, filter string, minRequired in
 			return false
 		}
 
+		var required int
+
 		if minRequired == 0 {
-			minRequired = len(podList.Items)
+			required = len(podList.Items)
+		} else {
+			required = minRequired
 		}
 
-		if len(podList.Items) < minRequired {
+		if len(podList.Items) < required {
 			return false
 		}
 
@@ -585,7 +590,7 @@ func (kub *Kubectl) WaitforNPods(namespace string, filter string, minRequired in
 			currScheduled++
 		}
 
-		return currScheduled >= minRequired
+		return currScheduled >= required
 	}
 
 	return WithTimeout(


### PR DESCRIPTION
If `minRequired` was set to 0, it was overwritten on the first pass of
`body` function (since it's in this function's closure) and if some pods
were being deleted during the test startup time, it could cause
`minRequired` to be higher than possible with test pods number.

Fixes: #7995

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8002)
<!-- Reviewable:end -->
