### PR TITLE
Improve IP blacklisting & router IP allocation

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -902,19 +902,10 @@ func deleteHostDevice() {
 }
 
 func (d *Daemon) prepareAllocationCIDR(family datapath.NodeAddressingFamily) (routerIP net.IP, err error) {
-	// Reserve the IPv4 external node IP within the allocation range if
-	// required.
-	allocRange := family.AllocationCIDR()
-	nodeIP := family.PrimaryExternal()
-	if allocRange.Contains(nodeIP) {
-		err = d.ipam.AllocateIP(nodeIP, "node")
-		if err != nil {
-			err = fmt.Errorf("Unable to allocate external IPv4 node IP %s from allocation range %s: %s",
-				nodeIP, allocRange, err)
-			return
-		}
-	}
+	// Blacklist allocation of the external IP
+	d.ipam.Blacklist(family.PrimaryExternal(), "node-ip")
 
+	allocRange := family.AllocationCIDR()
 	routerIP = family.Router()
 	if routerIP != nil && !allocRange.Contains(routerIP) {
 		log.Warningf("Detected allocation CIDR change to %s, previous router IP %s", allocRange, routerIP)

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -41,6 +41,14 @@ const (
 	IPv4 Family = "ipv4"
 )
 
+// DeriveFamily derives the address family of an IP
+func DeriveFamily(ip net.IP) Family {
+	if ip.To4() == nil {
+		return IPv6
+	}
+	return IPv4
+}
+
 // Configuration is the configuration of an IP address manager
 type Configuration struct {
 	EnableIPv4 bool

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -87,3 +87,8 @@ func (s *IPAMSuite) TestBlackList(c *C) {
 	c.Assert(err, Not(IsNil))
 	ipam.ReleaseIP(ipv6)
 }
+
+func (s *IPAMSuite) TestDeriveFamily(c *C) {
+	c.Assert(DeriveFamily(net.ParseIP("1.1.1.1")), Equals, IPv4)
+	c.Assert(DeriveFamily(net.ParseIP("f00d::1")), Equals, IPv6)
+}

--- a/pkg/ipam/types.go
+++ b/pkg/ipam/types.go
@@ -34,4 +34,6 @@ type IPAM struct {
 
 	// mutex covers access to all members of this struct
 	allocatorMutex lock.RWMutex
+
+	blacklist map[string]string
 }

--- a/pkg/workloads/config.go
+++ b/pkg/workloads/config.go
@@ -92,7 +92,7 @@ func setupWorkload(workloadRuntime WorkloadRuntimeType, opts map[string]string) 
 }
 
 type allocatorInterface interface {
-	AllocateIP(ip net.IP, owner string) error
+	Blacklist(ip net.IP, owner string)
 }
 
 // Setup sets up the workload runtime specified in workloadRuntime and configures it

--- a/pkg/workloads/cri.go
+++ b/pkg/workloads/cri.go
@@ -297,9 +297,7 @@ func (c *criClient) IgnoreRunningWorkloads() {
 		if cIP == nil {
 			continue
 		}
-		if err := allocator.AllocateIP(cIP.IP(), "ignored workload"); err != nil {
-			continue
-		}
+		allocator.Blacklist(cIP.IP(), "ignored container: "+pod.GetId())
 		//TODO Release this address when the ignored container leaves
 		scopedLog.WithFields(logrus.Fields{
 			logfields.IPAddr: cIP.IP(),

--- a/pkg/workloads/docker.go
+++ b/pkg/workloads/docker.go
@@ -513,9 +513,7 @@ func (d *dockerClient) IgnoreRunningWorkloads() {
 		if cIP == nil {
 			continue
 		}
-		if err := allocator.AllocateIP(cIP.IP(), "ignored workload"); err != nil {
-			continue
-		}
+		allocator.Blacklist(cIP.IP(), "ignored docker container: "+cont.ID)
 		// TODO Release this address when the ignored container leaves
 		scopedLog.WithFields(logrus.Fields{
 			logfields.IPAddr: cIP.IP(),


### PR DESCRIPTION
This is in preparation for external IPAM support which requires decoupling of IP allocation from a particular CIDR.

In order to achieve this, the following must be changed:
 * Blacklisting of IPs must be done using reservation as the IP range may not be known at the time of blacklisting.
 * The router IP is not guaranteed to be part of any CIDR range.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8005)
<!-- Reviewable:end -->
