### PR TITLE
v1.5 backports 2019-05-14

### DIFF
--- a/Documentation/architecture.rst
+++ b/Documentation/architecture.rst
@@ -137,8 +137,8 @@ handshake initiating the connection will traverse the endpoint policy object unt
 is ESTABLISHED. Then after the connection is ESTABLISHED only the L7 Policy
 object is still required.
 
-.. image:: /_static/cilium_bpf_endpoint.svg
-   :target: /_static/cilium_bpf_endpoint.svg
+.. image:: _static/cilium_bpf_endpoint.svg
+   :target: _static/cilium_bpf_endpoint.svg
 
 Egress from Endpoint
 --------------------
@@ -150,8 +150,8 @@ named cilium_vxlan. Similar to above, when socket layer enforcement is enabled
 and a L7 proxy is in use we can avoid running the endpoint policy block between
 the endpoint and the L7 Policy for TCP traffic.
 
-.. image:: /_static/cilium_bpf_egress.svg
-   :target: /_static/cilium_bpf_egress.svg
+.. image:: _static/cilium_bpf_egress.svg
+   :target: _static/cilium_bpf_egress.svg
 
 Ingress to Endpoint
 -------------------
@@ -160,8 +160,8 @@ Finally we show ingress to local endpoint also with optional overlay network.
 Similar to above socket layer enforcement can be used to avoid a set of
 policy traversals between the proxy and the endpoint socket.
 
-.. image:: /_static/cilium_bpf_ingress.svg
-   :target: /_static/cilium_bpf_ingress.svg
+.. image:: _static/cilium_bpf_ingress.svg
+   :target: _static/cilium_bpf_ingress.svg
 
 veth-based versus ipvlan-based datapath
 ---------------------------------------
@@ -251,5 +251,5 @@ Kubernetes Integration
 The following diagram shows the integration of iptables rules as installed by
 kube-proxy and the iptables rules as installed by Cilium.
 
-.. image:: /_static/kubernetes_iptables.svg
-   :target: /_static/kubernetes_iptables.svg
+.. image:: _static/kubernetes_iptables.svg
+   :target: _static/kubernetes_iptables.svg

--- a/Documentation/contributing.rst
+++ b/Documentation/contributing.rst
@@ -233,6 +233,9 @@ This box will need to be updated when a new developer needs a new dependency
 that is not installed in the current version of the box, or if a dependency that
 is cached within the box becomes stale.
 
+Make sure that you update vagrant box versions in `test Vagrantfile <https://github.com/cilium/cilium/blob/master/test/Vagrantfile>`
+and `root Vagrantfile <https://github.com/cilium/cilium/blob/master/Vagrantfile>` after new box is built and tested.
+
 Development process
 -------------------
 

--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -184,6 +184,7 @@ Both files are dedicated to "\ |SCM_BRANCH|" for each Kubernetes version.
 
       kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.14/cilium-rbac.yaml
       kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.14/cilium-ds.yaml
+      kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.14/cilium-operator-sa.yaml
       kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.14/cilium-operator.yaml
 
 

--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -286,6 +286,14 @@ New Default Values
  * The connection-tracking garbage collector intervals is now 12 hours when
    using LRU maps (newer kernels) and 15 minutes an all older kernels. The
    interval can be overwritten with the option ``--conntrack-gc-interval``.
+   If connectivity between pods is faulty and ``cilium monitor --type drop``
+   shows ``xx drop (CT: Map insertion failed)`` it is recommended to set
+   ``--conntrack-gc-interval`` to an interval lower than the default.
+   Alternatively, the value for ``bpf-ct-global-any-max`` and
+   ``bpf-ct-global-tcp-max`` should be increased. Setting both of these options
+   will be a trade-off of CPU for ``conntrack-gc-interval``, and for
+   ``bpf-ct-global-any-max`` and ``bpf-ct-global-tcp-max`` the amount of memory
+   consumed.
 
 .. _1.5_new_options:
 

--- a/Documentation/troubleshooting.rst
+++ b/Documentation/troubleshooting.rst
@@ -200,6 +200,15 @@ examples if running with Kubernetes):
 The above indicates that a packet to endpoint ID ``25729`` has been dropped due
 to violation of the Layer 3 policy.
 
+If connectivity between pods is faulty and ``cilium monitor --type drop``
+shows ``xx drop (CT: Map insertion failed)`` it is recommended to set
+``--conntrack-gc-interval`` to an interval lower than the default.
+Alternatively, the value for ``bpf-ct-global-any-max`` and
+``bpf-ct-global-tcp-max`` should be increased. Setting both of these options
+will be a trade-off of CPU for ``conntrack-gc-interval``, and for
+``bpf-ct-global-any-max`` and ``bpf-ct-global-tcp-max`` the amount of memory
+consumed.
+
 Policy Troubleshooting
 ======================
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -124,7 +124,7 @@ Vagrant.configure(2) do |config|
         vb.customize ["modifyvm", :id, "--audio", "none"]
 
         config.vm.box = "cilium/ubuntu-dev"
-        config.vm.box_version = "147"
+        config.vm.box_version = "151"
         vb.memory = ENV['VM_MEMORY'].to_i
         vb.cpus = ENV['VM_CPUS'].to_i
         if ENV["NFS"] then

--- a/operator/k8s_node.go
+++ b/operator/k8s_node.go
@@ -204,8 +204,9 @@ func runNodeWatcher() error {
 							}
 							if needsUpdate {
 								wg.Add(1)
+								cnpCpy := cnp.DeepCopy()
 								removeNodeFromCNP <- func() {
-									updateCNP(ciliumK8sClient.CiliumV2(), &cnp, nodesToDelete, k8sCapabilities)
+									updateCNP(ciliumK8sClient.CiliumV2(), cnpCpy, nodesToDelete, k8sCapabilities)
 									wg.Done()
 								}
 							}

--- a/pkg/datapath/maps/map.go
+++ b/pkg/datapath/maps/map.go
@@ -169,6 +169,9 @@ func RemoveDisabledMaps() {
 			"cilium_lb6_reverse_nat",
 			"cilium_lb6_rr_seq",
 			"cilium_lb6_services",
+			"cilium_lb6_services_v2",
+			"cilium_lb6_rr_seq_v2",
+			"cilium_lb6_backends",
 			"cilium_snat_v6_external",
 			"cilium_proxy6"}...)
 	}
@@ -180,6 +183,9 @@ func RemoveDisabledMaps() {
 			"cilium_lb4_reverse_nat",
 			"cilium_lb4_rr_seq",
 			"cilium_lb4_services",
+			"cilium_lb4_services_v2",
+			"cilium_lb4_rr_seq_v2",
+			"cilium_lb4_backends",
 			"cilium_snat_v4_external",
 			"cilium_proxy4"}...)
 	}

--- a/pkg/envoy/xds/cache.go
+++ b/pkg/envoy/xds/cache.go
@@ -109,9 +109,7 @@ func (c *Cache) tx(typeURL string, upsertedResources map[string]proto.Message, d
 		// If the value is unchanged, don't update the entry, to preserve its
 		// lastModifiedVersion. This allows minimizing the frequency of
 		// responses in GetResources.
-		// Calling proto.Message.String is not very cheap, but we assume that
-		// the reduced churn between the clients and the server is worth it.
-		if !found || oldV.resource.String() != value.String() {
+		if !found || !proto.Equal(oldV.resource, value) {
 			if found {
 				cacheLog.WithField(logfields.XDSResourceName, name).Debug("updating resource in cache")
 

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -210,8 +210,10 @@ func StartDNSProxy(address string, port uint16, lookupEPFunc LookupEndpointIDByI
 	}
 
 	// Bind the DNS forwarding clients on UDP and TCP
-	p.UDPClient = &dns.Client{Net: "udp", Timeout: ProxyForwardTimeout, SingleInflight: true}
-	p.TCPClient = &dns.Client{Net: "tcp", Timeout: ProxyForwardTimeout, SingleInflight: true}
+	// Note: SingleInFlight should remain disabled. When enabled it folds DNS
+	// retries into the previous lookup, supressing them.
+	p.UDPClient = &dns.Client{Net: "udp", Timeout: ProxyForwardTimeout, SingleInflight: false}
+	p.TCPClient = &dns.Client{Net: "tcp", Timeout: ProxyForwardTimeout, SingleInflight: false}
 
 	return p, nil
 }

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -8,7 +8,7 @@ $K8S_VERSION = ENV['K8S_VERSION'] || "1.14"
 $K8S_NODES = (ENV['K8S_NODES'] || "2").to_i
 $NFS = ENV['NFS']=="1"? true : false
 $SERVER_BOX = (ENV['SERVER_BOX'] || "cilium/ubuntu-dev")
-$SERVER_VERSION= "150"
+$SERVER_VERSION= "151"
 $NETNEXT_SERVER_BOX= "cilium/ubuntu-next"
 $NETNEXT_SERVER_VERSION= "23"
 $IPv6=(ENV['IPv6'] || "0")

--- a/test/k8sT/manifests/guestbook-policy-web.yaml
+++ b/test/k8sT/manifests/guestbook-policy-web.yaml
@@ -5,12 +5,12 @@ metadata:
 spec:
   endpointSelector:
     matchLabels:
-      k8s-app.guestbook: web
+      app: guestbook
   ingress:
   - fromEndpoints:
     - matchLabels:
         "reserved.world": ""
     toPorts:
     - ports:
-      - port: "3000"
+      - port: "80"
         protocol: TCP

--- a/test/k8sT/manifests/guestbook_deployment.json
+++ b/test/k8sT/manifests/guestbook_deployment.json
@@ -126,37 +126,50 @@
     }
 }
 {
-    "kind":"ReplicationController",
-    "apiVersion":"v1",
-    "metadata":{
-        "name":"guestbook",
-        "labels":{
-            "k8s-app.guestbook":"web"
-        }
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": {
+        "name": "frontend"
     },
-    "spec":{
-        "replicas":1,
-        "selector":{
-            "k8s-app.guestbook":"web"
+    "spec": {
+        "selector": {
+            "matchLabels": {
+                "app": "guestbook",
+                "tier": "frontend"
+            }
         },
-        "template":{
-            "metadata":{
-                "labels":{
-                    "k8s-app.guestbook":"web",
-                    "zgroup": "guestbook"
+        "replicas": 1,
+        "template": {
+            "metadata": {
+                "labels": {
+                    "app": "guestbook",
+                    "tier": "frontend"
                 }
             },
-            "spec":{
-                "terminationGracePeriodSeconds": 0,
-                "containers":[{
-                    "name":"guestbook",
-                    "image":"docker.io/kubernetes/guestbook:v2",
-                    "imagePullPolicy": "IfNotPresent",
-                    "ports":[{
-                        "name":"http-server",
-                        "containerPort":3000
-                    }]
-                }],
+            "spec": {
+                "containers": [
+                    {
+                        "name": "php-redis",
+                        "image": "gcr.io/google-samples/gb-frontend:v4",
+                        "resources": {
+                            "requests": {
+                                "cpu": "100m",
+                                "memory": "100Mi"
+                            }
+                        },
+                        "env": [
+                            {
+                                "name": "GET_HOSTS_FROM",
+                                "value": "dns"
+                            }
+                        ],
+                        "ports": [
+                            {
+                                "containerPort": 80
+                            }
+                        ]
+                    }
+                ],
                 "nodeSelector": {
                     "kubernetes.io/hostname": "k8s2"
                 }


### PR DESCRIPTION
* #7953 -- pkg/envoy: use proto.Equal instead comparing strings (@aanm)
 * #7955 -- test: replace guestbook test docker image (@aanm)
 * #7961 -- docs: give better troubleshooting for conntrack-gc-interval (@aanm)
 * #7975 -- operator: fix concurrent access of variable in cnp garbage collection that could lead to panic in cilium-operator (@aanm)
 * #7977 -- Bump vagrant box version for tests to 151 (@nebril)
 * #7978 -- cni: Fix unexpected end of JSON input on errors (@tgraf)
 * #7985 -- docs: add missing cilium-operator-sa.yaml for k8s 1.14 upgrade guide (@aanm)
 * #7990 -- maps: Remove disabled svc v2 maps (@brb)
 * #7979 -- fqdn: DNSProxy does not fold similar DNS requests (@raybejjani)
 * #8004 -- docs: fix architecture images' URL (@aanm)

Once this PR is merged, you can update the PR labels via:
```
$ for pr in 7953 7955 7961 7975 7977 7978 7985 7990 7979 8004; do contrib/backporting/set-labels.py $pr done 1.5; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8007)
<!-- Reviewable:end -->
