### PR TITLE
ipam: Add flag to disable reservation of IPs of local routes

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -19,6 +19,7 @@ cilium-agent [flags]
       --agent-labels strings                       Additional labels to identify this agent
       --allow-localhost string                     Policy when to allow local stack to reach local endpoints { auto | always | policy } (default "auto")
       --auto-direct-node-routes                    Enable automatic L2 routing between nodes
+      --blacklist-conflicting-routes               Don't blacklist IP allocations conflicting with local non-cilium routes (default true)
       --bpf-compile-debug                          Enable debugging of the BPF compilation process
       --bpf-ct-global-any-max int                  Maximum number of entries in non-TCP CT table (default 262144)
       --bpf-ct-global-tcp-max int                  Maximum number of entries in TCP CT table (default 1000000)

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -363,6 +363,9 @@ func init() {
 	flags.String(option.AllowLocalhost, option.AllowLocalhostAuto, "Policy when to allow local stack to reach local endpoints { auto | always | policy }")
 	option.BindEnv(option.AllowLocalhost)
 
+	flags.Bool(option.BlacklistConflictingRoutes, defaults.BlacklistConflictingRoutes, "Don't blacklist IP allocations conflicting with local non-cilium routes")
+	option.BindEnv(option.BlacklistConflictingRoutes)
+
 	flags.String(option.BPFRoot, "", "Path to BPF filesystem")
 	option.BindEnv(option.BPFRoot)
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -202,4 +202,8 @@ const (
 	// EndpointInterfaceNamePrefix is the default prefix name of the
 	// interface names shared by all endpoints
 	EndpointInterfaceNamePrefix = "lxc+"
+
+	// BlacklistConflictingRoutes removes all IPs from the IPAM block if a
+	// local route not owned by Cilium conflicts with it
+	BlacklistConflictingRoutes = true
 )

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
 
 	"github.com/vishvananda/netlink"
 	"k8s.io/kubernetes/pkg/registry/core/service/ipallocator"
@@ -127,6 +128,10 @@ func (ipam *IPAM) reserveLocalRoutes() {
 // ReserveLocalRoutes walks through local routes/subnets and reserves them in
 // the allocator pool in case of overlap
 func (ipam *IPAM) ReserveLocalRoutes() {
+	if !option.Config.BlacklistConflictingRoutes {
+		return
+	}
+
 	if ipam.IPv4Allocator != nil {
 		ipam.reserveLocalRoutes()
 	}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -455,6 +455,10 @@ const (
 	// EndpointInterfaceNamePrefix is the prefix name of the interface
 	// names shared by all endpoints
 	EndpointInterfaceNamePrefix = "endpoint-interface-name-prefix"
+
+	// BlacklistConflictingRoutes removes all IPs from the IPAM block if a
+	// local route not owned by Cilium conflicts with it
+	BlacklistConflictingRoutes = "blacklist-conflicting-routes"
 )
 
 // FQDNS variables
@@ -914,6 +918,10 @@ type DaemonConfig struct {
 	// EndpointInterfaceNamePrefix is the prefix name of the interface
 	// names shared by all endpoints
 	EndpointInterfaceNamePrefix string
+
+	// BlacklistConflictingRoutes removes all IPs from the IPAM block if a
+	// local route not owned by Cilium conflicts with it
+	BlacklistConflictingRoutes bool
 }
 
 var (
@@ -937,6 +945,7 @@ var (
 		SelectiveRegeneration:       defaults.SelectiveRegeneration,
 		LoopbackIPv4:                defaults.LoopbackIPv4,
 		EndpointInterfaceNamePrefix: defaults.EndpointInterfaceNamePrefix,
+		BlacklistConflictingRoutes:  defaults.BlacklistConflictingRoutes,
 	}
 )
 
@@ -1216,6 +1225,7 @@ func (c *DaemonConfig) Populate() {
 	c.PrependIptablesChains = viper.GetBool(PrependIptablesChainsName)
 	c.PrometheusServeAddr = getPrometheusServerAddr()
 	c.ProxyConnectTimeout = viper.GetInt(ProxyConnectTimeout)
+	c.BlacklistConflictingRoutes = viper.GetBool(BlacklistConflictingRoutes)
 	c.RestoreState = viper.GetBool(Restore)
 	c.RunDir = viper.GetString(StateDir)
 	c.SidecarIstioProxyImage = viper.GetString(SidecarIstioProxyImage)


### PR DESCRIPTION
This functionality can provide some "just works" magic but can also be
conflicting in more advanced architectures. Add a flag to disable the
logic.

An example of where this logic is insufficient is the upcoming ENI
routing architecture:
```
192.168.64.0/19 dev eth0  proto kernel  scope link  src 192.168.93.188
192.168.67.25 dev veth09e3dd46  scope link
192.168.69.202 dev veth9e3002f4  scope link
192.168.75.198 dev veth24c24471  scope link
192.168.81.91 dev veth5ae02eae  scope link
192.168.89.37 dev cilium_host  scope link
```

The overall route to eth0 will conflict with ENI based IPs allocated to the node

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8008)
<!-- Reviewable:end -->
