### PR TITLE
daemon/Makefile: rm -f on make clean for links

### DIFF
--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -29,7 +29,7 @@ clean:
 	@$(ECHO_CLEAN)
 	$(QUIET)rm -f $(TARGET)
 	$(QUIET)$(GO) clean
-	$(foreach link,$(LINKS), rm $(link);)
+	$(foreach link,$(LINKS), rm -f $(link);)
 
 ifeq ("$(PKG_BUILD)","")
 


### PR DESCRIPTION
This fixes error messages such as [0] while cleaning up Cilium.

[0]
```
rm: cannot remove 'cilium-node-monitor': No such file or directory
```

Fixes: 8ac4ed848811 ("Single cilium binary")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8010)
<!-- Reviewable:end -->
