### PR TITLE
envoy: Do not use deprecated configuration options.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1765,6 +1765,7 @@
     "github.com/cilium/proxy/go/cilium/api",
     "github.com/cilium/proxy/go/envoy/api/v2",
     "github.com/cilium/proxy/go/envoy/api/v2/core",
+    "github.com/cilium/proxy/go/envoy/api/v2/endpoint",
     "github.com/cilium/proxy/go/envoy/api/v2/listener",
     "github.com/cilium/proxy/go/envoy/api/v2/route",
     "github.com/cilium/proxy/go/envoy/config/bootstrap/v2",

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cilium/proxy/go/cilium/api"
 	envoy_api_v2 "github.com/cilium/proxy/go/envoy/api/v2"
 	envoy_api_v2_core "github.com/cilium/proxy/go/envoy/api/v2/core"
+	envoy_api_v2_endpoint "github.com/cilium/proxy/go/envoy/api/v2/endpoint"
 	envoy_api_v2_listener "github.com/cilium/proxy/go/envoy/api/v2/listener"
 	envoy_api_v2_route "github.com/cilium/proxy/go/envoy/api/v2/route"
 	envoy_config_bootstrap_v2 "github.com/cilium/proxy/go/envoy/config/bootstrap/v2"
@@ -539,11 +540,20 @@ func createBootstrap(filePath string, name, cluster, version string, xdsSock, eg
 					ClusterDiscoveryType: &envoy_api_v2.Cluster_Type{Type: envoy_api_v2.Cluster_STATIC},
 					ConnectTimeout:       &duration.Duration{Seconds: connectTimeout, Nanos: 0},
 					LbPolicy:             envoy_api_v2.Cluster_ROUND_ROBIN,
-					Hosts: []*envoy_api_v2_core.Address{
-						{
-							Address: &envoy_api_v2_core.Address_Pipe{
-								Pipe: &envoy_api_v2_core.Pipe{Path: xdsSock}},
-						},
+					LoadAssignment: &envoy_api_v2.ClusterLoadAssignment{
+						ClusterName: "xds-grpc-cilium",
+						Endpoints: []*envoy_api_v2_endpoint.LocalityLbEndpoints{{
+							LbEndpoints: []*envoy_api_v2_endpoint.LbEndpoint{{
+								HostIdentifier: &envoy_api_v2_endpoint.LbEndpoint_Endpoint{
+									Endpoint: &envoy_api_v2_endpoint.Endpoint{
+										Address: &envoy_api_v2_core.Address{
+											Address: &envoy_api_v2_core.Address_Pipe{
+												Pipe: &envoy_api_v2_core.Pipe{Path: xdsSock}},
+										},
+									},
+								},
+							}},
+						}},
 					},
 					Http2ProtocolOptions: &envoy_api_v2_core.Http2ProtocolOptions{},
 				},


### PR DESCRIPTION
Cluster.Hosts has been deprecated in favor of more general
LoadAssignment option. Use minimal LoadAssignment to keep the current
behavior.

This change removes logs like this:

May 14 11:20:03 runtime1 cilium-agent[14157]: level=warning msg="[[external/envoy/source/common/protobuf/utility.cc:174] Using deprecated option 'envoy.api.v2.Cluster.hosts' from file cds.proto. This configuration will be removed from Envoy soon. Please see https://www.envoyproxy.io/docs/envoy/latest/intro/deprecated for details." subsys=envoy-misc threadID=15632

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8014)
<!-- Reviewable:end -->
