### PR TITLE
bpf: Fix object file list

### DIFF
--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -4,7 +4,7 @@ include ../Makefile.defs
 
 SUBDIRS = sockops
 
-BPF_SIMPLE = bpf_netdev.o bpf_overlay.o bpf_xdp.o bpf_ipsec.o bpf_network.o bpf_alignchecker.o bpf_hostdev_ingress.c
+BPF_SIMPLE = bpf_netdev.o bpf_overlay.o bpf_xdp.o bpf_ipsec.o bpf_network.o bpf_alignchecker.o bpf_hostdev_ingress.o
 BPF = bpf_lxc.o bpf_lb.o bpf_sock.o $(BPF_SIMPLE)
 SCRIPTS = init.sh join_ep.sh run_probes.sh spawn_netns.sh
 


### PR DESCRIPTION
Change the suffix of 'bpf_hostdev_ingress.c' to '.o' in 'BPF_SIMPLE'
to get rid of an error like this when runtime tests run the privileged
unit tests:

[2019-05-14T12:15:05.209Z]   Stderr:
[2019-05-14T12:15:05.209Z]    	 can't load package: package github.com/cilium/cilium/test/bpf: C source files not allowed when not using cgo or SWIG: bpf-event-test.c elf-demo.c unit-test.c
[2019-05-14T12:15:05.209Z]   	 Makefile:18: target 'bpf_hostdev_ingress.c' doesn't match the target pattern

Fixes: 25a80dfdd5e ("bpf: Add to-container section to bpf_lxc")
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8015)
<!-- Reviewable:end -->
