### PR TITLE
Prepare IPAM for multiple backends

### DIFF
--- a/api/v1/models/ip_a_m_status.go
+++ b/api/v1/models/ip_a_m_status.go
@@ -25,6 +25,9 @@ type IPAMStatus struct {
 
 	// ipv6
 	IPV6 []string `json:"ipv6"`
+
+	// status
+	Status string `json:"status,omitempty"`
 }
 
 // Validate validates this IP a m status

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -1473,6 +1473,8 @@ definitions:
         type: array
         items:
           type: string
+      status:
+        type: string
   ClusterStatus:
     description: Status of cluster
     properties:

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -2044,6 +2044,9 @@ func init() {
           "items": {
             "type": "string"
           }
+        },
+        "status": {
+          "type": "string"
         }
       }
     },
@@ -4965,6 +4968,9 @@ func init() {
           "items": {
             "type": "string"
           }
+        },
+        "status": {
+          "type": "string"
         }
       }
     },

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1098,10 +1098,6 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 	}
 
 	// Set up ipam conf after init() because we might be running d.conf.KVStoreIPv4Registration
-	log.WithFields(logrus.Fields{
-		logfields.V4Prefix: dp.LocalNodeAddressing().IPv4().AllocationCIDR(),
-		logfields.V6Prefix: dp.LocalNodeAddressing().IPv6().AllocationCIDR(),
-	}).Info("Initializing IPAM")
 	d.ipam = ipam.NewIPAM(dp.LocalNodeAddressing(), ipam.Configuration{
 		EnableIPv4: option.Config.EnableIPv4,
 		EnableIPv6: option.Config.EnableIPv6,

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1021,6 +1021,7 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 	d.policyTrigger = t
 
 	debug.RegisterStatusObject("k8s-service-cache", &d.k8sSvcCache)
+	debug.RegisterStatusObject("ipam", d.ipam)
 
 	bootstrapStats.k8sInit.Start()
 	k8s.Configure(option.Config.K8sAPIServer, option.Config.K8sKubeConfigPath)

--- a/daemon/ipam.go
+++ b/daemon/ipam.go
@@ -102,8 +102,10 @@ func (h *deleteIPAMIP) Handle(params ipamapi.DeleteIPAMIPParams) middleware.Resp
 // DumpIPAM dumps in the form of a map, the list of
 // reserved IPv4 and IPv6 addresses.
 func (d *Daemon) DumpIPAM() *models.IPAMStatus {
-	allocv4, allocv6 := d.ipam.Dump()
-	status := &models.IPAMStatus{}
+	allocv4, allocv6, st := d.ipam.Dump()
+	status := &models.IPAMStatus{
+		Status: st,
+	}
 
 	v4 := []string{}
 	for ip := range allocv4 {

--- a/pkg/ip/ip.go
+++ b/pkg/ip/ip.go
@@ -31,11 +31,7 @@ const (
 // CountIPsInCIDR takes a RFC4632/RFC4291-formatted IPv4/IPv6 CIDR and
 // determines how many IP addresses reside within that CIDR.
 // Returns 0 if the input CIDR cannot be parsed.
-func CountIPsInCIDR(cidr string) int {
-	_, ipnet, err := net.ParseCIDR(cidr)
-	if err != nil {
-		return 0
-	}
+func CountIPsInCIDR(ipnet *net.IPNet) int {
 	subnet, size := ipnet.Mask.Size()
 	if subnet == size {
 		return 1

--- a/pkg/ip/ip_test.go
+++ b/pkg/ip/ip_test.go
@@ -47,7 +47,9 @@ func (s *IPTestSuite) TestCountIPs(c *C) {
 		"::1/120":        255,
 	}
 	for cidr, nIPs := range tests {
-		count := CountIPsInCIDR(cidr)
+		_, ipnet, err := net.ParseCIDR(cidr)
+		c.Assert(err, IsNil)
+		count := CountIPsInCIDR(ipnet)
 		c.Assert(count, Equals, nIPs)
 	}
 }

--- a/pkg/ipam/allocator_test.go
+++ b/pkg/ipam/allocator_test.go
@@ -42,7 +42,9 @@ func (s *IPAMSuite) TestAllocatedIPDump(c *C) {
 		nextIP(ipv6)
 	}
 
-	allocv4, allocv6 := ipam.Dump()
+	allocv4, allocv6, status := ipam.Dump()
+	c.Assert(status, Not(Equals), "")
+
 	// Test the format of the dumped ip addresses
 	for ip := range allocv4 {
 		c.Assert(net.ParseIP(ip), NotNil)

--- a/pkg/ipam/hostscope.go
+++ b/pkg/ipam/hostscope.go
@@ -1,0 +1,65 @@
+// Copyright 2017-2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipam
+
+import (
+	"math/big"
+	"net"
+
+	k8sAPI "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/registry/core/service/ipallocator"
+)
+
+type hostScopeAllocator struct {
+	allocCIDR *net.IPNet
+	allocator *ipallocator.Range
+}
+
+func newHostScopeAllocator(n *net.IPNet) Allocator {
+	a := &hostScopeAllocator{
+		allocCIDR: n,
+		allocator: ipallocator.NewCIDRRange(n),
+	}
+
+	return a
+}
+
+func (h *hostScopeAllocator) Allocate(ip net.IP, owner string) error {
+	return h.allocator.Allocate(ip)
+}
+
+func (h *hostScopeAllocator) Release(ip net.IP) error {
+	return h.allocator.Release(ip)
+}
+
+func (h *hostScopeAllocator) AllocateNext(owner string) (net.IP, error) {
+	return h.allocator.AllocateNext()
+}
+
+func (h *hostScopeAllocator) Dump() map[string]string {
+	alloc := map[string]string{}
+	ral := k8sAPI.RangeAllocation{}
+	h.allocator.Snapshot(&ral)
+	origIP := big.NewInt(0).SetBytes(h.allocCIDR.IP.To4())
+	bits := big.NewInt(0).SetBytes(ral.Data)
+	for i := 0; i < bits.BitLen(); i++ {
+		if bits.Bit(i) != 0 {
+			ip := net.IP(big.NewInt(0).Add(origIP, big.NewInt(int64(uint(i+1)))).Bytes()).String()
+			alloc[ip] = ""
+		}
+	}
+
+	return alloc
+}

--- a/pkg/ipam/hostscope.go
+++ b/pkg/ipam/hostscope.go
@@ -15,8 +15,11 @@
 package ipam
 
 import (
+	"fmt"
 	"math/big"
 	"net"
+
+	"github.com/cilium/cilium/pkg/ip"
 
 	k8sAPI "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/registry/core/service/ipallocator"
@@ -48,7 +51,7 @@ func (h *hostScopeAllocator) AllocateNext(owner string) (net.IP, error) {
 	return h.allocator.AllocateNext()
 }
 
-func (h *hostScopeAllocator) Dump() map[string]string {
+func (h *hostScopeAllocator) Dump() (map[string]string, string) {
 	alloc := map[string]string{}
 	ral := k8sAPI.RangeAllocation{}
 	h.allocator.Snapshot(&ral)
@@ -61,5 +64,8 @@ func (h *hostScopeAllocator) Dump() map[string]string {
 		}
 	}
 
-	return alloc
+	maxIPs := ip.CountIPsInCIDR(h.allocCIDR)
+	status := fmt.Sprintf("%d/%d allocated from %s", len(alloc), maxIPs, h.allocCIDR.String())
+
+	return alloc, status
 }

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -58,7 +58,7 @@ func (s *IPAMSuite) TestLock(c *C) {
 	c.Assert(err, IsNil)
 
 	// Let's allocate the IP first so we can see the tests failing
-	err = ipam.IPv4Allocator.Allocate(epipv4.IP())
+	err = ipam.IPv4Allocator.Allocate(epipv4.IP(), "test")
 	c.Assert(err, IsNil)
 
 	err = ipam.IPv4Allocator.Release(epipv4.IP())

--- a/pkg/ipam/types.go
+++ b/pkg/ipam/types.go
@@ -15,19 +15,36 @@
 package ipam
 
 import (
+	"net"
+
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/lock"
-
-	"k8s.io/kubernetes/pkg/registry/core/service/ipallocator"
 )
+
+// Allocator is the interface for an IP allocator implementation
+type Allocator interface {
+	// Allocate allocates a specific IP or fails
+	Allocate(ip net.IP, owner string) error
+
+	// Release releases a previously allocated IP or fails
+	Release(ip net.IP) error
+
+	// AllocateNext allocates the next available IP or fails if no more IPs
+	// are available
+	AllocateNext(owner string) (net.IP, error)
+
+	// Dump returns a map of all allocated IPs with the IP represented as
+	// key in the map
+	Dump() map[string]string
+}
 
 // Config is the IPAM configuration used for a particular IPAM type.
 type IPAM struct {
 	nodeAddressing datapath.NodeAddressing
 	config         Configuration
 
-	IPv6Allocator *ipallocator.Range
-	IPv4Allocator *ipallocator.Range
+	IPv6Allocator Allocator
+	IPv4Allocator Allocator
 
 	// owner maps an IP to the owner
 	owner map[string]string

--- a/pkg/ipam/types.go
+++ b/pkg/ipam/types.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/lock"
+
+	"github.com/davecgh/go-spew/spew"
 )
 
 // Allocator is the interface for an IP allocator implementation
@@ -53,4 +55,13 @@ type IPAM struct {
 	allocatorMutex lock.RWMutex
 
 	blacklist map[string]string
+}
+
+// DebugStatus implements debug.StatusObject to provide debug status collection
+// ability
+func (ipam *IPAM) DebugStatus() string {
+	ipam.allocatorMutex.RLock()
+	str := spew.Sdump(ipam)
+	ipam.allocatorMutex.RUnlock()
+	return str
 }

--- a/pkg/ipam/types.go
+++ b/pkg/ipam/types.go
@@ -36,8 +36,10 @@ type Allocator interface {
 	AllocateNext(owner string) (net.IP, error)
 
 	// Dump returns a map of all allocated IPs with the IP represented as
-	// key in the map
-	Dump() map[string]string
+	// key in the map. Dump must also provide a status one-liner to
+	// represent the overall status, e.g. number of IPs allocated and
+	// overall health information if available.
+	Dump() (map[string]string, string)
 }
 
 // Config is the IPAM configuration used for a particular IPAM type.


### PR DESCRIPTION
This is in preparation for CRD-backed IPAM. It introduces an interface to implement and moves the existing hostscope allocator to become a backend. It also moves the status definition logic from the client into the backend so different backends can provide backend specific status messages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8016)
<!-- Reviewable:end -->
