### PR TITLE
cilium: IsLocal() needs to compare both Name and Cluster

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -257,10 +257,14 @@ func (n *Node) Identity() Identity {
 	}
 }
 
+func getCluster() string {
+	return option.Config.ClusterName
+}
+
 // IsLocal returns true if this is the node on which the agent itself is
 // running on
 func (n *Node) IsLocal() bool {
-	return n != nil && n.Name == GetName()
+	return n != nil && n.Name == GetName() && n.Cluster == getCluster()
 }
 
 // PublicAttrEquals returns true only if the public attributes of both nodes


### PR DESCRIPTION
The cluster name should be used to determine if a node is local to
avoid an error if two nodes in different clusters have the same
name.

A unique string identifier is Cluster + Name.

Fixes: 076b018 ("Inter cluster connectivity (ClusterMesh)")
Signed-off-by: John Fastabend <john.fastabend@gmail.com>


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8017)
<!-- Reviewable:end -->
