### PR TITLE
Encryption state remove on node delete and restart

### DIFF
--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -773,13 +773,19 @@ func (n *linuxNodeHandler) replaceNodeIPSecInRoute(ip *net.IPNet) {
 
 func (n *linuxNodeHandler) deleteIPsec(oldNode *node.Node) {
 	if n.nodeConfig.EnableIPv4 && oldNode.IPv4AllocCIDR != nil {
+		ciliumInternalIPv4 := oldNode.GetCiliumInternalIP(false)
+		old4Net := &net.IPNet{IP: ciliumInternalIPv4, Mask: oldNode.IPv4AllocCIDR.Mask}
 		old4RouteNet := &net.IPNet{IP: oldNode.IPv4AllocCIDR.IP, Mask: oldNode.IPv4AllocCIDR.Mask}
 		n.deleteNodeIPSecOutRoute(old4RouteNet)
+		ipsec.DeleteIPsecEndpoint(old4Net)
 	}
 
 	if n.nodeConfig.EnableIPv6 && oldNode.IPv6AllocCIDR != nil {
+		ciliumInternalIPv6 := oldNode.GetCiliumInternalIP(true)
+		old6Net := &net.IPNet{IP: ciliumInternalIPv6, Mask: oldNode.IPv6AllocCIDR.Mask}
 		old6RouteNet := &net.IPNet{IP: oldNode.IPv6AllocCIDR.IP, Mask: oldNode.IPv6AllocCIDR.Mask}
 		n.deleteNodeIPSecOutRoute(old6RouteNet)
+		ipsec.DeleteIPsecEndpoint(old6Net)
 	}
 }
 


### PR DESCRIPTION
On node deletion the xfrm state was persisting this series will now remove it. This way we avoid polluting the xfrm state with old entries that are no longer useful. Also we cleanup routes/xfrm state on restart so when we transition from --enable-ipsec to encryption disabled the old state is also removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8027)
<!-- Reviewable:end -->
