### PR TITLE
examples/kubernetes: Set privileged option to false

### DIFF
--- a/examples/kubernetes/1.10/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-containerd-ds.yaml
@@ -113,7 +113,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -168,7 +168,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/1.10/cilium-containerd.yaml
+++ b/examples/kubernetes/1.10/cilium-containerd.yaml
@@ -281,7 +281,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -336,7 +336,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/1.10/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-crio-ds.yaml
@@ -121,7 +121,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -176,7 +176,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -289,7 +289,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -344,7 +344,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/1.10/cilium-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-ds.yaml
@@ -120,7 +120,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -181,7 +181,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/1.10/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.10/cilium-external-etcd.yaml
@@ -288,7 +288,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -349,7 +349,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/1.10/cilium-microk8s.yaml
+++ b/examples/kubernetes/1.10/cilium-microk8s.yaml
@@ -281,7 +281,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -336,7 +336,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/1.10/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-minikube-ds.yaml
@@ -120,7 +120,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -175,7 +175,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/1.10/cilium-minikube.yaml
+++ b/examples/kubernetes/1.10/cilium-minikube.yaml
@@ -288,7 +288,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -343,7 +343,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/1.10/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.10/cilium-with-node-init.yaml
@@ -288,7 +288,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -349,7 +349,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -288,7 +288,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -349,7 +349,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/1.11/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-containerd-ds.yaml
@@ -113,7 +113,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -168,7 +168,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/1.11/cilium-containerd.yaml
+++ b/examples/kubernetes/1.11/cilium-containerd.yaml
@@ -281,7 +281,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -336,7 +336,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/1.11/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-crio-ds.yaml
@@ -121,7 +121,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /var/run/cilium
           name: cilium-run
@@ -174,7 +174,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /var/run/cilium
           name: cilium-run

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -289,7 +289,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /var/run/cilium
           name: cilium-run
@@ -342,7 +342,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /var/run/cilium
           name: cilium-run

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -120,7 +120,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -181,7 +181,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/1.11/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.11/cilium-external-etcd.yaml
@@ -288,7 +288,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -349,7 +349,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/1.11/cilium-microk8s.yaml
+++ b/examples/kubernetes/1.11/cilium-microk8s.yaml
@@ -281,7 +281,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -336,7 +336,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/1.11/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-minikube-ds.yaml
@@ -120,7 +120,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -175,7 +175,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/1.11/cilium-minikube.yaml
+++ b/examples/kubernetes/1.11/cilium-minikube.yaml
@@ -288,7 +288,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -343,7 +343,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/1.11/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.11/cilium-with-node-init.yaml
@@ -288,7 +288,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -349,7 +349,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -288,7 +288,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -349,7 +349,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/1.12/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-containerd-ds.yaml
@@ -113,7 +113,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -168,7 +168,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/1.12/cilium-containerd.yaml
+++ b/examples/kubernetes/1.12/cilium-containerd.yaml
@@ -281,7 +281,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -336,7 +336,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/1.12/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-crio-ds.yaml
@@ -121,7 +121,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /var/run/cilium
           name: cilium-run
@@ -174,7 +174,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /var/run/cilium
           name: cilium-run

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -289,7 +289,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /var/run/cilium
           name: cilium-run
@@ -342,7 +342,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /var/run/cilium
           name: cilium-run

--- a/examples/kubernetes/1.12/cilium-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-ds.yaml
@@ -120,7 +120,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -181,7 +181,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/1.12/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.12/cilium-external-etcd.yaml
@@ -288,7 +288,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -349,7 +349,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/1.12/cilium-microk8s.yaml
+++ b/examples/kubernetes/1.12/cilium-microk8s.yaml
@@ -281,7 +281,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -336,7 +336,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/1.12/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-minikube-ds.yaml
@@ -120,7 +120,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -175,7 +175,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/1.12/cilium-minikube.yaml
+++ b/examples/kubernetes/1.12/cilium-minikube.yaml
@@ -288,7 +288,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -343,7 +343,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/1.12/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.12/cilium-with-node-init.yaml
@@ -288,7 +288,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -349,7 +349,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -288,7 +288,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -349,7 +349,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/1.13/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-containerd-ds.yaml
@@ -113,7 +113,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -168,7 +168,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/1.13/cilium-containerd.yaml
+++ b/examples/kubernetes/1.13/cilium-containerd.yaml
@@ -281,7 +281,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -336,7 +336,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/1.13/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-crio-ds.yaml
@@ -121,7 +121,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /var/run/cilium
           name: cilium-run
@@ -174,7 +174,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /var/run/cilium
           name: cilium-run

--- a/examples/kubernetes/1.13/cilium-crio.yaml
+++ b/examples/kubernetes/1.13/cilium-crio.yaml
@@ -289,7 +289,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /var/run/cilium
           name: cilium-run
@@ -342,7 +342,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /var/run/cilium
           name: cilium-run

--- a/examples/kubernetes/1.13/cilium-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-ds.yaml
@@ -120,7 +120,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -181,7 +181,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/1.13/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.13/cilium-external-etcd.yaml
@@ -288,7 +288,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -349,7 +349,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/1.13/cilium-microk8s.yaml
+++ b/examples/kubernetes/1.13/cilium-microk8s.yaml
@@ -281,7 +281,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -336,7 +336,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/1.13/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-minikube-ds.yaml
@@ -120,7 +120,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -175,7 +175,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/1.13/cilium-minikube.yaml
+++ b/examples/kubernetes/1.13/cilium-minikube.yaml
@@ -288,7 +288,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -343,7 +343,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/1.13/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.13/cilium-with-node-init.yaml
@@ -288,7 +288,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -349,7 +349,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/1.13/cilium.yaml
+++ b/examples/kubernetes/1.13/cilium.yaml
@@ -288,7 +288,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -349,7 +349,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/1.14/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.14/cilium-containerd-ds.yaml
@@ -113,7 +113,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -168,7 +168,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/1.14/cilium-containerd.yaml
+++ b/examples/kubernetes/1.14/cilium-containerd.yaml
@@ -281,7 +281,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -336,7 +336,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/1.14/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.14/cilium-crio-ds.yaml
@@ -121,7 +121,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /var/run/cilium
           name: cilium-run
@@ -174,7 +174,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /var/run/cilium
           name: cilium-run

--- a/examples/kubernetes/1.14/cilium-crio.yaml
+++ b/examples/kubernetes/1.14/cilium-crio.yaml
@@ -289,7 +289,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /var/run/cilium
           name: cilium-run
@@ -342,7 +342,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /var/run/cilium
           name: cilium-run

--- a/examples/kubernetes/1.14/cilium-ds.yaml
+++ b/examples/kubernetes/1.14/cilium-ds.yaml
@@ -120,7 +120,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -181,7 +181,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/1.14/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.14/cilium-external-etcd.yaml
@@ -288,7 +288,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -349,7 +349,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/1.14/cilium-microk8s.yaml
+++ b/examples/kubernetes/1.14/cilium-microk8s.yaml
@@ -281,7 +281,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -336,7 +336,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/1.14/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.14/cilium-minikube-ds.yaml
@@ -120,7 +120,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -175,7 +175,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/1.14/cilium-minikube.yaml
+++ b/examples/kubernetes/1.14/cilium-minikube.yaml
@@ -288,7 +288,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -343,7 +343,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/1.14/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.14/cilium-with-node-init.yaml
@@ -288,7 +288,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -349,7 +349,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/1.14/cilium.yaml
+++ b/examples/kubernetes/1.14/cilium.yaml
@@ -288,7 +288,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -349,7 +349,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/templates/v1/cilium-containerd-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-containerd-ds.yaml.sed
@@ -113,7 +113,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -168,7 +168,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
@@ -121,7 +121,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -176,7 +176,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
@@ -120,7 +120,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -181,7 +181,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps

--- a/examples/kubernetes/templates/v1/cilium-minikube-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-minikube-ds.yaml.sed
@@ -120,7 +120,7 @@ spec:
             add:
             - NET_ADMIN
             - SYS_MODULE
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
@@ -175,7 +175,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
+          privileged: false
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps


### PR DESCRIPTION
All yaml manifests already specify concrete capabilities, so there is no
need in using `priviliged` option which gives all capabilities.

Fixes: 4736fb5f1146 ("examples/kubernetes: add k8s spec file auto-generator")
Fixes: 175071468623 ("Run initContainer in privileged mode for cilium cleanup")

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8029)
<!-- Reviewable:end -->
