### PR TITLE
cli: Restore cilium cleanup behaviour

### DIFF
--- a/cilium/cmd/cleanup.go
+++ b/cilium/cmd/cleanup.go
@@ -209,13 +209,14 @@ func runCleanup() {
 	cleanAll = viper.GetBool(allFlagName) || viper.GetBool(cleanCiliumEnvVar)
 	cleanBPF = viper.GetBool(bpfFlagName) || viper.GetBool(cleanBpfEnvVar)
 
-	if cleanAll {
-		cleanBPF = true
+	// if no flags are specifed then clean all
+	if (cleanAll || cleanBPF) == false {
+		cleanAll = true
 	}
 
 	var cleanups []cleanup
 
-	if cleanBPF {
+	if cleanAll || cleanBPF {
 		cleanups = append(cleanups, bpfCleanup{})
 	}
 

--- a/contrib/packaging/docker/init-container.sh
+++ b/contrib/packaging/docker/init-container.sh
@@ -1,6 +1,18 @@
 #!/bin/sh
 
-cilium cleanup -f
+# Check for CLEAN_CILIUM_BPF_STATE and CLEAN_CILIUM_STATE
+# is there for backwards compatibility as we've used those
+# two env vars in our old kubernetes yaml files.
+
+if [ "${CILIUM_BPF_STATE}" = "true" ] \
+   || [ "${CLEAN_CILIUM_BPF_STATE}" = "true" ]; then
+	cilium cleanup -f --bpf-state
+fi
+
+if [ "${CILIUM_ALL_STATE}" = "true" ] \
+    || [ "${CLEAN_CILIUM_STATE}" = "true" ]; then
+	cilium cleanup -f --all-state
+fi
 
 if [ "${CILIUM_WAIT_BPF_MOUNT}" = "true" ]; then
 	until mount | grep bpf; do echo "BPF filesystem is not mounted yet"; sleep 1; done


### PR DESCRIPTION
when no flags(--all-state|--bpf-state) are specified fallback to
--all-state to keep the previous cilium cleanup behaviour

Fixes: 6145cb56c89086 ("k8s: Merge initContainer cleanup with cilium cleanup")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8031)
<!-- Reviewable:end -->
