### PR TITLE
CI: Consolidate Vagrant box information into 1 file

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,13 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+# The source of truth for vagrant box versions.
+# Sets SERVER_BOX, SERVER_VERSION, NETNEXT_SERVER_BOXET and NEXT_SERVER_VERSION
+# Accepts overrides from env variables
+require_relative 'vagrant_box_defaults.rb'
+$SERVER_BOX = (ENV['SERVER_BOX'] || $SERVER_BOX)
+$SERVER_VERSION= (ENV['SERVER_VERSION'] || $SERVER_VERSION)
+
 Vagrant.require_version ">= 2.0.0"
 
 if ARGV.first == "up" && ENV['CILIUM_SCRIPT'] != 'true'
@@ -124,7 +131,7 @@ Vagrant.configure(2) do |config|
         vb.customize ["modifyvm", :id, "--audio", "none"]
 
         config.vm.box = "cilium/ubuntu-dev"
-        config.vm.box_version = "151"
+        config.vm.box_version = $SERVER_VERSION
         vb.memory = ENV['VM_MEMORY'].to_i
         vb.cpus = ENV['VM_CPUS'].to_i
         if ENV["NFS"] then

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -2,15 +2,20 @@
 # vi: set ft=ruby
 Vagrant.require_version ">= 2.2.0"
 
+# The source of truth for vagrant box versions.
+# Sets SERVER_BOX, SERVER_VERSION, NETNEXT_SERVER_BOXET and NEXT_SERVER_VERSION
+# Accepts overrides from env variables
+require_relative '../vagrant_box_defaults.rb'
+$SERVER_BOX = (ENV['SERVER_BOX'] || $SERVER_BOX)
+$SERVER_VERSION= (ENV['SERVER_VERSION'] || $SERVER_VERSION)
+$NETNEXT_SERVER_BOX = (ENV['NETNEXT_SERVER_BOX'] || $NETNEXT_SERVER_BOX)
+$NETNEXT_SERVER_VERSION= (ENV['NETNEXT_SERVER_VERSION'] || $NETNEXT_SERVER_VERSION)
+
 $BUILD_NUMBER = ENV['BUILD_NUMBER'] || "0"
 $JOB_NAME = ENV['JOB_BASE_NAME'] || "LOCAL"
 $K8S_VERSION = ENV['K8S_VERSION'] || "1.14"
 $K8S_NODES = (ENV['K8S_NODES'] || "2").to_i
 $NFS = ENV['NFS']=="1"? true : false
-$SERVER_BOX = (ENV['SERVER_BOX'] || "cilium/ubuntu-dev")
-$SERVER_VERSION= "151"
-$NETNEXT_SERVER_BOX= "cilium/ubuntu-next"
-$NETNEXT_SERVER_VERSION= "23"
 $IPv6=(ENV['IPv6'] || "0")
 $CONTAINER_RUNTIME=(ENV['CONTAINER_RUNTIME'] || "docker")
 $CNI_INTEGRATION=(ENV['CNI_INTEGRATION'] || "")

--- a/vagrant_box_defaults.rb
+++ b/vagrant_box_defaults.rb
@@ -1,0 +1,8 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby
+Vagrant.require_version ">= 2.2.0"
+
+$SERVER_BOX = "cilium/ubuntu-dev"
+$SERVER_VERSION= "151"
+$NETNEXT_SERVER_BOX= "cilium/ubuntu-next"
+$NETNEXT_SERVER_VERSION= "23"


### PR DESCRIPTION
Setting the vagrant box name and version is needed for opertions not
directly done inside the test runs. Placing these versions in 1 place,
where they can be more easily parsed, allows us to build scripts that
can consume this data during CI provisioning. This also reduced a
possible mismatch between the dev vm and the CI VM versions.

nebril and I need something like this to simplify pre-caching vagrant images for backports. Currently, these are potentially pruned at the start of each build. This then causes backport CI runs to re-download them (and fail!)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8033)
<!-- Reviewable:end -->
