### PR TITLE
cilium: fix bpf metrics direction string

### DIFF
--- a/pkg/policy/trafficdirection/trafficdirection.go
+++ b/pkg/policy/trafficdirection/trafficdirection.go
@@ -19,13 +19,13 @@ type TrafficDirection uint8
 
 const (
 	// Invalid represents an invalid traffic direction.
-	Invalid TrafficDirection = 2
+	Invalid TrafficDirection = 0
 
 	// Egress represents egress traffic.
-	Egress TrafficDirection = 1
+	Egress TrafficDirection = 2
 
 	// Ingress represents ingress traffic.
-	Ingress TrafficDirection = 0
+	Ingress TrafficDirection = 1
 )
 
 // Uint8 normalizes the TrafficDirection for insertion into BPF maps.


### PR DESCRIPTION
'cilium bpf metrics list' was not reporting direction string correctly
resolve by aligning direction enum with bpf/lib/common.h

Old output,

REASON                       DIRECTION   PACKETS   BYTES
Decrypted packet             Egress      133503    19460385
Not a local target address   Egress      35752     2649216
Plaintext packet             Egress      136589    27255278
Success                      Egress      178538    30187364                                                                          Success                      Unknown     309766    55471316                                                                          Unsupported L3 protocol      Unknown     51        3798

In the above "Decrypted packet" is marked in BPF datapath as INGRESS,
but is reported as egress. In the new output,

$ kubectl exec -n cilium cilium-tlr28 -- cilium bpf metrics list
REASON                       DIRECTION   PACKETS   BYTES
Decrypted packet             Ingress     227499    33356006
Not a local target address   Ingress     169955    12580214
Plaintext packet             Ingress     232746    46630220
Success                      Egress      530483    124463343
Success                      Ingress     308415    57890891
Unsupported L3 protocol      Egress      110       8292

Signed-off-by: John Fastabend <john.fastabend@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8042)
<!-- Reviewable:end -->
