### PR TITLE
CI: WithTimeout channel buffering

### DIFF
--- a/test/helpers/ssh_command.go
+++ b/test/helpers/ssh_command.go
@@ -138,7 +138,7 @@ func ImportSSHconfig(config []byte) (SSHConfigs, error) {
 // copyWait runs an instance of io.Copy() in a goroutine, and returns a channel
 // to receive the error result.
 func copyWait(dst io.Writer, src io.Reader) chan error {
-	c := make(chan error)
+	c := make(chan error, 1)
 	go func() {
 		_, err := io.Copy(dst, src)
 		c <- err

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -124,7 +124,7 @@ func WithTimeout(body func() bool, msg string, config *TimeoutConfig) error {
 		return fmt.Errorf("Timeout config Ticker interval too short (must be at least 1 second): %v", config.Ticker)
 	}
 
-	bodyChan := make(chan bool)
+	bodyChan := make(chan bool, 1)
 
 	asyncBody := func(ch chan bool) {
 		success := body()


### PR DESCRIPTION
We seem to still get stuck in WithTimeout. I've made bodyChan buffered, which should allow the asyncBody goroutine exit in the case where it returns from body after a timeout has occurred, and nothing remains reading bodyChan. I made a similar change to copyWait. Finally, I stopped closing bodyChan in WaitTimeout since any read on that channel would then result in a false, an that could cause WaitTimeout to loop again (this isn't happening, however, since the logic doesn't allow for that).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8043)
<!-- Reviewable:end -->
