### PR TITLE
Envoy: Use an image with injection fix.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:f65bc191a9b99d7bdc6288821d5ee1fe2517f4db as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:02348da5500c791539e06f02ef4a8b7f95a030c1 as cilium-envoy
 
 #
 # Cilium incremental build. Should be fast given builder-deps is up-to-date!

--- a/pkg/envoy/envoy_test.go
+++ b/pkg/envoy/envoy_test.go
@@ -172,7 +172,7 @@ func (s *EnvoySuite) TestEnvoyNACK(c *C) {
 
 	err = s.waitForProxyCompletion()
 	c.Assert(err, Not(IsNil))
-	c.Assert(err, checker.DeepEquals, &xds.ProxyError{Err: xds.ErrNackReceived, Detail: "Error adding/updating listener listener:22: cannot bind '[::]:22': Address already in use"})
+	c.Assert(err, checker.DeepEquals, &xds.ProxyError{Err: xds.ErrNackReceived, Detail: "Error adding/updating listener(s) listener:22: cannot bind '[::]:22': Address already in use"})
 
 	s.waitGroup = completion.NewWaitGroup(ctx)
 	// Remove listener1

--- a/proxylib/proxylib/test_util.go
+++ b/proxylib/proxylib/test_util.go
@@ -116,4 +116,9 @@ func (conn *Connection) CheckOnData(c *C, reply, endStream bool, data *[][]byte,
 	buf := conn.ReplyBuf
 	c.Check(*buf, DeepEquals, expReplyBuf, Commentf("Inject buffer mismatch"))
 	*buf = (*buf)[:0] // make empty again
+
+	// Clear the same-direction inject buffer, simulating the datapath forwarding the injected data
+	injectBuf := conn.getInjectBuf(reply)
+	*injectBuf = (*injectBuf)[:0]
+	log.Debugf("proxylib test helper: Cleared inject buf, used %d/%d", len(*injectBuf), cap(*injectBuf))
 }


### PR DESCRIPTION
Cilium network filter failed to call back to proxylib when the OnData
call returned with a full inject buffer. Use a newer Envoy image that
fixes this.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8047)
<!-- Reviewable:end -->
