### PR TITLE
pkg/ipcache: initialize globalmap at import time

### DIFF
--- a/pkg/ipcache/kvstore.go
+++ b/pkg/ipcache/kvstore.go
@@ -49,7 +49,7 @@ var (
 
 	// globalMap wraps the kvstore and provides reference-tracking for keys
 	// that are upserted or released from the kvstore.
-	globalMap *kvReferenceCounter
+	globalMap = newKVReferenceCounter(kvstoreImplementation{})
 
 	setupIPIdentityWatcher sync.Once
 )
@@ -385,7 +385,6 @@ var (
 // in the key-value store.
 func InitIPIdentityWatcher() {
 	setupIPIdentityWatcher.Do(func() {
-		globalMap = newKVReferenceCounter(kvstoreImplementation{})
 		go func() {
 			log.Info("Starting IP identity watcher")
 			watcher = NewIPIdentityWatcher(kvstore.Client())


### PR DESCRIPTION
globalMap can be initialized at import time so there's no really need
to call InitIPIdentityWatcher to initialize this map.

Signed-off-by: André Martins <andre@cilium.io>

```release-note
Avoid panic of uninitialized variable when running with clustermesh 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8057)
<!-- Reviewable:end -->
