### PR TITLE
pkg/endpoint: fix assignment in nil map on restore

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -991,6 +991,9 @@ func (e *Endpoint) SetDefaultOpts(opts *option.IntOptions) {
 	if e.Options.Library == nil {
 		e.Options.Library = &EndpointMutableOptionLibrary
 	}
+	if e.Options.Opts == nil {
+		e.Options.Opts = option.OptionMap{}
+	}
 
 	if opts != nil {
 		epOptLib := option.GetEndpointMutableOptionLibrary()


### PR DESCRIPTION
If an endpoint is restored it can have its internal options map
uninitialized. We need to check if the map is nil and created it if
necessary.

Signed-off-by: André Martins <andre@cilium.io>

```release-note
pkg/endpoint: fix unlikely assignment to entry in nil map on endpoint restoration
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8066)
<!-- Reviewable:end -->
