### PR TITLE
cni: Fix incorrect logging in failure case

### DIFF
--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -371,7 +371,7 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 		}
 		defer func() {
 			if err != nil {
-				if err2 := netlink.LinkDel(veth); err != nil {
+				if err2 := netlink.LinkDel(veth); err2 != nil {
 					logger.WithError(err2).WithField(logfields.Veth, veth.Name).Warn("failed to clean up and delete veth")
 				}
 			}


### PR DESCRIPTION
This failure case should only trigger logging when the deletion of the
veth fails during an endpoint add request failure.

Fixes: b859b6d83c7d ("cni: Fix unexpected end of JSON input on errors")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8067)
<!-- Reviewable:end -->
