### PR TITLE
Make policymap size configurable

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -23,6 +23,7 @@ cilium-agent [flags]
       --bpf-compile-debug                          Enable debugging of the BPF compilation process
       --bpf-ct-global-any-max int                  Maximum number of entries in non-TCP CT table (default 262144)
       --bpf-ct-global-tcp-max int                  Maximum number of entries in TCP CT table (default 1000000)
+      --bpf-policy-map-max int                     Maximum number of entries in endpoint policy map (per endpoint) (default 16384)
       --bpf-root string                            Path to BPF filesystem
       --cgroup-root string                         Path to Cgroup2 filesystem
       --cluster-id int                             Unique identifier of the cluster

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -70,6 +70,7 @@ import (
 	"github.com/cilium/cilium/pkg/maps/lbmap"
 	"github.com/cilium/cilium/pkg/maps/lxcmap"
 	"github.com/cilium/cilium/pkg/maps/metricsmap"
+	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/maps/sockmap"
 	"github.com/cilium/cilium/pkg/maps/tunnel"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
@@ -947,6 +948,7 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 	}
 
 	ctmap.InitMapInfo(option.Config.CTMapEntriesGlobalTCP, option.Config.CTMapEntriesGlobalAny)
+	policymap.InitMapInfo(option.Config.PolicyMapMaxEntries)
 
 	if option.Config.EnableIPSec {
 		var spi uint8

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -708,6 +708,9 @@ func init() {
 	flags.Int(option.CTMapEntriesGlobalAnyName, option.CTMapEntriesGlobalAnyDefault, "Maximum number of entries in non-TCP CT table")
 	option.BindEnvWithLegacyEnvFallback(option.CTMapEntriesGlobalAnyName, "CILIUM_GLOBAL_CT_MAX_ANY")
 
+	flags.Int(option.PolicyMapEntriesName, defaults.PolicyMapEntries, "Maximum number of entries in endpoint policy map (per endpoint)")
+	option.BindEnv(option.PolicyMapEntriesName)
+
 	flags.String(option.CMDRef, "", "Path to cmdref output directory")
 	flags.MarkHidden(option.CMDRef)
 	option.BindEnv(option.CMDRef)

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -195,6 +195,11 @@ const (
 	// connection tracking garbage collection
 	ConntrackGCStartingInterval = 5 * time.Minute
 
+	// PolicyMapEntries is the default number of entries allowed in an
+	// endpoint's policymap, ie the maximum number of peer identities that
+	// the endpoint could send/receive traffic to/from.
+	PolicyMapEntries = 16384 // Cilium 1.5 and earlier value
+
 	// K8sEventHandover enables use of the kvstore to optimize Kubernetes
 	// event handling by listening for k8s events in the operator and
 	// mirroring it into the kvstore for reduced overhead in large

--- a/pkg/maps/eppolicymap/eppolicymap.go
+++ b/pkg/maps/eppolicymap/eppolicymap.go
@@ -71,7 +71,7 @@ func CreateEPPolicyMap() {
 		fd, err := bpf.CreateMap(bpf.BPF_MAP_TYPE_HASH,
 			uint32(unsafe.Sizeof(policymap.PolicyKey{})),
 			uint32(unsafe.Sizeof(policymap.PolicyEntry{})),
-			policymap.MaxEntries,
+			uint32(policymap.MaxEntries),
 			0, 0, innerMapName)
 
 		if err != nil {

--- a/pkg/maps/policymap/policymap.go
+++ b/pkg/maps/policymap/policymap.go
@@ -37,10 +37,6 @@ const (
 	// with that identity on that port for that direction.
 	MapName = CallMapName + "_"
 
-	// MaxEntries is the upper limit of entries in the per endpoint policy
-	// table
-	MaxEntries = 16384
-
 	// ProgArrayMaxEntries is the upper limit of entries in the program
 	// array for the tail calls to jump into the endpoint specific policy
 	// programs. This number *MUST* be identical to the maximum endponit ID.
@@ -52,7 +48,13 @@ const (
 	AllPorts = uint16(0)
 )
 
-var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "map-policy")
+var (
+	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "map-policy")
+
+	// MaxEntries is the upper limit of entries in the per endpoint policy
+	// table
+	MaxEntries = 16384
+)
 
 type PolicyMap struct {
 	*bpf.Map
@@ -287,4 +289,9 @@ func Open(path string) (*PolicyMap, error) {
 		return nil, err
 	}
 	return m, nil
+}
+
+// InitMapInfo updates the map info defaults for policy maps.
+func InitMapInfo(maxEntries int) {
+	MaxEntries = maxEntries
 }

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -354,6 +354,9 @@ const (
 	CTMapEntriesGlobalTCPName    = "bpf-ct-global-tcp-max"
 	CTMapEntriesGlobalAnyName    = "bpf-ct-global-any-max"
 
+	// PolicyMapEntriesName configures max entries for BPF policymap.
+	PolicyMapEntriesName = "bpf-policy-map-max"
+
 	// LogSystemLoadConfigName is the name of the option to enable system
 	// load loggging
 	LogSystemLoadConfigName = "log-system-load"
@@ -700,6 +703,10 @@ type DaemonConfig struct {
 	// CTMapEntriesGlobalAny is the maximum number of conntrack entries
 	// allowed in each non-TCP CT table for IPv4/IPv6.
 	CTMapEntriesGlobalAny int
+
+	// PolicyMapMaxEntries is the maximum number of peer identities that an
+	// endpoint may allow traffic to exchange traffic with.
+	PolicyMapMaxEntries int
 
 	// DisableCiliumEndpointCRD disables the use of CiliumEndpoint CRD
 	DisableCiliumEndpointCRD bool
@@ -1080,6 +1087,17 @@ func (c *DaemonConfig) Validate() error {
 			c.CTMapEntriesGlobalTCP, c.CTMapEntriesGlobalAny, ctTableMax)
 	}
 
+	policyMapMin := (1 << 8)
+	policyMapMax := (1 << 16)
+	if c.PolicyMapMaxEntries < policyMapMin {
+		return fmt.Errorf("Specified PolicyMap max entries %d must exceed minimum %d",
+			c.PolicyMapMaxEntries, policyMapMin)
+	}
+	if c.PolicyMapMaxEntries > policyMapMax {
+		return fmt.Errorf("Specified PolicyMap max entries %d must not exceed maximum %d",
+			c.PolicyMapMaxEntries, policyMapMax)
+	}
+
 	return nil
 }
 
@@ -1238,6 +1256,7 @@ func (c *DaemonConfig) Populate() {
 	c.FlannelMasterDevice = viper.GetString(FlannelMasterDevice)
 	c.FlannelUninstallOnExit = viper.GetBool(FlannelUninstallOnExit)
 	c.FlannelManageExistingContainers = viper.GetBool(FlannelManageExistingContainers)
+	c.PolicyMapMaxEntries = viper.GetInt(PolicyMapEntriesName)
 	c.PProf = viper.GetBool(PProf)
 	c.PreAllocateMaps = viper.GetBool(PreAllocateMapsName)
 	c.PrependIptablesChains = viper.GetBool(PrependIptablesChainsName)


### PR DESCRIPTION
Make the policymap size for an endpoint configurable through a new configmap option, `bpf-policy-map-max`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8071)
<!-- Reviewable:end -->
