### PR TITLE
ipam: Fix IPAM debuginfo race on bootstrap

### DIFF
--- a/pkg/ipam/types.go
+++ b/pkg/ipam/types.go
@@ -62,6 +62,10 @@ type IPAM struct {
 // DebugStatus implements debug.StatusObject to provide debug status collection
 // ability
 func (ipam *IPAM) DebugStatus() string {
+	if ipam == nil {
+		return "<nil>"
+	}
+
 	ipam.allocatorMutex.RLock()
 	str := spew.Sdump(ipam)
 	ipam.allocatorMutex.RUnlock()


### PR DESCRIPTION
d.ipam can still be nil when debuginfo is called. Fortunately the panic was
captured in the recover() of the API handler.

Fixes: 9ed8b372c14 ("ipam: Provide ipam information in debuginfo")
Fixes: #8074

This is unreleased so no backport required

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8075)
<!-- Reviewable:end -->
