### PR TITLE
pkg/maps: use pointer in receivers for GetKeyPtr and GetValuePtr

### DIFF
--- a/pkg/maps/encrypt/encrypt.go
+++ b/pkg/maps/encrypt/encrypt.go
@@ -48,10 +48,10 @@ func (v EncryptValue) String() string {
 }
 
 // GetValuePtr returns the unsafe pointer to the BPF value.
-func (v EncryptValue) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(&v) }
+func (v *EncryptValue) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(v) }
 
 // GetKeyPtr returns the unsafe pointer to the BPF key
-func (k EncryptKey) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(&k) }
+func (k *EncryptKey) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(k) }
 
 // NewValue returns a new empty instance of the structure represeting the BPF
 // map value

--- a/pkg/maps/eppolicymap/eppolicymap.go
+++ b/pkg/maps/eppolicymap/eppolicymap.go
@@ -90,7 +90,7 @@ func CreateEPPolicyMap() {
 func (v EPPolicyValue) String() string { return fmt.Sprintf("fd=%d", v.Fd) }
 
 // GetValuePtr returns the unsafe value pointer to the Endpoint Policy fd
-func (v EPPolicyValue) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(&v.Fd) }
+func (v *EPPolicyValue) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(v) }
 
 // NewValue returns a new empty instance of the Endpoint Policy fd
 func (k EndpointKey) NewValue() bpf.MapValue { return &EPPolicyValue{} }

--- a/pkg/maps/sockmap/sockmap.go
+++ b/pkg/maps/sockmap/sockmap.go
@@ -56,10 +56,10 @@ func (v SockmapValue) String() string {
 }
 
 // GetValuePtr returns the unsafe pointer to the BPF value.
-func (v SockmapValue) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(&v) }
+func (v *SockmapValue) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(v) }
 
 // GetKeyPtr returns the unsafe pointer to the BPF key
-func (k SockmapKey) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(&k) }
+func (k *SockmapKey) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(k) }
 
 // NewValue returns a new empty instance of the structure representing the BPF
 // map value


### PR DESCRIPTION
Not using a pointer in the receivers causes Get{Key,Value}Ptr to return
a pointer of the copy of the receiver structure being called. This can
have consequences if we use Get{Key,Value}Ptr to store data and expect
the data to still be present in the original structure.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8083)
<!-- Reviewable:end -->
