### PR TITLE
proxylib: Fix egress enforcement

### DIFF
--- a/proxylib/proxylib/connection.go
+++ b/proxylib/proxylib/connection.go
@@ -174,7 +174,11 @@ func (connection *Connection) OnData(reply, endStream bool, data *[][]byte, filt
 
 func (connection *Connection) Matches(l7 interface{}) bool {
 	log.Debugf("proxylib: Matching policy on connection %v", connection)
-	return connection.Instance.PolicyMatches(connection.PolicyName, connection.Ingress, connection.Port, connection.SrcId, l7)
+	remoteID := connection.DstId
+	if connection.Ingress {
+		remoteID = connection.SrcId
+	}
+	return connection.Instance.PolicyMatches(connection.PolicyName, connection.Ingress, connection.Port, remoteID, l7)
 }
 
 // getInjectBuf return the pointer to the inject buffer slice header for the indicated direction

--- a/proxylib/proxylib/policymap.go
+++ b/proxylib/proxylib/policymap.go
@@ -251,6 +251,7 @@ func newPolicyInstance(config *cilium.NetworkPolicy) *PolicyInstance {
 }
 
 func (p *PolicyInstance) Matches(ingress bool, port, remoteId uint32, l7 interface{}) bool {
+	log.Debugf("NPDS::PolicyInstance::Matches(ingress: %v, port: %d, remoteId: %d, l7: %v (policy: %v)", ingress, port, remoteId, l7, p.protobuf)
 	if ingress {
 		return p.Ingress.Matches(port, remoteId, l7)
 	}


### PR DESCRIPTION
Pass the destination ID of egress connections for policy enforcement.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8097)
<!-- Reviewable:end -->
