### PR TITLE
Recover from ginkgo fail in WithTimeout helper

### DIFF
--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -127,6 +127,7 @@ func WithTimeout(body func() bool, msg string, config *TimeoutConfig) error {
 	bodyChan := make(chan bool, 1)
 
 	asyncBody := func(ch chan bool) {
+		defer ginkgo.GinkgoRecover()
 		success := body()
 		ch <- success
 		if success {


### PR DESCRIPTION
If WithTimeout is called with func which is able to panic, ginkgo is not
able to get information about this panic without GinkgoRecover.

Fixes: #7796

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8105)
<!-- Reviewable:end -->
