### PR TITLE
policy: fix wildcarding at L7 for DNS

### DIFF
--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -146,7 +146,11 @@ func wildcardL3L4Rule(proto api.L4Proto, port int, endpoints api.EndpointSelecto
 		case ParserTypeDNS:
 			// Wildcard at L7 all the endpoints allowed at L3 or L4.
 			for _, sel := range endpoints {
-				rule := api.PortRuleDNS{}
+				// Wildcarding at L7 for DNS is specified via allowing all via
+				// MatchPattern!
+				rule := api.PortRuleDNS{
+					MatchPattern: "*",
+				}
 				rule.Sanitize()
 				cs := filter.cacheIdentitySelector(sel, selectorCache)
 				filter.L7RulesPerEp[cs] = api.L7Rules{


### PR DESCRIPTION
Previously, if there was L7 policy applying to DNS at a specific port, (e.g.
port 53), for a specific selector (e.g., the selector representing the
"kube-system" namespace), and another rule which allowed all at L3 for the
"kube-system" namespace, the behavior which was expected is to allow *all* DNS
traffic at L7 on port 53, since the second rule allows all at L3 (which thus
allows all at L4, and at L7). However, the FQDNSelector which was being used to
synthesize allow-all at L7 was an empty selector (with no "MatchName" nor no
"MatchPattern" specified). This is treated by the DNS proxying code as allowing
*no* DNS requests at all, which is incorrect. So, when wildcarding at L7, be
sure to specify allow-all via " "matchPattern": "*" " in the synthesized
selector which is utilized by the DNS proxy.

Signed-off by: Ian Vernon <ian@cilium.io>

I still need to add testing for this. I performed manual testing to ensure that this worked. It's most likely simplest to add a basic Ginkgo test that piggybacks on top of the existing FQDN Ginkgo tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8106)
<!-- Reviewable:end -->
