### PR TITLE
daemon: split out parts of `NewDaemon` into separate functions

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1061,52 +1061,7 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 		bootstrapStats.k8sInit.End(true)
 	}
 
-	// If the device has been specified, the IPv4AllocPrefix and the
-	// IPv6AllocPrefix were already allocated before the k8s.Init().
-	//
-	// If the device hasn't been specified, k8s.Init() allocated the
-	// IPv4AllocPrefix and the IPv6AllocPrefix from k8s node annotations.
-	//
-	// If k8s.Init() failed to retrieve the IPv4AllocPrefix we can try to derive
-	// it from an existing node_config.h file or from previous cilium_host
-	// interfaces.
-	//
-	// Then, we will calculate the IPv4 or IPv6 alloc prefix based on the IPv6
-	// or IPv4 alloc prefix, respectively, retrieved by k8s node annotations.
-	bootstrapStats.ipam.Start()
-	log.Info("Initializing node addressing")
-
-	node.SetIPv4ClusterCidrMaskSize(option.Config.IPv4ClusterCIDRMaskSize)
-
-	if option.Config.IPv4Range != AutoCIDR {
-		allocCIDR, err := cidr.ParseCIDR(option.Config.IPv4Range)
-		if err != nil {
-			log.WithError(err).WithField(logfields.V4Prefix, option.Config.IPv4Range).Fatal("Invalid IPv4 allocation prefix")
-		}
-		node.SetIPv4AllocRange(allocCIDR)
-	}
-
-	if option.Config.IPv6Range != AutoCIDR {
-		_, net, err := net.ParseCIDR(option.Config.IPv6Range)
-		if err != nil {
-			log.WithError(err).WithField(logfields.V6Prefix, option.Config.IPv6Range).Fatal("Invalid IPv6 allocation prefix")
-		}
-
-		if err := node.SetIPv6NodeRange(net); err != nil {
-			log.WithError(err).WithField(logfields.V6Prefix, net).Fatal("Invalid per node IPv6 allocation prefix")
-		}
-	}
-
-	if err := node.AutoComplete(); err != nil {
-		log.WithError(err).Fatal("Cannot autocomplete node addresses")
-	}
-
-	// Set up ipam conf after init() because we might be running d.conf.KVStoreIPv4Registration
-	d.ipam = ipam.NewIPAM(dp.LocalNodeAddressing(), ipam.Configuration{
-		EnableIPv4: option.Config.EnableIPv4,
-		EnableIPv6: option.Config.EnableIPv6,
-	})
-	bootstrapStats.ipam.End(true)
+	d.bootstrapIPAM()
 
 	if err := d.bootstrapWorkloads(); err != nil {
 		return nil, nil, err
@@ -1288,6 +1243,55 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 	bootstrapStats.fqdn.End(true)
 
 	return &d, restoredEndpoints, nil
+}
+
+func (d *Daemon) bootstrapIPAM() {
+	// If the device has been specified, the IPv4AllocPrefix and the
+	// IPv6AllocPrefix were already allocated before the k8s.Init().
+	//
+	// If the device hasn't been specified, k8s.Init() allocated the
+	// IPv4AllocPrefix and the IPv6AllocPrefix from k8s node annotations.
+	//
+	// If k8s.Init() failed to retrieve the IPv4AllocPrefix we can try to derive
+	// it from an existing node_config.h file or from previous cilium_host
+	// interfaces.
+	//
+	// Then, we will calculate the IPv4 or IPv6 alloc prefix based on the IPv6
+	// or IPv4 alloc prefix, respectively, retrieved by k8s node annotations.
+	bootstrapStats.ipam.Start()
+	log.Info("Initializing node addressing")
+
+	node.SetIPv4ClusterCidrMaskSize(option.Config.IPv4ClusterCIDRMaskSize)
+
+	if option.Config.IPv4Range != AutoCIDR {
+		allocCIDR, err := cidr.ParseCIDR(option.Config.IPv4Range)
+		if err != nil {
+			log.WithError(err).WithField(logfields.V4Prefix, option.Config.IPv4Range).Fatal("Invalid IPv4 allocation prefix")
+		}
+		node.SetIPv4AllocRange(allocCIDR)
+	}
+
+	if option.Config.IPv6Range != AutoCIDR {
+		_, net, err := net.ParseCIDR(option.Config.IPv6Range)
+		if err != nil {
+			log.WithError(err).WithField(logfields.V6Prefix, option.Config.IPv6Range).Fatal("Invalid IPv6 allocation prefix")
+		}
+
+		if err := node.SetIPv6NodeRange(net); err != nil {
+			log.WithError(err).WithField(logfields.V6Prefix, net).Fatal("Invalid per node IPv6 allocation prefix")
+		}
+	}
+
+	if err := node.AutoComplete(); err != nil {
+		log.WithError(err).Fatal("Cannot autocomplete node addresses")
+	}
+
+	// Set up ipam conf after init() because we might be running d.conf.KVStoreIPv4Registration
+	d.ipam = ipam.NewIPAM(d.datapath.LocalNodeAddressing(), ipam.Configuration{
+		EnableIPv4: option.Config.EnableIPv4,
+		EnableIPv6: option.Config.EnableIPv6,
+	})
+	bootstrapStats.ipam.End(true)
 }
 
 func (d *Daemon) bootstrapWorkloads() error {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1108,35 +1108,8 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 	})
 	bootstrapStats.ipam.End(true)
 
-	if option.Config.WorkloadsEnabled() {
-		bootstrapStats.workloadsInit.Start()
-		// workaround for to use the values of the deprecated dockerEndpoint
-		// variable if it is set with a different value than defaults.
-		defaultDockerEndpoint := workloads.GetRuntimeDefaultOpt(workloads.Docker, "endpoint")
-		if defaultDockerEndpoint != option.Config.DockerEndpoint {
-			option.Config.ContainerRuntimeEndpoint[string(workloads.Docker)] = option.Config.DockerEndpoint
-			log.Warn(`"docker" flag is deprecated.` +
-				`Please use "--container-runtime-endpoint=docker=` + defaultDockerEndpoint + `" instead`)
-		}
-
-		opts := make(map[workloads.WorkloadRuntimeType]map[string]string)
-		for rt, ep := range option.Config.ContainerRuntimeEndpoint {
-			opts[workloads.WorkloadRuntimeType(rt)] = make(map[string]string)
-			opts[workloads.WorkloadRuntimeType(rt)][workloads.EpOpt] = ep
-		}
-		if opts[workloads.Docker] == nil {
-			opts[workloads.Docker] = make(map[string]string)
-		}
-		opts[workloads.Docker][workloads.DatapathModeOpt] = option.Config.DatapathMode
-
-		// Workloads must be initialized after IPAM has started as it requires
-		// to allocate IPs.
-		if err := workloads.Setup(d.ipam, option.Config.Workloads, opts); err != nil {
-			return nil, nil, fmt.Errorf("unable to setup workload: %s", err)
-		}
-
-		log.Infof("Container runtime options set: %s", workloads.GetRuntimeOptions())
-		bootstrapStats.workloadsInit.End(true)
+	if err := d.bootstrapWorkloads(); err != nil {
+		return nil, nil, err
 	}
 
 	bootstrapStats.restore.Start()
@@ -1315,6 +1288,40 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 	bootstrapStats.fqdn.End(true)
 
 	return &d, restoredEndpoints, nil
+}
+
+func (d *Daemon) bootstrapWorkloads() error {
+	if option.Config.WorkloadsEnabled() {
+		bootstrapStats.workloadsInit.Start()
+		// workaround for to use the values of the deprecated dockerEndpoint
+		// variable if it is set with a different value than defaults.
+		defaultDockerEndpoint := workloads.GetRuntimeDefaultOpt(workloads.Docker, "endpoint")
+		if defaultDockerEndpoint != option.Config.DockerEndpoint {
+			option.Config.ContainerRuntimeEndpoint[string(workloads.Docker)] = option.Config.DockerEndpoint
+			log.Warn(`"docker" flag is deprecated.` +
+				`Please use "--container-runtime-endpoint=docker=` + defaultDockerEndpoint + `" instead`)
+		}
+
+		opts := make(map[workloads.WorkloadRuntimeType]map[string]string)
+		for rt, ep := range option.Config.ContainerRuntimeEndpoint {
+			opts[workloads.WorkloadRuntimeType(rt)] = make(map[string]string)
+			opts[workloads.WorkloadRuntimeType(rt)][workloads.EpOpt] = ep
+		}
+		if opts[workloads.Docker] == nil {
+			opts[workloads.Docker] = make(map[string]string)
+		}
+		opts[workloads.Docker][workloads.DatapathModeOpt] = option.Config.DatapathMode
+
+		// Workloads must be initialized after IPAM has started as it requires
+		// to allocate IPs.
+		if err := workloads.Setup(d.ipam, option.Config.Workloads, opts); err != nil {
+			return fmt.Errorf("unable to setup workload: %s", err)
+		}
+
+		log.Infof("Container runtime options set: %s", workloads.GetRuntimeOptions())
+		bootstrapStats.workloadsInit.End(true)
+	}
+	return nil
 }
 
 // Close shuts down a daemon

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -938,8 +938,6 @@ func (d *Daemon) allocateDatapathIPs(family datapath.NodeAddressingFamily) (rout
 
 // NewDaemon creates and returns a new Daemon with the parameters set in c.
 func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
-	var authKeySize int
-
 	bootstrapStats.daemonInit.Start()
 	// Validate the daemon-specific global options.
 	if err := option.Config.Validate(); err != nil {
@@ -948,20 +946,9 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 
 	ctmap.InitMapInfo(option.Config.CTMapEntriesGlobalTCP, option.Config.CTMapEntriesGlobalAny)
 
-	if option.Config.EnableIPSec {
-		var spi uint8
-		var err error
-
-		authKeySize, spi, err = ipsec.LoadIPSecKeysFile(option.Config.IPSecKeyFile)
-		if err != nil {
-			return nil, nil, err
-		}
-		if option.Config.EnableIPv6 {
-			if err := ipsec.EnableIPv6Forwarding(); err != nil {
-				return nil, nil, err
-			}
-		}
-		node.SetIPsecKeyIdentity(spi)
+	authKeySize, err := setupIPSec()
+	if err != nil {
+		return nil, nil, err
 	}
 
 	mtuConfig := mtu.NewConfiguration(authKeySize, option.Config.EnableIPSec, option.Config.Tunnel != option.TunnelDisabled, option.Config.MTU)
@@ -1150,6 +1137,27 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 	bootstrapStats.fqdn.End(true)
 
 	return &d, restoredEndpoints, nil
+}
+
+func setupIPSec() (int, error) {
+	var authKeySize int
+
+	if option.Config.EnableIPSec {
+		var spi uint8
+		var err error
+
+		authKeySize, spi, err := ipsec.LoadIPSecKeysFile(option.Config.IPSecKeyFile)
+		if err != nil {
+			return authKeySize, err
+		}
+		if option.Config.EnableIPv6 {
+			if err := ipsec.EnableIPv6Forwarding(); err != nil {
+				return authKeySize, err
+			}
+		}
+		node.SetIPsecKeyIdentity(spi)
+	}
+	return authKeySize, nil
 }
 
 func (d *Daemon) allocateHealthIPs() error {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1184,27 +1184,7 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 	// well known identities have already been initialized above
 	go cache.InitIdentityAllocator(&d)
 
-	bootstrapStats.clusterMeshInit.Start()
-	if path := option.Config.ClusterMeshConfig; path != "" {
-		if option.Config.ClusterID == 0 {
-			log.Info("Cluster-ID is not specified, skipping ClusterMesh initialization")
-		} else {
-			log.WithField("path", path).Info("Initializing ClusterMesh routing")
-			clustermesh, err := clustermesh.NewClusterMesh(clustermesh.Configuration{
-				Name:            "clustermesh",
-				ConfigDirectory: path,
-				NodeKeyCreator:  nodeStore.KeyCreator,
-				ServiceMerger:   &d.k8sSvcCache,
-				NodeManager:     nodeMngr,
-			})
-			if err != nil {
-				log.WithError(err).Fatal("Unable to initialize ClusterMesh")
-			}
-
-			d.clustermesh = clustermesh
-		}
-	}
-	bootstrapStats.clusterMeshInit.End(true)
+	d.bootstrapClusterMesh(nodeMngr)
 
 	bootstrapStats.bpfBase.Start()
 	err = d.init()
@@ -1243,6 +1223,30 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 	bootstrapStats.fqdn.End(true)
 
 	return &d, restoredEndpoints, nil
+}
+
+func (d *Daemon) bootstrapClusterMesh(nodeMngr *nodemanager.Manager) {
+	bootstrapStats.clusterMeshInit.Start()
+	if path := option.Config.ClusterMeshConfig; path != "" {
+		if option.Config.ClusterID == 0 {
+			log.Info("Cluster-ID is not specified, skipping ClusterMesh initialization")
+		} else {
+			log.WithField("path", path).Info("Initializing ClusterMesh routing")
+			clustermesh, err := clustermesh.NewClusterMesh(clustermesh.Configuration{
+				Name:            "clustermesh",
+				ConfigDirectory: path,
+				NodeKeyCreator:  nodeStore.KeyCreator,
+				ServiceMerger:   &d.k8sSvcCache,
+				NodeManager:     nodeMngr,
+			})
+			if err != nil {
+				log.WithError(err).Fatal("Unable to initialize ClusterMesh")
+			}
+
+			d.clustermesh = clustermesh
+		}
+	}
+	bootstrapStats.clusterMeshInit.End(true)
 }
 
 func (d *Daemon) bootstrapIPAM() {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1077,82 +1077,9 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 	}
 	bootstrapStats.restore.End(true)
 
-	bootstrapStats.ipam.Start()
-	if option.Config.EnableIPv4 {
-		routerIP, err := d.allocateDatapathIPs(dp.LocalNodeAddressing().IPv4())
-		if err != nil {
-			return nil, nil, err
-		}
-		if routerIP != nil {
-			node.SetInternalIPv4(routerIP)
-		}
+	if err := d.allocateIPs(); err != nil {
+		return nil, nil, err
 	}
-
-	if option.Config.EnableIPv6 {
-		routerIP, err := d.allocateDatapathIPs(dp.LocalNodeAddressing().IPv6())
-		if err != nil {
-			return nil, nil, err
-		}
-		if routerIP != nil {
-			node.SetIPv6Router(routerIP)
-		}
-	}
-
-	log.Info("Addressing information:")
-	log.Infof("  Cluster-Name: %s", option.Config.ClusterName)
-	log.Infof("  Cluster-ID: %d", option.Config.ClusterID)
-	log.Infof("  Local node-name: %s", node.GetName())
-	log.Infof("  Node-IPv6: %s", node.GetIPv6())
-
-	if option.Config.EnableIPv6 {
-		log.Infof("  IPv6 node prefix: %s", node.GetIPv6NodeRange())
-		log.Infof("  IPv6 allocation prefix: %s", node.GetIPv6AllocRange())
-		log.Infof("  IPv6 router address: %s", node.GetIPv6Router())
-	}
-
-	log.Infof("  External-Node IPv4: %s", node.GetExternalIPv4())
-	log.Infof("  Internal-Node IPv4: %s", node.GetInternalIPv4())
-
-	if option.Config.EnableIPv4 {
-		log.Infof("  Cluster IPv4 prefix: %s", node.GetIPv4ClusterRange())
-		log.Infof("  IPv4 allocation prefix: %s", node.GetIPv4AllocRange())
-
-		// Allocate IPv4 service loopback IP
-		loopbackIPv4 := net.ParseIP(option.Config.LoopbackIPv4)
-		if loopbackIPv4 == nil {
-			return nil, restoredEndpoints, fmt.Errorf("Invalid IPv4 loopback address %s", option.Config.LoopbackIPv4)
-		}
-		node.SetIPv4Loopback(loopbackIPv4)
-		log.Infof("  Loopback IPv4: %s", node.GetIPv4Loopback().String())
-	}
-	bootstrapStats.ipam.End(true)
-
-	bootstrapStats.healthCheck.Start()
-	if option.Config.EnableHealthChecking {
-		if option.Config.EnableIPv4 {
-			health4, err := d.ipam.AllocateNextFamily(ipam.IPv4, "health")
-			if err != nil {
-				return nil, restoredEndpoints, fmt.Errorf("unable to allocate health IPs: %s,see https://cilium.link/ipam-range-full", err)
-			}
-
-			d.nodeDiscovery.LocalNode.IPv4HealthIP = health4
-			log.Debugf("IPv4 health endpoint address: %s", health4)
-		}
-
-		if option.Config.EnableIPv6 {
-			health6, err := d.ipam.AllocateNextFamily(ipam.IPv6, "health")
-			if err != nil {
-				if d.nodeDiscovery.LocalNode.IPv4HealthIP != nil {
-					d.ipam.ReleaseIP(d.nodeDiscovery.LocalNode.IPv4HealthIP)
-				}
-				return nil, restoredEndpoints, fmt.Errorf("unable to allocate health IPs: %s,see https://cilium.link/ipam-range-full", err)
-			}
-
-			d.nodeDiscovery.LocalNode.IPv6HealthIP = health6
-			log.Debugf("IPv6 health endpoint address: %s", health6)
-		}
-	}
-	bootstrapStats.healthCheck.End(true)
 
 	// Annotation of the k8s node must happen after discovery of the
 	// PodCIDR range and allocation of the health IPs.
@@ -1223,6 +1150,89 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 	bootstrapStats.fqdn.End(true)
 
 	return &d, restoredEndpoints, nil
+}
+
+func (d *Daemon) allocateHealthIPs() error {
+	bootstrapStats.healthCheck.Start()
+	if option.Config.EnableHealthChecking {
+		if option.Config.EnableIPv4 {
+			health4, err := d.ipam.AllocateNextFamily(ipam.IPv4, "health")
+			if err != nil {
+				return fmt.Errorf("unable to allocate health IPs: %s,see https://cilium.link/ipam-range-full", err)
+			}
+
+			d.nodeDiscovery.LocalNode.IPv4HealthIP = health4
+			log.Debugf("IPv4 health endpoint address: %s", health4)
+		}
+
+		if option.Config.EnableIPv6 {
+			health6, err := d.ipam.AllocateNextFamily(ipam.IPv6, "health")
+			if err != nil {
+				if d.nodeDiscovery.LocalNode.IPv4HealthIP != nil {
+					d.ipam.ReleaseIP(d.nodeDiscovery.LocalNode.IPv4HealthIP)
+				}
+				return fmt.Errorf("unable to allocate health IPs: %s,see https://cilium.link/ipam-range-full", err)
+			}
+
+			d.nodeDiscovery.LocalNode.IPv6HealthIP = health6
+			log.Debugf("IPv6 health endpoint address: %s", health6)
+		}
+	}
+	bootstrapStats.healthCheck.End(true)
+	return nil
+}
+
+func (d *Daemon) allocateIPs() error {
+	bootstrapStats.ipam.Start()
+	if option.Config.EnableIPv4 {
+		routerIP, err := d.allocateDatapathIPs(d.datapath.LocalNodeAddressing().IPv4())
+		if err != nil {
+			return err
+		}
+		if routerIP != nil {
+			node.SetInternalIPv4(routerIP)
+		}
+	}
+
+	if option.Config.EnableIPv6 {
+		routerIP, err := d.allocateDatapathIPs(d.datapath.LocalNodeAddressing().IPv6())
+		if err != nil {
+			return err
+		}
+		if routerIP != nil {
+			node.SetIPv6Router(routerIP)
+		}
+	}
+
+	log.Info("Addressing information:")
+	log.Infof("  Cluster-Name: %s", option.Config.ClusterName)
+	log.Infof("  Cluster-ID: %d", option.Config.ClusterID)
+	log.Infof("  Local node-name: %s", node.GetName())
+	log.Infof("  Node-IPv6: %s", node.GetIPv6())
+
+	if option.Config.EnableIPv6 {
+		log.Infof("  IPv6 node prefix: %s", node.GetIPv6NodeRange())
+		log.Infof("  IPv6 allocation prefix: %s", node.GetIPv6AllocRange())
+		log.Infof("  IPv6 router address: %s", node.GetIPv6Router())
+	}
+
+	log.Infof("  External-Node IPv4: %s", node.GetExternalIPv4())
+	log.Infof("  Internal-Node IPv4: %s", node.GetInternalIPv4())
+
+	if option.Config.EnableIPv4 {
+		log.Infof("  Cluster IPv4 prefix: %s", node.GetIPv4ClusterRange())
+		log.Infof("  IPv4 allocation prefix: %s", node.GetIPv4AllocRange())
+
+		// Allocate IPv4 service loopback IP
+		loopbackIPv4 := net.ParseIP(option.Config.LoopbackIPv4)
+		if loopbackIPv4 == nil {
+			return fmt.Errorf("Invalid IPv4 loopback address %s", option.Config.LoopbackIPv4)
+		}
+		node.SetIPv4Loopback(loopbackIPv4)
+		log.Infof("  Loopback IPv4: %s", node.GetIPv4Loopback().String())
+	}
+	bootstrapStats.ipam.End(true)
+	return d.allocateHealthIPs()
 }
 
 func (d *Daemon) bootstrapClusterMesh(nodeMngr *nodemanager.Manager) {


### PR DESCRIPTION
This makes the code more readable, as the function is quite long. Separating bootstrap into distinct functions will help ordering of initializing certain subsystems easier.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8107)
<!-- Reviewable:end -->
