### PR TITLE
fix: add annotate-k8s-node flag to daemon

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -18,6 +18,7 @@ cilium-agent [flags]
       --access-log string                          Path to access log of supported L7 requests observed
       --agent-labels strings                       Additional labels to identify this agent
       --allow-localhost string                     Policy when to allow local stack to reach local endpoints { auto | always | policy } (default "auto")
+      --annotate-k8s-node                          Annotate Kubernetes node (default true)
       --auto-direct-node-routes                    Enable automatic L2 routing between nodes
       --blacklist-conflicting-routes               Don't blacklist IP allocations conflicting with local non-cilium routes (default true)
       --bpf-compile-debug                          Enable debugging of the BPF compilation process

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1072,7 +1072,7 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 
 	// Annotation of the k8s node must happen after discovery of the
 	// PodCIDR range and allocation of the health IPs.
-	if k8s.IsEnabled() {
+	if k8s.IsEnabled() && option.Config.AnnotateK8sNode {
 		bootstrapStats.k8sInit.Start()
 		log.WithFields(logrus.Fields{
 			logfields.V4Prefix:       node.GetIPv4AllocRange(),
@@ -1091,6 +1091,8 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 			log.WithError(err).Warning("Cannot annotate k8s node with CIDR range")
 		}
 		bootstrapStats.k8sInit.End(true)
+	} else if !option.Config.AnnotateK8sNode {
+		log.Debug("Annotate k8s node is disabled.")
 	}
 
 	d.nodeDiscovery.StartDiscovery(node.GetName())

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -363,6 +363,9 @@ func init() {
 	flags.String(option.AllowLocalhost, option.AllowLocalhostAuto, "Policy when to allow local stack to reach local endpoints { auto | always | policy }")
 	option.BindEnv(option.AllowLocalhost)
 
+	flags.Bool(option.AnnotateK8sNode, defaults.AnnotateK8sNode, "Annotate Kubernetes node")
+	option.BindEnv(option.AnnotateK8sNode)
+
 	flags.Bool(option.BlacklistConflictingRoutes, defaults.BlacklistConflictingRoutes, "Don't blacklist IP allocations conflicting with local non-cilium routes")
 	option.BindEnv(option.BlacklistConflictingRoutes)
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -225,4 +225,9 @@ const (
 	// EnableEndpointRoutes is the value for option.EnableEndpointRoutes.
 	// It is disabled by default for backwards compatibility.
 	EnableEndpointRoutes = false
+
+	// AnnotateK8sNode is the default value for option.AnnotateK8sNode. It is
+	// enabled by default to annotate kubernetes node and can be disabled using
+	// the provided option.
+	AnnotateK8sNode = true
 )

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -66,6 +66,10 @@ const (
 	// disabled.
 	AllowLocalhostPolicy = "policy"
 
+	// AnnotateK8sNode enables annotating a kubernetes node while bootstrapping
+	// the daemon, which can also be disbled using this option.
+	AnnotateK8sNode = "annotate-k8s-node"
+
 	// BPFRoot is the Path to BPF filesystem
 	BPFRoot = "bpf-root"
 
@@ -951,6 +955,9 @@ type DaemonConfig struct {
 
 	// EnableEndpointRoutes enables use of per endpoint routes
 	EnableEndpointRoutes bool
+
+	// Specifies wheather to annotate the kubernetes nodes or not
+	AnnotateK8sNode bool
 }
 
 var (
@@ -977,6 +984,7 @@ var (
 		BlacklistConflictingRoutes:   defaults.BlacklistConflictingRoutes,
 		ForceLocalPolicyEvalAtSource: defaults.ForceLocalPolicyEvalAtSource,
 		EnableEndpointRoutes:         defaults.EnableEndpointRoutes,
+		AnnotateK8sNode:              defaults.AnnotateK8sNode,
 	}
 )
 
@@ -1188,6 +1196,7 @@ func (c *DaemonConfig) Populate() {
 	c.AccessLog = viper.GetString(AccessLog)
 	c.AgentLabels = viper.GetStringSlice(AgentLabels)
 	c.AllowLocalhost = viper.GetString(AllowLocalhost)
+	c.AnnotateK8sNode = viper.GetBool(AnnotateK8sNode)
 	c.BPFCompilationDebug = viper.GetBool(BPFCompileDebugName)
 	c.CTMapEntriesGlobalTCP = viper.GetInt(CTMapEntriesGlobalTCPName)
 	c.CTMapEntriesGlobalAny = viper.GetInt(CTMapEntriesGlobalAnyName)


### PR DESCRIPTION
* Add a new flag for daemon to optionally annotate kubernetes node
* By default daemon will annotate the kubernetes node
* This can be optinally disabled by --annotate-k8s-node flag
* Fixes #7976

Fixes: #7976

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8109)
<!-- Reviewable:end -->
