### PR TITLE
CI: WaitForDeploy/Daemonset 

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1887,6 +1887,7 @@
     "gopkg.in/fsnotify.v1",
     "gopkg.in/natefinch/lumberjack.v2",
     "gopkg.in/yaml.v2",
+    "k8s.io/api/apps/v1",
     "k8s.io/api/core/v1",
     "k8s.io/api/extensions/v1beta1",
     "k8s.io/api/networking/v1",

--- a/test/k8sT/Chaos.go
+++ b/test/k8sT/Chaos.go
@@ -55,10 +55,8 @@ var _ = Describe("K8sChaosTest", func() {
 	Context("Connectivity demo application", func() {
 		BeforeEach(func() {
 			kubectl.Apply(demoDSPath).ExpectSuccess("DS deployment cannot be applied")
-
-			err := kubectl.WaitforPods(
-				helpers.DefaultNamespace, fmt.Sprintf("-l zgroup=testDS"), helpers.HelperTimeout)
-			Expect(err).Should(BeNil(), "Pods are not ready after timeout")
+			ExpectDaemonSetReady(kubectl, helpers.DefaultNamespace, "testds", helpers.HelperTimeout)
+			ExpectDaemonSetReady(kubectl, helpers.DefaultNamespace, "testclient", helpers.HelperTimeout)
 		})
 
 		AfterEach(func() {
@@ -115,12 +113,10 @@ var _ = Describe("K8sChaosTest", func() {
 
 		It("Endpoint can still connect while Cilium is not running", func() {
 			By("Waiting for deployed pods to be ready")
-			err := kubectl.WaitforPods(
-				helpers.DefaultNamespace,
-				fmt.Sprintf("-l zgroup=testDSClient"), helpers.HelperTimeout)
-			Expect(err).Should(BeNil(), "Pods are not ready after timeout")
+			ExpectDaemonSetReady(kubectl, helpers.DefaultNamespace, "testds", helpers.HelperTimeout)
+			ExpectDaemonSetReady(kubectl, helpers.DefaultNamespace, "testclient", helpers.HelperTimeout)
 
-			err = kubectl.CiliumEndpointWaitReady()
+			err := kubectl.CiliumEndpointWaitReady()
 			Expect(err).To(BeNil(), "Endpoints are not ready after timeout")
 
 			By("Checking connectivity before restarting Cilium")
@@ -213,9 +209,8 @@ var _ = Describe("K8sChaosTest", func() {
 			ExpectAllPodsTerminated(kubectl)
 
 			By("Waiting for cilium pods to be ready")
-			err := kubectl.WaitforPods(
-				helpers.KubeSystemNamespace, fmt.Sprintf("-l %s", ciliumFilter), helpers.HelperTimeout)
-			Expect(err).Should(BeNil(), "Pods are not ready after timeout")
+			err := kubectl.WaitforDaemonSetReady(helpers.KubeSystemNamespace, "cilium", helpers.HelperTimeout)
+			Expect(err).Should(BeNil(), "Cilium pods are not ready after timeout")
 
 			err = kubectl.CiliumEndpointWaitReady()
 			Expect(err).To(BeNil(), "Endpoints are not ready after timeout")

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -101,6 +101,9 @@ var _ = Describe("K8sDatapathConfig", func() {
 		By("Making sure all endpoints are in ready state")
 		err = kubectl.CiliumEndpointWaitReady()
 		ExpectWithOffset(1, err).To(BeNil(), "Failure while waiting for all cilium endpoints to reach ready state")
+
+		ExpectDaemonSetReady(kubectl, helpers.DefaultNamespace, "testds", helpers.HelperTimeout)
+		ExpectDaemonSetReady(kubectl, helpers.DefaultNamespace, "testclient", helpers.HelperTimeout)
 	}
 
 	Context("Encapsulation", func() {

--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -295,6 +295,7 @@ var _ = Describe("NightlyEpsMeasurement", func() {
 			kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 			manifest := helpers.ManifestGet(netcatDsManifest)
 			kubectl.Apply(manifest).ExpectSuccess("Cannot apply netcat ds")
+			ExpectDaemonSetReady(kubectl, helpers.DefaultNamespace, "netcatds", helpers.HelperTimeout)
 			defer kubectl.Delete(manifest)
 			testConnectivity()
 		})
@@ -302,6 +303,7 @@ var _ = Describe("NightlyEpsMeasurement", func() {
 		It("Test TCP Keepalive without L7 Policy", func() {
 			manifest := helpers.ManifestGet(netcatDsManifest)
 			kubectl.Apply(manifest).ExpectSuccess("Cannot apply netcat ds")
+			ExpectDaemonSetReady(kubectl, helpers.DefaultNamespace, "netcatds", helpers.HelperTimeout)
 			defer kubectl.Delete(manifest)
 			kubectl.Exec(fmt.Sprintf(
 				"%s delete --all cnp -n %s", helpers.KubectlCmd, helpers.DefaultNamespace))

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -120,6 +120,8 @@ var _ = Describe("K8sServicesTest", func() {
 		BeforeEach(func() {
 			res := kubectl.Apply(demoYAML)
 			res.ExpectSuccess("unable to apply %s", demoYAML)
+			ExpectDaemonSetReady(kubectl, helpers.DefaultNamespace, "testds", helpers.HelperTimeout)
+			ExpectDaemonSetReady(kubectl, helpers.DefaultNamespace, "testclient", helpers.HelperTimeout)
 		})
 
 		AfterEach(func() {
@@ -160,6 +162,8 @@ var _ = Describe("K8sServicesTest", func() {
 		BeforeAll(func() {
 			res := kubectl.Apply(demoYAML)
 			res.ExpectSuccess("Unable to apply %s", demoYAML)
+			ExpectDaemonSetReady(kubectl, helpers.DefaultNamespace, "testds", helpers.HelperTimeout)
+			ExpectDaemonSetReady(kubectl, helpers.DefaultNamespace, "testclient", helpers.HelperTimeout)
 		})
 
 		AfterAll(func() {

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -185,7 +185,7 @@ var _ = Describe("K8sServicesTest", func() {
 			waitPodsDs()
 
 			var data v1.Service
-			err := kubectl.Get("default", "service test-nodeport").Unmarshal(&data)
+			err := kubectl.Get(helpers.DefaultNamespace, "service test-nodeport").Unmarshal(&data)
 			Expect(err).Should(BeNil(), "Can not retrieve service")
 			url := fmt.Sprintf("http://%s",
 				net.JoinHostPort(data.Spec.ClusterIP, fmt.Sprintf("%d", data.Spec.Ports[0].Port)))

--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -38,18 +38,15 @@ func ExpectKubeDNSReady(vm *helpers.Kubectl) {
 // ExpectCiliumReady is a wrapper around helpers/WaitForPods. It asserts that
 // the error returned by that function is nil.
 func ExpectCiliumReady(vm *helpers.Kubectl) {
-	err := vm.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", longTimeout)
-	ExpectWithOffset(1, err).Should(BeNil(), "cilium was not able to get into ready state")
-
-	err = vm.CiliumPreFlightCheck()
+	ExpectCiliumRunning(vm)
+	err := vm.CiliumPreFlightCheck()
 	ExpectWithOffset(1, err).Should(BeNil(), "cilium pre-flight checks failed")
 }
 
 // ExpectCiliumOperatorReady is a wrapper around helpers/WaitForPods. It asserts that
 // the error returned by that function is nil.
 func ExpectCiliumOperatorReady(vm *helpers.Kubectl) {
-	err := vm.WaitforPods(helpers.KubeSystemNamespace, "-l name=cilium-operator", longTimeout)
-	ExpectWithOffset(1, err).Should(BeNil(), "Cilium operator was not able to get into ready state")
+	ExpectDeployReady(vm, "kube-system", "cilium-operator", longTimeout)
 }
 
 // ExpectCiliumRunning is a wrapper around helpers/WaitForPodsRunning. It
@@ -66,7 +63,7 @@ func ExpectAllPodsTerminated(vm *helpers.Kubectl) {
 	ExpectWithOffset(1, err).To(BeNil(), "terminating containers are not deleted after timeout")
 }
 
-// ExpectETCDOperatorReady is a wrapper around helpers/WaitForNPods. It asserts
+// ExpectETCDOperatorReady is a wrapper around helpers/ExpectDeployReady. It asserts
 // the error returned by that function is nil.
 func ExpectETCDOperatorReady(vm *helpers.Kubectl) {
 	// Etcd operator creates 5 nodes (1 cilium-etcd-operator + 1 etcd-operator + 3 etcd nodes),
@@ -74,17 +71,8 @@ func ExpectETCDOperatorReady(vm *helpers.Kubectl) {
 	// so we need to wait until 5 pods are in ready state.
 	// This is to avoid cases where a few pods are ready, but the
 	// new one is not created yet.
-	By("Waiting for all etcd-operator pods to be ready")
-
-	err := vm.WaitforNPods(helpers.KubeSystemNamespace, "-l io.cilium/app=etcd-operator", 5, longTimeout)
-	warningMessage := ""
-	if err != nil {
-		res := vm.Exec(fmt.Sprintf(
-			"%s -n %s get pods -l io.cilium/app=etcd-operator",
-			helpers.KubectlCmd, helpers.KubeSystemNamespace))
-		warningMessage = res.Output().String()
-	}
-	Expect(err).To(BeNil(), "etcd-operator is not ready after timeout, pods status:\n %s", warningMessage)
+	By("Waiting for all etcd-operator pods are ready")
+	ExpectDeployReady(vm, "kube-system", "cilium-etcd-operator", longTimeout)
 }
 
 // ExpectCiliumPreFlightInstallReady is a wrapper around helpers/WaitForNPods.
@@ -109,6 +97,14 @@ func ExpectCiliumPreFlightInstallReady(vm *helpers.Kubectl) {
 func ExpectDaemonSetReady(vm *helpers.Kubectl, namespace, name string, timeout time.Duration) {
 	err := vm.WaitforDaemonSetReady(namespace, name, timeout)
 	Expect(err).To(BeNil(), "DaemonSet %s/%s not ready after timeout:\n %s", namespace, name, err)
+}
+
+// ExpectDeployReady is a wrapper around helpers.WaitforDeployReady
+// It asserts that the error returned by that function is nil, indicating that
+// the deploy's pods were ready within timeout.
+func ExpectDeployReady(vm *helpers.Kubectl, namespace, name string, timeout time.Duration) {
+	err := vm.WaitforDeployReady(namespace, name, timeout)
+	Expect(err).To(BeNil(), "Deploy %s/%s not ready after timeout:\n %s", namespace, name, err)
 }
 
 // ProvisionInfraPods deploys DNS, etcd-operator, and cilium into the kubernetes

--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -55,9 +55,8 @@ func ExpectCiliumOperatorReady(vm *helpers.Kubectl) {
 // ExpectCiliumRunning is a wrapper around helpers/WaitForPodsRunning. It
 // asserts the cilium pods are running on all nodes.
 func ExpectCiliumRunning(vm *helpers.Kubectl) {
-	err := vm.WaitforNPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium", vm.GetNumNodes(), longTimeout)
+	err := vm.WaitforDaemonSetReady(helpers.KubeSystemNamespace, "cilium", longTimeout)
 	ExpectWithOffset(1, err).Should(BeNil(), "cilium was not able to get into ready state")
-
 }
 
 // ExpectAllPodsTerminated is a wrapper around helpers/WaitCleanAllTerminatingPods.
@@ -93,7 +92,7 @@ func ExpectETCDOperatorReady(vm *helpers.Kubectl) {
 func ExpectCiliumPreFlightInstallReady(vm *helpers.Kubectl) {
 	By("Waiting for all cilium pre-flight pods to be ready")
 
-	err := vm.WaitforPods(helpers.KubeSystemNamespace, "-l k8s-app=cilium-pre-flight-check", longTimeout)
+	err := vm.WaitforDaemonSetReady(helpers.KubeSystemNamespace, "cilium-pre-flight-check", longTimeout)
 	warningMessage := ""
 	if err != nil {
 		res := vm.Exec(fmt.Sprintf(
@@ -102,6 +101,14 @@ func ExpectCiliumPreFlightInstallReady(vm *helpers.Kubectl) {
 		warningMessage = res.Output().String()
 	}
 	Expect(err).To(BeNil(), "cilium pre-flight check is not ready after timeout, pods status:\n %s", warningMessage)
+}
+
+// ExpectDaemonSetReady is a wrapper around helpers.WaitforDaemonSetReady
+// It asserts that the error returned by that function is nil, indicating that
+// the daemonset's pods were ready within timeout.
+func ExpectDaemonSetReady(vm *helpers.Kubectl, namespace, name string, timeout time.Duration) {
+	err := vm.WaitforDaemonSetReady(namespace, name, timeout)
+	Expect(err).To(BeNil(), "DaemonSet %s/%s not ready after timeout:\n %s", namespace, name, err)
 }
 
 // ProvisionInfraPods deploys DNS, etcd-operator, and cilium into the kubernetes


### PR DESCRIPTION
WaitForDeployment uses the number of pods configured in k8s to determine
if the deploy is ready. This should be resilient to still-terminated
pods left over from other tests and better reflect what the k8s
scheduler thinks is true.

WaitForDaemonSetReady uses the k8s expected pods to determine that pods
are ready. This sidesteps passing a count to WaitforNPods or passing 0
to cause it to determine the number of pods from those currently
running.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8110)
<!-- Reviewable:end -->
