### PR TITLE
envoy: Use LPM ipcache instead of xDS when available

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:02348da5500c791539e06f02ef4a8b7f95a030c1 as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:18ed0eab0eb161b21e25c50b8d360ba6507b9a4b as cilium-envoy
 
 #
 # Cilium incremental build. Should be fast given builder-deps is up-to-date!

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -51,7 +51,6 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpoint/connector"
 	"github.com/cilium/cilium/pkg/endpointmanager"
-	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/fqdn"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
@@ -628,8 +627,8 @@ func (d *Daemon) initMaps() error {
 
 	// Set up the list of IPCache listeners in the daemon, to be
 	// used by syncLXCMap().
+	// xDS cache will be added later by calling AddListener(), but only if necessary.
 	ipcache.IPIdentityCache.SetListeners([]ipcache.IPIdentityMappingListener{
-		&envoy.NetworkPolicyHostsCache,
 		bpfIPCache.NewListener(d),
 	})
 

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -166,7 +166,7 @@ func StartXDSServer(stateDir string) *XDSServer {
 
 	nphdsConfig := &xds.ResourceTypeConfiguration{
 		Source:      NetworkPolicyHostsCache,
-		AckObserver: nil, // We don't wait for ACKs for those resources.
+		AckObserver: &NetworkPolicyHostsCache,
 	}
 
 	stopServer := startXDSGRPCServer(socketListener, ldsConfig, npdsConfig, nphdsConfig, 5*time.Second)

--- a/pkg/envoy/xds/server.go
+++ b/pkg/envoy/xds/server.go
@@ -314,18 +314,18 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 				if ackObserver != nil {
 					requestLog.Debug("notifying observers of ACKs")
 					ackObserver.HandleResourceVersionAck(versionInfo, nonce, req.GetNode(), state.resourceNames, typeURL, detail)
-					if versionInfo < nonce {
-						// versions after VersionInfo, upto and including ResponseNonce are NACKed
-						requestLog.Warningf("NACK received for versions after %s and up to %s; waiting for a version update before sending again", req.VersionInfo, req.ResponseNonce)
-						// Watcher will behave as if the sent version was acked.
-						// Otherwise we will just be sending the same failing
-						// version over and over filling logs.
-						versionInfo = state.version
-					}
-
 				} else {
 					requestLog.Debug("ACK received but no observers are waiting for ACKs")
 				}
+				if versionInfo < nonce {
+					// versions after VersionInfo, upto and including ResponseNonce are NACKed
+					requestLog.Warningf("NACK received for versions after %s and up to %s; waiting for a version update before sending again", req.VersionInfo, req.ResponseNonce)
+					// Watcher will behave as if the sent version was acked.
+					// Otherwise we will just be sending the same failing
+					// version over and over filling logs.
+					versionInfo = state.version
+				}
+
 				if state.pendingWatchCancel != nil {
 					// A pending watch exists for this type URL. Cancel it to
 					// start a new watch.

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -133,6 +133,15 @@ func (ipc *IPCache) SetListeners(listeners []IPIdentityMappingListener) {
 	ipc.mutex.Unlock()
 }
 
+// AddListenerLocked adds a listener for this IPCache.
+func (ipc *IPCache) AddListener(listener IPIdentityMappingListener) {
+	ipc.mutex.Lock()
+	ipc.listeners = append(ipc.listeners, listener)
+	// Initialize new listener with the current mappings
+	ipc.DumpToListenerLocked(listener)
+	ipc.mutex.Unlock()
+}
+
 func checkPrefixLengthsAgainstMap(impl Implementation, prefixes []*net.IPNet, existingPrefixes map[int]int, isIPv6 bool) error {
 	prefixLengths := make(map[int]struct{})
 


### PR DESCRIPTION
xDS IP/ID mapping is only needed when Envoy is running and requires
the IP/ID mapping information. Add support to the ipcache package for adding
listeners and trigger a call to the new AddListener() function when
the first xDS request for NetworkPolicyHosts is received.

This helps reduce overhead in cases where no L7 proxies are needed,
and also in cases when the L7 proxies do not need the IP/ID mapping
information via xDS.

A separate commit updates Envoy version that can use bpf ipcache instead of
NetworkPolicyHosts xDS, when available. If the bpf ipcache LPM map
open fails (such as on Linux kernels before 4.11), Envoy falls
back to using xDS.

The first commit (a minor bug fix) should be reviewed here: #8149 

Istio tests will still run on older Envoy version to ensure this PR does not break backwards compatibility. A separate PR updates Istio to the new Envoy version (#8150).

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8113)
<!-- Reviewable:end -->
