### PR TITLE
use SelectorCache for communicating mapping of FQDN to IPs instead of policy repository

### DIFF
--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -1322,6 +1322,7 @@ func runDaemon() {
 			if restoreComplete != nil {
 				<-restoreComplete
 			}
+			d.dnsRuleGen.CompleteBootstrap()
 			maps.CollectStaleMapGarbage()
 			maps.RemoveDisabledMaps()
 		}()

--- a/pkg/fqdn/config.go
+++ b/pkg/fqdn/config.go
@@ -25,7 +25,7 @@ import (
 // Config is a simple configuration structure to set how pkg/fqdn subcomponents
 // behave.
 // DNSPoller relies on LookupDNSNames to control how DNS lookups are done, and
-// AddGeneratedRulesAndUpdateSelectors to control how generated policy rules are emitted.
+// UpdateSelectors to control how generated policy rules are emitted.
 type Config struct {
 	// MinTTL is the time used by the poller to cache information.
 	// When set to 0, 2*DNSPollerInterval is used.
@@ -46,10 +46,9 @@ type Config struct {
 	// When set to nil, fqdn.DNSLookupDefaultResolver is used.
 	LookupDNSNames func(dnsNames []string) (DNSIPs map[string]*DNSIPRecords, errorDNSNames map[string]error)
 
-	// AddGeneratedRulesAndUpdateSelectors is a callback  to emit generated rules,
-	// as well as update the mapping of FQDNSelector to set of IPs.
-	// When set to nil, it is a no-op.
-	AddGeneratedRulesAndUpdateSelectors func(generatedRules []*api.Rule, selectorsWithIPs map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) error
+	// UpdateSelectors is a callback to update the mapping of FQDNSelector to
+	// sets of IPs.
+	UpdateSelectors func(selectorsWithIPs map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) error
 
 	// PollerResponseNotify is used when the poller recieves DNS data in response
 	// to a successful poll.

--- a/pkg/fqdn/dnspoller.go
+++ b/pkg/fqdn/dnspoller.go
@@ -49,7 +49,7 @@ func StartDNSPoller(poller *DNSPoller) {
 // handled directly, but will depend on the resolver's behavior.
 // fqdn.Config can be opitonally used to set how the DNS lookups are
 // executed (via LookupDNSNames) and how generated policy rules are handled
-// (via AddGeneratedRulesAndUpdateSelectors).
+// (via UpdateSelectors).
 type DNSPoller struct {
 	lock.Mutex // this guards both maps and their contents
 

--- a/pkg/fqdn/helpers.go
+++ b/pkg/fqdn/helpers.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 
 	"github.com/cilium/cilium/pkg/fqdn/matchpattern"
-	"github.com/cilium/cilium/pkg/fqdn/regexpmap"
 	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -40,110 +39,80 @@ func generateUUIDLabel() labels.Label {
 	return labels.NewLabel(generatedLabelNameUUID, uuid.NewUUID().String(), labels.LabelSourceCiliumGenerated)
 }
 
-// injectToCIDRSetRules resets the ToCIDRSets of all egress rules containing
-// ToFQDN matches to the latest IPs in the cache.  Note: matchNames in rules
-// are made into FQDNs
-func injectToCIDRSetRules(rule *api.Rule, cache *DNSCache, reMap *regexpmap.RegexpMap) (emittedIPs map[string][]net.IP, selectorsMissingIPs []api.FQDNSelector, selectorIPMapping map[api.FQDNSelector][]net.IP) {
+// mapSelectorsToIPs iterates through a set of FQDNSelectors and evalutes whether
+// they match the DNS Names in the cache. If so, the set of IPs which the cache
+// maintains as mapping to each DNS Name are mapped to the matching FQDNSelector.
+// Returns the mapping of DNSName to set of IPs which back said DNS name, the
+// set of FQDNSelectors which do not map to any IPs, and the set of
+// FQDNSelectors mapping to a set of IPs.
+func mapSelectorsToIPs(fqdnSelectors map[api.FQDNSelector]struct{}, cache *DNSCache) (selectorsMissingIPs []api.FQDNSelector, selectorIPMapping map[api.FQDNSelector][]net.IP) {
 	missing := make(map[api.FQDNSelector]struct{}) // a set to dedup missing dnsNames
-	emitted := make(map[string][]net.IP)           // name -> IPs we wrote out
 	selectorIPMapping = make(map[api.FQDNSelector][]net.IP)
-	// Add CIDR rules
-	// we need to edit Egress[*] in-place
-	for egressIdx := range rule.Egress {
-		egressRule := &rule.Egress[egressIdx]
 
-		// Build an IP collection to remove all duplicates
-		allIPs := []net.IP{}
+	log.WithField("fqdnSelectors", fqdnSelectors).Debug("mapSelectorsToIPs")
 
-		// Generate CIDR rules for each FQDN
-		for _, ToFQDN := range egressRule.ToFQDNs {
-			ipsSelected := make([]net.IP, 0)
-			// lookup matching DNS names
-			if len(ToFQDN.MatchName) > 0 {
-				dnsName := prepareMatchName(ToFQDN.MatchName)
-				lookupIPs := cache.Lookup(dnsName)
+	// Map each FQDNSelector to set of CIDRs
+	for ToFQDN := range fqdnSelectors {
+		ipsSelected := make([]net.IP, 0)
+		// lookup matching DNS names
+		if len(ToFQDN.MatchName) > 0 {
+			dnsName := prepareMatchName(ToFQDN.MatchName)
+			lookupIPs := cache.Lookup(dnsName)
 
-				// Mark this name missing; it will be unmarked in the loop below
-				if len(lookupIPs) == 0 {
-					missing[ToFQDN] = struct{}{}
-				}
-
-				// Accumulate toCIDRSet rules
-				log.WithFields(logrus.Fields{
-					"DNSName":   dnsName,
-					"IPs":       lookupIPs,
-					"matchName": ToFQDN.MatchName,
-				}).Debug("Emitting matching DNS Name -> IPs for ToFQDNs Rule")
-				emitted[dnsName] = append(emitted[dnsName], lookupIPs...)
-				allIPs = append(allIPs, lookupIPs...)
-				ipsSelected = append(ipsSelected, lookupIPs...)
-			}
-
-			if len(ToFQDN.MatchPattern) > 0 {
-				// lookup matching DNS names
-				dnsPattern := matchpattern.Sanitize(ToFQDN.MatchPattern)
-				patternREStr := matchpattern.ToRegexp(dnsPattern)
-				patternRE := reMap.GetPrecompiledRegexp(patternREStr)
-				var err error
-				if patternRE == nil {
-					if patternRE, err = regexp.Compile(patternREStr); err != nil {
-						log.WithError(err).Error("Error compiling matchPattern")
-					}
-				}
-				lookupIPs := cache.LookupByRegexp(patternRE)
-
-				// Mark this pattern missing; it will be unmarked in the loop below
+			// Mark this FQDNSelector as having no IPs corresponding to it.
+			// FQDNSelectors are guaranteed to have only their MatchName OR
+			// their MatchPattern set (having both set is invalid per
+			// sanitization of FQDNSelectors).
+			if len(lookupIPs) == 0 {
 				missing[ToFQDN] = struct{}{}
-
-				// Accumulate toCIDRSet rules
-				for name, ips := range lookupIPs {
-					log.WithFields(logrus.Fields{
-						"DNSName":      name,
-						"IPs":          ips,
-						"matchPattern": ToFQDN.MatchPattern,
-					}).Debug("Emitting matching DNS Name -> IPs for ToFQDNs Rule")
-					delete(missing, ToFQDN)
-					emitted[name] = append(emitted[name], ips...)
-					allIPs = append(allIPs, ips...)
-					ipsSelected = append(ipsSelected, ips...)
-				}
 			}
 
-			ips := ip.KeepUniqueIPs(ipsSelected)
-			selectorIPMapping[ToFQDN] = ips
+			log.WithFields(logrus.Fields{
+				"DNSName":   dnsName,
+				"IPs":       lookupIPs,
+				"matchName": ToFQDN.MatchName,
+			}).Debug("Emitting matching DNS Name -> IPs for FQDNSelector")
+			ipsSelected = append(ipsSelected, lookupIPs...)
+		}
 
-			// Always set the ToCIDRSet, in case that there are no IPs will be
-			// empty to clean old entries in case of TTL expires.
-			egressRule.ToCIDRSet = api.IPsToCIDRRules(ip.KeepUniqueIPs(allIPs))
+		if len(ToFQDN.MatchPattern) > 0 {
+			// lookup matching DNS names
+			dnsPattern := matchpattern.Sanitize(ToFQDN.MatchPattern)
+			patternREStr := matchpattern.ToRegexp(dnsPattern)
+			var (
+				err       error
+				patternRE *regexp.Regexp
+			)
+
+			if patternRE, err = regexp.Compile(patternREStr); err != nil {
+				log.WithError(err).Error("Error compiling matchPattern")
+			}
+			lookupIPs := cache.LookupByRegexp(patternRE)
+
+			// Mark this pattern missing; it will be unmarked in the loop below
+			missing[ToFQDN] = struct{}{}
+
+			for name, ips := range lookupIPs {
+				log.WithFields(logrus.Fields{
+					"DNSName":      name,
+					"IPs":          ips,
+					"matchPattern": ToFQDN.MatchPattern,
+				}).Debug("Emitting matching DNS Name -> IPs for FQDNSelector")
+				delete(missing, ToFQDN)
+				ipsSelected = append(ipsSelected, ips...)
+			}
+		}
+
+		ips := ip.KeepUniqueIPs(ipsSelected)
+		if len(ips) > 0 {
+			selectorIPMapping[ToFQDN] = ips
 		}
 	}
 
 	for dnsName := range missing {
 		selectorsMissingIPs = append(selectorsMissingIPs, dnsName)
 	}
-
-	return emitted, selectorsMissingIPs, selectorIPMapping
-}
-
-// stripToCIDRSet ensures no ToCIDRSet is nil when ToFQDNs is non-nil
-func stripToCIDRSet(rule *api.Rule) {
-	for i := range rule.Egress {
-		egressRule := &rule.Egress[i]
-		if len(egressRule.ToFQDNs) > 0 {
-			egressRule.ToCIDRSet = nil
-		}
-	}
-}
-
-// hasToFQDN indicates whether a ToFQDN rule exists in the api.Rule
-func hasToFQDN(rule *api.Rule) bool {
-	for _, egressRule := range rule.Egress {
-		if len(egressRule.ToFQDNs) > 0 {
-			return true
-		}
-	}
-
-	return false
+	return selectorsMissingIPs, selectorIPMapping
 }
 
 // sortedIPsAreEqual compares two lists of sorted IPs. If any differ it returns

--- a/pkg/fqdn/regexpmap/regexp_map.go
+++ b/pkg/fqdn/regexpmap/regexp_map.go
@@ -122,11 +122,11 @@ func (r refCount) Keys() []string {
 type RegexpMap struct {
 
 	// lookupValues is a map that use a lookupValue as a key and has a
-	// RegexpList with the regexes that ONLY affect that lookupValue.
+	// RegexpList with the stringToRegExp that ONLY affect that lookupValue
 	lookupValues map[string]*RegexpList
 
-	// stringToRegExp is a map that use a regular expression as a key and the
-	// value is the compiled regexp.
+	// stringToRegExp is a map that use a regular expression as a key and the value is
+	// the compiled regexp
 	stringToRegExp map[string]*regexp.Regexp
 
 	// regexRefCount is a map that use a regular expression as a key and the

--- a/pkg/fqdn/rulegen.go
+++ b/pkg/fqdn/rulegen.go
@@ -15,12 +15,14 @@
 package fqdn
 
 import (
+	"context"
 	"net"
-	"strings"
+	"regexp"
 	"time"
 
-	"github.com/cilium/cilium/pkg/fqdn/matchpattern"
-	"github.com/cilium/cilium/pkg/fqdn/regexpmap"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -52,7 +54,7 @@ var uuidLabelSearchKey = labels.LabelSourceCiliumGenerated + labels.PathDelimite
 // RuleGen tracks which rules depend on which DNS names. When DNS updates are
 // given to a RuleGen it will emit generated policy rules with DNS IPs inserted
 // as toCIDR rules. These correspond to the toFQDN matchName entries and are
-// emitted via AddGeneratedRulesAndUpdateSelectors.
+// emitted via UpdateSelectors.
 // DNS information is cached, respecting TTL.
 // Note: When DNS data expires rules are not generated again!
 type RuleGen struct {
@@ -66,19 +68,91 @@ type RuleGen struct {
 	// include regexes, as those are not polled directly.
 	namesToPoll map[string]struct{}
 
-	// sourceRules maps dnsNames to a set of rule UUIDs that depend on
-	// that dnsName, and drives CIDR rule generation.
-	// A lookup on sourceRules is looking for all rule UUIDs that have an exact
-	// match or a regex that would match.
-	// The UUID -> rule mapping is allRules below.
-	sourceRules *regexpmap.RegexpMap
-
-	// allRules is the global source of truth for rules we are managing. It maps
-	// UUID to the rule copy.
-	allRules map[string]*api.Rule
+	// allSelectors contains all FQDNSelectors which are present in all policy. We
+	// use these selectors to map selectors --> IPs.
+	allSelectors map[api.FQDNSelector]*regexp.Regexp
 
 	// cache is a private copy of the pointer from config.
 	cache *DNSCache
+
+	bootstrapCompleted bool
+}
+
+// RegisterForIdentityUpdates exposes this FQDNSelector so that identities
+// for IPs contained in a DNS response that matches said selector can be
+// propagated back to the SelectorCache via `UpdateFQDNSelector`. All DNS names
+// contained within the RuleGen's cache are iterated over to see if they match
+// the FQDNSelector. All IPs which correspond to the DNS names which match this
+// Selector will be returned as CIDR identities, as other DNS Names which have
+// already been resolved may match this FQDNSelector.
+func (gen *RuleGen) RegisterForIdentityUpdates(selector api.FQDNSelector) (identities []identity.NumericIdentity) {
+
+	gen.Mutex.Lock()
+	_, exists := gen.allSelectors[selector]
+	if exists {
+		gen.Mutex.Unlock()
+		return nil
+	}
+
+	// This error should never occur since the FQDNSelector has already been
+	// validated, but account for it for good measure.
+	regex, err := selector.ToRegex()
+	if err != nil {
+		log.WithError(err).WithField("fqdnSelector", selector).Error("FQDNSelector did not compile to valid regex")
+		gen.Mutex.Unlock()
+		return nil
+	}
+
+	// Update names to poll for DNS poller since we now care about this selector.
+	if len(selector.MatchName) > 0 {
+		gen.namesToPoll[prepareMatchName(selector.MatchName)] = struct{}{}
+	}
+
+	gen.allSelectors[selector] = regex
+	_, selectorIPMapping := mapSelectorsToIPs(map[api.FQDNSelector]struct{}{selector: {}}, gen.cache)
+	gen.Mutex.Unlock()
+
+	// Used to track identities which are allocated in calls to
+	// AllocateCIDRs. If we for some reason cannot allocate new CIDRs,
+	// we have to undo all of our changes and release the identities.
+	// This is best effort, as releasing can fail as well.
+	usedIdentities := make([]*identity.Identity, 0)
+	selectorIdentitySliceMapping := make(map[api.FQDNSelector][]identity.NumericIdentity)
+
+	// Allocate identities for each IPNet and then map to selector
+	for selector, selectorIPs := range selectorIPMapping {
+		log.WithFields(logrus.Fields{
+			"fqdnSelector": selector,
+			"ips":          selectorIPs,
+		}).Debug("getting identities for IPs associated with FQDNSelector")
+		var currentlyAllocatedIdentities []*identity.Identity
+		if currentlyAllocatedIdentities, err = ipcache.AllocateCIDRsForIPs(selectorIPs); err != nil {
+			cache.ReleaseSlice(context.TODO(), nil, usedIdentities)
+			log.WithError(err).WithField("prefixes", selectorIPs).Warn(
+				"failed to allocate identities for IPs")
+			return
+		}
+		usedIdentities = append(usedIdentities, currentlyAllocatedIdentities...)
+		numIDs := make([]identity.NumericIdentity, 0, len(currentlyAllocatedIdentities))
+		for i := range currentlyAllocatedIdentities {
+			numIDs = append(numIDs, currentlyAllocatedIdentities[i].ID)
+		}
+		selectorIdentitySliceMapping[selector] = numIDs
+	}
+
+	return selectorIdentitySliceMapping[selector]
+}
+
+// UnregisterForIdentityUpdates removes this FQDNSelector from the set of
+// FQDNSelectors which are being tracked by the RuleGen. No more updates for IPs
+// which correspond to said selector are propagated.
+func (gen *RuleGen) UnregisterForIdentityUpdates(selector api.FQDNSelector) {
+	gen.Mutex.Lock()
+	delete(gen.allSelectors, selector)
+	if len(selector.MatchName) > 0 {
+		delete(gen.namesToPoll, prepareMatchName(selector.MatchName))
+	}
+	gen.Mutex.Unlock()
 }
 
 // NewRuleGen creates an initialized RuleGen.
@@ -89,18 +163,17 @@ func NewRuleGen(config Config) *RuleGen {
 		config.Cache = NewDNSCache(0)
 	}
 
-	if config.AddGeneratedRulesAndUpdateSelectors == nil {
-		config.AddGeneratedRulesAndUpdateSelectors = func(generatedRules []*api.Rule, selectorIPMapping map[api.FQDNSelector][]net.IP, namesMissingIPs []api.FQDNSelector) error {
+	if config.UpdateSelectors == nil {
+		config.UpdateSelectors = func(selectorIPMapping map[api.FQDNSelector][]net.IP, namesMissingIPs []api.FQDNSelector) error {
 			return nil
 		}
 	}
 
 	return &RuleGen{
-		config:      config,
-		namesToPoll: make(map[string]struct{}),
-		sourceRules: regexpmap.NewRegexpMap(),
-		allRules:    make(map[string]*api.Rule),
-		cache:       config.Cache,
+		config:       config,
+		namesToPoll:  make(map[string]struct{}),
+		allSelectors: make(map[api.FQDNSelector]*regexp.Regexp),
+		cache:        config.Cache,
 	}
 
 }
@@ -108,148 +181,6 @@ func NewRuleGen(config Config) *RuleGen {
 // GetDNSCache returns the DNSCache used by the RuleGen
 func (gen *RuleGen) GetDNSCache() *DNSCache {
 	return gen.cache
-}
-
-// PrepareFQDNRules adds a tracking label to rules that contain ToFQDN sections.
-// The label is used to ensure that the ToFQDN rules are replaced correctly
-// when they are regenerated with IPs. It will also include the generated IPs
-// (in the ToCIDRSet) section for DNS names already present in the cache.
-// It returns the list of valid rules to apply into policyRepo, a valid rule is:
-// - A rule without toFQDN entries.
-// - A rule with toFQDN that already have a UUID and it is present on
-// gen.AllRules
-// - A new FQDN rule that does not have UUID(new UUID will be created in this function)
-// NOTE: It edits the rules in-place
-func (gen *RuleGen) PrepareFQDNRules(sourceRules []*api.Rule) ([]*api.Rule, map[api.FQDNSelector][]net.IP) {
-	gen.Lock()
-	defer gen.Unlock()
-
-	result := []*api.Rule{}
-	selectorIPMapping := make(map[api.FQDNSelector][]net.IP)
-	var selectorsMissingIPs []api.FQDNSelector
-perRule:
-	for _, sourceRule := range sourceRules {
-		// This rule has already been seen, and has a UUID label OR it has no
-		// ToFQDN rules. Do no more processing on it.
-		// Note: this label can only come from us. An external rule add or replace
-		// would lack the UUID-tagged rule and we would add a new UUID label in
-		// this function. Cleanup for existing rules with UUIDs is handled in
-		// StopManageDNSName
-		if !hasToFQDN(sourceRule) {
-			result = append(result, sourceRule)
-			continue perRule
-		}
-
-		// If the rule already have a UUID we check that it is present in the
-		// gen.allRules. If it is not present we don't need to append to
-		// result, due the rule was already updated by other process.
-		uuid := sourceRule.Labels.Get(uuidLabelSearchKey)
-		if uuid != "" {
-			_, exists := gen.allRules[uuid]
-			if !exists {
-				log.Debugf("Rule '%s' has been deleted from fqdn rules. This rule will be discarded", uuid)
-			} else {
-				result = append(result, sourceRule)
-			}
-			continue perRule
-		}
-		result = append(result, sourceRule)
-
-		// add a unique ID that we can use later to replace this rule.
-		uuidLabel := generateUUIDLabel()
-		sourceRule.Labels = append(sourceRule.Labels, uuidLabel)
-
-		// Strip out toCIDRSet
-		// Note: See Hack 1 above. When we generate rules, we add them and this
-		// function is called. This avoids accumulating generated toCIDRSet entries.
-		stripToCIDRSet(sourceRule)
-
-		var selectorIPMappingTmp map[api.FQDNSelector][]net.IP
-
-		// Insert any IPs for this rule from the cache. This is critical to do
-		// here, because we only update the rules on a DNS change later.
-		// Note: This will cause a needless regexp compile in this function,
-		// because the sourceRules RegexpMap hasn't seen the regexp yet
-		_, selectorsMissingIPs, selectorIPMappingTmp = injectToCIDRSetRules(sourceRule, gen.cache, gen.sourceRules)
-		if len(selectorsMissingIPs) != 0 {
-			log.WithField(logfields.DNSName, selectorsMissingIPs).
-				Debug("No IPs to inject on initial rule insert")
-		}
-
-		for k, v := range selectorIPMappingTmp {
-			selectorIPMapping[k] = v
-		}
-	}
-
-	return result, selectorIPMapping
-}
-
-// StartManageDNSName begins managing sourceRules that contain toFQDNs
-// sections. When the DNS data of the included matchNames changes, RuleGen will
-// emit a replacement rule that contains the IPs for each matchName.
-// It only adds rules with the ToFQDN-UUID label, added by MarkToFQDNRules, and
-// repeat inserts are effectively no-ops.
-func (gen *RuleGen) StartManageDNSName(sourceRules []*api.Rule) error {
-	gen.Lock()
-	defer gen.Unlock()
-
-perRule:
-	for _, sourceRule := range sourceRules {
-		// Note: we rely on MarkToFQDNRules to insert this label.
-		if !sourceRule.Labels.Has(uuidLabelSearchKey) {
-			continue perRule
-		}
-
-		// Make a copy to avoid breaking the input rules. Strip ToCIDRSet to avoid
-		// re-including IPs we optimistically inserted in MarkToFQDNRules
-		sourceRuleCopy := sourceRule.DeepCopy()
-		stripToCIDRSet(sourceRuleCopy)
-
-		uuid := getRuleUUIDLabel(sourceRuleCopy)
-		newDNSNames, alreadyExistsDNSNames, err := gen.addRule(uuid, sourceRuleCopy)
-		if err != nil {
-			return err
-		}
-
-		// only debug print for new names since this function is called
-		// unconditionally, even when we insert generated rules (which aren't new)
-		if len(newDNSNames) > 0 {
-			log.WithFields(logrus.Fields{
-				"newDNSNames":           newDNSNames,
-				"alreadyExistsDNSNames": alreadyExistsDNSNames,
-				"numRules":              len(sourceRules),
-			}).Debug("Added FQDN to managed list")
-		}
-	}
-
-	return nil
-}
-
-// StopManageDNSName runs the bookkeeping to remove each api.Rule from
-// corresponding dnsName entries in sourceRules and IPs. When no more rules
-// rely on a specific dnsName, we remove it from the maps and stop returning it
-// from GetDNSNames, or emitting it when regenerating rules. Only rules
-// labelled with a ToFQDN-UUID label are processed (added by MarkToFQDNRules).
-// Note: rule deletion in policy.Repository is by label, where the rules must
-// have at least the labels in the delete. This means our ToFQDN-UUID label,
-// and later ToCIDRSet additions will also be deleted correctly, and no action
-// is needed here to remove rules we generated.
-func (gen *RuleGen) StopManageDNSName(sourceRules []*api.Rule) {
-	gen.Lock()
-	defer gen.Unlock()
-
-	for _, sourceRule := range sourceRules {
-		// skip unmarked rules, nothing to do
-		if !sourceRule.Labels.Has(uuidLabelSearchKey) {
-			continue
-		}
-
-		uuid := getRuleUUIDLabel(sourceRule)
-		noLongerManagedDNSNames := gen.removeRule(uuid, sourceRule)
-		log.WithFields(logrus.Fields{
-			"noLongerManaged": noLongerManagedDNSNames,
-		}).Debug("Removed FQDN from managed list")
-	}
 }
 
 // GetDNSNames returns a snapshot of the DNS names managed by this RuleGen
@@ -266,83 +197,67 @@ func (gen *RuleGen) GetDNSNames() (dnsNames []string) {
 
 // UpdateGenerateDNS inserts the new DNS information into the cache. If the IPs
 // have changed for a name, store which rules must be updated in rulesToUpdate,
-// regenerate them, and emit via AddGeneratedRulesAndUpdateSelectors.
+// regenerate them, and emit via UpdateSelectors.
 func (gen *RuleGen) UpdateGenerateDNS(lookupTime time.Time, updatedDNSIPs map[string]*DNSIPRecords) error {
 	// Update IPs in gen
-	uuidsToUpdate, updatedDNSNames := gen.UpdateDNSIPs(lookupTime, updatedDNSIPs)
+	fqdnSelectorsToUpdate, updatedDNSNames := gen.UpdateDNSIPs(lookupTime, updatedDNSIPs)
 	for dnsName, IPs := range updatedDNSNames {
 		log.WithFields(logrus.Fields{
-			"matchName":     dnsName,
-			"IPs":           IPs,
-			"uuidsToUpdate": uuidsToUpdate,
+			"matchName":             dnsName,
+			"IPs":                   IPs,
+			"fqdnSelectorsToUpdate": fqdnSelectorsToUpdate,
 		}).Debug("Updated FQDN with new IPs")
 	}
 
-	// Generate a new rule for each sourceRule that needs an update.
-	rulesToUpdate, notFoundUUIDs := gen.GetRulesByUUID(uuidsToUpdate)
-	if len(notFoundUUIDs) != 0 {
-		log.WithField("uuid", strings.Join(notFoundUUIDs, ",")).
-			Debug("Did not find all rules during update")
-	}
-	generatedRules, namesMissingIPs, selectorIPMapping := gen.GenerateRulesFromSources(rulesToUpdate)
+	namesMissingIPs, selectorIPMapping := gen.GenerateSelectorUpdates(fqdnSelectorsToUpdate)
 	if len(namesMissingIPs) != 0 {
 		log.WithField(logfields.DNSName, namesMissingIPs).
 			Debug("No IPs to insert when generating DNS name selected by ToFQDN rule")
 	}
 
-	// TODO (ianvernon) if no new rules to add, add additional logic in function
-	// below?
-
-	// emit the new rules
-	return gen.config.AddGeneratedRulesAndUpdateSelectors(generatedRules, selectorIPMapping, namesMissingIPs)
+	return gen.config.UpdateSelectors(selectorIPMapping, namesMissingIPs)
 }
 
 // ForceGenerateDNS unconditionally regenerates all rules that refer to DNS
 // names in namesToRegen. These names are FQDNs and toFQDNs.matchPatterns or
 // matchNames that match them will cause these rules to regenerate.
 func (gen *RuleGen) ForceGenerateDNS(namesToRegen []string) error {
-	affectedRulesSet := make(map[string]struct{})
+	gen.Mutex.Lock()
+	affectedFQDNSels := make(map[api.FQDNSelector]struct{}, 0)
 	for _, dnsName := range namesToRegen {
-		for _, uuid := range gen.sourceRules.LookupValues(dnsName) {
-			affectedRulesSet[uuid] = struct{}{}
+		for fqdnSel, fqdnRegEx := range gen.allSelectors {
+			if fqdnRegEx.MatchString(dnsName) {
+				affectedFQDNSels[fqdnSel] = struct{}{}
+			}
 		}
 	}
 
-	// Convert the set to a list
-	var uuidsToUpdate []string
-	for uuid := range affectedRulesSet {
-		uuidsToUpdate = append(uuidsToUpdate, uuid)
-	}
-
-	// Generate a new rule for each sourceRule that needs an update.
-	rulesToUpdate, notFoundUUIDs := gen.GetRulesByUUID(uuidsToUpdate)
-	if len(notFoundUUIDs) != 0 {
-		log.WithField("uuid", strings.Join(notFoundUUIDs, ",")).
-			Debug("Did not find all rules during update")
-	}
-	generatedRules, namesMissingIPs, selectorIPMapping := gen.GenerateRulesFromSources(rulesToUpdate)
+	namesMissingIPs, selectorIPMapping := mapSelectorsToIPs(affectedFQDNSels, gen.cache)
 	if len(namesMissingIPs) != 0 {
 		log.WithField(logfields.DNSName, namesMissingIPs).
 			Debug("No IPs to insert when generating DNS name selected by ToFQDN rule")
 	}
-
-	// no new rules to add, do not call AddGeneratedRulesAndUpdateSelectors below
-	if len(generatedRules) == 0 {
-		return nil
-	}
+	gen.Mutex.Unlock()
 
 	// emit the new rules
 	return gen.config.
-		AddGeneratedRulesAndUpdateSelectors(generatedRules, selectorIPMapping, namesMissingIPs)
+		UpdateSelectors(selectorIPMapping, namesMissingIPs)
+}
+
+func (gen *RuleGen) CompleteBootstrap() {
+	gen.Lock()
+	gen.bootstrapCompleted = true
+	gen.Unlock()
 }
 
 // UpdateDNSIPs updates the IPs for each DNS name in updatedDNSIPs.
 // It returns:
-// affectedRules: a list of rule UUIDs that were affected by the new IPs (lookup in .allRules)
+// affectedSelectors: a set of all FQDNSelectors which match DNS Names whose
+// corresponding set of IPs has changed.
 // updatedNames: a map of DNS names to all the valid IPs we store for each.
-func (gen *RuleGen) UpdateDNSIPs(lookupTime time.Time, updatedDNSIPs map[string]*DNSIPRecords) (affectedRules []string, updatedNames map[string][]net.IP) {
+func (gen *RuleGen) UpdateDNSIPs(lookupTime time.Time, updatedDNSIPs map[string]*DNSIPRecords) (affectedSelectors map[api.FQDNSelector]struct{}, updatedNames map[string][]net.IP) {
 	updatedNames = make(map[string][]net.IP, len(updatedDNSIPs))
-	affectedRulesSet := make(map[string]struct{}, len(updatedDNSIPs))
+	affectedSelectors = make(map[api.FQDNSelector]struct{}, len(updatedDNSIPs))
 
 	gen.Lock()
 	defer gen.Unlock()
@@ -352,204 +267,39 @@ perDNSName:
 		updated := gen.updateIPsForName(lookupTime, dnsName, lookupIPs.IPs, lookupIPs.TTL)
 
 		// The IPs didn't change. No more to be done for this dnsName
-		if !updated {
+		if !updated && gen.bootstrapCompleted {
+			log.WithFields(logrus.Fields{
+				"dnsName":   dnsName,
+				"lookupIPs": lookupIPs,
+			}).Debug("IPs didn't change for DNS name")
 			continue perDNSName
 		}
 
 		// record the IPs that were different
 		updatedNames[dnsName] = lookupIPs.IPs
 
-		// accumulate the rules affected by new IPs, that we need to update with
-		// CIDR rules
-		for _, uuid := range gen.sourceRules.LookupValues(dnsName) {
-			affectedRulesSet[uuid] = struct{}{}
+		// accumulate the new selectors affected by new IPs
+		for fqdnSel, fqdnRegex := range gen.allSelectors {
+			matches := fqdnRegex.MatchString(dnsName)
+			if matches {
+				affectedSelectors[fqdnSel] = struct{}{}
+			}
 		}
 	}
 
-	// Convert the set to a list
-	for uuid := range affectedRulesSet {
-		affectedRules = append(affectedRules, uuid)
-	}
-
-	return affectedRules, updatedNames
+	return affectedSelectors, updatedNames
 }
 
-// GetRulesByUUID returns the sourceRule copies of inserted rules. These are
-// the source of truth when generating rules with update IPs.
-// sourceRules is the list of *api.Rule objects that were found (i.e. currently
-// in the gen and not deleted)
-// notFoundUUIDs is the set of UUIDs not found. This can occur when a delete
-// races with other operations. It is benign in the sense that if a rule UUID is
-// not found, no action further action is needed.
-func (gen *RuleGen) GetRulesByUUID(uuids []string) (sourceRules []*api.Rule, notFoundUUIDs []string) {
+// GenerateSelectorUpdates iterates over all names in the DNS cache managed by
+// gen and figures out to which FQDNSelectors managed by the cache these names
+// map. Returns the set of FQDNSelectors which map to no IPs, and a mapping
+// of FQDNSelectors to IPs.
+func (gen *RuleGen) GenerateSelectorUpdates(fqdnSelectors map[api.FQDNSelector]struct{}) (namesMissingIPs []api.FQDNSelector, selectorIPMapping map[api.FQDNSelector][]net.IP) {
 	gen.Lock()
 	defer gen.Unlock()
 
-	for _, uuid := range uuids {
-		rule, ok := gen.allRules[uuid]
-		// This may happen if a rule was deleted during, other processing, like the DNS lookups
-		if !ok {
-			notFoundUUIDs = append(notFoundUUIDs, uuid)
-			continue
-		}
-
-		sourceRules = append(sourceRules, rule)
-	}
-
-	return sourceRules, notFoundUUIDs
-}
-
-// GenerateRulesFromSources creates new api.Rule instances with all ToFQDN
-// targets resolved to IPs. The IPs are in generated CIDRSet rules in the
-// ToCIDRSet section. Pre-existing rules in ToCIDRSet are preserved
-// Note: GenerateRulesFromSources will make a copy of each sourceRule
-func (gen *RuleGen) GenerateRulesFromSources(sourceRules []*api.Rule) (generatedRules []*api.Rule, namesMissingIPs []api.FQDNSelector, selectorIPMapping map[api.FQDNSelector][]net.IP) {
-	gen.Lock()
-	defer gen.Unlock()
-
-	var namesMissingMap = make(map[api.FQDNSelector]struct{})
-
-	for _, sourceRule := range sourceRules {
-		newRule := sourceRule.DeepCopy()
-		_, namesMissingIPs, selectorIPMapping = injectToCIDRSetRules(newRule, gen.cache, gen.sourceRules)
-		for _, missing := range namesMissingIPs {
-			namesMissingMap[missing] = struct{}{}
-		}
-		generatedRules = append(generatedRules, newRule)
-	}
-
-	for missing := range namesMissingMap {
-		namesMissingIPs = append(namesMissingIPs, missing)
-	}
-
-	return generatedRules, namesMissingIPs, selectorIPMapping
-}
-
-// addRule places an api.Rule in the source list for a DNS name.
-// uuid must be the unique identifier generated for the ToFQDN-UUID label.
-// newDNSNames and oldDNSNames indicate names that were newly added from this
-// rule, or that were seen in this rule but were already managed.
-// If newDNSNames and oldDNSNames are both empty, the rule was not added to the
-// managed list.
-func (gen *RuleGen) addRule(uuid string, sourceRule *api.Rule) (newDNSNames, oldDNSNames []string, err error) {
-	// if we are updating a rule, track which old dnsNames are removed. We store
-	// possible names to stop managing in namesToStopManaging. As we add names
-	// from the new rule below, these are cleared.
-	namesToStopManaging := make(map[string]struct{})
-	if oldRule, exists := gen.allRules[uuid]; exists {
-		for _, egressRule := range oldRule.Egress {
-			for _, ToFQDN := range egressRule.ToFQDNs {
-				if len(ToFQDN.MatchName) > 0 {
-					dnsName := prepareMatchName(ToFQDN.MatchName)
-					dnsNameAsRE := matchpattern.ToRegexp(dnsName)
-					namesToStopManaging[dnsNameAsRE] = struct{}{}
-				}
-				if len(ToFQDN.MatchPattern) > 0 {
-					dnsPattern := matchpattern.Sanitize(ToFQDN.MatchPattern)
-					dnsPatternAsRE := matchpattern.ToRegexp(dnsPattern)
-					namesToStopManaging[dnsPatternAsRE] = struct{}{}
-				}
-			}
-		}
-	}
-
-	// Always add to allRules
-	gen.allRules[uuid] = sourceRule
-
-	// Add a dnsname -> rule reference. We track old/new names by the literal
-	// value in matchName/Pattern. They are inserted into the sourceRules
-	// RegexpMap as regexeps, however, so we can match against them later.
-	for _, egressRule := range sourceRule.Egress {
-		for _, ToFQDN := range egressRule.ToFQDNs {
-			REsToAddForUUID := map[string]string{}
-
-			if len(ToFQDN.MatchName) > 0 {
-				dnsName := prepareMatchName(ToFQDN.MatchName)
-				dnsNameAsRE := matchpattern.ToRegexp(dnsName)
-				REsToAddForUUID[ToFQDN.MatchName] = dnsNameAsRE
-				gen.namesToPoll[dnsName] = struct{}{}
-			}
-
-			if len(ToFQDN.MatchPattern) > 0 {
-				dnsPattern := matchpattern.Sanitize(ToFQDN.MatchPattern)
-				dnsPatternAsRE := matchpattern.ToRegexp(dnsPattern)
-				REsToAddForUUID[ToFQDN.MatchPattern] = dnsPatternAsRE
-			}
-
-			for policyMatchStr, dnsPatternAsRE := range REsToAddForUUID {
-				delete(namesToStopManaging, dnsPatternAsRE) // keep managing this matchName/Pattern
-				// check if this is already managed or not
-				if exists := gen.sourceRules.LookupContainsValue(dnsPatternAsRE, uuid); exists {
-					oldDNSNames = append(oldDNSNames, policyMatchStr)
-				} else {
-					// This ToFQDNs.MatchName/Pattern has not been seen before
-					newDNSNames = append(newDNSNames, policyMatchStr)
-					// Add this egress rule as a dependent on ToFQDNs.MatchPattern, but fixup the literal
-					// name so it can work as a regex
-					if err = gen.sourceRules.Add(dnsPatternAsRE, uuid); err != nil {
-						return nil, nil, err
-					}
-				}
-			}
-		}
-	}
-
-	// Stop managing names/patterns that remain in shouldStopManaging (i.e. not
-	// seen when iterating .ToFQDNs rules above). The net result is to remove
-	// dnsName -> uuid associations that existed in the older version of the rule
-	// with this UUID, but did not re-occur in the new instance.
-	// When a dnsName has no uuid associations, we remove it from the poll list
-	// outright.
-	for dnsName := range namesToStopManaging {
-		if shouldStopManaging := gen.removeFromDNSName(dnsName, uuid); shouldStopManaging {
-			delete(gen.namesToPoll, dnsName) // A no-op for matchPattern
-		}
-	}
-
-	return newDNSNames, oldDNSNames, nil
-}
-
-// removeRule removes an api.Rule from the source rule set for each DNS name,
-// and from the IPs if no rules depend on that DNS name.
-// uuid must be a unique identifier for the sourceRule
-// noLongerManaged indicates that no more rules rely on this DNS target
-func (gen *RuleGen) removeRule(uuid string, sourceRule *api.Rule) (noLongerManaged []string) {
-	// Always delete from allRules
-	delete(gen.allRules, uuid)
-
-	// Delete dnsname -> rule references
-	for _, egressRule := range sourceRule.Egress {
-		for _, ToFQDN := range egressRule.ToFQDNs {
-			if len(ToFQDN.MatchName) > 0 {
-				dnsName := prepareMatchName(ToFQDN.MatchName)
-				dnsNameAsRE := matchpattern.ToRegexp(dnsName)
-				if shouldStopManaging := gen.removeFromDNSName(dnsNameAsRE, uuid); shouldStopManaging {
-					delete(gen.namesToPoll, dnsName)
-					noLongerManaged = append(noLongerManaged, ToFQDN.MatchName)
-				}
-			}
-
-			if len(ToFQDN.MatchPattern) > 0 {
-				dnsPattern := matchpattern.Sanitize(ToFQDN.MatchPattern)
-				dnsPatternAsRE := matchpattern.ToRegexp(dnsPattern)
-				if shouldStopManaging := gen.removeFromDNSName(dnsPatternAsRE, uuid); shouldStopManaging {
-					noLongerManaged = append(noLongerManaged, ToFQDN.MatchPattern)
-				}
-			}
-		}
-	}
-
-	return noLongerManaged
-}
-
-// removeFromDNSName removes the uuid from the list attached to a dns name. It
-// will clean up gen.sourceRules if needed.
-// shouldStopManaging indicates that no more rules rely on this DNS target
-func (gen *RuleGen) removeFromDNSName(dnsName, uuid string) (shouldStopManaging bool) {
-	// remove the rule from the set of rules that rely on dnsName.
-	// Note: this isn't removing dnsName from gen.sourceRules, that is just
-	// below.
-	return gen.sourceRules.Remove(dnsName, uuid)
+	namesMissingIPs, selectorIPMapping = mapSelectorsToIPs(fqdnSelectors, gen.cache)
+	return namesMissingIPs, selectorIPMapping
 }
 
 // updateIPsName will update the IPs for dnsName. It always retains a copy of

--- a/pkg/fqdn/rulegen_test.go
+++ b/pkg/fqdn/rulegen_test.go
@@ -39,7 +39,7 @@ func lookupFail(c *C, dnsNames []string) (DNSIPs map[string]*DNSIPRecords, error
 // add a rule, get same UUID label on repeat generations
 func (ds *FQDNTestSuite) TestRuleGenCIDRGeneration(c *C) {
 	var (
-		generatedRules = make([]*api.Rule, 0)
+		selIPMap map[api.FQDNSelector][]net.IP
 
 		gen = NewRuleGen(Config{
 			MinTTL: 1,
@@ -49,92 +49,46 @@ func (ds *FQDNTestSuite) TestRuleGenCIDRGeneration(c *C) {
 				return lookupFail(c, dnsNames)
 			},
 
-			AddGeneratedRulesAndUpdateSelectors: func(rules []*api.Rule, selectorIPMapping map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) error {
-				generatedRules = append(generatedRules, rules...)
+			UpdateSelectors: func(selectorIPMapping map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) error {
+				for k, v := range selectorIPMapping {
+					selIPMap[k] = v
+				}
 				return nil
 			},
 		})
 	)
 
 	// add rules
-	rulesToAdd := []*api.Rule{rule1.DeepCopy()}
-	gen.PrepareFQDNRules(rulesToAdd)
-	gen.StartManageDNSName(rulesToAdd)
-
-	// store original UUID
-	uuidOrig := getRuleUUIDLabel(rulesToAdd[0])
-	c.Assert(uuidOrig, Not(Equals), "", Commentf("UUID label not set on rule, or not recovered correctly"))
+	ids := gen.RegisterForIdentityUpdates(ciliumIOSel)
+	c.Assert(len(ids), Equals, 0)
 
 	// poll DNS once, check that we only generate 1 rule (for 1 IP) and that we
 	// still have 1 ToFQDN rule, and that the IP is correct
-	generatedRules = nil
+	selIPMap = make(map[api.FQDNSelector][]net.IP)
 	err := gen.UpdateGenerateDNS(time.Now(), map[string]*DNSIPRecords{dns.Fqdn("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}}})
-	c.Assert(err, IsNil, Commentf("Error generating IP CIDR rules"))
-	c.Assert(len(generatedRules), Equals, 1, Commentf("Incorrect number of generated rules for testCase with single ToFQDNs entry"))
-	c.Assert(len(generatedRules[0].Egress), Equals, 1, Commentf("Incorrect number of generated egress rules for testCase with single ToFQDNs entry"))
-	c.Assert(len(generatedRules[0].Egress[0].ToFQDNs), Equals, len(generatedRules[0].Egress[0].ToCIDRSet), Commentf("Generated CIDR count is not the same as ToFQDNs"))
-	c.Assert(generatedRules[0].Egress[0].ToCIDRSet[0].Cidr, Equals, api.CIDR("1.1.1.1/32"), Commentf("Incorrect IP CIDR generated"))
+	c.Assert(err, IsNil, Commentf("Error mapping selectors to IPs"))
+	c.Assert(len(selIPMap), Equals, 1, Commentf("Incorrect length for testCase with single ToFQDNs entry"))
 
-	// Check that the UUID has not changed
-	uuid1 := getRuleUUIDLabel(generatedRules[0])
-	c.Assert(uuid1, Equals, uuidOrig, Commentf("UUID label has changed on rule since original insert"))
+	expectedIPs := []net.IP{net.ParseIP("1.1.1.1")}
+	ips, _ := selIPMap[ciliumIOSel]
+	c.Assert(ips[0].Equal(expectedIPs[0]), Equals, true)
 
 	// poll DNS once, check that we only generate 1 rule (for 2 IPs that we
 	// inserted) and that we still have 1 ToFQDN rule, and that the IP, now
 	// different, is correct
-	generatedRules = nil
+	selIPMap = make(map[api.FQDNSelector][]net.IP)
 	err = gen.UpdateGenerateDNS(time.Now(), map[string]*DNSIPRecords{dns.Fqdn("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("2.2.2.2")}}})
 	c.Assert(err, IsNil, Commentf("Error generating IP CIDR rules"))
-	c.Assert(len(generatedRules), Equals, 1, Commentf("More than 1 generated rule for testCase with single ToFQDNs entry"))
-	c.Assert(len(generatedRules[0].Egress), Equals, 1, Commentf("More than 1 generated rule for testCase with single ToFQDNs entry"))
-	c.Assert(len(generatedRules[0].Egress[0].ToFQDNs), Equals, 1, Commentf("toFQDNs rule count changed when it should not"))
-	c.Assert(len(generatedRules[0].Egress[0].ToCIDRSet), Equals, 2, Commentf("Generated CIDR count is not the same as inserted IPs"))
-	c.Assert(generatedRules[0].Egress[0].ToCIDRSet[0].Cidr, Equals, api.CIDR("1.1.1.1/32"), Commentf("Incorrect IP CIDR generated"))
-	c.Assert(generatedRules[0].Egress[0].ToCIDRSet[1].Cidr, Equals, api.CIDR("2.2.2.2/32"), Commentf("Incorrect IP CIDR generated"))
-
-	// check that the UUID has not changed
-	uuid2 := getRuleUUIDLabel(generatedRules[0])
-	c.Assert(uuid2, Equals, uuidOrig, Commentf("UUID label has changed on rule since original insert"))
-	c.Assert(uuid2, Equals, uuid1, Commentf("UUID label has changed on rule since previous generation"))
-}
-
-// TestRuleGenDropCIDROnReinsert tests that we correctly guard against
-// pre-existing toCIDRSet sections:
-// - when we initially insert
-// - when we re-insert a generated rule
-func (ds *FQDNTestSuite) TestRuleGenDropCIDROnReinsert(c *C) {
-	var (
-		generatedRules = make([]*api.Rule, 0)
-
-		gen = NewRuleGen(Config{
-			Cache: NewDNSCache(0),
-			LookupDNSNames: func(dnsNames []string) (DNSIPs map[string]*DNSIPRecords, errorDNSNames map[string]error) {
-				return lookupFail(c, dnsNames)
-			},
-
-			AddGeneratedRulesAndUpdateSelectors: func(rules []*api.Rule, selectorIPMapping map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) error {
-				generatedRules = append(generatedRules, rules...)
-				return nil
-			},
-		})
-	)
-
-	// Add a fake "generated" CIDR entry, it should not come back later when generated
-	rulesToAdd := []*api.Rule{rule1.DeepCopy()}
-	gen.PrepareFQDNRules(rulesToAdd)
-	rulesToAdd[0].Egress[0].ToCIDRSet = append(rulesToAdd[0].Egress[0].ToCIDRSet, api.CIDRRule{Cidr: api.CIDR("2.2.2.2/32")})
-	gen.StartManageDNSName(rulesToAdd)
-	err := gen.UpdateGenerateDNS(time.Now(), map[string]*DNSIPRecords{dns.Fqdn("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}}})
-	c.Assert(err, IsNil, Commentf("Error generating IP CIDR rules"))
-	c.Assert(len(generatedRules), Equals, 1, Commentf("Generated an unexpected number of rules"))
-	c.Assert(len(rulesToAdd[0].Egress[0].ToCIDRSet), Equals, 1, Commentf("existing toCIDRSet section not stripped by GenerateRules"))
-	c.Assert(generatedRules[0].Egress[0].ToCIDRSet[0].Cidr, Equals, api.CIDR("1.1.1.1/32"), Commentf("Incorrect IP CIDR generated"))
+	c.Assert(len(selIPMap), Equals, 1, Commentf("Only one entry per FQDNSelector should be present"))
+	expectedIPs = []net.IP{net.ParseIP("1.1.1.1"), net.ParseIP("2.2.2.2")}
+	c.Assert(selIPMap[ciliumIOSel][0].Equal(expectedIPs[0]), Equals, true)
+	c.Assert(selIPMap[ciliumIOSel][1].Equal(expectedIPs[1]), Equals, true)
 }
 
 // Test that all IPs are updated when one is
 func (ds *FQDNTestSuite) TestRuleGenMultiIPUpdate(c *C) {
 	var (
-		generatedRules = make([]*api.Rule, 0)
+		selIPMap map[api.FQDNSelector][]net.IP
 
 		gen = NewRuleGen(Config{
 			MinTTL: 1,
@@ -144,178 +98,63 @@ func (ds *FQDNTestSuite) TestRuleGenMultiIPUpdate(c *C) {
 				return lookupFail(c, dnsNames)
 			},
 
-			AddGeneratedRulesAndUpdateSelectors: func(rules []*api.Rule, selectorIPMapping map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) error {
-				generatedRules = append(generatedRules, rules...)
+			UpdateSelectors: func(selectorIPMapping map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) error {
+				for k, v := range selectorIPMapping {
+					selIPMap[k] = v
+				}
 				return nil
 			},
 		})
 	)
 
 	// add rules
-	rulesToAdd := []*api.Rule{rule3.DeepCopy()}
-	gen.PrepareFQDNRules(rulesToAdd)
-	gen.StartManageDNSName(rulesToAdd)
+	selectorsToAdd := api.FQDNSelectorSlice{ciliumIOSel, githubSel}
+	for _, sel := range selectorsToAdd {
+		gen.RegisterForIdentityUpdates(sel)
+	}
 
 	// poll DNS once, check that we only generate 1 IP for cilium.io
-	generatedRules = nil
+	selIPMap = make(map[api.FQDNSelector][]net.IP)
 	err := gen.UpdateGenerateDNS(time.Now(), map[string]*DNSIPRecords{dns.Fqdn("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}}})
-	c.Assert(err, IsNil, Commentf("Error generating IP CIDR rules"))
-	c.Assert(len(generatedRules), Equals, 1, Commentf("Incorrect number of generated rules for testCase with single ToFQDNs entry"))
-	c.Assert(len(generatedRules[0].Egress), Equals, 1, Commentf("Incorrect number of generated egress rules for testCase with single ToFQDNs entry"))
-	c.Assert(len(generatedRules[0].Egress[0].ToCIDRSet), Equals, 1, Commentf("Generated CIDR count is not the same as ToFQDNs"))
-	c.Assert(generatedRules[0].Egress[0].ToCIDRSet[0].Cidr, Equals, api.CIDR("1.1.1.1/32"), Commentf("Incorrect IP CIDR generated"))
+	c.Assert(err, IsNil, Commentf("Error mapping selectors to IPs"))
+	c.Assert(len(selIPMap), Equals, 1, Commentf("Incorrect number of plumbed FQDN selectors"))
+	c.Assert(selIPMap[ciliumIOSel][0].Equal(net.ParseIP("1.1.1.1")), Equals, true)
 
 	// poll DNS once, check that we only generate 3 IPs, 2 cached from before and 1 new one for github.com
-	generatedRules = nil
+	selIPMap = make(map[api.FQDNSelector][]net.IP)
 	err = gen.UpdateGenerateDNS(time.Now(), map[string]*DNSIPRecords{
 		dns.Fqdn("cilium.io"):  {TTL: 60, IPs: []net.IP{net.ParseIP("2.2.2.2")}},
 		dns.Fqdn("github.com"): {TTL: 60, IPs: []net.IP{net.ParseIP("3.3.3.3")}}})
-	c.Assert(err, IsNil, Commentf("Error generating IP CIDR rules"))
-	c.Assert(len(generatedRules), Equals, 1, Commentf("More than 1 generated rule for testCase with single ToFQDNs entry"))
-	c.Assert(len(generatedRules[0].Egress), Equals, 1, Commentf("Incorrect number of generated egress rules for testCase with single ToFQDNs entry"))
-	c.Assert(len(generatedRules[0].Egress[0].ToCIDRSet), Equals, 3, Commentf("Generated CIDR count is not the same as ToFQDNs"))
-	c.Assert(generatedRules[0].Egress[0].ToCIDRSet[0].Cidr, Equals, api.CIDR("1.1.1.1/32"), Commentf("Incorrect IP CIDR generated"))
-	c.Assert(generatedRules[0].Egress[0].ToCIDRSet[1].Cidr, Equals, api.CIDR("2.2.2.2/32"), Commentf("Incorrect IP CIDR generated"))
-	c.Assert(generatedRules[0].Egress[0].ToCIDRSet[2].Cidr, Equals, api.CIDR("3.3.3.3/32"), Commentf("Incorrect IP CIDR generated"))
+	c.Assert(err, IsNil, Commentf("Error mapping selectors to IPs"))
+	c.Assert(len(selIPMap), Equals, 2, Commentf("More than 2 FQDN selectors while only 2 were added"))
+	c.Assert(len(selIPMap[ciliumIOSel]), Equals, 2, Commentf("Incorrect number of IPs for cilium.io selector"))
+	c.Assert(len(selIPMap[githubSel]), Equals, 1, Commentf("Incorrect number of IPs for github.com selector"))
+	c.Assert(selIPMap[ciliumIOSel][0].Equal(net.ParseIP("1.1.1.1")), Equals, true, Commentf("Incorrect IP mapping to FQDN"))
+	c.Assert(selIPMap[ciliumIOSel][1].Equal(net.ParseIP("2.2.2.2")), Equals, true, Commentf("Incorrect IP mapping to FQDN"))
+	c.Assert(selIPMap[githubSel][0].Equal(net.ParseIP("3.3.3.3")), Equals, true, Commentf("Incorrect IP mapping to FQDN"))
 
-	// poll DNS once, check that we only generate 4 IPs, 2 cilium.io cached IPs, 1 cached gituhub.com IP, 1 new github.com IP
-	generatedRules = nil
+	// poll DNS once, check that we only generate 4 IPs, 2 cilium.io cached IPs, 1 cached github.com IP, 1 new github.com IP
+	selIPMap = make(map[api.FQDNSelector][]net.IP)
 	err = gen.UpdateGenerateDNS(time.Now(), map[string]*DNSIPRecords{
 		dns.Fqdn("cilium.io"):  {TTL: 60, IPs: []net.IP{net.ParseIP("2.2.2.2")}},
 		dns.Fqdn("github.com"): {TTL: 60, IPs: []net.IP{net.ParseIP("4.4.4.4")}}})
-	c.Assert(err, IsNil, Commentf("Error generating IP CIDR rules"))
-	c.Assert(len(generatedRules), Equals, 1, Commentf("More than 1 generated rule for testCase with single ToFQDNs entry"))
-	c.Assert(len(generatedRules[0].Egress), Equals, 1, Commentf("Incorrect number of generated egress rules for testCase with single ToFQDNs entry"))
-	c.Assert(len(generatedRules[0].Egress[0].ToCIDRSet), Equals, 4, Commentf("Generated CIDR count is not the same as ToFQDNs"))
-	c.Assert(generatedRules[0].Egress[0].ToCIDRSet[0].Cidr, Equals, api.CIDR("1.1.1.1/32"), Commentf("Incorrect IP CIDR generated"))
-	c.Assert(generatedRules[0].Egress[0].ToCIDRSet[1].Cidr, Equals, api.CIDR("2.2.2.2/32"), Commentf("Incorrect IP CIDR generated"))
-	c.Assert(generatedRules[0].Egress[0].ToCIDRSet[2].Cidr, Equals, api.CIDR("3.3.3.3/32"), Commentf("Incorrect IP CIDR generated"))
-	c.Assert(generatedRules[0].Egress[0].ToCIDRSet[3].Cidr, Equals, api.CIDR("4.4.4.4/32"), Commentf("Incorrect IP CIDR generated"))
-}
+	c.Assert(err, IsNil, Commentf("Error mapping selectors to IPs"))
+	c.Assert(len(selIPMap[ciliumIOSel]), Equals, 2, Commentf("Incorrect number of IPs for cilium.io selector"))
+	c.Assert(len(selIPMap[githubSel]), Equals, 2, Commentf("Incorrect number of IPs for github.com selector"))
+	c.Assert(selIPMap[ciliumIOSel][0].Equal(net.ParseIP("1.1.1.1")), Equals, true, Commentf("Incorrect IP mapping to FQDN"))
+	c.Assert(selIPMap[ciliumIOSel][1].Equal(net.ParseIP("2.2.2.2")), Equals, true, Commentf("Incorrect IP mapping to FQDN"))
+	c.Assert(selIPMap[githubSel][0].Equal(net.ParseIP("3.3.3.3")), Equals, true, Commentf("Incorrect IP mapping to FQDN"))
+	c.Assert(selIPMap[githubSel][1].Equal(net.ParseIP("4.4.4.4")), Equals, true, Commentf("Incorrect IP mapping to FQDN"))
 
-// TestRuleGenUpdatesOnReplace tests updates without deletion:
-// add 1 matchname, poll. re-add it. See the correct output on MarkToFQDNRules
-// add 2 matchnames with the different names, replace one, then back. See the correct output on MarkToFQDNRules
-// re-add the original rule with only 1 matchname. It is not cached because that name was deleted
-func (ds *FQDNTestSuite) TestRuleGenUpdatesOnReplace(c *C) {
+	ids := gen.RegisterForIdentityUpdates(githubSel)
+	c.Assert(ids, IsNil)
 
-	var (
-		lookups = make(map[string]int)
-		dnsIPs  = map[string]*DNSIPRecords{
-			dns.Fqdn("cilium.io"):         {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}},
-			dns.Fqdn("github.com"):        {TTL: 60, IPs: []net.IP{net.ParseIP("2.2.2.2")}},
-			dns.Fqdn("anotherdomain.com"): {TTL: 60, IPs: []net.IP{net.ParseIP("3.3.3.3")}},
-		}
+	gen.UnregisterForIdentityUpdates(githubSel)
+	_, exists := gen.allSelectors[githubSel]
+	c.Assert(exists, Equals, false)
 
-		gen = NewRuleGen(Config{
-			MinTTL: 1,
-			Cache:  NewDNSCache(0),
+	gen.UnregisterForIdentityUpdates(ciliumIOSel)
+	_, exists = gen.allSelectors[ciliumIOSel]
+	c.Assert(exists, Equals, false)
 
-			LookupDNSNames: func(dnsNames []string) (DNSIPs map[string]*DNSIPRecords, errorDNSNames map[string]error) {
-				return lookupFail(c, dnsNames)
-			},
-
-			AddGeneratedRulesAndUpdateSelectors: func(rules []*api.Rule, selectorIPMapping map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) error {
-				return nil
-			},
-		})
-	)
-
-	// Add 1 rules and poll
-	rules := []*api.Rule{makeRule("testRule", "cilium.io")}
-	// MarkToFQDNRules adds nothing on the first try
-	gen.PrepareFQDNRules(rules)
-	c.Assert(len(rules[0].Egress), Equals, 1, Commentf("Incorrect number of generated egress rules for testCase with single ToFQDNs entry"))
-	c.Assert(len(rules[0].Egress[0].ToCIDRSet), Equals, 0, Commentf("Generated CIDR count is 0 when no CIDRs should have been added"))
-
-	gen.StartManageDNSName(rules)
-	gen.UpdateGenerateDNS(time.Now(), lookupDNSNames(dnsIPs, lookups, []string{dns.Fqdn("cilium.io")}))
-
-	// Add another rule with the same FQDN. We should see IPs in-place BEFORE StartManageDNSName.
-	// MarkToFQDNRules adds the IP from the cache
-	rules = []*api.Rule{makeRule("testRule2", "cilium.io")}
-	gen.PrepareFQDNRules(rules)
-	c.Assert(len(rules[0].Egress), Equals, 1, Commentf("Incorrect number of generated egress rules for testCase with single ToFQDNs entry"))
-	c.Assert(len(rules[0].Egress[0].ToCIDRSet), Equals, 1, Commentf("Generated CIDR count is not the same as ToFQDNs"))
-	c.Assert(rules[0].Egress[0].ToCIDRSet[0].Cidr, Equals, api.CIDR("1.1.1.1/32"), Commentf("Incorrect IP CIDR generated"))
-
-	gen.StartManageDNSName(rules)
-	gen.UpdateGenerateDNS(time.Now(), lookupDNSNames(dnsIPs, lookups, []string{dns.Fqdn("cilium.io")}))
-
-	// Add 2 rules and poll
-	rules = []*api.Rule{makeRule("testRule3", "cilium.io", "github.com")}
-	gen.PrepareFQDNRules(rules)
-	gen.StartManageDNSName(rules)
-	gen.UpdateGenerateDNS(time.Now(), lookupDNSNames(dnsIPs, lookups, []string{dns.Fqdn("cilium.io"), dns.Fqdn("github.com")}))
-
-	// Add a 2 matchnames, only one overlaps
-	// MarkToFQDNRules should add only 1 entry
-	rules = []*api.Rule{makeRule("testRule4", "cilium.io", "anotherdomain.com")}
-	gen.PrepareFQDNRules(rules)
-	c.Assert(len(rules[0].Egress), Equals, 1, Commentf("Incorrect number of generated egress rules for testCase with single cached ToFQDNs DNS entry"))
-	c.Assert(len(rules[0].Egress[0].ToCIDRSet), Equals, 1, Commentf("Generated CIDR count is not the same as ToFQDNs DNS entries in cache"))
-	c.Assert(rules[0].Egress[0].ToCIDRSet[0].Cidr, Equals, api.CIDR("1.1.1.1/32"), Commentf("Incorrect IP CIDR generated"))
-
-	gen.StartManageDNSName(rules)
-	gen.UpdateGenerateDNS(time.Now(), lookupDNSNames(dnsIPs, lookups, []string{dns.Fqdn("cilium.io"), dns.Fqdn("anotherdomain.com")}))
-
-	// Add the original 2 matchnames without deleting
-	// MarkToFQDNRules should add 2 entries, as those should be in the gen cache
-	rules = []*api.Rule{makeRule("testRule5", "cilium.io", "github.com")}
-	gen.PrepareFQDNRules(rules)
-	c.Assert(len(rules[0].Egress), Equals, 1, Commentf("Incorrect number of generated egress rules for testCase with single cached ToFQDNs DNS entry"))
-	c.Assert(len(rules[0].Egress[0].ToCIDRSet), Equals, 2, Commentf("Generated CIDR count is not the same as ToFQDNs DNS entries in cache"))
-	c.Assert(rules[0].Egress[0].ToCIDRSet[0].Cidr, Equals, api.CIDR("1.1.1.1/32"), Commentf("Incorrect first IP CIDR generated from cache"))
-
-	gen.StartManageDNSName(rules)
-	gen.UpdateGenerateDNS(time.Now(), lookupDNSNames(dnsIPs, lookups, []string{dns.Fqdn("cilium.io"), dns.Fqdn("github.com")}))
-
-	// Add a rule with 1 old matchname
-	// MarkToFQDNRules should add one entry
-	rules = []*api.Rule{makeRule("testRule6", "anotherdomain.com")}
-	gen.PrepareFQDNRules(rules)
-	c.Assert(len(rules[0].Egress), Equals, 1, Commentf("Incorrect number of generated egress rules for testCase with single cached ToFQDNs DNS entry"))
-	c.Assert(len(rules[0].Egress[0].ToCIDRSet), Equals, 1, Commentf("Generated CIDR count is not the same as ToFQDNs DNS entries in cache"))
-}
-
-func (ds *FQDNTestSuite) TestPrepareFQDNRules(c *C) {
-
-	var (
-		generatedRules = make([]*api.Rule, 0)
-		gen            = NewRuleGen(Config{
-			MinTTL: 1,
-			Cache:  NewDNSCache(0),
-
-			LookupDNSNames: func(dnsNames []string) (DNSIPs map[string]*DNSIPRecords, errorDNSNames map[string]error) {
-				return lookupFail(c, dnsNames)
-			},
-
-			AddGeneratedRulesAndUpdateSelectors: func(rules []*api.Rule, selectorIPMapping map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) error {
-				generatedRules = append(generatedRules, rules...)
-				return nil
-			},
-		})
-	)
-
-	rules := []*api.Rule{rule3.DeepCopy()}
-
-	// Validate that no rules in RuleGen return the rule without issues.
-	rulez, _ := gen.PrepareFQDNRules(rules)
-	c.Assert(rulez, HasLen, 1)
-
-	// Validate that if rules is in RuleGen returns always 1
-	gen.StartManageDNSName(rules)
-	rulez, _ = gen.PrepareFQDNRules(rules)
-	c.Assert(rulez, HasLen, 1)
-
-	// Validate that an empty rule returns 0 len
-	emptyRules := []*api.Rule{}
-	rulez, _ = gen.PrepareFQDNRules(emptyRules)
-	c.Assert(rulez, HasLen, 0)
-
-	// Validate if the gen.AllRules are empty should return 0 rules due to UUID
-	// mismatch
-	gen.allRules = map[string]*api.Rule{}
-	rulez, _ = gen.PrepareFQDNRules(rules)
-	c.Assert(rulez, HasLen, 0)
 }

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -214,6 +214,20 @@ func (l4 *L4Filter) cacheIdentitySelectors(selectors api.EndpointSelectorSlice, 
 	}
 }
 
+func (l4 *L4Filter) cacheFQDNSelectors(selectors api.FQDNSelectorSlice, selectorCache *SelectorCache) {
+	for _, fqdnSel := range selectors {
+		l4.cacheFQDNSelector(fqdnSel, selectorCache)
+	}
+}
+
+func (l4 *L4Filter) cacheFQDNSelector(sel api.FQDNSelector, selectorCache *SelectorCache) CachedSelector {
+	cs, added := selectorCache.AddFQDNSelector(l4, sel)
+	if added {
+		l4.CachedSelectors = append(l4.CachedSelectors, cs)
+	}
+	return cs
+}
+
 // GetRelevantRulesForKafka returns the relevant rules based on the remote numeric identity.
 func (l7 L7DataMap) GetRelevantRulesForKafka(nid identity.NumericIdentity) []api.PortRuleKafka {
 	var rules []api.PortRuleKafka
@@ -242,7 +256,7 @@ func (l7 L7DataMap) addRulesForEndpoints(rules api.L7Rules, endpoints []CachedSe
 // rules via the `rule` parameter.
 // Not called with an empty peerEndpoints.
 func createL4Filter(peerEndpoints api.EndpointSelectorSlice, rule api.PortRule, port api.PortProtocol,
-	protocol api.L4Proto, ruleLabels labels.LabelArray, ingress bool, selectorCache *SelectorCache) *L4Filter {
+	protocol api.L4Proto, ruleLabels labels.LabelArray, ingress bool, selectorCache *SelectorCache, fqdns api.FQDNSelectorSlice) *L4Filter {
 
 	// already validated via PortRule.Validate()
 	p, _ := strconv.ParseUint(port.Port, 0, 16)
@@ -264,6 +278,7 @@ func createL4Filter(peerEndpoints api.EndpointSelectorSlice, rule api.PortRule, 
 	} else {
 		l4.CachedSelectors = make(CachedSelectorSlice, 0, len(peerEndpoints))
 		l4.cacheIdentitySelectors(peerEndpoints, selectorCache)
+		l4.cacheFQDNSelectors(fqdns, selectorCache)
 	}
 
 	if protocol == api.ProtoTCP && rule.Rules != nil {
@@ -305,7 +320,7 @@ func (l4 *L4Filter) detach(selectorCache *SelectorCache) {
 func createL4IngressFilter(fromEndpoints api.EndpointSelectorSlice, hostWildcardL7 bool, rule api.PortRule, port api.PortProtocol,
 	protocol api.L4Proto, ruleLabels labels.LabelArray, selectorCache *SelectorCache) *L4Filter {
 
-	filter := createL4Filter(fromEndpoints, rule, port, protocol, ruleLabels, true, selectorCache)
+	filter := createL4Filter(fromEndpoints, rule, port, protocol, ruleLabels, true, selectorCache, nil)
 
 	// If the filter would apply L7 rules for the Host, when we should accept everything from host,
 	// then wildcard Host at L7.
@@ -327,9 +342,9 @@ func createL4IngressFilter(fromEndpoints api.EndpointSelectorSlice, hostWildcard
 // to the original rules that the filter is derived from. This filter may be
 // associated with a series of L7 rules via the `rule` parameter.
 func createL4EgressFilter(toEndpoints api.EndpointSelectorSlice, rule api.PortRule, port api.PortProtocol,
-	protocol api.L4Proto, ruleLabels labels.LabelArray, selectorCache *SelectorCache) *L4Filter {
+	protocol api.L4Proto, ruleLabels labels.LabelArray, selectorCache *SelectorCache, fqdns api.FQDNSelectorSlice) *L4Filter {
 
-	return createL4Filter(toEndpoints, rule, port, protocol, ruleLabels, false, selectorCache)
+	return createL4Filter(toEndpoints, rule, port, protocol, ruleLabels, false, selectorCache, fqdns)
 }
 
 // IsRedirect returns true if the L4 filter contains a port redirection

--- a/pkg/policy/l4_test.go
+++ b/pkg/policy/l4_test.go
@@ -79,7 +79,7 @@ func (s *PolicyTestSuite) TestCreateL4Filter(c *C) {
 		filter := createL4IngressFilter(eps, false, portrule, tuple, tuple.Protocol, nil, testSelectorCache)
 		c.Assert(len(filter.L7RulesPerEp), Equals, 1)
 
-		filter = createL4EgressFilter(eps, portrule, tuple, tuple.Protocol, nil, testSelectorCache)
+		filter = createL4EgressFilter(eps, portrule, tuple, tuple.Protocol, nil, testSelectorCache, nil)
 		c.Assert(len(filter.L7RulesPerEp), Equals, 1)
 	}
 }

--- a/test/k8sT/fqdn.go
+++ b/test/k8sT/fqdn.go
@@ -48,11 +48,13 @@ var _ = Describe("K8sFQDNTest", func() {
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 		ProvisionInfraPods(kubectl)
 
+		By("Applying bind deployment")
 		bindManifest = helpers.ManifestGet("bind_deployment.yaml")
 
 		res := kubectl.Apply(bindManifest)
 		res.ExpectSuccess("Bind config cannot be deployed")
 
+		By("Applying demo manifest")
 		res = kubectl.Apply(demoManifest)
 		res.ExpectSuccess("Demo config cannot be deployed")
 


### PR DESCRIPTION
This PR uses the SelectorCache for storing the mapping of FQDNs to the IPs which match said FQDNs. These IPs are resolved via DNS lookups for both the poller and DNS proxy. Rules are not used to convey this information anymore. The FQDN subsystem is only notified of whether it needs to care about a given FQDNSelector if there is an endpoint which utilizes said selector running on the local cilium-agent.

Signed-off by: Ian Vernon <ian@cilium.io>

Miscellaneous thoughts:


I think this is ready for merge. I still need to go through and remove old references to CIDR rules, etc. We may want to rename `RuleGen` to something else since it doesn't really generate rules anymore.



<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8117)
<!-- Reviewable:end -->
