### PR TITLE
test: fix incorrect deletion statement for policy

### DIFF
--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -894,8 +894,8 @@ EOF`, k, v)
 		AfterAll(func() {
 			_ = kubectl.Delete(demoPath)
 			_ = kubectl.Delete(demoManifest)
+			_ = kubectl.Delete(cnpSecondNS)
 			_ = kubectl.NamespaceDelete(secondNS)
-			_ = kubectl.NamespaceDelete(cnpSecondNS)
 		})
 
 		It("Tests the same Policy in different namespaces", func() {


### PR DESCRIPTION
The deletion of policy should be done via the `Delete` function call instead of the
`Namespace` delete function call; fix an incorrect usage of this in the Policies.go
file accordingly.

Signed-off by: Ian Vernon <ian@cilium.io>

This will help stabilize the CI and eliminate the issue documented in #7902. This does not fix the issue (as it appears that L7 ingress policy to the host is broken in current master).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8118)
<!-- Reviewable:end -->
