### PR TITLE
CI: Longer git clone timeouts

### DIFF
--- a/docs.Jenkinsfile
+++ b/docs.Jenkinsfile
@@ -39,7 +39,7 @@ pipeline {
     stages {
         stage('Docs') {
             options {
-                timeout(time: 10, unit: 'MINUTES')
+                timeout(time: 20, unit: 'MINUTES')
             }
             steps {
                 Status("PENDING", "${env.JOB_NAME}")

--- a/flannel.Jenkinsfile
+++ b/flannel.Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
     stages {
         stage('Checkout') {
             options {
-                timeout(time: 10, unit: 'MINUTES')
+                timeout(time: 20, unit: 'MINUTES')
             }
 
             steps {

--- a/ginkgo-kubernetes-all.Jenkinsfile
+++ b/ginkgo-kubernetes-all.Jenkinsfile
@@ -50,7 +50,7 @@ pipeline {
     stages {
         stage('Checkout') {
             options {
-                timeout(time: 10, unit: 'MINUTES')
+                timeout(time: 20, unit: 'MINUTES')
             }
 
             steps {

--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
     stages {
         stage('Checkout') {
             options {
-                timeout(time: 10, unit: 'MINUTES')
+                timeout(time: 20, unit: 'MINUTES')
             }
 
             steps {


### PR DESCRIPTION
We've been hitting the 10 minute clone timeout in the CI-Pipeline tests.
The clone is simply slow in these cases, and is almost complete at
timeout. Doubling it allows us to proceed in these slow cases.

Note: We are trading time around because the build, overall, has a
timeout that includes build-queue wait times. We may still timeout, just
not during clone.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8122)
<!-- Reviewable:end -->
