### PR TITLE
CI: Enable Validate to-entities policies test

### DIFF
--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -564,8 +564,6 @@ var _ = Describe("K8sPolicyTest", func() {
 			})
 
 			It("Validate toEntities Cluster", func() {
-				Skip("Test currently broken GH-7947")
-
 				By("Installing toEntities Cluster")
 				importPolicy(cnpToEntitiesCluster, "to-entities-cluster")
 


### PR DESCRIPTION
This flake may now be fixed. This PR allows us to test that. I've run a small, not terribly insightful, count of test runs. They didn't fail but, ultimately, yolo enabling this test is the only way to get exposure to see if it still flakes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8123)
<!-- Reviewable:end -->
