### PR TITLE
Docs: Fix typo in upgrade instructions

### DIFF
--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -281,7 +281,7 @@ Changes that may require action
     perform more aggressive aggregation on packet forwarding related events to
     reduce CPU consumption while running ``cilium monitor``. The automatic
     change only applies to the default ConfigMap. Existing deployments will
-    need to change the setting in the ConfigMap explicitely.
+    need to change the setting in the ConfigMap explicitly.
 
 New ConfigMap Options
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This is currently on master. I will merge it if it passes tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8125)
<!-- Reviewable:end -->
