### PR TITLE
agent: Support reading CNI configuration from agent to set per node settings

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -113,6 +113,7 @@ cilium-agent [flags]
       --prepend-iptables-chains                    Prepend custom iptables chains instead of appending (default true)
       --prometheus-serve-addr string               IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
       --proxy-connect-timeout uint                 Time after which a TCP connect attempt is considered failed unless completed (in seconds) (default 1)
+      --read-cni-conf string                       Read to the CNI configuration at specified path to extract per node configuration
       --restore                                    Restores state, if possible, from previous daemon (default true)
       --sidecar-istio-proxy-image string           Regular expression matching compatible Istio sidecar istio-proxy container image names (default "cilium/istio_proxy")
       --single-cluster-route                       Use a single cluster route instead of per node routes

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -540,6 +540,11 @@ const (
 	// ProxyConnectTimeout specifies the time in seconds after which a TCP connection attempt
 	// is considered timed out
 	ProxyConnectTimeout = "proxy-connect-timeout"
+
+	// ReadCNIConfiguration reads the CNI configuration file and extracts
+	// Cilium relevant information. This can be used to pass per node
+	// configuration to Cilium.
+	ReadCNIConfiguration = "read-cni-conf"
 )
 
 // GetTunnelModes returns the list of all tunnel modes
@@ -961,6 +966,11 @@ type DaemonConfig struct {
 
 	// RunMonitorAgent indicates whether to run the monitor agent
 	RunMonitorAgent bool
+
+	// ReadCNIConfiguration reads the CNI configuration file and extracts
+	// Cilium relevant information. This can be used to pass per node
+	// configuration to Cilium.
+	ReadCNIConfiguration string
 }
 
 var (
@@ -1282,6 +1292,7 @@ func (c *DaemonConfig) Populate() {
 	c.PrometheusServeAddr = getPrometheusServerAddr()
 	c.ProxyConnectTimeout = viper.GetInt(ProxyConnectTimeout)
 	c.BlacklistConflictingRoutes = viper.GetBool(BlacklistConflictingRoutes)
+	c.ReadCNIConfiguration = viper.GetString(ReadCNIConfiguration)
 	c.RestoreState = viper.GetBool(Restore)
 	c.RunDir = viper.GetString(StateDir)
 	c.SidecarIstioProxyImage = viper.GetString(SidecarIstioProxyImage)

--- a/plugins/cilium-cni/types/types.go
+++ b/plugins/cilium-cni/types/types.go
@@ -17,6 +17,7 @@ package types
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net"
 
 	cniTypes "github.com/containernetworking/cni/pkg/types"
@@ -27,6 +28,17 @@ type NetConf struct {
 	cniTypes.NetConf
 	MTU  int  `json:"mtu"`
 	Args Args `json:"args"`
+}
+
+// ReadNetConf reads a CNI configuration file and returns the corresponding
+// NetConf structure
+func ReadNetConf(path string) (*NetConf, string, error) {
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, "", fmt.Errorf("Unable to read CNI configuration '%s': %s", path, err)
+	}
+
+	return LoadNetConf(b)
 }
 
 // LoadNetConf unmarshals a Cilium network configuration from JSON and returns

--- a/plugins/cilium-cni/types/types_test.go
+++ b/plugins/cilium-cni/types/types_test.go
@@ -1,0 +1,109 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package types
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/cilium/cilium/pkg/checker"
+
+	cnitypes "github.com/containernetworking/cni/pkg/types"
+	"gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	check.TestingT(t)
+}
+
+type CNITypesSuite struct{}
+
+var _ = check.Suite(&CNITypesSuite{})
+
+func testConfRead(c *check.C, confContent string, netconf *NetConf) {
+	dir, err := ioutil.TempDir("", "cilium-cnitype-testsuite")
+	c.Assert(err, check.IsNil)
+	defer os.RemoveAll(dir)
+
+	p := path.Join(dir, "conf1")
+	err = ioutil.WriteFile(p, []byte(confContent), 0644)
+	c.Assert(err, check.IsNil)
+
+	netConf, _, err := ReadNetConf(p)
+	c.Assert(err, check.IsNil)
+
+	c.Assert(netConf, checker.DeepEquals, netconf)
+}
+
+func (t *CNITypesSuite) TestReadCNIConf(c *check.C) {
+	confFile1 := `
+{
+  "name": "cilium",
+  "type": "cilium-cni"
+}
+`
+
+	netConf1 := NetConf{
+		NetConf: cnitypes.NetConf{
+			Name: "cilium",
+			Type: "cilium-cni",
+		},
+	}
+	testConfRead(c, confFile1, &netConf1)
+
+	confFile2 := `
+{
+  "name": "cilium",
+  "type": "cilium-cni",
+  "mtu": 9000
+}
+`
+
+	netConf2 := NetConf{
+		NetConf: cnitypes.NetConf{
+			Name: "cilium",
+			Type: "cilium-cni",
+		},
+		MTU: 9000,
+	}
+	testConfRead(c, confFile2, &netConf2)
+}
+
+func (t *CNITypesSuite) TestReadCNIConfError(c *check.C) {
+	// Try to read errorneous CNI configuration file with MTU provided as
+	// string instead of int
+	errorConf := `
+{
+  "name": "cilium",
+  "type": "cilium-cni",
+  "mtu": "9000"
+}
+`
+
+	dir, err := ioutil.TempDir("", "cilium-cnitype-testsuite")
+	c.Assert(err, check.IsNil)
+	defer os.RemoveAll(dir)
+
+	p := path.Join(dir, "errorconf")
+	err = ioutil.WriteFile(p, []byte(errorConf), 0644)
+	c.Assert(err, check.IsNil)
+
+	_, _, err = ReadNetConf(p)
+	c.Assert(err, check.Not(check.IsNil))
+}


### PR DESCRIPTION
This will be used for the upcoming ENI integration to allow specifying per node
configuration via the CNI configuration which is already templated in a lot of
environments. For now, allow setting the MTU as this field was already defined
although unused so far.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8128)
<!-- Reviewable:end -->
