### PR TITLE
endpoint: Guard against deleted endpoints in regenerate

### DIFF
--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -450,10 +450,14 @@ func regenerateEndpointNonBlocking(owner endpoint.Owner, ep *endpoint.Endpoint, 
 // by endpointIDs. It signals to the provided WaitGroup when all of the endpoints
 // in said set have had regenerations queued up.
 func RegenerateEndpointSetSignalWhenEnqueued(owner endpoint.Owner, regenMetadata *endpoint.ExternalRegenerationMetadata, endpointIDs map[uint16]struct{}, wg *sync.WaitGroup) {
-	wg.Add(len(endpointIDs))
 
 	for endpointID := range endpointIDs {
 		ep := endpoints[endpointID]
+		if ep == nil {
+			log.WithField(logfields.EndpointID, endpointID).Error("Enqueued regenerate for non-existent Endpoint")
+			continue
+		}
+		wg.Add(1)
 		go func() {
 			regenerateEndpointNonBlocking(owner, ep, regenMetadata)
 			wg.Done()


### PR DESCRIPTION
I've left a real issue at https://github.com/cilium/cilium/issues/8131

We may enqueue endpoints for regenerations that are not managed by
endpoint manager when it handles the regeneration request. This change
trivially guards against this to avoid crashing, at the risk of
suppressing a needed regenerate. This may occur when an endpoint is
still being created and has not been added to the endpoint manager, as
opposed to being deleted (i.e. it is eventually incorrect because it
missed the regenerate).

fixes https://github.com/cilium/cilium/pull/8131

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8132)
<!-- Reviewable:end -->
