### PR TITLE
cni: Fix incorrect merge of e99bee54 and 43e0c4e2a

### DIFF
--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -898,7 +898,7 @@ func initEnv(cmd *cobra.Command) {
 	}
 
 	if option.Config.ReadCNIConfiguration != "" {
-		netConf, _, err := cnitypes.ReadNetConf(option.Config.ReadCNIConfiguration)
+		netConf, err := cnitypes.ReadNetConf(option.Config.ReadCNIConfiguration)
 		if err != nil {
 			log.WithError(err).Fatal("Unable to read CNI configuration")
 		}

--- a/plugins/cilium-cni/types/types.go
+++ b/plugins/cilium-cni/types/types.go
@@ -34,10 +34,10 @@ type NetConf struct {
 
 // ReadNetConf reads a CNI configuration file and returns the corresponding
 // NetConf structure
-func ReadNetConf(path string) (*NetConf, string, error) {
+func ReadNetConf(path string) (*NetConf, error) {
 	b, err := ioutil.ReadFile(path)
 	if err != nil {
-		return nil, "", fmt.Errorf("Unable to read CNI configuration '%s': %s", path, err)
+		return nil, fmt.Errorf("Unable to read CNI configuration '%s': %s", path, err)
 	}
 
 	return LoadNetConf(b)

--- a/plugins/cilium-cni/types/types_test.go
+++ b/plugins/cilium-cni/types/types_test.go
@@ -45,7 +45,7 @@ func testConfRead(c *check.C, confContent string, netconf *NetConf) {
 	err = ioutil.WriteFile(p, []byte(confContent), 0644)
 	c.Assert(err, check.IsNil)
 
-	netConf, _, err := ReadNetConf(p)
+	netConf, err := ReadNetConf(p)
 	c.Assert(err, check.IsNil)
 
 	c.Assert(netConf, checker.DeepEquals, netconf)
@@ -104,6 +104,6 @@ func (t *CNITypesSuite) TestReadCNIConfError(c *check.C) {
 	err = ioutil.WriteFile(p, []byte(errorConf), 0644)
 	c.Assert(err, check.IsNil)
 
-	_, _, err = ReadNetConf(p)
+	_, err = ReadNetConf(p)
 	c.Assert(err, check.Not(check.IsNil))
 }


### PR DESCRIPTION
When merging 43e0c4e2a and e99bee54, a merge conflict should have been detected
but it was not so both PRs got merged, resulting in code revision that cannot
be compiled.

Fixes: e99bee54869b ("agent: Support reading CNI configuration from agent to set per node settings")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8136)
<!-- Reviewable:end -->
