### PR TITLE
service: Reduce backend ID allocation space

### DIFF
--- a/pkg/service/const.go
+++ b/pkg/service/const.go
@@ -37,7 +37,7 @@ const (
 
 	// MaxSetOfBackendID is maximum number of set of backendIDs IDs that can be
 	// stored in the local ID allocator.
-	MaxSetOfBackendID = uint32(0xFFFFFFFF)
+	MaxSetOfBackendID = uint32(0xFFFF)
 
 	serviceKvstorePrefix = common.OperationalPath + "/ServicesV2/"
 )


### PR DESCRIPTION
Currently, we store service backend ID as `uint16` in the BPF maps, which is going to be changed to `uint32` in upcoming releases. Meanwhile, the backend ID allocator allocates backend IDs as `uint32` and then casts the allocated ID to `uint16`.

To avoid having the same backend IDs for two different backends in the BPF maps until the proper fix will land (#8041), make sure that the allocator won't allocate an ID > `max(uint16)`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8145)
<!-- Reviewable:end -->
