### PR TITLE
ipam: Fix IPAM status when IPv4 is disabled

### DIFF
--- a/daemon/ipam.go
+++ b/daemon/ipam.go
@@ -113,6 +113,9 @@ func (d *Daemon) DumpIPAM() *models.IPAMStatus {
 	}
 
 	v6 := []string{}
+	if allocv4 == nil {
+		allocv4 = map[string]string{}
+	}
 	for ip, owner := range allocv6 {
 		v6 = append(v6, ip)
 		// merge allocv6 into allocv4


### PR DESCRIPTION
Dump() now returns nil maps if an address family is disabled

Fixes: ef23e9c4f82 ("ipam: Define interface for allocator")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8146)
<!-- Reviewable:end -->
