### PR TITLE
test: Fix NodeCleanMetadata by using --overwrite

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -515,7 +515,7 @@ func (kub *Kubectl) NodeCleanMetadata() error {
 	}
 	for _, node := range strings.Split(data.Output().String(), " ") {
 		for _, label := range metadata {
-			kub.Exec(fmt.Sprintf("%s annotate nodes %s %s", KubectlCmd, node, label))
+			kub.Exec(fmt.Sprintf("%s annotate --overwrite nodes %s %s=''", KubectlCmd, node, label))
 		}
 	}
 	return nil


### PR DESCRIPTION
Fixes the following errors:
```
cmd: "kubectl annotate nodes k8s1 io.cilium.network.ipv4-pod-cidr" exitCode: 1 duration: 76.869764ms stdout:

stderr:
error: at least one annotation update is required
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8148)
<!-- Reviewable:end -->
