### PR TITLE
pkg/labels: ignore all labels that match the regex "annotation.*"

### DIFF
--- a/pkg/labels/filter.go
+++ b/pkg/labels/filter.go
@@ -159,18 +159,15 @@ func defaultLabelPrefixCfg() *labelPrefixCfg {
 	}
 
 	expressions := []string{
-		k8sConst.PodNamespaceLabel,                                   // include io.kubernetes.pod.namspace
-		k8sConst.PodNamespaceMetaLabels,                              // include all namespace labels
-		"!io.kubernetes",                                             // ignore all other io.kubernetes labels
-		"!.*kubernetes.io",                                           // ignore all other kubernetes.io labels (annotation.*.k8s.io)
-		"!pod-template-generation",                                   // ignore pod-template-generation
-		"!pod-template-hash",                                         // ignore pod-template-hash
-		"!controller-revision-hash",                                  // ignore controller-revision-hash
-		"!annotation." + k8sConst.CiliumK8sAnnotationPrefix,          // ignore all cilium annotations
-		"!annotation." + k8sConst.CiliumIdentityAnnotationDeprecated, // ignore all cilium annotations
-		"!annotation.sidecar.istio.io",                               // ignore all istio sidecar annotation labels
-		"!annotation.etcd.version",                                   // ignore all etcd.version annotations
-		"!etcd_node",                                                 // ignore etcd_node label
+		k8sConst.PodNamespaceLabel,      // include io.kubernetes.pod.namspace
+		k8sConst.PodNamespaceMetaLabels, // include all namespace labels
+		"!io.kubernetes",                // ignore all other io.kubernetes labels
+		"!.*kubernetes.io",              // ignore all other kubernetes.io labels (annotation.*.k8s.io)
+		"!pod-template-generation",      // ignore pod-template-generation
+		"!pod-template-hash",            // ignore pod-template-hash
+		"!controller-revision-hash",     // ignore controller-revision-hash
+		"!annotation.*",                 // ignore all annotation labels
+		"!etcd_node",                    // ignore etcd_node label
 	}
 
 	for _, e := range expressions {

--- a/pkg/labels/filter_test.go
+++ b/pkg/labels/filter_test.go
@@ -18,6 +18,7 @@ package labels
 
 import (
 	"github.com/cilium/cilium/pkg/checker"
+	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 
 	. "gopkg.in/check.v1"
 )
@@ -44,19 +45,21 @@ func (s *LabelsPrefCfgSuite) TestFilterLabels(c *C) {
 	c.Assert(d, Not(IsNil))
 	dlpcfg.LabelPrefixes = append(dlpcfg.LabelPrefixes, d)
 	allNormalLabels := map[string]string{
-		"io.kubernetes.container.hash":                   "cf58006d",
-		"io.kubernetes.container.name":                   "POD",
-		"io.kubernetes.container.restartCount":           "0",
-		"io.kubernetes.container.terminationMessagePath": "",
-		"io.kubernetes.pod.name":                         "my-nginx-3800858182-07i3n",
-		"io.kubernetes.pod.namespace":                    "default",
-		"annotation.kubectl.kubernetes.io":               "foo",
-		"io.kubernetes.pod.terminationGracePeriod":       "30",
-		"io.kubernetes.pod.uid":                          "c2e22414-dfc3-11e5-9792-080027755f5a",
-		"ignore":                                         "foo",
-		"ignorE":                                         "foo",
-		"annotation.kubernetes.io/config.seen":           "2017-05-30T14:22:17.691491034Z",
-		"controller-revision-hash":                       "123456",
+		"io.kubernetes.container.hash":                              "cf58006d",
+		"io.kubernetes.container.name":                              "POD",
+		"io.kubernetes.container.restartCount":                      "0",
+		"io.kubernetes.container.terminationMessagePath":            "",
+		"io.kubernetes.pod.name":                                    "my-nginx-3800858182-07i3n",
+		"io.kubernetes.pod.namespace":                               "default",
+		"annotation.kubectl.kubernetes.io":                          "foo",
+		"annotation.hello":                                          "world",
+		"annotation." + k8sConst.CiliumIdentityAnnotationDeprecated: "12356",
+		"io.kubernetes.pod.terminationGracePeriod":                  "30",
+		"io.kubernetes.pod.uid":                                     "c2e22414-dfc3-11e5-9792-080027755f5a",
+		"ignore":                                                    "foo",
+		"ignorE":                                                    "foo",
+		"annotation.kubernetes.io/config.seen":                      "2017-05-30T14:22:17.691491034Z",
+		"controller-revision-hash":                                  "123456",
 	}
 	allLabels := Map2Labels(allNormalLabels, LabelSourceContainer)
 	filtered, _ := dlpcfg.filterLabels(allLabels)


### PR DESCRIPTION
This will help to decrease the cardinality of labels used to create a
security identity since pod annotations can be used for enumerous reasons
and aren't used for network policy enforcement.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8152)
<!-- Reviewable:end -->
