### PR TITLE
CI: Retry curl & wget within timeout

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -142,7 +142,7 @@ const (
 
 	// CurlConnectTimeout is the timeout for the connect() call that curl
 	// invokes
-	CurlConnectTimeout = 5
+	CurlConnectTimeout = 2
 
 	// CurlMaxTimeout is the hard timeout. It starts when curl is invoked
 	// and interrupts curl regardless of whether curl is currently
@@ -150,6 +150,11 @@ const (
 	// seconds longer than CurlConnectTimeout to provide some time to
 	// actually transfer data.
 	CurlMaxTimeout = 8
+
+	// CurlRetries is the number of retries to attempt. The intention is to retry
+	// multiple times within CurlMaxTimeout. In cases where we race to implement
+	// policy, this allows curl to resend the TCP SYN sooner.
+	CurlRetries = int(CurlMaxTimeout/CurlConnectTimeout) + 1
 
 	DefaultNamespace    = "default"
 	KubeSystemNamespace = "kube-system"

--- a/test/helpers/wrappers.go
+++ b/test/helpers/wrappers.go
@@ -53,8 +53,8 @@ func CurlFail(endpoint string, optionalValues ...interface{}) string {
 		endpoint = fmt.Sprintf(endpoint, optionalValues...)
 	}
 	return fmt.Sprintf(
-		`curl --path-as-is -s -D /dev/stderr --fail --connect-timeout %[1]d --max-time %[2]d %[3]s -w "%[4]s"`,
-		CurlConnectTimeout, CurlMaxTimeout, endpoint, statsInfo)
+		`curl --path-as-is -s -D /dev/stderr --fail --connect-timeout %d --max-time %d --retry %d  --retry-max-time 0 %s -w "%s"`,
+		CurlConnectTimeout, CurlMaxTimeout, CurlRetries, endpoint, statsInfo)
 }
 
 // CurlWithHTTPCode retunrs the string representation of the curl command which
@@ -67,8 +67,8 @@ func CurlWithHTTPCode(endpoint string, optionalValues ...interface{}) string {
 	}
 
 	return fmt.Sprintf(
-		`curl --path-as-is -s  -D /dev/stderr --output /dev/stderr -w '%%{http_code}' --connect-timeout %d %s`,
-		CurlConnectTimeout, endpoint)
+		`curl --path-as-is -s  -D /dev/stderr --output /dev/stderr -w '%%{http_code}' --connect-timeout %d --retry-delay 1 --retry %d  --retry-max-time 0 %s`,
+		CurlConnectTimeout, CurlRetries, endpoint)
 }
 
 // Netperf returns the string representing the netperf command to use when testing

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -386,7 +386,7 @@ var _ = Describe("K8sServicesTest", func() {
 		It("Tests bookinfo demo", func() {
 
 			// We use wget in this test because the Istio apps do not provide curl.
-			wgetCommand := fmt.Sprintf("wget --tries=2 --connect-timeout %d", helpers.CurlConnectTimeout)
+			wgetCommand := fmt.Sprintf("wget --tries=%d --connect-timeout %d", helpers.CurlRetries, helpers.CurlConnectTimeout)
 
 			version := "version"
 			v1 := "v1"


### PR DESCRIPTION
While fretting over https://github.com/cilium/cilium/issues/7105 I noticed that our curls might not allow for races between plumbing and the test.

We sometimes see connect timeouts but the post-failure system state we
dump suggests that everything is wired correctly. This may be because we
are racing with policy being plumbed. By retrying we can get through
instead of waiting for the TCP retry (in the cases where our first SYN
was dropped).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8154)
<!-- Reviewable:end -->
