### PR TITLE
backport 1.5 2019 05 29

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -33,23 +33,25 @@ import (
 )
 
 const (
-	ciliumOutputChain     = "CILIUM_OUTPUT"
-	ciliumOutputRawChain  = "CILIUM_OUTPUT_raw"
-	ciliumPostNatChain    = "CILIUM_POST"
-	ciliumPostMangleChain = "CILIUM_POST_mangle"
-	ciliumPreMangleChain  = "CILIUM_PRE_mangle"
-	ciliumPreRawChain     = "CILIUM_PRE_raw"
-	ciliumForwardChain    = "CILIUM_FORWARD"
-	feederDescription     = "cilium-feeder:"
-	xfrmDescription       = "cilium-xfrm-notrack:"
+	ciliumOutputChain      = "CILIUM_OUTPUT"
+	ciliumOutputRawChain   = "CILIUM_OUTPUT_raw"
+	ciliumPostNatChain     = "CILIUM_POST"
+	ciliumPostNatKubeChain = "CILIUM_POST_KUBE"
+	ciliumPostMangleChain  = "CILIUM_POST_mangle"
+	ciliumPreMangleChain   = "CILIUM_PRE_mangle"
+	ciliumPreRawChain      = "CILIUM_PRE_raw"
+	ciliumForwardChain     = "CILIUM_FORWARD"
+	feederDescription      = "cilium-feeder:"
+	xfrmDescription        = "cilium-xfrm-notrack:"
 )
 
 type customChain struct {
-	name       string
-	table      string
-	hook       string
-	feederArgs []string
-	ipv6       bool // ip6tables chain in addition to iptables chain
+	name        string
+	table       string
+	hook        string
+	feederArgs  []string
+	ipv6        bool // ip6tables chain in addition to iptables chain
+	appendFixed bool
 }
 
 func runProg(prog string, args []string, quiet bool) error {
@@ -155,7 +157,7 @@ func (c *customChain) remove() {
 
 func (c *customChain) installFeeder() error {
 	installMode := "-A"
-	if option.Config.PrependIptablesChains {
+	if option.Config.PrependIptablesChains && !c.appendFixed {
 		installMode = "-I"
 	}
 
@@ -194,6 +196,14 @@ var ciliumChains = []customChain{
 		table:      "nat",
 		hook:       "POSTROUTING",
 		feederArgs: []string{""},
+	},
+	{
+		name:        ciliumPostNatKubeChain,
+		table:       "nat",
+		hook:        "POSTROUTING",
+		feederArgs:  []string{""},
+		ipv6:        true,
+		appendFixed: true,
 	},
 	{
 		name:       ciliumPostMangleChain,
@@ -258,7 +268,7 @@ func (m *IptablesManager) RemoveRules() {
 
 	// Set of tables that have had ip6tables rules in any Cilium version
 	if m.ip6tables {
-		tables6 := []string{"mangle", "raw"}
+		tables6 := []string{"nat", "mangle", "raw"}
 		for _, t := range tables6 {
 			removeCiliumRules(t, "ip6tables")
 		}
@@ -325,6 +335,39 @@ func (m *IptablesManager) InstallRules(ifName string) error {
 			"-m", "comment", "--comment", "cilium: cluster->any forward accept",
 			"-j", "ACCEPT"}, false); err != nil {
 			return err
+		}
+
+		// For communication from host to local services via k8s cluster IP
+		// we need to fix up wrong source address selection. Linux routing
+		// will initially select a source address based on the service IP and
+		// after Kubernetes iptables rules selected a local backend, we still
+		// retain the original source address (and not the one on cilium_host).
+		// As a result, ipcache will assign a WORLD identity (via catch-all 0/0)
+		// as opposed to a HOST identity and therefore policy is dropping the
+		// skb. As there is no fixup by iptables, we need to SNAT for these
+		// cases. This rule here must come after all Kubernetes post-routing
+		// chains, so we can match on our endpoint allocation range.
+		if option.Config.EnableIPv4 {
+			if err := runProg("iptables", []string{
+				"-t", "nat",
+				"-A", ciliumPostNatKubeChain,
+				"-d", node.GetIPv4AllocRange().String(),
+				"-o", ifName,
+				"-m", "comment", "--comment", "cilium: host->service(cluster ip)->local-endpoint on " + ifName + " src address fix",
+				"-j", "SNAT", "--to-source", node.GetHostMasqueradeIPv4().String()}, false); err != nil {
+				return err
+			}
+		}
+		if option.Config.EnableIPv6 {
+			if err := runProg("ip6tables", []string{
+				"-t", "nat",
+				"-A", ciliumPostNatKubeChain,
+				"-d", node.GetIPv6AllocRange().String(),
+				"-o", ifName,
+				"-m", "comment", "--comment", "cilium: host->service(cluster ip)->local-endpoint on " + ifName + " src address fix",
+				"-j", "SNAT", "--to-source", node.GetIPv6().String()}, false); err != nil {
+				return err
+			}
 		}
 
 		// Mark all packets sourced from processes running on the host with a

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -453,10 +453,14 @@ func regenerateEndpointNonBlocking(owner endpoint.Owner, ep *endpoint.Endpoint, 
 // by endpointIDs. It signals to the provided WaitGroup when all of the endpoints
 // in said set have had regenerations queued up.
 func RegenerateEndpointSetSignalWhenEnqueued(owner endpoint.Owner, regenMetadata *endpoint.ExternalRegenerationMetadata, endpointIDs map[uint16]struct{}, wg *sync.WaitGroup) {
-	wg.Add(len(endpointIDs))
 
 	for endpointID := range endpointIDs {
 		ep := endpoints[endpointID]
+		if ep == nil {
+			log.WithField(logfields.EndpointID, endpointID).Error("Enqueued regenerate for non-existent Endpoint")
+			continue
+		}
+		wg.Add(1)
 		go func() {
 			regenerateEndpointNonBlocking(owner, ep, regenMetadata)
 			wg.Done()

--- a/pkg/envoy/xds/server.go
+++ b/pkg/envoy/xds/server.go
@@ -314,18 +314,18 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 				if ackObserver != nil {
 					requestLog.Debug("notifying observers of ACKs")
 					ackObserver.HandleResourceVersionAck(versionInfo, nonce, req.GetNode(), state.resourceNames, typeURL, detail)
-					if versionInfo < nonce {
-						// versions after VersionInfo, upto and including ResponseNonce are NACKed
-						requestLog.Warningf("NACK received for versions after %s and up to %s; waiting for a version update before sending again", req.VersionInfo, req.ResponseNonce)
-						// Watcher will behave as if the sent version was acked.
-						// Otherwise we will just be sending the same failing
-						// version over and over filling logs.
-						versionInfo = state.version
-					}
-
 				} else {
 					requestLog.Debug("ACK received but no observers are waiting for ACKs")
 				}
+				if versionInfo < nonce {
+					// versions after VersionInfo, upto and including ResponseNonce are NACKed
+					requestLog.Warningf("NACK received for versions after %s and up to %s; waiting for a version update before sending again", req.VersionInfo, req.ResponseNonce)
+					// Watcher will behave as if the sent version was acked.
+					// Otherwise we will just be sending the same failing
+					// version over and over filling logs.
+					versionInfo = state.version
+				}
+
 				if state.pendingWatchCancel != nil {
 					// A pending watch exists for this type URL. Cancel it to
 					// start a new watch.

--- a/pkg/service/const.go
+++ b/pkg/service/const.go
@@ -37,7 +37,7 @@ const (
 
 	// MaxSetOfBackendID is maximum number of set of backendIDs IDs that can be
 	// stored in the local ID allocator.
-	MaxSetOfBackendID = uint32(0xFFFFFFFF)
+	MaxSetOfBackendID = uint32(0xFFFF)
 
 	serviceKvstorePrefix = common.OperationalPath + "/ServicesV2/"
 )


### PR DESCRIPTION
 * PR: 8141 -- cilium: fix up source address selection for cluster ip (@borkmann) -- https://github.com/cilium/cilium/pull/8141
   Merge with 1 commit(s) merged at: Wed, 29 May 2019 10:49:33 +0200!
     Branch:     master (!)                          refs/pull/8141/head
                 ----------                          -------------------
     v (start)
     |  2bdca067a90833a2d03d0d8a986f821a469121e0 via 10f2ffcdd65f162b03f1e5a9fa1e254f951424a3 ("cilium: fix up source address selection for cluster ip")
     v (end)

 * PR: 8145 -- service: Reduce backend ID allocation space (@brb) -- https://github.com/cilium/cilium/pull/8145
   Merge with 1 commit(s) merged at: Wed, 29 May 2019 11:10:45 +0200!
     Branch:     master (!)                          refs/pull/8145/head
                 ----------                          -------------------
     v (start)
     |  1c9cf6bd425952eef1983fe02b8e83f59013e94f via 1f4df4b316eb970df89133a7e9f06f0add634303 ("service: Reduce backend ID allocation space")
     v (end)

 * PR: 8132 -- endpoint: Guard against deleted endpoints in regenerate (@raybejjani) -- https://github.com/cilium/cilium/pull/8132
   Merge with 1 commit(s) merged at: Wed, 29 May 2019 13:26:43 +0200!
     Branch:     master (!)                          refs/pull/8132/head
                 ----------                          -------------------
     v (start)
     |  07ba2dcffe8dbef8d085d960d7ef4da033c3fb18 via bc5a4a7fba1e14f922e7bf1600f8dbddf8cd432b ("endpoint: Guard against deleted endpoints in regenerate")
     v (end)

 * PR: 8149 -- envoy: Prevent resending NACKed resources also when there are no ACK observers (@jrajahalme) -- https://github.com/cilium/cilium/pull/8149
   Merge with 1 commit(s) merged at: Wed, 29 May 2019 13:30:39 +0200!
     Branch:     master (!)                          refs/pull/8149/head
                 ----------                          -------------------
     v (start)
     |  ec3910f1f33e866885a08aede919f270b2912975 via 88128f62fd5854458ef0f5f01a15357d364812f1 ("envoy: Prevent resending NACKed resources also when there are no ACK observers.")
     v (end)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8155)
<!-- Reviewable:end -->
