### PR TITLE
docs: Update upgrade instructions for v1.5 -> v1.4 -> v1.5 case

### DIFF
--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -380,7 +380,11 @@ New ConfigMap Options
 
   * ``enable-legacy-services``: enables legacy services (prior v1.5) to
     prevent from terminating established connections to services when
-    upgrading Cilium from < v1.5 to v1.5.
+    upgrading Cilium from < v1.5 to v1.5. If enabled, the option needs
+    to stay enabled until a user is confident that they will not need to
+    downgrade to < v1.5 anymore. Disabling and then enabling the option is
+    not possible without breaking the established connections from `Pod`
+    to `Service`.
 
 Deprecated Options
 ~~~~~~~~~~~~~~~~~~

--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -305,6 +305,45 @@ Upgrading from >=1.4.0 to 1.5.y
    the ConfigMap before upgrading. Refer to the section :ref:`upgrade_configmap`
    on how to upgrade the `ConfigMap`.
 
+#. If you previously upgraded to v1.5, downgraded to <v1.5, and now want to
+   upgrade to v1.5 again, then you must run the following `DaemonSet` before
+   doing the upgrade:
+
+    .. tabs::
+      .. group-tab:: K8s 1.10
+
+        .. parsed-literal::
+
+          $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.10/cilium-pre-flight-with-rm-svc-v2.yaml
+
+      .. group-tab:: K8s 1.11
+
+        .. parsed-literal::
+
+          $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.11/cilium-pre-flight-with-rm-svc-v2.yaml
+
+      .. group-tab:: K8s 1.12
+
+        .. parsed-literal::
+
+          $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.12/cilium-pre-flight-with-rm-svc-v2.yaml
+
+      .. group-tab:: K8s 1.13
+
+        .. parsed-literal::
+
+          $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.13/cilium-pre-flight-with-rm-svc-v2.yaml
+
+      .. group-tab:: K8s 1.14
+
+        .. parsed-literal::
+
+          $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.14/cilium-pre-flight-with-rm-svc-v2.yaml
+
+
+   See :ref:`pre_flight` for instructions how to run, validate and remove
+   a pre-flight `DaemonSet`.
+
 #. Follow the standard procedures to perform the upgrade as described in :ref:`upgrade_minor`.
 
 New Default Values

--- a/examples/kubernetes/1.10/cilium-pre-flight-with-rm-svc-v2.yaml
+++ b/examples/kubernetes/1.10/cilium-pre-flight-with-rm-svc-v2.yaml
@@ -32,6 +32,16 @@ spec:
           command: ["/bin/echo"]
           args:
           - "hello"
+        - name: rm-cilium-svc-v2
+          image: docker.io/cilium/cilium:latest
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/bash"]
+          args:
+          - -c
+          - "rm /sys/fs/bpf/tc/globals/cilium_lb{4,6}_{services_v2,backends,rr_seq_v2}; true"
+          volumeMounts:
+          - mountPath: /sys/fs/bpf
+            name: bpf-maps
       containers:
         - image: docker.io/cilium/cilium:latest
           imagePullPolicy: Always

--- a/examples/kubernetes/1.11/cilium-pre-flight-with-rm-svc-v2.yaml
+++ b/examples/kubernetes/1.11/cilium-pre-flight-with-rm-svc-v2.yaml
@@ -32,6 +32,16 @@ spec:
           command: ["/bin/echo"]
           args:
           - "hello"
+        - name: rm-cilium-svc-v2
+          image: docker.io/cilium/cilium:latest
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/bash"]
+          args:
+          - -c
+          - "rm /sys/fs/bpf/tc/globals/cilium_lb{4,6}_{services_v2,backends,rr_seq_v2}; true"
+          volumeMounts:
+          - mountPath: /sys/fs/bpf
+            name: bpf-maps
       containers:
         - image: docker.io/cilium/cilium:latest
           imagePullPolicy: Always
@@ -58,6 +68,7 @@ spec:
           - mountPath: /var/run/cilium
             name: cilium-run
       hostNetwork: true
+      priorityClassName: system-node-critical
       restartPolicy: Always
       tolerations:
         - effect: NoSchedule

--- a/examples/kubernetes/1.11/cilium-pre-flight.yaml
+++ b/examples/kubernetes/1.11/cilium-pre-flight.yaml
@@ -76,3 +76,7 @@ spec:
           path: /var/run/cilium
           type: DirectoryOrCreate
         name: cilium-run
+      - hostPath:
+          path: /sys/fs/bpf
+          type: DirectoryOrCreate
+        name: bpf-maps

--- a/examples/kubernetes/1.12/cilium-pre-flight-with-rm-svc-v2.yaml
+++ b/examples/kubernetes/1.12/cilium-pre-flight-with-rm-svc-v2.yaml
@@ -32,6 +32,16 @@ spec:
           command: ["/bin/echo"]
           args:
           - "hello"
+        - name: rm-cilium-svc-v2
+          image: docker.io/cilium/cilium:latest
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/bash"]
+          args:
+          - -c
+          - "rm /sys/fs/bpf/tc/globals/cilium_lb{4,6}_{services_v2,backends,rr_seq_v2}; true"
+          volumeMounts:
+          - mountPath: /sys/fs/bpf
+            name: bpf-maps
       containers:
         - image: docker.io/cilium/cilium:latest
           imagePullPolicy: Always
@@ -58,6 +68,7 @@ spec:
           - mountPath: /var/run/cilium
             name: cilium-run
       hostNetwork: true
+      priorityClassName: system-node-critical
       restartPolicy: Always
       tolerations:
         - effect: NoSchedule

--- a/examples/kubernetes/1.12/cilium-pre-flight.yaml
+++ b/examples/kubernetes/1.12/cilium-pre-flight.yaml
@@ -76,3 +76,7 @@ spec:
           path: /var/run/cilium
           type: DirectoryOrCreate
         name: cilium-run
+      - hostPath:
+          path: /sys/fs/bpf
+          type: DirectoryOrCreate
+        name: bpf-maps

--- a/examples/kubernetes/1.13/cilium-pre-flight-with-rm-svc-v2.yaml
+++ b/examples/kubernetes/1.13/cilium-pre-flight-with-rm-svc-v2.yaml
@@ -32,6 +32,16 @@ spec:
           command: ["/bin/echo"]
           args:
           - "hello"
+        - name: rm-cilium-svc-v2
+          image: docker.io/cilium/cilium:latest
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/bash"]
+          args:
+          - -c
+          - "rm /sys/fs/bpf/tc/globals/cilium_lb{4,6}_{services_v2,backends,rr_seq_v2}; true"
+          volumeMounts:
+          - mountPath: /sys/fs/bpf
+            name: bpf-maps
       containers:
         - image: docker.io/cilium/cilium:latest
           imagePullPolicy: Always
@@ -58,6 +68,7 @@ spec:
           - mountPath: /var/run/cilium
             name: cilium-run
       hostNetwork: true
+      priorityClassName: system-node-critical
       restartPolicy: Always
       tolerations:
         - effect: NoSchedule

--- a/examples/kubernetes/1.13/cilium-pre-flight.yaml
+++ b/examples/kubernetes/1.13/cilium-pre-flight.yaml
@@ -76,3 +76,7 @@ spec:
           path: /var/run/cilium
           type: DirectoryOrCreate
         name: cilium-run
+      - hostPath:
+          path: /sys/fs/bpf
+          type: DirectoryOrCreate
+        name: bpf-maps

--- a/examples/kubernetes/1.14/cilium-pre-flight-with-rm-svc-v2.yaml
+++ b/examples/kubernetes/1.14/cilium-pre-flight-with-rm-svc-v2.yaml
@@ -32,6 +32,16 @@ spec:
           command: ["/bin/echo"]
           args:
           - "hello"
+        - name: rm-cilium-svc-v2
+          image: docker.io/cilium/cilium:latest
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/bash"]
+          args:
+          - -c
+          - "rm /sys/fs/bpf/tc/globals/cilium_lb{4,6}_{services_v2,backends,rr_seq_v2}; true"
+          volumeMounts:
+          - mountPath: /sys/fs/bpf
+            name: bpf-maps
       containers:
         - image: docker.io/cilium/cilium:latest
           imagePullPolicy: Always
@@ -58,6 +68,7 @@ spec:
           - mountPath: /var/run/cilium
             name: cilium-run
       hostNetwork: true
+      priorityClassName: system-node-critical
       restartPolicy: Always
       tolerations:
         - effect: NoSchedule

--- a/examples/kubernetes/1.14/cilium-pre-flight.yaml
+++ b/examples/kubernetes/1.14/cilium-pre-flight.yaml
@@ -76,3 +76,7 @@ spec:
           path: /var/run/cilium
           type: DirectoryOrCreate
         name: cilium-run
+      - hostPath:
+          path: /sys/fs/bpf
+          type: DirectoryOrCreate
+        name: bpf-maps

--- a/examples/kubernetes/1.15/cilium-pre-flight-with-rm-svc-v2.yaml
+++ b/examples/kubernetes/1.15/cilium-pre-flight-with-rm-svc-v2.yaml
@@ -32,6 +32,16 @@ spec:
           command: ["/bin/echo"]
           args:
           - "hello"
+        - name: rm-cilium-svc-v2
+          image: docker.io/cilium/cilium:latest
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/bash"]
+          args:
+          - -c
+          - "rm /sys/fs/bpf/tc/globals/cilium_lb{4,6}_{services_v2,backends,rr_seq_v2}; true"
+          volumeMounts:
+          - mountPath: /sys/fs/bpf
+            name: bpf-maps
       containers:
         - image: docker.io/cilium/cilium:latest
           imagePullPolicy: Always
@@ -58,6 +68,7 @@ spec:
           - mountPath: /var/run/cilium
             name: cilium-run
       hostNetwork: true
+      priorityClassName: system-node-critical
       restartPolicy: Always
       tolerations:
         - effect: NoSchedule

--- a/examples/kubernetes/1.15/cilium-pre-flight.yaml
+++ b/examples/kubernetes/1.15/cilium-pre-flight.yaml
@@ -76,3 +76,7 @@ spec:
           path: /var/run/cilium
           type: DirectoryOrCreate
         name: cilium-run
+      - hostPath:
+          path: /sys/fs/bpf
+          type: DirectoryOrCreate
+        name: bpf-maps

--- a/examples/kubernetes/Makefile
+++ b/examples/kubernetes/Makefile
@@ -62,7 +62,7 @@ CILIUM_CONTAINERD= \
   $(ETCD_OPERATOR) \
   cilium-rbac.yaml
 
-all: transform cilium.yaml cilium-crio.yaml cilium-containerd.yaml cilium-microk8s.yaml cilium-minikube.yaml cilium-external-etcd.yaml cilium-with-node-init.yaml
+all: transform cilium.yaml cilium-crio.yaml cilium-containerd.yaml cilium-microk8s.yaml cilium-minikube.yaml cilium-external-etcd.yaml cilium-with-node-init.yaml cilium-pre-flight-with-rm-svc-v2.yaml
 
 %.sed:
 	for k8s_version in $(K8S_VERSIONS); do \
@@ -190,6 +190,28 @@ cilium-minikube.yaml:
             sed -i 's+/var/lib/etcd-secrets/etcd-client.crt+/var/lib/etcd-secrets/apiserver-etcd-client.crt+' cilium-minikube.yaml; \
             fi); \
             done
+
+cilium-pre-flight.yaml.sed:
+	for k8s_version in $(K8S_VERSIONS); do \
+	    (mkdir -p $$k8s_version && \
+	    cd $$k8s_version && \
+	    sed -f transforms2sed.sed ../templates/v1/$@ | \
+	    sed s+__CILIUM_VERSION__+$(CILIUM_VERSION)+g | \
+	    sed s+__CILIUM_INIT_VERSION__+$(CILIUM_INIT_VERSION)+g | \
+	    sed s+__CILIUM_ETCD_OPERATOR_VERSION__+$(CILIUM_ETCD_OPERATOR_VERSION)+g | \
+		sed /__CILIUM_RM_SVC_V2__/d > "cilium-pre-flight.yaml") \
+	done
+
+cilium-pre-flight-with-rm-svc-v2.yaml:
+	for k8s_version in $(K8S_VERSIONS); do \
+	    (mkdir -p $$k8s_version && \
+	    cd $$k8s_version && \
+	    sed -f transforms2sed.sed ../templates/v1/cilium-pre-flight.yaml.sed | \
+	    sed s+__CILIUM_INIT_VERSION__+$(CILIUM_INIT_VERSION)+g | \
+	    sed s+__CILIUM_ETCD_OPERATOR_VERSION__+$(CILIUM_ETCD_OPERATOR_VERSION)+g | \
+		sed -e '/__CILIUM_RM_SVC_V2__/{r ../templates/v1/rm-svc-v2.tpl' -e 'd}' | \
+	    sed s+__CILIUM_VERSION__+$(CILIUM_VERSION)+g > "cilium-pre-flight-with-rm-svc-v2.yaml") \
+	done
 
 clean:
 	for k8s_version in $(K8S_VERSIONS); do \

--- a/examples/kubernetes/templates/v1/cilium-pre-flight.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-pre-flight.yaml.sed
@@ -32,6 +32,7 @@ spec:
           command: ["/bin/echo"]
           args:
           - "hello"
+__CILIUM_RM_SVC_V2__
       containers:
         - image: docker.io/cilium/cilium:__CILIUM_VERSION__
           imagePullPolicy: Always
@@ -75,3 +76,7 @@ spec:
           path: /var/run/cilium
           type: DirectoryOrCreate
         name: cilium-run
+      - hostPath:
+          path: /sys/fs/bpf
+          type: DirectoryOrCreate
+        name: bpf-maps

--- a/examples/kubernetes/templates/v1/rm-svc-v2.tpl
+++ b/examples/kubernetes/templates/v1/rm-svc-v2.tpl
@@ -1,0 +1,10 @@
+        - name: rm-cilium-svc-v2
+          image: docker.io/cilium/cilium:__CILIUM_VERSION__
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/bash"]
+          args:
+          - -c
+          - "rm /sys/fs/bpf/tc/globals/cilium_lb{4,6}_{services_v2,backends,rr_seq_v2}; true"
+          volumeMounts:
+          - mountPath: /sys/fs/bpf
+            name: bpf-maps


### PR DESCRIPTION
Currently, we do not maintain the svc-v2 BPF maps in `v1.4`, so if a user downgraded from `v1.5` to `v1.4`, then did some updates to `Services`, those changes won't be reflected in the v2 maps. When the user upgrades to `v1.5`, the `daemon/loadbalancer.go:restoreServices()` function won't apply the changes to the v2 maps from the legacy maps, neither `daemon/loadbalancer.go:syncLBMapsWithK8s()` will, as both functions don't do a "deep" comparison of the maps.

Therefore, for such upgrade case, we require the users to run the `cilium-pre-flight-rm-svc-v2.yaml` DaemonSet introduced in this PR which will remove the v2 maps.

In addition, this PR adds a note about losing the v2 maps content if user enables and then disables the `--enable-legacy-services` option.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8158)
<!-- Reviewable:end -->
