### PR TITLE
KVStore bug fixes and small improvements

### DIFF
--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -505,7 +505,7 @@ func (a *Allocator) lockedAllocate(ctx context.Context, key AllocatorKey) (idpoo
 		// We will leak the master key here as the key has already been
 		// exposed and may be in use by other nodes. The garbage
 		// collector will release it again.
-		a.localKeys.release(k)
+		releaseKeyAndID()
 		return 0, false, fmt.Errorf("slave key creation failed '%s': %s", k, err)
 	}
 

--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -488,17 +488,6 @@ func (a *Allocator) lockedAllocate(ctx context.Context, key AllocatorKey) (idpoo
 		return 0, false, fmt.Errorf("another writer has allocated this key")
 	}
 
-	value, err = a.GetNoCache(ctx, key)
-	if err != nil {
-		releaseKeyAndID()
-		return 0, false, err
-	}
-
-	if value != 0 {
-		releaseKeyAndID()
-		return 0, false, fmt.Errorf("master key already exists")
-	}
-
 	// create /id/<ID> and fail if it already exists
 	keyPath := path.Join(a.idPrefix, strID)
 	success, err := kvstore.CreateOnly(ctx, keyPath, []byte(k), false)

--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -133,6 +133,10 @@ type Allocator struct {
 	// being derived from the basePrefix.
 	valuePrefix string
 
+	// slaveKeysMutex protects the concurrent access of the slave key by this
+	// agent.
+	slaveKeysMutex lock.Mutex
+
 	// lockPrefix is the prefix to use for all kvstore locks. This prefix
 	// is different from the idPrefix and valuePrefix to simplify watching
 	// for ID and key changes.
@@ -445,6 +449,9 @@ func (a *Allocator) lockedAllocate(ctx context.Context, key AllocatorKey) (idpoo
 	kvstore.Trace("kvstore state is: ", nil, logrus.Fields{fieldID: value})
 
 	if value != 0 {
+		a.slaveKeysMutex.Lock()
+		defer a.slaveKeysMutex.Unlock()
+
 		_, err := a.localKeys.allocate(k, value)
 		if err != nil {
 			return 0, false, fmt.Errorf("unable to reserve local key '%s': %s", k, err)
@@ -474,6 +481,9 @@ func (a *Allocator) lockedAllocate(ctx context.Context, key AllocatorKey) (idpoo
 		a.localKeys.release(k)
 		a.idPool.Release(unmaskedID)
 	}
+
+	a.slaveKeysMutex.Lock()
+	defer a.slaveKeysMutex.Unlock()
 
 	oldID, err := a.localKeys.allocate(k, id)
 	if err != nil {
@@ -648,6 +658,10 @@ func (a *Allocator) Release(ctx context.Context, key AllocatorKey) (lastUse bool
 	}
 
 	k := key.GetKey()
+
+	a.slaveKeysMutex.Lock()
+	defer a.slaveKeysMutex.Unlock()
+
 	// release the key locally, if it was the last use, remove the node
 	// specific value key to remove the global reference mark
 	lastUse, err = a.localKeys.release(k)

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -801,7 +801,7 @@ func (e *etcdClient) Get(key string) ([]byte, error) {
 func (e *etcdClient) GetPrefix(ctx context.Context, prefix string) (string, []byte, error) {
 	duration := spanstat.Start()
 	e.limiter.Wait(ctx)
-	getR, err := e.client.Get(ctx, prefix, client.WithPrefix())
+	getR, err := e.client.Get(ctx, prefix, client.WithPrefix(), client.WithLimit(1))
 	increaseMetric(prefix, metricRead, "GetPrefix", duration.EndError(err).Total(), err)
 	if err != nil {
 		return "", nil, Hint(err)


### PR DESCRIPTION
```release-note
Avoid leaking local security IDs in case of KVStore operation failure.
On GetPrefix calls, do with limit of 1 for etcd.
Protect concurrent access of slave keys by the same cilium-agent
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8159)
<!-- Reviewable:end -->
