### PR TITLE
test: Enable IPv6 forwarding in test VMs

### DIFF
--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -95,6 +95,8 @@ Vagrant.configure("2") do |config|
                 nfs: $NFS
             # Provision section
             server.vm.provision :shell,
+                :inline => "sudo sysctl -w net.ipv6.conf.all.forwarding=1"
+            server.vm.provision :shell,
                 :inline => "sed -i 's/^mesg n$/tty -s \\&\\& mesg n/g' /root/.profile"
             server.vm.provision "file", source: "provision/", destination: "/tmp/"
             server.vm.provision "shell" do |sh|

--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -75,7 +75,7 @@ func ExpectETCDOperatorReady(vm *helpers.Kubectl) {
 	// so we need to wait until 5 pods are in ready state.
 	// This is to avoid cases where a few pods are ready, but the
 	// new one is not created yet.
-	By("Waiting for all etcd-operator pods are ready")
+	By("Waiting for all etcd-operator pods to be ready")
 
 	err := vm.WaitforNPods(helpers.KubeSystemNamespace, "-l io.cilium/app=etcd-operator", 5, longTimeout)
 	warningMessage := ""


### PR DESCRIPTION
This issue became visible after noticing in #7869
that there currently isn't IPv6 node connectivity
via health endpoints.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8160)
<!-- Reviewable:end -->
