### PR TITLE
allocator: Verify locally allocated key

### DIFF
--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -407,6 +407,11 @@ func (a *Allocator) createValueNodeKey(ctx context.Context, key string, newID id
 		return fmt.Errorf("unable to create value-node key '%s': %s", valueKey, err)
 	}
 
+	// mark the key as verified in the local cache
+	if err := a.localKeys.verify(key); err != nil {
+		log.WithError(err).Error("BUG: Unable to verify local key")
+	}
+
 	return nil
 }
 
@@ -453,11 +458,6 @@ func (a *Allocator) lockedAllocate(ctx context.Context, key AllocatorKey) (idpoo
 		if err = a.createValueNodeKey(ctx, k, value); err != nil {
 			a.localKeys.release(k)
 			return 0, false, fmt.Errorf("unable to create slave key '%s': %s", k, err)
-		}
-
-		// mark the key as verified in the local cache
-		if err := a.localKeys.verify(k); err != nil {
-			log.WithError(err).Error("BUG: Unable to verify local key")
 		}
 
 		return value, false, nil


### PR DESCRIPTION
The logic to re-create slave keys requires keys to be verified, i.e.
successfully created in the kvstore once. So far, only keys for which a master
key already existed have been marked as verified. This prevented the node that
originally created a slave key to ever re-create the key on accidental
deletion.

Mark all keys that have been successfully created in the kvstore as verified.

Reported-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8168)
<!-- Reviewable:end -->
