### PR TITLE
allocator: Provide additional info message on key allocation and deletion

### DIFF
--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -467,6 +467,8 @@ func (a *Allocator) lockedAllocate(ctx context.Context, key AllocatorKey) (idpoo
 			return 0, false, fmt.Errorf("unable to create slave key '%s': %s", k, err)
 		}
 
+		log.WithField(fieldKey, k).Info("Reusing existing global key")
+
 		return value, false, nil
 	}
 
@@ -518,6 +520,8 @@ func (a *Allocator) lockedAllocate(ctx context.Context, key AllocatorKey) (idpoo
 		releaseKeyAndID()
 		return 0, false, fmt.Errorf("slave key creation failed '%s': %s", k, err)
 	}
+
+	log.WithField(fieldKey, k).Info("Allocated new global key")
 
 	return id, true, nil
 }
@@ -671,6 +675,8 @@ func (a *Allocator) Release(ctx context.Context, key AllocatorKey) (lastUse bool
 
 	if lastUse {
 		valueKey := path.Join(a.valuePrefix, k, a.suffix)
+		log.WithField(fieldKey, key).Info("Released last local use of key, invoking global release")
+
 		if err := kvstore.Delete(valueKey); err != nil {
 			log.WithError(err).WithFields(logrus.Fields{fieldKey: key}).Warning("Ignoring node specific ID")
 		}


### PR DESCRIPTION
Tracking down identity leaks has been difficult due to lack of info level
messages. These events are rare and tied to endpoint lifecycle so providing
additional info level messages is safe and will help correlate identity
management across multiple nodes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8169)
<!-- Reviewable:end -->
