### PR TITLE
operator: Fix health check API

### DIFF
--- a/operator/main.go
+++ b/operator/main.go
@@ -161,7 +161,7 @@ func runOperator(cmd *cobra.Command) {
 	logging.SetupLogging([]string{}, map[string]string{}, "cilium-operator", viper.GetBool("debug"))
 
 	log.Infof("Cilium Operator %s", version.Version)
-	go StartServer(fmt.Sprintf(":%d", apiServerPort), shutdownSignal)
+	go startServer(fmt.Sprintf(":%d", apiServerPort), shutdownSignal)
 
 	if requiresKVstore() {
 		scopedLog := log.WithFields(logrus.Fields{


### PR DESCRIPTION
 * Error out for real when the health check API cannot be served. The most
   common problem is that the port is still in use by a previous operator
   instance running on the same node.

 * Do not fail the health check if the kvstore is unavailable if the kvstore is
   not needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8171)
<!-- Reviewable:end -->
