### PR TITLE
allocator: Make GetNoCache() and RunGC() deterministic

### DIFF
--- a/pkg/kvstore/allocator/allocator_test.go
+++ b/pkg/kvstore/allocator/allocator_test.go
@@ -290,21 +290,14 @@ func testGetNoCache(c *C, maxID idpool.ID, testName string, suffix string) {
 	c.Assert(err, IsNil)
 	c.Assert(observedID, Equals, idpool.NoID)
 
-	// Limitation: If we now insert the key for the short labels because
-	// it's not found, then we will have two keys with the same "foo;/;"
-	// prefix. At that point it's not deterministic whether we will find
-	// the key or not, because GetNoCache() only checks the first key that
-	// matches a given prefix.
 	shortID, new, err := allocator.Allocate(context.Background(), shortKey)
 	c.Assert(err, IsNil)
 	c.Assert(shortID, Not(Equals), 0)
 	c.Assert(new, Equals, true)
 
-	// So, if we look this up, the only thing we can be sure of is that it
-	// must not find the longID. It will either be idpool.NoID or shortID.
 	observedID, err = allocator.GetNoCache(context.Background(), shortKey)
 	c.Assert(err, IsNil)
-	c.Assert(observedID, Not(Equals), longID)
+	c.Assert(observedID, Equals, shortID)
 }
 
 func (s *AllocatorSuite) TestprefixMatchesKey(c *C) {


### PR DESCRIPTION
This ensures that GetNoCache() and RunGC() are 100% deterministic with regard to overlapping key prefixes.

Example:
```
    key1 := label1;label2;
    key2 := label1;label2;label3;
```

* `GetNoCache("label1;label2;")` should always only return users of key1.
* `RunGC()` should release key1 if unused even if key2 is present with users.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8172)
<!-- Reviewable:end -->
