### PR TITLE
Cilium: route/ipsec, add mask to delete rule and add a set of unit tests

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -144,7 +144,7 @@ func ipSecReplacePolicyInFwd(src, dst *net.IPNet, dir netlink.Dir) error {
 	return netlink.XfrmPolicyUpdate(policy)
 }
 
-func ipSecReplacePolicyOut(src, dst *net.IPNet, dir IPSecDir) error {
+func ipSecReplacePolicyOut(src, dst *net.IPNet) error {
 	var spiWide uint32
 
 	key := getIPSecKeys(dst.IP)
@@ -298,7 +298,7 @@ func UpsertIPsecEndpoint(local, remote *net.IPNet, dir IPSecDir) (uint8, error) 
 				}
 			}
 
-			if err = ipSecReplacePolicyOut(local, remote, dir); err != nil {
+			if err = ipSecReplacePolicyOut(local, remote); err != nil {
 				if !os.IsExist(err) {
 					return 0, fmt.Errorf("unable to replace policy out: %s", err)
 				}

--- a/pkg/datapath/linux/route/route_linux.go
+++ b/pkg/datapath/linux/route/route_linux.go
@@ -315,6 +315,30 @@ func Delete(route Route) error {
 	return nil
 }
 
+// LookupEncryptIPv4Rule returns true if IPv4 encrypt rule exists false otherwise. An error is reported
+// if kernel/agent netlink message reports an error.
+func LookupEncryptIPv4Rule() (bool, error) {
+	return lookupRule(linux_defaults.RouteMarkEncrypt, linux_defaults.RouteTableIPSec, netlink.FAMILY_V4)
+}
+
+// LookupEncryptIPv6Rule returns true if IPv6 encrypt rule exists false otherwise. An error is reported
+// if kernel/agent netlink message reports an error.
+func LookupEncryptIPv6Rule() (bool, error) {
+	return lookupRule(linux_defaults.RouteMarkEncrypt, linux_defaults.RouteTableIPSec, netlink.FAMILY_V6)
+}
+
+// LookupDecryptIPv4Rule returns true if IPv4 decrypt rule exists false otherwise. An error is reported
+// if kernel/agent netlink message reports an error.
+func LookupDecryptIPv4Rule() (bool, error) {
+	return lookupRule(linux_defaults.RouteMarkDecrypt, linux_defaults.RouteTableIPSec, netlink.FAMILY_V4)
+}
+
+// LookupDecryptIPv6Rule returns true if IPv6 decrypt rule exists false otherwise. An error is reported
+// if kernel/agent netlink message reports an error.
+func LookupDecryptIPv6Rule() (bool, error) {
+	return lookupRule(linux_defaults.RouteMarkDecrypt, linux_defaults.RouteTableIPSec, netlink.FAMILY_V6)
+}
+
 func lookupRule(fwmark, table, family int) (bool, error) {
 	rules, err := netlink.RuleList(family)
 	if err != nil {

--- a/pkg/datapath/linux/route/route_linux.go
+++ b/pkg/datapath/linux/route/route_linux.go
@@ -378,6 +378,7 @@ func DeleteRule(fwmark int, table int) error {
 func DeleteRuleIPv6(fwmark int, table int) error {
 	rule := netlink.NewRule()
 	rule.Mark = fwmark
+	rule.Mask = linux_defaults.RouteMarkMask
 	rule.Table = table
 	rule.Family = netlink.FAMILY_V6
 	return netlink.RuleDel(rule)


### PR DESCRIPTION
This adds the mask to delete route in the IPv6 case to be sure we only delete routes that are expected. This was found while adding unit tests included in this series for routes and ipsec.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8176)
<!-- Reviewable:end -->
