### PR TITLE
kvstore/allocator: use dedicated token to represent end of prefix

### DIFF
--- a/pkg/kvstore/allocator/allocator_test.go
+++ b/pkg/kvstore/allocator/allocator_test.go
@@ -327,13 +327,13 @@ func testGetNoCache(c *C, maxID idpool.ID, testName string, suffix string) {
 	c.Assert(longID, Not(Equals), 0)
 	c.Assert(new, Equals, true)
 
-	observedID, err := allocator.GetNoCache(context.Background(), key)
+	observedID, err := allocator.GetNoCache(context.Background(), key.GetKey())
 	c.Assert(err, IsNil)
 	c.Assert(observedID, Not(Equals), 0)
 
 	labelsShort := "foo;/;"
 	shortKey := TestType(labelsShort)
-	observedID, err = allocator.GetNoCache(context.Background(), shortKey)
+	observedID, err = allocator.GetNoCache(context.Background(), shortKey.GetKey())
 	c.Assert(err, IsNil)
 	c.Assert(observedID, Equals, idpool.NoID)
 
@@ -342,46 +342,9 @@ func testGetNoCache(c *C, maxID idpool.ID, testName string, suffix string) {
 	c.Assert(shortID, Not(Equals), 0)
 	c.Assert(new, Equals, true)
 
-	observedID, err = allocator.GetNoCache(context.Background(), shortKey)
+	observedID, err = allocator.GetNoCache(context.Background(), shortKey.GetKey())
 	c.Assert(err, IsNil)
 	c.Assert(observedID, Equals, shortID)
-}
-
-func (s *AllocatorSuite) TestprefixMatchesKey(c *C) {
-	// cilium/state/identities/v1/value/label;foo;bar;/172.0.124.60
-
-	tests := []struct {
-		prefix   string
-		key      string
-		expected bool
-	}{
-		{
-			prefix:   "foo",
-			key:      "foo/bar",
-			expected: true,
-		},
-		{
-			prefix:   "foo/;bar;baz;/;a;",
-			key:      "foo/;bar;baz;/;a;/alice",
-			expected: true,
-		},
-		{
-			prefix:   "foo/;bar;baz;",
-			key:      "foo/;bar;baz;/;a;/alice",
-			expected: false,
-		},
-		{
-			prefix:   "foo/;bar;baz;/;a;/baz",
-			key:      "foo/;bar;baz;/;a;/alice",
-			expected: false,
-		},
-	}
-
-	for _, tt := range tests {
-		c.Logf("prefixMatchesKey(%q, %q) expected to be %t", tt.prefix, tt.key, tt.expected)
-		result := prefixMatchesKey(tt.prefix, tt.key)
-		c.Assert(result, Equals, tt.expected)
-	}
 }
 
 func (s *AllocatorSuite) TestGetNoCache(c *C) {


### PR DESCRIPTION
To avoid listing all key and values when performing a list prefix, we
can make usage of a special token to represent the end of a prefix
label. This guarantees whenever we are performing a get operation with
prefix and limit 1 options that the returned key matches the given
prefix queried.

Example of the data stored in etcd:
```
cilium/state/identities/v1/value/foo=bar;foo=baz;/__CILIUM_SLASH__/192.168.34.11
hello
cilium/state/identities/v1/value/foo=bar;foo=baz;foo=1;/__CILIUM_SLASH__/192.168.34.11
world
```

Performing an operation with prefix for the key
`cilium/state/identities/v1/value/foo=bar;foo=baz;/__CILIUM_SLASH__/` is
guarantee to return the value "hello".

The value `;/__CILIUM_SLASH__/` will be considered forbidden as a label
value.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8177)
<!-- Reviewable:end -->
