### PR TITLE
v1.5: backports 19-05-30

### DIFF
--- a/cilium/cmd/kvstore_get.go
+++ b/cilium/cmd/kvstore_get.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ var kvstoreGetCmd = &cobra.Command{
 				return
 			}
 			for k, v := range pairs {
-				fmt.Printf("%s => %s\n", k, string(v))
+				fmt.Printf("%s => %s\n", k, string(v.Data))
 			}
 		} else {
 			val, err := kvstore.Get(key)

--- a/operator/identity_gc.go
+++ b/operator/identity_gc.go
@@ -31,10 +31,14 @@ func startIdentityGC() {
 	log.Infof("Starting security identity garbage collector with %s interval...", identityGCInterval)
 	a := allocator.NewAllocatorForGC(cache.IdentitiesPath)
 
+	keysToDelete := map[string]uint64{}
 	go func() {
 		for {
-			if err := a.RunGC(); err != nil {
+			keysToDelete2, err := a.RunGC(keysToDelete)
+			if err != nil {
 				log.WithError(err).Warning("Unable to run security identity garbage collector")
+			} else {
+				keysToDelete = keysToDelete2
 			}
 
 			<-time.After(identityGCInterval)

--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -383,14 +383,6 @@ func (a *Allocator) ForeachCache(cb RangeFunc) {
 	a.remoteCachesMutex.RUnlock()
 }
 
-func invalidKey(key, prefix string, deleteInvalid bool) {
-	log.WithFields(logrus.Fields{fieldKey: key, fieldPrefix: prefix}).Warning("Found invalid key outside of prefix")
-
-	if deleteInvalid {
-		kvstore.Delete(key)
-	}
-}
-
 // Selects an available ID.
 // Returns a triple of the selected ID ORed with prefixMask,
 // the ID string and the originally selected ID.

--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -407,6 +407,11 @@ func (a *Allocator) createValueNodeKey(ctx context.Context, key string, newID id
 		return fmt.Errorf("unable to create value-node key '%s': %s", valueKey, err)
 	}
 
+	// mark the key as verified in the local cache
+	if err := a.localKeys.verify(key); err != nil {
+		log.WithError(err).Error("BUG: Unable to verify local key")
+	}
+
 	return nil
 }
 
@@ -453,11 +458,6 @@ func (a *Allocator) lockedAllocate(ctx context.Context, key AllocatorKey) (idpoo
 		if err = a.createValueNodeKey(ctx, k, value); err != nil {
 			a.localKeys.release(k)
 			return 0, false, fmt.Errorf("unable to create slave key '%s': %s", k, err)
-		}
-
-		// mark the key as verified in the local cache
-		if err := a.localKeys.verify(k); err != nil {
-			log.WithError(err).Error("BUG: Unable to verify local key")
 		}
 
 		return value, false, nil

--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -505,7 +505,7 @@ func (a *Allocator) lockedAllocate(ctx context.Context, key AllocatorKey) (idpoo
 		// We will leak the master key here as the key has already been
 		// exposed and may be in use by other nodes. The garbage
 		// collector will release it again.
-		a.localKeys.release(k)
+		releaseKeyAndID()
 		return 0, false, fmt.Errorf("slave key creation failed '%s': %s", k, err)
 	}
 

--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -488,17 +488,6 @@ func (a *Allocator) lockedAllocate(ctx context.Context, key AllocatorKey) (idpoo
 		return 0, false, fmt.Errorf("another writer has allocated this key")
 	}
 
-	value, err = a.GetNoCache(ctx, key)
-	if err != nil {
-		releaseKeyAndID()
-		return 0, false, err
-	}
-
-	if value != 0 {
-		releaseKeyAndID()
-		return 0, false, fmt.Errorf("master key already exists")
-	}
-
 	// create /id/<ID> and fail if it already exists
 	keyPath := path.Join(a.idPrefix, strID)
 	success, err := kvstore.CreateOnly(ctx, keyPath, []byte(k), false)

--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -468,6 +468,8 @@ func (a *Allocator) lockedAllocate(ctx context.Context, key AllocatorKey) (idpoo
 			return 0, false, fmt.Errorf("unable to create slave key '%s': %s", k, err)
 		}
 
+		log.WithField(fieldKey, k).Info("Reusing existing global key")
+
 		return value, false, nil
 	}
 
@@ -519,6 +521,8 @@ func (a *Allocator) lockedAllocate(ctx context.Context, key AllocatorKey) (idpoo
 		releaseKeyAndID()
 		return 0, false, fmt.Errorf("slave key creation failed '%s': %s", k, err)
 	}
+
+	log.WithField(fieldKey, k).Info("Allocated new global key")
 
 	return id, true, nil
 }
@@ -683,6 +687,8 @@ func (a *Allocator) Release(ctx context.Context, key AllocatorKey) (lastUse bool
 
 	if lastUse {
 		valueKey := path.Join(a.valuePrefix, k, a.suffix)
+		log.WithField(fieldKey, key).Info("Released last local use of key, invoking global release")
+
 		if err := kvstore.Delete(valueKey); err != nil {
 			log.WithError(err).WithFields(logrus.Fields{fieldKey: key}).Warning("Ignoring node specific ID")
 		}

--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -639,7 +639,7 @@ func (a *Allocator) GetNoCache(ctx context.Context, key AllocatorKey) (idpool.ID
 
 	for k, v := range pairs {
 		if prefixMatchesKey(prefix, k) {
-			id, err := strconv.ParseUint(string(v), 10, 64)
+			id, err := strconv.ParseUint(string(v.Data), 10, 64)
 			if err == nil {
 				return idpool.ID(id), nil
 			}
@@ -727,7 +727,7 @@ func (a *Allocator) RunGC() error {
 		}
 
 		// fetch list of all /value/<key> keys
-		valueKeyPrefix := path.Join(a.valuePrefix, string(v))
+		valueKeyPrefix := path.Join(a.valuePrefix, string(v.Data))
 		pairs, err := kvstore.ListPrefix(valueKeyPrefix)
 		if err != nil {
 			log.WithError(err).WithField(fieldPrefix, valueKeyPrefix).Warning("allocator garbage collector was unable to list keys")

--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -719,15 +719,22 @@ func (a *Allocator) RunGC() error {
 
 		// fetch list of all /value/<key> keys
 		valueKeyPrefix := path.Join(a.valuePrefix, string(v))
-		uses, err := kvstore.ListPrefix(valueKeyPrefix)
+		pairs, err := kvstore.ListPrefix(valueKeyPrefix)
 		if err != nil {
 			log.WithError(err).WithField(fieldPrefix, valueKeyPrefix).Warning("allocator garbage collector was unable to list keys")
 			lock.Unlock()
 			continue
 		}
 
+		users := 0
+		for k := range pairs {
+			if prefixMatchesKey(valueKeyPrefix, k) {
+				users++
+			}
+		}
+
 		// if ID has no user, delete it
-		if len(uses) == 0 {
+		if users == 0 {
 			scopedLog := log.WithFields(logrus.Fields{
 				fieldKey: key,
 				fieldID:  path.Base(key),

--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -133,6 +133,10 @@ type Allocator struct {
 	// being derived from the basePrefix.
 	valuePrefix string
 
+	// slaveKeysMutex protects the concurrent access of the slave key by this
+	// agent.
+	slaveKeysMutex lock.Mutex
+
 	// lockPrefix is the prefix to use for all kvstore locks. This prefix
 	// is different from the idPrefix and valuePrefix to simplify watching
 	// for ID and key changes.
@@ -450,6 +454,9 @@ func (a *Allocator) lockedAllocate(ctx context.Context, key AllocatorKey) (idpoo
 	kvstore.Trace("kvstore state is: ", nil, logrus.Fields{fieldID: value})
 
 	if value != 0 {
+		a.slaveKeysMutex.Lock()
+		defer a.slaveKeysMutex.Unlock()
+
 		_, err := a.localKeys.allocate(k, value)
 		if err != nil {
 			return 0, false, fmt.Errorf("unable to reserve local key '%s': %s", k, err)
@@ -474,6 +481,9 @@ func (a *Allocator) lockedAllocate(ctx context.Context, key AllocatorKey) (idpoo
 		a.localKeys.release(k)
 		a.idPool.Release(unmaskedID)
 	}
+
+	a.slaveKeysMutex.Lock()
+	defer a.slaveKeysMutex.Unlock()
 
 	oldID, err := a.localKeys.allocate(k, id)
 	if err != nil {
@@ -647,6 +657,10 @@ func (a *Allocator) Release(ctx context.Context, key AllocatorKey) (lastUse bool
 	}
 
 	k := key.GetKey()
+
+	a.slaveKeysMutex.Lock()
+	defer a.slaveKeysMutex.Unlock()
+
 	// release the key locally, if it was the last use, remove the node
 	// specific value key to remove the global reference mark
 	lastUse, err = a.localKeys.release(k)

--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -707,12 +707,14 @@ func (a *Allocator) Release(ctx context.Context, key AllocatorKey) (lastUse bool
 }
 
 // RunGC scans the kvstore for unused master keys and removes them
-func (a *Allocator) RunGC() error {
+func (a *Allocator) RunGC(staleKeysPrevRound map[string]uint64) (map[string]uint64, error) {
 	// fetch list of all /id/ keys
 	allocated, err := kvstore.ListPrefix(a.idPrefix)
 	if err != nil {
-		return fmt.Errorf("list failed: %s", err)
+		return nil, fmt.Errorf("list failed: %s", err)
 	}
+
+	staleKeys := map[string]uint64{}
 
 	// iterate over /id/
 	for key, v := range allocated {
@@ -735,30 +737,37 @@ func (a *Allocator) RunGC() error {
 			continue
 		}
 
-		users := 0
+		hasUsers := false
 		for k := range pairs {
 			if prefixMatchesKey(valueKeyPrefix, k) {
-				users++
+				hasUsers = true
+				break
 			}
 		}
 
 		// if ID has no user, delete it
-		if users == 0 {
+		if !hasUsers {
 			scopedLog := log.WithFields(logrus.Fields{
 				fieldKey: key,
 				fieldID:  path.Base(key),
 			})
-			if err := kvstore.Delete(key); err != nil {
-				scopedLog.WithError(err).Warning("Unable to delete unused allocator master key")
+			// Only delete if this key was previously marked as to be deleted
+			if modRev, ok := staleKeysPrevRound[key]; ok && modRev == v.ModRevision {
+				if err := kvstore.Delete(key); err != nil {
+					scopedLog.WithError(err).Warning("Unable to delete unused allocator master key")
+				} else {
+					scopedLog.Info("Deleted unused allocator master key")
+				}
 			} else {
-				scopedLog.Info("Deleted unused allocator master key")
+				// If the key was not found mark it to be delete in the next RunGC
+				staleKeys[key] = v.ModRevision
 			}
 		}
 
 		lock.Unlock()
 	}
 
-	return nil
+	return staleKeys, nil
 }
 
 func (a *Allocator) recreateMasterKey(id idpool.ID, value string, reliablyMissing bool) {

--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -446,15 +446,29 @@ func (a *Allocator) lockedAllocate(ctx context.Context, key AllocatorKey) (idpoo
 
 	kvstore.Trace("kvstore state is: ", nil, logrus.Fields{fieldID: value})
 
-	if value != 0 {
-		a.slaveKeysMutex.Lock()
-		defer a.slaveKeysMutex.Unlock()
+	a.slaveKeysMutex.Lock()
+	defer a.slaveKeysMutex.Unlock()
 
+	// We shouldn't assume the fact the master key does not exist in the kvstore
+	// that localKeys does not have it. The KVStore might have lost all of its
+	// data but the local agent still holds a reference for the given master key.
+	if value == 0 {
+		value = a.localKeys.lookupKey(k)
+		if value != 0 {
+			// re-create master key
+			keyPath := path.Join(a.idPrefix, strconv.FormatUint(uint64(value), 10))
+			success, err := kvstore.CreateOnly(ctx, keyPath, []byte(k), false)
+			if err != nil || !success {
+				return 0, false, fmt.Errorf("unable to create master key '%s': %s", keyPath, err)
+			}
+		}
+	} else {
 		_, err := a.localKeys.allocate(k, value)
 		if err != nil {
 			return 0, false, fmt.Errorf("unable to reserve local key '%s': %s", k, err)
 		}
-
+	}
+	if value != 0 {
 		if err = a.createValueNodeKey(ctx, k, value); err != nil {
 			a.localKeys.release(k)
 			return 0, false, fmt.Errorf("unable to create slave key '%s': %s", k, err)
@@ -477,9 +491,6 @@ func (a *Allocator) lockedAllocate(ctx context.Context, key AllocatorKey) (idpoo
 		a.idPool.Release(unmaskedID)
 	}
 
-	a.slaveKeysMutex.Lock()
-	defer a.slaveKeysMutex.Unlock()
-
 	oldID, err := a.localKeys.allocate(k, id)
 	if err != nil {
 		a.idPool.Release(unmaskedID)
@@ -497,7 +508,7 @@ func (a *Allocator) lockedAllocate(ctx context.Context, key AllocatorKey) (idpoo
 	keyPath := path.Join(a.idPrefix, strID)
 	success, err := kvstore.CreateOnly(ctx, keyPath, []byte(k), false)
 	if err != nil || !success {
-		// Creation failed. Another agent most likely beat us to allocting this
+		// Creation failed. Another agent most likely beat us to allocating this
 		// ID, retry.
 		releaseKeyAndID()
 		return 0, false, fmt.Errorf("unable to create master key '%s': %s", keyPath, err)
@@ -602,7 +613,7 @@ func prefixMatchesKey(prefix, key string) bool {
 	return len(prefix) == lastSlash
 }
 
-// Get returns the ID which is allocated to a key in the kvstore
+// GetNoCache returns the ID which is allocated to a key in the kvstore
 func (a *Allocator) GetNoCache(ctx context.Context, key AllocatorKey) (idpool.ID, error) {
 	// ListPrefix() will return all keys matching the prefix, the prefix
 	// can cover multiple different keys, example:

--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -78,7 +78,8 @@ const (
 //
 // Lookup ID by key:
 // 1. Return ID from local cache updated by watcher (no kvstore interactions)
-// 2. Do GetPrefix() on slave key excluding node suffix, return first result
+// 2. Do ListPrefix() on slave key excluding node suffix, return the first
+//    result that matches the exact prefix.
 //
 // Lookup key by ID:
 // 1. Return key from local cache updated by watcher (no kvstore interactions)
@@ -607,26 +608,38 @@ func prefixMatchesKey(prefix, key string) bool {
 
 // Get returns the ID which is allocated to a key in the kvstore
 func (a *Allocator) GetNoCache(ctx context.Context, key AllocatorKey) (idpool.ID, error) {
-	// GetPrefix() will choose any "first" key with the same prefix as the
-	// specified key. In the worst case this may alternate between
-	// returning the prefix that is specified and returning a key with a
-	// longer prefix (even if this exact prefix already exists in the
-	// kvstore). In that case, we will potentially allocate duplicate
-	// identities for the same set of labels. This is not efficient, but
-	// should have the correct identity properties.
+	// ListPrefix() will return all keys matching the prefix, the prefix
+	// can cover multiple different keys, example:
+	//
+	// key1 := label1;label2;
+	// key2 := label1;label2;label3;
+	//
+	// In order to retrieve the correct key, the position of the last '/'
+	// is signficant, e.g.
+	//
+	// prefix := cilium/state/identities/v1/value/label;foo;
+	//
+	// key1 := cilium/state/identities/v1/value/label;foo;/172.0.124.60
+	// key2 := cilium/state/identities/v1/value/label;foo;bar;/172.0.124.60
+	//
+	// Only key1 should match
 	prefix := path.Join(a.valuePrefix, key.GetKey())
-	k, v, err := kvstore.GetPrefix(ctx, prefix)
-	kvstore.Trace("AllocateGet", err, logrus.Fields{fieldPrefix: prefix, fieldKey: k, fieldValue: v})
-	if err != nil || v == nil || !prefixMatchesKey(prefix, k) {
+	pairs, err := kvstore.ListPrefix(prefix)
+	kvstore.Trace("ListPrefix", err, logrus.Fields{fieldPrefix: prefix, "entries": len(pairs)})
+	if err != nil {
 		return 0, err
 	}
 
-	id, err := strconv.ParseUint(string(v), 10, 64)
-	if err != nil {
-		return idpool.NoID, fmt.Errorf("unable to parse value '%s': %s", v, err)
+	for k, v := range pairs {
+		if prefixMatchesKey(prefix, k) {
+			id, err := strconv.ParseUint(string(v), 10, 64)
+			if err == nil {
+				return idpool.ID(id), nil
+			}
+		}
 	}
 
-	return idpool.ID(id), nil
+	return idpool.NoID, nil
 }
 
 // GetByID returns the key associated with an ID. Returns nil if no key is

--- a/pkg/kvstore/allocator/allocator_test.go
+++ b/pkg/kvstore/allocator/allocator_test.go
@@ -290,21 +290,14 @@ func testGetNoCache(c *C, maxID idpool.ID, testName string, suffix string) {
 	c.Assert(err, IsNil)
 	c.Assert(observedID, Equals, idpool.NoID)
 
-	// Limitation: If we now insert the key for the short labels because
-	// it's not found, then we will have two keys with the same "foo;/;"
-	// prefix. At that point it's not deterministic whether we will find
-	// the key or not, because GetNoCache() only checks the first key that
-	// matches a given prefix.
 	shortID, new, err := allocator.Allocate(context.Background(), shortKey)
 	c.Assert(err, IsNil)
 	c.Assert(shortID, Not(Equals), 0)
 	c.Assert(new, Equals, true)
 
-	// So, if we look this up, the only thing we can be sure of is that it
-	// must not find the longID. It will either be idpool.NoID or shortID.
 	observedID, err = allocator.GetNoCache(context.Background(), shortKey)
 	c.Assert(err, IsNil)
-	c.Assert(observedID, Not(Equals), longID)
+	c.Assert(observedID, Equals, shortID)
 }
 
 func (s *AllocatorSuite) TestprefixMatchesKey(c *C) {

--- a/pkg/kvstore/allocator/cache.go
+++ b/pkg/kvstore/allocator/cache.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -91,6 +91,14 @@ func (c *cache) getLogger() *logrus.Entry {
 		"kvstoreErr":    err,
 		"prefix":        c.prefix,
 	})
+}
+
+func invalidKey(key, prefix string, deleteInvalid bool) {
+	log.WithFields(logrus.Fields{fieldKey: key, fieldPrefix: prefix}).Warning("Found invalid key outside of prefix")
+
+	if deleteInvalid {
+		kvstore.Delete(key)
+	}
 }
 
 func (c *cache) keyToID(key string, deleteInvalid bool) idpool.ID {

--- a/pkg/kvstore/allocator/localkeys.go
+++ b/pkg/kvstore/allocator/localkeys.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -83,6 +83,19 @@ func (lk *localKeys) verify(key string) error {
 	}
 
 	return fmt.Errorf("key %s not found", key)
+}
+
+// lookupKey returns the idpool.ID of the key is present in the map of keys.
+// if it isn't present, returns idpool.NoID
+func (lk *localKeys) lookupKey(key string) idpool.ID {
+	lk.RLock()
+	defer lk.RUnlock()
+
+	if k, ok := lk.keys[key]; ok {
+		return k.val
+	}
+
+	return idpool.NoID
 }
 
 // lookupID returns the key for a given ID or an empty string

--- a/pkg/kvstore/consul.go
+++ b/pkg/kvstore/consul.go
@@ -557,9 +557,12 @@ func (c *consulClient) ListPrefix(prefix string) (KeyValuePairs, error) {
 		return nil, err
 	}
 
-	p := KeyValuePairs(make(map[string][]byte, len(pairs)))
+	p := KeyValuePairs(make(map[string]Value, len(pairs)))
 	for i := 0; i < len(pairs); i++ {
-		p[pairs[i].Key] = pairs[i].Value
+		p[pairs[i].Key] = Value{
+			Data:        pairs[i].Value,
+			ModRevision: pairs[i].ModifyIndex,
+		}
 	}
 
 	return p, nil

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -915,9 +915,12 @@ func (e *etcdClient) ListPrefix(prefix string) (KeyValuePairs, error) {
 		return nil, Hint(err)
 	}
 
-	pairs := KeyValuePairs{}
+	pairs := KeyValuePairs(make(map[string]Value, getR.Count))
 	for i := int64(0); i < getR.Count; i++ {
-		pairs[string(getR.Kvs[i].Key)] = getR.Kvs[i].Value
+		pairs[string(getR.Kvs[i].Key)] = Value{
+			Data:        getR.Kvs[i].Value,
+			ModRevision: uint64(getR.Kvs[i].ModRevision),
+		}
 
 	}
 

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -755,7 +755,7 @@ func (e *etcdClient) Get(key string) ([]byte, error) {
 func (e *etcdClient) GetPrefix(ctx context.Context, prefix string) (string, []byte, error) {
 	duration := spanstat.Start()
 	e.limiter.Wait(ctx)
-	getR, err := e.client.Get(ctx, prefix, client.WithPrefix())
+	getR, err := e.client.Get(ctx, prefix, client.WithPrefix(), client.WithLimit(1))
 	increaseMetric(prefix, metricRead, "GetPrefix", duration.EndError(err).Total(), err)
 	if err != nil {
 		return "", nil, Hint(err)

--- a/pkg/kvstore/kvstore.go
+++ b/pkg/kvstore/kvstore.go
@@ -20,8 +20,15 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// Value is an abstraction of the data stored in the kvstore as well as the
+// mod revision of that data.
+type Value struct {
+	Data        []byte
+	ModRevision uint64
+}
+
 // KeyValuePairs is a map of key=value pairs
-type KeyValuePairs map[string][]byte
+type KeyValuePairs map[string]Value
 
 // Capabilities is a bitmask to indicate the capabilities of a backend
 type Capabilities uint32


### PR DESCRIPTION
* PR: 8168 -- allocator: Verify locally allocated key (@tgraf) -- https://github.com/cilium/cilium/pull/8168
* PR: 8159 -- KVStore bug fixes and small improvements (@aanm) -- https://github.com/cilium/cilium/pull/8159
* PR: 8172 -- allocator: Make GetNoCache() and RunGC() deterministic (@tgraf) -- https://github.com/cilium/cilium/pull/8172
* PR: 8169 -- allocator: Provide additional info message on key allocation and deletion (@tgraf) -- https://github.com/cilium/cilium/pull/8169
* PR: 8170 -- KVStore bug fixes and small improvements - 2 (@aanm) -- https://github.com/cilium/cilium/pull/8170

Please note that I did not backport anything but kvstore fixes, and the fix needed for the cilium-operator healthcheck. The rest are nice-to-haves, and can be punted to the next release of `v1.5`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8178)
<!-- Reviewable:end -->
