### PR TITLE
CI: Ensure SSH daemon is not OOM-killed in VMs

### DIFF
--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -93,6 +93,9 @@ Vagrant.configure("2") do |config|
             server.vm.network "private_network", type: "dhcp"
             server.vm.synced_folder "../", "/home/vagrant/go/src/github.com/cilium/cilium",
                 nfs: $NFS
+            # ensure SSH is never OOM killed
+            server.vm.provision :shell, 
+                :inline => "echo -17 > /proc/`cat /var/run/sshd.pid`/oom_adj"
             # Provision section
             server.vm.provision :shell,
                 :inline => "sed -i 's/^mesg n$/tty -s \\&\\& mesg n/g' /root/.profile"


### PR DESCRIPTION
This is a stab in the dark...

We sometimes see mystery timeouts and this may happen if SSH is
OOM-killed, locking the test suite out. This change ensures that SSH
isn't selected, hopefully allowing the suite to continue, fail, and
successfully collect data from within the VM.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8180)
<!-- Reviewable:end -->
