### PR TITLE
test: Add sonobuoy nightly test

### DIFF
--- a/pkg/workloads/docker.go
+++ b/pkg/workloads/docker.go
@@ -241,8 +241,6 @@ func (d *dockerClient) IsRunning(ep *endpoint.Endpoint) bool {
 		}
 
 		if err == nil {
-			runtimeRunning = true
-
 			// Container may exist but is not in running state
 			return cont.State.Running
 		}

--- a/test/helpers/sonobuoy.go
+++ b/test/helpers/sonobuoy.go
@@ -1,0 +1,21 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helpers
+
+// ExecSonobuoy runs a Sonobuoy CLI command (which launches conformance tests
+// for Kubernetes cluster) and returns the resultant cmdRes.
+func (s *SSHMeta) ExecSonobuoy() *CmdRes {
+	return s.ExecWithSudo("sonobuoy run --wait")
+}

--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -448,3 +448,25 @@ var _ = Describe("NightlyExamples", func() {
 		})
 	})
 })
+
+var _ = Describe("NightlySonobuoy", func() {
+	var kubectl *helpers.Kubectl
+
+	BeforeAll(func() {
+		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
+		ExpectCiliumReady(kubectl)
+	})
+
+	AfterFailed(func() {
+		kubectl.CiliumReport(helpers.KubeSystemNamespace,
+			"cilium service list",
+			"cilium endpoint list")
+	})
+
+	Context("Run sonobuoy", func() {
+		It("Run sonobuoy", func() {
+			res := kubectl.ExecSonobuoy()
+			res.ExpectSuccess("Sonobuoy conformance tests failed")
+		})
+	})
+})

--- a/vagrant_box_defaults.rb
+++ b/vagrant_box_defaults.rb
@@ -3,6 +3,6 @@
 Vagrant.require_version ">= 2.2.0"
 
 $SERVER_BOX = "cilium/ubuntu-dev"
-$SERVER_VERSION= "151"
+$SERVER_VERSION= "155"
 $NETNEXT_SERVER_BOX= "cilium/ubuntu-next"
 $NETNEXT_SERVER_VERSION= "23"


### PR DESCRIPTION
This change adds a nightly test which runs sonobuoy conformance tests
against the test cluster.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8183)
<!-- Reviewable:end -->
