### PR TITLE
cni: Add cniVersion in cni config file

### DIFF
--- a/plugins/cilium-cni/05-cilium-cni.conf
+++ b/plugins/cilium-cni/05-cilium-cni.conf
@@ -1,4 +1,5 @@
 {
+    "cniVersion": "0.3.1",
     "name": "cilium",
     "type": "cilium-cni"
 }

--- a/plugins/cilium-cni/cni-install.sh
+++ b/plugins/cilium-cni/cni-install.sh
@@ -96,6 +96,7 @@ EOF
 "portmap")
 	cat > ${CNI_CONF_NAME} <<EOF
 {
+  "cniVersion": "0.3.1",
   "name": "portmap",
   "plugins": [
     {
@@ -114,6 +115,7 @@ EOF
 "aws-cni")
 	cat > ${CNI_CONF_NAME} <<EOF
 {
+  "cniVersion": "0.3.1",
   "name": "aws-cni",
   "plugins": [
     {
@@ -138,6 +140,7 @@ EOF
 *)
 	cat > ${CNI_CONF_NAME} <<EOF
 {
+  "cniVersion": "0.3.1",
   "name": "cilium",
   "type": "cilium-cni"
 }


### PR DESCRIPTION
crio(1.14.2) fails to delete network if cniVersion is
missing in the config file.
Error message:
```
level=error msg="Error deleting network: failed to convert major version
part "": strconv.Atoi: parsing "": invalid syntax"
level=error msg="Error while removing pod from CNI network "cilium":
failed to convert major version part "": strconv.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8184)
<!-- Reviewable:end -->
