### PR TITLE
endpoint: Set the identity cache revision only when successful

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -147,10 +147,6 @@ func (e *Endpoint) regeneratePolicy(owner Owner) (retErr error) {
 		return nil
 	}
 
-	// Update fields within endpoint based off known identities, and whether
-	// policy needs to be enforced for either ingress or egress.
-	e.prevIdentityCacheRevision = prevIdentityCacheRevision
-
 	stats.policyCalculation.Start()
 	if e.selectorPolicy == nil {
 		// Upon initial insertion or restore, there's currently no good
@@ -175,6 +171,10 @@ func (e *Endpoint) regeneratePolicy(owner Owner) (retErr error) {
 	stats.policyCalculation.End(true)
 
 	e.desiredPolicy = calculatedPolicy
+
+	// Set the revision of the identity cache at which the policy computation started
+	// now that we know the policy computation was successful.
+	e.prevIdentityCacheRevision = prevIdentityCacheRevision
 
 	if e.forcePolicyCompute {
 		forceRegeneration = true     // Options were changed by the caller.


### PR DESCRIPTION
Set the identity cache revision at which the policy computation
started only after it is known that the policy computation has been
successful. Otherwise we could skip the next policy computation due to
the identity cache revision already being set even though the last
policy computation failed.

Fixes: #7958
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8189)
<!-- Reviewable:end -->
