### PR TITLE
Add dedicated etcd session for distributed locks

### DIFF
--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -396,11 +396,11 @@ func (a *Allocator) selectAvailableID() (idpool.ID, string, idpool.ID) {
 	return 0, "", 0
 }
 
-func (a *Allocator) createValueNodeKey(ctx context.Context, key string, newID idpool.ID) error {
+func (a *Allocator) createValueNodeKey(ctx context.Context, key string, newID idpool.ID, lock kvstore.KVLocker) error {
 	// add a new key /value/<key>/<node> to account for the reference
 	// The key is protected with a TTL/lease and will expire after LeaseTTL
 	valueKey := path.Join(a.valuePrefix, key, a.suffix)
-	if _, err := kvstore.UpdateIfDifferent(ctx, valueKey, []byte(newID.String()), true); err != nil {
+	if _, err := kvstore.UpdateIfDifferentIfLocked(ctx, valueKey, []byte(newID.String()), true, lock); err != nil {
 		return fmt.Errorf("unable to create value-node key '%s': %s", valueKey, err)
 	}
 
@@ -439,7 +439,7 @@ func (a *Allocator) lockedAllocate(ctx context.Context, key AllocatorKey) (idpoo
 
 	// fetch first key that matches /value/<key> while ignoring the
 	// node suffix
-	value, err := a.Get(ctx, key)
+	value, err := a.GetIfLocked(ctx, key, lock)
 	if err != nil {
 		return 0, false, err
 	}
@@ -457,7 +457,7 @@ func (a *Allocator) lockedAllocate(ctx context.Context, key AllocatorKey) (idpoo
 		if value != 0 {
 			// re-create master key
 			keyPath := path.Join(a.idPrefix, strconv.FormatUint(uint64(value), 10))
-			success, err := kvstore.CreateOnly(ctx, keyPath, []byte(k), false)
+			success, err := kvstore.CreateOnlyIfLocked(ctx, keyPath, []byte(k), false, lock)
 			if err != nil || !success {
 				return 0, false, fmt.Errorf("unable to create master key '%s': %s", keyPath, err)
 			}
@@ -469,7 +469,7 @@ func (a *Allocator) lockedAllocate(ctx context.Context, key AllocatorKey) (idpoo
 		}
 	}
 	if value != 0 {
-		if err = a.createValueNodeKey(ctx, k, value); err != nil {
+		if err = a.createValueNodeKey(ctx, k, value, lock); err != nil {
 			a.localKeys.release(k)
 			return 0, false, fmt.Errorf("unable to create slave key '%s': %s", k, err)
 		}
@@ -506,7 +506,7 @@ func (a *Allocator) lockedAllocate(ctx context.Context, key AllocatorKey) (idpoo
 
 	// create /id/<ID> and fail if it already exists
 	keyPath := path.Join(a.idPrefix, strID)
-	success, err := kvstore.CreateOnly(ctx, keyPath, []byte(k), false)
+	success, err := kvstore.CreateOnlyIfLocked(ctx, keyPath, []byte(k), false, lock)
 	if err != nil || !success {
 		// Creation failed. Another agent most likely beat us to allocating this
 		// ID, retry.
@@ -517,7 +517,7 @@ func (a *Allocator) lockedAllocate(ctx context.Context, key AllocatorKey) (idpoo
 	// Notify pool that leased ID is now in-use.
 	a.idPool.Use(unmaskedID)
 
-	if err = a.createValueNodeKey(ctx, k, id); err != nil {
+	if err = a.createValueNodeKey(ctx, k, id, lock); err != nil {
 		// We will leak the master key here as the key has already been
 		// exposed and may be in use by other nodes. The garbage
 		// collector will release it again.
@@ -598,6 +598,17 @@ func (a *Allocator) Allocate(ctx context.Context, key AllocatorKey) (idpool.ID, 
 	return 0, false, err
 }
 
+// GetIfLocked returns the ID which is allocated to a key. Returns an ID of NoID if no ID
+// has been allocated to this key yet if the client is still holding the given
+// lock.
+func (a *Allocator) GetIfLocked(ctx context.Context, key AllocatorKey, lock kvstore.KVLocker) (idpool.ID, error) {
+	if id := a.mainCache.get(key.GetKey()); id != idpool.NoID {
+		return id, nil
+	}
+
+	return a.GetNoCacheIfLocked(ctx, key, lock)
+}
+
 // Get returns the ID which is allocated to a key. Returns an ID of NoID if no ID
 // has been allocated to this key yet.
 func (a *Allocator) Get(ctx context.Context, key AllocatorKey) (idpool.ID, error) {
@@ -612,6 +623,43 @@ func prefixMatchesKey(prefix, key string) bool {
 	// cilium/state/identities/v1/value/label;foo;bar;/172.0.124.60
 	lastSlash := strings.LastIndex(key, "/")
 	return len(prefix) == lastSlash
+}
+
+// GetNoCacheIfLocked returns the ID which is allocated to a key in the kvstore
+// if the client is still holding the given lock.
+func (a *Allocator) GetNoCacheIfLocked(ctx context.Context, key AllocatorKey, lock kvstore.KVLocker) (idpool.ID, error) {
+	// ListPrefixIfLocked() will return all keys matching the prefix, the prefix
+	// can cover multiple different keys, example:
+	//
+	// key1 := label1;label2;
+	// key2 := label1;label2;label3;
+	//
+	// In order to retrieve the correct key, the position of the last '/'
+	// is signficant, e.g.
+	//
+	// prefix := cilium/state/identities/v1/value/label;foo;
+	//
+	// key1 := cilium/state/identities/v1/value/label;foo;/172.0.124.60
+	// key2 := cilium/state/identities/v1/value/label;foo;bar;/172.0.124.60
+	//
+	// Only key1 should match
+	prefix := path.Join(a.valuePrefix, key.GetKey())
+	pairs, err := kvstore.ListPrefixIfLocked(prefix, lock)
+	kvstore.Trace("ListPrefixLocked", err, logrus.Fields{fieldPrefix: prefix, "entries": len(pairs)})
+	if err != nil {
+		return 0, err
+	}
+
+	for k, v := range pairs {
+		if prefixMatchesKey(prefix, k) {
+			id, err := strconv.ParseUint(string(v.Data), 10, 64)
+			if err == nil {
+				return idpool.ID(id), nil
+			}
+		}
+	}
+
+	return idpool.NoID, nil
 }
 
 // GetNoCache returns the ID which is allocated to a key in the kvstore
@@ -693,6 +741,8 @@ func (a *Allocator) Release(ctx context.Context, key AllocatorKey) (lastUse bool
 		valueKey := path.Join(a.valuePrefix, k, a.suffix)
 		log.WithField(fieldKey, key).Info("Released last local use of key, invoking global release")
 
+		// does not need to be deleted with a lock as its protected by the
+		// a.slaveKeysMutex
 		if err := kvstore.Delete(valueKey); err != nil {
 			log.WithError(err).WithFields(logrus.Fields{fieldKey: key}).Warning("Ignoring node specific ID")
 		}
@@ -731,7 +781,7 @@ func (a *Allocator) RunGC(staleKeysPrevRound map[string]uint64) (map[string]uint
 
 		// fetch list of all /value/<key> keys
 		valueKeyPrefix := path.Join(a.valuePrefix, string(v.Data))
-		pairs, err := kvstore.ListPrefix(valueKeyPrefix)
+		pairs, err := kvstore.ListPrefixIfLocked(valueKeyPrefix, lock)
 		if err != nil {
 			log.WithError(err).WithField(fieldPrefix, valueKeyPrefix).Warning("allocator garbage collector was unable to list keys")
 			lock.Unlock()
@@ -754,7 +804,7 @@ func (a *Allocator) RunGC(staleKeysPrevRound map[string]uint64) (map[string]uint
 			})
 			// Only delete if this key was previously marked as to be deleted
 			if modRev, ok := staleKeysPrevRound[key]; ok && modRev == v.ModRevision {
-				if err := kvstore.Delete(key); err != nil {
+				if err := kvstore.DeleteIfLocked(key, lock); err != nil {
 					scopedLog.WithError(err).Warning("Unable to delete unused allocator master key")
 				} else {
 					scopedLog.Info("Deleted unused allocator master key")

--- a/pkg/kvstore/backend.go
+++ b/pkg/kvstore/backend.go
@@ -139,19 +139,19 @@ type BackendOperations interface {
 	Status() (string, error)
 
 	// LockPath locks the provided path
-	LockPath(ctx context.Context, path string) (kvLocker, error)
+	LockPath(ctx context.Context, path string) (KVLocker, error)
 
 	// Get returns value of key
 	Get(key string) ([]byte, error)
 
 	// GetIfLocked returns value of key if the client is still holding the given lock.
-	GetIfLocked(key string, lock kvLocker) ([]byte, error)
+	GetIfLocked(key string, lock KVLocker) ([]byte, error)
 
 	// GetPrefix returns the first key which matches the prefix and its value
 	GetPrefix(ctx context.Context, prefix string) (string, []byte, error)
 
 	// GetPrefixIfLocked returns the first key which matches the prefix and its value if the client is still holding the given lock.
-	GetPrefixIfLocked(ctx context.Context, prefix string, lock kvLocker) (string, []byte, error)
+	GetPrefixIfLocked(ctx context.Context, prefix string, lock KVLocker) (string, []byte, error)
 
 	// Set sets value of key
 	Set(key string, value []byte) error
@@ -160,7 +160,7 @@ type BackendOperations interface {
 	Delete(key string) error
 
 	// DeleteIfLocked deletes a key if the client is still holding the given lock.
-	DeleteIfLocked(key string, lock kvLocker) error
+	DeleteIfLocked(key string, lock KVLocker) error
 
 	DeletePrefix(path string) error
 
@@ -168,19 +168,19 @@ type BackendOperations interface {
 	Update(ctx context.Context, key string, value []byte, lease bool) error
 
 	// UpdateIfLocked atomically creates a key or fails if it already exists if the client is still holding the given lock.
-	UpdateIfLocked(ctx context.Context, key string, value []byte, lease bool, lock kvLocker) error
+	UpdateIfLocked(ctx context.Context, key string, value []byte, lease bool, lock KVLocker) error
 
 	// UpdateIfDifferent updates a key if the value is different
 	UpdateIfDifferent(ctx context.Context, key string, value []byte, lease bool) (bool, error)
 
 	// UpdateIfDifferentIfLocked updates a key if the value is different and if the client is still holding the given lock.
-	UpdateIfDifferentIfLocked(ctx context.Context, key string, value []byte, lease bool, lock kvLocker) (bool, error)
+	UpdateIfDifferentIfLocked(ctx context.Context, key string, value []byte, lease bool, lock KVLocker) (bool, error)
 
 	// CreateOnly atomically creates a key or fails if it already exists
 	CreateOnly(ctx context.Context, key string, value []byte, lease bool) (bool, error)
 
 	// CreateOnlyIfLocked atomically creates a key if the client is still holding the given lock or fails if it already exists
-	CreateOnlyIfLocked(ctx context.Context, key string, value []byte, lease bool, lock kvLocker) (bool, error)
+	CreateOnlyIfLocked(ctx context.Context, key string, value []byte, lease bool, lock KVLocker) (bool, error)
 
 	// CreateIfExists creates a key with the value only if key condKey exists
 	CreateIfExists(condKey, key string, value []byte, lease bool) error
@@ -189,7 +189,7 @@ type BackendOperations interface {
 	ListPrefix(prefix string) (KeyValuePairs, error)
 
 	// ListPrefixIfLocked returns a list of keys matching the prefix only if the client is still holding the given lock.
-	ListPrefixIfLocked(prefix string, lock kvLocker) (KeyValuePairs, error)
+	ListPrefixIfLocked(prefix string, lock KVLocker) (KeyValuePairs, error)
 
 	// Watch starts watching for changes in a prefix. If list is true, the
 	// current keys matching the prefix will be listed and reported as new

--- a/pkg/kvstore/backend.go
+++ b/pkg/kvstore/backend.go
@@ -144,8 +144,14 @@ type BackendOperations interface {
 	// Get returns value of key
 	Get(key string) ([]byte, error)
 
+	// GetIfLocked returns value of key if the client is still holding the given lock.
+	GetIfLocked(key string, lock kvLocker) ([]byte, error)
+
 	// GetPrefix returns the first key which matches the prefix and its value
 	GetPrefix(ctx context.Context, prefix string) (string, []byte, error)
+
+	// GetPrefixIfLocked returns the first key which matches the prefix and its value if the client is still holding the given lock.
+	GetPrefixIfLocked(ctx context.Context, prefix string, lock kvLocker) (string, []byte, error)
 
 	// Set sets value of key
 	Set(key string, value []byte) error
@@ -153,22 +159,37 @@ type BackendOperations interface {
 	// Delete deletes a key
 	Delete(key string) error
 
+	// DeleteIfLocked deletes a key if the client is still holding the given lock.
+	DeleteIfLocked(key string, lock kvLocker) error
+
 	DeletePrefix(path string) error
 
 	// Update atomically creates a key or fails if it already exists
 	Update(ctx context.Context, key string, value []byte, lease bool) error
 
+	// UpdateIfLocked atomically creates a key or fails if it already exists if the client is still holding the given lock.
+	UpdateIfLocked(ctx context.Context, key string, value []byte, lease bool, lock kvLocker) error
+
 	// UpdateIfDifferent updates a key if the value is different
 	UpdateIfDifferent(ctx context.Context, key string, value []byte, lease bool) (bool, error)
 
+	// UpdateIfDifferentIfLocked updates a key if the value is different and if the client is still holding the given lock.
+	UpdateIfDifferentIfLocked(ctx context.Context, key string, value []byte, lease bool, lock kvLocker) (bool, error)
+
 	// CreateOnly atomically creates a key or fails if it already exists
 	CreateOnly(ctx context.Context, key string, value []byte, lease bool) (bool, error)
+
+	// CreateOnlyIfLocked atomically creates a key if the client is still holding the given lock or fails if it already exists
+	CreateOnlyIfLocked(ctx context.Context, key string, value []byte, lease bool, lock kvLocker) (bool, error)
 
 	// CreateIfExists creates a key with the value only if key condKey exists
 	CreateIfExists(condKey, key string, value []byte, lease bool) error
 
 	// ListPrefix returns a list of keys matching the prefix
 	ListPrefix(prefix string) (KeyValuePairs, error)
+
+	// ListPrefixIfLocked returns a list of keys matching the prefix only if the client is still holding the given lock.
+	ListPrefixIfLocked(prefix string, lock kvLocker) (KeyValuePairs, error)
 
 	// Watch starts watching for changes in a prefix. If list is true, the
 	// current keys matching the prefix will be listed and reported as new

--- a/pkg/kvstore/client.go
+++ b/pkg/kvstore/client.go
@@ -43,7 +43,7 @@ func initClient(module backendModule, opts *ExtraOptions) error {
 
 	go func() {
 		err, isErr := <-errChan
-		if isErr {
+		if isErr && err != nil {
 			log.WithError(err).Fatalf("Unable to connect to kvstore")
 		}
 		deleteLegacyPrefixes()

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -17,6 +17,7 @@ package kvstore
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"net/url"
@@ -49,6 +50,12 @@ const (
 
 	// EtcdRateLimitOption specifies maximum kv operations per second
 	EtcdRateLimitOption = "etcd.qps"
+)
+
+var (
+	// ErrLockLeaseExpired is an error whenever the lease of the lock does not
+	// exist or it was expired.
+	ErrLockLeaseExpired = errors.New("transaction did not succeed: lock lease expired")
 )
 
 func init() {
@@ -787,7 +794,25 @@ func (e *etcdClient) Status() (string, error) {
 
 // GetIfLocked returns value of key if the client is still holding the given lock.
 func (e *etcdClient) GetIfLocked(key string, lock KVLocker) ([]byte, error) {
-	return e.Get(key)
+	duration := spanstat.Start()
+	e.limiter.Wait(ctx.TODO())
+	opGet := client.OpGet(key)
+	cmp := lock.Comparator().(client.Cmp)
+	txnReply, err := e.client.Txn(context.Background()).If(cmp).Then(opGet).Commit()
+	if err == nil && !txnReply.Succeeded {
+		err = ErrLockLeaseExpired
+	}
+	increaseMetric(key, metricRead, "GetLocked", duration.EndError(err).Total(), err)
+	if err != nil {
+		return nil, Hint(err)
+	}
+
+	getR := txnReply.Responses[0].GetResponseRange()
+	// RangeResponse
+	if getR.Count == 0 {
+		return nil, nil
+	}
+	return getR.Kvs[0].Value, nil
 }
 
 // Get returns value of key
@@ -808,7 +833,24 @@ func (e *etcdClient) Get(key string) ([]byte, error) {
 
 // GetPrefixIfLocked returns the first key which matches the prefix and its value if the client is still holding the given lock.
 func (e *etcdClient) GetPrefixIfLocked(ctx context.Context, prefix string, lock KVLocker) (string, []byte, error) {
-	return e.GetPrefix(ctx, prefix)
+	duration := spanstat.Start()
+	e.limiter.Wait(ctx)
+	opGet := client.OpGet(prefix, client.WithPrefix(), client.WithLimit(1))
+	cmp := lock.Comparator().(client.Cmp)
+	txnReply, err := e.client.Txn(ctx).If(cmp).Then(opGet).Commit()
+	if err == nil && !txnReply.Succeeded {
+		err = ErrLockLeaseExpired
+	}
+	increaseMetric(prefix, metricRead, "GetPrefixLocked", duration.EndError(err).Total(), err)
+	if err != nil {
+		return "", nil, Hint(err)
+	}
+	getR := txnReply.Responses[0].GetResponseRange()
+
+	if getR.Count == 0 {
+		return "", nil, nil
+	}
+	return string(getR.Kvs[0].Key), getR.Kvs[0].Value, nil
 }
 
 // GetPrefix returns the first key which matches the prefix and its value
@@ -838,7 +880,15 @@ func (e *etcdClient) Set(key string, value []byte) error {
 
 // DeleteIfLocked deletes a key if the client is still holding the given lock.
 func (e *etcdClient) DeleteIfLocked(key string, lock KVLocker) error {
-	return e.Delete(key)
+	duration := spanstat.Start()
+	opDel := client.OpDelete(key)
+	cmp := lock.Comparator().(client.Cmp)
+	txnReply, err := e.client.Txn(context.Background()).If(cmp).Then(opDel).Commit()
+	if err == nil && !txnReply.Succeeded {
+		err = ErrLockLeaseExpired
+	}
+	increaseMetric(key, metricDelete, "DeleteLocked", duration.EndError(err).Total(), err)
+	return Hint(err)
 }
 
 // Delete deletes a key
@@ -862,7 +912,35 @@ func (e *etcdClient) createOpPut(key string, value []byte, leaseID client.LeaseI
 
 // UpdateIfLocked atomically creates a key or fails if it already exists if the client is still holding the given lock.
 func (e *etcdClient) UpdateIfLocked(ctx context.Context, key string, value []byte, lease bool, lock KVLocker) error {
-	return e.Update(ctx, key, value, lease)
+	select {
+	case <-e.firstSession:
+	case <-ctx.Done():
+		return fmt.Errorf("update cancelled via context: %s", ctx.Err())
+	}
+
+	var (
+		txnReply *client.TxnResponse
+		err      error
+	)
+
+	duration := spanstat.Start()
+	e.limiter.Wait(ctx)
+	if lease {
+		leaseID := e.GetLeaseID()
+		opPut := client.OpPut(key, string(value), client.WithLease(leaseID))
+		cmp := lock.Comparator().(client.Cmp)
+		txnReply, err = e.client.Txn(context.Background()).If(cmp).Then(opPut).Commit()
+		e.checkSession(err, leaseID)
+	} else {
+		opPut := client.OpPut(key, string(value))
+		cmp := lock.Comparator().(client.Cmp)
+		txnReply, err = e.client.Txn(context.Background()).If(cmp).Then(opPut).Commit()
+	}
+	if err == nil && !txnReply.Succeeded {
+		err = ErrLockLeaseExpired
+	}
+	increaseMetric(key, metricSet, "UpdateIfLocked", duration.EndError(err).Total(), err)
+	return Hint(err)
 }
 
 // Update creates or updates a key
@@ -892,7 +970,46 @@ func (e *etcdClient) Update(ctx context.Context, key string, value []byte, lease
 
 // UpdateIfDifferentIfLocked updates a key if the value is different and if the client is still holding the given lock.
 func (e *etcdClient) UpdateIfDifferentIfLocked(ctx context.Context, key string, value []byte, lease bool, lock KVLocker) (bool, error) {
-	return e.UpdateIfDifferent(ctx, key, value, lease)
+	select {
+	case <-e.firstSession:
+	case <-ctx.Done():
+		return false, fmt.Errorf("update cancelled via context: %s", ctx.Err())
+	}
+	duration := spanstat.Start()
+	e.limiter.Wait(ctx)
+	cnds := lock.Comparator().(client.Cmp)
+	txnresp, err := e.client.Txn(ctx).If(cnds).Then(client.OpGet(key)).Commit()
+
+	increaseMetric(key, metricRead, "Get", duration.EndError(err).Total(), err)
+
+	if !txnresp.Succeeded {
+		return false, ErrLockLeaseExpired
+	}
+
+	// On error, attempt update blindly
+	if err != nil {
+		return true, e.UpdateIfLocked(ctx, key, value, lease, lock)
+	}
+
+	getR := txnresp.Responses[0].GetResponseRange()
+	if getR.Count == 0 {
+		return true, e.UpdateIfLocked(ctx, key, value, lease, lock)
+	}
+
+	if lease {
+		e.RWMutex.RLock()
+		leaseID := e.session.Lease()
+		e.RWMutex.RUnlock()
+		if getR.Kvs[0].Lease != int64(leaseID) {
+			return true, e.UpdateIfLocked(ctx, key, value, lease, lock)
+		}
+	}
+	// if value is not equal then update.
+	if !bytes.Equal(getR.Kvs[0].Value, value) {
+		return true, e.UpdateIfLocked(ctx, key, value, lease, lock)
+	}
+
+	return false, nil
 }
 
 // UpdateIfDifferent updates a key if the value is different
@@ -929,7 +1046,56 @@ func (e *etcdClient) UpdateIfDifferent(ctx context.Context, key string, value []
 
 // CreateOnlyIfLocked atomically creates a key if the client is still holding the given lock or fails if it already exists
 func (e *etcdClient) CreateOnlyIfLocked(ctx context.Context, key string, value []byte, lease bool, lock KVLocker) (bool, error) {
-	return e.CreateOnly(ctx, key, value, lease)
+	duration := spanstat.Start()
+	var leaseID client.LeaseID
+	if lease {
+		leaseID = e.GetLeaseID()
+	}
+	req := e.createOpPut(key, value, leaseID)
+	cnds := []client.Cmp{
+		client.Compare(client.Version(key), "=", 0),
+		lock.Comparator().(client.Cmp),
+	}
+
+	// We need to do a get in the else of the txn to detect if the lock is still
+	// valid or not.
+	opGets := []client.Op{
+		client.OpGet(key),
+	}
+
+	e.limiter.Wait(ctx)
+	txnresp, err := e.client.Txn(ctx).If(cnds...).Then(*req).Else(opGets...).Commit()
+	increaseMetric(key, metricSet, "CreateOnlyLocked", duration.EndError(err).Total(), err)
+	if err != nil {
+		e.checkSession(err, leaseID)
+		return false, Hint(err)
+	}
+
+	// The txn can failed for the following reasons:
+	//  - Key version is not zero;
+	//  - Lock does not exist or is expired.
+	// For both of those cases, the key that we are comparing might or not
+	// exist, so we have:
+	//  A - Key does not exist and lock does not exist => ErrLockLeaseExpired
+	//  B - Key does not exist and lock exist => txn should succeed
+	//  C - Key does exist, version is == 0 and lock does not exist => ErrLockLeaseExpired
+	//  D - Key does exist, version is != 0 and lock does not exist => ErrLockLeaseExpired
+	//  E - Key does exist, version is == 0 and lock does exist => txn should succeed
+	//  F - Key does exist, version is != 0 and lock does exist => txn fails but returned is nil!
+
+	if !txnresp.Succeeded {
+		// case F
+		if len(txnresp.Responses[0].GetResponseRange().Kvs) != 0 &&
+			txnresp.Responses[0].GetResponseRange().Kvs[0].Version != 0 {
+			return false, nil
+		}
+
+		// case A, C and D
+		return false, ErrLockLeaseExpired
+	}
+
+	// case B and E
+	return true, nil
 }
 
 // CreateOnly creates a key with the value and will fail if the key already exists
@@ -999,7 +1165,30 @@ func (e *etcdClient) CreateIfExists(condKey, key string, value []byte, lease boo
 
 // ListPrefixIfLocked returns a list of keys matching the prefix only if the client is still holding the given lock.
 func (e *etcdClient) ListPrefixIfLocked(prefix string, lock KVLocker) (KeyValuePairs, error) {
-	return e.ListPrefix(prefix)
+	duration := spanstat.Start()
+	e.limiter.Wait(ctx.TODO())
+	opGet := client.OpGet(prefix, client.WithPrefix())
+	cmp := lock.Comparator().(client.Cmp)
+	txnReply, err := e.client.Txn(context.Background()).If(cmp).Then(opGet).Commit()
+	if err == nil && !txnReply.Succeeded {
+		err = ErrLockLeaseExpired
+	}
+	increaseMetric(prefix, metricRead, "ListPrefixLocked", duration.EndError(err).Total(), err)
+	if err != nil {
+		return nil, Hint(err)
+	}
+	getR := txnReply.Responses[0].GetResponseRange()
+
+	pairs := KeyValuePairs(make(map[string]Value, getR.Count))
+	for i := int64(0); i < getR.Count; i++ {
+		pairs[string(getR.Kvs[i].Key)] = Value{
+			Data:        getR.Kvs[i].Value,
+			ModRevision: uint64(getR.Kvs[i].ModRevision),
+		}
+
+	}
+
+	return pairs, nil
 }
 
 // ListPrefix returns a map of matching keys

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -264,6 +264,10 @@ func (e *etcdMutex) Unlock() error {
 	return e.mutex.Unlock(ctx.TODO())
 }
 
+func (e *etcdMutex) Comparator() interface{} {
+	return e.mutex.IsOwner()
+}
+
 // GetLeaseID returns the current lease ID.
 func (e *etcdClient) GetLeaseID() client.LeaseID {
 	e.RWMutex.RLock()
@@ -546,7 +550,7 @@ func (e *etcdClient) checkMinVersion() error {
 	return nil
 }
 
-func (e *etcdClient) LockPath(ctx context.Context, path string) (kvLocker, error) {
+func (e *etcdClient) LockPath(ctx context.Context, path string) (KVLocker, error) {
 	select {
 	case <-e.firstSession:
 	case <-ctx.Done():
@@ -782,7 +786,7 @@ func (e *etcdClient) Status() (string, error) {
 }
 
 // GetIfLocked returns value of key if the client is still holding the given lock.
-func (e *etcdClient) GetIfLocked(key string, lock kvLocker) ([]byte, error) {
+func (e *etcdClient) GetIfLocked(key string, lock KVLocker) ([]byte, error) {
 	return e.Get(key)
 }
 
@@ -803,7 +807,7 @@ func (e *etcdClient) Get(key string) ([]byte, error) {
 }
 
 // GetPrefixIfLocked returns the first key which matches the prefix and its value if the client is still holding the given lock.
-func (e *etcdClient) GetPrefixIfLocked(ctx context.Context, prefix string, lock kvLocker) (string, []byte, error) {
+func (e *etcdClient) GetPrefixIfLocked(ctx context.Context, prefix string, lock KVLocker) (string, []byte, error) {
 	return e.GetPrefix(ctx, prefix)
 }
 
@@ -833,7 +837,7 @@ func (e *etcdClient) Set(key string, value []byte) error {
 }
 
 // DeleteIfLocked deletes a key if the client is still holding the given lock.
-func (e *etcdClient) DeleteIfLocked(key string, lock kvLocker) error {
+func (e *etcdClient) DeleteIfLocked(key string, lock KVLocker) error {
 	return e.Delete(key)
 }
 
@@ -857,7 +861,7 @@ func (e *etcdClient) createOpPut(key string, value []byte, leaseID client.LeaseI
 }
 
 // UpdateIfLocked atomically creates a key or fails if it already exists if the client is still holding the given lock.
-func (e *etcdClient) UpdateIfLocked(ctx context.Context, key string, value []byte, lease bool, lock kvLocker) error {
+func (e *etcdClient) UpdateIfLocked(ctx context.Context, key string, value []byte, lease bool, lock KVLocker) error {
 	return e.Update(ctx, key, value, lease)
 }
 
@@ -887,7 +891,7 @@ func (e *etcdClient) Update(ctx context.Context, key string, value []byte, lease
 }
 
 // UpdateIfDifferentIfLocked updates a key if the value is different and if the client is still holding the given lock.
-func (e *etcdClient) UpdateIfDifferentIfLocked(ctx context.Context, key string, value []byte, lease bool, lock kvLocker) (bool, error) {
+func (e *etcdClient) UpdateIfDifferentIfLocked(ctx context.Context, key string, value []byte, lease bool, lock KVLocker) (bool, error) {
 	return e.UpdateIfDifferent(ctx, key, value, lease)
 }
 
@@ -924,7 +928,7 @@ func (e *etcdClient) UpdateIfDifferent(ctx context.Context, key string, value []
 }
 
 // CreateOnlyIfLocked atomically creates a key if the client is still holding the given lock or fails if it already exists
-func (e *etcdClient) CreateOnlyIfLocked(ctx context.Context, key string, value []byte, lease bool, lock kvLocker) (bool, error) {
+func (e *etcdClient) CreateOnlyIfLocked(ctx context.Context, key string, value []byte, lease bool, lock KVLocker) (bool, error) {
 	return e.CreateOnly(ctx, key, value, lease)
 }
 
@@ -994,7 +998,7 @@ func (e *etcdClient) CreateIfExists(condKey, key string, value []byte, lease boo
 //}
 
 // ListPrefixIfLocked returns a list of keys matching the prefix only if the client is still holding the given lock.
-func (e *etcdClient) ListPrefixIfLocked(prefix string, lock kvLocker) (KeyValuePairs, error) {
+func (e *etcdClient) ListPrefixIfLocked(prefix string, lock KVLocker) (KeyValuePairs, error) {
 	return e.ListPrefix(prefix)
 }
 

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -781,6 +781,11 @@ func (e *etcdClient) Status() (string, error) {
 	return e.latestStatusSnapshot, Hint(e.latestErrorStatus)
 }
 
+// GetIfLocked returns value of key if the client is still holding the given lock.
+func (e *etcdClient) GetIfLocked(key string, lock kvLocker) ([]byte, error) {
+	return e.Get(key)
+}
+
 // Get returns value of key
 func (e *etcdClient) Get(key string) ([]byte, error) {
 	duration := spanstat.Start()
@@ -795,6 +800,11 @@ func (e *etcdClient) Get(key string) ([]byte, error) {
 		return nil, nil
 	}
 	return getR.Kvs[0].Value, nil
+}
+
+// GetPrefixIfLocked returns the first key which matches the prefix and its value if the client is still holding the given lock.
+func (e *etcdClient) GetPrefixIfLocked(ctx context.Context, prefix string, lock kvLocker) (string, []byte, error) {
+	return e.GetPrefix(ctx, prefix)
 }
 
 // GetPrefix returns the first key which matches the prefix and its value
@@ -822,6 +832,11 @@ func (e *etcdClient) Set(key string, value []byte) error {
 	return Hint(err)
 }
 
+// DeleteIfLocked deletes a key if the client is still holding the given lock.
+func (e *etcdClient) DeleteIfLocked(key string, lock kvLocker) error {
+	return e.Delete(key)
+}
+
 // Delete deletes a key
 func (e *etcdClient) Delete(key string) error {
 	duration := spanstat.Start()
@@ -839,6 +854,11 @@ func (e *etcdClient) createOpPut(key string, value []byte, leaseID client.LeaseI
 
 	op := client.OpPut(key, string(value))
 	return &op
+}
+
+// UpdateIfLocked atomically creates a key or fails if it already exists if the client is still holding the given lock.
+func (e *etcdClient) UpdateIfLocked(ctx context.Context, key string, value []byte, lease bool, lock kvLocker) error {
+	return e.Update(ctx, key, value, lease)
 }
 
 // Update creates or updates a key
@@ -866,6 +886,12 @@ func (e *etcdClient) Update(ctx context.Context, key string, value []byte, lease
 	return Hint(err)
 }
 
+// UpdateIfDifferentIfLocked updates a key if the value is different and if the client is still holding the given lock.
+func (e *etcdClient) UpdateIfDifferentIfLocked(ctx context.Context, key string, value []byte, lease bool, lock kvLocker) (bool, error) {
+	return e.UpdateIfDifferent(ctx, key, value, lease)
+}
+
+// UpdateIfDifferent updates a key if the value is different
 func (e *etcdClient) UpdateIfDifferent(ctx context.Context, key string, value []byte, lease bool) (bool, error) {
 	select {
 	case <-e.firstSession:
@@ -895,6 +921,11 @@ func (e *etcdClient) UpdateIfDifferent(ctx context.Context, key string, value []
 	}
 
 	return false, nil
+}
+
+// CreateOnlyIfLocked atomically creates a key if the client is still holding the given lock or fails if it already exists
+func (e *etcdClient) CreateOnlyIfLocked(ctx context.Context, key string, value []byte, lease bool, lock kvLocker) (bool, error) {
+	return e.CreateOnly(ctx, key, value, lease)
 }
 
 // CreateOnly creates a key with the value and will fail if the key already exists
@@ -961,6 +992,11 @@ func (e *etcdClient) CreateIfExists(condKey, key string, value []byte, lease boo
 //
 //	return nil
 //}
+
+// ListPrefixIfLocked returns a list of keys matching the prefix only if the client is still holding the given lock.
+func (e *etcdClient) ListPrefixIfLocked(prefix string, lock kvLocker) (KeyValuePairs, error) {
+	return e.ListPrefix(prefix)
+}
 
 // ListPrefix returns a map of matching keys
 func (e *etcdClient) ListPrefix(prefix string) (KeyValuePairs, error) {

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -229,9 +229,10 @@ type etcdClient struct {
 	config     *client.Config
 	configPath string
 
-	// protects session from concurrent access
+	// protects sessions from concurrent access
 	lock.RWMutex
-	session *concurrency.Session
+	session     *concurrency.Session
+	lockSession *concurrency.Session
 
 	// statusLock protects latestStatusSnapshot and latestErrorStatus for
 	// read/write access
@@ -275,10 +276,18 @@ func (e *etcdMutex) Comparator() interface{} {
 	return e.mutex.IsOwner()
 }
 
-// GetLeaseID returns the current lease ID.
-func (e *etcdClient) GetLeaseID() client.LeaseID {
+// GetSessionLeaseID returns the current lease ID.
+func (e *etcdClient) GetSessionLeaseID() client.LeaseID {
 	e.RWMutex.RLock()
 	l := e.session.Lease()
+	e.RWMutex.RUnlock()
+	return l
+}
+
+// GetLockSessionLeaseID returns the current lease ID for the lock session.
+func (e *etcdClient) GetLockSessionLeaseID() client.LeaseID {
+	e.RWMutex.RLock()
+	l := e.lockSession.Lease()
 	e.RWMutex.RUnlock()
 	return l
 }
@@ -294,6 +303,17 @@ func (e *etcdClient) checkSession(err error, leaseID client.LeaseID) {
 	}
 }
 
+// checkSession verifies if the lease is still valid from the return error of
+// an etcd API call. If the error explicitly states that a lease was not found
+// we mark the session has an orphan for this etcd client. If we would not mark
+// it as an Orphan() the session would be considered expired after the leaseTTL
+// By make it orphan we guarantee the session will be marked to be renewed.
+func (e *etcdClient) checkLockSession(err error, leaseID client.LeaseID) {
+	if err == v3rpcErrors.ErrLeaseNotFound {
+		e.closeLockSession(leaseID)
+	}
+}
+
 // closeSession closes the current session.
 func (e *etcdClient) closeSession(leaseID client.LeaseID) {
 	e.RWMutex.RLock()
@@ -301,6 +321,17 @@ func (e *etcdClient) closeSession(leaseID client.LeaseID) {
 	// session ID to avoid making any other sessions as orphan.
 	if e.session.Lease() == leaseID {
 		e.session.Orphan()
+	}
+	e.RWMutex.RUnlock()
+}
+
+// closeSession closes the current session.
+func (e *etcdClient) closeLockSession(leaseID client.LeaseID) {
+	e.RWMutex.RLock()
+	// only mark a session as orphan if the leaseID is the same as the
+	// session ID to avoid making any other sessions as orphan.
+	if e.lockSession.Lease() == leaseID {
+		e.lockSession.Orphan()
 	}
 	e.RWMutex.RUnlock()
 }
@@ -414,6 +445,29 @@ func (e *etcdClient) renewSession() error {
 	return nil
 }
 
+func (e *etcdClient) renewLockSession() error {
+	<-e.firstSession
+	<-e.lockSession.Done()
+	// This is an attempt to avoid concurrent access of a session that was
+	// already expired. It's not perfect as there is still a period between the
+	// e.lockSession.Done() is closed and the e.Lock() is held where parallel go
+	// routines can get a lease ID of an already expired lease.
+	e.Lock()
+
+	newSession, err := concurrency.NewSession(e.client, concurrency.WithTTL(int(LockLeaseTTL.Seconds())))
+	if err != nil {
+		e.UnlockIgnoreTime()
+		return fmt.Errorf("unable to renew etcd lock session: %s", err)
+	}
+
+	e.lockSession = newSession
+	e.UnlockIgnoreTime()
+
+	e.getLogger().WithField(fieldSession, newSession).Debug("Renewing etcd lock session")
+
+	return nil
+}
+
 func connectEtcdClient(config *client.Config, cfgPath string, errChan chan error, rateLimit int, opts *ExtraOptions) (BackendOperations, error) {
 	if cfgPath != "" {
 		cfg, err := clientyaml.NewConfig(cfgPath)
@@ -438,17 +492,26 @@ func connectEtcdClient(config *client.Config, cfgPath string, errChan chan error
 		"config":    cfgPath,
 	}).Info("Connecting to etcd server...")
 
-	var s concurrency.Session
+	var s, ls concurrency.Session
 	firstSession := make(chan struct{})
-	sessionChan := make(chan *concurrency.Session)
 	errorChan := make(chan error)
 
 	// create session in parallel as this is a blocking operation
 	go func() {
 		session, err := concurrency.NewSession(c, concurrency.WithTTL(int(LeaseTTL.Seconds())))
-		errorChan <- err
-		sessionChan <- session
-		close(sessionChan)
+		if err != nil {
+			errorChan <- err
+			close(errorChan)
+			return
+		}
+		lockSession, err := concurrency.NewSession(c, concurrency.WithTTL(int(LockLeaseTTL.Seconds())))
+		if err != nil {
+			errorChan <- err
+			close(errorChan)
+			return
+		}
+		s = *session
+		ls = *lockSession
 		close(errorChan)
 	}()
 
@@ -457,6 +520,7 @@ func connectEtcdClient(config *client.Config, cfgPath string, errChan chan error
 		config:               config,
 		configPath:           cfgPath,
 		session:              &s,
+		lockSession:          &ls,
 		firstSession:         firstSession,
 		controllers:          controller.NewManager(),
 		latestStatusSnapshot: "No connection to etcd",
@@ -469,27 +533,18 @@ func connectEtcdClient(config *client.Config, cfgPath string, errChan chan error
 	go func() {
 		defer close(errChan)
 
-		var session concurrency.Session
 		select {
 		case err = <-errorChan:
-			if err == nil {
-				session = *<-sessionChan
+			if err != nil {
+				errChan <- err
+				return
 			}
 		case <-time.After(initialConnectionTimeout):
-			err = fmt.Errorf("timed out while waiting for etcd session. Ensure that etcd is running on %s", config.Endpoints)
-		}
-		if err != nil {
-			errChan <- err
+			errChan <- fmt.Errorf("timed out while waiting for etcd session. Ensure that etcd is running on %s", config.Endpoints)
 			return
 		}
 
 		ec.getLogger().Debugf("Session received")
-		s = session
-		if err != nil {
-			c.Close()
-			errChan <- fmt.Errorf("unable to create default lease: %s", err)
-			return
-		}
 		close(ec.firstSession)
 
 		if err := ec.checkMinVersion(); err != nil {
@@ -503,6 +558,15 @@ func connectEtcdClient(config *client.Config, cfgPath string, errChan chan error
 		controller.ControllerParams{
 			DoFunc: func(ctx context.Context) error {
 				return ec.renewSession()
+			},
+			RunInterval: time.Duration(10) * time.Millisecond,
+		},
+	)
+
+	ec.controllers.UpdateController("kvstore-etcd-lock-session-renew",
+		controller.ControllerParams{
+			DoFunc: func(ctx context.Context) error {
+				return ec.renewLockSession()
 			},
 			RunInterval: time.Duration(10) * time.Millisecond,
 		},
@@ -565,13 +629,15 @@ func (e *etcdClient) LockPath(ctx context.Context, path string) (KVLocker, error
 	}
 
 	e.RLock()
-	mu := concurrency.NewMutex(e.session, path)
+	mu := concurrency.NewMutex(e.lockSession, path)
+	leaseID := e.lockSession.Lease()
 	e.RUnlock()
 
 	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 	err := mu.Lock(ctx)
 	if err != nil {
+		e.checkLockSession(err, leaseID)
 		return nil, Hint(err)
 	}
 
@@ -926,7 +992,7 @@ func (e *etcdClient) UpdateIfLocked(ctx context.Context, key string, value []byt
 	duration := spanstat.Start()
 	e.limiter.Wait(ctx)
 	if lease {
-		leaseID := e.GetLeaseID()
+		leaseID := e.GetSessionLeaseID()
 		opPut := client.OpPut(key, string(value), client.WithLease(leaseID))
 		cmp := lock.Comparator().(client.Cmp)
 		txnReply, err = e.client.Txn(context.Background()).If(cmp).Then(opPut).Commit()
@@ -953,7 +1019,7 @@ func (e *etcdClient) Update(ctx context.Context, key string, value []byte, lease
 
 	if lease {
 		duration := spanstat.Start()
-		leaseID := e.GetLeaseID()
+		leaseID := e.GetSessionLeaseID()
 		e.limiter.Wait(ctx)
 		_, err := e.client.Put(ctx, key, string(value), client.WithLease(leaseID))
 		e.checkSession(err, leaseID)
@@ -1049,7 +1115,7 @@ func (e *etcdClient) CreateOnlyIfLocked(ctx context.Context, key string, value [
 	duration := spanstat.Start()
 	var leaseID client.LeaseID
 	if lease {
-		leaseID = e.GetLeaseID()
+		leaseID = e.GetSessionLeaseID()
 	}
 	req := e.createOpPut(key, value, leaseID)
 	cnds := []client.Cmp{
@@ -1103,7 +1169,7 @@ func (e *etcdClient) CreateOnly(ctx context.Context, key string, value []byte, l
 	duration := spanstat.Start()
 	var leaseID client.LeaseID
 	if lease {
-		leaseID = e.GetLeaseID()
+		leaseID = e.GetSessionLeaseID()
 	}
 	req := e.createOpPut(key, value, leaseID)
 	cond := client.Compare(client.Version(key), "=", 0)
@@ -1124,7 +1190,7 @@ func (e *etcdClient) CreateIfExists(condKey, key string, value []byte, lease boo
 	duration := spanstat.Start()
 	var leaseID client.LeaseID
 	if lease {
-		leaseID = e.GetLeaseID()
+		leaseID = e.GetSessionLeaseID()
 	}
 	req := e.createOpPut(key, value, leaseID)
 	cond := client.Compare(client.Version(condKey), "!=", 0)
@@ -1223,6 +1289,7 @@ func (e *etcdClient) Close() {
 	}
 	e.RLock()
 	defer e.RUnlock()
+	e.lockSession.Close()
 	e.session.Close()
 	e.client.Close()
 }

--- a/pkg/kvstore/keepalive.go
+++ b/pkg/kvstore/keepalive.go
@@ -19,8 +19,11 @@ import (
 )
 
 var (
-	// LeaseTTL is the time-to-live ofthe lease
+	// LeaseTTL is the time-to-live of the lease
 	LeaseTTL = 15 * time.Minute // 15 minutes
+
+	// LockLeaseTTL is the time-to-live of the lease dedicated for locks
+	LockLeaseTTL = 25 * time.Second
 
 	// KeepAliveInterval is the interval in which the lease is being
 	// renewed. This must be set to a value lesser than the LeaseTTL

--- a/pkg/kvstore/kvstore.go
+++ b/pkg/kvstore/kvstore.go
@@ -54,10 +54,24 @@ func Get(key string) ([]byte, error) {
 	return v, err
 }
 
+// GetIfLocked returns value of key if the client is still holding the given lock.
+func GetIfLocked(key string, lock kvLocker) ([]byte, error) {
+	v, err := Client().GetIfLocked(key, lock)
+	Trace("GetIfLocked", err, logrus.Fields{fieldKey: key, fieldValue: string(v)})
+	return v, err
+}
+
 // GetPrefix returns the first key which matches the prefix and its value.
 func GetPrefix(ctx context.Context, prefix string) (k string, v []byte, err error) {
 	k, v, err = Client().GetPrefix(ctx, prefix)
 	Trace("GetPrefix", err, logrus.Fields{fieldPrefix: prefix, fieldKey: k, fieldValue: string(v)})
+	return
+}
+
+// GetPrefixIfLocked returns the first key which matches the prefix and its value if the client is still holding the given lock.
+func GetPrefixIfLocked(ctx context.Context, prefix string, lock kvLocker) (k string, v []byte, err error) {
+	k, v, err = Client().GetPrefixIfLocked(ctx, prefix, lock)
+	Trace("GetPrefixIfLocked", err, logrus.Fields{fieldPrefix: prefix, fieldKey: k, fieldValue: string(v)})
 	return
 }
 
@@ -68,10 +82,28 @@ func ListPrefix(prefix string) (KeyValuePairs, error) {
 	return v, err
 }
 
+// ListPrefixIfLocked  returns a list of keys matching the prefix only if the client is still holding the given lock.
+func ListPrefixIfLocked(prefix string, lock kvLocker) (KeyValuePairs, error) {
+	v, err := Client().ListPrefixIfLocked(prefix, lock)
+	Trace("ListPrefixIfLocked", err, logrus.Fields{fieldPrefix: prefix, fieldNumEntries: len(v)})
+	return v, err
+}
+
 // CreateOnly atomically creates a key or fails if it already exists
 func CreateOnly(ctx context.Context, key string, value []byte, lease bool) (bool, error) {
 	success, err := Client().CreateOnly(ctx, key, value, lease)
 	Trace("CreateOnly", err, logrus.Fields{
+		fieldKey: key, fieldValue: string(value),
+		fieldAttachLease: lease,
+		"success":        success,
+	})
+	return success, err
+}
+
+// CreateOnlyIfLocked atomically creates a key if the client is still holding the given lock or fails if it already exists
+func CreateOnlyIfLocked(ctx context.Context, key string, value []byte, lease bool, lock kvLocker) (bool, error) {
+	success, err := Client().CreateOnlyIfLocked(ctx, key, value, lease, lock)
+	Trace("CreateOnlyIfLocked", err, logrus.Fields{
 		fieldKey: key, fieldValue: string(value),
 		fieldAttachLease: lease,
 		"success":        success,
@@ -89,7 +121,19 @@ func Update(ctx context.Context, key string, value []byte, lease bool) error {
 // UpdateIfDifferent updates a key if the value is different
 func UpdateIfDifferent(ctx context.Context, key string, value []byte, lease bool) (bool, error) {
 	recreated, err := Client().UpdateIfDifferent(ctx, key, value, lease)
-	Trace("Update", err, logrus.Fields{
+	Trace("UpdateIfDifferent", err, logrus.Fields{
+		fieldKey:         key,
+		fieldValue:       string(value),
+		fieldAttachLease: lease,
+		"recreated":      recreated,
+	})
+	return recreated, err
+}
+
+// UpdateIfDifferentIfLocked updates a key if the value is different and if the client is still holding the given lock.
+func UpdateIfDifferentIfLocked(ctx context.Context, key string, value []byte, lease bool, lock kvLocker) (bool, error) {
+	recreated, err := Client().UpdateIfDifferentIfLocked(ctx, key, value, lease, lock)
+	Trace("UpdateIfDifferentIfLocked", err, logrus.Fields{
 		fieldKey:         key,
 		fieldValue:       string(value),
 		fieldAttachLease: lease,
@@ -116,6 +160,13 @@ func Set(key string, value []byte) error {
 func Delete(key string) error {
 	err := Client().Delete(key)
 	Trace("Delete", err, logrus.Fields{fieldKey: key})
+	return err
+}
+
+// DeleteIfLocked deletes a key if the client is still holding the given lock.
+func DeleteIfLocked(key string, lock kvLocker) error {
+	err := Client().DeleteIfLocked(key, lock)
+	Trace("DeleteIfLocked", err, logrus.Fields{fieldKey: key})
 	return err
 }
 

--- a/pkg/kvstore/kvstore.go
+++ b/pkg/kvstore/kvstore.go
@@ -55,7 +55,7 @@ func Get(key string) ([]byte, error) {
 }
 
 // GetIfLocked returns value of key if the client is still holding the given lock.
-func GetIfLocked(key string, lock kvLocker) ([]byte, error) {
+func GetIfLocked(key string, lock KVLocker) ([]byte, error) {
 	v, err := Client().GetIfLocked(key, lock)
 	Trace("GetIfLocked", err, logrus.Fields{fieldKey: key, fieldValue: string(v)})
 	return v, err
@@ -69,7 +69,7 @@ func GetPrefix(ctx context.Context, prefix string) (k string, v []byte, err erro
 }
 
 // GetPrefixIfLocked returns the first key which matches the prefix and its value if the client is still holding the given lock.
-func GetPrefixIfLocked(ctx context.Context, prefix string, lock kvLocker) (k string, v []byte, err error) {
+func GetPrefixIfLocked(ctx context.Context, prefix string, lock KVLocker) (k string, v []byte, err error) {
 	k, v, err = Client().GetPrefixIfLocked(ctx, prefix, lock)
 	Trace("GetPrefixIfLocked", err, logrus.Fields{fieldPrefix: prefix, fieldKey: k, fieldValue: string(v)})
 	return
@@ -83,7 +83,7 @@ func ListPrefix(prefix string) (KeyValuePairs, error) {
 }
 
 // ListPrefixIfLocked  returns a list of keys matching the prefix only if the client is still holding the given lock.
-func ListPrefixIfLocked(prefix string, lock kvLocker) (KeyValuePairs, error) {
+func ListPrefixIfLocked(prefix string, lock KVLocker) (KeyValuePairs, error) {
 	v, err := Client().ListPrefixIfLocked(prefix, lock)
 	Trace("ListPrefixIfLocked", err, logrus.Fields{fieldPrefix: prefix, fieldNumEntries: len(v)})
 	return v, err
@@ -101,7 +101,7 @@ func CreateOnly(ctx context.Context, key string, value []byte, lease bool) (bool
 }
 
 // CreateOnlyIfLocked atomically creates a key if the client is still holding the given lock or fails if it already exists
-func CreateOnlyIfLocked(ctx context.Context, key string, value []byte, lease bool, lock kvLocker) (bool, error) {
+func CreateOnlyIfLocked(ctx context.Context, key string, value []byte, lease bool, lock KVLocker) (bool, error) {
 	success, err := Client().CreateOnlyIfLocked(ctx, key, value, lease, lock)
 	Trace("CreateOnlyIfLocked", err, logrus.Fields{
 		fieldKey: key, fieldValue: string(value),
@@ -131,7 +131,7 @@ func UpdateIfDifferent(ctx context.Context, key string, value []byte, lease bool
 }
 
 // UpdateIfDifferentIfLocked updates a key if the value is different and if the client is still holding the given lock.
-func UpdateIfDifferentIfLocked(ctx context.Context, key string, value []byte, lease bool, lock kvLocker) (bool, error) {
+func UpdateIfDifferentIfLocked(ctx context.Context, key string, value []byte, lease bool, lock KVLocker) (bool, error) {
 	recreated, err := Client().UpdateIfDifferentIfLocked(ctx, key, value, lease, lock)
 	Trace("UpdateIfDifferentIfLocked", err, logrus.Fields{
 		fieldKey:         key,
@@ -164,7 +164,7 @@ func Delete(key string) error {
 }
 
 // DeleteIfLocked deletes a key if the client is still holding the given lock.
-func DeleteIfLocked(key string, lock kvLocker) error {
+func DeleteIfLocked(key string, lock KVLocker) error {
 	err := Client().DeleteIfLocked(key, lock)
 	Trace("DeleteIfLocked", err, logrus.Fields{fieldKey: key})
 	return err

--- a/pkg/kvstore/lock.go
+++ b/pkg/kvstore/lock.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -41,8 +41,12 @@ var (
 	staleLockTimeout = time.Duration(30) * time.Second
 )
 
-type kvLocker interface {
+type KVLocker interface {
 	Unlock() error
+	// Comparator returns an object that should be used by the KVStore to make
+	// sure if the lock is still valid for its client or nil if no such
+	// verification exists.
+	Comparator() interface{}
 }
 
 // getLockPath returns the lock path representation of the given path.
@@ -126,7 +130,7 @@ func (pl *pathLocks) unlock(path string, id uuid.UUID) {
 type Lock struct {
 	path   string
 	id     uuid.UUID
-	kvLock kvLocker
+	kvLock KVLocker
 }
 
 // LockPath locks the specified path. The key for the lock is not the path
@@ -169,4 +173,8 @@ func (l *Lock) Unlock() error {
 	Trace("Unlocked", nil, logrus.Fields{fieldKey: l.path})
 
 	return err
+}
+
+func (l *Lock) Comparator() interface{} {
+	return l.kvLock.Comparator()
 }


### PR DESCRIPTION
If a cilium agent was restarted while holding a distributed TTL in the KVStore it would make that lock from only being released after the default TTL of the Cilium agent expired, 15 minutes. This PR introduces a new session dedicated for locks which will have a TTL of 25 seconds making the lock to be released after 25 seconds if the cilium agent is restarted.

Fixes: #7966 Fixes: #7683 Fixes https://github.com/cilium/cilium/issues/7598

~Note to reviewers, the first commit is from #8194 so hold merge until #8194 is merged first.~

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8195)
<!-- Reviewable:end -->
