### PR TITLE
test: provide context which will be canceled to `CiliumExecContext`

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1215,7 +1215,9 @@ func (kub *Kubectl) CiliumExecContext(ctx context.Context, pod string, cmd strin
 // CiliumExec runs cmd in the specified Cilium pod.
 // Deprecated: use CiliumExecContext instead
 func (kub *Kubectl) CiliumExec(pod string, cmd string) *CmdRes {
-	return kub.CiliumExecContext(context.Background(), pod, cmd)
+	ctx, cancel := context.WithTimeout(context.Background(), HelperTimeout)
+	defer cancel()
+	return kub.CiliumExecContext(ctx, pod, cmd)
 }
 
 // CiliumExecUntilMatch executes the specified command repeatedly for the


### PR DESCRIPTION
Providing just `context.Background()` means that the context provided to `CiliumExecContext` is never canceled. Provide a context that uses the existing 4 minute timeout, and cancel the context after the call to `CiliumExecContext` is finished so that goroutines don't leak.

Signed-off by: Ian Vernon <ian@cilium.io>

I'm not 100 % sure whether this is cleanly backportable onto v1.4 or v1.5, but don't want to forget to backport.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8197)
<!-- Reviewable:end -->
