### PR TITLE
test/packet: add instructions to run CI on packet.net

### DIFF
--- a/test/packet/.gitignore
+++ b/test/packet/.gitignore
@@ -1,0 +1,3 @@
+.terraform.*
+.terraform/
+terraform.tfstate

--- a/test/packet/README.md
+++ b/test/packet/README.md
@@ -1,0 +1,28 @@
+# Instructions to run CI tests in your own packet-net instances
+
+# 1 - download terraform https://www.terraform.io/downloads.html
+# 2 - get your API key by clicking in your user profile (top right corner)
+#     and pick "API Keys" https://app.packet.net/login
+# 3 - Create an API Key with read/write permissions and give a description,
+#     something like "CI private testing"
+# 4 - store the private token as you will need it in the next steps
+# 5 - go to the packet.net and pick or create a project ID
+# 6 - terraform init .
+# 7 - terraform apply
+# 8 - After the VM is up and running you can check its IP with `terraform show`
+# 9 - SSH in to the public IP with `ssh -i <ssh-key-path> root@<publicIP>`
+# 10 - Checkout to the branch that you want to test `git checkout <my-faulty-branch>`
+# 11 - Run `screen` which will create a new terminal, this is helpful as you can leave your terminal while
+#      tests are running and come back again afterwards.
+# 12 - Enter the `test` directory with `cd test`
+# 13 - Run the ginkgo command to initialize the tests, for example:
+#     `K8S_VERSION=1.14 ginkgo --focus="K8s*" -v -- --cilium.showCommands --cilium.holdEnvironment=true`
+# 14 - Once tests are running and if you are running `screen`, you can leave the terminal
+#      by typing `CTRL+a+d`, to resume again type `screen -r`
+#
+export TF_VAR_private_key_path="<SSH KEY PATH>"
+export TF_VAR_packet_token="<TOKEN>"
+export TF_VAR_packet_project_id="<PROJECT ID>"
+# the location for europeans is better to pick Amsterdam (ams1) or Toronto (yyz1)
+export TF_VAR_packet_location="ams1"
+export TF_VAR_packet_plan="c1.small.x86"

--- a/test/packet/main.tf
+++ b/test/packet/main.tf
@@ -1,0 +1,55 @@
+variable "private_key_path" {
+}
+
+variable "packet_token" {
+}
+
+variable "packet_project_id" {
+}
+
+variable "packet_plan" {
+    default="baremetal_0"
+}
+
+variable "packet_location" {
+    default="sjc1"
+}
+
+variable "nodes" {
+    default =  1
+}
+
+provider "packet" {
+  auth_token = "${var.packet_token}"
+}
+
+# Create a device and add it to tf_project_1
+resource "packet_device" "test" {
+    count            = "${var.nodes}"
+    hostname         = "test-${count.index}"
+    plan             = "${var.packet_plan}"
+    facility         = "${var.packet_location}"
+    operating_system = "ubuntu_18_04"
+    billing_cycle    = "hourly"
+    project_id       = "${var.packet_project_id}"
+
+	connection {
+      type = "ssh"
+      user = "root"
+      private_key = "${file("${var.private_key_path}")}"
+      agent = false
+	}
+
+    provisioner "file" {
+            source="scripts"
+            destination="/provision"
+    }
+
+	provisioner "remote-exec" {
+		inline = [
+            "sudo chmod 755 /provision/*.sh",
+			"sudo /provision/install.sh",
+            "go get -u github.com/cilium/cilium || true"
+		]
+	}
+}

--- a/test/packet/scripts/install.sh
+++ b/test/packet/scripts/install.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+set -e
+
+GOLANG_VERSION="1.12.5"
+VAGRANT_VERSION="2.2.4"
+PACKER_VERSION="1.3.5"
+VIRTUALBOX_VERSION="6.0"
+
+#repositories
+
+echo "deb http://download.virtualbox.org/virtualbox/debian bionic contrib" > /etc/apt/sources.list.d/virtualbox.list
+
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+sudo apt-key fingerprint 0EBFCD88
+wget -q http://download.virtualbox.org/virtualbox/debian/oracle_vbox_2016.asc -O- | sudo apt-key add -
+wget -q http://download.virtualbox.org/virtualbox/debian/oracle_vbox.asc -O- | sudo apt-key add -
+sudo add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+   $(lsb_release -cs) \
+   stable"
+
+sudo apt-get update
+sudo apt-get install -y \
+    curl jq apt-transport-https htop bmon zip \
+    linux-tools-common linux-tools-generic \
+    ca-certificates software-properties-common \
+    git openjdk-8-jdk gcc make perl unzip awscli \
+    linux-headers-`uname -r` \
+    virtualbox-${VIRTUALBOX_VERSION} docker-ce
+
+cd /tmp/
+wget https://releases.hashicorp.com/vagrant/${VAGRANT_VERSION}/vagrant_${VAGRANT_VERSION}_x86_64.deb
+dpkg -i vagrant_*.deb
+
+wget https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip
+unzip packer_${PACKER_VERSION}_linux_amd64.zip
+mv packer /usr/local/bin/
+
+# Kernel parameters
+export CPU=$(($(nproc)-1))
+for i in $(seq 0 $CPU);
+do
+   echo performance > /sys/devices/system/cpu/cpu$i/cpufreq/scaling_governor
+done
+
+#Install Golang
+cd /tmp/
+sudo curl -Sslk -o go.tar.gz "https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-amd64.tar.gz"
+sudo tar -C /usr/local -xzf go.tar.gz
+sudo rm go.tar.gz
+sudo ln -s /usr/local/go/bin/* /usr/local/bin/
+go version
+sudo mkdir /go/
+export GOPATH=/go/
+go get -u github.com/cilium/go-bindata/...
+go get -u github.com/google/gops
+go get -u github.com/onsi/ginkgo/ginkgo
+go get -u github.com/onsi/gomega/...
+sudo ln -sf /go/bin/* /usr/local/bin/
+
+sudo curl -L https://github.com/docker/compose/releases/download/1.23.2/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose
+sudo chmod +x /usr/local/bin/docker-compose
+
+echo 'cd /root/go/src/github.com/cilium/cilium' >> /root/.bashrc


### PR DESCRIPTION
It is useful to run the CI tests in a dedicated machine that helps
bisecting problems in a particular branch.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8203)
<!-- Reviewable:end -->
