### PR TITLE
backport 1.5 Jenkinsfile: backport all Jenkinsfile from master

### DIFF
--- a/docs.Jenkinsfile
+++ b/docs.Jenkinsfile
@@ -39,7 +39,7 @@ pipeline {
     stages {
         stage('Docs') {
             options {
-                timeout(time: 10, unit: 'MINUTES')
+                timeout(time: 20, unit: 'MINUTES')
             }
             steps {
                 Status("PENDING", "${env.JOB_NAME}")

--- a/flannel.Jenkinsfile
+++ b/flannel.Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
     stages {
         stage('Checkout') {
             options {
-                timeout(time: 10, unit: 'MINUTES')
+                timeout(time: 20, unit: 'MINUTES')
             }
 
             steps {

--- a/ginkgo-kubernetes-all.Jenkinsfile
+++ b/ginkgo-kubernetes-all.Jenkinsfile
@@ -50,15 +50,15 @@ pipeline {
     stages {
         stage('Checkout') {
             options {
-                timeout(time: 10, unit: 'MINUTES')
+                timeout(time: 20, unit: 'MINUTES')
             }
 
             steps {
                 sh 'env'
                 Status("PENDING", "${env.JOB_NAME}")
-                sh 'rm -rf src; mkdir -p src/github.com/cilium'
-                sh 'ln -s $WORKSPACE src/github.com/cilium/cilium'
                 checkout scm
+                sh 'mkdir -p ${PROJ_PATH}'
+                sh 'ls -A | grep -v src | xargs mv -t ${PROJ_PATH}'
                 sh '/usr/local/bin/cleanup || true'
             }
         }
@@ -76,7 +76,7 @@ pipeline {
                 }
             }
         }
-        stage('Boot VMs 1.{11,12}'){
+        stage('Copy code and boot VMs 1.{11,12}'){
 
             options {
                 timeout(time: 30, unit: 'MINUTES')
@@ -87,9 +87,49 @@ pipeline {
                 TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
             }
 
-            steps {
-                sh 'cd ${TESTDIR}; K8S_VERSION=1.11 vagrant up --no-provision'
-                sh 'cd ${TESTDIR}; K8S_VERSION=1.12 vagrant up --no-provision'
+            parallel {
+                stage('Boot vms 1.11') {
+                    environment {
+                        TESTED_SUITE="1.11"
+                        GOPATH="${WORKSPACE}/${TESTED_SUITE}-gopath"
+                        TESTDIR="${GOPATH}/${PROJ_PATH}/test"
+                    }
+                    steps {
+                        sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
+                        sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
+                        sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} vagrant up k8s1-${TESTED_SUITE} k8s2-${TESTED_SUITE} --provision'
+                    }
+                    post {
+                        unsuccessful {
+                            script {
+                                if  (!currentBuild.displayName.contains('fail')) {
+                                    currentBuild.displayName = 'K8S 1.11 vm provisioning fail\n' + currentBuild.displayName
+                                }
+                            }
+                        }
+                    }
+                }
+                stage('Boot vms 1.12') {
+                    environment {
+                        TESTED_SUITE="1.12"
+                        GOPATH="${WORKSPACE}/${TESTED_SUITE}-gopath"
+                        TESTDIR="${GOPATH}/${PROJ_PATH}/test"
+                    }
+                    steps {
+                        sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
+                        sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
+                        sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} vagrant up k8s1-${TESTED_SUITE} k8s2-${TESTED_SUITE} --provision'
+                    }
+                    post {
+                        unsuccessful {
+                            script {
+                                if  (!currentBuild.displayName.contains('fail')) {
+                                    currentBuild.displayName = 'K8S 1.12 vm provisioning fail\n' + currentBuild.displayName
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
         stage('BDD-Test-k8s-1.11-and-1.12') {
@@ -99,36 +139,117 @@ pipeline {
             options {
                 timeout(time: 100, unit: 'MINUTES')
             }
-            steps {
-                script {
-                    parallel(
-                        "K8s-1.11":{
-                            sh 'cd ${TESTDIR}; K8S_VERSION=1.11 ginkgo --focus=" K8s*" -v --failFast=${FAILFAST}'
-                        },
-                        "K8s-1.12":{
-                            sh 'cd ${TESTDIR}; K8S_VERSION=1.12 ginkgo --focus=" K8s*" -v --failFast=${FAILFAST}'
-                        },
-                        failFast: "${FAILFAST}".toBoolean()
-                    )
+            failFast true
+            parallel {
+                stage('BDD-Test-k8s-1.11') {
+                    environment {
+                        TESTED_SUITE="1.11"
+                        GOPATH="${WORKSPACE}/${TESTED_SUITE}-gopath"
+                        TESTDIR="${GOPATH}/${PROJ_PATH}/test"
+                    }
+                    steps {
+                        sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
+                    }
+                    post {
+                        always {
+                            sh 'cd ${TESTDIR}; ./post_build_agent.sh || true'
+                            sh 'cd ${TESTDIR}; ./archive_test_results.sh || true'
+                            sh 'cd ${TESTDIR}/..; mv *.zip ${WORKSPACE} || true'
+                            sh 'cd ${TESTDIR}; mv *.xml ${WORKSPACE}/${PROJ_PATH}/test || true'
+                            sh 'cd ${TESTDIR}; vagrant destroy -f || true'
+                        }
+                        unsuccessful {
+                            script {
+                                if  (!currentBuild.displayName.contains('fail')) {
+                                    currentBuild.displayName = 'K8s 1.11 tests fail\n' + currentBuild.displayName
+                                }
+                            }
+                        }
+                    }
                 }
-            }
-            post {
-                always {
-                    sh 'cd test/; ./post_build_agent.sh || true'
-                    sh 'cd test/; ./archive_test_results.sh || true'
-                    archiveArtifacts artifacts: '*.zip'
-                    junit testDataPublishers: [[$class: 'AttachmentPublisher']], testResults: 'test/*.xml'
+                stage('BDD-Test-k8s-1.12') {
+                    environment {
+                        TESTED_SUITE="1.12"
+                        GOPATH="${WORKSPACE}/${TESTED_SUITE}-gopath"
+                        TESTDIR="${GOPATH}/${PROJ_PATH}/test"
+                    }
+                    steps {
+                        sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
+                    }
+                    post {
+                        always {
+                            sh 'cd ${TESTDIR}; ./post_build_agent.sh || true'
+                            sh 'cd ${TESTDIR}; ./archive_test_results.sh || true'
+                            sh 'cd ${TESTDIR}/..; mv *.zip ${WORKSPACE} || true'
+                            sh 'cd ${TESTDIR}; mv *.xml ${WORKSPACE}/${PROJ_PATH}/test || true'
+                            sh 'cd ${TESTDIR}; vagrant destroy -f || true'
+                        }
+                        unsuccessful {
+                            script {
+                                if  (!currentBuild.displayName.contains('fail')) {
+                                    currentBuild.displayName = 'K8s 1.12 tests fail\n' + currentBuild.displayName
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }
 
-        stage('Boot VMs 1.{13,15}'){
+        stage('Copy code and boot VMs 1.{13,15}'){
+
             options {
                 timeout(time: 30, unit: 'MINUTES')
             }
-            steps {
-                sh 'cd ${TESTDIR}; K8S_VERSION=1.13 vagrant up --no-provision'
-                sh 'cd ${TESTDIR}; K8S_VERSION=1.15 vagrant up --no-provision'
+
+            environment {
+                GOPATH="${WORKSPACE}"
+                TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
+            }
+
+            parallel {
+                stage('Boot vms 1.13') {
+                    environment {
+                        TESTED_SUITE="1.13"
+                        GOPATH="${WORKSPACE}/${TESTED_SUITE}-gopath"
+                        TESTDIR="${GOPATH}/${PROJ_PATH}/test"
+                    }
+                    steps {
+                        sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
+                        sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
+                        sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} vagrant up k8s1-${TESTED_SUITE} k8s2-${TESTED_SUITE} --provision'
+                    }
+                    post {
+                        unsuccessful {
+                            script {
+                                if  (!currentBuild.displayName.contains('fail')) {
+                                    currentBuild.displayName = 'K8S 1.13 vm provisioning fail\n' + currentBuild.displayName
+                                }
+                            }
+                        }
+                    }
+                }
+                stage('Boot vms 1.15') {
+                    environment {
+                        TESTED_SUITE="1.15"
+                        GOPATH="${WORKSPACE}/${TESTED_SUITE}-gopath"
+                        TESTDIR="${GOPATH}/${PROJ_PATH}/test"
+                    }
+                    steps {
+                        sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
+                        sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
+                        sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} vagrant up k8s1-${TESTED_SUITE} k8s2-${TESTED_SUITE} --provision'
+                    }
+                    post {
+                        unsuccessful {
+                            script {
+                                if  (!currentBuild.displayName.contains('fail')) {
+                                    currentBuild.displayName = 'K8S 1.15 vm provisioning fail\n' + currentBuild.displayName
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
         stage('BDD-Test-k8s-1.13-and-1.15') {
@@ -138,35 +259,67 @@ pipeline {
             options {
                 timeout(time: 100, unit: 'MINUTES')
             }
-            steps {
-                script {
-                    parallel(
-                        "K8s-1.13":{
-                            sh 'cd ${TESTDIR}; K8S_VERSION=1.13 ginkgo --focus=" K8s*" -v --failFast=${FAILFAST}'
-                        },
-                        "K8s-1.15":{
-                            sh 'cd ${TESTDIR}; K8S_VERSION=1.15 ginkgo --focus=" K8s*" -v --failFast=${FAILFAST}'
-                        },
-                        failFast: "${FAILFAST}".toBoolean()
-                    )
+            failFast true
+            parallel {
+                stage('BDD-Test-k8s-1.13') {
+                    environment {
+                        TESTED_SUITE="1.13"
+                        GOPATH="${WORKSPACE}/${TESTED_SUITE}-gopath"
+                        TESTDIR="${GOPATH}/${PROJ_PATH}/test"
+                    }
+                    steps {
+                        sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
+                    }
+                    post {
+                        always {
+                            sh 'cd ${TESTDIR}; ./post_build_agent.sh || true'
+                            sh 'cd ${TESTDIR}; ./archive_test_results.sh || true'
+                            sh 'cd ${TESTDIR}/..; mv *.zip ${WORKSPACE} || true'
+                            sh 'cd ${TESTDIR}; mv *.xml ${WORKSPACE}/${PROJ_PATH}/test || true'
+                            sh 'cd ${TESTDIR}; vagrant destroy -f || true'
+                        }
+                        unsuccessful {
+                            script {
+                                if  (!currentBuild.displayName.contains('fail')) {
+                                    currentBuild.displayName = 'K8s 1.13 tests fail\n' + currentBuild.displayName
+                                }
+                            }
+                        }
+                    }
                 }
-            }
-            post {
-                always {
-                    sh 'cd test/; ./post_build_agent.sh || true'
-                    sh 'cd test/; ./archive_test_results.sh || true'
-                    archiveArtifacts artifacts: '*.zip'
-                    junit testDataPublishers: [[$class: 'AttachmentPublisher']], testResults: 'test/*.xml'
+                stage('BDD-Test-k8s-1.15') {
+                    environment {
+                        TESTED_SUITE="1.15"
+                        GOPATH="${WORKSPACE}/${TESTED_SUITE}-gopath"
+                        TESTDIR="${GOPATH}/${PROJ_PATH}/test"
+                    }
+                    steps {
+                        sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
+                    }
+                    post {
+                        always {
+                            sh 'cd ${TESTDIR}; ./post_build_agent.sh || true'
+                            sh 'cd ${TESTDIR}; ./archive_test_results.sh || true'
+                            sh 'cd ${TESTDIR}/..; mv *.zip ${WORKSPACE} || true'
+                            sh 'cd ${TESTDIR}; mv *.xml ${WORKSPACE}/${PROJ_PATH}/test || true'
+                            sh 'cd ${TESTDIR}; vagrant destroy -f || true'
+                        }
+                        unsuccessful {
+                            script {
+                                if  (!currentBuild.displayName.contains('fail')) {
+                                    currentBuild.displayName = 'K8s 1.15 tests fail\n' + currentBuild.displayName
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }
     }
     post {
         always {
-            sh "cd ${TESTDIR}; K8S_VERSION=1.11 vagrant destroy -f || true"
-            sh "cd ${TESTDIR}; K8S_VERSION=1.12 vagrant destroy -f || true"
-            sh "cd ${TESTDIR}; K8S_VERSION=1.13 vagrant destroy -f || true"
-            sh "cd ${TESTDIR}; ./post_build_agent.sh || true"
+            archiveArtifacts artifacts: '*.zip'
+            junit testDataPublishers: [[$class: 'AttachmentPublisher']], testResults: 'src/github.com/cilium/cilium/test/*.xml'
             cleanWs()
         }
         success {

--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
     stages {
         stage('Checkout') {
             options {
-                timeout(time: 10, unit: 'MINUTES')
+                timeout(time: 20, unit: 'MINUTES')
             }
 
             steps {
@@ -51,7 +51,7 @@ pipeline {
                always {
                    sh "cd ${TESTDIR}; make clean-jenkins-precheck || true"
                }
-               failure {
+               unsuccessful {
                    script {
                        if  (!currentBuild.displayName.contains('fail')) {
                            currentBuild.displayName = 'precheck fail\n' + currentBuild.displayName
@@ -76,14 +76,13 @@ pipeline {
         }
         stage ("Copy code and boot vms"){
             options {
-                timeout(time: 30, unit: 'MINUTES')
+                timeout(time: 45, unit: 'MINUTES')
             }
 
             environment {
                 FAILFAST=setIfLabel("ci/fail-fast", "true", "false")
                 CONTAINER_RUNTIME=setIfLabel("area/containerd", "containerd", "docker")
             }
-
             parallel {
                 stage('Boot vms runtime') {
                     environment {
@@ -97,7 +96,7 @@ pipeline {
                         sh 'cd ${TESTDIR}; vagrant up runtime --provision'
                     }
                     post {
-                        failure {
+                        unsuccessful {
                             script {
                                 if  (!currentBuild.displayName.contains('fail')) {
                                     currentBuild.displayName = 'runtime vm provisioning fail\n' + currentBuild.displayName
@@ -118,7 +117,7 @@ pipeline {
                         sh 'cd ${TESTDIR}; K8S_VERSION=1.10 vagrant up k8s1-1.10 k8s2-1.10 --provision'
                     }
                     post {
-                        failure {
+                        unsuccessful {
                             script {
                                 if  (!currentBuild.displayName.contains('fail')) {
                                     currentBuild.displayName = 'K8s 1.10 vm provisioning fail\n' + currentBuild.displayName
@@ -139,7 +138,7 @@ pipeline {
                         sh 'cd ${TESTDIR}; K8S_VERSION=1.14 vagrant up k8s1-1.14 k8s2-1.14 --provision'
                     }
                     post {
-                        failure {
+                        unsuccessful {
                             script {
                                 if  (!currentBuild.displayName.contains('fail')) {
                                     currentBuild.displayName = 'K8s 1.14 vm provisioning fail\n' + currentBuild.displayName
@@ -158,7 +157,6 @@ pipeline {
                 FAILFAST=setIfLabel("ci/fail-fast", "true", "false")
                 CONTAINER_RUNTIME=setIfLabel("area/containerd", "containerd", "docker")
             }
-
             failFast true
             parallel {
                 stage('BDD-Test-PR-runtime') {
@@ -178,7 +176,7 @@ pipeline {
                             sh 'cd ${TESTDIR}; mv *.xml ${WORKSPACE}/${PROJ_PATH}/test || true'
                             sh 'cd ${TESTDIR}; vagrant destroy -f || true'
                         }
-                        failure {
+                        unsuccessful {
                             script {
                                 if  (!currentBuild.displayName.contains('fail')) {
                                     currentBuild.displayName = 'Runtime tests fail\n' + currentBuild.displayName
@@ -204,7 +202,7 @@ pipeline {
                             sh 'cd ${TESTDIR}; mv *.xml ${WORKSPACE}/${PROJ_PATH}/test || true'
                             sh 'cd ${TESTDIR}; K8S_VERSION=1.10 vagrant destroy -f || true'
                         }
-                        failure {
+                        unsuccessful {
                             script {
                                 if  (!currentBuild.displayName.contains('fail')) {
                                     currentBuild.displayName = 'K8s 1.10 fail\n' + currentBuild.displayName
@@ -230,7 +228,7 @@ pipeline {
                             sh 'cd ${TESTDIR}; mv *.xml ${WORKSPACE}/${PROJ_PATH}/test || true'
                             sh 'cd ${TESTDIR}; K8S_VERSION=1.14 vagrant destroy -f || true'
                         }
-                        failure {
+                        unsuccessful {
                             script {
                                 if  (!currentBuild.displayName.contains('fail')) {
                                     currentBuild.displayName = 'K8s 1.14 fail\n' + currentBuild.displayName


### PR DESCRIPTION
We have made lots of changes in jenkins that were not and should have
been backported into this branch. For this reason this commit is a copy
of all Jenkinsfiles present in master with the k8s versions being tested
changed to be v1.5 specific.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8205)
<!-- Reviewable:end -->
