### PR TITLE
monitor: Error out early if endpoint doesn't exist

### DIFF
--- a/pkg/monitor/format/flags.go
+++ b/pkg/monitor/format/flags.go
@@ -51,7 +51,8 @@ func (i *Uint16Flags) Type() string {
 	return "[]uint16"
 }
 
-func (i *Uint16Flags) has(value uint16) bool {
+// Has returns true of value exist
+func (i *Uint16Flags) Has(value uint16) bool {
 	for _, v := range *i {
 		if v == value {
 			return true

--- a/pkg/monitor/format/format.go
+++ b/pkg/monitor/format/format.go
@@ -82,11 +82,11 @@ func NewMonitorFormatter(verbosity Verbosity) *MonitorFormatter {
 func (m *MonitorFormatter) match(messageType int, src uint16, dst uint16) bool {
 	if len(m.EventTypes) > 0 && !m.EventTypes.Contains(messageType) {
 		return false
-	} else if len(m.FromSource) > 0 && !m.FromSource.has(src) {
+	} else if len(m.FromSource) > 0 && !m.FromSource.Has(src) {
 		return false
-	} else if len(m.ToDst) > 0 && !m.ToDst.has(dst) {
+	} else if len(m.ToDst) > 0 && !m.ToDst.Has(dst) {
 		return false
-	} else if len(m.Related) > 0 && !m.Related.has(src) && !m.Related.has(dst) {
+	} else if len(m.Related) > 0 && !m.Related.Has(src) && !m.Related.Has(dst) {
 		return false
 	}
 


### PR DESCRIPTION
Monitor options --from and --to can expect non-existing endpoint
which just let cilium monitor to fetch all the results and without
any output.

This commit prechecks --from and --to endpoints first and
error out in case of nonexisting endpoints

This PR also exposes/renames Uint16Flags.has() -> Uint16Flags.Has()

Signed-off-by: Nirmoy Das <ndas@suse.de>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8206)
<!-- Reviewable:end -->
