### PR TITLE
test/k8sT: disabling direct routing tests

### DIFF
--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -157,6 +157,8 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 	Context("DirectRouting", func() {
 		It("Check connectivity with automatic direct nodes routes", func() {
+			// FIXME: @ray, @jrajahalme, @nebril
+			Skip("Skipping test because it is currently braking the SSH connectivity between Ginkgo and the VM running the test")
 			SkipIfFlannel()
 
 			deployCilium("cilium-ds-patch-auto-node-routes.yaml")


### PR DESCRIPTION
The test is currently broken which is affecting the CI runs. Should be
disabled once the issue was tracked down.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8207)
<!-- Reviewable:end -->
