### PR TITLE
examples/kubernetes: add missing CILIUM_CUSTOM_CNI_CONF in DaemonSets

### DIFF
--- a/examples/kubernetes/1.10/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-containerd-ds.yaml
@@ -66,6 +66,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:
@@ -159,6 +165,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:2019-04-05

--- a/examples/kubernetes/1.10/cilium-containerd.yaml
+++ b/examples/kubernetes/1.10/cilium-containerd.yaml
@@ -235,6 +235,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:
@@ -328,6 +334,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:2019-04-05

--- a/examples/kubernetes/1.10/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-crio-ds.yaml
@@ -74,6 +74,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:
@@ -167,6 +173,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:2019-04-05

--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -243,6 +243,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:
@@ -336,6 +342,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:2019-04-05

--- a/examples/kubernetes/1.10/cilium-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-ds.yaml
@@ -73,6 +73,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:

--- a/examples/kubernetes/1.10/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.10/cilium-external-etcd.yaml
@@ -242,6 +242,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:

--- a/examples/kubernetes/1.10/cilium-microk8s.yaml
+++ b/examples/kubernetes/1.10/cilium-microk8s.yaml
@@ -235,6 +235,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:
@@ -328,6 +334,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:2019-04-05

--- a/examples/kubernetes/1.10/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.10/cilium-with-node-init.yaml
@@ -242,6 +242,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:

--- a/examples/kubernetes/1.10/cilium.yaml
+++ b/examples/kubernetes/1.10/cilium.yaml
@@ -242,6 +242,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:

--- a/examples/kubernetes/1.11/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-containerd-ds.yaml
@@ -66,6 +66,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:
@@ -159,6 +165,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:2019-04-05

--- a/examples/kubernetes/1.11/cilium-containerd.yaml
+++ b/examples/kubernetes/1.11/cilium-containerd.yaml
@@ -235,6 +235,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:
@@ -328,6 +334,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:2019-04-05

--- a/examples/kubernetes/1.11/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-crio-ds.yaml
@@ -74,6 +74,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:
@@ -165,6 +171,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:2019-04-05

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -243,6 +243,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:
@@ -334,6 +340,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:2019-04-05

--- a/examples/kubernetes/1.11/cilium-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-ds.yaml
@@ -73,6 +73,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:

--- a/examples/kubernetes/1.11/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.11/cilium-external-etcd.yaml
@@ -242,6 +242,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:

--- a/examples/kubernetes/1.11/cilium-microk8s.yaml
+++ b/examples/kubernetes/1.11/cilium-microk8s.yaml
@@ -235,6 +235,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:
@@ -328,6 +334,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:2019-04-05

--- a/examples/kubernetes/1.11/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.11/cilium-with-node-init.yaml
@@ -242,6 +242,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:

--- a/examples/kubernetes/1.11/cilium.yaml
+++ b/examples/kubernetes/1.11/cilium.yaml
@@ -242,6 +242,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:

--- a/examples/kubernetes/1.12/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-containerd-ds.yaml
@@ -66,6 +66,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:
@@ -159,6 +165,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:2019-04-05

--- a/examples/kubernetes/1.12/cilium-containerd.yaml
+++ b/examples/kubernetes/1.12/cilium-containerd.yaml
@@ -235,6 +235,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:
@@ -328,6 +334,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:2019-04-05

--- a/examples/kubernetes/1.12/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-crio-ds.yaml
@@ -74,6 +74,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:
@@ -165,6 +171,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:2019-04-05

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -243,6 +243,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:
@@ -334,6 +340,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:2019-04-05

--- a/examples/kubernetes/1.12/cilium-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-ds.yaml
@@ -73,6 +73,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:

--- a/examples/kubernetes/1.12/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.12/cilium-external-etcd.yaml
@@ -242,6 +242,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:

--- a/examples/kubernetes/1.12/cilium-microk8s.yaml
+++ b/examples/kubernetes/1.12/cilium-microk8s.yaml
@@ -235,6 +235,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:
@@ -328,6 +334,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:2019-04-05

--- a/examples/kubernetes/1.12/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.12/cilium-with-node-init.yaml
@@ -242,6 +242,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:

--- a/examples/kubernetes/1.12/cilium.yaml
+++ b/examples/kubernetes/1.12/cilium.yaml
@@ -242,6 +242,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:

--- a/examples/kubernetes/1.13/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-containerd-ds.yaml
@@ -66,6 +66,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:
@@ -159,6 +165,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:2019-04-05

--- a/examples/kubernetes/1.13/cilium-containerd.yaml
+++ b/examples/kubernetes/1.13/cilium-containerd.yaml
@@ -235,6 +235,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:
@@ -328,6 +334,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:2019-04-05

--- a/examples/kubernetes/1.13/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-crio-ds.yaml
@@ -74,6 +74,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:
@@ -165,6 +171,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:2019-04-05

--- a/examples/kubernetes/1.13/cilium-crio.yaml
+++ b/examples/kubernetes/1.13/cilium-crio.yaml
@@ -243,6 +243,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:
@@ -334,6 +340,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:2019-04-05

--- a/examples/kubernetes/1.13/cilium-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-ds.yaml
@@ -73,6 +73,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:

--- a/examples/kubernetes/1.13/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.13/cilium-external-etcd.yaml
@@ -242,6 +242,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:

--- a/examples/kubernetes/1.13/cilium-microk8s.yaml
+++ b/examples/kubernetes/1.13/cilium-microk8s.yaml
@@ -235,6 +235,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:
@@ -328,6 +334,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:2019-04-05

--- a/examples/kubernetes/1.13/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.13/cilium-with-node-init.yaml
@@ -242,6 +242,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:

--- a/examples/kubernetes/1.13/cilium.yaml
+++ b/examples/kubernetes/1.13/cilium.yaml
@@ -242,6 +242,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:

--- a/examples/kubernetes/1.14/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.14/cilium-containerd-ds.yaml
@@ -66,6 +66,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:
@@ -159,6 +165,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:2019-04-05

--- a/examples/kubernetes/1.14/cilium-containerd.yaml
+++ b/examples/kubernetes/1.14/cilium-containerd.yaml
@@ -235,6 +235,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:
@@ -328,6 +334,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:2019-04-05

--- a/examples/kubernetes/1.14/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.14/cilium-crio-ds.yaml
@@ -74,6 +74,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:
@@ -165,6 +171,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:2019-04-05

--- a/examples/kubernetes/1.14/cilium-crio.yaml
+++ b/examples/kubernetes/1.14/cilium-crio.yaml
@@ -243,6 +243,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:
@@ -334,6 +340,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:2019-04-05

--- a/examples/kubernetes/1.14/cilium-ds.yaml
+++ b/examples/kubernetes/1.14/cilium-ds.yaml
@@ -73,6 +73,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:

--- a/examples/kubernetes/1.14/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.14/cilium-external-etcd.yaml
@@ -242,6 +242,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:

--- a/examples/kubernetes/1.14/cilium-microk8s.yaml
+++ b/examples/kubernetes/1.14/cilium-microk8s.yaml
@@ -235,6 +235,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:
@@ -328,6 +334,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:2019-04-05

--- a/examples/kubernetes/1.14/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.14/cilium-with-node-init.yaml
@@ -242,6 +242,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:

--- a/examples/kubernetes/1.14/cilium.yaml
+++ b/examples/kubernetes/1.14/cilium.yaml
@@ -242,6 +242,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:

--- a/examples/kubernetes/1.15/cilium-cm.yaml
+++ b/examples/kubernetes/1.15/cilium-cm.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none

--- a/examples/kubernetes/1.15/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.15/cilium-containerd-ds.yaml
@@ -66,6 +66,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:
@@ -159,6 +165,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:2019-04-05

--- a/examples/kubernetes/1.15/cilium-containerd.yaml
+++ b/examples/kubernetes/1.15/cilium-containerd.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none
@@ -232,6 +233,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: cni-chaining-mode
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium:latest
@@ -327,6 +334,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:2019-04-05

--- a/examples/kubernetes/1.15/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.15/cilium-crio-ds.yaml
@@ -74,6 +74,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:
@@ -165,6 +171,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:2019-04-05

--- a/examples/kubernetes/1.15/cilium-crio.yaml
+++ b/examples/kubernetes/1.15/cilium-crio.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none
@@ -240,6 +241,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: cni-chaining-mode
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium:latest
@@ -333,6 +340,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:2019-04-05

--- a/examples/kubernetes/1.15/cilium-ds.yaml
+++ b/examples/kubernetes/1.15/cilium-ds.yaml
@@ -73,6 +73,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: Always
         lifecycle:

--- a/examples/kubernetes/1.15/cilium-external-etcd.yaml
+++ b/examples/kubernetes/1.15/cilium-external-etcd.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none
@@ -239,6 +240,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: cni-chaining-mode
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium:latest

--- a/examples/kubernetes/1.15/cilium-microk8s.yaml
+++ b/examples/kubernetes/1.15/cilium-microk8s.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none
@@ -232,6 +233,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: cni-chaining-mode
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium:latest
@@ -327,6 +334,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:2019-04-05

--- a/examples/kubernetes/1.15/cilium-minikube.yaml
+++ b/examples/kubernetes/1.15/cilium-minikube.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none

--- a/examples/kubernetes/1.15/cilium-with-node-init.yaml
+++ b/examples/kubernetes/1.15/cilium-with-node-init.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none
@@ -239,6 +240,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: cni-chaining-mode
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium:latest

--- a/examples/kubernetes/1.15/cilium.yaml
+++ b/examples/kubernetes/1.15/cilium.yaml
@@ -163,6 +163,7 @@ data:
   # Enable chaining with another CNI plugin
   #
   # Supported modes:
+  #  - aws-cni
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   #cni-chaining-mode: none
@@ -239,6 +240,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: cni-chaining-mode
+              name: cilium-config
+              optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium:latest

--- a/examples/kubernetes/templates/v1/cilium-containerd-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-containerd-ds.yaml.sed
@@ -66,6 +66,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:__CILIUM_VERSION__
         imagePullPolicy: Always
         lifecycle:
@@ -159,6 +165,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:__CILIUM_INIT_VERSION__

--- a/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
@@ -74,6 +74,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:__CILIUM_VERSION__
         imagePullPolicy: Always
         lifecycle:
@@ -167,6 +173,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: clean-cilium-bpf-state
+              name: cilium-config
+              optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
               name: cilium-config
               optional: true
         image: docker.io/cilium/cilium-init:__CILIUM_INIT_VERSION__

--- a/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-ds.yaml.sed
@@ -73,6 +73,12 @@ spec:
               key: cni-chaining-mode
               name: cilium-config
               optional: true
+        - name: CILIUM_CUSTOM_CNI_CONF
+          valueFrom:
+            configMapKeyRef:
+              key: custom-cni-conf
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:__CILIUM_VERSION__
         imagePullPolicy: Always
         lifecycle:


### PR DESCRIPTION
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8209)
<!-- Reviewable:end -->
