### PR TITLE
test: log when we are waiting for SSH session to be stopped

### DIFF
--- a/test/helpers/ssh_command.go
+++ b/test/helpers/ssh_command.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/kevinburke/ssh_config"
+	"github.com/onsi/ginkgo"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 )
@@ -290,6 +291,7 @@ func (client *SSHClient) RunCommandContext(ctx context.Context, cmd *SSHCommand)
 	select {
 	case <-ctx.Done():
 		// Wait until the ssh session is stopped
+		ginkgo.By("Waiting for SSH session to be stopped")
 		wg.Wait()
 		return ctx.Err()
 	default:


### PR DESCRIPTION
This log will only occur if the context provided to `RunCommandContext` is
canceled, which is not common. Otherwise, we can potentially wait forever with
no indication as to where the code is stuck.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8213)
<!-- Reviewable:end -->
