### PR TITLE
node: Delay handling of node delete events received via kvstore

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -236,4 +236,9 @@ const (
 	// MonitorBufferPages is the default number of pages to use for the
 	// ring buffer interacting with the kernel
 	MonitorBufferPages = 64
+
+	// NodeDeleteDelay is the delay before an unreliable node delete is
+	// handled. During this delay, the node can re-appear and the delete
+	// event is ignored.
+	NodeDeleteDelay = 30 * time.Second
 )

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -346,6 +346,14 @@ func (m *Manager) NodeDeleted(n node.Node) {
 	entry.mutex.Unlock()
 }
 
+// Exists returns true if a node with the name exists
+func (m *Manager) Exists(id node.Identity) bool {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+	_, ok := m.nodes[id]
+	return ok
+}
+
 // GetNodes returns a copy of all of the nodes as a map from Identity to Node.
 func (m *Manager) GetNodes() map[node.Identity]node.Node {
 	m.mutex.RLock()

--- a/pkg/node/store/store.go
+++ b/pkg/node/store/store.go
@@ -16,11 +16,15 @@ package store
 
 import (
 	"path"
+	"time"
 
+	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/node"
 )
 
@@ -36,6 +40,8 @@ var (
 		n := node.Node{}
 		return &n
 	}
+
+	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "node-store")
 )
 
 // NodeObserver implements the store.Observer interface and delegates update
@@ -81,16 +87,27 @@ func (o *NodeObserver) OnDelete(k store.NamedKey) {
 	if n, ok := k.(*node.Node); ok {
 		nodeCopy := n.DeepCopy()
 		nodeCopy.Source = node.FromKVStore
-		o.manager.NodeDeleted(*nodeCopy)
 
-		ciliumIPv4 := nodeCopy.GetCiliumInternalIP(false)
-		if ciliumIPv4 != nil {
-			ipcache.IPIdentityCache.Delete(ciliumIPv4.String(), ipcache.FromKVStore)
-		}
-		ciliumIPv6 := nodeCopy.GetCiliumInternalIP(true)
-		if ciliumIPv6 != nil {
-			ipcache.IPIdentityCache.Delete(ciliumIPv6.String(), ipcache.FromKVStore)
-		}
+		go func() {
+			time.Sleep(defaults.NodeDeleteDelay)
+
+			if o.manager.Exists(nodeCopy.Identity()) {
+				log.Warningf("Received node delete event for node %s which re-appeared within %s",
+					nodeCopy.Name, defaults.NodeDeleteDelay)
+				return
+			}
+
+			o.manager.NodeDeleted(*nodeCopy)
+
+			ciliumIPv4 := nodeCopy.GetCiliumInternalIP(false)
+			if ciliumIPv4 != nil {
+				ipcache.IPIdentityCache.Delete(ciliumIPv4.String(), ipcache.FromKVStore)
+			}
+			ciliumIPv6 := nodeCopy.GetCiliumInternalIP(true)
+			if ciliumIPv6 != nil {
+				ipcache.IPIdentityCache.Delete(ciliumIPv6.String(), ipcache.FromKVStore)
+			}
+		}()
 	}
 }
 
@@ -111,6 +128,9 @@ type NodeManager interface {
 
 	// NodeDeleted is called when the store detects a deletion of a node
 	NodeDeleted(n node.Node)
+
+	// Exists is called to verify if a node exists
+	Exists(id node.Identity) bool
 }
 
 // RegisterNode registers the local node in the cluster


### PR DESCRIPTION
As for other kvstore keys, each node will protect its own node key and
re-create it as needed on loss of kvstore state.

However, when immediately acting upon receiving a node delete event via the
kvstore, the removal of routes and similar can cause etcd itself to become
unreachable when etcd is hosted as a pod. A subsequent readdition of the key
can then not be received and the node is lost forever.

There are several more complex long-term options including relying on k8s node
state. For a short-term resolution, introduce a 30 seconds delay when handling
node delete events from the kvstore and require the node to not be re-created
in that timeframe. This workaround works regardless of how node discovery is
performed.

A potential side effect of this is that when a node re-appears with different
IP addressing. In that scenario, the k8s node delete event will forcefully
remove all state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8214)
<!-- Reviewable:end -->
