### PR TITLE
v1.4 backports 2019-06-05

### DIFF
--- a/Documentation/gettingstarted/k8s-install-eks.rst
+++ b/Documentation/gettingstarted/k8s-install-eks.rst
@@ -82,6 +82,19 @@ leaving a node to be automatically be masqueraded.
 
        kubectl -n kube-system set env ds aws-node AWS_VPC_K8S_CNI_EXTERNALSNAT=true
        
+Prepare the nodes for Cilium
+============================
+
+Deploy the following DaemonSet to prepare all EKS nodes for Cilium:
+
+   .. code:: bash
+
+       kubectl -n kube-system apply -f \ |SCM_WEB|\/examples/kubernetes/node-init/eks-node-init.yaml
+
+This will mount the BPF filesystem and ensures that the filesystem is
+automatically mounted when the node is rebooted. Due to being a DaemonSet, any
+new node added to the cluster will automatically get initialized as well.
+
 .. include:: k8s-install-etcd-operator-steps.rst
 
 .. note::
@@ -89,6 +102,7 @@ leaving a node to be automatically be masqueraded.
    You may notice that the ``kube-dns-*`` pods get restarted. The
    ``cilium-operator`` will automatically restart CoreDNS if the pods are not
    managed by the Cilium CNI plugin.
+
 
 Validate the Installation
 =========================

--- a/examples/kubernetes/node-init/eks-node-init.yaml
+++ b/examples/kubernetes/node-init/eks-node-init.yaml
@@ -1,0 +1,72 @@
+kind: DaemonSet
+apiVersion: extensions/v1beta1
+metadata:
+  name: cilium-node-init
+  labels:
+    app: cilium-node-init
+spec:
+  template:
+    metadata:
+      labels:
+        app: cilium-node-init
+    spec:
+      tolerations:
+      - operator: Exists
+      hostPID: true
+      hostNetwork: true
+      containers:
+        - name: node-init
+          image: gcr.io/google-containers/startup-script:v1
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+          env:
+          - name: STARTUP_SCRIPT
+            value: |
+              #!/bin/bash
+
+              set -o errexit
+              set -o pipefail
+              set -o nounset
+
+              if [[ ! -f /tmp/cilium-installed-v1 ]]; then
+                echo "Installing BPF filesystem mount"
+
+                cat >/tmp/sys-fs-bpf.mount <<EOF
+              [Unit]
+              Description=Mount BPF filesystem (Cilium)
+              Documentation=http://docs.cilium.io/
+              DefaultDependencies=no
+              Before=local-fs.target umount.target
+              After=swap.target
+
+              [Mount]
+              What=bpffs
+              Where=/sys/fs/bpf
+              Type=bpf
+
+              [Install]
+              WantedBy=multi-user.target
+              EOF
+
+                if [ -d "/etc/systemd/system/" ]; then
+                  mv /tmp/sys-fs-bpf.mount /etc/systemd/system/
+                  echo "Installed sys-fs-bpf.mount to /etc/systemd/system/"
+                elif [ -d "/lib/systemd/system/" ]; then
+                  mv /tmp/sys-fs-bpf.mount /lib/systemd/system/
+                  echo "Installed sys-fs-bpf.mount to /lib/systemd/system/"
+                fi
+
+                systemctl enable sys-fs-bpf.mount
+                systemctl start sys-fs-bpf.mount
+
+                echo "Link information:"
+                ip link
+
+                echo "Routing table:"
+                ip route
+
+                echo "Node initialization complete"
+
+                touch /tmp/cilium-installed-v1
+              fi

--- a/kubernetes-upstream.Jenkinsfile
+++ b/kubernetes-upstream.Jenkinsfile
@@ -57,6 +57,15 @@ pipeline {
                 sh '/usr/local/bin/cleanup || true'
             }
         }
+        stage('Preload vagrant boxes'){
+            options {
+                timeout(time: 20, unit: 'MINUTES')
+            }
+
+            steps {
+                sh '/usr/local/bin/add_vagrant_box ${WORKSPACE}/${PROJ_PATH}/vagrant_box_defaults.rb'
+            }
+        }
         stage('Boot VMs'){
             options {
                 timeout(time: 30, unit: 'MINUTES')

--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -406,6 +406,11 @@ func (a *Allocator) createValueNodeKey(key string, newID idpool.ID) error {
 		return fmt.Errorf("unable to create value-node key '%s': %s", valueKey, err)
 	}
 
+	// mark the key as verified in the local cache
+	if err := a.localKeys.verify(key); err != nil {
+		log.WithError(err).Error("BUG: Unable to verify local key")
+	}
+
 	return nil
 }
 
@@ -452,11 +457,6 @@ func (a *Allocator) lockedAllocate(ctx context.Context, key AllocatorKey) (idpoo
 		if err = a.createValueNodeKey(k, value); err != nil {
 			a.localKeys.release(k)
 			return 0, false, fmt.Errorf("unable to create slave key '%s': %s", k, err)
-		}
-
-		// mark the key as verified in the local cache
-		if err := a.localKeys.verify(k); err != nil {
-			log.WithError(err).Error("BUG: Unable to verify local key")
 		}
 
 		return value, false, nil

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1125,7 +1125,9 @@ func (kub *Kubectl) CiliumExecContext(ctx context.Context, pod string, cmd strin
 // CiliumExec runs cmd in the specified Cilium pod.
 // Deprecated: use CiliumExecContext instead
 func (kub *Kubectl) CiliumExec(pod string, cmd string) *CmdRes {
-	return kub.CiliumExecContext(context.Background(), pod, cmd)
+	ctx, cancel := context.WithTimeout(context.Background(), HelperTimeout)
+	defer cancel()
+	return kub.CiliumExecContext(ctx, pod, cmd)
 }
 
 // CiliumExecUntilMatch executes the specified command repeatedly for the


### PR DESCRIPTION
 * ~~#8014 -- envoy: Do not use deprecated configuration options. (@jrajahalme)~~
    * ~~Needed #7618 as a dependency (@jrajahalme, please double check)~~
 * #8168 -- allocator: Verify locally allocated key (@tgraf)
 * #8173 -- doc: Add EKS node-init DaemonSet to mount BPF filesystem (@tgraf)
 * #8197 -- test: provide context which will be canceled to `CiliumExecContext` (@ianvernon)
* #8290 -- Preload vagrant boxes in k8s upstream jenkinsfile (@nebril)

Once this PR is merged, you can update the PR labels via:
```
$ for pr in 8168 8290 8173 8197; do contrib/backporting/set-labels.py $pr done 1.4; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8216)
<!-- Reviewable:end -->
