### PR TITLE
Fix error behavior on node registration

### DIFF
--- a/pkg/kvstore/store/store.go
+++ b/pkg/kvstore/store/store.go
@@ -335,25 +335,18 @@ func (s *SharedStore) UpdateLocalKey(key LocalKey) {
 // and adds it to the list of local keys to be synchronized if the initial
 // synchronous synchronization was successful
 func (s *SharedStore) UpdateLocalKeySync(key LocalKey) error {
-	s.UpdateLocalKey(key)
-
-	if err := s.syncLocalKey(key); err != nil {
-		s.DeleteLocalKey(key)
-		return err
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	err := s.syncLocalKey(key)
+	if err == nil {
+		s.localKeys[key.GetKeyName()] = key.DeepKeyCopy()
 	}
-
-	return nil
+	return err
 }
 
 // UpdateKeySync synchronously synchronizes a key with the kvstore.
 func (s *SharedStore) UpdateKeySync(key LocalKey) error {
-	err := s.syncLocalKey(key)
-	if err != nil {
-		s.DeleteLocalKey(key)
-		return err
-	}
-
-	return err
+	return s.syncLocalKey(key)
 }
 
 // DeleteLocalKey removes a key from being synchronized with the kvstore

--- a/pkg/kvstore/store/store.go
+++ b/pkg/kvstore/store/store.go
@@ -230,9 +230,9 @@ func (s *SharedStore) onUpdate(k Key) {
 	}
 }
 
-// Close stops participation with a shared store. This stops the controller
-// started by JoinSharedStore().
-func (s *SharedStore) Close() {
+// Release frees all resources own by the store but leaves all keys in the
+// kvstore intact
+func (s *SharedStore) Release() {
 	// Wait for all write operations to complete and then block all further
 	// operations
 	s.mutex.Lock()
@@ -243,6 +243,13 @@ func (s *SharedStore) Close() {
 	}
 
 	controllers.RemoveController(s.controllerName)
+}
+
+// Close stops participation with a shared store and removes all keys owned by
+// this node in the kvstore. This stops the controller started by
+// JoinSharedStore().
+func (s *SharedStore) Close() {
+	s.Release()
 
 	for name, key := range s.localKeys {
 		if err := s.backend.Delete(s.keyPath(key)); err != nil {

--- a/pkg/node/store/store.go
+++ b/pkg/node/store/store.go
@@ -141,7 +141,7 @@ func (nr *NodeRegistrar) RegisterNode(n *node.Node, manager NodeManager) error {
 	}
 
 	if err = store.UpdateLocalKeySync(n); err != nil {
-		store.Close()
+		store.Release()
 		return err
 	}
 


### PR DESCRIPTION
When registration fails, do not attempt to remove an eventually existing key in
the kvstore. This may in fact remove a key that is already present from a
previous agent run. If the agent fails to update the key it will eventually
expire via the lease. Removing it on the first failed attempt to udpate will
trigger an unwanted delete notification.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8217)
<!-- Reviewable:end -->
