### PR TITLE
test: Prevent from breaking connections to migrate-svc

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -232,6 +232,10 @@ const CiliumDefaultPreFlight = "cilium-pre-flight.yaml"
 // CiliumConfigMapPatch is the default Cilium ConfigMap patch to be used in all tests.
 const CiliumConfigMapPatch = "cilium-cm-patch.yaml"
 
+// CiliumConfigMapWithEnabledLegacySVCPatch is the default Cilium ConfigMap patch
+// with enabled legacy services.
+const CiliumConfigMapWithEnabledLegacySVCPatch = "cilium-cm-patch-legacy-svc.yaml"
+
 // badLogMessages is a map which key is a part of a log message which indicates
 // a failure if the message does not contain any part from value list.
 var badLogMessages = map[string][]string{

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -445,3 +445,14 @@ func failIfContainsBadLogMsg(logs string) {
 func RunsOnNetNext() bool {
 	return os.Getenv("NETNEXT") == "true"
 }
+
+// RunsOnlyLegacySVC returns true if the given ciliumVersion supports only legacy
+// services.
+func RunsOnlyLegacySVC(ciliumVersion string) bool {
+	vsn, err := go_version.NewVersion(ciliumVersion)
+	vsn = go_version.Must(vsn, err)
+	// Legacy-only services are pre-v1.5
+	constraint := versioncheck.MustCompile("< 1.5")
+
+	return constraint.Check(vsn)
+}

--- a/test/k8sT/manifests/cilium-cm-patch-legacy-svc.yaml
+++ b/test/k8sT/manifests/cilium-cm-patch-legacy-svc.yaml
@@ -21,4 +21,7 @@ data:
   # If you want to run cilium in debug mode change this value to true
   debug: "true"
 
-  ct-global-max-entries-tcp: "524288"
+  enable-ipv4: "true"
+  enable-ipv6: "true"
+  preallocate-bpf-maps: "true"
+  enable-legacy-services: "true"

--- a/test/k8sT/manifests/v1.3/cilium-cm-patch-clean-cilium-state.yaml
+++ b/test/k8sT/manifests/v1.3/cilium-cm-patch-clean-cilium-state.yaml
@@ -20,4 +20,4 @@ data:
 
   debug: "true"
   clean-cilium-state: "true"
-  ct-global-max-entries-tcp: "1000000"
+  ct-global-max-entries-tcp: "524288"


### PR DESCRIPTION
This PR fixes the test case which checks whether any connection to `migrate-svc` hasn't been broken by:

* Fixing CT TCP map sizes (again) to prevent their removal upon restart.
* Enabling legacy services only if upgrading from < v1.5. We cannot enable in all cases, as otherwise when upgrading from v1.5 to master all services are considered as orphan, and therefore they are removed which breaks connectivity.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8220)
<!-- Reviewable:end -->
