### PR TITLE
test: do not spawn goroutines to wait for canceled context in `RunCommandContext`

### DIFF
--- a/test/helpers/ssh_command.go
+++ b/test/helpers/ssh_command.go
@@ -23,7 +23,6 @@ import (
 	"net"
 	"os"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/kevinburke/ssh_config"
@@ -253,34 +252,11 @@ func (client *SSHClient) RunCommandContext(ctx context.Context, cmd *SSHCommand)
 	if err != nil {
 		return err
 	}
-	defer session.Close()
 
-	stdin, err := session.StdinPipe()
-	if err != nil {
-		log.Errorf("Could not get stdin %s", err)
-	}
-
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		select {
-		case <-ctx.Done():
-			_, err := stdin.Write([]byte{3})
-			if err != nil {
-				log.Errorf("write ^C error: %s", err)
-			}
-			err = session.Wait()
-			if err != nil {
-				log.Errorf("wait error: %s", err)
-			}
-			if err = session.Signal(ssh.SIGHUP); err != nil {
-				log.Errorf("failed to kill command: %s", err)
-			}
-			if err = session.Close(); err != nil {
-				log.Errorf("failed to close session: %s", err)
-			}
+	defer func() {
+		if closeErr := session.Close(); closeErr != nil {
+			log.WithError(closeErr).Error("failed to close session")
 		}
-		wg.Done()
 	}()
 
 	running, err := runCommand(session, cmd)
@@ -289,8 +265,10 @@ func (client *SSHClient) RunCommandContext(ctx context.Context, cmd *SSHCommand)
 	}
 	select {
 	case <-ctx.Done():
-		// Wait until the ssh session is stopped
-		wg.Wait()
+		log.Warning("sending SIGHUP to session due to canceled context")
+		if err = session.Signal(ssh.SIGHUP); err != nil {
+			log.Errorf("failed to kill command when context is canceled: %s", err)
+		}
 		return ctx.Err()
 	default:
 		return err


### PR DESCRIPTION
It was observed while running `gops stack` for the Ginkgo test suite locally,
that we were leaking goroutines that were getting stuck while waiting for SSH
sessions to finish. We accrued over 1000 of these per K8s CI run, for example:

```
16 unique stack traces
960 occurences. Sample stack trace:
github.com/cilium/cilium/vendor/golang.org/x/crypto/ssh.(*Session).Wait(0xc00098e000, 0x230f79c, 0x1a)
        /Users/ianvernon/go/src/github.com/cilium/cilium/vendor/golang.org/x/crypto/ssh/session.go:403 +0x57
github.com/cilium/cilium/test/helpers.(*SSHClient).RunCommandContext.func1(0x2502600, 0xc000542280, 0xc00098e000, 0xc0001aa780, 0xc000268220)
        /Users/ianvernon/go/src/github.com/cilium/cilium/test/helpers/ssh_command.go:262 +0x1cc
created by github.com/cilium/cilium/test/helpers.(*SSHClient).RunCommandContext
        /Users/ianvernon/go/src/github.com/cilium/cilium/test/helpers/ssh_command.go:253 +0x13c
```

This example shows that there were 960 goroutines stuck on `session.Wait()`.

Whenever we run a command via SSH, we call `runCommand`. When we call
`runCommand`, it calls `session.Run`, which calls `session.Start()` and
`session.Wait()`. I observed that  that calling `Wait()` on a session which
already has had `Run` invoked will never return, even if we try
to call `session.Close()` before invoking `session.Wait()`. This indicates
that our logic for trying to kill the session if the context which is provided
to `RunCommandContext` is canceled is flawed, as waiting for the session to
finish before closing it will block infinitely.

I enabled debug mode for the SSH library we use (`golang.org/x/crypto/ssh`), and
I see that the session receives an EOF message *before* we even try to close the
session:

```
>------- session started, and session.Run() invoked

2019/06/05 08:16:59 send global(2): ssh.channelOpenMsg{ChanType:"session", PeersID:0x2, PeersWindow:0x200000, MaxPacketSize:0x8000, TypeSpecificData:[]uint8(nil)}
2019/06/05 08:16:59 decoding(2): 91 &ssh.channelOpenConfirmMsg{PeersID:0x2, MyID:0x0, MyWindow:0x0, MaxPacketSize:0x8000, TypeSpecificData:[]uint8{}} - 17 bytes
2019/06/05 08:16:59 send(2): ssh.channelRequestMsg{PeersID:0x0, Request:"exec", WantReply:true, RequestSpecificData:[]uint8{0x0, 0x0, 0x0, 0x6d, 0x6b, 0x75, 0x62, 0x65, 0x63, 0x74, 0x6c, 0x20, 0x65, 0x78, 0x65, 0x63, 0x20, 0x2d, 0x6e, 0x20, 0x6b, 0x75, 0x62, 0x65, 0x2d, 0x73, 0x79, 0x73, 0x74, 0x65, 0x6d, 0x20, 0x63, 0x69, 0x6c, 0x69, 0x75, 0x6d, 0x2d, 0x62, 0x63, 0x63, 0x6d, 0x34, 0x20, 0x2d, 0x2d, 0x20, 0x63, 0x69, 0x6c, 0x69, 0x75, 0x6d, 0x20, 0x73, 0x74, 0x61, 0x74, 0x75, 0x73, 0x20, 0x2d, 0x6f, 0x20, 0x6a, 0x73, 0x6f, 0x6e, 0x70, 0x61, 0x74, 0x68, 0x3d, 0x27, 0x7b, 0x2e, 0x63, 0x6c, 0x75, 0x73, 0x74, 0x65, 0x72, 0x2e, 0x6e, 0x6f, 0x64, 0x65, 0x73, 0x5b, 0x2a, 0x5d, 0x2e, 0x70, 0x72, 0x69, 0x6d, 0x61, 0x72, 0x79, 0x2d, 0x61, 0x64, 0x64, 0x72, 0x65, 0x73, 0x73, 0x2e, 0x2a, 0x7d, 0x27}}
2019/06/05 08:16:59 decoding(2): 93 &ssh.windowAdjustMsg{PeersID:0x2, AdditionalBytes:0x200000} - 9 bytes
2019/06/05 08:16:59 decoding(2): 99 &ssh.channelRequestSuccessMsg{PeersID:0x2} - 5 bytes

>-------  EOF sent on channel (not by us; we have not closed the sesion yet!

2019/06/05 08:16:59 send(2): ssh.channelEOFMsg{PeersID:0x0}
2019/06/05 08:16:59 decoding(2): data packet - 181 bytes
2019/06/05 08:16:59 send(2): ssh.windowAdjustMsg{PeersID:0x0, AdditionalBytes:0xac}
2019/06/05 08:16:59 decoding(2): 96 &ssh.channelEOFMsg{PeersID:0x2} - 5 bytes
2019/06/05 08:16:59 decoding(2): 98 &ssh.channelRequestMsg{PeersID:0x2, Request:"exit-status", WantReply:false, RequestSpecificData:[]uint8{0x0, 0x0, 0x0, 0x0}} - 25 bytes
2019/06/05 08:16:59 decoding(2): 97 &ssh.channelCloseMsg{PeersID:0x2} - 5 bytes
2019/06/05 08:16:59 send(2): ssh.channelCloseMsg{PeersID:0x0}

>------- we try to close the session, and receive the following error

failed to close session: EOF
```

It appears that we cannot close the session, since an EOF has already been sent
for it. I am not exactly sure where this comes from. I've posted an issue /
question in the GitHub repository for golang:
https://github.com/golang/go/issues/32453 . Our attempts to send signals (SIGHUP
and SIGINT) are met by this same EOF error as well; there is no point on
waiting for the session to finish in this case, so just try to close it
and move on, and not leak goroutines that will be stuck forever. When running
`gops` now against the Gingko test suite, we no longer accrue a ton of these
goroutines blocked on `session.Wait()` - the biggest # of occcurrences for
"similar" goroutines is at most 2 in a stack trace captured below, for example:

```
$ ../contrib/scripts/consolidate_go_stacktrace.py stack9.out  | head -n 15
14 unique stack traces
2 occurences. Sample stack trace:
internal/poll.runtime_pollWait(0x3f14d50, 0x72, 0xc000a6cad0)
	/usr/local/go/src/runtime/netpoll.go:173 +0x66
internal/poll.(*pollDesc).wait(0xc00043c218, 0x72, 0xffffffffffffff00, 0x24e7ac0, 0x3225738)
	/usr/local/go/src/internal/poll/fd_poll_runtime.go:85 +0x9a
...
```

Signed-off by: Ian Vernon <ian@cilium.io>

EDIT: after I filed this PR, I saw a `v1.5` build that was stuck in the Cilium Preflight check stage. `v1.5` of course, does not have the changes in this PR

Build link: https://jenkins.cilium.io/job/Cilium-PR-Ginkgo-Tests-K8s/2167/ :

```
18:08:44  STEP: Testing connectivity when cilium is restoring using IPS without DNS
18:09:27  STEP: Performing Cilium preflight check
19:21:30  Sending interrupt signal to process
19:21:42  cleaning up VMs started for k8s tests
19:21:42  
19:21:42  ---------------------------------------------------------
19:21:42  Received interrupt.  Running AfterSuite...
19:21:42  ^C again to terminate immediately
19:21:42  
```

I decided to SSH onto the Jenkins node itself and get a stacktrace. I have eliminated some of the less interesting parts of the trace for brevity in the pasted output below, but have attached the full trace:



We appear to have a ton of SSH commands stuck running in `copyWait` - this is intriguing!
```
20 unique stack traces
2843 occurences. Sample stack trace:
github.com/cilium/cilium/test/helpers.copyWait.func1(0x17cce60, 0xc4201da7e0, 0x7f78a4c2c6d8, 0xc420428d80, 0xc42004f0e0)
	/home/jenkins/workspace/Cilium-PR-Ginkgo-Tests-K8s/1.13-gopath/src/github.com/cilium/cilium/test/helpers/ssh_command.go:144 +0x75
created by github.com/cilium/cilium/test/helpers.copyWait
	/home/jenkins/workspace/Cilium-PR-Ginkgo-Tests-K8s/1.13-gopath/src/github.com/cilium/cilium/test/helpers/ssh_command.go:142 +0x89
```

and a ton stuck in `session.Wait()` (expected, per the above explanation):
```
2048 occurences. Sample stack trace:
github.com/cilium/cilium/vendor/golang.org/x/crypto/ssh.(*Session).Wait(0xc420884090, 0x1678902, 0x12)
	/home/jenkins/workspace/Cilium-PR-Ginkgo-Tests-K8s/1.13-gopath/src/github.com/cilium/cilium/vendor/golang.org/x/crypto/ssh/session.go:403 +0x54
github.com/cilium/cilium/test/helpers.(*SSHClient).RunCommandContext.func1(0x17e9e80, 0xc420a222a0, 0x17d2420, 0xc420730440, 0xc420884090, 0xc4203fc500)
	/home/jenkins/workspace/Cilium-PR-Ginkgo-Tests-K8s/1.13-gopath/src/github.com/cilium/cilium/test/helpers/ssh_command.go:269 +0x126
created by github.com/cilium/cilium/test/helpers.(*SSHClient).RunCommandContext
	/home/jenkins/workspace/Cilium-PR-Ginkgo-Tests-K8s/1.13-gopath/src/github.com/cilium/cilium/test/helpers/ssh_command.go:262 +0x1ec
```

These are goroutines which are waiting to have their context canceled - why it isn't canceled, I'm not sure. Perhaps this is another bug :) : 

```
206 occurences. Sample stack trace:
github.com/cilium/cilium/test/helpers.(*SSHClient).RunCommandContext.func1(0x17e9e40, 0xc4200d0058, 0x17d2420, 0xc4215e99c0, 0xc420884090, 0xc4218feac0)
	/home/jenkins/workspace/Cilium-PR-Ginkgo-Tests-K8s/1.13-gopath/src/github.com/cilium/cilium/test/helpers/ssh_command.go:264 +0x2b8
created by github.com/cilium/cilium/test/helpers.(*SSHClient).RunCommandContext
	/home/jenkins/workspace/Cilium-PR-Ginkgo-Tests-K8s/1.13-gopath/src/github.com/cilium/cilium/test/helpers/ssh_command.go:262 +0x1ec
```

This is the `sync.WaitGroup` getting stuck on waiting for the session to be closed:
```
2 occurences. Sample stack trace:
sync.runtime_Semacquire(0xc4209f416c)
	/usr/local/go/src/runtime/sema.go:56 +0x39
sync.(*WaitGroup).Wait(0xc4209f4160)
	/usr/local/go/src/sync/waitgroup.go:129 +0x72
github.com/cilium/cilium/test/helpers.(*SSHClient).RunCommandContext(0xc4208484e0, 0x17e9e80, 0xc421550a20, 0xc421c37a38, 0x0, 0x0)
	/home/jenkins/workspace/Cilium-PR-Ginkgo-Tests-K8s/1.13-gopath/src/github.com/cilium/cilium/test/helpers/ssh_command.go:286 +0x259
github.com/cilium/cilium/test/helpers.(*SSHMeta).ExecuteContext(0xc420338410, 0x17e9e80, 0xc421550a20, 0xc421fc85a0, 0x48, 0x17cce60, 0xc4202f9b90, 0x17cce60, 0xc4202f9c00, 0xc423389bd0, ...)
	/home/jenkins/workspace/Cilium-PR-Ginkgo-Tests-K8s/1.13-gopath/src/github.com/cilium/cilium/test/helpers/node.go:138 +0x1e1
github.com/cilium/cilium/test/helpers.(*SSHMeta).ExecContext(0xc420338410, 0x17e9e80, 0xc421550a20, 0xc421fc85a0, 0x48, 0x0, 0x0, 0x0, 0xc42026a800)
	/home/jenkins/workspace/Cilium-PR-Ginkgo-Tests-K8s/1.13-gopath/src/github.com/cilium/cilium/test/helpers/node.go:175 +0x1bb
github.com/cilium/cilium/test/helpers.(*Kubectl).CiliumExecContext.func1(0x156c1a0)
	/home/jenkins/workspace/Cilium-PR-Ginkgo-Tests-K8s/1.13-gopath/src/github.com/cilium/cilium/test/helpers/kubectl.go:1193 +0x18a
github.com/cilium/cilium/test/helpers.(*Kubectl).CiliumExecContext(0xc420332e70, 0x17e9e80, 0xc421550a20, 0xc4200d228d, 0xc, 0x16884bb, 0x1c, 0x0)
	/home/jenkins/workspace/Cilium-PR-Ginkgo-Tests-K8s/1.13-gopath/src/github.com/cilium/cilium/test/helpers/kubectl.go:1202 +0xf4
github.com/cilium/cilium/test/helpers.(*Kubectl).CiliumEndpointsList(0xc420332e70, 0x17e9e80, 0xc421550a20, 0xc4200d228d, 0xc, 0xc4202f9a40)
	/home/jenkins/workspace/Cilium-PR-Ginkgo-Tests-K8s/1.13-gopath/src/github.com/cilium/cilium/test/helpers/kubectl.go:1045 +0x68
github.com/cilium/cilium/test/helpers.(*Kubectl).CiliumEndpointWaitReady.func1.1(0xc4200d228d, 0xc)
	/home/jenkins/workspace/Cilium-PR-Ginkgo-Tests-K8s/1.13-gopath/src/github.com/cilium/cilium/test/helpers/kubectl.go:1076 +0x174
created by github.com/cilium/cilium/test/helpers.(*Kubectl).CiliumEndpointWaitReady.func1
	/home/jenkins/workspace/Cilium-PR-Ginkgo-Tests-K8s/1.13-gopath/src/github.com/cilium/cilium/test/helpers/kubectl.go:1117 +0x14f
```

And I have no idea what this function is doing, but this looks like it needs some investigation:
```
1 occurences. Sample stack trace:
sync.runtime_Semacquire(0xc4222a3cdc)
	/usr/local/go/src/runtime/sema.go:56 +0x39
sync.(*WaitGroup).Wait(0xc4222a3cd0)
	/usr/local/go/src/sync/waitgroup.go:129 +0x72
github.com/cilium/cilium/test/helpers.(*Kubectl).CiliumEndpointWaitReady.func1(0x17e9e80, 0xc421550a20, 0x0, 0x0, 0x0)
	/home/jenkins/workspace/Cilium-PR-Ginkgo-Tests-K8s/1.13-gopath/src/github.com/cilium/cilium/test/helpers/kubectl.go:1120 +0x179
github.com/cilium/cilium/test/helpers.WithContext(0x17e9e80, 0xc421550a20, 0xc4205044b0, 0x3b9aca00, 0x0, 0x0)
	/home/jenkins/workspace/Cilium-PR-Ginkgo-Tests-K8s/1.13-gopath/src/github.com/cilium/cilium/test/helpers/utils.go:172 +0x171
github.com/cilium/cilium/test/helpers.(*Kubectl).CiliumEndpointWaitReady(0xc420332e70, 0x0, 0x0)
	/home/jenkins/workspace/Cilium-PR-Ginkgo-Tests-K8s/1.13-gopath/src/github.com/cilium/cilium/test/helpers/kubectl.go:1133 +0x17d
github.com/cilium/cilium/test/k8sT.glob..func12.9()
	/home/jenkins/workspace/Cilium-PR-Ginkgo-Tests-K8s/1.13-gopath/src/github.com/cilium/cilium/test/k8sT/fqdn.go:187 +0x754
reflect.Value.call(0x13fb1a0, 0xc4213b0780, 0x13, 0x1662aaa, 0x4, 0x223ea08, 0x0, 0x0, 0xc420544ab0, 0x0, ...)
	/usr/local/go/src/reflect/value.go:447 +0x969
reflect.Value.Call(0x13fb1a0, 0xc4213b0780, 0x13, 0x223ea08, 0x0, 0x0, 0x443a27, 0x0, 0x165cce0)
	/usr/local/go/src/reflect/value.go:308 +0xa4
github.com/cilium/cilium/test/ginkgo-ext.applyAdvice.func1(0x223ea08, 0x0, 0x0, 0x0, 0x0, 0x0)
	/home/jenkins/workspace/Cilium-PR-Ginkgo-Tests-K8s/1.13-gopath/src/github.com/cilium/cilium/test/ginkgo-ext/scopes.go:434 +0x90
reflect.callReflect(0xc42038f040, 0xc42034b1b8)
	/usr/local/go/src/reflect/value.go:528 +0x331
reflect.makeFuncStub(0xc400000020, 0x1723040, 0xc42034b1ef, 0xc4213b0a20, 0xc42034b210, 0xc42034b208, 0x4, 0xc42034b498, 0x812fee, 0xc4213b0a20, ...)
	/usr/local/go/src/reflect/asm_amd64.s:17 +0x33
github.com/cilium/cilium/vendor/github.com/onsi/ginkgo/internal/leafnodes.(*runner).runSync(0xc4213b0a20, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/home/jenkins/workspace/Cilium-PR-Ginkgo-Tests-K8s/1.13-gopath/src/github.com/cilium/cilium/vendor/github.com/onsi/ginkgo/internal/leafnodes/runner.go:113 +0x9c
github.com/cilium/cilium/vendor/github.com/onsi/ginkgo/internal/leafnodes.(*runner).run(0xc4213b0a20, 0x3, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/home/jenkins/workspace/Cilium-PR-Ginkgo-Tests-K8s/1.13-gopath/src/github.com/cilium/cilium/vendor/github.com/onsi/ginkgo/internal/leafnodes/runner.go:64 +0x13e
github.com/cilium/cilium/vendor/github.com/onsi/ginkgo/internal/leafnodes.(*ItNode).Run(0xc42038f1a0, 0x17cdb00, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/home/jenkins/workspace/Cilium-PR-Ginkgo-Tests-K8s/1.13-gopath/src/github.com/cilium/cilium/vendor/github.com/onsi/ginkgo/internal/leafnodes/it_node.go:26 +0x7f
github.com/cilium/cilium/vendor/github.com/onsi/ginkgo/internal/spec.(*Spec).runSample(0xc42083ab40, 0x0, 0x17cdb00, 0xc4200d9080)
	/home/jenkins/workspace/Cilium-PR-Ginkgo-Tests-K8s/1.13-gopath/src/github.com/cilium/cilium/vendor/github.com/onsi/ginkgo/internal/spec/spec.go:215 +0x648
github.com/cilium/cilium/vendor/github.com/onsi/ginkgo/internal/spec.(*Spec).Run(0xc42083ab40, 0x17cdb00, 0xc4200d9080)
	/home/jenkins/workspace/Cilium-PR-Ginkgo-Tests-K8s/1.13-gopath/src/github.com/cilium/cilium/vendor/github.com/onsi/ginkgo/internal/spec/spec.go:138 +0xff
github.com/cilium/cilium/vendor/github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).runSpec(0xc4202c6780, 0xc42083ab40, 0x0)
	/home/jenkins/workspace/Cilium-PR-Ginkgo-Tests-K8s/1.13-gopath/src/github.com/cilium/cilium/vendor/github.com/onsi/ginkgo/internal/specrunner/spec_runner.go:200 +0x10d
github.com/cilium/cilium/vendor/github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).runSpecs(0xc4202c6780, 0x1)
	/home/jenkins/workspace/Cilium-PR-Ginkgo-Tests-K8s/1.13-gopath/src/github.com/cilium/cilium/vendor/github.com/onsi/ginkgo/internal/specrunner/spec_runner.go:170 +0x329
github.com/cilium/cilium/vendor/github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).Run(0xc4202c6780, 0xe)
	/home/jenkins/workspace/Cilium-PR-Ginkgo-Tests-K8s/1.13-gopath/src/github.com/cilium/cilium/vendor/github.com/onsi/ginkgo/internal/specrunner/spec_runner.go:66 +0x11b
github.com/cilium/cilium/vendor/github.com/onsi/ginkgo/internal/suite.(*Suite).Run(0xc4200d6a00, 0x7f78a4cf18a0, 0xc42083a0f0, 0xc4203fd650, 0xe, 0xc42038fc80, 0x2, 0x2, 0x17eef40, 0xc4200d9080, ...)
	/home/jenkins/workspace/Cilium-PR-Ginkgo-Tests-K8s/1.13-gopath/src/github.com/cilium/cilium/vendor/github.com/onsi/ginkgo/internal/suite/suite.go:62 +0x27c
github.com/cilium/cilium/vendor/github.com/onsi/ginkgo.RunSpecsWithCustomReporters(0x17ce540, 0xc42083a0f0, 0xc4203fd650, 0xe, 0xc42038fbc0, 0x2, 0x2, 0x2)
	/home/jenkins/workspace/Cilium-PR-Ginkgo-Tests-K8s/1.13-gopath/src/github.com/cilium/cilium/vendor/github.com/onsi/ginkgo/ginkgo_dsl.go:221 +0x258
github.com/cilium/cilium/vendor/github.com/onsi/ginkgo.RunSpecsWithDefaultAndCustomReporters(0x17ce540, 0xc42083a0f0, 0xc4203fd650, 0xe, 0xc4204298a0, 0x1, 0x1, 0x4f8320)
	/home/jenkins/workspace/Cilium-PR-Ginkgo-Tests-K8s/1.13-gopath/src/github.com/cilium/cilium/vendor/github.com/onsi/ginkgo/ginkgo_dsl.go:209 +0xab
github.com/cilium/cilium/test.TestTest(0xc42083a0f0)
	/home/jenkins/workspace/Cilium-PR-Ginkgo-Tests-K8s/1.13-gopath/src/github.com/cilium/cilium/test/test_suite_test.go:101 +0x342
testing.tRunner(0xc42083a0f0, 0x1721628)
	/usr/local/go/src/testing/testing.go:777 +0xd0
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:824 +0x2e0
...
```

Full trace with common goroutines consolidated with a count of # of occurrences: [consolidated.txt](https://github.com/cilium/cilium/files/3258954/consolidated.txt)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8223)
<!-- Reviewable:end -->