### PR TITLE
endpoint: log when regenError is non-nil in Regenerate

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -470,6 +470,10 @@ func (e *Endpoint) Regenerate(owner Owner, regenMetadata *ExternalRegenerationMe
 				regenResult := result.(*EndpointRegenerationResult)
 				regenError = regenResult.err
 				buildSuccess = regenError == nil
+
+				if regenError != nil {
+					e.getLogger().WithError(regenError).Error("endpoint regeneration failed")
+				}
 			} else {
 				// This may be unnecessary(?) since 'closing' of the results
 				// channel means that event has been cancelled?


### PR DESCRIPTION
Otherwise, we don't have insight into why the endpoint failed to regenerate via
logs in case producers of the error do not log it.

Signed-off by: Ian Vernon <ian@cilium.io>

The motivation behind this is that an endpoint was in `not-ready` state in a PR ( https://github.com/cilium/cilium/pull/8223 ) but there are no logs indicating the cause of the failure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8224)
<!-- Reviewable:end -->
