### PR TITLE
endpoint: make sure `updateRegenerationStatistics` is called within anonymous function

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -253,7 +253,11 @@ func (e *Endpoint) regenerate(owner Owner, context *regenerationContext) (retErr
 		logfields.Reason:    context.Reason,
 	}).Debug("Regenerating endpoint")
 
-	defer e.updateRegenerationStatistics(context, retErr)
+	defer func() {
+		// This has to be within a func(), not deferred directly, so that the
+		// value of retErr is passed in from when regenerate returns.
+		e.updateRegenerationStatistics(context, retErr)
+	}()
 
 	e.BuildMutex.Lock()
 	defer e.BuildMutex.Unlock()


### PR DESCRIPTION
This ensures that the value of `retErr` that is passed into the function is the
value after `regenerate` returns, not the value at the time the function was
deferred, in which case it would be nil.

An example of this behavior when deferred directly:
https://play.golang.org/p/YRRm4VpiI92 (incorrect).

And when wrapped in an anonymous function: https://play.golang.org/p/NWxyhID5Eeg
(correct).

Signed-off by: Ian Vernon <ian@cilium.io>

Nominating for backport as this can effect how we log errors for endpoint regeneration, which may be critical to finding the root cause of issues that may occur in the future. The change is also well-contained.

Fixes: 96fc70f1196633ddaf6953bb2eede23f9833c652

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8225)
<!-- Reviewable:end -->
