### PR TITLE
Make clang available in builder image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ FROM quay.io/cilium/cilium-envoy:18ed0eab0eb161b21e25c50b8d360ba6507b9a4b as cil
 # versions to be built while allowing the new versions to make changes
 # that are not backwards compatible.
 #
-FROM quay.io/cilium/cilium-builder:2019-05-22 as builder
+FROM quay.io/cilium/cilium-builder:2019-06-05 as builder
 LABEL maintainer="maintainer@cilium.io"
 WORKDIR /go/src/github.com/cilium/cilium
 COPY . ./

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -45,7 +45,8 @@ RUN apt-get update \
 		zip \
 		zlib1g-dev \
 	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+  && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-7 100
 
 #
 # Install Go

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     command: "etcd -name etcd0 -advertise-client-urls http://0.0.0.0:4002 -listen-client-urls http://0.0.0.0:4002 -initial-cluster-token etcd-cluster-1 -initial-cluster-state new"
     privileged: true
   base_image:
-    image: "quay.io/cilium/cilium-builder:2019-05-22"
+    image: "quay.io/cilium/cilium-builder:2019-06-05"
     volumes:
       - "./../:/go/src/github.com/cilium/cilium/"
     privileged: true


### PR DESCRIPTION
Update the builder image to link `clang` to `clang-7`, so that it can be used in #8211 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8226)
<!-- Reviewable:end -->
