### PR TITLE
daemon: Configure Rlimits earlier

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -595,6 +595,10 @@ func (d *Daemon) initMaps() error {
 		return nil
 	}
 
+	if err := bpf.ConfigureResourceLimits(); err != nil {
+		log.WithError(err).Fatal("Unable to set memory resource limits")
+	}
+
 	if _, err := lxcmap.LXCMap.OpenOrCreate(); err != nil {
 		return err
 	}

--- a/pkg/bpf/bpf_linux.go
+++ b/pkg/bpf/bpf_linux.go
@@ -21,7 +21,6 @@ import "C"
 
 import (
 	"fmt"
-	"math"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -429,21 +428,8 @@ func OpenOrCreateMap(path string, mapType int, keySize, valueSize, maxEntries, f
 	redo := false
 	isNewMap := false
 
-	rl := unix.Rlimit{
-		Cur: math.MaxUint64,
-		Max: math.MaxUint64,
-	}
-
-	err := unix.Setrlimit(unix.RLIMIT_MEMLOCK, &rl)
-	if err != nil {
-		if os.IsPermission(err) {
-			log.Error("Unable to set RLimits, insufficient permissions")
-		}
-		return 0, isNewMap, fmt.Errorf("Unable to increase rlimit: %s", err)
-	}
-
 recreate:
-	if _, err = os.Stat(path); os.IsNotExist(err) || redo {
+	if _, err := os.Stat(path); os.IsNotExist(err) || redo {
 		mapDir := filepath.Dir(path)
 		if _, err = os.Stat(mapDir); os.IsNotExist(err) {
 			if err = os.MkdirAll(mapDir, 0755); err != nil {
@@ -487,7 +473,7 @@ recreate:
 		return fd, isNewMap, nil
 	}
 
-	fd, err = ObjGet(path)
+	fd, err := ObjGet(path)
 	if err == nil {
 		redo = objCheck(
 			fd,

--- a/pkg/bpf/map_linux_test.go
+++ b/pkg/bpf/map_linux_test.go
@@ -68,6 +68,9 @@ var (
 
 func runTests(m *testing.M) (int, error) {
 	CheckOrMountFS("")
+	if err := ConfigureResourceLimits(); err != nil {
+		return 1, fmt.Errorf("Failed to configure rlimit")
+	}
 
 	_, err := testMap.OpenOrCreate()
 	if err != nil {

--- a/pkg/bpf/rlimit_linux.go
+++ b/pkg/bpf/rlimit_linux.go
@@ -1,0 +1,30 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bpf
+
+import (
+	"math"
+
+	"golang.org/x/sys/unix"
+)
+
+// ConfigureResourceLimits configures the memory resource limits for the process to allow
+// BPF syscall interactions.
+func ConfigureResourceLimits() error {
+	return unix.Setrlimit(unix.RLIMIT_MEMLOCK, &unix.Rlimit{
+		Cur: math.MaxUint64,
+		Max: math.MaxUint64,
+	})
+}

--- a/pkg/datapath/linux/config_test.go
+++ b/pkg/datapath/linux/config_test.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/datapath/loader"
 	"github.com/cilium/cilium/pkg/node"
@@ -42,6 +43,8 @@ var (
 )
 
 func (s *DatapathSuite) SetUpTest(c *C) {
+	err := bpf.ConfigureResourceLimits()
+	c.Assert(err, IsNil)
 	node.InitDefaultPrefix("")
 	node.SetInternalIPv4(ipv4DummyAddr)
 	node.SetIPv4Loopback(ipv4DummyAddr)

--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,9 +22,10 @@ import (
 	"os"
 	"testing"
 
-	. "gopkg.in/check.v1"
+	"github.com/cilium/cilium/pkg/bpf"
 
 	"github.com/vishvananda/netlink"
+	. "gopkg.in/check.v1"
 )
 
 // Hook up gocheck into the "go test" runner.
@@ -40,6 +41,11 @@ var (
 	keysAeadDat    = []byte("6 rfc4106(gcm(aes)) 44434241343332312423222114131211f4f3f2f1 128\n")
 	invalidKeysDat = []byte("1 test abcdefghijklmnopqrstuvwzyzABCDEF test abcdefghijklmnopqrstuvwzyzABCDEF\n")
 )
+
+func (p *IPSecSuitePrivileged) SetUpTest(c *C) {
+	err := bpf.ConfigureResourceLimits()
+	c.Assert(err, IsNil)
+}
 
 func (p *IPSecSuitePrivileged) TestLoadKeysNoFile(c *C) {
 	_, _, err := LoadIPSecKeysFile(path)

--- a/pkg/datapath/loader/loader_test.go
+++ b/pkg/datapath/loader/loader_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/datapath/linux"
 	"github.com/cilium/cilium/pkg/elf"
 	bpfconfig "github.com/cilium/cilium/pkg/maps/configmap"
@@ -64,8 +65,10 @@ func (s *LoaderTestSuite) SetUpSuite(c *C) {
 		fmt.Sprintf("-I%s", filepath.Join(bpfDir, "include")),
 	})
 
+	err := bpf.ConfigureResourceLimits()
+	c.Assert(err, IsNil)
 	sourceFile := filepath.Join(bpfDir, endpointProg)
-	err := os.Symlink(sourceFile, endpointProg)
+	err = os.Symlink(sourceFile, endpointProg)
 	c.Assert(err, IsNil)
 }
 

--- a/pkg/maps/eppolicymap/eppolicymap_test.go
+++ b/pkg/maps/eppolicymap/eppolicymap_test.go
@@ -42,6 +42,8 @@ var _ = Suite(&EPPolicyMapTestSuite{})
 func (e *EPPolicyMapTestSuite) SetUpTest(c *C) {
 	MapName = "unit_test_ep_to_policy"
 	innerMapName = "unit_test_ep_policy_inner_map"
+	err := bpf.ConfigureResourceLimits()
+	c.Assert(err, IsNil)
 }
 
 func (e *EPPolicyMapTestSuite) TearDownTest(c *C) {


### PR DESCRIPTION
Resource limits are associated with the process, so initialize them
during daemon startup rather than during map creation events.
This will assist in refactoring the `pkg/bpf` library for better sharing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8227)
<!-- Reviewable:end -->
