### PR TITLE
test: have timeout for `Exec`

### DIFF
--- a/test/helpers/node.go
+++ b/test/helpers/node.go
@@ -158,10 +158,9 @@ type ExecOptions struct {
 
 // Exec returns the results of executing the provided cmd via SSH.
 func (s *SSHMeta) Exec(cmd string, options ...ExecOptions) *CmdRes {
-	// Since we have no timeout, ensure that the context given to ExecContext
-	// eventually cancels in case something is blocked on ctx.Done() (something
-	// is).
-	ctx, cancel := context.WithCancel(context.TODO())
+	// Bound all command executions to be at most the timeout used by the CI
+	// so that commands do not block forever.
+	ctx, cancel := context.WithTimeout(context.Background(), HelperTimeout)
 	defer cancel()
 	return s.ExecContext(ctx, cmd, options...)
 }


### PR DESCRIPTION
Otherwise, cases which cause subsequent child function calls to
get stuck upon receiving from `ctx.Done()` will never be called,
as the previously provided context was never canceled on timeout. Bounding all
executions to take at most four minutes is a reasonable expectation
for our CI.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8228)
<!-- Reviewable:end -->
