### PR TITLE
test: add serial ports to CI VMs

### DIFF
--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -73,6 +73,9 @@ Vagrant.configure("2") do |config|
                 vb.default_nic_type = "virtio"
                 # Prevent VirtualBox from interfering with host audio stack
                 vb.customize ["modifyvm", :id, "--audio", "none"]
+                # Use serial ports if the VM is no longer accessible via SSH
+                vb.customize ["modifyvm", :id, "--uart1", "0x3F8", "4"]
+                vb.customize ["modifyvm", :id, "--uartmode1", "server", "k8s#{i}-#{$K8S_VERSION}-ttyS0.sock"]
             end
 
             server.vm.box =  "#{$SERVER_BOX}"

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -41,6 +41,16 @@ source ${PROVISIONSRC}/helpers.bash
 sudo bash -c "echo MaxSessions 200 >> /etc/ssh/sshd_config"
 sudo systemctl restart ssh
 
+# Install serial ttyS0 server
+cat <<EOF > /etc/systemd/system/serial-getty@ttyS0.service
+[Service]
+ExecStart=
+ExecStart=/sbin/agetty --autologin root -8 --keep-baud 115200,38400,9600 ttyS0 \$TERM
+EOF
+
+systemctl daemon-reload
+sudo service serial-getty@ttyS0 start
+
 # TODO: Check if the k8s version is the same
 if [[ -f  "/etc/provision_finished" ]]; then
     sudo dpkg -l | grep kubelet


### PR DESCRIPTION
This will allow us to connect to a VM that is not rechable via SSH so we
can debug what was wrong with the VM.

To access the VM can be done with:

```
socat -d -d ./k8s1-1.14-ttyS0.sock PTY
screen /dev/pts/1 115200
```

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8232)
<!-- Reviewable:end -->
