### PR TITLE
*.Jenkinsfile: remove leftover failFast

### DIFF
--- a/ginkgo-kubernetes-all.Jenkinsfile
+++ b/ginkgo-kubernetes-all.Jenkinsfile
@@ -139,7 +139,6 @@ pipeline {
             options {
                 timeout(time: 100, unit: 'MINUTES')
             }
-            failFast true
             parallel {
                 stage('BDD-Test-k8s-1.11') {
                     environment {
@@ -259,7 +258,6 @@ pipeline {
             options {
                 timeout(time: 100, unit: 'MINUTES')
             }
-            failFast true
             parallel {
                 stage('BDD-Test-k8s-1.13') {
                     environment {

--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -158,7 +158,6 @@ pipeline {
                 FAILFAST=setIfLabel("ci/fail-fast", "true", "false")
                 CONTAINER_RUNTIME=setIfLabel("area/containerd", "containerd", "docker")
             }
-            failFast true
             parallel {
                 stage('BDD-Test-PR-runtime') {
                     environment {


### PR DESCRIPTION
Fixes: 166d9c2333c0 ("Separate envs for tests in jenkins k8s pipeline")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8235)
<!-- Reviewable:end -->
