### PR TITLE
Add benchmarks for endpoint headerfile write

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -76,7 +76,7 @@ func (e *Endpoint) BPFIpvlanMapPath() string {
 // strings describing the configuration of the datapath.
 //
 // For configuration of actual datapath behavior, see WriteEndpointConfig().
-func (e *Endpoint) writeInformationalComments(w io.Writer, owner Owner) error {
+func (e *Endpoint) writeInformationalComments(w io.Writer) error {
 	fw := bufio.NewWriter(w)
 
 	fmt.Fprint(fw, "/*\n")
@@ -140,7 +140,7 @@ func (e *Endpoint) writeHeaderfile(prefix string, owner Owner) error {
 	}
 	defer f.Close()
 
-	if err = e.writeInformationalComments(f, owner); err != nil {
+	if err = e.writeInformationalComments(f); err != nil {
 		return err
 	}
 	return owner.Datapath().WriteEndpointConfig(f, e)

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 	"path/filepath"
 	"time"
 
@@ -109,7 +108,7 @@ func (e *Endpoint) writeInformationalComments(w io.Writer) error {
 		" * NodeMAC: %s\n"+
 		" */\n\n",
 		e.IPv6.String(), e.IPv4.String(),
-		e.GetIdentity(), path.Base(e.PolicyMapPathLocked()),
+		e.GetIdentity(), bpf.LocalMapName(policymap.MapName, e.ID),
 		e.NodeMAC)
 
 	fw.WriteString("/*\n")

--- a/pkg/endpoint/bpf_test.go
+++ b/pkg/endpoint/bpf_test.go
@@ -1,0 +1,80 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package endpoint
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"testing"
+
+	"github.com/cilium/cilium/pkg/datapath/linux"
+	"github.com/cilium/cilium/pkg/policy"
+
+	. "gopkg.in/check.v1"
+)
+
+func (s *EndpointSuite) TestWriteInformationalComments(c *C) {
+	e := NewEndpointWithState(s.repo, 100, StateCreating)
+
+	var f bytes.Buffer
+	err := e.writeInformationalComments(&f)
+	c.Assert(err, IsNil)
+}
+
+type writeFunc func(io.Writer) error
+
+func BenchmarkWriteHeaderfile(b *testing.B) {
+	repo := policy.NewPolicyRepository()
+	e := NewEndpointWithState(repo, 100, StateCreating)
+	dp := linux.NewDatapath(linux.DatapathConfiguration{})
+
+	targetComments := func(w io.Writer) error {
+		return e.writeInformationalComments(w)
+	}
+	targetConfig := func(w io.Writer) error {
+		return dp.WriteEndpointConfig(w, e)
+	}
+
+	var buf bytes.Buffer
+	file, err := ioutil.TempFile("", "cilium_ep_bench_")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer file.Close()
+
+	benchmarks := []struct {
+		name   string
+		output io.Writer
+		write  writeFunc
+	}{
+		{"in-memory-info", &buf, targetComments},
+		{"in-memory-cfg", &buf, targetConfig},
+		{"to-disk-info", file, targetComments},
+		{"to-disk-cfg", file, targetConfig},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				if err := bm.write(bm.output); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add some basic testing/benchmarks for writing of the endpoint headerfile. Unlike the real write in runtime environments, these only write into memory rather than the filesystem.

```
$ make bench TESTPKGS=pkg/endpoint
can't load package: package github.com/cilium/cilium/test/bpf: C source files not allowed when not using cgo or SWIG: bpf-event-test.c elf-demo.c unit-test.c
Starting key-value store containers...
a8a55ad236995b7b9b2591e04404eaf83ffc3a25aec0e5a47a85661871e35ae9
ef0361cd42b30a504183c1936bb2a83300015dc2c5b0f9b0a83dd3c9c96d6c21
goos: linux
goarch: amd64
pkg: github.com/cilium/cilium/pkg/endpoint
BenchmarkWriteInformationalComments-4              50000             25666 ns/op
BenchmarkWriteEndpointConfig-4                    200000             12052 ns/op
PASS
ok      github.com/cilium/cilium/pkg/endpoint   4.287s
can't load package: package github.com/cilium/cilium/test/bpf: C source files not allowed when not using cgo or SWIG: bpf-event-test.c elf-demo.c unit-test.c
cilium-etcd-test-container
cilium-consul-test-container
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8239)
<!-- Reviewable:end -->
