### PR TITLE
docs: Fix architecture images URLs

### DIFF
--- a/Documentation/architecture.rst
+++ b/Documentation/architecture.rst
@@ -138,7 +138,6 @@ is ESTABLISHED. Then after the connection is ESTABLISHED only the L7 Policy
 object is still required.
 
 .. image:: _static/cilium_bpf_endpoint.svg
-   :target: _static/cilium_bpf_endpoint.svg
 
 Egress from Endpoint
 --------------------
@@ -151,7 +150,6 @@ and a L7 proxy is in use we can avoid running the endpoint policy block between
 the endpoint and the L7 Policy for TCP traffic.
 
 .. image:: _static/cilium_bpf_egress.svg
-   :target: _static/cilium_bpf_egress.svg
 
 Ingress to Endpoint
 -------------------
@@ -161,7 +159,6 @@ Similar to above socket layer enforcement can be used to avoid a set of
 policy traversals between the proxy and the endpoint socket.
 
 .. image:: _static/cilium_bpf_ingress.svg
-   :target: _static/cilium_bpf_ingress.svg
 
 veth-based versus ipvlan-based datapath
 ---------------------------------------
@@ -252,4 +249,3 @@ The following diagram shows the integration of iptables rules as installed by
 kube-proxy and the iptables rules as installed by Cilium.
 
 .. image:: _static/kubernetes_iptables.svg
-   :target: _static/kubernetes_iptables.svg


### PR DESCRIPTION
Several attempts to fix these URL targets have been made, and none of
them seem to work in all setups (eg, RTD, the render-docs container,
etc). Since we can't seem to figure out a good way to fix the link, just
remove the target link. Users can right click and open the URL to view
the image in a larger size.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8242)
<!-- Reviewable:end -->
