### PR TITLE
Recognize all local addresses

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -58,6 +58,7 @@ cilium-agent [flags]
       --endpoint-interface-name-prefix string      Prefix of interface name shared by all endpoints (default "lxc+")
       --endpoint-queue-size int                    size of EventQueue per-endpoint (default 25)
       --envoy-log string                           Path to a separate Envoy log file, if any
+      --exclude-local-address strings              Exclude CIDR from being recognized as local address
       --fixed-identity-mapping map                 Key-value for the fixed identity mapping which allows to use reserved label for fixed identities (default map[])
       --flannel-manage-existing-containers         Installs a BPF program to allow for policy enforcement in already running containers managed by Flannel. Require Cilium to be running in the hostPID.
       --flannel-master-device string               Installs a BPF program to allow for policy enforcement in the given network interface. Allows to run Cilium on top of other CNI plugins that provide networking, e.g. flannel, where for flannel, this value should be set with 'cni0'. [EXPERIMENTAL]

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -726,7 +726,7 @@ func (d *Daemon) init() error {
 				DoFunc: func(ctx context.Context) error {
 					return d.syncEndpointsAndHostIPs()
 				},
-				RunInterval: 5 * time.Second,
+				RunInterval: time.Minute,
 			})
 	}
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1231,6 +1231,15 @@ func (d *Daemon) allocateIPs() error {
 		log.Infof("  IPv6 node prefix: %s", node.GetIPv6NodeRange())
 		log.Infof("  IPv6 allocation prefix: %s", node.GetIPv6AllocRange())
 		log.Infof("  IPv6 router address: %s", node.GetIPv6Router())
+
+		if addrs, err := d.datapath.LocalNodeAddressing().IPv6().LocalAddresses(); err != nil {
+			log.WithError(err).Fatal("Unable to list local IPv6 addresses")
+		} else {
+			log.Info("  Local IPv6 addresses:")
+			for _, ip := range addrs {
+				log.Infof("  - %s", ip)
+			}
+		}
 	}
 
 	log.Infof("  External-Node IPv4: %s", node.GetExternalIPv4())
@@ -1247,6 +1256,15 @@ func (d *Daemon) allocateIPs() error {
 		}
 		node.SetIPv4Loopback(loopbackIPv4)
 		log.Infof("  Loopback IPv4: %s", node.GetIPv4Loopback().String())
+
+		if addrs, err := d.datapath.LocalNodeAddressing().IPv4().LocalAddresses(); err != nil {
+			log.WithError(err).Fatal("Unable to list local IPv4 addresses")
+		} else {
+			log.Info("  Local IPv4 addresses:")
+			for _, ip := range addrs {
+				log.Infof("  - %s", ip)
+			}
+		}
 	}
 	bootstrapStats.ipam.End(true)
 	return d.allocateHealthIPs()

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -849,6 +849,8 @@ func (d *Daemon) syncEndpointsAndHostIPs() error {
 			} else {
 				log.Debugf("Removed outdated host ip %s from endpoint map", hostIP)
 			}
+
+			ipcache.IPIdentityCache.Delete(hostIP, ipcache.FromAgentLocal)
 		}
 	}
 

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -454,6 +454,9 @@ func init() {
 	flags.String(option.EndpointInterfaceNamePrefix, defaults.EndpointInterfaceNamePrefix, "Prefix of interface name shared by all endpoints")
 	option.BindEnv(option.EndpointInterfaceNamePrefix)
 
+	flags.StringSlice(option.ExcludeLocalAddress, []string{}, "Exclude CIDR from being recognized as local address")
+	option.BindEnv(option.ExcludeLocalAddress)
+
 	flags.Bool(option.DisableCiliumEndpointCRDName, false, "Disable use of CiliumEndpoint CRD")
 	option.BindEnv(option.DisableCiliumEndpointCRDName)
 

--- a/pkg/datapath/fake/datapath_test.go
+++ b/pkg/datapath/fake/datapath_test.go
@@ -45,4 +45,11 @@ func (s *fakeTestSuite) TestNewDatapath(c *check.C) {
 	c.Assert(dp.LocalNodeAddressing().IPv6().Router(), check.Not(check.IsNil))
 	c.Assert(dp.LocalNodeAddressing().IPv4().Router(), check.Not(check.IsNil))
 	c.Assert(dp.LocalNodeAddressing().IPv4().AllocationCIDR(), check.Not(check.IsNil))
+
+	list, err := dp.LocalNodeAddressing().IPv4().LocalAddresses()
+	c.Assert(len(list), check.Not(check.Equals), 0)
+	c.Assert(err, check.IsNil)
+	list, err = dp.LocalNodeAddressing().IPv6().LocalAddresses()
+	c.Assert(len(list), check.Not(check.Equals), 0)
+	c.Assert(err, check.IsNil)
 }

--- a/pkg/datapath/fake/node_addressing.go
+++ b/pkg/datapath/fake/node_addressing.go
@@ -59,11 +59,21 @@ func NewNodeAddressing() datapath.NodeAddressing {
 			router:          net.ParseIP("1.1.1.2"),
 			primaryExternal: net.ParseIP("1.1.1.1"),
 			allocCIDR:       cidr.MustParseCIDR("1.1.1.0/24"),
+			localAddresses: []net.IP{
+				net.ParseIP("2.2.2.2"),
+				net.ParseIP("3.3.3.3"),
+				net.ParseIP("4.4.4.4"),
+			},
 		},
 		ipv6: addressFamily{
 			router:          net.ParseIP("cafe::2"),
 			primaryExternal: net.ParseIP("cafe::1"),
 			allocCIDR:       cidr.MustParseCIDR("cafe::/96"),
+			localAddresses: []net.IP{
+				net.ParseIP("f00d::1"),
+				net.ParseIP("f00d::2"),
+				net.ParseIP("f00d::3"),
+			},
 		},
 	}
 }
@@ -72,6 +82,7 @@ type addressFamily struct {
 	router          net.IP
 	primaryExternal net.IP
 	allocCIDR       *cidr.CIDR
+	localAddresses  []net.IP
 }
 
 func (a *addressFamily) Router() net.IP {
@@ -84,6 +95,10 @@ func (a *addressFamily) PrimaryExternal() net.IP {
 
 func (a *addressFamily) AllocationCIDR() *cidr.CIDR {
 	return a.allocCIDR
+}
+
+func (a *addressFamily) LocalAddresses() ([]net.IP, error) {
+	return a.localAddresses, nil
 }
 
 func (n *fakeNodeAddressing) IPv6() datapath.NodeAddressingFamily {

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -35,25 +35,23 @@ import (
 )
 
 const (
-	ciliumOutputChain      = "CILIUM_OUTPUT"
-	ciliumOutputRawChain   = "CILIUM_OUTPUT_raw"
-	ciliumPostNatChain     = "CILIUM_POST"
-	ciliumPostNatKubeChain = "CILIUM_POST_KUBE"
-	ciliumPostMangleChain  = "CILIUM_POST_mangle"
-	ciliumPreMangleChain   = "CILIUM_PRE_mangle"
-	ciliumPreRawChain      = "CILIUM_PRE_raw"
-	ciliumForwardChain     = "CILIUM_FORWARD"
-	feederDescription      = "cilium-feeder:"
-	xfrmDescription        = "cilium-xfrm-notrack:"
+	ciliumOutputChain     = "CILIUM_OUTPUT"
+	ciliumOutputRawChain  = "CILIUM_OUTPUT_raw"
+	ciliumPostNatChain    = "CILIUM_POST"
+	ciliumPostMangleChain = "CILIUM_POST_mangle"
+	ciliumPreMangleChain  = "CILIUM_PRE_mangle"
+	ciliumPreRawChain     = "CILIUM_PRE_raw"
+	ciliumForwardChain    = "CILIUM_FORWARD"
+	feederDescription     = "cilium-feeder:"
+	xfrmDescription       = "cilium-xfrm-notrack:"
 )
 
 type customChain struct {
-	name        string
-	table       string
-	hook        string
-	feederArgs  []string
-	ipv6        bool // ip6tables chain in addition to iptables chain
-	appendFixed bool
+	name       string
+	table      string
+	hook       string
+	feederArgs []string
+	ipv6       bool // ip6tables chain in addition to iptables chain
 }
 
 func runProg(prog string, args []string, quiet bool) error {
@@ -159,7 +157,7 @@ func (c *customChain) remove() {
 
 func (c *customChain) installFeeder() error {
 	installMode := "-A"
-	if option.Config.PrependIptablesChains && !c.appendFixed {
+	if option.Config.PrependIptablesChains {
 		installMode = "-I"
 	}
 
@@ -205,14 +203,6 @@ var ciliumChains = []customChain{
 		table:      "nat",
 		hook:       "POSTROUTING",
 		feederArgs: []string{""},
-	},
-	{
-		name:        ciliumPostNatKubeChain,
-		table:       "nat",
-		hook:        "POSTROUTING",
-		feederArgs:  []string{""},
-		ipv6:        true,
-		appendFixed: true,
 	},
 	{
 		name:       ciliumPostMangleChain,
@@ -285,7 +275,7 @@ func (m *IptablesManager) RemoveRules() {
 
 	// Set of tables that have had ip6tables rules in any Cilium version
 	if m.ip6tables {
-		tables6 := []string{"nat", "mangle", "raw"}
+		tables6 := []string{"mangle", "raw"}
 		for _, t := range tables6 {
 			removeCiliumRules(t, "ip6tables")
 		}
@@ -529,39 +519,6 @@ func (m *IptablesManager) InstallRules(ifName string) error {
 			"-m", "comment", "--comment", "cilium: cluster->any forward accept",
 			"-j", "ACCEPT"}, false); err != nil {
 			return err
-		}
-
-		// For communication from host to local services via k8s cluster IP
-		// we need to fix up wrong source address selection. Linux routing
-		// will initially select a source address based on the service IP and
-		// after Kubernetes iptables rules selected a local backend, we still
-		// retain the original source address (and not the one on cilium_host).
-		// As a result, ipcache will assign a WORLD identity (via catch-all 0/0)
-		// as opposed to a HOST identity and therefore policy is dropping the
-		// skb. As there is no fixup by iptables, we need to SNAT for these
-		// cases. This rule here must come after all Kubernetes post-routing
-		// chains, so we can match on our endpoint allocation range.
-		if option.Config.EnableIPv4 {
-			if err := runProg("iptables", []string{
-				"-t", "nat",
-				"-A", ciliumPostNatKubeChain,
-				"-d", node.GetIPv4AllocRange().String(),
-				"-o", ifName,
-				"-m", "comment", "--comment", "cilium: host->service(cluster ip)->local-endpoint on " + ifName + " src address fix",
-				"-j", "SNAT", "--to-source", node.GetHostMasqueradeIPv4().String()}, false); err != nil {
-				return err
-			}
-		}
-		if option.Config.EnableIPv6 {
-			if err := runProg("ip6tables", []string{
-				"-t", "nat",
-				"-A", ciliumPostNatKubeChain,
-				"-d", node.GetIPv6AllocRange().String(),
-				"-o", ifName,
-				"-m", "comment", "--comment", "cilium: host->service(cluster ip)->local-endpoint on " + ifName + " src address fix",
-				"-j", "SNAT", "--to-source", node.GetIPv6().String()}, false); err != nil {
-				return err
-			}
 		}
 
 		// Mark all packets sourced from processes running on the host with a

--- a/pkg/datapath/node_addressing.go
+++ b/pkg/datapath/node_addressing.go
@@ -35,6 +35,9 @@ type NodeAddressingFamily interface {
 	// AllocationCIDR is the CIDR used for IP allocation of all endpoints
 	// on the node
 	AllocationCIDR() *cidr.CIDR
+
+	// LocalAddresses lists all local addresses
+	LocalAddresses() ([]net.IP, error)
 }
 
 // NodeAddressing implements addressing of a node

--- a/pkg/option/config_test.go
+++ b/pkg/option/config_test.go
@@ -19,6 +19,7 @@ package option
 import (
 	"fmt"
 	"io/ioutil"
+	"net"
 	"os"
 	"path/filepath"
 	"testing"
@@ -236,4 +237,16 @@ func (s *OptionSuite) TestBindEnv(c *C) {
 	c.Assert(viper.GetString(optName2), Equals, "legacy")
 
 	viper.Reset()
+}
+
+func (s *OptionSuite) TestLocalAddressExclusion(c *C) {
+	d := &DaemonConfig{}
+	err := d.parseExcludedLocalAddresses([]string{"1.1.1.1/32", "3.3.3.0/24", "f00d::1/128"})
+	c.Assert(err, IsNil)
+
+	c.Assert(d.IsExcludedLocalAddress(net.ParseIP("1.1.1.1")), Equals, true)
+	c.Assert(d.IsExcludedLocalAddress(net.ParseIP("1.1.1.2")), Equals, false)
+	c.Assert(d.IsExcludedLocalAddress(net.ParseIP("3.3.3.1")), Equals, true)
+	c.Assert(d.IsExcludedLocalAddress(net.ParseIP("f00d::1")), Equals, true)
+	c.Assert(d.IsExcludedLocalAddress(net.ParseIP("f00d::2")), Equals, false)
 }

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -980,6 +980,10 @@ func (s *SSHMeta) SetUpCilium() error {
 // SetUpCiliumWithOptions sets up Cilium as a systemd service with a given set of options. It
 // returns an error if any of the operations needed to start Cilium fail.
 func (s *SSHMeta) SetUpCiliumWithOptions(ciliumOpts string) error {
+	ciliumOpts += " --exclude-local-address=" + DockerBridgeIP + "/32"
+	ciliumOpts += " --exclude-local-address=" + FakeIPv4WorldAddress + "/32"
+	ciliumOpts += " --exclude-local-address=" + FakeIPv6WorldAddress + "/128"
+
 	systemdTemplate := `
 PATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
 CILIUM_OPTS=--kvstore consul --kvstore-opt consul.address=127.0.0.1:8500 --debug --pprof=true --log-system-load %s

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -185,11 +185,13 @@ const (
 	// the test are saved.
 	CiliumTestLog = "cilium-test.log"
 
-	// IPv4Host is an IP which is used in some datapath tests for simulating external IPv4 connectivity.
-	IPv4Host = "192.168.254.254"
+	// FakeIPv4WorldAddress is an IP which is used in some datapath tests
+	// for simulating external IPv4 connectivity.
+	FakeIPv4WorldAddress = "192.168.254.254"
 
-	// IPv6Host is an IP which is used in some datapath tests for simulating external IPv6 connectivity.
-	IPv6Host = "fdff::ff"
+	// FakeIPv6WorldAddress is an IP which is used in some datapath tests
+	// for simulating external IPv6 connectivity.
+	FakeIPv6WorldAddress = "fdff::ff"
 
 	// Logs messages that should not be in the cilium logs.
 	panicMessage      = "panic:"

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -193,6 +193,9 @@ const (
 	// for simulating external IPv6 connectivity.
 	FakeIPv6WorldAddress = "fdff::ff"
 
+	// DockerBridgeIP is the IP on the docker0 bridge
+	DockerBridgeIP = "172.17.0.1"
+
 	// Logs messages that should not be in the cilium logs.
 	panicMessage      = "panic:"
 	deadLockHeader    = "POTENTIAL DEADLOCK:"       // from github.com/sasha-s/go-deadlock/deadlock.go:header

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -1355,7 +1355,7 @@ var _ = Describe("RuntimePolicies", func() {
 			Expect(err).NotTo(HaveOccurred(), "Error occurred while finding docker bridge IP")
 			Expect(obj).To(HaveLen(1), "Unexpectedly found more than one IPAM config element for docker bridge")
 			otherHostIP = obj[0].Interface().(string)
-			Expect(otherHostIP).Should(MatchRegexp("^[.:0-9a-f][.:0-9a-f]*$"), "docker bridge IP is in unexpected format")
+			Expect(otherHostIP).To(Equal(helpers.DockerBridgeIP), "Please adjust value of DockerBridgeIP")
 			By("Using %q for world CIDR IP", otherHostIP)
 		})
 


### PR DESCRIPTION
This extends the agent to automatically recognize all local addresses instead of just the ones known to Kubernetes. This has several benefits:

* The host identity now covers all local processes, regardless of the source path selection
* Ability to revert the SNAT changes to support local processes talking to service IPs which can cause source IP selection to map to an unknown local address
* Simplification of node to node traffic encryption

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8243)
<!-- Reviewable:end -->
