### PR TITLE
Makefiles: Fix find for non-existing directories

### DIFF
--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -9,7 +9,7 @@ include ../Makefile.defs
 
 TARGET=cilium-agent
 LINKS=cilium-node-monitor cilium
-SOURCES := $(shell find ../api ../common ../daemon ../pkg ../monitor . \( -name '*.go'  ! -name '*_test.go' \))
+SOURCES := $(shell find ../api ../common ../daemon ../pkg . \( -name '*.go'  ! -name '*_test.go' \))
 $(TARGET): $(SOURCES) check-bindata
 	@$(ECHO_GO)
 	$(QUIET)$(GO) build $(GOBUILD) -o $(TARGET)

--- a/tools/alignchecker/Makefile
+++ b/tools/alignchecker/Makefile
@@ -1,7 +1,7 @@
 include ../../Makefile.defs
 
 TARGET=cilium-align-checker
-SOURCES := $(shell find ../../pkg/bpf cmd . \( -name '*.go' ! -name '*_test.go' \))
+SOURCES := $(shell find ../../pkg/bpf . \( -name '*.go' ! -name '*_test.go' \))
 $(TARGET): $(SOURCES)
 	@$(ECHO_GO)
 	$(QUIET)$(GO) build $(GOBUILD) -o $(TARGET)


### PR DESCRIPTION
These find commands were searching directories that don't exist. Fix
them up to quieten some warnings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8245)
<!-- Reviewable:end -->
