### PR TITLE
test: bump k8s 1.13 to 1.13.7

### DIFF
--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -194,7 +194,7 @@ case $K8S_VERSION in
         ;;
     "1.13")
         KUBERNETES_CNI_VERSION="0.7.5"
-        K8S_FULL_VERSION="1.13.6"
+        K8S_FULL_VERSION="1.13.7"
         KUBEADM_OPTIONS="--ignore-preflight-errors=cri,SystemVerification"
         KUBEADM_SLAVE_OPTIONS="--discovery-token-unsafe-skip-ca-verification --ignore-preflight-errors=cri,SystemVerification"
         sudo ln -sf $COREDNS_DEPLOYMENT $DNS_DEPLOYMENT


### PR DESCRIPTION
Signed-off-by: André Martins <andre@cilium.io>

```release-note
add support to k8s 1.13.7
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8249)
<!-- Reviewable:end -->
