### PR TITLE
docs: Add BPF section about invalidated references to skb->data

### DIFF
--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -123,6 +123,7 @@ decapsulation
 deletetopic
 demux
 dep
+dereference
 deserialization
 dev
 devel


### PR DESCRIPTION
This PR adds a section to common pitfalls about accessing `skb->data` via a reference which gets invalidated by the BPF verifier after `skb->data` has been changed with a helper function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8250)
<!-- Reviewable:end -->
