### PR TITLE
Run log periodic system load on debug mode only

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -483,10 +483,12 @@ func (e *Endpoint) realizeBPFState(regenContext *regenerationContext) (compilati
 	e.getLogger().WithField(fieldRegenLevel, datapathRegenCtxt.regenerationLevel).Debug("Preparing to compile BPF")
 
 	if datapathRegenCtxt.regenerationLevel > RegenerateWithoutDatapath {
-		debugFunc := log.WithFields(logrus.Fields{logfields.EndpointID: e.StringID()}).Debugf
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-		loadinfo.LogPeriodicSystemLoad(ctx, debugFunc, time.Second)
+		if e.Options.IsEnabled(option.Debug) {
+			debugFunc := log.WithFields(logrus.Fields{logfields.EndpointID: e.StringID()}).Debugf
+			ctx, cancel := context.WithCancel(regenContext.parentContext)
+			defer cancel()
+			loadinfo.LogPeriodicSystemLoad(ctx, debugFunc, time.Second)
+		}
 
 		// Compile and install BPF programs for this endpoint
 		if datapathRegenCtxt.regenerationLevel == RegenerateWithDatapathRebuild {


### PR DESCRIPTION
`LogPeriodicSystemLoad` was being called even if the endpoint was not running in debug mode which was causing a lot of unnecessary memory allocations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8251)
<!-- Reviewable:end -->
