### PR TITLE
v1.5 backports 2019-06-07

### DIFF
--- a/Documentation/architecture.rst
+++ b/Documentation/architecture.rst
@@ -138,7 +138,6 @@ is ESTABLISHED. Then after the connection is ESTABLISHED only the L7 Policy
 object is still required.
 
 .. image:: _static/cilium_bpf_endpoint.svg
-   :target: _static/cilium_bpf_endpoint.svg
 
 Egress from Endpoint
 --------------------
@@ -151,7 +150,6 @@ and a L7 proxy is in use we can avoid running the endpoint policy block between
 the endpoint and the L7 Policy for TCP traffic.
 
 .. image:: _static/cilium_bpf_egress.svg
-   :target: _static/cilium_bpf_egress.svg
 
 Ingress to Endpoint
 -------------------
@@ -161,7 +159,6 @@ Similar to above socket layer enforcement can be used to avoid a set of
 policy traversals between the proxy and the endpoint socket.
 
 .. image:: _static/cilium_bpf_ingress.svg
-   :target: _static/cilium_bpf_ingress.svg
 
 veth-based versus ipvlan-based datapath
 ---------------------------------------
@@ -252,4 +249,3 @@ The following diagram shows the integration of iptables rules as installed by
 kube-proxy and the iptables rules as installed by Cilium.
 
 .. image:: _static/kubernetes_iptables.svg
-   :target: _static/kubernetes_iptables.svg

--- a/ginkgo-kubernetes-all.Jenkinsfile
+++ b/ginkgo-kubernetes-all.Jenkinsfile
@@ -139,7 +139,6 @@ pipeline {
             options {
                 timeout(time: 100, unit: 'MINUTES')
             }
-            failFast true
             parallel {
                 stage('BDD-Test-k8s-1.11') {
                     environment {
@@ -259,7 +258,6 @@ pipeline {
             options {
                 timeout(time: 100, unit: 'MINUTES')
             }
-            failFast true
             parallel {
                 stage('BDD-Test-k8s-1.13') {
                     environment {

--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -157,7 +157,6 @@ pipeline {
                 FAILFAST=setIfLabel("ci/fail-fast", "true", "false")
                 CONTAINER_RUNTIME=setIfLabel("area/containerd", "containerd", "docker")
             }
-            failFast true
             parallel {
                 stage('BDD-Test-PR-runtime') {
                     environment {

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -244,7 +244,11 @@ func (e *Endpoint) regenerate(owner Owner, context *regenerationContext) (retErr
 		logfields.Reason:    context.Reason,
 	}).Debug("Regenerating endpoint")
 
-	defer e.updateRegenerationStatistics(context, retErr)
+	defer func() {
+		// This has to be within a func(), not deferred directly, so that the
+		// value of retErr is passed in from when regenerate returns.
+		e.updateRegenerationStatistics(context, retErr)
+	}()
 
 	e.BuildMutex.Lock()
 	defer e.BuildMutex.Unlock()

--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -396,11 +396,11 @@ func (a *Allocator) selectAvailableID() (idpool.ID, string, idpool.ID) {
 	return 0, "", 0
 }
 
-func (a *Allocator) createValueNodeKey(ctx context.Context, key string, newID idpool.ID) error {
+func (a *Allocator) createValueNodeKey(ctx context.Context, key string, newID idpool.ID, lock kvstore.KVLocker) error {
 	// add a new key /value/<key>/<node> to account for the reference
 	// The key is protected with a TTL/lease and will expire after LeaseTTL
 	valueKey := path.Join(a.valuePrefix, key, a.suffix)
-	if _, err := kvstore.UpdateIfDifferent(ctx, valueKey, []byte(newID.String()), true); err != nil {
+	if _, err := kvstore.UpdateIfDifferentIfLocked(ctx, valueKey, []byte(newID.String()), true, lock); err != nil {
 		return fmt.Errorf("unable to create value-node key '%s': %s", valueKey, err)
 	}
 
@@ -439,7 +439,7 @@ func (a *Allocator) lockedAllocate(ctx context.Context, key AllocatorKey) (idpoo
 
 	// fetch first key that matches /value/<key> while ignoring the
 	// node suffix
-	value, err := a.Get(ctx, key)
+	value, err := a.GetIfLocked(ctx, key, lock)
 	if err != nil {
 		return 0, false, err
 	}
@@ -457,7 +457,7 @@ func (a *Allocator) lockedAllocate(ctx context.Context, key AllocatorKey) (idpoo
 		if value != 0 {
 			// re-create master key
 			keyPath := path.Join(a.idPrefix, strconv.FormatUint(uint64(value), 10))
-			success, err := kvstore.CreateOnly(ctx, keyPath, []byte(k), false)
+			success, err := kvstore.CreateOnlyIfLocked(ctx, keyPath, []byte(k), false, lock)
 			if err != nil || !success {
 				return 0, false, fmt.Errorf("unable to create master key '%s': %s", keyPath, err)
 			}
@@ -469,7 +469,7 @@ func (a *Allocator) lockedAllocate(ctx context.Context, key AllocatorKey) (idpoo
 		}
 	}
 	if value != 0 {
-		if err = a.createValueNodeKey(ctx, k, value); err != nil {
+		if err = a.createValueNodeKey(ctx, k, value, lock); err != nil {
 			a.localKeys.release(k)
 			return 0, false, fmt.Errorf("unable to create slave key '%s': %s", k, err)
 		}
@@ -506,7 +506,7 @@ func (a *Allocator) lockedAllocate(ctx context.Context, key AllocatorKey) (idpoo
 
 	// create /id/<ID> and fail if it already exists
 	keyPath := path.Join(a.idPrefix, strID)
-	success, err := kvstore.CreateOnly(ctx, keyPath, []byte(k), false)
+	success, err := kvstore.CreateOnlyIfLocked(ctx, keyPath, []byte(k), false, lock)
 	if err != nil || !success {
 		// Creation failed. Another agent most likely beat us to allocating this
 		// ID, retry.
@@ -517,7 +517,7 @@ func (a *Allocator) lockedAllocate(ctx context.Context, key AllocatorKey) (idpoo
 	// Notify pool that leased ID is now in-use.
 	a.idPool.Use(unmaskedID)
 
-	if err = a.createValueNodeKey(ctx, k, id); err != nil {
+	if err = a.createValueNodeKey(ctx, k, id, lock); err != nil {
 		// We will leak the master key here as the key has already been
 		// exposed and may be in use by other nodes. The garbage
 		// collector will release it again.
@@ -597,6 +597,17 @@ func (a *Allocator) Allocate(ctx context.Context, key AllocatorKey) (idpool.ID, 
 	return 0, false, err
 }
 
+// GetIfLocked returns the ID which is allocated to a key. Returns an ID of NoID if no ID
+// has been allocated to this key yet if the client is still holding the given
+// lock.
+func (a *Allocator) GetIfLocked(ctx context.Context, key AllocatorKey, lock kvstore.KVLocker) (idpool.ID, error) {
+	if id := a.mainCache.get(key.GetKey()); id != idpool.NoID {
+		return id, nil
+	}
+
+	return a.GetNoCacheIfLocked(ctx, key, lock)
+}
+
 // Get returns the ID which is allocated to a key. Returns an ID of NoID if no ID
 // has been allocated to this key yet.
 func (a *Allocator) Get(ctx context.Context, key AllocatorKey) (idpool.ID, error) {
@@ -611,6 +622,43 @@ func prefixMatchesKey(prefix, key string) bool {
 	// cilium/state/identities/v1/value/label;foo;bar;/172.0.124.60
 	lastSlash := strings.LastIndex(key, "/")
 	return len(prefix) == lastSlash
+}
+
+// GetNoCacheIfLocked returns the ID which is allocated to a key in the kvstore
+// if the client is still holding the given lock.
+func (a *Allocator) GetNoCacheIfLocked(ctx context.Context, key AllocatorKey, lock kvstore.KVLocker) (idpool.ID, error) {
+	// ListPrefixIfLocked() will return all keys matching the prefix, the prefix
+	// can cover multiple different keys, example:
+	//
+	// key1 := label1;label2;
+	// key2 := label1;label2;label3;
+	//
+	// In order to retrieve the correct key, the position of the last '/'
+	// is signficant, e.g.
+	//
+	// prefix := cilium/state/identities/v1/value/label;foo;
+	//
+	// key1 := cilium/state/identities/v1/value/label;foo;/172.0.124.60
+	// key2 := cilium/state/identities/v1/value/label;foo;bar;/172.0.124.60
+	//
+	// Only key1 should match
+	prefix := path.Join(a.valuePrefix, key.GetKey())
+	pairs, err := kvstore.ListPrefixIfLocked(prefix, lock)
+	kvstore.Trace("ListPrefixLocked", err, logrus.Fields{fieldPrefix: prefix, "entries": len(pairs)})
+	if err != nil {
+		return 0, err
+	}
+
+	for k, v := range pairs {
+		if prefixMatchesKey(prefix, k) {
+			id, err := strconv.ParseUint(string(v.Data), 10, 64)
+			if err == nil {
+				return idpool.ID(id), nil
+			}
+		}
+	}
+
+	return idpool.NoID, nil
 }
 
 // GetNoCache returns the ID which is allocated to a key in the kvstore
@@ -692,6 +740,8 @@ func (a *Allocator) Release(ctx context.Context, key AllocatorKey) (lastUse bool
 		valueKey := path.Join(a.valuePrefix, k, a.suffix)
 		log.WithField(fieldKey, key).Info("Released last local use of key, invoking global release")
 
+		// does not need to be deleted with a lock as its protected by the
+		// a.slaveKeysMutex
 		if err := kvstore.Delete(valueKey); err != nil {
 			log.WithError(err).WithFields(logrus.Fields{fieldKey: key}).Warning("Ignoring node specific ID")
 		}
@@ -730,7 +780,7 @@ func (a *Allocator) RunGC(staleKeysPrevRound map[string]uint64) (map[string]uint
 
 		// fetch list of all /value/<key> keys
 		valueKeyPrefix := path.Join(a.valuePrefix, string(v.Data))
-		pairs, err := kvstore.ListPrefix(valueKeyPrefix)
+		pairs, err := kvstore.ListPrefixIfLocked(valueKeyPrefix, lock)
 		if err != nil {
 			log.WithError(err).WithField(fieldPrefix, valueKeyPrefix).Warning("allocator garbage collector was unable to list keys")
 			lock.Unlock()
@@ -753,7 +803,7 @@ func (a *Allocator) RunGC(staleKeysPrevRound map[string]uint64) (map[string]uint
 			})
 			// Only delete if this key was previously marked as to be deleted
 			if modRev, ok := staleKeysPrevRound[key]; ok && modRev == v.ModRevision {
-				if err := kvstore.Delete(key); err != nil {
+				if err := kvstore.DeleteIfLocked(key, lock); err != nil {
 					scopedLog.WithError(err).Warning("Unable to delete unused allocator master key")
 				} else {
 					scopedLog.Info("Deleted unused allocator master key")

--- a/pkg/kvstore/backend.go
+++ b/pkg/kvstore/backend.go
@@ -144,19 +144,19 @@ type BackendOperations interface {
 	Status() (string, error)
 
 	// LockPath locks the provided path
-	LockPath(ctx context.Context, path string) (kvLocker, error)
+	LockPath(ctx context.Context, path string) (KVLocker, error)
 
 	// Get returns value of key
 	Get(key string) ([]byte, error)
 
 	// GetIfLocked returns value of key if the client is still holding the given lock.
-	GetIfLocked(key string, lock kvLocker) ([]byte, error)
+	GetIfLocked(key string, lock KVLocker) ([]byte, error)
 
 	// GetPrefix returns the first key which matches the prefix and its value
 	GetPrefix(ctx context.Context, prefix string) (string, []byte, error)
 
 	// GetPrefixIfLocked returns the first key which matches the prefix and its value if the client is still holding the given lock.
-	GetPrefixIfLocked(ctx context.Context, prefix string, lock kvLocker) (string, []byte, error)
+	GetPrefixIfLocked(ctx context.Context, prefix string, lock KVLocker) (string, []byte, error)
 
 	// Set sets value of key
 	Set(key string, value []byte) error
@@ -165,7 +165,7 @@ type BackendOperations interface {
 	Delete(key string) error
 
 	// DeleteIfLocked deletes a key if the client is still holding the given lock.
-	DeleteIfLocked(key string, lock kvLocker) error
+	DeleteIfLocked(key string, lock KVLocker) error
 
 	DeletePrefix(path string) error
 
@@ -173,19 +173,19 @@ type BackendOperations interface {
 	Update(ctx context.Context, key string, value []byte, lease bool) error
 
 	// UpdateIfLocked atomically creates a key or fails if it already exists if the client is still holding the given lock.
-	UpdateIfLocked(ctx context.Context, key string, value []byte, lease bool, lock kvLocker) error
+	UpdateIfLocked(ctx context.Context, key string, value []byte, lease bool, lock KVLocker) error
 
 	// UpdateIfDifferent updates a key if the value is different
 	UpdateIfDifferent(ctx context.Context, key string, value []byte, lease bool) (bool, error)
 
 	// UpdateIfDifferentIfLocked updates a key if the value is different and if the client is still holding the given lock.
-	UpdateIfDifferentIfLocked(ctx context.Context, key string, value []byte, lease bool, lock kvLocker) (bool, error)
+	UpdateIfDifferentIfLocked(ctx context.Context, key string, value []byte, lease bool, lock KVLocker) (bool, error)
 
 	// CreateOnly atomically creates a key or fails if it already exists
 	CreateOnly(ctx context.Context, key string, value []byte, lease bool) (bool, error)
 
 	// CreateOnlyIfLocked atomically creates a key if the client is still holding the given lock or fails if it already exists
-	CreateOnlyIfLocked(ctx context.Context, key string, value []byte, lease bool, lock kvLocker) (bool, error)
+	CreateOnlyIfLocked(ctx context.Context, key string, value []byte, lease bool, lock KVLocker) (bool, error)
 
 	// CreateIfExists creates a key with the value only if key condKey exists
 	CreateIfExists(condKey, key string, value []byte, lease bool) error
@@ -194,7 +194,7 @@ type BackendOperations interface {
 	ListPrefix(prefix string) (KeyValuePairs, error)
 
 	// ListPrefixIfLocked returns a list of keys matching the prefix only if the client is still holding the given lock.
-	ListPrefixIfLocked(prefix string, lock kvLocker) (KeyValuePairs, error)
+	ListPrefixIfLocked(prefix string, lock KVLocker) (KeyValuePairs, error)
 
 	// Watch starts watching for changes in a prefix. If list is true, the
 	// current keys matching the prefix will be listed and reported as new

--- a/pkg/kvstore/backend.go
+++ b/pkg/kvstore/backend.go
@@ -149,8 +149,14 @@ type BackendOperations interface {
 	// Get returns value of key
 	Get(key string) ([]byte, error)
 
+	// GetIfLocked returns value of key if the client is still holding the given lock.
+	GetIfLocked(key string, lock kvLocker) ([]byte, error)
+
 	// GetPrefix returns the first key which matches the prefix and its value
 	GetPrefix(ctx context.Context, prefix string) (string, []byte, error)
+
+	// GetPrefixIfLocked returns the first key which matches the prefix and its value if the client is still holding the given lock.
+	GetPrefixIfLocked(ctx context.Context, prefix string, lock kvLocker) (string, []byte, error)
 
 	// Set sets value of key
 	Set(key string, value []byte) error
@@ -158,22 +164,37 @@ type BackendOperations interface {
 	// Delete deletes a key
 	Delete(key string) error
 
+	// DeleteIfLocked deletes a key if the client is still holding the given lock.
+	DeleteIfLocked(key string, lock kvLocker) error
+
 	DeletePrefix(path string) error
 
 	// Update atomically creates a key or fails if it already exists
 	Update(ctx context.Context, key string, value []byte, lease bool) error
 
+	// UpdateIfLocked atomically creates a key or fails if it already exists if the client is still holding the given lock.
+	UpdateIfLocked(ctx context.Context, key string, value []byte, lease bool, lock kvLocker) error
+
 	// UpdateIfDifferent updates a key if the value is different
 	UpdateIfDifferent(ctx context.Context, key string, value []byte, lease bool) (bool, error)
 
+	// UpdateIfDifferentIfLocked updates a key if the value is different and if the client is still holding the given lock.
+	UpdateIfDifferentIfLocked(ctx context.Context, key string, value []byte, lease bool, lock kvLocker) (bool, error)
+
 	// CreateOnly atomically creates a key or fails if it already exists
 	CreateOnly(ctx context.Context, key string, value []byte, lease bool) (bool, error)
+
+	// CreateOnlyIfLocked atomically creates a key if the client is still holding the given lock or fails if it already exists
+	CreateOnlyIfLocked(ctx context.Context, key string, value []byte, lease bool, lock kvLocker) (bool, error)
 
 	// CreateIfExists creates a key with the value only if key condKey exists
 	CreateIfExists(condKey, key string, value []byte, lease bool) error
 
 	// ListPrefix returns a list of keys matching the prefix
 	ListPrefix(prefix string) (KeyValuePairs, error)
+
+	// ListPrefixIfLocked returns a list of keys matching the prefix only if the client is still holding the given lock.
+	ListPrefixIfLocked(prefix string, lock kvLocker) (KeyValuePairs, error)
 
 	// Watch starts watching for changes in a prefix. If list is true, the
 	// current keys matching the prefix will be listed and reported as new

--- a/pkg/kvstore/client.go
+++ b/pkg/kvstore/client.go
@@ -45,7 +45,7 @@ func initClient(module backendModule, opts *ExtraOptions) error {
 
 	go func() {
 		err, isErr := <-errChan
-		if isErr {
+		if isErr && err != nil {
 			log.WithError(err).Fatalf("Unable to connect to kvstore")
 		}
 		deleteLegacyPrefixes()

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -264,6 +264,10 @@ func (e *etcdMutex) Unlock() error {
 	return e.mutex.Unlock(ctx.TODO())
 }
 
+func (e *etcdMutex) Comparator() interface{} {
+	return e.mutex.IsOwner()
+}
+
 // GetLeaseID returns the current lease ID.
 func (e *etcdClient) GetLeaseID() client.LeaseID {
 	e.RWMutex.RLock()
@@ -548,7 +552,7 @@ func (e *etcdClient) checkMinVersion() error {
 	return nil
 }
 
-func (e *etcdClient) LockPath(ctx context.Context, path string) (kvLocker, error) {
+func (e *etcdClient) LockPath(ctx context.Context, path string) (KVLocker, error) {
 	select {
 	case <-e.firstSession:
 	case <-ctx.Done():
@@ -784,7 +788,7 @@ func (e *etcdClient) Status() (string, error) {
 }
 
 // GetIfLocked returns value of key if the client is still holding the given lock.
-func (e *etcdClient) GetIfLocked(key string, lock kvLocker) ([]byte, error) {
+func (e *etcdClient) GetIfLocked(key string, lock KVLocker) ([]byte, error) {
 	return e.Get(key)
 }
 
@@ -805,7 +809,7 @@ func (e *etcdClient) Get(key string) ([]byte, error) {
 }
 
 // GetPrefixIfLocked returns the first key which matches the prefix and its value if the client is still holding the given lock.
-func (e *etcdClient) GetPrefixIfLocked(ctx context.Context, prefix string, lock kvLocker) (string, []byte, error) {
+func (e *etcdClient) GetPrefixIfLocked(ctx context.Context, prefix string, lock KVLocker) (string, []byte, error) {
 	return e.GetPrefix(ctx, prefix)
 }
 
@@ -835,7 +839,7 @@ func (e *etcdClient) Set(key string, value []byte) error {
 }
 
 // DeleteIfLocked deletes a key if the client is still holding the given lock.
-func (e *etcdClient) DeleteIfLocked(key string, lock kvLocker) error {
+func (e *etcdClient) DeleteIfLocked(key string, lock KVLocker) error {
 	return e.Delete(key)
 }
 
@@ -859,7 +863,7 @@ func (e *etcdClient) createOpPut(key string, value []byte, leaseID client.LeaseI
 }
 
 // UpdateIfLocked atomically creates a key or fails if it already exists if the client is still holding the given lock.
-func (e *etcdClient) UpdateIfLocked(ctx context.Context, key string, value []byte, lease bool, lock kvLocker) error {
+func (e *etcdClient) UpdateIfLocked(ctx context.Context, key string, value []byte, lease bool, lock KVLocker) error {
 	return e.Update(ctx, key, value, lease)
 }
 
@@ -889,7 +893,7 @@ func (e *etcdClient) Update(ctx context.Context, key string, value []byte, lease
 }
 
 // UpdateIfDifferentIfLocked updates a key if the value is different and if the client is still holding the given lock.
-func (e *etcdClient) UpdateIfDifferentIfLocked(ctx context.Context, key string, value []byte, lease bool, lock kvLocker) (bool, error) {
+func (e *etcdClient) UpdateIfDifferentIfLocked(ctx context.Context, key string, value []byte, lease bool, lock KVLocker) (bool, error) {
 	return e.UpdateIfDifferent(ctx, key, value, lease)
 }
 
@@ -926,7 +930,7 @@ func (e *etcdClient) UpdateIfDifferent(ctx context.Context, key string, value []
 }
 
 // CreateOnlyIfLocked atomically creates a key if the client is still holding the given lock or fails if it already exists
-func (e *etcdClient) CreateOnlyIfLocked(ctx context.Context, key string, value []byte, lease bool, lock kvLocker) (bool, error) {
+func (e *etcdClient) CreateOnlyIfLocked(ctx context.Context, key string, value []byte, lease bool, lock KVLocker) (bool, error) {
 	return e.CreateOnly(ctx, key, value, lease)
 }
 
@@ -996,7 +1000,7 @@ func (e *etcdClient) CreateIfExists(condKey, key string, value []byte, lease boo
 //}
 
 // ListPrefixIfLocked returns a list of keys matching the prefix only if the client is still holding the given lock.
-func (e *etcdClient) ListPrefixIfLocked(prefix string, lock kvLocker) (KeyValuePairs, error) {
+func (e *etcdClient) ListPrefixIfLocked(prefix string, lock KVLocker) (KeyValuePairs, error) {
 	return e.ListPrefix(prefix)
 }
 

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -229,9 +229,10 @@ type etcdClient struct {
 	config     *client.Config
 	configPath string
 
-	// protects session from concurrent access
+	// protects sessions from concurrent access
 	lock.RWMutex
-	session *concurrency.Session
+	session     *concurrency.Session
+	lockSession *concurrency.Session
 
 	// statusLock protects latestStatusSnapshot and latestErrorStatus for
 	// read/write access
@@ -275,10 +276,18 @@ func (e *etcdMutex) Comparator() interface{} {
 	return e.mutex.IsOwner()
 }
 
-// GetLeaseID returns the current lease ID.
-func (e *etcdClient) GetLeaseID() client.LeaseID {
+// GetSessionLeaseID returns the current lease ID.
+func (e *etcdClient) GetSessionLeaseID() client.LeaseID {
 	e.RWMutex.RLock()
 	l := e.session.Lease()
+	e.RWMutex.RUnlock()
+	return l
+}
+
+// GetLockSessionLeaseID returns the current lease ID for the lock session.
+func (e *etcdClient) GetLockSessionLeaseID() client.LeaseID {
+	e.RWMutex.RLock()
+	l := e.lockSession.Lease()
 	e.RWMutex.RUnlock()
 	return l
 }
@@ -294,6 +303,17 @@ func (e *etcdClient) checkSession(err error, leaseID client.LeaseID) {
 	}
 }
 
+// checkSession verifies if the lease is still valid from the return error of
+// an etcd API call. If the error explicitly states that a lease was not found
+// we mark the session has an orphan for this etcd client. If we would not mark
+// it as an Orphan() the session would be considered expired after the leaseTTL
+// By make it orphan we guarantee the session will be marked to be renewed.
+func (e *etcdClient) checkLockSession(err error, leaseID client.LeaseID) {
+	if err == v3rpcErrors.ErrLeaseNotFound {
+		e.closeLockSession(leaseID)
+	}
+}
+
 // closeSession closes the current session.
 func (e *etcdClient) closeSession(leaseID client.LeaseID) {
 	e.RWMutex.RLock()
@@ -301,6 +321,17 @@ func (e *etcdClient) closeSession(leaseID client.LeaseID) {
 	// session ID to avoid making any other sessions as orphan.
 	if e.session.Lease() == leaseID {
 		e.session.Orphan()
+	}
+	e.RWMutex.RUnlock()
+}
+
+// closeSession closes the current session.
+func (e *etcdClient) closeLockSession(leaseID client.LeaseID) {
+	e.RWMutex.RLock()
+	// only mark a session as orphan if the leaseID is the same as the
+	// session ID to avoid making any other sessions as orphan.
+	if e.lockSession.Lease() == leaseID {
+		e.lockSession.Orphan()
 	}
 	e.RWMutex.RUnlock()
 }
@@ -416,6 +447,29 @@ func (e *etcdClient) renewSession() error {
 	return nil
 }
 
+func (e *etcdClient) renewLockSession() error {
+	<-e.firstSession
+	<-e.lockSession.Done()
+	// This is an attempt to avoid concurrent access of a session that was
+	// already expired. It's not perfect as there is still a period between the
+	// e.lockSession.Done() is closed and the e.Lock() is held where parallel go
+	// routines can get a lease ID of an already expired lease.
+	e.Lock()
+
+	newSession, err := concurrency.NewSession(e.client, concurrency.WithTTL(int(LockLeaseTTL.Seconds())))
+	if err != nil {
+		e.UnlockIgnoreTime()
+		return fmt.Errorf("unable to renew etcd lock session: %s", err)
+	}
+
+	e.lockSession = newSession
+	e.UnlockIgnoreTime()
+
+	e.getLogger().WithField(fieldSession, newSession).Debug("Renewing etcd lock session")
+
+	return nil
+}
+
 func connectEtcdClient(config *client.Config, cfgPath string, errChan chan error, rateLimit int, opts *ExtraOptions) (BackendOperations, error) {
 	if cfgPath != "" {
 		cfg, err := clientyaml.NewConfig(cfgPath)
@@ -440,17 +494,26 @@ func connectEtcdClient(config *client.Config, cfgPath string, errChan chan error
 		"config":    cfgPath,
 	}).Info("Connecting to etcd server...")
 
-	var s concurrency.Session
+	var s, ls concurrency.Session
 	firstSession := make(chan struct{})
-	sessionChan := make(chan *concurrency.Session)
 	errorChan := make(chan error)
 
 	// create session in parallel as this is a blocking operation
 	go func() {
 		session, err := concurrency.NewSession(c, concurrency.WithTTL(int(LeaseTTL.Seconds())))
-		errorChan <- err
-		sessionChan <- session
-		close(sessionChan)
+		if err != nil {
+			errorChan <- err
+			close(errorChan)
+			return
+		}
+		lockSession, err := concurrency.NewSession(c, concurrency.WithTTL(int(LockLeaseTTL.Seconds())))
+		if err != nil {
+			errorChan <- err
+			close(errorChan)
+			return
+		}
+		s = *session
+		ls = *lockSession
 		close(errorChan)
 	}()
 
@@ -459,6 +522,7 @@ func connectEtcdClient(config *client.Config, cfgPath string, errChan chan error
 		config:               config,
 		configPath:           cfgPath,
 		session:              &s,
+		lockSession:          &ls,
 		firstSession:         firstSession,
 		controllers:          controller.NewManager(),
 		latestStatusSnapshot: "No connection to etcd",
@@ -471,27 +535,18 @@ func connectEtcdClient(config *client.Config, cfgPath string, errChan chan error
 	go func() {
 		defer close(errChan)
 
-		var session concurrency.Session
 		select {
 		case err = <-errorChan:
-			if err == nil {
-				session = *<-sessionChan
+			if err != nil {
+				errChan <- err
+				return
 			}
 		case <-time.After(initialConnectionTimeout):
-			err = fmt.Errorf("timed out while waiting for etcd session. Ensure that etcd is running on %s", config.Endpoints)
-		}
-		if err != nil {
-			errChan <- err
+			errChan <- fmt.Errorf("timed out while waiting for etcd session. Ensure that etcd is running on %s", config.Endpoints)
 			return
 		}
 
 		ec.getLogger().Debugf("Session received")
-		s = session
-		if err != nil {
-			c.Close()
-			errChan <- fmt.Errorf("unable to create default lease: %s", err)
-			return
-		}
 		close(ec.firstSession)
 
 		if err := ec.checkMinVersion(); err != nil {
@@ -505,6 +560,15 @@ func connectEtcdClient(config *client.Config, cfgPath string, errChan chan error
 		controller.ControllerParams{
 			DoFunc: func(ctx context.Context) error {
 				return ec.renewSession()
+			},
+			RunInterval: time.Duration(10) * time.Millisecond,
+		},
+	)
+
+	ec.controllers.UpdateController("kvstore-etcd-lock-session-renew",
+		controller.ControllerParams{
+			DoFunc: func(ctx context.Context) error {
+				return ec.renewLockSession()
 			},
 			RunInterval: time.Duration(10) * time.Millisecond,
 		},
@@ -567,13 +631,15 @@ func (e *etcdClient) LockPath(ctx context.Context, path string) (KVLocker, error
 	}
 
 	e.RLock()
-	mu := concurrency.NewMutex(e.session, path)
+	mu := concurrency.NewMutex(e.lockSession, path)
+	leaseID := e.lockSession.Lease()
 	e.RUnlock()
 
 	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 	err := mu.Lock(ctx)
 	if err != nil {
+		e.checkLockSession(err, leaseID)
 		return nil, Hint(err)
 	}
 
@@ -928,7 +994,7 @@ func (e *etcdClient) UpdateIfLocked(ctx context.Context, key string, value []byt
 	duration := spanstat.Start()
 	e.limiter.Wait(ctx)
 	if lease {
-		leaseID := e.GetLeaseID()
+		leaseID := e.GetSessionLeaseID()
 		opPut := client.OpPut(key, string(value), client.WithLease(leaseID))
 		cmp := lock.Comparator().(client.Cmp)
 		txnReply, err = e.client.Txn(context.Background()).If(cmp).Then(opPut).Commit()
@@ -955,7 +1021,7 @@ func (e *etcdClient) Update(ctx context.Context, key string, value []byte, lease
 
 	if lease {
 		duration := spanstat.Start()
-		leaseID := e.GetLeaseID()
+		leaseID := e.GetSessionLeaseID()
 		e.limiter.Wait(ctx)
 		_, err := e.client.Put(ctx, key, string(value), client.WithLease(leaseID))
 		e.checkSession(err, leaseID)
@@ -1051,7 +1117,7 @@ func (e *etcdClient) CreateOnlyIfLocked(ctx context.Context, key string, value [
 	duration := spanstat.Start()
 	var leaseID client.LeaseID
 	if lease {
-		leaseID = e.GetLeaseID()
+		leaseID = e.GetSessionLeaseID()
 	}
 	req := e.createOpPut(key, value, leaseID)
 	cnds := []client.Cmp{
@@ -1105,7 +1171,7 @@ func (e *etcdClient) CreateOnly(ctx context.Context, key string, value []byte, l
 	duration := spanstat.Start()
 	var leaseID client.LeaseID
 	if lease {
-		leaseID = e.GetLeaseID()
+		leaseID = e.GetSessionLeaseID()
 	}
 	req := e.createOpPut(key, value, leaseID)
 	cond := client.Compare(client.Version(key), "=", 0)
@@ -1126,7 +1192,7 @@ func (e *etcdClient) CreateIfExists(condKey, key string, value []byte, lease boo
 	duration := spanstat.Start()
 	var leaseID client.LeaseID
 	if lease {
-		leaseID = e.GetLeaseID()
+		leaseID = e.GetSessionLeaseID()
 	}
 	req := e.createOpPut(key, value, leaseID)
 	cond := client.Compare(client.Version(condKey), "!=", 0)
@@ -1225,6 +1291,7 @@ func (e *etcdClient) Close() {
 	}
 	e.RLock()
 	defer e.RUnlock()
+	e.lockSession.Close()
 	e.session.Close()
 	e.client.Close()
 }

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -783,6 +783,11 @@ func (e *etcdClient) Status() (string, error) {
 	return e.latestStatusSnapshot, Hint(e.latestErrorStatus)
 }
 
+// GetIfLocked returns value of key if the client is still holding the given lock.
+func (e *etcdClient) GetIfLocked(key string, lock kvLocker) ([]byte, error) {
+	return e.Get(key)
+}
+
 // Get returns value of key
 func (e *etcdClient) Get(key string) ([]byte, error) {
 	duration := spanstat.Start()
@@ -797,6 +802,11 @@ func (e *etcdClient) Get(key string) ([]byte, error) {
 		return nil, nil
 	}
 	return getR.Kvs[0].Value, nil
+}
+
+// GetPrefixIfLocked returns the first key which matches the prefix and its value if the client is still holding the given lock.
+func (e *etcdClient) GetPrefixIfLocked(ctx context.Context, prefix string, lock kvLocker) (string, []byte, error) {
+	return e.GetPrefix(ctx, prefix)
 }
 
 // GetPrefix returns the first key which matches the prefix and its value
@@ -824,6 +834,11 @@ func (e *etcdClient) Set(key string, value []byte) error {
 	return Hint(err)
 }
 
+// DeleteIfLocked deletes a key if the client is still holding the given lock.
+func (e *etcdClient) DeleteIfLocked(key string, lock kvLocker) error {
+	return e.Delete(key)
+}
+
 // Delete deletes a key
 func (e *etcdClient) Delete(key string) error {
 	duration := spanstat.Start()
@@ -841,6 +856,11 @@ func (e *etcdClient) createOpPut(key string, value []byte, leaseID client.LeaseI
 
 	op := client.OpPut(key, string(value))
 	return &op
+}
+
+// UpdateIfLocked atomically creates a key or fails if it already exists if the client is still holding the given lock.
+func (e *etcdClient) UpdateIfLocked(ctx context.Context, key string, value []byte, lease bool, lock kvLocker) error {
+	return e.Update(ctx, key, value, lease)
 }
 
 // Update creates or updates a key
@@ -868,6 +888,12 @@ func (e *etcdClient) Update(ctx context.Context, key string, value []byte, lease
 	return Hint(err)
 }
 
+// UpdateIfDifferentIfLocked updates a key if the value is different and if the client is still holding the given lock.
+func (e *etcdClient) UpdateIfDifferentIfLocked(ctx context.Context, key string, value []byte, lease bool, lock kvLocker) (bool, error) {
+	return e.UpdateIfDifferent(ctx, key, value, lease)
+}
+
+// UpdateIfDifferent updates a key if the value is different
 func (e *etcdClient) UpdateIfDifferent(ctx context.Context, key string, value []byte, lease bool) (bool, error) {
 	select {
 	case <-e.firstSession:
@@ -897,6 +923,11 @@ func (e *etcdClient) UpdateIfDifferent(ctx context.Context, key string, value []
 	}
 
 	return false, nil
+}
+
+// CreateOnlyIfLocked atomically creates a key if the client is still holding the given lock or fails if it already exists
+func (e *etcdClient) CreateOnlyIfLocked(ctx context.Context, key string, value []byte, lease bool, lock kvLocker) (bool, error) {
+	return e.CreateOnly(ctx, key, value, lease)
 }
 
 // CreateOnly creates a key with the value and will fail if the key already exists
@@ -963,6 +994,11 @@ func (e *etcdClient) CreateIfExists(condKey, key string, value []byte, lease boo
 //
 //	return nil
 //}
+
+// ListPrefixIfLocked returns a list of keys matching the prefix only if the client is still holding the given lock.
+func (e *etcdClient) ListPrefixIfLocked(prefix string, lock kvLocker) (KeyValuePairs, error) {
+	return e.ListPrefix(prefix)
+}
 
 // ListPrefix returns a map of matching keys
 func (e *etcdClient) ListPrefix(prefix string) (KeyValuePairs, error) {

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -17,6 +17,7 @@ package kvstore
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"net/url"
@@ -49,6 +50,12 @@ const (
 
 	// EtcdRateLimitOption specifies maximum kv operations per second
 	EtcdRateLimitOption = "etcd.qps"
+)
+
+var (
+	// ErrLockLeaseExpired is an error whenever the lease of the lock does not
+	// exist or it was expired.
+	ErrLockLeaseExpired = errors.New("transaction did not succeed: lock lease expired")
 )
 
 func init() {
@@ -789,7 +796,25 @@ func (e *etcdClient) Status() (string, error) {
 
 // GetIfLocked returns value of key if the client is still holding the given lock.
 func (e *etcdClient) GetIfLocked(key string, lock KVLocker) ([]byte, error) {
-	return e.Get(key)
+	duration := spanstat.Start()
+	e.limiter.Wait(ctx.TODO())
+	opGet := client.OpGet(key)
+	cmp := lock.Comparator().(client.Cmp)
+	txnReply, err := e.client.Txn(context.Background()).If(cmp).Then(opGet).Commit()
+	if err == nil && !txnReply.Succeeded {
+		err = ErrLockLeaseExpired
+	}
+	increaseMetric(key, metricRead, "GetLocked", duration.EndError(err).Total(), err)
+	if err != nil {
+		return nil, Hint(err)
+	}
+
+	getR := txnReply.Responses[0].GetResponseRange()
+	// RangeResponse
+	if getR.Count == 0 {
+		return nil, nil
+	}
+	return getR.Kvs[0].Value, nil
 }
 
 // Get returns value of key
@@ -810,7 +835,24 @@ func (e *etcdClient) Get(key string) ([]byte, error) {
 
 // GetPrefixIfLocked returns the first key which matches the prefix and its value if the client is still holding the given lock.
 func (e *etcdClient) GetPrefixIfLocked(ctx context.Context, prefix string, lock KVLocker) (string, []byte, error) {
-	return e.GetPrefix(ctx, prefix)
+	duration := spanstat.Start()
+	e.limiter.Wait(ctx)
+	opGet := client.OpGet(prefix, client.WithPrefix(), client.WithLimit(1))
+	cmp := lock.Comparator().(client.Cmp)
+	txnReply, err := e.client.Txn(ctx).If(cmp).Then(opGet).Commit()
+	if err == nil && !txnReply.Succeeded {
+		err = ErrLockLeaseExpired
+	}
+	increaseMetric(prefix, metricRead, "GetPrefixLocked", duration.EndError(err).Total(), err)
+	if err != nil {
+		return "", nil, Hint(err)
+	}
+	getR := txnReply.Responses[0].GetResponseRange()
+
+	if getR.Count == 0 {
+		return "", nil, nil
+	}
+	return string(getR.Kvs[0].Key), getR.Kvs[0].Value, nil
 }
 
 // GetPrefix returns the first key which matches the prefix and its value
@@ -840,7 +882,15 @@ func (e *etcdClient) Set(key string, value []byte) error {
 
 // DeleteIfLocked deletes a key if the client is still holding the given lock.
 func (e *etcdClient) DeleteIfLocked(key string, lock KVLocker) error {
-	return e.Delete(key)
+	duration := spanstat.Start()
+	opDel := client.OpDelete(key)
+	cmp := lock.Comparator().(client.Cmp)
+	txnReply, err := e.client.Txn(context.Background()).If(cmp).Then(opDel).Commit()
+	if err == nil && !txnReply.Succeeded {
+		err = ErrLockLeaseExpired
+	}
+	increaseMetric(key, metricDelete, "DeleteLocked", duration.EndError(err).Total(), err)
+	return Hint(err)
 }
 
 // Delete deletes a key
@@ -864,7 +914,35 @@ func (e *etcdClient) createOpPut(key string, value []byte, leaseID client.LeaseI
 
 // UpdateIfLocked atomically creates a key or fails if it already exists if the client is still holding the given lock.
 func (e *etcdClient) UpdateIfLocked(ctx context.Context, key string, value []byte, lease bool, lock KVLocker) error {
-	return e.Update(ctx, key, value, lease)
+	select {
+	case <-e.firstSession:
+	case <-ctx.Done():
+		return fmt.Errorf("update cancelled via context: %s", ctx.Err())
+	}
+
+	var (
+		txnReply *client.TxnResponse
+		err      error
+	)
+
+	duration := spanstat.Start()
+	e.limiter.Wait(ctx)
+	if lease {
+		leaseID := e.GetLeaseID()
+		opPut := client.OpPut(key, string(value), client.WithLease(leaseID))
+		cmp := lock.Comparator().(client.Cmp)
+		txnReply, err = e.client.Txn(context.Background()).If(cmp).Then(opPut).Commit()
+		e.checkSession(err, leaseID)
+	} else {
+		opPut := client.OpPut(key, string(value))
+		cmp := lock.Comparator().(client.Cmp)
+		txnReply, err = e.client.Txn(context.Background()).If(cmp).Then(opPut).Commit()
+	}
+	if err == nil && !txnReply.Succeeded {
+		err = ErrLockLeaseExpired
+	}
+	increaseMetric(key, metricSet, "UpdateIfLocked", duration.EndError(err).Total(), err)
+	return Hint(err)
 }
 
 // Update creates or updates a key
@@ -894,7 +972,46 @@ func (e *etcdClient) Update(ctx context.Context, key string, value []byte, lease
 
 // UpdateIfDifferentIfLocked updates a key if the value is different and if the client is still holding the given lock.
 func (e *etcdClient) UpdateIfDifferentIfLocked(ctx context.Context, key string, value []byte, lease bool, lock KVLocker) (bool, error) {
-	return e.UpdateIfDifferent(ctx, key, value, lease)
+	select {
+	case <-e.firstSession:
+	case <-ctx.Done():
+		return false, fmt.Errorf("update cancelled via context: %s", ctx.Err())
+	}
+	duration := spanstat.Start()
+	e.limiter.Wait(ctx)
+	cnds := lock.Comparator().(client.Cmp)
+	txnresp, err := e.client.Txn(ctx).If(cnds).Then(client.OpGet(key)).Commit()
+
+	increaseMetric(key, metricRead, "Get", duration.EndError(err).Total(), err)
+
+	if !txnresp.Succeeded {
+		return false, ErrLockLeaseExpired
+	}
+
+	// On error, attempt update blindly
+	if err != nil {
+		return true, e.UpdateIfLocked(ctx, key, value, lease, lock)
+	}
+
+	getR := txnresp.Responses[0].GetResponseRange()
+	if getR.Count == 0 {
+		return true, e.UpdateIfLocked(ctx, key, value, lease, lock)
+	}
+
+	if lease {
+		e.RWMutex.RLock()
+		leaseID := e.session.Lease()
+		e.RWMutex.RUnlock()
+		if getR.Kvs[0].Lease != int64(leaseID) {
+			return true, e.UpdateIfLocked(ctx, key, value, lease, lock)
+		}
+	}
+	// if value is not equal then update.
+	if !bytes.Equal(getR.Kvs[0].Value, value) {
+		return true, e.UpdateIfLocked(ctx, key, value, lease, lock)
+	}
+
+	return false, nil
 }
 
 // UpdateIfDifferent updates a key if the value is different
@@ -931,7 +1048,56 @@ func (e *etcdClient) UpdateIfDifferent(ctx context.Context, key string, value []
 
 // CreateOnlyIfLocked atomically creates a key if the client is still holding the given lock or fails if it already exists
 func (e *etcdClient) CreateOnlyIfLocked(ctx context.Context, key string, value []byte, lease bool, lock KVLocker) (bool, error) {
-	return e.CreateOnly(ctx, key, value, lease)
+	duration := spanstat.Start()
+	var leaseID client.LeaseID
+	if lease {
+		leaseID = e.GetLeaseID()
+	}
+	req := e.createOpPut(key, value, leaseID)
+	cnds := []client.Cmp{
+		client.Compare(client.Version(key), "=", 0),
+		lock.Comparator().(client.Cmp),
+	}
+
+	// We need to do a get in the else of the txn to detect if the lock is still
+	// valid or not.
+	opGets := []client.Op{
+		client.OpGet(key),
+	}
+
+	e.limiter.Wait(ctx)
+	txnresp, err := e.client.Txn(ctx).If(cnds...).Then(*req).Else(opGets...).Commit()
+	increaseMetric(key, metricSet, "CreateOnlyLocked", duration.EndError(err).Total(), err)
+	if err != nil {
+		e.checkSession(err, leaseID)
+		return false, Hint(err)
+	}
+
+	// The txn can failed for the following reasons:
+	//  - Key version is not zero;
+	//  - Lock does not exist or is expired.
+	// For both of those cases, the key that we are comparing might or not
+	// exist, so we have:
+	//  A - Key does not exist and lock does not exist => ErrLockLeaseExpired
+	//  B - Key does not exist and lock exist => txn should succeed
+	//  C - Key does exist, version is == 0 and lock does not exist => ErrLockLeaseExpired
+	//  D - Key does exist, version is != 0 and lock does not exist => ErrLockLeaseExpired
+	//  E - Key does exist, version is == 0 and lock does exist => txn should succeed
+	//  F - Key does exist, version is != 0 and lock does exist => txn fails but returned is nil!
+
+	if !txnresp.Succeeded {
+		// case F
+		if len(txnresp.Responses[0].GetResponseRange().Kvs) != 0 &&
+			txnresp.Responses[0].GetResponseRange().Kvs[0].Version != 0 {
+			return false, nil
+		}
+
+		// case A, C and D
+		return false, ErrLockLeaseExpired
+	}
+
+	// case B and E
+	return true, nil
 }
 
 // CreateOnly creates a key with the value and will fail if the key already exists
@@ -1001,7 +1167,30 @@ func (e *etcdClient) CreateIfExists(condKey, key string, value []byte, lease boo
 
 // ListPrefixIfLocked returns a list of keys matching the prefix only if the client is still holding the given lock.
 func (e *etcdClient) ListPrefixIfLocked(prefix string, lock KVLocker) (KeyValuePairs, error) {
-	return e.ListPrefix(prefix)
+	duration := spanstat.Start()
+	e.limiter.Wait(ctx.TODO())
+	opGet := client.OpGet(prefix, client.WithPrefix())
+	cmp := lock.Comparator().(client.Cmp)
+	txnReply, err := e.client.Txn(context.Background()).If(cmp).Then(opGet).Commit()
+	if err == nil && !txnReply.Succeeded {
+		err = ErrLockLeaseExpired
+	}
+	increaseMetric(prefix, metricRead, "ListPrefixLocked", duration.EndError(err).Total(), err)
+	if err != nil {
+		return nil, Hint(err)
+	}
+	getR := txnReply.Responses[0].GetResponseRange()
+
+	pairs := KeyValuePairs(make(map[string]Value, getR.Count))
+	for i := int64(0); i < getR.Count; i++ {
+		pairs[string(getR.Kvs[i].Key)] = Value{
+			Data:        getR.Kvs[i].Value,
+			ModRevision: uint64(getR.Kvs[i].ModRevision),
+		}
+
+	}
+
+	return pairs, nil
 }
 
 // ListPrefix returns a map of matching keys

--- a/pkg/kvstore/etcd_test.go
+++ b/pkg/kvstore/etcd_test.go
@@ -17,6 +17,7 @@
 package kvstore
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -24,8 +25,9 @@ import (
 	"path"
 	"time"
 
+	"github.com/cilium/cilium/pkg/checker"
+
 	etcdAPI "github.com/coreos/etcd/clientv3"
-	"golang.org/x/net/context"
 	. "gopkg.in/check.v1"
 )
 
@@ -265,5 +267,1237 @@ endpoints:
 	for i, tt := range tests {
 		got := IsEtcdOperator(tt.args.backend, tt.args.opts, tt.args.k8sNamespace)
 		c.Assert(got, Equals, tt.want, Commentf("Test %d", i))
+	}
+}
+
+type EtcdLockedSuite struct {
+	etcdClient *etcdAPI.Client
+}
+
+var _ = Suite(&EtcdLockedSuite{})
+
+func (e *EtcdLockedSuite) SetUpSuite(c *C) {
+	SetupDummy("etcd")
+
+	// setup client
+	cfg := etcdAPI.Config{}
+	cfg.Endpoints = []string{etcdDummyAddress}
+	cfg.DialTimeout = 0
+	cli, err := etcdAPI.New(cfg)
+	c.Assert(err, IsNil)
+	e.etcdClient = cli
+}
+
+func (e *EtcdLockedSuite) TearDownSuite(c *C) {
+	err := e.etcdClient.Close()
+	c.Assert(err, IsNil)
+	Close()
+}
+
+func (e *EtcdLockedSuite) TestGetIfLocked(c *C) {
+	randomPath := c.MkDir()
+	type args struct {
+		key  string
+		lock KVLocker
+	}
+	type wanted struct {
+		err   error
+		value []byte
+	}
+	tests := []struct {
+		name        string
+		setupArgs   func() args
+		setupWanted func() wanted
+		cleanup     func(args args) error
+	}{
+		{
+			name: "getting locked path",
+			setupArgs: func() args {
+				key := randomPath + "foo"
+				kvlocker, err := Client().LockPath(context.Background(), "locks/"+key+"/.lock")
+				c.Assert(err, IsNil)
+				_, err = e.etcdClient.Put(context.Background(), key, "bar")
+				c.Assert(err, IsNil)
+
+				return args{
+					key:  key,
+					lock: kvlocker,
+				}
+			},
+			setupWanted: func() wanted {
+				return wanted{
+					err:   nil,
+					value: []byte("bar"),
+				}
+			},
+			cleanup: func(args args) error {
+				_, err := e.etcdClient.Delete(context.Background(), args.key)
+				if err != nil {
+					return err
+				}
+				return args.lock.Unlock()
+			},
+		},
+		{
+			name: "getting locked path with no value",
+			setupArgs: func() args {
+				key := randomPath + "foo"
+				kvlocker, err := Client().LockPath(context.Background(), "locks/"+key+"/.lock")
+				c.Assert(err, IsNil)
+				_, err = e.etcdClient.Delete(context.Background(), key)
+				c.Assert(err, IsNil)
+
+				return args{
+					key:  key,
+					lock: kvlocker,
+				}
+			},
+			setupWanted: func() wanted {
+				return wanted{
+					err:   nil,
+					value: nil,
+				}
+			},
+			cleanup: func(args args) error {
+				return args.lock.Unlock()
+			},
+		},
+		{
+			name: "getting locked path where lock was lost",
+			setupArgs: func() args {
+				key := randomPath + "foo"
+				kvlocker, err := Client().LockPath(context.Background(), "locks/"+key+"/.lock")
+				c.Assert(err, IsNil)
+				err = kvlocker.Unlock()
+				c.Assert(err, IsNil)
+
+				_, err = e.etcdClient.Put(context.Background(), key, "bar")
+				c.Assert(err, IsNil)
+
+				return args{
+					key:  key,
+					lock: kvlocker,
+				}
+			},
+			setupWanted: func() wanted {
+				return wanted{
+					err:   ErrLockLeaseExpired,
+					value: nil,
+				}
+			},
+			cleanup: func(args args) error {
+				_, err := e.etcdClient.Delete(context.Background(), args.key)
+				return err
+			},
+		},
+	}
+	for _, tt := range tests {
+		c.Log(tt.name)
+		args := tt.setupArgs()
+		want := tt.setupWanted()
+		value, err := Client().GetIfLocked(args.key, args.lock)
+		c.Assert(err, Equals, want.err)
+		c.Assert(value, checker.DeepEquals, want.value)
+		err = tt.cleanup(args)
+		c.Assert(err, IsNil)
+	}
+}
+
+func (e *EtcdLockedSuite) TestGetPrefixIfLocked(c *C) {
+	randomPath := c.MkDir()
+	type args struct {
+		key  string
+		lock KVLocker
+	}
+	type wanted struct {
+		err   error
+		key   string
+		value []byte
+	}
+	tests := []struct {
+		name        string
+		setupArgs   func() args
+		setupWanted func() wanted
+		cleanup     func(args args) error
+	}{
+		{
+			name: "getting locked prefix path",
+			setupArgs: func() args {
+				key := randomPath + "foo"
+				kvlocker, err := Client().LockPath(context.Background(), "locks/"+key+"/.lock")
+				c.Assert(err, IsNil)
+				_, err = e.etcdClient.Put(context.Background(), key, "bar")
+				c.Assert(err, IsNil)
+
+				return args{
+					key:  key,
+					lock: kvlocker,
+				}
+			},
+			setupWanted: func() wanted {
+				return wanted{
+					err:   nil,
+					key:   randomPath + "foo",
+					value: []byte("bar"),
+				}
+			},
+			cleanup: func(args args) error {
+				_, err := e.etcdClient.Delete(context.Background(), args.key)
+				if err != nil {
+					return err
+				}
+				return args.lock.Unlock()
+			},
+		},
+		{
+			name: "getting locked prefix path with no value",
+			setupArgs: func() args {
+				key := randomPath + "foo"
+				kvlocker, err := Client().LockPath(context.Background(), "locks/"+key+"/.lock")
+				c.Assert(err, IsNil)
+
+				return args{
+					key:  key,
+					lock: kvlocker,
+				}
+			},
+			setupWanted: func() wanted {
+				return wanted{
+					err:   nil,
+					value: nil,
+				}
+			},
+			cleanup: func(args args) error {
+				return args.lock.Unlock()
+			},
+		},
+		{
+			name: "getting locked prefix path where lock was lost",
+			setupArgs: func() args {
+				key := randomPath + "foo"
+				kvlocker, err := Client().LockPath(context.Background(), "locks/"+key+"/.lock")
+				c.Assert(err, IsNil)
+				err = kvlocker.Unlock()
+				c.Assert(err, IsNil)
+				_, err = e.etcdClient.Put(context.Background(), key, "bar")
+				c.Assert(err, IsNil)
+
+				return args{
+					key:  key,
+					lock: kvlocker,
+				}
+			},
+			setupWanted: func() wanted {
+				return wanted{
+					err:   ErrLockLeaseExpired,
+					value: nil,
+				}
+			},
+			cleanup: func(args args) error {
+				_, err := e.etcdClient.Delete(context.Background(), args.key)
+				return err
+			},
+		},
+	}
+	for _, tt := range tests {
+		c.Log(tt.name)
+		args := tt.setupArgs()
+		want := tt.setupWanted()
+		k, value, err := Client().GetPrefixIfLocked(context.Background(), args.key, args.lock)
+		c.Assert(err, Equals, want.err)
+		c.Assert(k, Equals, want.key)
+		c.Assert(value, checker.DeepEquals, want.value)
+		err = tt.cleanup(args)
+		c.Assert(err, IsNil)
+	}
+}
+
+func (e *EtcdLockedSuite) TestDeleteIfLocked(c *C) {
+	randomPath := c.MkDir()
+	type args struct {
+		key  string
+		lock KVLocker
+	}
+	type wanted struct {
+		err error
+	}
+	tests := []struct {
+		name        string
+		setupArgs   func() args
+		setupWanted func() wanted
+		cleanup     func(args args) error
+	}{
+		{
+			name: "deleting locked path",
+			setupArgs: func() args {
+				key := randomPath + "foo"
+				kvlocker, err := Client().LockPath(context.Background(), "locks/"+key+"/.lock")
+				c.Assert(err, IsNil)
+				_, err = e.etcdClient.Put(context.Background(), key, "bar")
+				c.Assert(err, IsNil)
+
+				return args{
+					key:  key,
+					lock: kvlocker,
+				}
+			},
+			setupWanted: func() wanted {
+				return wanted{
+					err: nil,
+				}
+			},
+			cleanup: func(args args) error {
+				key := randomPath + "foo"
+				// verify that key was actually deleted
+				gr, err := e.etcdClient.Get(context.Background(), key)
+				c.Assert(err, IsNil)
+				c.Assert(gr.Count, Equals, int64(0))
+
+				return args.lock.Unlock()
+			},
+		},
+		{
+			name: "deleting locked path with no value",
+			setupArgs: func() args {
+				key := randomPath + "foo"
+				kvlocker, err := Client().LockPath(context.Background(), "locks/"+key+"/.lock")
+				c.Assert(err, IsNil)
+
+				_, err = e.etcdClient.Delete(context.Background(), key)
+				c.Assert(err, IsNil)
+
+				return args{
+					key:  key,
+					lock: kvlocker,
+				}
+			},
+			setupWanted: func() wanted {
+				return wanted{
+					err: nil,
+				}
+			},
+			cleanup: func(args args) error {
+				key := randomPath + "foo"
+				// verify that key was actually deleted (this should not matter
+				// as the key was never in the kvstore but still)
+				gr, err := e.etcdClient.Get(context.Background(), key)
+				c.Assert(err, IsNil)
+				c.Assert(gr.Count, Equals, int64(0))
+
+				return args.lock.Unlock()
+			},
+		},
+		{
+			name: "deleting locked path where lock was lost",
+			setupArgs: func() args {
+				key := randomPath + "foo"
+				kvlocker, err := Client().LockPath(context.Background(), "locks/"+key+"/.lock")
+				c.Assert(err, IsNil)
+				_, err = e.etcdClient.Put(context.Background(), key, "bar")
+				c.Assert(err, IsNil)
+				err = kvlocker.Unlock()
+				c.Assert(err, IsNil)
+
+				return args{
+					key:  key,
+					lock: kvlocker,
+				}
+			},
+			setupWanted: func() wanted {
+				return wanted{
+					err: ErrLockLeaseExpired,
+				}
+			},
+			cleanup: func(args args) error {
+				key := randomPath + "foo"
+				// If the lock was lost it means the value still exists
+				value, err := e.etcdClient.Get(context.Background(), key)
+				c.Assert(err, IsNil)
+				c.Assert(value.Count, Equals, int64(1))
+				c.Assert(value.Kvs[0].Value, checker.DeepEquals, []byte("bar"))
+				return nil
+			},
+		},
+	}
+	for _, tt := range tests {
+		c.Log(tt.name)
+		args := tt.setupArgs()
+		want := tt.setupWanted()
+		err := Client().DeleteIfLocked(args.key, args.lock)
+		c.Assert(err, Equals, want.err)
+		err = tt.cleanup(args)
+		c.Assert(err, IsNil)
+	}
+}
+
+func (e *EtcdLockedSuite) TestUpdateIfLocked(c *C) {
+	randomPath := c.MkDir()
+	type args struct {
+		key      string
+		lock     KVLocker
+		newValue []byte
+		lease    bool
+	}
+	type wanted struct {
+		err error
+	}
+	tests := []struct {
+		name        string
+		setupArgs   func() args
+		setupWanted func() wanted
+		cleanup     func(args args) error
+	}{
+		{
+			name: "update locked path without lease",
+			setupArgs: func() args {
+				key := randomPath + "foo"
+				kvlocker, err := Client().LockPath(context.Background(), "locks/"+key+"/.lock")
+				c.Assert(err, IsNil)
+				_, err = e.etcdClient.Put(context.Background(), key, "bar")
+				c.Assert(err, IsNil)
+
+				return args{
+					key:      key,
+					lock:     kvlocker,
+					newValue: []byte("newbar"),
+				}
+			},
+			setupWanted: func() wanted {
+				return wanted{
+					err: nil,
+				}
+			},
+			cleanup: func(args args) error {
+				key := randomPath + "foo"
+				// verify that key was actually updated
+				gr, err := e.etcdClient.Get(context.Background(), key)
+				c.Assert(err, IsNil)
+				c.Assert(gr.Count, Equals, int64(1))
+				c.Assert(gr.Kvs[0].Value, checker.DeepEquals, []byte("newbar"))
+
+				return args.lock.Unlock()
+			},
+		},
+		{
+			name: "update locked path with no value without lease",
+			setupArgs: func() args {
+				key := randomPath + "foo"
+				kvlocker, err := Client().LockPath(context.Background(), "locks/"+key+"/.lock")
+				c.Assert(err, IsNil)
+
+				_, err = e.etcdClient.Delete(context.Background(), key)
+				c.Assert(err, IsNil)
+
+				return args{
+					key:      key,
+					lock:     kvlocker,
+					newValue: []byte("newbar"),
+				}
+			},
+			setupWanted: func() wanted {
+				return wanted{
+					err: nil,
+				}
+			},
+			cleanup: func(args args) error {
+				key := randomPath + "foo"
+				// a key that was updated with no value will create a new value
+				gr, err := e.etcdClient.Get(context.Background(), key)
+				c.Assert(err, IsNil)
+				c.Assert(gr.Count, Equals, int64(1))
+				c.Assert(gr.Kvs[0].Value, checker.DeepEquals, []byte("newbar"))
+
+				return args.lock.Unlock()
+			},
+		},
+		{
+			name: "update locked path where lock was lost without lease",
+			setupArgs: func() args {
+				key := randomPath + "foo"
+				kvlocker, err := Client().LockPath(context.Background(), "locks/"+key+"/.lock")
+				c.Assert(err, IsNil)
+				_, err = e.etcdClient.Put(context.Background(), key, "bar")
+				c.Assert(err, IsNil)
+				err = kvlocker.Unlock()
+				c.Assert(err, IsNil)
+
+				return args{
+					key:  key,
+					lock: kvlocker,
+				}
+			},
+			setupWanted: func() wanted {
+				return wanted{
+					err: ErrLockLeaseExpired,
+				}
+			},
+			cleanup: func(args args) error {
+				key := randomPath + "foo"
+				// verify that key was actually updated
+				gr, err := e.etcdClient.Get(context.Background(), key)
+				c.Assert(err, IsNil)
+				c.Assert(gr.Count, Equals, int64(1))
+				c.Assert(gr.Kvs[0].Value, checker.DeepEquals, []byte("bar"))
+				return nil
+			},
+		},
+		{
+			name: "update locked path with lease",
+			setupArgs: func() args {
+				key := randomPath + "foo"
+				kvlocker, err := Client().LockPath(context.Background(), "locks/"+key+"/.lock")
+				c.Assert(err, IsNil)
+				_, err = e.etcdClient.Put(context.Background(), key, "bar")
+				c.Assert(err, IsNil)
+
+				return args{
+					key:      key,
+					lock:     kvlocker,
+					newValue: []byte("newbar"),
+					lease:    true,
+				}
+			},
+			setupWanted: func() wanted {
+				return wanted{
+					err: nil,
+				}
+			},
+			cleanup: func(args args) error {
+				key := randomPath + "foo"
+				// verify that key was actually updated
+				gr, err := e.etcdClient.Get(context.Background(), key)
+				c.Assert(err, IsNil)
+				c.Assert(gr.Count, Equals, int64(1))
+				c.Assert(gr.Kvs[0].Value, checker.DeepEquals, []byte("newbar"))
+
+				return args.lock.Unlock()
+			},
+		},
+		{
+			name: "update locked path with no value with lease",
+			setupArgs: func() args {
+				key := randomPath + "foo"
+				kvlocker, err := Client().LockPath(context.Background(), "locks/"+key+"/.lock")
+				c.Assert(err, IsNil)
+
+				_, err = e.etcdClient.Delete(context.Background(), key)
+				c.Assert(err, IsNil)
+
+				return args{
+					key:      key,
+					lock:     kvlocker,
+					newValue: []byte("newbar"),
+					lease:    true,
+				}
+			},
+			setupWanted: func() wanted {
+				return wanted{
+					err: nil,
+				}
+			},
+			cleanup: func(args args) error {
+				key := randomPath + "foo"
+				// a key that was updated with no value will create a new value
+				gr, err := e.etcdClient.Get(context.Background(), key)
+				c.Assert(err, IsNil)
+				c.Assert(gr.Count, Equals, int64(1))
+				c.Assert(gr.Kvs[0].Value, checker.DeepEquals, []byte("newbar"))
+
+				return args.lock.Unlock()
+			},
+		},
+		{
+			name: "update locked path where lock was lost with lease",
+			setupArgs: func() args {
+				key := randomPath + "foo"
+				kvlocker, err := Client().LockPath(context.Background(), "locks/"+key+"/.lock")
+				c.Assert(err, IsNil)
+				_, err = e.etcdClient.Put(context.Background(), key, "bar")
+				c.Assert(err, IsNil)
+				err = kvlocker.Unlock()
+				c.Assert(err, IsNil)
+
+				return args{
+					key:   key,
+					lock:  kvlocker,
+					lease: true,
+				}
+			},
+			setupWanted: func() wanted {
+				return wanted{
+					err: ErrLockLeaseExpired,
+				}
+			},
+			cleanup: func(args args) error {
+				key := randomPath + "foo"
+				// verify that key was actually updated
+				gr, err := e.etcdClient.Get(context.Background(), key)
+				c.Assert(err, IsNil)
+				c.Assert(gr.Count, Equals, int64(1))
+				c.Assert(gr.Kvs[0].Value, checker.DeepEquals, []byte("bar"))
+				return nil
+			},
+		},
+	}
+	for _, tt := range tests {
+		c.Log(tt.name)
+		args := tt.setupArgs()
+		want := tt.setupWanted()
+		err := Client().UpdateIfLocked(context.Background(), args.key, args.newValue, args.lease, args.lock)
+		c.Assert(err, Equals, want.err)
+		err = tt.cleanup(args)
+		c.Assert(err, IsNil)
+	}
+}
+
+func (e *EtcdLockedSuite) TestUpdateIfDifferentIfLocked(c *C) {
+	randomPath := c.MkDir()
+	type args struct {
+		key      string
+		lock     KVLocker
+		newValue []byte
+		lease    bool
+	}
+	type wanted struct {
+		err     error
+		updated bool
+	}
+	tests := []struct {
+		name        string
+		setupArgs   func() args
+		setupWanted func() wanted
+		cleanup     func(args args) error
+	}{
+		{
+			name: "update locked path without lease",
+			setupArgs: func() args {
+				key := randomPath + "foo"
+				kvlocker, err := Client().LockPath(context.Background(), "locks/"+key+"/.lock")
+				c.Assert(err, IsNil)
+				_, err = e.etcdClient.Put(context.Background(), key, "bar")
+				c.Assert(err, IsNil)
+
+				return args{
+					key:      key,
+					lock:     kvlocker,
+					newValue: []byte("newbar"),
+				}
+			},
+			setupWanted: func() wanted {
+				return wanted{
+					err:     nil,
+					updated: true,
+				}
+			},
+			cleanup: func(args args) error {
+				key := randomPath + "foo"
+				// verify that key was actually updated
+				gr, err := e.etcdClient.Get(context.Background(), key)
+				c.Assert(err, IsNil)
+				c.Assert(gr.Count, Equals, int64(1))
+				c.Assert(gr.Kvs[0].Value, checker.DeepEquals, []byte("newbar"))
+				_, err = e.etcdClient.Delete(context.Background(), key)
+				c.Assert(err, IsNil)
+				return args.lock.Unlock()
+			},
+		},
+		{
+			name: "update locked path without lease and with same value",
+			setupArgs: func() args {
+				key := randomPath + "foo"
+				kvlocker, err := Client().LockPath(context.Background(), "locks/"+key+"/.lock")
+				c.Assert(err, IsNil)
+				_, err = e.etcdClient.Put(context.Background(), key, "bar")
+				c.Assert(err, IsNil)
+
+				return args{
+					key:      key,
+					lock:     kvlocker,
+					newValue: []byte("bar"),
+				}
+			},
+			setupWanted: func() wanted {
+				return wanted{
+					err: nil,
+				}
+			},
+			cleanup: func(args args) error {
+				key := randomPath + "foo"
+				// verify that key was actually updated
+				gr, err := e.etcdClient.Get(context.Background(), key)
+				c.Assert(err, IsNil)
+				c.Assert(gr.Count, Equals, int64(1))
+				c.Assert(gr.Kvs[0].Value, checker.DeepEquals, []byte("bar"))
+
+				return args.lock.Unlock()
+			},
+		},
+		{
+			name: "update locked path with no value without lease",
+			setupArgs: func() args {
+				key := randomPath + "foo"
+				kvlocker, err := Client().LockPath(context.Background(), "locks/"+key+"/.lock")
+				c.Assert(err, IsNil)
+
+				_, err = e.etcdClient.Delete(context.Background(), key)
+				c.Assert(err, IsNil)
+
+				return args{
+					key:      key,
+					lock:     kvlocker,
+					newValue: []byte("newbar"),
+				}
+			},
+			setupWanted: func() wanted {
+				return wanted{
+					err:     nil,
+					updated: true,
+				}
+			},
+			cleanup: func(args args) error {
+				key := randomPath + "foo"
+				// a key that was updated with no value will create a new value
+				gr, err := e.etcdClient.Get(context.Background(), key)
+				c.Assert(err, IsNil)
+				c.Assert(gr.Count, Equals, int64(1))
+				c.Assert(gr.Kvs[0].Value, checker.DeepEquals, []byte("newbar"))
+				_, err = e.etcdClient.Delete(context.Background(), key)
+				c.Assert(err, IsNil)
+				return args.lock.Unlock()
+			},
+		},
+		{
+			name: "update locked path where lock was lost without lease",
+			setupArgs: func() args {
+				key := randomPath + "foo"
+				kvlocker, err := Client().LockPath(context.Background(), "locks/"+key+"/.lock")
+				c.Assert(err, IsNil)
+				_, err = e.etcdClient.Put(context.Background(), key, "bar")
+				c.Assert(err, IsNil)
+				err = kvlocker.Unlock()
+				c.Assert(err, IsNil)
+
+				return args{
+					key:      key,
+					newValue: []byte("baz"),
+					lock:     kvlocker,
+				}
+			},
+			setupWanted: func() wanted {
+				return wanted{
+					err: ErrLockLeaseExpired,
+				}
+			},
+			cleanup: func(args args) error {
+				key := randomPath + "foo"
+				// verify that key was actually updated
+				gr, err := e.etcdClient.Get(context.Background(), key)
+				c.Assert(err, IsNil)
+				c.Assert(gr.Count, Equals, int64(1))
+				c.Assert(gr.Kvs[0].Value, checker.DeepEquals, []byte("bar"))
+				_, err = e.etcdClient.Delete(context.Background(), key)
+				c.Assert(err, IsNil)
+				return nil
+			},
+		},
+		{
+			name: "update locked path with lease",
+			setupArgs: func() args {
+				key := randomPath + "foo"
+				kvlocker, err := Client().LockPath(context.Background(), "locks/"+key+"/.lock")
+				c.Assert(err, IsNil)
+				_, err = e.etcdClient.Put(context.Background(), key, "bar")
+				c.Assert(err, IsNil)
+
+				return args{
+					key:      key,
+					lock:     kvlocker,
+					newValue: []byte("newbar"),
+					lease:    true,
+				}
+			},
+			setupWanted: func() wanted {
+				return wanted{
+					err:     nil,
+					updated: true,
+				}
+			},
+			cleanup: func(args args) error {
+				key := randomPath + "foo"
+				// verify that key was actually updated
+				gr, err := e.etcdClient.Get(context.Background(), key)
+				c.Assert(err, IsNil)
+				c.Assert(gr.Count, Equals, int64(1))
+				c.Assert(gr.Kvs[0].Value, checker.DeepEquals, []byte("newbar"))
+				_, err = e.etcdClient.Delete(context.Background(), key)
+				c.Assert(err, IsNil)
+				return args.lock.Unlock()
+			},
+		},
+		{
+			name: "update locked path with no value with lease",
+			setupArgs: func() args {
+				key := randomPath + "foo"
+				kvlocker, err := Client().LockPath(context.Background(), "locks/"+key+"/.lock")
+				c.Assert(err, IsNil)
+
+				_, err = e.etcdClient.Delete(context.Background(), key)
+				c.Assert(err, IsNil)
+
+				return args{
+					key:      key,
+					lock:     kvlocker,
+					newValue: []byte("newbar"),
+					lease:    true,
+				}
+			},
+			setupWanted: func() wanted {
+				return wanted{
+					err:     nil,
+					updated: true,
+				}
+			},
+			cleanup: func(args args) error {
+				key := randomPath + "foo"
+				// a key that was updated with no value will create a new value
+				gr, err := e.etcdClient.Get(context.Background(), key)
+				c.Assert(err, IsNil)
+				c.Assert(gr.Count, Equals, int64(1))
+				c.Assert(gr.Kvs[0].Value, checker.DeepEquals, []byte("newbar"))
+
+				_, err = e.etcdClient.Delete(context.Background(), key)
+				c.Assert(err, IsNil)
+
+				return args.lock.Unlock()
+			},
+		},
+		{
+			name: "update locked path with lease and with same value",
+			setupArgs: func() args {
+				key := randomPath + "foo"
+				kvlocker, err := Client().LockPath(context.Background(), "locks/"+key+"/.lock")
+				c.Assert(err, IsNil)
+				created, err := Client().CreateOnly(context.Background(), key, []byte("bar"), true)
+				c.Assert(err, IsNil)
+				c.Assert(created, Equals, true)
+
+				return args{
+					key:      key,
+					lock:     kvlocker,
+					newValue: []byte("bar"),
+					lease:    true,
+				}
+			},
+			setupWanted: func() wanted {
+				return wanted{
+					err: nil,
+				}
+			},
+			cleanup: func(args args) error {
+				key := randomPath + "foo"
+				// verify that key was actually updated
+				gr, err := e.etcdClient.Get(context.Background(), key)
+				c.Assert(err, IsNil)
+				c.Assert(gr.Count, Equals, int64(1))
+				c.Assert(gr.Kvs[0].Value, checker.DeepEquals, []byte("bar"))
+				_, err = e.etcdClient.Delete(context.Background(), key)
+				c.Assert(err, IsNil)
+				return args.lock.Unlock()
+			},
+		},
+		{
+			name: "update locked path where lock was lost with lease",
+			setupArgs: func() args {
+				key := randomPath + "foo"
+				kvlocker, err := Client().LockPath(context.Background(), "locks/"+key+"/.lock")
+				c.Assert(err, IsNil)
+				_, err = e.etcdClient.Put(context.Background(), key, "bar")
+				c.Assert(err, IsNil)
+				err = kvlocker.Unlock()
+				c.Assert(err, IsNil)
+
+				return args{
+					key:   key,
+					lock:  kvlocker,
+					lease: true,
+				}
+			},
+			setupWanted: func() wanted {
+				return wanted{
+					err: ErrLockLeaseExpired,
+				}
+			},
+			cleanup: func(args args) error {
+				key := randomPath + "foo"
+				// verify that key was actually updated
+				gr, err := e.etcdClient.Get(context.Background(), key)
+				c.Assert(err, IsNil)
+				c.Assert(gr.Count, Equals, int64(1))
+				c.Assert(gr.Kvs[0].Value, checker.DeepEquals, []byte("bar"))
+				return nil
+			},
+		},
+	}
+	for _, tt := range tests {
+		c.Log(tt.name)
+		args := tt.setupArgs()
+		want := tt.setupWanted()
+		updated, err := Client().UpdateIfDifferentIfLocked(context.Background(), args.key, args.newValue, args.lease, args.lock)
+		c.Assert(err, Equals, want.err)
+		c.Assert(updated, Equals, want.updated)
+		err = tt.cleanup(args)
+		c.Assert(err, IsNil)
+	}
+}
+
+func (e *EtcdLockedSuite) TestCreateOnlyIfLocked(c *C) {
+	randomPath := c.MkDir()
+	type args struct {
+		key      string
+		lock     KVLocker
+		newValue []byte
+		lease    bool
+	}
+	type wanted struct {
+		err     error
+		created bool
+	}
+	tests := []struct {
+		name        string
+		setupArgs   func() args
+		setupWanted func() wanted
+		cleanup     func(args args) error
+	}{
+		{
+			name: "create only locked path without lease",
+			setupArgs: func() args {
+				key := randomPath + "foo"
+				kvlocker, err := Client().LockPath(context.Background(), "locks/"+key+"/.lock")
+				c.Assert(err, IsNil)
+
+				_, err = e.etcdClient.Delete(context.Background(), key)
+				c.Assert(err, IsNil)
+
+				return args{
+					key:      key,
+					lock:     kvlocker,
+					newValue: []byte("newbar"),
+				}
+			},
+			setupWanted: func() wanted {
+				return wanted{
+					err:     nil,
+					created: true,
+				}
+			},
+			cleanup: func(args args) error {
+				key := randomPath + "foo"
+				// verify that key was actually created
+				gr, err := e.etcdClient.Get(context.Background(), key)
+				c.Assert(err, IsNil)
+				c.Assert(gr.Count, Equals, int64(1))
+				c.Assert(gr.Kvs[0].Value, checker.DeepEquals, []byte("newbar"))
+
+				return args.lock.Unlock()
+			},
+		},
+		{
+			name: "create only locked path with an existing value without lease",
+			setupArgs: func() args {
+				key := randomPath + "foo"
+				kvlocker, err := Client().LockPath(context.Background(), "locks/"+key+"/.lock")
+				c.Assert(err, IsNil)
+
+				_, err = e.etcdClient.Put(context.Background(), key, "bar")
+				c.Assert(err, IsNil)
+
+				return args{
+					key:      key,
+					lock:     kvlocker,
+					newValue: []byte("newbar"),
+				}
+			},
+			setupWanted: func() wanted {
+				return wanted{
+					err: nil,
+				}
+			},
+			cleanup: func(args args) error {
+				key := randomPath + "foo"
+				// the key should not have been created and therefore the old
+				// value is still there
+				gr, err := e.etcdClient.Get(context.Background(), key)
+				c.Assert(err, IsNil)
+				c.Assert(gr.Count, Equals, int64(1))
+				c.Assert(gr.Kvs[0].Value, checker.DeepEquals, []byte("bar"))
+
+				return args.lock.Unlock()
+			},
+		},
+		{
+			name: "create only locked path where lock was lost without lease",
+			setupArgs: func() args {
+				key := randomPath + "foo"
+				kvlocker, err := Client().LockPath(context.Background(), "locks/"+key+"/.lock")
+				c.Assert(err, IsNil)
+				_, err = e.etcdClient.Delete(context.Background(), key)
+				c.Assert(err, IsNil)
+				err = kvlocker.Unlock()
+				c.Assert(err, IsNil)
+
+				return args{
+					key:      key,
+					lock:     kvlocker,
+					newValue: []byte("bar"),
+				}
+			},
+			setupWanted: func() wanted {
+				return wanted{
+					err: ErrLockLeaseExpired,
+				}
+			},
+			cleanup: func(args args) error {
+				key := randomPath + "foo"
+				// verify that key was not created
+				gr, err := e.etcdClient.Get(context.Background(), key)
+				c.Assert(err, IsNil)
+				c.Assert(gr.Count, Equals, int64(0))
+				return nil
+			},
+		},
+		{
+			name: "create only locked path with lease",
+			setupArgs: func() args {
+				key := randomPath + "foo"
+				kvlocker, err := Client().LockPath(context.Background(), "locks/"+key+"/.lock")
+				c.Assert(err, IsNil)
+
+				_, err = e.etcdClient.Delete(context.Background(), key)
+				c.Assert(err, IsNil)
+
+				return args{
+					key:      key,
+					lock:     kvlocker,
+					newValue: []byte("newbar"),
+					lease:    true,
+				}
+			},
+			setupWanted: func() wanted {
+				return wanted{
+					err:     nil,
+					created: true,
+				}
+			},
+			cleanup: func(args args) error {
+				key := randomPath + "foo"
+				// verify that key was actually created
+				gr, err := e.etcdClient.Get(context.Background(), key)
+				c.Assert(err, IsNil)
+				c.Assert(gr.Count, Equals, int64(1))
+				c.Assert(gr.Kvs[0].Value, checker.DeepEquals, []byte("newbar"))
+
+				return args.lock.Unlock()
+			},
+		},
+		{
+			name: "create only locked path with an existing value with lease",
+			setupArgs: func() args {
+				key := randomPath + "foo"
+				kvlocker, err := Client().LockPath(context.Background(), "locks/"+key+"/.lock")
+				c.Assert(err, IsNil)
+
+				_, err = e.etcdClient.Put(context.Background(), key, "bar")
+				c.Assert(err, IsNil)
+
+				return args{
+					key:      key,
+					lock:     kvlocker,
+					newValue: []byte("newbar"),
+					lease:    true,
+				}
+			},
+			setupWanted: func() wanted {
+				return wanted{
+					err: nil,
+				}
+			},
+			cleanup: func(args args) error {
+				key := randomPath + "foo"
+				// the key should not have been created and therefore the old
+				// value is still there
+				gr, err := e.etcdClient.Get(context.Background(), key)
+				c.Assert(err, IsNil)
+				c.Assert(gr.Count, Equals, int64(1))
+				c.Assert(gr.Kvs[0].Value, checker.DeepEquals, []byte("bar"))
+
+				return args.lock.Unlock()
+			},
+		},
+		{
+			name: "create only locked path where lock was lost with lease",
+			setupArgs: func() args {
+				key := randomPath + "foo"
+				kvlocker, err := Client().LockPath(context.Background(), "locks/"+key+"/.lock")
+				c.Assert(err, IsNil)
+				_, err = e.etcdClient.Delete(context.Background(), key)
+				c.Assert(err, IsNil)
+				err = kvlocker.Unlock()
+				c.Assert(err, IsNil)
+
+				return args{
+					key:      key,
+					lock:     kvlocker,
+					newValue: []byte("bar"),
+					lease:    true,
+				}
+			},
+			setupWanted: func() wanted {
+				return wanted{
+					err: ErrLockLeaseExpired,
+				}
+			},
+			cleanup: func(args args) error {
+				key := randomPath + "foo"
+				// verify that key was not created
+				gr, err := e.etcdClient.Get(context.Background(), key)
+				c.Assert(err, IsNil)
+				c.Assert(gr.Count, Equals, int64(0))
+				return nil
+			},
+		},
+	}
+	for _, tt := range tests {
+		c.Log(tt.name)
+		args := tt.setupArgs()
+		want := tt.setupWanted()
+		created, err := Client().CreateOnlyIfLocked(context.Background(), args.key, args.newValue, args.lease, args.lock)
+		c.Assert(err, Equals, want.err)
+		c.Assert(created, Equals, want.created)
+		err = tt.cleanup(args)
+		c.Assert(err, IsNil)
+	}
+}
+
+func (e *EtcdLockedSuite) TestListPrefixIfLocked(c *C) {
+	randomPath := c.MkDir()
+	type args struct {
+		key  string
+		lock KVLocker
+	}
+	type wanted struct {
+		err     error
+		kvPairs KeyValuePairs
+	}
+	tests := []struct {
+		name        string
+		setupArgs   func() args
+		setupWanted func() wanted
+		cleanup     func(args args) error
+	}{
+		{
+			name: "list prefix locked",
+			setupArgs: func() args {
+				key := randomPath + "foo"
+				kvlocker, err := Client().LockPath(context.Background(), "locks/"+key+"/.lock")
+				c.Assert(err, IsNil)
+				_, err = e.etcdClient.Put(context.Background(), key, "bar")
+				c.Assert(err, IsNil)
+				_, err = e.etcdClient.Put(context.Background(), key+"1", "bar1")
+				c.Assert(err, IsNil)
+
+				return args{
+					key:  key,
+					lock: kvlocker,
+				}
+			},
+			setupWanted: func() wanted {
+				key := randomPath + "foo"
+				return wanted{
+					err: nil,
+					kvPairs: KeyValuePairs{
+						key: Value{
+							Data: []byte("bar"),
+						},
+						key + "1": Value{
+							Data: []byte("bar1"),
+						},
+					},
+				}
+			},
+			cleanup: func(args args) error {
+				_, err := e.etcdClient.Delete(context.Background(), args.key, etcdAPI.WithPrefix())
+				if err != nil {
+					return err
+				}
+				return args.lock.Unlock()
+			},
+		},
+		{
+			name: "list prefix locked with no values",
+			setupArgs: func() args {
+				key := randomPath + "foo"
+				kvlocker, err := Client().LockPath(context.Background(), "locks/"+key+"/.lock")
+				c.Assert(err, IsNil)
+				_, err = e.etcdClient.Delete(context.Background(), key, etcdAPI.WithPrefix())
+				c.Assert(err, IsNil)
+
+				return args{
+					key:  key,
+					lock: kvlocker,
+				}
+			},
+			setupWanted: func() wanted {
+				return wanted{
+					err: nil,
+				}
+			},
+			cleanup: func(args args) error {
+				return args.lock.Unlock()
+			},
+		},
+		{
+			name: "list prefix locked where lock was lost",
+			setupArgs: func() args {
+				key := randomPath + "foo"
+				kvlocker, err := Client().LockPath(context.Background(), "locks/"+key+"/.lock")
+				c.Assert(err, IsNil)
+				_, err = e.etcdClient.Put(context.Background(), key, "bar")
+				c.Assert(err, IsNil)
+				_, err = e.etcdClient.Put(context.Background(), key+"1", "bar1")
+				c.Assert(err, IsNil)
+				err = kvlocker.Unlock()
+				c.Assert(err, IsNil)
+
+				return args{
+					key:  key,
+					lock: kvlocker,
+				}
+			},
+			setupWanted: func() wanted {
+				return wanted{
+					err: ErrLockLeaseExpired,
+				}
+			},
+			cleanup: func(args args) error {
+				_, err := e.etcdClient.Delete(context.Background(), args.key)
+				return err
+			},
+		},
+	}
+	for _, tt := range tests {
+		c.Log(tt.name)
+		args := tt.setupArgs()
+		want := tt.setupWanted()
+		kvPairs, err := Client().ListPrefixIfLocked(args.key, args.lock)
+		c.Assert(err, Equals, want.err)
+		for k, v := range kvPairs {
+			// We don't compare revision of the value because we can't predict
+			// its value.
+			v1, ok := want.kvPairs[k]
+			c.Assert(ok, Equals, true)
+			c.Assert(v.Data, checker.DeepEquals, v1.Data)
+		}
+		err = tt.cleanup(args)
+		c.Assert(err, IsNil)
 	}
 }

--- a/pkg/kvstore/keepalive.go
+++ b/pkg/kvstore/keepalive.go
@@ -19,8 +19,11 @@ import (
 )
 
 var (
-	// LeaseTTL is the time-to-live ofthe lease
+	// LeaseTTL is the time-to-live of the lease
 	LeaseTTL = 15 * time.Minute // 15 minutes
+
+	// LockLeaseTTL is the time-to-live of the lease dedicated for locks
+	LockLeaseTTL = 25 * time.Second
 
 	// KeepAliveInterval is the interval in which the lease is being
 	// renewed. This must be set to a value lesser than the LeaseTTL

--- a/pkg/kvstore/kvstore.go
+++ b/pkg/kvstore/kvstore.go
@@ -54,10 +54,24 @@ func Get(key string) ([]byte, error) {
 	return v, err
 }
 
+// GetIfLocked returns value of key if the client is still holding the given lock.
+func GetIfLocked(key string, lock kvLocker) ([]byte, error) {
+	v, err := Client().GetIfLocked(key, lock)
+	Trace("GetIfLocked", err, logrus.Fields{fieldKey: key, fieldValue: string(v)})
+	return v, err
+}
+
 // GetPrefix returns the first key which matches the prefix and its value.
 func GetPrefix(ctx context.Context, prefix string) (k string, v []byte, err error) {
 	k, v, err = Client().GetPrefix(ctx, prefix)
 	Trace("GetPrefix", err, logrus.Fields{fieldPrefix: prefix, fieldKey: k, fieldValue: string(v)})
+	return
+}
+
+// GetPrefixIfLocked returns the first key which matches the prefix and its value if the client is still holding the given lock.
+func GetPrefixIfLocked(ctx context.Context, prefix string, lock kvLocker) (k string, v []byte, err error) {
+	k, v, err = Client().GetPrefixIfLocked(ctx, prefix, lock)
+	Trace("GetPrefixIfLocked", err, logrus.Fields{fieldPrefix: prefix, fieldKey: k, fieldValue: string(v)})
 	return
 }
 
@@ -68,10 +82,28 @@ func ListPrefix(prefix string) (KeyValuePairs, error) {
 	return v, err
 }
 
+// ListPrefixIfLocked  returns a list of keys matching the prefix only if the client is still holding the given lock.
+func ListPrefixIfLocked(prefix string, lock kvLocker) (KeyValuePairs, error) {
+	v, err := Client().ListPrefixIfLocked(prefix, lock)
+	Trace("ListPrefixIfLocked", err, logrus.Fields{fieldPrefix: prefix, fieldNumEntries: len(v)})
+	return v, err
+}
+
 // CreateOnly atomically creates a key or fails if it already exists
 func CreateOnly(ctx context.Context, key string, value []byte, lease bool) (bool, error) {
 	success, err := Client().CreateOnly(ctx, key, value, lease)
 	Trace("CreateOnly", err, logrus.Fields{
+		fieldKey: key, fieldValue: string(value),
+		fieldAttachLease: lease,
+		"success":        success,
+	})
+	return success, err
+}
+
+// CreateOnlyIfLocked atomically creates a key if the client is still holding the given lock or fails if it already exists
+func CreateOnlyIfLocked(ctx context.Context, key string, value []byte, lease bool, lock kvLocker) (bool, error) {
+	success, err := Client().CreateOnlyIfLocked(ctx, key, value, lease, lock)
+	Trace("CreateOnlyIfLocked", err, logrus.Fields{
 		fieldKey: key, fieldValue: string(value),
 		fieldAttachLease: lease,
 		"success":        success,
@@ -89,7 +121,19 @@ func Update(ctx context.Context, key string, value []byte, lease bool) error {
 // UpdateIfDifferent updates a key if the value is different
 func UpdateIfDifferent(ctx context.Context, key string, value []byte, lease bool) (bool, error) {
 	recreated, err := Client().UpdateIfDifferent(ctx, key, value, lease)
-	Trace("Update", err, logrus.Fields{
+	Trace("UpdateIfDifferent", err, logrus.Fields{
+		fieldKey:         key,
+		fieldValue:       string(value),
+		fieldAttachLease: lease,
+		"recreated":      recreated,
+	})
+	return recreated, err
+}
+
+// UpdateIfDifferentIfLocked updates a key if the value is different and if the client is still holding the given lock.
+func UpdateIfDifferentIfLocked(ctx context.Context, key string, value []byte, lease bool, lock kvLocker) (bool, error) {
+	recreated, err := Client().UpdateIfDifferentIfLocked(ctx, key, value, lease, lock)
+	Trace("UpdateIfDifferentIfLocked", err, logrus.Fields{
 		fieldKey:         key,
 		fieldValue:       string(value),
 		fieldAttachLease: lease,
@@ -116,6 +160,13 @@ func Set(key string, value []byte) error {
 func Delete(key string) error {
 	err := Client().Delete(key)
 	Trace("Delete", err, logrus.Fields{fieldKey: key})
+	return err
+}
+
+// DeleteIfLocked deletes a key if the client is still holding the given lock.
+func DeleteIfLocked(key string, lock kvLocker) error {
+	err := Client().DeleteIfLocked(key, lock)
+	Trace("DeleteIfLocked", err, logrus.Fields{fieldKey: key})
 	return err
 }
 

--- a/pkg/kvstore/kvstore.go
+++ b/pkg/kvstore/kvstore.go
@@ -55,7 +55,7 @@ func Get(key string) ([]byte, error) {
 }
 
 // GetIfLocked returns value of key if the client is still holding the given lock.
-func GetIfLocked(key string, lock kvLocker) ([]byte, error) {
+func GetIfLocked(key string, lock KVLocker) ([]byte, error) {
 	v, err := Client().GetIfLocked(key, lock)
 	Trace("GetIfLocked", err, logrus.Fields{fieldKey: key, fieldValue: string(v)})
 	return v, err
@@ -69,7 +69,7 @@ func GetPrefix(ctx context.Context, prefix string) (k string, v []byte, err erro
 }
 
 // GetPrefixIfLocked returns the first key which matches the prefix and its value if the client is still holding the given lock.
-func GetPrefixIfLocked(ctx context.Context, prefix string, lock kvLocker) (k string, v []byte, err error) {
+func GetPrefixIfLocked(ctx context.Context, prefix string, lock KVLocker) (k string, v []byte, err error) {
 	k, v, err = Client().GetPrefixIfLocked(ctx, prefix, lock)
 	Trace("GetPrefixIfLocked", err, logrus.Fields{fieldPrefix: prefix, fieldKey: k, fieldValue: string(v)})
 	return
@@ -83,7 +83,7 @@ func ListPrefix(prefix string) (KeyValuePairs, error) {
 }
 
 // ListPrefixIfLocked  returns a list of keys matching the prefix only if the client is still holding the given lock.
-func ListPrefixIfLocked(prefix string, lock kvLocker) (KeyValuePairs, error) {
+func ListPrefixIfLocked(prefix string, lock KVLocker) (KeyValuePairs, error) {
 	v, err := Client().ListPrefixIfLocked(prefix, lock)
 	Trace("ListPrefixIfLocked", err, logrus.Fields{fieldPrefix: prefix, fieldNumEntries: len(v)})
 	return v, err
@@ -101,7 +101,7 @@ func CreateOnly(ctx context.Context, key string, value []byte, lease bool) (bool
 }
 
 // CreateOnlyIfLocked atomically creates a key if the client is still holding the given lock or fails if it already exists
-func CreateOnlyIfLocked(ctx context.Context, key string, value []byte, lease bool, lock kvLocker) (bool, error) {
+func CreateOnlyIfLocked(ctx context.Context, key string, value []byte, lease bool, lock KVLocker) (bool, error) {
 	success, err := Client().CreateOnlyIfLocked(ctx, key, value, lease, lock)
 	Trace("CreateOnlyIfLocked", err, logrus.Fields{
 		fieldKey: key, fieldValue: string(value),
@@ -131,7 +131,7 @@ func UpdateIfDifferent(ctx context.Context, key string, value []byte, lease bool
 }
 
 // UpdateIfDifferentIfLocked updates a key if the value is different and if the client is still holding the given lock.
-func UpdateIfDifferentIfLocked(ctx context.Context, key string, value []byte, lease bool, lock kvLocker) (bool, error) {
+func UpdateIfDifferentIfLocked(ctx context.Context, key string, value []byte, lease bool, lock KVLocker) (bool, error) {
 	recreated, err := Client().UpdateIfDifferentIfLocked(ctx, key, value, lease, lock)
 	Trace("UpdateIfDifferentIfLocked", err, logrus.Fields{
 		fieldKey:         key,
@@ -164,7 +164,7 @@ func Delete(key string) error {
 }
 
 // DeleteIfLocked deletes a key if the client is still holding the given lock.
-func DeleteIfLocked(key string, lock kvLocker) error {
+func DeleteIfLocked(key string, lock KVLocker) error {
 	err := Client().DeleteIfLocked(key, lock)
 	Trace("DeleteIfLocked", err, logrus.Fields{fieldKey: key})
 	return err

--- a/pkg/kvstore/lock.go
+++ b/pkg/kvstore/lock.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,8 +39,12 @@ var (
 	staleLockTimeout = time.Duration(30) * time.Second
 )
 
-type kvLocker interface {
+type KVLocker interface {
 	Unlock() error
+	// Comparator returns an object that should be used by the KVStore to make
+	// sure if the lock is still valid for its client or nil if no such
+	// verification exists.
+	Comparator() interface{}
 }
 
 // getLockPath returns the lock path representation of the given path.
@@ -101,7 +105,7 @@ func (pl *pathLocks) unlock(path string, id uuid.UUID) {
 type Lock struct {
 	path   string
 	id     uuid.UUID
-	kvLock kvLocker
+	kvLock KVLocker
 }
 
 // LockPath locks the specified path. The key for the lock is not the path
@@ -141,4 +145,8 @@ func (l *Lock) Unlock() error {
 	Trace("Unlocked", nil, logrus.Fields{fieldKey: l.path})
 
 	return err
+}
+
+func (l *Lock) Comparator() interface{} {
+	return l.kvLock.Comparator()
 }

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -73,6 +73,9 @@ Vagrant.configure("2") do |config|
                 vb.default_nic_type = "virtio"
                 # Prevent VirtualBox from interfering with host audio stack
                 vb.customize ["modifyvm", :id, "--audio", "none"]
+                # Use serial ports if the VM is no longer accessible via SSH
+                vb.customize ["modifyvm", :id, "--uart1", "0x3F8", "4"]
+                vb.customize ["modifyvm", :id, "--uartmode1", "server", "k8s#{i}-#{$K8S_VERSION}-ttyS0.sock"]
             end
 
             server.vm.box =  "#{$SERVER_BOX}"

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -98,6 +98,8 @@ Vagrant.configure("2") do |config|
                 nfs: $NFS
             # Provision section
             server.vm.provision :shell,
+                :inline => "sudo sysctl -w net.ipv6.conf.all.forwarding=1"
+            server.vm.provision :shell,
                 :inline => "sed -i 's/^mesg n$/tty -s \\&\\& mesg n/g' /root/.profile"
             server.vm.provision "file", source: "provision/", destination: "/tmp/"
             server.vm.provision "shell" do |sh|

--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -75,7 +75,7 @@ func ExpectETCDOperatorReady(vm *helpers.Kubectl) {
 	// so we need to wait until 5 pods are in ready state.
 	// This is to avoid cases where a few pods are ready, but the
 	// new one is not created yet.
-	By("Waiting for all etcd-operator pods are ready")
+	By("Waiting for all etcd-operator pods to be ready")
 
 	err := vm.WaitforNPods(helpers.KubeSystemNamespace, "-l io.cilium/app=etcd-operator", 5, longTimeout)
 	warningMessage := ""

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -194,7 +194,7 @@ case $K8S_VERSION in
         ;;
     "1.13")
         KUBERNETES_CNI_VERSION="0.7.5"
-        K8S_FULL_VERSION="1.13.6"
+        K8S_FULL_VERSION="1.13.7"
         KUBEADM_OPTIONS="--ignore-preflight-errors=cri,SystemVerification"
         KUBEADM_SLAVE_OPTIONS="--discovery-token-unsafe-skip-ca-verification --ignore-preflight-errors=cri,SystemVerification"
         sudo ln -sf $COREDNS_DEPLOYMENT $DNS_DEPLOYMENT

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -41,6 +41,16 @@ source ${PROVISIONSRC}/helpers.bash
 sudo bash -c "echo MaxSessions 200 >> /etc/ssh/sshd_config"
 sudo systemctl restart ssh
 
+# Install serial ttyS0 server
+cat <<EOF > /etc/systemd/system/serial-getty@ttyS0.service
+[Service]
+ExecStart=
+ExecStart=/sbin/agetty --autologin root -8 --keep-baud 115200,38400,9600 ttyS0 \$TERM
+EOF
+
+systemctl daemon-reload
+sudo service serial-getty@ttyS0 start
+
 # TODO: Check if the k8s version is the same
 if [[ -f  "/etc/provision_finished" ]]; then
     sudo dpkg -l | grep kubelet


### PR DESCRIPTION
 * #8225 -- endpoint: make sure `updateRegenerationStatistics` is called within anonymous function (@ianvernon)
 * ~~#8220 -- test: Prevent from breaking connections to migrate-svc (@brb)~~
 * #8235 -- .Jenkinsfile: remove leftover failFast (@aanm)
 * #8232 -- test: add serial ports to CI VMs (@aanm)
 * #8195 -- Add dedicated etcd session for distributed locks (@aanm)
 * #8242 -- docs: Fix architecture images URLs (@joestringer)
 * #8160 -- test: Enable IPv6 forwarding in test VMs (@iffyio)
 * #8249 -- test: bump k8s 1.13 to 1.13.7 (@aanm)

Once this PR is merged, you can update the PR labels via:
```
$ for pr in 8225 8235 8232 8195 8242 8160 8249; do contrib/backporting/set-labels.py $pr done 1.5; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8252)
<!-- Reviewable:end -->
