### PR TITLE
daemon: split up bootstrapping code into smaller functions, logically group specific code into smaller files

### DIFF
--- a/daemon/config.go
+++ b/daemon/config.go
@@ -1,0 +1,143 @@
+// Copyright 2016-2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/cilium/cilium/api/v1/models"
+	. "github.com/cilium/cilium/api/v1/server/restapi/daemon"
+	"github.com/cilium/cilium/pkg/api"
+	"github.com/cilium/cilium/pkg/k8s"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/policy"
+	"github.com/go-openapi/runtime/middleware"
+)
+
+type patchConfig struct {
+	daemon *Daemon
+}
+
+func NewPatchConfigHandler(d *Daemon) PatchConfigHandler {
+	return &patchConfig{daemon: d}
+}
+
+func (h *patchConfig) Handle(params PatchConfigParams) middleware.Responder {
+	log.WithField(logfields.Params, logfields.Repr(params)).Debug("PATCH /config request")
+
+	d := h.daemon
+
+	cfgSpec := params.Configuration
+
+	om, err := option.Config.Opts.Library.ValidateConfigurationMap(cfgSpec.Options)
+	if err != nil {
+		msg := fmt.Errorf("Invalid configuration option %s", err)
+		return api.Error(PatchConfigBadRequestCode, msg)
+	}
+
+	// Serialize configuration updates to the daemon.
+	option.Config.ConfigPatchMutex.Lock()
+	defer option.Config.ConfigPatchMutex.Unlock()
+
+	// Track changes to daemon's configuration
+	var changes int
+
+	// Only update if value provided for PolicyEnforcement.
+	if enforcement := cfgSpec.PolicyEnforcement; enforcement != "" {
+		switch enforcement {
+		case option.NeverEnforce, option.DefaultEnforcement, option.AlwaysEnforce:
+			// Update policy enforcement configuration if needed.
+			oldEnforcementValue := policy.GetPolicyEnabled()
+
+			// If the policy enforcement configuration has indeed changed, we have
+			// to regenerate endpoints and update daemon's configuration.
+			if enforcement != oldEnforcementValue {
+				log.Debug("configuration request to change PolicyEnforcement for daemon")
+				changes++
+				policy.SetPolicyEnabled(enforcement)
+			}
+
+		default:
+			msg := fmt.Errorf("Invalid option for PolicyEnforcement %s", enforcement)
+			log.Warn(msg)
+			return api.Error(PatchConfigFailureCode, msg)
+		}
+		log.Debug("finished configuring PolicyEnforcement for daemon")
+	}
+
+	changes += option.Config.Opts.ApplyValidated(om, changedOption, d)
+
+	log.WithField("count", changes).Debug("Applied changes to daemon's configuration")
+
+	if changes > 0 {
+		// Only recompile if configuration has changed.
+		log.Debug("daemon configuration has changed; recompiling base programs")
+		if err := d.compileBase(); err != nil {
+			msg := fmt.Errorf("Unable to recompile base programs: %s", err)
+			return api.Error(PatchConfigFailureCode, msg)
+		}
+		d.TriggerPolicyUpdates(true, "agent configuration update")
+	}
+
+	return NewPatchConfigOK()
+}
+
+type getConfig struct {
+	daemon *Daemon
+}
+
+func NewGetConfigHandler(d *Daemon) GetConfigHandler {
+	return &getConfig{daemon: d}
+}
+
+func (h *getConfig) Handle(params GetConfigParams) middleware.Responder {
+	log.WithField(logfields.Params, logfields.Repr(params)).Debug("GET /config request")
+
+	d := h.daemon
+
+	spec := &models.DaemonConfigurationSpec{
+		Options:           *option.Config.Opts.GetMutableModel(),
+		PolicyEnforcement: policy.GetPolicyEnabled(),
+	}
+
+	monitorState := d.monitorAgent.State()
+	status := &models.DaemonConfigurationStatus{
+		Addressing:       node.GetNodeAddressing(),
+		K8sConfiguration: k8s.GetKubeconfigPath(),
+		K8sEndpoint:      k8s.GetAPIServer(),
+		NodeMonitor:      &monitorState,
+		KvstoreConfiguration: &models.KVstoreConfiguration{
+			Type:    option.Config.KVStore,
+			Options: option.Config.KVStoreOpt,
+		},
+		Realized:     spec,
+		DeviceMTU:    int64(d.mtuConfig.GetDeviceMTU()),
+		RouteMTU:     int64(d.mtuConfig.GetRouteMTU()),
+		DatapathMode: models.DatapathMode(option.Config.DatapathMode),
+		IpvlanConfiguration: &models.IpvlanConfiguration{
+			MasterDeviceIndex: int64(option.Config.Ipvlan.MasterDeviceIndex),
+			OperationMode:     option.Config.Ipvlan.OperationMode,
+		},
+	}
+
+	cfg := &models.DaemonConfiguration{
+		Spec:   spec,
+		Status: status,
+	}
+
+	return NewGetConfigOK().WithPayload(cfg)
+}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1506,19 +1506,6 @@ func numWorkerThreads() int {
 	return ncpu
 }
 
-// GetServiceList returns list of services
-func (d *Daemon) GetServiceList() []*models.Service {
-	list := []*models.Service{}
-
-	d.loadBalancer.BPFMapMU.RLock()
-	defer d.loadBalancer.BPFMapMU.RUnlock()
-
-	for _, v := range d.loadBalancer.SVCMap {
-		list = append(list, v.GetModel())
-	}
-	return list
-}
-
 // SendNotification sends an agent notification to the monitor
 func (d *Daemon) SendNotification(typ monitorAPI.AgentNotification, text string) error {
 	if option.Config.DryMode {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -31,7 +31,6 @@ import (
 	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/cgroups"
-	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/clustermesh"
 	"github.com/cilium/cilium/pkg/command/exec"
 	"github.com/cilium/cilium/pkg/completion"
@@ -901,42 +900,6 @@ func deleteHostDevice() {
 	}
 }
 
-func (d *Daemon) allocateDatapathIPs(family datapath.NodeAddressingFamily) (routerIP net.IP, err error) {
-	// Blacklist allocation of the external IP
-	d.ipam.BlacklistIP(family.PrimaryExternal(), "node-ip")
-
-	// (Re-)allocate the router IP. If not possible, allocate a fresh IP.
-	// In that case, removal and re-creation of the cilium_host is
-	// required. It will also cause disruption of networking until all
-	// endpoints have been regenerated.
-	routerIP = family.Router()
-	if routerIP != nil {
-		err = d.ipam.AllocateIP(routerIP, "router")
-		if err != nil {
-			log.Warningf("Router IP could not be re-allocated. Need to re-allocate. This will cause brief network disruption")
-
-			// The restored router IP is not part of the allocation range.
-			// This indicates that the allocation range has changed.
-			if !option.Config.IsFlannelMasterDeviceSet() {
-				deleteHostDevice()
-			}
-
-			// force re-allocation of the router IP
-			routerIP = nil
-		}
-	}
-
-	if routerIP == nil {
-		routerIP, err = d.ipam.AllocateNextFamily(ipam.DeriveFamily(family.PrimaryExternal()), "router")
-		if err != nil {
-			err = fmt.Errorf("Unable to allocate IPv4 router IP: %s", err)
-			return
-		}
-	}
-
-	return
-}
-
 // NewDaemon creates and returns a new Daemon with the parameters set in c.
 func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 	bootstrapStats.daemonInit.Start()
@@ -1170,107 +1133,6 @@ func setupIPSec() (int, error) {
 	return authKeySize, nil
 }
 
-func (d *Daemon) allocateHealthIPs() error {
-	bootstrapStats.healthCheck.Start()
-	if option.Config.EnableHealthChecking {
-		if option.Config.EnableIPv4 {
-			health4, err := d.ipam.AllocateNextFamily(ipam.IPv4, "health")
-			if err != nil {
-				return fmt.Errorf("unable to allocate health IPs: %s,see https://cilium.link/ipam-range-full", err)
-			}
-
-			d.nodeDiscovery.LocalNode.IPv4HealthIP = health4
-			log.Debugf("IPv4 health endpoint address: %s", health4)
-		}
-
-		if option.Config.EnableIPv6 {
-			health6, err := d.ipam.AllocateNextFamily(ipam.IPv6, "health")
-			if err != nil {
-				if d.nodeDiscovery.LocalNode.IPv4HealthIP != nil {
-					d.ipam.ReleaseIP(d.nodeDiscovery.LocalNode.IPv4HealthIP)
-				}
-				return fmt.Errorf("unable to allocate health IPs: %s,see https://cilium.link/ipam-range-full", err)
-			}
-
-			d.nodeDiscovery.LocalNode.IPv6HealthIP = health6
-			log.Debugf("IPv6 health endpoint address: %s", health6)
-		}
-	}
-	bootstrapStats.healthCheck.End(true)
-	return nil
-}
-
-func (d *Daemon) allocateIPs() error {
-	bootstrapStats.ipam.Start()
-	if option.Config.EnableIPv4 {
-		routerIP, err := d.allocateDatapathIPs(d.datapath.LocalNodeAddressing().IPv4())
-		if err != nil {
-			return err
-		}
-		if routerIP != nil {
-			node.SetInternalIPv4(routerIP)
-		}
-	}
-
-	if option.Config.EnableIPv6 {
-		routerIP, err := d.allocateDatapathIPs(d.datapath.LocalNodeAddressing().IPv6())
-		if err != nil {
-			return err
-		}
-		if routerIP != nil {
-			node.SetIPv6Router(routerIP)
-		}
-	}
-
-	log.Info("Addressing information:")
-	log.Infof("  Cluster-Name: %s", option.Config.ClusterName)
-	log.Infof("  Cluster-ID: %d", option.Config.ClusterID)
-	log.Infof("  Local node-name: %s", node.GetName())
-	log.Infof("  Node-IPv6: %s", node.GetIPv6())
-
-	if option.Config.EnableIPv6 {
-		log.Infof("  IPv6 node prefix: %s", node.GetIPv6NodeRange())
-		log.Infof("  IPv6 allocation prefix: %s", node.GetIPv6AllocRange())
-		log.Infof("  IPv6 router address: %s", node.GetIPv6Router())
-
-		if addrs, err := d.datapath.LocalNodeAddressing().IPv6().LocalAddresses(); err != nil {
-			log.WithError(err).Fatal("Unable to list local IPv6 addresses")
-		} else {
-			log.Info("  Local IPv6 addresses:")
-			for _, ip := range addrs {
-				log.Infof("  - %s", ip)
-			}
-		}
-	}
-
-	log.Infof("  External-Node IPv4: %s", node.GetExternalIPv4())
-	log.Infof("  Internal-Node IPv4: %s", node.GetInternalIPv4())
-
-	if option.Config.EnableIPv4 {
-		log.Infof("  Cluster IPv4 prefix: %s", node.GetIPv4ClusterRange())
-		log.Infof("  IPv4 allocation prefix: %s", node.GetIPv4AllocRange())
-
-		// Allocate IPv4 service loopback IP
-		loopbackIPv4 := net.ParseIP(option.Config.LoopbackIPv4)
-		if loopbackIPv4 == nil {
-			return fmt.Errorf("Invalid IPv4 loopback address %s", option.Config.LoopbackIPv4)
-		}
-		node.SetIPv4Loopback(loopbackIPv4)
-		log.Infof("  Loopback IPv4: %s", node.GetIPv4Loopback().String())
-
-		if addrs, err := d.datapath.LocalNodeAddressing().IPv4().LocalAddresses(); err != nil {
-			log.WithError(err).Fatal("Unable to list local IPv4 addresses")
-		} else {
-			log.Info("  Local IPv4 addresses:")
-			for _, ip := range addrs {
-				log.Infof("  - %s", ip)
-			}
-		}
-	}
-	bootstrapStats.ipam.End(true)
-	return d.allocateHealthIPs()
-}
-
 func (d *Daemon) bootstrapClusterMesh(nodeMngr *nodemanager.Manager) {
 	bootstrapStats.clusterMeshInit.Start()
 	if path := option.Config.ClusterMeshConfig; path != "" {
@@ -1293,55 +1155,6 @@ func (d *Daemon) bootstrapClusterMesh(nodeMngr *nodemanager.Manager) {
 		}
 	}
 	bootstrapStats.clusterMeshInit.End(true)
-}
-
-func (d *Daemon) bootstrapIPAM() {
-	// If the device has been specified, the IPv4AllocPrefix and the
-	// IPv6AllocPrefix were already allocated before the k8s.Init().
-	//
-	// If the device hasn't been specified, k8s.Init() allocated the
-	// IPv4AllocPrefix and the IPv6AllocPrefix from k8s node annotations.
-	//
-	// If k8s.Init() failed to retrieve the IPv4AllocPrefix we can try to derive
-	// it from an existing node_config.h file or from previous cilium_host
-	// interfaces.
-	//
-	// Then, we will calculate the IPv4 or IPv6 alloc prefix based on the IPv6
-	// or IPv4 alloc prefix, respectively, retrieved by k8s node annotations.
-	bootstrapStats.ipam.Start()
-	log.Info("Initializing node addressing")
-
-	node.SetIPv4ClusterCidrMaskSize(option.Config.IPv4ClusterCIDRMaskSize)
-
-	if option.Config.IPv4Range != AutoCIDR {
-		allocCIDR, err := cidr.ParseCIDR(option.Config.IPv4Range)
-		if err != nil {
-			log.WithError(err).WithField(logfields.V4Prefix, option.Config.IPv4Range).Fatal("Invalid IPv4 allocation prefix")
-		}
-		node.SetIPv4AllocRange(allocCIDR)
-	}
-
-	if option.Config.IPv6Range != AutoCIDR {
-		_, net, err := net.ParseCIDR(option.Config.IPv6Range)
-		if err != nil {
-			log.WithError(err).WithField(logfields.V6Prefix, option.Config.IPv6Range).Fatal("Invalid IPv6 allocation prefix")
-		}
-
-		if err := node.SetIPv6NodeRange(net); err != nil {
-			log.WithError(err).WithField(logfields.V6Prefix, net).Fatal("Invalid per node IPv6 allocation prefix")
-		}
-	}
-
-	if err := node.AutoComplete(); err != nil {
-		log.WithError(err).Fatal("Cannot autocomplete node addresses")
-	}
-
-	// Set up ipam conf after init() because we might be running d.conf.KVStoreIPv4Registration
-	d.ipam = ipam.NewIPAM(d.datapath.LocalNodeAddressing(), ipam.Configuration{
-		EnableIPv4: option.Config.EnableIPv4,
-		EnableIPv6: option.Config.EnableIPv6,
-	})
-	bootstrapStats.ipam.End(true)
 }
 
 func (d *Daemon) bootstrapWorkloads() error {

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -36,7 +36,6 @@ import (
 	"github.com/cilium/cilium/pkg/cgroups"
 	"github.com/cilium/cilium/pkg/cleanup"
 	"github.com/cilium/cilium/pkg/components"
-	"github.com/cilium/cilium/pkg/controller"
 	linuxdatapath "github.com/cilium/cilium/pkg/datapath/linux"
 	"github.com/cilium/cilium/pkg/datapath/loader"
 	"github.com/cilium/cilium/pkg/datapath/maps"
@@ -1293,51 +1292,7 @@ func runDaemon() {
 	// (Check Daemon.initK8sSubsystem() for more info)
 	<-k8sCachesSynced
 	bootstrapStats.k8sInit.End(true)
-	bootstrapStats.restore.Start()
-	var restoreComplete chan struct{}
-	if option.Config.RestoreState {
-		// When we regenerate restored endpoints, it is guaranteed tha we have
-		// received the full list of policies present at the time the daemon
-		// is bootstrapped.
-		restoreComplete = d.regenerateRestoredEndpoints(restoredEndpoints)
-		go func() {
-			<-restoreComplete
-			endParallelMapMode()
-		}()
-
-		go func() {
-			if k8s.IsEnabled() {
-				// Start controller which removes any leftover Kubernetes
-				// services that may have been deleted while Cilium was not
-				// running. Once this controller succeeds, because it has no
-				// RunInterval specified, it will not run again unless updated
-				// elsewhere. This means that if, for instance, a user manually
-				// adds a service via the CLI into the BPF maps, that it will
-				// not be cleaned up by the daemon until it restarts.
-				controller.NewManager().UpdateController("sync-lb-maps-with-k8s-services",
-					controller.ControllerParams{
-						DoFunc: func(ctx context.Context) error {
-							return d.syncLBMapsWithK8s()
-						},
-					},
-				)
-				return
-			}
-			if err := d.SyncLBMap(); err != nil {
-				log.WithError(err).Warn("Error while recovering endpoints")
-			}
-		}()
-	} else {
-		log.Info("State restore is disabled. Existing endpoints on node are ignored")
-		// We need to read all docker containers so we know we won't
-		// going to allocate the same IP addresses and we will ignore
-		// these containers from reading.
-		workloads.IgnoreRunningWorkloads()
-
-		// No restore happened, end parallel map mode immediately
-		endParallelMapMode()
-	}
-	bootstrapStats.restore.End(true)
+	restoreComplete := d.initRestore(restoredEndpoints)
 
 	if option.Config.IsFlannelMasterDeviceSet() {
 		// health checking is not supported by flannel

--- a/daemon/loadbalancer.go
+++ b/daemon/loadbalancer.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/api/v1/server/restapi/service"
 	"github.com/cilium/cilium/pkg/api"
 	"github.com/cilium/cilium/pkg/loadbalancer"
@@ -973,4 +974,17 @@ func restoreServices() {
 		"skipped":          skipped,
 		"removed":          removed,
 	}).Info("Restore service IDs from BPF maps")
+}
+
+// GetServiceList returns list of services
+func (d *Daemon) GetServiceList() []*models.Service {
+	list := []*models.Service{}
+
+	d.loadBalancer.BPFMapMU.RLock()
+	defer d.loadBalancer.BPFMapMU.RUnlock()
+
+	for _, v := range d.loadBalancer.SVCMap {
+		list = append(list, v.GetModel())
+	}
+	return list
 }


### PR DESCRIPTION
Having smaller files + functions makes it easier to figure out how parts of the daemon are logically grouped together. This will make the code easier to change and read as time goes on.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8255)
<!-- Reviewable:end -->
