### PR TITLE
Cilium: encrypt-node fixes for invalid route and missing rp_filter zero

### DIFF
--- a/pkg/datapath/linux/datapath.go
+++ b/pkg/datapath/linux/datapath.go
@@ -17,6 +17,8 @@ package linux
 import (
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/datapath/iptables"
+	"github.com/cilium/cilium/pkg/endpoint/connector"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
 // DatapathConfiguration is the static configuration of the datapath. The
@@ -42,6 +44,12 @@ func NewDatapath(config DatapathConfiguration) datapath.Datapath {
 	}
 
 	dp.node = NewNodeHandler(config, dp.nodeAddressing)
+
+	if config.EncryptInterface != "" {
+		if err := connector.DisableRpFilter(config.EncryptInterface); err != nil {
+			log.WithField(logfields.Interface, config.EncryptInterface).Warn("Rpfilter could not be disabled, node to node encryption may fail")
+		}
+	}
 
 	return dp
 }

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -745,15 +745,8 @@ func (n *linuxNodeHandler) createNodeIPSecOutRoute(ip *net.IPNet) route.Route {
 }
 
 func (n *linuxNodeHandler) createNodeExternalIPSecOutRoute(ip *net.IPNet, dflt bool) route.Route {
-	var nexthop net.IP
 	var tbl int
 	var dev string
-
-	if ip.IP.To4() != nil {
-		nexthop = n.nodeAddressing.IPv4().PrimaryExternal()
-	} else {
-		nexthop = n.nodeAddressing.IPv6().PrimaryExternal()
-	}
 
 	if dflt {
 		dev = n.datapathConfig.HostDevice
@@ -763,10 +756,9 @@ func (n *linuxNodeHandler) createNodeExternalIPSecOutRoute(ip *net.IPNet, dflt b
 	}
 
 	return route.Route{
-		Nexthop: &nexthop,
-		Device:  dev,
-		Prefix:  *ip,
-		Table:   tbl,
+		Device: dev,
+		Prefix: *ip,
+		Table:  tbl,
 	}
 }
 

--- a/pkg/endpoint/connector/add.go
+++ b/pkg/endpoint/connector/add.go
@@ -20,6 +20,7 @@ import (
 	"math/rand"
 	"net"
 	"os"
+	"path/filepath"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/logging"
@@ -92,6 +93,15 @@ func WriteSysConfig(fileName, value string) error {
 	err = f.Close()
 	if err != nil {
 		return fmt.Errorf("unable to close configuration file: %s", err)
+	}
+	return nil
+}
+
+// DisableRpFilter tries to disable rpfilter on specified interface
+func DisableRpFilter(ifName string) error {
+	rpFilterPath := filepath.Join("/proc", "sys", "net", "ipv4", "conf", ifName, "rp_filter")
+	if err := WriteSysConfig(rpFilterPath, "0\n"); err != nil {
+		return fmt.Errorf("unable to disable %s: %s", rpFilterPath, err)
 	}
 	return nil
 }

--- a/pkg/endpoint/connector/ipvlan.go
+++ b/pkg/endpoint/connector/ipvlan.go
@@ -17,7 +17,6 @@ package connector
 import (
 	"fmt"
 	"math"
-	"path/filepath"
 	"unsafe"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -275,10 +274,9 @@ func createIpvlanSlave(lxcIfName string, mtu, masterDev int, mode string, ep *mo
 
 	log.WithField(logfields.Ipvlan, []string{lxcIfName}).Debug("Created ipvlan slave in L3 mode")
 
-	rpFilterPath := filepath.Join("/proc", "sys", "net", "ipv4", "conf", lxcIfName, "rp_filter")
-	err = WriteSysConfig(rpFilterPath, "0\n")
+	err = DisableRpFilter(lxcIfName)
 	if err != nil {
-		return nil, nil, fmt.Errorf("unable to disable %s: %s", rpFilterPath, err)
+		return nil, nil, err
 	}
 
 	link, err = netlink.LinkByName(lxcIfName)

--- a/pkg/endpoint/connector/veth.go
+++ b/pkg/endpoint/connector/veth.go
@@ -16,7 +16,6 @@ package connector
 
 import (
 	"fmt"
-	"path/filepath"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/datapath/link"
@@ -82,10 +81,9 @@ func SetupVethWithNames(lxcIfName, tmpIfName string, mtu int, ep *models.Endpoin
 	// Disable reverse path filter on the host side veth peer to allow
 	// container addresses to be used as source address when the linux
 	// stack performs routing.
-	rpFilterPath := filepath.Join("/proc", "sys", "net", "ipv4", "conf", lxcIfName, "rp_filter")
-	err = WriteSysConfig(rpFilterPath, "0\n")
+	err = DisableRpFilter(lxcIfName)
 	if err != nil {
-		return nil, nil, fmt.Errorf("unable to disable %s: %s", rpFilterPath, err)
+		return nil, nil, err
 	}
 
 	peer, err := netlink.LinkByName(tmpIfName)


### PR DESCRIPTION
When encrypt-node is enabled a route is added in the default routing table that routes the IP assigned to the encrypt-interface to cilium_host. However, this is problematic because it results in a routing loop when trying to send traffic (tested with ping) to the node.

After some amount of debugging and staring at the code it appears this happens when a route.Route is specified with a Nexthop but without a Local IPNet. As shown here,

       route.Route{
               Nexthop: nexthop,
               Device:  dev,
               Prefix:  *ip,
               Table:   tbl,
        }

Then the Nexthop address is used as the route destination for the routing table entry and the Prefix ip is ignored(?!). I verified this by putting a log statement just above the route add to ensure it was in-fact using the correct IPs. Further, I found the line that was adding this route by commenting it out and verifying the rule is in fact not added. The offending route is from reateNodeExternalIPSecOutRoute() in the dflt=true case.

There are a few workarounds for this problem. Simply not specifying a Nexthop is the easiest and is the approach we take in this PR because the Nexthop is not needed for encrypt-node and can be removed. An alternative fix is to add a Local IP field.

At this point I don't have a root-cause for the above. The above route.Route is pre-processed by ./pkg/datapath/linux/route/route_linux.go and then translated into a netlink route by the netlink/route_linux.go code in the vendor API. After this it is pushed into the kernel. Presumably, somewhere here either the translation is broken (I'm not seeing how though) or the kernel is buggy. These tests were run on GKEs ubuntu 4.15 kernel. We can root-cause later the above fix resolves this in the meantime. Further its a nice optimization even if there was no issue with the initial route.Route spec.

Lastly, this PR automatically disables rp_filter on the network facing interface. Otherwise if this defaults to '1' node to node traffic will fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8257)
<!-- Reviewable:end -->
