### PR TITLE
test: make sure that `GetPodNames` times out after 30 seconds

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -311,10 +311,9 @@ func (kub *Kubectl) GetPodNames(namespace string, label string) ([]string, error
 
 	cmd := fmt.Sprintf("%s -n %s get pods -l %s %s", KubectlCmd, namespace, label, filter)
 
-	// Since we have no timeout, ensure that the context given to ExecuteContext
-	// eventually cancels in case something is blocked on ctx.Done() (something
-	// is).
-	ctx, cancel := context.WithCancel(context.TODO())
+	// Taking more than 30 seconds to get pods means that something is wrong
+	// connecting to the node.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	err := kub.ExecuteContext(ctx, cmd, stdout, nil)
 


### PR DESCRIPTION
This ensures that (assuming that the child functions are correctly waiting for context to be canceled vs. getting stuck forever before selecting upon context getting canceled / deadline being reached) that the command will exit after a specified amount of time.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8258)
<!-- Reviewable:end -->
