### PR TITLE
test: try to dial to remote host upon each SSH connection

### DIFF
--- a/test/helpers/ssh_command.go
+++ b/test/helpers/ssh_command.go
@@ -280,6 +280,20 @@ func (client *SSHClient) newSession() (*ssh.Session, error) {
 	var err error
 
 	if client.client != nil {
+
+		// First check if we are still able to dial to the remote host with
+		// the client to which we have already connected. If we
+		// can't, return an error. If we can, then close the connection we have
+		// just created, as we already have a session to access.
+		connection, err = ssh.Dial(
+			"tcp",
+			fmt.Sprintf("%s:%d", client.Host, client.Port),
+			client.Config)
+
+		if err != nil {
+			return nil, fmt.Errorf("failed to dial to preexisting client: %s", err)
+		}
+		connection.Close()
 		connection = client.client
 	} else {
 		connection, err = ssh.Dial(


### PR DESCRIPTION
Given that the golang SSH library provides no timeouts for establishing a new session with an existing client, to get around this, try to dial to the same remote host upon each time we create a new session. Given that we don't want to leak clients / connections, close this new connection if the connection was successful. 

This is added to try to avoid the CI getting completely stuck when SSH connectivity is lost to VMs, which has been occurring during the direct node routes CI test. 

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8259)
<!-- Reviewable:end -->
