### PR TITLE
metrics: Add metric for number of allocated identities

### DIFF
--- a/Documentation/configuration/metrics.rst
+++ b/Documentation/configuration/metrics.rst
@@ -101,6 +101,11 @@ Policy L7 (HTTP/Kafka)
 * ``policy_l7_denied_total``: Number of total L7 denied requests/responses due to policy
 * ``policy_l7_received_total``: Number of total L7 received requests/responses
 
+Identity
+--------
+
+* ``identity_count``: Number of identities currently allocated
+
 
 Events external to Cilium
 -------------------------

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -921,7 +921,8 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 		return nil, nil, err
 	}
 
-	// Must be done before calling policy.NewPolicyRepostory() below.
+	identity.UpdateReservedIdentitiesMetrics()
+	// Must be done before calling policy.NewPolicyRepository() below.
 	identity.InitWellKnownIdentities()
 
 	d := Daemon{

--- a/pkg/identity/numericidentity.go
+++ b/pkg/identity/numericidentity.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,11 +17,12 @@ package identity
 import (
 	"errors"
 	"fmt"
-	"github.com/cilium/cilium/pkg/option"
 	"strconv"
 
 	api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 const (
@@ -123,6 +124,7 @@ func (w wellKnownIdentities) add(i NumericIdentity, lbls []string) {
 	}
 
 	ReservedIdentityCache[i] = identity
+	metrics.IdentityCount.Inc()
 }
 
 func (w wellKnownIdentities) LookupByLabels(lbls labels.Labels) *Identity {
@@ -283,6 +285,11 @@ var (
 	// reserved.
 	ErrNotUserIdentity = errors.New("not a user reserved identity")
 )
+
+// UpdateReservedIdentitiesMetrics updates identity metrics based on the reserved identities.
+func UpdateReservedIdentitiesMetrics() {
+	metrics.IdentityCount.Add(float64(len(reservedIdentities)))
+}
 
 // IsUserReservedIdentity returns true if the given NumericIdentity belongs
 // to the space reserved for users.

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -371,7 +371,7 @@ func (ipc *IPCache) DumpToListenerLocked(listener IPIdentityMappingListener) {
 	}
 }
 
-// deleteLocked removes removes the provided IP-to-security-identity mapping
+// deleteLocked removes the provided IP-to-security-identity mapping
 // from ipc with the assumption that the IPCache's mutex is held.
 func (ipc *IPCache) deleteLocked(ip string, source Source) {
 	scopedLog := log.WithFields(logrus.Fields{

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -214,6 +214,11 @@ var (
 	// time taken to fully deploy an endpoint.
 	PolicyImplementationDelay = NoOpObserverVec
 
+	// Identity
+
+	// IdentityCount is the number of identities currently in use on the node
+	IdentityCount = NoOpGauge
+
 	// Events
 
 	// EventTS*is the time in seconds since epoch that we last received an
@@ -370,6 +375,7 @@ type Configuration struct {
 	PolicyImportErrorsEnabled               bool
 	PolicyEndpointStatusEnabled             bool
 	PolicyImplementationDelayEnabled        bool
+	IdentityCountEnabled                    bool
 	EventTSK8sEnabled                       bool
 	EventTSContainerdEnabled                bool
 	EventTSAPIEnabled                       bool
@@ -420,6 +426,7 @@ func DefaultMetrics() map[string]struct{} {
 		Namespace + "_policy_import_errors":                                       {},
 		Namespace + "_policy_endpoint_enforcement_status":                         {},
 		Namespace + "_policy_implementation_delay":                                {},
+		Namespace + "_identity_count":                                             {},
 		Namespace + "_event_ts":                                                   {},
 		Namespace + "_proxy_redirects":                                            {},
 		Namespace + "_policy_l7_parse_errors_total":                               {},
@@ -587,6 +594,16 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 
 			collectors = append(collectors, PolicyImplementationDelay)
 			c.PolicyImplementationDelayEnabled = true
+
+		case Namespace + "_identity_count":
+			IdentityCount = prometheus.NewGauge(prometheus.GaugeOpts{
+				Namespace: Namespace,
+				Name:      "identity_count",
+				Help:      "Number of identities currently allocated",
+			})
+
+			collectors = append(collectors, IdentityCount)
+			c.IdentityCountEnabled = true
 
 		case Namespace + "_event_ts":
 			EventTSK8s = prometheus.NewGauge(prometheus.GaugeOpts{

--- a/pkg/spanstat/spanstat.go
+++ b/pkg/spanstat/spanstat.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -79,7 +79,7 @@ func (s *SpanStat) SuccessTotal() time.Duration {
 	return s.successDuration
 }
 
-// FailureTotal returns the total duration of all successful spans measured
+// FailureTotal returns the total duration of all unsuccessful spans measured
 func (s *SpanStat) FailureTotal() time.Duration {
 	return s.failureDuration
 }


### PR DESCRIPTION
This commit adds the `cilium_identity_count` prometheus
metric of type guage to expose the number of identities
in use, as reported by `IPIdentityWatcher`.

Fixes #8143

Happy to fix anything that isn't right!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8261)
<!-- Reviewable:end -->
