### PR TITLE
Use incremental policy updates when identities are added or deleted.

### DIFF
--- a/daemon/fqdn.go
+++ b/daemon/fqdn.go
@@ -124,7 +124,7 @@ func (d *Daemon) updateSelectorCacheFQDNs(selectors map[policyApi.FQDNSelector][
 	if len(selectors) == 0 && len(selectorsWithoutIPs) == 0 {
 		return
 	}
-	d.TriggerPolicyUpdates(true, "updated identities for FQDNs")
+	d.TriggerPolicyUpdates(false, "updated identities for FQDNs")
 }
 
 // bootstrapFQDN initializes the toFQDNs related subsystems: DNSPoller,

--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -72,7 +72,7 @@ func (d *Daemon) TriggerPolicyUpdates(force bool, reason string) {
 // and also triggers policy updates.
 func (d *Daemon) UpdateIdentities(added, deleted cache.IdentityCache) {
 	d.policy.GetSelectorCache().UpdateIdentities(added, deleted)
-	d.TriggerPolicyUpdates(true, "one or more identities created or deleted")
+	d.TriggerPolicyUpdates(false, "one or more identities created or deleted")
 }
 
 type getPolicyResolve struct {

--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -70,6 +70,9 @@ func (d *Daemon) TriggerPolicyUpdates(force bool, reason string) {
 
 // UpdateIdentities informs the policy package of all identity changes
 // and also triggers policy updates.
+//
+// The caller is responsible for making sure the same identity is not
+// present in both 'added' and 'deleted'.
 func (d *Daemon) UpdateIdentities(added, deleted cache.IdentityCache) {
 	d.policy.GetSelectorCache().UpdateIdentities(added, deleted)
 	d.TriggerPolicyUpdates(false, "one or more identities created or deleted")

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -914,7 +914,7 @@ func (e *Endpoint) deletePolicyKey(keyToDelete policy.Key) error {
 
 	err := e.PolicyMap.DeleteKey(policymapKey)
 	if err != nil {
-		e.getLogger().WithError(err).Errorf("Failed to delete PolicyMap key %s", policymapKey.String())
+		e.getLogger().WithError(err).WithField(logfields.BPFMapKey, policymapKey).Error("Failed to delete PolicyMap key")
 		return err
 	}
 
@@ -935,7 +935,10 @@ func (e *Endpoint) addPolicyKey(keyToAdd policy.Key, entry policy.MapStateEntry)
 
 	err := e.PolicyMap.AllowKey(policymapKey, entry.ProxyPort)
 	if err != nil {
-		e.getLogger().WithError(err).Errorf("Failed to add PolicyMap key %s %d", policymapKey.String(), entry.ProxyPort)
+		e.getLogger().WithError(err).WithFields(logrus.Fields{
+			logfields.BPFMapKey: policymapKey,
+			logfields.Port:      entry.ProxyPort,
+		}).Error("Failed to add PolicyMap key")
 		return err
 	}
 

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1069,6 +1069,7 @@ func (e *Endpoint) syncPolicyMap() error {
 
 		// If key that is in policy map is not in desired state, just remove it.
 		if _, ok := e.desiredPolicy.PolicyMapState[keyToDelete]; !ok {
+			e.getLogger().WithField(logfields.BPFMapKey, entry.Key.String()).Debug("syncPolicyMap removing a bpf policy entry not in the desired state")
 			err := e.deletePolicyKey(keyToDelete)
 			if err != nil {
 				errors = append(errors, err)

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -187,10 +187,6 @@ type Endpoint struct {
 	// TODO: Currently this applies only to HTTP L7 rules. Kafka L7 rules are still enforced by Cilium's node-wide Kafka proxy.
 	hasSidecarProxy bool
 
-	// prevIdentityCacheRevision is the revision of the identity cache used in the
-	// previous policy computation
-	prevIdentityCacheRevision uint64
-
 	// PolicyMap is the policy related state of the datapath including
 	// reference to all policy related BPF
 	PolicyMap *policymap.PolicyMap `json:"-"`
@@ -2043,7 +2039,7 @@ func (e *Endpoint) identityLabelsChanged(ctx context.Context, owner Owner, myCha
 
 	readyToRegenerate := false
 
-	// Regeneration is olny triggered once the endpoint ID has been
+	// Regeneration is only triggered once the endpoint ID has been
 	// assigned. This ensures that on the initial creation, the endpoint is
 	// not generated until the endpoint ID has been assigned. If the
 	// identity is resolved before the endpoint ID is assigned, the

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -80,6 +80,10 @@ var (
 // must implement
 type IdentityAllocatorOwner interface {
 	// UpdateIdentities will be called when identities have changed
+	//
+	// The caller is responsible for making sure the same identity
+	// is not present in both 'added' and 'deleted', so that they
+	// can be processed in either order.
 	UpdateIdentities(added, deleted IdentityCache)
 
 	// GetSuffix must return the node specific suffix to use

--- a/pkg/identity/cache/cache.go
+++ b/pkg/identity/cache/cache.go
@@ -103,6 +103,9 @@ type identityWatcher struct {
 	stopChan chan bool
 }
 
+// collectEvent records the 'event' as an added or deleted identity,
+// and makes sure that any identity is present in only one of the sets
+// (added or deleted).
 func collectEvent(event allocator.AllocatorEvent, added, deleted IdentityCache) bool {
 	id := identity.NumericIdentity(event.ID)
 	// Only create events have the key
@@ -188,7 +191,7 @@ func (w *identityWatcher) watch(owner IdentityAllocatorOwner, events allocator.A
 				}
 			}
 			// Issue collected updates
-			owner.UpdateIdentities(added, deleted)
+			owner.UpdateIdentities(added, deleted) // disjoint sets
 		}
 	}()
 }

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -172,7 +172,7 @@ func (s *K8sSuite) TestParseNetworkPolicyIngress(c *C) {
 	ingressL4Policy, err := repo.ResolveL4IngressPolicy(&ctx)
 	c.Assert(ingressL4Policy, Not(IsNil))
 	c.Assert(err, IsNil)
-	c.Assert(ingressL4Policy, checker.Equals, &policy.L4PolicyMap{
+	c.Assert(ingressL4Policy, checker.Equals, policy.L4PolicyMap{
 		"80/TCP": {
 			Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 			CachedSelectors: policy.CachedSelectorSlice{cachedEPSelector},
@@ -500,7 +500,7 @@ func (s *K8sSuite) TestParseNetworkPolicyEgress(c *C) {
 	egressL4Policy, err := repo.ResolveL4EgressPolicy(&ctx)
 	c.Assert(egressL4Policy, Not(IsNil))
 	c.Assert(err, IsNil)
-	c.Assert(egressL4Policy, checker.DeepEquals, &policy.L4PolicyMap{
+	c.Assert(egressL4Policy, checker.DeepEquals, policy.L4PolicyMap{
 		"80/TCP": {
 			Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 			CachedSelectors: policy.CachedSelectorSlice{cachedEPSelector},

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -75,6 +75,12 @@ const (
 	// PolicyID is the identifier of a L3, L4 or L7 Policy. Ideally the .NumericIdentity
 	PolicyID = "policyID"
 
+	// AddedPolicyID is the .NumericIdentity, or set or them
+	AddedPolicyID = "policyID.Added"
+
+	// DeletedPolicyID is the .NumericIdentity, or set or them
+	DeletedPolicyID = "policyID.Deleted"
+
 	// L3PolicyID is the identifier of a L3 Policy
 	L3PolicyID = "policyID.L3"
 

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -357,10 +357,10 @@ func updateBackendsLocked(addedBackends map[loadbalancer.BackendID]ServiceValue)
 
 		if svcVal.IsIPv6() {
 			svc6Val := svcVal.(*Service6Value)
-			b, err = NewBackend6(backendID, svc6Val.Address.IP(), svc6Val.Port, u8proto.All)
+			b, err = NewBackend6(backendID, svc6Val.Address.IP(), svc6Val.Port, u8proto.ANY)
 		} else {
 			svc4Val := svcVal.(*Service4Value)
-			b, err = NewBackend4(backendID, svc4Val.Address.IP(), svc4Val.Port, u8proto.All)
+			b, err = NewBackend4(backendID, svc4Val.Address.IP(), svc4Val.Port, u8proto.ANY)
 		}
 		if err != nil {
 			return err
@@ -436,10 +436,10 @@ func updateServiceV2Locked(fe ServiceKey, backends map[BackendAddrID]ServiceValu
 
 	if fe.IsIPv6() {
 		svc6Key := fe.(*Service6Key)
-		svcKeyV2 = NewService6KeyV2(svc6Key.Address.IP(), svc6Key.Port, u8proto.All, 0)
+		svcKeyV2 = NewService6KeyV2(svc6Key.Address.IP(), svc6Key.Port, u8proto.ANY, 0)
 	} else {
 		svc4Key := fe.(*Service4Key)
-		svcKeyV2 = NewService4KeyV2(svc4Key.Address.IP(), svc4Key.Port, u8proto.All, 0)
+		svcKeyV2 = NewService4KeyV2(svc4Key.Address.IP(), svc4Key.Port, u8proto.ANY, 0)
 	}
 
 	svcValV2, err := lookupServiceV2(svcKeyV2)
@@ -917,9 +917,9 @@ func DeleteServiceV2(svc loadbalancer.L3n4AddrID, releaseBackendID func(loadbala
 	log.WithField(logfields.ServiceName, svc).Debug("Deleting service")
 
 	if isIPv6 {
-		svcKey = NewService6KeyV2(svc.IP, svc.Port, u8proto.All, 0)
+		svcKey = NewService6KeyV2(svc.IP, svc.Port, u8proto.ANY, 0)
 	} else {
-		svcKey = NewService4KeyV2(svc.IP, svc.Port, u8proto.All, 0)
+		svcKey = NewService4KeyV2(svc.IP, svc.Port, u8proto.ANY, 0)
 	}
 
 	backendsToRemove, backendsCount, err := cache.removeServiceV2(svcKey)
@@ -978,9 +978,9 @@ func DeleteServiceCache(svc loadbalancer.L3n4AddrID) {
 func DeleteOrphanServiceV2AndRevNAT(svc loadbalancer.L3n4AddrID, delRevNAT bool) error {
 	var svcKey ServiceKeyV2
 	if !svc.IsIPv6() {
-		svcKey = NewService4KeyV2(svc.IP, svc.Port, u8proto.All, 0)
+		svcKey = NewService4KeyV2(svc.IP, svc.Port, u8proto.ANY, 0)
 	} else {
-		svcKey = NewService6KeyV2(svc.IP, svc.Port, u8proto.All, 0)
+		svcKey = NewService6KeyV2(svc.IP, svc.Port, u8proto.ANY, 0)
 	}
 
 	svcKey.SetSlave(0)
@@ -1001,9 +1001,9 @@ func DeleteOrphanServiceV2AndRevNAT(svc loadbalancer.L3n4AddrID, delRevNAT bool)
 	for i := numBackends; i > 0; i-- {
 		var slaveKey ServiceKeyV2
 		if !svc.IsIPv6() {
-			slaveKey = NewService4KeyV2(svc.IP, svc.Port, u8proto.All, i)
+			slaveKey = NewService4KeyV2(svc.IP, svc.Port, u8proto.ANY, i)
 		} else {
-			slaveKey = NewService6KeyV2(svc.IP, svc.Port, u8proto.All, i)
+			slaveKey = NewService6KeyV2(svc.IP, svc.Port, u8proto.ANY, i)
 		}
 		log.WithFields(logrus.Fields{
 			"idx.backend": i,

--- a/pkg/maps/lbmap/lbmap_test.go
+++ b/pkg/maps/lbmap/lbmap_test.go
@@ -218,12 +218,12 @@ func (b *LBMapTestSuite) TestGetBackends(c *C) {
 }
 
 func (b *LBMapTestSuite) TestBackendAddrID(c *C) {
-	b4, err := NewBackend4Value(net.ParseIP("1.1.1.1"), 80, u8proto.All)
+	b4, err := NewBackend4Value(net.ParseIP("1.1.1.1"), 80, u8proto.ANY)
 	c.Assert(err, IsNil)
 	v4 := NewService4Value(0, net.ParseIP("1.1.1.1"), 80, 0, 0)
 	c.Assert(b4.BackendAddrID(), Equals, v4.BackendAddrID())
 
-	b6, err := NewBackend6Value(net.ParseIP("f00d::0:0"), 80, u8proto.All)
+	b6, err := NewBackend6Value(net.ParseIP("f00d::0:0"), 80, u8proto.ANY)
 	c.Assert(err, IsNil)
 	v6 := NewService6Value(0, net.ParseIP("f00d::0:0"), 80, 0, 0)
 	c.Assert(b6.BackendAddrID(), Equals, v6.BackendAddrID())

--- a/pkg/maps/lbmap/types.go
+++ b/pkg/maps/lbmap/types.go
@@ -521,16 +521,16 @@ func serviceKeynValuenBackendValue2FEnBE(svcKey ServiceKeyV2, svcValue ServiceVa
 func l3n4Addr2ServiceKeyV2(l3n4Addr loadbalancer.L3n4AddrID) ServiceKeyV2 {
 	log.WithField(logfields.L3n4AddrID, l3n4Addr).Debug("converting L3n4Addr to ServiceKeyV2")
 	if l3n4Addr.IsIPv6() {
-		return NewService6KeyV2(l3n4Addr.IP, l3n4Addr.Port, u8proto.All, 0)
+		return NewService6KeyV2(l3n4Addr.IP, l3n4Addr.Port, u8proto.ANY, 0)
 	}
 
-	return NewService4KeyV2(l3n4Addr.IP, l3n4Addr.Port, u8proto.All, 0)
+	return NewService4KeyV2(l3n4Addr.IP, l3n4Addr.Port, u8proto.ANY, 0)
 }
 
 func lbBackEnd2Backend(be loadbalancer.LBBackEnd) (Backend, error) {
 	if be.IsIPv6() {
-		return NewBackend6(loadbalancer.BackendID(be.ID), be.IP, be.Port, u8proto.All)
+		return NewBackend6(loadbalancer.BackendID(be.ID), be.IP, be.Port, u8proto.ANY)
 	}
 
-	return NewBackend4(loadbalancer.BackendID(be.ID), be.IP, be.Port, u8proto.All)
+	return NewBackend4(loadbalancer.BackendID(be.ID), be.IP, be.Port, u8proto.ANY)
 }

--- a/pkg/policy/api/fqdn.go
+++ b/pkg/policy/api/fqdn.go
@@ -58,7 +58,7 @@ type FQDNSelector struct {
 }
 
 func (s *FQDNSelector) String() string {
-	return fmt.Sprintf("MatchName: %s, MatchPattern %s", s.MatchName, s.MatchPattern)
+	return fmt.Sprintf("MatchName: %s, MatchPattern: %s", s.MatchName, s.MatchPattern)
 }
 
 // sanitize for FQDNSelector is a little wonky. While we do more processing
@@ -80,7 +80,7 @@ func (s *FQDNSelector) sanitize() error {
 }
 
 // ToRegex converts the given FQDNSelector to its corresponding regular
-// expression. If the MatchName field is set in the selector, it  performs all
+// expression. If the MatchName field is set in the selector, it performs all
 // needed formatting to ensure that the field is a valid regular expression.
 func (s *FQDNSelector) ToRegex() (*regexp.Regexp, error) {
 	var preparedMatch string

--- a/pkg/policy/api/l4.go
+++ b/pkg/policy/api/l4.go
@@ -18,6 +18,8 @@ package api
 type L4Proto string
 
 const (
+	// Keep pkg/u8proto up-to-date with any additions here
+
 	ProtoTCP L4Proto = "TCP"
 	ProtoUDP L4Proto = "UDP"
 	ProtoAny L4Proto = "ANY"

--- a/pkg/policy/distillery.go
+++ b/pkg/policy/distillery.go
@@ -108,8 +108,6 @@ func (cache *PolicyCache) delete(identity *identityPkg.Identity) bool {
 //
 // Must be called with repo.Mutex held for reading.
 func (cache *PolicyCache) updateSelectorPolicy(identity *identityPkg.Identity) (bool, error) {
-	revision := cache.repo.GetRevision()
-
 	cache.Lock()
 	cip, ok := cache.policies[identity.ID]
 	cache.Unlock()
@@ -129,10 +127,8 @@ func (cache *PolicyCache) updateSelectorPolicy(identity *identityPkg.Identity) (
 	cip.Lock()
 	defer cip.Unlock()
 
-	currentPolicy := cip.getPolicy()
-
 	// Don't resolve policy if it was already done for this or later revision.
-	if revision <= currentPolicy.Revision {
+	if cip.getPolicy().Revision >= cache.repo.GetRevision() {
 		return false, nil
 	}
 

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -313,7 +313,7 @@ func (d *policyDistillery) distillPolicy(epLabels labels.LabelArray) (MapState, 
 
 	// Handle L4 ingress from each identity in the cache to the endpoint.
 	io.WriteString(d.log, "[distill] Producing L4 filter keys\n")
-	for _, l4 := range *l4IngressPolicy {
+	for _, l4 := range l4IngressPolicy {
 		io.WriteString(d.log, fmt.Sprintf("[distill] Processing L4Filter (l3: %+v), (l4: %d/%s), (l7: %+v)\n", l4.CachedSelectors, l4.Port, l4.Protocol, l4.L7RulesPerEp))
 		for _, key := range l4.ToKeys(0) {
 			io.WriteString(d.log, fmt.Sprintf("[distill] L4 ingress allow %+v (parser=%s, redirect=%t)\n", key, l4.L7Parser, l4.IsRedirect()))

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -472,11 +472,12 @@ type L4Policy struct {
 	Revision uint64
 }
 
-func NewL4Policy() *L4Policy {
+// NewL4Policy creates a new L4Policy
+func NewL4Policy(revision uint64) *L4Policy {
 	return &L4Policy{
 		Ingress:  L4PolicyMap{},
 		Egress:   L4PolicyMap{},
-		Revision: 0,
+		Revision: revision,
 	}
 }
 

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -214,6 +214,9 @@ func (l4 *L4Filter) ToKeys(direction trafficdirection.TrafficDirection) []Key {
 
 // IdentitySelectionUpdated implements CachedSelectionUser interface
 // This call is made while holding selector cache lock, must beware of deadlocking!
+//
+// The caller is responsible for making sure the same identity is not
+// present in both 'added' and 'deleted'.
 func (l4 *L4Filter) IdentitySelectionUpdated(selector CachedSelector, selections, added, deleted []identity.NumericIdentity) {
 	log.WithFields(logrus.Fields{
 		logfields.EndpointSelector: selector,
@@ -564,6 +567,9 @@ func (l4 *L4Policy) insertUser(user *EndpointPolicy) {
 }
 
 // AccumulateMapChanges distributes the given changes to the registered users.
+//
+// The caller is responsible for making sure the same identity is not
+// present in both 'adds' and 'deletes'.
 func (l4 *L4Policy) AccumulateMapChanges(adds, deletes []identity.NumericIdentity,
 	port uint16, proto uint8, direction trafficdirection.TrafficDirection) {
 	l4.mutex.RLock()

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -217,7 +217,7 @@ func (ds *PolicyTestSuite) TestMergeAllowAllL3AndShadowedL7(c *C) {
 	ctx.Logging = logging.NewLogBackend(buffer, "", 0)
 
 	ingressState := traceState{}
-	res, err := rule1.resolveIngressPolicy(&ctx, &ingressState, NewL4Policy(), nil, testSelectorCache)
+	res, err := rule1.resolveIngressPolicy(&ctx, &ingressState, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 
@@ -228,7 +228,7 @@ func (ds *PolicyTestSuite) TestMergeAllowAllL3AndShadowedL7(c *C) {
 	// allows all at L7, based on the first API rule imported above. We
 	// just set the expected set of L7 rules below to include this to match
 	// the current implementation.
-	expected := NewL4Policy()
+	expected := NewL4Policy(0)
 	expected.Ingress["80/TCP"] = &L4Filter{
 		Port:            80,
 		Protocol:        api.ProtoTCP,
@@ -337,7 +337,7 @@ func (ds *PolicyTestSuite) TestMergeIdenticalAllowAllL3AndRestrictedL7HTTP(c *C)
 			},
 		}}
 
-	expected := NewL4Policy()
+	expected := NewL4Policy(0)
 	expected.Ingress["80/TCP"] = &L4Filter{
 		Port:            80,
 		Protocol:        api.ProtoTCP,
@@ -360,7 +360,7 @@ func (ds *PolicyTestSuite) TestMergeIdenticalAllowAllL3AndRestrictedL7HTTP(c *C)
 	c.Log(buffer)
 
 	state := traceState{}
-	res, err := identicalHTTPRule.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(), nil, testSelectorCache)
+	res, err := identicalHTTPRule.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, checker.Equals, *expected)
@@ -370,7 +370,7 @@ func (ds *PolicyTestSuite) TestMergeIdenticalAllowAllL3AndRestrictedL7HTTP(c *C)
 	expected.Detach(testSelectorCache)
 
 	state = traceState{}
-	res, err = identicalHTTPRule.resolveIngressPolicy(toFoo, &state, NewL4Policy(), nil, testSelectorCache)
+	res, err = identicalHTTPRule.resolveIngressPolicy(toFoo, &state, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -418,7 +418,7 @@ func (ds *PolicyTestSuite) TestMergeIdenticalAllowAllL3AndRestrictedL7Kafka(c *C
 	ctxToA.Logging = logging.NewLogBackend(buffer, "", 0)
 	c.Log(buffer)
 
-	expected := NewL4Policy()
+	expected := NewL4Policy(0)
 	expected.Ingress["9092/TCP"] = &L4Filter{
 		Port:            9092,
 		Protocol:        api.ProtoTCP,
@@ -436,7 +436,7 @@ func (ds *PolicyTestSuite) TestMergeIdenticalAllowAllL3AndRestrictedL7Kafka(c *C
 	}
 
 	state := traceState{}
-	res, err := identicalKafkaRule.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(), nil, testSelectorCache)
+	res, err := identicalKafkaRule.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, checker.Equals, *expected)
@@ -446,7 +446,7 @@ func (ds *PolicyTestSuite) TestMergeIdenticalAllowAllL3AndRestrictedL7Kafka(c *C
 	expected.Detach(testSelectorCache)
 
 	state = traceState{}
-	res, err = identicalKafkaRule.resolveIngressPolicy(toFoo, &state, NewL4Policy(), nil, testSelectorCache)
+	res, err = identicalKafkaRule.resolveIngressPolicy(toFoo, &state, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -497,7 +497,7 @@ func (ds *PolicyTestSuite) TestMergeIdenticalAllowAllL3AndMismatchingParsers(c *
 	c.Log(buffer)
 
 	state := traceState{}
-	res, err := conflictingParsersRule.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(), nil, testSelectorCache)
+	res, err := conflictingParsersRule.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, Not(IsNil))
 	c.Assert(res, IsNil)
 
@@ -541,7 +541,7 @@ func (ds *PolicyTestSuite) TestMergeIdenticalAllowAllL3AndMismatchingParsers(c *
 	c.Log(buffer)
 
 	state = traceState{}
-	res, err = conflictingParsersRule.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(), nil, testSelectorCache)
+	res, err = conflictingParsersRule.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, Not(IsNil))
 	c.Assert(res, IsNil)
 
@@ -589,7 +589,7 @@ func (ds *PolicyTestSuite) TestMergeIdenticalAllowAllL3AndMismatchingParsers(c *
 	c.Assert(err, IsNil)
 
 	state = traceState{}
-	res, err = conflictingParsersIngressRule.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(), nil, testSelectorCache)
+	res, err = conflictingParsersIngressRule.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, Not(IsNil))
 	c.Assert(res, IsNil)
 
@@ -634,7 +634,7 @@ func (ds *PolicyTestSuite) TestMergeIdenticalAllowAllL3AndMismatchingParsers(c *
 	c.Assert(err, IsNil)
 
 	state = traceState{}
-	res, err = conflictingParsersEgressRule.resolveEgressPolicy(&ctxAToC, &state, NewL4Policy(), nil, testSelectorCache)
+	res, err = conflictingParsersEgressRule.resolveEgressPolicy(&ctxAToC, &state, NewL4Policy(0), nil, testSelectorCache)
 	c.Log(buffer)
 	c.Assert(err, Not(IsNil))
 	c.Assert(res, IsNil)
@@ -673,7 +673,7 @@ func (ds *PolicyTestSuite) TestL3RuleShadowedByL3AllowAll(c *C) {
 	ctxToA.Logging = logging.NewLogBackend(buffer, "", 0)
 	c.Log(buffer)
 
-	expected := NewL4Policy()
+	expected := NewL4Policy(0)
 	expected.Ingress["80/TCP"] = &L4Filter{
 		Port:             80,
 		Protocol:         api.ProtoTCP,
@@ -687,7 +687,7 @@ func (ds *PolicyTestSuite) TestL3RuleShadowedByL3AllowAll(c *C) {
 	}
 
 	state := traceState{}
-	res, err := shadowRule.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(), nil, testSelectorCache)
+	res, err := shadowRule.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, checker.Equals, *expected)
@@ -697,7 +697,7 @@ func (ds *PolicyTestSuite) TestL3RuleShadowedByL3AllowAll(c *C) {
 	expected.Detach(testSelectorCache)
 
 	state = traceState{}
-	res, err = shadowRule.resolveIngressPolicy(toFoo, &state, NewL4Policy(), nil, testSelectorCache)
+	res, err = shadowRule.resolveIngressPolicy(toFoo, &state, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -732,7 +732,7 @@ func (ds *PolicyTestSuite) TestL3RuleShadowedByL3AllowAll(c *C) {
 	ctxToA.Logging = logging.NewLogBackend(buffer, "", 0)
 	c.Log(buffer)
 
-	expected = NewL4Policy()
+	expected = NewL4Policy(0)
 	expected.Ingress["80/TCP"] = &L4Filter{
 		Port:             80,
 		Protocol:         api.ProtoTCP,
@@ -746,7 +746,7 @@ func (ds *PolicyTestSuite) TestL3RuleShadowedByL3AllowAll(c *C) {
 	}
 
 	state = traceState{}
-	res, err = shadowRule.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(), nil, testSelectorCache)
+	res, err = shadowRule.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, checker.Equals, *expected)
@@ -756,7 +756,7 @@ func (ds *PolicyTestSuite) TestL3RuleShadowedByL3AllowAll(c *C) {
 	expected.Detach(testSelectorCache)
 
 	state = traceState{}
-	res, err = shadowRule.resolveIngressPolicy(toFoo, &state, NewL4Policy(), nil, testSelectorCache)
+	res, err = shadowRule.resolveIngressPolicy(toFoo, &state, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -804,7 +804,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RulePartiallyShadowedByL3AllowAll(c *
 	ctxToA.Logging = logging.NewLogBackend(buffer, "", 0)
 	c.Log(buffer)
 
-	expected := NewL4Policy()
+	expected := NewL4Policy(0)
 	expected.Ingress["80/TCP"] = &L4Filter{
 		Port:            80,
 		Protocol:        api.ProtoTCP,
@@ -822,7 +822,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RulePartiallyShadowedByL3AllowAll(c *
 	}
 
 	state := traceState{}
-	res, err := shadowRule.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(), nil, testSelectorCache)
+	res, err := shadowRule.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, checker.Equals, *expected)
@@ -832,7 +832,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RulePartiallyShadowedByL3AllowAll(c *
 	expected.Detach(testSelectorCache)
 
 	state = traceState{}
-	res, err = shadowRule.resolveIngressPolicy(toFoo, &state, NewL4Policy(), nil, testSelectorCache)
+	res, err = shadowRule.resolveIngressPolicy(toFoo, &state, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -874,7 +874,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RulePartiallyShadowedByL3AllowAll(c *
 	ctxToA.Logging = logging.NewLogBackend(buffer, "", 0)
 	c.Log(buffer)
 
-	expected = NewL4Policy()
+	expected = NewL4Policy(0)
 	expected.Ingress["80/TCP"] = &L4Filter{
 		Port:            80,
 		Protocol:        api.ProtoTCP,
@@ -892,7 +892,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RulePartiallyShadowedByL3AllowAll(c *
 	}
 
 	state = traceState{}
-	res, err = shadowRule.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(), nil, testSelectorCache)
+	res, err = shadowRule.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, checker.Equals, *expected)
@@ -902,7 +902,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RulePartiallyShadowedByL3AllowAll(c *
 	expected.Detach(testSelectorCache)
 
 	state = traceState{}
-	res, err = shadowRule.resolveIngressPolicy(toFoo, &state, NewL4Policy(), nil, testSelectorCache)
+	res, err = shadowRule.resolveIngressPolicy(toFoo, &state, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -957,7 +957,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RuleShadowedByL3AllowAll(c *C) {
 	ctxToA.Logging = logging.NewLogBackend(buffer, "", 0)
 	c.Log(buffer)
 
-	expected := NewL4Policy()
+	expected := NewL4Policy(0)
 	expected.Ingress["80/TCP"] = &L4Filter{
 		Port:            80,
 		Protocol:        api.ProtoTCP,
@@ -978,7 +978,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RuleShadowedByL3AllowAll(c *C) {
 	}
 
 	state := traceState{}
-	res, err := case8Rule.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(), nil, testSelectorCache)
+	res, err := case8Rule.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, checker.Equals, *expected)
@@ -988,7 +988,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RuleShadowedByL3AllowAll(c *C) {
 	expected.Detach(testSelectorCache)
 
 	state = traceState{}
-	res, err = case8Rule.resolveIngressPolicy(toFoo, &state, NewL4Policy(), nil, testSelectorCache)
+	res, err = case8Rule.resolveIngressPolicy(toFoo, &state, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -1036,7 +1036,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RuleShadowedByL3AllowAll(c *C) {
 	ctxToA.Logging = logging.NewLogBackend(buffer, "", 0)
 	c.Log(buffer)
 
-	expected = NewL4Policy()
+	expected = NewL4Policy(0)
 	expected.Ingress["80/TCP"] = &L4Filter{
 		Port:            80,
 		Protocol:        api.ProtoTCP,
@@ -1057,7 +1057,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RuleShadowedByL3AllowAll(c *C) {
 	}
 
 	state = traceState{}
-	res, err = case8Rule.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(), nil, testSelectorCache)
+	res, err = case8Rule.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, checker.Equals, *expected)
@@ -1067,7 +1067,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RuleShadowedByL3AllowAll(c *C) {
 	expected.Detach(testSelectorCache)
 
 	state = traceState{}
-	res, err = case8Rule.resolveIngressPolicy(toFoo, &state, NewL4Policy(), nil, testSelectorCache)
+	res, err = case8Rule.resolveIngressPolicy(toFoo, &state, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -1119,12 +1119,12 @@ func (ds *PolicyTestSuite) TestL3SelectingEndpointAndL3AllowAllMergeConflictingL
 	c.Log(buffer)
 
 	state := traceState{}
-	res, err := conflictingL7Rule.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(), nil, testSelectorCache)
+	res, err := conflictingL7Rule.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, Not(IsNil))
 	c.Assert(res, IsNil)
 
 	state = traceState{}
-	res, err = conflictingL7Rule.resolveIngressPolicy(toFoo, &state, NewL4Policy(), nil, testSelectorCache)
+	res, err = conflictingL7Rule.resolveIngressPolicy(toFoo, &state, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -1170,12 +1170,12 @@ func (ds *PolicyTestSuite) TestL3SelectingEndpointAndL3AllowAllMergeConflictingL
 	c.Log(buffer)
 
 	state = traceState{}
-	res, err = conflictingL7Rule.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(), nil, testSelectorCache)
+	res, err = conflictingL7Rule.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, Not(IsNil))
 	c.Assert(res, IsNil)
 
 	state = traceState{}
-	res, err = conflictingL7Rule.resolveIngressPolicy(toFoo, &state, NewL4Policy(), nil, testSelectorCache)
+	res, err = conflictingL7Rule.resolveIngressPolicy(toFoo, &state, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -1224,7 +1224,7 @@ func (ds *PolicyTestSuite) TestMergingWithDifferentEndpointsSelectedAllowSameL7(
 	ctxToA.Logging = logging.NewLogBackend(buffer, "", 0)
 	c.Log(buffer)
 
-	expected := NewL4Policy()
+	expected := NewL4Policy(0)
 	expected.Ingress["80/TCP"] = &L4Filter{
 		Port:            80,
 		Protocol:        api.ProtoTCP,
@@ -1244,7 +1244,7 @@ func (ds *PolicyTestSuite) TestMergingWithDifferentEndpointsSelectedAllowSameL7(
 	}
 
 	state := traceState{}
-	res, err := selectDifferentEndpointsRestrictL7.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(), nil, testSelectorCache)
+	res, err := selectDifferentEndpointsRestrictL7.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, checker.Equals, *expected)
@@ -1259,7 +1259,7 @@ func (ds *PolicyTestSuite) TestMergingWithDifferentEndpointsSelectedAllowSameL7(
 	c.Log(buffer)
 
 	state = traceState{}
-	res, err = selectDifferentEndpointsRestrictL7.resolveIngressPolicy(toFoo, &state, NewL4Policy(), nil, testSelectorCache)
+	res, err = selectDifferentEndpointsRestrictL7.resolveIngressPolicy(toFoo, &state, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -1297,7 +1297,7 @@ func (ds *PolicyTestSuite) TestMergingWithDifferentEndpointSelectedAllowAllL7(c 
 	ctxToA.Logging = logging.NewLogBackend(buffer, "", 0)
 	c.Log(buffer)
 
-	expected := NewL4Policy()
+	expected := NewL4Policy(0)
 	expected.Ingress["80/TCP"] = &L4Filter{
 		Port:             80,
 		Protocol:         api.ProtoTCP,
@@ -1310,7 +1310,7 @@ func (ds *PolicyTestSuite) TestMergingWithDifferentEndpointSelectedAllowAllL7(c 
 	}
 
 	state := traceState{}
-	res, err := selectDifferentEndpointsAllowAllL7.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(), nil, testSelectorCache)
+	res, err := selectDifferentEndpointsAllowAllL7.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, checker.Equals, *expected)
@@ -1325,7 +1325,7 @@ func (ds *PolicyTestSuite) TestMergingWithDifferentEndpointSelectedAllowAllL7(c 
 	c.Log(buffer)
 
 	state = traceState{}
-	res, err = selectDifferentEndpointsAllowAllL7.resolveIngressPolicy(toFoo, &state, NewL4Policy(), nil, testSelectorCache)
+	res, err = selectDifferentEndpointsAllowAllL7.resolveIngressPolicy(toFoo, &state, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -1370,7 +1370,7 @@ func (ds *PolicyTestSuite) TestAllowingLocalhostShadowsL7(c *C) {
 	ctxToA := SearchContext{To: labelsA, Trace: TRACE_VERBOSE}
 	ctxToA.Logging = logging.NewLogBackend(buffer, "", 0)
 
-	expected := NewL4Policy()
+	expected := NewL4Policy(0)
 	expected.Ingress["80/TCP"] = &L4Filter{
 		Port:            80,
 		Protocol:        api.ProtoTCP,
@@ -1389,7 +1389,7 @@ func (ds *PolicyTestSuite) TestAllowingLocalhostShadowsL7(c *C) {
 	}
 
 	state := traceState{}
-	res, err := rule.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(), nil, testSelectorCache)
+	res, err := rule.resolveIngressPolicy(&ctxToA, &state, NewL4Policy(0), nil, testSelectorCache)
 	c.Log(buffer)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
@@ -1405,7 +1405,7 @@ func (ds *PolicyTestSuite) TestAllowingLocalhostShadowsL7(c *C) {
 	ctxToC.Logging = logging.NewLogBackend(buffer, "", 0)
 
 	state = traceState{}
-	res, err = rule.resolveIngressPolicy(toFoo, &state, NewL4Policy(), nil, testSelectorCache)
+	res, err = rule.resolveIngressPolicy(toFoo, &state, NewL4Policy(0), nil, testSelectorCache)
 	c.Log(buffer)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
@@ -1430,7 +1430,7 @@ func (ds *PolicyTestSuite) TestEntitiesL3(c *C) {
 	ctxFromA.Logging = logging.NewLogBackend(buffer, "", 0)
 	c.Log(buffer)
 
-	expected := NewL4Policy()
+	expected := NewL4Policy(0)
 	expected.Egress["0/ANY"] = &L4Filter{
 		Port:             0,
 		Protocol:         api.ProtoAny,
@@ -1444,7 +1444,7 @@ func (ds *PolicyTestSuite) TestEntitiesL3(c *C) {
 	}
 
 	state := traceState{}
-	res, err := allowWorldRule.resolveEgressPolicy(&ctxFromA, &state, NewL4Policy(), nil, testSelectorCache)
+	res, err := allowWorldRule.resolveEgressPolicy(&ctxFromA, &state, NewL4Policy(0), nil, testSelectorCache)
 
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))

--- a/pkg/policy/l4_test.go
+++ b/pkg/policy/l4_test.go
@@ -28,34 +28,6 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func (s *PolicyTestSuite) testDPortCoverage(c *C, policy L4Policy, covers func([]*models.Port) api.Decision) {
-
-	ports := []*models.Port{}
-	c.Assert(covers(ports), Equals, api.Denied)
-
-	// Policy should match all of the below ports.
-	ports = []*models.Port{
-		{
-			Port:     8080,
-			Protocol: models.PortProtocolTCP,
-		},
-	}
-	c.Assert(covers(ports), Equals, api.Allowed)
-
-	// Adding another port outside the policy will now be denied.
-	ports = append(ports, &models.Port{Port: 8080, Protocol: models.PortProtocolUDP})
-	c.Assert(covers(ports), Equals, api.Denied)
-
-	// Ports with protocol any should match the TCP policy above.
-	ports = []*models.Port{
-		{
-			Port:     8080,
-			Protocol: models.PortProtocolANY,
-		},
-	}
-	c.Assert(covers(ports), Equals, api.Allowed)
-}
-
 func (s *PolicyTestSuite) TestCreateL4Filter(c *C) {
 	tuple := api.PortProtocol{Port: "80", Protocol: api.ProtoTCP}
 	portrule := api.PortRule{

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -117,6 +117,12 @@ type MapChanges struct {
 // AccumulateMapChanges accumulates the given changes to the
 // MapChanges, updating both maps for each add and delete, as
 // applicable.
+//
+// The caller is responsible for making sure the same identity is not
+// present in both 'adds' and 'deletes'.  Accross multiple calls we
+// maintain the adds and deletes within the MapChanges are disjoint in
+// cases where an identity is first added and then deleted, or first
+// deleted and then added.
 func (mc *MapChanges) AccumulateMapChanges(adds, deletes []identity.NumericIdentity,
 	port uint16, proto uint8, direction trafficdirection.TrafficDirection) {
 	key := Key{
@@ -131,13 +137,15 @@ func (mc *MapChanges) AccumulateMapChanges(adds, deletes []identity.NumericIdent
 		ProxyPort: 0, // Will be updated by the caller when applicable
 	}
 
-	log.WithFields(logrus.Fields{
-		logfields.AddedPolicyID:    adds,
-		logfields.DeletedPolicyID:  deletes,
-		logfields.Port:             port,
-		logfields.Protocol:         proto,
-		logfields.TrafficDirection: direction,
-	}).Debug("AccumulateMapChanges")
+	if option.Config.Debug {
+		log.WithFields(logrus.Fields{
+			logfields.AddedPolicyID:    adds,
+			logfields.DeletedPolicyID:  deletes,
+			logfields.Port:             port,
+			logfields.Protocol:         proto,
+			logfields.TrafficDirection: direction,
+		}).Debug("AccumulateMapChanges")
+	}
 
 	mc.mutex.Lock()
 	if len(adds) > 0 {

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -17,8 +17,11 @@ package policy
 import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
+
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -128,8 +131,13 @@ func (mc *MapChanges) AccumulateMapChanges(adds, deletes []identity.NumericIdent
 		ProxyPort: 0, // Will be updated by the caller when applicable
 	}
 
-	log.Debugf("MapChanges: AccumulateMapChanges(adds: %v, deletes: %v, port: %d, proto: %d, direction: %d)",
-		adds, deletes, port, proto, direction.Uint8())
+	log.WithFields(logrus.Fields{
+		logfields.AddedPolicyID:    adds,
+		logfields.DeletedPolicyID:  deletes,
+		logfields.Port:             port,
+		logfields.Protocol:         proto,
+		logfields.TrafficDirection: direction,
+	}).Debug("AccumulateMapChanges")
 
 	mc.mutex.Lock()
 	if len(adds) > 0 {

--- a/pkg/policy/proxyid.go
+++ b/pkg/policy/proxyid.go
@@ -18,15 +18,27 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+
+	"github.com/cilium/cilium/pkg/policy/trafficdirection"
+	"github.com/cilium/cilium/pkg/u8proto"
 )
 
-// ProxyID returns a unique string to identify a proxy mapping.
-func ProxyID(endpointID uint16, ingress bool, protocol string, port uint16) string {
+func proxyID(endpointID uint16, ingress bool, protocol string, port uint16) string {
 	direction := "egress"
 	if ingress {
 		direction = "ingress"
 	}
 	return fmt.Sprintf("%d:%s:%s:%d", endpointID, direction, protocol, port)
+}
+
+// ProxyIDFromKey returns a unique string to identify a proxy mapping.
+func ProxyIDFromKey(endpointID uint16, key Key) string {
+	return proxyID(endpointID, key.TrafficDirection == trafficdirection.Ingress.Uint8(), u8proto.U8proto(key.Nexthdr).String(), key.DestPort)
+}
+
+// ProxyIDFromFilter returns a unique string to identify a proxy mapping.
+func ProxyIDFromFilter(endpointID uint16, l4 *L4Filter) string {
+	return proxyID(endpointID, l4.Ingress, string(l4.Protocol), uint16(l4.Port))
 }
 
 // ParseProxyID parses a proxy ID returned by ProxyID and returns its components.

--- a/pkg/policy/proxyid_test.go
+++ b/pkg/policy/proxyid_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func (s *PolicyTestSuite) TestProxyID(c *C) {
-	id := ProxyID(123, true, "TCP", uint16(8080))
+	id := proxyID(123, true, "TCP", uint16(8080))
 	endpointID, ingress, protocol, port, err := ParseProxyID(id)
 	c.Assert(endpointID, Equals, uint16(123))
 	c.Assert(ingress, Equals, true)

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -651,6 +651,9 @@ func (p *Repository) resolvePolicyLocked(securityIdentity *identity.Identity) (*
 		calculatedPolicy.L4Policy.Egress = newL4EgressPolicy
 	}
 
+	// Make the calculated policy ready for incremental updates
+	calculatedPolicy.Attach()
+
 	return calculatedPolicy, nil
 }
 

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -597,7 +597,7 @@ func (p *Repository) resolvePolicyLocked(securityIdentity *identity.Identity) (*
 	calculatedPolicy := &selectorPolicy{
 		Revision:             p.GetRevision(),
 		SelectorCache:        p.GetSelectorCache(),
-		L4Policy:             NewL4Policy(),
+		L4Policy:             NewL4Policy(p.GetRevision()),
 		CIDRPolicy:           NewCIDRPolicy(),
 		IngressPolicyEnabled: ingressEnabled,
 		EgressPolicyEnabled:  egressEnabled,

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -1664,7 +1664,7 @@ func (ds *PolicyTestSuite) TestMinikubeGettingStarted(c *C) {
 	cachedSelectorApp2 := testSelectorCache.FindCachedIdentitySelector(selFromApp2)
 	c.Assert(cachedSelectorApp2, Not(IsNil))
 
-	expected := NewL4Policy()
+	expected := NewL4Policy(repo.GetRevision())
 	expected.Ingress["80/TCP"] = &L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		CachedSelectors: CachedSelectorSlice{cachedSelectorApp2},
@@ -1677,7 +1677,6 @@ func (ds *PolicyTestSuite) TestMinikubeGettingStarted(c *C) {
 		Ingress:          true,
 		DerivedFromRules: []labels.LabelArray{nil, nil, nil, nil},
 	}
-	expected.Revision = repo.GetRevision()
 
 	if equal, err := checker.Equal(*l4IngressPolicy, expected.Ingress); !equal {
 		c.Logf("%s", logBuffer.String())
@@ -1687,8 +1686,7 @@ func (ds *PolicyTestSuite) TestMinikubeGettingStarted(c *C) {
 	expected.Detach(testSelectorCache)
 
 	// L4 from app3 has no rules
-	expected = NewL4Policy()
-	expected.Revision = repo.GetRevision()
+	expected = NewL4Policy(repo.GetRevision())
 	l4IngressPolicy, err = repo.ResolveL4IngressPolicy(fromApp3)
 	c.Assert(err, IsNil)
 	c.Assert(len(*l4IngressPolicy), Equals, 0)

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -718,7 +718,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngress(c *C) {
 			DerivedFromRules: labels.LabelArrayList{labelsL7, labelsL3},
 		},
 	}
-	c.Assert((*policy), checker.Equals, expectedPolicy)
+	c.Assert(policy, checker.Equals, expectedPolicy)
 	policy.Detach(repo.GetSelectorCache())
 }
 
@@ -861,7 +861,7 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesIngress(c *C) {
 			DerivedFromRules: labels.LabelArrayList{labelsL4, labelsKafka, labelsL4},
 		},
 	}
-	c.Assert((*policy), checker.Equals, expectedPolicy)
+	c.Assert(policy, checker.Equals, expectedPolicy)
 	policy.Detach(repo.GetSelectorCache())
 }
 
@@ -927,7 +927,7 @@ func (ds *PolicyTestSuite) TestL3DependentL4IngressFromRequires(c *C) {
 			DerivedFromRules: labels.LabelArrayList{nil},
 		},
 	}
-	c.Assert((*policy), checker.Equals, expectedPolicy)
+	c.Assert(policy, checker.Equals, expectedPolicy)
 	policy.Detach(repo.GetSelectorCache())
 }
 
@@ -1015,7 +1015,7 @@ func (ds *PolicyTestSuite) TestL3DependentL4EgressFromRequires(c *C) {
 			DerivedFromRules: labels.LabelArrayList{nil},
 		},
 	}
-	if !c.Check((*policy), checker.Equals, expectedPolicy) {
+	if !c.Check(policy, checker.Equals, expectedPolicy) {
 		c.Errorf("Policy doesn't match expected:\n%s", logBuffer.String())
 	}
 	policy.Detach(repo.GetSelectorCache())
@@ -1148,7 +1148,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgress(c *C) {
 			DerivedFromRules: labels.LabelArrayList{labelsL4},
 		},
 	}
-	c.Assert((*policy), checker.Equals, expectedPolicy)
+	c.Assert(policy, checker.Equals, expectedPolicy)
 	policy.Detach(repo.GetSelectorCache())
 }
 
@@ -1291,7 +1291,7 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesEgress(c *C) {
 			DerivedFromRules: labels.LabelArrayList{labelsL3, labelsKafka, labelsL3},
 		},
 	}
-	c.Assert((*policy), checker.Equals, expectedPolicy)
+	c.Assert(policy, checker.Equals, expectedPolicy)
 	policy.Detach(repo.GetSelectorCache())
 }
 
@@ -1373,9 +1373,9 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngressFromEntities(c *C) {
 
 	policy, err := repo.ResolveL4IngressPolicy(ctx)
 	c.Assert(err, IsNil)
-	c.Assert(len(*policy), Equals, 3)
+	c.Assert(len(policy), Equals, 3)
 	selWorld := api.EntitySelectorMapping[api.EntityWorld][0]
-	c.Assert(len((*policy)["80/TCP"].CachedSelectors), Equals, 2)
+	c.Assert(len(policy["80/TCP"].CachedSelectors), Equals, 2)
 	cachedSelectorWorld := testSelectorCache.FindCachedIdentitySelector(selWorld)
 	c.Assert(cachedSelectorWorld, Not(IsNil))
 
@@ -1427,7 +1427,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngressFromEntities(c *C) {
 		},
 	}
 
-	c.Assert((*policy), checker.Equals, expectedPolicy)
+	c.Assert(policy, checker.Equals, expectedPolicy)
 	policy.Detach(repo.GetSelectorCache())
 }
 
@@ -1509,9 +1509,9 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgressToEntities(c *C) {
 
 	policy, err := repo.ResolveL4EgressPolicy(ctx)
 	c.Assert(err, IsNil)
-	c.Assert(len(*policy), Equals, 3)
+	c.Assert(len(policy), Equals, 3)
 	selWorld := api.EntitySelectorMapping[api.EntityWorld][0]
-	c.Assert(len((*policy)["80/TCP"].CachedSelectors), Equals, 2)
+	c.Assert(len(policy["80/TCP"].CachedSelectors), Equals, 2)
 	cachedSelectorWorld := testSelectorCache.FindCachedIdentitySelector(selWorld)
 	c.Assert(cachedSelectorWorld, Not(IsNil))
 
@@ -1563,7 +1563,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgressToEntities(c *C) {
 		},
 	}
 
-	c.Assert((*policy), checker.Equals, expectedPolicy)
+	c.Assert(policy, checker.Equals, expectedPolicy)
 	policy.Detach(repo.GetSelectorCache())
 }
 
@@ -1678,7 +1678,7 @@ func (ds *PolicyTestSuite) TestMinikubeGettingStarted(c *C) {
 		DerivedFromRules: []labels.LabelArray{nil, nil, nil, nil},
 	}
 
-	if equal, err := checker.Equal(*l4IngressPolicy, expected.Ingress); !equal {
+	if equal, err := checker.Equal(l4IngressPolicy, expected.Ingress); !equal {
 		c.Logf("%s", logBuffer.String())
 		c.Errorf("Resolved policy did not match expected: \n%s", err)
 	}
@@ -1689,8 +1689,8 @@ func (ds *PolicyTestSuite) TestMinikubeGettingStarted(c *C) {
 	expected = NewL4Policy(repo.GetRevision())
 	l4IngressPolicy, err = repo.ResolveL4IngressPolicy(fromApp3)
 	c.Assert(err, IsNil)
-	c.Assert(len(*l4IngressPolicy), Equals, 0)
-	c.Assert(*l4IngressPolicy, checker.Equals, expected.Ingress)
+	c.Assert(len(l4IngressPolicy), Equals, 0)
+	c.Assert(l4IngressPolicy, checker.Equals, expected.Ingress)
 	l4IngressPolicy.Detach(testSelectorCache)
 	expected.Detach(testSelectorCache)
 }

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -59,6 +59,9 @@ type EndpointPolicy struct {
 	// All fields within the Key and the proxy port must be in host byte-order.
 	PolicyMapState MapState
 
+	// PolicyMapChanges collects pending changes to the PolicyMapState
+	PolicyMapChanges MapChanges
+
 	// PolicyOwner describes any type which consumes this EndpointPolicy object.
 	PolicyOwner PolicyOwner
 }

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	. "gopkg.in/check.v1"
 )
 
@@ -86,7 +87,7 @@ func (ds *PolicyTestSuite) SetUpSuite(c *C) {
 	wg.Wait()
 
 	c.Assert(epSet.Len(), Equals, 0)
-	c.Assert(len(idSet.IDs), Equals, 1)
+	c.Assert(idSet.IDs, HasLen, 1)
 }
 
 func (ds *PolicyTestSuite) TearDownSuite(c *C) {
@@ -248,6 +249,9 @@ func (ds *PolicyTestSuite) TestL7WithIngressWildcard(c *C) {
 		PolicyMapState: policy.PolicyMapState,
 	}
 
+	// Have to remove circular reference before testing to avoid an infinite loop
+	policy.selectorPolicy.Detach()
+
 	c.Assert(policy, checker.Equals, &expectedEndpointPolicy)
 }
 
@@ -340,5 +344,233 @@ func (ds *PolicyTestSuite) TestL7WithLocalHostWildcardd(c *C) {
 		PolicyMapState: policy.PolicyMapState,
 	}
 
+	// Have to remove circular reference before testing to avoid an infinite loop
+	policy.selectorPolicy.Detach()
+
 	c.Assert(policy, checker.Equals, &expectedEndpointPolicy)
+}
+
+func (ds *PolicyTestSuite) TestMapStateWithIngressWildcard(c *C) {
+
+	idFooSelectLabelArray := labels.ParseSelectLabelArray("id=foo")
+	idFooSelectLabels := labels.Labels{}
+	for _, lbl := range idFooSelectLabelArray {
+		idFooSelectLabels[lbl.Key] = lbl
+	}
+	fooIdentity := identity.NewIdentity(12345, idFooSelectLabels)
+
+	repo := NewPolicyRepository()
+	repo.selectorCache = testSelectorCache
+
+	selFoo := api.NewESFromLabels(labels.ParseSelectLabel("id=foo"))
+	rule1 := api.Rule{
+		EndpointSelector: selFoo,
+		Ingress: []api.IngressRule{
+			{
+				ToPorts: []api.PortRule{{
+					Ports: []api.PortProtocol{
+						{Port: "80", Protocol: api.ProtoTCP},
+					},
+					Rules: &api.L7Rules{},
+				}},
+			},
+		},
+	}
+
+	rule1.Sanitize()
+	_, _, err := repo.Add(rule1, []Endpoint{})
+	c.Assert(err, IsNil)
+
+	repo.Mutex.RLock()
+	defer repo.Mutex.RUnlock()
+	selPolicy, err := repo.resolvePolicyLocked(fooIdentity)
+	c.Assert(err, IsNil)
+	policy := selPolicy.DistillPolicy(DummyOwner{})
+
+	expectedEndpointPolicy := EndpointPolicy{
+		selectorPolicy: &selectorPolicy{
+			Revision:      repo.GetRevision(),
+			SelectorCache: repo.GetSelectorCache(),
+			L4Policy: &L4Policy{
+				Revision: repo.GetRevision(),
+				Ingress: L4PolicyMap{
+					"80/TCP": {
+						Port:     80,
+						Protocol: api.ProtoTCP,
+						U8Proto:  0x6,
+						CachedSelectors: CachedSelectorSlice{
+							wildcardCachedSelector,
+						},
+						allowsAllAtL3:    true,
+						L7Parser:         ParserTypeNone,
+						Ingress:          true,
+						L7RulesPerEp:     L7DataMap{},
+						DerivedFromRules: labels.LabelArrayList{nil},
+					},
+				},
+				Egress: L4PolicyMap{},
+			},
+			CIDRPolicy:           policy.CIDRPolicy,
+			IngressPolicyEnabled: true,
+			EgressPolicyEnabled:  false,
+		},
+		PolicyOwner: DummyOwner{},
+		PolicyMapState: MapState{
+			{TrafficDirection: trafficdirection.Egress.Uint8()}: {},
+			{DestPort: 80, Nexthdr: 6}:                          {},
+		},
+	}
+
+	// Add new identity to test accumulation of PolicyMapChanges
+	added1 := cache.IdentityCache{
+		identity.NumericIdentity(192): labels.ParseSelectLabelArray("id=resolve_test_1"),
+	}
+	testSelectorCache.UpdateIdentities(added1, nil)
+	c.Assert(policy.PolicyMapChanges.adds, HasLen, 0)
+	c.Assert(policy.PolicyMapChanges.deletes, HasLen, 0)
+
+	// Have to remove circular reference before testing to avoid an infinite loop
+	policy.selectorPolicy.Detach()
+
+	c.Assert(policy, checker.Equals, &expectedEndpointPolicy)
+}
+
+func (ds *PolicyTestSuite) TestMapStateWithIngress(c *C) {
+	idFooSelectLabelArray := labels.ParseSelectLabelArray("id=foo")
+	idFooSelectLabels := labels.Labels{}
+	for _, lbl := range idFooSelectLabelArray {
+		idFooSelectLabels[lbl.Key] = lbl
+	}
+	fooIdentity := identity.NewIdentity(12345, idFooSelectLabels)
+
+	repo := NewPolicyRepository()
+	repo.selectorCache = testSelectorCache
+
+	lblTest := labels.ParseLabel("id=resolve_test_1")
+
+	selFoo := api.NewESFromLabels(labels.ParseSelectLabel("id=foo"))
+	rule1 := api.Rule{
+		EndpointSelector: selFoo,
+		Ingress: []api.IngressRule{
+			{
+				FromEntities: []api.Entity{api.EntityWorld},
+				ToPorts: []api.PortRule{{
+					Ports: []api.PortProtocol{
+						{Port: "80", Protocol: api.ProtoTCP},
+					},
+					Rules: &api.L7Rules{},
+				}},
+			},
+			{
+				FromEndpoints: []api.EndpointSelector{
+					api.NewESFromLabels(lblTest),
+				},
+				ToPorts: []api.PortRule{{
+					Ports: []api.PortProtocol{
+						{Port: "80", Protocol: api.ProtoTCP},
+					},
+					Rules: &api.L7Rules{},
+				}},
+			},
+		},
+	}
+
+	rule1.Sanitize()
+	_, _, err := repo.Add(rule1, []Endpoint{})
+	c.Assert(err, IsNil)
+
+	repo.Mutex.RLock()
+	defer repo.Mutex.RUnlock()
+	selPolicy, err := repo.resolvePolicyLocked(fooIdentity)
+	c.Assert(err, IsNil)
+	policy := selPolicy.DistillPolicy(DummyOwner{})
+
+	// Add new identity to test accumulation of PolicyMapChanges
+	added1 := cache.IdentityCache{
+		identity.NumericIdentity(192): labels.ParseSelectLabelArray("id=resolve_test_1", "num=1"),
+		identity.NumericIdentity(193): labels.ParseSelectLabelArray("id=resolve_test_1", "num=2"),
+		identity.NumericIdentity(194): labels.ParseSelectLabelArray("id=resolve_test_1", "num=3"),
+	}
+	testSelectorCache.UpdateIdentities(added1, nil)
+	c.Assert(policy.PolicyMapChanges.adds, HasLen, 3)
+	c.Assert(policy.PolicyMapChanges.deletes, HasLen, 0)
+
+	deleted1 := cache.IdentityCache{
+		identity.NumericIdentity(193): labels.ParseSelectLabelArray("id=resolve_test_1", "num=2"),
+	}
+	testSelectorCache.UpdateIdentities(nil, deleted1)
+	c.Assert(policy.PolicyMapChanges.adds, HasLen, 2)
+	c.Assert(policy.PolicyMapChanges.deletes, HasLen, 1)
+
+	cachedSelectorWorld := testSelectorCache.FindCachedIdentitySelector(api.ReservedEndpointSelectors[labels.IDNameWorld])
+	c.Assert(cachedSelectorWorld, Not(IsNil))
+
+	cachedSelectorTest := testSelectorCache.FindCachedIdentitySelector(api.NewESFromLabels(lblTest))
+	c.Assert(cachedSelectorTest, Not(IsNil))
+
+	expectedEndpointPolicy := EndpointPolicy{
+		selectorPolicy: &selectorPolicy{
+			Revision:      repo.GetRevision(),
+			SelectorCache: repo.GetSelectorCache(),
+			L4Policy: &L4Policy{
+				Revision: repo.GetRevision(),
+				Ingress: L4PolicyMap{
+					"80/TCP": {
+						Port:     80,
+						Protocol: api.ProtoTCP,
+						U8Proto:  0x6,
+						CachedSelectors: CachedSelectorSlice{
+							cachedSelectorWorld,
+							cachedSelectorTest,
+						},
+						allowsAllAtL3:    false,
+						L7Parser:         ParserTypeNone,
+						Ingress:          true,
+						L7RulesPerEp:     L7DataMap{},
+						DerivedFromRules: labels.LabelArrayList{nil, nil},
+					},
+				},
+				Egress: L4PolicyMap{},
+			},
+			CIDRPolicy:           policy.CIDRPolicy,
+			IngressPolicyEnabled: true,
+			EgressPolicyEnabled:  false,
+		},
+		PolicyOwner: DummyOwner{},
+		PolicyMapState: MapState{
+			{TrafficDirection: trafficdirection.Egress.Uint8()}:                          {},
+			{Identity: uint32(identity.ReservedIdentityWorld), DestPort: 80, Nexthdr: 6}: {},
+		},
+		PolicyMapChanges: MapChanges{
+			adds: MapState{
+				{Identity: 192, DestPort: 80, Nexthdr: 6}: {},
+				{Identity: 194, DestPort: 80, Nexthdr: 6}: {},
+			},
+			deletes: MapState{
+				{Identity: 193, DestPort: 80, Nexthdr: 6}: {},
+			},
+		},
+	}
+
+	// Have to remove circular reference before testing for Equality to avoid an infinite loop
+	policy.selectorPolicy.Detach()
+	// Verify that cached selector is not found after Detach().
+	// Note that this depends on the other tests NOT using the same selector concurrently!
+	cachedSelectorTest = testSelectorCache.FindCachedIdentitySelector(api.NewESFromLabels(lblTest))
+	c.Assert(cachedSelectorTest, IsNil)
+
+	c.Assert(policy, checker.Equals, &expectedEndpointPolicy)
+
+	adds, deletes := policy.PolicyMapChanges.ConsumeMapChanges()
+	// maps on the policy got cleared
+	c.Assert(policy.PolicyMapChanges.adds, IsNil)
+	c.Assert(policy.PolicyMapChanges.deletes, IsNil)
+
+	c.Assert(adds, checker.Equals, MapState{
+		{Identity: 192, DestPort: 80, Nexthdr: 6}: {},
+		{Identity: 194, DestPort: 80, Nexthdr: 6}: {},
+	})
+	c.Assert(deletes, checker.Equals, MapState{
+		{Identity: 193, DestPort: 80, Nexthdr: 6}: {},
+	})
 }

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -216,6 +216,7 @@ func (ds *PolicyTestSuite) TestL7WithIngressWildcard(c *C) {
 			Revision:      repo.GetRevision(),
 			SelectorCache: repo.GetSelectorCache(),
 			L4Policy: &L4Policy{
+				Revision: repo.GetRevision(),
 				Ingress: L4PolicyMap{
 					"80/TCP": {
 						Port:     80,
@@ -305,6 +306,7 @@ func (ds *PolicyTestSuite) TestL7WithLocalHostWildcardd(c *C) {
 			Revision:      repo.GetRevision(),
 			SelectorCache: repo.GetSelectorCache(),
 			L4Policy: &L4Policy{
+				Revision: repo.GetRevision(),
 				Ingress: L4PolicyMap{
 					"80/TCP": {
 						Port:     80,

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -350,7 +350,7 @@ func (state *traceState) unSelectRule(ctx *SearchContext, labels labels.LabelArr
 // other rules are stored in the specified slice of LabelSelectorRequirement.
 // These requirements are dynamically inserted into a copy of the receiver rule,
 // as requirements form conjunctions across all rules.
-func (r *rule) resolveIngressPolicy(ctx *SearchContext, state *traceState, result *L4Policy, requirements []v1.LabelSelectorRequirement, selectorCache *SelectorCache) (*L4Policy, error) {
+func (r *rule) resolveIngressPolicy(ctx *SearchContext, state *traceState, result L4PolicyMap, requirements []v1.LabelSelectorRequirement, selectorCache *SelectorCache) (L4PolicyMap, error) {
 	if !ctx.rulesSelect {
 		if !r.EndpointSelector.Matches(ctx.To) {
 			state.unSelectRule(ctx, ctx.To, r)
@@ -366,7 +366,7 @@ func (r *rule) resolveIngressPolicy(ctx *SearchContext, state *traceState, resul
 	}
 	for _, ingressRule := range r.Ingress {
 		fromEndpoints := ingressRule.GetSourceEndpointSelectorsWithRequirements(requirements)
-		cnt, err := mergeIngress(ctx, fromEndpoints, ingressRule.ToPorts, r.Rule.Labels.DeepCopy(), result.Ingress, selectorCache)
+		cnt, err := mergeIngress(ctx, fromEndpoints, ingressRule.ToPorts, r.Rule.Labels.DeepCopy(), result, selectorCache)
 		if err != nil {
 			return nil, err
 		}
@@ -585,7 +585,7 @@ func mergeEgressPortProto(ctx *SearchContext, endpoints api.EndpointSelectorSlic
 	return 1, nil
 }
 
-func (r *rule) resolveEgressPolicy(ctx *SearchContext, state *traceState, result *L4Policy, requirements []v1.LabelSelectorRequirement, selectorCache *SelectorCache) (*L4Policy, error) {
+func (r *rule) resolveEgressPolicy(ctx *SearchContext, state *traceState, result L4PolicyMap, requirements []v1.LabelSelectorRequirement, selectorCache *SelectorCache) (L4PolicyMap, error) {
 	if !ctx.rulesSelect {
 		if !r.EndpointSelector.Matches(ctx.From) {
 			state.unSelectRule(ctx, ctx.From, r)
@@ -601,7 +601,7 @@ func (r *rule) resolveEgressPolicy(ctx *SearchContext, state *traceState, result
 	}
 	for _, egressRule := range r.Egress {
 		toEndpoints := egressRule.GetDestinationEndpointSelectorsWithRequirements(requirements)
-		cnt, err := mergeEgress(ctx, toEndpoints, egressRule.ToPorts, r.Rule.Labels.DeepCopy(), result.Egress, selectorCache, egressRule.ToFQDNs)
+		cnt, err := mergeEgress(ctx, toEndpoints, egressRule.ToPorts, r.Rule.Labels.DeepCopy(), result, selectorCache, egressRule.ToFQDNs)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -118,7 +118,7 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(res.Egress, Not(IsNil))
 
-	c.Assert(*res, checker.Equals, *expected)
+	c.Assert(res, checker.Equals, expected)
 	c.Assert(ingressState.selectedRules, Equals, 1)
 	c.Assert(ingressState.matchedRules, Equals, 0)
 
@@ -224,7 +224,7 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 	c.Assert(res.Egress, Not(IsNil))
 
 	c.Assert(len(res.Ingress), Equals, 1)
-	c.Assert(*res, checker.Equals, *expected)
+	c.Assert(res, checker.Equals, expected)
 	c.Assert(ingressState.selectedRules, Equals, 1)
 	c.Assert(ingressState.matchedRules, Equals, 0)
 

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -75,7 +75,7 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 		wildcardCachedSelector: l7rules,
 	}
 
-	expected := NewL4Policy()
+	expected := NewL4Policy(0)
 	expected.Ingress["80/TCP"] = &L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		allowsAllAtL3:   true,
@@ -108,11 +108,11 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 
 	ingressState := traceState{}
 	egressState := traceState{}
-	res, err := rule1.resolveIngressPolicy(toBar, &ingressState, NewL4Policy(), nil, testSelectorCache)
+	res, err := rule1.resolveIngressPolicy(toBar, &ingressState, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 
-	res2, err := rule1.resolveEgressPolicy(fromBar, &egressState, NewL4Policy(), nil, testSelectorCache)
+	res2, err := rule1.resolveEgressPolicy(fromBar, &egressState, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res2, Not(IsNil))
 
@@ -131,9 +131,9 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 	ingressState = traceState{}
 	egressState = traceState{}
 
-	res, err = rule1.resolveIngressPolicy(toFoo, &ingressState, NewL4Policy(), nil, testSelectorCache)
+	res, err = rule1.resolveIngressPolicy(toFoo, &ingressState, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, IsNil)
-	res2, err = rule1.resolveEgressPolicy(fromFoo, &ingressState, NewL4Policy(), nil, testSelectorCache)
+	res2, err = rule1.resolveEgressPolicy(fromFoo, &ingressState, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, IsNil)
 
 	c.Assert(res, IsNil)
@@ -181,7 +181,7 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 		},
 	}
 
-	expected = NewL4Policy()
+	expected = NewL4Policy(0)
 	expected.Ingress["80/TCP"] = &L4Filter{
 		Port:            80,
 		Protocol:        api.ProtoTCP,
@@ -214,11 +214,11 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 
 	ingressState = traceState{}
 	egressState = traceState{}
-	res, err = rule2.resolveIngressPolicy(toBar, &ingressState, NewL4Policy(), nil, testSelectorCache)
+	res, err = rule2.resolveIngressPolicy(toBar, &ingressState, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 
-	res2, err = rule2.resolveEgressPolicy(fromBar, &egressState, NewL4Policy(), nil, testSelectorCache)
+	res2, err = rule2.resolveEgressPolicy(fromBar, &egressState, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res2, Not(IsNil))
 
@@ -237,11 +237,11 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 	ingressState = traceState{}
 	egressState = traceState{}
 
-	res, err = rule2.resolveIngressPolicy(toFoo, &ingressState, NewL4Policy(), nil, testSelectorCache)
+	res, err = rule2.resolveIngressPolicy(toFoo, &ingressState, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 
-	res2, err = rule2.resolveEgressPolicy(fromFoo, &egressState, NewL4Policy(), nil, testSelectorCache)
+	res2, err = rule2.resolveEgressPolicy(fromFoo, &egressState, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res2, IsNil)
 
@@ -281,7 +281,7 @@ func (ds *PolicyTestSuite) TestMergeL4PolicyIngress(c *C) {
 	}
 
 	mergedES := CachedSelectorSlice{cachedFooSelector, cachedBazSelector}
-	expected := NewL4Policy()
+	expected := NewL4Policy(0)
 	expected.Ingress["80/TCP"] = &L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6, CachedSelectors: mergedES,
 		L7Parser: ParserTypeNone, L7RulesPerEp: L7DataMap{}, Ingress: true,
@@ -289,7 +289,7 @@ func (ds *PolicyTestSuite) TestMergeL4PolicyIngress(c *C) {
 	}
 
 	state := traceState{}
-	res, err := rule1.resolveIngressPolicy(toBar, &state, NewL4Policy(), nil, testSelectorCache)
+	res, err := rule1.resolveIngressPolicy(toBar, &state, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, checker.Equals, *expected)
@@ -334,7 +334,7 @@ func (ds *PolicyTestSuite) TestMergeL4PolicyEgress(c *C) {
 	}
 
 	mergedES := CachedSelectorSlice{cachedFooSelector, cachedBazSelector}
-	expected := NewL4Policy()
+	expected := NewL4Policy(0)
 	expected.Egress["80/TCP"] = &L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6, CachedSelectors: mergedES,
 		L7Parser: ParserTypeNone, L7RulesPerEp: L7DataMap{}, Ingress: false,
@@ -342,7 +342,7 @@ func (ds *PolicyTestSuite) TestMergeL4PolicyEgress(c *C) {
 	}
 
 	state := traceState{}
-	res, err := rule1.resolveEgressPolicy(fromBar, &state, NewL4Policy(), nil, testSelectorCache)
+	res, err := rule1.resolveEgressPolicy(fromBar, &state, NewL4Policy(0), nil, testSelectorCache)
 
 	c.Log(buffer)
 
@@ -402,7 +402,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
 		},
 	}
 
-	expected := NewL4Policy()
+	expected := NewL4Policy(0)
 	expected.Ingress["80/TCP"] = &L4Filter{
 		Port:            80,
 		Protocol:        api.ProtoTCP,
@@ -423,7 +423,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
 	}
 
 	state := traceState{}
-	res, err := rule1.resolveIngressPolicy(toBar, &state, NewL4Policy(), nil, testSelectorCache)
+	res, err := rule1.resolveIngressPolicy(toBar, &state, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, checker.Equals, *expected)
@@ -433,7 +433,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
 	expected.Detach(testSelectorCache)
 
 	state = traceState{}
-	res, err = rule1.resolveIngressPolicy(toFoo, &state, NewL4Policy(), nil, testSelectorCache)
+	res, err = rule1.resolveIngressPolicy(toFoo, &state, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -480,7 +480,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
 		cachedFooSelector:      l7rules,
 	}
 
-	expected = NewL4Policy()
+	expected = NewL4Policy(0)
 	expected.Ingress["80/TCP"] = &L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		allowsAllAtL3:   true,
@@ -490,7 +490,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
 	}
 
 	state = traceState{}
-	res, err = rule2.resolveIngressPolicy(toBar, &state, NewL4Policy(), nil, testSelectorCache)
+	res, err = rule2.resolveIngressPolicy(toBar, &state, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, checker.Equals, *expected)
@@ -500,14 +500,14 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
 	expected.Detach(testSelectorCache)
 
 	state = traceState{}
-	res, err = rule2.resolveIngressPolicy(toFoo, &state, NewL4Policy(), nil, testSelectorCache)
+	res, err = rule2.resolveIngressPolicy(toFoo, &state, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
 	c.Assert(state.matchedRules, Equals, 0)
 
 	// Resolve rule1's policy, then try to add rule2.
-	res, err = rule1.resolveIngressPolicy(toBar, &state, NewL4Policy(), nil, testSelectorCache)
+	res, err = rule1.resolveIngressPolicy(toBar, &state, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 
@@ -566,7 +566,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
 		cachedFooSelector:      fooRules,
 		wildcardCachedSelector: barRules,
 	}
-	expected = NewL4Policy()
+	expected = NewL4Policy(0)
 
 	expected.Ingress["80/TCP"] = &L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
@@ -577,7 +577,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
 	}
 
 	state = traceState{}
-	res, err = rule3.resolveIngressPolicy(toBar, &state, NewL4Policy(), nil, testSelectorCache)
+	res, err = rule3.resolveIngressPolicy(toBar, &state, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, checker.Equals, *expected)
@@ -635,7 +635,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 		},
 	}
 
-	expected := NewL4Policy()
+	expected := NewL4Policy(0)
 	expected.Egress["80/TCP"] = &L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		allowsAllAtL3:   true,
@@ -654,7 +654,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 	}
 
 	state := traceState{}
-	res, err := rule1.resolveEgressPolicy(fromBar, &state, NewL4Policy(), nil, testSelectorCache)
+	res, err := rule1.resolveEgressPolicy(fromBar, &state, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, checker.Equals, *expected)
@@ -664,7 +664,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 	expected.Detach(testSelectorCache)
 
 	state = traceState{}
-	res, err = rule1.resolveEgressPolicy(fromFoo, &state, NewL4Policy(), nil, testSelectorCache)
+	res, err = rule1.resolveEgressPolicy(fromFoo, &state, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -710,7 +710,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 		},
 	}
 
-	expected = NewL4Policy()
+	expected = NewL4Policy(0)
 	expected.Egress["80/TCP"] = &L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		allowsAllAtL3:   true,
@@ -729,7 +729,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 	}
 
 	state = traceState{}
-	res, err = rule2.resolveEgressPolicy(fromBar, &state, NewL4Policy(), nil, testSelectorCache)
+	res, err = rule2.resolveEgressPolicy(fromBar, &state, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, checker.Equals, *expected)
@@ -739,14 +739,14 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 	expected.Detach(testSelectorCache)
 
 	state = traceState{}
-	res, err = rule2.resolveEgressPolicy(fromFoo, &state, NewL4Policy(), nil, testSelectorCache)
+	res, err = rule2.resolveEgressPolicy(fromFoo, &state, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
 	c.Assert(state.matchedRules, Equals, 0)
 
 	// Resolve rule1's policy, then try to add rule2.
-	res, err = rule1.resolveEgressPolicy(fromBar, &state, NewL4Policy(), nil, testSelectorCache)
+	res, err = rule1.resolveEgressPolicy(fromBar, &state, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	res.Detach(testSelectorCache)
@@ -798,7 +798,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 		cachedFooSelector:      fooRules,
 		wildcardCachedSelector: barRules,
 	}
-	expected = NewL4Policy()
+	expected = NewL4Policy(0)
 	expected.Egress["80/TCP"] = &L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		allowsAllAtL3:   true,
@@ -808,7 +808,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 	}
 
 	state = traceState{}
-	res, err = rule3.resolveEgressPolicy(fromBar, &state, NewL4Policy(), nil, testSelectorCache)
+	res, err = rule3.resolveEgressPolicy(fromBar, &state, NewL4Policy(0), nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	c.Assert(*res, checker.Equals, *expected)
@@ -1277,7 +1277,7 @@ func (ds *PolicyTestSuite) TestL4RuleLabels(c *C) {
 	fromBar := &SearchContext{From: labels.ParseSelectLabelArray("bar")}
 
 	for _, test := range testCases {
-		finalPolicy := NewL4Policy()
+		finalPolicy := NewL4Policy(0)
 		for _, r := range test.rulesToApply {
 			apiRule := rules[r]
 			err := apiRule.Sanitize()

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -108,15 +108,15 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 
 	ingressState := traceState{}
 	egressState := traceState{}
-	res, err := rule1.resolveIngressPolicy(toBar, &ingressState, NewL4Policy(0), nil, testSelectorCache)
+	res := NewL4Policy(0)
+	var err error
+	res.Ingress, err = rule1.resolveIngressPolicy(toBar, &ingressState, L4PolicyMap{}, nil, testSelectorCache)
 	c.Assert(err, IsNil)
-	c.Assert(res, Not(IsNil))
+	c.Assert(res.Ingress, Not(IsNil))
 
-	res2, err := rule1.resolveEgressPolicy(fromBar, &egressState, NewL4Policy(0), nil, testSelectorCache)
+	res.Egress, err = rule1.resolveEgressPolicy(fromBar, &egressState, L4PolicyMap{}, nil, testSelectorCache)
 	c.Assert(err, IsNil)
-	c.Assert(res2, Not(IsNil))
-
-	res.Egress = res2.Egress
+	c.Assert(res.Egress, Not(IsNil))
 
 	c.Assert(*res, checker.Equals, *expected)
 	c.Assert(ingressState.selectedRules, Equals, 1)
@@ -131,12 +131,12 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 	ingressState = traceState{}
 	egressState = traceState{}
 
-	res, err = rule1.resolveIngressPolicy(toFoo, &ingressState, NewL4Policy(0), nil, testSelectorCache)
+	res1, err := rule1.resolveIngressPolicy(toFoo, &ingressState, L4PolicyMap{}, nil, testSelectorCache)
 	c.Assert(err, IsNil)
-	res2, err = rule1.resolveEgressPolicy(fromFoo, &ingressState, NewL4Policy(0), nil, testSelectorCache)
+	res2, err := rule1.resolveEgressPolicy(fromFoo, &ingressState, L4PolicyMap{}, nil, testSelectorCache)
 	c.Assert(err, IsNil)
 
-	c.Assert(res, IsNil)
+	c.Assert(res1, IsNil)
 	c.Assert(res2, IsNil)
 	c.Assert(ingressState.selectedRules, Equals, 0)
 	c.Assert(ingressState.matchedRules, Equals, 0)
@@ -214,15 +214,14 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 
 	ingressState = traceState{}
 	egressState = traceState{}
-	res, err = rule2.resolveIngressPolicy(toBar, &ingressState, NewL4Policy(0), nil, testSelectorCache)
+	res = NewL4Policy(0)
+	res.Ingress, err = rule2.resolveIngressPolicy(toBar, &ingressState, L4PolicyMap{}, nil, testSelectorCache)
 	c.Assert(err, IsNil)
-	c.Assert(res, Not(IsNil))
+	c.Assert(res.Ingress, Not(IsNil))
 
-	res2, err = rule2.resolveEgressPolicy(fromBar, &egressState, NewL4Policy(0), nil, testSelectorCache)
+	res.Egress, err = rule2.resolveEgressPolicy(fromBar, &egressState, L4PolicyMap{}, nil, testSelectorCache)
 	c.Assert(err, IsNil)
-	c.Assert(res2, Not(IsNil))
-
-	res.Egress = res2.Egress
+	c.Assert(res.Egress, Not(IsNil))
 
 	c.Assert(len(res.Ingress), Equals, 1)
 	c.Assert(*res, checker.Equals, *expected)
@@ -237,11 +236,11 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 	ingressState = traceState{}
 	egressState = traceState{}
 
-	res, err = rule2.resolveIngressPolicy(toFoo, &ingressState, NewL4Policy(0), nil, testSelectorCache)
+	res1, err = rule2.resolveIngressPolicy(toFoo, &ingressState, L4PolicyMap{}, nil, testSelectorCache)
 	c.Assert(err, IsNil)
-	c.Assert(res, IsNil)
+	c.Assert(res1, IsNil)
 
-	res2, err = rule2.resolveEgressPolicy(fromFoo, &egressState, NewL4Policy(0), nil, testSelectorCache)
+	res2, err = rule2.resolveEgressPolicy(fromFoo, &egressState, L4PolicyMap{}, nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res2, IsNil)
 
@@ -281,18 +280,17 @@ func (ds *PolicyTestSuite) TestMergeL4PolicyIngress(c *C) {
 	}
 
 	mergedES := CachedSelectorSlice{cachedFooSelector, cachedBazSelector}
-	expected := NewL4Policy(0)
-	expected.Ingress["80/TCP"] = &L4Filter{
+	expected := L4PolicyMap{"80/TCP": &L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6, CachedSelectors: mergedES,
 		L7Parser: ParserTypeNone, L7RulesPerEp: L7DataMap{}, Ingress: true,
 		DerivedFromRules: labels.LabelArrayList{nil, nil},
-	}
+	}}
 
 	state := traceState{}
-	res, err := rule1.resolveIngressPolicy(toBar, &state, NewL4Policy(0), nil, testSelectorCache)
+	res, err := rule1.resolveIngressPolicy(toBar, &state, L4PolicyMap{}, nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
-	c.Assert(*res, checker.Equals, *expected)
+	c.Assert(res, checker.Equals, expected)
 	c.Assert(state.selectedRules, Equals, 1)
 	c.Assert(state.matchedRules, Equals, 0)
 	res.Detach(testSelectorCache)
@@ -334,21 +332,20 @@ func (ds *PolicyTestSuite) TestMergeL4PolicyEgress(c *C) {
 	}
 
 	mergedES := CachedSelectorSlice{cachedFooSelector, cachedBazSelector}
-	expected := NewL4Policy(0)
-	expected.Egress["80/TCP"] = &L4Filter{
+	expected := L4PolicyMap{"80/TCP": &L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6, CachedSelectors: mergedES,
 		L7Parser: ParserTypeNone, L7RulesPerEp: L7DataMap{}, Ingress: false,
 		DerivedFromRules: labels.LabelArrayList{nil, nil},
-	}
+	}}
 
 	state := traceState{}
-	res, err := rule1.resolveEgressPolicy(fromBar, &state, NewL4Policy(0), nil, testSelectorCache)
+	res, err := rule1.resolveEgressPolicy(fromBar, &state, L4PolicyMap{}, nil, testSelectorCache)
 
 	c.Log(buffer)
 
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
-	c.Assert(*res, checker.Equals, *expected)
+	c.Assert(res, checker.Equals, expected)
 	c.Assert(state.selectedRules, Equals, 1)
 	c.Assert(state.matchedRules, Equals, 0)
 	res.Detach(testSelectorCache)
@@ -402,8 +399,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
 		},
 	}
 
-	expected := NewL4Policy(0)
-	expected.Ingress["80/TCP"] = &L4Filter{
+	expected := L4PolicyMap{"80/TCP": &L4Filter{
 		Port:            80,
 		Protocol:        api.ProtoTCP,
 		U8Proto:         6,
@@ -420,20 +416,20 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
 		},
 		Ingress:          true,
 		DerivedFromRules: labels.LabelArrayList{nil, nil, nil},
-	}
+	}}
 
 	state := traceState{}
-	res, err := rule1.resolveIngressPolicy(toBar, &state, NewL4Policy(0), nil, testSelectorCache)
+	res, err := rule1.resolveIngressPolicy(toBar, &state, L4PolicyMap{}, nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
-	c.Assert(*res, checker.Equals, *expected)
+	c.Assert(res, checker.Equals, expected)
 	c.Assert(state.selectedRules, Equals, 1)
 	c.Assert(state.matchedRules, Equals, 0)
 	res.Detach(testSelectorCache)
 	expected.Detach(testSelectorCache)
 
 	state = traceState{}
-	res, err = rule1.resolveIngressPolicy(toFoo, &state, NewL4Policy(0), nil, testSelectorCache)
+	res, err = rule1.resolveIngressPolicy(toFoo, &state, L4PolicyMap{}, nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -480,34 +476,33 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
 		cachedFooSelector:      l7rules,
 	}
 
-	expected = NewL4Policy(0)
-	expected.Ingress["80/TCP"] = &L4Filter{
+	expected = L4PolicyMap{"80/TCP": &L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		allowsAllAtL3:   true,
 		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector},
 		L7Parser:        "kafka", L7RulesPerEp: l7map, Ingress: true,
 		DerivedFromRules: labels.LabelArrayList{nil, nil},
-	}
+	}}
 
 	state = traceState{}
-	res, err = rule2.resolveIngressPolicy(toBar, &state, NewL4Policy(0), nil, testSelectorCache)
+	res, err = rule2.resolveIngressPolicy(toBar, &state, L4PolicyMap{}, nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
-	c.Assert(*res, checker.Equals, *expected)
+	c.Assert(res, checker.Equals, expected)
 	c.Assert(state.selectedRules, Equals, 1)
 	c.Assert(state.matchedRules, Equals, 0)
 	res.Detach(testSelectorCache)
 	expected.Detach(testSelectorCache)
 
 	state = traceState{}
-	res, err = rule2.resolveIngressPolicy(toFoo, &state, NewL4Policy(0), nil, testSelectorCache)
+	res, err = rule2.resolveIngressPolicy(toFoo, &state, L4PolicyMap{}, nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
 	c.Assert(state.matchedRules, Equals, 0)
 
 	// Resolve rule1's policy, then try to add rule2.
-	res, err = rule1.resolveIngressPolicy(toBar, &state, NewL4Policy(0), nil, testSelectorCache)
+	res, err = rule1.resolveIngressPolicy(toBar, &state, L4PolicyMap{}, nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 
@@ -566,21 +561,19 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
 		cachedFooSelector:      fooRules,
 		wildcardCachedSelector: barRules,
 	}
-	expected = NewL4Policy(0)
-
-	expected.Ingress["80/TCP"] = &L4Filter{
+	expected = L4PolicyMap{"80/TCP": &L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		allowsAllAtL3:   true,
 		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector},
 		L7Parser:        "kafka", L7RulesPerEp: l7map, Ingress: true,
 		DerivedFromRules: labels.LabelArrayList{nil, nil},
-	}
+	}}
 
 	state = traceState{}
-	res, err = rule3.resolveIngressPolicy(toBar, &state, NewL4Policy(0), nil, testSelectorCache)
+	res, err = rule3.resolveIngressPolicy(toBar, &state, L4PolicyMap{}, nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
-	c.Assert(*res, checker.Equals, *expected)
+	c.Assert(res, checker.Equals, expected)
 	c.Assert(state.selectedRules, Equals, 1)
 	c.Assert(state.matchedRules, Equals, 0)
 	res.Detach(testSelectorCache)
@@ -635,8 +628,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 		},
 	}
 
-	expected := NewL4Policy(0)
-	expected.Egress["80/TCP"] = &L4Filter{
+	expected := L4PolicyMap{"80/TCP": &L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		allowsAllAtL3:   true,
 		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector},
@@ -651,20 +643,20 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 		},
 		Ingress:          false,
 		DerivedFromRules: labels.LabelArrayList{nil, nil, nil},
-	}
+	}}
 
 	state := traceState{}
-	res, err := rule1.resolveEgressPolicy(fromBar, &state, NewL4Policy(0), nil, testSelectorCache)
+	res, err := rule1.resolveEgressPolicy(fromBar, &state, L4PolicyMap{}, nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
-	c.Assert(*res, checker.Equals, *expected)
+	c.Assert(res, checker.Equals, expected)
 	c.Assert(state.selectedRules, Equals, 1)
 	c.Assert(state.matchedRules, Equals, 0)
 	res.Detach(testSelectorCache)
 	expected.Detach(testSelectorCache)
 
 	state = traceState{}
-	res, err = rule1.resolveEgressPolicy(fromFoo, &state, NewL4Policy(0), nil, testSelectorCache)
+	res, err = rule1.resolveEgressPolicy(fromFoo, &state, L4PolicyMap{}, nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
@@ -710,8 +702,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 		},
 	}
 
-	expected = NewL4Policy(0)
-	expected.Egress["80/TCP"] = &L4Filter{
+	expected = L4PolicyMap{"80/TCP": &L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		allowsAllAtL3:   true,
 		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector},
@@ -726,27 +717,27 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 		},
 		Ingress:          false,
 		DerivedFromRules: labels.LabelArrayList{nil, nil, nil},
-	}
+	}}
 
 	state = traceState{}
-	res, err = rule2.resolveEgressPolicy(fromBar, &state, NewL4Policy(0), nil, testSelectorCache)
+	res, err = rule2.resolveEgressPolicy(fromBar, &state, L4PolicyMap{}, nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
-	c.Assert(*res, checker.Equals, *expected)
+	c.Assert(res, checker.Equals, expected)
 	c.Assert(state.selectedRules, Equals, 1)
 	c.Assert(state.matchedRules, Equals, 0)
 	res.Detach(testSelectorCache)
 	expected.Detach(testSelectorCache)
 
 	state = traceState{}
-	res, err = rule2.resolveEgressPolicy(fromFoo, &state, NewL4Policy(0), nil, testSelectorCache)
+	res, err = rule2.resolveEgressPolicy(fromFoo, &state, L4PolicyMap{}, nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, IsNil)
 	c.Assert(state.selectedRules, Equals, 0)
 	c.Assert(state.matchedRules, Equals, 0)
 
 	// Resolve rule1's policy, then try to add rule2.
-	res, err = rule1.resolveEgressPolicy(fromBar, &state, NewL4Policy(0), nil, testSelectorCache)
+	res, err = rule1.resolveEgressPolicy(fromBar, &state, L4PolicyMap{}, nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
 	res.Detach(testSelectorCache)
@@ -798,20 +789,19 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 		cachedFooSelector:      fooRules,
 		wildcardCachedSelector: barRules,
 	}
-	expected = NewL4Policy(0)
-	expected.Egress["80/TCP"] = &L4Filter{
+	expected = L4PolicyMap{"80/TCP": &L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		allowsAllAtL3:   true,
 		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector},
 		L7Parser:        "kafka", L7RulesPerEp: l7map, Ingress: false,
 		DerivedFromRules: labels.LabelArrayList{nil, nil},
-	}
+	}}
 
 	state = traceState{}
-	res, err = rule3.resolveEgressPolicy(fromBar, &state, NewL4Policy(0), nil, testSelectorCache)
+	res, err = rule3.resolveEgressPolicy(fromBar, &state, L4PolicyMap{}, nil, testSelectorCache)
 	c.Assert(err, IsNil)
 	c.Assert(res, Not(IsNil))
-	c.Assert(*res, checker.Equals, *expected)
+	c.Assert(res, checker.Equals, expected)
 	c.Assert(state.selectedRules, Equals, 1)
 	c.Assert(state.matchedRules, Equals, 0)
 	res.Detach(testSelectorCache)
@@ -1285,8 +1275,8 @@ func (ds *PolicyTestSuite) TestL4RuleLabels(c *C) {
 
 			rule := &rule{Rule: apiRule}
 
-			rule.resolveIngressPolicy(toBar, &traceState{}, finalPolicy, nil, testSelectorCache)
-			rule.resolveEgressPolicy(fromBar, &traceState{}, finalPolicy, nil, testSelectorCache)
+			rule.resolveIngressPolicy(toBar, &traceState{}, finalPolicy.Ingress, nil, testSelectorCache)
+			rule.resolveEgressPolicy(fromBar, &traceState{}, finalPolicy.Egress, nil, testSelectorCache)
 		}
 
 		c.Assert(len(finalPolicy.Ingress), Equals, len(test.expectedIngressLabels), Commentf(test.description))
@@ -1451,7 +1441,7 @@ func (ds *PolicyTestSuite) TestIngressL4AllowAll(c *C) {
 	l4IngressPolicy, err := repo.ResolveL4IngressPolicy(&ctxAToC80)
 	c.Assert(err, IsNil)
 
-	filter, ok := (*l4IngressPolicy)["80/TCP"]
+	filter, ok := l4IngressPolicy["80/TCP"]
 	c.Assert(ok, Equals, true)
 	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, true)
@@ -1520,7 +1510,7 @@ func (ds *PolicyTestSuite) TestEgressL4AllowAll(c *C) {
 
 	c.Log(buffer)
 
-	filter, ok := (*l4EgressPolicy)["80/TCP"]
+	filter, ok := l4EgressPolicy["80/TCP"]
 	c.Assert(ok, Equals, true)
 	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, false)
@@ -1574,7 +1564,7 @@ func (ds *PolicyTestSuite) TestEgressL4AllowWorld(c *C) {
 
 	c.Log(buffer)
 
-	filter, ok := (*l4EgressPolicy)["80/TCP"]
+	filter, ok := l4EgressPolicy["80/TCP"]
 	c.Assert(ok, Equals, true)
 	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, false)
@@ -1627,7 +1617,7 @@ func (ds *PolicyTestSuite) TestEgressL4AllowAllEntity(c *C) {
 
 	c.Log(buffer)
 
-	filter, ok := (*l4EgressPolicy)["80/TCP"]
+	filter, ok := l4EgressPolicy["80/TCP"]
 	c.Assert(ok, Equals, true)
 	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, false)
@@ -1750,7 +1740,7 @@ func (ds *PolicyTestSuite) TestL4WildcardMerge(c *C) {
 
 	c.Log(buffer)
 
-	filter, ok := (*l4IngressPolicy)["80/TCP"]
+	filter, ok := l4IngressPolicy["80/TCP"]
 	c.Assert(ok, Equals, true)
 	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, true)
@@ -1801,7 +1791,7 @@ func (ds *PolicyTestSuite) TestL4WildcardMerge(c *C) {
 
 	c.Log(buffer)
 
-	filter, ok = (*l4IngressPolicy)["80/TCP"]
+	filter, ok = l4IngressPolicy["80/TCP"]
 	c.Assert(ok, Equals, true)
 	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, true)
@@ -1850,7 +1840,7 @@ func (ds *PolicyTestSuite) TestL4WildcardMerge(c *C) {
 
 	c.Log(buffer)
 
-	filter, ok = (*l4IngressPolicy)["80/TCP"]
+	filter, ok = l4IngressPolicy["80/TCP"]
 	c.Assert(ok, Equals, true)
 	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, true)
@@ -1900,7 +1890,7 @@ func (ds *PolicyTestSuite) TestL4WildcardMerge(c *C) {
 
 	c.Log(buffer)
 
-	filter, ok = (*l4IngressPolicy)["80/TCP"]
+	filter, ok = l4IngressPolicy["80/TCP"]
 	c.Assert(ok, Equals, true)
 	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, true)
@@ -1958,7 +1948,7 @@ func (ds *PolicyTestSuite) TestL3L4L7Merge(c *C) {
 
 	c.Log(buffer)
 
-	filter, ok := (*l4IngressPolicy)["80/TCP"]
+	filter, ok := l4IngressPolicy["80/TCP"]
 	c.Assert(ok, Equals, true)
 	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, true)
@@ -2006,7 +1996,7 @@ func (ds *PolicyTestSuite) TestL3L4L7Merge(c *C) {
 
 	c.Log(buffer)
 
-	filter, ok = (*l4IngressPolicy)["80/TCP"]
+	filter, ok = l4IngressPolicy["80/TCP"]
 	c.Assert(ok, Equals, true)
 	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, true)

--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -103,7 +103,7 @@ func (rules ruleSlice) wildcardL3L4Rules(ingress bool, l4Policy L4PolicyMap, req
 }
 
 func (rules ruleSlice) resolveL4IngressPolicy(ctx *SearchContext, revision uint64, selectorCache *SelectorCache) (*L4Policy, error) {
-	result := NewL4Policy()
+	result := NewL4Policy(revision)
 
 	ctx.PolicyTrace("\n")
 	ctx.PolicyTrace("Resolving ingress policy for %+v\n", ctx.To)
@@ -140,14 +140,13 @@ func (rules ruleSlice) resolveL4IngressPolicy(ctx *SearchContext, revision uint6
 	}
 
 	matchedRules.wildcardL3L4Rules(true, result.Ingress, requirements, selectorCache)
-	result.Revision = revision
 
 	state.trace(len(rules), ctx)
 	return result, nil
 }
 
 func (rules ruleSlice) resolveL4EgressPolicy(ctx *SearchContext, revision uint64, selectorCache *SelectorCache) (*L4Policy, error) {
-	result := NewL4Policy()
+	result := NewL4Policy(revision)
 
 	ctx.PolicyTrace("\n")
 	ctx.PolicyTrace("Resolving egress policy for %+v\n", ctx.From)
@@ -185,7 +184,6 @@ func (rules ruleSlice) resolveL4EgressPolicy(ctx *SearchContext, revision uint64
 	}
 
 	matchedRules.wildcardL3L4Rules(false, result.Egress, requirements, selectorCache)
-	result.Revision = revision
 
 	state.trace(len(rules), ctx)
 	return result, nil

--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -102,8 +102,8 @@ func (rules ruleSlice) wildcardL3L4Rules(ingress bool, l4Policy L4PolicyMap, req
 	}
 }
 
-func (rules ruleSlice) resolveL4IngressPolicy(ctx *SearchContext, revision uint64, selectorCache *SelectorCache) (*L4Policy, error) {
-	result := NewL4Policy(revision)
+func (rules ruleSlice) resolveL4IngressPolicy(ctx *SearchContext, revision uint64, selectorCache *SelectorCache) (L4PolicyMap, error) {
+	result := L4PolicyMap{}
 
 	ctx.PolicyTrace("\n")
 	ctx.PolicyTrace("Resolving ingress policy for %+v\n", ctx.To)
@@ -139,14 +139,14 @@ func (rules ruleSlice) resolveL4IngressPolicy(ctx *SearchContext, revision uint6
 		}
 	}
 
-	matchedRules.wildcardL3L4Rules(true, result.Ingress, requirements, selectorCache)
+	matchedRules.wildcardL3L4Rules(true, result, requirements, selectorCache)
 
 	state.trace(len(rules), ctx)
 	return result, nil
 }
 
-func (rules ruleSlice) resolveL4EgressPolicy(ctx *SearchContext, revision uint64, selectorCache *SelectorCache) (*L4Policy, error) {
-	result := NewL4Policy(revision)
+func (rules ruleSlice) resolveL4EgressPolicy(ctx *SearchContext, revision uint64, selectorCache *SelectorCache) (L4PolicyMap, error) {
+	result := L4PolicyMap{}
 
 	ctx.PolicyTrace("\n")
 	ctx.PolicyTrace("Resolving egress policy for %+v\n", ctx.From)
@@ -183,7 +183,7 @@ func (rules ruleSlice) resolveL4EgressPolicy(ctx *SearchContext, revision uint64
 		}
 	}
 
-	matchedRules.wildcardL3L4Rules(false, result.Egress, requirements, selectorCache)
+	matchedRules.wildcardL3L4Rules(false, result, requirements, selectorCache)
 
 	state.trace(len(rules), ctx)
 	return result, nil

--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -167,8 +167,7 @@ type SelectorCache struct {
 	// idCache contains all known identities as informed by the
 	// kv-store and the local identity facility via our
 	// UpdateIdentities() function.
-	idCache         scIdentityCache
-	idCacheRevision uint64
+	idCache scIdentityCache
 
 	// map key is the string representation of the selector being cached.
 	selectors map[string]identitySelector
@@ -705,8 +704,6 @@ func (sc *SelectorCache) UpdateIdentities(added, deleted cache.IdentityCache) {
 	}
 
 	if len(deleted)+len(added) > 0 {
-		sc.idCacheRevision++
-
 		// Iterate through all locally used identity selectors and
 		// update the cached numeric identities as required.
 		for _, sel := range sc.selectors {
@@ -737,16 +734,6 @@ func (sc *SelectorCache) UpdateIdentities(added, deleted cache.IdentityCache) {
 			}
 		}
 	}
-}
-
-// GetIDCacheRevision can be used to figure our if the selections
-// may have changed. Should not be used when identity updates are
-// properly propagated to the policy realization.
-func (sc *SelectorCache) GetIDCacheRevision() uint64 {
-	sc.mutex.Lock()
-	rev := sc.idCacheRevision
-	sc.mutex.Unlock()
-	return rev
 }
 
 // RemoveIdentitiesFQDNSelectors removes all identities from being mapped to the

--- a/pkg/u8proto/u8proto.go
+++ b/pkg/u8proto/u8proto.go
@@ -20,9 +20,12 @@ import (
 	"strings"
 )
 
+// These definitions must contain and be compatible with the string
+// values defined for pkg/pollicy/api/L4Proto
+
 const (
-	// All represents all protocols.
-	All    U8proto = 0
+	// ANY represents all protocols.
+	ANY    U8proto = 0
 	ICMP   U8proto = 1
 	TCP    U8proto = 6
 	UDP    U8proto = 17
@@ -30,7 +33,7 @@ const (
 )
 
 var protoNames = map[U8proto]string{
-	0:  "all",
+	0:  "ANY",
 	1:  "ICMP",
 	6:  "TCP",
 	17: "UDP",


### PR DESCRIPTION
Accumulate MapState entires due to identity changes and apply them
without full policy recalculation.

A policy update trigger is still needed like before, but the policy computation is skipped if not forced and the policy itself did not change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8263)
<!-- Reviewable:end -->
