### PR TITLE
test: create session and run commands asynchronously

### DIFF
--- a/test/helpers/cmd.go
+++ b/test/helpers/cmd.go
@@ -317,6 +317,11 @@ func (res *CmdRes) GetErr(context string) error {
 	return &cmdError{fmt.Sprintf("%s output: %s", context, res.GetDebugMessage())}
 }
 
+// GetError returns the error for this CmdRes.
+func (res *CmdRes) GetError() error {
+	return res.err
+}
+
 // BeSuccesfulMatcher a new Ginkgo matcher for CmdRes struct
 type BeSuccesfulMatcher struct{}
 

--- a/test/runtime/ssh.go
+++ b/test/runtime/ssh.go
@@ -1,0 +1,42 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package RuntimeTest
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	. "github.com/cilium/cilium/test/ginkgo-ext"
+	"github.com/cilium/cilium/test/helpers"
+)
+
+var _ = Describe("RuntimeSSHTests", func() {
+
+	var vm *helpers.SSHMeta
+
+	BeforeAll(func() {
+		vm = helpers.InitRuntimeHelper(helpers.Runtime, logger)
+	})
+
+	It("Should fail when context times out", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		By("Running sleep command which is longer than timeout for context")
+		res := vm.ExecContext(ctx, "sleep 10")
+		Expect(res.GetError()).Should(Equal(context.DeadlineExceeded))
+	})
+})


### PR DESCRIPTION
The existing code surrounding the use of `context.Context` to enforce timeouts
is correct, but the way that commands are ran currently in the CI code makes
their use somewhat useless. This is because previously, we called `newSession`
and `runCommand` synchronously *before* we select on the deadline of provided
contexts being reached. This means that if the calls to create sessions / run
commands hang forever, we will never reach the timeout provided to us via
Context. In order to ensure that we do not block forever on running of commands
/ creation of sessions, do the aforementioned in a goroutine. Unfortunately,
there is no way via the SSH library we currently use in the CI to propagate
Context to creation of sessions, running commands, etc., so in the case that
Contexts are reached, we try to close the session we have created as to not leak
goroutines.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8264)
<!-- Reviewable:end -->
