### PR TITLE
test: be sure to close SSH client after a given Describe completes

### DIFF
--- a/test/helpers/node.go
+++ b/test/helpers/node.go
@@ -58,6 +58,17 @@ func (s *SSHMeta) String() string {
 
 }
 
+// CloseSSHClient closes all of the connections made by the SSH Client for this
+// SSHMeta.
+func (s *SSHMeta) CloseSSHClient() {
+	if s.sshClient == nil || s.sshClient.client == nil {
+		log.Error("SSH client is nil; cannot close")
+	}
+	if err := s.sshClient.client.Close(); err != nil {
+		log.WithError(err).Error("error closing SSH client")
+	}
+}
+
 // GetVagrantSSHMeta returns a SSHMeta initialized based on the provided
 // SSH-config target.
 func GetVagrantSSHMeta(vmName string) *SSHMeta {

--- a/test/k8sT/Chaos.go
+++ b/test/k8sT/Chaos.go
@@ -49,6 +49,7 @@ var _ = Describe("K8sChaosTest", func() {
 
 	AfterAll(func() {
 		ExpectAllPodsTerminated(kubectl)
+		kubectl.CloseSSHClient()
 	})
 
 	Context("Connectivity demo application", func() {

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -65,6 +65,10 @@ var _ = Describe("K8sDatapathConfig", func() {
 			"cilium endpoint list")
 	})
 
+	AfterAll(func() {
+		kubectl.CloseSSHClient()
+	})
+
 	JustAfterEach(func() {
 		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 	})

--- a/test/k8sT/Health.go
+++ b/test/k8sT/Health.go
@@ -47,6 +47,10 @@ var _ = Describe("K8sHealthTest", func() {
 		ExpectAllPodsTerminated(kubectl)
 	})
 
+	AfterAll(func() {
+		kubectl.CloseSSHClient()
+	})
+
 	getCilium := func(node string) (pod, ip string) {
 		pod, err := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, node)
 		Expect(err).Should(BeNil())

--- a/test/k8sT/KafkaPolicies.go
+++ b/test/k8sT/KafkaPolicies.go
@@ -60,6 +60,10 @@ var _ = Describe("K8sKafkaPolicyTest", func() {
 			"cilium endpoint list")
 	})
 
+	AfterAll(func() {
+		kubectl.CloseSSHClient()
+	})
+
 	Context("Kafka Policy Tests", func() {
 		createTopicCmd := func(topic string) string {
 			return fmt.Sprintf("/opt/kafka_2.11-0.10.1.0/bin/kafka-topics.sh --create "+

--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -65,6 +65,7 @@ var _ = Describe("NightlyEpsMeasurement", func() {
 	AfterAll(func() {
 		deleteAll()
 		ExpectAllPodsTerminated(kubectl)
+		kubectl.CloseSSHClient()
 	})
 
 	AfterFailed(func() {
@@ -339,6 +340,10 @@ var _ = Describe("NightlyExamples", func() {
 		kubectl.Delete(l7Policy)
 
 		ExpectAllPodsTerminated(kubectl)
+	})
+
+	AfterAll(func() {
+		kubectl.CloseSSHClient()
 	})
 
 	Context("Upgrade test", func() {

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -68,6 +68,7 @@ var _ = Describe("K8sPolicyTest", func() {
 
 	AfterAll(func() {
 		ExpectAllPodsTerminated(kubectl)
+		kubectl.CloseSSHClient()
 	})
 
 	JustBeforeEach(func() {

--- a/test/k8sT/PoliciesNightly.go
+++ b/test/k8sT/PoliciesNightly.go
@@ -52,6 +52,7 @@ var _ = Describe("NightlyPolicies", func() {
 			helpers.KubectlCmd, helpers.DefaultNamespace))
 		err := kubectl.WaitCleanAllTerminatingPods(timeout)
 		Expect(err).To(BeNil(), "Cannot clean pods during timeout")
+		kubectl.CloseSSHClient()
 	})
 
 	Context("PolicyEnforcement default", func() {

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -80,6 +80,10 @@ var _ = Describe("K8sServicesTest", func() {
 		ExpectAllPodsTerminated(kubectl)
 	})
 
+	AfterAll(func() {
+		kubectl.CloseSSHClient()
+	})
+
 	testHTTPRequest := func(url string) {
 		pods, err := kubectl.GetPodNames(helpers.DefaultNamespace, testDSClient)
 		ExpectWithOffset(1, err).Should(BeNil(), "cannot retrieve pod names by filter %q", testDSClient)

--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -56,6 +56,7 @@ var _ = Describe("K8sUpdates", func() {
 
 	AfterAll(func() {
 		_ = kubectl.Apply(helpers.DNSDeployment())
+		kubectl.CloseSSHClient()
 	})
 
 	AfterFailed(func() {

--- a/test/k8sT/demos.go
+++ b/test/k8sT/demos.go
@@ -85,6 +85,10 @@ var _ = Describe("K8sDemosTest", func() {
 		ExpectAllPodsTerminated(kubectl)
 	})
 
+	AfterAll(func() {
+		kubectl.CloseSSHClient()
+	})
+
 	It("Tests Star Wars Demo", func() {
 
 		allianceLabel := "org=alliance"

--- a/test/k8sT/fqdn.go
+++ b/test/k8sT/fqdn.go
@@ -76,6 +76,7 @@ var _ = Describe("K8sFQDNTest", func() {
 		_ = kubectl.Delete(bindManifest)
 		_ = kubectl.Delete(demoManifest)
 		ExpectAllPodsTerminated(kubectl)
+		kubectl.CloseSSHClient()
 	})
 
 	JustBeforeEach(func() {

--- a/test/k8sT/istio.go
+++ b/test/k8sT/istio.go
@@ -137,6 +137,8 @@ var _ = Describe("K8sIstioTest", func() {
 		_ = kubectl.NamespaceDelete(istioSystemNamespace)
 
 		kubectl.WaitCleanAllTerminatingPods(teardownTimeout)
+
+		kubectl.CloseSSHClient()
 	})
 
 	JustBeforeEach(func() {

--- a/test/k8sT/microscope.go
+++ b/test/k8sT/microscope.go
@@ -40,6 +40,7 @@ var _ = Describe("K8sMicroscope", func() {
 
 	AfterAll(func() {
 		ExpectAllPodsTerminated(kubectl)
+		kubectl.CloseSSHClient()
 	})
 
 	It("Runs microscope", func() {

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -75,6 +75,7 @@ var _ = Describe("RuntimePolicyEnforcement", func() {
 
 	AfterAll(func() {
 		vm.ContainerRm(appContainerName)
+		vm.CloseSSHClient()
 	})
 
 	BeforeEach(func() {
@@ -295,6 +296,7 @@ var _ = Describe("RuntimePolicies", func() {
 	AfterAll(func() {
 		vm.PolicyDelAll().ExpectSuccess("Unable to delete all policies")
 		vm.SampleContainersActions(helpers.Delete, helpers.CiliumDockerNetwork)
+		vm.CloseSSHClient()
 	})
 
 	pingRequests := []string{ping, ping6}

--- a/test/runtime/benchmark.go
+++ b/test/runtime/benchmark.go
@@ -106,6 +106,10 @@ var _ = Describe("BenchmarkNetperfPerformance", func() {
 		PerfLogWriter.Reset()
 	}, 500)
 
+	AfterAll(func() {
+		vm.CloseSSHClient()
+	})
+
 	createContainers := func() {
 		By("create Client container")
 		vm.ContainerCreate(helpers.Client, constants.NetperfImage, helpers.CiliumDockerNetwork, "-l id.client")

--- a/test/runtime/cassandra.go
+++ b/test/runtime/cassandra.go
@@ -115,6 +115,7 @@ var _ = Describe("RuntimeCassandra", func() {
 
 	AfterAll(func() {
 		containers("delete")
+		vm.CloseSSHClient()
 	})
 
 	JustAfterEach(func() {

--- a/test/runtime/chaos.go
+++ b/test/runtime/chaos.go
@@ -50,6 +50,7 @@ var _ = Describe("RuntimeChaos", func() {
 		vm.ContainerRm(helpers.Client)
 		vm.ContainerRm(helpers.Server)
 		vm.SampleContainersActions(helpers.Delete, helpers.CiliumDockerNetwork)
+		vm.CloseSSHClient()
 	})
 
 	AfterEach(func() {

--- a/test/runtime/cli.go
+++ b/test/runtime/cli.go
@@ -46,6 +46,10 @@ var _ = Describe("RuntimeCLI", func() {
 		vm.ReportFailed()
 	})
 
+	AfterAll(func() {
+		vm.CloseSSHClient()
+	})
+
 	Context("Identity CLI testing", func() {
 
 		var (

--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -57,6 +57,7 @@ var runtimeConnectivityTest = func(datapathMode string) func() {
 				vm.SetUpCilium()
 				vm.Exec("sudo systemctl restart cilium-docker")
 			}
+			vm.CloseSSHClient()
 		})
 
 		removeContainer := func(containerName string) {
@@ -375,6 +376,7 @@ var runtimeConntrackTest = func(datapathMode string) func() {
 				vm.SetUpCilium()
 				vm.Exec("sudo systemctl restart cilium-docker")
 			}
+			vm.CloseSSHClient()
 		})
 
 		clientServerConnectivity := func() {

--- a/test/runtime/examples.go
+++ b/test/runtime/examples.go
@@ -42,6 +42,10 @@ var _ = Describe("RuntimePolicyValidationTests", func() {
 		vm.ReportFailed()
 	})
 
+	AfterAll(func() {
+		vm.CloseSSHClient()
+	})
+
 	It("Validates Example Policies", func() {
 		By("Validating Demos")
 

--- a/test/runtime/fqdn.go
+++ b/test/runtime/fqdn.go
@@ -270,6 +270,7 @@ var _ = Describe("RuntimeFQDNPolicies", func() {
 		vm.SampleContainersActions(helpers.Delete, "")
 		vm.ContainerRm(bindContainerName)
 		vm.Exec(fmt.Sprintf("docker network rm  %s", worldNetwork))
+		vm.CloseSSHClient()
 	})
 
 	JustBeforeEach(func() {

--- a/test/runtime/kafka.go
+++ b/test/runtime/kafka.go
@@ -140,6 +140,8 @@ var _ = Describe("RuntimeKafka", func() {
 		status := vm.ExecCilium(fmt.Sprintf("config %s=false",
 			helpers.OptionConntrackLocal))
 		status.ExpectSuccess()
+
+		vm.CloseSSHClient()
 	})
 
 	JustBeforeEach(func() {

--- a/test/runtime/kvstore.go
+++ b/test/runtime/kvstore.go
@@ -64,6 +64,10 @@ var _ = Describe("RuntimeKVStoreTest", func() {
 		vm.ReportFailed("cilium status")
 	})
 
+	AfterAll(func() {
+		vm.CloseSSHClient()
+	})
+
 	It("Consul KVStore", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()

--- a/test/runtime/lb.go
+++ b/test/runtime/lb.go
@@ -38,6 +38,7 @@ var _ = Describe("RuntimeLB", func() {
 
 	AfterAll(func() {
 		vm.ServiceDelAll().ExpectSuccess()
+		vm.CloseSSHClient()
 	})
 
 	JustBeforeEach(func() {

--- a/test/runtime/memcache.go
+++ b/test/runtime/memcache.go
@@ -112,6 +112,7 @@ var _ = Describe("RuntimeMemcache", func() {
 
 	AfterAll(func() {
 		containers("delete")
+		vm.CloseSSHClient()
 	})
 
 	JustAfterEach(func() {

--- a/test/runtime/monitor.go
+++ b/test/runtime/monitor.go
@@ -70,6 +70,10 @@ var _ = Describe("RuntimeMonitorTest", func() {
 		ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementDefault)
 	})
 
+	AfterAll(func() {
+		vm.CloseSSHClient()
+	})
+
 	Context("With Sample Containers", func() {
 
 		BeforeAll(func() {

--- a/test/runtime/privileged_tests.go
+++ b/test/runtime/privileged_tests.go
@@ -37,6 +37,7 @@ var _ = Describe("RuntimePrivilegedUnitTests", func() {
 	AfterAll(func() {
 		err := vm.RestartCilium()
 		Expect(err).Should(BeNil(), "Failed to restart Cilium")
+		vm.CloseSSHClient()
 	})
 
 	It("Run Tests", func() {

--- a/test/runtime/verifier.go
+++ b/test/runtime/verifier.go
@@ -61,6 +61,7 @@ var _ = Describe("RuntimeVerifier", func() {
 	AfterAll(func() {
 		err := vm.RestartCilium()
 		Expect(err).Should(BeNil(), "restarting Cilium failed")
+		vm.CloseSSHClient()
 	})
 
 	It("runs the kernel verifier against the tree copy of the BPF datapath", func() {


### PR DESCRIPTION
We were never closing the clients we created, and the code should clean up after
itself once it is finished. Do so.
This adds some boilerplate code, unfortunately, but it's better than leaving
open clients around.

Signed-off by: Ian Vernon <ian@cilium.io>"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8266)
<!-- Reviewable:end -->
