### PR TITLE
cilium: Fix parsing of embedded JSON

### DIFF
--- a/cilium/cmd/helpers_test.go
+++ b/cilium/cmd/helpers_test.go
@@ -38,30 +38,514 @@ var _ = Suite(&CMDHelpersSuite{})
 
 func (s *CMDHelpersSuite) TestExpandNestedJSON(c *C) {
 	buf := bytes.NewBufferString("not json at all")
-	_, err := expandNestedJSON(*buf)
+	res, err := expandNestedJSON(*buf)
 	c.Assert(err, IsNil)
+	c.Assert(string(res.Bytes()), Equals, `not json at all`)
 
-	buf = bytes.NewBufferString(`{\n\"escapedJson\": \"foo\"}`)
-	_, err = expandNestedJSON(*buf)
+	buf = bytes.NewBufferString(`{\n\"notEscapedJson\": \"foo\"}`)
+	res, err = expandNestedJSON(*buf)
 	c.Assert(err, IsNil)
+	c.Assert(string(res.Bytes()), Equals, `{\n\"notEscapedJson\": \"foo\"}`)
 
-	buf = bytes.NewBufferString(`nonjson={\n\"escapedJson\": \"foo\"}`)
-	_, err = expandNestedJSON(*buf)
+	buf = bytes.NewBufferString(`nonjson={\n\"notEscapedJson\": \"foo\"}`)
+	res, err = expandNestedJSON(*buf)
 	c.Assert(err, IsNil)
+	c.Assert(string(res.Bytes()), Equals, `nonjson={\n\"notEscapedJson\": \"foo\"}`)
 
-	buf = bytes.NewBufferString(`nonjson:morenonjson={\n\"escapedJson\": \"foo\"}`)
-	_, err = expandNestedJSON(*buf)
+	buf = bytes.NewBufferString(`nonjson:morenonjson={\n\"notEscapedJson\": \"foo\"}`)
+	res, err = expandNestedJSON(*buf)
 	c.Assert(err, IsNil)
+	c.Assert(string(res.Bytes()), Equals, `nonjson:morenonjson={\n\"notEscapedJson\": \"foo\"}`)
 
 	buf = bytes.NewBufferString(`{"foo": ["{\n  \"port\": 8080,\n  \"protocol\": \"TCP\"\n}"]}`)
-	_, err = expandNestedJSON(*buf)
+	res, err = expandNestedJSON(*buf)
 	c.Assert(err, IsNil)
+	c.Assert(string(res.Bytes()), Equals, `{"foo": [{
+  "port": 8080,
+  "protocol": "TCP"
+}]}`)
 
 	buf = bytes.NewBufferString(`"foo": [
   "bar:baz/alice={\"bob\":{\"charlie\":4}}\n"
 ]`)
-	_, err = expandNestedJSON(*buf)
+	res, err = expandNestedJSON(*buf)
 	c.Assert(err, IsNil)
+	c.Assert(string(res.Bytes()), Equals, `"foo": [
+  bar:baz/alice={
+				  "bob": {
+				    "charlie": 4
+				  }
+				}
+
+]`)
+
+	buf = bytes.NewBufferString(`"foo": [
+  "bar:baz/alice={\n\"bob\":\n{\n\"charlie\":\n4\n}\n}\n"
+]`)
+	res, err = expandNestedJSON(*buf)
+	c.Assert(err, IsNil)
+	c.Assert(string(res.Bytes()), Equals, `"foo": [
+  bar:baz/alice={
+				  "bob": {
+				    "charlie": 4
+				  }
+				}
+
+]`)
+
+	buf = bytes.NewBufferString(`[
+  {
+    "id": 2669,
+    "spec": {
+      "label-configuration": {},
+      "options": {
+        "Conntrack": "Enabled",
+        "ConntrackAccounting": "Enabled",
+        "ConntrackLocal": "Disabled",
+        "Debug": "Enabled",
+        "DebugLB": "Enabled",
+        "DropNotification": "Enabled",
+        "MonitorAggregationLevel": "None",
+        "NAT46": "Disabled",
+        "TraceNotification": "Enabled"
+      }
+    },
+    "status": {
+      "controllers": [
+        {
+          "configuration": {
+            "error-retry": true,
+            "interval": "5m0s"
+          },
+          "name": "resolve-identity-2669",
+          "status": {
+            "last-failure-timestamp": "0001-01-01T00:00:00.000Z",
+            "last-success-timestamp": "2019-06-10T19:36:42.497Z",
+            "success-count": 4
+          },
+          "uuid": "aba643d9-8bb5-11e9-9be2-080027486be3"
+        },
+        {
+          "configuration": {
+            "error-retry": true,
+            "interval": "5m0s"
+          },
+          "name": "sync-IPv4-identity-mapping (2669)",
+          "status": {
+            "last-failure-timestamp": "0001-01-01T00:00:00.000Z",
+            "last-success-timestamp": "2019-06-10T19:36:42.529Z",
+            "success-count": 4
+          },
+          "uuid": "aba631c3-8bb5-11e9-9be2-080027486be3"
+        },
+        {
+          "configuration": {
+            "error-retry": true,
+            "interval": "5m0s"
+          },
+          "name": "sync-IPv6-identity-mapping (2669)",
+          "status": {
+            "last-failure-timestamp": "0001-01-01T00:00:00.000Z",
+            "last-success-timestamp": "2019-06-10T19:36:42.529Z",
+            "success-count": 4
+          },
+          "uuid": "aba637e9-8bb5-11e9-9be2-080027486be3"
+        },
+        {
+          "configuration": {
+            "error-retry": true,
+            "interval": "1m0s"
+          },
+          "name": "sync-policymap-2669",
+          "status": {
+            "last-failure-timestamp": "0001-01-01T00:00:00.000Z",
+            "last-success-timestamp": "2019-06-10T19:39:43.974Z",
+            "success-count": 16
+          },
+          "uuid": "ad0a1388-8bb5-11e9-9be2-080027486be3"
+        }
+      ],
+      "external-identifiers": {
+        "container-id": "1968a48396a0e42f3faad360a7ffa23d8629faddee7f828408bf177d3eeac47a",
+        "container-name": "client",
+        "docker-endpoint-id": "05a27bef9f339e5ae25a191108b91ee1e7fdc2696d2c46908645157a62438ccd",
+        "docker-network-id": "e3ea8f2e1df2250df6702fd802ea0d3706091c1b374db998d48e7327bf9bd0fe",
+        "pod-name": "/"
+      },
+      "health": {
+        "bpf": "OK",
+        "connected": true,
+        "overallHealth": "OK",
+        "policy": "OK"
+      },
+      "identity": {
+        "id": 62004,
+        "labels": [
+          "container:id.client"
+        ],
+        "labelsSHA256": "c2e7b3482b5e9e1abca840b8cc5568ff876c7524d723b3068683f539008537dc"
+      },
+      "labels": {
+        "realized": {},
+        "security-relevant": [
+          "container:id.client"
+        ]
+      },
+      "log": [
+        {
+          "code": "OK",
+          "message": "Successfully regenerated endpoint program (Reason: policy rules added)",
+          "state": "ready",
+          "timestamp": "2019-06-10T19:26:43Z"
+        }
+      ],
+      "networking": {
+        "addressing": [
+          {
+            "ipv4": "10.11.212.174",
+            "ipv6": "f00d::a0b:0:0:8cdf"
+          }
+        ],
+        "host-mac": "1a:c9:b9:4f:98:65",
+        "interface-index": 250,
+        "interface-name": "lxca8e38e6f627e",
+        "mac": "7e:41:1b:fd:02:81"
+      },
+      "policy": {
+        "proxy-policy-revision": 48,
+        "proxy-statistics": [
+          {
+            "allocated-proxy-port": 15814,
+            "location": "egress",
+            "port": 80,
+            "protocol": "http",
+            "statistics": {
+              "requests": {
+                "denied": 2,
+                "forwarded": 2,
+                "received": 4
+              },
+              "responses": {
+                "forwarded": 2,
+                "received": 2
+              }
+            }
+          }
+        ],
+        "realized": {
+          "allowed-egress-identities": [],
+          "allowed-ingress-identities": [
+            0,
+            1
+          ],
+          "build": 48,
+          "cidr-policy": {
+            "egress": [],
+            "ingress": []
+          },
+          "id": 62004,
+          "l4": {
+            "egress": [
+              {
+                "derived-from-rules": [
+                  []
+                ],
+                "rule": "{\n  \"port\": 80,\n  \"protocol\": \"TCP\",\n  \"l7-rules\": [\n    {\n      \"\\u0026LabelSelector{MatchLabels:map[string]string{},MatchExpressions:[],}\": {\n        \"http\": [\n          {\n            \"path\": \"/public\",\n            \"method\": \"GET\"\n          }\n        ]\n      }\n    }\n  ]\n}"
+              }
+            ],
+            "ingress": []
+          },
+          "policy-enabled": "egress",
+          "policy-revision": 48
+        },
+        "spec": {
+          "allowed-egress-identities": [],
+          "allowed-ingress-identities": [
+            0,
+            1
+          ],
+          "build": 48,
+          "cidr-policy": {
+            "egress": [],
+            "ingress": []
+          },
+          "id": 62004,
+          "l4": {
+            "egress": [
+              {
+                "derived-from-rules": [
+                  []
+                ],
+                "rule": "{\n  \"port\": 80,\n  \"protocol\": \"TCP\",\n  \"l7-rules\": [\n    {\n      \"\\u0026LabelSelector{MatchLabels:map[string]string{},MatchExpressions:[],}\": {\n        \"http\": [\n          {\n            \"path\": \"/public\",\n            \"method\": \"GET\"\n          }\n        ]\n      }\n    }\n  ]\n}"
+              }
+            ],
+            "ingress": []
+          },
+          "policy-enabled": "egress",
+          "policy-revision": 48
+        }
+      },
+      "realized": {
+        "label-configuration": {},
+        "options": {
+          "Conntrack": "Enabled",
+          "ConntrackAccounting": "Enabled",
+          "ConntrackLocal": "Disabled",
+          "Debug": "Enabled",
+          "DebugLB": "Enabled",
+          "DropNotification": "Enabled",
+          "MonitorAggregationLevel": "None",
+          "NAT46": "Disabled",
+          "TraceNotification": "Enabled"
+        }
+      },
+      "state": "ready"
+    }
+  }
+]`)
+	res, err = expandNestedJSON(*buf)
+	c.Assert(err, IsNil)
+	c.Assert(string(res.Bytes()), Equals, `[
+  {
+    "id": 2669,
+    "spec": {
+      "label-configuration": {},
+      "options": {
+        "Conntrack": "Enabled",
+        "ConntrackAccounting": "Enabled",
+        "ConntrackLocal": "Disabled",
+        "Debug": "Enabled",
+        "DebugLB": "Enabled",
+        "DropNotification": "Enabled",
+        "MonitorAggregationLevel": "None",
+        "NAT46": "Disabled",
+        "TraceNotification": "Enabled"
+      }
+    },
+    "status": {
+      "controllers": [
+        {
+          "configuration": {
+            "error-retry": true,
+            "interval": "5m0s"
+          },
+          "name": "resolve-identity-2669",
+          "status": {
+            "last-failure-timestamp": "0001-01-01T00:00:00.000Z",
+            "last-success-timestamp": "2019-06-10T19:36:42.497Z",
+            "success-count": 4
+          },
+          "uuid": "aba643d9-8bb5-11e9-9be2-080027486be3"
+        },
+        {
+          "configuration": {
+            "error-retry": true,
+            "interval": "5m0s"
+          },
+          "name": "sync-IPv4-identity-mapping (2669)",
+          "status": {
+            "last-failure-timestamp": "0001-01-01T00:00:00.000Z",
+            "last-success-timestamp": "2019-06-10T19:36:42.529Z",
+            "success-count": 4
+          },
+          "uuid": "aba631c3-8bb5-11e9-9be2-080027486be3"
+        },
+        {
+          "configuration": {
+            "error-retry": true,
+            "interval": "5m0s"
+          },
+          "name": "sync-IPv6-identity-mapping (2669)",
+          "status": {
+            "last-failure-timestamp": "0001-01-01T00:00:00.000Z",
+            "last-success-timestamp": "2019-06-10T19:36:42.529Z",
+            "success-count": 4
+          },
+          "uuid": "aba637e9-8bb5-11e9-9be2-080027486be3"
+        },
+        {
+          "configuration": {
+            "error-retry": true,
+            "interval": "1m0s"
+          },
+          "name": "sync-policymap-2669",
+          "status": {
+            "last-failure-timestamp": "0001-01-01T00:00:00.000Z",
+            "last-success-timestamp": "2019-06-10T19:39:43.974Z",
+            "success-count": 16
+          },
+          "uuid": "ad0a1388-8bb5-11e9-9be2-080027486be3"
+        }
+      ],
+      "external-identifiers": {
+        "container-id": "1968a48396a0e42f3faad360a7ffa23d8629faddee7f828408bf177d3eeac47a",
+        "container-name": "client",
+        "docker-endpoint-id": "05a27bef9f339e5ae25a191108b91ee1e7fdc2696d2c46908645157a62438ccd",
+        "docker-network-id": "e3ea8f2e1df2250df6702fd802ea0d3706091c1b374db998d48e7327bf9bd0fe",
+        "pod-name": "/"
+      },
+      "health": {
+        "bpf": "OK",
+        "connected": true,
+        "overallHealth": "OK",
+        "policy": "OK"
+      },
+      "identity": {
+        "id": 62004,
+        "labels": [
+          "container:id.client"
+        ],
+        "labelsSHA256": "c2e7b3482b5e9e1abca840b8cc5568ff876c7524d723b3068683f539008537dc"
+      },
+      "labels": {
+        "realized": {},
+        "security-relevant": [
+          "container:id.client"
+        ]
+      },
+      "log": [
+        {
+          "code": "OK",
+          "message": "Successfully regenerated endpoint program (Reason: policy rules added)",
+          "state": "ready",
+          "timestamp": "2019-06-10T19:26:43Z"
+        }
+      ],
+      "networking": {
+        "addressing": [
+          {
+            "ipv4": "10.11.212.174",
+            "ipv6": "f00d::a0b:0:0:8cdf"
+          }
+        ],
+        "host-mac": "1a:c9:b9:4f:98:65",
+        "interface-index": 250,
+        "interface-name": "lxca8e38e6f627e",
+        "mac": "7e:41:1b:fd:02:81"
+      },
+      "policy": {
+        "proxy-policy-revision": 48,
+        "proxy-statistics": [
+          {
+            "allocated-proxy-port": 15814,
+            "location": "egress",
+            "port": 80,
+            "protocol": "http",
+            "statistics": {
+              "requests": {
+                "denied": 2,
+                "forwarded": 2,
+                "received": 4
+              },
+              "responses": {
+                "forwarded": 2,
+                "received": 2
+              }
+            }
+          }
+        ],
+        "realized": {
+          "allowed-egress-identities": [],
+          "allowed-ingress-identities": [
+            0,
+            1
+          ],
+          "build": 48,
+          "cidr-policy": {
+            "egress": [],
+            "ingress": []
+          },
+          "id": 62004,
+          "l4": {
+            "egress": [
+              {
+                "derived-from-rules": [
+                  []
+                ],
+                "rule": {
+		  "l7-rules": [
+		    {
+		      "\u0026LabelSelector{MatchLabels:map[string]string{},MatchExpressions:[],}": {
+		        "http": [
+		          {
+		            "method": "GET",
+		            "path": "/public"
+		          }
+		        ]
+		      }
+		    }
+		  ],
+		  "port": 80,
+		  "protocol": "TCP"
+		}
+              }
+            ],
+            "ingress": []
+          },
+          "policy-enabled": "egress",
+          "policy-revision": 48
+        },
+        "spec": {
+          "allowed-egress-identities": [],
+          "allowed-ingress-identities": [
+            0,
+            1
+          ],
+          "build": 48,
+          "cidr-policy": {
+            "egress": [],
+            "ingress": []
+          },
+          "id": 62004,
+          "l4": {
+            "egress": [
+              {
+                "derived-from-rules": [
+                  []
+                ],
+                "rule": {
+		  "l7-rules": [
+		    {
+		      "\u0026LabelSelector{MatchLabels:map[string]string{},MatchExpressions:[],}": {
+		        "http": [
+		          {
+		            "method": "GET",
+		            "path": "/public"
+		          }
+		        ]
+		      }
+		    }
+		  ],
+		  "port": 80,
+		  "protocol": "TCP"
+		}
+              }
+            ],
+            "ingress": []
+          },
+          "policy-enabled": "egress",
+          "policy-revision": 48
+        }
+      },
+      "realized": {
+        "label-configuration": {},
+        "options": {
+          "Conntrack": "Enabled",
+          "ConntrackAccounting": "Enabled",
+          "ConntrackLocal": "Disabled",
+          "Debug": "Enabled",
+          "DebugLB": "Enabled",
+          "DropNotification": "Enabled",
+          "MonitorAggregationLevel": "None",
+          "NAT46": "Disabled",
+          "TraceNotification": "Enabled"
+        }
+      },
+      "state": "ready"
+    }
+  }
+]`)
+
 }
 
 func (s *CMDHelpersSuite) TestParseTrafficString(c *C) {


### PR DESCRIPTION
'cilium endpoint get' returns embedded JSON (JSON within JSON as a
quoted string). The parsing of the returned embedded JSON has broken
down; this commit fixes that.

The problem was with the definition of the regular expression used to
match the embedded JSON from the unquoted string. By the spec of the
Perl RE '.' matches any character BUT the newline, so we need to
explicitly allow newlines with '(.|\n)'. When newlines are properly
matched by the regular expression, the alternative Match() on the
quoted string is no longer necessary. Besides, the alternative Match()
only worked if the unquoted string did not contain any newlines, and
contained only the JSON, because the match was successful on any part
of the quited string containing the embedded JSON, not only when the
whole byte array was JSON.

Finally, FindAllStringIndex() returns successive, non-overlapping
matches, so taking the last only works when there is onlly one
match. In this case the simpler FindStringIndex(), which returns the
left-most match works equally well.

The unit tests are also enhanced:
- make them run in non-privileged mode
- verify results
- add an example of a 'cilium endpoint get' output, which failed before
  this commit

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8267)
<!-- Reviewable:end -->
