### PR TITLE
daemon: Remove unnecessary and unsafe arg append for init.sh

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -524,8 +524,6 @@ func (d *Daemon) compileBase() error {
 
 		args[initArgMode] = mode
 		args[initArgDevice] = option.Config.Device
-
-		args = append(args, option.Config.Device)
 	} else {
 		if option.Config.IsLBEnabled() && strings.ToLower(option.Config.Tunnel) != "disabled" {
 			//FIXME: allow LBMode in tunnel


### PR DESCRIPTION
The append was adding `Device` beyond `initArgMax` which was not used by `init.sh`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8270)
<!-- Reviewable:end -->
