### PR TITLE
k8s: Fix policies with multiple From/To selectors

### DIFF
--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -1423,11 +1423,11 @@ func (s *K8sSuite) TestCIDRPolicyExamples(c *C) {
 	}
 
 	expectedCIDRs = []api.CIDR{"11.96.0.0/12", "11.255.255.254/32"}
-	for k, v := range rules[0].Egress[0].ToCIDRSet[1].ExceptCIDRs {
+	for k, v := range rules[0].Egress[1].ToCIDRSet[0].ExceptCIDRs {
 		c.Assert(v, Equals, expectedCIDRs[k])
 	}
 
-	c.Assert(len(rules[0].Egress), Equals, 1)
+	c.Assert(len(rules[0].Egress), Equals, 2)
 
 }
 


### PR DESCRIPTION
This PR fixes an issue where `NetworkPolicy` selectors in the `From` clause were combined with a logical `and` instead of an `or`. 

Previously, all selectors of the ingress `From` clause where combined into a single `IngressRule` (and thus accidentally performing a logical `and` for differently typed selectors). This commit introduces a new  `IngressRule` for each k8s selector in the `From` clause (and thereby logically `or`ing them). The same logic is also applied for `EgressRule`s generated from a `To` clause which had the same issue.

If L4 ports are specified, they are pushed down into the rules generated from the adjacent `From`/`To` clause to maintain proper semantics.

This PR also introduces a new unit test for this.

Fixes: #8231

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8271)
<!-- Reviewable:end -->
