### PR TITLE
bpf: Get rid of CGO in bpf_linux.go

### DIFF
--- a/pkg/bpf/bpf_linux.go
+++ b/pkg/bpf/bpf_linux.go
@@ -16,9 +16,6 @@
 
 package bpf
 
-// #include <stdlib.h>
-import "C"
-
 import (
 	"fmt"
 	"os"
@@ -255,10 +252,9 @@ type bpfAttrObjOp struct {
 
 // ObjPin stores the map's fd in pathname.
 func ObjPin(fd int, pathname string) error {
-	pathStr := C.CString(pathname)
-	defer C.free(unsafe.Pointer(pathStr))
+	pathStr := []byte(pathname)
 	uba := bpfAttrObjOp{
-		pathname: uint64(uintptr(unsafe.Pointer(pathStr))),
+		pathname: uint64(uintptr(unsafe.Pointer(&pathStr[0]))),
 		fd:       uint32(fd),
 	}
 
@@ -285,10 +281,9 @@ func ObjPin(fd int, pathname string) error {
 
 // ObjGet reads the pathname and returns the map's fd read.
 func ObjGet(pathname string) (int, error) {
-	pathStr := C.CString(pathname)
-	defer C.free(unsafe.Pointer(pathStr))
+	pathStr := []byte(pathname)
 	uba := bpfAttrObjOp{
-		pathname: uint64(uintptr(unsafe.Pointer(pathStr))),
+		pathname: uint64(uintptr(unsafe.Pointer(&pathStr[0]))),
 	}
 
 	var duration *spanstat.SpanStat


### PR DESCRIPTION
This PR replaces the usage of`C.CString()` with `&[]byte()[0]` which is safe and allows us to get rid of the CGO dependency in `bpf_linux.go`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8272)
<!-- Reviewable:end -->
