### PR TITLE
daemon: move datapath-related code into new file, datapath.go

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1060,23 +1060,6 @@ func changedOption(key string, value option.OptionSetting, data interface{}) {
 	d.policy.BumpRevision() // force policy recalculation
 }
 
-// listFilterIfs returns a map of interfaces based on the given filter.
-// The filter should take a link and, if found, return the index of that
-// interface, if not found return -1.
-func listFilterIfs(filter func(netlink.Link) int) (map[int]netlink.Link, error) {
-	ifs, err := netlink.LinkList()
-	if err != nil {
-		return nil, err
-	}
-	vethLXCIdxs := map[int]netlink.Link{}
-	for _, intf := range ifs {
-		if idx := filter(intf); idx != -1 {
-			vethLXCIdxs[idx] = intf
-		}
-	}
-	return vethLXCIdxs, nil
-}
-
 // clearCiliumVeths checks all veths created by cilium and removes all that
 // are considered a leftover from failed attempts to connect the container.
 func (d *Daemon) clearCiliumVeths() error {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -337,25 +337,6 @@ func (d *Daemon) GetCIDRPrefixLengths() (s6, s4 []int) {
 	return d.prefixLengths.ToBPFData()
 }
 
-// Must be called with option.Config.EnablePolicyMU locked.
-func (d *Daemon) writePreFilterHeader(dir string) error {
-	headerPath := filepath.Join(dir, common.PreFilterHeaderFileName)
-	log.WithField(logfields.Path, headerPath).Debug("writing configuration")
-	f, err := os.Create(headerPath)
-	if err != nil {
-		return fmt.Errorf("failed to open file %s for writing: %s", headerPath, err)
-
-	}
-	defer f.Close()
-	fw := bufio.NewWriter(f)
-	fmt.Fprint(fw, "/*\n")
-	fmt.Fprintf(fw, " * XDP device: %s\n", option.Config.DevicePreFilter)
-	fmt.Fprintf(fw, " * XDP mode: %s\n", option.Config.ModePreFilter)
-	fmt.Fprint(fw, " */\n\n")
-	d.preFilter.WriteConfig(fw)
-	return fw.Flush()
-}
-
 // GetOptions returns the datapath configuration options of the daemon.
 func (d *Daemon) GetOptions() *option.IntOptions {
 	return option.Config.Opts

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1060,36 +1060,6 @@ func changedOption(key string, value option.OptionSetting, data interface{}) {
 	d.policy.BumpRevision() // force policy recalculation
 }
 
-// clearCiliumVeths checks all veths created by cilium and removes all that
-// are considered a leftover from failed attempts to connect the container.
-func (d *Daemon) clearCiliumVeths() error {
-	log.Info("Removing stale endpoint interfaces")
-
-	leftVeths, err := listFilterIfs(func(intf netlink.Link) int {
-		// Filter by veth and return the index of the interface.
-		if intf.Type() == "veth" {
-			return intf.Attrs().Index
-		}
-		return -1
-	})
-
-	if err != nil {
-		return fmt.Errorf("unable to retrieve host network interfaces: %s", err)
-	}
-
-	for _, v := range leftVeths {
-		peerIndex := v.Attrs().ParentIndex
-		parentVeth, found := leftVeths[peerIndex]
-		if found && peerIndex != 0 && strings.HasPrefix(parentVeth.Attrs().Name, "lxc") {
-			err := netlink.LinkDel(v)
-			if err != nil {
-				log.WithError(err).Warningf("Unable to delete stale veth device %s", v.Attrs().Name)
-			}
-		}
-	}
-	return nil
-}
-
 // numWorkerThreads returns the number of worker threads with a minimum of 4.
 func numWorkerThreads() int {
 	ncpu := runtime.NumCPU()

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -314,23 +314,6 @@ func (d *Daemon) DebugEnabled() bool {
 	return option.Config.Opts.IsEnabled(option.Debug)
 }
 
-func (d *Daemon) writeNetdevHeader(dir string) error {
-	headerPath := filepath.Join(dir, common.NetdevHeaderFileName)
-	log.WithField(logfields.Path, headerPath).Debug("writing configuration")
-
-	f, err := os.Create(headerPath)
-	if err != nil {
-		return fmt.Errorf("failed to open file %s for writing: %s", headerPath, err)
-
-	}
-	defer f.Close()
-
-	if err := d.datapath.WriteNetdevConfig(f, d); err != nil {
-		return err
-	}
-	return nil
-}
-
 // GetCIDRPrefixLengths returns the sorted list of unique prefix lengths used
 // by CIDR policies.
 func (d *Daemon) GetCIDRPrefixLengths() (s6, s4 []int) {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -699,18 +699,6 @@ func createPrefixLengthCounter() *counter.PrefixLengthCounter {
 	return counter
 }
 
-func deleteHostDevice() {
-	link, err := netlink.LinkByName(option.Config.HostDevice)
-	if err != nil {
-		log.WithError(err).Warningf("Unable to lookup host device %s. No old cilium_host interface exists", option.Config.HostDevice)
-		return
-	}
-
-	if err := netlink.LinkDel(link); err != nil {
-		log.WithError(err).Errorf("Unable to delete host device %s to change allocation CIDR", option.Config.HostDevice)
-	}
-}
-
 // NewDaemon creates and returns a new Daemon with the parameters set in c.
 func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 	bootstrapStats.daemonInit.Start()

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -560,22 +560,6 @@ func (d *Daemon) init() error {
 	return nil
 }
 
-func (d *Daemon) createNodeConfigHeaderfile() error {
-	nodeConfigPath := option.Config.GetNodeConfigPath()
-	f, err := os.Create(nodeConfigPath)
-	if err != nil {
-		log.WithError(err).WithField(logfields.Path, nodeConfigPath).Fatal("Failed to create node configuration file")
-		return err
-	}
-	defer f.Close()
-
-	if err = d.datapath.WriteNodeConfig(f, &d.nodeDiscovery.LocalConfig); err != nil {
-		log.WithError(err).WithField(logfields.Path, nodeConfigPath).Fatal("Failed to write node configuration file")
-		return err
-	}
-	return nil
-}
-
 // syncLXCMap adds local host enties to bpf lxcmap, as well as
 // ipcache, if needed, and also notifies the daemon and network policy
 // hosts cache if changes were made.

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -15,20 +15,16 @@
 package main
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"net"
 	"os"
-	"path/filepath"
 	"runtime"
-	"strings"
 	"sync"
 	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
 	health "github.com/cilium/cilium/cilium-health/launch"
-	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/clustermesh"
 	"github.com/cilium/cilium/pkg/completion"

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -30,16 +30,12 @@ import (
 	health "github.com/cilium/cilium/cilium-health/launch"
 	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/pkg/bpf"
-	"github.com/cilium/cilium/pkg/cgroups"
 	"github.com/cilium/cilium/pkg/clustermesh"
-	"github.com/cilium/cilium/pkg/command/exec"
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/counter"
 	"github.com/cilium/cilium/pkg/datapath"
-	"github.com/cilium/cilium/pkg/datapath/alignchecker"
 	bpfIPCache "github.com/cilium/cilium/pkg/datapath/ipcache"
-	"github.com/cilium/cilium/pkg/datapath/iptables"
 	"github.com/cilium/cilium/pkg/datapath/linux/ipsec"
 	"github.com/cilium/cilium/pkg/datapath/loader"
 	"github.com/cilium/cilium/pkg/datapath/prefilter"
@@ -412,173 +408,6 @@ func (d *Daemon) setHostAddresses() error {
 // of BPF programs.
 func (d *Daemon) GetCompilationLock() *lock.RWMutex {
 	return d.compilationMutex
-}
-
-func (d *Daemon) compileBase() error {
-	var args []string
-	var mode string
-	var ret error
-
-	args = make([]string, initArgMax)
-
-	// Lock so that endpoints cannot be built while we are compile base programs.
-	d.compilationMutex.Lock()
-	defer d.compilationMutex.Unlock()
-
-	if err := d.writeNetdevHeader("./"); err != nil {
-		log.WithError(err).Warn("Unable to write netdev header")
-		return err
-	}
-	loader.Init(d.datapath, &d.nodeDiscovery.LocalConfig)
-
-	scopedLog := log.WithField(logfields.XDPDevice, option.Config.DevicePreFilter)
-	if option.Config.DevicePreFilter != "undefined" {
-		if err := prefilter.ProbePreFilter(option.Config.DevicePreFilter, option.Config.ModePreFilter); err != nil {
-			scopedLog.WithError(err).Warn("Turning off prefilter")
-			option.Config.DevicePreFilter = "undefined"
-		}
-	}
-	if option.Config.DevicePreFilter != "undefined" {
-		if d.preFilter, ret = prefilter.NewPreFilter(); ret != nil {
-			scopedLog.WithError(ret).Warn("Unable to init prefilter")
-			return ret
-		}
-
-		if err := d.writePreFilterHeader("./"); err != nil {
-			scopedLog.WithError(err).Warn("Unable to write prefilter header")
-			return err
-		}
-
-		args[initArgDevicePreFilter] = option.Config.DevicePreFilter
-		args[initArgModePreFilter] = option.Config.ModePreFilter
-	}
-
-	args[initArgLib] = option.Config.BpfDir
-	args[initArgRundir] = option.Config.StateDir
-	args[initArgCgroupRoot] = cgroups.GetCgroupRoot()
-	args[initArgBpffsRoot] = bpf.GetMapRoot()
-
-	if option.Config.EnableIPv4 {
-		args[initArgIPv4NodeIP] = node.GetInternalIPv4().String()
-	} else {
-		args[initArgIPv4NodeIP] = "<nil>"
-	}
-
-	if option.Config.EnableIPv6 {
-		args[initArgIPv6NodeIP] = node.GetIPv6().String()
-	} else {
-		args[initArgIPv6NodeIP] = "<nil>"
-	}
-
-	args[initArgMTU] = fmt.Sprintf("%d", d.mtuConfig.GetDeviceMTU())
-
-	if option.Config.EnableIPSec {
-		args[initArgIPSec] = "true"
-	} else {
-		args[initArgIPSec] = "false"
-	}
-
-	if !option.Config.InstallIptRules && option.Config.Masquerade {
-		args[initArgMasquerade] = "true"
-	} else {
-		args[initArgMasquerade] = "false"
-	}
-
-	if option.Config.EnableHostReachableServices {
-		args[initArgHostReachableServices] = "true"
-	} else {
-		args[initArgHostReachableServices] = "false"
-	}
-
-	if option.Config.EncryptInterface != "" {
-		args[initArgEncryptInterface] = option.Config.EncryptInterface
-	}
-
-	if option.Config.Device != "undefined" {
-		_, err := netlink.LinkByName(option.Config.Device)
-		if err != nil {
-			log.WithError(err).WithField("device", option.Config.Device).Warn("Link does not exist")
-			return err
-		}
-
-		if option.Config.IsLBEnabled() {
-			if option.Config.Device != option.Config.LBInterface {
-				//FIXME: allow different interfaces
-				return fmt.Errorf("Unable to have an interface for LB mode different than snooping interface")
-			}
-			if err := d.setHostAddresses(); err != nil {
-				return err
-			}
-			mode = "lb"
-		} else {
-			if option.Config.DatapathMode == option.DatapathModeIpvlan {
-				mode = "ipvlan"
-			} else {
-				mode = "direct"
-			}
-		}
-
-		args[initArgMode] = mode
-		args[initArgDevice] = option.Config.Device
-	} else {
-		if option.Config.IsLBEnabled() && strings.ToLower(option.Config.Tunnel) != "disabled" {
-			//FIXME: allow LBMode in tunnel
-			return fmt.Errorf("Unable to run LB mode with tunnel mode")
-		}
-
-		args[initArgMode] = option.Config.Tunnel
-
-		if option.Config.IsFlannelMasterDeviceSet() {
-			args[initArgMode] = "flannel"
-			args[initArgDevice] = option.Config.FlannelMasterDevice
-		}
-	}
-
-	prog := filepath.Join(option.Config.BpfDir, "init.sh")
-	ctx, cancel := context.WithTimeout(context.Background(), defaults.ExecTimeout)
-	defer cancel()
-	cmd := exec.CommandContext(ctx, prog, args...)
-	cmd.Env = bpf.Environment()
-	if _, err := cmd.CombinedOutput(log, true); err != nil {
-		return err
-	}
-
-	if canDisableDwarfRelocations {
-		// Validate alignments of C and Go equivalent structs
-		if err := alignchecker.CheckStructAlignments(defaults.AlignCheckerName); err != nil {
-			log.WithError(err).Fatal("C and Go structs alignment check failed")
-		}
-	} else {
-		log.Warning("Cannot check matching of C and Go common struct alignments due to old LLVM/clang version")
-	}
-
-	if !option.Config.IsFlannelMasterDeviceSet() {
-		d.ipam.ReserveLocalRoutes()
-	}
-
-	if err := d.datapath.Node().NodeConfigurationChanged(d.nodeDiscovery.LocalConfig); err != nil {
-		return err
-	}
-
-	iptablesManager := iptables.IptablesManager{}
-	iptablesManager.Init()
-	// Always remove masquerade rule and then re-add it if required
-	iptablesManager.RemoveRules()
-	if option.Config.InstallIptRules {
-		if err := iptablesManager.InstallRules(option.Config.HostDevice); err != nil {
-			return err
-		}
-	}
-	// Reinstall proxy rules for any running proxies
-	if d.l7Proxy != nil {
-		d.l7Proxy.ReinstallRules()
-	}
-
-	log.Info("Setting sysctl net.core.bpf_jit_enable=1")
-	log.Info("Setting sysctl net.ipv4.conf.all.rp_filter=0")
-	log.Info("Setting sysctl net.ipv6.conf.all.disable_ipv6=0")
-
-	return nil
 }
 
 // initMaps opens all BPF maps (and creates them if they do not exist). This

--- a/daemon/datapath.go
+++ b/daemon/datapath.go
@@ -17,6 +17,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -198,5 +199,21 @@ func (d *Daemon) compileBase() error {
 	log.Info("Setting sysctl net.ipv4.conf.all.rp_filter=0")
 	log.Info("Setting sysctl net.ipv6.conf.all.disable_ipv6=0")
 
+	return nil
+}
+
+func (d *Daemon) createNodeConfigHeaderfile() error {
+	nodeConfigPath := option.Config.GetNodeConfigPath()
+	f, err := os.Create(nodeConfigPath)
+	if err != nil {
+		log.WithError(err).WithField(logfields.Path, nodeConfigPath).Fatal("Failed to create node configuration file")
+		return err
+	}
+	defer f.Close()
+
+	if err = d.datapath.WriteNodeConfig(f, &d.nodeDiscovery.LocalConfig); err != nil {
+		log.WithError(err).WithField(logfields.Path, nodeConfigPath).Fatal("Failed to write node configuration file")
+		return err
+	}
 	return nil
 }

--- a/daemon/datapath.go
+++ b/daemon/datapath.go
@@ -298,3 +298,20 @@ func (d *Daemon) writePreFilterHeader(dir string) error {
 	d.preFilter.WriteConfig(fw)
 	return fw.Flush()
 }
+
+func (d *Daemon) writeNetdevHeader(dir string) error {
+	headerPath := filepath.Join(dir, common.NetdevHeaderFileName)
+	log.WithField(logfields.Path, headerPath).Debug("writing configuration")
+
+	f, err := os.Create(headerPath)
+	if err != nil {
+		return fmt.Errorf("failed to open file %s for writing: %s", headerPath, err)
+
+	}
+	defer f.Close()
+
+	if err := d.datapath.WriteNetdevConfig(f, d); err != nil {
+		return err
+	}
+	return nil
+}

--- a/daemon/datapath.go
+++ b/daemon/datapath.go
@@ -1,0 +1,202 @@
+// Copyright 2016-2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/cgroups"
+	"github.com/cilium/cilium/pkg/command/exec"
+	"github.com/cilium/cilium/pkg/datapath/alignchecker"
+	"github.com/cilium/cilium/pkg/datapath/iptables"
+	"github.com/cilium/cilium/pkg/datapath/loader"
+	"github.com/cilium/cilium/pkg/datapath/prefilter"
+	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/vishvananda/netlink"
+)
+
+func (d *Daemon) compileBase() error {
+	var args []string
+	var mode string
+	var ret error
+
+	args = make([]string, initArgMax)
+
+	// Lock so that endpoints cannot be built while we are compile base programs.
+	d.compilationMutex.Lock()
+	defer d.compilationMutex.Unlock()
+
+	if err := d.writeNetdevHeader("./"); err != nil {
+		log.WithError(err).Warn("Unable to write netdev header")
+		return err
+	}
+	loader.Init(d.datapath, &d.nodeDiscovery.LocalConfig)
+
+	scopedLog := log.WithField(logfields.XDPDevice, option.Config.DevicePreFilter)
+	if option.Config.DevicePreFilter != "undefined" {
+		if err := prefilter.ProbePreFilter(option.Config.DevicePreFilter, option.Config.ModePreFilter); err != nil {
+			scopedLog.WithError(err).Warn("Turning off prefilter")
+			option.Config.DevicePreFilter = "undefined"
+		}
+	}
+	if option.Config.DevicePreFilter != "undefined" {
+		if d.preFilter, ret = prefilter.NewPreFilter(); ret != nil {
+			scopedLog.WithError(ret).Warn("Unable to init prefilter")
+			return ret
+		}
+
+		if err := d.writePreFilterHeader("./"); err != nil {
+			scopedLog.WithError(err).Warn("Unable to write prefilter header")
+			return err
+		}
+
+		args[initArgDevicePreFilter] = option.Config.DevicePreFilter
+		args[initArgModePreFilter] = option.Config.ModePreFilter
+	}
+
+	args[initArgLib] = option.Config.BpfDir
+	args[initArgRundir] = option.Config.StateDir
+	args[initArgCgroupRoot] = cgroups.GetCgroupRoot()
+	args[initArgBpffsRoot] = bpf.GetMapRoot()
+
+	if option.Config.EnableIPv4 {
+		args[initArgIPv4NodeIP] = node.GetInternalIPv4().String()
+	} else {
+		args[initArgIPv4NodeIP] = "<nil>"
+	}
+
+	if option.Config.EnableIPv6 {
+		args[initArgIPv6NodeIP] = node.GetIPv6().String()
+	} else {
+		args[initArgIPv6NodeIP] = "<nil>"
+	}
+
+	args[initArgMTU] = fmt.Sprintf("%d", d.mtuConfig.GetDeviceMTU())
+
+	if option.Config.EnableIPSec {
+		args[initArgIPSec] = "true"
+	} else {
+		args[initArgIPSec] = "false"
+	}
+
+	if !option.Config.InstallIptRules && option.Config.Masquerade {
+		args[initArgMasquerade] = "true"
+	} else {
+		args[initArgMasquerade] = "false"
+	}
+
+	if option.Config.EnableHostReachableServices {
+		args[initArgHostReachableServices] = "true"
+	} else {
+		args[initArgHostReachableServices] = "false"
+	}
+
+	if option.Config.EncryptInterface != "" {
+		args[initArgEncryptInterface] = option.Config.EncryptInterface
+	}
+
+	if option.Config.Device != "undefined" {
+		_, err := netlink.LinkByName(option.Config.Device)
+		if err != nil {
+			log.WithError(err).WithField("device", option.Config.Device).Warn("Link does not exist")
+			return err
+		}
+
+		if option.Config.IsLBEnabled() {
+			if option.Config.Device != option.Config.LBInterface {
+				//FIXME: allow different interfaces
+				return fmt.Errorf("Unable to have an interface for LB mode different than snooping interface")
+			}
+			if err := d.setHostAddresses(); err != nil {
+				return err
+			}
+			mode = "lb"
+		} else {
+			if option.Config.DatapathMode == option.DatapathModeIpvlan {
+				mode = "ipvlan"
+			} else {
+				mode = "direct"
+			}
+		}
+
+		args[initArgMode] = mode
+		args[initArgDevice] = option.Config.Device
+	} else {
+		if option.Config.IsLBEnabled() && strings.ToLower(option.Config.Tunnel) != "disabled" {
+			//FIXME: allow LBMode in tunnel
+			return fmt.Errorf("Unable to run LB mode with tunnel mode")
+		}
+
+		args[initArgMode] = option.Config.Tunnel
+
+		if option.Config.IsFlannelMasterDeviceSet() {
+			args[initArgMode] = "flannel"
+			args[initArgDevice] = option.Config.FlannelMasterDevice
+		}
+	}
+
+	prog := filepath.Join(option.Config.BpfDir, "init.sh")
+	ctx, cancel := context.WithTimeout(context.Background(), defaults.ExecTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, prog, args...)
+	cmd.Env = bpf.Environment()
+	if _, err := cmd.CombinedOutput(log, true); err != nil {
+		return err
+	}
+
+	if canDisableDwarfRelocations {
+		// Validate alignments of C and Go equivalent structs
+		if err := alignchecker.CheckStructAlignments(defaults.AlignCheckerName); err != nil {
+			log.WithError(err).Fatal("C and Go structs alignment check failed")
+		}
+	} else {
+		log.Warning("Cannot check matching of C and Go common struct alignments due to old LLVM/clang version")
+	}
+
+	if !option.Config.IsFlannelMasterDeviceSet() {
+		d.ipam.ReserveLocalRoutes()
+	}
+
+	if err := d.datapath.Node().NodeConfigurationChanged(d.nodeDiscovery.LocalConfig); err != nil {
+		return err
+	}
+
+	iptablesManager := iptables.IptablesManager{}
+	iptablesManager.Init()
+	// Always remove masquerade rule and then re-add it if required
+	iptablesManager.RemoveRules()
+	if option.Config.InstallIptRules {
+		if err := iptablesManager.InstallRules(option.Config.HostDevice); err != nil {
+			return err
+		}
+	}
+	// Reinstall proxy rules for any running proxies
+	if d.l7Proxy != nil {
+		d.l7Proxy.ReinstallRules()
+	}
+
+	log.Info("Setting sysctl net.core.bpf_jit_enable=1")
+	log.Info("Setting sysctl net.ipv4.conf.all.rp_filter=0")
+	log.Info("Setting sysctl net.ipv6.conf.all.disable_ipv6=0")
+
+	return nil
+}

--- a/daemon/datapath.go
+++ b/daemon/datapath.go
@@ -217,3 +217,15 @@ func (d *Daemon) createNodeConfigHeaderfile() error {
 	}
 	return nil
 }
+
+func deleteHostDevice() {
+	link, err := netlink.LinkByName(option.Config.HostDevice)
+	if err != nil {
+		log.WithError(err).Warningf("Unable to lookup host device %s. No old cilium_host interface exists", option.Config.HostDevice)
+		return
+	}
+
+	if err := netlink.LinkDel(link); err != nil {
+		log.WithError(err).Errorf("Unable to delete host device %s to change allocation CIDR", option.Config.HostDevice)
+	}
+}

--- a/daemon/datapath.go
+++ b/daemon/datapath.go
@@ -229,3 +229,20 @@ func deleteHostDevice() {
 		log.WithError(err).Errorf("Unable to delete host device %s to change allocation CIDR", option.Config.HostDevice)
 	}
 }
+
+// listFilterIfs returns a map of interfaces based on the given filter.
+// The filter should take a link and, if found, return the index of that
+// interface, if not found return -1.
+func listFilterIfs(filter func(netlink.Link) int) (map[int]netlink.Link, error) {
+	ifs, err := netlink.LinkList()
+	if err != nil {
+		return nil, err
+	}
+	vethLXCIdxs := map[int]netlink.Link{}
+	for _, intf := range ifs {
+		if idx := filter(intf); idx != -1 {
+			vethLXCIdxs[idx] = intf
+		}
+	}
+	return vethLXCIdxs, nil
+}


### PR DESCRIPTION
This is part of my long quest to split up the size of our files, especially in the daemon directory. This makes the code more logically organized, which allows for easier potential refactoring in the future. It also makes it easier to make changes across multiple files, but only commit one at a time. 

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8274)
<!-- Reviewable:end -->
