### PR TITLE
pkg/ipam: protect map against concurrent access

### DIFF
--- a/pkg/ipam/allocator.go
+++ b/pkg/ipam/allocator.go
@@ -122,6 +122,8 @@ func (ipam *IPAM) allocateNextFamily(family Family, allocator Allocator, owner s
 
 // AllocateNextFamily allocates the next IP of the requested address family
 func (ipam *IPAM) AllocateNextFamily(family Family, owner string) (ip net.IP, err error) {
+	ipam.allocatorMutex.Lock()
+	defer ipam.allocatorMutex.Unlock()
 	switch family {
 	case IPv6:
 		ip, err = ipam.allocateNextFamily(family, ipam.IPv6Allocator, owner)


### PR DESCRIPTION
Fixes: 58579f18280c ("ipam: Use Blacklist() to reserve IP in allocation range")
Signed-off-by: André Martins <andre@cilium.io>

Fixes #8278

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8279)
<!-- Reviewable:end -->
