### PR TITLE
policy: cache aggregated list of selectors in rule

### DIFF
--- a/pkg/k8s/apis/cilium.io/utils/utils.go
+++ b/pkg/k8s/apis/cilium.io/utils/utils.go
@@ -125,6 +125,8 @@ func parseToCiliumIngressRule(namespace string, inRule, retRule *api.Rule) {
 				retRule.Ingress[i].FromEntities = make([]api.Entity, len(ing.FromEntities))
 				copy(retRule.Ingress[i].FromEntities, ing.FromEntities)
 			}
+
+			retRule.Ingress[i].SetAggregatedSelectors()
 		}
 	}
 }
@@ -183,6 +185,8 @@ func parseToCiliumEgressRule(namespace string, inRule, retRule *api.Rule) {
 				retRule.Egress[i].ToGroups = make([]api.ToGroups, len(egr.ToGroups))
 				copy(retRule.Egress[i].ToGroups, egr.ToGroups)
 			}
+
+			retRule.Egress[i].SetAggregatedSelectors()
 		}
 	}
 }

--- a/pkg/k8s/rule_translate.go
+++ b/pkg/k8s/rule_translate.go
@@ -52,6 +52,8 @@ func (k RuleTranslator) Translate(r *api.Rule, result *policy.TranslationResult)
 // TranslateEgress populates/depopulates egress rules with ToCIDR entries based
 // on toService entries
 func (k RuleTranslator) TranslateEgress(r *api.EgressRule, result *policy.TranslationResult) error {
+
+	defer r.SetAggregatedSelectors()
 	err := k.depopulateEgress(r, result)
 	if err != nil {
 		return err

--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -143,6 +143,8 @@ func (i *IngressRule) sanitize() error {
 		return fmt.Errorf("too many ingress CIDR prefix lengths %d/%d", l, MaxCIDRPrefixLengths)
 	}
 
+	i.SetAggregatedSelectors()
+
 	return nil
 }
 
@@ -231,6 +233,8 @@ func (e *EgressRule) sanitize() error {
 	if l := len(prefixLengths); l > MaxCIDRPrefixLengths {
 		return fmt.Errorf("too many egress CIDR prefix lengths %d/%d", l, MaxCIDRPrefixLengths)
 	}
+
+	e.SetAggregatedSelectors()
 
 	return nil
 }

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -120,13 +120,13 @@ func GenerateNumIdentities(numIdentities int) {
 func GenerateNumRules(numRules int) api.Rules {
 	parseFooLabel := labels.ParseSelectLabel("k8s:foo")
 	fooSelector := api.NewESFromLabels(parseFooLabel)
-	barSelector := api.NewESFromLabels(labels.ParseSelectLabel("bar"))
+	//barSelector := api.NewESFromLabels(labels.ParseSelectLabel("bar"))
 
 	// Change ingRule and rule in the for-loop below to change what type of rules
 	// are added into the policy repository.
-	ingRule := api.IngressRule{
-		FromEndpoints: []api.EndpointSelector{barSelector},
-		/*FromRequires:  []api.EndpointSelector{barSelector},
+	egRule := api.EgressRule{
+		ToCIDR: []api.CIDR{api.CIDR("10.2.3.0/24"), api.CIDR("ff02::/64")},
+		/*ToRequires:  []api.EndpointSelector{barSelector},
 		ToPorts: []api.PortRule{
 			{
 				Ports: []api.PortProtocol{
@@ -144,7 +144,7 @@ func GenerateNumRules(numRules int) api.Rules {
 
 		rule := api.Rule{
 			EndpointSelector: fooSelector,
-			Ingress:          []api.IngressRule{ingRule},
+			Egress:           []api.EgressRule{egRule},
 		}
 		rule.Sanitize()
 		rules = append(rules, &rule)
@@ -167,6 +167,7 @@ func (ds *PolicyTestSuite) BenchmarkRegeneratePolicyRules(c *C) {
 	for i := 0; i < c.N; i++ {
 		ip, _ := repo.resolvePolicyLocked(fooIdentity)
 		_ = ip.DistillPolicy(DummyOwner{})
+		ip.Detach()
 	}
 }
 


### PR DESCRIPTION
Add a new, unexported field to the `IngressRule` and `EgressRule` types in the
API called `aggregatedSelectors`.

For `IngressRule`, it is an aggregation of the following fields within the type,
all converted to `EndpointSelector`:

* `FromEntities`
* `FromCIDR`
* `FromCIDRSet`

For `EgressRule`, it is an aggregation of the following fields within the type,
all converted to `EndpointSelector`:

* `ToEntities`
* `ToCIDR`
* `ToCIDRSet`
* `ToFQDNs`

Previously, upon each policy calculation, for each rule, this aggregate list of
rule fields as `EndpointSelector` was created in an ad-hoc manner, and was not
performant, as it allocated many different slices of `EndpointSelector` in calls
to `GetSourceEndpointSelectorsWithRequirements` and
`GetDestinationEndpointSelectorsWithRequirements`. This new field caches the
aggregated list only once, upon rule sanitization, or in calls to the two
aforementioned functions if the field has not been initialized yet.

The performance gains by making this change are significant. With 1000
egress rules containing a ToCIDR with 2 CIDRs, and 3000 identities
from before making this change:

```
PASS: resolve_test.go:168: PolicyTestSuite.BenchmarkRegeneratePolicyRules	     100	  12630576 ns/op	 4127697 B/op	  106148 allocs/op
```

And after:

```
PASS: resolve_test.go:168: PolicyTestSuite.BenchmarkRegeneratePolicyRules	     500	   6208546 ns/op	 2265445 B/op	   61134 allocs/op
```

This is a 50 % performance improvement in policy calculation for this simple
policy benchmark.

Note: This is a revival of PR #7250 (commit 21fe2cc18c99 of the same name) that got reverted in f64cf1c420f2 ("policy: Remove more dead code.") due to not being used any more.

Signed-off-by: Ian Vernon <ian@cilium.io>
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8282)
<!-- Reviewable:end -->
