### PR TITLE
kvstore: add agent option for kvstore lease TTL

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -92,7 +92,6 @@ cilium-agent [flags]
       --keep-bpf-templates                         Do not restore BPF template files from binary
       --keep-config                                When restoring state, keeps containers' configuration in place
       --kvstore string                             Key-value store type
-      --kvstore-lease-ttl duration                 Time-to-live for the KVstore lease. (default 15m0s)
       --kvstore-opt map                            Key-value store options (default map[])
       --kvstore-periodic-sync duration             Periodic KVstore synchronization interval (default 5m0s)
       --label-prefix-file string                   Valid label prefixes file path

--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -92,6 +92,7 @@ cilium-agent [flags]
       --keep-bpf-templates                         Do not restore BPF template files from binary
       --keep-config                                When restoring state, keeps containers' configuration in place
       --kvstore string                             Key-value store type
+      --kvstore-lease-ttl duration                 Time-to-live for the KVstore lease. (default 15m0s)
       --kvstore-opt map                            Key-value store options (default map[])
       --kvstore-periodic-sync duration             Periodic KVstore synchronization interval (default 5m0s)
       --label-prefix-file string                   Valid label prefixes file path

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -578,6 +578,9 @@ func init() {
 	flags.String(option.KVStore, "", "Key-value store type")
 	option.BindEnv(option.KVStore)
 
+	flags.Duration(option.KVstoreLeaseTTL, defaults.KVstoreLeaseTTL, "Time-to-live for the KVstore lease.")
+	option.BindEnv(option.KVstoreLeaseTTL)
+
 	flags.Duration(option.KVstorePeriodicSync, defaults.KVstorePeriodicSync, "Periodic KVstore synchronization interval")
 	option.BindEnv(option.KVstorePeriodicSync)
 

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -579,6 +579,7 @@ func init() {
 	option.BindEnv(option.KVStore)
 
 	flags.Duration(option.KVstoreLeaseTTL, defaults.KVstoreLeaseTTL, "Time-to-live for the KVstore lease.")
+	flags.MarkHidden(option.KVstoreLeaseTTL)
 	option.BindEnv(option.KVstoreLeaseTTL)
 
 	flags.Duration(option.KVstorePeriodicSync, defaults.KVstorePeriodicSync, "Periodic KVstore synchronization interval")

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -245,4 +245,11 @@ const (
 	// handled. During this delay, the node can re-appear and the delete
 	// event is ignored.
 	NodeDeleteDelay = 30 * time.Second
+
+	// KVstoreLeaseTTL is the time-to-live of the kvstore lease.
+	KVstoreLeaseTTL = 15 * time.Minute
+
+	// KVstoreKeepAliveIntervalFactor is the factor to calculate the interval
+	// from KVstoreLeaseTTL in which KVstore lease is being renewed.
+	KVstoreKeepAliveIntervalFactor = 3
 )

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -252,4 +252,11 @@ const (
 	// KVstoreKeepAliveIntervalFactor is the factor to calculate the interval
 	// from KVstoreLeaseTTL in which KVstore lease is being renewed.
 	KVstoreKeepAliveIntervalFactor = 3
+
+	// LockLeaseTTL is the time-to-live of the lease dedicated for locks of Kvstore.
+	LockLeaseTTL = 25 * time.Second
+
+	// KVstoreLeaseMaxTTL is the upper bound for KVStore lease TTL value.
+	// It is calculated as Min(int64 positive max, etcd MaxLeaseTTL, consul MaxLeaseTTL)
+	KVstoreLeaseMaxTTL = 86400 * time.Second
 )

--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -65,7 +65,7 @@ const (
 //   key must be considered to be in use in the allocation space.
 //
 //   Slave keys are protected by a lease and will automatically get removed
-//   after ~ kstore.LeaseTTL if the node does not renew in time.
+//   after ~ option.Config.KVstoreLeaseTTL if the node does not renew in time.
 //
 // Master key:
 //    - basePath/id/1001 => key1

--- a/pkg/kvstore/consul.go
+++ b/pkg/kvstore/consul.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/spanstat"
 
 	consulAPI "github.com/hashicorp/consul/api"
@@ -213,7 +214,7 @@ func newConsulClient(config *consulAPI.Config, opts *ExtraOptions) (BackendOpera
 	}
 
 	entry := &consulAPI.SessionEntry{
-		TTL:      fmt.Sprintf("%ds", int(LeaseTTL.Seconds())),
+		TTL:      fmt.Sprintf("%ds", int(option.Config.KVstoreLeaseTTL.Seconds())),
 		Behavior: consulAPI.SessionBehaviorDelete,
 	}
 
@@ -243,7 +244,7 @@ func newConsulClient(config *consulAPI.Config, opts *ExtraOptions) (BackendOpera
 				}
 				return err
 			},
-			RunInterval: KeepAliveInterval,
+			RunInterval: option.Config.KVstoreKeepAliveInterval,
 		},
 	)
 

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/spanstat"
 
 	client "github.com/coreos/etcd/clientv3"
@@ -427,7 +428,7 @@ func (e *etcdClient) renewSession() error {
 	// routines can get a lease ID of an already expired lease.
 	e.Lock()
 
-	newSession, err := concurrency.NewSession(e.client, concurrency.WithTTL(int(LeaseTTL.Seconds())))
+	newSession, err := concurrency.NewSession(e.client, concurrency.WithTTL(int(option.Config.KVstoreLeaseTTL.Seconds())))
 	if err != nil {
 		e.UnlockIgnoreTime()
 		return fmt.Errorf("unable to renew etcd session: %s", err)
@@ -498,7 +499,7 @@ func connectEtcdClient(config *client.Config, cfgPath string, errChan chan error
 
 	// create session in parallel as this is a blocking operation
 	go func() {
-		session, err := concurrency.NewSession(c, concurrency.WithTTL(int(LeaseTTL.Seconds())))
+		session, err := concurrency.NewSession(c, concurrency.WithTTL(int(option.Config.KVstoreLeaseTTL.Seconds())))
 		if err != nil {
 			errorChan <- err
 			close(errorChan)

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -455,7 +455,7 @@ func (e *etcdClient) renewLockSession() error {
 	// routines can get a lease ID of an already expired lease.
 	e.Lock()
 
-	newSession, err := concurrency.NewSession(e.client, concurrency.WithTTL(int(LockLeaseTTL.Seconds())))
+	newSession, err := concurrency.NewSession(e.client, concurrency.WithTTL(int(defaults.LockLeaseTTL.Seconds())))
 	if err != nil {
 		e.UnlockIgnoreTime()
 		return fmt.Errorf("unable to renew etcd lock session: %s", err)
@@ -505,7 +505,7 @@ func connectEtcdClient(config *client.Config, cfgPath string, errChan chan error
 			close(errorChan)
 			return
 		}
-		lockSession, err := concurrency.NewSession(c, concurrency.WithTTL(int(LockLeaseTTL.Seconds())))
+		lockSession, err := concurrency.NewSession(c, concurrency.WithTTL(int(defaults.LockLeaseTTL.Seconds())))
 		if err != nil {
 			errorChan <- err
 			close(errorChan)

--- a/pkg/kvstore/keepalive.go
+++ b/pkg/kvstore/keepalive.go
@@ -19,15 +19,8 @@ import (
 )
 
 var (
-	// LeaseTTL is the time-to-live of the lease
-	LeaseTTL = 15 * time.Minute // 15 minutes
-
 	// LockLeaseTTL is the time-to-live of the lease dedicated for locks
 	LockLeaseTTL = 25 * time.Second
-
-	// KeepAliveInterval is the interval in which the lease is being
-	// renewed. This must be set to a value lesser than the LeaseTTL
-	KeepAliveInterval = 5 * time.Minute
 
 	// RetryInterval is the interval in which retries occur in the case of
 	// errors in communication with the KVstore. This should be set to a

--- a/pkg/kvstore/keepalive.go
+++ b/pkg/kvstore/keepalive.go
@@ -19,9 +19,6 @@ import (
 )
 
 var (
-	// LockLeaseTTL is the time-to-live of the lease dedicated for locks
-	LockLeaseTTL = 25 * time.Second
-
 	// RetryInterval is the interval in which retries occur in the case of
 	// errors in communication with the KVstore. This should be set to a
 	// small value to account for temporary errors while communicating with

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1160,6 +1160,12 @@ func (c *DaemonConfig) Validate() error {
 		return fmt.Errorf("Specified PolicyMap max entries %d must not exceed maximum %d",
 			c.PolicyMapMaxEntries, policyMapMax)
 	}
+	// Validate that the KVStore Lease TTL value lies between a particular range.
+	if c.KVstoreLeaseTTL > defaults.KVstoreLeaseMaxTTL || c.KVstoreLeaseTTL < defaults.LockLeaseTTL {
+		return fmt.Errorf("KVstoreLeaseTTL does not lie in required range(%ds, %ds)",
+			int64(defaults.LockLeaseTTL.Seconds()),
+			int64(defaults.KVstoreLeaseMaxTTL.Seconds()))
+	}
 
 	return nil
 }

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -430,6 +430,9 @@ const (
 	// IPSecKeyFileName is the name of the option for ipsec key file
 	IPSecKeyFileName = "ipsec-key-file"
 
+	// KVstoreLeaseTTL is the time-to-live for lease in kvstore.
+	KVstoreLeaseTTL = "kvstore-lease-ttl"
+
 	// KVstorePeriodicSync is the time interval in which periodic
 	// synchronization with the kvstore occurs
 	KVstorePeriodicSync = "kvstore-periodic-sync"
@@ -906,6 +909,14 @@ type DaemonConfig struct {
 	// health endpoints
 	EnableHealthChecking bool
 
+	// KVstoreKeepAliveInterval is the interval in which the lease is being
+	// renewed. This must be set to a value lesser than the LeaseTTL ideally
+	// by a factor of 3.
+	KVstoreKeepAliveInterval time.Duration
+
+	// KVstoreLeaseTTL is the time-to-live for kvstore lease.
+	KVstoreLeaseTTL time.Duration
+
 	// KVstorePeriodicSync is the time interval in which periodic
 	// synchronization with the kvstore occurs
 	KVstorePeriodicSync time.Duration
@@ -1304,6 +1315,8 @@ func (c *DaemonConfig) Populate() {
 	c.KeepTemplates = viper.GetBool(KeepBPFTemplates)
 	c.KeepConfig = viper.GetBool(KeepConfig)
 	c.KVStore = viper.GetString(KVStore)
+	c.KVstoreLeaseTTL = viper.GetDuration(KVstoreLeaseTTL)
+	c.KVstoreKeepAliveInterval = c.KVstoreLeaseTTL / defaults.KVstoreKeepAliveIntervalFactor
 	c.KVstorePeriodicSync = viper.GetDuration(KVstorePeriodicSync)
 	c.LabelPrefixFile = viper.GetString(LabelPrefixFile)
 	c.Labels = viper.GetStringSlice(Labels)

--- a/test/k8sT/manifests/cilium-cm-patch.yaml
+++ b/test/k8sT/manifests/cilium-cm-patch.yaml
@@ -25,3 +25,4 @@ data:
   enable-ipv6: "true"
   preallocate-bpf-maps: "true"
   enable-legacy-services: "false"
+  kvstore-lease-ttl: "30s"


### PR DESCRIPTION
* Add option `kvstore-leasettl` to set lease TTL for kvstore from command line.
* Calculate kvstore KeepAliveInterval from Lease TTL which should be
ideally less by a factor of 3.
* Fixes #8222 

Fixes: #8222

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8284)
<!-- Reviewable:end -->
