### PR TITLE
pkg/k8s: remove TPR vs CRD error

### DIFF
--- a/pkg/k8s/error_helpers.go
+++ b/pkg/k8s/error_helpers.go
@@ -74,9 +74,7 @@ func K8sErrorHandler(e error) {
 	// that used ThirdPartyResource to define CiliumNetworkPolicy.
 	case strings.Contains(errstr, "Failed to list *v2.CiliumNetworkPolicy: the server could not find the requested resource"):
 		if k8sErrorUpdateCheckUnmuteTime(errstr, now) {
-			log.WithError(e).Error("Conflicting TPR and CRD resources")
-			log.Warn("Detected conflicting TPR and CRD, please migrate all ThirdPartyResource to CustomResourceDefinition! More info: https://cilium.link/migrate-tpr")
-			log.Warn("Due to conflicting TPR and CRD rules, CiliumNetworkPolicy enforcement can't be guaranteed!")
+			log.WithError(e).Error("No Cilium Network Policy CRD defined in the cluster, please set `--skip-crd-creation=false` to avoid seeing this error.")
 		}
 
 	// fromCIDR and toCIDR used to expect an "ip" subfield (so, they were a YAML


### PR DESCRIPTION
We no longer support TPR so we can replace the message with a new one to
avoid users running into issues when running cilium with
`--skip-crd-creation`

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8286)
<!-- Reviewable:end -->
