### PR TITLE
bpf: Fix string conversion to byte array

### DIFF
--- a/pkg/bpf/bpf_linux.go
+++ b/pkg/bpf/bpf_linux.go
@@ -252,9 +252,9 @@ type bpfAttrObjOp struct {
 
 // ObjPin stores the map's fd in pathname.
 func ObjPin(fd int, pathname string) error {
-	pathStr := []byte(pathname)
+	pathStr := syscall.StringBytePtr(pathname)
 	uba := bpfAttrObjOp{
-		pathname: uint64(uintptr(unsafe.Pointer(&pathStr[0]))),
+		pathname: uint64(uintptr(unsafe.Pointer(pathStr))),
 		fd:       uint32(fd),
 	}
 
@@ -281,9 +281,9 @@ func ObjPin(fd int, pathname string) error {
 
 // ObjGet reads the pathname and returns the map's fd read.
 func ObjGet(pathname string) (int, error) {
-	pathStr := []byte(pathname)
+	pathStr := syscall.StringBytePtr(pathname)
 	uba := bpfAttrObjOp{
-		pathname: uint64(uintptr(unsafe.Pointer(&pathStr[0]))),
+		pathname: uint64(uintptr(unsafe.Pointer(pathStr))),
 	}
 
 	var duration *spanstat.SpanStat


### PR DESCRIPTION
The commit "bpf: Get rid of CGO in bpf_linux.go" missed the fact that strings in Go are not NUL-terminated, as internally they are represented as `(len, byte array)` tuple. So, the conversion introduced in the commit
was unsafe.

Fix the conversion by reusing `syscall.StringBytePtr` which takes care of appending `"\0"` to the end of a byte array.

Fixes: 83807dd168 "bpf: Get rid of CGO in bpf_linux.go"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8289)
<!-- Reviewable:end -->
