### PR TITLE
Backport 1.5 2019 06 13

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1477,7 +1477,7 @@
     "storage/v1beta1",
   ]
   pruneopts = "NUT"
-  revision = "kubernetes-1.14.2"
+  revision = "kubernetes-1.14.3"
 
 [[projects]]
   digest = "1:47ddb5be73e959bd73931c04911cd05e3f45d7f7c978a45eb817e1fb85e21da4"
@@ -1491,7 +1491,7 @@
     "pkg/features",
   ]
   pruneopts = "NUT"
-  revision = "kubernetes-1.14.2"
+  revision = "kubernetes-1.14.3"
 
 [[projects]]
   digest = "1:062b06c1ccb71c956f40a8627cc93dba1dc7713a21876572ccd0e314c5362884"
@@ -1542,7 +1542,7 @@
     "third_party/forked/golang/reflect",
   ]
   pruneopts = "NUT"
-  revision = "kubernetes-1.14.2"
+  revision = "kubernetes-1.14.3"
 
 [[projects]]
   digest = "1:fe60b6d8b8208ecb0e70e97963fef38ce27443c6934ec00a37f80a3f9372f42b"
@@ -1552,10 +1552,10 @@
     "pkg/util/feature",
   ]
   pruneopts = "NUT"
-  revision = "kubernetes-1.14.2"
+  revision = "kubernetes-1.14.3"
 
 [[projects]]
-  digest = "1:8342528e1275c10c0db434bd9e4853bacd901835366a1734fe112c731a2deda3"
+  digest = "1:f5f9a937cb820170631d81c17da1092d00195bc83c00f830e3a4e0e670e7a857"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -1663,7 +1663,7 @@
     "util/retry",
   ]
   pruneopts = "NUT"
-  revision = "ba08258719486bf36f7df9de3aa90d5d556ca330"
+  revision = "ca2568102b5586386bac5b40eb9a31e67a7e93ea"
   source = "https://github.com/cilium/client-go"
 
 [[projects]]
@@ -1690,7 +1690,7 @@
     "pkg/util",
   ]
   pruneopts = "T"
-  revision = "kubernetes-1.14.2"
+  revision = "kubernetes-1.14.3"
 
 [[projects]]
   digest = "1:da31d8be5af84b69ef83b212d833d8e10930cd9e8a876780a20099ea306c4c13"
@@ -1725,7 +1725,7 @@
   revision = "c01ed926f1243ac17a23a66f67da7fbdb2e2e298"
 
 [[projects]]
-  digest = "1:47ae94c02bd8c9820145e81291c086451d3f1d2faaa39d53cb31583092f4f9f1"
+  digest = "1:9eb2609da2d09beb6e2095e893a5523365cd3e770a541b3504ad9af99931f967"
   name = "k8s.io/kubernetes"
   packages = [
     "pkg/apis/core",
@@ -1738,7 +1738,7 @@
     "pkg/registry/core/service/ipallocator",
   ]
   pruneopts = "NUT"
-  revision = "v1.14.2"
+  revision = "v1.14.3"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -497,28 +497,28 @@ required = [
 
 [[constraint]]
   name = "k8s.io/api"
-  revision = "kubernetes-1.14.2"
+  revision = "kubernetes-1.14.3"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
 
 [[constraint]]
   name = "k8s.io/apiextensions-apiserver"
-  revision = "kubernetes-1.14.2"
+  revision = "kubernetes-1.14.3"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
 
 [[override]]
   name = "k8s.io/apiserver"
-  revision = "kubernetes-1.14.2"
+  revision = "kubernetes-1.14.3"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
 
 [[constraint]]
   name = "k8s.io/apimachinery"
-  revision = "kubernetes-1.14.2"
+  revision = "kubernetes-1.14.3"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
@@ -526,14 +526,14 @@ required = [
 [[constraint]]
   name = "k8s.io/client-go"
   source = "https://github.com/cilium/client-go"
-  revision = "ba08258719486bf36f7df9de3aa90d5d556ca330"
+  revision = "ca2568102b5586386bac5b40eb9a31e67a7e93ea"
 
   # main-usage = "pkg/k8s"
-  # on-revision = "TODO @aanm is on ba08258719486bf36f7df9de3aa90d5d556ca330 as it contains the hotfix for the metrics path"
+  # on-revision = "TODO @aanm is on ca2568102b5586386bac5b40eb9a31e67a7e93ea as it contains the hotfix for the metrics path"
 
 [[constraint]]
   name = "k8s.io/code-generator"
-  revision = "kubernetes-1.14.2"
+  revision = "kubernetes-1.14.3"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
@@ -547,7 +547,7 @@ required = [
 
 [[constraint]]
   name = "k8s.io/kubernetes"
-  revision = "v1.14.2"
+  revision = "v1.14.3"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""

--- a/kubernetes-upstream.Jenkinsfile
+++ b/kubernetes-upstream.Jenkinsfile
@@ -57,6 +57,15 @@ pipeline {
                 sh '/usr/local/bin/cleanup || true'
             }
         }
+        stage('Preload vagrant boxes'){
+            options {
+                timeout(time: 20, unit: 'MINUTES')
+            }
+
+            steps {
+                sh '/usr/local/bin/add_vagrant_box ${WORKSPACE}/${PROJ_PATH}/vagrant_box_defaults.rb'
+            }
+        }
         stage('Boot VMs'){
             options {
                 timeout(time: 30, unit: 'MINUTES')

--- a/pkg/health/server/prober.go
+++ b/pkg/health/server/prober.go
@@ -15,8 +15,8 @@
 package server
 
 import (
-	"fmt"
 	"net"
+	"strconv"
 	"strings"
 	"time"
 
@@ -229,7 +229,7 @@ func (p *prober) setNodes(nodes nodeMap) {
 func (p *prober) httpProbe(node string, ip string, port int) *models.ConnectivityStatus {
 	result := &models.ConnectivityStatus{}
 
-	host := fmt.Sprintf("http://%s:%d", ip, port)
+	host := "http://" + net.JoinHostPort(ip, strconv.Itoa(port))
 	scopedLog := log.WithFields(logrus.Fields{
 		logfields.NodeName: node,
 		logfields.IPAddr:   ip,
@@ -249,7 +249,7 @@ func (p *prober) httpProbe(node string, ip string, port int) *models.Connectivit
 			result.Latency = rtt.Nanoseconds()
 		} else {
 			scopedLog.WithError(err).Debug("Greeting snubbed")
-			result.Status = "Connection timed out"
+			result.Status = err.Error()
 		}
 	} else {
 		scopedLog.WithError(err).Info("Failed to express greeting to host")

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -206,6 +206,146 @@ func (s *K8sSuite) TestParseNetworkPolicyIngress(c *C) {
 	c.Assert(repo.CanReachIngressRLocked(&ctx), Not(Equals), api.Allowed)
 }
 
+func (s *K8sSuite) TestParseNetworkPolicyMultipleSelectors(c *C) {
+
+	// Rule with multiple selectors in egress and ingress
+	ex1 := []byte(`{
+"kind":"NetworkPolicy",
+"apiVersion":"extensions/networkingv1",
+"metadata":{
+  "name":"ingress-multiple-selectors"
+},
+"spec":{
+  "podSelector":{
+    "matchLabels":{
+      "role":"backend"
+    }
+  },
+  "egress":[
+    {
+      "ports":[
+        {
+          "protocol":"TCP",
+          "port":5432
+        }
+      ],
+      "to":[
+        {
+          "podSelector":{
+            "matchLabels":{
+              "app":"db1"
+            }
+          }
+        },
+        {
+          "podSelector":{
+            "matchLabels":{
+              "app":"db2"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "ingress":[
+    {
+      "from":[
+        {
+          "podSelector":{
+            "matchLabels":{
+              "role":"frontend"
+            }
+          },
+          "namespaceSelector":{
+            "matchLabels":{
+              "project":"myproject"
+            }
+          }
+        },
+        {
+          "podSelector":{
+            "matchLabels":{
+              "app":"inventory"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}
+}`)
+
+	np := networkingv1.NetworkPolicy{}
+	err := json.Unmarshal(ex1, &np)
+	c.Assert(err, IsNil)
+
+	rules, err := ParseNetworkPolicy(&np)
+	c.Assert(err, IsNil)
+	c.Assert(len(rules), Equals, 1)
+
+	repo := policy.NewPolicyRepository()
+	repo.AddList(rules)
+
+	endpointLabels := labels.LabelArray{
+		labels.NewLabel(k8sConst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+		labels.NewLabel("role", "backend", labels.LabelSourceK8s),
+	}
+
+	// Ingress context
+	ctx := policy.SearchContext{
+		From: labels.LabelArray{
+			labels.NewLabel("role", "frontend", labels.LabelSourceK8s),
+		},
+		To:    endpointLabels,
+		Trace: policy.TRACE_VERBOSE,
+	}
+
+	// should be DENIED because ctx.From is missing the namespace selector
+	c.Assert(repo.AllowsIngressRLocked(&ctx), Equals, api.Denied)
+
+	ctx.From = labels.LabelArray{
+		labels.NewLabel("role", "frontend", labels.LabelSourceK8s),
+		labels.NewLabel(policy.JoinPath(k8sConst.PodNamespaceMetaLabels, "project"), "myproject", labels.LabelSourceK8s),
+	}
+
+	// should be ALLOWED with the namespace label properly set
+	c.Assert(repo.AllowsIngressRLocked(&ctx), Equals, api.Allowed)
+
+	ctx.From = labels.LabelArray{
+		labels.NewLabel(k8sConst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+		labels.NewLabel("app", "inventory", labels.LabelSourceK8s),
+	}
+
+	// should be ALLOWED since all rules in From must match
+	c.Assert(repo.AllowsIngressRLocked(&ctx), Equals, api.Allowed)
+
+	// Egress context
+	ctx = policy.SearchContext{
+		From: endpointLabels,
+		To: labels.LabelArray{
+			labels.NewLabel(k8sConst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+			labels.NewLabel("app", "db1", labels.LabelSourceK8s),
+		},
+		Trace: policy.TRACE_VERBOSE,
+	}
+
+	// should be DENIED because DPorts are missing in context
+	c.Assert(repo.AllowsEgressRLocked(&ctx), Equals, api.Denied)
+
+	ctx.DPorts = []*models.Port{{Port: 5432, Protocol: models.PortProtocolTCP}}
+
+	// should be ALLOWED with DPorts set correctly
+	c.Assert(repo.AllowsEgressRLocked(&ctx), Equals, api.Allowed)
+
+	ctx.To = labels.LabelArray{
+		labels.NewLabel(k8sConst.PodNamespaceLabel, v1.NamespaceDefault, labels.LabelSourceK8s),
+		labels.NewLabel("app", "db2", labels.LabelSourceK8s),
+	}
+
+	// should be ALLOWED for db2 as well
+	c.Assert(repo.AllowsEgressRLocked(&ctx), Equals, api.Allowed)
+}
+
 func (s *K8sSuite) TestParseNetworkPolicyNoSelectors(c *C) {
 
 	// Ingress with neither pod nor namespace selector set.

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -1405,11 +1405,11 @@ func (s *K8sSuite) TestCIDRPolicyExamples(c *C) {
 	}
 
 	expectedCIDRs = []api.CIDR{"11.96.0.0/12", "11.255.255.254/32"}
-	for k, v := range rules[0].Egress[0].ToCIDRSet[1].ExceptCIDRs {
+	for k, v := range rules[0].Egress[1].ToCIDRSet[0].ExceptCIDRs {
 		c.Assert(v, Equals, expectedCIDRs[k])
 	}
 
-	c.Assert(len(rules[0].Egress), Equals, 1)
+	c.Assert(len(rules[0].Egress), Equals, 2)
 
 }
 

--- a/test/helpers/cmd.go
+++ b/test/helpers/cmd.go
@@ -316,6 +316,11 @@ func (res *CmdRes) GetErr(context string) error {
 	return &cmdError{fmt.Sprintf("%s output: %s", context, res.GetDebugMessage())}
 }
 
+// GetError returns the error for this CmdRes.
+func (res *CmdRes) GetError() error {
+	return res.err
+}
+
 // BeSuccesfulMatcher a new Ginkgo matcher for CmdRes struct
 type BeSuccesfulMatcher struct{}
 

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -175,9 +175,9 @@ func (kub *Kubectl) ExecPodCmd(namespace string, pod string, cmd string, options
 // ExecPodCmdContext executes command cmd in background in the specified pod residing
 // in the specified namespace. It returns a pointer to CmdRes with all the
 // output
-func (kub *Kubectl) ExecPodCmdContext(ctx context.Context, namespace string, pod string, cmd string) *CmdRes {
+func (kub *Kubectl) ExecPodCmdContext(ctx context.Context, namespace string, pod string, cmd string, options ...ExecOptions) *CmdRes {
 	command := fmt.Sprintf("%s exec -n %s %s -- %s", KubectlCmd, namespace, pod, cmd)
-	return kub.ExecInBackground(ctx, command)
+	return kub.ExecInBackground(ctx, command, options...)
 }
 
 // Get retrieves the provided Kubernetes objects from the specified namespace.
@@ -275,14 +275,14 @@ func (kub *Kubectl) GetEndpoints(namespace string, filter string) *CmdRes {
 // GetAllPods returns a slice of all pods present in Kubernetes cluster, along
 // with an error if the pods could not be retrieved via `kubectl`, or if the
 // pod objects are unable to be marshaled from JSON.
-func (kub *Kubectl) GetAllPods(options ...ExecOptions) ([]v1.Pod, error) {
+func (kub *Kubectl) GetAllPods(ctx context.Context, options ...ExecOptions) ([]v1.Pod, error) {
 	var ops ExecOptions
 	if len(options) > 0 {
 		ops = options[0]
 	}
 
 	var podsList v1.List
-	err := kub.Exec(
+	err := kub.ExecContext(ctx,
 		fmt.Sprintf("%s get pods --all-namespaces -o json", KubectlCmd),
 		ExecOptions{SkipLog: ops.SkipLog}).Unmarshal(&podsList)
 	if err != nil {
@@ -306,6 +306,15 @@ func (kub *Kubectl) GetAllPods(options ...ExecOptions) ([]v1.Pod, error) {
 // in the specified namespace, along with an error if the pod names cannot be
 // retrieved.
 func (kub *Kubectl) GetPodNames(namespace string, label string) ([]string, error) {
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	return kub.GetPodNamesContext(ctx, namespace, label)
+}
+
+// GetPodNamesContext returns the names of all of the pods that are labeled with
+// label in the specified namespace, along with an error if the pod names cannot
+// be retrieved.
+func (kub *Kubectl) GetPodNamesContext(ctx context.Context, namespace string, label string) ([]string, error) {
 	stdout := new(bytes.Buffer)
 	filter := "-o jsonpath='{.items[*].metadata.name}'"
 
@@ -1039,6 +1048,12 @@ func (kub *Kubectl) GetCiliumPods(namespace string) ([]string, error) {
 	return kub.GetPodNames(namespace, "k8s-app=cilium")
 }
 
+// GetCiliumPodsContext returns a list of all Cilium pods in the specified
+// namespace, and an error if the Cilium pods were not able to be retrieved.
+func (kub *Kubectl) GetCiliumPodsContext(ctx context.Context, namespace string) ([]string, error) {
+	return kub.GetPodNamesContext(ctx, namespace, "k8s-app=cilium")
+}
+
 // CiliumEndpointsList returns the result of `cilium endpoint list` from the
 // specified pod.
 func (kub *Kubectl) CiliumEndpointsList(ctx context.Context, pod string) *CmdRes {
@@ -1458,27 +1473,34 @@ func (kub *Kubectl) CiliumReport(namespace string, commands ...string) {
 		ginkgoext.GinkgoPrint("Skipped gathering logs (-cilium.skipLogs=true)\n")
 		return
 	}
+
+	// Log gathering for Cilium should take at most 5 minutes. This ensures that
+	// the CiliumReport stage doesn't cause the entire CI to hang.
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
 	var wg sync.WaitGroup
 	wg.Add(1)
 
 	go func() {
 		defer wg.Done()
-		kub.DumpCiliumCommandOutput(namespace)
-		kub.GatherLogs()
+		kub.DumpCiliumCommandOutput(ctx, namespace)
+		kub.GatherLogs(ctx)
 	}()
 
-	kub.CiliumCheckReport()
+	kub.CiliumCheckReport(ctx)
 
-	pods, err := kub.GetCiliumPods(namespace)
+	pods, err := kub.GetCiliumPodsContext(ctx, namespace)
 	if err != nil {
 		kub.logger.WithError(err).Error("cannot retrieve cilium pods on ReportDump")
 	}
-	res := kub.Exec(fmt.Sprintf("%s get pods -o wide --all-namespaces", KubectlCmd))
+	res := kub.ExecContext(ctx, fmt.Sprintf("%s get pods -o wide --all-namespaces", KubectlCmd))
 	ginkgoext.GinkgoPrint(res.GetDebugMessage())
 
 	for _, pod := range pods {
 		for _, cmd := range commands {
-			res = kub.ExecPodCmd(namespace, pod, cmd, ExecOptions{SkipLog: true})
+			res = kub.ExecPodCmdContext(ctx, namespace, pod, cmd, ExecOptions{SkipLog: true})
 			ginkgoext.GinkgoPrint(res.GetDebugMessage())
 		}
 	}
@@ -1488,12 +1510,12 @@ func (kub *Kubectl) CiliumReport(namespace string, commands ...string) {
 
 // EtcdOperatorReport dump etcd pods data into the report directory to be able
 // to debug etcd operator status in case of fail test.
-func (kub *Kubectl) EtcdOperatorReport(reportCmds map[string]string) {
+func (kub *Kubectl) EtcdOperatorReport(ctx context.Context, reportCmds map[string]string) {
 	if reportCmds == nil {
 		reportCmds = make(map[string]string)
 	}
 
-	pods, err := kub.GetPodNames(KubeSystemNamespace, "etcd_cluster=cilium-etcd")
+	pods, err := kub.GetPodNamesContext(ctx, KubeSystemNamespace, "etcd_cluster=cilium-etcd")
 	if err != nil {
 		kub.logger.WithError(err).Error("No etcd pods")
 		return
@@ -1525,23 +1547,23 @@ func (kub *Kubectl) EtcdOperatorReport(reportCmds map[string]string) {
 // - Number of Kubernetes and Cilium policies installed.
 // - Policy enforcement status by endpoint.
 // - Controller, health, kvstore status.
-func (kub *Kubectl) CiliumCheckReport() {
+func (kub *Kubectl) CiliumCheckReport(ctx context.Context) {
 	pods, _ := kub.GetCiliumPods(KubeSystemNamespace)
 	fmt.Fprintf(CheckLogs, "Cilium pods: %v\n", pods)
 
 	var policiesFilter = `{range .items[*]}{.metadata.namespace}{"::"}{.metadata.name}{" "}{end}`
-	netpols := kub.Exec(fmt.Sprintf(
+	netpols := kub.ExecContext(ctx, fmt.Sprintf(
 		"%s get netpol -o jsonpath='%s' --all-namespaces",
 		KubectlCmd, policiesFilter))
 	fmt.Fprintf(CheckLogs, "Netpols loaded: %v\n", netpols.Output())
 
-	cnp := kub.Exec(fmt.Sprintf(
+	cnp := kub.ExecContext(ctx, fmt.Sprintf(
 		"%s get cnp -o jsonpath='%s' --all-namespaces",
 		KubectlCmd, policiesFilter))
 	fmt.Fprintf(CheckLogs, "CiliumNetworkPolicies loaded: %v\n", cnp.Output())
 
 	cepFilter := `{range .items[*]}{.metadata.name}{"="}{.status.policy.ingress.enforcing}{":"}{.status.policy.egress.enforcing}{"\n"}{end}`
-	cepStatus := kub.Exec(fmt.Sprintf(
+	cepStatus := kub.ExecContext(ctx, fmt.Sprintf(
 		"%s get cep -o jsonpath='%s' --all-namespaces",
 		KubectlCmd, cepFilter))
 
@@ -1563,7 +1585,7 @@ func (kub *Kubectl) CiliumCheckReport() {
 	var failedControllers string
 	for _, pod := range pods {
 		var prefix = ""
-		status := kub.CiliumExec(pod, "cilium status --all-controllers -o json")
+		status := kub.CiliumExecContext(ctx, pod, "cilium status --all-controllers -o json")
 		result, err := status.Filter(controllersFilter)
 		if err != nil {
 			kub.logger.WithError(err).Error("Cannot filter controller status output")
@@ -1636,10 +1658,10 @@ func (kub *Kubectl) ValidateNoErrorsInLogs(duration time.Duration) {
 
 // GatherCiliumCoreDumps copies core dumps if are present in the /tmp folder
 // into the test report folder for further analysis.
-func (kub *Kubectl) GatherCiliumCoreDumps(ciliumPod string) {
+func (kub *Kubectl) GatherCiliumCoreDumps(ctx context.Context, ciliumPod string) {
 	log := kub.logger.WithField("pod", ciliumPod)
 
-	cores := kub.CiliumExec(ciliumPod, "ls /tmp/ | grep core")
+	cores := kub.CiliumExecContext(ctx, ciliumPod, "ls /tmp/ | grep core")
 	if !cores.WasSuccessful() {
 		log.Debug("There is no core dumps in the pod")
 		return
@@ -1658,7 +1680,7 @@ func (kub *Kubectl) GatherCiliumCoreDumps(ciliumPod string) {
 		cmd := fmt.Sprintf("%s -n %s cp %s:%s %s",
 			KubectlCmd, KubeSystemNamespace,
 			ciliumPod, src, dst)
-		res := kub.Exec(cmd, ExecOptions{SkipLog: true})
+		res := kub.ExecContext(ctx, cmd, ExecOptions{SkipLog: true})
 		if !res.WasSuccessful() {
 			log.WithField("output", res.CombineOutput()).Error("Cannot get core from pod")
 		}
@@ -1667,7 +1689,7 @@ func (kub *Kubectl) GatherCiliumCoreDumps(ciliumPod string) {
 
 // DumpCiliumCommandOutput runs a variety of commands (CiliumKubCLICommands) and writes the results to
 // TestResultsPath
-func (kub *Kubectl) DumpCiliumCommandOutput(namespace string) {
+func (kub *Kubectl) DumpCiliumCommandOutput(ctx context.Context, namespace string) {
 	ReportOnPod := func(pod string) {
 		logger := kub.logger.WithField("CiliumPod", pod)
 
@@ -1682,7 +1704,7 @@ func (kub *Kubectl) DumpCiliumCommandOutput(namespace string) {
 			command := fmt.Sprintf("%s exec -n %s %s -- %s", KubectlCmd, namespace, pod, cmd)
 			reportCmds[command] = fmt.Sprintf("%s_%s", pod, logfile)
 		}
-		reportMap(testPath, reportCmds, kub.SSHMeta)
+		reportMapContext(ctx, testPath, reportCmds, kub.SSHMeta)
 
 		logsPath := filepath.Join(BasePath, testPath)
 
@@ -1690,13 +1712,13 @@ func (kub *Kubectl) DumpCiliumCommandOutput(namespace string) {
 		// copy it over with `kubectl cp`.
 		bugtoolCmd := fmt.Sprintf("%s exec -n %s %s -- %s",
 			KubectlCmd, namespace, pod, CiliumBugtool)
-		res := kub.Exec(bugtoolCmd, ExecOptions{SkipLog: true})
+		res := kub.ExecContext(ctx, bugtoolCmd, ExecOptions{SkipLog: true})
 		if !res.WasSuccessful() {
 			logger.Errorf("%s failed: %s", bugtoolCmd, res.CombineOutput().String())
 			return
 		}
 		// Default output directory is /tmp for bugtool.
-		res = kub.Exec(fmt.Sprintf("%s exec -n %s %s -- ls /tmp/", KubectlCmd, namespace, pod))
+		res = kub.ExecContext(ctx, fmt.Sprintf("%s exec -n %s %s -- ls /tmp/", KubectlCmd, namespace, pod))
 		tmpList := res.ByLines()
 		for _, line := range tmpList {
 			// Only copy over bugtool output to directory.
@@ -1704,7 +1726,7 @@ func (kub *Kubectl) DumpCiliumCommandOutput(namespace string) {
 				continue
 			}
 
-			res = kub.Exec(fmt.Sprintf("%[1]s cp %[2]s/%[3]s:/tmp/%[4]s /tmp/%[4]s",
+			res = kub.ExecContext(ctx, fmt.Sprintf("%[1]s cp %[2]s/%[3]s:/tmp/%[4]s /tmp/%[4]s",
 				KubectlCmd, namespace, pod, line),
 				ExecOptions{SkipLog: true})
 			if !res.WasSuccessful() {
@@ -1713,7 +1735,7 @@ func (kub *Kubectl) DumpCiliumCommandOutput(namespace string) {
 			}
 
 			archiveName := filepath.Join(logsPath, fmt.Sprintf("bugtool-%s", pod))
-			res = kub.Exec(fmt.Sprintf("mkdir -p %s", archiveName))
+			res = kub.ExecContext(ctx, fmt.Sprintf("mkdir -p %s", archiveName))
 			if !res.WasSuccessful() {
 				logger.WithField("cmd", res.GetCmd()).Errorf(
 					"cannot create bugtool archive folder: %s", res.CombineOutput())
@@ -1721,31 +1743,31 @@ func (kub *Kubectl) DumpCiliumCommandOutput(namespace string) {
 			}
 
 			cmd := fmt.Sprintf("tar -xf /tmp/%s -C %s --strip-components=1", line, archiveName)
-			res = kub.Exec(cmd, ExecOptions{SkipLog: true})
+			res = kub.ExecContext(ctx, cmd, ExecOptions{SkipLog: true})
 			if !res.WasSuccessful() {
 				logger.WithField("cmd", cmd).Errorf(
 					"Cannot untar bugtool output: %s", res.CombineOutput())
 				continue
 			}
 			//Remove bugtool artifact, so it'll be not used if any other fail test
-			_ = kub.ExecPodCmd(KubeSystemNamespace, pod, fmt.Sprintf("rm /tmp/%s", line))
+			_ = kub.ExecPodCmdContext(ctx, KubeSystemNamespace, pod, fmt.Sprintf("rm /tmp/%s", line))
 		}
 	}
 
-	pods, err := kub.GetCiliumPods(namespace)
+	pods, err := kub.GetCiliumPodsContext(ctx, namespace)
 	if err != nil {
 		kub.logger.WithError(err).Error("cannot retrieve cilium pods on ReportDump")
 		return
 	}
 	for _, pod := range pods {
 		ReportOnPod(pod)
-		kub.GatherCiliumCoreDumps(pod)
+		kub.GatherCiliumCoreDumps(ctx, pod)
 	}
 }
 
 // GatherLogs dumps kubernetes pods, services, DaemonSet to the testResultsPath
 // directory
-func (kub *Kubectl) GatherLogs() {
+func (kub *Kubectl) GatherLogs(ctx context.Context) {
 	reportCmds := map[string]string{
 		"kubectl get pods --all-namespaces -o json":                  "pods.txt",
 		"kubectl get services --all-namespaces -o json":              "svc.txt",
@@ -1759,10 +1781,10 @@ func (kub *Kubectl) GatherLogs() {
 		"kubectl get deployment --all-namespaces -o json":            "deployment.txt",
 	}
 
-	kub.GeneratePodLogGatheringCommands(reportCmds)
-	kub.EtcdOperatorReport(reportCmds)
+	kub.GeneratePodLogGatheringCommands(ctx, reportCmds)
+	kub.EtcdOperatorReport(ctx, reportCmds)
 
-	res := kub.Exec(fmt.Sprintf(`%s api-resources | grep -v "^NAME" | awk '{print $1}'`, KubectlCmd))
+	res := kub.ExecContext(ctx, fmt.Sprintf(`%s api-resources | grep -v "^NAME" | awk '{print $1}'`, KubectlCmd))
 	if res.WasSuccessful() {
 		for _, line := range res.ByLines() {
 			key := fmt.Sprintf("%s get %s --all-namespaces -o wide", KubectlCmd, line)
@@ -1787,18 +1809,18 @@ func (kub *Kubectl) GatherLogs() {
 			"sudo top -n 1 -b":                  fmt.Sprintf("top-%s.log", node),
 			"sudo ps aux":                       fmt.Sprintf("ps-%s.log", node),
 		}
-		reportMap(testPath, reportCmds, vm)
+		reportMapContext(ctx, testPath, reportCmds, vm)
 	}
 }
 
 // GeneratePodLogGatheringCommands generates the commands to gather logs for
 // all pods in the Kubernetes cluster, and maps the commands to the filename
 // in which they will be stored in reportCmds.
-func (kub *Kubectl) GeneratePodLogGatheringCommands(reportCmds map[string]string) {
+func (kub *Kubectl) GeneratePodLogGatheringCommands(ctx context.Context, reportCmds map[string]string) {
 	if reportCmds == nil {
 		reportCmds = make(map[string]string)
 	}
-	pods, err := kub.GetAllPods(ExecOptions{SkipLog: true})
+	pods, err := kub.GetAllPods(ctx, ExecOptions{SkipLog: true})
 	if err != nil {
 		kub.logger.WithError(err).Error("Unable to get pods from Kubernetes via kubectl")
 	}

--- a/test/helpers/node.go
+++ b/test/helpers/node.go
@@ -158,7 +158,11 @@ type ExecOptions struct {
 
 // Exec returns the results of executing the provided cmd via SSH.
 func (s *SSHMeta) Exec(cmd string, options ...ExecOptions) *CmdRes {
-	return s.ExecContext(context.Background(), cmd, options...)
+	// Bound all command executions to be at most the timeout used by the CI
+	// so that commands do not block forever.
+	ctx, cancel := context.WithTimeout(context.Background(), HelperTimeout)
+	defer cancel()
+	return s.ExecContext(ctx, cmd, options...)
 }
 
 // ExecContext returns the results of executing the provided cmd via SSH.

--- a/test/helpers/ssh_command.go
+++ b/test/helpers/ssh_command.go
@@ -245,26 +245,50 @@ func (client *SSHClient) RunCommandContext(ctx context.Context, cmd *SSHCommand)
 		panic("nil context provided to RunCommandContext()")
 	}
 
-	session, err := client.newSession()
-	if err != nil {
-		return err
-	}
+	var (
+		session        *ssh.Session
+		sessionErrChan = make(chan error, 1)
+	)
 
-	defer func() {
+	go func() {
+		var sessionErr error
+
+		// This may block depending on the state of the setup tests are being
+		// ran against. As a result, these goroutines may leak, but the logic
+		// below will fail and propagate to the rest of the CI framework, which
+		// will error out anyway. It's better to leak in really bad cases since
+		// the CI will fail anyway. Unfortunately, the golang SSH library does
+		// not provide a way to propagate context through to creating sessions.
+
+		// Note that this is a closure on the session variable!
+		session, sessionErr = client.newSession()
+		if sessionErr != nil {
+			log.Infof("error creating session: %s", sessionErr)
+			sessionErrChan <- sessionErr
+			return
+		}
+
+		_, runErr := runCommand(session, cmd)
+		sessionErrChan <- runErr
+
 		if closeErr := session.Close(); closeErr != nil {
 			log.WithError(closeErr).Error("failed to close session")
 		}
 	}()
-	err = runCommand(session, cmd)
+
 	select {
+	case asyncErr := <-sessionErrChan:
+		return asyncErr
 	case <-ctx.Done():
-		log.Warning("sending SIGHUP to session due to canceled context")
-		if err = session.Signal(ssh.SIGHUP); err != nil {
-			log.Errorf("failed to kill command when context is canceled: %s", err)
+		if session != nil {
+			log.Warning("sending SIGHUP to session due to canceled context")
+			if err := session.Signal(ssh.SIGHUP); err != nil {
+				log.Errorf("failed to kill command when context is canceled: %s", err)
+			}
+		} else {
+			log.Error("timeout reached; no session was able to be created")
 		}
 		return ctx.Err()
-	default:
-		return err
 	}
 }
 

--- a/test/helpers/ssh_command.go
+++ b/test/helpers/ssh_command.go
@@ -268,7 +268,7 @@ func (client *SSHClient) RunCommandContext(ctx context.Context, cmd *SSHCommand)
 			return
 		}
 
-		_, runErr := runCommand(session, cmd)
+		runErr := runCommand(session, cmd)
 		sessionErrChan <- runErr
 
 		if closeErr := session.Close(); closeErr != nil {

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -275,13 +275,22 @@ func CreateLogFile(filename string, data []byte) error {
 // Function needs a directory path where the files are going to be written and
 // a *SSHMeta instance to execute the commands
 func reportMap(path string, reportCmds map[string]string, node *SSHMeta) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	reportMapContext(ctx, path, reportCmds, node)
+}
+
+// reportMap saves the output of the given commands to the specified filename.
+// Function needs a directory path where the files are going to be written and
+// a *SSHMeta instance to execute the commands
+func reportMapContext(ctx context.Context, path string, reportCmds map[string]string, node *SSHMeta) {
 	if node == nil {
 		log.Errorf("cannot execute reportMap due invalid node instance")
 		return
 	}
 
 	for cmd, logfile := range reportCmds {
-		res := node.Exec(cmd, ExecOptions{SkipLog: true})
+		res := node.ExecContext(ctx, cmd, ExecOptions{SkipLog: true})
 		err := ioutil.WriteFile(
 			fmt.Sprintf("%s/%s", path, logfile),
 			res.CombineOutput().Bytes(),

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -627,9 +627,15 @@ var _ = Describe("K8sPolicyTest", func() {
 				By("Applying no-specs policy")
 				_, err = kubectl.CiliumPolicyAction(
 					helpers.KubeSystemNamespace, cnpUpdateNoSpecs, helpers.KubectlApply, helpers.HelperTimeout)
-				Expect(err).Should(BeNil(), "%q Policy cannot be applied", cnpUpdateAllow)
-
-				validateL3L4(allowAll)
+				switch helpers.GetCurrentK8SEnv() {
+				// In k8s 1.15 no-specs policy is not allowed by kube-apiserver
+				case "1.15":
+					Expect(err).Should(Not(BeNil()), "%q Policy cannot be applied", cnpUpdateAllow)
+					validateL3L4(denyFromApp3)
+				default:
+					Expect(err).Should(BeNil(), "%q Policy cannot be applied", cnpUpdateAllow)
+					validateL3L4(allowAll)
+				}
 
 				By("Applying l3-l4 policy with user-specified labels")
 				_, err = kubectl.CiliumPolicyAction(

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -202,7 +202,7 @@ case $K8S_VERSION in
         ;;
     "1.14")
         KUBERNETES_CNI_VERSION="0.7.5"
-        K8S_FULL_VERSION="1.14.2"
+        K8S_FULL_VERSION="1.14.3"
         KUBEADM_OPTIONS="--ignore-preflight-errors=cri"
         KUBEADM_SLAVE_OPTIONS="--discovery-token-unsafe-skip-ca-verification --ignore-preflight-errors=cri,SystemVerification"
         sudo ln -sf $COREDNS_DEPLOYMENT $DNS_DEPLOYMENT

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -210,7 +210,7 @@ case $K8S_VERSION in
         ;;
     "1.15")
         KUBERNETES_CNI_VERSION="0.7.5"
-        K8S_FULL_VERSION="1.15.0-beta.0"
+        K8S_FULL_VERSION="1.15.0-beta.2"
         KUBEADM_OPTIONS="--ignore-preflight-errors=cri"
         KUBEADM_SLAVE_OPTIONS="--discovery-token-unsafe-skip-ca-verification --ignore-preflight-errors=cri,SystemVerification"
         sudo ln -sf $COREDNS_DEPLOYMENT $DNS_DEPLOYMENT

--- a/test/runtime/ssh.go
+++ b/test/runtime/ssh.go
@@ -1,0 +1,42 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package RuntimeTest
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	. "github.com/cilium/cilium/test/ginkgo-ext"
+	"github.com/cilium/cilium/test/helpers"
+)
+
+var _ = Describe("RuntimeSSHTests", func() {
+
+	var vm *helpers.SSHMeta
+
+	BeforeAll(func() {
+		vm = helpers.InitRuntimeHelper(helpers.Runtime, logger)
+	})
+
+	It("Should fail when context times out", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		By("Running sleep command which is longer than timeout for context")
+		res := vm.ExecContext(ctx, "sleep 10")
+		Expect(res.GetError()).Should(Equal(context.DeadlineExceeded))
+	})
+})

--- a/vendor/k8s.io/client-go/rest/transport.go
+++ b/vendor/k8s.io/client-go/rest/transport.go
@@ -74,9 +74,10 @@ func (c *Config) TransportConfig() (*transport.Config, error) {
 			KeyFile:    c.KeyFile,
 			KeyData:    c.KeyData,
 		},
-		Username:    c.Username,
-		Password:    c.Password,
-		BearerToken: c.BearerToken,
+		Username:        c.Username,
+		Password:        c.Password,
+		BearerToken:     c.BearerToken,
+		BearerTokenFile: c.BearerTokenFile,
 		Impersonate: transport.ImpersonationConfig{
 			UserName: c.Impersonate.UserName,
 			Groups:   c.Impersonate.Groups,

--- a/vendor/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/vendor/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -228,6 +228,7 @@ func (config *DirectClientConfig) getUserIdentificationPartialConfig(configAuthI
 	// blindly overwrite existing values based on precedence
 	if len(configAuthInfo.Token) > 0 {
 		mergedConfig.BearerToken = configAuthInfo.Token
+		mergedConfig.BearerTokenFile = configAuthInfo.TokenFile
 	} else if len(configAuthInfo.TokenFile) > 0 {
 		tokenBytes, err := ioutil.ReadFile(configAuthInfo.TokenFile)
 		if err != nil {
@@ -499,8 +500,9 @@ func (config *inClusterClientConfig) ClientConfig() (*restclient.Config, error) 
 		if server := config.overrides.ClusterInfo.Server; len(server) > 0 {
 			icc.Host = server
 		}
-		if token := config.overrides.AuthInfo.Token; len(token) > 0 {
-			icc.BearerToken = token
+		if len(config.overrides.AuthInfo.Token) > 0 || len(config.overrides.AuthInfo.TokenFile) > 0 {
+			icc.BearerToken = config.overrides.AuthInfo.Token
+			icc.BearerTokenFile = config.overrides.AuthInfo.TokenFile
 		}
 		if certificateAuthorityFile := config.overrides.ClusterInfo.CertificateAuthority; len(certificateAuthorityFile) > 0 {
 			icc.TLSClientConfig.CAFile = certificateAuthorityFile


### PR DESCRIPTION
 * PR: 8228 -- test: have timeout for `Exec` (@ianvernon) -- https://github.com/cilium/cilium/pull/8228
 * PR: 8147 -- test/provision: upgrade k8s 1.15 to 1.15.0-beta.2 (@aanm) -- https://github.com/cilium/cilium/pull/8147
 * PR: 8248 -- test: bump to k8s 1.14.3 (@aanm) -- https://github.com/cilium/cilium/pull/8248
 * PR: 8264 -- test: create session and run commands asynchronously (@ianvernon) -- https://github.com/cilium/cilium/pull/8264
 * PR: 8271 -- k8s: Fix policies with multiple From/To selectors (@gandro) -- https://github.com/cilium/cilium/pull/8271
 * PR: 8262 -- test: use context with timeout to ensure that Cilium log gathering takes <= 5 minutes (@ianvernon) -- https://github.com/cilium/cilium/pull/8262
 * PR: 7869 -- pkg/health: Fix IPv6 URL format in HTTP probe (@iffyio) -- https://github.com/cilium/cilium/pull/7869
 * PR: 8290 -- Preload vagrant boxes in k8s upstream jenkinsfile (@nebril) -- https://github.com/cilium/cilium/pull/8290

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8291)
<!-- Reviewable:end -->
