### PR TITLE
cilium: docker.go ineffectual assignment

### DIFF
--- a/pkg/workloads/docker.go
+++ b/pkg/workloads/docker.go
@@ -241,8 +241,6 @@ func (d *dockerClient) IsRunning(ep *endpoint.Endpoint) bool {
 		}
 
 		if err == nil {
-			runtimeRunning = true
-
 			// Container may exist but is not in running state
 			return cont.State.Running
 		}


### PR DESCRIPTION
Remove unnecessary runtime assignment.

ineffassign .
/home/john/go/src/github.com/cilium/cilium/pkg/workloads/docker.go:244:4: ineffectual assignment to runtimeRunning
make: *** [Makefile:395: ineffassign] Error 1

Fixes: 910d8d7 ("pkg/workloads: add containerd integration")
Signed-off-by: John Fastabend <john.fastabend@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8293)
<!-- Reviewable:end -->
