### PR TITLE
node/manager: add GetNodeIdentities

### DIFF
--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -198,10 +198,10 @@ func (m *Manager) backgroundSync() {
 		syncInterval := m.backgroundSyncInterval()
 		log.WithField("syncInterval", syncInterval.String()).Debug("Performing regular background work")
 
-		// get a copy of the nodes to avoid locking the entire manager
+		// get a copy of the node identities to avoid locking the entire manager
 		// throughout the process of running the datapath validation.
-		nodes := m.GetNodes()
-		for nodeIdentity := range nodes {
+		nodes := m.GetNodeIdentities()
+		for _, nodeIdentity := range nodes {
 			// Retrieve latest node information in case any event
 			// changed the node since the call to GetNodes()
 			m.mutex.RLock()
@@ -352,6 +352,20 @@ func (m *Manager) Exists(id node.Identity) bool {
 	defer m.mutex.RUnlock()
 	_, ok := m.nodes[id]
 	return ok
+}
+
+// GetNodeIdentities returns a list of all node identities store in node
+// manager.
+func (m *Manager) GetNodeIdentities() []node.Identity {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+
+	nodes := make([]node.Identity, 0, len(m.nodes))
+	for nodeIdentity := range m.nodes {
+		nodes = append(nodes, nodeIdentity)
+	}
+
+	return nodes
 }
 
 // GetNodes returns a copy of all of the nodes as a map from Identity to Node.


### PR DESCRIPTION
As the manager's backgroundsync only uses the nodes' identities, it does
not make sense to run GetNodes every interval. Instead make use of
GetNodeIdentities which returns all identities store in this given
manager.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8295)
<!-- Reviewable:end -->
