### PR TITLE
Vagrant development VM fixes

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -69,6 +69,7 @@ sudo cp /home/vagrant/go/src/github.com/cilium/cilium/contrib/systemd/cilium.ser
 sudo cp /home/vagrant/go/src/github.com/cilium/cilium/contrib/systemd/cilium-operator.service /lib/systemd/system
 sudo cp /home/vagrant/go/src/github.com/cilium/cilium/contrib/systemd/cilium /etc/sysconfig
 
+getent group cilium >/dev/null || sudo groupadd -r cilium
 sudo usermod -a -G cilium vagrant
 SCRIPT
 

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -23,7 +23,7 @@ GO_BINDATA := $(QUIET) go-bindata -prefix ../ -mode 0640 -modtime 1450269211 \
 all: $(TARGET) links
 
 links:
-	$(foreach link,$(LINKS), ln -f -s $(TARGET) $(link);)
+	$(foreach link,$(LINKS), ln -f -s $(TARGET) $(link) || cp $(TARGET) $(link);)
 
 clean:
 	@$(ECHO_CLEAN)
@@ -37,14 +37,14 @@ install:
 	groupadd -f cilium
 	$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)
 	$(INSTALL) -m 0755 $(TARGET) $(DESTDIR)$(BINDIR)
-	$(foreach link,$(LINKS), ln -f -s $(TARGET) $(DESTDIR)$(BINDIR)/$(link);)
+	$(foreach link,$(LINKS), ln -f -s $(TARGET) $(DESTDIR)$(BINDIR)/$(link) || cp $(TARGET) $(DESTDIR)$(BINDIR)/$(link);)
 
 else
 
 install:
 	$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)
 	$(INSTALL) -m 0755 $(TARGET) $(DESTDIR)$(BINDIR)
-	$(foreach link,$(LINKS), ln -f -s $(TARGET) $(DESTDIR)$(BINDIR)/$(link);)
+	$(foreach link,$(LINKS), ln -f -s $(TARGET) $(DESTDIR)$(BINDIR)/$(link) || cp $(TARGET) $(DESTDIR)$(BINDIR)/$(link);)
 
 endif
 

--- a/proxylib/Makefile
+++ b/proxylib/Makefile
@@ -9,7 +9,7 @@ DEPS := $(shell find ../pkg accesslog npds test . \( -name '*.go' ! -name '*_tes
 $(TARGET): $(DEPS)
 	@$(ECHO_GO)
 	$(QUIET)$(GO) build $(PROXYLIB_GOBUILD) -o $@.$(VERSION_MAJOR) -buildmode=c-shared
-	$(QUIET)ln -sf $@.$(VERSION_MAJOR) $@
+	$(QUIET)ln -sf $@.$(VERSION_MAJOR) $@ || cp $@.$(VERSION_MAJOR) $@
 
 all: $(TARGET)
 


### PR DESCRIPTION
This PR contains two fixes for the development VM:
- creating the `cilium` group if it does not exist
- copying files if `vboxfs` does not support file linking

It fixes the following errors:

```
runtime1: make: Leaving directory '/home/vagrant/go/src/github.com/cilium/cilium'
runtime1: usermod: group 'cilium' does not exist
```

```
runtime1: ln -sf libcilium.so.1 libcilium.so
runtime1: ln: failed to create symbolic link 'libcilium.so': Operation not permitted
runtime1: Makefile:10: recipe for target 'libcilium.so' failed
runtime1: make[1]: Leaving directory '/home/vagrant/go/src/github.com/cilium/cilium/proxylib'
runtime1: Makefile:53: recipe for target 'proxylib' failed
runtime1: make[1]: *** [libcilium.so] Error 1
runtime1: make: *** [proxylib] Error 2
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8296)
<!-- Reviewable:end -->
