### PR TITLE
ginkgo.Jenkinsfile: reduce VM boot and provision timeout to 30 minutes

### DIFF
--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -76,7 +76,7 @@ pipeline {
         }
         stage ("Copy code and boot vms"){
             options {
-                timeout(time: 45, unit: 'MINUTES')
+                timeout(time: 30, unit: 'MINUTES')
             }
 
             environment {


### PR DESCRIPTION
Now that we cache Vagrant boxes locally in our CI, we can reduce the time the
provisioning / booting stage takes. The longest provisioning time recently was
around 13 minutes, so 30 minutes provides a good cushion for any variability
beyond the longest most recently observed duration for the stage.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8297)
<!-- Reviewable:end -->
