### PR TITLE
Fix Makefile coverpkg when using TESTPKGS=...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ BPF_SRCFILES=$(subst ../,,$(BPF_FILES))
 SWAGGER_VERSION = v0.19.0
 SWAGGER = $(CONTAINER_ENGINE_FULL) run --rm -v $(CURDIR):$(CURDIR) -w $(CURDIR) -e GOPATH=$(GOPATH) --entrypoint swagger quay.io/goswagger/swagger:$(SWAGGER_VERSION)
 
-COVERPKG ?= ./...
+COVERPKG ?= $(shell if [ $$(echo "$(TESTPKGS)" | wc -w) -gt 1 ]; then echo "./..."; else echo "$(TESTPKGS)"; fi)
 GOTEST_BASE = -test.v -timeout 360s
 GOTEST_UNIT_BASE = $(GOTEST_BASE) -check.vv
 GOTEST_PRIV_OPTS = $(GOTEST_UNIT_BASE) -tags=privileged_tests

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ clean-jenkins-precheck:
 	# remove the networks
 	docker-compose -f test/docker-compose.yml -p $(JOB_BASE_NAME)-$$BUILD_NUMBER down
 
-PRIV_TEST_PKGS ?= $(shell grep --include='*.go' -ril '+build privileged_tests' | xargs dirname | sort | uniq)
+PRIV_TEST_PKGS ?= $(shell echo $(TESTPKGS) | xargs grep --include='*.go' -ril '+build privileged_tests' | xargs dirname | sort | uniq)
 tests-privileged:
 	# cilium-map-migrate is a dependency of some unit tests.
 	$(MAKE) -C bpf cilium-map-migrate


### PR DESCRIPTION
The coverpkg parameter was not passing the correct value to go test when
the user specified TESTPKGS, which meant that if developers wanted to
figure out the coverage of a particular package, they'd either have to
run the full set of unit tests or figure out the correct COVERPKG
argument and pass that into "make unit-tests".

Fix it so that COVERPKG inherits the correct package names from TESTPKGS.

While we're at it, fix up the privileged tests options so that you can use TESTPKGS (just like with the regular unit tests), instead of needing to specify PRIV_TEST_PKGS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8308)
<!-- Reviewable:end -->
