### PR TITLE
Trim down CEP EndpointPolicy output for allow-all/allow-world cases

### DIFF
--- a/pkg/endpoint/endpoint_status_test.go
+++ b/pkg/endpoint/endpoint_status_test.go
@@ -282,6 +282,42 @@ func (s *EndpointSuite) TestgetEndpointPolicyMapState(c *check.C) {
 		ingressResult []apiResult
 	}{
 		{
+			name: "Deny all",
+		},
+		{
+			name: "Allow world ingress",
+			args: []args{
+				{uint32(identity.ReservedIdentityWorld), 0, 0, trafficdirection.Ingress},
+			},
+			ingressResult: []apiResult{
+				{"reserved:world", uint64(identity.ReservedIdentityWorld), 0, 0},
+			},
+			egressResult: nil,
+		},
+		{
+			name: "Allow world egress",
+			args: []args{
+				{uint32(identity.ReservedIdentityWorld), 0, 0, trafficdirection.Egress},
+			},
+			ingressResult: nil,
+			egressResult: []apiResult{
+				{"reserved:world", uint64(identity.ReservedIdentityWorld), 0, 0},
+			},
+		},
+		{
+			name: "Allow world both directions",
+			args: []args{
+				{uint32(identity.ReservedIdentityWorld), 0, 0, trafficdirection.Ingress},
+				{uint32(identity.ReservedIdentityWorld), 0, 0, trafficdirection.Egress},
+			},
+			ingressResult: []apiResult{
+				{"reserved:world", uint64(identity.ReservedIdentityWorld), 0, 0},
+			},
+			egressResult: []apiResult{
+				{"reserved:world", uint64(identity.ReservedIdentityWorld), 0, 0},
+			},
+		},
+		{
 			name: "Ingress mix of L3, L4, L3-dependent L4",
 			args: []args{
 				{uint32(fooIdentity.ID), 0, 0, trafficdirection.Ingress},  // L3-only map state
@@ -294,6 +330,20 @@ func (s *EndpointSuite) TestgetEndpointPolicyMapState(c *check.C) {
 				{"unspec:foo", uint64(fooIdentity.ID), 80, 6},
 			},
 			egressResult: nil,
+		},
+		{
+			name: "Egress mix of L3, L4, L3-dependent L4",
+			args: []args{
+				{uint32(fooIdentity.ID), 0, 0, trafficdirection.Egress},  // L3-only map state
+				{0, 80, 6, trafficdirection.Egress},                      // L4-only map state
+				{uint32(fooIdentity.ID), 80, 6, trafficdirection.Egress}, // L3-dependent L4 map state
+			},
+			ingressResult: nil,
+			egressResult: []apiResult{
+				{"unspec:foo", uint64(fooIdentity.ID), 0, 0},
+				{"", 0, 80, 6},
+				{"unspec:foo", uint64(fooIdentity.ID), 80, 6},
+			},
 		},
 	}
 

--- a/pkg/endpoint/endpoint_status_test.go
+++ b/pkg/endpoint/endpoint_status_test.go
@@ -370,6 +370,28 @@ func (s *EndpointSuite) TestgetEndpointPolicyMapState(c *check.C) {
 				{"unspec:foo", uint64(fooIdentity.ID), 80, 6},
 			},
 		},
+		{
+			name: "World shadows CIDR ingress",
+			args: []args{
+				{uint32(identity.ReservedIdentityWorld), 0, 0, trafficdirection.Ingress},
+				{uint32(identity.LocalIdentityFlag), 0, 0, trafficdirection.Ingress},
+			},
+			ingressResult: []apiResult{
+				{"reserved:world", uint64(identity.ReservedIdentityWorld), 0, 0},
+			},
+			egressResult: nil,
+		},
+		{
+			name: "World shadows CIDR egress",
+			args: []args{
+				{uint32(identity.ReservedIdentityWorld), 0, 0, trafficdirection.Egress},
+				{uint32(identity.LocalIdentityFlag), 0, 0, trafficdirection.Egress},
+			},
+			ingressResult: nil,
+			egressResult: []apiResult{
+				{"reserved:world", uint64(identity.ReservedIdentityWorld), 0, 0},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/endpoint/endpoint_status_test.go
+++ b/pkg/endpoint/endpoint_status_test.go
@@ -256,8 +256,8 @@ func (s *EndpointSuite) TestgetEndpointPolicyMapState(c *check.C) {
 	})
 	// Policy not enabled; allow all.
 	apiPolicy := e.getEndpointPolicy()
-	c.Assert(apiPolicy.Ingress.Allowed, checker.DeepEquals, cilium_v2.AllowedIdentityList(nil))
-	c.Assert(apiPolicy.Egress.Allowed, checker.DeepEquals, cilium_v2.AllowedIdentityList(nil))
+	c.Assert(apiPolicy.Ingress.Allowed, checker.DeepEquals, allowAllIdentityList)
+	c.Assert(apiPolicy.Egress.Allowed, checker.DeepEquals, allowAllIdentityList)
 
 	fooLbls := labels.Labels{"": labels.ParseLabel("foo")}
 	fooIdentity, _, err := cache.AllocateIdentity(context.Background(), nil, fooLbls)
@@ -283,6 +283,31 @@ func (s *EndpointSuite) TestgetEndpointPolicyMapState(c *check.C) {
 	}{
 		{
 			name: "Deny all",
+		},
+		{
+			name: "Allow all ingress",
+			args: []args{
+				{0, 0, 0, trafficdirection.Ingress},
+			},
+			ingressResult: []apiResult{{}},
+			egressResult:  nil,
+		},
+		{
+			name: "Allow all egress",
+			args: []args{
+				{0, 0, 0, trafficdirection.Egress},
+			},
+			ingressResult: nil,
+			egressResult:  []apiResult{{}},
+		},
+		{
+			name: "Allow all both directions",
+			args: []args{
+				{0, 0, 0, trafficdirection.Ingress},
+				{0, 0, 0, trafficdirection.Egress},
+			},
+			ingressResult: []apiResult{{}},
+			egressResult:  []apiResult{{}},
 		},
 		{
 			name: "Allow world ingress",


### PR DESCRIPTION
This PR adjusts the CEP EndpointPolicy representation for a couple of key cases, to reduce message size, CPU usage, and memory usage when a large number of identities are used in conjunction with lenient policies.

Specifically:
* If policy is enabled, but traffic is allowed to/from all destinations, then only encode one entry in the API EndpointPolicy per direction to indicate that all traffic is allowed; Do not encode an allow for each individual identity
* If policy is enabled, and traffic is allowed to/from world, then don't bother encoding local CIDR identities into the API EndpointPolicy for the direction that has an allow-world policy. These local identities are always selected by the world policy any way, so encoding these additional identities doesn't provide any additional information, however if there are a large number of these identities then they can take up processing, memory, and CEP message size with no gain.

Furthermore, expand the unit test coverage for these cases (and a few other cases).

Review commit by commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8309)
<!-- Reviewable:end -->
