### PR TITLE
route: Fix table assignment of nexthop route

### DIFF
--- a/pkg/datapath/linux/route/route_linux_test.go
+++ b/pkg/datapath/linux/route/route_linux_test.go
@@ -41,22 +41,25 @@ func parseIP(ip string) *net.IP {
 }
 
 func testReplaceNexthopRoute(c *C, link netlink.Link, routerNet *net.IPNet) {
+	route := Route{
+		Table: 10,
+	}
 	// delete route in case it exists from a previous failed run
-	deleteNexthopRoute(link, routerNet)
+	deleteNexthopRoute(route, link, routerNet)
 
 	// defer cleanup in case of failure
-	defer deleteNexthopRoute(link, routerNet)
+	defer deleteNexthopRoute(route, link, routerNet)
 
-	replaced, err := replaceNexthopRoute(link, routerNet)
+	replaced, err := replaceNexthopRoute(route, link, routerNet)
 	c.Assert(err, IsNil)
 	c.Assert(replaced, Equals, true)
 
 	// We expect routes to always be replaced
-	replaced, err = replaceNexthopRoute(link, routerNet)
+	replaced, err = replaceNexthopRoute(route, link, routerNet)
 	c.Assert(err, IsNil)
 	c.Assert(replaced, Equals, true)
 
-	err = deleteNexthopRoute(link, routerNet)
+	err = deleteNexthopRoute(route, link, routerNet)
 	c.Assert(err, IsNil)
 }
 


### PR DESCRIPTION
Waiting for #8322 to be merged

The nexthop route was injected into the default table instead of the table
specified. This code path was not used so far, this is a fix for a potential
future usage.

Fixes: fec54996ebf ("route: Fix route replacement logic for IPv6")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8312)
<!-- Reviewable:end -->
