### PR TITLE
pkg/ipcache: do not hold write lock while populating listener

### DIFF
--- a/pkg/lock/semaphored_mutex.go
+++ b/pkg/lock/semaphored_mutex.go
@@ -1,0 +1,62 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lock
+
+import (
+	"context"
+
+	"golang.org/x/sync/semaphore"
+)
+
+// SemaphoredMutex is a semaphored mutex that provides a RWLocker interface.
+type SemaphoredMutex struct {
+	semaphore *semaphore.Weighted
+}
+
+// using the same value set in `go/src/rwmutex.go#rwmutexMaxReaders
+const maxReaders = 1 << 30
+
+// NewSemaphoredMutex returns a new SemaphoredMutex.
+func NewSemaphoredMutex() SemaphoredMutex {
+	return SemaphoredMutex{
+		semaphore: semaphore.NewWeighted(maxReaders),
+	}
+}
+
+func (i *SemaphoredMutex) Lock() {
+	// It's fine ignoring error since the error is only caused by passing a
+	// context with a deadline.
+	i.semaphore.Acquire(context.Background(), maxReaders)
+}
+
+// UnlockToRLock releases the current lock for writing but it still keeps it
+// for reading purposes.
+func (i *SemaphoredMutex) UnlockToRLock() {
+	i.semaphore.Release(maxReaders - 1)
+}
+
+func (i *SemaphoredMutex) Unlock() {
+	i.semaphore.Release(maxReaders)
+}
+
+func (i *SemaphoredMutex) RLock() {
+	// It's fine ignoring error since the error is only caused by passing a
+	// context with a deadline.
+	i.semaphore.Acquire(context.Background(), 1)
+}
+
+func (i *SemaphoredMutex) RUnlock() {
+	i.semaphore.Release(1)
+}

--- a/pkg/lock/semaphored_mutex_test.go
+++ b/pkg/lock/semaphored_mutex_test.go
@@ -1,0 +1,49 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package lock
+
+import (
+	. "gopkg.in/check.v1"
+)
+
+type SemaphoredMutexSuite struct{}
+
+var _ = Suite(&SemaphoredMutexSuite{})
+
+func (s *SemaphoredMutexSuite) TestLock(c *C) {
+	lock1 := NewSemaphoredMutex()
+	lock1.Lock()
+	lock1.Unlock()
+
+	lock1.RLock()
+	lock1.RUnlock()
+
+	lock2 := NewSemaphoredMutex()
+	lock2.Lock()
+	lock2.Unlock()
+
+	lock2.Lock()
+	lock2.UnlockToRLock()
+
+	lock2.RLock()
+	lock2.RLock()
+
+	lock2.RUnlock()
+	lock2.RUnlock()
+	lock2.RUnlock()
+
+}


### PR DESCRIPTION
Holding a write locker while populating an ipcache listener can cause
the locker to be held for a long period of time preventing the ipcache
from doing any other read operations. This is unecessary as the listener
will never write into the ipcache map.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8315)
<!-- Reviewable:end -->
