### PR TITLE
agent: Allow writing CNI configuration when ready

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -135,5 +135,6 @@ cilium-agent [flags]
       --trace-payloadlen int                       Length of payload to capture when tracing (default 128)
   -t, --tunnel string                              Tunnel mode {vxlan, geneve, disabled} (default "vxlan" for the "veth" datapath mode)
       --version                                    Print version information
+      --write-cni-conf-when-ready string           Write the CNI configuration as specified via --read-cni-conf to path when agent is ready
 ```
 

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -769,6 +769,9 @@ func init() {
 	flags.Bool(option.SkipCRDCreation, false, "Skip Kubernetes Custom Resource Definitions creations")
 	option.BindEnv(option.SkipCRDCreation)
 
+	flags.String(option.WriteCNIConfigurationWhenReady, "", fmt.Sprintf("Write the CNI configuration as specified via --%s to path when agent is ready", option.ReadCNIConfiguration))
+	option.BindEnv(option.WriteCNIConfigurationWhenReady)
+
 	viper.BindPFlags(flags)
 }
 
@@ -1371,6 +1374,18 @@ func runDaemon() {
 
 	log.WithField("bootstrapTime", time.Since(bootstrapTimestamp)).
 		Info("Daemon initialization completed")
+
+	if option.Config.WriteCNIConfigurationWhenReady != "" {
+		input, err := ioutil.ReadFile(option.Config.ReadCNIConfiguration)
+		if err != nil {
+			log.WithError(err).Fatal("Unable to read CNI configuration file")
+		}
+
+		err = ioutil.WriteFile(option.Config.WriteCNIConfigurationWhenReady, input, 0644)
+		if err != nil {
+			log.WithError(err).Fatalf("Unable to write CNI configuration file to %s", option.Config.WriteCNIConfigurationWhenReady)
+		}
+	}
 
 	errs := make(chan error, 1)
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -563,6 +563,12 @@ const (
 	// Cilium relevant information. This can be used to pass per node
 	// configuration to Cilium.
 	ReadCNIConfiguration = "read-cni-conf"
+
+	// WriteCNIConfigurationWhenReady writes the CNI configuration to the
+	// specified location once the agent is ready to serve requests. This
+	// allows to keep a Kubernetes node NotReady until Cilium is up and
+	// running and able to schedule endpoints.
+	WriteCNIConfigurationWhenReady = "write-cni-conf-when-ready"
 )
 
 // GetTunnelModes returns the list of all tunnel modes
@@ -991,6 +997,12 @@ type DaemonConfig struct {
 	// configuration to Cilium.
 	ReadCNIConfiguration string
 
+	// WriteCNIConfigurationWhenReady writes the CNI configuration to the
+	// specified location once the agent is ready to serve requests. This
+	// allows to keep a Kubernetes node NotReady until Cilium is up and
+	// running and able to schedule endpoints.
+	WriteCNIConfigurationWhenReady string
+
 	// excludeLocalAddresses excludes certain addresses to be recognized as
 	// a local address
 	excludeLocalAddresses []*net.IPNet
@@ -1170,6 +1182,10 @@ func (c *DaemonConfig) Validate() error {
 	if c.PolicyMapMaxEntries > policyMapMax {
 		return fmt.Errorf("specified PolicyMap max entries %d must not exceed maximum %d",
 			c.PolicyMapMaxEntries, policyMapMax)
+	}
+
+	if c.WriteCNIConfigurationWhenReady != "" && c.ReadCNIConfiguration == "" {
+		return fmt.Errorf("%s must be set when using %s", ReadCNIConfiguration, WriteCNIConfigurationWhenReady)
 	}
 
 	return nil
@@ -1364,6 +1380,7 @@ func (c *DaemonConfig) Populate() {
 	c.Tunnel = viper.GetString(TunnelName)
 	c.Version = viper.GetString(Version)
 	c.Workloads = viper.GetStringSlice(ContainerRuntime)
+	c.WriteCNIConfigurationWhenReady = viper.GetString(WriteCNIConfigurationWhenReady)
 
 	// toFQDNs options
 	// When the poller is enabled, the default MinTTL is lowered. This is to


### PR DESCRIPTION
This can be used to generate the CNI configuration in a location outside of the
cni-conf-dir and then copy the CNI configuration into the config directory once
the agent is up. This avoids the node being marked ready before the agent is
ready to schedule pods.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8316)
<!-- Reviewable:end -->
