### PR TITLE
health: Split out passive mode into separate binary

### DIFF
--- a/Documentation/cmdref/cilium-health.md
+++ b/Documentation/cmdref/cilium-health.md
@@ -15,7 +15,6 @@ cilium-health [flags]
 ### Options
 
 ```
-      --admin string         Expose resources over 'unix' socket, 'any' socket (default "unix")
   -c, --cilium string        URI to Cilium server API
   -d, --daemon               Run as a daemon
   -D, --debug                Enable debug messages
@@ -24,8 +23,6 @@ cilium-health [flags]
   -i, --interval uint        Interval (in seconds) for periodic connectivity probes (default 60)
       --log-driver strings   Logging endpoints to use for example syslog
       --log-opt map          Log driver options for cilium-health (default map[])
-  -p, --passive              Only respond to HTTP health checks
-      --pidfile string       Write the PID to the specified file
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-health_get.md
+++ b/Documentation/cmdref/cilium-health_get.md
@@ -22,7 +22,6 @@ cilium-health get [flags]
 ### Options inherited from parent commands
 
 ```
-      --admin string         Expose resources over 'unix' socket, 'any' socket (default "unix")
   -c, --cilium string        URI to Cilium server API
   -d, --daemon               Run as a daemon
   -D, --debug                Enable debug messages
@@ -30,8 +29,6 @@ cilium-health get [flags]
   -i, --interval uint        Interval (in seconds) for periodic connectivity probes (default 60)
       --log-driver strings   Logging endpoints to use for example syslog
       --log-opt map          Log driver options for cilium-health (default map[])
-  -p, --passive              Only respond to HTTP health checks
-      --pidfile string       Write the PID to the specified file
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-health_ping.md
+++ b/Documentation/cmdref/cilium-health_ping.md
@@ -21,7 +21,6 @@ cilium-health ping [flags]
 ### Options inherited from parent commands
 
 ```
-      --admin string         Expose resources over 'unix' socket, 'any' socket (default "unix")
   -c, --cilium string        URI to Cilium server API
   -d, --daemon               Run as a daemon
   -D, --debug                Enable debug messages
@@ -29,8 +28,6 @@ cilium-health ping [flags]
   -i, --interval uint        Interval (in seconds) for periodic connectivity probes (default 60)
       --log-driver strings   Logging endpoints to use for example syslog
       --log-opt map          Log driver options for cilium-health (default map[])
-  -p, --passive              Only respond to HTTP health checks
-      --pidfile string       Write the PID to the specified file
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-health_status.md
+++ b/Documentation/cmdref/cilium-health_status.md
@@ -25,7 +25,6 @@ cilium-health status [flags]
 ### Options inherited from parent commands
 
 ```
-      --admin string         Expose resources over 'unix' socket, 'any' socket (default "unix")
   -c, --cilium string        URI to Cilium server API
   -d, --daemon               Run as a daemon
   -D, --debug                Enable debug messages
@@ -33,8 +32,6 @@ cilium-health status [flags]
   -i, --interval uint        Interval (in seconds) for periodic connectivity probes (default 60)
       --log-driver strings   Logging endpoints to use for example syslog
       --log-opt map          Log driver options for cilium-health (default map[])
-  -p, --passive              Only respond to HTTP health checks
-      --pidfile string       Write the PID to the specified file
 ```
 
 ### SEE ALSO

--- a/cilium-health/Makefile
+++ b/cilium-health/Makefile
@@ -1,18 +1,31 @@
 include ../Makefile.defs
 
-TARGET=cilium-health
-SOURCES := $(shell find ../api/v1/health ../pkg/health cmd . \( -name '*.go' ! -name '*_test.go' \))
+SUBDIRS = responder
+TARGET = cilium-health
+
+.PHONY: all $(SUBDIRS) install clean
+
+all: $(TARGET) $(SUBDIRS)
+
+SOURCES := $(shell find ../api/v1/health ../pkg/health cmd . \
+	\( -name '*.go' ! -name '*_test.go' $(foreach dir,$(SUBDIRS),! -path './$(dir)/*') \) )
 $(TARGET): $(SOURCES)
 	@$(ECHO_GO)
 	$(QUIET)$(GO) build $(GOBUILD) -o $(TARGET)
 
-all: $(TARGET)
+$(SUBDIRS): force
+	@ $(MAKE) -C $@ all
 
 clean:
 	@$(ECHO_CLEAN)
+	$(QUIET)for i in $(SUBDIRS); do $(MAKE) -C $$i clean; done
 	-$(QUIET)rm -f $(TARGET)
 	$(QUIET)$(GO) clean
 
 install:
+	$(QUIET)for i in $(SUBDIRS); do $(MAKE) -C $$i install; done
 	$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)
 	$(INSTALL) -m 0755 $(TARGET) $(DESTDIR)$(BINDIR)
+
+.PHONY: force
+force :;

--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -30,8 +30,8 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpoint/connector"
 	"github.com/cilium/cilium/pkg/endpointmanager"
-	healthPkg "github.com/cilium/cilium/pkg/health/client"
 	healthDefaults "github.com/cilium/cilium/pkg/health/defaults"
+	"github.com/cilium/cilium/pkg/health/probe"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/launcher"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -50,6 +50,7 @@ import (
 const (
 	ciliumHealth = "cilium-health"
 	netNSName    = "cilium-health"
+	binaryName   = "cilium-health-responder"
 )
 
 var (
@@ -147,14 +148,13 @@ func configureHealthInterface(netNS ns.NetNS, ifName string, ip4Addr, ip6Addr *n
 // Client wraps a client to a specific cilium-health endpoint instance, to
 // provide convenience methods such as PingEndpoint().
 type Client struct {
-	*healthPkg.Client
+	*probe.Client
 }
 
 // PingEndpoint attempts to make an API ping request to the local cilium-health
 // endpoint, and returns whether this was successful.
 func (c *Client) PingEndpoint() error {
-	_, err := c.Restapi.GetHello(nil)
-	return err
+	return c.Client.GetHello()
 }
 
 // KillEndpoint attempts to kill any existing cilium-health endpoint if it
@@ -254,7 +254,7 @@ func LaunchAsEndpoint(baseCtx context.Context, owner endpoint.Owner, n *node.Nod
 
 	pidfile := filepath.Join(option.Config.StateDir, PidfilePath)
 	prog := "ip"
-	args := []string{"netns", "exec", netNSName, ciliumHealth, "-d", "--admin=unix", "--passive", "--pidfile", pidfile}
+	args := []string{"netns", "exec", netNSName, binaryName, "--pidfile", pidfile}
 	cmd.SetTarget(prog)
 	cmd.SetArgs(args)
 	log.Infof("Spawning health endpoint with command %q %q", prog, args)
@@ -304,7 +304,7 @@ func LaunchAsEndpoint(baseCtx context.Context, owner endpoint.Owner, n *node.Nod
 
 	// Initialize the health client to talk to this instance. This is why
 	// the caller must limit usage of this package to a single goroutine.
-	client, err := healthPkg.NewClient("tcp://" + net.JoinHostPort(healthIP.String(), fmt.Sprintf("%d", healthDefaults.HTTPPathPort)))
+	client, err := probe.NewClient("http://" + net.JoinHostPort(healthIP.String(), fmt.Sprintf("%d", healthDefaults.HTTPPathPort)))
 	if err != nil {
 		return nil, fmt.Errorf("Cannot establish connection to health endpoint: %s", err)
 	}

--- a/cilium-health/launch/launcher.go
+++ b/cilium-health/launch/launcher.go
@@ -68,6 +68,7 @@ func (ch *CiliumHealth) Run() {
 		ch.client, err = healthPkg.NewDefaultClient()
 		if err != nil {
 			log.WithError(err).Infof("Cannot establish connection to local %s instance", targetName)
+			ch.Launcher.Stop()
 			time.Sleep(connectRetryInterval)
 			continue
 		}

--- a/cilium-health/responder/.gitignore
+++ b/cilium-health/responder/.gitignore
@@ -1,0 +1,1 @@
+cilium-health-responder

--- a/cilium-health/responder/Makefile
+++ b/cilium-health/responder/Makefile
@@ -1,0 +1,18 @@
+include ../../Makefile.defs
+
+TARGET=cilium-health-responder
+SOURCES := $(shell find ../../pkg/health/probe/responder . \( -name '*.go' ! -name '*_test.go' \))
+$(TARGET): $(SOURCES)
+	@$(ECHO_GO)
+	$(QUIET)$(GO) build $(GOBUILD) -o $(TARGET)
+
+all: $(TARGET)
+
+clean:
+	@$(ECHO_CLEAN)
+	-$(QUIET)rm -f $(TARGET)
+	$(QUIET)$(GO) clean
+
+install:
+	$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)
+	$(INSTALL) -m 0755 $(TARGET) $(DESTDIR)$(BINDIR)

--- a/cilium-health/responder/main.go
+++ b/cilium-health/responder/main.go
@@ -1,0 +1,84 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+
+	"github.com/cilium/cilium/pkg/health/probe/responder"
+
+	flag "github.com/spf13/pflag"
+)
+
+func removePidfile(path string) {
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		fmt.Fprintf(os.Stderr, "failed to remove pidfile: %s\n", err.Error())
+	}
+}
+
+func writePidfile(path string) error {
+	pid := os.Getpid()
+	pidBytes := []byte(strconv.Itoa(pid) + "\n")
+	return ioutil.WriteFile(path, pidBytes, 0660)
+}
+
+func cancelOnSignal(cancel context.CancelFunc) {
+	go func() {
+		defer cancel()
+
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, syscall.SIGTERM, syscall.SIGINT, syscall.SIGHUP)
+		<-c
+	}()
+}
+
+func main() {
+	var (
+		pidfile string
+		listen  int
+	)
+	flag.StringVar(&pidfile, "pidfile", "", "Write pid to the specified file")
+	flag.IntVar(&listen, "listen", 4240, "Port on which the responder listens")
+	flag.Parse()
+
+	// Shutdown gracefully to halt server and remove pidfile
+	ctx, cancel := context.WithCancel(context.Background())
+	cancelOnSignal(cancel)
+
+	srv := responder.NewServer(listen)
+	defer srv.Shutdown()
+	go func() {
+		if err := srv.Serve(); err != nil {
+			fmt.Fprintf(os.Stderr, "error while listening: %s\n", err.Error())
+			cancel()
+		}
+	}()
+
+	if pidfile != "" {
+		defer removePidfile(pidfile)
+		if err := writePidfile(pidfile); err != nil {
+			fmt.Fprintf(os.Stderr, "cannot write pidfile: %s: %s\n", pidfile, err.Error())
+			os.Exit(-1)
+		}
+	}
+
+	<-ctx.Done()
+}

--- a/pkg/health/probe/probe.go
+++ b/pkg/health/probe/probe.go
@@ -1,0 +1,62 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package probe
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// DefaultTimeout used for requests
+var DefaultTimeout = 30 * time.Second
+
+// Client for accessing the http probe
+type Client struct {
+	client *http.Client
+	host   *url.URL
+}
+
+// NewClient creates a new http client with DefaultTransport
+func NewClient(host string) (*Client, error) {
+	hostURL, err := url.Parse(host)
+	if err != nil {
+		return nil, err
+	}
+
+	cl := &http.Client{Timeout: DefaultTimeout}
+	return &Client{cl, hostURL}, nil
+}
+
+// GetHello performs a GET request on the /hello endpoint
+func (c *Client) GetHello() error {
+	requestURL, err := c.host.Parse("/hello")
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.client.Get(requestURL.String())
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status code: %d %s", resp.StatusCode, resp.Status)
+	}
+
+	return nil
+}

--- a/pkg/health/probe/responder/responder.go
+++ b/pkg/health/probe/responder/responder.go
@@ -1,0 +1,62 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package responder
+
+// this implementation is intentionally kept with minimal dependencies
+// as this package typically runs in its own process
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// DefaultTimeout used for shutdown
+var DefaultTimeout = 30 * time.Second
+
+// Server wraps a minimal http server for the /hello endpoint
+type Server struct {
+	httpServer http.Server
+}
+
+// NewServer creates a new server listening on the given port
+func NewServer(port int) *Server {
+	return &Server{
+		http.Server{
+			Addr:    fmt.Sprintf(":%d", port),
+			Handler: http.HandlerFunc(serverRequests),
+		},
+	}
+}
+
+// Serve http requests until shut down
+func (s *Server) Serve() error {
+	return s.httpServer.ListenAndServe()
+}
+
+// Shutdown server gracefully
+func (s *Server) Shutdown() error {
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
+	defer cancel()
+	return s.httpServer.Shutdown(ctx)
+}
+
+func serverRequests(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path == "/hello" {
+		w.WriteHeader(http.StatusOK)
+	} else {
+		w.WriteHeader(http.StatusNotFound)
+	}
+}

--- a/pkg/health/server/prober.go
+++ b/pkg/health/server/prober.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/cilium/cilium/api/v1/health/models"
 	ciliumModels "github.com/cilium/cilium/api/v1/models"
-	"github.com/cilium/cilium/pkg/health/client"
 	"github.com/cilium/cilium/pkg/health/defaults"
+	"github.com/cilium/cilium/pkg/health/probe"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 
@@ -237,11 +237,11 @@ func (p *prober) httpProbe(node string, ip string, port int) *models.Connectivit
 		"path":             PortToPaths[port],
 	})
 
-	client, err := client.NewClient(host)
+	client, err := probe.NewClient(host)
 	if err == nil {
 		scopedLog.Debug("Greeting host")
 		start := time.Now()
-		_, err = client.Restapi.GetHello(nil)
+		err = client.GetHello()
 		rtt := time.Since(start)
 		if err == nil {
 			scopedLog.WithField("rtt", rtt).Debug("Greeting successful")

--- a/pkg/launcher/launcher.go
+++ b/pkg/launcher/launcher.go
@@ -66,11 +66,10 @@ func (launcher *Launcher) Run() error {
 	return nil
 }
 
-// Restart stops the launcher which will trigger a rerun.
-func (launcher *Launcher) Restart(args []string) {
+// Stop kills the current instance so it can be started again
+func (launcher *Launcher) Stop() {
 	launcher.Mutex.Lock()
 	defer launcher.Mutex.Unlock()
-	launcher.args = args
 
 	if launcher.process == nil {
 		return


### PR DESCRIPTION
This change introduces a new binary called `cilium-health-probe`, which replaces the 'passive' mode the existing `cilium-heath` executable. Its purpose is emulating an endpoint by running a HTTP server in the cilium-health namespace for testing endpoint connectivity.

To reduce memory consumption, the new TCP-only server in the new binary is based on net/http instead of go-openapi and comes with a small client. The old `/hello` endpoint of the cilium-health API is still there, as it is also accessed by commands such as `cilium-health ping` on the "admin API" (exposed via unix socket only), but I plan to eventually remove it in a follow-up PR.

The new binary reduces the resident set size (RSS) of the endpoint process by roughly 12-15MB.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8317)
<!-- Reviewable:end -->
