### PR TITLE
daemon: fix endpoint restore when endpoints are not available

### DIFF
--- a/daemon/state.go
+++ b/daemon/state.go
@@ -260,6 +260,7 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) (resto
 		go func(ep *endpoint.Endpoint, epRegenerated chan<- bool) {
 			if err := ep.RLockAlive(); err != nil {
 				ep.LogDisconnectedMutexAction(err, "before filtering labels during regenerating restored endpoint")
+				epRegenerated <- false
 				return
 			}
 			scopedLog := log.WithField(logfields.EndpointID, ep.ID)
@@ -272,6 +273,7 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) (resto
 			if err != nil {
 				scopedLog.WithError(err).Warn("Unable to restore endpoint")
 				epRegenerated <- false
+				return
 			}
 
 			// Wait for initial identities and ipcache from the
@@ -285,6 +287,7 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) (resto
 
 			if err := ep.LockAlive(); err != nil {
 				scopedLog.Warn("Endpoint to restore has been deleted")
+				epRegenerated <- false
 				return
 			}
 


### PR DESCRIPTION
As containers can be removed between cilium-agent restarts, their
endpoints will no longer be valid and they can't be restored. By not
being restored in this case, the channel signalizing they were not
restored was not written making the go routine to be kept running until
the cilium-agent forever.

Fixes: 5035a582d952 ("daemon: synchronously add endpoints to endpointmanager in \`regenerateRestoredEndpoints\`")
Fixes: 20a49da060fd ("Consistently check for liveness of endpoint when re-locking (#5116)")
Fixes: f59daacc1382 ("daemon: on restore, run identity allocation in the background")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8319)
<!-- Reviewable:end -->
