### PR TITLE
pkg/lock: RUnlock in RUnlockIgnoreTime

### DIFF
--- a/pkg/lock/lock_debug.go
+++ b/pkg/lock/lock_debug.go
@@ -1,6 +1,4 @@
-// +build lockdebug
-
-// Copyright 2017-2018 Authors of Cilium
+// Copyright 2017-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// +build lockdebug
 
 package lock
 
@@ -75,7 +75,7 @@ func (i *internalRWMutex) UnlockIgnoreTime() {
 }
 
 func (i *internalRWMutex) RLock() {
-	i.RWMutex.Lock()
+	i.RWMutex.RLock()
 	i.t = time.Now()
 }
 
@@ -83,11 +83,11 @@ func (i *internalRWMutex) RUnlock() {
 	if sec := time.Since(i.t).Seconds(); sec >= selfishThresholdSec {
 		printStackTo(sec, debug.Stack(), os.Stderr)
 	}
-	i.RWMutex.Unlock()
+	i.RWMutex.RUnlock()
 }
 
 func (i *internalRWMutex) RUnlockIgnoreTime() {
-	i.RWMutex.Unlock()
+	i.RWMutex.RUnlock()
 }
 
 type internalMutex struct {

--- a/pkg/lock/lock_fast.go
+++ b/pkg/lock/lock_fast.go
@@ -1,6 +1,4 @@
-// +build !lockdebug
-
-// Copyright 2017 Authors of Cilium
+// Copyright 2017-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// +build !lockdebug
 
 package lock
 
@@ -29,7 +29,7 @@ func (i *internalRWMutex) UnlockIgnoreTime() {
 }
 
 func (i *internalRWMutex) RUnlockIgnoreTime() {
-	i.RWMutex.Unlock()
+	i.RWMutex.RUnlock()
 }
 
 type internalMutex struct {


### PR DESCRIPTION
These functions were wrongly executing Unlocks internally instead of
RUnlocks.

Fixes: 8e976dd1598b ("pkg/lock: add detector if a lock was held for more than n seconds")
Signed-off-by: André Martins <andre@cilium.io>

This does not affect production as we don't ship cilium with the tag lockdebug set as well as `RUnlockIgnoreTime` is a function that is not used anywhere.

Marking as backported needed for all branches as we never know if we will use this code tomorrow.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8320)
<!-- Reviewable:end -->
