### PR TITLE
cilium: encryption cleanup encryption and fix table assignment of nexthop route

### DIFF
--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -802,7 +802,7 @@ func (n *linuxNodeHandler) createNodeExternalIPSecOutRoute(ip *net.IPNet, dflt b
 		dev = n.datapathConfig.HostDevice
 	} else {
 		tbl = linux_defaults.RouteTableIPSec
-		dev = n.datapathConfig.HostDevice //n.datapathConfig.EncryptInterface
+		dev = n.datapathConfig.HostDevice
 	}
 
 	return route.Route{

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -555,7 +555,6 @@ func (n *linuxNodeHandler) enableIPsec(newNode *node.Node) {
 	if n.nodeConfig.EnableIPv6 && newNode.IPv6AllocCIDR != nil {
 		new6Net := &net.IPNet{IP: newNode.IPv6AllocCIDR.IP, Mask: newNode.IPv6AllocCIDR.Mask}
 		if newNode.IsLocal() {
-			n.replaceHostRules()
 			n.replaceNodeIPSecInRoute(new6Net)
 			ciliumInternalIPv6 := newNode.GetCiliumInternalIP(true)
 			if ciliumInternalIPv6 != nil {

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -552,25 +552,6 @@ func (n *linuxNodeHandler) enableIPsec(newNode *node.Node) {
 		}
 	}
 
-	if n.nodeConfig.EnableIPv4 && n.nodeConfig.EncryptNode {
-		internalIPv4 := n.nodeAddressing.IPv4().PrimaryExternal()
-		exactMask := net.IPv4Mask(255, 255, 255, 255)
-		ipsecLocal := &net.IPNet{IP: internalIPv4, Mask: exactMask}
-		if newNode.IsLocal() {
-			ipsecIPv4Wildcard := &net.IPNet{IP: net.ParseIP(wildcardIPv4), Mask: net.IPv4Mask(0, 0, 0, 0)}
-			n.replaceNodeIPSecInRoute(ipsecLocal)
-			spi, err = ipsec.UpsertIPsecEndpoint(ipsecLocal, ipsecIPv4Wildcard, ipsec.IPSecDirIn)
-			upsertIPsecLog(err, "local IPv4", ipsecLocal, ipsecIPv4Wildcard, spi)
-		} else {
-			if remoteIPv4 := newNode.GetNodeIP(false); remoteIPv4 != nil {
-				ipsecRemote := &net.IPNet{IP: remoteIPv4, Mask: exactMask}
-				n.replaceNodeExternalIPSecOutRoute(ipsecRemote)
-				spi, err = ipsec.UpsertIPsecEndpoint(ipsecLocal, ipsecRemote, ipsec.IPSecDirOut)
-				upsertIPsecLog(err, "IPv4", ipsecLocal, ipsecRemote, spi)
-			}
-		}
-	}
-
 	if n.nodeConfig.EnableIPv6 && newNode.IPv6AllocCIDR != nil {
 		new6Net := &net.IPNet{IP: newNode.IPv6AllocCIDR.IP, Mask: newNode.IPv6AllocCIDR.Mask}
 		if newNode.IsLocal() {
@@ -593,26 +574,6 @@ func (n *linuxNodeHandler) enableIPsec(newNode *node.Node) {
 			}
 		}
 	}
-
-	if n.nodeConfig.EnableIPv6 && n.nodeConfig.EncryptNode {
-		internalIPv6 := n.nodeAddressing.IPv6().PrimaryExternal()
-		internalMask := net.CIDRMask(64, 128)
-		ipsecLocal := &net.IPNet{IP: internalIPv6, Mask: internalMask}
-		if newNode.IsLocal() {
-			ipsecIPv6Wildcard := &net.IPNet{IP: net.ParseIP(wildcardIPv6), Mask: net.CIDRMask(0, 0)}
-			n.replaceNodeIPSecInRoute(ipsecLocal)
-			spi, err = ipsec.UpsertIPsecEndpoint(ipsecLocal, ipsecIPv6Wildcard, ipsec.IPSecDirIn)
-			upsertIPsecLog(err, "local IPv6", ipsecLocal, ipsecIPv6Wildcard, spi)
-		} else {
-			if remoteIPv6 := newNode.GetNodeIP(false); remoteIPv6 != nil {
-				ipsecRemote := &net.IPNet{IP: remoteIPv6, Mask: internalMask}
-				n.replaceNodeExternalIPSecOutRoute(ipsecRemote)
-				spi, err = ipsec.UpsertIPsecEndpoint(ipsecLocal, ipsecRemote, ipsec.IPSecDirOut)
-				upsertIPsecLog(err, "IPv6", ipsecLocal, ipsecRemote, spi)
-			}
-		}
-	}
-
 }
 
 func (n *linuxNodeHandler) subnetEncryption() bool {

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -777,16 +777,8 @@ func (n *linuxNodeHandler) createNodeIPSecInRoute(ip *net.IPNet) route.Route {
 }
 
 func (n *linuxNodeHandler) createNodeIPSecOutRoute(ip *net.IPNet) route.Route {
-	var nexthop net.IP
-
-	if ip.IP.To4() != nil {
-		nexthop = n.nodeAddressing.IPv4().Router()
-	} else {
-		nexthop = n.nodeAddressing.IPv6().Router()
-	}
-
 	return route.Route{
-		Nexthop: &nexthop,
+		Nexthop: nil,
 		Device:  n.datapathConfig.HostDevice,
 		Prefix:  *ip,
 		Table:   linux_defaults.RouteTableIPSec,

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -503,8 +503,8 @@ func (n *linuxNodeHandler) encryptNode(newNode *node.Node) {
 
 	if n.nodeConfig.EnableIPv6 && n.nodeConfig.EncryptNode {
 		internalIPv6 := n.nodeAddressing.IPv6().PrimaryExternal()
-		internalMask := net.CIDRMask(128, 128)
-		ipsecLocal := &net.IPNet{IP: internalIPv6, Mask: internalMask}
+		exactMask := net.CIDRMask(128, 128)
+		ipsecLocal := &net.IPNet{IP: internalIPv6, Mask: exactMask}
 		if newNode.IsLocal() {
 			ipsecIPv6Wildcard := &net.IPNet{IP: net.ParseIP(wildcardIPv6), Mask: net.CIDRMask(0, 0)}
 			n.replaceNodeIPSecInRoute(ipsecLocal)
@@ -512,7 +512,7 @@ func (n *linuxNodeHandler) encryptNode(newNode *node.Node) {
 			upsertIPsecLog(err, "EncryptNode local IPv6", ipsecLocal, ipsecIPv6Wildcard, spi)
 		} else {
 			if remoteIPv6 := newNode.GetNodeIP(true); remoteIPv6 != nil {
-				ipsecRemote := &net.IPNet{IP: remoteIPv6, Mask: internalMask}
+				ipsecRemote := &net.IPNet{IP: remoteIPv6, Mask: exactMask}
 				n.replaceNodeExternalIPSecOutRoute(ipsecRemote)
 				spi, err = ipsec.UpsertIPsecEndpoint(ipsecLocal, ipsecRemote, ipsec.IPSecDirOut)
 				upsertIPsecLog(err, "EncryptNode IPv6", ipsecLocal, ipsecRemote, spi)

--- a/pkg/datapath/linux/route/route_linux_test.go
+++ b/pkg/datapath/linux/route/route_linux_test.go
@@ -41,22 +41,25 @@ func parseIP(ip string) *net.IP {
 }
 
 func testReplaceNexthopRoute(c *C, link netlink.Link, routerNet *net.IPNet) {
+	route := Route{
+		Table: 10,
+	}
 	// delete route in case it exists from a previous failed run
-	deleteNexthopRoute(link, routerNet)
+	deleteNexthopRoute(route, link, routerNet)
 
 	// defer cleanup in case of failure
-	defer deleteNexthopRoute(link, routerNet)
+	defer deleteNexthopRoute(route, link, routerNet)
 
-	replaced, err := replaceNexthopRoute(link, routerNet)
+	replaced, err := replaceNexthopRoute(route, link, routerNet)
 	c.Assert(err, IsNil)
 	c.Assert(replaced, Equals, true)
 
 	// We expect routes to always be replaced
-	replaced, err = replaceNexthopRoute(link, routerNet)
+	replaced, err = replaceNexthopRoute(route, link, routerNet)
 	c.Assert(err, IsNil)
 	c.Assert(replaced, Equals, true)
 
-	err = deleteNexthopRoute(link, routerNet)
+	err = deleteNexthopRoute(route, link, routerNet)
 	c.Assert(err, IsNil)
 }
 


### PR DESCRIPTION
Series of cleanup to encryption code and removes nexthop specifier from out encryption route. Its not needed and will break encryption after PR #8312 by forcing ingress esp traffic to cilium_host when we expect to decrypt it first.

@tgraf says, "The nexthop route was injected into the default table instead of the table
specified. This code path was not used so far, this is a fix for a potential
future usage."

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8322)
<!-- Reviewable:end -->
