### PR TITLE
fqdn: correctly populate Source IP and Port in `notifyOnDNSMsg`

### DIFF
--- a/daemon/fqdn.go
+++ b/daemon/fqdn.go
@@ -337,9 +337,9 @@ func (d *Daemon) lookupEPByIP(endpointIP net.IP) (endpoint *endpoint.Endpoint, e
 // - Report the verdict in a monitor event and emit proxy metrics
 // - Insert the DNS data into the cache when msg is a DNS response and we
 //   can lookup the endpoint related to it
-// epAddr and serverAddr should match the original request, where epAddr is
+// epIPPort and serverAddr should match the original request, where epAddr is
 // the source for egress (the only case current).
-func (d *Daemon) notifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, serverAddr string, msg *dns.Msg, protocol string, allowed bool, stat dnsproxy.ProxyRequestContext) error {
+func (d *Daemon) notifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epIPPort string, serverAddr string, msg *dns.Msg, protocol string, allowed bool, stat dnsproxy.ProxyRequestContext) error {
 	var protoID = u8proto.ProtoIDs[strings.ToLower(protocol)]
 	var verdict accesslog.FlowVerdict
 	var reason string
@@ -412,7 +412,7 @@ func (d *Daemon) notifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, ser
 		func(lr *logger.LogRecord) { lr.LogRecord.TransportProtocol = accesslog.TransportProtocol(protoID) },
 		logger.LogTags.Verdict(verdict, reason),
 		logger.LogTags.Addressing(logger.AddressingInfo{
-			SrcIPPort:   ep.String(),
+			SrcIPPort:   epIPPort,
 			DstIPPort:   serverAddr,
 			SrcIdentity: ep.GetIdentity().Uint32(),
 		}),

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -89,7 +89,7 @@ func (s *DNSProxyTestSuite) SetUpSuite(c *C) {
 			ep := endpoint.NewEndpointWithState(s.repo, 123, endpoint.StateReady)
 			return ep, nil
 		},
-		func(lookupTime time.Time, ep *endpoint.Endpoint, dstAddr string, msg *dns.Msg, protocol string, allowed bool, stat ProxyRequestContext) error {
+		func(lookupTime time.Time, ep *endpoint.Endpoint, epIPPort string, dstAddr string, msg *dns.Msg, protocol string, allowed bool, stat ProxyRequestContext) error {
 			return nil
 		})
 	c.Assert(err, IsNil, Commentf("error starting DNS Proxy"))


### PR DESCRIPTION
Before, we were calling `endpoint.String()` for each DNS request going through
the DNS proxy and providing that as the value for `SrcIPPort` for the
`AddressingInfo` portion of the corresponding `LogRecord` for said DNS request.
This in and of itself was a bug (the endpoint string is not a valid hostname /
port tuple). On top of this, this was a performance bottleneck, because of the
amount of CPU being used to marshal the endpoint into JSON and convert it into a
string, per the output of running `gops pprof-cpu <cilium-agent PID>` and
running `list notifyOnDNSMsg`:

```
ROUTINE ======================== main.(*Daemon).notifyOnDNSMsg in /home/vagrant/go/src/github.com/cilium/cilium/daemon/fqdn.go
      10ms      2.75s (flat, cum) 47.33% of Total
         .          .    399:		err := errors.New("DNS request cannot be associated with an existing endpoint")
         .          .    400:		log.WithError(err).Error("cannot find matching endpoint")
         .          .    401:		endMetric()
         .          .    402:		return err
         .          .    403:	}
         .       10ms    404:	qname, responseIPs, TTL, CNAMEs, rcode, recordTypes, qTypes, err := dnsproxy.ExtractMsgDetails(msg)
         .          .    405:	if err != nil {
         .          .    406:		// This error is ok because all these values are used for reporting, or filling in the cache.
         .          .    407:		log.WithError(err).Error("cannot extract DNS message details")
         .          .    408:	}
         .          .    409:
         .       60ms    410:	ep.UpdateProxyStatistics("dns", uint16(serverPort), false, !msg.Response, verdict)
         .      240ms    411:	record := logger.NewLogRecord(proxy.DefaultEndpointInfoRegistry, ep, flowType, false,
         .          .    412:		func(lr *logger.LogRecord) { lr.LogRecord.TransportProtocol = accesslog.TransportProtocol(protoID) },
         .          .    413:		logger.LogTags.Verdict(verdict, reason),
         .          .    414:		logger.LogTags.Addressing(logger.AddressingInfo{
         .      1.81s    415:			SrcIPPort:   ep.String(),
         .          .    416:			DstIPPort:   serverAddr,
         .          .    417:			SrcIdentity: ep.GetIdentity().Uint32(),
         .          .    418:		}),
```

Instead, provide the IP/Port tuple from the initial request into all
`NotifyOnDNSMsg` invocations for the `DNSProxy`. This correctly populates the
`SrcIPPort` field, and improves performance due to not having to marshal the
endpoint. When running the aforementioned pprof commands again, the performance
is clearly much better when running cilium against the same set of pods
making DNS requests at the same cadence:

```
ROUTINE ======================== main.(*Daemon).notifyOnDNSMsg in /home/vagrant/go/src/github.com/cilium/cilium/daemon/fqdn.go
         0      460ms (flat, cum) 17.83% of Total
         .          .    405:	if err != nil {
         .          .    406:		// This error is ok because all these values are used for reporting, or filling in the cache.
         .          .    407:		log.WithError(err).Error("cannot extract DNS message details")
         .          .    408:	}
         .          .    409:
         .       30ms    410:	ep.UpdateProxyStatistics("dns", uint16(serverPort), false, !msg.Response, verdict)
         .       70ms    411:	record := logger.NewLogRecord(proxy.DefaultEndpointInfoRegistry, ep, flowType, false,
         .          .    412:		func(lr *logger.LogRecord) { lr.LogRecord.TransportProtocol = accesslog.TransportProtocol(protoID) },
         .          .    413:		logger.LogTags.Verdict(verdict, reason),
         .          .    414:		logger.LogTags.Addressing(logger.AddressingInfo{
         .          .    415:			SrcIPPort:   epIPPort,
         .          .    416:			DstIPPort:   serverAddr,
         .          .    417:			SrcIdentity: ep.GetIdentity().Uint32(),
         .          .    418:		}),

```

Fixes: 2935f589ab

Signed-off by: Ian Vernon <ian@cilium.io>

```release-note
Do not marshal endpoint structure into `SrcIPPort` field for each DNS logging record
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8328)
<!-- Reviewable:end -->
