### PR TITLE
cni: Avoid returning error in DEL command

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -142,30 +142,6 @@ func NewClient(host string) (*Client, error) {
 	return &Client{*clientapi.New(clientTrans, strfmt.Default)}, nil
 }
 
-// ClientError is the error returned by all client functions which use Hint()
-type ClientError struct {
-	msg         string
-	recoverable bool
-}
-
-// Recoverable returns true if the error is likely to be recoverable
-func (c ClientError) Recoverable() bool {
-	return c.recoverable
-}
-
-// Error returns the error message representing the error
-func (c ClientError) Error() string {
-	return c.msg
-}
-
-func newRecoverableError(msg string, args ...interface{}) ClientError {
-	return ClientError{recoverable: true, msg: fmt.Sprintf(msg, args...)}
-}
-
-func newUnrecoverableError(msg string, args ...interface{}) ClientError {
-	return ClientError{recoverable: false, msg: fmt.Sprintf(msg, args...)}
-}
-
 // Hint tries to improve the error message displayed to the user.
 func Hint(err error) error {
 	if err == nil {
@@ -173,14 +149,14 @@ func Hint(err error) error {
 	}
 
 	if err == context.DeadlineExceeded {
-		return newRecoverableError("Cilium API client timeout exceeded")
+		return fmt.Errorf("Cilium API client timeout exceeded")
 	}
 
 	e, _ := url.PathUnescape(err.Error())
 	if strings.Contains(err.Error(), defaults.SockPath) {
-		return newRecoverableError("%s\nIs the agent running?", e)
+		return fmt.Errorf("%s\nIs the agent running?", e)
 	}
-	return newUnrecoverableError("%s", e)
+	return fmt.Errorf("%s", e)
 }
 
 func timeSince(since time.Time) string {

--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -558,15 +558,7 @@ func cmdDel(args *skel.CmdArgs) error {
 		// DeleteEndpointIDErrors: Errors encountered while deleting,
 		//                         the endpoint is always deleted though, no
 		//                         need to retry
-		// ClientError: Various reasons, type will be ClientError and
-		//              Recoverable() will return true if error can be
-		//              retried
 		log.WithError(err).Warning("Errors encountered while deleting endpoint")
-		if clientError, ok := err.(client.ClientError); ok {
-			if clientError.Recoverable() {
-				return err
-			}
-		}
 	}
 
 	netNs, err := ns.GetNS(args.Netns)


### PR DESCRIPTION
CNI DEL operations might be never retried by the container runtime, so
it's better to clean up as much as possible and make sure that Cilium
agent is going to clean up everything after start.

Fixes: #8313

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8335)
<!-- Reviewable:end -->
