### PR TITLE
metrics: Merge `cilium_policy_l7_*` into single metric

### DIFF
--- a/Documentation/configuration/metrics.rst
+++ b/Documentation/configuration/metrics.rst
@@ -96,10 +96,11 @@ Policy L7 (HTTP/Kafka)
 
 * ``proxy_redirects``: Number of redirects installed for endpoints, labeled by protocol
 * ``proxy_upstream_reply_seconds``: Seconds waited for upstream server to reply to a request
-* ``policy_l7_parse_errors_total``: Number of total L7 parse errors
-* ``policy_l7_forwarded_total``: Number of total L7 forwarded requests/responses
-* ``policy_l7_denied_total``: Number of total L7 denied requests/responses due to policy
-* ``policy_l7_received_total``: Number of total L7 received requests/responses
+* ``policy_l7_parse_errors_total``: Number of total L7 parse errors. Deprecated. Use ``policy_l7_total`` instead.
+* ``policy_l7_forwarded_total``: Number of total L7 forwarded requests/responses. Deprecated. Use ``policy_l7_total`` instead.
+* ``policy_l7_denied_total``: Number of total L7 denied requests/responses due to policy. Deprecated. Use ``policy_l7_total`` instead.
+* ``policy_l7_received_total``: Number of total L7 received requests/responses. Deprecated. Use ``policy_l7_total`` instead.
+* ``policy_l7_total``: Number of total L7 requests/responses, tagged by received/parse_errors/forwarded/denied
 
 Identity
 --------

--- a/examples/kubernetes/addons/prometheus/templates/06-grafana-config.yaml
+++ b/examples/kubernetes/addons/prometheus/templates/06-grafana-config.yaml
@@ -4224,21 +4224,21 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(cilium_policy_l7_denied_total{kubernetes_pod_name=~\"$pod\"}[1m]))",
+              "expr": "sum(rate(cilium_policy_l7_total{rule=\"denied\", kubernetes_pod_name=~\"$pod\"}[1m]))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "denied",
               "refId": "A"
             },
             {
-              "expr": "sum(rate(cilium_policy_l7_forwarded_total{kubernetes_pod_name=~\"$pod\"}[1m]))",
+              "expr": "sum(rate(cilium_policy_l7_total{rule=\"forwarded\", kubernetes_pod_name=~\"$pod\"}[1m]))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "forwarded",
               "refId": "B"
             },
             {
-              "expr": "sum(rate(cilium_policy_l7_received_total{kubernetes_pod_name=~\"$pod\"}[1m]))",
+              "expr": "sum(rate(cilium_policy_l7_total{rule=\"received\", kubernetes_pod_name=~\"$pod\"}[1m]))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "received",
@@ -4376,7 +4376,7 @@ data:
           "aliasColors": {
             "Max per node processingTime": "#e24d42",
             "Max per node upstreamTime": "#58140c",
-            "avg(cilium_policy_l7_parse_errors_total{kubernetes_pod_name=~\"cilium.*\"})": "#bf1b00",
+            "avg(cilium_policy_l7_total{rule=\"parse_errors\", kubernetes_pod_name=~\"cilium.*\"})": "#bf1b00",
             "parse errors": "#bf1b00"
           },
           "bars": true,
@@ -4421,7 +4421,7 @@ data:
               "yaxis": 2
             },
             {
-              "alias": "avg(cilium_policy_l7_parse_errors_total{kubernetes_pod_name=~\"cilium.*\"})",
+              "alias": "avg(cilium_policy_l7_total{rule=\"parse_errors\", kubernetes_pod_name=~\"cilium.*\"})",
               "yaxis": 2
             },
             {
@@ -4442,7 +4442,7 @@ data:
               "refId": "A"
             },
             {
-              "expr": "avg(cilium_policy_l7_parse_errors_total{kubernetes_pod_name=~\"$pod\"}) by (pod)",
+              "expr": "avg(cilium_policy_l7_total{rule=\"parse_errors\", kubernetes_pod_name=~\"$pod\"}) by (pod)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "parse errors",
@@ -4758,7 +4758,7 @@ data:
               "refId": "B"
             },
             {
-              "expr": "max(rate(cilium_policy_l7_parse_errors_total{kubernetes_pod_name=~\"$pod\"}[1m])) by (pod)",
+              "expr": "max(rate(cilium_policy_l7_total{rule=\"parse_errors\", kubernetes_pod_name=~\"$pod\"}[1m])) by (pod)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "parse errors",

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1747,17 +1747,21 @@ func (e *Endpoint) UpdateProxyStatistics(l7Protocol string, port uint16, ingress
 
 	stats.Received++
 	metrics.ProxyReceived.Inc()
+	metrics.ProxyPolicyL7Total.WithLabelValues("received").Inc()
 
 	switch verdict {
 	case accesslog.VerdictForwarded:
 		stats.Forwarded++
 		metrics.ProxyForwarded.Inc()
+		metrics.ProxyPolicyL7Total.WithLabelValues("forwarded").Inc()
 	case accesslog.VerdictDenied:
 		stats.Denied++
 		metrics.ProxyDenied.Inc()
+		metrics.ProxyPolicyL7Total.WithLabelValues("denied").Inc()
 	case accesslog.VerdictError:
 		stats.Error++
 		metrics.ProxyParseErrors.Inc()
+		metrics.ProxyPolicyL7Total.WithLabelValues("parse_errors").Inc()
 	}
 }
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -239,16 +239,23 @@ var (
 	// ProxyRedirects is the number of redirects labelled by protocol
 	ProxyRedirects = NoOpGaugeVec
 
+	// ProxyPolicyL7Total is a count of all l7 requests handled by proxy
+	ProxyPolicyL7Total = NoOpCounterVec
+
 	// ProxyParseErrors is a count of failed parse errors on proxy
+	// Deprecated: in favor of ProxyPolicyL7Total
 	ProxyParseErrors = NoOpCounter
 
 	// ProxyForwarded is a count of all forwarded requests by proxy
+	// Deprecated: in favor of ProxyPolicyL7Total
 	ProxyForwarded = NoOpCounter
 
 	// ProxyDenied is a count of all denied requests by policy by the proxy
+	// Deprecated: in favor of ProxyPolicyL7Total
 	ProxyDenied = NoOpCounter
 
 	// ProxyReceived is a count of all received requests by the proxy
+	// Deprecated: in favor of ProxyPolicyL7Total
 	ProxyReceived = NoOpCounter
 
 	// ProxyUpstreamTime is how long the upstream server took to reply labeled
@@ -380,6 +387,7 @@ type Configuration struct {
 	EventTSContainerdEnabled                bool
 	EventTSAPIEnabled                       bool
 	ProxyRedirectsEnabled                   bool
+	ProxyPolicyL7Enabled                    bool
 	ProxyParseErrorsEnabled                 bool
 	ProxyForwardedEnabled                   bool
 	ProxyDeniedEnabled                      bool
@@ -429,6 +437,7 @@ func DefaultMetrics() map[string]struct{} {
 		Namespace + "_identity_count":                                             {},
 		Namespace + "_event_ts":                                                   {},
 		Namespace + "_proxy_redirects":                                            {},
+		Namespace + "_policy_l7_total":                                            {},
 		Namespace + "_policy_l7_parse_errors_total":                               {},
 		Namespace + "_policy_l7_forwarded_total":                                  {},
 		Namespace + "_policy_l7_denied_total":                                     {},
@@ -645,6 +654,16 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 
 			collectors = append(collectors, ProxyRedirects)
 			c.ProxyRedirectsEnabled = true
+
+		case Namespace + "_policy_l7_total":
+			ProxyPolicyL7Total = prometheus.NewCounterVec(prometheus.CounterOpts{
+				Namespace: Namespace,
+				Name:      "policy_l7_total",
+				Help:      "Number of total proxy requests handled",
+			}, []string{"rule"})
+
+			collectors = append(collectors, ProxyPolicyL7Total)
+			c.ProxyPolicyL7Enabled = true
 
 		case Namespace + "_policy_l7_parse_errors_total":
 			ProxyParseErrors = prometheus.NewCounter(prometheus.CounterOpts{


### PR DESCRIPTION
This commit adds the `cilium_policy_l7_total` metric tagged
with labels and deprecates the `cilium_policy_l7_*` metrics.
For example `cilium_policy_l7_denied_total` becomes
`cilium_policy_l7_total{rule="denied"}`.

Fixes #5314

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8337)
<!-- Reviewable:end -->
