### PR TITLE
cilium: encrypt subnet include node xfrm rules

### DIFF
--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -638,8 +638,11 @@ func (n *linuxNodeHandler) nodeUpdate(oldNode, newNode *node.Node, firstAddition
 
 	if n.nodeConfig.EnableIPSec && !n.subnetEncryption() {
 		n.enableIPsec(newNode)
-		n.encryptNode(newNode)
 		newKey = newNode.EncryptionKey
+	}
+
+	if n.nodeConfig.EnableIPSec {
+		n.encryptNode(newNode)
 	}
 
 	if newNode.IsLocal() {
@@ -649,7 +652,6 @@ func (n *linuxNodeHandler) nodeUpdate(oldNode, newNode *node.Node, firstAddition
 		}
 		if n.subnetEncryption() {
 			n.enableSubnetIPsec(n.nodeConfig.IPv4PodSubnets, n.nodeConfig.IPv6PodSubnets)
-			n.encryptNode(newNode)
 		}
 		return nil
 	}


### PR DESCRIPTION
For node-to-node and node-to-pod traffic to be encrypted we include
a xfrm rule in the state/policy tables to match the node IPs. This
was only being called when subnet mode was disabled.

To get subnet mode to encrypt node-to-node and node-to-pod traffic
ensure we setup xfrm rules for all modes.

Fixes: 47bd875512770 ("cilium: encrypt, use ipcache to lookup IPsec destination IP")
Signed-off-by: John Fastabend <john.fastabend@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8338)
<!-- Reviewable:end -->
