### PR TITLE
Move owner and regeneration context to their own package

### DIFF
--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpoint/connector"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	healthPkg "github.com/cilium/cilium/pkg/health/client"
 	healthDefaults "github.com/cilium/cilium/pkg/health/defaults"
@@ -192,7 +193,7 @@ func CleanupEndpoint() {
 //
 // CleanupEndpoint() must be called before calling LaunchAsEndpoint() to ensure
 // cleanup of prior cilium-health endpoint instances.
-func LaunchAsEndpoint(baseCtx context.Context, owner endpoint.Owner, n *node.Node, mtuConfig mtu.Configuration) (*Client, error) {
+func LaunchAsEndpoint(baseCtx context.Context, owner regeneration.Owner, n *node.Node, mtuConfig mtu.Configuration) (*Client, error) {
 	var (
 		cmd  = launcher.Launcher{}
 		info = &models.EndpointChangeRequest{

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpoint/connector"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/fqdn"
 	"github.com/cilium/cilium/pkg/identity"
@@ -1003,9 +1004,9 @@ func (d *Daemon) TriggerReloadWithoutCompile(reason string) (*sync.WaitGroup, er
 		return nil, fmt.Errorf("Unable to recompile base programs from %s: %s", reason, err)
 	}
 
-	regenRequest := &endpoint.ExternalRegenerationMetadata{
+	regenRequest := &regeneration.ExternalRegenerationMetadata{
 		Reason:            reason,
-		RegenerationLevel: endpoint.RegenerateWithDatapathLoad,
+		RegenerationLevel: regeneration.RegenerateWithDatapathLoad,
 	}
 	return endpointmanager.RegenerateAllEndpoints(d, regenRequest), nil
 }

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/endpoint"
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/labels"
@@ -290,7 +291,7 @@ func (d *Daemon) createEndpoint(ctx context.Context, epTemplate *models.Endpoint
 		// is executed; if we waited for regeneration to be complete, including
 		// proxy configuration, this code would effectively deadlock addition
 		// of endpoints.
-		ep.Regenerate(d, &endpoint.ExternalRegenerationMetadata{
+		ep.Regenerate(d, &regeneration.ExternalRegenerationMetadata{
 			Reason:        "Initial build on endpoint creation",
 			ParentContext: ctx,
 		})

--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/api/v1/server/restapi/policy"
 	"github.com/cilium/cilium/pkg/api"
-	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/eventqueue"
 	"github.com/cilium/cilium/pkg/identity/cache"
@@ -51,7 +51,7 @@ func (d *Daemon) policyUpdateTrigger(reasons []string) {
 	log.Debugf("Regenerating all endpoints")
 	reason := strings.Join(reasons, ", ")
 
-	regenerationMetadata := &endpoint.ExternalRegenerationMetadata{Reason: reason}
+	regenerationMetadata := &regeneration.ExternalRegenerationMetadata{Reason: reason}
 	endpointmanager.RegenerateAllEndpoints(d, regenerationMetadata)
 }
 
@@ -453,7 +453,7 @@ func (d *Daemon) ReactToRuleUpdates(wg *sync.WaitGroup, epsToBumpRevision *polic
 
 	epsToRegen.Mutex.RLock()
 	// Regenerate all other endpoints.
-	endpointmanager.RegenerateEndpointSetSignalWhenEnqueued(d, &endpoint.ExternalRegenerationMetadata{Reason: "policy rules added"}, epsToRegen.IDs, &enqueueWaitGroup)
+	endpointmanager.RegenerateEndpointSetSignalWhenEnqueued(d, &regeneration.ExternalRegenerationMetadata{Reason: "policy rules added"}, epsToRegen.IDs, &enqueueWaitGroup)
 	epsToRegen.Mutex.RUnlock()
 
 	enqueueWaitGroup.Wait()

--- a/daemon/policy_test.go
+++ b/daemon/policy_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cilium/cilium/common/addressing"
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/labels"
@@ -56,7 +57,7 @@ var (
 
 	testEndpointID = uint16(1)
 
-	regenerationMetadata = &endpoint.ExternalRegenerationMetadata{
+	regenerationMetadata = &regeneration.ExternalRegenerationMetadata{
 		Reason: "test",
 	}
 

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/ipcache"
@@ -360,7 +361,7 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) (resto
 				epRegenerated <- false
 				return
 			}
-			regenerationMetadata := &endpoint.ExternalRegenerationMetadata{
+			regenerationMetadata := &regeneration.ExternalRegenerationMetadata{
 				Reason: "syncing state to host",
 			}
 			if buildSuccess := <-ep.Regenerate(d, regenerationMetadata); !buildSuccess {

--- a/daemon/state_test.go
+++ b/daemon/state_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cilium/cilium/pkg/completion"
 	linuxDatapath "github.com/cilium/cilium/pkg/datapath/linux"
 	e "github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	"github.com/cilium/cilium/pkg/labels"
@@ -145,12 +146,12 @@ func (ds *DaemonSuite) generateEPs(baseDir string, epsWanted []*e.Endpoint, epsM
 		return nil
 	}
 
-	ds.OnUpdateNetworkPolicy = func(e *e.Endpoint, policy *policy.L4Policy,
+	ds.OnUpdateNetworkPolicy = func(e regeneration.EndpointUpdater, policy *policy.L4Policy,
 		proxyWaitGroup *completion.WaitGroup) (error, revert.RevertFunc) {
 		return nil, nil
 	}
 
-	ds.OnRemoveNetworkPolicy = func(e *e.Endpoint) {}
+	ds.OnRemoveNetworkPolicy = func(e regeneration.EndpointInfoSource) {}
 
 	// Since all owner's funcs are implemented we can regenerate every endpoint.
 	epsNames := []string{}

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -128,7 +128,7 @@ func (e *Endpoint) writeInformationalComments(w io.Writer) error {
 	return fw.Flush()
 }
 
-func (e *Endpoint) writeHeaderfile(prefix string, owner Owner) error {
+func (e *Endpoint) writeHeaderfile(prefix string, owner regeneration.Owner) error {
 	headerPath := filepath.Join(prefix, common.CHeaderFileName)
 	e.getLogger().WithFields(logrus.Fields{
 		logfields.Path: headerPath,
@@ -150,7 +150,7 @@ func (e *Endpoint) writeHeaderfile(prefix string, owner Owner) error {
 // writing. On success, returns nil; otherwise, returns an error  indicating the
 // problem that occurred while adding an l7 redirect for the specified policy.
 // Must be called with endpoint.Mutex held.
-func (e *Endpoint) addNewRedirectsFromMap(owner Owner, m policy.L4PolicyMap, desiredRedirects map[string]bool, proxyWaitGroup *completion.WaitGroup) (error, revert.FinalizeFunc, revert.RevertFunc) {
+func (e *Endpoint) addNewRedirectsFromMap(owner regeneration.Owner, m policy.L4PolicyMap, desiredRedirects map[string]bool, proxyWaitGroup *completion.WaitGroup) (error, revert.FinalizeFunc, revert.RevertFunc) {
 	if option.Config.DryMode {
 		return nil, nil, nil
 	}
@@ -253,7 +253,7 @@ func (e *Endpoint) addNewRedirectsFromMap(owner Owner, m policy.L4PolicyMap, des
 // The returned map contains the exact set of IDs of proxy redirects that is
 // required to implement the given L4 policy.
 // Must be called with endpoint.Mutex held.
-func (e *Endpoint) addNewRedirects(owner Owner, m *policy.L4Policy, proxyWaitGroup *completion.WaitGroup) (desiredRedirects map[string]bool, err error, finalizeFunc revert.FinalizeFunc, revertFunc revert.RevertFunc) {
+func (e *Endpoint) addNewRedirects(owner regeneration.Owner, m *policy.L4Policy, proxyWaitGroup *completion.WaitGroup) (desiredRedirects map[string]bool, err error, finalizeFunc revert.FinalizeFunc, revertFunc revert.RevertFunc) {
 	desiredRedirects = make(map[string]bool)
 	var finalizeList revert.FinalizeList
 	var revertStack revert.RevertStack
@@ -288,7 +288,7 @@ func (e *Endpoint) addNewRedirects(owner Owner, m *policy.L4Policy, proxyWaitGro
 }
 
 // Must be called with endpoint.Mutex held.
-func (e *Endpoint) removeOldRedirects(owner Owner, desiredRedirects map[string]bool, proxyWaitGroup *completion.WaitGroup) (revert.FinalizeFunc, revert.RevertFunc) {
+func (e *Endpoint) removeOldRedirects(owner regeneration.Owner, desiredRedirects map[string]bool, proxyWaitGroup *completion.WaitGroup) (revert.FinalizeFunc, revert.RevertFunc) {
 	if option.Config.DryMode {
 		return nil, nil
 	}
@@ -366,7 +366,7 @@ func (e *Endpoint) removeOldRedirects(owner Owner, desiredRedirects map[string]b
 // Must be called with endpoint.Mutex not held and endpoint.BuildMutex held.
 // Returns the policy revision number when the regeneration has called, a
 // boolean if the BPF compilation was executed and an error in case of an error.
-func (e *Endpoint) regenerateBPF(owner Owner, regenContext *regenerationContext) (revnum uint64, compiled bool, reterr error) {
+func (e *Endpoint) regenerateBPF(owner regeneration.Owner, regenContext *regenerationContext) (revnum uint64, compiled bool, reterr error) {
 	var (
 		err                 error
 		compilationExecuted bool
@@ -528,7 +528,7 @@ func (e *Endpoint) realizeBPFState(regenContext *regenerationContext) (compilati
 // runPreCompilationSteps runs all of the regeneration steps that are necessary
 // right before compiling the BPF for the given endpoint.
 // The endpoint mutex must not be held.
-func (e *Endpoint) runPreCompilationSteps(owner Owner, regenContext *regenerationContext) (preCompilationError error) {
+func (e *Endpoint) runPreCompilationSteps(owner regeneration.Owner, regenContext *regenerationContext) (preCompilationError error) {
 	stats := &regenContext.Stats
 	datapathRegenCtxt := regenContext.datapathRegenerationContext
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1166,7 +1166,7 @@ func (e UpdateStateChangeError) Error() string { return e.msg }
 // if there was an issue triggering policy updates for the given endpoint,
 // or if endpoint regeneration was unable to be triggered. Note that the
 // LabelConfiguration in the EndpointConfigurationSpec is *not* consumed here.
-func (e *Endpoint) Update(owner Owner, cfg *models.EndpointConfigurationSpec) error {
+func (e *Endpoint) Update(owner regeneration.Owner, cfg *models.EndpointConfigurationSpec) error {
 	om, err := EndpointMutableOptionLibrary.ValidateConfigurationMap(cfg.Options)
 	if err != nil {
 		return UpdateValidationError{err.Error()}
@@ -1316,7 +1316,7 @@ type DeleteConfig struct {
 // endpoints which failed to be restored. Any cleanup routine of LeaveLocked()
 // which depends on kvstore connectivity must be protected by a flag in
 // DeleteConfig and the restore logic must opt-out of it.
-func (e *Endpoint) LeaveLocked(owner Owner, proxyWaitGroup *completion.WaitGroup, conf DeleteConfig) []error {
+func (e *Endpoint) LeaveLocked(owner regeneration.Owner, proxyWaitGroup *completion.WaitGroup, conf DeleteConfig) []error {
 	errors := []error{}
 
 	loader.Unload(e.createEpInfoCache(""))
@@ -1374,7 +1374,7 @@ func (e *Endpoint) LeaveLocked(owner Owner, proxyWaitGroup *completion.WaitGroup
 
 // RegenerateWait should only be called when endpoint's state has successfully
 // been changed to "waiting-to-regenerate"
-func (e *Endpoint) RegenerateWait(owner Owner, reason string) error {
+func (e *Endpoint) RegenerateWait(owner regeneration.Owner, reason string) error {
 	if !<-e.Regenerate(owner, &regeneration.ExternalRegenerationMetadata{Reason: reason}) {
 		return fmt.Errorf("error while regenerating endpoint."+
 			" For more info run: 'cilium endpoint get %d'", e.ID)
@@ -1790,7 +1790,7 @@ func (e *Endpoint) getIDandLabels() string {
 // Labels can be added or deleted. If a label change is performed, the
 // endpoint will receive a new identity and will be regenerated. Both of these
 // operations will happen in the background.
-func (e *Endpoint) ModifyIdentityLabels(owner Owner, addLabels, delLabels pkgLabels.Labels) error {
+func (e *Endpoint) ModifyIdentityLabels(owner regeneration.Owner, addLabels, delLabels pkgLabels.Labels) error {
 	if err := e.LockAlive(); err != nil {
 		return err
 	}
@@ -1833,7 +1833,7 @@ func (e *Endpoint) IsInit() bool {
 // If a net label changed was performed, the endpoint will receive a new
 // identity and will be regenerated. Both of these operations will happen in
 // the background.
-func (e *Endpoint) UpdateLabels(ctx context.Context, owner Owner, identityLabels, infoLabels pkgLabels.Labels, blocking bool) {
+func (e *Endpoint) UpdateLabels(ctx context.Context, owner regeneration.Owner, identityLabels, infoLabels pkgLabels.Labels, blocking bool) {
 	log.WithFields(logrus.Fields{
 		logfields.ContainerID:    e.GetShortContainerID(),
 		logfields.EndpointID:     e.StringID(),
@@ -1866,7 +1866,7 @@ func (e *Endpoint) identityResolutionIsObsolete(myChangeRev int) bool {
 }
 
 // Must be called with e.Mutex NOT held.
-func (e *Endpoint) runLabelsResolver(ctx context.Context, owner Owner, myChangeRev int, blocking bool) {
+func (e *Endpoint) runLabelsResolver(ctx context.Context, owner regeneration.Owner, myChangeRev int, blocking bool) {
 	if err := e.RLockAlive(); err != nil {
 		// If a labels update and an endpoint delete API request arrive
 		// in quick succession, this could occur; in that case, there's
@@ -1916,7 +1916,7 @@ func (e *Endpoint) runLabelsResolver(ctx context.Context, owner Owner, myChangeR
 	)
 }
 
-func (e *Endpoint) identityLabelsChanged(ctx context.Context, owner Owner, myChangeRev int) error {
+func (e *Endpoint) identityLabelsChanged(ctx context.Context, owner regeneration.Owner, myChangeRev int) error {
 	if err := e.RLockAlive(); err != nil {
 		return ErrNotAlive
 	}
@@ -2202,7 +2202,7 @@ func (e *Endpoint) PinDatapathMap() error {
 	return err
 }
 
-func (e *Endpoint) syncEndpointHeaderFile(owner Owner, reasons []string) {
+func (e *Endpoint) syncEndpointHeaderFile(owner regeneration.Owner, reasons []string) {
 	e.BuildMutex.Lock()
 	defer e.BuildMutex.Unlock()
 
@@ -2221,7 +2221,7 @@ func (e *Endpoint) syncEndpointHeaderFile(owner Owner, reasons []string) {
 
 // SyncEndpointHeaderFile it bumps the current DNS History information for the
 // endpoint in the lxc_config.h file.
-func (e *Endpoint) SyncEndpointHeaderFile(owner Owner) error {
+func (e *Endpoint) SyncEndpointHeaderFile(owner regeneration.Owner) error {
 	if err := e.LockAlive(); err != nil {
 		// endpoint was removed in the meanwhile, return
 		return nil

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/datapath/loader"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/eventqueue"
 	"github.com/cilium/cilium/pkg/fqdn"
 	identityPkg "github.com/cilium/cilium/pkg/identity"
@@ -1182,20 +1183,20 @@ func (e *Endpoint) Update(owner Owner, cfg *models.EndpointConfigurationSpec) er
 	// succeeding.
 	// Note: This "retry" behaviour is better suited to a controller, and can be
 	// moved there once we have an endpoint regeneration controller.
-	regenCtx := &ExternalRegenerationMetadata{
+	regenCtx := &regeneration.ExternalRegenerationMetadata{
 		Reason: "endpoint was updated via API",
 	}
 
 	// If configuration options are provided, we only regenerate if necessary.
 	// Otherwise always regenerate.
 	if cfg.Options == nil {
-		regenCtx.RegenerationLevel = RegenerateWithDatapathRebuild
+		regenCtx.RegenerationLevel = regeneration.RegenerateWithDatapathRebuild
 		regenCtx.Reason = "endpoint was manually regenerated via API"
 	} else if e.updateAndOverrideEndpointOptions(om) || e.Status.CurrentStatus() != OK {
-		regenCtx.RegenerationLevel = RegenerateWithDatapathRewrite
+		regenCtx.RegenerationLevel = regeneration.RegenerateWithDatapathRewrite
 	}
 
-	if regenCtx.RegenerationLevel > RegenerateWithoutDatapath {
+	if regenCtx.RegenerationLevel > regeneration.RegenerateWithoutDatapath {
 		e.getLogger().Debug("need to regenerate endpoint; checking state before" +
 			" attempting to regenerate")
 
@@ -1374,7 +1375,7 @@ func (e *Endpoint) LeaveLocked(owner Owner, proxyWaitGroup *completion.WaitGroup
 // RegenerateWait should only be called when endpoint's state has successfully
 // been changed to "waiting-to-regenerate"
 func (e *Endpoint) RegenerateWait(owner Owner, reason string) error {
-	if !<-e.Regenerate(owner, &ExternalRegenerationMetadata{Reason: reason}) {
+	if !<-e.Regenerate(owner, &regeneration.ExternalRegenerationMetadata{Reason: reason}) {
 		return fmt.Errorf("error while regenerating endpoint."+
 			" For more info run: 'cilium endpoint get %d'", e.ID)
 	}
@@ -2050,7 +2051,7 @@ func (e *Endpoint) identityLabelsChanged(ctx context.Context, owner Owner, myCha
 	e.Unlock()
 
 	if readyToRegenerate {
-		e.Regenerate(owner, &ExternalRegenerationMetadata{Reason: "updated security labels"})
+		e.Regenerate(owner, &regeneration.ExternalRegenerationMetadata{Reason: "updated security labels"})
 	}
 
 	return nil

--- a/pkg/endpoint/events.go
+++ b/pkg/endpoint/events.go
@@ -15,12 +15,13 @@
 package endpoint
 
 import (
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/eventqueue"
 )
 
 // EndpointRegenerationEvent contains all fields necessary to regenerate an endpoint.
 type EndpointRegenerationEvent struct {
-	owner        Owner
+	owner        regeneration.Owner
 	regenContext *regenerationContext
 	ep           *Endpoint
 }

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -63,7 +63,7 @@ func (e *Endpoint) LookupRedirectPort(l4Filter *policy.L4Filter) uint16 {
 
 // Note that this function assumes that endpoint policy has already been generated!
 // must be called with endpoint.Mutex held for reading
-func (e *Endpoint) updateNetworkPolicy(owner Owner, proxyWaitGroup *completion.WaitGroup) (reterr error, revertFunc revert.RevertFunc) {
+func (e *Endpoint) updateNetworkPolicy(owner regeneration.Owner, proxyWaitGroup *completion.WaitGroup) (reterr error, revertFunc revert.RevertFunc) {
 	// Skip updating the NetworkPolicy if no identity has been computed for this
 	// endpoint.
 	// This breaks a circular dependency between configuring NetworkPolicies in
@@ -93,7 +93,7 @@ func (e *Endpoint) setNextPolicyRevision(revision uint64) {
 }
 
 // regeneratePolicy computes the policy for the given endpoint based off of the
-// rules in Owner's policy repository.
+// rules in regeneration.Owner's policy repository.
 //
 // Policy generation may fail, and in that case we exit before actually changing
 // the policy in any way, so that the last policy remains fully in effect if the
@@ -106,7 +106,7 @@ func (e *Endpoint) setNextPolicyRevision(revision uint64) {
 // policy could not be generated given the current set of rules in the
 // repository.
 // Must be called with endpoint mutex held.
-func (e *Endpoint) regeneratePolicy(owner Owner) (retErr error) {
+func (e *Endpoint) regeneratePolicy(owner regeneration.Owner) (retErr error) {
 	var forceRegeneration bool
 
 	// No point in calculating policy if endpoint does not have an identity yet.
@@ -240,7 +240,7 @@ func (e *Endpoint) updateAndOverrideEndpointOptions(opts option.OptionMap) (opts
 }
 
 // Called with e.Mutex UNlocked
-func (e *Endpoint) regenerate(owner Owner, context *regenerationContext) (retErr error) {
+func (e *Endpoint) regenerate(owner regeneration.Owner, context *regenerationContext) (retErr error) {
 	var revision uint64
 	var compilationExecuted bool
 	var err error
@@ -428,7 +428,7 @@ func (e *Endpoint) updateRegenerationStatistics(context *regenerationContext, er
 // Regenerate forces the regeneration of endpoint programs & policy
 // Should only be called with e.state == StateWaitingToRegenerate or with
 // e.state == StateWaitingForIdentity
-func (e *Endpoint) Regenerate(owner Owner, regenMetadata *regeneration.ExternalRegenerationMetadata) <-chan bool {
+func (e *Endpoint) Regenerate(owner regeneration.Owner, regenMetadata *regeneration.ExternalRegenerationMetadata) <-chan bool {
 	done := make(chan bool, 1)
 
 	var (
@@ -487,7 +487,7 @@ func (e *Endpoint) Regenerate(owner Owner, regenMetadata *regeneration.ExternalR
 	return done
 }
 
-func (e *Endpoint) notifyEndpointRegeneration(owner Owner, err error) {
+func (e *Endpoint) notifyEndpointRegeneration(owner regeneration.Owner, err error) {
 	repr, reprerr := monitorAPI.EndpointRegenRepr(e, err)
 	if reprerr != nil {
 		e.getLogger().WithError(reprerr).Warn("Notifying monitor about endpoint regeneration failed")

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/controller"
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/eventqueue"
 	identityPkg "github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
@@ -427,7 +428,7 @@ func (e *Endpoint) updateRegenerationStatistics(context *regenerationContext, er
 // Regenerate forces the regeneration of endpoint programs & policy
 // Should only be called with e.state == StateWaitingToRegenerate or with
 // e.state == StateWaitingForIdentity
-func (e *Endpoint) Regenerate(owner Owner, regenMetadata *ExternalRegenerationMetadata) <-chan bool {
+func (e *Endpoint) Regenerate(owner Owner, regenMetadata *regeneration.ExternalRegenerationMetadata) <-chan bool {
 	done := make(chan bool, 1)
 
 	var (
@@ -441,7 +442,7 @@ func (e *Endpoint) Regenerate(owner Owner, regenMetadata *ExternalRegenerationMe
 		ctx, cFunc = context.WithCancel(context.Background())
 	}
 
-	regenContext := regenMetadata.toRegenerationContext(ctx, cFunc)
+	regenContext := ParseExternalRegenerationMetadata(ctx, cFunc, regenMetadata)
 
 	epEvent := eventqueue.NewEvent(&EndpointRegenerationEvent{
 		owner:        owner,

--- a/pkg/endpoint/regeneration/regeneration_context.go
+++ b/pkg/endpoint/regeneration/regeneration_context.go
@@ -1,0 +1,69 @@
+// Copyright 2016-2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package regeneration
+
+import (
+	"context"
+)
+
+// DatapathRegenerationLevel determines what is expected of the datapath when
+// a regeneration event is processed.
+type DatapathRegenerationLevel int
+
+const (
+	// RegenerateWithoutDatapath indicates that datapath rebuild or reload
+	// is not required to implement this regeneration.
+	RegenerateWithoutDatapath DatapathRegenerationLevel = iota
+	// RegenerateWithDatapathLoad indicates that the datapath must be
+	// reloaded but not recompiled to implement this regeneration.
+	RegenerateWithDatapathLoad
+	// RegenerateWithDatapathRewrite indicates that the datapath must be
+	// recompiled and reloaded to implement this regeneration.
+	RegenerateWithDatapathRewrite
+	// RegenerateWithDatapathRebuild indicates that the datapath must be
+	// fully recompiled and reloaded without using any cached templates.
+	RegenerateWithDatapathRebuild
+)
+
+// String converts a DatapathRegenerationLevel into a human-readable string.
+func (r DatapathRegenerationLevel) String() string {
+	switch r {
+	case RegenerateWithoutDatapath:
+		return "no-rebuild"
+	case RegenerateWithDatapathLoad:
+		return "reload"
+	case RegenerateWithDatapathRewrite:
+		return "rewrite+load"
+	case RegenerateWithDatapathRebuild:
+		return "compile+load"
+	default:
+		break
+	}
+	return "BUG: Unknown DatapathRegenerationLevel"
+}
+
+// ExternalRegenerationMetadata contains any information about a regeneration that
+// the endpoint subsystem should be made aware of for a given endpoint.
+type ExternalRegenerationMetadata struct {
+	// Reason provides context to source for the regeneration, which is
+	// used to generate useful log messages.
+	Reason string
+
+	// RegenerationLevel forces datapath regeneration according to the
+	// levels defined in the DatapathRegenerationLevel description.
+	RegenerationLevel DatapathRegenerationLevel
+
+	ParentContext context.Context
+}

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -20,13 +20,14 @@ import (
 	"strings"
 
 	"github.com/cilium/cilium/common"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/sirupsen/logrus"
 )
 
 // ReadEPsFromDirNames returns a mapping of endpoint ID to endpoint of endpoints
 // from a list of directory names that can possible contain an endpoint.
-func ReadEPsFromDirNames(owner Owner, basePath string, eptsDirNames []string) map[uint16]*Endpoint {
+func ReadEPsFromDirNames(owner regeneration.Owner, basePath string, eptsDirNames []string) map[uint16]*Endpoint {
 	possibleEPs := map[uint16]*Endpoint{}
 	for _, epDirName := range eptsDirNames {
 		epDir := filepath.Join(basePath, epDirName)

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -396,7 +396,7 @@ func updateReferences(ep *endpoint.Endpoint) {
 // list is locked and cannot be modified.
 // Returns a waiting group that can be used to know when all the endpoints are
 // regenerated.
-func RegenerateAllEndpoints(owner endpoint.Owner, regenMetadata *regeneration.ExternalRegenerationMetadata) *sync.WaitGroup {
+func RegenerateAllEndpoints(owner regeneration.Owner, regenMetadata *regeneration.ExternalRegenerationMetadata) *sync.WaitGroup {
 	var wg sync.WaitGroup
 
 	eps := GetEndpoints()
@@ -410,7 +410,7 @@ func RegenerateAllEndpoints(owner endpoint.Owner, regenMetadata *regeneration.Ex
 	return &wg
 }
 
-func regenerateEndpointBlocking(owner endpoint.Owner, ep *endpoint.Endpoint, regenMetadata *regeneration.ExternalRegenerationMetadata, wg *sync.WaitGroup) {
+func regenerateEndpointBlocking(owner regeneration.Owner, ep *endpoint.Endpoint, regenMetadata *regeneration.ExternalRegenerationMetadata, wg *sync.WaitGroup) {
 	if err := ep.LockAlive(); err != nil {
 		log.WithError(err).Warnf("Endpoint disappeared while queued to be regenerated: %s", regenMetadata.Reason)
 		ep.LogStatus(endpoint.Policy, endpoint.Failure, "Error while handling policy updates for endpoint: "+err.Error())
@@ -433,7 +433,7 @@ func regenerateEndpointBlocking(owner endpoint.Owner, ep *endpoint.Endpoint, reg
 	wg.Done()
 }
 
-func regenerateEndpointNonBlocking(owner endpoint.Owner, ep *endpoint.Endpoint, regenMetadata *regeneration.ExternalRegenerationMetadata) {
+func regenerateEndpointNonBlocking(owner regeneration.Owner, ep *endpoint.Endpoint, regenMetadata *regeneration.ExternalRegenerationMetadata) {
 	if err := ep.LockAlive(); err != nil {
 		log.WithError(err).Warnf("Endpoint disappeared while queued to be regenerated: %s", regenMetadata.Reason)
 		ep.LogStatus(endpoint.Policy, endpoint.Failure, "Error while handling policy updates for endpoint: "+err.Error())
@@ -450,7 +450,7 @@ func regenerateEndpointNonBlocking(owner endpoint.Owner, ep *endpoint.Endpoint, 
 // RegenerateEndpointSetSignalWhenEnqueued regenerates the endpoints represented
 // by endpointIDs. It signals to the provided WaitGroup when all of the endpoints
 // in said set have had regenerations queued up.
-func RegenerateEndpointSetSignalWhenEnqueued(owner endpoint.Owner, regenMetadata *regeneration.ExternalRegenerationMetadata, endpointIDs map[uint16]struct{}, wg *sync.WaitGroup) {
+func RegenerateEndpointSetSignalWhenEnqueued(owner regeneration.Owner, regenMetadata *regeneration.ExternalRegenerationMetadata, endpointIDs map[uint16]struct{}, wg *sync.WaitGroup) {
 
 	for endpointID := range endpointIDs {
 		ep := endpoints[endpointID]
@@ -489,7 +489,7 @@ func GetEndpoints() []*endpoint.Endpoint {
 }
 
 // AddEndpoint takes the prepared endpoint object and starts managing it.
-func AddEndpoint(owner endpoint.Owner, ep *endpoint.Endpoint, reason string) (err error) {
+func AddEndpoint(owner regeneration.Owner, ep *endpoint.Endpoint, reason string) (err error) {
 	alwaysEnforce := policy.GetPolicyEnabled() == option.AlwaysEnforce
 	ep.SetDesiredIngressPolicyEnabled(alwaysEnforce)
 	ep.SetDesiredEgressPolicyEnabled(alwaysEnforce)

--- a/pkg/proxy/logger/epinfo.go
+++ b/pkg/proxy/logger/epinfo.go
@@ -18,6 +18,7 @@ import (
 	"net"
 
 	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 )
 
@@ -34,6 +35,9 @@ type EndpointInfoSource interface {
 	GetLabelsSHA() string
 	HasSidecarProxy() bool
 	ConntrackName() string
+	GetIngressPolicyEnabledLocked() bool
+	GetEgressPolicyEnabledLocked() bool
+	ProxyID(l4 *policy.L4Filter) string
 }
 
 // getEndpointInfo returns a consistent snapshot of the given source.

--- a/pkg/proxy/mock_test.go
+++ b/pkg/proxy/mock_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Authors of Cilium
+// Copyright 2017-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 )
 
@@ -40,7 +41,10 @@ func (m *proxyUpdaterMock) GetID() uint64                         { return m.id 
 func (m *proxyUpdaterMock) GetIPv4Address() string                { return m.ipv4 }
 func (m *proxyUpdaterMock) GetIPv6Address() string                { return m.ipv6 }
 func (m *proxyUpdaterMock) GetLabels() []string                   { return m.labels }
+func (m *proxyUpdaterMock) GetEgressPolicyEnabledLocked() bool    { return true }
+func (m *proxyUpdaterMock) GetIngressPolicyEnabledLocked() bool   { return true }
 func (m *proxyUpdaterMock) GetIdentity() identity.NumericIdentity { return m.identity }
+func (m *proxyUpdaterMock) ProxyID(l4 *policy.L4Filter) string    { return "" }
 func (m *proxyUpdaterMock) GetLabelsSHA() string {
 	return labels.NewLabelsFromModel(m.labels).SHA256Sum()
 }

--- a/pkg/workloads/runtimes.go
+++ b/pkg/workloads/runtimes.go
@@ -22,11 +22,12 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 )
 
 // WorkloadOwner is the interface that the owner of workloads must implement.
 type WorkloadOwner interface {
-	endpoint.Owner
+	regeneration.Owner
 
 	// DeleteEndpoint is called when the underlying workload has died
 	DeleteEndpoint(id string) (int, error)


### PR DESCRIPTION
This PR does not add any functionality, I was just doing some work and I already had implemented this locally. Unfortunately I end up *not* need for these commits so it's a matter of the team to accept it or not. I'm fine either case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8339)
<!-- Reviewable:end -->
