### PR TITLE
Policy scalabilty improvements

### DIFF
--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -306,17 +306,11 @@ func (d *Daemon) policyAdd(sourceRules policyAPI.Rules, opts *AddOptions, resCha
 
 	// Get all endpoints at the time rules were added / updated so we can figure
 	// out which endpoints to regenerate / bump policy revision.
-	allEndpoints := endpointmanager.GetEndpoints()
+	allEndpoints := endpointmanager.GetPolicyEndpoints()
 
 	// Start with all endpoints to be in set for which we need to bump their
 	// revision.
-	endpointsToBumpRevision := policy.NewEndpointSet(len(allEndpoints))
-
-	// Need to explicitly convert endpoints to policy.Endpoint.
-	// See: https://github.com/golang/go/wiki/InterfaceSlice
-	for i := range allEndpoints {
-		endpointsToBumpRevision.Insert(allEndpoints[i])
-	}
+	endpointsToBumpRevision := policy.NewEndpointSet(allEndpoints)
 
 	endpointsToRegen := policy.NewIDSet()
 
@@ -535,14 +529,10 @@ func (d *Daemon) policyDelete(labels labels.LabelArray, res chan interface{}) {
 
 	// Get all endpoints at the time rules were added / updated so we can figure
 	// out which endpoints to regenerate / bump policy revision.
-	allEndpoints := endpointmanager.GetEndpoints()
-	epsToBumpRevision := policy.NewEndpointSet(len(allEndpoints))
-
+	allEndpoints := endpointmanager.GetPolicyEndpoints()
 	// Initially keep all endpoints in set of endpoints which need to have
 	// revision bumped.
-	for i := range allEndpoints {
-		epsToBumpRevision.Insert(allEndpoints[i])
-	}
+	epsToBumpRevision := policy.NewEndpointSet(allEndpoints)
 
 	endpointsToRegen := policy.NewIDSet()
 

--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -456,9 +456,10 @@ func (d *Daemon) ReactToRuleUpdates(wg *sync.WaitGroup, epsToBumpRevision *polic
 
 	epsToRegen.Mutex.RLock()
 	// Regenerate all other endpoints.
-	endpointmanager.RegenerateEndpointSetSignalWhenEnqueued(d, &regeneration.ExternalRegenerationMetadata{Reason: "policy rules added"}, epsToRegen.IDs, &enqueueWaitGroup)
+	endpointRegen := endpointmanager.RegenerateEndpointSet(d, &regeneration.ExternalRegenerationMetadata{Reason: "policy rules added"}, epsToRegen.IDs)
 	epsToRegen.Mutex.RUnlock()
 
+	endpointRegen.Wait()
 	enqueueWaitGroup.Wait()
 }
 

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -443,22 +443,6 @@ func (e *Endpoint) RegenerateIfAlive(owner regeneration.Owner, regenMetadata *re
 	return ch
 }
 
-// RegenerateASync regenerates the endpoint asynchronously and signalizes the given waitGroup
-// once the endpoint regeneration is completed.
-func (e *Endpoint) RegenerateASync(owner regeneration.Owner, regenMetadata *regeneration.ExternalRegenerationMetadata) {
-	if err := e.LockAlive(); err != nil {
-		log.WithError(err).Warnf("Endpoint disappeared while queued to be regenerated: %s", regenMetadata.Reason)
-		e.LogStatus(Policy, Failure, "Error while handling policy updates for endpoint: "+err.Error())
-	} else {
-		regen := e.SetStateLocked(StateWaitingToRegenerate, fmt.Sprintf("Triggering endpoint regeneration due to %s", regenMetadata.Reason))
-		e.Unlock()
-		if regen {
-			// Regenerate logs status according to the build success/failure
-			e.Regenerate(owner, regenMetadata)
-		}
-	}
-}
-
 // Regenerate forces the regeneration of endpoint programs & policy
 // Should only be called with e.state == StateWaitingToRegenerate or with
 // e.state == StateWaitingForIdentity

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -33,7 +33,6 @@ import (
 	"github.com/cilium/cilium/pkg/policy"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -411,31 +410,6 @@ func RegenerateAllEndpoints(owner regeneration.Owner, regenMetadata *regeneratio
 		}(ep)
 	}
 
-	return &wg
-}
-
-// RegenerateEndpointSet calls a SetStateLocked for each endpoint from the given
-// set 'epsToRegen' and if it still exists in the list of endpoints manager it
-// regenerates if state transaction is valid. During this process, the endpoint
-// list is locked and cannot be modified.
-// Returns a waiting group that can be used to know when all the endpoints are
-// regenerated.
-func RegenerateEndpointSet(owner regeneration.Owner, regenMetadata *regeneration.ExternalRegenerationMetadata, epsToRegen map[uint16]struct{}) *sync.WaitGroup {
-	mutex.RLock()
-	defer mutex.RUnlock()
-
-	var wg sync.WaitGroup
-	log.WithFields(logrus.Fields{"endpoints": epsToRegen}).Infof("regenerating some endpoints due to %s", regenMetadata.Reason)
-	for epID := range epsToRegen {
-		ep := endpoints[epID]
-		if ep != nil {
-			wg.Add(1)
-			go func(ep *endpoint.Endpoint) {
-				ep.RegenerateSync(owner, regenMetadata)
-				wg.Done()
-			}(ep)
-		}
-	}
 	return &wg
 }
 

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -404,47 +404,13 @@ func RegenerateAllEndpoints(owner regeneration.Owner, regenMetadata *regeneratio
 
 	log.Infof("regenerating all endpoints due to %s", regenMetadata.Reason)
 	for _, ep := range eps {
-		go regenerateEndpointBlocking(owner, ep, regenMetadata, &wg)
+		go func(ep *endpoint.Endpoint) {
+			<-ep.RegenerateIfAlive(owner, regenMetadata)
+			wg.Done()
+		}(ep)
 	}
 
 	return &wg
-}
-
-func regenerateEndpointBlocking(owner regeneration.Owner, ep *endpoint.Endpoint, regenMetadata *regeneration.ExternalRegenerationMetadata, wg *sync.WaitGroup) {
-	if err := ep.LockAlive(); err != nil {
-		log.WithError(err).Warnf("Endpoint disappeared while queued to be regenerated: %s", regenMetadata.Reason)
-		ep.LogStatus(endpoint.Policy, endpoint.Failure, "Error while handling policy updates for endpoint: "+err.Error())
-	} else {
-		var regen bool
-		state := ep.GetStateLocked()
-		switch state {
-		case endpoint.StateRestoring, endpoint.StateWaitingToRegenerate:
-			ep.SetStateLocked(state, fmt.Sprintf("Skipped duplicate endpoint regeneration trigger due to %s", regenMetadata.Reason))
-			regen = false
-		default:
-			regen = ep.SetStateLocked(endpoint.StateWaitingToRegenerate, fmt.Sprintf("Triggering endpoint regeneration due to %s", regenMetadata.Reason))
-		}
-		ep.Unlock()
-		if regen {
-			// Regenerate logs status according to the build success/failure
-			<-ep.Regenerate(owner, regenMetadata)
-		}
-	}
-	wg.Done()
-}
-
-func regenerateEndpointNonBlocking(owner regeneration.Owner, ep *endpoint.Endpoint, regenMetadata *regeneration.ExternalRegenerationMetadata) {
-	if err := ep.LockAlive(); err != nil {
-		log.WithError(err).Warnf("Endpoint disappeared while queued to be regenerated: %s", regenMetadata.Reason)
-		ep.LogStatus(endpoint.Policy, endpoint.Failure, "Error while handling policy updates for endpoint: "+err.Error())
-	} else {
-		regen := ep.SetStateLocked(endpoint.StateWaitingToRegenerate, fmt.Sprintf("Triggering endpoint regeneration due to %s", regenMetadata.Reason))
-		ep.Unlock()
-		if regen {
-			// Regenerate logs status according to the build success/failure
-			ep.Regenerate(owner, regenMetadata)
-		}
-	}
 }
 
 // RegenerateEndpointSetSignalWhenEnqueued regenerates the endpoints represented
@@ -461,10 +427,10 @@ func RegenerateEndpointSetSignalWhenEnqueued(owner regeneration.Owner, regenMeta
 			continue
 		}
 		wg.Add(1)
-		go func() {
-			regenerateEndpointNonBlocking(owner, ep, regenMetadata)
+		go func(ep *endpoint.Endpoint) {
+			ep.RegenerateASync(owner, regenMetadata)
 			wg.Done()
-		}()
+		}(ep)
 	}
 }
 

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -461,6 +461,18 @@ func GetEndpoints() []*endpoint.Endpoint {
 	return eps
 }
 
+// GetPolicyEndpoints returns a map of all endpoints present in endpoint
+// manager as policy.Endpoint interface set for the map key.
+func GetPolicyEndpoints() map[policy.Endpoint]struct{} {
+	mutex.RLock()
+	eps := make(map[policy.Endpoint]struct{}, len(endpoints))
+	for _, ep := range endpoints {
+		eps[ep] = struct{}{}
+	}
+	mutex.RUnlock()
+	return eps
+}
+
 // AddEndpoint takes the prepared endpoint object and starts managing it.
 func AddEndpoint(owner regeneration.Owner, ep *endpoint.Endpoint, reason string) (err error) {
 	alwaysEnforce := policy.GetPolicyEnabled() == option.AlwaysEnforce

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -402,7 +403,7 @@ func RegenerateAllEndpoints(owner regeneration.Owner, regenMetadata *regeneratio
 	eps := GetEndpoints()
 	wg.Add(len(eps))
 
-	log.Infof("regenerating all endpoints due to %s", regenMetadata.Reason)
+	log.WithFields(logrus.Fields{"reason": regenMetadata.Reason}).Info("regenerating all endpoints")
 	for _, ep := range eps {
 		go func(ep *endpoint.Endpoint) {
 			<-ep.RegenerateIfAlive(owner, regenMetadata)

--- a/pkg/policy/identifier.go
+++ b/pkg/policy/identifier.go
@@ -99,8 +99,9 @@ func (e *EndpointSet) Insert(ep Endpoint) {
 }
 
 // Len returns the number of elements in the EndpointSet.
-func (e *EndpointSet) Len() int {
+func (e *EndpointSet) Len() (nElem int) {
 	e.mutex.RLock()
-	defer e.mutex.RUnlock()
-	return len(e.endpoints)
+	nElem = len(e.endpoints)
+	e.mutex.RUnlock()
+	return
 }

--- a/pkg/policy/identifier.go
+++ b/pkg/policy/identifier.go
@@ -55,11 +55,15 @@ type EndpointSet struct {
 	endpoints map[Endpoint]struct{}
 }
 
-// NewEndpointSet returns an EndpointSet with the Endpoints map allocated with
-// the specified capacity.
-func NewEndpointSet(capacity int) *EndpointSet {
+// NewEndpointSet returns an EndpointSet with the given Endpoints map
+func NewEndpointSet(m map[Endpoint]struct{}) *EndpointSet {
+	if m != nil {
+		return &EndpointSet{
+			endpoints: m,
+		}
+	}
 	return &EndpointSet{
-		endpoints: make(map[Endpoint]struct{}, capacity),
+		endpoints: map[Endpoint]struct{}{},
 	}
 }
 

--- a/pkg/policy/identifier.go
+++ b/pkg/policy/identifier.go
@@ -21,20 +21,6 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 )
 
-// IDSet is a wrapper type around a set of unsigned 16-bit integers, with
-// a mutex for protecting access.
-type IDSet struct {
-	Mutex lock.RWMutex
-	IDs   map[uint16]struct{}
-}
-
-// NewIDSet returns a new instance of an IDSet.
-func NewIDSet() *IDSet {
-	return &IDSet{
-		IDs: map[uint16]struct{}{},
-	}
-}
-
 // Endpoint refers to any structure which has the following properties:
 // * a node-local ID stored as a uint16
 // * a security identity
@@ -67,10 +53,10 @@ func NewEndpointSet(m map[Endpoint]struct{}) *EndpointSet {
 	}
 }
 
-// ForEach runs epFunc asynchronously for all endpoints in the EndpointSet. It
-// signals to the provided WaitGroup when epFunc has been executed for each
-// endpoint.
-func (e *EndpointSet) ForEach(wg *sync.WaitGroup, epFunc func(epp Endpoint)) {
+// ForEachGo runs epFunc asynchronously inside a go routine for each endpoint in
+// the EndpointSet. It signals to the provided WaitGroup when epFunc has been
+// executed for each endpoint.
+func (e *EndpointSet) ForEachGo(wg *sync.WaitGroup, epFunc func(epp Endpoint)) {
 	e.mutex.RLock()
 	defer e.mutex.RUnlock()
 

--- a/pkg/policy/identifier.go
+++ b/pkg/policy/identifier.go
@@ -67,8 +67,8 @@ func NewEndpointSet(capacity int) *EndpointSet {
 // signals to the provided WaitGroup when epFunc has been executed for each
 // endpoint.
 func (e *EndpointSet) ForEach(wg *sync.WaitGroup, epFunc func(epp Endpoint)) {
-	e.mutex.Lock()
-	defer e.mutex.Unlock()
+	e.mutex.RLock()
+	defer e.mutex.RUnlock()
 
 	wg.Add(len(e.endpoints))
 

--- a/pkg/policy/identifier_test.go
+++ b/pkg/policy/identifier_test.go
@@ -48,11 +48,10 @@ func (d *DummyEndpoint) RUnlock() {
 }
 
 func (ds *PolicyTestSuite) TestNewEndpointSet(c *C) {
-	epSet := NewEndpointSet(20)
-	c.Assert(epSet.Len(), Equals, 0)
-
 	d := &DummyEndpoint{}
-	epSet.Insert(d)
+	epSet := NewEndpointSet(map[Endpoint]struct{}{
+		d: {},
+	})
 	c.Assert(epSet.Len(), Equals, 1)
 	epSet.Delete(d)
 	c.Assert(epSet.Len(), Equals, 0)
@@ -64,9 +63,10 @@ func (ds *PolicyTestSuite) TestForEach(c *C) {
 	d0 := &DummyEndpoint{}
 	d1 := &DummyEndpoint{}
 
-	epSet := NewEndpointSet(20)
-	epSet.Insert(d0)
-	epSet.Insert(d1)
+	epSet := NewEndpointSet(map[Endpoint]struct{}{
+		d0: {},
+		d1: {},
+	})
 	epSet.ForEach(&wg, func(e Endpoint) {
 		e.PolicyRevisionBumpEvent(100)
 	})

--- a/pkg/policy/identifier_test.go
+++ b/pkg/policy/identifier_test.go
@@ -67,7 +67,7 @@ func (ds *PolicyTestSuite) TestForEach(c *C) {
 		d0: {},
 		d1: {},
 	})
-	epSet.ForEach(&wg, func(e Endpoint) {
+	epSet.ForEachGo(&wg, func(e Endpoint) {
 		e.PolicyRevisionBumpEvent(100)
 	})
 

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -379,14 +379,14 @@ func (p *Repository) AddList(rules api.Rules) (ruleSlice, uint64) {
 // the endpoints, it is added to the provided IDSet, and removed from the
 // provided EndpointSet. The provided WaitGroup is signaled for a given endpoint
 // when it is finished being processed.
-func (r ruleSlice) UpdateRulesEndpointsCaches(endpointsToBumpRevision *EndpointSet, endpointsToRegenerate *IDSet, policySelectionWG *sync.WaitGroup) {
+func (r ruleSlice) UpdateRulesEndpointsCaches(endpointsToBumpRevision, endpointsToRegenerate *EndpointSet, policySelectionWG *sync.WaitGroup) {
 	// No need to check whether endpoints need to be regenerated here since we
 	// will unconditionally regenerate all endpoints later.
 	if !option.Config.SelectiveRegeneration {
 		return
 	}
 
-	endpointsToBumpRevision.ForEach(policySelectionWG, func(epp Endpoint) {
+	endpointsToBumpRevision.ForEachGo(policySelectionWG, func(epp Endpoint) {
 		endpointSelected, err := r.updateEndpointsCaches(epp, endpointsToRegenerate)
 
 		// If we could not evaluate the rules against the current endpoint, or

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -76,12 +76,13 @@ func (ds *PolicyTestSuite) SetUpSuite(c *C) {
 	repo.selectorCache = testSelectorCache
 	rulez, _ := repo.AddList(GenerateNumRules(1000))
 
-	epSet := NewEndpointSet(5)
-
-	epSet.Insert(&dummyEndpoint{
-		ID:               9001,
-		SecurityIdentity: fooIdentity,
+	epSet := NewEndpointSet(map[Endpoint]struct{}{
+		&dummyEndpoint{
+			ID:               9001,
+			SecurityIdentity: fooIdentity,
+		}: {},
 	})
+
 	idSet := NewIDSet()
 	rulez.UpdateRulesEndpointsCaches(epSet, idSet, &wg)
 	wg.Wait()

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -83,12 +83,12 @@ func (ds *PolicyTestSuite) SetUpSuite(c *C) {
 		}: {},
 	})
 
-	idSet := NewIDSet()
-	rulez.UpdateRulesEndpointsCaches(epSet, idSet, &wg)
+	epsToRegen := NewEndpointSet(nil)
+	rulez.UpdateRulesEndpointsCaches(epSet, epsToRegen, &wg)
 	wg.Wait()
 
 	c.Assert(epSet.Len(), Equals, 0)
-	c.Assert(idSet.IDs, HasLen, 1)
+	c.Assert(epsToRegen.Len(), Equals, 1)
 }
 
 func (ds *PolicyTestSuite) TearDownSuite(c *C) {

--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -218,8 +218,8 @@ func (rules ruleSlice) updateEndpointsCaches(ep Endpoint, epSet *EndpointSet) (b
 	if err := ep.RLockAlive(); err != nil {
 		return false, fmt.Errorf("cannot update caches in rules for endpoint %d because it is being deleted: %s", id, err)
 	}
-	defer ep.RUnlock()
 	securityIdentity := ep.GetSecurityIdentity()
+	ep.RUnlock()
 
 	if securityIdentity == nil {
 		return false, fmt.Errorf("cannot update caches in rules for endpoint %d because it has a nil identity", id)

--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -207,10 +207,10 @@ func (rules ruleSlice) resolveCIDRPolicy(ctx *SearchContext) *CIDRPolicy {
 // updateEndpointsCaches iterates over a given list of rules to update the cache
 // within the rule which determines whether or not the given identity is
 // selected by that rule. If a rule in the list does select said identity, it is
-// added to epIDSet. Note that epIDSet can be shared across goroutines!
+// added to epSet. Note that epSet can be shared across goroutines!
 // Returns whether the endpoint was selected by one of the rules, or if the
 // endpoint is nil.
-func (rules ruleSlice) updateEndpointsCaches(ep Endpoint, epIDSet *IDSet) (bool, error) {
+func (rules ruleSlice) updateEndpointsCaches(ep Endpoint, epSet *EndpointSet) (bool, error) {
 	if ep == nil {
 		return false, fmt.Errorf("cannot update caches in rules because endpoint is nil")
 	}
@@ -227,11 +227,9 @@ func (rules ruleSlice) updateEndpointsCaches(ep Endpoint, epIDSet *IDSet) (bool,
 
 	for _, r := range rules {
 		if ruleMatches := r.matches(securityIdentity); ruleMatches {
-			epIDSet.Mutex.Lock()
-			epIDSet.IDs[id] = struct{}{}
-			epIDSet.Mutex.Unlock()
+			epSet.Insert(ep)
 
-			// If epIDSet is updated, we can exit since updating it again if
+			// If epSet is updated, we can exit since updating it again if
 			// another rule selects the Endpoint is a no-op.
 			return true, nil
 		}


### PR DESCRIPTION
Initially, the changes in this PR were an attempt to reduce the number of go routines being scheduled on each policy computation. While performing the attempt to reduce the number of go routines scheduled there were a couple of code refactoring needed as well as 2 bug fixes, of which we should decide if we should backport these commits or we can make a new PR to backport the bug fixes.

One of the bug fixes is accessing the `endpointIDs` variable without acquire the mutex in the `endpointmanager`:

https://github.com/cilium/cilium/blob/07ba2dcffe8dbef8d085d960d7ef4da033c3fb18/pkg/endpointmanager/manager.go#L452-L454

The 2nd bug, which I'm not sure if it is in fact a bug or a documentation typo, @ianvernon could give his input here.

https://github.com/cilium/cilium/blob/6d14ec4d1ac747b063f656e48fae76e7ef85682d/daemon/policy.go#L435-L439

The documentation states it "regenerate all endpoints in epsToRegen", however `enqueueWaitGroup` is marked as `Done()` here:
https://github.com/cilium/cilium/blob/07ba2dcffe8dbef8d085d960d7ef4da033c3fb18/pkg/endpointmanager/manager.go#L461-L464

Which means it's marked as "Done" without knowing if the endpoint was actually regenerated or not. I went with the documentation and fixed this bug so right now the `enqueueWaitGroup` is only marked as "Done" once the regeneration of that endpoint completes.

**Backport this PR to 1.5, yes or no?**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8340)
<!-- Reviewable:end -->
