### PR TITLE
v1.5 backports with CI waitDeleteCilium fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: trusty
 sudo: required
 
 go:
- - 1.12.1
+ - 1.12.5
 
 if: branch = master OR type = pull_request
 
@@ -17,6 +17,6 @@ before_install: ./.travis/prepare.sh
 
 before_script:
   - export PATH=/usr/local/clang/bin:$PATH
-  - export GO=/home/travis/.gimme/versions/go1.12.1.linux.amd64/bin/go
+  - export GO=/home/travis/.gimme/versions/go1.12.5.linux.amd64/bin/go
 
 script: ./.travis/build.sh

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -260,6 +260,7 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) (resto
 		go func(ep *endpoint.Endpoint, epRegenerated chan<- bool) {
 			if err := ep.RLockAlive(); err != nil {
 				ep.LogDisconnectedMutexAction(err, "before filtering labels during regenerating restored endpoint")
+				epRegenerated <- false
 				return
 			}
 			scopedLog := log.WithField(logfields.EndpointID, ep.ID)
@@ -271,6 +272,7 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) (resto
 			if err != nil {
 				scopedLog.WithError(err).Warn("Unable to restore endpoint")
 				epRegenerated <- false
+				return
 			}
 
 			// Wait for initial identities and ipcache from the
@@ -284,6 +286,7 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) (resto
 
 			if err := ep.LockAlive(); err != nil {
 				scopedLog.Warn("Endpoint to restore has been deleted")
+				epRegenerated <- false
 				return
 			}
 

--- a/pkg/lock/lock_debug.go
+++ b/pkg/lock/lock_debug.go
@@ -1,6 +1,4 @@
-// +build lockdebug
-
-// Copyright 2017-2018 Authors of Cilium
+// Copyright 2017-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// +build lockdebug
 
 package lock
 
@@ -75,7 +75,7 @@ func (i *internalRWMutex) UnlockIgnoreTime() {
 }
 
 func (i *internalRWMutex) RLock() {
-	i.RWMutex.Lock()
+	i.RWMutex.RLock()
 	i.t = time.Now()
 }
 
@@ -83,11 +83,11 @@ func (i *internalRWMutex) RUnlock() {
 	if sec := time.Since(i.t).Seconds(); sec >= selfishThresholdSec {
 		printStackTo(sec, debug.Stack(), os.Stderr)
 	}
-	i.RWMutex.Unlock()
+	i.RWMutex.RUnlock()
 }
 
 func (i *internalRWMutex) RUnlockIgnoreTime() {
-	i.RWMutex.Unlock()
+	i.RWMutex.RUnlock()
 }
 
 type internalMutex struct {

--- a/pkg/lock/lock_fast.go
+++ b/pkg/lock/lock_fast.go
@@ -1,6 +1,4 @@
-// +build !lockdebug
-
-// Copyright 2017 Authors of Cilium
+// Copyright 2017-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// +build !lockdebug
 
 package lock
 
@@ -29,7 +29,7 @@ func (i *internalRWMutex) UnlockIgnoreTime() {
 }
 
 func (i *internalRWMutex) RUnlockIgnoreTime() {
-	i.RWMutex.Unlock()
+	i.RWMutex.RUnlock()
 }
 
 type internalMutex struct {

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -15,6 +15,7 @@
 package k8sTest
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -38,7 +39,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 		kubectl.Exec("kubectl -n kube-system delete ds cilium")
 
-		waitToDeleteCilium(kubectl, logger)
+		Expect(waitToDeleteCilium(kubectl, logger)).To(BeNil(), "timed out deleting Cilium pods")
 	})
 
 	BeforeEach(func() {
@@ -56,7 +57,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 		// incomplete teardown.
 		_ = kubectl.DeleteResource(
 			"ds", fmt.Sprintf("-n %s cilium", helpers.KubeSystemNamespace))
-		waitToDeleteCilium(kubectl, logger)
+		Expect(waitToDeleteCilium(kubectl, logger)).To(BeNil(), "timed out deleting Cilium pods")
 	})
 
 	AfterFailed(func() {
@@ -190,15 +191,31 @@ func testPodConnectivityAcrossNodes(kubectl *helpers.Kubectl) bool {
 	return res.WasSuccessful()
 }
 
-func waitToDeleteCilium(kubectl *helpers.Kubectl, logger *logrus.Entry) {
+func waitToDeleteCilium(kubectl *helpers.Kubectl, logger *logrus.Entry) error {
+	var (
+		pods []string
+		err  error
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), helpers.HelperTimeout)
+	defer cancel()
+
 	status := 1
 	for status > 0 {
-		pods, err := kubectl.GetCiliumPods(helpers.KubeSystemNamespace)
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting to delete Cilium: pods still remaining: %s", pods)
+		default:
+		}
+
+		pods, err = kubectl.GetCiliumPodsContext(ctx, helpers.KubeSystemNamespace)
 		status := len(pods)
 		logger.Infof("Cilium pods terminating '%d' err='%v' pods='%v'", status, err, pods)
 		if status == 0 {
-			return
+			return nil
 		}
 		time.Sleep(1 * time.Second)
 	}
+	return nil
 }

--- a/test/runtime/monitor.go
+++ b/test/runtime/monitor.go
@@ -40,10 +40,6 @@ const (
 	// MonitorTraceNotification represents the TraceNotification configuration
 	// value for the Cilium monitor
 	MonitorTraceNotification = "TraceNotification"
-
-	// MonitorDebug represents the Debug configuration  value for
-	// the Cilium monitor
-	MonitorDebug = "Debug"
 )
 
 var _ = Describe("RuntimeMonitorTest", func() {
@@ -85,8 +81,8 @@ var _ = Describe("RuntimeMonitorTest", func() {
 		})
 
 		monitorConfig := func() {
-			res := vm.ExecCilium(fmt.Sprintf("config %s=true %s=true %s=true",
-				MonitorDebug, MonitorDropNotification, MonitorTraceNotification))
+			res := vm.ExecCilium(fmt.Sprintf("config %s=true %s=true",
+				MonitorDropNotification, MonitorTraceNotification))
 			ExpectWithOffset(1, res.WasSuccessful()).To(BeTrue(), "cannot update monitor config")
 		}
 
@@ -280,12 +276,10 @@ var _ = Describe("RuntimeMonitorTest", func() {
 		})
 
 		It("checks container ids match monitor output", func() {
-			res := vm.ExecCilium(fmt.Sprintf("config %s=true", MonitorDebug))
-			res.ExpectSuccess()
 			ExpectPolicyEnforcementUpdated(vm, helpers.PolicyEnforcementAlways)
 
 			ctx, cancel := context.WithCancel(context.Background())
-			res = vm.ExecInBackground(ctx, "cilium monitor -v")
+			res := vm.ExecInBackground(ctx, "cilium monitor -v")
 
 			vm.ContainerExec(helpers.App1, helpers.Ping(helpers.Httpd1))
 			vm.ContainerExec(helpers.Httpd1, helpers.Ping(helpers.App1))


### PR DESCRIPTION
This is based on top of https://github.com/cilium/cilium/pull/8331 with an added CI fix.


* #8294 - .travis: update travis golang to 1.12.5 (@aanm)
* #8318 - Don't set debug to true in monitor test (@nebril)
* #8320 - pkg/lock: RUnlock in RUnlockIgnoreTime (@aanm)
* #8319 - daemon: fix endpoint restore when endpoints are not available (@aanm)
* #8334 - test: add timeout to `waitToDeleteCilium` helper function (@ianvernon)

Once this PR is merged, you can update the PR labels via:

$ for pr in 8334 8294 8318 8320 8319; do contrib/backporting/set-labels.py $pr done 1.5; done


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8343)
<!-- Reviewable:end -->