### PR TITLE
cilium: encrypt, wildcard src out policy rules

### DIFF
--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -495,7 +495,7 @@ func (n *linuxNodeHandler) encryptNode(newNode *node.Node) {
 			if remoteIPv4 := newNode.GetNodeIP(false); remoteIPv4 != nil {
 				ipsecRemote := &net.IPNet{IP: remoteIPv4, Mask: exactMask}
 				n.replaceNodeExternalIPSecOutRoute(ipsecRemote)
-				spi, err = ipsec.UpsertIPsecEndpoint(ipsecLocal, ipsecRemote, ipsec.IPSecDirOut)
+				spi, err = ipsec.UpsertIPsecEndpoint(ipsecLocal, ipsecRemote, ipsec.IPSecDirOutNode)
 				upsertIPsecLog(err, "EncryptNode IPv4", ipsecLocal, ipsecRemote, spi)
 			}
 		}


### PR DESCRIPTION
Encryption policy rules in xfrm are already restricted by the mark
value which is set by BPF program. This ensures we do not have
hits in the table for local traffic, loops, etc. and only encrypt
traffic as expected from the BPF datapath.

However, the policy rules for outgoing traffic for node to node
traffic additionally specify the rule with source IP. This means
only traffic to a remote node with the source node set to the
local node get encrypted. If a pod sends traffic to a remote node
the source IP will be the pod IP and not the node IP so the policy
rule will not match and the packet will not be encrypted.

To fix this wildcard the source IP in the policy rule so any
traffic with the encrypt mark (0xe00) set being sent to the remote
node will be encrypted.

Fixes: 47bd875512770 ("cilium: encrypt, use ipcache to lookup IPsec destination IP")
Signed-off-by: John Fastabend <john.fastabend@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8344)
<!-- Reviewable:end -->
