### PR TITLE
allocator: fix race condition when allocating local identities upon bootstrap

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -829,7 +829,9 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 	// This needs to be done after the node addressing has been configured
 	// as the node address is required as suffix.
 	// well known identities have already been initialized above
-	go cache.InitIdentityAllocator(&d)
+	// Ignore the channel returned by this function, as we want the global
+	// identity allocator to run asynchronously.
+	cache.InitIdentityAllocator(&d)
 
 	d.bootstrapClusterMesh(nodeMngr)
 

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -1294,9 +1294,6 @@ func runDaemon() {
 	// We need to set up etcd in parallel so we will initialize the k8s
 	// subsystem as well in parallel so caches will start to be synchronized
 	// with k8s.
-	// This is required because CNP with CIDRs rely on the allocator which
-	// itself relies on the kvstore to be setup and the caches will not be
-	// synced unless we setup the kvstore at the same time.
 	k8sCachesSynced := d.initK8sSubsystem()
 	d.initKVStore()
 

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -281,7 +281,7 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) (resto
 			// endpoints that don't have a fixed identity or are
 			// not well known.
 			if !identity.IsFixed() && !identity.IsWellKnown() {
-				cache.WaitForInitialIdentities(context.Background())
+				cache.WaitForInitialGlobalIdentities(context.Background())
 				ipcache.WaitForInitialSync()
 			}
 

--- a/pkg/clustermesh/clustermesh_test.go
+++ b/pkg/clustermesh/clustermesh_test.go
@@ -109,7 +109,7 @@ func (s *ClusterMeshTestSuite) TestClusterMesh(c *C) {
 	defer kvstore.Close()
 
 	identity.InitWellKnownIdentities()
-	cache.InitIdentityAllocator(&identityAllocatorOwnerMock{})
+	<-cache.InitIdentityAllocator(&identityAllocatorOwnerMock{})
 	defer cache.Close()
 
 	dir, err := ioutil.TempDir("", "multicluster")

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -63,7 +63,7 @@ func (s *ClusterMeshServicesTestSuite) SetUpTest(c *C) {
 	kvstore.DeletePrefix("cilium/state/services/v1/" + s.randomName)
 	s.svcCache = k8s.NewServiceCache()
 	identity.InitWellKnownIdentities()
-	cache.InitIdentityAllocator(&identityAllocatorOwnerMock{})
+	<-cache.InitIdentityAllocator(&identityAllocatorOwnerMock{})
 	dir, err := ioutil.TempDir("", "multicluster")
 	s.testDir = dir
 	c.Assert(err, IsNil)

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -58,7 +58,7 @@ func (s *EndpointSuite) SetUpTest(c *C) {
 	/* Required to test endpoint CEP policy model */
 	kvstore.SetupDummy("etcd")
 	identity.InitWellKnownIdentities()
-	cache.InitIdentityAllocator(&testIdentityAllocator{})
+	<-cache.InitIdentityAllocator(&testIdentityAllocator{})
 	s.repo = policy.NewPolicyRepository()
 }
 

--- a/pkg/identity/cache/allocation_test.go
+++ b/pkg/identity/cache/allocation_test.go
@@ -219,7 +219,7 @@ func (ias *IdentityAllocatorSuite) TestEventWatcherBatching(c *C) {
 
 func (ias *IdentityAllocatorSuite) TestGetIdentityCache(c *C) {
 	identity.InitWellKnownIdentities()
-	InitIdentityAllocator(newDummyOwner())
+	<-InitIdentityAllocator(newDummyOwner())
 	defer Close()
 	defer IdentityAllocator.DeleteAllKeys()
 
@@ -235,7 +235,7 @@ func (ias *IdentityAllocatorSuite) TestAllocator(c *C) {
 
 	owner := newDummyOwner()
 	identity.InitWellKnownIdentities()
-	InitIdentityAllocator(owner)
+	<-InitIdentityAllocator(owner)
 	defer Close()
 	defer IdentityAllocator.DeleteAllKeys()
 
@@ -318,7 +318,7 @@ func (ias *IdentityAllocatorSuite) TestLocalAllocation(c *C) {
 
 	owner := newDummyOwner()
 	identity.InitWellKnownIdentities()
-	InitIdentityAllocator(owner)
+	<-InitIdentityAllocator(owner)
 	defer Close()
 	defer IdentityAllocator.DeleteAllKeys()
 


### PR DESCRIPTION
When identities are attempted to be allocated by `AllocateIdentity`, both the
labels are checked for if the identity is local, *and* whether the
`localIdentities` structure is non-nil:

```
...

if !identity.RequiresGlobalIdentity(lbls) && localIdentities != nil {
        return localIdentities.lookupOrCreate(lbls)
}

// else allocate global identity

...
```

Upon bootstrap, the creation of the localIdentities structure was done
asynchronously along with the creation of the global identity allocator. This
meant that if a local identity for a CIDR was attempted to be allocated upon
bootstrap soon after `InitIdentityAllocator` was invoked, there was no guarantee
as to whether `localIdentities` was initialized or not. Consequently, even if a
set of labels did correspond to a local identity (e.g., for a CIDR), there would
be no local identity allocated for the CIDR, and instead, a global identity
would be allocated. This is incorrect behavior.

Fix this incorrect behavior by doing the following:

* Create `localIdentities` synchronously with calls to `InitIdentityAllocator`.
The initialization of the global allocator is still done asynchronously.
* Do not asynchronously call `InitIdentityAllocator` upon bootstrap any more,
since `InitIdentityAllocator` synchronously creates the local identity allocator
now, but now creates the global identity allocator asynchronously.

Additionally, add another function, which calls the refactored
`InitIdentityAllocator` and waits for it to be initialized, to preserve existing
behavior in unit tests.

Fixes: f3bbcd8e88 ("identity: Use local identities to represent CIDR")
Fixes: #8342

Signed-off by: Ian Vernon <ian@cilium.io>

```release-note
Fix bug where global identities are allocated for CIDRs
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8345)
<!-- Reviewable:end -->
