### PR TITLE
CI: Cleanup VMs and reclaim disk on job completion

### DIFF
--- a/flannel.Jenkinsfile
+++ b/flannel.Jenkinsfile
@@ -106,6 +106,7 @@ pipeline {
             sh 'cd ${TESTDIR}/test/; K8S_VERSION=1.10 vagrant destroy -f || true'
             sh 'cd ${TESTDIR}/test/; K8S_VERSION=1.13 vagrant destroy -f || true'
             cleanWs()
+            sh '/usr/local/bin/cleanup || true'
         }
         success {
             Status("SUCCESS", "$JOB_BASE_NAME")

--- a/ginkgo-kubernetes-all.Jenkinsfile
+++ b/ginkgo-kubernetes-all.Jenkinsfile
@@ -319,6 +319,7 @@ pipeline {
             archiveArtifacts artifacts: '*.zip'
             junit testDataPublishers: [[$class: 'AttachmentPublisher']], testResults: 'src/github.com/cilium/cilium/test/*.xml'
             cleanWs()
+            sh '/usr/local/bin/cleanup || true'
         }
         success {
             Status("SUCCESS", "${env.JOB_NAME}")

--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -248,4 +248,10 @@ pipeline {
             }
         }
     }
+
+    post {
+        always {
+            sh '/usr/local/bin/cleanup || true'
+        }
+    }
 }

--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -243,7 +243,6 @@ pipeline {
                 always {
                     archiveArtifacts artifacts: '*.zip'
                     junit testDataPublishers: [[$class: 'AttachmentPublisher']], testResults: 'src/github.com/cilium/cilium/test/*.xml'
-                    cleanWs()
                 }
             }
         }
@@ -251,6 +250,7 @@ pipeline {
 
     post {
         always {
+            cleanWs()
             sh '/usr/local/bin/cleanup || true'
         }
     }

--- a/kubernetes-upstream.Jenkinsfile
+++ b/kubernetes-upstream.Jenkinsfile
@@ -106,6 +106,7 @@ pipeline {
         always {
             sh 'cd ${TESTDIR}; K8S_VERSION=${K8S_VERSION} vagrant destroy -f || true'
             cleanWs()
+            sh '/usr/local/bin/cleanup || true'
         }
         success {
             Status("SUCCESS", "$JOB_BASE_NAME")


### PR DESCRIPTION
This is two changes. I'm not sure that the second is correct or safe (the docs suggest that it enqueues a deferred cleanup anyway, so it is ok to invoke anywhere https://plugins.jenkins.io/ws-cleanup)

* CI: Clean VMs and reclaim disk after jobs complete
We cleanup when starting a job, to ensure we have enough space. There is
a race here, however, where if a job exits and leaves a full disk
jenkins may no longer schedule on it. We now clean when a job completes,
since the cleanup script is more conservative on when to prune vagrant
images.

* CI: Clean workspace when all stages complete  …
We previously cleaned the workspace when the test stage ends, and not
when the pipeline exits. This is probably benign but some archival
operations may be interrupted by a premature cleanup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8352)
<!-- Reviewable:end -->
