### PR TITLE
Simplified endpoint state machine

### DIFF
--- a/Documentation/concepts.rst
+++ b/Documentation/concepts.rst
@@ -337,6 +337,40 @@ example is a Kubernetes cluster which uses containerd as the container runtime.
 Endpoints will derive Kubernetes pod labels (prefixed with the ``k8s:`` source
 prefix) and containerd labels (prefixed with ``container:`` source prefix).
 
+Endpoint States
+---------------
+
+An endpoint can be in the following state to describe its current status:
+
+* **Creating:** The endpoint has been created via the API and has not been
+  successfully built yet. The endpoint is *not* connected.
+
+* **Restoring:** The endpoint is being restored from previous state and has not
+  been rebuilt yet. The connectivity state of the endpoint depends on the
+  endpoint state while the previous instance of the Cilium agent was managing
+  the endpoint. The endpoint will transition to Ready once the restore
+  operation has completed successfully.
+
+* **Regenerating:** The endpoint is currently being regenerated to implement
+  the desired state such as policy requirements. The endpoint may or may not be
+  currently connected. After the build has been completed, the endpoint will
+  transition into a state that represents the connectivity state.
+
+* **WaitingForIdentity:** The endpoint had its identity metadata changed and is
+  currently resolving its new identity. After successful identity resolution,
+  the endpoint will be regenerated as needed.
+
+* **WaitingToRegenerate:** The latest changes have been integrated but there are
+  changes outstanding to be incorporated. The endpoint is queued to be built.
+
+* **Ready:** The endpoint is stable and healthy without outstanding changes
+
+* **NotReady:** The endpoint build is currently failing
+
+* **Disconnecting:** The endpoint is being removed
+
+* **Disconnected:** The endpoint has been removed.
+
 .. _identity:
 
 Identity

--- a/api/v1/models/endpoint_change_request.go
+++ b/api/v1/models/endpoint_change_request.go
@@ -68,10 +68,6 @@ type EndpointChangeRequest struct {
 	// Whether policy enforcement is enabled or not
 	PolicyEnabled bool `json:"policy-enabled,omitempty"`
 
-	// Current state of endpoint
-	// Required: true
-	State EndpointState `json:"state"`
-
 	// Whether to build an endpoint synchronously
 	//
 	SyncBuildEndpoint bool `json:"sync-build-endpoint,omitempty"`
@@ -90,10 +86,6 @@ func (m *EndpointChangeRequest) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateLabels(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateState(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -148,18 +140,6 @@ func (m *EndpointChangeRequest) validateLabels(formats strfmt.Registry) error {
 	if err := m.Labels.Validate(formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("labels")
-		}
-		return err
-	}
-
-	return nil
-}
-
-func (m *EndpointChangeRequest) validateState(formats strfmt.Registry) error {
-
-	if err := m.State.Validate(formats); err != nil {
-		if ve, ok := err.(*errors.Validation); ok {
-			return ve.ValidateName("state")
 		}
 		return err
 	}

--- a/api/v1/models/endpoint_status.go
+++ b/api/v1/models/endpoint_status.go
@@ -44,8 +44,7 @@ type EndpointStatus struct {
 	Realized *EndpointConfigurationSpec `json:"realized,omitempty"`
 
 	// Current state of endpoint
-	// Required: true
-	State EndpointState `json:"state"`
+	State EndpointState `json:"state,omitempty"`
 }
 
 // Validate validates this endpoint status
@@ -257,6 +256,10 @@ func (m *EndpointStatus) validateRealized(formats strfmt.Registry) error {
 }
 
 func (m *EndpointStatus) validateState(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.State) { // not required
+		return nil
+	}
 
 	if err := m.State.Validate(formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {

--- a/api/v1/models/endpoint_status_change.go
+++ b/api/v1/models/endpoint_status_change.go
@@ -19,12 +19,15 @@ import (
 // swagger:model EndpointStatusChange
 type EndpointStatusChange struct {
 
-	// Code indicate type of status change
-	// Enum: [ok failed]
-	Code string `json:"code,omitempty"`
-
 	// Status message
 	Message string `json:"message,omitempty"`
+
+	// old state
+	OldState EndpointState `json:"old-state,omitempty"`
+
+	// Indicates the severity of the log message
+	// Enum: [info warning failed]
+	Severity string `json:"severity,omitempty"`
 
 	// state
 	State EndpointState `json:"state,omitempty"`
@@ -37,7 +40,11 @@ type EndpointStatusChange struct {
 func (m *EndpointStatusChange) Validate(formats strfmt.Registry) error {
 	var res []error
 
-	if err := m.validateCode(formats); err != nil {
+	if err := m.validateOldState(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateSeverity(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -51,43 +58,62 @@ func (m *EndpointStatusChange) Validate(formats strfmt.Registry) error {
 	return nil
 }
 
-var endpointStatusChangeTypeCodePropEnum []interface{}
+func (m *EndpointStatusChange) validateOldState(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.OldState) { // not required
+		return nil
+	}
+
+	if err := m.OldState.Validate(formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("old-state")
+		}
+		return err
+	}
+
+	return nil
+}
+
+var endpointStatusChangeTypeSeverityPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["ok","failed"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["info","warning","failed"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
-		endpointStatusChangeTypeCodePropEnum = append(endpointStatusChangeTypeCodePropEnum, v)
+		endpointStatusChangeTypeSeverityPropEnum = append(endpointStatusChangeTypeSeverityPropEnum, v)
 	}
 }
 
 const (
 
-	// EndpointStatusChangeCodeOk captures enum value "ok"
-	EndpointStatusChangeCodeOk string = "ok"
+	// EndpointStatusChangeSeverityInfo captures enum value "info"
+	EndpointStatusChangeSeverityInfo string = "info"
 
-	// EndpointStatusChangeCodeFailed captures enum value "failed"
-	EndpointStatusChangeCodeFailed string = "failed"
+	// EndpointStatusChangeSeverityWarning captures enum value "warning"
+	EndpointStatusChangeSeverityWarning string = "warning"
+
+	// EndpointStatusChangeSeverityFailed captures enum value "failed"
+	EndpointStatusChangeSeverityFailed string = "failed"
 )
 
 // prop value enum
-func (m *EndpointStatusChange) validateCodeEnum(path, location string, value string) error {
-	if err := validate.Enum(path, location, value, endpointStatusChangeTypeCodePropEnum); err != nil {
+func (m *EndpointStatusChange) validateSeverityEnum(path, location string, value string) error {
+	if err := validate.Enum(path, location, value, endpointStatusChangeTypeSeverityPropEnum); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (m *EndpointStatusChange) validateCode(formats strfmt.Registry) error {
+func (m *EndpointStatusChange) validateSeverity(formats strfmt.Registry) error {
 
-	if swag.IsZero(m.Code) { // not required
+	if swag.IsZero(m.Severity) { // not required
 		return nil
 	}
 
 	// value enum
-	if err := m.validateCodeEnum("code", "body", m.Code); err != nil {
+	if err := m.validateSeverityEnum("severity", "body", m.Severity); err != nil {
 		return err
 	}
 

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -906,8 +906,6 @@ definitions:
     description: |
       Structure which contains the mutable elements of an Endpoint.
     type: object
-    required:
-      - state
     properties:
       id:
         description: Local endpoint ID
@@ -933,9 +931,6 @@ definitions:
       interface-index:
         description: Index of network device
         type: integer
-      state:
-        description: Current state of endpoint
-        "$ref": "#/definitions/EndpointState"
       mac:
         description: MAC address
         type: string
@@ -997,8 +992,6 @@ definitions:
   EndpointStatus:
     description: The current state and configuration of the endpoint, its policy & datapath, and subcomponents
     type: object
-    required:
-      - state
     properties:
       external-identifiers:
         description: Unique identifiers for this endpoint from outside cilium
@@ -1085,15 +1078,18 @@ definitions:
       timestamp:
         description: Timestamp when status change occurred
         type: string
-      code:
-        description: Code indicate type of status change
+      severity:
+        description: Indicates the severity of the log message
         type: string
         enum:
-         - ok
+         - info
+         - warning
          - failed
       message:
         description: Status message
         type: string
+      old-state:
+        "$ref": "#/definitions/EndpointState"
       state:
         "$ref": "#/definitions/EndpointState"
   EndpointPolicyStatus:

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -1599,9 +1599,6 @@ func init() {
     "EndpointChangeRequest": {
       "description": "Structure which contains the mutable elements of an Endpoint.\n",
       "type": "object",
-      "required": [
-        "state"
-      ],
       "properties": {
         "addressing": {
           "$ref": "#/definitions/AddressPair"
@@ -1668,10 +1665,6 @@ func init() {
         "policy-enabled": {
           "description": "Whether policy enforcement is enabled or not",
           "type": "boolean"
-        },
-        "state": {
-          "description": "Current state of endpoint",
-          "$ref": "#/definitions/EndpointState"
         },
         "sync-build-endpoint": {
           "description": "Whether to build an endpoint synchronously\n",
@@ -1922,9 +1915,6 @@ func init() {
     "EndpointStatus": {
       "description": "The current state and configuration of the endpoint, its policy \u0026 datapath, and subcomponents",
       "type": "object",
-      "required": [
-        "state"
-      ],
       "properties": {
         "controllers": {
           "description": "Status of internal controllers attached to this endpoint",
@@ -1972,17 +1962,21 @@ func init() {
       "description": "Indication of a change of status",
       "type": "object",
       "properties": {
-        "code": {
-          "description": "Code indicate type of status change",
-          "type": "string",
-          "enum": [
-            "ok",
-            "failed"
-          ]
-        },
         "message": {
           "description": "Status message",
           "type": "string"
+        },
+        "old-state": {
+          "$ref": "#/definitions/EndpointState"
+        },
+        "severity": {
+          "description": "Indicates the severity of the log message",
+          "type": "string",
+          "enum": [
+            "info",
+            "warning",
+            "failed"
+          ]
         },
         "state": {
           "$ref": "#/definitions/EndpointState"
@@ -4567,9 +4561,6 @@ func init() {
     "EndpointChangeRequest": {
       "description": "Structure which contains the mutable elements of an Endpoint.\n",
       "type": "object",
-      "required": [
-        "state"
-      ],
       "properties": {
         "addressing": {
           "$ref": "#/definitions/AddressPair"
@@ -4636,10 +4627,6 @@ func init() {
         "policy-enabled": {
           "description": "Whether policy enforcement is enabled or not",
           "type": "boolean"
-        },
-        "state": {
-          "description": "Current state of endpoint",
-          "$ref": "#/definitions/EndpointState"
         },
         "sync-build-endpoint": {
           "description": "Whether to build an endpoint synchronously\n",
@@ -4890,9 +4877,6 @@ func init() {
     "EndpointStatus": {
       "description": "The current state and configuration of the endpoint, its policy \u0026 datapath, and subcomponents",
       "type": "object",
-      "required": [
-        "state"
-      ],
       "properties": {
         "controllers": {
           "description": "Status of internal controllers attached to this endpoint",
@@ -4940,17 +4924,21 @@ func init() {
       "description": "Indication of a change of status",
       "type": "object",
       "properties": {
-        "code": {
-          "description": "Code indicate type of status change",
-          "type": "string",
-          "enum": [
-            "ok",
-            "failed"
-          ]
-        },
         "message": {
           "description": "Status message",
           "type": "string"
+        },
+        "old-state": {
+          "$ref": "#/definitions/EndpointState"
+        },
+        "severity": {
+          "description": "Indicates the severity of the log message",
+          "type": "string",
+          "enum": [
+            "info",
+            "warning",
+            "failed"
+          ]
         },
         "state": {
           "$ref": "#/definitions/EndpointState"

--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -197,7 +197,6 @@ func LaunchAsEndpoint(baseCtx context.Context, owner endpoint.Owner, n *node.Nod
 		cmd  = launcher.Launcher{}
 		info = &models.EndpointChangeRequest{
 			ContainerName: ciliumHealth,
-			State:         models.EndpointStateWaitingForIdentity,
 			Addressing:    &models.AddressPair{},
 		}
 		healthIP               net.IP

--- a/cilium/cmd/endpoint_log.go
+++ b/cilium/cmd/endpoint_log.go
@@ -54,9 +54,9 @@ func getEndpointLog(cmd *cobra.Command, args []string) {
 		}
 	} else {
 		w := tabwriter.NewWriter(os.Stdout, 2, 0, 3, ' ', 0)
-		fmt.Fprintf(w, "%s\t%s\t%s\t%v\n", "Timestamp", "Status", "State", "Message")
+		fmt.Fprintf(w, "%s\t%s\t%s\t%v\n", "Timestamp", "Severity", "State", "Message")
 		for _, entry := range epLog {
-			fmt.Fprintf(w, "%s\t%s\t%s\t%v\n", entry.Timestamp, entry.Code, entry.State, entry.Message)
+			fmt.Fprintf(w, "%s\t%s\t%s -> %s\t%v\n", entry.Timestamp, entry.Severity, entry.OldState, entry.State, entry.Message)
 		}
 		w.Flush()
 	}

--- a/daemon/endpoint_test.go
+++ b/daemon/endpoint_test.go
@@ -40,7 +40,6 @@ func getEPTemplate(c *C, d *Daemon) *models.EndpointChangeRequest {
 
 	return &models.EndpointChangeRequest{
 		ContainerName: "foo",
-		State:         models.EndpointStateWaitingForIdentity,
 		Addressing: &models.AddressPair{
 			IPV6: ip6.String(),
 			IPV4: ip4.String(),

--- a/daemon/policy_test.go
+++ b/daemon/policy_test.go
@@ -126,7 +126,7 @@ func prepareEndpointDirs() (cleanup func(), err error) {
 }
 
 func (ds *DaemonSuite) prepareEndpoint(c *C, identity *identity.Identity, qa bool) *endpoint.Endpoint {
-	e := endpoint.NewEndpointWithState(ds.d.GetPolicyRepository(), testEndpointID, endpoint.StateWaitingForIdentity)
+	e := endpoint.NewTestEndpoint(ds.d.GetPolicyRepository(), testEndpointID)
 	e.IfName = "dummy1"
 	if qa {
 		e.IPv6 = QAIPv6Addr
@@ -141,10 +141,6 @@ func (ds *DaemonSuite) prepareEndpoint(c *C, identity *identity.Identity, qa boo
 	}
 	e.SetIdentity(identity)
 
-	e.UnconditionalLock()
-	ready := e.SetStateLocked(endpoint.StateWaitingToRegenerate, "test")
-	e.Unlock()
-	c.Assert(ready, Equals, true)
 	buildSuccess := <-e.Regenerate(ds.d, regenerationMetadata)
 	c.Assert(buildSuccess, Equals, true)
 
@@ -152,10 +148,6 @@ func (ds *DaemonSuite) prepareEndpoint(c *C, identity *identity.Identity, qa boo
 }
 
 func (ds *DaemonSuite) regenerateEndpoint(c *C, e *endpoint.Endpoint) {
-	e.UnconditionalLock()
-	ready := e.SetStateLocked(endpoint.StateWaitingToRegenerate, "test")
-	e.Unlock()
-	c.Assert(ready, Equals, true)
 	buildSuccess := <-e.Regenerate(ds.d, regenerationMetadata)
 	c.Assert(buildSuccess, Equals, true)
 }

--- a/daemon/state_test.go
+++ b/daemon/state_test.go
@@ -81,7 +81,7 @@ func (ds *DaemonSuite) endpointCreator(id uint16, secID identity.NumericIdentity
 	repo := ds.d.GetPolicyRepository()
 	repo.GetPolicyCache().LocalEndpointIdentityAdded(identity)
 
-	ep := e.NewEndpointWithState(repo, id, e.StateReady)
+	ep := e.NewTestEndpoint(repo, id)
 	// Random network ID and docker endpoint ID with 59 hex chars + 5 strID = 64 hex chars
 	ep.DockerNetworkID = "603e047d2268a57f5a5f93f7f9e1263e9207e348a06654bf64948def001" + strID
 	ep.DockerEndpointID = "93529fda8c401a071d21d6bd46fdf5499b9014dcb5a35f2e3efaa8d8002" + strID
@@ -164,11 +164,8 @@ func (ds *DaemonSuite) generateEPs(baseDir string, epsWanted []*e.Endpoint, epsM
 		identitymanager.Add(ep.SecurityIdentity)
 		defer identitymanager.Remove(ep.SecurityIdentity)
 
-		ready := ep.SetStateLocked(e.StateWaitingToRegenerate, "test")
 		ep.Unlock()
-		if ready {
-			<-ep.Regenerate(ds, regenerationMetadata)
-		}
+		<-ep.Regenerate(ds, regenerationMetadata)
 
 		switch ep.ID {
 		case 256, 257:
@@ -187,11 +184,8 @@ func (ds *DaemonSuite) generateEPs(baseDir string, epsWanted []*e.Endpoint, epsM
 				// Change endpoint a little bit so we know which endpoint is in
 				// "256_next_fail" and with one is in the "256" directory.
 				ep.SetNodeMACLocked(mac.MAC([]byte{0x02, 0xff, 0xf2, 0x12, 0xc1, 0xc1}))
-				ready := ep.SetStateLocked(e.StateWaitingToRegenerate, "test")
 				ep.Unlock()
-				if ready {
-					<-ep.Regenerate(ds, regenerationMetadata)
-				}
+				<-ep.Regenerate(ds, regenerationMetadata)
 				epsNames = append(epsNames, ep.DirectoryPath())
 			}
 		default:

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -90,7 +90,7 @@ func (e *Endpoint) writeInformationalComments(w io.Writer) error {
 		}
 	}
 	if err != nil {
-		e.logStatusLocked(BPF, Warning, fmt.Sprintf("Unable to create a base64: %s", err))
+		e.logStatusLocked(Warning, StateUnspecified, "Unable to create a base64: %s", err)
 	}
 
 	if e.ContainerID == "" {
@@ -425,7 +425,7 @@ func (e *Endpoint) regenerateBPF(owner Owner, regenContext *regenerationContext)
 	err = lxcmap.WriteEndpoint(datapathRegenCtxt.epInfoCache)
 	stats.mapSync.End(err == nil)
 	if epErr != nil {
-		e.logStatusLocked(BPF, Warning, fmt.Sprintf("Unable to sync EpToPolicy Map continue with Sockmap support: %s", epErr))
+		e.logStatusLocked(Warning, StateUnspecified, "Unable to sync EpToPolicy Map continue with Sockmap support: %s", epErr)
 	}
 	if err != nil {
 		return 0, compilationExecuted, fmt.Errorf("Exposing new BPF failed: %s", err)

--- a/pkg/endpoint/bpf_test.go
+++ b/pkg/endpoint/bpf_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func (s *EndpointSuite) TestWriteInformationalComments(c *C) {
-	e := NewEndpointWithState(s.repo, 100, StateCreating)
+	e := NewTestEndpoint(s.repo, 100)
 
 	var f bytes.Buffer
 	err := e.writeInformationalComments(&f)
@@ -40,7 +40,7 @@ type writeFunc func(io.Writer) error
 
 func BenchmarkWriteHeaderfile(b *testing.B) {
 	repo := policy.NewPolicyRepository()
-	e := NewEndpointWithState(repo, 100, StateCreating)
+	e := NewTestEndpoint(repo, 100)
 	dp := linux.NewDatapath(linux.DatapathConfiguration{})
 
 	targetComments := func(w io.Writer) error {

--- a/pkg/endpoint/connector/add.go
+++ b/pkg/endpoint/connector/add.go
@@ -185,7 +185,6 @@ func DeriveEndpointFrom(hostDevice, containerID string, pid int) (*models.Endpoi
 			// IPV6: ip6.String(),
 		},
 		ContainerID: containerID,
-		State:       models.EndpointStateWaitingForIdentity,
 	}
 	err = GetVethInfo(hostDevice, parentIdx, lxcMAC, epModel)
 	if err != nil {

--- a/pkg/endpoint/endpoint_status.go
+++ b/pkg/endpoint/endpoint_status.go
@@ -77,17 +77,13 @@ func (e *Endpoint) getEndpointStatusLog() (log []*models.EndpointStatusChange) {
 			if i < len(s.Log) && s.Log[i] != nil {
 				l := &models.EndpointStatusChange{
 					Timestamp: s.Log[i].Timestamp.Format(time.RFC3339),
-					Code:      s.Log[i].Status.Code.String(),
+					Severity:  s.Log[i].Status.Severity.String(),
 					Message:   s.Log[i].Status.Msg,
 					State:     models.EndpointState(s.Log[i].Status.State),
 				}
 
-				if strings.ToLower(l.Code) != models.EndpointStatusChangeCodeOk {
-					if log == nil {
-						log = []*models.EndpointStatusChange{l}
-					} else {
-						log = append(log, l)
-					}
+				if strings.ToLower(l.Severity) != models.EndpointStatusChangeSeverityInfo {
+					log = append(log, l)
 
 					// Limit the number of endpoint log
 					// entries to keep the size of the

--- a/pkg/endpoint/endpoint_status_test.go
+++ b/pkg/endpoint/endpoint_status_test.go
@@ -59,7 +59,6 @@ func newEndpoint(c *check.C, repo *policy.Repository, spec endpointGeneratorSpec
 			"k8s:io.kubernetes.pod.namespace=default",
 			"k8s:name=probe",
 		},
-		State: models.EndpointState("waiting-for-identity"),
 	})
 	c.Assert(err, check.IsNil)
 
@@ -79,7 +78,7 @@ func newEndpoint(c *check.C, repo *policy.Repository, spec endpointGeneratorSpec
 
 	for i := 0; i < spec.logErrors; i++ {
 		e.Status.addStatusLog(&statusLogMsg{
-			Status: Status{Code: Failure, Msg: "Failure", Type: BPF},
+			Status: Status{Severity: Failure, Msg: "Failure"},
 		})
 	}
 
@@ -153,7 +152,7 @@ func (s *EndpointSuite) TestGetCiliumEndpointStatusSuccessfulLog(c *check.C) {
 	go func() {
 		for i := 0; i < 1000; i++ {
 			e.Status.addStatusLog(&statusLogMsg{
-				Status: Status{Code: OK, Msg: "Success", Type: BPF},
+				Status: Status{Severity: Info, Msg: "Success"},
 			})
 			time.Sleep(time.Millisecond)
 		}

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -67,107 +67,8 @@ func (s *EndpointSuite) TearDownTest(c *C) {
 	kvstore.Close()
 }
 
-func (s *EndpointSuite) TestEndpointStatus(c *C) {
-	eps := NewEndpointStatus()
-
-	c.Assert(eps.String(), Equals, "OK")
-
-	sts := &statusLogMsg{
-		Status: Status{
-			Code: OK,
-			Msg:  "BPF Program compiled",
-			Type: BPF,
-		},
-		Timestamp: time.Now(),
-	}
-	eps.addStatusLog(sts)
-	c.Assert(eps.String(), Equals, "OK")
-
-	sts = &statusLogMsg{
-		Status: Status{
-			Code: Failure,
-			Msg:  "BPF Program failed to compile",
-			Type: BPF,
-		},
-		Timestamp: time.Now(),
-	}
-	eps.addStatusLog(sts)
-	c.Assert(eps.String(), Equals, "Failure")
-
-	sts = &statusLogMsg{
-		Status: Status{
-			Code: OK,
-			Msg:  "Policy compiled",
-			Type: Policy,
-		},
-		Timestamp: time.Now(),
-	}
-	eps.addStatusLog(sts)
-	c.Assert(eps.String(), Equals, "Failure")
-
-	// An OK message with priority Other can't hide a High Failure message.
-	for i := 0; i <= maxLogs; i++ {
-		st := &statusLogMsg{
-			Status: Status{
-				Code: OK,
-				Msg:  "Other thing compiled",
-				Type: Other,
-			},
-			Timestamp: time.Now(),
-		}
-		eps.addStatusLog(st)
-	}
-	eps.addStatusLog(sts)
-	c.Assert(eps.String(), Equals, "Failure")
-
-	sts = &statusLogMsg{
-		Status: Status{
-			Code: Failure,
-			Msg:  "Policy failed",
-			Type: Policy,
-		},
-		Timestamp: time.Now(),
-	}
-	eps.addStatusLog(sts)
-	c.Assert(eps.String(), Equals, "Failure")
-
-	sts = &statusLogMsg{
-		Status: Status{
-			Code: OK,
-			Msg:  "BPF Program compiled",
-			Type: BPF,
-		},
-		Timestamp: time.Now(),
-	}
-	eps.addStatusLog(sts)
-	// BPF might be ok but the policy is still in fail mode.
-	c.Assert(eps.String(), Equals, "Failure")
-
-	sts = &statusLogMsg{
-		Status: Status{
-			Code: Failure,
-			Msg:  "Policy failed",
-			Type: Policy,
-		},
-		Timestamp: time.Now(),
-	}
-	eps.addStatusLog(sts)
-	c.Assert(eps.String(), Equals, "Failure")
-
-	sts = &statusLogMsg{
-		Status: Status{
-			Code: OK,
-			Msg:  "Policy compiled",
-			Type: Policy,
-		},
-		Timestamp: time.Now(),
-	}
-	eps.addStatusLog(sts)
-	c.Assert(eps.String(), Equals, "OK")
-}
-
 func (s *EndpointSuite) TestEndpointUpdateLabels(c *C) {
-	e := NewEndpointWithState(s.repo, 100, StateCreating)
+	e := NewTestEndpoint(s.repo, 100)
 
 	// Test that inserting identity labels works
 	rev := e.replaceIdentityLabels(pkgLabels.Map2Labels(map[string]string{"foo": "bar", "zip": "zop"}, "cilium"))
@@ -188,126 +89,6 @@ func (s *EndpointSuite) TestEndpointUpdateLabels(c *C) {
 	// Remove one label, change the source and value of the other.
 	e.replaceInformationLabels(pkgLabels.Map2Labels(map[string]string{"foo": "zop"}, "nginx"))
 	c.Assert(string(e.OpLabels.OrchestrationInfo.SortedList()), Equals, "nginx:foo=zop;")
-}
-
-func (s *EndpointSuite) TestEndpointState(c *C) {
-	e := NewEndpointWithState(s.repo, 100, StateCreating)
-	e.UnconditionalLock()
-	defer e.Unlock()
-
-	e.state = StateCreating
-	c.Assert(e.SetStateLocked(StateCreating, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateWaitingForIdentity, "test"), Equals, true)
-	e.state = StateCreating
-	c.Assert(e.SetStateLocked(StateReady, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateWaitingToRegenerate, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateRegenerating, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateDisconnecting, "test"), Equals, true)
-	e.state = StateCreating
-	c.Assert(e.SetStateLocked(StateDisconnected, "test"), Equals, false)
-
-	e.state = StateWaitingForIdentity
-	c.Assert(e.SetStateLocked(StateCreating, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateWaitingForIdentity, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateReady, "test"), Equals, true)
-	e.state = StateWaitingForIdentity
-	c.Assert(e.SetStateLocked(StateWaitingToRegenerate, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateRegenerating, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateDisconnecting, "test"), Equals, true)
-	e.state = StateWaitingForIdentity
-	c.Assert(e.SetStateLocked(StateDisconnected, "test"), Equals, false)
-
-	e.state = StateReady
-	c.Assert(e.SetStateLocked(StateCreating, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateWaitingForIdentity, "test"), Equals, true)
-	e.state = StateReady
-	c.Assert(e.SetStateLocked(StateReady, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateWaitingToRegenerate, "test"), Equals, true)
-	e.state = StateReady
-	c.Assert(e.SetStateLocked(StateRegenerating, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateDisconnecting, "test"), Equals, true)
-	e.state = StateReady
-	c.Assert(e.SetStateLocked(StateDisconnected, "test"), Equals, false)
-
-	e.state = StateWaitingToRegenerate
-	c.Assert(e.SetStateLocked(StateCreating, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateWaitingForIdentity, "test"), Equals, true)
-	e.state = StateWaitingToRegenerate
-	c.Assert(e.SetStateLocked(StateReady, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateWaitingToRegenerate, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateRegenerating, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateDisconnecting, "test"), Equals, true)
-	e.state = StateWaitingToRegenerate
-	c.Assert(e.SetStateLocked(StateDisconnected, "test"), Equals, false)
-
-	e.state = StateRegenerating
-	c.Assert(e.SetStateLocked(StateCreating, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateWaitingForIdentity, "test"), Equals, true)
-	e.state = StateRegenerating
-	c.Assert(e.SetStateLocked(StateReady, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateWaitingToRegenerate, "test"), Equals, true)
-	e.state = StateRegenerating
-	c.Assert(e.SetStateLocked(StateRegenerating, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateDisconnecting, "test"), Equals, true)
-	e.state = StateRegenerating
-	c.Assert(e.SetStateLocked(StateDisconnected, "test"), Equals, false)
-
-	e.state = StateDisconnecting
-	c.Assert(e.SetStateLocked(StateCreating, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateWaitingForIdentity, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateReady, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateWaitingToRegenerate, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateRegenerating, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateDisconnecting, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateDisconnected, "test"), Equals, true)
-
-	e.state = StateDisconnected
-	c.Assert(e.SetStateLocked(StateCreating, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateWaitingForIdentity, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateReady, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateWaitingToRegenerate, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateRegenerating, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateDisconnecting, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateDisconnected, "test"), Equals, false)
-
-	// Builder-specific transitions
-	e.state = StateWaitingToRegenerate
-	// Builder can't transition to ready from waiting-to-regenerate
-	// as (another) build is pending
-	c.Assert(e.BuilderSetStateLocked(StateReady, "test"), Equals, false)
-	// Only builder knows when bpf regeneration starts
-	c.Assert(e.SetStateLocked(StateRegenerating, "test"), Equals, false)
-	c.Assert(e.BuilderSetStateLocked(StateRegenerating, "test"), Equals, true)
-	// Builder does not trigger the need for regeneration
-	c.Assert(e.BuilderSetStateLocked(StateWaitingToRegenerate, "test"), Equals, false)
-	// Builder transitions to ready state after build is done
-	c.Assert(e.BuilderSetStateLocked(StateReady, "test"), Equals, true)
-
-	// Typical lifecycle
-	e.state = StateCreating
-	c.Assert(e.SetStateLocked(StateWaitingForIdentity, "test"), Equals, true)
-	// Initial build does not change the state
-	c.Assert(e.BuilderSetStateLocked(StateRegenerating, "test"), Equals, false)
-	c.Assert(e.BuilderSetStateLocked(StateReady, "test"), Equals, false)
-	// identity arrives
-	c.Assert(e.SetStateLocked(StateReady, "test"), Equals, true)
-	// a build is triggered after the identity is set
-	c.Assert(e.SetStateLocked(StateWaitingToRegenerate, "test"), Equals, true)
-	// build starts
-	c.Assert(e.BuilderSetStateLocked(StateRegenerating, "test"), Equals, true)
-	// another change arrives while building
-	c.Assert(e.SetStateLocked(StateWaitingToRegenerate, "test"), Equals, true)
-	// Builder's transition to ready fails due to the queued build
-	c.Assert(e.BuilderSetStateLocked(StateReady, "test"), Equals, false)
-	// second build starts
-	c.Assert(e.BuilderSetStateLocked(StateRegenerating, "test"), Equals, true)
-	// second build finishes
-	c.Assert(e.BuilderSetStateLocked(StateReady, "test"), Equals, true)
-	// endpoint is being deleted
-	c.Assert(e.SetStateLocked(StateDisconnecting, "test"), Equals, true)
-	// parallel disconnect fails
-	c.Assert(e.SetStateLocked(StateDisconnecting, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateDisconnected, "test"), Equals, true)
 }
 
 func (s *EndpointSuite) TestWaitForPolicyRevision(c *C) {
@@ -360,7 +141,7 @@ func (s *EndpointSuite) TestWaitForPolicyRevision(c *C) {
 	// Number of policy revision signals should be 0
 	c.Assert(len(e.policyRevisionSignals), Equals, 0)
 
-	e.state = StateDisconnected
+	e.state.disconnecting = true
 
 	ctx, cancel = context.WithCancel(context.Background())
 	cbRan = false
@@ -377,7 +158,7 @@ func (s *EndpointSuite) TestWaitForPolicyRevision(c *C) {
 	// Number of policy revision signals should be 0
 	c.Assert(len(e.policyRevisionSignals), Equals, 0)
 
-	e.state = StateCreating
+	e.state.initialBuildSuccessful = false
 	ctx, cancel = context.WithCancel(context.Background())
 	ch = e.WaitForPolicyRevision(ctx, 99, func(time.Time) { cbRan = true })
 

--- a/pkg/endpoint/lock.go
+++ b/pkg/endpoint/lock.go
@@ -19,7 +19,7 @@ import "fmt"
 // LockAlive returns error if endpoint was removed, locks underlying mutex otherwise
 func (e *Endpoint) LockAlive() error {
 	e.mutex.Lock()
-	if e.IsDisconnecting() {
+	if e.isDisconnectingLocked() {
 		e.mutex.Unlock()
 		return fmt.Errorf("lock failed: endpoint is in the process of being removed")
 	}
@@ -34,7 +34,7 @@ func (e *Endpoint) Unlock() {
 // RLockAlive returns error if endpoint was removed, read locks underlying mutex otherwise
 func (e *Endpoint) RLockAlive() error {
 	e.mutex.RLock()
-	if e.IsDisconnecting() {
+	if e.isDisconnectingLocked() {
 		e.mutex.RUnlock()
 		return ErrNotAlive
 	}
@@ -47,7 +47,6 @@ func (e *Endpoint) RUnlock() {
 }
 
 // UnconditionalLock should be used only for locking endpoint for
-// - setting its state to StateDisconnected
 // - handling regular Lock errors
 // - reporting endpoint status (like in LogStatus method)
 // Use Lock in all other cases

--- a/pkg/endpoint/state.go
+++ b/pkg/endpoint/state.go
@@ -1,0 +1,311 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endpoint
+
+import (
+	"fmt"
+
+	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/metrics"
+)
+
+// State is the state the endpoint is in
+type State string
+
+// String returns the string representation
+func (s State) String() string {
+	return string(s)
+}
+
+const (
+	// StateUnspecified is used when the state is not known
+	StateUnspecified = ""
+
+	// StateCreating is used to set the endpoint is being created.
+	StateCreating = State(models.EndpointStateCreating)
+
+	// StateWaitingForIdentity is used to set if the endpoint is waiting
+	// for an identity from the KVStore.
+	StateWaitingForIdentity = State(models.EndpointStateWaitingForIdentity)
+
+	// StateReady specifies if the endpoint is ready to be used.
+	StateReady = State(models.EndpointStateReady)
+
+	// StateWaitingToRegenerate specifies when the endpoint needs to be regenerated, but regeneration has not started yet.
+	StateWaitingToRegenerate = State(models.EndpointStateWaitingToRegenerate)
+
+	// StateRegenerating specifies when the endpoint is being regenerated.
+	StateRegenerating = State(models.EndpointStateRegenerating)
+
+	// StateDisconnecting indicates that the endpoint is being disconnected
+	StateDisconnecting = State(models.EndpointStateDisconnecting)
+
+	// StateDisconnected is used to set the endpoint is disconnected.
+	StateDisconnected = State(models.EndpointStateDisconnected)
+
+	// StateRestoring is used to set the endpoint is being restored.
+	StateRestoring = State(models.EndpointStateRestoring)
+
+	// StateNotReady indicates that the endpoint build is currently failing
+	StateNotReady = State(models.EndpointStateNotReady)
+)
+
+type state struct {
+	// disconnecting is true when the endpoint is disconnecting, an
+	// endpoint cannot transition out of disconnecting again
+	disconnecting bool
+
+	// disconnected is the final state, it is true once when the endpoint
+	// is fully disconnected
+	disconnected bool
+
+	// building is true while the endpoint is being regenerated
+	building bool
+
+	// initialBuildSuccessful becomes true after the first build has been
+	// successful
+	initialBuildSuccessful bool
+
+	// buildsQueued is the number of builds queued
+	buildsQueued int
+
+	// restored is true if the endpoint has been restored from disk
+	restored bool
+
+	// initialStateTransitionDone is true after the first initial state
+	// transition
+	initialStateTransitionDone bool
+
+	// consecutiveBuildFailures is the number of build failures in a row
+	consecutiveBuildFailures int
+
+	// lastBuildError is the error message of the last build failure or nil
+	// if the last build succeeded
+	lastBuildError error
+}
+
+// BuildPendingLocked returns true if at least one build is currently pending
+// with no build currently ongoing
+func (e *Endpoint) BuildPendingLocked() bool {
+	return e.state.buildsQueued > 0 && !e.state.building
+}
+
+// ReadyToBuild returns true if the endpoint is in a state where it can be built
+func (e *Endpoint) ReadyToBuild() bool {
+	e.UnconditionalRLock()
+	defer e.RUnlock()
+
+	return e.realizedIdentityRevision > 0 && !e.state.disconnecting
+}
+
+// State returns the state of the endpoint
+func (e *Endpoint) State() State {
+	e.UnconditionalRLock()
+	defer e.RUnlock()
+
+	return e.StateLocked()
+}
+
+// StateLocked returns the state of the endpoint if the endpoint is already
+// locked
+func (e *Endpoint) StateLocked() State {
+	switch {
+	case e.state.disconnected:
+		return StateDisconnected
+
+	case e.state.disconnecting:
+		return StateDisconnecting
+
+	case e.state.building:
+		return StateRegenerating
+
+	case e.identityRevision > e.realizedIdentityRevision:
+		return StateWaitingForIdentity
+
+	case e.state.buildsQueued > 0:
+		return StateWaitingToRegenerate
+
+	case !e.state.initialBuildSuccessful:
+		if e.state.restored {
+			return StateRestoring
+		}
+
+		return StateCreating
+
+	case e.state.consecutiveBuildFailures > 0 || e.state.lastBuildError != nil:
+		return StateNotReady
+
+	default:
+		return StateReady
+	}
+}
+
+// setBuilding is used to indicate whether the endpoint is currently being
+// built/regenerated. Note that this only includes the actual regeneration, not
+// the time in which the endpoint is queued and waiting to be regenerated.
+func (e *Endpoint) setBuilding(value bool, reason string) {
+	e.UnconditionalLock()
+	oldState := e.StateLocked()
+	e.state.building = value
+	e.postStateModificationLocked(oldState, reason)
+	e.Unlock()
+}
+
+// markRestored is called to mark an endpoint to have been restored
+func (e *Endpoint) markRestoredLocked() {
+	oldState := e.StateLocked()
+	e.state.restored = true
+	e.postStateModificationLocked(oldState, "Restoring endpoint from state")
+}
+
+// buildQueued is called each time an endpoint build has been queued
+func (e *Endpoint) buildQueued(reason string) {
+	e.UnconditionalLock()
+	oldState := e.StateLocked()
+	e.state.buildsQueued++
+	e.postStateModificationLocked(oldState, reason)
+	e.Unlock()
+}
+
+// buildDone is called after each successful, unsuccessful or cancelled
+// endpoint build/regeneration
+func (e *Endpoint) buildDone(success, cancelled bool, buildError error) {
+	e.UnconditionalLock()
+	oldState := e.StateLocked()
+	e.state.building = false
+	if success || !cancelled {
+		e.state.initialBuildSuccessful = true
+	}
+	e.state.buildsQueued--
+
+	switch {
+	case success:
+		e.state.lastBuildError = nil
+		e.state.consecutiveBuildFailures = 0
+		e.postStateModificationLocked(oldState, "Build successful")
+	case cancelled:
+		e.state.lastBuildError = fmt.Errorf("build timed out")
+		e.state.consecutiveBuildFailures++
+		e.postStateModificationLocked(oldState, "Build timed out")
+	case buildError != nil:
+		e.state.lastBuildError = buildError
+		e.state.consecutiveBuildFailures++
+		e.postStateModificationLocked(oldState, "Build failed: "+buildError.Error())
+	default:
+		e.state.lastBuildError = fmt.Errorf("unspecified build error")
+		e.state.consecutiveBuildFailures++
+		e.postStateModificationLocked(oldState, "Build failed without error")
+	}
+	e.Unlock()
+}
+
+// StartDisconnectingLocked starts to disconnect the endpoint. e.Mutex must be
+// held.
+func (e *Endpoint) StartDisconnectingLocked(reason string) {
+	oldState := e.StateLocked()
+	e.state.disconnecting = true
+	e.postStateModificationLocked(oldState, reason)
+}
+
+// markDisconnected marks the endpoint as disconnected
+func (e *Endpoint) markDisconnectedLocked() {
+	oldState := e.StateLocked()
+	e.state.disconnected = true
+	e.postStateModificationLocked(oldState, "")
+}
+
+// bumpIdentityRevisionLocked is called to indicate that identity relevant
+// labels may have changed and the identity must be resolved
+func (e *Endpoint) bumpIdentityRevisionLocked(reason string) int {
+	oldState := e.StateLocked()
+	e.identityRevision++
+	e.postStateModificationLocked(oldState, "%s, new identity revision is %d", reason, e.identityRevision)
+	return e.identityRevision
+}
+
+// markIdentityRevisionResolvedLocked is called when an identity has been
+// resolved. The revision number provided must be the revision returned from
+// bumpIdentityRevisionLocked() at the time the labels have changed.
+func (e *Endpoint) markIdentityRevisionResolvedLocked(rev int) {
+	if rev > e.realizedIdentityRevision {
+		oldState := e.StateLocked()
+		e.realizedIdentityRevision = rev
+		e.postStateModificationLocked(oldState, "Resolved identity revision %d to identity %d", rev, e.SecurityIdentity.ID)
+	}
+}
+
+// isDisconnectingLocked returns true if the endpoint is being disconnected or
+// already disconnected
+//
+// This function must be called after re-acquiring the endpoint mutex to verify
+// that the endpoint has not been removed in the meantime.
+//
+// endpoint.mutex must be held in read mode at least
+func (e *Endpoint) isDisconnectingLocked() bool {
+	return e.state.disconnecting
+}
+
+// postStateModificationLocked must be called after any endpoint field is
+// changed which may modify the endpoint's state
+func (e *Endpoint) postStateModificationLocked(oldState State, reason string, args ...interface{}) {
+	newState := e.StateLocked()
+
+	e.logStatusLocked(Info, oldState, reason, args...)
+
+	if e.state.initialStateTransitionDone {
+		metrics.EndpointStateCount.WithLabelValues(oldState.String()).Dec()
+	} else {
+		e.state.initialStateTransitionDone = true
+	}
+
+	// Since StateDisconnected is the final state, after which the
+	// endpoint is gone, we should not increment metrics for this state.
+	if newState != StateDisconnected {
+		metrics.EndpointStateCount.WithLabelValues(newState.String()).Inc()
+	}
+}
+
+// GetHealthModel returns the endpoint's health object.
+//
+// Must be called with e.Mutex locked or read-locked
+func (e *Endpoint) getHealthModel() (h *models.EndpointHealth) {
+	h = &models.EndpointHealth{
+		Bpf:           models.EndpointHealthStatusDisabled,
+		Policy:        models.EndpointHealthStatusDisabled,
+		Connected:     e.state.initialBuildSuccessful || e.state.restored,
+		OverallHealth: models.EndpointHealthStatusDisabled,
+	}
+
+	if e.state.disconnecting || e.state.disconnected {
+		return
+	}
+
+	switch {
+	case e.state.lastBuildError != nil:
+		h.Bpf = models.EndpointHealthStatusWarning
+		h.Policy = models.EndpointHealthStatusWarning
+		h.OverallHealth = models.EndpointHealthStatusWarning
+	case !e.state.initialBuildSuccessful:
+		h.Bpf = models.EndpointHealthStatusPending
+		h.Policy = models.EndpointHealthStatusPending
+		h.OverallHealth = models.EndpointHealthStatusPending
+	default:
+		h.Bpf = models.EndpointHealthStatusOK
+		h.Policy = models.EndpointHealthStatusOK
+		h.OverallHealth = models.EndpointHealthStatusOK
+	}
+
+	return
+}

--- a/pkg/endpoint/state_test.go
+++ b/pkg/endpoint/state_test.go
@@ -1,0 +1,84 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package endpoint
+
+import (
+	. "gopkg.in/check.v1"
+)
+
+func (s *EndpointSuite) TestEndpointState(c *C) {
+	// new endpoint, no changes yet
+	e := Endpoint{}
+	c.Assert(e.State(), Equals, StateCreating)
+
+	// resolving identity
+	e = Endpoint{identityRevision: 1}
+	c.Assert(e.State(), Equals, StateWaitingForIdentity)
+	c.Assert(e.StateLocked(), Equals, StateWaitingForIdentity)
+	c.Assert(e.ReadyToBuild(), Equals, false)
+
+	// identity resolved, back to restored
+	e = Endpoint{identityRevision: 1, realizedIdentityRevision: 1}
+	c.Assert(e.State(), Equals, StateCreating)
+	c.Assert(e.ReadyToBuild(), Equals, true)
+
+	// identity resolved, initial build queued
+	e = Endpoint{identityRevision: 1, realizedIdentityRevision: 1, state: state{buildsQueued: 1}}
+	c.Assert(e.State(), Equals, StateWaitingToRegenerate)
+	c.Assert(e.BuildPendingLocked(), Equals, true)
+
+	// identity resolved, initial build in progress
+	e = Endpoint{identityRevision: 1, realizedIdentityRevision: 1, state: state{building: true}}
+	c.Assert(e.State(), Equals, StateRegenerating)
+	c.Assert(e.BuildPendingLocked(), Equals, false)
+
+	// identity resolved, initial build successful
+	e = Endpoint{identityRevision: 1, realizedIdentityRevision: 1, state: state{initialBuildSuccessful: true}}
+	c.Assert(e.State(), Equals, StateReady)
+
+	// restored endpoint
+	e = Endpoint{state: state{restored: true}}
+	c.Assert(e.State(), Equals, StateRestoring)
+
+	// resolving identity
+	e = Endpoint{identityRevision: 1, state: state{restored: true}}
+	c.Assert(e.State(), Equals, StateWaitingForIdentity)
+
+	// identity resolved, back to restored
+	e = Endpoint{identityRevision: 1, realizedIdentityRevision: 1, state: state{restored: true}}
+	c.Assert(e.State(), Equals, StateRestoring)
+
+	// identity resolved, initial build queued
+	e = Endpoint{identityRevision: 1, realizedIdentityRevision: 1, state: state{restored: true, buildsQueued: 1}}
+	c.Assert(e.State(), Equals, StateWaitingToRegenerate)
+
+	// identity resolved, initial build in progress
+	e = Endpoint{identityRevision: 1, realizedIdentityRevision: 1, state: state{restored: true, building: true}}
+	c.Assert(e.State(), Equals, StateRegenerating)
+
+	// identity resolved, initial build successful
+	e = Endpoint{identityRevision: 1, realizedIdentityRevision: 1, state: state{restored: true, initialBuildSuccessful: true}}
+	c.Assert(e.State(), Equals, StateReady)
+
+	// identity resolved, initial build successful, build failing
+	e = Endpoint{identityRevision: 1, realizedIdentityRevision: 1, state: state{restored: true, initialBuildSuccessful: true, consecutiveBuildFailures: 1}}
+	c.Assert(e.State(), Equals, StateNotReady)
+
+	// disconnecting
+	e = Endpoint{identityRevision: 1, realizedIdentityRevision: 1, state: state{restored: true, initialBuildSuccessful: true, disconnecting: true}}
+	c.Assert(e.State(), Equals, StateDisconnecting)
+}

--- a/pkg/endpoint/status.go
+++ b/pkg/endpoint/status.go
@@ -15,86 +15,46 @@
 package endpoint
 
 import (
-	"fmt"
-	"sort"
 	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
-	"github.com/cilium/cilium/pkg/color"
 	"github.com/cilium/cilium/pkg/lock"
 )
 
-type StatusCode int
+// Severity is the severity of an endpoint log message
+type Severity int
 
 const (
-	OK       StatusCode = 0
-	Warning  StatusCode = -1
-	Failure  StatusCode = -2
-	Disabled StatusCode = -3
+	// Info indicates an informational message
+	Info Severity = 0
+
+	// Warning indicates a warning message
+	Warning Severity = -1
+
+	// Failure indicates a message about a failed operation
+	Failure Severity = -2
 )
 
-// StatusType represents the type for the given status, higher the value, higher
-// the priority.
-type StatusType int
-
-const (
-	BPF    StatusType = 200
-	Policy StatusType = 100
-	Other  StatusType = 0
-)
-
-type Status struct {
-	Code  StatusCode `json:"code"`
-	Msg   string     `json:"msg"`
-	Type  StatusType `json:"status-type"`
-	State string     `json:"state"`
-}
-
-func (sc StatusCode) ColorString() string {
-	var text string
-	switch sc {
-	case OK:
-		text = color.Green("OK")
-	case Warning:
-		text = color.Yellow("Warning")
-	case Failure:
-		text = color.Red("Failure")
-	case Disabled:
-		text = color.Yellow("Disabled")
-	default:
-		text = "Unknown code"
-	}
-	return fmt.Sprintf("%s", text)
-}
-
-func (sc StatusCode) String() string {
-	switch sc {
-	case OK:
-		return "OK"
+// String returns the severity as human readable string
+func (s Severity) String() string {
+	switch s {
+	case Info:
+		return "Info"
 	case Warning:
 		return "Warning"
 	case Failure:
 		return "Failure"
-	case Disabled:
-		return "Disabled"
 	default:
-		return "Unknown code"
+		return "Unknown"
 	}
 }
 
-func (s Status) String() string {
-	if s.Msg == "" {
-		return fmt.Sprintf("%s", s.Code)
-	}
-	return fmt.Sprintf("%s - %s", s.Code, s.Msg)
-}
-
-type StatusResponse struct {
-	KVStore    Status              `json:"kvstore"`
-	Docker     Status              `json:"docker"`
-	Kubernetes Status              `json:"kubernetes"`
-	Cilium     Status              `json:"cilium"`
-	IPAMStatus map[string][]string `json:",omitempty"`
+// Status is an endpoint status log message
+type Status struct {
+	Severity Severity `json:"code"`
+	Msg      string   `json:"msg"`
+	OldState string   `json:"old-state"`
+	State    string   `json:"state"`
 }
 
 // statusLogMsg represents a log message.
@@ -106,47 +66,8 @@ type statusLogMsg struct {
 // statusLog represents a slice of statusLogMsg.
 type statusLog []*statusLogMsg
 
-// componentStatus represents a map of a single statusLogMsg by StatusType.
-type componentStatus map[StatusType]*statusLogMsg
-
-// contains checks if the given `s` statusLogMsg is present in the
-// priorityStatus.
-func (ps componentStatus) contains(s *statusLogMsg) bool {
-	return ps[s.Status.Type] == s
-}
-
-// statusTypeSlice represents a slice of StatusType, is used for sorting
-// purposes.
-type statusTypeSlice []StatusType
-
-// Len returns the length of the slice.
-func (p statusTypeSlice) Len() int { return len(p) }
-
-// Less returns true if the element `j` is less than element `i`.
-// *It's reversed* so that we can sort the slice by high to lowest priority.
-func (p statusTypeSlice) Less(i, j int) bool { return p[i] > p[j] }
-
-// Swap swaps element in `i` with element in `j`.
-func (p statusTypeSlice) Swap(i, j int) { p[i], p[j] = p[j], p[i] }
-
-// sortByPriority returns a statusLog ordered from highest priority to lowest.
-func (ps componentStatus) sortByPriority() statusLog {
-	prs := statusTypeSlice{}
-	for k := range ps {
-		prs = append(prs, k)
-	}
-	sort.Sort(prs)
-	slogSorted := statusLog{}
-	for _, pr := range prs {
-		slogSorted = append(slogSorted, ps[pr])
-	}
-	return slogSorted
-}
-
 // EndpointStatus represents the endpoint status.
 type EndpointStatus struct {
-	// CurrentStatuses is the last status of a given priority.
-	CurrentStatuses componentStatus `json:"current-status,omitempty"`
 	// Contains the last maxLogs messages for this endpoint.
 	Log statusLog `json:"log,omitempty"`
 	// Index is the index in the statusLog, is used to keep track the next
@@ -157,10 +78,7 @@ type EndpointStatus struct {
 }
 
 func NewEndpointStatus() *EndpointStatus {
-	return &EndpointStatus{
-		CurrentStatuses: componentStatus{},
-		Log:             statusLog{},
-	}
+	return &EndpointStatus{Log: statusLog{}}
 }
 
 func (e *EndpointStatus) lastIndex() int {
@@ -179,11 +97,7 @@ func (e *EndpointStatus) getAndIncIdx() int {
 	if e.Index >= maxLogs {
 		e.Index = 0
 	}
-	// Lets skip the CurrentStatus message from the log to prevent removing
-	// non-OK status!
-	if e.Index < len(e.Log) &&
-		e.CurrentStatuses.contains(e.Log[e.Index]) &&
-		e.Log[e.Index].Status.Code != OK {
+	if e.Index < len(e.Log) {
 		e.Index++
 		if e.Index >= maxLogs {
 			e.Index = 0
@@ -193,25 +107,11 @@ func (e *EndpointStatus) getAndIncIdx() int {
 }
 
 // addStatusLog adds statusLogMsg to endpoint log.
-// example of e.Log's contents where maxLogs = 3 and Index = 0
-// [index] - Priority - Code
-// [0] - BPF - OK
-// [1] - Policy - Failure
-// [2] - BPF - OK
-// With this log, the CurrentStatus will keep [1] for Policy priority and [2]
-// for BPF priority.
-//
-// Whenever a new statusLogMsg is received, that log will be kept in the
-// CurrentStatus map for the statusLogMsg's priority.
-// The CurrentStatus map, ensures non of the failure messages are deleted for
-// higher priority messages and vice versa.
 func (e *EndpointStatus) addStatusLog(s *statusLogMsg) {
-	e.CurrentStatuses[s.Status.Type] = s
-	idx := e.getAndIncIdx()
 	if len(e.Log) < maxLogs {
 		e.Log = append(e.Log, s)
 	} else {
-		e.Log[idx] = s
+		e.Log[e.getAndIncIdx()] = s
 	}
 }
 
@@ -227,8 +127,9 @@ func (e *EndpointStatus) GetModel() []*models.EndpointStatusChange {
 		if i < len(e.Log) && e.Log[i] != nil {
 			list = append(list, &models.EndpointStatusChange{
 				Timestamp: e.Log[i].Timestamp.Format(time.RFC3339),
-				Code:      e.Log[i].Status.Code.String(),
+				Severity:  e.Log[i].Status.Severity.String(),
 				Message:   e.Log[i].Status.Msg,
+				OldState:  models.EndpointState(e.Log[i].Status.OldState),
 				State:     models.EndpointState(e.Log[i].Status.State),
 			})
 		}
@@ -237,20 +138,4 @@ func (e *EndpointStatus) GetModel() []*models.EndpointStatusChange {
 		}
 	}
 	return list
-}
-
-func (e *EndpointStatus) CurrentStatus() StatusCode {
-	e.indexMU.RLock()
-	defer e.indexMU.RUnlock()
-	sP := e.CurrentStatuses.sortByPriority()
-	for _, v := range sP {
-		if v.Status.Code != OK {
-			return v.Status.Code
-		}
-	}
-	return OK
-}
-
-func (e *EndpointStatus) String() string {
-	return e.CurrentStatus().String()
 }

--- a/pkg/endpointmanager/conntrack.go
+++ b/pkg/endpointmanager/conntrack.go
@@ -15,7 +15,6 @@
 package endpointmanager
 
 import (
-	"fmt"
 	"os"
 	"time"
 
@@ -57,7 +56,7 @@ func runGC(e *endpoint.Endpoint, ipv4, ipv6 bool, filter *ctmap.GCFilter) (mapTy
 				scopedLog.Warn(msg)
 			}
 			if e != nil {
-				e.LogStatus(endpoint.BPF, endpoint.Warning, fmt.Sprintf("%s: %s", msg, err))
+				e.LogStatus(endpoint.Warning, "%s: %s", msg, err)
 			}
 			continue
 		}

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -48,7 +48,7 @@ func (d *DummyRuleCacheOwner) ClearPolicyConsumers(id uint16) *sync.WaitGroup {
 }
 
 func (s *EndpointManagerSuite) TestLookup(c *C) {
-	ep := endpoint.NewEndpointWithState(s.repo, 10, endpoint.StateReady)
+	ep := endpoint.NewTestEndpoint(s.repo, 10)
 	ep.UpdateLogger(nil)
 	type args struct {
 		id string
@@ -294,7 +294,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 }
 
 func (s *EndpointManagerSuite) TestLookupCiliumID(c *C) {
-	ep := endpoint.NewEndpointWithState(s.repo, 2, endpoint.StateReady)
+	ep := endpoint.NewTestEndpoint(s.repo, 2)
 	ep.UpdateLogger(nil)
 	type args struct {
 		id uint16
@@ -361,7 +361,7 @@ func (s *EndpointManagerSuite) TestLookupCiliumID(c *C) {
 }
 
 func (s *EndpointManagerSuite) TestLookupContainerID(c *C) {
-	ep := endpoint.NewEndpointWithState(s.repo, 3, endpoint.StateReady)
+	ep := endpoint.NewTestEndpoint(s.repo, 3)
 	ep.UpdateLogger(nil)
 	type args struct {
 		id string
@@ -428,7 +428,7 @@ func (s *EndpointManagerSuite) TestLookupContainerID(c *C) {
 }
 
 func (s *EndpointManagerSuite) TestLookupIPv4(c *C) {
-	ep := endpoint.NewEndpointWithState(s.repo, 4, endpoint.StateReady)
+	ep := endpoint.NewTestEndpoint(s.repo, 4)
 	ep.UpdateLogger(nil)
 	type args struct {
 		ip string
@@ -497,7 +497,7 @@ func (s *EndpointManagerSuite) TestLookupIPv4(c *C) {
 }
 
 func (s *EndpointManagerSuite) TestLookupPodName(c *C) {
-	ep := endpoint.NewEndpointWithState(s.repo, 5, endpoint.StateReady)
+	ep := endpoint.NewTestEndpoint(s.repo, 5)
 	ep.UpdateLogger(nil)
 	type args struct {
 		podName string
@@ -565,7 +565,7 @@ func (s *EndpointManagerSuite) TestLookupPodName(c *C) {
 }
 
 func (s *EndpointManagerSuite) TestUpdateReferences(c *C) {
-	ep := endpoint.NewEndpointWithState(s.repo, 6, endpoint.StateReady)
+	ep := endpoint.NewTestEndpoint(s.repo, 6)
 	ep.UpdateLogger(nil)
 	type args struct {
 		ep *endpoint.Endpoint
@@ -645,7 +645,7 @@ func (s *EndpointManagerSuite) TestUpdateReferences(c *C) {
 }
 
 func (s *EndpointManagerSuite) TestRemove(c *C) {
-	ep := endpoint.NewEndpointWithState(s.repo, 7, endpoint.StateReady)
+	ep := endpoint.NewTestEndpoint(s.repo, 7)
 	ep.UpdateLogger(nil)
 	type args struct {
 	}
@@ -685,7 +685,7 @@ func (s *EndpointManagerSuite) TestRemove(c *C) {
 }
 
 func (s *EndpointManagerSuite) TestHasGlobalCT(c *C) {
-	ep := endpoint.NewEndpointWithState(s.repo, 1, endpoint.StateReady)
+	ep := endpoint.NewTestEndpoint(s.repo, 1)
 	ep.UpdateLogger(nil)
 	type args struct {
 		ep *endpoint.Endpoint
@@ -748,7 +748,7 @@ func (s *EndpointManagerSuite) TestHasGlobalCT(c *C) {
 }
 
 func (s *EndpointManagerSuite) TestWaitForEndpointsAtPolicyRev(c *C) {
-	ep := endpoint.NewEndpointWithState(s.repo, 1, endpoint.StateReady)
+	ep := endpoint.NewTestEndpoint(s.repo, 1)
 	ep.UpdateLogger(nil)
 	type args struct {
 		ctx    context.Context
@@ -787,7 +787,7 @@ func (s *EndpointManagerSuite) TestWaitForEndpointsAtPolicyRev(c *C) {
 			},
 			postTestRun: func() {
 				WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s.repo, 1, endpoint.StateReady)
+				ep = endpoint.NewTestEndpoint(s.repo, 1)
 			},
 		},
 		{
@@ -813,7 +813,7 @@ func (s *EndpointManagerSuite) TestWaitForEndpointsAtPolicyRev(c *C) {
 			},
 			postTestRun: func() {
 				WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s.repo, 1, endpoint.StateReady)
+				ep = endpoint.NewTestEndpoint(s.repo, 1)
 			},
 		},
 		{
@@ -839,7 +839,7 @@ func (s *EndpointManagerSuite) TestWaitForEndpointsAtPolicyRev(c *C) {
 			},
 			postTestRun: func() {
 				WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s.repo, 1, endpoint.StateReady)
+				ep = endpoint.NewTestEndpoint(s.repo, 1)
 			},
 		},
 	}

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -86,7 +86,7 @@ func (s *DNSProxyTestSuite) SetUpSuite(c *C) {
 
 	proxy, err := StartDNSProxy("", 0,
 		func(ip net.IP) (*endpoint.Endpoint, error) {
-			ep := endpoint.NewEndpointWithState(s.repo, 123, endpoint.StateReady)
+			ep := endpoint.NewTestEndpoint(s.repo, 123)
 			return ep, nil
 		},
 		func(lookupTime time.Time, ep *endpoint.Endpoint, epIPPort string, dstAddr string, msg *dns.Msg, protocol string, allowed bool, stat ProxyRequestContext) error {

--- a/pkg/k8s/endpointsynchronizer/cep.go
+++ b/pkg/k8s/endpointsynchronizer/cep.go
@@ -118,11 +118,10 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 				// it. Deleting first allows for upgrade scenarios where the format has
 				// changed but our k8s CEP code cannot read in the upstream value.
 				if needInit {
-					state := e.GetState()
+					state := e.State()
 					// Don't bother to create if the
 					// endpoint is already disconnecting
-					if state == endpoint.StateDisconnecting ||
-						state == endpoint.StateDisconnected {
+					if state == endpoint.StateDisconnecting {
 						return nil
 					}
 

--- a/pkg/proxy/kafka_test.go
+++ b/pkg/proxy/kafka_test.go
@@ -216,7 +216,7 @@ func (s *proxyTestSuite) TestKafkaRedirect(c *C) {
 
 	// Insert a mock EP to the endpointmanager so that DefaultEndpointInfoRegistry may find
 	// the EP ID by the IP.
-	ep := endpoint.NewEndpointWithState(s.repo, uint16(localEndpointMock.GetID()), endpoint.StateReady)
+	ep := endpoint.NewTestEndpoint(s.repo, uint16(localEndpointMock.GetID()))
 	ipv4, err := addressing.NewCiliumIPv4("127.0.0.1")
 	c.Assert(err, IsNil)
 	ep.IPv4 = ipv4

--- a/plugins/cilium-cni/chaining/flannel/flannel.go
+++ b/plugins/cilium-cni/chaining/flannel/flannel.go
@@ -118,7 +118,6 @@ func (f *flannelChainer) Add(ctx context.Context, pluginCtx chainingapi.PluginCo
 			IPV4: vethIP,
 		},
 		ContainerID:       pluginCtx.Args.ContainerID,
-		State:             models.EndpointStateWaitingForIdentity,
 		HostMac:           hostMac,
 		InterfaceIndex:    int64(vethHostIdx),
 		Mac:               vethLXCMac,

--- a/plugins/cilium-cni/chaining/generic-veth/generic-veth.go
+++ b/plugins/cilium-cni/chaining/generic-veth/generic-veth.go
@@ -152,7 +152,6 @@ func (f *GenericVethChainer) Add(ctx context.Context, pluginCtx chainingapi.Plug
 			IPV4: vethIP,
 		},
 		ContainerID:       pluginCtx.Args.ContainerID,
-		State:             models.EndpointStateWaitingForIdentity,
 		HostMac:           hostMac,
 		InterfaceIndex:    int64(vethHostIdx),
 		Mac:               vethLXCMac,

--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -358,7 +358,6 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 	ep := &models.EndpointChangeRequest{
 		ContainerID:  args.ContainerID,
 		Labels:       addLabels,
-		State:        models.EndpointStateWaitingForIdentity,
 		Addressing:   &models.AddressPair{},
 		K8sPodName:   string(cniArgs.K8S_POD_NAME),
 		K8sNamespace: string(cniArgs.K8S_POD_NAMESPACE),

--- a/plugins/cilium-docker/driver/driver.go
+++ b/plugins/cilium-docker/driver/driver.go
@@ -291,7 +291,6 @@ func (driver *driver) createEndpoint(w http.ResponseWriter, r *http.Request) {
 
 	endpoint := &models.EndpointChangeRequest{
 		SyncBuildEndpoint: true,
-		State:             models.EndpointStateWaitingForIdentity,
 		DockerEndpointID:  create.EndpointID,
 		DockerNetworkID:   create.NetworkID,
 		Addressing: &models.AddressPair{


### PR DESCRIPTION
This commit removes the endpoint state machine and replaces it with a set of
state variables that keep track of individual states an endpoint can be in.
The overall endpoint state is then derived based on those fine grained state
variables.

This avoids requiring to ensure well-defined states when regenerating and
decouples decouples individual code sections better.

* **Creating:** The endpoint has been created via the API and has not been
  successfully built yet. The endpoint is *not* connected.

* **Restoring:** The endpoint is being restored from previous state and has not
  been rebuilt yet. The connectivity state of the endpoint depends on the
  endpoint state while the previous instance of the Cilium agent was managing
  the endpoint. The endpoint will transition to Ready once the restore
  operation has completed successfully.

* **Regenerating:** The endpoint is currently being regenerated to implement
  the desired state such as policy requirements. The endpoint may or may not be
  currently connected. After the build has been completed, the endpoint will
  transition into a state that represents the connectivity state.

* **WaitingForIdentity:** The endpoint had its identity metadata changed and is
  currently resolving its new identity. After successful identity resolution,
  the endpoint will be regenerated as needed.

* **WaitingToRegenerate:** The latest changes have been integrated but there are
  changes outstanding to be incorporated. The endpoint is queued to be built.

* **Ready:** The endpoint is stable and healthy without outstanding changes

* **Disconnecting:** The endpoint is being removed

* **Disconnected:** The endpoint has been removed.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8354)
<!-- Reviewable:end -->
