### PR TITLE
test: add `ExecShort` function, misc. cleanups

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -30,6 +30,10 @@ var (
 	// HelperTimeout is a predefined timeout value for commands.
 	HelperTimeout = 4 * time.Minute
 
+	// ShortCommandTimeout is a timeout for commands which should not take a
+	// long time to execute.
+	ShortCommandTimeout = 10 * time.Second
+
 	// CiliumStartTimeout is a predefined timeout value for Cilium startup.
 	CiliumStartTimeout = 100 * time.Second
 

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1256,25 +1256,6 @@ func (kub *Kubectl) CiliumExecUntilMatch(pod, cmd, substr string) error {
 		&TimeoutConfig{Timeout: HelperTimeout})
 }
 
-// CiliumExecAll runs cmd in all cilium instances
-func (kub *Kubectl) CiliumExecAll(cmd string) error {
-	pods, err := kub.GetCiliumPods(KubeSystemNamespace)
-	if err != nil {
-		return fmt.Errorf("cannot retrieve cilium pods: %s", err)
-	}
-	if len(pods) == 0 {
-		return fmt.Errorf("No cilium pods available")
-	}
-
-	for _, pod := range pods {
-		res := kub.CiliumExec(pod, cmd)
-		if !res.WasSuccessful() {
-			return fmt.Errorf("Command failed on %s: %s", pod, res.CombineOutput())
-		}
-	}
-	return nil
-}
-
 // WaitForCiliumInitContainerToFinish waits for all Cilium init containers to
 // finish
 func (kub *Kubectl) WaitForCiliumInitContainerToFinish() error {

--- a/test/helpers/node.go
+++ b/test/helpers/node.go
@@ -170,6 +170,22 @@ func (s *SSHMeta) Exec(cmd string, options ...ExecOptions) *CmdRes {
 	return s.ExecContext(ctx, cmd, options...)
 }
 
+// ExecShort runs command with the provided options. It will take up to
+// ShortCommandTimeout seconds to run the command before it times out.
+func (s *SSHMeta) ExecShort(cmd string, options ...ExecOptions) *CmdRes {
+	ctx, cancel := context.WithTimeout(context.Background(), ShortCommandTimeout)
+	defer cancel()
+	return s.ExecContext(ctx, cmd, options...)
+}
+
+// ExecContextShort is a wrapper around ExecContext which creates a child
+// context with a timeout of ShortCommandTimeout.
+func (s *SSHMeta) ExecContextShort(ctx context.Context, cmd string, options ...ExecOptions) *CmdRes {
+	shortCtx, cancel := context.WithTimeout(ctx, ShortCommandTimeout)
+	defer cancel()
+	return s.ExecContext(shortCtx, cmd, options...)
+}
+
 // ExecContext returns the results of executing the provided cmd via SSH.
 func (s *SSHMeta) ExecContext(ctx context.Context, cmd string, options ...ExecOptions) *CmdRes {
 	var ops ExecOptions


### PR DESCRIPTION
`ExecShort` runs commands that do not require a lot of time to complete with a timeout of 10 seconds. Before, the default was up to 5 minutes. Now, we have separate timeouts depending on the nature of the command being ran. Use `ExecShort` in various helper functions that should return results quickly.

Also use context more consistently across other various helper functions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8355)
<!-- Reviewable:end -->
