### PR TITLE
Test k8s CI without iptables forward allow policy

### DIFF
--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -257,8 +257,8 @@ sudo systemctl restart $MOUNT_SYSTEMD
 sudo rm -rfv /var/lib/kubelet
 
 # Allow iptables forwarding so kube-dns can function.
-sudo iptables -P FORWARD ACCEPT
-sudo ip6tables -P FORWARD ACCEPT
+#sudo iptables -P FORWARD ACCEPT
+#sudo ip6tables -P FORWARD ACCEPT
 
 #check hostname to know if is kubernetes or runtime test
 if [[ "${HOST}" == "k8s1" ]]; then


### PR DESCRIPTION
Looking into the possibility of a regression from https://github.com/cilium/cilium/pull/7944

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8356)
<!-- Reviewable:end -->
