### PR TITLE
CI: Clean VMs and reclaim disk in nightly test

### DIFF
--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -53,6 +53,7 @@ pipeline {
                 sh 'rm -rf src; mkdir -p src/github.com/cilium'
                 sh 'ln -s $WORKSPACE src/github.com/cilium/cilium'
                 checkout scm
+                sh '/usr/local/bin/cleanup || true'
             }
         }
         stage('Preload vagrant boxes') {
@@ -120,6 +121,7 @@ pipeline {
             sh "cd ${TESTDIR}; vagrant destroy -f || true"
             sh 'cd ${TEST_DIR}; ./post_build_agent.sh || true'
             cleanWs()
+            sh '/usr/local/bin/cleanup || true'
         }
         success {
             Status("SUCCESS", "$JOB_BASE_NAME")


### PR DESCRIPTION
We didn't cleanup VM images in the nighty test. This isn't a problem
overall but nodes that may see more nightly builds (e.g.
jenkins-fixed-node-0) may run out of space if only these jobs execute.
We now run the cleanup script in a similar way to our other jobs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8358)
<!-- Reviewable:end -->
