### PR TITLE
pkg/metrics: re-register newStatusCollector function

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -975,6 +975,7 @@ func init() {
 	MustRegister(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{Namespace: Namespace}))
 	// TODO: Figure out how to put this into a Namespace
 	// MustRegister(prometheus.NewGoCollector())
+	MustRegister(newStatusCollector())
 }
 
 // MustRegister adds the collector to the registry, exposing this metric to


### PR DESCRIPTION
Fixes: 0fec218c33ff ("pkg/metrics: set all metrics as a no-op unless they are enabled")
Reported-by: Christian <christian.huening@figo.io>
Signed-off-by: André Martins <andre@cilium.io>

```release-note
Re add `cilium_unreachable_nodes`, `cilium_controllers_failing`,  `cilium_ip_addresses`, `cilium_unreachable_health_endpoints` accidentally removed
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8361)
<!-- Reviewable:end -->
