### PR TITLE
u8proto: Be compatible with policy/api

### DIFF
--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -357,10 +357,10 @@ func updateBackendsLocked(addedBackends map[loadbalancer.BackendID]ServiceValue)
 
 		if svcVal.IsIPv6() {
 			svc6Val := svcVal.(*Service6Value)
-			b, err = NewBackend6(backendID, svc6Val.Address.IP(), svc6Val.Port, u8proto.All)
+			b, err = NewBackend6(backendID, svc6Val.Address.IP(), svc6Val.Port, u8proto.ANY)
 		} else {
 			svc4Val := svcVal.(*Service4Value)
-			b, err = NewBackend4(backendID, svc4Val.Address.IP(), svc4Val.Port, u8proto.All)
+			b, err = NewBackend4(backendID, svc4Val.Address.IP(), svc4Val.Port, u8proto.ANY)
 		}
 		if err != nil {
 			return err
@@ -436,10 +436,10 @@ func updateServiceV2Locked(fe ServiceKey, backends map[BackendAddrID]ServiceValu
 
 	if fe.IsIPv6() {
 		svc6Key := fe.(*Service6Key)
-		svcKeyV2 = NewService6KeyV2(svc6Key.Address.IP(), svc6Key.Port, u8proto.All, 0)
+		svcKeyV2 = NewService6KeyV2(svc6Key.Address.IP(), svc6Key.Port, u8proto.ANY, 0)
 	} else {
 		svc4Key := fe.(*Service4Key)
-		svcKeyV2 = NewService4KeyV2(svc4Key.Address.IP(), svc4Key.Port, u8proto.All, 0)
+		svcKeyV2 = NewService4KeyV2(svc4Key.Address.IP(), svc4Key.Port, u8proto.ANY, 0)
 	}
 
 	svcValV2, err := lookupServiceV2(svcKeyV2)
@@ -917,9 +917,9 @@ func DeleteServiceV2(svc loadbalancer.L3n4AddrID, releaseBackendID func(loadbala
 	log.WithField(logfields.ServiceName, svc).Debug("Deleting service")
 
 	if isIPv6 {
-		svcKey = NewService6KeyV2(svc.IP, svc.Port, u8proto.All, 0)
+		svcKey = NewService6KeyV2(svc.IP, svc.Port, u8proto.ANY, 0)
 	} else {
-		svcKey = NewService4KeyV2(svc.IP, svc.Port, u8proto.All, 0)
+		svcKey = NewService4KeyV2(svc.IP, svc.Port, u8proto.ANY, 0)
 	}
 
 	backendsToRemove, backendsCount, err := cache.removeServiceV2(svcKey)
@@ -978,9 +978,9 @@ func DeleteServiceCache(svc loadbalancer.L3n4AddrID) {
 func DeleteOrphanServiceV2AndRevNAT(svc loadbalancer.L3n4AddrID, delRevNAT bool) error {
 	var svcKey ServiceKeyV2
 	if !svc.IsIPv6() {
-		svcKey = NewService4KeyV2(svc.IP, svc.Port, u8proto.All, 0)
+		svcKey = NewService4KeyV2(svc.IP, svc.Port, u8proto.ANY, 0)
 	} else {
-		svcKey = NewService6KeyV2(svc.IP, svc.Port, u8proto.All, 0)
+		svcKey = NewService6KeyV2(svc.IP, svc.Port, u8proto.ANY, 0)
 	}
 
 	svcKey.SetSlave(0)
@@ -1001,9 +1001,9 @@ func DeleteOrphanServiceV2AndRevNAT(svc loadbalancer.L3n4AddrID, delRevNAT bool)
 	for i := numBackends; i > 0; i-- {
 		var slaveKey ServiceKeyV2
 		if !svc.IsIPv6() {
-			slaveKey = NewService4KeyV2(svc.IP, svc.Port, u8proto.All, i)
+			slaveKey = NewService4KeyV2(svc.IP, svc.Port, u8proto.ANY, i)
 		} else {
-			slaveKey = NewService6KeyV2(svc.IP, svc.Port, u8proto.All, i)
+			slaveKey = NewService6KeyV2(svc.IP, svc.Port, u8proto.ANY, i)
 		}
 		log.WithFields(logrus.Fields{
 			"idx.backend": i,

--- a/pkg/maps/lbmap/lbmap_test.go
+++ b/pkg/maps/lbmap/lbmap_test.go
@@ -218,12 +218,12 @@ func (b *LBMapTestSuite) TestGetBackends(c *C) {
 }
 
 func (b *LBMapTestSuite) TestBackendAddrID(c *C) {
-	b4, err := NewBackend4Value(net.ParseIP("1.1.1.1"), 80, u8proto.All)
+	b4, err := NewBackend4Value(net.ParseIP("1.1.1.1"), 80, u8proto.ANY)
 	c.Assert(err, IsNil)
 	v4 := NewService4Value(0, net.ParseIP("1.1.1.1"), 80, 0, 0)
 	c.Assert(b4.BackendAddrID(), Equals, v4.BackendAddrID())
 
-	b6, err := NewBackend6Value(net.ParseIP("f00d::0:0"), 80, u8proto.All)
+	b6, err := NewBackend6Value(net.ParseIP("f00d::0:0"), 80, u8proto.ANY)
 	c.Assert(err, IsNil)
 	v6 := NewService6Value(0, net.ParseIP("f00d::0:0"), 80, 0, 0)
 	c.Assert(b6.BackendAddrID(), Equals, v6.BackendAddrID())

--- a/pkg/maps/lbmap/types.go
+++ b/pkg/maps/lbmap/types.go
@@ -521,16 +521,16 @@ func serviceKeynValuenBackendValue2FEnBE(svcKey ServiceKeyV2, svcValue ServiceVa
 func l3n4Addr2ServiceKeyV2(l3n4Addr loadbalancer.L3n4AddrID) ServiceKeyV2 {
 	log.WithField(logfields.L3n4AddrID, l3n4Addr).Debug("converting L3n4Addr to ServiceKeyV2")
 	if l3n4Addr.IsIPv6() {
-		return NewService6KeyV2(l3n4Addr.IP, l3n4Addr.Port, u8proto.All, 0)
+		return NewService6KeyV2(l3n4Addr.IP, l3n4Addr.Port, u8proto.ANY, 0)
 	}
 
-	return NewService4KeyV2(l3n4Addr.IP, l3n4Addr.Port, u8proto.All, 0)
+	return NewService4KeyV2(l3n4Addr.IP, l3n4Addr.Port, u8proto.ANY, 0)
 }
 
 func lbBackEnd2Backend(be loadbalancer.LBBackEnd) (Backend, error) {
 	if be.IsIPv6() {
-		return NewBackend6(loadbalancer.BackendID(be.ID), be.IP, be.Port, u8proto.All)
+		return NewBackend6(loadbalancer.BackendID(be.ID), be.IP, be.Port, u8proto.ANY)
 	}
 
-	return NewBackend4(loadbalancer.BackendID(be.ID), be.IP, be.Port, u8proto.All)
+	return NewBackend4(loadbalancer.BackendID(be.ID), be.IP, be.Port, u8proto.ANY)
 }

--- a/pkg/policy/api/l4.go
+++ b/pkg/policy/api/l4.go
@@ -18,6 +18,8 @@ package api
 type L4Proto string
 
 const (
+	// Keep pkg/u8proto up-to-date with any additions here
+
 	ProtoTCP L4Proto = "TCP"
 	ProtoUDP L4Proto = "UDP"
 	ProtoAny L4Proto = "ANY"

--- a/pkg/u8proto/u8proto.go
+++ b/pkg/u8proto/u8proto.go
@@ -20,9 +20,12 @@ import (
 	"strings"
 )
 
+// These definitions must contain and be compatible with the string
+// values defined for pkg/pollicy/api/L4Proto
+
 const (
-	// All represents all protocols.
-	All    U8proto = 0
+	// ANY represents all protocols.
+	ANY    U8proto = 0
 	ICMP   U8proto = 1
 	TCP    U8proto = 6
 	UDP    U8proto = 17
@@ -30,7 +33,7 @@ const (
 )
 
 var protoNames = map[U8proto]string{
-	0:  "all",
+	0:  "ANY",
 	1:  "ICMP",
 	6:  "TCP",
 	17: "UDP",


### PR DESCRIPTION
Change the string form of the wildcard protocol from "All" to "ANY" to
be compatible with the definitions in policy/api.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8362)
<!-- Reviewable:end -->
