### PR TITLE
api: add field which caches content of LabelSelector string representation of EndpointSelector

### DIFF
--- a/pkg/policy/api/egress.go
+++ b/pkg/policy/api/egress.go
@@ -188,6 +188,9 @@ func (e *EgressRule) GetDestinationEndpointSelectorsWithRequirements(requirement
 			sel := *e.ToEndpoints[idx].DeepCopy()
 			sel.MatchExpressions = append(sel.MatchExpressions, requirements...)
 			sel.SyncRequirementsWithLabelSelector()
+			// Even though this string is deep copied, we need to override it
+			// because we are updating the contents of the MatchExpressions.
+			sel.cachedLabelSelectorString = sel.LabelSelector.String()
 			res = append(res, sel)
 		}
 	} else {

--- a/pkg/policy/api/ingress.go
+++ b/pkg/policy/api/ingress.go
@@ -145,6 +145,9 @@ func (i *IngressRule) GetSourceEndpointSelectorsWithRequirements(requirements []
 			sel := *i.FromEndpoints[idx].DeepCopy()
 			sel.MatchExpressions = append(sel.MatchExpressions, requirements...)
 			sel.SyncRequirementsWithLabelSelector()
+			// Even though this string is deep copied, we need to override it
+			// because we are updating the contents of the MatchExpressions.
+			sel.cachedLabelSelectorString = sel.LabelSelector.String()
 			res = append(res, sel)
 		}
 	} else {

--- a/pkg/policy/api/zz_generated.deepcopy.go
+++ b/pkg/policy/api/zz_generated.deepcopy.go
@@ -179,6 +179,13 @@ func (in *EgressRule) DeepCopyInto(out *EgressRule) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.aggregatedSelectors != nil {
+		in, out := &in.aggregatedSelectors, &out.aggregatedSelectors
+		*out = make(EndpointSelectorSlice, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 
@@ -342,6 +349,13 @@ func (in *IngressRule) DeepCopyInto(out *IngressRule) {
 		in, out := &in.FromEntities, &out.FromEntities
 		*out = make(EntitySlice, len(*in))
 		copy(*out, *in)
+	}
+	if in.aggregatedSelectors != nil {
+		in, out := &in.aggregatedSelectors, &out.aggregatedSelectors
+		*out = make(EndpointSelectorSlice, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 	return
 }

--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -578,7 +578,7 @@ func (sc *SelectorCache) AddFQDNSelector(user CachedSelectionUser, fqdnSelec api
 // FindCachedIdentitySelector finds the given api.EndpointSelector in the
 // selector cache, returning nil if one can not be found.
 func (sc *SelectorCache) FindCachedIdentitySelector(selector api.EndpointSelector) CachedSelector {
-	key := selector.LabelSelector.String()
+	key := selector.CachedString()
 	sc.mutex.Lock()
 	idSel := sc.selectors[key]
 	sc.mutex.Unlock()
@@ -594,7 +594,7 @@ func (sc *SelectorCache) AddIdentitySelector(user CachedSelectionUser, selector 
 	// labelselectors, if the selector's requirements are stored
 	// in different orders. When this happens we'll be tracking
 	// essentially two copies of the same selector.
-	key := selector.LabelSelector.String()
+	key := selector.CachedString()
 	sc.mutex.Lock()
 	defer sc.mutex.Unlock()
 	idSel, exists := sc.selectors[key]


### PR DESCRIPTION
Performance analysis of policy generatinon revealed that there was a large
amount of time being spent calling \`String()\` on the LabelSelector
within the EndpointSelector, as the string representation of the LabelSelector
within an EndpointSelector is used to lookup the set of identities matched
by said EndpointSelector in the SelectorCache. To reduce the performance
impact of creation of strings upon policy computation, store the string
representation of the LabelSelector as a non-exported field in the
EndpointSelector.

This field is populated whenever we create an EndpointSelector in Cilium.
This will consume more memory overall in the cilium-agent, but the performance
improvements gained by caching this string representation are considerable:

Before:

```
PASS: resolve_test.go:166: PolicyTestSuite.BenchmarkRegeneratePolicyRules	     200	   9003593 ns/op
```

```
ROUTINE ======================== github.com/cilium/cilium/pkg/policy.(*SelectorCache).AddIdentitySelector in /Users/ianvernon/go/src/github.com/cilium/cilium/pkg/policy/selectorcache.go
      40ms      1.49s (flat, cum) 49.34% of Total
         .          .    592:func (sc *SelectorCache) AddIdentitySelector(user CachedSelectionUser, selector api.EndpointSelector) (cachedSelector CachedSelector, added bool) {
         .          .    593:	// The key returned here may be different for equivalent
         .          .    594:	// labelselectors, if the selector's requirements are stored
         .          .    595:	// in different orders. When this happens we'll be tracking
         .          .    596:	// essentially two copies of the same selector.
         .      600ms    597:	key := selector.LabelSelector.String()
         .       10ms    598:	sc.mutex.Lock()

```

After:

```
PASS: resolve_test.go:166: PolicyTestSuite.BenchmarkRegeneratePolicyRules	     500	   6230246 ns/op
```

```
      70ms      1.18s (flat, cum) 29.80% of Total
         .          .    593:	// The key returned here may be different for equivalent
         .          .    594:	// labelselectors, if the selector's requirements are stored
         .          .    595:	// in different orders. When this happens we'll be tracking
         .          .    596:	// essentially two copies of the same selector.
         .          .    597:	key := selector.CachedString()
```

This is approximately a 31 % performance increase in the policy computation
benchmark.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #8093 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8365)
<!-- Reviewable:end -->
