### PR TITLE
v1.5 backports 2019-06-21

### DIFF
--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -371,13 +371,13 @@ New ConfigMap Options
     Kubernetes event handling by listening for k8s events in the operator and
     mirroring it into the kvstore for reduced overhead in large clusters.
 
-  * ``enable-legacy-services``: enables legacy services (prior v1.5) to
-    prevent from terminating established connections to services when
-    upgrading Cilium from < v1.5 to v1.5. If enabled, the option needs
-    to stay enabled until a user is confident that they will not need to
-    downgrade to < v1.5 anymore. Disabling and then enabling the option is
-    not possible without breaking the established connections from `Pod`
-    to `Service`.
+  * ``enable-legacy-services``: enables legacy services (prior v1.5) to prevent
+    from terminating established connections to services when upgrading Cilium
+    from < v1.5 to v1.5. When the option is not disabled, legacy services are
+    enabled by default. Legacy services need to stay enabled until a user is
+    confident that they will not need to downgrade to < v1.5 anymore. Disabling
+    and then enabling legacy services is not possible without breaking the
+    established connections from `Pod` to `Service`.
 
 Deprecated Options
 ~~~~~~~~~~~~~~~~~~

--- a/daemon/fqdn.go
+++ b/daemon/fqdn.go
@@ -222,7 +222,7 @@ func (d *Daemon) bootstrapFQDN(restoredEndpoints *endpointRestoreState, preCache
 		//   can lookup the endpoint related to it
 		// epAddr and serverAddr should match the original request, where epAddr is
 		// the source for egress (the only case current).
-		func(lookupTime time.Time, ep *endpoint.Endpoint, serverAddr string, msg *dns.Msg, protocol string, allowed bool, stat dnsproxy.ProxyRequestContext) error {
+		func(lookupTime time.Time, ep *endpoint.Endpoint, epIPPort string, serverAddr string, msg *dns.Msg, protocol string, allowed bool, stat dnsproxy.ProxyRequestContext) error {
 			var protoID = u8proto.ProtoIDs[strings.ToLower(protocol)]
 			var verdict accesslog.FlowVerdict
 			var reason string
@@ -295,7 +295,7 @@ func (d *Daemon) bootstrapFQDN(restoredEndpoints *endpointRestoreState, preCache
 				func(lr *logger.LogRecord) { lr.LogRecord.TransportProtocol = accesslog.TransportProtocol(protoID) },
 				logger.LogTags.Verdict(verdict, reason),
 				logger.LogTags.Addressing(logger.AddressingInfo{
-					SrcIPPort:   ep.String(),
+					SrcIPPort:   epIPPort,
 					DstIPPort:   serverAddr,
 					SrcIdentity: ep.GetIdentity().Uint32(),
 				}),

--- a/flannel.Jenkinsfile
+++ b/flannel.Jenkinsfile
@@ -106,6 +106,7 @@ pipeline {
             sh 'cd ${TESTDIR}/test/; K8S_VERSION=1.10 vagrant destroy -f || true'
             sh 'cd ${TESTDIR}/test/; K8S_VERSION=1.13 vagrant destroy -f || true'
             cleanWs()
+            sh '/usr/local/bin/cleanup || true'
         }
         success {
             Status("SUCCESS", "$JOB_BASE_NAME")

--- a/ginkgo-kubernetes-all.Jenkinsfile
+++ b/ginkgo-kubernetes-all.Jenkinsfile
@@ -319,6 +319,7 @@ pipeline {
             archiveArtifacts artifacts: '*.zip'
             junit testDataPublishers: [[$class: 'AttachmentPublisher']], testResults: 'src/github.com/cilium/cilium/test/*.xml'
             cleanWs()
+            sh '/usr/local/bin/cleanup || true'
         }
         success {
             Status("SUCCESS", "${env.JOB_NAME}")

--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -246,4 +246,10 @@ pipeline {
             }
         }
     }
+
+    post {
+        always {
+            sh '/usr/local/bin/cleanup || true'
+        }
+    }
 }

--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -241,7 +241,6 @@ pipeline {
                 always {
                     archiveArtifacts artifacts: '*.zip'
                     junit testDataPublishers: [[$class: 'AttachmentPublisher']], testResults: 'src/github.com/cilium/cilium/test/*.xml'
-                    cleanWs()
                 }
             }
         }
@@ -249,6 +248,7 @@ pipeline {
 
     post {
         always {
+            cleanWs()
             sh '/usr/local/bin/cleanup || true'
         }
     }

--- a/kubernetes-upstream.Jenkinsfile
+++ b/kubernetes-upstream.Jenkinsfile
@@ -106,6 +106,7 @@ pipeline {
         always {
             sh 'cd ${TESTDIR}; K8S_VERSION=${K8S_VERSION} vagrant destroy -f || true'
             cleanWs()
+            sh '/usr/local/bin/cleanup || true'
         }
         success {
             Status("SUCCESS", "$JOB_BASE_NAME")

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -121,7 +121,7 @@ type LookupEndpointIDByIPFunc func(ip net.IP) (endpoint *endpoint.Endpoint, err 
 
 // NotifyOnDNSMsgFunc handles propagating DNS response data
 // See DNSProxy.LookupEndpointIDByIP for usage.
-type NotifyOnDNSMsgFunc func(lookupTime time.Time, ep *endpoint.Endpoint, serverAddr string, msg *dns.Msg, protocol string, allowed bool, stat ProxyRequestContext) error
+type NotifyOnDNSMsgFunc func(lookupTime time.Time, ep *endpoint.Endpoint, epIPPort string, serverAddr string, msg *dns.Msg, protocol string, allowed bool, stat ProxyRequestContext) error
 
 // ProxyRequestContext proxy dns request context struct to send in the callback
 type ProxyRequestContext struct {
@@ -284,12 +284,13 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		logfields.DNSRequestID: request.Id})
 	scopedLog.Debug("Handling DNS query from endpoint")
 
-	addr, _, err := net.SplitHostPort(w.RemoteAddr().String())
+	epIPPort := w.RemoteAddr().String()
+	addr, _, err := net.SplitHostPort(epIPPort)
 	if err != nil {
 		scopedLog.WithError(err).Error("cannot extract endpoint IP from DNS request")
 		stat.Err = fmt.Errorf("Cannot extract endpoint IP from DNS request: %s", err)
 		stat.ProcessingTime.End(false)
-		p.NotifyOnDNSMsg(time.Now(), nil, "", request, protocol, false, stat)
+		p.NotifyOnDNSMsg(time.Now(), nil, epIPPort, "", request, protocol, false, stat)
 		p.sendRefused(scopedLog, w, request)
 		return
 	}
@@ -298,7 +299,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		scopedLog.WithError(err).Error("cannot extract endpoint ID from DNS request")
 		stat.Err = fmt.Errorf("Cannot extract endpoint ID from DNS request: %s", err)
 		stat.ProcessingTime.End(false)
-		p.NotifyOnDNSMsg(time.Now(), nil, "", request, protocol, false, stat)
+		p.NotifyOnDNSMsg(time.Now(), nil, epIPPort, "", request, protocol, false, stat)
 		p.sendRefused(scopedLog, w, request)
 		return
 	}
@@ -310,7 +311,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		scopedLog.WithError(err).Error("Cannot extract target server address to forward DNS request to")
 		stat.Err = fmt.Errorf("Cannot extract target server address to forward DNS request to: %s", err)
 		stat.ProcessingTime.End(false)
-		p.NotifyOnDNSMsg(time.Now(), ep, targetServerAddr, request, protocol, false, stat)
+		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerAddr, request, protocol, false, stat)
 		p.sendRefused(scopedLog, w, request)
 		return
 	}
@@ -325,12 +326,12 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		scopedLog.Debug("Rejecting DNS query from endpoint due to policy")
 		stat.Err = p.sendRefused(scopedLog, w, request)
 		stat.ProcessingTime.End(true)
-		p.NotifyOnDNSMsg(time.Now(), ep, targetServerAddr, request, protocol, false, stat)
+		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerAddr, request, protocol, false, stat)
 		return
 	}
 
 	scopedLog.Debug("Forwarding DNS request for a name that is allowed")
-	p.NotifyOnDNSMsg(time.Now(), ep, targetServerAddr, request, protocol, true, stat)
+	p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerAddr, request, protocol, true, stat)
 
 	// Keep the same L4 protocol. This handles DNS re-requests over TCP, for
 	// requests that were too large for UDP.
@@ -344,7 +345,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		scopedLog.Error("Cannot parse DNS proxy client network to select forward client")
 		stat.Err = fmt.Errorf("Cannot parse DNS proxy client network to select forward client: %s", err)
 		stat.ProcessingTime.End(true)
-		p.NotifyOnDNSMsg(time.Now(), ep, targetServerAddr, request, protocol, false, stat)
+		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerAddr, request, protocol, false, stat)
 		p.sendRefused(scopedLog, w, request)
 		return
 	}
@@ -363,7 +364,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 			p.sendRefused(scopedLog, w, request)
 			stat.Err = fmt.Errorf("Cannot forward proxied DNS lookup: %s", err)
 		}
-		p.NotifyOnDNSMsg(time.Now(), ep, targetServerAddr, request, protocol, false, stat)
+		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerAddr, request, protocol, false, stat)
 		return
 	}
 
@@ -377,13 +378,13 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	if err != nil {
 		scopedLog.WithError(err).Error("Cannot forward proxied DNS response")
 		stat.Err = fmt.Errorf("Cannot forward proxied DNS response: %s", err)
-		p.NotifyOnDNSMsg(time.Now(), ep, targetServerAddr, response, protocol, true, stat)
+		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerAddr, response, protocol, true, stat)
 	}
 
 	// Note: This may block and it is safer to do it after we have written out
 	// the DNS response to the pod.
 	scopedLog.Debug("Notifying with DNS response to original DNS query")
-	p.NotifyOnDNSMsg(time.Now(), ep, targetServerAddr, response, protocol, true, stat)
+	p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerAddr, response, protocol, true, stat)
 }
 
 // sendRefused creates and sends a REFUSED response for request to w

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -86,7 +86,7 @@ func (s *DNSProxyTestSuite) SetUpSuite(c *C) {
 			ep := endpoint.NewEndpointWithState(123, endpoint.StateReady)
 			return ep, nil
 		},
-		func(lookupTime time.Time, ep *endpoint.Endpoint, dstAddr string, msg *dns.Msg, protocol string, allowed bool, stat ProxyRequestContext) error {
+		func(lookupTime time.Time, ep *endpoint.Endpoint, epIPPort string, dstAddr string, msg *dns.Msg, protocol string, allowed bool, stat ProxyRequestContext) error {
 			return nil
 		})
 	c.Assert(err, IsNil, Commentf("error starting DNS Proxy"))

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -976,6 +976,7 @@ func init() {
 	MustRegister(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{Namespace: Namespace}))
 	// TODO: Figure out how to put this into a Namespace
 	// MustRegister(prometheus.NewGoCollector())
+	MustRegister(newStatusCollector())
 }
 
 // MustRegister adds the collector to the registry, exposing this metric to

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -30,6 +30,10 @@ var (
 	// HelperTimeout is a predefined timeout value for commands.
 	HelperTimeout = 5 * time.Minute
 
+	// ShortCommandTimeout is a timeout for commands which should not take a
+	// long time to execute.
+	ShortCommandTimeout = 10 * time.Second
+
 	// CiliumStartTimeout is a predefined timeout value for Cilium startup.
 	CiliumStartTimeout = 100 * time.Second
 

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -306,7 +306,7 @@ func (kub *Kubectl) GetAllPods(ctx context.Context, options ...ExecOptions) ([]v
 // in the specified namespace, along with an error if the pod names cannot be
 // retrieved.
 func (kub *Kubectl) GetPodNames(namespace string, label string) ([]string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), HelperTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	return kub.GetPodNamesContext(ctx, namespace, label)
 }
@@ -322,9 +322,9 @@ func (kub *Kubectl) GetPodNamesContext(ctx context.Context, namespace string, la
 
 	// Taking more than 30 seconds to get pods means that something is wrong
 	// connecting to the node.
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	podNamesCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	err := kub.ExecuteContext(ctx, cmd, stdout, nil)
+	err := kub.ExecuteContext(podNamesCtx, cmd, stdout, nil)
 
 	if err != nil {
 		return nil, fmt.Errorf(

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -306,7 +306,7 @@ func (kub *Kubectl) GetAllPods(ctx context.Context, options ...ExecOptions) ([]v
 // in the specified namespace, along with an error if the pod names cannot be
 // retrieved.
 func (kub *Kubectl) GetPodNames(namespace string, label string) ([]string, error) {
-	ctx, cancel := context.WithCancel(context.TODO())
+	ctx, cancel := context.WithTimeout(context.Background(), HelperTimeout)
 	defer cancel()
 	return kub.GetPodNamesContext(ctx, namespace, label)
 }

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1906,7 +1906,6 @@ func (kub *Kubectl) CiliumPreFlightCheck() error {
 	// Doing this withTimeout because the Status can be ready, but the other
 	// nodes cannot be show up yet, and the cilium-health can fail as a false positive.
 	var (
-		err                 error
 		lastError           string
 		consecutiveFailures int
 	)
@@ -1928,7 +1927,7 @@ func (kub *Kubectl) CiliumPreFlightCheck() error {
 	}
 	timeoutErr := WithTimeout(body, "PreflightCheck failed", &TimeoutConfig{Timeout: HelperTimeout})
 	if timeoutErr != nil {
-		return fmt.Errorf("CiliumPreFlightCheck error: %s: %s", timeoutErr, err)
+		return fmt.Errorf("CiliumPreFlightCheck error: %s: Last polled error: %s", timeoutErr, lastError)
 	}
 	return nil
 }

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -320,10 +320,9 @@ func (kub *Kubectl) GetPodNamesContext(ctx context.Context, namespace string, la
 
 	cmd := fmt.Sprintf("%s -n %s get pods -l %s %s", KubectlCmd, namespace, label, filter)
 
-	// Since we have no timeout, ensure that the context given to ExecuteContext
-	// eventually cancels in case something is blocked on ctx.Done() (something
-	// is).
-	ctx, cancel := context.WithCancel(context.TODO())
+	// Taking more than 30 seconds to get pods means that something is wrong
+	// connecting to the node.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	err := kub.ExecuteContext(ctx, cmd, stdout, nil)
 

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -320,7 +320,12 @@ func (kub *Kubectl) GetPodNamesContext(ctx context.Context, namespace string, la
 
 	cmd := fmt.Sprintf("%s -n %s get pods -l %s %s", KubectlCmd, namespace, label, filter)
 
-	err := kub.ExecuteContext(context.TODO(), cmd, stdout, nil)
+	// Since we have no timeout, ensure that the context given to ExecuteContext
+	// eventually cancels in case something is blocked on ctx.Done() (something
+	// is).
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	err := kub.ExecuteContext(ctx, cmd, stdout, nil)
 
 	if err != nil {
 		return nil, fmt.Errorf(

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -550,7 +550,7 @@ func (kub *Kubectl) NodeCleanMetadata() error {
 	}
 	for _, node := range strings.Split(data.Output().String(), " ") {
 		for _, label := range metadata {
-			kub.Exec(fmt.Sprintf("%s annotate nodes %s %s", KubectlCmd, node, label))
+			kub.Exec(fmt.Sprintf("%s annotate --overwrite nodes %s %s=''", KubectlCmd, node, label))
 		}
 	}
 	return nil

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -98,7 +98,7 @@ func CreateKubectl(vmName string, log *logrus.Entry) *Kubectl {
 	// This `ls` command is a sanity check, sometimes the meta ssh info is not
 	// nil but new commands cannot be executed using SSH, tests failed and it
 	// was hard to debug.
-	res := node.Exec("ls /tmp/")
+	res := node.ExecShort("ls /tmp/")
 	if !res.WasSuccessful() {
 		ginkgoext.Fail(fmt.Sprintf(
 			"Cannot execute ls command on vmName '%s'", vmName), 1)
@@ -119,7 +119,7 @@ func (kub *Kubectl) CepGet(namespace string, pod string) *cnpv2.EndpointStatus {
 		"namespace": namespace})
 
 	cmd := fmt.Sprintf("%s -n %s get cep %s -o json | jq '.status'", KubectlCmd, namespace, pod)
-	res := kub.Exec(cmd)
+	res := kub.ExecShort(cmd)
 	if !res.WasSuccessful() {
 		log.Debug("cep is not present")
 		return nil
@@ -137,7 +137,7 @@ func (kub *Kubectl) CepGet(namespace string, pod string) *cnpv2.EndpointStatus {
 // GetNumNodes returns the number of Kubernetes nodes running
 func (kub *Kubectl) GetNumNodes() int {
 	getNodesCmd := fmt.Sprintf("%s get nodes -o jsonpath='{.items.*.metadata.name}'", KubectlCmd)
-	res := kub.Exec(getNodesCmd)
+	res := kub.ExecShort(getNodesCmd)
 	if !res.WasSuccessful() {
 		return 0
 	}
@@ -182,13 +182,13 @@ func (kub *Kubectl) ExecPodCmdContext(ctx context.Context, namespace string, pod
 
 // Get retrieves the provided Kubernetes objects from the specified namespace.
 func (kub *Kubectl) Get(namespace string, command string) *CmdRes {
-	return kub.Exec(fmt.Sprintf(
+	return kub.ExecShort(fmt.Sprintf(
 		"%s -n %s get %s -o json", KubectlCmd, namespace, command))
 }
 
 // GetFromAllNS retrieves provided Kubernetes objects from all namespaces
 func (kub *Kubectl) GetFromAllNS(kind string) *CmdRes {
-	return kub.Exec(fmt.Sprintf(
+	return kub.ExecShort(fmt.Sprintf(
 		"%s get %s --all-namespaces -o json", KubectlCmd, kind))
 }
 
@@ -221,7 +221,7 @@ func (kub *Kubectl) WaitForCRDCount(filter string, count int, timeout time.Durat
 	// at most one match per line (like "grep <filter> | wc -l")
 	regex := regexp.MustCompile("(?m:^.*(?:" + filter + ").*$)")
 	body := func() bool {
-		res := kub.Exec(fmt.Sprintf("%s get crds", KubectlCmd))
+		res := kub.ExecShort(fmt.Sprintf("%s get crds", KubectlCmd))
 		if !res.WasSuccessful() {
 			log.Error(res.GetErr("kubectl get crds failed"))
 			return false
@@ -237,7 +237,7 @@ func (kub *Kubectl) WaitForCRDCount(filter string, count int, timeout time.Durat
 // GetPods gets all of the pods in the given namespace that match the provided
 // filter.
 func (kub *Kubectl) GetPods(namespace string, filter string) *CmdRes {
-	return kub.Exec(fmt.Sprintf("%s -n %s get pods %s -o json", KubectlCmd, namespace, filter))
+	return kub.ExecShort(fmt.Sprintf("%s -n %s get pods %s -o json", KubectlCmd, namespace, filter))
 }
 
 // GetPodsNodes returns a map with pod name as a key and node name as value. It
@@ -258,7 +258,7 @@ func (kub *Kubectl) GetPodsNodes(namespace string, filter string) (map[string]st
 // returns an error if pods cannot be retrieved correctly
 func (kub *Kubectl) GetPodsIPs(namespace string, filter string) (map[string]string, error) {
 	jsonFilter := `{range .items[*]}{@.metadata.name}{"="}{@.status.podIP}{"\n"}{end}`
-	res := kub.Exec(fmt.Sprintf("%s -n %s get pods -l %s -o jsonpath='%s'",
+	res := kub.ExecShort(fmt.Sprintf("%s -n %s get pods -l %s -o jsonpath='%s'",
 		KubectlCmd, namespace, filter, jsonFilter))
 	if !res.WasSuccessful() {
 		return nil, fmt.Errorf("cannot retrieve pods: %s", res.CombineOutput())
@@ -269,7 +269,7 @@ func (kub *Kubectl) GetPodsIPs(namespace string, filter string) (map[string]stri
 // GetEndpoints gets all of the endpoints in the given namespace that match the
 // provided filter.
 func (kub *Kubectl) GetEndpoints(namespace string, filter string) *CmdRes {
-	return kub.Exec(fmt.Sprintf("%s -n %s get endpoints %s -o json", KubectlCmd, namespace, filter))
+	return kub.ExecShort(fmt.Sprintf("%s -n %s get endpoints %s -o json", KubectlCmd, namespace, filter))
 }
 
 // GetAllPods returns a slice of all pods present in Kubernetes cluster, along
@@ -281,8 +281,11 @@ func (kub *Kubectl) GetAllPods(ctx context.Context, options ...ExecOptions) ([]v
 		ops = options[0]
 	}
 
+	getPodsCtx, cancel := context.WithTimeout(ctx, ShortCommandTimeout)
+	defer cancel()
+
 	var podsList v1.List
-	err := kub.ExecContext(ctx,
+	err := kub.ExecContext(getPodsCtx,
 		fmt.Sprintf("%s get pods --all-namespaces -o json", KubectlCmd),
 		ExecOptions{SkipLog: ops.SkipLog}).Unmarshal(&podsList)
 	if err != nil {
@@ -306,7 +309,7 @@ func (kub *Kubectl) GetAllPods(ctx context.Context, options ...ExecOptions) ([]v
 // in the specified namespace, along with an error if the pod names cannot be
 // retrieved.
 func (kub *Kubectl) GetPodNames(namespace string, label string) ([]string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), ShortCommandTimeout)
 	defer cancel()
 	return kub.GetPodNamesContext(ctx, namespace, label)
 }
@@ -322,7 +325,7 @@ func (kub *Kubectl) GetPodNamesContext(ctx context.Context, namespace string, la
 
 	// Taking more than 30 seconds to get pods means that something is wrong
 	// connecting to the node.
-	podNamesCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	podNamesCtx, cancel := context.WithTimeout(ctx, ShortCommandTimeout)
 	defer cancel()
 	err := kub.ExecuteContext(podNamesCtx, cmd, stdout, nil)
 
@@ -548,13 +551,13 @@ func (kub *Kubectl) NodeCleanMetadata() error {
 		annotation.V6CIDRName,
 	}
 
-	data := kub.Exec(fmt.Sprintf("%s get nodes -o jsonpath='{.items[*].metadata.name}'", KubectlCmd))
+	data := kub.ExecShort(fmt.Sprintf("%s get nodes -o jsonpath='{.items[*].metadata.name}'", KubectlCmd))
 	if !data.WasSuccessful() {
 		return fmt.Errorf("could not get nodes via %s: %s", KubectlCmd, data.CombineOutput())
 	}
 	for _, node := range strings.Split(data.Output().String(), " ") {
 		for _, label := range metadata {
-			kub.Exec(fmt.Sprintf("%s annotate --overwrite nodes %s %s=''", KubectlCmd, node, label))
+			kub.ExecShort(fmt.Sprintf("%s annotate --overwrite nodes %s %s=''", KubectlCmd, node, label))
 		}
 	}
 	return nil
@@ -562,12 +565,12 @@ func (kub *Kubectl) NodeCleanMetadata() error {
 
 // NamespaceCreate creates a new Kubernetes namespace with the given name
 func (kub *Kubectl) NamespaceCreate(name string) *CmdRes {
-	return kub.Exec(fmt.Sprintf("%s create namespace %s", KubectlCmd, name))
+	return kub.ExecShort(fmt.Sprintf("%s create namespace %s", KubectlCmd, name))
 }
 
 // NamespaceDelete deletes a given Kubernetes namespace
 func (kub *Kubectl) NamespaceDelete(name string) *CmdRes {
-	return kub.Exec(fmt.Sprintf("%s delete namespace %s", KubectlCmd, name))
+	return kub.ExecShort(fmt.Sprintf("%s delete namespace %s", KubectlCmd, name))
 }
 
 // WaitforPods waits up until timeout seconds have elapsed for all pods in the
@@ -673,20 +676,20 @@ func (kub *Kubectl) WaitForServiceEndpoints(namespace string, filter string, ser
 // manifest located at path filepath in the given namespace
 func (kub *Kubectl) Action(action ResourceLifeCycleAction, filePath string) *CmdRes {
 	kub.logger.Debugf("performing '%v' on '%v'", action, filePath)
-	return kub.Exec(fmt.Sprintf("%s %s -f %s", KubectlCmd, action, filePath))
+	return kub.ExecShort(fmt.Sprintf("%s %s -f %s", KubectlCmd, action, filePath))
 }
 
 // Apply applies the Kubernetes manifest located at path filepath.
 func (kub *Kubectl) Apply(filePath string) *CmdRes {
 	kub.logger.Debugf("applying %s", filePath)
-	return kub.Exec(
+	return kub.ExecShort(
 		fmt.Sprintf("%s apply -f  %s", KubectlCmd, filePath))
 }
 
 // Create creates the Kubernetes kanifest located at path filepath.
 func (kub *Kubectl) Create(filePath string) *CmdRes {
 	kub.logger.Debugf("creating %s", filePath)
-	return kub.Exec(
+	return kub.ExecShort(
 		fmt.Sprintf("%s create -f  %s", KubectlCmd, filePath))
 }
 
@@ -694,7 +697,7 @@ func (kub *Kubectl) Create(filePath string) *CmdRes {
 // <resourceName>.
 func (kub *Kubectl) CreateResource(resource, resourceName string) *CmdRes {
 	kub.logger.Debug(fmt.Sprintf("creating resource %s with name %s", resource, resourceName))
-	return kub.Exec(fmt.Sprintf("kubectl create %s %s", resource, resourceName))
+	return kub.ExecShort(fmt.Sprintf("kubectl create %s %s", resource, resourceName))
 }
 
 // DeleteResource is a wrapper around `kubernetes delete <resource>
@@ -707,7 +710,7 @@ func (kub *Kubectl) DeleteResource(resource, resourceName string) *CmdRes {
 // Delete deletes the Kubernetes manifest at path filepath.
 func (kub *Kubectl) Delete(filePath string) *CmdRes {
 	kub.logger.Debugf("deleting %s", filePath)
-	return kub.Exec(
+	return kub.ExecShort(
 		fmt.Sprintf("%s delete -f  %s", KubectlCmd, filePath))
 }
 
@@ -754,12 +757,12 @@ func (kub *Kubectl) WaitForKubeDNSEntry(serviceName, serviceNamespace string) er
 		// an IP of the pod itself, not ClusterIPNone, which is what Kubernetes
 		// shows as the IP for the service for headless services.
 		if serviceIP == v1.ClusterIPNone {
-			res := kub.Exec(fmt.Sprintf(digCMD, serviceNameWithNamespace, dnsClusterIP))
-			_ = kub.Exec(fmt.Sprintf(digCMDFallback, serviceNameWithNamespace, dnsClusterIP))
+			res := kub.ExecShort(fmt.Sprintf(digCMD, serviceNameWithNamespace, dnsClusterIP))
+			_ = kub.ExecShort(fmt.Sprintf(digCMDFallback, serviceNameWithNamespace, dnsClusterIP))
 			return res.WasSuccessful()
 		}
 		log.Debugf("service is not headless; checking whether IP retrieved from DNS matches the IP for the service stored in Kubernetes")
-		res := kub.Exec(fmt.Sprintf(digCMD, serviceNameWithNamespace, dnsClusterIP))
+		res := kub.ExecShort(fmt.Sprintf(digCMD, serviceNameWithNamespace, dnsClusterIP))
 		serviceIPFromDNS := res.SingleOut()
 		if !govalidator.IsIP(serviceIPFromDNS) {
 			logger.Debugf("output of dig (%s) did not return an IP", serviceIPFromDNS)
@@ -774,7 +777,7 @@ func (kub *Kubectl) WaitForKubeDNSEntry(serviceName, serviceNamespace string) er
 		// name to resolve via DNS.
 		if !strings.Contains(serviceIPFromDNS, serviceIP) {
 			logger.Debugf("service IP retrieved from DNS (%s) does not match the IP for the service stored in Kubernetes (%s)", serviceIPFromDNS, serviceIP)
-			_ = kub.Exec(fmt.Sprintf(digCMDFallback, serviceNameWithNamespace, dnsClusterIP))
+			_ = kub.ExecShort(fmt.Sprintf(digCMDFallback, serviceNameWithNamespace, dnsClusterIP))
 			return false
 		}
 		logger.Debugf("service IP retrieved from DNS (%s) matches the IP for the service stored in Kubernetes (%s)", serviceIPFromDNS, serviceIP)
@@ -792,7 +795,7 @@ func (kub *Kubectl) WaitForKubeDNSEntry(serviceName, serviceNamespace string) er
 // given timeout (in seconds) it returns an error
 func (kub *Kubectl) WaitCleanAllTerminatingPods(timeout time.Duration) error {
 	body := func() bool {
-		res := kub.Exec(fmt.Sprintf(
+		res := kub.ExecShort(fmt.Sprintf(
 			"%s get pods --all-namespaces -o jsonpath='{.items[*].metadata.deletionTimestamp}'",
 			KubectlCmd))
 		if !res.WasSuccessful() {
@@ -827,11 +830,11 @@ func (kub *Kubectl) DeployPatch(original, patch string) error {
 		// dry-run is only available since k8s 1.11
 		switch GetCurrentK8SEnv() {
 		case "1.8", "1.9", "1.10":
-			_ = kub.Exec(fmt.Sprintf(
+			_ = kub.ExecShort(fmt.Sprintf(
 				`%s patch --filename='%s' --patch "$(cat '%s')" --local -o yaml`,
 				KubectlCmd, original, patch))
 		default:
-			_ = kub.Exec(fmt.Sprintf(
+			_ = kub.ExecShort(fmt.Sprintf(
 				`%s patch --filename='%s' --patch "$(cat '%s')" --local --dry-run -o yaml`,
 				KubectlCmd, original, patch))
 		}
@@ -843,7 +846,7 @@ func (kub *Kubectl) DeployPatch(original, patch string) error {
 	switch GetCurrentK8SEnv() {
 	case "1.8", "1.9", "1.10":
 	default:
-		res = kub.Exec(fmt.Sprintf(
+		res = kub.ExecShort(fmt.Sprintf(
 			`%s patch --filename='%s' --patch "$(cat '%s')" --local --dry-run`,
 			KubectlCmd, original, patch))
 		if !res.WasSuccessful() {
@@ -852,7 +855,7 @@ func (kub *Kubectl) DeployPatch(original, patch string) error {
 		}
 	}
 
-	res = kub.Exec(fmt.Sprintf(
+	res = kub.ExecShort(fmt.Sprintf(
 		`%s patch --filename='%s' --patch "$(cat '%s')" --local -o yaml | kubectl apply -f -`,
 		KubectlCmd, original, patch))
 	if !res.WasSuccessful() {
@@ -889,11 +892,11 @@ func (kub *Kubectl) ciliumInstall(dsPatchName, cmPatchName string, getK8sDescrip
 		// debugYaml only dumps the full created yaml file to the test output if
 		// the cilium manifest can not be created correctly.
 		debugYaml := func(original string) {
-			_ = kub.Exec(fmt.Sprintf("kubectl apply --filename='%s' --dry-run -o yaml", original))
+			_ = kub.ExecShort(fmt.Sprintf("kubectl apply --filename='%s' --dry-run -o yaml", original))
 		}
 
 		// validation 1st
-		res := kub.Exec(fmt.Sprintf("kubectl apply --filename='%s' --dry-run", original))
+		res := kub.ExecShort(fmt.Sprintf("kubectl apply --filename='%s' --dry-run", original))
 		if !res.WasSuccessful() {
 			debugYaml(original)
 			return res.GetErr("Cilium manifest validation fails")
@@ -1068,7 +1071,9 @@ func (kub *Kubectl) CiliumEndpointsList(ctx context.Context, pod string) *CmdRes
 // endpoint's status
 func (kub *Kubectl) CiliumEndpointsStatus(pod string) map[string]string {
 	filter := `{range [*]}{@.status.external-identifiers.pod-name}{"="}{@.status.state}{"\n"}{end}`
-	return kub.CiliumExec(pod, fmt.Sprintf(
+	ctx, cancel := context.WithTimeout(context.Background(), ShortCommandTimeout)
+	defer cancel()
+	return kub.CiliumExecContext(ctx, pod, fmt.Sprintf(
 		"cilium endpoint list -o jsonpath='%s'", filter)).KVOutput()
 }
 
@@ -1240,7 +1245,9 @@ func (kub *Kubectl) CiliumExec(pod string, cmd string) *CmdRes {
 // If the timeout is reached it will return an error.
 func (kub *Kubectl) CiliumExecUntilMatch(pod, cmd, substr string) error {
 	body := func() bool {
-		res := kub.CiliumExec(pod, cmd)
+		ctx, cancel := context.WithTimeout(context.Background(), ShortCommandTimeout)
+		defer cancel()
+		res := kub.CiliumExecContext(ctx, pod, cmd)
 		return strings.Contains(res.Output().String(), substr)
 	}
 
@@ -1308,7 +1315,7 @@ func (kub *Kubectl) WaitForCiliumInitContainerToFinish() error {
 func (kub *Kubectl) CiliumNodesWait() (bool, error) {
 	body := func() bool {
 		filter := `{range .items[*]}{@.metadata.name}{"="}{@.metadata.annotations.io\.cilium\.network\.ipv4-pod-cidr}{"\n"}{end}`
-		data := kub.Exec(fmt.Sprintf(
+		data := kub.ExecShort(fmt.Sprintf(
 			"%s get nodes -o jsonpath='%s'", KubectlCmd, filter))
 		if !data.WasSuccessful() {
 			return false
@@ -1335,7 +1342,9 @@ func (kub *Kubectl) CiliumNodesWait() (bool, error) {
 // be deleted after some amount of time.
 func (kub *Kubectl) WaitPolicyDeleted(pod string, policyName string) error {
 	body := func() bool {
-		res := kub.CiliumExec(pod, fmt.Sprintf("cilium policy get %s", policyName))
+		ctx, cancel := context.WithTimeout(context.Background(), ShortCommandTimeout)
+		defer cancel()
+		res := kub.CiliumExecContext(ctx, pod, fmt.Sprintf("cilium policy get %s", policyName))
 
 		// `cilium policy get <policy name>` fails if the policy is not loaded,
 		// which is the condition we want.
@@ -1348,14 +1357,18 @@ func (kub *Kubectl) WaitPolicyDeleted(pod string, policyName string) error {
 // CiliumIsPolicyLoaded returns true if the policy is loaded in the given
 // cilium Pod. it returns false in case that the policy is not in place
 func (kub *Kubectl) CiliumIsPolicyLoaded(pod string, policyCmd string) bool {
-	res := kub.CiliumExec(pod, fmt.Sprintf("cilium policy get %s", policyCmd))
+	ctx, cancel := context.WithTimeout(context.Background(), ShortCommandTimeout)
+	defer cancel()
+	res := kub.CiliumExecContext(ctx, pod, fmt.Sprintf("cilium policy get %s", policyCmd))
 	return res.WasSuccessful()
 }
 
 // CiliumPolicyRevision returns the policy revision in the specified Cilium pod.
 // Returns an error if the policy revision cannot be retrieved.
 func (kub *Kubectl) CiliumPolicyRevision(pod string) (int, error) {
-	res := kub.CiliumExec(pod, "cilium policy get -o json")
+	ctx, cancel := context.WithTimeout(context.Background(), ShortCommandTimeout)
+	defer cancel()
+	res := kub.CiliumExecContext(ctx, pod, "cilium policy get -o json")
 	if !res.WasSuccessful() {
 		return -1, fmt.Errorf("cannot get the revision %s", res.Output())
 	}
@@ -1408,7 +1421,7 @@ func (kub *Kubectl) CiliumPolicyAction(namespace, filepath string, action Resour
 		cmd := fmt.Sprintf("%s get cnp --all-namespaces -o json | jq '%s'",
 			KubectlCmd, jqFilter)
 
-		res := kub.Exec(cmd)
+		res := kub.ExecShort(cmd)
 		if !res.WasSuccessful() {
 			kub.logger.WithError(res.GetErr("")).Error("cannot get cnp status")
 			return false
@@ -1440,7 +1453,7 @@ func (kub *Kubectl) CiliumPolicyAction(namespace, filepath string, action Resour
 	}
 
 	knpBody := func() bool {
-		knp := kub.Exec(fmt.Sprintf("%s get --all-namespaces netpol -o jsonpath='%s'",
+		knp := kub.ExecShort(fmt.Sprintf("%s get --all-namespaces netpol -o jsonpath='%s'",
 			KubectlCmd, npFilter))
 		result := knp.ByLines()
 		if len(result) == 0 {
@@ -1499,7 +1512,7 @@ func (kub *Kubectl) CiliumReport(namespace string, commands ...string) {
 	if err != nil {
 		kub.logger.WithError(err).Error("cannot retrieve cilium pods on ReportDump")
 	}
-	res := kub.ExecContext(ctx, fmt.Sprintf("%s get pods -o wide --all-namespaces", KubectlCmd))
+	res := kub.ExecContextShort(ctx, fmt.Sprintf("%s get pods -o wide --all-namespaces", KubectlCmd))
 	ginkgoext.GinkgoPrint(res.GetDebugMessage())
 
 	for _, pod := range pods {
@@ -1556,18 +1569,18 @@ func (kub *Kubectl) CiliumCheckReport(ctx context.Context) {
 	fmt.Fprintf(CheckLogs, "Cilium pods: %v\n", pods)
 
 	var policiesFilter = `{range .items[*]}{.metadata.namespace}{"::"}{.metadata.name}{" "}{end}`
-	netpols := kub.ExecContext(ctx, fmt.Sprintf(
+	netpols := kub.ExecContextShort(ctx, fmt.Sprintf(
 		"%s get netpol -o jsonpath='%s' --all-namespaces",
 		KubectlCmd, policiesFilter))
 	fmt.Fprintf(CheckLogs, "Netpols loaded: %v\n", netpols.Output())
 
-	cnp := kub.ExecContext(ctx, fmt.Sprintf(
+	cnp := kub.ExecContextShort(ctx, fmt.Sprintf(
 		"%s get cnp -o jsonpath='%s' --all-namespaces",
 		KubectlCmd, policiesFilter))
 	fmt.Fprintf(CheckLogs, "CiliumNetworkPolicies loaded: %v\n", cnp.Output())
 
 	cepFilter := `{range .items[*]}{.metadata.name}{"="}{.status.policy.ingress.enforcing}{":"}{.status.policy.egress.enforcing}{"\n"}{end}`
-	cepStatus := kub.ExecContext(ctx, fmt.Sprintf(
+	cepStatus := kub.ExecContextShort(ctx, fmt.Sprintf(
 		"%s get cep -o jsonpath='%s' --all-namespaces",
 		KubectlCmd, cepFilter))
 
@@ -1628,14 +1641,18 @@ func (kub *Kubectl) CiliumCheckReport(ctx context.Context) {
 // `deadlocks` or `segmentation faults` messages. In case of any of these
 // messages, it'll mark the test as failed.
 func (kub *Kubectl) ValidateNoErrorsInLogs(duration time.Duration) {
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+
 	var logs string
 	cmd := fmt.Sprintf("%s -n %s logs --timestamps=true -l k8s-app=cilium --since=%vs",
 		KubectlCmd, KubeSystemNamespace, duration.Seconds())
-	res := kub.Exec(fmt.Sprintf("%s --previous", cmd), ExecOptions{SkipLog: true})
+	res := kub.ExecContext(ctx, fmt.Sprintf("%s --previous", cmd), ExecOptions{SkipLog: true})
 	if res.WasSuccessful() {
 		logs += res.Output().String()
 	}
-	res = kub.Exec(cmd, ExecOptions{SkipLog: true})
+	res = kub.ExecContext(ctx, cmd, ExecOptions{SkipLog: true})
 	if res.WasSuccessful() {
 		logs += res.Output().String()
 	}
@@ -1850,7 +1867,7 @@ func (kub *Kubectl) GetCiliumPodOnNode(namespace string, node string) (string, e
 	filter := fmt.Sprintf(
 		"-o jsonpath='{.items[?(@.spec.nodeName == \"%s\")].metadata.name}'", node)
 
-	res := kub.Exec(fmt.Sprintf(
+	res := kub.ExecShort(fmt.Sprintf(
 		"%s -n %s get pods -l k8s-app=cilium %s", KubectlCmd, namespace, filter))
 	if !res.WasSuccessful() {
 		return "", fmt.Errorf("Cilium pod not found on node '%s'", node)

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1257,25 +1257,6 @@ func (kub *Kubectl) CiliumExecUntilMatch(pod, cmd, substr string) error {
 		&TimeoutConfig{Timeout: HelperTimeout})
 }
 
-// CiliumExecAll runs cmd in all cilium instances
-func (kub *Kubectl) CiliumExecAll(cmd string) error {
-	pods, err := kub.GetCiliumPods(KubeSystemNamespace)
-	if err != nil {
-		return fmt.Errorf("cannot retrieve cilium pods: %s", err)
-	}
-	if len(pods) == 0 {
-		return fmt.Errorf("No cilium pods available")
-	}
-
-	for _, pod := range pods {
-		res := kub.CiliumExec(pod, cmd)
-		if !res.WasSuccessful() {
-			return fmt.Errorf("Command failed on %s: %s", pod, res.CombineOutput())
-		}
-	}
-	return nil
-}
-
 // WaitForCiliumInitContainerToFinish waits for all Cilium init containers to
 // finish
 func (kub *Kubectl) WaitForCiliumInitContainerToFinish() error {

--- a/test/helpers/node.go
+++ b/test/helpers/node.go
@@ -165,6 +165,22 @@ func (s *SSHMeta) Exec(cmd string, options ...ExecOptions) *CmdRes {
 	return s.ExecContext(ctx, cmd, options...)
 }
 
+// ExecShort runs command with the provided options. It will take up to
+// ShortCommandTimeout seconds to run the command before it times out.
+func (s *SSHMeta) ExecShort(cmd string, options ...ExecOptions) *CmdRes {
+	ctx, cancel := context.WithTimeout(context.Background(), ShortCommandTimeout)
+	defer cancel()
+	return s.ExecContext(ctx, cmd, options...)
+}
+
+// ExecContextShort is a wrapper around ExecContext which creates a child
+// context with a timeout of ShortCommandTimeout.
+func (s *SSHMeta) ExecContextShort(ctx context.Context, cmd string, options ...ExecOptions) *CmdRes {
+	shortCtx, cancel := context.WithTimeout(ctx, ShortCommandTimeout)
+	defer cancel()
+	return s.ExecContext(shortCtx, cmd, options...)
+}
+
 // ExecContext returns the results of executing the provided cmd via SSH.
 func (s *SSHMeta) ExecContext(ctx context.Context, cmd string, options ...ExecOptions) *CmdRes {
 	var ops ExecOptions


### PR DESCRIPTION
* #8328 -- fqdn: correctly populate Source IP and Port in `notifyOnDNSMsg` (@ianvernon)
   * Had to make minor fixups because the function was refactored out
 * #8350 -- CI: Report last seen error in CiliumPreFlightCheck (@raybejjani)
 * #8352 -- CI: Cleanup VMs and reclaim disk on job completion (@raybejjani)
 * #8361 -- pkg/metrics: re-register newStatusCollector function (@aanm)
 * #8366 -- docs: Clarify about legacy services enabled by default (@brb)

[ Round 2, added CI fixes]
 * #7911 
    * This was partially backported before in f7a1bd149a40f237850c91baa9b6987de6c67061, so I went back and backported the other half.
 * #8148
 * #8341 
 * #8355 

Skipped:
* Changes that require vendor updates
   * @aanm how do you update vendor dependencies during backport ? I get errors[1]
   * https://github.com/cilium/cilium/pull/8280 -- Add support for k8s 1.15 (@aanm)
   * https://github.com/cilium/cilium/pull/8351 -- Workaround for systemd 242 assigning MAC addr for virtual devices (@brb)

[1]
```
$ dep ensure
Solving failure: No versions of github.com/go-openapi/spec met constraints:
        v0.18.0: Could not introduce github.com/go-openapi/spec@v0.18.0, as it requires github.com/go-openapi/jsonpointer at revision v0.18.0, but that revision does not exist         
        v0.19.2: Could not introduce github.com/go-openapi/spec@v0.19.2, as it is not allowed by constraint v0.18.0 from project github.com/cilium/cilium.                              
        v0.19.0: Could not introduce github.com/go-openapi/spec@v0.19.0, as it is not allowed by constraint v0.18.0 from project github.com/cilium/cilium.                              
        v0.18.0: Could not introduce github.com/go-openapi/spec@v0.18.0, as it is not allowed by constraint v0.18.0 from project github.com/cilium/cilium.                              
        v0.17.2: Could not introduce github.com/go-openapi/spec@v0.17.2, as it is not allowed by constraint v0.18.0 from project github.com/cilium/cilium.                              
        v0.17.1: Could not introduce github.com/go-openapi/spec@v0.17.1, as it is not allowed by constraint v0.18.0 from project github.com/cilium/cilium.                              
        v0.17.0: Could not introduce github.com/go-openapi/spec@v0.17.0, as it is not allowed by constraint v0.18.0 from project github.com/cilium/cilium.                              
        0.16.0: Could not introduce github.com/go-openapi/spec@0.16.0, as it is not allowed by constraint v0.18.0 from project github.com/cilium/cilium.                                
        0.15.0: Could not introduce github.com/go-openapi/spec@0.15.0, as it is not allowed by constraint v0.18.0 from project github.com/cilium/cilium.                                
        master: Could not introduce github.com/go-openapi/spec@master, as it is not allowed by constraint v0.18.0 from project github.com/cilium/cilium.                                
        fix-definitions-omitempty: Could not introduce github.com/go-openapi/spec@fix-definitions-omitempty, as it is not allowed by constraint v0.18.0 from project github.com/cilium/cilium.
        fixSpelling: Could not introduce github.com/go-openapi/spec@fixSpelling, as it is not allowed by constraint v0.18.0 from project github.com/cilium/cilium.                      
        revert-79-fix-circular: Could not introduce github.com/go-openapi/spec@revert-79-fix-circular, as it is not allowed by constraint v0.18.0 from project github.com/cilium/cilium.
        transitiveResolverLocalRefCheck: Could not introduce github.com/go-openapi/spec@transitiveResolverLocalRefCheck, as it is not allowed by constraint v0.18.0 from project github.com/cilium/cilium.
```

Once this PR is merged, you can update the PR labels via:
```
$ for pr in 7911 8148 8328 8341 8350 8352 8355 8361 8366; do contrib/backporting/set-labels.py $pr done 1.5; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8369)
<!-- Reviewable:end -->
