### PR TITLE
u8proto: add "any" --> 0 mapping to "ProtoIDs"

### DIFF
--- a/pkg/u8proto/u8proto.go
+++ b/pkg/u8proto/u8proto.go
@@ -42,6 +42,7 @@ var protoNames = map[U8proto]string{
 
 var ProtoIDs = map[string]U8proto{
 	"all":    0,
+	"any":    0,
 	"icmp":   1,
 	"tcp":    6,
 	"udp":    17,


### PR DESCRIPTION
This mapping was errantly not in the map to figure out what the corresponding L4
protocol was for policy which specified "any" instead of "all" (which are
semantically equivalent). However, given that "any" and "all" both mapped to
U8Proto "0", and the function "ParseProtocol" returned "0" and an error in the
case that the parameter passed to it (protocol as a string) did not map to
the corresponding protocol number for said protocol, we inadvertently were
always getting the correct U8Proto mapping to "any", but with an error as well.
During policy generation, we were ignoring this error, since we assumed that the
analysis we were performing on the content of the rules was on rules which
already had been sanitized. However, an error was indeed getting returned,
resulting in a bunch of construction of strings and error objects which were
immediately ignored. This hampered performance with respect to policy generation
when policy had "any" L4 protocol specified:

Profiling from before this fix was implemented:

```
PASS: resolve_test.go:165: PolicyTestSuite.BenchmarkRegeneratePolicyRules	     200	   7346367 ns/op
```

```
ROUTINE ======================== github.com/cilium/cilium/pkg/policy.createL4Filter in /Users/ianvernon/go/src/github.com/cilium/cilium/pkg/policy/l4.go
      20ms      1.01s (flat, cum) 39.76% of Total
         .          .    257:// Not called with an empty peerEndpoints.
         .          .    258:func createL4Filter(peerEndpoints api.EndpointSelectorSlice, rule api.PortRule, port api.PortProtocol,
         .          .    259:	protocol api.L4Proto, ruleLabels labels.LabelArray, ingress bool, selectorCache *SelectorCache, fqdns api.FQDNSelectorSlice) *L4Filter {
         .          .    260:
         .          .    261:	// already validated via PortRule.Validate()
         .       10ms    262:	p, _ := strconv.ParseUint(port.Port, 0, 16)
         .          .    263:	// already validated via L4Proto.Validate()
         .       70ms    264:	u8p, _ := u8proto.ParseProtocol(string(protocol))
```

Profiling information after the fix:

```
PASS: resolve_test.go:165: PolicyTestSuite.BenchmarkRegeneratePolicyRules	     500	   7233541 ns/op
```

```
ROUTINE ======================== github.com/cilium/cilium/pkg/policy.createL4Filter in /Users/ianvernon/go/src/github.com/cilium/cilium/pkg/policy/l4.go
      10ms      2.09s (flat, cum) 43.72% of Total
         .          .    259:	protocol api.L4Proto, ruleLabels labels.LabelArray, ingress bool, selectorCache *SelectorCache, fqdns api.FQDNSelectorSlice) *L4Filter {
         .          .    260:
         .          .    261:	// already validated via PortRule.Validate()
         .          .    262:	p, _ := strconv.ParseUint(port.Port, 0, 16)
         .          .    263:	// already validated via L4Proto.Validate()
         .       10ms    264:	u8p, _ := u8proto.ParseProtocol(string(protocol))
```

This is an decrease in amount of time to perform policy calculation by around 2
percent.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8370)
<!-- Reviewable:end -->
