### PR TITLE
pkg/endpointmanager: protecting endpoints against concurrent access

### DIFF
--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -451,6 +451,8 @@ func regenerateEndpointNonBlocking(owner endpoint.Owner, ep *endpoint.Endpoint, 
 // in said set have had regenerations queued up.
 func RegenerateEndpointSetSignalWhenEnqueued(owner endpoint.Owner, regenMetadata *endpoint.ExternalRegenerationMetadata, endpointIDs map[uint16]struct{}, wg *sync.WaitGroup) {
 
+	mutex.RLock()
+	defer mutex.RUnlock()
 	for endpointID := range endpointIDs {
 		ep := endpoints[endpointID]
 		if ep == nil {


### PR DESCRIPTION
Fixes: f71d87a71c99 ("endpointmanager: signal when work is done")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8379)
<!-- Reviewable:end -->
