### PR TITLE
test: set k8s 1.15 as default k8s version

### DIFF
--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -39,7 +39,7 @@ import (
 var (
 	log             = logging.DefaultLogger
 	DefaultSettings = map[string]string{
-		"K8S_VERSION": "1.14",
+		"K8S_VERSION": "1.15",
 	}
 	k8sNodesEnv         = "K8S_NODES"
 	commandsLogFileName = "cmds.log"


### PR DESCRIPTION
Fixes: 4794445b0e02 ("test: test against 1.15.0")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8380)
<!-- Reviewable:end -->
