### PR TITLE
examples/kubernetes: remove container runtime option from cilium-agent

### DIFF
--- a/examples/kubernetes/1.10/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-containerd-ds.yaml
@@ -31,7 +31,6 @@ spec:
       - args:
         - --kvstore=etcd
         - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
-        - --container-runtime=containerd
         - --config-dir=/tmp/cilium/config-map
         command:
         - cilium-agent

--- a/examples/kubernetes/1.10/cilium-containerd.yaml
+++ b/examples/kubernetes/1.10/cilium-containerd.yaml
@@ -221,7 +221,6 @@ spec:
       - args:
         - --kvstore=etcd
         - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
-        - --container-runtime=containerd
         - --config-dir=/tmp/cilium/config-map
         command:
         - cilium-agent

--- a/examples/kubernetes/1.10/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-crio-ds.yaml
@@ -31,7 +31,6 @@ spec:
       - args:
         - --kvstore=etcd
         - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
-        - --container-runtime=crio
         - --config-dir=/tmp/cilium/config-map
         command:
         - cilium-agent

--- a/examples/kubernetes/1.10/cilium-crio.yaml
+++ b/examples/kubernetes/1.10/cilium-crio.yaml
@@ -221,7 +221,6 @@ spec:
       - args:
         - --kvstore=etcd
         - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
-        - --container-runtime=crio
         - --config-dir=/tmp/cilium/config-map
         command:
         - cilium-agent

--- a/examples/kubernetes/1.10/cilium-microk8s.yaml
+++ b/examples/kubernetes/1.10/cilium-microk8s.yaml
@@ -221,7 +221,6 @@ spec:
       - args:
         - --kvstore=etcd
         - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
-        - --container-runtime=containerd
         - --config-dir=/tmp/cilium/config-map
         command:
         - cilium-agent

--- a/examples/kubernetes/1.11/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-containerd-ds.yaml
@@ -31,7 +31,6 @@ spec:
       - args:
         - --kvstore=etcd
         - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
-        - --container-runtime=containerd
         - --config-dir=/tmp/cilium/config-map
         command:
         - cilium-agent

--- a/examples/kubernetes/1.11/cilium-containerd.yaml
+++ b/examples/kubernetes/1.11/cilium-containerd.yaml
@@ -221,7 +221,6 @@ spec:
       - args:
         - --kvstore=etcd
         - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
-        - --container-runtime=containerd
         - --config-dir=/tmp/cilium/config-map
         command:
         - cilium-agent

--- a/examples/kubernetes/1.11/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-crio-ds.yaml
@@ -31,7 +31,6 @@ spec:
       - args:
         - --kvstore=etcd
         - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
-        - --container-runtime=crio
         - --config-dir=/tmp/cilium/config-map
         command:
         - cilium-agent

--- a/examples/kubernetes/1.11/cilium-crio.yaml
+++ b/examples/kubernetes/1.11/cilium-crio.yaml
@@ -221,7 +221,6 @@ spec:
       - args:
         - --kvstore=etcd
         - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
-        - --container-runtime=crio
         - --config-dir=/tmp/cilium/config-map
         command:
         - cilium-agent

--- a/examples/kubernetes/1.11/cilium-microk8s.yaml
+++ b/examples/kubernetes/1.11/cilium-microk8s.yaml
@@ -221,7 +221,6 @@ spec:
       - args:
         - --kvstore=etcd
         - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
-        - --container-runtime=containerd
         - --config-dir=/tmp/cilium/config-map
         command:
         - cilium-agent

--- a/examples/kubernetes/1.12/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-containerd-ds.yaml
@@ -31,7 +31,6 @@ spec:
       - args:
         - --kvstore=etcd
         - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
-        - --container-runtime=containerd
         - --config-dir=/tmp/cilium/config-map
         command:
         - cilium-agent

--- a/examples/kubernetes/1.12/cilium-containerd.yaml
+++ b/examples/kubernetes/1.12/cilium-containerd.yaml
@@ -221,7 +221,6 @@ spec:
       - args:
         - --kvstore=etcd
         - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
-        - --container-runtime=containerd
         - --config-dir=/tmp/cilium/config-map
         command:
         - cilium-agent

--- a/examples/kubernetes/1.12/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-crio-ds.yaml
@@ -31,7 +31,6 @@ spec:
       - args:
         - --kvstore=etcd
         - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
-        - --container-runtime=crio
         - --config-dir=/tmp/cilium/config-map
         command:
         - cilium-agent

--- a/examples/kubernetes/1.12/cilium-crio.yaml
+++ b/examples/kubernetes/1.12/cilium-crio.yaml
@@ -221,7 +221,6 @@ spec:
       - args:
         - --kvstore=etcd
         - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
-        - --container-runtime=crio
         - --config-dir=/tmp/cilium/config-map
         command:
         - cilium-agent

--- a/examples/kubernetes/1.12/cilium-microk8s.yaml
+++ b/examples/kubernetes/1.12/cilium-microk8s.yaml
@@ -221,7 +221,6 @@ spec:
       - args:
         - --kvstore=etcd
         - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
-        - --container-runtime=containerd
         - --config-dir=/tmp/cilium/config-map
         command:
         - cilium-agent

--- a/examples/kubernetes/1.13/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-containerd-ds.yaml
@@ -31,7 +31,6 @@ spec:
       - args:
         - --kvstore=etcd
         - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
-        - --container-runtime=containerd
         - --config-dir=/tmp/cilium/config-map
         command:
         - cilium-agent

--- a/examples/kubernetes/1.13/cilium-containerd.yaml
+++ b/examples/kubernetes/1.13/cilium-containerd.yaml
@@ -221,7 +221,6 @@ spec:
       - args:
         - --kvstore=etcd
         - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
-        - --container-runtime=containerd
         - --config-dir=/tmp/cilium/config-map
         command:
         - cilium-agent

--- a/examples/kubernetes/1.13/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-crio-ds.yaml
@@ -31,7 +31,6 @@ spec:
       - args:
         - --kvstore=etcd
         - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
-        - --container-runtime=crio
         - --config-dir=/tmp/cilium/config-map
         command:
         - cilium-agent

--- a/examples/kubernetes/1.13/cilium-crio.yaml
+++ b/examples/kubernetes/1.13/cilium-crio.yaml
@@ -221,7 +221,6 @@ spec:
       - args:
         - --kvstore=etcd
         - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
-        - --container-runtime=crio
         - --config-dir=/tmp/cilium/config-map
         command:
         - cilium-agent

--- a/examples/kubernetes/1.13/cilium-microk8s.yaml
+++ b/examples/kubernetes/1.13/cilium-microk8s.yaml
@@ -221,7 +221,6 @@ spec:
       - args:
         - --kvstore=etcd
         - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
-        - --container-runtime=containerd
         - --config-dir=/tmp/cilium/config-map
         command:
         - cilium-agent

--- a/examples/kubernetes/1.14/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.14/cilium-containerd-ds.yaml
@@ -31,7 +31,6 @@ spec:
       - args:
         - --kvstore=etcd
         - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
-        - --container-runtime=containerd
         - --config-dir=/tmp/cilium/config-map
         command:
         - cilium-agent

--- a/examples/kubernetes/1.14/cilium-containerd.yaml
+++ b/examples/kubernetes/1.14/cilium-containerd.yaml
@@ -221,7 +221,6 @@ spec:
       - args:
         - --kvstore=etcd
         - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
-        - --container-runtime=containerd
         - --config-dir=/tmp/cilium/config-map
         command:
         - cilium-agent

--- a/examples/kubernetes/1.14/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.14/cilium-crio-ds.yaml
@@ -31,7 +31,6 @@ spec:
       - args:
         - --kvstore=etcd
         - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
-        - --container-runtime=crio
         - --config-dir=/tmp/cilium/config-map
         command:
         - cilium-agent

--- a/examples/kubernetes/1.14/cilium-crio.yaml
+++ b/examples/kubernetes/1.14/cilium-crio.yaml
@@ -221,7 +221,6 @@ spec:
       - args:
         - --kvstore=etcd
         - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
-        - --container-runtime=crio
         - --config-dir=/tmp/cilium/config-map
         command:
         - cilium-agent

--- a/examples/kubernetes/1.14/cilium-microk8s.yaml
+++ b/examples/kubernetes/1.14/cilium-microk8s.yaml
@@ -221,7 +221,6 @@ spec:
       - args:
         - --kvstore=etcd
         - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
-        - --container-runtime=containerd
         - --config-dir=/tmp/cilium/config-map
         command:
         - cilium-agent

--- a/examples/kubernetes/1.15/cilium-containerd-ds.yaml
+++ b/examples/kubernetes/1.15/cilium-containerd-ds.yaml
@@ -31,7 +31,6 @@ spec:
       - args:
         - --kvstore=etcd
         - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
-        - --container-runtime=containerd
         - --config-dir=/tmp/cilium/config-map
         command:
         - cilium-agent

--- a/examples/kubernetes/1.15/cilium-containerd.yaml
+++ b/examples/kubernetes/1.15/cilium-containerd.yaml
@@ -221,7 +221,6 @@ spec:
       - args:
         - --kvstore=etcd
         - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
-        - --container-runtime=containerd
         - --config-dir=/tmp/cilium/config-map
         command:
         - cilium-agent

--- a/examples/kubernetes/1.15/cilium-crio-ds.yaml
+++ b/examples/kubernetes/1.15/cilium-crio-ds.yaml
@@ -31,7 +31,6 @@ spec:
       - args:
         - --kvstore=etcd
         - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
-        - --container-runtime=crio
         - --config-dir=/tmp/cilium/config-map
         command:
         - cilium-agent

--- a/examples/kubernetes/1.15/cilium-crio.yaml
+++ b/examples/kubernetes/1.15/cilium-crio.yaml
@@ -221,7 +221,6 @@ spec:
       - args:
         - --kvstore=etcd
         - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
-        - --container-runtime=crio
         - --config-dir=/tmp/cilium/config-map
         command:
         - cilium-agent

--- a/examples/kubernetes/1.15/cilium-microk8s.yaml
+++ b/examples/kubernetes/1.15/cilium-microk8s.yaml
@@ -221,7 +221,6 @@ spec:
       - args:
         - --kvstore=etcd
         - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
-        - --container-runtime=containerd
         - --config-dir=/tmp/cilium/config-map
         command:
         - cilium-agent

--- a/examples/kubernetes/templates/v1/cilium-containerd-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-containerd-ds.yaml.sed
@@ -31,7 +31,6 @@ spec:
       - args:
         - --kvstore=etcd
         - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
-        - --container-runtime=containerd
         - --config-dir=/tmp/cilium/config-map
         command:
         - cilium-agent

--- a/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-crio-ds.yaml.sed
@@ -31,7 +31,6 @@ spec:
       - args:
         - --kvstore=etcd
         - --kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config
-        - --container-runtime=crio
         - --config-dir=/tmp/cilium/config-map
         command:
         - cilium-agent


### PR DESCRIPTION
As we are planning to remove all workloads integrations with Cilium, we
will remove the cilium-agent daemon option set directly in each
DaemonSet. In the next release we will be to removing the socket mounts
for each container runtime integrations.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8386)
<!-- Reviewable:end -->
