### PR TITLE
pkg/pidfile: Strip logging statements for use in cilium-health-responder

### DIFF
--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -168,9 +168,13 @@ func (c *Client) PingEndpoint() error {
 //   and needs to be cleaned up before it is restarted.
 func KillEndpoint() {
 	path := filepath.Join(option.Config.StateDir, PidfilePath)
-	if err := pidfile.Kill(path); err != nil {
-		log.WithField(logfields.Path, path).WithError(err).
-			Warning("Failed to kill cilium-health instance")
+	scopedLog := log.WithField(logfields.PIDFile, path)
+	scopedLog.Debug("Killing old health endpoint process")
+	pid, err := pidfile.Kill(path)
+	if err != nil {
+		scopedLog.WithError(err).Warning("Failed to kill cilium-health-responder")
+	} else if pid != 0 {
+		scopedLog.WithField(logfields.PID, pid).Debug("Killed endpoint process")
 	}
 }
 

--- a/daemon/health.go
+++ b/daemon/health.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/k8s"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/pidfile"
 )
@@ -48,7 +49,12 @@ func (d *Daemon) initHealth() {
 		// When Cilium starts up in k8s mode, it is guaranteed to be
 		// running inside a new PID namespace which means that existing
 		// PIDfiles are referring to PIDs that may be reused. Clean up.
-		pidfile.Remove(filepath.Join(option.Config.StateDir, health.PidfilePath))
+		pidfilePath := filepath.Join(option.Config.StateDir, health.PidfilePath)
+		if err := pidfile.Remove(pidfilePath); err != nil {
+			log.WithField(logfields.PIDFile, pidfilePath).
+				WithError(err).
+				Warning("Failed to remove pidfile")
+		}
 	}
 
 	// Wait for the API, then launch the controller


### PR DESCRIPTION
The `pidfile` package is supposed to be used by `cilium-health-responder`, but due its dependency on `logrus` it almost doubled the file size of the binary and increased its memory consumption by 20%. With this commit, we strip the logging statements from `pkg/pidfile` to avoid this dependency and move the logging statements to the call site of `pidfile.Kill()`. This allows us to deduplicate the logic in the responder by switching back to a `pidfile`-based implementation without any additional overhead.

Previous discussion: https://github.com/cilium/cilium/pull/8317#issuecomment-505550923 (cc @joestringer)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8390)
<!-- Reviewable:end -->
