### PR TITLE
cilium: Add new line to 'cilium policy selectors' with no ids.

### DIFF
--- a/cilium/cmd/policy_selectors.go
+++ b/cilium/cmd/policy_selectors.go
@@ -42,6 +42,9 @@ var policyCacheGetCmd = &cobra.Command{
 				first := true
 				fmt.Fprintf(w, "%s", mapping.Selector)
 				fmt.Fprintf(w, "\t%d", mapping.Users)
+				if len(mapping.Identities) == 0 {
+					fmt.Fprintf(w, "\t\n")
+				}
 				for _, idty := range mapping.Identities {
 					if first {
 						fmt.Fprintf(w, "\t%d\t\n", idty)


### PR DESCRIPTION
Add the missing newline when printing out the selector cache for a
selector that selects nothing.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8393)
<!-- Reviewable:end -->
