### PR TITLE
iptables, docker: fix direct routing regression

### DIFF
--- a/Documentation/install/system_requirements.rst
+++ b/Documentation/install/system_requirements.rst
@@ -162,21 +162,10 @@ Source            `Cilium iproute2 source`_
 .. _`Open Build Service`: https://build.opensuse.org/package/show/security:netfilter/iproute2
 .. _`Cilium iproute2 source`: https://github.com/cilium/iproute2/tree/static-data
 
-Host Firewall Rules
-===================
-
-If you have iptables enabled on your system, the following must be allowed:
-
-========= =======================================
-Chain     Required policy
-========= =======================================
-FORWARD   Accept forwarding to and from PodIPs
-========= =======================================
-
 .. _firewall_requirements:
 
-Network Firewall Rules
-======================
+Firewall Rules
+==============
 
 If you are running Cilium in an environment that requires firewall rules to enable connectivity, you will have to add the following rules to ensure Cilium works properly.
 

--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -103,7 +103,6 @@ ip -6 a a ${vm_ipv6}/16 dev enp0s8
 
 echo '${master_ipv6} ${VM_BASENAME}1' >> /etc/hosts
 sysctl -w net.ipv6.conf.all.forwarding=1
-iptables -P FORWARD ACCEPT
 EOF
 }
 
@@ -378,19 +377,11 @@ service cilium restart
 EOF
 }
 
-function write_iptables_rules(){
-    filename="${1}"
-    cat <<EOF >> "${filename}"
-sudo iptables -P FORWARD ACCEPT
-EOF
-}
-
 function create_master(){
     split_ipv4 ipv4_array "${MASTER_IPV4}"
     get_cilium_node_addr master_cilium_ipv6 "${MASTER_IPV4}"
     output_file="${dir}/node-1.sh"
     write_netcfg_header "${MASTER_IPV6}" "${MASTER_IPV6}" "${output_file}"
-    write_iptables_rules "${output_file}"
 
     if [ -n "${NWORKERS}" ]; then
         write_nodes_routes 1 "${MASTER_IPV4}" "${output_file}"
@@ -414,7 +405,6 @@ function create_workers(){
             ipv6_public_workers_addrs+=(${worker_host_ipv6})
 
             write_netcfg_header "${worker_ipv6}" "${MASTER_IPV6}" "${output_file}"
-            write_iptables_rules "${output_file}"
 
             write_master_route "${master_prefix_ip}" "${master_cilium_ipv6}" \
                 "${MASTER_IPV6}" "${i}" "${worker_ipv6}" "${output_file}"

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -256,10 +256,6 @@ sudo systemctl enable $MOUNT_SYSTEMD
 sudo systemctl restart $MOUNT_SYSTEMD
 sudo rm -rfv /var/lib/kubelet
 
-# Allow iptables forwarding so kube-dns can function.
-sudo iptables -P FORWARD ACCEPT
-sudo ip6tables -P FORWARD ACCEPT
-
 #check hostname to know if is kubernetes or runtime test
 if [[ "${HOST}" == "k8s1" ]]; then
 

--- a/test/provision/runtime_install.sh
+++ b/test/provision/runtime_install.sh
@@ -11,9 +11,6 @@ source "${PROVISIONSRC}/helpers.bash"
 sudo bash -c "echo MaxSessions 200 >> /etc/ssh/sshd_config"
 sudo systemctl restart ssh
 
-sudo iptables -P FORWARD ACCEPT
-sudo ip6tables -P FORWARD ACCEPT
-
 "${PROVISIONSRC}"/dns.sh
 "${PROVISIONSRC}"/compile.sh
 "${PROVISIONSRC}"/wait-cilium.sh


### PR DESCRIPTION
/cc @brb 

After rebasing our BPF nodeport work, it was not working anymore
in combination with direct routing. Doing a git bisection with
our multi-host setup pointed reliably to b08cf3fa1df6 ("iptables:
Remove legacy workaround for kube-proxy of k8s < 1.8"):

  known bad:  319ccde9f19deaa435dd6d29a84ee13cfcea90fa
  known good: 80912fc6cb2b2dd6ef92cec3080c66d33d36a925

  step01: 0fec218c33ffc87d204a64e146e427b1bafdaf8f --> ok
  step02: e667025a268412321139f2a4d7cd388053f7f5da --> ok
  step03: 88409092797d27d6fcf1cffddeaf3261ae5091bc --> ok
  step04: bcc9ade1bfccc6baf47da2a6a4483455a69a7541 --> bad
  step05: 16dfbcb29fc6a5a664b09f6fbe8a792f699784c1 --> bad
  step06: 5430b1e5c1071911dd1af3e930ae060f86b0c6cb --> bad
  step07: 7f4b0b93cf892bc47ce4b3f83962e4fbc6ae947c --> bad
  step08: 5c12962622c8e531be7b6cd95b9d56783b1fc12b --> ok
  step09: b08cf3fa1df6c270981eb07a2ccc9c64b3f353d0 --> bad
  step10: 1f88ae5b3456db21384be5028ca7af6a4b5e24cf --> ok

  b08cf3fa1df6c270981eb07a2ccc9c64b3f353d0 is the first bad commit

Reverting this commit gets direct routing working again in master;
comment for the iptables rule is extended to cover Docker case as
well.

Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8394)
<!-- Reviewable:end -->
