### PR TITLE
Ci fix nightly

### DIFF
--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -51,7 +51,7 @@ var _ = Describe("NightlyEpsMeasurement", func() {
 		ProvisionInfraPods(kubectl)
 	})
 	deleteAll := func() {
-		ctx, cancel := context.WithTimeout(context.Background(), helpers.HelperTimeout)
+		ctx, cancel := context.WithTimeout(context.Background(), endpointsTimeout)
 		defer cancel()
 		kubectl.ExecInBackground(ctx, fmt.Sprintf(
 			"%s delete --all pods,svc,cnp -n %s --grace-period=0 --force",
@@ -113,9 +113,9 @@ var _ = Describe("NightlyEpsMeasurement", func() {
 
 		deployEndpoints()
 		waitForPodsTime := b.Time("Wait for pods", func() {
-			err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=testapp", endpointTimeout)
+			err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=testapp", endpointsTimeout)
 			Expect(err).Should(BeNil(),
-				"Cannot retrieve %d pods in %d seconds", endpointCount, endpointsTimeout)
+				"Cannot retrieve %d pods in %d seconds", endpointCount, endpointsTimeout.Seconds())
 		})
 
 		log.WithFields(logrus.Fields{"pod creation time": waitForPodsTime}).Info("")

--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -88,7 +88,12 @@ var _ = Describe("NightlyEpsMeasurement", func() {
 	deployEndpoints := func() {
 		_, _, err = helpers.GenerateManifestForEndpoints(endpointCount, manifestPath)
 		ExpectWithOffset(1, err).Should(BeNil(), "Manifest cannot be created correctly")
-		res := kubectl.Apply(vagrantManifestPath)
+
+		// This is equivalent to res := kubectl.Apply(vagrantManifestPath) but we
+		// need a longer timeout than helpers.ShortCommandTimeout
+		ctx, cancel := context.WithTimeout(context.Background(), endpointsTimeout)
+		defer cancel()
+		res := kubectl.ExecContext(ctx, fmt.Sprintf("%s apply -f  %s", helpers.KubectlCmd, vagrantManifestPath))
 		res.ExpectSuccess("cannot apply eps manifest :%s", res.GetDebugMessage())
 	}
 


### PR DESCRIPTION
_It's possible that I lost my sanity and I haven't actually fixed anything here_
Thanks to @eloycoto for helping me out with this :)

Nightly has been failing consistently for about 2 weeks, roughly coinciding with https://github.com/cilium/cilium/pull/8266. That PR closed the SSHClient instance and the NightlyEpsMeasurement failed because it saw a closed connection. This was because `ginkgo.Measure` needs to be wrapped by our ginkgo-ext to know when to call AfterAll. Without this, AfterAll was being called prematurely.

That wasn't all, though! This test also saw failures on kubectl commands that were clearly succeeding. This turned out to be timeouts. In one case, it was because we used the wrong timeout when waiting for endpoints to be ready (the per-endpoint value that we scale to the count of endpoints we are testing with, instead of the actually scaled value).

In another case, we shortened kubectl command timeouts to 10s in https://github.com/cilium/cilium/pull/8355 and this caused specific kubectl commands to time out (namely, apply and delete). Instead of reverting #8355 (because I don't know why we did it exactly) I opted to manually build these two commands. This test is a little special since it expects to be slow.

Alternatives could be: 1) Switch all kubectl commands to take a context or 2) modify the globally shared timeout value during these tests. Neither seemed like improvements, so I opted to keep the mess local to this test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8395)
<!-- Reviewable:end -->
