### PR TITLE
pkg/kvstore: fix nil pointer in error while doing a transaction in etcd 

### DIFF
--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -1049,13 +1049,13 @@ func (e *etcdClient) UpdateIfDifferentIfLocked(ctx context.Context, key string, 
 
 	increaseMetric(key, metricRead, "Get", duration.EndError(err).Total(), err)
 
-	if !txnresp.Succeeded {
-		return false, ErrLockLeaseExpired
-	}
-
 	// On error, attempt update blindly
 	if err != nil {
 		return true, e.UpdateIfLocked(ctx, key, value, lease, lock)
+	}
+
+	if !txnresp.Succeeded {
+		return false, ErrLockLeaseExpired
 	}
 
 	getR := txnresp.Responses[0].GetResponseRange()


### PR DESCRIPTION
txnresp can obviously be nil if err is != nil. We should check if
txnresp.Succeeded after checking if err == nil first.

Fixes: 84291c30ece5 ("pkg/kvstore: implement new *IfLocked methods for etcd")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8402)
<!-- Reviewable:end -->
