### PR TITLE
pkg/lock: remove RUnlockIgnoreTime

### DIFF
--- a/pkg/lock/lock_debug.go
+++ b/pkg/lock/lock_debug.go
@@ -76,13 +76,9 @@ func (i *internalRWMutex) UnlockIgnoreTime() {
 
 func (i *internalRWMutex) RLock() {
 	i.RWMutex.RLock()
-	i.t = time.Now()
 }
 
 func (i *internalRWMutex) RUnlock() {
-	if sec := time.Since(i.t).Seconds(); sec >= selfishThresholdSec {
-		printStackTo(sec, debug.Stack(), os.Stderr)
-	}
 	i.RWMutex.RUnlock()
 }
 

--- a/pkg/lock/lock_debug.go
+++ b/pkg/lock/lock_debug.go
@@ -82,10 +82,6 @@ func (i *internalRWMutex) RUnlock() {
 	i.RWMutex.RUnlock()
 }
 
-func (i *internalRWMutex) RUnlockIgnoreTime() {
-	i.RWMutex.RUnlock()
-}
-
 type internalMutex struct {
 	deadlock.Mutex
 	time.Time

--- a/pkg/lock/lock_fast.go
+++ b/pkg/lock/lock_fast.go
@@ -28,10 +28,6 @@ func (i *internalRWMutex) UnlockIgnoreTime() {
 	i.RWMutex.Unlock()
 }
 
-func (i *internalRWMutex) RUnlockIgnoreTime() {
-	i.RWMutex.RUnlock()
-}
-
 type internalMutex struct {
 	sync.Mutex
 }


### PR DESCRIPTION
Tracking the time a go routine took while holding a RLock can create some unnecessary overhead. Instead of tracking the time wrongly for the RLock function, tracking time for this function was entirely removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8405)
<!-- Reviewable:end -->
