### PR TITLE
maps/ctmap: fix nil pointer access

### DIFF
--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -278,11 +278,13 @@ func doGC6(m *Map, filter *GCFilter) gcStats {
 	stats := statStartGc(m)
 	defer stats.finish()
 
-	err := natMap.Open()
-	if err == nil {
-		defer natMap.Close()
-	} else {
-		natMap = nil
+	if natMap != nil {
+		err := natMap.Open()
+		if err == nil {
+			defer natMap.Close()
+		} else {
+			natMap = nil
+		}
 	}
 
 	filterCallback := func(key bpf.MapKey, value bpf.MapValue) {


### PR DESCRIPTION
`natMap` can be nil, for example for CT local maps, we can have a nil
pointer access while accessing this variable.

Fixes: 319ccde9f19d ("maps/ctmap: explicitly set which nat file is for each map type")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8406)
<!-- Reviewable:end -->
