### PR TITLE
operator: add warning message if status returns an error

### DIFF
--- a/operator/api.go
+++ b/operator/api.go
@@ -48,6 +48,7 @@ func healthHandler(w http.ResponseWriter, r *http.Request) {
 	if err := checkStatus(); err != nil {
 		statusCode = http.StatusInternalServerError
 		reply = err.Error()
+		log.WithError(err).Warn("Health check status")
 	}
 
 	w.WriteHeader(statusCode)


### PR DESCRIPTION
It might be helpful to track down why kubernetes killed cilium-operator
due the readiness probe failures.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8408)
<!-- Reviewable:end -->
