### PR TITLE
Fix selector cache FQDN handling 

### DIFF
--- a/pkg/fqdn/rulegen.go
+++ b/pkg/fqdn/rulegen.go
@@ -31,16 +31,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// Notes
-// Hack 1: We strip ToCIDRSet rules. These are already dissallowed by our
-// validation. We do this to simplify handling our own generated rules.
-// StartManageDNSName is called by daemon when we inject the generated rules. By
-// stripping ToCIDRSet we make the rule equivalent to what it was before. This is
-// inefficient.
-// We also rely on this in addRule, where we now keep the newest instance of a
-// rule to allow handling policy updates for rules we don't look at, but need to
-// retain while generating.
-
 const (
 	// generatedLabelNameUUID is the label key for policy rules that contain a
 	// ToFQDN section and need to be updated
@@ -51,10 +41,8 @@ const (
 // expects the source:key delimiter to be the labels.PathDelimiter
 var uuidLabelSearchKey = labels.LabelSourceCiliumGenerated + labels.PathDelimiter + generatedLabelNameUUID
 
-// RuleGen tracks which rules depend on which DNS names. When DNS updates are
-// given to a RuleGen it will emit generated policy rules with DNS IPs inserted
-// as toCIDR rules. These correspond to the toFQDN matchName entries and are
-// emitted via UpdateSelectors.
+// RuleGen tracks which selectors depend on which DNS names. When DNS updates are
+// given to a RuleGen it update cached selectors as required via UpdateSelectors.
 // DNS information is cached, respecting TTL.
 // Note: When DNS data expires rules are not generated again!
 type RuleGen struct {

--- a/pkg/fqdn/rulegen_test.go
+++ b/pkg/fqdn/rulegen_test.go
@@ -61,6 +61,7 @@ func (ds *FQDNTestSuite) TestRuleGenCIDRGeneration(c *C) {
 	// add rules
 	ids := gen.RegisterForIdentityUpdates(ciliumIOSel)
 	c.Assert(len(ids), Equals, 0)
+	c.Assert(ids, Not(IsNil))
 
 	// poll DNS once, check that we only generate 1 rule (for 1 IP) and that we
 	// still have 1 ToFQDN rule, and that the IP is correct
@@ -110,7 +111,8 @@ func (ds *FQDNTestSuite) TestRuleGenMultiIPUpdate(c *C) {
 	// add rules
 	selectorsToAdd := api.FQDNSelectorSlice{ciliumIOSel, githubSel}
 	for _, sel := range selectorsToAdd {
-		gen.RegisterForIdentityUpdates(sel)
+		ids := gen.RegisterForIdentityUpdates(sel)
+		c.Assert(ids, Not(IsNil))
 	}
 
 	// poll DNS once, check that we only generate 1 IP for cilium.io
@@ -146,6 +148,7 @@ func (ds *FQDNTestSuite) TestRuleGenMultiIPUpdate(c *C) {
 	c.Assert(selIPMap[githubSel][0].Equal(net.ParseIP("3.3.3.3")), Equals, true, Commentf("Incorrect IP mapping to FQDN"))
 	c.Assert(selIPMap[githubSel][1].Equal(net.ParseIP("4.4.4.4")), Equals, true, Commentf("Incorrect IP mapping to FQDN"))
 
+	// Second registration returns nil
 	ids := gen.RegisterForIdentityUpdates(githubSel)
 	c.Assert(ids, IsNil)
 

--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -674,8 +674,10 @@ func (sc *SelectorCache) ChangeUser(selector CachedSelector, from, to CachedSele
 	sc.mutex.Lock()
 	idSel, exists := sc.selectors[key]
 	if exists {
-		idSel.removeUser(from)
+		// Add before remove so that the count does not dip to zero in between,
+		// as this causes FQDN unregistration (if applicable).
 		idSel.addUser(to)
+		idSel.removeUser(from)
 	}
 	sc.mutex.Unlock()
 }


### PR DESCRIPTION
Change the order in which the user is added and removed when changing
the user of a cached selector; Add the new user first, and remove the
old user next. This prevents the count of users dipping to 0 when
changing the only user of a cached selector, which is significant for
FQDN selectors, as the selector will be unregistered from the DNS
proxy whenever the user count reaches zero.

First three commits are clean-ups, the fourth one is the bug fix.

Fixes: #8117
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8409)
<!-- Reviewable:end -->
