### PR TITLE
v1.5 backports 2019-06-27

### DIFF
--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -53,6 +53,7 @@ pipeline {
                 sh 'rm -rf src; mkdir -p src/github.com/cilium'
                 sh 'ln -s $WORKSPACE src/github.com/cilium/cilium'
                 checkout scm
+                sh '/usr/local/bin/cleanup || true'
             }
         }
         stage('Preload vagrant boxes') {
@@ -120,6 +121,7 @@ pipeline {
             sh "cd ${TESTDIR}; vagrant destroy -f || true"
             sh 'cd ${TEST_DIR}; ./post_build_agent.sh || true'
             cleanWs()
+            sh '/usr/local/bin/cleanup || true'
         }
         success {
             Status("SUCCESS", "$JOB_BASE_NAME")

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1243,7 +1243,9 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 	// This needs to be done after the node addressing has been configured
 	// as the node address is required as suffix.
 	// well known identities have already been initialized above
-	go cache.InitIdentityAllocator(&d)
+	// Ignore the channel returned by this function, as we want the global
+	// identity allocator to run asynchronously.
+	cache.InitIdentityAllocator(&d)
 
 	bootstrapStats.clusterMeshInit.Start()
 	if path := option.Config.ClusterMeshConfig; path != "" {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -957,6 +957,9 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 		return nil, nil, err
 	}
 
+	// Must be done before calling policy.NewPolicyRepostory() below.
+	identity.InitWellKnownIdentities()
+
 	d := Daemon{
 		loadBalancer:      loadbalancer.NewLoadBalancer(),
 		k8sSvcCache:       k8s.NewServiceCache(),
@@ -1239,6 +1242,7 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 
 	// This needs to be done after the node addressing has been configured
 	// as the node address is required as suffix.
+	// well known identities have already been initialized above
 	go cache.InitIdentityAllocator(&d)
 
 	bootstrapStats.clusterMeshInit.Start()

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -1196,9 +1196,6 @@ func runDaemon() {
 	// We need to set up etcd in parallel so we will initialize the k8s
 	// subsystem as well in parallel so caches will start to be synchronized
 	// with k8s.
-	// This is required because CNP with CIDRs rely on the allocator which
-	// itself relies on the kvstore to be setup and the caches will not be
-	// synced unless we setup the kvstore at the same time.
 	k8sCachesSynced := d.initK8sSubsystem()
 
 	goopts := &kvstore.ExtraOptions{

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -280,7 +280,7 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) (resto
 			// endpoints that don't have a fixed identity or are
 			// not well known.
 			if !identity.IsFixed() && !identity.IsWellKnown() {
-				cache.WaitForInitialIdentities(context.Background())
+				cache.WaitForInitialGlobalIdentities(context.Background())
 				ipcache.WaitForInitialSync()
 			}
 

--- a/pkg/clustermesh/clustermesh_test.go
+++ b/pkg/clustermesh/clustermesh_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
@@ -108,6 +109,7 @@ func (s *ClusterMeshTestSuite) TestClusterMesh(c *C) {
 	kvstore.SetupDummy("etcd")
 	defer kvstore.Close()
 
+	identity.InitWellKnownIdentities()
 	cache.InitIdentityAllocator(&identityAllocatorOwnerMock{})
 	defer cache.Close()
 

--- a/pkg/clustermesh/clustermesh_test.go
+++ b/pkg/clustermesh/clustermesh_test.go
@@ -110,7 +110,7 @@ func (s *ClusterMeshTestSuite) TestClusterMesh(c *C) {
 	defer kvstore.Close()
 
 	identity.InitWellKnownIdentities()
-	cache.InitIdentityAllocator(&identityAllocatorOwnerMock{})
+	<-cache.InitIdentityAllocator(&identityAllocatorOwnerMock{})
 	defer cache.Close()
 
 	dir, err := ioutil.TempDir("", "multicluster")

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -23,6 +23,7 @@ import (
 	"path"
 	"time"
 
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/k8s/types"
@@ -61,6 +62,7 @@ func (s *ClusterMeshServicesTestSuite) SetUpTest(c *C) {
 
 	kvstore.DeletePrefix("cilium/state/services/v1/" + s.randomName)
 	s.svcCache = k8s.NewServiceCache()
+	identity.InitWellKnownIdentities()
 	cache.InitIdentityAllocator(&identityAllocatorOwnerMock{})
 	dir, err := ioutil.TempDir("", "multicluster")
 	s.testDir = dir

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -63,7 +63,7 @@ func (s *ClusterMeshServicesTestSuite) SetUpTest(c *C) {
 	kvstore.DeletePrefix("cilium/state/services/v1/" + s.randomName)
 	s.svcCache = k8s.NewServiceCache()
 	identity.InitWellKnownIdentities()
-	cache.InitIdentityAllocator(&identityAllocatorOwnerMock{})
+	<-cache.InitIdentityAllocator(&identityAllocatorOwnerMock{})
 	dir, err := ioutil.TempDir("", "multicluster")
 	s.testDir = dir
 	c.Assert(err, IsNil)

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/common/addressing"
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/kvstore"
@@ -54,6 +55,7 @@ func (t *testIdentityAllocator) GetNodeSuffix() string { return "foo" }
 func (s *EndpointSuite) SetUpTest(c *C) {
 	/* Required to test endpoint CEP policy model */
 	kvstore.SetupDummy("etcd")
+	identity.InitWellKnownIdentities()
 	cache.InitIdentityAllocator(&testIdentityAllocator{})
 }
 

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -56,7 +56,7 @@ func (s *EndpointSuite) SetUpTest(c *C) {
 	/* Required to test endpoint CEP policy model */
 	kvstore.SetupDummy("etcd")
 	identity.InitWellKnownIdentities()
-	cache.InitIdentityAllocator(&testIdentityAllocator{})
+	<-cache.InitIdentityAllocator(&testIdentityAllocator{})
 }
 
 func (s *EndpointSuite) TearDownTest(c *C) {

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -454,6 +454,8 @@ func regenerateEndpointNonBlocking(owner endpoint.Owner, ep *endpoint.Endpoint, 
 // in said set have had regenerations queued up.
 func RegenerateEndpointSetSignalWhenEnqueued(owner endpoint.Owner, regenMetadata *endpoint.ExternalRegenerationMetadata, endpointIDs map[uint16]struct{}, wg *sync.WaitGroup) {
 
+	mutex.RLock()
+	defer mutex.RUnlock()
 	for endpointID := range endpointIDs {
 		ep := endpoints[endpointID]
 		if ep == nil {

--- a/pkg/identity/cache/allocation_test.go
+++ b/pkg/identity/cache/allocation_test.go
@@ -111,7 +111,7 @@ func (d dummyOwner) GetNodeSuffix() string {
 
 func (ias *IdentityAllocatorSuite) TestGetIdentityCache(c *C) {
 	identity.InitWellKnownIdentities()
-	InitIdentityAllocator(dummyOwner{})
+	<-InitIdentityAllocator(dummyOwner{})
 	defer Close()
 	defer IdentityAllocator.DeleteAllKeys()
 
@@ -126,7 +126,7 @@ func (ias *IdentityAllocatorSuite) TestAllocator(c *C) {
 	lbls3 := labels.NewLabelsFromSortedList("id=bar;user=susan")
 
 	identity.InitWellKnownIdentities()
-	InitIdentityAllocator(dummyOwner{})
+	<-InitIdentityAllocator(dummyOwner{})
 	defer Close()
 	defer IdentityAllocator.DeleteAllKeys()
 
@@ -189,7 +189,7 @@ func (ias *IdentityAllocatorSuite) TestLocalAllocationr(c *C) {
 	lbls1 := labels.NewLabelsFromSortedList("cidr:192.0.2.3/32")
 
 	identity.InitWellKnownIdentities()
-	InitIdentityAllocator(dummyOwner{})
+	<-InitIdentityAllocator(dummyOwner{})
 	defer Close()
 	defer IdentityAllocator.DeleteAllKeys()
 

--- a/pkg/identity/cache/allocation_test.go
+++ b/pkg/identity/cache/allocation_test.go
@@ -110,6 +110,7 @@ func (d dummyOwner) GetNodeSuffix() string {
 }
 
 func (ias *IdentityAllocatorSuite) TestGetIdentityCache(c *C) {
+	identity.InitWellKnownIdentities()
 	InitIdentityAllocator(dummyOwner{})
 	defer Close()
 	defer IdentityAllocator.DeleteAllKeys()
@@ -124,6 +125,7 @@ func (ias *IdentityAllocatorSuite) TestAllocator(c *C) {
 	lbls2 := labels.NewLabelsFromSortedList("id=bar;user=anna")
 	lbls3 := labels.NewLabelsFromSortedList("id=bar;user=susan")
 
+	identity.InitWellKnownIdentities()
 	InitIdentityAllocator(dummyOwner{})
 	defer Close()
 	defer IdentityAllocator.DeleteAllKeys()
@@ -186,6 +188,7 @@ func (ias *IdentityAllocatorSuite) TestAllocator(c *C) {
 func (ias *IdentityAllocatorSuite) TestLocalAllocationr(c *C) {
 	lbls1 := labels.NewLabelsFromSortedList("cidr:192.0.2.3/32")
 
+	identity.InitWellKnownIdentities()
 	InitIdentityAllocator(dummyOwner{})
 	defer Close()
 	defer IdentityAllocator.DeleteAllKeys()

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -55,9 +55,14 @@ var (
 	// IdentityAllocator is an allocator for security identities from the
 	// kvstore.
 	IdentityAllocator *allocator.Allocator
-	// identityAllocatorInitialized is closed whenever the identity allocator is
-	// initialized
-	identityAllocatorInitialized = make(chan struct{})
+
+	// globalIdentityAllocatorInitialized is closed whenever the global identity
+	// allocator is initialized.
+	globalIdentityAllocatorInitialized = make(chan struct{})
+
+	// localIdentityAllocatorInitialized is closed whenever the local identity
+	// allocator is initialized.
+	localIdentityAllocatorInitialized = make(chan struct{})
 
 	localIdentities *localIdentityCache
 
@@ -85,8 +90,9 @@ type IdentityAllocatorOwner interface {
 // InitIdentityAllocator creates the the identity allocator. Only the
 // first invocation of this function will have an effect.  Caller must
 // have initialized well known identities before calling this (by
-// calling identity.InitWellKnownIdentities()).
-func InitIdentityAllocator(owner IdentityAllocatorOwner) {
+// calling identity.InitWellKnownIdentities()). Returns a channel which is
+// closed when initialization of the allocator is completed.
+func InitIdentityAllocator(owner IdentityAllocatorOwner) <-chan struct{} {
 	setupMutex.Lock()
 	defer setupMutex.Unlock()
 
@@ -96,29 +102,41 @@ func InitIdentityAllocator(owner IdentityAllocatorOwner) {
 
 	log.Info("Initializing identity allocator")
 
+	// Local identity cache can be created synchronously since it doesn't
+	// rely upon any external resources (e.g., external kvstore).
+	events := make(allocator.AllocatorEventChan, 1024)
+	localIdentities = newLocalIdentityCache(1, 0xFFFFFF, events)
+	close(localIdentityAllocatorInitialized)
+
 	minID := idpool.ID(identity.MinimalAllocationIdentity)
 	maxID := idpool.ID(identity.MaximumAllocationIdentity)
-	events := make(allocator.AllocatorEventChan, 1024)
 
 	// It is important to start listening for events before calling
 	// NewAllocator() as it will emit events while filling the
 	// initial cache
 	watcher.watch(owner, events)
 
-	a, err := allocator.NewAllocator(IdentitiesPath, globalIdentity{},
-		allocator.WithMax(maxID), allocator.WithMin(minID),
-		allocator.WithSuffix(owner.GetNodeSuffix()),
-		allocator.WithEvents(events),
-		allocator.WithMasterKeyProtection(),
-		allocator.WithPrefixMask(idpool.ID(option.Config.ClusterID<<identity.ClusterIDShift)))
-	if err != nil {
-		log.WithError(err).Fatal("Unable to initialize identity allocator")
-	}
+	// Asynchronously set up the global identity allocator since it connects
+	// to the kvstore.
+	go func(owner IdentityAllocatorOwner, evs allocator.AllocatorEventChan, minID, maxID idpool.ID) {
+		setupMutex.Lock()
+		defer setupMutex.Unlock()
 
-	IdentityAllocator = a
-	close(identityAllocatorInitialized)
-	localIdentities = newLocalIdentityCache(1, 0xFFFFFF, events)
+		a, err := allocator.NewAllocator(IdentitiesPath, globalIdentity{},
+			allocator.WithMax(maxID), allocator.WithMin(minID),
+			allocator.WithSuffix(owner.GetNodeSuffix()),
+			allocator.WithEvents(evs),
+			allocator.WithMasterKeyProtection(),
+			allocator.WithPrefixMask(idpool.ID(option.Config.ClusterID<<identity.ClusterIDShift)))
+		if err != nil {
+			log.WithError(err).Fatal("Unable to initialize identity allocator")
+		}
 
+		IdentityAllocator = a
+		close(globalIdentityAllocatorInitialized)
+	}(owner, events, minID, maxID)
+
+	return globalIdentityAllocatorInitialized
 }
 
 // Close closes the identity allocator and allows to call
@@ -128,7 +146,16 @@ func Close() {
 	defer setupMutex.Unlock()
 
 	select {
-	case <-identityAllocatorInitialized:
+	case <-globalIdentityAllocatorInitialized:
+		// This means the channel was closed and therefore the IdentityAllocator == nil will never be true
+	default:
+		if IdentityAllocator == nil {
+			log.Panic("Close() called without calling InitIdentityAllocator() first")
+		}
+	}
+
+	select {
+	case <-localIdentityAllocatorInitialized:
 		// This means the channel was closed and therefore the IdentityAllocator == nil will never be true
 	default:
 		if IdentityAllocator == nil {
@@ -139,17 +166,18 @@ func Close() {
 	IdentityAllocator.Delete()
 	watcher.stop()
 	IdentityAllocator = nil
-	identityAllocatorInitialized = make(chan struct{})
+	globalIdentityAllocatorInitialized = make(chan struct{})
+	localIdentityAllocatorInitialized = make(chan struct{})
 	localIdentities = nil
 }
 
-// WaitForInitialIdentities waits for the initial set of security identities to
-// have been received and populated into the allocator cache
-func WaitForInitialIdentities(ctx context.Context) error {
+// WaitForInitialGlobalIdentities waits for the initial set of global security
+// identities to have been received and populated into the allocator cache.
+func WaitForInitialGlobalIdentities(ctx context.Context) error {
 	select {
-	case <-identityAllocatorInitialized:
+	case <-globalIdentityAllocatorInitialized:
 	case <-ctx.Done():
-		return fmt.Errorf("initial identity sync was cancelled: %s", ctx.Err())
+		return fmt.Errorf("initial global identity sync was cancelled: %s", ctx.Err())
 	}
 
 	return IdentityAllocator.WaitForInitialSync(ctx)
@@ -187,13 +215,14 @@ func AllocateIdentity(ctx context.Context, lbls labels.Labels) (*identity.Identi
 		return reservedIdentity, false, nil
 	}
 
-	if !identity.RequiresGlobalIdentity(lbls) && localIdentities != nil {
+	if !identity.RequiresGlobalIdentity(lbls) {
+		<-localIdentityAllocatorInitialized
 		return localIdentities.lookupOrCreate(lbls)
 	}
 
 	// This will block until the kvstore can be accessed and all identities
-	// were succesfully synced
-	WaitForInitialIdentities(ctx)
+	// were successfully synced
+	WaitForInitialGlobalIdentities(ctx)
 
 	if IdentityAllocator == nil {
 		return nil, false, fmt.Errorf("allocator not initialized")
@@ -222,14 +251,15 @@ func Release(ctx context.Context, id *identity.Identity) (bool, error) {
 	}
 
 	// Ignore reserved identities.
-	if !identity.RequiresGlobalIdentity(id.Labels) && localIdentities != nil {
+	if !identity.RequiresGlobalIdentity(id.Labels) {
+		<-localIdentityAllocatorInitialized
 		released := localIdentities.release(id)
 		return released, nil
 	}
 
 	// This will block until the kvstore can be accessed and all identities
-	// were succesfully synced
-	WaitForInitialIdentities(ctx)
+	// were successfully synced
+	WaitForInitialGlobalIdentities(ctx)
 
 	if IdentityAllocator == nil {
 		return false, fmt.Errorf("allocator not initialized")
@@ -261,6 +291,6 @@ func ReleaseSlice(ctx context.Context, identities []*identity.Identity) error {
 // WatchRemoteIdentities starts watching for identities in another kvstore and
 // syncs all identities to the local identity cache.
 func WatchRemoteIdentities(backend kvstore.BackendOperations) *allocator.RemoteCache {
-	<-identityAllocatorInitialized
+	<-globalIdentityAllocatorInitialized
 	return IdentityAllocator.WatchRemoteKVStore(backend, IdentitiesPath)
 }

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -82,8 +82,10 @@ type IdentityAllocatorOwner interface {
 	GetNodeSuffix() string
 }
 
-// InitIdentityAllocator creates the the identity allocator. Only the first
-// invocation of this function will have an effect.
+// InitIdentityAllocator creates the the identity allocator. Only the
+// first invocation of this function will have an effect.  Caller must
+// have initialized well known identities before calling this (by
+// calling identity.InitWellKnownIdentities()).
 func InitIdentityAllocator(owner IdentityAllocatorOwner) {
 	setupMutex.Lock()
 	defer setupMutex.Unlock()
@@ -91,8 +93,6 @@ func InitIdentityAllocator(owner IdentityAllocatorOwner) {
 	if IdentityAllocator != nil {
 		log.Panic("InitIdentityAllocator() in succession without calling Close()")
 	}
-
-	identity.InitWellKnownIdentities()
 
 	log.Info("Initializing identity allocator")
 

--- a/pkg/workloads/docker.go
+++ b/pkg/workloads/docker.go
@@ -241,8 +241,6 @@ func (d *dockerClient) IsRunning(ep *endpoint.Endpoint) bool {
 		}
 
 		if err == nil {
-			runtimeRunning = true
-
 			// Container may exist but is not in running state
 			return cont.State.Running
 		}

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -39,7 +39,7 @@ import (
 var (
 	log             = logging.DefaultLogger
 	DefaultSettings = map[string]string{
-		"K8S_VERSION": "1.14",
+		"K8S_VERSION": "1.15",
 	}
 	k8sNodesEnv         = "K8S_NODES"
 	commandsLogFileName = "cmds.log"


### PR DESCRIPTION
* #8293 -- cilium: docker.go ineffectual assignment (@jrfastab)
* #8345 -- allocator: fix race condition when allocating local identities upon bootstrap (@ianvernon)
  - cherry-picked prerequisite: commit [9974c7bf2fad](https://github.com/cilium/cilium/commit/9974c7bf2fad64d9a98c642ae68721d4ba323e1e) -- identity: Initialize well-known identities before the policy repository. (@jrajahalme)
  - applied minor fixes due to master changes that need no backporting
* #8358 -- CI: Clean VMs and reclaim disk in nightly test (@raybejjani)
* #8380 -- test: set k8s 1.15 as default k8s version (@aanm)
* #8379 -- pkg/endpointmanager: protecting endpoints against concurrent access (@aanm)

Once this PR is merged, you can update the PR labels via:
```
$ for pr in 8293 8345 8358 8379 8380; do contrib/backporting/set-labels.py $pr done 1.5; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8410)
<!-- Reviewable:end -->
