### PR TITLE
Improve the BPF verifier runtime test

### DIFF
--- a/test/bpf/verifier-test.sh
+++ b/test/bpf/verifier-test.sh
@@ -19,6 +19,7 @@ set -eo pipefail
 DEV="cilium-probe"
 DIR=$(dirname $0)/../../bpf
 TC_PROGS="bpf_hostdev_ingress bpf_ipsec bpf_lb bpf_lxc bpf_netdev bpf_network bpf_overlay"
+CG_PROGS="bpf_sock sockops/bpf_sockops sockops/bpf_redir"
 XDP_PROGS="bpf_xdp"
 VERBOSE=false
 
@@ -57,6 +58,12 @@ function load_tc {
 	for p in ${TC_PROGS}; do
 		load_prog "tc filter replace" "ingress bpf da" ${DIR}/${p}
 		clean_maps
+	done
+}
+
+function load_cg {
+	for p in ${CG_PROGS}; do
+		echo "=> Skipping ${DIR}/${p}.c."
 	done
 }
 
@@ -107,6 +114,7 @@ function main {
 	tc qdisc replace dev ${DEV} clsact
 
 	load_tc
+	load_cg
 	load_xdp
 }
 

--- a/test/bpf/verifier-test.sh
+++ b/test/bpf/verifier-test.sh
@@ -18,7 +18,7 @@ set -eo pipefail
 
 DEV="cilium-probe"
 DIR=$(dirname $0)/../../bpf
-TC_PROGS="bpf_lb bpf_lxc bpf_netdev bpf_overlay"
+TC_PROGS="bpf_hostdev_ingress bpf_ipsec bpf_lb bpf_lxc bpf_netdev bpf_network bpf_overlay"
 XDP_PROGS="bpf_xdp"
 VERBOSE=false
 

--- a/test/bpf/verifier-test.sh
+++ b/test/bpf/verifier-test.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
+set -eo pipefail
 
 DEV="cilium-probe"
 DIR=$(dirname $0)/../../bpf


### PR DESCRIPTION
Extend the verifier runtime test so that it:
* Tests all of the TC progs in the tree currently,
* Has the structure to support cgroups tests (although lacking the implementation right now),
* Complains to developers when they add a new BPF program without adding it to the test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8412)
<!-- Reviewable:end -->
