### PR TITLE
maps/lbmap: protect service cache refcount with concurrent access

### DIFF
--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -265,6 +265,9 @@ func UpdateService(fe ServiceKey, backends []ServiceValue,
 		return err
 	}
 
+	mutex.Lock()
+	defer mutex.Unlock()
+
 	// Store mapping of backend addr ID => backend ID in the cache
 	cache.addBackendIDs(newBackendIDs)
 
@@ -282,9 +285,6 @@ func UpdateService(fe ServiceKey, backends []ServiceValue,
 	//		nNonZeroWeights++
 	//	}
 	//}
-
-	mutex.Lock()
-	defer mutex.Unlock()
 
 	besValuesV2 := svc.getBackendsV2()
 


### PR DESCRIPTION
As updating services can modify the lbmapCache the mutex to access the
same bpf map should be held before modifying the cache. Without it we
can risk to have the bpf map out of sync with the lbmap cache.

Fixes: 2766bc127368 ("daemon,lbmap: Do not update legacy svc if they are disabled")
Signed-off-by: André Martins <andre@cilium.io>

```release-note
Fix possible out-of-sync service backends from user space to bpf maps
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8416)
<!-- Reviewable:end -->
