### PR TITLE
Make render-docs port configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -468,9 +468,10 @@ docs-container:
 	$(CONTAINER_ENGINE_FULL) image build -t cilium/docs-builder -f Documentation/Dockerfile ./Documentation; \
 	  (ret=$$?; rm -r ./Documentation/_api && exit $$ret)
 
+DOCS_PORT=9081
 render-docs: test-docs
-	$(CONTAINER_ENGINE_FULL) container run --rm -dit --name docs-cilium -p 9080:80 -v $$(pwd)/Documentation/_build/html/:/usr/local/apache2/htdocs/ httpd:2.4
-	@echo "$$(tput setaf 2)Running at http://localhost:9080$$(tput sgr0)"
+	$(CONTAINER_ENGINE_FULL) container run --rm -dit --name docs-cilium -p $(DOCS_PORT):80 -v $$(pwd)/Documentation/_build/html/:/usr/local/apache2/htdocs/ httpd:2.4
+	@echo "$$(tput setaf 2)Running at http://localhost:$(DOCS_PORT)$$(tput sgr0)"
 
 test-docs: docs-container
 	-$(CONTAINER_ENGINE_FULL) container rm -f docs-cilium >/dev/null 2>&1 || true


### PR DESCRIPTION
The current `make render-docs` port is 9080, which conflicts with the
prometheus port in the examples. Change it to 9081 and make it
configurable via environment variable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8420)
<!-- Reviewable:end -->
