### PR TITLE
envoy: Reduce error logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:74a21763dce81def53aef3a76ccc794bd9a062ad as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:dc81ab244a2b240c7ecda8683fd86e29b476e141 as cilium-envoy
 
 #
 # Cilium incremental build. Should be fast given builder-deps is up-to-date!

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1881,6 +1881,7 @@
     "golang.org/x/time/rate",
     "google.golang.org/genproto/googleapis/rpc/status",
     "google.golang.org/grpc",
+    "google.golang.org/grpc/codes",
     "google.golang.org/grpc/reflection",
     "gopkg.in/check.v1",
     "gopkg.in/fsnotify.v1",


### PR DESCRIPTION
gRPC stream on the server side gets cancelled if the client side
cancels the stream. This happens when the Envoy listener is being shut
down, which happens when the policy is changed to not contain L7 rules
any more. As this is part of the normal operation, change these logs
to the debug level.

Use a new cilium-envoy image with sanitized logging.

This should remove these from the CI output:

Top 5 errors/warnings:
error while receiving request from xDS stream
xDS stream context canceled
[[cilium/network_policy.cc:129] Bad Network Policy Configuration
[[cilium/host_map.cc:187] Bad NetworkPolicyHosts Configuration
[[cilium/bpf.cc:81] cilium.bpf_metadata: map /sys/fs/bpf/tc/globals/cilium_ipcache mismatch 1!=11 || 24!=24 || 12!=12

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8425)
<!-- Reviewable:end -->
