### PR TITLE
CI: Wait on DNS to be ready in dependent tests

### DIFF
--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -90,6 +90,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 		ExpectWithOffset(1, err).To(BeNil(), "Unable to install Cilium")
 
 		ExpectCiliumReady(kubectl)
+		ExpectKubeDNSReady(kubectl)
 		ExpectETCDOperatorReady(kubectl)
 
 		err = kubectl.WaitforPods(helpers.DefaultNamespace, "", helpers.HelperTimeout)

--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -371,6 +371,7 @@ var _ = Describe("NightlyExamples", func() {
 
 		AfterAll(func() {
 			_ = kubectl.Apply(helpers.DNSDeployment())
+			ExpectKubeDNSReady(kubectl)
 		})
 
 		for _, image := range helpers.NightlyStableUpgradesFrom {

--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -56,6 +56,7 @@ var _ = Describe("K8sUpdates", func() {
 
 	AfterAll(func() {
 		_ = kubectl.Apply(helpers.DNSDeployment())
+		ExpectKubeDNSReady(kubectl)
 		kubectl.CloseSSHClient()
 	})
 
@@ -155,6 +156,7 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldVersion, newV
 
 		By("Installing kube-dns")
 		_ = kubectl.Apply(helpers.DNSDeployment())
+		ExpectKubeDNSReady(kubectl)
 
 		// Deploy the etcd operator
 		By("Deploying etcd-operator")

--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -130,7 +130,6 @@ func ProvisionInfraPods(vm *helpers.Kubectl) {
 	}
 
 	ExpectETCDOperatorReady(vm)
-	Expect(vm.WaitKubeDNS()).To(BeNil(), "KubeDNS is not ready after timeout")
 	ExpectCiliumReady(vm)
 	if operatorIsInstalled {
 		ExpectCiliumOperatorReady(vm)


### PR DESCRIPTION
We deploy DNS in these tests, but don't ensure that it is running. This
may result in races if the DNS pods are slow to start.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8429)
<!-- Reviewable:end -->
