### PR TITLE
health: Re-introduce deletion of endpoint interfaces upon termination

### DIFF
--- a/daemon/health.go
+++ b/daemon/health.go
@@ -88,6 +88,7 @@ func (d *Daemon) initHealth() {
 
 	// Make sure to clean up the endpoint namespace when cilium-agent terminates
 	cleanup.DeferTerminationCleanupFunction(cleanUPWg, cleanUPSig, func() {
+		health.KillEndpoint()
 		health.CleanupEndpoint()
 	})
 }

--- a/daemon/health.go
+++ b/daemon/health.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"time"
 
@@ -71,8 +72,15 @@ func (d *Daemon) initHealth() {
 				// On the first initialization, or on
 				// error, restart the health EP.
 				if client == nil || err != nil {
+					var launchErr error
 					d.cleanupHealthEndpoint()
-					client, err = health.LaunchAsEndpoint(ctx, d, &d.nodeDiscovery.LocalNode, d.mtuConfig)
+					client, launchErr = health.LaunchAsEndpoint(ctx, d, &d.nodeDiscovery.LocalNode, d.mtuConfig)
+					if launchErr != nil {
+						if err != nil {
+							return fmt.Errorf("failed to restart endpoint (check failed: %q): %s", err, launchErr)
+						}
+						return launchErr
+					}
 				}
 				return err
 			},

--- a/pkg/netns/netns.go
+++ b/pkg/netns/netns.go
@@ -42,6 +42,22 @@ func RemoveIfFromNetNSIfExists(netNS ns.NetNS, ifName string) error {
 	})
 }
 
+// RemoveIfFromNetNSWithNameIfBothExist removes the given interface from
+// the given network namespace identified by its name.
+//
+// If either the interface or the namespace do not exist, no error will
+// be returned.
+func RemoveIfFromNetNSWithNameIfBothExist(netNSName, ifName string) error {
+	netNS, err := ns.GetNS(netNSPath(netNSName))
+	if err != nil {
+		if _, ok := err.(ns.NSPathNotExistErr); ok {
+			return nil
+		}
+		return err
+	}
+	return RemoveIfFromNetNSIfExists(netNS, ifName)
+}
+
 // ReplaceNetNSWithName creates a network namespace with the given name.
 // If such netns already exists from a previous run, it will be removed
 // and then re-created to avoid any previous state of the netns.


### PR DESCRIPTION
This re-introduces the manual removal of the virtual interfaces in the health endpoint cleanup. The existing logic relied on the kernel to remove these interfaces as part of namespace deletion. However, the deletion by the kernel happens asynchronously, and can be blocked when there is still a process in that namespace.

This caused a race where the old veth pair for the health endpoint was not deleted when cilium would try to create a new one, causing the launch of the enpoint responder to fail. To fix this, we manually remove the interfaces during cleanup, exactly as it was done in previous versions of cilium.

In addition, we now also explicitly kill the endpoint child process when the parent agent receives a termination signal.

Fixes: 9b8cf2aeaf2e ("health: Remove spawn_netns.sh")
Fixes: #8400

/cc @brb and @aanm how have both hit this this bug during testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8430)
<!-- Reviewable:end -->
