### PR TITLE
contrib/release: Add cilium-health-responder to uploadrev

### DIFF
--- a/contrib/release/README.md
+++ b/contrib/release/README.md
@@ -62,6 +62,8 @@ CLI, agent, health, bugtool, monitor and seperate sha256 files. Using
 	cilium-bugtool-x86_64.sha256sum
 	cilium-health-x86_64
 	cilium-health-x86_64.sha256sum
+	cilium-health-responder-x86_64
+	cilium-health-responder-x86_64.sha256sum
 	cilium-node-monitor-x86_64
 	cilium-node-monitor-x86_64.sha256sum
 	cilium-x86_64

--- a/contrib/release/uploadrev
+++ b/contrib/release/uploadrev
@@ -91,6 +91,7 @@ function copy_binaries() {
   docker cp $SHA:/usr/bin/cilium-agent $TARGET_DIR/cilium-node-monitor-$ARCH
   docker cp $SHA:/usr/bin/cilium-bugtool $TARGET_DIR/cilium-bugtool-$ARCH
   docker cp $SHA:/usr/bin/cilium-health $TARGET_DIR/cilium-health-$ARCH
+  docker cp $SHA:/usr/bin/cilium-health-responder $TARGET_DIR/cilium-health-responder-$ARCH
   docker cp $SHA:/usr/bin/cilium-envoy $TARGET_DIR/cilium-envoy-$ARCH
   docker cp $SHA:/opt/cni/bin/cilium-cni $TARGET_DIR/cilium-cni-$ARCH
   cp contrib/k8s/k8s-cilium-exec.sh $TARGET_DIR/tools/ || true


### PR DESCRIPTION
Commit dcdea00 introduced a new binary, the `cilium-health-responder`. It is spawend as child process by the endpoint connectivity health check and therefore should also be part of the binary release.

Fixes: dcdea00891ad ("health: Split out passive endpoint into separate binary")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8432)
<!-- Reviewable:end -->
