### PR TITLE
cli: fix panic in cilium bpf sha get command

### DIFF
--- a/cilium/cmd/bpf_sha_get.go
+++ b/cilium/cmd/bpf_sha_get.go
@@ -31,7 +31,11 @@ var bpfShaGetCmd = &cobra.Command{
 	Short:   "Get datapath SHA header",
 	Run: func(cmd *cobra.Command, args []string) {
 		common.RequireRootPrivilege("cilium bpf sha get")
-		dumpSha(args[0])
+		if len(args) == 0 {
+			cmd.Help()
+		} else {
+			dumpSha(args[0])
+		}
 	},
 }
 


### PR DESCRIPTION
* Fixes #8423
* Fixes panic issue in `cilium bpf sha get` command when no sha is provided

Signed-off-by: Deepesh Pathak <deepshpathak@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8449)
<!-- Reviewable:end -->
