### PR TITLE
policy: check if rules already select endpoint in resolveL4{Ingress,Egress}Policy

### DIFF
--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -117,7 +117,7 @@ func (rules ruleSlice) resolveL4IngressPolicy(ctx *SearchContext, revision uint6
 	// each FromEndpoints for all ingress rules. This ensures that FromRequires
 	// is taken into account when evaluating policy at L4.
 	for _, r := range rules {
-		if r.EndpointSelector.Matches(ctx.To) {
+		if ctx.rulesSelect || r.EndpointSelector.Matches(ctx.To) {
 			matchedRules = append(matchedRules, r)
 			for _, ingressRule := range r.Ingress {
 				for _, requirement := range ingressRule.FromRequires {
@@ -167,7 +167,7 @@ func (rules ruleSlice) resolveL4EgressPolicy(ctx *SearchContext, revision uint64
 	// ToEndpoints for all egress rules. This ensures that ToRequires is
 	// taken into account when evaluating policy at L4.
 	for _, r := range rules {
-		if r.EndpointSelector.Matches(ctx.From) {
+		if ctx.rulesSelect || r.EndpointSelector.Matches(ctx.From) {
 			matchedRules = append(matchedRules, r)
 			for _, egressRule := range r.Egress {
 				for _, requirement := range egressRule.ToRequires {


### PR DESCRIPTION
A SearchContext has a field, `rulesSelect`, which indicates whether the given
set of rules which we are evaluating have already been determined to select
the set of labels for which we are computing policy. Utilize this in the
`resolveL4{Ingress,Egress}Policy` functions to improve performance, as
label-based matching is costly.

Before change:

```
PASS: resolve_test.go:167: PolicyTestSuite.BenchmarkRegeneratePolicyRules	     500	   4802029 ns/op
```

```
(pprof) list resolveL4EgressPolicy
Total: 3.22s
ROUTINE ======================== github.com/cilium/cilium/pkg/policy.ruleSlice.resolveL4EgressPolicy in /Users/ianvernon/go/src/github.com/cilium/cilium/pkg/policy/rules.go
         0      1.71s (flat, cum) 53.11% of Total
         .          .    158:	// Iterate over all ToRequires which select ctx.To. These requirements will
         .          .    159:	// be appended to each EndpointSelector's MatchExpressions in each
         .          .    160:	// ToEndpoints for all egress rules. This ensures that ToRequires is
         .          .    161:	// taken into account when evaluating policy at L4.
         .          .    162:	for _, r := range rules {
         .      230ms    163:		if r.EndpointSelector.Matches(ctx.From) {
         .          .    164:			matchedRules = append(matchedRules, r)
         .          .    165:			for _, egressRule := range r.Egress {
         .          .    166:				for _, requirement := range egressRule.ToRequires {
         .          .    167:					requirements = append(requirements, requirement.ConvertToLabelSelectorRequirementSlice()...)
         .          .    168:				}
         .          .    169:			}
         .          .    170:		}
         .          .    171:	}
         .          .    172:
         .          .    173:	ctx.rulesSelect = true
         .          .    174:	for i, r := range matchedRules {
         .          .    175:		state.ruleID = i
         .      1.45s    176:		found, err := r.resolveEgressPolicy(ctx, &state, result, requirements, selectorCache)
         .          .    177:		if err != nil {
         .          .    178:			return nil, err
         .          .    179:		}
         .          .    180:		state.ruleID++
         .          .    181:		if found != nil {
         .          .    182:			state.matchedRules++
         .          .    183:		}
         .          .    184:	}
```

After change:

```
PASS: resolve_test.go:167: PolicyTestSuite.BenchmarkRegeneratePolicyRules	     500	   4478747 ns/op
```

```
(pprof) list resolveL4EgressPolicy
Total: 3.04s
ROUTINE ======================== github.com/cilium/cilium/pkg/policy.ruleSlice.resolveL4EgressPolicy in /Users/ianvernon/go/src/github.com/cilium/cilium/pkg/policy/rules.go
      40ms      1.67s (flat, cum) 54.93% of Total
         .          .    167:		ruleSelects := true
         .          .    168:		if !ctx.rulesSelect {
         .          .    169:			ruleSelects = r.EndpointSelector.Matches(ctx.From)
         .          .    170:		}
         .          .    171:		if ruleSelects {
      10ms       30ms    172:			matchedRules = append(matchedRules, r)
         .          .    173:			for _, egressRule := range r.Egress {
         .          .    174:				for _, requirement := range egressRule.ToRequires {
         .          .    175:					requirements = append(requirements, requirement.ConvertToLabelSelectorRequirementSlice()...)
         .          .    176:				}
         .          .    177:			}
         .          .    178:		}
         .          .    179:	}
         .          .    180:
         .          .    181:	ctx.rulesSelect = true
      10ms       10ms    182:	for i, r := range matchedRules {
      10ms       10ms    183:		state.ruleID = i
         .      1.57s    184:		found, err := r.resolveEgressPolicy(ctx, &state, result, requirements, selectorCache)
         .          .    185:		if err != nil {
         .          .    186:			return nil, err

```

The amount of time the benchmark improved in these two cases was 6.73% as a
result of this optimization when generating policy for a specific identity
against 1000 Egress rules selecting that identity.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8450)
<!-- Reviewable:end -->
