### PR TITLE
policy: Restore changes to search context

### DIFF
--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -127,7 +127,10 @@ func (rules ruleSlice) resolveL4IngressPolicy(ctx *SearchContext, revision uint6
 		}
 	}
 
+	// Only dealing with matching rules from now on. Mark it in the ctx
+	oldRulesSelect := ctx.rulesSelect
 	ctx.rulesSelect = true
+
 	for _, r := range matchedRules {
 		found, err := r.resolveIngressPolicy(ctx, &state, result, requirements, selectorCache)
 		if err != nil {
@@ -142,6 +145,10 @@ func (rules ruleSlice) resolveL4IngressPolicy(ctx *SearchContext, revision uint6
 	matchedRules.wildcardL3L4Rules(true, result, requirements, selectorCache)
 
 	state.trace(len(rules), ctx)
+
+	// Restore ctx in case caller uses it again.
+	ctx.rulesSelect = oldRulesSelect
+
 	return result, nil
 }
 
@@ -170,7 +177,10 @@ func (rules ruleSlice) resolveL4EgressPolicy(ctx *SearchContext, revision uint64
 		}
 	}
 
+	// Only dealing with matching rules from now on. Mark it in the ctx
+	oldRulesSelect := ctx.rulesSelect
 	ctx.rulesSelect = true
+
 	for i, r := range matchedRules {
 		state.ruleID = i
 		found, err := r.resolveEgressPolicy(ctx, &state, result, requirements, selectorCache)
@@ -186,6 +196,10 @@ func (rules ruleSlice) resolveL4EgressPolicy(ctx *SearchContext, revision uint64
 	matchedRules.wildcardL3L4Rules(false, result, requirements, selectorCache)
 
 	state.trace(len(rules), ctx)
+
+	// Restore ctx in case caller uses it again.
+	ctx.rulesSelect = oldRulesSelect
+
 	return result, nil
 }
 


### PR DESCRIPTION
Policy resolution changes 'rulesSelect' which may cause problems if
the caller re-uses the same search context again. Restore the changes
before returning.

This makes no functional difference now, but keeps the internal API
consistent. Alternatively we could either document that the search
context may not be re-used for multiple resolution calls, or we could
pass the ctx by value, which would allow arbitrary changes to the
local copy. The first option is a bit more brittle, while the second
has a performance impact.

Fixes: 40a53fcc82e ("policy: Remove denied identities maps")
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8451)
<!-- Reviewable:end -->
