### PR TITLE
policy: add additional benchmarks for different types of rules

### DIFF
--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -2011,7 +2011,7 @@ func (ds *PolicyTestSuite) TestL3L4L7Merge(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestMatches(c *C) {
-	repo = parseAndAddRules(c, api.Rules{&api.Rule{
+	repo := parseAndAddRules(c, api.Rules{&api.Rule{
 		EndpointSelector: endpointSelectorA,
 		Ingress: []api.IngressRule{
 			{


### PR DESCRIPTION
This PR refactors code in `resolve_test.go` to allow for different benchmarks to be ran for different types of rules (e.g., L3-only ingress, L3-only egress, CIDR-only, etc).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8452)
<!-- Reviewable:end -->
