### PR TITLE
pkg/k8s: hold mutex while adding events to the queue

### DIFF
--- a/pkg/k8s/service_cache.go
+++ b/pkg/k8s/service_cache.go
@@ -160,10 +160,11 @@ func (s *ServiceCache) DeleteService(k8sSvc *types.Service) {
 	svcID := ParseServiceID(k8sSvc)
 
 	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
 	oldService, serviceOK := s.services[svcID]
 	endpoints, _ := s.correlateEndpoints(svcID)
 	delete(s.services, svcID)
-	s.mutex.Unlock()
 
 	if serviceOK {
 		s.Events <- ServiceEvent{
@@ -214,10 +215,11 @@ func (s *ServiceCache) DeleteEndpoints(k8sEndpoints *types.Endpoints) ServiceID 
 	svcID := ParseEndpointsID(k8sEndpoints)
 
 	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
 	service, serviceOK := s.services[svcID]
 	delete(s.endpoints, svcID)
 	endpoints, serviceReady := s.correlateEndpoints(svcID)
-	s.mutex.Unlock()
 
 	if serviceOK {
 		event := ServiceEvent{
@@ -271,10 +273,11 @@ func (s *ServiceCache) DeleteIngress(ingress *types.Ingress) {
 	svcID := ParseIngressID(ingress)
 
 	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
 	oldService, ok := s.ingresses[svcID]
 	endpoints := s.endpoints[svcID]
 	delete(s.ingresses, svcID)
-	s.mutex.Unlock()
 
 	if ok {
 		s.Events <- ServiceEvent{


### PR DESCRIPTION
As there are certain code regions where the mutex is held it might
occur the events are put in to the channel out of the original order
they got the mutex.

Fixes: 7efa98e03b9b ("k8s: Factor out service and endpoints correlation into a new ServiceCache")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8453)
<!-- Reviewable:end -->
