### PR TITLE
eni: Retry on attachment index conflict

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1778,6 +1778,7 @@
   input-imports = [
     "github.com/asaskevich/govalidator",
     "github.com/aws/aws-sdk-go-v2/aws",
+    "github.com/aws/aws-sdk-go-v2/aws/awserr",
     "github.com/aws/aws-sdk-go-v2/aws/ec2metadata",
     "github.com/aws/aws-sdk-go-v2/aws/external",
     "github.com/aws/aws-sdk-go-v2/service/ec2",


### PR DESCRIPTION
Allocation is delayed until metadata is synced but it can still be oudated when
an ENI is attached to an instance. Detect the error returned which indicates
that the index is already in use. Retry with the next available index up to
a maximum number of retries.

ENI creation is expensive, deletion due to index conflict should be avoided.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8471)
<!-- Reviewable:end -->
