### PR TITLE
Fix invalid JSON in CNI portmap config

### DIFF
--- a/plugins/cilium-cni/cni-install.sh
+++ b/plugins/cilium-cni/cni-install.sh
@@ -105,7 +105,7 @@ EOF
     },
     {
       "type": "portmap",
-      "capabilities": {"portMappings": true},
+      "capabilities": {"portMappings": true}
     }
   ]
 }


### PR DESCRIPTION
The `portmap` CNI config JSON rendered by `cni-install.sh` has an extra `,` making it invalid:
```
Error loading CNI config list file /etc/cni/net.d/05-cilium.conflist: error parsing configuration list: invalid character '}' looking for beginning of object key string
``` 

- [x] For first time contributors, read [Submitting a pull request](http://docs.cilium.io/en/stable/contributing/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue. 
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](http://docs.cilium.io/en/stable/contributing/#dev-coo).
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

Signed-off-by: Steven Normore <snormore@digitalocean.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8474)
<!-- Reviewable:end -->
