### PR TITLE
daemon: Remove svc-v2 maps when restore is disabled

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -440,10 +440,21 @@ func (d *Daemon) initMaps() error {
 		defer d.loadBalancer.BPFMapMU.Unlock()
 
 		if option.Config.EnableIPv6 {
-			if err := lbmap.Service6Map.DeleteAll(); err != nil {
+			if option.Config.EnableLegacyServices {
+				if err := lbmap.Service6Map.DeleteAll(); err != nil {
+					return err
+				}
+				if err := lbmap.RRSeq6Map.DeleteAll(); err != nil {
+					return err
+				}
+			}
+			if err := lbmap.Service6MapV2.DeleteAll(); err != nil {
 				return err
 			}
-			if err := lbmap.RRSeq6Map.DeleteAll(); err != nil {
+			if err := lbmap.RRSeq6MapV2.DeleteAll(); err != nil {
+				return err
+			}
+			if err := lbmap.Backend6Map.DeleteAll(); err != nil {
 				return err
 			}
 		}
@@ -452,10 +463,21 @@ func (d *Daemon) initMaps() error {
 		}
 
 		if option.Config.EnableIPv4 {
-			if err := lbmap.Service4Map.DeleteAll(); err != nil {
+			if option.Config.EnableLegacyServices {
+				if err := lbmap.Service4Map.DeleteAll(); err != nil {
+					return err
+				}
+				if err := lbmap.RRSeq4Map.DeleteAll(); err != nil {
+					return err
+				}
+			}
+			if err := lbmap.Service4MapV2.DeleteAll(); err != nil {
 				return err
 			}
-			if err := lbmap.RRSeq4Map.DeleteAll(); err != nil {
+			if err := lbmap.RRSeq4MapV2.DeleteAll(); err != nil {
+				return err
+			}
+			if err := lbmap.Backend4Map.DeleteAll(); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Previously, in the case of `--restore=false`, the svc-v2 related BPF map entries were not removed. Also, the daemon was trying to remove the legacy entries even when the legacy svc was disabled. This PR fixes both issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8486)
<!-- Reviewable:end -->
