### PR TITLE
daemon: Do not remove revNAT if removing svc fails

### DIFF
--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -1192,7 +1192,7 @@ func (d *Daemon) delK8sSVCs(svc k8s.ServiceID, svcInfo *k8s.Service, se *k8s.End
 		if err := d.svcDeleteByFrontend(fe); err != nil {
 			scopedLog.WithError(err).WithField(logfields.Object, logfields.Repr(fe)).
 				Warn("Error deleting service by frontend")
-
+			continue
 		} else {
 			scopedLog.Debugf("# cilium lb delete-service %s %d 0", fe.IP, fe.Port)
 		}


### PR DESCRIPTION
It has been observed that the daemon can receive the duplicate events for a k8s svc removal, e.g.:

    msg="Kubernetes service definition changed" action=service-deleted endpoints= k8sNamespace=default k8sSvcName=migrate-svc-6 service="frontend:10.104.17.176/ports=[]/selector=map[app:migrate-svc-server-6]" subsys=daemon
    <..>
    msg="Kubernetes service definition changed" action=service-deleted endpoints= k8sNamespace=default k8sSvcName=migrate-svc-6 service="frontend:10.104.17.176/ports=[]/selector=map[app:migrate-svc-server-6]" subsys=daemon
    g msg="Error deleting service by frontend" error="Service frontend not found 10.104.17.176:8000" k8sNamespace=default k8sSvcName=migrate-svc-6 obj="10.104.17.176:8000" subsys=daemon
    msg="# cilium lb delete-rev-nat 32" k8sNamespace=default k8sSvcName=migrate-svc-6 subsys=daemon
    msg="deleting L3n4Addr by ID" l3n4AddrID=33 subsys=service

In such situations, the daemon tries to remove the revNAT entry twice, which can lead to a removal of a valid revNAT entry if in between the events the daemon creates a new service with the same ID.

Fix this by skipping the revNAT removal if the frontend removal fails.

OT: @aanm has explanation for the duplicate events.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8487)
<!-- Reviewable:end -->
