### PR TITLE
aws/eni: Fall back to Get() when Update() does not return latest revision

### DIFF
--- a/operator/eni.go
+++ b/operator/eni.go
@@ -31,11 +31,16 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws/external"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var nodeManager *eni.NodeManager
 
 type k8sAPI struct{}
+
+func (k *k8sAPI) Get(node string) (*v2.CiliumNode, error) {
+	return ciliumK8sClient.CiliumV2().CiliumNodes().Get(node, metav1.GetOptions{})
+}
 
 func (k *k8sAPI) UpdateStatus(node, origNode *v2.CiliumNode) (*v2.CiliumNode, error) {
 	// If k8s supports status as a sub-resource, then we need to update the status separately

--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -530,7 +530,7 @@ func (n *Node) SyncToAPIServer() (err error) {
 	scopedLog.Debug("Refreshing node")
 
 	node := n.ResourceCopy()
-	origNode := n.ResourceCopy()
+	origNode := node.DeepCopy()
 
 	n.mutex.RLock()
 	defer n.mutex.RUnlock()
@@ -559,8 +559,17 @@ func (n *Node) SyncToAPIServer() (err error) {
 		updatedNode, err = n.manager.k8sAPI.UpdateStatus(node, origNode)
 		if updatedNode != nil && updatedNode.Name != "" {
 			node = updatedNode.DeepCopy()
-		}
-		if err == nil || updatedNode == nil {
+			if err == nil {
+				break
+			}
+		} else if err != nil {
+			node, err = n.manager.k8sAPI.Get(node.Name)
+			if err != nil {
+				break
+			}
+			node = node.DeepCopy()
+			origNode = node.DeepCopy()
+		} else {
 			break
 		}
 	}
@@ -589,8 +598,17 @@ func (n *Node) SyncToAPIServer() (err error) {
 		updatedNode, err = n.manager.k8sAPI.Update(node, origNode)
 		if updatedNode != nil && updatedNode.Name != "" {
 			node = updatedNode.DeepCopy()
-		}
-		if err == nil || updatedNode == nil {
+			if err == nil {
+				break
+			}
+		} else if err != nil {
+			node, err = n.manager.k8sAPI.Get(node.Name)
+			if err != nil {
+				break
+			}
+			node = node.DeepCopy()
+			origNode = node.DeepCopy()
+		} else {
 			break
 		}
 	}

--- a/pkg/aws/eni/node_manager.go
+++ b/pkg/aws/eni/node_manager.go
@@ -33,6 +33,7 @@ import (
 type k8sAPI interface {
 	Update(origResource, newResource *v2.CiliumNode) (*v2.CiliumNode, error)
 	UpdateStatus(origResource, newResource *v2.CiliumNode) (*v2.CiliumNode, error)
+	Get(name string) (*v2.CiliumNode, error)
 }
 
 type nodeManagerAPI interface {

--- a/pkg/aws/eni/node_manager_test.go
+++ b/pkg/aws/eni/node_manager_test.go
@@ -93,6 +93,10 @@ func (k *k8sMock) UpdateStatus(node, origNode *v2.CiliumNode) (*v2.CiliumNode, e
 	return nil, nil
 }
 
+func (k *k8sMock) Get(node string) (*v2.CiliumNode, error) {
+	return &v2.CiliumNode{}, nil
+}
+
 func newCiliumNode(node, instanceID, instanceType, az, vpcID string, preAllocate, minAllocate, available, used int) *v2.CiliumNode {
 	cn := &v2.CiliumNode{
 		ObjectMeta: metav1.ObjectMeta{Name: node, Namespace: "default"},


### PR DESCRIPTION
Update() and UpdateStatus() don't always provide the latest revision. Use Get()
to avoid requiring to avoid for the update notification.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8488)
<!-- Reviewable:end -->
