### PR TITLE
operator: startSynchronizingServices before kvstore

### DIFF
--- a/operator/main.go
+++ b/operator/main.go
@@ -209,6 +209,10 @@ func runOperator(cmd *cobra.Command) {
 		startSynchronizingCiliumNodes()
 	}
 
+	if synchronizeServices {
+		startSynchronizingServices()
+	}
+
 	if requiresKVstore() {
 		var goopts *kvstore.ExtraOptions
 		scopedLog := log.WithFields(logrus.Fields{
@@ -259,10 +263,6 @@ func runOperator(cmd *cobra.Command) {
 		if err := kvstore.Setup(kvStore, kvStoreOpts, goopts); err != nil {
 			scopedLog.WithError(err).Fatal("Unable to setup kvstore")
 		}
-	}
-
-	if synchronizeServices {
-		startSynchronizingServices()
 	}
 
 	if enableCepGC {


### PR DESCRIPTION
As kvstore with etcd-operator requires the services to be synchronized
first the setup of those services need to happen before the kvstore
setup is done.

Fixes: a9ed3577bcb2 ("operator: do not depend on cluster DNS to connect to etcd")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8495)
<!-- Reviewable:end -->
