### PR TITLE
daemon: Fix merge between PRs #8419 and #8486

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -441,14 +441,6 @@ func (d *Daemon) initMaps() error {
 		defer d.loadBalancer.BPFMapMU.Unlock()
 
 		if option.Config.EnableIPv6 {
-			if option.Config.EnableLegacyServices {
-				if err := lbmap.Service6Map.DeleteAll(); err != nil {
-					return err
-				}
-				if err := lbmap.RRSeq6Map.DeleteAll(); err != nil {
-					return err
-				}
-			}
 			if err := lbmap.Service6MapV2.DeleteAll(); err != nil {
 				return err
 			}
@@ -464,14 +456,6 @@ func (d *Daemon) initMaps() error {
 		}
 
 		if option.Config.EnableIPv4 {
-			if option.Config.EnableLegacyServices {
-				if err := lbmap.Service4Map.DeleteAll(); err != nil {
-					return err
-				}
-				if err := lbmap.RRSeq4Map.DeleteAll(); err != nil {
-					return err
-				}
-			}
 			if err := lbmap.Service4MapV2.DeleteAll(); err != nil {
 				return err
 			}


### PR DESCRIPTION
These PRs (#8419, #8486) were tested in the CI around the same time, then each one merged. They didn't have direct merge conflicts, but they broke with each other on master. Fix the build breakage by removing code related to legacy service map cleanup.

After #8419, legacy service maps are deleted always on startup if they exist, so code for deleting all elements is no longer necessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8499)
<!-- Reviewable:end -->
