### PR TITLE
v1.4 backports 2019-07-08

### DIFF
--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -2,7 +2,7 @@
 
 pipeline {
     agent {
-        label 'fixed'
+        label 'baremetal'
     }
 
     parameters {

--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -852,7 +852,7 @@ func (d *Daemon) delK8sSVCs(svc k8s.ServiceID, svcInfo *k8s.Service, se *k8s.End
 		if err := d.svcDeleteByFrontend(fe); err != nil {
 			scopedLog.WithError(err).WithField(logfields.Object, logfields.Repr(fe)).
 				Warn("Error deleting service by frontend")
-
+			continue
 		} else {
 			scopedLog.Debugf("# cilium lb delete-service %s %d 0", svcInfo.FrontendIP, svcPort.Port)
 		}

--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -105,6 +105,8 @@ var (
 	endpointMetadataCache = endpointImportMetadataCache{
 		endpointImportMetadataMap: make(map[string]endpointImportMetadata),
 	}
+
+	errIPCacheOwnedByNonK8s = fmt.Errorf("ipcache entry owned by kvstore or agent")
 )
 
 // ruleImportMetadataCache maps the unique identifier of a CiliumNetworkPolicy
@@ -1472,7 +1474,12 @@ func (d *Daemon) addK8sPodV1(pod *v1.Pod) error {
 		logger.WithError(err).Debug("Skipped ipcache map update on pod add")
 		return nil
 	case err != nil:
-		logger.WithError(err).Warning("Unable to update ipcache map entry on pod add ")
+		msg := "Unable to update ipcache map entry on pod add"
+		if err == errIPCacheOwnedByNonK8s {
+			logger.WithError(err).Debug(msg)
+		} else {
+			logger.WithError(err).Warning(msg)
+		}
 	default:
 		logger.Debug("Updated ipcache map entry on pod add")
 	}
@@ -1723,7 +1730,7 @@ func (d *Daemon) updateK8sNodeTunneling(k8sNodeOld, k8sNodeNew *v1.Node) error {
 		Source: ipcache.FromKubernetes,
 	})
 	if !selfOwned {
-		return fmt.Errorf("ipcache entry owned by kvstore or agent")
+		return errIPCacheOwnedByNonK8s
 	}
 
 	d.nodeDiscovery.manager.NodeUpdated(*nodeNew)

--- a/flannel.Jenkinsfile
+++ b/flannel.Jenkinsfile
@@ -51,14 +51,18 @@ pipeline {
         }
         stage('Boot VMs'){
             options {
-                timeout(time: 30, unit: 'MINUTES')
+                timeout(time: 60, unit: 'MINUTES')
             }
             environment {
                 TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
             }
             steps {
-                sh 'cd ${TESTDIR}; K8S_VERSION=1.9 vagrant up --no-provision'
-                sh 'cd ${TESTDIR}; K8S_VERSION=1.13 vagrant up --no-provision'
+                retry(3){
+                    sh 'cd ${TESTDIR}; K8S_VERSION=1.9 vagrant destroy --force'
+                    sh 'cd ${TESTDIR}; K8S_VERSION=1.13 vagrant destroy --force'
+                    sh 'cd ${TESTDIR}; K8S_VERSION=1.9 vagrant up --no-provision'
+                    sh 'cd ${TESTDIR}; K8S_VERSION=1.13 vagrant up --no-provision'
+                }
             }
         }
         stage('BDD-Test-PR') {

--- a/ginkgo-kubernetes-all.Jenkinsfile
+++ b/ginkgo-kubernetes-all.Jenkinsfile
@@ -79,7 +79,7 @@ pipeline {
         stage('Copy code and boot VMs 1.{9,10}'){
 
             options {
-                timeout(time: 30, unit: 'MINUTES')
+                timeout(time: 60, unit: 'MINUTES')
             }
 
             environment {
@@ -97,7 +97,10 @@ pipeline {
                     steps {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
-                        sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} vagrant up k8s1-${TESTED_SUITE} k8s2-${TESTED_SUITE} --provision'
+                        retry(3) {
+                            sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} vagrant destroy k8s1-${TESTED_SUITE} k8s2-${TESTED_SUITE} --force'
+                            sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} vagrant up k8s1-${TESTED_SUITE} k8s2-${TESTED_SUITE} --provision'
+                        }
                     }
                     post {
                         unsuccessful {
@@ -118,7 +121,10 @@ pipeline {
                     steps {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
-                        sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} vagrant up k8s1-${TESTED_SUITE} k8s2-${TESTED_SUITE} --provision'
+                        retry(3) {
+                            sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} vagrant destroy k8s1-${TESTED_SUITE} k8s2-${TESTED_SUITE} --force'
+                            sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} vagrant up k8s1-${TESTED_SUITE} k8s2-${TESTED_SUITE} --provision'
+                        }
                     }
                     post {
                         unsuccessful {
@@ -199,7 +205,7 @@ pipeline {
         stage('Copy code and boot VMs 1.{11,12}'){
 
             options {
-                timeout(time: 30, unit: 'MINUTES')
+                timeout(time: 60, unit: 'MINUTES')
             }
 
             environment {
@@ -217,7 +223,10 @@ pipeline {
                     steps {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
-                        sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} vagrant up k8s1-${TESTED_SUITE} k8s2-${TESTED_SUITE} --provision'
+                        retry(3) {
+                            sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} vagrant destroy k8s1-${TESTED_SUITE} k8s2-${TESTED_SUITE} --force'
+                            sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} vagrant up k8s1-${TESTED_SUITE} k8s2-${TESTED_SUITE} --provision'
+                        }
                     }
                     post {
                         unsuccessful {
@@ -238,7 +247,10 @@ pipeline {
                     steps {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
-                        sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} vagrant up k8s1-${TESTED_SUITE} k8s2-${TESTED_SUITE} --provision'
+                        retry(3) {
+                            sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} vagrant destroy k8s1-${TESTED_SUITE} k8s2-${TESTED_SUITE} --force'
+                            sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} vagrant up k8s1-${TESTED_SUITE} k8s2-${TESTED_SUITE} --provision'
+                        }
                     }
                     post {
                         unsuccessful {

--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -76,7 +76,7 @@ pipeline {
         }
         stage ("Copy code and boot vms"){
             options {
-                timeout(time: 45, unit: 'MINUTES')
+                timeout(time: 60, unit: 'MINUTES')
             }
 
             environment {

--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -93,7 +93,10 @@ pipeline {
                     steps {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
-                        sh 'cd ${TESTDIR}; vagrant up runtime --provision'
+                        retry(3) {
+                            sh 'cd ${TESTDIR}; vagrant destroy runtime --force'
+                            sh 'cd ${TESTDIR}; vagrant up runtime --provision'
+                        }
                     }
                     post {
                         unsuccessful {
@@ -114,7 +117,10 @@ pipeline {
                     steps {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
-                        sh 'cd ${TESTDIR}; K8S_VERSION=1.8 vagrant up k8s1-1.8 k8s2-1.8 --provision'
+                        retry(3) {
+                            sh 'cd ${TESTDIR}; K8S_VERSION=1.8 vagrant destroy k8s1-1.8 k8s2-1.8 --force'
+                            sh 'cd ${TESTDIR}; K8S_VERSION=1.8 vagrant up k8s1-1.8 k8s2-1.8 --provision'
+                        }
                     }
                     post {
                         unsuccessful {
@@ -135,7 +141,10 @@ pipeline {
                     steps {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
-                        sh 'cd ${TESTDIR}; K8S_VERSION=1.14 vagrant up k8s1-1.14 k8s2-1.14 --provision'
+                        retry(3) {
+                            sh 'cd ${TESTDIR}; K8S_VERSION=1.14 vagrant destroy k8s1-1.14 k8s2-1.14 --force'
+                            sh 'cd ${TESTDIR}; K8S_VERSION=1.14 vagrant up k8s1-1.14 k8s2-1.14 --provision'
+                        }
                     }
                     post {
                         unsuccessful {

--- a/kubernetes-upstream.Jenkinsfile
+++ b/kubernetes-upstream.Jenkinsfile
@@ -68,12 +68,16 @@ pipeline {
         }
         stage('Boot VMs'){
             options {
-                timeout(time: 30, unit: 'MINUTES')
+                timeout(time: 60, unit: 'MINUTES')
             }
 
             steps {
-                sh 'cd ${TESTDIR}; vagrant up k8s1-${K8S_VERSION}'
-                sh 'cd ${TESTDIR}; vagrant up k8s2-${K8S_VERSION}'
+                retry(3){
+                    sh 'cd ${TESTDIR}; vagrant destroy k8s1-${K8S_VERSION} --force'
+                    sh 'cd ${TESTDIR}; vagrant destroy k8s2-${K8S_VERSION} --force'
+                    sh 'cd ${TESTDIR}; vagrant up k8s1-${K8S_VERSION}'
+                    sh 'cd ${TESTDIR}; vagrant up k8s2-${K8S_VERSION}'
+                }
             }
         }
 

--- a/kubernetes-upstream.Jenkinsfile
+++ b/kubernetes-upstream.Jenkinsfile
@@ -74,6 +74,15 @@ pipeline {
             steps {
                 sh 'cd ${TESTDIR}; vagrant up k8s1-${K8S_VERSION}'
                 sh 'cd ${TESTDIR}; vagrant up k8s2-${K8S_VERSION}'
+            }
+        }
+
+        stage('BDD-tests'){
+            options {
+                timeout(time: 45, unit: 'MINUTES')
+            }
+
+            steps {
                 sh 'cd ${TESTDIR}; vagrant ssh k8s1-${K8S_VERSION} -c "cd /home/vagrant/go/${PROJ_PATH}; ./test/kubernetes-test.sh"'
             }
         }

--- a/pkg/k8s/service_cache.go
+++ b/pkg/k8s/service_cache.go
@@ -146,10 +146,11 @@ func (s *ServiceCache) DeleteService(k8sSvc *v1.Service) {
 	svcID := ParseServiceID(k8sSvc)
 
 	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
 	oldService, serviceOK := s.services[svcID]
 	endpoints, _ := s.correlateEndpoints(svcID)
 	delete(s.services, svcID)
-	s.mutex.Unlock()
 
 	if serviceOK {
 		s.Events <- ServiceEvent{
@@ -226,10 +227,11 @@ func (s *ServiceCache) DeleteEndpoints(k8sEndpoints *v1.Endpoints) ServiceID {
 	svcID := ParseEndpointsID(k8sEndpoints)
 
 	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
 	service, serviceOK := s.services[svcID]
 	delete(s.endpoints, svcID)
 	endpoints, serviceReady := s.correlateEndpoints(svcID)
-	s.mutex.Unlock()
 
 	if serviceOK {
 		event := ServiceEvent{
@@ -323,10 +325,11 @@ func (s *ServiceCache) DeleteIngress(ingress *v1beta1.Ingress) {
 	svcID := ParseIngressID(ingress)
 
 	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
 	oldService, ok := s.ingresses[svcID]
 	endpoints, _ := s.endpoints[svcID]
 	delete(s.ingresses, svcID)
-	s.mutex.Unlock()
 
 	if ok {
 		s.Events <- ServiceEvent{

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -356,6 +356,9 @@ func UpdateService(fe ServiceKey, backends []ServiceValue, addRevNAT bool, revNA
 		existingCount   int
 	)
 
+	mutex.Lock()
+	defer mutex.Unlock()
+
 	svc := cache.prepareUpdate(fe, backends)
 	besValues := svc.getBackends()
 
@@ -370,9 +373,6 @@ func UpdateService(fe ServiceKey, backends []ServiceValue, addRevNAT bool, revNA
 			nNonZeroWeights++
 		}
 	}
-
-	mutex.Lock()
-	defer mutex.Unlock()
 
 	// Check if the service already exists, it is not failure scenario if
 	// the services doesn't exist. That's simply a new service. Even if the


### PR DESCRIPTION
v1.4 backports 2019-07-08

 * #8416 -- maps/lbmap: protect service cache refcount with concurrent access (@aanm)
 * #8388 -- daemon: Change loglevel of "ipcache entry owned by kvstore or agent" (@brb)
 * #8443 -- Change nightly CI job label from fixed to baremetal (@nebril)
 * #8453 -- pkg/k8s: hold mutex while adding events to the queue (@aanm)
 * #8462 -- Retry provisioning vagrant vms in CI (@nebril)
 * #8487 -- daemon: Do not remove revNAT if removing svc fails (@brb)
 * #8477 -- [CI] retry vm provisioning, increase timeout (@nebril)

Once this PR is merged, you can update the PR labels via:
```
$ for pr in 8416 8388 8443 8453 8462 8487 8477; do contrib/backporting/set-labels.py $pr done 1.4; done
```

---

Note: I also backported commit https://github.com/cilium/cilium/commit/1cd9e2b41d0fbfe6ef6e0fb4319c0aa88bdc4582 since [this part](https://github.com/cilium/cilium/commit/2a50e8fd5cdd1620b23026fbdd24fa1d95ae82d5#diff-af75893097d64ec4f3a955d27071437cR75) of #8477 doesn't make sense otherwise.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8500)
<!-- Reviewable:end -->
