### PR TITLE
[tests] don't wait on ssh sessions twice

### DIFF
--- a/test/helpers/ssh_command.go
+++ b/test/helpers/ssh_command.go
@@ -163,7 +163,7 @@ func runCommand(session *ssh.Session, cmd *SSHCommand) (bool, error) {
 	}
 	outChan := copyWait(cmd.Stdout, stdout)
 
-	if err = session.Run(cmd.Path); err != nil {
+	if err = session.Start(cmd.Path); err != nil {
 		return false, err
 	}
 


### PR DESCRIPTION
Since we are running `Wait` on sessions explicitely, we can `Start` the
session instead of running it.
Fixes: #8241

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8503)
<!-- Reviewable:end -->
