### PR TITLE
Update documentation for legacy service removal

### DIFF
--- a/Documentation/architecture.rst
+++ b/Documentation/architecture.rst
@@ -231,16 +231,11 @@ Map Name                 Scope            Default Limit   Scale Implications
 Connection Tracking      node or endpoint 1M TCP/256K UDP Max 1M concurrent TCP connections, max 256K expected UDP answers
 Endpoints                node             64k             Max 64k local endpoints + host IPs per node
 IP cache                 node             512K            Max 256K endpoints (IPv4+IPv6), max 512k endpoints (IPv4 or IPv6) across all clusters
-Load Balancer            node             64k             Max 64k cumulative backends across all services across all clusters [*]
+Load Balancer            node             64k             Max 64k cumulative backends across all services across all clusters
 Policy                   endpoint         16k             Max 16k allowed identity + port + protocol pairs for specific endpoint
 Proxy Map                node             512k            Max 512k concurrent redirected TCP connections to proxy
 Tunnel                   node             64k             Max 32k nodes (IPv4+IPv6) or 64k nodes (IPv4 or IPv6) across all clusters
 ======================== ================ =============== =====================================================
-
-[*] Due to a limitation in the load-balancing implementation, constant churn in
-the load balancing table by scaling the number of service backends up and down
-can reduce the maximum number of supported service backends further. If in
-doubt, increase the limit to 512k.
 
 Kubernetes Integration
 ======================

--- a/Documentation/gettingstarted/grafana.rst
+++ b/Documentation/gettingstarted/grafana.rst
@@ -49,7 +49,7 @@ Expose the port on your local machine
 
     kubectl -n cilium-monitoring port-forward service/grafana 3000:3000
 
-Access it via your browser: `https://localhost:3000`
+Access it via your browser: ``https://localhost:3000``
 
 How to access Prometheus
 ========================
@@ -60,7 +60,7 @@ Expose the port on your local machine
 
     kubectl -n cilium-monitoring port-forward service/prometheus 9090:9090
 
-Access it via your browser: `https://localhost:9090`
+Access it via your browser: ``https://localhost:9090``
 
 Examples
 ========

--- a/Documentation/gettingstarted/istio.rst
+++ b/Documentation/gettingstarted/istio.rst
@@ -220,6 +220,7 @@ making a query from reviews pod to the productpage:
         <title>Simple Bookstore App</title>
 
 .. only:: not (epub or latex or html)
+
    Notes for Istio debugging:
    - Set istio proxy to debug or trace mode:
    $ kubectl exec -it $(kubectl get pod -l app=productpage -o jsonpath='{.items[0].metadata.name}') -c istio-proxy -- curl -XPOST http://127.0.0.1:15000/logging?level=debug

--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -266,6 +266,8 @@ latest ``1.1.y`` release before subsequently upgrading to ``1.2.z``.
 +-----------------------+-----------------------+-----------------------+-------------------------+---------------------------+
 | ``>=1.2.5``           | ``1.5.y``             | Required              | Minimal to None         | Clients must reconnect[1] |
 +-----------------------+-----------------------+-----------------------+-------------------------+---------------------------+
+| ``1.5.x``             | ``1.6.y``             | Required              | Minimal to None         | Clients must reconnect[1] |
++-----------------------+-----------------------+-----------------------+-------------------------+---------------------------+
 
 Annotations:
 
@@ -282,6 +284,14 @@ Annotations:
 
 1.6 Upgrade Notes
 -----------------
+
+Upgrading from >=1.5.0 to 1.6.y
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+#. Follow the standard procedures to perform the upgrade as described in
+   :ref:`upgrade_minor`. Users running older versions should first upgrade to
+   the latest v1.5.x point release to minimize disruption of service
+   connections during upgrade.
 
 Changes that may require action
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -321,6 +331,15 @@ New ConfigMap Options
   * ``cni-chaining-mode`` has been added to automatically generate CNI chaining
     configurations with various other plugins. See the section
     :ref:`cni_chaining` for a list of supported CNI chaining plugins.
+
+Deprecated options
+~~~~~~~~~~~~~~~~~~
+
+* ``enable-legacy-services``: This option was introduced to ease the transition
+  between Cilium 1.4.x and 1.5.x releases, allowing smooth upgrade and
+  downgrade. As of 1.6.0, it is deprecated. Subsequently downgrading from 1.6.x
+  or later to 1.4.x may result in disruption of connections that connect via
+  services.
 
 Deprecated metrics
 ~~~~~~~~~~~~~~~~~~

--- a/Documentation/policy/troubleshooting.rst
+++ b/Documentation/policy/troubleshooting.rst
@@ -205,62 +205,66 @@ podname`` when running in kubernetes.
 .. only:: html
 
    .. tabs::
-     .. group-tab:: k8s YAML
+      .. group-tab:: k8s YAML
 
-        .. code-block:: yaml
+         .. code-block:: yaml
 
-                cidr-policy:
-                  egress:
-                  - derived-from-rules:
-                    - - k8s:io.cilium.k8s.policy.name=rebel-escape
-                      - k8s:io.cilium.k8s.policy.uid=c96f66a8-135e-11e9-babd-080027d2d952
-                      - k8s:io.cilium.k8s.policy.namespace=default
-                      - k8s:io.cilium.k8s.policy.derived-from=CiliumNetworkPolicy
-                      - cilium-generated:ToFQDN-UUID=4cee1da1-1361-11e9-a6d4-080027d2d952
-                    rule: 104.198.14.52/32
-                  ingress: []
+            cidr-policy:
+              egress:
+              - derived-from-rules:
+                - - k8s:io.cilium.k8s.policy.name=rebel-escape
+                  - k8s:io.cilium.k8s.policy.uid=c96f66a8-135e-11e9-babd-080027d2d952
+                  - k8s:io.cilium.k8s.policy.namespace=default
+                  - k8s:io.cilium.k8s.policy.derived-from=CiliumNetworkPolicy
+                  - cilium-generated:ToFQDN-UUID=4cee1da1-1361-11e9-a6d4-080027d2d952
+                rule: 104.198.14.52/32
+              ingress: []
 
-     .. group-tab:: JSON
+      .. group-tab:: JSON
 
-        .. code-block:: json
+         .. code-block:: json
 
-                "cidr-policy": {
-                  "egress": [
-                    {
-                      "derived-from-rules": [
-                        [
-                          "k8s:io.cilium.k8s.policy.name=rebel-escape",
-                          "k8s:io.cilium.k8s.policy.uid=c96f66a8-135e-11e9-babd-080027d2d952",
-                          "k8s:io.cilium.k8s.policy.namespace=default",
-                          "k8s:io.cilium.k8s.policy.derived-from=CiliumNetworkPolicy",
-                          "cilium-generated:ToFQDN-UUID=9a1d4006-1360-11e9-a6d4-080027d2d952"
-                        ]
-                      ],
-                      "rule": "104.198.14.52/32"
-                    }
-                  ],
-                  "ingress": []
-                },
+            {
+              "cidr-policy": {
+                "egress": [
+                  {
+                    "derived-from-rules": [
+                      [
+                        "k8s:io.cilium.k8s.policy.name=rebel-escape",
+                        "k8s:io.cilium.k8s.policy.uid=c96f66a8-135e-11e9-babd-080027d2d952",
+                        "k8s:io.cilium.k8s.policy.namespace=default",
+                        "k8s:io.cilium.k8s.policy.derived-from=CiliumNetworkPolicy",
+                        "cilium-generated:ToFQDN-UUID=9a1d4006-1360-11e9-a6d4-080027d2d952"
+                      ]
+                    ],
+                    "rule": "104.198.14.52/32"
+                  }
+                ],
+                "ingress": []
+              }
+            }
 
 .. only:: epub or latex
 
-        .. code-block:: json
+   .. code-block:: json
 
-                "cidr-policy": {
-                  "egress": [
-                    {
-                      "derived-from-rules": [
-                        [
-                          "k8s:io.cilium.k8s.policy.name=rebel-escape",
-                          "k8s:io.cilium.k8s.policy.uid=c96f66a8-135e-11e9-babd-080027d2d952",
-                          "k8s:io.cilium.k8s.policy.namespace=default",
-                          "k8s:io.cilium.k8s.policy.derived-from=CiliumNetworkPolicy",
-                          "cilium-generated:ToFQDN-UUID=9a1d4006-1360-11e9-a6d4-080027d2d952"
-                        ]
-                      ],
-                      "rule": "104.198.14.52/32"
-                    }
-                  ],
-                  "ingress": []
-                },
+      {
+        "cidr-policy": {
+          "egress": [
+            {
+              "derived-from-rules": [
+                [
+                  "k8s:io.cilium.k8s.policy.name=rebel-escape",
+                  "k8s:io.cilium.k8s.policy.uid=c96f66a8-135e-11e9-babd-080027d2d952",
+                  "k8s:io.cilium.k8s.policy.namespace=default",
+                  "k8s:io.cilium.k8s.policy.derived-from=CiliumNetworkPolicy",
+                  "cilium-generated:ToFQDN-UUID=9a1d4006-1360-11e9-a6d4-080027d2d952"
+                ]
+              ],
+              "rule": "104.198.14.52/32"
+            }
+          ],
+          "ingress": []
+        }
+      }
 


### PR DESCRIPTION
This PR fixes documentation warnings and documents #8419 .

I realise that the FQDN troubleshooting docs are now out-of-date, I'll prepare another docs PR to fix that up.

Fixes: #7967

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8505)
<!-- Reviewable:end -->
