### PR TITLE
endpoint: do not log warning for specific state transition

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1564,9 +1564,19 @@ func (e *Endpoint) SetStateLocked(toState, reason string) bool {
 		// No valid transitions, as disconnected is a terminal state for the endpoint.
 	case StateWaitingToRegenerate:
 		switch toState {
-		// Note that transitions to waiting-to-regenerate state
+		// Note that transitions to StateWaitingToRegenerate are not allowed,
+		// as callers of this function enqueue regenerations if 'true' is
+		// returned. We don't want to return 'true' for the case of
+		// transitioning to StateWaitingToRegenerate, as this means that a
+		// regeneration is already queued up. Callers would then queue up
+		// another unneeded regeneration, which is undesired.
 		case StateWaitingForIdentity, StateDisconnecting, StateRestoring:
 			goto OKState
+		// Don't log this state transition being invalid below so that we don't
+		// put warnings in the logs for a case which does not result in incorrect
+		// behavior.
+		case StateWaitingToRegenerate:
+			return false
 		}
 	case StateRegenerating:
 		switch toState {


### PR DESCRIPTION
Do not log a warning when transition from waiting-to-regenerate to waiting-to-regenerate is
triggered. The correct action is to do nothing, since a regeneration is already enqueued.

Several callers rely upon existing behavior (i.e., that we do not allow this as a valid
state transition) so that we do not enqueue a lot of regenerations, which are costly
operations. Maintain this behavior, but suppress the warning log since there will not
be any degradation in performance / incorrect state realized.

Signed-off by: Ian Vernon <ian@cilium.io>

This is somewhat of a hack to make the fix backport-able to v1.5. Additional work is already being done to rework the endpoint state machine, so I didn't want to put too many cycles into this.

Fixes: #8493 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8511)
<!-- Reviewable:end -->
