### PR TITLE
v1.5: backports 19-07-09

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -653,10 +653,21 @@ func (d *Daemon) initMaps() error {
 		defer d.loadBalancer.BPFMapMU.Unlock()
 
 		if option.Config.EnableIPv6 {
-			if err := lbmap.Service6Map.DeleteAll(); err != nil {
+			if option.Config.EnableLegacyServices {
+				if err := lbmap.Service6Map.DeleteAll(); err != nil {
+					return err
+				}
+				if err := lbmap.RRSeq6Map.DeleteAll(); err != nil {
+					return err
+				}
+			}
+			if err := lbmap.Service6MapV2.DeleteAll(); err != nil {
 				return err
 			}
-			if err := lbmap.RRSeq6Map.DeleteAll(); err != nil {
+			if err := lbmap.RRSeq6MapV2.DeleteAll(); err != nil {
+				return err
+			}
+			if err := lbmap.Backend6Map.DeleteAll(); err != nil {
 				return err
 			}
 		}
@@ -665,10 +676,21 @@ func (d *Daemon) initMaps() error {
 		}
 
 		if option.Config.EnableIPv4 {
-			if err := lbmap.Service4Map.DeleteAll(); err != nil {
+			if option.Config.EnableLegacyServices {
+				if err := lbmap.Service4Map.DeleteAll(); err != nil {
+					return err
+				}
+				if err := lbmap.RRSeq4Map.DeleteAll(); err != nil {
+					return err
+				}
+			}
+			if err := lbmap.Service4MapV2.DeleteAll(); err != nil {
 				return err
 			}
-			if err := lbmap.RRSeq4Map.DeleteAll(); err != nil {
+			if err := lbmap.RRSeq4MapV2.DeleteAll(); err != nil {
+				return err
+			}
+			if err := lbmap.Backend4Map.DeleteAll(); err != nil {
 				return err
 			}
 		}

--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -1195,7 +1195,7 @@ func (d *Daemon) delK8sSVCs(svc k8s.ServiceID, svcInfo *k8s.Service, se *k8s.End
 		if err := d.svcDeleteByFrontend(fe); err != nil {
 			scopedLog.WithError(err).WithField(logfields.Object, logfields.Repr(fe)).
 				Warn("Error deleting service by frontend")
-
+			continue
 		} else {
 			scopedLog.Debugf("# cilium lb delete-service %s %d 0", svcInfo.FrontendIP, svcPort.Port)
 		}

--- a/flannel.Jenkinsfile
+++ b/flannel.Jenkinsfile
@@ -51,14 +51,18 @@ pipeline {
         }
         stage('Boot VMs'){
             options {
-                timeout(time: 30, unit: 'MINUTES')
+                timeout(time: 60, unit: 'MINUTES')
             }
             environment {
                 TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
             }
             steps {
-                sh 'cd ${TESTDIR}; K8S_VERSION=1.10 vagrant up --no-provision'
-                sh 'cd ${TESTDIR}; K8S_VERSION=1.13 vagrant up --no-provision'
+                retry(3){
+                    sh 'cd ${TESTDIR}; K8S_VERSION=1.10 vagrant destroy --force'
+                    sh 'cd ${TESTDIR}; K8S_VERSION=1.13 vagrant destroy --force'
+                    sh 'cd ${TESTDIR}; K8S_VERSION=1.10 vagrant up --no-provision'
+                    sh 'cd ${TESTDIR}; K8S_VERSION=1.13 vagrant up --no-provision'
+                }
             }
         }
         stage('BDD-Test-PR') {

--- a/ginkgo-kubernetes-all.Jenkinsfile
+++ b/ginkgo-kubernetes-all.Jenkinsfile
@@ -79,7 +79,7 @@ pipeline {
         stage('Copy code and boot VMs 1.{11,12}'){
 
             options {
-                timeout(time: 30, unit: 'MINUTES')
+                timeout(time: 60, unit: 'MINUTES')
             }
 
             environment {
@@ -97,7 +97,10 @@ pipeline {
                     steps {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
-                        sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} vagrant up k8s1-${TESTED_SUITE} k8s2-${TESTED_SUITE} --provision'
+                        retry(3) {
+                            sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} vagrant destroy k8s1-${TESTED_SUITE} k8s2-${TESTED_SUITE} --force'
+                            sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} vagrant up k8s1-${TESTED_SUITE} k8s2-${TESTED_SUITE} --provision'
+                        }
                     }
                     post {
                         unsuccessful {
@@ -118,7 +121,10 @@ pipeline {
                     steps {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
-                        sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} vagrant up k8s1-${TESTED_SUITE} k8s2-${TESTED_SUITE} --provision'
+                        retry(3) {
+                            sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} vagrant destroy k8s1-${TESTED_SUITE} k8s2-${TESTED_SUITE} --force'
+                            sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} vagrant up k8s1-${TESTED_SUITE} k8s2-${TESTED_SUITE} --provision'
+                        }
                     }
                     post {
                         unsuccessful {
@@ -198,7 +204,7 @@ pipeline {
         stage('Copy code and boot VMs 1.{13,15}'){
 
             options {
-                timeout(time: 30, unit: 'MINUTES')
+                timeout(time: 60, unit: 'MINUTES')
             }
 
             environment {
@@ -216,7 +222,10 @@ pipeline {
                     steps {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
-                        sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} vagrant up k8s1-${TESTED_SUITE} k8s2-${TESTED_SUITE} --provision'
+                        retry(3) {
+                            sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} vagrant destroy k8s1-${TESTED_SUITE} k8s2-${TESTED_SUITE} --force'
+                            sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} vagrant up k8s1-${TESTED_SUITE} k8s2-${TESTED_SUITE} --provision'
+                        }
                     }
                     post {
                         unsuccessful {
@@ -237,7 +246,10 @@ pipeline {
                     steps {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
-                        sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} vagrant up k8s1-${TESTED_SUITE} k8s2-${TESTED_SUITE} --provision'
+                        retry(3) {
+                            sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} vagrant destroy k8s1-${TESTED_SUITE} k8s2-${TESTED_SUITE} --force'
+                            sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} vagrant up k8s1-${TESTED_SUITE} k8s2-${TESTED_SUITE} --provision'
+                        }
                     }
                     post {
                         unsuccessful {

--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -76,7 +76,7 @@ pipeline {
         }
         stage ("Copy code and boot vms"){
             options {
-                timeout(time: 45, unit: 'MINUTES')
+                timeout(time: 60, unit: 'MINUTES')
             }
 
             environment {

--- a/kubernetes-upstream.Jenkinsfile
+++ b/kubernetes-upstream.Jenkinsfile
@@ -68,12 +68,16 @@ pipeline {
         }
         stage('Boot VMs'){
             options {
-                timeout(time: 30, unit: 'MINUTES')
+                timeout(time: 60, unit: 'MINUTES')
             }
 
             steps {
-                sh 'cd ${TESTDIR}; vagrant up k8s1-${K8S_VERSION}'
-                sh 'cd ${TESTDIR}; vagrant up k8s2-${K8S_VERSION}'
+                retry(3){
+                    sh 'cd ${TESTDIR}; vagrant destroy k8s1-${K8S_VERSION} --force'
+                    sh 'cd ${TESTDIR}; vagrant destroy k8s2-${K8S_VERSION} --force'
+                    sh 'cd ${TESTDIR}; vagrant up k8s1-${K8S_VERSION}'
+                    sh 'cd ${TESTDIR}; vagrant up k8s2-${K8S_VERSION}'
+                }
             }
         }
 

--- a/pkg/k8s/factory_functions.go
+++ b/pkg/k8s/factory_functions.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/client-go/tools/cache"
 )
 
 func CopyObjToV1NetworkPolicy(obj interface{}) *types.NetworkPolicy {
@@ -232,137 +233,299 @@ func EqualV1Namespace(ns1, ns2 *types.Namespace) bool {
 }
 
 // ConvertToNetworkPolicy converts a *networkingv1.NetworkPolicy into a
-// *types.NetworkPolicy
+// *types.NetworkPolicy or a cache.DeletedFinalStateUnknown into
+// a cache.DeletedFinalStateUnknown with a *types.NetworkPolicy in its Obj.
+// If the given obj can't be cast into either *networkingv1.NetworkPolicy
+// nor cache.DeletedFinalStateUnknown, the original obj is returned.
 func ConvertToNetworkPolicy(obj interface{}) interface{} {
-	netPol, ok := obj.(*networkingv1.NetworkPolicy)
-	if !ok {
-		return nil
-	}
 	// TODO check which fields we really need
-	return &types.NetworkPolicy{
-		NetworkPolicy: netPol,
+	switch concreteObj := obj.(type) {
+	case *networkingv1.NetworkPolicy:
+		return &types.NetworkPolicy{
+			NetworkPolicy: concreteObj,
+		}
+	case cache.DeletedFinalStateUnknown:
+		netPol, ok := concreteObj.Obj.(*networkingv1.NetworkPolicy)
+		if !ok {
+			return obj
+		}
+		return cache.DeletedFinalStateUnknown{
+			Key: concreteObj.Key,
+			Obj: &types.NetworkPolicy{
+				NetworkPolicy: netPol,
+			},
+		}
+	default:
+		return obj
 	}
 }
 
-// ConvertToK8sService converts a *v1.Service into a *types.Service
+// ConvertToK8sService converts a *v1.Service into a
+// *types.Service or a cache.DeletedFinalStateUnknown into
+// a cache.DeletedFinalStateUnknown with a *types.Service in its Obj.
+// If the given obj can't be cast into either *v1.Service
+// nor cache.DeletedFinalStateUnknown, the original obj is returned.
 func ConvertToK8sService(obj interface{}) interface{} {
-	service, ok := obj.(*v1.Service)
-	if !ok {
-		return nil
-	}
 	// TODO check which fields we really need
-	return &types.Service{
-		Service: service,
+	switch concreteObj := obj.(type) {
+	case *v1.Service:
+		return &types.Service{
+			Service: concreteObj,
+		}
+	case cache.DeletedFinalStateUnknown:
+		svc, ok := concreteObj.Obj.(*v1.Service)
+		if !ok {
+			return obj
+		}
+		return cache.DeletedFinalStateUnknown{
+			Key: concreteObj.Key,
+			Obj: &types.Service{
+				Service: svc,
+			},
+		}
+	default:
+		return obj
 	}
 }
 
-// ConvertToK8sEndpoints converts a *v1.Endpoints into a *types.Endpoints
+// ConvertToK8sEndpoints converts a *v1.Endpoints into a
+// *types.Endpoints or a cache.DeletedFinalStateUnknown into
+// a cache.DeletedFinalStateUnknown with a *types.Endpoints in its Obj.
+// If the given obj can't be cast into either *v1.Endpoints
+// nor cache.DeletedFinalStateUnknown, the original obj is returned.
 func ConvertToK8sEndpoints(obj interface{}) interface{} {
-	endpoints, ok := obj.(*v1.Endpoints)
-	if !ok {
-		return nil
-	}
 	// TODO check which fields we really need
-	return &types.Endpoints{
-		Endpoints: endpoints,
+	switch concreteObj := obj.(type) {
+	case *v1.Endpoints:
+		return &types.Endpoints{
+			Endpoints: concreteObj,
+		}
+	case cache.DeletedFinalStateUnknown:
+		eps, ok := concreteObj.Obj.(*v1.Endpoints)
+		if !ok {
+			return obj
+		}
+		return cache.DeletedFinalStateUnknown{
+			Key: concreteObj.Key,
+			Obj: &types.Endpoints{
+				Endpoints: eps,
+			},
+		}
+	default:
+		return obj
 	}
 }
 
-// ConvertToIngress converts a *v1beta1.Ingress into a *v1beta1.Ingress
+// ConvertToIngress converts a *v1beta1.Ingress into a
+// *types.Ingress or a cache.DeletedFinalStateUnknown into
+// a cache.DeletedFinalStateUnknown with a *types.Ingress in its Obj.
+// If the given obj can't be cast into either *v1beta1.Ingress
+// nor cache.DeletedFinalStateUnknown, the original obj is returned.
 func ConvertToIngress(obj interface{}) interface{} {
-	ingress, ok := obj.(*v1beta1.Ingress)
-	if !ok {
-		return nil
-	}
 	// TODO check which fields we really need
-	return &types.Ingress{
-		Ingress: ingress,
+	switch concreteObj := obj.(type) {
+	case *v1beta1.Ingress:
+		return &types.Ingress{
+			Ingress: concreteObj,
+		}
+	case cache.DeletedFinalStateUnknown:
+		ingrss, ok := concreteObj.Obj.(*v1beta1.Ingress)
+		if !ok {
+			return obj
+		}
+		return cache.DeletedFinalStateUnknown{
+			Key: concreteObj.Key,
+			Obj: &types.Ingress{
+				Ingress: ingrss,
+			},
+		}
+	default:
+		return obj
 	}
 }
 
 // ConvertToCNPWithStatus converts a *cilium_v2.CiliumNetworkPolicy into a
-// *types.SlimCNP
+// *types.SlimCNP or a cache.DeletedFinalStateUnknown into
+// a cache.DeletedFinalStateUnknown with a *types.SlimCNP in its Obj.
+// If the given obj can't be cast into either *cilium_v2.CiliumNetworkPolicy
+// nor cache.DeletedFinalStateUnknown, the original obj is returned.
 func ConvertToCNPWithStatus(obj interface{}) interface{} {
-	cnp, ok := obj.(*cilium_v2.CiliumNetworkPolicy)
-	if !ok {
-		return nil
+	switch concreteObj := obj.(type) {
+	case *cilium_v2.CiliumNetworkPolicy:
+		return &types.SlimCNP{
+			CiliumNetworkPolicy: concreteObj,
+		}
+	case cache.DeletedFinalStateUnknown:
+		cnp, ok := concreteObj.Obj.(*cilium_v2.CiliumNetworkPolicy)
+		if !ok {
+			return obj
+		}
+		return cache.DeletedFinalStateUnknown{
+			Key: concreteObj.Key,
+			Obj: &types.SlimCNP{
+				CiliumNetworkPolicy: cnp,
+			},
+		}
+	default:
+		return obj
 	}
-	slimCNP := &types.SlimCNP{
-		CiliumNetworkPolicy: cnp,
-	}
-	return slimCNP
 }
 
-// ConvertToCNP converts a *cilium_v2.CiliumNetworkPolicy into a *types.SlimCNP
-// without the Status field of the given CNP.
+// ConvertToCNP converts a *cilium_v2.CiliumNetworkPolicy into a
+// *types.SlimCNP without the Status field of the given CNP, or a
+// cache.DeletedFinalStateUnknown into a cache.DeletedFinalStateUnknown with a
+// *types.SlimCNP, also without the Status field of the given CNP, in its Obj.
+// If the given obj can't be cast into either *cilium_v2.CiliumNetworkPolicy
+// nor cache.DeletedFinalStateUnknown, the original obj is returned.
 // WARNING calling this function will set *all* fields of the given CNP as
 // empty.
 func ConvertToCNP(obj interface{}) interface{} {
-	cnp, ok := obj.(*cilium_v2.CiliumNetworkPolicy)
-	if !ok {
-		return nil
+	switch concreteObj := obj.(type) {
+	case *cilium_v2.CiliumNetworkPolicy:
+		cnp := &types.SlimCNP{
+			CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
+				TypeMeta:   concreteObj.TypeMeta,
+				ObjectMeta: concreteObj.ObjectMeta,
+				Spec:       concreteObj.Spec,
+				Specs:      concreteObj.Specs,
+			},
+		}
+		*concreteObj = cilium_v2.CiliumNetworkPolicy{}
+		return cnp
+	case cache.DeletedFinalStateUnknown:
+		cnp, ok := concreteObj.Obj.(*cilium_v2.CiliumNetworkPolicy)
+		if !ok {
+			return obj
+		}
+		dfsu := cache.DeletedFinalStateUnknown{
+			Key: concreteObj.Key,
+			Obj: &types.SlimCNP{
+				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
+					TypeMeta:   cnp.TypeMeta,
+					ObjectMeta: cnp.ObjectMeta,
+					Spec:       cnp.Spec,
+					Specs:      cnp.Specs,
+				},
+			},
+		}
+		*cnp = cilium_v2.CiliumNetworkPolicy{}
+		return dfsu
+	default:
+		return obj
 	}
-	slimCNP := &types.SlimCNP{
-		CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
-			TypeMeta:   cnp.TypeMeta,
-			ObjectMeta: cnp.ObjectMeta,
-			Spec:       cnp.Spec,
-			Specs:      cnp.Specs,
-		},
-	}
-	*cnp = cilium_v2.CiliumNetworkPolicy{}
-	return slimCNP
 }
 
-// ConvertToPod converts a *v1.Pod into a *types.Pod.
+// ConvertToPod converts a *v1.Pod into a
+// *types.Pod or a cache.DeletedFinalStateUnknown into
+// a cache.DeletedFinalStateUnknown with a *types.Pod in its Obj.
+// If the given obj can't be cast into either *v1.Pod
+// nor cache.DeletedFinalStateUnknown, the original obj is returned.
 // WARNING calling this function will set *all* fields of the given Pod as
 // empty.
 func ConvertToPod(obj interface{}) interface{} {
-	pod, ok := obj.(*v1.Pod)
-	if !ok {
-		return nil
+	switch concreteObj := obj.(type) {
+	case *v1.Pod:
+		p := &types.Pod{
+			TypeMeta:        concreteObj.TypeMeta,
+			ObjectMeta:      concreteObj.ObjectMeta,
+			StatusPodIP:     concreteObj.Status.PodIP,
+			StatusHostIP:    concreteObj.Status.HostIP,
+			SpecHostNetwork: concreteObj.Spec.HostNetwork,
+		}
+		*concreteObj = v1.Pod{}
+		return p
+	case cache.DeletedFinalStateUnknown:
+		pod, ok := concreteObj.Obj.(*v1.Pod)
+		if !ok {
+			return obj
+		}
+		dfsu := cache.DeletedFinalStateUnknown{
+			Key: concreteObj.Key,
+			Obj: &types.Pod{
+				TypeMeta:        pod.TypeMeta,
+				ObjectMeta:      pod.ObjectMeta,
+				StatusPodIP:     pod.Status.PodIP,
+				StatusHostIP:    pod.Status.HostIP,
+				SpecHostNetwork: pod.Spec.HostNetwork,
+			},
+		}
+		*pod = v1.Pod{}
+		return dfsu
+	default:
+		return obj
 	}
-	p := &types.Pod{
-		TypeMeta:        pod.TypeMeta,
-		ObjectMeta:      pod.ObjectMeta,
-		StatusPodIP:     pod.Status.PodIP,
-		StatusHostIP:    pod.Status.HostIP,
-		SpecHostNetwork: pod.Spec.HostNetwork,
-	}
-	*pod = v1.Pod{}
-	return p
 }
 
-// ConvertToNode converts a *v1.Node into a *types.Node.
+// ConvertToNode converts a *v1.Node into a
+// *types.Node or a cache.DeletedFinalStateUnknown into
+// a cache.DeletedFinalStateUnknown with a *types.Node in its Obj.
+// If the given obj can't be cast into either *v1.Node
+// nor cache.DeletedFinalStateUnknown, the original obj is returned.
 // WARNING calling this function will set *all* fields of the given Node as
 // empty.
 func ConvertToNode(obj interface{}) interface{} {
-	node, ok := obj.(*v1.Node)
-	if !ok {
-		return nil
+	switch concreteObj := obj.(type) {
+	case *v1.Node:
+		p := &types.Node{
+			TypeMeta:        concreteObj.TypeMeta,
+			ObjectMeta:      concreteObj.ObjectMeta,
+			StatusAddresses: concreteObj.Status.Addresses,
+			SpecPodCIDR:     concreteObj.Spec.PodCIDR,
+		}
+		*concreteObj = v1.Node{}
+		return p
+	case cache.DeletedFinalStateUnknown:
+		node, ok := concreteObj.Obj.(*v1.Node)
+		if !ok {
+			return obj
+		}
+		dfsu := cache.DeletedFinalStateUnknown{
+			Key: concreteObj.Key,
+			Obj: &types.Node{
+				TypeMeta:        node.TypeMeta,
+				ObjectMeta:      node.ObjectMeta,
+				StatusAddresses: node.Status.Addresses,
+				SpecPodCIDR:     node.Spec.PodCIDR,
+			},
+		}
+		*node = v1.Node{}
+		return dfsu
+	default:
+		return obj
 	}
-	n := &types.Node{
-		TypeMeta:        node.TypeMeta,
-		ObjectMeta:      node.ObjectMeta,
-		StatusAddresses: node.Status.Addresses,
-		SpecPodCIDR:     node.Spec.PodCIDR,
-	}
-	*node = v1.Node{}
-	return n
 }
 
-// ConvertToNamespace converts a *v1.Namespace into a *types.Namespace.
+// ConvertToNamespace converts a *v1.Namespace into a
+// *types.Namespace or a cache.DeletedFinalStateUnknown into
+// a cache.DeletedFinalStateUnknown with a *types.Namespace in its Obj.
+// If the given obj can't be cast into either *v1.Namespace
+// nor cache.DeletedFinalStateUnknown, the original obj is returned.
 // WARNING calling this function will set *all* fields of the given Namespace as
 // empty.
 func ConvertToNamespace(obj interface{}) interface{} {
-	namespace, ok := obj.(*v1.Namespace)
-	if !ok {
-		return nil
+	switch concreteObj := obj.(type) {
+	case *v1.Namespace:
+		p := &types.Namespace{
+			TypeMeta:   concreteObj.TypeMeta,
+			ObjectMeta: concreteObj.ObjectMeta,
+		}
+		*concreteObj = v1.Namespace{}
+		return p
+	case cache.DeletedFinalStateUnknown:
+		namespace, ok := concreteObj.Obj.(*v1.Namespace)
+		if !ok {
+			return obj
+		}
+		dfsu := cache.DeletedFinalStateUnknown{
+			Key: concreteObj.Key,
+			Obj: &types.Namespace{
+				TypeMeta:   namespace.TypeMeta,
+				ObjectMeta: namespace.ObjectMeta,
+			},
+		}
+		*namespace = v1.Namespace{}
+		return dfsu
+	default:
+		return obj
 	}
-	n := &types.Namespace{
-		TypeMeta:   namespace.TypeMeta,
-		ObjectMeta: namespace.ObjectMeta,
-	}
-	*namespace = v1.Namespace{}
-	return n
 }

--- a/pkg/k8s/factory_functions_test.go
+++ b/pkg/k8s/factory_functions_test.go
@@ -18,16 +18,20 @@ package k8s
 
 import (
 	"github.com/cilium/cilium/pkg/annotation"
-	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/checker"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/types"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy/api"
 
 	. "gopkg.in/check.v1"
+	"k8s.io/api/core/v1"
 	core_v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/tools/cache"
 )
 
 func (s *K8sSuite) Test_EqualV2CNP(c *C) {
@@ -854,5 +858,533 @@ func (s *K8sSuite) Test_EqualV1Service(c *C) {
 	for _, tt := range tests {
 		got := EqualV1Services(tt.args.o1, tt.args.o2)
 		c.Assert(got, Equals, tt.want, Commentf("Test Name: %s", tt.name))
+	}
+}
+
+func (s *K8sSuite) Test_ConvertToNetworkPolicy(c *C) {
+	type args struct {
+		obj interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want interface{}
+	}{
+		{
+			name: "normal conversion",
+			args: args{
+				obj: &networkingv1.NetworkPolicy{},
+			},
+			want: &types.NetworkPolicy{
+				NetworkPolicy: &networkingv1.NetworkPolicy{},
+			},
+		},
+		{
+			name: "delete final state unknown conversion",
+			args: args{
+				obj: cache.DeletedFinalStateUnknown{
+					Key: "foo",
+					Obj: &networkingv1.NetworkPolicy{},
+				},
+			},
+			want: cache.DeletedFinalStateUnknown{
+				Key: "foo",
+				Obj: &types.NetworkPolicy{
+					NetworkPolicy: &networkingv1.NetworkPolicy{},
+				},
+			},
+		},
+		{
+			name: "unknown object type in delete final state unknown conversion",
+			args: args{
+				obj: cache.DeletedFinalStateUnknown{
+					Key: "foo",
+					Obj: 100,
+				},
+			},
+			want: cache.DeletedFinalStateUnknown{
+				Key: "foo",
+				Obj: 100,
+			},
+		},
+		{
+			name: "unknown object type in conversion",
+			args: args{
+				obj: 100,
+			},
+			want: 100,
+		},
+	}
+	for _, tt := range tests {
+		got := ConvertToNetworkPolicy(tt.args.obj)
+		c.Assert(got, checker.DeepEquals, tt.want, Commentf("Test Name: %s", tt.name))
+	}
+}
+
+func (s *K8sSuite) Test_ConvertToK8sService(c *C) {
+	type args struct {
+		obj interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want interface{}
+	}{
+		{
+			name: "normal conversion",
+			args: args{
+				obj: &v1.Service{},
+			},
+			want: &types.Service{
+				Service: &v1.Service{},
+			},
+		},
+		{
+			name: "delete final state unknown conversion",
+			args: args{
+				obj: cache.DeletedFinalStateUnknown{
+					Key: "foo",
+					Obj: &v1.Service{},
+				},
+			},
+			want: cache.DeletedFinalStateUnknown{
+				Key: "foo",
+				Obj: &types.Service{
+					Service: &v1.Service{},
+				},
+			},
+		},
+		{
+			name: "unknown object type in delete final state unknown conversion",
+			args: args{
+				obj: cache.DeletedFinalStateUnknown{
+					Key: "foo",
+					Obj: 100,
+				},
+			},
+			want: cache.DeletedFinalStateUnknown{
+				Key: "foo",
+				Obj: 100,
+			},
+		},
+		{
+			name: "unknown object type in conversion",
+			args: args{
+				obj: 100,
+			},
+			want: 100,
+		},
+	}
+	for _, tt := range tests {
+		got := ConvertToK8sService(tt.args.obj)
+		c.Assert(got, checker.DeepEquals, tt.want, Commentf("Test Name: %s", tt.name))
+	}
+}
+
+func (s *K8sSuite) Test_ConvertToK8sEndpoints(c *C) {
+	type args struct {
+		obj interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want interface{}
+	}{
+		{
+			name: "normal conversion",
+			args: args{
+				obj: &v1.Endpoints{},
+			},
+			want: &types.Endpoints{
+				Endpoints: &v1.Endpoints{},
+			},
+		},
+		{
+			name: "delete final state unknown conversion",
+			args: args{
+				obj: cache.DeletedFinalStateUnknown{
+					Key: "foo",
+					Obj: &v1.Endpoints{},
+				},
+			},
+			want: cache.DeletedFinalStateUnknown{
+				Key: "foo",
+				Obj: &types.Endpoints{
+					Endpoints: &v1.Endpoints{},
+				},
+			},
+		},
+		{
+			name: "unknown object type in delete final state unknown conversion",
+			args: args{
+				obj: cache.DeletedFinalStateUnknown{
+					Key: "foo",
+					Obj: 100,
+				},
+			},
+			want: cache.DeletedFinalStateUnknown{
+				Key: "foo",
+				Obj: 100,
+			},
+		},
+		{
+			name: "unknown object type in conversion",
+			args: args{
+				obj: 100,
+			},
+			want: 100,
+		},
+	}
+	for _, tt := range tests {
+		got := ConvertToK8sEndpoints(tt.args.obj)
+		c.Assert(got, checker.DeepEquals, tt.want, Commentf("Test Name: %s", tt.name))
+	}
+}
+
+func (s *K8sSuite) Test_ConvertToIngress(c *C) {
+	type args struct {
+		obj interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want interface{}
+	}{
+		{
+			name: "normal conversion",
+			args: args{
+				obj: &v1beta1.Ingress{},
+			},
+			want: &types.Ingress{
+				Ingress: &v1beta1.Ingress{},
+			},
+		},
+		{
+			name: "delete final state unknown conversion",
+			args: args{
+				obj: cache.DeletedFinalStateUnknown{
+					Key: "foo",
+					Obj: &v1beta1.Ingress{},
+				},
+			},
+			want: cache.DeletedFinalStateUnknown{
+				Key: "foo",
+				Obj: &types.Ingress{
+					Ingress: &v1beta1.Ingress{},
+				},
+			},
+		},
+		{
+			name: "unknown object type in delete final state unknown conversion",
+			args: args{
+				obj: cache.DeletedFinalStateUnknown{
+					Key: "foo",
+					Obj: 100,
+				},
+			},
+			want: cache.DeletedFinalStateUnknown{
+				Key: "foo",
+				Obj: 100,
+			},
+		},
+		{
+			name: "unknown object type in conversion",
+			args: args{
+				obj: 100,
+			},
+			want: 100,
+		},
+	}
+	for _, tt := range tests {
+		got := ConvertToIngress(tt.args.obj)
+		c.Assert(got, checker.DeepEquals, tt.want, Commentf("Test Name: %s", tt.name))
+	}
+}
+
+func (s *K8sSuite) Test_ConvertToCNPWithStatus(c *C) {
+	type args struct {
+		obj interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want interface{}
+	}{
+		{
+			name: "normal conversion",
+			args: args{
+				obj: &v2.CiliumNetworkPolicy{},
+			},
+			want: &types.SlimCNP{
+				CiliumNetworkPolicy: &v2.CiliumNetworkPolicy{},
+			},
+		},
+		{
+			name: "delete final state unknown conversion",
+			args: args{
+				obj: cache.DeletedFinalStateUnknown{
+					Key: "foo",
+					Obj: &v2.CiliumNetworkPolicy{},
+				},
+			},
+			want: cache.DeletedFinalStateUnknown{
+				Key: "foo",
+				Obj: &types.SlimCNP{
+					CiliumNetworkPolicy: &v2.CiliumNetworkPolicy{},
+				},
+			},
+		},
+		{
+			name: "unknown object type in delete final state unknown conversion",
+			args: args{
+				obj: cache.DeletedFinalStateUnknown{
+					Key: "foo",
+					Obj: 100,
+				},
+			},
+			want: cache.DeletedFinalStateUnknown{
+				Key: "foo",
+				Obj: 100,
+			},
+		},
+		{
+			name: "unknown object type in conversion",
+			args: args{
+				obj: 100,
+			},
+			want: 100,
+		},
+	}
+	for _, tt := range tests {
+		got := ConvertToCNPWithStatus(tt.args.obj)
+		c.Assert(got, checker.DeepEquals, tt.want, Commentf("Test Name: %s", tt.name))
+	}
+}
+
+func (s *K8sSuite) Test_ConvertToCNP(c *C) {
+	type args struct {
+		obj interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want interface{}
+	}{
+		{
+			name: "normal conversion",
+			args: args{
+				obj: &v2.CiliumNetworkPolicy{},
+			},
+			want: &types.SlimCNP{
+				CiliumNetworkPolicy: &v2.CiliumNetworkPolicy{},
+			},
+		},
+		{
+			name: "delete final state unknown conversion",
+			args: args{
+				obj: cache.DeletedFinalStateUnknown{
+					Key: "foo",
+					Obj: &v2.CiliumNetworkPolicy{},
+				},
+			},
+			want: cache.DeletedFinalStateUnknown{
+				Key: "foo",
+				Obj: &types.SlimCNP{
+					CiliumNetworkPolicy: &v2.CiliumNetworkPolicy{},
+				},
+			},
+		},
+		{
+			name: "unknown object type in delete final state unknown conversion",
+			args: args{
+				obj: cache.DeletedFinalStateUnknown{
+					Key: "foo",
+					Obj: 100,
+				},
+			},
+			want: cache.DeletedFinalStateUnknown{
+				Key: "foo",
+				Obj: 100,
+			},
+		},
+		{
+			name: "unknown object type in conversion",
+			args: args{
+				obj: 100,
+			},
+			want: 100,
+		},
+	}
+	for _, tt := range tests {
+		got := ConvertToCNP(tt.args.obj)
+		c.Assert(got, checker.DeepEquals, tt.want, Commentf("Test Name: %s", tt.name))
+	}
+}
+
+func (s *K8sSuite) Test_ConvertToK8sPod(c *C) {
+	type args struct {
+		obj interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want interface{}
+	}{
+		{
+			name: "normal conversion",
+			args: args{
+				obj: &v1.Pod{},
+			},
+			want: &types.Pod{},
+		},
+		{
+			name: "delete final state unknown conversion",
+			args: args{
+				obj: cache.DeletedFinalStateUnknown{
+					Key: "foo",
+					Obj: &v1.Pod{},
+				},
+			},
+			want: cache.DeletedFinalStateUnknown{
+				Key: "foo",
+				Obj: &types.Pod{},
+			},
+		},
+		{
+			name: "unknown object type in delete final state unknown conversion",
+			args: args{
+				obj: cache.DeletedFinalStateUnknown{
+					Key: "foo",
+					Obj: 100,
+				},
+			},
+			want: cache.DeletedFinalStateUnknown{
+				Key: "foo",
+				Obj: 100,
+			},
+		},
+		{
+			name: "unknown object type in conversion",
+			args: args{
+				obj: 100,
+			},
+			want: 100,
+		},
+	}
+	for _, tt := range tests {
+		got := ConvertToPod(tt.args.obj)
+		c.Assert(got, checker.DeepEquals, tt.want, Commentf("Test Name: %s", tt.name))
+	}
+}
+
+func (s *K8sSuite) Test_ConvertToNode(c *C) {
+	type args struct {
+		obj interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want interface{}
+	}{
+		{
+			name: "normal conversion",
+			args: args{
+				obj: &v1.Node{},
+			},
+			want: &types.Node{},
+		},
+		{
+			name: "delete final state unknown conversion",
+			args: args{
+				obj: cache.DeletedFinalStateUnknown{
+					Key: "foo",
+					Obj: &v1.Node{},
+				},
+			},
+			want: cache.DeletedFinalStateUnknown{
+				Key: "foo",
+				Obj: &types.Node{},
+			},
+		},
+		{
+			name: "unknown object type in delete final state unknown conversion",
+			args: args{
+				obj: cache.DeletedFinalStateUnknown{
+					Key: "foo",
+					Obj: 100,
+				},
+			},
+			want: cache.DeletedFinalStateUnknown{
+				Key: "foo",
+				Obj: 100,
+			},
+		},
+		{
+			name: "unknown object type in conversion",
+			args: args{
+				obj: 100,
+			},
+			want: 100,
+		},
+	}
+	for _, tt := range tests {
+		got := ConvertToNode(tt.args.obj)
+		c.Assert(got, checker.DeepEquals, tt.want, Commentf("Test Name: %s", tt.name))
+	}
+}
+
+func (s *K8sSuite) Test_ConvertToNamespace(c *C) {
+	type args struct {
+		obj interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want interface{}
+	}{
+		{
+			name: "normal conversion",
+			args: args{
+				obj: &v1.Namespace{},
+			},
+			want: &types.Namespace{},
+		},
+		{
+			name: "delete final state unknown conversion",
+			args: args{
+				obj: cache.DeletedFinalStateUnknown{
+					Key: "foo",
+					Obj: &v1.Namespace{},
+				},
+			},
+			want: cache.DeletedFinalStateUnknown{
+				Key: "foo",
+				Obj: &types.Namespace{},
+			},
+		},
+		{
+			name: "unknown object type in delete final state unknown conversion",
+			args: args{
+				obj: cache.DeletedFinalStateUnknown{
+					Key: "foo",
+					Obj: 100,
+				},
+			},
+			want: cache.DeletedFinalStateUnknown{
+				Key: "foo",
+				Obj: 100,
+			},
+		},
+		{
+			name: "unknown object type in conversion",
+			args: args{
+				obj: 100,
+			},
+			want: 100,
+		},
+	}
+	for _, tt := range tests {
+		got := ConvertToNamespace(tt.args.obj)
+		c.Assert(got, checker.DeepEquals, tt.want, Commentf("Test Name: %s", tt.name))
 	}
 }


### PR DESCRIPTION
 * PR: 8460 -- pkg/k8s: add conversion for DeleteFinalStateUnknown objects (@aanm) -- https://github.com/cilium/cilium/pull/8460
 * PR: 8487 -- daemon: Do not remove revNAT if removing svc fails (@brb) -- https://github.com/cilium/cilium/pull/8487
 * PR: 8486 -- daemon: Remove svc-v2 maps when restore is disabled (@brb) -- https://github.com/cilium/cilium/pull/8486
 * PR: 8477 -- [CI] retry vm provisioning, increase timeout (@nebril) -- https://github.com/cilium/cilium/pull/8477
 * PR: 8494 -- lbmap: Get rid of bpfService cache lock (@brb) -- https://github.com/cilium/cilium/pull/8494

```
$ for pr in 8460 8487 8486 8477 8494; do contrib/backporting/set-labels.py $pr pending 1.5; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8512)
<!-- Reviewable:end -->
