### PR TITLE
datapath: Do not fail if route contains gw equal to dst

### DIFF
--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -161,7 +161,7 @@ func createDirectRouteSpec(CIDR *cidr.CIDR, nodeIP net.IP) (routeSpec *netlink.R
 		return
 	}
 
-	if routes[0].Gw != nil && !routes[0].Gw.IsUnspecified() {
+	if routes[0].Gw != nil && !routes[0].Gw.IsUnspecified() && !routes[0].Gw.Equal(nodeIP) {
 		err = fmt.Errorf("route to destination %s contains gateway %s, must be directly reachable",
 			nodeIP, routes[0].Gw.String())
 		return


### PR DESCRIPTION
Some recent change in the kernel started to include `RTA_GATEWAY` field in a response to `RTM_GETROUTE` even if a dst was local.

On Linux 5.1.6:
```
recvmsg(3, {msg_name={sa_family=AF_NETLINK, nl_pid=0, nl_groups=00000000}, msg_namelen=12, msg_iov=[{iov_base={{len=104, type=RTM_NEWROUTE, flags=0, seq=1562755119, pid=29233}, {rtm_family=AF_INET, rtm_dst_len=32, rtm_src_len=0, rtm_tos=0, rtm_table=RT_TABLE_LOCAL, rtm_protocol=RTPROT_UNSPEC, rtm_scope=RT_SCOPE_UNIVERSE, rtm_type=RTN_LOCAL, rtm_flags=RTM_F_CLONED|0x80000000}, [{{nla_len=8, nla_type=RTA_TABLE}, RT_TABLE_LOCAL}, {{nla_len=8, nla_type=RTA_DST}, inet_addr("4.4.4.4")}, {{nla_len=8, nla_type=RTA_OIF}, if_nametoindex("lo")}, {{nla_len=8, nla_type=RTA_PREFSRC}, inet_addr("4.4.4.4")}, {{nla_len=8, nla_type=RTA_UID}, 0}, {{nla_len=36, nla_type=RTA_CACHEINFO}, {rta_clntref=1, rta_lastuse=0, rta_expires=0, rta_error=0, rta_used=0, rta_id=0, rta_ts=0, rta_tsage=0}}]}, iov_len=104}], msg_iovlen=1, msg_controllen=0, msg_flags=0}, 0) = 104
```
On Linux 5.2.0-rc5:
```
recvmsg(3, {msg_name={sa_family=AF_NETLINK, nl_pid=0, nl_groups=00000000}, msg_namelen=12, msg_iov=[{iov_base={{len=112, type=RTM_NEWROUTE, flags=0, seq=1562754944, pid=4275}, {rtm_family=AF_INET, rtm_dst_len=32, rtm_src_len=0, rtm_tos=0, rtm_table=RT_TABLE_LOCAL, rtm_protocol=RTPROT_UNSPEC, rtm_scope=RT_SCOPE_UNIVERSE, rtm_type=RTN_LOCAL, rtm_flags=RTM_F_CLONED|0x80000000}, [{{nla_len=8, nla_type=RTA_TABLE}, RT_TABLE_LOCAL}, {{nla_len=8, nla_type=RTA_DST}, 4.4.4.4}, {{nla_len=8, nla_type=RTA_OIF}, if_nametoindex("lo")}, {{nla_len=8, nla_type=RTA_PREFSRC}, 4.4.4.4}, {{nla_len=8, nla_type=RTA_GATEWAY}, 4.4.4.4}, {{nla_len=8, nla_type=RTA_UID}, 0}, {{nla_len=36, nla_type=RTA_CACHEINFO}, {rta_clntref=1, rta_lastuse=0, rta_expires=0, rta_error=0, rta_used=0, rta_id=0, rta_ts=0, rta_tsage=0}}]}, iov_len=112}], msg_iovlen=1, msg_controllen=0, msg_flags=0}, 0) = 112
```
This commit extends the check for route to a non-directly reachable gateway by making the check to pass if a gateway IP addr is equal to a given dst IP address.

Should fix the `RuntimePrivilegedUnitTests` failure observed when running on `ubuntu-next`:
```
 level=warning msg="Unable to install direct node route {Ifindex: 0 Dst: 5.5.5.0/24 Src: <nil> Gw: 4.4.4.4 Flags: [] Table: 0}" error="route to destination 4.4.4.4 contains gateway 4.4.4.4, must be directly reachable" subsys=linux-datapath
	 node_linux_test.go:668:
	     c.Assert(err, check.IsNil)
	 ... value *errors.errorString = &errors.errorString{s:"route to destination 4.4.4.4 contains gateway 4.4.4.4, must be directly reachable"} ("route to destination 4.4.4.4 contains gateway 4.4.4.4, must be directly reachable")
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8513)
<!-- Reviewable:end -->
