### PR TITLE
endpoint: Correctly check whether pod name is available

### DIFF
--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -227,7 +227,7 @@ func (d *Daemon) createEndpoint(ctx context.Context, epTemplate *models.Endpoint
 		}
 	}
 
-	if ep.GetK8sNamespaceAndPodNameLocked() != "" && k8s.IsEnabled() {
+	if ep.K8sNamespaceAndPodNameIsSet() && k8s.IsEnabled() {
 		identityLabels, info, err := fetchK8sLabels(ep)
 		if err != nil {
 			ep.Logger("api").WithError(err).Warning("Unable to fetch kubernetes labels")

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1404,6 +1404,14 @@ func (e *Endpoint) SetK8sNamespace(name string) {
 	e.Unlock()
 }
 
+// K8sNamespaceAndPodNameIsSet returns true if the pod name is set
+func (e *Endpoint) K8sNamespaceAndPodNameIsSet() bool {
+	e.UnconditionalLock()
+	podName := e.GetK8sNamespaceAndPodNameLocked()
+	e.Unlock()
+	return podName != "" && podName != "/"
+}
+
 // GetK8sPodName returns the name of the pod if the endpoint represents a
 // Kubernetes pod
 func (e *Endpoint) GetK8sPodName() string {

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -469,3 +469,11 @@ func TestEndpoint_GetK8sPodLabels(t *testing.T) {
 		})
 	}
 }
+
+func (s *EndpointSuite) TestK8sPodNameIsSet(c *C) {
+	e := Endpoint{}
+	c.Assert(e.K8sNamespaceAndPodNameIsSet(), Equals, false)
+	e.K8sPodName = "foo"
+	e.K8sNamespace = "default"
+	c.Assert(e.K8sNamespaceAndPodNameIsSet(), Equals, true)
+}


### PR DESCRIPTION
GetK8sNamespaceAndPodNameLocked() returns "/" and not "" when the pod name is
not available.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8514)
<!-- Reviewable:end -->
