### PR TITLE
test: bump CNI version to 0.7.5 for K8s 1.12

### DIFF
--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -138,7 +138,7 @@ case $K8S_VERSION in
         sudo ln -sf $COREDNS_DEPLOYMENT $DNS_DEPLOYMENT
         ;;
     "1.12")
-        KUBERNETES_CNI_VERSION="0.6.0"
+        KUBERNETES_CNI_VERSION="0.7.5"
         K8S_FULL_VERSION="1.12.1"
         KUBEADM_OPTIONS="--ignore-preflight-errors=cri"
         KUBEADM_SLAVE_OPTIONS="--discovery-token-unsafe-skip-ca-verification --ignore-preflight-errors=cri"


### PR DESCRIPTION
The CI fails otherwise, with the following error:

```

20:22:58      k8s1-1.12: The following packages have unmet dependencies:
20:22:58      k8s1-1.12:  kubeadm : Depends: kubernetes-cni (>= 0.7.5) but 0.6.0-00 is to be installed
20:22:58      k8s1-1.12:  kubelet : Depends: kubernetes-cni (>= 0.7.5) but 0.6.0-00 is to be installed
20:22:58      k8s1-1.12: E: Unable to correct problems, you have held broken packages.
```

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8518)
<!-- Reviewable:end -->
