### PR TITLE
config: make policy trigger duration configurable

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -767,7 +767,7 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 	t, err := trigger.NewTrigger(trigger.Parameters{
 		Name:              "policy_update",
 		PrometheusMetrics: true,
-		MinInterval:       time.Second,
+		MinInterval:       option.Config.PolicyTriggerInterval,
 		TriggerFunc:       d.policyUpdateTrigger,
 	})
 	if err != nil {

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -794,6 +794,10 @@ func init() {
 	flags.String(option.WriteCNIConfigurationWhenReady, "", fmt.Sprintf("Write the CNI configuration as specified via --%s to path when agent is ready", option.ReadCNIConfiguration))
 	option.BindEnv(option.WriteCNIConfigurationWhenReady)
 
+	flags.Duration(option.PolicyTriggerInterval, defaults.PolicyTriggerInterval, "Time between triggers of policy updates (regenerations for all endpoints)")
+	flags.MarkHidden(option.PolicyTriggerInterval)
+	option.BindEnv(option.PolicyTriggerInterval)
+
 	viper.BindPFlags(flags)
 }
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -267,4 +267,8 @@ const (
 	// AutoCreateCiliumNodeResource enables automatic creation of a
 	// CiliumNode resource for the local node
 	AutoCreateCiliumNodeResource = false
+
+	// PolicyTriggerInterval is default amount of time between triggers of
+	// policy updates are invoked.
+	PolicyTriggerInterval = 1 * time.Second
 )

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -542,6 +542,10 @@ const (
 
 	// DeprecatedEnableLegacyServices enables the legacy services
 	DeprecatedEnableLegacyServices = "enable-legacy-services"
+
+	// PolicyTriggerInterval is the amount of time between triggers of policy
+	// updates are invoked.
+	PolicyTriggerInterval = "policy-trigger-interval"
 )
 
 // FQDNS variables
@@ -1099,6 +1103,10 @@ type DaemonConfig struct {
 	// EgressMasqueradeInterfaces is the selector used to select interfaces
 	// subject to egress masquerading
 	EgressMasqueradeInterfaces string
+
+	// PolicyTriggerInterval is the amount of time between when policy updates
+	// are triggered.
+	PolicyTriggerInterval time.Duration
 }
 
 var (
@@ -1502,6 +1510,7 @@ func (c *DaemonConfig) Populate() {
 	c.Version = viper.GetString(Version)
 	c.Workloads = viper.GetStringSlice(ContainerRuntime)
 	c.WriteCNIConfigurationWhenReady = viper.GetString(WriteCNIConfigurationWhenReady)
+	c.PolicyTriggerInterval = viper.GetDuration(PolicyTriggerInterval)
 
 	if nativeCIDR := viper.GetString(IPv4NativeRoutingCIDR); nativeCIDR != "" {
 		c.ipv4NativeRoutingCIDR = cidr.MustParseCIDR(nativeCIDR)


### PR DESCRIPTION
Maintain the default to be one second. Make this option configurable for testing
purposes when testing strain on regenerations of endpoints.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8519)
<!-- Reviewable:end -->
