### PR TITLE
Add k8s client qps and burst as cli flags for the operator

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -779,7 +779,7 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 	debug.RegisterStatusObject("ipam", d.ipam)
 
 	bootstrapStats.k8sInit.Start()
-	k8s.Configure(option.Config.K8sAPIServer, option.Config.K8sKubeConfigPath)
+	k8s.Configure(option.Config.K8sAPIServer, option.Config.K8sKubeConfigPath, defaults.K8sClientQPSLimit, defaults.K8sClientBurst)
 	bootstrapStats.k8sInit.End(true)
 	d.runK8sServiceHandler()
 	policyApi.InitEntities(option.Config.ClusterName)

--- a/operator/main.go
+++ b/operator/main.go
@@ -126,6 +126,9 @@ func init() {
 	flags.Int(option.AWSClientBurst, 4, "Burst value allowed for the AWS client used by the AWS ENI IPAM")
 	flags.Float64(option.AWSClientQPSLimit, 20.0, "Queries per second limit for the AWS client used by the AWS ENI IPAM")
 
+	flags.Float32(option.K8sClientQPSLimit, defaults.K8sClientQPSLimit, "Queries per second limit for the K8s client")
+	flags.Int(option.K8sClientBurst, defaults.K8sClientBurst, "Burst value allowed for the K8s client")
+
 	// We need to obtain from Cilium ConfigMap if the CiliumEndpointCRD option
 	// is enabled or disabled. This option is marked as hidden because the
 	// Cilium Endpoint CRD controller is not in this program and by having it
@@ -185,7 +188,10 @@ func runOperator(cmd *cobra.Command) {
 		registerMetrics()
 	}
 
-	k8s.Configure(k8sAPIServer, k8sKubeConfigPath)
+	k8sClientQPSLimit := viper.GetFloat64(option.K8sClientQPSLimit)
+	k8sClientBurst := viper.GetInt(option.K8sClientBurst)
+
+	k8s.Configure(k8sAPIServer, k8sKubeConfigPath, float32(k8sClientQPSLimit), k8sClientBurst)
 	if err := k8s.Init(); err != nil {
 		log.WithError(err).Fatal("Unable to connect to Kubernetes apiserver")
 	}

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -271,4 +271,12 @@ const (
 	// PolicyTriggerInterval is default amount of time between triggers of
 	// policy updates are invoked.
 	PolicyTriggerInterval = 1 * time.Second
+
+	// K8sClientQPSLimit is is the default qps for the k8s client. It is set to 0 because the the k8s client
+	// has its own default.
+	K8sClientQPSLimit float32 = 0.0
+
+	// K8sClientBurst is is the default burst for the k8s client. It is set to 0 because the the k8s client
+	// has its own default.
+	K8sClientBurst = 0
 )

--- a/pkg/k8s/cnp_test.go
+++ b/pkg/k8s/cnp_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/pkg/checker"
+	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	clientset "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned"
 	"github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/fake"
@@ -60,9 +61,9 @@ func (k *K8sIntegrationSuite) SetUpSuite(c *C) {
 	}
 	if os.Getenv("INTEGRATION") != "" {
 		if k8sConfigPath := os.Getenv("KUBECONFIG"); k8sConfigPath == "" {
-			Configure("", "/var/lib/cilium/cilium.kubeconfig")
+			Configure("", "/var/lib/cilium/cilium.kubeconfig", defaults.K8sClientQPSLimit, defaults.K8sClientBurst)
 		} else {
-			Configure("", k8sConfigPath)
+			Configure("", k8sConfigPath, defaults.K8sClientQPSLimit, defaults.K8sClientBurst)
 		}
 		restConfig, err := CreateConfig()
 		c.Assert(err, IsNil)

--- a/pkg/k8s/config.go
+++ b/pkg/k8s/config.go
@@ -32,6 +32,12 @@ type configuration struct {
 	// KubeconfigPath is the local path to the kubeconfig configuration
 	// file on the filesystem
 	KubeconfigPath string
+
+	// QPS is the QPS to pass to the kubernetes client configuration.
+	QPS float32
+
+	// Burst is the burst to pass to the kubernetes client configuration.
+	Burst int
 }
 
 // GetAPIServer returns the configured API server address
@@ -45,10 +51,22 @@ func GetKubeconfigPath() string {
 	return config.KubeconfigPath
 }
 
+// GetQPS gets the QPS of the K8s configuration.
+func GetQPS() float32 {
+	return config.QPS
+}
+
+// GetBurst gets the burst limit of the K8s configuration.
+func GetBurst() int {
+	return config.Burst
+}
+
 // Configure sets the parameters of the Kubernetes package
-func Configure(apiServer, kubeconfigPath string) {
+func Configure(apiServer, kubeconfigPath string, qps float32, burst int) {
 	config.APIServer = apiServer
 	config.KubeconfigPath = kubeconfigPath
+	config.QPS = qps
+	config.Burst = burst
 
 	if IsEnabled() &&
 		config.APIServer != "" &&

--- a/pkg/k8s/informer/informer_test.go
+++ b/pkg/k8s/informer/informer_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/k8s"
 
+	"github.com/cilium/cilium/pkg/defaults"
 	. "gopkg.in/check.v1"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,9 +47,9 @@ var _ = Suite(&K8sIntegrationSuite{})
 func (k *K8sIntegrationSuite) SetUpSuite(c *C) {
 	if os.Getenv("INTEGRATION") != "" {
 		if k8sConfigPath := os.Getenv("KUBECONFIG"); k8sConfigPath == "" {
-			k8s.Configure("", "/var/lib/cilium/cilium.kubeconfig")
+			k8s.Configure("", "/var/lib/cilium/cilium.kubeconfig", defaults.K8sClientQPSLimit, defaults.K8sClientBurst)
 		} else {
-			k8s.Configure("", k8sConfigPath)
+			k8s.Configure("", k8sConfigPath, defaults.K8sClientQPSLimit, defaults.K8sClientBurst)
 		}
 	}
 }

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -529,6 +529,12 @@ const (
 	// AWSClientBurst is the burst value allowed for the AWS client used by the AWS ENI IPAM
 	AWSClientBurst = "aws-client-burst"
 
+	// K8sClientQPSLimit is the queries per second limit for the K8s client. Defaults to k8s client defaults.
+	K8sClientQPSLimit = "k8s-client-qps"
+
+	// K8sClientBurst is the burst value allowed for the K8s client. Defaults to k8s client defaults.
+	K8sClientBurst = "k8s-client-burst"
+
 	// AutoCreateCiliumNodeResource enables automatic creation of a
 	// CiliumNode resource for the local node
 	AutoCreateCiliumNodeResource = "auto-create-cilium-node-resource"


### PR DESCRIPTION
Note that these are not configurable via the kubeconfig file

Flags values default to 0, which is the same behavior as before this
change.

Please ensure your pull request adheres to the following guidelines:

```release-note
Add k8s client qps and burst as cli flags for the operator
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8520)
<!-- Reviewable:end -->
