### PR TITLE
 cilium: fix incorrect removal of stale maps in node-port

### DIFF
--- a/daemon/datapath.go
+++ b/daemon/datapath.go
@@ -168,6 +168,8 @@ func (d *Daemon) compileBase() error {
 		args[initArgNodePort] = "true"
 	}
 
+	log.Info("Setting up base BPF datapath")
+
 	prog := filepath.Join(option.Config.BpfDir, "init.sh")
 	ctx, cancel := context.WithTimeout(context.Background(), defaults.ExecTimeout)
 	defer cancel()

--- a/pkg/datapath/maps/map.go
+++ b/pkg/datapath/maps/map.go
@@ -114,7 +114,8 @@ func (ms *mapSweeper) deleteMapIfStale(path string, filename string, endpointID 
 }
 
 func (ms *mapSweeper) checkStaleGlobalMap(path string, filename string) {
-	globalCTinUse := endpointmanager.HasGlobalCT()
+	globalCTinUse := endpointmanager.HasGlobalCT() || option.Config.EnableNodePort ||
+		!option.Config.InstallIptRules && option.Config.Masquerade
 
 	if !globalCTinUse && ctmap.NameIsGlobal(filename) {
 		ms.removeMapPath(path)


### PR DESCRIPTION
See second commit message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8527)
<!-- Reviewable:end -->
