### PR TITLE
Fix bpf map handling of zero keys

### DIFF
--- a/pkg/bpf/bpf_linux.go
+++ b/pkg/bpf/bpf_linux.go
@@ -243,6 +243,17 @@ func GetNextKey(fd int, key, nextKey unsafe.Pointer) error {
 	return GetNextKeyFromPointers(fd, uintptr(unsafe.Pointer(&uba)), unsafe.Sizeof(uba))
 }
 
+// GetFirstKey fetches the first key in the map.
+func GetFirstKey(fd int, nextKey unsafe.Pointer) error {
+	uba := bpfAttrMapOpElem{
+		mapFd: uint32(fd),
+		key:   0, // NULL -> Get first element
+		value: uint64(uintptr(nextKey)),
+	}
+
+	return GetNextKeyFromPointers(fd, uintptr(unsafe.Pointer(&uba)), unsafe.Sizeof(uba))
+}
+
 // This struct must be in sync with union bpf_attr's anonymous struct used by
 // BPF_OBJ_*_ commands
 type bpfAttrObjOp struct {

--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -870,7 +870,6 @@ func (m *Map) DeleteAll() error {
 	scopedLog := m.scopedLogger()
 	scopedLog.Debug("deleting all entries in map")
 
-	key := make([]byte, m.KeySize)
 	nextKey := make([]byte, m.KeySize)
 
 	if m.cache != nil {
@@ -890,17 +889,11 @@ func (m *Map) DeleteAll() error {
 	mv := m.MapValue.DeepCopyMapValue()
 
 	for {
-		err := GetNextKey(
-			m.fd,
-			unsafe.Pointer(&key[0]),
-			unsafe.Pointer(&nextKey[0]),
-		)
-
-		if err != nil {
+		if err := GetFirstKey(m.fd, unsafe.Pointer(&nextKey[0])); err != nil {
 			break
 		}
 
-		err = DeleteElement(m.fd, unsafe.Pointer(&nextKey[0]))
+		err := DeleteElement(m.fd, unsafe.Pointer(&nextKey[0]))
 
 		mk, _, err2 := m.dumpParser(nextKey, []byte{}, mk, mv)
 		if err2 == nil {
@@ -912,8 +905,6 @@ func (m *Map) DeleteAll() error {
 		if err != nil {
 			return err
 		}
-
-		copy(key, nextKey)
 	}
 
 	return nil

--- a/pkg/bpf/map_linux_test.go
+++ b/pkg/bpf/map_linux_test.go
@@ -384,6 +384,41 @@ func (s *BPFPrivilegedTestSuite) TestDump(c *C) {
 	})
 }
 
+func (s *BPFPrivilegedTestSuite) TestDeleteAll(c *C) {
+	key1 := &TestKey{Key: 105}
+	value1 := &TestValue{Value: 205}
+	key2 := &TestKey{Key: 106}
+	value2 := &TestValue{Value: 206}
+
+	err := testMap.Update(key1, value1)
+	c.Assert(err, IsNil)
+	err = testMap.Update(key2, value1)
+	c.Assert(err, IsNil)
+	err = testMap.Update(key2, value2)
+	c.Assert(err, IsNil)
+
+	keyZero := &TestKey{Key: 0}
+	valueZero := &TestValue{Value: 0}
+	err = testMap.Update(keyZero, valueZero)
+	c.Assert(err, IsNil)
+
+	dump1 := map[string][]string{}
+	err = testMap.Dump(dump1)
+	c.Assert(err, IsNil)
+	c.Assert(dump1, checker.DeepEquals, map[string][]string{
+		"key=0":   {"value=0"},
+		"key=105": {"value=205"},
+		"key=106": {"value=206"},
+	})
+
+	err = testMap.DeleteAll()
+	c.Assert(err, IsNil)
+
+	dump2 := map[string][]string{}
+	err = testMap.Dump(dump2)
+	c.Assert(err, IsNil)
+}
+
 func (s *BPFPrivilegedTestSuite) TestGetModel(c *C) {
 	model := testMap.GetModel()
 	c.Assert(model, Not(IsNil))

--- a/pkg/maps/policymap/policymap_privileged_test.go
+++ b/pkg/maps/policymap/policymap_privileged_test.go
@@ -1,0 +1,94 @@
+// Copyright 2018-2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build privileged_tests
+
+package policymap
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/checker"
+
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type PolicyMapTestSuite struct{}
+
+var (
+	_ = Suite(&PolicyMapTestSuite{})
+
+	testMap = newMap("cilium_policy_test")
+)
+
+func runTests(m *testing.M) (int, error) {
+	bpf.CheckOrMountFS("")
+	if err := bpf.ConfigureResourceLimits(); err != nil {
+		return 1, fmt.Errorf("Failed to configure rlimit")
+	}
+
+	_ = os.RemoveAll(bpf.MapPath("cilium_policy_test"))
+	_, err := testMap.OpenOrCreate()
+	if err != nil {
+		return 1, fmt.Errorf("Failed to create map")
+	}
+	defer func() {
+		path, _ := testMap.Path()
+		os.Remove(path)
+	}()
+	defer testMap.Close()
+
+	return m.Run(), nil
+}
+
+func TestMain(m *testing.M) {
+	exitCode, err := runTests(m)
+	if err != nil {
+		log.Fatal(err)
+	}
+	os.Exit(exitCode)
+}
+
+func (pm *PolicyMapTestSuite) TestPolicyMapDumpToSlice(c *C) {
+	c.Assert(testMap, NotNil)
+
+	fooEntry := newKey(1, 1, 1, 1)
+	err := testMap.AllowKey(fooEntry, 0)
+	c.Assert(err, IsNil)
+
+	dump, err := testMap.DumpToSlice()
+	c.Assert(err, IsNil)
+	c.Assert(len(dump), Equals, 1)
+
+	// FIXME: It's weird that AllowKey() does the implicit byteorder
+	//        conversion above. But not really a bug, so work around it.
+	fooEntry = fooEntry.ToNetwork()
+	c.Assert(dump[0].Key, checker.DeepEquals, fooEntry)
+
+	// Special case: allow-all entry
+	barEntry := newKey(0, 0, 0, 0)
+	err = testMap.AllowKey(barEntry, 0)
+	c.Assert(err, IsNil)
+
+	dump, err = testMap.DumpToSlice()
+	c.Assert(err, IsNil)
+	c.Assert(len(dump), Equals, 2)
+}


### PR DESCRIPTION
This PR fixes two bugs in map handling logic if there was an element whose key consists of all zeroes:
* When dumping, only an arbitrary subset of the map would be dumped back.
* When issuing a `DeleteAll()`, only an arbitrary subset of elements in the map would be deleted.

Furthermore, add unit tests to catch these issues.

For backport, we may want to consider avoiding the test backports just because they may depend on functionality not available on older kernels. In particular, the last commit relies on refactoring performed during v1.6 cycle.

These fixes are important for v1.6 because v1.6 begins to write policymap entries with all-zero keys; I'm not sure whether we create such keys for any other maps and hence I don't know for sure how important this is to backport to older versions. Given some of the changes that have happened to the dump functionality over the past couple of releases, these may or may not backport cleanly.

Fixes: #8507

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8535)
<!-- Reviewable:end -->
