### PR TITLE
cilium: encrypt, fix encrypt-node delete and add CI test

### DIFF
--- a/pkg/datapath/linux/route/route_linux.go
+++ b/pkg/datapath/linux/route/route_linux.go
@@ -42,6 +42,9 @@ const (
 
 	// MainTable is Linux's default routing table
 	MainTable = 254
+
+	// Route protocol for Encryption specific routes
+	EncryptRouteProtocol = 192
 )
 
 // getNetlinkRoute returns the route configuration as netlink.Route

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -180,6 +180,16 @@ var _ = Describe("K8sDatapathConfig", func() {
 		})
 	})
 
+	Context("Transparent encryption with encrypt-node DirectRouting", func() {
+		It("Check connectivity with automatic direct nodes routes", func() {
+			SkipIfFlannel()
+
+			deployCilium("cilium-ds-patch-auto-node-routes-node-ipsec.yaml")
+			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
+			cleanService()
+		})
+	})
+
 	Context("IPv4Only", func() {
 		It("Check connectivity with IPv6 disabled", func() {
 			deployCilium("cilium-ds-patch-ipv4-only.yaml")

--- a/test/k8sT/manifests/cilium-ds-patch-auto-node-routes-node-ipsec.yaml
+++ b/test/k8sT/manifests/cilium-ds-patch-auto-node-routes-node-ipsec.yaml
@@ -1,0 +1,37 @@
+---
+metadata:
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+      - image: k8s1:5000/cilium/cilium-dev:latest
+        imagePullPolicy: Always
+        name: cilium-agent
+        args:
+        - "--tunnel=disabled"
+        - "--auto-direct-node-routes"
+        - "--kvstore=etcd"
+        - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
+        - "--k8s-require-ipv4-pod-cidr"
+        - "--pprof=true"
+        - "--log-system-load"
+        - "--config-dir=/tmp/cilium/config-map"
+        - "--enable-ipsec"
+        - "--ipsec-key-file=/etc/ipsec/keys"
+        - "--encrypt-interface=enp0s8"
+        - "--encrypt-node"
+        volumeMounts:
+          - name: cilium-ipsec-secrets
+            mountPath: /etc/ipsec
+      volumes:
+      - name: cilium-ipsec-secrets
+        secret:
+          secretName: cilium-ipsec-keys
+      - name: etcd-secrets
+        secret:
+          secretName: cilium-etcd-client-tls
+      dnsPolicy: ClusterFirstWithHostNet
+      initContainers:
+        - image: k8s1:5000/cilium/cilium-dev:latest
+          name: clean-cilium-state


### PR DESCRIPTION
Cilium encrypt-node object must delete old routes when disabled otherwise we have broken routes in the system that routes all node traffic to cilium_host. Also add a test to CI to catch this case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8536)
<!-- Reviewable:end -->
