### PR TITLE
endpoint: Fix handling of proxy statistics.

### DIFF
--- a/daemon/fqdn.go
+++ b/daemon/fqdn.go
@@ -407,7 +407,7 @@ func (d *Daemon) notifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epI
 		log.WithError(err).Error("cannot extract DNS message details")
 	}
 
-	ep.UpdateProxyStatistics("dns", uint16(serverPort), false, !msg.Response, verdict)
+	ep.UpdateProxyStatistics(strings.ToUpper(protocol), uint16(serverPort), false, !msg.Response, verdict)
 	record := logger.NewLogRecord(proxy.DefaultEndpointInfoRegistry, ep, flowType, false,
 		func(lr *logger.LogRecord) { lr.LogRecord.TransportProtocol = accesslog.TransportProtocol(protoID) },
 		logger.LogTags.Verdict(verdict, reason),

--- a/pkg/endpoint/regeneration/owner.go
+++ b/pkg/endpoint/regeneration/owner.go
@@ -101,5 +101,5 @@ type EndpointUpdater interface {
 
 	// UpdateProxyStatistics updates the Endpoint's proxy statistics to account
 	// for a new observed flow with the given characteristics.
-	UpdateProxyStatistics(l7Protocol string, port uint16, ingress, request bool, verdict accesslog.FlowVerdict)
+	UpdateProxyStatistics(l4Protocol string, port uint16, ingress, request bool, verdict accesslog.FlowVerdict)
 }

--- a/pkg/envoy/accesslog_server.go
+++ b/pkg/envoy/accesslog_server.go
@@ -170,5 +170,5 @@ func (s *accessLogServer) logRecord(localEndpoint logger.EndpointUpdater, pblog 
 	// Update stats for the endpoint.
 	ingress := r.ObservationPoint == accesslog.Ingress
 	request := r.Type == accesslog.TypeRequest
-	localEndpoint.UpdateProxyStatistics("http", r.DestinationEndpoint.Port, ingress, request, r.Verdict)
+	localEndpoint.UpdateProxyStatistics("TCP", r.DestinationEndpoint.Port, ingress, request, r.Verdict)
 }

--- a/pkg/policy/proxyid.go
+++ b/pkg/policy/proxyid.go
@@ -23,7 +23,8 @@ import (
 	"github.com/cilium/cilium/pkg/u8proto"
 )
 
-func proxyID(endpointID uint16, ingress bool, protocol string, port uint16) string {
+// ProxyID returns a unique string to identify a proxy mapping.
+func ProxyID(endpointID uint16, ingress bool, protocol string, port uint16) string {
 	direction := "egress"
 	if ingress {
 		direction = "ingress"
@@ -33,12 +34,12 @@ func proxyID(endpointID uint16, ingress bool, protocol string, port uint16) stri
 
 // ProxyIDFromKey returns a unique string to identify a proxy mapping.
 func ProxyIDFromKey(endpointID uint16, key Key) string {
-	return proxyID(endpointID, key.TrafficDirection == trafficdirection.Ingress.Uint8(), u8proto.U8proto(key.Nexthdr).String(), key.DestPort)
+	return ProxyID(endpointID, key.TrafficDirection == trafficdirection.Ingress.Uint8(), u8proto.U8proto(key.Nexthdr).String(), key.DestPort)
 }
 
 // ProxyIDFromFilter returns a unique string to identify a proxy mapping.
 func ProxyIDFromFilter(endpointID uint16, l4 *L4Filter) string {
-	return proxyID(endpointID, l4.Ingress, string(l4.Protocol), uint16(l4.Port))
+	return ProxyID(endpointID, l4.Ingress, string(l4.Protocol), uint16(l4.Port))
 }
 
 // ParseProxyID parses a proxy ID returned by ProxyID and returns its components.

--- a/pkg/policy/proxyid_test.go
+++ b/pkg/policy/proxyid_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func (s *PolicyTestSuite) TestProxyID(c *C) {
-	id := proxyID(123, true, "TCP", uint16(8080))
+	id := ProxyID(123, true, "TCP", uint16(8080))
 	endpointID, ingress, protocol, port, err := ParseProxyID(id)
 	c.Assert(endpointID, Equals, uint16(123))
 	c.Assert(ingress, Equals, true)

--- a/pkg/proxy/kafka.go
+++ b/pkg/proxy/kafka.go
@@ -304,8 +304,7 @@ func (l *kafkaLogRecord) log(verdict accesslog.FlowVerdict, code int, info strin
 		return
 	}
 	request := l.Type == accesslog.TypeRequest
-	l.localEndpoint.UpdateProxyStatistics("kafka", port, ingress, request, l.Verdict)
-
+	l.localEndpoint.UpdateProxyStatistics("TCP", port, ingress, request, l.Verdict)
 }
 
 func (k *kafkaRedirect) handleRequest(pair *connectionPair, req *kafka.RequestMessage, correlationCache *kafka.CorrelationCache,

--- a/pkg/proxy/logger/epinfo.go
+++ b/pkg/proxy/logger/epinfo.go
@@ -67,7 +67,7 @@ type EndpointUpdater interface {
 
 	// UpdateProxyStatistics updates the Endpoint's proxy statistics to account
 	// for a new observed flow with the given characteristics.
-	UpdateProxyStatistics(l7Protocol string, port uint16, ingress, request bool, verdict accesslog.FlowVerdict)
+	UpdateProxyStatistics(l4Protocol string, port uint16, ingress, request bool, verdict accesslog.FlowVerdict)
 }
 
 // EndpointInfoRegistry provides endpoint information lookup by endpoint IP

--- a/pkg/proxy/mock_test.go
+++ b/pkg/proxy/mock_test.go
@@ -52,6 +52,6 @@ func (m *proxyUpdaterMock) HasSidecarProxy() bool { return m.hasSidecarProxy }
 func (m *proxyUpdaterMock) ConntrackName() string { return "global" }
 
 func (m *proxyUpdaterMock) OnProxyPolicyUpdate(policyRevision uint64) {}
-func (m *proxyUpdaterMock) UpdateProxyStatistics(l7Protocol string, port uint16, ingress, request bool,
+func (m *proxyUpdaterMock) UpdateProxyStatistics(l4Protocol string, port uint16, ingress, request bool,
 	verdict accesslog.FlowVerdict) {
 }


### PR DESCRIPTION
Now that redirects share proxy ports, proxy stats entries can not be
distinguished by the proxy port any more. Change the proxy statistics
map to be keyed by the ProxyID, so that the entries can be found when
needed without needing to know the l7 protocol.

Fixes: #6921
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8539)
<!-- Reviewable:end -->
