### PR TITLE
Remove policy dependency from pkg/regeneration

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -188,7 +188,7 @@ func (d *Daemon) Datapath() datapath.Datapath {
 
 // UpdateProxyRedirect updates the redirect rules in the proxy for a particular
 // endpoint using the provided L4 filter. Returns the allocated proxy port
-func (d *Daemon) UpdateProxyRedirect(e regeneration.EndpointUpdater, l4 *policy.L4Filter, proxyWaitGroup *completion.WaitGroup) (uint16, error, revert.FinalizeFunc, revert.RevertFunc) {
+func (d *Daemon) UpdateProxyRedirect(e regeneration.EndpointUpdater, l4 regeneration.PolicyL4Filter, proxyWaitGroup *completion.WaitGroup) (uint16, error, revert.FinalizeFunc, revert.RevertFunc) {
 	if d.l7Proxy == nil {
 		return 0, fmt.Errorf("can't redirect, proxy disabled"), nil, nil
 	}
@@ -217,7 +217,7 @@ func (d *Daemon) RemoveProxyRedirect(e regeneration.EndpointInfoSource, id strin
 
 // UpdateNetworkPolicy adds or updates a network policy in the set
 // published to L7 proxies.
-func (d *Daemon) UpdateNetworkPolicy(e regeneration.EndpointUpdater, policy *policy.L4Policy,
+func (d *Daemon) UpdateNetworkPolicy(e regeneration.EndpointUpdater, policy regeneration.L4Policy,
 	proxyWaitGroup *completion.WaitGroup) (error, revert.RevertFunc) {
 	if d.l7Proxy == nil {
 		return fmt.Errorf("can't update network policy, proxy disabled"), nil
@@ -307,7 +307,7 @@ func (d *Daemon) RemoveFromEndpointQueue(epID uint64) {
 }
 
 // GetPolicyRepository returns the policy repository of the daemon
-func (d *Daemon) GetPolicyRepository() *policy.Repository {
+func (d *Daemon) GetPolicyRepository() regeneration.PolicyRepository {
 	return d.policy
 }
 

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -63,10 +63,10 @@ type DaemonSuite struct {
 	OnTracingEnabled          func() bool
 	OnAlwaysAllowLocalhost    func() bool
 	OnGetCachedLabelList      func(id identity.NumericIdentity) (labels.LabelArray, error)
-	OnGetPolicyRepository     func() *policy.Repository
-	OnUpdateProxyRedirect     func(e regeneration.EndpointUpdater, l4 *policy.L4Filter, proxyWaitGroup *completion.WaitGroup) (uint16, error, revert.FinalizeFunc, revert.RevertFunc)
+	OnGetPolicyRepository     func() regeneration.PolicyRepository
+	OnUpdateProxyRedirect     func(e regeneration.EndpointUpdater, l4 regeneration.PolicyL4Filter, proxyWaitGroup *completion.WaitGroup) (uint16, error, revert.FinalizeFunc, revert.RevertFunc)
 	OnRemoveProxyRedirect     func(e regeneration.EndpointInfoSource, id string, proxyWaitGroup *completion.WaitGroup) (error, revert.FinalizeFunc, revert.RevertFunc)
-	OnUpdateNetworkPolicy     func(e regeneration.EndpointUpdater, policy *policy.L4Policy, proxyWaitGroup *completion.WaitGroup) (error, revert.RevertFunc)
+	OnUpdateNetworkPolicy     func(e regeneration.EndpointUpdater, policy regeneration.L4Policy, proxyWaitGroup *completion.WaitGroup) (error, revert.RevertFunc)
 	OnRemoveNetworkPolicy     func(e regeneration.EndpointInfoSource)
 	OnQueueEndpointBuild      func(ctx context.Context, epID uint64) (func(), error)
 	OnRemoveFromEndpointQueue func(epID uint64)
@@ -208,14 +208,14 @@ func (ds *DaemonSuite) GetCachedLabelList(id identity.NumericIdentity) (labels.L
 	panic("GetCachedLabelList should not have been called")
 }
 
-func (ds *DaemonSuite) GetPolicyRepository() *policy.Repository {
+func (ds *DaemonSuite) GetPolicyRepository() regeneration.PolicyRepository {
 	if ds.OnGetPolicyRepository != nil {
 		return ds.OnGetPolicyRepository()
 	}
 	panic("GetPolicyRepository should not have been called")
 }
 
-func (ds *DaemonSuite) UpdateProxyRedirect(e regeneration.EndpointUpdater, l4 *policy.L4Filter, proxyWaitGroup *completion.WaitGroup) (uint16, error, revert.FinalizeFunc, revert.RevertFunc) {
+func (ds *DaemonSuite) UpdateProxyRedirect(e regeneration.EndpointUpdater, l4 regeneration.PolicyL4Filter, proxyWaitGroup *completion.WaitGroup) (uint16, error, revert.FinalizeFunc, revert.RevertFunc) {
 	if ds.OnUpdateProxyRedirect != nil {
 		return ds.OnUpdateProxyRedirect(e, l4, proxyWaitGroup)
 	}
@@ -229,7 +229,7 @@ func (ds *DaemonSuite) RemoveProxyRedirect(e regeneration.EndpointInfoSource, id
 	panic("RemoveProxyRedirect should not have been called")
 }
 
-func (ds *DaemonSuite) UpdateNetworkPolicy(e regeneration.EndpointUpdater, policy *policy.L4Policy,
+func (ds *DaemonSuite) UpdateNetworkPolicy(e regeneration.EndpointUpdater, policy regeneration.L4Policy,
 	proxyWaitGroup *completion.WaitGroup) (error, revert.RevertFunc) {
 	if ds.OnUpdateNetworkPolicy != nil {
 		return ds.OnUpdateNetworkPolicy(e, policy, proxyWaitGroup)

--- a/daemon/state_test.go
+++ b/daemon/state_test.go
@@ -146,7 +146,7 @@ func (ds *DaemonSuite) generateEPs(baseDir string, epsWanted []*e.Endpoint, epsM
 		return nil
 	}
 
-	ds.OnUpdateNetworkPolicy = func(e regeneration.EndpointUpdater, policy *policy.L4Policy,
+	ds.OnUpdateNetworkPolicy = func(e regeneration.EndpointUpdater, policy regeneration.L4Policy,
 		proxyWaitGroup *completion.WaitGroup) (error, revert.RevertFunc) {
 		return nil, nil
 	}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -405,7 +405,7 @@ func (e *Endpoint) WaitForProxyCompletions(proxyWaitGroup *completion.WaitGroup)
 }
 
 // NewEndpointWithState creates a new endpoint useful for testing purposes
-func NewEndpointWithState(repo *policy.Repository, ID uint16, state string) *Endpoint {
+func NewEndpointWithState(repo regeneration.PolicyRepository, ID uint16, state string) *Endpoint {
 	ep := &Endpoint{
 		ID:            ID,
 		OpLabels:      pkgLabels.NewOpLabels(),
@@ -1050,7 +1050,7 @@ func FilterEPDir(dirFiles []os.FileInfo) []string {
 
 // ParseEndpoint parses the given strEp which is in the form of:
 // common.CiliumCHeaderPrefix + common.Version + ":" + endpointBase64
-func ParseEndpoint(repo *policy.Repository, strEp string) (*Endpoint, error) {
+func ParseEndpoint(repo regeneration.PolicyRepository, strEp string) (*Endpoint, error) {
 	// TODO: Provide a better mechanism to update from old version once we bump
 	// TODO: cilium version.
 	strEpSlice := strings.Split(strEp, ":")

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -44,7 +44,7 @@ import (
 )
 
 // ProxyID returns a unique string to identify a proxy mapping.
-func (e *Endpoint) ProxyID(l4 *policy.L4Filter) string {
+func (e *Endpoint) ProxyID(l4 regeneration.PolicyL4Filter) string {
 	return policy.ProxyIDFromFilter(e.ID, l4)
 }
 
@@ -52,7 +52,7 @@ func (e *Endpoint) ProxyID(l4 *policy.L4Filter) string {
 // policy map key, in host byte order. Returns 0 if not found or the
 // filter doesn't require a redirect.
 // Must be called with Endpoint.Mutex held.
-func (e *Endpoint) LookupRedirectPort(l4Filter *policy.L4Filter) uint16 {
+func (e *Endpoint) LookupRedirectPort(l4Filter regeneration.PolicyL4Filter) uint16 {
 	if !l4Filter.IsRedirect() {
 		return 0
 	}
@@ -120,9 +120,9 @@ func (e *Endpoint) regeneratePolicy(owner regeneration.Owner) (retErr error) {
 
 	stats.waitingForPolicyRepository.Start()
 	repo := owner.GetPolicyRepository()
-	repo.Mutex.RLock()
+	repo.RLock()
 	revision := repo.GetRevision()
-	defer repo.Mutex.RUnlock()
+	defer repo.RUnlock()
 	stats.waitingForPolicyRepository.End(true)
 
 	// Recompute policy for this endpoint only if not already done for this revision.

--- a/pkg/endpoint/regeneration/owner.go
+++ b/pkg/endpoint/regeneration/owner.go
@@ -16,6 +16,7 @@ package regeneration
 
 import (
 	"context"
+	"strings"
 
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/datapath"
@@ -23,26 +24,28 @@ import (
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/lock"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
-	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/revert"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 )
 
 // Owner is the interface defines the requirements for anybody owning policies.
 type Owner interface {
 
 	// Must return the policy repository
-	GetPolicyRepository() *policy.Repository
+	GetPolicyRepository() PolicyRepository
 
 	// UpdateProxyRedirect must update the redirect configuration of an endpoint in the proxy
-	UpdateProxyRedirect(e EndpointUpdater, l4 *policy.L4Filter, proxyWaitGroup *completion.WaitGroup) (uint16, error, revert.FinalizeFunc, revert.RevertFunc)
+	UpdateProxyRedirect(e EndpointUpdater, l4 PolicyL4Filter, proxyWaitGroup *completion.WaitGroup) (uint16, error, revert.FinalizeFunc, revert.RevertFunc)
 
 	// RemoveProxyRedirect must remove the redirect installed by UpdateProxyRedirect
 	RemoveProxyRedirect(e EndpointInfoSource, id string, proxyWaitGroup *completion.WaitGroup) (error, revert.FinalizeFunc, revert.RevertFunc)
 
 	// UpdateNetworkPolicy adds or updates a network policy in the set
 	// published to L7 proxies.
-	UpdateNetworkPolicy(e EndpointUpdater, policy *policy.L4Policy,
+	UpdateNetworkPolicy(e EndpointUpdater, policy L4Policy,
 		proxyWaitGroup *completion.WaitGroup) (error, revert.RevertFunc)
 
 	// RemoveNetworkPolicy removes a network policy from the set published to
@@ -87,7 +90,7 @@ type EndpointInfoSource interface {
 	ConntrackName() string
 	GetIngressPolicyEnabledLocked() bool
 	GetEgressPolicyEnabledLocked() bool
-	ProxyID(l4 *policy.L4Filter) string
+	ProxyID(l4 PolicyL4Filter) string
 }
 
 // EndpointUpdater returns information about an endpoint being proxied and
@@ -102,4 +105,150 @@ type EndpointUpdater interface {
 	// UpdateProxyStatistics updates the Endpoint's proxy statistics to account
 	// for a new observed flow with the given characteristics.
 	UpdateProxyStatistics(l7Protocol string, port uint16, ingress, request bool, verdict accesslog.FlowVerdict)
+}
+
+// PolicyRepository is the interface which needs to be implemented by the owner 
+// of a policy repository.
+type PolicyRepository interface {
+	GetRevision() uint64
+	GetPolicyCache() PolicyCache
+	RLock()
+	RUnlock()
+	GetSelectorCache() SelectorCache
+}
+
+type PolicyCache interface {
+	UpdatePolicy(*identity.Identity) error
+	Lookup(*identity.Identity) SelectorPolicy
+}
+
+type SelectorCache interface {
+	RemoveSelectors(CachedSelectorSlice, CachedSelectionUser)
+	RemoveSelector(CachedSelector, CachedSelectionUser)
+	ChangeUser(CachedSelector, CachedSelectionUser, CachedSelectionUser)
+	AddIdentitySelector(CachedSelectionUser, api.EndpointSelector) (CachedSelector, bool)
+	AddFQDNSelector(CachedSelectionUser, api.FQDNSelector) (CachedSelector, bool)
+}
+
+type PolicyL4Filter interface {
+	L7ParserType() string
+	IsIngress() bool
+	GetPort() int
+	GetProtocol() api.L4Proto
+	GetL7RulesPerEp() L7DataMap
+	GetL7RulesPerEpCopy() L7DataMap
+	IsRedirect() bool
+
+	Detach(SelectorCache)
+	Attach(L4Policy)
+	MatchesLabels(labels labels.LabelArray) bool
+
+	GetRuleLabels() labels.LabelArrayList
+	SetRuleLabels(labels.LabelArrayList)
+	MarshalIndent() string
+
+	CacheIdentitySelector(api.EndpointSelector, SelectorCache) CachedSelector
+
+	IdentitySelectionUpdated(CachedSelector, []identity.NumericIdentity, []identity.NumericIdentity, []identity.NumericIdentity)
+	ToKeys(trafficdirection.TrafficDirection) PolicyKeySlice
+
+	AllowsAllAtL3() bool
+	SetAllowsAllAtL3(bool)
+	SetCachedSelectors(CachedSelectorSlice)
+	GetCachedSelectors() CachedSelectorSlice
+	SetL7ParserType(parser string)
+
+	MergeCachedSelectors(PolicyL4Filter, SelectorCache)
+}
+
+type L4Policy interface {
+	GetIngressPolicies() L4PolicyMap
+	GetEgressPolicies() L4PolicyMap
+
+	GetRevision() uint64
+}
+
+type L4PolicyMap interface {
+	Detach(SelectorCache)
+	Attach(L4Policy)
+
+	GetMap() map[string]PolicyL4Filter
+}
+
+type L7DataMap map[CachedSelector]api.L7Rules
+
+// CachedSelector represents an identity selector owned by the selector cache
+type CachedSelector interface {
+	// GetSelections returns the cached set of numeric identities
+	// selected by the CachedSelector.  The retuned slice must NOT
+	// be modified, as it is shared among multiple users.
+	GetSelections() []identity.NumericIdentity
+
+	// Selects return 'true' if the CachedSelector selects the given
+	// numeric identity.
+	Selects(nid identity.NumericIdentity) bool
+
+	// IsWildcard returns true if the endpoint selector selects
+	// all endpoints.
+	IsWildcard() bool
+
+	// String returns the string representation of this selector.
+	// Used as a map key.
+	String() string
+}
+
+// CachedSelectorSlice is a slice of CachedSelectors that can be sorted.
+type CachedSelectorSlice []CachedSelector
+
+func (s CachedSelectorSlice) Len() int      { return len(s) }
+func (s CachedSelectorSlice) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+
+func (s CachedSelectorSlice) Less(i, j int) bool {
+	return strings.Compare(s[i].String(), s[j].String()) < 0
+}
+
+// SelectsAllEndpoints returns whether the CachedSelectorSlice selects all
+// endpoints, which is true if the wildcard endpoint selector is present in the
+// slice.
+func (s CachedSelectorSlice) SelectsAllEndpoints() bool {
+	for _, selector := range s {
+		if selector.IsWildcard() {
+			return true
+		}
+	}
+	return false
+}
+
+// Insert in a sorted order? Returns true if inserted, false if cs was already in
+func (s *CachedSelectorSlice) Insert(cs CachedSelector) bool {
+	for _, selector := range *s {
+		if selector == cs {
+			return false
+		}
+	}
+	*s = append(*s, cs)
+	return true
+}
+
+
+type CachedSelectionUser interface {
+	// IdentitySelectionUpdated implementations MUST NOT call back
+	// to selector cache while executing this function!
+	//
+	// The caller is responsible for making sure the same identity is not
+	// present in both 'added' and 'deleted'.
+	IdentitySelectionUpdated(selector CachedSelector, selections, added, deleted []identity.NumericIdentity)
+}
+
+type PolicyKey interface {
+	GetIdentity() uint32
+	GetDestPort() uint16
+	GetNexthdr() uint8
+	GetTrafficDirection() uint8
+}
+
+type PolicyKeySlice []PolicyKey
+
+func (pk PolicyKeySlice) Append(key PolicyKey) {
+	pk = append(pk, key)
 }

--- a/pkg/envoy/server_test.go
+++ b/pkg/envoy/server_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 
 	"github.com/cilium/proxy/go/cilium/api"
 	envoy_api_v2_core "github.com/cilium/proxy/go/envoy/api/v2/core"
@@ -34,7 +35,7 @@ type ServerSuite struct{}
 
 type DummySelectorCacheUser struct{}
 
-func (d *DummySelectorCacheUser) IdentitySelectionUpdated(selector policy.CachedSelector, selections, added, deleted []identity.NumericIdentity) {
+func (d *DummySelectorCacheUser) IdentitySelectionUpdated(selector regeneration.CachedSelector, selections, added, deleted []identity.NumericIdentity) {
 }
 
 var (

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 
 	. "gopkg.in/check.v1"
 	v1 "k8s.io/api/core/v1"
@@ -100,7 +101,7 @@ var (
 
 type DummySelectorCacheUser struct{}
 
-func (d *DummySelectorCacheUser) IdentitySelectionUpdated(selector policy.CachedSelector, selections, added, deleted []identity.NumericIdentity) {
+func (d *DummySelectorCacheUser) IdentitySelectionUpdated(selector regeneration.CachedSelector, selections, added, deleted []identity.NumericIdentity) {
 }
 
 func (s *K8sSuite) TestParseNetworkPolicyIngress(c *C) {
@@ -175,7 +176,7 @@ func (s *K8sSuite) TestParseNetworkPolicyIngress(c *C) {
 	c.Assert(ingressL4Policy, checker.Equals, policy.L4PolicyMap{
 		"80/TCP": {
 			Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
-			CachedSelectors: policy.CachedSelectorSlice{cachedEPSelector},
+			CachedSelectors: regeneration.CachedSelectorSlice{cachedEPSelector},
 			L7Parser:        policy.ParserTypeNone,
 			L7RulesPerEp:    policy.L7DataMap{},
 			Ingress:         true,
@@ -503,7 +504,7 @@ func (s *K8sSuite) TestParseNetworkPolicyEgress(c *C) {
 	c.Assert(egressL4Policy, checker.DeepEquals, policy.L4PolicyMap{
 		"80/TCP": {
 			Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
-			CachedSelectors: policy.CachedSelectorSlice{cachedEPSelector},
+			CachedSelectors: regeneration.CachedSelectorSlice{cachedEPSelector},
 			L7Parser:        policy.ParserTypeNone,
 			L7RulesPerEp:    policy.L7DataMap{},
 			Ingress:         false,

--- a/pkg/policy/distillery.go
+++ b/pkg/policy/distillery.go
@@ -22,16 +22,8 @@ import (
 	identityPkg "github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 )
-
-// SelectorPolicy represents a cached selectorPolicy, previously resolved from
-// the policy repository and ready to be distilled against a set of identities
-// to compute datapath-level policy configuration.
-type SelectorPolicy interface {
-	// Consume returns the policy in terms of connectivity to peer
-	// Identities. The callee MUST NOT modify the returned pointer.
-	Consume(owner PolicyOwner) *EndpointPolicy
-}
 
 // PolicyCache represents a cache of resolved policies for identities.
 type PolicyCache struct {
@@ -57,7 +49,7 @@ func NewPolicyCache(repo *Repository, subscribe bool) *PolicyCache {
 	return cache
 }
 
-func (cache *PolicyCache) GetSelectorCache() *SelectorCache {
+func (cache *PolicyCache) GetSelectorCache() regeneration.SelectorCache {
 	return cache.repo.GetSelectorCache()
 }
 
@@ -182,7 +174,7 @@ type cachedSelectorPolicy struct {
 	policy   unsafe.Pointer
 }
 
-func newCachedSelectorPolicy(identity *identityPkg.Identity, selectorCache *SelectorCache) *cachedSelectorPolicy {
+func newCachedSelectorPolicy(identity *identityPkg.Identity, selectorCache regeneration.SelectorCache) *cachedSelectorPolicy {
 	cip := &cachedSelectorPolicy{
 		identity: identity,
 	}

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/testutils"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 
 	logging "github.com/op/go-logging"
 	. "gopkg.in/check.v1"
@@ -65,7 +66,7 @@ func (ep *testEP) WithIdentity(id int64) *testEP {
 	return ep
 }
 
-func (ep *testEP) LookupRedirectPort(l4 *L4Filter) uint16 {
+func (ep *testEP) LookupRedirectPort(l4 regeneration.PolicyL4Filter) uint16 {
 	return 42
 }
 

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 
 	logging "github.com/op/go-logging"
 	. "gopkg.in/check.v1"
@@ -233,7 +234,7 @@ func (ds *PolicyTestSuite) TestMergeAllowAllL3AndShadowedL7(c *C) {
 		Protocol:        api.ProtoTCP,
 		U8Proto:         6,
 		allowsAllAtL3:   true,
-		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector},
+		CachedSelectors: regeneration.CachedSelectorSlice{wildcardCachedSelector},
 		L7Parser:        "http",
 		L7RulesPerEp: L7DataMap{
 			wildcardCachedSelector: api.L7Rules{
@@ -341,7 +342,7 @@ func (ds *PolicyTestSuite) TestMergeIdenticalAllowAllL3AndRestrictedL7HTTP(c *C)
 		Protocol:        api.ProtoTCP,
 		U8Proto:         6,
 		allowsAllAtL3:   true,
-		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector},
+		CachedSelectors: regeneration.CachedSelectorSlice{wildcardCachedSelector},
 		L7Parser:        ParserTypeHTTP,
 		L7RulesPerEp: L7DataMap{
 			wildcardCachedSelector: api.L7Rules{
@@ -421,7 +422,7 @@ func (ds *PolicyTestSuite) TestMergeIdenticalAllowAllL3AndRestrictedL7Kafka(c *C
 		Protocol:        api.ProtoTCP,
 		U8Proto:         6,
 		allowsAllAtL3:   true,
-		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector},
+		CachedSelectors: regeneration.CachedSelectorSlice{wildcardCachedSelector},
 		L7Parser:        ParserTypeKafka,
 		L7RulesPerEp: L7DataMap{
 			wildcardCachedSelector: api.L7Rules{
@@ -675,7 +676,7 @@ func (ds *PolicyTestSuite) TestL3RuleShadowedByL3AllowAll(c *C) {
 		Protocol:         api.ProtoTCP,
 		U8Proto:          6,
 		allowsAllAtL3:    true,
-		CachedSelectors:  CachedSelectorSlice{wildcardCachedSelector},
+		CachedSelectors:  regeneration.CachedSelectorSlice{wildcardCachedSelector},
 		L7Parser:         ParserTypeNone,
 		L7RulesPerEp:     L7DataMap{},
 		Ingress:          true,
@@ -733,7 +734,7 @@ func (ds *PolicyTestSuite) TestL3RuleShadowedByL3AllowAll(c *C) {
 		Protocol:         api.ProtoTCP,
 		U8Proto:          6,
 		allowsAllAtL3:    true,
-		CachedSelectors:  CachedSelectorSlice{wildcardCachedSelector},
+		CachedSelectors:  regeneration.CachedSelectorSlice{wildcardCachedSelector},
 		L7Parser:         ParserTypeNone,
 		L7RulesPerEp:     L7DataMap{},
 		Ingress:          true,
@@ -804,7 +805,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RulePartiallyShadowedByL3AllowAll(c *
 		Protocol:        api.ProtoTCP,
 		U8Proto:         6,
 		allowsAllAtL3:   true,
-		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector},
+		CachedSelectors: regeneration.CachedSelectorSlice{wildcardCachedSelector},
 		L7Parser:        ParserTypeHTTP,
 		L7RulesPerEp: L7DataMap{
 			cachedSelectorA: api.L7Rules{
@@ -873,7 +874,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RulePartiallyShadowedByL3AllowAll(c *
 		Protocol:        api.ProtoTCP,
 		U8Proto:         6,
 		allowsAllAtL3:   true,
-		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector},
+		CachedSelectors: regeneration.CachedSelectorSlice{wildcardCachedSelector},
 		L7Parser:        ParserTypeHTTP,
 		L7RulesPerEp: L7DataMap{
 			cachedSelectorA: api.L7Rules{
@@ -955,7 +956,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RuleShadowedByL3AllowAll(c *C) {
 		Protocol:        api.ProtoTCP,
 		U8Proto:         6,
 		allowsAllAtL3:   true,
-		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector},
+		CachedSelectors: regeneration.CachedSelectorSlice{wildcardCachedSelector},
 		L7Parser:        ParserTypeHTTP,
 		L7RulesPerEp: L7DataMap{
 			wildcardCachedSelector: api.L7Rules{
@@ -1033,7 +1034,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RuleShadowedByL3AllowAll(c *C) {
 		Protocol:        api.ProtoTCP,
 		U8Proto:         6,
 		allowsAllAtL3:   true,
-		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector},
+		CachedSelectors: regeneration.CachedSelectorSlice{wildcardCachedSelector},
 		L7Parser:        ParserTypeHTTP,
 		L7RulesPerEp: L7DataMap{
 			wildcardCachedSelector: api.L7Rules{
@@ -1219,7 +1220,7 @@ func (ds *PolicyTestSuite) TestMergingWithDifferentEndpointsSelectedAllowSameL7(
 		Port:            80,
 		Protocol:        api.ProtoTCP,
 		U8Proto:         6,
-		CachedSelectors: CachedSelectorSlice{cachedSelectorA, cachedSelectorC},
+		CachedSelectors: regeneration.CachedSelectorSlice{cachedSelectorA, cachedSelectorC},
 		L7Parser:        ParserTypeHTTP,
 		L7RulesPerEp: L7DataMap{
 			cachedSelectorC: api.L7Rules{
@@ -1291,7 +1292,7 @@ func (ds *PolicyTestSuite) TestMergingWithDifferentEndpointSelectedAllowAllL7(c 
 		Port:             80,
 		Protocol:         api.ProtoTCP,
 		U8Proto:          6,
-		CachedSelectors:  CachedSelectorSlice{cachedSelectorA, cachedSelectorC},
+		CachedSelectors:  regeneration.CachedSelectorSlice{cachedSelectorA, cachedSelectorC},
 		L7Parser:         ParserTypeNone,
 		L7RulesPerEp:     L7DataMap{},
 		Ingress:          true,
@@ -1364,7 +1365,7 @@ func (ds *PolicyTestSuite) TestAllowingLocalhostShadowsL7(c *C) {
 		Protocol:        api.ProtoTCP,
 		U8Proto:         6,
 		allowsAllAtL3:   true,
-		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector, cachedSelectorHost},
+		CachedSelectors: regeneration.CachedSelectorSlice{wildcardCachedSelector, cachedSelectorHost},
 		L7Parser:        ParserTypeHTTP,
 		L7RulesPerEp: L7DataMap{
 			wildcardCachedSelector: api.L7Rules{
@@ -1422,7 +1423,7 @@ func (ds *PolicyTestSuite) TestEntitiesL3(c *C) {
 		Port:             0,
 		Protocol:         api.ProtoAny,
 		U8Proto:          0,
-		CachedSelectors:  CachedSelectorSlice{wildcardCachedSelector},
+		CachedSelectors:  regeneration.CachedSelectorSlice{wildcardCachedSelector},
 		L7Parser:         ParserTypeNone,
 		L7RulesPerEp:     L7DataMap{},
 		Ingress:          false,

--- a/pkg/policy/l4_test.go
+++ b/pkg/policy/l4_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/kr/pretty"
 
 	. "gopkg.in/check.v1"
@@ -78,7 +79,7 @@ func (s *PolicyTestSuite) TestJSONMarshal(c *C) {
 		Ingress: L4PolicyMap{
 			"80/TCP": {
 				Port: 80, Protocol: api.ProtoTCP,
-				CachedSelectors: CachedSelectorSlice{cachedFooSelector},
+				CachedSelectors: regeneration.CachedSelectorSlice{cachedFooSelector},
 				L7Parser:        "http",
 				L7RulesPerEp: L7DataMap{
 					cachedFooSelector: api.L7Rules{
@@ -89,7 +90,7 @@ func (s *PolicyTestSuite) TestJSONMarshal(c *C) {
 			},
 			"9090/TCP": {
 				Port: 9090, Protocol: api.ProtoTCP,
-				CachedSelectors: CachedSelectorSlice{cachedFooSelector},
+				CachedSelectors: regeneration.CachedSelectorSlice{cachedFooSelector},
 				L7Parser:        "tester",
 				L7RulesPerEp: L7DataMap{
 					cachedFooSelector: api.L7Rules{
@@ -108,7 +109,7 @@ func (s *PolicyTestSuite) TestJSONMarshal(c *C) {
 			},
 			"8080/TCP": {
 				Port: 8080, Protocol: api.ProtoTCP,
-				CachedSelectors: CachedSelectorSlice{cachedFooSelector},
+				CachedSelectors: regeneration.CachedSelectorSlice{cachedFooSelector},
 				L7Parser:        "http",
 				L7RulesPerEp: L7DataMap{
 					cachedFooSelector: api.L7Rules{

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 
 	"github.com/sirupsen/logrus"
 )
@@ -51,6 +52,22 @@ type Key struct {
 	TrafficDirection uint8
 }
 
+func (k Key) GetIdentity() uint32 {
+	return k.Identity
+}
+
+func (k Key) GetDestPort() uint16 {
+	return k.DestPort
+}
+
+func (k Key) GetNexthdr() uint8 {
+	return k.Nexthdr
+}
+
+func (k Key) GetTrafficDirection() uint8 {
+	return k.TrafficDirection
+}
+
 // IsIngress returns true if the key refers to an ingress policy key
 func (k Key) IsIngress() bool {
 	return k.TrafficDirection == trafficdirection.Ingress.Uint8()
@@ -59,6 +76,15 @@ func (k Key) IsIngress() bool {
 // IsEgress returns true if the key refers to an egress policy key
 func (k Key) IsEgress() bool {
 	return k.TrafficDirection == trafficdirection.Egress.Uint8()
+}
+
+func NewPolicyKey(key regeneration.PolicyKey) Key {
+	return Key{
+		Identity: key.GetIdentity(),
+		DestPort: key.GetDestPort(),
+		Nexthdr: key.GetNexthdr(),
+		TrafficDirection: key.GetTrafficDirection(),
+	}
 }
 
 // MapStateEntry is the configuration associated with a Key in a

--- a/pkg/policy/proxyid.go
+++ b/pkg/policy/proxyid.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/u8proto"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 )
 
 func proxyID(endpointID uint16, ingress bool, protocol string, port uint16) string {
@@ -37,8 +38,8 @@ func ProxyIDFromKey(endpointID uint16, key Key) string {
 }
 
 // ProxyIDFromFilter returns a unique string to identify a proxy mapping.
-func ProxyIDFromFilter(endpointID uint16, l4 *L4Filter) string {
-	return proxyID(endpointID, l4.Ingress, string(l4.Protocol), uint16(l4.Port))
+func ProxyIDFromFilter(endpointID uint16, l4 regeneration.PolicyL4Filter) string {
+	return proxyID(endpointID, l4.IsIngress(), string(l4.GetProtocol()), uint16(l4.GetPort()))
 }
 
 // ParseProxyID parses a proxy ID returned by ProxyID and returns its components.

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 
 	logging "github.com/op/go-logging"
 	. "gopkg.in/check.v1"
@@ -659,7 +660,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngress(c *C) {
 			Port:             0,
 			Protocol:         api.ProtoAny,
 			U8Proto:          0x0,
-			CachedSelectors:  CachedSelectorSlice{cachedSelectorBar1},
+			CachedSelectors:  regeneration.CachedSelectorSlice{cachedSelectorBar1},
 			L7RulesPerEp:     L7DataMap{},
 			Ingress:          true,
 			DerivedFromRules: labels.LabelArrayList{labelsL3},
@@ -668,7 +669,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngress(c *C) {
 			Port:            9092,
 			Protocol:        api.ProtoTCP,
 			U8Proto:         0x6,
-			CachedSelectors: CachedSelectorSlice{cachedSelectorBar2, cachedSelectorBar1},
+			CachedSelectors: regeneration.CachedSelectorSlice{cachedSelectorBar2, cachedSelectorBar1},
 			L7Parser:        ParserTypeKafka,
 			Ingress:         true,
 			L7RulesPerEp: L7DataMap{
@@ -685,7 +686,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngress(c *C) {
 			Port:            80,
 			Protocol:        api.ProtoTCP,
 			U8Proto:         0x6,
-			CachedSelectors: CachedSelectorSlice{cachedSelectorBar2, cachedSelectorBar1},
+			CachedSelectors: regeneration.CachedSelectorSlice{cachedSelectorBar2, cachedSelectorBar1},
 			L7Parser:        ParserTypeHTTP,
 			Ingress:         true,
 			L7RulesPerEp: L7DataMap{
@@ -702,7 +703,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngress(c *C) {
 			Port:            9090,
 			Protocol:        api.ProtoTCP,
 			U8Proto:         0x6,
-			CachedSelectors: CachedSelectorSlice{cachedSelectorBar2, cachedSelectorBar1},
+			CachedSelectors: regeneration.CachedSelectorSlice{cachedSelectorBar2, cachedSelectorBar1},
 			L7Parser:        L7ParserType("tester"),
 			Ingress:         true,
 			L7RulesPerEp: L7DataMap{
@@ -830,7 +831,7 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesIngress(c *C) {
 			Port:            80,
 			Protocol:        api.ProtoTCP,
 			U8Proto:         0x6,
-			CachedSelectors: CachedSelectorSlice{cachedSelectorBar1, cachedSelectorBar2},
+			CachedSelectors: regeneration.CachedSelectorSlice{cachedSelectorBar1, cachedSelectorBar2},
 			L7Parser:        ParserTypeHTTP,
 			Ingress:         true,
 			L7RulesPerEp: L7DataMap{
@@ -847,7 +848,7 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesIngress(c *C) {
 			Port:            9092,
 			Protocol:        api.ProtoTCP,
 			U8Proto:         0x6,
-			CachedSelectors: CachedSelectorSlice{cachedSelectorBar1, cachedSelectorBar2},
+			CachedSelectors: regeneration.CachedSelectorSlice{cachedSelectorBar1, cachedSelectorBar2},
 			L7Parser:        ParserTypeKafka,
 			Ingress:         true,
 			L7RulesPerEp: L7DataMap{
@@ -919,7 +920,7 @@ func (ds *PolicyTestSuite) TestL3DependentL4IngressFromRequires(c *C) {
 			Port:     80,
 			Protocol: api.ProtoTCP,
 			U8Proto:  0x6,
-			CachedSelectors: CachedSelectorSlice{
+			CachedSelectors: regeneration.CachedSelectorSlice{
 				expectedCachedSelector,
 			},
 			L7RulesPerEp:     L7DataMap{},
@@ -998,7 +999,7 @@ func (ds *PolicyTestSuite) TestL3DependentL4EgressFromRequires(c *C) {
 			Protocol:      "ANY",
 			U8Proto:       0x0,
 			allowsAllAtL3: false,
-			CachedSelectors: CachedSelectorSlice{
+			CachedSelectors: regeneration.CachedSelectorSlice{
 				expectedCachedSelector2,
 			},
 			L7RulesPerEp:     L7DataMap{},
@@ -1008,7 +1009,7 @@ func (ds *PolicyTestSuite) TestL3DependentL4EgressFromRequires(c *C) {
 			Port:     80,
 			Protocol: api.ProtoTCP,
 			U8Proto:  0x6,
-			CachedSelectors: CachedSelectorSlice{
+			CachedSelectors: regeneration.CachedSelectorSlice{
 				expectedCachedSelector,
 			},
 			L7RulesPerEp:     L7DataMap{},
@@ -1106,7 +1107,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgress(c *C) {
 			Port:            9092,
 			Protocol:        api.ProtoTCP,
 			U8Proto:         0x6,
-			CachedSelectors: CachedSelectorSlice{cachedSelectorBar2, cachedSelectorBar1},
+			CachedSelectors: regeneration.CachedSelectorSlice{cachedSelectorBar2, cachedSelectorBar1},
 			L7Parser:        ParserTypeKafka,
 			Ingress:         false,
 			L7RulesPerEp: L7DataMap{
@@ -1123,7 +1124,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgress(c *C) {
 			Port:            80,
 			Protocol:        api.ProtoTCP,
 			U8Proto:         0x6,
-			CachedSelectors: CachedSelectorSlice{cachedSelectorBar2, cachedSelectorBar1},
+			CachedSelectors: regeneration.CachedSelectorSlice{cachedSelectorBar2, cachedSelectorBar1},
 			L7Parser:        ParserTypeHTTP,
 			Ingress:         false,
 			L7RulesPerEp: L7DataMap{
@@ -1141,7 +1142,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgress(c *C) {
 			Protocol:         "ANY",
 			U8Proto:          0x0,
 			allowsAllAtL3:    false,
-			CachedSelectors:  CachedSelectorSlice{cachedSelectorBar1},
+			CachedSelectors:  regeneration.CachedSelectorSlice{cachedSelectorBar1},
 			L7Parser:         "",
 			L7RulesPerEp:     L7DataMap{},
 			Ingress:          false,
@@ -1260,7 +1261,7 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesEgress(c *C) {
 			Port:            80,
 			Protocol:        api.ProtoTCP,
 			U8Proto:         0x6,
-			CachedSelectors: CachedSelectorSlice{cachedSelectorBar1, cachedSelectorBar2},
+			CachedSelectors: regeneration.CachedSelectorSlice{cachedSelectorBar1, cachedSelectorBar2},
 			L7Parser:        ParserTypeHTTP,
 			Ingress:         false,
 			L7RulesPerEp: L7DataMap{
@@ -1277,7 +1278,7 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesEgress(c *C) {
 			Port:            9092,
 			Protocol:        api.ProtoTCP,
 			U8Proto:         0x6,
-			CachedSelectors: CachedSelectorSlice{cachedSelectorBar1, cachedSelectorBar2},
+			CachedSelectors: regeneration.CachedSelectorSlice{cachedSelectorBar1, cachedSelectorBar2},
 			L7Parser:        ParserTypeKafka,
 			Ingress:         false,
 			L7RulesPerEp: L7DataMap{
@@ -1385,7 +1386,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngressFromEntities(c *C) {
 			Protocol:         "ANY",
 			U8Proto:          0x0,
 			allowsAllAtL3:    false,
-			CachedSelectors:  CachedSelectorSlice{cachedSelectorWorld},
+			CachedSelectors:  regeneration.CachedSelectorSlice{cachedSelectorWorld},
 			L7Parser:         "",
 			L7RulesPerEp:     L7DataMap{},
 			Ingress:          true,
@@ -1395,7 +1396,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngressFromEntities(c *C) {
 			Port:            9092,
 			Protocol:        api.ProtoTCP,
 			U8Proto:         0x6,
-			CachedSelectors: CachedSelectorSlice{cachedSelectorBar2, cachedSelectorWorld},
+			CachedSelectors: regeneration.CachedSelectorSlice{cachedSelectorBar2, cachedSelectorWorld},
 			L7Parser:        ParserTypeKafka,
 			Ingress:         true,
 			L7RulesPerEp: L7DataMap{
@@ -1412,7 +1413,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngressFromEntities(c *C) {
 			Port:            80,
 			Protocol:        api.ProtoTCP,
 			U8Proto:         0x6,
-			CachedSelectors: CachedSelectorSlice{cachedSelectorBar2, cachedSelectorWorld},
+			CachedSelectors: regeneration.CachedSelectorSlice{cachedSelectorBar2, cachedSelectorWorld},
 			L7Parser:        ParserTypeHTTP,
 			Ingress:         true,
 			L7RulesPerEp: L7DataMap{
@@ -1521,7 +1522,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgressToEntities(c *C) {
 			Protocol:         "ANY",
 			U8Proto:          0x0,
 			allowsAllAtL3:    false,
-			CachedSelectors:  CachedSelectorSlice{cachedSelectorWorld},
+			CachedSelectors:  regeneration.CachedSelectorSlice{cachedSelectorWorld},
 			L7Parser:         "",
 			L7RulesPerEp:     L7DataMap{},
 			Ingress:          false,
@@ -1531,7 +1532,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgressToEntities(c *C) {
 			Port:            9092,
 			Protocol:        api.ProtoTCP,
 			U8Proto:         0x6,
-			CachedSelectors: CachedSelectorSlice{cachedSelectorBar2, cachedSelectorWorld},
+			CachedSelectors: regeneration.CachedSelectorSlice{cachedSelectorBar2, cachedSelectorWorld},
 			L7Parser:        ParserTypeKafka,
 			Ingress:         false,
 			L7RulesPerEp: L7DataMap{
@@ -1548,7 +1549,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgressToEntities(c *C) {
 			Port:            80,
 			Protocol:        api.ProtoTCP,
 			U8Proto:         0x6,
-			CachedSelectors: CachedSelectorSlice{cachedSelectorBar2, cachedSelectorWorld},
+			CachedSelectors: regeneration.CachedSelectorSlice{cachedSelectorBar2, cachedSelectorWorld},
 			L7Parser:        ParserTypeHTTP,
 			Ingress:         false,
 			L7RulesPerEp: L7DataMap{
@@ -1667,7 +1668,7 @@ func (ds *PolicyTestSuite) TestMinikubeGettingStarted(c *C) {
 	expected := NewL4Policy(repo.GetRevision())
 	expected.Ingress["80/TCP"] = &L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
-		CachedSelectors: CachedSelectorSlice{cachedSelectorApp2},
+		CachedSelectors: regeneration.CachedSelectorSlice{cachedSelectorApp2},
 		L7Parser:        ParserTypeHTTP,
 		L7RulesPerEp: L7DataMap{
 			cachedSelectorApp2: api.L7Rules{

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	. "gopkg.in/check.v1"
 )
 
@@ -176,7 +177,7 @@ func GenerateCIDRRules(numRules int) api.Rules {
 
 type DummyOwner struct{}
 
-func (d DummyOwner) LookupRedirectPort(l4 *L4Filter) uint16 {
+func (d DummyOwner) LookupRedirectPort(l4 regeneration.PolicyL4Filter) uint16 {
 	return 0
 }
 
@@ -292,7 +293,7 @@ func (ds *PolicyTestSuite) TestL7WithIngressWildcard(c *C) {
 						Port:     80,
 						Protocol: api.ProtoTCP,
 						U8Proto:  0x6,
-						CachedSelectors: CachedSelectorSlice{
+						CachedSelectors: regeneration.CachedSelectorSlice{
 							wildcardCachedSelector,
 						},
 						allowsAllAtL3: true,
@@ -384,7 +385,7 @@ func (ds *PolicyTestSuite) TestL7WithLocalHostWildcardd(c *C) {
 						Port:     80,
 						Protocol: api.ProtoTCP,
 						U8Proto:  0x6,
-						CachedSelectors: CachedSelectorSlice{
+						CachedSelectors: regeneration.CachedSelectorSlice{
 							wildcardCachedSelector,
 							cachedSelectorHost,
 						},
@@ -464,7 +465,7 @@ func (ds *PolicyTestSuite) TestMapStateWithIngressWildcard(c *C) {
 						Port:     80,
 						Protocol: api.ProtoTCP,
 						U8Proto:  0x6,
-						CachedSelectors: CachedSelectorSlice{
+						CachedSelectors: regeneration.CachedSelectorSlice{
 							wildcardCachedSelector,
 						},
 						allowsAllAtL3:    true,
@@ -584,7 +585,7 @@ func (ds *PolicyTestSuite) TestMapStateWithIngress(c *C) {
 						Port:     80,
 						Protocol: api.ProtoTCP,
 						U8Proto:  0x6,
-						CachedSelectors: CachedSelectorSlice{
+						CachedSelectors: regeneration.CachedSelectorSlice{
 							cachedSelectorWorld,
 							cachedSelectorTest,
 						},

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -27,6 +27,7 @@ import (
 	identity2 "github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 
 	logging "github.com/op/go-logging"
 	. "gopkg.in/check.v1"
@@ -79,14 +80,14 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 	expected.Ingress["80/TCP"] = &L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		allowsAllAtL3:   true,
-		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector},
+		CachedSelectors: regeneration.CachedSelectorSlice{wildcardCachedSelector},
 		L7Parser:        "http", L7RulesPerEp: l7map, Ingress: true,
 		DerivedFromRules: labels.LabelArrayList{nil},
 	}
 	expected.Ingress["8080/TCP"] = &L4Filter{
 		Port: 8080, Protocol: api.ProtoTCP, U8Proto: 6,
 		allowsAllAtL3:   true,
-		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector},
+		CachedSelectors: regeneration.CachedSelectorSlice{wildcardCachedSelector},
 		L7Parser:        "http", L7RulesPerEp: l7map, Ingress: true,
 		DerivedFromRules: labels.LabelArrayList{nil},
 	}
@@ -94,14 +95,14 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 	expected.Egress["3000/TCP"] = &L4Filter{
 		Port: 3000, Protocol: api.ProtoTCP, U8Proto: 6, Ingress: false,
 		allowsAllAtL3:    true,
-		CachedSelectors:  CachedSelectorSlice{wildcardCachedSelector},
+		CachedSelectors:  regeneration.CachedSelectorSlice{wildcardCachedSelector},
 		L7RulesPerEp:     L7DataMap{},
 		DerivedFromRules: labels.LabelArrayList{nil},
 	}
 	expected.Egress["3000/UDP"] = &L4Filter{
 		Port: 3000, Protocol: api.ProtoUDP, U8Proto: 17, Ingress: false,
 		allowsAllAtL3:    true,
-		CachedSelectors:  CachedSelectorSlice{wildcardCachedSelector},
+		CachedSelectors:  regeneration.CachedSelectorSlice{wildcardCachedSelector},
 		L7RulesPerEp:     L7DataMap{},
 		DerivedFromRules: labels.LabelArrayList{nil},
 	}
@@ -187,7 +188,7 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 		Protocol:        api.ProtoTCP,
 		U8Proto:         6,
 		allowsAllAtL3:   true,
-		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector},
+		CachedSelectors: regeneration.CachedSelectorSlice{wildcardCachedSelector},
 		L7Parser:        ParserTypeHTTP,
 		L7RulesPerEp: L7DataMap{
 			wildcardCachedSelector: api.L7Rules{
@@ -200,14 +201,14 @@ func (ds *PolicyTestSuite) TestL4Policy(c *C) {
 	expected.Egress["3000/TCP"] = &L4Filter{
 		Port: 3000, Protocol: api.ProtoTCP, U8Proto: 6, Ingress: false,
 		allowsAllAtL3:    true,
-		CachedSelectors:  CachedSelectorSlice{wildcardCachedSelector},
+		CachedSelectors:  regeneration.CachedSelectorSlice{wildcardCachedSelector},
 		L7RulesPerEp:     L7DataMap{},
 		DerivedFromRules: labels.LabelArrayList{nil},
 	}
 	expected.Egress["3000/UDP"] = &L4Filter{
 		Port: 3000, Protocol: api.ProtoUDP, U8Proto: 17, Ingress: false,
 		allowsAllAtL3:    true,
-		CachedSelectors:  CachedSelectorSlice{wildcardCachedSelector},
+		CachedSelectors:  regeneration.CachedSelectorSlice{wildcardCachedSelector},
 		L7RulesPerEp:     L7DataMap{},
 		DerivedFromRules: labels.LabelArrayList{nil},
 	}
@@ -279,7 +280,7 @@ func (ds *PolicyTestSuite) TestMergeL4PolicyIngress(c *C) {
 		},
 	}
 
-	mergedES := CachedSelectorSlice{cachedFooSelector, cachedBazSelector}
+	mergedES := regeneration.CachedSelectorSlice{cachedFooSelector, cachedBazSelector}
 	expected := L4PolicyMap{"80/TCP": &L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6, CachedSelectors: mergedES,
 		L7Parser: ParserTypeNone, L7RulesPerEp: L7DataMap{}, Ingress: true,
@@ -331,7 +332,7 @@ func (ds *PolicyTestSuite) TestMergeL4PolicyEgress(c *C) {
 		},
 	}
 
-	mergedES := CachedSelectorSlice{cachedFooSelector, cachedBazSelector}
+	mergedES := regeneration.CachedSelectorSlice{cachedFooSelector, cachedBazSelector}
 	expected := L4PolicyMap{"80/TCP": &L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6, CachedSelectors: mergedES,
 		L7Parser: ParserTypeNone, L7RulesPerEp: L7DataMap{}, Ingress: false,
@@ -404,7 +405,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
 		Protocol:        api.ProtoTCP,
 		U8Proto:         6,
 		allowsAllAtL3:   true,
-		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector},
+		CachedSelectors: regeneration.CachedSelectorSlice{wildcardCachedSelector},
 		L7Parser:        ParserTypeHTTP,
 		L7RulesPerEp: L7DataMap{
 			wildcardCachedSelector: api.L7Rules{
@@ -479,7 +480,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
 	expected = L4PolicyMap{"80/TCP": &L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		allowsAllAtL3:   true,
-		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector},
+		CachedSelectors: regeneration.CachedSelectorSlice{wildcardCachedSelector},
 		L7Parser:        "kafka", L7RulesPerEp: l7map, Ingress: true,
 		DerivedFromRules: labels.LabelArrayList{nil, nil},
 	}}
@@ -564,7 +565,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
 	expected = L4PolicyMap{"80/TCP": &L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		allowsAllAtL3:   true,
-		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector},
+		CachedSelectors: regeneration.CachedSelectorSlice{wildcardCachedSelector},
 		L7Parser:        "kafka", L7RulesPerEp: l7map, Ingress: true,
 		DerivedFromRules: labels.LabelArrayList{nil, nil},
 	}}
@@ -631,7 +632,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 	expected := L4PolicyMap{"80/TCP": &L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		allowsAllAtL3:   true,
-		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector},
+		CachedSelectors: regeneration.CachedSelectorSlice{wildcardCachedSelector},
 		L7Parser:        ParserTypeHTTP,
 		L7RulesPerEp: L7DataMap{
 			wildcardCachedSelector: api.L7Rules{
@@ -705,7 +706,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 	expected = L4PolicyMap{"80/TCP": &L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		allowsAllAtL3:   true,
-		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector},
+		CachedSelectors: regeneration.CachedSelectorSlice{wildcardCachedSelector},
 		L7Parser:        ParserTypeKafka,
 		L7RulesPerEp: L7DataMap{
 			wildcardCachedSelector: api.L7Rules{
@@ -792,7 +793,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 	expected = L4PolicyMap{"80/TCP": &L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		allowsAllAtL3:   true,
-		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector},
+		CachedSelectors: regeneration.CachedSelectorSlice{wildcardCachedSelector},
 		L7Parser:        "kafka", L7RulesPerEp: l7map, Ingress: false,
 		DerivedFromRules: labels.LabelArrayList{nil, nil},
 	}}

--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 
 	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -27,7 +28,7 @@ import (
 // to be written with []*rule as a receiver.
 type ruleSlice []*rule
 
-func (rules ruleSlice) wildcardL3L4Rules(ingress bool, l4Policy L4PolicyMap, requirements []v1.LabelSelectorRequirement, selectorCache *SelectorCache) {
+func (rules ruleSlice) wildcardL3L4Rules(ingress bool, l4Policy L4PolicyMap, requirements []v1.LabelSelectorRequirement, selectorCache regeneration.SelectorCache) {
 	// Duplicate L3-only rules into wildcard L7 rules.
 	for _, r := range rules {
 		if ingress {
@@ -102,7 +103,7 @@ func (rules ruleSlice) wildcardL3L4Rules(ingress bool, l4Policy L4PolicyMap, req
 	}
 }
 
-func (rules ruleSlice) resolveL4IngressPolicy(ctx *SearchContext, revision uint64, selectorCache *SelectorCache) (L4PolicyMap, error) {
+func (rules ruleSlice) resolveL4IngressPolicy(ctx *SearchContext, revision uint64, selectorCache regeneration.SelectorCache) (L4PolicyMap, error) {
 	result := L4PolicyMap{}
 
 	ctx.PolicyTrace("\n")
@@ -152,7 +153,7 @@ func (rules ruleSlice) resolveL4IngressPolicy(ctx *SearchContext, revision uint6
 	return result, nil
 }
 
-func (rules ruleSlice) resolveL4EgressPolicy(ctx *SearchContext, revision uint64, selectorCache *SelectorCache) (L4PolicyMap, error) {
+func (rules ruleSlice) resolveL4EgressPolicy(ctx *SearchContext, revision uint64, selectorCache regeneration.SelectorCache) (L4PolicyMap, error) {
 	result := L4PolicyMap{}
 
 	ctx.PolicyTrace("\n")

--- a/pkg/proxy/dns.go
+++ b/pkg/proxy/dns.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy/logger"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/revert"
 	"github.com/miekg/dns"
 	"github.com/sirupsen/logrus"
@@ -94,7 +95,7 @@ func (dr *dnsRedirect) setRules(wg *completion.WaitGroup, newRules policy.L7Data
 // UpdateRules atomically replaces the proxy rules in effect for this redirect.
 // It is not aware of revision number and doesn't account for out-of-order
 // calls to UpdateRules or the returned RevertFunc.
-func (dr *dnsRedirect) UpdateRules(wg *completion.WaitGroup, l4 *policy.L4Filter) (revert.RevertFunc, error) {
+func (dr *dnsRedirect) UpdateRules(wg *completion.WaitGroup, l4 regeneration.PolicyL4Filter) (revert.RevertFunc, error) {
 	oldRules := dr.currentRules
 	err := dr.setRules(wg, dr.redirect.rules)
 	revertFunc := func() error {

--- a/pkg/proxy/envoyproxy.go
+++ b/pkg/proxy/envoyproxy.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/revert"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 )
 
 // the global Envoy instance
@@ -61,7 +62,7 @@ func createEnvoyRedirect(r *Redirect, stateDir string, xdsServer *envoy.XDSServe
 
 // UpdateRules is a no-op for envoy, as redirect data is synchronized via the
 // xDS cache.
-func (k *envoyRedirect) UpdateRules(wg *completion.WaitGroup, l4 *policy.L4Filter) (revert.RevertFunc, error) {
+func (k *envoyRedirect) UpdateRules(wg *completion.WaitGroup, l4 regeneration.PolicyL4Filter) (revert.RevertFunc, error) {
 	return func() error { return nil }, nil
 }
 

--- a/pkg/proxy/kafka.go
+++ b/pkg/proxy/kafka.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/proxy/logger"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 
 	"github.com/optiopay/kafka/proto"
 	"github.com/sirupsen/logrus"
@@ -517,7 +518,7 @@ func (k *kafkaRedirect) handleResponseConnection(pair *connectionPair, correlati
 
 // UpdateRules is a no-op for kafka redirects, as rules are read directly
 // during request processing.
-func (k *kafkaRedirect) UpdateRules(wg *completion.WaitGroup, l4 *policy.L4Filter) (revert.RevertFunc, error) {
+func (k *kafkaRedirect) UpdateRules(wg *completion.WaitGroup, l4 regeneration.PolicyL4Filter) (revert.RevertFunc, error) {
 	return func() error { return nil }, nil
 }
 

--- a/pkg/proxy/kafka_test.go
+++ b/pkg/proxy/kafka_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/cilium/cilium/common/addressing"
 	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
@@ -57,7 +58,7 @@ func (s *proxyTestSuite) SetUpSuite(c *C) {
 
 type DummySelectorCacheUser struct{}
 
-func (d *DummySelectorCacheUser) IdentitySelectionUpdated(selector policy.CachedSelector, selections, added, deleted []identity.NumericIdentity) {
+func (d *DummySelectorCacheUser) IdentitySelectionUpdated(selector regeneration.CachedSelector, selections, added, deleted []identity.NumericIdentity) {
 }
 
 var (

--- a/pkg/proxy/redirect.go
+++ b/pkg/proxy/redirect.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy/logger"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 )
 
 // RedirectImplementation is the generic proxy redirect interface that each
@@ -33,7 +34,7 @@ type RedirectImplementation interface {
 	// until it is complete.
 	// The returned RevertFunc must be non-nil.
 	// Note: UpdateRules is not called when a redirect is created.
-	UpdateRules(wg *completion.WaitGroup, l4 *policy.L4Filter) (revert.RevertFunc, error)
+	UpdateRules(wg *completion.WaitGroup, l4 regeneration.PolicyL4Filter) (revert.RevertFunc, error)
 
 	// Close closes and cleans up resources associated with the redirect
 	// implementation. The implementation should .Add to the WaitGroup if the
@@ -73,12 +74,10 @@ func newRedirect(localEndpoint logger.EndpointUpdater, listener *ProxyPort, dstP
 // updateRules updates the rules of the redirect, Redirect.mutex must be held
 // 'implementation' is not initialized when this is called the first time.
 // TODO: Replace this with RedirectImplementation UpdateRules method!
-func (r *Redirect) updateRules(l4 *policy.L4Filter) revert.RevertFunc {
+func (r *Redirect) updateRules(l4 regeneration.PolicyL4Filter) revert.RevertFunc {
 	oldRules := r.rules
-	r.rules = make(policy.L7DataMap, len(l4.L7RulesPerEp))
-	for key, val := range l4.L7RulesPerEp {
-		r.rules[key] = val
-	}
+	r.rules = l4.GetL7RulesPerEpCopy()
+
 	return func() error {
 		r.mutex.Lock()
 		r.rules = oldRules


### PR DESCRIPTION
This is with reference to the issue #8364 
The aim of the issue was to remove the dependency of `pkg/policy` from `pkg/endpoint/regeneration`, similar to what @aanm did in #8339. We are trying to loosen the dependency between policy and endpoint.

This is an experimental PR to see how much change to the code is required to bring out the desired functionality and does the existence of the existing/created interfaces made sense to actually carry out the refactor.

The process of splitting out the two code packages seems to turn out very ugly as in the Pull Request. As mentioned by @joestringer the way the code looks does not make sense as to how Go sees the structure of interfaces. Interfaces should be declared where they are used to reduce the dependencies between the packages, but the above code has a lot of policy-related interfaces lying in `/pkg/endpoint/regeneration` which does not look very great. The code is leading us to a position where we won't be having any dependency of `pkg/policy` in `pkg/endpoint/regeneration` but a strong one of `pkg/endpoint/regeneration` in the policy.

We will be discussing the same on Slack to see what others think about this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8542)
<!-- Reviewable:end -->
