### PR TITLE
pkg/{kvstore,node}: delay node delete event in kvstore

### DIFF
--- a/pkg/node/store/store.go
+++ b/pkg/node/store/store.go
@@ -16,9 +16,7 @@ package store
 
 import (
 	"path"
-	"time"
 
-	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/kvstore"
@@ -101,26 +99,16 @@ func (o *NodeObserver) OnDelete(k store.NamedKey) {
 		nodeCopy := n.DeepCopy()
 		nodeCopy.Source = node.FromKVStore
 
-		go func() {
-			time.Sleep(defaults.NodeDeleteDelay)
+		o.manager.NodeDeleted(*nodeCopy)
 
-			if o.manager.Exists(nodeCopy.Identity()) {
-				log.Warningf("Received node delete event for node %s which re-appeared within %s",
-					nodeCopy.Name, defaults.NodeDeleteDelay)
-				return
-			}
-
-			o.manager.NodeDeleted(*nodeCopy)
-
-			ciliumIPv4 := nodeCopy.GetCiliumInternalIP(false)
-			if ciliumIPv4 != nil {
-				ipcache.IPIdentityCache.Delete(ciliumIPv4.String(), ipcache.FromKVStore)
-			}
-			ciliumIPv6 := nodeCopy.GetCiliumInternalIP(true)
-			if ciliumIPv6 != nil {
-				ipcache.IPIdentityCache.Delete(ciliumIPv6.String(), ipcache.FromKVStore)
-			}
-		}()
+		ciliumIPv4 := nodeCopy.GetCiliumInternalIP(false)
+		if ciliumIPv4 != nil {
+			ipcache.IPIdentityCache.Delete(ciliumIPv4.String(), ipcache.FromKVStore)
+		}
+		ciliumIPv6 := nodeCopy.GetCiliumInternalIP(true)
+		if ciliumIPv6 != nil {
+			ipcache.IPIdentityCache.Delete(ciliumIPv6.String(), ipcache.FromKVStore)
+		}
 	}
 }
 


### PR DESCRIPTION
Instead of checking if the node is still present in the observer, we
should check if the node is still present in the store instead. Checking
if the node is still available in the observer is irrelevant as the node
will never be deleted since the check for its existence in the store
will always be true.

Intead, delay the propagation of the deletion event to the observer in
the store itself.

Fixes: 3137ad5eee6c ("node: Delay handling of node delete events received via kvstore")
Signed-off-by: André Martins <andre@cilium.io>

```release-note
Remove leftover nodes from cilium node list
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8544)
<!-- Reviewable:end -->
