### PR TITLE
update golang to 1.12.7 for cilium-{operator,docker-plugin}

### DIFF
--- a/cilium-docker-plugin.Dockerfile
+++ b/cilium-docker-plugin.Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.12.1 as builder
+FROM docker.io/library/golang:1.12.7 as builder
 LABEL maintainer="maintainer@cilium.io"
 ADD . /go/src/github.com/cilium/cilium
 WORKDIR /go/src/github.com/cilium/cilium/plugins/cilium-docker

--- a/cilium-operator.Dockerfile
+++ b/cilium-operator.Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.12.1 as builder
+FROM docker.io/library/golang:1.12.7 as builder
 LABEL maintainer="maintainer@cilium.io"
 ADD . /go/src/github.com/cilium/cilium
 WORKDIR /go/src/github.com/cilium/cilium/operator


### PR DESCRIPTION
Fixes: 7266476ee5a9 ("update to golang 1.12.7")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8546)
<!-- Reviewable:end -->
