### PR TITLE
operator: restart non-managed kube-dns pods before connecting to etcd

### DIFF
--- a/operator/main.go
+++ b/operator/main.go
@@ -203,6 +203,15 @@ func runOperator(cmd *cobra.Command) {
 			k8sversion.Version(), k8sversion.MinimalVersionConstraint)
 	}
 
+	// Restart kube-dns as soon as possible since it helps etcd-operator to be
+	// properly setup. If kube-dns is not managed by Cilium it can prevent
+	// etcd from reaching out kube-dns in EKS.
+	if option.Config.DisableCiliumEndpointCRD {
+		log.Infof("KubeDNS unmanaged pods controller disabled as %q option is set to 'disabled' in Cilium ConfigMap", option.DisableCiliumEndpointCRDName)
+	} else {
+		enableUnmanagedKubeDNSController()
+	}
+
 	enableENI = viper.GetString(option.IPAM) == option.IPAMENI
 	if enableENI {
 		awsClientQPSLimit := viper.GetFloat64(option.AWSClientQPSLimit)
@@ -285,13 +294,6 @@ func runOperator(cmd *cobra.Command) {
 	if identityGCInterval != time.Duration(0) {
 		startIdentityGC()
 	}
-
-	if option.Config.DisableCiliumEndpointCRD {
-		log.Infof("KubeDNS unmanaged pods controller disabled as %q option is set to 'disabled' in Cilium ConfigMap", option.DisableCiliumEndpointCRDName)
-	} else {
-		enableUnmanagedKubeDNSController()
-	}
-
 	err := enableCNPWatcher()
 	if err != nil {
 		log.WithError(err).WithField("subsys", "CNPWatcher").Fatal(


### PR DESCRIPTION
In a new cluster, if [kube|core]-dns is not being managed by Cilium it
can make etcd, from cilium-etcd-operator, on not being able to reach
[kube|core]-dns. Restarting [kube|core]-dns to force it to be managed by
Cilium will make etcd cluster to be able to be setup properly. Since
cilium-operator blocks until it gets connectivity with etcd it will
never restart [kube|core]-dns as the restart of such pod happens after
cilium-operator gets connectivity with etcd.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8547)
<!-- Reviewable:end -->
