### PR TITLE
test: misc. runtime policy test fixes

### DIFF
--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -259,8 +259,11 @@ var _ = Describe("RuntimePolicies", func() {
 
 	BeforeAll(func() {
 		vm = helpers.InitRuntimeHelper(helpers.Runtime, logger)
+		// Make sure that Cilium is started with appropriate CLI options
+		// (specifically to exclude the local addresses that are populated for
+		// CIDR policy tests).
+		Expect(vm.SetUpCilium()).To(BeNil())
 		ExpectCiliumReady(vm)
-
 		vm.SampleContainersActions(helpers.Create, helpers.CiliumDockerNetwork)
 		vm.PolicyDelAll()
 
@@ -1528,7 +1531,7 @@ var _ = Describe("RuntimePolicies", func() {
 					curlFailures++
 				}
 			}
-			Expect(curlFailures).To(BeNumerically("<=", 1), "Curl to %q have failed more than once")
+			Expect(curlFailures).To(BeNumerically("<=", 1), "Curl to %q have failed more than once", cloudFlare)
 
 			By("Pinging %q from %q (should not work)", api.EntityHost, helpers.App1)
 			res = vm.ContainerExec(helpers.App1, helpers.Ping(cloudFlare))


### PR DESCRIPTION
* Ensure that Cilium is started with the set of configuration options
set in `SetUpCilium`, specifically of excluding of local addresses
that are used to simulate external IPs for CIDR policy testing.
* Fix a log error message to contain a string that was expected.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8548)
<!-- Reviewable:end -->
