### PR TITLE
RFC: endpoint: change transition from restore state

### DIFF
--- a/daemon/state.go
+++ b/daemon/state.go
@@ -345,22 +345,8 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) (resto
 			// parts of the identity not being marshaled to JSON. Hence we must set
 			// the identity even if has not changed.
 			ep.SetIdentity(identity)
-
-			if ep.GetStateLocked() == endpoint.StateWaitingToRegenerate {
-				ep.Unlock()
-				// EP is already waiting to regenerate. This is no error so no logging.
-				epRegenerated <- false
-				return
-			}
-
-			ready := ep.SetStateLocked(endpoint.StateWaitingToRegenerate, "Triggering synchronous endpoint regeneration while syncing state to host")
 			ep.Unlock()
 
-			if !ready {
-				scopedLog.WithField(logfields.EndpointState, ep.GetState()).Warn("Endpoint in inconsistent state")
-				epRegenerated <- false
-				return
-			}
 			regenerationMetadata := &regeneration.ExternalRegenerationMetadata{
 				Reason: "syncing state to host",
 			}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1597,7 +1597,7 @@ func (e *Endpoint) SetStateLocked(toState, reason string) bool {
 		}
 	case StateRestoring:
 		switch toState {
-		case StateDisconnecting, StateWaitingToRegenerate, StateRestoring:
+		case StateDisconnecting, StateRestoring:
 			goto OKState
 		}
 	}
@@ -1640,7 +1640,7 @@ func (e *Endpoint) BuilderSetStateLocked(toState, reason string) bool {
 	switch fromState { // From state
 	case StateCreating, StateWaitingForIdentity, StateReady, StateDisconnecting, StateDisconnected:
 		// No valid transitions for the builder
-	case StateWaitingToRegenerate:
+	case StateWaitingToRegenerate, StateRestoring:
 		switch toState {
 		// Builder transitions the endpoint from
 		// waiting-to-regenerate state to regenerating state

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -285,6 +285,10 @@ func (s *EndpointSuite) TestEndpointState(c *C) {
 	// Builder transitions to ready state after build is done
 	c.Assert(e.BuilderSetStateLocked(StateReady, "test"), Equals, true)
 
+	// Check that direct transition from restoring --> regenerating is valid.
+	e.state = StateRestoring
+	c.Assert(e.BuilderSetStateLocked(StateRegenerating, "test"), Equals, true)
+
 	// Typical lifecycle
 	e.state = StateCreating
 	c.Assert(e.SetStateLocked(StateWaitingForIdentity, "test"), Equals, true)
@@ -310,6 +314,15 @@ func (s *EndpointSuite) TestEndpointState(c *C) {
 	// parallel disconnect fails
 	c.Assert(e.SetStateLocked(StateDisconnecting, "test"), Equals, false)
 	c.Assert(e.SetStateLocked(StateDisconnected, "test"), Equals, true)
+
+	// Restoring state
+	e.state = StateRestoring
+	c.Assert(e.SetStateLocked(StateWaitingToRegenerate, "test"), Equals, false)
+	c.Assert(e.SetStateLocked(StateDisconnecting, "test"), Equals, true)
+
+	e.state = StateRestoring
+	c.Assert(e.SetStateLocked(StateRestoring, "test"), Equals, true)
+
 }
 
 func (s *EndpointSuite) TestWaitForPolicyRevision(c *C) {


### PR DESCRIPTION
Restoring state for an endpoint is quite a special case for the endpoint; it only occurs once per-endpoint per-run of cilium-agent. Whenever we restore an endpoint, we have specific logic within the restoration process which queues it for a regeneration.
Allowing the transition from restoring state to waiting to regenerate means that
if the endpoint is exposed to the rest of the cilium-agent via the
endpointmanager, that while an endpoint is in restoring state, another thread
could change its state, and the endpoint would regenerate out-of-band of the
restoring goroutine for the endpoint. This has produced noise in our CI because
the regeneration triggered via the restore goroutine triggered for endpoints has
failed when the endpoint is restored, exposed to the endpointmanager, and
another goroutine swoops in and begins to restore it, putting it into a state
which restoring state cannot transition into. When the restore goroutine then
tries to regenerate the endpoint, it is no longer in a state which is valid for
regeneration, and the regeneration fails, putting the endpoint into a not-ready
state.

So, remove the transition from restoring to waiting-to-regenerate state. All
other code in Cilium tries to set the endpoint into waiting-to-regenerate state,
which will fail if it is in restoring state. However, the restoring goroutine
will be able to transition into regenerating state directly.

This semantically makes sense since restoring is a special case, and we want to
guarantee exclusivity of regenerating the endpoint for the first time to just
the restoring goroutine.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8551)
<!-- Reviewable:end -->
