### PR TITLE
health: Add ability to restrict listener address

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -66,6 +66,7 @@ cilium-agent [flags]
       --flannel-master-device string               Installs a BPF program to allow for policy enforcement in the given network interface. Allows to run Cilium on top of other CNI plugins that provide networking, e.g. flannel, where for flannel, this value should be set with 'cni0'. [EXPERIMENTAL]
       --flannel-uninstall-on-exit                  When used along the flannel-master-device flag, it cleans up all BPF programs installed when Cilium agent is terminated.
       --force-local-policy-eval-at-source          Force policy evaluation of all local communication at the source endpoint (default true)
+      --health-serve-addr string                   IP:Port on which the cilium health host connectivity check responds (pass ":Port" to bind on all interfaces) (default ":4240")
   -h, --help                                       help for cilium-agent
       --host-reachable-services-protos strings     Only enable reachability of services for host applications for specific protocols (default [tcp,udp])
       --http-idle-timeout uint                     Time after which a non-gRPC HTTP stream is considered failed unless traffic in the stream has been processed (in seconds); defaults to 0 (unlimited)

--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -31,7 +31,6 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint/connector"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/endpointmanager"
-	healthDefaults "github.com/cilium/cilium/pkg/health/defaults"
 	"github.com/cilium/cilium/pkg/health/probe"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/launcher"
@@ -278,9 +277,14 @@ func LaunchAsEndpoint(baseCtx context.Context, owner regeneration.Owner, n *node
 		return nil, fmt.Errorf("failed configure health interface %q: %s", epIfaceName, err)
 	}
 
+	_, port, err := net.SplitHostPort(option.Config.HealthServeAddr)
+	if err != nil {
+		return nil, err
+	}
+
 	pidfile := filepath.Join(option.Config.StateDir, PidfilePath)
 	prog := "ip"
-	args := []string{"netns", "exec", netNSName, binaryName, "--pidfile", pidfile}
+	args := []string{"netns", "exec", netNSName, binaryName, "--listen", ":" + port, "--pidfile", pidfile}
 	cmd.SetTarget(prog)
 	cmd.SetArgs(args)
 	log.Infof("Spawning health endpoint with command %q %q", prog, args)
@@ -330,7 +334,7 @@ func LaunchAsEndpoint(baseCtx context.Context, owner regeneration.Owner, n *node
 
 	// Initialize the health client to talk to this instance. This is why
 	// the caller must limit usage of this package to a single goroutine.
-	client, err := probe.NewClient("http://" + net.JoinHostPort(healthIP.String(), fmt.Sprintf("%d", healthDefaults.HTTPPathPort)))
+	client, err := probe.NewClient("http://" + net.JoinHostPort(healthIP.String(), port))
 	if err != nil {
 		return nil, fmt.Errorf("Cannot establish connection to health endpoint: %s", err)
 	}

--- a/cilium-health/launch/launcher.go
+++ b/cilium-health/launch/launcher.go
@@ -59,6 +59,7 @@ func Launch() (*CiliumHealth, error) {
 		Debug:         option.Config.Opts.IsEnabled(option.Debug),
 		ProbeInterval: serverProbeInterval,
 		ProbeDeadline: serverProbeDeadline,
+		TCPServerAddr: option.Config.HealthServeAddr,
 	}
 
 	ch.server, err = server.NewServer(config)

--- a/cilium-health/responder/Makefile
+++ b/cilium-health/responder/Makefile
@@ -1,7 +1,7 @@
 include ../../Makefile.defs
 
 TARGET=cilium-health-responder
-SOURCES := $(shell find ../../pkg/health/probe/responder . \( -name '*.go' ! -name '*_test.go' \))
+SOURCES := $(shell find ../../pkg/health/defaults ../../pkg/health/probe/responder ../../pkg/pidfile . \( -name '*.go' ! -name '*_test.go' \))
 $(TARGET): $(SOURCES)
 	@$(ECHO_GO)
 	$(QUIET)$(GO) build $(GOBUILD) -o $(TARGET)

--- a/cilium-health/responder/main.go
+++ b/cilium-health/responder/main.go
@@ -21,6 +21,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/cilium/cilium/pkg/health/defaults"
 	"github.com/cilium/cilium/pkg/health/probe/responder"
 	"github.com/cilium/cilium/pkg/pidfile"
 
@@ -39,17 +40,17 @@ func cancelOnSignal(cancel context.CancelFunc, sig ...os.Signal) {
 func main() {
 	var (
 		pidfilePath string
-		listen      int
+		listenAddr  string
 	)
 	flag.StringVar(&pidfilePath, "pidfile", "", "Write pid to the specified file")
-	flag.IntVar(&listen, "listen", 4240, "Port on which the responder listens")
+	flag.StringVar(&listenAddr, "listen", defaults.ServeAddr, "Address on which the responder listens")
 	flag.Parse()
 
 	// Shutdown gracefully to halt server and remove pidfile
 	ctx, cancel := context.WithCancel(context.Background())
 	cancelOnSignal(cancel, syscall.SIGINT, syscall.SIGHUP, syscall.SIGTERM, syscall.SIGQUIT)
 
-	srv := responder.NewServer(listen)
+	srv := responder.NewServer(listenAddr)
 	defer srv.Shutdown()
 	go func() {
 		if err := srv.Serve(); err != nil {

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -43,6 +43,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/flowdebug"
+	healthDefaults "github.com/cilium/cilium/pkg/health/defaults"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/k8s"
@@ -505,6 +506,9 @@ func init() {
 
 	flags.Bool(option.ForceLocalPolicyEvalAtSource, defaults.ForceLocalPolicyEvalAtSource, "Force policy evaluation of all local communication at the source endpoint")
 	option.BindEnv(option.ForceLocalPolicyEvalAtSource)
+
+	flags.String(option.HealthServeAddr, healthDefaults.ServeAddr, "IP:Port on which the cilium health host connectivity check responds (pass \":Port\" to bind on all interfaces)")
+	option.BindEnv(option.HealthServeAddr)
 
 	flags.String(option.HTTP403Message, "", "Message returned in proxy L7 403 body")
 	flags.MarkHidden(option.HTTP403Message)

--- a/pkg/health/defaults/defaults.go
+++ b/pkg/health/defaults/defaults.go
@@ -25,15 +25,6 @@ const (
 	// SockPathEnv is the environment variable to overwrite SockPath
 	SockPathEnv = "CILIUM_HEALTH_SOCK"
 
-	// HTTPPathPort is used for probing base HTTP path connectivity
-	HTTPPathPort = 4240
-
-	// L7PathPort is used for probing L7 path connectivity
-	L7PathPort = 4241
-
-	// ServicePathPort is used for probing service redirect path connectivity
-	ServicePathPort = 4242
-
-	// ServiceL7PathPort is used for probing service redirect path connectivity with L7
-	ServiceL7PathPort = 4243
+	// ServeAddr is the IP:Port on which the health host connectivity check listens on
+	ServeAddr = ":4240"
 )

--- a/pkg/health/probe/responder/responder.go
+++ b/pkg/health/probe/responder/responder.go
@@ -18,7 +18,6 @@ package responder
 // as this package typically runs in its own process
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"time"
 )
@@ -32,10 +31,10 @@ type Server struct {
 }
 
 // NewServer creates a new server listening on the given port
-func NewServer(port int) *Server {
+func NewServer(addr string) *Server {
 	return &Server{
 		http.Server{
-			Addr:    fmt.Sprintf(":%d", port),
+			Addr:    addr,
 			Handler: http.HandlerFunc(serverRequests),
 		},
 	}

--- a/pkg/health/server/server.go
+++ b/pkg/health/server/server.go
@@ -16,6 +16,8 @@ package server
 
 import (
 	"fmt"
+	"net"
+	"strconv"
 	"time"
 
 	"github.com/cilium/cilium/api/v1/client/daemon"
@@ -36,12 +38,6 @@ import (
 
 var (
 	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "health-server")
-
-	// PortToPaths is a convenience map for access to the ports and their
-	// common string representations
-	PortToPaths = map[int]string{
-		defaults.HTTPPathPort: "Via L3",
-	}
 )
 
 // Config stores the configuration data for a cilium-health server.
@@ -50,6 +46,7 @@ type Config struct {
 	CiliumURI     string
 	ProbeInterval time.Duration
 	ProbeDeadline time.Duration
+	TCPServerAddr string
 }
 
 // ipString is an IP address used as a more descriptive type name in maps.
@@ -70,8 +67,9 @@ type Server struct {
 	// a diff of the nodes added and removed based on this clientID.
 	clientID int64
 
-	tcpServers []*responder.Server // Servers for external pings
-	startTime  time.Time
+	tcpServer       *responder.Server // Server for external pings
+	tcpExternalPort int               // Port on which to ping external hosts
+	startTime       time.Time
 
 	// The lock protects against read and write access to the IP->Node map,
 	// the list of statuses as most recently seen, and the last time a
@@ -260,7 +258,7 @@ func (s *Server) runActiveServices() error {
 }
 
 // Serve spins up the following goroutines:
-// * TCP API Server: Responders to the health API "/hello" message, one per path
+// * TCP API Server: Responder to the health API "/hello" message
 // * Prober: Periodically run pings across the cluster at a configured interval
 //   and update the server's connectivity status cache.
 // * Unix API Server: Handle all health API requests over a unix socket.
@@ -269,12 +267,9 @@ func (s *Server) runActiveServices() error {
 func (s *Server) Serve() (err error) {
 	errors := make(chan error)
 
-	for i := range s.tcpServers {
-		srv := s.tcpServers[i]
-		go func() {
-			errors <- srv.Serve()
-		}()
-	}
+	go func() {
+		errors <- s.tcpServer.Serve()
+	}()
 
 	go func() {
 		errors <- s.runActiveServices()
@@ -287,9 +282,7 @@ func (s *Server) Serve() (err error) {
 
 // Shutdown server and clean up resources
 func (s *Server) Shutdown() {
-	for i := range s.tcpServers {
-		s.tcpServers[i].Shutdown()
-	}
+	s.tcpServer.Shutdown()
 	s.Server.Shutdown()
 }
 
@@ -318,7 +311,6 @@ func NewServer(config Config) (*Server, error) {
 	server := &Server{
 		startTime:    time.Now(),
 		Config:       config,
-		tcpServers:   []*responder.Server{},
 		connectivity: &healthReport{},
 	}
 
@@ -332,13 +324,18 @@ func NewServer(config Config) (*Server, error) {
 		return nil, err
 	}
 
+	_, tcpPort, err := net.SplitHostPort(config.TCPServerAddr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse health tcp serve address: %s", err)
+	}
+	server.tcpExternalPort, err = strconv.Atoi(tcpPort)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse health tcp serve port: %s", err)
+	}
+
 	server.Client = cl
 	server.Server = *server.newServer(swaggerSpec)
-
-	for port := range PortToPaths {
-		srv := responder.NewServer(port)
-		server.tcpServers = append(server.tcpServers, srv)
-	}
+	server.tcpServer = responder.NewServer(config.TCPServerAddr)
 
 	return server, nil
 }

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -31,10 +31,12 @@ import (
 	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/defaults"
+	healthDefaults "github.com/cilium/cilium/pkg/health/defaults"
 	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+
 	"github.com/cilium/cilium/pkg/metrics"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -138,6 +140,9 @@ const (
 	// FixedIdentityMapping is the key-value for the fixed identity mapping
 	// which allows to use reserved label for fixed identities
 	FixedIdentityMapping = "fixed-identity-mapping"
+
+	// HealthServeAddr is the IP:Port on which the cilium health host connectivity check is served
+	HealthServeAddr = "health-serve-addr"
 
 	// IPv4ClusterCIDRMaskSize is the mask size for the cluster wide CIDR
 	IPv4ClusterCIDRMaskSize = "ipv4-cluster-cidr-mask-size"
@@ -979,6 +984,9 @@ type DaemonConfig struct {
 	// health endpoints
 	EnableHealthChecking bool
 
+	// HealthServeAddr is the address the health host connectivity check listens on
+	HealthServeAddr string
+
 	// KVstoreKeepAliveInterval is the interval in which the lease is being
 	// renewed. This must be set to a value lesser than the LeaseTTL ideally
 	// by a factor of 3.
@@ -1127,6 +1135,7 @@ var (
 		EnableEndpointRoutes:         defaults.EnableEndpointRoutes,
 		AnnotateK8sNode:              defaults.AnnotateK8sNode,
 		AutoCreateCiliumNodeResource: defaults.AutoCreateCiliumNodeResource,
+		HealthServeAddr:              healthDefaults.ServeAddr,
 	}
 )
 
@@ -1436,6 +1445,7 @@ func (c *DaemonConfig) Populate() {
 	c.EnvoyLogPath = viper.GetString(EnvoyLog)
 	c.ForceLocalPolicyEvalAtSource = viper.GetBool(ForceLocalPolicyEvalAtSource)
 	c.HostDevice = getHostDevice()
+	c.HealthServeAddr = viper.GetString(HealthServeAddr)
 	c.HTTPIdleTimeout = viper.GetInt(HTTPIdleTimeout)
 	c.HTTPMaxGRPCTimeout = viper.GetInt(HTTPMaxGRPCTimeout)
 	c.HTTPRequestTimeout = viper.GetInt(HTTPRequestTimeout)


### PR DESCRIPTION
This commit introduces a new cilium-agent CLI option, `--health-serve-addr` and a corresponding environment variable `CILIUM_HEALTH_SERVE_ADDR`, to allow the user to restrict the address on which the cilium-health connectivity check responder listens on.

The listener address can be specified in the common `IP:Port` format. The `IP` part should always select an interfaces which is reachable from all other nodes. By default, all interfaces are bound. For the endpoint connectivity responder running inside the cluster network, only the `Port` portion is used.

This commit also removes unused code in the health package which was intended to support listening on multiple ports. That feature however was never completely implemented, therefore, the corresponding code is removed by this commit in order to support dynamic port selection.

Fixes: #8473

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8554)
<!-- Reviewable:end -->
