### PR TITLE
policy: explicitly return nil when returning nil SelectorPolicy interface

### DIFF
--- a/pkg/policy/distillery.go
+++ b/pkg/policy/distillery.go
@@ -72,11 +72,10 @@ func (cache *PolicyCache) lookupOrCreate(identity *identityPkg.Identity, create 
 		cip = newCachedSelectorPolicy(identity, cache.repo.GetSelectorCache())
 		cache.policies[identity.ID] = cip
 	}
-	computed := false
 	if cip != nil {
-		computed = cip.getPolicy().Revision > 0
+		return cip, cip.getPolicy().Revision > 0
 	}
-	return cip, computed
+	return nil, false
 }
 
 // insert adds the specified Identity to the policy cache, with a reference


### PR DESCRIPTION
In the `lookupOrCreate` function for a PolicyCache, a `SelectorPolicy` interface
is returned. Returning a nil implementation of this interface (e.g., a nil
`*cachedSelectorPolicy`) means that the returned value (an interface) is
non-nil, while the underlying value (the instance of the type implementing this
interface) is nil.

Fix this by explicitly checking if the implementation of the interface is
nil, and if so, return nil explicitly instead of the nil
`*cachedSelectorPolicy`. This fixes the following panic in Cilium:

```
2019-07-13T22:47:33.566905132Z panic: runtime error: invalid memory address or nil pointer dereference
2019-07-13T22:47:33.566925867Z [signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x2486023]
2019-07-13T22:47:33.566929611Z
2019-07-13T22:47:33.566933568Z goroutine 7362 [running]:
2019-07-13T22:47:33.566937662Z github.com/cilium/cilium/pkg/policy.(*cachedSelectorPolicy).getPolicy(...)
2019-07-13T22:47:33.56694222Z /go/src/github.com/cilium/cilium/pkg/policy/distillery.go:197
2019-07-13T22:47:33.566946516Z github.com/cilium/cilium/pkg/policy.(*cachedSelectorPolicy).Consume(0x0, 0x34cfb60, 0xc000520840, 0x0)
2019-07-13T22:47:33.566950518Z /go/src/github.com/cilium/cilium/pkg/policy/distillery.go:219 +0x23
2019-07-13T22:47:33.566954505Z github.com/cilium/cilium/pkg/endpoint.(*Endpoint).regeneratePolicy(0xc000520840, 0x355a6e0, 0xc0004a5200, 0x0, 0x0)
2019-07-13T22:47:33.566961164Z /go/src/github.com/cilium/cilium/pkg/endpoint/policy.go:159 +0x45a
2019-07-13T22:47:33.567055159Z github.com/cilium/cilium/pkg/endpoint.(*Endpoint).runPreCompilationSteps(0xc000520840, 0x355a6e0, 0xc0004a5200, 0xc0012ec280, 0x0, 0x0)
2019-07-13T22:47:33.567065171Z /go/src/github.com/cilium/cilium/pkg/endpoint/bpf.go:617 +0xf4e
2019-07-13T22:47:33.567122531Z github.com/cilium/cilium/pkg/endpoint.(*Endpoint).regenerateBPF(0xc000520840, 0x355a6e0, 0xc0004a5200, 0xc0012ec280, 0x0, 0x0, 0x0, 0x0)
2019-07-13T22:47:33.567129072Z /go/src/github.com/cilium/cilium/pkg/endpoint/bpf.go:382 +0x1cc
2019-07-13T22:47:33.567213177Z github.com/cilium/cilium/pkg/endpoint.(*Endpoint).regenerate(0xc000520840, 0x355a6e0, 0xc0004a5200, 0xc0012ec280, 0x0, 0x0)
2019-07-13T22:47:33.5672276Z /go/src/github.com/cilium/cilium/pkg/endpoint/policy.go:321 +0xb43
2019-07-13T22:47:33.567230564Z github.com/cilium/cilium/pkg/endpoint.(*EndpointRegenerationEvent).Handle(0xc001761f40, 0xc0014d2ae0)
2019-07-13T22:47:33.567234123Z /go/src/github.com/cilium/cilium/pkg/endpoint/events.go:57 +0x4a9
2019-07-13T22:47:33.567237962Z github.com/cilium/cilium/pkg/eventqueue.(*EventQueue).Run.func1()
2019-07-13T22:47:33.567241862Z /go/src/github.com/cilium/cilium/pkg/eventqueue/eventqueue.go:240 +0x150
2019-07-13T22:47:33.567246316Z sync.(*Once).Do(0xc00086af68, 0xc0003ccc20)
2019-07-13T22:47:33.56725045Z /usr/local/go/src/sync/once.go:44 +0xb3
2019-07-13T22:47:33.567254325Z created by github.com/cilium/cilium/pkg/eventqueue.(*EventQueue).Run
2019-07-13T22:47:33.567342327Z /go/src/github.com/cilium/cilium/pkg/eventqueue/eventqueue.go:229 +0xaa
```

In this case, we should never really be returning a nil `SelectorPolicy`, but
functions in `pkg/endpoint` which use it check if the returned interface is nil.
But, that is outside of the scope of this commit.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #8563 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8567)
<!-- Reviewable:end -->
