### PR TITLE
Allow disabling the kvstore

### DIFF
--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -1358,7 +1358,11 @@ func runDaemon() {
 	// subsystem as well in parallel so caches will start to be synchronized
 	// with k8s.
 	k8sCachesSynced := d.initK8sSubsystem()
-	d.initKVStore()
+	if option.Config.KVStore == "" {
+		log.Info("Skipping kvstore configuration")
+	} else {
+		d.initKVStore()
+	}
 
 	// Wait only for certain caches, but not all!
 	// (Check Daemon.initK8sSubsystem() for more info)

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -78,6 +78,8 @@ type DaemonSuite struct {
 
 func TestMain(m *testing.M) {
 	option.Config.Populate()
+	option.Config.IdentityAllocationMode = option.IdentityAllocationModeKVstore
+
 	time.Local = time.UTC
 	tempRunDir, err := ioutil.TempDir("", "cilium-test-run")
 	if err != nil {

--- a/daemon/status.go
+++ b/daemon/status.go
@@ -383,7 +383,11 @@ func (d *Daemon) startStatusCollector() {
 		{
 			Name: "kvstore",
 			Probe: func(ctx context.Context) (interface{}, error) {
-				return kvstore.Client().Status()
+				if option.Config.KVStore == "" {
+					return models.StatusStateDisabled, nil
+				} else {
+					return kvstore.Client().Status()
+				}
 			},
 			OnStatusUpdate: func(status status.Status) {
 				var msg string

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -174,6 +174,10 @@ const (
 	// KVstoreConnectivityTimeout is the timeout when performing kvstore operations
 	KVstoreConnectivityTimeout = 2 * time.Minute
 
+	// KVStoreStaleLockTimeout is the timeout for when a lock is held for
+	// a kvstore path for too long.
+	KVStoreStaleLockTimeout = 30 * time.Second
+
 	// IPAllocationTimeout is the timeout when allocating CIDRs
 	IPAllocationTimeout = 2 * time.Minute
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1689,6 +1689,16 @@ func (c *DaemonConfig) Populate() {
 	default:
 		log.Fatalf("Invalid identity allocation mode %q. It must be one of %s or %s", c.IdentityAllocationMode, IdentityAllocationModeKVstore, IdentityAllocationModeCRD)
 	}
+	if c.KVStore == "" {
+		if c.IdentityAllocationMode != IdentityAllocationModeCRD {
+			log.Warningf("Running Cilium with %q=%q requires identity allocation via CRDs. Changing %s to %q", KVStore, c.KVStore, IdentityAllocationMode, IdentityAllocationModeCRD)
+			c.IdentityAllocationMode = IdentityAllocationModeCRD
+		}
+		if c.DisableCiliumEndpointCRD {
+			log.Warningf("Running Cilium with %q=%q requires endpoint CRDs. Changing %s to %t", KVStore, c.KVStore, DisableCiliumEndpointCRDName, false)
+			c.DisableCiliumEndpointCRD = false
+		}
+	}
 
 	// Hidden options
 	c.ConfigFile = viper.GetString(ConfigFile)


### PR DESCRIPTION
Remaining known kvstore dependencies:
* [x] KVstore initialization
* [x] `pkg/kvstore/lock.go:init()`

Future work:
* [ ] IPCache (Needs conversion over to CEP)
* [ ] Node Discovery (maybe just needs an extra check to ensure kvstore="" sets node discovery via CRD?)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8572)
<!-- Reviewable:end -->
