### PR TITLE
labels: Do not filter out app.kubernetes.io prefix

### DIFF
--- a/pkg/k8s/apis/cilium.io/const.go
+++ b/pkg/k8s/apis/cilium.io/const.go
@@ -50,6 +50,9 @@ const (
 	// PodNamespaceLabel is the label used in kubernetes containers to
 	// specify which namespace they belong to.
 	PodNamespaceLabel = "io.kubernetes.pod.namespace"
+	// AppKubernetes is the label which is recommended by the official k8s
+	// documentation ad the lablel for every resource object.
+	AppKubernetes = "app.kubernetes.io"
 	// CtrlPrefixPolicyStatus is the prefix used for the controllers set up
 	// to sync the CNP with kube-apiserver.
 	CtrlPrefixPolicyStatus = "sync-cnp-policy-status"

--- a/pkg/labels/filter.go
+++ b/pkg/labels/filter.go
@@ -159,10 +159,13 @@ func defaultLabelPrefixCfg() *labelPrefixCfg {
 	}
 
 	expressions := []string{
-		k8sConst.PodNamespaceLabel,      // include io.kubernetes.pod.namspace
+		k8sConst.PodNamespaceLabel,      // include io.kubernetes.pod.namespace
 		k8sConst.PodNamespaceMetaLabels, // include all namespace labels
+		k8sConst.AppKubernetes,          // include app.kubernetes.io
 		"!io.kubernetes",                // ignore all other io.kubernetes labels
-		"!.*kubernetes.io",              // ignore all other kubernetes.io labels (annotation.*.k8s.io)
+		"!kubernetes.io",                // ignore all other kubernetes.io labels
+		"!.*beta.kubernetes.io",         // ignore all beta.kubernetes.io labels
+		"!k8s.io",                       // ignore all k8s.io labels
 		"!pod-template-generation",      // ignore pod-template-generation
 		"!pod-template-hash",            // ignore pod-template-hash
 		"!controller-revision-hash",     // ignore controller-revision-hash

--- a/pkg/labels/filter_test.go
+++ b/pkg/labels/filter_test.go
@@ -33,6 +33,7 @@ func (s *LabelsPrefCfgSuite) TestFilterLabels(c *C) {
 		"id.lizards":                  NewLabel("id.lizards", "web", LabelSourceContainer),
 		"id.lizards.k8s":              NewLabel("id.lizards.k8s", "web", LabelSourceK8s),
 		"io.kubernetes.pod.namespace": NewLabel("io.kubernetes.pod.namespace", "default", LabelSourceContainer),
+		"app.kubernetes.io":           NewLabel("app.kubernetes.io", "my-nginx", LabelSourceContainer),
 	}
 
 	dlpcfg := defaultLabelPrefixCfg()
@@ -51,6 +52,9 @@ func (s *LabelsPrefCfgSuite) TestFilterLabels(c *C) {
 		"io.kubernetes.container.terminationMessagePath":            "",
 		"io.kubernetes.pod.name":                                    "my-nginx-3800858182-07i3n",
 		"io.kubernetes.pod.namespace":                               "default",
+		"app.kubernetes.io":                                         "my-nginx",
+		"kubernetes.io.foo":                                         "foo",
+		"beta.kubernetes.io.foo":                                    "foo",
 		"annotation.kubectl.kubernetes.io":                          "foo",
 		"annotation.hello":                                          "world",
 		"annotation." + k8sConst.CiliumIdentityAnnotationDeprecated: "12356",
@@ -63,11 +67,11 @@ func (s *LabelsPrefCfgSuite) TestFilterLabels(c *C) {
 	}
 	allLabels := Map2Labels(allNormalLabels, LabelSourceContainer)
 	filtered, _ := dlpcfg.filterLabels(allLabels)
-	c.Assert(len(filtered), Equals, 1)
+	c.Assert(len(filtered), Equals, 2)
 	allLabels["id.lizards"] = NewLabel("id.lizards", "web", LabelSourceContainer)
 	allLabels["id.lizards.k8s"] = NewLabel("id.lizards.k8s", "web", LabelSourceK8s)
 	filtered, _ = dlpcfg.filterLabels(allLabels)
-	c.Assert(len(filtered), Equals, 3)
+	c.Assert(len(filtered), Equals, 4)
 	c.Assert(filtered, checker.DeepEquals, wanted)
 	// Making sure we are deep copying the labels
 	allLabels["id.lizards"] = NewLabel("id.lizards", "web", "I can change this and doesn't affect any one")


### PR DESCRIPTION
Prefix app.kubernetes.io is recommended for labels and annotations and
it shouldn't be considered as a private label used internally by
Kubernetes. Instead, kubernetes.io and *beta.kubernetes.io should be
filtered out.

Fixes #8357

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8574)
<!-- Reviewable:end -->
