### PR TITLE
docs: Fix up unparsed SCM_WEB literals

### DIFF
--- a/Documentation/gettingstarted/k8s-install-eks.rst
+++ b/Documentation/gettingstarted/k8s-install-eks.rst
@@ -101,7 +101,7 @@ Prepare the nodes for Cilium
 
 Deploy the following DaemonSet to prepare all EKS nodes for Cilium:
 
-   .. code:: bash
+   .. parsed-literal::
 
        kubectl -n kube-system apply -f \ |SCM_WEB|\/examples/kubernetes/node-init/eks-node-init.yaml
 

--- a/Documentation/gettingstarted/kube-router.rst
+++ b/Documentation/gettingstarted/kube-router.rst
@@ -142,7 +142,7 @@ installed:
 
 You can test connectivity by deploying the following connectivity checker pods:
 
-.. code:: bash
+.. parsed-literal::
 
     $ kubectl create -f \ |SCM_WEB|\/examples/kubernetes/connectivity-check/connectivity-check.yaml
     $ kubectl get pods


### PR DESCRIPTION
These weren't being parsed, and so were rendered as SCM_WEB rather than
having the github link. Fix them up.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8575)
<!-- Reviewable:end -->
