### PR TITLE
test: add `ExecMiddle` function

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -34,6 +34,10 @@ var (
 	// long time to execute.
 	ShortCommandTimeout = 10 * time.Second
 
+	// MidCommandTimeout is a timeout for commands which may take a bit longer
+	// than ShortCommandTimeout, but less time than HelperTimeout to execute.
+	MidCommandTimeout = 30 * time.Second
+
 	// CiliumStartTimeout is a predefined timeout value for Cilium startup.
 	CiliumStartTimeout = 100 * time.Second
 

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -682,7 +682,7 @@ func (kub *Kubectl) Action(action ResourceLifeCycleAction, filePath string) *Cmd
 // Apply applies the Kubernetes manifest located at path filepath.
 func (kub *Kubectl) Apply(filePath string) *CmdRes {
 	kub.logger.Debugf("applying %s", filePath)
-	return kub.ExecShort(
+	return kub.ExecMiddle(
 		fmt.Sprintf("%s apply -f  %s", KubectlCmd, filePath))
 }
 

--- a/test/helpers/node.go
+++ b/test/helpers/node.go
@@ -178,6 +178,14 @@ func (s *SSHMeta) ExecShort(cmd string, options ...ExecOptions) *CmdRes {
 	return s.ExecContext(ctx, cmd, options...)
 }
 
+// ExecMiddle runs command with the provided options. It will take up to
+// MidCommandTimeout seconds to run the command before it times out.
+func (s *SSHMeta) ExecMiddle(cmd string, options ...ExecOptions) *CmdRes {
+	ctx, cancel := context.WithTimeout(context.Background(), MidCommandTimeout)
+	defer cancel()
+	return s.ExecContext(ctx, cmd, options...)
+}
+
 // ExecContextShort is a wrapper around ExecContext which creates a child
 // context with a timeout of ShortCommandTimeout.
 func (s *SSHMeta) ExecContextShort(ctx context.Context, cmd string, options ...ExecOptions) *CmdRes {


### PR DESCRIPTION
In certain cases, commands have failed when given a timeout of only 10 seconds,
the value used for `ExecShort`. Add another small utility function which has
a timeout of 30 seconds to use for said commands. Cases where this has been
observed are for `Apply` for a resource in Kubernetes. Plumb accordingly.

Signed-off by: Ian Vernon <ian@cilium.io>

Note: this is kind of a hack, but I wanted to make this easy to backport onto v1.5, as that is where this issue has been observed. The long-term fix is to be able to provide 'configuration' to calls to `Exec` which includes an overridable timeout in some cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8579)
<!-- Reviewable:end -->
