### PR TITLE
envoy: Add SO_MARK option to listener config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:5fd04721d8db90e1d5f3ad1ac8ba4f6ac91e623a as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:0bf044dd5e8c0b7dacc8e1e49d5e18330000bfc6 as cilium-envoy
 
 #
 # Cilium incremental build. Should be fast given builder-deps is up-to-date!

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/cilium/cilium/pkg/bpf"
@@ -183,6 +184,13 @@ func StartXDSServer(stateDir string) *XDSServer {
 			},
 		},
 		Transparent: &wrappers.BoolValue{Value: true},
+		SocketOptions: []*envoy_api_v2_core.SocketOption{{
+			Description: "Listener socket mark",
+			Level:       syscall.SOL_SOCKET,
+			Name:        syscall.SO_MARK,
+			Value:       &envoy_api_v2_core.SocketOption_IntValue{IntValue: 0xB00}, // egress
+			State:       envoy_api_v2_core.SocketOption_STATE_PREBIND,
+		}},
 		// FilterChains: []*envoy_api_v2_listener.FilterChain
 		ListenerFilters: []*envoy_api_v2_listener.ListenerFilter{{
 			Name: "cilium.bpf_metadata",
@@ -374,6 +382,7 @@ func (s *XDSServer) AddListener(name string, kind policy.L7ParserType, port uint
 	listenerConf.Name = name
 	listenerConf.Address.GetSocketAddress().PortSpecifier = &envoy_api_v2_core.SocketAddress_PortValue{PortValue: uint32(port)}
 	if isIngress {
+		listenerConf.SocketOptions[0].Value.(*envoy_api_v2_core.SocketOption_IntValue).IntValue = 0xA00 // Ingress socket mark
 		listenerConf.ListenerFilters[0].ConfigType.(*envoy_api_v2_listener.ListenerFilter_Config).Config.Fields["is_ingress"].GetKind().(*structpb.Value_BoolValue).BoolValue = true
 	}
 


### PR DESCRIPTION
Envoy is removing socket option support from Listener callbacks, so we
need to set the SO_MARK option in the listener config instead.

Use a cilium-envoy image that does not set the same option from the
cilium filters.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8581)
<!-- Reviewable:end -->
