### PR TITLE
proxy: Do not error out if reading of open ports fails.

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -117,7 +117,7 @@ func StartProxySupport(minPort uint16, maxPort uint16, stateDir string,
 
 	if accessLogFile != "" {
 		if err := logger.OpenLogfile(accessLogFile); err != nil {
-			log.WithError(err).WithField(logger.FieldFilePath, accessLogFile).
+			log.WithError(err).WithField(logfields.Path, accessLogFile).
 				Warn("Cannot open L7 access log")
 		}
 	}
@@ -212,10 +212,7 @@ func isPortAvailable(openLocalPorts map[uint16]struct{}, port uint16) bool {
 // Called with proxyPortsMutex held!
 func allocatePort(port, min, max uint16) (uint16, error) {
 	// Get a snapshot of the TCP and UDP ports already open locally.
-	openLocalPorts, err := readOpenLocalPorts(append(procNetTCPFiles, procNetUDPFiles...))
-	if err != nil {
-		return 0, fmt.Errorf("couldn't read local ports from /proc: %s", err)
-	}
+	openLocalPorts := readOpenLocalPorts(append(procNetTCPFiles, procNetUDPFiles...))
 
 	if isPortAvailable(openLocalPorts, port) {
 		return port, nil


### PR DESCRIPTION
Checking the random port number against known open ports is a
precaution to avoid trying to re-use an open port. We should not error
out if the reading of the open ports fails, however, as there is a
high likelihood that the port selection will result in an usable port
anyway.

This fixes the problem where Cilium fails to start due to kernel lacking
the support for the proc filesystems being used to read the open ports.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8583)
<!-- Reviewable:end -->
