### PR TITLE
policy: Update all rule caches in updateEndpointsCaches()

### DIFF
--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -387,8 +387,10 @@ func (r ruleSlice) UpdateRulesEndpointsCaches(endpointsToBumpRevision, endpoints
 	}
 
 	endpointsToBumpRevision.ForEachGo(policySelectionWG, func(epp Endpoint) {
-		endpointSelected, err := r.updateEndpointsCaches(epp, endpointsToRegenerate)
-
+		endpointSelected, err := r.updateEndpointsCaches(epp)
+		if endpointSelected {
+			endpointsToRegenerate.Insert(epp)
+		}
 		// If we could not evaluate the rules against the current endpoint, or
 		// the endpoint is not selected by the rules, remove it from the set
 		// of endpoints to bump the revision. If the error is non-nil, the


### PR DESCRIPTION
Update the endpoint caches of all the rules in updateEndpointsCaches()
instead of returning on the first rule that selects the
endpoint. Shift the map manipulation to the caller to simplify the
code.

This allows later commits to see if a rule is used locally by looking at the
length of the rule's cache map.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8584)
<!-- Reviewable:end -->
