### PR TITLE
endpoint: Make owner a member of Endpoint

### DIFF
--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -295,7 +295,7 @@ func LaunchAsEndpoint(baseCtx context.Context, owner regeneration.Owner, n *node
 	}
 
 	// Create the endpoint
-	ep, err := endpoint.NewEndpointFromChangeModel(owner.GetPolicyRepository(), info)
+	ep, err := endpoint.NewEndpointFromChangeModel(owner, info)
 	if err != nil {
 		return nil, fmt.Errorf("Error while creating endpoint model: %s", err)
 	}
@@ -319,7 +319,7 @@ func LaunchAsEndpoint(baseCtx context.Context, owner regeneration.Owner, n *node
 		return nil, fmt.Errorf("Error while configuring routes: %s", err)
 	}
 
-	if err := endpointmanager.AddEndpoint(owner, ep, "Create cilium-health endpoint"); err != nil {
+	if err := endpointmanager.AddEndpoint(ep, "Create cilium-health endpoint"); err != nil {
 		return nil, fmt.Errorf("Error while adding endpoint: %s", err)
 	}
 
@@ -332,7 +332,7 @@ func LaunchAsEndpoint(baseCtx context.Context, owner regeneration.Owner, n *node
 	// Give the endpoint a security identity
 	ctx, cancel := context.WithTimeout(baseCtx, LaunchTime)
 	defer cancel()
-	ep.UpdateLabels(ctx, owner, labels.LabelHealth, nil, true)
+	ep.UpdateLabels(ctx, labels.LabelHealth, nil, true)
 
 	// Initialize the health client to talk to this instance. This is why
 	// the caller must limit usage of this package to a single goroutine.

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1047,7 +1047,7 @@ func (d *Daemon) TriggerReloadWithoutCompile(reason string) (*sync.WaitGroup, er
 		Reason:            reason,
 		RegenerationLevel: regeneration.RegenerateWithDatapathLoad,
 	}
-	return endpointmanager.RegenerateAllEndpoints(d, regenRequest), nil
+	return endpointmanager.RegenerateAllEndpoints(regenRequest), nil
 }
 
 func changedOption(key string, value option.OptionSetting, data interface{}) {

--- a/daemon/fqdn.go
+++ b/daemon/fqdn.go
@@ -467,7 +467,7 @@ func (d *Daemon) notifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epI
 		// this data is included in the serialized Endpoint object.
 		log.WithField(logfields.EndpointID, ep.ID).Debug("Recording DNS lookup in endpoint specific cache")
 		if ep.DNSHistory.Update(lookupTime, qname, responseIPs, int(TTL)) {
-			ep.SyncEndpointHeaderFile(d)
+			ep.SyncEndpointHeaderFile()
 		}
 
 		log.WithFields(logrus.Fields{

--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -1709,7 +1709,7 @@ func (d *Daemon) updateK8sPodV1(oldK8sPod, newK8sPod *types.Pod) error {
 	oldLabels := labels.Map2Labels(oldPodLabels, labels.LabelSourceK8s)
 	oldIdtyLabels, _ := labels.FilterLabels(oldLabels)
 
-	err := podEP.ModifyIdentityLabels(d, newIdtyLabels, oldIdtyLabels)
+	err := podEP.ModifyIdentityLabels(newIdtyLabels, oldIdtyLabels)
 	if err != nil {
 		log.WithError(err).Debugf("error while updating endpoint with new labels")
 		return err
@@ -1773,7 +1773,7 @@ func (d *Daemon) updateK8sV1Namespace(oldNS, newNS *types.Namespace) error {
 	for _, ep := range eps {
 		epNS := ep.GetK8sNamespace()
 		if oldNS.Name == epNS {
-			err := ep.ModifyIdentityLabels(d, newIdtyLabels, oldIdtyLabels)
+			err := ep.ModifyIdentityLabels(newIdtyLabels, oldIdtyLabels)
 			if err != nil {
 				log.WithError(err).WithField(logfields.EndpointID, ep.ID).
 					Warningf("unable to update endpoint with new namespace labels")

--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -71,7 +71,7 @@ func (d *Daemon) policyUpdateTrigger(reasons []string) {
 	reason := strings.Join(reasons, ", ")
 
 	regenerationMetadata := &regeneration.ExternalRegenerationMetadata{Reason: reason}
-	endpointmanager.RegenerateAllEndpoints(d, regenerationMetadata)
+	endpointmanager.RegenerateAllEndpoints(regenerationMetadata)
 }
 
 // TriggerPolicyUpdates triggers policy updates for every daemon's endpoint.
@@ -474,7 +474,7 @@ func (d *Daemon) ReactToRuleUpdates(epsToBumpRevision, epsToRegen *policy.Endpoi
 			case *endpoint.Endpoint:
 				// Do not wait for the returned channel as we want this to be
 				// ASync
-				e.RegenerateIfAlive(d, regenMetadata)
+				e.RegenerateIfAlive(regenMetadata)
 			default:
 				log.Errorf("BUG: endpoint not type of *endpoint.Endpoint, received '%s' instead", e)
 			}

--- a/daemon/policy_test.go
+++ b/daemon/policy_test.go
@@ -127,7 +127,7 @@ func prepareEndpointDirs() (cleanup func(), err error) {
 }
 
 func (ds *DaemonSuite) prepareEndpoint(c *C, identity *identity.Identity, qa bool) *endpoint.Endpoint {
-	e := endpoint.NewEndpointWithState(ds.d.GetPolicyRepository(), testEndpointID, endpoint.StateWaitingForIdentity)
+	e := endpoint.NewEndpointWithState(ds.d, testEndpointID, endpoint.StateWaitingForIdentity)
 	e.IfName = "dummy1"
 	if qa {
 		e.IPv6 = QAIPv6Addr
@@ -146,7 +146,7 @@ func (ds *DaemonSuite) prepareEndpoint(c *C, identity *identity.Identity, qa boo
 	ready := e.SetStateLocked(endpoint.StateWaitingToRegenerate, "test")
 	e.Unlock()
 	c.Assert(ready, Equals, true)
-	buildSuccess := <-e.Regenerate(ds.d, regenerationMetadata)
+	buildSuccess := <-e.Regenerate(regenerationMetadata)
 	c.Assert(buildSuccess, Equals, true)
 
 	return e
@@ -157,7 +157,7 @@ func (ds *DaemonSuite) regenerateEndpoint(c *C, e *endpoint.Endpoint) {
 	ready := e.SetStateLocked(endpoint.StateWaitingToRegenerate, "test")
 	e.Unlock()
 	c.Assert(ready, Equals, true)
-	buildSuccess := <-e.Regenerate(ds.d, regenerationMetadata)
+	buildSuccess := <-e.Regenerate(regenerationMetadata)
 	c.Assert(buildSuccess, Equals, true)
 }
 
@@ -547,7 +547,7 @@ func (ds *DaemonSuite) TestRemovePolicy(c *C) {
 
 	// Delete the endpoint.
 	e.UnconditionalLock()
-	e.LeaveLocked(ds.d, nil, endpoint.DeleteConfig{})
+	e.LeaveLocked(nil, endpoint.DeleteConfig{})
 	e.Unlock()
 
 	// Check that the policy has been removed from the xDS cache.
@@ -649,7 +649,7 @@ func (ds *DaemonSuite) TestIncrementalPolicy(c *C) {
 
 	// Delete the endpoint.
 	e.UnconditionalLock()
-	e.LeaveLocked(ds.d, nil, endpoint.DeleteConfig{})
+	e.LeaveLocked(nil, endpoint.DeleteConfig{})
 	e.Unlock()
 
 	// Check that the policy has been removed from the xDS cache.

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -359,7 +359,7 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) (resto
 			regenerationMetadata := &regeneration.ExternalRegenerationMetadata{
 				Reason: "syncing state to host",
 			}
-			if buildSuccess := <-ep.Regenerate(d, regenerationMetadata); !buildSuccess {
+			if buildSuccess := <-ep.Regenerate(regenerationMetadata); !buildSuccess {
 				scopedLog.Warn("Failed while regenerating endpoint")
 				epRegenerated <- false
 				return

--- a/daemon/state_test.go
+++ b/daemon/state_test.go
@@ -82,7 +82,7 @@ func (ds *DaemonSuite) endpointCreator(id uint16, secID identity.NumericIdentity
 	repo := ds.d.GetPolicyRepository()
 	repo.GetPolicyCache().LocalEndpointIdentityAdded(identity)
 
-	ep := e.NewEndpointWithState(repo, id, e.StateReady)
+	ep := e.NewEndpointWithState(ds.d, id, e.StateReady)
 	// Random network ID and docker endpoint ID with 59 hex chars + 5 strID = 64 hex chars
 	ep.DockerNetworkID = "603e047d2268a57f5a5f93f7f9e1263e9207e348a06654bf64948def001" + strID
 	ep.DockerEndpointID = "93529fda8c401a071d21d6bd46fdf5499b9014dcb5a35f2e3efaa8d8002" + strID
@@ -168,7 +168,7 @@ func (ds *DaemonSuite) generateEPs(baseDir string, epsWanted []*e.Endpoint, epsM
 		ready := ep.SetStateLocked(e.StateWaitingToRegenerate, "test")
 		ep.Unlock()
 		if ready {
-			<-ep.Regenerate(ds, regenerationMetadata)
+			<-ep.Regenerate(regenerationMetadata)
 		}
 
 		switch ep.ID {
@@ -191,7 +191,7 @@ func (ds *DaemonSuite) generateEPs(baseDir string, epsWanted []*e.Endpoint, epsM
 				ready := ep.SetStateLocked(e.StateWaitingToRegenerate, "test")
 				ep.Unlock()
 				if ready {
-					<-ep.Regenerate(ds, regenerationMetadata)
+					<-ep.Regenerate(regenerationMetadata)
 				}
 				epsNames = append(epsNames, ep.DirectoryPath())
 			}

--- a/pkg/endpoint/bpf_test.go
+++ b/pkg/endpoint/bpf_test.go
@@ -23,13 +23,12 @@ import (
 	"testing"
 
 	"github.com/cilium/cilium/pkg/datapath/linux"
-	"github.com/cilium/cilium/pkg/policy"
 
 	. "gopkg.in/check.v1"
 )
 
 func (s *EndpointSuite) TestWriteInformationalComments(c *C) {
-	e := NewEndpointWithState(s.repo, 100, StateCreating)
+	e := NewEndpointWithState(s, 100, StateCreating)
 
 	var f bytes.Buffer
 	err := e.writeInformationalComments(&f)
@@ -39,8 +38,7 @@ func (s *EndpointSuite) TestWriteInformationalComments(c *C) {
 type writeFunc func(io.Writer) error
 
 func BenchmarkWriteHeaderfile(b *testing.B) {
-	repo := policy.NewPolicyRepository()
-	e := NewEndpointWithState(repo, 100, StateCreating)
+	e := NewEndpointWithState(&suite, 100, StateCreating)
 	dp := linux.NewDatapath(linux.DatapathConfiguration{})
 
 	targetComments := func(w io.Writer) error {

--- a/pkg/endpoint/endpoint_status_test.go
+++ b/pkg/endpoint/endpoint_status_test.go
@@ -49,8 +49,8 @@ type endpointGeneratorSpec struct {
 	fakeControllerManager    bool
 }
 
-func newEndpoint(c *check.C, repo *policy.Repository, spec endpointGeneratorSpec) *Endpoint {
-	e, err := NewEndpointFromChangeModel(repo, &models.EndpointChangeRequest{
+func (s *EndpointSuite) newEndpoint(c *check.C, spec endpointGeneratorSpec) *Endpoint {
+	e, err := NewEndpointFromChangeModel(s, &models.EndpointChangeRequest{
 		Addressing: &models.AddressPair{},
 		ID:         200,
 		Labels: models.Labels{
@@ -115,7 +115,7 @@ func newEndpoint(c *check.C, repo *policy.Repository, spec endpointGeneratorSpec
 }
 
 func (s *EndpointSuite) TestGetCiliumEndpointStatusSuccessfulControllers(c *check.C) {
-	e := newEndpoint(c, s.repo, endpointGeneratorSpec{})
+	e := s.newEndpoint(c, endpointGeneratorSpec{})
 	cepA := e.GetCiliumEndpointStatus()
 
 	// Run successful controllers in the background
@@ -147,7 +147,7 @@ func (s *EndpointSuite) TestGetCiliumEndpointStatusSuccessfulControllers(c *chec
 }
 
 func (s *EndpointSuite) TestGetCiliumEndpointStatusSuccessfulLog(c *check.C) {
-	e := newEndpoint(c, s.repo, endpointGeneratorSpec{})
+	e := s.newEndpoint(c, endpointGeneratorSpec{})
 	cepA := e.GetCiliumEndpointStatus()
 
 	go func() {
@@ -175,7 +175,7 @@ func (s *EndpointSuite) TestGetCiliumEndpointStatusSuccessfulLog(c *check.C) {
 }
 
 func (s *EndpointSuite) TestGetCiliumEndpointStatusDeepEqual(c *check.C) {
-	a := newEndpoint(c, s.repo, endpointGeneratorSpec{
+	a := s.newEndpoint(c, endpointGeneratorSpec{
 		fakeControllerManager:    true,
 		failingControllers:       10,
 		logErrors:                maxLogs,
@@ -184,7 +184,7 @@ func (s *EndpointSuite) TestGetCiliumEndpointStatusDeepEqual(c *check.C) {
 		numPortsPerIdentity:      10,
 	})
 
-	b := newEndpoint(c, s.repo, endpointGeneratorSpec{
+	b := s.newEndpoint(c, endpointGeneratorSpec{
 		fakeControllerManager:    true,
 		failingControllers:       10,
 		logErrors:                maxLogs,
@@ -200,7 +200,7 @@ func (s *EndpointSuite) TestGetCiliumEndpointStatusDeepEqual(c *check.C) {
 }
 
 func (s *EndpointSuite) TestGetCiliumEndpointStatusCorrectnes(c *check.C) {
-	e := newEndpoint(c, s.repo, endpointGeneratorSpec{
+	e := s.newEndpoint(c, endpointGeneratorSpec{
 		fakeControllerManager:    true,
 		failingControllers:       10,
 		logErrors:                maxLogs,
@@ -246,7 +246,7 @@ func prepareExpectedList(want []apiResult) cilium_v2.AllowedIdentityList {
 }
 
 func (s *EndpointSuite) TestgetEndpointPolicyMapState(c *check.C) {
-	e := newEndpoint(c, s.repo, endpointGeneratorSpec{
+	e := s.newEndpoint(c, endpointGeneratorSpec{
 		fakeControllerManager:    true,
 		failingControllers:       10,
 		logErrors:                maxLogs,
@@ -415,7 +415,7 @@ func (s *EndpointSuite) TestgetEndpointPolicyMapState(c *check.C) {
 }
 
 func (s *EndpointSuite) BenchmarkGetCiliumEndpointStatusDeepEqual(c *check.C) {
-	a := newEndpoint(c, s.repo, endpointGeneratorSpec{
+	a := s.newEndpoint(c, endpointGeneratorSpec{
 		fakeControllerManager:    true,
 		failingControllers:       10,
 		logErrors:                maxLogs,
@@ -424,7 +424,7 @@ func (s *EndpointSuite) BenchmarkGetCiliumEndpointStatusDeepEqual(c *check.C) {
 		numPortsPerIdentity:      10,
 	})
 
-	b := newEndpoint(c, s.repo, endpointGeneratorSpec{
+	b := s.newEndpoint(c, endpointGeneratorSpec{
 		fakeControllerManager:    true,
 		failingControllers:       10,
 		logErrors:                maxLogs,
@@ -443,7 +443,7 @@ func (s *EndpointSuite) BenchmarkGetCiliumEndpointStatusDeepEqual(c *check.C) {
 }
 
 func (s *EndpointSuite) BenchmarkGetCiliumEndpointStatus(c *check.C) {
-	e := newEndpoint(c, s.repo, endpointGeneratorSpec{
+	e := s.newEndpoint(c, endpointGeneratorSpec{
 		failingControllers:       10,
 		logErrors:                maxLogs,
 		allowedIngressIdentities: 100,

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -71,7 +71,7 @@ func ReadEPsFromDirNames(owner regeneration.Owner, basePath string, eptsDirNames
 			scopedLog.WithError(err).Warn("Unable to read the C header file")
 			continue
 		}
-		ep, err := ParseEndpoint(owner.GetPolicyRepository(), strEp)
+		ep, err := ParseEndpoint(owner, strEp)
 		if err != nil {
 			scopedLog.WithError(err).Warn("Unable to parse the C header file")
 			continue

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -397,7 +397,7 @@ func updateReferences(ep *endpoint.Endpoint) {
 // list is locked and cannot be modified.
 // Returns a waiting group that can be used to know when all the endpoints are
 // regenerated.
-func RegenerateAllEndpoints(owner regeneration.Owner, regenMetadata *regeneration.ExternalRegenerationMetadata) *sync.WaitGroup {
+func RegenerateAllEndpoints(regenMetadata *regeneration.ExternalRegenerationMetadata) *sync.WaitGroup {
 	var wg sync.WaitGroup
 
 	eps := GetEndpoints()
@@ -406,7 +406,7 @@ func RegenerateAllEndpoints(owner regeneration.Owner, regenMetadata *regeneratio
 	log.WithFields(logrus.Fields{"reason": regenMetadata.Reason}).Info("regenerating all endpoints")
 	for _, ep := range eps {
 		go func(ep *endpoint.Endpoint) {
-			<-ep.RegenerateIfAlive(owner, regenMetadata)
+			<-ep.RegenerateIfAlive(regenMetadata)
 			wg.Done()
 		}(ep)
 	}
@@ -449,7 +449,7 @@ func GetPolicyEndpoints() map[policy.Endpoint]struct{} {
 }
 
 // AddEndpoint takes the prepared endpoint object and starts managing it.
-func AddEndpoint(owner regeneration.Owner, ep *endpoint.Endpoint, reason string) (err error) {
+func AddEndpoint(ep *endpoint.Endpoint, reason string) (err error) {
 	alwaysEnforce := policy.GetPolicyEnabled() == option.AlwaysEnforce
 	ep.SetDesiredIngressPolicyEnabled(alwaysEnforce)
 	ep.SetDesiredEgressPolicyEnabled(alwaysEnforce)

--- a/pkg/workloads/defaults.go
+++ b/pkg/workloads/defaults.go
@@ -73,5 +73,5 @@ func processCreateWorkload(ep *endpoint.Endpoint, containerID string, allLabels 
 	endpointmanager.UpdateReferences(ep)
 
 	identityLabels, informationLabels := getFilteredLabels(containerID, allLabels)
-	ep.UpdateLabels(context.Background(), Owner(), identityLabels, informationLabels, false)
+	ep.UpdateLabels(context.Background(), identityLabels, informationLabels, false)
 }


### PR DESCRIPTION
Endpoint functions taking 'owner' as an argument expect the same
'owner' to be passed across calls to all of these functions. Make
this more explicit by making 'owner' a member of the Endpoint itself.

This allows calls not originating from the 'owner' directly to call
Owner functions. This is needed by later PRs.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8586)
<!-- Reviewable:end -->
