### PR TITLE
lbmap: Remove svc frontend from cache when removing svc

### DIFF
--- a/daemon/loadbalancer.go
+++ b/daemon/loadbalancer.go
@@ -268,8 +268,6 @@ func (d *Daemon) svcDeleteBPF(svc loadbalancer.L3n4AddrID) error {
 		return fmt.Errorf("Deleting service from BPF maps failed: %s", err)
 	}
 
-	lbmap.DeleteServiceCache(svc)
-
 	return nil
 }
 

--- a/pkg/maps/lbmap/bpfservice.go
+++ b/pkg/maps/lbmap/bpfservice.go
@@ -241,9 +241,7 @@ func (l *lbmapCache) removeServiceV2(svcKey ServiceKeyV2) ([]BackendKey, int, er
 		}
 	}
 
-	// FIXME(brb) uncomment the following line after we have removed the support for
-	// legacy svc.
-	//delete(l.entries, frontendID)
+	delete(l.entries, frontendID)
 
 	return backendsToRemove, count, nil
 }

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -707,22 +707,6 @@ func DeleteServiceV2(svc loadbalancer.L3n4AddrID, releaseBackendID func(loadbala
 	return nil
 }
 
-// DeleteServiceCache deletes the service cache.
-func DeleteServiceCache(svc loadbalancer.L3n4AddrID) {
-	mutex.Lock()
-	defer mutex.Unlock()
-
-	var svcKey ServiceKey
-
-	if !svc.IsIPv6() {
-		svcKey = NewService4Key(svc.IP, svc.Port, 0)
-	} else {
-		svcKey = NewService6Key(svc.IP, svc.Port, 0)
-	}
-
-	cache.delete(svcKey)
-}
-
 func DeleteOrphanBackends(releaseBackendID func(loadbalancer.BackendID)) []error {
 	mutex.Lock()
 	defer mutex.Unlock()


### PR DESCRIPTION
As we no longer support the legacy svc, we can finally remove a svc from the lbmap cache when removing the svc. This should prevent from a double backend ref-count decrement when removing the same svc twice which e.g. could happen due to a bug (I haven't observed this).

Also, get rid of `lbmap.DeleteServiceCache()` as it becomes obsolete due to the change above.

TODO:
- [ ] Add unit tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8588)
<!-- Reviewable:end -->
