### PR TITLE
migrate test which checks too many ports in rule to unit test from Ginkgo

### DIFF
--- a/pkg/policy/api/rule_validation_test.go
+++ b/pkg/policy/api/rule_validation_test.go
@@ -495,3 +495,63 @@ func (s *PolicyAPITestSuite) TestInvalidEndpointSelectors(c *C) {
 	c.Assert(err, Not(IsNil))
 
 }
+
+func (s *PolicyAPITestSuite) TestTooManyPortsRule(c *C) {
+	tooManyPortsRule := Rule{
+		EndpointSelector: WildcardEndpointSelector,
+		Ingress: []IngressRule{
+			{
+				FromEndpoints: []EndpointSelector{WildcardEndpointSelector},
+				ToPorts: []PortRule{{
+					Ports: []PortProtocol{
+						// Max is 40 ports
+						{Port: "80", Protocol: ProtoTCP},
+						{Port: "81", Protocol: ProtoTCP},
+						{Port: "82", Protocol: ProtoTCP},
+						{Port: "83", Protocol: ProtoTCP},
+						{Port: "84", Protocol: ProtoTCP},
+						{Port: "85", Protocol: ProtoTCP},
+						{Port: "86", Protocol: ProtoTCP},
+						{Port: "87", Protocol: ProtoTCP},
+						{Port: "88", Protocol: ProtoTCP},
+						{Port: "89", Protocol: ProtoTCP},
+						{Port: "90", Protocol: ProtoTCP},
+						{Port: "91", Protocol: ProtoTCP},
+						{Port: "92", Protocol: ProtoTCP},
+						{Port: "93", Protocol: ProtoTCP},
+						{Port: "94", Protocol: ProtoTCP},
+						{Port: "95", Protocol: ProtoTCP},
+						{Port: "96", Protocol: ProtoTCP},
+						{Port: "97", Protocol: ProtoTCP},
+						{Port: "98", Protocol: ProtoTCP},
+						{Port: "99", Protocol: ProtoTCP},
+						{Port: "100", Protocol: ProtoTCP},
+						{Port: "101", Protocol: ProtoTCP},
+						{Port: "102", Protocol: ProtoTCP},
+						{Port: "103", Protocol: ProtoTCP},
+						{Port: "104", Protocol: ProtoTCP},
+						{Port: "105", Protocol: ProtoTCP},
+						{Port: "106", Protocol: ProtoTCP},
+						{Port: "107", Protocol: ProtoTCP},
+						{Port: "108", Protocol: ProtoTCP},
+						{Port: "109", Protocol: ProtoTCP},
+						{Port: "110", Protocol: ProtoTCP},
+						{Port: "111", Protocol: ProtoTCP},
+						{Port: "112", Protocol: ProtoTCP},
+						{Port: "113", Protocol: ProtoTCP},
+						{Port: "114", Protocol: ProtoTCP},
+						{Port: "115", Protocol: ProtoTCP},
+						{Port: "116", Protocol: ProtoTCP},
+						{Port: "117", Protocol: ProtoTCP},
+						{Port: "118", Protocol: ProtoTCP},
+						{Port: "119", Protocol: ProtoTCP},
+						{Port: "120", Protocol: ProtoTCP},
+						{Port: "121", Protocol: ProtoTCP},
+					},
+				}},
+			},
+		},
+	}
+	err := tooManyPortsRule.Sanitize()
+	c.Assert(err, NotNil)
+}

--- a/pkg/policy/api/rule_validation_test.go
+++ b/pkg/policy/api/rule_validation_test.go
@@ -17,6 +17,8 @@
 package api
 
 import (
+	"fmt"
+
 	"github.com/cilium/cilium/pkg/labels"
 
 	. "gopkg.in/check.v1"
@@ -497,57 +499,23 @@ func (s *PolicyAPITestSuite) TestInvalidEndpointSelectors(c *C) {
 }
 
 func (s *PolicyAPITestSuite) TestTooManyPortsRule(c *C) {
+
+	var portProtocols []PortProtocol
+
+	for i := 80; i <= 80+maxPorts; i++ {
+		portProtocols = append(portProtocols, PortProtocol{
+			Port:     fmt.Sprintf("%d", i),
+			Protocol: ProtoTCP,
+		})
+	}
+
 	tooManyPortsRule := Rule{
 		EndpointSelector: WildcardEndpointSelector,
 		Ingress: []IngressRule{
 			{
 				FromEndpoints: []EndpointSelector{WildcardEndpointSelector},
 				ToPorts: []PortRule{{
-					Ports: []PortProtocol{
-						// Max is 40 ports
-						{Port: "80", Protocol: ProtoTCP},
-						{Port: "81", Protocol: ProtoTCP},
-						{Port: "82", Protocol: ProtoTCP},
-						{Port: "83", Protocol: ProtoTCP},
-						{Port: "84", Protocol: ProtoTCP},
-						{Port: "85", Protocol: ProtoTCP},
-						{Port: "86", Protocol: ProtoTCP},
-						{Port: "87", Protocol: ProtoTCP},
-						{Port: "88", Protocol: ProtoTCP},
-						{Port: "89", Protocol: ProtoTCP},
-						{Port: "90", Protocol: ProtoTCP},
-						{Port: "91", Protocol: ProtoTCP},
-						{Port: "92", Protocol: ProtoTCP},
-						{Port: "93", Protocol: ProtoTCP},
-						{Port: "94", Protocol: ProtoTCP},
-						{Port: "95", Protocol: ProtoTCP},
-						{Port: "96", Protocol: ProtoTCP},
-						{Port: "97", Protocol: ProtoTCP},
-						{Port: "98", Protocol: ProtoTCP},
-						{Port: "99", Protocol: ProtoTCP},
-						{Port: "100", Protocol: ProtoTCP},
-						{Port: "101", Protocol: ProtoTCP},
-						{Port: "102", Protocol: ProtoTCP},
-						{Port: "103", Protocol: ProtoTCP},
-						{Port: "104", Protocol: ProtoTCP},
-						{Port: "105", Protocol: ProtoTCP},
-						{Port: "106", Protocol: ProtoTCP},
-						{Port: "107", Protocol: ProtoTCP},
-						{Port: "108", Protocol: ProtoTCP},
-						{Port: "109", Protocol: ProtoTCP},
-						{Port: "110", Protocol: ProtoTCP},
-						{Port: "111", Protocol: ProtoTCP},
-						{Port: "112", Protocol: ProtoTCP},
-						{Port: "113", Protocol: ProtoTCP},
-						{Port: "114", Protocol: ProtoTCP},
-						{Port: "115", Protocol: ProtoTCP},
-						{Port: "116", Protocol: ProtoTCP},
-						{Port: "117", Protocol: ProtoTCP},
-						{Port: "118", Protocol: ProtoTCP},
-						{Port: "119", Protocol: ProtoTCP},
-						{Port: "120", Protocol: ProtoTCP},
-						{Port: "121", Protocol: ProtoTCP},
-					},
+					Ports: portProtocols,
 				}},
 			},
 		},

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -1814,36 +1814,6 @@ var _ = Describe("RuntimePolicyImportTests", func() {
 				"matchLabels":{"id.httpd1":""}
 			},`)
 		testInvalidPolicy(invalidJSON)
-
-		By("Test maximum tcp ports")
-		var ports string
-		for i := 0; i < 50; i++ {
-			ports += fmt.Sprintf(`{"port": "%d", "protocol": "tcp"}`, i)
-		}
-		tooManyTCPPorts := fmt.Sprintf(`[{
-		"endpointSelector": {
-			"matchLabels": {
-				"foo": ""
-			}
-		},
-		"ingress": [{
-			"fromEndpoints": [{
-					"matchLabels": {
-						"reserved:host": ""
-					}
-				},
-				{
-					"matchLabels": {
-						"bar": ""
-					}
-				}
-			],
-			"toPorts": [{
-				"ports": [%s]
-			}]
-		}]
-		}]`, ports)
-		testInvalidPolicy(tooManyTCPPorts)
 	})
 
 	Context("Policy command", func() {


### PR DESCRIPTION
This is unit-testable; remove it from the Ginkgo framework, as unit tests should be created instead of Ginkgo tests if they can test specific functionality.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8593)
<!-- Reviewable:end -->
