### PR TITLE
logging: allow for injection of log level when running unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,8 @@ BENCH_EVAL := "."
 BENCH ?= $(BENCH_EVAL)
 BENCHFLAGS_EVAL := -bench=$(BENCH) -run=^$ -benchtime=10s
 BENCHFLAGS ?= $(BENCHFLAGS_EVAL)
+# Level of logs emitted to console during unit test runs
+LOGLEVEL ?= "error"
 
 JOB_BASE_NAME ?= cilium_test
 
@@ -44,12 +46,10 @@ TEST_LDFLAGS=-ldflags "-X github.com/cilium/cilium/pkg/kvstore.consulDummyAddres
 	-X github.com/cilium/cilium/pkg/testutils.CiliumRootDir=$(ROOT_DIR) \
 	-X github.com/cilium/cilium/pkg/datapath.DatapathSHA=1234567890abcdef7890"
 
-# If you want to change the logging level of all unit tests below, you can change
-# the value of github.com/cilium/cilium/pkg/logging.DefaultLogLevelStr.
 TEST_UNITTEST_LDFLAGS= -ldflags "-X github.com/cilium/cilium/pkg/kvstore.consulDummyConfigFile=/tmp/cilium-consul-certs/cilium-consul.yaml \
 	-X github.com/cilium/cilium/pkg/testutils.CiliumRootDir=$(ROOT_DIR) \
 	-X github.com/cilium/cilium/pkg/datapath.DatapathSHA=1234567890abcdef7890 \
-	-X github.com/cilium/cilium/pkg/logging.DefaultLogLevelStr=error"
+	-X github.com/cilium/cilium/pkg/logging.DefaultLogLevelStr=$(LOGLEVEL)"
 
 all: precheck build postcheck
 	@echo "Build finished."

--- a/Makefile
+++ b/Makefile
@@ -43,9 +43,13 @@ TEST_LDFLAGS=-ldflags "-X github.com/cilium/cilium/pkg/kvstore.consulDummyAddres
 	-X github.com/cilium/cilium/pkg/kvstore.etcdDummyAddress=http://etcd:4002 \
 	-X github.com/cilium/cilium/pkg/testutils.CiliumRootDir=$(ROOT_DIR) \
 	-X github.com/cilium/cilium/pkg/datapath.DatapathSHA=1234567890abcdef7890"
+
+# If you want to change the logging level of all unit tests below, you can change
+# the value of github.com/cilium/cilium/pkg/logging.DefaultLogLevelStr.
 TEST_UNITTEST_LDFLAGS= -ldflags "-X github.com/cilium/cilium/pkg/kvstore.consulDummyConfigFile=/tmp/cilium-consul-certs/cilium-consul.yaml \
 	-X github.com/cilium/cilium/pkg/testutils.CiliumRootDir=$(ROOT_DIR) \
-	-X github.com/cilium/cilium/pkg/datapath.DatapathSHA=1234567890abcdef7890"
+	-X github.com/cilium/cilium/pkg/datapath.DatapathSHA=1234567890abcdef7890 \
+	-X github.com/cilium/cilium/pkg/logging.DefaultLogLevelStr=error"
 
 all: precheck build postcheck
 	@echo "Build finished."

--- a/pkg/command/exec/exec_test.go
+++ b/pkg/command/exec/exec_test.go
@@ -106,6 +106,8 @@ func (h *LoggingHook) Fire(entry *logrus.Entry) error {
 func (s *ExecTestSuite) TestWithFilters(c *C) {
 	hook := &LoggingHook{}
 	logging.DefaultLogger.Hooks.Add(hook)
+	logging.DefaultLogger.SetLevel(logrus.WarnLevel)
+	defer logging.DefaultLogger.SetLevel(logging.LevelStringToLogrusLevel[logging.DefaultLogLevelStr])
 
 	// This command will print the following output to stderr:
 	//

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -42,6 +42,11 @@ var (
 	// DefaultLogLevel is the alternative we provide to Debug
 	DefaultLogLevel = logrus.InfoLevel
 
+	// DefaultLogLevelStr is the string representation of DefaultLogLevel. It
+	// is used to allow for injection of the logging level via go's ldflags in
+	// unit tests, as only injection with strings via ldflags is allowed.
+	DefaultLogLevelStr = "info"
+
 	// syslogOpts is the set of supported options for syslog configuration.
 	syslogOpts = map[string]bool{
 		"syslog.level": true,
@@ -56,12 +61,23 @@ var (
 		logrus.InfoLevel:  syslog.LOG_INFO,
 		logrus.DebugLevel: syslog.LOG_DEBUG,
 	}
+
+	// LevelStringToLogrusLevel maps string representations of logrus.Level into
+	// their corresponding logrus.Level.
+	LevelStringToLogrusLevel = map[string]logrus.Level{
+		"panic":   logrus.PanicLevel,
+		"error":   logrus.ErrorLevel,
+		"warning": logrus.WarnLevel,
+		"info":    logrus.InfoLevel,
+		"debug":   logrus.DebugLevel,
+	}
 )
 
 // InitializeDefaultLogger returns a logrus Logger with a custom text formatter.
 func InitializeDefaultLogger() *logrus.Logger {
 	logger := logrus.New()
 	logger.Formatter = setupFormatter()
+	logger.SetLevel(LevelStringToLogrusLevel[DefaultLogLevelStr])
 	return logger
 }
 
@@ -74,7 +90,6 @@ func SetupLogging(loggers []string, logOpts map[string]string, tag string, debug
 		logrus.SetOutput(os.Stdout)
 	}
 
-	SetLogLevel(DefaultLogLevel)
 	ToggleDebugLogs(debug)
 
 	// always suppress the default logger so libraries don't print things


### PR DESCRIPTION
Set logging level to error level for the unit test suites. The unit
tests should be debuggable without logs, and the amount of output
from the unit tests makes it difficult to load Travis CI.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8597)
<!-- Reviewable:end -->
