### PR TITLE
eni: Disable installation of local node route

### DIFF
--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -51,7 +51,7 @@ type NodeDiscovery struct {
 }
 
 func enableLocalNodeRoute() bool {
-	return !option.Config.IsFlannelMasterDeviceSet()
+	return !option.Config.IsFlannelMasterDeviceSet() && option.Config.IPAM != option.IPAMENI
 }
 
 // NewNodeDiscovery returns a pointer to new node discovery object


### PR DESCRIPTION
The route pointing to the cilium_host interface is not required in ENI mode and
can conflict with other uses of the default allocation range.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8598)
<!-- Reviewable:end -->
