### PR TITLE
test: provide capability for tests to run in their own namespace

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2403,3 +2403,12 @@ func getK8sEndpointAddresses(ep v1.Endpoints) []*models.BackendAddress {
 func addrsEqual(addr1, addr2 *models.BackendAddress) bool {
 	return *addr1.IP == *addr2.IP && addr1.Port == addr2.Port
 }
+
+// GenerateNamespaceForTest generates a namespace based off of the current test
+// which is running.
+func GenerateNamespaceForTest() string {
+	lowered := strings.ToLower(ginkgoext.CurrentGinkgoTestDescription().FullTestText)
+	// K8s namespaces cannot have spaces.
+	replaced := strings.Replace(lowered, " ", "", -1)
+	return replaced
+}

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -566,6 +566,7 @@ func (kub *Kubectl) NodeCleanMetadata() error {
 
 // NamespaceCreate creates a new Kubernetes namespace with the given name
 func (kub *Kubectl) NamespaceCreate(name string) *CmdRes {
+	ginkgoext.By("Creating namespace %s", name)
 	return kub.ExecShort(fmt.Sprintf("%s create namespace %s", KubectlCmd, name))
 }
 
@@ -734,16 +735,28 @@ func (kub *Kubectl) WaitForServiceEndpoints(namespace string, filter string, ser
 
 // Action performs the specified ResourceLifeCycleAction on the Kubernetes
 // manifest located at path filepath in the given namespace
-func (kub *Kubectl) Action(action ResourceLifeCycleAction, filePath string) *CmdRes {
-	kub.logger.Debugf("performing '%v' on '%v'", action, filePath)
-	return kub.ExecShort(fmt.Sprintf("%s %s -f %s", KubectlCmd, action, filePath))
+func (kub *Kubectl) Action(action ResourceLifeCycleAction, filePath string, namespace ...string) *CmdRes {
+	if len(namespace) == 0 {
+		kub.logger.Debugf("performing '%v' on '%v'", action, filePath)
+		return kub.ExecShort(fmt.Sprintf("%s %s -f %s", KubectlCmd, action, filePath))
+	}
+
+	kub.logger.Debugf("performing '%v' on '%v' in namespace '%v'", action, filePath, namespace[0])
+	return kub.ExecShort(fmt.Sprintf("%s %s -f %s -n %s", KubectlCmd, action, filePath, namespace[0]))
 }
 
 // Apply applies the Kubernetes manifest located at path filepath.
-func (kub *Kubectl) Apply(filePath string) *CmdRes {
-	kub.logger.Debugf("applying %s", filePath)
+func (kub *Kubectl) Apply(filePath string, namespace ...string) *CmdRes {
+	if len(namespace) == 0 {
+		kub.logger.Debugf("applying %s", filePath)
+		return kub.ExecMiddle(
+			fmt.Sprintf("%s apply -f  %s", KubectlCmd, filePath))
+	}
+	namespaceToApply := namespace[0]
+	kub.logger.Debugf("applying %s in namespace %s", filePath, namespaceToApply)
 	return kub.ExecMiddle(
-		fmt.Sprintf("%s apply -f  %s", KubectlCmd, filePath))
+		fmt.Sprintf("%s apply -f  %s -n %s", KubectlCmd, filePath, namespaceToApply))
+
 }
 
 // Create creates the Kubernetes kanifest located at path filepath.
@@ -1447,7 +1460,7 @@ func (kub *Kubectl) CiliumPolicyAction(namespace, filepath string, action Resour
 		KubectlPolicyNameLabel, KubectlPolicyNameSpaceLabel)
 	kub.logger.Infof("Performing %s action on resource '%s'", action, filepath)
 
-	if status := kub.Action(action, filepath); !status.WasSuccessful() {
+	if status := kub.Action(action, filepath, namespace); !status.WasSuccessful() {
 		return "", status.GetErr(fmt.Sprintf("Cannot perform '%s' on resorce '%s'", action, filepath))
 	}
 
@@ -1500,7 +1513,7 @@ func (kub *Kubectl) CiliumPolicyAction(namespace, filepath string, action Resour
 			return true
 		}
 
-		pods, err := kub.GetCiliumPods(namespace)
+		pods, err := kub.GetCiliumPods(KubeSystemNamespace)
 		if err != nil {
 			kub.logger.WithError(err).Error("cannot retrieve cilium pods")
 			return false

--- a/test/helpers/policygen/models.go
+++ b/test/helpers/policygen/models.go
@@ -675,7 +675,7 @@ func (t *TestSpec) NetworkPolicyApply() error {
 	}
 
 	_, err = t.Kub.CiliumPolicyAction(
-		helpers.KubeSystemNamespace,
+		helpers.DefaultNamespace,
 		fmt.Sprintf("%s/%s", helpers.BasePath, t.NetworkPolicyName()),
 		helpers.KubectlApply,
 		helpers.HelperTimeout)

--- a/test/k8sT/Chaos.go
+++ b/test/k8sT/Chaos.go
@@ -245,7 +245,7 @@ var _ = Describe("K8sChaosTest", func() {
 
 			By("Installing the L3-L4 Policy")
 			_, err := kubectl.CiliumPolicyAction(
-				helpers.KubeSystemNamespace, netperfPolicy, helpers.KubectlApply, helpers.HelperTimeout)
+				helpers.DefaultNamespace, netperfPolicy, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Cannot install %q policy", netperfPolicy)
 
 			restartCilium()

--- a/test/k8sT/KafkaPolicies.go
+++ b/test/k8sT/KafkaPolicies.go
@@ -192,7 +192,7 @@ var _ = Describe("K8sKafkaPolicyTest", func() {
 			By("Apply L7 kafka policy and wait")
 
 			_, err = kubectl.CiliumPolicyAction(
-				helpers.KubeSystemNamespace, l7Policy,
+				helpers.DefaultNamespace, l7Policy,
 				helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).To(BeNil(), "L7 policy cannot be imported correctly")
 

--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -439,7 +439,7 @@ var _ = Describe("NightlyExamples", func() {
 
 			By("Testing with L7 policy")
 			_, err = kubectl.CiliumPolicyAction(
-				helpers.KubeSystemNamespace, PolicyManifest,
+				helpers.DefaultNamespace, PolicyManifest,
 				helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).To(BeNil(), "Cannot import GPRC policy")
 

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -87,16 +87,17 @@ var _ = Describe("K8sPolicyTest", func() {
 
 	Context("Basic Test", func() {
 		var (
-			ciliumPod string
-			clusterIP string
-			appPods   map[string]string
+			ciliumPod        string
+			clusterIP        string
+			appPods          map[string]string
+			namespaceForTest = "basictest"
 		)
 
 		importPolicy := func(file, name string) {
 			_, err := kubectl.CiliumPolicyAction(
-				helpers.KubeSystemNamespace, file, helpers.KubectlApply, helpers.HelperTimeout)
+				namespaceForTest, file, helpers.KubectlApply, helpers.HelperTimeout)
 			ExpectWithOffset(1, err).Should(BeNil(),
-				"policy %s cannot be applied in %q namespace", file, helpers.DefaultNamespace)
+				"policy %s cannot be applied in %q namespace", file, namespaceForTest)
 		}
 
 		// getMatcher returns a helper.CMDSucess() matcher for success or
@@ -112,7 +113,7 @@ var _ = Describe("K8sPolicyTest", func() {
 			for _, pod := range []string{appPods[helpers.App2], appPods[helpers.App3]} {
 				By("HTTP connectivity to google.com")
 				res := kubectl.ExecPodCmd(
-					helpers.DefaultNamespace, pod,
+					namespaceForTest, pod,
 					helpers.CurlFail("http://www.google.com/"))
 
 				ExpectWithOffset(1, res).To(getMatcher(expectWorldSuccess),
@@ -120,7 +121,7 @@ var _ = Describe("K8sPolicyTest", func() {
 
 				By("ICMP connectivity to 8.8.8.8")
 				res = kubectl.ExecPodCmd(
-					helpers.DefaultNamespace, pod,
+					namespaceForTest, pod,
 					helpers.Ping("8.8.8.8"))
 
 				ExpectWithOffset(1, res).To(getMatcher(expectWorldSuccess),
@@ -128,7 +129,7 @@ var _ = Describe("K8sPolicyTest", func() {
 
 				By("DNS lookup of google.com")
 				res = kubectl.ExecPodCmd(
-					helpers.DefaultNamespace, pod,
+					namespaceForTest, pod,
 					"host -v www.google.com")
 
 				// kube-dns is always whitelisted so this should always work
@@ -137,7 +138,7 @@ var _ = Describe("K8sPolicyTest", func() {
 
 				By("HTTP connectivity from pod to pod")
 				res = kubectl.ExecPodCmd(
-					helpers.DefaultNamespace, pod,
+					namespaceForTest, pod,
 					helpers.CurlFail(fmt.Sprintf("http://%s/public", clusterIP)))
 
 				ExpectWithOffset(1, res).To(getMatcher(expectClusterSuccess),
@@ -146,17 +147,18 @@ var _ = Describe("K8sPolicyTest", func() {
 		}
 
 		BeforeAll(func() {
-			kubectl.Apply(demoPath)
+			kubectl.NamespaceCreate(namespaceForTest).ExpectSuccess("could not create namespace")
+			kubectl.Apply(demoPath, namespaceForTest).ExpectSuccess("could not create resource")
 
-			err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=testapp", helpers.HelperTimeout)
+			err := kubectl.WaitforPods(namespaceForTest, "-l zgroup=testapp", helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Test pods are not ready after timeout")
 
 			ciliumPod, err = kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
 			Expect(err).Should(BeNil(), "cannot get CiliumPod")
 
-			clusterIP, _, err = kubectl.GetServiceHostPort(helpers.DefaultNamespace, app1Service)
-			Expect(err).To(BeNil(), "Cannot get service on %q namespace", helpers.DefaultNamespace)
-			appPods = helpers.GetAppPods(apps, helpers.DefaultNamespace, kubectl, "id")
+			clusterIP, _, err = kubectl.GetServiceHostPort(namespaceForTest, app1Service)
+			Expect(err).To(BeNil(), "Cannot get service in %q namespace", namespaceForTest)
+			appPods = helpers.GetAppPods(apps, namespaceForTest, kubectl, "id")
 			logger.WithFields(logrus.Fields{
 				"ciliumPod": ciliumPod,
 				"clusterIP": clusterIP}).Info("Initial data")
@@ -164,6 +166,7 @@ var _ = Describe("K8sPolicyTest", func() {
 		})
 
 		AfterAll(func() {
+			kubectl.NamespaceDelete(namespaceForTest)
 			kubectl.Delete(demoPath)
 		})
 
@@ -176,13 +179,13 @@ var _ = Describe("K8sPolicyTest", func() {
 			err := kubectl.CiliumEndpointWaitReady()
 			Expect(err).To(BeNil(), "Endpoints are not ready after timeout")
 
-			err = kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=testapp", helpers.HelperTimeout)
+			err = kubectl.WaitforPods(namespaceForTest, "-l zgroup=testapp", helpers.HelperTimeout)
 			Expect(err).Should(BeNil())
 
 		})
 
 		AfterEach(func() {
-			cmd := fmt.Sprintf("%s delete --all cnp,netpol", helpers.KubectlCmd)
+			cmd := fmt.Sprintf("%s delete --all cnp,netpol -n %s", helpers.KubectlCmd, namespaceForTest)
 			_ = kubectl.Exec(cmd)
 		})
 
@@ -193,67 +196,67 @@ var _ = Describe("K8sPolicyTest", func() {
 			By("Testing L3/L4 rules")
 
 			_, err := kubectl.CiliumPolicyAction(
-				helpers.KubeSystemNamespace, l3Policy, helpers.KubectlApply, helpers.HelperTimeout)
+				namespaceForTest, l3Policy, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil())
 
 			for _, appName := range []string{helpers.App1, helpers.App2, helpers.App3} {
-				err = kubectl.WaitForCEPIdentity(helpers.DefaultNamespace, appPods[appName])
+				err = kubectl.WaitForCEPIdentity(namespaceForTest, appPods[appName])
 				Expect(err).Should(BeNil())
 			}
 
 			trace := kubectl.CiliumExec(ciliumPod, fmt.Sprintf(
-				"cilium policy trace --src-k8s-pod default:%s --dst-k8s-pod default:%s --dport 80/TCP",
-				appPods[helpers.App2], appPods[helpers.App1]))
+				"cilium policy trace --src-k8s-pod %s:%s --dst-k8s-pod %s:%s --dport 80/TCP",
+				namespaceForTest, appPods[helpers.App2], namespaceForTest, appPods[helpers.App1]))
 			trace.ExpectSuccess(trace.CombineOutput().String())
 			trace.ExpectContains("Final verdict: ALLOWED", "Policy trace output mismatch")
 
 			trace = kubectl.CiliumExec(ciliumPod, fmt.Sprintf(
-				"cilium policy trace --src-k8s-pod default:%s --dst-k8s-pod default:%s",
-				appPods[helpers.App3], appPods[helpers.App1]))
+				"cilium policy trace --src-k8s-pod %s:%s --dst-k8s-pod %s:%s",
+				namespaceForTest, appPods[helpers.App3], namespaceForTest, appPods[helpers.App1]))
 			trace.ExpectSuccess(trace.CombineOutput().String())
 			trace.ExpectContains("Final verdict: DENIED", "Policy trace output mismatch")
 
 			res := kubectl.ExecPodCmd(
-				helpers.DefaultNamespace, appPods[helpers.App2],
+				namespaceForTest, appPods[helpers.App2],
 				helpers.CurlFail(fmt.Sprintf("http://%s/public", clusterIP)))
 			res.ExpectSuccess("%q cannot curl clusterIP %q", appPods[helpers.App2], clusterIP)
 
 			res = kubectl.ExecPodCmd(
-				helpers.DefaultNamespace, appPods[helpers.App3],
+				namespaceForTest, appPods[helpers.App3],
 				helpers.CurlFail(fmt.Sprintf("http://%s/public", clusterIP)))
 			res.ExpectFail("%q can curl to %q", appPods[helpers.App3], clusterIP)
 
 			_, err = kubectl.CiliumPolicyAction(
-				helpers.KubeSystemNamespace, l3Policy,
+				namespaceForTest, l3Policy,
 				helpers.KubectlDelete, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Cannot delete L3 Policy")
 
 			By("Testing L7 Policy")
 
 			_, err = kubectl.CiliumPolicyAction(
-				helpers.KubeSystemNamespace, l7Policy, helpers.KubectlApply, helpers.HelperTimeout)
+				namespaceForTest, l7Policy, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Cannot install %q policy", l7Policy)
 
 			res = kubectl.ExecPodCmd(
-				helpers.DefaultNamespace, appPods[helpers.App2],
+				namespaceForTest, appPods[helpers.App2],
 				helpers.CurlFail("http://%s/public", clusterIP))
 			res.ExpectSuccess("Cannot connect from %q to 'http://%s/public'",
 				appPods[helpers.App2], clusterIP)
 
 			res = kubectl.ExecPodCmd(
-				helpers.DefaultNamespace, appPods[helpers.App2],
+				namespaceForTest, appPods[helpers.App2],
 				helpers.CurlFail(fmt.Sprintf("http://%s/private", clusterIP)))
 			res.ExpectFail("Unexpected connection from %q to 'http://%s/private'",
 				appPods[helpers.App2], clusterIP)
 
 			res = kubectl.ExecPodCmd(
-				helpers.DefaultNamespace, appPods[helpers.App3],
+				namespaceForTest, appPods[helpers.App3],
 				helpers.CurlFail(fmt.Sprintf("http://%s/public", clusterIP)))
 			res.ExpectFail("Unexpected connection from %q to 'http://%s/public'",
 				appPods[helpers.App3], clusterIP)
 
 			res = kubectl.ExecPodCmd(
-				helpers.DefaultNamespace, appPods[helpers.App3],
+				namespaceForTest, appPods[helpers.App3],
 				helpers.CurlFail("http://%s/private", clusterIP))
 			res.ExpectFail("Unexpected connection from %q to 'http://%s/private'",
 				appPods[helpers.App3], clusterIP)
@@ -262,10 +265,10 @@ var _ = Describe("K8sPolicyTest", func() {
 		It("Invalid Policy report status correctly", func() {
 			manifest := helpers.ManifestGet("invalid_cnp.yaml")
 			cnpName := "foo"
-			kubectl.Apply(manifest).ExpectSuccess("Cannot apply policy manifest")
+			kubectl.Apply(manifest, namespaceForTest).ExpectSuccess("Cannot apply policy manifest")
 
 			body := func() bool {
-				cnp := kubectl.GetCNP(helpers.DefaultNamespace, cnpName)
+				cnp := kubectl.GetCNP(namespaceForTest, cnpName)
 				if cnp != nil && len(cnp.Status.Nodes) > 0 {
 					for _, node := range cnp.Status.Nodes {
 						if node.Error == "" {
@@ -289,33 +292,33 @@ var _ = Describe("K8sPolicyTest", func() {
 			// Load policy allowing serviceAccount of app2 to talk
 			// to app1 on port 80 TCP
 			_, err := kubectl.CiliumPolicyAction(
-				helpers.KubeSystemNamespace, serviceAccountPolicy, helpers.KubectlApply, helpers.HelperTimeout)
+				namespaceForTest, serviceAccountPolicy, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil())
 
 			for _, appName := range []string{helpers.App1, helpers.App2, helpers.App3} {
-				err = kubectl.WaitForCEPIdentity(helpers.DefaultNamespace, appPods[appName])
+				err = kubectl.WaitForCEPIdentity(namespaceForTest, appPods[appName])
 				Expect(err).Should(BeNil())
 			}
 
 			trace := kubectl.CiliumExec(ciliumPod, fmt.Sprintf(
-				"cilium policy trace --src-k8s-pod default:%s --dst-k8s-pod default:%s --dport 80/TCP",
-				appPods[helpers.App2], appPods[helpers.App1]))
+				"cilium policy trace --src-k8s-pod %s:%s --dst-k8s-pod %s:%s --dport 80/TCP",
+				namespaceForTest, appPods[helpers.App2], namespaceForTest, appPods[helpers.App1]))
 			trace.ExpectSuccess(trace.CombineOutput().String())
 			trace.ExpectContains("Final verdict: ALLOWED", "Policy trace output mismatch")
 
 			trace = kubectl.CiliumExec(ciliumPod, fmt.Sprintf(
-				"cilium policy trace --src-k8s-pod default:%s --dst-k8s-pod default:%s",
-				appPods[helpers.App3], appPods[helpers.App1]))
+				"cilium policy trace --src-k8s-pod %s:%s --dst-k8s-pod %s:%s",
+				namespaceForTest, appPods[helpers.App3], namespaceForTest, appPods[helpers.App1]))
 			trace.ExpectSuccess(trace.CombineOutput().String())
 			trace.ExpectContains("Final verdict: DENIED", "Policy trace output mismatch")
 
 			res := kubectl.ExecPodCmd(
-				helpers.DefaultNamespace, appPods[helpers.App2],
+				namespaceForTest, appPods[helpers.App2],
 				helpers.CurlFail(fmt.Sprintf("http://%s/public", clusterIP)))
 			res.ExpectSuccess("%q cannot curl clusterIP %q", appPods[helpers.App2], clusterIP)
 
 			res = kubectl.ExecPodCmd(
-				helpers.DefaultNamespace, appPods[helpers.App3],
+				namespaceForTest, appPods[helpers.App3],
 				helpers.CurlFail(fmt.Sprintf("http://%s/public", clusterIP)))
 			res.ExpectFail("%q can curl to %q", appPods[helpers.App3], clusterIP)
 
@@ -323,16 +326,16 @@ var _ = Describe("K8sPolicyTest", func() {
 
 		It("CNP test MatchExpressions key", func() {
 			_, err := kubectl.CiliumPolicyAction(
-				helpers.KubeSystemNamespace, cnpMatchExpression, helpers.KubectlApply, helpers.HelperTimeout)
+				namespaceForTest, cnpMatchExpression, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "cannot install policy %s", cnpMatchExpression)
 
 			res := kubectl.ExecPodCmd(
-				helpers.DefaultNamespace, appPods[helpers.App2],
+				namespaceForTest, appPods[helpers.App2],
 				helpers.CurlFail(fmt.Sprintf("http://%s/public", clusterIP)))
 			res.ExpectSuccess("%q cannot curl clusterIP %q", appPods[helpers.App2], clusterIP)
 
 			res = kubectl.ExecPodCmd(
-				helpers.DefaultNamespace, appPods[helpers.App3],
+				namespaceForTest, appPods[helpers.App3],
 				helpers.CurlFail(fmt.Sprintf("http://%s/public", clusterIP)))
 			res.ExpectFail("%q can curl to %q", appPods[helpers.App3], clusterIP)
 
@@ -341,12 +344,12 @@ var _ = Describe("K8sPolicyTest", func() {
 		It("Denies traffic with k8s default-deny ingress policy", func() {
 
 			res := kubectl.ExecPodCmd(
-				helpers.DefaultNamespace, appPods[helpers.App2],
+				namespaceForTest, appPods[helpers.App2],
 				helpers.CurlFail(fmt.Sprintf("http://%s/public", clusterIP)))
 			res.ExpectSuccess("%q cannot curl clusterIP %q", appPods[helpers.App2], clusterIP)
 
 			res = kubectl.ExecPodCmd(
-				helpers.DefaultNamespace, appPods[helpers.App3],
+				namespaceForTest, appPods[helpers.App3],
 				helpers.CurlFail(fmt.Sprintf("http://%s/public", clusterIP)))
 			res.ExpectSuccess("%q cannot curl to %q", appPods[helpers.App3], clusterIP)
 
@@ -354,19 +357,19 @@ var _ = Describe("K8sPolicyTest", func() {
 
 			// Import the policy and wait for all required endpoints to enforce the policy
 			_, err := kubectl.CiliumPolicyAction(
-				helpers.KubeSystemNamespace, knpDenyIngress, helpers.KubectlApply, helpers.HelperTimeout)
+				namespaceForTest, knpDenyIngress, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(),
-				"L3 deny-ingress Policy cannot be applied in %q namespace", helpers.DefaultNamespace)
+				"L3 deny-ingress Policy cannot be applied in %q namespace", namespaceForTest)
 
 			By("Testing connectivity with ingress default-deny policy loaded")
 
 			res = kubectl.ExecPodCmd(
-				helpers.DefaultNamespace, appPods[helpers.App2],
+				namespaceForTest, appPods[helpers.App2],
 				helpers.CurlFail(fmt.Sprintf("http://%s/public", clusterIP)))
 			res.ExpectFail("Ingress connectivity should be denied by policy")
 
 			res = kubectl.ExecPodCmd(
-				helpers.DefaultNamespace, appPods[helpers.App3],
+				namespaceForTest, appPods[helpers.App3],
 				helpers.CurlFail(fmt.Sprintf("http://%s/public", clusterIP)))
 			res.ExpectFail("Ingress connectivity should be denied by policy")
 		})
@@ -375,24 +378,24 @@ var _ = Describe("K8sPolicyTest", func() {
 			By("Installing knp egress default-deny")
 
 			_, err := kubectl.CiliumPolicyAction(
-				helpers.KubeSystemNamespace, knpDenyEgress, helpers.KubectlApply, helpers.HelperTimeout)
+				namespaceForTest, knpDenyEgress, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(),
-				"L3 deny-egress Policy cannot be applied in %q namespace", helpers.DefaultNamespace)
+				"L3 deny-egress Policy cannot be applied in %q namespace", namespaceForTest)
 
 			By("Testing if egress policy enforcement is enabled on the endpoint")
 			for _, pod := range []string{appPods[helpers.App2], appPods[helpers.App3]} {
 				res := kubectl.ExecPodCmd(
-					helpers.DefaultNamespace, pod,
+					namespaceForTest, pod,
 					helpers.CurlFail("http://www.google.com/"))
 				res.ExpectFail("Egress connectivity should be denied for pod %q", pod)
 
 				res = kubectl.ExecPodCmd(
-					helpers.DefaultNamespace, pod,
+					namespaceForTest, pod,
 					helpers.Ping("8.8.8.8"))
 				res.ExpectFail("Egress ping connectivity should be denied for pod %q", pod)
 
 				res = kubectl.ExecPodCmd(
-					helpers.DefaultNamespace, pod,
+					namespaceForTest, pod,
 					"host www.google.com")
 				res.ExpectFail("Egress DNS connectivity should be denied for pod %q", pod)
 			}
@@ -402,36 +405,36 @@ var _ = Describe("K8sPolicyTest", func() {
 			By("Installing knp ingress-egress default-deny")
 
 			_, err := kubectl.CiliumPolicyAction(
-				helpers.KubeSystemNamespace, knpDenyIngressEgress, helpers.KubectlApply, helpers.HelperTimeout)
+				namespaceForTest, knpDenyIngressEgress, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(),
-				"L3 deny-ingress-egress policy cannot be applied in %q namespace", helpers.DefaultNamespace)
+				"L3 deny-ingress-egress policy cannot be applied in %q namespace", namespaceForTest)
 
 			By("Testing if egress and ingress policy enforcement is enabled on the endpoint")
 			for _, pod := range []string{appPods[helpers.App2], appPods[helpers.App3]} {
 				res := kubectl.ExecPodCmd(
-					helpers.DefaultNamespace, pod,
+					namespaceForTest, pod,
 					helpers.CurlFail("http://www.google.com/"))
 				res.ExpectFail("Egress connectivity should be denied for pod %q", pod)
 
 				res = kubectl.ExecPodCmd(
-					helpers.DefaultNamespace, pod,
+					namespaceForTest, pod,
 					helpers.Ping("8.8.8.8"))
 				res.ExpectFail("Egress ping connectivity should be denied for pod %q", pod)
 
 				res = kubectl.ExecPodCmd(
-					helpers.DefaultNamespace, pod,
+					namespaceForTest, pod,
 					"host www.google.com")
 				res.ExpectFail("Egress DNS connectivity should be denied for pod %q", pod)
 			}
 
 			By("Testing ingress connectivity with default-deny policy loaded")
 			res := kubectl.ExecPodCmd(
-				helpers.DefaultNamespace, appPods[helpers.App2],
+				namespaceForTest, appPods[helpers.App2],
 				helpers.CurlFail(fmt.Sprintf("http://%s/public", clusterIP)))
 			res.ExpectFail("Ingress connectivity should be denied by policy")
 
 			res = kubectl.ExecPodCmd(
-				helpers.DefaultNamespace, appPods[helpers.App3],
+				namespaceForTest, appPods[helpers.App3],
 				helpers.CurlFail(fmt.Sprintf("http://%s/public", clusterIP)))
 			res.ExpectFail("Ingress connectivity should be denied by policy")
 		})
@@ -441,20 +444,20 @@ var _ = Describe("K8sPolicyTest", func() {
 			By("Installing cnp ingress default-deny")
 
 			_, err := kubectl.CiliumPolicyAction(
-				helpers.KubeSystemNamespace, cnpDenyIngress, helpers.KubectlApply, helpers.HelperTimeout)
+				namespaceForTest, cnpDenyIngress, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(),
-				"L3 deny-ingress Policy cannot be applied in %q namespace", helpers.DefaultNamespace)
+				"L3 deny-ingress Policy cannot be applied in %q namespace", namespaceForTest)
 
 			By("Testing connectivity with ingress default-deny policy loaded")
 
 			res := kubectl.ExecPodCmd(
-				helpers.DefaultNamespace, appPods[helpers.App2],
+				namespaceForTest, appPods[helpers.App2],
 				helpers.CurlFail(fmt.Sprintf("http://%s/public", clusterIP)))
 			res.ExpectFail("Ingress connectivity should be denied by policy")
 
 			By("Testing egress connnectivity works correctly")
 			res = kubectl.ExecPodCmd(
-				helpers.DefaultNamespace, appPods[helpers.App2],
+				namespaceForTest, appPods[helpers.App2],
 				helpers.Ping("8.8.8.8"))
 			res.ExpectSuccess("Egress ping connectivity should work")
 		})
@@ -463,23 +466,23 @@ var _ = Describe("K8sPolicyTest", func() {
 
 			By("Installing cnp egress default-deny")
 			_, err := kubectl.CiliumPolicyAction(
-				helpers.KubeSystemNamespace, cnpDenyEgress, helpers.KubectlApply, helpers.HelperTimeout)
+				namespaceForTest, cnpDenyEgress, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(),
-				"L3 deny-egress Policy cannot be applied in %q namespace", helpers.DefaultNamespace)
+				"L3 deny-egress Policy cannot be applied in %q namespace", namespaceForTest)
 
 			for _, pod := range apps {
 				res := kubectl.ExecPodCmd(
-					helpers.DefaultNamespace, pod,
+					namespaceForTest, pod,
 					helpers.CurlFail("http://www.google.com/"))
 				res.ExpectFail("Egress connectivity should be denied for pod %q", pod)
 
 				res = kubectl.ExecPodCmd(
-					helpers.DefaultNamespace, pod,
+					namespaceForTest, pod,
 					helpers.Ping("8.8.8.8"))
 				res.ExpectFail("Egress ping connectivity should be denied for pod %q", pod)
 
 				res = kubectl.ExecPodCmd(
-					helpers.DefaultNamespace, pod,
+					namespaceForTest, pod,
 					"host www.google.com")
 				res.ExpectFail("Egress DNS connectivity should be denied for pod %q", pod)
 			}
@@ -488,18 +491,18 @@ var _ = Describe("K8sPolicyTest", func() {
 		It("Allows traffic with k8s default-allow ingress policy", func() {
 			By("Installing ingress default-allow")
 			_, err := kubectl.CiliumPolicyAction(
-				helpers.KubeSystemNamespace, knpAllowIngress, helpers.KubectlApply, helpers.HelperTimeout)
+				namespaceForTest, knpAllowIngress, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(),
-				"L3 allow-ingress Policy cannot be applied in %q namespace", helpers.DefaultNamespace)
+				"L3 allow-ingress Policy cannot be applied in %q namespace", namespaceForTest)
 
 			By("Testing connectivity with ingress default-allow policy loaded")
 			res := kubectl.ExecPodCmd(
-				helpers.DefaultNamespace, appPods[helpers.App2],
+				namespaceForTest, appPods[helpers.App2],
 				helpers.CurlFail("http://%s/public", clusterIP))
 			res.ExpectSuccess("Ingress connectivity should be allowed by policy")
 
 			res = kubectl.ExecPodCmd(
-				helpers.DefaultNamespace, appPods[helpers.App3],
+				namespaceForTest, appPods[helpers.App3],
 				helpers.CurlFail("http://%s/public", clusterIP))
 			res.ExpectSuccess("Ingress connectivity should be allowed by policy")
 		})
@@ -507,25 +510,25 @@ var _ = Describe("K8sPolicyTest", func() {
 		It("Allows traffic with k8s default-allow egress policy", func() {
 			By("Installing egress default-allow")
 			_, err := kubectl.CiliumPolicyAction(
-				helpers.KubeSystemNamespace, knpAllowEgress, helpers.KubectlApply, helpers.HelperTimeout)
+				namespaceForTest, knpAllowEgress, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(),
-				"L3 allow-egress Policy cannot be applied in %q namespace", helpers.DefaultNamespace)
+				"L3 allow-egress Policy cannot be applied in %q namespace", namespaceForTest)
 
 			By("Checking connectivity between pods and external services after installing egress policy")
 
 			for _, pod := range []string{appPods[helpers.App2], appPods[helpers.App3]} {
 				res := kubectl.ExecPodCmd(
-					helpers.DefaultNamespace, pod,
+					namespaceForTest, pod,
 					helpers.CurlFail("http://www.google.com/"))
 				res.ExpectSuccess("Egress connectivity should be allowed for pod %q", pod)
 
 				res = kubectl.ExecPodCmd(
-					helpers.DefaultNamespace, pod,
+					namespaceForTest, pod,
 					helpers.Ping("8.8.8.8"))
 				res.ExpectSuccess("Egress ping connectivity should be allowed for pod %q", pod)
 
 				res = kubectl.ExecPodCmd(
-					helpers.DefaultNamespace, pod,
+					namespaceForTest, pod,
 					"host www.google.com")
 				res.ExpectSuccess("Egress DNS connectivity should be allowed for pod %q", pod)
 			}
@@ -596,14 +599,14 @@ var _ = Describe("K8sPolicyTest", func() {
 
 			validateL3L4 := func(allowApp3 bool) {
 				res := kubectl.ExecPodCmd(
-					helpers.DefaultNamespace, appPods[helpers.App2],
+					namespaceForTest, appPods[helpers.App2],
 					helpers.CurlFail(fmt.Sprintf("http://%s/public", clusterIP)))
 				ExpectWithOffset(1, res).Should(helpers.CMDSuccess(),
 					"%q cannot curl clusterIP %q",
 					appPods[helpers.App2], clusterIP)
 
 				res = kubectl.ExecPodCmd(
-					helpers.DefaultNamespace, appPods[helpers.App3],
+					namespaceForTest, appPods[helpers.App3],
 					helpers.CurlFail(fmt.Sprintf("http://%s/public", clusterIP)))
 				ExpectWithOffset(1, res).To(getMatcher(allowApp3),
 					"%q curl clusterIP %q (expected to allow: %t)",
@@ -613,21 +616,21 @@ var _ = Describe("K8sPolicyTest", func() {
 			It("Enforces connectivity correctly when the same L3/L4 CNP is updated", func() {
 				By("Applying default allow policy")
 				_, err := kubectl.CiliumPolicyAction(
-					helpers.KubeSystemNamespace, cnpUpdateAllow, helpers.KubectlApply, helpers.HelperTimeout)
+					namespaceForTest, cnpUpdateAllow, helpers.KubectlApply, helpers.HelperTimeout)
 				Expect(err).Should(BeNil(), "%q Policy cannot be applied", cnpUpdateAllow)
 
 				validateL3L4(allowAll)
 
 				By("Applying l3-l4 policy")
 				_, err = kubectl.CiliumPolicyAction(
-					helpers.KubeSystemNamespace, cnpUpdateDeny, helpers.KubectlApply, helpers.HelperTimeout)
+					namespaceForTest, cnpUpdateDeny, helpers.KubectlApply, helpers.HelperTimeout)
 				Expect(err).Should(BeNil(), "%q Policy cannot be applied", cnpUpdateDeny)
 
 				validateL3L4(denyFromApp3)
 
 				By("Applying no-specs policy")
 				_, err = kubectl.CiliumPolicyAction(
-					helpers.KubeSystemNamespace, cnpUpdateNoSpecs, helpers.KubectlApply, helpers.HelperTimeout)
+					namespaceForTest, cnpUpdateNoSpecs, helpers.KubectlApply, helpers.HelperTimeout)
 				switch helpers.GetCurrentK8SEnv() {
 				// In k8s 1.15 no-specs policy is not allowed by kube-apiserver
 				case "1.15":
@@ -640,14 +643,14 @@ var _ = Describe("K8sPolicyTest", func() {
 
 				By("Applying l3-l4 policy with user-specified labels")
 				_, err = kubectl.CiliumPolicyAction(
-					helpers.KubeSystemNamespace, cnpUpdateDenyLabelled, helpers.KubectlApply, helpers.HelperTimeout)
+					namespaceForTest, cnpUpdateDenyLabelled, helpers.KubectlApply, helpers.HelperTimeout)
 				Expect(err).Should(BeNil(), "%q Policy cannot be applied", cnpUpdateDeny)
 
 				validateL3L4(denyFromApp3)
 
 				By("Applying default allow policy (should remove policy with user labels)")
 				_, err = kubectl.CiliumPolicyAction(
-					helpers.KubeSystemNamespace, cnpUpdateAllow, helpers.KubectlApply, helpers.HelperTimeout)
+					namespaceForTest, cnpUpdateAllow, helpers.KubectlApply, helpers.HelperTimeout)
 				Expect(err).Should(BeNil(), "%q Policy cannot be applied", cnpUpdateAllow)
 
 				validateL3L4(allowAll)
@@ -660,7 +663,7 @@ var _ = Describe("K8sPolicyTest", func() {
 				// test "checks all kind of Kubernetes policies".
 				// Install it then move on.
 				_, err := kubectl.CiliumPolicyAction(
-					helpers.KubeSystemNamespace, l7Policy, helpers.KubectlApply, helpers.HelperTimeout)
+					namespaceForTest, l7Policy, helpers.KubectlApply, helpers.HelperTimeout)
 				Expect(err).Should(BeNil(), "Cannot install %q policy", l7Policy)
 
 				// Update existing policy on port 80 from http to kafka
@@ -668,17 +671,17 @@ var _ = Describe("K8sPolicyTest", func() {
 				// Traffic cannot flow but policy must be able to be
 				// imported and applied to the endpoints.
 				_, err = kubectl.CiliumPolicyAction(
-					helpers.KubeSystemNamespace, l7PolicyKafka, helpers.KubectlApply, helpers.HelperTimeout)
+					namespaceForTest, l7PolicyKafka, helpers.KubectlApply, helpers.HelperTimeout)
 				Expect(err).Should(BeNil(), "Cannot update L7 policy (%q) from parser http to kafka", l7PolicyKafka)
 
 				res := kubectl.ExecPodCmd(
-					helpers.DefaultNamespace, appPods[helpers.App3],
+					namespaceForTest, appPods[helpers.App3],
 					helpers.CurlFail("http://%s/public", clusterIP))
 				res.ExpectFail("Unexpected connection from %q to 'http://%s/public'",
 					appPods[helpers.App3], clusterIP)
 
 				res = kubectl.ExecPodCmd(
-					helpers.DefaultNamespace, appPods[helpers.App2],
+					namespaceForTest, appPods[helpers.App2],
 					helpers.CurlFail("http://%s/public", clusterIP))
 				res.ExpectFail("Unexpected connection from %q to 'http://%s/public'",
 					appPods[helpers.App2], clusterIP)
@@ -793,7 +796,7 @@ EOF`, k, v)
 
 			By("Apply policy to web")
 			_, err = kubectl.CiliumPolicyAction(
-				helpers.KubeSystemNamespace, helpers.ManifestGet(webPolicy),
+				helpers.DefaultNamespace, helpers.ManifestGet(webPolicy),
 				helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Cannot apply web-policy")
 
@@ -804,7 +807,7 @@ EOF`, k, v)
 
 			By("Apply policy to Redis")
 			_, err = kubectl.CiliumPolicyAction(
-				helpers.KubeSystemNamespace, helpers.ManifestGet(redisPolicy),
+				helpers.DefaultNamespace, helpers.ManifestGet(redisPolicy),
 				helpers.KubectlApply, helpers.HelperTimeout)
 
 			Expect(err).Should(BeNil(), "Cannot apply redis policy")
@@ -817,14 +820,14 @@ EOF`, k, v)
 			testConnectivitytoRedis()
 
 			_, err = kubectl.CiliumPolicyAction(
-				helpers.KubeSystemNamespace, helpers.ManifestGet(redisPolicy),
+				helpers.DefaultNamespace, helpers.ManifestGet(redisPolicy),
 				helpers.KubectlDelete, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Cannot apply redis policy")
 
 			By("Apply deprecated policy to Redis")
 
 			_, err = kubectl.CiliumPolicyAction(
-				helpers.KubeSystemNamespace, helpers.ManifestGet(redisPolicyDeprecated),
+				helpers.DefaultNamespace, helpers.ManifestGet(redisPolicyDeprecated),
 				helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Cannot apply redis deprecated policy err: %q", err)
 
@@ -908,13 +911,13 @@ EOF`, k, v)
 			// namespace and all works as expected.
 			By("Applying Policy in %q namespace", secondNS)
 			_, err = kubectl.CiliumPolicyAction(
-				helpers.KubeSystemNamespace, l3l4PolicySecondNS, helpers.KubectlApply, helpers.HelperTimeout)
+				secondNS, l3l4PolicySecondNS, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(),
 				"%q Policy cannot be applied in %q namespace", l3l4PolicySecondNS, secondNS)
 
 			By("Applying Policy in default namespace")
 			_, err = kubectl.CiliumPolicyAction(
-				helpers.KubeSystemNamespace, l3L4Policy, helpers.KubectlApply, helpers.HelperTimeout)
+				helpers.DefaultNamespace, l3L4Policy, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(),
 				"%q Policy cannot be applied in %q namespace", l3L4Policy, helpers.DefaultNamespace)
 
@@ -964,7 +967,7 @@ EOF`, k, v)
 
 			By("Applying Policy in %q namespace", secondNS)
 			_, err = kubectl.CiliumPolicyAction(
-				helpers.KubeSystemNamespace, netpolNsSelector, helpers.KubectlApply, helpers.HelperTimeout)
+				secondNS, netpolNsSelector, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Policy cannot be applied")
 
 			for _, pod := range []string{helpers.App2, helpers.App3} {
@@ -985,7 +988,7 @@ EOF`, k, v)
 
 			By("Delete Kubernetes Network Policies in %q namespace", secondNS)
 			_, err = kubectl.CiliumPolicyAction(
-				helpers.KubeSystemNamespace, netpolNsSelector, helpers.KubectlDelete, helpers.HelperTimeout)
+				secondNS, netpolNsSelector, helpers.KubectlDelete, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Policy %q cannot be deleted", netpolNsSelector)
 
 			for _, pod := range []string{helpers.App2, helpers.App3} {
@@ -1004,7 +1007,7 @@ EOF`, k, v)
 		It("Cilium Network policy using namespace label and L7", func() {
 
 			_, err := kubectl.CiliumPolicyAction(
-				helpers.KubeSystemNamespace, cnpSecondNS, helpers.KubectlApply, helpers.HelperTimeout)
+				helpers.DefaultNamespace, cnpSecondNS, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "%q Policy cannot be applied", cnpSecondNS)
 
 			By("Testing connectivity in %q namespace", secondNS)

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -90,7 +90,7 @@ var _ = Describe("K8sPolicyTest", func() {
 			ciliumPod        string
 			clusterIP        string
 			appPods          map[string]string
-			namespaceForTest = "basictest"
+			namespaceForTest string
 		)
 
 		importPolicy := func(file, name string) {
@@ -147,6 +147,7 @@ var _ = Describe("K8sPolicyTest", func() {
 		}
 
 		BeforeAll(func() {
+			namespaceForTest = helpers.GenerateNamespaceForTest()
 			kubectl.NamespaceCreate(namespaceForTest).ExpectSuccess("could not create namespace")
 			kubectl.Apply(demoPath, namespaceForTest).ExpectSuccess("could not create resource")
 

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -43,7 +43,7 @@ var _ = Describe("K8sServicesTest", func() {
 
 	applyPolicy := func(path string) {
 		By(fmt.Sprintf("Applying policy %s", path))
-		_, err := kubectl.CiliumPolicyAction(helpers.KubeSystemNamespace, path, helpers.KubectlApply, helpers.HelperTimeout)
+		_, err := kubectl.CiliumPolicyAction(helpers.DefaultNamespace, path, helpers.KubectlApply, helpers.HelperTimeout)
 		ExpectWithOffset(1, err).Should(BeNil(), fmt.Sprintf("Error creating resource %s: %s", path, err))
 	}
 
@@ -600,7 +600,7 @@ var _ = Describe("K8sServicesTest", func() {
 
 			By("Importing policy")
 
-			_, err = kubectl.CiliumPolicyAction(helpers.KubeSystemNamespace, policyPath, helpers.KubectlCreate, helpers.HelperTimeout)
+			_, err = kubectl.CiliumPolicyAction(helpers.DefaultNamespace, policyPath, helpers.KubectlCreate, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Error creating policy %q", policyPath)
 
 			By("Checking that policies were correctly imported into Cilium")

--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -261,7 +261,7 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldVersion, newV
 		ExpectKubeDNSReady(kubectl)
 
 		_, err = kubectl.CiliumPolicyAction(
-			helpers.KubeSystemNamespace, l7Policy, helpers.KubectlApply, timeout)
+			helpers.DefaultNamespace, l7Policy, helpers.KubectlApply, timeout)
 		Expect(err).Should(BeNil(), "cannot import l7 policy: %v", l7Policy)
 
 		By("Creating service and clients for migration")

--- a/test/k8sT/demos.go
+++ b/test/k8sT/demos.go
@@ -132,7 +132,7 @@ var _ = Describe("K8sDemosTest", func() {
 
 		By("Importing L7 Policy which restricts access to %q", exhaustPortPath)
 		_, err = kubectl.CiliumPolicyAction(
-			helpers.KubeSystemNamespace, l7PolicyYAMLLink, helpers.KubectlApply, helpers.HelperTimeout)
+			helpers.DefaultNamespace, l7PolicyYAMLLink, helpers.KubectlApply, helpers.HelperTimeout)
 		Expect(err).Should(BeNil(), "Unable to apply %s", l7PolicyYAMLLink)
 
 		By("Waiting for endpoints to be ready after importing policy")

--- a/test/k8sT/fqdn.go
+++ b/test/k8sT/fqdn.go
@@ -146,7 +146,7 @@ var _ = Describe("K8sFQDNTest", func() {
 		fqndProxyPolicy := helpers.ManifestGet("fqdn-proxy-policy.yaml")
 
 		_, err := kubectl.CiliumPolicyAction(
-			helpers.KubeSystemNamespace, fqndProxyPolicy,
+			helpers.DefaultNamespace, fqndProxyPolicy,
 			helpers.KubectlApply, helpers.HelperTimeout)
 		Expect(err).To(BeNil(), "Cannot install fqdn proxy policy")
 
@@ -213,7 +213,7 @@ var _ = Describe("K8sFQDNTest", func() {
 		world2Target := "http://world2.cilium.test"
 
 		_, err := kubectl.CiliumPolicyAction(
-			helpers.KubeSystemNamespace, fqdnPolicy,
+			helpers.DefaultNamespace, fqdnPolicy,
 			helpers.KubectlApply, helpers.HelperTimeout)
 		Expect(err).To(BeNil(), "Cannot install fqdn proxy policy")
 

--- a/test/k8sT/istio.go
+++ b/test/k8sT/istio.go
@@ -271,7 +271,7 @@ var _ = Describe("K8sIstioTest", func() {
 			policyPaths = []string{l7PolicyPath}
 			for _, policyPath := range policyPaths {
 				By("Creating policy in file %q", policyPath)
-				_, err := kubectl.CiliumPolicyAction(helpers.KubeSystemNamespace, policyPath, helpers.KubectlApply, helpers.HelperTimeout)
+				_, err := kubectl.CiliumPolicyAction(helpers.DefaultNamespace, policyPath, helpers.KubectlApply, helpers.HelperTimeout)
 				Expect(err).Should(BeNil(), "Unable to create policy %q", policyPath)
 			}
 

--- a/test/k8sT/manifests/invalid_cnp.yaml
+++ b/test/k8sT/manifests/invalid_cnp.yaml
@@ -3,7 +3,6 @@ apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
   name: foo
-  namespace: default
 specs:
 - endpointSelector:
     matchLabels:


### PR DESCRIPTION
Running each set of tests in a `Describe` in its own namespace instead of the `default` namespace ensures that resource leakage between tests w.r.t. policies, services, and other associated resources stored in K8s is kept to a minimum. It also allows for deletion of all resources in a namespace with one command at the end of a run of a given set of tests. To allow for this functionality, a variety of changes had to be made:
    
* add variadic arguments for providing namespace to existing commands for backwards compatibility.
* change namespace parameter of `CiliumPolicyAction` to apply the policy in the namespace parameter, and hardcode the namespace used to get Cilium pods to be `kube-system`. Change callers accordingly.
    
One given set of tests within the `K8sPolicyTest` have been changed to use a specific namespace. Misc. fixes / changes needed for said tests to pass were added as well. Other tests can be migrated over time to use their own namespaces.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8600)
<!-- Reviewable:end -->
