### PR TITLE
test: only close SSH session if context is canceled

### DIFF
--- a/test/helpers/ssh_command.go
+++ b/test/helpers/ssh_command.go
@@ -273,10 +273,6 @@ func (client *SSHClient) RunCommandContext(ctx context.Context, cmd *SSHCommand)
 
 		_, runErr := runCommand(session, cmd)
 		sessionErrChan <- runErr
-
-		if closeErr := session.Close(); closeErr != nil {
-			log.WithError(closeErr).Error("failed to close session")
-		}
 	}()
 
 	select {
@@ -287,6 +283,9 @@ func (client *SSHClient) RunCommandContext(ctx context.Context, cmd *SSHCommand)
 			log.Warning("sending SIGHUP to session due to canceled context")
 			if err := session.Signal(ssh.SIGHUP); err != nil {
 				log.Errorf("failed to kill command when context is canceled: %s", err)
+			}
+			if closeErr := session.Close(); closeErr != nil {
+				log.WithError(closeErr).Error("failed to close session")
 			}
 		} else {
 			log.Error("timeout reached; no session was able to be created")


### PR DESCRIPTION
If an SSH has `Run` called on it, and `Run` returns, there is no need to close=
the session because calling `Run` implicitly closes it. If we call `Close` on a
session for which `Run` has already completed, we riddle the logs for test runs
with errors like the following:

```
"failed to close session" error=EOF
```

So, only try to close the session in the case that `session.Run` is still
ongoing (e.g., when a context associated with running the command is canceled /
has reached its timeout).

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8602)
<!-- Reviewable:end -->
