### PR TITLE
logging: add way to configure logging level via cilium-agent option

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1067,7 +1067,7 @@ func changedOption(key string, value option.OptionSetting, data interface{}) {
 	d := data.(*Daemon)
 	if key == option.Debug {
 		// Set the debug toggle (this can be a no-op)
-		logging.ToggleDebugLogs(d.DebugEnabled())
+		logging.ConfigureLogLevel(d.DebugEnabled())
 		// Reflect log level change to proxies
 		proxy.ChangeLogLevel(logging.GetLevel(logging.DefaultLogger))
 	}

--- a/pkg/endpoint/log.go
+++ b/pkg/endpoint/log.go
@@ -88,6 +88,12 @@ func (e *Endpoint) UpdateLogger(fields map[string]interface{}) {
 	if e.Options != nil && e.Options.IsEnabled(option.Debug) {
 		baseLogger = logging.InitializeDefaultLogger()
 		baseLogger.SetLevel(logrus.DebugLevel)
+	} else {
+		// Debug mode takes priority; if not in debug, check what log level user
+		// has set and set the endpoint's log to log at that level.
+		if lvl, ok := logging.GetLogLevelFromConfig(); ok {
+			baseLogger.SetLevel(lvl)
+		}
 	}
 
 	// When adding new fields, make sure they are abstracted by a setter

--- a/pkg/logging/logging_test.go
+++ b/pkg/logging/logging_test.go
@@ -1,0 +1,86 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package logging
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type LoggingSuite struct{}
+
+var _ = Suite(&LoggingSuite{})
+
+func (s *LoggingSuite) TestGetLogLevel(c *C) {
+	opts := LogOptions{}
+
+	// case doesn't matter with log options
+	opts[LevelOpt] = "DeBuG"
+	lvl, ok := opts.GetLogLevel()
+	c.Assert(ok, Equals, true)
+	c.Assert(lvl, Equals, logrus.DebugLevel)
+
+	opts[LevelOpt] = "Invalid"
+	_, ok = opts.GetLogLevel()
+	c.Assert(ok, Equals, false)
+}
+
+func (s *LoggingSuite) TestConfigureLogLevelFromOptions(c *C) {
+	opts := LogOptions{}
+
+	// corresponding logrus level correctly returned
+	opts[LevelOpt] = "panic"
+	lvl := opts.configureLogLevelFromOptions()
+	c.Assert(lvl, Equals, logrus.PanicLevel)
+
+	// invalid level gets set to default value
+	opts[LevelOpt] = "invalid"
+	lvl = opts.configureLogLevelFromOptions()
+	c.Assert(lvl, Equals, LevelStringToLogrusLevel[DefaultLogLevelStr])
+
+	// no LogOpt provided returns default value and updates the map.
+	delete(opts, LevelOpt)
+	lvl = opts.configureLogLevelFromOptions()
+	c.Assert(lvl, Equals, LevelStringToLogrusLevel[DefaultLogLevelStr])
+	lvl, ok := opts.GetLogLevel()
+	c.Assert(ok, Equals, true)
+	c.Assert(lvl, Equals, LevelStringToLogrusLevel[DefaultLogLevelStr])
+
+}
+
+func (s *LoggingSuite) TestConfigureLogLevelGlobal(c *C) {
+	oldLevel := DefaultLogger.GetLevel()
+
+	// The joys of globals...
+	defer DefaultLogger.SetLevel(oldLevel)
+
+	ConfigureLogLevel(true)
+	lvl := DefaultLogger.GetLevel()
+	c.Assert(lvl, Equals, logrus.DebugLevel)
+
+	ConfigureLogLevel(false)
+	lvl = DefaultLogger.GetLevel()
+	c.Assert(lvl, Equals, LevelStringToLogrusLevel[DefaultLogLevelStr])
+
+}


### PR DESCRIPTION
The new option can be provided as follows to `cilium-agent`:

```
--log-opt level=error
```

If no option is set, or the provided option does not match a level for logrus,
use the default logging level (info level). If debug mode is not enabled,
endpoint loggers will use the logging level provided via the command-line
option, if there was one provided. If not, the endpoitn logger will default
to info level as well.

I added this because I thought I would be able to inject the logging level for
unit testing via a `-X` parameter when running `go test`, but given how we 
set up our loggers (in their own package), that didn't work very well. But, 
I didn't want my work to go to waste, so I posted this PR.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8607)
<!-- Reviewable:end -->
