### PR TITLE
policy: Expose L3 selectors within endpoint JSON

### DIFF
--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -117,7 +117,7 @@ type L4Filter struct {
 	// This includes selectors for destinations affected by entity-based
 	// and CIDR-based policy.
 	// Holds references to the CachedSelectors, which must be released!
-	CachedSelectors CachedSelectorSlice `json:"-"`
+	CachedSelectors CachedSelectorSlice `json:"l3-selectors,omitempty"`
 	// L7Parser specifies the L7 protocol parser (optional). If specified as
 	// an empty string, then means that no L7 proxy redirect is performed.
 	L7Parser L7ParserType `json:"-"`

--- a/pkg/policy/l4_test.go
+++ b/pkg/policy/l4_test.go
@@ -143,6 +143,9 @@ func (s *PolicyTestSuite) TestJSONMarshal(c *C) {
 	expectedIngress := []string{`{
   "port": 80,
   "protocol": "TCP",
+  "l3-selectors": [
+    "\u0026LabelSelector{MatchLabels:map[string]string{any.foo: ,},MatchExpressions:[],}"
+  ],
   "l7-rules": [
     {
       "\u0026LabelSelector{MatchLabels:map[string]string{any.foo: ,},MatchExpressions:[],}": {
@@ -159,6 +162,9 @@ func (s *PolicyTestSuite) TestJSONMarshal(c *C) {
 		`{
   "port": 9090,
   "protocol": "TCP",
+  "l3-selectors": [
+    "\u0026LabelSelector{MatchLabels:map[string]string{any.foo: ,},MatchExpressions:[],}"
+  ],
   "l7-rules": [
     {
       "\u0026LabelSelector{MatchLabels:map[string]string{any.foo: ,},MatchExpressions:[],}": {
@@ -180,6 +186,9 @@ func (s *PolicyTestSuite) TestJSONMarshal(c *C) {
 		`{
   "port": 8080,
   "protocol": "TCP",
+  "l3-selectors": [
+    "\u0026LabelSelector{MatchLabels:map[string]string{any.foo: ,},MatchExpressions:[],}"
+  ],
   "l7-rules": [
     {
       "\u0026LabelSelector{MatchLabels:map[string]string{any.foo: ,},MatchExpressions:[],}": {

--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -15,6 +15,8 @@
 package policy
 
 import (
+	"bytes"
+	"encoding/json"
 	"sort"
 	"strings"
 	"sync/atomic"
@@ -54,6 +56,24 @@ type CachedSelector interface {
 
 // CachedSelectorSlice is a slice of CachedSelectors that can be sorted.
 type CachedSelectorSlice []CachedSelector
+
+// MarshalJSON returns the CachedSelectors as JSON formatted buffer
+func (s CachedSelectorSlice) MarshalJSON() ([]byte, error) {
+	buffer := bytes.NewBufferString("[")
+	for i, selector := range s {
+		buf, err := json.Marshal(selector.String())
+		if err != nil {
+			return nil, err
+		}
+
+		buffer.Write(buf)
+		if i < len(s)-1 {
+			buffer.WriteString(",")
+		}
+	}
+	buffer.WriteString("]")
+	return buffer.Bytes(), nil
+}
 
 func (s CachedSelectorSlice) Len() int      { return len(s) }
 func (s CachedSelectorSlice) Swap(i, j int) { s[i], s[j] = s[j], s[i] }


### PR DESCRIPTION
Currently, these are omitted from the raw
endpoint JSON due to omitting `CachedSelectors`
from the `L4Filter` struct, which can lead to incomplete
information when retrieving the endpoint using:
    `cilium endpoint get $id -o json`.

This patch fixes this issue by exposing `CachedSelectors`
and registering a custom JSON serializer for its
`CachedSelectorSlice` type.

Fixes #8506

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8610)
<!-- Reviewable:end -->
