### PR TITLE
proxy: Perform dnsproxy Close() in the returned finalizeFunc

### DIFF
--- a/pkg/proxy/dns.go
+++ b/pkg/proxy/dns.go
@@ -105,19 +105,20 @@ func (dr *dnsRedirect) UpdateRules(wg *completion.WaitGroup, l4 *policy.L4Filter
 
 // Close the redirect.
 func (dr *dnsRedirect) Close(wg *completion.WaitGroup) (revert.FinalizeFunc, revert.RevertFunc) {
-	for _, rule := range dr.currentRules {
-		for _, dnsRule := range rule.DNS {
-			dnsName := strings.ToLower(dns.Fqdn(dnsRule.MatchName))
-			dnsNameAsRE := matchpattern.ToRegexp(dnsName)
-			DefaultDNSProxy.RemoveAllowed(dnsNameAsRE, fmt.Sprintf("%d", dr.redirect.endpointID))
+	return func() {
+		for _, rule := range dr.currentRules {
+			for _, dnsRule := range rule.DNS {
+				dnsName := strings.ToLower(dns.Fqdn(dnsRule.MatchName))
+				dnsNameAsRE := matchpattern.ToRegexp(dnsName)
+				DefaultDNSProxy.RemoveAllowed(dnsNameAsRE, fmt.Sprintf("%d", dr.redirect.endpointID))
 
-			dnsPattern := matchpattern.Sanitize(dnsRule.MatchPattern)
-			dnsPatternAsRE := matchpattern.ToRegexp(dnsPattern)
-			DefaultDNSProxy.RemoveAllowed(dnsPatternAsRE, fmt.Sprintf("%d", dr.redirect.endpointID))
+				dnsPattern := matchpattern.Sanitize(dnsRule.MatchPattern)
+				dnsPatternAsRE := matchpattern.ToRegexp(dnsPattern)
+				DefaultDNSProxy.RemoveAllowed(dnsPatternAsRE, fmt.Sprintf("%d", dr.redirect.endpointID))
+			}
 		}
-	}
-	dr.currentRules = nil
-	return func() {}, nil
+		dr.currentRules = nil
+	}, nil
 }
 
 // creatednsRedirect creates a redirect to the dns proxy. The redirect structure passed


### PR DESCRIPTION
Removing the dns redirect implementation state should be only
performed when we know all updates are successful, i.e., when the
returned finalizeFunc is run. Alternatively, we could revert the
changes in the revertFunc, but we'd rather remove the revertFunc
return value in a later commit.

This implementation is similar to `Close()` for Kafka redirects.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8612)
<!-- Reviewable:end -->
