### PR TITLE
health: Change cilium-health host-side veth link device name

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -498,6 +498,8 @@ func (m *IptablesManager) InstallRules(ifName string) error {
 		// it doesn't seem to handle all cases, e.g. host network pods that use
 		// the node IP which would still end up in default DENY. Similarly, for
 		// plain Docker setup, we would otherwise hit default DENY in FORWARD chain.
+		// Also, k8s 1.15 introduced "-m conntrack --ctstate INVALID -j DROP" which
+		// in the direct routing case can drop EP replies.
 		// Therefore, add both rules below to avoid having a user to manually opt-in.
 		// See also: https://github.com/kubernetes/kubernetes/issues/39823
 		if err := runProg("iptables", []string{


### PR DESCRIPTION
k8s 1.15 introduced the iptables rule `-A KUBE-FORWARD -m conntrack --ctstate INVALID -j DROP` which drops a packet if its CT entry is in INVALID state: https://github.com/kubernetes/kubernetes/pull/74840. The reason for this rule is to work around a nf_conntrack bug which marks a CT entry as INVALID if a client receives an ACK from a server which is above client's TCP window. The INVALID state prevents a packet from being reverse xlated which results in the connection being terminated by a host of the client which sends TCP RST to the server. (@borkmann @joestringer @jrfastab it's worth discussing whether we want to work around the nf_conntrack bug as well. UPDATE: as discussed offline, I will add the `--ctstate INVALID -j DROP` rule in between `-i lxc+ -j ACCEPT` and `-o lxc+ -j ACCEPT` in a separate PR).

Most likely, in the case of the direct routing mode when bpf_netdev is attached to a native device, a request packet avoids nf_conntrack hooks, thus no CT entry is created. For some reasons, passing the request to the stack instead of redirecting to EP's iface bypasses the hooks as well (tested on 5.2 kernel, see #8605 ), so no entry is created either way. A reply send from the EP gets dropped due to missing CT entry (=INVALID state) for the request.

Luckily, there is the iptables rule `-A CILIUM_FORWARD -i lxc+ -m comment --comment "cilium:  cluster->any on lxc+ forward accept" -j ACCEPT` which prevents from a reply of an EP being dropped. However, this does not apply to cilium-health EP as its host-side veth name is `cilium_health` which makes its reply to bypass the rule, and thus to be dropped.

This commit changes the iface name to `lxcciliumhealth` instead of adding a rule or extending the existing one (= adding more latency to the datapath). Unfortunately, `lxc_cilium_health` is above the dev name max limit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8614)
<!-- Reviewable:end -->
