### PR TITLE
endpoint: Create redirects before bpf map updates.

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1344,7 +1344,6 @@ func (e *Endpoint) LeaveLocked(owner regeneration.Owner, proxyWaitGroup *complet
 		if err != nil {
 			errors = append(errors, fmt.Errorf("unable to release identity: %s", err))
 		}
-		// TODO: Check if network policy was created even without SecurityIdentity
 		owner.RemoveNetworkPolicy(e)
 		e.SecurityIdentity = nil
 	}


### PR DESCRIPTION
Create new redirects and generate the new proxy policy before updating
bpf policy maps in order to give the proxies a chance to be ready when
new traffic is redirected at them. This could help reduce transient
drops in some cases.

Remove old redirects only if the endpoint has a security identity. To
begin with, endpoints can have redirects only if they have a security
identity, and the only instance where the endpoint's security identity
is nilled is when it is being destroyed.

Fixes: ea62a6b2eb2 ("endpoint: Fix sidecar proxy deadlock during BPF generation")
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8618)
<!-- Reviewable:end -->
