### PR TITLE
ip: add ip_darwin / ip_linux files

### DIFF
--- a/pkg/ip/ip.go
+++ b/pkg/ip/ip.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Authors of Cilium
+// Copyright 2017-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,9 +21,6 @@ import (
 	"math/big"
 	"net"
 	"sort"
-	"strings"
-
-	"github.com/vishvananda/netlink"
 )
 
 const (
@@ -754,39 +751,6 @@ func initPrivatePrefixes() {
 }
 
 var excludedIPs []net.IP
-
-func initExcludedIPs() {
-	// We exclude below bad device prefixes from address selection ...
-	prefixes := []string{
-		"docker",
-	}
-	links, err := netlink.LinkList()
-	if err != nil {
-		return
-	}
-	for _, l := range links {
-		// ... also all down devices since they won't be reachable.
-		if l.Attrs().OperState == netlink.OperUp {
-			skip := true
-			for _, p := range prefixes {
-				if strings.HasPrefix(l.Attrs().Name, p) {
-					skip = false
-					break
-				}
-			}
-			if skip {
-				continue
-			}
-		}
-		addr, err := netlink.AddrList(l, netlink.FAMILY_ALL)
-		if err != nil {
-			continue
-		}
-		for _, a := range addr {
-			excludedIPs = append(excludedIPs, a.IP)
-		}
-	}
-}
 
 func init() {
 	initPrivatePrefixes()

--- a/pkg/ip/ip_darwin.go
+++ b/pkg/ip/ip_darwin.go
@@ -1,0 +1,17 @@
+// Copyright 2017-2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ip
+
+func initExcludedIPs() {}

--- a/pkg/ip/ip_linux.go
+++ b/pkg/ip/ip_linux.go
@@ -1,0 +1,54 @@
+// Copyright 2017-2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ip
+
+import (
+	"strings"
+
+	"github.com/vishvananda/netlink"
+)
+
+func initExcludedIPs() {
+	// We exclude below bad device prefixes from address selection ...
+	prefixes := []string{
+		"docker",
+	}
+	links, err := netlink.LinkList()
+	if err != nil {
+		return
+	}
+	for _, l := range links {
+		// ... also all down devices since they won't be reachable.
+		if l.Attrs().OperState == netlink.OperUp {
+			skip := true
+			for _, p := range prefixes {
+				if strings.HasPrefix(l.Attrs().Name, p) {
+					skip = false
+					break
+				}
+			}
+			if skip {
+				continue
+			}
+		}
+		addr, err := netlink.AddrList(l, netlink.FAMILY_ALL)
+		if err != nil {
+			continue
+		}
+		for _, a := range addr {
+			excludedIPs = append(excludedIPs, a.IP)
+		}
+	}
+}


### PR DESCRIPTION
This ensures that the IP package is not compiled with the netlink dependency in
Darwin (Mac) environments. Packages are imported into the Ginkgo tests which
transitively imported `pkg/ip`, which caused running the Ginkgo tests locally to
not work:

```
$ K8S_VERSION=1.15 ginkgo --focus=K8sServicesTest -v -- -cilium.holdEnvironment=true -cilium.skipLogs=true -cilium.provision=false
Failed to compile test:

../pkg/ip/ip.go:781:36: undefined: netlink.FAMILY_ALL

Ginkgo ran 1 suite in 6.686508356s
Test Suite Failed
```

Factoring out the functions which depend on the netlink library into
a separate file for Linux / Darwin works around this problem.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8621)
<!-- Reviewable:end -->
