### PR TITLE
test: replace calls to `kubectl apply` using `ExecShort` with `ExecMiddle` in `ciliumInstall`

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -952,11 +952,11 @@ func (kub *Kubectl) ciliumInstall(dsPatchName, cmPatchName string, getK8sDescrip
 		// debugYaml only dumps the full created yaml file to the test output if
 		// the cilium manifest can not be created correctly.
 		debugYaml := func(original string) {
-			_ = kub.ExecShort(fmt.Sprintf("kubectl apply --filename='%s' --dry-run -o yaml", original))
+			_ = kub.ExecMiddle(fmt.Sprintf("kubectl apply --filename='%s' --dry-run -o yaml", original))
 		}
 
 		// validation 1st
-		res := kub.ExecShort(fmt.Sprintf("kubectl apply --filename='%s' --dry-run", original))
+		res := kub.ExecMiddle(fmt.Sprintf("kubectl apply --filename='%s' --dry-run", original))
 		if !res.WasSuccessful() {
 			debugYaml(original)
 			return res.GetErr("Cilium manifest validation fails")


### PR DESCRIPTION


Calls using `kubectl` apply shown to time out using a timeout of only 10
seconds:

```
time="2019-07-22T15:56:32Z" level=debug msg="running command: kubectl apply --filename='https://raw.githubusercontent.com/cilium/cilium/v1.5/examples/kubernetes/1.15/cilium-rbac.yaml' --dry-run"
time="2019-07-22T15:56:42Z" level=error msg="Error executing command 'kubectl apply --filename='https://raw.githubusercontent.com/cilium/cilium/v1.5/examples/kubernetes/1.15/cilium-rbac.yaml' --dry-run'" error="context deadline exceeded"
time="2019-07-22T15:56:42Z" level=error msg="Error executing command 'kubectl apply --filename='https://raw.githubusercontent.com/cilium/cilium/v1.5/examples/kubernetes/1.15/cilium-rbac.yaml' --dry-run'" error="context deadline exceeded"
cmd: "kubectl apply --filename='https://raw.githubusercontent.com/cilium/cilium/v1.5/examples/kubernetes/1.15/cilium-rbac.yaml' --dry-run" exitCode: 1 duration: 10.000253844s stdout:
time="2019-07-22T15:56:42Z" level=debug msg="running command: kubectl apply --filename='https://raw.githubusercontent.com/cilium/cilium/v1.5/examples/kubernetes/1.15/cilium-rbac.yaml' --dry-run -o yaml"
time="2019-07-22T15:56:52Z" level=error msg="Error executing command 'kubectl apply --filename='https://raw.githubusercontent.com/cilium/cilium/v1.5/examples/kubernetes/1.15/cilium-rbac.yaml' --dry-run -o yaml'" error="context deadline exceeded"
time="2019-07-22T15:56:52Z" level=error msg="Error executing command 'kubectl apply --filename='https://raw.githubusercontent.com/cilium/cilium/v1.5/examples/kubernetes/1.15/cilium-rbac.yaml' --dry-run -o yaml'" error="context deadline exceeded"
cmd: "kubectl apply --filename='https://raw.githubusercontent.com/cilium/cilium/v1.5/examples/kubernetes/1.15/cilium-rbac.yaml' --dry-run -o yaml" exitCode: 1 duration: 10.000289215s stdout:
```

Use `ExecMiddle` which has a longer timeout associated with its context to allow
for 30 seconds to pass before said commands fail.

Fixes: #8634

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8635)
<!-- Reviewable:end -->
