### PR TITLE
v1.5: backports 19 07 22

### DIFF
--- a/Documentation/gettingstarted/k8s-install-eks.rst
+++ b/Documentation/gettingstarted/k8s-install-eks.rst
@@ -101,7 +101,7 @@ Prepare the nodes for Cilium
 
 Deploy the following DaemonSet to prepare all EKS nodes for Cilium:
 
-   .. code:: bash
+   .. parsed-literal::
 
        kubectl -n kube-system apply -f \ |SCM_WEB|\/examples/kubernetes/node-init/eks-node-init.yaml
 

--- a/Documentation/gettingstarted/kube-router.rst
+++ b/Documentation/gettingstarted/kube-router.rst
@@ -142,7 +142,7 @@ installed:
 
 You can test connectivity by deploying the following connectivity checker pods:
 
-.. code:: bash
+.. parsed-literal::
 
     $ kubectl create -f \ |SCM_WEB|\/examples/kubernetes/connectivity-check/connectivity-check.yaml
     $ kubectl get pods

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -347,22 +347,8 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) (resto
 			// We don't need to hold the policy repository mutex here because
 			// the content of the rules themselves are not being changed.
 			d.policy.UpdateLocalConsumers([]policy.Endpoint{ep}).Wait()
-
-			if ep.GetStateLocked() == endpoint.StateWaitingToRegenerate {
-				ep.Unlock()
-				// EP is already waiting to regenerate. This is no error so no logging.
-				epRegenerated <- false
-				return
-			}
-
-			ready := ep.SetStateLocked(endpoint.StateWaitingToRegenerate, "Triggering synchronous endpoint regeneration while syncing state to host")
 			ep.Unlock()
 
-			if !ready {
-				scopedLog.WithField(logfields.EndpointState, ep.GetState()).Warn("Endpoint in inconsistent state")
-				epRegenerated <- false
-				return
-			}
 			regenerationMetadata := &endpoint.ExternalRegenerationMetadata{
 				Reason: "syncing state to host",
 			}

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -617,6 +617,34 @@ func (e *Endpoint) runPreCompilationSteps(owner Owner, regenContext *regeneratio
 
 		_ = e.updateAndOverrideEndpointOptions(nil)
 
+		// Configure the new network policy with the proxies.
+		// Do this before updating the bpf policy maps, so that the proxy listeners have a chance to be
+		// ready when new traffic is redirected to them.
+		stats.proxyPolicyCalculation.Start()
+		err, networkPolicyRevertFunc := e.updateNetworkPolicy(owner, datapathRegenCtxt.proxyWaitGroup)
+		stats.proxyPolicyCalculation.End(err == nil)
+		if err != nil {
+			return err
+		}
+		datapathRegenCtxt.revertStack.Push(networkPolicyRevertFunc)
+
+		// Walk the L4Policy to add new redirects and update the desired policy for existing redirects.
+		// Do this before updating the bpf policy maps, so that the proxies are ready when new traffic
+		// is redirected to them.
+		var desiredRedirects map[string]bool
+		var finalizeFunc revert.FinalizeFunc
+		var revertFunc revert.RevertFunc
+		if e.desiredPolicy != nil && e.desiredPolicy.L4Policy != nil && e.desiredPolicy.L4Policy.HasRedirect() {
+			stats.proxyConfiguration.Start()
+			desiredRedirects, err, finalizeFunc, revertFunc = e.addNewRedirects(owner, e.desiredPolicy.L4Policy, datapathRegenCtxt.proxyWaitGroup)
+			stats.proxyConfiguration.End(err == nil)
+			if err != nil {
+				return err
+			}
+			datapathRegenCtxt.finalizeList.Append(finalizeFunc)
+			datapathRegenCtxt.revertStack.Push(revertFunc)
+		}
+
 		// realizedBPFConfig may be updated at any point after we figure out
 		// whether ingress/egress policy is enabled.
 		e.desiredBPFConfig = bpfconfig.GetConfig(e)
@@ -628,7 +656,7 @@ func (e *Endpoint) runPreCompilationSteps(owner Owner, regenContext *regeneratio
 		// GH-3897 would fix this by creating a new map to do an atomic swap
 		// with the old one.
 		stats.mapSync.Start()
-		err := e.syncPolicyMap()
+		err = e.syncPolicyMap()
 		stats.mapSync.End(err == nil)
 		if err != nil {
 			return fmt.Errorf("unable to regenerate policy because PolicyMap synchronization failed: %s", err)
@@ -648,41 +676,15 @@ func (e *Endpoint) runPreCompilationSteps(owner Owner, regenContext *regeneratio
 			return e.bpfConfigMap.Update(e.realizedBPFConfig)
 		})
 
-		// Configure the new network policy with the proxies.
-		stats.proxyPolicyCalculation.Start()
-		var networkPolicyRevertFunc revert.RevertFunc
-		err, networkPolicyRevertFunc = e.updateNetworkPolicy(owner, datapathRegenCtxt.proxyWaitGroup)
-		stats.proxyPolicyCalculation.End(err == nil)
-		if err != nil {
-			return err
-		}
-
-		datapathRegenCtxt.revertStack.Push(networkPolicyRevertFunc)
-	}
-
-	stats.proxyConfiguration.Start()
-	var finalizeFunc revert.FinalizeFunc
-	var revertFunc revert.RevertFunc
-	// Walk the L4Policy to add new redirects and update the desired policy map
-	// state to set the newly allocated proxy ports.
-	var desiredRedirects map[string]bool
-	if e.desiredPolicy != nil && e.desiredPolicy.L4Policy != nil {
-		desiredRedirects, err, finalizeFunc, revertFunc = e.addNewRedirects(owner, e.desiredPolicy.L4Policy, datapathRegenCtxt.proxyWaitGroup)
-		if err != nil {
-			stats.proxyConfiguration.End(false)
-			return err
-		}
+		// At this point, traffic is no longer redirected to the proxy for
+		// now-obsolete redirects, since we synced the updated policy map above.
+		// It's now safe to remove the redirects from the proxy's configuration.
+		stats.proxyConfiguration.Start()
+		finalizeFunc, revertFunc = e.removeOldRedirects(owner, desiredRedirects, datapathRegenCtxt.proxyWaitGroup)
 		datapathRegenCtxt.finalizeList.Append(finalizeFunc)
 		datapathRegenCtxt.revertStack.Push(revertFunc)
+		stats.proxyConfiguration.End(true)
 	}
-
-	// At this point, traffic is no longer redirected to the proxy for
-	// now-obsolete redirects, since we synced the updated policy map above.
-	// It's now safe to remove the redirects from the proxy's configuration.
-	finalizeFunc, revertFunc = e.removeOldRedirects(owner, desiredRedirects, datapathRegenCtxt.proxyWaitGroup)
-	datapathRegenCtxt.finalizeList.Append(finalizeFunc)
-	datapathRegenCtxt.revertStack.Push(revertFunc)
-	stats.proxyConfiguration.End(true)
 
 	stats.prepareBuild.Start()
 	defer func() {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1323,7 +1323,6 @@ func (e *Endpoint) LeaveLocked(owner Owner, proxyWaitGroup *completion.WaitGroup
 		if err != nil {
 			errors = append(errors, fmt.Errorf("unable to release identity: %s", err))
 		}
-		// TODO: Check if network policy was created even without SecurityIdentity
 		owner.RemoveNetworkPolicy(e)
 		e.SecurityIdentity = nil
 	}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1570,7 +1570,7 @@ func (e *Endpoint) SetStateLocked(toState, reason string) bool {
 		}
 	case StateRestoring:
 		switch toState {
-		case StateDisconnecting, StateWaitingToRegenerate, StateRestoring:
+		case StateDisconnecting, StateRestoring:
 			goto OKState
 		}
 	}
@@ -1613,7 +1613,7 @@ func (e *Endpoint) BuilderSetStateLocked(toState, reason string) bool {
 	switch fromState { // From state
 	case StateCreating, StateWaitingForIdentity, StateReady, StateDisconnecting, StateDisconnected:
 		// No valid transitions for the builder
-	case StateWaitingToRegenerate:
+	case StateWaitingToRegenerate, StateRestoring:
 		switch toState {
 		// Builder transitions the endpoint from
 		// waiting-to-regenerate state to regenerating state

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -280,6 +280,10 @@ func (s *EndpointSuite) TestEndpointState(c *C) {
 	// Builder transitions to ready state after build is done
 	c.Assert(e.BuilderSetStateLocked(StateReady, "test"), Equals, true)
 
+	// Check that direct transition from restoring --> regenerating is valid.
+	e.state = StateRestoring
+	c.Assert(e.BuilderSetStateLocked(StateRegenerating, "test"), Equals, true)
+
 	// Typical lifecycle
 	e.state = StateCreating
 	c.Assert(e.SetStateLocked(StateWaitingForIdentity, "test"), Equals, true)
@@ -305,6 +309,15 @@ func (s *EndpointSuite) TestEndpointState(c *C) {
 	// parallel disconnect fails
 	c.Assert(e.SetStateLocked(StateDisconnecting, "test"), Equals, false)
 	c.Assert(e.SetStateLocked(StateDisconnected, "test"), Equals, true)
+
+	// Restoring state
+	e.state = StateRestoring
+	c.Assert(e.SetStateLocked(StateWaitingToRegenerate, "test"), Equals, false)
+	c.Assert(e.SetStateLocked(StateDisconnecting, "test"), Equals, true)
+
+	e.state = StateRestoring
+	c.Assert(e.SetStateLocked(StateRestoring, "test"), Equals, true)
+
 }
 
 func (s *EndpointSuite) TestWaitForPolicyRevision(c *C) {

--- a/pkg/kvstore/store/store.go
+++ b/pkg/kvstore/store/store.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/pkg/controller"
+	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
@@ -257,6 +258,10 @@ func (s *SharedStore) Close() {
 		}
 
 		delete(s.localKeys, name)
+		// Since we have received our own notification we also need to remove
+		// it from the shared keys.
+		delete(s.sharedKeys, name)
+
 		s.onDelete(key)
 	}
 }
@@ -426,14 +431,26 @@ func (s *SharedStore) updateKey(name string, value []byte) error {
 	return nil
 }
 
-func (s *SharedStore) deleteKey(name string) {
+func (s *SharedStore) deleteSharedKey(name string) {
 	s.mutex.Lock()
 	existingKey, ok := s.sharedKeys[name]
 	delete(s.sharedKeys, name)
 	s.mutex.Unlock()
 
 	if ok {
-		s.onDelete(existingKey)
+		go func() {
+			time.Sleep(defaults.NodeDeleteDelay)
+			s.mutex.RLock()
+			_, ok := s.sharedKeys[name]
+			s.mutex.RUnlock()
+			if ok {
+				log.Warningf("Received node delete event for node %s which re-appeared within %s",
+					name, defaults.NodeDeleteDelay)
+				return
+			}
+
+			s.onDelete(existingKey)
+		}()
 	} else {
 		s.getLogger().WithField("key", name).
 			Warning("Unable to find deleted key in local state")
@@ -494,7 +511,7 @@ func (s *SharedStore) watcher(listDone chan bool) {
 
 					s.syncLocalKey(localKey)
 				} else {
-					s.deleteKey(keyName)
+					s.deleteSharedKey(keyName)
 				}
 			}
 		}

--- a/pkg/kvstore/store/store_test.go
+++ b/pkg/kvstore/store/store_test.go
@@ -69,6 +69,7 @@ func (e *StoreConsulSuite) SetUpTest(c *C) {
 func (e *StoreConsulSuite) TearDownTest(c *C) {
 	kvstore.DeletePrefix(testPrefix)
 	kvstore.Close()
+	time.Sleep(defaults.NodeDeleteDelay + 5*time.Second)
 }
 
 type TestType struct {
@@ -198,7 +199,7 @@ func (s *StoreSuite) TestStoreOperations(c *C) {
 	c.Assert(expect(func() bool { return localKey3.updated() == 0 }), IsNil)
 
 	store.DeleteLocalKey(&localKey1)
-	// localKey2 will be deleted 2 times, one from local key and other from
+	// localKey1 will be deleted 2 times, one from local key and other from
 	// the kvstore watcher
 	c.Assert(expect(func() bool { return localKey1.deleted() == 2 }), IsNil)
 	c.Assert(expect(func() bool { return localKey2.deleted() == 0 }), IsNil)
@@ -242,8 +243,8 @@ func (s *StoreSuite) TestStorePeriodicSync(c *C) {
 	store.DeleteLocalKey(&localKey1)
 	store.DeleteLocalKey(&localKey2)
 
-	c.Assert(expect(func() bool { return localKey1.deleted() >= 1 }), IsNil)
-	c.Assert(expect(func() bool { return localKey2.deleted() >= 1 }), IsNil)
+	c.Assert(expect(func() bool { return localKey1.deleted() == 1 }), IsNil)
+	c.Assert(expect(func() bool { return localKey2.deleted() == 1 }), IsNil)
 }
 
 func (s *StoreSuite) TestStoreLocalKeyProtection(c *C) {

--- a/pkg/node/store/store.go
+++ b/pkg/node/store/store.go
@@ -16,9 +16,7 @@ package store
 
 import (
 	"path"
-	"time"
 
-	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/kvstore"
@@ -88,26 +86,16 @@ func (o *NodeObserver) OnDelete(k store.NamedKey) {
 		nodeCopy := n.DeepCopy()
 		nodeCopy.Source = node.FromKVStore
 
-		go func() {
-			time.Sleep(defaults.NodeDeleteDelay)
+		o.manager.NodeDeleted(*nodeCopy)
 
-			if o.manager.Exists(nodeCopy.Identity()) {
-				log.Warningf("Received node delete event for node %s which re-appeared within %s",
-					nodeCopy.Name, defaults.NodeDeleteDelay)
-				return
-			}
-
-			o.manager.NodeDeleted(*nodeCopy)
-
-			ciliumIPv4 := nodeCopy.GetCiliumInternalIP(false)
-			if ciliumIPv4 != nil {
-				ipcache.IPIdentityCache.Delete(ciliumIPv4.String(), ipcache.FromKVStore)
-			}
-			ciliumIPv6 := nodeCopy.GetCiliumInternalIP(true)
-			if ciliumIPv6 != nil {
-				ipcache.IPIdentityCache.Delete(ciliumIPv6.String(), ipcache.FromKVStore)
-			}
-		}()
+		ciliumIPv4 := nodeCopy.GetCiliumInternalIP(false)
+		if ciliumIPv4 != nil {
+			ipcache.IPIdentityCache.Delete(ciliumIPv4.String(), ipcache.FromKVStore)
+		}
+		ciliumIPv6 := nodeCopy.GetCiliumInternalIP(true)
+		if ciliumIPv6 != nil {
+			ipcache.IPIdentityCache.Delete(ciliumIPv6.String(), ipcache.FromKVStore)
+		}
 	}
 }
 

--- a/pkg/proxy/dns.go
+++ b/pkg/proxy/dns.go
@@ -105,19 +105,20 @@ func (dr *dnsRedirect) UpdateRules(wg *completion.WaitGroup, l4 *policy.L4Filter
 
 // Close the redirect.
 func (dr *dnsRedirect) Close(wg *completion.WaitGroup) (revert.FinalizeFunc, revert.RevertFunc) {
-	for _, rule := range dr.currentRules {
-		for _, dnsRule := range rule.DNS {
-			dnsName := strings.ToLower(dns.Fqdn(dnsRule.MatchName))
-			dnsNameAsRE := matchpattern.ToRegexp(dnsName)
-			DefaultDNSProxy.RemoveAllowed(dnsNameAsRE, fmt.Sprintf("%d", dr.redirect.endpointID))
+	return func() {
+		for _, rule := range dr.currentRules {
+			for _, dnsRule := range rule.DNS {
+				dnsName := strings.ToLower(dns.Fqdn(dnsRule.MatchName))
+				dnsNameAsRE := matchpattern.ToRegexp(dnsName)
+				DefaultDNSProxy.RemoveAllowed(dnsNameAsRE, fmt.Sprintf("%d", dr.redirect.endpointID))
 
-			dnsPattern := matchpattern.Sanitize(dnsRule.MatchPattern)
-			dnsPatternAsRE := matchpattern.ToRegexp(dnsPattern)
-			DefaultDNSProxy.RemoveAllowed(dnsPatternAsRE, fmt.Sprintf("%d", dr.redirect.endpointID))
+				dnsPattern := matchpattern.Sanitize(dnsRule.MatchPattern)
+				dnsPatternAsRE := matchpattern.ToRegexp(dnsPattern)
+				DefaultDNSProxy.RemoveAllowed(dnsPatternAsRE, fmt.Sprintf("%d", dr.redirect.endpointID))
+			}
 		}
-	}
-	dr.currentRules = nil
-	return func() {}, nil
+		dr.currentRules = nil
+	}, nil
 }
 
 // creatednsRedirect creates a redirect to the dns proxy. The redirect structure passed

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -258,8 +258,11 @@ var _ = Describe("RuntimePolicies", func() {
 
 	BeforeAll(func() {
 		vm = helpers.InitRuntimeHelper(helpers.Runtime, logger)
+		// Make sure that Cilium is started with appropriate CLI options
+		// (specifically to exclude the local addresses that are populated for
+		// CIDR policy tests).
+		Expect(vm.SetUpCilium()).To(BeNil())
 		ExpectCiliumReady(vm)
-
 		vm.SampleContainersActions(helpers.Create, helpers.CiliumDockerNetwork)
 		vm.PolicyDelAll()
 
@@ -1526,7 +1529,7 @@ var _ = Describe("RuntimePolicies", func() {
 					curlFailures++
 				}
 			}
-			Expect(curlFailures).To(BeNumerically("<=", 1), "Curl to %q have failed more than once")
+			Expect(curlFailures).To(BeNumerically("<=", 1), "Curl to %q have failed more than once", cloudFlare)
 
 			By("Pinging %q from %q (should not work)", api.EntityHost, helpers.App1)
 			res = vm.ContainerExec(helpers.App1, helpers.Ping(cloudFlare))


### PR DESCRIPTION
Backported PRs:

* PR: 8508 -- test: move creation of Istio resources into `It` (@ianvernon) -- https://github.com/cilium/cilium/pull/8508
* **had conflicts** PR: 8547 -- operator: restart non-managed kube-dns pods before connecting to etcd (@aanm) -- https://github.com/cilium/cilium/pull/8547
* **had conflicts** PR: 8544 -- pkg/{kvstore,node}: delay node delete event in kvstore (@aanm) -- https://github.com/cilium/cilium/pull/8544
* PR: 8575 -- docs: Fix up unparsed SCM_WEB literals (@joestringer) -- https://github.com/cilium/cilium/pull/8575
* PR: 8579 -- test: add `ExecMiddle` function (@ianvernon) -- https://github.com/cilium/cilium/pull/8579
* PR: 8548 -- test: misc. runtime policy test fixes (@ianvernon) -- https://github.com/cilium/cilium/pull/8548
* **had conflicts** PR: 8551 -- RFC: endpoint: change transition from restore state (@ianvernon) -- https://github.com/cilium/cilium/pull/8551
* PR: 8612 -- proxy: Perform dnsproxy Close() in the returned finalizeFunc (@jrajahalme) -- https://github.com/cilium/cilium/pull/8612
* **had conflicts** PR: 8618 -- endpoint: Create redirects before bpf map updates. (@jrajahalme) -- https://github.com/cilium/cilium/pull/8618 
* PR: #8611 -- pkg/kvstore: wait for node delete delay in unit tests (@aanm) -- https://github.com/cilium/cilium/pull/8611 

Not backported due to conflicts that were difficult to resolve:

 * **had conflicts** PR: 8583 -- proxy: Do not error out if reading of open ports fails. (@jrajahalme) -- https://github.com/cilium/cilium/pull/8583
* **had conflicts** PR: 8566 -- daemon: Remove svc from cache in syncLBMapsWithK8s (@brb) -- https://github.com/cilium/cilium/pull/8566
* **had conflicts** PR: 8581 -- envoy: Add SO_MARK option to listener config (@jrajahalme) -- https://github.com/cilium/cilium/pull/8581

When you have backported the above commits, you can update the PR labels via this command:
```
$ for pr in 8508 8547 8544 8575 8579 8581 8548 8551 8612 8618; do contrib/backporting/set-labels.py $pr done 1.5; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8640)
<!-- Reviewable:end -->