### PR TITLE
daemon: register warning_error metric after parsing CLI options

### DIFF
--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -120,10 +120,6 @@ var (
 	bootstrapStats = bootstrapStatistics{}
 )
 
-func init() {
-	logging.DefaultLogger.Hooks.Add(metrics.NewLoggingHook(components.CiliumAgentName))
-}
-
 func daemonMain() {
 	bootstrapStats.overall.Start()
 
@@ -889,6 +885,9 @@ func initConfig() {
 func initEnv(cmd *cobra.Command) {
 	// Prepopulate option.Config with options from CLI.
 	option.Config.Populate()
+
+	// add hooks after setting up metrics in the option.Confog
+	logging.DefaultLogger.Hooks.Add(metrics.NewLoggingHook(components.CiliumAgentName))
 
 	// Logging should always be bootstrapped first. Do not add any code above this!
 	logging.SetupLogging(option.Config.LogDriver, option.Config.LogOpt, "cilium-agent", option.Config.Debug)


### PR DESCRIPTION
As the logger was being setup in an init function, and since the metrics
are only enabled after parsing the configuration flag, the default
metrics function being used was a NoOp which was causing the metric from
not being reported.

Fixes: 0fec218c33ff ("pkg/metrics: set all metrics as a no-op unless they are enabled")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8644)
<!-- Reviewable:end -->
