### PR TITLE
Fix seds in microk8s docs

### DIFF
--- a/Documentation/gettingstarted/microk8s.rst
+++ b/Documentation/gettingstarted/microk8s.rst
@@ -33,8 +33,8 @@ Install microk8s
 
       echo "--allow-privileged" >> /var/snap/microk8s/current/args/kube-apiserver
       sed -i 's/--network-plugin=kubenet/--network-plugin=cni/g'  /var/snap/microk8s/current/args/kubelet
-      sed -i 's/--cni-bin-dir=${SNAP}\/opt/--cni-bin-dir=\/opt/g'  /var/snap/microk8s/current/args/kubelet
-      sed -i 's/bin_dir = "${SNAP}\/opt/bin_dir = "\/opt/g'  /var/snap/microk8s/current/args/containerd-template.toml
+      sed -i 's;--cni-bin-dir=${SNAP}/opt;--cni-bin-dir=/opt;g'  /var/snap/microk8s/current/args/kubelet
+      sed -i 's;bin_dir = "${SNAP}/opt;bin_dir = "/opt;g'  /var/snap/microk8s/current/args/containerd-template.toml
       rm /var/snap/microk8s/current/args/cni-network/cni.conf
       curl \ |SCM_WEB|\/plugins/cilium-cni/05-cilium-cni.conf > /var/snap/microk8s/current/args/cni-network/05-cilium.conf
       systemctl restart snap.microk8s.daemon-containerd.service


### PR DESCRIPTION
Sed commands rendered without backslashes which caused them to not be
copy-able. Use semicolon as the delimiter for sed substitutions with
paths.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8647)
<!-- Reviewable:end -->
