### PR TITLE
daemon: Fix removal of non-existing SVCs in syncLBMapsWithK8s

### DIFF
--- a/daemon/loadbalancer.go
+++ b/daemon/loadbalancer.go
@@ -708,7 +708,7 @@ func (d *Daemon) syncLBMapsWithK8s() error {
 	for _, svc := range k8sDeletedServices {
 		svcLogger := log.WithField(logfields.Object, logfields.Repr(svc))
 		svcLogger.Debug("removing service because it was not synced from Kubernetes")
-		if err := d.svcDeleteByFrontendLocked(&svc); err != nil {
+		if err := d.svcDeleteBPF(svc); err != nil {
 			bpfDeleteErrors = append(bpfDeleteErrors, err)
 		}
 	}


### PR DESCRIPTION
59315dcdcf missed the fact that population of `daemon.loadBalancer` happens only via k8s_watcher's `UpdateService`. So, in the case of a non-existing SVC, `daemon.loadBalancer` doesn't have an entry for
the SVC.

Revert the change, but keep the locking at the top of the function.

Fixes: 59315dcdcf ("daemon: Remove svc from cache in syncLBMapsWithK8s")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8650)
<!-- Reviewable:end -->
