### PR TITLE
examples: Add CILIUM_WAIT_BPF_MOUNT variable to minikube DS

### DIFF
--- a/examples/kubernetes/1.10/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-minikube-ds.yaml
@@ -168,6 +168,12 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state

--- a/examples/kubernetes/1.10/cilium-minikube.yaml
+++ b/examples/kubernetes/1.10/cilium-minikube.yaml
@@ -365,6 +365,12 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state

--- a/examples/kubernetes/1.11/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-minikube-ds.yaml
@@ -168,6 +168,12 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state

--- a/examples/kubernetes/1.11/cilium-minikube.yaml
+++ b/examples/kubernetes/1.11/cilium-minikube.yaml
@@ -365,6 +365,12 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state

--- a/examples/kubernetes/1.12/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-minikube-ds.yaml
@@ -168,6 +168,12 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state

--- a/examples/kubernetes/1.12/cilium-minikube.yaml
+++ b/examples/kubernetes/1.12/cilium-minikube.yaml
@@ -365,6 +365,12 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state

--- a/examples/kubernetes/1.13/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-minikube-ds.yaml
@@ -168,6 +168,12 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state

--- a/examples/kubernetes/1.13/cilium-minikube.yaml
+++ b/examples/kubernetes/1.13/cilium-minikube.yaml
@@ -365,6 +365,12 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state

--- a/examples/kubernetes/1.14/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.14/cilium-minikube-ds.yaml
@@ -168,6 +168,12 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state

--- a/examples/kubernetes/1.14/cilium-minikube.yaml
+++ b/examples/kubernetes/1.14/cilium-minikube.yaml
@@ -365,6 +365,12 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state

--- a/examples/kubernetes/1.15/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.15/cilium-minikube-ds.yaml
@@ -168,6 +168,12 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state

--- a/examples/kubernetes/1.15/cilium-minikube.yaml
+++ b/examples/kubernetes/1.15/cilium-minikube.yaml
@@ -365,6 +365,12 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state

--- a/examples/kubernetes/templates/v1/cilium-minikube-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-minikube-ds.yaml.sed
@@ -168,6 +168,12 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:__CILIUM_INIT_VERSION__
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state


### PR DESCRIPTION
The variable CILIUM_WAIT_BPF_MOUNT was missing in minikube DaemonSet
which made wait-bpf-config ConfigMap key not having any effect on the
init script.

Fixes #8646

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8651)
<!-- Reviewable:end -->
