### PR TITLE
endpoint: Do not error out when bpf map entry is already deleted.

### DIFF
--- a/pkg/maps/policymap/policymap.go
+++ b/pkg/maps/policymap/policymap.go
@@ -17,6 +17,7 @@ package policymap
 import (
 	"bytes"
 	"fmt"
+	"syscall"
 	"unsafe"
 
 	"github.com/cilium/cilium/pkg/bpf"
@@ -198,9 +199,9 @@ func (pm *PolicyMap) Exists(id uint32, dport uint16, proto u8proto.U8proto, traf
 
 // DeleteKey deletes the key-value pair from the given PolicyMap with PolicyKey
 // k. Returns an error if deletion from the PolicyMap fails.
-func (pm *PolicyMap) DeleteKey(key PolicyKey) error {
+func (pm *PolicyMap) DeleteKeyWithErrno(key PolicyKey) (error, syscall.Errno) {
 	k := key.ToNetwork()
-	return pm.Map.Delete(&k)
+	return pm.Map.DeleteWithErrno(&k)
 }
 
 // Delete removes an entry from the PolicyMap for identity `id`

--- a/pkg/maps/policymap/policymap_privileged_test.go
+++ b/pkg/maps/policymap/policymap_privileged_test.go
@@ -19,10 +19,13 @@ package policymap
 import (
 	"fmt"
 	"os"
+	"syscall"
 	"testing"
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/checker"
+	"github.com/cilium/cilium/pkg/policy/trafficdirection"
+	"github.com/cilium/cilium/pkg/u8proto"
 
 	. "gopkg.in/check.v1"
 )
@@ -91,4 +94,11 @@ func (pm *PolicyMapTestSuite) TestPolicyMapDumpToSlice(c *C) {
 	dump, err = testMap.DumpToSlice()
 	c.Assert(err, IsNil)
 	c.Assert(len(dump), Equals, 2)
+}
+
+func (pm *PolicyMapTestSuite) TestDeleteNonexistentKey(c *C) {
+	key := newKey(27, 80, u8proto.ANY, trafficdirection.Ingress)
+	err, errno := testMap.Map.DeleteWithErrno(&key)
+	c.Assert(err, Not(IsNil))
+	c.Assert(errno, Equals, syscall.ENOENT)
 }


### PR DESCRIPTION
Do not error out if the map entry was already deleted from the bpf
map.  Incremental updates depend on this being OK in cases where
identity change events overlap with full policy computation.  In other
cases we only delete entries that exist, but even in that case it is
better to not error out if the map entry has been deleted in the
meanwhile.

Fixes: 7cca091b9dd ("endpoint: Use accumulated map changes for policy updates")
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8655)
<!-- Reviewable:end -->
