### PR TITLE
v1.5: backports 19-07-23

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1490,7 +1490,7 @@
     "storage/v1beta1",
   ]
   pruneopts = "NUT"
-  revision = "kubernetes-1.15.0"
+  revision = "kubernetes-1.15.1"
 
 [[projects]]
   digest = "1:2c1e111c1b0793e7b2e3bfe64743ce68c02035d30fd7bf540edfbd7b9ae318e0"
@@ -1504,7 +1504,7 @@
     "pkg/features",
   ]
   pruneopts = "NUT"
-  revision = "kubernetes-1.15.0"
+  revision = "kubernetes-1.15.1"
 
 [[projects]]
   digest = "1:81e06243f0372a0dd83e81fdca810b2128321e578f494f00b150d500fe504abb"
@@ -1555,7 +1555,7 @@
     "third_party/forked/golang/reflect",
   ]
   pruneopts = "NUT"
-  revision = "kubernetes-1.15.0"
+  revision = "kubernetes-1.15.1"
 
 [[projects]]
   digest = "1:2e3f244d6f43f038d3fa4450be13ca29574df19f32f64f358a75c24770d5f002"
@@ -1565,7 +1565,7 @@
     "pkg/util/feature",
   ]
   pruneopts = "NUT"
-  revision = "kubernetes-1.15.0"
+  revision = "kubernetes-1.15.1"
 
 [[projects]]
   digest = "1:de42297763aabde3e66c7880eec6c5338344d1aa94cf96be7614fa9ea7ad9c4e"
@@ -1695,7 +1695,7 @@
     "pkg/util",
   ]
   pruneopts = "T"
-  revision = "kubernetes-1.15.0"
+  revision = "kubernetes-1.15.1"
 
 [[projects]]
   branch = "master"
@@ -1710,7 +1710,7 @@
   name = "k8s.io/cri-api"
   packages = ["pkg/apis/runtime/v1alpha2"]
   pruneopts = "NUT"
-  revision = "kubernetes-1.15.0"
+  revision = "kubernetes-1.15.1"
 
 [[projects]]
   digest = "1:61024ed77a53ac618effed55043bf6a9afbdeb64136bd6a5b0c992d4c0363766"
@@ -1756,7 +1756,7 @@
     "pkg/registry/core/service/ipallocator",
   ]
   pruneopts = "NUT"
-  revision = "v1.15.0"
+  revision = "v1.15.1"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -497,28 +497,28 @@ required = [
 
 [[constraint]]
   name = "k8s.io/api"
-  revision = "kubernetes-1.15.0"
+  revision = "kubernetes-1.15.1"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
 
 [[constraint]]
   name = "k8s.io/apiextensions-apiserver"
-  revision = "kubernetes-1.15.0"
+  revision = "kubernetes-1.15.1"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
 
 [[override]]
   name = "k8s.io/apiserver"
-  revision = "kubernetes-1.15.0"
+  revision = "kubernetes-1.15.1"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
 
 [[constraint]]
   name = "k8s.io/apimachinery"
-  revision = "kubernetes-1.15.0"
+  revision = "kubernetes-1.15.1"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
@@ -533,7 +533,7 @@ required = [
 
 [[constraint]]
   name = "k8s.io/code-generator"
-  revision = "kubernetes-1.15.0"
+  revision = "kubernetes-1.15.1"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
@@ -547,14 +547,14 @@ required = [
 
 [[constraint]]
   name = "k8s.io/kubernetes"
-  revision = "v1.15.0"
+  revision = "v1.15.1"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
 
 [[constraint]]
   name = "k8s.io/cri-api"
-  revision = "kubernetes-1.15.0"
+  revision = "kubernetes-1.15.1"
 
   # main-usage = "pkg/workloads"
   # on-revision = ""

--- a/daemon/loadbalancer.go
+++ b/daemon/loadbalancer.go
@@ -800,7 +800,7 @@ func (d *Daemon) syncLBMapsWithK8s() error {
 	for _, svc := range k8sDeletedServices {
 		svcLogger := log.WithField(logfields.Object, logfields.Repr(svc))
 		svcLogger.Debug("removing service because it was not synced from Kubernetes")
-		if err := d.svcDeleteByFrontendLocked(&svc); err != nil {
+		if err := d.svcDeleteBPF(svc); err != nil {
 			bpfDeleteErrors = append(bpfDeleteErrors, err)
 		}
 	}

--- a/daemon/loadbalancer.go
+++ b/daemon/loadbalancer.go
@@ -728,11 +728,11 @@ func (d *Daemon) syncLBMapsWithK8s() error {
 	// Maps service IDs to whether they are IPv6 (true) or IPv4 (false).
 	k8sDeletedRevNATS := make(map[loadbalancer.ServiceID]bool)
 
-	// Set of L3n4Addrs in string form for storage as a key in map.
-	k8sServicesFrontendAddresses := d.k8sSvcCache.UniqueServiceFrontends()
-
 	d.loadBalancer.BPFMapMU.Lock()
 	defer d.loadBalancer.BPFMapMU.Unlock()
+
+	// Set of L3n4Addrs in string form for storage as a key in map.
+	k8sServicesFrontendAddresses := d.k8sSvcCache.UniqueServiceFrontends()
 
 	log.Debugf("dumping BPF service maps to userspace")
 	// At this point the creation of the v2 svc from the corresponding legacy
@@ -800,7 +800,7 @@ func (d *Daemon) syncLBMapsWithK8s() error {
 	for _, svc := range k8sDeletedServices {
 		svcLogger := log.WithField(logfields.Object, logfields.Repr(svc))
 		svcLogger.Debug("removing service because it was not synced from Kubernetes")
-		if err := d.svcDeleteBPF(svc); err != nil {
+		if err := d.svcDeleteByFrontendLocked(&svc); err != nil {
 			bpfDeleteErrors = append(bpfDeleteErrors, err)
 		}
 	}

--- a/examples/kubernetes-ingress/scripts/helpers.bash
+++ b/examples/kubernetes-ingress/scripts/helpers.bash
@@ -76,7 +76,7 @@ cluster_api_server_ip=${K8S_CLUSTER_API_SERVER_IP:-"172.20.0.1"}
 #cluster_dns_ip=${K8S_CLUSTER_DNS_IP:-"FD03::A"}
 #cluster_api_server_ip=${K8S_CLUSTER_API_SERVER_IP:-"FD03::1"}
 
-k8s_version="v1.14.0"
+k8s_version="v1.15.1"
 etcd_version="v3.3.12"
 
 function restore_flag {

--- a/flannel.Jenkinsfile
+++ b/flannel.Jenkinsfile
@@ -12,6 +12,7 @@ pipeline {
         SERVER_BOX = "cilium/ubuntu"
         NETNEXT=setIfLabel("ci/net-next", "true", "false")
         CNI_INTEGRATION="flannel"
+        GINKGO_TIMEOUT="73m"
     }
 
     options {
@@ -83,11 +84,11 @@ pipeline {
                     parallel(
                         "K8s-1.10":{
                             sh 'cd ${TESTDIR}; K8S_VERSION=1.10 vagrant provision k8s1-1.10; K8S_VERSION=1.10 vagrant provision k8s2-1.10'
-                            sh 'cd ${TESTDIR}; K8S_VERSION=1.10 ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
+                            sh 'cd ${TESTDIR}; K8S_VERSION=1.10 ginkgo --timeout=${GINKGO_TIMEOUT} --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
                         },
                         "K8s-1.13":{
                             sh 'cd ${TESTDIR}; K8S_VERSION=1.13 vagrant provision k8s1-1.13; K8S_VERSION=1.13 vagrant provision k8s2-1.13'
-                            sh 'cd ${TESTDIR}; K8S_VERSION=1.13 ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
+                            sh 'cd ${TESTDIR}; K8S_VERSION=1.13 ginkgo --timeout=${GINKGO_TIMEOUT} --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
                         },
                         failFast: "${FAILFAST}".toBoolean()
                     )

--- a/ginkgo-kubernetes-all.Jenkinsfile
+++ b/ginkgo-kubernetes-all.Jenkinsfile
@@ -39,6 +39,7 @@ pipeline {
         SERVER_BOX = "cilium/ubuntu"
         FAILFAST=setIfLabel("ci/fail-fast", "true", "false")
         CNI_INTEGRATION=setIfLabel("integration/cni-flannel", "FLANNEL", "")
+        GINKGO_TIMEOUT="98m"
     }
 
     options {
@@ -153,7 +154,7 @@ pipeline {
                         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
                     }
                     steps {
-                        sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
+                        sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} ginkgo --timeout=${GINKGO_TIMEOUT} --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
                     }
                     post {
                         always {
@@ -179,7 +180,7 @@ pipeline {
                         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
                     }
                     steps {
-                        sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
+                        sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} ginkgo --timeout=${GINKGO_TIMEOUT} --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
                     }
                     post {
                         always {
@@ -278,7 +279,7 @@ pipeline {
                         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
                     }
                     steps {
-                        sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
+                        sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} ginkgo --timeout=${GINKGO_TIMEOUT} --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
                     }
                     post {
                         always {
@@ -304,7 +305,7 @@ pipeline {
                         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
                     }
                     steps {
-                        sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
+                        sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} ginkgo --timeout=${GINKGO_TIMEOUT} --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
                     }
                     post {
                         always {

--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -10,6 +10,7 @@ pipeline {
         MEMORY = "4096"
         SERVER_BOX = "cilium/ubuntu"
         NETNEXT=setIfLabel("ci/net-next", "true", "false")
+        GINKGO_TIMEOUT="108m"
     }
 
     options {
@@ -174,7 +175,7 @@ pipeline {
                         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
                     }
                     steps {
-                        sh 'cd ${TESTDIR}; ginkgo --focus=" Runtime*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
+                        sh 'cd ${TESTDIR}; ginkgo --timeout=${GINKGO_TIMEOUT} --focus=" Runtime*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
                     }
                     post {
                         always {
@@ -200,7 +201,7 @@ pipeline {
                         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
                     }
                     steps {
-                        sh 'cd ${TESTDIR}; K8S_VERSION=1.10 ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
+                        sh 'cd ${TESTDIR}; K8S_VERSION=1.10 ginkgo --timeout=${GINKGO_TIMEOUT} --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
                     }
                     post {
                         always {
@@ -226,7 +227,7 @@ pipeline {
                         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
                     }
                     steps {
-                        sh 'cd ${TESTDIR}; K8S_VERSION=1.15 ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
+                        sh 'cd ${TESTDIR}; K8S_VERSION=1.15 ginkgo --timeout=${GINKGO_TIMEOUT} --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
                     }
                     post {
                         always {

--- a/pkg/proxy/netstat.go
+++ b/pkg/proxy/netstat.go
@@ -16,10 +16,11 @@ package proxy
 
 import (
 	"bytes"
-	"fmt"
 	"io/ioutil"
 	"regexp"
 	"strconv"
+
+	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
 var (
@@ -42,15 +43,15 @@ var (
 	procNetFileRegexp = regexp.MustCompile("^ *[[:digit:]]*: *[[:xdigit:]]*:([[:xdigit:]]*) ")
 )
 
-// readOpenLocalPorts returns the set of L4 ports currently open locally.
-// procNetFiles should be procNetTCPFiles or procNetUDPFiles.
-func readOpenLocalPorts(procNetFiles []string) (map[uint16]struct{}, error) {
+// procNetFiles should be procNetTCPFiles or procNetUDPFiles (or both).
+func readOpenLocalPorts(procNetFiles []string) map[uint16]struct{} {
 	openLocalPorts := make(map[uint16]struct{}, 128)
 
 	for _, file := range procNetFiles {
 		b, err := ioutil.ReadFile(file)
 		if err != nil {
-			return nil, fmt.Errorf("cannot read proc file %s: %s", file, err)
+			log.WithError(err).WithField(logfields.Path, file).Errorf("cannot read proc file")
+			continue
 		}
 
 		lines := bytes.Split(b, []byte("\n"))
@@ -65,11 +66,12 @@ func readOpenLocalPorts(procNetFiles []string) (map[uint16]struct{}, error) {
 			// The port number is in hexadecimal.
 			localPort, err := strconv.ParseUint(string(groups[1]), 16, 16)
 			if err != nil {
-				return nil, fmt.Errorf("invalid local port number in %s: %s", file, err)
+				log.WithError(err).WithField(logfields.Path, file).Errorf("cannot read proc file")
+				continue
 			}
 			openLocalPorts[uint16(localPort)] = struct{}{}
 		}
 	}
 
-	return openLocalPorts, nil
+	return openLocalPorts
 }

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -91,7 +91,7 @@ func StartProxySupport(minPort uint16, maxPort uint16, stateDir string,
 
 	if accessLogFile != "" {
 		if err := logger.OpenLogfile(accessLogFile); err != nil {
-			log.WithError(err).WithField(logger.FieldFilePath, accessLogFile).
+			log.WithError(err).WithField(logfields.Path, accessLogFile).
 				Warn("Cannot open L7 access log")
 		}
 	}
@@ -122,11 +122,8 @@ var (
 )
 
 func (p *Proxy) allocatePort() (uint16, error) {
-	// Get a snapshot of the TCP ports already open locally.
-	openLocalPorts, err := readOpenLocalPorts(procNetTCPFiles)
-	if err != nil {
-		return 0, fmt.Errorf("couldn't read local ports from /proc: %s", err)
-	}
+	// Get a snapshot of the TCP and UDP ports already open locally.
+	openLocalPorts := readOpenLocalPorts(append(procNetTCPFiles, procNetUDPFiles...))
 
 	portRandomizerMutex.Lock()
 	defer portRandomizerMutex.Unlock()

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -210,7 +210,7 @@ case $K8S_VERSION in
         ;;
     "1.15")
         KUBERNETES_CNI_VERSION="0.7.5"
-        K8S_FULL_VERSION="1.15.0"
+        K8S_FULL_VERSION="1.15.1"
         KUBEADM_OPTIONS="--ignore-preflight-errors=cri"
         KUBEADM_SLAVE_OPTIONS="--discovery-token-unsafe-skip-ca-verification --ignore-preflight-errors=cri,SystemVerification"
         sudo ln -sf $COREDNS_DEPLOYMENT $DNS_DEPLOYMENT


### PR DESCRIPTION
 * #8566 -- daemon: Remove svc from cache in syncLBMapsWithK8s (@brb)
 * #8583 -- proxy: Do not error out if reading of open ports fails. (@jrajahalme)
 * #8631 -- [CI] Add timeout to ginkgo calls (@nebril)
 * #8642 -- Bump k8s 1.15 to 1.15.1 (@aanm)
 * #8650 -- daemon: Fix removal of non-existing SVCs in syncLBMapsWithK8s (@brb)

Once this PR is merged, you can update the PR labels via:
```
$ for pr in 8566 8583 8631 8642 8650; do contrib/backporting/set-labels.py $pr done 1.5; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8659)
<!-- Reviewable:end -->
