### PR TITLE
v1.4: backports 19-07-24

### DIFF
--- a/daemon/loadbalancer.go
+++ b/daemon/loadbalancer.go
@@ -678,11 +678,11 @@ func (d *Daemon) syncLBMapsWithK8s() error {
 	// Maps service IDs to whether they are IPv6 (true) or IPv4 (false).
 	k8sDeletedRevNATS := make(map[loadbalancer.ServiceID]bool)
 
-	// Set of L3n4Addrs in string form for storage as a key in map.
-	k8sServicesFrontendAddresses := d.k8sSvcCache.UniqueServiceFrontends()
-
 	d.loadBalancer.BPFMapMU.Lock()
 	defer d.loadBalancer.BPFMapMU.Unlock()
+
+	// Set of L3n4Addrs in string form for storage as a key in map.
+	k8sServicesFrontendAddresses := d.k8sSvcCache.UniqueServiceFrontends()
 
 	log.Debugf("dumping BPF service maps to userspace")
 	_, newSVCList, lbmapDumpErrors := lbmap.DumpServiceMapsToUserspace(true)
@@ -747,7 +747,7 @@ func (d *Daemon) syncLBMapsWithK8s() error {
 	for _, svc := range k8sDeletedServices {
 		svcLogger := log.WithField(logfields.Object, logfields.Repr(svc))
 		svcLogger.Debug("removing service because it was not synced from Kubernetes")
-		if err := d.svcDeleteBPF(svc); err != nil {
+		if err := d.svcDeleteByFrontendLocked(&svc); err != nil {
 			bpfDeleteErrors = append(bpfDeleteErrors, err)
 		}
 	}

--- a/daemon/loadbalancer.go
+++ b/daemon/loadbalancer.go
@@ -747,7 +747,7 @@ func (d *Daemon) syncLBMapsWithK8s() error {
 	for _, svc := range k8sDeletedServices {
 		svcLogger := log.WithField(logfields.Object, logfields.Repr(svc))
 		svcLogger.Debug("removing service because it was not synced from Kubernetes")
-		if err := d.svcDeleteByFrontendLocked(&svc); err != nil {
+		if err := d.svcDeleteBPF(svc); err != nil {
 			bpfDeleteErrors = append(bpfDeleteErrors, err)
 		}
 	}

--- a/flannel.Jenkinsfile
+++ b/flannel.Jenkinsfile
@@ -12,6 +12,7 @@ pipeline {
         SERVER_BOX = "cilium/ubuntu"
         NETNEXT=setIfLabel("ci/net-next", "true", "false")
         CNI_INTEGRATION="flannel"
+        GINKGO_TIMEOUT="73m"
     }
 
     options {
@@ -83,11 +84,11 @@ pipeline {
                     parallel(
                         "K8s-1.9":{
                             sh 'cd ${TESTDIR}; K8S_VERSION=1.9 vagrant provision k8s1-1.9; K8S_VERSION=1.9 vagrant provision k8s2-1.9'
-                            sh 'cd ${TESTDIR}; K8S_VERSION=1.9 ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
+                            sh 'cd ${TESTDIR}; K8S_VERSION=1.9 ginkgo --timeout=${GINKGO_TIMEOUT} --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
                         },
                         "K8s-1.13":{
                             sh 'cd ${TESTDIR}; K8S_VERSION=1.13 vagrant provision k8s1-1.13; K8S_VERSION=1.13 vagrant provision k8s2-1.13'
-                            sh 'cd ${TESTDIR}; K8S_VERSION=1.13 ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
+                            sh 'cd ${TESTDIR}; K8S_VERSION=1.13 ginkgo --timeout=${GINKGO_TIMEOUT} --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
                         },
                         failFast: "${FAILFAST}".toBoolean()
                     )

--- a/ginkgo-kubernetes-all.Jenkinsfile
+++ b/ginkgo-kubernetes-all.Jenkinsfile
@@ -39,6 +39,7 @@ pipeline {
         SERVER_BOX = "cilium/ubuntu"
         FAILFAST=setIfLabel("ci/fail-fast", "true", "false")
         CNI_INTEGRATION=setIfLabel("integration/cni-flannel", "FLANNEL", "")
+        GINKGO_TIMEOUT="98m"
     }
 
     options {
@@ -154,7 +155,7 @@ pipeline {
                         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
                     }
                     steps {
-                        sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
+                        sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} ginkgo --timeout=${GINKGO_TIMEOUT} --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
                     }
                     post {
                         always {
@@ -180,7 +181,7 @@ pipeline {
                         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
                     }
                     steps {
-                        sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
+                        sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} ginkgo --timeout=${GINKGO_TIMEOUT} --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
                     }
                     post {
                         always {
@@ -279,7 +280,7 @@ pipeline {
                         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
                     }
                     steps {
-                        sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
+                        sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} ginkgo --timeout=${GINKGO_TIMEOUT} --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
                     }
                     post {
                         always {
@@ -305,7 +306,7 @@ pipeline {
                         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
                     }
                     steps {
-                        sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
+                        sh 'cd ${TESTDIR}; K8S_VERSION=${TESTED_SUITE} ginkgo --timeout=${GINKGO_TIMEOUT} --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
                     }
                     post {
                         always {

--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -10,6 +10,7 @@ pipeline {
         MEMORY = "4096"
         SERVER_BOX = "cilium/ubuntu"
         NETNEXT=setIfLabel("ci/net-next", "true", "false")
+        GINKGO_TIMEOUT="108m"
     }
 
     options {
@@ -174,7 +175,7 @@ pipeline {
                         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
                     }
                     steps {
-                        sh 'cd ${TESTDIR}; ginkgo --focus=" Runtime*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
+                        sh 'cd ${TESTDIR}; ginkgo --timeout=${GINKGO_TIMEOUT} --focus=" Runtime*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
                     }
                     post {
                         always {
@@ -200,7 +201,7 @@ pipeline {
                         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
                     }
                     steps {
-                        sh 'cd ${TESTDIR}; K8S_VERSION=1.8 ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
+                        sh 'cd ${TESTDIR}; K8S_VERSION=1.8 ginkgo --timeout=${GINKGO_TIMEOUT} --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
                     }
                     post {
                         always {
@@ -226,7 +227,7 @@ pipeline {
                         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
                     }
                     steps {
-                        sh 'cd ${TESTDIR}; K8S_VERSION=1.14 ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
+                        sh 'cd ${TESTDIR}; K8S_VERSION=1.14 ginkgo --timeout=${GINKGO_TIMEOUT} --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false'
                     }
                     post {
                         always {

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -767,6 +767,34 @@ func (e *Endpoint) runPreCompilationSteps(owner Owner, regenContext *regeneratio
 
 		_ = e.updateAndOverrideEndpointOptions(nil)
 
+		// Configure the new network policy with the proxies.
+		// Do this before updating the bpf policy maps, so that the proxy listeners have a chance to be
+		// ready when new traffic is redirected to them.
+		stats.proxyPolicyCalculation.Start()
+		err, networkPolicyRevertFunc := e.updateNetworkPolicy(owner, datapathRegenCtxt.proxyWaitGroup)
+		stats.proxyPolicyCalculation.End(err == nil)
+		if err != nil {
+			return err
+		}
+		datapathRegenCtxt.revertStack.Push(networkPolicyRevertFunc)
+
+		// Walk the L4Policy to add new redirects and update the desired policy for existing redirects.
+		// Do this before updating the bpf policy maps, so that the proxies are ready when new traffic
+		// is redirected to them.
+		var desiredRedirects map[string]bool
+		var finalizeFunc revert.FinalizeFunc
+		var revertFunc revert.RevertFunc
+		if e.desiredPolicy != nil && e.desiredPolicy.L4Policy != nil && e.desiredPolicy.L4Policy.HasRedirect() {
+			stats.proxyConfiguration.Start()
+			desiredRedirects, err, finalizeFunc, revertFunc = e.addNewRedirects(owner, e.desiredPolicy.L4Policy, datapathRegenCtxt.proxyWaitGroup)
+			stats.proxyConfiguration.End(err == nil)
+			if err != nil {
+				return err
+			}
+			datapathRegenCtxt.finalizeList.Append(finalizeFunc)
+			datapathRegenCtxt.revertStack.Push(revertFunc)
+		}
+
 		// realizedBPFConfig may be updated at any point after we figure out
 		// whether ingress/egress policy is enabled.
 		e.desiredBPFConfig = bpfconfig.GetConfig(e)
@@ -778,7 +806,7 @@ func (e *Endpoint) runPreCompilationSteps(owner Owner, regenContext *regeneratio
 		// GH-3897 would fix this by creating a new map to do an atomic swap
 		// with the old one.
 		stats.mapSync.Start()
-		err := e.syncPolicyMap()
+		err = e.syncPolicyMap()
 		stats.mapSync.End(err == nil)
 		if err != nil {
 			return fmt.Errorf("unable to regenerate policy because PolicyMap synchronization failed: %s", err)
@@ -798,41 +826,15 @@ func (e *Endpoint) runPreCompilationSteps(owner Owner, regenContext *regeneratio
 			return e.bpfConfigMap.Update(e.realizedBPFConfig)
 		})
 
-		// Configure the new network policy with the proxies.
-		stats.proxyPolicyCalculation.Start()
-		var networkPolicyRevertFunc revert.RevertFunc
-		err, networkPolicyRevertFunc = e.updateNetworkPolicy(owner, datapathRegenCtxt.proxyWaitGroup)
-		stats.proxyPolicyCalculation.End(err == nil)
-		if err != nil {
-			return err
-		}
-
-		datapathRegenCtxt.revertStack.Push(networkPolicyRevertFunc)
-	}
-
-	stats.proxyConfiguration.Start()
-	var finalizeFunc revert.FinalizeFunc
-	var revertFunc revert.RevertFunc
-	// Walk the L4Policy to add new redirects and update the desired policy map
-	// state to set the newly allocated proxy ports.
-	var desiredRedirects map[string]bool
-	if e.desiredPolicy != nil && e.desiredPolicy.L4Policy != nil {
-		desiredRedirects, err, finalizeFunc, revertFunc = e.addNewRedirects(owner, e.desiredPolicy.L4Policy, datapathRegenCtxt.proxyWaitGroup)
-		if err != nil {
-			stats.proxyConfiguration.End(false)
-			return err
-		}
+		// At this point, traffic is no longer redirected to the proxy for
+		// now-obsolete redirects, since we synced the updated policy map above.
+		// It's now safe to remove the redirects from the proxy's configuration.
+		stats.proxyConfiguration.Start()
+		finalizeFunc, revertFunc = e.removeOldRedirects(owner, desiredRedirects, datapathRegenCtxt.proxyWaitGroup)
 		datapathRegenCtxt.finalizeList.Append(finalizeFunc)
 		datapathRegenCtxt.revertStack.Push(revertFunc)
+		stats.proxyConfiguration.End(true)
 	}
-
-	// At this point, traffic is no longer redirected to the proxy for
-	// now-obsolete redirects, since we synced the updated policy map above.
-	// It's now safe to remove the redirects from the proxy's configuration.
-	finalizeFunc, revertFunc = e.removeOldRedirects(owner, desiredRedirects, datapathRegenCtxt.proxyWaitGroup)
-	datapathRegenCtxt.finalizeList.Append(finalizeFunc)
-	datapathRegenCtxt.revertStack.Push(revertFunc)
-	stats.proxyConfiguration.End(true)
 
 	stats.prepareBuild.Start()
 	defer func() {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1488,7 +1488,6 @@ func (e *Endpoint) LeaveLocked(owner Owner, proxyWaitGroup *completion.WaitGroup
 		if err != nil {
 			errors = append(errors, fmt.Errorf("unable to release identity: %s", err))
 		}
-		// TODO: Check if network policy was created even without SecurityIdentity
 		owner.RemoveNetworkPolicy(e)
 		e.SecurityIdentity = nil
 	}

--- a/pkg/proxy/netstat.go
+++ b/pkg/proxy/netstat.go
@@ -16,10 +16,11 @@ package proxy
 
 import (
 	"bytes"
-	"fmt"
 	"io/ioutil"
 	"regexp"
 	"strconv"
+
+	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
 var (
@@ -43,14 +44,15 @@ var (
 )
 
 // readOpenLocalPorts returns the set of L4 ports currently open locally.
-// procNetFiles should be procNetTCPFiles or procNetUDPFiles.
-func readOpenLocalPorts(procNetFiles []string) (map[uint16]struct{}, error) {
+// procNetFiles should be procNetTCPFiles or procNetUDPFiles (or both).
+func readOpenLocalPorts(procNetFiles []string) map[uint16]struct{} {
 	openLocalPorts := make(map[uint16]struct{}, 128)
 
 	for _, file := range procNetFiles {
 		b, err := ioutil.ReadFile(file)
 		if err != nil {
-			return nil, fmt.Errorf("cannot read proc file %s: %s", file, err)
+			log.WithError(err).WithField(logfields.Path, file).Errorf("cannot read proc file")
+			continue
 		}
 
 		lines := bytes.Split(b, []byte("\n"))
@@ -65,11 +67,12 @@ func readOpenLocalPorts(procNetFiles []string) (map[uint16]struct{}, error) {
 			// The port number is in hexadecimal.
 			localPort, err := strconv.ParseUint(string(groups[1]), 16, 16)
 			if err != nil {
-				return nil, fmt.Errorf("invalid local port number in %s: %s", file, err)
+				log.WithError(err).WithField(logfields.Path, file).Errorf("cannot read proc file")
+				continue
 			}
 			openLocalPorts[uint16(localPort)] = struct{}{}
 		}
 	}
 
-	return openLocalPorts, nil
+	return openLocalPorts
 }

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -91,7 +91,7 @@ func StartProxySupport(minPort uint16, maxPort uint16, stateDir string,
 
 	if accessLogFile != "" {
 		if err := logger.OpenLogfile(accessLogFile); err != nil {
-			log.WithError(err).WithField(logger.FieldFilePath, accessLogFile).
+			log.WithError(err).WithField(logfields.Path, accessLogFile).
 				Warn("Cannot open L7 access log")
 		}
 	}
@@ -123,10 +123,7 @@ var (
 
 func (p *Proxy) allocatePort() (uint16, error) {
 	// Get a snapshot of the TCP ports already open locally.
-	openLocalPorts, err := readOpenLocalPorts(procNetTCPFiles)
-	if err != nil {
-		return 0, fmt.Errorf("couldn't read local ports from /proc: %s", err)
-	}
+	openLocalPorts := readOpenLocalPorts(append(procNetTCPFiles, procNetUDPFiles...))
 
 	portRandomizerMutex.Lock()
 	defer portRandomizerMutex.Unlock()


### PR DESCRIPTION
 * #8566 -- daemon: Remove svc from cache in syncLBMapsWithK8s (@brb)
 * #8583 -- proxy: Do not error out if reading of open ports fails. (@jrajahalme)
 * #8618 -- endpoint: Create redirects before bpf map updates. (@jrajahalme)
 * #8631 -- [CI] Add timeout to ginkgo calls (@nebril)
 * #8650 -- daemon: Fix removal of non-existing SVCs in syncLBMapsWithK8s (@brb)

Once this PR is merged, you can update the PR labels via:
```
$ for pr in 8566 8583 8618 8631 8650; do contrib/backporting/set-labels.py $pr done 1.4; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8660)
<!-- Reviewable:end -->
