### PR TITLE
v1.6: backports 19-07-24

### DIFF
--- a/examples/kubernetes/1.10/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.10/cilium-minikube-ds.yaml
@@ -168,6 +168,12 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state

--- a/examples/kubernetes/1.10/cilium-minikube.yaml
+++ b/examples/kubernetes/1.10/cilium-minikube.yaml
@@ -365,6 +365,12 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state

--- a/examples/kubernetes/1.11/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.11/cilium-minikube-ds.yaml
@@ -168,6 +168,12 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state

--- a/examples/kubernetes/1.11/cilium-minikube.yaml
+++ b/examples/kubernetes/1.11/cilium-minikube.yaml
@@ -365,6 +365,12 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state

--- a/examples/kubernetes/1.12/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.12/cilium-minikube-ds.yaml
@@ -168,6 +168,12 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state

--- a/examples/kubernetes/1.12/cilium-minikube.yaml
+++ b/examples/kubernetes/1.12/cilium-minikube.yaml
@@ -365,6 +365,12 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state

--- a/examples/kubernetes/1.13/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.13/cilium-minikube-ds.yaml
@@ -168,6 +168,12 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state

--- a/examples/kubernetes/1.13/cilium-minikube.yaml
+++ b/examples/kubernetes/1.13/cilium-minikube.yaml
@@ -365,6 +365,12 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state

--- a/examples/kubernetes/1.14/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.14/cilium-minikube-ds.yaml
@@ -168,6 +168,12 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state

--- a/examples/kubernetes/1.14/cilium-minikube.yaml
+++ b/examples/kubernetes/1.14/cilium-minikube.yaml
@@ -365,6 +365,12 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state

--- a/examples/kubernetes/1.15/cilium-minikube-ds.yaml
+++ b/examples/kubernetes/1.15/cilium-minikube-ds.yaml
@@ -168,6 +168,12 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state

--- a/examples/kubernetes/1.15/cilium-minikube.yaml
+++ b/examples/kubernetes/1.15/cilium-minikube.yaml
@@ -365,6 +365,12 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:latest
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state

--- a/examples/kubernetes/templates/v1/cilium-minikube-ds.yaml.sed
+++ b/examples/kubernetes/templates/v1/cilium-minikube-ds.yaml.sed
@@ -168,6 +168,12 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
+        - name: CILIUM_WAIT_BPF_MOUNT
+          valueFrom:
+            configMapKeyRef:
+              key: wait-bpf-mount
+              name: cilium-config
+              optional: true
         image: docker.io/cilium/cilium:__CILIUM_INIT_VERSION__
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state

--- a/pkg/maps/policymap/policymap.go
+++ b/pkg/maps/policymap/policymap.go
@@ -17,6 +17,7 @@ package policymap
 import (
 	"bytes"
 	"fmt"
+	"syscall"
 	"unsafe"
 
 	"github.com/cilium/cilium/pkg/bpf"
@@ -198,9 +199,9 @@ func (pm *PolicyMap) Exists(id uint32, dport uint16, proto u8proto.U8proto, traf
 
 // DeleteKey deletes the key-value pair from the given PolicyMap with PolicyKey
 // k. Returns an error if deletion from the PolicyMap fails.
-func (pm *PolicyMap) DeleteKey(key PolicyKey) error {
+func (pm *PolicyMap) DeleteKeyWithErrno(key PolicyKey) (error, syscall.Errno) {
 	k := key.ToNetwork()
-	return pm.Map.Delete(&k)
+	return pm.Map.DeleteWithErrno(&k)
 }
 
 // Delete removes an entry from the PolicyMap for identity `id`

--- a/pkg/maps/policymap/policymap_privileged_test.go
+++ b/pkg/maps/policymap/policymap_privileged_test.go
@@ -19,10 +19,13 @@ package policymap
 import (
 	"fmt"
 	"os"
+	"syscall"
 	"testing"
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/checker"
+	"github.com/cilium/cilium/pkg/policy/trafficdirection"
+	"github.com/cilium/cilium/pkg/u8proto"
 
 	. "gopkg.in/check.v1"
 )
@@ -91,4 +94,11 @@ func (pm *PolicyMapTestSuite) TestPolicyMapDumpToSlice(c *C) {
 	dump, err = testMap.DumpToSlice()
 	c.Assert(err, IsNil)
 	c.Assert(len(dump), Equals, 2)
+}
+
+func (pm *PolicyMapTestSuite) TestDeleteNonexistentKey(c *C) {
+	key := newKey(27, 80, u8proto.ANY, trafficdirection.Ingress)
+	err, errno := testMap.Map.DeleteWithErrno(&key)
+	c.Assert(err, Not(IsNil))
+	c.Assert(errno, Equals, syscall.ENOENT)
 }


### PR DESCRIPTION
 * #8651 -- examples: Add CILIUM_WAIT_BPF_MOUNT variable to minikube DS (@mrostecki)
 * #8655 -- endpoint: Do not error out when bpf map entry is already deleted. (@jrajahalme)

Once this PR is merged, you can update the PR labels via:
```
$ for pr in 8651 8655; do contrib/backporting/set-labels.py $pr done 1.6; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8661)
<!-- Reviewable:end -->
