### PR TITLE
init-container: Look for a concrete BPFFS mount in /sys/fs/bpf

### DIFF
--- a/contrib/packaging/docker/init-container.sh
+++ b/contrib/packaging/docker/init-container.sh
@@ -15,5 +15,5 @@ if [ "${CILIUM_ALL_STATE}" = "true" ] \
 fi
 
 if [ "${CILIUM_WAIT_BPF_MOUNT}" = "true" ]; then
-	until mount | grep bpf; do echo "BPF filesystem is not mounted yet"; sleep 1; done
+	until mount | grep "/sys/fs/bpf type bpf"; do echo "BPF filesystem is not mounted yet"; sleep 1; done
 fi;


### PR DESCRIPTION
Before this change, init container was looking for any mount which
contains the `bpf` string, which was always true, even if there was no
real BPFFS mount. When BPFFS is not mounted on host, init container sees
the mount from host directory of sysfs type:

```
sysfs on /sys/fs/bpf type sysfs (rw,relatime)
```

To check whether BPFFS is mounted properly, we need to look explicitly
for a mount entry like:

```
bpf on /sys/fs/bpf type bpf (rw,nosuid,nodev,noexec,relatime,mode=700)
```

Fixes: b264343377fe ("Add bpf mount check to Cilium init container")
Fixes: #8646
Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8665)
<!-- Reviewable:end -->
