### PR TITLE
RFC: add way to run `dep` via container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -515,5 +515,14 @@ postcheck: build
 minikube:
 	$(QUIET) contrib/scripts/minikube.sh
 
+deps-image:
+	$(CONTAINER_ENGINE_FULL) build -t cilium/dep -f ./contrib/deps/deps.Dockerfile ./contrib/deps
+
+update-deps:
+	# Need to mount \$GOPATH/pkg/dep as that is where dep's cache is located.
+	# Otherwise, builds would be very slow.
+	# See: https://github.com/golang/dep/blob/master/docs/FAQ.md#why-is-dep-slow
+	$(CONTAINER_ENGINE_FULL) run  --rm -v $$(pwd):/go/src/github.com/cilium/cilium -v $(GOPATH)/pkg/dep:/go/pkg/dep -w /go/src/github.com/cilium/cilium cilium/dep:latest
+
 .PHONY: force generate-api generate-health-api
 force :;

--- a/contrib/deps/deps.Dockerfile
+++ b/contrib/deps/deps.Dockerfile
@@ -1,0 +1,3 @@
+FROM docker.io/library/golang:1.12.7
+RUN curl https://raw.githubusercontent.com/golang/dep/v0.5.4/install.sh | sh
+CMD dep ensure -v


### PR DESCRIPTION
This ensures that the same version of `dep` is utilized between all
developers who need to update a dependency.

To build the image:

```
make deps-image
```

To update dependencies:
```
make update-deps
```

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #8658 

TODOs if the general idea for this is approved:
- [ ] Create a repository on Dockerhub and build a specified version of it, and put it in the `make update-deps` target instead of `latest`
- [ ] Update documentation to remove need to install `dep` directly

I didn't do the above because I figured it'd be best to get a basic POC going.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8667)
<!-- Reviewable:end -->
