### PR TITLE
test: Fix etcd-operator readiness check

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1612,6 +1612,41 @@ func (kub *Kubectl) EtcdOperatorReport(ctx context.Context, reportCmds map[strin
 	}
 }
 
+// WaitForEtcdCRDReady inspects the etcdclusters CRD to validate that the etcd
+// pods being started by the etcd-operator are ready.
+func (kub *Kubectl) WaitForEtcdCRDReady(namespace, name string, expectedCount int, timeout time.Duration) error {
+	// Test filter: https://jqplay.org/s/_rqbx7hTmI
+	jqFilter := fmt.Sprintf(`.status.members.ready | length`)
+	cmd := fmt.Sprintf("%s get etcdclusters -n %s %s -o json | jq '%s'",
+		KubectlCmd, namespace, name, jqFilter)
+	kub.logger.Infof("Querying etcdclusters on %s/%s", namespace, name)
+
+	body := func() bool {
+		res := kub.ExecShort(cmd)
+		if !res.WasSuccessful() {
+			kub.logger.WithError(res.GetErr("")).Error("cannot get etcdclusters status")
+			return false
+		}
+
+		var value int
+		if err := res.Unmarshal(&value); err != nil {
+			kub.logger.WithError(err).Error("Cannot unmarshel etcdclusters status json")
+			return false
+		}
+
+		if value != expectedCount {
+			kub.logger.Infof("Only %d/%d pods are ready", value, expectedCount)
+			return false
+		}
+		return true
+	}
+
+	return WithTimeout(
+		body,
+		"etcd pods not ready after timeout",
+		&TimeoutConfig{Timeout: timeout})
+}
+
 // CiliumCheckReport prints a few checks on the Junit output to provide more
 // context to users. The list of checks that prints are the following:
 // - Number of Kubernetes and Cilium policies installed.

--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -72,7 +72,10 @@ func ExpectETCDOperatorReady(vm *helpers.Kubectl) {
 	// This is to avoid cases where a few pods are ready, but the
 	// new one is not created yet.
 	By("Waiting for all etcd-operator pods are ready")
-	ExpectDeployReady(vm, "kube-system", "cilium-etcd-operator", longTimeout)
+	ExpectDeployReady(vm, "kube-system", "cilium-etcd-operator", helpers.MidCommandTimeout)
+	ExpectDeployReady(vm, "kube-system", "etcd-operator", helpers.HelperTimeout)
+	err := vm.WaitForEtcdCRDReady("kube-system", "cilium-etcd", 3, longTimeout)
+	Expect(err).To(BeNil(), fmt.Sprintf("etcdcluster not ready after timeout"))
 }
 
 // ExpectCiliumPreFlightInstallReady is a wrapper around helpers/WaitForNPods.


### PR DESCRIPTION
Commit d9c3256a4af6 ("CI: Add/Use WaitforDeploy & ExpectDeployReady")
attempted to rework the etcd operator readiness by relying upon
deployment readiness to ensure that leftover pods from a previous test
run don't interfere with the current etcd deployment, however in
practice it *only checked for the etcd operator to be ready* and didn't wait for the
underlying etcd pods to be ready.

Add a wait for the etcd-operator deployment to be ready, and
add a wait for the cilium-etcd etcdclusters CRD to report that there are
three etcd pods ready, before continuing.

Fixes: d9c3256a4af6 ("CI: Add/Use WaitforDeploy & ExpectDeployReady")

Found while triaging flannel bootstrap flakes (#8578).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8673)
<!-- Reviewable:end -->
