### PR TITLE
[CI] Use LocalExecutor if kubeconfig is defined

### DIFF
--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -115,13 +115,16 @@ pipeline {
                         GOPATH="${WORKSPACE}/${TESTED_SUITE}-gopath"
                         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
                         NETNEXT="true"
+                        K8S_VERSION="1.11"
+                        KUBECONFIG="vagrant-kubeconfig"
                     }
                     steps {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
                         retry(3) {
-                            sh 'cd ${TESTDIR}; K8S_VERSION=1.11 vagrant destroy k8s1-1.11 k8s2-1.11 --force'
-                            sh 'cd ${TESTDIR}; K8S_VERSION=1.11 vagrant up k8s1-1.11 k8s2-1.11 --provision'
+                            dir("${TESTDIR}") {
+                                sh './vagrant-ci-start.sh'
+                            }
                         }
                     }
                     post {
@@ -139,13 +142,16 @@ pipeline {
                         TESTED_SUITE="k8s-1.15"
                         GOPATH="${WORKSPACE}/${TESTED_SUITE}-gopath"
                         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
+                        K8S_VERSION="1.15"
+                        KUBECONFIG="vagrant-kubeconfig"
                     }
                     steps {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
                         retry(3) {
-                            sh 'cd ${TESTDIR}; K8S_VERSION=1.15 vagrant destroy k8s1-1.15 k8s2-1.15 --force'
-                            sh 'cd ${TESTDIR}; K8S_VERSION=1.15 vagrant up k8s1-1.15 k8s2-1.15 --provision'
+                            dir("${TESTDIR}") {
+                                sh './vagrant-ci-start.sh'
+                            }
                         }
                     }
                     post {
@@ -203,7 +209,7 @@ pipeline {
                         NETNEXT="true"
                     }
                     steps {
-                        sh 'cd ${TESTDIR}; K8S_VERSION=1.11 ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT}'
+                        sh 'cd ${TESTDIR}; K8S_VERSION=1.11 ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.kubeconfig=${TESTDIR}/vagrant-kubeconfig'
                     }
                     post {
                         always {
@@ -229,7 +235,7 @@ pipeline {
                         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
                     }
                     steps {
-                        sh 'cd ${TESTDIR}; K8S_VERSION=1.15 ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT}'
+                        sh 'cd ${TESTDIR}; K8S_VERSION=1.15 ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.kubeconfig=${TESTDIR}/vagrant-kubeconfig'
                     }
                     post {
                         always {

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -85,6 +85,10 @@ Vagrant.configure("2") do |config|
             server.vm.box_version = $SERVER_VERSION
             server.vm.hostname = "k8s#{i}"
             server.vm.boot_timeout = 600
+            if i == 1 then
+                server.vm.network "forwarded_port", guest: 6443, host: 9443,
+                  auto_correct: true
+            end
             server.vm.network "private_network",
                 ip: "192.168.36.1#{i}",
                 virtualbox__intnet: "cilium-k8s#{$BUILD_NUMBER}-#{$JOB_NAME}-#{$K8S_VERSION}"

--- a/test/config/config.go
+++ b/test/config/config.go
@@ -31,6 +31,7 @@ type CiliumTestConfigType struct {
 	CiliumOperatorImage string
 	ProvisionK8s        bool
 	Timeout             time.Duration
+	Kubeconfig          string
 }
 
 // CiliumTestConfig holds the global configuration of commandline flags
@@ -59,4 +60,6 @@ func (c *CiliumTestConfigType) ParseFlags() {
 		"Specifies whether Kubernetes should be deployed and installed via kubeadm or not")
 	flag.DurationVar(&c.Timeout, "cilium.timeout", 24*time.Hour,
 		"Specifies timeout for test run")
+	flag.StringVar(&c.Kubeconfig, "cilium.kubeconfig", "",
+		"Kubeconfig to be used for k8s tests")
 }

--- a/test/get-vagrant-kubeconfig.sh
+++ b/test/get-vagrant-kubeconfig.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+K8S_VERSION_NO_DOTS=$(echo $K8S_VERSION | sed "s/\.//g")
+
+config=$(vagrant ssh k8s1-${K8S_VERSION} -- sudo cat /etc/kubernetes/admin.conf)
+port=$(cat .vagrant/machines/k8s1-${K8S_VERSION}/virtualbox/id | xargs vboxmanage showvminfo --machinereadable | grep 'Forwarding.*6443' | awk -F ',' '{print $4}')
+echo "$config" | sed "s/6443/$port/g"

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -43,7 +43,7 @@ var (
 
 	// CiliumBasePath is the absolute path to the cilium source repository
 	// in the guest VMs
-	CiliumBasePath = "/home/vagrant/go/src/github.com/cilium/cilium"
+	CiliumBasePath = "../"
 
 	// BasePath is the path in the Vagrant VMs to which the test directory
 	// is mounted
@@ -213,7 +213,7 @@ const (
 	sizeMismatch      = "size mismatch for BPF map" // from https://github.com/cilium/cilium/issues/7851
 
 	// HelmTemplate is the location of the Helm templates to install Cilium
-	HelmTemplate = "go/src/github.com/cilium/cilium/install/kubernetes/cilium"
+	HelmTemplate = "../install/kubernetes/cilium"
 )
 
 // Re-definitions of stable constants in the API. The re-definition is on

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"path"
 	"time"
 
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
@@ -40,14 +39,6 @@ var (
 
 	// CiliumStartTimeout is a predefined timeout value for Cilium startup.
 	CiliumStartTimeout = 100 * time.Second
-
-	// CiliumBasePath is the absolute path to the cilium source repository
-	// in the guest VMs
-	CiliumBasePath = "../"
-
-	// BasePath is the path in the Vagrant VMs to which the test directory
-	// is mounted
-	BasePath = path.Join(CiliumBasePath, "test")
 
 	// CheckLogs newtes a new buffer where all the warnings and checks that
 	// happens during the test are saved. This buffer will be printed in the
@@ -290,11 +281,6 @@ const (
 	ciliumEtcdOperatorRBAC = "cilium-etcd-operator-rbac.yaml"
 	ciliumEtcdOperator     = "cilium-etcd-operator.yaml"
 )
-
-//GetFilePath returns the absolute path of the provided filename
-func GetFilePath(filename string) string {
-	return fmt.Sprintf("%s/%s", BasePath, filename)
-}
 
 // K8s1VMName is the name of the Kubernetes master node when running K8s tests.
 func K8s1VMName() string {

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -105,7 +105,7 @@ func GetCurrentIntegration() string {
 // commands on the node which is accessible via the SSH metadata stored in its
 // SSHMeta.
 type Kubectl struct {
-	*SSHMeta
+	Executor
 	*serviceCache
 }
 
@@ -113,31 +113,50 @@ type Kubectl struct {
 // It marks the test as Fail if cannot get the ssh meta information or cannot
 // execute a `ls` on the virtual machine.
 func CreateKubectl(vmName string, log *logrus.Entry) *Kubectl {
-	node := GetVagrantSSHMeta(vmName)
-	if node == nil {
-		ginkgoext.Fail(fmt.Sprintf("Cannot connect to vmName  '%s'", vmName), 1)
-		return nil
-	}
-	// This `ls` command is a sanity check, sometimes the meta ssh info is not
-	// nil but new commands cannot be executed using SSH, tests failed and it
-	// was hard to debug.
-	res := node.ExecShort("ls /tmp/")
-	if !res.WasSuccessful() {
-		ginkgoext.Fail(fmt.Sprintf(
-			"Cannot execute ls command on vmName '%s'", vmName), 1)
-		return nil
-	}
-	node.logger = log
+	if config.CiliumTestConfig.Kubeconfig == "" {
+		node := GetVagrantSSHMeta(vmName)
+		if node == nil {
+			ginkgoext.Fail(fmt.Sprintf("Cannot connect to vmName  '%s'", vmName), 1)
+			return nil
+		}
+		// This `ls` command is a sanity check, sometimes the meta ssh info is not
+		// nil but new commands cannot be executed using SSH, tests failed and it
+		// was hard to debug.
+		res := node.ExecShort("ls /tmp/")
+		if !res.WasSuccessful() {
+			ginkgoext.Fail(fmt.Sprintf(
+				"Cannot execute ls command on vmName '%s'", vmName), 1)
+			return nil
+		}
+		node.logger = log
 
-	return &Kubectl{
-		SSHMeta: node,
+		return &Kubectl{
+			Executor: node,
+		}
 	}
+
+	exec := CreateLocalExecutor([]string{"KUBECONFIG=" + config.CiliumTestConfig.Kubeconfig})
+	exec.logger = log
+
+	k := &Kubectl{
+		Executor: exec,
+	}
+
+	res := k.GetPods("default", "")
+	if !res.WasSuccessful() {
+		ginkgoext.Fail(fmt.Sprintf("Cannot connect to k8s cluster, output:\n%s", res.CombineOutput().String()), 1)
+		return nil
+	}
+
+	k.setBasePath()
+
+	return k
 }
 
 // CepGet returns the endpoint model for the given pod name in the specified
 // namespaces. If the pod is not present it returns nil
 func (kub *Kubectl) CepGet(namespace string, pod string) *cnpv2.EndpointStatus {
-	log := kub.logger.WithFields(logrus.Fields{
+	log := kub.Logger().WithFields(logrus.Fields{
 		"cep":       pod,
 		"namespace": namespace})
 
@@ -230,7 +249,7 @@ func (kub *Kubectl) GetFromAllNS(kind string) *CmdRes {
 // the given CNP and return a CNP struct. If the CNP does not exists or cannot
 // unmarshal the Json output will return nil.
 func (kub *Kubectl) GetCNP(namespace string, cnp string) *cnpv2.CiliumNetworkPolicy {
-	log := kub.logger.WithFields(logrus.Fields{
+	log := kub.Logger().WithFields(logrus.Fields{
 		"fn":  "GetCNP",
 		"cnp": cnp,
 		"ns":  namespace,
@@ -438,7 +457,7 @@ func (kub *Kubectl) MicroscopeStart(microscopeOptions ...string) (error, func() 
 		<-ctx.Done()
 		testPath, err := CreateReportDirectory()
 		if err != nil {
-			kub.logger.WithError(err).Errorf(
+			kub.Logger().WithError(err).Errorf(
 				"cannot create test results path '%s'", testPath)
 			return err
 		}
@@ -473,7 +492,7 @@ func (kub *Kubectl) MonitorStart(namespace, pod, filename string) func() error {
 		<-ctx.Done()
 		testPath, err := CreateReportDirectory()
 		if err != nil {
-			kub.logger.WithError(err).Errorf(
+			kub.Logger().WithError(err).Errorf(
 				"cannot create test results path '%s'", testPath)
 			return err
 		}
@@ -527,7 +546,7 @@ func (kub *Kubectl) BackgroundReport(commands ...string) (context.CancelFunc, er
 func (kub *Kubectl) PprofReport() {
 	PProfCadence := 5 * time.Minute
 	ticker := time.NewTicker(PProfCadence)
-	log := kub.logger.WithField("subsys", "pprofReport")
+	log := kub.Logger().WithField("subsys", "pprofReport")
 
 	retrievePProf := func(pod, testPath string) {
 		res := kub.ExecPodCmd(KubeSystemNamespace, pod, "gops pprof-cpu 1")
@@ -672,7 +691,7 @@ func (kub *Kubectl) waitForNPods(checkStatus checkPodStatusFunc, namespace strin
 		podList := &v1.PodList{}
 		err := kub.GetPods(namespace, filter).Unmarshal(podList)
 		if err != nil {
-			kub.logger.Infof("Error while getting PodList: %s", err)
+			kub.Logger().Infof("Error while getting PodList: %s", err)
 			return false
 		}
 
@@ -720,7 +739,7 @@ func (kub *Kubectl) WaitForServiceEndpoints(namespace string, filter string, ser
 		data, err := kub.GetEndpoints(namespace, filter).Filter(jsonPath)
 
 		if err != nil {
-			kub.logger.WithError(err)
+			kub.Logger().WithError(err)
 			return false
 		}
 
@@ -728,7 +747,7 @@ func (kub *Kubectl) WaitForServiceEndpoints(namespace string, filter string, ser
 			return true
 		}
 
-		kub.logger.WithFields(logrus.Fields{
+		kub.Logger().WithFields(logrus.Fields{
 			"namespace": namespace,
 			"filter":    filter,
 			"data":      data,
@@ -744,23 +763,23 @@ func (kub *Kubectl) WaitForServiceEndpoints(namespace string, filter string, ser
 // manifest located at path filepath in the given namespace
 func (kub *Kubectl) Action(action ResourceLifeCycleAction, filePath string, namespace ...string) *CmdRes {
 	if len(namespace) == 0 {
-		kub.logger.Debugf("performing '%v' on '%v'", action, filePath)
+		kub.Logger().Debugf("performing '%v' on '%v'", action, filePath)
 		return kub.ExecShort(fmt.Sprintf("%s %s -f %s", KubectlCmd, action, filePath))
 	}
 
-	kub.logger.Debugf("performing '%v' on '%v' in namespace '%v'", action, filePath, namespace[0])
+	kub.Logger().Debugf("performing '%v' on '%v' in namespace '%v'", action, filePath, namespace[0])
 	return kub.ExecShort(fmt.Sprintf("%s %s -f %s -n %s", KubectlCmd, action, filePath, namespace[0]))
 }
 
 // Apply applies the Kubernetes manifest located at path filepath.
 func (kub *Kubectl) Apply(filePath string, namespace ...string) *CmdRes {
 	if len(namespace) == 0 {
-		kub.logger.Debugf("applying %s", filePath)
+		kub.Logger().Debugf("applying %s", filePath)
 		return kub.ExecMiddle(
 			fmt.Sprintf("%s apply -f  %s", KubectlCmd, filePath))
 	}
 	namespaceToApply := namespace[0]
-	kub.logger.Debugf("applying %s in namespace %s", filePath, namespaceToApply)
+	kub.Logger().Debugf("applying %s in namespace %s", filePath, namespaceToApply)
 	return kub.ExecMiddle(
 		fmt.Sprintf("%s apply -f  %s -n %s", KubectlCmd, filePath, namespaceToApply))
 
@@ -768,7 +787,7 @@ func (kub *Kubectl) Apply(filePath string, namespace ...string) *CmdRes {
 
 // Create creates the Kubernetes kanifest located at path filepath.
 func (kub *Kubectl) Create(filePath string) *CmdRes {
-	kub.logger.Debugf("creating %s", filePath)
+	kub.Logger().Debugf("creating %s", filePath)
 	return kub.ExecShort(
 		fmt.Sprintf("%s create -f  %s", KubectlCmd, filePath))
 }
@@ -776,20 +795,20 @@ func (kub *Kubectl) Create(filePath string) *CmdRes {
 // CreateResource is a wrapper around `kubernetes create <resource>
 // <resourceName>.
 func (kub *Kubectl) CreateResource(resource, resourceName string) *CmdRes {
-	kub.logger.Debug(fmt.Sprintf("creating resource %s with name %s", resource, resourceName))
+	kub.Logger().Debug(fmt.Sprintf("creating resource %s with name %s", resource, resourceName))
 	return kub.ExecShort(fmt.Sprintf("kubectl create %s %s", resource, resourceName))
 }
 
 // DeleteResource is a wrapper around `kubernetes delete <resource>
 // resourceName>.
 func (kub *Kubectl) DeleteResource(resource, resourceName string) *CmdRes {
-	kub.logger.Debug(fmt.Sprintf("deleting resource %s with name %s", resource, resourceName))
+	kub.Logger().Debug(fmt.Sprintf("deleting resource %s with name %s", resource, resourceName))
 	return kub.Exec(fmt.Sprintf("kubectl delete %s %s", resource, resourceName))
 }
 
 // Delete deletes the Kubernetes manifest at path filepath.
 func (kub *Kubectl) Delete(filePath string) *CmdRes {
-	kub.logger.Debugf("deleting %s", filePath)
+	kub.Logger().Debugf("deleting %s", filePath)
 	return kub.ExecShort(
 		fmt.Sprintf("%s delete -f  %s", KubectlCmd, filePath))
 }
@@ -806,7 +825,7 @@ func (kub *Kubectl) WaitKubeDNS() error {
 // is not present, it appends to the given name and it checks the service's FQDN.
 func (kub *Kubectl) WaitForKubeDNSEntry(serviceName, serviceNamespace string) error {
 	svcSuffix := "svc.cluster.local"
-	logger := kub.logger.WithFields(logrus.Fields{"serviceName": serviceName, "serviceNamespace": serviceNamespace})
+	logger := kub.Logger().WithFields(logrus.Fields{"serviceName": serviceName, "serviceNamespace": serviceNamespace})
 
 	serviceNameWithNamespace := fmt.Sprintf("%s.%s", serviceName, serviceNamespace)
 	if !strings.HasSuffix(serviceNameWithNamespace, svcSuffix) {
@@ -888,7 +907,7 @@ func (kub *Kubectl) WaitCleanAllTerminatingPods(timeout time.Duration) error {
 		}
 
 		podsTerminating := len(strings.Split(res.Output().String(), " "))
-		kub.logger.WithField("Terminating pods", podsTerminating).Info("List of pods terminating")
+		kub.Logger().WithField("Terminating pods", podsTerminating).Info("List of pods terminating")
 		if podsTerminating > 0 {
 			return false
 		}
@@ -1182,7 +1201,7 @@ func (kub *Kubectl) CiliumEndpointsStatus(pod string) map[string]string {
 func (kub *Kubectl) CiliumEndpointWaitReady() error {
 	ciliumPods, err := kub.GetCiliumPods(KubeSystemNamespace)
 	if err != nil {
-		kub.logger.WithError(err).Error("cannot get Cilium pods")
+		kub.Logger().WithError(err).Error("cannot get Cilium pods")
 		return err
 	}
 
@@ -1195,7 +1214,7 @@ func (kub *Kubectl) CiliumEndpointWaitReady() error {
 				queue <- valid
 				wg.Done()
 			}()
-			logCtx := kub.logger.WithField("pod", pod)
+			logCtx := kub.Logger().WithField("pod", pod)
 			status, err := kub.CiliumEndpointsList(ctx, pod).Filter(`{range [*]}{.status.state}{"="}{.status.identity.id}{"\n"}{end}`)
 			if err != nil {
 				logCtx.WithError(err).Errorf("cannot get endpoints states on Cilium pod")
@@ -1363,7 +1382,7 @@ func (kub *Kubectl) WaitForCiliumInitContainerToFinish() error {
 		podList := &v1.PodList{}
 		err := kub.GetPods("kube-system", "-l k8s-app=cilium").Unmarshal(podList)
 		if err != nil {
-			kub.logger.Infof("Error while getting PodList: %s", err)
+			kub.Logger().Infof("Error while getting PodList: %s", err)
 			return false
 		}
 		if len(podList.Items) == 0 {
@@ -1372,7 +1391,7 @@ func (kub *Kubectl) WaitForCiliumInitContainerToFinish() error {
 		for _, pod := range podList.Items {
 			for _, v := range pod.Status.InitContainerStatuses {
 				if v.State.Terminated.Reason != "Completed" || v.State.Terminated.ExitCode != 0 {
-					kub.logger.WithFields(logrus.Fields{
+					kub.Logger().WithFields(logrus.Fields{
 						"podName":      pod.Name,
 						"currentState": v.State.String(),
 					}).Infof("Cilium Init container not completed")
@@ -1403,10 +1422,10 @@ func (kub *Kubectl) CiliumNodesWait() (bool, error) {
 		result := data.KVOutput()
 		for k, v := range result {
 			if v == "" {
-				kub.logger.Infof("Kubernetes node '%v' does not have Cilium metadata", k)
+				kub.Logger().Infof("Kubernetes node '%v' does not have Cilium metadata", k)
 				return false
 			}
-			kub.logger.Infof("Kubernetes node '%v' IPv4 address: '%v'", k, v)
+			kub.Logger().Infof("Kubernetes node '%v' IPv4 address: '%v'", k, v)
 		}
 		return true
 	}
@@ -1460,7 +1479,7 @@ func (kub *Kubectl) CiliumPolicyRevision(pod string) (int, error) {
 
 	revi, err := strconv.Atoi(strings.Trim(revision.String(), "\n"))
 	if err != nil {
-		kub.logger.Errorf("revision on pod '%s' is not valid '%s'", pod, res.CombineOutput())
+		kub.Logger().Errorf("revision on pod '%s' is not valid '%s'", pod, res.CombineOutput())
 		return -1, err
 	}
 	return revi, nil
@@ -1485,7 +1504,7 @@ func (kub *Kubectl) CiliumPolicyAction(namespace, filepath string, action Resour
 	npFilter := fmt.Sprintf(
 		`{range .items[*]}{"%s="}{.metadata.name}{" %s="}{.metadata.namespace}{"\n"}{end}`,
 		KubectlPolicyNameLabel, KubectlPolicyNameSpaceLabel)
-	kub.logger.Infof("Performing %s action on resource '%s'", action, filepath)
+	kub.Logger().Infof("Performing %s action on resource '%s'", action, filepath)
 
 	if status := kub.Action(action, filepath, namespace); !status.WasSuccessful() {
 		return "", status.GetErr(fmt.Sprintf("Cannot perform '%s' on resorce '%s'", action, filepath))
@@ -1503,20 +1522,20 @@ func (kub *Kubectl) CiliumPolicyAction(namespace, filepath string, action Resour
 
 		res := kub.ExecShort(cmd)
 		if !res.WasSuccessful() {
-			kub.logger.WithError(res.GetErr("")).Error("cannot get cnp status")
+			kub.Logger().WithError(res.GetErr("")).Error("cannot get cnp status")
 			return false
 
 		}
 
 		err := res.Unmarshal(&data)
 		if err != nil {
-			kub.logger.WithError(err).Error("Cannot unmarshal json")
+			kub.Logger().WithError(err).Error("Cannot unmarshal json")
 			return false
 		}
 
 		for _, item := range data {
 			if item["enforcing"] != "true" || item["status"] != "true" {
-				kub.logger.Errorf("Policy '%s' is not enforcing yet", item["name"])
+				kub.Logger().Errorf("Policy '%s' is not enforcing yet", item["name"])
 				return false
 			}
 		}
@@ -1542,13 +1561,13 @@ func (kub *Kubectl) CiliumPolicyAction(namespace, filepath string, action Resour
 
 		pods, err := kub.GetCiliumPods(KubeSystemNamespace)
 		if err != nil {
-			kub.logger.WithError(err).Error("cannot retrieve cilium pods")
+			kub.Logger().WithError(err).Error("cannot retrieve cilium pods")
 			return false
 		}
 		for _, item := range result {
 			for _, ciliumPod := range pods {
 				if !kub.CiliumIsPolicyLoaded(ciliumPod, item) {
-					kub.logger.Infof("Policy '%s' is not ready on Cilium pod '%s'", item, ciliumPod)
+					kub.Logger().Infof("Policy '%s' is not ready on Cilium pod '%s'", item, ciliumPod)
 					return false
 				}
 			}
@@ -1590,7 +1609,7 @@ func (kub *Kubectl) CiliumReport(namespace string, commands ...string) {
 
 	pods, err := kub.GetCiliumPodsContext(ctx, namespace)
 	if err != nil {
-		kub.logger.WithError(err).Error("cannot retrieve cilium pods on ReportDump")
+		kub.Logger().WithError(err).Error("cannot retrieve cilium pods on ReportDump")
 	}
 	res := kub.ExecContextShort(ctx, fmt.Sprintf("%s get pods -o wide --all-namespaces", KubectlCmd))
 	ginkgoext.GinkgoPrint(res.GetDebugMessage())
@@ -1621,7 +1640,7 @@ func (kub *Kubectl) EtcdOperatorReport(ctx context.Context, reportCmds map[strin
 
 	pods, err := kub.GetPodNamesContext(ctx, KubeSystemNamespace, "etcd_cluster=cilium-etcd")
 	if err != nil {
-		kub.logger.WithError(err).Error("No etcd pods")
+		kub.Logger().WithError(err).Error("No etcd pods")
 		return
 	}
 
@@ -1692,7 +1711,7 @@ func (kub *Kubectl) CiliumCheckReport(ctx context.Context) {
 		status := kub.CiliumExecContext(ctx, pod, "cilium status --all-controllers -o json")
 		result, err := status.Filter(controllersFilter)
 		if err != nil {
-			kub.logger.WithError(err).Error("Cannot filter controller status output")
+			kub.Logger().WithError(err).Error("Cannot filter controller status output")
 			continue
 		}
 		var total = 0
@@ -1747,7 +1766,7 @@ func (kub *Kubectl) ValidateNoErrorsInLogs(duration time.Duration) {
 		// Keep the cilium logs for the given test in a separate file.
 		testPath, err := CreateReportDirectory()
 		if err != nil {
-			kub.logger.WithError(err).Error("Cannot create report directory")
+			kub.Logger().WithError(err).Error("Cannot create report directory")
 			return
 		}
 		err = ioutil.WriteFile(
@@ -1755,7 +1774,7 @@ func (kub *Kubectl) ValidateNoErrorsInLogs(duration time.Duration) {
 			[]byte(logs), LogPerm)
 
 		if err != nil {
-			kub.logger.WithError(err).Errorf("Cannot create %s", CiliumTestLog)
+			kub.Logger().WithError(err).Errorf("Cannot create %s", CiliumTestLog)
 		}
 	}()
 
@@ -1767,7 +1786,7 @@ func (kub *Kubectl) ValidateNoErrorsInLogs(duration time.Duration) {
 // GatherCiliumCoreDumps copies core dumps if are present in the /tmp folder
 // into the test report folder for further analysis.
 func (kub *Kubectl) GatherCiliumCoreDumps(ctx context.Context, ciliumPod string) {
-	log := kub.logger.WithField("pod", ciliumPod)
+	log := kub.Logger().WithField("pod", ciliumPod)
 
 	cores := kub.CiliumExecContext(ctx, ciliumPod, "ls /tmp/ | grep core")
 	if !cores.WasSuccessful() {
@@ -1799,7 +1818,7 @@ func (kub *Kubectl) GatherCiliumCoreDumps(ctx context.Context, ciliumPod string)
 // TestResultsPath
 func (kub *Kubectl) DumpCiliumCommandOutput(ctx context.Context, namespace string) {
 	ReportOnPod := func(pod string) {
-		logger := kub.logger.WithField("CiliumPod", pod)
+		logger := kub.Logger().WithField("CiliumPod", pod)
 
 		testPath, err := CreateReportDirectory()
 		if err != nil {
@@ -1816,8 +1835,9 @@ func (kub *Kubectl) DumpCiliumCommandOutput(ctx context.Context, namespace strin
 			return reportCmds
 		}
 
-		reportCmds := genReportCmds(ciliumKubCLICommands)
-		reportMapContext(ctx, testPath, reportCmds, kub.SSHMeta)
+		//TODO: do this via kubectl
+		//reportCmds := genReportCmds(ciliumKubCLICommands)
+		//reportMapContext(ctx, testPath, reportCmds, kub.SSHMeta)
 
 		logsPath := filepath.Join(BasePath, testPath)
 
@@ -1882,7 +1902,7 @@ func (kub *Kubectl) DumpCiliumCommandOutput(ctx context.Context, namespace strin
 
 	pods, err := kub.GetCiliumPodsContext(ctx, namespace)
 	if err != nil {
-		kub.logger.WithError(err).Error("cannot retrieve cilium pods on ReportDump")
+		kub.Logger().WithError(err).Error("cannot retrieve cilium pods on ReportDump")
 		return
 	}
 	for _, pod := range pods {
@@ -1917,16 +1937,17 @@ func (kub *Kubectl) GatherLogs(ctx context.Context) {
 			reportCmds[key] = fmt.Sprintf("api-resource-%s.txt", line)
 		}
 	} else {
-		kub.logger.Errorf("Cannot get api-resoureces: %s", res.GetDebugMessage())
+		kub.Logger().Errorf("Cannot get api-resoureces: %s", res.GetDebugMessage())
 	}
 
 	testPath, err := CreateReportDirectory()
 	if err != nil {
-		kub.logger.WithError(err).Errorf(
+		kub.Logger().WithError(err).Errorf(
 			"cannot create test results path '%s'", testPath)
 		return
 	}
-	reportMap(testPath, reportCmds, kub.SSHMeta)
+	//TODO: do it via kubectl
+	//reportMap(testPath, reportCmds, kub.SSHMeta)
 
 	for _, node := range []string{K8s1VMName(), K8s2VMName()} {
 		vm := GetVagrantSSHMeta(node)
@@ -1948,7 +1969,7 @@ func (kub *Kubectl) GeneratePodLogGatheringCommands(ctx context.Context, reportC
 	}
 	pods, err := kub.GetAllPods(ctx, ExecOptions{SkipLog: true})
 	if err != nil {
-		kub.logger.WithError(err).Error("Unable to get pods from Kubernetes via kubectl")
+		kub.Logger().WithError(err).Error("Unable to get pods from Kubernetes via kubectl")
 	}
 
 	for _, pod := range pods {

--- a/test/helpers/local_node.go
+++ b/test/helpers/local_node.go
@@ -1,0 +1,254 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helpers
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	ginkgoext "github.com/cilium/cilium/test/ginkgo-ext"
+
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	//LocalExecutorLogs is a buffer where all commands sent over ssh are saved.
+	LocalExecutorLogs = ginkgoext.NewWriter(new(Buffer))
+)
+
+// Executor executes commands
+type Executor interface {
+	CloseSSHClient()
+	Exec(cmd string, options ...ExecOptions) *CmdRes
+	ExecContext(ctx context.Context, cmd string, options ...ExecOptions) *CmdRes
+	ExecContextShort(ctx context.Context, cmd string, options ...ExecOptions) *CmdRes
+	ExecInBackground(ctx context.Context, cmd string, options ...ExecOptions) *CmdRes
+	ExecMiddle(cmd string, options ...ExecOptions) *CmdRes
+	ExecShort(cmd string, options ...ExecOptions) *CmdRes
+	ExecWithSudo(cmd string, options ...ExecOptions) *CmdRes
+	ExecuteContext(ctx context.Context, cmd string, stdout io.Writer, stderr io.Writer) error
+	String() string
+	setBasePath()
+
+	Logger() *logrus.Entry
+}
+
+// LocalExecutor executes commands, implements Executor interface
+type LocalExecutor struct {
+	env    []string
+	logger *logrus.Entry
+}
+
+// CreateLocalExecutor returns a local executor
+func CreateLocalExecutor(env []string) *LocalExecutor {
+	return &LocalExecutor{env: env}
+}
+
+// Logger returns logger for executor
+func (s *LocalExecutor) Logger() *logrus.Entry {
+	return s.logger
+}
+
+func (s *LocalExecutor) String() string {
+	return fmt.Sprintf("environment: %s", s.env)
+
+}
+
+// CloseSSHClient is a no-op
+func (s *LocalExecutor) CloseSSHClient() {
+	return
+}
+
+// setBasePath is a no-op
+func (s *LocalExecutor) setBasePath() {
+	gopath := os.Getenv("GOPATH")
+	if gopath != "" {
+		BasePath = filepath.Join(gopath, CiliumPath)
+		return
+	}
+
+	home := os.Getenv("HOME")
+	if home == "" {
+		return
+	}
+
+	BasePath = filepath.Join(home, "go", CiliumPath)
+	return
+}
+
+func (s LocalExecutor) getLocalCmd(ctx context.Context, command string, stdout io.Writer, stderr io.Writer) *exec.Cmd {
+	com := "bash"
+	args := []string{"-c", command}
+
+	cmd := exec.CommandContext(ctx, com, args...)
+	if stdout == nil {
+		stdout = os.Stdout
+	}
+	if stderr == nil {
+		stderr = os.Stderr
+	}
+
+	fmt.Fprintln(LocalExecutorLogs, cmd)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+
+	cmd.Env = s.env
+
+	return cmd
+}
+
+// ExecuteContext executes the given `cmd` and writes the cmd's stdout and
+// stderr into the given io.Writers.
+// Returns an error if context Deadline() is reached or if there was an error
+// executing the command.
+func (s *LocalExecutor) ExecuteContext(ctx context.Context, command string, stdout io.Writer, stderr io.Writer) error {
+	cmd := s.getLocalCmd(ctx, command, stdout, stderr)
+	return cmd.Run()
+}
+
+// ExecWithSudo returns the result of executing the provided cmd via SSH using
+// sudo.
+func (s *LocalExecutor) ExecWithSudo(cmd string, options ...ExecOptions) *CmdRes {
+	command := fmt.Sprintf("sudo %s", cmd)
+	return s.Exec(command, options...)
+}
+
+// Exec returns the results of executing the provided cmd via SSH.
+func (s *LocalExecutor) Exec(cmd string, options ...ExecOptions) *CmdRes {
+	// Bound all command executions to be at most the timeout used by the CI
+	// so that commands do not block forever.
+	ctx, cancel := context.WithTimeout(context.Background(), HelperTimeout)
+	defer cancel()
+	return s.ExecContext(ctx, cmd, options...)
+}
+
+// ExecShort runs command with the provided options. It will take up to
+// ShortCommandTimeout seconds to run the command before it times out.
+func (s *LocalExecutor) ExecShort(cmd string, options ...ExecOptions) *CmdRes {
+	ctx, cancel := context.WithTimeout(context.Background(), ShortCommandTimeout)
+	defer cancel()
+	return s.ExecContext(ctx, cmd, options...)
+}
+
+// ExecMiddle runs command with the provided options. It will take up to
+// MidCommandTimeout seconds to run the command before it times out.
+func (s *LocalExecutor) ExecMiddle(cmd string, options ...ExecOptions) *CmdRes {
+	ctx, cancel := context.WithTimeout(context.Background(), MidCommandTimeout)
+	defer cancel()
+	return s.ExecContext(ctx, cmd, options...)
+}
+
+// ExecContextShort is a wrapper around ExecContext which creates a child
+// context with a timeout of ShortCommandTimeout.
+func (s *LocalExecutor) ExecContextShort(ctx context.Context, cmd string, options ...ExecOptions) *CmdRes {
+	shortCtx, cancel := context.WithTimeout(ctx, ShortCommandTimeout)
+	defer cancel()
+	return s.ExecContext(shortCtx, cmd, options...)
+}
+
+// ExecContext returns the results of executing the provided cmd via SSH.
+func (s *LocalExecutor) ExecContext(ctx context.Context, cmd string, options ...ExecOptions) *CmdRes {
+	var ops ExecOptions
+	if len(options) > 0 {
+		ops = options[0]
+	}
+
+	log.Debugf("running command: %s", cmd)
+	stdout := new(Buffer)
+	stderr := new(Buffer)
+	start := time.Now()
+	err := s.ExecuteContext(ctx, cmd, stdout, stderr)
+
+	res := CmdRes{
+		cmd:      cmd,
+		stdout:   stdout,
+		stderr:   stderr,
+		success:  true, // this may be toggled when err != nil below
+		duration: time.Since(start),
+	}
+
+	if err != nil {
+
+		if exitError, ok := err.(*exec.ExitError); ok {
+			res.exitcode = exitError.ExitCode()
+		}
+		res.success = false
+
+		log.WithError(err).Errorf("Error executing command '%s'", cmd)
+		res.err = err
+	}
+
+	res.SendToLog(ops.SkipLog)
+	return &res
+}
+
+// ExecInBackground returns the results of running cmd in the specified
+// context. The command will be executed in the background until context.Context
+// is canceled or the command has finish its execution.
+func (s *LocalExecutor) ExecInBackground(ctx context.Context, cmd string, options ...ExecOptions) *CmdRes {
+	if ctx == nil {
+		panic("no context provided")
+	}
+
+	var ops ExecOptions
+	if len(options) > 0 {
+		ops = options[0]
+	}
+
+	fmt.Fprintln(LocalExecutorLogs, cmd)
+	stdout := new(Buffer)
+	stderr := new(Buffer)
+
+	command := s.getLocalCmd(ctx, cmd, stdout, stderr)
+
+	var wg sync.WaitGroup
+	res := &CmdRes{
+		cmd:     cmd,
+		stdout:  stdout,
+		stderr:  stderr,
+		success: true,
+		wg:      &wg,
+	}
+
+	res.wg.Add(1)
+	go func(cmd *exec.Cmd, res *CmdRes) {
+		defer res.wg.Done()
+		start := time.Now()
+		err := cmd.Run()
+		res.duration = time.Since(start)
+
+		if err != nil {
+			if exitError, ok := err.(*exec.ExitError); ok {
+				res.exitcode = exitError.ExitCode()
+			}
+			res.success = false
+
+			log.WithError(err).Errorf("Error executing command '%s'", strings.Join(append([]string{cmd.Path}, cmd.Args...), " "))
+			res.err = err
+		}
+
+		res.SendToLog(ops.SkipLog)
+	}(command, res)
+
+	return res
+}

--- a/test/helpers/local_node.go
+++ b/test/helpers/local_node.go
@@ -47,6 +47,7 @@ type Executor interface {
 	ExecWithSudo(cmd string, options ...ExecOptions) *CmdRes
 	ExecuteContext(ctx context.Context, cmd string, stdout io.Writer, stderr io.Writer) error
 	String() string
+	BasePath() string
 	setBasePath()
 
 	Logger() *logrus.Entry
@@ -54,8 +55,9 @@ type Executor interface {
 
 // LocalExecutor executes commands, implements Executor interface
 type LocalExecutor struct {
-	env    []string
-	logger *logrus.Entry
+	env      []string
+	logger   *logrus.Entry
+	basePath string
 }
 
 // CreateLocalExecutor returns a local executor
@@ -82,7 +84,7 @@ func (s *LocalExecutor) CloseSSHClient() {
 func (s *LocalExecutor) setBasePath() {
 	gopath := os.Getenv("GOPATH")
 	if gopath != "" {
-		BasePath = filepath.Join(gopath, CiliumPath)
+		s.basePath = filepath.Join(gopath, CiliumPath)
 		return
 	}
 
@@ -91,7 +93,7 @@ func (s *LocalExecutor) setBasePath() {
 		return
 	}
 
-	BasePath = filepath.Join(home, "go", CiliumPath)
+	s.basePath = filepath.Join(home, "go", CiliumPath)
 	return
 }
 
@@ -251,4 +253,8 @@ func (s *LocalExecutor) ExecInBackground(ctx context.Context, cmd string, option
 	}(command, res)
 
 	return res
+}
+
+func (s *LocalExecutor) BasePath() string {
+	return s.basePath
 }

--- a/test/helpers/node.go
+++ b/test/helpers/node.go
@@ -24,7 +24,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cilium/cilium/test/config"
 	ginkgoext "github.com/cilium/cilium/test/ginkgo-ext"
 
 	"github.com/sirupsen/logrus"
@@ -43,6 +42,7 @@ type SSHMeta struct {
 	rawConfig []byte
 	nodeName  string
 	logger    *logrus.Entry
+	basePath  string
 }
 
 // CreateSSHMeta returns an SSHMeta with the specified host, port, and user, as
@@ -113,13 +113,9 @@ func GetVagrantSSHMeta(vmName string) *SSHMeta {
 // setBasePath if the SSHConfig is defined we set the BasePath to the GOPATH,
 // from golang 1.8 GOPATH is by default $HOME/go so we also check that.
 func (s *SSHMeta) setBasePath() {
-	if config.CiliumTestConfig.SSHConfig == "" {
-		return
-	}
-
 	gopath := s.Exec("echo $GOPATH").SingleOut()
 	if gopath != "" {
-		BasePath = filepath.Join(gopath, CiliumPath)
+		s.basePath = filepath.Join(gopath, CiliumPath)
 		return
 	}
 
@@ -128,7 +124,7 @@ func (s *SSHMeta) setBasePath() {
 		return
 	}
 
-	BasePath = filepath.Join(home, "go", CiliumPath)
+	s.basePath = filepath.Join(home, "go", CiliumPath)
 	return
 }
 

--- a/test/helpers/node.go
+++ b/test/helpers/node.go
@@ -53,6 +53,11 @@ func CreateSSHMeta(host string, port int, user string) *SSHMeta {
 	}
 }
 
+// Logger returns logger for SSHMeta
+func (s *SSHMeta) Logger() *logrus.Entry {
+	return s.logger
+}
+
 func (s *SSHMeta) String() string {
 	return fmt.Sprintf("environment: %s, SSHClient: %s", s.env, s.sshClient.String())
 

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -318,7 +318,7 @@ func reportMapContext(ctx context.Context, path string, reportCmds map[string]st
 // 2- base_path/k8s_version/integration/filename
 // 3- base_path/k8s_version/filename
 // 4- base_path/filename
-func ManifestGet(manifestFilename string) string {
+func ManifestGet(base, manifestFilename string) string {
 	// Try dependent integration file only if we have one configured. This is
 	// needed since no integration is "" and that causes us to find the
 	// base_path/filename before we check the base_path/k8s_version/filename
@@ -326,14 +326,14 @@ func ManifestGet(manifestFilename string) string {
 		fullPath := filepath.Join(manifestsPath, integration, manifestFilename)
 		_, err := os.Stat(fullPath)
 		if err == nil {
-			return filepath.Join(BasePath, fullPath)
+			return filepath.Join(base, fullPath)
 		}
 
 		// try dependent k8s version and integration file
 		fullPath = filepath.Join(manifestsPath, GetCurrentK8SEnv(), integration, manifestFilename)
 		_, err = os.Stat(fullPath)
 		if err == nil {
-			return filepath.Join(BasePath, fullPath)
+			return filepath.Join(base, fullPath)
 		}
 	}
 
@@ -341,9 +341,9 @@ func ManifestGet(manifestFilename string) string {
 	fullPath := filepath.Join(manifestsPath, GetCurrentK8SEnv(), manifestFilename)
 	_, err := os.Stat(fullPath)
 	if err == nil {
-		return filepath.Join(BasePath, fullPath)
+		return filepath.Join(base, fullPath)
 	}
-	return filepath.Join(BasePath, "k8sT", "manifests", manifestFilename)
+	return filepath.Join(base, "k8sT", "manifests", manifestFilename)
 }
 
 // WriteOrAppendToFile writes data to a file named by filename.
@@ -365,7 +365,7 @@ func WriteOrAppendToFile(filename string, data []byte, perm os.FileMode) error {
 }
 
 // DNSDeployment returns the manifest to install dns engine on the server.
-func DNSDeployment() string {
+func DNSDeployment(base string) string {
 	var DNSEngine = "coredns"
 	k8sVersion := GetCurrentK8SEnv()
 	switch k8sVersion {
@@ -375,9 +375,9 @@ func DNSDeployment() string {
 	fullPath := filepath.Join("provision", "manifest", k8sVersion, DNSEngine+"_deployment.yaml")
 	_, err := os.Stat(fullPath)
 	if err == nil {
-		return filepath.Join(BasePath, fullPath)
+		return filepath.Join(base, fullPath)
 	}
-	return filepath.Join(BasePath, "provision", "manifest", DNSEngine+"_deployment.yaml")
+	return filepath.Join(base, "provision", "manifest", DNSEngine+"_deployment.yaml")
 }
 
 // getK8sSupportedConstraints returns the Kubernetes versions supported by

--- a/test/k8sT/Chaos.go
+++ b/test/k8sT/Chaos.go
@@ -28,12 +28,13 @@ var _ = Describe("K8sChaosTest", func() {
 
 	var (
 		kubectl       *helpers.Kubectl
-		demoDSPath    = helpers.ManifestGet("demo_ds.yaml")
+		demoDSPath    string
 		testDSService = "testds-service"
 	)
 
 	BeforeAll(func() {
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
+		demoDSPath = helpers.ManifestGet(kubectl.BasePath(), "demo_ds.yaml")
 		DeployCiliumAndDNS(kubectl)
 	})
 
@@ -169,8 +170,8 @@ var _ = Describe("K8sChaosTest", func() {
 	Context("Restart with long lived connections", func() {
 
 		var (
-			netperfManifest    = helpers.ManifestGet("netperf-deployment.yaml")
-			netperfPolicy      = helpers.ManifestGet("netperf-policy.yaml")
+			netperfManifest    string
+			netperfPolicy      string
 			netperfServiceName = "netperf-service"
 			podsIps            map[string]string
 			netperfClient      = "netperf-client"
@@ -178,6 +179,9 @@ var _ = Describe("K8sChaosTest", func() {
 		)
 
 		BeforeAll(func() {
+			netperfManifest = helpers.ManifestGet(kubectl.BasePath(), "netperf-deployment.yaml")
+			netperfPolicy = helpers.ManifestGet(kubectl.BasePath(), "netperf-policy.yaml")
+
 			kubectl.Apply(netperfManifest).ExpectSuccess("Netperf cannot be deployed")
 
 			err := kubectl.WaitforPods(

--- a/test/k8sT/Chaos.go
+++ b/test/k8sT/Chaos.go
@@ -232,12 +232,11 @@ var _ = Describe("K8sChaosTest", func() {
 				ctx,
 				helpers.DefaultNamespace,
 				netperfClient,
-				fmt.Sprintf("netperf -l 300 -t TCP_STREAM -H %s", podsIps[netperfServer]))
+				fmt.Sprintf("netperf -l 60 -t TCP_STREAM -H %s", podsIps[netperfServer]))
 
 			restartCilium()
 
 			By("Stopping netperf client test")
-			cancel()
 			res.WaitUntilFinish()
 			res.ExpectSuccess("Failed while cilium was restarting")
 		})
@@ -250,7 +249,7 @@ var _ = Describe("K8sChaosTest", func() {
 				ctx,
 				helpers.DefaultNamespace,
 				netperfClient,
-				fmt.Sprintf("netperf -l 300 -t TCP_STREAM -H %s", podsIps[netperfServer]))
+				fmt.Sprintf("netperf -l 60 -t TCP_STREAM -H %s", podsIps[netperfServer]))
 
 			By("Installing the L3-L4 Policy")
 			_, err := kubectl.CiliumPolicyAction(
@@ -260,7 +259,6 @@ var _ = Describe("K8sChaosTest", func() {
 			restartCilium()
 
 			By("Stopping netperf client test")
-			cancel()
 			res.WaitUntilFinish()
 			res.ExpectSuccess("Failed while cilium was restarting")
 		})

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -31,8 +31,8 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 	BeforeAll(func() {
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
-		demoDSPath = helpers.ManifestGet("demo_ds.yaml")
-		ipsecDSPath = helpers.ManifestGet("ipsec_ds.yaml")
+		demoDSPath = helpers.ManifestGet(kubectl.BasePath(), "demo_ds.yaml")
+		ipsecDSPath = helpers.ManifestGet(kubectl.BasePath(), "ipsec_ds.yaml")
 
 		deleteCiliumDS(kubectl)
 	})

--- a/test/k8sT/KafkaPolicies.go
+++ b/test/k8sT/KafkaPolicies.go
@@ -29,13 +29,16 @@ import (
 var _ = Describe("K8sKafkaPolicyTest", func() {
 
 	var (
-		kubectl             *helpers.Kubectl
-		microscopeErr       error
-		microscopeCancel                       = func() error { return nil }
-		backgroundCancel    context.CancelFunc = func() { return }
-		backgroundError     error
-		l7Policy            = helpers.ManifestGet("kafka-sw-security-policy.yaml")
-		demoPath            = helpers.ManifestGet("kafka-sw-app.yaml")
+		kubectl          *helpers.Kubectl
+		microscopeErr    error
+		microscopeCancel                    = func() error { return nil }
+		backgroundCancel context.CancelFunc = func() { return }
+		backgroundError  error
+
+		// these two are set in BeforeAll
+		l7Policy string
+		demoPath string
+
 		kafkaApp            = "kafka"
 		backupApp           = "empire-backup"
 		empireHqApp         = "empire-hq"
@@ -127,6 +130,10 @@ var _ = Describe("K8sKafkaPolicyTest", func() {
 
 		BeforeAll(func() {
 			kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
+
+			l7Policy = helpers.ManifestGet(kubectl.BasePath(), "kafka-sw-security-policy.yaml")
+			demoPath = helpers.ManifestGet(kubectl.BasePath(), "kafka-sw-app.yaml")
+
 			DeployCiliumAndDNS(kubectl)
 
 			kubectl.Apply(demoPath)

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -29,20 +29,21 @@ import (
 var _ = Describe("K8sPolicyTest", func() {
 
 	var (
-		kubectl              *helpers.Kubectl
-		demoPath             = helpers.ManifestGet("demo.yaml")
-		l3Policy             = helpers.ManifestGet("l3-l4-policy.yaml")
-		l7Policy             = helpers.ManifestGet("l7-policy.yaml")
-		l7PolicyKafka        = helpers.ManifestGet("l7-policy-kafka.yaml")
-		serviceAccountPolicy = helpers.ManifestGet("service-account.yaml")
-		knpDenyIngress       = helpers.ManifestGet("knp-default-deny-ingress.yaml")
-		knpDenyEgress        = helpers.ManifestGet("knp-default-deny-egress.yaml")
-		knpDenyIngressEgress = helpers.ManifestGet("knp-default-deny-ingress-egress.yaml")
-		cnpDenyIngress       = helpers.ManifestGet("cnp-default-deny-ingress.yaml")
-		cnpDenyEgress        = helpers.ManifestGet("cnp-default-deny-egress.yaml")
-		knpAllowIngress      = helpers.ManifestGet("knp-default-allow-ingress.yaml")
-		knpAllowEgress       = helpers.ManifestGet("knp-default-allow-egress.yaml")
-		cnpMatchExpression   = helpers.ManifestGet("cnp-matchexpressions.yaml")
+		kubectl *helpers.Kubectl
+		// these are set in BeforeAll()
+		demoPath             string
+		l3Policy             string
+		l7Policy             string
+		l7PolicyKafka        string
+		serviceAccountPolicy string
+		knpDenyIngress       string
+		knpDenyEgress        string
+		knpDenyIngressEgress string
+		cnpDenyIngress       string
+		cnpDenyEgress        string
+		knpAllowIngress      string
+		knpAllowEgress       string
+		cnpMatchExpression   string
 		app1Service          = "app1-service"
 		microscopeErr        error
 		microscopeCancel                        = func() error { return nil }
@@ -53,6 +54,21 @@ var _ = Describe("K8sPolicyTest", func() {
 
 	BeforeAll(func() {
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
+
+		demoPath = helpers.ManifestGet(kubectl.BasePath(), "demo.yaml")
+		l3Policy = helpers.ManifestGet(kubectl.BasePath(), "l3-l4-policy.yaml")
+		l7Policy = helpers.ManifestGet(kubectl.BasePath(), "l7-policy.yaml")
+		l7PolicyKafka = helpers.ManifestGet(kubectl.BasePath(), "l7-policy-kafka.yaml")
+		serviceAccountPolicy = helpers.ManifestGet(kubectl.BasePath(), "service-account.yaml")
+		knpDenyIngress = helpers.ManifestGet(kubectl.BasePath(), "knp-default-deny-ingress.yaml")
+		knpDenyEgress = helpers.ManifestGet(kubectl.BasePath(), "knp-default-deny-egress.yaml")
+		knpDenyIngressEgress = helpers.ManifestGet(kubectl.BasePath(), "knp-default-deny-ingress-egress.yaml")
+		cnpDenyIngress = helpers.ManifestGet(kubectl.BasePath(), "cnp-default-deny-ingress.yaml")
+		cnpDenyEgress = helpers.ManifestGet(kubectl.BasePath(), "cnp-default-deny-egress.yaml")
+		knpAllowIngress = helpers.ManifestGet(kubectl.BasePath(), "knp-default-allow-ingress.yaml")
+		knpAllowEgress = helpers.ManifestGet(kubectl.BasePath(), "knp-default-allow-egress.yaml")
+		cnpMatchExpression = helpers.ManifestGet(kubectl.BasePath(), "cnp-matchexpressions.yaml")
+
 		DeployCiliumAndDNS(kubectl)
 	})
 
@@ -264,7 +280,7 @@ var _ = Describe("K8sPolicyTest", func() {
 		}, 500)
 
 		It("Invalid Policy report status correctly", func() {
-			manifest := helpers.ManifestGet("invalid_cnp.yaml")
+			manifest := helpers.ManifestGet(kubectl.BasePath(), "invalid_cnp.yaml")
 			cnpName := "foo"
 			kubectl.Apply(manifest, namespaceForTest).ExpectSuccess("Cannot apply policy manifest")
 
@@ -545,11 +561,18 @@ var _ = Describe("K8sPolicyTest", func() {
 			)
 
 			var (
-				cnpToEntitiesAll     = helpers.ManifestGet("cnp-to-entities-all.yaml")
-				cnpToEntitiesWorld   = helpers.ManifestGet("cnp-to-entities-world.yaml")
-				cnpToEntitiesCluster = helpers.ManifestGet("cnp-to-entities-cluster.yaml")
-				cnpToEntitiesHost    = helpers.ManifestGet("cnp-to-entities-host.yaml")
+				cnpToEntitiesAll     string
+				cnpToEntitiesWorld   string
+				cnpToEntitiesCluster string
+				cnpToEntitiesHost    string
 			)
+
+			BeforeAll(func() {
+				cnpToEntitiesAll = helpers.ManifestGet(kubectl.BasePath(), "cnp-to-entities-all.yaml")
+				cnpToEntitiesWorld = helpers.ManifestGet(kubectl.BasePath(), "cnp-to-entities-world.yaml")
+				cnpToEntitiesCluster = helpers.ManifestGet(kubectl.BasePath(), "cnp-to-entities-cluster.yaml")
+				cnpToEntitiesHost = helpers.ManifestGet(kubectl.BasePath(), "cnp-to-entities-host.yaml")
+			})
 
 			It("Validate toEntities All", func() {
 				By("Installing toEntities All")
@@ -592,11 +615,18 @@ var _ = Describe("K8sPolicyTest", func() {
 			)
 
 			var (
-				cnpUpdateAllow        = helpers.ManifestGet("cnp-update-allow-all.yaml")
-				cnpUpdateDeny         = helpers.ManifestGet("cnp-update-deny-ingress.yaml")
-				cnpUpdateNoSpecs      = helpers.ManifestGet("cnp-update-no-specs.yaml")
-				cnpUpdateDenyLabelled = helpers.ManifestGet("cnp-update-deny-ingress-labelled.yaml")
+				cnpUpdateAllow        string
+				cnpUpdateDeny         string
+				cnpUpdateNoSpecs      string
+				cnpUpdateDenyLabelled string
 			)
+
+			BeforeAll(func() {
+				cnpUpdateAllow = helpers.ManifestGet(kubectl.BasePath(), "cnp-update-allow-all.yaml")
+				cnpUpdateDeny = helpers.ManifestGet(kubectl.BasePath(), "cnp-update-deny-ingress.yaml")
+				cnpUpdateNoSpecs = helpers.ManifestGet(kubectl.BasePath(), "cnp-update-no-specs.yaml")
+				cnpUpdateDenyLabelled = helpers.ManifestGet(kubectl.BasePath(), "cnp-update-deny-ingress-labelled.yaml")
+			})
 
 			validateL3L4 := func(allowApp3 bool) {
 				res := kubectl.ExecPodCmd(
@@ -707,7 +737,7 @@ var _ = Describe("K8sPolicyTest", func() {
 		var err error
 
 		BeforeEach(func() {
-			kubectl.Apply(helpers.ManifestGet(deployment))
+			kubectl.Apply(helpers.ManifestGet(kubectl.BasePath(), deployment))
 			ciliumPods, err := kubectl.GetCiliumPods(helpers.KubeSystemNamespace)
 			Expect(err).To(BeNil(), "cannot retrieve Cilium Pods")
 			Expect(ciliumPods).ShouldNot(BeEmpty(), "cannot retrieve Cilium pods")
@@ -721,16 +751,16 @@ var _ = Describe("K8sPolicyTest", func() {
 
 		AfterEach(func() {
 
-			kubectl.Delete(helpers.ManifestGet(webPolicy)).ExpectSuccess(
+			kubectl.Delete(helpers.ManifestGet(kubectl.BasePath(), webPolicy)).ExpectSuccess(
 				"Web policy cannot be deleted")
-			kubectl.Delete(helpers.ManifestGet(redisPolicyDeprecated)).ExpectSuccess(
+			kubectl.Delete(helpers.ManifestGet(kubectl.BasePath(), redisPolicyDeprecated)).ExpectSuccess(
 				"Redis deprecated policy cannot be deleted")
-			kubectl.Delete(helpers.ManifestGet(deployment)).ExpectSuccess(
+			kubectl.Delete(helpers.ManifestGet(kubectl.BasePath(), deployment)).ExpectSuccess(
 				"Guestbook deployment cannot be deleted")
 
 			// This policy shouldn't be there, but test can fail before delete
 			// the policy and we want to make sure that it's deleted
-			kubectl.Delete(helpers.ManifestGet(redisPolicy))
+			kubectl.Delete(helpers.ManifestGet(kubectl.BasePath(), redisPolicy))
 			for _, ciliumPod := range ciliumPods {
 				err := kubectl.WaitPolicyDeleted(ciliumPod, getPolicyCmd(webPolicyName))
 				Expect(err).To(
@@ -797,7 +827,7 @@ EOF`, k, v)
 
 			By("Apply policy to web")
 			_, err = kubectl.CiliumPolicyAction(
-				helpers.DefaultNamespace, helpers.ManifestGet(webPolicy),
+				helpers.DefaultNamespace, helpers.ManifestGet(kubectl.BasePath(), webPolicy),
 				helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Cannot apply web-policy")
 
@@ -808,7 +838,7 @@ EOF`, k, v)
 
 			By("Apply policy to Redis")
 			_, err = kubectl.CiliumPolicyAction(
-				helpers.DefaultNamespace, helpers.ManifestGet(redisPolicy),
+				helpers.DefaultNamespace, helpers.ManifestGet(kubectl.BasePath(), redisPolicy),
 				helpers.KubectlApply, helpers.HelperTimeout)
 
 			Expect(err).Should(BeNil(), "Cannot apply redis policy")
@@ -821,14 +851,14 @@ EOF`, k, v)
 			testConnectivitytoRedis()
 
 			_, err = kubectl.CiliumPolicyAction(
-				helpers.DefaultNamespace, helpers.ManifestGet(redisPolicy),
+				helpers.DefaultNamespace, helpers.ManifestGet(kubectl.BasePath(), redisPolicy),
 				helpers.KubectlDelete, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Cannot apply redis policy")
 
 			By("Apply deprecated policy to Redis")
 
 			_, err = kubectl.CiliumPolicyAction(
-				helpers.DefaultNamespace, helpers.ManifestGet(redisPolicyDeprecated),
+				helpers.DefaultNamespace, helpers.ManifestGet(kubectl.BasePath(), redisPolicyDeprecated),
 				helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Cannot apply redis deprecated policy err: %q", err)
 
@@ -851,15 +881,21 @@ EOF`, k, v)
 			clusterIP         string
 			secondNSclusterIP string
 
-			demoPath           = helpers.ManifestGet("demo.yaml")
-			l3L4Policy         = helpers.ManifestGet("l3-l4-policy.yaml")
-			cnpSecondNS        = helpers.ManifestGet("cnp-second-namespaces.yaml")
-			netpolNsSelector   = fmt.Sprintf("%s -n %s", helpers.ManifestGet("netpol-namespace-selector.yaml"), secondNS)
-			l3l4PolicySecondNS = fmt.Sprintf("%s -n %s", l3L4Policy, secondNS)
-			demoManifest       = fmt.Sprintf("%s -n %s", demoPath, secondNS)
+			demoPath           string
+			l3L4Policy         string
+			cnpSecondNS        string
+			netpolNsSelector   string
+			l3l4PolicySecondNS string
+			demoManifest       string
 		)
 
 		BeforeAll(func() {
+			demoPath = helpers.ManifestGet(kubectl.BasePath(), "demo.yaml")
+			l3L4Policy = helpers.ManifestGet(kubectl.BasePath(), "l3-l4-policy.yaml")
+			cnpSecondNS = helpers.ManifestGet(kubectl.BasePath(), "cnp-second-namespaces.yaml")
+			netpolNsSelector = fmt.Sprintf("%s -n %s", helpers.ManifestGet(kubectl.BasePath(), "netpol-namespace-selector.yaml"), secondNS)
+			l3l4PolicySecondNS = fmt.Sprintf("%s -n %s", l3L4Policy, secondNS)
+			demoManifest = fmt.Sprintf("%s -n %s", demoPath, secondNS)
 
 			res := kubectl.NamespaceCreate(secondNS)
 			res.ExpectSuccess("unable to create namespace %q", secondNS)

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -117,8 +117,13 @@ var _ = Describe("K8sServicesTest", func() {
 	Context("Checks ClusterIP Connectivity", func() {
 
 		var (
-			demoYAML = helpers.ManifestGet("demo.yaml")
+			demoYAML string
 		)
+
+		BeforeAll(func() {
+
+			demoYAML = helpers.ManifestGet(kubectl.BasePath(), "demo.yaml")
+		})
 
 		BeforeEach(func() {
 			res := kubectl.Apply(demoYAML)
@@ -157,10 +162,11 @@ var _ = Describe("K8sServicesTest", func() {
 	Context("Checks service across nodes", func() {
 
 		var (
-			demoYAML = helpers.ManifestGet("demo_ds.yaml")
+			demoYAML string
 		)
 
 		BeforeAll(func() {
+			demoYAML = helpers.ManifestGet(kubectl.BasePath(), "demo_ds.yaml")
 			res := kubectl.Apply(demoYAML)
 			res.ExpectSuccess("Unable to apply %s", demoYAML)
 		})
@@ -239,8 +245,12 @@ var _ = Describe("K8sServicesTest", func() {
 
 		Context("with L7 policy", func() {
 			var (
-				demoPolicy = helpers.ManifestGet("l7-policy-demo.yaml")
+				demoPolicy string
 			)
+
+			BeforeAll(func() {
+				demoPolicy = helpers.ManifestGet(kubectl.BasePath(), "l7-policy-demo.yaml")
+			})
 
 			AfterAll(func() {
 				// Explicitly ignore result of deletion of resources to avoid incomplete
@@ -313,14 +323,20 @@ var _ = Describe("K8sServicesTest", func() {
 			expectedCIDR = "198.49.23.144/32"
 			podName      = "toservices"
 
-			endpointPath      = helpers.ManifestGet("external_endpoint.yaml")
-			podPath           = helpers.ManifestGet("external_pod.yaml")
-			policyPath        = helpers.ManifestGet("external-policy.yaml")
-			policyLabeledPath = helpers.ManifestGet("external-policy-labeled.yaml")
-			servicePath       = helpers.ManifestGet("external_service.yaml")
+			endpointPath      string
+			podPath           string
+			policyPath        string
+			policyLabeledPath string
+			servicePath       string
 		)
 
 		BeforeAll(func() {
+			endpointPath = helpers.ManifestGet(kubectl.BasePath(), "external_endpoint.yaml")
+			podPath = helpers.ManifestGet(kubectl.BasePath(), "external_pod.yaml")
+			policyPath = helpers.ManifestGet(kubectl.BasePath(), "external-policy.yaml")
+			policyLabeledPath = helpers.ManifestGet(kubectl.BasePath(), "external-policy-labeled.yaml")
+			servicePath = helpers.ManifestGet(kubectl.BasePath(), "external_service.yaml")
+
 			kubectl.Apply(servicePath).ExpectSuccess("cannot install external service")
 			kubectl.Apply(podPath).ExpectSuccess("cannot install pod path")
 
@@ -437,9 +453,9 @@ var _ = Describe("K8sServicesTest", func() {
 
 		BeforeEach(func() {
 
-			bookinfoV1YAML = helpers.ManifestGet("bookinfo-v1.yaml")
-			bookinfoV2YAML = helpers.ManifestGet("bookinfo-v2.yaml")
-			policyPath = helpers.ManifestGet("cnp-specs.yaml")
+			bookinfoV1YAML = helpers.ManifestGet(kubectl.BasePath(), "bookinfo-v1.yaml")
+			bookinfoV2YAML = helpers.ManifestGet(kubectl.BasePath(), "bookinfo-v2.yaml")
+			policyPath = helpers.ManifestGet(kubectl.BasePath(), "cnp-specs.yaml")
 
 			resourceYAMLs = []string{bookinfoV1YAML, bookinfoV2YAML}
 

--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -2,6 +2,7 @@ package k8sTest
 
 import (
 	"fmt"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -11,10 +12,11 @@ import (
 )
 
 var (
-	demoPath         = helpers.ManifestGet("demo.yaml")
-	l7Policy         = helpers.ManifestGet("l7-policy.yaml")
-	migrateSVCClient = helpers.ManifestGet("migrate-svc-client.yaml")
-	migrateSVCServer = helpers.ManifestGet("migrate-svc-server.yaml")
+	// These are set in BeforeAll
+	demoPath         string
+	l7Policy         string
+	migrateSVCClient string
+	migrateSVCServer string
 )
 
 var _ = Describe("K8sUpdates", func() {
@@ -42,7 +44,11 @@ var _ = Describe("K8sUpdates", func() {
 	BeforeAll(func() {
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 
-		_ = kubectl.Delete(helpers.DNSDeployment())
+		demoPath = helpers.ManifestGet(kubectl.BasePath(), "demo.yaml")
+		l7Policy = helpers.ManifestGet(kubectl.BasePath(), "l7-policy.yaml")
+		migrateSVCClient = helpers.ManifestGet(kubectl.BasePath(), "migrate-svc-client.yaml")
+		migrateSVCServer = helpers.ManifestGet(kubectl.BasePath(), "migrate-svc-server.yaml")
+		_ = kubectl.Delete(helpers.DNSDeployment(kubectl.BasePath()))
 
 		kubectl.Delete(migrateSVCClient)
 		kubectl.Delete(migrateSVCServer)
@@ -129,7 +135,7 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldVersion, newV
 		err = kubectl.WaitForCiliumInitContainerToFinish()
 		ExpectWithOffset(1, err).To(BeNil(), "Cilium %q was not able to be clean up environment", newVersion)
 
-		if res := kubectl.Delete(helpers.DNSDeployment()); !res.WasSuccessful() {
+		if res := kubectl.Delete(helpers.DNSDeployment(kubectl.BasePath())); !res.WasSuccessful() {
 			log.Warningf("Unable to delete CoreDNS deployment: %s", res.OutputPrettyPrint())
 		}
 
@@ -148,7 +154,7 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldVersion, newV
 
 		// Delete kube-dns because if not will be a restore the old
 		// endpoints from master instead of create the new ones.
-		if res := kubectl.Delete(helpers.DNSDeployment()); !res.WasSuccessful() {
+		if res := kubectl.Delete(helpers.DNSDeployment(kubectl.BasePath())); !res.WasSuccessful() {
 			log.Warningf("Unable to delete CoreDNS deployment: %s", res.OutputPrettyPrint())
 		}
 
@@ -180,7 +186,7 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldVersion, newV
 		Expect(err).To(BeNil(), "Cilium %q was not able to be deployed", oldVersion)
 
 		By("Installing kube-dns")
-		_ = kubectl.Apply(helpers.DNSDeployment())
+		_ = kubectl.Apply(helpers.DNSDeployment(kubectl.BasePath()))
 
 		// Cilium is only ready if kvstore is ready, the kvstore is ready if
 		// kube-dns is running.
@@ -318,9 +324,9 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldVersion, newV
 		}
 
 		By("Install Cilium pre-flight check DaemonSet")
-
+		helmTemplate := filepath.Join(kubectl.BasePath(), helpers.HelmTemplate)
 		res = kubectl.ExecMiddle("helm template " +
-			helpers.HelmTemplate + " " +
+			helmTemplate + " " +
 			"--namespace=kube-system " +
 			"--set preflight.enabled=true " +
 			"--set agent.enabled=false " +

--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -123,12 +123,12 @@ func DeployCiliumOptionsAndDNS(vm *helpers.Kubectl, options []string) {
 	ExpectCiliumRunning(vm)
 
 	By("Installing DNS Deployment")
-	_ = vm.Apply(helpers.DNSDeployment())
+	_ = vm.Apply(helpers.DNSDeployment(vm.BasePath()))
 
 	switch helpers.GetCurrentIntegration() {
 	case helpers.CIIntegrationFlannel:
 		By("Installing Flannel")
-		vm.Apply(helpers.GetFilePath("../examples/kubernetes/addons/flannel/flannel.yaml"))
+		vm.Apply(vm.GetFilePath("../examples/kubernetes/addons/flannel/flannel.yaml"))
 	default:
 	}
 

--- a/test/k8sT/fqdn.go
+++ b/test/k8sT/fqdn.go
@@ -32,8 +32,8 @@ var _ = Describe("K8sFQDNTest", func() {
 		backgroundCancel context.CancelFunc = func() { return }
 		backgroundError  error
 
-		bindManifest = helpers.ManifestGet("bind_deployment.yaml")
-		demoManifest = helpers.ManifestGet("demo.yaml")
+		bindManifest = ""
+		demoManifest = ""
 
 		apps    = []string{helpers.App2, helpers.App3}
 		appPods map[string]string
@@ -46,10 +46,12 @@ var _ = Describe("K8sFQDNTest", func() {
 
 	BeforeAll(func() {
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
+		bindManifest = helpers.ManifestGet(kubectl.BasePath(), "bind_deployment.yaml")
+		demoManifest = helpers.ManifestGet(kubectl.BasePath(), "demo.yaml")
 		DeployCiliumAndDNS(kubectl)
 
 		By("Applying bind deployment")
-		bindManifest = helpers.ManifestGet("bind_deployment.yaml")
+		bindManifest = helpers.ManifestGet(kubectl.BasePath(), "bind_deployment.yaml")
 
 		res := kubectl.Apply(bindManifest)
 		res.ExpectSuccess("Bind config cannot be deployed")
@@ -143,7 +145,7 @@ var _ = Describe("K8sFQDNTest", func() {
 			res.ExpectFail("%q can  connect when it should not work", helpers.App2)
 		}
 
-		fqndProxyPolicy := helpers.ManifestGet("fqdn-proxy-policy.yaml")
+		fqndProxyPolicy := helpers.ManifestGet(kubectl.BasePath(), "fqdn-proxy-policy.yaml")
 
 		_, err := kubectl.CiliumPolicyAction(
 			helpers.DefaultNamespace, fqndProxyPolicy,
@@ -208,7 +210,7 @@ var _ = Describe("K8sFQDNTest", func() {
 	It("Validate that multiple specs are working correctly", func() {
 		// To make sure that UUID in multiple specs are plumbed correctly to
 		// Cilium Policy
-		fqdnPolicy := helpers.ManifestGet("fqdn-proxy-multiple-specs.yaml")
+		fqdnPolicy := helpers.ManifestGet(kubectl.BasePath(), "fqdn-proxy-multiple-specs.yaml")
 		world1Target := "http://world1.cilium.test"
 		world2Target := "http://world2.cilium.test"
 

--- a/test/k8sT/istio.go
+++ b/test/k8sT/istio.go
@@ -45,12 +45,12 @@ var _ = Describe("K8sIstioTest", func() {
 		// istioCRDYAMLPath is the file generated from istio-init during a
 		// step in Documentation/gettingstarted/istio.rst to setup
 		// Istio 1.2.5. In the GSG the file is directly piped to kubectl.
-		istioCRDYAMLPath = helpers.ManifestGet("istio-crds.yaml")
+		istioCRDYAMLPath = ""
 
 		// istioYAMLPath is the istio-cilium.yaml file generated following the
 		// instructions in Documentation/gettingstarted/istio.rst to setup
 		// Istio 1.2.5. mTLS is enabled.
-		istioYAMLPath = helpers.ManifestGet("istio-cilium.yaml")
+		istioYAMLPath = ""
 
 		// istioServiceNames is the subset of Istio services in the Istio
 		// namespace that are accessed from sidecar proxies.
@@ -85,6 +85,9 @@ var _ = Describe("K8sIstioTest", func() {
 		}
 
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
+
+		istioCRDYAMLPath = helpers.ManifestGet(kubectl.BasePath(), "istio-crds.yaml")
+		istioYAMLPath = helpers.ManifestGet(kubectl.BasePath(), "istio-cilium.yaml")
 		DeployCiliumAndDNS(kubectl)
 
 		By("Creating the istio-system namespace")
@@ -272,9 +275,9 @@ var _ = Describe("K8sIstioTest", func() {
 			// cd test/k8sT/manifests/
 			// istioctl kube-inject -f bookinfo-v1.yaml > bookinfo-v1-istio.yaml
 			// istioctl kube-inject -f bookinfo-v2.yaml > bookinfo-v2-istio.yaml
-			bookinfoV1YAML := helpers.ManifestGet("bookinfo-v1-istio.yaml")
-			bookinfoV2YAML := helpers.ManifestGet("bookinfo-v2-istio.yaml")
-			l7PolicyPath := helpers.ManifestGet("cnp-specs.yaml")
+			bookinfoV1YAML := helpers.ManifestGet(kubectl.BasePath(), "bookinfo-v1-istio.yaml")
+			bookinfoV2YAML := helpers.ManifestGet(kubectl.BasePath(), "bookinfo-v2-istio.yaml")
+			l7PolicyPath := helpers.ManifestGet(kubectl.BasePath(), "cnp-specs.yaml")
 
 			waitIstioReady()
 

--- a/test/k8sT/manifests/log-gatherer.yaml
+++ b/test/k8sT/manifests/log-gatherer.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: log-gatherer
+  namespace: kube-system
+  labels:
+    k8s-app: cilium-test-logs
+spec:
+  selector:
+    matchLabels:
+      k8s-app: cilium-test-logs
+      kubernetes.io/cluster-service: "true"
+  template:
+    metadata:
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+      labels:
+        k8s-app: cilium-test-logs
+        kubernetes.io/cluster-service: "true"
+    spec:
+      containers:
+      - args:
+        - "10000"
+        command:
+        - sleep
+        image: nebril/systemd:latest #TODO: move to cilium org
+        imagePullPolicy: Always
+        name: log-gatherer
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+            - SYS_MODULE
+            - SYS_ADMIN
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/bpf
+          name: bpf-maps
+        - mountPath: /var/log/hostjournal
+          name: journald
+      dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true
+      hostPID: false
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      serviceAccount: cilium
+      serviceAccountName: cilium
+      terminationGracePeriodSeconds: 1
+      tolerations:
+      - operator: Exists
+      volumes:
+      - hostPath:
+          path: /sys/fs/bpf
+          type: DirectoryOrCreate
+        name: bpf-maps
+      - hostPath:
+          path: /var/log/journal
+          type: DirectoryOrCreate
+        name: journald

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -100,6 +100,7 @@ kubernetesVersion: "v{{ .K8S_FULL_VERSION }}"
 token: "{{ .TOKEN }}"
 networking:
   podSubnet: "{{ .KUBEADM_POD_NETWORK }}/{{ .KUBEADM_POD_CIDR}}"
+controlPlaneEndpoint: "k8s1:6443"
 EOF
 )
 
@@ -122,6 +123,7 @@ networking:
   serviceSubnet: "{{ .KUBEADM_SVC_CIDR }}"
 nodeRegistration:
   criSocket: "{{ .KUBEADM_CRI_SOCKET }}"
+controlPlaneEndpoint: "k8s1:6443"
 EOF
 )
 
@@ -149,6 +151,7 @@ networking:
   dnsDomain: cluster.local
   podSubnet: "{{ .KUBEADM_POD_NETWORK }}/{{ .KUBEADM_POD_CIDR}}"
   serviceSubnet: "{{ .KUBEADM_SVC_CIDR }}"
+controlPlaneEndpoint: "k8s1:6443"
 EOF
 )
 
@@ -271,6 +274,7 @@ if [[ "${HOST}" == "k8s1" ]]; then
       sudo kubeadm init  --config /tmp/config.yaml $KUBEADM_OPTIONS
 
       mkdir -p /root/.kube
+      sudo sed -i "s/${KUBEADM_ADDR}/k8s1/" /etc/kubernetes/admin.conf
       sudo cp -i /etc/kubernetes/admin.conf /root/.kube/config
       sudo chown root:root /root/.kube/config
 
@@ -292,6 +296,7 @@ if [[ "${HOST}" == "k8s1" ]]; then
     $PROVISIONSRC/compile.sh
 else
     if [[ "${SKIP_K8S_PROVISION}" == "false" ]]; then
+      sudo -E bash -c 'echo "${KUBEADM_ADDR} k8s1" >> /etc/hosts'
       kubeadm join --token=$TOKEN ${KUBEADM_ADDR}:6443 \
           ${KUBEADM_SLAVE_OPTIONS}
     else

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -1610,7 +1610,7 @@ var _ = Describe("RuntimePolicyImportTests", func() {
 			err := helpers.RenderTemplateToFile(invalidJSON, data, 0777)
 			Expect(err).Should(BeNil())
 
-			path := helpers.GetFilePath(invalidJSON)
+			path := vm.GetFilePath(invalidJSON)
 			_, err = vm.PolicyImportAndWait(path, helpers.HelperTimeout)
 			Expect(err).Should(HaveOccurred())
 			defer os.Remove(invalidJSON)
@@ -1643,7 +1643,7 @@ var _ = Describe("RuntimePolicyImportTests", func() {
 			err := helpers.RenderTemplateToFile(policyJSON, policy, 0777)
 			Expect(err).Should(BeNil())
 
-			path := helpers.GetFilePath(policyJSON)
+			path := vm.GetFilePath(policyJSON)
 			_, err = vm.PolicyImportAndWait(path, helpers.HelperTimeout)
 			Expect(err).Should(BeNil())
 		})

--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -279,7 +279,7 @@ var runtimeConnectivityTest = func(datapathMode string) func() {
 				Expect(err).To(BeNil())
 
 				cmd := vm.ExecWithSudo(fmt.Sprintf("mv %s %s",
-					helpers.GetFilePath(filename),
+					vm.GetFilePath(filename),
 					filepath.Join(netDPath, filename)))
 				cmd.ExpectSuccess("cannot install cilium cni plugin conf")
 				script := fmt.Sprintf(`
@@ -305,7 +305,7 @@ var runtimeConnectivityTest = func(datapathMode string) func() {
 				}]`
 				err = helpers.RenderTemplateToFile(policyFileName, policy, os.ModePerm)
 				Expect(err).Should(BeNil())
-				_, err = vm.PolicyImportAndWait(helpers.GetFilePath(policyFileName), helpers.HelperTimeout)
+				_, err = vm.PolicyImportAndWait(vm.GetFilePath(policyFileName), helpers.HelperTimeout)
 				Expect(err).Should(BeNil(), fmt.Sprintf("Cannot import policy %s", policyFileName))
 
 				By("Adding containers")

--- a/test/runtime/examples.go
+++ b/test/runtime/examples.go
@@ -89,7 +89,7 @@ var _ = Describe("RuntimePolicyValidationTests", func() {
 		jsonFiles, err := getFilesWithExtensionFromDir(examplePathHost, "json")
 		Expect(err).Should(BeNil(), "Unable to get files at path %s: %s", examplePathHost, err)
 
-		examplePathVM := filepath.Join(helpers.BasePath, "..", examplesDemoPath)
+		examplePathVM := filepath.Join(vm.BasePath(), "..", examplesDemoPath)
 		for _, file := range jsonFiles {
 			jsonPolicyPath := filepath.Join(examplePathVM, file)
 			vm.ExecCilium(fmt.Sprintf("policy validate %s", jsonPolicyPath)).ExpectSuccess("Unable to validate policy %s", jsonPolicyPath)
@@ -101,7 +101,7 @@ var _ = Describe("RuntimePolicyValidationTests", func() {
 		jsonFiles, err = getFilesWithExtensionFromDir(jsonExamplesPathHost, "json")
 		Expect(err).Should(BeNil(), "Unable to get files at path %s: %s", jsonExamplesPathHost, err)
 
-		jsonExamplesPathVM := filepath.Join(helpers.BasePath, "..", examplesPoliciesPath)
+		jsonExamplesPathVM := filepath.Join(vm.BasePath(), "..", examplesPoliciesPath)
 		for _, file := range jsonFiles {
 			jsonPolicyPath := filepath.Join(jsonExamplesPathVM, file)
 			vm.ExecCilium(fmt.Sprintf("policy validate %s", jsonPolicyPath)).ExpectSuccess("Unable to validate policy %s", jsonPolicyPath)
@@ -113,10 +113,10 @@ var _ = Describe("RuntimePolicyValidationTests", func() {
 		jsonFiles, err = getFilesWithExtensionFromDir(yamlExamplesPathHost, "yaml")
 		Expect(err).Should(BeNil(), "Unable to get files at path %s: %s", yamlExamplesPathHost, err)
 
-		yamlExamplesPathVM := filepath.Join(helpers.BasePath, "..", examplesPoliciesPath)
+		yamlExamplesPathVM := filepath.Join(vm.BasePath(), "..", examplesPoliciesPath)
 		for _, file := range jsonFiles {
 			yamlPolicyPath := filepath.Join(yamlExamplesPathVM, file)
-			res := vm.Exec(fmt.Sprintf("yamllint -c %s %s", filepath.Join(helpers.BasePath, "yaml.config"), yamlPolicyPath))
+			res := vm.Exec(fmt.Sprintf("yamllint -c %s %s", filepath.Join(vm.BasePath(), "yaml.config"), yamlPolicyPath))
 			res.ExpectSuccess("Unable to validate YAML %s", yamlPolicyPath)
 		}
 	})

--- a/test/runtime/fqdn.go
+++ b/test/runtime/fqdn.go
@@ -215,7 +215,7 @@ var _ = Describe("RuntimeFQDNPolicies", func() {
 		vm.ExecWithSudo("mkdir -m777 -p /data")
 		for _, file := range generatedFiles {
 			vm.Exec(fmt.Sprintf("mv %s /data/%s",
-				filepath.Join(helpers.BasePath, file), file)).ExpectSuccess(
+				filepath.Join(vm.BasePath(), file), file)).ExpectSuccess(
 				"Cannot copy %q to bind container", file)
 		}
 

--- a/test/runtime/lb.go
+++ b/test/runtime/lb.go
@@ -513,7 +513,7 @@ tc filter add dev lbtest2 ingress bpf da obj tmp_lb.o sec from-netdev
 	}
 
 	// filesystem is mounted at path /vagrant on VM
-	scriptPath := fmt.Sprintf("%s/%s", helpers.BasePath, scriptName)
+	scriptPath := node.GetFilePath(scriptName)
 
 	ipAddrCmd := "sudo ip addr add fd02:1:1:1:1:1:1:1 dev cilium_host"
 	res := node.Exec(ipAddrCmd)

--- a/test/runtime/privileged_tests.go
+++ b/test/runtime/privileged_tests.go
@@ -16,6 +16,7 @@ package RuntimeTest
 
 import (
 	"fmt"
+	"path/filepath"
 
 	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
@@ -41,7 +42,8 @@ var _ = Describe("RuntimePrivilegedUnitTests", func() {
 	})
 
 	It("Run Tests", func() {
-		res := vm.ExecWithSudo(fmt.Sprintf("make -C %s tests-privileged", helpers.CiliumBasePath))
+		path, _ := filepath.Split(vm.BasePath())
+		res := vm.ExecWithSudo(fmt.Sprintf("make -C %s tests-privileged", path))
 		res.ExpectSuccess("Failed to run privileged unit tests")
 	})
 })

--- a/test/runtime/verifier.go
+++ b/test/runtime/verifier.go
@@ -41,7 +41,7 @@ var _ = Describe("RuntimeVerifier", func() {
 		ExpectCiliumNotRunning(vm)
 		res = vm.ExecWithSudo("rm -f /sys/fs/bpf/tc/globals/cilium*")
 		res.ExpectSuccess()
-		cmd := fmt.Sprintf("make -C %s/../bpf clean V=0", helpers.BasePath)
+		cmd := fmt.Sprintf("make -C %s/../bpf clean V=0", vm.BasePath())
 		res = vm.Exec(cmd)
 		res.ExpectSuccess("Expected cleaning the bpf/ tree to succeed")
 	})
@@ -69,12 +69,12 @@ var _ = Describe("RuntimeVerifier", func() {
 
 	It("runs the kernel verifier against the tree copy of the BPF datapath", func() {
 		By("Building BPF objects from the tree")
-		cmd := fmt.Sprintf("make -C %s/../bpf V=0", helpers.BasePath)
+		cmd := fmt.Sprintf("make -C %s/../bpf V=0", vm.BasePath())
 		res := vm.Exec(cmd)
 		res.ExpectSuccess("Expected compilation of the BPF objects to succeed")
 
 		By("Running the verifier test script")
-		cmd = fmt.Sprintf("%s/%s", helpers.BasePath, script)
+		cmd = vm.GetFilePath(script)
 		res = vm.ExecWithSudo(cmd)
 		res.ExpectSuccess("Expected the kernel verifier to pass for BPF programs")
 	})

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -266,7 +266,7 @@ var _ = BeforeAll(func() {
 		}
 		kubectl := helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 
-		kubectl.Apply(helpers.GetFilePath("../examples/kubernetes/addons/prometheus/prometheus.yaml"))
+		kubectl.Apply(kubectl.GetFilePath("../examples/kubernetes/addons/prometheus/prometheus.yaml"))
 
 		go kubectl.PprofReport()
 	}

--- a/test/vagrant-ci-start.sh
+++ b/test/vagrant-ci-start.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+echo "destroying vms in case this is a retry"
+vagrant destroy k8s1-${K8S_VERSION} k8s2-${K8S_VERSION} --force
+
+echo "starting vms"
+vagrant up k8s1-${K8S_VERSION} k8s2-${K8S_VERSION} --provision
+
+echo "getting vagrant kubeconfig from provisioned vagrant cluster"
+./get-vagrant-kubeconfig.sh > vagrant-kubeconfig
+
+echo "checking whether kubeconfig works for vagrant cluster"
+kubectl get nodes


### PR DESCRIPTION
Executor interface is implemented by both LocalExecutor and
SSHMeta

This PR should not change the way tests are run on CI, but introduces code which will allow to switch to local kubectl execution as soon as we allow access to vagrant k8s cluster from host and are able to gather logs from all nodes via kubectl instead of ssh commands.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8683)
<!-- Reviewable:end -->
