### PR TITLE
docs: Remove confusing mentioning of etcd server in ConfigMap

### DIFF
--- a/Documentation/gettingstarted/host-services.rst
+++ b/Documentation/gettingstarted/host-services.rst
@@ -64,11 +64,10 @@ First step is to download the Cilium Kubernetes descriptor:
 
       curl -LO \ |SCM_WEB|\/examples/kubernetes/1.10/cilium.yaml
 
-Edit the ``cilium-config`` ConfigMap in that file with the etcd server
-that is running in your cluster and set the option ``enable-host-reachable-services``
-to ``"true"``. This is all which is required to expose services to the
-host namespace. A Linux kernel of v4.19.57, v5.1.16, v5.2.0 or more
-recent is needed for exposing both TCP and UDP-based services.
+Edit the ``cilium-config`` ConfigMap in that file and set the option
+``enable-host-reachable-services`` to ``"true"``. This is all which is required
+to expose services to the host namespace. A Linux kernel of v4.19.57, v5.1.16,
+v5.2.0 or more recent is needed for exposing both TCP and UDP-based services.
 
 The basic minimum required for host-reachable services is a Linux kernel
 v4.17.0. This allows to only enable TCP-based services to the host, but

--- a/Documentation/gettingstarted/ipvlan.rst
+++ b/Documentation/gettingstarted/ipvlan.rst
@@ -72,9 +72,8 @@ First step is to download the Cilium Kubernetes descriptor:
 
       curl -LO \ |SCM_WEB|\/examples/kubernetes/1.10/cilium.yaml
 
-Edit the ``cilium-config`` ConfigMap in that file with the etcd server
-that is running in your cluster and set the option ``datapath-mode`` to
-``"ipvlan"``.
+Edit the ``cilium-config`` ConfigMap in that file and set the option
+``datapath-mode`` to ``"ipvlan"``.
 
 It is also required to specify the ipvlan master device which typically
 points to a networking device that is facing the external network. This


### PR DESCRIPTION
Probably a copy-paste leftover from the past.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8684)
<!-- Reviewable:end -->
