### PR TITLE
endpoint: fix deadlock when endpoint EventQueue is full

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1319,7 +1319,9 @@ type DeleteConfig struct {
 func (e *Endpoint) LeaveLocked(proxyWaitGroup *completion.WaitGroup, conf DeleteConfig) []error {
 	errors := []error{}
 
-	loader.Unload(e.createEpInfoCache(""))
+	if !option.Config.DryMode {
+		loader.Unload(e.createEpInfoCache(""))
+	}
 
 	e.owner.RemoveFromEndpointQueue(uint64(e.ID))
 	if e.SecurityIdentity != nil && len(e.realizedRedirects) > 0 {


### PR DESCRIPTION
This commit fixes a problem that affects a deadlock during Endpoint deletion:

An event is being processed by the endpoint's EventQueue, but has not yet
acquired the Endpoint's mutex. The endpoint's EventQueue is full
(e.g., it has reached its full capacity),  and there are calls to `Enqueue` for
the Endpoint which are blocking on returning due to the queue being full. The
endpoint is being deleted in `deleteEndpointQuiet`, and has acquired
the Endpoint's mutex. The event being processed by the endpoint's EventQueue
tries to acquire the Endpoint's mutex. It cannot, because `deleteEndpointQuiet`
just acquired the Endpoint's mutex. The EventQueue's buffer is still full; the
event currently being processed cannot be consumed due to the deadlock, so as a
result, calls to Enqueue are still blocking forever. `deleteEndpointQuiet` calls
`Stop` on the EventQueue. This never returns, because calls to Enqueue are still
in flight, and EventQueues have a safeguard built in via a `sync.WaitGroup`
which guards against writing to closed channels during `Enqueue`; that is, the
EventQueue cannot be closed while Enqueues are still in progress. Enqueues in
this case, are still in progress, because the channel is full. But, the channel
will never drain due to `deleteEndpointQuiet` holding the lock.
`deleteEndpointQuiet` will never release the lock, because it is waiting for the
queue to be drained.

The fix for the above is to stop the Endpoint's EventQueue before we acquire the
Endpoint's mutex, and ensure that the queue is drained (e.g., no events are
queued up for it) after we stop the queue as well. This ensures that if multiple
calls to `deleteEndpointQuiet` occur for the same Endpoint, they all wait before
acquiring the Endpoint's mutex.

Add a unit test in the daemon to test this fix as well.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8687)
<!-- Reviewable:end -->
