### PR TITLE
[bugfix] - mtu for interfaces in host-network

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -914,23 +914,21 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 }
 
 func setupIPSec() (int, error) {
-	var authKeySize int
-
-	if option.Config.EnableIPSec {
-		var spi uint8
-		var err error
-
-		authKeySize, spi, err = ipsec.LoadIPSecKeysFile(option.Config.IPSecKeyFile)
-		if err != nil {
-			return authKeySize, err
-		}
-		if option.Config.EnableIPv6 {
-			if err := ipsec.EnableIPv6Forwarding(); err != nil {
-				return authKeySize, err
-			}
-		}
-		node.SetIPsecKeyIdentity(spi)
+	if !option.Config.EnableIPSec {
+		return 0, nil
 	}
+
+	authKeySize, spi, err := ipsec.LoadIPSecKeysFile(option.Config.IPSecKeyFile)
+	if err != nil {
+		return 0, err
+	}
+	if option.Config.EnableIPv6 {
+		if err := ipsec.EnableIPv6Forwarding(); err != nil {
+			return 0, err
+		}
+	}
+	node.SetIPsecKeyIdentity(spi)
+
 	return authKeySize, nil
 }
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -920,7 +920,7 @@ func setupIPSec() (int, error) {
 		var spi uint8
 		var err error
 
-		authKeySize, spi, err := ipsec.LoadIPSecKeysFile(option.Config.IPSecKeyFile)
+		authKeySize, spi, err = ipsec.LoadIPSecKeysFile(option.Config.IPSecKeyFile)
 		if err != nil {
 			return authKeySize, err
 		}

--- a/daemon/datapath.go
+++ b/daemon/datapath.go
@@ -94,7 +94,7 @@ func (d *Daemon) compileBase() error {
 		args[initArgIPv6NodeIP] = "<nil>"
 	}
 
-	args[initArgMTU] = fmt.Sprintf("%d", d.mtuConfig.GetDeviceMTU())
+	args[initArgMTU] = fmt.Sprintf("%d", d.mtuConfig.GetRouteMTU())
 
 	if option.Config.EnableIPSec {
 		args[initArgIPSec] = "true"


### PR DESCRIPTION
We've had some issue with hostNetwork pods not being able to reach other pods.
The investigation lead us to a MTU issue (because for once it wasn't DNS)

This PR change the MTU set by the `init.sh` script.
Instead of using `getDeviceMTU` which provide the mtu of the host interface.
We're using the `getRouteMTU` which provide the mtu minus the bytes used by the various protocols.

While doing that we noticed that the MTU generated by [mtu.NewConfiguration](https://github.com/cilium/cilium/blob/2bc1fdeb97331761241f2e4b3fb88ad524a0681b/pkg/mtu/mtu.go#L106) was not the correct one. We were expecting `8924` and got `8940`
Which lead us to the patch in daemon.go

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8688)
<!-- Reviewable:end -->
