### PR TITLE
identity: Reduce churn, fix manager refcounts

### DIFF
--- a/daemon/policy_test.go
+++ b/daemon/policy_test.go
@@ -140,7 +140,7 @@ func (ds *DaemonSuite) prepareEndpoint(c *C, identity *identity.Identity, qa boo
 		e.LXCMAC = ProdHardAddr
 		e.SetNodeMACLocked(ProdHardAddr)
 	}
-	e.SetIdentity(identity)
+	e.SetIdentity(identity, true)
 
 	e.UnconditionalLock()
 	ready := e.SetStateLocked(endpoint.StateWaitingToRegenerate, "test")

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -353,7 +353,7 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) (resto
 			// The identity of a freshly restored endpoint is incomplete due to some
 			// parts of the identity not being marshaled to JSON. Hence we must set
 			// the identity even if has not changed.
-			ep.SetIdentity(identity)
+			ep.SetIdentity(identity, true)
 			ep.Unlock()
 
 			regenerationMetadata := &regeneration.ExternalRegenerationMetadata{

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1053,6 +1053,8 @@ func FilterEPDir(dirFiles []os.FileInfo) []string {
 
 // ParseEndpoint parses the given strEp which is in the form of:
 // common.CiliumCHeaderPrefix + common.Version + ":" + endpointBase64
+// Note that the parse'd endpoint's identity is only partially restored. The
+// caller must call `SetIdentity()` to make the returned endpoint's identity useful.
 func ParseEndpoint(owner regeneration.Owner, strEp string) (*Endpoint, error) {
 	// TODO: Provide a better mechanism to update from old version once we bump
 	// TODO: cilium version.
@@ -1086,11 +1088,12 @@ func ParseEndpoint(owner regeneration.Owner, strEp string) (*Endpoint, error) {
 		ep.Status = NewEndpointStatus()
 	}
 
+	// Make sure the endpoint has an identity, using the 'init' identity if none.
 	if ep.SecurityIdentity == nil {
-		ep.SetIdentity(identityPkg.LookupReservedIdentity(identityPkg.ReservedIdentityInit))
-	} else {
-		ep.SecurityIdentity.Sanitize()
+		ep.SecurityIdentity = identityPkg.LookupReservedIdentity(identityPkg.ReservedIdentityInit)
 	}
+	ep.SecurityIdentity.Sanitize()
+
 	ep.UpdateLogger(nil)
 
 	ep.SetStateLocked(StateRestoring, "Endpoint restoring")
@@ -2051,7 +2054,7 @@ func (e *Endpoint) identityLabelsChanged(ctx context.Context, myChangeRev int) e
 	elog.WithFields(logrus.Fields{logfields.Identity: identity.StringID()}).
 		Debug("Assigned new identity to endpoint")
 
-	e.SetIdentity(identity)
+	e.SetIdentity(identity, false)
 
 	if oldIdentity != nil {
 		_, err := cache.Release(releaseCtx, e.owner, oldIdentity)

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -579,7 +579,7 @@ func (e *Endpoint) runIPIdentitySync(endpointIP addressing.CiliumIP) {
 // SetIdentity resets endpoint's policy identity to 'id'.
 // Caller triggers policy regeneration if needed.
 // Called with e.Mutex Locked
-func (e *Endpoint) SetIdentity(identity *identityPkg.Identity) {
+func (e *Endpoint) SetIdentity(identity *identityPkg.Identity, newEndpoint bool) {
 
 	// Set a boolean flag to indicate whether the endpoint has been injected by
 	// Istio with a Cilium-compatible sidecar proxy.
@@ -596,7 +596,11 @@ func (e *Endpoint) SetIdentity(identity *identityPkg.Identity) {
 	// Current security identity for endpoint is its old identity - delete its
 	// reference from global identity manager, add add a reference to the new
 	// identity for the endpoint.
-	identitymanager.RemoveOldAddNew(e.SecurityIdentity, identity)
+	if newEndpoint {
+		identitymanager.Add(identity)
+	} else {
+		identitymanager.RemoveOldAddNew(e.SecurityIdentity, identity)
+	}
 	e.SecurityIdentity = identity
 	e.replaceIdentityLabels(identity.Labels)
 

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -61,7 +61,7 @@ func newTestEP() *testEP {
 }
 
 func (ep *testEP) WithIdentity(id int64) *testEP {
-	ep.SetIdentity(id)
+	ep.SetIdentity(id, true)
 	return ep
 }
 

--- a/pkg/testutils/endpoint.go
+++ b/pkg/testutils/endpoint.go
@@ -80,7 +80,7 @@ func (e *TestEndpoint) Logger(subsystem string) *logrus.Entry {
 	return log
 }
 
-func (e *TestEndpoint) SetIdentity(secID int64) {
+func (e *TestEndpoint) SetIdentity(secID int64, newEndpoint bool) {
 	e.Identity = identity.NewIdentityFromModel(&identityMdl.Identity{
 		ID:     secID,
 		Labels: []string{"bar"},


### PR DESCRIPTION
Use identitymanager.Add instead of identitymanager.RemoveOldAddNew
when initially adding the identity of a new endpoint into the identity
manager. This fixes a refcounting bug, where upon the restoration of
two endpoints with the same labels the first restoration adds the
identity to the manager with refcount 1, but the second restoration
first deletes the lone refcount, triggering removal of the associated
policy from the policy cache, and then adds the same ID back, with the
resulting refcount of 1, even when two endpoints are using the same
ID.

Require the old identity given to RemoveOldAddNew to have been added
to the identity manager previously, and make the case where
RemoveOldAddNew is called with two identities with the same numerical
ID a no-op to reduce churn in the observers.

Fixes: #8685
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8691)
<!-- Reviewable:end -->
