### PR TITLE
v1.5 backports 2019-07-25

### DIFF
--- a/Documentation/gettingstarted/microk8s.rst
+++ b/Documentation/gettingstarted/microk8s.rst
@@ -33,8 +33,8 @@ Install microk8s
 
       echo "--allow-privileged" >> /var/snap/microk8s/current/args/kube-apiserver
       sed -i 's/--network-plugin=kubenet/--network-plugin=cni/g'  /var/snap/microk8s/current/args/kubelet
-      sed -i 's/--cni-bin-dir=${SNAP}\/opt/--cni-bin-dir=\/opt/g'  /var/snap/microk8s/current/args/kubelet
-      sed -i 's/bin_dir = "${SNAP}\/opt/bin_dir = "\/opt/g'  /var/snap/microk8s/current/args/containerd-template.toml
+      sed -i 's;--cni-bin-dir=${SNAP}/opt;--cni-bin-dir=/opt;g'  /var/snap/microk8s/current/args/kubelet
+      sed -i 's;bin_dir = "${SNAP}/opt;bin_dir = "/opt;g'  /var/snap/microk8s/current/args/containerd-template.toml
       rm /var/snap/microk8s/current/args/cni-network/cni.conf
       curl \ |SCM_WEB|\/plugins/cilium-cni/05-cilium-cni.conf > /var/snap/microk8s/current/args/cni-network/05-cilium.conf
       systemctl restart snap.microk8s.daemon-containerd.service

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -120,10 +120,6 @@ var (
 	bootstrapStats = bootstrapStatistics{}
 )
 
-func init() {
-	logging.DefaultLogger.Hooks.Add(metrics.NewLoggingHook(components.CiliumAgentName))
-}
-
 func daemonMain() {
 	bootstrapStats.overall.Start()
 
@@ -812,6 +808,9 @@ func initConfig() {
 func initEnv(cmd *cobra.Command) {
 	// Prepopulate option.Config with options from CLI.
 	option.Config.Populate()
+
+	// add hooks after setting up metrics in the option.Confog
+	logging.DefaultLogger.Hooks.Add(metrics.NewLoggingHook(components.CiliumAgentName))
 
 	// Logging should always be bootstrapped first. Do not add any code above this!
 	logging.SetupLogging(option.Config.LogDriver, option.Config.LogOpt, "cilium-agent", option.Config.Debug)


### PR DESCRIPTION
 * #8647 -- Fix seds in microk8s docs (@nebril)
 * #8644 -- daemon: register warning_error metric after parsing CLI options (@aanm)

Once this PR is merged, you can update the PR labels via:
```
$ for pr in 8647 8644; do contrib/backporting/set-labels.py $pr done 1.5; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8696)
<!-- Reviewable:end -->