### PR TITLE
contrib: Improve rebase-bindata function

### DIFF
--- a/contrib/scripts/fix-sha.sh
+++ b/contrib/scripts/fix-sha.sh
@@ -10,3 +10,4 @@ fi
 echo "GO_BINDATA_SHA1SUM=01234567890abcdef78901234567890abcdef789" > "$SHA_PATH"
 echo "BPF_FILES=../bpf/.gitignore" >> "$SHA_PATH"
 ${MAKE} -C daemon apply-bindata
+${MAKE} -C daemon apply-bindata

--- a/contrib/shell/util.sh
+++ b/contrib/shell/util.sh
@@ -94,6 +94,9 @@ function rebase-bindata
 {
     (
         local dir
+        if ! git rebase --show-current-patch ; then
+            return
+        fi
         set -x
         while ! git rebase --continue ; do
             dir=$(cd $(dirname ${BASH_SOURCE})/../.. && pwd)


### PR DESCRIPTION
The function previously had two bad behaviours:
* If run when not rebasing, it would go into an infinite loop,
  attempting to rebase even though there is no rebase ongoing
* The fix-sha script would rewrite the paths to hash, which resulted in
  the hash always being wrong the first time you write the bindata. Fix
  it by just running the build twice - first to populate the right bpf
  paths, second to populate the right hash.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8702)
<!-- Reviewable:end -->
