### PR TITLE
daemon: Remove old proxymaps on startup, use proxy with legacy fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:0bf044dd5e8c0b7dacc8e1e49d5e18330000bfc6 as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:2e42144f26667ddee9f5d2506019f16c57386b29 as cilium-envoy
 
 #
 # Cilium incremental build. Should be fast given builder-deps is up-to-date!

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -385,6 +385,17 @@ func (d *Daemon) initMaps() error {
 		return nil
 	}
 
+	// Delete old proxymaps if left over from an upgrade.
+	// TODO: Remove this code when Cilium 1.6 is the oldest supported release
+	for _, name := range []string{"cilium_proxy4", "cilium_proxy6"} {
+		path := bpf.MapPath(name)
+		if _, err := os.Stat(path); err == nil {
+			if err = os.RemoveAll(path); err == nil {
+				log.Infof("removed legacy proxymap file %s", path)
+			}
+		}
+	}
+
 	if err := bpf.ConfigureResourceLimits(); err != nil {
 		log.WithError(err).Fatal("Unable to set memory resource limits")
 	}


### PR DESCRIPTION
Old proxymaps confuse cilium-envoy, which is compatible also with
earlier Cilium releases. Delete the old proxymaps on startup so that
cilium-envoy can operate normally with the current Cilium TPROXY use.

Use cilium-envoy with a fix for regression that broke support for
Cilium versions without TPROXY support (< 1.6).

Fixes: #6921
Fixes: #8721
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8703)
<!-- Reviewable:end -->
