### PR TITLE
cilium: encryption, use default route interface if encrypt-interface is not specified.

### DIFF
--- a/pkg/datapath/linux/config.go
+++ b/pkg/datapath/linux/config.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/datapath"
+	"github.com/cilium/cilium/pkg/datapath/linux/route"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
 	bpfconfig "github.com/cilium/cilium/pkg/maps/configmap"
@@ -183,8 +184,16 @@ func (l *linuxDatapath) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeConf
 		}
 	}
 
-	if option.Config.EncryptInterface != "" {
-		link, err := netlink.LinkByName(option.Config.EncryptInterface)
+	if option.Config.EnableIPSec {
+		var link netlink.Link
+		var err error
+
+		if option.Config.EncryptInterface != "" {
+			link, err = netlink.LinkByName(option.Config.EncryptInterface)
+		} else {
+			link, err = route.NodeDeviceWithDefaultRoute()
+		}
+
 		if err == nil {
 			cDefinesMap["ENCRYPT_IFACE"] = fmt.Sprintf("%d", link.Attrs().Index)
 


### PR DESCRIPTION
This uses the default route to lookup interface to use with encryption if the user does not specify a encrypt-interface when using encryption.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8711)
<!-- Reviewable:end -->
