### PR TITLE
 node: Update ipcache with health IPs

### DIFF
--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -307,6 +307,20 @@ func (m *Manager) NodeUpdated(n node.Node) {
 		}
 	}
 
+	for _, address := range []net.IP{n.IPv4HealthIP, n.IPv6HealthIP} {
+		if address == nil {
+			continue
+		}
+		isIPv6 := address.To4() == nil
+		isOwning := ipcache.IPIdentityCache.Upsert(address.String(), n.GetNodeIP(isIPv6), n.EncryptionKey, ipcache.Identity{
+			ID:     identity.ReservedIdentityHealth,
+			Source: n.Source,
+		})
+		if !isOwning {
+			dpUpdate = false
+		}
+	}
+
 	m.mutex.Lock()
 	entry, oldNodeExists := m.nodes[nodeIdentity]
 	if oldNodeExists {


### PR DESCRIPTION
These can be propagated in multiple ways, but were ignored when the
update came only via a pkg/node/manager.NodeUpdated call. We now update
the ipcache and datapath similarly to other IPs associated with a node.

I'll run tests a few times to confirm that nothing broke. I'm not sure how to test this directly with the current configuration. It manifested when I removed the kvstore entirely in https://github.com/cilium/cilium/pull/8641. I suspect the IPs were being propagated via kvstore in that case. #8641 may be superseded by changes to how we create the various configuration files so it may be closed or shrink to only code changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8715)
<!-- Reviewable:end -->
