### PR TITLE
monitor: Add human-readable reason for NO_FIB_LOOKUP drops

### DIFF
--- a/pkg/monitor/api/drop.go
+++ b/pkg/monitor/api/drop.go
@@ -72,6 +72,7 @@ var errors = map[uint8]string{
 	166: "Unsupported L2 protocol",
 	167: "No mapping for NAT masquerade",
 	168: "Unsupported protocol for NAT masquerade",
+	169: "FIB lookup failed",
 	170: "Encapsulation traffic is prohibited",
 	171: "Invalid identity",
 	172: "Unknown sender",


### PR DESCRIPTION
Previously, in the case of packet drops due to `NO_FIB_LOOKUP`,
`cilium metrics list` would output:

    [...] direction="EGRESS" reason="169"

Replace the `NO_FIB_LOOKUP` code with the human-readable reason.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8717)
<!-- Reviewable:end -->
