### PR TITLE
lbmap: Do not fail to upsert if ARP neigh add fails

### DIFF
--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -154,7 +154,7 @@ func neighAddBackends(backends []ServiceValue) error {
 		}
 		err := neigh.NeighAddAddress(option.Config.Device, b.GetAddress())
 		if err != nil {
-			return err
+			return fmt.Errorf("Neigh add for backend %s failed: %s", b, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
Previously, a LB service upsert would have failed if any ARP neigh add (arping + netlink neigh add) for its backends failed. This prevented the service from being added to the BPF LB maps which made the service unavailable.

The failure has been observed a couple of times during the cilium-agent initialization:

        level=error msg="Error while inserting service in LB map" error=timeout k8sNamespace=default k8sSvcName=kubernetes subsys=daemon

The neigh failure is not critical, therefore instead of failing, just log a warning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8718)
<!-- Reviewable:end -->
