### PR TITLE
CI: Switch WaitforDeamonset/Deploy to shorter poll timeout

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -582,7 +582,7 @@ func (kub *Kubectl) WaitforDeployReady(namespace, name string, timeout time.Dura
 
 	body := func() bool {
 		deploy := apps_v1.Deployment{}
-		cmdRes := kub.Exec(fmt.Sprintf("%s -n %s get deploy %s -o json", KubectlCmd, namespace, name))
+		cmdRes := kub.ExecShort(fmt.Sprintf("%s -n %s get deploy %s -o json", KubectlCmd, namespace, name))
 		if cmdRes == nil {
 			kub.logger.Infof("kubectl.Exec returned nil result while getting Deployment for %s/%s", namespace, name)
 			return false
@@ -613,7 +613,7 @@ func (kub *Kubectl) WaitforDaemonSetReady(namespace, name string, timeout time.D
 
 	body := func() bool {
 		ds := apps_v1.DaemonSet{}
-		cmdRes := kub.Exec(fmt.Sprintf("%s -n %s get daemonset %s -o json", KubectlCmd, namespace, name))
+		cmdRes := kub.ExecShort(fmt.Sprintf("%s -n %s get daemonset %s -o json", KubectlCmd, namespace, name))
 		if cmdRes == nil {
 			kub.logger.Infof("kubectl.Exec returned nil result while getting DaemonSet for %s/%s", namespace, name)
 			return false


### PR DESCRIPTION
Each poll command was given the 4 minute HelperTimeout. This was
excesive since time overall timeouts used could be shorter than this,
resulting in the poll never completing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8720)
<!-- Reviewable:end -->
