### PR TITLE
daemon: Remove old proxymaps on startup

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -385,6 +385,17 @@ func (d *Daemon) initMaps() error {
 		return nil
 	}
 
+	// Delete old proxymaps if left over from an upgrade.
+	// TODO: Remove this code when Cilium 1.6 is the oldest supported release
+	for _, name := range []string{"cilium_proxy4", "cilium_proxy6"} {
+		path := bpf.MapPath(name)
+		if _, err := os.Stat(path); err == nil {
+			if err = os.RemoveAll(path); err == nil {
+				log.Infof("removed legacy proxymap file %s", path)
+			}
+		}
+	}
+
 	if err := bpf.ConfigureResourceLimits(); err != nil {
 		log.WithError(err).Fatal("Unable to set memory resource limits")
 	}


### PR DESCRIPTION
Old proxymaps confuse cilium-envoy, which is compatible also with
earlier Cilium releases. Delete the old proxymaps on startup so that
cilium-envoy can operate normally with the current Cilium TPROXY use.

Fixes: #6921
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8724)
<!-- Reviewable:end -->
