### PR TITLE
pkg/monitor: add endpoint create and delete monitor notifications

### DIFF
--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -319,7 +319,7 @@ func LaunchAsEndpoint(baseCtx context.Context, owner regeneration.Owner, n *node
 		return nil, fmt.Errorf("Error while configuring routes: %s", err)
 	}
 
-	if err := endpointmanager.AddEndpoint(ep, "Create cilium-health endpoint"); err != nil {
+	if err := endpointmanager.AddEndpoint(owner, ep, "Create cilium-health endpoint"); err != nil {
 		return nil, fmt.Errorf("Error while adding endpoint: %s", err)
 	}
 

--- a/pkg/monitor/api/types.go
+++ b/pkg/monitor/api/types.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -117,6 +117,8 @@ const (
 	AgentNotifyEndpointRegenerateFail
 	AgentNotifyPolicyUpdated
 	AgentNotifyPolicyDeleted
+	AgentNotifyEndpointCreated
+	AgentNotifyEndpointDeleted
 )
 
 var notifyTable = map[AgentNotification]string{
@@ -124,6 +126,8 @@ var notifyTable = map[AgentNotification]string{
 	AgentNotifyGeneric:                   "Message",
 	AgentNotifyStart:                     "Cilium agent started",
 	AgentNotifyEndpointRegenerateSuccess: "Endpoint regenerated",
+	AgentNotifyEndpointCreated:           "Endpoint created",
+	AgentNotifyEndpointDeleted:           "Endpoint deleted",
 	AgentNotifyEndpointRegenerateFail:    "Failed endpoint regeneration",
 	AgentNotifyPolicyUpdated:             "Policy updated",
 	AgentNotifyPolicyDeleted:             "Policy deleted",
@@ -199,6 +203,52 @@ func EndpointRegenRepr(e notifications.RegenNotificationInfo, err error) (string
 
 	if err != nil {
 		notification.Error = err.Error()
+	}
+
+	repr, err := json.Marshal(notification)
+
+	return string(repr), err
+}
+
+// EndpointCreateNotification structures the endpoint create notification
+type EndpointCreateNotification struct {
+	EndpointRegenNotification
+	PodName   string `json:"pod-name,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
+}
+
+// EndpointCreateRepr returns string representation of monitor notification
+func EndpointCreateRepr(e notifications.RegenNotificationInfo) (string, error) {
+	notification := EndpointCreateNotification{
+		EndpointRegenNotification: EndpointRegenNotification{
+			ID:     e.GetID(),
+			Labels: e.GetOpLabels(),
+		},
+		PodName:   e.GetK8sPodName(),
+		Namespace: e.GetK8sNamespace(),
+	}
+
+	repr, err := json.Marshal(notification)
+
+	return string(repr), err
+}
+
+// EndpointDeleteNotification structures the an endpoint delete notification
+type EndpointDeleteNotification struct {
+	EndpointRegenNotification
+	PodName   string `json:"pod-name,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
+}
+
+// EndpointDeleteRepr returns string representation of monitor notification
+func EndpointDeleteRepr(e notifications.RegenNotificationInfo) (string, error) {
+	notification := EndpointDeleteNotification{
+		EndpointRegenNotification: EndpointRegenNotification{
+			ID:     e.GetID(),
+			Labels: e.GetOpLabels(),
+		},
+		PodName:   e.GetK8sPodName(),
+		Namespace: e.GetK8sNamespace(),
 	}
 
 	repr, err := json.Marshal(notification)

--- a/pkg/monitor/api/types_test.go
+++ b/pkg/monitor/api/types_test.go
@@ -123,6 +123,14 @@ func (MockEndpoint) GetOpLabels() []string {
 	}.GetModel()
 }
 
+func (MockEndpoint) GetK8sPodName() string {
+	return ""
+}
+
+func (MockEndpoint) GetK8sNamespace() string {
+	return ""
+}
+
 func (s *MonitorAPISuite) TestEndpointRegenRepr(c *C) {
 	e := MockEndpoint{}
 	rerr := RegenError{}

--- a/pkg/monitor/notifications/notifications.go
+++ b/pkg/monitor/notifications/notifications.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,4 +18,6 @@ package notifications
 type RegenNotificationInfo interface {
 	GetID() uint64
 	GetOpLabels() []string
+	GetK8sPodName() string
+	GetK8sNamespace() string
 }


### PR DESCRIPTION
It is useful to get monitor events for when an endpoint is added and /
or deleted from Cilium.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8728)
<!-- Reviewable:end -->
