### PR TITLE
cilium: encryption, delete encrypt node routes

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -939,6 +939,9 @@ func setupIPSec() (int, error) {
 		}
 	}
 	node.SetIPsecKeyIdentity(spi)
+	if option.Config.EncryptNode == false {
+		ipsec.DeleteIPsecEncryptRoute()
+	}
 
 	return authKeySize, nil
 }

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -887,6 +887,7 @@ func (n *linuxNodeHandler) createNodeExternalIPSecOutRoute(ip *net.IPNet, dflt b
 		Device: dev,
 		Prefix: *ip,
 		Table:  tbl,
+		Proto:  route.EncryptRouteProtocol,
 	}
 }
 

--- a/pkg/datapath/linux/route/route_linux.go
+++ b/pkg/datapath/linux/route/route_linux.go
@@ -42,6 +42,9 @@ const (
 
 	// MainTable is Linux's default routing table
 	MainTable = 254
+
+	// EncryptRouteProtocol for Encryption specific routes
+	EncryptRouteProtocol = 192
 )
 
 // getNetlinkRoute returns the route configuration as netlink.Route


### PR DESCRIPTION
The routes installed by --encrypt-node need to be deleted when
the node is removed.

Without this enabling and then disabling encrypt-node will cause a node to longer be able to send to other nodes causing cilium-agent into crash loop backoff eventually.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8731)
<!-- Reviewable:end -->
