### PR TITLE
test: use kvstore-based allocator for upgrade tests

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -245,6 +245,10 @@ const CiliumDefaultPreFlight = "cilium-pre-flight.yaml"
 // CiliumConfigMapPatch is the default Cilium ConfigMap patch to be used in all tests.
 const CiliumConfigMapPatch = "cilium-cm-patch.yaml"
 
+// CiliumConfigMapPatchKvstoreAllocator is equivalent to CiliumConfigMapPatch
+// except it uses the kvstore-based allocator instead of the CRD-based allocator.
+const CiliumConfigMapPatchKvstoreAllocator = "cilium-cm-kvstore-allocator-patch.yaml"
+
 // badLogMessages is a map which key is a part of a log message which indicates
 // a failure if the message does not contain any part from value list.
 var badLogMessages = map[string][]string{

--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -311,7 +311,11 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldVersion, newV
 		By("Removing Cilium pre-flight check DaemonSet")
 		kubectl.Delete(helpers.GetK8sDescriptor(helpers.CiliumDefaultPreFlight))
 
-		cmPatch := helpers.CiliumConfigMapPatch
+		// Need to run using the kvstore-based allocator because upgrading from
+		// kvstore-based allocator to CRD-based allocator is not currently
+		// supported at this time.
+		By("Installing Cilium using kvstore-based allocator")
+		cmPatch := helpers.CiliumConfigMapPatchKvstoreAllocator
 		err = kubectl.CiliumInstall(helpers.CiliumDefaultDSPatch, cmPatch)
 		ExpectWithOffset(1, err).To(BeNil(), "Cilium %q was not able to be deployed", newVersion)
 

--- a/test/k8sT/manifests/cilium-cm-kvstore-allocator-patch.yaml
+++ b/test/k8sT/manifests/cilium-cm-kvstore-allocator-patch.yaml
@@ -1,0 +1,28 @@
+---
+metadata:
+  namespace: kube-system
+data:
+  etcd-config: |-
+    ---
+    endpoints:
+      - https://cilium-etcd-client.kube-system.svc:2379
+    #
+    # In case you want to use TLS in etcd, uncomment the 'ca-file' line
+    # and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
+    ca-file: '/var/lib/etcd-secrets/etcd-client-ca.crt'
+    #
+    # In case you want client to server authentication, uncomment the following
+    # lines and create a kubernetes secret by following the tutorial in
+    # https://cilium.link/etcd-config
+    key-file: '/var/lib/etcd-secrets/etcd-client.key'
+    cert-file: '/var/lib/etcd-secrets/etcd-client.crt'
+
+  # If you want to run cilium in debug mode change this value to true
+  debug: "true"
+
+  enable-ipv4: "true"
+  enable-ipv6: "true"
+  preallocate-bpf-maps: "true"
+  kvstore-lease-ttl: "30s"
+  identity-allocation-mode: "kvstore"


### PR DESCRIPTION
The upgrade test in the CI was sporadically failing when performing the upgrade
from `v1.5` to the latest version of Cilium, with errors like the following:

```
2019-07-29T23:07:13.582080226Z level=warning msg="Key allocation attempt failed" attempt=11 error="unable to reserve local key 'k8s:app=migrate-svc-client;k8s:io.cilium.k8s.policy.cluster=default;k8s:io.cilium.k8s.policy.serviceaccount=default;k8s:io.kubernetes.pod.namespace=default;k8s:zgroup=migrate-svc;': local key already allocated with different value (6696 != 38347)" key="[k8s:app=migrate-svc-client k8s:io.cilium.k8s.policy.cluster=default k8s:io.cilium.k8s.policy.serviceaccount=default k8s:io.kubernetes.pod.namespace=default k8s:zgroup=migrate-svc]" subsys=allocator
2019-07-29T23:07:47.293412631Z level=warning msg="Unable to restore endpoint" endpointID=823 error="exponential backoff cancelled via context: context deadline exceeded" subsys=daemon
```

By default in master, we use the CRD-based identity allocator. The upgrade path
from using the kvstore-based allocator (which is on by default in `v1.5`) to the
CRD-based allocator is not officially supported. So, make sure that in the
upgrade test, we are still using the kvstore-based allocator. The CRD alloaction
mode will still be used in the rest of the CI, as we delete the Cilium DaemonSet
and clear all Cilium state when the upgrade test finishes up.

This is a band-aid over the real problem that we do not support the upgrade path
yet. We should revert this patch once we support changing the allocator backend
when upgrade occurs.

Fixes: #8727

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8734)
<!-- Reviewable:end -->
