### PR TITLE
agent: Fix wait for ipcache synchroniation when kvstore is disabled

### DIFF
--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -333,6 +333,11 @@ func (d *Daemon) initK8sSubsystem() <-chan struct{} {
 			// being restored to have the right identity.
 			k8sAPIGroupPodV1Core,
 		)
+		// CiliumEndpoint is used to synchronize the ipcache, wait for
+		// it unless it is disabled
+		if !option.Config.DisableCiliumEndpointCRD {
+			d.waitForCacheSync(k8sAPIGroupCiliumEndpointV2)
+		}
 		close(cachesSynced)
 	}()
 

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -292,7 +292,9 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) (resto
 					scopedLog.WithError(err).Warn("Failed while waiting for initial global identities")
 					return
 				}
-				ipcache.WaitForInitialSync()
+				if option.Config.KVStore != "" {
+					ipcache.WaitForKVStoreSync()
+				}
 			}
 
 			if err := ep.LockAlive(); err != nil {

--- a/pkg/ipcache/kvstore.go
+++ b/pkg/ipcache/kvstore.go
@@ -343,8 +343,8 @@ func InitIPIdentityWatcher() {
 	})
 }
 
-// WaitForInitialSync waits until the ipcache has been synchronized from the kvstore
-func WaitForInitialSync() {
+// WaitForKVStoreSync waits until the ipcache has been synchronized from the kvstore
+func WaitForKVStoreSync() {
 	<-initialized
 	watcher.waitForInitialSync()
 }


### PR DESCRIPTION
The ipcache sync routine was specific to kvstore connectivity, only wait on it
when the kvstore is enabled and wait on k8s init for CiliumEndpoint
synchronization.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8736)
<!-- Reviewable:end -->
