### PR TITLE
cilium: encryption, fixes for encrypt-node mode

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -118,6 +118,7 @@ ENV["LC_CTYPE"] = "en_US.UTF-8"
 # network namespace, to reach out kube-api-server.
 $kube_proxy_workaround = <<SCRIPT
 sudo iptables -t nat -A POSTROUTING -o enp0s8 ! -s 192.168.34.12 -j MASQUERADE
+sudo iptables -t nat -A POSTROUTING -o cilium_host -s 10.0.2.15 -j SNAT --to 192.168.36.12
 SCRIPT
 
 Vagrant.configure(2) do |config|

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -925,6 +925,10 @@ func NewDaemon(dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 }
 
 func setupIPSec() (int, error) {
+	if option.Config.EncryptNode == false {
+		ipsec.DeleteIPsecEncryptRoute()
+	}
+
 	if !option.Config.EnableIPSec {
 		return 0, nil
 	}
@@ -939,10 +943,6 @@ func setupIPSec() (int, error) {
 		}
 	}
 	node.SetIPsecKeyIdentity(spi)
-	if option.Config.EncryptNode == false {
-		ipsec.DeleteIPsecEncryptRoute()
-	}
-
 	return authKeySize, nil
 }
 

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -880,6 +880,7 @@ func (n *linuxNodeHandler) createNodeIPSecOutRoute(ip *net.IPNet) route.Route {
 func (n *linuxNodeHandler) createNodeExternalIPSecOutRoute(ip *net.IPNet, dflt bool) route.Route {
 	var tbl int
 	var dev string
+	var local net.IP
 
 	if dflt {
 		dev = n.datapathConfig.HostDevice
@@ -888,9 +889,18 @@ func (n *linuxNodeHandler) createNodeExternalIPSecOutRoute(ip *net.IPNet, dflt b
 		dev = n.datapathConfig.HostDevice
 	}
 
+	link, err := netlink.LinkByName(option.Config.EncryptInterface)
+	if err == nil {
+		addr, err := netlink.AddrList(link, netlink.FAMILY_V4)
+		if err == nil {
+			local = addr[0].IPNet.IP
+		}
+	}
+
 	return route.Route{
 		Device: dev,
 		Prefix: *ip,
+		Local:  local,
 		Table:  tbl,
 		Proto:  route.EncryptRouteProtocol,
 	}

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -179,6 +179,27 @@ var _ = Describe("K8sDatapathConfig", func() {
 		})
 	})
 
+	Context("Transparent encryption with encrypt-node DirectRouting", func() {
+		It("Check connectivity with automatic direct nodes routes", func() {
+			SkipIfFlannel()
+
+			if !helpers.RunsOnNetNext() {
+				Skip("Skipping test because it is not running with the net-next kernel")
+				return
+			}
+
+			deployCilium([]string{
+				"--set global.tunnel=disabled",
+				"--set global.autoDirectNodeRoutes=true",
+				"--set global.encryption.enabled=true",
+				"--set global.encryption.interface=enp0s8",
+				"--set global.encryption.nodeEncryption=true",
+			})
+			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
+			cleanService()
+		})
+	})
+
 	Context("IPv4Only", func() {
 		It("Check connectivity with IPv6 disabled", func() {
 			// Flannel always disables IPv6, this test is a no-op in that case.

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -305,6 +305,8 @@ else
     # This particular workaround is only needed for cilium, running on a pod on host
     # network namespace, to reach out kube-api-server.
     sudo iptables -t nat -A POSTROUTING -o enp0s8 ! -s 192.168.36.12 -j MASQUERADE
+    # Same as above for encryption case the output device is cilium_host
+    sudo iptables -t nat -A POSTROUTING -o cilium_host -s 10.0.2.15 -j SNAT --to 192.168.36.12
 fi
 
 # Create world network


### PR DESCRIPTION
Fixes needed to get CI running encrypt-node tests.

The following improvements are made,
 * Specify local addr (e.g. src) in node route for peer nodes so  that we use node IP for source IP
 * Add iptables rule to translate source IP chosen from default route when sending to service IP, this is specific to vagrant setup.
 * Add CI test
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8737)
<!-- Reviewable:end -->
