### PR TITLE
1.5 backports 19 07 31

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -469,7 +469,7 @@ func (d *Daemon) compileBase() error {
 		args[initArgIPv6NodeIP] = "<nil>"
 	}
 
-	args[initArgMTU] = fmt.Sprintf("%d", d.mtuConfig.GetDeviceMTU())
+	args[initArgMTU] = fmt.Sprintf("%d", d.mtuConfig.GetRouteMTU())
 
 	if option.Config.EnableIPSec {
 		args[initArgIPSec] = "true"

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -537,6 +537,18 @@ func (d *Daemon) deleteEndpointQuiet(ep *endpoint.Endpoint, conf endpoint.Delete
 
 	errs := []error{}
 
+	// Since the endpoint is being deleted, we no longer need to run events
+	// in its event queue. This is a no-op if the queue has already been
+	// closed elsewhere.
+	ep.EventQueue.Stop()
+
+	// Wait for the queue to be drained in case an event which is currently
+	// running for the endpoint tries to acquire the lock - we cannot be sure
+	// what types of events will be pushed onto the EventQueue for an endpoint
+	// and when they will happen. After this point, no events for the endpoint
+	// will be processed on its EventQueue, specifically regenerations.
+	ep.EventQueue.WaitToBeDrained()
+
 	// Wait for existing builds to complete and prevent further builds
 	ep.BuildMutex.Lock()
 
@@ -560,10 +572,6 @@ func (d *Daemon) deleteEndpointQuiet(ep *endpoint.Endpoint, conf endpoint.Delete
 		return []error{}
 	}
 	ep.SetStateLocked(endpoint.StateDisconnecting, "Deleting endpoint")
-
-	// Since the endpoint is being deleted, we no longer need to run events
-	// in its event queue.
-	ep.EventQueue.Stop()
 
 	// Remove the endpoint before we clean up. This ensures it is no longer
 	// listed or queued for rebuilds.


### PR DESCRIPTION

 * PR: 8687 -- endpoint: fix deadlock when endpoint EventQueue is full (@ianvernon) -- https://github.com/cilium/cilium/pull/8687
 * PR: 8688 -- [bugfix] - mtu for interfaces in host-network (@nyodas) -- https://github.com/cilium/cilium/pull/8688

@ianvernon for #8687 I dropped https://github.com/cilium/cilium/pull/8687/files#diff-f1df7e4a68fb40edee3342c348eb2f13R1322-R1324 because that code didn't exist in 1.5

@nyodas For #8688 I didn't backport 4d8726f77b3a76751142c4aed686b11880416fc6 because the scoping issue didn't exist (it assigns to the function global variable to begin with). I didn't backport 7ef55367cf9bdaf195a5b020acbd25fd46867808 because the code isn't factored out into a separate function, making the early returns infeasible. Instead of half-porting it I left it as is. Let me know if I got it wrong.


2019-07-31
removed  https://github.com/cilium/cilium/pull/8581. It is in https://github.com/cilium/cilium/pull/8707 
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8738)
<!-- Reviewable:end -->
