### PR TITLE
endpointmanager: add EndpointManager type and remove package-level variables

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -934,7 +934,7 @@ func NewDaemon(dp datapath.Datapath, iptablesManager rulesManager) (*Daemon, *en
 	// FIXME: Make the port range configurable.
 	if option.Config.InstallIptRules {
 		d.l7Proxy = proxy.StartProxySupport(10000, 20000, option.Config.RunDir,
-			option.Config.AccessLog, &d, option.Config.AgentLabels, d.datapath)
+			option.Config.AccessLog, &d, option.Config.AgentLabels, d.datapath, d.endpointManager)
 	} else {
 		log.Warning("L7 proxies not supported when --install-iptables-rules=\"false\"")
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -47,6 +47,7 @@ import (
 	"github.com/cilium/cilium/pkg/ipam"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s"
+	"github.com/cilium/cilium/pkg/k8s/endpointsynchronizer"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
@@ -183,6 +184,8 @@ type Daemon struct {
 
 	// iptablesManager deals with all iptables rules installed in the node
 	iptablesManager rulesManager
+
+	endpointManager *endpointmanager.EndpointManager
 }
 
 // Datapath returns a reference to the datapath implementation.
@@ -756,6 +759,8 @@ func NewDaemon(dp datapath.Datapath, iptablesManager rulesManager) (*Daemon, *en
 		nodeDiscovery:     nodediscovery.NewNodeDiscovery(nodeMngr, mtuConfig),
 		iptablesManager:   iptablesManager,
 	}
+
+	endpointmanager.GlobalEndpointManager = endpointmanager.NewEndpointManager(&endpointsynchronizer.EndpointSynchronizer{})
 
 	if option.Config.RunMonitorAgent {
 		monitorAgent, err := monitoragent.NewAgent(context.TODO(), defaults.MonitorBufferPages)

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -745,6 +745,7 @@ func NewDaemon(dp datapath.Datapath, iptablesManager rulesManager) (*Daemon, *en
 	identity.InitWellKnownIdentities()
 
 	epMgr := endpointmanager.NewEndpointManager(&endpointsynchronizer.EndpointSynchronizer{})
+	epMgr.InitMetrics()
 
 	// Cleanup flannel on exit
 	cleanupFuncs.Add(func() {
@@ -771,8 +772,6 @@ func NewDaemon(dp datapath.Datapath, iptablesManager rulesManager) (*Daemon, *en
 		iptablesManager:   iptablesManager,
 		endpointManager:   epMgr,
 	}
-
-	endpointmanager.GlobalEndpointManager = endpointmanager.NewEndpointManager(&endpointsynchronizer.EndpointSynchronizer{})
 
 	if option.Config.RunMonitorAgent {
 		monitorAgent, err := monitoragent.NewAgent(context.TODO(), defaults.MonitorBufferPages)

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -747,14 +747,14 @@ func NewDaemon(dp datapath.Datapath, iptablesManager rulesManager) (*Daemon, *en
 	epMgr := endpointmanager.NewEndpointManager(&endpointsynchronizer.EndpointSynchronizer{})
 	epMgr.InitMetrics()
 
-	// Cleanup flannel on exit
-	cleanupFuncs.Add(func() {
-		if option.Config.FlannelUninstallOnExit {
+	// Cleanup on exit if running in tandem with Flannel.
+	if option.Config.FlannelUninstallOnExit {
+		cleanupFuncs.Add(func() {
 			for _, ep := range epMgr.GetEndpoints() {
 				ep.DeleteBPFProgramLocked()
 			}
-		}
-	})
+		})
+	}
 
 	d := Daemon{
 		loadBalancer:      loadbalancer.NewLoadBalancer(),

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -758,6 +758,7 @@ func NewDaemon(dp datapath.Datapath, iptablesManager rulesManager) (*Daemon, *en
 		datapath:          dp,
 		nodeDiscovery:     nodediscovery.NewNodeDiscovery(nodeMngr, mtuConfig),
 		iptablesManager:   iptablesManager,
+		endpointManager:   endpointmanager.NewEndpointManager(&endpointsynchronizer.EndpointSynchronizer{}),
 	}
 
 	endpointmanager.GlobalEndpointManager = endpointmanager.NewEndpointManager(&endpointsynchronizer.EndpointSynchronizer{})
@@ -1014,7 +1015,7 @@ func (d *Daemon) bootstrapWorkloads() error {
 
 		// Workloads must be initialized after IPAM has started as it requires
 		// to allocate IPs.
-		if err := workloads.Setup(d.ipam, option.Config.Workloads, opts); err != nil {
+		if err := workloads.Setup(d.ipam, option.Config.Workloads, opts, d.endpointManager); err != nil {
 			return fmt.Errorf("unable to setup workload: %s", err)
 		}
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1025,7 +1025,7 @@ func (d *Daemon) bootstrapWorkloads() error {
 
 		// Workloads must be initialized after IPAM has started as it requires
 		// to allocate IPs.
-		if err := workloads.Setup(d.ipam, option.Config.Workloads, opts, d.endpointManager); err != nil {
+		if err := workloads.Setup(d.ipam, d.endpointManager, option.Config.Workloads, opts); err != nil {
 			return fmt.Errorf("unable to setup workload: %s", err)
 		}
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1081,7 +1081,7 @@ func (d *Daemon) TriggerReloadWithoutCompile(reason string) (*sync.WaitGroup, er
 		Reason:            reason,
 		RegenerationLevel: regeneration.RegenerateWithDatapathLoad,
 	}
-	return endpointmanager.RegenerateAllEndpoints(regenRequest), nil
+	return d.endpointManager.RegenerateAllEndpoints(regenRequest), nil
 }
 
 func changedOption(key string, value option.OptionSetting, data interface{}) {

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -1439,8 +1439,12 @@ func runDaemon() {
 				<-restoreComplete
 			}
 			d.dnsNameManager.CompleteBootstrap()
-			maps.CollectStaleMapGarbage()
-			maps.RemoveDisabledMaps()
+
+			ms := maps.NewMapSweeper(&EndpointMapManager{
+				endpointManager: d.endpointManager,
+			})
+			ms.CollectStaleMapGarbage()
+			ms.RemoveDisabledMaps()
 		}()
 	}
 

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -1441,7 +1441,7 @@ func runDaemon() {
 			d.dnsNameManager.CompleteBootstrap()
 
 			ms := maps.NewMapSweeper(&EndpointMapManager{
-				endpointManager: d.endpointManager,
+				EndpointManager: d.endpointManager,
 			})
 			ms.CollectStaleMapGarbage()
 			ms.RemoveDisabledMaps()

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -48,7 +48,6 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/k8s"
-	"github.com/cilium/cilium/pkg/k8s/endpointsynchronizer"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/loadinfo"
@@ -1401,8 +1400,6 @@ func runDaemon() {
 	endpointmanager.EnableConntrackGC(option.Config.EnableIPv4, option.Config.EnableIPv6,
 		restoredEndpoints.restored)
 	bootstrapStats.enableConntrack.End(true)
-
-	endpointmanager.EndpointSynchronizer = &endpointsynchronizer.EndpointSynchronizer{}
 
 	bootstrapStats.k8sInit.Start()
 

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -42,7 +42,6 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/loader"
 	"github.com/cilium/cilium/pkg/datapath/maps"
 	"github.com/cilium/cilium/pkg/defaults"
-	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/flowdebug"
 	"github.com/cilium/cilium/pkg/identity"
@@ -1397,7 +1396,7 @@ func runDaemon() {
 
 	bootstrapStats.enableConntrack.Start()
 	log.Info("Starting connection tracking garbage collector")
-	endpointmanager.EnableConntrackGC(option.Config.EnableIPv4, option.Config.EnableIPv6,
+	d.endpointManager.EnableConntrackGC(option.Config.EnableIPv4, option.Config.EnableIPv6,
 		restoredEndpoints.restored)
 	bootstrapStats.enableConntrack.End(true)
 

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/cilium/cilium/pkg/datapath"
 	fakedatapath "github.com/cilium/cilium/pkg/datapath/fake"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
-	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/kvstore"
@@ -141,7 +140,7 @@ func (ds *DaemonSuite) SetUpTest(c *C) {
 }
 
 func (ds *DaemonSuite) TearDownTest(c *C) {
-	endpointmanager.RemoveAll()
+	ds.d.endpointManager.RemoveAll()
 
 	if ds.d != nil {
 		os.RemoveAll(option.Config.RunDir)

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -30,7 +30,9 @@ import (
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/datapath"
 	fakedatapath "github.com/cilium/cilium/pkg/datapath/fake"
+	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
+	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/kvstore"
@@ -111,6 +113,10 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
+type dummyEpSyncher struct{}
+
+func (epSync *dummyEpSyncher) RunK8sCiliumEndpointSync(e *endpoint.Endpoint) {}
+
 func (ds *DaemonSuite) SetUpTest(c *C) {
 	ds.oldPolicyEnabled = policy.GetPolicyEnabled()
 	policy.SetPolicyEnabled(option.DefaultEnforcement)
@@ -137,6 +143,7 @@ func (ds *DaemonSuite) SetUpTest(c *C) {
 	ds.OnSendNotification = nil
 	ds.OnNewProxyLogRecord = nil
 	ds.OnClearPolicyConsumers = nil
+	ds.d.endpointManager = endpointmanager.NewEndpointManager(&dummyEpSyncher{})
 }
 
 func (ds *DaemonSuite) TearDownTest(c *C) {

--- a/daemon/datapath.go
+++ b/daemon/datapath.go
@@ -341,21 +341,7 @@ func (d *Daemon) writeNetdevHeader(dir string) error {
 // EndpointMapManager is a wrapper around an endpointmanager as well as the
 // filesystem for removing maps related to endpoints from the filesystem.
 type EndpointMapManager struct {
-	endpointManager *endpointmanager.EndpointManager
-}
-
-// EndpointExists returns whether the endpoint with the specified ID is managed
-// by this Cilium instance.
-func (e *EndpointMapManager) EndpointExists(endpointID uint16) bool {
-	if ep := e.endpointManager.LookupCiliumID(endpointID); ep != nil {
-		return true
-	}
-	return false
-}
-
-// HasGlobalCT returns whether global conntrack maps are being used.s
-func (e *EndpointMapManager) HasGlobalCT() bool {
-	return e.endpointManager.HasGlobalCT()
+	*endpointmanager.EndpointManager
 }
 
 // RemoveDatapathMapping unlinks the endpointID from the global policy map, preventing

--- a/daemon/debuginfo.go
+++ b/daemon/debuginfo.go
@@ -54,7 +54,7 @@ func (h *getDebugInfo) Handle(params restapi.GetDebuginfoParams) middleware.Resp
 
 	var p endpoint.GetEndpointParams
 
-	dr.EndpointList = getEndpointList(p)
+	dr.EndpointList = d.getEndpointList(p)
 	dr.Policy = d.policy.GetRulesList()
 	dr.Subsystem = debug.CollectSubsystemStatus()
 	dr.CiliumMemoryMap = memoryMap(os.Getpid())

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint"
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
-	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -50,7 +49,7 @@ func NewGetEndpointHandler(d *Daemon) GetEndpointHandler {
 
 func (h *getEndpoint) Handle(params GetEndpointParams) middleware.Responder {
 	log.WithField(logfields.Params, logfields.Repr(params)).Debug("GET /endpoint request")
-	resEPs := getEndpointList(params)
+	resEPs := h.d.getEndpointList(params)
 
 	if params.Labels != nil && len(resEPs) == 0 {
 		return NewGetEndpointNotFound()
@@ -59,7 +58,7 @@ func (h *getEndpoint) Handle(params GetEndpointParams) middleware.Responder {
 	return NewGetEndpointOK().WithPayload(resEPs)
 }
 
-func getEndpointList(params GetEndpointParams) []*models.Endpoint {
+func (d *Daemon) getEndpointList(params GetEndpointParams) []*models.Endpoint {
 	var (
 		epModelsWg, epsAppendWg sync.WaitGroup
 		convertedLabels         labels.Labels
@@ -71,7 +70,7 @@ func getEndpointList(params GetEndpointParams) []*models.Endpoint {
 		convertedLabels = labels.NewLabelsFromModel(params.Labels)
 	}
 
-	eps := endpointmanager.GetEndpoints()
+	eps := d.endpointManager.GetEndpoints()
 	epModelsCh := make(chan *models.Endpoint, len(eps))
 
 	epModelsWg.Add(len(eps))
@@ -113,7 +112,7 @@ func NewGetEndpointIDHandler(d *Daemon) GetEndpointIDHandler {
 func (h *getEndpointID) Handle(params GetEndpointIDParams) middleware.Responder {
 	log.WithField(logfields.EndpointID, params.ID).Debug("GET /endpoint/{id} request")
 
-	ep, err := endpointmanager.Lookup(params.ID)
+	ep, err := h.d.endpointManager.Lookup(params.ID)
 
 	if err != nil {
 		return api.Error(GetEndpointIDInvalidCode, err)
@@ -186,12 +185,12 @@ func (d *Daemon) createEndpoint(ctx context.Context, epTemplate *models.Endpoint
 		return invalidDataError(ep, fmt.Errorf("unable to parse endpoint parameters: %s", err))
 	}
 
-	oldEp := endpointmanager.LookupCiliumID(ep.ID)
+	oldEp := d.endpointManager.LookupCiliumID(ep.ID)
 	if oldEp != nil {
 		return invalidDataError(ep, fmt.Errorf("endpoint ID %d already exists", ep.ID))
 	}
 
-	oldEp = endpointmanager.LookupContainerID(ep.ContainerID)
+	oldEp = d.endpointManager.LookupContainerID(ep.ContainerID)
 	if oldEp != nil {
 		return invalidDataError(ep, fmt.Errorf("endpoint for container %s already exists", ep.ContainerID))
 	}
@@ -207,7 +206,7 @@ func (d *Daemon) createEndpoint(ctx context.Context, epTemplate *models.Endpoint
 	}
 
 	for _, id := range checkIDs {
-		oldEp, err := endpointmanager.Lookup(id)
+		oldEp, err := d.endpointManager.Lookup(id)
 		if err != nil {
 			return invalidDataError(ep, err)
 		} else if oldEp != nil {
@@ -252,7 +251,7 @@ func (d *Daemon) createEndpoint(ctx context.Context, epTemplate *models.Endpoint
 		}
 	}
 
-	err = endpointmanager.AddEndpoint(d, ep, "Create endpoint from API PUT")
+	err = d.endpointManager.AddEndpoint(d, ep, "Create endpoint from API PUT")
 	logger := ep.Logger(daemonSubsys)
 	if err != nil {
 		return d.errorDuringCreation(ep, fmt.Errorf("unable to insert endpoint into manager: %s", err))
@@ -417,7 +416,7 @@ func (h *patchEndpointID) Handle(params PatchEndpointIDParams) middleware.Respon
 		scopedLog.Debugf("PATCH /endpoint/{id} to invalid state '%s'", epTemplate.State)
 	}
 
-	ep, err := endpointmanager.Lookup(params.ID)
+	ep, err := h.d.endpointManager.Lookup(params.ID)
 	if err != nil {
 		return api.Error(GetEndpointIDInvalidCode, err)
 	}
@@ -594,7 +593,7 @@ func (d *Daemon) deleteEndpointQuiet(ep *endpoint.Endpoint, conf endpoint.Delete
 
 	// Remove the endpoint before we clean up. This ensures it is no longer
 	// listed or queued for rebuilds.
-	endpointmanager.Remove(ep)
+	d.endpointManager.Remove(ep)
 
 	defer func() {
 		repr, err := monitorAPI.EndpointDeleteRepr(ep)
@@ -649,7 +648,7 @@ func (d *Daemon) deleteEndpointQuiet(ep *endpoint.Endpoint, conf endpoint.Delete
 }
 
 func (d *Daemon) DeleteEndpoint(id string) (int, error) {
-	if ep, err := endpointmanager.Lookup(id); err != nil {
+	if ep, err := d.endpointManager.Lookup(id); err != nil {
 		return 0, api.Error(DeleteEndpointIDInvalidCode, err)
 	} else if ep == nil {
 		return 0, api.New(DeleteEndpointIDNotFoundCode, "endpoint not found")
@@ -686,7 +685,7 @@ func (h *deleteEndpointID) Handle(params DeleteEndpointIDParams) middleware.Resp
 
 // EndpointUpdate updates the options of the given endpoint and regenerates the endpoint
 func (d *Daemon) EndpointUpdate(id string, cfg *models.EndpointConfigurationSpec) error {
-	ep, err := endpointmanager.Lookup(id)
+	ep, err := d.endpointManager.Lookup(id)
 	if err != nil {
 		return api.Error(PatchEndpointIDInvalidCode, err)
 	} else if ep == nil {
@@ -706,7 +705,7 @@ func (d *Daemon) EndpointUpdate(id string, cfg *models.EndpointConfigurationSpec
 	if err := ep.RLockAlive(); err != nil {
 		return api.Error(PatchEndpointIDNotFoundCode, err)
 	}
-	endpointmanager.UpdateReferences(ep)
+	d.endpointManager.UpdateReferences(ep)
 	ep.RUnlock()
 
 	return nil
@@ -745,7 +744,7 @@ func NewGetEndpointIDConfigHandler(d *Daemon) GetEndpointIDConfigHandler {
 func (h *getEndpointIDConfig) Handle(params GetEndpointIDConfigParams) middleware.Responder {
 	log.WithField(logfields.Params, logfields.Repr(params)).Debug("GET /endpoint/{id}/config")
 
-	ep, err := endpointmanager.Lookup(params.ID)
+	ep, err := h.daemon.endpointManager.Lookup(params.ID)
 	if err != nil {
 		return api.Error(GetEndpointIDInvalidCode, err)
 	} else if ep == nil {
@@ -776,7 +775,7 @@ func NewGetEndpointIDLabelsHandler(d *Daemon) GetEndpointIDLabelsHandler {
 func (h *getEndpointIDLabels) Handle(params GetEndpointIDLabelsParams) middleware.Responder {
 	log.WithField(logfields.Params, logfields.Repr(params)).Debug("GET /endpoint/{id}/labels")
 
-	ep, err := endpointmanager.Lookup(params.ID)
+	ep, err := h.daemon.endpointManager.Lookup(params.ID)
 	if err != nil {
 		return api.Error(GetEndpointIDInvalidCode, err)
 	}
@@ -804,7 +803,7 @@ func NewGetEndpointIDLogHandler(d *Daemon) GetEndpointIDLogHandler {
 func (h *getEndpointIDLog) Handle(params GetEndpointIDLogParams) middleware.Responder {
 	log.WithField(logfields.EndpointID, params.ID).Debug("GET /endpoint/{id}/log request")
 
-	ep, err := endpointmanager.Lookup(params.ID)
+	ep, err := h.d.endpointManager.Lookup(params.ID)
 
 	if err != nil {
 		return api.Error(GetEndpointIDLogInvalidCode, err)
@@ -826,7 +825,7 @@ func NewGetEndpointIDHealthzHandler(d *Daemon) GetEndpointIDHealthzHandler {
 func (h *getEndpointIDHealthz) Handle(params GetEndpointIDHealthzParams) middleware.Responder {
 	log.WithField(logfields.EndpointID, params.ID).Debug("GET /endpoint/{id}/log request")
 
-	ep, err := endpointmanager.Lookup(params.ID)
+	ep, err := h.d.endpointManager.Lookup(params.ID)
 
 	if err != nil {
 		return api.Error(GetEndpointIDHealthzInvalidCode, err)
@@ -865,7 +864,7 @@ func (d *Daemon) modifyEndpointIdentityLabelsFromAPI(id string, add, del labels.
 		return PatchEndpointIDLabelsUpdateFailedCode, fmt.Errorf("Not allowed to delete reserved labels: %s", lbls)
 	}
 
-	ep, err := endpointmanager.Lookup(id)
+	ep, err := d.endpointManager.Lookup(id)
 	if err != nil {
 		return PatchEndpointIDInvalidCode, err
 	}
@@ -898,7 +897,7 @@ func (h *putEndpointIDLabels) Handle(params PatchEndpointIDLabelsParams) middlew
 	mod := params.Configuration
 	lbls := labels.NewLabelsFromModel(mod.User)
 
-	ep, err := endpointmanager.Lookup(params.ID)
+	ep, err := d.endpointManager.Lookup(params.ID)
 	if err != nil {
 		return api.Error(PutEndpointIDInvalidCode, err)
 	} else if ep == nil {

--- a/daemon/endpoint_test.go
+++ b/daemon/endpoint_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/endpoint"
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
-	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/eventqueue"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
@@ -77,7 +76,7 @@ func (ds *DaemonSuite) TestEndpointAddNoLabels(c *C) {
 		labels.IDNameInit: labels.NewLabel(labels.IDNameInit, "", labels.LabelSourceReserved),
 	}
 	// Check that the endpoint has the reserved:init label.
-	ep, err := endpointmanager.Lookup(endpointid.NewIPPrefixID(net.ParseIP(epTemplate.Addressing.IPV4)))
+	ep, err := ds.d.endpointManager.Lookup(endpointid.NewIPPrefixID(net.ParseIP(epTemplate.Addressing.IPV4)))
 	c.Assert(err, IsNil)
 	c.Assert(ep.OpLabels.IdentityLabels(), checker.DeepEquals, expectedLabels)
 

--- a/daemon/health.go
+++ b/daemon/health.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cilium/cilium/pkg/cleanup"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/endpoint"
-	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
@@ -77,7 +76,7 @@ func (d *Daemon) initHealth() {
 				if client == nil || err != nil {
 					var launchErr error
 					d.cleanupHealthEndpoint()
-					client, launchErr = health.LaunchAsEndpoint(ctx, d, &d.nodeDiscovery.LocalNode, d.mtuConfig)
+					client, launchErr = health.LaunchAsEndpoint(ctx, d, &d.nodeDiscovery.LocalNode, d.mtuConfig, d.endpointManager)
 					if launchErr != nil {
 						if err != nil {
 							return fmt.Errorf("failed to restart endpoint (check failed: %q): %s", err, launchErr)
@@ -113,10 +112,10 @@ func (d *Daemon) cleanupHealthEndpoint() {
 	// Clean up agent resources
 	var ep *endpoint.Endpoint
 	if localNode.IPv4HealthIP != nil {
-		ep = endpointmanager.LookupIPv4(localNode.IPv4HealthIP.String())
+		ep = d.endpointManager.LookupIPv4(localNode.IPv4HealthIP.String())
 	}
 	if ep == nil && localNode.IPv6HealthIP != nil {
-		ep = endpointmanager.LookupIPv6(localNode.IPv6HealthIP.String())
+		ep = d.endpointManager.LookupIPv6(localNode.IPv6HealthIP.String())
 	}
 	if ep == nil {
 		log.Debug("Didn't find existing cilium-health endpoint to delete")

--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/comparator"
 	"github.com/cilium/cilium/pkg/controller"
-	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s"
@@ -1566,7 +1565,7 @@ func (d *Daemon) updateCiliumNetworkPolicyV2AnnotationsOnly(ciliumNPClient clien
 		NodeName:                    node.GetName(),
 		NodeManager:                 d.nodeDiscovery.Manager,
 		UpdateDuration:              spanstat.Start(),
-		WaitForEndpointsAtPolicyRev: endpointmanager.WaitForEndpointsAtPolicyRev,
+		WaitForEndpointsAtPolicyRev: d.endpointManager.WaitForEndpointsAtPolicyRev,
 	}
 
 	k8sCM.UpdateController(ctrlName,
@@ -1618,7 +1617,7 @@ func (d *Daemon) addCiliumNetworkPolicyV2(ciliumNPClient clientset.Interface, ci
 			NodeName:                    node.GetName(),
 			NodeManager:                 d.nodeDiscovery.Manager,
 			UpdateDuration:              spanstat.Start(),
-			WaitForEndpointsAtPolicyRev: endpointmanager.WaitForEndpointsAtPolicyRev,
+			WaitForEndpointsAtPolicyRev: d.endpointManager.WaitForEndpointsAtPolicyRev,
 		}
 
 		ctrlName := cnp.GetControllerName()
@@ -1817,7 +1816,7 @@ func (d *Daemon) updateK8sPodV1(oldK8sPod, newK8sPod *types.Pod) error {
 
 	podNSName := k8sUtils.GetObjNamespaceName(&newK8sPod.ObjectMeta)
 
-	podEP := endpointmanager.LookupPodName(podNSName)
+	podEP := d.endpointManager.LookupPodName(podNSName)
 	if podEP == nil {
 		log.WithField("pod", podNSName).Debugf("Endpoint not found running for the given pod")
 		return nil
@@ -1887,7 +1886,7 @@ func (d *Daemon) updateK8sV1Namespace(oldNS, newNS *types.Namespace) error {
 	oldIdtyLabels, _ := labels.FilterLabels(oldLabels)
 	newIdtyLabels, _ := labels.FilterLabels(newLabels)
 
-	eps := endpointmanager.GetEndpoints()
+	eps := d.endpointManager.GetEndpoints()
 	failed := false
 	for _, ep := range eps {
 		epNS := ep.GetK8sNamespace()

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/endpoint"
-	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -245,7 +244,7 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) (resto
 		// upon returning that endpoints are exposed to other subsystems via
 		// endpointmanager.
 
-		if err := endpointmanager.Insert(ep); err != nil {
+		if err := d.endpointManager.Insert(ep); err != nil {
 			log.WithError(err).Warning("Unable to restore endpoint")
 			// remove endpoint from slice of endpoints to restore
 			state.restored = append(state.restored[:i], state.restored[i+1:]...)

--- a/pkg/datapath/maps/map_test.go
+++ b/pkg/datapath/maps/map_test.go
@@ -40,17 +40,21 @@ type testEPManager struct {
 	removedMappings []int
 }
 
-func (tm *testEPManager) endpointExists(id uint16) bool {
+func (tm *testEPManager) EndpointExists(id uint16) bool {
 	_, exists := tm.endpoints[id]
 	return exists
 }
 
-func (tm *testEPManager) removeDatapathMapping(id uint16) error {
+func (tm *testEPManager) HasGlobalCT() bool {
+	return false
+}
+
+func (tm *testEPManager) RemoveDatapathMapping(id uint16) error {
 	tm.removedMappings = append(tm.removedMappings, int(id))
 	return nil
 }
 
-func (tm *testEPManager) removeMapPath(path string) {
+func (tm *testEPManager) RemoveMapPath(path string) {
 	tm.removedPaths = append(tm.removedPaths, path)
 }
 
@@ -205,7 +209,7 @@ func (s *MapTestSuite) TestCollectStaleMapGarbage(c *C) {
 	for _, tt := range testCases {
 		c.Log(tt.name)
 		testEPManager := newTestEPManager()
-		sweeper := newMapSweeper(testEPManager)
+		sweeper := NewMapSweeper(testEPManager)
 
 		for _, ep := range tt.endpoints {
 			testEPManager.addEndpoint(ep)

--- a/pkg/endpointmanager/conntrack.go
+++ b/pkg/endpointmanager/conntrack.go
@@ -36,6 +36,12 @@ import (
 // garbage collected and any failures will be logged to the endpoint log.
 // Otherwise it will garbage-collect the global map and use the global log.
 func runGC(e *endpoint.Endpoint, ipv4, ipv6 bool, filter *ctmap.GCFilter) (mapType bpf.MapType, maxDeleteRatio float64) {
+	return GlobalEndpointManager.runGC(e, ipv4, ipv6, filter)
+}
+
+// garbage collected and any failures will be logged to the endpoint log.
+// Otherwise it will garbage-collect the global map and use the global log.
+func (epMgr *EndpointManager) runGC(e *endpoint.Endpoint, ipv4, ipv6 bool, filter *ctmap.GCFilter) (mapType bpf.MapType, maxDeleteRatio float64) {
 	var maps []*ctmap.Map
 
 	if e == nil {
@@ -103,7 +109,7 @@ func createGCFilter(initialScan bool, restoredEndpoints []*endpoint.Endpoint) *c
 }
 
 // EnableConntrackGC enables the connection tracking garbage collection.
-func EnableConntrackGC(ipv4, ipv6 bool, restoredEndpoints []*endpoint.Endpoint) {
+func (epMgr *EndpointManager) EnableConntrackGC(ipv4, ipv6 bool, restoredEndpoints []*endpoint.Endpoint) {
 	var (
 		initialScan         = true
 		initialScanComplete = make(chan struct{})

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -525,3 +525,8 @@ func (mgr *EndpointManager) CallbackForEndpointsAtPolicyRev(ctx context.Context,
 	}
 	return nil
 }
+
+// EndpointExists returns whether the endpoint with id exists.
+func (mgr *EndpointManager) EndpointExists(id uint16) bool {
+	return mgr.LookupCiliumID(id) != nil
+}

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -415,7 +415,9 @@ func (s *EndpointManagerSuite) TestLookupCiliumID(c *C) {
 		args := tt.setupArgs()
 		want := tt.setupWant()
 		got := mgr.LookupCiliumID(args.id)
+		exists := mgr.EndpointExists(args.id)
 		c.Assert(got, checker.DeepEquals, want.ep, Commentf("Test Name: %s", tt.name))
+		c.Assert(exists, checker.Equals, want.ep != nil, Commentf("Test Name: %s", tt.name))
 		tt.postTestRun()
 	}
 }

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -732,8 +732,8 @@ func (s *EndpointManagerSuite) TestRemove(c *C) {
 		tt.preTestRun()
 
 		RemoveAll()
-		c.Assert(len(endpoints), Equals, 0, Commentf("Test Name: %s", tt.name))
-		c.Assert(len(endpointsAux), Equals, 0, Commentf("Test Name: %s", tt.name))
+		c.Assert(len(GlobalEndpointManager.endpoints), Equals, 0, Commentf("Test Name: %s", tt.name))
+		c.Assert(len(GlobalEndpointManager.endpointsAux), Equals, 0, Commentf("Test Name: %s", tt.name))
 		tt.postTestRun()
 	}
 }

--- a/pkg/proxy/epinfo.go
+++ b/pkg/proxy/epinfo.go
@@ -17,7 +17,7 @@ package proxy
 import (
 	"net"
 
-	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
@@ -28,7 +28,13 @@ var (
 	// DefaultEndpointInfoRegistry is the default instance implementing the
 	// EndpointInfoRegistry interface.
 	DefaultEndpointInfoRegistry logger.EndpointInfoRegistry = &defaultEndpointInfoRegistry{}
+	endpointManager             EndpointLookup
 )
+
+// EndpointLookup is any type which maps from IP to the endpoint owning that IP.
+type EndpointLookup interface {
+	LookupIP(ip net.IP) (ep *endpoint.Endpoint)
+}
 
 // defaultEndpointInfoRegistry is the default implementation of the
 // EndpointInfoRegistry interface.
@@ -48,7 +54,7 @@ func (r *defaultEndpointInfoRegistry) FillEndpointIdentityByID(id identity.Numer
 }
 
 func (r *defaultEndpointInfoRegistry) FillEndpointIdentityByIP(ip net.IP, info *accesslog.EndpointInfo) bool {
-	ep := endpointmanager.LookupIP(ip)
+	ep := endpointManager.LookupIP(ip)
 	if ep == nil {
 		return false
 	}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -112,7 +112,8 @@ type Proxy struct {
 // and access log server.
 func StartProxySupport(minPort uint16, maxPort uint16, stateDir string,
 	accessLogFile string, accessLogNotifier logger.LogRecordNotifier, accessLogMetadata []string,
-	datapathUpdater DatapathUpdater) *Proxy {
+	datapathUpdater DatapathUpdater, mgr EndpointLookup) *Proxy {
+	endpointManager = mgr
 	xdsServer := envoy.StartXDSServer(stateDir)
 
 	if accessLogFile != "" {

--- a/pkg/workloads/client.go
+++ b/pkg/workloads/client.go
@@ -17,6 +17,7 @@ package workloads
 import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/endpointmanager"
 )
 
 var (
@@ -24,8 +25,8 @@ var (
 	defaultClient WorkloadRuntime
 )
 
-func initClient(module workloadModule) error {
-	c, err := module.newClient()
+func initClient(module workloadModule, epMgr *endpointmanager.EndpointManager) error {
+	c, err := module.newClient(epMgr)
 	if err != nil {
 		return err
 	}

--- a/pkg/workloads/config.go
+++ b/pkg/workloads/config.go
@@ -98,11 +98,11 @@ type allocatorInterface interface {
 
 // Setup sets up the workload runtime specified in workloadRuntime and configures it
 // with the options provided in opts
-func Setup(a allocatorInterface, workloadRuntimes []string, opts map[WorkloadRuntimeType]map[string]string, epMgr *endpointmanager.EndpointManager) error {
-	return setup(a, workloadRuntimes, opts, false, epMgr)
+func Setup(a allocatorInterface, epMgr *endpointmanager.EndpointManager, workloadRuntimes []string, opts map[WorkloadRuntimeType]map[string]string) error {
+	return setup(a, epMgr, workloadRuntimes, opts, false)
 }
 
-func setup(a allocatorInterface, workloadRuntimes []string, opts map[WorkloadRuntimeType]map[string]string, bypassStatusCheck bool, epMgr *endpointmanager.EndpointManager) error {
+func setup(a allocatorInterface, epMgr *endpointmanager.EndpointManager, workloadRuntimes []string, opts map[WorkloadRuntimeType]map[string]string, bypassStatusCheck bool) error {
 	var (
 		st  *models.Status
 		err error

--- a/pkg/workloads/containerd.go
+++ b/pkg/workloads/containerd.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/endpoint"
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
+	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 
 	"github.com/containerd/containerd"
@@ -85,8 +86,8 @@ func (c *containerDModule) getConfig() map[string]string {
 	return getOpts(c.opts)
 }
 
-func (c *containerDModule) newClient() (WorkloadRuntime, error) {
-	return newContainerDClient(c.opts)
+func (c *containerDModule) newClient(epMgr *endpointmanager.EndpointManager) (WorkloadRuntime, error) {
+	return newContainerDClient(c.opts, epMgr)
 }
 
 type containerDClient struct {
@@ -94,7 +95,7 @@ type containerDClient struct {
 	cri *criClient
 }
 
-func newContainerDClient(opts workloadRuntimeOpts) (WorkloadRuntime, error) {
+func newContainerDClient(opts workloadRuntimeOpts, epMgr *endpointmanager.EndpointManager) (WorkloadRuntime, error) {
 	ep := string(opts[EpOpt].value)
 	c, err := containerd.New(ep)
 	if err != nil {
@@ -107,7 +108,7 @@ func newContainerDClient(opts workloadRuntimeOpts) (WorkloadRuntime, error) {
 	if p.Scheme == "" {
 		ep = "unix://" + ep
 	}
-	rsc, err := newCRIClient(context.WithValue(context.Background(), EpOpt, ep))
+	rsc, err := newCRIClient(context.WithValue(context.Background(), EpOpt, ep), epMgr)
 	return &containerDClient{c, rsc}, err
 }
 

--- a/pkg/workloads/crio.go
+++ b/pkg/workloads/crio.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/endpointmanager"
 )
 
 const (
@@ -64,15 +65,15 @@ func (c *criOModule) getConfig() map[string]string {
 	return getOpts(c.opts)
 }
 
-func (c *criOModule) newClient() (WorkloadRuntime, error) {
-	return newCRIOClient(c.opts)
+func (c *criOModule) newClient(epMgr *endpointmanager.EndpointManager) (WorkloadRuntime, error) {
+	return newCRIOClient(c.opts, epMgr)
 }
 
 type criOClient struct {
 	cri *criClient
 }
 
-func newCRIOClient(opts workloadRuntimeOpts) (WorkloadRuntime, error) {
+func newCRIOClient(opts workloadRuntimeOpts, epMgr *endpointmanager.EndpointManager) (WorkloadRuntime, error) {
 	ep := string(opts[EpOpt].value)
 	p, err := url.Parse(ep)
 	if err != nil {
@@ -81,7 +82,7 @@ func newCRIOClient(opts workloadRuntimeOpts) (WorkloadRuntime, error) {
 	if p.Scheme == "" {
 		ep = "unix://" + ep
 	}
-	rsc, err := newCRIClient(context.WithValue(context.Background(), EpOpt, ep))
+	rsc, err := newCRIClient(context.WithValue(context.Background(), EpOpt, ep), epMgr)
 	return &criOClient{rsc}, err
 }
 

--- a/pkg/workloads/defaults.go
+++ b/pkg/workloads/defaults.go
@@ -64,12 +64,12 @@ func getFilteredLabels(containerID string, allLabels map[string]string) (identit
 	return labels.FilterLabels(combinedLabels)
 }
 
-func processCreateWorkload(ep *endpoint.Endpoint, containerID string, allLabels map[string]string) {
+func processCreateWorkload(ep *endpoint.Endpoint, containerID string, allLabels map[string]string, epMgr *endpointmanager.EndpointManager) {
 	ep.SetContainerID(containerID)
 
 	// Update map allowing to lookup endpoint by endpoint
 	// attributes with new attributes set on endpoint
-	endpointmanager.UpdateReferences(ep)
+	epMgr.UpdateReferences(ep)
 
 	identityLabels, informationLabels := getFilteredLabels(containerID, allLabels)
 	ep.UpdateLabels(context.Background(), identityLabels, informationLabels, false)

--- a/pkg/workloads/runtimes.go
+++ b/pkg/workloads/runtimes.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
+	"github.com/cilium/cilium/pkg/endpointmanager"
 )
 
 // WorkloadOwner is the interface that the owner of workloads must implement.
@@ -90,7 +91,7 @@ type workloadModule interface {
 
 	// newClient must initializes the workload and create a new kvstore
 	// client which implements the WorkloadRuntime interface
-	newClient() (WorkloadRuntime, error)
+	newClient(epMgr *endpointmanager.EndpointManager) (WorkloadRuntime, error)
 }
 
 // WorkloadRuntimeType is the type of a container runtime

--- a/pkg/workloads/runtimes_test.go
+++ b/pkg/workloads/runtimes_test.go
@@ -76,7 +76,7 @@ func (s *WorkloadsTestSuite) TestSetupWithoutStatusCheck(c *C) {
 	}
 	for _, tt := range tests {
 		epMgr := endpointmanager.NewEndpointManager(&dummyEpSyncher{})
-		if err := setup(nil, tt.args.containerRuntimes, tt.args.containerRuntimesOpts, true, epMgr); (err != nil) != tt.wantErr {
+		if err := setup(nil, epMgr, tt.args.containerRuntimes, tt.args.containerRuntimesOpts, true); (err != nil) != tt.wantErr {
 			c.Errorf("setup() for %s error = %v, wantErr %v", tt.name, err, tt.wantErr)
 		}
 		setupOnce = sync.Once{}
@@ -113,7 +113,7 @@ func (s *WorkloadsTestSuite) TestSetupWithoutStatusCheck(c *C) {
 	}
 	for _, tt := range tests {
 		epMgr := endpointmanager.NewEndpointManager(&dummyEpSyncher{})
-		if err := setup(nil, tt.args.containerRuntimes, tt.args.containerRuntimesOpts, true, epMgr); (err != nil) != tt.wantErr {
+		if err := setup(nil, epMgr, tt.args.containerRuntimes, tt.args.containerRuntimesOpts, true); (err != nil) != tt.wantErr {
 			c.Errorf("setup() for %s error = %v, wantErr %v", tt.name, err, tt.wantErr)
 		}
 		setupOnce = sync.Once{}

--- a/pkg/workloads/runtimes_test.go
+++ b/pkg/workloads/runtimes_test.go
@@ -21,6 +21,8 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/endpointmanager"
 	. "gopkg.in/check.v1"
 )
 
@@ -32,6 +34,10 @@ func Test(t *testing.T) {
 type WorkloadsTestSuite struct{}
 
 var _ = Suite(&WorkloadsTestSuite{})
+
+type dummyEpSyncher struct{}
+
+func (epSync *dummyEpSyncher) RunK8sCiliumEndpointSync(e *endpoint.Endpoint) {}
 
 func (s *WorkloadsTestSuite) TestSetupWithoutStatusCheck(c *C) {
 	// backup registered workload since None will unregister them all
@@ -69,7 +75,8 @@ func (s *WorkloadsTestSuite) TestSetupWithoutStatusCheck(c *C) {
 		},
 	}
 	for _, tt := range tests {
-		if err := setup(nil, tt.args.containerRuntimes, tt.args.containerRuntimesOpts, true); (err != nil) != tt.wantErr {
+		epMgr := endpointmanager.NewEndpointManager(&dummyEpSyncher{})
+		if err := setup(nil, tt.args.containerRuntimes, tt.args.containerRuntimesOpts, true, epMgr); (err != nil) != tt.wantErr {
 			c.Errorf("setup() for %s error = %v, wantErr %v", tt.name, err, tt.wantErr)
 		}
 		setupOnce = sync.Once{}
@@ -105,7 +112,8 @@ func (s *WorkloadsTestSuite) TestSetupWithoutStatusCheck(c *C) {
 		},
 	}
 	for _, tt := range tests {
-		if err := setup(nil, tt.args.containerRuntimes, tt.args.containerRuntimesOpts, true); (err != nil) != tt.wantErr {
+		epMgr := endpointmanager.NewEndpointManager(&dummyEpSyncher{})
+		if err := setup(nil, tt.args.containerRuntimes, tt.args.containerRuntimesOpts, true, epMgr); (err != nil) != tt.wantErr {
 			c.Errorf("setup() for %s error = %v, wantErr %v", tt.name, err, tt.wantErr)
 		}
 		setupOnce = sync.Once{}


### PR DESCRIPTION
This is part of the effort to make Cilium more unit-testable overall. Having global state is not unit-testable by its nature. As such, refactor the fields from `pkg/endpointmanager` into a type that is passed around explicitly from `daemon` to various subsystems that need it. When packages need to use functionality from endpointmanager, it is via an interface. This allows for more unit-testable code in consumers of endpointmanager as well. 

TODO still:

- [x] address hound's comments / add additional documentation / clean up some interface names
- [ ] rebase into one commit - I split this up more for reviewing purposes, as it's quite hard to do this in an atomic way without one singular commit. Squashing into a single commit is best to ensure there are no issues while bisecting.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8742)
<!-- Reviewable:end -->
