### PR TITLE
daemon: don't hold endpoint BuildMutex while deleting

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -357,7 +357,7 @@ func (e *Endpoint) removeOldRedirects(desiredRedirects map[string]bool, proxyWai
 // specified endpoint.
 // ReloadDatapath forces the datapath programs to be reloaded. It does
 // not guarantee recompilation of the programs.
-// Must be called with endpoint.Mutex not held and endpoint.BuildMutex held.
+// Must be called with endpoint.Mutex not held and endpoint.buildMutex held.
 // Returns the policy revision number when the regeneration has called, a
 // boolean if the BPF compilation was executed and an error in case of an error.
 func (e *Endpoint) regenerateBPF(regenContext *regenerationContext) (revnum uint64, compiled bool, reterr error) {

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -244,8 +244,8 @@ func (e *Endpoint) regenerate(context *regenerationContext) (retErr error) {
 		e.updateRegenerationStatistics(context, retErr)
 	}()
 
-	e.BuildMutex.Lock()
-	defer e.BuildMutex.Unlock()
+	e.buildMutex.Lock()
+	defer e.buildMutex.Unlock()
 
 	stats.waitingForLock.Start()
 	// Check if endpoints is still alive before doing any build


### PR DESCRIPTION
Stopping the endpoint's EventQueue is sufficient, as when we stop the queue and wait for
in-flight regenerations to complete before proceeding further and cleaning up various state
relevant to the endpoint. Stopping the endpoint's EventQueue means that no events which are
enqueued after stopping (e.g., regenerations) are processed, and as such they are no-ops.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8744)
<!-- Reviewable:end -->
