### PR TITLE
endpoint: remove duplicate closing of maps from endpoint deletion logic

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1332,18 +1332,6 @@ func (e *Endpoint) LeaveLocked(proxyWaitGroup *completion.WaitGroup, conf Delete
 		e.removeOldRedirects(nil, proxyWaitGroup)
 	}
 
-	if e.policyMap != nil {
-		if err := e.policyMap.Close(); err != nil {
-			errors = append(errors, fmt.Errorf("unable to close policymap %s: %s", e.policyMap.String(), err))
-		}
-	}
-
-	if e.bpfConfigMap != nil {
-		if err := e.bpfConfigMap.Close(); err != nil {
-			errors = append(errors, fmt.Errorf("unable to close configmap %s: %s", e.BPFConfigMapPath(), err))
-		}
-	}
-
 	if !conf.NoIdentityRelease && e.SecurityIdentity != nil {
 		identitymanager.Remove(e.SecurityIdentity)
 


### PR DESCRIPTION
`daemon.deleteEndpointQuiet` already calls`DeleteMapsLocked`  which cleans up the BPF ConfigMap
and PolicyMap for the endpoint, so no need to do it again in `LeaveLocked`.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8745)
<!-- Reviewable:end -->
