### PR TITLE
bugtool: Add counters to iptables-save output

### DIFF
--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -85,7 +85,7 @@ func defaultCommands(confDir string, cmdDir string, k8sPods []string) []string {
 		"journalctl -u cilium*",
 		"journalctl -u kubelet",
 		// iptables
-		"iptables-save",
+		"iptables-save -c",
 		"iptables -S",
 		"ip6tables -S",
 		"iptables -L -v",


### PR DESCRIPTION
These can be really handy for debugging some classes of problems where
iptables rules that we expect to be hit are in fact not hit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8747)
<!-- Reviewable:end -->
