### PR TITLE
test: add capability to specify images / skip K8s provisioning

### DIFF
--- a/Documentation/contributing/contributing.rst
+++ b/Documentation/contributing/contributing.rst
@@ -721,16 +721,24 @@ framework in the ``test/`` directory and interact with ginkgo directly:
     $ cd test/
     $ ginkgo . -- --help | grep -A 1 cilium
       -cilium.SSHConfig string
-            Specify a custom command to fetch SSH configuration (eg: 'vagrant ssh-config')
+    	    Specify a custom command to fetch SSH configuration (eg: 'vagrant ssh-config')
       -cilium.holdEnvironment
-            On failure, hold the environment in its current state
+    	    On failure, hold the environment in its current state
+      -cilium.image string
+        	Specifies which image of cilium to use during tests
+      -cilium.operator-image string
+        	Specifies which image of cilium-operator to use during tests
       -cilium.provision
-            Provision Vagrant boxes and Cilium before running test (default true)
+        	Provision Vagrant boxes and Cilium before running test (default true)
+      -cilium.provision-k8s
+        	Specifies whether Kubernetes should be deployed and installed via kubeadm or not (default true)
       -cilium.showCommands
-            Output which commands are ran to stdout
+        	Output which commands are ran to stdout
+      -cilium.skipLogs
+        	skip gathering logs if a test fails
       -cilium.testScope string
-            Specifies scope of test to be ran (k8s, Nightly, runtime)
-    $ ginkgo --focus "Policies*" -- --cilium.provision=false
+        	Specifies scope of test to be ran (k8s, Nightly, runtime)   
+    
 
 For more information about other built-in options to Ginkgo, consult the
 `Ginkgo documentation <https://onsi.github.io/ginkgo/>`_.

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -19,6 +19,9 @@ $NFS = ENV['NFS']=="1"? true : false
 $IPv6=(ENV['IPv6'] || "0")
 $CONTAINER_RUNTIME=(ENV['CONTAINER_RUNTIME'] || "docker")
 $CNI_INTEGRATION=(ENV['CNI_INTEGRATION'] || "")
+$CILIUM_IMAGE = ENV['CILIUM_IMAGE'] || ""
+$CILIUM_OPERATOR_IMAGE = ENV['CILIUM_OPERATOR_IMAGE'] || ""
+$SKIP_K8S_PROVISION = ENV['SKIP_K8S_PROVISION'] || "false"
 
 # RAM and CPU settings
 $MEMORY = (ENV['MEMORY'] || "4096").to_i
@@ -107,6 +110,9 @@ Vagrant.configure("2") do |config|
                 sh.args = [
                     "k8s#{i}", "192.168.36.1#{i}", "#{$K8S_VERSION}",
                     "#{$IPv6}", "#{$CONTAINER_RUNTIME}", "#{$CNI_INTEGRATION}"]
+                sh.env = {"CILIUM_IMAGE" => "#{$CILIUM_IMAGE}",
+                          "CILIUM_OPERATOR_IMAGE" => "#{$CILIUM_OPERATOR_IMAGE}",
+                          "SKIP_K8S_PROVISION" => "#{$SKIP_K8S_PROVISION}"}
             end
         end
     end

--- a/test/config/config.go
+++ b/test/config/config.go
@@ -18,12 +18,15 @@ import "flag"
 
 // CiliumTestConfigType holds all of the configurable elements of the testsuite
 type CiliumTestConfigType struct {
-	Reprovision      bool
-	HoldEnvironment  bool
-	SSHConfig        string
-	ShowCommands     bool
-	TestScope        string
-	SkipLogGathering bool
+	Reprovision         bool
+	HoldEnvironment     bool
+	SSHConfig           string
+	ShowCommands        bool
+	TestScope           string
+	SkipLogGathering    bool
+	CiliumImage         string
+	CiliumOperatorImage string
+	ProvisionK8s        bool
 }
 
 // CiliumTestConfig holds the global configuration of commandline flags
@@ -44,4 +47,10 @@ func (c *CiliumTestConfigType) ParseFlags() {
 		"Output which commands are ran to stdout")
 	flag.StringVar(&c.TestScope, "cilium.testScope", "",
 		"Specifies scope of test to be ran (k8s, Nightly, runtime)")
+	flag.StringVar(&c.CiliumImage, "cilium.image", "",
+		"Specifies which image of cilium to use during tests")
+	flag.StringVar(&c.CiliumOperatorImage, "cilium.operator-image", "",
+		"Specifies which image of cilium-operator to use during tests")
+	flag.BoolVar(&c.ProvisionK8s, "cilium.provision-k8s", true,
+		"Specifies whether Kubernetes should be deployed and installed via kubeadm or not")
 }

--- a/test/provision/compile.sh
+++ b/test/provision/compile.sh
@@ -6,30 +6,58 @@ KUBE_SYSTEM_NAMESPACE="kube-system"
 KUBECTL="/usr/bin/kubectl"
 PROVISIONSRC="/tmp/provision"
 GOPATH="/home/vagrant/go"
+REGISTRY="k8s1:5000"
+CILIUM_TAG="cilium/cilium-dev"
+CILIUM_OPERATOR_TAG="cilium/operator"
 
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 source "${PROVISIONSRC}/helpers.bash"
 
+function delete_cilium_pods {
+  echo "Executing: $KUBECTL delete pods -n $KUBE_SYSTEM_NAMESPACE -l $CILIUM_DS_TAG"
+  $KUBECTL delete pods -n $KUBE_SYSTEM_NAMESPACE -l $CILIUM_DS_TAG
+}
+
+
 cd ${GOPATH}/src/github.com/cilium/cilium
+
 
 if echo $(hostname) | grep "k8s" -q;
 then
+    # Only need to build on one host, since we can pull from the other host.
     if [[ "$(hostname)" == "k8s1" ]]; then
+      if [[ "${CILIUM_IMAGE}" == "" && "${CILIUM_OPERATOR_IMAGE}" == "" ]]; then
         echo "building cilium/cilium container image..."
         make LOCKDEBUG=1 docker-image-no-clean
-        make LOCKDEBUG=1 docker-operator-image&
+
+        echo "building cilium/operator container image..."
+	make LOCKDEBUG=1 docker-operator-image&
         export OPERATORPID=$!
-        echo "pushing container image to k8s1:5000/cilium/cilium-dev..."
+
+        echo "pushing cilium/cilium image to k8s1:5000/cilium/cilium-dev..."
         docker tag cilium/cilium k8s1:5000/cilium/cilium-dev
         docker rmi cilium/cilium:latest
         docker push k8s1:5000/cilium/cilium-dev
 
         wait $OPERATORPID
+        echo "pushing cilium/operator image to k8s1:5000/cilium/operator..."
         docker tag cilium/operator k8s1:5000/cilium/operator
         docker push k8s1:5000/cilium/operator
-        echo "Executing: $KUBECTL delete pods -n $KUBE_SYSTEM_NAMESPACE -l $CILIUM_DS_TAG"
-        $KUBECTL delete pods -n $KUBE_SYSTEM_NAMESPACE -l $CILIUM_DS_TAG
+        delete_cilium_pods
+      elif [[ "${CILIUM_IMAGE}" != "" && "${CILIUM_OPERATOR_IMAGE}" == "" ]]; then
+        pull_image_and_push_to_local_registry ${CILIUM_IMAGE} ${REGISTRY} ${CILIUM_TAG}
+        build_operator_image
+        delete_cilium_pods
+      elif [[ "${CILIUM_IMAGE}" == "" && "${CILIUM_OPERATOR_IMAGE}" != "" ]]; then
+        pull_image_and_push_to_local_registry ${CILIUM_OPERATOR_IMAGE} ${REGISTRY} ${CILIUM_OPERATOR_TAG}
+        build_cilium_image
+        delete_cilium_pods
+      else
+        pull_image_and_push_to_local_registry ${CILIUM_IMAGE} ${REGISTRY} ${CILIUM_TAG}
+        pull_image_and_push_to_local_registry ${CILIUM_OPERATOR_IMAGE} ${REGISTRY} ${CILIUM_OPERATOR_TAG}
+        delete_cilium_pods
+      fi
     else
         echo "Not on master K8S node; no need to compile Cilium container"
     fi

--- a/test/provision/helpers.bash
+++ b/test/provision/helpers.bash
@@ -67,3 +67,42 @@ function install_k8s_using_binary {
     curl -sSL "https://raw.githubusercontent.com/kubernetes/kubernetes/${RELEASE}/build/debs/10-kubeadm.conf" > /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
     systemctl enable kubelet
 }
+
+function pull_image_and_push_to_local_registry {
+  local IMG=$1
+  local REGISTRY=$2
+  local TAG_NAME=$3
+
+  local TAG_WITH_REG="${REGISTRY}/${TAG_NAME}"
+
+  echo "pulling ${IMG}..."
+  docker pull "${IMG}"
+  echo "done pulling ${IMG}"
+
+  echo "tagging ${IMG} with tag ${TAG_WITH_REG}"
+  docker tag "${IMG}" ${TAG_WITH_REG}
+  echo "done tagging ${IMG} with tag ${TAG_WITH_REG}"
+
+  echo "pushing ${TAG_WITH_REG}"
+  docker push ${TAG_WITH_REG}
+  echo "done pushing ${TAG_WITH_REG}"
+}
+
+function build_cilium_image {
+  echo "building cilium image..."
+  make LOCKDEBUG=1 docker-image-no-clean
+  echo "tagging cilium image..."
+  docker tag cilium/cilium k8s1:5000/cilium/cilium-dev
+  echo "pushing cilium image..."
+  docker push k8s1:5000/cilium/cilium-dev
+}
+
+function build_operator_image {
+  # build cilium-operator image
+  echo "building cilium-operator image..."
+  make LOCKDEBUG=1 docker-operator-image
+  echo "tagging cilium-operator image..."
+  docker tag cilium/operator k8s1:5000/cilium/operator
+  echo "pushing cilium-operator image..."
+  docker push k8s1:5000/cilium/operator
+}

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -214,6 +214,18 @@ var _ = BeforeAll(func() {
 		// Start k8s2
 		// Wait until compilation finished, and pull cilium image on k8s2
 
+		if config.CiliumTestConfig.CiliumImage != "" {
+			os.Setenv("CILIUM_IMAGE", config.CiliumTestConfig.CiliumImage)
+		}
+
+		if config.CiliumTestConfig.CiliumOperatorImage != "" {
+			os.Setenv("CILIUM_OPERATOR_IMAGE", config.CiliumTestConfig.CiliumOperatorImage)
+		}
+
+		if config.CiliumTestConfig.ProvisionK8s == false {
+			os.Setenv("SKIP_K8S_PROVISION", "true")
+		}
+
 		// Name for K8s VMs depends on K8s version that is running.
 
 		// Boot / provision VMs if specified by configuration.


### PR DESCRIPTION
Add three new options to the Ginkgo CI:

* `-cilium.operator-image` - image containing cilium-operator
* `-cilium.image` - image containing cilium-agent
* `-cilium.provision-k8s` - whether or not to provision K8s (true or false)

These flags are useful when running CI-only changes locally, so that developers
can quickly deploy cilium and cilium-operator without having to build it. This
also allows for tests to be ran against specific tags, e.g. v1.4.5, etc.

If either image option is not set, the scripts for running tests will build the
image which was not specified, and pull the other one. If neither are set, the
existing behavior of building both images is performed.

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #8638

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8748)
<!-- Reviewable:end -->