### PR TITLE
k8s: Update ipcache based on CiliumEndpoint only if NodeIP is available

### DIFF
--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -1913,9 +1913,17 @@ func endpointUpdated(endpoint *types.CiliumEndpoint) {
 	}
 
 	if endpoint.Networking != nil {
+		if endpoint.Networking.NodeIP == "" {
+			// When upgrading from an older version, the nodeIP may
+			// not be available yet in the CiliumEndpoint and we
+			// have to wait for it to be propagated
+			return
+		}
+
 		nodeIP := net.ParseIP(endpoint.Networking.NodeIP)
 		if nodeIP == nil {
 			log.WithField("nodeIP", endpoint.Networking.NodeIP).Warning("Unable to parse node IP while processing CiliumEndpoint update")
+			return
 		}
 
 		for _, pair := range endpoint.Networking.Addressing {


### PR DESCRIPTION
During the upgrade test, existing CiliumEndpoint are present which do not
contains a NodeIP yet. Skip updating the ipcache until the NodeIP is available.

Related: #8722

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8754)
<!-- Reviewable:end -->
