### PR TITLE
test: gather kvstore output last

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -275,14 +275,21 @@ var ciliumCLICommands = map[string]string{
 // ciliumKubCLICommands these commands are the same as `ciliumCLICommands` but
 // it'll run inside a container and it does not have sudo support
 var ciliumKubCLICommands = map[string]string{
-	"cilium endpoint list -o json":          "endpoint_list.txt",
-	"cilium service list -o json":           "service_list.txt",
-	"cilium config":                         "config.txt",
-	"cilium bpf lb list":                    "bpf_lb_list.txt",
-	"cilium bpf ct list global":             "bpf_ct_list.txt",
-	"cilium bpf tunnel list":                "bpf_tunnel_list.txt",
-	"cilium policy get":                     "policy_get.txt",
-	"cilium status --all-controllers":       "status.txt",
+	"cilium endpoint list -o json":    "endpoint_list.txt",
+	"cilium service list -o json":     "service_list.txt",
+	"cilium config":                   "config.txt",
+	"cilium bpf lb list":              "bpf_lb_list.txt",
+	"cilium bpf ct list global":       "bpf_ct_list.txt",
+	"cilium bpf tunnel list":          "bpf_tunnel_list.txt",
+	"cilium policy get":               "policy_get.txt",
+	"cilium status --all-controllers": "status.txt",
+}
+
+// ciliumKubCLICommandsKVStore contains commands related to querying the kvstore.
+// It is separate from ciliumKubCLICommands because it has a higher likelihood
+// of timing out in our CI, so we want to run it separately. Otherwise, we might
+// lose out on getting other critical debugging output when a test fails.
+var ciliumKubCLICommandsKVStore = map[string]string{
 	"cilium kvstore get cilium --recursive": "kvstore_get.txt",
 }
 

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1746,11 +1746,16 @@ func (kub *Kubectl) DumpCiliumCommandOutput(ctx context.Context, namespace strin
 			return
 		}
 
-		reportCmds := map[string]string{}
-		for cmd, logfile := range ciliumKubCLICommands {
-			command := fmt.Sprintf("%s exec -n %s %s -- %s", KubectlCmd, namespace, pod, cmd)
-			reportCmds[command] = fmt.Sprintf("%s_%s", pod, logfile)
+		genReportCmds := func(cliCmds map[string]string) map[string]string {
+			reportCmds := map[string]string{}
+			for cmd, logfile := range cliCmds {
+				command := fmt.Sprintf("%s exec -n %s %s -- %s", KubectlCmd, namespace, pod, cmd)
+				reportCmds[command] = fmt.Sprintf("%s_%s", pod, logfile)
+			}
+			return reportCmds
 		}
+
+		reportCmds := genReportCmds(ciliumKubCLICommands)
 		reportMapContext(ctx, testPath, reportCmds, kub.SSHMeta)
 
 		logsPath := filepath.Join(BasePath, testPath)
@@ -1799,6 +1804,19 @@ func (kub *Kubectl) DumpCiliumCommandOutput(ctx context.Context, namespace strin
 			//Remove bugtool artifact, so it'll be not used if any other fail test
 			_ = kub.ExecPodCmdContext(ctx, KubeSystemNamespace, pod, fmt.Sprintf("rm /tmp/%s", line))
 		}
+
+		// Finally, get kvstore output - this is best effort; we do this last
+		// because if connectivity to the kvstore is broken from a cilium pod,
+		// we don't want the context above to timeout and as a result, get none
+		// of the other logs from the tests.
+
+		// Use a shorter context for kvstore-related commands to avoid having
+		// further log-gathering fail as well if the first Cilium pod fails to
+		// gather kvstore logs.
+		kvstoreCmdCtx, cancel := context.WithTimeout(ctx, MidCommandTimeout)
+		defer cancel()
+		reportCmds = genReportCmds(ciliumKubCLICommandsKVStore)
+		reportMapContext(kvstoreCmdCtx, testPath, reportCmds, kub.SSHMeta)
 	}
 
 	pods, err := kub.GetCiliumPodsContext(ctx, namespace)


### PR DESCRIPTION
Log gathering is bounded by a timeout through a Context, so that the CI does
not get stuck if a single operation takes a long amount of time. However, if
one of the commands when gathering logs in the CI takes an inordinate amount
of time, all subsequent log-gathering commands will fail, because the Context's
deadline will have been reached. In a few CI runs, it has been observed that the
command to get the output from the kvstore has timed out, which is symptomatic
of broken connectivity to the kvstore from a given Cilium agent. Because this
command was ran as one of the first commands when gathering logs, if it timed
out, a lot of additional logs (e.g., bugtool, specific dumps, etc.) were not
performed because of the deadline being reached. So, this commit separates out
the kvstore log-gathering to be the file step of the log-gathering process in
the CI, so that if it times out, it will not affect gathering of other logs.
That way, if kvstore connectivity is messed up, we can have more actionable data
(bugtool, logs, etc.) to help debug the underlying issue.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8755)
<!-- Reviewable:end -->
