### PR TITLE
ginkgo: Fix CiliumReport calls

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -172,10 +172,21 @@ func (kub *Kubectl) ExecPodCmd(namespace string, pod string, cmd string, options
 	return kub.Exec(command, options...)
 }
 
-// ExecPodCmdContext executes command cmd in background in the specified pod residing
+// ExecPodCmdContext synchronously executes command cmd in the specified pod residing in the
+// specified namespace. It returns a pointer to CmdRes with all the output.
+func (kub *Kubectl) ExecPodCmdContext(ctx context.Context, namespace string, pod string, cmd string, options ...ExecOptions) *CmdRes {
+	command := fmt.Sprintf("%s exec -n %s %s -- %s", KubectlCmd, namespace, pod, cmd)
+	return kub.ExecContext(ctx, command, options...)
+}
+
+// ExecPodCmdBackground executes command cmd in background in the specified pod residing
 // in the specified namespace. It returns a pointer to CmdRes with all the
 // output
-func (kub *Kubectl) ExecPodCmdContext(ctx context.Context, namespace string, pod string, cmd string, options ...ExecOptions) *CmdRes {
+//
+// To receive the output of this function, the caller must invoke either
+// kub.WaitUntilFinish() or kub.WaitUntilMatch() then subsequently fetch the
+// output out of the result.
+func (kub *Kubectl) ExecPodCmdBackground(ctx context.Context, namespace string, pod string, cmd string, options ...ExecOptions) *CmdRes {
 	command := fmt.Sprintf("%s exec -n %s %s -- %s", KubectlCmd, namespace, pod, cmd)
 	return kub.ExecInBackground(ctx, command, options...)
 }
@@ -1541,14 +1552,21 @@ func (kub *Kubectl) CiliumReport(namespace string, commands ...string) {
 	res := kub.ExecContextShort(ctx, fmt.Sprintf("%s get pods -o wide --all-namespaces", KubectlCmd))
 	ginkgoext.GinkgoPrint(res.GetDebugMessage())
 
+	results := make([]*CmdRes, 0, len(pods)*len(commands))
+	ginkgoext.GinkgoPrint("Fetching command output from pods %s", pods)
 	for _, pod := range pods {
 		for _, cmd := range commands {
-			res = kub.ExecPodCmdContext(ctx, namespace, pod, cmd, ExecOptions{SkipLog: true})
-			ginkgoext.GinkgoPrint(res.GetDebugMessage())
+			res = kub.ExecPodCmdBackground(ctx, namespace, pod, cmd, ExecOptions{SkipLog: true})
+			results = append(results, res)
 		}
 	}
 
 	wg.Wait()
+
+	for _, res := range results {
+		res.WaitUntilFinish()
+		ginkgoext.GinkgoPrint(res.GetDebugMessage())
+	}
 }
 
 // EtcdOperatorReport dump etcd pods data into the report directory to be able
@@ -1797,7 +1815,7 @@ func (kub *Kubectl) DumpCiliumCommandOutput(ctx context.Context, namespace strin
 				continue
 			}
 			//Remove bugtool artifact, so it'll be not used if any other fail test
-			_ = kub.ExecPodCmdContext(ctx, KubeSystemNamespace, pod, fmt.Sprintf("rm /tmp/%s", line))
+			_ = kub.ExecPodCmdBackground(ctx, KubeSystemNamespace, pod, fmt.Sprintf("rm /tmp/%s", line))
 		}
 	}
 

--- a/test/k8sT/Chaos.go
+++ b/test/k8sT/Chaos.go
@@ -224,7 +224,7 @@ var _ = Describe("K8sChaosTest", func() {
 		It("TCP connection is not dropped when cilium restarts", func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			res := kubectl.ExecPodCmdContext(
+			res := kubectl.ExecPodCmdBackground(
 				ctx,
 				helpers.DefaultNamespace,
 				netperfClient,
@@ -242,7 +242,7 @@ var _ = Describe("K8sChaosTest", func() {
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			res := kubectl.ExecPodCmdContext(
+			res := kubectl.ExecPodCmdBackground(
 				ctx,
 				helpers.DefaultNamespace,
 				netperfClient,

--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -271,11 +271,11 @@ var _ = Describe("NightlyEpsMeasurement", func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			serverctx := kubectl.ExecPodCmdContext(ctx, helpers.DefaultNamespace, server, ncServer)
+			serverctx := kubectl.ExecPodCmdBackground(ctx, helpers.DefaultNamespace, server, ncServer)
 			err = serverctx.WaitUntilMatch(listeningString)
 			Expect(err).To(BeNil(), "netcat server did not start correctly")
 
-			_ = kubectl.ExecPodCmdContext(ctx, helpers.DefaultNamespace, client, ncClient)
+			_ = kubectl.ExecPodCmdBackground(ctx, helpers.DefaultNamespace, client, ncClient)
 
 			testNcConnectivity := func(sleep time.Duration) {
 				helpers.Sleep(sleep)


### PR DESCRIPTION
CiliumReport function calls have been failing for a little while now,
in a way that provides no output and appears to show success of running
the command:
    
      cmd: kubectl exec -n kube-system cilium-ghm8l -- cilium service list
      Exitcode: 0
      Stdout:
    
      Stderr:
    
Fix this by accumulating a slice of results from various commands that are run, then iterating over the results to wait for them to complete and retrieve their output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8765)
<!-- Reviewable:end -->
