### PR TITLE
ipam: eni: Resolve bootstrap misorder to create CiliumNode CR for ENI

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1123,3 +1123,9 @@ func (d *Daemon) GetNodeSuffix() string {
 func (d *Daemon) GetNetConf() *cnitypes.NetConf {
 	return d.netConf
 }
+
+// UpdateCiliumNodeResource implements nodediscovery.Owner to create/update the
+// CiliumNode resource
+func (d *Daemon) UpdateCiliumNodeResource() {
+	d.nodeDiscovery.UpdateCiliumNodeResource(d)
+}

--- a/pkg/ipam/allocator_test.go
+++ b/pkg/ipam/allocator_test.go
@@ -29,6 +29,7 @@ type ownerMock struct{}
 
 func (o *ownerMock) K8sEventReceived(scope string, action string, valid, equal bool) {}
 func (o *ownerMock) K8sEventProcessed(scope string, action string, status bool)      {}
+func (o *ownerMock) UpdateCiliumNodeResource()                                       {}
 
 func (s *IPAMSuite) TestAllocatedIPDump(c *C) {
 	fakeAddressing := fake.NewNodeAddressing()

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -93,6 +93,10 @@ func newNodeStore(nodeName string, owner Owner) *nodeStore {
 	}
 	store.refreshTrigger = t
 
+	// Create the CiliumNode custom resource. This call will block until
+	// the custom resource has been created
+	owner.UpdateCiliumNodeResource()
+
 	ciliumNodeSelector := fields.ParseSelectorOrDie("metadata.name=" + nodeName)
 	ciliumNodeStore := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
 	ciliumNodeInformer := informer.NewInformerWithStore(

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -66,6 +66,11 @@ type Owner interface {
 	// K8sEventProcessed is called to do metrics accounting for each processed
 	// Kubernetes event
 	K8sEventProcessed(scope string, action string, status bool)
+
+	// UpdateCiliumNodeResource is called to create/update the CiliumNode
+	// resource. The function must block until the custom resource has been
+	// created.
+	UpdateCiliumNodeResource()
 }
 
 // NewIPAM returns a new IP address manager

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -178,9 +178,9 @@ func (n *NodeDiscovery) StartDiscovery(nodeName string, conf Configuration) {
 	}()
 
 	if k8s.IsEnabled() {
-		// Creation of the CiliumNode can be done in the background,
-		// nothing depends on the completion of this.
-		go n.createCiliumNodeResource(conf)
+		// Creation or update of the CiliumNode can be done in the
+		// background, nothing depends on the completion of this.
+		go n.UpdateCiliumNodeResource(conf)
 	}
 
 	if option.Config.KVStore != "" {
@@ -205,7 +205,9 @@ func (n *NodeDiscovery) Close() {
 	n.Manager.Close()
 }
 
-func (n *NodeDiscovery) createCiliumNodeResource(conf Configuration) {
+// UpdateCiliumNodeResource updates the CiliumNode resource representing the
+// local node
+func (n *NodeDiscovery) UpdateCiliumNodeResource(conf Configuration) {
 	if !option.Config.AutoCreateCiliumNodeResource {
 		return
 	}


### PR DESCRIPTION
Commit cb0d869b9d6 has moved the creation of the CiliumNode CR into the
nodediscovery package to allow inclusion of health and node IP addresses. This
created a deadlock on bootstrap as nodediscovery is only performed after IPAM
init. IPAM init for CRD depends on the creation of the CR in the ENI scenario.

Export the update call and create the CR in the ENI IPAM init code and then
update it in the nodediscovery case.

Fixes: cb0d869b9d6 ("nodediscovery: Create CiliumNode from the nodediscovery package")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8768)
<!-- Reviewable:end -->
