### PR TITLE
refactor loader into a type and hide it behind Datapath interface

### DIFF
--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -39,7 +39,6 @@ import (
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/datapath/iptables"
 	linuxdatapath "github.com/cilium/cilium/pkg/datapath/linux"
-	"github.com/cilium/cilium/pkg/datapath/loader"
 	"github.com/cilium/cilium/pkg/datapath/maps"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/envoy"
@@ -1389,7 +1388,7 @@ func runDaemon() {
 	if option.Config.IsFlannelMasterDeviceSet() && option.Config.FlannelUninstallOnExit {
 		cleanup.DeferTerminationCleanupFunction(cleanUPWg, cleanUPSig, func() {
 			d.compilationMutex.Lock()
-			loader.DeleteDatapath(context.Background(), option.FlannelMasterDevice, "egress")
+			d.Datapath().Loader().DeleteDatapath(context.Background(), option.FlannelMasterDevice, "egress")
 			d.compilationMutex.Unlock()
 		})
 	}

--- a/daemon/datapath.go
+++ b/daemon/datapath.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cilium/cilium/pkg/cgroups"
 	"github.com/cilium/cilium/pkg/command/exec"
 	"github.com/cilium/cilium/pkg/datapath/alignchecker"
-	"github.com/cilium/cilium/pkg/datapath/loader"
 	"github.com/cilium/cilium/pkg/datapath/prefilter"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/endpointmanager"
@@ -54,7 +53,7 @@ func (d *Daemon) compileBase() error {
 		log.WithError(err).Warn("Unable to write netdev header")
 		return err
 	}
-	loader.Init(d.datapath, &d.nodeDiscovery.LocalConfig)
+	d.datapath.Loader().Init(d.datapath, &d.nodeDiscovery.LocalConfig)
 
 	scopedLog := log.WithField(logfields.XDPDevice, option.Config.DevicePreFilter)
 	if option.Config.DevicePreFilter != "undefined" {

--- a/pkg/datapath/config.go
+++ b/pkg/datapath/config.go
@@ -15,6 +15,8 @@
 package datapath
 
 import (
+	"io"
+
 	"github.com/cilium/cilium/common/addressing"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/mac"
@@ -72,4 +74,26 @@ type EndpointConfiguration interface {
 	// per endpoint route installed in the host's routing table to point to
 	// the endpoint's interface
 	RequireEndpointRoute() bool
+}
+
+// ConfigWriter is anything which writes the configuration for various datapath
+// program types.
+type ConfigWriter interface {
+	// WriteNodeConfig writes the implementation-specific configuration of
+	// node-wide options into the specified writer.
+	WriteNodeConfig(io.Writer, *LocalNodeConfiguration) error
+
+	// WriteNetdevConfig writes the implementation-specific configuration
+	// of configurable options to the specified writer. Options specified
+	// here will apply to base programs and not to endpoints, though
+	// endpoints may have equivalent configurable options.
+	WriteNetdevConfig(io.Writer, DeviceConfiguration) error
+
+	// WriteTemplateConfig writes the implementation-specific configuration
+	// of configurable options for BPF templates to the specified writer.
+	WriteTemplateConfig(w io.Writer, cfg EndpointConfiguration) error
+
+	// WriteEndpointConfig writes the implementation-specific configuration
+	// of configurable options for the endpoint to the specified writer.
+	WriteEndpointConfig(w io.Writer, cfg EndpointConfiguration) error
 }

--- a/pkg/datapath/datapath.go
+++ b/pkg/datapath/datapath.go
@@ -34,4 +34,8 @@ type Datapath interface {
 	// RemoveProxyRules creates the necessary datapath config (e.g., iptables
 	// rules for redirecting host proxy traffic on a specific ProxyPort)
 	RemoveProxyRules(proxyPort uint16, ingress bool, name string) error
+
+	// Loader must return the implementation of the loader, which is responsible
+	// for loading, reloading, and compiling datapath programs.
+	Loader() Loader
 }

--- a/pkg/datapath/datapath.go
+++ b/pkg/datapath/datapath.go
@@ -14,38 +14,18 @@
 
 package datapath
 
-import (
-	"io"
-)
-
 // Datapath is the interface to abstract all datapath interactions. The
 // abstraction allows to implement the datapath requirements with multiple
 // implementations
 type Datapath interface {
+	ConfigWriter
+
 	// Node must return the handler for node events
 	Node() NodeHandler
 
 	// LocalNodeAddressing must return the node addressing implementation
 	// of the local node
 	LocalNodeAddressing() NodeAddressing
-
-	// WriteNodeConfig writes the implementation-specific configuration of
-	// node-wide options into the specified writer.
-	WriteNodeConfig(io.Writer, *LocalNodeConfiguration) error
-
-	// WriteNetdevConfig writes the implementation-specific configuration
-	// of configurable options to the specified writer. Options specified
-	// here will apply to base programs and not to endpoints, though
-	// endpoints may have equivalent configurable options.
-	WriteNetdevConfig(io.Writer, DeviceConfiguration) error
-
-	// WriteTemplateConfig writes the implementation-specific configuration
-	// of configurable options for BPF templates to the specified writer.
-	WriteTemplateConfig(w io.Writer, cfg EndpointConfiguration) error
-
-	// WriteEndpointConfig writes the implementation-specific configuration
-	// of configurable options for the endpoint to the specified writer.
-	WriteEndpointConfig(w io.Writer, cfg EndpointConfiguration) error
 
 	// InstallProxyRules creates the necessary datapath config (e.g., iptables
 	// rules for redirecting host proxy traffic on a specific ProxyPort)

--- a/pkg/datapath/endpoint.go
+++ b/pkg/datapath/endpoint.go
@@ -1,0 +1,27 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datapath
+
+import "github.com/sirupsen/logrus"
+
+// Endpoint provides access endpoint configuration information that is necessary
+// to compile and load the datapath.
+type Endpoint interface {
+	EndpointConfiguration
+	InterfaceName() string
+	Logger(subsystem string) *logrus.Entry
+	StateDir() string
+	MapPath() string
+}

--- a/pkg/datapath/fake/datapath.go
+++ b/pkg/datapath/fake/datapath.go
@@ -71,3 +71,7 @@ func (f *fakeDatapath) InstallProxyRules(uint16, bool, string) error {
 func (f *fakeDatapath) RemoveProxyRules(uint16, bool, string) error {
 	return nil
 }
+
+func (f *fakeDatapath) Loader() datapath.Loader {
+	return nil
+}

--- a/pkg/datapath/linux/config/config_test.go
+++ b/pkg/datapath/linux/config/config_test.go
@@ -14,13 +14,14 @@
 
 // +build privileged_tests
 
-package linux
+package config
 
 import (
 	"bytes"
 	"errors"
 	"io"
 	"strings"
+	"testing"
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/datapath"
@@ -31,10 +32,14 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-type DatapathSuite struct{}
+type ConfigSuite struct{}
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
 
 var (
-	_ = Suite(&DatapathSuite{})
+	_ = Suite(&ConfigSuite{})
 
 	dummyNodeCfg  = datapath.LocalNodeConfiguration{}
 	dummyDevCfg   = testutils.NewTestEndpoint()
@@ -42,7 +47,7 @@ var (
 	ipv4DummyAddr = []byte{192, 0, 2, 3}
 )
 
-func (s *DatapathSuite) SetUpTest(c *C) {
+func (s *ConfigSuite) SetUpTest(c *C) {
 	err := bpf.ConfigureResourceLimits()
 	c.Assert(err, IsNil)
 	node.InitDefaultPrefix("")
@@ -50,7 +55,7 @@ func (s *DatapathSuite) SetUpTest(c *C) {
 	node.SetIPv4Loopback(ipv4DummyAddr)
 }
 
-func (s *DatapathSuite) TearDownTest(c *C) {
+func (s *ConfigSuite) TearDownTest(c *C) {
 	node.SetInternalIPv4(nil)
 	node.SetIPv4Loopback(nil)
 }
@@ -61,7 +66,7 @@ func (b *badWriter) Write(p []byte) (int, error) {
 	return 0, errors.New("bad write :(")
 }
 
-type writeFn func(io.Writer, datapath.Datapath) error
+type writeFn func(io.Writer, datapath.ConfigWriter) error
 
 func writeConfig(c *C, header string, write writeFn) {
 	tests := []struct {
@@ -82,37 +87,37 @@ func writeConfig(c *C, header string, write writeFn) {
 	}
 	for _, test := range tests {
 		c.Logf("  Testing %s configuration: %s", header, test.description)
-		dp := NewDatapath(DatapathConfiguration{}, nil)
-		c.Assert(write(test.output, dp), test.expResult)
+		cfg := &HeaderfileWriter{}
+		c.Assert(write(test.output, cfg), test.expResult)
 	}
 }
 
-func (s *DatapathSuite) TestWriteNodeConfig(c *C) {
-	writeConfig(c, "node", func(w io.Writer, dp datapath.Datapath) error {
+func (s *ConfigSuite) TestWriteNodeConfig(c *C) {
+	writeConfig(c, "node", func(w io.Writer, dp datapath.ConfigWriter) error {
 		return dp.WriteNodeConfig(w, &dummyNodeCfg)
 	})
 }
 
-func (s *DatapathSuite) TestWriteNetdevConfig(c *C) {
-	writeConfig(c, "netdev", func(w io.Writer, dp datapath.Datapath) error {
+func (s *ConfigSuite) TestWriteNetdevConfig(c *C) {
+	writeConfig(c, "netdev", func(w io.Writer, dp datapath.ConfigWriter) error {
 		return dp.WriteNetdevConfig(w, &dummyDevCfg)
 	})
 }
 
-func (s *DatapathSuite) TestWriteEndpointConfig(c *C) {
-	writeConfig(c, "endpoint", func(w io.Writer, dp datapath.Datapath) error {
+func (s *ConfigSuite) TestWriteEndpointConfig(c *C) {
+	writeConfig(c, "endpoint", func(w io.Writer, dp datapath.ConfigWriter) error {
 		return dp.WriteEndpointConfig(w, &dummyEPCfg)
 	})
 }
 
-func (s *DatapathSuite) TestWriteStaticData(c *C) {
-	dp := NewDatapath(DatapathConfiguration{}, nil).(*linuxDatapath)
+func (s *ConfigSuite) TestWriteStaticData(c *C) {
+	cfg := &HeaderfileWriter{}
 	ep := &dummyEPCfg
 
 	varSub, stringSub := loader.ELFSubstitutions(ep)
 
 	var buf bytes.Buffer
-	dp.writeStaticData(&buf, ep)
+	cfg.writeStaticData(&buf, ep)
 	b := buf.Bytes()
 	for k := range varSub {
 		for _, suffix := range []string{"_1", "_2", "_3", "_4"} {

--- a/pkg/datapath/linux/config/utils.go
+++ b/pkg/datapath/linux/config/utils.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package linux
+package config
 
 import (
 	"fmt"

--- a/pkg/datapath/linux/config/utils_test.go
+++ b/pkg/datapath/linux/config/utils_test.go
@@ -14,24 +14,30 @@
 
 // +build !privileged_tests
 
-package linux
+package config
 
 import (
+	"testing"
+
 	. "gopkg.in/check.v1"
 )
 
-type DatapathSuite struct{}
+type ConfigSuite struct{}
 
 var (
-	_ = Suite(&DatapathSuite{})
+	_ = Suite(&ConfigSuite{})
 )
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
 
 type formatTestCase struct {
 	input  []byte
 	output string
 }
 
-func (s *DatapathSuite) TestGoArray2C(c *C) {
+func (s *ConfigSuite) TestGoArray2C(c *C) {
 	tests := []formatTestCase{
 		{
 			input:  []byte{0, 0x01, 0x02, 0x03},
@@ -60,7 +66,7 @@ func (s *DatapathSuite) TestGoArray2C(c *C) {
 	}
 }
 
-func (s *DatapathSuite) TestdefineIPv6(c *C) {
+func (s *ConfigSuite) TestdefineIPv6(c *C) {
 	tests := []formatTestCase{
 		{
 			input:  nil,
@@ -85,7 +91,7 @@ func (s *DatapathSuite) TestdefineIPv6(c *C) {
 	}
 }
 
-func (s *DatapathSuite) TestdefineMAC(c *C) {
+func (s *ConfigSuite) TestdefineMAC(c *C) {
 	tests := []formatTestCase{
 		{
 			input:  nil,

--- a/pkg/datapath/linux/datapath.go
+++ b/pkg/datapath/linux/datapath.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/datapath/linux/config"
+	"github.com/cilium/cilium/pkg/datapath/loader"
 	"github.com/cilium/cilium/pkg/endpoint/connector"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
@@ -42,6 +43,7 @@ type linuxDatapath struct {
 	nodeAddressing datapath.NodeAddressing
 	config         DatapathConfiguration
 	configWriter   *config.HeaderfileWriter
+	loader         *loader.Loader
 	ruleManager    rulesManager
 }
 
@@ -51,6 +53,7 @@ func NewDatapath(cfg DatapathConfiguration, ruleManager rulesManager) datapath.D
 		nodeAddressing: NewNodeAddressing(),
 		config:         cfg,
 		configWriter:   &config.HeaderfileWriter{},
+		loader:         &loader.Loader{},
 		ruleManager:    ruleManager,
 	}
 
@@ -98,4 +101,8 @@ func (l *linuxDatapath) WriteNetdevConfig(w io.Writer, cfg datapath.DeviceConfig
 
 func (l *linuxDatapath) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeConfiguration) error {
 	return l.configWriter.WriteNodeConfig(w, cfg)
+}
+
+func (l *linuxDatapath) Loader() datapath.Loader {
+	return l.loader
 }

--- a/pkg/datapath/linux/datapath.go
+++ b/pkg/datapath/linux/datapath.go
@@ -15,8 +15,6 @@
 package linux
 
 import (
-	"io"
-
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/datapath/linux/config"
 	"github.com/cilium/cilium/pkg/datapath/loader"
@@ -39,6 +37,7 @@ type rulesManager interface {
 }
 
 type linuxDatapath struct {
+	datapath.ConfigWriter
 	node           datapath.NodeHandler
 	nodeAddressing datapath.NodeAddressing
 	config         DatapathConfiguration
@@ -52,7 +51,7 @@ func NewDatapath(cfg DatapathConfiguration, ruleManager rulesManager) datapath.D
 	dp := &linuxDatapath{
 		nodeAddressing: NewNodeAddressing(),
 		config:         cfg,
-		configWriter:   &config.HeaderfileWriter{},
+		ConfigWriter:   &config.HeaderfileWriter{},
 		loader:         &loader.Loader{},
 		ruleManager:    ruleManager,
 	}
@@ -85,22 +84,6 @@ func (l *linuxDatapath) InstallProxyRules(proxyPort uint16, ingress bool, name s
 
 func (l *linuxDatapath) RemoveProxyRules(proxyPort uint16, ingress bool, name string) error {
 	return l.ruleManager.RemoveProxyRules(proxyPort, ingress, name)
-}
-
-func (l *linuxDatapath) WriteTemplateConfig(w io.Writer, e datapath.EndpointConfiguration) error {
-	return l.configWriter.WriteTemplateConfig(w, e)
-}
-
-func (l *linuxDatapath) WriteEndpointConfig(w io.Writer, e datapath.EndpointConfiguration) error {
-	return l.configWriter.WriteEndpointConfig(w, e)
-}
-
-func (l *linuxDatapath) WriteNetdevConfig(w io.Writer, cfg datapath.DeviceConfiguration) error {
-	return l.configWriter.WriteNetdevConfig(w, cfg)
-}
-
-func (l *linuxDatapath) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeConfiguration) error {
-	return l.configWriter.WriteNodeConfig(w, cfg)
 }
 
 func (l *linuxDatapath) Loader() datapath.Loader {

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"testing"
 
+	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/datapath/fake"
@@ -68,6 +69,7 @@ const (
 )
 
 func (s *linuxPrivilegedBaseTestSuite) SetUpTest(c *check.C, addressing datapath.NodeAddressing, enableIPv6, enableIPv4 bool) {
+	bpf.ConfigureResourceLimits()
 	s.nodeAddressing = addressing
 	s.mtuConfig = mtu.NewConfiguration(0, false, false, 1500)
 	s.enableIPv6 = enableIPv6

--- a/pkg/datapath/loader.go
+++ b/pkg/datapath/loader.go
@@ -1,1 +1,33 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package datapath
+
+import (
+	"context"
+
+	"github.com/cilium/cilium/pkg/datapath/loader/metrics"
+)
+
+// Loader is an interface to abstract out loading of datapath programs.
+type Loader interface {
+	CallsMapPath(id uint16) string
+	CompileAndLoad(ctx context.Context, ep Endpoint, stats *metrics.SpanStat) error
+	CompileOrLoad(ctx context.Context, ep Endpoint, stats *metrics.SpanStat) error
+	ReloadDatapath(ctx context.Context, ep Endpoint, stats *metrics.SpanStat) error
+	EndpointHash(cfg EndpointConfiguration) (string, error)
+	DeleteDatapath(ctx context.Context, ifName, direction string) error
+	Unload(ep Endpoint)
+	Init(d ConfigWriter, nodeCfg *LocalNodeConfiguration)
+}

--- a/pkg/datapath/loader.go
+++ b/pkg/datapath/loader.go
@@ -1,0 +1,1 @@
+package datapath

--- a/pkg/datapath/loader/cache_test.go
+++ b/pkg/datapath/loader/cache_test.go
@@ -23,7 +23,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/cilium/cilium/pkg/datapath/linux"
+	"github.com/cilium/cilium/pkg/datapath/linux/config"
 	"github.com/cilium/cilium/pkg/testutils"
 
 	. "gopkg.in/check.v1"
@@ -37,7 +37,7 @@ func (s *LoaderTestSuite) TestobjectCache(c *C) {
 	ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
 	defer cancel()
 
-	cache := newObjectCache(linux.NewDatapath(linux.DatapathConfiguration{}, nil), nil, tmpDir)
+	cache := newObjectCache(&config.HeaderfileWriter{}, nil, tmpDir)
 	realEP := testutils.NewTestEndpoint()
 
 	// First run should compile and generate the object.
@@ -116,7 +116,7 @@ func (s *LoaderTestSuite) TestobjectCacheParallel(c *C) {
 		c.Logf("  %s", t.description)
 
 		results := make(chan buildResult, t.builds)
-		cache := newObjectCache(linux.NewDatapath(linux.DatapathConfiguration{}, nil), nil, tmpDir)
+		cache := newObjectCache(&config.HeaderfileWriter{}, nil, tmpDir)
 		for i := 0; i < t.builds; i++ {
 			go func(i int) {
 				ep := testutils.NewTestEndpoint()

--- a/pkg/datapath/loader/hash.go
+++ b/pkg/datapath/loader/hash.go
@@ -48,18 +48,18 @@ func newDatapathHash() *datapathHash {
 // The endpoint's static data is NOT included in this hash, for that perform:
 //	hash := hashDatapath(dp, nodeCfg, netdevCfg, ep)
 //	hashStr := hash.sumEndpoint(ep)
-func hashDatapath(dp datapath.Datapath, nodeCfg *datapath.LocalNodeConfiguration, netdevCfg datapath.DeviceConfiguration, epCfg datapath.EndpointConfiguration) *datapathHash {
+func hashDatapath(c datapath.ConfigWriter, nodeCfg *datapath.LocalNodeConfiguration, netdevCfg datapath.DeviceConfiguration, epCfg datapath.EndpointConfiguration) *datapathHash {
 	d := newDatapathHash()
 
 	// Writes won't fail; it's an in-memory hash.
 	if nodeCfg != nil {
-		_ = dp.WriteNodeConfig(d, nodeCfg)
+		_ = c.WriteNodeConfig(d, nodeCfg)
 	}
 	if netdevCfg != nil {
-		_ = dp.WriteNetdevConfig(d, netdevCfg)
+		_ = c.WriteNetdevConfig(d, netdevCfg)
 	}
 	if epCfg != nil {
-		_ = dp.WriteTemplateConfig(d, epCfg)
+		_ = c.WriteTemplateConfig(d, epCfg)
 	}
 
 	return d
@@ -67,15 +67,15 @@ func hashDatapath(dp datapath.Datapath, nodeCfg *datapath.LocalNodeConfiguration
 
 // sumEndpoint returns the hash of the complete datapath for an endpoint.
 // It does not change the underlying hash state.
-func (d *datapathHash) sumEndpoint(dp datapath.Datapath, epCfg datapath.EndpointConfiguration, staticData bool) (string, error) {
+func (d *datapathHash) sumEndpoint(c datapath.ConfigWriter, epCfg datapath.EndpointConfiguration, staticData bool) (string, error) {
 	result, err := d.Copy()
 	if err != nil {
 		return "", err
 	}
 	if staticData {
-		dp.WriteEndpointConfig(result, epCfg)
+		c.WriteEndpointConfig(result, epCfg)
 	} else {
-		dp.WriteTemplateConfig(result, epCfg)
+		c.WriteTemplateConfig(result, epCfg)
 	}
 	return result.String(), nil
 }

--- a/pkg/datapath/loader/hash_test.go
+++ b/pkg/datapath/loader/hash_test.go
@@ -18,7 +18,7 @@ package loader
 
 import (
 	"github.com/cilium/cilium/pkg/datapath"
-	"github.com/cilium/cilium/pkg/datapath/linux"
+	"github.com/cilium/cilium/pkg/datapath/linux/config"
 	"github.com/cilium/cilium/pkg/testutils"
 
 	. "gopkg.in/check.v1"
@@ -33,12 +33,12 @@ var (
 // TesthashDatapath is done in this package just for easy access to dummy
 // configuration objects.
 func (s *LoaderTestSuite) TesthashDatapath(c *C) {
-	dp := linux.NewDatapath(linux.DatapathConfiguration{}, nil)
+	cfg := &config.HeaderfileWriter{}
 	h := newDatapathHash()
 	baseHash := h.String()
 
 	// Ensure we get different hashes when config is added
-	h = hashDatapath(dp, &dummyNodeCfg, &dummyDevCfg, &dummyEPCfg)
+	h = hashDatapath(cfg, &dummyNodeCfg, &dummyDevCfg, &dummyEPCfg)
 	dummyHash := h.String()
 	c.Assert(dummyHash, Not(Equals), baseHash)
 
@@ -49,7 +49,7 @@ func (s *LoaderTestSuite) TesthashDatapath(c *C) {
 
 	// Ensure that with a copy of the endpoint config we get the same hash
 	newEPCfg := dummyEPCfg
-	h = hashDatapath(dp, &dummyNodeCfg, &dummyDevCfg, &newEPCfg)
+	h = hashDatapath(cfg, &dummyNodeCfg, &dummyDevCfg, &newEPCfg)
 	c.Assert(h.String(), Not(Equals), baseHash)
 	c.Assert(h.String(), Equals, dummyHash)
 
@@ -58,14 +58,14 @@ func (s *LoaderTestSuite) TesthashDatapath(c *C) {
 	// This is the key to avoiding recompilation per endpoint; static
 	// data substitution is performed via pkg/elf instead.
 	newEPCfg.Id++
-	h = hashDatapath(dp, &dummyNodeCfg, &dummyDevCfg, &newEPCfg)
+	h = hashDatapath(cfg, &dummyNodeCfg, &dummyDevCfg, &newEPCfg)
 	c.Assert(h.String(), Not(Equals), baseHash)
 	c.Assert(h.String(), Equals, dummyHash)
 
 	// But when we configure the endpoint differently, it's different
 	newEPCfg = testutils.NewTestEndpoint()
 	newEPCfg.Opts.SetBool("foo", true)
-	h = hashDatapath(dp, &dummyNodeCfg, &dummyDevCfg, &newEPCfg)
+	h = hashDatapath(cfg, &dummyNodeCfg, &dummyDevCfg, &newEPCfg)
 	c.Assert(h.String(), Not(Equals), baseHash)
 	c.Assert(h.String(), Not(Equals), dummyHash)
 }

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -49,10 +49,6 @@ const (
 	dirEgress  = "egress"
 )
 
-var (
-	globalLoader *Loader
-)
-
 // Loader is a wrapper structure around operations related to compiling,
 // loading, and reloading datapath programs.
 type Loader struct {
@@ -289,40 +285,4 @@ func (l *Loader) EndpointHash(cfg datapath.EndpointConfiguration) (string, error
 // CallsMapPath gets the BPF Calls Map for the endpoint with the specified ID.
 func (l *Loader) CallsMapPath(id uint16) string {
 	return bpf.LocalMapPath(CallsMapName, id)
-}
-
-// Init initializes the globalLoader.
-func Init(dp datapath.ConfigWriter, nodeCfg *datapath.LocalNodeConfiguration) {
-	globalLoader.Init(dp, nodeCfg)
-}
-
-// CompileAndLoad compiles the BPF datapath programs for the specified endpoint
-// and loads it onto the interface associated with the endpoint via the
-// globalLoader.
-func CompileAndLoad(ctx context.Context, ep datapath.Endpoint, stats *metrics.SpanStat) error {
-	return globalLoader.CompileAndLoad(ctx, ep, stats)
-}
-
-// CompileOrLoad loads the BPF datapath programs for the specified endpoint via
-// the globalLoader.
-func CompileOrLoad(ctx context.Context, ep datapath.Endpoint, stats *metrics.SpanStat) error {
-	return globalLoader.CompileOrLoad(ctx, ep, stats)
-}
-
-// ReloadDatapath reloads the BPF datapath pgorams for the specified endpoint
-// via the globalLoader.
-func ReloadDatapath(ctx context.Context, ep datapath.Endpoint, stats *metrics.SpanStat) error {
-	return globalLoader.ReloadDatapath(ctx, ep, stats)
-}
-
-// Unload removes the datapath specific program aspects for the package-level
-// globalLoader.
-func Unload(ep datapath.Endpoint) {
-	globalLoader.Unload(ep)
-}
-
-// EndpointHash hashes the specified endpoint configuration with the current
-// datapath hash cache and returns the hash as string via the globalLoader.
-func EndpointHash(cfg datapath.EndpointConfiguration) (string, error) {
-	return globalLoader.EndpointHash(cfg)
 }

--- a/pkg/datapath/loader/loader_test.go
+++ b/pkg/datapath/loader/loader_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/datapath/linux/config"
+	"github.com/cilium/cilium/pkg/datapath/loader/metrics"
 	"github.com/cilium/cilium/pkg/elf"
 	bpfconfig "github.com/cilium/cilium/pkg/maps/configmap"
 	"github.com/cilium/cilium/pkg/maps/policymap"
@@ -165,7 +166,7 @@ func getDirs(tmpDir string) *directoryInfo {
 func (s *LoaderTestSuite) TestCompileAndLoad(c *C) {
 	ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
 	defer cancel()
-	stats := &SpanStat{}
+	stats := &metrics.SpanStat{}
 
 	l := &Loader{}
 	err := l.compileAndLoad(ctx, &ep, dirInfo, stats)
@@ -209,7 +210,7 @@ func (s *LoaderTestSuite) TestCompileFailure(c *C) {
 	l := &Loader{}
 	timeout := time.Now().Add(contextTimeout)
 	var err error
-	stats := &SpanStat{}
+	stats := &metrics.SpanStat{}
 	for err == nil && time.Now().Before(timeout) {
 		err = l.compileAndLoad(ctx, &ep, dirInfo, stats)
 	}
@@ -232,7 +233,7 @@ func BenchmarkCompileOnly(b *testing.B) {
 
 // BenchmarkCompileAndLoad benchmarks the entire compilation + loading process.
 func BenchmarkCompileAndLoad(b *testing.B) {
-	stats := &SpanStat{}
+	stats := &metrics.SpanStat{}
 	ctx, cancel := context.WithTimeout(context.Background(), benchTimeout)
 	defer cancel()
 

--- a/pkg/datapath/loader/loader_test.go
+++ b/pkg/datapath/loader/loader_test.go
@@ -27,7 +27,8 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/pkg/bpf"
-	"github.com/cilium/cilium/pkg/datapath/linux"
+	"github.com/cilium/cilium/pkg/datapath/linux/config"
+	"github.com/cilium/cilium/pkg/datapath/loader/metrics"
 	"github.com/cilium/cilium/pkg/elf"
 	bpfconfig "github.com/cilium/cilium/pkg/maps/configmap"
 	"github.com/cilium/cilium/pkg/maps/policymap"
@@ -303,7 +304,8 @@ func BenchmarkCompileOrLoad(b *testing.B) {
 	}
 	defer os.RemoveAll(epDir)
 
-	templateCache = newObjectCache(linux.NewDatapath(linux.DatapathConfiguration{}, nil), nil, tmpDir)
+	l := &Loader{}
+	l.templateCache = newObjectCache(&config.HeaderfileWriter{}, nil, tmpDir)
 	if err := CompileOrLoad(ctx, &ep, nil); err != nil {
 		log.Warningf("Failure in %s: %s", tmpDir, err)
 		time.Sleep(1 * time.Minute)

--- a/pkg/datapath/loader/metrics/metrics.go
+++ b/pkg/datapath/loader/metrics/metrics.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package loader
+package metrics
 
 import (
 	"github.com/cilium/cilium/pkg/spanstat"
@@ -21,18 +21,18 @@ import (
 // SpanStat is a statistics structure for storing metrics related to datapath
 // load operations.
 type SpanStat struct {
-	bpfCompilation spanstat.SpanStat
-	bpfWaitForELF  spanstat.SpanStat
-	bpfWriteELF    spanstat.SpanStat
-	bpfLoadProg    spanstat.SpanStat
+	BpfCompilation spanstat.SpanStat
+	BpfWaitForELF  spanstat.SpanStat
+	BpfWriteELF    spanstat.SpanStat
+	BpfLoadProg    spanstat.SpanStat
 }
 
 // GetMap returns a map of statistic names to stats
 func (s *SpanStat) GetMap() map[string]*spanstat.SpanStat {
 	return map[string]*spanstat.SpanStat{
-		"bpfCompilation": &s.bpfCompilation,
-		"bpfWaitForELF":  &s.bpfWaitForELF,
-		"bpfWriteELF":    &s.bpfWriteELF,
-		"bpfLoadProg":    &s.bpfLoadProg,
+		"bpfCompilation": &s.BpfCompilation,
+		"bpfWaitForELF":  &s.BpfWaitForELF,
+		"bpfWriteELF":    &s.BpfWriteELF,
+		"bpfLoadProg":    &s.BpfLoadProg,
 	}
 }

--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -141,8 +141,3 @@ func (l *Loader) DeleteDatapath(ctx context.Context, ifName, direction string) e
 
 	return nil
 }
-
-// DeleteDatapath filter from the given ifName via the globalLoader
-func DeleteDatapath(ctx context.Context, ifName, direction string) error {
-	return globalLoader.DeleteDatapath(ctx, ifName, direction)
-}

--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -54,7 +54,7 @@ func replaceQdisc(ifName string) error {
 }
 
 // replaceDatapath the qdisc and BPF program for a endpoint
-func replaceDatapath(ctx context.Context, ifName, objPath, progSec, progDirection string) error {
+func (l *Loader) replaceDatapath(ctx context.Context, ifName, objPath, progSec, progDirection string) error {
 	err := replaceQdisc(ifName)
 	if err != nil {
 		return fmt.Errorf("Failed to replace Qdisc for %s: %s", ifName, err)
@@ -131,7 +131,7 @@ func graftDatapath(ctx context.Context, mapPath, objPath, progSec string) error 
 }
 
 // DeleteDatapath filter from the given ifName
-func DeleteDatapath(ctx context.Context, ifName, direction string) error {
+func (l *Loader) DeleteDatapath(ctx context.Context, ifName, direction string) error {
 	args := []string{"filter", "delete", "dev", ifName, direction, "pref", "1", "handle", "1", "bpf"}
 	cmd := exec.CommandContext(ctx, "tc", args...).WithFilters(libbpfFixupMsg)
 	_, err := cmd.CombinedOutput(log, true)
@@ -140,4 +140,9 @@ func DeleteDatapath(ctx context.Context, ifName, direction string) error {
 	}
 
 	return nil
+}
+
+// DeleteDatapath filter from the given ifName via the globalLoader
+func DeleteDatapath(ctx context.Context, ifName, direction string) error {
+	return globalLoader.DeleteDatapath(ctx, ifName, direction)
 }

--- a/pkg/datapath/loader/template.go
+++ b/pkg/datapath/loader/template.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/datapath"
+	"github.com/cilium/cilium/pkg/datapath/loader/metrics"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/mac"
 	bpfconfig "github.com/cilium/cilium/pkg/maps/configmap"
@@ -66,7 +67,7 @@ var (
 // as allowing traffic to leak out with routable addresses.
 type templateCfg struct {
 	datapath.EndpointConfiguration
-	stats *SpanStat
+	stats *metrics.SpanStat
 }
 
 // GetID returns a uint64, but in practice on the datapath side it is
@@ -117,9 +118,9 @@ func (t *templateCfg) IPv6Address() addressing.CiliumIPv6 {
 // it inside a templateCfg which hides static data from callers that wish to
 // generate header files based on the configuration, substituting it for
 // template data.
-func wrap(cfg datapath.EndpointConfiguration, stats *SpanStat) *templateCfg {
+func wrap(cfg datapath.EndpointConfiguration, stats *metrics.SpanStat) *templateCfg {
 	if stats == nil {
-		stats = &SpanStat{}
+		stats = &metrics.SpanStat{}
 	}
 	return &templateCfg{
 		EndpointConfiguration: cfg,

--- a/pkg/datapath/loader/template.go
+++ b/pkg/datapath/loader/template.go
@@ -131,7 +131,7 @@ func wrap(cfg datapath.EndpointConfiguration, stats *metrics.SpanStat) *template
 // elfMapSubstitutions returns the set of map substitutions that must occur in
 // an ELF template object file to update map references for the specified
 // endpoint.
-func elfMapSubstitutions(ep endpoint) map[string]string {
+func elfMapSubstitutions(ep datapath.Endpoint) map[string]string {
 	result := make(map[string]string)
 
 	epID := uint16(ep.GetID())
@@ -181,7 +181,7 @@ func sliceToBe32(input []byte) uint32 {
 // elfVariableSubstitutions returns the set of data substitutions that must
 // occur in an ELF template object file to update static data for the specified
 // endpoint.
-func elfVariableSubstitutions(ep endpoint) map[string]uint32 {
+func elfVariableSubstitutions(ep datapath.Endpoint) map[string]uint32 {
 	result := make(map[string]uint32)
 
 	if ipv6 := ep.IPv6Address(); ipv6 != nil {
@@ -210,6 +210,6 @@ func elfVariableSubstitutions(ep endpoint) map[string]uint32 {
 // ELFSubstitutions fetches the set of variable and map substitutions that
 // must be implemented against an ELF template to configure the datapath for
 // the specified endpoint.
-func ELFSubstitutions(ep endpoint) (map[string]uint32, map[string]string) {
+func ELFSubstitutions(ep datapath.Endpoint) (map[string]uint32, map[string]string) {
 	return elfVariableSubstitutions(ep), elfMapSubstitutions(ep)
 }

--- a/pkg/datapath/loader/template_test.go
+++ b/pkg/datapath/loader/template_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 
 	"github.com/cilium/cilium/pkg/checker"
-	"github.com/cilium/cilium/pkg/datapath/linux"
+	"github.com/cilium/cilium/pkg/datapath/linux/config"
 	"github.com/cilium/cilium/pkg/testutils"
 
 	. "gopkg.in/check.v1"
@@ -34,12 +34,12 @@ func (s *LoaderTestSuite) TestWrap(c *C) {
 
 	realEP := testutils.NewTestEndpoint()
 	template := wrap(&realEP, nil)
-	dp := linux.NewDatapath(linux.DatapathConfiguration{}, nil)
+	cfg := &config.HeaderfileWriter{}
 
 	// Write the configuration that should be the same, and verify it is.
-	err := dp.WriteTemplateConfig(&realEPBuffer, &realEP)
+	err := cfg.WriteTemplateConfig(&realEPBuffer, &realEP)
 	c.Assert(err, IsNil)
-	err = dp.WriteTemplateConfig(&templateBuffer, template)
+	err = cfg.WriteTemplateConfig(&templateBuffer, template)
 	c.Assert(err, IsNil)
 	c.Assert(realEPBuffer.String(), checker.DeepEquals, templateBuffer.String())
 
@@ -49,9 +49,9 @@ func (s *LoaderTestSuite) TestWrap(c *C) {
 	// define every bit of static data differently in the templates.
 	realEPBuffer.Reset()
 	templateBuffer.Reset()
-	err = dp.WriteEndpointConfig(&realEPBuffer, &realEP)
+	err = cfg.WriteEndpointConfig(&realEPBuffer, &realEP)
 	c.Assert(err, IsNil)
-	err = dp.WriteEndpointConfig(&templateBuffer, template)
+	err = cfg.WriteEndpointConfig(&templateBuffer, template)
 	c.Assert(err, IsNil)
 	c.Assert(realEPBuffer.String(), Not(Equals), templateBuffer.String())
 }

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/controller"
-	"github.com/cilium/cilium/pkg/datapath/loader"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/loadinfo"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -58,7 +57,7 @@ func (e *Endpoint) PolicyMapPathLocked() string {
 
 // CallsMapPathLocked returns the path to cilium tail calls map of an endpoint.
 func (e *Endpoint) CallsMapPathLocked() string {
-	return bpf.LocalMapPath(loader.CallsMapName, e.ID)
+	return e.owner.Datapath().Loader().CallsMapPath(e.ID)
 }
 
 // BPFConfigMapPath returns the path to the BPF config map of endpoint.
@@ -486,11 +485,11 @@ func (e *Endpoint) realizeBPFState(regenContext *regenerationContext) (compilati
 
 		// Compile and install BPF programs for this endpoint
 		if datapathRegenCtxt.regenerationLevel == regeneration.RegenerateWithDatapathRebuild {
-			err = loader.CompileAndLoad(datapathRegenCtxt.completionCtx, datapathRegenCtxt.epInfoCache, &stats.datapathRealization)
+			err = e.owner.Datapath().Loader().CompileAndLoad(datapathRegenCtxt.completionCtx, datapathRegenCtxt.epInfoCache, &stats.datapathRealization)
 			e.getLogger().WithError(err).Info("Regenerated endpoint BPF program")
 			compilationExecuted = true
 		} else if datapathRegenCtxt.regenerationLevel == regeneration.RegenerateWithDatapathRewrite {
-			err = loader.CompileOrLoad(datapathRegenCtxt.completionCtx, datapathRegenCtxt.epInfoCache, &stats.datapathRealization)
+			err = e.owner.Datapath().Loader().CompileOrLoad(datapathRegenCtxt.completionCtx, datapathRegenCtxt.epInfoCache, &stats.datapathRealization)
 			if err == nil {
 				e.getLogger().Info("Rewrote endpoint BPF program")
 			} else {
@@ -498,7 +497,7 @@ func (e *Endpoint) realizeBPFState(regenContext *regenerationContext) (compilati
 			}
 			compilationExecuted = true
 		} else { // RegenerateWithDatapathLoad
-			err = loader.ReloadDatapath(datapathRegenCtxt.completionCtx, datapathRegenCtxt.epInfoCache, &stats.datapathRealization)
+			err = e.owner.Datapath().Loader().ReloadDatapath(datapathRegenCtxt.completionCtx, datapathRegenCtxt.epInfoCache, &stats.datapathRealization)
 			if err == nil {
 				e.getLogger().Info("Reloaded endpoint BPF program")
 			} else {
@@ -699,7 +698,7 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (pr
 	// Avoid BPF program compilation and installation if the headerfile for the endpoint
 	// or the node have not changed.
 	var changed bool
-	datapathRegenCtxt.bpfHeaderfilesHash, err = loader.EndpointHash(e)
+	datapathRegenCtxt.bpfHeaderfilesHash, err = e.owner.Datapath().Loader().EndpointHash(e)
 	if err != nil {
 		e.getLogger().WithError(err).Warn("Unable to hash header file")
 		datapathRegenCtxt.bpfHeaderfilesHash = ""
@@ -799,7 +798,7 @@ func (e *Endpoint) DeleteMapsLocked() []error {
 // veth interface.
 func (e *Endpoint) DeleteBPFProgramLocked() error {
 	e.getLogger().Debug("deleting bpf program from endpoint")
-	return loader.DeleteDatapath(context.TODO(), e.ifName, "ingress")
+	return e.owner.Datapath().Loader().DeleteDatapath(context.TODO(), e.ifName, "ingress")
 }
 
 // garbageCollectConntrack will run the ctmap.GC() on either the endpoint's

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -32,7 +32,6 @@ import (
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/controller"
-	"github.com/cilium/cilium/pkg/datapath/loader"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/eventqueue"
 	"github.com/cilium/cilium/pkg/fqdn"
@@ -957,7 +956,7 @@ func (e *Endpoint) LeaveLocked(proxyWaitGroup *completion.WaitGroup, conf Delete
 	errors := []error{}
 
 	if !option.Config.DryMode {
-		loader.Unload(e.createEpInfoCache(""))
+		e.owner.Datapath().Loader().Unload(e.createEpInfoCache(""))
 	}
 
 	e.owner.RemoveFromEndpointQueue(uint64(e.ID))

--- a/pkg/endpoint/metrics.go
+++ b/pkg/endpoint/metrics.go
@@ -18,7 +18,7 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
-	"github.com/cilium/cilium/pkg/datapath/loader"
+	loaderMetrics "github.com/cilium/cilium/pkg/datapath/loader/metrics"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
@@ -62,7 +62,7 @@ type regenerationStatistics struct {
 	proxyConfiguration     spanstat.SpanStat
 	proxyPolicyCalculation spanstat.SpanStat
 	proxyWaitForAck        spanstat.SpanStat
-	datapathRealization    loader.SpanStat
+	datapathRealization    loaderMetrics.SpanStat
 	mapSync                spanstat.SpanStat
 	prepareBuild           spanstat.SpanStat
 }


### PR DESCRIPTION
Read per-commit.

The goal here is to abstract out the datapath interactions away from the endpoint / daemon, so that we can do more unit / mock-based testing around things which use the datapath. There are no functional changes intended as part of this PR. 

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8769)
<!-- Reviewable:end -->
