### PR TITLE
cli: add k8s-service-cache-size agent cli flag

### DIFF
--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -581,6 +581,10 @@ func init() {
 	flags.Bool(option.K8sRequireIPv6PodCIDRName, false, "Require IPv6 PodCIDR to be specified in node resource")
 	option.BindEnv(option.K8sRequireIPv6PodCIDRName)
 
+	flags.Uint(option.K8sServiceCacheSize, defaults.K8sServiceCacheSize, "Cilium service cache size for kubernetes")
+	option.BindEnv(option.K8sServiceCacheSize)
+	flags.MarkHidden(option.K8sServiceCacheSize)
+
 	flags.Bool(option.K8sForceJSONPatch, false, "When set uses JSON Patch to update CNP and CEP status in kube-apiserver")
 	option.BindEnv(option.K8sForceJSONPatch)
 	flags.MarkHidden(option.K8sForceJSONPatch)

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -282,11 +282,15 @@ const (
 	// policy updates are invoked.
 	PolicyTriggerInterval = 1 * time.Second
 
-	// K8sClientQPSLimit is is the default qps for the k8s client. It is set to 0 because the the k8s client
+	// K8sClientQPSLimit is the default qps for the k8s client. It is set to 0 because the the k8s client
 	// has its own default.
 	K8sClientQPSLimit float32 = 0.0
 
-	// K8sClientBurst is is the default burst for the k8s client. It is set to 0 because the the k8s client
+	// K8sClientBurst is the default burst for the k8s client. It is set to 0 because the the k8s client
 	// has its own default.
 	K8sClientBurst = 0
+
+	// K8sServiceCacheSize is the default value for option.K8sServiceCacheSize
+	// which denotes the value of Cilium's K8s service cache size.
+	K8sServiceCacheSize = 128
 )

--- a/pkg/k8s/service_cache.go
+++ b/pkg/k8s/service_cache.go
@@ -101,7 +101,7 @@ func NewServiceCache() ServiceCache {
 		endpoints:         map[ServiceID]*Endpoints{},
 		ingresses:         map[ServiceID]*Service{},
 		externalEndpoints: map[ServiceID]externalEndpoints{},
-		Events:            make(chan ServiceEvent, 128),
+		Events:            make(chan ServiceEvent, option.Config.K8sServiceCacheSize),
 	}
 }
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -183,6 +183,9 @@ const (
 	// K8sKubeConfigPath is the absolute path of the kubernetes kubeconfig file
 	K8sKubeConfigPath = "k8s-kubeconfig-path"
 
+	// K8sServiceCacheSize is service cache size for cilium k8s package.
+	K8sServiceCacheSize = "k8s-service-cache-size"
+
 	// K8sWatcherQueueSize is the queue size used to serialize each k8s event type
 	K8sWatcherQueueSize = "k8s-watcher-queue-size"
 
@@ -800,6 +803,9 @@ type DaemonConfig struct {
 	// is available.
 	K8sRequireIPv6PodCIDR bool
 
+	// K8sServiceCacheSize is the service cache size for cilium k8s package.
+	K8sServiceCacheSize uint
+
 	// K8sForceJSONPatch when set, uses JSON Patch to update CNP and CEP
 	// status in kube-apiserver.
 	K8sForceJSONPatch bool
@@ -1174,6 +1180,7 @@ var (
 		ForceLocalPolicyEvalAtSource: defaults.ForceLocalPolicyEvalAtSource,
 		EnableEndpointRoutes:         defaults.EnableEndpointRoutes,
 		AnnotateK8sNode:              defaults.AnnotateK8sNode,
+		K8sServiceCacheSize:          defaults.K8sServiceCacheSize,
 		AutoCreateCiliumNodeResource: defaults.AutoCreateCiliumNodeResource,
 		IdentityAllocationMode:       IdentityAllocationModeKVstore,
 	}
@@ -1504,6 +1511,7 @@ func (c *DaemonConfig) Populate() {
 	c.K8sKubeConfigPath = viper.GetString(K8sKubeConfigPath)
 	c.K8sRequireIPv4PodCIDR = viper.GetBool(K8sRequireIPv4PodCIDRName)
 	c.K8sRequireIPv6PodCIDR = viper.GetBool(K8sRequireIPv6PodCIDRName)
+	c.K8sServiceCacheSize = uint(viper.GetInt(K8sServiceCacheSize))
 	c.K8sForceJSONPatch = viper.GetBool(K8sForceJSONPatch)
 	c.K8sEventHandover = viper.GetBool(K8sEventHandover)
 	c.K8sWatcherQueueSize = uint(viper.GetInt(K8sWatcherQueueSize))


### PR DESCRIPTION
Make K8s Service cache size for cilium configurable by adding a cli flag.
The flag is `--k8s-service-cache-size`
The default value for ServiceCacheSize is `128` - previous default.

Fixes #8762

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8770)
<!-- Reviewable:end -->
