### PR TITLE
test: Install CoreDNS after Cilium is up

### DIFF
--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -106,12 +106,14 @@ func ExpectCiliumPreFlightInstallReady(vm *helpers.Kubectl) {
 
 // DeployCiliumAndDNS deploys DNS and cilium into the kubernetes cluster
 func DeployCiliumAndDNS(vm *helpers.Kubectl) {
-	By("Installing DNS Deployment")
-	_ = vm.Apply(helpers.DNSDeployment())
-
 	By("Installing Cilium")
 	err := vm.CiliumInstall([]string{})
 	Expect(err).To(BeNil(), "Cilium cannot be installed")
+
+	ExpectCiliumReady(vm)
+
+	By("Installing DNS Deployment")
+	_ = vm.Apply(helpers.DNSDeployment())
 
 	switch helpers.GetCurrentIntegration() {
 	case helpers.CIIntegrationFlannel:
@@ -122,7 +124,6 @@ func DeployCiliumAndDNS(vm *helpers.Kubectl) {
 	}
 
 	Expect(vm.WaitKubeDNS()).To(BeNil(), "KubeDNS is not ready after timeout")
-	ExpectCiliumReady(vm)
 	ExpectCiliumOperatorReady(vm)
 	ExpectKubeDNSReady(vm)
 }


### PR DESCRIPTION
Cilium no longer depends on CoreDNS to start up. Deploy Cilium afterwards.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8772)
<!-- Reviewable:end -->
