### PR TITLE
Documentation: update Quick Install guide

### DIFF
--- a/Documentation/gettingstarted/k8s-install-default.rst
+++ b/Documentation/gettingstarted/k8s-install-default.rst
@@ -17,12 +17,17 @@ on Kubernetes and does not require additional external dependencies. It is a
 good option for environments up to about 250 nodes. For bigger environments or
 for environments which want to leverage the clustermesh functionality, a
 kvstore set up is required which can be set up using an
-:ref:`k8s_install_standard` or using the :ref:`k8s_install_etcd_operator`.
+:ref:`k8s_install_etcd` or using the :ref:`k8s_install_etcd_operator`.
 
 Should you encounter any issues during the installation, please refer to the
 :ref:`troubleshooting_k8s` section and / or seek help on the `Slack channel`.
 
-.. include:: requirements_intro.rst
+Please consult the Kubernetes :ref:`k8s_requirements` for information on  how
+you need to configure your Kubernetes cluster to operate with Cilium.
+
+
+Install Cilium
+==============
 
 .. parsed-literal::
 


### PR DESCRIPTION
* Fix broken link to external etcd configuration guide
* Link directly to Kubernetes requirements instead of duplicating that
information in the guide, as it was stale. Linking to a single place with
requirements ensures we do not have duplicate information spread across our
guides that gets out-of-sync.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8785)
<!-- Reviewable:end -->
