### PR TITLE
doc: Document downgrade limitation when changing identity allocation

### DIFF
--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -255,7 +255,7 @@ IMPORTANT: Changes required before upgrading to 1.6.0
   .. code:: bash
 
      kvstore: etcd
-     kvstore-opt: etcd.config=/var/lib/etcd-config/etcd.config
+     kvstore-opt: '{"etcd.config": "/var/lib/etcd-config/etcd.config"}'
 
   This will preserve the existing behavior of the DaemonSet. Adding the options
   to the `ConfigMap` will not impact the ability to rollback. Cilium 1.5.y and
@@ -263,6 +263,12 @@ IMPORTANT: Changes required before upgrading to 1.6.0
   as both options are defined in the `DaemonSet` definitions for these versions
   which takes precedence over the `ConfigMap`.
 
+* **Downgrade warning:** Be aware that if you want to change the
+  ``identity-allocation-mode`` from ``kvstore`` to ``crd`` in order to no
+  longer depend on the kvstore for identity allocation, then a
+  rollback/downgrade requires you to revert that option and it will result in
+  brief disruptions of all connections as identities are re-created in the
+  kvstore.
 
 Upgrading from >=1.5.0 to 1.6.y
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Document the limitation that the downgrade will lead to connectivity issues
when the identity allocation method is changed from kvstore to crd and back.

Also fix the syntax for the required ConfigMap change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8787)
<!-- Reviewable:end -->
