### PR TITLE
cni: Fix warning when chaining is disabled

### DIFF
--- a/plugins/cilium-cni/chaining/api/api.go
+++ b/plugins/cilium-cni/chaining/api/api.go
@@ -77,6 +77,10 @@ func Register(name string, p ChainingPlugin) error {
 
 // Lookup searches for a chaining plugin with a given name and returns it
 func Lookup(name string) ChainingPlugin {
+	if name == "cilium" {
+		return nil
+	}
+
 	mutex.RLock()
 	defer mutex.RUnlock()
 

--- a/plugins/cilium-cni/chaining/api/api_test.go
+++ b/plugins/cilium-cni/chaining/api/api_test.go
@@ -57,3 +57,7 @@ func (a *APISuite) TestRegistration(c *check.C) {
 	err = Register("foo", &pluginTest{})
 	c.Assert(err, check.Not(check.IsNil))
 }
+
+func (a *APISuite) TestNonChaining(c *check.C) {
+	c.Assert(Lookup("cilium"), check.IsNil)
+}


### PR DESCRIPTION
Even when no chaining is enabled, the CNI configuration still caries a name.
Ignore the well known name "cilium".

This avoids the following warning in the logs:
```
Unknown CNI chaining configuration name 'cilium'
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8792)
<!-- Reviewable:end -->
