### PR TITLE
doc: Disable wait-for-bpf in EKS guide

### DIFF
--- a/Documentation/gettingstarted/k8s-install-eks.rst
+++ b/Documentation/gettingstarted/k8s-install-eks.rst
@@ -84,7 +84,6 @@ Generate the required YAML file and deploy it:
      --set global.cni.chainingMode=aws-cni \
      --set global.masquerade=false \
      --set global.tunnel=disabled \
-     --set global.bpf.waitForMount=true \
      --set nodeinit.enabled=true \
      > cilium.yaml
    kubectl create -f cilium.yaml


### PR DESCRIPTION
This feature is currently not reliable enough to be enabled by default

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8798)
<!-- Reviewable:end -->
