### PR TITLE
test: Improve upgrade/downgrade test

### DIFF
--- a/test/k8sT/manifests/cilium-ds-clean-only.yaml
+++ b/test/k8sT/manifests/cilium-ds-clean-only.yaml
@@ -1,0 +1,18 @@
+---
+metadata:
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+      - name: cilium-agent
+        command: [ "/bin/bash", "-c", "--" ]
+        args: [ "while true; do sleep 30; done;" ]
+        livenessProbe:
+          exec:
+            command:
+            - "true"
+        readinessProbe:
+          exec:
+            command:
+            - "true"


### PR DESCRIPTION
 * Warn if deletion of Cilium or CoreDNS fails to assist in debugging

 * Delete all etcd-operator resources instead of just deleting pods. Deleting
   pods is insufficient as they will get re-created. It also leaves behind
   resources which may not be used in older versions of Cilium and then cause
   issues.

 * Clean the state using a minimal DaemonSet and then re-deploy Cilium to avoid
   cleaning state again if Cilium restarts for some reason.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8799)
<!-- Reviewable:end -->
