### PR TITLE
helm/docs: Adjust Prometheus & Grafana guides to use Helm

### DIFF
--- a/Documentation/configuration/metrics.rst
+++ b/Documentation/configuration/metrics.rst
@@ -17,6 +17,9 @@ and storage system and can act as a data source for `Grafana
 collectors like statsd, Prometheus requires the collectors to pull metrics from
 each source.
 
+To run Cilium with Prometheus metrics enabled, deploy it with the
+``global.prometheus=true`` Helm value set.
+
 All metrics are exported under the ``cilium`` Prometheus namespace. When
 running and collecting in Kubernetes they will be tagged with a pod name and
 namespace.
@@ -24,8 +27,9 @@ namespace.
 Installation
 ============
 
-All Cilium components already have the annotations to signal Prometheus whether
-to scrape metrics:
+When deployed with the Helm value ``global.prometheus=true``, all Cilium
+components will have the annotations to signal Prometheus whether to scrape
+metrics:
 
 .. code-block:: yaml
 

--- a/Documentation/gettingstarted/grafana.rst
+++ b/Documentation/gettingstarted/grafana.rst
@@ -37,29 +37,32 @@ The default installation contains:
     service/grafana created
     configmap/grafana-config created
 
-How to enable metrics
-=====================
+Deploy Cilium with metrics enabled
+==================================
 
 Both ``cilium-agent`` and ``cilium-operator`` do not expose metrics by
 default. Enabling metrics for these services will open ports ``9090``
 and ``6942`` on all nodes of your cluster where these components are running.
 
-To enable metrics for ``cilium-agent`` for the default installation, set the
-``prometheus-serve-addr`` option as follows:
+To deploy Cilium with metrics enabled, set the ``global.prometheus=true`` Helm
+value:
+
+.. include:: k8s-install-download-release.rst
+
+Generate the required YAML file and deploy it:
 
 .. parsed-literal::
-    $ kubectl patch -n kube-system configmap cilium-config --type merge --patch '{"data":{"prometheus-serve-addr":":9090"}}'
-    configmap/cilium-config patched
 
-As with any changes to the config map, you will have to restart any existing
-Cilium pods in order for this change to take effect.
+   helm template cilium \
+      --namespace kube-system \
+      --set global.prometheus=true \
+      > cilium.yaml
+   kubectl create -f cilium.yaml
 
-For ``cilium-operator``, append the ``--enable-metrics`` command-line
-argument to the ``cilium-operator`` deployment:
+.. note::
 
-.. parsed-literal::
-    $ kubectl patch -n kube-system deployment cilium-operator --type=json -p='[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--enable-metrics"}]'
-    deployment.extensions/cilium-operator patched
+   You can combine the ``global.prometheus=true`` option with any of
+   the other installation guides.
 
 How to access Grafana
 =====================

--- a/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-{{- if .Values.global.prometheus }} 
+{{- if .Values.global.prometheus }}
         prometheus.io/port: "6942"
         prometheus.io/scrape: "true"
 {{- end }}
@@ -31,6 +31,9 @@ spec:
       containers:
       - args:
         - --debug=$(CILIUM_DEBUG)
+{{- if .Values.global.prometheus }}
+        - --enable-metrics
+{{- end }}
         command:
         - cilium-operator
         env:
@@ -99,7 +102,7 @@ spec:
 {{- end }}
         imagePullPolicy: {{ .Values.global.pullPolicy }}
         name: cilium-operator
-{{- if .Values.global.prometheus }} 
+{{- if .Values.global.prometheus }}
         ports:
         - containerPort: 6942
           hostPort: 6942


### PR DESCRIPTION
The new Helm-generated `quick-install.yaml` does not contain the necessary Prometheus annotations anymore, so we need to explicitly state in the documentation how to enable metrics with Helm.

In addition, this PR also fixes the `cilium-operator` Helm chart to pass `--enable-metrics` when `.Values.global.prometheus` is set. The chart already sets up the ports if this value is set, but the daemon itself also needs to be told to actually export metrics on the port.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8800)
<!-- Reviewable:end -->
