### PR TITLE
doc: Disable wait-for-bpf in AWS-CNI guide

### DIFF
--- a/Documentation/gettingstarted/cni-chaining-aws-cni.rst
+++ b/Documentation/gettingstarted/cni-chaining-aws-cni.rst
@@ -40,7 +40,6 @@ Generate the required YAML files and deploy them:
      --set global.cni.chainingMode=aws-cni \
      --set global.masquerade=false \
      --set global.tunnel=disabled \
-     --set global.bpf.waitForMount=true \
      --set nodeinit.enabled=true \
      > cilium.yaml
    kubectl apply -f cilium.yaml


### PR DESCRIPTION
For the same reason it was disabled in the EKS guide in 59ec7da7e - it is currently not reliable enough.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8801)
<!-- Reviewable:end -->
