### PR TITLE
test: misc. improvements to tests for connectivity across namespaces

### DIFF
--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -971,7 +971,9 @@ EOF`, k, v)
 				secondNS, netpolNsSelector, helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Policy cannot be applied")
 
+			By("Testing connectivity across namespaces with policy")
 			for _, pod := range []string{helpers.App2, helpers.App3} {
+				By("Checking that namespace %s cannot connect to %s:%s", helpers.DefaultNamespace, secondNS, pod)
 				// Make sure that the Default namespace can NOT connect to
 				// second namespace.
 				res := kubectl.ExecPodCmd(
@@ -980,6 +982,7 @@ EOF`, k, v)
 				res.ExpectFail("%q can curl to service, policy is not blocking"+
 					"communication to %q namespace", appPods[pod], secondNS)
 
+				By("Checking that pod %s within namespace %s can communicate with each other", pod, secondNS)
 				// Second namespace pods can connect to the same namespace based on policy.
 				res = kubectl.ExecPodCmd(
 					secondNS, appPodsNS[pod],

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -890,6 +890,13 @@ EOF`, k, v)
 			secondNSclusterIP, _, err = kubectl.GetServiceHostPort(secondNS, app1Service)
 			Expect(err).To(BeNil(), "Cannot get service on %q namespace", secondNS)
 
+			for _, ns := range []string{helpers.DefaultNamespace, secondNS} {
+				By("Waiting for backends to be plumbed for %s in %s namespace", app1Service, ns)
+				err = kubectl.WaitForServiceEndpoints(
+					ns, "", app1Service,
+					helpers.HelperTimeout)
+				Expect(err).Should(BeNil(), "Service %q in namespace %q is not ready after timeout", app1Service, ns)
+			}
 		})
 
 		AfterEach(func() {


### PR DESCRIPTION
* Add more narration statements to namespace selector policy test
* Add helper function to wait for service backends to be plumbed. Use this in `BeforeEach` to ensure that we have not had backends for services deleted due to effects from a previous test run. Also use this after we have applied policy in the test "Kubernetes Network Policy by namespace selector" as well - see #8781.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8803)
<!-- Reviewable:end -->
