### PR TITLE
cilium: CI, fix DatapathConfiguration tests previously running with default config

### DIFF
--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -236,8 +236,8 @@ data:
 {{- if .Values.global.encryption.interface }}
   encrypt-interface: {{ .Values.global.encryption.interface }}
 {{- end }}
-{{- if .Values.encryption.nodeEncryption }}
-  encrypt-node: {{ .Values.encryption.nodeEncryption | quote }}
+{{- if .Values.global.encryption.nodeEncryption }}
+  encrypt-node: {{ .Values.global.encryption.nodeEncryption | quote }}
 {{- end }}
 {{- end }}
 

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -81,7 +81,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 	}
 
 	deployCilium := func(options []string) {
-		DeployCiliumAndDNS(kubectl)
+		DeployCiliumOptionsAndDNS(kubectl, options)
 
 		err := kubectl.WaitforPods(helpers.DefaultNamespace, "", helpers.HelperTimeout)
 		ExpectWithOffset(1, err).Should(BeNil(), "Pods are not ready after timeout")

--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -106,8 +106,13 @@ func ExpectCiliumPreFlightInstallReady(vm *helpers.Kubectl) {
 
 // DeployCiliumAndDNS deploys DNS and cilium into the kubernetes cluster
 func DeployCiliumAndDNS(vm *helpers.Kubectl) {
+	DeployCiliumOptionsAndDNS(vm, []string{})
+}
+
+// DeployCiliumOptionsAndDNS deploys DNS and cilium with options into the kubernetes cluster
+func DeployCiliumOptionsAndDNS(vm *helpers.Kubectl, options []string) {
 	By("Installing Cilium")
-	err := vm.CiliumInstall([]string{})
+	err := vm.CiliumInstall(options)
 	Expect(err).To(BeNil(), "Cilium cannot be installed")
 
 	ExpectCiliumReady(vm)


### PR DESCRIPTION
We were running DatapathConfiguration tests without applying test options. This series fixes the encryption nil pointer error when using encryption values and pushes test options into configuration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8806)
<!-- Reviewable:end -->
