### PR TITLE
eventqueue: protect against enqueueing same Event twice

### DIFF
--- a/daemon/endpoint_test.go
+++ b/daemon/endpoint_test.go
@@ -189,10 +189,13 @@ func (ds *DaemonSuite) TestEndpointEventQueueDeadlockUponDeletion(c *C) {
 	ev2EnqueueCh := make(chan struct{})
 
 	go func() {
-		ep.EventQueue.Enqueue(ev)
-		ep.EventQueue.Enqueue(ev2)
+		_, err := ep.EventQueue.Enqueue(ev)
+		c.Assert(err, IsNil)
+		_, err = ep.EventQueue.Enqueue(ev2)
+		c.Assert(err, IsNil)
 		close(ev2EnqueueCh)
-		ep.EventQueue.Enqueue(ev3)
+		_, err = ep.EventQueue.Enqueue(ev3)
+		c.Assert(err, IsNil)
 	}()
 
 	// Ensure that the second event is enqueued before proceeding further, as

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -468,7 +468,13 @@ func (e *Endpoint) Regenerate(regenMetadata *regeneration.ExternalRegenerationMe
 	// This may block if the Endpoint's EventQueue is full. This has to be done
 	// synchronously as some callers depend on the fact that the event is
 	// synchronously enqueued.
-	resChan := e.EventQueue.Enqueue(epEvent)
+	resChan, err := e.EventQueue.Enqueue(epEvent)
+	if err != nil {
+		e.getLogger().Errorf("enqueue of EndpointRegenerationEvent failed: %s", err)
+		done <- false
+		close(done)
+		return done
+	}
 
 	go func() {
 

--- a/pkg/eventqueue/eventqueue_test.go
+++ b/pkg/eventqueue/eventqueue_test.go
@@ -183,3 +183,22 @@ func (s *EventQueueSuite) TestDrain(c *C) {
 	// NewHangEvent.
 	c.Assert(nh3.processed, Equals, false)
 }
+
+func (s *EventQueueSuite) TestEnqueueTwice(c *C) {
+	q := NewEventQueue()
+	q.Run()
+
+	ev := NewEvent(&DummyEvent{})
+	res := q.Enqueue(ev)
+	select {
+	case <-res:
+	case <-time.After(5 * time.Second):
+		c.Fail()
+	}
+
+	res = q.Enqueue(ev)
+	c.Assert(res, IsNil)
+
+	q.Stop()
+	q.WaitToBeDrained()
+}


### PR DESCRIPTION
Previously, if an Event is enqueued twice, the following panic would occur:

```
PANIC: eventqueue_test.go:187: EventQueueSuite.TestPanic

... Panic: close of closed channel (PC=0x42EFD4)

/usr/local/go/src/runtime/panic.go:522
  in gopanic
/usr/local/go/src/runtime/chan.go:342
  in closechan
eventqueue.go:188
  in EventQueue.Enqueue
eventqueue_test.go:197
  in EventQueueSuite.TestPanic
/usr/local/go/src/reflect/value.go:308
  in Value.Call
/usr/local/go/src/runtime/asm_amd64.s:1337
  in goexit
OOPS: 9 passed, 1 PANICKED
--- FAIL: Test (1.51s)
FAIL
coverage: 0.0% of statements in pkg/eventqueue
FAIL	github.com/cilium/cilium/pkg/eventqueue	1.550s
Makefile:129: recipe for target 'unit-tests' failed
make: *** [unit-tests] Error 1
```

To protect against this, do not allow enqueueing the same Event twice, by using
an atomic boolean which contains information about whether a given Event has
been enqueued or not.

Fixes: #8805

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8809)
<!-- Reviewable:end -->
