### PR TITLE
endpointmanager: move dereference outside of `WithFields` invocation to avoid possible panic

### DIFF
--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -404,7 +404,10 @@ func RegenerateAllEndpoints(regenMetadata *regeneration.ExternalRegenerationMeta
 	eps := GetEndpoints()
 	wg.Add(len(eps))
 
-	log.WithFields(logrus.Fields{"reason": regenMetadata.Reason}).Info("regenerating all endpoints")
+	// Dereference "reason" field outside of logging statement; see
+	// https://github.com/sirupsen/logrus/issues/1003.
+	reason := regenMetadata.Reason
+	log.WithFields(logrus.Fields{"reason": reason}).Info("regenerating all endpoints")
 	for _, ep := range eps {
 		go func(ep *endpoint.Endpoint) {
 			<-ep.RegenerateIfAlive(regenMetadata)


### PR DESCRIPTION
The following panic was observed in an instance of Cilium:

```
 panic: runtime error: invalid memory address or nil pointer dereference)
 [signal SIGSEGV: segmentation violation code=0x1 addr=0x28e pc=0x12fd8de])
 goroutine 124 [running]:)
 github.com/cilium/cilium/vendor/github.com/sirupsen/logrus.(*TextFormatter).needsQuoting(0xc0000fa730, 0x28e, 0x23cb91, 0x1c))
       /go/src/github.com/cilium/cilium/vendor/github.com/sirupsen/logrus/text_formatter.go:268 +0x4e)
 github.com/cilium/cilium/vendor/github.com/sirupsen/logrus.(*TextFormatter).appendValue(0xc0000fa730, 0xc00934e120, 0x2c78180, 0xc0091e4060))
        /go/src/github.com/cilium/cilium/vendor/github.com/sirupsen/logrus/text_formatter.go:294 +0x6d)
 github.com/cilium/cilium/vendor/github.com/sirupsen/logrus.(*TextFormatter).appendKeyValue(0xc0000fa730, 0xc00934e120, 0x30969b2, 0x6, 0x2c78180, 0xc0091e4060))
       /go/src/github.com/cilium/cilium/vendor/github.com/sirupsen/logrus/text_formatter.go:285 +0x90)
 github.com/cilium/cilium/vendor/github.com/sirupsen/logrus.(*TextFormatter).Format(0xc0000fa730, 0xc003dc61c0, 0xc0000b8510, 0xc000dbcb18, 0x12206b6, 0x302dfe0, 0xc000dbcb18))
       /go/src/github.com/cilium/cilium/vendor/github.com/sirupsen/logrus/text_formatter.go:202 +0xa52)
 github.com/cilium/cilium/vendor/github.com/sirupsen/logrus.(*Entry).write(0xc003dc61c0))
       /go/src/github.com/cilium/cilium/vendor/github.com/sirupsen/logrus/entry.go:255 +0x81)
 github.com/cilium/cilium/vendor/github.com/sirupsen/logrus.Entry.log(0xc0000b84e0, 0xc00934e0f0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...))
       /go/src/github.com/cilium/cilium/vendor/github.com/sirupsen/logrus/entry.go:231 +0x193)
 github.com/cilium/cilium/vendor/github.com/sirupsen/logrus.(*Entry).Log(0xc003dc6150, 0xc000000004, 0xc000dbcce0, 0x1, 0x1))
       /go/src/github.com/cilium/cilium/vendor/github.com/sirupsen/logrus/entry.go:268 +0xed)
 github.com/cilium/cilium/vendor/github.com/sirupsen/logrus.(*Entry).Info(...))
       /go/src/github.com/cilium/cilium/vendor/github.com/sirupsen/logrus/entry.go:285)
 github.com/cilium/cilium/pkg/endpointmanager.RegenerateAllEndpoints(0x35429a0, 0xc0001ae780, 0xc00934e0c0, 0x3091c02))
       /go/src/github.com/cilium/cilium/pkg/endpointmanager/manager.go:406 +0x1ad)
 main.(*Daemon).policyUpdateTrigger(0xc0001ae780, 0xc0091e4050, 0x1, 0x1))
       /go/src/github.com/cilium/cilium/daemon/policy.go:74 +0xf9)
 github.com/cilium/cilium/pkg/trigger.(*Trigger).waiter(0xc0004ca960))
       /go/src/github.com/cilium/cilium/pkg/trigger/trigger.go:210 +0x2d7)
 created by github.com/cilium/cilium/pkg/trigger.NewTrigger)
       /go/src/github.com/cilium/cilium/pkg/trigger/trigger.go:133 +0x130)
```

The panic is on the following line in the logrus library:
https://github.com/sirupsen/logrus/blob/v1.4.1/text_formatter.go

We are unsure of how this panic is occurring given that the string which is
being iterated over is not modified elsewhere (as far as we know). But, given
that we are doing a dreference of the `regenMetadata` field in
`RegenerateAllEndpoints`, it cannot hurt to put it outside of the logging
statement itself so that if that nil derference fails, the way in which it fails
is not as obtuse.

An issue has been filed upstream against logrus regarding this:
https://github.com/sirupsen/logrus/issues/1003

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8810)
<!-- Reviewable:end -->
