### PR TITLE
Add helm option for ENI mode configuration

### DIFF
--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -154,6 +154,13 @@ data:
   cluster-id: "{{ .Values.global.cluster.id }}"
 {{- end }}
 
+{{- if .Values.global.eni }}
+  ipam: "eni"
+  enable-endpoint-routes: "true"
+  auto-create-cilium-node-resource: "true"
+  blacklist-conflicting-routes: "false"
+{{- end }}
+
 {{- if .Values.global.flannel.enabled }}
   # Interface to be used when running Cilium on top of a CNI plugin.
   # For flannel, use "cni0"

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -242,6 +242,9 @@ global:
     # range via the Kubernetes node resource
     requireIPv4PodCIDR: false
 
+  # ENI mode configures the options required to run with ENI
+  eni: false
+
   # cleanState instructs the cilium-agent DaemonSet to clean all state in the
   # initContainer
   #


### PR DESCRIPTION
Support a new helm option `--set global.eni=true` for configuring all
ENI-related options.

Tested manually in an EKS ENI cluster.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8811)
<!-- Reviewable:end -->
