### PR TITLE
test: wait for k8s external service in [kube|core]-dns

### DIFF
--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -434,6 +434,8 @@ var _ = Describe("K8sServicesTest", func() {
 		})
 
 		It("Connects to service IP backed by external IPs", func() {
+			err := kubectl.WaitForKubeDNSEntry("external-ips-service", helpers.DefaultNamespace)
+			Expect(err).To(BeNil(), "DNS entry is not ready after timeout")
 			shouldConnect(podName, serviceName)
 		})
 


### PR DESCRIPTION
Fixes: 01e2a5ef0872 ("test: add integration tests for k8s services with external IPs")
Signed-off-by: André Martins <andre@cilium.io>

Fixes https://github.com/cilium/cilium/issues/8672

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8828)
<!-- Reviewable:end -->
