### PR TITLE
Added prometheus-operator ServiceMonitor

### DIFF
--- a/Documentation/configuration/metrics.rst
+++ b/Documentation/configuration/metrics.rst
@@ -18,7 +18,7 @@ collectors like statsd, Prometheus requires the collectors to pull metrics from
 each source.
 
 To run Cilium with Prometheus metrics enabled, deploy it with the
-``global.prometheus=true`` Helm value set.
+``global.prometheus.enabled=true`` Helm value set.
 
 All metrics are exported under the ``cilium`` Prometheus namespace. When
 running and collecting in Kubernetes they will be tagged with a pod name and
@@ -27,7 +27,7 @@ namespace.
 Installation
 ============
 
-When deployed with the Helm value ``global.prometheus=true``, all Cilium
+When deployed with the Helm value ``global.prometheus.enabled=true``, all Cilium
 components will have the annotations to signal Prometheus whether to scrape
 metrics:
 

--- a/Documentation/gettingstarted/grafana.rst
+++ b/Documentation/gettingstarted/grafana.rst
@@ -44,7 +44,7 @@ Both ``cilium-agent`` and ``cilium-operator`` do not expose metrics by
 default. Enabling metrics for these services will open ports ``9090``
 and ``6942`` on all nodes of your cluster where these components are running.
 
-To deploy Cilium with metrics enabled, set the ``global.prometheus=true`` Helm
+To deploy Cilium with metrics enabled, set the ``global.prometheus.enabled=true`` Helm
 value:
 
 .. include:: k8s-install-download-release.rst
@@ -55,13 +55,13 @@ Generate the required YAML file and deploy it:
 
    helm template cilium \
       --namespace kube-system \
-      --set global.prometheus=true \
+      --set global.prometheus.enabled=true \
       > cilium.yaml
    kubectl create -f cilium.yaml
 
 .. note::
 
-   You can combine the ``global.prometheus=true`` option with any of
+   You can combine the ``global.prometheus.enabled=true`` option with any of
    the other installation guides.
 
 How to access Grafana

--- a/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-{{- if .Values.global.prometheus }}
+{{- if and .Values.global.prometheus.enabled (not .Values.global.prometheus.serviceMonitor.enabled) }}
         prometheus.io/port: "9090"
         prometheus.io/scrape: "true"
 {{- end }}
@@ -100,7 +100,7 @@ spec:
           successThreshold: 1
           timeoutSeconds: 5
         name: cilium-agent
-{{- if .Values.global.prometheus }}
+{{- if .Values.global.prometheus.enabled }}
         ports:
         - containerPort: 9090
           hostPort: 9090

--- a/install/kubernetes/cilium/charts/agent/templates/servicemonitor.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/servicemonitor.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.global.prometheus.enabled (.Values.global.prometheus.serviceMonitor.enabled) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: cilium-agent
+  {{- if .Values.global.prometheus.serviceMonitor.namespace }}
+  namespace: {{ .Values.global.prometheus.serviceMonitor.namespace }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      k8s-app: cilium-agent
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  endpoints:
+  - port: metrics
+    interval: 10s
+    honorLabels: true
+    path: /metrics
+{{- end }}

--- a/install/kubernetes/cilium/charts/agent/templates/svc.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/svc.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.global.prometheus.enabled (.Values.global.prometheus.serviceMonitor.enabled) }}
+kind: Service
+apiVersion: v1
+metadata:
+  name: cilium-agent
+  namespace: {{ .Release.Namespace }}
+  labels:
+    k8s-app: cilium
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+  - name: metrics
+    port: 9090
+    protocol: TCP
+    targetPort: prometheus
+  selector:
+    k8s-app: cilium
+{{- end }}

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -49,7 +49,7 @@ data:
   debug-verbose: "{{ .Values.global.debug.verbose }}"
 {{- end }}
 
-{{- if .Values.global.prometheus }}
+{{- if .Values.global.prometheus.enabled }}
   # If you want metrics enabled in all of your Cilium agents, set the port for
   # which the Cilium agents will have their metrics exposed.
   # This option deprecates the "prometheus-serve-addr" in the

--- a/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-{{- if .Values.global.prometheus }}
+{{- if and .Values.global.prometheus.enabled (not .Values.global.prometheus.serviceMonitor.enabled) }}
         prometheus.io/port: "6942"
         prometheus.io/scrape: "true"
 {{- end }}
@@ -31,7 +31,7 @@ spec:
       containers:
       - args:
         - --debug=$(CILIUM_DEBUG)
-{{- if .Values.global.prometheus }}
+{{- if .Values.global.prometheus.enabled }}
         - --enable-metrics
 {{- end }}
         command:
@@ -102,7 +102,7 @@ spec:
 {{- end }}
         imagePullPolicy: {{ .Values.global.pullPolicy }}
         name: cilium-operator
-{{- if .Values.global.prometheus }}
+{{- if .Values.global.prometheus.enabled }}
         ports:
         - containerPort: 6942
           hostPort: 6942

--- a/install/kubernetes/cilium/charts/operator/templates/servicemonitor.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/servicemonitor.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.global.prometheus.enabled (.Values.global.prometheus.serviceMonitor.enabled) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: cilium-operator
+  {{- if .Values.global.prometheus.serviceMonitor.namespace }}
+  namespace: {{ .Values.global.prometheus.serviceMonitor.namespace }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      io.cilium/app: operator
+      name: cilium-operator
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  endpoints:
+  - port: metrics
+    interval: 10s
+    honorLabels: true
+    path: /metrics
+{{- end }}

--- a/install/kubernetes/cilium/charts/operator/templates/svc.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/svc.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.global.prometheus.enabled (.Values.global.prometheus.serviceMonitor.enabled) }}
+kind: Service
+apiVersion: v1
+metadata:
+  name: cilium-operator
+  namespace: {{ .Release.Namespace }}
+  labels:
+    io.cilium/app: operator
+    name: cilium-operator
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+  - name: metrics
+    port: 6942
+    protocol: TCP
+    targetPort: prometheus
+  selector:
+    io.cilium/app: operator
+    name: cilium-operator
+{{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -68,7 +68,10 @@ global:
     #verbose: flow
 
   # prometheus enables
-  prometheus: false
+  prometheus:
+    enabled: false
+    serviceMonitor:
+      enabled: false
 
   # installIptablesRules enables installation of iptables rules to allow for
   # TPROXY (L7 proxy injection), itpables based masquerading and compatibility


### PR DESCRIPTION
This adds an option to create prometheus-operator [ServiceMonitor](https://github.com/coreos/prometheus-operator/blob/master/Documentation/design.md#servicemonitor) resources.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8833)
<!-- Reviewable:end -->
