### PR TITLE
Fix DNS egress L7 policy in ENI mode

### DIFF
--- a/pkg/datapath/linux/config.go
+++ b/pkg/datapath/linux/config.go
@@ -372,9 +372,7 @@ func (l *linuxDatapath) writeTemplateConfig(fw *bufio.Writer, e datapath.Endpoin
 			fmt.Fprint(fw, "#define ENABLE_ARP_RESPONDER 1\n")
 		}
 
-		if option.Config.IPAM != option.IPAMENI {
-			fmt.Fprint(fw, "#define ENABLE_HOST_REDIRECT 1\n")
-		}
+		fmt.Fprint(fw, "#define ENABLE_HOST_REDIRECT 1\n")
 		if option.Config.IsFlannelMasterDeviceSet() {
 			fmt.Fprint(fw, "#define HOST_REDIRECT_TO_INGRESS 1\n")
 		}


### PR DESCRIPTION
ENI mode was disabling L7 proxy entirely previously due to an overeager check in the datapath to avoid redirecting to the proxy in cases where the endpoint devices are IPVLAN devices.

These fixes enable the following cases in ENI mode:
* Egress L7 policy plus no ingress policy

Fixes: https://github.com/cilium/cilium/issues/8813

Future work:
* Egress L7 + Ingress L7 policy within a single node (#8864)
* Ingress L7 policy plus no egress policy within single node (#8864)
* Ingress L7 policy plus no egress policy across multiple nodes (This doesn't work at all in my kernel 4.14.128-112.105.amzn2.x86_64 setup)
* Egress L7 policy + Ingress L7 policy across multiple nodes (it's not so much that this completely doesn't work, rather in this combination the destination sees source id world rather than of the pod)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8837)
<!-- Reviewable:end -->
