### PR TITLE
datapath: Always include IP of cilium_host in list of local IPs

### DIFF
--- a/pkg/datapath/linux/node_addressing.go
+++ b/pkg/datapath/linux/node_addressing.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/datapath"
+	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/node"
 
@@ -50,6 +51,18 @@ func listLocalAddresses(family int) ([]net.IP, error) {
 		}
 
 		addresses = append(addresses, addr.IP)
+	}
+
+	if hostDevice, err := netlink.LinkByName(defaults.HostDevice); hostDevice != nil && err == nil {
+		addrs, err = netlink.AddrList(hostDevice, family)
+		if err != nil {
+			return nil, err
+		}
+		for _, addr := range addrs {
+			if addr.Scope == int(netlink.SCOPE_LINK) {
+				addresses = append(addresses, addr.IP)
+			}
+		}
 	}
 
 	return addresses, nil


### PR DESCRIPTION
Due to adding the cilium_host IP address as scope link, the IP was skipped in:
```
func (a *addressFamilyIPv4) LocalAddresses() ([]net.IP, error) {
```

This further lead for `func (d *Daemon) syncEndpointsAndHostIPs()` to not add
the host IP to the lxcmap and ipcache. In fact, due to not being in the list
but previously being added to the lxcmap. The IP even got removed from the
lxcmap.

Depending on the configuration of Cilium, it was possible for this IP to be
added to the ipcache via other means but it was no longer guaranteed.

As soon as policy was involved, the IP was mapped to world and no host and thus
subject to drops as well.

The most obvious side effect of this was that host <-> pod communication could
be affected which often manifested itself in failing readiness probes.

Fixes: #8781
Fixes: #8776
Fixes: #8775

Signed-off-by: Martynas Pumputis <m@lambda.lt>
Signed-off-by: Thomas Graf <thomas@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8839)
<!-- Reviewable:end -->
