### PR TITLE
Revert "test: Temporarily disable Istio CI test"

### DIFF
--- a/test/k8sT/istio.go
+++ b/test/k8sT/istio.go
@@ -79,8 +79,6 @@ var _ = Describe("K8sIstioTest", func() {
 	)
 
 	BeforeAll(func() {
-		Skip("Istio test is unstable, disable for now until we find the cause")
-
 		k8sVersion := helpers.GetCurrentK8SEnv()
 		switch k8sVersion {
 		case "1.7", "1.8", "1.9":


### PR DESCRIPTION
This reverts commit 97216619a1dc938feacd14d652360b06f4d40b53.

PR #8839 revealed the cause of the Istio test failing; re-enable the test
accordingly by reverting the commit which disabled it.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8844)
<!-- Reviewable:end -->
