### PR TITLE
Add RBAC to cilium preflight manifests

### DIFF
--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -789,7 +789,7 @@ The steps below assume a stable cluster with no new identities created during
 the rollout. Once a cilium using CRD-backed identities is running, it may begin
 allocating identities in a way that conflicts with older ones in the kvstore. 
 
-The cilium preflight manifest requires etcd support and can be build with:
+The cilium preflight manifest requires etcd support and can be built with:
 
 .. code:: bash
 
@@ -811,7 +811,7 @@ Example migration
 
 .. code-block:: shell-session
 
-      $ kubectl exec -n kube-system cilium-preflight-1234 -- cilium preflight migrate-identity --k8s-kubeconfig-path /var/lib/cilium/cilium.kubeconfig --kvstore etcd --kvstore-opt etcd.config=/var/lib/cilium/etcd-config.yml
+      $ kubectl exec -n kube-system cilium-preflight-1234 -- cilium preflight migrate-identity
       INFO[0000] Setting up kvstore client
       INFO[0000] Connecting to etcd server...                  config=/var/lib/cilium/etcd-config.yml endpoints="[https://192.168.33.11:2379]" subsys=kvstore
       INFO[0000] Setting up kubernetes client
@@ -837,6 +837,16 @@ Example migration
       INFO[0003] Reusing existing global key                   key="k8s:class=deathstar;k8s:io.cilium.k8s.policy.cluster=default;k8s:io.cilium.k8s.policy.serviceaccount=default;k8s:io.kubernetes.pod.namespace=default;k8s:org=empire;" subsys=allocator
       INFO[0003] New ID allocated for key in CRD               identity=17281 identityLabels="k8s:class=deathstar;k8s:io.cilium.k8s.policy.cluster=default;k8s:io.cilium.k8s.policy.serviceaccount=default;k8s:io.kubernetes.pod.namespace=default;k8s:org=empire;" oldIdentity=11730
       INFO[0003] ID was already allocated to this key. It is already migrated  identity=17003 identityLabels="k8s:class=xwing;k8s:io.cilium.k8s.policy.cluster=default;k8s:io.cilium.k8s.policy.serviceaccount=default;k8s:io.kubernetes.pod.namespace=default;k8s:org=alliance;"
+
+.. note::
+
+    It is also possible to use the `--k8s-kubeconfig-path`  and `--kvstore-opt`
+    ``cilium`` CLI options with the preflight command. The default is to derive the
+    configuration as cilium-agent does.
+
+  .. parsed-literal::
+
+        cilium preflight migrate-identity --k8s-kubeconfig-path /var/lib/cilium/cilium.kubeconfig --kvstore etcd --kvstore-opt etcd.config=/var/lib/cilium/etcd-config.yml
 
 Clearing CRD identities
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/install/kubernetes/cilium/charts/preflight/templates/cilium-preflight-clusterrole-binding.yaml
+++ b/install/kubernetes/cilium/charts/preflight/templates/cilium-preflight-clusterrole-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cilium-preflight-check
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium
+subjects:
+- kind: ServiceAccount
+  name: cilium-preflight-check
+  namespace: {{ .Release.Namespace }}

--- a/install/kubernetes/cilium/charts/preflight/templates/cilium-preflight-serviceaccount.yaml
+++ b/install/kubernetes/cilium/charts/preflight/templates/cilium-preflight-serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cilium-preflight-check
+  namespace: {{ .Release.Namespace }}

--- a/install/kubernetes/cilium/charts/preflight/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/preflight/templates/daemonset.yaml
@@ -119,4 +119,6 @@ spec:
           secretName: cilium-etcd-secrets
 {{- end }}
 {{- end }}
+      serviceAccount: cilium-preflight-check
+      serviceAccountName: cilium-preflight-check
 


### PR DESCRIPTION
The migrate-identity command is able to derive the configuration from the environment the
same way cilium-agent does. The example now reflects this, and we include appropriate RBAC bindings in the helm templates.

I had to add a role for `cilium-preflight-check` but I think there should be a way to re-use the cilium role directly from the preflight daemonset spec.

[Fixes 23ec9760431a89c3b132adf7194d67cad26a4c64]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8848)
<!-- Reviewable:end -->
