### PR TITLE
Bump vagrant box versions

### DIFF
--- a/vagrant_box_defaults.rb
+++ b/vagrant_box_defaults.rb
@@ -3,6 +3,6 @@
 Vagrant.require_version ">= 2.2.0"
 
 $SERVER_BOX = "cilium/ubuntu-dev"
-$SERVER_VERSION= "157"
+$SERVER_VERSION= "158"
 $NETNEXT_SERVER_BOX= "cilium/ubuntu-next"
-$NETNEXT_SERVER_VERSION= "31"
+$NETNEXT_SERVER_VERSION= "32"


### PR DESCRIPTION
Merge after https://github.com/cilium/packer-ci-build/pull/165 is merged and new boxes are built on vagrant cloud: https://app.vagrantup.com/cilium

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8854)
<!-- Reviewable:end -->
