### PR TITLE
Connection readiness of k8s client gets ns

### DIFF
--- a/install/kubernetes/cilium/charts/agent/templates/clusterrole.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/clusterrole.yaml
@@ -18,7 +18,6 @@ rules:
   - services
   - nodes
   - endpoints
-  - componentstatuses
   verbs:
   - get
   - list

--- a/install/kubernetes/cilium/charts/operator/templates/clusterrole.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/clusterrole.yaml
@@ -6,13 +6,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  # to get k8s version and status
-  - componentstatuses
-  verbs:
-  - get
-- apiGroups:
-  - ""
-  resources:
   # to automatically delete [core|kube]dns pods so that are starting to being
   # managed by Cilium
   - pods
@@ -31,6 +24,8 @@ rules:
   # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
+  # to check apiserver connectivity
+  - namespaces
   verbs:
   - get
   - list

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -173,7 +173,6 @@ rules:
   - services
   - nodes
   - endpoints
-  - componentstatuses
   verbs:
   - get
   - list
@@ -238,13 +237,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  # to get k8s version and status
-  - componentstatuses
-  verbs:
-  - get
-- apiGroups:
-  - ""
-  resources:
   # to automatically delete [core|kube]dns pods so that are starting to being
   # managed by Cilium
   - pods
@@ -263,6 +255,8 @@ rules:
   # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
+  # to check apiserver connectivity
+  - namespaces
   verbs:
   - get
   - list

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -128,9 +128,9 @@ func CreateClient(config *rest.Config) (*kubernetes.Clientset, error) {
 	return cs, err
 }
 
-// isConnReady returns the err for the controller-manager status
+// isConnReady returns the err for the kube-system namespace get
 func isConnReady(c *kubernetes.Clientset) error {
-	_, err := c.CoreV1().ComponentStatuses().Get("controller-manager", metav1.GetOptions{})
+	_, err := c.CoreV1().Namespaces().Get("kube-system", metav1.GetOptions{})
 	return err
 }
 


### PR DESCRIPTION
kube-system is always in the cluster, getting it indicates that
connection to apiserver is ready.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8855)
<!-- Reviewable:end -->
