### PR TITLE
daemon: sleep 2 seconds before fatal

### DIFF
--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -98,6 +98,10 @@ const (
 
 	apiTimeout   = 60 * time.Second
 	daemonSubsys = "daemon"
+
+	// fatalSleep is the duration Cilium should sleep before existing in case
+	// of a log.Fatal is issued or a CLI flag is specified but does not exist.
+	fatalSleep = 2 * time.Second
 )
 
 var (
@@ -119,6 +123,17 @@ var (
 
 	bootstrapStats = bootstrapStatistics{}
 )
+
+func init() {
+	RootCmd.SetFlagErrorFunc(func(_ *cobra.Command, e error) error {
+		time.Sleep(fatalSleep)
+		return e
+	})
+	logrus.RegisterExitHandler(func() {
+		time.Sleep(fatalSleep)
+	},
+	)
+}
 
 func daemonMain() {
 	bootstrapStats.overall.Start()


### PR DESCRIPTION
If the user specifies a flag that does not exist to cilium-agent it can
make Cilium to present the following error to the user:
```
PostStartHookError: command '/cni-install.sh' exited with 126:
```

This is misleading and the reason for it to happen is because
cni-install.sh was not completed by the time `cilium-agent` process
exited. For this reason, before printing the helper message and / or
fatal, Cilium will be delayed 2 seconds so it gives enough time for
`cni-install.sh` to complete and the user will see a different type of
error in the pod status message.

Signed-off-by: Ray Bejjani <ray@isovalent.com>
Signed-off-by: André Martins <andre@cilium.io>


Fixes https://github.com/cilium/cilium/issues/7983

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8857)
<!-- Reviewable:end -->
