### PR TITLE
Fix NodePort template and GSG

### DIFF
--- a/Documentation/gettingstarted/nodeport.rst
+++ b/Documentation/gettingstarted/nodeport.rst
@@ -33,12 +33,12 @@ Generate the required YAML file and deploy it:
 
    helm template cilium \
      --namespace kube-system \
-     --set global.nodeport.enabled=true \
+     --set global.nodePort.enabled=true \
      > cilium.yaml
 
 By default, a NodePort service will be accessible via an IP address of a native
 device which has a default route on the host. To change a device, set its name
-in the ``device`` option.
+in the ``global.nodePort.device`` option.
 
 In addition, thanks to the :ref:`host-services` feature, the NodePort service
 can be accessed from a host or a Pod within a cluster via it's public,
@@ -68,6 +68,6 @@ Limitations
       are currently not supported.
     * NodePort services are currently exposed through the native device which has
       the default route on the host or a user specified device. In tunneling mode,
-      they are additionally exposed through the tunnel interface (cilium_vxlan or
-      cilium_geneve). Exposing services through multiple native devices will be
-      supported in upcoming Cilium versions.
+      they are additionally exposed through the tunnel interface (``cilium_vxlan``
+      or ``cilium_geneve``). Exposing services through multiple native devices
+      will be supported in upcoming Cilium versions.

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -268,8 +268,12 @@ data:
 {{- if .Values.global.nodePort }}
   enable-node-port: {{ .Values.global.nodePort.enabled | default false | quote }}
 {{- if .Values.global.nodePort.range }}
-  node-port-range: {{ .Values.global.nodePort.range }}
+  node-port-range: {{ .Values.global.nodePort.range | quote }}
 {{- end }}
+{{- if .Values.global.nodePort.device }}
+  device: {{ .Values.global.nodePort.device | quote }}
+{{- end }}
+
 {{- end }}
 {{- if and .Values.global.pprof .Values.global.pprof.enabled }}
   pprof: {{ .Values.global.pprof.enabled | quote }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -199,7 +199,10 @@ global:
     enabled: false
 
     # range is the port range to use for NodePort
-    # range: 
+    # range:
+
+    # device is the name of the device handling NodePort requests
+    # device:
 
   # flannel is the flannel specific configuration
   flannel:


### PR DESCRIPTION
This PR has the following changes:

Helm template for NodePort
    - Add `device` var, so a user can specify it.
    - Quote NodePort range, otherwise invalid `cilium.yaml` can be generated.

GSG:
    - Fix `nodePort` var name.
    - Use correct `device` var name.
    - Improve formatting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8858)
<!-- Reviewable:end -->
