### PR TITLE
Emit AvailableIPsPerSubnet metric

### DIFF
--- a/operator/eni.go
+++ b/operator/eni.go
@@ -176,12 +176,13 @@ func (m *noOpMetricsObserver) QueueEvent(reason string)                         
 type noOpMetrics struct{}
 
 // eni metricsAPI interface implementation
-func (m *noOpMetrics) IncENIAllocationAttempt(status, subnetID string)  {}
-func (m *noOpMetrics) AddIPAllocation(subnetID string, allocated int64) {}
-func (m *noOpMetrics) SetAllocatedIPs(typ string, allocated int)        {}
-func (m *noOpMetrics) SetAvailableENIs(available int)                   {}
-func (m *noOpMetrics) SetNodes(category string, nodes int)              {}
-func (m *noOpMetrics) IncResyncCount()                                  {}
+func (m *noOpMetrics) IncENIAllocationAttempt(status, subnetID string)                           {}
+func (m *noOpMetrics) AddIPAllocation(subnetID string, allocated int64)                          {}
+func (m *noOpMetrics) SetAllocatedIPs(typ string, allocated int)                                 {}
+func (m *noOpMetrics) SetAvailableENIs(available int)                                            {}
+func (m *noOpMetrics) SetAvailableIPsPerSubnet(subnetID, availabilityZone string, available int) {}
+func (m *noOpMetrics) SetNodes(category string, nodes int)                                       {}
+func (m *noOpMetrics) IncResyncCount()                                                           {}
 func (m *noOpMetrics) DeficitResolverTrigger() trigger.MetricsObserver {
 	return &noOpMetricsObserver{}
 }

--- a/pkg/aws/eni/instances.go
+++ b/pkg/aws/eni/instances.go
@@ -69,6 +69,21 @@ func (m *InstancesManager) GetSubnet(subnetID string) *types.Subnet {
 	return m.subnets[subnetID]
 }
 
+// GetSubnets returns all the tracked subnets
+//
+// The returned subnetMap is immutable so it can be safely accessed
+func (m *InstancesManager) GetSubnets() types.SubnetMap {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+
+	subnetsCopy := make(types.SubnetMap)
+	for k, v := range m.subnets {
+		subnetsCopy[k] = v
+	}
+
+	return subnetsCopy
+}
+
 // FindSubnetByTags returns the subnet with the most addresses matching VPC ID,
 // availability zone and all required tags
 //

--- a/pkg/aws/eni/metrics/mock/mock.go
+++ b/pkg/aws/eni/metrics/mock/mock.go
@@ -23,26 +23,28 @@ import (
 )
 
 type mockMetrics struct {
-	mutex              lock.RWMutex
-	allocationAttempts map[string]int64
-	ipAllocations      map[string]int64
-	allocatedIPs       map[string]int
-	availableENIs      int
-	nodes              map[string]int
-	ec2ApiCall         map[string]float64
-	ec2RateLimit       map[string]time.Duration
-	resyncCount        int64
+	mutex                 lock.RWMutex
+	allocationAttempts    map[string]int64
+	ipAllocations         map[string]int64
+	allocatedIPs          map[string]int
+	availableENIs         int
+	availableIPsPerSubnet map[string]int
+	nodes                 map[string]int
+	ec2ApiCall            map[string]float64
+	ec2RateLimit          map[string]time.Duration
+	resyncCount           int64
 }
 
 // NewMockMetrics returns a new metrics implementation with a mocked backend
 func NewMockMetrics() *mockMetrics {
 	return &mockMetrics{
-		allocationAttempts: map[string]int64{},
-		ipAllocations:      map[string]int64{},
-		allocatedIPs:       map[string]int{},
-		nodes:              map[string]int{},
-		ec2ApiCall:         map[string]float64{},
-		ec2RateLimit:       map[string]time.Duration{},
+		allocationAttempts:    map[string]int64{},
+		ipAllocations:         map[string]int64{},
+		allocatedIPs:          map[string]int{},
+		nodes:                 map[string]int{},
+		availableIPsPerSubnet: map[string]int{},
+		ec2ApiCall:            map[string]float64{},
+		ec2RateLimit:          map[string]time.Duration{},
 	}
 }
 
@@ -127,6 +129,12 @@ func (m *mockMetrics) EC2RateLimit(operation string) time.Duration {
 func (m *mockMetrics) ObserveEC2RateLimit(operation string, delay time.Duration) {
 	m.mutex.Lock()
 	m.ec2RateLimit[operation] += delay
+	m.mutex.Unlock()
+}
+
+func (m *mockMetrics) SetAvailableIPsPerSubnet(subnetID, availabilityZone string, available int) {
+	m.mutex.Lock()
+	m.availableIPsPerSubnet[fmt.Sprintf("subnetId=%s, availabilityZone=%s", subnetID, availabilityZone)] = available
 	m.mutex.Unlock()
 }
 


### PR DESCRIPTION


```release-note
Expose available IPs per subnet/availability-zone as a metric when running in ENI IPAM mode.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8862)
<!-- Reviewable:end -->
