### PR TITLE
cilium: encryption, use default route interface if encrypt-interface is not specified

### DIFF
--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -1145,8 +1145,11 @@ func initEnv(cmd *cobra.Command) {
 	}
 
 	if option.Config.EnableIPSec && option.Config.Tunnel == option.TunnelDisabled && option.Config.EncryptInterface == "" {
-		log.WithField(logfields.Tunnel, option.Config.Tunnel).
-			Fatal("Currently ipsec with tunneling disabled requires option \"encrypt-interface\".")
+		link, err := linuxdatapath.NodeDeviceNameWithDefaultRoute()
+		if err != nil {
+			log.Fatal("Ipsec enabled without tunneling but option \"encrypt-interface\" not set and unable to get link for default interface ")
+		}
+		option.Config.EncryptInterface = link
 	}
 
 	// BPF masquerade specified, rejecting unsupported options for this mode.

--- a/pkg/datapath/linux/config.go
+++ b/pkg/datapath/linux/config.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/datapath"
-	"github.com/cilium/cilium/pkg/datapath/linux/route"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
 	bpfconfig "github.com/cilium/cilium/pkg/maps/configmap"
@@ -184,16 +183,8 @@ func (l *linuxDatapath) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeConf
 		}
 	}
 
-	if option.Config.EnableIPSec {
-		var link netlink.Link
-		var err error
-
-		if option.Config.EncryptInterface != "" {
-			link, err = netlink.LinkByName(option.Config.EncryptInterface)
-		} else {
-			link, err = route.NodeDeviceWithDefaultRoute()
-		}
-
+	if option.Config.EncryptInterface != "" {
+		link, err := netlink.LinkByName(option.Config.EncryptInterface)
 		if err == nil {
 			cDefinesMap["ENCRYPT_IFACE"] = fmt.Sprintf("%d", link.Attrs().Index)
 


### PR DESCRIPTION
This PR completes https://github.com/cilium/cilium/pull/8711 "use default route interface if encrypt-interface is not specified"

- removes the test in initEnv
- add the logic from WriteNodeConfig in compileBase to inject the variable in init.sh
- add the logic from WriteNodeConfig in runDaemon to inject the variable in datapathConfig

@jrfastab I used the logic from your initial PR but we now have the same exact code in 3 locations. I wonder if it wouldn't be clearer to put this in initEnv instead. What do you think? I can update the PR

(I tested this change on a test cluster and things look fine)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8867)
<!-- Reviewable:end -->
