### PR TITLE
doc: Fix cosmetic problem of two helm blocks in guides

### DIFF
--- a/Documentation/gettingstarted/grafana.rst
+++ b/Documentation/gettingstarted/grafana.rst
@@ -51,7 +51,7 @@ value:
 
 Generate the required YAML file and deploy it:
 
-.. parsed-literal::
+.. code:: bash
 
    helm template cilium \
       --namespace kube-system \

--- a/Documentation/gettingstarted/k8s-install-etcd-operator.rst
+++ b/Documentation/gettingstarted/k8s-install-etcd-operator.rst
@@ -35,7 +35,7 @@ Deploy Cilium + cilium-etcd-operator
 
 Generate the required YAML file and deploy it:
 
-.. parsed-literal::
+.. code:: bash
 
    helm template cilium \
       --namespace kube-system \


### PR DESCRIPTION
The parsed-literal statement causes the '\' to be interpreted instead of
printing it as-is on multiple lines. Use a code block to have the example
rendered correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8871)
<!-- Reviewable:end -->
