### PR TITLE
Revert "[daemon] - Change MTU source for cilium_host (Use the Route o…ne)"

### DIFF
--- a/daemon/datapath.go
+++ b/daemon/datapath.go
@@ -94,7 +94,7 @@ func (d *Daemon) compileBase() error {
 		args[initArgIPv6NodeIP] = "<nil>"
 	}
 
-	args[initArgMTU] = fmt.Sprintf("%d", d.mtuConfig.GetRouteMTU())
+	args[initArgMTU] = fmt.Sprintf("%d", d.mtuConfig.GetDeviceMTU())
 
 	if option.Config.EnableIPSec {
 		args[initArgIPSec] = "true"


### PR DESCRIPTION
This reverts commit 86f926e816dc871bdd985c82f556644aae58c6d9.

This commit introduces a regression in the datapath which causes traffic
coming from the outside world to have its packets fragmented since the
MTU of the cilium_host interface is lower than the MTU of the external
facing device. This causes 2 major problems:

1) Regression in the network speed of communications made to the outside
world, here is a simple `curl` made to `www.google.com` where the first
attempt was made with the commit reverted and the second
attempt was made with the current master branch:
```
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 12482    0 12482    0     0  30155      0 --:--:-- --:--:-- --:--:-- 30222
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 12525    0 12525    0     0   5320      0 --:--:--  0:00:02 --:--:--  5322
```

2) Since the datapath does not handle IP fragmentation it creates CT
entries that are wrong, since the offset of a the 5 tuple assumes the IP
packet is not fragmented, here are a couple of entries that should not
have been created: (One of the ports in this tuple should have port 80
and not random ports that were based in the offset of the 5 tuple of a
fragmented IP packet)

```
TCP IN 172.217.168.4:26740 -> 10.16.238.103:14896 expir...
TCP IN 172.217.168.4:28525 -> 10.16.238.103:28769 expir...
TCP IN 172.217.168.4:28521 -> 10.16.238.103:28276 expir...
TCP IN 172.217.168.4:28263 -> 10.16.238.103:24930 expir...
TCP IN 172.217.168.4:26469 -> 10.16.238.103:29780 expir...
TCP IN 172.217.168.4:12344 -> 10.16.238.103:11313 expir...
```

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8882)
<!-- Reviewable:end -->
