### PR TITLE
[WIP] Ensure connectivity between pods when ip_forward is globally disabled

### DIFF
--- a/pkg/sysctl/doc.go
+++ b/pkg/sysctl/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package sysctl allows to change kernel parameters at runtime.
+package sysctl

--- a/pkg/sysctl/sysctl.go
+++ b/pkg/sysctl/sysctl.go
@@ -1,0 +1,15 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sysctl

--- a/pkg/sysctl/sysctl_linux.go
+++ b/pkg/sysctl/sysctl_linux.go
@@ -1,0 +1,61 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// +build linux
+
+package sysctl
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	prefixDir = "/proc/sys"
+)
+
+func fullPath(name string) string {
+	return filepath.Join(prefixDir, strings.Replace(name, ".", "/", -1))
+}
+
+func readSysctl(name string) ([]byte, error) {
+	fPath := fullPath(name)
+	b, err := ioutil.ReadFile(fPath)
+	if err != nil {
+		return nil, fmt.Errorf("could not read the sysctl file %s: %s",
+			fPath, err)
+	}
+	return b[:], nil
+}
+
+func writeSysctl(name string, value []byte) error {
+	fPath := fullPath(name)
+	if err := ioutil.WriteFile(fPath, value, 0644); err != nil {
+		return fmt.Errorf("could not write to the systctl file %s: %s",
+			fPath, err)
+	}
+	return nil
+}
+
+// Disable disables the given sysctl parameter.
+func Disable(name string) error {
+	return writeSysctl(name, []byte("0"))
+}
+
+// Enable enables the given sysctl parameter.
+func Enable(name string) error {
+	return writeSysctl(name, []byte("1"))
+}

--- a/pkg/sysctl/sysctl_linux_privileged_test.go
+++ b/pkg/sysctl/sysctl_linux_privileged_test.go
@@ -1,0 +1,110 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux,privileged_tests
+
+package sysctl
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type SysctlLinuxPrivilegedTestSuite struct{}
+
+var _ = Suite(&SysctlLinuxPrivilegedTestSuite{})
+
+func (s *SysctlLinuxPrivilegedTestSuite) TestWriteSysctl(c *C) {
+	testCases := []struct {
+		name        string
+		value       []byte
+		oldValue    []byte
+		expectedErr bool
+	}{
+		{
+			name:        "net.ipv4.ip_forward",
+			value:       []byte("0"),
+			expectedErr: false,
+		},
+		{
+			name:        "net.ipv4.conf.all.forwarding",
+			value:       []byte("0"),
+			expectedErr: false,
+		},
+		{
+			name:        "net.ipv6.conf.all.forwarding",
+			value:       []byte("0"),
+			expectedErr: false,
+		},
+		{
+			name:        "foo.bar",
+			value:       []byte("1"),
+			expectedErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		err := writeSysctl(tc.name, tc.value)
+		if tc.expectedErr {
+			c.Assert(err, NotNil)
+		} else {
+			c.Assert(err, IsNil)
+		}
+	}
+}
+
+func (s *SysctlLinuxPrivilegedTestSuite) TestDisableEnable(c *C) {
+	testCases := []struct {
+		name        string
+		expectedErr bool
+	}{
+		{
+			name:        "net.ipv4.ip_forward",
+			expectedErr: false,
+		},
+		{
+			name:        "net.ipv4.conf.all.forwarding",
+			expectedErr: false,
+		},
+		{
+			name:        "net.ipv6.conf.all.forwarding",
+			expectedErr: false,
+		},
+		{
+			name:        "foo.bar",
+			expectedErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		err := Enable(tc.name)
+		if tc.expectedErr {
+			c.Assert(err, NotNil)
+		} else {
+			c.Assert(err, IsNil)
+		}
+		err = Disable(tc.name)
+		if tc.expectedErr {
+			c.Assert(err, NotNil)
+		} else {
+			c.Assert(err, IsNil)
+		}
+	}
+}

--- a/pkg/sysctl/sysctl_linux_test.go
+++ b/pkg/sysctl/sysctl_linux_test.go
@@ -1,0 +1,93 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux
+
+package sysctl
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type SysctlLinuxTestSuite struct{}
+
+var _ = Suite(&SysctlLinuxTestSuite{})
+
+func (s *SysctlLinuxTestSuite) TestFullPath(c *C) {
+	testCases := []struct {
+		name     string
+		expected string
+	}{
+		{
+			name:     "net.ipv4.ip_forward",
+			expected: "/proc/sys/net/ipv4/ip_forward",
+		},
+		{
+			name:     "net.ipv4.conf.all.forwarding",
+			expected: "/proc/sys/net/ipv4/conf/all/forwarding",
+		},
+		{
+			name:     "net.ipv6.conf.all.forwarding",
+			expected: "/proc/sys/net/ipv6/conf/all/forwarding",
+		},
+		{
+			name:     "foo.bar",
+			expected: "/proc/sys/foo/bar",
+		},
+	}
+
+	for _, tc := range testCases {
+		c.Assert(fullPath(tc.name), Equals, tc.expected)
+	}
+}
+
+func (s *SysctlLinuxTestSuite) TestReadSysctl(c *C) {
+	testCases := []struct {
+		name        string
+		expectedErr bool
+	}{
+		{
+			name:        "net.ipv4.ip_forward",
+			expectedErr: false,
+		},
+		{
+			name:        "net.ipv4.conf.all.forwarding",
+			expectedErr: false,
+		},
+		{
+			name:        "net.ipv6.conf.all.forwarding",
+			expectedErr: false,
+		},
+		{
+			name:        "foo.bar",
+			expectedErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		_, err := readSysctl(tc.name)
+		if tc.expectedErr {
+			c.Assert(err, NotNil)
+		} else {
+			c.Assert(err, IsNil)
+		}
+	}
+}

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -101,7 +101,9 @@ Vagrant.configure("2") do |config|
                 nfs: $NFS
             # Provision section
             server.vm.provision :shell,
-                :inline => "sudo sysctl -w net.ipv6.conf.all.forwarding=1"
+                :inline => "sudo sysctl -w net.ipv4.conf.all.forwarding=0"
+            server.vm.provision :shell,
+                :inline => "sudo sysctl -w net.ipv6.conf.all.forwarding=0"
             server.vm.provision :shell,
                 :inline => "sed -i 's/^mesg n$/tty -s \\&\\& mesg n/g' /root/.profile"
             server.vm.provision "file", source: "provision/", destination: "/tmp/"


### PR DESCRIPTION
This PR aims to enable forwarding for network devices managed by Cilium in case when the global `net.ipv4.ip_forward` sysctl is disabled. Still in progress.

TODO
- [x] enable routing for endpoint veth pairs
- [ ] ensure that there are no other devices to enable
- [ ] unit tests
- [x] integration test with `net.ipv4.ip_forward` disabled

<!-- Description of change -->

Fixes: #8476

```release-note
Ensure connectivity between pods when ip_forward is globally disabled
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8887)
<!-- Reviewable:end -->
