### PR TITLE
envoy: Use patched image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:2e42144f26667ddee9f5d2506019f16c57386b29 as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:d68c2561fae4c83960969a7aaa2a186c3b30e17a as cilium-envoy
 
 #
 # Cilium incremental build. Should be fast given builder-deps is up-to-date!


### PR DESCRIPTION
[ upstream commit a309f9886c34a834a03bd7a4079db99119e364f8 ]

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

```release-note
Envoy is updated to version 1.11.1
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8892)
<!-- Reviewable:end -->
