### PR TITLE
Enable insertNeighbor when tunneling is disabled

### DIFF
--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -660,7 +660,7 @@ func (n *linuxNodeHandler) nodeUpdate(oldNode, newNode *node.Node, firstAddition
 	}
 
 	if option.Config.EnableNodePort ||
-		(n.nodeConfig.EnableIPSec && option.Config.Tunnel != option.TunnelDisabled) {
+		(n.nodeConfig.EnableIPSec && option.Config.Tunnel == option.TunnelDisabled) {
 		var ifaceName string
 		if option.Config.EnableNodePort {
 			ifaceName = option.Config.Device


### PR DESCRIPTION
This test was reversed: we need to insertNeighbor when tunneling is disabled

cc @brb / @jrfastab

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8893)
<!-- Reviewable:end -->
