### PR TITLE
controller: do not return controller from `UpdateController`

### DIFF
--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -121,7 +121,7 @@ func (b *ControllerSuite) TestRunController(c *C) {
 	mngr := NewManager()
 	o := &testObj{}
 
-	ctrl := mngr.UpdateController("test", ControllerParams{
+	ctrl := mngr.updateController("test", ControllerParams{
 		DoFunc: func(ctx context.Context) error {
 			// after two failed attempts, start succeeding
 			if o.cnt >= 2 {

--- a/pkg/controller/manager.go
+++ b/pkg/controller/manager.go
@@ -55,7 +55,11 @@ func GetGlobalStatus() models.ControllerStatuses {
 // controller. Updating a controller will cause the DoFunc to be run
 // immediately regardless of any previous conditions. It will also cause any
 // statistics to be reset.
-func (m *Manager) UpdateController(name string, params ControllerParams) *Controller {
+func (m *Manager) UpdateController(name string, params ControllerParams) {
+	m.updateController(name, params)
+}
+
+func (m *Manager) updateController(name string, params ControllerParams) *Controller {
 	start := time.Now()
 
 	// ensure the callbacks are valid

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -303,8 +303,8 @@ type Endpoint struct {
 
 // UpdateController updates the controller with the specified name with the
 // provided list of parameters in endpoint's list of controllers.
-func (e *Endpoint) UpdateController(name string, params controller.ControllerParams) *controller.Controller {
-	return e.controllers.UpdateController(name, params)
+func (e *Endpoint) UpdateController(name string, params controller.ControllerParams) {
+	e.controllers.UpdateController(name, params)
 }
 
 // CloseBPFProgramChannel closes the channel that signals whether the endpoint


### PR DESCRIPTION
Only one callee of this function ever used the resultant controller, which was
in the tests within the package itself. Callers should not need access to the
controller directly, as the manager is responsible for it.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8894)
<!-- Reviewable:end -->
