### PR TITLE
endpoint: remove unused `HealthCEPPrefix` string

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -98,9 +98,6 @@ const (
 
 	// IpvlanMapName specifies the tail call map for EP on egress used with ipvlan.
 	IpvlanMapName = "cilium_lxc_ipve_"
-
-	// HealthCEPPrefix is the prefix used to name the cilium health endpoints' CEP
-	HealthCEPPrefix = "cilium-health-"
 )
 
 // compile time interface check


### PR DESCRIPTION
Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8896)
<!-- Reviewable:end -->
