### PR TITLE
Fix documentation warnings and fail out when new ones are introduced

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -6,6 +6,7 @@ include ../Makefile.quiet
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = Cilium
+IGNOREDWARNINGS := -e "tabs assets" -e "misspelled words" -e "RemovedInSphinx20Warning"
 SOURCEDIR     = .
 BUILDDIR      = _build
 CMDREFDIR     = cmdref
@@ -51,8 +52,13 @@ cmdref:
 # Finally, fail out if we can't remove the file that marks success.
 check-build: check-requirements
 	@$(ECHO_CHECK) documentation build...
-	$(QUIET)! ($(SPHINXBUILD) -b spelling -d "$(BUILDDIR)/doctrees" "$(SOURCEDIR)" "$(BUILDDIR)/spelling" -q -E $(SPHINXOPTS) && touch $@.ok) \
-		| grep -v -e "tabs assets" -e "misspelled words"
+	@mkdir -p $(BUILDDIR)
+	$(QUIET)($(SPHINXBUILD) -b spelling -d "$(BUILDDIR)/doctrees" "$(SOURCEDIR)" "$(BUILDDIR)/spelling" -q -E $(SPHINXOPTS) 2>&1 && touch $@.ok) > $(BUILDDIR)/warnings.txt
+	@if grep -q -v $(IGNOREDWARNINGS) $(BUILDDIR)/warnings.txt; then \
+		echo "Please fix the following documentation warnings:"; \
+		grep -v $(IGNOREDWARNINGS) "$(BUILDDIR)/warnings.txt"; \
+		exit 1; \
+	fi
 	@if [ "$$(wc -l < "$(BUILDDIR)/spelling/output.txt")" -ne "0" ]; then \
 		echo "Please fix the following spelling mistakes:"; \
 		sed 's/^/* Documentation\//' $(BUILDDIR)/spelling/output.txt; \

--- a/Documentation/contributing/ci.rst
+++ b/Documentation/contributing/ci.rst
@@ -70,13 +70,13 @@ Cilium-Nightly-Tests-PR
 Runs long-lived tests which take extended time. Some of these tests have an
 expected failure rate.
 
-Nightly tests run once per day in the `Cilium-Nightly-Tests Job`_.  The
+Nightly tests run once per day in the ``Cilium-Nightly-Tests Job``.  The
 configuration for this job is stored in ``Jenkinsfile.nightly``.
 
 To see the results of these tests, you can view the JUnit Report for an individual job:
 
 1. Click on the build number you wish to get test results from on the left hand
-   side of the `Cilium-Nightly-Tests Job`_.
+   side of the ``Cilium-Nightly-Tests Job``.
 2. Click on 'Test Results' on the left side of the page to view the results from the build.
    This will give you a report of which tests passed and failed. You can click on each test
    to view its corresponding output created from Ginkgo.

--- a/Documentation/contributing/contributing.rst
+++ b/Documentation/contributing/contributing.rst
@@ -1367,61 +1367,61 @@ update:
 
 0. After login, select the tab "builds" on the left menu.
 
-.. image:: images/cilium-quayio-tag-0.png
+.. image:: ../images/cilium-quayio-tag-0.png
     :align: center
 
 1. Click on the wheel.
 2. Enable the trigger for that build trigger.
 
-.. image:: images/cilium-quayio-tag-1.png
+.. image:: ../images/cilium-quayio-tag-1.png
     :align: center
 
 3. Confirm that you want to enable the trigger.
 
-.. image:: images/cilium-quayio-tag-2.png
+.. image:: ../images/cilium-quayio-tag-2.png
     :align: center
 
 4. After enabling the trigger, click again on the wheel.
 5. And click on "Run Trigger Now".
 
-.. image:: images/cilium-quayio-tag-3.png
+.. image:: ../images/cilium-quayio-tag-3.png
     :align: center
 
 6. A new pop-up will appear and you can select the branch that contains your
    changes.
 7. Select the branch that contains the new changes.
 
-.. image:: images/cilium-quayio-tag-4.png
+.. image:: ../images/cilium-quayio-tag-4.png
     :align: center
 
 8. After selecting your branch click on "Start Build".
 
-.. image:: images/cilium-quayio-tag-5.png
+.. image:: ../images/cilium-quayio-tag-5.png
     :align: center
 
 9. Once the build has started you can disable the Build trigger by clicking on
    the wheel.
 10. And click on "Disable Trigger".
 
-.. image:: images/cilium-quayio-tag-6.png
+.. image:: ../images/cilium-quayio-tag-6.png
     :align: center
 
 11. Confirm that you want to disable the build trigger.
 
-.. image:: images/cilium-quayio-tag-7.png
+.. image:: ../images/cilium-quayio-tag-7.png
     :align: center
 
 12. Once the build is finished click under Tags (on the left menu).
 13. Click on the wheel and;
 14. Add a new tag to the image that was built.
 
-.. image:: images/cilium-quayio-tag-8.png
+.. image:: ../images/cilium-quayio-tag-8.png
     :align: center
 
 15. Write the name of the tag that you want to give for the newly built image.
 16. Confirm the name is correct and click on "Create Tag".
 
-.. image:: images/cilium-quayio-tag-9.png
+.. image:: ../images/cilium-quayio-tag-9.png
     :align: center
 
 17. After the new tag was created you can delete the other tag, which is the
@@ -1429,12 +1429,12 @@ update:
 18. Click in Actions.
 19. Click in "Delete Tags".
 
-.. image:: images/cilium-quayio-tag-10.png
+.. image:: ../images/cilium-quayio-tag-10.png
     :align: center
 
 20. Confirm that you want to delete tag with your branch name.
 
-.. image:: images/cilium-quayio-tag-11.png
+.. image:: ../images/cilium-quayio-tag-11.png
     :align: center
 
 You have created a new image build with a new tag. The next steps should be to
@@ -1521,7 +1521,7 @@ Use your real name (sorry, no pseudonyms or anonymous contributions.)
 
 .. toctree::
 
-   commit-access
+   ../commit-access
 
 .. _cilium/nightly: https://hub.docker.com/r/cilium/nightly/
 .. _Cilium-Nightly-Tests Job: https://jenkins.cilium.io/job/Cilium-Master-Nightly-Tests-All/

--- a/Documentation/gettingstarted/kata-gce.rst
+++ b/Documentation/gettingstarted/kata-gce.rst
@@ -173,7 +173,7 @@ Generate the required YAML file and deploy it:
 
 .. note::
 
-   If you are using `containerd`, set ``global.containerRuntime.integration=containerd``.
+   If you are using ``containerd``, set ``global.containerRuntime.integration=containerd``.
 
 Validate cilium
 ===============

--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -839,7 +839,7 @@ Example migration
 
 .. note::
 
-    It is also possible to use the `--k8s-kubeconfig-path`  and `--kvstore-opt`
+    It is also possible to use the ``--k8s-kubeconfig-path``  and ``--kvstore-opt``
     ``cilium`` CLI options with the preflight command. The default is to derive the
     configuration as cilium-agent does.
 


### PR DESCRIPTION
* Fix all the existing documentation warnings
* Amend the makefile to ensure that when there's a new warning introduced, `make test-docs` will fail out too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8900)
<!-- Reviewable:end -->
