### PR TITLE
cilium: route mtu not set unless route.Spec set MTU

### DIFF
--- a/pkg/datapath/linux/route/route_linux.go
+++ b/pkg/datapath/linux/route/route_linux.go
@@ -259,7 +259,7 @@ func Upsert(route Route, mtuConfig *mtu.Configuration) (bool, error) {
 	routeSpec := route.getNetlinkRoute()
 	routeSpec.LinkIndex = link.Attrs().Index
 
-	if routeSpec.MTU != 0 && mtuConfig != nil {
+	if mtuConfig != nil {
 		// If the route includes the local address, then the route is for
 		// local containers and we can use a high MTU for transmit. Otherwise,
 		// it needs to be able to fit within the MTU of tunnel devices.


### PR DESCRIPTION
Calling route.Upsert() with an MTU parameter will only set the MTU on
the route if the MTU of the route spec (first argument to Upsert)
also sets the MTU to some non-zero value. However, this condition is
not met by any route.Upsert() calls. It seems calling code expects
the route to use the MTU param.

At least Encryption code expected this and is causing routes to
violate MTU. And when using vxlan I expected routes to use a lower
route MTU to account for vxlan header but this is not the case.

After this patch the MTU param will be used to set the route MTU if
it is !nil. If users of the API want to explicitly set the MTU then
they need to set the route spec MTU value and nil the MTU param into
route.Upsert().

Fixes:#8883
Signed-off-by: John Fastabend <john.fastabend@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8903)
<!-- Reviewable:end -->
