### PR TITLE
operator: Fix kvstore configuration inheritance from ConfigMap

### DIFF
--- a/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
@@ -77,6 +77,18 @@ spec:
               key: disable-endpoint-crd
               name: cilium-config
               optional: true
+        - name: CILIUM_KVSTORE
+          valueFrom:
+            configMapKeyRef:
+              key: kvstore
+              name: cilium-config
+              optional: true
+        - name: CILIUM_KVSTORE_OPT
+          valueFrom:
+            configMapKeyRef:
+              key: kvstore-opt
+              name: cilium-config
+              optional: true
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
             secretKeyRef:

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -128,6 +128,7 @@ data:
   # - auto (automatically detect the container runtime)
   #
   container-runtime: none
+
   masquerade: "true"
 
   install-iptables-rules: "true"
@@ -441,6 +442,8 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
+        - mountPath: /run/xtables.lock
+          name: xtables-lock
       hostNetwork: true
       initContainers:
       - command:
@@ -508,6 +511,11 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
+        # To access iptables concurrently with other processes (e.g. kube-proxy)
+      - hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate
+        name: xtables-lock
         # To read the clustermesh configuration
       - name: clustermesh-secrets
         secret:
@@ -597,6 +605,18 @@ spec:
               key: disable-endpoint-crd
               name: cilium-config
               optional: true
+        - name: CILIUM_KVSTORE
+          valueFrom:
+            configMapKeyRef:
+              key: kvstore
+              name: cilium-config
+              optional: true
+        - name: CILIUM_KVSTORE_OPT
+          valueFrom:
+            configMapKeyRef:
+              key: kvstore-opt
+              name: cilium-config
+              optional: true
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
             secretKeyRef:
@@ -630,4 +650,16 @@ spec:
       restartPolicy: Always
       serviceAccount: cilium-operator
       serviceAccountName: cilium-operator
+
+---
+# Source: cilium/charts/agent/templates/servicemonitor.yaml
+
+---
+# Source: cilium/charts/agent/templates/svc.yaml
+
+---
+# Source: cilium/charts/operator/templates/servicemonitor.yaml
+
+---
+# Source: cilium/charts/operator/templates/svc.yaml
 

--- a/operator/main.go
+++ b/operator/main.go
@@ -105,8 +105,10 @@ func init() {
 	flags.BoolP("debug", "D", false, "Enable debugging mode")
 	flags.StringVar(&k8sAPIServer, "k8s-api-server", "", "Kubernetes api address server (for https use --k8s-kubeconfig-path instead)")
 	flags.StringVar(&k8sKubeConfigPath, "k8s-kubeconfig-path", "", "Absolute path of the kubernetes kubeconfig file")
-	flags.StringVar(&kvStore, "kvstore", "", "Key-value store type")
-	flags.Var(option.NewNamedMapOptions("kvstore-opts", &kvStoreOpts, nil), "kvstore-opt", "Key-value store options")
+	flags.String(option.KVStore, "", "Key-value store type")
+	option.BindEnv(option.KVStore)
+	flags.Var(option.NewNamedMapOptions(option.KVStoreOpt, &kvStoreOpts, nil), option.KVStoreOpt, "Key-value store options")
+	option.BindEnv(option.KVStoreOpt)
 	flags.Uint16Var(&apiServerPort, "api-server-port", 9234, "Port on which the operator should serve API requests")
 	flags.String(option.IPAM, "", "Backend to use for IPAM")
 	option.BindEnv(option.IPAM)
@@ -171,7 +173,7 @@ func initConfig() {
 }
 
 func kvstoreEnabled() bool {
-	if option.Config.KVStore == "" {
+	if kvStore == "" {
 		return false
 	}
 
@@ -193,6 +195,8 @@ func runOperator(cmd *cobra.Command) {
 
 	k8sClientQPSLimit := viper.GetFloat64(option.K8sClientQPSLimit)
 	k8sClientBurst := viper.GetInt(option.K8sClientBurst)
+	kvStore = viper.GetString(option.KVStore)
+	kvStoreOpts = viper.GetStringMapString(option.KVStoreOpt)
 
 	k8s.Configure(k8sAPIServer, k8sKubeConfigPath, float32(k8sClientQPSLimit), k8sClientBurst)
 	if err := k8s.Init(); err != nil {

--- a/test/k8sT/manifests/v1.5/cilium-operator-patch.yaml
+++ b/test/k8sT/manifests/v1.5/cilium-operator-patch.yaml
@@ -1,0 +1,15 @@
+---
+metadata:
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      terminationGracePeriodSeconds: 0
+      containers:
+      - image: docker.io/cilium/operator:v1.5.5
+        imagePullPolicy: IfNotPresent
+        name: cilium-operator
+      volumes:
+      - name: etcd-secrets
+        secret:
+          secretName: cilium-etcd-client-tls


### PR DESCRIPTION
The kvstore settings were not correctly derived from the ConfigMap which
resulted in all kvstore functionality to always be disabled.

Fixes: da0c5271b923 ("operator: Don't attempt to connect to kvstore if disabled")
Fixes: #8849

Reported-by: @juan-daishogroup
Reported-by: Ara Zarifian

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8904)
<!-- Reviewable:end -->
