### PR TITLE
cilium: route mtu not set unless route.Spec set MTU

### DIFF
--- a/pkg/datapath/linux/route/route_linux.go
+++ b/pkg/datapath/linux/route/route_linux.go
@@ -259,7 +259,7 @@ func Upsert(route Route, mtuConfig *mtu.Configuration) (bool, error) {
 	routeSpec := route.getNetlinkRoute()
 	routeSpec.LinkIndex = link.Attrs().Index
 
-	if routeSpec.MTU != 0 && mtuConfig != nil {
+	if mtuConfig != nil {
 		// If the route includes the local address, then the route is for
 		// local containers and we can use a high MTU for transmit. Otherwise,
 		// it needs to be able to fit within the MTU of tunnel devices.


### PR DESCRIPTION
Duplicate of #8903 but I think the patch is missing from the PR

Tested on our clusters and things look much better now: routes have the proper MTU and things that were failing work fine without changing on cilium_host

(feel free to close and @jrfastab PR instead of course)

Signed-off-by: Laurent Bernaille <laurent.bernaille@datadoghq.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8909)
<!-- Reviewable:end -->
