### PR TITLE
Revert "Bump vagrant box versions"

### DIFF
--- a/vagrant_box_defaults.rb
+++ b/vagrant_box_defaults.rb
@@ -3,6 +3,6 @@
 Vagrant.require_version ">= 2.2.0"
 
 $SERVER_BOX = "cilium/ubuntu-dev"
-$SERVER_VERSION= "158"
+$SERVER_VERSION= "157"
 $NETNEXT_SERVER_BOX= "cilium/ubuntu-next"
-$NETNEXT_SERVER_VERSION= "32"
+$NETNEXT_SERVER_VERSION= "31"


### PR DESCRIPTION
This reverts commit 7a26388b37652efc9aefb2a347e3bcff0facefa0.

Seems like we might have hit some issue with apt in newest vagrant box and it caused CI to fail, let's revert it for now just in case until we get to the bottom of it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8912)
<!-- Reviewable:end -->
