### PR TITLE
install: Allow skipping CNI install

### DIFF
--- a/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
@@ -75,6 +75,7 @@ spec:
         image: "{{ .Values.global.registry }}/{{ .Values.image }}:{{ .Values.global.tag }}"
 {{- end }}
         imagePullPolicy: {{ .Values.global.pullPolicy }}
+{{- if .Values.global.cni.install }}
         lifecycle:
           postStart:
             exec:
@@ -84,6 +85,7 @@ spec:
             exec:
               command:
               - /cni-uninstall.sh
+{{- end }}
         livenessProbe:
           exec:
             command:

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -94,6 +94,10 @@ global:
 
   # cni is the CNI configuration
   cni:
+    # install determines whether to install the CNI configuration and binary
+    # files into the filesystem.
+    install: true
+
     # chainingMode enables chaining on top of other CNI plugins. Possible
     # values:
     #  - none


### PR DESCRIPTION
In microk8s environments, the containers shouldn't be rewriting files on the filesystem at runtime for things like custom configuration or the CNI binaries. 

The current guide basically configures the CNI binary path to a writable location under `/opt` to get around this, but it's a bit messy to pollute the filesystem like this.

Upcoming work on upstream microk8s can configure Cilium in a microk8s/snap-friendly manner by disabling the CNI binary install here and instead copying the binary into the correct location in the filesystem as part of the cilium addon install scripting.

Nominating for v1.6 as it's low risk and would assist microk8s + cilium if it's part of the upcoming release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8913)
<!-- Reviewable:end -->
