### PR TITLE
v1.6 backports 2019-08-15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: trusty
 sudo: required
 
 go:
- - 1.12.7
+ - 1.12.8
 
 if: branch = master OR type = pull_request
 
@@ -17,6 +17,6 @@ before_install: ./.travis/prepare.sh
 
 before_script:
   - export PATH=/usr/local/clang/bin:$PATH
-  - export GO=/home/travis/.gimme/versions/go1.12.7.linux.amd64/bin/go
+  - export GO=/home/travis/.gimme/versions/go1.12.8.linux.amd64/bin/go
 
 script: ./.travis/build.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ FROM quay.io/cilium/cilium-envoy:d68c2561fae4c83960969a7aaa2a186c3b30e17a as cil
 # versions to be built while allowing the new versions to make changes
 # that are not backwards compatible.
 #
-FROM quay.io/cilium/cilium-builder:2019-07-11 as builder
+FROM quay.io/cilium/cilium-builder:2019-08-13 as builder
 LABEL maintainer="maintainer@cilium.io"
 WORKDIR /go/src/github.com/cilium/cilium
 COPY . ./
@@ -37,7 +37,7 @@ RUN make LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 V=$V LIBNETWORK_PLUGIN=$LIBNETWORK_PLU
 # built while allowing the new versions to make changes that are not
 # backwards compatible.
 #
-FROM quay.io/cilium/cilium-runtime:2019-07-11
+FROM quay.io/cilium/cilium-runtime:2019-08-13
 LABEL maintainer="maintainer@cilium.io"
 COPY --from=builder /tmp/install /
 COPY --from=cilium-envoy / /

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -14,7 +14,7 @@ WORKDIR /go/src/github.com/cilium/cilium
 ENV GOROOT /usr/local/go
 ENV GOPATH /go
 ENV PATH "$GOROOT/bin:$GOPATH/bin:$PATH"
-ENV GO_VERSION 1.12.7
+ENV GO_VERSION 1.12.8
 
 #
 # Build dependencies

--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -15,135 +15,136 @@ cilium-agent [flags]
 ### Options
 
 ```
-      --access-log string                          Path to access log of supported L7 requests observed
-      --agent-labels strings                       Additional labels to identify this agent
-      --allow-localhost string                     Policy when to allow local stack to reach local endpoints { auto | always | policy } (default "auto")
-      --annotate-k8s-node                          Annotate Kubernetes node (default true)
-      --auto-create-cilium-node-resource           Automatically create CiliumNode resource for own node on startup (default true)
-      --auto-direct-node-routes                    Enable automatic L2 routing between nodes
-      --blacklist-conflicting-routes               Don't blacklist IP allocations conflicting with local non-cilium routes (default true)
-      --bpf-compile-debug                          Enable debugging of the BPF compilation process
-      --bpf-ct-global-any-max int                  Maximum number of entries in non-TCP CT table (default 262144)
-      --bpf-ct-global-tcp-max int                  Maximum number of entries in TCP CT table (default 1000000)
-      --bpf-nat-global-max int                     Maximum number of entries for the global BPF NAT table (default 841429)
-      --bpf-policy-map-max int                     Maximum number of entries in endpoint policy map (per endpoint) (default 16384)
-      --bpf-root string                            Path to BPF filesystem
-      --cgroup-root string                         Path to Cgroup2 filesystem
-      --cluster-id int                             Unique identifier of the cluster
-      --cluster-name string                        Name of the cluster (default "default")
-      --clustermesh-config string                  Path to the ClusterMesh configuration directory
-      --config string                              Configuration file (default "$HOME/ciliumd.yaml")
-      --config-dir string                          Configuration directory that contains a file for each option
-      --conntrack-gc-interval duration             Overwrite the connection-tracking garbage collection interval
-      --container-runtime strings                  Sets the container runtime(s) used by Cilium { containerd | crio | docker | none | auto } ( "auto" uses the container runtime found in the order: "docker", "containerd", "crio" ) (default [auto])
-      --container-runtime-endpoint map             Container runtime(s) endpoint(s). (default: --container-runtime-endpoint=containerd=/var/run/containerd/containerd.sock, --container-runtime-endpoint=crio=/var/run/crio/crio.sock, --container-runtime-endpoint=docker=unix:///var/run/docker.sock) (default map[])
-      --datapath-mode string                       Datapath mode name (default "veth")
-  -D, --debug                                      Enable debugging mode
-      --debug-verbose strings                      List of enabled verbose debug groups
-  -d, --device string                              Device facing cluster/external network for direct L3 (non-overlay mode) (default "undefined")
-      --disable-conntrack                          Disable connection tracking
-      --disable-endpoint-crd                       Disable use of CiliumEndpoint CRD
-      --disable-k8s-services                       Disable east-west K8s load balancing by cilium
-  -e, --docker string                              Path to docker runtime socket (DEPRECATED: use container-runtime-endpoint instead) (default "unix:///var/run/docker.sock")
-      --egress-masquerade-interfaces string        Limit egress masquerading to interface selector
-      --enable-endpoint-routes                     Use per endpoint routes instead of routing via cilium_host
-      --enable-health-checking                     Enable connectivity health checking (default true)
-      --enable-host-reachable-services             Enable reachability of services for host applications (beta)
-      --enable-ipsec                               Enable IPSec support
-      --enable-ipv4                                Enable IPv4 support (default true)
-      --enable-ipv6                                Enable IPv6 support (default true)
-      --enable-k8s-event-handover                  Enable k8s event handover to kvstore for improved scalability
-      --enable-node-port                           Enable NodePort type services by Cilium (beta)
-      --enable-policy string                       Enable policy enforcement (default "default")
-      --enable-tracing                             Enable tracing while determining policy (debugging)
-      --encrypt-interface string                   Transparent encryption interface
-      --encrypt-node                               Enables encrypting traffic from non-Cilium pods and host networking
-      --endpoint-interface-name-prefix string      Prefix of interface name shared by all endpoints (default "lxc+")
-      --endpoint-queue-size int                    size of EventQueue per-endpoint (default 25)
-      --envoy-log string                           Path to a separate Envoy log file, if any
-      --exclude-local-address strings              Exclude CIDR from being recognized as local address
-      --fixed-identity-mapping map                 Key-value for the fixed identity mapping which allows to use reserved label for fixed identities (default map[])
-      --flannel-manage-existing-containers         Installs a BPF program to allow for policy enforcement in already running containers managed by Flannel. Require Cilium to be running in the hostPID.
-      --flannel-master-device string               Installs a BPF program to allow for policy enforcement in the given network interface. Allows to run Cilium on top of other CNI plugins that provide networking, e.g. flannel, where for flannel, this value should be set with 'cni0'. [EXPERIMENTAL]
-      --flannel-uninstall-on-exit                  When used along the flannel-master-device flag, it cleans up all BPF programs installed when Cilium agent is terminated.
-      --force-local-policy-eval-at-source          Force policy evaluation of all local communication at the source endpoint (default true)
-  -h, --help                                       help for cilium-agent
-      --host-reachable-services-protos strings     Only enable reachability of services for host applications for specific protocols (default [tcp,udp])
-      --http-idle-timeout uint                     Time after which a non-gRPC HTTP stream is considered failed unless traffic in the stream has been processed (in seconds); defaults to 0 (unlimited)
-      --http-max-grpc-timeout uint                 Time after which a forwarded gRPC request is considered failed unless completed (in seconds). A "grpc-timeout" header may override this with a shorter value; defaults to 0 (unlimited)
-      --http-request-timeout uint                  Time after which a forwarded HTTP request is considered failed unless completed (in seconds); Use 0 for unlimited (default 3600)
-      --http-retry-count uint                      Number of retries performed after a forwarded request attempt fails (default 3)
-      --http-retry-timeout uint                    Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
-      --identity-allocation-mode string            Method to use for identity allocation (default "kvstore")
-      --identity-change-grace-period duration      Time to wait before using new identity on endpoint identity change (default 5s)
-      --install-iptables-rules                     Install base iptables rules for cilium to mainly interact with kube-proxy (and masquerading) (default true)
-      --ip-allocation-timeout duration             Time after which an incomplete CIDR allocation is considered failed (default 2m0s)
-      --ipam string                                Backend to use for IPAM
-      --ipsec-key-file string                      Path to IPSec key file
-      --ipv4-cluster-cidr-mask-size int            Mask size for the cluster wide CIDR (default 8)
-      --ipv4-node string                           IPv4 address of node (default "auto")
-      --ipv4-pod-subnets strings                   List of IPv4 pod subnets to preconfigure for encryption
-      --ipv4-range string                          Per-node IPv4 endpoint prefix, e.g. 10.16.0.0/16 (default "auto")
-      --ipv4-service-loopback-address string       IPv4 address for service loopback SNAT (default "169.254.42.1")
-      --ipv4-service-range string                  Kubernetes IPv4 services CIDR if not inside cluster prefix (default "auto")
-      --ipv6-cluster-alloc-cidr string             IPv6 /64 CIDR used to allocate per node endpoint /96 CIDR (default "f00d::/64")
-      --ipv6-node string                           IPv6 address of node (default "auto")
-      --ipv6-pod-subnets strings                   List of IPv6 pod subnets to preconfigure for encryption
-      --ipv6-range string                          Per-node IPv6 endpoint prefix, must be /96, e.g. fd02:1:1::/96 (default "auto")
-      --ipv6-service-range string                  Kubernetes IPv6 services CIDR if not inside cluster prefix (default "auto")
-      --ipvlan-master-device string                Device facing external network acting as ipvlan master (default "undefined")
-      --k8s-api-server string                      Kubernetes api address server (for https use --k8s-kubeconfig-path instead)
-      --k8s-kubeconfig-path string                 Absolute path of the kubernetes kubeconfig file
-      --k8s-require-ipv4-pod-cidr                  Require IPv4 PodCIDR to be specified in node resource
-      --k8s-require-ipv6-pod-cidr                  Require IPv6 PodCIDR to be specified in node resource
-      --k8s-watcher-endpoint-selector string       K8s endpoint watcher will watch for these k8s endpoints (default "metadata.name!=kube-scheduler,metadata.name!=kube-controller-manager,metadata.name!=etcd-operator,metadata.name!=gcp-controller-manager")
-      --k8s-watcher-queue-size uint                Queue size used to serialize each k8s event type (default 1024)
-      --keep-bpf-templates                         Do not restore BPF template files from binary
-      --keep-config                                When restoring state, keeps containers' configuration in place
-      --kvstore string                             Key-value store type
-      --kvstore-connectivity-timeout duration      Time after which an incomplete kvstore operation  is considered failed (default 2m0s)
-      --kvstore-opt map                            Key-value store options (default map[])
-      --kvstore-periodic-sync duration             Periodic KVstore synchronization interval (default 5m0s)
-      --label-prefix-file string                   Valid label prefixes file path
-      --labels strings                             List of label prefixes used to determine identity of an endpoint
-      --lb string                                  Enables load balancer mode where load balancer bpf program is attached to the given interface
-      --lib-dir string                             Directory path to store runtime build environment (default "/var/lib/cilium")
-      --log-driver strings                         Logging endpoints to use for example syslog
-      --log-opt map                                Log driver options for cilium (default map[])
-      --log-system-load                            Enable periodic logging of system load
-      --masquerade                                 Masquerade packets from endpoints leaving the host (default true)
-      --metrics strings                            Metrics that should be enabled or disabled from the default metric list. (+metric_foo to enable metric_foo , -metric_bar to disable metric_bar)
-      --monitor-aggregation string                 Level of monitor aggregation for traces from the datapath (default "None")
-      --monitor-queue-size int                     Size of the event queue when reading monitor events
-      --mtu int                                    Overwrite auto-detected MTU of underlying network
-      --nat46-range string                         IPv6 prefix to map IPv4 addresses to (default "0:0:0:0:0:FFFF::/96")
-      --node-port-range strings                    Set the min/max NodePort port range (default [30000,32767])
-      --policy-queue-size int                      size of queues for policy-related events (default 100)
-      --pprof                                      Enable serving the pprof debugging API
-      --preallocate-bpf-maps                       Enable BPF map pre-allocation (default true)
-      --prefilter-device string                    Device facing external network for XDP prefiltering (default "undefined")
-      --prefilter-mode string                      Prefilter mode { native | generic } (default: native) (default "native")
-      --prepend-iptables-chains                    Prepend custom iptables chains instead of appending (default true)
-      --prometheus-serve-addr string               IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
-      --proxy-connect-timeout uint                 Time after which a TCP connect attempt is considered failed unless completed (in seconds) (default 1)
-      --read-cni-conf string                       Read to the CNI configuration at specified path to extract per node configuration
-      --restore                                    Restores state, if possible, from previous daemon (default true)
-      --sidecar-istio-proxy-image string           Regular expression matching compatible Istio sidecar istio-proxy container image names (default "cilium/istio_proxy")
-      --single-cluster-route                       Use a single cluster route instead of per node routes
-      --skip-crd-creation                          Skip Kubernetes Custom Resource Definitions creations
-      --socket-path string                         Sets daemon's socket path to listen for connections (default "/var/run/cilium/cilium.sock")
-      --sockops-enable                             Enable sockops when kernel supported
-      --state-dir string                           Directory path to store runtime state (default "/var/run/cilium")
-      --tofqdns-dns-reject-response-code string    DNS response code for rejecting DNS requests, available options are '[nameError refused]' (default "refused")
-      --tofqdns-enable-poller                      Enable proactive polling of DNS names in toFQDNs.matchName rules.
-      --tofqdns-enable-poller-events               Emit DNS responses seen by the DNS poller as Monitor events, if the poller is enabled. (default true)
-      --tofqdns-endpoint-max-ip-per-hostname int   Maximum number of IPs to maintain per FQDN name for each endpoint (default 50)
-      --tofqdns-min-ttl int                        The minimum time, in seconds, to use DNS data for toFQDNs policies. (default 3600 when --tofqdns-enable-poller, 604800 otherwise)
-      --tofqdns-pre-cache string                   DNS cache data at this path is preloaded on agent startup
-      --tofqdns-proxy-port int                     Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port.
-      --trace-payloadlen int                       Length of payload to capture when tracing (default 128)
-  -t, --tunnel string                              Tunnel mode {vxlan, geneve, disabled} (default "vxlan" for the "veth" datapath mode)
-      --version                                    Print version information
-      --write-cni-conf-when-ready string           Write the CNI configuration as specified via --read-cni-conf to path when agent is ready
+      --access-log string                                     Path to access log of supported L7 requests observed
+      --agent-labels strings                                  Additional labels to identify this agent
+      --allow-localhost string                                Policy when to allow local stack to reach local endpoints { auto | always | policy } (default "auto")
+      --annotate-k8s-node                                     Annotate Kubernetes node (default true)
+      --auto-create-cilium-node-resource                      Automatically create CiliumNode resource for own node on startup (default true)
+      --auto-direct-node-routes                               Enable automatic L2 routing between nodes
+      --blacklist-conflicting-routes                          Don't blacklist IP allocations conflicting with local non-cilium routes (default true)
+      --bpf-compile-debug                                     Enable debugging of the BPF compilation process
+      --bpf-ct-global-any-max int                             Maximum number of entries in non-TCP CT table (default 262144)
+      --bpf-ct-global-tcp-max int                             Maximum number of entries in TCP CT table (default 1000000)
+      --bpf-nat-global-max int                                Maximum number of entries for the global BPF NAT table (default 841429)
+      --bpf-policy-map-max int                                Maximum number of entries in endpoint policy map (per endpoint) (default 16384)
+      --bpf-root string                                       Path to BPF filesystem
+      --cgroup-root string                                    Path to Cgroup2 filesystem
+      --cluster-id int                                        Unique identifier of the cluster
+      --cluster-name string                                   Name of the cluster (default "default")
+      --clustermesh-config string                             Path to the ClusterMesh configuration directory
+      --config string                                         Configuration file (default "$HOME/ciliumd.yaml")
+      --config-dir string                                     Configuration directory that contains a file for each option
+      --conntrack-gc-interval duration                        Overwrite the connection-tracking garbage collection interval
+      --container-runtime strings                             Sets the container runtime(s) used by Cilium { containerd | crio | docker | none | auto } ( "auto" uses the container runtime found in the order: "docker", "containerd", "crio" ) (default [auto])
+      --container-runtime-endpoint map                        Container runtime(s) endpoint(s). (default: --container-runtime-endpoint=containerd=/var/run/containerd/containerd.sock, --container-runtime-endpoint=crio=/var/run/crio/crio.sock, --container-runtime-endpoint=docker=unix:///var/run/docker.sock) (default map[])
+      --datapath-mode string                                  Datapath mode name (default "veth")
+  -D, --debug                                                 Enable debugging mode
+      --debug-verbose strings                                 List of enabled verbose debug groups
+  -d, --device string                                         Device facing cluster/external network for direct L3 (non-overlay mode) (default "undefined")
+      --disable-cnp-status-updates cnp-node-status-gc=false   Do not send CNP NodeStatus updates to the Kubernetes api-server (recommended to run with cnp-node-status-gc=false in cilium-operator)
+      --disable-conntrack                                     Disable connection tracking
+      --disable-endpoint-crd                                  Disable use of CiliumEndpoint CRD
+      --disable-k8s-services                                  Disable east-west K8s load balancing by cilium
+  -e, --docker string                                         Path to docker runtime socket (DEPRECATED: use container-runtime-endpoint instead) (default "unix:///var/run/docker.sock")
+      --egress-masquerade-interfaces string                   Limit egress masquerading to interface selector
+      --enable-endpoint-routes                                Use per endpoint routes instead of routing via cilium_host
+      --enable-health-checking                                Enable connectivity health checking (default true)
+      --enable-host-reachable-services                        Enable reachability of services for host applications (beta)
+      --enable-ipsec                                          Enable IPSec support
+      --enable-ipv4                                           Enable IPv4 support (default true)
+      --enable-ipv6                                           Enable IPv6 support (default true)
+      --enable-k8s-event-handover                             Enable k8s event handover to kvstore for improved scalability
+      --enable-node-port                                      Enable NodePort type services by Cilium (beta)
+      --enable-policy string                                  Enable policy enforcement (default "default")
+      --enable-tracing                                        Enable tracing while determining policy (debugging)
+      --encrypt-interface string                              Transparent encryption interface
+      --encrypt-node                                          Enables encrypting traffic from non-Cilium pods and host networking
+      --endpoint-interface-name-prefix string                 Prefix of interface name shared by all endpoints (default "lxc+")
+      --endpoint-queue-size int                               size of EventQueue per-endpoint (default 25)
+      --envoy-log string                                      Path to a separate Envoy log file, if any
+      --exclude-local-address strings                         Exclude CIDR from being recognized as local address
+      --fixed-identity-mapping map                            Key-value for the fixed identity mapping which allows to use reserved label for fixed identities (default map[])
+      --flannel-manage-existing-containers                    Installs a BPF program to allow for policy enforcement in already running containers managed by Flannel. Require Cilium to be running in the hostPID.
+      --flannel-master-device string                          Installs a BPF program to allow for policy enforcement in the given network interface. Allows to run Cilium on top of other CNI plugins that provide networking, e.g. flannel, where for flannel, this value should be set with 'cni0'. [EXPERIMENTAL]
+      --flannel-uninstall-on-exit                             When used along the flannel-master-device flag, it cleans up all BPF programs installed when Cilium agent is terminated.
+      --force-local-policy-eval-at-source                     Force policy evaluation of all local communication at the source endpoint (default true)
+  -h, --help                                                  help for cilium-agent
+      --host-reachable-services-protos strings                Only enable reachability of services for host applications for specific protocols (default [tcp,udp])
+      --http-idle-timeout uint                                Time after which a non-gRPC HTTP stream is considered failed unless traffic in the stream has been processed (in seconds); defaults to 0 (unlimited)
+      --http-max-grpc-timeout uint                            Time after which a forwarded gRPC request is considered failed unless completed (in seconds). A "grpc-timeout" header may override this with a shorter value; defaults to 0 (unlimited)
+      --http-request-timeout uint                             Time after which a forwarded HTTP request is considered failed unless completed (in seconds); Use 0 for unlimited (default 3600)
+      --http-retry-count uint                                 Number of retries performed after a forwarded request attempt fails (default 3)
+      --http-retry-timeout uint                               Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
+      --identity-allocation-mode string                       Method to use for identity allocation (default "kvstore")
+      --identity-change-grace-period duration                 Time to wait before using new identity on endpoint identity change (default 5s)
+      --install-iptables-rules                                Install base iptables rules for cilium to mainly interact with kube-proxy (and masquerading) (default true)
+      --ip-allocation-timeout duration                        Time after which an incomplete CIDR allocation is considered failed (default 2m0s)
+      --ipam string                                           Backend to use for IPAM
+      --ipsec-key-file string                                 Path to IPSec key file
+      --ipv4-cluster-cidr-mask-size int                       Mask size for the cluster wide CIDR (default 8)
+      --ipv4-node string                                      IPv4 address of node (default "auto")
+      --ipv4-pod-subnets strings                              List of IPv4 pod subnets to preconfigure for encryption
+      --ipv4-range string                                     Per-node IPv4 endpoint prefix, e.g. 10.16.0.0/16 (default "auto")
+      --ipv4-service-loopback-address string                  IPv4 address for service loopback SNAT (default "169.254.42.1")
+      --ipv4-service-range string                             Kubernetes IPv4 services CIDR if not inside cluster prefix (default "auto")
+      --ipv6-cluster-alloc-cidr string                        IPv6 /64 CIDR used to allocate per node endpoint /96 CIDR (default "f00d::/64")
+      --ipv6-node string                                      IPv6 address of node (default "auto")
+      --ipv6-pod-subnets strings                              List of IPv6 pod subnets to preconfigure for encryption
+      --ipv6-range string                                     Per-node IPv6 endpoint prefix, must be /96, e.g. fd02:1:1::/96 (default "auto")
+      --ipv6-service-range string                             Kubernetes IPv6 services CIDR if not inside cluster prefix (default "auto")
+      --ipvlan-master-device string                           Device facing external network acting as ipvlan master (default "undefined")
+      --k8s-api-server string                                 Kubernetes api address server (for https use --k8s-kubeconfig-path instead)
+      --k8s-kubeconfig-path string                            Absolute path of the kubernetes kubeconfig file
+      --k8s-require-ipv4-pod-cidr                             Require IPv4 PodCIDR to be specified in node resource
+      --k8s-require-ipv6-pod-cidr                             Require IPv6 PodCIDR to be specified in node resource
+      --k8s-watcher-endpoint-selector string                  K8s endpoint watcher will watch for these k8s endpoints (default "metadata.name!=kube-scheduler,metadata.name!=kube-controller-manager,metadata.name!=etcd-operator,metadata.name!=gcp-controller-manager")
+      --k8s-watcher-queue-size uint                           Queue size used to serialize each k8s event type (default 1024)
+      --keep-bpf-templates                                    Do not restore BPF template files from binary
+      --keep-config                                           When restoring state, keeps containers' configuration in place
+      --kvstore string                                        Key-value store type
+      --kvstore-connectivity-timeout duration                 Time after which an incomplete kvstore operation  is considered failed (default 2m0s)
+      --kvstore-opt map                                       Key-value store options (default map[])
+      --kvstore-periodic-sync duration                        Periodic KVstore synchronization interval (default 5m0s)
+      --label-prefix-file string                              Valid label prefixes file path
+      --labels strings                                        List of label prefixes used to determine identity of an endpoint
+      --lb string                                             Enables load balancer mode where load balancer bpf program is attached to the given interface
+      --lib-dir string                                        Directory path to store runtime build environment (default "/var/lib/cilium")
+      --log-driver strings                                    Logging endpoints to use for example syslog
+      --log-opt map                                           Log driver options for cilium (default map[])
+      --log-system-load                                       Enable periodic logging of system load
+      --masquerade                                            Masquerade packets from endpoints leaving the host (default true)
+      --metrics strings                                       Metrics that should be enabled or disabled from the default metric list. (+metric_foo to enable metric_foo , -metric_bar to disable metric_bar)
+      --monitor-aggregation string                            Level of monitor aggregation for traces from the datapath (default "None")
+      --monitor-queue-size int                                Size of the event queue when reading monitor events
+      --mtu int                                               Overwrite auto-detected MTU of underlying network
+      --nat46-range string                                    IPv6 prefix to map IPv4 addresses to (default "0:0:0:0:0:FFFF::/96")
+      --node-port-range strings                               Set the min/max NodePort port range (default [30000,32767])
+      --policy-queue-size int                                 size of queues for policy-related events (default 100)
+      --pprof                                                 Enable serving the pprof debugging API
+      --preallocate-bpf-maps                                  Enable BPF map pre-allocation (default true)
+      --prefilter-device string                               Device facing external network for XDP prefiltering (default "undefined")
+      --prefilter-mode string                                 Prefilter mode { native | generic } (default: native) (default "native")
+      --prepend-iptables-chains                               Prepend custom iptables chains instead of appending (default true)
+      --prometheus-serve-addr string                          IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
+      --proxy-connect-timeout uint                            Time after which a TCP connect attempt is considered failed unless completed (in seconds) (default 1)
+      --read-cni-conf string                                  Read to the CNI configuration at specified path to extract per node configuration
+      --restore                                               Restores state, if possible, from previous daemon (default true)
+      --sidecar-istio-proxy-image string                      Regular expression matching compatible Istio sidecar istio-proxy container image names (default "cilium/istio_proxy")
+      --single-cluster-route                                  Use a single cluster route instead of per node routes
+      --skip-crd-creation                                     Skip Kubernetes Custom Resource Definitions creations
+      --socket-path string                                    Sets daemon's socket path to listen for connections (default "/var/run/cilium/cilium.sock")
+      --sockops-enable                                        Enable sockops when kernel supported
+      --state-dir string                                      Directory path to store runtime state (default "/var/run/cilium")
+      --tofqdns-dns-reject-response-code string               DNS response code for rejecting DNS requests, available options are '[nameError refused]' (default "refused")
+      --tofqdns-enable-poller                                 Enable proactive polling of DNS names in toFQDNs.matchName rules.
+      --tofqdns-enable-poller-events                          Emit DNS responses seen by the DNS poller as Monitor events, if the poller is enabled. (default true)
+      --tofqdns-endpoint-max-ip-per-hostname int              Maximum number of IPs to maintain per FQDN name for each endpoint (default 50)
+      --tofqdns-min-ttl int                                   The minimum time, in seconds, to use DNS data for toFQDNs policies. (default 3600 when --tofqdns-enable-poller, 604800 otherwise)
+      --tofqdns-pre-cache string                              DNS cache data at this path is preloaded on agent startup
+      --tofqdns-proxy-port int                                Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port.
+      --trace-payloadlen int                                  Length of payload to capture when tracing (default 128)
+  -t, --tunnel string                                         Tunnel mode {vxlan, geneve, disabled} (default "vxlan" for the "veth" datapath mode)
+      --version                                               Print version information
+      --write-cni-conf-when-ready string                      Write the CNI configuration as specified via --read-cni-conf to path when agent is ready
 ```
 

--- a/Documentation/gettingstarted/ipvlan.rst
+++ b/Documentation/gettingstarted/ipvlan.rst
@@ -41,13 +41,13 @@ Generate the required YAML file and deploy it:
    helm template cilium \
      --namespace kube-system \
      --set global.datapathMode=ipvlan \
-     --set global.ipvlan.primaryDevice=eth0 \
+     --set global.ipvlan.masterDevice=eth0 \
      --set global.tunnel=disabled \
      > cilium.yaml
 
-It is required to specify the primary ipvlan device which typically points to a
+It is required to specify the master ipvlan device which typically points to a
 networking device that is facing the external network. This is done through
-setting ``global.ipvlan.primaryDevice`` to the name of the networking device
+setting ``global.ipvlan.masterDevice`` to the name of the networking device
 such as ``"eth0"`` or ``"bond0"``, for example. Be aware this option will be
 used by all nodes, so it is required this device name is consistent on all
 nodes where you are going to deploy Cilium.
@@ -89,7 +89,7 @@ Example ConfigMap extract for ipvlan in pure L3 mode:
    helm template ciliumn \
      --namespace kube-system \
      --set global.datapathMode=ipvlan \
-     --set global.ipvlan.primaryDevice=bond0 \
+     --set global.ipvlan.masterDevice=bond0 \
      --set global.tunnel=disabled \
      --set global.installIptablesRules=false \
      --set global.autoDirectNodeRoutes=true \
@@ -103,7 +103,7 @@ masquerading all traffic leaving the node:
    helm template cilium \
      --namespace kube-system \
      --set global.datapathMode=ipvlan \
-     --set global.ipvlan.primaryDevice=bond0 \
+     --set global.ipvlan.masterDevice=bond0 \
      --set global.tunnel=disabled \
      --set global.masquerade=true \
      --set global.autoDirectNodeRoutes=true \
@@ -117,7 +117,7 @@ BPF-based masquerading instead of iptables-based:
    helm template cilium \
      --namespace kube-system \
      --set global.datapathMode=ipvlan \
-     --set global.ipvlan.primaryDevice=bond0 \
+     --set global.ipvlan.masterDevice=bond0 \
      --set global.tunnel=disabled \
      --set global.masquerade=true \
      --set global.installIptablesRules=false \

--- a/contrib/packaging/docker/Dockerfile.runtime
+++ b/contrib/packaging/docker/Dockerfile.runtime
@@ -78,7 +78,7 @@ apt-get clean
 #
 # Go-based tools we need at runtime
 #
-FROM docker.io/library/golang:1.12.7 as runtime-gobuild
+FROM docker.io/library/golang:1.12.8 as runtime-gobuild
 WORKDIR /tmp
 RUN go get -d github.com/google/gops && \
 cd /go/src/github.com/google/gops && \

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -689,6 +689,8 @@ func createPrefixLengthCounter() *counter.PrefixLengthCounter {
 type rulesManager interface {
 	RemoveRules()
 	InstallRules(ifName string) error
+	TransientRulesStart(ifName string) error
+	TransientRulesEnd()
 }
 
 // NewDaemon creates and returns a new Daemon with the parameters set in c.

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -828,6 +828,9 @@ func init() {
 	flags.MarkHidden(option.PolicyTriggerInterval)
 	option.BindEnv(option.PolicyTriggerInterval)
 
+	flags.Bool(option.DisableCNPStatusUpdates, false, "Do not send CNP NodeStatus updates to the Kubernetes api-server (recommended to run with `cnp-node-status-gc=false` in cilium-operator)")
+	option.BindEnv(option.DisableCNPStatusUpdates)
+
 	viper.BindPFlags(flags)
 }
 

--- a/daemon/datapath.go
+++ b/daemon/datapath.go
@@ -199,10 +199,17 @@ func (d *Daemon) compileBase() error {
 		return err
 	}
 
+	if option.Config.InstallIptRules {
+		if err := d.iptablesManager.TransientRulesStart(option.Config.HostDevice); err != nil {
+			return err
+		}
+	}
 	// Always remove masquerade rule and then re-add it if required
 	d.iptablesManager.RemoveRules()
 	if option.Config.InstallIptRules {
-		if err := d.iptablesManager.InstallRules(option.Config.HostDevice); err != nil {
+		err := d.iptablesManager.InstallRules(option.Config.HostDevice)
+		d.iptablesManager.TransientRulesEnd()
+		if err != nil {
 			return err
 		}
 	}

--- a/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
@@ -76,6 +76,7 @@ spec:
         image: "{{ .Values.global.registry }}/{{ .Values.image }}:{{ .Values.global.tag }}"
 {{- end }}
         imagePullPolicy: {{ .Values.global.pullPolicy }}
+{{- if .Values.global.cni.install }}
         lifecycle:
           postStart:
             exec:
@@ -85,6 +86,7 @@ spec:
             exec:
               command:
               - /cni-uninstall.sh
+{{- end }}
         livenessProbe:
           exec:
             command:

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -260,9 +260,11 @@ data:
 {{- end }}
 {{- end }}
 
-{{- if and .Values.global.ipvlan .Values.global.ipvlan.enabled }}
+{{- if .Values.global.datapathMode }}
+{{- if eq .Values.global.datapathMode "ipvlan" }}
   datapath-mode: ipvlan
-  ipvlan-master-device: {{ .Values.global.ipvlan.primaryDevice }}
+  ipvlan-master-device: {{ .Values.global.ipvlan.masterDevice }}
+{{- end }}
 {{- end }}
 
   install-iptables-rules: {{ .Values.global.installIptablesRules | quote }}

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -43,7 +43,7 @@ data:
   identity-allocation-mode: {{ .Values.global.identityAllocationMode }}
 
   # If you want to run cilium in debug mode change this value to true
-  debug: {{ .Values.global.debug.enabled | default false | quote }}
+  debug: {{ .Values.global.debug.enabled | quote }}
 
 {{- if .Values.global.debug.verbose }}
   debug-verbose: "{{ .Values.global.debug.verbose }}"
@@ -62,13 +62,13 @@ data:
   # Enable IPv4 addressing. If enabled, all endpoints are allocated an IPv4
   # address.
 {{- if .Values.global.ipv4 }}
-  enable-ipv4: {{ .Values.global.ipv4.enabled | default true | quote }}
+  enable-ipv4: {{ .Values.global.ipv4.enabled | quote }}
 {{- end }}
 
   # Enable IPv6 addressing. If enabled, all endpoints are allocated an IPv6
   # address.
 {{- if .Values.global.ipv6 }}
-  enable-ipv6: {{ .Values.global.ipv6.enabled | default false | quote }}
+  enable-ipv6: {{ .Values.global.ipv6.enabled | quote }}
 {{- end }}
 
 {{- if .Values.global.cleanState }}
@@ -265,10 +265,10 @@ data:
   ipvlan-master-device: {{ .Values.global.ipvlan.primaryDevice }}
 {{- end }}
 
-  install-iptables-rules: {{ .Values.global.installIptablesRules | default true | quote }}
-  auto-direct-node-routes: {{ .Values.global.autoDirectNodeRoutes | default false | quote }}
+  install-iptables-rules: {{ .Values.global.installIptablesRules | quote }}
+  auto-direct-node-routes: {{ .Values.global.autoDirectNodeRoutes | quote }}
 {{- if .Values.global.nodePort }}
-  enable-node-port: {{ .Values.global.nodePort.enabled | default false | quote }}
+  enable-node-port: {{ .Values.global.nodePort.enabled | quote }}
 {{- if .Values.global.nodePort.range }}
   node-port-range: {{ .Values.global.nodePort.range | quote }}
 {{- end }}

--- a/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
@@ -77,6 +77,18 @@ spec:
               key: disable-endpoint-crd
               name: cilium-config
               optional: true
+        - name: CILIUM_KVSTORE
+          valueFrom:
+            configMapKeyRef:
+              key: kvstore
+              name: cilium-config
+              optional: true
+        - name: CILIUM_KVSTORE_OPT
+          valueFrom:
+            configMapKeyRef:
+              key: kvstore-opt
+              name: cilium-config
+              optional: true
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
             secretKeyRef:

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -94,6 +94,10 @@ global:
 
   # cni is the CNI configuration
   cni:
+    # install determines whether to install the CNI configuration and binary
+    # files into the filesystem.
+    install: true
+
     # chainingMode enables chaining on top of other CNI plugins. Possible
     # values:
     #  - none

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -128,6 +128,7 @@ data:
   # - auto (automatically detect the container runtime)
   #
   container-runtime: none
+
   masquerade: "true"
 
   install-iptables-rules: "true"
@@ -442,6 +443,8 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
+        - mountPath: /run/xtables.lock
+          name: xtables-lock
       hostNetwork: true
       initContainers:
       - command:
@@ -509,6 +512,11 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
+        # To access iptables concurrently with other processes (e.g. kube-proxy)
+      - hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate
+        name: xtables-lock
         # To read the clustermesh configuration
       - name: clustermesh-secrets
         secret:
@@ -598,6 +606,18 @@ spec:
               key: disable-endpoint-crd
               name: cilium-config
               optional: true
+        - name: CILIUM_KVSTORE
+          valueFrom:
+            configMapKeyRef:
+              key: kvstore
+              name: cilium-config
+              optional: true
+        - name: CILIUM_KVSTORE_OPT
+          valueFrom:
+            configMapKeyRef:
+              key: kvstore-opt
+              name: cilium-config
+              optional: true
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
             secretKeyRef:
@@ -631,4 +651,16 @@ spec:
       restartPolicy: Always
       serviceAccount: cilium-operator
       serviceAccountName: cilium-operator
+
+---
+# Source: cilium/charts/agent/templates/servicemonitor.yaml
+
+---
+# Source: cilium/charts/agent/templates/svc.yaml
+
+---
+# Source: cilium/charts/operator/templates/servicemonitor.yaml
+
+---
+# Source: cilium/charts/operator/templates/svc.yaml
 

--- a/operator/k8s_node.go
+++ b/operator/k8s_node.go
@@ -46,7 +46,9 @@ import (
 
 var (
 	// kvNodeGCInterval duration for which the nodes are GC in the KVStore.
-	kvNodeGCInterval time.Duration
+	kvNodeGCInterval              time.Duration
+	enableCNPNodeStatusGC         bool
+	ciliumCNPNodeStatusGCInterval time.Duration
 )
 
 func runNodeWatcher() error {
@@ -161,6 +163,9 @@ func runNodeWatcher() error {
 	}()
 
 	go func() {
+		if !enableCNPNodeStatusGC {
+			return
+		}
 		parallelRequests := 4
 		removeNodeFromCNP := make(chan func(), 50)
 		for i := 0; i < parallelRequests; i++ {
@@ -172,7 +177,7 @@ func runNodeWatcher() error {
 		}
 		controller.NewManager().UpdateController("cnp-node-gc",
 			controller.ControllerParams{
-				RunInterval: kvNodeGCInterval,
+				RunInterval: ciliumCNPNodeStatusGCInterval,
 				DoFunc: func(ctx context.Context) error {
 					lastRun := time.Now().Add(-kvNodeGCInterval)
 					k8sCapabilities := k8sversion.Capabilities()

--- a/operator/main.go
+++ b/operator/main.go
@@ -105,8 +105,10 @@ func init() {
 	flags.BoolP("debug", "D", false, "Enable debugging mode")
 	flags.StringVar(&k8sAPIServer, "k8s-api-server", "", "Kubernetes api address server (for https use --k8s-kubeconfig-path instead)")
 	flags.StringVar(&k8sKubeConfigPath, "k8s-kubeconfig-path", "", "Absolute path of the kubernetes kubeconfig file")
-	flags.StringVar(&kvStore, "kvstore", "", "Key-value store type")
-	flags.Var(option.NewNamedMapOptions("kvstore-opts", &kvStoreOpts, nil), "kvstore-opt", "Key-value store options")
+	flags.String(option.KVStore, "", "Key-value store type")
+	option.BindEnv(option.KVStore)
+	flags.Var(option.NewNamedMapOptions(option.KVStoreOpt, &kvStoreOpts, nil), option.KVStoreOpt, "Key-value store options")
+	option.BindEnv(option.KVStoreOpt)
 	flags.Uint16Var(&apiServerPort, "api-server-port", 9234, "Port on which the operator should serve API requests")
 	flags.String(option.IPAM, "", "Backend to use for IPAM")
 	option.BindEnv(option.IPAM)
@@ -171,7 +173,7 @@ func initConfig() {
 }
 
 func kvstoreEnabled() bool {
-	if option.Config.KVStore == "" {
+	if kvStore == "" {
 		return false
 	}
 
@@ -193,6 +195,8 @@ func runOperator(cmd *cobra.Command) {
 
 	k8sClientQPSLimit := viper.GetFloat64(option.K8sClientQPSLimit)
 	k8sClientBurst := viper.GetInt(option.K8sClientBurst)
+	kvStore = viper.GetString(option.KVStore)
+	kvStoreOpts = viper.GetStringMapString(option.KVStoreOpt)
 
 	k8s.Configure(k8sAPIServer, k8sKubeConfigPath, float32(k8sClientQPSLimit), k8sClientBurst)
 	if err := k8s.Init(); err != nil {

--- a/operator/main.go
+++ b/operator/main.go
@@ -144,6 +144,9 @@ func init() {
 	flags.MarkHidden(option.DisableCiliumEndpointCRDName)
 	option.BindEnv(option.DisableCiliumEndpointCRDName)
 
+	flags.BoolVar(&enableCNPNodeStatusGC, "cnp-node-status-gc", true, "Enable CiliumNetworkPolicy Status garbage collection for nodes which have been removed from the cluster")
+	flags.DurationVar(&ciliumCNPNodeStatusGCInterval, "cnp-node-status-gc-interval", time.Minute*2, "GC interval for nodes which have been removed from the cluster in CiliumNetworkPolicy Status")
+
 	viper.BindPFlags(flags)
 
 	// Make sure that klog logging variables are initialized so that we can

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -36,18 +36,20 @@ import (
 )
 
 const (
-	ciliumInputChain      = "CILIUM_INPUT"
-	ciliumOutputChain     = "CILIUM_OUTPUT"
-	ciliumOutputRawChain  = "CILIUM_OUTPUT_raw"
-	ciliumPostNatChain    = "CILIUM_POST_nat"
-	ciliumOutputNatChain  = "CILIUM_OUTPUT_nat"
-	ciliumPreNatChain     = "CILIUM_PRE_nat"
-	ciliumPostMangleChain = "CILIUM_POST_mangle"
-	ciliumPreMangleChain  = "CILIUM_PRE_mangle"
-	ciliumPreRawChain     = "CILIUM_PRE_raw"
-	ciliumForwardChain    = "CILIUM_FORWARD"
-	feederDescription     = "cilium-feeder:"
-	xfrmDescription       = "cilium-xfrm-notrack:"
+	ciliumPrefix                = "CILIUM_"
+	ciliumInputChain            = "CILIUM_INPUT"
+	ciliumOutputChain           = "CILIUM_OUTPUT"
+	ciliumOutputRawChain        = "CILIUM_OUTPUT_raw"
+	ciliumPostNatChain          = "CILIUM_POST_nat"
+	ciliumOutputNatChain        = "CILIUM_OUTPUT_nat"
+	ciliumPreNatChain           = "CILIUM_PRE_nat"
+	ciliumPostMangleChain       = "CILIUM_POST_mangle"
+	ciliumPreMangleChain        = "CILIUM_PRE_mangle"
+	ciliumPreRawChain           = "CILIUM_PRE_raw"
+	ciliumForwardChain          = "CILIUM_FORWARD"
+	ciliumTransientForwardChain = "CILIUM_TRANSIENT_FORWARD"
+	feederDescription           = "cilium-feeder:"
+	xfrmDescription             = "cilium-xfrm-notrack:"
 )
 
 // Minimum iptables versions supporting the -w and -w<seconds> flags
@@ -126,7 +128,7 @@ func reverseRule(rule string) ([]string, error) {
 	return []string{}, nil
 }
 
-func (m *IptablesManager) removeCiliumRules(table, prog string) {
+func (m *IptablesManager) removeCiliumRules(table, prog, match string) {
 	args := append(m.waitArgs, "-t", table, "-S")
 
 	out, err := exec.WithTimeout(defaults.ExecTimeout, prog, args...).CombinedOutput(log, true)
@@ -138,12 +140,15 @@ func (m *IptablesManager) removeCiliumRules(table, prog string) {
 	for scanner.Scan() {
 		rule := scanner.Text()
 		log.WithField(logfields.Object, logfields.Repr(rule)).Debugf("Considering removing %s rule", prog)
+		if match != ciliumTransientForwardChain && strings.Contains(rule, ciliumTransientForwardChain) {
+			continue
+		}
 
 		// All rules installed by cilium either belong to a chain with
 		// the name CILIUM_ or call a chain with the name CILIUM_:
 		// -A CILIUM_FORWARD -o cilium_host -m comment --comment "cilium: any->cluster on cilium_host forward accept" -j ACCEPT
 		// -A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST" -j CILIUM_POST
-		if strings.Contains(rule, "CILIUM_") {
+		if strings.Contains(rule, match) {
 			reversedRule, err := reverseRule(rule)
 			if err != nil {
 				log.WithError(err).WithField(logfields.Object, rule).Warnf("Unable to parse %s rule into slice. Leaving rule behind.", prog)
@@ -289,6 +294,13 @@ var ciliumChains = []customChain{
 	},
 }
 
+var transientChain = customChain{
+	name:       ciliumTransientForwardChain,
+	table:      "filter",
+	hook:       "FORWARD",
+	feederArgs: []string{""},
+}
+
 // IptablesManager manages the iptables-related configuration for Cilium.
 type IptablesManager struct {
 	ip6tables bool
@@ -338,14 +350,14 @@ func (m *IptablesManager) RemoveRules() {
 	// Set of tables that have had iptables rules in any Cilium version
 	tables := []string{"nat", "mangle", "raw", "filter"}
 	for _, t := range tables {
-		m.removeCiliumRules(t, "iptables")
+		m.removeCiliumRules(t, "iptables", ciliumPrefix)
 	}
 
 	// Set of tables that have had ip6tables rules in any Cilium version
 	if m.ip6tables {
 		tables6 := []string{"mangle", "raw"}
 		for _, t := range tables6 {
-			m.removeCiliumRules(t, "ip6tables")
+			m.removeCiliumRules(t, "ip6tables", ciliumPrefix)
 		}
 	}
 
@@ -527,11 +539,73 @@ func (m *IptablesManager) remoteSnatDstAddrExclusion() string {
 	}
 }
 
+func getDeliveryInterface(ifName string) string {
+	deliveryInterface := ifName
+	if option.Config.IPAM == option.IPAMENI || option.Config.EnableEndpointRoutes {
+		deliveryInterface = "lxc+"
+	}
+	return deliveryInterface
+}
+
+// TransientRulesStart installs iptables rules for Cilium that need to be
+// kept in-tact during agent restart which removes/installs its main rules.
+// Transient rules are then removed once iptables rule update cycle has
+// completed. This is mainly due to interactions with kube-proxy.
+func (m *IptablesManager) TransientRulesStart(ifName string) error {
+	if option.Config.EnableIPv4 {
+		localDeliveryInterface := getDeliveryInterface(ifName)
+
+		m.TransientRulesEnd()
+
+		if err := transientChain.add(m.waitArgs); err != nil {
+			return fmt.Errorf("cannot add custom chain %s: %s", transientChain.name, err)
+		}
+		// While kube-proxy does change the policy of the iptables FORWARD chain
+		// it doesn't seem to handle all cases, e.g. host network pods that use
+		// the node IP which would still end up in default DENY. Similarly, for
+		// plain Docker setup, we would otherwise hit default DENY in FORWARD chain.
+		// Also, k8s 1.15 introduced "-m conntrack --ctstate INVALID -j DROP" which
+		// in the direct routing case can drop EP replies.
+		// Therefore, add both rules below to avoid having a user to manually opt-in.
+		// See also: https://github.com/kubernetes/kubernetes/issues/39823
+		// In here can only be basic ACCEPT rules, nothing more complicated.
+		if err := runProg("iptables", append(
+			m.waitArgs,
+			"-A", ciliumTransientForwardChain,
+			"-o", localDeliveryInterface,
+			"-m", "comment", "--comment", "cilium (transient): any->cluster on "+localDeliveryInterface+" forward accept",
+			"-j", "ACCEPT"), false); err != nil {
+			return err
+		}
+		if err := runProg("iptables", append(
+			m.waitArgs,
+			"-A", ciliumTransientForwardChain,
+			"-i", "lxc+",
+			"-m", "comment", "--comment", "cilium (transient): cluster->any on lxc+ forward accept",
+			"-j", "ACCEPT"), false); err != nil {
+			return err
+		}
+		if err := transientChain.installFeeder(m.waitArgs); err != nil {
+			return fmt.Errorf("cannot install feeder rule %s: %s", transientChain.feederArgs, err)
+		}
+	}
+	return nil
+}
+
+// TransientRulesEnd removes Cilium related rules installed from TransientRulesStart.
+func (m *IptablesManager) TransientRulesEnd() {
+	if option.Config.EnableIPv4 {
+		m.removeCiliumRules("filter", "iptables", ciliumTransientForwardChain)
+		transientChain.remove(m.waitArgs)
+	}
+}
+
 // InstallRules installs iptables rules for Cilium in specific use-cases
 // (most specifically, interaction with kube-proxy).
 func (m *IptablesManager) InstallRules(ifName string) error {
 	matchFromIPSecEncrypt := fmt.Sprintf("%#08x/%#08x", linux_defaults.RouteMarkDecrypt, linux_defaults.RouteMarkMask)
 	matchFromIPSecDecrypt := fmt.Sprintf("%#08x/%#08x", linux_defaults.RouteMarkEncrypt, linux_defaults.RouteMarkMask)
+	localDeliveryInterface := getDeliveryInterface(ifName)
 
 	for _, c := range ciliumChains {
 		if err := c.add(m.waitArgs); err != nil {
@@ -541,11 +615,6 @@ func (m *IptablesManager) InstallRules(ifName string) error {
 
 	if err := m.installProxyNotrackRules(); err != nil {
 		return fmt.Errorf("cannot add proxy NOTRACK rules: %s", err)
-	}
-
-	localDeliveryInterface := ifName
-	if option.Config.IPAM == option.IPAMENI || option.Config.EnableEndpointRoutes {
-		localDeliveryInterface = "lxc+"
 	}
 
 	if err := m.addCiliumAcceptXfrmRules(); err != nil {
@@ -570,14 +639,7 @@ func (m *IptablesManager) InstallRules(ifName string) error {
 			return err
 		}
 
-		// While kube-proxy does change the policy of the iptables FORWARD chain
-		// it doesn't seem to handle all cases, e.g. host network pods that use
-		// the node IP which would still end up in default DENY. Similarly, for
-		// plain Docker setup, we would otherwise hit default DENY in FORWARD chain.
-		// Also, k8s 1.15 introduced "-m conntrack --ctstate INVALID -j DROP" which
-		// in the direct routing case can drop EP replies.
-		// Therefore, add both rules below to avoid having a user to manually opt-in.
-		// See also: https://github.com/kubernetes/kubernetes/issues/39823
+		// See kube-proxy comment in TransientRules().
 		if err := runProg("iptables", append(
 			m.waitArgs,
 			"-A", ciliumForwardChain,

--- a/pkg/datapath/linux/route/route_linux.go
+++ b/pkg/datapath/linux/route/route_linux.go
@@ -259,7 +259,7 @@ func Upsert(route Route, mtuConfig *mtu.Configuration) (bool, error) {
 	routeSpec := route.getNetlinkRoute()
 	routeSpec.LinkIndex = link.Attrs().Index
 
-	if routeSpec.MTU != 0 && mtuConfig != nil {
+	if mtuConfig != nil {
 		// If the route includes the local address, then the route is for
 		// local containers and we can use a high MTU for transmit. Otherwise,
 		// it needs to be able to fit within the MTU of tunnel devices.

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -586,6 +586,10 @@ const (
 	// IdentityAllocationModeCRD enables use of Kubernetes CRDs for
 	// identity allocation
 	IdentityAllocationModeCRD = "crd"
+
+	// DisableCNPStatusUpdates disables updating of CNP NodeStatus in the CNP
+	// CRD.
+	DisableCNPStatusUpdates = "disable-cnp-status-updates"
 )
 
 // Default string arguments
@@ -1168,6 +1172,10 @@ type DaemonConfig struct {
 	// IdentityAllocationMode specifies what mode to use for identity
 	// allocation
 	IdentityAllocationMode string
+
+	// DisableCNPStatusUpdates disables updating of CNP NodeStatus in the CNP
+	// CRD.
+	DisableCNPStatusUpdates bool
 }
 
 var (
@@ -1758,6 +1766,7 @@ func (c *DaemonConfig) Populate() {
 	c.EndpointQueueSize = sanitizeIntParam(EndpointQueueSize, defaults.EndpointQueueSize)
 	c.SelectiveRegeneration = viper.GetBool(SelectiveRegeneration)
 	c.SkipCRDCreation = viper.GetBool(SkipCRDCreation)
+	c.DisableCNPStatusUpdates = viper.GetBool(DisableCNPStatusUpdates)
 }
 
 func sanitizeIntParam(paramName string, paramDefault int) int {

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     command: "etcd -name etcd0 -advertise-client-urls http://0.0.0.0:4002 -listen-client-urls http://0.0.0.0:4002 -initial-cluster-token etcd-cluster-1 -initial-cluster-state new"
     privileged: true
   base_image:
-    image: "quay.io/cilium/cilium-builder:2019-07-11"
+    image: "quay.io/cilium/cilium-builder:2019-08-13"
     volumes:
       - "./../:/go/src/github.com/cilium/cilium/"
     privileged: true

--- a/test/k8sT/manifests/v1.5/cilium-operator-patch.yaml
+++ b/test/k8sT/manifests/v1.5/cilium-operator-patch.yaml
@@ -1,0 +1,15 @@
+---
+metadata:
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      terminationGracePeriodSeconds: 0
+      containers:
+      - image: docker.io/cilium/operator:v1.5.5
+        imagePullPolicy: IfNotPresent
+        name: cilium-operator
+      volumes:
+      - name: etcd-secrets
+        secret:
+          secretName: cilium-etcd-client-tls


### PR DESCRIPTION
v1.6 backports 2019-08-15

 * #8906 -- helm: Do not use default function when setting default values (@brb)
 * #8904 -- operator: Fix kvstore configuration inheritance from ConfigMap (@tgraf)
 * #8903 -- cilium: route mtu not set unless route.Spec set MTU (@jrfastab)
 * #8913 -- install: Allow skipping CNI install (@joestringer)
 * #8899 -- add capability to disable CNP NodeStatus updates (@ianvernon)
 * #8908 -- cilium: install transient rules during agent restart (@borkmann)
 * #8905 -- Fix ipvlan helm template and gsg (@brb)
 * #8901 -- Dockerfiles: update to golang 1.12.8 (@ianvernon)

Once this PR is merged, you can update the PR labels via:
```
$ for pr in 8906 8904 8903 8913 8899 8908 8905 8901; do contrib/backporting/set-labels.py $pr done 1.6; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8920)
<!-- Reviewable:end -->
