### PR TITLE
test: add script which pulls images which have not been pulled during VM provisioning

### DIFF
--- a/test/provision/compile.sh
+++ b/test/provision/compile.sh
@@ -27,6 +27,7 @@ if echo $(hostname) | grep "k8s" -q;
 then
     # Only need to build on one host, since we can pull from the other host.
     if [[ "$(hostname)" == "k8s1" ]]; then
+      ./test/provision/container-images.sh cilium_images .
       if [[ "${CILIUM_IMAGE}" == "" && "${CILIUM_OPERATOR_IMAGE}" == "" ]]; then
         echo "building cilium/cilium container image..."
         make LOCKDEBUG=1 docker-image-no-clean
@@ -78,3 +79,6 @@ else
     echo "running \"sudo adduser vagrant cilium\" "
     sudo adduser vagrant cilium
 fi
+
+# Download all images needed for tests.
+./test/provision/container-images.sh test_images .

--- a/test/provision/container-images.sh
+++ b/test/provision/container-images.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+function check_img_list {
+  local imgs=$@
+  for img in $imgs ; do 
+    #fmt_img=$img
+    fmt_img=$(echo $img | sed -e 's/.*docker.io\///g' | sed -e 's/library\///g')
+    #echo "checking if $img is cached..."
+    IMG_EXISTS=$(docker images $fmt_img | wc -l) 
+    if [[ "$IMG_EXISTS" != "2" ]] ; then
+      #echo "*******************************"
+      echo -e "not cached in VM: \t$img"
+      echo -e "pulling: \t\t$img"
+      docker pull $img --quiet &
+      #echo "*******************************"
+    else
+      echo -e "already cached: \t$img"
+    fi
+  done
+}
+
+function test_images {
+  echo "Downloading all container images needed for tests"
+  DOCKER_IMAGES=$(grep -rI "docker.io/.*/.*:.*" test/ | sed -e 's/\"//g' | grep -v "{}"  | sed -e 's/.*docker.io/docker.io/g' |  sort | uniq)
+  QUAY_IMAGES=$(grep -rI "quay.io/.*/.*:.*" test/ | sed -e 's/\"//g' | grep -v "{}" | sed -e 's/.*quay.io/quay.io/g'  | sort | uniq)
+
+  check_img_list $DOCKER_IMAGES
+  check_img_list $QUAY_IMAGES
+
+  for p in `jobs -p`; do
+    wait $p
+  done
+}
+
+function cilium_images {
+  echo "Downloading all images needed to build cilium"
+  CILIUM_DOCKERFILES="./Dockerfile ./cilium-operator.Dockerfile ./Dockerfile.builder"
+  CILIUM_IMGS=$(grep -rI "quay.io/.*/.*:.*" $CILIUM_DOCKERFILES | sed -e 's/\"//g' | grep -v "{}" | sed -e 's/.*quay.io/quay.io/g' | sed -e 's/ as.*//g'  | sort | uniq)
+
+  check_img_list $CILIUM_IMGS
+  for p in `jobs -p`; do
+    wait $p
+  done
+}
+
+if [ $# -lt 2 ]; then
+  echo "Usage: $0 <function-name> <path to root of cilium repository>"
+  exit 1
+fi
+
+OLDDIR=$PWD
+cd $2
+
+trap "cd $OLDDIR" EXIT
+
+$1


### PR DESCRIPTION
Ideally, we would have all images cached in the VMs that our tests use. However,
in practice, there is always going to be some time between when we use new
images in our tests and when we push a new VM image to utilize said images. So,
add a script which pulls the images that we need for building Cilium / use in
tests so that we know we have all needed images before even starting to run
tests.

This also makes end-users aware when images are not cached in the VMs.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8921)
<!-- Reviewable:end -->
