### PR TITLE
v1.5 backports 2019-08-15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: trusty
 sudo: required
 
 go:
- - 1.12.7
+ - 1.12.8
 
 if: branch = master OR type = pull_request
 
@@ -17,6 +17,6 @@ before_install: ./.travis/prepare.sh
 
 before_script:
   - export PATH=/usr/local/clang/bin:$PATH
-  - export GO=/home/travis/.gimme/versions/go1.12.7.linux.amd64/bin/go
+  - export GO=/home/travis/.gimme/versions/go1.12.8.linux.amd64/bin/go
 
 script: ./.travis/build.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ FROM quay.io/cilium/cilium-envoy:d68c2561fae4c83960969a7aaa2a186c3b30e17a as cil
 # versions to be built while allowing the new versions to make changes
 # that are not backwards compatible.
 #
-FROM quay.io/cilium/cilium-builder:2019-07-11 as builder
+FROM quay.io/cilium/cilium-builder:2019-08-13 as builder
 LABEL maintainer="maintainer@cilium.io"
 WORKDIR /go/src/github.com/cilium/cilium
 COPY . ./
@@ -37,7 +37,7 @@ RUN make LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 V=$V LIBNETWORK_PLUGIN=$LIBNETWORK_PLU
 # built while allowing the new versions to make changes that are not
 # backwards compatible.
 #
-FROM quay.io/cilium/cilium-runtime:2019-07-11
+FROM quay.io/cilium/cilium-runtime:2019-08-13
 LABEL maintainer="maintainer@cilium.io"
 COPY --from=builder /tmp/install /
 COPY --from=cilium-envoy / /

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -14,7 +14,7 @@ WORKDIR /go/src/github.com/cilium/cilium
 ENV GOROOT /usr/local/go
 ENV GOPATH /go
 ENV PATH "$GOROOT/bin:$GOPATH/bin:$PATH"
-ENV GO_VERSION 1.12.7
+ENV GO_VERSION 1.12.8
 
 #
 # Build dependencies

--- a/cilium-docker-plugin.Dockerfile
+++ b/cilium-docker-plugin.Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.12.7 as builder
+FROM docker.io/library/golang:1.12.8 as builder
 LABEL maintainer="maintainer@cilium.io"
 ADD . /go/src/github.com/cilium/cilium
 WORKDIR /go/src/github.com/cilium/cilium/plugins/cilium-docker

--- a/cilium-operator.Dockerfile
+++ b/cilium-operator.Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.12.7 as builder
+FROM docker.io/library/golang:1.12.8 as builder
 LABEL maintainer="maintainer@cilium.io"
 ADD . /go/src/github.com/cilium/cilium
 WORKDIR /go/src/github.com/cilium/cilium/operator

--- a/contrib/packaging/docker/Dockerfile.runtime
+++ b/contrib/packaging/docker/Dockerfile.runtime
@@ -78,7 +78,7 @@ apt-get clean
 #
 # Go-based tools we need at runtime
 #
-FROM docker.io/library/golang:1.12.7 as runtime-gobuild
+FROM docker.io/library/golang:1.12.8 as runtime-gobuild
 WORKDIR /tmp
 RUN go get -u github.com/cilium/go-bindata/... && \
 go get -u github.com/google/gops && \

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -558,10 +558,17 @@ func (d *Daemon) compileBase() error {
 	}
 
 	if option.Config.EnableIPv4 {
+		if option.Config.InstallIptRules {
+			if err := d.iptablesManager.TransientRulesStart(option.Config.HostDevice); err != nil {
+				return err
+			}
+		}
 		// Always remove masquerade rule and then re-add it if required
 		d.iptablesManager.RemoveRules()
 		if option.Config.InstallIptRules {
-			if err := d.iptablesManager.InstallRules(option.Config.HostDevice); err != nil {
+			err := d.iptablesManager.InstallRules(option.Config.HostDevice)
+			d.iptablesManager.TransientRulesEnd()
+			if err != nil {
 				return err
 			}
 		}
@@ -892,6 +899,8 @@ func createPrefixLengthCounter() *counter.PrefixLengthCounter {
 type rulesManager interface {
 	RemoveRules()
 	InstallRules(ifName string) error
+	TransientRulesStart(ifName string) error
+	TransientRulesEnd()
 }
 
 func deleteHostDevice() {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1303,7 +1303,10 @@ func (e *Endpoint) LeaveLocked(owner Owner, proxyWaitGroup *completion.WaitGroup
 	owner.RemoveFromEndpointQueue(uint64(e.ID))
 	if e.SecurityIdentity != nil && e.realizedPolicy != nil && e.realizedPolicy.L4Policy != nil {
 		// Passing a new map of nil will purge all redirects
-		e.removeOldRedirects(owner, nil, proxyWaitGroup)
+		finalize, _ := e.removeOldRedirects(owner, nil, proxyWaitGroup)
+		if finalize != nil {
+			finalize()
+		}
 	}
 
 	if e.PolicyMap != nil {

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     command: "etcd -name etcd0 -advertise-client-urls http://0.0.0.0:4002 -listen-client-urls http://0.0.0.0:4002 -initial-cluster-token etcd-cluster-1 -initial-cluster-state new"
     privileged: true
   base_image:
-    image: "quay.io/cilium/cilium-builder:2019-07-11"
+    image: "quay.io/cilium/cilium-builder:2019-08-13"
     volumes:
       - "./../:/go/src/github.com/cilium/cilium/"
     privileged: true


### PR DESCRIPTION
 * #8908 -- cilium: install transient rules during agent restart (@borkmann)
 * #8901 -- Dockerfiles: update to golang 1.12.8 (@ianvernon)
* #8925 -- Fix proxy port leak on endpoint delete (@joestringer)

Once this PR is merged, you can update the PR labels via:
```
$ for pr in 8908 8901 8925; do contrib/backporting/set-labels.py $pr done 1.5; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8922)
<!-- Reviewable:end -->
