### PR TITLE
Fix proxy port leak on endpoint delete

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1336,7 +1336,8 @@ func (e *Endpoint) LeaveLocked(proxyWaitGroup *completion.WaitGroup, conf Delete
 	e.owner.RemoveFromEndpointQueue(uint64(e.ID))
 	if e.SecurityIdentity != nil && len(e.realizedRedirects) > 0 {
 		// Passing a new map of nil will purge all redirects
-		e.removeOldRedirects(nil, proxyWaitGroup)
+		finalize, _ := e.removeOldRedirects(nil, proxyWaitGroup)
+		finalize()
 	}
 
 	if e.policyMap != nil {


### PR DESCRIPTION
Deep in the `proxy.removeRedirect()` logic, a finalize function is created
to defer proxy port release to allow a port to be reused by the proxy
after a grace period. The port is not actually released when the
`removeRedirect()` function is returned, instead the finalize function is
passed all the way up to the caller.

In the endpoint leave case, this finalize function was being ignored,
meaning that the proxy port used by this endpoint is never released.
After 10,000 endpoint deletions of endpoints that have L7 policy
applied, the endpoint regeneration begins to fail for new endpoints that
are subject to L7 policy. As a result, the CNI times out:

    Failed create pod sandbox: rpc error:
    code = Unknown
    desc = failed to set up sandbox container "xxx" network for pod "yyy":
    NetworkPlugin cni failed to set up pod "yyy" network:
    Unable to create endpoint:
    Put http:///var/run/cilium/cilium.sock/v1/endpoint/cilium-local:0:
    context deadline exceeded

Fix this by running the finalize function upon endpoint leave.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8925)
<!-- Reviewable:end -->
