### PR TITLE
Makefile: add automated way to update golang in Dockerfiles

### DIFF
--- a/.travis.yml.tmpl
+++ b/.travis.yml.tmpl
@@ -1,0 +1,22 @@
+language: go
+
+dist: trusty
+sudo: required
+
+go:
+ - TRAVIS_GO_VERSION
+
+if: branch = master OR type = pull_request
+
+addons:
+  apt:
+    packages:
+      - kernel-package libc6-dev-i386
+
+before_install: ./.travis/prepare.sh
+
+before_script:
+  - export PATH=/usr/local/clang/bin:$PATH
+  - export GO=/home/travis/.gimme/versions/goTRAVIS_GO_VERSION.linux.amd64/bin/go
+
+script: ./.travis/build.sh

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,8 @@ JOB_BASE_NAME ?= cilium_test
 
 UTC_DATE=$(shell date -u "+%Y-%m-%d")
 
+GO_VERSION := 1.12.8
+
 # Since there's a bug with NFS or the kernel, the flock syscall hangs the documentation
 # build in the developer VM. For this reason the documentation build is skipped if NFS
 # is running in the developer VM.
@@ -522,6 +524,17 @@ postcheck: build
 
 minikube:
 	$(QUIET) contrib/scripts/minikube.sh
+
+update-golang: update-golang-dockerfiles update-travis-go-version
+
+update-golang-dockerfiles:
+	$(QUIET) sed -i 's/GO_VERSION .*/GO_VERSION $(GO_VERSION)/g' Dockerfile.builder
+	$(QUIET) for fl in $(shell find . -name "*Dockerfile*") ; do sed -i 's/golang:.* /golang:$(GO_VERSION) as /g' $$fl ; done
+	@echo "Updated go version in Dockerfiles to $(GO_VERSION)"
+	
+update-travis-go-version:
+	$(QUIET) sed -e 's/TRAVIS_GO_VERSION/$(GO_VERSION)/g' .travis.yml.tmpl > .travis.yml
+	@echo "Updated go version in .travis.yml to $(GO_VERSION)"
 
 .PHONY: force generate-api generate-health-api install
 force :;


### PR DESCRIPTION
There are a lot of separate Dockerfiles that need to be updated when a new
version of golang is released. Provide a Makefile target for updating these, as
well as the golang version utilized by Travis. This ensures that all Dockerfiles
that use golang use the same version across the respository.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8927)
<!-- Reviewable:end -->
