### PR TITLE
daemon: Do not start L7 proxy support if --install-iptables-rules="false"

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -915,8 +915,12 @@ func NewDaemon(dp datapath.Datapath, iptablesManager rulesManager) (*Daemon, *en
 
 	bootstrapStats.proxyStart.Start()
 	// FIXME: Make the port range configurable.
-	d.l7Proxy = proxy.StartProxySupport(10000, 20000, option.Config.RunDir,
-		option.Config.AccessLog, &d, option.Config.AgentLabels, d.datapath)
+	if option.Config.InstallIptRules {
+		d.l7Proxy = proxy.StartProxySupport(10000, 20000, option.Config.RunDir,
+			option.Config.AccessLog, &d, option.Config.AgentLabels, d.datapath)
+	} else {
+		log.Warning("L7 proxies not supported when --install-iptables-rules=\"false\"")
+	}
 	bootstrapStats.proxyStart.End(true)
 
 	bootstrapStats.fqdn.Start()

--- a/daemon/fqdn.go
+++ b/daemon/fqdn.go
@@ -218,10 +218,10 @@ func (d *Daemon) bootstrapFQDN(restoredEndpoints *endpointRestoreState, preCache
 		}
 	}
 
-	// Do not start the proxy in dry mode. The proxy would not get any traffic in the
-	// dry mode anyway, and some of the socket operations require privileges not available
-	// in all unit tests.
-	if option.Config.DryMode {
+	// Do not start the proxy in dry mode or if iptables rules should not be installed.
+	// The proxy would not get any traffic in the dry mode anyway, and some of the socket
+	// operations require privileges not available in all unit tests.
+	if option.Config.DryMode || !option.Config.InstallIptRules {
 		return nil
 	}
 


### PR DESCRIPTION
L7 proxy redirection needs support from iptables rules, so disable it
if no iptables rules should be installed.

Fixes: #8910
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8928)
<!-- Reviewable:end -->
