### PR TITLE
endpoint: check if returned FinalizeFunc is nil before executing it

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1337,7 +1337,9 @@ func (e *Endpoint) LeaveLocked(proxyWaitGroup *completion.WaitGroup, conf Delete
 	if e.SecurityIdentity != nil && len(e.realizedRedirects) > 0 {
 		// Passing a new map of nil will purge all redirects
 		finalize, _ := e.removeOldRedirects(nil, proxyWaitGroup)
-		finalize()
+		if finalize != nil {
+			finalize()
+		}
 	}
 
 	if e.policyMap != nil {


### PR DESCRIPTION
This avoids a potential panic, specifically during the unit tests, which return
a nil `FinalizeFunc` due to `option.Config.DryMode` being set to `true`.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8929)
<!-- Reviewable:end -->
