### PR TITLE
test: Add SkipContextIf helper

### DIFF
--- a/test/ginkgo-ext/scopes.go
+++ b/test/ginkgo-ext/scopes.go
@@ -536,3 +536,15 @@ func FailWithToggle(message string, callerSkip ...int) {
 		ginkgo.Fail(message, callerSkip...)
 	}
 }
+
+// SkipContextIf is a wrapper for the Context block which is being executed
+// if the given condition is NOT met.
+func SkipContextIf(condition func() bool, text string, body func()) bool {
+	if condition() {
+		return It(text, func() {
+			Skip("skipping due to unmet condition")
+		})
+	}
+
+	return Context(text, body)
+}

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -461,3 +461,8 @@ func failIfContainsBadLogMsg(logs string) {
 func RunsOnNetNext() bool {
 	return os.Getenv("NETNEXT") == "true"
 }
+
+// DoesNotRunOnNetNext is the inverse function of RunsOnNetNext.
+func DoesNotRunOnNetNext() bool {
+	return !RunsOnNetNext()
+}

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -254,14 +254,10 @@ var _ = Describe("K8sServicesTest", func() {
 			})
 		})
 
-		Context("Tests NodePort BPF", func() {
+		SkipContextIf(helpers.DoesNotRunOnNetNext, "Tests NodePort BPF", func() {
 			// TODO(brb) Add with L7 policy test cases after GH#8864 has been merged
 
 			nativeDev := "enp0s8"
-
-			BeforeEach(func() {
-				skipIfDoesNotRunOnNetNext()
-			})
 
 			BeforeAll(func() {
 				enableBackgroundReport = false

--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -146,14 +146,6 @@ func SkipIfFlannel() {
 	}
 }
 
-// skipIfDoesNotRunOnNetNext will skip the test if it's not running on
-// the {net,bpf}-next kernel (=ubuntu-next VM).
-func skipIfDoesNotRunOnNetNext() {
-	if !helpers.RunsOnNetNext() {
-		Skip("Test requires to be run on net-next. Skipping test.")
-	}
-}
-
 func deleteCiliumDS(kubectl *helpers.Kubectl) {
 	// Do not assert on success in AfterEach intentionally to avoid
 	// incomplete teardown.


### PR DESCRIPTION
Previously, it was not possible with ginkgo to skip the whole `Context(..)` block if some condition is not met. E.g. the following would result in test failure:

        Context("foobar", func() {
            Skip("skipping")
        })

This is quite annoying, as the `Skip` statement has to be added to any function within the `Context` block.

This PR introduces a wrapper which allows to skip the whole `Context` if a given condition is not met, and replaces `skipIfNotRunningOnNetNext()` with the wrapper in the `Test NodePort BPF` suite.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8931)
<!-- Reviewable:end -->
