### PR TITLE
bump minimum supported kubernetes version to 1.11.0

### DIFF
--- a/ginkgo-kubernetes-all.Jenkinsfile
+++ b/ginkgo-kubernetes-all.Jenkinsfile
@@ -202,7 +202,7 @@ pipeline {
             }
         }
 
-        stage('Copy code and boot VMs 1.{13,15}'){
+        stage('Copy code and boot VMs 1.{13,14}'){
 
             options {
                 timeout(time: 60, unit: 'MINUTES')

--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -109,9 +109,9 @@ pipeline {
                         }
                     }
                 }
-                stage('Boot vms K8s-1.10 net-next') {
+                stage('Boot vms K8s-1.11 net-next') {
                     environment {
-                        TESTED_SUITE="k8s-1.10"
+                        TESTED_SUITE="k8s-1.11"
                         GOPATH="${WORKSPACE}/${TESTED_SUITE}-gopath"
                         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
                         NETNEXT="true"
@@ -120,15 +120,15 @@ pipeline {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
                         retry(3) {
-                            sh 'cd ${TESTDIR}; K8S_VERSION=1.10 vagrant destroy k8s1-1.10 k8s2-1.10 --force'
-                            sh 'cd ${TESTDIR}; K8S_VERSION=1.10 vagrant up k8s1-1.10 k8s2-1.10 --provision'
+                            sh 'cd ${TESTDIR}; K8S_VERSION=1.11 vagrant destroy k8s1-1.11 k8s2-1.11 --force'
+                            sh 'cd ${TESTDIR}; K8S_VERSION=1.11 vagrant up k8s1-1.11 k8s2-1.11 --provision'
                         }
                     }
                     post {
                         unsuccessful {
                             script {
                                 if  (!currentBuild.displayName.contains('fail')) {
-                                    currentBuild.displayName = 'K8s 1.10 net-next vm provisioning fail\n' + currentBuild.displayName
+                                    currentBuild.displayName = 'K8s 1.11 net-next vm provisioning fail\n' + currentBuild.displayName
                                 }
                             }
                         }
@@ -195,15 +195,15 @@ pipeline {
                         }
                     }
                 }
-                stage('BDD-Test-PR-K8s-1.10-net-next') {
+                stage('BDD-Test-PR-K8s-1.11-net-next') {
                     environment {
-                        TESTED_SUITE="k8s-1.10"
+                        TESTED_SUITE="k8s-1.11"
                         GOPATH="${WORKSPACE}/${TESTED_SUITE}-gopath"
                         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
                         NETNEXT="true"
                     }
                     steps {
-                        sh 'cd ${TESTDIR}; K8S_VERSION=1.10 ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT}'
+                        sh 'cd ${TESTDIR}; K8S_VERSION=1.11 ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT}'
                     }
                     post {
                         always {
@@ -211,12 +211,12 @@ pipeline {
                             sh 'cd ${TESTDIR}; ./archive_test_results.sh || true'
                             sh 'cd ${TESTDIR}/..; mv *.zip ${WORKSPACE} || true'
                             sh 'cd ${TESTDIR}; mv *.xml ${WORKSPACE}/${PROJ_PATH}/test || true'
-                            sh 'cd ${TESTDIR}; K8S_VERSION=1.10 vagrant destroy -f || true'
+                            sh 'cd ${TESTDIR}; K8S_VERSION=1.11 vagrant destroy -f || true'
                         }
                         unsuccessful {
                             script {
                                 if  (!currentBuild.displayName.contains('fail')) {
-                                    currentBuild.displayName = 'K8s 1.10-net-next fail\n' + currentBuild.displayName
+                                    currentBuild.displayName = 'K8s 1.11-net-next fail\n' + currentBuild.displayName
                                 }
                             }
                         }

--- a/pkg/k8s/version/version.go
+++ b/pkg/k8s/version/version.go
@@ -55,7 +55,7 @@ var (
 
 	// MinimalVersionConstraint is the minimal version required to run
 	// Cilium
-	MinimalVersionConstraint = versioncheck.MustCompile(">= 1.8.0")
+	MinimalVersionConstraint = versioncheck.MustCompile(">= 1.11.0")
 )
 
 // Version returns the version of the Kubernetes apiserver


### PR DESCRIPTION
* Kubernetes 1.10 has been EOL'd for some time; we should try to minimize the support matrix we have and stay fairly close to what Kubernetes supports. This will allow us in the future to use specific K8s features, especially around CRDs without having to worry about less efficient fallback mechanisms. 
* Fix a typo in the K8s Jenkinsfile.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8938)
<!-- Reviewable:end -->
