### PR TITLE
endpoint: create distinct type for restoring

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -651,8 +651,7 @@ func (e *Endpoint) base64() (string, error) {
 		err       error
 	)
 
-	processedEp := e.toRestoredEndpoint()
-	jsonBytes, err = json.Marshal(processedEp)
+	jsonBytes, err = json.Marshal(e)
 	if err != nil {
 		return "", err
 	}
@@ -666,18 +665,10 @@ func parseBase64ToEndpoint(str string, ep *Endpoint) error {
 		return err
 	}
 
-	// We may have to populate structures in the Endpoint manually to do the
-	// translation from serializableEndpoint --> Endpoint.
-	log.Info("parsing serializableEndpoint marshaled into headerfile")
-	restoredEp := &serializableEndpoint{
-		OpLabels:   pkgLabels.NewOpLabels(),
-		DNSHistory: fqdn.NewDNSCacheWithLimit(option.Config.ToFQDNsMinTTL, option.Config.ToFQDNsMaxIPsPerHost),
-	}
-	if err := json.Unmarshal(jsonBytes, restoredEp); err != nil {
+	if err := json.Unmarshal(jsonBytes, ep); err != nil {
 		return fmt.Errorf("error unmarshaling serializableEndpoint from base64 representation: %s", err)
 	}
 
-	ep.fromSerializedEndpoint(restoredEp)
 	return nil
 }
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -677,7 +677,7 @@ func parseBase64ToEndpoint(str string, ep *Endpoint) error {
 		return fmt.Errorf("error unmarshaling serializableEndpoint from base64 representation: %s", err)
 	}
 
-	restoredEp.populateEndpoint(ep)
+	ep.fromSerializedEndpoint(restoredEp)
 	return nil
 }
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -664,14 +664,14 @@ func parseBase64ToEndpoint(str string, ep *Endpoint) error {
 	}
 
 	// We may have to populate structures in the Endpoint manually to do the
-	// translation from restoredEndpoint --> Endpoint.
-	log.Info("parsing restoredEndpoint marshaled into headerfile")
-	restoredEp := &restoredEndpoint{
+	// translation from serializableEndpoint --> Endpoint.
+	log.Info("parsing serializableEndpoint marshaled into headerfile")
+	restoredEp := &serializableEndpoint{
 		OpLabels:   pkgLabels.NewOpLabels(),
 		DNSHistory: fqdn.NewDNSCacheWithLimit(option.Config.ToFQDNsMinTTL, option.Config.ToFQDNsMaxIPsPerHost),
 	}
 	if err := json.Unmarshal(jsonBytes, restoredEp); err != nil {
-		return fmt.Errorf("error unmarshaling restoredEndpoint from base64 representation: %s", err)
+		return fmt.Errorf("error unmarshaling serializableEndpoint from base64 representation: %s", err)
 	}
 
 	restoredEp.populateEndpoint(ep)

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -104,6 +104,9 @@ var _ notifications.RegenNotificationInfo = &Endpoint{}
 // Endpoint represents a container or similar which can be individually
 // addresses on L3 with its own IP addresses. This structured is managed by the
 // endpoint manager in pkg/endpointmanager.
+//
+// The representation of the Endpoint which is serialized to disk for restore
+// purposes is the serializableEndpoint type in this package.
 type Endpoint struct {
 	owner regeneration.Owner
 

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -341,7 +341,7 @@ type serializableEndpoint struct {
 	DatapathConfiguration models.EndpointDatapathConfiguration
 }
 
-func (r *serializableEndpoint) populateEndpoint(ep *Endpoint) {
+func (ep *Endpoint) fromSerializedEndpoint(r *serializableEndpoint) {
 	ep.ID = r.ID
 	ep.ContainerName = r.ContainerName
 	ep.ContainerID = r.ContainerID

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -232,11 +232,11 @@ func (e *Endpoint) restoreIdentity() error {
 }
 
 // toRestoredEndpoint converts the Endpoint to its corresponding
-// restoredEndpoint, which contains all of the fields that are needed upon
+// serializableEndpoint, which contains all of the fields that are needed upon
 // restoring an Endpoint after cilium-agent restarts.
-func (e *Endpoint) toRestoredEndpoint() *restoredEndpoint {
+func (e *Endpoint) toRestoredEndpoint() *serializableEndpoint {
 
-	return &restoredEndpoint{
+	return &serializableEndpoint{
 		ID:                    e.ID,
 		ContainerName:         e.ContainerName,
 		ContainerID:           e.ContainerID,
@@ -259,7 +259,7 @@ func (e *Endpoint) toRestoredEndpoint() *restoredEndpoint {
 	}
 }
 
-// restoredEndpoint contains the fields from an Endpoint which are needed to be
+// serializableEndpoint contains the fields from an Endpoint which are needed to be
 // restored if cilium-agent restarts.
 //
 //
@@ -270,7 +270,7 @@ func (e *Endpoint) toRestoredEndpoint() *restoredEndpoint {
 // marked as private to JSON marshal. Do NOT modify this structure in ways which
 // is not JSON forward compatible.
 //
-type restoredEndpoint struct {
+type serializableEndpoint struct {
 	// ID of the endpoint, unique in the scope of the node
 	ID uint16
 
@@ -341,7 +341,7 @@ type restoredEndpoint struct {
 	DatapathConfiguration models.EndpointDatapathConfiguration
 }
 
-func (r *restoredEndpoint) populateEndpoint(ep *Endpoint) {
+func (r *serializableEndpoint) populateEndpoint(ep *Endpoint) {
 	ep.ID = r.ID
 	ep.ContainerName = r.ContainerName
 	ep.ContainerID = r.ContainerID


### PR DESCRIPTION
The Endpoint structure has been tied to contain specific fields which specific
names, as well as a flat structure due to the need to have compatibility upon
upgrades from one version of Cilium to the next. However, this means that
doing refactoring of the internals of the Endpoint structure is impossible,
as it has to maintain these API guarantees. To allow for more flexibility in
changing the structure of the Endpoint, instead, create another type which
clearly specifies what fields in the Endpoint are needed to be serialized into
its headerfile, which is then read upon restore after cilium-agent restarts.
The forward-compatible guarantee is now placed on this type instead of the
Endpoint itself, allowing for future refactoring of Endpoint without need to
worry about breaking API guarantees.

For now, do not make any changes to the Endpoint type itself to avoid coupling
refactoring changes with this PR.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8941)
<!-- Reviewable:end -->
