### PR TITLE
docs: Fix versioned archive path

### DIFF
--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -86,7 +86,7 @@ scm_web = githubusercontent + branch
 jenkins_branch = 'https://jenkins.cilium.io/view/Cilium-v' + release[0:3]
 archive_filename = archive_name +'.tar.gz'
 archive_link = 'https://github.com/cilium/cilium/archive/' + archive_filename
-archive_name = 'cilium-' + archive_name
+archive_name = 'cilium-' + archive_name.strip('v')
 
 # Store variables in the epilogue so they are globally available.
 rst_epilog = """


### PR DESCRIPTION
Fix the version path for the inner directory inside the archive for a
given tree version of the source code fetched from github archives.

Example URL: https://github.com/cilium/cilium/archive/v1.6.tar.gz
Inner directory: cilium-1.6

Prior to this commit, we would generate doc instructions pointing
users to "cd cilium-v1.6" which doesn't exist.

I validated this manually with the following patch:
```
diff --git a/Documentation/Dockerfile b/Documentation/Dockerfile
index cf5b3be53f77..2540cf0b690a 100644
--- a/Documentation/Dockerfile
+++ b/Documentation/Dockerfile
@@ -21,6 +21,7 @@ ENV PACKAGES="\
 RUN apk add --no-cache --virtual --update $PACKAGES && \
     pip install --upgrade pip && \
     pip install -r $DOCS_DIR/requirements.txt
+ENV READTHEDOCS_VERSION="v1.6"

 WORKDIR $DOCS_DIR
 ADD _api $API_DIR
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8942)
<!-- Reviewable:end -->
