### PR TITLE
CLI: Support user-specified monitor socket

### DIFF
--- a/Documentation/cmdref/cilium_monitor.md
+++ b/Documentation/cmdref/cilium_monitor.md
@@ -19,14 +19,15 @@ cilium monitor [flags]
 ### Options
 
 ```
-      --from []uint16         Filter by source endpoint id
-  -h, --help                  help for monitor
-      --hex                   Do not dissect, print payload in HEX
-  -j, --json                  Enable json output. Shadows -v flag
-      --related-to []uint16   Filter by either source or destination endpoint id
-      --to []uint16           Filter by destination endpoint id
-  -t, --type []string         Filter by event types [agent capture debug drop l7 trace]
-  -v, --verbose               Enable verbose output
+      --from []uint16           Filter by source endpoint id
+  -h, --help                    help for monitor
+      --hex                     Do not dissect, print payload in HEX
+  -j, --json                    Enable json output. Shadows -v flag
+      --monitor-socket string   Configure monitor socket path
+      --related-to []uint16     Filter by either source or destination endpoint id
+      --to []uint16             Filter by destination endpoint id
+  -t, --type []string           Filter by event types [agent capture debug drop l7 trace]
+  -v, --verbose                 Enable verbose output
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
For some use cases, Cilium may be deployed such that the monitor socket
resides somewhere other than /var/run/cilium. In that case, provide an
environment variable `CILIUM_MONITOR_SOCK` and commandline argument to
cilium monitor so that the user can specify where to find the socket.

I'd like to sneak this into v1.6 or v1.6.1, as it would make the microk8s cilium CLI wrapper
handle a bit more smoothly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8943)
<!-- Reviewable:end -->
