### PR TITLE
datapath: Limit host->service IP SNAT to local traffic

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -475,6 +475,7 @@ func (m *IptablesManager) InstallRules(ifName string) error {
 				"-A", ciliumPostNatKubeChain,
 				"-d", node.GetIPv4AllocRange().String(),
 				"-o", ifName,
+				"-m", "addrtype", "--src-type", "local",
 				"-m", "comment", "--comment", "cilium: host->service(cluster ip)->local-endpoint on "+ifName+" src address fix",
 				"-j", "SNAT", "--to-source", node.GetHostMasqueradeIPv4().String()), false); err != nil {
 				return err
@@ -487,6 +488,7 @@ func (m *IptablesManager) InstallRules(ifName string) error {
 				"-A", ciliumPostNatKubeChain,
 				"-d", node.GetIPv6AllocRange().String(),
 				"-o", ifName,
+				"-m", "addrtype", "--src-type", "local",
 				"-m", "comment", "--comment", "cilium: host->service(cluster ip)->local-endpoint on "+ifName+" src address fix",
 				"-j", "SNAT", "--to-source", node.GetIPv6().String()), false); err != nil {
 				return err


### PR DESCRIPTION
The existing rule applies to all traffic via cilium_host which also applies to
traffic that is routed into cilium_host from an external interface. This breaks
"externaltrafficpolicy: local".

Fixes: 431bd82d39c ("cilium: fix up source address selection for cluster ip# Please enter the commit message for your changes. Lines starting")

Reported-by: Ole Markus With

**Review comments:**
This is a 1.5 specific fix as 1.6 no longer includes this rule. Breaking of `externaltrafficpolicy: local` is a regression since the 1.4 release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8944)
<!-- Reviewable:end -->
