### PR TITLE
    cilium: update IsEtcdCluster to return true if etcd.operator="true"

### DIFF
--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -45,8 +45,9 @@ const (
 	// EtcdBackendName is the backend name fo etcd
 	EtcdBackendName = "etcd"
 
-	addrOption       = "etcd.address"
-	EtcdOptionConfig = "etcd.config"
+	addrOption           = "etcd.address"
+	isEtcdOperatorOption = "etcd.operator"
+	EtcdOptionConfig     = "etcd.config"
 
 	// EtcdRateLimitOption specifies maximum kv operations per second
 	EtcdRateLimitOption = "etcd.qps"
@@ -96,6 +97,9 @@ func EtcdDummyAddress() string {
 func newEtcdModule() backendModule {
 	return &etcdModule{
 		opts: backendOptions{
+			isEtcdOperatorOption: &backendOption{
+				description: "if the configuration is setting up an etcd-operator",
+			},
 			addrOption: &backendOption{
 				description: "Addresses of etcd cluster",
 			},
@@ -1333,6 +1337,11 @@ func (e *etcdClient) ListAndWatch(name, prefix string, chanSize int) *Watcher {
 func IsEtcdOperator(selectedBackend string, opts map[string]string, k8sNamespace string) bool {
 	if selectedBackend != EtcdBackendName {
 		return false
+	}
+
+	isEtcdOperator := opts[isEtcdOperatorOption]
+	if strings.ToLower(isEtcdOperator) == "true" {
+		return true
 	}
 
 	fqdnIsEtcdOperator := func(address string) bool {

--- a/pkg/kvstore/etcd_test.go
+++ b/pkg/kvstore/etcd_test.go
@@ -263,6 +263,72 @@ endpoints:
 			// config file with everything setup
 			want: true,
 		},
+		{
+			args: args{
+				backend: EtcdBackendName,
+				opts: map[string]string{
+					"etcd.address":  "foo-bar.kube-system.svc",
+					"etcd.operator": "true",
+				},
+				k8sNamespace: "kube-system",
+			},
+			want: true,
+		},
+		{
+			args: args{
+				backend: EtcdBackendName,
+				opts: map[string]string{
+					"etcd.address":  "foo-bar.kube-system.svc",
+					"etcd.operator": "false",
+				},
+				k8sNamespace: "kube-system",
+			},
+			want: false,
+		},
+		{
+			args: args{
+				backend: EtcdBackendName,
+				opts: map[string]string{
+					"etcd.address": "foo-bar.kube-system.svc",
+				},
+				k8sNamespace: "kube-system",
+			},
+			want: false,
+		},
+		{
+			args: args{
+				backend: EtcdBackendName,
+				opts: map[string]string{
+					"etcd.address":  "foo-bar.kube-system.svc",
+					"etcd.operator": "foo-bar",
+				},
+				k8sNamespace: "kube-system",
+			},
+			want: false,
+		},
+		{
+			args: args{
+				backend: EtcdBackendName,
+				opts: map[string]string{
+					"etcd.address":  "https://cilium-etcd-client.kube-system.svc",
+					"etcd.operator": "foo-bar",
+				},
+				k8sNamespace: "kube-system",
+			},
+			want: true,
+		},
+		{
+			args: args{
+				backend: EtcdBackendName,
+				opts: map[string]string{
+					"etcd.config":   etcdTempFile,
+					"etcd.operator": "foo-bar",
+				},
+				k8sNamespace: "kube-system",
+			},
+			// config file with everything setup
+			want: true,
+		},
 	}
 	for i, tt := range tests {
 		got := IsEtcdOperator(tt.args.backend, tt.args.opts, tt.args.k8sNamespace)


### PR DESCRIPTION
cilium: update IsEtcdCluster to return true if etcd.operator="true" kv option is set

    [ upstream commit: none ]

    Signed-off-by: Rajat Jindal <rajatjindal83@gmail.com>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](http://docs.cilium.io/en/stable/contributing/#submitting-a-pull-request)
- [X] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue. 
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](http://docs.cilium.io/en/stable/contributing/#dev-coo).
- [X] Provide a title or release-note blurb suitable for the release notes.
- [X] Thanks for contributing!

<!-- Description of change -->

This adds option `etcd.operator`. if set to "true" (string) IsEtcdOperator function will return true.

```release-note
adds an option etcd.operator which if set to string value "true", makes IsEtcdOperator function return true.
<!-- Enter the release note text here if needed -->
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8947)
<!-- Reviewable:end -->
