### PR TITLE
pre-flight: set terminationGracePeriodSeconds to 1

### DIFF
--- a/install/kubernetes/cilium/charts/preflight/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/preflight/templates/daemonset.yaml
@@ -84,6 +84,7 @@ spec:
       restartPolicy: Always
       serviceAccount: cilium
       serviceAccountName: cilium
+      terminationGracePeriodSeconds: 1
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready


### PR DESCRIPTION
This is done for the cilium DaemonSet to reduce the amount of time it takes to
rollout Cilium across a cluster. While updating Cilium in the upgrade tests, we
use the preflight DaemonSet, but deleting it from the cluster takes some time:

```
STEP: Removing Cilium pre-flight check DaemonSet
time="2019-08-17T07:29:44Z" level=debug msg=\"deleting cilium-preflight.yaml\"
time="2019-08-17T07:29:44Z" level=debug msg="running command: kubectl delete -f  cilium-preflight.yaml"
time="2019-08-17T07:29:54Z" level=warning msg="sending SIGHUP to session due to canceled context"
time="2019-08-17T07:29:54Z" level=warning msg="sending SIGHUP to session due to canceled context"
time="2019-08-17T07:29:54Z" level=error msg="Error executing command 'kubectl delete -f  cilium-preflight.yaml'" error="context deadline exceeded"
time="2019-08-17T07:29:54Z" level=error msg="Error executing command 'kubectl delete -f  cilium-preflight.yaml'" error="context deadline exceeded"
cmd: "kubectl delete -f  cilium-preflight.yaml" exitCode: 1 duration: 10.000189765s stdout:
```

This is not a good end-user experience, plus it adds time to our CI runs. So,
add said terminationGracePeriodSeconds configuration to terminate the pods after
1 second.

Fixes: #8021

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8952)
<!-- Reviewable:end -->
