### PR TITLE
v1.5 Fix: cilium: encryption, fix getting started guides create secrets command

### DIFF
--- a/Documentation/gettingstarted/encryption.rst
+++ b/Documentation/gettingstarted/encryption.rst
@@ -32,10 +32,11 @@ GCM-128-AES, but any of the supported
 Linux algorithms may be used. To generate use the following
 
 .. parsed-literal::
-    $ kubectl create -n kube-system secret generic cilium-ipsec-keys \
-        --from-literal=keys="3 rfc4106(gcm(aes)) $(echo `dd if=/dev/urandom count=20 bs=1 2> /dev/null| xxd -p -c 64`) 128"
 
-The secret can be displayed with 'kubectl -n kube-system get secret' and will be
+    $ kubectl create -n kube-system secret generic cilium-ipsec-keys \\
+        --from-literal=keys="3 rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null| xxd -p -c 64)) 128"
+
+The secret can be displayed with ``kubectl -n kube-system get secret`` and will be
 listed as 'cilium-ipsec-keys'.
 
 .. parsed-literal::


### PR DESCRIPTION
[ upstream commit 26e32a365a8ae7d9a5ec525f59326b0616b0ef12 ]

Some users have reported a "invalid argument" from cilium-agent when it adds
encryption rules after following the v1.5 getting started guide.

We debugged this to an incorrect secret command when using the docs from

	http://docs.cilium.io/en/v1.5/gettingstarted/encryption/#

Here the secrets command was rendered as follows,
```
  $ kubectl create -n kube-system secret generic cilium-ipsec-keys  \
      --from-literal=keys="3 rfc4106(gcm(aes)) $(echo dd if=/dev/urandom count=20 bs=1 2> /dev/null| xxd -p -c 64) 128"
```
This is actually wrong! It will give you a secret that is almost correct but has a key of the wrong length and the cilium-agent will show the reported "invalid argument" error when rules are loaded because the kernel detects the key length is wrong.

The correct command is
```
  $ kubectl create -n kube-system secret generic cilium-ipsec-keys \
    --from-literal=keys="3 rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null| xxd -p -c 64)) 128"
```
Which is the command shown in the v1.6 documentation here,

	http://docs.cilium.io/en/v1.6/gettingstarted/encryption/#

Additionally if the user (like I typically do) was following the docs
from the source using a different editor they may have got this command

```
   $ kubectl create -n kube-system secret generic cilium-ipsec-keys \
        --from-literal=keys="3 rfc4106(gcm(aes)) $(echo `dd if=/dev/urandom count=20 bs=1 2> /dev/null| xxd -p -c 64`) 128"
```

depending on how the shell handles the \` escape around the `dd` command
this may work. At least it worked for me. But at docs.cilium.io guide the
markup dropped the ` and broke the command.

Unfortunately when I was testing this I ran the commands from the source
version with my editor that did not drop the ' and did not catch the above
error.

Fix this by pulling in the fix applied to v1.6 version back to the
v1.5 documents to get everything consistent. We missed tagging this for
backport to v1.5.

To test I spun up an eks instance,
```
  uname -a
   Linux ip-192-168-77-71.us-west-2.compute.internal 4.14.128-112.105.amzn2.x86_64 #1 SMP Wed Jun 19 16:53:40 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux
```
And ran into the above fix through the html rendered version of docs. With
this I see encryption rules installed correctly and no errors.

This is a fix to a patch below in the Fixes tag (efd7bb47f5bld) where we
lost an escape char "\" that fixed this. But Andre also fixed this upstream
but we missed backporting so lets pull in Andre's fix back to v1.5.

Fixes: #8484
Fixes: efd7bb47f5b1d ("cilium: docs update encryption algo example to use GCM")
Signed-off-by: André Martins <andre@cilium.io>
Signed-off-by: John Fastabend <john.fastabend@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8961)
<!-- Reviewable:end -->
