### PR TITLE
doc: Update minikube requirement to meet TPROXY requirements

### DIFF
--- a/Documentation/gettingstarted/minikube.rst
+++ b/Documentation/gettingstarted/minikube.rst
@@ -20,12 +20,19 @@ Install kubectl & minikube
 
 1. Install ``kubectl`` version >= v1.10.0 as described in the `Kubernetes Docs <https://kubernetes.io/docs/tasks/tools/install-kubectl/>`_.
 
-2. Install ``minikube`` >= v0.33.1 as per minikube documentation: `Install Minikube <https://kubernetes.io/docs/tasks/tools/install-minikube/>`_.
+2. Install ``minikube`` >= v1.3.1 as per minikube documentation: `Install Minikube <https://kubernetes.io/docs/tasks/tools/install-minikube/>`_.
+
+.. note::
+
+   It is important to validate that you have minikube v1.3.1 installed. Older
+   versions of minikube are shipping a kernel configuration that is *not*
+   compatible with the TPROXY requirements of Cilium >= 1.6.0.
 
 ::
 
      minikube version
-     minikube version: v0.33.1
+     minikube version: v1.3.1
+     commit: ca60a424ce69a4d79f502650199ca2b52f29e631
 
 3. Create a minikube cluster:
 


### PR DESCRIPTION
Older versions of minikube do not ship xt_socket.o and thus Cilium fails to run
on these versions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8964)
<!-- Reviewable:end -->
