### PR TITLE
endpoint: move patching update functionality to pkg/endpoint

### DIFF
--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// This file contains functions related to conversion of information about
+// an Endpoint to its corresponding Cilium API representation.
+
 package endpoint
 
 import (

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -15,6 +15,7 @@
 package endpoint
 
 import (
+	"bytes"
 	"sort"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -422,4 +423,109 @@ func (e *Endpoint) policyStatus() models.EndpointPolicyEnabled {
 		policyEnabled = models.EndpointPolicyEnabledEgress
 	}
 	return policyEnabled
+}
+
+func ValidPatchTransitionState(state models.EndpointState) bool {
+	switch string(state) {
+	case "", StateWaitingForIdentity, StateReady:
+		return true
+	}
+	return false
+}
+
+// ProcessChangeRequest handles the update logic for performing a PATCH operation
+// on a given Endpoint. Returns the reason which will be used for informational
+// purposes should a caller choose to try to regenerate this endpoint, as well
+// as an error if the Endpoint is being deleted, since there is no point in
+// changing an Endpoint if it is going to be deleted.
+func (e *Endpoint) ProcessChangeRequest(epTemplate *models.EndpointChangeRequest, newEp *Endpoint) (string, error) {
+	var (
+		changed bool
+		reason  string
+	)
+
+	if err := e.LockAlive(); err != nil {
+		return "", err
+	}
+	defer e.Unlock()
+
+	if epTemplate.InterfaceIndex != 0 && e.IfIndex != newEp.IfIndex {
+		e.IfIndex = newEp.IfIndex
+		changed = true
+	}
+
+	if epTemplate.InterfaceName != "" && e.IfName != newEp.IfName {
+		e.IfName = newEp.IfName
+		changed = true
+	}
+
+	// Only support transition to waiting-for-identity state, also
+	// if the request is for ready state, as we will check the
+	// existence of the security label below. Other transitions
+	// are always internally managed, but we do not error out for
+	// backwards compatibility.
+	if epTemplate.State != "" &&
+		ValidPatchTransitionState(epTemplate.State) &&
+		e.GetStateLocked() != StateWaitingForIdentity {
+		// Will not change state if the current state does not allow the transition.
+		if e.SetStateLocked(StateWaitingForIdentity, "Update endpoint from API PATCH") {
+			changed = true
+		}
+	}
+
+	if epTemplate.Mac != "" && bytes.Compare(e.LXCMAC, newEp.LXCMAC) != 0 {
+		e.LXCMAC = newEp.LXCMAC
+		changed = true
+	}
+
+	if epTemplate.HostMac != "" && bytes.Compare(e.GetNodeMAC(), newEp.NodeMAC) != 0 {
+		e.SetNodeMACLocked(newEp.NodeMAC)
+		changed = true
+	}
+
+	if epTemplate.Addressing != nil {
+		if ip := epTemplate.Addressing.IPV6; ip != "" && bytes.Compare(e.IPv6, newEp.IPv6) != 0 {
+			e.IPv6 = newEp.IPv6
+			changed = true
+		}
+
+		if ip := epTemplate.Addressing.IPV4; ip != "" && bytes.Compare(e.IPv4, newEp.IPv4) != 0 {
+			e.IPv4 = newEp.IPv4
+			changed = true
+		}
+	}
+
+	// TODO: Do something with the labels?
+	// addLabels := labels.NewLabelsFromModel(params.Endpoint.Labels)
+
+	// If desired state is waiting-for-identity but identity is already
+	// known, bump it to ready state immediately to force re-generation
+	if e.GetStateLocked() == StateWaitingForIdentity && e.SecurityIdentity != nil {
+		e.SetStateLocked(StateReady, "Preparing to force endpoint regeneration because identity is known while handling API PATCH")
+		changed = true
+	}
+
+	if changed {
+		// Force policy regeneration as endpoint's configuration was changed.
+		// Other endpoints need not be regenerated as no labels were changed.
+		// Note that we still need to (eventually) regenerate the endpoint for
+		// the changes to take effect.
+		e.ForcePolicyCompute()
+
+		// Transition to waiting-to-regenerate if ready.
+		if e.GetStateLocked() == StateReady {
+			e.SetStateLocked(StateWaitingToRegenerate, "Forcing endpoint regeneration because identity is known while handling API PATCH")
+		}
+
+		switch e.GetStateLocked() {
+		case StateWaitingToRegenerate:
+			reason = "Waiting on endpoint regeneration because identity is known while handling API PATCH"
+		case StateWaitingForIdentity:
+			reason = "Waiting on endpoint initial program regeneration while handling API PATCH"
+		}
+	}
+
+	e.UpdateLogger(nil)
+
+	return reason, nil
 }

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -425,6 +425,9 @@ func (e *Endpoint) policyStatus() models.EndpointPolicyEnabled {
 	return policyEnabled
 }
 
+// ValidPatchTransitionState checks whether the state to which the provided
+// model specifies is one to which an Endpoint can transition as part of a
+// call to PATCH on an Endpoint.
 func ValidPatchTransitionState(state models.EndpointState) bool {
 	switch string(state) {
 	case "", StateWaitingForIdentity, StateReady:
@@ -510,7 +513,7 @@ func (e *Endpoint) ProcessChangeRequest(epTemplate *models.EndpointChangeRequest
 		// Other endpoints need not be regenerated as no labels were changed.
 		// Note that we still need to (eventually) regenerate the endpoint for
 		// the changes to take effect.
-		e.ForcePolicyCompute()
+		e.forcePolicyComputation()
 
 		// Transition to waiting-to-regenerate if ready.
 		if e.GetStateLocked() == StateReady {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -603,8 +603,9 @@ func (e *Endpoint) applyOptsLocked(opts option.OptionMap) bool {
 	return changed
 }
 
-// ForcePolicyCompute marks the endpoint for forced bpf regeneration.
-func (e *Endpoint) ForcePolicyCompute() {
+// forcePolicyComputation ensures that upon the next policy calculation for this
+// Endpoint, that no short-circuiting of said operation occurs.
+func (e *Endpoint) forcePolicyComputation() {
 	e.forcePolicyCompute = true
 }
 
@@ -1721,7 +1722,7 @@ func (e *Endpoint) identityLabelsChanged(ctx context.Context, myChangeRev int) e
 
 	// Unconditionally force policy recomputation after a new identity has been
 	// assigned.
-	e.ForcePolicyCompute()
+	e.forcePolicyComputation()
 
 	e.Unlock()
 


### PR DESCRIPTION
A lot of Endpoint implementation information, including locking, internal fields, etc. was being leaked outside of the Endpoint package in the handling of `PATCH /endpoint`. Factor this into a function within the Endpoint package instead. As a result of this, the function `ForcePolicyCompute` is no longer used outside of `pkg/endpoint`, so do not export it.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8968)
<!-- Reviewable:end -->
