### PR TITLE
cilium: encryption, if IPv6 is not supported do not throw debug warning

### DIFF
--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"syscall"
 
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/datapath"
@@ -836,14 +837,14 @@ func (n *linuxNodeHandler) removeEncryptRules() error {
 
 	rule.Mark = linux_defaults.RouteMarkDecrypt
 	if err := route.DeleteRuleIPv6(rule); err != nil {
-		if !os.IsNotExist(err) {
+		if !os.IsNotExist(err) && err != syscall.EAFNOSUPPORT {
 			return fmt.Errorf("Delete previous IPv6 decrypt rule failed: %s", err)
 		}
 	}
 
 	rule.Mark = linux_defaults.RouteMarkEncrypt
 	if err := route.DeleteRuleIPv6(rule); err != nil {
-		if !os.IsNotExist(err) {
+		if !os.IsNotExist(err) && err != syscall.EAFNOSUPPORT {
 			return fmt.Errorf("Delete previous IPv6 encrypt rule failed: %s", err)
 		}
 	}


### PR DESCRIPTION
Currently, encryption cleanup code will throw a warning when checking
encryption state with IPv6 support disabled. Lets silence the warning
by adding a check if the error is a 'address not supported' error.

Fixes: #8963
Signed-off-by: John Fastabend <john.fastabend@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8969)
<!-- Reviewable:end -->
