### PR TITLE
endpoint: factor out duplicate code into helper function

### DIFF
--- a/daemon/state.go
+++ b/daemon/state.go
@@ -179,9 +179,7 @@ func (d *Daemon) restoreOldEndpoints(dir string, clean bool) (*endpointRestoreSt
 
 		if !option.Config.KeepConfig {
 			ep.SetDefaultOpts(option.Config.Opts)
-			alwaysEnforce := policy.GetPolicyEnabled() == option.AlwaysEnforce
-			ep.SetDesiredIngressPolicyEnabledLocked(alwaysEnforce)
-			ep.SetDesiredEgressPolicyEnabledLocked(alwaysEnforce)
+			ep.SetPolicyEnforcement(policy.GetPolicyEnabled() == option.AlwaysEnforce)
 		}
 
 		ep.Unlock()

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -359,23 +359,6 @@ func (e *Endpoint) GetEgressPolicyEnabledLocked() bool {
 	return e.desiredPolicy.EgressPolicyEnabled
 }
 
-// SetDesiredIngressPolicyEnabled sets Endpoint's ingress policy enforcement
-// configuration to the specified value. The endpoint's mutex must not be held.
-func (e *Endpoint) SetDesiredIngressPolicyEnabled(ingress bool) {
-	e.UnconditionalLock()
-	e.desiredPolicy.IngressPolicyEnabled = ingress
-	e.Unlock()
-
-}
-
-// SetDesiredEgressPolicyEnabled sets Endpoint's egress policy enforcement
-// configuration to the specified value. The endpoint's mutex must not be held.
-func (e *Endpoint) SetDesiredEgressPolicyEnabled(egress bool) {
-	e.UnconditionalLock()
-	e.desiredPolicy.EgressPolicyEnabled = egress
-	e.Unlock()
-}
-
 // SetDesiredIngressPolicyEnabledLocked sets Endpoint's ingress policy enforcement
 // configuration to the specified value. The endpoint's mutex must be held.
 func (e *Endpoint) SetDesiredIngressPolicyEnabledLocked(ingress bool) {

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -43,6 +43,15 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// SetPolicyEnforcement sets whether policy enforcement is enabled at both
+// ingress and egress for the given endpoint to the value of alwaysEnforce.
+func (e *Endpoint) SetPolicyEnforcement(alwaysEnforce bool) {
+	e.UnconditionalLock()
+	e.desiredPolicy.IngressPolicyEnabled = alwaysEnforce
+	e.desiredPolicy.EgressPolicyEnabled = alwaysEnforce
+	e.Unlock()
+}
+
 // ProxyID returns a unique string to identify a proxy mapping.
 func (e *Endpoint) ProxyID(l4 *policy.L4Filter) string {
 	return policy.ProxyIDFromFilter(e.ID, l4)

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -454,9 +454,7 @@ func GetPolicyEndpoints() map[policy.Endpoint]struct{} {
 
 // AddEndpoint takes the prepared endpoint object and starts managing it.
 func AddEndpoint(owner regeneration.Owner, ep *endpoint.Endpoint, reason string) (err error) {
-	alwaysEnforce := policy.GetPolicyEnabled() == option.AlwaysEnforce
-	ep.SetDesiredIngressPolicyEnabled(alwaysEnforce)
-	ep.SetDesiredEgressPolicyEnabled(alwaysEnforce)
+	ep.SetPolicyEnforcement(policy.GetPolicyEnabled() == option.AlwaysEnforce)
 
 	if ep.ID != 0 {
 		return fmt.Errorf("Endpoint ID is already set to %d", ep.ID)


### PR DESCRIPTION
There were two locations in which policy enforcement was set based off of the
enforcement mode of the policy repository. Factor this out into a function, and
remove functions that are now unused as a result of this refactor.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8970)
<!-- Reviewable:end -->
