### PR TITLE
endpoint: refactor Docker + IPVLAN interactions

### DIFF
--- a/pkg/datapath/datapath.go
+++ b/pkg/datapath/datapath.go
@@ -43,4 +43,9 @@ type Datapath interface {
 	// Loader must return the implementation of the loader, which is responsible
 	// for loading, reloading, and compiling datapath programs.
 	Loader() Loader
+
+	// SetupIPVLAN sets up IPVLAN in the specified network namespace. Returns
+	// the file descriptor for the tail call map / ID, and an error if any
+	// operation while configuring said namespace fails.
+	SetupIPVLAN(netNS string) (int, int, error)
 }

--- a/pkg/datapath/fake/datapath.go
+++ b/pkg/datapath/fake/datapath.go
@@ -118,3 +118,7 @@ func (f *fakeLoader) Init(d datapath.ConfigWriter, nodeCfg *datapath.LocalNodeCo
 func (f *fakeLoader) CallsMapPath(id uint16) string {
 	return ""
 }
+
+func (f *fakeDatapath) SetupIPVLAN(netNS string) (int, int, error) {
+	return 0, 0, nil
+}

--- a/pkg/datapath/linux/datapath.go
+++ b/pkg/datapath/linux/datapath.go
@@ -94,3 +94,7 @@ func (l *linuxDatapath) SupportsOriginalSourceAddr() bool {
 func (l *linuxDatapath) Loader() datapath.Loader {
 	return l.loader
 }
+
+func (l *linuxDatapath) SetupIPVLAN(netNS string) (int, int, error) {
+	return connector.ConfigureNetNSForIPVLAN(netNS)
+}

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1137,9 +1137,7 @@ func (e *Endpoint) ValidateConnectorPlumbing(linkChecker linkCheckerFunc) error 
 	return nil
 }
 
-type netNSManager interface {
-	ConfigureNetNSForIPVLAN(netNsPath string) (mapFD, mapID int, err error)
-}
+type netNSIPVLANConfigFunc func(netNsPath string) (mapFD, mapID int, err error)
 
 // FinishIPVLANInit finishes configuring ipvlan slave device of the given endpoint.
 //
@@ -1158,7 +1156,7 @@ type netNSManager interface {
 // policies for an ipvlan slave before a process of a container has started. So,
 // this enables a window between the two stages during which ALL container traffic
 // is allowed.
-func (e *Endpoint) FinishIPVLANInit(mgr netNSManager, netNsPath string) error {
+func (e *Endpoint) FinishIPVLANInit(netNSIPVLANConfigFunc netNSIPVLANConfigFunc, netNsPath string) error {
 	if netNsPath == "" {
 		return fmt.Errorf("netNsPath is empty")
 	}
@@ -1181,7 +1179,7 @@ func (e *Endpoint) FinishIPVLANInit(mgr netNSManager, netNsPath string) error {
 		return nil
 	}
 
-	mapFD, mapID, err := mgr.ConfigureNetNSForIPVLAN(netNsPath)
+	mapFD, mapID, err := netNSIPVLANConfigFunc(netNsPath)
 	if err != nil {
 		return fmt.Errorf("Unable to setup ipvlan slave: %s", err)
 	}

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1137,8 +1137,6 @@ func (e *Endpoint) ValidateConnectorPlumbing(linkChecker linkCheckerFunc) error 
 	return nil
 }
 
-type netNSIPVLANConfigFunc func(netNsPath string) (mapFD, mapID int, err error)
-
 // FinishIPVLANInit finishes configuring ipvlan slave device of the given endpoint.
 //
 // Unfortunately, Docker libnetwork itself moves a netdev to netns of a container
@@ -1156,7 +1154,7 @@ type netNSIPVLANConfigFunc func(netNsPath string) (mapFD, mapID int, err error)
 // policies for an ipvlan slave before a process of a container has started. So,
 // this enables a window between the two stages during which ALL container traffic
 // is allowed.
-func (e *Endpoint) FinishIPVLANInit(netNSIPVLANConfigFunc netNSIPVLANConfigFunc, netNsPath string) error {
+func (e *Endpoint) FinishIPVLANInit(netNsPath string) error {
 	if netNsPath == "" {
 		return fmt.Errorf("netNsPath is empty")
 	}
@@ -1179,7 +1177,7 @@ func (e *Endpoint) FinishIPVLANInit(netNSIPVLANConfigFunc netNSIPVLANConfigFunc,
 		return nil
 	}
 
-	mapFD, mapID, err := netNSIPVLANConfigFunc(netNsPath)
+	mapFD, mapID, err := e.owner.Datapath().SetupIPVLAN(netNsPath)
 	if err != nil {
 		return fmt.Errorf("Unable to setup ipvlan slave: %s", err)
 	}

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1175,7 +1175,7 @@ func (e *Endpoint) FinishIPVLANInit(mgr netNSManager, netNsPath string) error {
 		return nil
 	}
 
-	if e.IsDatapathMapPinnedLocked() {
+	if e.isDatapathMapPinnedLocked() {
 		// The datapath map is pinned which implies that the post-initialization
 		// for the ipvlan slave has been successfully performed
 		return nil
@@ -1192,7 +1192,7 @@ func (e *Endpoint) FinishIPVLANInit(mgr netNSManager, netNsPath string) error {
 		unix.Close(mapFD)
 	}()
 
-	if err = e.SetDatapathMapIDAndPinMapLocked(mapID); err != nil {
+	if err = e.setDatapathMapIDAndPinMapLocked(mapID); err != nil {
 		return fmt.Errorf("Unable to pin datapath map: %s", err)
 	}
 

--- a/pkg/endpoint/connector/docker.go
+++ b/pkg/endpoint/connector/docker.go
@@ -1,0 +1,20 @@
+// Copyright 2016-2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connector
+
+const (
+	// ContainerInterfacePrefix is the container's internal interface name prefix.
+	ContainerInterfacePrefix = "cilium"
+)

--- a/pkg/endpoint/connector/ipvlan.go
+++ b/pkg/endpoint/connector/ipvlan.go
@@ -327,14 +327,10 @@ func CreateAndSetupIpvlanSlave(id string, slaveIfName string, netNs ns.NetNS, mt
 	return mapFD, nil
 }
 
-// DockerNetNSConfigurer is a wrapper around the configuration of a network
-// namespace for IPVLAN integration.
-type DockerNetNSConfigurer struct{}
-
 // ConfigureNetNSForIPVLAN sets up IPVLAN in the specified network namespace.
 // Returns the file descriptor for the tail call map / ID, and an error if
 // any operation while configuring said namespace fails.
-func (d *DockerNetNSConfigurer) ConfigureNetNSForIPVLAN(netNsPath string) (mapFD, mapID int, err error) {
+func ConfigureNetNSForIPVLAN(netNsPath string) (mapFD, mapID int, err error) {
 	var ipvlanIface string
 	// To access the netns, `/var/run/docker/netns` has to
 	// be bind mounted into the cilium-agent container with

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1166,14 +1166,14 @@ func (e *Endpoint) GetDockerNetworkID() string {
 	return e.DockerNetworkID
 }
 
-// SetDatapathMapIDAndPinMapLocked modifies the endpoint's datapath map ID
-func (e *Endpoint) SetDatapathMapIDAndPinMapLocked(id int) error {
+// setDatapathMapIDAndPinMapLocked modifies the endpoint's datapath map ID
+func (e *Endpoint) setDatapathMapIDAndPinMapLocked(id int) error {
 	e.datapathMapID = id
 	return e.PinDatapathMap()
 }
 
-// IsDatapathMapPinnedLocked returns whether the endpoint's datapath map has been pinned
-func (e *Endpoint) IsDatapathMapPinnedLocked() bool {
+// isDatapathMapPinnedLocked returns whether the endpoint's datapath map has been pinned
+func (e *Endpoint) isDatapathMapPinnedLocked() bool {
 	return e.isDatapathMapPinned
 }
 

--- a/pkg/workloads/docker.go
+++ b/pkg/workloads/docker.go
@@ -467,7 +467,7 @@ func (d *dockerClient) handleCreateWorkload(id string, retry bool) {
 
 		// Finish ipvlan initialization if endpoint is connected via Docker libnetwork (cilium-docker)
 		if d.datapathMode == option.DatapathModeIpvlan {
-			if err := ep.FinishIPVLANInit(&connector.DockerNetNSConfigurer{}, sandboxKey); err != nil {
+			if err := ep.FinishIPVLANInit(connector.ConfigureNetNSForIPVLAN, sandboxKey); err != nil {
 				retryLog.WithError(err).Warn("Cannot finish ipvlan initialization")
 				continue
 			}

--- a/pkg/workloads/docker.go
+++ b/pkg/workloads/docker.go
@@ -30,7 +30,6 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/common/addressing"
 	"github.com/cilium/cilium/pkg/endpoint"
-	"github.com/cilium/cilium/pkg/endpoint/connector"
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/k8s/utils"
@@ -467,7 +466,7 @@ func (d *dockerClient) handleCreateWorkload(id string, retry bool) {
 
 		// Finish ipvlan initialization if endpoint is connected via Docker libnetwork (cilium-docker)
 		if d.datapathMode == option.DatapathModeIpvlan {
-			if err := ep.FinishIPVLANInit(connector.ConfigureNetNSForIPVLAN, sandboxKey); err != nil {
+			if err := ep.FinishIPVLANInit(sandboxKey); err != nil {
 				retryLog.WithError(err).Warn("Cannot finish ipvlan initialization")
 				continue
 			}

--- a/plugins/cilium-docker/driver/driver.go
+++ b/plugins/cilium-docker/driver/driver.go
@@ -42,11 +42,6 @@ import (
 
 var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "cilium-docker-driver")
 
-const (
-	// ContainerInterfacePrefix is the container's internal interface name prefix.
-	ContainerInterfacePrefix = "cilium"
-)
-
 // Driver interface that listens for docker requests.
 type Driver interface {
 	Listen(string) error
@@ -415,7 +410,7 @@ func (driver *driver) joinEndpoint(w http.ResponseWriter, r *http.Request) {
 	res := &api.JoinResponse{
 		InterfaceName: &api.InterfaceName{
 			SrcName:   connector.Endpoint2TempIfName(j.EndpointID),
-			DstPrefix: ContainerInterfacePrefix,
+			DstPrefix: connector.ContainerInterfacePrefix,
 		},
 		StaticRoutes:          driver.routes,
 		DisableGatewayService: true,


### PR DESCRIPTION
The endpoint's internals were leaked in the `finishIpvlanInit` function. Refactor this function to be part of the endpoint, and hide the implementation of the actual IPVLAN + netNS interactions behind a callback.

A consequence of this refactoring is that certain functions no longer need to be exported in both `pkg/endpoint/connector` and `pkg/endpoint`. 

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8974)
<!-- Reviewable:end -->
