### PR TITLE
Fix local node service connectivity issue with endpoint-routes mode

### DIFF
--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -174,6 +174,11 @@ func (d *Daemon) createEndpoint(ctx context.Context, epTemplate *models.Endpoint
 		// program is needed on that device at egress as BPF program on
 		// cilium_host interface is bypassed
 		epTemplate.DatapathConfiguration.RequireEgressProg = true
+
+		// Delegate routing to the Linux stack rather than tail-calling
+		// between BPF programs.
+		disabled := false
+		epTemplate.DatapathConfiguration.RequireRouting = &disabled
 	}
 
 	ep, err := endpoint.NewEndpointFromChangeModel(d, epTemplate)


### PR DESCRIPTION
When `--enable-endpoint-routes` is enabled, Cilium configures the Linux
routing stack to ensure that it has all the knowledge necessary to
forward traffic towards endpoints, and configures BPF programs on the
device facing the endpoint such that ingress policy will be applied when
directing traffic towards it. Therefore, in this mode the endpoint
`DatapathConfiguration` should be configured to ensure that the Linux
stack handles routing between pods.

Fixes: #8960

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8975)
<!-- Reviewable:end -->
