### PR TITLE
daemon: factor out generation of endpoint labels model into `pkg/endpoint`

### DIFF
--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -779,25 +779,13 @@ func (h *getEndpointIDLabels) Handle(params GetEndpointIDLabelsParams) middlewar
 		return NewGetEndpointIDLabelsNotFound()
 	}
 
-	if err := ep.RLockAlive(); err != nil {
+	cfg, err := ep.GetLabelsModel()
+
+	if err != nil {
 		return api.Error(GetEndpointIDInvalidCode, err)
 	}
-	spec := &models.LabelConfigurationSpec{
-		User: ep.OpLabels.Custom.GetModel(),
-	}
 
-	cfg := models.LabelConfiguration{
-		Spec: spec,
-		Status: &models.LabelConfigurationStatus{
-			Realized:         spec,
-			SecurityRelevant: ep.OpLabels.OrchestrationIdentity.GetModel(),
-			Derived:          ep.OpLabels.OrchestrationInfo.GetModel(),
-			Disabled:         ep.OpLabels.Disabled.GetModel(),
-		},
-	}
-	ep.RUnlock()
-
-	return NewGetEndpointIDLabelsOK().WithPayload(&cfg)
+	return NewGetEndpointIDLabelsOK().WithPayload(cfg)
 }
 
 type getEndpointIDLog struct {

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -1,0 +1,42 @@
+// Copyright 2016-2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endpoint
+
+import (
+	"github.com/cilium/cilium/api/v1/models"
+)
+
+// GetLabelsModel returns the labels of the endpoint in their representation
+// for the Cilium API. Returns an error if the Endpoint is being deleted.
+func (e *Endpoint) GetLabelsModel() (*models.LabelConfiguration, error) {
+	if err := e.RLockAlive(); err != nil {
+		return nil, err
+	}
+	spec := &models.LabelConfigurationSpec{
+		User: e.OpLabels.Custom.GetModel(),
+	}
+
+	cfg := models.LabelConfiguration{
+		Spec: spec,
+		Status: &models.LabelConfigurationStatus{
+			Realized:         spec,
+			SecurityRelevant: e.OpLabels.OrchestrationIdentity.GetModel(),
+			Derived:          e.OpLabels.OrchestrationInfo.GetModel(),
+			Disabled:         e.OpLabels.Disabled.GetModel(),
+		},
+	}
+	e.RUnlock()
+	return &cfg, nil
+}


### PR DESCRIPTION
This allows for the the locking functionality of the Endpoint to not be exposed
as much outside of `pkg/endpoint`.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8976)
<!-- Reviewable:end -->
