### PR TITLE
endpoint: remove need to expose read-locking in `updateEndpointsCaches`

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -822,8 +822,12 @@ func (e *Endpoint) GetLabels() []string {
 
 // GetSecurityIdentity returns the security identity of the endpoint. It assumes
 // the endpoint's mutex is held.
-func (e *Endpoint) GetSecurityIdentity() *identityPkg.Identity {
-	return e.SecurityIdentity
+func (e *Endpoint) GetSecurityIdentity() (*identityPkg.Identity, error) {
+	if err := e.RLockAlive(); err != nil {
+		return nil, err
+	}
+	defer e.RUnlock()
+	return e.SecurityIdentity, nil
 }
 
 // GetID16 returns the endpoint's ID as a 16-bit unsigned integer.

--- a/pkg/policy/identifier.go
+++ b/pkg/policy/identifier.go
@@ -27,9 +27,7 @@ import (
 // * a means of incrementing its policy revision
 type Endpoint interface {
 	GetID16() uint16
-	RLockAlive() error
-	RUnlock()
-	GetSecurityIdentity() *identity.Identity
+	GetSecurityIdentity() (*identity.Identity, error)
 	PolicyRevisionBumpEvent(rev uint64)
 }
 

--- a/pkg/policy/identifier_test.go
+++ b/pkg/policy/identifier_test.go
@@ -32,8 +32,8 @@ func (d *DummyEndpoint) GetID16() uint16 {
 	return 0
 }
 
-func (d *DummyEndpoint) GetSecurityIdentity() *identity.Identity {
-	return nil
+func (d *DummyEndpoint) GetSecurityIdentity() (*identity.Identity, error) {
+	return nil, nil
 }
 
 func (d *DummyEndpoint) PolicyRevisionBumpEvent(rev uint64) {

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -15,7 +15,6 @@
 package policy
 
 import (
-	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 )
 
@@ -77,7 +76,6 @@ type EndpointPolicy struct {
 // PolicyOwner is anything which consumes a EndpointPolicy.
 type PolicyOwner interface {
 	LookupRedirectPort(l4 *L4Filter) uint16
-	GetSecurityIdentity() *identity.Identity
 }
 
 // newSelectorPolicy returns an empty selectorPolicy stub.

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -53,18 +53,11 @@ func (d *dummyEndpoint) GetID16() uint16 {
 	return d.ID
 }
 
-func (d *dummyEndpoint) GetSecurityIdentity() *identity.Identity {
-	return d.SecurityIdentity
+func (d *dummyEndpoint) GetSecurityIdentity() (*identity.Identity, error) {
+	return d.SecurityIdentity, nil
 }
 
 func (d *dummyEndpoint) PolicyRevisionBumpEvent(rev uint64) {
-}
-
-func (d *dummyEndpoint) RLockAlive() error {
-	return nil
-}
-
-func (d *dummyEndpoint) RUnlock() {
 }
 
 func GenerateNumIdentities(numIdentities int) {
@@ -178,10 +171,6 @@ type DummyOwner struct{}
 
 func (d DummyOwner) LookupRedirectPort(l4 *L4Filter) uint16 {
 	return 0
-}
-
-func (d DummyOwner) GetSecurityIdentity() *identity.Identity {
-	return fooIdentity
 }
 
 func bootstrapRepo(ruleGenFunc func(int) api.Rules, numRules int, c *C) *Repository {

--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -229,11 +229,10 @@ func (rules ruleSlice) updateEndpointsCaches(ep Endpoint) (bool, error) {
 		return false, fmt.Errorf("cannot update caches in rules because endpoint is nil")
 	}
 	id := ep.GetID16()
-	if err := ep.RLockAlive(); err != nil {
+	securityIdentity, err := ep.GetSecurityIdentity()
+	if err != nil {
 		return false, fmt.Errorf("cannot update caches in rules for endpoint %d because it is being deleted: %s", id, err)
 	}
-	securityIdentity := ep.GetSecurityIdentity()
-	ep.RUnlock()
 
 	if securityIdentity == nil {
 		return false, fmt.Errorf("cannot update caches in rules for endpoint %d because it has a nil identity", id)


### PR DESCRIPTION
The only caller of `GetSecurityIdentity` for `pkg/endpoint` is in
`updateEndpointsCaches`. This exposed the read-locking functionality of Endpoint
unnecessarily, as the read-locking can be put in `GetSecurityIdentity`.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8977)
<!-- Reviewable:end -->
