### PR TITLE
cni: Fix disabling of routing in chaining mode

### DIFF
--- a/plugins/cilium-cni/chaining/generic-veth/generic-veth.go
+++ b/plugins/cilium-cni/chaining/generic-veth/generic-veth.go
@@ -145,7 +145,7 @@ func (f *GenericVethChainer) Add(ctx context.Context, pluginCtx chainingapi.Plug
 		return
 	}
 
-	var enabled = true
+	var disabled = false
 	ep := &models.EndpointChangeRequest{
 		Addressing: &models.AddressPair{
 			IPV4: vethIP,
@@ -174,7 +174,7 @@ func (f *GenericVethChainer) Add(ctx context.Context, pluginCtx chainingapi.Plug
 			ExternalIPAM: true,
 
 			// All routing is performed by the Linux stack
-			RequireRouting: &enabled,
+			RequireRouting: &disabled,
 		},
 	}
 


### PR DESCRIPTION
The comment here indicated that routing should be deferred to the Linux
routing stack, but the value indicated that Cilium should perform the
routing. Disable it properly.

API side model code definition:
https://github.com/cilium/cilium/blob/42229305fd2e24cf6ece5e9411539341f23852ff/api/v1/models/endpoint_datapath_configuration.go#L33-L35

**I haven't tested this** out, but logically the comment is at dissonance with what it actually does. I welcome comments and testing by anyone using CNI chaining with the generic veth mode.

This misconfiguration could plausibly cause a similar problem to the one observed with `--enable-endpoint-routes` mode in #8960.

Note that this patch will only affect newly created endpoints, it will not fix existing endpoint deployments; After upgrade, a restart of pods will be required to configure these new settings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8978)
<!-- Reviewable:end -->
