### PR TITLE
helm: Add global.kubeConfigPath

### DIFF
--- a/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
@@ -179,6 +179,11 @@ spec:
         - mountPath: {{ .Values.global.encryption.mountPath }}
           name: cilium-ipsec-secrets
 {{- end }}
+{{- if .Values.global.kubeConfigPath }}
+        - mountPath: {{ .Values.global.kubeConfigPath }}
+          name: kube-config
+          readOnly: true
+{{- end}}
 {{- if .Values.global.etcd.managed }}
       # In managed etcd mode, Cilium must be able to resolve the DNS name of
       # the etcd service
@@ -300,6 +305,12 @@ spec:
           path: /run/xtables.lock
           type: FileOrCreate
         name: xtables-lock
+{{- if .Values.global.kubeConfigPath }}
+      - hostPath:
+          path: {{ .Values.global.kubeConfigPath }}
+          type: FileOrCreate
+        name: kube-config
+{{- end }}
 {{- if .Values.global.etcd.enabled }}
         # To read the etcd config stored in config maps
       - configMap:

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -298,3 +298,6 @@ data:
   read-cni-conf: {{ .Values.global.cni.confFileMountPath }}/{{ .Values.global.cni.configMapKey }}
   write-cni-conf-when-ready: {{ .Values.global.cni.hostConfDirMountPath }}/05-cilium.conflist
 {{- end }}
+{{- if .Values.global.kubeConfigPath }}
+  k8s-kubeconfig-path: {{ .Values.global.kubeConfigPath | quote }}
+{{- end }}

--- a/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
@@ -34,6 +34,9 @@ spec:
 {{- if .Values.global.prometheus.enabled }}
         - --enable-metrics
 {{- end }}
+{{- if .Values.global.kubeConfigPath }}
+        - --k8s-kubeconfig-path={{ .Values.global.kubeConfigPath }}
+{{- end }}
         command:
         - cilium-operator
         env:
@@ -129,8 +132,10 @@ spec:
           initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 3
-{{- if .Values.global.etcd.enabled }}
+{{- if or .Values.global.etcd.enabled .Values.global.kubeConfigPath }}
         volumeMounts:
+{{- end }}
+{{- if .Values.global.etcd.enabled }}
         - mountPath: /var/lib/etcd-config
           name: etcd-config-path
           readOnly: true
@@ -140,6 +145,12 @@ spec:
           readOnly: true
 {{- end }}
 {{- end }}
+{{- if .Values.global.kubeConfigPath }}
+        - mountPath: {{ .Values.global.kubeConfigPath }}
+          name: kube-config
+          readOnly: true
+{{- end}}
+
       hostNetwork: true
 {{- if .Values.global.etcd.managed }}
       # In managed etcd mode, Cilium must be able to resolve the DNS name of
@@ -149,8 +160,10 @@ spec:
       restartPolicy: Always
       serviceAccount: cilium-operator
       serviceAccountName: cilium-operator
-{{- if .Values.global.etcd.enabled }}
+{{- if or .Values.global.etcd.enabled .Values.global.kubeConfigPath }}
       volumes:
+{{- end }}
+{{- if .Values.global.etcd.enabled }}
       # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420
@@ -167,4 +180,10 @@ spec:
           optional: true
           secretName: cilium-etcd-secrets
 {{- end }}
+{{- end }}
+{{- if .Values.global.kubeConfigPath }}
+      - hostPath:
+          path: {{ .Values.global.kubeConfigPath }}
+          type: FileOrCreate
+        name: kube-config
 {{- end }}


### PR DESCRIPTION
This commits introduces `.Values.global.kubeConfigPath` which enables mounting of k8s config file into cilium-agent and cilium-operator pods, and passes the mounted path via `--k8s-kubeconfig-path` to both.

This is required for cilium-{agent,operator} to access k8s api-server when kube-proxy is not provisioned and the api-server is accessible only via https (i.e. `--k8s-api-server` is not possible to use).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8981)
<!-- Reviewable:end -->
