### PR TITLE
Fix cilium startup failure when xt_socket kernel module is not available

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -378,6 +378,26 @@ func (m *IptablesManager) ingressProxyRule(cmd, l4Match, markMatch, mark, port, 
 		"--on-port", port)
 }
 
+func (m *IptablesManager) inboundProxyRedirectRule(cmd string) []string {
+	// Mark host proxy transparent connections to be routed to the local stack.
+	// This comes before the TPROXY rules in the chain, and setting the mark
+	// without the proxy port number will make the TPROXY rule to not match,
+	// as we do not want to try to tproxy packets that are going to the stack
+	// already.
+	// This rule is needed for couple of reasons:
+	// 1. route return traffic to the proxy
+	// 2. route original direction traffic that would otherwise be intercepted
+	//    by ip_early_demux
+	toProxyMark := fmt.Sprintf("%#08x", linux_defaults.MagicMarkIsToProxy)
+	return append(m.waitArgs,
+		"-t", "mangle",
+		cmd, ciliumPreMangleChain,
+		"-m", "socket", "--transparent", "--nowildcard",
+		"-m", "comment", "--comment", "cilium: any->pod redirect proxied traffic to host proxy",
+		"-j", "MARK",
+		"--set-mark", toProxyMark)
+}
+
 func (m *IptablesManager) iptIngressProxyRule(cmd string, l4proto string, proxyPort uint16, name string) error {
 	// Match
 	port := uint32(byteorder.HostToNetwork(proxyPort).(uint16)) << 16
@@ -438,7 +458,7 @@ func (m *IptablesManager) iptEgressProxyRule(cmd string, l4proto string, proxyPo
 	return err
 }
 
-func (m *IptablesManager) installProxyNotrackRules() error {
+func (m *IptablesManager) installStaticProxyRules() error {
 	// match traffic to a proxy (upper 16 bits has the proxy port, which is masked out)
 	matchToProxy := fmt.Sprintf("%#08x/%#08x", linux_defaults.MagicMarkIsToProxy, linux_defaults.MagicMarkHostMask)
 	// proxy return traffic has 0 ID in the mask
@@ -468,6 +488,8 @@ func (m *IptablesManager) installProxyNotrackRules() error {
 				"-m", "comment", "--comment", "cilium: NOTRACK for proxy return traffic",
 				"-j", "NOTRACK"), false)
 		}
+		// Direct inbound TPROXYed traffic towards the socket
+		err := runProg("iptables", m.inboundProxyRedirectRule("-A"), false)
 	}
 	if err == nil && option.Config.EnableIPv6 {
 		// No conntrack for traffic to ingress proxy
@@ -492,6 +514,8 @@ func (m *IptablesManager) installProxyNotrackRules() error {
 				"-m", "comment", "--comment", "cilium: NOTRACK for proxy return traffic",
 				"-j", "NOTRACK"), false)
 		}
+		// Direct inbound TPROXYed traffic towards the socket
+		err = runProg("ip6tables", m.inboundProxyRedirectRule("-A"), false)
 	}
 	return err
 }
@@ -613,49 +637,15 @@ func (m *IptablesManager) InstallRules(ifName string) error {
 		}
 	}
 
-	if err := m.installProxyNotrackRules(); err != nil {
-		return fmt.Errorf("cannot add proxy NOTRACK rules: %s", err)
+	if err := m.installStaticProxyRules(); err != nil {
+		return fmt.Errorf("cannot add static proxy rules: %s", err)
 	}
 
 	if err := m.addCiliumAcceptXfrmRules(); err != nil {
 		return err
 	}
 
-	toProxyMark := fmt.Sprintf("%#08x", linux_defaults.MagicMarkIsToProxy)
-
-	if option.Config.EnableIPv6 {
-		// Mark host proxy transparent connections to be routed to the local stack.
-		// This comes before the TPROXY rules in the chain, and setting the mark
-		// without the proxy port number will make the TPROXY rule to not match,
-		// as we do not want to try to tproxy packets that are going to the stack
-		// already.
-		// This rule is needed for couple of reasons:
-		// 1. route return traffic to the proxy
-		// 2. route original direction traffic that would otherwise be intercepted
-		//    by ip_early_demux
-		if err := runProg("ip6tables", append(
-			m.waitArgs,
-			"-t", "mangle",
-			"-A", ciliumPreMangleChain,
-			"-m", "socket", "--transparent", "--nowildcard",
-			"-m", "comment", "--comment", "cilium: mark transparent proxy traffic to be routed locally",
-			"-j", "MARK", "--set-mark", toProxyMark), false); err != nil {
-			return err
-		}
-	}
-
 	if option.Config.EnableIPv4 {
-		// See comment above for the IPv6 case.
-		if err := runProg("iptables", append(
-			m.waitArgs,
-			"-t", "mangle",
-			"-A", ciliumPreMangleChain,
-			"-m", "socket", "--transparent", "--nowildcard",
-			"-m", "comment", "--comment", "cilium: mark transparent proxy traffic to be routed locally",
-			"-j", "MARK", "--set-mark", toProxyMark), false); err != nil {
-			return err
-		}
-
 		// Clear the Kubernetes masquerading mark bit to skip source PAT
 		// performed by kube-proxy for all packets destined for Cilium. Cilium
 		// installs a dedicated rule which does the source PAT to the right


### PR DESCRIPTION
Per #8982, Cilium v1.6.0 fails to start in some GKE environments because we attempt to configure an iptables rule which uses the socket match, for ensuring that tproxy traffic can reach proxies in direct routing mode.

Rather than crashing out entirely, this PR proposes to just print a warning in the logs that the rule was not configured, which could cause unexpected drops when using L7 policy in direct routing mode.

Future work can potentially look to better support this direct routing mode + L7 policy case with tproxy perhaps by substituting the iptables rule installation with instead disabling early demux, however this will require further testing and validation to ensure it works correctly. For now, it's better to allow common use cases such as Cilium in tunnel mode, or Cilium in direct routing without L7 policy, rather than always exiting out in such environments.

Fixes: #8982

I manually validated this locally by removing the `xt_socket` module and running Cilium to observe that the warning message is formatted correctly and Cilium continues to run in that case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8983)
<!-- Reviewable:end -->
