### PR TITLE
Fix 'make microk8s' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -422,9 +422,9 @@ logging-subsys-field:
 
 check-microk8s:
 	@$(ECHO_CHECK) microk8s is ready...
-	$(QUIET)microk8s.status >/dev/null \
+	$(QUIET)sudo microk8s.status >/dev/null \
 		|| (echo "Error: Microk8s is not running" && exit 1)
-	$(QUIET)microk8s.status -o yaml | grep -q "registry.*enabled" \
+	$(QUIET)sudo microk8s.status -o yaml | grep -q "registry.*enabled" \
 		|| (echo "Error: Microk8s registry must be enabled" && exit 1)
 
 LOCAL_IMAGE_TAG=local


### PR DESCRIPTION
Microk8s recently introduced a requirement to run the status command as
root, which broke this "make microk8s" target. Fix it by prepending
microk8s commands with "sudo".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8984)
<!-- Reviewable:end -->
