### PR TITLE
operator: Fix passing kvstore options via arguments

### DIFF
--- a/operator/main.go
+++ b/operator/main.go
@@ -213,7 +213,9 @@ func runOperator(cmd *cobra.Command) {
 	k8sClientQPSLimit := viper.GetFloat64(option.K8sClientQPSLimit)
 	k8sClientBurst := viper.GetInt(option.K8sClientBurst)
 	kvStore = viper.GetString(option.KVStore)
-	kvStoreOpts = viper.GetStringMapString(option.KVStoreOpt)
+	if m := viper.GetStringMapString(option.KVStoreOpt); len(m) > 0 {
+		kvStoreOpts = m
+	}
 
 	k8s.Configure(k8sAPIServer, k8sKubeConfigPath, float32(k8sClientQPSLimit), k8sClientBurst)
 	if err := k8s.Init(); err != nil {


### PR DESCRIPTION
The kvstore option variable was overwritten to be an empty array unless passed
in as environment variable.

Fixes: a37ff0ff2ba ("operator: Fix kvstore configuration inheritance from ConfigMap")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8988)
<!-- Reviewable:end -->
