### PR TITLE
Pr/v1.6 backports 2019 08 21

### DIFF
--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -174,6 +174,11 @@ func (d *Daemon) createEndpoint(ctx context.Context, epTemplate *models.Endpoint
 		// program is needed on that device at egress as BPF program on
 		// cilium_host interface is bypassed
 		epTemplate.DatapathConfiguration.RequireEgressProg = true
+
+		// Delegate routing to the Linux stack rather than tail-calling
+		// between BPF programs.
+		disabled := false
+		epTemplate.DatapathConfiguration.RequireRouting = &disabled
 	}
 
 	ep, err := endpoint.NewEndpointFromChangeModel(d, epTemplate)

--- a/install/kubernetes/cilium/charts/agent/templates/clusterrole.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/clusterrole.yaml
@@ -18,7 +18,6 @@ rules:
   - services
   - nodes
   - endpoints
-  - componentstatuses
   verbs:
   - get
   - list

--- a/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
@@ -180,6 +180,11 @@ spec:
         - mountPath: {{ .Values.global.encryption.mountPath }}
           name: cilium-ipsec-secrets
 {{- end }}
+{{- if .Values.global.kubeConfigPath }}
+        - mountPath: {{ .Values.global.kubeConfigPath }}
+          name: kube-config
+          readOnly: true
+{{- end}}
 {{- if .Values.global.etcd.managed }}
       # In managed etcd mode, Cilium must be able to resolve the DNS name of
       # the etcd service
@@ -301,6 +306,12 @@ spec:
           path: /run/xtables.lock
           type: FileOrCreate
         name: xtables-lock
+{{- if .Values.global.kubeConfigPath }}
+      - hostPath:
+          path: {{ .Values.global.kubeConfigPath }}
+          type: FileOrCreate
+        name: kube-config
+{{- end }}
 {{- if .Values.global.etcd.enabled }}
         # To read the etcd config stored in config maps
       - configMap:

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -298,3 +298,6 @@ data:
   read-cni-conf: {{ .Values.global.cni.confFileMountPath }}/{{ .Values.global.cni.configMapKey }}
   write-cni-conf-when-ready: {{ .Values.global.cni.hostConfDirMountPath }}/05-cilium.conflist
 {{- end }}
+{{- if .Values.global.kubeConfigPath }}
+  k8s-kubeconfig-path: {{ .Values.global.kubeConfigPath | quote }}
+{{- end }}

--- a/install/kubernetes/cilium/charts/operator/templates/clusterrole.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/clusterrole.yaml
@@ -6,13 +6,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  # to get k8s version and status
-  - componentstatuses
-  verbs:
-  - get
-- apiGroups:
-  - ""
-  resources:
   # to automatically delete [core|kube]dns pods so that are starting to being
   # managed by Cilium
   - pods
@@ -31,6 +24,8 @@ rules:
   # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
+  # to check apiserver connectivity
+  - namespaces
   verbs:
   - get
   - list

--- a/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
@@ -34,6 +34,9 @@ spec:
 {{- if .Values.global.prometheus.enabled }}
         - --enable-metrics
 {{- end }}
+{{- if .Values.global.kubeConfigPath }}
+        - --k8s-kubeconfig-path={{ .Values.global.kubeConfigPath }}
+{{- end }}
         command:
         - cilium-operator
         env:
@@ -129,8 +132,10 @@ spec:
           initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 3
-{{- if .Values.global.etcd.enabled }}
+{{- if or .Values.global.etcd.enabled .Values.global.kubeConfigPath }}
         volumeMounts:
+{{- end }}
+{{- if .Values.global.etcd.enabled }}
         - mountPath: /var/lib/etcd-config
           name: etcd-config-path
           readOnly: true
@@ -140,6 +145,12 @@ spec:
           readOnly: true
 {{- end }}
 {{- end }}
+{{- if .Values.global.kubeConfigPath }}
+        - mountPath: {{ .Values.global.kubeConfigPath }}
+          name: kube-config
+          readOnly: true
+{{- end}}
+
       hostNetwork: true
 {{- if .Values.global.etcd.managed }}
       # In managed etcd mode, Cilium must be able to resolve the DNS name of
@@ -149,8 +160,10 @@ spec:
       restartPolicy: Always
       serviceAccount: cilium-operator
       serviceAccountName: cilium-operator
-{{- if .Values.global.etcd.enabled }}
+{{- if or .Values.global.etcd.enabled .Values.global.kubeConfigPath }}
       volumes:
+{{- end }}
+{{- if .Values.global.etcd.enabled }}
       # To read the etcd config stored in config maps
       - configMap:
           defaultMode: 420
@@ -167,4 +180,10 @@ spec:
           optional: true
           secretName: cilium-etcd-secrets
 {{- end }}
+{{- end }}
+{{- if .Values.global.kubeConfigPath }}
+      - hostPath:
+          path: {{ .Values.global.kubeConfigPath }}
+          type: FileOrCreate
+        name: kube-config
 {{- end }}

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -173,7 +173,6 @@ rules:
   - services
   - nodes
   - endpoints
-  - componentstatuses
   verbs:
   - get
   - list
@@ -238,13 +237,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  # to get k8s version and status
-  - componentstatuses
-  verbs:
-  - get
-- apiGroups:
-  - ""
-  resources:
   # to automatically delete [core|kube]dns pods so that are starting to being
   # managed by Cilium
   - pods
@@ -263,6 +255,8 @@ rules:
   # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
+  # to check apiserver connectivity
+  - namespaces
   verbs:
   - get
   - list

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -378,6 +378,26 @@ func (m *IptablesManager) ingressProxyRule(cmd, l4Match, markMatch, mark, port, 
 		"--on-port", port)
 }
 
+func (m *IptablesManager) inboundProxyRedirectRule(cmd string) []string {
+	// Mark host proxy transparent connections to be routed to the local stack.
+	// This comes before the TPROXY rules in the chain, and setting the mark
+	// without the proxy port number will make the TPROXY rule to not match,
+	// as we do not want to try to tproxy packets that are going to the stack
+	// already.
+	// This rule is needed for couple of reasons:
+	// 1. route return traffic to the proxy
+	// 2. route original direction traffic that would otherwise be intercepted
+	//    by ip_early_demux
+	toProxyMark := fmt.Sprintf("%#08x", linux_defaults.MagicMarkIsToProxy)
+	return append(m.waitArgs,
+		"-t", "mangle",
+		cmd, ciliumPreMangleChain,
+		"-m", "socket", "--transparent", "--nowildcard",
+		"-m", "comment", "--comment", "cilium: any->pod redirect proxied traffic to host proxy",
+		"-j", "MARK",
+		"--set-mark", toProxyMark)
+}
+
 func (m *IptablesManager) iptIngressProxyRule(cmd string, l4proto string, proxyPort uint16, name string) error {
 	// Match
 	port := uint32(byteorder.HostToNetwork(proxyPort).(uint16)) << 16
@@ -438,7 +458,7 @@ func (m *IptablesManager) iptEgressProxyRule(cmd string, l4proto string, proxyPo
 	return err
 }
 
-func (m *IptablesManager) installProxyNotrackRules() error {
+func (m *IptablesManager) installStaticProxyRules() error {
 	// match traffic to a proxy (upper 16 bits has the proxy port, which is masked out)
 	matchToProxy := fmt.Sprintf("%#08x/%#08x", linux_defaults.MagicMarkIsToProxy, linux_defaults.MagicMarkHostMask)
 	// proxy return traffic has 0 ID in the mask
@@ -468,6 +488,8 @@ func (m *IptablesManager) installProxyNotrackRules() error {
 				"-m", "comment", "--comment", "cilium: NOTRACK for proxy return traffic",
 				"-j", "NOTRACK"), false)
 		}
+		// Direct inbound TPROXYed traffic towards the socket
+		err := runProg("iptables", m.inboundProxyRedirectRule("-A"), false)
 	}
 	if err == nil && option.Config.EnableIPv6 {
 		// No conntrack for traffic to ingress proxy
@@ -492,6 +514,8 @@ func (m *IptablesManager) installProxyNotrackRules() error {
 				"-m", "comment", "--comment", "cilium: NOTRACK for proxy return traffic",
 				"-j", "NOTRACK"), false)
 		}
+		// Direct inbound TPROXYed traffic towards the socket
+		err = runProg("ip6tables", m.inboundProxyRedirectRule("-A"), false)
 	}
 	return err
 }
@@ -613,49 +637,15 @@ func (m *IptablesManager) InstallRules(ifName string) error {
 		}
 	}
 
-	if err := m.installProxyNotrackRules(); err != nil {
-		return fmt.Errorf("cannot add proxy NOTRACK rules: %s", err)
+	if err := m.installStaticProxyRules(); err != nil {
+		return fmt.Errorf("cannot add static proxy rules: %s", err)
 	}
 
 	if err := m.addCiliumAcceptXfrmRules(); err != nil {
 		return err
 	}
 
-	toProxyMark := fmt.Sprintf("%#08x", linux_defaults.MagicMarkIsToProxy)
-
-	if option.Config.EnableIPv6 {
-		// Mark host proxy transparent connections to be routed to the local stack.
-		// This comes before the TPROXY rules in the chain, and setting the mark
-		// without the proxy port number will make the TPROXY rule to not match,
-		// as we do not want to try to tproxy packets that are going to the stack
-		// already.
-		// This rule is needed for couple of reasons:
-		// 1. route return traffic to the proxy
-		// 2. route original direction traffic that would otherwise be intercepted
-		//    by ip_early_demux
-		if err := runProg("ip6tables", append(
-			m.waitArgs,
-			"-t", "mangle",
-			"-A", ciliumPreMangleChain,
-			"-m", "socket", "--transparent", "--nowildcard",
-			"-m", "comment", "--comment", "cilium: mark transparent proxy traffic to be routed locally",
-			"-j", "MARK", "--set-mark", toProxyMark), false); err != nil {
-			return err
-		}
-	}
-
 	if option.Config.EnableIPv4 {
-		// See comment above for the IPv6 case.
-		if err := runProg("iptables", append(
-			m.waitArgs,
-			"-t", "mangle",
-			"-A", ciliumPreMangleChain,
-			"-m", "socket", "--transparent", "--nowildcard",
-			"-m", "comment", "--comment", "cilium: mark transparent proxy traffic to be routed locally",
-			"-j", "MARK", "--set-mark", toProxyMark), false); err != nil {
-			return err
-		}
-
 		// Clear the Kubernetes masquerading mark bit to skip source PAT
 		// performed by kube-proxy for all packets destined for Cilium. Cilium
 		// installs a dedicated rule which does the source PAT to the right

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"syscall"
 
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/datapath"
@@ -836,14 +837,14 @@ func (n *linuxNodeHandler) removeEncryptRules() error {
 
 	rule.Mark = linux_defaults.RouteMarkDecrypt
 	if err := route.DeleteRuleIPv6(rule); err != nil {
-		if !os.IsNotExist(err) {
+		if !os.IsNotExist(err) && err != syscall.EAFNOSUPPORT {
 			return fmt.Errorf("Delete previous IPv6 decrypt rule failed: %s", err)
 		}
 	}
 
 	rule.Mark = linux_defaults.RouteMarkEncrypt
 	if err := route.DeleteRuleIPv6(rule); err != nil {
-		if !os.IsNotExist(err) {
+		if !os.IsNotExist(err) && err != syscall.EAFNOSUPPORT {
 			return fmt.Errorf("Delete previous IPv6 encrypt rule failed: %s", err)
 		}
 	}

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -128,9 +128,9 @@ func CreateClient(config *rest.Config) (*kubernetes.Clientset, error) {
 	return cs, err
 }
 
-// isConnReady returns the err for the controller-manager status
+// isConnReady returns the err for the kube-system namespace get
 func isConnReady(c *kubernetes.Clientset) error {
-	_, err := c.CoreV1().ComponentStatuses().Get("controller-manager", metav1.GetOptions{})
+	_, err := c.CoreV1().Namespaces().Get("kube-system", metav1.GetOptions{})
 	return err
 }
 

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -46,8 +46,9 @@ const (
 	// EtcdBackendName is the backend name for etcd
 	EtcdBackendName = "etcd"
 
-	addrOption       = "etcd.address"
-	EtcdOptionConfig = "etcd.config"
+	addrOption           = "etcd.address"
+	isEtcdOperatorOption = "etcd.operator"
+	EtcdOptionConfig     = "etcd.config"
 
 	// EtcdRateLimitOption specifies maximum kv operations per second
 	EtcdRateLimitOption = "etcd.qps"
@@ -97,6 +98,9 @@ func EtcdDummyAddress() string {
 func newEtcdModule() backendModule {
 	return &etcdModule{
 		opts: backendOptions{
+			isEtcdOperatorOption: &backendOption{
+				description: "if the configuration is setting up an etcd-operator",
+			},
 			addrOption: &backendOption{
 				description: "Addresses of etcd cluster",
 			},
@@ -1337,6 +1341,11 @@ func (e *etcdClient) ListAndWatch(name, prefix string, chanSize int) *Watcher {
 func IsEtcdOperator(selectedBackend string, opts map[string]string, k8sNamespace string) bool {
 	if selectedBackend != EtcdBackendName {
 		return false
+	}
+
+	isEtcdOperator := opts[isEtcdOperatorOption]
+	if strings.ToLower(isEtcdOperator) == "true" {
+		return true
 	}
 
 	fqdnIsEtcdOperator := func(address string) bool {

--- a/pkg/kvstore/etcd_test.go
+++ b/pkg/kvstore/etcd_test.go
@@ -260,6 +260,72 @@ endpoints:
 			// config file with everything setup
 			want: true,
 		},
+		{
+			args: args{
+				backend: EtcdBackendName,
+				opts: map[string]string{
+					"etcd.address":  "foo-bar.kube-system.svc",
+					"etcd.operator": "true",
+				},
+				k8sNamespace: "kube-system",
+			},
+			want: true,
+		},
+		{
+			args: args{
+				backend: EtcdBackendName,
+				opts: map[string]string{
+					"etcd.address":  "foo-bar.kube-system.svc",
+					"etcd.operator": "false",
+				},
+				k8sNamespace: "kube-system",
+			},
+			want: false,
+		},
+		{
+			args: args{
+				backend: EtcdBackendName,
+				opts: map[string]string{
+					"etcd.address": "foo-bar.kube-system.svc",
+				},
+				k8sNamespace: "kube-system",
+			},
+			want: false,
+		},
+		{
+			args: args{
+				backend: EtcdBackendName,
+				opts: map[string]string{
+					"etcd.address":  "foo-bar.kube-system.svc",
+					"etcd.operator": "foo-bar",
+				},
+				k8sNamespace: "kube-system",
+			},
+			want: false,
+		},
+		{
+			args: args{
+				backend: EtcdBackendName,
+				opts: map[string]string{
+					"etcd.address":  "https://cilium-etcd-client.kube-system.svc",
+					"etcd.operator": "foo-bar",
+				},
+				k8sNamespace: "kube-system",
+			},
+			want: true,
+		},
+		{
+			args: args{
+				backend: EtcdBackendName,
+				opts: map[string]string{
+					"etcd.config":   etcdTempFile,
+					"etcd.operator": "foo-bar",
+				},
+				k8sNamespace: "kube-system",
+			},
+			// config file with everything setup
+			want: true,
+		},
 	}
 	for i, tt := range tests {
 		got := IsEtcdOperator(tt.args.backend, tt.args.opts, tt.args.k8sNamespace)

--- a/test/ginkgo-ext/scopes.go
+++ b/test/ginkgo-ext/scopes.go
@@ -536,3 +536,15 @@ func FailWithToggle(message string, callerSkip ...int) {
 		ginkgo.Fail(message, callerSkip...)
 	}
 }
+
+// SkipContextIf is a wrapper for the Context block which is being executed
+// if the given condition is NOT met.
+func SkipContextIf(condition func() bool, text string, body func()) bool {
+	if condition() {
+		return It(text, func() {
+			Skip("skipping due to unmet condition")
+		})
+	}
+
+	return Context(text, body)
+}

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -461,3 +461,8 @@ func failIfContainsBadLogMsg(logs string) {
 func RunsOnNetNext() bool {
 	return os.Getenv("NETNEXT") == "true"
 }
+
+// DoesNotRunOnNetNext is the inverse function of RunsOnNetNext.
+func DoesNotRunOnNetNext() bool {
+	return !RunsOnNetNext()
+}

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -254,14 +254,10 @@ var _ = Describe("K8sServicesTest", func() {
 			})
 		})
 
-		Context("Tests NodePort BPF", func() {
+		SkipContextIf(helpers.DoesNotRunOnNetNext, "Tests NodePort BPF", func() {
 			// TODO(brb) Add with L7 policy test cases after GH#8864 has been merged
 
 			nativeDev := "enp0s8"
-
-			BeforeEach(func() {
-				skipIfDoesNotRunOnNetNext()
-			})
 
 			BeforeAll(func() {
 				enableBackgroundReport = false

--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -146,14 +146,6 @@ func SkipIfFlannel() {
 	}
 }
 
-// skipIfDoesNotRunOnNetNext will skip the test if it's not running on
-// the {net,bpf}-next kernel (=ubuntu-next VM).
-func skipIfDoesNotRunOnNetNext() {
-	if !helpers.RunsOnNetNext() {
-		Skip("Test requires to be run on net-next. Skipping test.")
-	}
-}
-
 func deleteCiliumDS(kubectl *helpers.Kubectl) {
 	// Do not assert on success in AfterEach intentionally to avoid
 	// incomplete teardown.


### PR DESCRIPTION
v1.6 backports 2019-08-21

 * #8931 -- test: Add SkipContextIf helper (@brb)
 * #8855 -- Connection readiness of k8s client gets ns (@nebril)
 * #8975 -- Fix local node service connectivity issue with endpoint-routes mode (@joestringer)
 * #8969 -- cilium: encryption, if IPv6 is not supported do not throw debug warning (@jrfastab)
 * #8983 -- Fix cilium startup failure when xt_socket kernel module is not available (@joestringer)
 * #8962 -- cilium: update IsEtcdCluster to return true if etcd.operator="true" (@rajatjindal)
 * #8981 -- helm: Add global.kubeConfigPath (@brb)

Once this PR is merged, you can update the PR labels via:
```
$ for pr in 8931 8855 8975 8969 8983 8962 8981; do contrib/backporting/set-labels.py $pr done 1.6; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8993)
<!-- Reviewable:end -->
