### PR TITLE
workloads: Fix disabled status reflection in API

### DIFF
--- a/pkg/workloads/client.go
+++ b/pkg/workloads/client.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ func IsRunning(ep *endpoint.Endpoint) bool {
 // Status returns the status of the workload runtime
 func Status() *models.Status {
 	if Client() == nil {
-		return &models.Status{State: models.StatusStateDisabled}
+		return workloadStatusDisabled
 	}
 	return Client().Status()
 }

--- a/pkg/workloads/containerd.go
+++ b/pkg/workloads/containerd.go
@@ -120,7 +120,7 @@ func (c *containerDClient) IsRunning(ep *endpoint.Endpoint) bool {
 // Status returns the status of the workload runtime
 func (c *containerDClient) Status() *models.Status {
 	if c == nil {
-		return &models.Status{State: models.StatusStateDisabled}
+		return workloadStatusDisabled
 	}
 
 	criStatus := c.cri.Status()

--- a/pkg/workloads/cri.go
+++ b/pkg/workloads/cri.go
@@ -102,7 +102,7 @@ func (c *criClient) IsRunning(ep *endpoint.Endpoint) bool {
 // Status returns the status of the workload runtime
 func (c *criClient) Status() *models.Status {
 	if c == nil {
-		return &models.Status{State: models.StatusStateDisabled}
+		return workloadStatusDisabled
 	}
 
 	sreq := &criRuntime.StatusRequest{

--- a/pkg/workloads/crio.go
+++ b/pkg/workloads/crio.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
+
 package workloads
 
 import (
@@ -94,7 +94,7 @@ func (c *criOClient) IsRunning(ep *endpoint.Endpoint) bool {
 // Status returns the status of the workload runtime
 func (c *criOClient) Status() *models.Status {
 	if c == nil {
-		return &models.Status{State: models.StatusStateDisabled}
+		return workloadStatusDisabled
 	}
 
 	criStatus := c.cri.Status()

--- a/pkg/workloads/defaults.go
+++ b/pkg/workloads/defaults.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/k8s"
@@ -30,6 +31,13 @@ const (
 	// EndpointCorrelationMaxRetries is the number of retries to correlate
 	// a workload start event with an existing endpoint before giving up.
 	EndpointCorrelationMaxRetries = 20
+)
+
+var (
+	workloadStatusDisabled = &models.Status{
+		State: models.StatusStateOk,
+		Msg:   models.StatusStateDisabled,
+	}
 )
 
 // EndpointCorrelationSleepTime returns the sleep time between correlation

--- a/pkg/workloads/docker.go
+++ b/pkg/workloads/docker.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 Authors of Cilium
+// Copyright 2017-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -252,7 +252,7 @@ func (d *dockerClient) IsRunning(ep *endpoint.Endpoint) bool {
 // Status returns the status of the workload runtime
 func (d *dockerClient) Status() *models.Status {
 	if d == nil {
-		return &models.Status{State: models.StatusStateDisabled}
+		return workloadStatusDisabled
 	}
 
 	if _, err := d.Info(ctx.Background()); err != nil {


### PR DESCRIPTION
Previously in Cilium status, because the status (and not the message)
was set to disabled, the primary cilium status would complain in a way
that hints that something is wrong with the container runtime plugin:

    $ cilium status | grep -i runtime
    ContainerRuntime:       Disabled
    Cilium:                 Disabled   Container runtime is not ready

However, other status like kvstore when disabled show up like this:

    KVStore:                Ok         Disabled

This commit fixes the container runtime to follow the kvstore style,
which means that the "Cilium" status line will no longer format a
message stating that the container runtime isn't ready.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8994)
<!-- Reviewable:end -->
