### PR TITLE
helm: Allow to specify k8s api-server host and port via env vars

### DIFF
--- a/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
@@ -69,6 +69,14 @@ spec:
               key: custom-cni-conf
               name: cilium-config
               optional: true
+{{- if .Values.global.k8sServiceHost }}
+        - name: KUBERNETES_SERVICE_HOST
+          value: {{ .Values.global.k8sServiceHost | quote }}
+{{- end }}
+{{- if .Values.global.k8sServicePort }}
+        - name: KUBERNETES_SERVICE_PORT
+          value: {{ .Values.global.k8sServicePort | quote }}
+{{- end }}
 {{- if contains "/" .Values.image }}
         image: "{{ .Values.image }}"
 {{- else }}

--- a/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
@@ -107,6 +107,14 @@ spec:
               key: AWS_DEFAULT_REGION
               name: cilium-aws
               optional: true
+{{- if .Values.global.k8sServiceHost }}
+        - name: KUBERNETES_SERVICE_HOST
+          value: {{ .Values.global.k8sServiceHost | quote }}
+{{- end }}
+{{- if .Values.global.k8sServicePort }}
+        - name: KUBERNETES_SERVICE_PORT
+          value: {{ .Values.global.k8sServicePort | quote }}
+{{- end }}
 {{- if contains "/" .Values.image }}
         image: "{{ .Values.image }}"
 {{- else }}


### PR DESCRIPTION
Currently, there are three ways how k8s api-server address can be passed to cilium-{agent,operator}:

1. Default: k8s passes it to cilium-agent pod via the `KUBERNETES_SERVICE_{HOST,PORT}` env vars. Usually, it's a ClusterIP which is translated to the master node IP address via iptables rules installed by kube-proxy.
2. Via the `--k8s-kubeconfig-path` cilium-agent param. This way seems to be unecessary too complicated because the kubeconfig file has to be distributed among all cilium nodes, and cilium-agent needs only IP addr + port of the api service, as the service account credentials are already mounted into cilium-agent pod \[1\].
3. Via the `--k8s-api-server` cilium-agent param. Unfortunately, this way provides http-only access to the api-server, as `pkg/k8s/config.go` does not try to set certificate authority and token when `--k8s-api-server` is set.

This commit introduces a fourth way to pass the address to the api-server by overriding `KUBERNETES_SERVICE_{HOST,PORT}` env vars with helm. This is a temporary workaround needed for the kube-proxy-free getting started guide until the third way has been fixed.

\[1\]: https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/#accessing-the-api-from-a-pod

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8995)
<!-- Reviewable:end -->
