### PR TITLE
Fix and generalize packet terraform scripts

### DIFF
--- a/test/packet/README.md
+++ b/test/packet/README.md
@@ -1,28 +1,49 @@
-# Instructions to run CI tests in your own packet-net instances
+# Instructions to run CI tests in your own packet.net instances
 
-# 1 - download terraform https://www.terraform.io/downloads.html
-# 2 - get your API key by clicking in your user profile (top right corner)
-#     and pick "API Keys" https://app.packet.net/login
-# 3 - Create an API Key with read/write permissions and give a description,
-#     something like "CI private testing"
-# 4 - store the private token as you will need it in the next steps
-# 5 - go to the packet.net and pick or create a project ID
-# 6 - terraform init .
-# 7 - terraform apply
-# 8 - After the VM is up and running you can check its IP with `terraform show`
-# 9 - SSH in to the public IP with `ssh -i <ssh-key-path> root@<publicIP>`
-# 10 - Checkout to the branch that you want to test `git checkout <my-faulty-branch>`
-# 11 - Run `screen` which will create a new terminal, this is helpful as you can leave your terminal while
-#      tests are running and come back again afterwards.
-# 12 - Enter the `test` directory with `cd test`
-# 13 - Run the ginkgo command to initialize the tests, for example:
-#     `K8S_VERSION=1.14 ginkgo --focus="K8s*" -v -- --cilium.showCommands --cilium.holdEnvironment=true`
-# 14 - Once tests are running and if you are running `screen`, you can leave the terminal
-#      by typing `CTRL+a+d`, to resume again type `screen -r`
-#
+1. Download terraform https://www.terraform.io/downloads.html
+1. Log into [Packet.net](https://app.packet.net/login) and get your API key by
+   clicking in your user profile (top right corner) and pick "API Keys"
+   * If this is the first time, create an API Key with read/write permissions
+     and give a description, something like "CI private testing"
+   * Store the private token as you will need it in the next steps
+1. Go to the packet.net and pick or create a project ID
+   * Store the project id (from "Project Settings" page)
+   * Add your public ssh key to the project
+1. Open a terminal at this path in the Cilium repository.
+1. `terraform init .`
+1. `terraform apply`
+   * This step asks for the above token, project id, whether you want to use
+     a shared project key, and the path to the shared project key locally
+     (optional, not required if you added your public key to the project above).
+   * Confirm that you want to create the resources.
+   * After a few minutes, terraform may ask for ssh agent authentication to
+     provision the CI dependencies into the node.
+1. After the VM is up and running you can check its IP with `terraform show`
+1. SSH in to the public IP with `ssh -i <ssh-key-path> root@<publicIP>`
+1. Checkout to the branch that you want to test `git checkout <my-faulty-branch>`
+1. Run `screen` which will create a new terminal, this is helpful as you can leave your terminal while
+     tests are running and come back again afterwards.
+1. Enter the `test` directory with `cd test`
+1. Run the ginkgo command to initialize the tests, for example:
+    `K8S_VERSION=1.14 ginkgo --focus="K8s*" -v -- --cilium.showCommands --cilium.holdEnvironment=true`
+   * If you customize the `packet_plan` to `t1.small.x86`, you will need to
+     specify a smaller amount of memory, eg `MEMORY=3072`.
+1. Once tests are running and if you are running `screen`, you can leave the terminal
+     by typing `CTRL+a+d`, to resume again type `screen -r`
+
+## Configuring the terraform variables in your `~/.bashrc`
+
+```
 export TF_VAR_private_key_path="<SSH KEY PATH>"
 export TF_VAR_packet_token="<TOKEN>"
 export TF_VAR_packet_project_id="<PROJECT ID>"
 # the location for europeans is better to pick Amsterdam (ams1) or Toronto (yyz1)
 export TF_VAR_packet_location="ams1"
 export TF_VAR_packet_plan="c1.small.x86"
+```
+
+## Cleaning up afterwards
+
+```
+terraform destroy
+```

--- a/test/packet/README.md
+++ b/test/packet/README.md
@@ -24,6 +24,8 @@
 1. Run `screen` which will create a new terminal, this is helpful as you can leave your terminal while
      tests are running and come back again afterwards.
 1. Enter the `test` directory with `cd test`
+1. Consider configuring the memory for each VM lower, depending on memory available:
+   `export MEMORY=3072`
 1. Run the ginkgo command to initialize the tests, for example:
     `K8S_VERSION=1.14 ginkgo --focus="K8s*" -v -- --cilium.showCommands --cilium.holdEnvironment=true`
    * If you customize the `packet_plan` to `t1.small.x86`, you will need to

--- a/test/packet/README.md
+++ b/test/packet/README.md
@@ -1,36 +1,36 @@
 # Instructions to run CI tests in your own packet.net instances
 
 1. Download terraform https://www.terraform.io/downloads.html
-1. Log into [Packet.net](https://app.packet.net/login) and get your API key by
+2. Log into [Packet.net](https://app.packet.net/login) and get your API key by
    clicking in your user profile (top right corner) and pick "API Keys"
    * If this is the first time, create an API Key with read/write permissions
      and give a description, something like "CI private testing"
    * Store the private token as you will need it in the next steps
-1. Go to the packet.net and pick or create a project ID
+3. Go to the packet.net and pick or create a project ID
    * Store the project id (from "Project Settings" page)
    * Add your public ssh key to the project
-1. Open a terminal at this path in the Cilium repository.
-1. `terraform init .`
-1. `terraform apply`
+4. Open a terminal at this path in the Cilium repository.
+5. `terraform init .`
+6. `terraform apply`
    * This step asks for the above token, project id, whether you want to use
      a shared project key, and the path to the shared project key locally
      (optional, not required if you added your public key to the project above).
    * Confirm that you want to create the resources.
    * After a few minutes, terraform may ask for ssh agent authentication to
      provision the CI dependencies into the node.
-1. After the VM is up and running you can check its IP with `terraform show`
-1. SSH in to the public IP with `ssh -i <ssh-key-path> root@<publicIP>`
-1. Checkout to the branch that you want to test `git checkout <my-faulty-branch>`
-1. Run `screen` which will create a new terminal, this is helpful as you can leave your terminal while
+7. After the VM is up and running you can check its IP with `terraform show`
+8. SSH in to the public IP with `ssh -i <ssh-key-path> root@<publicIP>`
+9. Checkout to the branch that you want to test `git checkout <my-faulty-branch>`
+10. Run `screen` which will create a new terminal, this is helpful as you can leave your terminal while
      tests are running and come back again afterwards.
-1. Enter the `test` directory with `cd test`
-1. Consider configuring the memory for each VM lower, depending on memory available:
+11. Enter the `test` directory with `cd test`
+12. Consider configuring the memory for each VM lower, depending on memory available:
    `export MEMORY=3072`
-1. Run the ginkgo command to initialize the tests, for example:
+13. Run the ginkgo command to initialize the tests, for example:
     `K8S_VERSION=1.14 ginkgo --focus="K8s*" -v -- --cilium.showCommands --cilium.holdEnvironment=true`
    * If you customize the `packet_plan` to `t1.small.x86`, you will need to
      specify a smaller amount of memory, eg `MEMORY=3072`.
-1. Once tests are running and if you are running `screen`, you can leave the terminal
+14. Once tests are running and if you are running `screen`, you can leave the terminal
      by typing `CTRL+a+d`, to resume again type `screen -r`
 
 ## Configuring the terraform variables in your `~/.bashrc`

--- a/test/packet/main.tf
+++ b/test/packet/main.tf
@@ -1,10 +1,13 @@
 variable "private_key_path" {
+    description = "If sharing a private key for packet access, specify the path"
 }
 
 variable "packet_token" {
+    description = "Packet.net user token for authentication"
 }
 
 variable "packet_project_id" {
+    description = "Packet.net for identifying the project to deploy nodes"
 }
 
 variable "packet_plan" {
@@ -20,7 +23,7 @@ variable "nodes" {
 }
 
 provider "packet" {
-  auth_token = "${var.packet_token}"
+    auth_token = "${var.packet_token}"
 }
 
 # Create a device and add it to tf_project_1
@@ -33,23 +36,23 @@ resource "packet_device" "test" {
     billing_cycle    = "hourly"
     project_id       = "${var.packet_project_id}"
 
-	connection {
-      type = "ssh"
-      user = "root"
-      private_key = "${file("${var.private_key_path}")}"
-      agent = false
-	}
-
-    provisioner "file" {
-            source="scripts"
-            destination="/provision"
+    connection {
+        type = "ssh"
+        user = "root"
+        private_key = "${file("${var.private_key_path}")}"
+        agent = false
     }
 
-	provisioner "remote-exec" {
-		inline = [
+    provisioner "file" {
+        source="scripts"
+        destination="/provision"
+    }
+
+    provisioner "remote-exec" {
+        inline = [
             "sudo chmod 755 /provision/*.sh",
-			"sudo /provision/install.sh",
+            "sudo /provision/install.sh",
             "go get -u github.com/cilium/cilium || true"
-		]
-	}
+        ]
+    }
 }

--- a/test/packet/main.tf
+++ b/test/packet/main.tf
@@ -8,7 +8,7 @@ variable "packet_project_id" {
 }
 
 variable "packet_plan" {
-    default="baremetal_0"
+    default="t1.small.x86"
 }
 
 variable "packet_location" {

--- a/test/packet/main.tf
+++ b/test/packet/main.tf
@@ -28,7 +28,7 @@ resource "packet_device" "test" {
     count            = "${var.nodes}"
     hostname         = "test-${count.index}"
     plan             = "${var.packet_plan}"
-    facility         = "${var.packet_location}"
+    facilities       = ["${var.packet_location}"]
     operating_system = "ubuntu_18_04"
     billing_cycle    = "hourly"
     project_id       = "${var.packet_project_id}"

--- a/test/packet/main.tf
+++ b/test/packet/main.tf
@@ -42,6 +42,7 @@ resource "packet_device" "test" {
     project_id       = "${var.packet_project_id}"
 
     connection {
+        host = self.access_public_ipv4
         type = "ssh"
         user = "root"
         private_key = var.shared_key ? "${file("${var.private_key_path}")}" : ""

--- a/test/packet/main.tf
+++ b/test/packet/main.tf
@@ -2,6 +2,11 @@ variable "private_key_path" {
     description = "If sharing a private key for packet access, specify the path"
 }
 
+variable "shared_key" {
+    description = "If set to true, use a shared key"
+    type        = bool
+}
+
 variable "packet_token" {
     description = "Packet.net user token for authentication"
 }
@@ -39,8 +44,8 @@ resource "packet_device" "test" {
     connection {
         type = "ssh"
         user = "root"
-        private_key = "${file("${var.private_key_path}")}"
-        agent = false
+        private_key = var.shared_key ? "${file("${var.private_key_path}")}" : ""
+        agent = var.shared_key ? false : true
     }
 
     provisioner "file" {

--- a/test/packet/scripts/install.sh
+++ b/test/packet/scripts/install.sh
@@ -84,7 +84,7 @@ install_docker() {
 
 main() {
     install_vagrant
-    preload_vagrant
+    preload_vagrant || true
     install_packer
     configure_kernel
     install_golang

--- a/test/packet/scripts/install.sh
+++ b/test/packet/scripts/install.sh
@@ -10,68 +10,86 @@ VAGRANT_VERSION="2.2.4"
 PACKER_VERSION="1.3.5"
 VIRTUALBOX_VERSION="6.0"
 
-#repositories
+install_vagrant() {
+    echo "deb http://download.virtualbox.org/virtualbox/debian bionic contrib" > /etc/apt/sources.list.d/virtualbox.list
 
-echo "deb http://download.virtualbox.org/virtualbox/debian bionic contrib" > /etc/apt/sources.list.d/virtualbox.list
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+    sudo apt-key fingerprint 0EBFCD88
+    wget -q http://download.virtualbox.org/virtualbox/debian/oracle_vbox_2016.asc -O- | sudo apt-key add -
+    wget -q http://download.virtualbox.org/virtualbox/debian/oracle_vbox.asc -O- | sudo apt-key add -
+    sudo add-apt-repository \
+       "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+       $(lsb_release -cs) \
+       stable"
 
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-sudo apt-key fingerprint 0EBFCD88
-wget -q http://download.virtualbox.org/virtualbox/debian/oracle_vbox_2016.asc -O- | sudo apt-key add -
-wget -q http://download.virtualbox.org/virtualbox/debian/oracle_vbox.asc -O- | sudo apt-key add -
-sudo add-apt-repository \
-   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-   $(lsb_release -cs) \
-   stable"
+    sudo --preserve-env=DEBIAN_FRONTEND apt-get update
+    sudo --preserve-env=DEBIAN_FRONTEND apt-get install -y \
+        curl jq apt-transport-https htop bmon zip \
+        linux-tools-common linux-tools-generic \
+        ca-certificates software-properties-common \
+        git openjdk-8-jdk gcc make perl unzip awscli \
+        linux-headers-`uname -r` \
+        virtualbox-${VIRTUALBOX_VERSION} docker-ce
 
-sudo --preserve-env=DEBIAN_FRONTEND apt-get update
-sudo --preserve-env=DEBIAN_FRONTEND apt-get install -y \
-    curl jq apt-transport-https htop bmon zip \
-    linux-tools-common linux-tools-generic \
-    ca-certificates software-properties-common \
-    git openjdk-8-jdk gcc make perl unzip awscli \
-    linux-headers-`uname -r` \
-    virtualbox-${VIRTUALBOX_VERSION} docker-ce
+    cd /tmp/
+    wget https://releases.hashicorp.com/vagrant/${VAGRANT_VERSION}/vagrant_${VAGRANT_VERSION}_x86_64.deb
+    dpkg -i vagrant_*.deb
+}
 
-cd /tmp/
-wget https://releases.hashicorp.com/vagrant/${VAGRANT_VERSION}/vagrant_${VAGRANT_VERSION}_x86_64.deb
-dpkg -i vagrant_*.deb
+preload_vagrant() {
+    # this block will attempt to preload required vagrant boxes from the vagrant cache server
+    # (it's configuration is in vagrant-cache directory in root of this repo).
+    # vagrant cache server is a separate packet box which vagrant-cache.ci.cilium.io points to
+    cp /provision/add_vagrant_box /usr/local/bin/
+    chmod 755 /usr/local/bin/add_vagrant_box
 
-# this block will attempt to preload required vagrant boxes from the vagrant cache server
-# (it's configuration is in vagrant-cache directory in root of this repo).
-# vagrant cache server is a separate packet box which vagrant-cache.ci.cilium.io points to
-cp /provision/add_vagrant_box /usr/local/bin/
-chmod 755 /usr/local/bin/add_vagrant_box
+    curl -s https://raw.githubusercontent.com/cilium/cilium/master/vagrant_box_defaults.rb > defaults.rb
+    /usr/local/bin/add_vagrant_box defaults.rb
+}
 
-curl -s https://raw.githubusercontent.com/cilium/cilium/master/vagrant_box_defaults.rb > defaults.rb
-/usr/local/bin/add_vagrant_box defaults.rb
+install_packer() {
+    wget https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip
+    unzip packer_${PACKER_VERSION}_linux_amd64.zip
+    mv packer /usr/local/bin/
+}
 
-wget https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip
-unzip packer_${PACKER_VERSION}_linux_amd64.zip
-mv packer /usr/local/bin/
+configure_kernel() {
+    export CPU=$(($(nproc)-1))
+    for i in $(seq 0 $CPU);
+    do
+       echo performance > /sys/devices/system/cpu/cpu$i/cpufreq/scaling_governor
+    done
+}
 
-# Kernel parameters
-export CPU=$(($(nproc)-1))
-for i in $(seq 0 $CPU);
-do
-   echo performance > /sys/devices/system/cpu/cpu$i/cpufreq/scaling_governor
-done
+install_golang() {
+    cd /tmp/
+    sudo curl -Sslk -o go.tar.gz "https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-amd64.tar.gz"
+    sudo tar -C /usr/local -xzf go.tar.gz
+    sudo rm go.tar.gz
+    sudo ln -s /usr/local/go/bin/* /usr/local/bin/
+    go version
+    sudo mkdir /go/
+    export GOPATH=/go/
+    go get -u github.com/cilium/go-bindata/...
+    go get -u github.com/google/gops
+    go get -u github.com/onsi/ginkgo/ginkgo
+    go get -u github.com/onsi/gomega/...
+    sudo ln -sf /go/bin/* /usr/local/bin/
+}
 
-#Install Golang
-cd /tmp/
-sudo curl -Sslk -o go.tar.gz "https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-amd64.tar.gz"
-sudo tar -C /usr/local -xzf go.tar.gz
-sudo rm go.tar.gz
-sudo ln -s /usr/local/go/bin/* /usr/local/bin/
-go version
-sudo mkdir /go/
-export GOPATH=/go/
-go get -u github.com/cilium/go-bindata/...
-go get -u github.com/google/gops
-go get -u github.com/onsi/ginkgo/ginkgo
-go get -u github.com/onsi/gomega/...
-sudo ln -sf /go/bin/* /usr/local/bin/
+install_docker() {
+    sudo curl -L https://github.com/docker/compose/releases/download/1.24.0/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose
+    sudo chmod +x /usr/local/bin/docker-compose
+}
 
-sudo curl -L https://github.com/docker/compose/releases/download/1.24.0/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose
-sudo chmod +x /usr/local/bin/docker-compose
+main() {
+    install_vagrant
+    preload_vagrant
+    install_packer
+    configure_kernel
+    install_golang
+    install_docker
+    echo 'cd /root/go/src/github.com/cilium/cilium' >> /root/.bashrc
+}
 
-echo 'cd /root/go/src/github.com/cilium/cilium' >> /root/.bashrc
+main "$@"


### PR DESCRIPTION
Give the packet.net terraform scripts some love:
* Fix the default instance type so it can actually run 2-VM CI runs
* Fix terraform syntax errors
* Support running outside the Cilium CI instances
* Support both the previous shared keys model for provisioning, or alternatively just using the developer's SSH agent to authenticate via new `TF_VAR_shared_key` boolean
* Fix broken provision script due to missing vagrant preload script (only available on CI instances)
* Format the scripts more consistently
* Update the readme

(Validated through my own packet.net project, haven't tried with shared keys for access into CI environment)

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8996)
<!-- Reviewable:end -->
