### PR TITLE
workloads: do not set pod name and namespace via workloads plugin

### DIFF
--- a/pkg/workloads/defaults.go
+++ b/pkg/workloads/defaults.go
@@ -20,10 +20,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpointmanager"
-	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/labels"
-
-	k8sLbls "k8s.io/kubernetes/pkg/kubelet/types"
 )
 
 const (
@@ -61,12 +58,6 @@ func getFilteredLabels(containerID string, allLabels map[string]string) (identit
 
 func processCreateWorkload(ep *endpoint.Endpoint, containerID string, allLabels map[string]string) {
 	ep.SetContainerID(containerID)
-
-	// FIXME: Remove this in 2019-06: GH-6526
-	if k8s.IsEnabled() && ep.GetK8sPodName() == "" {
-		ep.SetK8sNamespace(k8sLbls.GetPodNamespace(allLabels))
-		ep.SetK8sPodName(k8sLbls.GetPodName(allLabels))
-	}
 
 	// Update map allowing to lookup endpoint by endpoint
 	// attributes with new attributes set on endpoint


### PR DESCRIPTION
We now serialize pod name / namespace and restore it during endpoint restore.
We were waiting to remove setting it in the workloads package as to not
break upgrade from versions of Cilium which did not serialize pod namespace /
name.

Fixes: #6526

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/8999)
<!-- Reviewable:end -->
