### PR TITLE
docs: Document how to specify Flannel bridge name

### DIFF
--- a/Documentation/gettingstarted/flannel-integration.rst
+++ b/Documentation/gettingstarted/flannel-integration.rst
@@ -61,6 +61,9 @@ Generate the required YAML file and deploy it:
 Set ``global.flannel.uninstallOnExit=true`` if you want Cilium to uninstall
 itself when the Cilium pod is stopped.
 
+If the Flannel bridge has a different name than ``cni0``, you must specify
+the name by setting ``global.flannel.masterDevice=...``.
+
 *Optional step:*
 If your cluster has already pods being managed by Flannel, there is also
 an option available that allows Cilium to start managing those pods without


### PR DESCRIPTION
Some user has reported that their bridge name was `flannel.1` instead of `cni0`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9003)
<!-- Reviewable:end -->
