### PR TITLE
Use sysctl library and remove redundant sysctl code

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -948,11 +948,6 @@ func setupIPSec() (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	if option.Config.EnableIPv6 {
-		if err := ipsec.EnableIPv6Forwarding(); err != nil {
-			return 0, err
-		}
-	}
 	node.SetIPsecKeyIdentity(spi)
 	if option.Config.EncryptNode == false {
 		ipsec.DeleteIPsecEncryptRoute()

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -21,10 +21,8 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -32,9 +30,9 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
 	"github.com/cilium/cilium/pkg/maps/encrypt"
-	"github.com/vishvananda/netlink"
 
 	"github.com/sirupsen/logrus"
+	"github.com/vishvananda/netlink"
 )
 
 type IPSecDir string
@@ -454,16 +452,6 @@ func loadIPSecKeys(r io.Reader) (int, uint8, error) {
 	}
 	encrypt.MapUpdateContext(0, spi)
 	return keyLen, spi, nil
-}
-
-// EnableIPv6Forwarding sets proc file to enable IPv6 forwarding
-func EnableIPv6Forwarding() error {
-	ip6ConfPath := "/proc/sys/net/ipv6/conf/"
-	device := "all"
-	forwarding := "forwarding"
-	forwardingOn := "1"
-	path := filepath.Join(ip6ConfPath, device, forwarding)
-	return ioutil.WriteFile(path, []byte(forwardingOn), 0644)
 }
 
 // DeleteIPsecEncryptRoute removes nodes in main routing table by walking

--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"path/filepath"
 	"runtime"
 	"sort"
 	"syscall"
@@ -36,6 +35,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/netns"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/sysctl"
 	"github.com/cilium/cilium/pkg/uuid"
 	"github.com/cilium/cilium/pkg/version"
 	chainingapi "github.com/cilium/cilium/plugins/cilium-cni/chaining/api"
@@ -486,9 +486,7 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 
 	var macAddrStr string
 	if err = netNs.Do(func(_ ns.NetNS) error {
-		allInterfacesPath := filepath.Join("/proc", "sys", "net", "ipv6", "conf", "all", "disable_ipv6")
-		err = connector.WriteSysConfig(allInterfacesPath, "0\n")
-		if err != nil {
+		if err := sysctl.Disable("net.ipv6.conf.all.disable_ipv6"); err != nil {
 			logger.WithError(err).Warn("unable to enable ipv6 on all interfaces")
 		}
 		macAddrStr, err = configureIface(ipam, args.IfName, &state)


### PR DESCRIPTION
This PR is a follow up to #8954. It removes redundant code which:

- writes sysctl values on its own
- enables IP forwarding despite the fact, it's already enabled globally for both IPv4 and IPv6

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9004)
<!-- Reviewable:end -->
