### PR TITLE
endpoint: do not export various fields

### DIFF
--- a/daemon/policy_test.go
+++ b/daemon/policy_test.go
@@ -125,7 +125,6 @@ func prepareEndpointDirs() (cleanup func(), err error) {
 
 func (ds *DaemonSuite) prepareEndpoint(c *C, identity *identity.Identity, qa bool) *endpoint.Endpoint {
 	e := endpoint.NewEndpointWithState(ds.d, testEndpointID, endpoint.StateWaitingForIdentity)
-	e.IfName = "dummy1"
 	if qa {
 		e.IPv6 = QAIPv6Addr
 		e.IPv4 = QAIPv4Addr

--- a/daemon/policy_test.go
+++ b/daemon/policy_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/labels"
-	"github.com/cilium/cilium/pkg/mac"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/testutils"
 
@@ -41,10 +40,8 @@ import (
 )
 
 var (
-	QAHardAddr      = mac.MAC{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}
 	QAIPv6Addr, _   = addressing.NewCiliumIPv6("beef:beef:beef:beef:aaaa:aaaa:1111:1112")
 	QAIPv4Addr, _   = addressing.NewCiliumIPv4("10.11.12.13")
-	ProdHardAddr    = mac.MAC{0x01, 0x07, 0x08, 0x09, 0x0a, 0x0b}
 	ProdIPv6Addr, _ = addressing.NewCiliumIPv6("cafe:cafe:cafe:cafe:aaaa:aaaa:1111:1112")
 	ProdIPv4Addr, _ = addressing.NewCiliumIPv4("10.11.12.14")
 
@@ -132,13 +129,9 @@ func (ds *DaemonSuite) prepareEndpoint(c *C, identity *identity.Identity, qa boo
 	if qa {
 		e.IPv6 = QAIPv6Addr
 		e.IPv4 = QAIPv4Addr
-		e.LXCMAC = QAHardAddr
-		e.SetNodeMACLocked(QAHardAddr)
 	} else {
 		e.IPv6 = ProdIPv6Addr
 		e.IPv4 = ProdIPv4Addr
-		e.LXCMAC = ProdHardAddr
-		e.SetNodeMACLocked(ProdHardAddr)
 	}
 	e.SetIdentity(identity, true)
 

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -99,7 +99,7 @@ func NewEndpointFromChangeModel(owner regeneration.Owner, base *models.EndpointC
 		if err != nil {
 			return nil, err
 		}
-		ep.NodeMAC = m
+		ep.nodeMAC = m
 	}
 
 	if base.Addressing != nil {
@@ -189,7 +189,7 @@ func (e *Endpoint) GetModelRLocked() *models.Endpoint {
 				InterfaceIndex: int64(e.ifIndex),
 				InterfaceName:  e.ifName,
 				Mac:            e.mac.String(),
-				HostMac:        e.NodeMAC.String(),
+				HostMac:        e.nodeMAC.String(),
 			},
 			ExternalIdentifiers: &models.EndpointIdentifiers{
 				ContainerID:      e.ContainerID,
@@ -484,8 +484,8 @@ func (e *Endpoint) ProcessChangeRequest(newEp *Endpoint, validPatchTransitionSta
 		changed = true
 	}
 
-	if len(newEp.NodeMAC) != 0 && bytes.Compare(e.GetNodeMAC(), newEp.NodeMAC) != 0 {
-		e.SetNodeMACLocked(newEp.NodeMAC)
+	if len(newEp.nodeMAC) != 0 && bytes.Compare(e.GetNodeMAC(), newEp.nodeMAC) != 0 {
+		e.SetNodeMACLocked(newEp.nodeMAC)
 		changed = true
 	}
 

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -74,7 +74,7 @@ func NewEndpointFromChangeModel(owner regeneration.Owner, base *models.EndpointC
 		ifName:           base.InterfaceName,
 		K8sPodName:       base.K8sPodName,
 		K8sNamespace:     base.K8sNamespace,
-		DatapathMapID:    int(base.DatapathMapID),
+		datapathMapID:    int(base.DatapathMapID),
 		ifIndex:          int(base.InterfaceIndex),
 		OpLabels:         labels.NewOpLabels(),
 		DNSHistory:       fqdn.NewDNSCacheWithLimit(option.Config.ToFQDNsMinTTL, option.Config.ToFQDNsMaxIPsPerHost),

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -71,7 +71,7 @@ func NewEndpointFromChangeModel(owner regeneration.Owner, base *models.EndpointC
 		ContainerID:      base.ContainerID,
 		DockerNetworkID:  base.DockerNetworkID,
 		DockerEndpointID: base.DockerEndpointID,
-		IfName:           base.InterfaceName,
+		ifName:           base.InterfaceName,
 		K8sPodName:       base.K8sPodName,
 		K8sNamespace:     base.K8sNamespace,
 		DatapathMapID:    int(base.DatapathMapID),
@@ -187,7 +187,7 @@ func (e *Endpoint) GetModelRLocked() *models.Endpoint {
 					IPV6: e.IPv6.String(),
 				}},
 				InterfaceIndex: int64(e.IfIndex),
-				InterfaceName:  e.IfName,
+				InterfaceName:  e.ifName,
 				Mac:            e.LXCMAC.String(),
 				HostMac:        e.NodeMAC.String(),
 			},
@@ -460,8 +460,8 @@ func (e *Endpoint) ProcessChangeRequest(newEp *Endpoint, validPatchTransitionSta
 		changed = true
 	}
 
-	if newEp.IfName != "" && e.IfName != newEp.IfName {
-		e.IfName = newEp.IfName
+	if newEp.ifName != "" && e.ifName != newEp.ifName {
+		e.ifName = newEp.ifName
 		changed = true
 	}
 

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -75,7 +75,7 @@ func NewEndpointFromChangeModel(owner regeneration.Owner, base *models.EndpointC
 		K8sPodName:       base.K8sPodName,
 		K8sNamespace:     base.K8sNamespace,
 		DatapathMapID:    int(base.DatapathMapID),
-		IfIndex:          int(base.InterfaceIndex),
+		ifIndex:          int(base.InterfaceIndex),
 		OpLabels:         labels.NewOpLabels(),
 		DNSHistory:       fqdn.NewDNSCacheWithLimit(option.Config.ToFQDNsMinTTL, option.Config.ToFQDNsMaxIPsPerHost),
 		state:            "",
@@ -186,7 +186,7 @@ func (e *Endpoint) GetModelRLocked() *models.Endpoint {
 					IPV4: e.IPv4.String(),
 					IPV6: e.IPv6.String(),
 				}},
-				InterfaceIndex: int64(e.IfIndex),
+				InterfaceIndex: int64(e.ifIndex),
 				InterfaceName:  e.ifName,
 				Mac:            e.LXCMAC.String(),
 				HostMac:        e.NodeMAC.String(),
@@ -455,8 +455,8 @@ func (e *Endpoint) ProcessChangeRequest(newEp *Endpoint, validPatchTransitionSta
 	}
 	defer e.Unlock()
 
-	if newEp.IfIndex != 0 && e.IfIndex != newEp.IfIndex {
-		e.IfIndex = newEp.IfIndex
+	if newEp.ifIndex != 0 && e.ifIndex != newEp.ifIndex {
+		e.ifIndex = newEp.ifIndex
 		changed = true
 	}
 

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -91,7 +91,7 @@ func NewEndpointFromChangeModel(owner regeneration.Owner, base *models.EndpointC
 		if err != nil {
 			return nil, err
 		}
-		ep.LXCMAC = m
+		ep.mac = m
 	}
 
 	if base.HostMac != "" {
@@ -188,7 +188,7 @@ func (e *Endpoint) GetModelRLocked() *models.Endpoint {
 				}},
 				InterfaceIndex: int64(e.ifIndex),
 				InterfaceName:  e.ifName,
-				Mac:            e.LXCMAC.String(),
+				Mac:            e.mac.String(),
 				HostMac:        e.NodeMAC.String(),
 			},
 			ExternalIdentifiers: &models.EndpointIdentifiers{
@@ -479,8 +479,8 @@ func (e *Endpoint) ProcessChangeRequest(newEp *Endpoint, validPatchTransitionSta
 		}
 	}
 
-	if len(newEp.LXCMAC) != 0 && bytes.Compare(e.LXCMAC, newEp.LXCMAC) != 0 {
-		e.LXCMAC = newEp.LXCMAC
+	if len(newEp.mac) != 0 && bytes.Compare(e.mac, newEp.mac) != 0 {
+		e.mac = newEp.mac
 		changed = true
 	}
 

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -110,7 +110,7 @@ func (e *Endpoint) writeInformationalComments(w io.Writer) error {
 		" */\n\n",
 		e.IPv6.String(), e.IPv4.String(),
 		e.GetIdentity(), bpf.LocalMapName(policymap.MapName, e.ID),
-		e.NodeMAC)
+		e.nodeMAC)
 
 	fw.WriteString("/*\n")
 	fw.WriteString(" * Labels:\n")

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1159,8 +1159,14 @@ func (e *Endpoint) ValidateConnectorPlumbing(linkChecker linkCheckerFunc) error 
 		if _, err := os.Stat(e.BPFIpvlanMapPath()); err != nil {
 			return fmt.Errorf("tail call map for IPvlan unavailable: %s", err)
 		}
-	} else if err := linkChecker(e.ifName); err != nil {
-		return fmt.Errorf("interface %s could not be found", e.ifName)
+	} else {
+		if linkChecker == nil {
+			return fmt.Errorf("cannot check state of datapath; link checker is nil")
+		}
+		err := linkChecker(e.ifName)
+		if err != nil {
+			return fmt.Errorf("interface %s could not be found", e.ifName)
+		}
 	}
 	return nil
 }

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -799,7 +799,7 @@ func (e *Endpoint) DeleteMapsLocked() []error {
 // veth interface.
 func (e *Endpoint) DeleteBPFProgramLocked() error {
 	e.getLogger().Debug("deleting bpf program from endpoint")
-	return loader.DeleteDatapath(context.TODO(), e.IfName, "ingress")
+	return loader.DeleteDatapath(context.TODO(), e.ifName, "ingress")
 }
 
 // garbageCollectConntrack will run the ctmap.GC() on either the endpoint's
@@ -1159,8 +1159,8 @@ func (e *Endpoint) ValidateConnectorPlumbing(linkChecker linkCheckerFunc) error 
 		if _, err := os.Stat(e.BPFIpvlanMapPath()); err != nil {
 			return fmt.Errorf("tail call map for IPvlan unavailable: %s", err)
 		}
-	} else if err := linkChecker(e.IfName); err != nil {
-		return fmt.Errorf("interface %s could not be found", e.IfName)
+	} else if err := linkChecker(e.ifName); err != nil {
+		return fmt.Errorf("interface %s could not be found", e.ifName)
 	}
 	return nil
 }

--- a/pkg/endpoint/cache.go
+++ b/pkg/endpoint/cache.go
@@ -88,7 +88,7 @@ func (e *Endpoint) createEpInfoCache(epdir string) *epInfoCache {
 		cidr6PrefixLengths:    cidr6,
 		options:               e.Options.DeepCopy(),
 		lxcMAC:                e.LXCMAC,
-		ifIndex:               e.IfIndex,
+		ifIndex:               e.ifIndex,
 
 		endpoint: e,
 	}

--- a/pkg/endpoint/cache.go
+++ b/pkg/endpoint/cache.go
@@ -73,7 +73,7 @@ func (e *Endpoint) createEpInfoCache(epdir string) *epInfoCache {
 
 		epdir:                 epdir,
 		id:                    e.GetID(),
-		ifName:                e.IfName,
+		ifName:                e.ifName,
 		ipvlan:                e.HasIpvlanDataPath(),
 		identity:              e.GetIdentity(),
 		mac:                   e.GetNodeMAC(),

--- a/pkg/endpoint/cache.go
+++ b/pkg/endpoint/cache.go
@@ -87,7 +87,7 @@ func (e *Endpoint) createEpInfoCache(epdir string) *epInfoCache {
 		cidr4PrefixLengths:    cidr4,
 		cidr6PrefixLengths:    cidr6,
 		options:               e.Options.DeepCopy(),
-		lxcMAC:                e.LXCMAC,
+		lxcMAC:                e.mac,
 		ifIndex:               e.ifIndex,
 
 		endpoint: e,

--- a/pkg/endpoint/connector/veth.go
+++ b/pkg/endpoint/connector/veth.go
@@ -41,7 +41,7 @@ func SetupVethRemoteNs(netNs ns.NetNS, srcIfName, dstIfName string) (int, int, e
 }
 
 // SetupVeth sets up the net interface, the temporary interface and fills up some endpoint
-// fields such as LXCMAC, NodeMac, ifIndex and ifName. Returns a pointer for the created
+// fields such as mac, NodeMac, ifIndex and ifName. Returns a pointer for the created
 // veth, a pointer for the temporary link, the name of the temporary link and error if
 // something fails.
 func SetupVeth(id string, mtu int, ep *models.EndpointChangeRequest) (*netlink.Veth, *netlink.Link, string, error) {
@@ -57,7 +57,7 @@ func SetupVeth(id string, mtu int, ep *models.EndpointChangeRequest) (*netlink.V
 }
 
 // SetupVethWithNames sets up the net interface, the temporary interface and fills up some endpoint
-// fields such as LXCMAC, NodeMac, ifIndex and ifName. Returns a pointer for the created
+// fields such as mac, NodeMac, ifIndex and ifName. Returns a pointer for the created
 // veth, a pointer for the temporary link, the name of the temporary link and error if
 // something fails.
 func SetupVethWithNames(lxcIfName, tmpIfName string, mtu int, ep *models.EndpointChangeRequest) (*netlink.Veth, *netlink.Link, error) {

--- a/pkg/endpoint/connector/veth.go
+++ b/pkg/endpoint/connector/veth.go
@@ -41,7 +41,7 @@ func SetupVethRemoteNs(netNs ns.NetNS, srcIfName, dstIfName string) (int, int, e
 }
 
 // SetupVeth sets up the net interface, the temporary interface and fills up some endpoint
-// fields such as LXCMAC, NodeMac, IfIndex and IfName. Returns a pointer for the created
+// fields such as LXCMAC, NodeMac, IfIndex and ifName. Returns a pointer for the created
 // veth, a pointer for the temporary link, the name of the temporary link and error if
 // something fails.
 func SetupVeth(id string, mtu int, ep *models.EndpointChangeRequest) (*netlink.Veth, *netlink.Link, string, error) {
@@ -57,7 +57,7 @@ func SetupVeth(id string, mtu int, ep *models.EndpointChangeRequest) (*netlink.V
 }
 
 // SetupVethWithNames sets up the net interface, the temporary interface and fills up some endpoint
-// fields such as LXCMAC, NodeMac, IfIndex and IfName. Returns a pointer for the created
+// fields such as LXCMAC, NodeMac, IfIndex and ifName. Returns a pointer for the created
 // veth, a pointer for the temporary link, the name of the temporary link and error if
 // something fails.
 func SetupVethWithNames(lxcIfName, tmpIfName string, mtu int, ep *models.EndpointChangeRequest) (*netlink.Veth, *netlink.Link, error) {

--- a/pkg/endpoint/connector/veth.go
+++ b/pkg/endpoint/connector/veth.go
@@ -41,7 +41,7 @@ func SetupVethRemoteNs(netNs ns.NetNS, srcIfName, dstIfName string) (int, int, e
 }
 
 // SetupVeth sets up the net interface, the temporary interface and fills up some endpoint
-// fields such as LXCMAC, NodeMac, IfIndex and ifName. Returns a pointer for the created
+// fields such as LXCMAC, NodeMac, ifIndex and ifName. Returns a pointer for the created
 // veth, a pointer for the temporary link, the name of the temporary link and error if
 // something fails.
 func SetupVeth(id string, mtu int, ep *models.EndpointChangeRequest) (*netlink.Veth, *netlink.Link, string, error) {
@@ -57,7 +57,7 @@ func SetupVeth(id string, mtu int, ep *models.EndpointChangeRequest) (*netlink.V
 }
 
 // SetupVethWithNames sets up the net interface, the temporary interface and fills up some endpoint
-// fields such as LXCMAC, NodeMac, IfIndex and ifName. Returns a pointer for the created
+// fields such as LXCMAC, NodeMac, ifIndex and ifName. Returns a pointer for the created
 // veth, a pointer for the temporary link, the name of the temporary link and error if
 // something fails.
 func SetupVethWithNames(lxcIfName, tmpIfName string, mtu int, ep *models.EndpointChangeRequest) (*netlink.Veth, *netlink.Link, error) {

--- a/pkg/endpoint/connector/veth.go
+++ b/pkg/endpoint/connector/veth.go
@@ -141,3 +141,9 @@ func SetupVethWithNames(lxcIfName, tmpIfName string, mtu int, ep *models.Endpoin
 
 	return veth, &peer, nil
 }
+
+// CheckLink returns an error if a link with linkName does not exist.
+func CheckLink(linkName string) error {
+	_, err := netlink.LinkByName(linkName)
+	return err
+}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1028,6 +1028,13 @@ func (e *Endpoint) RegenerateWait(reason string) error {
 	return nil
 }
 
+// GetContainerName returns the name of the container for the endpoint.
+func (e *Endpoint) GetContainerName() string {
+	e.UnconditionalRLock()
+	defer e.RUnlock()
+	return e.ContainerName
+}
+
 // SetContainerName modifies the endpoint's container name
 func (e *Endpoint) SetContainerName(name string) {
 	e.UnconditionalLock()

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -138,9 +138,9 @@ type Endpoint struct {
 	// isDatapathMapPinned denotes whether the datapath map has been pinned.
 	isDatapathMapPinned bool
 
-	// IfName is the name of the host facing interface (veth pair) which
+	// ifName is the name of the host facing interface (veth pair) which
 	// connects into the endpoint
-	IfName string
+	ifName string
 
 	// IfIndex is the interface index of the host face interface (veth pair)
 	IfIndex int

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -164,8 +164,8 @@ type Endpoint struct {
 	// IPv4 is the IPv4 address of the endpoint
 	IPv4 addressing.CiliumIPv4
 
-	// NodeMAC is the MAC of the node (agent). The MAC is different for every endpoint.
-	NodeMAC mac.MAC
+	// nodeMAC is the MAC of the node (agent). The MAC is different for every endpoint.
+	nodeMAC mac.MAC
 
 	// SecurityIdentity is the security identity of this endpoint. This is computed from
 	// the endpoint's labels.
@@ -519,12 +519,12 @@ func (e *Endpoint) IPv6Address() addressing.CiliumIPv6 {
 
 // GetNodeMAC returns the MAC address of the node from this endpoint's perspective.
 func (e *Endpoint) GetNodeMAC() mac.MAC {
-	return e.NodeMAC
+	return e.nodeMAC
 }
 
 // SetNodeMACLocked updates the node MAC inside the endpoint.
 func (e *Endpoint) SetNodeMACLocked(m mac.MAC) {
-	e.NodeMAC = m
+	e.nodeMAC = m
 }
 
 func (e *Endpoint) HasSidecarProxy() bool {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -142,8 +142,8 @@ type Endpoint struct {
 	// connects into the endpoint
 	ifName string
 
-	// IfIndex is the interface index of the host face interface (veth pair)
-	IfIndex int
+	// ifIndex is the interface index of the host face interface (veth pair)
+	ifIndex int
 
 	// OpLabels is the endpoint's label configuration
 	//
@@ -296,9 +296,9 @@ func (e *Endpoint) UpdateController(name string, params controller.ControllerPar
 	e.controllers.UpdateController(name, params)
 }
 
-// GetIfIndex returns the IfIndex for this endpoint.
+// GetIfIndex returns the ifIndex for this endpoint.
 func (e *Endpoint) GetIfIndex() int {
-	return e.IfIndex
+	return e.ifIndex
 }
 
 // LXCMac returns the LXCMac for this endpoint.

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -133,7 +133,7 @@ type Endpoint struct {
 	DockerEndpointID string
 
 	// Corresponding BPF map identifier for tail call map of ipvlan datapath
-	DatapathMapID int
+	datapathMapID int
 
 	// isDatapathMapPinned denotes whether the datapath map has been pinned.
 	isDatapathMapPinned bool
@@ -330,7 +330,7 @@ func (e *Endpoint) HasBPFProgram() bool {
 
 // HasIpvlanDataPath returns whether the daemon is running in ipvlan mode.
 func (e *Endpoint) HasIpvlanDataPath() bool {
-	if e.DatapathMapID > 0 {
+	if e.datapathMapID > 0 {
 		return true
 	}
 	return false
@@ -1168,7 +1168,7 @@ func (e *Endpoint) GetDockerNetworkID() string {
 
 // SetDatapathMapIDAndPinMapLocked modifies the endpoint's datapath map ID
 func (e *Endpoint) SetDatapathMapIDAndPinMapLocked(id int) error {
-	e.DatapathMapID = id
+	e.datapathMapID = id
 	return e.PinDatapathMap()
 }
 
@@ -1864,11 +1864,11 @@ func (e *Endpoint) IsDisconnecting() bool {
 // PinDatapathMap retrieves a file descriptor from the map ID from the API call
 // and pins the corresponding map into the BPF file system.
 func (e *Endpoint) PinDatapathMap() error {
-	if e.DatapathMapID == 0 {
+	if e.datapathMapID == 0 {
 		return nil
 	}
 
-	mapFd, err := bpf.MapFdFromID(e.DatapathMapID)
+	mapFd, err := bpf.MapFdFromID(e.datapathMapID)
 	if err != nil {
 		return err
 	}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -154,10 +154,9 @@ type Endpoint struct {
 	// information of the endpoint has changed
 	identityRevision int
 
-	// LXCMAC is the MAC address of the endpoint
+	// mac is the MAC address of the endpoint
 	//
-	// FIXME: Rename this field to MAC
-	LXCMAC mac.MAC // Container MAC address.
+	mac mac.MAC // Container MAC address.
 
 	// IPv6 is the IPv6 address of the endpoint
 	IPv6 addressing.CiliumIPv6
@@ -303,7 +302,7 @@ func (e *Endpoint) GetIfIndex() int {
 
 // LXCMac returns the LXCMac for this endpoint.
 func (e *Endpoint) LXCMac() mac.MAC {
-	return e.LXCMAC
+	return e.mac
 }
 
 // CloseBPFProgramChannel closes the channel that signals whether the endpoint

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -250,7 +250,7 @@ func (e *Endpoint) toSerializedEndpoint() *serializableEndpoint {
 		LXCMAC:                e.mac,
 		IPv6:                  e.IPv6,
 		IPv4:                  e.IPv4,
-		NodeMAC:               e.NodeMAC,
+		NodeMAC:               e.nodeMAC,
 		SecurityIdentity:      e.SecurityIdentity,
 		Options:               e.Options,
 		DNSHistory:            e.DNSHistory,
@@ -316,7 +316,7 @@ type serializableEndpoint struct {
 	// IPv4 is the IPv4 address of the endpoint
 	IPv4 addressing.CiliumIPv4
 
-	// NodeMAC is the MAC of the node (agent). The MAC is different for every endpoint.
+	// nodeMAC is the MAC of the node (agent). The MAC is different for every endpoint.
 	NodeMAC mac.MAC
 
 	// SecurityIdentity is the security identity of this endpoint. This is computed from
@@ -378,7 +378,7 @@ func (ep *Endpoint) fromSerializedEndpoint(r *serializableEndpoint) {
 	ep.mac = r.LXCMAC
 	ep.IPv6 = r.IPv6
 	ep.IPv4 = r.IPv4
-	ep.NodeMAC = r.NodeMAC
+	ep.nodeMAC = r.NodeMAC
 	ep.SecurityIdentity = r.SecurityIdentity
 	ep.DNSHistory = r.DNSHistory
 	ep.K8sPodName = r.K8sPodName

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -243,7 +243,7 @@ func (e *Endpoint) toSerializedEndpoint() *serializableEndpoint {
 		ContainerID:           e.ContainerID,
 		DockerNetworkID:       e.DockerNetworkID,
 		DockerEndpointID:      e.DockerEndpointID,
-		DatapathMapID:         e.DatapathMapID,
+		DatapathMapID:         e.datapathMapID,
 		IfName:                e.ifName,
 		IfIndex:               e.ifIndex,
 		OpLabels:              e.OpLabels,
@@ -371,7 +371,7 @@ func (ep *Endpoint) fromSerializedEndpoint(r *serializableEndpoint) {
 	ep.ContainerID = r.ContainerID
 	ep.DockerNetworkID = r.DockerNetworkID
 	ep.DockerEndpointID = r.DockerEndpointID
-	ep.DatapathMapID = r.DatapathMapID
+	ep.datapathMapID = r.DatapathMapID
 	ep.ifName = r.IfName
 	ep.ifIndex = r.IfIndex
 	ep.OpLabels = r.OpLabels

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -247,7 +247,7 @@ func (e *Endpoint) toSerializedEndpoint() *serializableEndpoint {
 		IfName:                e.ifName,
 		IfIndex:               e.ifIndex,
 		OpLabels:              e.OpLabels,
-		LXCMAC:                e.LXCMAC,
+		LXCMAC:                e.mac,
 		IPv6:                  e.IPv6,
 		IPv4:                  e.IPv4,
 		NodeMAC:               e.NodeMAC,
@@ -305,7 +305,7 @@ type serializableEndpoint struct {
 	// FIXME: Rename this field to Labels
 	OpLabels labels.OpLabels
 
-	// LXCMAC is the MAC address of the endpoint
+	// mac is the MAC address of the endpoint
 	//
 	// FIXME: Rename this field to MAC
 	LXCMAC mac.MAC // Container MAC address.
@@ -375,7 +375,7 @@ func (ep *Endpoint) fromSerializedEndpoint(r *serializableEndpoint) {
 	ep.ifName = r.IfName
 	ep.ifIndex = r.IfIndex
 	ep.OpLabels = r.OpLabels
-	ep.LXCMAC = r.LXCMAC
+	ep.mac = r.LXCMAC
 	ep.IPv6 = r.IPv6
 	ep.IPv4 = r.IPv4
 	ep.NodeMAC = r.NodeMAC

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -245,7 +245,7 @@ func (e *Endpoint) toSerializedEndpoint() *serializableEndpoint {
 		DockerEndpointID:      e.DockerEndpointID,
 		DatapathMapID:         e.DatapathMapID,
 		IfName:                e.ifName,
-		IfIndex:               e.IfIndex,
+		IfIndex:               e.ifIndex,
 		OpLabels:              e.OpLabels,
 		LXCMAC:                e.LXCMAC,
 		IPv6:                  e.IPv6,
@@ -297,7 +297,7 @@ type serializableEndpoint struct {
 	// connects into the endpoint
 	IfName string
 
-	// IfIndex is the interface index of the host face interface (veth pair)
+	// ifIndex is the interface index of the host face interface (veth pair)
 	IfIndex int
 
 	// OpLabels is the endpoint's label configuration
@@ -373,7 +373,7 @@ func (ep *Endpoint) fromSerializedEndpoint(r *serializableEndpoint) {
 	ep.DockerEndpointID = r.DockerEndpointID
 	ep.DatapathMapID = r.DatapathMapID
 	ep.ifName = r.IfName
-	ep.IfIndex = r.IfIndex
+	ep.ifIndex = r.IfIndex
 	ep.OpLabels = r.OpLabels
 	ep.LXCMAC = r.LXCMAC
 	ep.IPv6 = r.IPv6

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -244,7 +244,7 @@ func (e *Endpoint) toSerializedEndpoint() *serializableEndpoint {
 		DockerNetworkID:       e.DockerNetworkID,
 		DockerEndpointID:      e.DockerEndpointID,
 		DatapathMapID:         e.DatapathMapID,
-		IfName:                e.IfName,
+		IfName:                e.ifName,
 		IfIndex:               e.IfIndex,
 		OpLabels:              e.OpLabels,
 		LXCMAC:                e.LXCMAC,
@@ -293,7 +293,7 @@ type serializableEndpoint struct {
 	// Corresponding BPF map identifier for tail call map of ipvlan datapath
 	DatapathMapID int
 
-	// IfName is the name of the host facing interface (veth pair) which
+	// ifName is the name of the host facing interface (veth pair) which
 	// connects into the endpoint
 	IfName string
 
@@ -372,7 +372,7 @@ func (ep *Endpoint) fromSerializedEndpoint(r *serializableEndpoint) {
 	ep.DockerNetworkID = r.DockerNetworkID
 	ep.DockerEndpointID = r.DockerEndpointID
 	ep.DatapathMapID = r.DatapathMapID
-	ep.IfName = r.IfName
+	ep.ifName = r.IfName
 	ep.IfIndex = r.IfIndex
 	ep.OpLabels = r.OpLabels
 	ep.LXCMAC = r.LXCMAC

--- a/pkg/endpoint/restore_test.go
+++ b/pkg/endpoint/restore_test.go
@@ -76,7 +76,7 @@ func (ds *EndpointSuite) endpointCreator(id uint16, secID identity.NumericIdenti
 	ep.DockerNetworkID = "603e047d2268a57f5a5f93f7f9e1263e9207e348a06654bf64948def001" + strID
 	ep.DockerEndpointID = "93529fda8c401a071d21d6bd46fdf5499b9014dcb5a35f2e3efaa8d8002" + strID
 	ep.ifName = "lxc" + strID
-	ep.LXCMAC = mac.MAC([]byte{0x01, 0xff, 0xf2, 0x12, b[0], b[1]})
+	ep.mac = mac.MAC([]byte{0x01, 0xff, 0xf2, 0x12, b[0], b[1]})
 	ep.IPv4 = addressing.DeriveCiliumIPv4(net.IP{0xc0, 0xa8, b[0], b[1]})
 	ep.IPv6 = addressing.DeriveCiliumIPv6(net.IP{0xbe, 0xef, 0xbe, 0xef, 0xbe, 0xef, 0xbe, 0xef, 0xaa, 0xaa, 0xaa, 0xaa, 0x00, 0x00, b[0], b[1]})
 	ep.ifIndex = 1

--- a/pkg/endpoint/restore_test.go
+++ b/pkg/endpoint/restore_test.go
@@ -79,7 +79,7 @@ func (ds *EndpointSuite) endpointCreator(id uint16, secID identity.NumericIdenti
 	ep.LXCMAC = mac.MAC([]byte{0x01, 0xff, 0xf2, 0x12, b[0], b[1]})
 	ep.IPv4 = addressing.DeriveCiliumIPv4(net.IP{0xc0, 0xa8, b[0], b[1]})
 	ep.IPv6 = addressing.DeriveCiliumIPv6(net.IP{0xbe, 0xef, 0xbe, 0xef, 0xbe, 0xef, 0xbe, 0xef, 0xaa, 0xaa, 0xaa, 0xaa, 0x00, 0x00, b[0], b[1]})
-	ep.IfIndex = 1
+	ep.ifIndex = 1
 	ep.SetNodeMACLocked(mac.MAC([]byte{0x02, 0xff, 0xf2, 0x12, 0x0, 0x0}))
 	ep.SecurityIdentity = identity
 	ep.OpLabels = labels.NewOpLabels()

--- a/pkg/endpoint/restore_test.go
+++ b/pkg/endpoint/restore_test.go
@@ -75,7 +75,7 @@ func (ds *EndpointSuite) endpointCreator(id uint16, secID identity.NumericIdenti
 	// Random network ID and docker endpoint ID with 59 hex chars + 5 strID = 64 hex chars
 	ep.DockerNetworkID = "603e047d2268a57f5a5f93f7f9e1263e9207e348a06654bf64948def001" + strID
 	ep.DockerEndpointID = "93529fda8c401a071d21d6bd46fdf5499b9014dcb5a35f2e3efaa8d8002" + strID
-	ep.IfName = "lxc" + strID
+	ep.ifName = "lxc" + strID
 	ep.LXCMAC = mac.MAC([]byte{0x01, 0xff, 0xf2, 0x12, b[0], b[1]})
 	ep.IPv4 = addressing.DeriveCiliumIPv4(net.IP{0xc0, 0xa8, b[0], b[1]})
 	ep.IPv6 = addressing.DeriveCiliumIPv6(net.IP{0xbe, 0xef, 0xbe, 0xef, 0xbe, 0xef, 0xbe, 0xef, 0xaa, 0xaa, 0xaa, 0xaa, 0x00, 0x00, b[0], b[1]})

--- a/pkg/endpoint/restore_test.go
+++ b/pkg/endpoint/restore_test.go
@@ -132,7 +132,7 @@ func (ds *EndpointSuite) TestReadEPsFromDirNames(c *C) {
 			if ep.ID == 256 {
 				// Change endpoint a little bit so we know which endpoint is in
 				// "256_next_fail" and with one is in the "256" directory.
-				ep.NodeMAC = []byte{0x02, 0xff, 0xf2, 0x12, 0xc1, 0xc1}
+				ep.nodeMAC = []byte{0x02, 0xff, 0xf2, 0x12, 0xc1, 0xc1}
 				err = ep.writeHeaderfile(failedDir)
 				c.Assert(err, IsNil)
 				epsNames = append(epsNames, ep.DirectoryPath())

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -235,7 +235,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 		{
 			name: "endpoint by container name",
 			preTestRun: func() {
-				ep.ContainerName = "foo"
+				ep.SetContainerName("foo")
 				mgr.Insert(ep)
 			},
 			setupArgs: func() args {
@@ -252,7 +252,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep.ContainerName = ""
+				ep.SetContainerName("")
 			},
 		},
 		{
@@ -699,7 +699,7 @@ func (s *EndpointManagerSuite) TestUpdateReferences(c *C) {
 		ep = mgr.LookupIPv4(want.ep.IPv4.String())
 		c.Assert(ep, checker.DeepEquals, want.ep, Commentf("Test Name: %s", tt.name))
 
-		ep = mgr.lookupDockerContainerName(want.ep.ContainerName)
+		ep = mgr.lookupDockerContainerName(want.ep.GetContainerName())
 		c.Assert(ep, checker.DeepEquals, want.ep, Commentf("Test Name: %s", tt.name))
 
 		want.ep.UnconditionalRLock()


### PR DESCRIPTION
Now that the Endpoint itself is not serialized into its headerfile (it is converted to a type now, `serializedEndpoint`), we can do some refactors on its internal structure without worrying about breaking backwards compatibility for restoring during upgrade / downgrade.

The following fields are now not exported from `Endpoint`:
* IfName
* DatapathMapID
* IfIndex
* LXCMAC
* NodeMAC

Also use setters / getters for various fields to reduce direct access to them, as these fields will eventually be made private as well. 

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9012)
<!-- Reviewable:end -->
