### PR TITLE
test: Use global.tag in helm command line

### DIFF
--- a/test/kubernetes-test.sh
+++ b/test/kubernetes-test.sh
@@ -3,10 +3,9 @@
 helm template install/kubernetes/cilium \
   --namespace=kube-system \
   --set global.registry=k8s1:5000/cilium \
+  --set global.tag=latest \
   --set agent.image=cilium-dev \
-  --set agent.tag=latest \
   --set operator.image=operator \
-  --set operator.tag=latest \
   --set global.debug.enabled=true \
   --set global.k8s.requireIPv4PodCIDR=true \
   --set global.pprof.enabled=true \


### PR DESCRIPTION
test-upstream-k8s was failing on release branch (v1.6) due to the
global.tag defaulting to v1.6.0. Use 'global.tag' instead of
'agent.tag' and 'operator.tag' to use the 'latest' tag in the test.

The changed script is only used for the upstream k8s test, so it should suffice to run `test-upstream-k8s`.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9013)
<!-- Reviewable:end -->
