### PR TITLE
Allow DNS policy on ports other than 53

### DIFF
--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -990,11 +990,6 @@ DNS Proxy (preferred)
   DNS requests. It allows L3 connections to ``cilium.io``, ``sub.cilium.io``
   and any subdomains of ``sub.cilium.io``.
 
-.. note:: The port number 53 shown in the examples is currently the
-          only supported port number on which DNS requests can be
-          proxied. This is the standard DNS port number, so it should
-          work for most uses.
-
 .. only:: html
 
    .. tabs::

--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -349,11 +349,6 @@ func (pr *L7Rules) sanitize(ports []PortProtocol) error {
 		if len(ports) == 0 {
 			return fmt.Errorf("Port 53 must be specified for DNS rules")
 		}
-		for _, port := range ports {
-			if port.Port != "53" {
-				return fmt.Errorf("DNS rules are only allowed on port 53")
-			}
-		}
 
 		nTypes++
 		for i := range pr.DNS {

--- a/pkg/policy/api/rule_validation_test.go
+++ b/pkg/policy/api/rule_validation_test.go
@@ -55,30 +55,7 @@ func (s *PolicyAPITestSuite) TestL7RulesWithNonTCPProtocols(c *C) {
 	err := validPortRule.Sanitize()
 	c.Assert(err, IsNil)
 
-	// Rule is invalid because port is not 53 for DNS proxy rule.
-	validPortRule = Rule{
-		EndpointSelector: WildcardEndpointSelector,
-		Egress: []EgressRule{
-			{
-				ToEndpoints: []EndpointSelector{WildcardEndpointSelector},
-				ToPorts: []PortRule{{
-					Ports: []PortProtocol{
-						{Port: "80", Protocol: ProtoTCP},
-					},
-					Rules: &L7Rules{
-						DNS: []PortRuleDNS{
-							{MatchName: "domain.com"},
-						},
-					},
-				}},
-			},
-		},
-	}
-
-	err = validPortRule.Sanitize()
-	c.Assert(err, Not(IsNil), Commentf("Port 80 should not be allowed for DNS"))
-
-	// Rule is invalid because port is not 53 for DNS proxy rule.
+	// Rule is invalid because no port is specified for DNS proxy rule.
 	validPortRule = Rule{
 		EndpointSelector: WildcardEndpointSelector,
 		Egress: []EgressRule{


### PR DESCRIPTION
Loosen the restriction that previously forced DNS policy to apply on port 53.

I manually tested this with coredns configured on port 8053 and confirmed that traffic flowed through the proxy as expected and FQDN policy could be plumbed with a DNS instance on a non-standard port.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9014)
<!-- Reviewable:end -->
