### PR TITLE
endpoint: move deletion into Endpoint package, remove acquisition of Endpoint locks in EndpointManager

### DIFF
--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -23,14 +23,12 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/api/v1/server/restapi/endpoint"
 	"github.com/cilium/cilium/pkg/api"
-	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/endpoint"
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/maps/lxcmap"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/workloads"
@@ -466,6 +464,15 @@ func (d *Daemon) deleteEndpoint(ep *endpoint.Endpoint) int {
 	return len(errs)
 }
 
+// NotifyMonitorDeleted notifies the monitor that an endpoint has been deleted.
+func (d *Daemon) NotifyMonitorDeleted(ep *endpoint.Endpoint) {
+	repr, err := monitorAPI.EndpointDeleteRepr(ep)
+	// Ignore endpoint deletion if EndpointDeleteRepr != nil
+	if err == nil {
+		d.SendNotification(monitorAPI.AgentNotifyEndpointDeleted, repr)
+	}
+}
+
 // deleteEndpointQuiet sets the endpoint into disconnecting state and removes
 // it from Cilium, releasing all resources associated with it such as its
 // visibility in the endpointmanager, its BPF programs and maps, (optional) IP,
@@ -483,92 +490,7 @@ func (d *Daemon) deleteEndpointQuiet(ep *endpoint.Endpoint, conf endpoint.Delete
 		}
 	}
 
-	errs := []error{}
-
-	// Since the endpoint is being deleted, we no longer need to run events
-	// in its event queue. This is a no-op if the queue has already been
-	// closed elsewhere.
-	ep.EventQueue.Stop()
-
-	// Wait for the queue to be drained in case an event which is currently
-	// running for the endpoint tries to acquire the lock - we cannot be sure
-	// what types of events will be pushed onto the EventQueue for an endpoint
-	// and when they will happen. After this point, no events for the endpoint
-	// will be processed on its EventQueue, specifically regenerations.
-	ep.EventQueue.WaitToBeDrained()
-
-	// Given that we are deleting the endpoint and that no more builds are
-	// going to occur for this endpoint, close the channel which signals whether
-	// the endpoint has its BPF program compiled or not to avoid it persisting
-	// if anything is blocking on it. If a delete request has already been
-	// enqueued for this endpoint, this is a no-op.
-	ep.CloseBPFProgramChannel()
-
-	// Lock out any other writers to the endpoint.  In case multiple delete
-	// requests have been enqueued, have all of them except the first
-	// return here. Ignore the request if the endpoint is already
-	// disconnected. We don't need to acquire the BuildMutex for the Endpoint
-	// here because no more builds (regenerations) can be performed for this
-	// Endpoint because its EventQueue has been closed.
-	if err := ep.LockAlive(); err != nil {
-		return []error{}
-	}
-	ep.SetStateLocked(endpoint.StateDisconnecting, "Deleting endpoint")
-
-	// Remove the endpoint before we clean up. This ensures it is no longer
-	// listed or queued for rebuilds.
-	d.endpointManager.Remove(ep)
-
-	defer func() {
-		repr, err := monitorAPI.EndpointDeleteRepr(ep)
-		// Ignore endpoint deletion if EndpointDeleteRepr != nil
-		if err == nil {
-			d.SendNotification(monitorAPI.AgentNotifyEndpointDeleted, repr)
-		}
-	}()
-
-	// If dry mode is enabled, no changes to BPF maps are performed
-	if !option.Config.DryMode {
-		if errs2 := lxcmap.DeleteElement(ep); errs2 != nil {
-			errs = append(errs, errs2...)
-		}
-
-		if errs2 := ep.DeleteMapsLocked(); errs2 != nil {
-			errs = append(errs, errs2...)
-		}
-	}
-
-	if !conf.NoIPRelease {
-		if option.Config.EnableIPv4 {
-			if err := d.ipam.ReleaseIP(ep.IPv4.IP()); err != nil {
-				errs = append(errs, fmt.Errorf("unable to release ipv4 address: %s", err))
-			}
-		}
-		if option.Config.EnableIPv6 {
-			if err := d.ipam.ReleaseIP(ep.IPv6.IP()); err != nil {
-				errs = append(errs, fmt.Errorf("unable to release ipv6 address: %s", err))
-			}
-		}
-	}
-
-	completionCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	proxyWaitGroup := completion.NewWaitGroup(completionCtx)
-
-	errs = append(errs, ep.LeaveLocked(proxyWaitGroup, conf)...)
-	ep.Unlock()
-
-	err := ep.WaitForProxyCompletions(proxyWaitGroup)
-	if err != nil {
-		errs = append(errs, fmt.Errorf("unable to remove proxy redirects: %s", err))
-	}
-	cancel()
-
-	if option.Config.IsFlannelMasterDeviceSet() &&
-		option.Config.FlannelUninstallOnExit {
-		ep.DeleteBPFProgramLocked()
-	}
-
-	return errs
+	return ep.Delete(d, d.ipam, d.endpointManager, conf)
 }
 
 func (d *Daemon) DeleteEndpoint(id string) (int, error) {

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -548,11 +548,9 @@ func (d *Daemon) EndpointUpdate(id string, cfg *models.EndpointConfigurationSpec
 			return api.Error(PatchEndpointIDConfigFailedCode, err)
 		}
 	}
-	if err := ep.RLockAlive(); err != nil {
+	if err := ep.UpdateReferences(d.endpointManager); err != nil {
 		return api.Error(PatchEndpointIDNotFoundCode, err)
 	}
-	d.endpointManager.UpdateReferences(ep)
-	ep.RUnlock()
 
 	return nil
 }

--- a/daemon/policy_test.go
+++ b/daemon/policy_test.go
@@ -538,13 +538,17 @@ func (ds *DaemonSuite) TestRemovePolicy(c *C) {
 	c.Assert(qaBarNetworkPolicy, Not(IsNil))
 
 	// Delete the endpoint.
-	e.UnconditionalLock()
-	e.LeaveLocked(nil, endpoint.DeleteConfig{})
-	e.Unlock()
+	e.Delete(ds.d, ds.d.ipam, &dummyManager{}, endpoint.DeleteConfig{})
 
 	// Check that the policy has been removed from the xDS cache.
 	networkPolicies = ds.getXDSNetworkPolicies(c, nil)
 	c.Assert(networkPolicies, HasLen, 0)
+}
+
+type dummyManager struct{}
+
+func (d *dummyManager) Remove(ep *endpoint.Endpoint) <-chan struct{} {
+	return nil
 }
 
 func (ds *DaemonSuite) TestIncrementalPolicy(c *C) {
@@ -640,9 +644,7 @@ func (ds *DaemonSuite) TestIncrementalPolicy(c *C) {
 	c.Assert(qaBarNetworkPolicy.IngressPerPortPolicies[0].Rules[0].RemotePolicies[0], Equals, uint64(qaFooID.ID))
 
 	// Delete the endpoint.
-	e.UnconditionalLock()
-	e.LeaveLocked(nil, endpoint.DeleteConfig{})
-	e.Unlock()
+	e.Delete(ds.d, ds.d.ipam, &dummyManager{}, endpoint.DeleteConfig{})
 
 	// Check that the policy has been removed from the xDS cache.
 	networkPolicies = ds.getXDSNetworkPolicies(c, nil)

--- a/daemon/policy_test.go
+++ b/daemon/policy_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cilium/cilium/common/addressing"
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
@@ -547,8 +548,26 @@ func (ds *DaemonSuite) TestRemovePolicy(c *C) {
 
 type dummyManager struct{}
 
-func (d *dummyManager) Remove(ep *endpoint.Endpoint) <-chan struct{} {
-	return nil
+func (d *dummyManager) AllocateID(id uint16) (uint16, error) {
+	return uint16(1), nil
+}
+
+func (d *dummyManager) RunK8sCiliumEndpointSync(*endpoint.Endpoint) {
+}
+
+func (d *dummyManager) UpdateReferences(map[id.PrefixType]string, *endpoint.Endpoint) {
+}
+
+func (d *dummyManager) UpdateIDReference(*endpoint.Endpoint) {
+}
+
+func (d *dummyManager) RemoveReferences(map[id.PrefixType]string) {
+}
+
+func (d *dummyManager) RemoveID(uint16) {
+}
+
+func (d *dummyManager) ReleaseID(*endpoint.Endpoint) {
 }
 
 func (ds *DaemonSuite) TestIncrementalPolicy(c *C) {

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -236,7 +236,7 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) (resto
 		// upon returning that endpoints are exposed to other subsystems via
 		// endpointmanager.
 
-		if err := d.endpointManager.Insert(ep); err != nil {
+		if err := ep.Expose(d.endpointManager); err != nil {
 			log.WithError(err).Warning("Unable to restore endpoint")
 			// remove endpoint from slice of endpoints to restore
 			state.restored = append(state.restored[:i], state.restored[i+1:]...)

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -55,8 +55,8 @@ func (e *Endpoint) policyMapPath() string {
 	return bpf.LocalMapPath(policymap.MapName, e.ID)
 }
 
-// CallsMapPathLocked returns the path to cilium tail calls map of an endpoint.
-func (e *Endpoint) CallsMapPathLocked() string {
+// callsMapPath returns the path to cilium tail calls map of an endpoint.
+func (e *Endpoint) callsMapPath() string {
 	return e.owner.Datapath().Loader().CallsMapPath(e.ID)
 }
 
@@ -764,7 +764,7 @@ func (e *Endpoint) deleteMapsLocked() []error {
 	maps := map[string]string{
 		"config": e.BPFConfigMapPath(),
 		"policy": e.policyMapPath(),
-		"calls":  e.CallsMapPathLocked(),
+		"calls":  e.callsMapPath(),
 		"egress": e.BPFIpvlanMapPath(),
 	}
 	for name, path := range maps {

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -426,7 +426,7 @@ func (e *Endpoint) regenerateBPF(regenContext *regenerationContext) (revnum uint
 
 	// Signal that BPF program has been generated.
 	// The endpoint has at least L3/L4 connectivity at this point.
-	e.CloseBPFProgramChannel()
+	e.closeBPFProgramChannel()
 
 	// Allow another builder to start while we wait for the proxy
 	if regenContext.DoneFunc != nil {

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -751,14 +751,14 @@ func (e *Endpoint) finalizeProxyState(regenContext *regenerationContext, err err
 	}
 }
 
-// DeleteMapsLocked releases references to all BPF maps associated with this
+// deleteMapsLocked releases references to all BPF maps associated with this
 // endpoint.
 //
 // For each error that occurs while releasing these references, an error is
 // added to the resulting error slice which is returned.
 //
 // Returns nil on success.
-func (e *Endpoint) DeleteMapsLocked() []error {
+func (e *Endpoint) deleteMapsLocked() []error {
 	var errors []error
 
 	maps := map[string]string{

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -60,8 +60,8 @@ func (e *Endpoint) callsMapPath() string {
 	return e.owner.Datapath().Loader().CallsMapPath(e.ID)
 }
 
-// BPFConfigMapPath returns the path to the BPF config map of endpoint.
-func (e *Endpoint) BPFConfigMapPath() string {
+// bpfConfigMapPath returns the path to the BPF config map of endpoint.
+func (e *Endpoint) bpfConfigMapPath() string {
 	return bpf.LocalMapPath(bpfconfig.MapNamePrefix, e.ID)
 }
 
@@ -600,7 +600,7 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (pr
 	}
 
 	if e.bpfConfigMap == nil {
-		e.bpfConfigMap, _, err = bpfconfig.OpenMapWithName(e.BPFConfigMapPath())
+		e.bpfConfigMap, _, err = bpfconfig.OpenMapWithName(e.bpfConfigMapPath())
 		if err != nil {
 			return err
 		}
@@ -762,7 +762,7 @@ func (e *Endpoint) deleteMapsLocked() []error {
 	var errors []error
 
 	maps := map[string]string{
-		"config": e.BPFConfigMapPath(),
+		"config": e.bpfConfigMapPath(),
 		"policy": e.policyMapPath(),
 		"calls":  e.callsMapPath(),
 		"egress": e.BPFIpvlanMapPath(),

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -50,8 +50,8 @@ const (
 	EndpointGenerationTimeout = 330 * time.Second
 )
 
-// PolicyMapPathLocked returns the path to the policy map of endpoint.
-func (e *Endpoint) PolicyMapPathLocked() string {
+// policyMapPath returns the path to the policy map of endpoint.
+func (e *Endpoint) policyMapPath() string {
 	return bpf.LocalMapPath(policymap.MapName, e.ID)
 }
 
@@ -583,7 +583,7 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (pr
 	}
 
 	if e.policyMap == nil {
-		e.policyMap, _, err = policymap.OpenOrCreate(e.PolicyMapPathLocked())
+		e.policyMap, _, err = policymap.OpenOrCreate(e.policyMapPath())
 		if err != nil {
 			return err
 		}
@@ -763,7 +763,7 @@ func (e *Endpoint) deleteMapsLocked() []error {
 
 	maps := map[string]string{
 		"config": e.BPFConfigMapPath(),
-		"policy": e.PolicyMapPathLocked(),
+		"policy": e.policyMapPath(),
 		"calls":  e.CallsMapPathLocked(),
 		"egress": e.BPFIpvlanMapPath(),
 	}
@@ -1055,7 +1055,7 @@ func (e *Endpoint) syncPolicyMapWithDump() error {
 			e.getLogger().WithError(err).Error("unable to close PolicyMap which was not able to be dumped")
 		}
 
-		e.policyMap, _, err = policymap.OpenOrCreate(e.PolicyMapPathLocked())
+		e.policyMap, _, err = policymap.OpenOrCreate(e.policyMapPath())
 		if err != nil {
 			return fmt.Errorf("unable to open PolicyMap for endpoint: %s", err)
 		}

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -751,14 +751,14 @@ func (e *Endpoint) finalizeProxyState(regenContext *regenerationContext, err err
 	}
 }
 
-// deleteMapsLocked releases references to all BPF maps associated with this
+// deleteMaps releases references to all BPF maps associated with this
 // endpoint.
 //
 // For each error that occurs while releasing these references, an error is
 // added to the resulting error slice which is returned.
 //
 // Returns nil on success.
-func (e *Endpoint) deleteMapsLocked() []error {
+func (e *Endpoint) deleteMaps() []error {
 	var errors []error
 
 	maps := map[string]string{

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -305,10 +305,10 @@ func (e *Endpoint) LXCMac() mac.MAC {
 	return e.mac
 }
 
-// CloseBPFProgramChannel closes the channel that signals whether the endpoint
+// closeBPFProgramChannel closes the channel that signals whether the endpoint
 // has had its BPF program compiled. If the channel is already closed, this is
 // a no-op.
-func (e *Endpoint) CloseBPFProgramChannel() {
+func (e *Endpoint) closeBPFProgramChannel() {
 	select {
 	case <-e.hasBPFProgram:
 	default:
@@ -1965,7 +1965,7 @@ func (e *Endpoint) Delete(monitor monitorOwner, ipam ipReleaser, manager Endpoin
 	// the endpoint has its BPF program compiled or not to avoid it persisting
 	// if anything is blocking on it. If a delete request has already been
 	// enqueued for this endpoint, this is a no-op.
-	e.CloseBPFProgramChannel()
+	e.closeBPFProgramChannel()
 
 	// Lock out any other writers to the endpoint.  In case multiple delete
 	// requests have been enqueued, have all of them except the first

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -977,7 +977,7 @@ func (e *Endpoint) LeaveLocked(proxyWaitGroup *completion.WaitGroup, conf Delete
 
 	if e.bpfConfigMap != nil {
 		if err := e.bpfConfigMap.Close(); err != nil {
-			errors = append(errors, fmt.Errorf("unable to close configmap %s: %s", e.BPFConfigMapPath(), err))
+			errors = append(errors, fmt.Errorf("unable to close configmap %s: %s", e.bpfConfigMapPath(), err))
 		}
 	}
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -946,14 +946,14 @@ type DeleteConfig struct {
 	NoIdentityRelease bool
 }
 
-// LeaveLocked removes the endpoint's directory from the system. Must be called
+// leaveLocked removes the endpoint's directory from the system. Must be called
 // with Endpoint's mutex AND buildMutex locked.
 //
-// Note: LeaveLocked() is called indirectly from endpoint restore logic for
-// endpoints which failed to be restored. Any cleanup routine of LeaveLocked()
+// Note: leaveLocked() is called indirectly from endpoint restore logic for
+// endpoints which failed to be restored. Any cleanup routine of leaveLocked()
 // which depends on kvstore connectivity must be protected by a flag in
 // DeleteConfig and the restore logic must opt-out of it.
-func (e *Endpoint) LeaveLocked(proxyWaitGroup *completion.WaitGroup, conf DeleteConfig) []error {
+func (e *Endpoint) leaveLocked(proxyWaitGroup *completion.WaitGroup, conf DeleteConfig) []error {
 	errors := []error{}
 
 	if !option.Config.DryMode {
@@ -2011,7 +2011,7 @@ func (e *Endpoint) Delete(monitor monitorOwner, ipam ipReleaser, manager Endpoin
 	completionCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	proxyWaitGroup := completion.NewWaitGroup(completionCtx)
 
-	errs = append(errs, e.LeaveLocked(proxyWaitGroup, conf)...)
+	errs = append(errs, e.leaveLocked(proxyWaitGroup, conf)...)
 	e.Unlock()
 
 	err := e.WaitForProxyCompletions(proxyWaitGroup)

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1990,7 +1990,7 @@ func (e *Endpoint) Delete(monitor monitorOwner, ipam ipReleaser, manager Endpoin
 			errs = append(errs, errs2...)
 		}
 
-		if errs2 := e.DeleteMapsLocked(); errs2 != nil {
+		if errs2 := e.deleteMapsLocked(); errs2 != nil {
 			errs = append(errs, errs2...)
 		}
 	}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1990,7 +1990,7 @@ func (e *Endpoint) Delete(monitor monitorOwner, ipam ipReleaser, manager Endpoin
 			errs = append(errs, errs2...)
 		}
 
-		if errs2 := e.deleteMapsLocked(); errs2 != nil {
+		if errs2 := e.deleteMaps(); errs2 != nil {
 			errs = append(errs, errs2...)
 		}
 	}

--- a/pkg/endpoint/manager.go
+++ b/pkg/endpoint/manager.go
@@ -1,0 +1,143 @@
+// Copyright 2016-2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endpoint
+
+import (
+	"fmt"
+
+	"github.com/cilium/cilium/pkg/endpoint/id"
+	"github.com/cilium/cilium/pkg/eventqueue"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+type endpointManager interface {
+	AllocateID(id uint16) (uint16, error)
+	RunK8sCiliumEndpointSync(*Endpoint)
+	UpdateReferences(map[id.PrefixType]string, *Endpoint)
+	UpdateIDReference(*Endpoint)
+	RemoveReferences(map[id.PrefixType]string)
+	RemoveID(uint16)
+	ReleaseID(*Endpoint)
+}
+
+// Expose exposes the endpoint to the endpointmanager. After this function
+// is called, the endpoint may be accessed by any lookup in the endpointmanager.
+func (e *Endpoint) Expose(mgr endpointManager) error {
+	newID, err := mgr.AllocateID(e.ID)
+	if err != nil {
+		return err
+	}
+
+	e.ID = newID
+	e.UpdateLogger(map[string]interface{}{
+		logfields.EndpointID: e.ID,
+	})
+
+	// Now that the endpoint has its ID, it can be created with a name based on
+	// its ID, and its eventqueue can be safely started. Ensure that it is only
+	// started once it is exposed to the endpointmanager so that it will be
+	// stopped when the endpoint is removed from the endpointmanager.
+	e.EventQueue = eventqueue.NewEventQueueBuffered(fmt.Sprintf("endpoint-%d", e.ID), option.Config.EndpointQueueSize)
+	e.EventQueue.Run()
+
+	// No need to check liveness as an endpoint can only be deleted via the
+	// API after it has been inserted into the manager.
+	e.UnconditionalRLock()
+	mgr.UpdateIDReference(e)
+	e.updateReferences(mgr)
+	e.RUnlock()
+
+	e.InsertEvent()
+
+	mgr.RunK8sCiliumEndpointSync(e)
+	return nil
+}
+
+// UpdateReferences updates the endpointmanager mappings of identifiers to
+// endpoints for the given endpoint. Returns an error if the endpoint is
+// being deleted.
+func (e *Endpoint) UpdateReferences(mgr endpointManager) error {
+	if err := e.RLockAlive(); err != nil {
+		return err
+	}
+	defer e.RUnlock()
+	e.updateReferences(mgr)
+	return nil
+}
+
+func (e *Endpoint) updateReferences(mgr endpointManager) {
+	refs := e.generateReferences()
+	mgr.UpdateReferences(refs, e)
+}
+
+func (e *Endpoint) generateReferences() map[id.PrefixType]string {
+	refs := make(map[id.PrefixType]string, 6)
+	if e.ContainerID != "" {
+		refs[id.ContainerIdPrefix] = e.ContainerID
+	}
+
+	if e.DockerEndpointID != "" {
+		refs[id.DockerEndpointPrefix] = e.DockerEndpointID
+	}
+
+	if e.IPv4.IsSet() {
+		refs[id.IPv4Prefix] = e.IPv4.String()
+	}
+
+	if e.IPv6.IsSet() {
+		refs[id.IPv6Prefix] = e.IPv6.String()
+	}
+
+	if e.ContainerName != "" {
+		refs[id.ContainerNamePrefix] = e.ContainerName
+	}
+
+	if podName := e.GetK8sNamespaceAndPodNameLocked(); podName != "" {
+		refs[id.PodNamePrefix] = podName
+	}
+	return refs
+}
+
+func (e *Endpoint) removeReferences(mgr endpointManager) {
+	refs := e.generateReferences()
+	mgr.RemoveReferences(refs)
+}
+
+// Unexpose removes the endpoint from being globally acccessible via other
+// packages.
+func (e *Endpoint) Unexpose(mgr endpointManager) <-chan struct{} {
+	epRemoved := make(chan struct{})
+
+	// This must be done before the ID is released for the endpoint!
+	mgr.RemoveID(e.ID)
+
+	go func(ep *Endpoint) {
+
+		// The endpoint's EventQueue may not be stopped yet (depending on whether
+		// the caller of the EventQueue has stopped it or not). Call it here
+		// to be safe so that ep.WaitToBeDrained() does not hang forever.
+		ep.EventQueue.Stop()
+
+		// Wait for no more events (primarily regenerations) to be occurring for
+		// this endpoint.
+		ep.EventQueue.WaitToBeDrained()
+
+		mgr.ReleaseID(ep)
+		close(epRemoved)
+	}(e)
+	e.removeReferences(mgr)
+	return epRemoved
+}

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -145,7 +145,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 			name: "endpoint by cilium local ID",
 			preTestRun: func() {
 				ep.ID = 1234
-				mgr.Insert(ep)
+				ep.Expose(mgr)
 			},
 			setupArgs: func() args {
 				return args{
@@ -168,7 +168,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 			name: "endpoint by cilium global ID",
 			preTestRun: func() {
 				ep.ID = 1234
-				mgr.Insert(ep)
+				ep.Expose(mgr)
 			},
 			setupArgs: func() args {
 				return args{
@@ -190,7 +190,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 			name: "endpoint by container ID",
 			preTestRun: func() {
 				ep.ContainerID = "1234"
-				mgr.Insert(ep)
+				ep.Expose(mgr)
 			},
 			setupArgs: func() args {
 				return args{
@@ -213,7 +213,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 			name: "endpoint by docker endpoint ID",
 			preTestRun: func() {
 				ep.DockerEndpointID = "1234"
-				mgr.Insert(ep)
+				ep.Expose(mgr)
 			},
 			setupArgs: func() args {
 				return args{
@@ -236,7 +236,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 			name: "endpoint by container name",
 			preTestRun: func() {
 				ep.SetContainerName("foo")
-				mgr.Insert(ep)
+				ep.Expose(mgr)
 			},
 			setupArgs: func() args {
 				return args{
@@ -260,7 +260,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 			preTestRun: func() {
 				ep.SetK8sNamespace("default")
 				ep.SetK8sPodName("foo")
-				mgr.Insert(ep)
+				ep.Expose(mgr)
 			},
 			setupArgs: func() args {
 				return args{
@@ -285,7 +285,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 				ipv4, err := addressing.NewCiliumIPv4("127.0.0.1")
 				ep.IPv4 = ipv4
 				c.Assert(err, IsNil)
-				mgr.Insert(ep)
+				ep.Expose(mgr)
 			},
 			setupArgs: func() args {
 				return args{
@@ -375,7 +375,7 @@ func (s *EndpointManagerSuite) TestLookupCiliumID(c *C) {
 			name: "existing cilium ID",
 			preTestRun: func() {
 				ep.ID = 1
-				mgr.Insert(ep)
+				ep.Expose(mgr)
 			},
 			setupArgs: func() args {
 				return args{
@@ -445,7 +445,7 @@ func (s *EndpointManagerSuite) TestLookupContainerID(c *C) {
 			name: "existing container ID",
 			preTestRun: func() {
 				ep.SetContainerID("foo")
-				mgr.Insert(ep)
+				ep.Expose(mgr)
 			},
 			setupArgs: func() args {
 				return args{
@@ -515,7 +515,7 @@ func (s *EndpointManagerSuite) TestLookupIPv4(c *C) {
 				ip, err := addressing.NewCiliumIPv4("127.0.0.1")
 				c.Assert(err, IsNil)
 				ep.IPv4 = ip
-				mgr.Insert(ep)
+				ep.Expose(mgr)
 			},
 			setupArgs: func() args {
 				return args{
@@ -584,7 +584,7 @@ func (s *EndpointManagerSuite) TestLookupPodName(c *C) {
 			preTestRun: func() {
 				ep.SetK8sNamespace("default")
 				ep.SetK8sPodName("foo")
-				mgr.Insert(ep)
+				ep.Expose(mgr)
 			},
 			setupArgs: func() args {
 				return args{
@@ -652,7 +652,7 @@ func (s *EndpointManagerSuite) TestUpdateReferences(c *C) {
 			name: "Updating all references",
 			preTestRun: func() {
 				ep.ID = 1
-				mgr.Insert(ep)
+				ep.Expose(mgr)
 			},
 			setupArgs: func() args {
 				// Update endpoint before running test
@@ -688,7 +688,7 @@ func (s *EndpointManagerSuite) TestUpdateReferences(c *C) {
 		tt.preTestRun()
 		args := tt.setupArgs()
 		want := tt.setupWant()
-		mgr.UpdateReferences(args.ep)
+		args.ep.UpdateReferences(mgr)
 
 		ep = mgr.LookupContainerID(want.ep.GetContainerID())
 		c.Assert(ep, checker.DeepEquals, want.ep, Commentf("Test Name: %s", tt.name))
@@ -729,7 +729,7 @@ func (s *EndpointManagerSuite) TestRemove(c *C) {
 			name: "Updating all references",
 			preTestRun: func() {
 				ep.ID = 1
-				mgr.Insert(ep)
+				ep.Expose(mgr)
 			},
 			setupArgs: func() args {
 				return args{}
@@ -773,7 +773,7 @@ func (s *EndpointManagerSuite) TestHasGlobalCT(c *C) {
 			preTestRun: func() {
 				ep.ID = 1
 				ep.Options = option.NewIntOptions(&endpoint.EndpointMutableOptionLibrary)
-				mgr.Insert(ep)
+				ep.Expose(mgr)
 			},
 			setupWant: func() want {
 				return want{
@@ -792,7 +792,7 @@ func (s *EndpointManagerSuite) TestHasGlobalCT(c *C) {
 				ep.ID = 1
 				ep.Options = option.NewIntOptions(&endpoint.EndpointMutableOptionLibrary)
 				ep.Options.SetIfUnset(option.ConntrackLocal, option.OptionEnabled)
-				mgr.Insert(ep)
+				ep.Expose(mgr)
 			},
 			setupWant: func() want {
 				return want{
@@ -840,7 +840,7 @@ func (s *EndpointManagerSuite) TestWaitForEndpointsAtPolicyRev(c *C) {
 			preTestRun: func() {
 				ep.ID = 1
 				ep.SetPolicyRevision(5)
-				mgr.Insert(ep)
+				ep.Expose(mgr)
 			},
 			setupArgs: func() args {
 				return args{
@@ -864,7 +864,7 @@ func (s *EndpointManagerSuite) TestWaitForEndpointsAtPolicyRev(c *C) {
 			preTestRun: func() {
 				ep.ID = 1
 				ep.SetPolicyRevision(5)
-				mgr.Insert(ep)
+				ep.Expose(mgr)
 			},
 			setupArgs: func() args {
 				ctx, cancel := context.WithTimeout(context.Background(), 0)
@@ -890,7 +890,7 @@ func (s *EndpointManagerSuite) TestWaitForEndpointsAtPolicyRev(c *C) {
 			preTestRun: func() {
 				ep.ID = 1
 				ep.SetPolicyRevision(4)
-				mgr.Insert(ep)
+				ep.Expose(mgr)
 			},
 			setupArgs: func() args {
 				ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)

--- a/pkg/proxy/kafka_test.go
+++ b/pkg/proxy/kafka_test.go
@@ -279,8 +279,8 @@ func (s *proxyTestSuite) TestKafkaRedirect(c *C) {
 	c.Assert(err, IsNil)
 	ep.IPv4 = ipv4
 	ep.UpdateLogger(nil)
-	epMgr.Insert(ep)
-	defer epMgr.Remove(ep)
+	ep.Expose(epMgr)
+	defer ep.Unexpose(epMgr)
 
 	_, dstPortStr, err := net.SplitHostPort(server.Address())
 	c.Assert(err, IsNil)

--- a/pkg/workloads/defaults.go
+++ b/pkg/workloads/defaults.go
@@ -69,7 +69,7 @@ func processCreateWorkload(ep *endpoint.Endpoint, containerID string, allLabels 
 
 	// Update map allowing to lookup endpoint by endpoint
 	// attributes with new attributes set on endpoint
-	epMgr.UpdateReferences(ep)
+	ep.UpdateReferences(epMgr)
 
 	identityLabels, informationLabels := getFilteredLabels(containerID, allLabels)
 	ep.UpdateLabels(context.Background(), identityLabels, informationLabels, false)


### PR DESCRIPTION
Now that `pkg/endpointmanager` has a type `EndpointManager`, we can pass instances of it to functions in `pkg/endpoint` which would otherwise have import loops if they imported `pkg/endpointmanager` directly. The `EndpointManager` from the `Daemon` is passed into a new function which acts on `Endpoint`, `Delete`. This function encapsulates all of the logic needed to clean up resources associated with an `Endpoint` into the `Endpoint` package. As a result, a lot of functions are no longer exported from `pkg/endpoint`, improving encapsulation. 

The latter part of this PR reworks the interactions between `Endpoint` and `EndpointManager`. The order of locking is important between `Endpoint` and `EndpointManager`. The `Endpoint` must have its mutex acquired before accessing the `EndpointManager`, as its fields are accessed / modified depending on the operation performed. If locking was done in the opposite order, one `Endpoint` mutex being held would block out all operations on the` EndpointManager`, which is not desirable, since it is accessed frequently. Previously, `EndpointManager` functions themselves had to lock the `Endpoint`. Leaking the locking internals of an `Endpoint`, though, means that callers have to ensure that access to `Endpoint` is performed correctly, which leaks implementation. In order to maintain the same locking ordering as before, reverse the receiver / parameter w.r.t. insertion and deletion of `Endpoint` from the `EndpointManager`. Now, an `Endpoint` acquires its mutex before performing an operation on an `EndpointManager` instead of the `EndpointManager` having to be aware of the mutex of the `Endpoint`. As a result, exposure of `Endpoint` identifiers, like `ContainerID`, `DockerEndpointID`, etc., is dramatically reduced.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9025)
<!-- Reviewable:end -->
