### PR TITLE
k8s: Use api.WildcardEndpointSelector, remove the endpoint label reserved:all

### DIFF
--- a/pkg/k8s/network_policy.go
+++ b/pkg/k8s/network_policy.go
@@ -160,11 +160,8 @@ func ParseNetworkPolicy(np *networkingv1.NetworkPolicy) (api.Rules, error) {
 			//   From []NetworkPolicyPeer
 			//   If this field is empty or missing, this rule matches all
 			//   sources (traffic not restricted by source).
-			all := api.NewESFromLabels(
-				labels.NewLabel(labels.IDNameAll, "", labels.LabelSourceReserved),
-			)
 			ingress := api.IngressRule{}
-			ingress.FromEndpoints = append(ingress.FromEndpoints, all)
+			ingress.FromEndpoints = append(ingress.FromEndpoints, api.WildcardEndpointSelector)
 
 			fromRules = append(fromRules, ingress)
 		}
@@ -206,11 +203,8 @@ func ParseNetworkPolicy(np *networkingv1.NetworkPolicy) (api.Rules, error) {
 			//   To []NetworkPolicyPeer
 			//   If this field is empty or missing, this rule matches all
 			//   destinations (traffic not restricted by destination)
-			all := api.NewESFromLabels(
-				labels.NewLabel(labels.IDNameAll, "", labels.LabelSourceReserved),
-			)
 			egress := api.EgressRule{}
-			egress.ToEndpoints = append(egress.ToEndpoints, all)
+			egress.ToEndpoints = append(egress.ToEndpoints, api.WildcardEndpointSelector)
 
 			toRules = append(toRules, egress)
 		}

--- a/pkg/labels/array.go
+++ b/pkg/labels/array.go
@@ -96,7 +96,7 @@ func (ls LabelArray) Contains(needed LabelArray) bool {
 nextLabel:
 	for i := range needed {
 		for l := range ls {
-			if needed[i].Matches(&ls[l]) {
+			if needed[i].matches(&ls[l]) {
 				continue nextLabel
 			}
 		}
@@ -113,7 +113,7 @@ func (ls LabelArray) Lacks(needed LabelArray) LabelArray {
 nextLabel:
 	for i := range needed {
 		for l := range ls {
-			if needed[i].Matches(&ls[l]) {
+			if needed[i].matches(&ls[l]) {
 				continue nextLabel
 			}
 		}

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -219,7 +219,7 @@ func NewLabel(key string, value string, source string) Label {
 	}
 }
 
-// Equals returns true if source, AbsoluteKey() and Value are equal and false otherwise.
+// Equals returns true if source, Key and Value are equal and false otherwise.
 func (l *Label) Equals(b *Label) bool {
 	if !l.IsAnySource() && l.Source != b.Source {
 		return false
@@ -242,8 +242,8 @@ func (l *Label) IsReservedSource() bool {
 	return l.Source == LabelSourceReserved
 }
 
-// Matches returns true if l matches the target
-func (l *Label) Matches(target *Label) bool {
+// matches returns true if l matches the target
+func (l *Label) matches(target *Label) bool {
 	return l.IsAllLabel() || l.Equals(target)
 }
 

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -28,9 +28,6 @@ const (
 	// PathDelimiter is the delimiter used in the labels paths.
 	PathDelimiter = "."
 
-	// IDNameAll is a special label which matches all labels.
-	IDNameAll = "all"
-
 	// IDNameHost is the label used for the hostname ID.
 	IDNameHost = "host"
 
@@ -227,11 +224,6 @@ func (l *Label) Equals(b *Label) bool {
 	return l.Key == b.Key && l.Value == b.Value
 }
 
-// IsAllLabel returns true if the label is reserved and matches with IDNameAll.
-func (l *Label) IsAllLabel() bool {
-	return l.Source == LabelSourceReserved && l.Key == "all"
-}
-
 // IsAnySource return if the label was set with source "any".
 func (l *Label) IsAnySource() bool {
 	return l.Source == LabelSourceAny
@@ -244,7 +236,7 @@ func (l *Label) IsReservedSource() bool {
 
 // matches returns true if l matches the target
 func (l *Label) matches(target *Label) bool {
-	return l.IsAllLabel() || l.Equals(target)
+	return l.Equals(target)
 }
 
 // String returns the string representation of Label in the for of Source:Key=Value or

--- a/pkg/policy/api/entity.go
+++ b/pkg/policy/api/entity.go
@@ -81,26 +81,6 @@ var (
 // EntitySlice is a slice of entities
 type EntitySlice []Entity
 
-// Matches returns true if the entity matches the labels
-func (e Entity) Matches(ctx labels.LabelArray) bool {
-	if selectors, ok := EntitySelectorMapping[e]; ok {
-		return selectors.Matches(ctx)
-	}
-
-	return false
-}
-
-// Matches returns true if any of the entities in the slice match the labels
-func (s EntitySlice) Matches(ctx labels.LabelArray) bool {
-	for _, entity := range s {
-		if entity.Matches(ctx) {
-			return true
-		}
-	}
-
-	return false
-}
-
 // GetAsEndpointSelectors returns the provided entity slice as a slice of
 // endpoint selectors
 func (s EntitySlice) GetAsEndpointSelectors() EndpointSelectorSlice {

--- a/pkg/policy/api/entity_test.go
+++ b/pkg/policy/api/entity_test.go
@@ -25,46 +25,56 @@ import (
 	. "gopkg.in/check.v1"
 )
 
+// matches returns true if the entity matches the labels
+func (e Entity) matches(ctx labels.LabelArray) bool {
+	return EntitySlice{e}.matches(ctx)
+}
+
+// matches returns true if any of the entities in the slice match the labels
+func (s EntitySlice) matches(ctx labels.LabelArray) bool {
+	return s.GetAsEndpointSelectors().Matches(ctx)
+}
+
 func (s *PolicyAPITestSuite) TestEntityMatches(c *C) {
 	InitEntities("cluster1")
 
-	c.Assert(EntityHost.Matches(labels.ParseLabelArray("reserved:host")), Equals, true)
-	c.Assert(EntityHost.Matches(labels.ParseLabelArray("reserved:host", "id:foo")), Equals, true)
-	c.Assert(EntityHost.Matches(labels.ParseLabelArray("reserved:world")), Equals, false)
-	c.Assert(EntityHost.Matches(labels.ParseLabelArray("reserved:unmanaged")), Equals, false)
-	c.Assert(EntityHost.Matches(labels.ParseLabelArray("reserved:none")), Equals, false)
-	c.Assert(EntityHost.Matches(labels.ParseLabelArray("id=foo")), Equals, false)
+	c.Assert(EntityHost.matches(labels.ParseLabelArray("reserved:host")), Equals, true)
+	c.Assert(EntityHost.matches(labels.ParseLabelArray("reserved:host", "id:foo")), Equals, true)
+	c.Assert(EntityHost.matches(labels.ParseLabelArray("reserved:world")), Equals, false)
+	c.Assert(EntityHost.matches(labels.ParseLabelArray("reserved:unmanaged")), Equals, false)
+	c.Assert(EntityHost.matches(labels.ParseLabelArray("reserved:none")), Equals, false)
+	c.Assert(EntityHost.matches(labels.ParseLabelArray("id=foo")), Equals, false)
 
-	c.Assert(EntityAll.Matches(labels.ParseLabelArray("reserved:host")), Equals, true)
-	c.Assert(EntityAll.Matches(labels.ParseLabelArray("reserved:world")), Equals, true)
-	c.Assert(EntityAll.Matches(labels.ParseLabelArray("reserved:unmanaged")), Equals, true)
-	c.Assert(EntityAll.Matches(labels.ParseLabelArray("reserved:none")), Equals, true) // in a white-list model, All trumps None
-	c.Assert(EntityAll.Matches(labels.ParseLabelArray("id=foo")), Equals, true)
+	c.Assert(EntityAll.matches(labels.ParseLabelArray("reserved:host")), Equals, true)
+	c.Assert(EntityAll.matches(labels.ParseLabelArray("reserved:world")), Equals, true)
+	c.Assert(EntityAll.matches(labels.ParseLabelArray("reserved:unmanaged")), Equals, true)
+	c.Assert(EntityAll.matches(labels.ParseLabelArray("reserved:none")), Equals, true) // in a white-list model, All trumps None
+	c.Assert(EntityAll.matches(labels.ParseLabelArray("id=foo")), Equals, true)
 
-	c.Assert(EntityCluster.Matches(labels.ParseLabelArray("reserved:host")), Equals, true)
-	c.Assert(EntityCluster.Matches(labels.ParseLabelArray("reserved:init")), Equals, true)
-	c.Assert(EntityCluster.Matches(labels.ParseLabelArray("reserved:unmanaged")), Equals, true)
-	c.Assert(EntityCluster.Matches(labels.ParseLabelArray("reserved:world")), Equals, false)
-	c.Assert(EntityCluster.Matches(labels.ParseLabelArray("reserved:none")), Equals, false)
+	c.Assert(EntityCluster.matches(labels.ParseLabelArray("reserved:host")), Equals, true)
+	c.Assert(EntityCluster.matches(labels.ParseLabelArray("reserved:init")), Equals, true)
+	c.Assert(EntityCluster.matches(labels.ParseLabelArray("reserved:unmanaged")), Equals, true)
+	c.Assert(EntityCluster.matches(labels.ParseLabelArray("reserved:world")), Equals, false)
+	c.Assert(EntityCluster.matches(labels.ParseLabelArray("reserved:none")), Equals, false)
 
 	clusterLabel := fmt.Sprintf("k8s:%s=%s", k8sapi.PolicyLabelCluster, "cluster1")
-	c.Assert(EntityCluster.Matches(labels.ParseLabelArray(clusterLabel, "id=foo")), Equals, true)
-	c.Assert(EntityCluster.Matches(labels.ParseLabelArray(clusterLabel, "id=foo", "id=bar")), Equals, true)
-	c.Assert(EntityCluster.Matches(labels.ParseLabelArray("id=foo")), Equals, false)
+	c.Assert(EntityCluster.matches(labels.ParseLabelArray(clusterLabel, "id=foo")), Equals, true)
+	c.Assert(EntityCluster.matches(labels.ParseLabelArray(clusterLabel, "id=foo", "id=bar")), Equals, true)
+	c.Assert(EntityCluster.matches(labels.ParseLabelArray("id=foo")), Equals, false)
 
-	c.Assert(EntityWorld.Matches(labels.ParseLabelArray("reserved:host")), Equals, false)
-	c.Assert(EntityWorld.Matches(labels.ParseLabelArray("reserved:world")), Equals, true)
-	c.Assert(EntityWorld.Matches(labels.ParseLabelArray("reserved:unmanaged")), Equals, false)
-	c.Assert(EntityWorld.Matches(labels.ParseLabelArray("reserved:none")), Equals, false)
-	c.Assert(EntityWorld.Matches(labels.ParseLabelArray("id=foo")), Equals, false)
-	c.Assert(EntityWorld.Matches(labels.ParseLabelArray("id=foo", "id=bar")), Equals, false)
+	c.Assert(EntityWorld.matches(labels.ParseLabelArray("reserved:host")), Equals, false)
+	c.Assert(EntityWorld.matches(labels.ParseLabelArray("reserved:world")), Equals, true)
+	c.Assert(EntityWorld.matches(labels.ParseLabelArray("reserved:unmanaged")), Equals, false)
+	c.Assert(EntityWorld.matches(labels.ParseLabelArray("reserved:none")), Equals, false)
+	c.Assert(EntityWorld.matches(labels.ParseLabelArray("id=foo")), Equals, false)
+	c.Assert(EntityWorld.matches(labels.ParseLabelArray("id=foo", "id=bar")), Equals, false)
 
-	c.Assert(EntityNone.Matches(labels.ParseLabelArray("reserved:host")), Equals, false)
-	c.Assert(EntityNone.Matches(labels.ParseLabelArray("reserved:world")), Equals, false)
-	c.Assert(EntityNone.Matches(labels.ParseLabelArray("reserved:unmanaged")), Equals, false)
-	c.Assert(EntityNone.Matches(labels.ParseLabelArray("reserved:init")), Equals, false)
-	c.Assert(EntityNone.Matches(labels.ParseLabelArray("id=foo")), Equals, false)
-	c.Assert(EntityNone.Matches(labels.ParseLabelArray(clusterLabel, "id=foo", "id=bar")), Equals, false)
+	c.Assert(EntityNone.matches(labels.ParseLabelArray("reserved:host")), Equals, false)
+	c.Assert(EntityNone.matches(labels.ParseLabelArray("reserved:world")), Equals, false)
+	c.Assert(EntityNone.matches(labels.ParseLabelArray("reserved:unmanaged")), Equals, false)
+	c.Assert(EntityNone.matches(labels.ParseLabelArray("reserved:init")), Equals, false)
+	c.Assert(EntityNone.matches(labels.ParseLabelArray("id=foo")), Equals, false)
+	c.Assert(EntityNone.matches(labels.ParseLabelArray(clusterLabel, "id=foo", "id=bar")), Equals, false)
 
 }
 
@@ -72,17 +82,9 @@ func (s *PolicyAPITestSuite) TestEntitySliceMatches(c *C) {
 	InitEntities("cluster1")
 
 	slice := EntitySlice{EntityHost, EntityWorld}
-	c.Assert(slice.Matches(labels.ParseLabelArray("reserved:host")), Equals, true)
-	c.Assert(slice.Matches(labels.ParseLabelArray("reserved:world")), Equals, true)
-	c.Assert(slice.Matches(labels.ParseLabelArray("reserved:unmanaged")), Equals, false)
-	c.Assert(slice.Matches(labels.ParseLabelArray("reserved:none")), Equals, false)
-	c.Assert(slice.Matches(labels.ParseLabelArray("id=foo")), Equals, false)
-
-	// result must be identical if matched via endpoint selector
-	selector := slice.GetAsEndpointSelectors()
-	c.Assert(selector.Matches(labels.ParseLabelArray("reserved:host")), Equals, true)
-	c.Assert(selector.Matches(labels.ParseLabelArray("reserved:world")), Equals, true)
-	c.Assert(selector.Matches(labels.ParseLabelArray("reserved:unmanaged")), Equals, false)
-	c.Assert(selector.Matches(labels.ParseLabelArray("reserved:none")), Equals, false)
-	c.Assert(selector.Matches(labels.ParseLabelArray("id=foo")), Equals, false)
+	c.Assert(slice.matches(labels.ParseLabelArray("reserved:host")), Equals, true)
+	c.Assert(slice.matches(labels.ParseLabelArray("reserved:world")), Equals, true)
+	c.Assert(slice.matches(labels.ParseLabelArray("reserved:unmanaged")), Equals, false)
+	c.Assert(slice.matches(labels.ParseLabelArray("reserved:none")), Equals, false)
+	c.Assert(slice.matches(labels.ParseLabelArray("id=foo")), Equals, false)
 }

--- a/pkg/policy/api/selector.go
+++ b/pkg/policy/api/selector.go
@@ -290,7 +290,6 @@ func (n *EndpointSelector) AddMatch(key, value string) {
 // Returns always true if the endpoint selector contains the reserved label for
 // "all".
 func (n *EndpointSelector) Matches(lblsToMatch k8sLbls.Labels) bool {
-
 	// Try to update cached requirements for this EndpointSelector if possible.
 	if n.requirements == nil {
 		n.requirements = labelSelectorToRequirements(n.LabelSelector)
@@ -301,13 +300,6 @@ func (n *EndpointSelector) Matches(lblsToMatch k8sLbls.Labels) bool {
 			return false
 		}
 	}
-
-	for k := range n.MatchLabels {
-		if k == labels.LabelSourceReservedKeyPrefix+labels.IDNameAll {
-			return true
-		}
-	}
-
 	for _, req := range *n.requirements {
 		if !req.Matches(lblsToMatch) {
 			return false

--- a/pkg/policy/api/selector_test.go
+++ b/pkg/policy/api/selector_test.go
@@ -33,11 +33,15 @@ var _ = Suite(&PolicyAPITestSuite{})
 
 func (s *PolicyAPITestSuite) TestSelectsAllEndpoints(c *C) {
 
-	// Empty endpoint selector slice equates to a wildcard.
+	// Empty endpoint selector slice does NOT equate to a wildcard.
 	selectorSlice := EndpointSelectorSlice{}
 	c.Assert(selectorSlice.SelectsAllEndpoints(), Equals, false)
 
 	selectorSlice = EndpointSelectorSlice{WildcardEndpointSelector}
+	c.Assert(selectorSlice.SelectsAllEndpoints(), Equals, true)
+
+	// Entity "reserved:all" maps to WildcardEndpointSelector
+	selectorSlice = EntitySlice{EntityAll}.GetAsEndpointSelectors()
 	c.Assert(selectorSlice.SelectsAllEndpoints(), Equals, true)
 
 	// Slice that contains wildcard and other selectors still selects all endpoints.


### PR DESCRIPTION
Mapping the k8s network policy "all" selector to
api.WildcardEndpointSelector allows removal of the special identity
name all and the special matching logic for it in selector.Matches().

This improves KNP to bpf policy translation by not enumerating all
known identities as separate entities in the endpoint's bpf policy map
when a single wildcard entry suffices. We already do this optimized
mapping for CNPs, but have previously failed to update how KNPs are
translated.

As this change removes the notion of the "reserved:all" label (but not
the "reserved:all" entity), this also changes how
LabelArray.Contains() and LabelArray.Lacks() function with regard to
"reserved:all" label.  It seems that this was not well defined anyway
(previously ["foo","bar"].Contains(["reserved:all"]) would have
returned 'true', but ["reserved:all"].Contains["foo","bar"]) would
have returned 'false'), so maybe this is for the better.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9028)
<!-- Reviewable:end -->
