### PR TITLE
v1.6 backports 2019-08-23

### DIFF
--- a/Documentation/concepts/networking.rst
+++ b/Documentation/concepts/networking.rst
@@ -102,10 +102,9 @@ This is typically achieved using two methods:
   combination with the ``--allocate-node-cidrs`` option then this is configured
   automatically for IPv4 prefixes.
 
-.. note:: Use of direct routing mode currently only offers identity based
-          security policy enforcement for IPv6 where the security identity is
-          stored in the flowlabel. IPv4 is currently not supported and thus
-          security must be enforced using CIDR policy rules.
+.. note:: Use of direct routing mode with advanced policy use cases such as
+          L7 policies is currently beta. Please provide feedback and file a
+          GitHub issue if you experience any problems.
 
 
 .. _AWS VPC Route Tables: http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Route_Tables.html

--- a/Documentation/gettingstarted/flannel-integration.rst
+++ b/Documentation/gettingstarted/flannel-integration.rst
@@ -61,6 +61,9 @@ Generate the required YAML file and deploy it:
 Set ``global.flannel.uninstallOnExit=true`` if you want Cilium to uninstall
 itself when the Cilium pod is stopped.
 
+If the Flannel bridge has a different name than ``cni0``, you must specify
+the name by setting ``global.flannel.masterDevice=...``.
+
 *Optional step:*
 If your cluster has already pods being managed by Flannel, there is also
 an option available that allows Cilium to start managing those pods without

--- a/Documentation/gettingstarted/index.rst
+++ b/Documentation/gettingstarted/index.rst
@@ -59,6 +59,7 @@ Advanced Networking
    encryption
    host-services
    nodeport
+   kubeproxy-free
    kata-gce
    ipam
 

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -1,0 +1,95 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+    http://docs.cilium.io
+
+.. _kubeproxy-free:
+
+************************************
+Kubernetes without kube-proxy (beta)
+************************************
+
+This guide explains how to provision a Kubernetes cluster without
+``kube-proxy``, and to use Cilium to replace it. For simplicity,
+we will use ``kubeadm`` to bootstrap the cluster.
+
+For installing ``kubeadm`` and for more provisioning options please refer to
+`the official kubeadm documentation <https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm>`__.
+
+Initialize the control-plane node:
+
+.. code:: bash
+
+    kubeadm init --pod-network-cidr=10.217.0.0/16
+
+.. note::
+
+    Currently, it is not possible to disable kube-proxy via ``--skip-phases=addon/kube-proxy``
+    due to the bug `kubeadm#1733 <https://github.com/kubernetes/kubeadm/issues/1733>`__.
+
+    Once it has been resolved, the workaround below for manually removing the
+    ``kube-proxy`` DaemonSet and iptables-save/restore cleaning is no longer needed
+    and initialization would look like:
+    ``kubeadm init --pod-network-cidr=10.217.0.0/16 --skip-phases=addon/kube-proxy``
+
+Next, delete the ``kube-proxy`` DaemonSet and remove its iptables rules:
+
+.. code:: bash
+
+   kubectl -n kube-system delete ds kube-proxy
+   iptables-restore <(iptables-save | grep -v KUBE)
+
+Afterwards, join worker nodes by specifying the control-plane node IP address
+and the token returned by ``kubeadm init``:
+
+.. code:: bash
+
+   kubectl join <..>
+
+Download the Cilium release tarball and change to the Kubernetes
+install directory:
+
+.. code:: bash
+
+    curl -LO https://github.com/cilium/cilium/archive/master.tar.gz
+    tar xzvf cilium-master.tar.gz
+    cd cilium-master/install/kubernetes
+
+`Install Helm <https://helm.sh/docs/using_helm/#install-helm>`__ to prepare generating
+the deployment artifacts based on the Helm templates.
+
+Next, generate the required YAML files and deploy them. Replace ``$API_SERVER_IP``
+and ``$API_SERVER_PORT`` with the control-plane node IP address and the kube-apiserver
+port number reported by ``kubeadm init`` (usually it is ``6443``).
+
+.. code:: bash
+
+    helm template cilium \
+        --namespace kube-system \
+        --set global.nodePort.enabled=true \
+        --set global.k8sServiceHost=$API_SERVER_IP \
+        --set global.k8sServicePort=$API_SERVER_PORT \
+        --set global.tag=v1.6.0 \
+    > cilium.yaml
+    kubectl apply -f cilium.yaml
+
+This will install Cilium as a CNI plugin with the BPF kube-proxy replacement.
+See :ref:`nodeport` for requirements and configuration options for NodePort
+services.
+
+.. note::
+
+   Currently, in the kube-proxy-free setup, Cilium will connect to only one
+   kube-apiserver specified by ``k8sServiceHost:k8sServicePort``. This is not
+   ideal in a multi-control-plane node setup. The upcoming Cilium release will
+   allow to connect to multiple nodes (`GH#9018 <https://github.com/cilium/cilium/issues/9018>`__).
+
+Finally, verify that Cilium has come up correctly on all nodes:
+
+.. parsed-literal::
+
+    kubectl -n kube-system get pods -l k8s-app=cilium
+    NAME                READY     STATUS    RESTARTS   AGE
+    cilium-crf7f        1/1       Running   0          10m
+    cilium-mkcmb        1/1       Running   0          10m

--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -990,11 +990,6 @@ DNS Proxy (preferred)
   DNS requests. It allows L3 connections to ``cilium.io``, ``sub.cilium.io``
   and any subdomains of ``sub.cilium.io``.
 
-.. note:: The port number 53 shown in the examples is currently the
-          only supported port number on which DNS requests can be
-          proxied. This is the standard DNS port number, so it should
-          work for most uses.
-
 .. only:: html
 
    .. tabs::

--- a/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
@@ -70,6 +70,14 @@ spec:
               key: custom-cni-conf
               name: cilium-config
               optional: true
+{{- if .Values.global.k8sServiceHost }}
+        - name: KUBERNETES_SERVICE_HOST
+          value: {{ .Values.global.k8sServiceHost | quote }}
+{{- end }}
+{{- if .Values.global.k8sServicePort }}
+        - name: KUBERNETES_SERVICE_PORT
+          value: {{ .Values.global.k8sServicePort | quote }}
+{{- end }}
 {{- if contains "/" .Values.image }}
         image: "{{ .Values.image }}"
 {{- else }}

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -148,9 +148,9 @@ data:
   # Name of the cluster. Only relevant when building a mesh of clusters.
   cluster-name: {{ .Values.global.cluster.name }}
 
+{{- if .Values.global.cluster.id }}
   # Unique ID of the cluster. Must be unique across all conneted clusters and
   # in the range of 1 and 255. Only relevant when building a mesh of clusters.
-{{- if .Values.global.cluster.id }}
   cluster-id: "{{ .Values.global.cluster.id }}"
 {{- end }}
 

--- a/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
@@ -110,6 +110,14 @@ spec:
               key: AWS_DEFAULT_REGION
               name: cilium-aws
               optional: true
+{{- if .Values.global.k8sServiceHost }}
+        - name: KUBERNETES_SERVICE_HOST
+          value: {{ .Values.global.k8sServiceHost | quote }}
+{{- end }}
+{{- if .Values.global.k8sServicePort }}
+        - name: KUBERNETES_SERVICE_PORT
+          value: {{ .Values.global.k8sServicePort | quote }}
+{{- end }}
 {{- if contains "/" .Values.image }}
         image: "{{ .Values.image }}"
 {{- else }}

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -81,9 +81,6 @@ data:
   # Name of the cluster. Only relevant when building a mesh of clusters.
   cluster-name: default
 
-  # Unique ID of the cluster. Must be unique across all conneted clusters and
-  # in the range of 1 and 255. Only relevant when building a mesh of clusters.
-
   # DNS Polling periodically issues a DNS lookup for each `matchName` from
   # cilium-agent. The result is used to regenerate endpoint policy.
   # DNS lookups are repeated with an interval of 5 seconds, and are made for

--- a/operator/main.go
+++ b/operator/main.go
@@ -213,7 +213,9 @@ func runOperator(cmd *cobra.Command) {
 	k8sClientQPSLimit := viper.GetFloat64(option.K8sClientQPSLimit)
 	k8sClientBurst := viper.GetInt(option.K8sClientBurst)
 	kvStore = viper.GetString(option.KVStore)
-	kvStoreOpts = viper.GetStringMapString(option.KVStoreOpt)
+	if m := viper.GetStringMapString(option.KVStoreOpt); len(m) > 0 {
+		kvStoreOpts = m
+	}
 
 	k8s.Configure(k8sAPIServer, k8sKubeConfigPath, float32(k8sClientQPSLimit), k8sClientBurst)
 	if err := k8s.Init(); err != nil {

--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -349,11 +349,6 @@ func (pr *L7Rules) sanitize(ports []PortProtocol) error {
 		if len(ports) == 0 {
 			return fmt.Errorf("Port 53 must be specified for DNS rules")
 		}
-		for _, port := range ports {
-			if port.Port != "53" {
-				return fmt.Errorf("DNS rules are only allowed on port 53")
-			}
-		}
 
 		nTypes++
 		for i := range pr.DNS {

--- a/pkg/policy/api/rule_validation_test.go
+++ b/pkg/policy/api/rule_validation_test.go
@@ -55,30 +55,7 @@ func (s *PolicyAPITestSuite) TestL7RulesWithNonTCPProtocols(c *C) {
 	err := validPortRule.Sanitize()
 	c.Assert(err, IsNil)
 
-	// Rule is invalid because port is not 53 for DNS proxy rule.
-	validPortRule = Rule{
-		EndpointSelector: WildcardEndpointSelector,
-		Egress: []EgressRule{
-			{
-				ToEndpoints: []EndpointSelector{WildcardEndpointSelector},
-				ToPorts: []PortRule{{
-					Ports: []PortProtocol{
-						{Port: "80", Protocol: ProtoTCP},
-					},
-					Rules: &L7Rules{
-						DNS: []PortRuleDNS{
-							{MatchName: "domain.com"},
-						},
-					},
-				}},
-			},
-		},
-	}
-
-	err = validPortRule.Sanitize()
-	c.Assert(err, Not(IsNil), Commentf("Port 80 should not be allowed for DNS"))
-
-	// Rule is invalid because port is not 53 for DNS proxy rule.
+	// Rule is invalid because no port is specified for DNS proxy rule.
 	validPortRule = Rule{
 		EndpointSelector: WildcardEndpointSelector,
 		Egress: []EgressRule{

--- a/test/kubernetes-test.sh
+++ b/test/kubernetes-test.sh
@@ -3,10 +3,9 @@
 helm template install/kubernetes/cilium \
   --namespace=kube-system \
   --set global.registry=k8s1:5000/cilium \
+  --set global.tag=latest \
   --set agent.image=cilium-dev \
-  --set agent.tag=latest \
   --set operator.image=operator \
-  --set operator.tag=latest \
   --set global.debug.enabled=true \
   --set global.k8s.requireIPv4PodCIDR=true \
   --set global.pprof.enabled=true \


### PR DESCRIPTION
 * #8988 -- operator: Fix passing kvstore options via arguments (@tgraf)
 * #9000 -- iptables: Add explicit ACCEPT rules for host proxy traffic (@jrajahalme)
 * #9003 -- docs: Document how to specify Flannel bridge name (@brb)
 * #8995 -- helm: Allow to specify k8s api-server host and port via env vars (@brb)
 * #9013 -- test: Use global.tag in helm command line (@jrajahalme)
 * #9014 -- Allow DNS policy on ports other than 53 (@joestringer)
 * #8986 -- docs: Add kube-proxy free getting started guide (@brb)
 * #9019 -- install/kubernetes: do not add clustermesh documentation by default (@aanm)
 * #9015 -- docs: Update direct routing policy limitations (@joestringer)

Once this PR is merged, you can update the PR labels via:
```
$ for pr in 8988 9000 9003 8995 9013 9014 8986 9019 9015; do contrib/backporting/set-labels.py $pr done 1.6; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9029)
<!-- Reviewable:end -->
