### PR TITLE
test: Return the error in CmdRes.GetErr()

### DIFF
--- a/test/helpers/cmd.go
+++ b/test/helpers/cmd.go
@@ -314,7 +314,7 @@ func (res *CmdRes) GetErr(context string) error {
 	if res.WasSuccessful() {
 		return nil
 	}
-	return &cmdError{fmt.Sprintf("%s output: %s", context, res.GetDebugMessage())}
+	return &cmdError{fmt.Sprintf("%s (%s) output: %s", context, res.err, res.GetDebugMessage())}
 }
 
 // GetError returns the error for this CmdRes.


### PR DESCRIPTION
The CmdRes.GetErr() helper does not include the command error in the returned
error value. Fix this.

For example, an error like this does not show what is the actual error:

```
<*helpers.cmdError | 0xc0000bfb90>: Unable to generate YAML output: cmd: helm template go/src/github.com/cilium/cilium/install/kubernetes/cilium --namespace=kube-system --set global.etcd.leaseTTL=30s --set agent.image=cilium-dev --set operator.image=operator --set global.debug.enabled=true --set global.k8s.requireIPv4PodCIDR=true --set global.logSystemLoad=true --set global.bpf.preallocateMaps=true --set global.ipv4.enabled=true --set global.ipv6.enabled=true --set global.registry=k8s1:5000/cilium --set global.tag=latest --set managed-etcd.registry=docker.io/cilium --set global.pprof.enabled=true > cilium.yaml
```

The log message for this reveals that this was a context deadline exceeded error:

```
level=error msg="Error executing command 'helm template ... '" error="context deadline exceeded"
```

With this commit the above error in the test output should be like:

```
<*helpers.cmdError | 0xc0000bfb90>: Unable to generate YAML (context deadline exceeded) output: cmd: helm template go/src/github.com/cilium/cilium/install/kubernetes/cilium --namespace=kube-system --set global.etcd.leaseTTL=30s --set agent.image=cilium-dev --set operator.image=operator --set global.debug.enabled=true --set global.k8s.requireIPv4PodCIDR=true --set global.logSystemLoad=true --set global.bpf.preallocateMaps=true --set global.ipv4.enabled=true --set global.ipv6.enabled=true --set global.registry=k8s1:5000/cilium --set global.tag=latest --set managed-etcd.registry=docker.io/cilium --set global.pprof.enabled=true > cilium.yaml
```

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9031)
<!-- Reviewable:end -->
