### PR TITLE
cilium: encryption fixes for encryptNode modes

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -958,6 +958,10 @@ func NewDaemon(dp datapath.Datapath, iptablesManager rulesManager) (*Daemon, *en
 }
 
 func setupIPSec() (int, error) {
+	if option.Config.EncryptNode == false {
+		ipsec.DeleteIPsecEncryptRoute()
+	}
+
 	if !option.Config.EnableIPSec {
 		return 0, nil
 	}
@@ -967,10 +971,6 @@ func setupIPSec() (int, error) {
 		return 0, err
 	}
 	node.SetIPsecKeyIdentity(spi)
-	if option.Config.EncryptNode == false {
-		ipsec.DeleteIPsecEncryptRoute()
-	}
-
 	return authKeySize, nil
 }
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -402,10 +402,6 @@ func (d *Daemon) initMaps() error {
 		}
 	}
 
-	if err := bpf.ConfigureResourceLimits(); err != nil {
-		log.WithError(err).Fatal("Unable to set memory resource limits")
-	}
-
 	if _, err := lxcmap.LXCMap.OpenOrCreate(); err != nil {
 		return err
 	}
@@ -727,6 +723,12 @@ func NewDaemon(dp datapath.Datapath, iptablesManager rulesManager) (*Daemon, *en
 		option.Config.EnableIPv4, option.Config.EnableIPv6,
 	)
 	policymap.InitMapInfo(option.Config.PolicyMapMaxEntries)
+
+	if option.Config.DryMode == false {
+		if err := bpf.ConfigureResourceLimits(); err != nil {
+			log.WithError(err).Fatal("Unable to set memory resource limits")
+		}
+	}
 
 	authKeySize, err := setupIPSec()
 	if err != nil {

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -452,7 +452,10 @@ func loadIPSecKeys(r io.Reader) (int, uint8, error) {
 			}()
 		}
 	}
-	encrypt.MapUpdateContext(0, spi)
+	if err := encrypt.MapUpdateContext(0, spi); err != nil {
+		scopedLog.WithError(err).Warn("cilium_encrypt_state map updated failed:")
+		return 0, 0, err
+	}
 	return keyLen, spi, nil
 }
 

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -348,7 +348,9 @@ func loadIPSecKeys(r io.Reader) (int, uint8, error) {
 		"spi": spi,
 	})
 
-	encrypt.MapCreate()
+	if err := encrypt.MapCreate(); err != nil {
+		return 0, 0, fmt.Errorf("Encrypt map create failed: %v", err)
+	}
 
 	scanner := bufio.NewScanner(r)
 	scanner.Split(bufio.ScanLines)

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -144,7 +144,7 @@ func ipSecReplacePolicyInFwd(src, dst *net.IPNet, dir netlink.Dir) error {
 	return netlink.XfrmPolicyUpdate(policy)
 }
 
-func ipSecReplacePolicyOut(src, dst *net.IPNet, dir IPSecDir) error {
+func ipSecReplacePolicyOut(src, dst, tmplSrc, tmplDst *net.IPNet, dir IPSecDir) error {
 	var spiWide uint32
 
 	key := getIPSecKeys(dst.IP)
@@ -167,7 +167,11 @@ func ipSecReplacePolicyOut(src, dst *net.IPNet, dir IPSecDir) error {
 		Value: ((spiWide << 12) | linux_defaults.RouteMarkEncrypt),
 		Mask:  linux_defaults.IPsecMarkMask,
 	}
-	ipSecAttachPolicyTempl(policy, key, src.IP, dst.IP, true)
+	if tmplSrc != nil && tmplDst != nil {
+		ipSecAttachPolicyTempl(policy, key, tmplSrc.IP, tmplDst.IP, true)
+	} else {
+		ipSecAttachPolicyTempl(policy, key, src.IP, dst.IP, true)
+	}
 	return netlink.XfrmPolicyUpdate(policy)
 }
 
@@ -304,7 +308,7 @@ func UpsertIPsecEndpoint(local, remote *net.IPNet, dir IPSecDir) (uint8, error) 
 				}
 			}
 
-			if err = ipSecReplacePolicyOut(local, remote, dir); err != nil {
+			if err = ipSecReplacePolicyOut(local, remote, nil, nil, dir); err != nil {
 				if !os.IsExist(err) {
 					return 0, fmt.Errorf("unable to replace policy out: %s", err)
 				}
@@ -312,6 +316,17 @@ func UpsertIPsecEndpoint(local, remote *net.IPNet, dir IPSecDir) (uint8, error) 
 		}
 	}
 	return spi, nil
+}
+
+// UpsertIPsecEndpointPolicy adds a policy to the xfrm rules. Used to add a policy when the state
+// rule is already available.
+func UpsertIPsecEndpointPolicy(local, remote, localT, remoteT *net.IPNet, dir IPSecDir) error {
+	if err := ipSecReplacePolicyOut(local, remote, localT, remoteT, dir); err != nil {
+		if !os.IsExist(err) {
+			return fmt.Errorf("unable to replace templated policy out: %s", err)
+		}
+	}
+	return nil
 }
 
 // DeleteIPsecEndpoint deletes a endpoint associated with the remote IP address

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -524,9 +524,10 @@ func (n *linuxNodeHandler) encryptNode(newNode *node.Node) {
 
 }
 
-func neighborLog(spec string, err error, ip *net.IP, hwAddr *net.HardwareAddr, link int) {
+func neighborLog(spec, iface string, err error, ip *net.IP, hwAddr *net.HardwareAddr, link int) {
 	scopedLog := log.WithFields(logrus.Fields{
 		logfields.Reason: spec,
+		"Interface":      iface,
 		"IP":             ip,
 		"HardwareAddr":   hwAddr,
 		"LinkIndex":      link,
@@ -550,19 +551,19 @@ func (n *linuxNodeHandler) insertNeighbor(newNode *node.Node, ifaceName string) 
 
 	iface, err := net.InterfaceByName(ifaceName)
 	if err != nil {
-		neighborLog("insertNeightbor InterfaceByName", err, &ciliumIPv4, &hwAddr, link)
+		neighborLog("insertNeightbor InterfaceByName", ifaceName, err, &ciliumIPv4, &hwAddr, link)
 		return
 	}
 
 	_, err = arping.FindIPInNetworkFromIface(ciliumIPv4, *iface)
 	if err != nil {
-		neighborLog("insertNeightbor IP not L2 reachable", nil, &ciliumIPv4, &hwAddr, link)
+		neighborLog("insertNeightbor IP not L2 reachable", ifaceName, nil, &ciliumIPv4, &hwAddr, link)
 		return
 	}
 
 	linkAttr, err := netlink.LinkByName(ifaceName)
 	if err != nil {
-		neighborLog("insertNeightbor LinkByName", err, &ciliumIPv4, &hwAddr, link)
+		neighborLog("insertNeightbor LinkByName", ifaceName, err, &ciliumIPv4, &hwAddr, link)
 		return
 	}
 	link = linkAttr.Attrs().Index
@@ -575,9 +576,9 @@ func (n *linuxNodeHandler) insertNeighbor(newNode *node.Node, ifaceName string) 
 			State:        netlink.NUD_PERMANENT,
 		}
 		err := netlink.NeighSet(&neigh)
-		neighborLog("insertNeighbor NeighSet", err, &ciliumIPv4, &hwAddr, link)
+		neighborLog("insertNeighbor NeighSet", ifaceName, err, &ciliumIPv4, &hwAddr, link)
 	} else {
-		neighborLog("insertNeighbor arping failed", err, &ciliumIPv4, &hwAddr, link)
+		neighborLog("insertNeighbor arping failed", ifaceName, err, &ciliumIPv4, &hwAddr, link)
 	}
 }
 

--- a/pkg/maps/encrypt/encrypt.go
+++ b/pkg/maps/encrypt/encrypt.go
@@ -88,8 +88,9 @@ var (
 )
 
 // MapCreate will create an encrypt map
-func MapCreate() {
-	encryptMap.OpenOrCreate()
+func MapCreate() error {
+	_, err := encryptMap.OpenOrCreate()
+	return err
 }
 
 // MapUpdateContext updates the encrypt state with ctxID to use the new keyID


### PR DESCRIPTION
This series does the following

  - fix a somewhat rare case where encrypt node map failed to be created due to resource constraints usually after restarting agent when there is locked memory in use already
 - throw a hard error if we hit the above in the future instead of limping along with a somewhat broken configuration
 - cleanup logging some to make it easier to debug above issues and a kernel bug where netlink was broke
 - cleanup encrypt-node routes if encryptNode is disabled but encryption is left enabled. This could create a routing loop depending on system configuration
 - When nodes are deleted delete encryptNode routes otherwise we have stale routes in the system.

commit messages have more details on each.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9032)
<!-- Reviewable:end -->
