### PR TITLE
AKS getting started guide

### DIFF
--- a/Documentation/gettingstarted/cni-chaining.rst
+++ b/Documentation/gettingstarted/cni-chaining.rst
@@ -12,6 +12,11 @@ CNI Chaining
 
 CNI chaining allows to use Cilium in combination with other CNI plugins.
 
+With Cilium CNI chaining, the base network connectivity and IP address management
+is managed by the non-Cilium CNI plugin, but Cilium attaches BPF programs to the
+network devices created by the non-Cilium plugin to provide L3/L4/L7 network visibility &
+policy enforcement and other advanced features like transparent encryption.
+
 .. toctree::
    :maxdepth: 1
    :glob:

--- a/Documentation/gettingstarted/k8s-install-aks.rst
+++ b/Documentation/gettingstarted/k8s-install-aks.rst
@@ -1,0 +1,199 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+    http://docs.cilium.io
+
+.. _k8s_install_aks:
+
+*************************
+Installation on Azure AKS
+*************************
+
+This guide covers installing Cilium into an Azure AKS environment running in
+`Advanced Networking Mode <https://docs.microsoft.com/en-us/azure/aks/concepts-network#azure-cni-advanced-networking>`_ .
+
+This is achieved using Cilium CNI chaining, with the Azure CNI plugin as the base CNI plugin and Cilium chaining
+on top to provide L3/L4/L7 visibility and enforcement, as well as other advanced features like transparent encryption.
+
+
+Prerequisites
+=============
+
+Ensure that you have the `azure cloud cli
+<https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest>`_ installed.
+
+To verify, confirm that the following command displays the set of available Kubernetes versions.
+
+.. code:: bash
+
+        az aks get-versions -l westus -o table
+
+Create an AKS Cluster in Advanced Networking Mode
+=================================================
+
+The full background on creating AKS clusters in advanced networking mode, see `this guide
+<https://docs.microsoft.com/en-us/azure/aks/configure-azure-cni>`_ .
+
+If you want to us the CLI to create a dedicated set of Azure resources (resource groups, networks, etc.)
+specifically for this tutorial, the following commands (borrowed from the AKS documentation)
+run as a script or manually all in the same terminal are sufficient.
+
+It can take 10+ minutes for the final command to be complete indicating that the cluster is ready.
+
+.. note:: **Do NOT specify the '--network-policy' flag** when creating the cluster,
+    as this will cause the Azure CNI plugin to push down unwanted iptables rules:
+
+
+.. code:: bash
+
+        export SP_PASSWORD=mySecurePassword
+        export RESOURCE_GROUP_NAME=myResourceGroup-NP
+        export CLUSTER_NAME=myAKSCluster
+        export LOCATION=westus
+
+        # Create a resource group
+        az group create --name $RESOURCE_GROUP_NAME --location $LOCATION
+
+        # Create a virtual network and subnet
+        az network vnet create \
+            --resource-group $RESOURCE_GROUP_NAME \
+            --name myVnet \
+            --address-prefixes 10.0.0.0/8 \
+            --subnet-name myAKSSubnet \
+            --subnet-prefix 10.240.0.0/16
+
+        # Create a service principal and read in the application ID
+        SP_ID=$(az ad sp create-for-rbac --password $SP_PASSWORD --skip-assignment --query [appId] -o tsv)
+
+        # Wait 15 seconds to make sure that service principal has propagated
+        echo "Waiting for service principal to propagate..."
+        sleep 15
+
+        # Get the virtual network resource ID
+        VNET_ID=$(az network vnet show --resource-group $RESOURCE_GROUP_NAME --name myVnet --query id -o tsv)
+
+        # Assign the service principal Contributor permissions to the virtual network resource
+        az role assignment create --assignee $SP_ID --scope $VNET_ID --role Contributor
+
+        # Get the virtual network subnet resource ID
+        SUBNET_ID=$(az network vnet subnet show --resource-group $RESOURCE_GROUP_NAME --vnet-name myVnet --name myAKSSubnet --query id -o tsv)
+
+        # Create the AKS cluster and specify the virtual network and service principal information
+        # Enable network policy by using the `--network-policy` parameter
+        az aks create \
+            --resource-group $RESOURCE_GROUP_NAME \
+            --name $CLUSTER_NAME \
+            --node-count 1 \
+            --generate-ssh-keys \
+            --network-plugin azure \
+            --service-cidr 10.0.0.0/16 \
+            --dns-service-ip 10.0.0.10 \
+            --docker-bridge-address 172.17.0.1/16 \
+            --vnet-subnet-id $SUBNET_ID \
+            --service-principal $SP_ID \
+            --client-secret $SP_PASSWORD
+
+
+Configure kubectl to Point to Newly Created Cluster
+===================================================
+
+Run the following commands to configure kubectl to connect to this
+AKS cluster:
+
+.. code:: bash
+
+    az aks get-credentials --resource-group $RESOURCE_GROUP_NAME --name $CLUSTER_NAME
+
+
+.. code:: bash
+
+    export KUBECONFIG=/Users/danwent/.kube/config
+
+
+To verify, you should see AKS in the name of the nodes when you run:
+
+.. code:: bash
+
+    kubectl get nodes
+    NAME                       STATUS   ROLES   AGE     VERSION
+    aks-nodepool1-12032939-0   Ready    agent   8m26s   v1.13.10
+
+
+Create an AKS + Cilium CNI configuration
+========================================
+
+Create a ``chaining.yaml`` file based on the following template to specify the
+desired CNI chaining configuration:
+
+
+.. code:: yaml
+
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: cni-configuration
+      namespace: cilium
+    data:
+      cni-config: |-
+        {
+          "cniVersion": "0.3.0",
+          "name": "azure",
+          "plugins": [
+            {
+              "type": "azure-vnet",
+              "mode": "transparent",
+              "bridge": "azure0",
+              "ipam": {
+                 "type": "azure-vnet-ipam"
+               }
+            },
+            {
+              "type": "portmap",
+              "capabilities": {"portMappings": true},
+              "snat": true
+            },
+            {
+               "name": "cilium",
+               "type": "cilium-cni"
+            }
+          ]
+        }
+
+Create the cilium namespace:
+
+.. code:: bash
+
+   kubectl create namespace cilium
+
+
+Deploy the `ConfigMap`:
+
+.. code:: bash
+
+   kubectl apply -f chaining.yaml
+
+
+Prepare & Deploy Cilium
+=======================
+
+.. include:: k8s-install-download-release.rst
+
+Generate the required YAML file and deploy it:
+
+.. code:: bash
+
+   helm template cilium \
+     --namespace cilium \
+     --set global.cni.chainingMode=generic-veth \
+     --set global.cni.customConf=true \
+     --set nodeinit.enabled=true \
+     --set global.cni.configMap=cni-configuration \
+     --set global.tunnel=disabled \
+     > cilium.yaml
+   kubectl create -f cilium.yaml
+
+This will create both the main cilium daemonset, as well as the cilium-node-init daemonset, which handles tasks like mounting the BPF filesystem and updating the
+existing Azure CNI plugin to run in 'transparent' mode.
+
+.. include:: k8s-install-validate.rst

--- a/Documentation/gettingstarted/k8s-install-managed.rst
+++ b/Documentation/gettingstarted/k8s-install-managed.rst
@@ -19,3 +19,4 @@ working out of the box as well.
 
    k8s-install-eks
    k8s-install-gke
+   k8s-install-aks


### PR DESCRIPTION
Signed-off-by: Dan Wendlandt <dan@covalent.io>

AKS guide that leverages CNI chaining.    Requires 'latest' for testing, as @tgraf recently added a commit to add some required logic to cilium-node-init .    

Scaling out nodes also hits an issue that is attempting to be addressed by #9023.

One doc only issue is that because we use 'cilium' rather than 'kube-system', the text included by ".. include:: k8s-install-validate.rst" at the end seems to have 'kube-system' hardcoded.   I think we have the same issue with GKE as well.   Hopefully someone much better at restructed text than I am can figure out if there is a good way to do template substitution or similar for both AKS + GKE guides

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9033)
<!-- Reviewable:end -->
