### PR TITLE
cilium: only enable IPv6 forwarding if IPv6 is enabled

### DIFF
--- a/daemon/sysctl_linux.go
+++ b/daemon/sysctl_linux.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/sysctl"
 )
 
@@ -25,8 +26,10 @@ func enableIPForwarding() error {
 	if err := sysctl.Enable("net.ipv4.conf.all.forwarding"); err != nil {
 		return err
 	}
-	if err := sysctl.Enable("net.ipv6.conf.all.forwarding"); err != nil {
-		return err
+	if option.Config.EnableIPv6 {
+		if err := sysctl.Enable("net.ipv6.conf.all.forwarding"); err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
When running with a kernel that has IPv6 compiled out there is no
/proc/net/ipv6/ directory so trying to enable IPv6 fails and the
daemon can not start.

To resolve this only enable IPv6 forwarding when daemon is running with
IPv6 enabled.

Error seen with IPv6 compiled out and IPv6 disabled in config map is

level=fatal msg="Error when enabling sysctl parameters" error="could not open the sysctl file /proc/sys/net/ipv6/conf/all/forwarding: open /proc/sys/net/ipv6/conf/all/forwarding: no such file or directory" subsys=daemon

Fixes: 294cf66a9c9c8 ("daemon: Enable IP forwarding on start")
Signed-off-by: John Fastabend <john.fastabend@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9034)
<!-- Reviewable:end -->
