### PR TITLE
CI: Update upgrade test to 1.6 -> master

### DIFF
--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -100,7 +100,7 @@ pipeline {
             steps {
                 parallel(
                     "Nightly":{
-                        sh 'cd ${TESTDIR}; ginkgo --focus="Nightly*" -v --failFast=${FAILFAST} -- -cilium.timeout=450m'
+                        sh 'cd ${TESTDIR}; ginkgo --focus="NightlyExamples Upgrade test" -v --failFast=${FAILFAST} -- -cilium.timeout=450m'
                     },
                 )
             }

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -182,7 +182,7 @@ const (
 	KubectlPolicyNameLabel      = k8sConst.PolicyLabelName
 	KubectlPolicyNameSpaceLabel = k8sConst.PolicyLabelNamespace
 
-	CiliumStableVersion      = "v1.5"
+	CiliumStableVersion      = "v1.6"
 	CiliumStableImageVersion = "cilium/cilium:" + CiliumStableVersion
 	CiliumDeveloperImage     = "k8s1:5000/cilium/cilium-dev:latest"
 
@@ -224,7 +224,7 @@ const (
 )
 
 // NightlyStableUpgradesFrom the cilium images to update from in Nightly test.
-var NightlyStableUpgradesFrom = []string{"v1.3"}
+var NightlyStableUpgradesFrom = []string{"v1.6"}
 
 var (
 	CiliumV1_5 = versioncheck.MustCompile(">=v1.4.90,<v1.6")

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1109,43 +1109,12 @@ func (kub *Kubectl) CiliumUninstall(options []string) error {
 // Returns an error if any patch or if any original descriptors files were not
 // found.
 func (kub *Kubectl) CiliumInstallVersion(dsPatchName, cmPatchName, versionTag string) error {
-	getK8sDescriptorPatch := func(filename string) string {
-		// try dependent Cilium, k8s and integration version patch file
-		ginkgoVersionedPath := filepath.Join(manifestsPath, versionTag, GetCurrentK8SEnv(), GetCurrentIntegration(), filename)
-		_, err := os.Stat(ginkgoVersionedPath)
-		if err == nil {
-			return filepath.Join(BasePath, ginkgoVersionedPath)
-		}
-		// try dependent Cilium version and integration patch file
-		ginkgoVersionedPath = filepath.Join(manifestsPath, versionTag, GetCurrentIntegration(), filename)
-		_, err = os.Stat(ginkgoVersionedPath)
-		if err == nil {
-			return filepath.Join(BasePath, ginkgoVersionedPath)
-		}
-		// try dependent Cilium and k8s version patch file
-		ginkgoVersionedPath = filepath.Join(manifestsPath, versionTag, GetCurrentK8SEnv(), filename)
-		_, err = os.Stat(ginkgoVersionedPath)
-		if err == nil {
-			return filepath.Join(BasePath, ginkgoVersionedPath)
-		}
-		// try dependent Cilium version patch file
-		ginkgoVersionedPath = filepath.Join(manifestsPath, versionTag, filename)
-		_, err = os.Stat(ginkgoVersionedPath)
-		if err == nil {
-			return filepath.Join(BasePath, ginkgoVersionedPath)
-		}
-		// try dependent integration patch file
-		ginkgoVersionedPath = filepath.Join(manifestsPath, GetCurrentIntegration(), filename)
-		_, err = os.Stat(ginkgoVersionedPath)
-		if err == nil {
-			return filepath.Join(BasePath, ginkgoVersionedPath)
-		}
-		return filepath.Join(BasePath, manifestsPath, filename)
+	switch {
+	default:
+		return kub.ciliumInstallHelm([]string{
+			"--set global.values.tag=" + versionTag,
+		})
 	}
-	getK8sDescriptor := func(filename string) string {
-		return fmt.Sprintf("https://raw.githubusercontent.com/cilium/cilium/%s/examples/kubernetes/%s/%s", versionTag, GetCurrentK8SEnv(), filename)
-	}
-	return kub.ciliumInstall(dsPatchName, cmPatchName, getK8sDescriptor, getK8sDescriptorPatch)
 }
 
 // GetCiliumPods returns a list of all Cilium pods in the specified namespace,

--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -365,9 +365,7 @@ var _ = Describe("NightlyExamples", func() {
 			// Delete etcd operator because sometimes when install from
 			// clean-state the quorum is lost.
 			// ETCD operator maybe is not installed at all, so no assert here.
-			kubectl.DeleteETCDOperator()
 			ExpectAllPodsTerminated(kubectl)
-
 		})
 
 		AfterEach(func() {

--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -61,8 +61,6 @@ var _ = Describe("K8sUpdates", func() {
 		kubectl.Exec(fmt.Sprintf(
 			"%s delete --all pods,svc,cnp -n %s", helpers.KubectlCmd, helpers.DefaultNamespace))
 
-		kubectl.DeleteETCDOperator()
-
 		ExpectAllPodsTerminated(kubectl)
 	})
 
@@ -155,8 +153,6 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldVersion, newV
 		// Delete all etcd pods otherwise they will be kept running but
 		// the bpf endpoints will be cleaned up when we restart cilium
 		// with a clean state a couple lines bellow
-		kubectl.DeleteETCDOperator()
-
 		By("Waiting for pods to be terminated..")
 		ExpectAllPodsTerminated(kubectl)
 
@@ -187,7 +183,6 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldVersion, newV
 		By("Cilium %q is installed and running", oldVersion)
 		ExpectCiliumReady(kubectl)
 
-		ExpectETCDOperatorReady(kubectl)
 		ExpectCiliumOperatorReady(kubectl)
 
 		By("Installing Microscope")


### PR DESCRIPTION
This has been incorrect for some time, causing nightly to fail. We
support upgrading from one version to the next, but not skipping. Thus,
the version is the current release on master, and the previous version
on release branches.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9037)
<!-- Reviewable:end -->
