### PR TITLE
Revert "Remove componentstatus from rbac"

### DIFF
--- a/install/kubernetes/cilium/charts/agent/templates/clusterrole.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/clusterrole.yaml
@@ -18,6 +18,7 @@ rules:
   - services
   - nodes
   - endpoints
+  - componentstatuses
   verbs:
   - get
   - list

--- a/install/kubernetes/cilium/charts/operator/templates/clusterrole.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/clusterrole.yaml
@@ -6,6 +6,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  # to get k8s version and status
+  - componentstatuses
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   # to automatically delete [core|kube]dns pods so that are starting to being
   # managed by Cilium
   - pods

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -170,6 +170,7 @@ rules:
   - services
   - nodes
   - endpoints
+  - componentstatuses
   verbs:
   - get
   - list
@@ -231,6 +232,13 @@ kind: ClusterRole
 metadata:
   name: cilium-operator
 rules:
+- apiGroups:
+  - ""
+  resources:
+  # to get k8s version and status
+  - componentstatuses
+  verbs:
+  - get
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
This reverts commit 0fb23b57e6fe1d6abe544024f1e248c96ab87d7b.

[1] changed the way we probe a connection to k8s api-server. The probe no longer requires the RBAC for `componentstatuses`, and therefore the relevant RBAC got removed from the v1.6 helm templates.

Unfortunately, we haven't released v1.6.1 yet, which will include the changed probing. Therefore, any user using the templates from the v1.6 branch won't be able to start cilium-agent due to the missing RBAC permissions.

We can remove the RBAC once we have release v1.6.1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9038)
<!-- Reviewable:end -->
