### PR TITLE
daemon: Improve host-lb log messages and lower kernel vsn requirement for TCP host-lb

### DIFF
--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -1203,14 +1203,14 @@ func initEnv(cmd *cobra.Command) {
 	}
 
 	if option.Config.EnableHostReachableServices {
-		// Note: probing for BPF_CGROUP_UDP{4,6}_SENDMSG instead of BPF_CGROUP_INET{4,6}_CONNECT hook since
-		// we want to catch 4.18+ and not 4.17+ kernels as they also have fib lookup helper which we require
-		// for BPF based node port.
 		if option.Config.EnableHostServicesTCP &&
-			(option.Config.EnableIPv4 && bpf.TestDummyProg(bpf.ProgTypeCgroupSockAddr, bpf.BPF_CGROUP_UDP4_SENDMSG) != nil ||
-				option.Config.EnableIPv6 && bpf.TestDummyProg(bpf.ProgTypeCgroupSockAddr, bpf.BPF_CGROUP_UDP6_SENDMSG) != nil) {
-			log.Fatal("BPF host reachable services for TCP needs kernel 4.18.0 or higher.")
+			(option.Config.EnableIPv4 && bpf.TestDummyProg(bpf.ProgTypeCgroupSockAddr, bpf.BPF_CGROUP_INET4_CONNECT) != nil ||
+				option.Config.EnableIPv6 && bpf.TestDummyProg(bpf.ProgTypeCgroupSockAddr, bpf.BPF_CGROUP_INET6_CONNECT) != nil) {
+			log.Fatal("BPF host reachable services for TCP needs kernel 4.17.0 or newer.")
 		}
+		// NOTE: as host-lb is a hard dependency for NodePort BPF, the following
+		//       probe will catch if the fib_lookup helper is missing (< 4.18),
+		//       which is another hard dependency for NodePort BPF.
 		if option.Config.EnableHostServicesUDP &&
 			(option.Config.EnableIPv4 && bpf.TestDummyProg(bpf.ProgTypeCgroupSockAddr, bpf.BPF_CGROUP_UDP4_RECVMSG) != nil ||
 				option.Config.EnableIPv6 && bpf.TestDummyProg(bpf.ProgTypeCgroupSockAddr, bpf.BPF_CGROUP_UDP6_RECVMSG) != nil) {

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -1214,7 +1214,7 @@ func initEnv(cmd *cobra.Command) {
 		if option.Config.EnableHostServicesUDP &&
 			(option.Config.EnableIPv4 && bpf.TestDummyProg(bpf.ProgTypeCgroupSockAddr, bpf.BPF_CGROUP_UDP4_RECVMSG) != nil ||
 				option.Config.EnableIPv6 && bpf.TestDummyProg(bpf.ProgTypeCgroupSockAddr, bpf.BPF_CGROUP_UDP6_RECVMSG) != nil) {
-			log.Fatal("BPF host reachable services for UDP needs kernel 4.19.57 or higher. If you run an older kernel and only need TCP, then specify: --host-reachable-services-protos=tcp")
+			log.Fatal("BPF host reachable services for UDP needs kernel 4.19.57, 5.1.16, 5.2.0 or newer. If you run an older kernel and only need TCP, then specify: --host-reachable-services-protos=tcp")
 		}
 	}
 


### PR DESCRIPTION
This PR addresses the following:

- host-lb TCP requires v4.17 kernel or newer.
- Be more specific about required versions for host-lb UDP to avoid confusion when e.g. a user runs on the kernel v5.0.0, and sees the fatal log message saying that `[..] needs kernel 4.19.57 or higher`.

Reviewable per commit.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9040)
<!-- Reviewable:end -->
