### PR TITLE
daemon: signal endpoint restore fail when waiting for global identities times out

### DIFF
--- a/daemon/state.go
+++ b/daemon/state.go
@@ -290,6 +290,7 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) (resto
 				err = cache.WaitForInitialGlobalIdentities(identityCtx)
 				if err != nil {
 					scopedLog.WithError(err).Warn("Failed while waiting for initial global identities")
+					epRegenerated <- false
 					return
 				}
 				if option.Config.KVStore != "" {


### PR DESCRIPTION
If this error case is hit (which is not common), then daemon bootstrap will hang
forever because the goroutine receiving off of the channel will never get any
values sent to it

Signed-off by: Ian Vernon <ian@cilium.io>

Fixes: #9007

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9043)
<!-- Reviewable:end -->
