### PR TITLE
RFC: Update CODEOWNERS for specific packages and files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -37,6 +37,7 @@ contrib/packaging/docker/ @aanm @ianvernon
 contrib/vagrant @cilium/ci
 daemon/ @cilium/agent
 daemon/bpf.sha @cilium/bpf
+daemon/datapath.* @cilium/bpf
 daemon/endpoint.* @cilium/endpoint
 daemon/health.* @cilium/health
 daemon/k8s_watcher.* @cilium/kubernetes
@@ -118,6 +119,7 @@ pkg/proxy/ @cilium/proxy
 pkg/proxy/accesslog @cilium/api
 pkg/serializer @cilium/agent
 pkg/service @cilium/policy
+pkg/sysctl @cilium/bpf
 pkg/tuple @cilium/bpf
 plugins/cilium-cni/ @cilium/kubernetes
 plugins/cilium-docker/ @cilium/docker


### PR DESCRIPTION
Now that `daemon` has its own `datapath.go` file, it makes sense for that to be
owned by @cilium/bpf. The same goes for `pkg/sysctl`.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9044)
<!-- Reviewable:end -->
