### PR TITLE
test: Wait for at least one Istio POD to get ready

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -643,7 +643,7 @@ func checkReady(pod v1.Pod) bool {
 	return true
 }
 
-// WaitforNPodsRunning waits up until timeout seconds have elapsed for at least
+// WaitforNPodsRunning waits up until timeout duration has elapsed for at least
 // minRequired pods in the specified namespace that match the provided JSONPath
 // filter to have their containterStatuses equal to "running".
 // Returns no error if minRequired pods achieve the aforementioned desired

--- a/test/k8sT/istio.go
+++ b/test/k8sT/istio.go
@@ -59,7 +59,6 @@ var _ = Describe("K8sIstioTest", func() {
 			// those that we care about are uncommented.
 			// "istio-citadel",
 			// "istio-galley",
-			// "istio-egressgateway",
 			"istio-ingressgateway",
 			"istio-pilot",
 			// "istio-policy",
@@ -92,7 +91,7 @@ var _ = Describe("K8sIstioTest", func() {
 		res := kubectl.NamespaceCreate(istioSystemNamespace)
 		res.ExpectSuccess("unable to create namespace %q", istioSystemNamespace)
 
-		By("Creating the Istio resources")
+		By("Creating the Istio CRDs")
 
 		res = kubectl.Apply(istioCRDYAMLPath)
 		res.ExpectSuccess("unable to create Istio CRDs")
@@ -101,6 +100,8 @@ var _ = Describe("K8sIstioTest", func() {
 		err := kubectl.WaitForCRDCount("istio.io|certmanager.k8s.io", 23, helpers.HelperTimeout)
 		Expect(err).To(BeNil(),
 			"Istio CRDs are not ready after timeout")
+
+		By("Creating the Istio system PODs")
 
 		res = kubectl.Apply(istioYAMLPath)
 		res.ExpectSuccess("unable to create Istio resources")
@@ -143,11 +144,22 @@ var _ = Describe("K8sIstioTest", func() {
 			"cilium bpf proxy list")
 	})
 
+	// This is defined as a separate function to be called from the test below
+	// so that we properly capture test artifacts if any of the assertions fail
+	// (see https://github.com/cilium/cilium/pull/8508).
 	waitIstioReady := func() {
 		// Ignore one-time jobs and Prometheus. All other pods in the
 		// namespaces have an "istio" label.
 		By("Waiting for Istio pods to be ready")
-		err := kubectl.WaitforPods(istioSystemNamespace, "-l istio", helpers.HelperTimeout)
+		// First wait for at least one POD to get into running state so that WaitforPods
+		// below does not succeed if there are no PODs with the "istio" label.
+		err := kubectl.WaitforNPodsRunning(istioSystemNamespace, "-l istio", 1, helpers.HelperTimeout)
+		ExpectWithOffset(1, err).To(BeNil(),
+			"No Istio POD is Running after timeout in namespace %q", istioSystemNamespace)
+
+		// Then wait for all the Istio PODs to get Ready
+		// Note that this succeeds if there are no PODs matching the filter (-l istio -n istio-system).
+		err = kubectl.WaitforPods(istioSystemNamespace, "-l istio", helpers.HelperTimeout)
 		ExpectWithOffset(1, err).To(BeNil(),
 			"Istio pods are not ready after timeout in namespace %q", istioSystemNamespace)
 


### PR DESCRIPTION
WaitforPods() succeeds if there are no PODs matching the given filter
("-l istio" in this case). Wait for at least one Istio POD to get
Running before waiting for all of them to get Ready.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9049)
<!-- Reviewable:end -->
