### PR TITLE
Clean up reference counting of ipcache prefix lengths

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -661,10 +661,8 @@ func (d *Daemon) syncEndpointsAndHostIPs() error {
 // createPrefixLengthCounter wraps around the counter library, providing
 // references to prefix lengths that will always be present.
 func createPrefixLengthCounter() *counter.PrefixLengthCounter {
-	prefixLengths4 := ipcachemap.IPCache.GetMaxPrefixLengths(false)
-	prefixLengths6 := ipcachemap.IPCache.GetMaxPrefixLengths(true)
-
-	return counter.DefaultPrefixLengthCounter(prefixLengths4, prefixLengths6)
+	max6, max4 := ipcachemap.IPCache.GetMaxPrefixLengths()
+	return counter.DefaultPrefixLengthCounter(max6, max4)
 }
 
 type rulesManager interface {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -658,35 +658,13 @@ func (d *Daemon) syncEndpointsAndHostIPs() error {
 	return nil
 }
 
-func createIPNet(ones, bits int) *net.IPNet {
-	return &net.IPNet{
-		Mask: net.CIDRMask(ones, bits),
-	}
-}
-
 // createPrefixLengthCounter wraps around the counter library, providing
 // references to prefix lengths that will always be present.
 func createPrefixLengthCounter() *counter.PrefixLengthCounter {
 	prefixLengths4 := ipcachemap.IPCache.GetMaxPrefixLengths(false)
 	prefixLengths6 := ipcachemap.IPCache.GetMaxPrefixLengths(true)
-	counter := counter.NewPrefixLengthCounter(prefixLengths6, prefixLengths4)
 
-	// This is a bit ugly, but there's not a great way to define an IPNet
-	// without parsing strings, etc.
-	defaultPrefixes := []*net.IPNet{
-		// IPv4
-		createIPNet(0, net.IPv4len*8),             // world
-		createIPNet(net.IPv4len*8, net.IPv4len*8), // hosts
-
-		// IPv6
-		createIPNet(0, net.IPv6len*8),             // world
-		createIPNet(net.IPv6len*8, net.IPv6len*8), // hosts
-	}
-	_, err := counter.Add(defaultPrefixes)
-	if err != nil {
-		log.WithError(err).Fatal("Failed to create default prefix lengths")
-	}
-	return counter
+	return counter.DefaultPrefixLengthCounter(prefixLengths4, prefixLengths6)
 }
 
 type rulesManager interface {

--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -43,7 +43,6 @@ import (
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	bpfIPCache "github.com/cilium/cilium/pkg/maps/ipcache"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
@@ -1176,7 +1175,7 @@ func (d *Daemon) k8sServiceHandler() {
 			// corresponding external service for any toServices rules which
 			// select said service.
 			if !cacheOK || (cacheOK && serviceImportMeta.ruleTranslationError != nil) {
-				translator := k8s.NewK8sTranslator(event.ID, *event.Endpoints, false, svc.Labels, bpfIPCache.IPCache)
+				translator := k8s.NewK8sTranslator(event.ID, *event.Endpoints, false, svc.Labels, true)
 				result, err := d.policy.TranslateRules(translator)
 				endpointMetadataCache.upsert(event.ID, err)
 				if err != nil {
@@ -1201,7 +1200,7 @@ func (d *Daemon) k8sServiceHandler() {
 
 			endpointMetadataCache.delete(event.ID)
 
-			translator := k8s.NewK8sTranslator(event.ID, *event.Endpoints, true, svc.Labels, bpfIPCache.IPCache)
+			translator := k8s.NewK8sTranslator(event.ID, *event.Endpoints, true, svc.Labels, true)
 			result, err := d.policy.TranslateRules(translator)
 			if err != nil {
 				log.Errorf("Unable to depopulate egress policies from ToService rules: %v", err)

--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -300,7 +300,7 @@ func (d *Daemon) policyAdd(sourceRules policyAPI.Rules, opts *AddOptions, resCha
 		}
 	}
 
-	if _, err := ipcache.AllocateCIDRs(bpfIPCache.IPCache, prefixes); err != nil {
+	if _, err := ipcache.AllocateCIDRs(prefixes); err != nil {
 		_ = d.prefixLengths.Delete(prefixes)
 		metrics.PolicyImportErrors.Inc()
 		logger.WithError(err).WithField("prefixes", prefixes).Warn(

--- a/pkg/counter/prefixes_test.go
+++ b/pkg/counter/prefixes_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -203,4 +203,16 @@ func (cs *CounterTestSuite) TestToBPFData(c *C) {
 	s6, s4 := result.ToBPFData()
 	c.Assert(s6, checker.DeepEquals, []int{})
 	c.Assert(s4, checker.DeepEquals, []int{32, 24, 20})
+}
+
+func (cs *CounterTestSuite) TestDefaultPrefixLengthCounter(c *C) {
+	defer func() {
+		r := recover()
+		c.Assert(r, IsNil)
+	}()
+	result := DefaultPrefixLengthCounter(net.IPv6len*8, net.IPv4len*8)
+	c.Assert(result.v4[0], Equals, 1)
+	c.Assert(result.v6[0], Equals, 1)
+	c.Assert(result.v4[net.IPv4len*8], Equals, 1)
+	c.Assert(result.v6[net.IPv6len*8], Equals, 1)
 }

--- a/pkg/ipcache/cidr.go
+++ b/pkg/ipcache/cidr.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -32,12 +32,7 @@ import (
 // allocation fails, all allocations are rolled back and the error is returned.
 // When an identity is freshly allocated for a CIDR, it is added to the
 // ipcache.
-func AllocateCIDRs(impl Implementation, prefixes []*net.IPNet) ([]*identity.Identity, error) {
-	// First, if the implementation will complain, exit early.
-	if err := checkPrefixes(impl, prefixes); err != nil {
-		return nil, err
-	}
-
+func AllocateCIDRs(prefixes []*net.IPNet) ([]*identity.Identity, error) {
 	return allocateCIDRs(prefixes)
 }
 

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -66,13 +66,6 @@ type IPCache struct {
 	listeners []IPIdentityMappingListener
 }
 
-// Implementation represents a concrete datapath implementation of the IPCache
-// which may restrict the ability to apply IPCache mappings, depending on the
-// underlying details of that implementation.
-type Implementation interface {
-	GetMaxPrefixLengths(ipv6 bool) int
-}
-
 // NewIPCache returns a new IPCache with the mappings of endpoint IP to security
 // identity (and vice-versa) initialized.
 func NewIPCache() *IPCache {

--- a/pkg/k8s/rule_translate.go
+++ b/pkg/k8s/rule_translate.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -127,7 +127,7 @@ func generateToCidrFromEndpoint(
 		if err != nil {
 			return err
 		}
-		if _, err := ipcache.AllocateCIDRs(impl, prefixes); err != nil {
+		if _, err := ipcache.AllocateCIDRs(prefixes); err != nil {
 			return err
 		}
 	}

--- a/pkg/k8s/rule_translate_test.go
+++ b/pkg/k8s/rule_translate_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -65,7 +65,7 @@ func (s *K8sSuite) TestTranslatorDirect(c *C) {
 		Labels: tag1,
 	}
 
-	translator := NewK8sTranslator(serviceInfo, endpointInfo, false, map[string]string{}, nil)
+	translator := NewK8sTranslator(serviceInfo, endpointInfo, false, map[string]string{}, false)
 
 	_, _, err := repo.Add(rule1, []policy.Endpoint{})
 	c.Assert(err, IsNil)
@@ -79,7 +79,7 @@ func (s *K8sSuite) TestTranslatorDirect(c *C) {
 	c.Assert(len(rule.ToCIDRSet), Equals, 1)
 	c.Assert(string(rule.ToCIDRSet[0].Cidr), Equals, epIP+"/32")
 
-	translator = NewK8sTranslator(serviceInfo, endpointInfo, true, map[string]string{}, nil)
+	translator = NewK8sTranslator(serviceInfo, endpointInfo, true, map[string]string{}, false)
 	result, err = repo.TranslateRules(translator)
 	c.Assert(result.NumToServicesRules, Equals, 1)
 
@@ -119,7 +119,7 @@ func (s *K8sSuite) TestServiceMatches(c *C) {
 		},
 	}
 
-	translator := NewK8sTranslator(serviceInfo, endpointInfo, false, svcLabels, nil)
+	translator := NewK8sTranslator(serviceInfo, endpointInfo, false, svcLabels, false)
 	c.Assert(translator.serviceMatches(service), Equals, true)
 }
 
@@ -164,7 +164,7 @@ func (s *K8sSuite) TestTranslatorLabels(c *C) {
 		Labels: tag1,
 	}
 
-	translator := NewK8sTranslator(serviceInfo, endpointInfo, false, svcLabels, nil)
+	translator := NewK8sTranslator(serviceInfo, endpointInfo, false, svcLabels, false)
 
 	_, _, err := repo.Add(rule1, []policy.Endpoint{})
 	c.Assert(err, IsNil)
@@ -178,7 +178,7 @@ func (s *K8sSuite) TestTranslatorLabels(c *C) {
 	c.Assert(len(rule.ToCIDRSet), Equals, 1)
 	c.Assert(string(rule.ToCIDRSet[0].Cidr), Equals, epIP+"/32")
 
-	translator = NewK8sTranslator(serviceInfo, endpointInfo, true, svcLabels, nil)
+	translator = NewK8sTranslator(serviceInfo, endpointInfo, true, svcLabels, false)
 	result, err = repo.TranslateRules(translator)
 
 	rule = repo.SearchRLocked(tag1)[0].Egress[0]
@@ -204,20 +204,20 @@ func (s *K8sSuite) TestGenerateToCIDRFromEndpoint(c *C) {
 		},
 	}
 
-	err := generateToCidrFromEndpoint(rule, endpointInfo, nil)
+	err := generateToCidrFromEndpoint(rule, endpointInfo, false)
 	c.Assert(err, IsNil)
 
 	c.Assert(len(rule.ToCIDRSet), Equals, 1)
 	c.Assert(string(rule.ToCIDRSet[0].Cidr), Equals, epIP+"/32")
 
 	// second run, to make sure there are no duplicates added
-	err = generateToCidrFromEndpoint(rule, endpointInfo, nil)
+	err = generateToCidrFromEndpoint(rule, endpointInfo, false)
 	c.Assert(err, IsNil)
 
 	c.Assert(len(rule.ToCIDRSet), Equals, 1)
 	c.Assert(string(rule.ToCIDRSet[0].Cidr), Equals, epIP+"/32")
 
-	err = deleteToCidrFromEndpoint(rule, endpointInfo, nil)
+	err = deleteToCidrFromEndpoint(rule, endpointInfo, false)
 	c.Assert(err, IsNil)
 	c.Assert(len(rule.ToCIDRSet), Equals, 0)
 }
@@ -301,20 +301,20 @@ func (s *K8sSuite) TestDontDeleteUserRules(c *C) {
 		},
 	}
 
-	err := generateToCidrFromEndpoint(rule, endpointInfo, nil)
+	err := generateToCidrFromEndpoint(rule, endpointInfo, false)
 	c.Assert(err, IsNil)
 
 	c.Assert(len(rule.ToCIDRSet), Equals, 2)
 	c.Assert(string(rule.ToCIDRSet[1].Cidr), Equals, epIP+"/32")
 
 	// second run, to make sure there are no duplicates added
-	err = generateToCidrFromEndpoint(rule, endpointInfo, nil)
+	err = generateToCidrFromEndpoint(rule, endpointInfo, false)
 	c.Assert(err, IsNil)
 
 	c.Assert(len(rule.ToCIDRSet), Equals, 2)
 	c.Assert(string(rule.ToCIDRSet[1].Cidr), Equals, epIP+"/32")
 
-	err = deleteToCidrFromEndpoint(rule, endpointInfo, nil)
+	err = deleteToCidrFromEndpoint(rule, endpointInfo, false)
 	c.Assert(err, IsNil)
 	c.Assert(len(rule.ToCIDRSet), Equals, 1)
 	c.Assert(string(rule.ToCIDRSet[0].Cidr), Equals, string(userCIDR))

--- a/pkg/maps/ipcache/ipcache.go
+++ b/pkg/maps/ipcache/ipcache.go
@@ -202,18 +202,11 @@ func (m *Map) Delete(k bpf.MapKey) error {
 
 // GetMaxPrefixLengths determines how many unique prefix lengths are supported
 // simultaneously based on the underlying BPF map type in use.
-func (m *Map) GetMaxPrefixLengths(ipv6 bool) (count int) {
+func (m *Map) GetMaxPrefixLengths() (ipv6, ipv4 int) {
 	if IPCache.MapType == bpf.BPF_MAP_TYPE_LPM_TRIE {
-		if ipv6 {
-			return net.IPv6len*8 + 1
-		} else {
-			return net.IPv4len*8 + 1
-		}
+		return net.IPv6len*8 + 1, net.IPv4len*8 + 1
 	}
-	if ipv6 {
-		return maxPrefixLengths6
-	}
-	return maxPrefixLengths4
+	return maxPrefixLengths6, maxPrefixLengths4
 }
 
 func (m *Map) supportsDelete() bool {


### PR DESCRIPTION
* The daemon has a reference counter for prefixes. Refactor common code to `pkg/counter` and test it.
* The k8s service translation only generates full IPs. We always count such prefixes, so no need to reference count prefixes in the ipcache.
* The ipcache reference counted prefixes even though the only users were the daemon (with its own reference counting of prefixes for handling implementation limitations) and the service translation layer (which doesn't need reference counting).

Refactor and delete unnecessary code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9050)
<!-- Reviewable:end -->
