### PR TITLE
daemon: Improve logging for auto-enabling host-lb

### DIFF
--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -1184,9 +1184,12 @@ func initEnv(cmd *cobra.Command) {
 		}
 	}
 
-	if option.Config.EnableNodePort {
+	if option.Config.EnableNodePort &&
+		!(option.Config.EnableHostReachableServices &&
+			option.Config.EnableHostServicesTCP && option.Config.EnableHostServicesUDP) {
 		// We enable host reachable services in order to allow
 		// access to node port services from the host.
+		log.Info("Auto-enabling host reachable services for UDP and TCP as required by BPF NodePort.")
 		option.Config.EnableHostReachableServices = true
 		option.Config.EnableHostServicesTCP = true
 		option.Config.EnableHostServicesUDP = true


### PR DESCRIPTION
The log statement makes it explicit that host-lb TCP and UDP is required when BPF NodePort is enabled, and therefore is auto-enabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9053)
<!-- Reviewable:end -->
