### PR TITLE
Revert "Remove componentstatus from rbac"

### DIFF
--- a/install/kubernetes/cilium/charts/agent/templates/clusterrole.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/clusterrole.yaml
@@ -18,6 +18,7 @@ rules:
   - services
   - nodes
   - endpoints
+  - componentstatuses
   verbs:
   - get
   - list

--- a/install/kubernetes/cilium/charts/operator/templates/clusterrole.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/clusterrole.yaml
@@ -6,6 +6,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  # to get k8s version and status
+  - componentstatuses
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   # to automatically delete [core|kube]dns pods so that are starting to being
   # managed by Cilium
   - pods

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -170,6 +170,7 @@ rules:
   - services
   - nodes
   - endpoints
+  - componentstatuses
   verbs:
   - get
   - list
@@ -231,6 +232,13 @@ kind: ClusterRole
 metadata:
   name: cilium-operator
 rules:
+- apiGroups:
+  - ""
+  resources:
+  # to get k8s version and status
+  - componentstatuses
+  verbs:
+  - get
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
This reverts commit dfd389f223c03a6bb593b2cb61f6c0ada18636c2.

Unfortunately, we cannot remove the `componentstatuses` RBAC from the master branch templates until we have released v1.6.1, as the kube-proxy-free getting started guide uses the templates from the master.

Keeping access to `namespaces` in place, as this is required by the current k8s client probing mechanism.

I will undo the revert once we have released v1.6.1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9054)
<!-- Reviewable:end -->
