### PR TITLE
docs: Update source branch in kube-proxy-free guide

### DIFF
--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -52,9 +52,9 @@ install directory:
 
 .. code:: bash
 
-    curl -LO https://github.com/cilium/cilium/archive/master.tar.gz
-    tar xzvf cilium-master.tar.gz
-    cd cilium-master/install/kubernetes
+    curl -LO https://github.com/cilium/cilium/archive/v1.6.tar.gz
+    tar xzvf v1.6.tar.gz
+    cd cilium-1.6/install/kubernetes
 
 `Install Helm <https://helm.sh/docs/using_helm/#install-helm>`__ to prepare generating
 the deployment artifacts based on the Helm templates.


### PR DESCRIPTION
Switch to v1.6, because:

1. https://github.com/cilium/cilium/pull/8995 got backported to the v1.6.
2. The templates from the master branch cannot be used with the v1.6.0 image due to removed RBAC for `componentstatuses`.

Once v1.6.1 is released, we can just include `k8s-install-download-release.rst`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9055)
<!-- Reviewable:end -->
