### PR TITLE
Correct Contributing link in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -281,7 +281,7 @@ under the `General Public License, Version 2.0 <bpf/COPYING>`_.
 .. _`Architecture and Concepts`: http://docs.cilium.io/en/stable/concepts/
 .. _`Installing Cilium`: http://docs.cilium.io/en/stable/gettingstarted/#installation
 .. _`Frequently Asked Questions`: https://github.com/cilium/cilium/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3Akind%2Fquestion+
-.. _Contributing: http://docs.cilium.io/en/stable/contributing
+.. _Contributing: http://docs.cilium.io/en/stable/contributing/contributing/
 .. _Prerequisites: http://docs.cilium.io/en/doc-1.0/install/system_requirements
 .. _`BPF and XDP Reference Guide`: http://docs.cilium.io/en/stable/bpf/
 


### PR DESCRIPTION
I was looking at getting involved, and noticed the contributing link in README.rst is broken, this pull request corrects that. I am not sure if I should have filed an issue first, then submitted a pull request to fix it, if so I am happy to update it but this seemed like less overheard to a very simple fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9060)
<!-- Reviewable:end -->
