### PR TITLE
cilium: encryption, add CI test for auto discovery of interface

### DIFF
--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -191,6 +191,17 @@ var _ = Describe("K8sDatapathConfig", func() {
 			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
 			cleanService()
 		})
+		It("Check connectivity with transparent encryption, auto-interface, and direct routing", func() {
+			SkipIfFlannel()
+
+			deployCilium([]string{
+				"--set global.tunnel=disabled",
+				"--set global.autoDirectNodeRoutes=true",
+				"--set global.encryption.enabled=true",
+			})
+			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
+			cleanService()
+		})
 	})
 
 	Context("IPv4Only", func() {


### PR DESCRIPTION
Adds a CI test for direct routing without the interface being specified.

Signed-off-by: John Fastabend <john.fastabend@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9061)
<!-- Reviewable:end -->
