### PR TITLE
CI: decouple HTTP and DNS testing in K8sPolicyTest

### DIFF
--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -111,13 +111,13 @@ var _ = Describe("K8sPolicyTest", func() {
 
 		validateConnectivity := func(expectWorldSuccess, expectClusterSuccess bool) {
 			for _, pod := range []string{appPods[helpers.App2], appPods[helpers.App3]} {
-				By("HTTP connectivity to google.com")
+				By("HTTP connectivity to 1.1.1.1")
 				res := kubectl.ExecPodCmd(
 					namespaceForTest, pod,
-					helpers.CurlFail("http://www.google.com/"))
+					helpers.CurlFail("http://1.1.1.1/"))
 
 				ExpectWithOffset(1, res).To(getMatcher(expectWorldSuccess),
-					"HTTP egress connectivity to google.com from pod %q", pod)
+					"HTTP egress connectivity to 1.1.1.1 from pod %q", pod)
 
 				By("ICMP connectivity to 8.8.8.8")
 				res = kubectl.ExecPodCmd(
@@ -387,7 +387,7 @@ var _ = Describe("K8sPolicyTest", func() {
 			for _, pod := range []string{appPods[helpers.App2], appPods[helpers.App3]} {
 				res := kubectl.ExecPodCmd(
 					namespaceForTest, pod,
-					helpers.CurlFail("http://www.google.com/"))
+					helpers.CurlFail("http://1.1.1.1/"))
 				res.ExpectFail("Egress connectivity should be denied for pod %q", pod)
 
 				res = kubectl.ExecPodCmd(
@@ -414,7 +414,7 @@ var _ = Describe("K8sPolicyTest", func() {
 			for _, pod := range []string{appPods[helpers.App2], appPods[helpers.App3]} {
 				res := kubectl.ExecPodCmd(
 					namespaceForTest, pod,
-					helpers.CurlFail("http://www.google.com/"))
+					helpers.CurlFail("http://1.1.1.1/"))
 				res.ExpectFail("Egress connectivity should be denied for pod %q", pod)
 
 				res = kubectl.ExecPodCmd(
@@ -474,7 +474,7 @@ var _ = Describe("K8sPolicyTest", func() {
 			for _, pod := range apps {
 				res := kubectl.ExecPodCmd(
 					namespaceForTest, pod,
-					helpers.CurlFail("http://www.google.com/"))
+					helpers.CurlFail("http://1.1.1.1/"))
 				res.ExpectFail("Egress connectivity should be denied for pod %q", pod)
 
 				res = kubectl.ExecPodCmd(
@@ -520,7 +520,7 @@ var _ = Describe("K8sPolicyTest", func() {
 			for _, pod := range []string{appPods[helpers.App2], appPods[helpers.App3]} {
 				res := kubectl.ExecPodCmd(
 					namespaceForTest, pod,
-					helpers.CurlFail("http://www.google.com/"))
+					helpers.CurlFail("http://1.1.1.1/"))
 				res.ExpectSuccess("Egress connectivity should be allowed for pod %q", pod)
 
 				res = kubectl.ExecPodCmd(

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -127,14 +127,14 @@ var _ = Describe("K8sPolicyTest", func() {
 				ExpectWithOffset(1, res).To(getMatcher(expectWorldSuccess),
 					"ICMP egress connectivity to 8.8.8.8 from pod %q", pod)
 
-				By("DNS lookup of google.com")
+				By("DNS lookup of kubernetes.default.svc.cluster.local")
 				res = kubectl.ExecPodCmd(
 					namespaceForTest, pod,
-					"host -v www.google.com")
+					"host -v kubernetes.default.svc.cluster.local")
 
 				// kube-dns is always whitelisted so this should always work
 				ExpectWithOffset(1, res).To(getMatcher(expectWorldSuccess || expectClusterSuccess),
-					"DNS connectivity of www.google.com from pod %q", pod)
+					"DNS connectivity of kubernetes.default.svc.cluster.local from pod %q", pod)
 
 				By("HTTP connectivity from pod to pod")
 				res = kubectl.ExecPodCmd(
@@ -397,7 +397,7 @@ var _ = Describe("K8sPolicyTest", func() {
 
 				res = kubectl.ExecPodCmd(
 					namespaceForTest, pod,
-					"host www.google.com")
+					"host kubernetes.default.svc.cluster.local")
 				res.ExpectFail("Egress DNS connectivity should be denied for pod %q", pod)
 			}
 		})
@@ -424,7 +424,7 @@ var _ = Describe("K8sPolicyTest", func() {
 
 				res = kubectl.ExecPodCmd(
 					namespaceForTest, pod,
-					"host www.google.com")
+					"host kubernetes.default.svc.cluster.local")
 				res.ExpectFail("Egress DNS connectivity should be denied for pod %q", pod)
 			}
 
@@ -484,7 +484,7 @@ var _ = Describe("K8sPolicyTest", func() {
 
 				res = kubectl.ExecPodCmd(
 					namespaceForTest, pod,
-					"host www.google.com")
+					"host kubernetes.default.svc.cluster.local")
 				res.ExpectFail("Egress DNS connectivity should be denied for pod %q", pod)
 			}
 		})
@@ -530,7 +530,7 @@ var _ = Describe("K8sPolicyTest", func() {
 
 				res = kubectl.ExecPodCmd(
 					namespaceForTest, pod,
-					"host www.google.com")
+					"host kubernetes.default.svc.cluster.local")
 				res.ExpectSuccess("Egress DNS connectivity should be allowed for pod %q", pod)
 			}
 		})


### PR DESCRIPTION
We previously implicitly tested pod-DNS lookup while connecting to
www.google.com. Switching to 1.1.1.1 sidesteps the DNS lookup so that a
failure here can only be related to the actual connection, not to the
DNS behaviour of the pod or the cluster DNS server.

We ruined our all-green streak in the CI pipeline test in https://jenkins.cilium.io/job/Ginkgo-CI-Tests-Pipeline/8377/testReport/junit/Suite-k8s-1/15/K8sPolicyTest_Basic_Test_Validate_to_entities_policies_Validate_toEntities_World/ and this is an attempt to remove DNS from the equation since that seems to be the source of the timeout here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9063)
<!-- Reviewable:end -->
