### PR TITLE
identity: create `CachingIdentityAllocator ` type

### DIFF
--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	healthDefaults "github.com/cilium/cilium/pkg/health/defaults"
 	"github.com/cilium/cilium/pkg/health/probe"
+	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/launcher"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -234,7 +235,7 @@ type EndpointAdder interface {
 //
 // CleanupEndpoint() must be called before calling LaunchAsEndpoint() to ensure
 // cleanup of prior cilium-health endpoint instances.
-func LaunchAsEndpoint(baseCtx context.Context, owner regeneration.Owner, n *node.Node, mtuConfig mtu.Configuration, epMgr EndpointAdder, proxy endpoint.EndpointProxy) (*Client, error) {
+func LaunchAsEndpoint(baseCtx context.Context, owner regeneration.Owner, n *node.Node, mtuConfig mtu.Configuration, epMgr EndpointAdder, proxy endpoint.EndpointProxy, allocator cache.IdentityAllocator) (*Client, error) {
 	var (
 		cmd  = launcher.Launcher{}
 		info = &models.EndpointChangeRequest{
@@ -312,7 +313,7 @@ func LaunchAsEndpoint(baseCtx context.Context, owner regeneration.Owner, n *node
 	}
 
 	// Create the endpoint
-	ep, err := endpoint.NewEndpointFromChangeModel(owner, proxy, info)
+	ep, err := endpoint.NewEndpointFromChangeModel(owner, proxy, allocator, info)
 	if err != nil {
 		return nil, fmt.Errorf("Error while creating endpoint model: %s", err)
 	}

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -43,7 +43,6 @@ import (
 	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/flowdebug"
 	"github.com/cilium/cilium/pkg/identity"
-	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/labels"
@@ -925,7 +924,7 @@ func initEnv(cmd *cobra.Command) {
 
 	policy.SetPolicyEnabled(option.Config.EnablePolicy)
 
-	if err := cache.AddUserDefinedNumericIdentitySet(option.Config.FixedIdentityMapping); err != nil {
+	if err := identity.AddUserDefinedNumericIdentitySet(option.Config.FixedIdentityMapping); err != nil {
 		log.Fatalf("Invalid fixed identities provided: %s", err)
 	}
 
@@ -1381,7 +1380,7 @@ func (d *Daemon) instantiateAPI() *restapi.CiliumAPI {
 
 	// /identity/
 	api.PolicyGetIdentityHandler = newGetIdentityHandler(d)
-	api.PolicyGetIdentityIDHandler = newGetIdentityIDHandler(d)
+	api.PolicyGetIdentityIDHandler = newGetIdentityIDHandler(d.identityAllocator)
 
 	// /identity/endpoints
 	api.PolicyGetIdentityEndpointsHandler = newGetIdentityEndpointsIDHandler(d)

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
@@ -144,7 +145,9 @@ func (ds *DaemonSuite) TearDownTest(c *C) {
 
 	// Release the identity allocator reference created by NewDaemon. This
 	// is done manually here as we have no Close() function daemon
-	cache.Close()
+	ds.d.identityAllocator.Close()
+
+	identitymanager.RemoveAll()
 
 	ds.d.Close()
 }

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -179,7 +179,7 @@ func (d *Daemon) createEndpoint(ctx context.Context, epTemplate *models.Endpoint
 		epTemplate.DatapathConfiguration.RequireRouting = &disabled
 	}
 
-	ep, err := endpoint.NewEndpointFromChangeModel(d, d.l7Proxy, epTemplate)
+	ep, err := endpoint.NewEndpointFromChangeModel(d, d.l7Proxy, d.identityAllocator, epTemplate)
 	if err != nil {
 		return invalidDataError(ep, fmt.Errorf("unable to parse endpoint parameters: %s", err))
 	}
@@ -362,7 +362,7 @@ func (h *patchEndpointID) Handle(params PatchEndpointIDParams) middleware.Respon
 
 	// Validate the template. Assignment afterwards is atomic.
 	// Note: newEp's labels are ignored.
-	newEp, err2 := endpoint.NewEndpointFromChangeModel(h.d, h.d.l7Proxy, epTemplate)
+	newEp, err2 := endpoint.NewEndpointFromChangeModel(h.d, h.d.l7Proxy, h.d.identityAllocator, epTemplate)
 	if err2 != nil {
 		return api.Error(PutEndpointIDInvalidCode, err2)
 	}

--- a/daemon/fqdn.go
+++ b/daemon/fqdn.go
@@ -64,7 +64,7 @@ const (
 	metricErrorAllow   = "allow"
 )
 
-func identitiesForFQDNSelectorIPs(selectorsWithIPsToUpdate map[policyApi.FQDNSelector][]net.IP) (map[policyApi.FQDNSelector][]*identity.Identity, error) {
+func identitiesForFQDNSelectorIPs(selectorsWithIPsToUpdate map[policyApi.FQDNSelector][]net.IP, identityAllocator *secIDCache.CachingIdentityAllocator) (map[policyApi.FQDNSelector][]*identity.Identity, error) {
 	var err error
 
 	// Used to track identities which are allocated in calls to
@@ -82,7 +82,7 @@ func identitiesForFQDNSelectorIPs(selectorsWithIPsToUpdate map[policyApi.FQDNSel
 		}).Debug("getting identities for IPs associated with FQDNSelector")
 		var currentlyAllocatedIdentities []*identity.Identity
 		if currentlyAllocatedIdentities, err = ipcache.AllocateCIDRsForIPs(selectorIPs); err != nil {
-			secIDCache.ReleaseSlice(context.TODO(), nil, usedIdentities)
+			identityAllocator.ReleaseSlice(context.TODO(), nil, usedIdentities)
 			log.WithError(err).WithField("prefixes", selectorIPs).Warn(
 				"failed to allocate identities for IPs")
 			return nil, err
@@ -252,7 +252,7 @@ func (d *Daemon) bootstrapFQDN(restoredEndpoints *endpointRestoreState, preCache
 func (d *Daemon) updateSelectors(ctx context.Context, selectorWithIPsToUpdate map[policyApi.FQDNSelector][]net.IP, selectorsWithoutIPs []policyApi.FQDNSelector) (wg *sync.WaitGroup, err error) {
 	// Convert set of selectors with IPs to update to set of selectors
 	// with identities corresponding to said IPs.
-	selectorsIdentities, err := identitiesForFQDNSelectorIPs(selectorWithIPsToUpdate)
+	selectorsIdentities, err := identitiesForFQDNSelectorIPs(selectorWithIPsToUpdate, d.identityAllocator)
 	if err != nil {
 		return &sync.WaitGroup{}, err
 	}
@@ -450,7 +450,7 @@ func (d *Daemon) notifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epI
 					Port:         uint16(serverPort),
 				}
 			} else if serverSecID, exists := ipcache.IPIdentityCache.LookupByIP(serverIP); exists {
-				secID := secIDCache.LookupIdentityByID(serverSecID.ID)
+				secID := d.identityAllocator.LookupIdentityByID(serverSecID.ID)
 				// TODO: handle IPv6
 				lr.LogRecord.DestinationEndpoint = accesslog.EndpointInfo{
 					IPv4: serverIP,

--- a/daemon/health.go
+++ b/daemon/health.go
@@ -76,7 +76,7 @@ func (d *Daemon) initHealth() {
 				if client == nil || err != nil {
 					var launchErr error
 					d.cleanupHealthEndpoint()
-					client, launchErr = health.LaunchAsEndpoint(ctx, d, &d.nodeDiscovery.LocalNode, d.mtuConfig, d.endpointManager, d.l7Proxy)
+					client, launchErr = health.LaunchAsEndpoint(ctx, d, &d.nodeDiscovery.LocalNode, d.mtuConfig, d.endpointManager, d.l7Proxy, d.identityAllocator)
 					if launchErr != nil {
 						if err != nil {
 							return fmt.Errorf("failed to restart endpoint (check failed: %q): %s", err, launchErr)

--- a/daemon/identity.go
+++ b/daemon/identity.go
@@ -26,9 +26,11 @@ import (
 	"github.com/go-openapi/runtime/middleware"
 )
 
-type getIdentity struct{}
+type getIdentity struct {
+	d *Daemon
+}
 
-func newGetIdentityHandler(d *Daemon) GetIdentityHandler { return &getIdentity{} }
+func newGetIdentityHandler(d *Daemon) GetIdentityHandler { return &getIdentity{d: d} }
 
 func (h *getIdentity) Handle(params GetIdentityParams) middleware.Responder {
 	log.WithField(logfields.Params, logfields.Repr(params)).Debug("GET /identity request")
@@ -37,9 +39,9 @@ func (h *getIdentity) Handle(params GetIdentityParams) middleware.Responder {
 	if params.Labels == nil {
 		// if labels is nil, return all identities from the kvstore
 		// This is in response to "identity list" command
-		identities = cache.GetIdentities()
+		identities = h.d.identityAllocator.GetIdentities()
 	} else {
-		identity := cache.LookupIdentity(labels.NewLabelsFromModel(params.Labels))
+		identity := h.d.identityAllocator.LookupIdentity(labels.NewLabelsFromModel(params.Labels))
 		if identity == nil {
 			return NewGetIdentityIDNotFound()
 		}
@@ -50,9 +52,13 @@ func (h *getIdentity) Handle(params GetIdentityParams) middleware.Responder {
 	return NewGetIdentityOK().WithPayload(identities)
 }
 
-type getIdentityID struct{}
+type getIdentityID struct {
+	c *cache.CachingIdentityAllocator
+}
 
-func newGetIdentityIDHandler(d *Daemon) GetIdentityIDHandler { return &getIdentityID{} }
+func newGetIdentityIDHandler(c *cache.CachingIdentityAllocator) GetIdentityIDHandler {
+	return &getIdentityID{c: c}
+}
 
 func (h *getIdentityID) Handle(params GetIdentityIDParams) middleware.Responder {
 	nid, err := identity.ParseNumericIdentity(params.ID)
@@ -60,7 +66,7 @@ func (h *getIdentityID) Handle(params GetIdentityIDParams) middleware.Responder 
 		return NewGetIdentityIDBadRequest()
 	}
 
-	identity := cache.LookupIdentityByID(nid)
+	identity := h.c.LookupIdentityByID(nid)
 	if identity == nil {
 		return NewGetIdentityIDNotFound()
 	}

--- a/daemon/k8s_watcher_test.go
+++ b/daemon/k8s_watcher_test.go
@@ -74,11 +74,11 @@ func (ds *DaemonSuite) Test_addCiliumNetworkPolicyV2(c *C) {
 							},
 						},
 					},
-					repo: policy.NewPolicyRepository(),
+					repo: policy.NewPolicyRepository(nil),
 				}
 			},
 			setupWanted: func() wanted {
-				r := policy.NewPolicyRepository()
+				r := policy.NewPolicyRepository(nil)
 				r.AddList(api.Rules{
 					api.NewRule().
 						WithEndpointSelector(api.EndpointSelector{
@@ -107,7 +107,7 @@ func (ds *DaemonSuite) Test_addCiliumNetworkPolicyV2(c *C) {
 		{
 			name: "have a rule with user labels and update it without user labels, all other rules should be deleted",
 			setupArgs: func() args {
-				r := policy.NewPolicyRepository()
+				r := policy.NewPolicyRepository(nil)
 				lbls := utils.GetPolicyLabels("production", "db", uuid, utils.ResourceTypeCiliumNetworkPolicy)
 				lbls = append(lbls, labels.ParseLabelArray("foo=bar")...).Sort()
 				r.AddList(api.Rules{
@@ -150,7 +150,7 @@ func (ds *DaemonSuite) Test_addCiliumNetworkPolicyV2(c *C) {
 				}
 			},
 			setupWanted: func() wanted {
-				r := policy.NewPolicyRepository()
+				r := policy.NewPolicyRepository(nil)
 				r.AddList(api.Rules{
 					api.NewRule().
 						WithEndpointSelector(api.EndpointSelector{
@@ -179,7 +179,7 @@ func (ds *DaemonSuite) Test_addCiliumNetworkPolicyV2(c *C) {
 		{
 			name: "have a rule without user labels and update it with user labels, all other rules should be deleted",
 			setupArgs: func() args {
-				r := policy.NewPolicyRepository()
+				r := policy.NewPolicyRepository(nil)
 				r.AddList(api.Rules{
 					{
 						EndpointSelector: api.EndpointSelector{
@@ -221,7 +221,7 @@ func (ds *DaemonSuite) Test_addCiliumNetworkPolicyV2(c *C) {
 				}
 			},
 			setupWanted: func() wanted {
-				r := policy.NewPolicyRepository()
+				r := policy.NewPolicyRepository(nil)
 				lbls := utils.GetPolicyLabels("production", "db", uuid, utils.ResourceTypeCiliumNetworkPolicy)
 				lbls = append(lbls, labels.ParseLabelArray("foo=bar")...).Sort()
 				r.AddList(api.Rules{
@@ -247,7 +247,7 @@ func (ds *DaemonSuite) Test_addCiliumNetworkPolicyV2(c *C) {
 		{
 			name: "have a rule policy installed with multiple rules and apply an empty spec should delete all rules installed",
 			setupArgs: func() args {
-				r := policy.NewPolicyRepository()
+				r := policy.NewPolicyRepository(nil)
 				r.AddList(api.Rules{
 					{
 						EndpointSelector: api.EndpointSelector{
@@ -292,7 +292,7 @@ func (ds *DaemonSuite) Test_addCiliumNetworkPolicyV2(c *C) {
 				}
 			},
 			setupWanted: func() wanted {
-				r := policy.NewPolicyRepository()
+				r := policy.NewPolicyRepository(nil)
 				r.AddList(api.Rules{})
 				return wanted{
 					err:  nil,

--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -17,7 +17,9 @@ package clustermesh
 import (
 	"fmt"
 
+	"github.com/cilium/cilium/pkg/allocator"
 	"github.com/cilium/cilium/pkg/controller"
+	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/lock"
 	nodemanager "github.com/cilium/cilium/pkg/node/manager"
@@ -55,6 +57,21 @@ type Configuration struct {
 	NodeManager *nodemanager.Manager
 
 	nodeObserver store.Observer
+
+	// RemoteIdentityWatcher provides identities that have been allocated on a
+	// remote cluster.
+	RemoteIdentityWatcher RemoteIdentityWatcher
+}
+
+// RemoteIdentityWatcher is any type which provides identities that have been
+// allocated on a remote cluster.
+type RemoteIdentityWatcher interface {
+	// WatchRemoteIdentities starts watching for identities in another kvstore and
+	// syncs all identities to the local identity cache.
+	WatchRemoteIdentities(backend kvstore.BackendOperations) *allocator.RemoteCache
+
+	// Close stops the watcher.
+	Close()
 }
 
 // NodeObserver returns the node store observer of the configuration
@@ -119,7 +136,6 @@ func (cm *ClusterMesh) Close() {
 		cluster.onRemove()
 		delete(cm.clusters, name)
 	}
-
 	cm.controllers.RemoveAllAndWait()
 }
 
@@ -152,7 +168,7 @@ func (cm *ClusterMesh) add(name, path string) {
 	log.WithField(fieldClusterName, name).Debug("Remote cluster configuration added")
 
 	if inserted {
-		cluster.onInsert()
+		cluster.onInsert(cm.conf.RemoteIdentityWatcher)
 	} else {
 		// signal a change in configuration
 		cluster.changed <- true

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/allocator"
 	"github.com/cilium/cilium/pkg/controller"
-	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
@@ -129,7 +128,7 @@ func (rc *remoteCluster) releaseOldConnection() {
 	}
 }
 
-func (rc *remoteCluster) restartRemoteConnection() {
+func (rc *remoteCluster) restartRemoteConnection(allocator RemoteIdentityWatcher) {
 	rc.controllers.UpdateController(rc.remoteConnectionControllerName,
 		controller.ControllerParams{
 			DoFunc: func(ctx context.Context) error {
@@ -193,7 +192,7 @@ func (rc *remoteCluster) restartRemoteConnection() {
 				ipCacheWatcher := ipcache.NewIPIdentityWatcher(backend)
 				go ipCacheWatcher.Watch()
 
-				remoteIdentityCache := cache.WatchRemoteIdentities(backend)
+				remoteIdentityCache := allocator.WatchRemoteIdentities(backend)
 
 				rc.mutex.Lock()
 				rc.remoteNodes = remoteNodes
@@ -220,7 +219,7 @@ func (rc *remoteCluster) restartRemoteConnection() {
 	)
 }
 
-func (rc *remoteCluster) onInsert() {
+func (rc *remoteCluster) onInsert(allocator RemoteIdentityWatcher) {
 	rc.getLogger().Info("New remote cluster configuration")
 
 	if skipKvstoreConnection {
@@ -228,14 +227,14 @@ func (rc *remoteCluster) onInsert() {
 	}
 
 	rc.remoteConnectionControllerName = fmt.Sprintf("remote-etcd-%s", rc.name)
-	rc.restartRemoteConnection()
+	rc.restartRemoteConnection(allocator)
 
 	go func() {
 		for {
 			val := <-rc.changed
 			if val {
 				rc.getLogger().Info("etcd configuration has changed, re-creating connection")
-				rc.restartRemoteConnection()
+				rc.restartRemoteConnection(allocator)
 			} else {
 				rc.getLogger().Info("Closing connection to remote etcd")
 				return

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/fqdn"
+	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/labels/model"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -60,7 +61,7 @@ func (e *Endpoint) GetLabelsModel() (*models.LabelConfiguration, error) {
 }
 
 // NewEndpointFromChangeModel creates a new endpoint from a request
-func NewEndpointFromChangeModel(owner regeneration.Owner, proxy EndpointProxy, base *models.EndpointChangeRequest) (*Endpoint, error) {
+func NewEndpointFromChangeModel(owner regeneration.Owner, proxy EndpointProxy, allocator cache.IdentityAllocator, base *models.EndpointChangeRequest) (*Endpoint, error) {
 	if base == nil {
 		return nil, nil
 	}
@@ -86,6 +87,7 @@ func NewEndpointFromChangeModel(owner regeneration.Owner, proxy EndpointProxy, b
 		desiredPolicy:    policy.NewEndpointPolicy(owner.GetPolicyRepository()),
 		controllers:      controller.NewManager(),
 		regenFailedChan:  make(chan struct{}, 1),
+		allocator:        allocator,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/endpoint/bpf_test.go
+++ b/pkg/endpoint/bpf_test.go
@@ -23,12 +23,12 @@ import (
 	"testing"
 
 	"github.com/cilium/cilium/pkg/datapath/linux"
-
+	"github.com/cilium/cilium/pkg/testutils/allocator"
 	. "gopkg.in/check.v1"
 )
 
 func (s *EndpointSuite) TestWriteInformationalComments(c *C) {
-	e := NewEndpointWithState(s, &FakeEndpointProxy{}, 100, StateCreating)
+	e := NewEndpointWithState(s, &FakeEndpointProxy{}, &allocator.FakeIdentityAllocator{}, 100, StateCreating)
 
 	var f bytes.Buffer
 	err := e.writeInformationalComments(&f)
@@ -38,7 +38,7 @@ func (s *EndpointSuite) TestWriteInformationalComments(c *C) {
 type writeFunc func(io.Writer) error
 
 func BenchmarkWriteHeaderfile(b *testing.B) {
-	e := NewEndpointWithState(&suite, &FakeEndpointProxy{}, 100, StateCreating)
+	e := NewEndpointWithState(&suite, &FakeEndpointProxy{}, &allocator.FakeIdentityAllocator{}, 100, StateCreating)
 	dp := linux.NewDatapath(linux.DatapathConfiguration{}, nil)
 
 	targetComments := func(w io.Writer) error {

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -669,6 +669,7 @@ func (e *Endpoint) SetIdentity(identity *identityPkg.Identity, newEndpoint bool)
 	// reference from global identity manager, add add a reference to the new
 	// identity for the endpoint.
 	if newEndpoint {
+		// TODO - GH-9354.
 		identitymanager.Add(identity)
 	} else {
 		identitymanager.RemoveOldAddNew(e.SecurityIdentity, identity)

--- a/pkg/endpoint/policy_test.go
+++ b/pkg/endpoint/policy_test.go
@@ -18,12 +18,13 @@ package endpoint
 
 import (
 	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/testutils/allocator"
 	"github.com/cilium/cilium/pkg/u8proto"
 	"gopkg.in/check.v1"
 )
 
 func (s *EndpointSuite) TestUpdateVisibilityPolicy(c *check.C) {
-	ep := NewEndpointWithState(&DummyOwner{repo: policy.NewPolicyRepository()}, nil, 12345, StateReady)
+	ep := NewEndpointWithState(&DummyOwner{repo: policy.NewPolicyRepository(nil)}, nil, &allocator.FakeIdentityAllocator{}, 12345, StateReady)
 	ep.UpdateVisibilityPolicy("")
 	c.Assert(ep.visibilityPolicy, check.IsNil)
 

--- a/pkg/endpoint/regeneration/owner.go
+++ b/pkg/endpoint/regeneration/owner.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/identity"
-	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/lock"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/policy"
@@ -43,12 +42,6 @@ type Owner interface {
 
 	// Datapath returns a reference to the datapath implementation.
 	Datapath() datapath.Datapath
-
-	// GetNodeSuffix returns the suffix to be appended to kvstore keys of this
-	GetNodeSuffix() string
-
-	// UpdateIdentities propagates identity updates to selectors
-	UpdateIdentities(added, deleted cache.IdentityCache)
 }
 
 // EndpointInfoSource returns information about an endpoint being proxied.

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/fqdn"
 	"github.com/cilium/cilium/pkg/identity"
-	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -143,7 +142,7 @@ func (e *Endpoint) restoreIdentity() error {
 
 	allocateCtx, cancel := context.WithTimeout(context.Background(), option.Config.KVstoreConnectivityTimeout)
 	defer cancel()
-	identity, _, err := cache.AllocateIdentity(allocateCtx, e.owner, l)
+	identity, _, err := e.allocator.AllocateIdentity(allocateCtx, l, true)
 
 	if err != nil {
 		scopedLog.WithError(err).Warn("Unable to restore endpoint")
@@ -158,7 +157,7 @@ func (e *Endpoint) restoreIdentity() error {
 		identityCtx, cancel := context.WithTimeout(context.Background(), option.Config.KVstoreConnectivityTimeout)
 		defer cancel()
 
-		err = cache.WaitForInitialGlobalIdentities(identityCtx)
+		err = e.allocator.WaitForInitialGlobalIdentities(identityCtx)
 		if err != nil {
 			scopedLog.WithError(err).Warn("Failed while waiting for initial global identities")
 			return err

--- a/pkg/endpoint/restore_test.go
+++ b/pkg/endpoint/restore_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/mac"
+	"github.com/cilium/cilium/pkg/testutils/allocator"
 	. "gopkg.in/check.v1"
 )
 
@@ -71,7 +72,7 @@ func (ds *EndpointSuite) endpointCreator(id uint16, secID identity.NumericIdenti
 	repo := ds.GetPolicyRepository()
 	repo.GetPolicyCache().LocalEndpointIdentityAdded(identity)
 
-	ep := NewEndpointWithState(ds, &FakeEndpointProxy{}, id, StateReady)
+	ep := NewEndpointWithState(ds, &FakeEndpointProxy{}, &allocator.FakeIdentityAllocator{}, id, StateReady)
 	// Random network ID and docker endpoint ID with 59 hex chars + 5 strID = 64 hex chars
 	ep.dockerNetworkID = "603e047d2268a57f5a5f93f7f9e1263e9207e348a06654bf64948def001" + strID
 	ep.dockerEndpointID = "93529fda8c401a071d21d6bd46fdf5499b9014dcb5a35f2e3efaa8d8002" + strID

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -764,7 +764,6 @@ func getNetworkPolicy(name string, id identity.NumericIdentity, conntrackName st
 // a subsequent call to the endpoint's OnProxyPolicyUpdate() function.
 func (s *XDSServer) UpdateNetworkPolicy(ep logger.EndpointUpdater, policy *policy.L4Policy,
 	ingressPolicyEnforced, egressPolicyEnforced bool, wg *completion.WaitGroup) (error, func() error) {
-
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/pkg/identity/cache/allocation_test.go
+++ b/pkg/identity/cache/allocation_test.go
@@ -42,8 +42,12 @@ func (s *IdentityCacheTestSuite) TestAllocateIdentityReserved(c *C) {
 	lbls = labels.Labels{
 		labels.IDNameHost: labels.NewLabel(labels.IDNameHost, "", labels.LabelSourceReserved),
 	}
-	c.Assert(IdentityAllocationIsLocal(lbls), Equals, true)
-	i, isNew, err = AllocateIdentity(context.Background(), nil, lbls)
+
+	mgr := NewCachingIdentityAllocator(newDummyOwner())
+	<-mgr.InitIdentityAllocator(nil, nil)
+
+	c.Assert(identity.IdentityAllocationIsLocal(lbls), Equals, true)
+	i, isNew, err = mgr.AllocateIdentity(context.Background(), lbls, false)
 	c.Assert(err, IsNil)
 	c.Assert(i.ID, Equals, identity.ReservedIdentityHost)
 	c.Assert(isNew, Equals, false)
@@ -51,14 +55,14 @@ func (s *IdentityCacheTestSuite) TestAllocateIdentityReserved(c *C) {
 	lbls = labels.Labels{
 		labels.IDNameWorld: labels.NewLabel(labels.IDNameWorld, "", labels.LabelSourceReserved),
 	}
-	c.Assert(IdentityAllocationIsLocal(lbls), Equals, true)
-	i, isNew, err = AllocateIdentity(context.Background(), nil, lbls)
+	c.Assert(identity.IdentityAllocationIsLocal(lbls), Equals, true)
+	i, isNew, err = mgr.AllocateIdentity(context.Background(), lbls, false)
 	c.Assert(err, IsNil)
 	c.Assert(i.ID, Equals, identity.ReservedIdentityWorld)
 	c.Assert(isNew, Equals, false)
 
-	c.Assert(IdentityAllocationIsLocal(labels.LabelHealth), Equals, true)
-	i, isNew, err = AllocateIdentity(context.Background(), nil, labels.LabelHealth)
+	c.Assert(identity.IdentityAllocationIsLocal(labels.LabelHealth), Equals, true)
+	i, isNew, err = mgr.AllocateIdentity(context.Background(), labels.LabelHealth, false)
 	c.Assert(err, IsNil)
 	c.Assert(i.ID, Equals, identity.ReservedIdentityHealth)
 	c.Assert(isNew, Equals, false)
@@ -66,8 +70,8 @@ func (s *IdentityCacheTestSuite) TestAllocateIdentityReserved(c *C) {
 	lbls = labels.Labels{
 		labels.IDNameInit: labels.NewLabel(labels.IDNameInit, "", labels.LabelSourceReserved),
 	}
-	c.Assert(IdentityAllocationIsLocal(lbls), Equals, true)
-	i, isNew, err = AllocateIdentity(context.Background(), nil, lbls)
+	c.Assert(identity.IdentityAllocationIsLocal(lbls), Equals, true)
+	i, isNew, err = mgr.AllocateIdentity(context.Background(), lbls, false)
 	c.Assert(err, IsNil)
 	c.Assert(i.ID, Equals, identity.ReservedIdentityInit)
 	c.Assert(isNew, Equals, false)
@@ -75,8 +79,8 @@ func (s *IdentityCacheTestSuite) TestAllocateIdentityReserved(c *C) {
 	lbls = labels.Labels{
 		labels.IDNameUnmanaged: labels.NewLabel(labels.IDNameUnmanaged, "", labels.LabelSourceReserved),
 	}
-	c.Assert(IdentityAllocationIsLocal(lbls), Equals, true)
-	i, isNew, err = AllocateIdentity(context.Background(), nil, lbls)
+	c.Assert(identity.IdentityAllocationIsLocal(lbls), Equals, true)
+	i, isNew, err = mgr.AllocateIdentity(context.Background(), lbls, false)
 	c.Assert(err, IsNil)
 	c.Assert(i.ID, Equals, identity.ReservedIdentityUnmanaged)
 	c.Assert(isNew, Equals, false)
@@ -168,9 +172,12 @@ func (d *dummyOwner) WaitUntilID(target identity.NumericIdentity) int {
 func (ias *IdentityAllocatorSuite) TestEventWatcherBatching(c *C) {
 	owner := newDummyOwner()
 	events := make(allocator.AllocatorEventChan, 1024)
-	var watcher identityWatcher
+	watcher := identityWatcher{
+		stopChan: make(chan bool),
+		owner:    owner,
+	}
 
-	watcher.watch(owner, events)
+	watcher.watch(events)
 	defer close(watcher.stopChan)
 
 	lbls := labels.NewLabelsFromSortedList("id=foo")
@@ -220,11 +227,12 @@ func (ias *IdentityAllocatorSuite) TestEventWatcherBatching(c *C) {
 func (ias *IdentityAllocatorSuite) TestGetIdentityCache(c *C) {
 	identity.InitWellKnownIdentities()
 	// The nils are only used by k8s CRD identities. We default to kvstore.
-	<-InitIdentityAllocator(newDummyOwner(), nil, nil)
-	defer Close()
-	defer IdentityAllocator.DeleteAllKeys()
+	mgr := NewCachingIdentityAllocator(newDummyOwner())
+	<-mgr.InitIdentityAllocator(nil, nil)
+	defer mgr.Close()
+	defer mgr.IdentityAllocator.DeleteAllKeys()
 
-	cache := GetIdentityCache()
+	cache := mgr.GetIdentityCache()
 	_, ok := cache[identity.ReservedCiliumKVStore]
 	c.Assert(ok, Equals, true)
 }
@@ -237,11 +245,12 @@ func (ias *IdentityAllocatorSuite) TestAllocator(c *C) {
 	owner := newDummyOwner()
 	identity.InitWellKnownIdentities()
 	// The nils are only used by k8s CRD identities. We default to kvstore.
-	<-InitIdentityAllocator(owner, nil, nil)
-	defer Close()
-	defer IdentityAllocator.DeleteAllKeys()
+	mgr := NewCachingIdentityAllocator(owner)
+	<-mgr.InitIdentityAllocator(nil, nil)
+	defer mgr.Close()
+	defer mgr.IdentityAllocator.DeleteAllKeys()
 
-	id1a, isNew, err := AllocateIdentity(context.Background(), nil, lbls1)
+	id1a, isNew, err := mgr.AllocateIdentity(context.Background(), lbls1, false)
 	c.Assert(id1a, Not(IsNil))
 	c.Assert(err, IsNil)
 	c.Assert(isNew, Equals, true)
@@ -250,16 +259,16 @@ func (ias *IdentityAllocatorSuite) TestAllocator(c *C) {
 	c.Assert(owner.GetIdentity(id1a.ID), checker.DeepEquals, lbls1.LabelArray())
 
 	// reuse the same identity
-	id1b, isNew, err := AllocateIdentity(context.Background(), nil, lbls1)
+	id1b, isNew, err := mgr.AllocateIdentity(context.Background(), lbls1, false)
 	c.Assert(id1b, Not(IsNil))
 	c.Assert(isNew, Equals, false)
 	c.Assert(err, IsNil)
 	c.Assert(id1a.ID, Equals, id1b.ID)
 
-	released, err := Release(context.Background(), nil, id1a)
+	released, err := mgr.Release(context.Background(), id1a)
 	c.Assert(err, IsNil)
 	c.Assert(released, Equals, false)
-	released, err = Release(context.Background(), nil, id1b)
+	released, err = mgr.Release(context.Background(), id1b)
 	c.Assert(err, IsNil)
 	c.Assert(released, Equals, true)
 	// KV-store still keeps the ID even when a single node has released it.
@@ -268,7 +277,7 @@ func (ias *IdentityAllocatorSuite) TestAllocator(c *C) {
 	// owner's cache.
 	c.Assert(owner.GetIdentity(id1a.ID), checker.DeepEquals, lbls1.LabelArray())
 
-	id1b, isNew, err = AllocateIdentity(context.Background(), nil, lbls1)
+	id1b, isNew, err = mgr.AllocateIdentity(context.Background(), lbls1, false)
 	c.Assert(id1b, Not(IsNil))
 	c.Assert(err, IsNil)
 	// the value key should not have been removed so the same ID should be
@@ -278,11 +287,11 @@ func (ias *IdentityAllocatorSuite) TestAllocator(c *C) {
 	// Should still be cached, no new events should have been received.
 	c.Assert(owner.GetIdentity(id1a.ID), checker.DeepEquals, lbls1.LabelArray())
 
-	identity := LookupIdentityByID(id1b.ID)
+	identity := mgr.LookupIdentityByID(id1b.ID)
 	c.Assert(identity, Not(IsNil))
 	c.Assert(lbls1, checker.DeepEquals, identity.Labels)
 
-	id2, isNew, err := AllocateIdentity(context.Background(), nil, lbls2)
+	id2, isNew, err := mgr.AllocateIdentity(context.Background(), lbls2, false)
 	c.Assert(id2, Not(IsNil))
 	c.Assert(isNew, Equals, true)
 	c.Assert(err, IsNil)
@@ -291,7 +300,7 @@ func (ias *IdentityAllocatorSuite) TestAllocator(c *C) {
 	c.Assert(owner.WaitUntilID(id2.ID), Not(Equals), 0)
 	c.Assert(owner.GetIdentity(id2.ID), checker.DeepEquals, lbls2.LabelArray())
 
-	id3, isNew, err := AllocateIdentity(context.Background(), nil, lbls3)
+	id3, isNew, err := mgr.AllocateIdentity(context.Background(), lbls3, false)
 	c.Assert(id3, Not(IsNil))
 	c.Assert(isNew, Equals, true)
 	c.Assert(err, IsNil)
@@ -301,17 +310,17 @@ func (ias *IdentityAllocatorSuite) TestAllocator(c *C) {
 	c.Assert(owner.WaitUntilID(id3.ID), Not(Equals), 0)
 	c.Assert(owner.GetIdentity(id3.ID), checker.DeepEquals, lbls3.LabelArray())
 
-	released, err = Release(context.Background(), nil, id1b)
+	released, err = mgr.Release(context.Background(), id1b)
 	c.Assert(err, IsNil)
 	c.Assert(released, Equals, true)
-	released, err = Release(context.Background(), nil, id2)
+	released, err = mgr.Release(context.Background(), id2)
 	c.Assert(err, IsNil)
 	c.Assert(released, Equals, true)
-	released, err = Release(context.Background(), nil, id3)
+	released, err = mgr.Release(context.Background(), id3)
 	c.Assert(err, IsNil)
 	c.Assert(released, Equals, true)
 
-	IdentityAllocator.DeleteAllKeys()
+	mgr.IdentityAllocator.DeleteAllKeys()
 	c.Assert(owner.WaitUntilID(id3.ID), Not(Equals), 0)
 }
 
@@ -321,11 +330,12 @@ func (ias *IdentityAllocatorSuite) TestLocalAllocation(c *C) {
 	owner := newDummyOwner()
 	identity.InitWellKnownIdentities()
 	// The nils are only used by k8s CRD identities. We default to kvstore.
-	<-InitIdentityAllocator(owner, nil, nil)
-	defer Close()
-	defer IdentityAllocator.DeleteAllKeys()
+	mgr := NewCachingIdentityAllocator(owner)
+	<-mgr.InitIdentityAllocator(nil, nil)
+	defer mgr.Close()
+	defer mgr.IdentityAllocator.DeleteAllKeys()
 
-	id, isNew, err := AllocateIdentity(context.Background(), nil, lbls1)
+	id, isNew, err := mgr.AllocateIdentity(context.Background(), lbls1, false)
 	c.Assert(id, Not(IsNil))
 	c.Assert(err, IsNil)
 	c.Assert(isNew, Equals, true)
@@ -335,16 +345,16 @@ func (ias *IdentityAllocatorSuite) TestLocalAllocation(c *C) {
 	c.Assert(owner.GetIdentity(id.ID), checker.DeepEquals, lbls1.LabelArray())
 
 	// reuse the same identity
-	id, isNew, err = AllocateIdentity(context.Background(), nil, lbls1)
+	id, isNew, err = mgr.AllocateIdentity(context.Background(), lbls1, false)
 	c.Assert(id, Not(IsNil))
 	c.Assert(err, IsNil)
 	c.Assert(isNew, Equals, false)
 
-	cache := GetIdentityCache()
+	cache := mgr.GetIdentityCache()
 	c.Assert(cache[id.ID], Not(IsNil))
 
 	// 1st Release, not released
-	released, err := Release(context.Background(), nil, id)
+	released, err := mgr.Release(context.Background(), id)
 	c.Assert(err, IsNil)
 	c.Assert(released, Equals, false)
 
@@ -352,7 +362,7 @@ func (ias *IdentityAllocatorSuite) TestLocalAllocation(c *C) {
 	c.Assert(owner.GetIdentity(id.ID), checker.DeepEquals, lbls1.LabelArray())
 
 	// 2nd Release, released
-	released, err = Release(context.Background(), nil, id)
+	released, err = mgr.Release(context.Background(), id)
 	c.Assert(err, IsNil)
 	c.Assert(released, Equals, true)
 
@@ -361,19 +371,19 @@ func (ias *IdentityAllocatorSuite) TestLocalAllocation(c *C) {
 	// Identity does not exist any more
 	c.Assert(owner.GetIdentity(id.ID), IsNil)
 
-	cache = GetIdentityCache()
+	cache = mgr.GetIdentityCache()
 	c.Assert(cache[id.ID], IsNil)
 
-	id, isNew, err = AllocateIdentity(context.Background(), nil, lbls1)
+	id, isNew, err = mgr.AllocateIdentity(context.Background(), lbls1, false)
 	c.Assert(id, Not(IsNil))
 	c.Assert(err, IsNil)
 	c.Assert(isNew, Equals, true)
 	c.Assert(id.ID.HasLocalScope(), Equals, true)
 
-	released, err = Release(context.Background(), nil, id)
+	released, err = mgr.Release(context.Background(), id)
 	c.Assert(err, IsNil)
 	c.Assert(released, Equals, true)
 
-	IdentityAllocator.DeleteAllKeys()
+	mgr.IdentityAllocator.DeleteAllKeys()
 	c.Assert(owner.WaitUntilID(id.ID), Not(Equals), 0)
 }

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -36,6 +36,12 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+var (
+	// IdentitiesPath is the path to where identities are stored in the
+	// key-value store.
+	IdentitiesPath = path.Join(kvstore.BaseKeyPrefix, "state", "identities", "v1")
+)
+
 // GlobalIdentity is the structure used to store an identity
 type GlobalIdentity struct {
 	labels.LabelArray
@@ -68,30 +74,32 @@ func (gi GlobalIdentity) PutKeyFromMap(v map[string]string) allocator.AllocatorK
 	return GlobalIdentity{labels.Map2Labels(v, "").LabelArray()}
 }
 
-var (
+// CachingIdentityAllocator manages the allocation of identities for both
+// global and local identities.
+type CachingIdentityAllocator struct {
 	// IdentityAllocator is an allocator for security identities from the
 	// kvstore.
 	IdentityAllocator *allocator.Allocator
 
-	// GlobalIdentityAllocatorInitialized is closed whenever the global identity
+	// globalIdentityAllocatorInitialized is closed whenever the global identity
 	// allocator is initialized.
-	GlobalIdentityAllocatorInitialized = make(chan struct{})
+	globalIdentityAllocatorInitialized chan struct{}
 
 	// localIdentityAllocatorInitialized is closed whenever the local identity
 	// allocator is initialized.
-	localIdentityAllocatorInitialized = make(chan struct{})
+	localIdentityAllocatorInitialized chan struct{}
 
 	localIdentities *localIdentityCache
 
-	// IdentitiesPath is the path to where identities are stored in the key-value
-	// store.
-	IdentitiesPath = path.Join(kvstore.BaseKeyPrefix, "state", "identities", "v1")
+	identitiesPath string
 
 	// setupMutex synchronizes InitIdentityAllocator() and Close()
 	setupMutex lock.Mutex
 
 	watcher identityWatcher
-)
+
+	owner IdentityAllocatorOwner
+}
 
 // IdentityAllocatorOwner is the interface the owner of an identity allocator
 // must implement
@@ -107,6 +115,26 @@ type IdentityAllocatorOwner interface {
 	GetNodeSuffix() string
 }
 
+// IdentityAllocator is any type which is responsible for allocating security
+// identities based of sets of labels, and caching information about identities
+// locally.
+type IdentityAllocator interface {
+	// WaitForInitialGlobalIdentities waits for the initial set of global
+	// security identities to have been received.
+	WaitForInitialGlobalIdentities(context.Context) error
+
+	// AllocateIdentity allocates an identity described by the specified labels.
+	AllocateIdentity(context.Context, labels.Labels, bool) (*identity.Identity, bool, error)
+
+	// Release is the reverse operation of AllocateIdentity() and releases the
+	// specified identity.
+	Release(context.Context, *identity.Identity) (released bool, err error)
+
+	// LookupIdentityByID returns the identity that corresponds to the given
+	// numeric identity.
+	LookupIdentityByID(id identity.NumericIdentity) *identity.Identity
+}
+
 // InitIdentityAllocator creates the the identity allocator. Only the first
 // invocation of this function will have an effect. The Caller must have
 // initialized well known identities before calling this (by calling
@@ -118,11 +146,11 @@ type IdentityAllocatorOwner interface {
 // TODO: identity backends are initialized directly in this function, pulling
 // in dependencies on kvstore and k8s. It would be better to decouple this,
 // since the backends are an interface.
-func InitIdentityAllocator(owner IdentityAllocatorOwner, client clientset.Interface, identityStore cache.Store) <-chan struct{} {
-	setupMutex.Lock()
-	defer setupMutex.Unlock()
+func (m *CachingIdentityAllocator) InitIdentityAllocator(client clientset.Interface, identityStore cache.Store) <-chan struct{} {
+	m.setupMutex.Lock()
+	defer m.setupMutex.Unlock()
 
-	if IdentityAllocator != nil {
+	if m.IdentityAllocator != nil {
 		log.Panic("InitIdentityAllocator() in succession without calling Close()")
 	}
 
@@ -131,8 +159,8 @@ func InitIdentityAllocator(owner IdentityAllocatorOwner, client clientset.Interf
 	// Local identity cache can be created synchronously since it doesn't
 	// rely upon any external resources (e.g., external kvstore).
 	events := make(allocator.AllocatorEventChan, 1024)
-	localIdentities = newLocalIdentityCache(1, 0xFFFFFF, events)
-	close(localIdentityAllocatorInitialized)
+	m.localIdentities = newLocalIdentityCache(1, 0xFFFFFF, events)
+	close(m.localIdentityAllocatorInitialized)
 
 	minID := idpool.ID(identity.MinimalAllocationIdentity)
 	maxID := idpool.ID(identity.MaximumAllocationIdentity)
@@ -140,13 +168,13 @@ func InitIdentityAllocator(owner IdentityAllocatorOwner, client clientset.Interf
 	// It is important to start listening for events before calling
 	// NewAllocator() as it will emit events while filling the
 	// initial cache
-	watcher.watch(owner, events)
+	m.watcher.watch(events)
 
 	// Asynchronously set up the global identity allocator since it connects
 	// to the kvstore.
 	go func(owner IdentityAllocatorOwner, evs allocator.AllocatorEventChan, minID, maxID idpool.ID) {
-		setupMutex.Lock()
-		defer setupMutex.Unlock()
+		m.setupMutex.Lock()
+		defer m.setupMutex.Unlock()
 
 		var (
 			backend allocator.Backend
@@ -156,7 +184,7 @@ func InitIdentityAllocator(owner IdentityAllocatorOwner, client clientset.Interf
 		switch option.Config.IdentityAllocationMode {
 		case option.IdentityAllocationModeKVstore:
 			log.Debug("Identity allocation backed by KVStore")
-			backend, err = kvstoreallocator.NewKVStoreBackend(IdentitiesPath, owner.GetNodeSuffix(), GlobalIdentity{})
+			backend, err = kvstoreallocator.NewKVStoreBackend(m.identitiesPath, owner.GetNodeSuffix(), GlobalIdentity{})
 			if err != nil {
 				log.WithError(err).Fatal("Unable to initialize kvstore backend for identity allocation")
 			}
@@ -186,85 +214,103 @@ func InitIdentityAllocator(owner IdentityAllocatorOwner, client clientset.Interf
 			log.WithError(err).Fatalf("Unable to initialize Identity Allocator with backend %s", option.Config.IdentityAllocationMode)
 		}
 
-		IdentityAllocator = a
-		close(GlobalIdentityAllocatorInitialized)
-	}(owner, events, minID, maxID)
+		m.IdentityAllocator = a
+		close(m.globalIdentityAllocatorInitialized)
+	}(m.owner, events, minID, maxID)
 
-	return GlobalIdentityAllocatorInitialized
+	return m.globalIdentityAllocatorInitialized
+}
+
+// InitIdentityAllocator creates the the identity allocator. Only the first
+// invocation of this function will have an effect. The Caller must have
+// initialized well known identities before calling this (by calling
+// identity.InitWellKnownIdentities()).
+// client and identityStore are only used by the CRD identity allocator,
+// currently, and identityStore may be nil.
+// Returns a channel which is closed when initialization of the allocator is
+// completed.
+// TODO: identity backends are initialized directly in this function, pulling
+// in dependencies on kvstore and k8s. It would be better to decouple this,
+// since the backends are an interface.
+
+// NewCachingIdentityAllocator creates a new instance of an
+// CachingIdentityAllocator.
+func NewCachingIdentityAllocator(owner IdentityAllocatorOwner) *CachingIdentityAllocator {
+	watcher := identityWatcher{
+		stopChan: make(chan bool),
+		owner:    owner,
+	}
+
+	mgr := &CachingIdentityAllocator{
+		globalIdentityAllocatorInitialized: make(chan struct{}),
+		localIdentityAllocatorInitialized:  make(chan struct{}),
+		owner:                              owner,
+		identitiesPath:                     IdentitiesPath,
+		watcher:                            watcher,
+	}
+	return mgr
 }
 
 // Close closes the identity allocator and allows to call
-// InitIdentityAllocator() again
-func Close() {
-	setupMutex.Lock()
-	defer setupMutex.Unlock()
+// InitIdentityAllocator() again.
+func (m *CachingIdentityAllocator) Close() {
+	m.setupMutex.Lock()
+	defer m.setupMutex.Unlock()
 
 	select {
-	case <-GlobalIdentityAllocatorInitialized:
+	case <-m.globalIdentityAllocatorInitialized:
 		// This means the channel was closed and therefore the IdentityAllocator == nil will never be true
 	default:
-		if IdentityAllocator == nil {
+		if m.IdentityAllocator == nil {
 			log.Panic("Close() called without calling InitIdentityAllocator() first")
 		}
 	}
 
 	select {
-	case <-localIdentityAllocatorInitialized:
+	case <-m.localIdentityAllocatorInitialized:
 		// This means the channel was closed and therefore the IdentityAllocator == nil will never be true
 	default:
-		if IdentityAllocator == nil {
+		if m.IdentityAllocator == nil {
 			log.Panic("Close() called without calling InitIdentityAllocator() first")
 		}
 	}
 
-	IdentityAllocator.Delete()
-	watcher.stop()
-	IdentityAllocator = nil
-	GlobalIdentityAllocatorInitialized = make(chan struct{})
-	localIdentityAllocatorInitialized = make(chan struct{})
-	localIdentities = nil
+	m.IdentityAllocator.Delete()
+	m.watcher.stop()
+	m.IdentityAllocator = nil
+	m.globalIdentityAllocatorInitialized = make(chan struct{})
+	m.localIdentityAllocatorInitialized = make(chan struct{})
+	m.localIdentities = nil
 }
 
 // WaitForInitialGlobalIdentities waits for the initial set of global security
 // identities to have been received and populated into the allocator cache.
-func WaitForInitialGlobalIdentities(ctx context.Context) error {
+func (m *CachingIdentityAllocator) WaitForInitialGlobalIdentities(ctx context.Context) error {
 	select {
-	case <-GlobalIdentityAllocatorInitialized:
+	case <-m.globalIdentityAllocatorInitialized:
 	case <-ctx.Done():
 		return fmt.Errorf("initial global identity sync was cancelled: %s", ctx.Err())
 	}
 
-	return IdentityAllocator.WaitForInitialSync(ctx)
-}
-
-// IdentityAllocationIsLocal returns true if a call to AllocateIdentity with
-// the given labels would not require accessing the KV store to allocate the
-// identity.
-// Currently, this function returns true only if the labels are those of a
-// reserved identity, i.e. if the slice contains a single reserved
-// "reserved:*" label.
-func IdentityAllocationIsLocal(lbls labels.Labels) bool {
-	// If there is only one label with the "reserved" source and a well-known
-	// key, the well-known identity for it can be allocated locally.
-	return LookupReservedIdentityByLabels(lbls) != nil
+	return m.IdentityAllocator.WaitForInitialSync(ctx)
 }
 
 // AllocateIdentity allocates an identity described by the specified labels. If
 // an identity for the specified set of labels already exist, the identity is
 // re-used and reference counting is performed, otherwise a new identity is
 // allocated via the kvstore.
-func AllocateIdentity(ctx context.Context, owner IdentityAllocatorOwner, lbls labels.Labels) (id *identity.Identity, allocated bool, err error) {
+func (m *CachingIdentityAllocator) AllocateIdentity(ctx context.Context, lbls labels.Labels, notifyOwner bool) (id *identity.Identity, allocated bool, err error) {
 	// Notify the owner of the newly added identities so that the
 	// cached identities can be updated ASAP, rather than just
 	// relying on the kv-store update events.
 	defer func() {
 		if err == nil && allocated {
 			metrics.IdentityCount.Inc()
-			if owner != nil {
+			if notifyOwner {
 				added := IdentityCache{
 					id.ID: id.LabelArray,
 				}
-				owner.UpdateIdentities(added, nil)
+				m.owner.UpdateIdentities(added, nil)
 			}
 		}
 	}()
@@ -276,7 +322,7 @@ func AllocateIdentity(ctx context.Context, owner IdentityAllocatorOwner, lbls la
 
 	// If there is only one label with the "reserved" source and a well-known
 	// key, use the well-known identity for that key.
-	if reservedIdentity := LookupReservedIdentityByLabels(lbls); reservedIdentity != nil {
+	if reservedIdentity := identity.LookupReservedIdentityByLabels(lbls); reservedIdentity != nil {
 		if option.Config.Debug {
 			log.WithFields(logrus.Fields{
 				logfields.Identity:       reservedIdentity.ID,
@@ -288,22 +334,22 @@ func AllocateIdentity(ctx context.Context, owner IdentityAllocatorOwner, lbls la
 	}
 
 	if !identity.RequiresGlobalIdentity(lbls) {
-		<-localIdentityAllocatorInitialized
-		return localIdentities.lookupOrCreate(lbls)
+		<-m.localIdentityAllocatorInitialized
+		return m.localIdentities.lookupOrCreate(lbls)
 	}
 
 	// This will block until the kvstore can be accessed and all identities
 	// were successfully synced
-	err = WaitForInitialGlobalIdentities(ctx)
+	err = m.WaitForInitialGlobalIdentities(ctx)
 	if err != nil {
 		return nil, false, err
 	}
 
-	if IdentityAllocator == nil {
+	if m.IdentityAllocator == nil {
 		return nil, false, fmt.Errorf("allocator not initialized")
 	}
 
-	idp, isNew, err := IdentityAllocator.Allocate(ctx, GlobalIdentity{lbls.LabelArray()})
+	idp, isNew, err := m.IdentityAllocator.Allocate(ctx, GlobalIdentity{lbls.LabelArray()})
 	if err != nil {
 		return nil, false, err
 	}
@@ -322,7 +368,7 @@ func AllocateIdentity(ctx context.Context, owner IdentityAllocatorOwner, lbls la
 // Release is the reverse operation of AllocateIdentity() and releases the
 // identity again. This function may result in kvstore operations.
 // After the last user has released the ID, the returned lastUse value is true.
-func Release(ctx context.Context, owner IdentityAllocatorOwner, id *identity.Identity) (released bool, err error) {
+func (m *CachingIdentityAllocator) Release(ctx context.Context, id *identity.Identity) (released bool, err error) {
 	defer func() {
 		if released {
 			metrics.IdentityCount.Dec()
@@ -335,26 +381,26 @@ func Release(ctx context.Context, owner IdentityAllocatorOwner, id *identity.Ide
 	}
 
 	if !identity.RequiresGlobalIdentity(id.Labels) {
-		<-localIdentityAllocatorInitialized
-		lastUse := localIdentities.release(id)
+		<-m.localIdentityAllocatorInitialized
+		lastUse := m.localIdentities.release(id)
 		// Notify release of locally managed identities on last use
-		if owner != nil && lastUse {
+		if m.owner != nil && lastUse {
 			deleted := IdentityCache{
 				id.ID: id.LabelArray,
 			}
-			owner.UpdateIdentities(nil, deleted)
+			m.owner.UpdateIdentities(nil, deleted)
 		}
 		return lastUse, nil
 	}
 
 	// This will block until the kvstore can be accessed and all identities
 	// were successfully synced
-	err = WaitForInitialGlobalIdentities(ctx)
+	err = m.WaitForInitialGlobalIdentities(ctx)
 	if err != nil {
 		return false, err
 	}
 
-	if IdentityAllocator == nil {
+	if m.IdentityAllocator == nil {
 		return false, fmt.Errorf("allocator not initialized")
 	}
 
@@ -363,20 +409,20 @@ func Release(ctx context.Context, owner IdentityAllocatorOwner, id *identity.Ide
 	// ID is no longer used locally, it may still be used by
 	// remote nodes, so we can't rely on the locally computed
 	// "lastUse".
-	return IdentityAllocator.Release(ctx, GlobalIdentity{id.LabelArray})
+	return m.IdentityAllocator.Release(ctx, GlobalIdentity{id.LabelArray})
 }
 
 // ReleaseSlice attempts to release a set of identities. It is a helper
 // function that may be useful for cleaning up multiple identities in paths
 // where several identities may be allocated and another error means that they
 // should all be released.
-func ReleaseSlice(ctx context.Context, owner IdentityAllocatorOwner, identities []*identity.Identity) error {
+func (m *CachingIdentityAllocator) ReleaseSlice(ctx context.Context, owner IdentityAllocatorOwner, identities []*identity.Identity) error {
 	var err error
 	for _, id := range identities {
 		if id == nil {
 			continue
 		}
-		_, err2 := Release(ctx, owner, id)
+		_, err2 := m.Release(ctx, id)
 		if err2 != nil {
 			log.WithError(err2).WithFields(logrus.Fields{
 				logfields.Identity: id,
@@ -389,7 +435,7 @@ func ReleaseSlice(ctx context.Context, owner IdentityAllocatorOwner, identities 
 
 // WatchRemoteIdentities starts watching for identities in another kvstore and
 // syncs all identities to the local identity cache.
-func WatchRemoteIdentities(backend kvstore.BackendOperations) *allocator.RemoteCache {
-	<-GlobalIdentityAllocatorInitialized
-	return IdentityAllocator.WatchRemoteKVStore(backend, IdentitiesPath)
+func (m *CachingIdentityAllocator) WatchRemoteIdentities(backend kvstore.BackendOperations) *allocator.RemoteCache {
+	<-m.globalIdentityAllocatorInitialized
+	return m.IdentityAllocator.WatchRemoteKVStore(backend, m.identitiesPath)
 }

--- a/pkg/identity/cache/cache.go
+++ b/pkg/identity/cache/cache.go
@@ -46,12 +46,13 @@ func (s IdentitiesModel) Less(i, j int) bool {
 }
 
 // GetIdentityCache returns a cache of all known identities
-func GetIdentityCache() IdentityCache {
+func (m *CachingIdentityAllocator) GetIdentityCache() IdentityCache {
+	log.Debug("getting identity cache for identity allocator manager")
 	cache := IdentityCache{}
 
-	if IdentityAllocator != nil {
+	if m.IdentityAllocator != nil {
 
-		IdentityAllocator.ForeachCache(func(id idpool.ID, val allocator.AllocatorKey) {
+		m.IdentityAllocator.ForeachCache(func(id idpool.ID, val allocator.AllocatorKey) {
 			if val != nil {
 				if gi, ok := val.(GlobalIdentity); ok {
 					cache[identity.NumericIdentity(id)] = gi.LabelArray
@@ -67,8 +68,8 @@ func GetIdentityCache() IdentityCache {
 		cache[key] = identity.Labels.LabelArray()
 	}
 
-	if localIdentities != nil {
-		for _, identity := range localIdentities.GetIdentities() {
+	if m.localIdentities != nil {
+		for _, identity := range m.localIdentities.GetIdentities() {
 			cache[identity.ID] = identity.Labels.LabelArray()
 		}
 	}
@@ -77,10 +78,10 @@ func GetIdentityCache() IdentityCache {
 }
 
 // GetIdentities returns all known identities
-func GetIdentities() IdentitiesModel {
+func (m *CachingIdentityAllocator) GetIdentities() IdentitiesModel {
 	identities := IdentitiesModel{}
 
-	IdentityAllocator.ForeachCache(func(id idpool.ID, val allocator.AllocatorKey) {
+	m.IdentityAllocator.ForeachCache(func(id idpool.ID, val allocator.AllocatorKey) {
 		if gi, ok := val.(GlobalIdentity); ok {
 			identity := identity.NewIdentityFromLabelArray(identity.NumericIdentity(id), gi.LabelArray)
 			identities = append(identities, identity.GetModel())
@@ -92,7 +93,7 @@ func GetIdentities() IdentitiesModel {
 		identities = append(identities, v.GetModel())
 	}
 
-	for _, v := range localIdentities.GetIdentities() {
+	for _, v := range m.localIdentities.GetIdentities() {
 		identities = append(identities, v.GetModel())
 	}
 
@@ -101,6 +102,7 @@ func GetIdentities() IdentitiesModel {
 
 type identityWatcher struct {
 	stopChan chan bool
+	owner    IdentityAllocatorOwner
 }
 
 // collectEvent records the 'event' as an added or deleted identity,
@@ -137,8 +139,7 @@ func collectEvent(event allocator.AllocatorEvent, added, deleted IdentityCache) 
 }
 
 // watch starts the identity watcher
-func (w *identityWatcher) watch(owner IdentityAllocatorOwner, events allocator.AllocatorEventChan) {
-	w.stopChan = make(chan bool)
+func (w *identityWatcher) watch(events allocator.AllocatorEventChan) {
 
 	go func() {
 		for {
@@ -191,7 +192,7 @@ func (w *identityWatcher) watch(owner IdentityAllocatorOwner, events allocator.A
 				}
 			}
 			// Issue collected updates
-			owner.UpdateIdentities(added, deleted) // disjoint sets
+			w.owner.UpdateIdentities(added, deleted) // disjoint sets
 		}
 	}()
 }
@@ -204,21 +205,21 @@ func (w *identityWatcher) stop() {
 // LookupIdentity looks up the identity by its labels but does not create it.
 // This function will first search through the local cache and fall back to
 // querying the kvstore.
-func LookupIdentity(lbls labels.Labels) *identity.Identity {
-	if reservedIdentity := LookupReservedIdentityByLabels(lbls); reservedIdentity != nil {
+func (m *CachingIdentityAllocator) LookupIdentity(lbls labels.Labels) *identity.Identity {
+	if reservedIdentity := identity.LookupReservedIdentityByLabels(lbls); reservedIdentity != nil {
 		return reservedIdentity
 	}
 
-	if identity := localIdentities.lookup(lbls); identity != nil {
+	if identity := m.localIdentities.lookup(lbls); identity != nil {
 		return identity
 	}
 
-	if IdentityAllocator == nil {
+	if m.IdentityAllocator == nil {
 		return nil
 	}
 
 	lblArray := lbls.LabelArray()
-	id, err := IdentityAllocator.Get(context.TODO(), GlobalIdentity{lblArray})
+	id, err := m.IdentityAllocator.Get(context.TODO(), GlobalIdentity{lblArray})
 	if err != nil {
 		return nil
 	}
@@ -230,47 +231,11 @@ func LookupIdentity(lbls labels.Labels) *identity.Identity {
 	return identity.NewIdentityFromLabelArray(identity.NumericIdentity(id), lblArray)
 }
 
-// LookupReservedIdentityByLabels looks up a reserved identity by its labels and
-// returns it if found. Returns nil if not found.
-func LookupReservedIdentityByLabels(lbls labels.Labels) *identity.Identity {
-	if identity := identity.WellKnown.LookupByLabels(lbls); identity != nil {
-		return identity
-	}
-
-	for _, lbl := range lbls {
-		switch {
-		// If the set of labels contain a fixed identity then and exists in
-		// the map of reserved IDs then return the identity of that reserved ID.
-		case lbl.Key == labels.LabelKeyFixedIdentity:
-			id := identity.GetReservedID(lbl.Value)
-			if id != identity.IdentityUnknown && identity.IsUserReservedIdentity(id) {
-				return identity.LookupReservedIdentity(id)
-			}
-			// If a fixed identity was not found then we return nil to avoid
-			// falling to a reserved identity.
-			return nil
-		// If it doesn't contain a fixed-identity then make sure the set of
-		// labels only contains a single label and that label is of the reserved
-		// type. This is to prevent users from adding cilium-reserved labels
-		// into the workloads.
-		case lbl.Source == labels.LabelSourceReserved:
-			if len(lbls) != 1 {
-				return nil
-			}
-			id := identity.GetReservedID(lbl.Key)
-			if id != identity.IdentityUnknown && !identity.IsUserReservedIdentity(id) {
-				return identity.LookupReservedIdentity(id)
-			}
-		}
-	}
-	return nil
-}
-
 var unknownIdentity = identity.NewIdentity(identity.IdentityUnknown, labels.Labels{labels.IDNameUnknown: labels.NewLabel(labels.IDNameUnknown, "", labels.LabelSourceReserved)})
 
 // LookupIdentityByID returns the identity by ID. This function will first
 // search through the local cache and fall back to querying the kvstore.
-func LookupIdentityByID(id identity.NumericIdentity) *identity.Identity {
+func (m *CachingIdentityAllocator) LookupIdentityByID(id identity.NumericIdentity) *identity.Identity {
 	if id == identity.IdentityUnknown {
 		return unknownIdentity
 	}
@@ -279,15 +244,15 @@ func LookupIdentityByID(id identity.NumericIdentity) *identity.Identity {
 		return identity
 	}
 
-	if IdentityAllocator == nil {
+	if m.IdentityAllocator == nil {
 		return nil
 	}
 
-	if identity := localIdentities.lookupByID(id); identity != nil {
+	if identity := m.localIdentities.lookupByID(id); identity != nil {
 		return identity
 	}
 
-	allocatorKey, err := IdentityAllocator.GetByID(idpool.ID(id))
+	allocatorKey, err := m.IdentityAllocator.GetByID(idpool.ID(id))
 	if err != nil {
 		return nil
 	}
@@ -296,28 +261,5 @@ func LookupIdentityByID(id identity.NumericIdentity) *identity.Identity {
 		return identity.NewIdentityFromLabelArray(id, gi.LabelArray)
 	}
 
-	return nil
-}
-
-// AddUserDefinedNumericIdentitySet adds all key-value pairs from the given map
-// to the map of user defined numeric identities and reserved identities.
-// The key-value pairs should map a numeric identity to a valid label.
-// Is not safe for concurrent use.
-func AddUserDefinedNumericIdentitySet(m map[string]string) error {
-	// Validate first
-	for k := range m {
-		ni, err := identity.ParseNumericIdentity(k)
-		if err != nil {
-			return err
-		}
-		if !identity.IsUserReservedIdentity(ni) {
-			return identity.ErrNotUserIdentity
-		}
-	}
-	for k, lbl := range m {
-		ni, _ := identity.ParseNumericIdentity(k)
-		identity.AddUserDefinedNumericIdentity(ni, lbl)
-		identity.AddReservedIdentity(ni, lbl)
-	}
 	return nil
 }

--- a/pkg/identity/cache/cache_test.go
+++ b/pkg/identity/cache/cache_test.go
@@ -57,23 +57,26 @@ func (s *IdentityCacheTestSuite) TestLookupReservedIdentity(c *C) {
 		option.Config.ClusterName = bak
 	}()
 
-	hostID := identity.GetReservedID("host")
-	c.Assert(LookupIdentityByID(hostID), Not(IsNil))
+	mgr := NewCachingIdentityAllocator(newDummyOwner())
+	<-mgr.InitIdentityAllocator(nil, nil)
 
-	id := LookupIdentity(labels.NewLabelsFromModel([]string{"reserved:host"}))
+	hostID := identity.GetReservedID("host")
+	c.Assert(mgr.LookupIdentityByID(hostID), Not(IsNil))
+
+	id := mgr.LookupIdentity(labels.NewLabelsFromModel([]string{"reserved:host"}))
 	c.Assert(id, Not(IsNil))
 	c.Assert(id.ID, Equals, hostID)
 
 	worldID := identity.GetReservedID("world")
-	c.Assert(LookupIdentityByID(worldID), Not(IsNil))
+	c.Assert(mgr.LookupIdentityByID(worldID), Not(IsNil))
 
-	id = LookupIdentity(labels.NewLabelsFromModel([]string{"reserved:world"}))
+	id = mgr.LookupIdentity(labels.NewLabelsFromModel([]string{"reserved:world"}))
 	c.Assert(id, Not(IsNil))
 	c.Assert(id.ID, Equals, worldID)
 
 	identity.InitWellKnownIdentities()
 
-	id = LookupIdentity(kvstoreLabels)
+	id = mgr.LookupIdentity(kvstoreLabels)
 	c.Assert(id, Not(IsNil))
 	c.Assert(id.ID, Equals, identity.ReservedCiliumKVStore)
 }
@@ -133,7 +136,7 @@ func (s *IdentityCacheTestSuite) TestLookupReservedIdentityByLabels(c *C) {
 	}
 
 	for _, tt := range tests {
-		got := LookupReservedIdentityByLabels(tt.args.lbls)
+		got := identity.LookupReservedIdentityByLabels(tt.args.lbls)
 		switch {
 		case got == nil && tt.want == nil:
 		case got == nil && tt.want != nil ||

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -212,3 +212,74 @@ func RequiresGlobalIdentity(lbls labels.Labels) bool {
 
 	return false
 }
+
+// AddUserDefinedNumericIdentitySet adds all key-value pairs from the given map
+// to the map of user defined numeric identities and reserved identities.
+// The key-value pairs should map a numeric identity to a valid label.
+// Is not safe for concurrent use.
+func AddUserDefinedNumericIdentitySet(m map[string]string) error {
+	// Validate first
+	for k := range m {
+		ni, err := ParseNumericIdentity(k)
+		if err != nil {
+			return err
+		}
+		if !IsUserReservedIdentity(ni) {
+			return ErrNotUserIdentity
+		}
+	}
+	for k, lbl := range m {
+		ni, _ := ParseNumericIdentity(k)
+		AddUserDefinedNumericIdentity(ni, lbl)
+		AddReservedIdentity(ni, lbl)
+	}
+	return nil
+}
+
+// LookupReservedIdentityByLabels looks up a reserved identity by its labels and
+// returns it if found. Returns nil if not found.
+func LookupReservedIdentityByLabels(lbls labels.Labels) *Identity {
+	if identity := WellKnown.LookupByLabels(lbls); identity != nil {
+		return identity
+	}
+
+	for _, lbl := range lbls {
+		switch {
+		// If the set of labels contain a fixed identity then and exists in
+		// the map of reserved IDs then return the identity of that reserved ID.
+		case lbl.Key == labels.LabelKeyFixedIdentity:
+			id := GetReservedID(lbl.Value)
+			if id != IdentityUnknown && IsUserReservedIdentity(id) {
+				return LookupReservedIdentity(id)
+			}
+			// If a fixed identity was not found then we return nil to avoid
+			// falling to a reserved identity.
+			return nil
+		// If it doesn't contain a fixed-identity then make sure the set of
+		// labels only contains a single label and that label is of the reserved
+		// type. This is to prevent users from adding cilium-reserved labels
+		// into the workloads.
+		case lbl.Source == labels.LabelSourceReserved:
+			if len(lbls) != 1 {
+				return nil
+			}
+			id := GetReservedID(lbl.Key)
+			if id != IdentityUnknown && !IsUserReservedIdentity(id) {
+				return LookupReservedIdentity(id)
+			}
+		}
+	}
+	return nil
+}
+
+// IdentityAllocationIsLocal returns true if a call to AllocateIdentity with
+// the given labels would not require accessing the KV store to allocate the
+// identity.
+// Currently, this function returns true only if the labels are those of a
+// reserved identity, i.e. if the slice contains a single reserved
+// "reserved:*" label.
+func IdentityAllocationIsLocal(lbls labels.Labels) bool {
+	// If there is only one label with the "reserved" source and a well-known
+	// key, the well-known identity for it can be allocated locally.
+	return LookupReservedIdentityByLabels(lbls) != nil
+}

--- a/pkg/identity/identitymanager/manager.go
+++ b/pkg/identity/identitymanager/manager.go
@@ -62,6 +62,11 @@ func Remove(identity *identity.Identity) {
 	GlobalIdentityManager.Remove(identity)
 }
 
+// RemoveAll deletes all identities from the GlobalIdentityManager.
+func RemoveAll() {
+	GlobalIdentityManager.RemoveAll()
+}
+
 // Add inserts the identity into the identity manager. If the identity is
 // already in the identity manager, the reference count for the identity is
 // incremented.
@@ -90,6 +95,7 @@ func (idm *IdentityManager) add(identity *identity.Identity) {
 		for o := range idm.observers {
 			o.LocalEndpointIdentityAdded(identity)
 		}
+
 	} else {
 		idMeta.refCount++
 	}
@@ -123,6 +129,16 @@ func (idm *IdentityManager) RemoveOldAddNew(old, new *identity.Identity) {
 // GlobalIdentityManager.
 func RemoveOldAddNew(old, new *identity.Identity) {
 	GlobalIdentityManager.RemoveOldAddNew(old, new)
+}
+
+// RemoveAll removes all identities.
+func (idm *IdentityManager) RemoveAll() {
+	idm.mutex.Lock()
+	defer idm.mutex.Unlock()
+
+	for id := range idm.identities {
+		idm.remove(idm.identities[id].identity)
+	}
 }
 
 // Remove deletes the identity from the identity manager. If the identity is

--- a/pkg/k8s/endpointsynchronizer/cep.go
+++ b/pkg/k8s/endpointsynchronizer/cep.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/k8s"
 	"reflect"
 	"time"
@@ -38,7 +39,9 @@ import (
 // of CiliumEndpoint resources.
 // TODO - see whether folding the global variables below into this function
 // is cleaner.
-type EndpointSynchronizer struct{}
+type EndpointSynchronizer struct {
+	Allocator *cache.CachingIdentityAllocator
+}
 
 // RunK8sCiliumEndpointSync starts a controller that synchronizes the endpoint
 // to the corresponding k8s CiliumEndpoint CRD. It is expected that each CEP

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -160,7 +160,7 @@ func (s *K8sSuite) TestParseNetworkPolicyIngress(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(len(rules), Equals, 1)
 
-	repo := policy.NewPolicyRepository()
+	repo := policy.NewPolicyRepository(nil)
 
 	repo.AddList(rules)
 	c.Assert(repo.AllowsIngressRLocked(&ctx), Equals, api.Denied)
@@ -289,7 +289,7 @@ func (s *K8sSuite) TestParseNetworkPolicyMultipleSelectors(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(len(rules), Equals, 1)
 
-	repo := policy.NewPolicyRepository()
+	repo := policy.NewPolicyRepository(nil)
 	repo.AddList(rules)
 
 	endpointLabels := labels.LabelArray{
@@ -487,7 +487,7 @@ func (s *K8sSuite) TestParseNetworkPolicyEgress(c *C) {
 		Trace: policy.TRACE_VERBOSE,
 	}
 
-	repo := policy.NewPolicyRepository()
+	repo := policy.NewPolicyRepository(nil)
 	repo.AddList(rules)
 	// Because search context did not contain port-specific policy, deny is
 	// expected.
@@ -542,7 +542,7 @@ func (s *K8sSuite) TestParseNetworkPolicyEgress(c *C) {
 }
 
 func parseAndAddRules(c *C, p *networkingv1.NetworkPolicy) *policy.Repository {
-	repo := policy.NewPolicyRepository()
+	repo := policy.NewPolicyRepository(nil)
 	rules, err := ParseNetworkPolicy(p)
 	c.Assert(err, IsNil)
 	rev := repo.GetRevision()
@@ -700,7 +700,7 @@ func (s *K8sSuite) TestParseNetworkPolicyEmptyFrom(c *C) {
 		Trace: policy.TRACE_VERBOSE,
 	}
 
-	repo := policy.NewPolicyRepository()
+	repo := policy.NewPolicyRepository(nil)
 	repo.AddList(rules)
 	c.Assert(repo.AllowsIngressRLocked(&ctx), Equals, api.Allowed)
 
@@ -724,7 +724,7 @@ func (s *K8sSuite) TestParseNetworkPolicyEmptyFrom(c *C) {
 	rules, err = ParseNetworkPolicy(netPolicy2)
 	c.Assert(err, IsNil)
 	c.Assert(len(rules), Equals, 1)
-	repo = policy.NewPolicyRepository()
+	repo = policy.NewPolicyRepository(nil)
 	repo.AddList(rules)
 	c.Assert(repo.AllowsIngressRLocked(&ctx), Equals, api.Allowed)
 }
@@ -755,7 +755,7 @@ func (s *K8sSuite) TestParseNetworkPolicyDenyAll(c *C) {
 		Trace: policy.TRACE_VERBOSE,
 	}
 
-	repo := policy.NewPolicyRepository()
+	repo := policy.NewPolicyRepository(nil)
 	repo.AddList(rules)
 	c.Assert(repo.AllowsIngressRLocked(&ctx), Equals, api.Denied)
 }
@@ -866,7 +866,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(len(rules), Equals, 1)
 
-	repo := policy.NewPolicyRepository()
+	repo := policy.NewPolicyRepository(nil)
 	repo.AddList(rules)
 	ctx := policy.SearchContext{
 		From: labels.LabelArray{
@@ -1000,7 +1000,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(len(rules), Equals, 1)
 
-	repo = policy.NewPolicyRepository()
+	repo = policy.NewPolicyRepository(nil)
 	repo.AddList(rules)
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
@@ -1068,7 +1068,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(len(rules), Equals, 1)
 
-	repo = policy.NewPolicyRepository()
+	repo = policy.NewPolicyRepository(nil)
 	repo.AddList(rules)
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
@@ -1207,7 +1207,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(len(rules), Equals, 1)
 
-	repo = policy.NewPolicyRepository()
+	repo = policy.NewPolicyRepository(nil)
 	// add example 4
 	repo.AddList(rules)
 

--- a/pkg/k8s/rule_translate_test.go
+++ b/pkg/k8s/rule_translate_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func (s *K8sSuite) TestTranslatorDirect(c *C) {
-	repo := policy.NewPolicyRepository()
+	repo := policy.NewPolicyRepository(nil)
 
 	tag1 := labels.LabelArray{labels.ParseLabel("tag1")}
 	serviceInfo := ServiceID{
@@ -124,7 +124,7 @@ func (s *K8sSuite) TestServiceMatches(c *C) {
 }
 
 func (s *K8sSuite) TestTranslatorLabels(c *C) {
-	repo := policy.NewPolicyRepository()
+	repo := policy.NewPolicyRepository(nil)
 	svcLabels := map[string]string{
 		"app": "tested-service",
 	}

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -70,7 +70,7 @@ func (ep *testEP) LookupRedirectPort(l4 *L4Filter) uint16 {
 }
 
 func (s *DistilleryTestSuite) TestCacheManagement(c *C) {
-	repo := NewPolicyRepository()
+	repo := NewPolicyRepository(nil)
 	cache := repo.policyCache
 	identity := ep1.GetSecurityIdentity()
 	c.Assert(ep2.GetSecurityIdentity(), Equals, identity)
@@ -105,7 +105,7 @@ func (s *DistilleryTestSuite) TestCacheManagement(c *C) {
 }
 
 func (s *DistilleryTestSuite) TestCachePopulation(c *C) {
-	repo := NewPolicyRepository()
+	repo := NewPolicyRepository(nil)
 	repo.revision = 42
 	cache := repo.policyCache
 
@@ -272,7 +272,7 @@ type policyDistillery struct {
 
 func newPolicyDistillery(selectorCache *SelectorCache) *policyDistillery {
 	ret := &policyDistillery{
-		Repository: NewPolicyRepository(),
+		Repository: NewPolicyRepository(nil),
 	}
 	ret.selectorCache = selectorCache
 	return ret

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -24,8 +24,9 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/testutils/allocator"
 
-	logging "github.com/op/go-logging"
+	"github.com/op/go-logging"
 	. "gopkg.in/check.v1"
 )
 
@@ -34,7 +35,8 @@ var (
 	toFoo        = &SearchContext{To: labels.ParseSelectLabelArray("foo")}
 
 	dummySelectorCacheUser = &DummySelectorCacheUser{}
-	testSelectorCache      = NewSelectorCache(cache.GetIdentityCache())
+	c                      = cache.NewCachingIdentityAllocator(&allocator.IdentityAllocatorOwnerMock{})
+	testSelectorCache      = NewSelectorCache(c.GetIdentityCache())
 
 	wildcardCachedSelector, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, api.WildcardEndpointSelector)
 

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -71,17 +71,19 @@ func (p *Repository) GetPolicyCache() *PolicyCache {
 	return p.policyCache
 }
 
-// NewPolicyRepository allocates a new policy repository
-func NewPolicyRepository() *Repository {
+// NewPolicyRepository creates a new policy repository.
+func NewPolicyRepository(idCache cache.IdentityCache) *Repository {
 	repoChangeQueue := eventqueue.NewEventQueueBuffered("repository-change-queue", option.Config.PolicyQueueSize)
 	ruleReactionQueue := eventqueue.NewEventQueueBuffered("repository-reaction-queue", option.Config.PolicyQueueSize)
 	repoChangeQueue.Run()
 	ruleReactionQueue.Run()
+	selectorCache := NewSelectorCache(idCache)
+
 	repo := &Repository{
 		revision:              1,
 		RepositoryChangeQueue: repoChangeQueue,
 		RuleReactionQueue:     ruleReactionQueue,
-		selectorCache:         NewSelectorCache(cache.GetIdentityCache()),
+		selectorCache:         selectorCache,
 	}
 	repo.policyCache = NewPolicyCache(repo, true)
 	return repo

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -43,7 +43,7 @@ func (ds *PolicyTestSuite) TestComputePolicyEnforcementAndRules(c *C) {
 
 	SetPolicyEnabled(option.DefaultEnforcement)
 
-	repo := NewPolicyRepository()
+	repo := NewPolicyRepository(nil)
 	repo.selectorCache = testSelectorCache
 
 	fooSelectLabel := labels.ParseSelectLabel("foo")
@@ -237,7 +237,7 @@ func (ds *PolicyTestSuite) TestComputePolicyEnforcementAndRules(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestAddSearchDelete(c *C) {
-	repo := NewPolicyRepository()
+	repo := NewPolicyRepository(nil)
 	repo.selectorCache = testSelectorCache
 
 	// cannot add empty rule
@@ -323,7 +323,7 @@ func (ds *PolicyTestSuite) TestAddSearchDelete(c *C) {
 }
 
 func BenchmarkParseLabel(b *testing.B) {
-	repo := NewPolicyRepository()
+	repo := NewPolicyRepository(nil)
 	repo.selectorCache = testSelectorCache
 
 	b.ResetTimer()
@@ -362,7 +362,7 @@ func BenchmarkParseLabel(b *testing.B) {
 }
 
 func (ds *PolicyTestSuite) TestAllowsIngress(c *C) {
-	repo := NewPolicyRepository()
+	repo := NewPolicyRepository(nil)
 	repo.selectorCache = testSelectorCache
 
 	fooToBar := &SearchContext{
@@ -455,7 +455,7 @@ func (ds *PolicyTestSuite) TestAllowsIngress(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestAllowsEgress(c *C) {
-	repo := NewPolicyRepository()
+	repo := NewPolicyRepository(nil)
 	repo.selectorCache = testSelectorCache
 
 	fooToBar := &SearchContext{
@@ -557,7 +557,7 @@ func (ds *PolicyTestSuite) TestAllowsEgress(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestWildcardL3RulesIngress(c *C) {
-	repo := NewPolicyRepository()
+	repo := NewPolicyRepository(nil)
 	repo.selectorCache = testSelectorCache
 
 	labelsL3 := labels.LabelArray{labels.ParseLabel("L3")}
@@ -723,7 +723,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngress(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestWildcardL4RulesIngress(c *C) {
-	repo := NewPolicyRepository()
+	repo := NewPolicyRepository(nil)
 	repo.selectorCache = testSelectorCache
 
 	selFoo := api.NewESFromLabels(labels.ParseSelectLabel("id=foo"))
@@ -866,7 +866,7 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesIngress(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestL3DependentL4IngressFromRequires(c *C) {
-	repo := NewPolicyRepository()
+	repo := NewPolicyRepository(nil)
 	repo.selectorCache = testSelectorCache
 
 	selFoo := api.NewESFromLabels(labels.ParseSelectLabel("id=foo"))
@@ -932,7 +932,7 @@ func (ds *PolicyTestSuite) TestL3DependentL4IngressFromRequires(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestL3DependentL4EgressFromRequires(c *C) {
-	repo := NewPolicyRepository()
+	repo := NewPolicyRepository(nil)
 	repo.selectorCache = testSelectorCache
 
 	selFoo := api.NewESFromLabels(labels.ParseSelectLabel("id=foo"))
@@ -1022,7 +1022,7 @@ func (ds *PolicyTestSuite) TestL3DependentL4EgressFromRequires(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestWildcardL3RulesEgress(c *C) {
-	repo := NewPolicyRepository()
+	repo := NewPolicyRepository(nil)
 	repo.selectorCache = testSelectorCache
 
 	selFoo := api.NewESFromLabels(labels.ParseSelectLabel("id=foo"))
@@ -1153,7 +1153,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgress(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestWildcardL4RulesEgress(c *C) {
-	repo := NewPolicyRepository()
+	repo := NewPolicyRepository(nil)
 	repo.selectorCache = testSelectorCache
 
 	selFoo := api.NewESFromLabels(labels.ParseSelectLabel("id=foo"))
@@ -1296,7 +1296,7 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesEgress(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestWildcardCIDRRulesEgress(c *C) {
-	repo := NewPolicyRepository()
+	repo := NewPolicyRepository(nil)
 	repo.selectorCache = testSelectorCache
 
 	labelsL3 := labels.LabelArray{labels.ParseLabel("L3")}
@@ -1396,7 +1396,7 @@ func (ds *PolicyTestSuite) TestWildcardCIDRRulesEgress(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestWildcardL3RulesIngressFromEntities(c *C) {
-	repo := NewPolicyRepository()
+	repo := NewPolicyRepository(nil)
 	repo.selectorCache = testSelectorCache
 
 	selFoo := api.NewESFromLabels(labels.ParseSelectLabel("id=foo"))
@@ -1532,7 +1532,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngressFromEntities(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestWildcardL3RulesEgressToEntities(c *C) {
-	repo := NewPolicyRepository()
+	repo := NewPolicyRepository(nil)
 	repo.selectorCache = testSelectorCache
 
 	selFoo := api.NewESFromLabels(labels.ParseSelectLabel("id=foo"))
@@ -1668,7 +1668,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgressToEntities(c *C) {
 }
 
 func (ds *PolicyTestSuite) TestMinikubeGettingStarted(c *C) {
-	repo := NewPolicyRepository()
+	repo := NewPolicyRepository(nil)
 	repo.selectorCache = testSelectorCache
 
 	app2Selector := labels.ParseSelectLabelArray("id=app2")
@@ -1846,7 +1846,7 @@ func (repo *Repository) checkTrace(c *C, ctx *SearchContext, trace string,
 }
 
 func (ds *PolicyTestSuite) TestPolicyTrace(c *C) {
-	repo := NewPolicyRepository()
+	repo := NewPolicyRepository(nil)
 	repo.selectorCache = testSelectorCache
 
 	// Add rules to allow foo=>bar

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
+	"github.com/cilium/cilium/pkg/testutils/allocator"
 	. "gopkg.in/check.v1"
 )
 
@@ -174,7 +175,8 @@ func (d DummyOwner) LookupRedirectPort(l4 *L4Filter) uint16 {
 }
 
 func bootstrapRepo(ruleGenFunc func(int) api.Rules, numRules int, c *C) *Repository {
-	testRepo := NewPolicyRepository()
+	mgr := cache.NewCachingIdentityAllocator(&allocator.IdentityAllocatorOwnerMock{})
+	testRepo := NewPolicyRepository(mgr.GetIdentityCache())
 
 	var wg sync.WaitGroup
 	SetPolicyEnabled(option.DefaultEnforcement)

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -1346,7 +1346,7 @@ func checkEgress(c *C, repo *Repository, ctx *SearchContext, verdict api.Decisio
 }
 
 func parseAndAddRules(c *C, rules api.Rules) *Repository {
-	repo := NewPolicyRepository()
+	repo := NewPolicyRepository(nil)
 	repo.selectorCache = testSelectorCache
 
 	_, _ = repo.AddList(rules)

--- a/pkg/proxy/epinfo.go
+++ b/pkg/proxy/epinfo.go
@@ -29,6 +29,11 @@ var (
 	// EndpointInfoRegistry interface.
 	DefaultEndpointInfoRegistry logger.EndpointInfoRegistry = &defaultEndpointInfoRegistry{}
 	endpointManager             EndpointLookup
+	// Allocator is a package-level variable which is used to lookup security
+	// identities from their numeric representation.
+	// TODO: plumb an allocator in from callers of these functions vs. having
+	// this as a package-level variable.
+	Allocator *cache.CachingIdentityAllocator
 )
 
 // EndpointLookup is any type which maps from IP to the endpoint owning that IP.
@@ -41,7 +46,7 @@ type EndpointLookup interface {
 type defaultEndpointInfoRegistry struct{}
 
 func (r *defaultEndpointInfoRegistry) FillEndpointIdentityByID(id identity.NumericIdentity, info *accesslog.EndpointInfo) bool {
-	identity := cache.LookupIdentityByID(id)
+	identity := Allocator.LookupIdentityByID(id)
 	if identity == nil {
 		return false
 	}

--- a/pkg/testutils/allocator/allocator.go
+++ b/pkg/testutils/allocator/allocator.go
@@ -1,0 +1,58 @@
+// Copyright 2018-2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package allocator
+
+import (
+	"context"
+
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/labels"
+)
+
+type IdentityAllocatorOwnerMock struct{}
+
+func (i *IdentityAllocatorOwnerMock) UpdateIdentities(added, deleted cache.IdentityCache) {}
+
+func (i *IdentityAllocatorOwnerMock) GetNodeSuffix() string {
+	return "foo"
+}
+
+// FakeIdentityAllocator is used as a mock identity allocator for unit tests.
+type FakeIdentityAllocator struct{}
+
+// WaitForInitialGlobalIdentities does nothing.
+func (f *FakeIdentityAllocator) WaitForInitialGlobalIdentities(context.Context) error {
+	return nil
+}
+
+// AllocateIdentity does nothing.
+func (f *FakeIdentityAllocator) AllocateIdentity(context.Context, labels.Labels, bool) (*identity.Identity, bool, error) {
+	return nil, true, nil
+}
+
+// Release does nothing.
+func (f *FakeIdentityAllocator) Release(context.Context, *identity.Identity) (released bool, err error) {
+	return true, nil
+}
+
+// LookupIdentityByID returns the identity corresponding to the id if the
+// identity is a reserved identity. Otherwise, returns nil.
+func (f *FakeIdentityAllocator) LookupIdentityByID(id identity.NumericIdentity) *identity.Identity {
+	if identity := identity.LookupReservedIdentity(id); identity != nil {
+		return identity
+	}
+	return nil
+}

--- a/pkg/workloads/config.go
+++ b/pkg/workloads/config.go
@@ -76,7 +76,7 @@ func getOpts(opts workloadRuntimeOpts) map[string]string {
 
 var (
 	setupOnce sync.Once
-	allocator allocatorInterface
+	allocator ipAllocator
 )
 
 func setupWorkload(workloadRuntime WorkloadRuntimeType, opts map[string]string, epMgr *endpointmanager.EndpointManager) error {
@@ -92,17 +92,17 @@ func setupWorkload(workloadRuntime WorkloadRuntimeType, opts map[string]string, 
 	return initClient(workloadMod, epMgr)
 }
 
-type allocatorInterface interface {
+type ipAllocator interface {
 	BlacklistIP(ip net.IP, owner string)
 }
 
 // Setup sets up the workload runtime specified in workloadRuntime and configures it
 // with the options provided in opts
-func Setup(a allocatorInterface, epMgr *endpointmanager.EndpointManager, workloadRuntimes []string, opts map[WorkloadRuntimeType]map[string]string) error {
+func Setup(a ipAllocator, epMgr *endpointmanager.EndpointManager, workloadRuntimes []string, opts map[WorkloadRuntimeType]map[string]string) error {
 	return setup(a, epMgr, workloadRuntimes, opts, false)
 }
 
-func setup(a allocatorInterface, epMgr *endpointmanager.EndpointManager, workloadRuntimes []string, opts map[WorkloadRuntimeType]map[string]string, bypassStatusCheck bool) error {
+func setup(a ipAllocator, epMgr *endpointmanager.EndpointManager, workloadRuntimes []string, opts map[WorkloadRuntimeType]map[string]string, bypassStatusCheck bool) error {
 	var (
 		st  *models.Status
 		err error

--- a/test/runtime/chaos.go
+++ b/test/runtime/chaos.go
@@ -206,6 +206,7 @@ var _ = Describe("RuntimeChaos", func() {
 		identities, err := vm.GetEndpointsIdentityIds()
 		Expect(err).To(BeNil(), "Cannot get identities")
 
+		By("Deleting identities from kvstore")
 		for _, identityID := range identities {
 			action := helpers.CurlFail("%s/%s -X DELETE", prefix, identityID)
 			vm.Exec(action).ExpectSuccess("Key %s cannot be deleted correctly", identityID)
@@ -217,6 +218,7 @@ var _ = Describe("RuntimeChaos", func() {
 		Expect(newidentities).To(Equal(identities),
 			"Identities are not the same after delete keys from kvstore")
 
+		By("Checking that identities were restored correctly after deletion")
 		for _, identityID := range newidentities {
 			id, err := identity.ParseNumericIdentity(identityID)
 			Expect(err).To(BeNil(), "Cannot parse identity")
@@ -224,7 +226,7 @@ var _ = Describe("RuntimeChaos", func() {
 				continue
 			}
 			action := helpers.CurlFail("%s/%s", prefix, identityID)
-			vm.Exec(action).ExpectSuccess("Key %s cannot is not restored correctly", identityID)
+			vm.Exec(action).ExpectSuccess("Key %s was not restored correctly", identityID)
 		}
 	})
 


### PR DESCRIPTION
This type encapsulates values which previously were package-level variables
into a specific type, `CachingIdentityAllocator `. This removes the need
to directly import `pkg/identity/cache`, and will make unit testing easier
in packages which need to allocat identities on demand, e.g. `pkg/endpoint`.

The daemon now has an `CachingIdentityAllocator ` member, which it plumbs
down into various subsystems which need to allocate identities.

This review looks more daunting than it is - a lot of it is substituting of calls to `cache.*` to work on the new type instead of calling the package-level function, as well as to account for the changing of parameters for `NewPolicyRepository`. 

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9066)
<!-- Reviewable:end -->
