### PR TITLE
v1.6 backports 2019-08-29

### DIFF
--- a/Documentation/gettingstarted/host-services.rst
+++ b/Documentation/gettingstarted/host-services.rst
@@ -21,8 +21,11 @@ reached from the host namespace.
 .. note::
 
    Host-reachable services for TCP and UDP requires a v4.19.57, v5.1.16, v5.2.0
-   or more recent Linux kernel. For only enabling TCP-based host-reachable
-   services a v4.17.0 or newer kernel is required.
+   or more recent Linux kernel. Note that v5.0.y kernels do not have the fix
+   required to run host-reachable services with UDP since at this point in time
+   the v5.0.y stable kernel is end-of-life (EOL) and not maintained anymore. For
+   only enabling TCP-based host-reachable services a v4.17.0 or newer kernel
+   is required.
 
 .. include:: k8s-install-download-release.rst
 

--- a/Documentation/gettingstarted/nodeport.rst
+++ b/Documentation/gettingstarted/nodeport.rst
@@ -23,7 +23,10 @@ without ``kube-proxy``.
 .. note::
 
    NodePort services depend on the :ref:`host-services` feature, therefore
-   a v4.19.57, v5.1.16, v5.2.0 or more recent Linux kernel is required.
+   a v4.19.57, v5.1.16, v5.2.0 or more recent Linux kernel is required. Note
+   that v5.0.y kernels do not have the fix required to run BPF NodePort since
+   at this point in time the v5.0.y stable kernel is end-of-life (EOL) and
+   not maintained anymore.
 
 .. include:: k8s-install-download-release.rst
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -690,7 +690,7 @@ type rulesManager interface {
 	RemoveRules()
 	InstallRules(ifName string) error
 	TransientRulesStart(ifName string) error
-	TransientRulesEnd()
+	TransientRulesEnd(quiet bool)
 }
 
 // NewDaemon creates and returns a new Daemon with the parameters set in c.

--- a/daemon/datapath.go
+++ b/daemon/datapath.go
@@ -212,7 +212,7 @@ func (d *Daemon) compileBase() error {
 	d.iptablesManager.RemoveRules()
 	if option.Config.InstallIptRules {
 		err := d.iptablesManager.InstallRules(option.Config.HostDevice)
-		d.iptablesManager.TransientRulesEnd()
+		d.iptablesManager.TransientRulesEnd(false)
 		if err != nil {
 			return err
 		}

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -644,7 +644,7 @@ func checkReady(pod v1.Pod) bool {
 	return true
 }
 
-// WaitforNPodsRunning waits up until timeout seconds have elapsed for at least
+// WaitforNPodsRunning waits up until timeout duration has elapsed for at least
 // minRequired pods in the specified namespace that match the provided JSONPath
 // filter to have their containterStatuses equal to "running".
 // Returns no error if minRequired pods achieve the aforementioned desired

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -111,13 +111,13 @@ var _ = Describe("K8sPolicyTest", func() {
 
 		validateConnectivity := func(expectWorldSuccess, expectClusterSuccess bool) {
 			for _, pod := range []string{appPods[helpers.App2], appPods[helpers.App3]} {
-				By("HTTP connectivity to google.com")
+				By("HTTP connectivity to 1.1.1.1")
 				res := kubectl.ExecPodCmd(
 					namespaceForTest, pod,
-					helpers.CurlFail("http://www.google.com/"))
+					helpers.CurlFail("http://1.1.1.1/"))
 
 				ExpectWithOffset(1, res).To(getMatcher(expectWorldSuccess),
-					"HTTP egress connectivity to google.com from pod %q", pod)
+					"HTTP egress connectivity to 1.1.1.1 from pod %q", pod)
 
 				By("ICMP connectivity to 8.8.8.8")
 				res = kubectl.ExecPodCmd(
@@ -387,7 +387,7 @@ var _ = Describe("K8sPolicyTest", func() {
 			for _, pod := range []string{appPods[helpers.App2], appPods[helpers.App3]} {
 				res := kubectl.ExecPodCmd(
 					namespaceForTest, pod,
-					helpers.CurlFail("http://www.google.com/"))
+					helpers.CurlFail("http://1.1.1.1/"))
 				res.ExpectFail("Egress connectivity should be denied for pod %q", pod)
 
 				res = kubectl.ExecPodCmd(
@@ -414,7 +414,7 @@ var _ = Describe("K8sPolicyTest", func() {
 			for _, pod := range []string{appPods[helpers.App2], appPods[helpers.App3]} {
 				res := kubectl.ExecPodCmd(
 					namespaceForTest, pod,
-					helpers.CurlFail("http://www.google.com/"))
+					helpers.CurlFail("http://1.1.1.1/"))
 				res.ExpectFail("Egress connectivity should be denied for pod %q", pod)
 
 				res = kubectl.ExecPodCmd(
@@ -474,7 +474,7 @@ var _ = Describe("K8sPolicyTest", func() {
 			for _, pod := range apps {
 				res := kubectl.ExecPodCmd(
 					namespaceForTest, pod,
-					helpers.CurlFail("http://www.google.com/"))
+					helpers.CurlFail("http://1.1.1.1/"))
 				res.ExpectFail("Egress connectivity should be denied for pod %q", pod)
 
 				res = kubectl.ExecPodCmd(
@@ -520,7 +520,7 @@ var _ = Describe("K8sPolicyTest", func() {
 			for _, pod := range []string{appPods[helpers.App2], appPods[helpers.App3]} {
 				res := kubectl.ExecPodCmd(
 					namespaceForTest, pod,
-					helpers.CurlFail("http://www.google.com/"))
+					helpers.CurlFail("http://1.1.1.1/"))
 				res.ExpectSuccess("Egress connectivity should be allowed for pod %q", pod)
 
 				res = kubectl.ExecPodCmd(

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -127,14 +127,14 @@ var _ = Describe("K8sPolicyTest", func() {
 				ExpectWithOffset(1, res).To(getMatcher(expectWorldSuccess),
 					"ICMP egress connectivity to 8.8.8.8 from pod %q", pod)
 
-				By("DNS lookup of google.com")
+				By("DNS lookup of kubernetes.default.svc.cluster.local")
 				res = kubectl.ExecPodCmd(
 					namespaceForTest, pod,
-					"host -v www.google.com")
+					"host -v kubernetes.default.svc.cluster.local")
 
 				// kube-dns is always whitelisted so this should always work
 				ExpectWithOffset(1, res).To(getMatcher(expectWorldSuccess || expectClusterSuccess),
-					"DNS connectivity of www.google.com from pod %q", pod)
+					"DNS connectivity of kubernetes.default.svc.cluster.local from pod %q", pod)
 
 				By("HTTP connectivity from pod to pod")
 				res = kubectl.ExecPodCmd(
@@ -397,7 +397,7 @@ var _ = Describe("K8sPolicyTest", func() {
 
 				res = kubectl.ExecPodCmd(
 					namespaceForTest, pod,
-					"host www.google.com")
+					"host kubernetes.default.svc.cluster.local")
 				res.ExpectFail("Egress DNS connectivity should be denied for pod %q", pod)
 			}
 		})
@@ -424,7 +424,7 @@ var _ = Describe("K8sPolicyTest", func() {
 
 				res = kubectl.ExecPodCmd(
 					namespaceForTest, pod,
-					"host www.google.com")
+					"host kubernetes.default.svc.cluster.local")
 				res.ExpectFail("Egress DNS connectivity should be denied for pod %q", pod)
 			}
 
@@ -484,7 +484,7 @@ var _ = Describe("K8sPolicyTest", func() {
 
 				res = kubectl.ExecPodCmd(
 					namespaceForTest, pod,
-					"host www.google.com")
+					"host kubernetes.default.svc.cluster.local")
 				res.ExpectFail("Egress DNS connectivity should be denied for pod %q", pod)
 			}
 		})
@@ -530,7 +530,7 @@ var _ = Describe("K8sPolicyTest", func() {
 
 				res = kubectl.ExecPodCmd(
 					namespaceForTest, pod,
-					"host www.google.com")
+					"host kubernetes.default.svc.cluster.local")
 				res.ExpectSuccess("Egress DNS connectivity should be allowed for pod %q", pod)
 			}
 		})

--- a/test/k8sT/istio.go
+++ b/test/k8sT/istio.go
@@ -59,7 +59,6 @@ var _ = Describe("K8sIstioTest", func() {
 			// those that we care about are uncommented.
 			// "istio-citadel",
 			// "istio-galley",
-			// "istio-egressgateway",
 			"istio-ingressgateway",
 			"istio-pilot",
 			// "istio-policy",
@@ -92,7 +91,7 @@ var _ = Describe("K8sIstioTest", func() {
 		res := kubectl.NamespaceCreate(istioSystemNamespace)
 		res.ExpectSuccess("unable to create namespace %q", istioSystemNamespace)
 
-		By("Creating the Istio resources")
+		By("Creating the Istio CRDs")
 
 		res = kubectl.Apply(istioCRDYAMLPath)
 		res.ExpectSuccess("unable to create Istio CRDs")
@@ -101,6 +100,8 @@ var _ = Describe("K8sIstioTest", func() {
 		err := kubectl.WaitForCRDCount("istio.io|certmanager.k8s.io", 23, helpers.HelperTimeout)
 		Expect(err).To(BeNil(),
 			"Istio CRDs are not ready after timeout")
+
+		By("Creating the Istio system PODs")
 
 		res = kubectl.Apply(istioYAMLPath)
 		res.ExpectSuccess("unable to create Istio resources")
@@ -143,11 +144,22 @@ var _ = Describe("K8sIstioTest", func() {
 			"cilium bpf proxy list")
 	})
 
+	// This is defined as a separate function to be called from the test below
+	// so that we properly capture test artifacts if any of the assertions fail
+	// (see https://github.com/cilium/cilium/pull/8508).
 	waitIstioReady := func() {
 		// Ignore one-time jobs and Prometheus. All other pods in the
 		// namespaces have an "istio" label.
 		By("Waiting for Istio pods to be ready")
-		err := kubectl.WaitforPods(istioSystemNamespace, "-l istio", helpers.HelperTimeout)
+		// First wait for at least one POD to get into running state so that WaitforPods
+		// below does not succeed if there are no PODs with the "istio" label.
+		err := kubectl.WaitforNPodsRunning(istioSystemNamespace, "-l istio", 1, helpers.HelperTimeout)
+		ExpectWithOffset(1, err).To(BeNil(),
+			"No Istio POD is Running after timeout in namespace %q", istioSystemNamespace)
+
+		// Then wait for all the Istio PODs to get Ready
+		// Note that this succeeds if there are no PODs matching the filter (-l istio -n istio-system).
+		err = kubectl.WaitforPods(istioSystemNamespace, "-l istio", helpers.HelperTimeout)
 		ExpectWithOffset(1, err).To(BeNil(),
 			"Istio pods are not ready after timeout in namespace %q", istioSystemNamespace)
 


### PR DESCRIPTION
- PR: 9039 -- doc: Add Azure CNI to CNI chaining section (@tgraf) -- https://github.com/cilium/cilium/pull/9039
- PR: 9049 -- test: Wait for at least one Istio POD to get ready (@jrajahalme) -- https://github.com/cilium/cilium/pull/9049
- PR: 9063 -- CI: decouple HTTP and DNS testing in K8sPolicyTest (@raybejjani) -- https://github.com/cilium/cilium/pull/9063
- PR: 9074 -- docs: clarify nodeport and host-reachable services and 5.0.y kernel (@borkmann) -- https://github.com/cilium/cilium/pull/9074
- PR: 9072 -- cilium: silence harmless CILIUM_TRANSIENT_FORWARD warning on startup (@borkmann) -- https://github.com/cilium/cilium/pull/9072

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9078)
<!-- Reviewable:end -->
