### PR TITLE
test: Remove workaround to MASQ traffic from k8s2

### DIFF
--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -299,14 +299,6 @@ else
     fi
     sudo systemctl stop etcd
     docker pull k8s1:5000/cilium/cilium-dev:latest
-    # We need this workaround since kube-proxy is not aware of multiple network
-    # interfaces. If we send a packet to a service IP that packet is sent
-    # to the default route, because the service IP is unknown by the linux routing
-    # table, with the source IP of the interface in the default routing table, even
-    # though the service IP should be routed to a different interface.
-    # This particular workaround is only needed for cilium, running on a pod on host
-    # network namespace, to reach out kube-api-server.
-    sudo iptables -t nat -A POSTROUTING -o enp0s8 ! -s 192.168.36.12 -j MASQUERADE
 fi
 
 # Create world network


### PR DESCRIPTION
The workaround is no longer needed, as a request to api-server from k8s2 is being MASQUERADE'd by the following kube-proxy rules:

```
-A KUBE-SERVICES ! -s 10.10.0.0/16 -d 10.96.0.1/32 -p tcp -m comment --comment "default/kubernetes:https cluster IP" -m tcp --dport 443 -j KUBE-MARK-MASQ
-A KUBE-SERVICES -d 10.96.0.1/32 -p tcp -m comment --comment "default/kubernetes:https cluster IP" -m tcp --dport 443 -j KUBE-SVC-NPX46M4PTMTKRN6Y

-A KUBE-MARK-MASQ -j MARK --set-xmark 0x4000/0x4000
-A KUBE-POSTROUTING -m comment --comment "kubernetes service traffic requiring SNAT" -m mark --mark 0x4000/0x4000 -j MASQUERADE
```

The MASQUERADE happens after the service DNAT translation, so the source IP of the right interface is going to be selected.

In the case of kubeproxy-free, we don't need any MASQUERADE rule, as the transparent host-lb changes the api-server ClusterIP to a node IP before the kernel routing layer gets involved.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9079)
<!-- Reviewable:end -->
