### PR TITLE
endpoint: do not export `EventQueue`

### DIFF
--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -655,12 +655,12 @@ func (s *EndpointSuite) TestEndpointEventQueueDeadlockUponDeletion(c *C) {
 	ev2EnqueueCh := make(chan struct{})
 
 	go func() {
-		_, err := ep.EventQueue.Enqueue(ev)
+		_, err := ep.eventQueue.Enqueue(ev)
 		c.Assert(err, IsNil)
-		_, err = ep.EventQueue.Enqueue(ev2)
+		_, err = ep.eventQueue.Enqueue(ev2)
 		c.Assert(err, IsNil)
 		close(ev2EnqueueCh)
-		_, err = ep.EventQueue.Enqueue(ev3)
+		_, err = ep.eventQueue.Enqueue(ev3)
 		c.Assert(err, IsNil)
 	}()
 

--- a/pkg/endpoint/events.go
+++ b/pkg/endpoint/events.go
@@ -104,7 +104,7 @@ func (ev *EndpointRevisionBumpEvent) Handle(res chan interface{}) {
 func (e *Endpoint) PolicyRevisionBumpEvent(rev uint64) {
 	epBumpEvent := eventqueue.NewEvent(&EndpointRevisionBumpEvent{Rev: rev, ep: e})
 	// Don't check policy revision event results - it is best effort.
-	_, err := e.EventQueue.Enqueue(epBumpEvent)
+	_, err := e.eventQueue.Enqueue(epBumpEvent)
 	if err != nil {
 		log.WithFields(logrus.Fields{
 			logfields.PolicyRevision: rev,

--- a/pkg/endpoint/manager.go
+++ b/pkg/endpoint/manager.go
@@ -50,8 +50,8 @@ func (e *Endpoint) Expose(mgr endpointManager) error {
 	// its ID, and its eventqueue can be safely started. Ensure that it is only
 	// started once it is exposed to the endpointmanager so that it will be
 	// stopped when the endpoint is removed from the endpointmanager.
-	e.EventQueue = eventqueue.NewEventQueueBuffered(fmt.Sprintf("endpoint-%d", e.ID), option.Config.EndpointQueueSize)
-	e.EventQueue.Run()
+	e.eventQueue = eventqueue.NewEventQueueBuffered(fmt.Sprintf("endpoint-%d", e.ID), option.Config.EndpointQueueSize)
+	e.eventQueue.Run()
 
 	// No need to check liveness as an endpoint can only be deleted via the
 	// API after it has been inserted into the manager.
@@ -129,11 +129,11 @@ func (e *Endpoint) Unexpose(mgr endpointManager) <-chan struct{} {
 		// The endpoint's EventQueue may not be stopped yet (depending on whether
 		// the caller of the EventQueue has stopped it or not). Call it here
 		// to be safe so that ep.WaitToBeDrained() does not hang forever.
-		ep.EventQueue.Stop()
+		ep.eventQueue.Stop()
 
 		// Wait for no more events (primarily regenerations) to be occurring for
 		// this endpoint.
-		ep.EventQueue.WaitToBeDrained()
+		ep.eventQueue.WaitToBeDrained()
 
 		mgr.ReleaseID(ep)
 		close(epRemoved)

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -466,7 +466,7 @@ func (e *Endpoint) Regenerate(regenMetadata *regeneration.ExternalRegenerationMe
 	// This may block if the Endpoint's EventQueue is full. This has to be done
 	// synchronously as some callers depend on the fact that the event is
 	// synchronously enqueued.
-	resChan, err := e.EventQueue.Enqueue(epEvent)
+	resChan, err := e.eventQueue.Enqueue(epEvent)
 	if err != nil {
 		e.getLogger().Errorf("enqueue of EndpointRegenerationEvent failed: %s", err)
 		done <- false


### PR DESCRIPTION
The field is not used outside of `pkg/endpoint` any more; do not export it.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9080)
<!-- Reviewable:end -->
