### PR TITLE
Add mechanism to bootstrap k8s api-server BPF service

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -94,6 +94,7 @@ cilium-agent [flags]
       --ipv6-service-range string                             Kubernetes IPv6 services CIDR if not inside cluster prefix (default "auto")
       --ipvlan-master-device string                           Device facing external network acting as ipvlan master (default "undefined")
       --k8s-api-server string                                 Kubernetes api address server (for https use --k8s-kubeconfig-path instead)
+      --k8s-api-server-url-no-kubeproxy string                Kubernetes api server address for bootstrapping without kube-proxy
       --k8s-kubeconfig-path string                            Absolute path of the kubernetes kubeconfig file
       --k8s-require-ipv4-pod-cidr                             Require IPv4 PodCIDR to be specified in node resource
       --k8s-require-ipv6-pod-cidr                             Require IPv6 PodCIDR to be specified in node resource

--- a/daemon/config.go
+++ b/daemon/config.go
@@ -119,7 +119,7 @@ func (h *getConfig) Handle(params GetConfigParams) middleware.Responder {
 	status := &models.DaemonConfigurationStatus{
 		Addressing:       node.GetNodeAddressing(),
 		K8sConfiguration: k8s.GetKubeconfigPath(),
-		K8sEndpoint:      k8s.GetAPIServer(),
+		K8sEndpoint:      k8s.GetAPIServerURL(),
 		NodeMonitor:      &monitorState,
 		KvstoreConfiguration: &models.KVstoreConfiguration{
 			Type:    option.Config.KVStore,

--- a/daemon/k8s.go
+++ b/daemon/k8s.go
@@ -1,0 +1,104 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+
+	"github.com/cilium/cilium/pkg/k8s"
+	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/maps/lbmap"
+)
+
+// k8sAPIServerSVCBootstrap stores a state when bootstrapping the k8s api-server
+// service w/o kube-proxy.
+type k8sAPIServerSVCBootstrap struct {
+	// Previous URL of k8s api-server which will be restored after the bootstrap.
+	// Usually, it is a ClusterIP of k8s api-server SVC.
+	prevAPIServerURL string
+	// Indicates whether the bootstrap has been successfully finished.
+	done bool
+}
+
+// initK8sAPIServerSVCBootstrap temporarily changes the API server URL so that
+// the k8s client could connect to the api-server. Later on, after we have received
+// a Service update for the api-server and created the BPF LB service for it,
+// we can restore the URL (done by maybeFinish(), which should be called from
+// a handler which receives k8s Service updates).
+func initK8sAPIServerSVCBootstrap(apiServerURL string) (*k8sAPIServerSVCBootstrap, error) {
+	// Read the existing api-server address which will be restored after
+	// the bootstrap has been finished.
+	ipAddr := os.Getenv("KUBERNETES_SERVICE_HOST")
+	port := os.Getenv("KUBERNETES_SERVICE_PORT")
+	if ipAddr == "" || port == "" {
+		return nil, fmt.Errorf("KUBERNETES_SERVICE_{HOST,PORT} env variable is not set")
+	}
+	portNum, err := strconv.Atoi(port)
+	if err != nil {
+		return nil, fmt.Errorf("Invalid KUBERNETES_SERVICE_PORT %s: %s", port, err)
+	}
+
+	// Check whether a svc for the api-server already exists. If yes, then there
+	// is no need to bootstrap again (happens after cilium-agent has restarted
+	// after the successful bootstrap).
+	svc := loadbalancer.NewL3n4Addr(loadbalancer.NONE, net.ParseIP(ipAddr), uint16(portNum))
+	if lbmap.ExistAndHaveBackends(svc) {
+		return &k8sAPIServerSVCBootstrap{done: true}, nil
+	}
+
+	log.WithField(logfields.L3n4Addr, svc).
+		Infof("Bootstrapping k8s api-server service via %s", apiServerURL)
+
+	// Temporarily set the api-server address.
+	k8s.SetAPIServerURL(apiServerURL)
+
+	return &k8sAPIServerSVCBootstrap{
+		prevAPIServerURL: "https://" + net.JoinHostPort(ipAddr, port),
+		done:             false,
+	}, nil
+}
+
+func (b *k8sAPIServerSVCBootstrap) maybeFinish(svcFrontendIPAddr net.IP, svcPort uint16, backendCount int) error {
+	if b.done {
+		// The SVC has been already done, so nothing to do.
+		return nil
+	}
+
+	if backendCount == 0 {
+		// The SVC update didn't contain any backend. Restoring the API Server URL
+		// would blackhole all new connections to the api-server.
+		return nil
+	}
+
+	url := "https://" + net.JoinHostPort(svcFrontendIPAddr.String(), strconv.Itoa(int(svcPort)))
+	if url != b.prevAPIServerURL {
+		// Bail out if the SVC update wasn't for the api-server.
+		return nil
+	}
+
+	if err := k8s.UpdateAPIServerURL(b.prevAPIServerURL); err != nil {
+		fmt.Errorf("Failed to restore k8s api-server URL: %s", err)
+	}
+
+	log.Infof("Finished bootstrapping k8s api-server service")
+
+	b.done = true
+
+	return nil
+}

--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -1400,6 +1400,13 @@ func (d *Daemon) addK8sSVCs(svcID k8s.ServiceID, svc *k8s.Service, endpoints *k8
 			if _, err := d.svcAdd(*fe.addr, besValues, true, fe.nodePort); err != nil {
 				scopedLog.WithError(err).Error("Error while inserting service in LB map")
 			}
+			if d.k8sAPIServerSVCBootstrap != nil {
+				if err := d.k8sAPIServerSVCBootstrap.maybeFinish(
+					fe.addr.IP, fe.addr.Port, len(besValues)); err != nil {
+					scopedLog.WithError(err).Fatal("Failed to bootstrap the k8s api-server service")
+				}
+			}
+
 		}
 	}
 	return nil

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -95,7 +95,7 @@ func CreateConfigFromAgentResponse(resp *models.DaemonConfiguration) (*rest.Conf
 // CreateConfig creates a client configuration based on the configured API
 // server and Kubeconfig path
 func CreateConfig() (*rest.Config, error) {
-	return createConfig(GetAPIServer(), GetKubeconfigPath(), GetQPS(), GetBurst())
+	return createConfig(GetAPIServerURL(), GetKubeconfigPath(), GetQPS(), GetBurst())
 }
 
 // CreateClient creates a new client to access the Kubernetes API

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -74,11 +74,7 @@ func createConfig(apiServerURL, kubeCfgPath string, qps float32, burst int) (*re
 		}
 		config.Host = apiServerURL
 	default:
-		config := &rest.Config{Host: apiServerURL, UserAgent: userAgent}
-		setConfig(config, userAgent, qps, burst)
-		if err := rest.SetKubernetesDefaults(config); err != nil {
-			return nil, err
-		}
+		config = &rest.Config{Host: apiServerURL, UserAgent: userAgent}
 	}
 
 	setConfig(config, userAgent, qps, burst)

--- a/pkg/k8s/config.go
+++ b/pkg/k8s/config.go
@@ -26,8 +26,8 @@ var (
 )
 
 type configuration struct {
-	// APIServer is the address of the API server
-	APIServer string
+	// APIServerURL is the URL address of the API server
+	APIServerURL string
 
 	// KubeconfigPath is the local path to the kubeconfig configuration
 	// file on the filesystem
@@ -40,9 +40,9 @@ type configuration struct {
 	Burst int
 }
 
-// GetAPIServer returns the configured API server address
-func GetAPIServer() string {
-	return config.APIServer
+// GetAPIServerURL returns the configured API server URL address
+func GetAPIServerURL() string {
+	return config.APIServerURL
 }
 
 // GetKubeconfigPath returns the configured path to the kubeconfig
@@ -62,22 +62,22 @@ func GetBurst() int {
 }
 
 // Configure sets the parameters of the Kubernetes package
-func Configure(apiServer, kubeconfigPath string, qps float32, burst int) {
-	config.APIServer = apiServer
+func Configure(apiServerURL, kubeconfigPath string, qps float32, burst int) {
+	config.APIServerURL = apiServerURL
 	config.KubeconfigPath = kubeconfigPath
 	config.QPS = qps
 	config.Burst = burst
 
 	if IsEnabled() &&
-		config.APIServer != "" &&
-		!strings.HasPrefix(apiServer, "http") {
-		config.APIServer = "http://" + apiServer
+		config.APIServerURL != "" &&
+		!strings.HasPrefix(apiServerURL, "http") {
+		config.APIServerURL = "http://" + apiServerURL // default to HTTP
 	}
 }
 
 // IsEnabled checks if Cilium is being used in tandem with Kubernetes.
 func IsEnabled() bool {
-	return config.APIServer != "" ||
+	return config.APIServerURL != "" ||
 		config.KubeconfigPath != "" ||
 		(os.Getenv("KUBERNETES_SERVICE_HOST") != "" &&
 			os.Getenv("KUBERNETES_SERVICE_PORT") != "")

--- a/pkg/k8s/config.go
+++ b/pkg/k8s/config.go
@@ -45,6 +45,11 @@ func GetAPIServerURL() string {
 	return config.APIServerURL
 }
 
+// SetAPIServerURL sets the k8s API server URL address
+func SetAPIServerURL(url string) {
+	config.APIServerURL = url
+}
+
 // GetKubeconfigPath returns the configured path to the kubeconfig
 // configuration file
 func GetKubeconfigPath() string {

--- a/pkg/maps/lbmap/bpfservice.go
+++ b/pkg/maps/lbmap/bpfservice.go
@@ -262,3 +262,11 @@ func (l *lbmapCache) removeBackendsWithRefCountZero() map[BackendAddrID]BackendK
 
 	return removed
 }
+
+func (l *lbmapCache) existAndHaveBackends(svcKey ServiceKeyV2) bool {
+	frontendID := svcKey.String()
+	if svc, found := l.entries[frontendID]; found {
+		return len(svc.uniqueBackends) > 0
+	}
+	return false
+}

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -763,3 +763,20 @@ func RemoveDeprecatedMaps() error {
 	}
 	return nil
 }
+
+// ExistAndHaveBackends return true if a service identified with the given
+// frontend addr exists and has at least one backend.
+func ExistAndHaveBackends(svc *loadbalancer.L3n4Addr) bool {
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	var svcKey ServiceKeyV2
+
+	if !svc.IsIPv6() {
+		svcKey = NewService4KeyV2(svc.IP, svc.Port, u8proto.ANY, 0)
+	} else {
+		svcKey = NewService6KeyV2(svc.IP, svc.Port, u8proto.ANY, 0)
+	}
+
+	return cache.existAndHaveBackends(svcKey)
+}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -183,6 +183,10 @@ const (
 	// K8sKubeConfigPath is the absolute path of the kubernetes kubeconfig file
 	K8sKubeConfigPath = "k8s-kubeconfig-path"
 
+	// K8sAPIServerURLForBootstrap is the kubernetes api server address for
+	// bootstrapping api-server service when running without kube-proxy
+	K8sAPIServerURLForBootstrap = "k8s-api-server-url-no-kubeproxy"
+
 	// K8sServiceCacheSize is service cache size for cilium k8s package.
 	K8sServiceCacheSize = "k8s-service-cache-size"
 
@@ -964,6 +968,7 @@ type DaemonConfig struct {
 	IPv6ServiceRange              string
 	K8sAPIServer                  string
 	K8sKubeConfigPath             string
+	K8sAPIServerURLForBootstrap   string
 	K8sWatcherEndpointSelector    string
 	KVStore                       string
 	KVStoreOpt                    map[string]string
@@ -1556,6 +1561,7 @@ func (c *DaemonConfig) Populate() {
 	c.IPv6ServiceRange = viper.GetString(IPv6ServiceRange)
 	c.K8sAPIServer = viper.GetString(K8sAPIServer)
 	c.K8sKubeConfigPath = viper.GetString(K8sKubeConfigPath)
+	c.K8sAPIServerURLForBootstrap = viper.GetString(K8sAPIServerURLForBootstrap)
 	c.K8sRequireIPv4PodCIDR = viper.GetBool(K8sRequireIPv4PodCIDRName)
 	c.K8sRequireIPv6PodCIDR = viper.GetBool(K8sRequireIPv6PodCIDRName)
 	c.K8sServiceCacheSize = uint(viper.GetInt(K8sServiceCacheSize))


### PR DESCRIPTION
This PR introduces a mechanism for bootstrapping k8s api-server BPF service when running Kubernetes without kube-proxy.

The main problem in such setup is that the iptables DNAT rule `(ClusterIP:443 => $MASTER_NODE_IP:6443)` is no longer installed, as kube-proxy is not running. Therefore, cilium-agent is not able to connect to the api-server via the ClusterIP which is passed to the cilium-agent Pod via the env vars by kubelet.

To resolve this chicken-n-egg problem, we ask users to pass `"https://$MASTER_NODE_IP:6443"` via the `--k8s-api-server-url-no-kubeproxy` flag (OT: happy to consider a better name for the flag). This allows cilium-agent to connect to the api-server, and consequently the corresponding BPF LB entry can be created for it which allows the api-server address to be reset to ClusterIP (a connection to the ClusterIP from the host netns is possible thanks to the host reachable services feature).

An alternative solution would have been to pre-populate the BPF LB maps with the required mapping. Unfortunately it cannot be so easily achieved, as bpf_sock.o (the host-reachable services program) gets loaded after cilium-agent has established a connection to the api-server.

Reviewable per commit.

Fixes #9018.

TODO:

- [ ] Add CI test.
- [ ] Atomic updates of pkg/k8s.Client pointers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9089)
<!-- Reviewable:end -->
