### PR TITLE
cilium: fix restore v6 router ip to not break pod connectivity on restart

### DIFF
--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/datapath"
+	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
@@ -66,24 +67,18 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 	routerIP := node.GetIPv6Router()
 	hostIP := node.GetIPv6()
 
-	fmt.Fprintf(fw, ""+
-		"/*\n"+
-		" * Node-IPv6: %s\n"+
-		" * Router-IPv6: %s\n"+
-		" * Host-IPv4: %s\n"+
-		" *\n"+
-		" * External-IPv4: %s\n"+
-		" * External-IPv6: %s\n"+
-		" *\n"+
-		" * NodePort-SNAT-IPv4: %s\n"+
-		" * NodePort-SNAT-IPv6: %s\n"+
-		" */\n\n",
-		hostIP.String(), routerIP.String(),
-		node.GetInternalIPv4().String(),
-		node.GetExternalIPv4().String(),
-		node.GetIPv6().String(),
-		node.GetNodePortIPv4().String(),
-		node.GetNodePortIPv6().String())
+	fmt.Fprintf(fw, "/*\n")
+	fmt.Fprintf(fw, " cilium.v6.external.str %s\n", node.GetIPv6().String())
+	fmt.Fprintf(fw, " cilium.v6.internal.str %s\n", node.GetIPv6Router().String())
+	fmt.Fprintf(fw, " cilium.v6.nodeport.str %s\n", node.GetNodePortIPv6().String())
+	fmt.Fprintf(fw, "\n")
+	fmt.Fprintf(fw, " cilium.v4.external.str %s\n", node.GetExternalIPv4().String())
+	fmt.Fprintf(fw, " cilium.v4.internal.str %s\n", node.GetInternalIPv4().String())
+	fmt.Fprintf(fw, " cilium.v4.nodeport.str %s\n", node.GetNodePortIPv4().String())
+	fmt.Fprintf(fw, "\n")
+	fw.WriteString(dumpRaw(defaults.RestoreV6Addr, node.GetIPv6Router()))
+	fw.WriteString(dumpRaw(defaults.RestoreV4Addr, node.GetInternalIPv4()))
+	fmt.Fprintf(fw, " */\n\n")
 
 	if option.Config.EnableIPv6 {
 		extraMacrosMap["ROUTER_IP"] = routerIP.String()

--- a/pkg/datapath/linux/config/utils.go
+++ b/pkg/datapath/linux/config/utils.go
@@ -69,6 +69,10 @@ func defineIPv6(name string, addr []byte) string {
 	return fmt.Sprintf("DEFINE_IPV6(%s, %s);\n", name, goArray2C(addr))
 }
 
+func dumpRaw(name string, addr []byte) string {
+	return fmt.Sprintf(" %s%s\n", name, goArray2C(addr))
+}
+
 // defineMAC writes the C definition for the given MAC name and addr.
 func defineMAC(name string, addr []byte) string {
 	if len(addr) != 6 { /* MAC len */

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -298,4 +298,10 @@ const (
 	// It is enabled by default and directs that the ICMP Fragmentation needed type
 	// packets are allowed to enable TCP Path MTU.
 	AllowICMPFragNeeded = true
+
+	// RestoreV4Addr is used as match for cilium_host v4 address
+	RestoreV4Addr = "cilium.v4.internal.raw "
+
+	// RestoreV6Addr is used as match for cilium_host v6 (router) address
+	RestoreV6Addr = "cilium.v6.internal.raw "
 )


### PR DESCRIPTION
See commit msg.

Fixes (probably) https://github.com/cilium/cilium/issues/9087

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9090)
<!-- Reviewable:end -->
