### PR TITLE
tofqdns: Allow "_" in DNS names to support service discovery schemes

### DIFF
--- a/pkg/fqdn/matchpattern/matchpattern.go
+++ b/pkg/fqdn/matchpattern/matchpattern.go
@@ -22,7 +22,7 @@ import (
 	"github.com/miekg/dns"
 )
 
-const allowedDNSCharsREGroup = "[-a-zA-Z0-9]"
+const allowedDNSCharsREGroup = "[-a-zA-Z0-9_]"
 
 // Validate ensures that pattern is a parseable matchPattern. It returns the
 // regexp generated when validating.

--- a/pkg/fqdn/matchpattern/matchpattern_test.go
+++ b/pkg/fqdn/matchpattern/matchpattern_test.go
@@ -79,8 +79,20 @@ func (ts *MatchPatternTestSuite) TestMatchPatternMatching(c *C) {
 		},
 		{
 			pattern: "*",
-			accept:  []string{"io.", "cilium.io.", "svc.cluster.local.", "service.namesace.svc.cluster.local."},
-			reject:  []string{"", ".", ".io.", ".cilium.io.", ".svc.cluster.local.", "cilium.io"}, // note no final . on this last one
+			accept:  []string{"io.", "cilium.io.", "svc.cluster.local.", "service.namesace.svc.cluster.local.", "_foobar._tcp.cilium.io."}, // the last is for SRV RFC-2782 and DNS-SD RFC6763
+			reject:  []string{"", ".", ".io.", ".cilium.io.", ".svc.cluster.local.", "cilium.io"},                                          // note no final . on this last one
+		},
+
+		// These are more explicit tests for SRV RFC-2782 and DNS-SD RFC6763
+		{
+			pattern: "_foobar._tcp.cilium.io.",
+			accept:  []string{"_foobar._tcp.cilium.io."},
+			reject:  []string{"", "_tcp.cilium.io.", "cilium.io."},
+		},
+		{
+			pattern: "*.*.cilium.io.",
+			accept:  []string{"_foobar._tcp.cilium.io."},
+			reject:  []string{""},
 		},
 	} {
 		reStr := ToRegexp(testCase.pattern)


### PR DESCRIPTION
DNS SRV records (RFC-2782 https://tools.ietf.org/html/rfc2782) and
DNS-SD RFC-6736 https://tools.ietf.org/html/rfc6763 explicitly allow and
expect leading "_"s in the RR names. Furthermore, DNS itself isn't
restrictive about this. We add support for these types of names since
they are more common than arbitrary binary names, but we may further
loosen the requirements here later.

I'll re-read the RFCs in case I missed something but this is a start. Partially addresses https://github.com/cilium/cilium/issues/9083

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9094)
<!-- Reviewable:end -->
