### PR TITLE
test: Ensure managed etcd test tears down etcd

### DIFF
--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -208,6 +208,9 @@ var _ = Describe("K8sDatapathConfig", func() {
 	})
 
 	Context("ManagedEtcd", func() {
+		AfterAll(func() {
+			deleteETCDOperator(kubectl)
+		})
 		It("Check connectivity with managed etcd", func() {
 			deployCilium([]string{
 				"--set global.etcd.enabled=true",

--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -153,6 +153,14 @@ func deleteCiliumDS(kubectl *helpers.Kubectl) {
 	Expect(waitToDeleteCilium(kubectl, logger)).To(BeNil(), "timed out deleting Cilium pods")
 }
 
+func deleteETCDOperator(kubectl *helpers.Kubectl) {
+	// Do not assert on success in AfterEach intentionally to avoid
+	// incomplete teardown.
+	_ = kubectl.DeleteResource("deploy", fmt.Sprintf("-n %s -l io.cilium/app=etcd-operator", helpers.KubeSystemNamespace))
+	_ = kubectl.DeleteResource("pod", fmt.Sprintf("-n %s -l io.cilium/app=etcd-operator", helpers.KubeSystemNamespace))
+	_ = kubectl.WaitCleanAllTerminatingPods(helpers.HelperTimeout)
+}
+
 func waitToDeleteCilium(kubectl *helpers.Kubectl, logger *logrus.Entry) error {
 	var (
 		pods []string


### PR DESCRIPTION
Previously this test left etcd-operator and related pods running in the
cluster, which consumes resources and potentially impacts subsequent
tests. Clean up after running the managed etcd test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9096)
<!-- Reviewable:end -->
