### PR TITLE
Makefile: remove deepcopy for configmap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -328,12 +328,6 @@ generate-k8s-api:
 	./generate-groups.sh deepcopy \
 	    github.com/cilium/cilium/pkg/k8s/client \
 	    github.com/cilium/cilium/pkg \
-	    "maps:configmap" \
-	    --go-header-file "$(PWD)/hack/custom-boilerplate.go.txt"
-	cd "./vendor/k8s.io/code-generator" && \
-	./generate-groups.sh deepcopy \
-	    github.com/cilium/cilium/pkg/k8s/client \
-	    github.com/cilium/cilium/pkg \
 	    "maps:lbmap" \
 	    --go-header-file "$(PWD)/hack/custom-boilerplate.go.txt"
 	cd "./vendor/k8s.io/code-generator" && \


### PR DESCRIPTION
Fixes: 587d6a40d0d0 ("maps: remove configmap")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9098)
<!-- Reviewable:end -->
