### PR TITLE
bump manifests apiVersion to apps/v1

### DIFF
--- a/examples/kubernetes-cassandra/cass-sw-app.yaml
+++ b/examples/kubernetes-cassandra/cass-sw-app.yaml
@@ -1,9 +1,12 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cass-server
 spec:
+  selector:
+    matchLabels:
+      app: cass-server
   replicas: 1
   template:
     metadata:
@@ -32,11 +35,14 @@ spec:
     app: cass-server
   clusterIP: None
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: empire-hq
 spec:
+  selector:
+    matchLabels:
+      app: empire-hq
   replicas: 1
   template:
     metadata:
@@ -49,11 +55,14 @@ spec:
         command: ["sleep"]
         args: ["30000"]
 --- 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: empire-outpost
 spec:
+  selector:
+    matchLabels:
+      app: empire-outpost
   replicas: 1
   template:
     metadata:

--- a/examples/kubernetes-grpc/cc-door-app.yaml
+++ b/examples/kubernetes-grpc/cc-door-app.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/examples/kubernetes-istio/authaudit-logger-v1.yaml
+++ b/examples/kubernetes-istio/authaudit-logger-v1.yaml
@@ -1,8 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: authaudit-logger-v1
 spec:
+  selector:
+    matchLabels:
+      app: authaudit-logger
+      version: v1
   replicas: 1
   template:
     metadata:

--- a/examples/kubernetes-istio/bookinfo-details-v1.yaml
+++ b/examples/kubernetes-istio/bookinfo-details-v1.yaml
@@ -51,11 +51,15 @@ specs:
           - method: GET
             path: "/details/[0-9]*"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: details-v1
 spec:
+  selector:
+    matchLabels:
+      app: details
+      version: v1
   replicas: 1
   template:
     metadata:

--- a/examples/kubernetes-istio/bookinfo-productpage-v1.yaml
+++ b/examples/kubernetes-istio/bookinfo-productpage-v1.yaml
@@ -51,11 +51,15 @@ specs:
           - method: GET
             path: "/api/v1/products/[0-9]*/ratings"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: productpage-v1
 spec:
+  selector:
+    matchLabels:
+      app: productpage
+      version: v1
   replicas: 1
   template:
     metadata:

--- a/examples/kubernetes-istio/bookinfo-productpage-v2.yaml
+++ b/examples/kubernetes-istio/bookinfo-productpage-v2.yaml
@@ -47,11 +47,15 @@ specs:
           - method: GET
             path: "/api/v1/products/[0-9]*"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: productpage-v2
 spec:
+  selector:
+    matchLabels:
+      app: productpage
+      version: v2
   replicas: 1
   template:
     metadata:

--- a/examples/kubernetes-istio/bookinfo-ratings-v1.yaml
+++ b/examples/kubernetes-istio/bookinfo-ratings-v1.yaml
@@ -64,11 +64,15 @@ specs:
           - method: GET
             path: "/ratings/[0-9]*"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ratings-v1
 spec:
+  selector:
+    matchLabels:
+      app: ratings
+      version: v1
   replicas: 1
   template:
     metadata:

--- a/examples/kubernetes-istio/bookinfo-reviews-v1.yaml
+++ b/examples/kubernetes-istio/bookinfo-reviews-v1.yaml
@@ -51,11 +51,15 @@ specs:
           - method: GET
             path: "/reviews/[0-9]*"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: reviews-v1
 spec:
+  selector:
+    matchLabels:
+      app: reviews
+      version: v1
   replicas: 1
   template:
     metadata:

--- a/examples/kubernetes-istio/bookinfo-reviews-v2.yaml
+++ b/examples/kubernetes-istio/bookinfo-reviews-v2.yaml
@@ -38,11 +38,15 @@ specs:
           - method: GET
             path: "/reviews/[0-9]*"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: reviews-v2
 spec:
+  selector:
+    matchLabels:
+      app: reviews
+      version: v2
   replicas: 1
   template:
     metadata:

--- a/examples/kubernetes-kafka/kafka-sw-app.yaml
+++ b/examples/kubernetes-kafka/kafka-sw-app.yaml
@@ -1,9 +1,12 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kafka-broker
 spec:
+  selector:
+    matchLabels:
+      app: kafka
   replicas: 1
   template:
     metadata:
@@ -29,11 +32,14 @@ spec:
         - name: KAFKA_ZOOKEEPER_CONNECTION_TIMEOUT_MS
           value: "60000"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: zookeeper
 spec:
+  selector:
+    matchLabels:
+      app: zook
   replicas: 1
   template:
     metadata:
@@ -77,11 +83,14 @@ spec:
     app: kafka
   clusterIP: None
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: empire-hq
 spec:
+  selector:
+    matchLabels:
+      app: empire-hq
   replicas: 1
   template:
     metadata:
@@ -92,11 +101,15 @@ spec:
       - name: empire-hq
         image: docker.io/cilium/kafkaclient
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: empire-outpost-8888
 spec:
+  selector:
+    matchLabels:
+      app: empire-outpost
+      outpostid: "8888"
   replicas: 1
   template:
     metadata:
@@ -108,11 +121,15 @@ spec:
       - name: empire-outpost-8888
         image: docker.io/cilium/kafkaclient
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: empire-outpost-9999
 spec:
+  selector:
+    matchLabels:
+      app: empire-outpost
+      outpostid: "9999"
   replicas: 1
   template:
     metadata:
@@ -124,11 +141,14 @@ spec:
       - name: empire-outpost-9999
         image: docker.io/cilium/kafkaclient
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: empire-backup
 spec:
+  selector:
+    matchLabels:
+      app: empire-backup
   replicas: 1
   template:
     metadata:

--- a/examples/kubernetes-memcached/memcd-sw-app.yaml
+++ b/examples/kubernetes-memcached/memcd-sw-app.yaml
@@ -1,9 +1,12 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: memcached-server
 spec:
+  selector:
+    matchLabels:
+      app: memcd-server
   replicas: 1
   template:
     metadata:
@@ -32,11 +35,14 @@ spec:
     app: memcd-server
   clusterIP: None
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: a-wing
 spec:
+  selector:
+    matchLabels:
+      app: a-wing
   replicas: 1
   template:
     metadata:
@@ -49,11 +55,14 @@ spec:
         command: ["sleep"]
         args: ["30000"]
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: x-wing
 spec:
+  selector:
+    matchLabels:
+      app: x-wing
   replicas: 1
   template:
     metadata:
@@ -66,11 +75,14 @@ spec:
         command: ["sleep"]
         args: ["30000"]
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: alliance-tracker
 spec:
+  selector:
+    matchLabels:
+      name: fleet-tracker
   replicas: 1
   template:
     metadata:

--- a/examples/kubernetes/addons/flannel/flannel.yaml
+++ b/examples/kubernetes/addons/flannel/flannel.yaml
@@ -79,7 +79,7 @@ data:
       }
     }
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: kube-flannel-ds-amd64
@@ -88,6 +88,10 @@ metadata:
     tier: node
     app: flannel
 spec:
+  selector:
+    matchLabels:
+      tier: node
+      app: flannel
   template:
     metadata:
       labels:

--- a/examples/kubernetes/addons/prometheus/monitoring-example.yaml
+++ b/examples/kubernetes/addons/prometheus/monitoring-example.yaml
@@ -120,7 +120,7 @@ data:
             target_label: __metrics_path__
             replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -230,7 +230,7 @@ spec:
     app: prometheus
   type: ClusterIP
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/examples/kubernetes/addons/prometheus/templates/02-prometheus.yaml
+++ b/examples/kubernetes/addons/prometheus/templates/02-prometheus.yaml
@@ -115,7 +115,7 @@ data:
             target_label: __metrics_path__
             replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/examples/kubernetes/addons/prometheus/templates/03-grafana.yaml
+++ b/examples/kubernetes/addons/prometheus/templates/03-grafana.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/examples/kubernetes/clustermesh/global-service-example/cluster1.yaml
+++ b/examples/kubernetes/clustermesh/global-service-example/cluster1.yaml
@@ -12,11 +12,14 @@ spec:
   selector:
     name: rebel-base
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rebel-base
 spec:
+  selector:
+    matchLabels:
+      name: rebel-base
   replicas: 2
   template:
     metadata:
@@ -53,11 +56,14 @@ metadata:
 data:
   message: "{\"Galaxy\": \"Alderaan\", \"Cluster\": \"Cluster-1\"}\n"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: x-wing
 spec:
+  selector:
+    matchLabels:
+      name: x-wing
   replicas: 2
   template:
     metadata:

--- a/examples/kubernetes/clustermesh/global-service-example/cluster2.yaml
+++ b/examples/kubernetes/clustermesh/global-service-example/cluster2.yaml
@@ -12,11 +12,14 @@ spec:
   selector:
     name: rebel-base
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rebel-base
 spec:
+  selector:
+    matchLabels:
+      name: rebel-base
   replicas: 2
   template:
     metadata:
@@ -53,11 +56,14 @@ metadata:
 data:
   message: "{\"Galaxy\": \"Alderaan\", \"Cluster\": \"Cluster-2\"}\n"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: x-wing
 spec:
+  selector:
+    matchLabels:
+      name: x-wing
   replicas: 2
   template:
     metadata:

--- a/examples/kubernetes/connectivity-check/connectivity-check.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check.yaml
@@ -1,8 +1,11 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: probe
 spec:
+  selector:
+    matchLabels:
+      name: probe
   replicas: 5
   template:
     metadata:
@@ -40,11 +43,14 @@ spec:
   selector:
     name: echo
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: echo
 spec:
+  selector:
+    matchLabels:
+      name: echo
   replicas: 5
   template:
     metadata:

--- a/examples/minikube/http-sw-app.yaml
+++ b/examples/minikube/http-sw-app.yaml
@@ -11,7 +11,7 @@ spec:
     org: empire
     class: deathstar
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: deathstar

--- a/examples/policies/kubernetes/namespace/demo-pods.yaml
+++ b/examples/policies/kubernetes/namespace/demo-pods.yaml
@@ -8,12 +8,15 @@ kind: Namespace
 metadata:
   name: ns2
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: leia-deployment
   namespace: ns1
 spec:
+  selector:
+    matchLabels:
+      name: leia
   replicas: 1
   template:
     metadata:

--- a/examples/policies/kubernetes/serviceaccount/demo-pods.yaml
+++ b/examples/policies/kubernetes/serviceaccount/demo-pods.yaml
@@ -13,11 +13,14 @@ apiVersion: v1
 metadata:
   name: vader
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: leia-deployment
 spec:
+  selector:
+    matchLabels:
+      name: leia
   replicas: 1
   template:
     metadata:

--- a/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
@@ -1,11 +1,14 @@
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: cilium-node-init
   namespace: {{ .Release.Namespace }}
   labels:
     app: cilium-node-init
 spec:
+  selector:
+    matchLabels:
+      app: cilium-node-init
   template:
     metadata:
       labels:

--- a/test/k8sT/manifests/bind_deployment.yaml
+++ b/test/k8sT/manifests/bind_deployment.yaml
@@ -41,7 +41,7 @@ data:
             file "/data/db.cilium.test";
     };
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -49,6 +49,9 @@ metadata:
   name: bind
   namespace: default
 spec:
+  selector:
+    matchLabels:
+      zgroup: bind
   replicas: 1
   template:
     metadata:

--- a/test/k8sT/manifests/bookinfo-v1-istio.yaml
+++ b/test/k8sT/manifests/bookinfo-v1-istio.yaml
@@ -28,14 +28,19 @@ spec:
   selector:
     app: details
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
   name: details-v1
 spec:
   replicas: 1
-  selector: null
+  selector:
+    matchLabels:
+      app: details
+      track: stable
+      version: v1
+      zgroup: bookinfo
   strategy: {}
   template:
     metadata:
@@ -223,14 +228,19 @@ spec:
   selector:
     app: reviews
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
   name: reviews-v1
 spec:
   replicas: 1
-  selector: null
+  selector:
+    matchLabels:
+      app: reviews
+      track: stable
+      version: v1
+      zgroup: bookinfo
   strategy: {}
   template:
     metadata:
@@ -418,14 +428,19 @@ spec:
   selector:
     app: productpage
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
   name: productpage-v1
 spec:
   replicas: 1
-  selector: null
+  selector:
+    matchLabels:
+      app: productpage
+      track: stable
+      version: v1
+      zgroup: bookinfo
   strategy: {}
   template:
     metadata:

--- a/test/k8sT/manifests/bookinfo-v1.yaml
+++ b/test/k8sT/manifests/bookinfo-v1.yaml
@@ -28,11 +28,17 @@ spec:
   selector:
     app: details
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: details-v1
 spec:
+  selector:
+    matchLabels:
+      app: details
+      version: v1
+      track: stable
+      zgroup: bookinfo
   replicas: 1
   template:
     metadata:
@@ -66,11 +72,17 @@ spec:
   selector:
     app: reviews
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: reviews-v1
 spec:
+  selector:
+    matchLabels:
+      app: reviews
+      version: v1
+      track: stable
+      zgroup: bookinfo
   replicas: 1
   template:
     metadata:
@@ -104,11 +116,17 @@ spec:
   selector:
     app: productpage
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: productpage-v1
 spec:
+  selector:
+    matchLabels:
+      app: productpage
+      version: v1
+      track: stable
+      zgroup: bookinfo
   replicas: 1
   template:
     metadata:

--- a/test/k8sT/manifests/bookinfo-v2-istio.yaml
+++ b/test/k8sT/manifests/bookinfo-v2-istio.yaml
@@ -28,14 +28,18 @@ spec:
   selector:
     app: ratings
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
   name: ratings-v1
 spec:
   replicas: 1
-  selector: null
+  selector:
+    matchLabels:
+      app: ratings
+      version: v1
+      zgroup: bookinfo
   strategy: {}
   template:
     metadata:
@@ -206,14 +210,18 @@ spec:
           secretName: istio.default
 status: {}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
   name: reviews-v2
 spec:
   replicas: 1
-  selector: null
+  selector:
+    matchLabels:
+      app: reviews
+      version: v2
+      zgroup: bookinfo
   strategy: {}
   template:
     metadata:

--- a/test/k8sT/manifests/bookinfo-v2.yaml
+++ b/test/k8sT/manifests/bookinfo-v2.yaml
@@ -28,11 +28,16 @@ spec:
   selector:
     app: ratings
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ratings-v1
 spec:
+  selector:
+    matchLabels:
+      app: ratings
+      version: v1
+      zgroup: bookinfo
   replicas: 1
   template:
     metadata:
@@ -52,11 +57,16 @@ spec:
 ##################################################################################################
 # Reviews service v2
 ##################################################################################################
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: reviews-v2
 spec:
+  selector:
+    matchLabels:
+      app: reviews
+      version: v2
+      zgroup: bookinfo
   replicas: 1
   template:
     metadata:

--- a/test/k8sT/manifests/demo.yaml
+++ b/test/k8sT/manifests/demo.yaml
@@ -18,11 +18,15 @@ spec:
   selector:
     id: app1
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: app1
 spec:
+  selector:
+    matchLabels:
+      id: app1
+      zgroup: testapp
   replicas: 2
   template:
     metadata:
@@ -45,11 +49,16 @@ spec:
       nodeSelector:
         "kubernetes.io/hostname": k8s1
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: app2
 spec:
+  selector:
+    matchLabels:
+      id: app2
+      zgroup: testapp
+      appSecond: "true"
   replicas: 1
   template:
     metadata:
@@ -70,11 +79,15 @@ spec:
       nodeSelector:
         "kubernetes.io/hostname": k8s1
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: app3
 spec:
+  selector:
+    matchLabels:
+      id: app3
+      zgroup: testapp
   replicas: 1
   template:
     metadata:

--- a/test/k8sT/manifests/demo_ds.yaml
+++ b/test/k8sT/manifests/demo_ds.yaml
@@ -1,10 +1,13 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: testds
   namespace: default
 spec:
+  selector:
+    matchLabels:
+      zgroup: testDS
   template:
     metadata:
       labels:
@@ -28,12 +31,15 @@ spec:
         key: node.cloudprovider.kubernetes.io/uninitialized
         value: "true"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: testclient
   namespace: default
 spec:
+  selector:
+    matchLabels:
+      zgroup: testDSClient
   template:
     metadata:
       labels:

--- a/test/k8sT/manifests/kafka-sw-app.yaml
+++ b/test/k8sT/manifests/kafka-sw-app.yaml
@@ -1,8 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kafka-broker
 spec:
+  selector:
+    matchLabels:
+      app: kafka
+      zgroup: kafkaTestApp
   replicas: 1
   template:
     metadata:
@@ -52,11 +56,15 @@ spec:
     app: kafka
   clusterIP: None
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: empire-hq
 spec:
+  selector:
+    matchLabels:
+      app: empire-hq
+      zgroup: kafkaTestApp
   replicas: 1
   template:
     metadata:
@@ -72,11 +80,16 @@ spec:
       nodeSelector:
         "kubernetes.io/hostname": k8s1
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: empire-outpost-8888
 spec:
+  selector:
+    matchLabels:
+      app: empire-outpost
+      outpostid: "8888"
+      zgroup: kafkaTestApp
   replicas: 1
   template:
     metadata:
@@ -91,11 +104,16 @@ spec:
         image: docker.io/cilium/kafkaclient:latest
         imagePullPolicy: IfNotPresent
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: empire-outpost-9999
 spec:
+  selector:
+    matchLabels:
+      app: empire-outpost
+      outpostid: "9999"
+      zgroup: kafkaTestApp
   replicas: 1
   template:
     metadata:
@@ -110,11 +128,15 @@ spec:
         image: docker.io/cilium/kafkaclient:latest
         imagePullPolicy: IfNotPresent
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: empire-backup
 spec:
+  selector:
+    matchLabels:
+      app: empire-backup
+      zgroup: kafkaTestApp
   replicas: 1
   template:
     metadata:

--- a/test/k8sT/manifests/netcat-ds.yaml
+++ b/test/k8sT/manifests/netcat-ds.yaml
@@ -1,10 +1,13 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: netcatds
   namespace: default
 spec:
+  selector:
+    matchLabels:
+      zgroup: netcatds
   template:
     metadata:
       labels:

--- a/test/k8sT/manifests/netpol-namespace-selector.yaml
+++ b/test/k8sT/manifests/netpol-namespace-selector.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: "netpol-namespace-selector"

--- a/test/provision/manifest/coredns_deployment.yaml
+++ b/test/provision/manifest/coredns_deployment.yaml
@@ -1,7 +1,7 @@
 # File source
 # https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/app/phases/addons/dns/manifests.go
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:

--- a/test/provision/manifest/kubedns_deployment.yaml
+++ b/test/provision/manifest/kubedns_deployment.yaml
@@ -43,7 +43,7 @@ data:
   stubDomains: |
     {"cilium.test": ["10.96.0.100"]}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   generation: 1


### PR DESCRIPTION
Since k8s 1.16 will remove support for extensions/v1beta1 API version we
should bump the manifests that we use in our tests to accommodate for
the upcoming k8s version.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9105)
<!-- Reviewable:end -->
