### PR TITLE
Docs: tofqdns-pre-cache is optional in preflight templates

### DIFF
--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -786,10 +786,23 @@ Upgrade steps - :ref:`DNS Polling`
    ``--tofqdns-pre-cache="/var/run/cilium/dns-precache-upgrade.json"`` to
    cilium-agent.
 
-#. Deploy the cilium :ref:`pre_flight` helper. This will download the cilium
-   container image and also create DNS pre-cache data at
+#. Deploy the cilium :ref:`pre_flight` helper by generating the manifest with
+   the ``preflight.tofqdnsPreCache`` option set as below. This will download the
+   cilium container image and also create DNS pre-cache data at
    ``/var/run/cilium/dns-precache-upgrade.json``. This data will have a TTL of
    1 week.
+
+.. code:: bash
+
+    helm template cilium \
+      --namespace=kube-system \
+      --set preflight.enabled=true \
+      --set preflight.tofqdnsPrecache="/var/run/cilium/dns-precache-upgrade.json" \
+      --set agent.enabled=false \
+      --set config.enabled=false \
+      --set operator.enabled=false \
+      > cilium-preflight.yaml
+    kubectl create cilium-preflight.yaml
 
 #. Deploy the new cilium DaemonSet
 

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -593,6 +593,7 @@ toCIDR
 toCIDRSet
 tofqdns
 toFQDNs
+tofqdnsPreCache
 toGroups
 toolchain
 Toolchain

--- a/install/kubernetes/cilium/charts/preflight/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/preflight/templates/daemonset.yaml
@@ -46,7 +46,7 @@ spec:
           command: ["/bin/sh"]
           args:
           - -c
-          - "cilium preflight fqdn-poller --tofqdns-pre-cache /var/run/cilium/dns-precache-upgrade.json && touch /tmp/ready; sleep 1h"
+          - "touch /tmp/ready; sleep 1h"
           livenessProbe:
             exec:
               command:
@@ -72,6 +72,47 @@ spec:
           - mountPath: /var/lib/etcd-secrets
             name: etcd-secrets
             readOnly: true
+{{- end }}
+{{- end }}
+
+{{- if ne .Values.tofqdnsPreCache "" }}
+{{- if contains "/" .Values.image }}
+        - image: "{{ .Values.image }}"
+{{- else }}
+        - image: "{{ .Values.global.registry }}/{{ .Values.image }}:{{ .Values.global.tag }}"
+{{- end }}
+          imagePullPolicy: {{ .Values.global.pullPolicy }}
+          name: cilium-pre-flight-check
+          command: ["/bin/sh"]
+          args:
+          - -c
+          - "cilium preflight fqdn-poller --tofqdns-pre-cache {{ .Values.tofqdnsPreCache }} && touch /tmp/ready-tofqdns-precache"
+          livenessProbe:
+            exec:
+              command:
+              - cat
+              - /tmp/read-tofqdns-precachey
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+              - cat
+              - /tmp/read-tofqdns-precachey
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          volumeMounts:
+          - mountPath: /var/run/cilium
+            name: cilium-run
+{{- if .Values.global.etcd.enabled }}
+          - mountPath: /var/lib/etcd-config
+            name: etcd-config-path
+            readOnly: true
+{{- if or .Values.global.etcd.ssl .Values.global.etcd.managed }}
+          - mountPath: /var/lib/etcd-secrets
+            name: etcd-secrets
+            readOnly: true
+{{- end }}
 {{- end }}
 {{- end }}
       hostNetwork: true

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -13,6 +13,9 @@ operator:
 # Include the PreFlight DaemonSet
 preflight:
   enabled: false
+  # Path to write the --tofqdns-pre-cache file to. When empty no file is
+  # generated.
+  tofqdnsPreCache: ""
 
 # global groups all configuration options that have effect on all sub-charts
 global:


### PR DESCRIPTION
The fqdns precache is an opt-in feature but we had configured the
preflight pod to always produce it. This sometimes causes errors when
the a user has not opted into generating this file but still ran the
preflight manifest, possibly one pre-dating the feature.
It is now a more explicit option in the helm templates, making it more
clear what is happening.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9107)
<!-- Reviewable:end -->
