### PR TITLE
Fix connectivity test example probes

### DIFF
--- a/examples/kubernetes/connectivity-check/connectivity-check.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check.yaml
@@ -19,6 +19,7 @@ spec:
           exec:
             command:
             - curl
+            - "-4"
             - -sS
             - -o
             - /dev/null
@@ -27,6 +28,7 @@ spec:
           exec:
             command:
             - curl
+            - "-4"
             - -sS
             - -o
             - /dev/null


### PR DESCRIPTION
curl probe has the potential to fail when IPv6 is not available. curl will call
getaddrinfo, which on newer glibcs will send 2 DNS requests in parallel (one
for IPv4 and IPv6). IPv6 will get dropped, causing the request to timeout after
5s which is the threshold for the healtcheck. This can lead to failed
probes. By specifying -4, curl will only do IPv4.

See https://github.com/curl/curl/issues/593 for more info.

Signed-off-by: Boran Car <boran.car@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9126)
<!-- Reviewable:end -->
