### PR TITLE
Don't add route/xfrm state for internal IPs in subnet mode

### DIFF
--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -500,7 +500,8 @@ func (n *linuxNodeHandler) encryptNode(newNode *node.Node) {
 				spi, err = ipsec.UpsertIPsecEndpoint(ipsecLocal, ipsecRemote, ipsec.IPSecDirOutNode)
 				upsertIPsecLog(err, "EncryptNode IPv4", ipsecLocal, ipsecRemote, spi)
 			}
-			if remoteIPv4 := newNode.GetCiliumInternalIP(false); remoteIPv4 != nil {
+			remoteIPv4 := newNode.GetCiliumInternalIP(false)
+			if remoteIPv4 != nil && !n.subnetEncryption() {
 				mask := newNode.IPv4AllocCIDR.Mask
 				ipsecRemoteRoute := &net.IPNet{IP: remoteIPv4.Mask(mask), Mask: mask}
 				ipsecRemote := &net.IPNet{IP: remoteIPv4, Mask: mask}
@@ -532,7 +533,8 @@ func (n *linuxNodeHandler) encryptNode(newNode *node.Node) {
 				spi, err = ipsec.UpsertIPsecEndpoint(ipsecLocal, ipsecRemote, ipsec.IPSecDirOut)
 				upsertIPsecLog(err, "EncryptNode IPv6", ipsecLocal, ipsecRemote, spi)
 			}
-			if remoteIPv6 := newNode.GetCiliumInternalIP(true); remoteIPv6 != nil {
+			remoteIPv6 := newNode.GetCiliumInternalIP(true)
+			if remoteIPv6 != nil && !n.subnetEncryption() {
 				mask := newNode.IPv6AllocCIDR.Mask
 				ipsecRemoteRoute := &net.IPNet{IP: remoteIPv6.Mask(mask), Mask: mask}
 				ipsecRemote := &net.IPNet{IP: remoteIPv6, Mask: mask}


### PR DESCRIPTION
In our environment we use an external IPAM in chaining mode and subnet for pod encryption
We noticed that the internalIP ranges sometimes conflict with ranges we use elsewhere. When encryption is enabled this blackholes traffic to these destinations on all node.

In addition, even with ENI IPAM, this creates `routerIP/16` routes/ipsec configurations which given the size of the mask can conflict with other addresses in the network.

When using subnet mode, it does not make sense to add these routes (which are covered by the the subnets) and ENI IPAM requires subnet mode for encryption to work

cc @jrfastab , following our discussion on slack

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9129)
<!-- Reviewable:end -->
