### PR TITLE
Dockerfile: Use Envoy image with access logging fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:b7a919ebdca3d3bbc6aae51357e78e9c603450ae as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:feb9a25e46898a501d1f9e49e95e7efbb725fe02 as cilium-envoy
 
 #
 # Cilium incremental build. Should be fast given builder-deps is up-to-date!


### PR DESCRIPTION
Use Envoy image with access logging fixes:
- Use fresh timestamp for the response messages instead of repeating the request timestamp
- Correctly parse status codes from HTTP headers into access log messages

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9133)
<!-- Reviewable:end -->
