### PR TITLE
kvstore: clean up casting around kvstore.Encode

### DIFF
--- a/cilium/cmd/kvstore_get.go
+++ b/cilium/cmd/kvstore_get.go
@@ -53,16 +53,16 @@ var kvstoreGetCmd = &cobra.Command{
 			}
 		} else {
 			val, err := kvstore.Get(key)
-			if err != nil {
+			if err != nil || val == nil {
 				Fatalf("Unable to retrieve key: %s", err)
 			}
 			if command.OutputJSON() {
-				if err := command.PrintOutput(val); err != nil {
+				if err := command.PrintOutput(*val); err != nil {
 					os.Exit(1)
 				}
 				return
 			}
-			fmt.Printf("%s => %s\n", key, string(val))
+			fmt.Printf("%s => %s\n", key, *val)
 		}
 	},
 }

--- a/cilium/cmd/kvstore_set.go
+++ b/cilium/cmd/kvstore_set.go
@@ -36,7 +36,7 @@ var kvstoreSetCmd = &cobra.Command{
 
 		setupKvstore()
 
-		err := kvstore.Set(key, []byte(value))
+		err := kvstore.Set(key, value)
 		if err != nil {
 			Fatalf("Unable to set key: %s", err)
 		}

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -39,9 +39,9 @@ import (
 
 var etcdConfig = []byte(fmt.Sprintf("endpoints:\n- %s\n", kvstore.EtcdDummyAddress()))
 
-func (s *ClusterMeshServicesTestSuite) prepareServiceUpdate(clusterSuffix, backendIP, portName, port string) (string, []byte) {
+func (s *ClusterMeshServicesTestSuite) prepareServiceUpdate(clusterSuffix, backendIP, portName, port string) (string, string) {
 	return "cilium/state/services/v1/" + s.randomName + clusterSuffix + "/default/foo",
-		[]byte(`{"cluster":"` + s.randomName + clusterSuffix + `","namespace":"default","name":"foo","frontends":{"172.20.0.177":{"port":{"protocol":"TCP","port":80}}},"backends":{"` + backendIP + `":{"` + portName + `":{"protocol":"TCP","port":` + port + `}}},"labels":{},"selector":{"name":"foo"}}`)
+		`{"cluster":"` + s.randomName + clusterSuffix + `","namespace":"default","name":"foo","frontends":{"172.20.0.177":{"port":{"protocol":"TCP","port":80}}},"backends":{"` + backendIP + `":{"` + portName + `":{"protocol":"TCP","port":` + port + `}}},"labels":{},"selector":{"name":"foo"}}`
 
 }
 

--- a/pkg/kvstore/allocator/allocator_test.go
+++ b/pkg/kvstore/allocator/allocator_test.go
@@ -152,13 +152,12 @@ func (s *AllocatorSuite) TestGC(c *C) {
 			c.Error(err)
 			return false
 		}
-		//FIXME: This isn't nil but it probably should be. This is because TestAllocatorKey is setup with "" and returns itself, a non-nil
-		return key == nil || key.String() == ""
+		return key == nil
 	}, 5*time.Second), IsNil)
 
 	key, err := allocator.GetByID(shortID)
 	c.Assert(err, IsNil)
-	c.Assert(key, Equals, TestAllocatorKey(""))
+	c.Assert(key, IsNil)
 }
 
 func testAllocator(c *C, maxID idpool.ID, allocatorName string, suffix string) {

--- a/pkg/kvstore/kvstore.go
+++ b/pkg/kvstore/kvstore.go
@@ -49,50 +49,46 @@ const (
 
 // Get returns value of key
 func Get(key string) (*string, error) {
-	v, err := Client().Get(key)
-	Trace("Get", err, logrus.Fields{fieldKey: key, fieldValue: string(v)})
-	if v == nil {
+	bv, err := Client().Get(key)
+	Trace("Get", err, logrus.Fields{fieldKey: key, fieldValue: string(bv)})
+	if bv == nil {
 		return nil, err
-	} else {
-		v := string(v)
-		return &v, err
 	}
+	v := string(bv)
+	return &v, err
 }
 
 // GetIfLocked returns value of key if the client is still holding the given lock.
 func GetIfLocked(key string, lock KVLocker) (*string, error) {
-	v, err := Client().GetIfLocked(key, lock)
-	Trace("GetIfLocked", err, logrus.Fields{fieldKey: key, fieldValue: string(v)})
-	if v == nil {
+	bv, err := Client().GetIfLocked(key, lock)
+	Trace("GetIfLocked", err, logrus.Fields{fieldKey: key, fieldValue: string(bv)})
+	if bv == nil {
 		return nil, err
-	} else {
-		v := string(v)
-		return &v, err
 	}
+	v := string(bv)
+	return &v, err
 }
 
 // GetPrefix returns the first key which matches the prefix and its value.
 func GetPrefix(ctx context.Context, prefix string) (string, *string, error) {
-	k, v, err := Client().GetPrefix(ctx, prefix)
-	Trace("GetPrefix", err, logrus.Fields{fieldPrefix: prefix, fieldKey: k, fieldValue: string(v)})
-	if v == nil {
+	k, bv, err := Client().GetPrefix(ctx, prefix)
+	Trace("GetPrefix", err, logrus.Fields{fieldPrefix: prefix, fieldKey: k, fieldValue: string(bv)})
+	if bv == nil {
 		return k, nil, err
-	} else {
-		v := string(v)
-		return k, &v, err
 	}
+	v := string(bv)
+	return k, &v, err
 }
 
 // GetPrefixIfLocked returns the first key which matches the prefix and its value if the client is still holding the given lock.
 func GetPrefixIfLocked(ctx context.Context, prefix string, lock KVLocker) (string, *string, error) {
-	k, v, err := Client().GetPrefixIfLocked(ctx, prefix, lock)
-	Trace("GetPrefixIfLocked", err, logrus.Fields{fieldPrefix: prefix, fieldKey: k, fieldValue: string(v)})
-	if v == nil {
+	k, bv, err := Client().GetPrefixIfLocked(ctx, prefix, lock)
+	Trace("GetPrefixIfLocked", err, logrus.Fields{fieldPrefix: prefix, fieldKey: k, fieldValue: string(bv)})
+	if bv == nil {
 		return k, nil, err
-	} else {
-		v := string(v)
-		return k, &v, err
 	}
+	v := string(bv)
+	return k, &v, err
 }
 
 // ListPrefix returns the list of keys matching the prefix

--- a/pkg/kvstore/store/store_test.go
+++ b/pkg/kvstore/store/store_test.go
@@ -268,7 +268,7 @@ func (s *StoreSuite) TestStoreLocalKeyProtection(c *C) {
 	kvstore.DeletePrefix(store.conf.Prefix)
 	c.Assert(expect(func() bool {
 		v, err := kvstore.Get(store.keyPath(&localKey1))
-		return err == nil && string(v) != ""
+		return err == nil && v == nil
 	}), IsNil)
 }
 


### PR DESCRIPTION
Replace []byte with *string. In go, string is in effect a read-only slice of
bytes https://blog.golang.org/strings. The only semantic difference would be
that a byte[] can be nil, but a string can't, so use *string.

Fixes: #8630

Signed-off-by: Boran Car <boran.car@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9138)
<!-- Reviewable:end -->
