### PR TITLE
endpoint: do not export endpoint locking functions

### DIFF
--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -334,11 +334,9 @@ func LaunchAsEndpoint(baseCtx context.Context, owner regeneration.Owner, n *node
 		return nil, fmt.Errorf("Error while adding endpoint: %s", err)
 	}
 
-	if err := ep.LockAlive(); err != nil {
+	if err := ep.PinDatapathMap(); err != nil {
 		return nil, err
 	}
-	ep.PinDatapathMap()
-	ep.Unlock()
 
 	// Give the endpoint a security identity
 	ctx, cancel := context.WithTimeout(baseCtx, LaunchTime)

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -259,18 +259,11 @@ func (d *Daemon) createEndpoint(ctx context.Context, epTemplate *models.Endpoint
 	default:
 	}
 
-	if err := ep.LockAlive(); err != nil {
-		return d.errorDuringCreation(ep, fmt.Errorf("endpoint was deleted while processing the request"))
-	}
-
 	// Now that we have ep.ID we can pin the map from this point. This
 	// also has to happen before the first build took place.
 	if err = ep.PinDatapathMap(); err != nil {
-		ep.Unlock()
 		return d.errorDuringCreation(ep, fmt.Errorf("unable to pin datapath maps: %s", err))
 	}
-
-	ep.Unlock()
 
 	cfunc := func() {
 		// Only used for CRI-O since it does not support events.

--- a/daemon/endpoint_test.go
+++ b/daemon/endpoint_test.go
@@ -76,27 +76,7 @@ func (ds *DaemonSuite) TestEndpointAddNoLabels(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(ep.OpLabels.IdentityLabels(), checker.DeepEquals, expectedLabels)
 
-	// Check that the endpoint received the reserved identity for the
-	// reserved:init entities.
-	timeout := time.NewTimer(3 * time.Second)
-	defer timeout.Stop()
-	tick := time.NewTicker(200 * time.Millisecond)
-	defer tick.Stop()
-	var secID *identity.Identity
-Loop:
-	for {
-		select {
-		case <-timeout.C:
-			break Loop
-		case <-tick.C:
-			ep.UnconditionalRLock()
-			secID = ep.SecurityIdentity
-			ep.RUnlock()
-			if secID != nil {
-				break Loop
-			}
-		}
-	}
+	secID := ep.WaitForIdentity(3 * time.Second)
 	c.Assert(secID, Not(IsNil))
 	c.Assert(secID.ID, Equals, identity.ReservedIdentityInit)
 }

--- a/daemon/policy_test.go
+++ b/daemon/policy_test.go
@@ -135,9 +135,7 @@ func (ds *DaemonSuite) prepareEndpoint(c *C, identity *identity.Identity, qa boo
 	}
 	e.SetIdentity(identity, true)
 
-	e.UnconditionalLock()
-	ready := e.SetStateLocked(endpoint.StateWaitingToRegenerate, "test")
-	e.Unlock()
+	ready := e.SetState(endpoint.StateWaitingToRegenerate, "test")
 	c.Assert(ready, Equals, true)
 	buildSuccess := <-e.Regenerate(regenerationMetadata)
 	c.Assert(buildSuccess, Equals, true)
@@ -146,9 +144,7 @@ func (ds *DaemonSuite) prepareEndpoint(c *C, identity *identity.Identity, qa boo
 }
 
 func (ds *DaemonSuite) regenerateEndpoint(c *C, e *endpoint.Endpoint) {
-	e.UnconditionalLock()
-	ready := e.SetStateLocked(endpoint.StateWaitingToRegenerate, "test")
-	e.Unlock()
+	ready := e.SetState(endpoint.StateWaitingToRegenerate, "test")
 	c.Assert(ready, Equals, true)
 	buildSuccess := <-e.Regenerate(regenerationMetadata)
 	c.Assert(buildSuccess, Equals, true)

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -143,7 +143,7 @@ func (d *Daemon) restoreOldEndpoints(dir string, clean bool) (*endpointRestoreSt
 	for _, ep := range possibleEPs {
 		scopedLog := log.WithField(logfields.EndpointID, ep.ID)
 		if k8s.IsEnabled() {
-			scopedLog = scopedLog.WithField("k8sPodName", ep.GetK8sNamespaceAndPodNameLocked())
+			scopedLog = scopedLog.WithField("k8sPodName", ep.GetK8sNamespaceAndPodName())
 		}
 
 		restore, err := d.validateEndpoint(ep)

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -38,7 +38,7 @@ import (
 // GetLabelsModel returns the labels of the endpoint in their representation
 // for the Cilium API. Returns an error if the Endpoint is being deleted.
 func (e *Endpoint) GetLabelsModel() (*models.LabelConfiguration, error) {
-	if err := e.RLockAlive(); err != nil {
+	if err := e.rlockAlive(); err != nil {
 		return nil, err
 	}
 	spec := &models.LabelConfigurationSpec{
@@ -450,7 +450,7 @@ func (e *Endpoint) ProcessChangeRequest(newEp *Endpoint, validPatchTransitionSta
 		reason  string
 	)
 
-	if err := e.LockAlive(); err != nil {
+	if err := e.lockAlive(); err != nil {
 		return "", err
 	}
 	defer e.Unlock()
@@ -552,7 +552,7 @@ func (e *Endpoint) GetConfigurationStatus() *models.EndpointConfigurationStatus 
 // provided labels. Returns labels that were added and deleted. Returns an
 // error if the endpoint is being deleted.
 func (e *Endpoint) ApplyUserLabelChanges(lbls labels.Labels) (add, del labels.Labels, err error) {
-	if err := e.RLockAlive(); err != nil {
+	if err := e.rlockAlive(); err != nil {
 		return nil, nil, err
 	}
 	defer e.RUnlock()

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -453,7 +453,7 @@ func (e *Endpoint) ProcessChangeRequest(newEp *Endpoint, validPatchTransitionSta
 	if err := e.lockAlive(); err != nil {
 		return "", err
 	}
-	defer e.Unlock()
+	defer e.unlock()
 
 	if newEp.ifIndex != 0 && e.ifIndex != newEp.ifIndex {
 		e.ifIndex = newEp.ifIndex

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -196,7 +196,7 @@ func (e *Endpoint) GetModelRLocked() *models.Endpoint {
 				ContainerName:    e.ContainerName,
 				DockerEndpointID: e.DockerEndpointID,
 				DockerNetworkID:  e.DockerNetworkID,
-				PodName:          e.GetK8sNamespaceAndPodNameLocked(),
+				PodName:          e.getK8sNamespaceAndPodName(),
 			},
 			// FIXME GH-3280 When we begin returning endpoint revisions this should
 			// change to return the configured and in-datapath policies.

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -127,7 +127,7 @@ func NewEndpointFromChangeModel(owner regeneration.Owner, base *models.EndpointC
 	ep.SetDefaultOpts(option.Config.Opts)
 
 	ep.UpdateLogger(nil)
-	ep.SetStateLocked(string(base.State), "Endpoint creation")
+	ep.setState(string(base.State), "Endpoint creation")
 
 	return ep, nil
 }
@@ -474,7 +474,7 @@ func (e *Endpoint) ProcessChangeRequest(newEp *Endpoint, validPatchTransitionSta
 		validPatchTransitionState &&
 		e.GetStateLocked() != StateWaitingForIdentity {
 		// Will not change state if the current state does not allow the transition.
-		if e.SetStateLocked(StateWaitingForIdentity, "Update endpoint from API PATCH") {
+		if e.setState(StateWaitingForIdentity, "Update endpoint from API PATCH") {
 			changed = true
 		}
 	}
@@ -505,7 +505,7 @@ func (e *Endpoint) ProcessChangeRequest(newEp *Endpoint, validPatchTransitionSta
 	// If desired state is waiting-for-identity but identity is already
 	// known, bump it to ready state immediately to force re-generation
 	if e.GetStateLocked() == StateWaitingForIdentity && e.SecurityIdentity != nil {
-		e.SetStateLocked(StateReady, "Preparing to force endpoint regeneration because identity is known while handling API PATCH")
+		e.setState(StateReady, "Preparing to force endpoint regeneration because identity is known while handling API PATCH")
 		changed = true
 	}
 
@@ -518,7 +518,7 @@ func (e *Endpoint) ProcessChangeRequest(newEp *Endpoint, validPatchTransitionSta
 
 		// Transition to waiting-to-regenerate if ready.
 		if e.GetStateLocked() == StateReady {
-			e.SetStateLocked(StateWaitingToRegenerate, "Forcing endpoint regeneration because identity is known while handling API PATCH")
+			e.setState(StateWaitingToRegenerate, "Forcing endpoint regeneration because identity is known while handling API PATCH")
 		}
 
 		switch e.GetStateLocked() {

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -54,7 +54,7 @@ func (e *Endpoint) GetLabelsModel() (*models.LabelConfiguration, error) {
 			Disabled:         e.OpLabels.Disabled.GetModel(),
 		},
 	}
-	e.RUnlock()
+	e.runlock()
 	return &cfg, nil
 }
 
@@ -555,7 +555,7 @@ func (e *Endpoint) ApplyUserLabelChanges(lbls labels.Labels) (add, del labels.La
 	if err := e.rlockAlive(); err != nil {
 		return nil, nil, err
 	}
-	defer e.RUnlock()
+	defer e.runlock()
 	add, del = e.OpLabels.SplitUserLabelChanges(lbls)
 	return
 }

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -701,7 +701,7 @@ func (e *Endpoint) finalizeProxyState(regenContext *regenerationContext, err err
 	if err == nil {
 		// Always execute the finalization code, even if the endpoint is
 		// terminating, in order to properly release resources.
-		e.UnconditionalLock()
+		e.unconditionalLock()
 		e.getLogger().Debug("Finalizing successful endpoint regeneration")
 		datapathRegenCtx.finalizeList.Finalize()
 		e.Unlock()
@@ -807,7 +807,7 @@ func (e *Endpoint) scrubIPsInConntrackTableLocked() {
 }
 
 func (e *Endpoint) scrubIPsInConntrackTable() {
-	e.UnconditionalLock()
+	e.unconditionalLock()
 	e.scrubIPsInConntrackTableLocked()
 	e.Unlock()
 }
@@ -820,7 +820,7 @@ func (e *Endpoint) scrubIPsInConntrackTable() {
 // The endpoint lock must NOT be held.
 func (e *Endpoint) SkipStateClean() {
 	// Mark conntrack as already cleaned
-	e.UnconditionalLock()
+	e.unconditionalLock()
 	e.ctCleaned = true
 	e.Unlock()
 }

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -442,7 +442,7 @@ func (e *Endpoint) regenerateBPF(regenContext *regenerationContext) (revnum uint
 	if err != nil {
 		return 0, compilationExecuted, err
 	}
-	defer e.Unlock()
+	defer e.unlock()
 
 	e.ctCleaned = true
 
@@ -527,7 +527,7 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (pr
 		return err
 	}
 
-	defer e.Unlock()
+	defer e.unlock()
 
 	currentDir := datapathRegenCtxt.currentDir
 	nextDir := datapathRegenCtxt.nextDir
@@ -704,7 +704,7 @@ func (e *Endpoint) finalizeProxyState(regenContext *regenerationContext, err err
 		e.unconditionalLock()
 		e.getLogger().Debug("Finalizing successful endpoint regeneration")
 		datapathRegenCtx.finalizeList.Finalize()
-		e.Unlock()
+		e.unlock()
 	} else {
 		if err := e.lockAlive(); err != nil {
 			e.getLogger().WithError(err).Debug("Skipping unnecessary reverting of endpoint regeneration changes")
@@ -715,7 +715,7 @@ func (e *Endpoint) finalizeProxyState(regenContext *regenerationContext, err err
 			e.getLogger().WithError(err).Error("Reverting endpoint regeneration changes failed")
 		}
 		e.getLogger().Debug("Finished reverting endpoint changes after BPF regeneration failed")
-		e.Unlock()
+		e.unlock()
 	}
 }
 
@@ -809,7 +809,7 @@ func (e *Endpoint) scrubIPsInConntrackTableLocked() {
 func (e *Endpoint) scrubIPsInConntrackTable() {
 	e.unconditionalLock()
 	e.scrubIPsInConntrackTableLocked()
-	e.Unlock()
+	e.unlock()
 }
 
 // SkipStateClean can be called on a endpoint before its first build to skip
@@ -822,7 +822,7 @@ func (e *Endpoint) SkipStateClean() {
 	// Mark conntrack as already cleaned
 	e.unconditionalLock()
 	e.ctCleaned = true
-	e.Unlock()
+	e.unlock()
 }
 
 func (e *Endpoint) deletePolicyKey(keyToDelete policy.Key, incremental bool) bool {
@@ -1077,7 +1077,7 @@ func (e *Endpoint) syncPolicyMapController() {
 				if err := e.lockAlive(); err != nil {
 					return controller.NewExitReason("Endpoint disappeared")
 				}
-				defer e.Unlock()
+				defer e.unlock()
 				return e.syncPolicyMapWithDump()
 			},
 			RunInterval: 1 * time.Minute,
@@ -1163,7 +1163,7 @@ func (e *Endpoint) FinishIPVLANInit(netNsPath string) error {
 	if err := e.lockAlive(); err != nil {
 		return nil
 	}
-	defer e.Unlock()
+	defer e.unlock()
 
 	// No need to finish IPVLAN initialization for Docker if the endpoint isn't
 	// running with Docker.

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -437,7 +437,7 @@ func (e *Endpoint) regenerateBPF(regenContext *regenerationContext) (revnum uint
 	}
 
 	stats.waitingForLock.Start()
-	err = e.LockAlive()
+	err = e.lockAlive()
 	stats.waitingForLock.End(err == nil)
 	if err != nil {
 		return 0, compilationExecuted, err
@@ -521,7 +521,7 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (pr
 	datapathRegenCtxt := regenContext.datapathRegenerationContext
 
 	stats.waitingForLock.Start()
-	err := e.LockAlive()
+	err := e.lockAlive()
 	stats.waitingForLock.End(err == nil)
 	if err != nil {
 		return err
@@ -706,7 +706,7 @@ func (e *Endpoint) finalizeProxyState(regenContext *regenerationContext, err err
 		datapathRegenCtx.finalizeList.Finalize()
 		e.Unlock()
 	} else {
-		if err := e.LockAlive(); err != nil {
+		if err := e.lockAlive(); err != nil {
 			e.getLogger().WithError(err).Debug("Skipping unnecessary reverting of endpoint regeneration changes")
 			return
 		}
@@ -1074,7 +1074,7 @@ func (e *Endpoint) syncPolicyMapController() {
 				// Failure to lock is not an error, it means
 				// that the endpoint was disconnected and we
 				// should exit gracefully.
-				if err := e.LockAlive(); err != nil {
+				if err := e.lockAlive(); err != nil {
 					return controller.NewExitReason("Endpoint disappeared")
 				}
 				defer e.Unlock()
@@ -1160,7 +1160,7 @@ func (e *Endpoint) FinishIPVLANInit(netNsPath string) error {
 	}
 
 	// Just ignore if the endpoint is dying
-	if err := e.LockAlive(); err != nil {
+	if err := e.lockAlive(); err != nil {
 		return nil
 	}
 	defer e.Unlock()

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1171,7 +1171,7 @@ func (e *Endpoint) FinishIPVLANInit(netNsPath string) error {
 		return nil
 	}
 
-	if e.isDatapathMapPinnedLocked() {
+	if e.isDatapathMapPinned {
 		// The datapath map is pinned which implies that the post-initialization
 		// for the ipvlan slave has been successfully performed
 		return nil
@@ -1188,7 +1188,7 @@ func (e *Endpoint) FinishIPVLANInit(netNsPath string) error {
 		unix.Close(mapFD)
 	}()
 
-	if err = e.setDatapathMapIDAndPinMapLocked(mapID); err != nil {
+	if err = e.setDatapathMapIDAndPinMap(mapID); err != nil {
 		return fmt.Errorf("Unable to pin datapath map: %s", err)
 	}
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1132,15 +1132,10 @@ func (e *Endpoint) GetDockerNetworkID() string {
 	return e.DockerNetworkID
 }
 
-// setDatapathMapIDAndPinMapLocked modifies the endpoint's datapath map ID
-func (e *Endpoint) setDatapathMapIDAndPinMapLocked(id int) error {
+// setDatapathMapIDAndPinMap modifies the endpoint's datapath map ID
+func (e *Endpoint) setDatapathMapIDAndPinMap(id int) error {
 	e.datapathMapID = id
-	return e.PinDatapathMap()
-}
-
-// isDatapathMapPinnedLocked returns whether the endpoint's datapath map has been pinned
-func (e *Endpoint) isDatapathMapPinnedLocked() bool {
-	return e.isDatapathMapPinned
+	return e.pinDatapathMap()
 }
 
 // GetState returns the endpoint's state
@@ -1824,6 +1819,16 @@ func (e *Endpoint) IsDisconnecting() bool {
 // PinDatapathMap retrieves a file descriptor from the map ID from the API call
 // and pins the corresponding map into the BPF file system.
 func (e *Endpoint) PinDatapathMap() error {
+	if err := e.LockAlive(); err != nil {
+		return err
+	}
+	defer e.Unlock()
+	return e.pinDatapathMap()
+}
+
+// PinDatapathMap retrieves a file descriptor from the map ID from the API call
+// and pins the corresponding map into the BPF file system.
+func (e *Endpoint) pinDatapathMap() error {
 	if e.datapathMapID == 0 {
 		return nil
 	}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -709,7 +709,7 @@ func parseEndpoint(owner regeneration.Owner, strEp string) (*Endpoint, error) {
 }
 
 func (e *Endpoint) LogStatus(typ StatusType, code StatusCode, msg string) {
-	e.UnconditionalLock()
+	e.unconditionalLock()
 	defer e.Unlock()
 	// FIXME GH2323 instead of a mutex we could use a channel to send the status
 	// log message to a single writer?
@@ -1003,7 +1003,7 @@ func (e *Endpoint) GetContainerName() string {
 
 // SetContainerName modifies the endpoint's container name
 func (e *Endpoint) SetContainerName(name string) {
-	e.UnconditionalLock()
+	e.unconditionalLock()
 	e.ContainerName = name
 	e.Unlock()
 }
@@ -1019,7 +1019,7 @@ func (e *Endpoint) GetK8sNamespace() string {
 
 // SetK8sNamespace modifies the endpoint's pod name
 func (e *Endpoint) SetK8sNamespace(name string) {
-	e.UnconditionalLock()
+	e.unconditionalLock()
 	e.K8sNamespace = name
 	e.UpdateLogger(map[string]interface{}{
 		logfields.K8sPodName: e.GetK8sNamespaceAndPodNameLocked(),
@@ -1029,7 +1029,7 @@ func (e *Endpoint) SetK8sNamespace(name string) {
 
 // K8sNamespaceAndPodNameIsSet returns true if the pod name is set
 func (e *Endpoint) K8sNamespaceAndPodNameIsSet() bool {
-	e.UnconditionalLock()
+	e.unconditionalLock()
 	podName := e.GetK8sNamespaceAndPodNameLocked()
 	e.Unlock()
 	return podName != "" && podName != "/"
@@ -1062,7 +1062,7 @@ func (e *Endpoint) GetK8sNamespaceAndPodNameLocked() string {
 
 // SetK8sPodName modifies the endpoint's pod name
 func (e *Endpoint) SetK8sPodName(name string) {
-	e.UnconditionalLock()
+	e.unconditionalLock()
 	e.K8sPodName = name
 	e.UpdateLogger(map[string]interface{}{
 		logfields.K8sPodName: e.GetK8sNamespaceAndPodNameLocked(),
@@ -1072,7 +1072,7 @@ func (e *Endpoint) SetK8sPodName(name string) {
 
 // SetContainerID modifies the endpoint's container ID
 func (e *Endpoint) SetContainerID(id string) {
-	e.UnconditionalLock()
+	e.unconditionalLock()
 	e.ContainerID = id
 	e.UpdateLogger(map[string]interface{}{
 		logfields.ContainerID: e.getShortContainerID(),
@@ -1112,14 +1112,14 @@ func (e *Endpoint) getShortContainerID() string {
 
 // SetDockerEndpointID modifies the endpoint's Docker Endpoint ID
 func (e *Endpoint) SetDockerEndpointID(id string) {
-	e.UnconditionalLock()
+	e.unconditionalLock()
 	e.DockerEndpointID = id
 	e.Unlock()
 }
 
 // SetDockerNetworkID modifies the endpoint's Docker Endpoint ID
 func (e *Endpoint) SetDockerNetworkID(id string) {
-	e.UnconditionalLock()
+	e.unconditionalLock()
 	e.DockerNetworkID = id
 	e.Unlock()
 }
@@ -1155,7 +1155,7 @@ func (e *Endpoint) GetState() string {
 // SetState modifies the endpoint's state. Returns true only if endpoints state
 // was changed as requested
 func (e *Endpoint) SetState(toState, reason string) bool {
-	e.UnconditionalLock()
+	e.unconditionalLock()
 	defer e.Unlock()
 
 	return e.setState(toState, reason)
@@ -1327,8 +1327,8 @@ OKState:
 // proxyPolicyRevision when the specified revision has been applied in the
 // proxy.
 func (e *Endpoint) OnProxyPolicyUpdate(revision uint64) {
-	// NOTE: UnconditionalLock is used here because this callback has no way of reporting an error
-	e.UnconditionalLock()
+	// NOTE: unconditionalLock is used here because this callback has no way of reporting an error
+	e.unconditionalLock()
 	if revision > e.proxyPolicyRevision {
 		e.proxyPolicyRevision = revision
 	}
@@ -1772,8 +1772,8 @@ type policySignal struct {
 //  - the endpoint's policy revision reaches the wanted revision
 // When the done callback is non-nil it will be called just before the channel is closed.
 func (e *Endpoint) WaitForPolicyRevision(ctx context.Context, rev uint64, done func(ts time.Time)) <-chan struct{} {
-	// NOTE: UnconditionalLock is used here because this method handles endpoint in disconnected state on its own
-	e.UnconditionalLock()
+	// NOTE: unconditionalLock is used here because this method handles endpoint in disconnected state on its own
+	e.unconditionalLock()
 	defer e.Unlock()
 
 	if done == nil {
@@ -2123,7 +2123,7 @@ func (e *Endpoint) waitForFirstRegeneration(ctx context.Context) error {
 // the configuration option to keep endpoint configuration during endpoint
 // restore is checked, and if so, this is a no-op.
 func (e *Endpoint) SetDefaultConfiguration(restore bool) {
-	e.UnconditionalLock()
+	e.unconditionalLock()
 	defer e.Unlock()
 
 	if restore && option.Config.KeepConfig {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -417,7 +417,7 @@ func (e *Endpoint) GetID16() uint16 {
 // GetK8sPodLabels returns all labels that exist in the endpoint and were
 // derived from k8s pod.
 func (e *Endpoint) GetK8sPodLabels() pkgLabels.Labels {
-	e.UnconditionalRLock()
+	e.unconditionalRLock()
 	defer e.RUnlock()
 	allLabels := e.OpLabels.AllLabels()
 	if allLabels == nil {
@@ -448,7 +448,7 @@ func (e *Endpoint) GetLabelsSHA() string {
 
 // GetOpLabels returns the labels as slice
 func (e *Endpoint) GetOpLabels() []string {
-	e.UnconditionalRLock()
+	e.unconditionalRLock()
 	defer e.RUnlock()
 	return e.OpLabels.IdentityLabels().GetModel()
 }
@@ -491,7 +491,7 @@ func (e *Endpoint) HasSidecarProxy() bool {
 // conntrack map, which is a 5-digit endpoint ID, or "global" when the
 // global map should be used.
 func (e *Endpoint) ConntrackName() string {
-	e.UnconditionalRLock()
+	e.unconditionalRLock()
 	defer e.RUnlock()
 	return e.conntrackName()
 }
@@ -530,7 +530,7 @@ func (e *Endpoint) GetIdentity() identityPkg.NumericIdentity {
 
 // Allows is only used for unit testing
 func (e *Endpoint) Allows(id identityPkg.NumericIdentity) bool {
-	e.UnconditionalRLock()
+	e.unconditionalRLock()
 	defer e.RUnlock()
 
 	keyToLookup := policy.Key{
@@ -544,7 +544,7 @@ func (e *Endpoint) Allows(id identityPkg.NumericIdentity) bool {
 
 // String returns endpoint on a JSON format.
 func (e *Endpoint) String() string {
-	e.UnconditionalRLock()
+	e.unconditionalRLock()
 	defer e.RUnlock()
 	b, err := json.MarshalIndent(e, "", "  ")
 	if err != nil {
@@ -600,7 +600,7 @@ func (e *Endpoint) SetDefaultOpts(opts *option.IntOptions) {
 // ConntrackLocal determines whether this endpoint is currently using a local
 // table to handle connection tracking (true), or the global table (false).
 func (e *Endpoint) ConntrackLocal() bool {
-	e.UnconditionalRLock()
+	e.unconditionalRLock()
 	defer e.RUnlock()
 
 	return e.ConntrackLocalLocked()
@@ -854,7 +854,7 @@ func (e *Endpoint) Update(cfg *models.EndpointConfigurationSpec) error {
 // HasLabels returns whether endpoint e contains all labels l. Will return 'false'
 // if any label in l is not in the endpoint's labels.
 func (e *Endpoint) HasLabels(l pkgLabels.Labels) bool {
-	e.UnconditionalRLock()
+	e.unconditionalRLock()
 	defer e.RUnlock()
 
 	return e.hasLabelsRLocked(l)
@@ -996,7 +996,7 @@ func (e *Endpoint) RegenerateWait(reason string) error {
 
 // GetContainerName returns the name of the container for the endpoint.
 func (e *Endpoint) GetContainerName() string {
-	e.UnconditionalRLock()
+	e.unconditionalRLock()
 	defer e.RUnlock()
 	return e.ContainerName
 }
@@ -1011,7 +1011,7 @@ func (e *Endpoint) SetContainerName(name string) {
 // GetK8sNamespace returns the name of the pod if the endpoint represents a
 // Kubernetes pod
 func (e *Endpoint) GetK8sNamespace() string {
-	e.UnconditionalRLock()
+	e.unconditionalRLock()
 	ns := e.K8sNamespace
 	e.RUnlock()
 	return ns
@@ -1038,7 +1038,7 @@ func (e *Endpoint) K8sNamespaceAndPodNameIsSet() bool {
 // GetK8sPodName returns the name of the pod if the endpoint represents a
 // Kubernetes pod
 func (e *Endpoint) GetK8sPodName() string {
-	e.UnconditionalRLock()
+	e.unconditionalRLock()
 	k8sPodName := e.K8sPodName
 	e.RUnlock()
 
@@ -1057,7 +1057,7 @@ func (e *Endpoint) HumanStringLocked() string {
 // GetK8sNamespaceAndPodName returns the corresponding namespace and pod
 // name for this endpoint.
 func (e *Endpoint) GetK8sNamespaceAndPodName() string {
-	e.UnconditionalRLock()
+	e.unconditionalRLock()
 	defer e.RUnlock()
 
 	return e.getK8sNamespaceAndPodName()
@@ -1089,7 +1089,7 @@ func (e *Endpoint) SetContainerID(id string) {
 
 // GetContainerID returns the endpoint's container ID
 func (e *Endpoint) GetContainerID() string {
-	e.UnconditionalRLock()
+	e.unconditionalRLock()
 	cID := e.ContainerID
 	e.RUnlock()
 	return cID
@@ -1097,7 +1097,7 @@ func (e *Endpoint) GetContainerID() string {
 
 // GetShortContainerID returns the endpoint's shortened container ID
 func (e *Endpoint) GetShortContainerID() string {
-	e.UnconditionalRLock()
+	e.unconditionalRLock()
 	defer e.RUnlock()
 
 	return e.getShortContainerID()
@@ -1133,7 +1133,7 @@ func (e *Endpoint) SetDockerNetworkID(id string) {
 
 // GetDockerNetworkID returns the endpoint's Docker Endpoint ID
 func (e *Endpoint) GetDockerNetworkID() string {
-	e.UnconditionalRLock()
+	e.unconditionalRLock()
 	defer e.RUnlock()
 
 	return e.DockerNetworkID
@@ -1154,7 +1154,7 @@ func (e *Endpoint) GetStateLocked() string {
 // GetState returns the endpoint's state
 // endpoint.Mutex may only be.rlockAlive()ed
 func (e *Endpoint) GetState() string {
-	e.UnconditionalRLock()
+	e.unconditionalRLock()
 	defer e.RUnlock()
 	return e.GetStateLocked()
 }
@@ -1427,7 +1427,7 @@ func APICanModify(e *Endpoint) error {
 }
 
 func (e *Endpoint) getIDandLabels() string {
-	e.UnconditionalRLock()
+	e.unconditionalRLock()
 	defer e.RUnlock()
 
 	labels := ""
@@ -2009,7 +2009,7 @@ func (e *Endpoint) Delete(monitor monitorOwner, ipam ipReleaser, manager endpoin
 func (e *Endpoint) GetProxyInfoByFields() (uint64, string, string, []string, string, uint64, error) {
 	// We use unconditional locking here because we explicitly handle state
 	// in which the endpoint is being deleted.
-	e.UnconditionalRLock()
+	e.unconditionalRLock()
 	defer e.RUnlock()
 	var err error
 	if e.IsDisconnecting() {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -405,7 +405,7 @@ func (e *Endpoint) GetSecurityIdentity() (*identityPkg.Identity, error) {
 	if err := e.rlockAlive(); err != nil {
 		return nil, err
 	}
-	defer e.RUnlock()
+	defer e.runlock()
 	return e.SecurityIdentity, nil
 }
 
@@ -418,7 +418,7 @@ func (e *Endpoint) GetID16() uint16 {
 // derived from k8s pod.
 func (e *Endpoint) GetK8sPodLabels() pkgLabels.Labels {
 	e.unconditionalRLock()
-	defer e.RUnlock()
+	defer e.runlock()
 	allLabels := e.OpLabels.AllLabels()
 	if allLabels == nil {
 		return nil
@@ -449,7 +449,7 @@ func (e *Endpoint) GetLabelsSHA() string {
 // GetOpLabels returns the labels as slice
 func (e *Endpoint) GetOpLabels() []string {
 	e.unconditionalRLock()
-	defer e.RUnlock()
+	defer e.runlock()
 	return e.OpLabels.IdentityLabels().GetModel()
 }
 
@@ -492,7 +492,7 @@ func (e *Endpoint) HasSidecarProxy() bool {
 // global map should be used.
 func (e *Endpoint) ConntrackName() string {
 	e.unconditionalRLock()
-	defer e.RUnlock()
+	defer e.runlock()
 	return e.conntrackName()
 }
 
@@ -531,7 +531,7 @@ func (e *Endpoint) GetIdentity() identityPkg.NumericIdentity {
 // Allows is only used for unit testing
 func (e *Endpoint) Allows(id identityPkg.NumericIdentity) bool {
 	e.unconditionalRLock()
-	defer e.RUnlock()
+	defer e.runlock()
 
 	keyToLookup := policy.Key{
 		Identity:         uint32(id),
@@ -545,7 +545,7 @@ func (e *Endpoint) Allows(id identityPkg.NumericIdentity) bool {
 // String returns endpoint on a JSON format.
 func (e *Endpoint) String() string {
 	e.unconditionalRLock()
-	defer e.RUnlock()
+	defer e.runlock()
 	b, err := json.MarshalIndent(e, "", "  ")
 	if err != nil {
 		return err.Error()
@@ -601,7 +601,7 @@ func (e *Endpoint) SetDefaultOpts(opts *option.IntOptions) {
 // table to handle connection tracking (true), or the global table (false).
 func (e *Endpoint) ConntrackLocal() bool {
 	e.unconditionalRLock()
-	defer e.RUnlock()
+	defer e.runlock()
 
 	return e.ConntrackLocalLocked()
 }
@@ -855,7 +855,7 @@ func (e *Endpoint) Update(cfg *models.EndpointConfigurationSpec) error {
 // if any label in l is not in the endpoint's labels.
 func (e *Endpoint) HasLabels(l pkgLabels.Labels) bool {
 	e.unconditionalRLock()
-	defer e.RUnlock()
+	defer e.runlock()
 
 	return e.hasLabelsRLocked(l)
 }
@@ -997,7 +997,7 @@ func (e *Endpoint) RegenerateWait(reason string) error {
 // GetContainerName returns the name of the container for the endpoint.
 func (e *Endpoint) GetContainerName() string {
 	e.unconditionalRLock()
-	defer e.RUnlock()
+	defer e.runlock()
 	return e.ContainerName
 }
 
@@ -1013,7 +1013,7 @@ func (e *Endpoint) SetContainerName(name string) {
 func (e *Endpoint) GetK8sNamespace() string {
 	e.unconditionalRLock()
 	ns := e.K8sNamespace
-	e.RUnlock()
+	e.runlock()
 	return ns
 }
 
@@ -1040,7 +1040,7 @@ func (e *Endpoint) K8sNamespaceAndPodNameIsSet() bool {
 func (e *Endpoint) GetK8sPodName() string {
 	e.unconditionalRLock()
 	k8sPodName := e.K8sPodName
-	e.RUnlock()
+	e.runlock()
 
 	return k8sPodName
 }
@@ -1058,7 +1058,7 @@ func (e *Endpoint) HumanStringLocked() string {
 // name for this endpoint.
 func (e *Endpoint) GetK8sNamespaceAndPodName() string {
 	e.unconditionalRLock()
-	defer e.RUnlock()
+	defer e.runlock()
 
 	return e.getK8sNamespaceAndPodName()
 }
@@ -1091,14 +1091,14 @@ func (e *Endpoint) SetContainerID(id string) {
 func (e *Endpoint) GetContainerID() string {
 	e.unconditionalRLock()
 	cID := e.ContainerID
-	e.RUnlock()
+	e.runlock()
 	return cID
 }
 
 // GetShortContainerID returns the endpoint's shortened container ID
 func (e *Endpoint) GetShortContainerID() string {
 	e.unconditionalRLock()
-	defer e.RUnlock()
+	defer e.runlock()
 
 	return e.getShortContainerID()
 }
@@ -1134,7 +1134,7 @@ func (e *Endpoint) SetDockerNetworkID(id string) {
 // GetDockerNetworkID returns the endpoint's Docker Endpoint ID
 func (e *Endpoint) GetDockerNetworkID() string {
 	e.unconditionalRLock()
-	defer e.RUnlock()
+	defer e.runlock()
 
 	return e.DockerNetworkID
 }
@@ -1155,7 +1155,7 @@ func (e *Endpoint) GetStateLocked() string {
 // endpoint.Mutex may only be.rlockAlive()ed
 func (e *Endpoint) GetState() string {
 	e.unconditionalRLock()
-	defer e.RUnlock()
+	defer e.runlock()
 	return e.GetStateLocked()
 }
 
@@ -1428,7 +1428,7 @@ func APICanModify(e *Endpoint) error {
 
 func (e *Endpoint) getIDandLabels() string {
 	e.unconditionalRLock()
-	defer e.RUnlock()
+	defer e.runlock()
 
 	labels := ""
 	if e.SecurityIdentity != nil {
@@ -1527,7 +1527,7 @@ func (e *Endpoint) runLabelsResolver(ctx context.Context, myChangeRev int, block
 		return
 	}
 	newLabels := e.OpLabels.IdentityLabels()
-	e.RUnlock()
+	e.runlock()
 	scopedLog := e.getLogger().WithField(logfields.IdentityLabels, newLabels)
 
 	// If we are certain we can resolve the identity without accessing the KV
@@ -1580,7 +1580,7 @@ func (e *Endpoint) identityLabelsChanged(ctx context.Context, myChangeRev int) e
 
 	// Since we unlocked the endpoint and re-locked, the label update may already be obsolete
 	if e.identityResolutionIsObsolete(myChangeRev) {
-		e.RUnlock()
+		e.runlock()
 		elog.Debug("Endpoint identity has changed, aborting resolution routine in favour of new one")
 		return nil
 	}
@@ -1590,13 +1590,13 @@ func (e *Endpoint) identityLabelsChanged(ctx context.Context, myChangeRev int) e
 		if e.GetStateLocked() == StateWaitingForIdentity {
 			e.setState(StateReady, "Set identity for this endpoint")
 		}
-		e.RUnlock()
+		e.runlock()
 		elog.Debug("Endpoint labels unchanged, skipping resolution of identity")
 		return nil
 	}
 
 	// Unlock the endpoint mutex for the possibly long lasting kvstore operation
-	e.RUnlock()
+	e.runlock()
 	elog.Debug("Resolving identity for labels")
 
 	allocateCtx, cancel := context.WithTimeout(context.Background(), option.Config.KVstoreConnectivityTimeout)
@@ -2010,7 +2010,7 @@ func (e *Endpoint) GetProxyInfoByFields() (uint64, string, string, []string, str
 	// We use unconditional locking here because we explicitly handle state
 	// in which the endpoint is being deleted.
 	e.unconditionalRLock()
-	defer e.RUnlock()
+	defer e.runlock()
 	var err error
 	if e.IsDisconnecting() {
 		err = fmt.Errorf("endpoint is in the process of being deleted")
@@ -2108,7 +2108,7 @@ func (e *Endpoint) waitForFirstRegeneration(ctx context.Context) error {
 				return fmt.Errorf("endpoint was deleted while waiting for initial endpoint generation to complete")
 			}
 			hasSidecarProxy := e.HasSidecarProxy()
-			e.RUnlock()
+			e.runlock()
 			if hasSidecarProxy && e.HasBPFProgram() {
 				// If the endpoint is determined to have a sidecar proxy,
 				// return immediately to let the sidecar container start,

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1022,7 +1022,7 @@ func (e *Endpoint) SetK8sNamespace(name string) {
 	e.unconditionalLock()
 	e.K8sNamespace = name
 	e.UpdateLogger(map[string]interface{}{
-		logfields.K8sPodName: e.GetK8sNamespaceAndPodNameLocked(),
+		logfields.K8sPodName: e.getK8sNamespaceAndPodName(),
 	})
 	e.unlock()
 }
@@ -1030,7 +1030,7 @@ func (e *Endpoint) SetK8sNamespace(name string) {
 // K8sNamespaceAndPodNameIsSet returns true if the pod name is set
 func (e *Endpoint) K8sNamespaceAndPodNameIsSet() bool {
 	e.unconditionalLock()
-	podName := e.GetK8sNamespaceAndPodNameLocked()
+	podName := e.getK8sNamespaceAndPodName()
 	e.unlock()
 	return podName != "" && podName != "/"
 }
@@ -1047,16 +1047,23 @@ func (e *Endpoint) GetK8sPodName() string {
 
 // HumanStringLocked returns the endpoint's most human readable identifier as string
 func (e *Endpoint) HumanStringLocked() string {
-	if pod := e.GetK8sNamespaceAndPodNameLocked(); pod != "" {
+	if pod := e.getK8sNamespaceAndPodName(); pod != "" {
 		return pod
 	}
 
 	return e.StringID()
 }
 
-// GetK8sNamespaceAndPodNameLocked returns the namespace and pod name.  This
-// function requires e.Mutex to be held.
-func (e *Endpoint) GetK8sNamespaceAndPodNameLocked() string {
+// GetK8sNamespaceAndPodName returns the corresponding namespace and pod
+// name for this endpoint.
+func (e *Endpoint) GetK8sNamespaceAndPodName() string {
+	e.UnconditionalRLock()
+	defer e.RUnlock()
+
+	return e.getK8sNamespaceAndPodName()
+}
+
+func (e *Endpoint) getK8sNamespaceAndPodName() string {
 	return e.K8sNamespace + "/" + e.K8sPodName
 }
 
@@ -1065,7 +1072,7 @@ func (e *Endpoint) SetK8sPodName(name string) {
 	e.unconditionalLock()
 	e.K8sPodName = name
 	e.UpdateLogger(map[string]interface{}{
-		logfields.K8sPodName: e.GetK8sNamespaceAndPodNameLocked(),
+		logfields.K8sPodName: e.getK8sNamespaceAndPodName(),
 	})
 	e.unlock()
 }

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -195,7 +195,7 @@ type Endpoint struct {
 	// sure that restores when DNS policy is in there are correct
 	dnsHistoryTrigger *trigger.Trigger
 
-	// state is the state the endpoint is in. See SetStateLocked()
+	// state is the state the endpoint is in. See setState()
 	state string
 
 	// bpfHeaderfileHash is the hash of the last BPF headerfile that has been
@@ -703,7 +703,7 @@ func parseEndpoint(owner regeneration.Owner, strEp string) (*Endpoint, error) {
 
 	ep.UpdateLogger(nil)
 
-	ep.SetStateLocked(StateRestoring, "Endpoint restoring")
+	ep.setState(StateRestoring, "Endpoint restoring")
 
 	return &ep, nil
 }
@@ -832,7 +832,7 @@ func (e *Endpoint) Update(cfg *models.EndpointConfigurationSpec) error {
 				// Check endpoint state before attempting configuration update because
 				// configuration updates can only be applied when the endpoint is in
 				// specific states. See GH-3058.
-				stateTransitionSucceeded := e.SetStateLocked(StateWaitingToRegenerate, regenCtx.Reason)
+				stateTransitionSucceeded := e.setState(StateWaitingToRegenerate, regenCtx.Reason)
 				if stateTransitionSucceeded {
 					e.Unlock()
 					e.Regenerate(regenCtx)
@@ -976,7 +976,7 @@ func (e *Endpoint) leaveLocked(proxyWaitGroup *completion.WaitGroup, conf Delete
 		e.scrubIPsInConntrackTableLocked()
 	}
 
-	e.SetStateLocked(StateDisconnected, "Endpoint removed")
+	e.setState(StateDisconnected, "Endpoint removed")
 
 	endpointPolicyStatus.Remove(e.ID)
 	e.getLogger().Info("Removed endpoint")
@@ -1152,10 +1152,16 @@ func (e *Endpoint) GetState() string {
 	return e.GetStateLocked()
 }
 
-// SetStateLocked modifies the endpoint's state
-// endpoint.Mutex must be held
-// Returns true only if endpoints state was changed as requested
-func (e *Endpoint) SetStateLocked(toState, reason string) bool {
+// SetState modifies the endpoint's state. Returns true only if endpoints state
+// was changed as requested
+func (e *Endpoint) SetState(toState, reason string) bool {
+	e.UnconditionalLock()
+	defer e.Unlock()
+
+	return e.setState(toState, reason)
+}
+
+func (e *Endpoint) setState(toState, reason string) bool {
 	// Validate the state transition.
 	fromState := e.state
 
@@ -1445,7 +1451,7 @@ func (e *Endpoint) ModifyIdentityLabels(addLabels, delLabels pkgLabels.Labels) e
 		// Mark with StateWaitingForIdentity, it will be set to
 		// StateWaitingToRegenerate after the identity resolution has been
 		// completed
-		e.SetStateLocked(StateWaitingForIdentity, "Triggering identity resolution due to updated identity labels")
+		e.setState(StateWaitingForIdentity, "Triggering identity resolution due to updated identity labels")
 
 		e.identityRevision++
 		rev = e.identityRevision
@@ -1575,7 +1581,7 @@ func (e *Endpoint) identityLabelsChanged(ctx context.Context, myChangeRev int) e
 	if e.SecurityIdentity != nil && e.SecurityIdentity.Labels.Equals(newLabels) {
 		// Sets endpoint state to ready if was waiting for identity
 		if e.GetStateLocked() == StateWaitingForIdentity {
-			e.SetStateLocked(StateReady, "Set identity for this endpoint")
+			e.setState(StateReady, "Set identity for this endpoint")
 		}
 		e.RUnlock()
 		elog.Debug("Endpoint labels unchanged, skipping resolution of identity")
@@ -1683,7 +1689,7 @@ func (e *Endpoint) identityLabelsChanged(ctx context.Context, myChangeRev int) e
 	// called, the controller calling identityLabelsChanged() will trigger
 	// the regeneration as soon as the identity is known.
 	if e.ID != 0 {
-		readyToRegenerate = e.SetStateLocked(StateWaitingToRegenerate, "Triggering regeneration due to new identity")
+		readyToRegenerate = e.setState(StateWaitingToRegenerate, "Triggering regeneration due to new identity")
 	}
 
 	// Unconditionally force policy recomputation after a new identity has been
@@ -1936,7 +1942,7 @@ func (e *Endpoint) Delete(monitor monitorOwner, ipam ipReleaser, manager endpoin
 	if err := e.lockAlive(); err != nil {
 		return []error{}
 	}
-	e.SetStateLocked(StateDisconnecting, "Deleting endpoint")
+	e.setState(StateDisconnecting, "Deleting endpoint")
 
 	// Remove the endpoint before we clean up. This ensures it is no longer
 	// listed or queued for rebuilds.
@@ -2022,7 +2028,7 @@ func (e *Endpoint) RegenerateAfterCreation(ctx context.Context, endpointStartFun
 
 	build := e.GetStateLocked() == StateReady
 	if build {
-		e.SetStateLocked(StateWaitingToRegenerate, "Identity is known at endpoint creation time")
+		e.setState(StateWaitingToRegenerate, "Identity is known at endpoint creation time")
 	}
 	e.Unlock()
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1487,7 +1487,7 @@ func (e *Endpoint) UpdateLabels(ctx context.Context, identityLabels, infoLabels 
 	}).Debug("Refreshing labels of endpoint")
 
 	if err := e.lockAlive(); err != nil {
-		e.LogDisconnectedMutexAction(err, "when trying to refresh endpoint labels")
+		e.logDisconnectedMutexAction(err, "when trying to refresh endpoint labels")
 		return
 	}
 

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -273,7 +273,7 @@ func (s *EndpointSuite) TestEndpointUpdateLabels(c *C) {
 
 func (s *EndpointSuite) TestEndpointState(c *C) {
 	e := NewEndpointWithState(s, 100, StateCreating)
-	e.UnconditionalLock()
+	e.unconditionalLock()
 	defer e.Unlock()
 
 	e.state = StateCreating
@@ -590,7 +590,7 @@ func (n *EndpointDeadlockEvent) Handle(ifc chan interface{}) {
 	// lock *before* we call deleteEndpointQuiet (see below test).
 	close(n.deadlockChan)
 	time.Sleep(deadlockTimeout)
-	n.ep.UnconditionalLock()
+	n.ep.unconditionalLock()
 	n.ep.Unlock()
 }
 

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -274,7 +274,7 @@ func (s *EndpointSuite) TestEndpointUpdateLabels(c *C) {
 func (s *EndpointSuite) TestEndpointState(c *C) {
 	e := NewEndpointWithState(s, 100, StateCreating)
 	e.unconditionalLock()
-	defer e.Unlock()
+	defer e.unlock()
 
 	e.state = StateCreating
 	c.Assert(e.setState(StateCreating, "test"), Equals, false)
@@ -591,7 +591,7 @@ func (n *EndpointDeadlockEvent) Handle(ifc chan interface{}) {
 	close(n.deadlockChan)
 	time.Sleep(deadlockTimeout)
 	n.ep.unconditionalLock()
-	n.ep.Unlock()
+	n.ep.unlock()
 }
 
 // This unit test is a bit weird - see

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -277,79 +277,79 @@ func (s *EndpointSuite) TestEndpointState(c *C) {
 	defer e.Unlock()
 
 	e.state = StateCreating
-	c.Assert(e.SetStateLocked(StateCreating, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateWaitingForIdentity, "test"), Equals, true)
+	c.Assert(e.setState(StateCreating, "test"), Equals, false)
+	c.Assert(e.setState(StateWaitingForIdentity, "test"), Equals, true)
 	e.state = StateCreating
-	c.Assert(e.SetStateLocked(StateReady, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateWaitingToRegenerate, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateRegenerating, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateDisconnecting, "test"), Equals, true)
+	c.Assert(e.setState(StateReady, "test"), Equals, false)
+	c.Assert(e.setState(StateWaitingToRegenerate, "test"), Equals, false)
+	c.Assert(e.setState(StateRegenerating, "test"), Equals, false)
+	c.Assert(e.setState(StateDisconnecting, "test"), Equals, true)
 	e.state = StateCreating
-	c.Assert(e.SetStateLocked(StateDisconnected, "test"), Equals, false)
+	c.Assert(e.setState(StateDisconnected, "test"), Equals, false)
 
 	e.state = StateWaitingForIdentity
-	c.Assert(e.SetStateLocked(StateCreating, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateWaitingForIdentity, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateReady, "test"), Equals, true)
+	c.Assert(e.setState(StateCreating, "test"), Equals, false)
+	c.Assert(e.setState(StateWaitingForIdentity, "test"), Equals, false)
+	c.Assert(e.setState(StateReady, "test"), Equals, true)
 	e.state = StateWaitingForIdentity
-	c.Assert(e.SetStateLocked(StateWaitingToRegenerate, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateRegenerating, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateDisconnecting, "test"), Equals, true)
+	c.Assert(e.setState(StateWaitingToRegenerate, "test"), Equals, false)
+	c.Assert(e.setState(StateRegenerating, "test"), Equals, false)
+	c.Assert(e.setState(StateDisconnecting, "test"), Equals, true)
 	e.state = StateWaitingForIdentity
-	c.Assert(e.SetStateLocked(StateDisconnected, "test"), Equals, false)
+	c.Assert(e.setState(StateDisconnected, "test"), Equals, false)
 
 	e.state = StateReady
-	c.Assert(e.SetStateLocked(StateCreating, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateWaitingForIdentity, "test"), Equals, true)
+	c.Assert(e.setState(StateCreating, "test"), Equals, false)
+	c.Assert(e.setState(StateWaitingForIdentity, "test"), Equals, true)
 	e.state = StateReady
-	c.Assert(e.SetStateLocked(StateReady, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateWaitingToRegenerate, "test"), Equals, true)
+	c.Assert(e.setState(StateReady, "test"), Equals, false)
+	c.Assert(e.setState(StateWaitingToRegenerate, "test"), Equals, true)
 	e.state = StateReady
-	c.Assert(e.SetStateLocked(StateRegenerating, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateDisconnecting, "test"), Equals, true)
+	c.Assert(e.setState(StateRegenerating, "test"), Equals, false)
+	c.Assert(e.setState(StateDisconnecting, "test"), Equals, true)
 	e.state = StateReady
-	c.Assert(e.SetStateLocked(StateDisconnected, "test"), Equals, false)
+	c.Assert(e.setState(StateDisconnected, "test"), Equals, false)
 
 	e.state = StateWaitingToRegenerate
-	c.Assert(e.SetStateLocked(StateCreating, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateWaitingForIdentity, "test"), Equals, true)
+	c.Assert(e.setState(StateCreating, "test"), Equals, false)
+	c.Assert(e.setState(StateWaitingForIdentity, "test"), Equals, true)
 	e.state = StateWaitingToRegenerate
-	c.Assert(e.SetStateLocked(StateReady, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateWaitingToRegenerate, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateRegenerating, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateDisconnecting, "test"), Equals, true)
+	c.Assert(e.setState(StateReady, "test"), Equals, false)
+	c.Assert(e.setState(StateWaitingToRegenerate, "test"), Equals, false)
+	c.Assert(e.setState(StateRegenerating, "test"), Equals, false)
+	c.Assert(e.setState(StateDisconnecting, "test"), Equals, true)
 	e.state = StateWaitingToRegenerate
-	c.Assert(e.SetStateLocked(StateDisconnected, "test"), Equals, false)
+	c.Assert(e.setState(StateDisconnected, "test"), Equals, false)
 
 	e.state = StateRegenerating
-	c.Assert(e.SetStateLocked(StateCreating, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateWaitingForIdentity, "test"), Equals, true)
+	c.Assert(e.setState(StateCreating, "test"), Equals, false)
+	c.Assert(e.setState(StateWaitingForIdentity, "test"), Equals, true)
 	e.state = StateRegenerating
-	c.Assert(e.SetStateLocked(StateReady, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateWaitingToRegenerate, "test"), Equals, true)
+	c.Assert(e.setState(StateReady, "test"), Equals, false)
+	c.Assert(e.setState(StateWaitingToRegenerate, "test"), Equals, true)
 	e.state = StateRegenerating
-	c.Assert(e.SetStateLocked(StateRegenerating, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateDisconnecting, "test"), Equals, true)
+	c.Assert(e.setState(StateRegenerating, "test"), Equals, false)
+	c.Assert(e.setState(StateDisconnecting, "test"), Equals, true)
 	e.state = StateRegenerating
-	c.Assert(e.SetStateLocked(StateDisconnected, "test"), Equals, false)
+	c.Assert(e.setState(StateDisconnected, "test"), Equals, false)
 
 	e.state = StateDisconnecting
-	c.Assert(e.SetStateLocked(StateCreating, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateWaitingForIdentity, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateReady, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateWaitingToRegenerate, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateRegenerating, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateDisconnecting, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateDisconnected, "test"), Equals, true)
+	c.Assert(e.setState(StateCreating, "test"), Equals, false)
+	c.Assert(e.setState(StateWaitingForIdentity, "test"), Equals, false)
+	c.Assert(e.setState(StateReady, "test"), Equals, false)
+	c.Assert(e.setState(StateWaitingToRegenerate, "test"), Equals, false)
+	c.Assert(e.setState(StateRegenerating, "test"), Equals, false)
+	c.Assert(e.setState(StateDisconnecting, "test"), Equals, false)
+	c.Assert(e.setState(StateDisconnected, "test"), Equals, true)
 
 	e.state = StateDisconnected
-	c.Assert(e.SetStateLocked(StateCreating, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateWaitingForIdentity, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateReady, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateWaitingToRegenerate, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateRegenerating, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateDisconnecting, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateDisconnected, "test"), Equals, false)
+	c.Assert(e.setState(StateCreating, "test"), Equals, false)
+	c.Assert(e.setState(StateWaitingForIdentity, "test"), Equals, false)
+	c.Assert(e.setState(StateReady, "test"), Equals, false)
+	c.Assert(e.setState(StateWaitingToRegenerate, "test"), Equals, false)
+	c.Assert(e.setState(StateRegenerating, "test"), Equals, false)
+	c.Assert(e.setState(StateDisconnecting, "test"), Equals, false)
+	c.Assert(e.setState(StateDisconnected, "test"), Equals, false)
 
 	// Builder-specific transitions
 	e.state = StateWaitingToRegenerate
@@ -357,7 +357,7 @@ func (s *EndpointSuite) TestEndpointState(c *C) {
 	// as (another) build is pending
 	c.Assert(e.BuilderSetStateLocked(StateReady, "test"), Equals, false)
 	// Only builder knows when bpf regeneration starts
-	c.Assert(e.SetStateLocked(StateRegenerating, "test"), Equals, false)
+	c.Assert(e.setState(StateRegenerating, "test"), Equals, false)
 	c.Assert(e.BuilderSetStateLocked(StateRegenerating, "test"), Equals, true)
 	// Builder does not trigger the need for regeneration
 	c.Assert(e.BuilderSetStateLocked(StateWaitingToRegenerate, "test"), Equals, false)
@@ -370,18 +370,18 @@ func (s *EndpointSuite) TestEndpointState(c *C) {
 
 	// Typical lifecycle
 	e.state = StateCreating
-	c.Assert(e.SetStateLocked(StateWaitingForIdentity, "test"), Equals, true)
+	c.Assert(e.setState(StateWaitingForIdentity, "test"), Equals, true)
 	// Initial build does not change the state
 	c.Assert(e.BuilderSetStateLocked(StateRegenerating, "test"), Equals, false)
 	c.Assert(e.BuilderSetStateLocked(StateReady, "test"), Equals, false)
 	// identity arrives
-	c.Assert(e.SetStateLocked(StateReady, "test"), Equals, true)
+	c.Assert(e.setState(StateReady, "test"), Equals, true)
 	// a build is triggered after the identity is set
-	c.Assert(e.SetStateLocked(StateWaitingToRegenerate, "test"), Equals, true)
+	c.Assert(e.setState(StateWaitingToRegenerate, "test"), Equals, true)
 	// build starts
 	c.Assert(e.BuilderSetStateLocked(StateRegenerating, "test"), Equals, true)
 	// another change arrives while building
-	c.Assert(e.SetStateLocked(StateWaitingToRegenerate, "test"), Equals, true)
+	c.Assert(e.setState(StateWaitingToRegenerate, "test"), Equals, true)
 	// Builder's transition to ready fails due to the queued build
 	c.Assert(e.BuilderSetStateLocked(StateReady, "test"), Equals, false)
 	// second build starts
@@ -389,18 +389,18 @@ func (s *EndpointSuite) TestEndpointState(c *C) {
 	// second build finishes
 	c.Assert(e.BuilderSetStateLocked(StateReady, "test"), Equals, true)
 	// endpoint is being deleted
-	c.Assert(e.SetStateLocked(StateDisconnecting, "test"), Equals, true)
+	c.Assert(e.setState(StateDisconnecting, "test"), Equals, true)
 	// parallel disconnect fails
-	c.Assert(e.SetStateLocked(StateDisconnecting, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateDisconnected, "test"), Equals, true)
+	c.Assert(e.setState(StateDisconnecting, "test"), Equals, false)
+	c.Assert(e.setState(StateDisconnected, "test"), Equals, true)
 
 	// Restoring state
 	e.state = StateRestoring
-	c.Assert(e.SetStateLocked(StateWaitingToRegenerate, "test"), Equals, false)
-	c.Assert(e.SetStateLocked(StateDisconnecting, "test"), Equals, true)
+	c.Assert(e.setState(StateWaitingToRegenerate, "test"), Equals, false)
+	c.Assert(e.setState(StateDisconnecting, "test"), Equals, true)
 
 	e.state = StateRestoring
-	c.Assert(e.SetStateLocked(StateRestoring, "test"), Equals, true)
+	c.Assert(e.setState(StateRestoring, "test"), Equals, true)
 
 }
 

--- a/pkg/endpoint/events.go
+++ b/pkg/endpoint/events.go
@@ -41,7 +41,7 @@ func (ev *EndpointRegenerationEvent) Handle(res chan interface{}) {
 
 		return
 	}
-	e.RUnlock()
+	e.runlock()
 
 	// We should only queue the request after we use all the endpoint's
 	// lock/unlock. Otherwise this can get a deadlock if the endpoint is

--- a/pkg/endpoint/events.go
+++ b/pkg/endpoint/events.go
@@ -34,7 +34,7 @@ func (ev *EndpointRegenerationEvent) Handle(res chan interface{}) {
 
 	err := e.rlockAlive()
 	if err != nil {
-		e.LogDisconnectedMutexAction(err, "before regeneration")
+		e.logDisconnectedMutexAction(err, "before regeneration")
 		res <- &EndpointRegenerationResult{
 			err: err,
 		}

--- a/pkg/endpoint/events.go
+++ b/pkg/endpoint/events.go
@@ -32,7 +32,7 @@ func (ev *EndpointRegenerationEvent) Handle(res chan interface{}) {
 	e := ev.ep
 	regenContext := ev.regenContext
 
-	err := e.RLockAlive()
+	err := e.rlockAlive()
 	if err != nil {
 		e.LogDisconnectedMutexAction(err, "before regeneration")
 		res <- &EndpointRegenerationResult{

--- a/pkg/endpoint/lock.go
+++ b/pkg/endpoint/lock.go
@@ -60,7 +60,7 @@ func (e *Endpoint) UnconditionalRLock() {
 	e.mutex.RLock()
 }
 
-// LogDisconnectedMutexAction gets the logger and logs given error with context
-func (e *Endpoint) LogDisconnectedMutexAction(err error, context string) {
+// logDisconnectedMutexAction gets the logger and logs given error with context
+func (e *Endpoint) logDisconnectedMutexAction(err error, context string) {
 	e.getLogger().WithError(err).Error(context)
 }

--- a/pkg/endpoint/lock.go
+++ b/pkg/endpoint/lock.go
@@ -46,12 +46,12 @@ func (e *Endpoint) RUnlock() {
 	e.mutex.RUnlock()
 }
 
-// UnconditionalLock should be used only for locking endpoint for
+// unconditionalLock should be used only for locking endpoint for
 // - setting its state to StateDisconnected
 // - handling regular Lock errors
 // - reporting endpoint status (like in LogStatus method)
 // Use Lock in all other cases
-func (e *Endpoint) UnconditionalLock() {
+func (e *Endpoint) unconditionalLock() {
 	e.mutex.Lock()
 }
 

--- a/pkg/endpoint/lock.go
+++ b/pkg/endpoint/lock.go
@@ -55,8 +55,8 @@ func (e *Endpoint) unconditionalLock() {
 	e.mutex.Lock()
 }
 
-// UnconditionalRLock should be used only for reporting endpoint state
-func (e *Endpoint) UnconditionalRLock() {
+// unconditionalRLock should be used only for reporting endpoint state
+func (e *Endpoint) unconditionalRLock() {
 	e.mutex.RLock()
 }
 

--- a/pkg/endpoint/lock.go
+++ b/pkg/endpoint/lock.go
@@ -16,8 +16,8 @@ package endpoint
 
 import "fmt"
 
-// LockAlive returns error if endpoint was removed, locks underlying mutex otherwise
-func (e *Endpoint) LockAlive() error {
+// lockAlive returns error if endpoint was removed, locks underlying mutex otherwise
+func (e *Endpoint) lockAlive() error {
 	e.mutex.Lock()
 	if e.IsDisconnecting() {
 		e.mutex.Unlock()
@@ -31,8 +31,8 @@ func (e *Endpoint) Unlock() {
 	e.mutex.Unlock()
 }
 
-// RLockAlive returns error if endpoint was removed, read locks underlying mutex otherwise
-func (e *Endpoint) RLockAlive() error {
+// rlockAlive returns error if endpoint was removed, read locks underlying mutex otherwise
+func (e *Endpoint) rlockAlive() error {
 	e.mutex.RLock()
 	if e.IsDisconnecting() {
 		e.mutex.RUnlock()

--- a/pkg/endpoint/lock.go
+++ b/pkg/endpoint/lock.go
@@ -41,8 +41,8 @@ func (e *Endpoint) rlockAlive() error {
 	return nil
 }
 
-// RUnlock read unlocks endpoint mutex
-func (e *Endpoint) RUnlock() {
+// runlock read unlocks endpoint mutex
+func (e *Endpoint) runlock() {
 	e.mutex.RUnlock()
 }
 

--- a/pkg/endpoint/lock.go
+++ b/pkg/endpoint/lock.go
@@ -27,7 +27,7 @@ func (e *Endpoint) lockAlive() error {
 }
 
 // Unlock unlocks endpoint mutex
-func (e *Endpoint) Unlock() {
+func (e *Endpoint) unlock() {
 	e.mutex.Unlock()
 }
 

--- a/pkg/endpoint/log.go
+++ b/pkg/endpoint/log.go
@@ -106,7 +106,7 @@ func (e *Endpoint) UpdateLogger(fields map[string]interface{}) {
 		logfields.DesiredPolicyRevision:  e.nextPolicyRevision,
 		logfields.IPv4:                   e.IPv4.String(),
 		logfields.IPv6:                   e.IPv6.String(),
-		logfields.K8sPodName:             e.GetK8sNamespaceAndPodNameLocked(),
+		logfields.K8sPodName:             e.getK8sNamespaceAndPodName(),
 	})
 
 	if e.SecurityIdentity != nil {

--- a/pkg/endpoint/manager.go
+++ b/pkg/endpoint/manager.go
@@ -105,7 +105,7 @@ func (e *Endpoint) generateReferences() map[id.PrefixType]string {
 		refs[id.ContainerNamePrefix] = e.ContainerName
 	}
 
-	if podName := e.GetK8sNamespaceAndPodNameLocked(); podName != "" {
+	if podName := e.getK8sNamespaceAndPodName(); podName != "" {
 		refs[id.PodNamePrefix] = podName
 	}
 	return refs

--- a/pkg/endpoint/manager.go
+++ b/pkg/endpoint/manager.go
@@ -55,7 +55,7 @@ func (e *Endpoint) Expose(mgr endpointManager) error {
 
 	// No need to check liveness as an endpoint can only be deleted via the
 	// API after it has been inserted into the manager.
-	e.UnconditionalRLock()
+	e.unconditionalRLock()
 	mgr.UpdateIDReference(e)
 	e.updateReferences(mgr)
 	e.RUnlock()

--- a/pkg/endpoint/manager.go
+++ b/pkg/endpoint/manager.go
@@ -58,7 +58,7 @@ func (e *Endpoint) Expose(mgr endpointManager) error {
 	e.unconditionalRLock()
 	mgr.UpdateIDReference(e)
 	e.updateReferences(mgr)
-	e.RUnlock()
+	e.runlock()
 
 	e.getLogger().Info("New endpoint")
 
@@ -73,7 +73,7 @@ func (e *Endpoint) UpdateReferences(mgr endpointManager) error {
 	if err := e.rlockAlive(); err != nil {
 		return err
 	}
-	defer e.RUnlock()
+	defer e.runlock()
 	e.updateReferences(mgr)
 	return nil
 }

--- a/pkg/endpoint/manager.go
+++ b/pkg/endpoint/manager.go
@@ -70,7 +70,7 @@ func (e *Endpoint) Expose(mgr endpointManager) error {
 // endpoints for the given endpoint. Returns an error if the endpoint is
 // being deleted.
 func (e *Endpoint) UpdateReferences(mgr endpointManager) error {
-	if err := e.RLockAlive(); err != nil {
+	if err := e.rlockAlive(); err != nil {
 		return err
 	}
 	defer e.RUnlock()

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -299,7 +299,7 @@ func (e *Endpoint) regenerate(context *regenerationContext) (retErr error) {
 			if retErr == nil {
 				retErr = err
 			} else {
-				e.LogDisconnectedMutexAction(err, "after regenerate")
+				e.logDisconnectedMutexAction(err, "after regenerate")
 			}
 			return
 		}

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -249,7 +249,7 @@ func (e *Endpoint) regenerate(context *regenerationContext) (retErr error) {
 
 	stats.waitingForLock.Start()
 	// Check if endpoints is still alive before doing any build
-	err = e.LockAlive()
+	err = e.lockAlive()
 	stats.waitingForLock.End(err == nil)
 	if err != nil {
 		return err
@@ -295,7 +295,7 @@ func (e *Endpoint) regenerate(context *regenerationContext) (retErr error) {
 	stats.prepareBuild.End(true)
 
 	defer func() {
-		if err := e.LockAlive(); err != nil {
+		if err := e.lockAlive(); err != nil {
 			if retErr == nil {
 				retErr = err
 			} else {
@@ -342,7 +342,7 @@ func (e *Endpoint) updateRealizedState(stats *regenerationStatistics, origDir st
 	// in the datapath. PolicyMap state is not updated here, because that is
 	// performed in endpoint.syncPolicyMap().
 	stats.waitingForLock.Start()
-	err := e.LockAlive()
+	err := e.lockAlive()
 	stats.waitingForLock.End(err == nil)
 	if err != nil {
 		return err
@@ -414,7 +414,7 @@ func (e *Endpoint) updateRegenerationStatistics(context *regenerationContext, er
 //  - true if the regeneration succeed
 //  - nothing and the channel is closed if the regeneration did not happen
 func (e *Endpoint) RegenerateIfAlive(regenMetadata *regeneration.ExternalRegenerationMetadata) <-chan bool {
-	if err := e.LockAlive(); err != nil {
+	if err := e.lockAlive(); err != nil {
 		log.WithError(err).Warnf("Endpoint disappeared while queued to be regenerated: %s", regenMetadata.Reason)
 		e.LogStatus(Policy, Failure, "Error while handling policy updates for endpoint: "+err.Error())
 	} else {
@@ -544,7 +544,7 @@ func (e *Endpoint) runIPIdentitySync(endpointIP addressing.CiliumIP) {
 	e.controllers.UpdateController(fmt.Sprintf("sync-%s-identity-mapping (%d)", addressFamily, e.ID),
 		controller.ControllerParams{
 			DoFunc: func(ctx context.Context) error {
-				if err := e.RLockAlive(); err != nil {
+				if err := e.rlockAlive(); err != nil {
 					return controller.NewExitReason("Endpoint disappeared")
 				}
 

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -262,12 +262,12 @@ func (e *Endpoint) regenerate(context *regenerationContext) (retErr error) {
 	if e.GetStateLocked() != StateWaitingForIdentity &&
 		!e.BuilderSetStateLocked(StateRegenerating, "Regenerating endpoint: "+context.Reason) {
 		e.getLogger().WithField(logfields.EndpointState, e.state).Debug("Skipping build due to invalid state")
-		e.Unlock()
+		e.unlock()
 
 		return fmt.Errorf("Skipping build due to invalid state: %s", e.state)
 	}
 
-	e.Unlock()
+	e.unlock()
 
 	stats.prepareBuild.Start()
 	origDir := e.StateDirectoryPath()
@@ -315,7 +315,7 @@ func (e *Endpoint) regenerate(context *regenerationContext) (retErr error) {
 		// changes are needed. There should be an another regenerate
 		// queued for taking care of it.
 		e.BuilderSetStateLocked(StateReady, "Completed endpoint regeneration with no pending regeneration requests")
-		e.Unlock()
+		e.unlock()
 	}()
 
 	revision, compilationExecuted, err = e.regenerateBPF(context)
@@ -348,7 +348,7 @@ func (e *Endpoint) updateRealizedState(stats *regenerationStatistics, origDir st
 		return err
 	}
 
-	defer e.Unlock()
+	defer e.unlock()
 
 	// Depending upon result of BPF regeneration (compilation executed),
 	// shift endpoint directories to match said BPF regeneration
@@ -427,7 +427,7 @@ func (e *Endpoint) RegenerateIfAlive(regenMetadata *regeneration.ExternalRegener
 		default:
 			regen = e.setState(StateWaitingToRegenerate, fmt.Sprintf("Triggering endpoint regeneration due to %s", regenMetadata.Reason))
 		}
-		e.Unlock()
+		e.unlock()
 		if regen {
 			// Regenerate logs status according to the build success/failure
 			return e.Regenerate(regenMetadata)

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -383,7 +383,7 @@ func (e *Endpoint) updateRegenerationStatistics(context *regenerationContext, er
 	e.mutex.RLock()
 	stats.endpointID = e.ID
 	stats.policyStatus = e.policyStatus()
-	e.RUnlock()
+	e.runlock()
 	stats.SendMetrics()
 
 	fields := logrus.Fields{
@@ -549,7 +549,7 @@ func (e *Endpoint) runIPIdentitySync(endpointIP addressing.CiliumIP) {
 				}
 
 				if e.SecurityIdentity == nil {
-					e.RUnlock()
+					e.runlock()
 					return nil
 				}
 
@@ -561,7 +561,7 @@ func (e *Endpoint) runIPIdentitySync(endpointIP addressing.CiliumIP) {
 
 				// Release lock as we do not want to have long-lasting key-value
 				// store operations resulting in lock being held for a long time.
-				e.RUnlock()
+				e.runlock()
 
 				if err := ipcache.UpsertIPToKVStore(ctx, IP, hostIP, ID, key, metadata); err != nil {
 					return fmt.Errorf("unable to add endpoint IP mapping '%s'->'%d': %s", IP.String(), ID, err)

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -422,10 +422,10 @@ func (e *Endpoint) RegenerateIfAlive(regenMetadata *regeneration.ExternalRegener
 		state := e.GetStateLocked()
 		switch state {
 		case StateRestoring, StateWaitingToRegenerate:
-			e.SetStateLocked(state, fmt.Sprintf("Skipped duplicate endpoint regeneration trigger due to %s", regenMetadata.Reason))
+			e.setState(state, fmt.Sprintf("Skipped duplicate endpoint regeneration trigger due to %s", regenMetadata.Reason))
 			regen = false
 		default:
-			regen = e.SetStateLocked(StateWaitingToRegenerate, fmt.Sprintf("Triggering endpoint regeneration due to %s", regenMetadata.Reason))
+			regen = e.setState(StateWaitingToRegenerate, fmt.Sprintf("Triggering endpoint regeneration due to %s", regenMetadata.Reason))
 		}
 		e.Unlock()
 		if regen {
@@ -613,7 +613,7 @@ func (e *Endpoint) SetIdentity(identity *identityPkg.Identity, newEndpoint bool)
 
 	// Sets endpoint state to ready if was waiting for identity
 	if e.GetStateLocked() == StateWaitingForIdentity {
-		e.SetStateLocked(StateReady, "Set identity for this endpoint")
+		e.setState(StateReady, "Set identity for this endpoint")
 	}
 
 	// Whenever the identity is updated, propagate change to key-value store

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -227,7 +227,7 @@ func (e *Endpoint) restoreIdentity() error {
 	// parts of the identity not being marshaled to JSON. Hence we must set
 	// the identity even if has not changed.
 	e.SetIdentity(identity, true)
-	e.Unlock()
+	e.unlock()
 
 	return nil
 }

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -128,7 +128,7 @@ func (e *Endpoint) RegenerateAfterRestore() error {
 	// NOTE: unconditionalRLock is used here because it's used only for logging an already restored endpoint
 	e.unconditionalRLock()
 	scopedLog.WithField(logfields.IPAddr, []string{e.IPv4.String(), e.IPv6.String()}).Info("Restored endpoint")
-	e.RUnlock()
+	e.runlock()
 	return nil
 }
 
@@ -140,7 +140,7 @@ func (e *Endpoint) restoreIdentity() error {
 	scopedLog := log.WithField(logfields.EndpointID, e.ID)
 	// Filter the restored labels with the new daemon's filter
 	l, _ := labels.FilterLabels(e.OpLabels.AllLabels())
-	e.RUnlock()
+	e.runlock()
 
 	allocateCtx, cancel := context.WithTimeout(context.Background(), option.Config.KVstoreConnectivityTimeout)
 	defer cancel()

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -174,7 +174,7 @@ func (e *Endpoint) restoreIdentity() error {
 		return err
 	}
 
-	e.SetStateLocked(StateRestoring, "Synchronizing endpoint labels with KVStore")
+	e.setState(StateRestoring, "Synchronizing endpoint labels with KVStore")
 
 	if e.SecurityIdentity != nil {
 		if oldSecID := e.SecurityIdentity.ID; identity.ID != oldSecID {

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -125,8 +125,8 @@ func (e *Endpoint) RegenerateAfterRestore() error {
 		return fmt.Errorf("failed while regenerating endpoint")
 	}
 
-	// NOTE: UnconditionalRLock is used here because it's used only for logging an already restored endpoint
-	e.UnconditionalRLock()
+	// NOTE: unconditionalRLock is used here because it's used only for logging an already restored endpoint
+	e.unconditionalRLock()
 	scopedLog.WithField(logfields.IPAddr, []string{e.IPv4.String(), e.IPv6.String()}).Info("Restored endpoint")
 	e.RUnlock()
 	return nil

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -133,7 +133,7 @@ func (e *Endpoint) RegenerateAfterRestore() error {
 }
 
 func (e *Endpoint) restoreIdentity() error {
-	if err := e.RLockAlive(); err != nil {
+	if err := e.rlockAlive(); err != nil {
 		e.LogDisconnectedMutexAction(err, "before filtering labels during regenerating restored endpoint")
 		return err
 	}
@@ -169,7 +169,7 @@ func (e *Endpoint) restoreIdentity() error {
 		}
 	}
 
-	if err := e.LockAlive(); err != nil {
+	if err := e.lockAlive(); err != nil {
 		scopedLog.Warn("Endpoint to restore has been deleted")
 		return err
 	}

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -134,7 +134,7 @@ func (e *Endpoint) RegenerateAfterRestore() error {
 
 func (e *Endpoint) restoreIdentity() error {
 	if err := e.rlockAlive(); err != nil {
-		e.LogDisconnectedMutexAction(err, "before filtering labels during regenerating restored endpoint")
+		e.logDisconnectedMutexAction(err, "before filtering labels during regenerating restored endpoint")
 		return err
 	}
 	scopedLog := log.WithField(logfields.EndpointID, e.ID)

--- a/pkg/endpoint/test_utils.go
+++ b/pkg/endpoint/test_utils.go
@@ -33,7 +33,7 @@ func (e *Endpoint) WaitForIdentity(timeoutDuration time.Duration) *identity.Iden
 		case <-timeout.C:
 			return nil
 		case <-tick.C:
-			e.UnconditionalRLock()
+			e.unconditionalRLock()
 			secID = e.SecurityIdentity
 			e.RUnlock()
 			if secID != nil {

--- a/pkg/endpoint/test_utils.go
+++ b/pkg/endpoint/test_utils.go
@@ -35,7 +35,7 @@ func (e *Endpoint) WaitForIdentity(timeoutDuration time.Duration) *identity.Iden
 		case <-tick.C:
 			e.unconditionalRLock()
 			secID = e.SecurityIdentity
-			e.RUnlock()
+			e.runlock()
 			if secID != nil {
 				return secID
 			}

--- a/pkg/endpoint/test_utils.go
+++ b/pkg/endpoint/test_utils.go
@@ -1,0 +1,44 @@
+// Copyright 2016-2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endpoint
+
+import (
+	"time"
+
+	"github.com/cilium/cilium/pkg/identity"
+)
+
+// WaitForIdentity waits for up to timeoutDuration amount of time for the
+// endpoint to have an identity. If the timeout is reached, returns nil.
+func (e *Endpoint) WaitForIdentity(timeoutDuration time.Duration) *identity.Identity {
+	timeout := time.NewTimer(timeoutDuration)
+	defer timeout.Stop()
+	tick := time.NewTicker(200 * time.Millisecond)
+	defer tick.Stop()
+	var secID *identity.Identity
+	for {
+		select {
+		case <-timeout.C:
+			return nil
+		case <-tick.C:
+			e.UnconditionalRLock()
+			secID = e.SecurityIdentity
+			e.RUnlock()
+			if secID != nil {
+				return secID
+			}
+		}
+	}
+}

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -336,7 +336,7 @@ func (mgr *EndpointManager) RemoveReferences(mappings map[endpointid.PrefixType]
 	}
 }
 
-// RegenerateAllEndpoints calls a SetStateLocked for each endpoint and
+// RegenerateAllEndpoints calls a setState for each endpoint and
 // regenerates if state transaction is valid. During this process, the endpoint
 // list is locked and cannot be modified.
 // Returns a waiting group that can be used to know when all the endpoints are

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -702,9 +702,7 @@ func (s *EndpointManagerSuite) TestUpdateReferences(c *C) {
 		ep = mgr.lookupDockerContainerName(want.ep.GetContainerName())
 		c.Assert(ep, checker.DeepEquals, want.ep, Commentf("Test Name: %s", tt.name))
 
-		want.ep.UnconditionalRLock()
-		ep = mgr.LookupPodName(want.ep.GetK8sNamespaceAndPodNameLocked())
-		want.ep.RUnlock()
+		ep = mgr.LookupPodName(want.ep.GetK8sNamespaceAndPodName())
 		c.Assert(ep, checker.DeepEquals, want.ep, Commentf("Test Name: %s", tt.name))
 		tt.postTestRun()
 	}


### PR DESCRIPTION
All locking functionality for the endpoint is now contained within `pkg/endpoint`; do not export this functionality accordingly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9142)
<!-- Reviewable:end -->
