### PR TITLE
docs: Fix kubeadm join cmd in kubeproxy-free gsg

### DIFF
--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -45,7 +45,7 @@ and the token returned by ``kubeadm init``:
 
 .. code:: bash
 
-   kubectl join <..>
+   kubeadm join <..>
 
 Download the Cilium release tarball and change to the Kubernetes
 install directory:


### PR DESCRIPTION
`kubeadm join` is used to join a cluster provisioned with kubeadm.

Reported-by: Daniel Borkmann.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9144)
<!-- Reviewable:end -->
