### PR TITLE
operator: Pass identity allocation mode through correctly

### DIFF
--- a/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
@@ -31,6 +31,7 @@ spec:
       containers:
       - args:
         - --debug=$(CILIUM_DEBUG)
+        - --identity-allocation-mode=$(CILIUM_IDENTITY_ALLOCATION_MODE)
 {{- if .Values.global.prometheus.enabled }}
         - --enable-metrics
 {{- end }}
@@ -109,6 +110,12 @@ spec:
             secretKeyRef:
               key: AWS_DEFAULT_REGION
               name: cilium-aws
+              optional: true
+        - name: CILIUM_IDENTITY_ALLOCATION_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: identity-allocation-mode
+              name: cilium-config
               optional: true
 {{- if .Values.global.k8sServiceHost }}
         - name: KUBERNETES_SERVICE_HOST

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -553,6 +553,7 @@ spec:
       containers:
       - args:
         - --debug=$(CILIUM_DEBUG)
+        - --identity-allocation-mode=$(CILIUM_IDENTITY_ALLOCATION_MODE)
         command:
         - cilium-operator
         env:
@@ -625,6 +626,12 @@ spec:
             secretKeyRef:
               key: AWS_DEFAULT_REGION
               name: cilium-aws
+              optional: true
+        - name: CILIUM_IDENTITY_ALLOCATION_MODE
+          valueFrom:
+            configMapKeyRef:
+              key: identity-allocation-mode
+              name: cilium-config
               optional: true
         image: "docker.io/cilium/operator:latest"
         imagePullPolicy: Always


### PR DESCRIPTION
We introduced CRD identities and rely on cilium-operator to do the
garbage collection. The default mode, however, is kvstore allocation in
order to support upgrades where the option is not set. The configuration
we generate for examples does set it to crd but his wasn't passed to
cilium-operator and so it would never enable crd GC unless the option
was added to the arguments.

Fixes #9147 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9152)
<!-- Reviewable:end -->
