### PR TITLE
endpoint: create separate interface for proxy

### DIFF
--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -228,7 +228,7 @@ type EndpointAdder interface {
 //
 // CleanupEndpoint() must be called before calling LaunchAsEndpoint() to ensure
 // cleanup of prior cilium-health endpoint instances.
-func LaunchAsEndpoint(baseCtx context.Context, owner regeneration.Owner, n *node.Node, mtuConfig mtu.Configuration, epMgr EndpointAdder) (*Client, error) {
+func LaunchAsEndpoint(baseCtx context.Context, owner regeneration.Owner, n *node.Node, mtuConfig mtu.Configuration, epMgr EndpointAdder, proxy endpoint.EndpointProxy) (*Client, error) {
 	var (
 		cmd  = launcher.Launcher{}
 		info = &models.EndpointChangeRequest{
@@ -306,7 +306,7 @@ func LaunchAsEndpoint(baseCtx context.Context, owner regeneration.Owner, n *node
 	}
 
 	// Create the endpoint
-	ep, err := endpoint.NewEndpointFromChangeModel(owner, info)
+	ep, err := endpoint.NewEndpointFromChangeModel(owner, proxy, info)
 	if err != nil {
 		return nil, fmt.Errorf("Error while creating endpoint model: %s", err)
 	}

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -175,7 +175,7 @@ func (d *Daemon) createEndpoint(ctx context.Context, epTemplate *models.Endpoint
 		epTemplate.DatapathConfiguration.RequireRouting = &disabled
 	}
 
-	ep, err := endpoint.NewEndpointFromChangeModel(d, epTemplate)
+	ep, err := endpoint.NewEndpointFromChangeModel(d, d.l7Proxy, epTemplate)
 	if err != nil {
 		return invalidDataError(ep, fmt.Errorf("unable to parse endpoint parameters: %s", err))
 	}
@@ -322,7 +322,7 @@ func (h *patchEndpointID) Handle(params PatchEndpointIDParams) middleware.Respon
 
 	// Validate the template. Assignment afterwards is atomic.
 	// Note: newEp's labels are ignored.
-	newEp, err2 := endpoint.NewEndpointFromChangeModel(h.d, epTemplate)
+	newEp, err2 := endpoint.NewEndpointFromChangeModel(h.d, h.d.l7Proxy, epTemplate)
 	if err2 != nil {
 		return api.Error(PutEndpointIDInvalidCode, err2)
 	}

--- a/daemon/health.go
+++ b/daemon/health.go
@@ -76,7 +76,7 @@ func (d *Daemon) initHealth() {
 				if client == nil || err != nil {
 					var launchErr error
 					d.cleanupHealthEndpoint()
-					client, launchErr = health.LaunchAsEndpoint(ctx, d, &d.nodeDiscovery.LocalNode, d.mtuConfig, d.endpointManager)
+					client, launchErr = health.LaunchAsEndpoint(ctx, d, &d.nodeDiscovery.LocalNode, d.mtuConfig, d.endpointManager, d.l7Proxy)
 					if launchErr != nil {
 						if err != nil {
 							return fmt.Errorf("failed to restart endpoint (check failed: %q): %s", err, launchErr)

--- a/daemon/policy_test.go
+++ b/daemon/policy_test.go
@@ -125,7 +125,7 @@ func prepareEndpointDirs() (cleanup func(), err error) {
 }
 
 func (ds *DaemonSuite) prepareEndpoint(c *C, identity *identity.Identity, qa bool) *endpoint.Endpoint {
-	e := endpoint.NewEndpointWithState(ds.d, testEndpointID, endpoint.StateWaitingForIdentity)
+	e := endpoint.NewEndpointWithState(ds.d, ds.d.l7Proxy, testEndpointID, endpoint.StateWaitingForIdentity)
 	if qa {
 		e.IPv6 = QAIPv6Addr
 		e.IPv4 = QAIPv4Addr

--- a/daemon/proxy.go
+++ b/daemon/proxy.go
@@ -15,67 +15,9 @@
 package main
 
 import (
-	"fmt"
-
-	"github.com/cilium/cilium/pkg/completion"
-	"github.com/cilium/cilium/pkg/endpoint/regeneration"
-	"github.com/cilium/cilium/pkg/logging/logfields"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
-	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy/logger"
-	"github.com/cilium/cilium/pkg/revert"
-	"github.com/sirupsen/logrus"
 )
-
-// UpdateProxyRedirect updates the redirect rules in the proxy for a particular
-// endpoint using the provided L4 filter. Returns the allocated proxy port
-func (d *Daemon) UpdateProxyRedirect(e regeneration.EndpointUpdater, l4 *policy.L4Filter, proxyWaitGroup *completion.WaitGroup) (uint16, error, revert.FinalizeFunc, revert.RevertFunc) {
-	if d.l7Proxy == nil {
-		return 0, fmt.Errorf("can't redirect, proxy disabled"), nil, nil
-	}
-
-	port, err, finalizeFunc, revertFunc := d.l7Proxy.CreateOrUpdateRedirect(l4, e.ProxyID(l4), e, proxyWaitGroup)
-	if err != nil {
-		return 0, err, nil, nil
-	}
-
-	return port, nil, finalizeFunc, revertFunc
-}
-
-// RemoveProxyRedirect removes a previously installed proxy redirect for an
-// endpoint
-func (d *Daemon) RemoveProxyRedirect(e regeneration.EndpointInfoSource, id string, proxyWaitGroup *completion.WaitGroup) (error, revert.FinalizeFunc, revert.RevertFunc) {
-	if d.l7Proxy == nil {
-		return nil, nil, nil
-	}
-
-	log.WithFields(logrus.Fields{
-		logfields.EndpointID: e.GetID(),
-		logfields.L4PolicyID: id,
-	}).Debug("Removing redirect to endpoint")
-	return d.l7Proxy.RemoveRedirect(id, proxyWaitGroup)
-}
-
-// UpdateNetworkPolicy adds or updates a network policy in the set
-// published to L7 proxies.
-func (d *Daemon) UpdateNetworkPolicy(e regeneration.EndpointUpdater, policy *policy.L4Policy,
-	proxyWaitGroup *completion.WaitGroup) (error, revert.RevertFunc) {
-	if d.l7Proxy == nil {
-		return fmt.Errorf("can't update network policy, proxy disabled"), nil
-	}
-	err, revertFunc := d.l7Proxy.UpdateNetworkPolicy(e, policy, e.GetIngressPolicyEnabledLocked(),
-		e.GetEgressPolicyEnabledLocked(), proxyWaitGroup)
-	return err, revert.RevertFunc(revertFunc)
-}
-
-// RemoveNetworkPolicy removes a network policy from the set published to
-// L7 proxies.
-func (d *Daemon) RemoveNetworkPolicy(e regeneration.EndpointInfoSource) {
-	if d.l7Proxy == nil {
-		return
-	}
-	d.l7Proxy.RemoveNetworkPolicy(e)
-}
 
 // NewProxyLogRecord is invoked by the proxy accesslog on each new access log entry
 func (d *Daemon) NewProxyLogRecord(l *logger.LogRecord) error {

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -162,7 +162,7 @@ func (d *Daemon) restoreOldEndpoints(dir string, clean bool) (*endpointRestoreSt
 		ep.LogStatusOK(endpoint.Other, "Restoring endpoint from previous cilium instance")
 
 		ep.SetDefaultConfiguration(true)
-
+		ep.SetProxy(d.l7Proxy)
 		ep.SkipStateClean()
 
 		state.restored = append(state.restored, ep)
@@ -220,8 +220,6 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) (resto
 		if ep.Options.IsEnabled(option.ConntrackLocal) {
 			ctmap.DeleteIfUpgradeNeeded(ep)
 		}
-
-		ep.SetProxy(d.l7Proxy)
 
 		// Insert into endpoint manager so it can be regenerated when calls to
 		// RegenerateAllEndpoints() are made. This must be done synchronously (i.e.,

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -221,12 +221,13 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) (resto
 			ctmap.DeleteIfUpgradeNeeded(ep)
 		}
 
+		ep.SetProxy(d.l7Proxy)
+
 		// Insert into endpoint manager so it can be regenerated when calls to
 		// RegenerateAllEndpoints() are made. This must be done synchronously (i.e.,
 		// not in a goroutine) because regenerateRestoredEndpoints must guarantee
 		// upon returning that endpoints are exposed to other subsystems via
 		// endpointmanager.
-
 		if err := ep.Expose(d.endpointManager); err != nil {
 			log.WithError(err).Warning("Unable to restore endpoint")
 			// remove endpoint from slice of endpoints to restore

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -59,13 +59,14 @@ func (e *Endpoint) GetLabelsModel() (*models.LabelConfiguration, error) {
 }
 
 // NewEndpointFromChangeModel creates a new endpoint from a request
-func NewEndpointFromChangeModel(owner regeneration.Owner, base *models.EndpointChangeRequest) (*Endpoint, error) {
+func NewEndpointFromChangeModel(owner regeneration.Owner, proxy EndpointProxy, base *models.EndpointChangeRequest) (*Endpoint, error) {
 	if base == nil {
 		return nil, nil
 	}
 
 	ep := &Endpoint{
 		owner:            owner,
+		proxy:            proxy,
 		ID:               uint16(base.ID),
 		containerName:    base.ContainerName,
 		containerID:      base.ContainerID,

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -166,7 +166,7 @@ func (e *Endpoint) addNewRedirectsFromMap(m policy.L4PolicyMap, desiredRedirects
 			if !e.hasSidecarProxy || l4.L7Parser != policy.ParserTypeHTTP {
 				var finalizeFunc revert.FinalizeFunc
 				var revertFunc revert.RevertFunc
-				redirectPort, err, finalizeFunc, revertFunc = e.owner.UpdateProxyRedirect(e, l4, proxyWaitGroup)
+				redirectPort, err, finalizeFunc, revertFunc = e.updateProxyRedirect(l4, proxyWaitGroup)
 				if err != nil {
 					revertStack.Revert() // Ignore errors while reverting. This is best-effort.
 					return err, nil, nil
@@ -299,7 +299,7 @@ func (e *Endpoint) removeOldRedirects(desiredRedirects map[string]bool, proxyWai
 			continue
 		}
 
-		err, finalizeFunc, revertFunc := e.owner.RemoveProxyRedirect(e, id, proxyWaitGroup)
+		err, finalizeFunc, revertFunc := e.proxy.RemoveRedirect(id, proxyWaitGroup)
 		if err != nil {
 			e.getLogger().WithError(err).WithField(logfields.L4PolicyID, id).Warn("Error while removing proxy redirect")
 			continue

--- a/pkg/endpoint/bpf_test.go
+++ b/pkg/endpoint/bpf_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func (s *EndpointSuite) TestWriteInformationalComments(c *C) {
-	e := NewEndpointWithState(s, 100, StateCreating)
+	e := NewEndpointWithState(s, &FakeEndpointProxy{}, 100, StateCreating)
 
 	var f bytes.Buffer
 	err := e.writeInformationalComments(&f)
@@ -38,7 +38,7 @@ func (s *EndpointSuite) TestWriteInformationalComments(c *C) {
 type writeFunc func(io.Writer) error
 
 func BenchmarkWriteHeaderfile(b *testing.B) {
-	e := NewEndpointWithState(&suite, 100, StateCreating)
+	e := NewEndpointWithState(&suite, &FakeEndpointProxy{}, 100, StateCreating)
 	dp := linux.NewDatapath(linux.DatapathConfiguration{}, nil)
 
 	targetComments := func(w io.Writer) error {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -109,6 +109,8 @@ var _ notifications.RegenNotificationInfo = &Endpoint{}
 type Endpoint struct {
 	owner regeneration.Owner
 
+	proxy EndpointProxy
+
 	// ID of the endpoint, unique in the scope of the node
 	ID uint16
 
@@ -363,9 +365,10 @@ func (e *Endpoint) waitForProxyCompletions(proxyWaitGroup *completion.WaitGroup)
 }
 
 // NewEndpointWithState creates a new endpoint useful for testing purposes
-func NewEndpointWithState(owner regeneration.Owner, ID uint16, state string) *Endpoint {
+func NewEndpointWithState(owner regeneration.Owner, proxy EndpointProxy, ID uint16, state string) *Endpoint {
 	ep := &Endpoint{
 		owner:           owner,
+		proxy:           proxy,
 		ID:              ID,
 		OpLabels:        pkgLabels.NewOpLabels(),
 		status:          NewEndpointStatus(),
@@ -965,7 +968,7 @@ func (e *Endpoint) leaveLocked(proxyWaitGroup *completion.WaitGroup, conf Delete
 		if err != nil {
 			errors = append(errors, fmt.Errorf("unable to release identity: %s", err))
 		}
-		e.owner.RemoveNetworkPolicy(e)
+		e.removeNetworkPolicy()
 		e.SecurityIdentity = nil
 	}
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -109,8 +109,6 @@ var _ notifications.RegenNotificationInfo = &Endpoint{}
 type Endpoint struct {
 	owner regeneration.Owner
 
-	proxy EndpointProxy
-
 	// ID of the endpoint, unique in the scope of the node
 	ID uint16
 
@@ -224,6 +222,8 @@ type Endpoint struct {
 	// proxyStatisticsMutex is the mutex that must be held to read or write
 	// proxyStatistics.
 	proxyStatisticsMutex lock.RWMutex
+
+	proxy EndpointProxy
 
 	// proxyStatistics contains statistics of proxy redirects.
 	// They keys in this map are policy.ProxyIDs.

--- a/pkg/endpoint/endpoint_status_test.go
+++ b/pkg/endpoint/endpoint_status_test.go
@@ -50,7 +50,7 @@ type endpointGeneratorSpec struct {
 }
 
 func (s *EndpointSuite) newEndpoint(c *check.C, spec endpointGeneratorSpec) *Endpoint {
-	e, err := NewEndpointFromChangeModel(s, &models.EndpointChangeRequest{
+	e, err := NewEndpointFromChangeModel(s, nil, &models.EndpointChangeRequest{
 		Addressing: &models.AddressPair{},
 		ID:         200,
 		Labels: models.Labels{

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -78,8 +78,12 @@ func (e *Endpoint) updateNetworkPolicy(proxyWaitGroup *completion.WaitGroup) (re
 		return nil, nil
 	}
 
+	if e.proxy == nil {
+		return fmt.Errorf("can't update network policy, proxy disabled"), nil
+	}
+
 	// Publish the updated policy to L7 proxies.
-	return e.owner.UpdateNetworkPolicy(e, e.desiredPolicy.L4Policy, proxyWaitGroup)
+	return e.proxy.UpdateNetworkPolicy(e, e.desiredPolicy.L4Policy, e.desiredPolicy.IngressPolicyEnabled, e.desiredPolicy.EgressPolicyEnabled, proxyWaitGroup)
 }
 
 // setNextPolicyRevision updates the desired policy revision field

--- a/pkg/endpoint/proxy.go
+++ b/pkg/endpoint/proxy.go
@@ -1,0 +1,84 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endpoint
+
+import (
+	"fmt"
+
+	"github.com/cilium/cilium/pkg/completion"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/proxy/logger"
+	"github.com/cilium/cilium/pkg/revert"
+	"github.com/sirupsen/logrus"
+)
+
+// EndpointProxy defines any L7 proxy with which an Endpoint must interact.
+type EndpointProxy interface {
+	CreateOrUpdateRedirect(l4 *policy.L4Filter, id string, localEndpoint logger.EndpointUpdater, wg *completion.WaitGroup) (proxyPort uint16, err error, finalizeFunc revert.FinalizeFunc, revertFunc revert.RevertFunc)
+	RemoveRedirect(id string, wg *completion.WaitGroup) (error, revert.FinalizeFunc, revert.RevertFunc)
+	UpdateNetworkPolicy(ep logger.EndpointUpdater, policy *policy.L4Policy, ingressPolicyEnforced, egressPolicyEnforced bool, wg *completion.WaitGroup) (error, func() error)
+	RemoveNetworkPolicy(ep logger.EndpointInfoSource)
+}
+
+// SetProxy sets the proxy for this endpoint.
+func (e *Endpoint) SetProxy(p EndpointProxy) {
+	e.unconditionalLock()
+	defer e.unlock()
+	e.proxy = p
+}
+
+// updateProxyRedirect updates the redirect rules in the proxy for a particular
+// endpoint using the provided L4 filter. Returns the allocated proxy port
+func (e *Endpoint) updateProxyRedirect(l4 *policy.L4Filter, proxyWaitGroup *completion.WaitGroup) (proxyPort uint16, err error, finalizeFunc revert.FinalizeFunc, revertFunc revert.RevertFunc) {
+	if e.proxy == nil {
+		return 0, fmt.Errorf("can't redirect, proxy disabled"), nil, nil
+	}
+	return e.proxy.CreateOrUpdateRedirect(l4, e.ProxyID(l4), e, proxyWaitGroup)
+}
+
+// removeProxyRedirect removes a previously installed proxy redirect for an
+// endpoint.
+func (e *Endpoint) removeProxyRedirect(id string, proxyWaitGroup *completion.WaitGroup) (error, revert.FinalizeFunc, revert.RevertFunc) {
+	if e.proxy == nil {
+		return nil, nil, nil
+	}
+	log.WithFields(logrus.Fields{
+		logfields.EndpointID: e.ID,
+		logfields.L4PolicyID: id,
+	}).Debug("Removing redirect to endpoint")
+	return e.proxy.RemoveRedirect(id, proxyWaitGroup)
+}
+
+func (e *Endpoint) removeNetworkPolicy() {
+	if e.proxy == nil {
+		return
+	}
+	e.proxy.RemoveNetworkPolicy(e)
+}
+
+type FakeEndpointProxy struct{}
+
+func (f *FakeEndpointProxy) CreateOrUpdateRedirect(l4 *policy.L4Filter, id string, localEndpoint logger.EndpointUpdater, wg *completion.WaitGroup) (proxyPort uint16, err error, finalizeFunc revert.FinalizeFunc, revertFunc revert.RevertFunc) {
+	return
+}
+
+func (f *FakeEndpointProxy) RemoveRedirect(id string, wg *completion.WaitGroup) (error, revert.FinalizeFunc, revert.RevertFunc) {
+	return nil, nil, nil
+}
+func (f *FakeEndpointProxy) UpdateNetworkPolicy(ep logger.EndpointUpdater, policy *policy.L4Policy, ingressPolicyEnforced, egressPolicyEnforced bool, wg *completion.WaitGroup) (error, func() error) {
+	return nil, nil
+}
+func (f *FakeEndpointProxy) RemoveNetworkPolicy(ep logger.EndpointInfoSource) {}

--- a/pkg/endpoint/regeneration/owner.go
+++ b/pkg/endpoint/regeneration/owner.go
@@ -17,7 +17,6 @@ package regeneration
 import (
 	"context"
 
-	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
@@ -25,29 +24,12 @@ import (
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
-	"github.com/cilium/cilium/pkg/revert"
 )
 
 // Owner is the interface defines the requirements for anybody owning policies.
 type Owner interface {
-
 	// Must return the policy repository
 	GetPolicyRepository() *policy.Repository
-
-	// UpdateProxyRedirect must update the redirect configuration of an endpoint in the proxy
-	UpdateProxyRedirect(e EndpointUpdater, l4 *policy.L4Filter, proxyWaitGroup *completion.WaitGroup) (uint16, error, revert.FinalizeFunc, revert.RevertFunc)
-
-	// RemoveProxyRedirect must remove the redirect installed by UpdateProxyRedirect
-	RemoveProxyRedirect(e EndpointInfoSource, id string, proxyWaitGroup *completion.WaitGroup) (error, revert.FinalizeFunc, revert.RevertFunc)
-
-	// UpdateNetworkPolicy adds or updates a network policy in the set
-	// published to L7 proxies.
-	UpdateNetworkPolicy(e EndpointUpdater, policy *policy.L4Policy,
-		proxyWaitGroup *completion.WaitGroup) (error, revert.RevertFunc)
-
-	// RemoveNetworkPolicy removes a network policy from the set published to
-	// L7 proxies.
-	RemoveNetworkPolicy(e EndpointInfoSource)
 
 	// QueueEndpointBuild puts the given endpoint in the processing queue
 	QueueEndpointBuild(ctx context.Context, epID uint64) (func(), error)

--- a/pkg/endpoint/restore_test.go
+++ b/pkg/endpoint/restore_test.go
@@ -71,7 +71,7 @@ func (ds *EndpointSuite) endpointCreator(id uint16, secID identity.NumericIdenti
 	repo := ds.GetPolicyRepository()
 	repo.GetPolicyCache().LocalEndpointIdentityAdded(identity)
 
-	ep := NewEndpointWithState(ds, id, StateReady)
+	ep := NewEndpointWithState(ds, &FakeEndpointProxy{}, id, StateReady)
 	// Random network ID and docker endpoint ID with 59 hex chars + 5 strID = 64 hex chars
 	ep.dockerNetworkID = "603e047d2268a57f5a5f93f7f9e1263e9207e348a06654bf64948def001" + strID
 	ep.dockerEndpointID = "93529fda8c401a071d21d6bd46fdf5499b9014dcb5a35f2e3efaa8d8002" + strID

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -106,7 +106,7 @@ type dummyEpSyncher struct{}
 func (epSync *dummyEpSyncher) RunK8sCiliumEndpointSync(e *endpoint.Endpoint) {}
 
 func (s *EndpointManagerSuite) TestLookup(c *C) {
-	ep := endpoint.NewEndpointWithState(s, 10, endpoint.StateReady)
+	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, 10, endpoint.StateReady)
 	mgr := NewEndpointManager(&dummyEpSyncher{})
 	type args struct {
 		id string
@@ -353,7 +353,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 
 func (s *EndpointManagerSuite) TestLookupCiliumID(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
-	ep := endpoint.NewEndpointWithState(s, 2, endpoint.StateReady)
+	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, 2, endpoint.StateReady)
 	type args struct {
 		id uint16
 	}
@@ -422,7 +422,7 @@ func (s *EndpointManagerSuite) TestLookupCiliumID(c *C) {
 
 func (s *EndpointManagerSuite) TestLookupContainerID(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
-	ep := endpoint.NewEndpointWithState(s, 3, endpoint.StateReady)
+	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, 3, endpoint.StateReady)
 	type args struct {
 		id string
 	}
@@ -489,7 +489,7 @@ func (s *EndpointManagerSuite) TestLookupContainerID(c *C) {
 
 func (s *EndpointManagerSuite) TestLookupIPv4(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
-	ep := endpoint.NewEndpointWithState(s, 4, endpoint.StateReady)
+	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, 4, endpoint.StateReady)
 	type args struct {
 		ip string
 	}
@@ -558,7 +558,7 @@ func (s *EndpointManagerSuite) TestLookupIPv4(c *C) {
 
 func (s *EndpointManagerSuite) TestLookupPodName(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
-	ep := endpoint.NewEndpointWithState(s, 5, endpoint.StateReady)
+	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, 5, endpoint.StateReady)
 	type args struct {
 		podName string
 	}
@@ -626,7 +626,7 @@ func (s *EndpointManagerSuite) TestLookupPodName(c *C) {
 
 func (s *EndpointManagerSuite) TestUpdateReferences(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
-	ep := endpoint.NewEndpointWithState(s, 6, endpoint.StateReady)
+	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, 6, endpoint.StateReady)
 	type args struct {
 		ep *endpoint.Endpoint
 	}
@@ -704,7 +704,7 @@ func (s *EndpointManagerSuite) TestUpdateReferences(c *C) {
 
 func (s *EndpointManagerSuite) TestRemove(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
-	ep := endpoint.NewEndpointWithState(s, 7, endpoint.StateReady)
+	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, 7, endpoint.StateReady)
 	type args struct {
 	}
 	type want struct {
@@ -744,7 +744,7 @@ func (s *EndpointManagerSuite) TestRemove(c *C) {
 
 func (s *EndpointManagerSuite) TestHasGlobalCT(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
-	ep := endpoint.NewEndpointWithState(s, 1, endpoint.StateReady)
+	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, 1, endpoint.StateReady)
 	type args struct {
 		ep *endpoint.Endpoint
 	}
@@ -807,7 +807,7 @@ func (s *EndpointManagerSuite) TestHasGlobalCT(c *C) {
 
 func (s *EndpointManagerSuite) TestWaitForEndpointsAtPolicyRev(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
-	ep := endpoint.NewEndpointWithState(s, 1, endpoint.StateReady)
+	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, 1, endpoint.StateReady)
 	type args struct {
 		ctx    context.Context
 		rev    uint64
@@ -845,7 +845,7 @@ func (s *EndpointManagerSuite) TestWaitForEndpointsAtPolicyRev(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, 1, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, 1, endpoint.StateReady)
 			},
 		},
 		{
@@ -871,7 +871,7 @@ func (s *EndpointManagerSuite) TestWaitForEndpointsAtPolicyRev(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, 1, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, 1, endpoint.StateReady)
 			},
 		},
 		{
@@ -897,7 +897,7 @@ func (s *EndpointManagerSuite) TestWaitForEndpointsAtPolicyRev(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, 1, endpoint.StateReady)
+				ep = endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, 1, endpoint.StateReady)
 			},
 		},
 	}

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -141,7 +141,7 @@ func (s *DNSProxyTestSuite) SetUpSuite(c *C) {
 
 	proxy, err := StartDNSProxy("", 0,
 		func(ip net.IP) (*endpoint.Endpoint, error) {
-			ep := endpoint.NewEndpointWithState(s, 123, endpoint.StateReady)
+			ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, 123, endpoint.StateReady)
 			return ep, nil
 		},
 		func(lookupTime time.Time, ep *endpoint.Endpoint, epIPPort string, dstAddr string, msg *dns.Msg, protocol string, allowed bool, stat ProxyRequestContext) error {

--- a/pkg/proxy/kafka_test.go
+++ b/pkg/proxy/kafka_test.go
@@ -274,7 +274,7 @@ func (s *proxyTestSuite) TestKafkaRedirect(c *C) {
 
 	// Insert a mock EP to the endpointmanager so that DefaultEndpointInfoRegistry may find
 	// the EP ID by the IP.
-	ep := endpoint.NewEndpointWithState(s, uint16(localEndpointMock.GetID()), endpoint.StateReady)
+	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, uint16(localEndpointMock.GetID()), endpoint.StateReady)
 	ipv4, err := addressing.NewCiliumIPv4("127.0.0.1")
 	c.Assert(err, IsNil)
 	ep.IPv4 = ipv4

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -634,3 +634,8 @@ func (p *Proxy) UpdateRedirectMetrics() {
 		metrics.ProxyRedirects.WithLabelValues(proto).Set(float64(count))
 	}
 }
+
+// UpdateProxyRedirect must update the redirect configuration of an endpoint in the proxy
+func (p *Proxy) UpdateNetworkPolicy(ep logger.EndpointUpdater, policy *policy.L4Policy, ingressPolicyEnforced, egressPolicyEnforced bool, wg *completion.WaitGroup) (error, func() error) {
+	return p.XDSServer.UpdateNetworkPolicy(ep, policy, ingressPolicyEnforced, egressPolicyEnforced, wg)
+}


### PR DESCRIPTION
This is waiting on https://github.com/cilium/cilium/pull/9183 to be merged.

The `Owner` interface has served as a catch-all callback into the `Daemon` which is
managing an `Endpoint`. However, the necessary functions for proxy configuration are
specific enough to warrant their own separate interface. Create a separate interface
for the functions necessary for Endpoint<->Proxy interaction, and inject this L7 proxy
into the Endpoint upon Endpoint creation / Endpoint restoration.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9157)
<!-- Reviewable:end -->
