### PR TITLE
endpointmanager: remove unneeded calls to `UpdateLogger`

### DIFF
--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -108,7 +108,6 @@ func (epSync *dummyEpSyncher) RunK8sCiliumEndpointSync(e *endpoint.Endpoint) {}
 func (s *EndpointManagerSuite) TestLookup(c *C) {
 	ep := endpoint.NewEndpointWithState(s, 10, endpoint.StateReady)
 	mgr := NewEndpointManager(&dummyEpSyncher{})
-	ep.UpdateLogger(nil)
 	type args struct {
 		id string
 	}
@@ -355,7 +354,6 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 func (s *EndpointManagerSuite) TestLookupCiliumID(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
 	ep := endpoint.NewEndpointWithState(s, 2, endpoint.StateReady)
-	ep.UpdateLogger(nil)
 	type args struct {
 		id uint16
 	}
@@ -425,7 +423,6 @@ func (s *EndpointManagerSuite) TestLookupCiliumID(c *C) {
 func (s *EndpointManagerSuite) TestLookupContainerID(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
 	ep := endpoint.NewEndpointWithState(s, 3, endpoint.StateReady)
-	ep.UpdateLogger(nil)
 	type args struct {
 		id string
 	}
@@ -493,7 +490,6 @@ func (s *EndpointManagerSuite) TestLookupContainerID(c *C) {
 func (s *EndpointManagerSuite) TestLookupIPv4(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
 	ep := endpoint.NewEndpointWithState(s, 4, endpoint.StateReady)
-	ep.UpdateLogger(nil)
 	type args struct {
 		ip string
 	}
@@ -563,7 +559,6 @@ func (s *EndpointManagerSuite) TestLookupIPv4(c *C) {
 func (s *EndpointManagerSuite) TestLookupPodName(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
 	ep := endpoint.NewEndpointWithState(s, 5, endpoint.StateReady)
-	ep.UpdateLogger(nil)
 	type args struct {
 		podName string
 	}
@@ -632,7 +627,6 @@ func (s *EndpointManagerSuite) TestLookupPodName(c *C) {
 func (s *EndpointManagerSuite) TestUpdateReferences(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
 	ep := endpoint.NewEndpointWithState(s, 6, endpoint.StateReady)
-	ep.UpdateLogger(nil)
 	type args struct {
 		ep *endpoint.Endpoint
 	}
@@ -713,7 +707,6 @@ func (s *EndpointManagerSuite) TestUpdateReferences(c *C) {
 func (s *EndpointManagerSuite) TestRemove(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
 	ep := endpoint.NewEndpointWithState(s, 7, endpoint.StateReady)
-	ep.UpdateLogger(nil)
 	type args struct {
 	}
 	type want struct {
@@ -754,7 +747,6 @@ func (s *EndpointManagerSuite) TestRemove(c *C) {
 func (s *EndpointManagerSuite) TestHasGlobalCT(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
 	ep := endpoint.NewEndpointWithState(s, 1, endpoint.StateReady)
-	ep.UpdateLogger(nil)
 	type args struct {
 		ep *endpoint.Endpoint
 	}
@@ -818,7 +810,6 @@ func (s *EndpointManagerSuite) TestHasGlobalCT(c *C) {
 func (s *EndpointManagerSuite) TestWaitForEndpointsAtPolicyRev(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
 	ep := endpoint.NewEndpointWithState(s, 1, endpoint.StateReady)
-	ep.UpdateLogger(nil)
 	type args struct {
 		ctx    context.Context
 		rev    uint64


### PR DESCRIPTION
`NewEndpointWithState` already calls `UpdateLogger`; there is no need to call it again.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9158)
<!-- Reviewable:end -->
