### PR TITLE
daemon: fix container runtime disabled state status

### DIFF
--- a/daemon/status.go
+++ b/daemon/status.go
@@ -347,9 +347,13 @@ func (d *Daemon) getStatus(brief bool) models.StatusResponse {
 			Msg:   "Kvstore service is not ready",
 		}
 	case d.statusResponse.ContainerRuntime != nil && d.statusResponse.ContainerRuntime.State != models.StatusStateOk:
+		msg := "Container runtime is not ready"
+		if d.statusResponse.ContainerRuntime.State == models.StatusStateDisabled {
+			msg = "Container runtime is disabled"
+		}
 		sr.Cilium = &models.Status{
 			State: d.statusResponse.ContainerRuntime.State,
-			Msg:   "Container runtime is not ready",
+			Msg:   msg,
 		}
 	case k8s.IsEnabled() && d.statusResponse.Kubernetes != nil && d.statusResponse.Kubernetes.State != models.StatusStateOk:
 		sr.Cilium = &models.Status{


### PR DESCRIPTION
Container runtime log/status report by default is `Container runtime is not ready`
when the status is not OK. This is a bit confusing when the container
runtime is disabled(which is now by default). This pull request changes
the log message to `Container runtime disabled` when the container
runtime is not enabled.

Now doing a `cilium status` when the container runtime is disabled will
show the message as `Container runtime disabled` instead of `Container
runtime is not ready`.

Fixes #9123

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9159)
<!-- Reviewable:end -->
