### PR TITLE
factor out conntrack GC into separate package

### DIFF
--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -49,6 +49,7 @@ import (
 	"github.com/cilium/cilium/pkg/loadinfo"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/maps/ctmap/gc"
 	"github.com/cilium/cilium/pkg/metrics"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/node"
@@ -1185,8 +1186,8 @@ func runDaemon() {
 
 	bootstrapStats.enableConntrack.Start()
 	log.Info("Starting connection tracking garbage collector")
-	d.endpointManager.EnableConntrackGC(option.Config.EnableIPv4, option.Config.EnableIPv6,
-		restoredEndpoints.restored)
+	gc.EnableConntrackGC(option.Config.EnableIPv4, option.Config.EnableIPv6,
+		restoredEndpoints.restored, d.endpointManager)
 	bootstrapStats.enableConntrack.End(true)
 
 	bootstrapStats.k8sInit.Start()

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -1186,7 +1186,7 @@ func runDaemon() {
 
 	bootstrapStats.enableConntrack.Start()
 	log.Info("Starting connection tracking garbage collector")
-	gc.EnableConntrackGC(option.Config.EnableIPv4, option.Config.EnableIPv6,
+	gc.Enable(option.Config.EnableIPv4, option.Config.EnableIPv6,
 		restoredEndpoints.restored, d.endpointManager)
 	bootstrapStats.enableConntrack.End(true)
 

--- a/pkg/maps/ctmap/gc/gc.go
+++ b/pkg/maps/ctmap/gc/gc.go
@@ -35,8 +35,8 @@ type EndpointManager interface {
 	GetEndpoints() []*endpoint.Endpoint
 }
 
-// EnableConntrackGC enables the connection tracking garbage collection.
-func EnableConntrackGC(ipv4, ipv6 bool, restoredEndpoints []*endpoint.Endpoint, mgr EndpointManager) {
+// Enable enables the connection tracking garbage collection.
+func Enable(ipv4, ipv6 bool, restoredEndpoints []*endpoint.Endpoint, mgr EndpointManager) {
 	var (
 		initialScan         = true
 		initialScanComplete = make(chan struct{})


### PR DESCRIPTION
CT garbage collection uses the EndpointManager API - it does not need to be
tied into `pkg/endpointmanager`. Remove it accordingly.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9160)
<!-- Reviewable:end -->
