### PR TITLE
Refactor probing to reuse client

### DIFF
--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -345,12 +345,8 @@ func LaunchAsEndpoint(baseCtx context.Context, owner regeneration.Owner, n *node
 	defer cancel()
 	ep.UpdateLabels(ctx, labels.LabelHealth, nil, true)
 
-	// Initialize the health client to talk to this instance. This is why
-	// the caller must limit usage of this package to a single goroutine.
+	// Initialize the health client to talk to this instance.
 	client := &Client{host: "http://" + net.JoinHostPort(healthIP.String(), fmt.Sprintf("%d", healthDefaults.HTTPPathPort))}
-	if err = client.PingEndpoint(); err != nil {
-		return nil, fmt.Errorf("Cannot establish connection to health endpoint: %s", err)
-	}
 	metrics.SubprocessStart.WithLabelValues(ciliumHealth).Inc()
 
 	return client, nil

--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -152,13 +152,13 @@ func configureHealthInterface(netNS ns.NetNS, ifName string, ip4Addr, ip6Addr *n
 // Client wraps a client to a specific cilium-health endpoint instance, to
 // provide convenience methods such as PingEndpoint().
 type Client struct {
-	*probe.Client
+	host string
 }
 
 // PingEndpoint attempts to make an API ping request to the local cilium-health
 // endpoint, and returns whether this was successful.
 func (c *Client) PingEndpoint() error {
-	return c.Client.GetHello()
+	return probe.GetHello(c.host)
 }
 
 // KillEndpoint attempts to kill any existing cilium-health endpoint if it
@@ -347,11 +347,11 @@ func LaunchAsEndpoint(baseCtx context.Context, owner regeneration.Owner, n *node
 
 	// Initialize the health client to talk to this instance. This is why
 	// the caller must limit usage of this package to a single goroutine.
-	client, err := probe.NewClient("http://" + net.JoinHostPort(healthIP.String(), fmt.Sprintf("%d", healthDefaults.HTTPPathPort)))
-	if err != nil {
+	client := &Client{host: "http://" + net.JoinHostPort(healthIP.String(), fmt.Sprintf("%d", healthDefaults.HTTPPathPort))}
+	if err = client.PingEndpoint(); err != nil {
 		return nil, fmt.Errorf("Cannot establish connection to health endpoint: %s", err)
 	}
 	metrics.SubprocessStart.WithLabelValues(ciliumHealth).Inc()
 
-	return &Client{Client: client}, nil
+	return client, nil
 }

--- a/pkg/health/probe/probe.go
+++ b/pkg/health/probe/probe.go
@@ -21,34 +21,25 @@ import (
 	"time"
 )
 
-// DefaultTimeout used for requests
-var DefaultTimeout = 30 * time.Second
-
-// Client for accessing the http probe
-type Client struct {
-	client *http.Client
-	host   *url.URL
-}
-
-// NewClient creates a new http client with DefaultTransport
-func NewClient(host string) (*Client, error) {
-	hostURL, err := url.Parse(host)
-	if err != nil {
-		return nil, err
-	}
-
-	cl := &http.Client{Timeout: DefaultTimeout}
-	return &Client{cl, hostURL}, nil
-}
+// http Client for probing
+// Use our custom client since DefaultClient specifies timeout of 0 (no timeout).
+// See https://medium.com/@nate510/don-t-use-go-s-default-http-client-4804cb19f779.
+// Use a timeout of 30s.
+var client = &http.Client{Timeout: 30 * time.Second}
 
 // GetHello performs a GET request on the /hello endpoint
-func (c *Client) GetHello() error {
-	requestURL, err := c.host.Parse("/hello")
+func GetHello(host string) error {
+	hostURL, err := url.Parse(host)
 	if err != nil {
 		return err
 	}
 
-	resp, err := c.client.Get(requestURL.String())
+	requestURL, err := hostURL.Parse("/hello")
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Get(requestURL.String())
 	if err != nil {
 		return err
 	}

--- a/pkg/health/server/prober.go
+++ b/pkg/health/server/prober.go
@@ -243,22 +243,16 @@ func (p *prober) httpProbe(node string, ip string, port int) *models.Connectivit
 		"path":             PortToPaths[port],
 	})
 
-	client, err := probe.NewClient(host)
+	scopedLog.Debug("Greeting host")
+	start := time.Now()
+	err := probe.GetHello(host)
+	rtt := time.Since(start)
 	if err == nil {
-		scopedLog.Debug("Greeting host")
-		start := time.Now()
-		err = client.GetHello()
-		rtt := time.Since(start)
-		if err == nil {
-			scopedLog.WithField("rtt", rtt).Debug("Greeting successful")
-			result.Status = ""
-			result.Latency = rtt.Nanoseconds()
-		} else {
-			scopedLog.WithError(err).Debug("Greeting snubbed")
-			result.Status = err.Error()
-		}
+		scopedLog.WithField("rtt", rtt).Debug("Greeting successful")
+		result.Status = ""
+		result.Latency = rtt.Nanoseconds()
 	} else {
-		scopedLog.WithError(err).Info("Failed to express greeting to host")
+		scopedLog.WithError(err).Debug("Greeting failed")
 		result.Status = err.Error()
 	}
 


### PR DESCRIPTION
Rather than recreate the client every single time, just have a global http
client and pass the host to GetHello.

Fixes: #9136

Signed-off-by: Boran Car <boran.car@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9161)
<!-- Reviewable:end -->
