### PR TITLE
policy: Don't open localhost when allowing L7 traffic

### DIFF
--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -76,7 +76,7 @@ type MapStateEntry struct {
 // endpoint.
 func (keys MapState) DetermineAllowLocalhostIngress(l4Policy *L4Policy) {
 
-	if option.Config.AlwaysAllowLocalhost() || (l4Policy != nil && l4Policy.HasRedirect()) {
+	if option.Config.AlwaysAllowLocalhost() {
 		keys[localHostKey] = MapStateEntry{}
 	}
 }


### PR DESCRIPTION
Traffic from the proxy is already allowed by having the proxy propagate
the original identity of the packet through a socket option as the
traffic goes towards the destination, so I'm not sure why the presence
of a redirect means that localhost should be allowed. Tracing the origin
of this code, it goes at least two years back and I can only guess that
it predates that functionality.

This fixes an issue where if you configure `--allow-localhost=policy`
then traffic from the localhost is not subject to policy when attempting
to transmit traffic into an endpoint protected by L7 policy.

The vast majority of users are not affected by this so not opting for backport.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9162)
<!-- Reviewable:end -->
