### PR TITLE
CI: increase timeouts by 30m to avoid  k8s-1.10 test timeouts

### DIFF
--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -10,11 +10,11 @@ pipeline {
         MEMORY = "4096"
         SERVER_BOX = "cilium/ubuntu"
         NETNEXT=setIfLabel("ci/net-next", "true", "false")
-        GINKGO_TIMEOUT="108m"
+        GINKGO_TIMEOUT="138m"
     }
 
     options {
-        timeout(time: 240, unit: 'MINUTES')
+        timeout(time: 270, unit: 'MINUTES')
         timestamps()
         ansiColor('xterm')
     }
@@ -162,7 +162,7 @@ pipeline {
         }
         stage ("BDD-Test-PR"){
             options {
-                timeout(time: 110, unit: 'MINUTES')
+                timeout(time: 140, unit: 'MINUTES')
             }
             environment {
                 FAILFAST=setIfLabel("ci/fail-fast", "true", "false")


### PR DESCRIPTION
We seem to have slower test runs when running net-next and k8s 1.10.
This goes away when we upgrade to 1.11 but, to clean up the 1.6 branch,
we up the timeouts to allow the tests to complete.

Helps with https://github.com/cilium/cilium/issues/9041

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9163)
<!-- Reviewable:end -->
