### PR TITLE
endpoint: do not export additional fields

### DIFF
--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -185,9 +185,9 @@ func (d *Daemon) createEndpoint(ctx context.Context, epTemplate *models.Endpoint
 		return invalidDataError(ep, fmt.Errorf("endpoint ID %d already exists", ep.ID))
 	}
 
-	oldEp = d.endpointManager.LookupContainerID(ep.ContainerID)
+	oldEp = d.endpointManager.LookupContainerID(ep.GetContainerID())
 	if oldEp != nil {
-		return invalidDataError(ep, fmt.Errorf("endpoint for container %s already exists", ep.ContainerID))
+		return invalidDataError(ep, fmt.Errorf("endpoint for container %s already exists", ep.GetContainerID()))
 	}
 
 	var checkIDs []string

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -68,7 +68,7 @@ func NewEndpointFromChangeModel(owner regeneration.Owner, base *models.EndpointC
 		owner:            owner,
 		ID:               uint16(base.ID),
 		containerName:    base.ContainerName,
-		ContainerID:      base.ContainerID,
+		containerID:      base.ContainerID,
 		DockerNetworkID:  base.DockerNetworkID,
 		DockerEndpointID: base.DockerEndpointID,
 		ifName:           base.InterfaceName,
@@ -192,7 +192,7 @@ func (e *Endpoint) GetModelRLocked() *models.Endpoint {
 				HostMac:        e.nodeMAC.String(),
 			},
 			ExternalIdentifiers: &models.EndpointIdentifiers{
-				ContainerID:      e.ContainerID,
+				ContainerID:      e.containerID,
 				ContainerName:    e.containerName,
 				DockerEndpointID: e.DockerEndpointID,
 				DockerNetworkID:  e.DockerNetworkID,

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -70,7 +70,7 @@ func NewEndpointFromChangeModel(owner regeneration.Owner, base *models.EndpointC
 		containerName:    base.ContainerName,
 		containerID:      base.ContainerID,
 		dockerNetworkID:  base.DockerNetworkID,
-		DockerEndpointID: base.DockerEndpointID,
+		dockerEndpointID: base.DockerEndpointID,
 		ifName:           base.InterfaceName,
 		K8sPodName:       base.K8sPodName,
 		K8sNamespace:     base.K8sNamespace,
@@ -194,7 +194,7 @@ func (e *Endpoint) GetModelRLocked() *models.Endpoint {
 			ExternalIdentifiers: &models.EndpointIdentifiers{
 				ContainerID:      e.containerID,
 				ContainerName:    e.containerName,
-				DockerEndpointID: e.DockerEndpointID,
+				DockerEndpointID: e.dockerEndpointID,
 				DockerNetworkID:  e.dockerNetworkID,
 				PodName:          e.getK8sNamespaceAndPodName(),
 			},

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -67,7 +67,7 @@ func NewEndpointFromChangeModel(owner regeneration.Owner, base *models.EndpointC
 	ep := &Endpoint{
 		owner:            owner,
 		ID:               uint16(base.ID),
-		ContainerName:    base.ContainerName,
+		containerName:    base.ContainerName,
 		ContainerID:      base.ContainerID,
 		DockerNetworkID:  base.DockerNetworkID,
 		DockerEndpointID: base.DockerEndpointID,
@@ -193,7 +193,7 @@ func (e *Endpoint) GetModelRLocked() *models.Endpoint {
 			},
 			ExternalIdentifiers: &models.EndpointIdentifiers{
 				ContainerID:      e.ContainerID,
-				ContainerName:    e.ContainerName,
+				ContainerName:    e.containerName,
 				DockerEndpointID: e.DockerEndpointID,
 				DockerNetworkID:  e.DockerNetworkID,
 				PodName:          e.getK8sNamespaceAndPodName(),

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -69,7 +69,7 @@ func NewEndpointFromChangeModel(owner regeneration.Owner, base *models.EndpointC
 		ID:               uint16(base.ID),
 		containerName:    base.ContainerName,
 		containerID:      base.ContainerID,
-		DockerNetworkID:  base.DockerNetworkID,
+		dockerNetworkID:  base.DockerNetworkID,
 		DockerEndpointID: base.DockerEndpointID,
 		ifName:           base.InterfaceName,
 		K8sPodName:       base.K8sPodName,
@@ -195,7 +195,7 @@ func (e *Endpoint) GetModelRLocked() *models.Endpoint {
 				ContainerID:      e.containerID,
 				ContainerName:    e.containerName,
 				DockerEndpointID: e.DockerEndpointID,
-				DockerNetworkID:  e.DockerNetworkID,
+				DockerNetworkID:  e.dockerNetworkID,
 				PodName:          e.getK8sNamespaceAndPodName(),
 			},
 			// FIXME GH-3280 When we begin returning endpoint revisions this should

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -89,11 +89,11 @@ func (e *Endpoint) writeInformationalComments(w io.Writer) error {
 		e.logStatusLocked(BPF, Warning, fmt.Sprintf("Unable to create a base64: %s", err))
 	}
 
-	if e.ContainerID == "" {
+	if e.containerID == "" {
 		fmt.Fprintf(fw, " * Docker Network ID: %s\n", e.DockerNetworkID)
 		fmt.Fprintf(fw, " * Docker Endpoint ID: %s\n", e.DockerEndpointID)
 	} else {
-		fmt.Fprintf(fw, " * Container ID: %s\n", e.ContainerID)
+		fmt.Fprintf(fw, " * Container ID: %s\n", e.containerID)
 	}
 
 	fmt.Fprintf(fw, ""+

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -91,7 +91,7 @@ func (e *Endpoint) writeInformationalComments(w io.Writer) error {
 
 	if e.containerID == "" {
 		fmt.Fprintf(fw, " * Docker Network ID: %s\n", e.dockerNetworkID)
-		fmt.Fprintf(fw, " * Docker Endpoint ID: %s\n", e.DockerEndpointID)
+		fmt.Fprintf(fw, " * Docker Endpoint ID: %s\n", e.dockerEndpointID)
 	} else {
 		fmt.Fprintf(fw, " * Container ID: %s\n", e.containerID)
 	}

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -90,7 +90,7 @@ func (e *Endpoint) writeInformationalComments(w io.Writer) error {
 	}
 
 	if e.containerID == "" {
-		fmt.Fprintf(fw, " * Docker Network ID: %s\n", e.DockerNetworkID)
+		fmt.Fprintf(fw, " * Docker Network ID: %s\n", e.dockerNetworkID)
 		fmt.Fprintf(fw, " * Docker Endpoint ID: %s\n", e.DockerEndpointID)
 	} else {
 		fmt.Fprintf(fw, " * Container ID: %s\n", e.containerID)
@@ -1167,7 +1167,7 @@ func (e *Endpoint) FinishIPVLANInit(netNsPath string) error {
 
 	// No need to finish IPVLAN initialization for Docker if the endpoint isn't
 	// running with Docker.
-	if e.DockerNetworkID == "" {
+	if e.dockerNetworkID == "" {
 		return nil
 	}
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -126,9 +126,9 @@ type Endpoint struct {
 	// endpoint is a docker managed container which uses libnetwork
 	dockerNetworkID string
 
-	// DockerEndpointID is the Docker network endpoint ID if managed by
+	// dockerEndpointID is the Docker network endpoint ID if managed by
 	// libnetwork
-	DockerEndpointID string
+	dockerEndpointID string
 
 	// Corresponding BPF map identifier for tail call map of ipvlan datapath
 	datapathMapID int
@@ -1119,8 +1119,14 @@ func (e *Endpoint) getShortContainerID() string {
 // SetDockerEndpointID modifies the endpoint's Docker Endpoint ID
 func (e *Endpoint) SetDockerEndpointID(id string) {
 	e.unconditionalLock()
-	e.DockerEndpointID = id
+	e.dockerEndpointID = id
 	e.unlock()
+}
+
+func (e *Endpoint) GetDockerEndpointID() string {
+	e.unconditionalRLock()
+	defer e.runlock()
+	return e.dockerEndpointID
 }
 
 // SetDockerNetworkID modifies the endpoint's Docker Endpoint ID

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -116,8 +116,8 @@ type Endpoint struct {
 	// for the logger field which has its own mutex
 	mutex lock.RWMutex
 
-	// ContainerName is the name given to the endpoint by the container runtime
-	ContainerName string
+	// containerName is the name given to the endpoint by the container runtime
+	containerName string
 
 	// ContainerID is the container ID that docker has assigned to the endpoint
 	// Note: The JSON tag was kept for backward compatibility.
@@ -998,13 +998,13 @@ func (e *Endpoint) RegenerateWait(reason string) error {
 func (e *Endpoint) GetContainerName() string {
 	e.unconditionalRLock()
 	defer e.runlock()
-	return e.ContainerName
+	return e.containerName
 }
 
 // SetContainerName modifies the endpoint's container name
 func (e *Endpoint) SetContainerName(name string) {
 	e.unconditionalLock()
-	e.ContainerName = name
+	e.containerName = name
 	e.unlock()
 }
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -119,9 +119,8 @@ type Endpoint struct {
 	// containerName is the name given to the endpoint by the container runtime
 	containerName string
 
-	// ContainerID is the container ID that docker has assigned to the endpoint
-	// Note: The JSON tag was kept for backward compatibility.
-	ContainerID string `json:"dockerID,omitempty"`
+	// containerID is the container ID that docker has assigned to the endpoint
+	containerID string
 
 	// DockerNetworkID is the network ID of the libnetwork network if the
 	// endpoint is a docker managed container which uses libnetwork
@@ -1080,7 +1079,7 @@ func (e *Endpoint) SetK8sPodName(name string) {
 // SetContainerID modifies the endpoint's container ID
 func (e *Endpoint) SetContainerID(id string) {
 	e.unconditionalLock()
-	e.ContainerID = id
+	e.containerID = id
 	e.UpdateLogger(map[string]interface{}{
 		logfields.ContainerID: e.getShortContainerID(),
 	})
@@ -1090,7 +1089,7 @@ func (e *Endpoint) SetContainerID(id string) {
 // GetContainerID returns the endpoint's container ID
 func (e *Endpoint) GetContainerID() string {
 	e.unconditionalRLock()
-	cID := e.ContainerID
+	cID := e.containerID
 	e.runlock()
 	return cID
 }
@@ -1109,11 +1108,11 @@ func (e *Endpoint) getShortContainerID() string {
 	}
 
 	caplen := 10
-	if len(e.ContainerID) <= caplen {
-		return e.ContainerID
+	if len(e.containerID) <= caplen {
+		return e.containerID
 	}
 
-	return e.ContainerID[:caplen]
+	return e.containerID[:caplen]
 
 }
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -122,9 +122,9 @@ type Endpoint struct {
 	// containerID is the container ID that docker has assigned to the endpoint
 	containerID string
 
-	// DockerNetworkID is the network ID of the libnetwork network if the
+	// dockerNetworkID is the network ID of the libnetwork network if the
 	// endpoint is a docker managed container which uses libnetwork
-	DockerNetworkID string
+	dockerNetworkID string
 
 	// DockerEndpointID is the Docker network endpoint ID if managed by
 	// libnetwork
@@ -1126,7 +1126,7 @@ func (e *Endpoint) SetDockerEndpointID(id string) {
 // SetDockerNetworkID modifies the endpoint's Docker Endpoint ID
 func (e *Endpoint) SetDockerNetworkID(id string) {
 	e.unconditionalLock()
-	e.DockerNetworkID = id
+	e.dockerNetworkID = id
 	e.unlock()
 }
 
@@ -1135,7 +1135,7 @@ func (e *Endpoint) GetDockerNetworkID() string {
 	e.unconditionalRLock()
 	defer e.runlock()
 
-	return e.DockerNetworkID
+	return e.dockerNetworkID
 }
 
 // setDatapathMapIDAndPinMap modifies the endpoint's datapath map ID

--- a/pkg/endpoint/log.go
+++ b/pkg/endpoint/log.go
@@ -34,14 +34,14 @@ const (
 	fieldRegenLevel = "regeneration-level"
 )
 
-// getLogger returns a logrus object with EndpointID, ContainerID and the Endpoint
+// getLogger returns a logrus object with EndpointID, containerID and the Endpoint
 // revision fields.
 func (e *Endpoint) getLogger() *logrus.Entry {
 	v := atomic.LoadPointer(&e.logger)
 	return (*logrus.Entry)(v)
 }
 
-// Logger returns a logrus object with EndpointID, ContainerID and the Endpoint
+// Logger returns a logrus object with EndpointID, containerID and the Endpoint
 // revision fields. The caller must specify their subsystem.
 func (e *Endpoint) Logger(subsystem string) *logrus.Entry {
 	if e == nil {
@@ -68,7 +68,7 @@ func (e *Endpoint) UpdateLogger(fields map[string]interface{}) {
 	// We need to update if
 	// - e.logger is nil (this happens on the first ever call to UpdateLogger via
 	//   Logger above). This clause has to come first to guard the others.
-	// - If any of EndpointID, ContainerID or policyRevision are different on the
+	// - If any of EndpointID, containerID or policyRevision are different on the
 	//   endpoint from the logger.
 	// - The debug option on the endpoint is true, and the logger is not debug,
 	//   or vice versa.

--- a/pkg/endpoint/manager.go
+++ b/pkg/endpoint/manager.go
@@ -85,8 +85,8 @@ func (e *Endpoint) updateReferences(mgr endpointManager) {
 
 func (e *Endpoint) generateReferences() map[id.PrefixType]string {
 	refs := make(map[id.PrefixType]string, 6)
-	if e.ContainerID != "" {
-		refs[id.ContainerIdPrefix] = e.ContainerID
+	if e.containerID != "" {
+		refs[id.ContainerIdPrefix] = e.containerID
 	}
 
 	if e.DockerEndpointID != "" {

--- a/pkg/endpoint/manager.go
+++ b/pkg/endpoint/manager.go
@@ -89,8 +89,8 @@ func (e *Endpoint) generateReferences() map[id.PrefixType]string {
 		refs[id.ContainerIdPrefix] = e.containerID
 	}
 
-	if e.DockerEndpointID != "" {
-		refs[id.DockerEndpointPrefix] = e.DockerEndpointID
+	if e.dockerEndpointID != "" {
+		refs[id.DockerEndpointPrefix] = e.dockerEndpointID
 	}
 
 	if e.IPv4.IsSet() {

--- a/pkg/endpoint/manager.go
+++ b/pkg/endpoint/manager.go
@@ -101,8 +101,8 @@ func (e *Endpoint) generateReferences() map[id.PrefixType]string {
 		refs[id.IPv6Prefix] = e.IPv6.String()
 	}
 
-	if e.ContainerName != "" {
-		refs[id.ContainerNamePrefix] = e.ContainerName
+	if e.containerName != "" {
+		refs[id.ContainerNamePrefix] = e.containerName
 	}
 
 	if podName := e.getK8sNamespaceAndPodName(); podName != "" {

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -241,7 +241,7 @@ func (e *Endpoint) toSerializedEndpoint() *serializableEndpoint {
 		ID:                    e.ID,
 		ContainerName:         e.containerName,
 		ContainerID:           e.containerID,
-		DockerNetworkID:       e.DockerNetworkID,
+		DockerNetworkID:       e.dockerNetworkID,
 		DockerEndpointID:      e.DockerEndpointID,
 		DatapathMapID:         e.datapathMapID,
 		IfName:                e.ifName,
@@ -282,7 +282,7 @@ type serializableEndpoint struct {
 	// Note: The JSON tag was kept for backward compatibility.
 	ContainerID string `json:"dockerID,omitempty"`
 
-	// DockerNetworkID is the network ID of the libnetwork network if the
+	// dockerNetworkID is the network ID of the libnetwork network if the
 	// endpoint is a docker managed container which uses libnetwork
 	DockerNetworkID string
 
@@ -369,7 +369,7 @@ func (ep *Endpoint) fromSerializedEndpoint(r *serializableEndpoint) {
 	ep.ID = r.ID
 	ep.containerName = r.ContainerName
 	ep.containerID = r.ContainerID
-	ep.DockerNetworkID = r.DockerNetworkID
+	ep.dockerNetworkID = r.DockerNetworkID
 	ep.DockerEndpointID = r.DockerEndpointID
 	ep.datapathMapID = r.DatapathMapID
 	ep.ifName = r.IfName

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -239,7 +239,7 @@ func (e *Endpoint) toSerializedEndpoint() *serializableEndpoint {
 
 	return &serializableEndpoint{
 		ID:                    e.ID,
-		ContainerName:         e.ContainerName,
+		ContainerName:         e.containerName,
 		ContainerID:           e.ContainerID,
 		DockerNetworkID:       e.DockerNetworkID,
 		DockerEndpointID:      e.DockerEndpointID,
@@ -275,7 +275,7 @@ type serializableEndpoint struct {
 	// ID of the endpoint, unique in the scope of the node
 	ID uint16
 
-	// ContainerName is the name given to the endpoint by the container runtime
+	// containerName is the name given to the endpoint by the container runtime
 	ContainerName string
 
 	// ContainerID is the container ID that docker has assigned to the endpoint
@@ -367,7 +367,7 @@ func (ep *Endpoint) MarshalJSON() ([]byte, error) {
 
 func (ep *Endpoint) fromSerializedEndpoint(r *serializableEndpoint) {
 	ep.ID = r.ID
-	ep.ContainerName = r.ContainerName
+	ep.containerName = r.ContainerName
 	ep.ContainerID = r.ContainerID
 	ep.DockerNetworkID = r.DockerNetworkID
 	ep.DockerEndpointID = r.DockerEndpointID

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -242,7 +242,7 @@ func (e *Endpoint) toSerializedEndpoint() *serializableEndpoint {
 		ContainerName:         e.containerName,
 		ContainerID:           e.containerID,
 		DockerNetworkID:       e.dockerNetworkID,
-		DockerEndpointID:      e.DockerEndpointID,
+		DockerEndpointID:      e.dockerEndpointID,
 		DatapathMapID:         e.datapathMapID,
 		IfName:                e.ifName,
 		IfIndex:               e.ifIndex,
@@ -286,7 +286,7 @@ type serializableEndpoint struct {
 	// endpoint is a docker managed container which uses libnetwork
 	DockerNetworkID string
 
-	// DockerEndpointID is the Docker network endpoint ID if managed by
+	// dockerEndpointID is the Docker network endpoint ID if managed by
 	// libnetwork
 	DockerEndpointID string
 
@@ -370,7 +370,7 @@ func (ep *Endpoint) fromSerializedEndpoint(r *serializableEndpoint) {
 	ep.containerName = r.ContainerName
 	ep.containerID = r.ContainerID
 	ep.dockerNetworkID = r.DockerNetworkID
-	ep.DockerEndpointID = r.DockerEndpointID
+	ep.dockerEndpointID = r.DockerEndpointID
 	ep.datapathMapID = r.DatapathMapID
 	ep.ifName = r.IfName
 	ep.ifIndex = r.IfIndex

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -240,7 +240,7 @@ func (e *Endpoint) toSerializedEndpoint() *serializableEndpoint {
 	return &serializableEndpoint{
 		ID:                    e.ID,
 		ContainerName:         e.containerName,
-		ContainerID:           e.ContainerID,
+		ContainerID:           e.containerID,
 		DockerNetworkID:       e.DockerNetworkID,
 		DockerEndpointID:      e.DockerEndpointID,
 		DatapathMapID:         e.datapathMapID,
@@ -278,7 +278,7 @@ type serializableEndpoint struct {
 	// containerName is the name given to the endpoint by the container runtime
 	ContainerName string
 
-	// ContainerID is the container ID that docker has assigned to the endpoint
+	// containerID is the container ID that docker has assigned to the endpoint
 	// Note: The JSON tag was kept for backward compatibility.
 	ContainerID string `json:"dockerID,omitempty"`
 
@@ -368,7 +368,7 @@ func (ep *Endpoint) MarshalJSON() ([]byte, error) {
 func (ep *Endpoint) fromSerializedEndpoint(r *serializableEndpoint) {
 	ep.ID = r.ID
 	ep.containerName = r.ContainerName
-	ep.ContainerID = r.ContainerID
+	ep.containerID = r.ContainerID
 	ep.DockerNetworkID = r.DockerNetworkID
 	ep.DockerEndpointID = r.DockerEndpointID
 	ep.datapathMapID = r.DatapathMapID

--- a/pkg/endpoint/restore_test.go
+++ b/pkg/endpoint/restore_test.go
@@ -74,7 +74,7 @@ func (ds *EndpointSuite) endpointCreator(id uint16, secID identity.NumericIdenti
 	ep := NewEndpointWithState(ds, id, StateReady)
 	// Random network ID and docker endpoint ID with 59 hex chars + 5 strID = 64 hex chars
 	ep.dockerNetworkID = "603e047d2268a57f5a5f93f7f9e1263e9207e348a06654bf64948def001" + strID
-	ep.DockerEndpointID = "93529fda8c401a071d21d6bd46fdf5499b9014dcb5a35f2e3efaa8d8002" + strID
+	ep.dockerEndpointID = "93529fda8c401a071d21d6bd46fdf5499b9014dcb5a35f2e3efaa8d8002" + strID
 	ep.ifName = "lxc" + strID
 	ep.mac = mac.MAC([]byte{0x01, 0xff, 0xf2, 0x12, b[0], b[1]})
 	ep.IPv4 = addressing.DeriveCiliumIPv4(net.IP{0xc0, 0xa8, b[0], b[1]})

--- a/pkg/endpoint/restore_test.go
+++ b/pkg/endpoint/restore_test.go
@@ -73,7 +73,7 @@ func (ds *EndpointSuite) endpointCreator(id uint16, secID identity.NumericIdenti
 
 	ep := NewEndpointWithState(ds, id, StateReady)
 	// Random network ID and docker endpoint ID with 59 hex chars + 5 strID = 64 hex chars
-	ep.DockerNetworkID = "603e047d2268a57f5a5f93f7f9e1263e9207e348a06654bf64948def001" + strID
+	ep.dockerNetworkID = "603e047d2268a57f5a5f93f7f9e1263e9207e348a06654bf64948def001" + strID
 	ep.DockerEndpointID = "93529fda8c401a071d21d6bd46fdf5499b9014dcb5a35f2e3efaa8d8002" + strID
 	ep.ifName = "lxc" + strID
 	ep.mac = mac.MAC([]byte{0x01, 0xff, 0xf2, 0x12, b[0], b[1]})

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -188,7 +188,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 		{
 			name: "endpoint by container ID",
 			preTestRun: func() {
-				ep.ContainerID = "1234"
+				ep.SetContainerID("1234")
 				ep.Expose(mgr)
 			},
 			setupArgs: func() args {
@@ -205,7 +205,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep.ContainerID = ""
+				ep.SetContainerID("")
 			},
 		},
 		{

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -211,7 +211,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 		{
 			name: "endpoint by docker endpoint ID",
 			preTestRun: func() {
-				ep.DockerEndpointID = "1234"
+				ep.SetDockerEndpointID("1234")
 				ep.Expose(mgr)
 			},
 			setupArgs: func() args {
@@ -228,7 +228,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 			},
 			postTestRun: func() {
 				mgr.WaitEndpointRemoved(ep)
-				ep.DockerEndpointID = ""
+				ep.SetDockerEndpointID("")
 			},
 		},
 		{
@@ -687,7 +687,7 @@ func (s *EndpointManagerSuite) TestUpdateReferences(c *C) {
 		ep = mgr.LookupContainerID(want.ep.GetContainerID())
 		c.Assert(ep, checker.DeepEquals, want.ep, Commentf("Test Name: %s", tt.name))
 
-		ep = mgr.lookupDockerEndpoint(want.ep.DockerEndpointID)
+		ep = mgr.lookupDockerEndpoint(want.ep.GetDockerEndpointID())
 		c.Assert(ep, checker.DeepEquals, want.ep, Commentf("Test Name: %s", tt.name))
 
 		ep = mgr.LookupIPv4(want.ep.IPv4.String())

--- a/pkg/workloads/docker.go
+++ b/pkg/workloads/docker.go
@@ -210,6 +210,7 @@ func (d *dockerClient) IsRunning(ep *endpoint.Endpoint) bool {
 
 	networkID := ep.GetDockerNetworkID()
 	containerID := ep.GetContainerID()
+	dockerEndpointID := ep.GetDockerEndpointID()
 
 	if networkID != "" {
 		nls, err := d.NetworkInspect(ctx.Background(), networkID, dTypes.NetworkInspectOptions{})
@@ -221,7 +222,7 @@ func (d *dockerClient) IsRunning(ep *endpoint.Endpoint) bool {
 			runtimeRunning = true
 			found := false
 			for _, v := range nls.Containers {
-				if v.EndpointID == ep.DockerEndpointID {
+				if v.EndpointID == dockerEndpointID {
 					found = true
 					break
 				}


### PR DESCRIPTION
The following fields are now hidden:

* Container ID
* Docker Endpoint ID
* Docker Network ID
* Container Name

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9170)
<!-- Reviewable:end -->
