### PR TITLE
k8s: Allow `_` in CNP CRD toFQDNs validation

### DIFF
--- a/examples/crds/ciliumnetworkpolicies.yaml
+++ b/examples/crds/ciliumnetworkpolicies.yaml
@@ -179,6 +179,22 @@ spec:
               items:
                 type: string
               type: array
+            toFQDNs:
+                description: "ToFQDNs is a list of rules matching fqdns that endpoint\n\t\t\t\tis
+                  allowed to communicate with"
+                items:
+                  description: FQDNRule is a rule that specifies an fully qualified
+                    domain name to which outside communication is allowed
+                  properties:
+                    matchName:
+                      description: MatchName matches fqdn name
+                      pattern: ^([-a-zA-Z0-9_]+[.]?)+$
+                      type: string
+                    matchPattern:
+                      description: MatchPattern matches fqdn by pattern
+                      pattern: ^([-a-zA-Z0-9_*]+[.]?)+$
+                      type: string
+                type: array
             toGroups:
               description: "ToGroups is a list of constraints that will\n\t\t\t\tgather
                 data from third-party providers and create a new\n\t\t\t\tderived
@@ -237,6 +253,22 @@ spec:
                       must be met in order for the PortRule to allow the traffic.
                       If omitted or empty, no layer 7 rules are enforced.
                     properties:
+                      dns:
+                        description: DNS specific rules
+                        items:
+                          description: FQDNRule is a rule that specifies an fully
+                            qualified domain name to which outside communication
+                            is allowed
+                          properties:
+                            matchName:
+                              description: MatchName matches fqdn name
+                              pattern: ^([-a-zA-Z0-9_]+[.]?)+$
+                              type: string
+                            matchPattern:
+                              description: MatchPattern matches fqdn by pattern
+                              pattern: ^([-a-zA-Z0-9_*]+[.]?)+$
+                              type: string
+                        type: array
                       http:
                         description: HTTP specific rules.
                         items:
@@ -724,6 +756,22 @@ spec:
                       must be met in order for the PortRule to allow the traffic.
                       If omitted or empty, no layer 7 rules are enforced.
                     properties:
+                      dns:
+                        description: DNS specific rules
+                        items:
+                          description: FQDNRule is a rule that specifies an fully
+                            qualified domain name to which outside communication
+                            is allowed
+                          properties:
+                            matchName:
+                              description: MatchName matches fqdn name
+                              pattern: ^([-a-zA-Z0-9_]+[.]?)+$
+                              type: string
+                            matchPattern:
+                              description: MatchPattern matches fqdn by pattern
+                              pattern: ^([-a-zA-Z0-9_*]+[.]?)+$
+                              type: string
+                        type: array
                       http:
                         description: HTTP specific rules.
                         items:
@@ -840,6 +888,21 @@ spec:
             be set. If none are specified, then no additional port level rules are
             applied.
           properties:
+            dns:
+              description: DNS specific rules
+              items:
+                description: FQDNRule is a rule that specifies an fully qualified
+                  domain name to which outside communication is allowed
+                properties:
+                  matchName:
+                    description: MatchName matches fqdn name
+                    pattern: ^([-a-zA-Z0-9_]+[.]?)+$
+                    type: string
+                  matchPattern:
+                    description: MatchPattern matches fqdn by pattern
+                    pattern: ^([-a-zA-Z0-9_*]+[.]?)+$
+                    type: string
+              type: array
             http:
               description: HTTP specific rules.
               items:
@@ -1075,6 +1138,21 @@ spec:
                 be met in order for the PortRule to allow the traffic. If omitted
                 or empty, no layer 7 rules are enforced.
               properties:
+                dns:
+                  description: DNS specific rules
+                  items:
+                    description: FQDNRule is a rule that specifies an fully qualified
+                      domain name to which outside communication is allowed
+                    properties:
+                      matchName:
+                        description: MatchName matches fqdn name
+                        pattern: ^([-a-zA-Z0-9_]+[.]?)+$
+                        type: string
+                      matchPattern:
+                        description: MatchPattern matches fqdn by pattern
+                        pattern: ^([-a-zA-Z0-9_*]+[.]?)+$
+                        type: string
+                  type: array
                 http:
                   description: HTTP specific rules.
                   items:
@@ -1398,6 +1476,22 @@ spec:
                     items:
                       type: string
                     type: array
+                  toFQDNs:
+                    description: "ToFQDNs is a list of rules matching fqdns that
+                      endpoint\n\t\t\t\tis allowed to communicate with"
+                    items:
+                      description: FQDNRule is a rule that specifies an fully qualified
+                        domain name to which outside communication is allowed
+                      properties:
+                        matchName:
+                          description: MatchName matches fqdn name
+                          pattern: ^([-a-zA-Z0-9_]+[.]?)+$
+                          type: string
+                        matchPattern:
+                          description: MatchPattern matches fqdn by pattern
+                          pattern: ^([-a-zA-Z0-9_*]+[.]?)+$
+                          type: string
+                    type: array
                   toGroups:
                     description: "ToGroups is a list of constraints that will\n\t\t\t\tgather
                       data from third-party providers and create a new\n\t\t\t\tderived
@@ -1460,6 +1554,22 @@ spec:
                             which must be met in order for the PortRule to allow the
                             traffic. If omitted or empty, no layer 7 rules are enforced.
                           properties:
+                            dns:
+                              description: DNS specific rules
+                              items:
+                                description: FQDNRule is a rule that specifies an
+                                  fully qualified domain name to which outside communication
+                                  is allowed
+                                properties:
+                                  matchName:
+                                    description: MatchName matches fqdn name
+                                    pattern: ^([-a-zA-Z0-9_]+[.]?)+$
+                                    type: string
+                                  matchPattern:
+                                    description: MatchPattern matches fqdn by pattern
+                                    pattern: ^([-a-zA-Z0-9_*]+[.]?)+$
+                                    type: string
+                              type: array
                             http:
                               description: HTTP specific rules.
                               items:
@@ -1964,6 +2074,22 @@ spec:
                             which must be met in order for the PortRule to allow the
                             traffic. If omitted or empty, no layer 7 rules are enforced.
                           properties:
+                            dns:
+                              description: DNS specific rules
+                              items:
+                                description: FQDNRule is a rule that specifies an
+                                  fully qualified domain name to which outside communication
+                                  is allowed
+                                properties:
+                                  matchName:
+                                    description: MatchName matches fqdn name
+                                    pattern: ^([-a-zA-Z0-9_]+[.]?)+$
+                                    type: string
+                                  matchPattern:
+                                    description: MatchPattern matches fqdn by pattern
+                                    pattern: ^([-a-zA-Z0-9_*]+[.]?)+$
+                                    type: string
+                              type: array
                             http:
                               description: HTTP specific rules.
                               items:
@@ -2354,6 +2480,22 @@ spec:
                     items:
                       type: string
                     type: array
+                  toFQDNs:
+                    description: "ToFQDNs is a list of rules matching fqdns that
+                      endpoint\n\t\t\t\tis allowed to communicate with"
+                    items:
+                      description: FQDNRule is a rule that specifies an fully qualified
+                        domain name to which outside communication is allowed
+                      properties:
+                        matchName:
+                          description: MatchName matches fqdn name
+                          pattern: ^([-a-zA-Z0-9_]+[.]?)+$
+                          type: string
+                        matchPattern:
+                          description: MatchPattern matches fqdn by pattern
+                          pattern: ^([-a-zA-Z0-9_*]+[.]?)+$
+                          type: string
+                    type: array
                   toGroups:
                     description: "ToGroups is a list of constraints that will\n\t\t\t\tgather
                       data from third-party providers and create a new\n\t\t\t\tderived
@@ -2417,6 +2559,22 @@ spec:
                             so exactly one of the following must be set. If none are
                             specified, then no additional port level rules are applied.
                           properties:
+                            dns:
+                              description: DNS specific rules
+                              items:
+                                description: FQDNRule is a rule that specifies an
+                                  fully qualified domain name to which outside communication
+                                  is allowed
+                                properties:
+                                  matchName:
+                                    description: MatchName matches fqdn name
+                                    pattern: ^([-a-zA-Z0-9_]+[.]?)+$
+                                    type: string
+                                  matchPattern:
+                                    description: MatchPattern matches fqdn by pattern
+                                    pattern: ^([-a-zA-Z0-9_*]+[.]?)+$
+                                    type: string
+                              type: array
                             http:
                               description: HTTP specific rules.
                               items:
@@ -2933,6 +3091,22 @@ spec:
                             so exactly one of the following must be set. If none are
                             specified, then no additional port level rules are applied.
                           properties:
+                            dns:
+                              description: DNS specific rules
+                              items:
+                                description: FQDNRule is a rule that specifies an
+                                  fully qualified domain name to which outside communication
+                                  is allowed
+                                properties:
+                                  matchName:
+                                    description: MatchName matches fqdn name
+                                    pattern: ^([-a-zA-Z0-9_]+[.]?)+$
+                                    type: string
+                                  matchPattern:
+                                    description: MatchPattern matches fqdn by pattern
+                                    pattern: ^([-a-zA-Z0-9_*]+[.]?)+$
+                                    type: string
+                              type: array
                             http:
                               description: HTTP specific rules.
                               items:
@@ -3200,6 +3374,23 @@ spec:
                       items:
                         type: string
                       type: array
+                    toFQDNs:
+                      description: "ToFQDNs is a list of rules matching fqdns that
+                        endpoint\n\t\t\t\tis allowed to communicate with"
+                      items:
+                        description: FQDNRule is a rule that specifies an fully
+                          qualified domain name to which outside communication is
+                          allowed
+                        properties:
+                          matchName:
+                            description: MatchName matches fqdn name
+                            pattern: ^([-a-zA-Z0-9_]+[.]?)+$
+                            type: string
+                          matchPattern:
+                            description: MatchPattern matches fqdn by pattern
+                            pattern: ^([-a-zA-Z0-9_*]+[.]?)+$
+                            type: string
+                      type: array
                     toGroups:
                       description: "ToGroups is a list of constraints that will\n\t\t\t\tgather
                         data from third-party providers and create a new\n\t\t\t\tderived
@@ -3264,6 +3455,23 @@ spec:
                               are specified, then no additional port level rules are
                               applied.
                             properties:
+                              dns:
+                                description: DNS specific rules
+                                items:
+                                  description: FQDNRule is a rule that specifies
+                                    an fully qualified domain name to which outside
+                                    communication is allowed
+                                  properties:
+                                    matchName:
+                                      description: MatchName matches fqdn name
+                                      pattern: ^([-a-zA-Z0-9_]+[.]?)+$
+                                      type: string
+                                    matchPattern:
+                                      description: MatchPattern matches fqdn by
+                                        pattern
+                                      pattern: ^([-a-zA-Z0-9_*]+[.]?)+$
+                                      type: string
+                                type: array
                               http:
                                 description: HTTP specific rules.
                                 items:
@@ -3788,6 +3996,23 @@ spec:
                               are specified, then no additional port level rules are
                               applied.
                             properties:
+                              dns:
+                                description: DNS specific rules
+                                items:
+                                  description: FQDNRule is a rule that specifies
+                                    an fully qualified domain name to which outside
+                                    communication is allowed
+                                  properties:
+                                    matchName:
+                                      description: MatchName matches fqdn name
+                                      pattern: ^([-a-zA-Z0-9_]+[.]?)+$
+                                      type: string
+                                    matchPattern:
+                                      description: MatchPattern matches fqdn by
+                                        pattern
+                                      pattern: ^([-a-zA-Z0-9_*]+[.]?)+$
+                                      type: string
+                                type: array
                               http:
                                 description: HTTP specific rules.
                                 items:

--- a/pkg/fqdn/matchpattern/matchpattern.go
+++ b/pkg/fqdn/matchpattern/matchpattern.go
@@ -32,7 +32,7 @@ func Validate(pattern string) (matcher *regexp.Regexp, err error) {
 
 	// error check
 	if strings.ContainsAny(pattern, "[]+{},") {
-		return nil, errors.New(`Only alphanumeric ASCII characters, the hyphen "-", "." and "*" are allowed in a matchPattern`)
+		return nil, errors.New(`Only alphanumeric ASCII characters, the hyphen "-", underscore "_", "." and "*" are allowed in a matchPattern`)
 	}
 
 	return regexp.Compile(ToRegexp(pattern))

--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -42,7 +42,7 @@ const (
 
 	// CustomResourceDefinitionSchemaVersion is semver-conformant version of CRD schema
 	// Used to determine if CRD needs to be updated in cluster
-	CustomResourceDefinitionSchemaVersion = "1.14"
+	CustomResourceDefinitionSchemaVersion = "1.15"
 
 	// CustomResourceDefinitionSchemaVersionKey is key to label which holds the CRD schema version
 	CustomResourceDefinitionSchemaVersionKey = "io.cilium.k8s.crd.schema.version"
@@ -50,9 +50,9 @@ const (
 	// CNPKindDefinition is the kind name for Cilium Network Policy
 	CNPKindDefinition = "CiliumNetworkPolicy"
 
-	fqdnNameRegex = `^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])\.?$`
+	fqdnNameRegex = `^([-a-zA-Z0-9_]+[.]?)+$`
 
-	fqdnPatternRegex = `^(([a-zA-Z0-9\*]|[a-zA-Z0-9\*][a-zA-Z0-9\-\*]*[a-zA-Z0-9\*])\.)*([A-Za-z0-9\*]|[A-Za-z0-9\*][A-Za-z0-9\-\*]*[A-Za-z0-9\*])\.?$`
+	fqdnPatternRegex = `^([-a-zA-Z0-9_*]+[.]?)+$`
 )
 
 // SchemeGroupVersion is group version used to register these objects

--- a/pkg/k8s/apis/cilium.io/v2/register_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/register_test.go
@@ -166,6 +166,9 @@ func (s *CiliumV2RegisterSuite) TestFQDNNameRegex(c *C) {
 		"cilium.io",
 		"cilium.io.",
 		"www.xn--e28h.com",
+		"_tcp.cilium.io",
+		"foo._tcp.cilium.io",
+		"_http._tcp.cilium.io",
 	}
 
 	badFqdnPatterns := []string{
@@ -178,6 +181,9 @@ func (s *CiliumV2RegisterSuite) TestFQDNNameRegex(c *C) {
 		"*.cilium.io.*",
 		"*.cilium.io.*.",
 		"*.xn--e28h.com",
+		"*._tcp.cilium.io",
+		"*._tcp.*",
+		"_http._tcp.*",
 	}
 
 	for _, f := range badFqdns {


### PR DESCRIPTION
We allowed `_` in f00f857 but did not
update the CRD validation to match. This changes the CRD validation to
match the internal matchpattern validation. The regex is quite different
because the older CRD validator enforced valid domain names but `_`
violates this. Since we aren't enforcing domain names the overall
pattern can be collapsed down.

fixes f00f857

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9179)
<!-- Reviewable:end -->
