### PR TITLE
daemon: check error from `d.init()`

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -491,6 +491,12 @@ func NewDaemon(dp datapath.Datapath, iptablesManager rulesManager) (*Daemon, *en
 
 	bootstrapStats.bpfBase.Start()
 	err = d.init()
+	bootstrapStats.bpfBase.EndError(err)
+	if err != nil {
+		log.WithError(err).Error("Error while initializing daemon")
+		return nil, restoredEndpoints, err
+	}
+
 	// We can only start monitor agent once cilium_event has been set up.
 	if option.Config.RunMonitorAgent {
 		monitorAgent, err := monitoragent.NewAgent(context.TODO(), defaults.MonitorBufferPages)
@@ -498,11 +504,6 @@ func NewDaemon(dp datapath.Datapath, iptablesManager rulesManager) (*Daemon, *en
 			return nil, nil, err
 		}
 		d.monitorAgent = monitorAgent
-	}
-	bootstrapStats.bpfBase.EndError(err)
-	if err != nil {
-		log.WithError(err).Error("Error while initializing daemon")
-		return nil, restoredEndpoints, err
 	}
 	if err := loader.RestoreTemplates(option.Config.StateDir); err != nil {
 		log.WithError(err).Error("Unable to restore previous BPF templates")


### PR DESCRIPTION
Commit a4f50323a7e0b437611d9567dfaa8f6d1a4a516b shuffled code around such that
the `err` variable from `d.init()` was not checked until after the call to
`monitoragent.NewAgent()`. While the error itself is not overwritten ( see
https://play.golang.org/p/Q-HzFMwhTAy for an example ), we still need to check
the error before starting the monitor agent, as it assumes that the base
programs were successfully installed, which we were not checking.
    
Fixes: a4f50323a7e0b437611d9567dfaa8f6d1a4a516b

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9182)
<!-- Reviewable:end -->
