### PR TITLE
daemon: move directory setup into `SetUpTest`

### DIFF
--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -77,7 +77,7 @@ type DaemonSuite struct {
 	OnClearPolicyConsumers    func(id uint16) *sync.WaitGroup
 }
 
-func TestMain(m *testing.M) {
+func setupTestConfig() {
 	option.Config.Populate()
 	option.Config.IdentityAllocationMode = option.IdentityAllocationModeKVstore
 
@@ -86,6 +86,7 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		panic("TempDir() failed.")
 	}
+
 	err = os.Mkdir(filepath.Join(tempRunDir, "globals"), 0777)
 	if err != nil {
 		panic("Mkdir failed")
@@ -110,6 +111,9 @@ func TestMain(m *testing.M) {
 	// state left on disk.
 	option.Config.EnableHostIPRestore = false
 
+}
+
+func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
@@ -118,6 +122,9 @@ type dummyEpSyncher struct{}
 func (epSync *dummyEpSyncher) RunK8sCiliumEndpointSync(e *endpoint.Endpoint) {}
 
 func (ds *DaemonSuite) SetUpTest(c *C) {
+
+	setupTestConfig()
+
 	ds.oldPolicyEnabled = policy.GetPolicyEnabled()
 	policy.SetPolicyEnabled(option.DefaultEnforcement)
 
@@ -149,9 +156,7 @@ func (ds *DaemonSuite) SetUpTest(c *C) {
 func (ds *DaemonSuite) TearDownTest(c *C) {
 	ds.d.endpointManager.RemoveAll()
 
-	if ds.d != nil {
-		os.RemoveAll(option.Config.RunDir)
-	}
+	os.RemoveAll(option.Config.RunDir)
 
 	if ds.kvstoreInit {
 		kvstore.DeletePrefix(common.OperationalPath)

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -77,11 +77,7 @@ type DaemonSuite struct {
 	OnClearPolicyConsumers    func(id uint16) *sync.WaitGroup
 }
 
-func setupTestConfig() {
-	option.Config.Populate()
-	option.Config.IdentityAllocationMode = option.IdentityAllocationModeKVstore
-
-	time.Local = time.UTC
+func setupTestDirectories() {
 	tempRunDir, err := ioutil.TempDir("", "cilium-test-run")
 	if err != nil {
 		panic("TempDir() failed.")
@@ -92,15 +88,21 @@ func setupTestConfig() {
 		panic("Mkdir failed")
 	}
 
-	option.Config.DryMode = true
-	option.Config.Opts = option.NewIntOptions(&option.DaemonMutableOptionLibrary)
 	option.Config.Device = "undefined"
 	option.Config.RunDir = tempRunDir
 	option.Config.StateDir = tempRunDir
 	option.Config.AccessLog = filepath.Join(tempRunDir, "cilium-access.log")
+}
 
+func TestMain(m *testing.M) {
+	// Set up all configuration options which are global to the entire test
+	// run.
+	option.Config.Populate()
+	option.Config.IdentityAllocationMode = option.IdentityAllocationModeKVstore
+	option.Config.DryMode = true
+	option.Config.Opts = option.NewIntOptions(&option.DaemonMutableOptionLibrary)
 	// GetConfig the default labels prefix filter
-	err = labels.ParseLabelPrefixCfg(nil, "")
+	err := labels.ParseLabelPrefixCfg(nil, "")
 	if err != nil {
 		panic("ParseLabelPrefixCfg() failed")
 	}
@@ -111,9 +113,7 @@ func setupTestConfig() {
 	// state left on disk.
 	option.Config.EnableHostIPRestore = false
 
-}
-
-func TestMain(m *testing.M) {
+	time.Local = time.UTC
 	os.Exit(m.Run())
 }
 
@@ -123,7 +123,7 @@ func (epSync *dummyEpSyncher) RunK8sCiliumEndpointSync(e *endpoint.Endpoint) {}
 
 func (ds *DaemonSuite) SetUpTest(c *C) {
 
-	setupTestConfig()
+	setupTestDirectories()
 
 	ds.oldPolicyEnabled = policy.GetPolicyEnabled()
 	policy.SetPolicyEnabled(option.DefaultEnforcement)
@@ -156,7 +156,11 @@ func (ds *DaemonSuite) SetUpTest(c *C) {
 func (ds *DaemonSuite) TearDownTest(c *C) {
 	ds.d.endpointManager.RemoveAll()
 
-	os.RemoveAll(option.Config.RunDir)
+	// It's helpful to keep the directories around if a test failed; only delete
+	// them if tests succeed.
+	if !c.Failed() {
+		os.RemoveAll(option.Config.RunDir)
+	}
 
 	if ds.kvstoreInit {
 		kvstore.DeletePrefix(common.OperationalPath)


### PR DESCRIPTION
Setting up the directories and associated configuration per-test means
that there is less global state to worry about that may leak between
tests if the configuration was set up in `SetUpMain`. Factor out this
setup into a function for better readability and move it into `SetUpTest`.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9183)
<!-- Reviewable:end -->
