### PR TITLE
daemon: create globals directory when other directories are created

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"os"
 	"runtime"
 	"sync"
 	"time"

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -205,10 +205,6 @@ func (d *Daemon) GetCompilationLock() *lock.RWMutex {
 }
 
 func (d *Daemon) init() error {
-	if err := os.Chdir(option.Config.StateDir); err != nil {
-		log.WithError(err).WithField(logfields.Path, option.Config.StateDir).Fatal("Could not change to runtime directory")
-	}
-
 	// Remove any old sockops and re-enable with _new_ programs if flag is set
 	sockops.SockmapDisable()
 	sockops.SkmsgDisable()

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -205,11 +205,6 @@ func (d *Daemon) GetCompilationLock() *lock.RWMutex {
 }
 
 func (d *Daemon) init() error {
-	globalsDir := option.Config.GetGlobalsDir()
-	if err := os.MkdirAll(globalsDir, defaults.RuntimePathRights); err != nil {
-		log.WithError(err).WithField(logfields.Path, globalsDir).Fatal("Could not create runtime directory")
-	}
-
 	if err := os.Chdir(option.Config.StateDir); err != nil {
 		log.WithError(err).WithField(logfields.Path, option.Config.StateDir).Fatal("Could not change to runtime directory")
 	}

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -832,6 +832,12 @@ func initEnv(cmd *cobra.Command) {
 	if err := os.MkdirAll(option.Config.LibDir, defaults.RuntimePathRights); err != nil {
 		scopedLog.WithError(err).Fatal("Could not create library directory")
 	}
+
+	globalsDir := option.Config.GetGlobalsDir()
+	if err := os.MkdirAll(globalsDir, defaults.RuntimePathRights); err != nil {
+		log.WithError(err).WithField(logfields.Path, globalsDir).Fatal("Could not create globals directory")
+	}
+
 	if !option.Config.KeepTemplates {
 		// We need to remove the old probes here as otherwise stale .t tests could
 		// still reside from newer Cilium versions which might break downgrade.

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -838,6 +838,10 @@ func initEnv(cmd *cobra.Command) {
 		log.WithError(err).WithField(logfields.Path, globalsDir).Fatal("Could not create globals directory")
 	}
 
+	if err := os.Chdir(option.Config.StateDir); err != nil {
+		log.WithError(err).WithField(logfields.Path, option.Config.StateDir).Fatal("Could not change to runtime directory")
+	}
+
 	if !option.Config.KeepTemplates {
 		// We need to remove the old probes here as otherwise stale .t tests could
 		// still reside from newer Cilium versions which might break downgrade.


### PR DESCRIPTION
Based on https://github.com/cilium/cilium/pull/9183

This reduces the creation of directories from being spread across different
parts of the code base.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9184)
<!-- Reviewable:end -->
