### PR TITLE
fqdn: Add configurable response delay to DNSProxy

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -148,6 +148,7 @@ cilium-agent [flags]
       --tofqdns-min-ttl int                                   The minimum time, in seconds, to use DNS data for toFQDNs policies. (default 3600 when --tofqdns-enable-poller, 604800 otherwise)
       --tofqdns-pre-cache string                              DNS cache data at this path is preloaded on agent startup
       --tofqdns-proxy-port int                                Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port.
+      --tofqdns-proxy-response-delay duration                 The miniumum time the DNS proxy holds an allowed response before sending it along. The higher this is the more time is allowed for cilium to update the datapath with the DNS information.
       --trace-payloadlen int                                  Length of payload to capture when tracing (default 128)
   -t, --tunnel string                                         Tunnel mode {vxlan, geneve, disabled} (default "vxlan" for the "veth" datapath mode)
       --version                                               Print version information

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -642,6 +642,9 @@ func init() {
 	flags.StringVar(&option.Config.FQDNRejectResponse, option.FQDNRejectResponseCode, option.FQDNProxyDenyWithRefused, fmt.Sprintf("DNS response code for rejecting DNS requests, available options are '%v'", option.FQDNRejectOptions))
 	option.BindEnv(option.FQDNRejectResponseCode)
 
+	flags.DurationVar(&option.Config.FQDNProxyResponseDelay, option.FQDNProxyResponseDelay, time.Duration(0), "The miniumum time the DNS proxy holds an allowed response before sending it along. The higher this is the more time is allowed for cilium to update the datapath with the DNS information.")
+	option.BindEnv(option.FQDNProxyResponseDelay)
+
 	flags.Int(option.ToFQDNsMaxIPsPerHost, defaults.ToFQDNsMaxIPsPerHost, "Maximum number of IPs to maintain per FQDN name for each endpoint")
 	option.BindEnv(option.ToFQDNsMaxIPsPerHost)
 

--- a/daemon/fqdn.go
+++ b/daemon/fqdn.go
@@ -233,7 +233,7 @@ func (d *Daemon) bootstrapFQDN(restoredEndpoints *endpointRestoreState, preCache
 	if err != nil {
 		return err
 	}
-	proxy.DefaultDNSProxy, err = dnsproxy.StartDNSProxy("", port, d.lookupEPByIP, d.notifyOnDNSMsg)
+	proxy.DefaultDNSProxy, err = dnsproxy.StartDNSProxy("", port, option.Config.FQDNProxyResponseDelay, d.lookupEPByIP, d.notifyOnDNSMsg)
 	if err == nil {
 		// Increase the ProxyPort reference count so that it will never get released.
 		err = d.l7Proxy.SetProxyPort(listenerName, proxy.DefaultDNSProxy.BindPort)

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -139,7 +139,7 @@ func (s *DNSProxyTestSuite) SetUpSuite(c *C) {
 	s.dnsServer = setupServer(c)
 	c.Assert(s.dnsServer, Not(IsNil), Commentf("unable to setup DNS server"))
 
-	proxy, err := StartDNSProxy("", 0,
+	proxy, err := StartDNSProxy("", 0, time.Duration(0),
 		func(ip net.IP) (*endpoint.Endpoint, error) {
 			ep := endpoint.NewEndpointWithState(s, 123, endpoint.StateReady)
 			return ep, nil

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -462,6 +462,9 @@ const (
 	// the default for denied DNS requests.
 	FQDNProxyDenyWithRefused = "refused"
 
+	//FQDNProxyResponseDelay is the minimum time the proxy holds back a response
+	FQDNProxyResponseDelay = "tofqdns-proxy-response-delay"
+
 	// PreAllocateMapsName is the name of the option PreAllocateMaps
 	PreAllocateMapsName = "preallocate-bpf-maps"
 
@@ -1031,6 +1034,11 @@ type DaemonConfig struct {
 
 	// FQDNRejectResponse is the dns-proxy response for invalid dns-proxy request
 	FQDNRejectResponse string
+
+	// FQDNProxyResponseDelay is the minimum time the proxy holds responses
+	// before sending them along. This time is useful to allow cilium to populate
+	// the datapath.
+	FQDNProxyResponseDelay time.Duration
 
 	// Path to a file with DNS cache data to preload on startup
 	ToFQDNsPreCache string


### PR DESCRIPTION
We've seen instances where the propagation of IPs from DNS responses
into the datapath is slower than the subsequent connection. This can
cause races with the CT table. Unfortunately, we have also seen cases
where delaying the response until after the data has been plumbed
results in the opposite problem: the DNS response is considered lost and
the app retries, causing repeat failures and more load.
While not ideal in the least, allowing for a tunable response delay
allows us to tweak this behaviour to some extent, minimizing the
disruption of either extreme.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9185)
<!-- Reviewable:end -->
