### PR TITLE
loader: remove hash from compileQueue if build fails

### DIFF
--- a/pkg/datapath/loader/cache.go
+++ b/pkg/datapath/loader/cache.go
@@ -268,6 +268,9 @@ func (o *objectCache) fetchOrCompile(ctx context.Context, cfg datapath.EndpointC
 			err := o.build(ctx, templateCfg, hash)
 			if err != nil {
 				scopedLog.WithError(err).Error("BPF template object creation failed")
+				o.Lock()
+				delete(o.compileQueue, hash)
+				o.Unlock()
 			}
 			return err
 		}, serializer.NoRetry)


### PR DESCRIPTION
Otherwise, the loader erroneously thinks that the template has been built,
while it actually needs to be rebuilt again.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9186)
<!-- Reviewable:end -->
