### PR TITLE
CI Fixups to target other runtimes

### DIFF
--- a/test/config/config.go
+++ b/test/config/config.go
@@ -21,8 +21,13 @@ import (
 
 // CiliumTestConfigType holds all of the configurable elements of the testsuite
 type CiliumTestConfigType struct {
-	Reprovision         bool
-	HoldEnvironment     bool
+	Reprovision bool
+	// HoldEnvironment leaves the test infrastructure in place on failure
+	HoldEnvironment bool
+	// PassCLIEnvironment passes through the environment invoking the gingko
+	// tests. When false all subcommands are executed with an empty environment,
+	// including PATH.
+	PassCLIEnvironment  bool
 	SSHConfig           string
 	ShowCommands        bool
 	TestScope           string
@@ -44,6 +49,8 @@ func (c *CiliumTestConfigType) ParseFlags() {
 		"Provision Vagrant boxes and Cilium before running test")
 	flag.BoolVar(&c.HoldEnvironment, "cilium.holdEnvironment", false,
 		"On failure, hold the environment in its current state")
+	flag.BoolVar(&c.PassCLIEnvironment, "cilium.passCLIEnvironment", false,
+		"Pass the environment invoking ginkgo, including PATH, to subcommands")
 	flag.BoolVar(&c.SkipLogGathering, "cilium.skipLogs", false,
 		"skip gathering logs if a test fails")
 	flag.StringVar(&c.SSHConfig, "cilium.SSHConfig", "",

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -138,7 +138,16 @@ func CreateKubectl(vmName string, log *logrus.Entry) (k *Kubectl) {
 		}
 		k.setBasePath()
 	} else {
-		exec := CreateLocalExecutor([]string{"KUBECONFIG=" + config.CiliumTestConfig.Kubeconfig})
+		// Prepare environment variables
+		// NOTE: order matters and we want the KUBECONFIG from config to win
+		var environ []string
+		if config.CiliumTestConfig.PassCLIEnvironment {
+			environ = append(environ, os.Environ()...)
+		}
+		environ = append(environ, "KUBECONFIG="+config.CiliumTestConfig.Kubeconfig)
+
+		// Create the executor
+		exec := CreateLocalExecutor(environ)
 		exec.logger = log
 
 		k = &Kubectl{

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -68,6 +68,12 @@ const (
 )
 
 var (
+	// defaultHelmOptions are passed to helm in ciliumInstallHelm, unless
+	// overridden by options passed in at invocation. In those cases, the test
+	// has a specific need to override the option.
+	// These defaults are made to match some environment variables in init(),
+	// below. These overrides represent a desire to set the default for all
+	// tests, instead of test-specific variations.
 	defaultHelmOptions = map[string]string{
 		"global.registry":               "k8s1:5000/cilium",
 		"agent.image":                   "cilium-dev",
@@ -90,6 +96,20 @@ var (
 		"global.tunnel":          "disabled",
 	}
 )
+
+func init() {
+	// Copy over envronment variables that are passed in.
+	for envVar, helmVar := range map[string]string{
+		"CILIUM_REGISTRY":       "global.registry",
+		"CILIUM_TAG":            "global.tag",
+		"CILIUM_IMAGE":          "agent.image",
+		"CILIUM_OPERATOR_IMAGE": "operator.image",
+	} {
+		if v := os.Getenv(envVar); v != "" {
+			defaultHelmOptions[helmVar] = v
+		}
+	}
+}
 
 // GetCurrentK8SEnv returns the value of K8S_VERSION from the OS environment.
 func GetCurrentK8SEnv() string { return os.Getenv("K8S_VERSION") }

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -372,6 +372,15 @@ func DNSDeployment(base string) string {
 	case "1.7", "1.8", "1.9", "1.10":
 		DNSEngine = "kubedns"
 	}
+
+	if integration := GetCurrentIntegration(); integration != "" {
+		fullPath := filepath.Join("provision", "manifest", k8sVersion, integration, DNSEngine+"_deployment.yaml")
+		_, err := os.Stat(fullPath)
+		if err == nil {
+			return filepath.Join(base, fullPath)
+		}
+	}
+
 	fullPath := filepath.Join("provision", "manifest", k8sVersion, DNSEngine+"_deployment.yaml")
 	_, err := os.Stat(fullPath)
 	if err == nil {

--- a/test/provision/manifest/1.14/coredns_deployment.yaml
+++ b/test/provision/manifest/1.14/coredns_deployment.yaml
@@ -67,7 +67,7 @@ data:
         health
         kubernetes cluster.local in-addr.arpa ip6.arpa {
             pods insecure
-            ttl 0
+            ttl 5
             upstream
             fallthrough in-addr.arpa ip6.arpa
         }

--- a/test/provision/manifest/1.15/coredns_deployment.yaml
+++ b/test/provision/manifest/1.15/coredns_deployment.yaml
@@ -69,7 +69,7 @@ data:
         health
         kubernetes cluster.local in-addr.arpa ip6.arpa {
             pods insecure
-            ttl 0
+            ttl 5
             upstream
             fallthrough in-addr.arpa ip6.arpa
         }

--- a/test/provision/manifest/1.15/eks/coredns_deployment.yaml
+++ b/test/provision/manifest/1.15/eks/coredns_deployment.yaml
@@ -1,0 +1,206 @@
+# File source
+# https://raw.githubusercontent.com/kubernetes/kubernetes/release-1.15/cluster/addons/dns/coredns/coredns.yaml.base
+# __MACHINE_GENERATED_WARNING__
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: coredns
+  namespace: kube-system
+  labels:
+      kubernetes.io/cluster-service: "true"
+      addonmanager.kubernetes.io/mode: Reconcile
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+    addonmanager.kubernetes.io/mode: Reconcile
+  name: system:coredns
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - services
+  - pods
+  - namespaces
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+    addonmanager.kubernetes.io/mode: EnsureExists
+  name: system:coredns
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:coredns
+subjects:
+- kind: ServiceAccount
+  name: coredns
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns
+  namespace: kube-system
+  labels:
+      addonmanager.kubernetes.io/mode: EnsureExists
+data:
+  Corefile: |
+    .:53 {
+        log
+        errors
+        health
+        kubernetes cluster.local in-addr.arpa ip6.arpa {
+            pods insecure
+            ttl 5
+            upstream
+            fallthrough in-addr.arpa ip6.arpa
+        }
+        proxy cilium.test 10.100.0.100:53 {
+            fail_timeout 10s
+            max_fails 0
+        }
+        proxy . /etc/resolv.conf {
+            fail_timeout 10s
+            max_fails 0
+        }
+        prometheus :9153
+        loop
+        reload
+        loadbalance
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coredns
+  namespace: kube-system
+  labels:
+    k8s-app: kube-dns
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+    kubernetes.io/name: "CoreDNS"
+spec:
+  # replicas: not specified here:
+  # 1. In order to make Addon Manager do not reconcile this replicas parameter.
+  # 2. Default is 1.
+  # 3. Will be tuned in real time if DNS horizontal auto-scaling is turned on.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      k8s-app: kube-dns
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-dns
+      annotations:
+        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
+    spec:
+      priorityClassName: system-cluster-critical
+      serviceAccountName: coredns
+      tolerations:
+        - key: "CriticalAddonsOnly"
+          operator: "Exists"
+      containers:
+      - name: coredns
+        image: k8s.gcr.io/coredns:1.3.1
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            memory: 170Mi
+          requests:
+            cpu: 100m
+            memory: 70Mi
+        args: [ "-conf", "/etc/coredns/Corefile" ]
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/coredns
+          readOnly: true
+        ports:
+        - containerPort: 53
+          name: dns
+          protocol: UDP
+        - containerPort: 53
+          name: dns-tcp
+          protocol: TCP
+        - containerPort: 9153
+          name: metrics
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 5
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+            drop:
+            - all
+          readOnlyRootFilesystem: true
+      dnsPolicy: Default
+      volumes:
+        - name: config-volume
+          configMap:
+            name: coredns
+            items:
+            - key: Corefile
+              path: Corefile
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-dns
+  namespace: kube-system
+  annotations:
+    prometheus.io/port: "9153"
+    prometheus.io/scrape: "true"
+  labels:
+    k8s-app: kube-dns
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+    kubernetes.io/name: "CoreDNS"
+spec:
+  selector:
+    k8s-app: kube-dns
+  clusterIP: 10.100.0.10
+  ports:
+  - name: dns
+    port: 53
+    protocol: UDP
+  - name: dns-tcp
+    port: 53
+    protocol: TCP
+  - name: metrics
+    port: 9153
+    protocol: TCP

--- a/test/provision/manifest/1.16/eks/coredns_deployment.yaml
+++ b/test/provision/manifest/1.16/eks/coredns_deployment.yaml
@@ -1,0 +1,202 @@
+# File source
+# https://raw.githubusercontent.com/kubernetes/kubernetes/release-1.16/cluster/addons/dns/coredns/coredns.yaml.base
+# __MACHINE_GENERATED_WARNING__
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: coredns
+  namespace: kube-system
+  labels:
+      kubernetes.io/cluster-service: "true"
+      addonmanager.kubernetes.io/mode: Reconcile
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+    addonmanager.kubernetes.io/mode: Reconcile
+  name: system:coredns
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - services
+  - pods
+  - namespaces
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+    addonmanager.kubernetes.io/mode: EnsureExists
+  name: system:coredns
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:coredns
+subjects:
+- kind: ServiceAccount
+  name: coredns
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns
+  namespace: kube-system
+  labels:
+      addonmanager.kubernetes.io/mode: EnsureExists
+data:
+  Corefile: |
+    .:53 {
+        log
+        errors
+        health
+        ready
+        kubernetes cluster.local in-addr.arpa ip6.arpa {
+            pods insecure
+            ttl 0
+            upstream
+            fallthrough in-addr.arpa ip6.arpa
+        }
+        forward cilium.test 10.100.0.100:53 {
+            max_fails 0
+        }
+        prometheus :9153
+        loop
+        reload
+        loadbalance
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coredns
+  namespace: kube-system
+  labels:
+    k8s-app: kube-dns
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+    kubernetes.io/name: "CoreDNS"
+spec:
+  # replicas: not specified here:
+  # 1. In order to make Addon Manager do not reconcile this replicas parameter.
+  # 2. Default is 1.
+  # 3. Will be tuned in real time if DNS horizontal auto-scaling is turned on.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      k8s-app: kube-dns
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-dns
+      annotations:
+        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
+    spec:
+      priorityClassName: system-cluster-critical
+      serviceAccountName: coredns
+      tolerations:
+        - key: "CriticalAddonsOnly"
+          operator: "Exists"
+      containers:
+      - name: coredns
+        image: k8s.gcr.io/coredns:1.6.2
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            memory: 170Mi
+          requests:
+            cpu: 100m
+            memory: 70Mi
+        args: [ "-conf", "/etc/coredns/Corefile" ]
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/coredns
+          readOnly: true
+        ports:
+        - containerPort: 53
+          name: dns
+          protocol: UDP
+        - containerPort: 53
+          name: dns-tcp
+          protocol: TCP
+        - containerPort: 9153
+          name: metrics
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 5
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8181
+            scheme: HTTP
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+            drop:
+            - all
+          readOnlyRootFilesystem: true
+      dnsPolicy: Default
+      volumes:
+        - name: config-volume
+          configMap:
+            name: coredns
+            items:
+            - key: Corefile
+              path: Corefile
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-dns
+  namespace: kube-system
+  annotations:
+    prometheus.io/port: "9153"
+    prometheus.io/scrape: "true"
+  labels:
+    k8s-app: kube-dns
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+    kubernetes.io/name: "CoreDNS"
+spec:
+  selector:
+    k8s-app: kube-dns
+  clusterIP: 10.100.0.10
+  ports:
+  - name: dns
+    port: 53
+    protocol: UDP
+  - name: dns-tcp
+    port: 53
+    protocol: TCP
+  - name: metrics
+    port: 9153
+    protocol: TCP

--- a/test/provision/manifest/coredns_deployment.yaml
+++ b/test/provision/manifest/coredns_deployment.yaml
@@ -94,6 +94,7 @@ data:
         health
         kubernetes cluster.local in-addr.arpa ip6.arpa {
            pods insecure
+           ttl 5
            upstream
            fallthrough in-addr.arpa ip6.arpa
         }


### PR DESCRIPTION
This PR allows running the CI against non-jenkins clusters. It's still WIP but everyone should try it out and let me know how it doesn't work.

ginkgo now honours environment variables to set the image sources to test with, and has an option to pass the environment to subprocesses.

**Relevant config**
`CILIUM_IMAGE` & `CILIUM_OPERATOR_IMAGE` set the images to use. I recommend using a fully qualified image name with tag here.
Internally, there are also `CILIUM_REGISTRY` and `CILIUM_TAG` variables but our helm templating treats any `CILIUM_IMAGE` with a `/` in it as a fully image path (which is always the case since it would be `cilium/cilium`).

`-cilium.provision=false` stops ginkgo from provisioning the CI VMs.

`-cilium.kubeconfig=/my/kube/config` will use this kubeconfig. It will honour the selected cluster. It also supports authentication schemes such as aws-authenticator that may be needed

`-cilium.passCLIEnvironment=true` Passes along the environment when invoking kubectl. This is needed when kubectl invokes other programs to do things, like authentication. This is the case with eks.

**Example invocation**
ginkgo expects to be run from the cilium/test directory
`CILIUM_IMAGE="docker.io/cilium/cilium:latest" CILIUM_OPERATOR_IMAGE="docker.io/cilium/operator:latest" K8S_VERSION=1.15  ginkgo -v --focus="K8sDemosTest*" -noColor -- -cilium.provision=false -cilium.kubeconfig=/Users/ray/.kube/config -cilium.passCLIEnvironment=true`


**Specific targets**
Minikube
1- Start minikube as in https://cilium.readthedocs.io/en/latest/gettingstarted/minikube/. You can skip installing cilium and the connectivity check.

2- [temp until we find a solution] Edit `test/helpers/kubectl.go` with
```
diff --git a/test/helpers/kubectl.go b/test/helpers/kubectl.go
index e18f56d35..30bcba1af 100644
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -86,3 +86,3 @@ var (
                "global.debug.enabled":          "true",
-               "global.k8s.requireIPv4PodCIDR": "true",
+               "global.k8s.requireIPv4PodCIDR": "false",
                "global.pprof.enabled":          "true",
```

3- in cilium/test `CILIUM_IMAGE="docker.io/cilium/cilium:latest" CILIUM_OPERATOR_IMAGE="docker.io/cilium/operator:latest" K8S_VERSION=1.15  ginkgo -v --focus="K8sDemosTest*" -noColor -- -cilium.provision=false -cilium.kubeconfig=/my/kubeconfig -cilium.passCLIEnvironment=true`

EKS
1- Follow our getting started guide at https://cilium.readthedocs.io/en/latest/gettingstarted/k8s-install-eks/ to get your tooling working and scale a cluster up. I've successfully scaled the cluster before installing cilium, which the tests will install anyway. Skip the connectivity check.

2- [temp until I figure out something] Change the coredns manifest with the below diff. Adjust the 1.15 to your k8s version.
```
diff --git a/test/provision/manifest/1.15/coredns_deployment.yaml b/test/provision/manifest/1.15/coredns_deployment.yaml
index 4b09572e4..3c69e566a 100644
--- a/test/provision/manifest/1.15/coredns_deployment.yaml
+++ b/test/provision/manifest/1.15/coredns_deployment.yaml
@@ -73,7 +73,7 @@ data:
             upstream
             fallthrough in-addr.arpa ip6.arpa
         }
-        proxy cilium.test 10.96.0.100:53 {
+        proxy cilium.test 10.100.0.100:53 {
             fail_timeout 10s
             max_fails 0
         }
@@ -193,7 +193,7 @@ metadata:
 spec:
   selector:
     k8s-app: kube-dns
-  clusterIP: 10.96.0.10
+  clusterIP: 10.100.0.10
   ports:
   - name: dns
     port: 53
```
The eks clusters come up with a different range and coredns should, ideally just use that.

3- in cilium/test `CNI_INTEGRATION=eks CILIUM_IMAGE="docker.io/cilium/cilium:latest" CILIUM_OPERATOR_IMAGE="docker.io/cilium/operator:latest" K8S_VERSION=1.15  ginkgo -v --focus="K8sDemosTest*" -noColor -- -cilium.provision=false -cilium.kubeconfig=/my/kubeconfig -cilium.passCLIEnvironment=true`


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9189)
<!-- Reviewable:end -->
