### PR TITLE
endpoint: reduce exported functionality

### DIFF
--- a/daemon/policy_test.go
+++ b/daemon/policy_test.go
@@ -563,7 +563,8 @@ func (d *dummyManager) RemoveReferences(map[id.PrefixType]string) {
 func (d *dummyManager) RemoveID(uint16) {
 }
 
-func (d *dummyManager) ReleaseID(*endpoint.Endpoint) {
+func (d *dummyManager) ReleaseID(*endpoint.Endpoint) error {
+	return nil
 }
 
 func (ds *DaemonSuite) TestIncrementalPolicy(c *C) {

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -472,7 +472,7 @@ func (e *Endpoint) ProcessChangeRequest(newEp *Endpoint, validPatchTransitionSta
 	// backwards compatibility.
 	if newEp.state != "" &&
 		validPatchTransitionState &&
-		e.GetStateLocked() != StateWaitingForIdentity {
+		e.getState() != StateWaitingForIdentity {
 		// Will not change state if the current state does not allow the transition.
 		if e.setState(StateWaitingForIdentity, "Update endpoint from API PATCH") {
 			changed = true
@@ -504,7 +504,7 @@ func (e *Endpoint) ProcessChangeRequest(newEp *Endpoint, validPatchTransitionSta
 
 	// If desired state is waiting-for-identity but identity is already
 	// known, bump it to ready state immediately to force re-generation
-	if e.GetStateLocked() == StateWaitingForIdentity && e.SecurityIdentity != nil {
+	if e.getState() == StateWaitingForIdentity && e.SecurityIdentity != nil {
 		e.setState(StateReady, "Preparing to force endpoint regeneration because identity is known while handling API PATCH")
 		changed = true
 	}
@@ -517,11 +517,11 @@ func (e *Endpoint) ProcessChangeRequest(newEp *Endpoint, validPatchTransitionSta
 		e.forcePolicyComputation()
 
 		// Transition to waiting-to-regenerate if ready.
-		if e.GetStateLocked() == StateReady {
+		if e.getState() == StateReady {
 			e.setState(StateWaitingToRegenerate, "Forcing endpoint regeneration because identity is known while handling API PATCH")
 		}
 
-		switch e.GetStateLocked() {
+		switch e.getState() {
 		case StateWaitingToRegenerate:
 			reason = "Waiting on endpoint regeneration because identity is known while handling API PATCH"
 		case StateWaitingForIdentity:

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -413,9 +413,9 @@ func (e *Endpoint) GetID16() uint16 {
 	return e.ID
 }
 
-// GetK8sPodLabels returns all labels that exist in the endpoint and were
+// getK8sPodLabels returns all labels that exist in the endpoint and were
 // derived from k8s pod.
-func (e *Endpoint) GetK8sPodLabels() pkgLabels.Labels {
+func (e *Endpoint) getK8sPodLabels() pkgLabels.Labels {
 	e.unconditionalRLock()
 	defer e.runlock()
 	allLabels := e.OpLabels.AllLabels()

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -305,9 +305,9 @@ func (e *Endpoint) closeBPFProgramChannel() {
 	}
 }
 
-// HasBPFProgram returns whether a BPF program has been generated for this
+// bpfProgramInstalled returns whether a BPF program has been generated for this
 // endpoint.
-func (e *Endpoint) HasBPFProgram() bool {
+func (e *Endpoint) bpfProgramInstalled() bool {
 	select {
 	case <-e.hasBPFProgram:
 		return true
@@ -2114,7 +2114,7 @@ func (e *Endpoint) waitForFirstRegeneration(ctx context.Context) error {
 			}
 			hasSidecarProxy := e.HasSidecarProxy()
 			e.runlock()
-			if hasSidecarProxy && e.HasBPFProgram() {
+			if hasSidecarProxy && e.bpfProgramInstalled() {
 				// If the endpoint is determined to have a sidecar proxy,
 				// return immediately to let the sidecar container start,
 				// in case it is required to enforce L7 rules.

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1150,9 +1150,9 @@ func (e *Endpoint) setDatapathMapIDAndPinMap(id int) error {
 	return e.pinDatapathMap()
 }
 
-// GetState returns the endpoint's state
+// getState returns the endpoint's state
 // endpoint.Mutex may only be.rlockAlive()ed
-func (e *Endpoint) GetStateLocked() string {
+func (e *Endpoint) getState() string {
 	return e.state
 }
 
@@ -1161,7 +1161,7 @@ func (e *Endpoint) GetStateLocked() string {
 func (e *Endpoint) GetState() string {
 	e.unconditionalRLock()
 	defer e.runlock()
-	return e.GetStateLocked()
+	return e.getState()
 }
 
 // SetState modifies the endpoint's state. Returns true only if endpoints state
@@ -1592,7 +1592,7 @@ func (e *Endpoint) identityLabelsChanged(ctx context.Context, myChangeRev int) e
 
 	if e.SecurityIdentity != nil && e.SecurityIdentity.Labels.Equals(newLabels) {
 		// Sets endpoint state to ready if was waiting for identity
-		if e.GetStateLocked() == StateWaitingForIdentity {
+		if e.getState() == StateWaitingForIdentity {
 			e.setState(StateReady, "Set identity for this endpoint")
 		}
 		e.runlock()
@@ -2038,7 +2038,7 @@ func (e *Endpoint) RegenerateAfterCreation(ctx context.Context, endpointStartFun
 		return fmt.Errorf("endpoint was deleted while processing the request")
 	}
 
-	build := e.GetStateLocked() == StateReady
+	build := e.getState() == StateReady
 	if build {
 		e.setState(StateWaitingToRegenerate, "Identity is known at endpoint creation time")
 	}

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -720,5 +720,6 @@ func (d *dummyManager) RemoveReferences(map[id.PrefixType]string) {
 func (d *dummyManager) RemoveID(uint16) {
 }
 
-func (d *dummyManager) ReleaseID(*Endpoint) {
+func (d *dummyManager) ReleaseID(*Endpoint) error {
+	return nil
 }

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -557,8 +557,8 @@ func TestEndpoint_GetK8sPodLabels(t *testing.T) {
 				mutex:    lock.RWMutex{},
 				OpLabels: tt.fields.OpLabels,
 			}
-			if got := e.GetK8sPodLabels(); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Endpoint.GetK8sPodLabels() = %v, want %v", got, tt.want)
+			if got := e.getK8sPodLabels(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Endpoint.getK8sPodLabels() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/endpoint/manager.go
+++ b/pkg/endpoint/manager.go
@@ -144,7 +144,7 @@ func (e *Endpoint) Unexpose(mgr endpointManager) <-chan struct{} {
 			// While endpoint is disconnecting, ID is already available in ID cache.
 			//
 			// Avoid irritating warning messages.
-			state := ep.GetStateLocked()
+			state := ep.getState()
 			if state != StateRestoring && state != StateDisconnecting {
 				log.WithError(err).WithField("state", state).Warning("Unable to release endpoint ID")
 			}

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -259,7 +259,7 @@ func (e *Endpoint) regenerate(context *regenerationContext) (retErr error) {
 	// the state remains unchanged
 	//
 	// GH-5350: Remove this special case to require checking for StateWaitingForIdentity
-	if e.GetStateLocked() != StateWaitingForIdentity &&
+	if e.getState() != StateWaitingForIdentity &&
 		!e.BuilderSetStateLocked(StateRegenerating, "Regenerating endpoint: "+context.Reason) {
 		e.getLogger().WithField(logfields.EndpointState, e.state).Debug("Skipping build due to invalid state")
 		e.unlock()
@@ -419,7 +419,7 @@ func (e *Endpoint) RegenerateIfAlive(regenMetadata *regeneration.ExternalRegener
 		e.LogStatus(Policy, Failure, "Error while handling policy updates for endpoint: "+err.Error())
 	} else {
 		var regen bool
-		state := e.GetStateLocked()
+		state := e.getState()
 		switch state {
 		case StateRestoring, StateWaitingToRegenerate:
 			e.setState(state, fmt.Sprintf("Skipped duplicate endpoint regeneration trigger due to %s", regenMetadata.Reason))
@@ -612,7 +612,7 @@ func (e *Endpoint) SetIdentity(identity *identityPkg.Identity, newEndpoint bool)
 	e.selectorPolicy = nil
 
 	// Sets endpoint state to ready if was waiting for identity
-	if e.GetStateLocked() == StateWaitingForIdentity {
+	if e.getState() == StateWaitingForIdentity {
 		e.setState(StateReady, "Set identity for this endpoint")
 	}
 

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -222,20 +222,8 @@ func (mgr *EndpointManager) LookupPodName(name string) *endpoint.Endpoint {
 
 // ReleaseID releases the ID of the specified endpoint from the EndpointManager.
 // Returns an error if the ID cannot be released.
-func (mgr *EndpointManager) ReleaseID(ep *endpoint.Endpoint) {
-	if err := endpointid.Release(ep.ID); err != nil {
-		// While restoring, endpoint IDs may not have been reused yet.
-		// Failure to release means that the endpoint ID was not reused
-		// yet.
-		//
-		// While endpoint is disconnecting, ID is already available in ID cache.
-		//
-		// Avoid irritating warning messages.
-		state := ep.GetStateLocked()
-		if state != endpoint.StateRestoring && state != endpoint.StateDisconnecting {
-			log.WithError(err).WithField("state", state).Warning("Unable to release endpoint ID")
-		}
-	}
+func (mgr *EndpointManager) ReleaseID(ep *endpoint.Endpoint) error {
+	return endpointid.Release(ep.ID)
 }
 
 // WaitEndpointRemoved waits until all operations associated with Remove of


### PR DESCRIPTION
* Do not export the check for if an endpoint has a BPF program exported
* Refactor how we release endpoint IDs in relation to the endpoint manager so that the endpointmanager does not have to be aware of endpoint state. Hide the `GetStateLocked` function as a result of this.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9191)
<!-- Reviewable:end -->
