### PR TITLE
Revert "Revert "Remove componentstatus from rbac""

### DIFF
--- a/install/kubernetes/cilium/charts/agent/templates/clusterrole.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/clusterrole.yaml
@@ -18,7 +18,6 @@ rules:
   - services
   - nodes
   - endpoints
-  - componentstatuses
   verbs:
   - get
   - list

--- a/install/kubernetes/cilium/charts/operator/templates/clusterrole.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/clusterrole.yaml
@@ -6,13 +6,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  # to get k8s version and status
-  - componentstatuses
-  verbs:
-  - get
-- apiGroups:
-  - ""
-  resources:
   # to automatically delete [core|kube]dns pods so that are starting to being
   # managed by Cilium
   - pods

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -170,7 +170,6 @@ rules:
   - services
   - nodes
   - endpoints
-  - componentstatuses
   verbs:
   - get
   - list
@@ -232,13 +231,6 @@ kind: ClusterRole
 metadata:
   name: cilium-operator
 rules:
-- apiGroups:
-  - ""
-  resources:
-  # to get k8s version and status
-  - componentstatuses
-  verbs:
-  - get
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
This reverts commit cb6c6808792a78c4bb3911cecb5795d61cad7853.

The v1.6.1 was released, so it's safe to remove the RBAC for `componentstatuses`. See https://github.com/cilium/cilium/pull/9038 for more context.

**NOTE**: Please merge it only after https://github.com/cilium/cilium/pull/9195 has been backported to the `v1.6` branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9196)
<!-- Reviewable:end -->
