### PR TITLE
Allow to specify a kube-apiserver HTTPS URL via "--k8s-api-server"

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -100,7 +100,7 @@ cilium-agent [flags]
       --ipv6-range string                                     Per-node IPv6 endpoint prefix, must be /96, e.g. fd02:1:1::/96 (default "auto")
       --ipv6-service-range string                             Kubernetes IPv6 services CIDR if not inside cluster prefix (default "auto")
       --ipvlan-master-device string                           Device facing external network acting as ipvlan master (default "undefined")
-      --k8s-api-server string                                 Kubernetes api address server (for https use --k8s-kubeconfig-path instead)
+      --k8s-api-server string                                 Kubernetes API server URL
       --k8s-kubeconfig-path string                            Absolute path of the kubernetes kubeconfig file
       --k8s-require-ipv4-pod-cidr                             Require IPv4 PodCIDR to be specified in node resource
       --k8s-require-ipv6-pod-cidr                             Require IPv6 PodCIDR to be specified in node resource

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -32,7 +32,7 @@ cilium-operator [flags]
       --identity-gc-interval duration          GC interval for security identities (default 15m0s)
       --identity-heartbeat-timeout duration    Timeout after which identity expires on lack of heartbeat (default 15m0s)
       --ipam string                            Backend to use for IPAM
-      --k8s-api-server string                  Kubernetes api address server (for https use --k8s-kubeconfig-path instead)
+      --k8s-api-server string                  Kubernetes API server URL
       --k8s-client-burst int                   Burst value allowed for the K8s client
       --k8s-client-qps float32                 Queries per second limit for the K8s client
       --k8s-kubeconfig-path string             Absolute path of the kubernetes kubeconfig file

--- a/daemon/config.go
+++ b/daemon/config.go
@@ -119,7 +119,7 @@ func (h *getConfig) Handle(params GetConfigParams) middleware.Responder {
 	status := &models.DaemonConfigurationStatus{
 		Addressing:       node.GetNodeAddressing(),
 		K8sConfiguration: k8s.GetKubeconfigPath(),
-		K8sEndpoint:      k8s.GetAPIServer(),
+		K8sEndpoint:      k8s.GetAPIServerURL(),
 		NodeMonitor:      &monitorState,
 		KvstoreConfiguration: &models.KVstoreConfiguration{
 			Type:    option.Config.KVStore,

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -402,7 +402,7 @@ func init() {
 	flags.Bool(option.K8sEventHandover, defaults.K8sEventHandover, "Enable k8s event handover to kvstore for improved scalability")
 	option.BindEnv(option.K8sEventHandover)
 
-	flags.String(option.K8sAPIServer, "", "Kubernetes api address server (for https use --k8s-kubeconfig-path instead)")
+	flags.String(option.K8sAPIServer, "", "Kubernetes API server URL")
 	option.BindEnv(option.K8sAPIServer)
 
 	flags.String(option.K8sKubeConfigPath, "", "Absolute path of the kubernetes kubeconfig file")

--- a/operator/main.go
+++ b/operator/main.go
@@ -106,7 +106,7 @@ func init() {
 	flags.String(option.ClusterName, defaults.ClusterName, "Name of the cluster")
 	option.BindEnv(option.ClusterName)
 	flags.BoolP("debug", "D", false, "Enable debugging mode")
-	flags.StringVar(&k8sAPIServer, "k8s-api-server", "", "Kubernetes api address server (for https use --k8s-kubeconfig-path instead)")
+	flags.StringVar(&k8sAPIServer, "k8s-api-server", "", "Kubernetes API server URL")
 	flags.StringVar(&k8sKubeConfigPath, "k8s-kubeconfig-path", "", "Absolute path of the kubernetes kubeconfig file")
 	flags.String(option.KVStore, "", "Key-value store type")
 	option.BindEnv(option.KVStore)

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -95,7 +95,7 @@ func CreateConfigFromAgentResponse(resp *models.DaemonConfiguration) (*rest.Conf
 // CreateConfig creates a client configuration based on the configured API
 // server and Kubeconfig path
 func CreateConfig() (*rest.Config, error) {
-	return createConfig(GetAPIServer(), GetKubeconfigPath(), GetQPS(), GetBurst())
+	return createConfig(GetAPIServerURL(), GetKubeconfigPath(), GetQPS(), GetBurst())
 }
 
 // CreateClient creates a new client to access the Kubernetes API

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -74,11 +74,7 @@ func createConfig(apiServerURL, kubeCfgPath string, qps float32, burst int) (*re
 		}
 		config.Host = apiServerURL
 	default:
-		config := &rest.Config{Host: apiServerURL, UserAgent: userAgent}
-		setConfig(config, userAgent, qps, burst)
-		if err := rest.SetKubernetesDefaults(config); err != nil {
-			return nil, err
-		}
+		config = &rest.Config{Host: apiServerURL, UserAgent: userAgent}
 	}
 
 	setConfig(config, userAgent, qps, burst)

--- a/pkg/k8s/config.go
+++ b/pkg/k8s/config.go
@@ -26,8 +26,8 @@ var (
 )
 
 type configuration struct {
-	// APIServer is the address of the API server
-	APIServer string
+	// APIServerURL is the URL address of the API server
+	APIServerURL string
 
 	// KubeconfigPath is the local path to the kubeconfig configuration
 	// file on the filesystem
@@ -40,9 +40,9 @@ type configuration struct {
 	Burst int
 }
 
-// GetAPIServer returns the configured API server address
-func GetAPIServer() string {
-	return config.APIServer
+// GetAPIServerURL returns the configured API server URL address
+func GetAPIServerURL() string {
+	return config.APIServerURL
 }
 
 // GetKubeconfigPath returns the configured path to the kubeconfig
@@ -62,22 +62,22 @@ func GetBurst() int {
 }
 
 // Configure sets the parameters of the Kubernetes package
-func Configure(apiServer, kubeconfigPath string, qps float32, burst int) {
-	config.APIServer = apiServer
+func Configure(apiServerURL, kubeconfigPath string, qps float32, burst int) {
+	config.APIServerURL = apiServerURL
 	config.KubeconfigPath = kubeconfigPath
 	config.QPS = qps
 	config.Burst = burst
 
 	if IsEnabled() &&
-		config.APIServer != "" &&
-		!strings.HasPrefix(apiServer, "http") {
-		config.APIServer = "http://" + apiServer
+		config.APIServerURL != "" &&
+		!strings.HasPrefix(apiServerURL, "http") {
+		config.APIServerURL = "http://" + apiServerURL // default to HTTP
 	}
 }
 
 // IsEnabled checks if Cilium is being used in tandem with Kubernetes.
 func IsEnabled() bool {
-	return config.APIServer != "" ||
+	return config.APIServerURL != "" ||
 		config.KubeconfigPath != "" ||
 		(os.Getenv("KUBERNETES_SERVICE_HOST") != "" &&
 			os.Getenv("KUBERNETES_SERVICE_PORT") != "")


### PR DESCRIPTION
This PR allows a user to specify a HTTPS URL of kube-apiserver via `--k8s-api-server`.

Previously, a HTTPS connection to kube-apiserver via non-default URL could have been configured only via kubeConfig(excl. the env hack used in the kubeproxy-free guide), which was quite a hassle for a user, as they had to distribute a kubeConfig within a cluster and to bind-mount it into a cilium-agent pod.

`rest.InClusterConfig()` returns a default config, which uses an endpoint specified in the `KUBERNETES_SERVICE_{HOST,PORT}` env vars and has the TLS config being set. So, we can just change the `Config.Host` to point to the user-specified URL to enable HTTPS for custom URLs.

**NOTE**: will add a CI test if the PR doesn't get rejected.

```release-note
HTTPS URL of kube-apiserver can be specified via "--k8s-api-server" from now on.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9198)
<!-- Reviewable:end -->
