### PR TITLE
endpoint: start a controller to retry regeneration if regeneration fails

### DIFF
--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -83,7 +83,10 @@ func NewEndpointFromChangeModel(owner regeneration.Owner, base *models.EndpointC
 		hasBPFProgram:    make(chan struct{}, 0),
 		desiredPolicy:    policy.NewEndpointPolicy(owner.GetPolicyRepository()),
 		controllers:      controller.NewManager(),
+		regenFailedChan:  make(chan struct{}, 1),
 	}
+
+	ep.startRegenerationFailureHandler()
 	ep.realizedPolicy = ep.desiredPolicy
 
 	if base.Mac != "" {

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -602,7 +602,7 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (pr
 		err = e.regeneratePolicy()
 		stats.policyCalculation.End(err == nil)
 		if err != nil {
-			return fmt.Errorf("unable to regenerate policy for '%s': %s", e.policyMap.String(), err)
+			return fmt.Errorf("unable to regenerate policy for '%s': %s", e.StringID(), err)
 		}
 
 		_ = e.updateAndOverrideEndpointOptions(nil)

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -276,6 +276,8 @@ type Endpoint struct {
 	// plugin which performed the plumbing will enable certain datapath
 	// features according to the mode selected.
 	DatapathConfiguration models.EndpointDatapathConfiguration
+
+	regenFailedChan chan struct{}
 }
 
 // UpdateController updates the controller with the specified name with the
@@ -363,17 +365,20 @@ func (e *Endpoint) waitForProxyCompletions(proxyWaitGroup *completion.WaitGroup)
 // NewEndpointWithState creates a new endpoint useful for testing purposes
 func NewEndpointWithState(owner regeneration.Owner, ID uint16, state string) *Endpoint {
 	ep := &Endpoint{
-		owner:         owner,
-		ID:            ID,
-		OpLabels:      pkgLabels.NewOpLabels(),
-		status:        NewEndpointStatus(),
-		DNSHistory:    fqdn.NewDNSCacheWithLimit(option.Config.ToFQDNsMinTTL, option.Config.ToFQDNsMaxIPsPerHost),
-		state:         state,
-		hasBPFProgram: make(chan struct{}, 0),
-		controllers:   controller.NewManager(),
-		eventQueue:    eventqueue.NewEventQueueBuffered(fmt.Sprintf("endpoint-%d", ID), option.Config.EndpointQueueSize),
-		desiredPolicy: policy.NewEndpointPolicy(owner.GetPolicyRepository()),
+		owner:           owner,
+		ID:              ID,
+		OpLabels:        pkgLabels.NewOpLabels(),
+		status:          NewEndpointStatus(),
+		DNSHistory:      fqdn.NewDNSCacheWithLimit(option.Config.ToFQDNsMinTTL, option.Config.ToFQDNsMaxIPsPerHost),
+		state:           state,
+		hasBPFProgram:   make(chan struct{}, 0),
+		controllers:     controller.NewManager(),
+		eventQueue:      eventqueue.NewEventQueueBuffered(fmt.Sprintf("endpoint-%d", ID), option.Config.EndpointQueueSize),
+		desiredPolicy:   policy.NewEndpointPolicy(owner.GetPolicyRepository()),
+		regenFailedChan: make(chan struct{}, 1),
 	}
+
+	ep.startRegenerationFailureHandler()
 	ep.realizedPolicy = ep.desiredPolicy
 
 	ep.SetDefaultOpts(option.Config.Opts)
@@ -685,6 +690,9 @@ func parseEndpoint(owner regeneration.Owner, strEp string) (*Endpoint, error) {
 	ep.desiredPolicy = policy.NewEndpointPolicy(owner.GetPolicyRepository())
 	ep.realizedPolicy = ep.desiredPolicy
 	ep.controllers = controller.NewManager()
+	ep.regenFailedChan = make(chan struct{}, 1)
+
+	ep.startRegenerationFailureHandler()
 
 	// We need to check for nil in Status, CurrentStatuses and Log, since in
 	// some use cases, status will be not nil and Cilium will eventually


### PR DESCRIPTION
If a given regeneration fails for an Endpoint, a controller is launched which will try to regenerate the Endpoint. This ensures that if an Endpoint goes into `not-ready` state, that it will not stay in that state forever until some other event which triggers a regeneration occurs.

This is intended to be as least-invasive of a change as possible, as this will need to be backported to prior releases. I definitely think this could be done more cleanly, but to do so, it would require a lot of refactoring (believe me, I tried!). 

Signed-off by: Ian Vernon <ian@cilium.io>

Testing was done manually by compiling Cilium with a patch which always caused builds to fail. I then ensured that the backoff / rate-limiting worked as expected.

Related-to: https://github.com/cilium/cilium/issues/8817

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9203)
<!-- Reviewable:end -->
