### PR TITLE
FQDN IP updates wait on endpoint regenerations

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -148,6 +148,7 @@ cilium-agent [flags]
       --tofqdns-min-ttl int                                   The minimum time, in seconds, to use DNS data for toFQDNs policies. (default 3600 when --tofqdns-enable-poller, 604800 otherwise)
       --tofqdns-pre-cache string                              DNS cache data at this path is preloaded on agent startup
       --tofqdns-proxy-port int                                Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port.
+      --tofqdns-proxy-response-max-delay duration             The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information. (default 50ms)
       --trace-payloadlen int                                  Length of payload to capture when tracing (default 128)
   -t, --tunnel string                                         Tunnel mode {vxlan, geneve, disabled} (default "vxlan" for the "veth" datapath mode)
       --version                                               Print version information

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -644,6 +644,9 @@ func init() {
 	flags.Int(option.ToFQDNsMaxIPsPerHost, defaults.ToFQDNsMaxIPsPerHost, "Maximum number of IPs to maintain per FQDN name for each endpoint")
 	option.BindEnv(option.ToFQDNsMaxIPsPerHost)
 
+	flags.DurationVar(&option.Config.FQDNProxyResponseMaxDelay, option.FQDNProxyResponseMaxDelay, 50*time.Millisecond, "The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information.")
+	option.BindEnv(option.FQDNProxyResponseMaxDelay)
+
 	flags.String(option.ToFQDNsPreCache, defaults.ToFQDNsPreCache, "DNS cache data at this path is preloaded on agent startup")
 	option.BindEnv(option.ToFQDNsPreCache)
 

--- a/daemon/fqdn.go
+++ b/daemon/fqdn.go
@@ -23,6 +23,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -93,7 +94,7 @@ func identitiesForFQDNSelectorIPs(selectorsWithIPsToUpdate map[policyApi.FQDNSel
 	return selectorIdentitySliceMapping, nil
 }
 
-func (d *Daemon) updateSelectorCacheFQDNs(selectors map[policyApi.FQDNSelector][]*identity.Identity, selectorsWithoutIPs []policyApi.FQDNSelector) {
+func (d *Daemon) updateSelectorCacheFQDNs(selectors map[policyApi.FQDNSelector][]*identity.Identity, selectorsWithoutIPs []policyApi.FQDNSelector) (wg *sync.WaitGroup) {
 	// Update mapping of selector to set of IPs in selector cache.
 	for selector, identitySlice := range selectors {
 		log.WithFields(logrus.Fields{
@@ -121,9 +122,9 @@ func (d *Daemon) updateSelectorCacheFQDNs(selectors map[policyApi.FQDNSelector][
 	// There may be nothing to update - in this case, we exit and do not need
 	// to trigger policy updates for all endpoints.
 	if len(selectors) == 0 && len(selectorsWithoutIPs) == 0 {
-		return
+		return &sync.WaitGroup{}
 	}
-	d.TriggerPolicyUpdates(false, "updated identities for FQDNs")
+	return d.endpointManager.UpdatePolicyMaps()
 }
 
 // bootstrapFQDN initializes the toFQDNs related subsystems: DNSPoller,
@@ -188,7 +189,8 @@ func (d *Daemon) bootstrapFQDN(restoredEndpoints *endpointRestoreState, preCache
 			metrics.FQDNGarbageCollectorCleanedTotal.Add(float64(len(namesToClean)))
 			log.WithField(logfields.Controller, dnsGCJobName).Infof(
 				"FQDN garbage collector work deleted %d name entries", len(namesToClean))
-			return d.dnsNameManager.ForceGenerateDNS(namesToClean)
+			_, err := d.dnsNameManager.ForceGenerateDNS(namesToClean)
+			return err
 		},
 	})
 
@@ -246,17 +248,16 @@ func (d *Daemon) bootstrapFQDN(restoredEndpoints *endpointRestoreState, preCache
 // updateSelectors propagates the mapping of FQDNSelector to identity, as well
 // as the set of FQDNSelectors which have no IPs which correspond to them
 // (usually due to TTL expiry), down to policy layer managed by this daemon.
-func (d *Daemon) updateSelectors(selectorWithIPsToUpdate map[policyApi.FQDNSelector][]net.IP, selectorsWithoutIPs []policyApi.FQDNSelector) error {
+func (d *Daemon) updateSelectors(selectorWithIPsToUpdate map[policyApi.FQDNSelector][]net.IP, selectorsWithoutIPs []policyApi.FQDNSelector) (wg *sync.WaitGroup, err error) {
 	// Convert set of selectors with IPs to update to set of selectors
 	// with identities corresponding to said IPs.
 	selectorsIdentities, err := identitiesForFQDNSelectorIPs(selectorWithIPsToUpdate)
 	if err != nil {
-		return err
+		return &sync.WaitGroup{}, err
 	}
 
 	// Update mapping in selector cache with new identities.
-	d.updateSelectorCacheFQDNs(selectorsIdentities, selectorsWithoutIPs)
-	return nil
+	return d.updateSelectorCacheFQDNs(selectorsIdentities, selectorsWithoutIPs), nil
 }
 
 // pollerResponseNotify handles update events for updates from the poller. It
@@ -473,7 +474,7 @@ func (d *Daemon) notifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epI
 			"qname": qname,
 			"ips":   responseIPs,
 		}).Debug("Updating DNS name in cache from response to to query")
-		err = d.dnsNameManager.UpdateGenerateDNS(lookupTime, map[string]*fqdn.DNSIPRecords{
+		_, err := d.dnsNameManager.UpdateGenerateDNS(lookupTime, map[string]*fqdn.DNSIPRecords{
 			qname: {
 				IPs: responseIPs,
 				TTL: int(TTL),

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -886,6 +886,17 @@ func (e *Endpoint) addPolicyKey(keyToAdd policy.Key, entry policy.MapStateEntry,
 	return true
 }
 
+// ApplyPolicyMapChanges updates the Endpoint's PolicyMap with the changes
+// that have accumulated for the PolicyMap via various outside events (e.g.,
+// identities added / deleted).
+func (e *Endpoint) ApplyPolicyMapChanges() error {
+	if err := e.lockAlive(); err != nil {
+		return err
+	}
+	defer e.unlock()
+	return e.applyPolicyMapChanges()
+}
+
 // applyPolicyMapChanges applies any incremental policy map changes
 // collected on the desired policy.
 func (e *Endpoint) applyPolicyMapChanges() error {

--- a/pkg/fqdn/config.go
+++ b/pkg/fqdn/config.go
@@ -16,6 +16,7 @@ package fqdn
 
 import (
 	"net"
+	"sync"
 	"time"
 
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -48,7 +49,7 @@ type Config struct {
 
 	// UpdateSelectors is a callback to update the mapping of FQDNSelector to
 	// sets of IPs.
-	UpdateSelectors func(selectorsWithIPs map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) error
+	UpdateSelectors func(selectorsWithIPs map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, error)
 
 	// PollerResponseNotify is used when the poller receives DNS data in response
 	// to a successful poll.

--- a/pkg/fqdn/dnspoller.go
+++ b/pkg/fqdn/dnspoller.go
@@ -113,7 +113,8 @@ func (poller *DNSPoller) LookupUpdateDNS(ctx context.Context) error {
 		poller.config.PollerResponseNotify(lookupTime, qname, response)
 	}
 
-	return poller.ruleManager.UpdateGenerateDNS(lookupTime, updatedDNSIPs)
+	_, err := poller.ruleManager.UpdateGenerateDNS(lookupTime, updatedDNSIPs)
+	return err
 }
 
 // noopPollerResponseNotify is used when no PollerResponseNotify is set.

--- a/pkg/fqdn/dnspoller_test.go
+++ b/pkg/fqdn/dnspoller_test.go
@@ -19,6 +19,7 @@ package fqdn
 import (
 	"context"
 	"net"
+	"sync"
 
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/miekg/dns"
@@ -142,8 +143,8 @@ func (ds *FQDNTestSuite) TestNameManagerSelectorHandling(c *C) {
 					return lookupDNSNames(ipLookups, lookups, dnsNames), nil
 				},
 
-				UpdateSelectors: func(map[api.FQDNSelector][]net.IP, []api.FQDNSelector) error {
-					return nil
+				UpdateSelectors: func(map[api.FQDNSelector][]net.IP, []api.FQDNSelector) (*sync.WaitGroup, error) {
+					return &sync.WaitGroup{}, nil
 				},
 			}
 

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -376,6 +376,9 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	scopedLog.WithField(logfields.Response, response).Debug("Received DNS response to proxied lookup")
 	stat.Success = true
 
+	scopedLog.Debug("Notifying with DNS response to original DNS query")
+	p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerAddr, response, protocol, true, stat)
+
 	scopedLog.Debug("Responding to original DNS query")
 	// restore the ID to the one in the initial request so it matches what the requester expects.
 	response.Id = requestID
@@ -385,11 +388,6 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		stat.Err = fmt.Errorf("Cannot forward proxied DNS response: %s", err)
 		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerAddr, response, protocol, true, stat)
 	}
-
-	// Note: This may block and it is safer to do it after we have written out
-	// the DNS response to the pod.
-	scopedLog.Debug("Notifying with DNS response to original DNS query")
-	p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerAddr, response, protocol, true, stat)
 }
 
 // sendRefused creates and sends a REFUSED response for request to w

--- a/pkg/fqdn/name_manager_test.go
+++ b/pkg/fqdn/name_manager_test.go
@@ -18,6 +18,7 @@ package fqdn
 
 import (
 	"net"
+	"sync"
 	"time"
 
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -49,11 +50,11 @@ func (ds *FQDNTestSuite) TestNameManagerCIDRGeneration(c *C) {
 				return lookupFail(c, dnsNames)
 			},
 
-			UpdateSelectors: func(selectorIPMapping map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) error {
+			UpdateSelectors: func(selectorIPMapping map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, error) {
 				for k, v := range selectorIPMapping {
 					selIPMap[k] = v
 				}
-				return nil
+				return &sync.WaitGroup{}, nil
 			},
 		})
 	)
@@ -66,7 +67,7 @@ func (ds *FQDNTestSuite) TestNameManagerCIDRGeneration(c *C) {
 	// poll DNS once, check that we only generate 1 rule (for 1 IP) and that we
 	// still have 1 ToFQDN rule, and that the IP is correct
 	selIPMap = make(map[api.FQDNSelector][]net.IP)
-	err := nameManager.UpdateGenerateDNS(time.Now(), map[string]*DNSIPRecords{dns.Fqdn("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}}})
+	_, err := nameManager.UpdateGenerateDNS(time.Now(), map[string]*DNSIPRecords{dns.Fqdn("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}}})
 	c.Assert(err, IsNil, Commentf("Error mapping selectors to IPs"))
 	c.Assert(len(selIPMap), Equals, 1, Commentf("Incorrect length for testCase with single ToFQDNs entry"))
 
@@ -78,7 +79,7 @@ func (ds *FQDNTestSuite) TestNameManagerCIDRGeneration(c *C) {
 	// inserted) and that we still have 1 ToFQDN rule, and that the IP, now
 	// different, is correct
 	selIPMap = make(map[api.FQDNSelector][]net.IP)
-	err = nameManager.UpdateGenerateDNS(time.Now(), map[string]*DNSIPRecords{dns.Fqdn("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("2.2.2.2")}}})
+	_, err = nameManager.UpdateGenerateDNS(time.Now(), map[string]*DNSIPRecords{dns.Fqdn("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("2.2.2.2")}}})
 	c.Assert(err, IsNil, Commentf("Error generating IP CIDR rules"))
 	c.Assert(len(selIPMap), Equals, 1, Commentf("Only one entry per FQDNSelector should be present"))
 	expectedIPs = []net.IP{net.ParseIP("1.1.1.1"), net.ParseIP("2.2.2.2")}
@@ -99,11 +100,11 @@ func (ds *FQDNTestSuite) TestNameManagerMultiIPUpdate(c *C) {
 				return lookupFail(c, dnsNames)
 			},
 
-			UpdateSelectors: func(selectorIPMapping map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) error {
+			UpdateSelectors: func(selectorIPMapping map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, error) {
 				for k, v := range selectorIPMapping {
 					selIPMap[k] = v
 				}
-				return nil
+				return &sync.WaitGroup{}, nil
 			},
 		})
 	)
@@ -117,14 +118,14 @@ func (ds *FQDNTestSuite) TestNameManagerMultiIPUpdate(c *C) {
 
 	// poll DNS once, check that we only generate 1 IP for cilium.io
 	selIPMap = make(map[api.FQDNSelector][]net.IP)
-	err := nameManager.UpdateGenerateDNS(time.Now(), map[string]*DNSIPRecords{dns.Fqdn("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}}})
+	_, err := nameManager.UpdateGenerateDNS(time.Now(), map[string]*DNSIPRecords{dns.Fqdn("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}}})
 	c.Assert(err, IsNil, Commentf("Error mapping selectors to IPs"))
 	c.Assert(len(selIPMap), Equals, 1, Commentf("Incorrect number of plumbed FQDN selectors"))
 	c.Assert(selIPMap[ciliumIOSel][0].Equal(net.ParseIP("1.1.1.1")), Equals, true)
 
 	// poll DNS once, check that we only generate 3 IPs, 2 cached from before and 1 new one for github.com
 	selIPMap = make(map[api.FQDNSelector][]net.IP)
-	err = nameManager.UpdateGenerateDNS(time.Now(), map[string]*DNSIPRecords{
+	_, err = nameManager.UpdateGenerateDNS(time.Now(), map[string]*DNSIPRecords{
 		dns.Fqdn("cilium.io"):  {TTL: 60, IPs: []net.IP{net.ParseIP("2.2.2.2")}},
 		dns.Fqdn("github.com"): {TTL: 60, IPs: []net.IP{net.ParseIP("3.3.3.3")}}})
 	c.Assert(err, IsNil, Commentf("Error mapping selectors to IPs"))
@@ -137,7 +138,7 @@ func (ds *FQDNTestSuite) TestNameManagerMultiIPUpdate(c *C) {
 
 	// poll DNS once, check that we only generate 4 IPs, 2 cilium.io cached IPs, 1 cached github.com IP, 1 new github.com IP
 	selIPMap = make(map[api.FQDNSelector][]net.IP)
-	err = nameManager.UpdateGenerateDNS(time.Now(), map[string]*DNSIPRecords{
+	_, err = nameManager.UpdateGenerateDNS(time.Now(), map[string]*DNSIPRecords{
 		dns.Fqdn("cilium.io"):  {TTL: 60, IPs: []net.IP{net.ParseIP("2.2.2.2")}},
 		dns.Fqdn("github.com"): {TTL: 60, IPs: []net.IP{net.ParseIP("4.4.4.4")}}})
 	c.Assert(err, IsNil, Commentf("Error mapping selectors to IPs"))

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -462,6 +462,9 @@ const (
 	// the default for denied DNS requests.
 	FQDNProxyDenyWithRefused = "refused"
 
+	// FQDNProxyResponseMaxDelay is the maximum time the proxy holds back a response
+	FQDNProxyResponseMaxDelay = "tofqdns-proxy-response-max-delay"
+
 	// PreAllocateMapsName is the name of the option PreAllocateMaps
 	PreAllocateMapsName = "preallocate-bpf-maps"
 
@@ -1031,6 +1034,11 @@ type DaemonConfig struct {
 
 	// FQDNRejectResponse is the dns-proxy response for invalid dns-proxy request
 	FQDNRejectResponse string
+
+	// FQDNProxyResponseMaxDelay The maximum time the DNS proxy holds an allowed
+	// DNS response before sending it along. Responses are sent as soon as the
+	// datapath is updated with the new IP information.
+	FQDNProxyResponseMaxDelay time.Duration
 
 	// Path to a file with DNS cache data to preload on startup
 	ToFQDNsPreCache string


### PR DESCRIPTION
This PR supersedes https://github.com/cilium/cilium/pull/9185 (assuming it works).
I still need to test this a little more but the general structure is there. An extension would be to add an option to wait on the endpoint that made the request, all endpoints, or no endpoints. I'm not sure that it's worth it, however, since any reasonable timeout would trigger in the cases where waiting on all endpoints is too slow (which also means the single-endpoint case is also slow).

I'm also a little worried that this PR adds a dependency of a type that @ianvernon is trying to remove. In particular, we now rely on a `BumpRevision` call for IP updates to selectors, and we may have a future where such updates don't require the bump or regeneration.

When new IPs are added to the DNS cache we also update FQDN
Selectors. These, in turn, may trigger policy regenerations. The most
ideal behaviour is that we have plumbed all needed policy before we
return the DNS response to the pod.
The DNS proxy now notifies about DNS responses before it forwards the
response. The daemon handler waits for regeneration, with a timeout.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9208)
<!-- Reviewable:end -->
