### PR TITLE
redirect traffic to proxy if proxy-visibility annotation is added to a pod if policy does not apply to an endpoint

### DIFF
--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/api/v1/server/restapi/endpoint"
+	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/api"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/endpoint"
@@ -237,7 +238,7 @@ func (d *Daemon) createEndpoint(ctx context.Context, epTemplate *models.Endpoint
 		} else {
 			addLabels.MergeLabels(identityLabels)
 			infoLabels.MergeLabels(info)
-			ep.UpdateVisibilityPolicy(annotations)
+			ep.UpdateVisibilityPolicy(annotations[annotation.ProxyVisibility])
 		}
 	}
 
@@ -270,7 +271,7 @@ func (d *Daemon) createEndpoint(ctx context.Context, epTemplate *models.Endpoint
 							ep.Logger(controllerName).WithError(err).Warning("Unable to fetch kubernetes labels")
 							return err
 						}
-						ep.UpdateVisibilityPolicy(annotations)
+						ep.UpdateVisibilityPolicy(annotations[annotation.ProxyVisibility])
 						ep.UpdateLabels(ctx, identityLabels, info, true)
 						close(done)
 						return nil

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -131,7 +131,7 @@ func NewPutEndpointIDHandler(d *Daemon) PutEndpointIDHandler {
 }
 
 func fetchK8sLabelsAndAnnotations(ep *endpoint.Endpoint) (labels.Labels, labels.Labels, map[string]string, error) {
-	lbls, annotations, err := k8s.GetPodLabels(ep.GetK8sNamespace(), ep.GetK8sPodName())
+	lbls, annotations, err := k8s.GetPodMetadata(ep.GetK8sNamespace(), ep.GetK8sPodName())
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -1577,22 +1577,18 @@ func (d *Daemon) updateK8sPodV1(oldK8sPod, newK8sPod *types.Pod) error {
 		return nil
 	}
 
-	switch {
-	case annotationsChanged && labelsChanged:
-		podEP.UpdateVisibilityPolicy(newAnno)
+	if labelsChanged {
 		err := updateEndpointLabels(podEP, oldPodLabels, newPodLabels)
-		realizePodAnnotationUpdate(podEP)
-		return err
-	case annotationsChanged:
-		//  Update annotations and regenerate.
+		if err != nil {
+			return err
+		}
+	}
+
+	if annotationsChanged {
 		podEP.UpdateVisibilityPolicy(newAnno)
 		realizePodAnnotationUpdate(podEP)
-		return nil
-	case labelsChanged:
-		return updateEndpointLabels(podEP, oldPodLabels, newPodLabels)
-	default:
-		return nil
 	}
+	return nil
 }
 
 func realizePodAnnotationUpdate(podEP *endpoint.Endpoint) {

--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -1585,7 +1585,7 @@ func (d *Daemon) updateK8sPodV1(oldK8sPod, newK8sPod *types.Pod) error {
 	}
 
 	if annotationsChanged {
-		podEP.UpdateVisibilityPolicy(newAnno)
+		podEP.UpdateVisibilityPolicy(newAnno[annotation.ProxyVisibility])
 		realizePodAnnotationUpdate(podEP)
 	}
 	return nil

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -75,6 +75,10 @@ func (d *Daemon) validateEndpoint(ep *endpoint.Endpoint) (valid bool, err error)
 			return false, fmt.Errorf("kubernetes pod not found")
 		}
 		if err == nil {
+			// We were able to get the pod. Given that we get the entire pod
+			// object, including annotations in the above API call, update
+			// the Endpoint's visibility policy accordingly so we don't have
+			// to make another API call later.
 			ep.UpdateVisibilityPolicy(p.Annotations)
 		}
 	}

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -70,9 +70,12 @@ func (d *Daemon) validateEndpoint(ep *endpoint.Endpoint) (valid bool, err error)
 	}
 
 	if ep.K8sPodName != "" && ep.K8sNamespace != "" && k8s.IsEnabled() {
-		_, err := k8s.Client().CoreV1().Pods(ep.K8sNamespace).Get(ep.K8sPodName, meta_v1.GetOptions{})
+		p, err := k8s.Client().CoreV1().Pods(ep.K8sNamespace).Get(ep.K8sPodName, meta_v1.GetOptions{})
 		if err != nil && k8serrors.IsNotFound(err) {
 			return false, fmt.Errorf("kubernetes pod not found")
+		}
+		if err == nil {
+			ep.UpdateVisibilityPolicy(p.Annotations)
 		}
 	}
 

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"sync"
 
+	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpoint/connector"
@@ -79,7 +80,7 @@ func (d *Daemon) validateEndpoint(ep *endpoint.Endpoint) (valid bool, err error)
 			// object, including annotations in the above API call, update
 			// the Endpoint's visibility policy accordingly so we don't have
 			// to make another API call later.
-			ep.UpdateVisibilityPolicy(p.Annotations)
+			ep.UpdateVisibilityPolicy(p.Annotations[annotation.ProxyVisibility])
 		}
 	}
 

--- a/pkg/annotation/k8s.go
+++ b/pkg/annotation/k8s.go
@@ -55,4 +55,10 @@ const (
 	// GlobalService to true allows to expose remote endpoints without
 	// sharing local endpoints.
 	SharedService = Prefix + "shared-service"
+
+	// ProxyVisibility is the annotation name used to indicate whether proxy
+	// visibility should be enabled for a given pod (i.e., all traffic for the
+	// pod is redirected to the proxy for the given port / protocol in the
+	// annotation
+	ProxyVisibility = Prefix + ".proxy-visibility"
 )

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -382,14 +382,12 @@ func (e *Endpoint) addNewRedirects(m *policy.L4Policy, proxyWaitGroup *completio
 	desiredRedirects = make(map[string]bool)
 
 	for dirLogStr, ingress := range map[string]bool{"ingress": true, "egress": false} {
-		if m != nil && m.HasRedirect() {
-			err, ff, rf = e.addNewRedirectsFromDesiredPolicy(ingress, desiredRedirects, proxyWaitGroup)
-			if err != nil {
-				return desiredRedirects, fmt.Errorf("unable to allocate %s redirects: %s", dirLogStr, err), nil, nil
-			}
-			finalizeList.Append(ff)
-			revertStack.Push(rf)
+		err, ff, rf = e.addNewRedirectsFromDesiredPolicy(ingress, desiredRedirects, proxyWaitGroup)
+		if err != nil {
+			return desiredRedirects, fmt.Errorf("unable to allocate %s redirects: %s", dirLogStr, err), nil, nil
 		}
+		finalizeList.Append(ff)
+		revertStack.Push(rf)
 
 		err, ff, rf = e.addVisibilityRedirects(ingress, desiredRedirects, proxyWaitGroup)
 		if err != nil {

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -279,56 +279,57 @@ func (e *Endpoint) addVisibilityRedirects(ingress bool, desiredRedirects map[str
 	if !policyEnabled {
 		for _, visMeta := range visPolicy {
 			// Create a redirect for every entry in the visibility policy.
-			if !e.hasSidecarProxy || visMeta.Parser != policy.ParserTypeHTTP {
-				var (
-					redirectPort uint16
-					err          error
-					finalizeFunc revert.FinalizeFunc
-					revertFunc   revert.RevertFunc
-				)
-				proxyID := policy.ProxyID(e.ID, visMeta.Ingress, visMeta.Proto.String(), visMeta.Port)
-				redirectPort, err, finalizeFunc, revertFunc = e.proxy.CreateOrUpdateRedirect(visMeta, proxyID, e, proxyWaitGroup)
-				if err != nil {
-					revertStack.Revert() // Ignore errors while reverting. This is best-effort.
-					return err, nil, nil
-				}
-				finalizeList.Append(finalizeFunc)
-				revertStack.Push(revertFunc)
-
-				if e.realizedRedirects == nil {
-					e.realizedRedirects = make(map[string]uint16)
-				}
-				if _, found := e.realizedRedirects[proxyID]; !found {
-					revertStack.Push(func() error {
-						delete(e.realizedRedirects, proxyID)
-						return nil
-					})
-				}
-				e.realizedRedirects[proxyID] = redirectPort
-
-				desiredRedirects[proxyID] = true
-
-				// Update the endpoint API model to report that Cilium manages a
-				// redirect for that port.
-				e.proxyStatisticsMutex.Lock()
-				proxyStats := e.getProxyStatisticsLocked(proxyID, string(visMeta.Parser), visMeta.Port, visMeta.Ingress)
-				proxyStats.AllocatedProxyPort = int64(redirectPort)
-				e.proxyStatisticsMutex.Unlock()
-
-				updatedStats = append(updatedStats, proxyStats)
-
-				newKey := policy.Key{
-					DestPort:         visMeta.Port,
-					Nexthdr:          uint8(visMeta.Proto),
-					TrafficDirection: direction.Uint8(),
-				}
-
-				e.desiredPolicy.PolicyMapState[newKey] = policy.MapStateEntry{
-					ProxyPort: redirectPort,
-				}
-
-				insertedDesiredMapState[newKey] = struct{}{}
+			if e.hasSidecarProxy && visMeta.Parser == policy.ParserTypeHTTP {
+				continue
 			}
+			var (
+				redirectPort uint16
+				err          error
+				finalizeFunc revert.FinalizeFunc
+				revertFunc   revert.RevertFunc
+			)
+			proxyID := policy.ProxyID(e.ID, visMeta.Ingress, visMeta.Proto.String(), visMeta.Port)
+			redirectPort, err, finalizeFunc, revertFunc = e.proxy.CreateOrUpdateRedirect(visMeta, proxyID, e, proxyWaitGroup)
+			if err != nil {
+				revertStack.Revert() // Ignore errors while reverting. This is best-effort.
+				return err, nil, nil
+			}
+			finalizeList.Append(finalizeFunc)
+			revertStack.Push(revertFunc)
+
+			if e.realizedRedirects == nil {
+				e.realizedRedirects = make(map[string]uint16)
+			}
+			if _, found := e.realizedRedirects[proxyID]; !found {
+				revertStack.Push(func() error {
+					delete(e.realizedRedirects, proxyID)
+					return nil
+				})
+			}
+			e.realizedRedirects[proxyID] = redirectPort
+
+			desiredRedirects[proxyID] = true
+
+			// Update the endpoint API model to report that Cilium manages a
+			// redirect for that port.
+			e.proxyStatisticsMutex.Lock()
+			proxyStats := e.getProxyStatisticsLocked(proxyID, string(visMeta.Parser), visMeta.Port, visMeta.Ingress)
+			proxyStats.AllocatedProxyPort = int64(redirectPort)
+			e.proxyStatisticsMutex.Unlock()
+
+			updatedStats = append(updatedStats, proxyStats)
+
+			newKey := policy.Key{
+				DestPort:         visMeta.Port,
+				Nexthdr:          uint8(visMeta.Proto),
+				TrafficDirection: direction.Uint8(),
+			}
+
+			e.desiredPolicy.PolicyMapState[newKey] = policy.MapStateEntry{
+				ProxyPort: redirectPort,
+			}
+
+			insertedDesiredMapState[newKey] = struct{}{}
 		}
 	}
 

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -141,11 +141,11 @@ func (e *Endpoint) writeHeaderfile(prefix string) error {
 	return e.owner.Datapath().WriteEndpointConfig(f, e)
 }
 
-// addNewRedirectsFromMap must be called while holding the endpoint lock for
+// addNewRedirectsFromDesiredPolicy must be called while holding the endpoint lock for
 // writing. On success, returns nil; otherwise, returns an error  indicating the
 // problem that occurred while adding an l7 redirect for the specified policy.
 // Must be called with endpoint.Mutex held.
-func (e *Endpoint) addNewRedirectsFromMap(ingress bool, desiredRedirects map[string]bool, proxyWaitGroup *completion.WaitGroup) (error, revert.FinalizeFunc, revert.RevertFunc) {
+func (e *Endpoint) addNewRedirectsFromDesiredPolicy(ingress bool, desiredRedirects map[string]bool, proxyWaitGroup *completion.WaitGroup) (error, revert.FinalizeFunc, revert.RevertFunc) {
 	if option.Config.DryMode {
 		return nil, nil, nil
 	}
@@ -383,7 +383,7 @@ func (e *Endpoint) addNewRedirects(m *policy.L4Policy, proxyWaitGroup *completio
 
 	for dirLogStr, ingress := range map[string]bool{"ingress": true, "egress": false} {
 		if m != nil && m.HasRedirect() {
-			err, ff, rf = e.addNewRedirectsFromMap(ingress, desiredRedirects, proxyWaitGroup)
+			err, ff, rf = e.addNewRedirectsFromDesiredPolicy(ingress, desiredRedirects, proxyWaitGroup)
 			if err != nil {
 				return desiredRedirects, fmt.Errorf("unable to allocate %s redirects: %s", dirLogStr, err), nil, nil
 			}

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -371,6 +371,14 @@ func (e *Endpoint) addNewRedirects(m *policy.L4Policy, proxyWaitGroup *completio
 		rf           revert.RevertFunc
 	)
 
+	defer func() {
+		// In case updates partially succeeded, and subsequently failed,
+		// revert.
+		if err != nil {
+			revertStack.Revert()
+		}
+	}()
+
 	desiredRedirects = make(map[string]bool)
 
 	for dirLogStr, ingress := range map[string]bool{"ingress": true, "egress": false} {

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -363,7 +363,7 @@ func (e *Endpoint) addVisibilityRedirects(ingress bool, desiredRedirects map[str
 // The returned map contains the exact set of IDs of proxy redirects that is
 // required to implement the given L4 policy.
 // Must be called with endpoint.Mutex held.
-func (e *Endpoint) addNewRedirects(m *policy.L4Policy, proxyWaitGroup *completion.WaitGroup) (desiredRedirects map[string]bool, err error, finalizeFunc revert.FinalizeFunc, revertFunc revert.RevertFunc) {
+func (e *Endpoint) addNewRedirects(proxyWaitGroup *completion.WaitGroup) (desiredRedirects map[string]bool, err error, finalizeFunc revert.FinalizeFunc, revertFunc revert.RevertFunc) {
 	var (
 		finalizeList revert.FinalizeList
 		revertStack  revert.RevertStack
@@ -754,7 +754,7 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (pr
 		)
 		if e.desiredPolicy != nil {
 			stats.proxyConfiguration.Start()
-			desiredRedirects, err, finalizeFunc, revertFunc = e.addNewRedirects(e.desiredPolicy.L4Policy, datapathRegenCtxt.proxyWaitGroup)
+			desiredRedirects, err, finalizeFunc, revertFunc = e.addNewRedirects(datapathRegenCtxt.proxyWaitGroup)
 			stats.proxyConfiguration.End(err == nil)
 			if err != nil {
 				return err

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -382,7 +382,6 @@ func (e *Endpoint) addNewRedirects(m *policy.L4Policy, proxyWaitGroup *completio
 	desiredRedirects = make(map[string]bool)
 
 	for dirLogStr, ingress := range map[string]bool{"ingress": true, "egress": false} {
-		// Ingress redirects.
 		if m != nil && m.HasRedirect() {
 			err, ff, rf = e.addNewRedirectsFromMap(ingress, desiredRedirects, proxyWaitGroup)
 			if err != nil {

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -373,11 +373,7 @@ func (e *Endpoint) addNewRedirects(m *policy.L4Policy, proxyWaitGroup *completio
 
 	desiredRedirects = make(map[string]bool)
 
-	for _, ingress := range []bool{true, false} {
-		dirLogStr := "ingress"
-		if !ingress {
-			dirLogStr = "egress"
-		}
+	for dirLogStr, ingress := range map[string]bool{"ingress": true, "egress": false} {
 		// Ingress redirects.
 		if m != nil && m.HasRedirect() {
 			err, ff, rf = e.addNewRedirectsFromMap(ingress, desiredRedirects, proxyWaitGroup)

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -271,6 +271,8 @@ type Endpoint struct {
 
 	realizedPolicy *policy.EndpointPolicy
 
+	visibilityPolicy *policy.VisibilityPolicy
+
 	eventQueue *eventqueue.EventQueue
 
 	// DatapathConfiguration is the endpoint's datapath configuration as

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -739,20 +739,19 @@ func (e *Endpoint) UpdateVisibilityPolicy(anno map[string]string) {
 		err error
 	)
 
-	if anno != nil {
-		if an, ok := anno[annotation.ProxyVisibility]; ok {
-			e.getLogger().Debug("proxy visibility annotation found for pod; creating visibility policy")
-			nvp, err = policy.NewVisibilityPolicy(an)
-			if err != nil {
-				e.getLogger().WithError(err).Warning("unable to parse annotations into visibility policy; disabling visibility policy for endpoint")
-				e.visibilityPolicy = &policy.VisibilityPolicy{
-					Ingress: make(policy.DirectionalVisibilityPolicy),
-					Egress:  make(policy.DirectionalVisibilityPolicy),
-				}
-				return
+	if an, ok := anno[annotation.ProxyVisibility]; ok {
+		e.getLogger().Debug("proxy visibility annotation found for pod; creating visibility policy")
+		nvp, err = policy.NewVisibilityPolicy(an)
+		if err != nil {
+			e.getLogger().WithError(err).Warning("unable to parse annotations into visibility policy; disabling visibility policy for endpoint")
+			e.visibilityPolicy = &policy.VisibilityPolicy{
+				Ingress: make(policy.DirectionalVisibilityPolicy),
+				Egress:  make(policy.DirectionalVisibilityPolicy),
 			}
+			return
 		}
 	}
+
 	e.visibilityPolicy = nvp
 	return
 }

--- a/pkg/endpoint/policy_test.go
+++ b/pkg/endpoint/policy_test.go
@@ -17,7 +17,6 @@
 package endpoint
 
 import (
-	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/u8proto"
 	"gopkg.in/check.v1"
@@ -25,12 +24,10 @@ import (
 
 func (s *EndpointSuite) TestUpdateVisibilityPolicy(c *check.C) {
 	ep := NewEndpointWithState(&DummyOwner{repo: policy.NewPolicyRepository()}, nil, 12345, StateReady)
-	ep.UpdateVisibilityPolicy(nil)
+	ep.UpdateVisibilityPolicy("")
 	c.Assert(ep.visibilityPolicy, check.IsNil)
 
-	ep.UpdateVisibilityPolicy(map[string]string{
-		annotation.ProxyVisibility: "<Ingress/80/TCP/HTTP>",
-	})
+	ep.UpdateVisibilityPolicy("<Ingress/80/TCP/HTTP>")
 
 	c.Assert(ep.visibilityPolicy, check.Not(check.Equals), nil)
 	c.Assert(ep.visibilityPolicy.Ingress["80/TCP"], check.DeepEquals, &policy.VisibilityMetadata{
@@ -41,6 +38,6 @@ func (s *EndpointSuite) TestUpdateVisibilityPolicy(c *check.C) {
 	})
 
 	// Check that updating after previously having value works.
-	ep.UpdateVisibilityPolicy(nil)
+	ep.UpdateVisibilityPolicy("")
 	c.Assert(ep.visibilityPolicy, check.IsNil)
 }

--- a/pkg/endpoint/policy_test.go
+++ b/pkg/endpoint/policy_test.go
@@ -1,0 +1,46 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package endpoint
+
+import (
+	"github.com/cilium/cilium/pkg/annotation"
+	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/u8proto"
+	"gopkg.in/check.v1"
+)
+
+func (s *EndpointSuite) TestUpdateVisibilityPolicy(c *check.C) {
+	ep := NewEndpointWithState(&DummyOwner{repo: policy.NewPolicyRepository()}, nil, 12345, StateReady)
+	ep.UpdateVisibilityPolicy(nil)
+	c.Assert(ep.visibilityPolicy, check.IsNil)
+
+	ep.UpdateVisibilityPolicy(map[string]string{
+		annotation.ProxyVisibility: "<Ingress/80/TCP/HTTP>",
+	})
+
+	c.Assert(ep.visibilityPolicy, check.Not(check.Equals), nil)
+	c.Assert(ep.visibilityPolicy.Ingress["80/TCP"], check.DeepEquals, &policy.VisibilityMetadata{
+		Parser:  policy.ParserTypeHTTP,
+		Port:    uint16(80),
+		Proto:   u8proto.TCP,
+		Ingress: true,
+	})
+
+	// Check that updating after previously having value works.
+	ep.UpdateVisibilityPolicy(nil)
+	c.Assert(ep.visibilityPolicy, check.IsNil)
+}

--- a/pkg/endpoint/proxy.go
+++ b/pkg/endpoint/proxy.go
@@ -27,7 +27,7 @@ import (
 
 // EndpointProxy defines any L7 proxy with which an Endpoint must interact.
 type EndpointProxy interface {
-	CreateOrUpdateRedirect(l4 *policy.L4Filter, id string, localEndpoint logger.EndpointUpdater, wg *completion.WaitGroup) (proxyPort uint16, err error, finalizeFunc revert.FinalizeFunc, revertFunc revert.RevertFunc)
+	CreateOrUpdateRedirect(l4 policy.ProxyPolicy, id string, localEndpoint logger.EndpointUpdater, wg *completion.WaitGroup) (proxyPort uint16, err error, finalizeFunc revert.FinalizeFunc, revertFunc revert.RevertFunc)
 	RemoveRedirect(id string, wg *completion.WaitGroup) (error, revert.FinalizeFunc, revert.RevertFunc)
 	UpdateNetworkPolicy(ep logger.EndpointUpdater, policy *policy.L4Policy, ingressPolicyEnforced, egressPolicyEnforced bool, wg *completion.WaitGroup) (error, func() error)
 	RemoveNetworkPolicy(ep logger.EndpointInfoSource)
@@ -69,16 +69,23 @@ func (e *Endpoint) removeNetworkPolicy() {
 	e.proxy.RemoveNetworkPolicy(e)
 }
 
+// FakeEndpointProxy is a stub proxy used for testing.
 type FakeEndpointProxy struct{}
 
-func (f *FakeEndpointProxy) CreateOrUpdateRedirect(l4 *policy.L4Filter, id string, localEndpoint logger.EndpointUpdater, wg *completion.WaitGroup) (proxyPort uint16, err error, finalizeFunc revert.FinalizeFunc, revertFunc revert.RevertFunc) {
+// CreateOrUpdateRedirect does nothing.
+func (f *FakeEndpointProxy) CreateOrUpdateRedirect(l4 policy.ProxyPolicy, id string, localEndpoint logger.EndpointUpdater, wg *completion.WaitGroup) (proxyPort uint16, err error, finalizeFunc revert.FinalizeFunc, revertFunc revert.RevertFunc) {
 	return
 }
 
+// RemoveRedirect does nothing.
 func (f *FakeEndpointProxy) RemoveRedirect(id string, wg *completion.WaitGroup) (error, revert.FinalizeFunc, revert.RevertFunc) {
 	return nil, nil, nil
 }
+
+// UpdateNetworkPolicy does nothing.
 func (f *FakeEndpointProxy) UpdateNetworkPolicy(ep logger.EndpointUpdater, policy *policy.L4Policy, ingressPolicyEnforced, egressPolicyEnforced bool, wg *completion.WaitGroup) (error, func() error) {
 	return nil, nil
 }
+
+//RemoveNetworkPolicy does nothing.
 func (f *FakeEndpointProxy) RemoveNetworkPolicy(ep logger.EndpointInfoSource) {}

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -19,7 +19,6 @@ package endpoint
 import (
 	"context"
 
-	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/identity"
@@ -161,9 +160,7 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 	c.Assert(err, check.IsNil)
 	ep.SetIdentity(epIdentity, true)
 
-	firstAnno := map[string]string{
-		annotation.ProxyVisibility: "<Ingress/80/TCP/HTTP>",
-	}
+	firstAnno := "<Ingress/80/TCP/HTTP>"
 	ep.UpdateVisibilityPolicy(firstAnno)
 	err = ep.regeneratePolicy()
 	c.Assert(err, check.IsNil)
@@ -183,9 +180,7 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 	c.Assert(ok, check.Equals, true)
 	c.Assert(v.ProxyPort, check.Equals, httpPort)
 
-	secondAnno := map[string]string{
-		annotation.ProxyVisibility: "<Ingress/80/TCP/Kafka>",
-	}
+	secondAnno := "<Ingress/80/TCP/Kafka>"
 
 	ep.UpdateVisibilityPolicy(secondAnno)
 	d, err, _, _ := ep.addNewRedirects(ep.desiredPolicy.L4Policy, cmp)
@@ -200,9 +195,7 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 	// Check that proxyport was updated accordingly.
 	c.Assert(v.ProxyPort, check.Equals, kafkaPort)
 
-	thirdAnno := map[string]string{
-		annotation.ProxyVisibility: "<Ingress/80/TCP/Kafka>,<Egress/80/TCP/HTTP>",
-	}
+	thirdAnno := "<Ingress/80/TCP/Kafka>,<Egress/80/TCP/HTTP>"
 
 	// Check that multiple values in annotation are handled correctly.
 	ep.UpdateVisibilityPolicy(thirdAnno)
@@ -247,7 +240,7 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 	c.Assert(ok, check.Equals, false)
 
 	// Check that all redirects are removed when no visibility policy applies.
-	noAnno := map[string]string{}
+	noAnno := ""
 	ep.UpdateVisibilityPolicy(noAnno)
 	d, err, _, _ = ep.addNewRedirects(ep.desiredPolicy.L4Policy, cmp)
 	c.Assert(err, check.IsNil)

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -169,7 +169,7 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 	defer cancel()
 	cmp := completion.NewWaitGroup(ctx)
 
-	_, err, _, _ = ep.addNewRedirects(ep.desiredPolicy.L4Policy, cmp)
+	_, err, _, _ = ep.addNewRedirects(cmp)
 	c.Assert(err, check.IsNil)
 	v, ok := ep.desiredPolicy.PolicyMapState[policy.Key{
 		Identity:         0,
@@ -183,7 +183,7 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 	secondAnno := "<Ingress/80/TCP/Kafka>"
 
 	ep.UpdateVisibilityPolicy(secondAnno)
-	d, err, _, _ := ep.addNewRedirects(ep.desiredPolicy.L4Policy, cmp)
+	d, err, _, _ := ep.addNewRedirects(cmp)
 	c.Assert(err, check.IsNil)
 	v, ok = ep.desiredPolicy.PolicyMapState[policy.Key{
 		Identity:         0,
@@ -199,7 +199,7 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 
 	// Check that multiple values in annotation are handled correctly.
 	ep.UpdateVisibilityPolicy(thirdAnno)
-	_, err, _, _ = ep.addNewRedirects(ep.desiredPolicy.L4Policy, cmp)
+	_, err, _, _ = ep.addNewRedirects(cmp)
 	c.Assert(err, check.IsNil)
 	v, ok = ep.desiredPolicy.PolicyMapState[policy.Key{
 		Identity:         0,
@@ -242,7 +242,7 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 	// Check that all redirects are removed when no visibility policy applies.
 	noAnno := ""
 	ep.UpdateVisibilityPolicy(noAnno)
-	d, err, _, _ = ep.addNewRedirects(ep.desiredPolicy.L4Policy, cmp)
+	d, err, _, _ = ep.addNewRedirects(cmp)
 	c.Assert(err, check.IsNil)
 	ep.removeOldRedirects(d, cmp)
 	c.Assert(len(ep.realizedRedirects), check.Equals, 0)

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -1,0 +1,256 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package endpoint
+
+import (
+	"context"
+
+	"github.com/cilium/cilium/pkg/annotation"
+	"github.com/cilium/cilium/pkg/completion"
+	"github.com/cilium/cilium/pkg/datapath"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/identity/identitymanager"
+	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/lock"
+	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
+	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/trafficdirection"
+	"github.com/cilium/cilium/pkg/proxy/logger"
+	"github.com/cilium/cilium/pkg/revert"
+	"github.com/cilium/cilium/pkg/u8proto"
+	"gopkg.in/check.v1"
+)
+
+type RedirectSuite struct{}
+
+// suite can be used by testing.T benchmarks or tests as a mock regeneration.Owner
+var redirectSuite = RedirectSuite{}
+var _ = check.Suite(&redirectSuite)
+
+// RedirectSuiteProxy implements EndpointProxy. It is used for testing the
+// functions related to generating proxy redirects for a given Endpoint.
+type RedirectSuiteProxy struct {
+	parserProxyPortMap  map[policy.L7ParserType]uint16
+	redirectPortUserMap map[uint16][]string
+}
+
+// CreateOrUpdateRedirect returns the proxy port for the given L7Parser from the
+// ProxyPolicy parameter.
+func (r *RedirectSuiteProxy) CreateOrUpdateRedirect(l4 policy.ProxyPolicy, id string, localEndpoint logger.EndpointUpdater, wg *completion.WaitGroup) (proxyPort uint16, err error, finalizeFunc revert.FinalizeFunc, revertFunc revert.RevertFunc) {
+	pp := r.parserProxyPortMap[l4.GetL7Parser()]
+	return pp, nil, nil, nil
+}
+
+// RemoveRedirect does nothing.
+func (r *RedirectSuiteProxy) RemoveRedirect(id string, wg *completion.WaitGroup) (error, revert.FinalizeFunc, revert.RevertFunc) {
+	return nil, nil, nil
+}
+
+// UpdateNetworkPolicy does nothing.
+func (r *RedirectSuiteProxy) UpdateNetworkPolicy(ep logger.EndpointUpdater, policy *policy.L4Policy, ingressPolicyEnforced, egressPolicyEnforced bool, wg *completion.WaitGroup) (error, func() error) {
+	return nil, nil
+}
+
+// RemoveNetworkPolicy does nothing.
+func (r *RedirectSuiteProxy) RemoveNetworkPolicy(ep logger.EndpointInfoSource) {}
+
+// DummyIdentityAllocatorOwner implements
+// pkg/identity/cache/IdentityAllocatorOwner. It is used for unit testing.
+type DummyIdentityAllocatorOwner struct{}
+
+// UpdateIdentities does nothing.
+func (d *DummyIdentityAllocatorOwner) UpdateIdentities(added, deleted cache.IdentityCache) {
+	return
+}
+
+// GetNodeSuffix does nothing.
+func (d *DummyIdentityAllocatorOwner) GetNodeSuffix() string {
+	return ""
+}
+
+// DummyOwner implements pkg/endpoint/regeneration/Owner. Used for unit testing.
+type DummyOwner struct {
+	repo *policy.Repository
+}
+
+// GetPolicyRepository returns the policy repository of the owner.
+func (d *DummyOwner) GetPolicyRepository() *policy.Repository {
+	return d.repo
+}
+
+// QueueEndpointBuild does nothing.
+func (d *DummyOwner) QueueEndpointBuild(ctx context.Context, epID uint64) (func(), error) {
+	return nil, nil
+}
+
+// GetCompilationLock does nothing.
+func (d *DummyOwner) GetCompilationLock() *lock.RWMutex {
+	return nil
+}
+
+// SendNotification does nothing.
+func (d *DummyOwner) SendNotification(typ monitorAPI.AgentNotification, text string) error {
+	return nil
+}
+
+// Datapath returns a nil datapath.
+func (d *DummyOwner) Datapath() datapath.Datapath {
+	return nil
+}
+
+// GetNodeSuffix does nothing.
+func (d *DummyOwner) GetNodeSuffix() string {
+	return ""
+}
+
+// UpdateIdentities does nothing.
+func (d *DummyOwner) UpdateIdentities(added, deleted cache.IdentityCache) {}
+
+func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
+	// Setup dependencies for endpoint.
+	kvstore.SetupDummy("etcd")
+	defer kvstore.Close()
+
+	identity.InitWellKnownIdentities()
+	idAllocatorOwner := &DummyIdentityAllocatorOwner{}
+
+	<-cache.InitIdentityAllocator(idAllocatorOwner, nil, nil)
+	defer cache.Close()
+
+	do := &DummyOwner{
+		repo: policy.NewPolicyRepository(),
+	}
+	identitymanager.Subscribe(do.repo)
+
+	lblQA := labels.ParseLabel("QA")
+	lblBar := labels.ParseLabel("bar")
+
+	httpPort := uint16(19001)
+	dnsPort := uint16(19002)
+	kafkaPort := uint16(19003)
+
+	rsp := &RedirectSuiteProxy{
+		parserProxyPortMap: map[policy.L7ParserType]uint16{
+			policy.ParserTypeHTTP:  httpPort,
+			policy.ParserTypeDNS:   dnsPort,
+			policy.ParserTypeKafka: kafkaPort,
+		},
+		redirectPortUserMap: make(map[uint16][]string),
+	}
+
+	ep := NewEndpointWithState(do, rsp, 12345, StateRegenerating)
+
+	qaBarLbls := labels.Labels{lblBar.Key: lblBar, lblQA.Key: lblQA}
+	epIdentity, _, err := cache.AllocateIdentity(context.Background(), idAllocatorOwner, qaBarLbls)
+	c.Assert(err, check.IsNil)
+	ep.SetIdentity(epIdentity, true)
+
+	firstAnno := map[string]string{
+		annotation.ProxyVisibility: "<Ingress/80/TCP/HTTP>",
+	}
+	ep.UpdateVisibilityPolicy(firstAnno)
+	err = ep.regeneratePolicy()
+	c.Assert(err, check.IsNil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cmp := completion.NewWaitGroup(ctx)
+
+	_, err, _, _ = ep.addNewRedirects(ep.desiredPolicy.L4Policy, cmp)
+	c.Assert(err, check.IsNil)
+	v, ok := ep.desiredPolicy.PolicyMapState[policy.Key{
+		Identity:         0,
+		DestPort:         uint16(80),
+		Nexthdr:          uint8(u8proto.TCP),
+		TrafficDirection: trafficdirection.Ingress.Uint8(),
+	}]
+	c.Assert(ok, check.Equals, true)
+	c.Assert(v.ProxyPort, check.Equals, httpPort)
+
+	secondAnno := map[string]string{
+		annotation.ProxyVisibility: "<Ingress/80/TCP/Kafka>",
+	}
+
+	ep.UpdateVisibilityPolicy(secondAnno)
+	d, err, _, _ := ep.addNewRedirects(ep.desiredPolicy.L4Policy, cmp)
+	c.Assert(err, check.IsNil)
+	v, ok = ep.desiredPolicy.PolicyMapState[policy.Key{
+		Identity:         0,
+		DestPort:         uint16(80),
+		Nexthdr:          uint8(u8proto.TCP),
+		TrafficDirection: trafficdirection.Ingress.Uint8(),
+	}]
+	c.Assert(ok, check.Equals, true)
+	// Check that proxyport was updated accordingly.
+	c.Assert(v.ProxyPort, check.Equals, kafkaPort)
+
+	thirdAnno := map[string]string{
+		annotation.ProxyVisibility: "<Ingress/80/TCP/Kafka>,<Egress/80/TCP/HTTP>",
+	}
+
+	// Check that multiple values in annotation are handled correctly.
+	ep.UpdateVisibilityPolicy(thirdAnno)
+	_, err, _, _ = ep.addNewRedirects(ep.desiredPolicy.L4Policy, cmp)
+	c.Assert(err, check.IsNil)
+	v, ok = ep.desiredPolicy.PolicyMapState[policy.Key{
+		Identity:         0,
+		DestPort:         uint16(80),
+		Nexthdr:          uint8(u8proto.TCP),
+		TrafficDirection: trafficdirection.Ingress.Uint8(),
+	}]
+	c.Assert(ok, check.Equals, true)
+	c.Assert(v.ProxyPort, check.Equals, kafkaPort)
+
+	v, ok = ep.desiredPolicy.PolicyMapState[policy.Key{
+		Identity:         0,
+		DestPort:         uint16(80),
+		Nexthdr:          uint8(u8proto.TCP),
+		TrafficDirection: trafficdirection.Ingress.Uint8(),
+	}]
+	c.Assert(ok, check.Equals, true)
+	c.Assert(v.ProxyPort, check.Equals, kafkaPort)
+
+	v, ok = ep.desiredPolicy.PolicyMapState[policy.Key{
+		Identity:         0,
+		DestPort:         uint16(80),
+		Nexthdr:          uint8(u8proto.TCP),
+		TrafficDirection: trafficdirection.Egress.Uint8(),
+	}]
+	c.Assert(ok, check.Equals, true)
+	c.Assert(v.ProxyPort, check.Equals, httpPort)
+	pID := policy.ProxyID(ep.ID, false, u8proto.TCP.String(), uint16(80))
+	p, ok := ep.realizedRedirects[pID]
+	c.Assert(ok, check.Equals, true)
+	c.Assert(p, check.Equals, httpPort)
+
+	// Check that the egress redirect is removed when the redirects have been
+	// updated.
+	ep.removeOldRedirects(d, cmp)
+	// Egress redirect should be removed.
+	_, ok = ep.realizedRedirects[pID]
+	c.Assert(ok, check.Equals, false)
+
+	// Check that all redirects are removed when no visibility policy applies.
+	noAnno := map[string]string{}
+	ep.UpdateVisibilityPolicy(noAnno)
+	d, err, _, _ = ep.addNewRedirects(ep.desiredPolicy.L4Policy, cmp)
+	c.Assert(err, check.IsNil)
+	ep.removeOldRedirects(d, cmp)
+	c.Assert(len(ep.realizedRedirects), check.Equals, 0)
+}

--- a/pkg/k8s/factory_functions.go
+++ b/pkg/k8s/factory_functions.go
@@ -194,12 +194,29 @@ func EqualV2CNP(cnp1, cnp2 *types.SlimCNP) bool {
 		reflect.DeepEqual(cnp1.Specs, cnp2.Specs)
 }
 
+// AnnotationsEqual returns whether the annotation with any key in
+// relevantAnnotations is equal in anno1 and anno2.
+func AnnotationsEqual(relevantAnnotations []string, anno1, anno2 map[string]string) bool {
+	for i := range relevantAnnotations {
+		an := relevantAnnotations[i]
+		if anno1[an] != anno2[an] {
+			return false
+		}
+	}
+	return true
+}
+
 func EqualV1Pod(pod1, pod2 *types.Pod) bool {
 	// We only care about the HostIP, the PodIP and the labels of the pods.
 	if pod1.StatusPodIP != pod2.StatusPodIP ||
 		pod1.StatusHostIP != pod2.StatusHostIP {
 		return false
 	}
+
+	if !AnnotationsEqual([]string{annotation.ProxyVisibility}, pod1.GetAnnotations(), pod2.GetAnnotations()) {
+		return false
+	}
+
 	oldPodLabels := pod1.GetLabels()
 	newPodLabels := pod2.GetLabels()
 	return comparator.MapStringEquals(oldPodLabels, newPodLabels)

--- a/pkg/k8s/factory_functions.go
+++ b/pkg/k8s/factory_functions.go
@@ -197,8 +197,7 @@ func EqualV2CNP(cnp1, cnp2 *types.SlimCNP) bool {
 // AnnotationsEqual returns whether the annotation with any key in
 // relevantAnnotations is equal in anno1 and anno2.
 func AnnotationsEqual(relevantAnnotations []string, anno1, anno2 map[string]string) bool {
-	for i := range relevantAnnotations {
-		an := relevantAnnotations[i]
+	for _, an := range relevantAnnotations {
 		if anno1[an] != anno2[an] {
 			return false
 		}

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -94,8 +94,9 @@ func isInjectedWithIstioSidecarProxy(scopedLog *logrus.Entry, pod *corev1.Pod) b
 	return false
 }
 
-// GetPodLabels returns the labels of a pod
-func GetPodLabels(namespace, podName string) (lbls map[string]string, retAnno map[string]string, retErr error) {
+// GetPodMetadata returns the labels and annotations of the pod with the given
+// namespace / name.
+func GetPodMetadata(namespace, podName string) (lbls map[string]string, retAnno map[string]string, retErr error) {
 	scopedLog := log.WithFields(logrus.Fields{
 		logfields.K8sNamespace: namespace,
 		logfields.K8sPodName:   podName,

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -74,6 +74,15 @@ func (l7 L7DataMap) MarshalJSON() ([]byte, error) {
 	return buffer.Bytes(), err
 }
 
+// ShallowCopy returns a shallow copy of the L7DataMap.
+func (l7 L7DataMap) ShallowCopy() L7DataMap {
+	m := make(L7DataMap, len(l7))
+	for k, v := range l7 {
+		m[k] = v
+	}
+	return m
+}
+
 // L7ParserType is the type used to indicate what L7 parser to use.
 // Consts are defined for all well known L7 parsers.
 // Unknown string values are created for key-value pair policies, which
@@ -132,14 +141,10 @@ type L4Filter struct {
 	policy unsafe.Pointer // *L4Policy
 }
 
-// CopyL7RulesPerEndpoint creates a copy of the L7RulesPerEp of the L4Filter.
+// CopyL7RulesPerEndpoint returns a shallow copy of the L7RulesPerEp of the
+// L4Filter.
 func (l4 *L4Filter) CopyL7RulesPerEndpoint() L7DataMap {
-	m := make(L7DataMap, len(l4.L7RulesPerEp))
-	for k, v := range l4.L7RulesPerEp {
-		m[k] = v
-	}
-	return m
-
+	return l4.L7RulesPerEp.ShallowCopy()
 }
 
 // GetL7Parser returns the L7ParserType of the L4Filter.

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -132,6 +132,31 @@ type L4Filter struct {
 	policy unsafe.Pointer // *L4Policy
 }
 
+// CopyL7RulesPerEndpoint creates a copy of the L7RulesPerEp of the L4Filter.
+func (l4 *L4Filter) CopyL7RulesPerEndpoint() L7DataMap {
+	m := make(L7DataMap, len(l4.L7RulesPerEp))
+	for k, v := range l4.L7RulesPerEp {
+		m[k] = v
+	}
+	return m
+
+}
+
+// GetL7Parser returns the L7ParserType of the L4Filter.
+func (l4 *L4Filter) GetL7Parser() L7ParserType {
+	return l4.L7Parser
+}
+
+// GetIngress returns whether the L4Filter applies at ingress or egress.
+func (l4 *L4Filter) GetIngress() bool {
+	return l4.Ingress
+}
+
+// GetPort returns the port at which the L4Filter applies as a uint16.
+func (l4 *L4Filter) GetPort() uint16 {
+	return uint16(l4.Port)
+}
+
 // AllowsAllAtL3 returns whether this L4Filter applies to all endpoints at L3.
 func (l4 *L4Filter) AllowsAllAtL3() bool {
 	return l4.allowsAllAtL3
@@ -657,4 +682,13 @@ func (l4 *L4Policy) GetModel() *models.L4Policy {
 		Ingress: ingress,
 		Egress:  egress,
 	}
+}
+
+// ProxyPolicy is any type which encodes state needed to redirect to an L7
+// proxy.
+type ProxyPolicy interface {
+	CopyL7RulesPerEndpoint() L7DataMap
+	GetL7Parser() L7ParserType
+	GetIngress() bool
+	GetPort() uint16
 }

--- a/pkg/policy/visibility.go
+++ b/pkg/policy/visibility.go
@@ -23,7 +23,7 @@ import (
 	"github.com/cilium/cilium/pkg/u8proto"
 )
 
-var annotationRegex = regexp.MustCompile("^((<(Ingress|Egress)/([0-9]{1,6})/(TCP|UDP|ANY)/([A-Za-z]{3,32})>,)+)$")
+var annotationRegex = regexp.MustCompile("`^((<(Ingress|Egress)/([0-9]{1,6})/(TCP|UDP|ANY)/([A-Za-z]{3,32})>)(,(<(Ingress|Egress)/([0-9]{1,6})/(TCP|UDP|ANY)/([A-Za-z]{3,32})>))*)$`")
 
 func validateL7ProtocolWithDirection(dir string, proto L7ParserType) error {
 	switch proto {
@@ -52,10 +52,6 @@ func validateL7ProtocolWithDirection(dir string, proto L7ParserType) error {
 // * if there is a conflict between the state encoded in the annotation (e.g.,
 //   different L7 protocols for the same L4 port / protocol / traffic direction.
 func NewVisibilityPolicy(anno string) (*VisibilityPolicy, error) {
-	// Add a trailing comma so we can match the regex for now.
-	if anno[len(anno)-1] != ',' {
-		anno = anno + ","
-	}
 	if !annotationRegex.MatchString(anno) {
 		return nil, fmt.Errorf("annotation for proxy visibility did not match expected format %s", annotationRegex.String())
 	}
@@ -67,10 +63,6 @@ func NewVisibilityPolicy(anno string) (*VisibilityPolicy, error) {
 
 	anSplit := strings.Split(anno, ",")
 	for i := range anSplit {
-		// Avoid empty string
-		if len(anSplit[i]) == 0 {
-			continue
-		}
 		proxyAnnoSplit := strings.Split(anSplit[i], "/")
 		if len(proxyAnnoSplit) != 4 {
 			err := fmt.Errorf("invalid number of fields (%d) in annotation", len(proxyAnnoSplit))

--- a/pkg/policy/visibility.go
+++ b/pkg/policy/visibility.go
@@ -24,7 +24,7 @@ import (
 )
 
 var (
-	singleAnnotationRegex = "<(Ingress|Egress)/([0-9]{1,6})/(TCP|UDP|ANY)/([A-Za-z]{3,32})>"
+	singleAnnotationRegex = "<(Ingress|Egress)/([1-9][0-9]{1,5})/(TCP|UDP|ANY)/([A-Za-z]{3,32})>"
 	annotationRegex       = regexp.MustCompile(fmt.Sprintf(`^((%s)(,(%s))*)$`, singleAnnotationRegex, singleAnnotationRegex))
 )
 

--- a/pkg/policy/visibility.go
+++ b/pkg/policy/visibility.go
@@ -1,0 +1,181 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/cilium/cilium/pkg/u8proto"
+)
+
+var annotationRegex = regexp.MustCompile("^((<(Ingress|Egress)/([0-9]{1,6})/(TCP|UDP|ANY)/([A-Za-z]{3,32})>,)+)$")
+
+func validateL7ProtocolWithDirection(dir string, proto L7ParserType) error {
+	switch proto {
+	case ParserTypeHTTP:
+		return nil
+	case ParserTypeDNS:
+		if dir == "Egress" {
+			return nil
+		}
+	case ParserTypeKafka:
+		if dir == "Ingress" {
+			return nil
+		}
+	default:
+		return fmt.Errorf("unsupported parser type %s", proto)
+
+	}
+	return fmt.Errorf("%s not allowed with direction %s", proto, dir)
+}
+
+// NewVisibilityPolicy generates the VisibilityPolicy that is encoded in the
+// annotation parameter.
+// Returns an error:
+// * if the annotation does not correspond to the expected
+//   format for a visibility annotation.
+// * if there is a conflict between the state encoded in the annotation (e.g.,
+//   different L7 protocols for the same L4 port / protocol / traffic direction.
+func NewVisibilityPolicy(anno string) (*VisibilityPolicy, error) {
+	// Add a trailing comma so we can match the regex for now.
+	if anno[len(anno)-1] != ',' {
+		anno = anno + ","
+	}
+	if !annotationRegex.MatchString(anno) {
+		return nil, fmt.Errorf("annotation for proxy visibility did not match expected format %s", annotationRegex.String())
+	}
+
+	nvp := &VisibilityPolicy{
+		Ingress: make(DirectionalVisibilityPolicy),
+		Egress:  make(DirectionalVisibilityPolicy),
+	}
+
+	anSplit := strings.Split(anno, ",")
+	for i := range anSplit {
+		// Avoid empty string
+		if len(anSplit[i]) == 0 {
+			continue
+		}
+		proxyAnnoSplit := strings.Split(anSplit[i], "/")
+		if len(proxyAnnoSplit) != 4 {
+			err := fmt.Errorf("invalid number of fields (%d) in annotation", len(proxyAnnoSplit))
+			return nil, err
+		}
+		// <Ingress|Egress --> Ingress|Egress
+		// Don't need to validate the content itself, regex already did that.
+		direction := proxyAnnoSplit[0][1:]
+		port := proxyAnnoSplit[1]
+		portInt, err := strconv.Atoi(port)
+		if err != nil {
+			err = fmt.Errorf("annotation for proxy visibility did not conform to expected format: %s", err)
+			return nil, err
+		}
+		// Don't need to validate, regex already did that.
+		l4Proto := proxyAnnoSplit[2]
+		u8Prot, err := u8proto.ParseProtocol(l4Proto)
+		if err != nil {
+			return nil, fmt.Errorf("invalid L4 protocol %s", l4Proto)
+		}
+		// Remove trailing '>'.
+		l7Protocol := L7ParserType(strings.ToLower(proxyAnnoSplit[3][:len(proxyAnnoSplit[3])-1]))
+
+		if err := validateL7ProtocolWithDirection(direction, l7Protocol); err != nil {
+			return nil, err
+		}
+
+		var dvp DirectionalVisibilityPolicy
+		var ingress bool
+		if direction == "Ingress" {
+			dvp = nvp.Ingress
+			ingress = true
+		} else {
+			dvp = nvp.Egress
+			ingress = false
+		}
+
+		pp := fmt.Sprintf("%d/%s", portInt, l4Proto)
+		if res, ok := dvp[pp]; ok {
+			if res.Parser != l7Protocol {
+				return nil, fmt.Errorf("duplicate annotations with different L7 protocols %s and %s for %s", res.Parser, l7Protocol, pp)
+			}
+		}
+		dvp[pp] = &VisibilityMetadata{
+			Parser:  l7Protocol,
+			Port:    uint16(portInt),
+			Proto:   u8Prot,
+			Ingress: ingress,
+		}
+	}
+
+	return nvp, nil
+}
+
+// VisibilityMetadata encodes state about what type of traffic should be
+// redirected to an L7Proxy. Implements the ProxyPolicy interface.
+// TODO: an L4Filter could be composed of this type.
+type VisibilityMetadata struct {
+	// Parser represents the proxy to which traffic should be redirected.
+	Parser L7ParserType
+
+	// Port, in tandem with Proto, signifies which L4 port for which traffic
+	// should be redirected.
+	Port uint16
+
+	// Proto, in tandem with port, signifies which L4 protocol for which traffic
+	// should be redirected.
+	Proto u8proto.U8proto
+
+	// Ingress specifies whether ingress traffic at the given L4 port / protocol
+	// should be redirected to the proxy.
+	Ingress bool
+}
+
+// DirectionalVisibilityPolicy is a mapping of VisibilityMetadata keyed by
+// L4 Port / L4 Protocol (e.g., 80/TCP) for a given traffic direction (e.g.,
+// ingress or egress). This encodes at which L4 Port / L4 Protocol traffic
+// should be redirected to a given L7 proxy. An empty instance of this type
+// indicates that no traffic should be redirected.
+type DirectionalVisibilityPolicy map[string]*VisibilityMetadata
+
+// VisibilityPolicy represents for both ingress and egress which types of
+// traffic should be redirected to a given L7 proxy.
+type VisibilityPolicy struct {
+	Ingress DirectionalVisibilityPolicy
+	Egress  DirectionalVisibilityPolicy
+}
+
+// CopyL7RulesPerEndpoint does nothing.
+func (v *VisibilityMetadata) CopyL7RulesPerEndpoint() L7DataMap {
+	return nil
+}
+
+// GetL7Parser returns the L7ParserType for this VisibilityMetadata.
+func (v *VisibilityMetadata) GetL7Parser() L7ParserType {
+	return v.Parser
+}
+
+// GetIngress returns whether the VisibilityMetadata applies at ingress or
+// egress.
+func (v *VisibilityMetadata) GetIngress() bool {
+	return v.Ingress
+}
+
+// GetPort returns at which port the VisibilityMetadata applies.
+func (v *VisibilityMetadata) GetPort() uint16 {
+	return v.Port
+}

--- a/pkg/policy/visibility.go
+++ b/pkg/policy/visibility.go
@@ -23,7 +23,7 @@ import (
 	"github.com/cilium/cilium/pkg/u8proto"
 )
 
-var annotationRegex = regexp.MustCompile("`^((<(Ingress|Egress)/([0-9]{1,6})/(TCP|UDP|ANY)/([A-Za-z]{3,32})>)(,(<(Ingress|Egress)/([0-9]{1,6})/(TCP|UDP|ANY)/([A-Za-z]{3,32})>))*)$`")
+var annotationRegex = regexp.MustCompile(`^((<(Ingress|Egress)/([0-9]{1,6})/(TCP|UDP|ANY)/([A-Za-z]{3,32})>)(,(<(Ingress|Egress)/([0-9]{1,6})/(TCP|UDP|ANY)/([A-Za-z]{3,32})>))*)$`)
 
 func validateL7ProtocolWithDirection(dir string, proto L7ParserType) error {
 	switch proto {
@@ -61,6 +61,7 @@ func NewVisibilityPolicy(anno string) (*VisibilityPolicy, error) {
 		Egress:  make(DirectionalVisibilityPolicy),
 	}
 
+	// TODO: look into using regex groups.
 	anSplit := strings.Split(anno, ",")
 	for i := range anSplit {
 		proxyAnnoSplit := strings.Split(anSplit[i], "/")

--- a/pkg/policy/visibility.go
+++ b/pkg/policy/visibility.go
@@ -77,7 +77,7 @@ func NewVisibilityPolicy(anno string) (*VisibilityPolicy, error) {
 		direction := proxyAnnoSplit[0][1:]
 		port := proxyAnnoSplit[1]
 
-		portInt, err := strconv.ParseUint(port, 0, 16)
+		portInt, err := strconv.ParseUint(port, 10, 16)
 		if err != nil {
 			return nil, fmt.Errorf("unable to parse port: %s", err)
 		}

--- a/pkg/policy/visibility.go
+++ b/pkg/policy/visibility.go
@@ -82,10 +82,6 @@ func NewVisibilityPolicy(anno string) (*VisibilityPolicy, error) {
 			return nil, fmt.Errorf("unable to parse port: %s", err)
 		}
 
-		if portInt == 0 {
-			return nil, fmt.Errorf("port cannot be 0")
-		}
-
 		// Don't need to validate, regex already did that.
 		l4Proto := proxyAnnoSplit[2]
 		u8Prot, err := u8proto.ParseProtocol(l4Proto)

--- a/pkg/policy/visibility.go
+++ b/pkg/policy/visibility.go
@@ -23,7 +23,10 @@ import (
 	"github.com/cilium/cilium/pkg/u8proto"
 )
 
-var annotationRegex = regexp.MustCompile(`^((<(Ingress|Egress)/([0-9]{1,6})/(TCP|UDP|ANY)/([A-Za-z]{3,32})>)(,(<(Ingress|Egress)/([0-9]{1,5})/(TCP|UDP|ANY)/([A-Za-z]{3,32})>))*)$`)
+var (
+	singleAnnotationRegex = "<(Ingress|Egress)/([0-9]{1,6})/(TCP|UDP|ANY)/([A-Za-z]{3,32})>"
+	annotationRegex       = regexp.MustCompile(fmt.Sprintf(`^((%s)(,(%s))*)$`, singleAnnotationRegex, singleAnnotationRegex))
+)
 
 func validateL7ProtocolWithDirection(dir string, proto L7ParserType) error {
 	switch proto {

--- a/pkg/policy/visibility_test.go
+++ b/pkg/policy/visibility_test.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // +build !privileged_tests
 
 package policy

--- a/pkg/policy/visibility_test.go
+++ b/pkg/policy/visibility_test.go
@@ -97,4 +97,16 @@ func (ds *PolicyTestSuite) TestVisibilityPolicyCreation(c *C) {
 	vp, err = NewVisibilityPolicy(anno)
 	c.Assert(vp, IsNil)
 	c.Assert(err, Not(IsNil))
+
+	// Do not allow > 5 digits.
+	anno = "<Ingress/123456/TCP/HTTP"
+	vp, err = NewVisibilityPolicy(anno)
+	c.Assert(vp, IsNil)
+	c.Assert(err, Not(IsNil))
+
+	// Do not allow leading zeroes.
+	anno = "<Ingress/02345/TCP/HTTP"
+	vp, err = NewVisibilityPolicy(anno)
+	c.Assert(vp, IsNil)
+	c.Assert(err, Not(IsNil))
 }

--- a/pkg/policy/visibility_test.go
+++ b/pkg/policy/visibility_test.go
@@ -77,4 +77,24 @@ func (ds *PolicyTestSuite) TestVisibilityPolicyCreation(c *C) {
 	vp, err = NewVisibilityPolicy(anno)
 	c.Assert(vp, IsNil)
 	c.Assert(err, Not(IsNil))
+
+	anno = "<Ingress/65536/TCP/HTTP>"
+	vp, err = NewVisibilityPolicy(anno)
+	c.Assert(vp, IsNil)
+	c.Assert(err, Not(IsNil))
+
+	anno = "<Ingress/65535/TCP/HTTP>"
+	vp, err = NewVisibilityPolicy(anno)
+	c.Assert(vp, Not(IsNil))
+	c.Assert(err, IsNil)
+
+	anno = "<Ingress/99999/TCP/HTTP>"
+	vp, err = NewVisibilityPolicy(anno)
+	c.Assert(vp, IsNil)
+	c.Assert(err, Not(IsNil))
+
+	anno = "<Ingress/0/TCP/HTTP>"
+	vp, err = NewVisibilityPolicy(anno)
+	c.Assert(vp, IsNil)
+	c.Assert(err, Not(IsNil))
 }

--- a/pkg/policy/visibility_test.go
+++ b/pkg/policy/visibility_test.go
@@ -1,0 +1,66 @@
+// +build !privileged_tests
+
+package policy
+
+import (
+	"github.com/cilium/cilium/pkg/u8proto"
+	. "gopkg.in/check.v1"
+)
+
+func (ds *PolicyTestSuite) TestVisibilityPolicyCreation(c *C) {
+
+	anno := "<Ingress/80/TCP/HTTP>"
+	vp, err := NewVisibilityPolicy(anno)
+	c.Assert(vp, Not(IsNil))
+	c.Assert(err, IsNil)
+
+	c.Assert(len(vp.Ingress), Equals, 1)
+	c.Assert(vp.Ingress["80/TCP"], DeepEquals, &VisibilityMetadata{
+		Proto:   u8proto.TCP,
+		Port:    uint16(80),
+		Parser:  ParserTypeHTTP,
+		Ingress: true,
+	})
+
+	anno = "<Ingress/80/TCP/HTTP>,<Ingress/8080/TCP/HTTP>"
+	vp, err = NewVisibilityPolicy(anno)
+	c.Assert(vp, Not(IsNil))
+	c.Assert(err, IsNil)
+
+	c.Assert(len(vp.Ingress), Equals, 2)
+	c.Assert(vp.Ingress["80/TCP"], DeepEquals, &VisibilityMetadata{
+		Proto:   u8proto.TCP,
+		Port:    uint16(80),
+		Parser:  ParserTypeHTTP,
+		Ingress: true,
+	})
+	c.Assert(vp.Ingress["8080/TCP"], DeepEquals, &VisibilityMetadata{
+		Proto:   u8proto.TCP,
+		Port:    uint16(8080),
+		Parser:  ParserTypeHTTP,
+		Ingress: true,
+	})
+
+	anno = "<Ingress/80/TCP/HTTP>,<Ingress/80/TCP/HTTP>"
+	vp, err = NewVisibilityPolicy(anno)
+	c.Assert(vp, Not(IsNil))
+	c.Assert(err, IsNil)
+
+	c.Assert(len(vp.Ingress), Equals, 1)
+	c.Assert(vp.Ingress["80/TCP"], DeepEquals, &VisibilityMetadata{
+		Proto:   u8proto.TCP,
+		Port:    uint16(80),
+		Parser:  ParserTypeHTTP,
+		Ingress: true,
+	})
+
+	anno = "<Ingress/80/TCP/HTTP>,<Ingress/80/TCP/Kafka>"
+	vp, err = NewVisibilityPolicy(anno)
+	c.Assert(vp, IsNil)
+	c.Assert(err, Not(IsNil))
+
+	anno = "asdf"
+	vp, err = NewVisibilityPolicy(anno)
+	c.Assert(vp, IsNil)
+	c.Assert(err, Not(IsNil))
+}

--- a/pkg/proxy/dns.go
+++ b/pkg/proxy/dns.go
@@ -94,7 +94,7 @@ func (dr *dnsRedirect) setRules(wg *completion.WaitGroup, newRules policy.L7Data
 // UpdateRules atomically replaces the proxy rules in effect for this redirect.
 // It is not aware of revision number and doesn't account for out-of-order
 // calls to UpdateRules or the returned RevertFunc.
-func (dr *dnsRedirect) UpdateRules(wg *completion.WaitGroup, l4 *policy.L4Filter) (revert.RevertFunc, error) {
+func (dr *dnsRedirect) UpdateRules(wg *completion.WaitGroup) (revert.RevertFunc, error) {
 	oldRules := dr.currentRules
 	err := dr.setRules(wg, dr.redirect.rules)
 	revertFunc := func() error {

--- a/pkg/proxy/envoyproxy.go
+++ b/pkg/proxy/envoyproxy.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/option"
-	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/revert"
 )
 
@@ -65,7 +64,7 @@ func createEnvoyRedirect(r *Redirect, stateDir string, xdsServer *envoy.XDSServe
 
 // UpdateRules is a no-op for envoy, as redirect data is synchronized via the
 // xDS cache.
-func (k *envoyRedirect) UpdateRules(wg *completion.WaitGroup, l4 *policy.L4Filter) (revert.RevertFunc, error) {
+func (k *envoyRedirect) UpdateRules(wg *completion.WaitGroup) (revert.RevertFunc, error) {
 	return func() error { return nil }, nil
 }
 

--- a/pkg/proxy/kafka.go
+++ b/pkg/proxy/kafka.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cilium/cilium/pkg/kafka"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/proxy/logger"
@@ -514,7 +513,7 @@ func (k *kafkaRedirect) handleResponseConnection(pair *connectionPair, correlati
 
 // UpdateRules is a no-op for kafka redirects, as rules are read directly
 // during request processing.
-func (k *kafkaRedirect) UpdateRules(wg *completion.WaitGroup, l4 *policy.L4Filter) (revert.RevertFunc, error) {
+func (k *kafkaRedirect) UpdateRules(wg *completion.WaitGroup) (revert.RevertFunc, error) {
 	return func() error { return nil }, nil
 }
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -393,7 +393,7 @@ func (p *Proxy) ReinstallRules() {
 // The proxy listening port is returned, but proxy configuration on that port
 // may still be ongoing asynchronously. Caller should wait for successful completion
 // on 'wg' before assuming the returned proxy port is listening.
-func (p *Proxy) CreateOrUpdateRedirect(l4 *policy.L4Filter, id string, localEndpoint logger.EndpointUpdater,
+func (p *Proxy) CreateOrUpdateRedirect(l4 policy.ProxyPolicy, id string, localEndpoint logger.EndpointUpdater,
 	wg *completion.WaitGroup) (proxyPort uint16, err error, finalizeFunc revert.FinalizeFunc, revertFunc revert.RevertFunc) {
 
 	p.mutex.Lock()
@@ -413,11 +413,11 @@ func (p *Proxy) CreateOrUpdateRedirect(l4 *policy.L4Filter, id string, localEndp
 	if redir, ok := p.redirects[id]; ok {
 		redir.mutex.Lock()
 
-		if redir.listener.parserType == l4.L7Parser {
+		if redir.listener.parserType == l4.GetL7Parser() {
 			updateRevertFunc := redir.updateRules(l4)
 			revertStack.Push(updateRevertFunc)
 			var implUpdateRevertFunc revert.RevertFunc
-			implUpdateRevertFunc, err = redir.implementation.UpdateRules(wg, l4)
+			implUpdateRevertFunc, err = redir.implementation.UpdateRules(wg)
 			if err != nil {
 				err = fmt.Errorf("unable to update existing redirect: %s", err)
 				return 0, err, nil, nil
@@ -427,7 +427,7 @@ func (p *Proxy) CreateOrUpdateRedirect(l4 *policy.L4Filter, id string, localEndp
 			redir.lastUpdated = time.Now()
 
 			scopedLog.WithField(logfields.Object, logfields.Repr(redir)).
-				Debug("updated existing ", l4.L7Parser, " proxy instance")
+				Debug("updated existing ", l4.GetL7Parser(), " proxy instance")
 
 			redir.mutex.Unlock()
 
@@ -450,14 +450,14 @@ func (p *Proxy) CreateOrUpdateRedirect(l4 *policy.L4Filter, id string, localEndp
 
 	proxyPortsMutex.Lock()
 	defer proxyPortsMutex.Unlock()
-	pp := getProxyPort(l4.L7Parser, l4.Ingress)
+	pp := getProxyPort(l4.GetL7Parser(), l4.GetIngress())
 	if pp == nil {
-		err = proxyNotFoundError(l4.L7Parser, l4.Ingress)
+		err = proxyNotFoundError(l4.GetL7Parser(), l4.GetIngress())
 		revertFunc()
 		return 0, err, nil, nil
 	}
 
-	redir := newRedirect(localEndpoint, pp, uint16(l4.Port))
+	redir := newRedirect(localEndpoint, pp, l4.GetPort())
 	redir.updateRules(l4)
 	// Rely on create*Redirect to update rules, unlike the update case above.
 
@@ -477,7 +477,7 @@ func (p *Proxy) CreateOrUpdateRedirect(l4 *policy.L4Filter, id string, localEndp
 			}
 		}
 
-		switch l4.L7Parser {
+		switch l4.GetL7Parser() {
 		case policy.ParserTypeDNS:
 			redir.implementation, err = createDNSRedirect(redir, dnsConfiguration{}, DefaultEndpointInfoRegistry)
 
@@ -492,7 +492,7 @@ func (p *Proxy) CreateOrUpdateRedirect(l4 *policy.L4Filter, id string, localEndp
 
 		if err == nil {
 			scopedLog.WithField(logfields.Object, logfields.Repr(redir)).
-				Debug("Created new ", l4.L7Parser, " proxy instance")
+				Debug("Created new ", l4.GetL7Parser(), " proxy instance")
 			p.redirects[id] = redir
 			// must mark the proxyPort configured while we still hold the lock to prevent racing between
 			// two parallel runs
@@ -535,7 +535,7 @@ func (p *Proxy) CreateOrUpdateRedirect(l4 *policy.L4Filter, id string, localEndp
 	}
 
 	// an error occurred, and we have no more retries
-	scopedLog.WithError(err).Error("Unable to create ", l4.L7Parser, " proxy")
+	scopedLog.WithError(err).Error("Unable to create ", l4.GetL7Parser(), " proxy")
 	revertFunc() // Ignore errors while reverting. This is best-effort.
 	return 0, err, nil, nil
 }

--- a/pkg/proxy/redirect.go
+++ b/pkg/proxy/redirect.go
@@ -17,12 +17,11 @@ package proxy
 import (
 	"time"
 
-	"github.com/cilium/cilium/pkg/revert"
-
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy/logger"
+	"github.com/cilium/cilium/pkg/revert"
 )
 
 // RedirectImplementation is the generic proxy redirect interface that each

--- a/pkg/workloads/kubernetes.go
+++ b/pkg/workloads/kubernetes.go
@@ -33,5 +33,6 @@ func fetchK8sLabels(containerID string, containerLbls map[string]string) (map[st
 	if ns == "" {
 		ns = "default"
 	}
-	return k8s.GetPodLabels(ns, podName)
+	lbls, _, err := k8s.GetPodLabels(ns, podName)
+	return lbls, err
 }

--- a/pkg/workloads/kubernetes.go
+++ b/pkg/workloads/kubernetes.go
@@ -33,6 +33,6 @@ func fetchK8sLabels(containerID string, containerLbls map[string]string) (map[st
 	if ns == "" {
 		ns = "default"
 	}
-	lbls, _, err := k8s.GetPodLabels(ns, podName)
+	lbls, _, err := k8s.GetPodMetadata(ns, podName)
 	return lbls, err
 }


### PR DESCRIPTION
If a proxy-visibility annotation is added to an Endpoint
(`io.cilium.annotation.proxy-visibility`), and no policy applies to the endpoint
representing the pod which was annotated in the traffic direction specified
in the annotation, add a redirect to the proxy which will redirect traffic
at the given direction, L4 port / protocol, to the proxy corresponding to the
L7 parser in the annotation.

The value of the above annotation is expected to be of the following format:

```
<Traffic Direction/L4 Port/L4 Protocol/L7 Parser>,<...>
```

This format specifies a set of tuples which represent which traffic should be
redirected for the given pod which has been annotated. If policy selects the
Endpoint in the traffic direction which also has been set in the
proxy-visibility annotation, then the proxy-visibility annotation currently does
not take effect. In other words, visibility annotations only work in a given
traffic direction for a pod if no policy applies in that traffic direction.

If any of the tuples in the annotation are improperly formatted (e.g., fields
out of order, port bigger than 16 bits), an empty visibility policy is created
for the Endpoint with the annotation. This means that no L7 visibility will
be in place if any of the tuples are improperly formatted.

Update the equality check for Pods to check whether the new annotation,
`io.cilium.proxy-visibility` is present in the new set of annotations,
but not present in the old one, and vice-versa. If so, plumb the annotations
into the Endpoint itself, and trigger a regeneration.

Signed-off by: Ian Vernon <ian@cilium.io>

TODO's / follow-ups:

- [ ] Remove need to force policy computation to make sure that pointer comparison in policy map syncing fails. 
- [ ] Make L4Filter compose `VisibilityMetadata`.
- [ ] Apply visibility policy in cases where policy does apply for a given l4 port / protocol.

```release-note
Add support for L7 visibility via pod annotations
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9210)
<!-- Reviewable:end -->
