### PR TITLE
service: Simplify logic of svc ID allocation

### DIFF
--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -1256,24 +1256,6 @@ func (d *Daemon) addK8sSVCs(svcID k8s.ServiceID, svc *k8s.Service, endpoints *k8
 
 		uniqPorts[fePort.Port] = false
 
-		feAddr := loadbalancer.NewL3n4Addr(fePort.Protocol, svc.FrontendIP, fePort.Port)
-		feAddrID, err := service.AcquireID(*feAddr, 0)
-		if err != nil {
-			scopedLog.WithError(err).WithFields(logrus.Fields{
-				logfields.ServiceID: fePortName,
-				logfields.IPAddr:    svc.FrontendIP,
-				logfields.Port:      fePort.Port,
-				logfields.Protocol:  fePort.Protocol,
-			}).Error("Error while getting a new service ID. Ignoring service...")
-			continue
-		}
-		scopedLog.WithFields(logrus.Fields{
-			logfields.ServiceName: fePortName,
-			logfields.ServiceID:   feAddrID.ID,
-			logfields.Object:      logfields.Repr(svc),
-		}).Debug("Got feAddr ID for service")
-		fePort.ID = loadbalancer.ServiceID(feAddrID.ID)
-
 		type frontend struct {
 			addr     *loadbalancer.L3n4AddrID
 			nodePort bool
@@ -1288,18 +1270,6 @@ func (d *Daemon) addK8sSVCs(svcID k8s.ServiceID, svc *k8s.Service, endpoints *k8
 			})
 
 		for _, nodePortFE := range svc.NodePorts[fePortName] {
-			feAddr := loadbalancer.NewL3n4Addr(nodePortFE.Protocol, nodePortFE.IP, nodePortFE.Port)
-			feAddrID, err := service.AcquireID(*feAddr, 0)
-			if err != nil {
-				scopedLog.WithError(err).WithFields(logrus.Fields{
-					logfields.ServiceID: fePortName,
-					logfields.IPAddr:    nodePortFE.IP,
-					logfields.Port:      nodePortFE.Port,
-					logfields.Protocol:  nodePortFE.Protocol,
-				}).Error("Error while getting a new nodeport service ID. Ignoring service...")
-				continue
-			}
-			nodePortFE.ID = feAddrID.ID
 			frontends = append(frontends, frontend{
 				addr:     nodePortFE,
 				nodePort: true,

--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -1287,7 +1287,7 @@ func (d *Daemon) addK8sSVCs(svcID k8s.ServiceID, svc *k8s.Service, endpoints *k8
 		}
 
 		for _, fe := range frontends {
-			if _, err := d.svcAdd(*fe.addr, besValues, true, fe.nodePort); err != nil {
+			if _, _, err := d.svcAdd(*fe.addr, besValues, true, fe.nodePort); err != nil {
 				scopedLog.WithError(err).Error("Error while inserting service in LB map")
 			}
 		}

--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -1256,25 +1256,23 @@ func (d *Daemon) addK8sSVCs(svcID k8s.ServiceID, svc *k8s.Service, endpoints *k8
 
 		uniqPorts[fePort.Port] = false
 
-		if fePort.ID == 0 {
-			feAddr := loadbalancer.NewL3n4Addr(fePort.Protocol, svc.FrontendIP, fePort.Port)
-			feAddrID, err := service.AcquireID(*feAddr, 0)
-			if err != nil {
-				scopedLog.WithError(err).WithFields(logrus.Fields{
-					logfields.ServiceID: fePortName,
-					logfields.IPAddr:    svc.FrontendIP,
-					logfields.Port:      fePort.Port,
-					logfields.Protocol:  fePort.Protocol,
-				}).Error("Error while getting a new service ID. Ignoring service...")
-				continue
-			}
-			scopedLog.WithFields(logrus.Fields{
-				logfields.ServiceName: fePortName,
-				logfields.ServiceID:   feAddrID.ID,
-				logfields.Object:      logfields.Repr(svc),
-			}).Debug("Got feAddr ID for service")
-			fePort.ID = loadbalancer.ServiceID(feAddrID.ID)
+		feAddr := loadbalancer.NewL3n4Addr(fePort.Protocol, svc.FrontendIP, fePort.Port)
+		feAddrID, err := service.AcquireID(*feAddr, 0)
+		if err != nil {
+			scopedLog.WithError(err).WithFields(logrus.Fields{
+				logfields.ServiceID: fePortName,
+				logfields.IPAddr:    svc.FrontendIP,
+				logfields.Port:      fePort.Port,
+				logfields.Protocol:  fePort.Protocol,
+			}).Error("Error while getting a new service ID. Ignoring service...")
+			continue
 		}
+		scopedLog.WithFields(logrus.Fields{
+			logfields.ServiceName: fePortName,
+			logfields.ServiceID:   feAddrID.ID,
+			logfields.Object:      logfields.Repr(svc),
+		}).Debug("Got feAddr ID for service")
+		fePort.ID = loadbalancer.ServiceID(feAddrID.ID)
 
 		type frontend struct {
 			addr     *loadbalancer.L3n4AddrID
@@ -1290,20 +1288,18 @@ func (d *Daemon) addK8sSVCs(svcID k8s.ServiceID, svc *k8s.Service, endpoints *k8
 			})
 
 		for _, nodePortFE := range svc.NodePorts[fePortName] {
-			if nodePortFE.ID == 0 {
-				feAddr := loadbalancer.NewL3n4Addr(nodePortFE.Protocol, nodePortFE.IP, nodePortFE.Port)
-				feAddrID, err := service.AcquireID(*feAddr, 0)
-				if err != nil {
-					scopedLog.WithError(err).WithFields(logrus.Fields{
-						logfields.ServiceID: fePortName,
-						logfields.IPAddr:    nodePortFE.IP,
-						logfields.Port:      nodePortFE.Port,
-						logfields.Protocol:  nodePortFE.Protocol,
-					}).Error("Error while getting a new nodeport service ID. Ignoring service...")
-					continue
-				}
-				nodePortFE.ID = feAddrID.ID
+			feAddr := loadbalancer.NewL3n4Addr(nodePortFE.Protocol, nodePortFE.IP, nodePortFE.Port)
+			feAddrID, err := service.AcquireID(*feAddr, 0)
+			if err != nil {
+				scopedLog.WithError(err).WithFields(logrus.Fields{
+					logfields.ServiceID: fePortName,
+					logfields.IPAddr:    nodePortFE.IP,
+					logfields.Port:      nodePortFE.Port,
+					logfields.Protocol:  nodePortFE.Protocol,
+				}).Error("Error while getting a new nodeport service ID. Ignoring service...")
+				continue
 			}
+			nodePortFE.ID = feAddrID.ID
 			frontends = append(frontends, frontend{
 				addr:     nodePortFE,
 				nodePort: true,

--- a/daemon/loadbalancer.go
+++ b/daemon/loadbalancer.go
@@ -66,27 +66,8 @@ func (d *Daemon) SVCAdd(feL3n4Addr loadbalancer.L3n4AddrID, be []loadbalancer.LB
 	if feL3n4Addr.ID == 0 {
 		return false, fmt.Errorf("invalid service ID 0")
 	}
-	// Check if the service is already registered with this ID.
-	feAddr, err := service.GetID(uint32(feL3n4Addr.ID))
-	if err != nil {
-		return false, fmt.Errorf("unable to get service %d: %s", feL3n4Addr.ID, err)
-	}
-	if feAddr == nil {
-		feAddr, err = service.AcquireID(feL3n4Addr.L3n4Addr, uint32(feL3n4Addr.ID))
-		if err != nil {
-			return false, fmt.Errorf("unable to store service %s in kvstore: %s", feL3n4Addr.String(), err)
-		}
-		// This won't be atomic so we need to check if the baseID, feL3n4Addr.ID was given to the service
-		if feAddr.ID != feL3n4Addr.ID {
-			return false, fmt.Errorf("the service provided %s is already registered with ID %d, please use that ID instead of %d", feL3n4Addr.L3n4Addr.String(), feAddr.ID, feL3n4Addr.ID)
-		}
-	}
-
-	feAddr256Sum := feAddr.L3n4Addr.SHA256Sum()
-	feL3n4Addr256Sum := feL3n4Addr.L3n4Addr.SHA256Sum()
-
-	if feAddr256Sum != feL3n4Addr256Sum {
-		return false, fmt.Errorf("service ID %d is already registered to L3n4Addr %s, please choose a different ID", feL3n4Addr.ID, feAddr.String())
+	if _, err := service.AcquireID(feL3n4Addr.L3n4Addr, uint32(feL3n4Addr.ID)); err != nil {
+		return false, fmt.Errorf("unable to store service %s in kvstore: %s", feL3n4Addr.String(), err)
 	}
 
 	return d.svcAdd(feL3n4Addr, be, addRevNAT, false)

--- a/pkg/maps/lbmap/types.go
+++ b/pkg/maps/lbmap/types.go
@@ -328,65 +328,6 @@ func L3n4Addr2RevNatKeynValue(svcID loadbalancer.ServiceID, feL3n4Addr loadbalan
 	return NewRevNat4Key(uint16(svcID)), NewRevNat4Value(feL3n4Addr.IP, feL3n4Addr.Port)
 }
 
-// serviceKey2L3n4Addr converts the given svcKey to a L3n4Addr.
-func serviceKey2L3n4Addr(svcKey ServiceKey) *loadbalancer.L3n4Addr {
-	log.WithField(logfields.ServiceID, svcKey).Debug("creating L3n4Addr for ServiceKey")
-	var (
-		feIP   net.IP
-		fePort uint16
-	)
-	if svcKey.IsIPv6() {
-		svc6Key := svcKey.(*Service6Key)
-		feIP = svc6Key.Address.IP()
-		fePort = svc6Key.Port
-	} else {
-		svc4Key := svcKey.(*Service4Key)
-		feIP = svc4Key.Address.IP()
-		fePort = svc4Key.Port
-	}
-	return loadbalancer.NewL3n4Addr(loadbalancer.NONE, feIP, fePort)
-}
-
-// serviceKeynValue2FEnBE converts the given svcKey and svcValue to a frontend in the
-// form of L3n4AddrID and backend in the form of L3n4Addr.
-func serviceKeynValue2FEnBE(svcKey ServiceKey, svcValue ServiceValue) (*loadbalancer.L3n4AddrID, *loadbalancer.LBBackEnd) {
-	var (
-		beIP     net.IP
-		svcID    loadbalancer.ID
-		bePort   uint16
-		beWeight uint16
-	)
-
-	log.WithFields(logrus.Fields{
-		logfields.ServiceID: svcKey,
-		logfields.Object:    logfields.Repr(svcValue),
-	}).Debug("converting ServiceKey and ServiceValue to frontend and backend")
-
-	if svcKey.IsIPv6() {
-		svc6Val := svcValue.(*Service6Value)
-		svcID = loadbalancer.ID(svc6Val.RevNat)
-		beIP = svc6Val.Address.IP()
-		bePort = svc6Val.Port
-		beWeight = svc6Val.Weight
-	} else {
-		svc4Val := svcValue.(*Service4Value)
-		svcID = loadbalancer.ID(svc4Val.RevNat)
-		beIP = svc4Val.Address.IP()
-		bePort = svc4Val.Port
-		beWeight = svc4Val.Weight
-	}
-
-	feL3n4Addr := serviceKey2L3n4Addr(svcKey)
-	beLBBackEnd := loadbalancer.NewLBBackEnd(0, loadbalancer.NONE, beIP, bePort, beWeight)
-
-	feL3n4AddrID := &loadbalancer.L3n4AddrID{
-		L3n4Addr: *feL3n4Addr,
-		ID:       svcID,
-	}
-
-	return feL3n4AddrID, beLBBackEnd
-}
-
 func serviceValue2L3n4Addr(svcVal ServiceValue) *loadbalancer.L3n4Addr {
 	var (
 		beIP   net.IP

--- a/pkg/service/id_kvstore.go
+++ b/pkg/service/id_kvstore.go
@@ -131,6 +131,10 @@ func setMaxID(key string, firstID, maxID uint32) error {
 // gasNewL3n4AddrID gets and sets a new L3n4Addr ID. If baseID is different than zero,
 // KVStore tries to assign that ID first.
 func gasNewL3n4AddrID(l3n4AddrID *loadbalancer.L3n4AddrID, baseID uint32) error {
+	var (
+		requireBaseID bool
+		requiredID    uint32
+	)
 	client := kvstore.Client()
 
 	if baseID == 0 {
@@ -139,6 +143,9 @@ func gasNewL3n4AddrID(l3n4AddrID *loadbalancer.L3n4AddrID, baseID uint32) error 
 		if err != nil {
 			return err
 		}
+	} else {
+		requireBaseID = true
+		requiredID = baseID
 	}
 
 	setIDtoL3n4Addr := func(id uint32) error {
@@ -198,6 +205,11 @@ func gasNewL3n4AddrID(l3n4AddrID *loadbalancer.L3n4AddrID, baseID uint32) error 
 			return err
 		} else if !retry {
 			return nil
+		} else {
+			if requireBaseID {
+				return fmt.Errorf("Service ID %d is already registered to other service",
+					requiredID)
+			}
 		}
 	}
 }

--- a/pkg/service/id_local.go
+++ b/pkg/service/id_local.go
@@ -81,9 +81,12 @@ func (alloc *IDAllocator) acquireLocalID(svc loadbalancer.L3n4Addr, desiredID ui
 	}
 
 	if desiredID != 0 {
-		if _, ok := alloc.entitiesID[desiredID]; !ok {
+		foundSVC, ok := alloc.entitiesID[desiredID]
+		if !ok {
 			return alloc.addID(svc, desiredID), nil
 		}
+		return nil, fmt.Errorf("Service ID %d is already registered to %q",
+			desiredID, foundSVC)
 	}
 
 	startingID := alloc.nextID

--- a/pkg/service/id_test.go
+++ b/pkg/service/id_test.go
@@ -40,6 +40,10 @@ var (
 		IP:     net.IPv6loopback,
 		L4Addr: loadbalancer.L4Addr{Port: 1, Protocol: "UDP"},
 	}
+	l3n4Addr4 = loadbalancer.L3n4Addr{
+		IP:     net.IPv6loopback,
+		L4Addr: loadbalancer.L4Addr{Port: 2, Protocol: "UDP"},
+	}
 	wantL3n4AddrID = &loadbalancer.L3n4AddrID{
 		ID:       123,
 		L3n4Addr: l3n4Addr2,
@@ -132,6 +136,11 @@ func (ds *ServiceTestSuite) TestServices(c *C) {
 	gotL3n4AddrID, err = AcquireID(l3n4Addr1, 99)
 	c.Assert(err, Equals, nil)
 	c.Assert(gotL3n4AddrID.ID, Equals, loadbalancer.ID(99))
+
+	// ID "99" has been already allocated to l3n4Addr1
+	gotL3n4AddrID, err = AcquireID(l3n4Addr4, 99)
+	c.Assert(err, NotNil)
+	c.Assert(gotL3n4AddrID, IsNil)
 }
 
 func (ds *ServiceTestSuite) TestGetMaxServiceID(c *C) {


### PR DESCRIPTION
This PR changes the logic of the service ID allocation which allows to simplify a code of the callers.

Previously, if a requested service ID had been allocated to another service, the allocation request silently allocated a new service ID. This behavior required additional checks at the caller side to validate whether the allocated ID and the requested ID were the same. This could lead to a service ID leak if the caller forgot to release the ID if the IDs were not the same.

The change is to return an error if a requested ID is already taken. This allows us to get rid of some boilerplate code when creating a service.

Reviewable per commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9213)
<!-- Reviewable:end -->
