### PR TITLE
pkg/k8s: add support for multi-stack

### DIFF
--- a/pkg/k8s/factory_functions.go
+++ b/pkg/k8s/factory_functions.go
@@ -471,6 +471,7 @@ func ConvertToNode(obj interface{}) interface{} {
 			ObjectMeta:      concreteObj.ObjectMeta,
 			StatusAddresses: concreteObj.Status.Addresses,
 			SpecPodCIDR:     concreteObj.Spec.PodCIDR,
+			SpecPodCIDRs:    concreteObj.Spec.PodCIDRs,
 		}
 		*concreteObj = v1.Node{}
 		return p
@@ -486,6 +487,7 @@ func ConvertToNode(obj interface{}) interface{} {
 				ObjectMeta:      node.ObjectMeta,
 				StatusAddresses: node.Status.Addresses,
 				SpecPodCIDR:     node.Spec.PodCIDR,
+				SpecPodCIDRs:    node.Spec.PodCIDRs,
 			},
 		}
 		*node = v1.Node{}

--- a/pkg/k8s/types/types.go
+++ b/pkg/k8s/types/types.go
@@ -64,6 +64,7 @@ type Node struct {
 	Type            v1.NodeAddressType
 	StatusAddresses []v1.NodeAddress
 	SpecPodCIDR     string
+	SpecPodCIDRs    []string
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
Kubernetes has introduced support for multi-stack environments. This
commit adds the missing integration with k8s for multi-stack.

Signed-off-by: André Martins <andre@cilium.io>

Fixes: https://github.com/cilium/cilium/issues/9214

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9215)
<!-- Reviewable:end -->
