### PR TITLE
contrib: Update minikube script

### DIFF
--- a/contrib/scripts/minikube.sh
+++ b/contrib/scripts/minikube.sh
@@ -2,12 +2,9 @@
 
 set -eux
 
-KUBERNETES_VERSION=${KUBERNETES_VERSION:-v1.13.2}
-
 export MINIKUBE_NETWORK_PLUGIN="cni"
 export MINIKUBE_EXTRA_CONFIG="kubelet.network-plugin=cni"
 export MINIKUBE_MEMORY=5120
-export MINIKUBE_KUBERNETES_VERSION="${KUBERNETES_VERSION}"
 unset CONTAINER_ENGINE
 
 minikube start
@@ -16,9 +13,7 @@ eval $(minikube docker-env)
 
 make docker-image DOCKER_IMAGE_TAG=dev
 
-version="${KUBERNETES_VERSION:1}"
-version_minor="${version%.*}"
-cp "examples/kubernetes/${version_minor}/cilium-minikube.yaml" /tmp/cilium-minikube.yaml
+cp "install/kubernetes/quick-install.yaml" /tmp/cilium-minikube.yaml
 
 sed -i 's|latest|dev|g' /tmp/cilium-minikube.yaml
 sed -i 's|docker.io/||g' /tmp/cilium-minikube.yaml


### PR DESCRIPTION
This change fixes the minikube script and `make minikube` target by
using the new `quick-install.yaml` file. It also removes unneeded
variables for defining Kubernetes version and from now the script will
always use the newest one.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9216)
<!-- Reviewable:end -->
