### PR TITLE
charts/managed-etcd: bump cilium-etcd-operator to v2.0.7

### DIFF
--- a/install/kubernetes/cilium/charts/managed-etcd/values.yaml
+++ b/install/kubernetes/cilium/charts/managed-etcd/values.yaml
@@ -1,2 +1,2 @@
 image: cilium-etcd-operator
-tag: v2.0.7-rc1
+tag: v2.0.7


### PR DESCRIPTION
cilium-etcd-operator was released with a bug fix that is required for
a correct operation with k8s 1.16. For this reason we are bumping this
version.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9217)
<!-- Reviewable:end -->
