### PR TITLE
workloads: remove `WorkloadOwner` from composing `regeneration.Owner`

### DIFF
--- a/pkg/workloads/runtimes.go
+++ b/pkg/workloads/runtimes.go
@@ -22,14 +22,11 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/endpoint"
-	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 )
 
 // WorkloadOwner is the interface that the owner of workloads must implement.
 type WorkloadOwner interface {
-	regeneration.Owner
-
 	// DeleteEndpoint is called when the underlying workload has died
 	DeleteEndpoint(id string) (int, error)
 }


### PR DESCRIPTION
It doesn't use any of the functions in the interface.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9221)
<!-- Reviewable:end -->
