### PR TITLE
service: Remove optional revNat param and cleanup svc removal 

### DIFF
--- a/Documentation/cheatsheet.rst
+++ b/Documentation/cheatsheet.rst
@@ -284,8 +284,7 @@ Add a new loadbalancer
 
     cilium service update --frontend 127.0.0.1:80 \
         --backends 127.0.0.2:90,127.0.0.3:90 \
-        --id 20 \
-        --rev 2
+        --id 20
 
 BPF
 ---

--- a/Documentation/cmdref/cilium_service_update.md
+++ b/Documentation/cmdref/cilium_service_update.md
@@ -19,7 +19,6 @@ cilium service update [flags]
       --frontend string    Frontend address
   -h, --help               help for update
       --id uint            Identifier
-      --rev                Add reverse translation (default true)
 ```
 
 ### Options inherited from parent commands

--- a/api/v1/models/service_spec.go
+++ b/api/v1/models/service_spec.go
@@ -138,12 +138,6 @@ func (m *ServiceSpec) UnmarshalBinary(b []byte) error {
 // swagger:model ServiceSpecFlags
 type ServiceSpecFlags struct {
 
-	// Frontend to backend translation activated
-	ActiveFrontend bool `json:"active-frontend,omitempty"`
-
-	// Perform direct server return
-	DirectServerReturn bool `json:"direct-server-return,omitempty"`
-
 	// Service is of Nodeport type
 	NodePort bool `json:"node-port,omitempty"`
 }

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -1931,12 +1931,6 @@ definitions:
         description: Optional service configuration flags
         type: object
         properties:
-          active-frontend:
-            description: Frontend to backend translation activated
-            type: boolean
-          direct-server-return:
-            description: Perform direct server return
-            type: boolean
           node-port:
             description: Service is of Nodeport type
             type: boolean

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -2734,14 +2734,6 @@ func init() {
           "description": "Optional service configuration flags",
           "type": "object",
           "properties": {
-            "active-frontend": {
-              "description": "Frontend to backend translation activated",
-              "type": "boolean"
-            },
-            "direct-server-return": {
-              "description": "Perform direct server return",
-              "type": "boolean"
-            },
             "node-port": {
               "description": "Service is of Nodeport type",
               "type": "boolean"
@@ -5872,14 +5864,6 @@ func init() {
           "description": "Optional service configuration flags",
           "type": "object",
           "properties": {
-            "active-frontend": {
-              "description": "Frontend to backend translation activated",
-              "type": "boolean"
-            },
-            "direct-server-return": {
-              "description": "Perform direct server return",
-              "type": "boolean"
-            },
             "node-port": {
               "description": "Service is of Nodeport type",
               "type": "boolean"

--- a/cilium/cmd/service_update.go
+++ b/cilium/cmd/service_update.go
@@ -29,7 +29,6 @@ import (
 )
 
 var (
-	addRev   bool
 	idU      uint64
 	frontend string
 	backends []string
@@ -46,7 +45,6 @@ var serviceUpdateCmd = &cobra.Command{
 
 func init() {
 	serviceCmd.AddCommand(serviceUpdateCmd)
-	serviceUpdateCmd.Flags().BoolVarP(&addRev, "rev", "", true, "Add reverse translation")
 	serviceUpdateCmd.Flags().Uint64VarP(&idU, "id", "", 0, "Identifier")
 	serviceUpdateCmd.Flags().StringVarP(&frontend, "frontend", "", "", "Frontend address")
 	serviceUpdateCmd.Flags().StringSliceVarP(&backends, "backends", "", []string{}, "Backend address or addresses followed by optional weight (<IP:Port>[/weight])")
@@ -92,7 +90,6 @@ func updateService(cmd *cobra.Command, args []string) {
 	}
 
 	spec.FrontendAddress = fa
-	spec.Flags.DirectServerReturn = addRev
 
 	if len(backends) == 0 {
 		fmt.Printf("Reading backend list from stdin...\n")

--- a/daemon/datapath.go
+++ b/daemon/datapath.go
@@ -608,9 +608,9 @@ func (d *Daemon) initMaps() error {
 			if err := lbmap.Backend6Map.DeleteAll(); err != nil {
 				return err
 			}
-		}
-		if err := d.RevNATDeleteAll(); err != nil {
-			return err
+			if err := lbmap.RevNat6Map.DeleteAll(); err != nil {
+				return err
+			}
 		}
 
 		if option.Config.EnableIPv4 {
@@ -621,6 +621,9 @@ func (d *Daemon) initMaps() error {
 				return err
 			}
 			if err := lbmap.Backend4Map.DeleteAll(); err != nil {
+				return err
+			}
+			if err := lbmap.RevNat4Map.DeleteAll(); err != nil {
 				return err
 			}
 		}

--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -1287,7 +1287,7 @@ func (d *Daemon) addK8sSVCs(svcID k8s.ServiceID, svc *k8s.Service, endpoints *k8
 		}
 
 		for _, fe := range frontends {
-			if _, _, err := d.svcAdd(*fe.addr, besValues, true, fe.nodePort); err != nil {
+			if _, _, err := d.svcAdd(*fe.addr, besValues, fe.nodePort); err != nil {
 				scopedLog.WithError(err).Error("Error while inserting service in LB map")
 			}
 		}

--- a/daemon/loadbalancer.go
+++ b/daemon/loadbalancer.go
@@ -302,10 +302,6 @@ func (h *getService) Handle(params GetServiceParams) middleware.Responder {
 }
 
 func openServiceMaps() error {
-	if err := lbmap.RemoveDeprecatedMaps(); err != nil {
-		return err
-	}
-
 	if option.Config.EnableIPv6 {
 		if _, err := lbmap.Service6MapV2.OpenOrCreate(); err != nil {
 			return err

--- a/daemon/loadbalancer.go
+++ b/daemon/loadbalancer.go
@@ -255,17 +255,6 @@ func (d *Daemon) svcDeleteLocked(svc *loadbalancer.LBSVC) error {
 		return fmt.Errorf("Deleting service from BPF maps failed: %s", err)
 	}
 
-	if revNAT, ok := d.loadBalancer.RevNATMap[svcID]; ok {
-		if err := lbmap.DeleteRevNATBPF(svcID, revNAT.IsIPv6()); err != nil {
-			return fmt.Errorf("Unable to delete revNAT for service %d: %s", svcID, err)
-		}
-
-		delete(d.loadBalancer.RevNATMap, svcID)
-	} else {
-		log.WithField(logfields.ServiceID, logfields.Repr(svc)).
-			Warn("Unable to find revNAT cache entry for service")
-	}
-
 	d.loadBalancer.DeleteService(svc)
 
 	return nil

--- a/daemon/loadbalancer.go
+++ b/daemon/loadbalancer.go
@@ -108,7 +108,7 @@ func (d *Daemon) svcAdd(
 	d.loadBalancer.BPFMapMU.Lock()
 	defer d.loadBalancer.BPFMapMU.Unlock()
 
-	if err := lbmap.UpdateService(fe, besValues, int(feL3n4Addr.ID), 0,
+	if err := lbmap.UpdateService(fe, besValues, int(feL3n4Addr.ID),
 		service.AcquireBackendID, service.DeleteBackendID); err != nil {
 		return false, loadbalancer.ID(0), err
 	}

--- a/daemon/loadbalancer.go
+++ b/daemon/loadbalancer.go
@@ -190,16 +190,11 @@ func (h *putServiceID) Handle(params PutServiceIDParams) middleware.Responder {
 		backends = append(backends, *b)
 	}
 
-	revnat := false
-	if params.Config.Flags != nil {
-		revnat = params.Config.Flags.DirectServerReturn
-	}
-
 	// FIXME
 	// Add flag to indicate whether service should be registered in
 	// global key value store
 
-	if created, err := h.d.SVCAdd(frontend, backends, revnat); err != nil {
+	if created, err := h.d.SVCAdd(frontend, backends, true); err != nil {
 		return api.Error(PutServiceIDFailureCode, err)
 	} else if created {
 		return NewPutServiceIDCreated()

--- a/daemon/loadbalancer.go
+++ b/daemon/loadbalancer.go
@@ -301,26 +301,6 @@ func (h *getService) Handle(params GetServiceParams) middleware.Responder {
 	return NewGetServiceOK().WithPayload(list)
 }
 
-// RevNATDeleteAll deletes all RevNAT4, if IPv4 is enabled on daemon, and all RevNAT6
-// stored on the daemon and on the bpf maps.
-//
-// Must be called with d.loadBalancer.BPFMapMU locked.
-func (d *Daemon) RevNATDeleteAll() error {
-	if option.Config.EnableIPv4 {
-		if err := lbmap.RevNat4Map.DeleteAll(); err != nil {
-			return err
-		}
-	}
-
-	if option.Config.EnableIPv6 {
-		if err := lbmap.RevNat6Map.DeleteAll(); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 func openServiceMaps() error {
 	if err := lbmap.RemoveDeprecatedMaps(); err != nil {
 		return err

--- a/daemon/loadbalancer.go
+++ b/daemon/loadbalancer.go
@@ -260,8 +260,6 @@ func (d *Daemon) svcDeleteBPF(svc loadbalancer.L3n4AddrID) error {
 		return fmt.Errorf("Deleting service from BPF maps failed: %s", err)
 	}
 
-	lbmap.DeleteServiceCache(svc)
-
 	return nil
 }
 

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -136,10 +136,9 @@ type RevNATMap map[ServiceID]L3n4Addr
 // LoadBalancer is the internal representation of the loadbalancer in the local cilium
 // daemon.
 type LoadBalancer struct {
-	BPFMapMU  lock.RWMutex
-	SVCMap    SVCMap
-	SVCMapID  SVCMapID
-	RevNATMap RevNATMap
+	BPFMapMU lock.RWMutex
+	SVCMap   SVCMap
+	SVCMapID SVCMapID
 }
 
 // AddService adds a service to list of loadbalancers and returns true if created.
@@ -189,9 +188,8 @@ func NewL4Type(name string) (L4Type, error) {
 // NewLoadBalancer returns a LoadBalancer with all maps initialized.
 func NewLoadBalancer() *LoadBalancer {
 	return &LoadBalancer{
-		SVCMap:    SVCMap{},
-		SVCMapID:  SVCMapID{},
-		RevNATMap: RevNATMap{},
+		SVCMap:   SVCMap{},
+		SVCMapID: SVCMapID{},
 	}
 }
 

--- a/pkg/maps/lbmap/bpfservice.go
+++ b/pkg/maps/lbmap/bpfservice.go
@@ -167,10 +167,6 @@ func (l *lbmapCache) prepareUpdate(fe ServiceKey, backends []ServiceValue) (
 	return bpfSvc, toAddBackendIDs, toRemoveBackendIDs, nil
 }
 
-func (l *lbmapCache) delete(fe ServiceKey) {
-	delete(l.entries, fe.String())
-}
-
 // addBackendV2Locked increments a ref count for the given backend and returns
 // whether any instance of the backend existed before.
 func (l *lbmapCache) addBackendV2Locked(addrID BackendAddrID) bool {
@@ -241,9 +237,7 @@ func (l *lbmapCache) removeServiceV2(svcKey ServiceKeyV2) ([]BackendKey, int, er
 		}
 	}
 
-	// FIXME(brb) uncomment the following line after we have removed the support for
-	// legacy svc.
-	//delete(l.entries, frontendID)
+	delete(l.entries, frontendID)
 
 	return backendsToRemove, count, nil
 }

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -379,8 +379,7 @@ func DeleteRevNATBPF(id loadbalancer.ServiceID, isIPv6 bool) error {
 	} else {
 		revNATK = NewRevNat4Key(uint16(id))
 	}
-	err := DeleteRevNat(revNATK)
-	return err
+	return deleteRevNatLocked(revNATK)
 }
 
 // DumpServiceMapsToUserspaceV2 dumps the services in the same way as
@@ -710,6 +709,10 @@ func DeleteServiceV2(svc loadbalancer.L3n4AddrID, releaseBackendID func(loadbala
 		}
 		releaseBackendID(backendKey.GetID())
 		log.WithField(logfields.BackendID, backendKey).Debug("Deleted backend")
+	}
+
+	if err := DeleteRevNATBPF(loadbalancer.ServiceID(svc.ID), isIPv6); err != nil {
+		return fmt.Errorf("Unable to delete revNAT entry %d: %s", svc.ID, err)
 	}
 
 	return nil

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -133,7 +133,7 @@ func generateWrrSeq(weights []uint16) (*RRSeqValue, error) {
 }
 
 // UpdateService adds or updates the given service in the bpf maps.
-func UpdateService(fe ServiceKey, backends []ServiceValue, revNATID int, oldID int,
+func UpdateService(fe ServiceKey, backends []ServiceValue, revNATID int,
 	acquireBackendID func(loadbalancer.L3n4Addr) (loadbalancer.BackendID, error),
 	releaseBackendID func(loadbalancer.BackendID)) error {
 
@@ -187,16 +187,6 @@ func UpdateService(fe ServiceKey, backends []ServiceValue, revNATID int, oldID i
 	// Update the v2 service BPF maps
 	if err := updateServiceV2Locked(fe, besValuesV2, svc, revNATID, weights, nNonZeroWeights); err != nil {
 		return err
-	}
-
-	// Delete old revNAT entry if svc ID has changed
-	if oldID != 0 && oldID != revNATID {
-		zeroValue := fe.NewValue().(ServiceValue)
-		zeroValue.SetRevNat(revNATID)
-		revNATKey := zeroValue.RevNatKey()
-		if err := deleteRevNatLocked(revNATKey); err != nil {
-			return err
-		}
 	}
 
 	// Delete no longer needed backends

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -147,7 +147,7 @@ func generateWrrSeq(weights []uint16) (*RRSeqValue, error) {
 }
 
 // UpdateService adds or updates the given service in the bpf maps.
-func UpdateService(fe ServiceKey, backends []ServiceValue, revNATID int,
+func UpdateService(fe ServiceKey, backends []ServiceValue, revNATID int, oldID int,
 	acquireBackendID func(loadbalancer.L3n4Addr) (loadbalancer.BackendID, error),
 	releaseBackendID func(loadbalancer.BackendID)) error {
 
@@ -201,6 +201,16 @@ func UpdateService(fe ServiceKey, backends []ServiceValue, revNATID int,
 	// Update the v2 service BPF maps
 	if err := updateServiceV2Locked(fe, besValuesV2, svc, revNATID, weights, nNonZeroWeights); err != nil {
 		return err
+	}
+
+	// Delete old revNAT entry if svc ID has changed
+	if oldID != 0 && oldID != revNATID {
+		zeroValue := fe.NewValue().(ServiceValue)
+		zeroValue.SetRevNat(revNATID)
+		revNATKey := zeroValue.RevNatKey()
+		if err := deleteRevNatLocked(revNATKey); err != nil {
+			return err
+		}
 	}
 
 	// Delete no longer needed backends

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -655,22 +655,6 @@ func DeleteServiceV2(svc loadbalancer.L3n4AddrID, releaseBackendID func(loadbala
 	return nil
 }
 
-// DeleteServiceCache deletes the service cache.
-func DeleteServiceCache(svc loadbalancer.L3n4AddrID) {
-	mutex.Lock()
-	defer mutex.Unlock()
-
-	var svcKey ServiceKey
-
-	if !svc.IsIPv6() {
-		svcKey = NewService4Key(svc.IP, svc.Port, 0)
-	} else {
-		svcKey = NewService6Key(svc.IP, svc.Port, 0)
-	}
-
-	cache.delete(svcKey)
-}
-
 func DeleteOrphanBackends(releaseBackendID func(loadbalancer.BackendID)) []error {
 	mutex.Lock()
 	defer mutex.Unlock()

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -689,23 +689,3 @@ func DeleteOrphanBackends(releaseBackendID func(loadbalancer.BackendID)) []error
 
 	return errors
 }
-
-// RemoveDeprecatedMaps removes the maps for legacy services, left over from
-// previous installations.
-//
-// Safe to remove in Cilium 1.7.
-func RemoveDeprecatedMaps() error {
-	if err := Service6Map.UnpinIfExists(); err != nil {
-		return err
-	}
-	if err := RRSeq6Map.UnpinIfExists(); err != nil {
-		return err
-	}
-	if err := Service4Map.UnpinIfExists(); err != nil {
-		return err
-	}
-	if err := RRSeq4Map.UnpinIfExists(); err != nil {
-		return err
-	}
-	return nil
-}

--- a/pkg/maps/lbmap/types.go
+++ b/pkg/maps/lbmap/types.go
@@ -345,39 +345,6 @@ func serviceValue2L3n4Addr(svcVal ServiceValue) *loadbalancer.L3n4Addr {
 	return loadbalancer.NewL3n4Addr(loadbalancer.NONE, beIP, bePort)
 }
 
-// RevNat6Value2L3n4Addr converts the given RevNat6Value to a L3n4Addr.
-func revNat6Value2L3n4Addr(revNATV *RevNat6Value) *loadbalancer.L3n4Addr {
-	return loadbalancer.NewL3n4Addr(loadbalancer.NONE, revNATV.Address.IP(), revNATV.Port)
-}
-
-// revNat4Value2L3n4Addr converts the given RevNat4Value to a L3n4Addr.
-func revNat4Value2L3n4Addr(revNATV *RevNat4Value) *loadbalancer.L3n4Addr {
-	return loadbalancer.NewL3n4Addr(loadbalancer.NONE, revNATV.Address.IP(), revNATV.Port)
-}
-
-// revNatValue2L3n4AddrID converts the given RevNatKey and RevNatValue to a L3n4AddrID.
-func revNatValue2L3n4AddrID(revNATKey RevNatKey, revNATValue RevNatValue) *loadbalancer.L3n4AddrID {
-	var (
-		svcID loadbalancer.ID
-		be    *loadbalancer.L3n4Addr
-	)
-	if revNATKey.IsIPv6() {
-		revNat6Key := revNATKey.(*RevNat6Key)
-		svcID = loadbalancer.ID(revNat6Key.Key)
-
-		revNat6Value := revNATValue.(*RevNat6Value)
-		be = revNat6Value2L3n4Addr(revNat6Value)
-	} else {
-		revNat4Key := revNATKey.(*RevNat4Key)
-		svcID = loadbalancer.ID(revNat4Key.Key)
-
-		revNat4Value := revNATValue.(*RevNat4Value)
-		be = revNat4Value2L3n4Addr(revNat4Value)
-	}
-
-	return &loadbalancer.L3n4AddrID{L3n4Addr: *be, ID: svcID}
-}
-
 // LBSVC2ServiceKeynValuenBackendValueV2 transforms the SVC Cilium type into a bpf SVC v2 type.
 func LBSVC2ServiceKeynValuenBackendV2(svc *loadbalancer.LBSVC) (ServiceKeyV2, []ServiceValueV2, []Backend, error) {
 	log.WithFields(logrus.Fields{

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -756,7 +756,7 @@ func (s *SSHMeta) GatherLogs() {
 // backends. Returns the result of creating said service.
 func (s *SSHMeta) ServiceAdd(id int, frontend string, backends []string) *CmdRes {
 	cmd := fmt.Sprintf(
-		"service update --frontend '%s' --backends '%s' --id '%d' --rev",
+		"service update --frontend '%s' --backends '%s' --id '%d'",
 		frontend, strings.Join(backends, ","), id)
 	return s.ExecCilium(cmd)
 }


### PR DESCRIPTION
This PR is a continuation of the ongoing LB refactoring (creating multiple relatively small PRs to ease the review process). The changes included:

- Removed `active-frontend` and `direct-server-return` options.
- `addRevNat` is no longer an option, and is enabled by default.
- Cleanup of SVC removal code.
- Hides revNAT implementation details from `daemon` and `pkg/loadbalancer`.
- Some dead code elimination.
- Remove removal of the deprecated legacy SVC maps.
- Simplify SVC restoration when running w/o k8s.

Again, reviewable per commit.

```release-notes
HTTP PUT /service/{id} API no longer accepts "active-frontend" and "direct-server-return" options.
```


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9227)
<!-- Reviewable:end -->
