### PR TITLE
Add a note on ignoring br_netfilter preflight check

### DIFF
--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -53,6 +53,16 @@ and the token returned by ``kubeadm init``:
 
    kubeadm join <..>
 
+.. note:: Newer kernels do not include ``br_netfilter`` module, so you might need to disable netfilter preflight check
+          when running your kubeadm ``init`` and ``join`` commands:
+
+          .. code:: bash
+
+             kubeadm <..> --ignore-preflight-errors=FileContent--proc-sys-net-bridge-bridge-nf-call-iptables
+
+          Cilium does not depend on any bridge device whether running with kube-proxy or not,
+          so it's safe to skip this step.
+
 .. include:: k8s-install-download-release.rst
 
 Next, generate the required YAML files and deploy them. Replace ``$API_SERVER_IP``


### PR DESCRIPTION
Newer kernels do not include `br_netfilter` module by default, so kubeadm will raise an exception on init and join, asking users to load this module. Cilium does not require this module to operate in kube-proxy-less mode, so it's safe to disable this pre-flight check when creating or joining a cluster.

This pull requests adds a small comment to kube-proxy-less documentation page at http://docs.cilium.io/en/latest/gettingstarted/kubeproxy-free/ to warn users what to do when this happens.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9229)
<!-- Reviewable:end -->
