### PR TITLE
api: Add API support for k8s secrets

### DIFF
--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -970,6 +970,42 @@ var (
 		},
 	}
 
+	K8sSecret = map[string]apiextensionsv1beta1.JSONSchemaProps{
+		"namespace": {
+			Description: "Namespace is the k8s namespace in which the secret exists. If " +
+				"namespace is omitted, the namespace of the enclosing rule is assumed.",
+			Type: "string",
+		},
+		"name": {
+			Description: "Name is the name of the k8s secret.",
+			Type:        "string",
+		},
+	}
+
+	TLSContext = map[string]apiextensionsv1beta1.JSONSchemaProps{
+		"certificate": {
+			Description: "Certificate is a chain of certificates presented to the remote party. " +
+				"If specified for an originating TLS context, then this is used as a " +
+				"client certificate.",
+			Type:       "object",
+			Properties: K8sSecret,
+		},
+		"privatekey": {
+			Description: "PrivateKey is the private key used to encrypt the TLS messages. This " +
+				"is the private part of the public/private key pair, corresponding to " +
+				"the public key in the certificate.",
+			Type:       "object",
+			Properties: K8sSecret,
+		},
+		"trustedca": {
+			Description: "TrustedCA is a set of trusted certificate authorities used to verify " +
+				"the certificate of the remote party. If specified for a terminating " +
+				"TLS context, then a client certificate is required.",
+			Type:       "object",
+			Properties: K8sSecret,
+		},
+	}
+
 	PortRule = apiextensionsv1beta1.JSONSchemaProps{
 		Description: "PortRule is a list of ports/protocol combinations with optional Layer 7 " +
 			"rules which must be met.",
@@ -980,6 +1016,26 @@ var (
 				Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
 					Schema: &PortProtocol,
 				},
+			},
+			"terminatingtls": {
+				Description: "TerminatingTLS is the TLS context for the connection terminated by " +
+					"the L7 proxy.  For egress policy this specifies the server-side TLS " +
+					"parameters to be applied on the connections originated from the local " +
+					"POD and terminated by the L7 proxy. For ingress policy this specifies " +
+					"the server-side TLS parameters to be applied on the connections " +
+					"originated from a remote source and terminated by the L7 proxy.",
+				Type:       "object",
+				Properties: TLSContext,
+			},
+			"originatingtls": {
+				Description: "OriginatingTLS is the TLS context for the connections originated by " +
+					"the L7 proxy.  For egress policy this specifies the client-side TLS " +
+					"parameters for the upstream connection originating from the L7 proxy " +
+					"to the remote destination. For ingress policy this specifies the " +
+					"client-side TLS parameters for the connection from the L7 proxy to " +
+					"the local POD.",
+				Type:       "object",
+				Properties: TLSContext,
 			},
 			"rules": L7Rules,
 		},

--- a/pkg/policy/api/l4.go
+++ b/pkg/policy/api/l4.go
@@ -55,6 +55,34 @@ func (p PortProtocol) Covers(other PortProtocol) bool {
 	return true
 }
 
+// K8sSecret is a reference to a k8s secret.
+type K8sSecret struct {
+	// Namespace is the k8s namespace in which the secret exists. If
+	// namespace is omitted, the namespace of the enclosing rule is assumed.
+	Namespace string `json:"namespace,omitempty"`
+
+	// Name is the name of the k8s secret
+	Name string `json:"name,omitempty"`
+}
+
+// TLSContext provides TLS configuration via reference to k8s secrets.
+type TLSContext struct {
+	// Certificate is a chain of certificates presented to the remote party.
+	// If specified for an originating TLS context, then this is used as a
+	// client certificate
+	Certificate K8sSecret `json:"certificate,omitempty"`
+
+	// PrivateKey is the private key used to encrypt the TLS messages. This
+	// is the private part of the public/private key pair, corresponding to
+	// the public key in the certificate.
+	PrivateKey K8sSecret `json:"privatekey,omitempty"`
+
+	// TrustedCA is a set of trusted certificate authorities used to verify
+	// the certificate of the remote party. If specified for a terminating
+	// TLS context, then a client certificate is required.
+	TrustedCA K8sSecret `json:"trustedca,omitempty"`
+}
+
 // PortRule is a list of ports/protocol combinations with optional Layer 7
 // rules which must be met.
 type PortRule struct {
@@ -62,6 +90,22 @@ type PortRule struct {
 	//
 	// +optional
 	Ports []PortProtocol `json:"ports,omitempty"`
+
+	// TerminatingTLS is the TLS context for the connection terminated by
+	// the L7 proxy.  For egress policy this specifies the server-side TLS
+	// parameters to be applied on the connections originated from the local
+	// POD and terminated by the L7 proxy. For ingress policy this specifies
+	// the server-side TLS parameters to be applied on the connections
+	// originated from a remote source and terminated by the L7 proxy.
+	TerminatingTLS TLSContext `json:"terminatingtls,omitempty"`
+
+	// OriginatingTLS is the TLS context for the connections originated by
+	// the L7 proxy.  For egress policy this specifies the client-side TLS
+	// parameters for the upstream connection originating from the L7 proxy
+	// to the remote destination. For ingress policy this specifies the
+	// client-side TLS parameters for the connection from the L7 proxy to
+	// the local POD.
+	OriginatingTLS TLSContext `json:"originatingtls,omitempty"`
 
 	// Rules is a list of additional port level rules which must be met in
 	// order for the PortRule to allow the traffic. If omitted or empty,


### PR DESCRIPTION
Add API definitions for k8s secrets. Not implmeneted yet.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9232)
<!-- Reviewable:end -->
