### PR TITLE
CI: Add HTTP tests to DatapathConfiguration tests

### DIFF
--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -269,5 +269,12 @@ func testPodConnectivityAcrossNodes(kubectl *helpers.Kubectl) bool {
 
 	// ICMP connectivity test
 	res := kubectl.ExecPodCmd(helpers.DefaultNamespace, srcPod, helpers.Ping(targetIP))
+	if !res.WasSuccessful() {
+		return false
+	}
+
+	// HTTP connectivity test
+	res = kubectl.ExecPodCmd(helpers.DefaultNamespace, srcPod,
+		helpers.CurlFail("http://%s:80/", targetIP))
 	return res.WasSuccessful()
 }


### PR DESCRIPTION
* Rework the DatapathConfiguration tests to initate requests from testDSClient pods to remote testDS (server) pods, while still ensuring they are on different nodes
* Add HTTP (curl) requests from a client on one node to a server on another node

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9233)
<!-- Reviewable:end -->
