### PR TITLE
endpoint: cleanup how build permits are acquired

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -116,9 +116,6 @@ type Daemon struct {
 	statusResponse     models.StatusResponse
 	statusCollector    *status.Collector
 
-	uniqueIDMU lock.Mutex
-	uniqueID   map[uint64]context.CancelFunc
-
 	monitorAgent *monitoragent.Agent
 	ciliumHealth *health.CiliumHealth
 
@@ -345,7 +342,6 @@ func NewDaemon(dp datapath.Datapath, iptablesManager rulesManager) (*Daemon, *en
 		loadBalancer:      loadbalancer.NewLoadBalancer(),
 		k8sSvcCache:       k8s.NewServiceCache(),
 		policy:            policy.NewPolicyRepository(),
-		uniqueID:          map[uint64]context.CancelFunc{},
 		prefixLengths:     createPrefixLengthCounter(),
 		k8sResourceSynced: map[string]chan struct{}{},
 		buildEndpointSem:  semaphore.NewWeighted(int64(numWorkerThreads())),

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -37,7 +37,6 @@ import (
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
-	"github.com/cilium/cilium/pkg/proxy/accesslog"
 
 	. "gopkg.in/check.v1"
 )
@@ -55,12 +54,10 @@ type DaemonSuite struct {
 	kvstoreInit bool
 
 	// Owners interface mock
-	OnGetPolicyRepository     func() *policy.Repository
-	OnQueueEndpointBuild      func(ctx context.Context, epID uint64) (func(), error)
-	OnRemoveFromEndpointQueue func(epID uint64)
-	OnGetCompilationLock      func() *lock.RWMutex
-	OnSendNotification        func(typ monitorAPI.AgentNotification, text string) error
-	OnNewProxyLogRecord       func(l *accesslog.LogRecord) error
+	OnGetPolicyRepository func() *policy.Repository
+	OnQueueEndpointBuild  func(ctx context.Context, epID uint64) (func(), error)
+	OnGetCompilationLock  func() *lock.RWMutex
+	OnSendNotification    func(typ monitorAPI.AgentNotification, text string) error
 }
 
 func setupTestDirectories() {
@@ -123,10 +120,8 @@ func (ds *DaemonSuite) SetUpTest(c *C) {
 
 	ds.OnGetPolicyRepository = nil
 	ds.OnQueueEndpointBuild = nil
-	ds.OnRemoveFromEndpointQueue = nil
 	ds.OnGetCompilationLock = nil
 	ds.OnSendNotification = nil
-	ds.OnNewProxyLogRecord = nil
 	ds.d.endpointManager = endpointmanager.NewEndpointManager(&dummyEpSyncher{})
 }
 
@@ -211,14 +206,6 @@ func (ds *DaemonSuite) QueueEndpointBuild(ctx context.Context, epID uint64) (fun
 	panic("QueueEndpointBuild should not have been called")
 }
 
-func (ds *DaemonSuite) RemoveFromEndpointQueue(epID uint64) {
-	if ds.OnRemoveFromEndpointQueue != nil {
-		ds.OnRemoveFromEndpointQueue(epID)
-		return
-	}
-	panic("RemoveFromEndpointQueue should not have been called")
-}
-
 func (ds *DaemonSuite) GetCompilationLock() *lock.RWMutex {
 	if ds.OnGetCompilationLock != nil {
 		return ds.OnGetCompilationLock()
@@ -231,13 +218,6 @@ func (ds *DaemonSuite) SendNotification(typ monitorAPI.AgentNotification, text s
 		return ds.OnSendNotification(typ, text)
 	}
 	panic("SendNotification should not have been called")
-}
-
-func (ds *DaemonSuite) NewProxyLogRecord(l *accesslog.LogRecord) error {
-	if ds.OnNewProxyLogRecord != nil {
-		return ds.OnNewProxyLogRecord(l)
-	}
-	panic("NewProxyLogRecord should not have been called")
 }
 
 func (ds *DaemonSuite) Datapath() datapath.Datapath {

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -19,6 +19,7 @@ package endpoint
 
 import (
 	"bytes"
+	"context"
 	"sort"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -86,6 +87,10 @@ func NewEndpointFromChangeModel(owner regeneration.Owner, proxy EndpointProxy, b
 		controllers:      controller.NewManager(),
 		regenFailedChan:  make(chan struct{}, 1),
 	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ep.aliveCancel = cancel
+	ep.aliveCtx = ctx
 
 	ep.startRegenerationFailureHandler()
 	ep.realizedPolicy = ep.desiredPolicy

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -952,7 +952,6 @@ func (e *Endpoint) leaveLocked(proxyWaitGroup *completion.WaitGroup, conf Delete
 		e.owner.Datapath().Loader().Unload(e.createEpInfoCache(""))
 	}
 
-	e.owner.RemoveFromEndpointQueue(uint64(e.ID))
 	if e.SecurityIdentity != nil && len(e.realizedRedirects) > 0 {
 		// Passing a new map of nil will purge all redirects
 		finalize, _ := e.removeOldRedirects(nil, proxyWaitGroup)

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -39,7 +39,6 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
-	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	. "gopkg.in/check.v1"
 )
 
@@ -63,7 +62,6 @@ type EndpointSuite struct {
 	OnRemoveFromEndpointQueue func(epID uint64)
 	OnGetCompilationLock      func() *lock.RWMutex
 	OnSendNotification        func(typ monitorAPI.AgentNotification, text string) error
-	OnNewProxyLogRecord       func(l *accesslog.LogRecord) error
 }
 
 // suite can be used by testing.T benchmarks or tests as a mock regeneration.Owner
@@ -81,8 +79,6 @@ func (s *EndpointSuite) GetPolicyRepository() *policy.Repository {
 func (s *EndpointSuite) QueueEndpointBuild(ctx context.Context, epID uint64) (func(), error) {
 	return nil, nil
 }
-
-func (s *EndpointSuite) RemoveFromEndpointQueue(epID uint64) {}
 
 func (s *EndpointSuite) GetCompilationLock() *lock.RWMutex {
 	return nil

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -457,7 +457,7 @@ func (e *Endpoint) Regenerate(regenMetadata *regeneration.ExternalRegenerationMe
 	if regenMetadata.ParentContext != nil {
 		ctx, cFunc = context.WithCancel(regenMetadata.ParentContext)
 	} else {
-		ctx, cFunc = context.WithCancel(context.Background())
+		ctx, cFunc = context.WithCancel(e.aliveCtx)
 	}
 
 	regenContext := ParseExternalRegenerationMetadata(ctx, cFunc, regenMetadata)

--- a/pkg/endpoint/regeneration/owner.go
+++ b/pkg/endpoint/regeneration/owner.go
@@ -34,9 +34,6 @@ type Owner interface {
 	// QueueEndpointBuild puts the given endpoint in the processing queue
 	QueueEndpointBuild(ctx context.Context, epID uint64) (func(), error)
 
-	// RemoveFromEndpointQueue removes an endpoint from the working queue
-	RemoveFromEndpointQueue(epID uint64)
-
 	// GetCompilationLock returns the mutex responsible for synchronizing compilation
 	// of BPF programs.
 	GetCompilationLock() *lock.RWMutex

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -75,8 +75,6 @@ func (s *EndpointManagerSuite) QueueEndpointBuild(ctx context.Context, epID uint
 	return nil, nil
 }
 
-func (s *EndpointManagerSuite) RemoveFromEndpointQueue(epID uint64) {}
-
 func (s *EndpointManagerSuite) GetCompilationLock() *lock.RWMutex {
 	return nil
 }

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -77,8 +77,6 @@ func (s *DNSProxyTestSuite) QueueEndpointBuild(ctx context.Context, epID uint64)
 	return nil, nil
 }
 
-func (s *DNSProxyTestSuite) RemoveFromEndpointQueue(epID uint64) {}
-
 func (s *DNSProxyTestSuite) GetCompilationLock() *lock.RWMutex {
 	return nil
 }

--- a/pkg/proxy/kafka_test.go
+++ b/pkg/proxy/kafka_test.go
@@ -85,8 +85,6 @@ func (s *proxyTestSuite) QueueEndpointBuild(ctx context.Context, epID uint64) (f
 	return nil, nil
 }
 
-func (s *proxyTestSuite) RemoveFromEndpointQueue(epID uint64) {}
-
 func (s *proxyTestSuite) GetCompilationLock() *lock.RWMutex {
 	return nil
 }


### PR DESCRIPTION
We encode whether a given Endpoint needs to be regenerated or not with changes
to its state; regenerations are not attempted by callers if the endpoint is in
`StateWaitingToRegenerate` already. The `uniqueID` map encoded this same state,
but outside of the Endpoint package; therefore, it is now redundant. It makes
more logical sense to have the logic of whether a regeneration needs to be
performed for an Endpoint to be part of `pkg/endpoint` itself.

If an Endpoint is waiting on the semaphore from the Daemon to be acquired which
meters the number of concurrent regenerations, provide its `aliveCtx` to the
call to `QueueEndpointBuild` if no context is provided in the call to
`regenerate`. This ensures that when an Endpoint is deleted, it will release all
resources associated with it, including if it is waiting on this semaphore.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9234)
<!-- Reviewable:end -->
