### PR TITLE
eni: Allow overwriting AWS instance limit via agent configuration

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -22,6 +22,7 @@ cilium-agent [flags]
       --annotate-k8s-node                                     Annotate Kubernetes node (default true)
       --auto-create-cilium-node-resource                      Automatically create CiliumNode resource for own node on startup (default true)
       --auto-direct-node-routes                               Enable automatic L2 routing between nodes
+      --aws-instance-limit-mapping map                        Add or overwrite mappings of AWS instance limit in the form of {"AWS instance type": "Maximum Network Interfaces","IPv4 Addresses per Interface","IPv6 Addresses per Interface"}. cli example: --aws-instance-limit-mapping=a1.medium=2,4,4 --aws-instance-limit-mapping=a2.somecustomflavor=4,5,6 configmap example: {"a1.medium": "2,4,4", "a2.somecustomflavor": "4,5,6"} (default map[])
       --blacklist-conflicting-routes                          Don't blacklist IP allocations conflicting with local non-cilium routes (default true)
       --bpf-compile-debug                                     Enable debugging of the BPF compilation process
       --bpf-ct-global-any-max int                             Maximum number of entries in non-TCP CT table (default 262144)

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cilium/cilium/api/v1/server/restapi"
 	"github.com/cilium/cilium/common"
 	_ "github.com/cilium/cilium/pkg/alignchecker"
+	"github.com/cilium/cilium/pkg/aws/eni"
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/cgroups"
 	"github.com/cilium/cilium/pkg/cleanup"
@@ -675,6 +676,10 @@ func init() {
 	flags.Bool(option.DisableCNPStatusUpdates, false, "Do not send CNP NodeStatus updates to the Kubernetes api-server (recommended to run with `cnp-node-status-gc=false` in cilium-operator)")
 	option.BindEnv(option.DisableCNPStatusUpdates)
 
+	flags.Var(option.NewNamedMapOptions(option.AwsInstanceLimitMapping, &option.Config.AwsInstanceLimitMapping, nil),
+		option.AwsInstanceLimitMapping, "Add or overwrite mappings of AWS instance limit in the form of {\"AWS instance type\": \"Maximum Network Interfaces\",\"IPv4 Addresses per Interface\",\"IPv6 Addresses per Interface\"}. cli example: --aws-instance-limit-mapping=a1.medium=2,4,4 --aws-instance-limit-mapping=a2.somecustomflavor=4,5,6 configmap example: {\"a1.medium\": \"2,4,4\", \"a2.somecustomflavor\": \"4,5,6\"}")
+	option.BindEnv(option.AwsInstanceLimitMapping)
+
 	viper.BindPFlags(flags)
 }
 
@@ -922,6 +927,10 @@ func initEnv(cmd *cobra.Command) {
 
 	if err := cache.AddUserDefinedNumericIdentitySet(option.Config.FixedIdentityMapping); err != nil {
 		log.Fatalf("Invalid fixed identities provided: %s", err)
+	}
+
+	if err := eni.UpdateLimitsFromUserDefinedMappings(option.Config.AwsInstanceLimitMapping); err != nil {
+		log.Fatalf("Parse aws-instance-limit-mapping failed: %s", err)
 	}
 
 	if !option.Config.EnableIPv4 && !option.Config.EnableIPv6 {

--- a/pkg/aws/eni/limits.go
+++ b/pkg/aws/eni/limits.go
@@ -15,6 +15,12 @@
 
 package eni
 
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
 // Limits specifies the ENI relevant instance limits
 type Limits struct {
 	// Adapters specifies the maximum number of ENIs that can be attached
@@ -29,6 +35,7 @@ type Limits struct {
 }
 
 // limit contains limits for adapter count and addresses
+// The mappings will be updated from agent configuration at bootstrap time
 //
 // Source: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html?shortFooter=true#AvailableIpPerENI
 var limits = map[string]Limits{
@@ -255,4 +262,34 @@ var limits = map[string]Limits{
 func GetLimits(instanceType string) (limit Limits, ok bool) {
 	limit, ok = limits[instanceType]
 	return
+}
+
+// UpdateLimitsFromUserDefinedMappings updates limits from the given map
+func UpdateLimitsFromUserDefinedMappings(m map[string]string) (err error) {
+	for instanceType, limitString := range m {
+		limit, err := parseLimitString(limitString)
+		if err != nil {
+			return err
+		}
+		// Add or overwrite limits
+		limits[instanceType] = limit
+	}
+	return nil
+}
+
+// parseLimitString returns the Limits struct parsed from config string
+func parseLimitString(limitString string) (limit Limits, err error) {
+	intSlice := make([]int, 3)
+	stringSlice := strings.Split(strings.ReplaceAll(limitString, " ", ""), ",")
+	if len(stringSlice) != 3 {
+		return limit, fmt.Errorf("invalid limit value")
+	}
+	for i, s := range stringSlice {
+		intLimit, err := strconv.Atoi(s)
+		if err != nil {
+			return limit, err
+		}
+		intSlice[i] = intLimit
+	}
+	return Limits{intSlice[0], intSlice[1], intSlice[2]}, nil
 }

--- a/pkg/aws/eni/limits_test.go
+++ b/pkg/aws/eni/limits_test.go
@@ -17,10 +17,14 @@
 package eni
 
 import (
+	"github.com/cilium/cilium/pkg/option"
+
 	"gopkg.in/check.v1"
 )
 
 func (e *ENISuite) TestGetLimits(c *check.C) {
+	option.Config.AwsInstanceLimitMapping = map[string]string{"a2.custom2": "4,5,6"}
+
 	_, ok := GetLimits("unknown")
 	c.Assert(ok, check.Equals, false)
 
@@ -28,4 +32,57 @@ func (e *ENISuite) TestGetLimits(c *check.C) {
 	c.Assert(ok, check.Equals, true)
 	c.Assert(l.Adapters, check.Not(check.Equals), 0)
 	c.Assert(l.IPv4, check.Not(check.Equals), 0)
+
+	UpdateLimitsFromUserDefinedMappings(option.Config.AwsInstanceLimitMapping)
+	l, ok = GetLimits("a2.custom2")
+	c.Assert(ok, check.Equals, true)
+	c.Assert(l.Adapters, check.Equals, 4)
+	c.Assert(l.IPv4, check.Equals, 5)
+	c.Assert(l.IPv6, check.Equals, 6)
+}
+
+func (e *ENISuite) TestUpdateLimitsFromUserDefinedMappings(c *check.C) {
+	m1 := map[string]string{"a1.medium": "2,4,100"}
+
+	err := UpdateLimitsFromUserDefinedMappings(m1)
+	c.Assert(err, check.Equals, nil)
+
+	limit, ok := GetLimits("a1.medium")
+	c.Assert(ok, check.Equals, true)
+	c.Assert(limit.Adapters, check.Equals, 2)
+	c.Assert(limit.IPv4, check.Equals, 4)
+	c.Assert(limit.IPv6, check.Equals, 100)
+}
+
+func (e *ENISuite) TestParseLimitString(c *check.C) {
+	limitString1 := "4,5 ,6"
+	limitString2 := "4,5,a"
+	limitString3 := "4,5"
+	limitString4 := "45"
+	limitString5 := ","
+	limitString6 := ""
+
+	limit, err := parseLimitString(limitString1)
+	c.Assert(err, check.Equals, nil)
+	c.Assert(limit.Adapters, check.Equals, 4)
+	c.Assert(limit.IPv4, check.Equals, 5)
+	c.Assert(limit.IPv6, check.Equals, 6)
+
+	limit, err = parseLimitString(limitString2)
+	c.Assert(err, check.Not(check.Equals), nil)
+
+	limit, err = parseLimitString(limitString3)
+	c.Assert(err.Error(), check.Equals, "invalid limit value")
+	c.Assert(limit.Adapters, check.Not(check.Equals), 4)
+	c.Assert(limit.IPv4, check.Not(check.Equals), 5)
+	c.Assert(limit.IPv6, check.Equals, 0)
+
+	limit, err = parseLimitString(limitString4)
+	c.Assert(err.Error(), check.Equals, "invalid limit value")
+
+	limit, err = parseLimitString(limitString5)
+	c.Assert(err.Error(), check.Equals, "invalid limit value")
+
+	limit, err = parseLimitString(limitString6)
+	c.Assert(err.Error(), check.Equals, "invalid limit value")
 }

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -77,6 +77,11 @@ const (
 	// the daemon, which can also be disbled using this option.
 	AnnotateK8sNode = "annotate-k8s-node"
 
+	// AwsInstanceLimitMapping allows overwirting AWS instance limits defined in
+	// pkg/aws/eni/limits.go
+	// e.g. {"a1.medium": "2,4,4", "a2.custom2": "4,5,6"}
+	AwsInstanceLimitMapping = "aws-instance-limit-mapping"
+
 	// BPFRoot is the Path to BPF filesystem
 	BPFRoot = "bpf-root"
 
@@ -1223,6 +1228,11 @@ type DaemonConfig struct {
 	// AllowICMPFragNeeded allows ICMP Fragmentation Needed type packets in
 	// the network policy for cilium-agent.
 	AllowICMPFragNeeded bool
+
+	// AwsInstanceLimitMapping allows overwirting AWS instance limits defined in
+	// pkg/aws/eni/limits.go
+	// e.g. {"a1.medium": "2,4,4", "a2.custom2": "4,5,6"}
+	AwsInstanceLimitMapping map[string]string
 }
 
 var (
@@ -1256,6 +1266,7 @@ var (
 		AutoCreateCiliumNodeResource: defaults.AutoCreateCiliumNodeResource,
 		IdentityAllocationMode:       IdentityAllocationModeKVstore,
 		AllowICMPFragNeeded:          defaults.AllowICMPFragNeeded,
+		AwsInstanceLimitMapping:      make(map[string]string),
 	}
 )
 
@@ -1750,6 +1761,10 @@ func (c *DaemonConfig) Populate() {
 	c.MonitorAggregationFlags = byteorder.HostToNetwork(ctMonitorReportFlags).(uint16)
 
 	// Map options
+	if m := viper.GetStringMapString(AwsInstanceLimitMapping); len(m) != 0 {
+		c.AwsInstanceLimitMapping = m
+	}
+
 	if m := viper.GetStringMapString(ContainerRuntimeEndpoint); len(m) != 0 {
 		c.ContainerRuntimeEndpoint = m
 	}


### PR DESCRIPTION
Allow adding or overwriting AWS instance limit via the cilium-agent option
`--aws-instance-limit-mapping`.

Fixes: #9052

Signed-off-by: Jaff Cheng <jaff.cheng.sh@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9236)
<!-- Reviewable:end -->
