### PR TITLE
ipcache: Associate IPs with K8s namespace and pod name

### DIFF
--- a/daemon/datapath.go
+++ b/daemon/datapath.go
@@ -504,7 +504,7 @@ func (d *Daemon) syncEndpointsAndHostIPs() error {
 
 		// Upsert will not propagate (reserved:foo->ID) mappings across the cluster,
 		// and we specifically don't want to do so.
-		ipcache.IPIdentityCache.Upsert(ipIDPair.PrefixString(), nil, hostKey, ipcache.Identity{
+		ipcache.IPIdentityCache.Upsert(ipIDPair.PrefixString(), nil, hostKey, nil, ipcache.Identity{
 			ID:     ipIDPair.ID,
 			Source: source.Local,
 		})

--- a/pkg/datapath/ipcache/listener.go
+++ b/pkg/datapath/ipcache/listener.go
@@ -79,7 +79,8 @@ func NewListener(d datapath) *BPFListener {
 // IP->ID mapping will replace any existing contents; knowledge of the old pair
 // is not required to upsert the new pair.
 func (l *BPFListener) OnIPIdentityCacheChange(modType ipcache.CacheModification, cidr net.IPNet,
-	oldHostIP, newHostIP net.IP, oldID *identity.NumericIdentity, newID identity.NumericIdentity, encryptKey uint8) {
+	oldHostIP, newHostIP net.IP, oldID *identity.NumericIdentity, newID identity.NumericIdentity,
+	encryptKey uint8, k8sMeta *ipcache.K8sMetadata) {
 
 	scopedLog := log
 	if option.Config.Debug {

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -624,12 +624,14 @@ func (e *Endpoint) runIPIdentitySync(endpointIP addressing.CiliumIP) {
 				hostIP := node.GetExternalIPv4()
 				key := node.GetIPsecKeyIdentity()
 				metadata := e.FormatGlobalEndpointID()
+				k8sNamespace := e.K8sNamespace
+				k8sPodName := e.K8sPodName
 
 				// Release lock as we do not want to have long-lasting key-value
 				// store operations resulting in lock being held for a long time.
 				e.runlock()
 
-				if err := ipcache.UpsertIPToKVStore(ctx, IP, hostIP, ID, key, metadata); err != nil {
+				if err := ipcache.UpsertIPToKVStore(ctx, IP, hostIP, ID, key, metadata, k8sNamespace, k8sPodName); err != nil {
 					return fmt.Errorf("unable to add endpoint IP mapping '%s'->'%d': %s", IP.String(), ID, err)
 				}
 				return nil

--- a/pkg/envoy/resources.go
+++ b/pkg/envoy/resources.go
@@ -75,7 +75,8 @@ func (cache *NPHDSCache) OnIPIdentityCacheGC() {
 // OnIPIdentityCacheChange pushes modifications to the IP<->Identity mapping
 // into the Network Policy Host Discovery Service (NPHDS).
 func (cache *NPHDSCache) OnIPIdentityCacheChange(modType ipcache.CacheModification, cidr net.IPNet,
-	oldHostIP, newHostIP net.IP, oldID *identity.NumericIdentity, newID identity.NumericIdentity, encryptKey uint8) {
+	oldHostIP, newHostIP net.IP, oldID *identity.NumericIdentity, newID identity.NumericIdentity,
+	encryptKey uint8, k8sMeta *ipcache.K8sMetadata) {
 	// An upsert where an existing pair exists should translate into a
 	// delete (for the old Identity) followed by an upsert (for the new).
 	if oldID != nil && modType == ipcache.Upsert {
@@ -84,7 +85,7 @@ func (cache *NPHDSCache) OnIPIdentityCacheChange(modType ipcache.CacheModificati
 			return
 		}
 
-		cache.OnIPIdentityCacheChange(ipcache.Delete, cidr, nil, nil, nil, *oldID, encryptKey)
+		cache.OnIPIdentityCacheChange(ipcache.Delete, cidr, nil, nil, nil, *oldID, encryptKey, k8sMeta)
 	}
 
 	cidrStr := cidr.String()

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -60,12 +60,14 @@ type Identity struct {
 // This structure is written as JSON to the key-value store. Do NOT modify this
 // structure in ways which are not JSON forward compatible.
 type IPIdentityPair struct {
-	IP       net.IP          `json:"IP"`
-	Mask     net.IPMask      `json:"Mask"`
-	HostIP   net.IP          `json:"HostIP"`
-	ID       NumericIdentity `json:"ID"`
-	Key      uint8           `json:"Key"`
-	Metadata string          `json:"Metadata"`
+	IP           net.IP          `json:"IP"`
+	Mask         net.IPMask      `json:"Mask"`
+	HostIP       net.IP          `json:"HostIP"`
+	ID           NumericIdentity `json:"ID"`
+	Key          uint8           `json:"Key"`
+	Metadata     string          `json:"Metadata"`
+	K8sNamespace string          `json:"K8sNamespace,omitempty"`
+	K8sPodName   string          `json:"K8sPodName,omitempty"`
 }
 
 func NewIdentityFromModel(base *models.Identity) *Identity {

--- a/pkg/ipcache/cidr.go
+++ b/pkg/ipcache/cidr.go
@@ -83,7 +83,7 @@ func allocateCIDRs(prefixes []*net.IPNet) ([]*identity.Identity, error) {
 
 	// Only upsert into ipcache if identity wasn't allocated before.
 	for prefixString, id := range newlyAllocatedIdentities {
-		IPIdentityCache.Upsert(prefixString, nil, 0, Identity{
+		IPIdentityCache.Upsert(prefixString, nil, 0, nil, Identity{
 			ID:     id.ID,
 			Source: source.Generated,
 		})

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -307,14 +307,7 @@ func (ipc *IPCache) deleteLocked(ip string, source source.Source) {
 		}
 	} else if endpointIP := net.ParseIP(ip); endpointIP != nil { // Endpoint IP.
 		// Convert the endpoint IP into an equivalent full CIDR.
-		bits := net.IPv6len * 8
-		if endpointIP.To4() != nil {
-			bits = net.IPv4len * 8
-		}
-		cidr = &net.IPNet{
-			IP:   endpointIP,
-			Mask: net.CIDRMask(bits, bits),
-		}
+		cidr = endpointIPToCIDR(endpointIP)
 
 		// Check whether the deleted endpoint IP was shadowing that CIDR, and
 		// restore its mapping with the listeners if that was the case.

--- a/pkg/ipcache/listener.go
+++ b/pkg/ipcache/listener.go
@@ -39,8 +39,10 @@ type IPIdentityMappingListener interface {
 	// oldID is not nil; otherwise it is nil.
 	// hostIP is the IP address of the location of the cidr.
 	// hostIP is optional and may only be non-nil for an Upsert modification.
+	// k8sMeta contains the Kubernetes pod namespace and name behind the IP
+	// and may be nil.
 	OnIPIdentityCacheChange(modType CacheModification, cidr net.IPNet, oldHostIP, newHostIP net.IP,
-		oldID *identity.NumericIdentity, newID identity.NumericIdentity, encryptKey uint8)
+		oldID *identity.NumericIdentity, newID identity.NumericIdentity, encryptKey uint8, k8sMeta *K8sMetadata)
 
 	// OnIPIdentityCacheGC will be called to sync other components which are
 	// reliant upon the IPIdentityCache with the IPIdentityCache.

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -294,7 +294,7 @@ func (m *Manager) NodeUpdated(n node.Node) {
 			continue
 		}
 
-		isOwning := ipcache.IPIdentityCache.Upsert(address.IP.String(), nodeIP, n.EncryptionKey, ipcache.Identity{
+		isOwning := ipcache.IPIdentityCache.Upsert(address.IP.String(), nodeIP, n.EncryptionKey, nil, ipcache.Identity{
 			ID:     identity.ReservedIdentityHost,
 			Source: n.Source,
 		})
@@ -313,7 +313,7 @@ func (m *Manager) NodeUpdated(n node.Node) {
 				continue
 			}
 
-			isOwning := ipcache.IPIdentityCache.Upsert(address.IP.String(), nodeIP4, n.EncryptionKey, ipcache.Identity{
+			isOwning := ipcache.IPIdentityCache.Upsert(address.IP.String(), nodeIP4, n.EncryptionKey, nil, ipcache.Identity{
 				ID:     identity.ReservedIdentityHost,
 				Source: n.Source,
 			})
@@ -327,7 +327,7 @@ func (m *Manager) NodeUpdated(n node.Node) {
 		if address == nil {
 			continue
 		}
-		isOwning := ipcache.IPIdentityCache.Upsert(address.String(), n.GetNodeIP(false), n.EncryptionKey, ipcache.Identity{
+		isOwning := ipcache.IPIdentityCache.Upsert(address.String(), n.GetNodeIP(false), n.EncryptionKey, nil, ipcache.Identity{
 			ID:     identity.ReservedIdentityHealth,
 			Source: n.Source,
 		})


### PR DESCRIPTION
This extends the user-level ipcache (excluding the bpf map) with the Kubernetes namespace and pod name of each address (if available). It is intended to be used by clients of cilium monitor to perform lookups to map IP address to pod names without having to consult the Kubernetes API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9237)
<!-- Reviewable:end -->
