### PR TITLE
k8s/types: fix missing deepcopy of SpecPodCIDRs in Node structure

### DIFF
--- a/pkg/k8s/types/zz_generated.deepcopy.go
+++ b/pkg/k8s/types/zz_generated.deepcopy.go
@@ -219,6 +219,11 @@ func (in *Node) DeepCopyInto(out *Node) {
 		*out = make([]v1.NodeAddress, len(*in))
 		copy(*out, *in)
 	}
+	if in.SpecPodCIDRs != nil {
+		in, out := &in.SpecPodCIDRs, &out.SpecPodCIDRs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 


### PR DESCRIPTION
Fixes: 47a87f838709 ("pkg/k8s: add support for multi-stack")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9239)
<!-- Reviewable:end -->
