### PR TITLE
Improve cilium getEndpointList function

### DIFF
--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -648,6 +648,20 @@ func (s *EndpointSuite) TestEndpointEventQueueDeadlockUponDeletion(c *C) {
 	}
 }
 
+func BenchmarkEndpointGetModel(b *testing.B) {
+	e := NewEndpointWithState(&suite, &FakeEndpointProxy{}, &allocator.FakeIdentityAllocator{}, 123, StateCreating)
+
+	for i := 0; i < 256; i++ {
+		e.LogStatusOK(BPF, "Hello World!")
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		e.GetModel()
+	}
+}
+
 type ipReleaserDummy struct{}
 
 func (i *ipReleaserDummy) ReleaseIP(ip net.IP) error {


### PR DESCRIPTION
* Currently when doing `cilium endpoint list` a number of goroutines equal to the number of endpoints are created which then extract the current state of individual endpoints. This does not make much sense since we don't have any blocking work when getting model for an endpoint using `endpoint.GetModel`.

* This pull request creates a pool of goroutines with a limit on the maximum number of goroutines(equal to the number of CPUs) and then distribute this work among those.

We ran a bunch of benchmarks to test memory spikes when using different number of concurrent goroutines. It turns out that the heap memory does not show spikes even with a large number of goroutines. This PR thus introduces changes to have a maximum goroutine pool equal to `NumCPU`, which does not alter the performance at all. The benchmark was performed using 50 endpoints in the following three settings -

* Current master - One goroutine for each endpoint.
* Patched with a goroutine pool distributing work for all the endpoints.
* Cilium v1.5

The pprof output for each of these cases are attached below for reference.
[PProf Output](https://drive.google.com/open?id=1B_96_6CBs-q03ZSw7Rc-ev3iy2S-1glM)

Fixes #9220 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9240)
<!-- Reviewable:end -->
