### PR TITLE
cilium: encryption, replace Router() IP with CiliumInternal

### DIFF
--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -624,7 +624,7 @@ func (n *linuxNodeHandler) enableIPsec(newNode *node.Node) {
 			n.replaceNodeIPSecInRoute(new4Net)
 			ciliumInternalIPv4 := newNode.GetCiliumInternalIP(false)
 			if ciliumInternalIPv4 != nil {
-				ipsecLocal := &net.IPNet{IP: n.nodeAddressing.IPv4().Router(), Mask: n.nodeAddressing.IPv4().AllocationCIDR().Mask}
+				ipsecLocal := &net.IPNet{IP: ciliumInternalIPv4, Mask: n.nodeAddressing.IPv4().AllocationCIDR().Mask}
 				ipsecIPv4Wildcard := &net.IPNet{IP: net.ParseIP(wildcardIPv4), Mask: net.IPv4Mask(0, 0, 0, 0)}
 				spi, err = ipsec.UpsertIPsecEndpoint(ipsecLocal, ipsecIPv4Wildcard, ipsec.IPSecDirIn)
 				upsertIPsecLog(err, "local IPv4", ipsecLocal, ipsecIPv4Wildcard, spi)
@@ -646,7 +646,7 @@ func (n *linuxNodeHandler) enableIPsec(newNode *node.Node) {
 			n.replaceNodeIPSecInRoute(new6Net)
 			ciliumInternalIPv6 := newNode.GetCiliumInternalIP(true)
 			if ciliumInternalIPv6 != nil {
-				ipsecLocal := &net.IPNet{IP: n.nodeAddressing.IPv6().Router(), Mask: n.nodeAddressing.IPv6().AllocationCIDR().Mask}
+				ipsecLocal := &net.IPNet{IP: ciliumInternalIPv6, Mask: n.nodeAddressing.IPv6().AllocationCIDR().Mask}
 				ipsecIPv6Wildcard := &net.IPNet{IP: net.ParseIP(wildcardIPv6), Mask: net.CIDRMask(0, 0)}
 				spi, err = ipsec.UpsertIPsecEndpoint(ipsecLocal, ipsecIPv6Wildcard, ipsec.IPSecDirIn)
 				upsertIPsecLog(err, "local IPv6", ipsecLocal, ipsecIPv6Wildcard, spi)


### PR DESCRIPTION
Apparently I thought the RouterIP _should_ be the same as the CiliumInternalIP
for a local Node. And this is usually the case, but it is not required. We
have had a couple reports of cases where encryption was not able to connect
because of this.

Fix by using the CiliumInternalIP in all cases.

Fixes: 05ea001368660 ("cilium: populate wildcard src->dst policy for ipsec")
Signed-off-by: John Fastabend <john.fastabend@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9241)
<!-- Reviewable:end -->
