### PR TITLE
endpoint: Update proxy policies when applying policy map changes out-of-band

### DIFF
--- a/daemon/fqdn.go
+++ b/daemon/fqdn.go
@@ -94,7 +94,7 @@ func identitiesForFQDNSelectorIPs(selectorsWithIPsToUpdate map[policyApi.FQDNSel
 	return selectorIdentitySliceMapping, nil
 }
 
-func (d *Daemon) updateSelectorCacheFQDNs(selectors map[policyApi.FQDNSelector][]*identity.Identity, selectorsWithoutIPs []policyApi.FQDNSelector) (wg *sync.WaitGroup) {
+func (d *Daemon) updateSelectorCacheFQDNs(ctx context.Context, selectors map[policyApi.FQDNSelector][]*identity.Identity, selectorsWithoutIPs []policyApi.FQDNSelector) (wg *sync.WaitGroup) {
 	// Update mapping of selector to set of IPs in selector cache.
 	for selector, identitySlice := range selectors {
 		log.WithFields(logrus.Fields{
@@ -124,7 +124,7 @@ func (d *Daemon) updateSelectorCacheFQDNs(selectors map[policyApi.FQDNSelector][
 	if len(selectors) == 0 && len(selectorsWithoutIPs) == 0 {
 		return &sync.WaitGroup{}
 	}
-	return d.endpointManager.UpdatePolicyMaps()
+	return d.endpointManager.UpdatePolicyMaps(ctx)
 }
 
 // bootstrapFQDN initializes the toFQDNs related subsystems: DNSPoller,
@@ -189,7 +189,7 @@ func (d *Daemon) bootstrapFQDN(restoredEndpoints *endpointRestoreState, preCache
 			metrics.FQDNGarbageCollectorCleanedTotal.Add(float64(len(namesToClean)))
 			log.WithField(logfields.Controller, dnsGCJobName).Infof(
 				"FQDN garbage collector work deleted %d name entries", len(namesToClean))
-			_, err := d.dnsNameManager.ForceGenerateDNS(namesToClean)
+			_, err := d.dnsNameManager.ForceGenerateDNS(context.TODO(), namesToClean)
 			return err
 		},
 	})
@@ -248,7 +248,7 @@ func (d *Daemon) bootstrapFQDN(restoredEndpoints *endpointRestoreState, preCache
 // updateSelectors propagates the mapping of FQDNSelector to identity, as well
 // as the set of FQDNSelectors which have no IPs which correspond to them
 // (usually due to TTL expiry), down to policy layer managed by this daemon.
-func (d *Daemon) updateSelectors(selectorWithIPsToUpdate map[policyApi.FQDNSelector][]net.IP, selectorsWithoutIPs []policyApi.FQDNSelector) (wg *sync.WaitGroup, err error) {
+func (d *Daemon) updateSelectors(ctx context.Context, selectorWithIPsToUpdate map[policyApi.FQDNSelector][]net.IP, selectorsWithoutIPs []policyApi.FQDNSelector) (wg *sync.WaitGroup, err error) {
 	// Convert set of selectors with IPs to update to set of selectors
 	// with identities corresponding to said IPs.
 	selectorsIdentities, err := identitiesForFQDNSelectorIPs(selectorWithIPsToUpdate)
@@ -257,7 +257,7 @@ func (d *Daemon) updateSelectors(selectorWithIPsToUpdate map[policyApi.FQDNSelec
 	}
 
 	// Update mapping in selector cache with new identities.
-	return d.updateSelectorCacheFQDNs(selectorsIdentities, selectorsWithoutIPs), nil
+	return d.updateSelectorCacheFQDNs(ctx, selectorsIdentities, selectorsWithoutIPs), nil
 }
 
 // pollerResponseNotify handles update events for updates from the poller. It
@@ -474,7 +474,12 @@ func (d *Daemon) notifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epI
 			"qname": qname,
 			"ips":   responseIPs,
 		}).Debug("Updating DNS name in cache from response to to query")
-		wg, err := d.dnsNameManager.UpdateGenerateDNS(lookupTime, map[string]*fqdn.DNSIPRecords{
+
+		updateCtx, updateCancel := context.WithTimeout(context.TODO(), option.Config.FQDNProxyResponseMaxDelay)
+		defer updateCancel()
+		updateStart := time.Now()
+
+		wg, err := d.dnsNameManager.UpdateGenerateDNS(updateCtx, lookupTime, map[string]*fqdn.DNSIPRecords{
 			qname: {
 				IPs: responseIPs,
 				TTL: int(TTL),
@@ -488,10 +493,6 @@ func (d *Daemon) notifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epI
 			wg.Wait()
 			close(updateComplete)
 		}(wg, updateComplete)
-
-		updateCtx, updateCancel := context.WithTimeout(context.TODO(), option.Config.FQDNProxyResponseMaxDelay)
-		defer updateCancel()
-		updateStart := time.Now()
 
 		select {
 		case <-updateCtx.Done():
@@ -570,7 +571,7 @@ func (h *deleteFqdnCache) Handle(params DeleteFqdnCacheParams) middleware.Respon
 	if err != nil {
 		return api.Error(DeleteFqdnCacheBadRequestCode, err)
 	}
-	h.daemon.dnsNameManager.ForceGenerateDNS(namesToRegen)
+	h.daemon.dnsNameManager.ForceGenerateDNS(context.TODO(), namesToRegen)
 	return NewDeleteFqdnCacheOK()
 }
 

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/endpoint"
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
@@ -74,23 +75,50 @@ func NewEndpointManager(epSynchronizer EndpointResourceSynchronizer) *EndpointMa
 	return &mgr
 }
 
+// waitForProxyCompletions blocks until all proxy changes have been completed.
+func waitForProxyCompletions(proxyWaitGroup *completion.WaitGroup) error {
+	err := proxyWaitGroup.Context().Err()
+	if err != nil {
+		return fmt.Errorf("context cancelled before waiting for proxy updates: %s", err)
+	}
+
+	start := time.Now()
+	log.Debug("Waiting for proxy updates to complete...")
+	err = proxyWaitGroup.Wait()
+	if err != nil {
+		return fmt.Errorf("proxy updates failed: %s", err)
+	}
+	log.Debug("Wait time for proxy updates: ", time.Since(start))
+
+	return nil
+}
+
 // UpdatePolicyMaps returns a WaitGroup which is signaled upon once all endpoints
 // have had their PolicyMaps updated against the Endpoint's desired policy state.
-func (mgr *EndpointManager) UpdatePolicyMaps() *sync.WaitGroup {
+func (mgr *EndpointManager) UpdatePolicyMaps(ctx context.Context) *sync.WaitGroup {
 	var wg sync.WaitGroup
 
+	proxyWaitGroup := completion.NewWaitGroup(ctx)
+
 	eps := mgr.GetEndpoints()
-	wg.Add(len(eps))
+	wg.Add(len(eps) + 1) // One more for the waitForProxyCompletions below
 
 	// TODO: bound by number of CPUs?
 	for _, ep := range eps {
 		go func(ep *endpoint.Endpoint) {
-			if err := ep.ApplyPolicyMapChanges(); err != nil {
-				ep.Logger("endpointmanager").Warning("Failed to apply policy map changes. These will be re-applied in future updates.")
+			if err := ep.ApplyPolicyMapChanges(proxyWaitGroup); err != nil {
+				ep.Logger("endpointmanager").WithError(err).Warning("Failed to apply policy map changes. These will be re-applied in future updates.")
 			}
 			wg.Done()
 		}(ep)
 	}
+
+	go func() {
+		if err := waitForProxyCompletions(proxyWaitGroup); err != nil {
+			log.WithError(err).Warning("Failed to apply L7 proxy policy changes. These will be re-applied in future updates.")
+		}
+		wg.Done()
+	}()
 
 	return &wg
 }

--- a/pkg/fqdn/config.go
+++ b/pkg/fqdn/config.go
@@ -15,6 +15,7 @@
 package fqdn
 
 import (
+	"context"
 	"net"
 	"sync"
 	"time"
@@ -49,7 +50,7 @@ type Config struct {
 
 	// UpdateSelectors is a callback to update the mapping of FQDNSelector to
 	// sets of IPs.
-	UpdateSelectors func(selectorsWithIPs map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, error)
+	UpdateSelectors func(ctx context.Context, selectorsWithIPs map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, error)
 
 	// PollerResponseNotify is used when the poller receives DNS data in response
 	// to a successful poll.

--- a/pkg/fqdn/dnspoller.go
+++ b/pkg/fqdn/dnspoller.go
@@ -113,7 +113,7 @@ func (poller *DNSPoller) LookupUpdateDNS(ctx context.Context) error {
 		poller.config.PollerResponseNotify(lookupTime, qname, response)
 	}
 
-	_, err := poller.ruleManager.UpdateGenerateDNS(lookupTime, updatedDNSIPs)
+	_, err := poller.ruleManager.UpdateGenerateDNS(ctx, lookupTime, updatedDNSIPs)
 	return err
 }
 

--- a/pkg/fqdn/dnspoller_test.go
+++ b/pkg/fqdn/dnspoller_test.go
@@ -143,7 +143,7 @@ func (ds *FQDNTestSuite) TestNameManagerSelectorHandling(c *C) {
 					return lookupDNSNames(ipLookups, lookups, dnsNames), nil
 				},
 
-				UpdateSelectors: func(map[api.FQDNSelector][]net.IP, []api.FQDNSelector) (*sync.WaitGroup, error) {
+				UpdateSelectors: func(context.Context, map[api.FQDNSelector][]net.IP, []api.FQDNSelector) (*sync.WaitGroup, error) {
 					return &sync.WaitGroup{}, nil
 				},
 			}

--- a/pkg/fqdn/name_manager.go
+++ b/pkg/fqdn/name_manager.go
@@ -15,6 +15,7 @@
 package fqdn
 
 import (
+	"context"
 	"net"
 	"regexp"
 	"sync"
@@ -162,7 +163,7 @@ func NewNameManager(config Config) *NameManager {
 	}
 
 	if config.UpdateSelectors == nil {
-		config.UpdateSelectors = func(selectorIPMapping map[api.FQDNSelector][]net.IP, namesMissingIPs []api.FQDNSelector) (*sync.WaitGroup, error) {
+		config.UpdateSelectors = func(ctx context.Context, selectorIPMapping map[api.FQDNSelector][]net.IP, namesMissingIPs []api.FQDNSelector) (*sync.WaitGroup, error) {
 			return &sync.WaitGroup{}, nil
 		}
 	}
@@ -196,7 +197,7 @@ func (n *NameManager) GetDNSNames() (dnsNames []string) {
 // UpdateGenerateDNS inserts the new DNS information into the cache. If the IPs
 // have changed for a name, store which rules must be updated in rulesToUpdate,
 // regenerate them, and emit via UpdateSelectors.
-func (n *NameManager) UpdateGenerateDNS(lookupTime time.Time, updatedDNSIPs map[string]*DNSIPRecords) (wg *sync.WaitGroup, err error) {
+func (n *NameManager) UpdateGenerateDNS(ctx context.Context, lookupTime time.Time, updatedDNSIPs map[string]*DNSIPRecords) (wg *sync.WaitGroup, err error) {
 	// Update IPs in n
 	fqdnSelectorsToUpdate, updatedDNSNames := n.UpdateDNSIPs(lookupTime, updatedDNSIPs)
 	for dnsName, IPs := range updatedDNSNames {
@@ -213,13 +214,13 @@ func (n *NameManager) UpdateGenerateDNS(lookupTime time.Time, updatedDNSIPs map[
 			Debug("No IPs to insert when generating DNS name selected by ToFQDN rule")
 	}
 
-	return n.config.UpdateSelectors(selectorIPMapping, namesMissingIPs)
+	return n.config.UpdateSelectors(ctx, selectorIPMapping, namesMissingIPs)
 }
 
 // ForceGenerateDNS unconditionally regenerates all rules that refer to DNS
 // names in namesToRegen. These names are FQDNs and toFQDNs.matchPatterns or
 // matchNames that match them will cause these rules to regenerate.
-func (n *NameManager) ForceGenerateDNS(namesToRegen []string) (wg *sync.WaitGroup, err error) {
+func (n *NameManager) ForceGenerateDNS(ctx context.Context, namesToRegen []string) (wg *sync.WaitGroup, err error) {
 	n.Mutex.Lock()
 	affectedFQDNSels := make(map[api.FQDNSelector]struct{}, 0)
 	for _, dnsName := range namesToRegen {
@@ -239,7 +240,7 @@ func (n *NameManager) ForceGenerateDNS(namesToRegen []string) (wg *sync.WaitGrou
 
 	// emit the new rules
 	return n.config.
-		UpdateSelectors(selectorIPMapping, namesMissingIPs)
+		UpdateSelectors(ctx, selectorIPMapping, namesMissingIPs)
 }
 
 func (n *NameManager) CompleteBootstrap() {

--- a/pkg/fqdn/name_manager_test.go
+++ b/pkg/fqdn/name_manager_test.go
@@ -17,6 +17,7 @@
 package fqdn
 
 import (
+	"context"
 	"net"
 	"sync"
 	"time"
@@ -50,7 +51,7 @@ func (ds *FQDNTestSuite) TestNameManagerCIDRGeneration(c *C) {
 				return lookupFail(c, dnsNames)
 			},
 
-			UpdateSelectors: func(selectorIPMapping map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, error) {
+			UpdateSelectors: func(ctx context.Context, selectorIPMapping map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, error) {
 				for k, v := range selectorIPMapping {
 					selIPMap[k] = v
 				}
@@ -67,7 +68,7 @@ func (ds *FQDNTestSuite) TestNameManagerCIDRGeneration(c *C) {
 	// poll DNS once, check that we only generate 1 rule (for 1 IP) and that we
 	// still have 1 ToFQDN rule, and that the IP is correct
 	selIPMap = make(map[api.FQDNSelector][]net.IP)
-	_, err := nameManager.UpdateGenerateDNS(time.Now(), map[string]*DNSIPRecords{dns.Fqdn("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}}})
+	_, err := nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{dns.Fqdn("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}}})
 	c.Assert(err, IsNil, Commentf("Error mapping selectors to IPs"))
 	c.Assert(len(selIPMap), Equals, 1, Commentf("Incorrect length for testCase with single ToFQDNs entry"))
 
@@ -79,7 +80,7 @@ func (ds *FQDNTestSuite) TestNameManagerCIDRGeneration(c *C) {
 	// inserted) and that we still have 1 ToFQDN rule, and that the IP, now
 	// different, is correct
 	selIPMap = make(map[api.FQDNSelector][]net.IP)
-	_, err = nameManager.UpdateGenerateDNS(time.Now(), map[string]*DNSIPRecords{dns.Fqdn("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("2.2.2.2")}}})
+	_, err = nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{dns.Fqdn("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("2.2.2.2")}}})
 	c.Assert(err, IsNil, Commentf("Error generating IP CIDR rules"))
 	c.Assert(len(selIPMap), Equals, 1, Commentf("Only one entry per FQDNSelector should be present"))
 	expectedIPs = []net.IP{net.ParseIP("1.1.1.1"), net.ParseIP("2.2.2.2")}
@@ -100,7 +101,7 @@ func (ds *FQDNTestSuite) TestNameManagerMultiIPUpdate(c *C) {
 				return lookupFail(c, dnsNames)
 			},
 
-			UpdateSelectors: func(selectorIPMapping map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, error) {
+			UpdateSelectors: func(ctx context.Context, selectorIPMapping map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, error) {
 				for k, v := range selectorIPMapping {
 					selIPMap[k] = v
 				}
@@ -118,14 +119,14 @@ func (ds *FQDNTestSuite) TestNameManagerMultiIPUpdate(c *C) {
 
 	// poll DNS once, check that we only generate 1 IP for cilium.io
 	selIPMap = make(map[api.FQDNSelector][]net.IP)
-	_, err := nameManager.UpdateGenerateDNS(time.Now(), map[string]*DNSIPRecords{dns.Fqdn("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}}})
+	_, err := nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{dns.Fqdn("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}}})
 	c.Assert(err, IsNil, Commentf("Error mapping selectors to IPs"))
 	c.Assert(len(selIPMap), Equals, 1, Commentf("Incorrect number of plumbed FQDN selectors"))
 	c.Assert(selIPMap[ciliumIOSel][0].Equal(net.ParseIP("1.1.1.1")), Equals, true)
 
 	// poll DNS once, check that we only generate 3 IPs, 2 cached from before and 1 new one for github.com
 	selIPMap = make(map[api.FQDNSelector][]net.IP)
-	_, err = nameManager.UpdateGenerateDNS(time.Now(), map[string]*DNSIPRecords{
+	_, err = nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{
 		dns.Fqdn("cilium.io"):  {TTL: 60, IPs: []net.IP{net.ParseIP("2.2.2.2")}},
 		dns.Fqdn("github.com"): {TTL: 60, IPs: []net.IP{net.ParseIP("3.3.3.3")}}})
 	c.Assert(err, IsNil, Commentf("Error mapping selectors to IPs"))
@@ -138,7 +139,7 @@ func (ds *FQDNTestSuite) TestNameManagerMultiIPUpdate(c *C) {
 
 	// poll DNS once, check that we only generate 4 IPs, 2 cilium.io cached IPs, 1 cached github.com IP, 1 new github.com IP
 	selIPMap = make(map[api.FQDNSelector][]net.IP)
-	_, err = nameManager.UpdateGenerateDNS(time.Now(), map[string]*DNSIPRecords{
+	_, err = nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{
 		dns.Fqdn("cilium.io"):  {TTL: 60, IPs: []net.IP{net.ParseIP("2.2.2.2")}},
 		dns.Fqdn("github.com"): {TTL: 60, IPs: []net.IP{net.ParseIP("4.4.4.4")}}})
 	c.Assert(err, IsNil, Commentf("Error mapping selectors to IPs"))


### PR DESCRIPTION
Update proxy policies in addition to bpf maps when applying policy map changes outside of the full endpoint regeneration logic.  Full regeneration is done when policy changes, without which there are no added or deleted proxy redirects. Given this we only need to update the proxy policy on this code path.  Proxy updates are only done if the changed bpf map entries have a non-zero proxy port.  The callers are expected to provide a context which bounds the wait time on proxy
completions if any.

Testing the problem with #9208 turned out to be very challenging. Basically it seems the proxy gets the policy update due to the full regeneration before it gets the request, but as full regeneration is currently gated at at most 2 times per second, this behavior cannot be relied upon, so this fix should still be applied.

Fixes: #9208

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9243)
<!-- Reviewable:end -->
