### PR TITLE
docs: Do not pin cilium image vsn in kubeproxy-free guide

### DIFF
--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -76,7 +76,6 @@ port number reported by ``kubeadm init`` (usually it is ``6443``).
         --set global.nodePort.enabled=true \
         --set global.k8sServiceHost=$API_SERVER_IP \
         --set global.k8sServicePort=$API_SERVER_PORT \
-        --set global.tag=v1.6.0 \
     > cilium.yaml
     kubectl apply -f cilium.yaml
 


### PR DESCRIPTION
This PR fixes the forgotten leftover from #9195 - we no longer need to pin the cilium Docker images vsn (see the linked PR for the explanation).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9249)
<!-- Reviewable:end -->
