### PR TITLE
docs: fix aks guide

### DIFF
--- a/Documentation/gettingstarted/k8s-install-aks.rst
+++ b/Documentation/gettingstarted/k8s-install-aks.rst
@@ -64,7 +64,10 @@ It can take 10+ minutes for the final command to be complete indicating that the
             --subnet-prefix 10.240.0.0/16
 
         # Create a service principal and read in the application ID
-        SP_ID=$(az ad sp create-for-rbac --password $SP_PASSWORD --skip-assignment --query [appId] -o tsv)
+        SP_ID_PASSWORD=$(az ad sp create-for-rbac --skip-assignment --query [appId,password] -o tsv)
+        SP_ID=$(echo ${SP_ID_PASSWORD} | sed -e 's/ .*//g')
+        SP_PASSWORD=$(echo ${SP_ID_PASSWORD} | sed -e 's/.* //g')
+        unset SP_ID_PASSWORD
 
         # Wait 15 seconds to make sure that service principal has propagated
         echo "Waiting for service principal to propagate..."

--- a/Documentation/gettingstarted/k8s-install-azure-cni-steps.rst
+++ b/Documentation/gettingstarted/k8s-install-azure-cni-steps.rst
@@ -65,7 +65,7 @@ Generate the required YAML file and deploy it:
      --namespace cilium \
      --set global.cni.chainingMode=generic-veth \
      --set global.cni.customConf=true \
-     --set nodeinit.enabled=true \
+     --set global.nodeinit.enabled=true \
      --set global.cni.configMap=cni-configuration \
      --set global.tunnel=disabled \
      > cilium.yaml


### PR DESCRIPTION
Rewrite AKS guide since as of Azure CLI 2.0.68, the --password parameter
to create a service principal with a user-defined password is no longer
supported to prevent the accidental use of weak passwords.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9250)
<!-- Reviewable:end -->
