### PR TITLE
Add support for running ginkgo tests in microk8s clusters

### DIFF
--- a/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
@@ -270,7 +270,7 @@ spec:
       volumes:
         # To keep state between restarts / upgrades
       - hostPath:
-          path: /var/run/cilium
+          path: {{ .Values.global.daemon.runPath }}
           type: DirectoryOrCreate
         name: cilium-run
 {{- /* CRI-O already mounts the BPF filesystem */ -}}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -287,3 +287,6 @@ global:
     # bootstrapFile is the location of the file where the bootstrap timestamp is
     # written by the node-init DaemonSet
     bootstrapFile: "/tmp/cilium-bootstrap-time"
+
+  daemon:
+    runPath: "/var/run/cilium"

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -66,6 +66,9 @@ const (
 	// CIIntegrationEKS contains the constants to be used when running tests on EKS.
 	CIIntegrationEKS = "eks"
 
+	// CIIntegrationMicrok8s contains the constant to be used when running tests on microk8s.
+	CIIntegrationMicrok8s = "microk8s"
+
 	LogGathererSelector  = "k8s-app=cilium-test-logs"
 	LogGathererNamespace = "kube-system"
 )
@@ -107,12 +110,22 @@ var (
 		"global.nodeinit.enabled":       "true",
 	}
 
+	microk8sHelmOverrides = map[string]string{
+		"global.cni.confPath":                 "/var/snap/microk8s/current/args/cni-network",
+		"global.cni.binPath":                  "/var/snap/microk8s/current/opt/cni/bin",
+		"global.cni.customConf":               "true",
+		"global.containerRuntime.integration": "containerd",
+		"global.containerRuntime.socketPath":  "/var/snap/microk8s/common/run/containerd.sock",
+		"global.daemon.runPath":               "/var/snap/microk8s/current/var/run/cilium",
+	}
+
 	// helmOverrides allows overriding of cilium-agent options for
 	// specific CI environment integrations.
 	// The key must be a string consisting of lower case characters.
 	helmOverrides = map[string]map[string]string{
 		CIIntegrationFlannel:  flannelHelmOverrides,
 		CIIntegrationEKS:      eksHelmOverrides,
+		CIIntegrationMicrok8s: microk8sHelmOverrides,
 	}
 )
 


### PR DESCRIPTION
This PR extends the kubectl-based ginkgo CI target to allow users to target the tests to run in a microk8s cluster by specifying `CNI_INTEGRATION=microk8s`.

Example usage:
```
$ CNI_INTEGRATION=microk8s CILIUM_IMAGE="localhost:32000/cilium/cilium:local" CILIUM_OPERATOR_IMAGE="docker.io/cilium/operator:latest" K8S_VERSION=1.16 ginkgo -v -focus="MonitorAggregation*" -- -cilium.provision=false -cilium.kubeconfig=/home/joe/.kube/config -cilium.passCLIEnvironment=true -cilium.testScope=k8s -cilium.holdEnvironment=true -cilium.skipLogs=true
```

Note, microk8s isn't really a CNI_INTEGRATION but this is the same variable we're using for allowing the cilium-agent options to be overridden for EKS environments so I figured it's simpler to just reuse the same environment variable for this. We can always rename it in future, eg to `CI_INTEGRATION` which would make more sense.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9253)
<!-- Reviewable:end -->
