### PR TITLE
Fix race condition in loader that causes policy drops for static pods

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN make LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 V=$V LIBNETWORK_PLUGIN=$LIBNETWORK_PLU
 # built while allowing the new versions to make changes that are not
 # backwards compatible.
 #
-FROM quay.io/cilium/cilium-runtime:2019-09-04
+FROM quay.io/cilium/cilium-runtime:2019-09-23
 LABEL maintainer="maintainer@cilium.io"
 COPY --from=builder /tmp/install /
 COPY --from=cilium-envoy / /


### PR DESCRIPTION
Pull in the `cilium-runtime` image which was built against the latest
iproute2 `static-data` branch changes to fix #9226.

Relevant `iproute2` changes: https://github.com/cilium/iproute2/pull/2

Fixes: #9226

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9255)
<!-- Reviewable:end -->
