### PR TITLE
endpoint: Remove useless restore log message

### DIFF
--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -347,7 +347,6 @@ type serializableEndpoint struct {
 func (ep *Endpoint) UnmarshalJSON(raw []byte) error {
 	// We may have to populate structures in the Endpoint manually to do the
 	// translation from serializableEndpoint --> Endpoint.
-	log.Info("parsing serializableEndpoint marshaled into headerfile")
 	restoredEp := &serializableEndpoint{
 		OpLabels:   labels.NewOpLabels(),
 		DNSHistory: fqdn.NewDNSCacheWithLimit(option.Config.ToFQDNsMinTTL, option.Config.ToFQDNsMaxIPsPerHost),


### PR DESCRIPTION
This log message just floods the logs upon restore, with no real useful information:

```
level=info msg="parsing serializableEndpoint marshaled into headerfile" subsys=endpoint
level=info msg="parsing serializableEndpoint marshaled into headerfile" subsys=endpoint                                                                                                                                                
level=info msg="parsing serializableEndpoint marshaled into headerfile" subsys=endpoint                                                                                                                                                
level=info msg="parsing serializableEndpoint marshaled into headerfile" subsys=endpoint                                                                                                                                                
level=info msg="parsing serializableEndpoint marshaled into headerfile" subsys=endpoint
level=info msg="parsing serializableEndpoint marshaled into headerfile" subsys=endpoint                                                                                                                                                
level=info msg="parsing serializableEndpoint marshaled into headerfile" subsys=endpoint      
```

Remove it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9256)
<!-- Reviewable:end -->
