### PR TITLE
Fix issue where static pods never receive kubernetes labels

### DIFF
--- a/test/standalone/microk8s-static-pods.sh
+++ b/test/standalone/microk8s-static-pods.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+SNAP_COMMON=${SNAP_COMMON:-"/var/snap/microk8s/common"}
+KUBELET_CONF="/var/snap/microk8s/current/args/kubelet"
+POD_MANIFESTS_PATH="${SNAP_COMMON}/etc/kubelet.d"
+STATIC_POD_PATH="${POD_MANIFESTS_PATH}/static-web.yaml"
+TEST_NAME="$0"
+
+set -e
+
+if [ $UID != 0 ]; then
+    echo "Script must be run as root"
+    exit
+fi
+
+trap cleanup EXIT
+
+function log {
+    echo "$@" >&2
+}
+
+function abort {
+    log "$@"
+    return 1
+}
+
+function test_succeeded {
+    log "$@"
+    echo "Success"
+}
+
+function cilium {
+    microk8s.cilium "$@"
+}
+
+function cleanup {
+    rm -rf $STATIC_POD_PATH
+}
+
+function cfg_kubelet {
+    if ! grep -q "pod-manifest-path" $KUBELET_CONF; then
+        echo "--pod-manifest-path=${POD_MANIFESTS_PATH}" >> $KUBELET_CONF
+        systemctl restart snap.microk8s.daemon-apiserver.service
+    fi
+}
+
+# $1 - start / stop / restart
+function apiserver {
+    systemctl "$1" snap.microk8s.daemon-apiserver.service
+}
+
+function cfg_static_pod {
+    mkdir -p $POD_MANIFESTS_PATH
+    cat <<EOF >$STATIC_POD_PATH
+apiVersion: v1
+kind: Pod
+metadata:
+  name: static-web
+  labels:
+    role: myrole
+spec:
+  containers:
+    - name: web
+      image: nginx
+      ports:
+        - name: web
+          containerPort: 80
+          protocol: TCP
+EOF
+}
+
+function check_pod_labels {
+    static_pod_labels="$(cilium endpoint list -o json \
+        | jq '.[].status.labels."security-relevant"
+              | select(any(.[]; contains("k8s"))|not)
+              | select(any(.[]; contains("health"))|not)')"
+    log "$static_pod_labels"
+    [ "$(echo "$static_pod_labels" | jq 'length')" = "" ]
+}
+
+# Setup
+log "Configuring the test"
+cleanup
+cfg_kubelet
+apiserver stop
+cfg_static_pod
+sleep 2
+apiserver start
+
+# Initial logging status
+log "Gathering initial state from cilium"
+log "$(cilium status)"
+log "$(cilium endpoint list)"
+
+log "Running test..."
+if ! check_pod_labels; then
+    # Sleep for up to 50 seconds, checking that the pod labels get properly updated from apiserver
+    for i in {1..10}; do
+        if check_pod_labels; then
+            break
+        fi
+        log "Static pod labels don't contain kubernetes labels"
+        sleep 5
+    done
+    if ! check_pod_labels; then
+        abort "Static pod labels don't contain kubernetes labels after timeout"
+    fi
+fi
+
+test_succeeded "${TEST_NAME}"


### PR DESCRIPTION
When a pod's labels are unable to be resolved in kube-apiserver, start
up a controller which will regularly attempt resolving the pod labels.
Eventually the apiserver should become aware of the pod and the labels
will be resolved, at which point this new code will update the
labels/identity and stop the controller.

We need this because apiserver is not sending notifications to Cilium
about static pods when it learns about them, so we would otherwise
never learn the labels of such pods.

Related: #9255
Fixes: #8559

I manually validated this by:
* Deploying this version of Cilium
* Configuring kubelet to support static pods (restart required)
* Disabled apiserver
* Created a static pod yaml in the configured kubelet directory
* Restarted apiserver after a couple of seconds
* Observed that the new controller was running
* After some time, observed that the new controller was no longer running, and the static pod had all of the labels from kubernetes.

The above manual test validation formed the basis for the script added in the second patch.

I also briefly considered instead supporting mounting the static pod directory into the Cilium container and having cilium-agent use these files as a potential second source of truth. This would be operationally more complex (requiring configuration of the directory at the very least), and would split the source of truth from just apiserver to two locations - files and apiserver. Furthermore the pod yaml doesn't specify the full pod name (which is derived from the hostname) and may not provide the namespace, so we would have to reproduce the logic for deriving these and the cluster in that logic (perhaps not a big deal). If it is strongly important to reduce the time period in which static pods may be represented with the "init" identity then we may still want to investigate this approach instead. That said we can also tweak the controller run period in this PR to speed things up, though it is still fundamentally dependent on the apiserver being notified about the static pod.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9257)
<!-- Reviewable:end -->
