### PR TITLE
v1.6 backports 2019-09-24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN make LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 V=$V LIBNETWORK_PLUGIN=$LIBNETWORK_PLU
 # built while allowing the new versions to make changes that are not
 # backwards compatible.
 #
-FROM quay.io/cilium/cilium-runtime:2019-08-13
+FROM quay.io/cilium/cilium-runtime:2019-09-23
 LABEL maintainer="maintainer@cilium.io"
 COPY --from=builder /tmp/install /
 COPY --from=cilium-envoy / /

--- a/Documentation/gettingstarted/k8s-install-aks.rst
+++ b/Documentation/gettingstarted/k8s-install-aks.rst
@@ -64,7 +64,10 @@ It can take 10+ minutes for the final command to be complete indicating that the
             --subnet-prefix 10.240.0.0/16
 
         # Create a service principal and read in the application ID
-        SP_ID=$(az ad sp create-for-rbac --password $SP_PASSWORD --skip-assignment --query [appId] -o tsv)
+        SP_ID_PASSWORD=$(az ad sp create-for-rbac --skip-assignment --query [appId,password] -o tsv)
+        SP_ID=$(echo ${SP_ID_PASSWORD} | sed -e 's/ .*//g')
+        SP_PASSWORD=$(echo ${SP_ID_PASSWORD} | sed -e 's/.* //g')
+        unset SP_ID_PASSWORD
 
         # Wait 15 seconds to make sure that service principal has propagated
         echo "Waiting for service principal to propagate..."

--- a/Documentation/gettingstarted/k8s-install-azure-cni-steps.rst
+++ b/Documentation/gettingstarted/k8s-install-azure-cni-steps.rst
@@ -63,6 +63,7 @@ Generate the required YAML file and deploy it:
 
    helm template cilium \
      --namespace cilium \
+     --set nodeinit.azure=true \
      --set global.cni.chainingMode=generic-veth \
      --set global.cni.customConf=true \
      --set global.nodeinit.enabled=true \

--- a/Documentation/gettingstarted/k8s-install-azure-cni-steps.rst
+++ b/Documentation/gettingstarted/k8s-install-azure-cni-steps.rst
@@ -65,7 +65,7 @@ Generate the required YAML file and deploy it:
      --namespace cilium \
      --set global.cni.chainingMode=generic-veth \
      --set global.cni.customConf=true \
-     --set nodeinit.enabled=true \
+     --set global.nodeinit.enabled=true \
      --set global.cni.configMap=cni-configuration \
      --set global.tunnel=disabled \
      > cilium.yaml

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -66,7 +66,6 @@ port number reported by ``kubeadm init`` (usually it is ``6443``).
         --set global.nodePort.enabled=true \
         --set global.k8sServiceHost=$API_SERVER_IP \
         --set global.k8sServicePort=$API_SERVER_PORT \
-        --set global.tag=v1.6.0 \
     > cilium.yaml
     kubectl apply -f cilium.yaml
 

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -4,6 +4,7 @@ Alemayhu
 allocators
 allocator
 alu
+aks
 ami
 analytics
 ansible
@@ -20,6 +21,7 @@ au
 authenticator
 awk
 aws
+az
 backend
 backends
 backport

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -25,11 +25,13 @@ import (
 	. "github.com/cilium/cilium/api/v1/server/restapi/endpoint"
 	"github.com/cilium/cilium/pkg/api"
 	"github.com/cilium/cilium/pkg/completion"
+	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/endpoint"
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/k8s"
+	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/lxcmap"
@@ -249,6 +251,42 @@ func (d *Daemon) createEndpoint(ctx context.Context, epTemplate *models.Endpoint
 		// get its actual identity.
 		addLabels = labels.Labels{
 			labels.IDNameInit: labels.NewLabel(labels.IDNameInit, "", labels.LabelSourceReserved),
+		}
+	}
+
+	// Static pods (mirror pods) might be configured before the apiserver
+	// is available or has received the notification that includes the
+	// static pod's labels. In this case, start a controller to attempt to
+	// resolve the labels.
+	if ep.K8sNamespaceAndPodNameIsSet() && k8s.IsEnabled() {
+		// If there are labels, but no pod namespace then it's
+		// likely that there are no k8s labels at all. Resolve.
+		if _, k8sLabelsConfigured := addLabels[k8sConst.PodNamespaceLabel]; !k8sLabelsConfigured {
+			done := make(chan struct{})
+
+			// 'ep' is not yet shared; safe to GetK8sNamespaceAndPodNameLocked() without lock.
+			controllerName := fmt.Sprintf("resolve-labels-%s", ep.GetK8sNamespaceAndPodNameLocked())
+			mgr := controller.NewManager()
+			mgr.UpdateController(controllerName,
+				controller.ControllerParams{
+					DoFunc: func(ctx context.Context) error {
+						identityLabels, info, err := fetchK8sLabels(ep)
+						if err != nil {
+							ep.Logger(controllerName).WithError(err).Warning("Unable to fetch kubernetes labels")
+							return err
+						}
+
+						ep.UpdateLabels(ctx, identityLabels, info, true)
+						close(done)
+						return nil
+					},
+					RunInterval: 30 * time.Second,
+				},
+			)
+			go func() {
+				<-done
+				mgr.RemoveController(controllerName)
+			}()
 		}
 	}
 

--- a/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
@@ -67,10 +67,16 @@ spec:
                 echo "Installed sys-fs-bpf.mount to /lib/systemd/system/"
               fi
 
+{{- if .Values.azure }}
               # Azure specific:
+              until [ -f /var/run/azure-vnet.json ]; do
+                echo waiting for azure-vnet to be created
+                sleep 1s
+              done
               if [ -f /var/run/azure-vnet.json ]; then
                 sed -i 's/"Mode": "bridge",/"Mode": "transparent",/g' /var/run/azure-vnet.json
               fi
+{{- end }}
 
               # Ensure that filesystem gets mounted on next reboot
               systemctl enable sys-fs-bpf.mount

--- a/install/kubernetes/cilium/charts/nodeinit/values.yaml
+++ b/install/kubernetes/cilium/charts/nodeinit/values.yaml
@@ -7,3 +7,7 @@ reconfigureKubelet: false
 
 # Delete the cbr0 bridge if it exists (GKE)
 removeCbrBridge: false
+
+# Wait for the /var/run/azure-vnet.json file to be created before continuing the
+# script
+azure: false

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -622,7 +622,7 @@ func (n *linuxNodeHandler) enableIPsec(newNode *node.Node) {
 			n.replaceNodeIPSecInRoute(new4Net)
 			ciliumInternalIPv4 := newNode.GetCiliumInternalIP(false)
 			if ciliumInternalIPv4 != nil {
-				ipsecLocal := &net.IPNet{IP: n.nodeAddressing.IPv4().Router(), Mask: n.nodeAddressing.IPv4().AllocationCIDR().Mask}
+				ipsecLocal := &net.IPNet{IP: ciliumInternalIPv4, Mask: n.nodeAddressing.IPv4().AllocationCIDR().Mask}
 				ipsecIPv4Wildcard := &net.IPNet{IP: net.ParseIP(wildcardIPv4), Mask: net.IPv4Mask(0, 0, 0, 0)}
 				spi, err = ipsec.UpsertIPsecEndpoint(ipsecLocal, ipsecIPv4Wildcard, ipsec.IPSecDirIn)
 				upsertIPsecLog(err, "local IPv4", ipsecLocal, ipsecIPv4Wildcard, spi)
@@ -644,7 +644,7 @@ func (n *linuxNodeHandler) enableIPsec(newNode *node.Node) {
 			n.replaceNodeIPSecInRoute(new6Net)
 			ciliumInternalIPv6 := newNode.GetCiliumInternalIP(true)
 			if ciliumInternalIPv6 != nil {
-				ipsecLocal := &net.IPNet{IP: n.nodeAddressing.IPv6().Router(), Mask: n.nodeAddressing.IPv6().AllocationCIDR().Mask}
+				ipsecLocal := &net.IPNet{IP: ciliumInternalIPv6, Mask: n.nodeAddressing.IPv6().AllocationCIDR().Mask}
 				ipsecIPv6Wildcard := &net.IPNet{IP: net.ParseIP(wildcardIPv6), Mask: net.CIDRMask(0, 0)}
 				spi, err = ipsec.UpsertIPsecEndpoint(ipsecLocal, ipsecIPv6Wildcard, ipsec.IPSecDirIn)
 				upsertIPsecLog(err, "local IPv6", ipsecLocal, ipsecIPv6Wildcard, spi)

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -901,7 +901,10 @@ func (e *Endpoint) GetBPFValue() (*lxcmap.EndpointInfo, error) {
 	return info, nil
 }
 
-func (e *Endpoint) deletePolicyKey(keyToDelete policy.Key, incremental bool) bool {
+// The bool pointed by hadProxy, if not nil, will be set to 'true' if
+// the deleted entry had a proxy port assigned to it.  *hadProxy is
+// not otherwise changed (e.g., it is never set to 'false').
+func (e *Endpoint) deletePolicyKey(keyToDelete policy.Key, incremental bool, hadProxy *bool) bool {
 	// Convert from policy.Key to policymap.Key
 	policymapKey := policymap.PolicyKey{
 		Identity:         keyToDelete.Identity,
@@ -920,6 +923,12 @@ func (e *Endpoint) deletePolicyKey(keyToDelete policy.Key, incremental bool) boo
 	if err != nil && errno != syscall.ENOENT {
 		e.getLogger().WithError(err).WithField(logfields.BPFMapKey, policymapKey).Error("Failed to delete PolicyMap key")
 		return false
+	}
+
+	if hadProxy != nil {
+		if entry, ok := e.realizedPolicy.PolicyMapState[keyToDelete]; ok && entry.ProxyPort != 0 {
+			*hadProxy = true
+		}
 	}
 
 	// Operation was successful, remove from realized state.
@@ -965,17 +974,28 @@ func (e *Endpoint) addPolicyKey(keyToAdd policy.Key, entry policy.MapStateEntry,
 // ApplyPolicyMapChanges updates the Endpoint's PolicyMap with the changes
 // that have accumulated for the PolicyMap via various outside events (e.g.,
 // identities added / deleted).
-func (e *Endpoint) ApplyPolicyMapChanges() error {
+func (e *Endpoint) ApplyPolicyMapChanges(proxyWaitGroup *completion.WaitGroup) error {
 	if err := e.LockAlive(); err != nil {
 		return err
 	}
 	defer e.Unlock()
-	return e.applyPolicyMapChanges()
+
+	proxyChanges, err := e.applyPolicyMapChanges()
+	if err != nil {
+		return err
+	}
+
+	if proxyChanges {
+		// Ignoring the revertFunc; keep all successful changes even if some fail.
+		err, _ = e.updateNetworkPolicy(proxyWaitGroup)
+	}
+
+	return err
 }
 
 // applyPolicyMapChanges applies any incremental policy map changes
 // collected on the desired policy.
-func (e *Endpoint) applyPolicyMapChanges() error {
+func (e *Endpoint) applyPolicyMapChanges() (proxyChanges bool, err error) {
 	errors := 0
 
 	//  Note that after successful endpoint regeneration the
@@ -989,19 +1009,22 @@ func (e *Endpoint) applyPolicyMapChanges() error {
 	for keyToAdd, entry := range adds {
 		// Keep the existing proxy port, if any
 		entry.ProxyPort = e.realizedRedirects[policy.ProxyIDFromKey(e.ID, keyToAdd)]
+		if entry.ProxyPort != 0 {
+			proxyChanges = true
+		}
 		if !e.addPolicyKey(keyToAdd, entry, true) {
 			errors++
 		}
 	}
 
 	for keyToDelete := range deletes {
-		if !e.deletePolicyKey(keyToDelete, true) {
+		if !e.deletePolicyKey(keyToDelete, true, &proxyChanges) {
 			errors++
 		}
 	}
 
 	if errors > 0 {
-		return fmt.Errorf("updating desired PolicyMap state failed")
+		return proxyChanges, fmt.Errorf("updating desired PolicyMap state failed")
 	} else if len(adds)+len(deletes) > 0 {
 		e.getLogger().WithFields(logrus.Fields{
 			logfields.AddedPolicyID:   adds,
@@ -1009,7 +1032,7 @@ func (e *Endpoint) applyPolicyMapChanges() error {
 		}).Debug("Applied policy map updates due identity changes")
 	}
 
-	return nil
+	return proxyChanges, nil
 }
 
 // syncPolicyMap updates the bpf policy map state based on the
@@ -1024,7 +1047,7 @@ func (e *Endpoint) syncPolicyMap() error {
 		for keyToDelete := range e.realizedPolicy.PolicyMapState {
 			// If key that is in realized state is not in desired state, just remove it.
 			if _, ok := e.desiredPolicy.PolicyMapState[keyToDelete]; !ok {
-				if !e.deletePolicyKey(keyToDelete, false) {
+				if !e.deletePolicyKey(keyToDelete, false, nil) {
 					errors++
 				}
 			}
@@ -1042,7 +1065,8 @@ func (e *Endpoint) syncPolicyMap() error {
 
 	// Still may have changes due to identities added and/or
 	// deleted after the desired policy was computed.
-	return e.applyPolicyMapChanges()
+	_, err := e.applyPolicyMapChanges()
+	return err
 }
 
 // addPolicyMapDelta adds new or updates existing bpf policy map state based
@@ -1138,7 +1162,7 @@ func (e *Endpoint) syncPolicyMapWithDump() error {
 		// If key that is in policy map is not in desired state, just remove it.
 		if _, ok := e.desiredPolicy.PolicyMapState[keyToDelete]; !ok {
 			e.getLogger().WithField(logfields.BPFMapKey, entry.Key.String()).Debug("syncPolicyMapWithDump removing a bpf policy entry not in the desired state")
-			if !e.deletePolicyKey(keyToDelete, false) {
+			if !e.deletePolicyKey(keyToDelete, false, nil) {
 				errors++
 			}
 		}

--- a/pkg/fqdn/config.go
+++ b/pkg/fqdn/config.go
@@ -15,6 +15,7 @@
 package fqdn
 
 import (
+	"context"
 	"net"
 	"sync"
 	"time"
@@ -49,7 +50,7 @@ type Config struct {
 
 	// UpdateSelectors is a callback to update the mapping of FQDNSelector to
 	// sets of IPs.
-	UpdateSelectors func(selectorsWithIPs map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, error)
+	UpdateSelectors func(ctx context.Context, selectorsWithIPs map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, error)
 
 	// PollerResponseNotify is used when the poller receives DNS data in response
 	// to a successful poll.

--- a/pkg/fqdn/dnspoller.go
+++ b/pkg/fqdn/dnspoller.go
@@ -113,7 +113,7 @@ func (poller *DNSPoller) LookupUpdateDNS(ctx context.Context) error {
 		poller.config.PollerResponseNotify(lookupTime, qname, response)
 	}
 
-	_, err := poller.ruleManager.UpdateGenerateDNS(lookupTime, updatedDNSIPs)
+	_, err := poller.ruleManager.UpdateGenerateDNS(ctx, lookupTime, updatedDNSIPs)
 	return err
 }
 

--- a/pkg/fqdn/dnspoller_test.go
+++ b/pkg/fqdn/dnspoller_test.go
@@ -143,7 +143,7 @@ func (ds *FQDNTestSuite) TestNameManagerSelectorHandling(c *C) {
 					return lookupDNSNames(ipLookups, lookups, dnsNames), nil
 				},
 
-				UpdateSelectors: func(map[api.FQDNSelector][]net.IP, []api.FQDNSelector) (*sync.WaitGroup, error) {
+				UpdateSelectors: func(context.Context, map[api.FQDNSelector][]net.IP, []api.FQDNSelector) (*sync.WaitGroup, error) {
 					return &sync.WaitGroup{}, nil
 				},
 			}

--- a/pkg/fqdn/name_manager_test.go
+++ b/pkg/fqdn/name_manager_test.go
@@ -17,6 +17,7 @@
 package fqdn
 
 import (
+	"context"
 	"net"
 	"sync"
 	"time"
@@ -50,7 +51,7 @@ func (ds *FQDNTestSuite) TestNameManagerCIDRGeneration(c *C) {
 				return lookupFail(c, dnsNames)
 			},
 
-			UpdateSelectors: func(selectorIPMapping map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, error) {
+			UpdateSelectors: func(ctx context.Context, selectorIPMapping map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, error) {
 				for k, v := range selectorIPMapping {
 					selIPMap[k] = v
 				}
@@ -67,7 +68,7 @@ func (ds *FQDNTestSuite) TestNameManagerCIDRGeneration(c *C) {
 	// poll DNS once, check that we only generate 1 rule (for 1 IP) and that we
 	// still have 1 ToFQDN rule, and that the IP is correct
 	selIPMap = make(map[api.FQDNSelector][]net.IP)
-	_, err := nameManager.UpdateGenerateDNS(time.Now(), map[string]*DNSIPRecords{dns.Fqdn("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}}})
+	_, err := nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{dns.Fqdn("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}}})
 	c.Assert(err, IsNil, Commentf("Error mapping selectors to IPs"))
 	c.Assert(len(selIPMap), Equals, 1, Commentf("Incorrect length for testCase with single ToFQDNs entry"))
 
@@ -79,7 +80,7 @@ func (ds *FQDNTestSuite) TestNameManagerCIDRGeneration(c *C) {
 	// inserted) and that we still have 1 ToFQDN rule, and that the IP, now
 	// different, is correct
 	selIPMap = make(map[api.FQDNSelector][]net.IP)
-	_, err = nameManager.UpdateGenerateDNS(time.Now(), map[string]*DNSIPRecords{dns.Fqdn("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("2.2.2.2")}}})
+	_, err = nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{dns.Fqdn("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("2.2.2.2")}}})
 	c.Assert(err, IsNil, Commentf("Error generating IP CIDR rules"))
 	c.Assert(len(selIPMap), Equals, 1, Commentf("Only one entry per FQDNSelector should be present"))
 	expectedIPs = []net.IP{net.ParseIP("1.1.1.1"), net.ParseIP("2.2.2.2")}
@@ -100,7 +101,7 @@ func (ds *FQDNTestSuite) TestNameManagerMultiIPUpdate(c *C) {
 				return lookupFail(c, dnsNames)
 			},
 
-			UpdateSelectors: func(selectorIPMapping map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, error) {
+			UpdateSelectors: func(ctx context.Context, selectorIPMapping map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, error) {
 				for k, v := range selectorIPMapping {
 					selIPMap[k] = v
 				}
@@ -118,14 +119,14 @@ func (ds *FQDNTestSuite) TestNameManagerMultiIPUpdate(c *C) {
 
 	// poll DNS once, check that we only generate 1 IP for cilium.io
 	selIPMap = make(map[api.FQDNSelector][]net.IP)
-	_, err := nameManager.UpdateGenerateDNS(time.Now(), map[string]*DNSIPRecords{dns.Fqdn("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}}})
+	_, err := nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{dns.Fqdn("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}}})
 	c.Assert(err, IsNil, Commentf("Error mapping selectors to IPs"))
 	c.Assert(len(selIPMap), Equals, 1, Commentf("Incorrect number of plumbed FQDN selectors"))
 	c.Assert(selIPMap[ciliumIOSel][0].Equal(net.ParseIP("1.1.1.1")), Equals, true)
 
 	// poll DNS once, check that we only generate 3 IPs, 2 cached from before and 1 new one for github.com
 	selIPMap = make(map[api.FQDNSelector][]net.IP)
-	_, err = nameManager.UpdateGenerateDNS(time.Now(), map[string]*DNSIPRecords{
+	_, err = nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{
 		dns.Fqdn("cilium.io"):  {TTL: 60, IPs: []net.IP{net.ParseIP("2.2.2.2")}},
 		dns.Fqdn("github.com"): {TTL: 60, IPs: []net.IP{net.ParseIP("3.3.3.3")}}})
 	c.Assert(err, IsNil, Commentf("Error mapping selectors to IPs"))
@@ -138,7 +139,7 @@ func (ds *FQDNTestSuite) TestNameManagerMultiIPUpdate(c *C) {
 
 	// poll DNS once, check that we only generate 4 IPs, 2 cilium.io cached IPs, 1 cached github.com IP, 1 new github.com IP
 	selIPMap = make(map[api.FQDNSelector][]net.IP)
-	_, err = nameManager.UpdateGenerateDNS(time.Now(), map[string]*DNSIPRecords{
+	_, err = nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{
 		dns.Fqdn("cilium.io"):  {TTL: 60, IPs: []net.IP{net.ParseIP("2.2.2.2")}},
 		dns.Fqdn("github.com"): {TTL: 60, IPs: []net.IP{net.ParseIP("4.4.4.4")}}})
 	c.Assert(err, IsNil, Commentf("Error mapping selectors to IPs"))

--- a/plugins/cilium-cni/chaining/azure/azure-cni.go
+++ b/plugins/cilium-cni/chaining/azure/azure-cni.go
@@ -1,0 +1,24 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azure
+
+import (
+	chainingapi "github.com/cilium/cilium/plugins/cilium-cni/chaining/api"
+	"github.com/cilium/cilium/plugins/cilium-cni/chaining/generic-veth"
+)
+
+func init() {
+	chainingapi.Register("azure", &genericveth.GenericVethChainer{})
+}

--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cilium/cilium/pkg/version"
 	chainingapi "github.com/cilium/cilium/plugins/cilium-cni/chaining/api"
 	_ "github.com/cilium/cilium/plugins/cilium-cni/chaining/awscni"
+	_ "github.com/cilium/cilium/plugins/cilium-cni/chaining/azure"
 	_ "github.com/cilium/cilium/plugins/cilium-cni/chaining/flannel"
 	_ "github.com/cilium/cilium/plugins/cilium-cni/chaining/generic-veth"
 	_ "github.com/cilium/cilium/plugins/cilium-cni/chaining/portmap"

--- a/test/standalone/microk8s-static-pods.sh
+++ b/test/standalone/microk8s-static-pods.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+SNAP_COMMON=${SNAP_COMMON:-"/var/snap/microk8s/common"}
+KUBELET_CONF="/var/snap/microk8s/current/args/kubelet"
+POD_MANIFESTS_PATH="${SNAP_COMMON}/etc/kubelet.d"
+STATIC_POD_PATH="${POD_MANIFESTS_PATH}/static-web.yaml"
+TEST_NAME="$0"
+
+set -e
+
+if [ $UID != 0 ]; then
+    echo "Script must be run as root"
+    exit
+fi
+
+trap cleanup EXIT
+
+function log {
+    echo "$@" >&2
+}
+
+function abort {
+    log "$@"
+    return 1
+}
+
+function test_succeeded {
+    log "$@"
+    echo "Success"
+}
+
+function cilium {
+    microk8s.cilium "$@"
+}
+
+function cleanup {
+    rm -rf $STATIC_POD_PATH
+}
+
+function cfg_kubelet {
+    if ! grep -q "pod-manifest-path" $KUBELET_CONF; then
+        echo "--pod-manifest-path=${POD_MANIFESTS_PATH}" >> $KUBELET_CONF
+        systemctl restart snap.microk8s.daemon-apiserver.service
+    fi
+}
+
+# $1 - start / stop / restart
+function apiserver {
+    systemctl "$1" snap.microk8s.daemon-apiserver.service
+}
+
+function cfg_static_pod {
+    mkdir -p $POD_MANIFESTS_PATH
+    cat <<EOF >$STATIC_POD_PATH
+apiVersion: v1
+kind: Pod
+metadata:
+  name: static-web
+  labels:
+    role: myrole
+spec:
+  containers:
+    - name: web
+      image: nginx
+      ports:
+        - name: web
+          containerPort: 80
+          protocol: TCP
+EOF
+}
+
+function check_pod_labels {
+    static_pod_labels="$(cilium endpoint list -o json \
+        | jq '.[].status.labels."security-relevant"
+              | select(any(.[]; contains("k8s"))|not)
+              | select(any(.[]; contains("health"))|not)')"
+    log "$static_pod_labels"
+    [ "$(echo "$static_pod_labels" | jq 'length')" = "" ]
+}
+
+# Setup
+log "Configuring the test"
+cleanup
+cfg_kubelet
+apiserver stop
+cfg_static_pod
+sleep 2
+apiserver start
+
+# Initial logging status
+log "Gathering initial state from cilium"
+log "$(cilium status)"
+log "$(cilium endpoint list)"
+
+log "Running test..."
+if ! check_pod_labels; then
+    # Sleep for up to 50 seconds, checking that the pod labels get properly updated from apiserver
+    for i in {1..10}; do
+        if check_pod_labels; then
+            break
+        fi
+        log "Static pod labels don't contain kubernetes labels"
+        sleep 5
+    done
+    if ! check_pod_labels; then
+        abort "Static pod labels don't contain kubernetes labels after timeout"
+    fi
+fi
+
+test_succeeded "${TEST_NAME}"


### PR DESCRIPTION
* #9241 -- cilium: encryption, replace Router() IP with CiliumInternal (@jrfastab)
 * #9249 -- docs: Do not pin cilium image vsn in kubeproxy-free guide (@brb)
 * #9250 -- docs: fix aks guide (@aanm)
 * #9252 -- plugins/cilium-cni: add support for AKS (@aanm)
 * #9243 -- endpoint: Update proxy policies when applying policy map changes out-of-band (@jrajahalme)
   * Manually resolved conflicts with now-hidden endpoint functions, singleton
     endpointmanager object rather than global functions. PTAL @jrajahalme
 * #9255 -- Fix race condition in loader that causes policy drops for static pods (@joestringer)
   * Implicitly included golang 1.13 image bump for cilium-runtime container
    * Related: #9118, /cc @aanm
 * #9258 -- docs: add more fixes to aks guide (@aanm)
 * #9259 -- iptables: fix cilium_forward chain rules to support openshift (@borkmann)
 * #9257 -- Fix issue where static pods never receive kubernetes labels (@joestringer)
   * Minor change to function call for getting k8s pod namespace/name

Once this PR is merged, you can update the PR labels via:
```
$ for pr in 9241 9249 9250 9252 9243 9255 9258 9259 9257; do contrib/backporting/set-labels.py $pr done 1.6; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9262)
<!-- Reviewable:end -->
