### PR TITLE
kvstore/etcd: always reload keypair

### DIFF
--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -17,6 +17,7 @@ package kvstore
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -1428,6 +1429,10 @@ func newConfig(fpath string) (*client.Config, error) {
 			return nil, err
 		}
 		cfg.TLS.RootCAs = cp
+	}
+	cfg.TLS.GetClientCertificate = func(_ *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+		cer, err := tls.LoadX509KeyPair(yc.Certfile, yc.Keyfile)
+		return &cer, err
 	}
 	return cfg, nil
 }


### PR DESCRIPTION
This PR allows to support certificates client rotation for the etcd client.

With our current setup, which is 5 etcd members for each remote clusters and the kvstore, I observe 5 reloads every 30 seconds.

These are my dev/tests logs:
```
2019-09-25T11:47:29.942184108Z stderr F level=debug msg="loading x509KeyPair" cert=/etc/vaultd/secrets/mesh5-cert.pem subsys=kvstore tls=GetClientCertificate
2019-09-25T11:47:29.947963769Z stderr F level=debug msg="loading x509KeyPair" cert=/etc/vaultd/secrets/mesh5-cert.pem subsys=kvstore tls=GetClientCertificate
2019-09-25T11:47:29.965020806Z stderr F level=debug msg="loading x509KeyPair" cert=/etc/vaultd/secrets/mesh5-cert.pem subsys=kvstore tls=GetClientCertificate
2019-09-25T11:47:29.970235052Z stderr F level=debug msg="loading x509KeyPair" cert=/etc/vaultd/secrets/mesh5-cert.pem subsys=kvstore tls=GetClientCertificate
2019-09-25T11:47:30.015405333Z stderr F level=debug msg="loading x509KeyPair" cert=/etc/vaultd/secrets/mesh5-cert.pem subsys=kvstore tls=GetClientCertificate
2019-09-25T11:48:00.0561075Z stderr F level=debug msg="loading x509KeyPair" cert=/etc/vaultd/secrets/mesh5-cert.pem subsys=kvstore tls=GetClientCertificate
2019-09-25T11:48:00.072182961Z stderr F level=debug msg="loading x509KeyPair" cert=/etc/vaultd/secrets/mesh5-cert.pem subsys=kvstore tls=GetClientCertificate
2019-09-25T11:48:00.077908592Z stderr F level=debug msg="loading x509KeyPair" cert=/etc/vaultd/secrets/mesh5-cert.pem subsys=kvstore tls=GetClientCertificate
2019-09-25T11:48:00.089582713Z stderr F level=debug msg="loading x509KeyPair" cert=/etc/vaultd/secrets/mesh5-cert.pem subsys=kvstore tls=GetClientCertificate
2019-09-25T11:48:00.108483989Z stderr F level=debug msg="loading x509KeyPair" cert=/etc/vaultd/secrets/mesh5-cert.pem subsys=kvstore tls=GetClientCertificate
2019-09-25T11:48:30.127711003Z stderr F level=debug msg="loading x509KeyPair" cert=/etc/vaultd/secrets/mesh5-cert.pem subsys=kvstore tls=GetClientCertificate
2019-09-25T11:48:30.13353387Z stderr F level=debug msg="loading x509KeyPair" cert=/etc/vaultd/secrets/mesh5-cert.pem subsys=kvstore tls=GetClientCertificate
2019-09-25T11:48:30.140220575Z stderr F level=debug msg="loading x509KeyPair" cert=/etc/vaultd/secrets/mesh5-cert.pem subsys=kvstore tls=GetClientCertificate
2019-09-25T11:48:30.147313036Z stderr F level=debug msg="loading x509KeyPair" cert=/etc/vaultd/secrets/mesh5-cert.pem subsys=kvstore tls=GetClientCertificate
2019-09-25T11:48:30.165503661Z stderr F level=debug msg="loading x509KeyPair" cert=/etc/vaultd/secrets/mesh5-cert.pem subsys=kvstore tls=GetClientCertificate
```
And the test metrics:
```
# HELP keypair_reload_histogram_milliseconds Distribution for loading keypair from disk in milliseconds
# TYPE keypair_reload_histogram_milliseconds histogram
keypair_reload_histogram_milliseconds_bucket{le="0.1"} 0
keypair_reload_histogram_milliseconds_bucket{le="0.2"} 0
keypair_reload_histogram_milliseconds_bucket{le="0.3"} 2120
keypair_reload_histogram_milliseconds_bucket{le="0.4"} 5230
keypair_reload_histogram_milliseconds_bucket{le="0.5"} 5554
keypair_reload_histogram_milliseconds_bucket{le="0.6"} 5568
keypair_reload_histogram_milliseconds_bucket{le="0.7"} 5572
keypair_reload_histogram_milliseconds_bucket{le="0.8"} 5575
keypair_reload_histogram_milliseconds_bucket{le="0.9"} 5575
keypair_reload_histogram_milliseconds_bucket{le="1"} 5576
keypair_reload_histogram_milliseconds_bucket{le="+Inf"} 5578
keypair_reload_histogram_milliseconds_sum 1775.6008849999994
keypair_reload_histogram_milliseconds_count 5578
```
Happy to engage a conversation if you want us to improve this implementation 👍 

```release-note
always reload the keypair to support certificates renew/rotation on the etcd client
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9266)
<!-- Reviewable:end -->
