### PR TITLE
health: Configure sysctl when IPv6 is disabled

### DIFF
--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/pidfile"
+	"github.com/cilium/cilium/pkg/sysctl"
 
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/vishvananda/netlink"
@@ -120,7 +121,12 @@ func configureHealthInterface(netNS ns.NetNS, ifName string, ip4Addr, ip6Addr *n
 			return err
 		}
 
-		if ip6Addr != nil {
+		if ip6Addr == nil {
+			name := fmt.Sprintf("net.ipv6.conf.%s.disable_ipv6", ifName)
+			// Ignore the error; if IPv6 is completely disabled
+			// then it's okay if we can't write the sysctl.
+			_ = sysctl.Write(name, "1")
+		} else {
 			if err = netlink.AddrAdd(link, &netlink.Addr{IPNet: ip6Addr}); err != nil {
 				return err
 			}


### PR DESCRIPTION
When IPv6 is disabled, ensure that the health endpoint's device is
configured to disable IPv6 so that it doesn't emit any IPv6 autoconf
frames or similar.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9278)
<!-- Reviewable:end -->
