### PR TITLE
pkg/bpf, pkg/endpoint/connector: use RLIM_INFINITY constant

### DIFF
--- a/pkg/bpf/bpf_linux.go
+++ b/pkg/bpf/bpf_linux.go
@@ -18,7 +18,6 @@ package bpf
 
 import (
 	"fmt"
-	"math"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -550,8 +549,8 @@ func TestDummyProg(progType ProgType, attachType uint32) error {
 		License:    uintptr(unsafe.Pointer(&license[0])),
 	}
 	tmpLim := unix.Rlimit{
-		Cur: math.MaxUint64,
-		Max: math.MaxUint64,
+		Cur: unix.RLIM_INFINITY,
+		Max: unix.RLIM_INFINITY,
 	}
 	err := unix.Getrlimit(unix.RLIMIT_MEMLOCK, &oldLim)
 	if err != nil {

--- a/pkg/bpf/rlimit_linux.go
+++ b/pkg/bpf/rlimit_linux.go
@@ -15,8 +15,6 @@
 package bpf
 
 import (
-	"math"
-
 	"golang.org/x/sys/unix"
 )
 
@@ -24,7 +22,7 @@ import (
 // BPF syscall interactions.
 func ConfigureResourceLimits() error {
 	return unix.Setrlimit(unix.RLIMIT_MEMLOCK, &unix.Rlimit{
-		Cur: math.MaxUint64,
-		Max: math.MaxUint64,
+		Cur: unix.RLIM_INFINITY,
+		Max: unix.RLIM_INFINITY,
 	})
 }

--- a/pkg/endpoint/connector/ipvlan.go
+++ b/pkg/endpoint/connector/ipvlan.go
@@ -16,7 +16,6 @@ package connector
 
 import (
 	"fmt"
-	"math"
 	"strings"
 	"unsafe"
 
@@ -141,8 +140,8 @@ func createTailCallMap() (int, int, error) {
 // the map will be destroyed.
 func setupIpvlanInRemoteNs(netNs ns.NetNS, srcIfName, dstIfName string) (int, int, error) {
 	rl := unix.Rlimit{
-		Cur: math.MaxUint64,
-		Max: math.MaxUint64,
+		Cur: unix.RLIM_INFINITY,
+		Max: unix.RLIM_INFINITY,
 	}
 
 	err := unix.Setrlimit(unix.RLIMIT_MEMLOCK, &rl)


### PR DESCRIPTION
Use the RLIM_INFINITY constant from golang.org/x/sys/unix for
Setrlimit(RLIMIT_MEMLOCK, ...) which makes the intended purpose a bit
clearer and also avoids a dependency on the "math" package.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9283)
<!-- Reviewable:end -->
