### PR TITLE
Change kind of daemonset in microk8s-prepull.yml to apps/v1

### DIFF
--- a/contrib/k8s/microk8s-prepull.yaml
+++ b/contrib/k8s/microk8s-prepull.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: prepull


### PR DESCRIPTION
Signed-off-by: Vlad Ungureanu <vladu@palantir.com>

Encountered while executing `make microk8s`. Running `microk8s` v1.16.0. Looks like in 1.16.x of k8s they actually removed serving daemonsets from `apps/v1beta2`.

```release-note
Change kind of daemonset in microk8s-prepull.yml to apps/v1
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9288)
<!-- Reviewable:end -->
