### PR TITLE
Add unit tests for pkg/service.Service

### DIFF
--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -192,11 +192,17 @@ const (
 	// ServiceValue is the value of the service in a BPF map
 	ServiceValue = "svcVal"
 
+	// ServiceType is the type of the service
+	ServiceType = "svcType"
+
 	// BackendIDs is the map of backend IDs (lbmap) indexed by backend address
 	BackendIDs = "backendIDs"
 
 	// BackendID is the ID of the backend
 	BackendID = "backendID"
+
+	// Backends is the list of the service backends
+	Backends = "backends"
 
 	// BackendName is the name of the backend
 	BackendName = "backendName"

--- a/pkg/maps/lbmap/ipv4.go
+++ b/pkg/maps/lbmap/ipv4.go
@@ -288,10 +288,6 @@ func (v *Backend4Value) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(v) 
 func (b *Backend4Value) GetAddress() net.IP { return b.Address.IP() }
 func (b *Backend4Value) GetPort() uint16    { return b.Port }
 
-func (b *Backend4Value) BackendAddrID() BackendAddrID {
-	return BackendAddrID(fmt.Sprintf("%s:%d", b.Address, b.Port))
-}
-
 func (v *Backend4Value) ToNetwork() BackendValue {
 	n := *v
 	n.Port = byteorder.HostToNetwork(n.Port).(uint16)

--- a/pkg/maps/lbmap/ipv6.go
+++ b/pkg/maps/lbmap/ipv6.go
@@ -278,10 +278,6 @@ func (v *Backend6Value) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(v) 
 func (b *Backend6Value) GetAddress() net.IP { return b.Address.IP() }
 func (b *Backend6Value) GetPort() uint16    { return b.Port }
 
-func (b *Backend6Value) BackendAddrID() BackendAddrID {
-	return BackendAddrID(fmt.Sprintf("[%s]:%d", b.Address, b.Port))
-}
-
 func (v *Backend6Value) ToNetwork() BackendValue {
 	n := *v
 	n.Port = byteorder.HostToNetwork(n.Port).(uint16)

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -275,9 +275,9 @@ func (*LBBPFMap) DumpServiceMapsToUserspaceV2() (loadbalancer.SVCMap, []*loadbal
 }
 
 // DumpBackendMapsToUserspace dumps the backend entries from the BPF maps.
-func (*LBBPFMap) DumpBackendMapsToUserspace() (map[BackendAddrID]*loadbalancer.LBBackEnd, error) {
+func (*LBBPFMap) DumpBackendMapsToUserspace() ([]*loadbalancer.LBBackEnd, error) {
 	backendValueMap := map[loadbalancer.BackendID]BackendValue{}
-	lbBackends := map[BackendAddrID]*loadbalancer.LBBackEnd{}
+	lbBackends := []*loadbalancer.LBBackEnd{}
 
 	parseBackendEntries := func(key bpf.MapKey, value bpf.MapValue) {
 		// No need to deep copy the key because we are using the ID which
@@ -306,7 +306,7 @@ func (*LBBPFMap) DumpBackendMapsToUserspace() (map[BackendAddrID]*loadbalancer.L
 		port := backendVal.GetPort()
 		proto := loadbalancer.NONE
 		lbBackend := loadbalancer.NewLBBackEnd(backendID, proto, ip, port)
-		lbBackends[backendVal.BackendAddrID()] = lbBackend
+		lbBackends = append(lbBackends, lbBackend)
 	}
 
 	return lbBackends, nil

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -201,9 +201,8 @@ func deleteRevNatLocked(key RevNatKey) error {
 	return key.Map().Delete(key.ToNetwork())
 }
 
-// DumpServiceMapsToUserspaceV2 dumps the services in the same way as
-// DumpServiceMapsToUserspace.
-func (*LBBPFMap) DumpServiceMapsToUserspaceV2() (loadbalancer.SVCMap, []*loadbalancer.LBSVC, []error) {
+// DumpServiceMapsToUserspaceV2 dumps the services from the BPF maps.
+func (*LBBPFMap) DumpServiceMapsToUserspaceV2() ([]*loadbalancer.LBSVC, []error) {
 	newSVCMap := loadbalancer.SVCMap{}
 	newSVCList := []*loadbalancer.LBSVC{}
 	errors := []error{}
@@ -284,13 +283,7 @@ func (*LBBPFMap) DumpServiceMapsToUserspaceV2() (loadbalancer.SVCMap, []*loadbal
 		newSVCList[i].FE.ID = loadbalancer.ID(idCache[newSVCList[i].FE.String()])
 	}
 
-	// Do the same for the svcMap
-	for key, svc := range newSVCMap {
-		svc.FE.ID = loadbalancer.ID(idCache[svc.FE.String()])
-		newSVCMap[key] = svc
-	}
-
-	return newSVCMap, newSVCList, errors
+	return newSVCList, errors
 }
 
 // DumpBackendMapsToUserspace dumps the backend entries from the BPF maps.

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -35,6 +35,9 @@ const (
 	MaxEntries = 65536
 )
 
+// LBBPFMap is an implementation of the LBMap interface.
+type LBBPFMap struct{}
+
 // UpsertService inserts or updates the given service in a BPF map.
 //
 // The corresponding backend entries (identified with the given backendIDs)
@@ -42,7 +45,7 @@ const (
 //
 // The given prevBackendCount denotes a previous service backend entries count,
 // so that the function can remove obsolete ones.
-func UpsertService(
+func (*LBBPFMap) UpsertService(
 	svcID uint16, svcIP net.IP, svcPort uint16,
 	backendIDs []uint16, prevBackendCount int,
 	ipv6 bool) error {
@@ -95,7 +98,7 @@ func UpsertService(
 }
 
 // DeleteService removes given service from a BPF map.
-func DeleteService(svc loadbalancer.L3n4AddrID, backendCount int) error {
+func (*LBBPFMap) DeleteService(svc loadbalancer.L3n4AddrID, backendCount int) error {
 	var (
 		svcKey    ServiceKeyV2
 		revNATKey RevNatKey
@@ -124,7 +127,7 @@ func DeleteService(svc loadbalancer.L3n4AddrID, backendCount int) error {
 }
 
 // AddBackend adds a backend into a BPF map.
-func AddBackend(id uint16, ip net.IP, port uint16, ipv6 bool) error {
+func (*LBBPFMap) AddBackend(id uint16, ip net.IP, port uint16, ipv6 bool) error {
 	var (
 		backend Backend
 		err     error
@@ -148,7 +151,7 @@ func AddBackend(id uint16, ip net.IP, port uint16, ipv6 bool) error {
 }
 
 // DeleteBackendByID removes a backend identified with the given ID from a BPF map.
-func DeleteBackendByID(id uint16, ipv6 bool) error {
+func (*LBBPFMap) DeleteBackendByID(id uint16, ipv6 bool) error {
 	var key BackendKey
 
 	if ipv6 {
@@ -181,7 +184,7 @@ func deleteRevNatLocked(key RevNatKey) error {
 
 // DumpServiceMapsToUserspaceV2 dumps the services in the same way as
 // DumpServiceMapsToUserspace.
-func DumpServiceMapsToUserspaceV2() (loadbalancer.SVCMap, []*loadbalancer.LBSVC, []error) {
+func (*LBBPFMap) DumpServiceMapsToUserspaceV2() (loadbalancer.SVCMap, []*loadbalancer.LBSVC, []error) {
 	newSVCMap := loadbalancer.SVCMap{}
 	newSVCList := []*loadbalancer.LBSVC{}
 	errors := []error{}
@@ -272,7 +275,7 @@ func DumpServiceMapsToUserspaceV2() (loadbalancer.SVCMap, []*loadbalancer.LBSVC,
 }
 
 // DumpBackendMapsToUserspace dumps the backend entries from the BPF maps.
-func DumpBackendMapsToUserspace() (map[BackendAddrID]*loadbalancer.LBBackEnd, error) {
+func (*LBBPFMap) DumpBackendMapsToUserspace() (map[BackendAddrID]*loadbalancer.LBBackEnd, error) {
 	backendValueMap := map[loadbalancer.BackendID]BackendValue{}
 	lbBackends := map[BackendAddrID]*loadbalancer.LBBackEnd{}
 

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -52,6 +52,10 @@ func (*LBBPFMap) UpsertService(
 
 	var svcKey ServiceKeyV2
 
+	if svcID == 0 {
+		return fmt.Errorf("Invalid svc ID 0")
+	}
+
 	if ipv6 {
 		svcKey = NewService6KeyV2(svcIP, svcPort, u8proto.ANY, 0)
 	} else {
@@ -61,6 +65,9 @@ func (*LBBPFMap) UpsertService(
 	slot := 1
 	svcVal := svcKey.NewValue().(ServiceValueV2)
 	for _, backendID := range backendIDs {
+		if backendID == 0 {
+			return fmt.Errorf("Invalid backend ID 0")
+		}
 		svcVal.SetBackendID(loadbalancer.BackendID(backendID))
 		svcVal.SetRevNat(int(svcID))
 		svcKey.SetSlave(slot) // TODO(brb) Rename to SetSlot
@@ -104,6 +111,10 @@ func (*LBBPFMap) DeleteService(svc loadbalancer.L3n4AddrID, backendCount int) er
 		revNATKey RevNatKey
 	)
 
+	if svc.ID == 0 {
+		return fmt.Errorf("Invalid svc ID 0")
+	}
+
 	if svc.IsIPv6() {
 		svcKey = NewService6KeyV2(svc.IP, svc.Port, u8proto.ANY, 0)
 		revNATKey = NewRevNat6Key(uint16(svc.ID))
@@ -133,6 +144,10 @@ func (*LBBPFMap) AddBackend(id uint16, ip net.IP, port uint16, ipv6 bool) error 
 		err     error
 	)
 
+	if id == 0 {
+		return fmt.Errorf("Invalid backend ID 0")
+	}
+
 	if ipv6 {
 		backend, err = NewBackend6(loadbalancer.BackendID(id), ip, port, u8proto.ANY)
 	} else {
@@ -153,6 +168,10 @@ func (*LBBPFMap) AddBackend(id uint16, ip net.IP, port uint16, ipv6 bool) error 
 // DeleteBackendByID removes a backend identified with the given ID from a BPF map.
 func (*LBBPFMap) DeleteBackendByID(id uint16, ipv6 bool) error {
 	var key BackendKey
+
+	if id == 0 {
+		return fmt.Errorf("Invalid backend ID 0")
+	}
 
 	if ipv6 {
 		key = NewBackend6Key(loadbalancer.BackendID(id))

--- a/pkg/maps/lbmap/lbmap_mock.go
+++ b/pkg/maps/lbmap/lbmap_mock.go
@@ -85,6 +85,6 @@ func (m *LBMockMap) DumpServiceMapsToUserspaceV2() (loadbalancer.SVCMap, []*load
 	panic("NYI")
 }
 
-func (m *LBMockMap) DumpBackendMapsToUserspace() (map[BackendAddrID]*loadbalancer.LBBackEnd, error) {
+func (m *LBMockMap) DumpBackendMapsToUserspace() ([]*loadbalancer.LBBackEnd, error) {
 	panic("NYI")
 }

--- a/pkg/maps/lbmap/lbmap_mock.go
+++ b/pkg/maps/lbmap/lbmap_mock.go
@@ -1,0 +1,90 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lbmap
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/cilium/cilium/pkg/loadbalancer"
+)
+
+type LBMockMap struct {
+	BackendByID         map[uint16]struct{}
+	ServiceBackendsByID map[uint16][]uint16
+}
+
+func NewLBMockMap() *LBMockMap {
+	return &LBMockMap{
+		BackendByID:         map[uint16]struct{}{},
+		ServiceBackendsByID: map[uint16][]uint16{},
+	}
+}
+
+func (m *LBMockMap) UpsertService(id uint16, ip net.IP, port uint16,
+	backendIDs []uint16, prevCount int, ipv6 bool) error {
+
+	if count := len(m.ServiceBackendsByID[id]); prevCount != count {
+		return fmt.Errorf("Invalid previous backends count: %d vs %d",
+			count, prevCount)
+	}
+
+	m.ServiceBackendsByID[id] = backendIDs
+
+	return nil
+}
+
+func (m *LBMockMap) DeleteService(addr loadbalancer.L3n4AddrID, backendCount int) error {
+	svc, found := m.ServiceBackendsByID[uint16(addr.ID)]
+	if !found {
+		return fmt.Errorf("Service not found %+v", addr)
+	}
+	if count := len(svc); count != backendCount {
+		return fmt.Errorf("Invalid backends count: %d vs %d",
+			count, backendCount)
+	}
+
+	delete(m.ServiceBackendsByID, uint16(addr.ID))
+
+	return nil
+}
+
+func (m *LBMockMap) AddBackend(id uint16, ip net.IP, port uint16, ipv6 bool) error {
+	if _, found := m.BackendByID[id]; found {
+		return fmt.Errorf("Backend %d already exists", id)
+	}
+
+	m.BackendByID[id] = struct{}{}
+
+	return nil
+}
+
+func (m *LBMockMap) DeleteBackendByID(id uint16, ipv6 bool) error {
+	if _, found := m.BackendByID[id]; !found {
+		return fmt.Errorf("Backend %d does not exist", id)
+	}
+
+	delete(m.BackendByID, id)
+
+	return nil
+}
+
+func (m *LBMockMap) DumpServiceMapsToUserspaceV2() (loadbalancer.SVCMap, []*loadbalancer.LBSVC, []error) {
+	panic("NYI")
+}
+
+func (m *LBMockMap) DumpBackendMapsToUserspace() (map[BackendAddrID]*loadbalancer.LBBackEnd, error) {
+	panic("NYI")
+}

--- a/pkg/maps/lbmap/lbmap_mock.go
+++ b/pkg/maps/lbmap/lbmap_mock.go
@@ -81,7 +81,7 @@ func (m *LBMockMap) DeleteBackendByID(id uint16, ipv6 bool) error {
 	return nil
 }
 
-func (m *LBMockMap) DumpServiceMapsToUserspaceV2() (loadbalancer.SVCMap, []*loadbalancer.LBSVC, []error) {
+func (m *LBMockMap) DumpServiceMapsToUserspaceV2() ([]*loadbalancer.LBSVC, []error) {
 	panic("NYI")
 }
 

--- a/pkg/maps/lbmap/types.go
+++ b/pkg/maps/lbmap/types.go
@@ -25,10 +25,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// BackendAddrID is the type of a service endpoint's unique identifier which
-// consists of "IP:PORT"
-type BackendAddrID string
-
 // ServiceKey is the interface describing protocol independent key for services map v2.
 //
 // NOTE: ServiceKeyV2.String() output should match output of corresponding ServiceKey.String()!
@@ -115,9 +111,6 @@ type BackendValue interface {
 
 	// Get backend port
 	GetPort() uint16
-
-	// Get backend address identifier (string of IP:Port)
-	BackendAddrID() BackendAddrID
 
 	// Convert fields to network byte order.
 	ToNetwork() BackendValue

--- a/pkg/service/manager_test.go
+++ b/pkg/service/manager_test.go
@@ -17,6 +17,7 @@
 package service
 
 import (
+	"fmt"
 	"net"
 
 	lb "github.com/cilium/cilium/pkg/loadbalancer"
@@ -46,6 +47,19 @@ func (e *ManagerTestSuite) TearDownTest(c *C) {
 	backendIDAlloc.resetLocalID()
 }
 
+var (
+	frontend1 = *lb.NewL3n4AddrID(lb.TCP, net.ParseIP("1.1.1.1"), 80, 0)
+	frontend2 = *lb.NewL3n4AddrID(lb.TCP, net.ParseIP("1.1.1.2"), 80, 0)
+	backends1 = []lb.LBBackEnd{
+		*lb.NewLBBackEnd(0, lb.TCP, net.ParseIP("10.0.0.1"), 8080),
+		*lb.NewLBBackEnd(0, lb.TCP, net.ParseIP("10.0.0.2"), 8080),
+	}
+	backends2 = []lb.LBBackEnd{
+		*lb.NewLBBackEnd(0, lb.TCP, net.ParseIP("10.0.0.2"), 8080),
+		*lb.NewLBBackEnd(0, lb.TCP, net.ParseIP("10.0.0.3"), 8080),
+	}
+)
+
 func (m *ManagerTestSuite) TestUpsertAndDeleteService(c *C) {
 	frontend1 := *lb.NewL3n4AddrID(lb.TCP, net.ParseIP("1.1.1.1"), 80, 0)
 	frontend2 := *lb.NewL3n4AddrID(lb.TCP, net.ParseIP("1.1.1.2"), 80, 0)
@@ -59,7 +73,7 @@ func (m *ManagerTestSuite) TestUpsertAndDeleteService(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(created, Equals, true)
 	c.Assert(id1, Equals, lb.ID(1))
-	c.Assert(len(m.lbmap.ServiceBackendsByID[uint16(id1)]), Equals, 2)
+	c.Assert(len(m.lbmap.ServiceByID[uint16(id1)].BES), Equals, 2)
 	c.Assert(len(m.lbmap.BackendByID), Equals, 2)
 
 	// Should update nothing
@@ -67,15 +81,16 @@ func (m *ManagerTestSuite) TestUpsertAndDeleteService(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(created, Equals, false)
 	c.Assert(id1, Equals, lb.ID(1))
-	c.Assert(len(m.lbmap.ServiceBackendsByID[uint16(id1)]), Equals, 2)
+	c.Assert(len(m.lbmap.ServiceByID[uint16(id1)].BES), Equals, 2)
 	c.Assert(len(m.lbmap.BackendByID), Equals, 2)
+	// TODO(brb) test that backends are the same
 
 	// Should remove one backend
 	created, id1, err = m.svc.UpsertService(frontend1, backends1[0:1], TypeNodePort)
 	c.Assert(err, IsNil)
 	c.Assert(created, Equals, false)
 	c.Assert(id1, Equals, lb.ID(1))
-	c.Assert(len(m.lbmap.ServiceBackendsByID[uint16(id1)]), Equals, 1)
+	c.Assert(len(m.lbmap.ServiceByID[uint16(id1)].BES), Equals, 1)
 	c.Assert(len(m.lbmap.BackendByID), Equals, 1)
 
 	// Should add another service
@@ -83,7 +98,7 @@ func (m *ManagerTestSuite) TestUpsertAndDeleteService(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(created, Equals, true)
 	c.Assert(id2, Equals, lb.ID(2))
-	c.Assert(len(m.lbmap.ServiceBackendsByID[uint16(id2)]), Equals, 2)
+	c.Assert(len(m.lbmap.ServiceByID[uint16(id2)].BES), Equals, 2)
 	c.Assert(len(m.lbmap.BackendByID), Equals, 2)
 
 	// Should remove the service and the backend, but keep another service and
@@ -91,7 +106,7 @@ func (m *ManagerTestSuite) TestUpsertAndDeleteService(c *C) {
 	found, err := m.svc.DeleteServiceByID(lb.ServiceID(id1))
 	c.Assert(err, IsNil)
 	c.Assert(found, Equals, true)
-	c.Assert(len(m.lbmap.ServiceBackendsByID), Equals, 1)
+	c.Assert(len(m.lbmap.ServiceByID), Equals, 1)
 	c.Assert(len(m.lbmap.BackendByID), Equals, 2)
 
 	// Should delete both backends of service
@@ -99,13 +114,41 @@ func (m *ManagerTestSuite) TestUpsertAndDeleteService(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(created, Equals, false)
 	c.Assert(id2, Equals, lb.ID(2))
-	c.Assert(len(m.lbmap.ServiceBackendsByID[uint16(id2)]), Equals, 0)
+	c.Assert(len(m.lbmap.ServiceByID[uint16(id2)].BES), Equals, 0)
 	c.Assert(len(m.lbmap.BackendByID), Equals, 0)
 
 	// Should delete the remaining service
 	found, err = m.svc.DeleteServiceByID(lb.ServiceID(id2))
 	c.Assert(err, IsNil)
 	c.Assert(found, Equals, true)
-	c.Assert(len(m.lbmap.ServiceBackendsByID), Equals, 0)
+	c.Assert(len(m.lbmap.ServiceByID), Equals, 0)
 	c.Assert(len(m.lbmap.BackendByID), Equals, 0)
+}
+
+func (m *ManagerTestSuite) TestRestoreServices(c *C) {
+	_, id1, err := m.svc.UpsertService(frontend1, backends1, TypeNodePort)
+	c.Assert(err, IsNil)
+	_, id2, err := m.svc.UpsertService(frontend2, backends2, TypeClusterIP)
+	c.Assert(err, IsNil)
+	fmt.Println(id1, id2)
+
+	// Restart service, but keep the lbmap to restore services from
+	lbmap := m.svc.lbmap.(*lbmap.LBMockMap)
+	m.svc = NewService()
+	m.svc.lbmap = lbmap
+	err = m.svc.RestoreServices()
+	c.Assert(err, IsNil)
+
+	// Backends have been restored
+	c.Assert(len(m.svc.backendByHash), Equals, 3)
+	backends := append(backends1, backends2...)
+	for _, b := range backends {
+		_, found := m.svc.backendByHash[b.SHA256Sum()]
+		c.Assert(found, Equals, true)
+	}
+
+	// Services have been restored too
+	c.Assert(len(m.svc.svcByID), Equals, 2)
+	c.Assert(m.svc.svcByID[id1], Equals, lbmap.ServiceByID[uint16(id1)])
+	c.Assert(m.svc.svcByID[id2], Equals, lbmap.ServiceByID[uint16(id2)])
 }

--- a/pkg/service/manager_test.go
+++ b/pkg/service/manager_test.go
@@ -1,0 +1,111 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package service
+
+import (
+	"net"
+
+	lb "github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/maps/lbmap"
+
+	. "gopkg.in/check.v1"
+)
+
+type ManagerTestSuite struct {
+	svc   *Service
+	lbmap *lbmap.LBMockMap // for accessing public fields
+}
+
+var _ = Suite(&ManagerTestSuite{})
+
+func (m *ManagerTestSuite) SetUpTest(c *C) {
+	serviceIDAlloc.resetLocalID()
+	backendIDAlloc.resetLocalID()
+
+	m.svc = NewService()
+	m.svc.lbmap = lbmap.NewLBMockMap()
+	m.lbmap = m.svc.lbmap.(*lbmap.LBMockMap)
+}
+
+func (e *ManagerTestSuite) TearDownTest(c *C) {
+	serviceIDAlloc.resetLocalID()
+	backendIDAlloc.resetLocalID()
+}
+
+func (m *ManagerTestSuite) TestUpsertAndDeleteService(c *C) {
+	frontend1 := *lb.NewL3n4AddrID(lb.TCP, net.ParseIP("1.1.1.1"), 80, 0)
+	frontend2 := *lb.NewL3n4AddrID(lb.TCP, net.ParseIP("1.1.1.2"), 80, 0)
+	backends1 := []lb.LBBackEnd{
+		*lb.NewLBBackEnd(0, lb.TCP, net.ParseIP("10.0.0.1"), 8080),
+		*lb.NewLBBackEnd(0, lb.TCP, net.ParseIP("10.0.0.2"), 8080),
+	}
+
+	// Should create a new service with two backends
+	created, id1, err := m.svc.UpsertService(frontend1, backends1, TypeNodePort)
+	c.Assert(err, IsNil)
+	c.Assert(created, Equals, true)
+	c.Assert(id1, Equals, lb.ID(1))
+	c.Assert(len(m.lbmap.ServiceBackendsByID[uint16(id1)]), Equals, 2)
+	c.Assert(len(m.lbmap.BackendByID), Equals, 2)
+
+	// Should update nothing
+	created, id1, err = m.svc.UpsertService(frontend1, backends1, TypeNodePort)
+	c.Assert(err, IsNil)
+	c.Assert(created, Equals, false)
+	c.Assert(id1, Equals, lb.ID(1))
+	c.Assert(len(m.lbmap.ServiceBackendsByID[uint16(id1)]), Equals, 2)
+	c.Assert(len(m.lbmap.BackendByID), Equals, 2)
+
+	// Should remove one backend
+	created, id1, err = m.svc.UpsertService(frontend1, backends1[0:1], TypeNodePort)
+	c.Assert(err, IsNil)
+	c.Assert(created, Equals, false)
+	c.Assert(id1, Equals, lb.ID(1))
+	c.Assert(len(m.lbmap.ServiceBackendsByID[uint16(id1)]), Equals, 1)
+	c.Assert(len(m.lbmap.BackendByID), Equals, 1)
+
+	// Should add another service
+	created, id2, err := m.svc.UpsertService(frontend2, backends1, TypeNodePort)
+	c.Assert(err, IsNil)
+	c.Assert(created, Equals, true)
+	c.Assert(id2, Equals, lb.ID(2))
+	c.Assert(len(m.lbmap.ServiceBackendsByID[uint16(id2)]), Equals, 2)
+	c.Assert(len(m.lbmap.BackendByID), Equals, 2)
+
+	// Should remove the service and the backend, but keep another service and
+	// its backends
+	found, err := m.svc.DeleteServiceByID(lb.ServiceID(id1))
+	c.Assert(err, IsNil)
+	c.Assert(found, Equals, true)
+	c.Assert(len(m.lbmap.ServiceBackendsByID), Equals, 1)
+	c.Assert(len(m.lbmap.BackendByID), Equals, 2)
+
+	// Should delete both backends of service
+	created, id2, err = m.svc.UpsertService(frontend2, nil, TypeNodePort)
+	c.Assert(err, IsNil)
+	c.Assert(created, Equals, false)
+	c.Assert(id2, Equals, lb.ID(2))
+	c.Assert(len(m.lbmap.ServiceBackendsByID[uint16(id2)]), Equals, 0)
+	c.Assert(len(m.lbmap.BackendByID), Equals, 0)
+
+	// Should delete the remaining service
+	found, err = m.svc.DeleteServiceByID(lb.ServiceID(id2))
+	c.Assert(err, IsNil)
+	c.Assert(found, Equals, true)
+	c.Assert(len(m.lbmap.ServiceBackendsByID), Equals, 0)
+	c.Assert(len(m.lbmap.BackendByID), Equals, 0)
+}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -48,7 +48,7 @@ type LBMap interface {
 	DeleteService(lb.L3n4AddrID, int) error
 	AddBackend(uint16, net.IP, uint16, bool) error
 	DeleteBackendByID(uint16, bool) error
-	DumpServiceMapsToUserspaceV2() (lb.SVCMap, []*lb.LBSVC, []error)
+	DumpServiceMapsToUserspaceV2() ([]*lb.LBSVC, []error)
 	DumpBackendMapsToUserspace() ([]*lb.LBBackEnd, error)
 }
 
@@ -393,7 +393,7 @@ func (s *Service) deleteOrphanBackends() error {
 func (s *Service) restoreServicesLocked() error {
 	failed, restored := 0, 0
 
-	_, svcs, errors := s.lbmap.DumpServiceMapsToUserspaceV2()
+	svcs, errors := s.lbmap.DumpServiceMapsToUserspaceV2()
 	for _, err := range errors {
 		log.WithError(err).Warning("Error occurred while dumping service maps")
 	}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -49,7 +49,7 @@ type LBMap interface {
 	AddBackend(uint16, net.IP, uint16, bool) error
 	DeleteBackendByID(uint16, bool) error
 	DumpServiceMapsToUserspaceV2() (lb.SVCMap, []*lb.LBSVC, []error)
-	DumpBackendMapsToUserspace() (map[lbmap.BackendAddrID]*lb.LBBackEnd, error)
+	DumpBackendMapsToUserspace() ([]*lb.LBBackEnd, error)
 }
 
 // Service is a service handler. Its main responsibility is to reflect

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -389,11 +389,14 @@ func (s *Service) restoreServicesLocked() error {
 			scopedLog.WithError(err).Warning("Unable to restore service ID")
 		}
 
-		for _, backend := range svc.BES {
-			s.backendRefCount.Add(backend.L3n4Addr.SHA256Sum())
+		svc.BackendByHash = map[string]*lb.LBBackEnd{}
+		for j, backend := range svc.BES {
+			hash := backend.L3n4Addr.SHA256Sum()
+			s.backendRefCount.Add(hash)
+			// TODO(brb) move to pkg/loadbalancer.NewBackend
+			svc.BackendByHash[hash] = &svc.BES[j]
 		}
 
-		svc.BackendByHash = map[string]*lb.LBBackEnd{}
 		s.svcByHash[svc.FE.SHA256Sum()] = svcs[i]
 		s.svcByID[svc.FE.ID] = svcs[i]
 		restored++


### PR DESCRIPTION
This PR:

- Introduces the `lbmap.LBMap` interface and its mock implementation - `LBMockMap`.
- Adds `pkg/service.Service` unit tests.
- Fixes the bug where backends were not properly accounted which resulted in the backend leak.
- Removes the `lbmap.BackendAddrID` type.

Reviewable per commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9289)
<!-- Reviewable:end -->
