### PR TITLE
Revert "Makefile: Fix 'make microk8s' privileges"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -346,9 +346,9 @@ logging-subsys-field:
 
 check-microk8s:
 	@$(ECHO_CHECK) microk8s is ready...
-	$(QUIET)sudo microk8s.status >/dev/null \
+	$(QUIET)microk8s.status >/dev/null \
 		|| (echo "Error: Microk8s is not running" && exit 1)
-	$(QUIET)sudo microk8s.status -o yaml | grep -q "registry.*enabled" \
+	$(QUIET)microk8s.status -o yaml | grep -q "registry.*enabled" \
 		|| (echo "Error: Microk8s registry must be enabled" && exit 1)
 
 LOCAL_IMAGE_TAG=local


### PR DESCRIPTION
This reverts commit 73948cdac2b2bbdfb613e4d98b4b6737532982d8.

Upstream, microk8s has introduced groups so that if you add your user to
the appropriate microk8s group then they can run commands without sudo.
Alternatively, the user can manually run `sudo make microk8s`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9290)
<!-- Reviewable:end -->
