### PR TITLE
Print header before the list of nodes

### DIFF
--- a/cilium/cmd/node_list.go
+++ b/cilium/cmd/node_list.go
@@ -62,7 +62,8 @@ func init() {
 }
 
 func formatStatusResponse(w io.Writer, nodes []*models.NodeElement) {
-	nodesOutput := []string{"Name\tIPv4 Address\tEndpoint CIDR\tIPv6 Address\tEndpoint CIDR\n"}
+	nodesOutputHeader := "Name\tIPv4 Address\tEndpoint CIDR\tIPv6 Address\tEndpoint CIDR\n"
+	nodesOutput := make([]string, len(nodes))
 
 	for _, node := range nodes {
 		ipv4, ipv4Range, ipv6, ipv6Range := "", "", "", ""
@@ -83,6 +84,7 @@ func formatStatusResponse(w io.Writer, nodes []*models.NodeElement) {
 
 	if len(nodesOutput) > 1 {
 		tab := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
+		fmt.Fprintf(tab, nodesOutputHeader)
 		sort.Strings(nodesOutput)
 		for _, s := range nodesOutput {
 			fmt.Fprint(tab, s)


### PR DESCRIPTION
Signed-off-by: Vlad Ungureanu <vladu@palantir.com>

While executing `cilium node list` I observed the following output:
```
$ kubectl exec -it -n kube-system cilium-njr9k -- cilium node list
ip-10-0-41-77   10.2.20.197    10.197.0.0/16
Name                           IPv4 Address   Endpoint CIDR   IPv6 Address   Endpoint CIDR
```

For the `cilium endpoint list` command looks like the header is printed before the actual table information. I think the idea is to do it the same for `node list` but the line at https://github.com/cilium/cilium/blob/master/cilium/cmd/node_list.go#L86 is causing the header to be sorted along side with the table output.

I just found it it a bit awkward from an UX perspective to see the header after the data.

```release-note
cli: Print node list header before the actual list of nodes.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9295)
<!-- Reviewable:end -->
