### PR TITLE
k8s/endpointsynchronizer: Do not delete CEP on empty k8s resource names

### DIFF
--- a/pkg/k8s/endpointsynchronizer/cep.go
+++ b/pkg/k8s/endpointsynchronizer/cep.go
@@ -239,7 +239,15 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 			},
 			StopFunc: func(ctx context.Context) error {
 				podName := e.GetK8sPodName()
+				if podName == "" {
+					scopedLog.Debug("Skipping CiliumEndpoint deletion because it has no k8s pod name")
+					return nil
+				}
 				namespace := e.GetK8sNamespace()
+				if namespace == "" {
+					scopedLog.Debug("Skipping CiliumEndpoint deletion because it has no k8s namespace")
+					return nil
+				}
 				if err := ciliumClient.CiliumEndpoints(namespace).Delete(podName, &meta_v1.DeleteOptions{}); err != nil {
 					if !k8serrors.IsNotFound(err) {
 						scopedLog.WithError(err).Warning("Unable to delete CEP")


### PR DESCRIPTION
When cilium-health endpoint is broken, after each restart it tries to
delete CEP with empty pod name and namespace. This change skips the CEP
deletion in that case. Instead of the warning about unsuccesful
deletion, information about empty resource names is logged on debug
level. CEP update was already working like that - update was skipped
when resource names were empty.

Fixes: #9017

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9300)
<!-- Reviewable:end -->
