### PR TITLE
Fix reporting the monitor status in `cilium status`

### DIFF
--- a/daemon/config.go
+++ b/daemon/config.go
@@ -115,12 +115,11 @@ func (h *getConfig) Handle(params GetConfigParams) middleware.Responder {
 		PolicyEnforcement: policy.GetPolicyEnabled(),
 	}
 
-	monitorState := d.monitorAgent.State()
 	status := &models.DaemonConfigurationStatus{
 		Addressing:       node.GetNodeAddressing(),
 		K8sConfiguration: k8s.GetKubeconfigPath(),
 		K8sEndpoint:      k8s.GetAPIServerURL(),
-		NodeMonitor:      &monitorState,
+		NodeMonitor:      d.monitorAgent.State(),
 		KvstoreConfiguration: &models.KVstoreConfiguration{
 			Type:    option.Config.KVStore,
 			Options: option.Config.KVStoreOpt,

--- a/pkg/monitor/agent/agent.go
+++ b/pkg/monitor/agent/agent.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Authors of Cilium
+// Copyright 2017-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -107,9 +107,9 @@ func (a *Agent) eventDrainer() {
 }
 
 // State returns the monitor status.
-func (a *Agent) State() models.MonitorStatus {
+func (a *Agent) State() *models.MonitorStatus {
 	if a == nil || a.monitor == nil {
-		return models.MonitorStatus{}
+		return nil
 	}
 
 	return a.monitor.Status()

--- a/pkg/monitor/agent/monitor.go
+++ b/pkg/monitor/agent/monitor.go
@@ -208,12 +208,12 @@ func (m *Monitor) perfEventReader(stopCtx context.Context, nPages int) {
 }
 
 // Status returns the current status of the monitor
-func (m *Monitor) Status() models.MonitorStatus {
+func (m *Monitor) Status() *models.MonitorStatus {
 	m.Lock()
 	defer m.Unlock()
 
 	if m.monitorEvents == nil {
-		return models.MonitorStatus{}
+		return nil
 	}
 
 	lost, _, unknown := m.monitorEvents.Stats()
@@ -225,8 +225,7 @@ func (m *Monitor) Status() models.MonitorStatus {
 		Unknown:  int64(unknown),
 	}
 
-	return status
-
+	return &status
 }
 
 // connectionHandler1_2 handles all the incoming connections and sets up the


### PR DESCRIPTION
Previously the `MonitorStatus` was returned directly as a structure,
rather than a pointer, which meant that the `node-monitor` status probe
in the daemon under `startStatusCollector()` would not successfully cast
the status report to a `*models.ClusterStatus`, and as such the monitor
would always report to be disabled.

Fix this by returning a pointer just like the other status reports do.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9305)
<!-- Reviewable:end -->
