### PR TITLE
pkg/datapath/loader/netlink: use native go implementation

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -597,6 +597,13 @@ required = [
   # main-usage = "kubernetes"
   # on-revision = "same revision set in the dependency list of k8s.io/kubernetes"
 
+[[constraint]]
+  name = "github.com/florianl/go-tc"
+  revision = "ed7f9af34b13511447b67a6a357a679d6d63a0ef"
+
+  # main-usage = "pkg/datapath/loader"
+  # on-revision = ""
+
 [prune]
   non-go = true
   go-tests = true


### PR DESCRIPTION
Signed-off-by: Lehner Florian <dev@der-flo.net>

This PR replaces execution commands with a native Go implementation. And therefore, it reduces the costs of context switches between Go and other binaries.

It does not replace the 'tc filter replace' command, as a file descriptor is needed as argument. If cilium-map-migrate has been replaced by an native Go implementation, like [1], this execution command can be replaced as well.

go-tc is not a package, which covers all functionality of the netlink family. It concentrates on NETLINK_ROUTE and its class, qdisc and filter part. Therefore, it does not generate the needed file descriptor from the given `objPath`. Based on netlink [2] its focus is on stability and testability, without package/global variables or states.

To keep the first draft of this PR small, I did not run `$ dep ensure -v`.
I'm curious of your feedback.

[1] https://github.com/cilium/ebpf
[2] https://github.com/mdlayher/netlink

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9309)
<!-- Reviewable:end -->
