### PR TITLE
operator/cilium-docker: build images with image arguments

### DIFF
--- a/cilium-docker-plugin.Dockerfile
+++ b/cilium-docker-plugin.Dockerfile
@@ -4,7 +4,7 @@ ADD . /go/src/github.com/cilium/cilium
 WORKDIR /go/src/github.com/cilium/cilium/plugins/cilium-docker
 ARG LOCKDEBUG
 ARG V
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o cilium-docker
+RUN make CGO_ENABLED=0 GOOS=linux LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 EXTRA_GOBUILD_FLAGS="-a -installsuffix cgo"
 RUN strip cilium-docker
 
 FROM scratch

--- a/cilium-operator.Dockerfile
+++ b/cilium-operator.Dockerfile
@@ -4,7 +4,7 @@ ADD . /go/src/github.com/cilium/cilium
 WORKDIR /go/src/github.com/cilium/cilium/operator
 ARG LOCKDEBUG
 ARG V
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o cilium-operator
+RUN make CGO_ENABLED=0 GOOS=linux LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 EXTRA_GOBUILD_FLAGS="-a -installsuffix cgo"
 RUN strip cilium-operator
 
 FROM docker.io/library/alpine:3.9.3 as certs


### PR DESCRIPTION
Dockerfiles for cilium-docker-plugin and cilium-operator are not making
any use of the LOCKDEBUG argument passed to build the images. This
commit fixes it.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9312)
<!-- Reviewable:end -->
