### PR TITLE
policy: remove checking of CIDR-based fields from `IsLabelBased` checks

### DIFF
--- a/pkg/policy/api/egress.go
+++ b/pkg/policy/api/egress.go
@@ -203,7 +203,7 @@ func (e *EgressRule) GetDestinationEndpointSelectorsWithRequirements(requirement
 // based on labels, i.e. either by setting ToEndpoints or ToEntities, or not
 // setting any To field.
 func (e *EgressRule) IsLabelBased() bool {
-	return len(e.ToRequires)+len(e.ToCIDR)+len(e.ToCIDRSet)+len(e.ToServices)+len(e.ToFQDNs) == 0
+	return len(e.ToRequires)+len(e.ToServices)+len(e.ToFQDNs) == 0
 }
 
 // RequiresDerivative returns true when the EgressRule contains sections that

--- a/pkg/policy/api/ingress.go
+++ b/pkg/policy/api/ingress.go
@@ -161,5 +161,5 @@ func (i *IngressRule) GetSourceEndpointSelectorsWithRequirements(requirements []
 // on labels, i.e. either by setting FromEndpoints or FromEntities, or not
 // setting any From field.
 func (i *IngressRule) IsLabelBased() bool {
-	return len(i.FromRequires)+len(i.FromCIDR)+len(i.FromCIDRSet) == 0
+	return len(i.FromRequires) == 0
 }

--- a/pkg/policy/api/ingress_test.go
+++ b/pkg/policy/api/ingress_test.go
@@ -1,0 +1,167 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package api
+
+import (
+	"github.com/cilium/cilium/pkg/checker"
+
+	. "gopkg.in/check.v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (s *PolicyAPITestSuite) TestIsLabelBasedIngress(c *C) {
+	type args struct {
+		eg *IngressRule
+	}
+	type wanted struct {
+		isLabelBased bool
+	}
+
+	tests := []struct {
+		name        string
+		setupArgs   func() args
+		setupWanted func() wanted
+	}{
+		{
+			name: "label-based-rule",
+			setupArgs: func() args {
+				return args{
+					eg: &IngressRule{
+						FromEndpoints: []EndpointSelector{
+							{
+								LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+									"test": "true",
+								},
+								},
+							},
+						},
+					},
+				}
+			},
+			setupWanted: func() wanted {
+				return wanted{
+					isLabelBased: true,
+				}
+			},
+		},
+		{
+			name: "cidr-based-rule",
+			setupArgs: func() args {
+				return args{
+					&IngressRule{
+						FromCIDR: CIDRSlice{"192.0.0.0/3"},
+					},
+				}
+			},
+			setupWanted: func() wanted {
+				return wanted{
+					isLabelBased: true,
+				}
+			},
+		},
+		{
+			name: "cidrset-based-rule",
+			setupArgs: func() args {
+				return args{
+					&IngressRule{
+						FromCIDRSet: CIDRRuleSlice{
+							{
+								Cidr: "192.0.0.0/3",
+							},
+						},
+					},
+				}
+			},
+			setupWanted: func() wanted {
+				return wanted{
+					isLabelBased: true,
+				}
+			},
+		},
+		{
+			name: "rule-with-requirements",
+			setupArgs: func() args {
+				return args{
+					&IngressRule{
+						FromRequires: []EndpointSelector{
+							{
+								LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+									"test": "true",
+								},
+								},
+							},
+						},
+					},
+				}
+			},
+			setupWanted: func() wanted {
+				return wanted{
+					isLabelBased: false,
+				}
+			},
+		},
+		{
+			name: "rule-with-entities",
+			setupArgs: func() args {
+				return args{
+					&IngressRule{
+						FromEntities: EntitySlice{
+							EntityHost,
+						},
+					},
+				}
+			},
+			setupWanted: func() wanted {
+				return wanted{
+					isLabelBased: true,
+				}
+			},
+		},
+		{
+			name: "rule-with-no-l3-specification",
+			setupArgs: func() args {
+				return args{
+					&IngressRule{
+						ToPorts: []PortRule{
+							{
+								Ports: []PortProtocol{
+									{
+										Port:     "80",
+										Protocol: ProtoTCP,
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+			setupWanted: func() wanted {
+				return wanted{
+					isLabelBased: true,
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		args := tt.setupArgs()
+		want := tt.setupWanted()
+		c.Assert(args.eg.sanitize(), Equals, nil, Commentf("Test name: %q", tt.name))
+		isLabelBased := args.eg.IsLabelBased()
+		c.Assert(isLabelBased, checker.DeepEquals, want.isLabelBased, Commentf("Test name: %q", tt.name))
+	}
+}


### PR DESCRIPTION
CIDR-based policy is converted to a label-based representation, so CIDR-policy
is in a sense label-based. Update the `IsLabelBased` functions for ingress and
egress rules, as well as add unit tests accordingly. The removal of checking of
CIDR-based fields in the `IsLabelBased` checks means that we now do wildcarding
at L7 for CIDR-based rules as well in addition to `EndpointSelector` based
rules. Policies like the following will now result in wildcarding at L7:

```
apiVersion: "cilium.io/v2"
kind: CiliumNetworkPolicy
description: "L3-L4-L7 CIDR policy"
metadata:
  name: "l7-cidr-cnp"
spec:
  egress:
  - toCIDR:
    - 1.2.3.4/32
    toPorts:
    - ports:
      - port: "80"
        protocol: TCP
      rules:
        http:
        - headers:
          - 'X-My-Header: true'
          method: GET
          path: /
  endpointSelector:
    matchLabels:
      id: app1
```

```
apiVersion: "cilium.io/v2"
kind: CiliumNetworkPolicy
description: "L3 CIDR policy"
metadata:
  name: "l3-cidr-cnp"
spec:
  egress:
  - toCIDR:
    - 1.2.3.4/32
  endpointSelector:
    matchLabels:
      id: app1
```

In other words, even though there is one rule (l7-cidr-cnp) which only allows
egress access to `GET /` with `X-My-Header:true` to `1.2.3.4/32` on port 80/TCP,
the second rule (l3-cidr-cnp) pokes a wider hole in the firewall to allow all
egress traffic to 1.2.3.4. However, we still will redirect to the proxy, but
we will allow all traffic to preserve existing behavior for visibility purposes.

Note that rules with `ToServices` and `ToFQDNs` are not considered label based
as of this commit.

Signed-off by: Ian Vernon <ian@cilium.io>
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9318)
<!-- Reviewable:end -->
