### PR TITLE
cli: Warn if --rev flag is used with cilium service update

### DIFF
--- a/cilium/cmd/service_update.go
+++ b/cilium/cmd/service_update.go
@@ -27,9 +27,10 @@ import (
 )
 
 var (
-	idU      uint64
-	frontend string
-	backends []string
+	deprecatedAddRev bool // TODO(v1.8+): remove it
+	idU              uint64
+	frontend         string
+	backends         []string
 )
 
 // serviceUpdateCmd represents the service_update command
@@ -44,6 +45,8 @@ var serviceUpdateCmd = &cobra.Command{
 func init() {
 	serviceCmd.AddCommand(serviceUpdateCmd)
 	serviceUpdateCmd.Flags().Uint64VarP(&idU, "id", "", 0, "Identifier")
+	serviceUpdateCmd.Flags().BoolVarP(&deprecatedAddRev, "rev", "", false, "Add reverse translation")
+	serviceUpdateCmd.Flags().MarkDeprecated("rev", "and it is inactive")
 	serviceUpdateCmd.Flags().StringVarP(&frontend, "frontend", "", "", "Frontend address")
 	serviceUpdateCmd.Flags().StringSliceVarP(&backends, "backends", "", []string{}, "Backend address or addresses (<IP:Port>)")
 }


### PR DESCRIPTION
Instead of returning an error, warn a user that the flag is deprecated and inactive. This will prevent from breaking user scripts which used to set the param.

Reported-by: Jarno Rajahalme
Fixes: 4234ed773 ("cli: Remove --rev param of cilium service update")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9319)
<!-- Reviewable:end -->
