### PR TITLE
Clean up misc verifier-test.sh functionality

### DIFF
--- a/test/bpf/verifier-test.sh
+++ b/test/bpf/verifier-test.sh
@@ -123,7 +123,7 @@ function handle_developers {
 }
 
 function main {
-	handle_args
+	handle_args "$@"
 	handle_developers
 
 	trap cleanup EXIT

--- a/test/bpf/verifier-test.sh
+++ b/test/bpf/verifier-test.sh
@@ -33,7 +33,9 @@ TC=${TC:-"tc"}
 IPROUTE2=${IPROUTE2:-"ip"}
 
 function clean_maps {
-	rm -rf $BPFFS/tc/globals/*
+	for f in $BPFFS/tc/globals/test_*; do
+		rm -f $f
+	done
 }
 
 function cleanup {
@@ -92,12 +94,6 @@ function load_xdp {
 function handle_args {
 	if [ $(id -u) -ne 0 ]; then
 		echo "Must be run as root" 1>&2
-		exit 1
-	fi
-
-	if ps cax | grep cilium-agent; then
-		echo "WARNING: This test will conflict with running cilium instances." 1>&2
-		echo "Shut down cilium before continuing." 1>&2
 		exit 1
 	fi
 


### PR DESCRIPTION
* Allow overriding the binaries used for tc, iproute2
* Allow skipping some tests using environment variables
* Allow running the verifier tests even if cilium-agent is running

For more details, inspect individual commits.

These are random cleanups I collected on my way to addressing #8424 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9325)
<!-- Reviewable:end -->
