### PR TITLE
Allow passing endpoint id to fqdn cache list cmd

### DIFF
--- a/Documentation/cmdref/cilium_fqdn_cache_list.md
+++ b/Documentation/cmdref/cilium_fqdn_cache_list.md
@@ -15,6 +15,7 @@ cilium fqdn cache list [flags]
 ### Options
 
 ```
+  -e, --endpoint string       List cache entries for a specific endpoint id
   -h, --help                  help for list
   -p, --matchpattern string   List cache entries with FQDN that match matchpattern
   -o, --output string         json| jsonpath='{}'


### PR DESCRIPTION
Signed-off-by: Vlad Ungureanu <vladu@palantir.com>

Please ensure your pull request adheres to the following guidelines:

<!-- Description of change -->
Adds another argument to `fqdn cache list` to show the cache just for a specific endpoint. The flag is `--endpoint` (short `-e`). 

I found out `/fqdn/cache/{id}` API exists which accepts an endpoint-id and does the thing I needed here so I extended just CLI support.

That is a bit complicated that I wanted it to be with the logic on which API it calls. I'm open to making this easier but found it hard to extract the logic given that `params` variable will have a different type based on what API it will call (same applies with the error checking).

I did not take a look into writing tests for this, need to still figure out how testing is done in the Cilium repo.

```release-note
Adds `--endpoint` argument to `fqdn cache list` to show the cache just for a specific endpoint.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9334)
<!-- Reviewable:end -->
