### PR TITLE
daemon: Fix race condition when syncing services with k8s

### DIFF
--- a/daemon/state.go
+++ b/daemon/state.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint/connector"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/labels"
-	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/maps/lxcmap"
@@ -364,11 +363,7 @@ func (d *Daemon) initRestore(restoredEndpoints *endpointRestoreState) chan struc
 				controller.NewManager().UpdateController("sync-lb-maps-with-k8s-services",
 					controller.ControllerParams{
 						DoFunc: func(ctx context.Context) error {
-							frontends := d.k8sWatcher.K8sSvcCache.UniqueServiceFrontends()
-							matchSVC := func(addr loadbalancer.L3n4Addr) bool {
-								return frontends.LooseMatch(addr)
-							}
-							return d.svc.SyncWithK8s(matchSVC)
+							return d.svc.SyncWithK8sFinished()
 						},
 					},
 				)


### PR DESCRIPTION
Previously, the `sync-lb-maps-with-k8s-services` controller did the following:

1. Fetched a list of services from `pkg/k8s.k8sServiceCache`.
2. Iterated over `pkg/service.Service` cache and removed those which couldn't be found in the former list.

As no lock was held during the (1) and (2) steps, any service added to `service.Service` after the (1) step was removed.

Fix the race condition by not relying on `k8sServiceCache` for the obsolete services removal. Instead, introduce the `noUpdateAfterRestore` flag for each service which is set when services are being restored from the LB BPF maps (in `(*Service).RestoreServices()`). Next, unset the flag when an event to update a service is handled (by `(*Service).UpsertService()`). Finally, remove those services in `(*Service).SyncWithK8sFinished()` which still have the flag being set. The timeline of above is the following:

1. cilium-agent starts.
2. `Service.RestoreServices()`: a list of `Service` is restored from the LB BPF maps; `noUpdateAfterRestore` is set for each service.
3. Connect to kube-apiserver.
4. Receive `UpdateService` events for all existing SVCs, call `Service.UpsertService()`: unset `noUpdateAfterRestore` flag for each service for which `UpdateService` was received. 
5. All events from kube-apiserver received, `Service.SyncWithK8sFinished()`: remove services which has `noUpdateAfterRestore` set.

The fix is based on an assumption that during the k8s service cache sync period `UpsertService()` (via `UpdateService`) is going to be called for each alive service.

**UPDATE**

Unfortunately, just having _"daemon: Fix race condition when syncing svcs with k8s"_ is not enough to fix the race.

The problem is that in our case `cache.WaitForCacheSync()` guarantees that a service-related k8s resource object was consumed by `k8s_service_cache`, but not by `k8sServiceHandler()` which is responsible for calling the `pkg/service.Service` handlers. This is due the following indirection we have:

```
        kube-apiserver ->
                          <- cache.Informer()
                               k8s_service_cache ->
                                                     <- k8sServiceHandler()
                                                          Service.UpsertService()
```

To fix the race, we need to wait until the events have been consumed by `k8sServiceHandler()`. To do that, we introduce the waitgroup which is incremented when calling `k8s_service_cache` and decremented by the `k8sServiceHandler` after calling the `Service` methods.

I will add tests for the waitgroup once `daemon/k8s_service.go` becomes testable.

**THE MOST RECENT UPDATE**

#9400 fixed the issue above.

Not backporting to v1.5 and v1.6, as the fix heavily relies on the recent LB refactoring.

```release-minor
Fix race condition when syncing Kubernetes services after cilium-agent restart which could resulted in failures to establish connections to some services.
```

Fix: #9333.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9341)
<!-- Reviewable:end -->
