### PR TITLE
Extend NodePort BPF tests

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1934,6 +1934,17 @@ func (kub *Kubectl) ExecInPods(ctx context.Context, namespace, selector, cmd str
 	return results, nil
 }
 
+// ExecInHostNetNS runs given command in a pod running in a host network namespace
+func (kub *Kubectl) ExecInHostNetNS(ctx context.Context, node, cmd string) (result *CmdRes, err error) {
+	// This is a hack, as we execute the given cmd in the log-gathering pod
+	// which runs in the host netns. Also, the log-gathering pods lack some
+	// packages, e.g. iproute2.
+	selector := fmt.Sprintf("%s --field-selector spec.nodeName=%s",
+		LogGathererSelector, node)
+
+	return kub.ExecInFirstPod(ctx, LogGathererNamespace, selector, cmd)
+}
+
 // DumpCiliumCommandOutput runs a variety of commands (CiliumKubCLICommands) and writes the results to
 // TestResultsPath
 func (kub *Kubectl) DumpCiliumCommandOutput(ctx context.Context, namespace string) {


### PR DESCRIPTION
This PR extends the NodePort BPF CI tests to cover all missing cases listed in
https://github.com/cilium/cilium/pull/8875#issuecomment-521298497.

In more details, test cases for accessing the NodePort service via local and remote `cilium_host` IPs were added. In the tunneling mode, the remote access is done via the tunneling device.

Reviewable per commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9342)
<!-- Reviewable:end -->
