### PR TITLE
Operator:  fix disconnects on operator restarts when using ipsec

### DIFF
--- a/operator/k8s_node.go
+++ b/operator/k8s_node.go
@@ -70,30 +70,30 @@ func runNodeWatcher() error {
 		&v1.Node{},
 		0,
 		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
-				if n := k8s.CopyObjToV1Node(obj); n != nil {
-					serNodes.Enqueue(func() error {
-						nodeNew := k8s.ParseNode(n, source.Kubernetes)
-						ciliumNodeStore.UpdateKeySync(nodeNew)
-						return nil
-					}, serializer.NoRetry)
-				}
-			},
-			UpdateFunc: func(oldObj, newObj interface{}) {
-				if oldNode := k8s.CopyObjToV1Node(oldObj); oldNode != nil {
-					if newNode := k8s.CopyObjToV1Node(newObj); newNode != nil {
-						if k8s.EqualV1Node(oldNode, newNode) {
-							return
-						}
-
-						serNodes.Enqueue(func() error {
-							newNode := k8s.ParseNode(newNode, source.Kubernetes)
-							ciliumNodeStore.UpdateKeySync(newNode)
-							return nil
-						}, serializer.NoRetry)
-					}
-				}
-			},
+			//			AddFunc: func(obj interface{}) {
+			//				if n := k8s.CopyObjToV1Node(obj); n != nil {
+			//					serNodes.Enqueue(func() error {
+			//						nodeNew := k8s.ParseNode(n, source.Kubernetes)
+			//						ciliumNodeStore.UpdateKeySync(nodeNew)
+			//						return nil
+			//					}, serializer.NoRetry)
+			//				}
+			//			},
+			//			UpdateFunc: func(oldObj, newObj interface{}) {
+			//				if oldNode := k8s.CopyObjToV1Node(oldObj); oldNode != nil {
+			//					if newNode := k8s.CopyObjToV1Node(newObj); newNode != nil {
+			//						if k8s.EqualV1Node(oldNode, newNode) {
+			//							return
+			//						}
+			//
+			//						serNodes.Enqueue(func() error {
+			//							newNode := k8s.ParseNode(newNode, source.Kubernetes)
+			//							ciliumNodeStore.UpdateKeySync(newNode)
+			//							return nil
+			//						}, serializer.NoRetry)
+			//					}
+			//				}
+			//			},
 			DeleteFunc: func(obj interface{}) {
 				n := k8s.CopyObjToV1Node(obj)
 				if n == nil {


### PR DESCRIPTION
We noticed that on container restarts established TCP connections were disconnected (under load).
After some investigation we noticed these events on the agent for all nodes:
- `Received key update via kvstore` with invalid `EncryptionKey:0`
- a few minutes later `Received key update via kvstore` with valid `EncryptionKey:x`

After looking into the code, it seems that on operator restart the node Informer will add all nodes to the kvstore based on the k8s-node resource which does not have the EncryptionKey info and will set it to 0. Watches on the agents will then update the ipsec configuration and create the issue. After a while, the agents update their kvstore resource to the the good value and traffic can flow again (I haven't checked but I assume there is a reconcile loop in the agents).

This PR removes the Add and Update handlers for the k8s-node resources (but keep the Delete handler to handle node deletion).

We've tested it and the following works:
- operator restart doesn't trigger wrong kvstore update
- adding a new node works (the agent create the kvstore and the ciliumnode resources)
- deleting a node works (the operator removes the kvstore and ciliumnode resources)

We don't know the operator well enough to be sure that we are not missing something (of course if it's approved I'll clean the PR to simply remove the code instead of commenting).

cc @tgraf / @jrfastab

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9343)
<!-- Reviewable:end -->
