### PR TITLE
policy: rename `IsLabelBased` to `AllowsWildcarding`

### DIFF
--- a/pkg/policy/api/egress.go
+++ b/pkg/policy/api/egress.go
@@ -199,10 +199,9 @@ func (e *EgressRule) GetDestinationEndpointSelectorsWithRequirements(requirement
 	return append(res, e.aggregatedSelectors...)
 }
 
-// IsLabelBased returns true whether the L3 destination endpoints are selected
-// based on labels, i.e. either by setting ToEndpoints or ToEntities, or not
-// setting any To field.
-func (e *EgressRule) IsLabelBased() bool {
+// AllowsWildcarding returns true if wildcarding should be performed upon
+//// policy evaluation for the given rule.
+func (e *EgressRule) AllowsWildcarding() bool {
 	return len(e.ToRequires)+len(e.ToServices)+len(e.ToFQDNs) == 0
 }
 

--- a/pkg/policy/api/egress_test.go
+++ b/pkg/policy/api/egress_test.go
@@ -293,7 +293,7 @@ func (s *PolicyAPITestSuite) TestIsLabelBasedEgress(c *C) {
 		args := tt.setupArgs()
 		want := tt.setupWanted()
 		c.Assert(args.eg.sanitize(), Equals, nil, Commentf("Test name: %q", tt.name))
-		isLabelBased := args.eg.IsLabelBased()
+		isLabelBased := args.eg.AllowsWildcarding()
 		c.Assert(isLabelBased, checker.DeepEquals, want.isLabelBased, Commentf("Test name: %q", tt.name))
 	}
 }

--- a/pkg/policy/api/ingress.go
+++ b/pkg/policy/api/ingress.go
@@ -157,9 +157,8 @@ func (i *IngressRule) GetSourceEndpointSelectorsWithRequirements(requirements []
 	return append(res, i.aggregatedSelectors...)
 }
 
-// IsLabelBased returns true whether the L3 source endpoints are selected based
-// on labels, i.e. either by setting FromEndpoints or FromEntities, or not
-// setting any From field.
-func (i *IngressRule) IsLabelBased() bool {
+// AllowsWildcarding returns true if wildcarding should be performed upon
+// policy evaluation for the given rule.
+func (i *IngressRule) AllowsWildcarding() bool {
 	return len(i.FromRequires) == 0
 }

--- a/pkg/policy/api/ingress_test.go
+++ b/pkg/policy/api/ingress_test.go
@@ -161,7 +161,7 @@ func (s *PolicyAPITestSuite) TestIsLabelBasedIngress(c *C) {
 		args := tt.setupArgs()
 		want := tt.setupWanted()
 		c.Assert(args.eg.sanitize(), Equals, nil, Commentf("Test name: %q", tt.name))
-		isLabelBased := args.eg.IsLabelBased()
+		isLabelBased := args.eg.AllowsWildcarding()
 		c.Assert(isLabelBased, checker.DeepEquals, want.isLabelBased, Commentf("Test name: %q", tt.name))
 	}
 }

--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -33,7 +33,7 @@ func (rules ruleSlice) wildcardL3L4Rules(ingress bool, l4Policy L4PolicyMap, req
 		if ingress {
 			for _, rule := range r.Ingress {
 				// Non-label-based rule. Ignore.
-				if !rule.IsLabelBased() {
+				if !rule.AllowsWildcarding() {
 					continue
 				}
 
@@ -67,7 +67,7 @@ func (rules ruleSlice) wildcardL3L4Rules(ingress bool, l4Policy L4PolicyMap, req
 		} else {
 			for _, rule := range r.Egress {
 				// Non-label-based rule. Ignore.
-				if !rule.IsLabelBased() {
+				if !rule.AllowsWildcarding() {
 					continue
 				}
 


### PR DESCRIPTION
The `IsLabelBased` function was used to determine whether wildcarding was
allowed upon merging generated policy together, so name it to reflect its usage.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9345)
<!-- Reviewable:end -->
