### PR TITLE
v1.6 backports 2019-10-07

### DIFF
--- a/daemon/fqdn.go
+++ b/daemon/fqdn.go
@@ -382,10 +382,19 @@ func (d *Daemon) notifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epI
 		flowType = accesslog.TypeRequest
 	}
 
-	var serverPort int
+	var epPort, serverPort int
+	_, epPortStr, err := net.SplitHostPort(epIPPort)
+	if err != nil {
+		log.WithError(err).Error("cannot extract source IP from DNS request")
+	} else {
+		if epPort, err = strconv.Atoi(epPortStr); err != nil {
+			log.WithError(err).WithField(logfields.Port, epPortStr).Error("cannot parse source port")
+		}
+	}
+
 	serverIP, serverPortStr, err := net.SplitHostPort(serverAddr)
 	if err != nil {
-		log.WithError(err).Error("cannot extract endpoint IP from DNS request")
+		log.WithError(err).Error("cannot extract destination IP from DNS request")
 	} else {
 		if serverPort, err = strconv.Atoi(serverPortStr); err != nil {
 			log.WithError(err).WithField(logfields.Port, serverPortStr).Error("cannot parse destination port")
@@ -425,6 +434,7 @@ func (d *Daemon) notifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epI
 				Labels:       ep.GetLabels(),
 				LabelsSHA256: ep.GetLabelsSHA(),
 				Identity:     uint64(ep.GetIdentity()),
+				Port:         uint16(epPort),
 			}
 
 			// When the server is an endpoint, get all the data for it.
@@ -437,6 +447,7 @@ func (d *Daemon) notifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epI
 					Labels:       serverEP.GetLabels(),
 					LabelsSHA256: serverEP.GetLabelsSHA(),
 					Identity:     uint64(serverEP.GetIdentity()),
+					Port:         uint16(serverPort),
 				}
 			} else if serverSecID, exists := ipcache.IPIdentityCache.LookupByIP(serverIP); exists {
 				secID := secIDCache.LookupIdentityByID(serverSecID.ID)
@@ -447,6 +458,7 @@ func (d *Daemon) notifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epI
 					Labels:       secID.Labels.GetModel(),
 					LabelsSHA256: secID.GetLabelsSHA256(),
 					Identity:     uint64(serverSecID.ID.Uint32()),
+					Port:         uint16(serverPort),
 				}
 			}
 		},

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -17,6 +17,7 @@ package kvstore
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -1428,6 +1429,10 @@ func newConfig(fpath string) (*client.Config, error) {
 			return nil, err
 		}
 		cfg.TLS.RootCAs = cp
+	}
+	cfg.TLS.GetClientCertificate = func(_ *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+		cer, err := tls.LoadX509KeyPair(yc.Certfile, yc.Keyfile)
+		return &cer, err
 	}
 	return cfg, nil
 }

--- a/pkg/policy/api/egress.go
+++ b/pkg/policy/api/egress.go
@@ -203,7 +203,7 @@ func (e *EgressRule) GetDestinationEndpointSelectorsWithRequirements(requirement
 // based on labels, i.e. either by setting ToEndpoints or ToEntities, or not
 // setting any To field.
 func (e *EgressRule) IsLabelBased() bool {
-	return len(e.ToRequires)+len(e.ToCIDR)+len(e.ToCIDRSet)+len(e.ToServices)+len(e.ToFQDNs) == 0
+	return len(e.ToRequires)+len(e.ToServices)+len(e.ToFQDNs) == 0
 }
 
 // RequiresDerivative returns true when the EgressRule contains sections that

--- a/pkg/policy/api/ingress.go
+++ b/pkg/policy/api/ingress.go
@@ -161,5 +161,5 @@ func (i *IngressRule) GetSourceEndpointSelectorsWithRequirements(requirements []
 // on labels, i.e. either by setting FromEndpoints or FromEntities, or not
 // setting any From field.
 func (i *IngressRule) IsLabelBased() bool {
-	return len(i.FromRequires)+len(i.FromCIDR)+len(i.FromCIDRSet) == 0
+	return len(i.FromRequires) == 0
 }

--- a/pkg/policy/api/ingress_test.go
+++ b/pkg/policy/api/ingress_test.go
@@ -1,0 +1,167 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package api
+
+import (
+	"github.com/cilium/cilium/pkg/checker"
+
+	. "gopkg.in/check.v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (s *PolicyAPITestSuite) TestIsLabelBasedIngress(c *C) {
+	type args struct {
+		eg *IngressRule
+	}
+	type wanted struct {
+		isLabelBased bool
+	}
+
+	tests := []struct {
+		name        string
+		setupArgs   func() args
+		setupWanted func() wanted
+	}{
+		{
+			name: "label-based-rule",
+			setupArgs: func() args {
+				return args{
+					eg: &IngressRule{
+						FromEndpoints: []EndpointSelector{
+							{
+								LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+									"test": "true",
+								},
+								},
+							},
+						},
+					},
+				}
+			},
+			setupWanted: func() wanted {
+				return wanted{
+					isLabelBased: true,
+				}
+			},
+		},
+		{
+			name: "cidr-based-rule",
+			setupArgs: func() args {
+				return args{
+					&IngressRule{
+						FromCIDR: CIDRSlice{"192.0.0.0/3"},
+					},
+				}
+			},
+			setupWanted: func() wanted {
+				return wanted{
+					isLabelBased: true,
+				}
+			},
+		},
+		{
+			name: "cidrset-based-rule",
+			setupArgs: func() args {
+				return args{
+					&IngressRule{
+						FromCIDRSet: CIDRRuleSlice{
+							{
+								Cidr: "192.0.0.0/3",
+							},
+						},
+					},
+				}
+			},
+			setupWanted: func() wanted {
+				return wanted{
+					isLabelBased: true,
+				}
+			},
+		},
+		{
+			name: "rule-with-requirements",
+			setupArgs: func() args {
+				return args{
+					&IngressRule{
+						FromRequires: []EndpointSelector{
+							{
+								LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+									"test": "true",
+								},
+								},
+							},
+						},
+					},
+				}
+			},
+			setupWanted: func() wanted {
+				return wanted{
+					isLabelBased: false,
+				}
+			},
+		},
+		{
+			name: "rule-with-entities",
+			setupArgs: func() args {
+				return args{
+					&IngressRule{
+						FromEntities: EntitySlice{
+							EntityHost,
+						},
+					},
+				}
+			},
+			setupWanted: func() wanted {
+				return wanted{
+					isLabelBased: true,
+				}
+			},
+		},
+		{
+			name: "rule-with-no-l3-specification",
+			setupArgs: func() args {
+				return args{
+					&IngressRule{
+						ToPorts: []PortRule{
+							{
+								Ports: []PortProtocol{
+									{
+										Port:     "80",
+										Protocol: ProtoTCP,
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+			setupWanted: func() wanted {
+				return wanted{
+					isLabelBased: true,
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		args := tt.setupArgs()
+		want := tt.setupWanted()
+		c.Assert(args.eg.sanitize(), Equals, nil, Commentf("Test name: %q", tt.name))
+		isLabelBased := args.eg.IsLabelBased()
+		c.Assert(isLabelBased, checker.DeepEquals, want.isLabelBased, Commentf("Test name: %q", tt.name))
+	}
+}


### PR DESCRIPTION
* PR: 9266 -- kvstore/etcd: always reload keypair (@JulienBalestra) -- https://github.com/cilium/cilium/pull/9266
* PR: 9316 -- daemon: Populate source and destination ports for DNS records (@michi-covalent) -- https://github.com/cilium/cilium/pull/9316
* PR: 9318 -- policy: remove checking of CIDR-based fields from `IsLabelBased` checks (@ianvernon) -- https://github.com/cilium/cilium/pull/9318
* PR: 9348 -- Fix IP leak on main interface when using eni IPAM (@lbernail) -- https://github.com/cilium/cilium/pull/9348

When you have backported the above commits, you can update the PR labels via this command:
```
$ for pr in 9266 9316 9318 9348; do contrib/backporting/set-labels.py $pr done 1.6; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9355)
<!-- Reviewable:end -->
