### PR TITLE
envoy: Update image for Envoy CVEs 2019-10-08

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:feb9a25e46898a501d1f9e49e95e7efbb725fe02 as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:25fead1ba740440008f74a382148373d9a6c082d as cilium-envoy
 
 #
 # Cilium incremental build. Should be fast given builder-deps is up-to-date!


### PR DESCRIPTION
[ upstream commit 6f60b4fd8fdb61c29ff1ece6126c0f1cb3eb00f9 ]

signed-off-by: Jarno Rajahalme <jarno@covalent.io>

```release-note
Envoy has been updated to address CVE-2019-15226
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9360)
<!-- Reviewable:end -->
