### PR TITLE
v1.6 backports 2019-10-08

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1796,6 +1796,26 @@ func (kub *Kubectl) GatherCiliumCoreDumps(ctx context.Context, ciliumPod string)
 	}
 }
 
+// GetCiliumHostIPv4 retrieves cilium_host IPv4 addr of the given node.
+func (kub *Kubectl) GetCiliumHostIPv4(ctx context.Context, node string) (string, error) {
+	pod, err := kub.GetCiliumPodOnNode(KubeSystemNamespace, node)
+	if err != nil {
+		return "", fmt.Errorf("unable to retrieve cilium pod: %s", err)
+	}
+
+	cmd := "ip -4 -o a show dev cilium_host | grep -o -e 'inet [0-9.]*' | cut -d' ' -f2"
+	res := kub.ExecPodCmd(KubeSystemNamespace, pod, cmd)
+	if !res.WasSuccessful() {
+		return "", fmt.Errorf("unable to retrieve cilium_host ipv4 addr: %s", res.GetError())
+	}
+	addr := res.SingleOut()
+	if addr == "" {
+		return "", fmt.Errorf("unable to retrieve cilium_host ipv4 addr")
+	}
+
+	return addr, nil
+}
+
 // DumpCiliumCommandOutput runs a variety of commands (CiliumKubCLICommands) and writes the results to
 // TestResultsPath
 func (kub *Kubectl) DumpCiliumCommandOutput(ctx context.Context, namespace string) {

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -191,6 +191,7 @@ var _ = Describe("K8sServicesTest", func() {
 					net.JoinHostPort(host, fmt.Sprintf("%d", port)))
 			}
 			doRequests := func(url string, count int) {
+				By("Making %d HTTP requests from k8s1 to %q", count, url)
 				for i := 1; i <= count; i++ {
 					res := kubectl.Exec(helpers.CurlFail(url))
 					ExpectWithOffset(1, res).Should(helpers.CMDSuccess(),
@@ -209,15 +210,12 @@ var _ = Describe("K8sServicesTest", func() {
 			// TODO: IPv6
 			count := 10
 			url = getURL("127.0.0.1", data.Spec.Ports[0].NodePort)
-			By("Making %d HTTP requests from k8s1 to %q", count, url)
 			doRequests(url, count)
 
 			url = getURL(helpers.K8s1Ip, data.Spec.Ports[0].NodePort)
-			By("Making %d HTTP requests from k8s1 to %q", count, url)
 			doRequests(url, count)
 
 			url = getURL(helpers.K8s2Ip, data.Spec.Ports[0].NodePort)
-			By("Making %d HTTP requests from k8s1 to %q", count, url)
 			doRequests(url, count)
 
 			// From pod via node IPs
@@ -226,9 +224,29 @@ var _ = Describe("K8sServicesTest", func() {
 			url = getURL(helpers.K8s2Ip, data.Spec.Ports[0].NodePort)
 			testHTTPRequest(url)
 
-			// From pod via loopback (host reachable services)
 			if bpfNodePort {
+				// From host via local cilium_host
+				localCiliumHostIPv4, err := kubectl.GetCiliumHostIPv4(context.TODO(), helpers.K8s1)
+				Expect(err).Should(BeNil(), "Cannot retrieve local cilium_host ipv4")
+				url = getURL(localCiliumHostIPv4, data.Spec.Ports[0].NodePort)
+				doRequests(url, count)
+
+				// From host via remote cilium_host
+				remoteCiliumHostIPv4, err := kubectl.GetCiliumHostIPv4(context.TODO(), helpers.K8s2)
+				Expect(err).Should(BeNil(), "Cannot retrieve remote cilium_host ipv4")
+				url = getURL(remoteCiliumHostIPv4, data.Spec.Ports[0].NodePort)
+				doRequests(url, count)
+
+				// From pod via loopback (host reachable services)
 				url = getURL("127.0.0.1", data.Spec.Ports[0].NodePort)
+				testHTTPRequest(url)
+
+				// From pod via local cilium_host
+				url = getURL(localCiliumHostIPv4, data.Spec.Ports[0].NodePort)
+				testHTTPRequest(url)
+
+				// From pod via remote cilium_host
+				url = getURL(remoteCiliumHostIPv4, data.Spec.Ports[0].NodePort)
 				testHTTPRequest(url)
 			}
 		}


### PR DESCRIPTION
 * PR: 9342 -- Extend NodePort BPF tests (@brb) -- https://github.com/cilium/cilium/pull/9342

When you have backported the above commits, you can update the PR labels via this command:
```
$ for pr in 9342; do contrib/backporting/set-labels.py $pr pending 1.6; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9364)
<!-- Reviewable:end -->
