### PR TITLE
[CI] Node affinity based on labels not hostname

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2140,6 +2140,21 @@ func (kub *Kubectl) GetCiliumPodOnNode(namespace string, node string) (string, e
 	return res.Output().String(), nil
 }
 
+// GetCiliumPodOnNodeWithLabel returns the name of the Cilium pod that is running on node with cilium.io/ci-node label
+func (kub *Kubectl) GetCiliumPodOnNodeWithLabel(namespace string, label string) (string, error) {
+	filter := "-o jsonpath='{.items[0].metadata.name}'"
+
+	res := kub.ExecShort(fmt.Sprintf(
+		"%s -n %s get nodes -l cilium.io/ci-node=%s %s", KubectlCmd, namespace, label, filter))
+	if !res.WasSuccessful() {
+		return "", fmt.Errorf("Unable to get nodes with label '%s'", label)
+	}
+
+	node := res.Output().String()
+
+	return kub.GetCiliumPodOnNode(namespace, node)
+}
+
 func (kub *Kubectl) ciliumPreFlightCheck() error {
 	err := kub.ciliumStatusPreFlightCheck()
 	if err != nil {

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -100,7 +100,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 			nodeName := helpers.K8s1
 
 			var err error
-			ciliumPodK8s1, err := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, nodeName)
+			ciliumPodK8s1, err := kubectl.GetCiliumPodOnNodeWithLabel(helpers.KubeSystemNamespace, nodeName)
 			Expect(err).Should(BeNil(), "Cannot get cilium pod on k8s1")
 
 			By(fmt.Sprintf("Launching cilium monitor on %q", ciliumPodK8s1))
@@ -172,7 +172,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 		validateBPFTunnelMap := func() {
 			By("Checking that BPF tunnels are in place")
-			ciliumPod, err := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
+			ciliumPod, err := kubectl.GetCiliumPodOnNodeWithLabel(helpers.KubeSystemNamespace, helpers.K8s1)
 			ExpectWithOffset(1, err).Should(BeNil(), "Unable to determine cilium pod on node %s", helpers.K8s1)
 			status := kubectl.CiliumExec(ciliumPod, "cilium bpf tunnel list | wc -l")
 			status.ExpectSuccess()

--- a/test/k8sT/Health.go
+++ b/test/k8sT/Health.go
@@ -52,7 +52,7 @@ var _ = Describe("K8sHealthTest", func() {
 	})
 
 	getCilium := func(node string) (pod, ip string) {
-		pod, err := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, node)
+		pod, err := kubectl.GetCiliumPodOnNodeWithLabel(helpers.KubeSystemNamespace, node)
 		Expect(err).Should(BeNil())
 
 		res, err := kubectl.Get(

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -178,7 +178,7 @@ var _ = Describe("K8sPolicyTest", func() {
 			err := kubectl.WaitforPods(namespaceForTest, "-l zgroup=testapp", helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Test pods are not ready after timeout")
 
-			ciliumPod, err = kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
+			ciliumPod, err = kubectl.GetCiliumPodOnNodeWithLabel(helpers.KubeSystemNamespace, helpers.K8s1)
 			Expect(err).Should(BeNil(), "cannot get CiliumPod")
 
 			clusterIP, _, err = kubectl.GetServiceHostPort(namespaceForTest, app1Service)

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -56,7 +56,7 @@ var _ = Describe("K8sServicesTest", func() {
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 		DeployCiliumAndDNS(kubectl)
 
-		ciliumPodK8s1, err = kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
+		ciliumPodK8s1, err = kubectl.GetCiliumPodOnNodeWithLabel(helpers.KubeSystemNamespace, helpers.K8s1)
 		Expect(err).Should(BeNil(), "Cannot get cilium pod on k8s1")
 	})
 
@@ -625,7 +625,7 @@ var _ = Describe("K8sServicesTest", func() {
 
 			By("Checking that policies were correctly imported into Cilium")
 
-			ciliumPodK8s1, err = kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s1)
+			ciliumPodK8s1, err = kubectl.GetCiliumPodOnNodeWithLabel(helpers.KubeSystemNamespace, helpers.K8s1)
 			Expect(err).Should(BeNil(), "Cannot get cilium pod on k8s1")
 			res := kubectl.ExecPodCmd(helpers.KubeSystemNamespace, ciliumPodK8s1, policyCmd)
 			res.ExpectSuccess("Policy %s is not imported", policyCmd)

--- a/test/k8sT/manifests/demo.yaml
+++ b/test/k8sT/manifests/demo.yaml
@@ -47,7 +47,7 @@ spec:
             path: /
             port: 80
       nodeSelector:
-        "kubernetes.io/hostname": k8s1
+        "cilium.io/ci-node": k8s1
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -77,7 +77,7 @@ spec:
         args:
           - "1000h"
       nodeSelector:
-        "kubernetes.io/hostname": k8s1
+        "cilium.io/ci-node": k8s1
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -106,4 +106,4 @@ spec:
         ports:
         - containerPort: 80
       nodeSelector:
-        "kubernetes.io/hostname": k8s1
+        "cilium.io/ci-node": k8s1

--- a/test/k8sT/manifests/guestbook_deployment.yaml
+++ b/test/k8sT/manifests/guestbook_deployment.yaml
@@ -27,7 +27,7 @@ spec:
         - name: redis-server
           containerPort: 6379
       nodeSelector:
-        kubernetes.io/hostname: k8s1
+        "cilium.io/ci-node": k8s1
 ---
 kind: Service
 apiVersion: v1
@@ -73,7 +73,7 @@ spec:
         - name: redis-server
           containerPort: 6379
       nodeSelector:
-        kubernetes.io/hostname: k8s1
+        "cilium.io/ci-node": k8s1
 ---
 kind: Service
 apiVersion: v1
@@ -119,4 +119,4 @@ spec:
         ports:
         - containerPort: 80
       nodeSelector:
-        kubernetes.io/hostname: k8s2
+        cilium.io/ci-node: k8s2

--- a/test/k8sT/manifests/kafka-sw-app.yaml
+++ b/test/k8sT/manifests/kafka-sw-app.yaml
@@ -78,7 +78,8 @@ spec:
         image: docker.io/cilium/kafkaclient:latest
         imagePullPolicy: IfNotPresent
       nodeSelector:
-        "kubernetes.io/hostname": k8s1
+        "cilium.io/ci-node": k8s1
+
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/test/vagrant-ci-start.sh
+++ b/test/vagrant-ci-start.sh
@@ -17,3 +17,7 @@ kubectl get nodes
 echo "adding local docker registry to cluster"
 helm template k8sT/manifests/registry-adder --set IP="$(./print-node-ip.sh)" > registry-adder.yaml
 kubectl apply -f registry-adder.yaml
+
+echo "labeling nodes"
+kubectl label node k8s1 cilium.io/ci-node=k8s1
+kubectl label node k8s2 cilium.io/ci-node=k8s2


### PR DESCRIPTION
This change allows node affinity-depending tests use custom labels
instead of kubernetes.io/hostname.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9365)
<!-- Reviewable:end -->
