### PR TITLE
RFC: k8s / operator: offload CNPNodeStatus updates to cilium-operator

### DIFF
--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -24,6 +24,7 @@ cilium-operator [flags]
       --cluster-name string                    Name of the cluster (default "default")
       --cnp-node-status-gc                     Enable CiliumNetworkPolicy Status garbage collection for nodes which have been removed from the cluster (default true)
       --cnp-node-status-gc-interval duration   GC interval for nodes which have been removed from the cluster in CiliumNetworkPolicy Status (default 2m0s)
+      --cnp-status-update-interval duration    interval between CNP status updates sent to the k8s-apiserver per-CNP (default 1s)
   -D, --debug                                  Enable debugging mode
       --enable-metrics                         Enable Prometheus metrics
       --eni-parallel-workers int               Maximum number of parallel workers used by ENI allocator (default 50)

--- a/operator/main.go
+++ b/operator/main.go
@@ -151,6 +151,8 @@ func init() {
 	flags.BoolVar(&enableCNPNodeStatusGC, "cnp-node-status-gc", true, "Enable CiliumNetworkPolicy Status garbage collection for nodes which have been removed from the cluster")
 	flags.DurationVar(&ciliumCNPNodeStatusGCInterval, "cnp-node-status-gc-interval", time.Minute*2, "GC interval for nodes which have been removed from the cluster in CiliumNetworkPolicy Status")
 
+	flags.DurationVar(&cnpStatusUpdateInterval, "cnp-status-update-interval", 1*time.Second, "interval between CNP status updates sent to the k8s-apiserver per-CNP")
+
 	flags.StringVar(&cmdRefDir, "cmdref", "", "Path to cmdref output directory")
 	flags.MarkHidden("cmdref")
 	viper.BindPFlags(flags)

--- a/pkg/k8s/apis/cilium.io/v2/types.go
+++ b/pkg/k8s/apis/cilium.io/v2/types.go
@@ -108,6 +108,22 @@ type CiliumNetworkPolicyNodeStatus struct {
 	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
+// CreateCNPNodeStatus returns a CiliumNetworkPolicyNodeStatus created from the
+// provided fields
+func CreateCNPNodeStatus(enforcing, ok bool, cnpError error, rev uint64, annotations map[string]string) CiliumNetworkPolicyNodeStatus {
+	cnpns := CiliumNetworkPolicyNodeStatus{
+		Enforcing:   enforcing,
+		Revision:    rev,
+		OK:          ok,
+		LastUpdated: NewTimestamp(),
+		Annotations: annotations,
+	}
+	if cnpError != nil {
+		cnpns.Error = cnpError.Error()
+	}
+	return cnpns
+}
+
 // NewTimestamp creates a new Timestamp with the current time.Now()
 func NewTimestamp() Timestamp {
 	return Timestamp{time.Now()}

--- a/pkg/k8s/cnp.go
+++ b/pkg/k8s/cnp.go
@@ -272,7 +272,6 @@ func (c *CNPStatusUpdateContext) update(cnp *types.SlimCNP, enforcing, ok bool, 
 	var (
 		cnpns       cilium_v2.CiliumNetworkPolicyNodeStatus
 		annotations map[string]string
-		err         error
 	)
 
 	capabilities := k8sversion.Capabilities()
@@ -325,6 +324,11 @@ func (c *CNPStatusUpdateContext) update(cnp *types.SlimCNP, enforcing, ok bool, 
 
 	ns := k8sUtils.ExtractNamespace(&cnp.ObjectMeta)
 
+	return updateStatusByCapabilities(capabilities, c, cnp, ns, cnpns)
+}
+
+func updateStatusByCapabilities(capabilities k8sversion.ServerCapabilities, c *CNPStatusUpdateContext, cnp *types.SlimCNP, ns string, cnpns cilium_v2.CiliumNetworkPolicyNodeStatus) error {
+	var err error
 	switch {
 	case capabilities.Patch:
 		// This is a JSON Patch [RFC 6902] used to create the `/status/nodes`

--- a/pkg/k8s/cnp.go
+++ b/pkg/k8s/cnp.go
@@ -383,11 +383,17 @@ func updateStatusByCapabilities(client clientset.Interface, capabilities k8svers
 			_, err = client.CiliumV2().CiliumNetworkPolicies(ns).Patch(name, k8sTypes.JSONPatchType, createStatusAndNodePatchJSON, "status")
 		}
 	case capabilities.UpdateStatus:
+		if cnp == nil {
+			return fmt.Errorf("cannot update status of nil CNP")
+		}
 		// k8s < 1.13 as minimal support for JSON patch where kube-apiserver
 		// can print Error messages and even panic in k8s < 1.10.
 		cnp.SetPolicyStatus(nodeName, cnpns)
 		_, err = client.CiliumV2().CiliumNetworkPolicies(ns).UpdateStatus(cnp.CiliumNetworkPolicy)
 	default:
+		if cnp == nil {
+			return fmt.Errorf("cannot update status of nil CNP")
+		}
 		// k8s < 1.13 as minimal support for JSON patch where kube-apiserver
 		// can print Error messages and even panic in k8s < 1.10.
 		cnp.SetPolicyStatus(nodeName, cnpns)

--- a/pkg/k8s/cnp_test.go
+++ b/pkg/k8s/cnp_test.go
@@ -322,7 +322,7 @@ func testUpdateCNPNodeStatusK8s(integrationTest bool, k8sVersion string, c *C) {
 	}
 
 	cnpns := wantedCNPS.Nodes["k8s1"]
-	err = updateContext.update(cnp, cnpns.Enforcing, cnpns.OK, err, cnpns.Revision, cnpns.Annotations)
+	err = updateContext.updateViaAPIServer(cnp, cnpns.Enforcing, cnpns.OK, err, cnpns.Revision, cnpns.Annotations)
 	c.Assert(err, IsNil)
 
 	if integrationTest {
@@ -336,7 +336,7 @@ func testUpdateCNPNodeStatusK8s(integrationTest bool, k8sVersion string, c *C) {
 	}
 
 	cnpns = wantedCNPS.Nodes["k8s2"]
-	err = updateContext.update(cnp, cnpns.Enforcing, cnpns.OK, err, cnpns.Revision, cnpns.Annotations)
+	err = updateContext.updateViaAPIServer(cnp, cnpns.Enforcing, cnpns.OK, err, cnpns.Revision, cnpns.Annotations)
 	c.Assert(err, IsNil)
 
 	if integrationTest {
@@ -370,7 +370,7 @@ func testUpdateCNPNodeStatusK8s(integrationTest bool, k8sVersion string, c *C) {
 	}
 
 	cnpns = wantedCNPS.Nodes["k8s1"]
-	err = updateContext.update(cnp, cnpns.Enforcing, cnpns.OK, err, cnpns.Revision, cnpns.Annotations)
+	err = updateContext.updateViaAPIServer(cnp, cnpns.Enforcing, cnpns.OK, err, cnpns.Revision, cnpns.Annotations)
 	c.Assert(err, IsNil)
 
 	if integrationTest {
@@ -600,7 +600,7 @@ func (k *K8sIntegrationSuite) benchmarkUpdateCNPNodeStatus(integrationTest bool,
 					CiliumNPClient: ciliumNPClients[i],
 					NodeName:       "k8s" + strconv.Itoa(i),
 				}
-				err := updateContext.update(cnp, true, true, nil, uint64(i), nil)
+				err := updateContext.updateViaAPIServer(cnp, true, true, nil, uint64(i), nil)
 				c.Assert(err, IsNil)
 				wg.Done()
 			}

--- a/pkg/k8s/cnpstatus.go
+++ b/pkg/k8s/cnpstatus.go
@@ -1,0 +1,334 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path"
+	"strings"
+	"time"
+
+	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/types"
+	k8sversion "github.com/cilium/cilium/pkg/k8s/version"
+	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/kvstore/store"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/sirupsen/logrus"
+
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+// CNPStatusEventHandler handles status updates events for all CNPs in the
+// cluster. Upon creation of CNPs, it will start a controller for that CNP which
+// handles sending of updates for that CNP to the Kubernetes API server. Upon
+// receiving events from the key-value store, it will send the update for the
+// CNP corresponding to the status update to the controller for that CNP.
+type CNPStatusEventHandler struct {
+	eventMap       *cnpEventMap
+	cnpStore       *store.SharedStore
+	k8sStore       cache.Store
+	updateInterval time.Duration
+}
+
+// NodeStatusUpdater handles the lifecycle around sending CNP NodeStatus updates.
+type NodeStatusUpdater struct {
+	updateChan chan *NodeStatusUpdate
+	stopChan   chan struct{}
+}
+
+type cnpEventMap struct {
+	lock.RWMutex
+	eventMap map[string]*NodeStatusUpdater
+}
+
+func newCNPEventMap() *cnpEventMap {
+	return &cnpEventMap{
+		eventMap: make(map[string]*NodeStatusUpdater),
+	}
+}
+
+func (c *cnpEventMap) lookup(cnpKey string) (*NodeStatusUpdater, bool) {
+	c.RLock()
+	ch, ok := c.eventMap[cnpKey]
+	c.RUnlock()
+	return ch, ok
+}
+
+func (c *cnpEventMap) createIfNotExist(cnpKey string) (*NodeStatusUpdater, bool) {
+	c.Lock()
+	defer c.Unlock()
+	nsu, ok := c.eventMap[cnpKey]
+	// Cannot reinsert into map when active channel present.
+	if ok {
+		return nsu, ok
+	}
+	nsu = &NodeStatusUpdater{
+		updateChan: make(chan *NodeStatusUpdate, 512),
+		stopChan:   make(chan struct{}),
+	}
+	c.eventMap[cnpKey] = nsu
+	return nsu, ok
+}
+
+func (c *cnpEventMap) delete(cnpKey string) {
+	c.Lock()
+	defer c.Unlock()
+	nsu, ok := c.eventMap[cnpKey]
+	if !ok {
+		return
+	}
+	// Signal that we should stop processing events.
+	close(nsu.stopChan)
+	delete(c.eventMap, cnpKey)
+}
+
+// NewCNPStatusEventHandler returns a new CNPStatusEventHandler.
+func NewCNPStatusEventHandler(cnpStore *store.SharedStore, k8sStore cache.Store, updateInterval time.Duration) *CNPStatusEventHandler {
+	return &CNPStatusEventHandler{
+		eventMap:       newCNPEventMap(),
+		cnpStore:       cnpStore,
+		k8sStore:       k8sStore,
+		updateInterval: updateInterval,
+	}
+}
+
+// NodeStatusUpdate pairs a CiliumNetworkPolicyNodeStatus to a specific node.
+type NodeStatusUpdate struct {
+	node string
+	*cilium_v2.CiliumNetworkPolicyNodeStatus
+}
+
+// WatchForCNPStatusEvents starts a watcher for all CNP status updates from
+// the key-value store.
+func (c *CNPStatusEventHandler) WatchForCNPStatusEvents() {
+
+restart:
+	watcher := kvstore.Client().ListAndWatch(context.TODO(), "cnpStatusWatcher", CNPStatusesPath, 512)
+	for {
+		select {
+		case event, ok := <-watcher.Events:
+			if !ok {
+				log.Debugf("%s closed, restarting watch", watcher.String())
+				time.Sleep(500 * time.Millisecond)
+				goto restart
+			}
+
+			switch event.Typ {
+			case kvstore.EventTypeListDone, kvstore.EventTypeDelete:
+			case kvstore.EventTypeCreate, kvstore.EventTypeModify:
+				var cnpStatusUpdate CNPNSWithMeta
+				err := json.Unmarshal(event.Value, &cnpStatusUpdate)
+				if err != nil {
+					log.WithFields(logrus.Fields{"kvstore-event": event.Typ.String(), "key": event.Key}).
+						WithError(err).Error("Not updating CNP Status; error unmarshaling data from key-value store")
+					continue
+				}
+
+				log.WithFields(logrus.Fields{
+					"uid":       cnpStatusUpdate.UID,
+					"name":      cnpStatusUpdate.Name,
+					"namespace": cnpStatusUpdate.Namespace,
+					"node":      cnpStatusUpdate.Node,
+					"key":       event.Key,
+					"type":      event.Typ,
+				}).Debug("received event from kvstore")
+
+				// Send the update to the corresponding controller for the
+				// CNP which sends all status updates to the K8s apiserver.
+				cnpKey := generateCNPKey(string(cnpStatusUpdate.UID), cnpStatusUpdate.Namespace, cnpStatusUpdate.Name)
+				updater, ok := c.eventMap.lookup(cnpKey)
+				if !ok {
+					log.WithField("cnp", cnpKey).Debug("received event from kvstore for cnp for which we do not have any updater goroutine")
+					continue
+				}
+				nsu := &NodeStatusUpdate{node: cnpStatusUpdate.Node}
+				nsu.CiliumNetworkPolicyNodeStatus = &(cnpStatusUpdate.CiliumNetworkPolicyNodeStatus)
+
+				// Given that select is not deterministic, ensure that we check
+				// for shutdown first. If not shut down, then try to send on
+				// channel, or wait for shutdown so that we don't block forever
+				// in case the channel is full and the updater is stopped.
+				select {
+				case <-updater.stopChan:
+					// This goroutine is the only sender on this channel; we can
+					// close safely if the stop channel is closed.
+					close(updater.updateChan)
+
+				default:
+					select {
+					// If the update is sent and we shut down after, the event
+					// is 'lost'; we don't care because this means the CNP
+					// was deleted anyway.
+					case updater.updateChan <- nsu:
+					case <-updater.stopChan:
+						// This goroutine is the only sender on this channel; we can
+						// close safely if the stop channel is closed.
+						close(updater.updateChan)
+					}
+				}
+			}
+		}
+	}
+}
+
+// StopStatusHandler signals that we need to stop managing the sending of
+// status updates to the Kubernetes APIServer for the given CNP. It also cleans
+// up all status updates from the key-value store for this CNP.
+func (c *CNPStatusEventHandler) StopStatusHandler(cnp *types.SlimCNP) {
+	cnpKey := getKeyFromObjectMeta(cnp.ObjectMeta)
+	prefix := path.Join(CNPStatusesPath, cnpKey)
+	err := kvstore.DeletePrefix(context.TODO(), prefix)
+	if err != nil {
+		log.WithError(err).WithField("prefix", prefix).Warning("error deleting prefix from kvstore")
+	}
+	c.eventMap.delete(cnpKey)
+
+}
+
+func (c *CNPStatusEventHandler) runStatusHandler(cnpKey string, cnp *types.SlimCNP, nodeStatusUpdater *NodeStatusUpdater) {
+	namespace := cnp.Namespace
+	name := cnp.Name
+	nodeStatusMap := make(map[string]cilium_v2.CiliumNetworkPolicyNodeStatus)
+
+	scopedLog := log.WithFields(logrus.Fields{
+		logfields.K8sNamespace:            namespace,
+		logfields.CiliumNetworkPolicyName: name,
+	})
+
+	scopedLog.Debug("started status handler")
+
+	// Iterate over the shared-store first. We may have received events for this
+	// CNP in the key-value store from nodes which received and processed this
+	// CNP and sent status updates for it before the watcher which updates this
+	// `CNPStatusEventHandler` did. Given that we have the shared store which
+	// caches all keys / values from the kvstore, we iterate and collect said
+	// events. Given that this function is called after we have updated the
+	// `eventMap` for this `CNPStatusEventHandler`, subsequent key updates from
+	// the kvstore are guaranteed to be sent on the channel in the
+	// `nodeStatusUpdater`, which we will receive in the for-loop below.
+	sharedKeys := c.cnpStore.SharedKeysMap()
+	for keyName, storeKey := range sharedKeys {
+		// Look for any key which matches this CNP.
+		if strings.HasPrefix(keyName, cnpKey) {
+			cnpns, ok := storeKey.(*CNPNSWithMeta)
+			if !ok {
+				scopedLog.Errorf("received unexpected type mapping to key %s in cnp shared store: %T", keyName, storeKey)
+				continue
+			}
+			// extract nodeName from keyName
+			nodeStatusMap[cnpns.Node] = cnpns.CiliumNetworkPolicyNodeStatus
+		}
+	}
+	for {
+		// Allow for a bunch of different node status updates to come before
+		// we break out to avoid jitter in updates across the cluster
+		// to affect batching on our end.
+		limit := time.After(c.updateInterval)
+
+		// Collect any other events that have come in, but bail out after the
+		// above limit is hit so that we can send the updates we have received.
+	Loop:
+		for {
+			select {
+			case <-nodeStatusUpdater.stopChan:
+				return
+			case <-limit:
+				if len(nodeStatusMap) == 0 {
+					// If nothing to update, wait until we have something to update.
+					limit = nil
+					continue
+				}
+				break Loop
+			case ev, ok := <-nodeStatusUpdater.updateChan:
+				if !ok {
+					return
+				}
+				nodeStatusMap[ev.node] = *ev.CiliumNetworkPolicyNodeStatus
+			}
+		}
+
+		// Return if we received a request to stop in case we selected on the
+		// limit being hit or receiving an update even if this goroutine was
+		// stopped, as `select` is nondeterministic in which `case` it hits.
+		select {
+		case <-nodeStatusUpdater.stopChan:
+			return
+		default:
+		}
+
+		var (
+			cnp *types.SlimCNP
+			err error
+		)
+
+		switch {
+		// Patching doesn't need us to get the CNP from
+		// the store because we can perform patches without
+		// needing the actual CNP object itself.
+		case k8sversion.Capabilities().Patch:
+		default:
+			cnp, err = getUpdatedCNPFromStore(c.k8sStore, fmt.Sprintf("%s/%s", namespace, name))
+			if err != nil {
+				scopedLog.WithError(err).Error("error getting updated cnp from store")
+			}
+		}
+
+		// Now that we have collected all events for
+		// the given CNP, update the status for all nodes
+		// which have sent us updates.
+		if err = updateStatusesByCapabilities(CiliumClient(), k8sversion.Capabilities(), cnp, namespace, name, nodeStatusMap); err != nil {
+			scopedLog.WithError(err).Error("error updating status for CNP")
+		}
+	}
+}
+
+// StartStatusHandler starts the goroutine which sends status updates for the
+// given CNP to the Kubernetes APIserver. If a status handler has already been
+// started, it is a no-op.
+func (c *CNPStatusEventHandler) StartStatusHandler(cnp *types.SlimCNP) {
+	cnpKey := generateCNPKey(string(cnp.UID), cnp.Namespace, cnp.Name)
+	nodeStatusUpdater, ok := c.eventMap.createIfNotExist(cnpKey)
+	if ok {
+		return
+	}
+	go c.runStatusHandler(cnpKey, cnp, nodeStatusUpdater)
+}
+
+func getKeyFromObjectMeta(t metaV1.ObjectMeta) string {
+	return path.Join(string(t.UID), t.Namespace, t.Name)
+}
+
+func getUpdatedCNPFromStore(ciliumStore cache.Store, nameNamespace string) (*types.SlimCNP, error) {
+	serverRuleStore, exists, err := ciliumStore.GetByKey(nameNamespace)
+	if err != nil {
+		return nil, fmt.Errorf("unable to find v2.CiliumNetworkPolicy in local cache: %s", err)
+	}
+	if !exists {
+		return nil, errors.New("v2.CiliumNetworkPolicy does not exist in local cache")
+	}
+
+	serverRule, ok := serverRuleStore.(*types.SlimCNP)
+	if !ok {
+		return nil, errors.New("received object of unknown type from API server, expecting v2.CiliumNetworkPolicy")
+	}
+
+	return serverRule, nil
+}


### PR DESCRIPTION
**Problem Statement**
In large scale environments, the current model of having each node in the cluster try to update the NodeStatus for a CNP means that the amount of requests sent to update the status via the API server is a `multiple of number of in the cluster CNPs * number of nodes in the cluster` . This does not scale for large numbers of policies / large numbers of nodes in the cluster, as this results in a large amount of load on kube-apiserver. 

**Summary of Changes / Design**

To reduce the amount of interaction directly with the kube-apiserver, have each node update the key-value store used by Cilium with its status for the CNP and have `cilium-operator` be the sole interactor with kube-apiserver for updating the status. `cilium-operator` will watch for events from the key-value store for CNP statuses, and will then update the kube-apiserver with the updates.

The information is stored in the key-value store in the following format:

```
cilium/state/cnpstatuses/v2/<UUID of CNP structure>/<namespace>/<name>/<node name> --> <marshaled CNPNodeStatus + namespace, name, UID, node name> 
```

The operator has a kvstore watcher which spawns at bootstrap. Upon creation or modification of a key in the the `cilium/state/cnpstatuses/v2/` prefix, it will send the update to a goroutine which is responsible for updating the K8s apiserver with the status of a specific CNP.

The per-CNP updating management is performed by a goroutine which is launched when the operator receives a creation event for the CNP from its Kubernetes watcher, and stopped when the watcher receives a deletion event. On deletion, the prefix of `cilium/state/cnpstatuses/v2/<UUID of CNP structure>/<namespace>/<name>` is deleted from the key-value store. If a node is deleted, there is separate logic already present in `cilium-operator` which will GC old nodes from CNP NodeStatus.

Upon spawning of this goroutine, a shared-store which is launched at operator bootstrap is used to ensure that we do not miss any events which were pushed for CNPs which may have received the CNP creation event and pushed them to the key-value store before the operator received the CNP creation event from its own watcher.

These logic within the goroutine consumes all status events transmitted by the key-value store watcher until there are no more left available to consume. It pushes all of these updates into JSON Patch(es) and patches the CNP's status accordingly. This allows for multiple status updates to be sent to the kube-apiserver at once for multiple nodes as opposed to each node itself updating the kube-apiserver, improving scalability of NodeStatus updates. 

Fixes: #8897 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9384)
<!-- Reviewable:end -->
