### PR TITLE
install: Add `system:nodes` Group to cilium ClusterRoleBinding

### DIFF
--- a/install/kubernetes/cilium/charts/agent/templates/clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/clusterrolebinding.yaml
@@ -10,3 +10,6 @@ subjects:
 - kind: ServiceAccount
   name: cilium
   namespace: {{ .Release.Namespace }}
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:nodes

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -277,6 +277,9 @@ subjects:
 - kind: ServiceAccount
   name: cilium
   namespace: kube-system
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:nodes
 
 ---
 # Source: cilium/charts/operator/templates/clusterrolebinding.yaml


### PR DESCRIPTION
Create a cilium cluster via cilium.yaml generated by helm template,
agent fails because User system:nodes:NODE_NAME cannot get desired k8s
resource, this fixes the issue.

Signed-off-by: Jaff Cheng <jaff.cheng.sh@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9388)
<!-- Reviewable:end -->
