### PR TITLE
policy: generate explicit allow-all at L7 for DNS-based visibility policy

### DIFF
--- a/pkg/policy/visibility_test.go
+++ b/pkg/policy/visibility_test.go
@@ -17,9 +17,32 @@
 package policy
 
 import (
+	"github.com/cilium/cilium/pkg/checker"
+	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/u8proto"
 	. "gopkg.in/check.v1"
 )
+
+func (ds *PolicyTestSuite) TestGenerateL7RulesByParser(c *C) {
+	m := generateL7AllowAllRules(ParserTypeHTTP)
+	c.Assert(m, IsNil)
+
+	m = generateL7AllowAllRules(ParserTypeKafka)
+	c.Assert(m, IsNil)
+
+	m = generateL7AllowAllRules(ParserTypeDNS)
+	c.Assert(m, Not(IsNil))
+	c.Assert(len(m), Equals, 1)
+
+	var l7Rules []api.L7Rules
+	for _, v := range m {
+		l7Rules = append(l7Rules, v)
+	}
+
+	// Check that we allow all at L7 for DNS for the one rule we should have
+	// generated.
+	c.Assert(l7Rules[0], checker.DeepEquals, api.L7Rules{DNS: []api.PortRuleDNS{{MatchPattern: "*"}}})
+}
 
 func (ds *PolicyTestSuite) TestVisibilityPolicyCreation(c *C) {
 

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -819,7 +819,7 @@ var _ = Describe("K8sPolicyTest", func() {
 				}
 			}
 
-			It("Tests proxy visibility without policy", func() {
+			It("Tests HTTP proxy visibility without policy", func() {
 				checkProxyRedirection(app1PodIP, false)
 
 				By("Annotating %s with <Ingress/80/TCP/HTTP>", app1Pod)


### PR DESCRIPTION
Different L7 parsers behave differently with respect to how they interpret what is allowed at L7; an empty set of L7Rules is interpreted as an allow-all by the HTTP proxy, while for DNS, the allow-all must explicitly be specified via an L7Rule. As such, with visibility policy, traffic would previously be redirected to the proxy, but dropped because the information sent to the proxy via the `VisibilityMetadata` structure was interpreted as a deny-all instead of an allow-all. Fix this by adding an `L7DataMap` to the `VisibilityMetadata` structure to contain the L7 allow-all for DNS-based visibility policy.

Also refactor the visibility test functionality in the Ginkgo test suite, and add a test to said test suite which tests DNS-based proxy visibility.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9391)
<!-- Reviewable:end -->
