### PR TITLE
xds: Allow endpoints to wait for the current policy version to be acked

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1026,6 +1026,7 @@ func (e *Endpoint) addPolicyKey(keyToAdd policy.Key, entry policy.MapStateEntry,
 // ApplyPolicyMapChanges updates the Endpoint's PolicyMap with the changes
 // that have accumulated for the PolicyMap via various outside events (e.g.,
 // identities added / deleted).
+// 'proxyWaitGroup' may not be nil.
 func (e *Endpoint) ApplyPolicyMapChanges(proxyWaitGroup *completion.WaitGroup) error {
 	if err := e.lockAlive(); err != nil {
 		return err
@@ -1040,6 +1041,9 @@ func (e *Endpoint) ApplyPolicyMapChanges(proxyWaitGroup *completion.WaitGroup) e
 	if proxyChanges {
 		// Ignoring the revertFunc; keep all successful changes even if some fail.
 		err, _ = e.updateNetworkPolicy(proxyWaitGroup)
+	} else {
+		// Allow caller to wait for the current network policy to be acked
+		e.useCurrentNetworkPolicy(proxyWaitGroup)
 	}
 
 	return err

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -86,6 +86,22 @@ func (e *Endpoint) updateNetworkPolicy(proxyWaitGroup *completion.WaitGroup) (re
 	return e.proxy.UpdateNetworkPolicy(e, e.desiredPolicy.L4Policy, e.desiredPolicy.IngressPolicyEnabled, e.desiredPolicy.EgressPolicyEnabled, proxyWaitGroup)
 }
 
+func (e *Endpoint) useCurrentNetworkPolicy(proxyWaitGroup *completion.WaitGroup) {
+	if e.SecurityIdentity == nil {
+		return
+	}
+
+	// If desired L4Policy is nil then no policy change is needed.
+	if e.desiredPolicy == nil || e.desiredPolicy.L4Policy == nil {
+		return
+	}
+
+	if e.proxy != nil {
+		// Wait for the current network policy to be acked
+		e.proxy.UseCurrentNetworkPolicy(e, e.desiredPolicy.L4Policy, proxyWaitGroup)
+	}
+}
+
 // setNextPolicyRevision updates the desired policy revision field
 // Must be called with the endpoint lock held for at least reading
 func (e *Endpoint) setNextPolicyRevision(revision uint64) {

--- a/pkg/endpoint/proxy.go
+++ b/pkg/endpoint/proxy.go
@@ -30,6 +30,7 @@ type EndpointProxy interface {
 	CreateOrUpdateRedirect(l4 policy.ProxyPolicy, id string, localEndpoint logger.EndpointUpdater, wg *completion.WaitGroup) (proxyPort uint16, err error, finalizeFunc revert.FinalizeFunc, revertFunc revert.RevertFunc)
 	RemoveRedirect(id string, wg *completion.WaitGroup) (error, revert.FinalizeFunc, revert.RevertFunc)
 	UpdateNetworkPolicy(ep logger.EndpointUpdater, policy *policy.L4Policy, ingressPolicyEnforced, egressPolicyEnforced bool, wg *completion.WaitGroup) (error, func() error)
+	UseCurrentNetworkPolicy(ep logger.EndpointUpdater, policy *policy.L4Policy, wg *completion.WaitGroup)
 	RemoveNetworkPolicy(ep logger.EndpointInfoSource)
 }
 
@@ -87,5 +88,9 @@ func (f *FakeEndpointProxy) UpdateNetworkPolicy(ep logger.EndpointUpdater, polic
 	return nil, nil
 }
 
-//RemoveNetworkPolicy does nothing.
+// UseCurrentNetworkPolicy does nothing.
+func (f *FakeEndpointProxy) UseCurrentNetworkPolicy(ep logger.EndpointUpdater, policy *policy.L4Policy, wg *completion.WaitGroup) {
+}
+
+// RemoveNetworkPolicy does nothing.
 func (f *FakeEndpointProxy) RemoveNetworkPolicy(ep logger.EndpointInfoSource) {}

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -66,6 +66,10 @@ func (r *RedirectSuiteProxy) UpdateNetworkPolicy(ep logger.EndpointUpdater, poli
 	return nil, nil
 }
 
+// UseCurrentNetworkPolicy does nothing.
+func (r *RedirectSuiteProxy) UseCurrentNetworkPolicy(ep logger.EndpointUpdater, policy *policy.L4Policy, wg *completion.WaitGroup) {
+}
+
 // RemoveNetworkPolicy does nothing.
 func (r *RedirectSuiteProxy) RemoveNetworkPolicy(ep logger.EndpointInfoSource) {}
 

--- a/pkg/envoy/resources.go
+++ b/pkg/envoy/resources.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 
 	envoyAPI "github.com/cilium/proxy/go/cilium/api"
-	envoy_api_v2_core "github.com/cilium/proxy/go/envoy/api/v2/core"
 	"github.com/sirupsen/logrus"
 )
 
@@ -60,7 +59,7 @@ var (
 )
 
 // HandleResourceVersionAck is required to implement ResourceVersionAckObserver.
-func (cache *NPHDSCache) HandleResourceVersionAck(ackVersion uint64, nackVersion uint64, node *envoy_api_v2_core.Node, resourceNames []string, typeURL string, detail string) {
+func (cache *NPHDSCache) HandleResourceVersionAck(ackVersion uint64, nackVersion uint64, nodeIP string, resourceNames []string, typeURL string, detail string) {
 	// Start caching for IP/ID mappings on the first indication someone wants them
 	observerOnce.Do(func() {
 		ipcache.IPIdentityCache.AddListener(cache)

--- a/pkg/envoy/resources.go
+++ b/pkg/envoy/resources.go
@@ -131,7 +131,7 @@ func (cache *NPHDSCache) OnIPIdentityCacheChange(modType ipcache.CacheModificati
 			}).Warning("Could not validate NPHDS resource update on upsert")
 			return
 		}
-		cache.Upsert(NetworkPolicyHostsTypeURL, resourceName, &newNpHost, false)
+		cache.Upsert(NetworkPolicyHostsTypeURL, resourceName, &newNpHost)
 	case ipcache.Delete:
 		if msg == nil {
 			// Doesn't exist; already deleted.
@@ -164,7 +164,7 @@ func (cache *NPHDSCache) handleIPDelete(npHost *envoyAPI.NetworkPolicyHosts, pee
 	// If removing this host would result in empty list, delete it.
 	// Otherwise, update to a list that doesn't contain the target IP
 	if len(npHost.HostAddresses) <= 1 {
-		cache.Delete(NetworkPolicyHostsTypeURL, peerIdentity, false)
+		cache.Delete(NetworkPolicyHostsTypeURL, peerIdentity)
 	} else {
 		// If the resource is to be updated, create a copy of it before
 		// removing the IP address from its HostAddresses list.
@@ -184,6 +184,6 @@ func (cache *NPHDSCache) handleIPDelete(npHost *envoyAPI.NetworkPolicyHosts, pee
 			scopedLog.WithError(err).Warning("Could not validate NPHDS resource update on delete")
 			return
 		}
-		cache.Upsert(NetworkPolicyHostsTypeURL, peerIdentity, &newNpHost, false)
+		cache.Upsert(NetworkPolicyHostsTypeURL, peerIdentity, &newNpHost)
 	}
 }

--- a/pkg/envoy/resources.go
+++ b/pkg/envoy/resources.go
@@ -59,6 +59,9 @@ var (
 )
 
 // HandleResourceVersionAck is required to implement ResourceVersionAckObserver.
+// We use this to start the IP Cache listener on the first ACK so that we only
+// start the IP Cache listener if there is an Envoy node that uses NPHDS (e.g.,
+// Istio node, or host proxy running on kernel w/o LPM bpf map support).
 func (cache *NPHDSCache) HandleResourceVersionAck(ackVersion uint64, nackVersion uint64, nodeIP string, resourceNames []string, typeURL string, detail string) {
 	// Start caching for IP/ID mappings on the first indication someone wants them
 	observerOnce.Do(func() {

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -896,12 +896,12 @@ func (s *XDSServer) RemoveNetworkPolicy(ep logger.EndpointInfoSource) {
 
 	name := ep.GetIPv6Address()
 	if name != "" {
-		s.networkPolicyCache.Delete(NetworkPolicyTypeURL, name, false)
+		s.networkPolicyCache.Delete(NetworkPolicyTypeURL, name)
 		delete(s.networkPolicyEndpoints, name)
 	}
 	name = ep.GetIPv4Address()
 	if name != "" {
-		s.networkPolicyCache.Delete(NetworkPolicyTypeURL, name, false)
+		s.networkPolicyCache.Delete(NetworkPolicyTypeURL, name)
 		delete(s.networkPolicyEndpoints, name)
 		// Delete node resources held in the cache for the endpoint (e.g., sidecar)
 		s.NetworkPolicyMutator.DeleteNode(name)
@@ -911,7 +911,7 @@ func (s *XDSServer) RemoveNetworkPolicy(ep logger.EndpointInfoSource) {
 // RemoveAllNetworkPolicies removes all network policies from the set published
 // to L7 proxies.
 func (s *XDSServer) RemoveAllNetworkPolicies() {
-	s.networkPolicyCache.Clear(NetworkPolicyTypeURL, false)
+	s.networkPolicyCache.Clear(NetworkPolicyTypeURL)
 }
 
 // GetNetworkPolicies returns the current version of the network policies with

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -152,14 +152,14 @@ func StartXDSServer(stateDir string) *XDSServer {
 	}
 
 	ldsCache := xds.NewCache()
-	ldsMutator := xds.NewAckingResourceMutatorWrapper(ldsCache, xds.IstioNodeToIP)
+	ldsMutator := xds.NewAckingResourceMutatorWrapper(ldsCache)
 	ldsConfig := &xds.ResourceTypeConfiguration{
 		Source:      ldsCache,
 		AckObserver: ldsMutator,
 	}
 
 	npdsCache := xds.NewCache()
-	npdsMutator := xds.NewAckingResourceMutatorWrapper(npdsCache, xds.IstioNodeToIP)
+	npdsMutator := xds.NewAckingResourceMutatorWrapper(npdsCache)
 	npdsConfig := &xds.ResourceTypeConfiguration{
 		Source:      npdsCache,
 		AckObserver: npdsMutator,

--- a/pkg/envoy/xds/ack.go
+++ b/pkg/envoy/xds/ack.go
@@ -219,10 +219,10 @@ func (m *AckingResourceMutatorWrapper) Delete(typeURL string, resourceName strin
 // 'ackVersion' is the last version that was acked. 'nackVersion', if greater than 'nackVersion', is the last version that was NACKed.
 func (m *AckingResourceMutatorWrapper) HandleResourceVersionAck(ackVersion uint64, nackVersion uint64, node *envoy_api_v2_core.Node, resourceNames []string, typeURL string, detail string) {
 	ackLog := log.WithFields(logrus.Fields{
-		logfields.XDSVersionInfo: ackVersion,
-		logfields.XDSNonce:       nackVersion,
-		logfields.XDSClientNode:  node,
-		logfields.XDSTypeURL:     typeURL,
+		logfields.XDSAckedVersion: ackVersion,
+		logfields.XDSNonce:        nackVersion,
+		logfields.XDSClientNode:   node,
+		logfields.XDSTypeURL:      typeURL,
 	})
 
 	nodeID, err := m.nodeToID(node)

--- a/pkg/envoy/xds/ack_test.go
+++ b/pkg/envoy/xds/ack_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/completion"
-	envoy_api_v2_core "github.com/cilium/proxy/go/envoy/api/v2/core"
 
 	. "gopkg.in/check.v1"
 )
@@ -36,12 +35,6 @@ const (
 	node1 = "10.0.0.1"
 	node2 = "10.0.0.2"
 )
-
-var nodes = map[string]*envoy_api_v2_core.Node{
-	node0: {Id: "sidecar~10.0.0.0~node0~bar"},
-	node1: {Id: "sidecar~10.0.0.1~node1~bar"},
-	node2: {Id: "sidecar~10.0.0.2~node2~bar"},
-}
 
 // IsCompletedChecker checks that a Completion is completed without errors.
 type IsCompletedChecker struct {
@@ -80,6 +73,7 @@ func (s *AckSuite) TestUpsertSingleNode(c *C) {
 	// Empty cache is the version 1
 	cache := NewCache()
 	acker := NewAckingResourceMutatorWrapper(cache)
+	c.Assert(acker.ackedVersions, HasLen, 0)
 
 	// Create version 2 with resource 0.
 	comp := wg.AddCompletion()
@@ -88,20 +82,28 @@ func (s *AckSuite) TestUpsertSingleNode(c *C) {
 	c.Assert(comp, Not(IsCompleted))
 
 	// Ack the right version, for the right resource, from another node.
-	acker.HandleResourceVersionAck(2, 2, nodes[node1], []string{resources[0].Name}, typeURL, "")
+	acker.HandleResourceVersionAck(2, 2, node1, []string{resources[0].Name}, typeURL, "")
 	c.Assert(comp, Not(IsCompleted))
+	c.Assert(acker.ackedVersions, HasLen, 1)
+	c.Assert(acker.ackedVersions[node1], Equals, uint64(2))
 
 	// Ack the right version, for another resource, from the right node.
-	acker.HandleResourceVersionAck(2, 2, nodes[node0], []string{resources[1].Name}, typeURL, "")
+	acker.HandleResourceVersionAck(2, 2, node0, []string{resources[1].Name}, typeURL, "")
 	c.Assert(comp, Not(IsCompleted))
+	c.Assert(acker.ackedVersions, HasLen, 2)
+	c.Assert(acker.ackedVersions[node0], Equals, uint64(2))
 
 	// Ack an older version, for the right resource, from the right node.
-	acker.HandleResourceVersionAck(1, 1, nodes[node0], []string{resources[0].Name}, typeURL, "")
+	acker.HandleResourceVersionAck(1, 1, node0, []string{resources[0].Name}, typeURL, "")
 	c.Assert(comp, Not(IsCompleted))
+	c.Assert(acker.ackedVersions, HasLen, 2)
+	c.Assert(acker.ackedVersions[node0], Equals, uint64(2))
 
 	// Ack the right version, for the right resource, from the right node.
-	acker.HandleResourceVersionAck(2, 2, nodes[node0], []string{resources[0].Name}, typeURL, "")
+	acker.HandleResourceVersionAck(2, 2, node0, []string{resources[0].Name}, typeURL, "")
 	c.Assert(comp, IsCompleted)
+	c.Assert(acker.ackedVersions, HasLen, 2)
+	c.Assert(acker.ackedVersions[node0], Equals, uint64(2))
 }
 
 func (s *AckSuite) TestUpsertMultipleNodes(c *C) {
@@ -113,25 +115,41 @@ func (s *AckSuite) TestUpsertMultipleNodes(c *C) {
 	// Empty cache is the version 1
 	cache := NewCache()
 	acker := NewAckingResourceMutatorWrapper(cache)
+	c.Assert(acker.ackedVersions, HasLen, 0)
 
 	// Create version 2 with resource 0.
 	comp := wg.AddCompletion()
 	defer comp.Complete(nil)
 	acker.Upsert(typeURL, resources[0].Name, resources[0], []string{node0, node1}, comp)
 	c.Assert(comp, Not(IsCompleted))
+	c.Assert(acker.currentVersionAcked([]string{node0}), Equals, false)
+	c.Assert(acker.currentVersionAcked([]string{node1}), Equals, false)
+	c.Assert(acker.currentVersionAcked([]string{node2}), Equals, false)
 
 	// Ack the right version, for the right resource, from another node.
-	acker.HandleResourceVersionAck(2, 2, nodes[node2], []string{resources[0].Name}, typeURL, "")
+	acker.HandleResourceVersionAck(2, 2, node2, []string{resources[0].Name}, typeURL, "")
 	c.Assert(comp, Not(IsCompleted))
+	c.Assert(acker.currentVersionAcked([]string{node0}), Equals, false)
+	c.Assert(acker.currentVersionAcked([]string{node1}), Equals, false)
+	c.Assert(acker.currentVersionAcked([]string{node2}), Equals, true)
 
 	// Ack the right version, for the right resource, from one of the nodes (node0).
 	// One of the nodes (node1) still needs to ACK.
-	acker.HandleResourceVersionAck(2, 2, nodes[node0], []string{resources[0].Name}, typeURL, "")
+	acker.HandleResourceVersionAck(2, 2, node0, []string{resources[0].Name}, typeURL, "")
 	c.Assert(comp, Not(IsCompleted))
+	c.Assert(acker.currentVersionAcked([]string{node0}), Equals, true)
+	c.Assert(acker.currentVersionAcked([]string{node1}), Equals, false)
+	c.Assert(acker.currentVersionAcked([]string{node2}), Equals, true)
+	c.Assert(acker.currentVersionAcked([]string{node0, node1}), Equals, false)
+	c.Assert(acker.currentVersionAcked([]string{node0, node2}), Equals, true)
 
 	// Ack the right version, for the right resource, from the last remaining node (node1).
-	acker.HandleResourceVersionAck(2, 2, nodes[node1], []string{resources[0].Name}, typeURL, "")
+	acker.HandleResourceVersionAck(2, 2, node1, []string{resources[0].Name}, typeURL, "")
 	c.Assert(comp, IsCompleted)
+	c.Assert(acker.currentVersionAcked([]string{node0}), Equals, true)
+	c.Assert(acker.currentVersionAcked([]string{node1}), Equals, true)
+	c.Assert(acker.currentVersionAcked([]string{node2}), Equals, true)
+	c.Assert(acker.currentVersionAcked([]string{node0, node1, node2}), Equals, true)
 }
 
 func (s *AckSuite) TestUpsertMoreRecentVersion(c *C) {
@@ -151,11 +169,11 @@ func (s *AckSuite) TestUpsertMoreRecentVersion(c *C) {
 	c.Assert(comp, Not(IsCompleted))
 
 	// Ack an older version, for the right resource, from the right node.
-	acker.HandleResourceVersionAck(1, 1, nodes[node0], []string{resources[0].Name}, typeURL, "")
+	acker.HandleResourceVersionAck(1, 1, node0, []string{resources[0].Name}, typeURL, "")
 	c.Assert(comp, Not(IsCompleted))
 
 	// Ack a more recent version, for the right resource, from the right node.
-	acker.HandleResourceVersionAck(123, 123, nodes[node0], []string{resources[0].Name}, typeURL, "")
+	acker.HandleResourceVersionAck(123, 123, node0, []string{resources[0].Name}, typeURL, "")
 	c.Assert(comp, IsCompleted)
 }
 
@@ -176,11 +194,11 @@ func (s *AckSuite) TestUpsertMoreRecentVersionNack(c *C) {
 	c.Assert(comp, Not(IsCompleted))
 
 	// Ack an older version, for the right resource, from the right node.
-	acker.HandleResourceVersionAck(1, 1, nodes[node0], []string{resources[0].Name}, typeURL, "")
+	acker.HandleResourceVersionAck(1, 1, node0, []string{resources[0].Name}, typeURL, "")
 	c.Assert(comp, Not(IsCompleted))
 
 	// NAck a more recent version, for the right resource, from the right node.
-	acker.HandleResourceVersionAck(1, 2, nodes[node0], []string{resources[0].Name}, typeURL, "Detail")
+	acker.HandleResourceVersionAck(1, 2, node0, []string{resources[0].Name}, typeURL, "Detail")
 	// IsCompleted is true only for completions without error
 	c.Assert(comp, Not(IsCompleted))
 	c.Assert(comp.Err(), Not(Equals), nil)
@@ -204,7 +222,7 @@ func (s *AckSuite) TestDeleteSingleNode(c *C) {
 	c.Assert(comp, Not(IsCompleted))
 
 	// Ack the right version, for the right resource, from the right node.
-	acker.HandleResourceVersionAck(2, 2, nodes[node0], []string{resources[0].Name}, typeURL, "")
+	acker.HandleResourceVersionAck(2, 2, node0, []string{resources[0].Name}, typeURL, "")
 	c.Assert(comp, IsCompleted)
 
 	// Create version 3 with no resources.
@@ -214,11 +232,11 @@ func (s *AckSuite) TestDeleteSingleNode(c *C) {
 	c.Assert(comp, Not(IsCompleted))
 
 	// Ack the right version, for another resource, from another node.
-	acker.HandleResourceVersionAck(3, 3, nodes[node1], []string{resources[2].Name}, typeURL, "")
+	acker.HandleResourceVersionAck(3, 3, node1, []string{resources[2].Name}, typeURL, "")
 	c.Assert(comp, Not(IsCompleted))
 
 	// Ack the right version, for another resource, from the right node.
-	acker.HandleResourceVersionAck(3, 3, nodes[node0], []string{resources[2].Name}, typeURL, "")
+	acker.HandleResourceVersionAck(3, 3, node0, []string{resources[2].Name}, typeURL, "")
 	// The resource name is ignored. For delete, we only consider the version.
 	c.Assert(comp, IsCompleted)
 }
@@ -240,7 +258,7 @@ func (s *AckSuite) TestDeleteMultipleNodes(c *C) {
 	c.Assert(comp, Not(IsCompleted))
 
 	// Ack the right version, for the right resource, from the right node.
-	acker.HandleResourceVersionAck(2, 2, nodes[node0], []string{resources[0].Name}, typeURL, "")
+	acker.HandleResourceVersionAck(2, 2, node0, []string{resources[0].Name}, typeURL, "")
 	c.Assert(comp, IsCompleted)
 
 	// Create version 3 with no resources.
@@ -250,11 +268,11 @@ func (s *AckSuite) TestDeleteMultipleNodes(c *C) {
 	c.Assert(comp, Not(IsCompleted))
 
 	// Ack the right version, for another resource, from one of the nodes.
-	acker.HandleResourceVersionAck(3, 3, nodes[node1], []string{resources[2].Name}, typeURL, "")
+	acker.HandleResourceVersionAck(3, 3, node1, []string{resources[2].Name}, typeURL, "")
 	c.Assert(comp, Not(IsCompleted))
 
 	// Ack the right version, for another resource, from the remaining node.
-	acker.HandleResourceVersionAck(3, 3, nodes[node0], []string{resources[2].Name}, typeURL, "")
+	acker.HandleResourceVersionAck(3, 3, node0, []string{resources[2].Name}, typeURL, "")
 	// The resource name is ignored. For delete, we only consider the version.
 	c.Assert(comp, IsCompleted)
 }

--- a/pkg/envoy/xds/ack_test.go
+++ b/pkg/envoy/xds/ack_test.go
@@ -79,7 +79,7 @@ func (s *AckSuite) TestUpsertSingleNode(c *C) {
 
 	// Empty cache is the version 1
 	cache := NewCache()
-	acker := NewAckingResourceMutatorWrapper(cache, IstioNodeToIP)
+	acker := NewAckingResourceMutatorWrapper(cache)
 
 	// Create version 2 with resource 0.
 	comp := wg.AddCompletion()
@@ -112,7 +112,7 @@ func (s *AckSuite) TestUpsertMultipleNodes(c *C) {
 
 	// Empty cache is the version 1
 	cache := NewCache()
-	acker := NewAckingResourceMutatorWrapper(cache, IstioNodeToIP)
+	acker := NewAckingResourceMutatorWrapper(cache)
 
 	// Create version 2 with resource 0.
 	comp := wg.AddCompletion()
@@ -142,7 +142,7 @@ func (s *AckSuite) TestUpsertMoreRecentVersion(c *C) {
 
 	// Empty cache is the version 1
 	cache := NewCache()
-	acker := NewAckingResourceMutatorWrapper(cache, IstioNodeToIP)
+	acker := NewAckingResourceMutatorWrapper(cache)
 
 	// Create version 2 with resource 0.
 	comp := wg.AddCompletion()
@@ -167,7 +167,7 @@ func (s *AckSuite) TestUpsertMoreRecentVersionNack(c *C) {
 
 	// Empty cache is the version 1
 	cache := NewCache()
-	acker := NewAckingResourceMutatorWrapper(cache, IstioNodeToIP)
+	acker := NewAckingResourceMutatorWrapper(cache)
 
 	// Create version 2 with resource 0.
 	comp := wg.AddCompletion()
@@ -195,7 +195,7 @@ func (s *AckSuite) TestDeleteSingleNode(c *C) {
 
 	// Empty cache is the version 1
 	cache := NewCache()
-	acker := NewAckingResourceMutatorWrapper(cache, IstioNodeToIP)
+	acker := NewAckingResourceMutatorWrapper(cache)
 
 	// Create version 2 with resource 0.
 	comp := wg.AddCompletion()
@@ -231,7 +231,7 @@ func (s *AckSuite) TestDeleteMultipleNodes(c *C) {
 
 	// Empty cache is the version 1
 	cache := NewCache()
-	acker := NewAckingResourceMutatorWrapper(cache, IstioNodeToIP)
+	acker := NewAckingResourceMutatorWrapper(cache)
 
 	// Create version 2 with resource 0.
 	comp := wg.AddCompletion()
@@ -266,7 +266,7 @@ func (s *AckSuite) TestRevertInsert(c *C) {
 	wg := completion.NewWaitGroup(ctx)
 
 	cache := NewCache()
-	acker := NewAckingResourceMutatorWrapper(cache, IstioNodeToIP)
+	acker := NewAckingResourceMutatorWrapper(cache)
 
 	// Create version 1 with resource 0.
 	// Insert.
@@ -303,7 +303,7 @@ func (s *AckSuite) TestRevertUpdate(c *C) {
 	wg := completion.NewWaitGroup(ctx)
 
 	cache := NewCache()
-	acker := NewAckingResourceMutatorWrapper(cache, IstioNodeToIP)
+	acker := NewAckingResourceMutatorWrapper(cache)
 
 	// Create version 1 with resource 0.
 	// Insert.
@@ -347,7 +347,7 @@ func (s *AckSuite) TestRevertDelete(c *C) {
 	wg := completion.NewWaitGroup(ctx)
 
 	cache := NewCache()
-	acker := NewAckingResourceMutatorWrapper(cache, IstioNodeToIP)
+	acker := NewAckingResourceMutatorWrapper(cache)
 
 	// Create version 1 with resource 0.
 	// Insert.

--- a/pkg/envoy/xds/cache.go
+++ b/pkg/envoy/xds/cache.go
@@ -84,8 +84,8 @@ func (c *Cache) tx(typeURL string, upsertedResources map[string]proto.Message, d
 	newVersion := c.version + 1
 
 	cacheLog := log.WithFields(logrus.Fields{
-		logfields.XDSTypeURL:     typeURL,
-		logfields.XDSVersionInfo: newVersion,
+		logfields.XDSTypeURL:       typeURL,
+		logfields.XDSCachedVersion: newVersion,
 	})
 
 	cacheLog.Debugf("preparing new cache transaction: upserting %d entries, deleting %d entries",
@@ -186,8 +186,8 @@ func (c *Cache) Clear(typeURL string, force bool) (version uint64, updated bool)
 	newVersion := c.version + 1
 
 	cacheLog := log.WithFields(logrus.Fields{
-		logfields.XDSTypeURL:     typeURL,
-		logfields.XDSVersionInfo: newVersion,
+		logfields.XDSTypeURL:       typeURL,
+		logfields.XDSCachedVersion: newVersion,
 	})
 
 	cacheLog.Debug("preparing new cache transaction: deleting all entries")
@@ -218,9 +218,9 @@ func (c *Cache) GetResources(ctx context.Context, typeURL string, lastVersion ui
 	defer c.locker.RUnlock()
 
 	cacheLog := log.WithFields(logrus.Fields{
-		logfields.XDSVersionInfo: lastVersion,
-		logfields.XDSClientNode:  node,
-		logfields.XDSTypeURL:     typeURL,
+		logfields.XDSAckedVersion: lastVersion,
+		logfields.XDSClientNode:   node,
+		logfields.XDSTypeURL:      typeURL,
 	})
 
 	res := &VersionedResources{
@@ -292,8 +292,8 @@ func (c *Cache) EnsureVersion(typeURL string, version uint64) {
 
 	if c.version < version {
 		cacheLog := log.WithFields(logrus.Fields{
-			logfields.XDSTypeURL:     typeURL,
-			logfields.XDSVersionInfo: version,
+			logfields.XDSTypeURL:      typeURL,
+			logfields.XDSAckedVersion: version,
 		})
 		cacheLog.Debug("increasing version to match client and notifying of new version")
 

--- a/pkg/envoy/xds/cache.go
+++ b/pkg/envoy/xds/cache.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/logging/logfields"
 
-	envoy_api_v2_core "github.com/cilium/proxy/go/envoy/api/v2/core"
 	"github.com/golang/protobuf/proto"
 	"github.com/sirupsen/logrus"
 )
@@ -212,14 +211,13 @@ func (c *Cache) Clear(typeURL string, force bool) (version uint64, updated bool)
 	return c.version, cacheIsUpdated
 }
 
-func (c *Cache) GetResources(ctx context.Context, typeURL string, lastVersion uint64,
-	node *envoy_api_v2_core.Node, resourceNames []string) (*VersionedResources, error) {
+func (c *Cache) GetResources(ctx context.Context, typeURL string, lastVersion uint64, nodeIP string, resourceNames []string) (*VersionedResources, error) {
 	c.locker.RLock()
 	defer c.locker.RUnlock()
 
 	cacheLog := log.WithFields(logrus.Fields{
 		logfields.XDSAckedVersion: lastVersion,
-		logfields.XDSClientNode:   node,
+		logfields.XDSClientNode:   nodeIP,
 		logfields.XDSTypeURL:      typeURL,
 	})
 
@@ -306,7 +304,7 @@ func (c *Cache) EnsureVersion(typeURL string, version uint64) {
 // if available, and returns it. Otherwise, returns nil. If an error occurs while
 // fetching the resource, also returns the error.
 func (c *Cache) Lookup(typeURL string, resourceName string) (proto.Message, error) {
-	res, err := c.GetResources(context.Background(), typeURL, 0, nil, []string{resourceName})
+	res, err := c.GetResources(context.Background(), typeURL, 0, "", []string{resourceName})
 	if err != nil || res == nil || len(res.Resources) == 0 {
 		return nil, err
 	}

--- a/pkg/envoy/xds/cache.go
+++ b/pkg/envoy/xds/cache.go
@@ -227,6 +227,7 @@ func (c *Cache) GetResources(ctx context.Context, typeURL string, lastVersion ui
 	}
 
 	// Return all resources.
+	// TODO: return nil if no changes since the last version?
 	if len(resourceNames) == 0 {
 		res.ResourceNames = make([]string, 0, len(c.resources))
 		res.Resources = make([]proto.Message, 0, len(c.resources))

--- a/pkg/envoy/xds/doc.go
+++ b/pkg/envoy/xds/doc.go
@@ -47,7 +47,7 @@
 //
 //    type ResourceSource interface {
 //        GetResources(ctx context.Context, typeURL string, lastVersion *uint64,
-//            node *api.Node, resourceNames []string) (*VersionedResources, error)
+//            nodeIP string, resourceNames []string) (*VersionedResources, error)
 //    }
 //
 // Resource sets should implement the ResourceSet interface to provide

--- a/pkg/envoy/xds/doc.go
+++ b/pkg/envoy/xds/doc.go
@@ -28,9 +28,9 @@
 // sets, e.g. to support the LDS and RDS protocols:
 //
 //    ldsCache := xds.NewCache()
-//    lds := xds.NewAckingResourceMutatorWrapper(ldsCache, xds.IstioNodeToIP)
+//    lds := xds.NewAckingResourceMutatorWrapper(ldsCache)
 //    rdsCache := xds.NewCache()
-//    rds := xds.NewAckingResourceMutatorWrapper(rdsCache, xds.IstioNodeToIP)
+//    rds := xds.NewAckingResourceMutatorWrapper(rdsCache)
 //
 //    resTypes := map[string]xds.ResourceTypeConfiguration{
 //        "type.googleapis.com/envoy.api.v2.Listener": {ldsCache, lds},
@@ -70,7 +70,7 @@
 //
 //    typeURL := "type.googleapis.com/envoy.api.v2.Listener"
 //    ldsCache := xds.NewCache()
-//    lds := xds.NewAckingResourceMutatorWrapper(ldsCache, IstioNodeToIP)
+//    lds := xds.NewAckingResourceMutatorWrapper(ldsCache)
 //
 //    ctx, cancel := context.WithTimeout(..., 5*time.Second)
 //    wg := completion.NewWaitGroup(ctx)

--- a/pkg/envoy/xds/server.go
+++ b/pkg/envoy/xds/server.go
@@ -121,10 +121,10 @@ func NewServer(resourceTypes map[string]*ResourceTypeConfiguration,
 
 func getXDSRequestFields(req *envoy_api_v2.DiscoveryRequest) logrus.Fields {
 	return logrus.Fields{
-		logfields.XDSVersionInfo: req.GetVersionInfo(),
-		logfields.XDSClientNode:  req.GetNode(),
-		logfields.XDSTypeURL:     req.GetTypeUrl(),
-		logfields.XDSNonce:       req.GetResponseNonce(),
+		logfields.XDSAckedVersion: req.GetVersionInfo(),
+		logfields.XDSClientNode:   req.GetNode(),
+		logfields.XDSTypeURL:      req.GetTypeUrl(),
+		logfields.XDSNonce:        req.GetResponseNonce(),
 	}
 }
 
@@ -377,10 +377,10 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *logrus.Ent
 			resp := recv.Interface().(*VersionedResources)
 
 			responseLog := streamLog.WithFields(logrus.Fields{
-				logfields.XDSVersionInfo: resp.Version,
-				logfields.XDSCanary:      resp.Canary,
-				logfields.XDSTypeURL:     state.typeURL,
-				logfields.XDSNonce:       resp.Version,
+				logfields.XDSCachedVersion: resp.Version,
+				logfields.XDSCanary:        resp.Canary,
+				logfields.XDSTypeURL:       state.typeURL,
+				logfields.XDSNonce:         resp.Version,
 			})
 
 			resources := make([]*any.Any, len(resp.Resources))

--- a/pkg/envoy/xds/server_e2e_test.go
+++ b/pkg/envoy/xds/server_e2e_test.go
@@ -202,7 +202,7 @@ func (s *ServerSuite) TestRequestAllResources(c *C) {
 
 	// Create version 2 with resource 0.
 	time.Sleep(CacheUpdateDelay)
-	v, mod, _ = cache.Upsert(typeURL, resources[0].Name, resources[0], false)
+	v, mod, _ = cache.Upsert(typeURL, resources[0].Name, resources[0])
 	c.Assert(v, Equals, uint64(2))
 	c.Assert(mod, Equals, true)
 
@@ -214,7 +214,7 @@ func (s *ServerSuite) TestRequestAllResources(c *C) {
 
 	// Create version 3 with resources 0 and 1.
 	// This time, update the cache before sending the request.
-	v, mod, _ = cache.Upsert(typeURL, resources[1].Name, resources[1], false)
+	v, mod, _ = cache.Upsert(typeURL, resources[1].Name, resources[1])
 	c.Assert(v, Equals, uint64(3))
 	c.Assert(mod, Equals, true)
 
@@ -248,7 +248,7 @@ func (s *ServerSuite) TestRequestAllResources(c *C) {
 
 	// Create version 4 with resource 1.
 	time.Sleep(CacheUpdateDelay)
-	v, mod, _ = cache.Delete(typeURL, resources[0].Name, false)
+	v, mod, _ = cache.Delete(typeURL, resources[0].Name)
 	c.Assert(v, Equals, uint64(4))
 	c.Assert(mod, Equals, true)
 
@@ -454,7 +454,7 @@ func (s *ServerSuite) TestRequestSomeResources(c *C) {
 
 	// Create version 2 with resource 0.
 	time.Sleep(CacheUpdateDelay)
-	v, mod, _ = cache.Upsert(typeURL, resources[0].Name, resources[0], false)
+	v, mod, _ = cache.Upsert(typeURL, resources[0].Name, resources[0])
 	c.Assert(v, Equals, uint64(2))
 	c.Assert(mod, Equals, true)
 
@@ -466,7 +466,7 @@ func (s *ServerSuite) TestRequestSomeResources(c *C) {
 
 	// Create version 3 with resource 0 and 1.
 	// This time, update the cache before sending the request.
-	v, mod, _ = cache.Upsert(typeURL, resources[1].Name, resources[1], false)
+	v, mod, _ = cache.Upsert(typeURL, resources[1].Name, resources[1])
 	c.Assert(v, Equals, uint64(3))
 	c.Assert(mod, Equals, true)
 
@@ -500,7 +500,7 @@ func (s *ServerSuite) TestRequestSomeResources(c *C) {
 
 	// Create version 4 with resources 0, 1 and 2.
 	time.Sleep(CacheUpdateDelay)
-	v, mod, _ = cache.Upsert(typeURL, resources[2].Name, resources[2], false)
+	v, mod, _ = cache.Upsert(typeURL, resources[2].Name, resources[2])
 	c.Assert(v, Equals, uint64(4))
 	c.Assert(mod, Equals, true)
 
@@ -523,7 +523,7 @@ func (s *ServerSuite) TestRequestSomeResources(c *C) {
 
 	// Create version 5 with resources 1 and 2.
 	time.Sleep(CacheUpdateDelay)
-	v, mod, _ = cache.Delete(typeURL, resources[0].Name, false)
+	v, mod, _ = cache.Delete(typeURL, resources[0].Name)
 	c.Assert(v, Equals, uint64(5))
 	c.Assert(mod, Equals, true)
 
@@ -532,12 +532,12 @@ func (s *ServerSuite) TestRequestSomeResources(c *C) {
 
 	// Updating resource 2 with the exact same value won't increase the version
 	// number. Remain at version 5.
-	v, mod, _ = cache.Upsert(typeURL, resources[2].Name, resources[2], false)
+	v, mod, _ = cache.Upsert(typeURL, resources[2].Name, resources[2])
 	c.Assert(v, Equals, uint64(5))
 	c.Assert(mod, Equals, false)
 
 	// Create version 6 with resource 1.
-	v, mod, _ = cache.Delete(typeURL, resources[1].Name, false)
+	v, mod, _ = cache.Delete(typeURL, resources[1].Name)
 	c.Assert(v, Equals, uint64(6))
 	c.Assert(mod, Equals, true)
 
@@ -603,7 +603,7 @@ func (s *ServerSuite) TestUpdateRequestResources(c *C) {
 	v, mod, _ = cache.tx(typeURL, map[string]proto.Message{
 		resources[0].Name: resources[0],
 		resources[1].Name: resources[1],
-	}, nil, false)
+	}, nil)
 	c.Assert(v, Equals, uint64(2))
 	c.Assert(mod, Equals, true)
 
@@ -637,7 +637,7 @@ func (s *ServerSuite) TestUpdateRequestResources(c *C) {
 
 	// Create version 3 with resource 0, 1 and 2.
 	time.Sleep(CacheUpdateDelay)
-	v, mod, _ = cache.Upsert(typeURL, resources[2].Name, resources[2], false)
+	v, mod, _ = cache.Upsert(typeURL, resources[2].Name, resources[2])
 	c.Assert(v, Equals, uint64(3))
 	c.Assert(mod, Equals, true)
 
@@ -731,7 +731,7 @@ func (s *ServerSuite) TestRequestStaleNonce(c *C) {
 
 	// Create version 2 with resource 0.
 	time.Sleep(CacheUpdateDelay)
-	v, mod, _ = cache.Upsert(typeURL, resources[0].Name, resources[0], false)
+	v, mod, _ = cache.Upsert(typeURL, resources[0].Name, resources[0])
 	c.Assert(v, Equals, uint64(2))
 	c.Assert(mod, Equals, true)
 
@@ -743,7 +743,7 @@ func (s *ServerSuite) TestRequestStaleNonce(c *C) {
 
 	// Create version 3 with resources 0 and 1.
 	// This time, update the cache before sending the request.
-	v, mod, _ = cache.Upsert(typeURL, resources[1].Name, resources[1], false)
+	v, mod, _ = cache.Upsert(typeURL, resources[1].Name, resources[1])
 	c.Assert(v, Equals, uint64(3))
 	c.Assert(mod, Equals, true)
 
@@ -791,7 +791,7 @@ func (s *ServerSuite) TestRequestStaleNonce(c *C) {
 
 	// Create version 4 with resource 1.
 	time.Sleep(CacheUpdateDelay)
-	v, mod, _ = cache.Delete(typeURL, resources[0].Name, false)
+	v, mod, _ = cache.Delete(typeURL, resources[0].Name)
 	c.Assert(v, Equals, uint64(4))
 	c.Assert(mod, Equals, true)
 

--- a/pkg/envoy/xds/server_e2e_test.go
+++ b/pkg/envoy/xds/server_e2e_test.go
@@ -148,7 +148,7 @@ func (s *ServerSuite) TestRequestAllResources(c *C) {
 	defer cancel()
 
 	cache := NewCache()
-	mutator := NewAckingResourceMutatorWrapper(cache, IstioNodeToIP)
+	mutator := NewAckingResourceMutatorWrapper(cache)
 
 	streamCtx, closeStream := context.WithCancel(ctx)
 	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
@@ -274,7 +274,7 @@ func (s *ServerSuite) TestAck(c *C) {
 	wg := completion.NewWaitGroup(ctx)
 
 	cache := NewCache()
-	mutator := NewAckingResourceMutatorWrapper(cache, IstioNodeToIP)
+	mutator := NewAckingResourceMutatorWrapper(cache)
 
 	streamCtx, closeStream := context.WithCancel(ctx)
 	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
@@ -402,7 +402,7 @@ func (s *ServerSuite) TestRequestSomeResources(c *C) {
 	defer cancel()
 
 	cache := NewCache()
-	mutator := NewAckingResourceMutatorWrapper(cache, IstioNodeToIP)
+	mutator := NewAckingResourceMutatorWrapper(cache)
 
 	streamCtx, closeStream := context.WithCancel(ctx)
 	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
@@ -576,7 +576,7 @@ func (s *ServerSuite) TestUpdateRequestResources(c *C) {
 	defer cancel()
 
 	cache := NewCache()
-	mutator := NewAckingResourceMutatorWrapper(cache, IstioNodeToIP)
+	mutator := NewAckingResourceMutatorWrapper(cache)
 
 	streamCtx, closeStream := context.WithCancel(ctx)
 	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
@@ -679,7 +679,7 @@ func (s *ServerSuite) TestRequestStaleNonce(c *C) {
 	defer cancel()
 
 	cache := NewCache()
-	mutator := NewAckingResourceMutatorWrapper(cache, IstioNodeToIP)
+	mutator := NewAckingResourceMutatorWrapper(cache)
 
 	streamCtx, closeStream := context.WithCancel(ctx)
 	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
@@ -819,7 +819,7 @@ func (s *ServerSuite) TestNAck(c *C) {
 	wg := completion.NewWaitGroup(ctx)
 
 	cache := NewCache()
-	mutator := NewAckingResourceMutatorWrapper(cache, IstioNodeToIP)
+	mutator := NewAckingResourceMutatorWrapper(cache)
 
 	streamCtx, closeStream := context.WithCancel(ctx)
 	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
@@ -962,7 +962,7 @@ func (s *ServerSuite) TestNAckFromTheStart(c *C) {
 	wg := completion.NewWaitGroup(ctx)
 
 	cache := NewCache()
-	mutator := NewAckingResourceMutatorWrapper(cache, IstioNodeToIP)
+	mutator := NewAckingResourceMutatorWrapper(cache)
 
 	streamCtx, closeStream := context.WithCancel(ctx)
 	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
@@ -1098,7 +1098,7 @@ func (s *ServerSuite) TestRequestHighVersionFromTheStart(c *C) {
 	wg := completion.NewWaitGroup(ctx)
 
 	cache := NewCache()
-	mutator := NewAckingResourceMutatorWrapper(cache, IstioNodeToIP)
+	mutator := NewAckingResourceMutatorWrapper(cache)
 
 	streamCtx, closeStream := context.WithCancel(ctx)
 	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)

--- a/pkg/envoy/xds/server_e2e_test.go
+++ b/pkg/envoy/xds/server_e2e_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/completion"
 	envoy_api_v2 "github.com/cilium/proxy/go/envoy/api/v2"
+	envoy_api_v2_core "github.com/cilium/proxy/go/envoy/api/v2/core"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/any"
@@ -53,6 +54,11 @@ const (
 
 var (
 	DeferredCompletion error = errors.New("Deferred completion")
+	nodes                    = map[string]*envoy_api_v2_core.Node{
+		node0: {Id: "sidecar~10.0.0.0~node0~bar"},
+		node1: {Id: "sidecar~10.0.0.1~node1~bar"},
+		node2: {Id: "sidecar~10.0.0.2~node2~bar"},
+	}
 )
 
 // ResponseMatchesChecker checks that a DiscoveryResponse's fields match the given

--- a/pkg/envoy/xds/server_e2e_test.go
+++ b/pkg/envoy/xds/server_e2e_test.go
@@ -328,9 +328,8 @@ func (s *ServerSuite) TestAck(c *C) {
 
 	// Create version 2 with resource 0.
 	time.Sleep(CacheUpdateDelay)
-	comp1 := wg.AddCompletion()
-	defer comp1.Complete(DeferredCompletion)
-	mutator.Upsert(typeURL, resources[0].Name, resources[0], []string{node0}, comp1)
+	callback1, comp1 := newCompCallback()
+	mutator.Upsert(typeURL, resources[0].Name, resources[0], []string{node0}, wg, callback1)
 	c.Assert(comp1, Not(IsCompleted))
 
 	// Expecting a response with that resource.
@@ -341,9 +340,8 @@ func (s *ServerSuite) TestAck(c *C) {
 
 	// Create version 3 with resources 0 and 1.
 	// This time, update the cache before sending the request.
-	comp2 := wg.AddCompletion()
-	defer comp2.Complete(DeferredCompletion)
-	mutator.Upsert(typeURL, resources[1].Name, resources[1], []string{node0}, comp2)
+	callback2, comp2 := newCompCallback()
+	mutator.Upsert(typeURL, resources[1].Name, resources[1], []string{node0}, wg, callback2)
 	c.Assert(comp2, Not(IsCompleted))
 
 	// Request the next version of resources.
@@ -874,13 +872,8 @@ func (s *ServerSuite) TestNAck(c *C) {
 
 	// Create version 2 with resource 0.
 	time.Sleep(CacheUpdateDelay)
-
-	callback := func(err error) {
-		log.Info("comp1 callback received with ", err)
-	}
-	comp1 := wg.AddCompletionWithCallback(callback)
-	defer comp1.Complete(DeferredCompletion)
-	mutator.Upsert(typeURL, resources[0].Name, resources[0], []string{node0}, comp1)
+	callback1, comp1 := newCompCallback()
+	mutator.Upsert(typeURL, resources[0].Name, resources[0], []string{node0}, wg, callback1)
 	c.Assert(comp1, Not(IsCompleted))
 
 	// Expecting a response with that resource.
@@ -906,11 +899,8 @@ func (s *ServerSuite) TestNAck(c *C) {
 
 	// NACK cancelled the wg, create a new one
 	wg = completion.NewWaitGroup(ctx)
-	comp2 := wg.AddCompletionWithCallback(func(err error) {
-		log.Info("comp2 callback received with ", err)
-	})
-	defer comp2.Complete(DeferredCompletion)
-	mutator.Upsert(typeURL, resources[1].Name, resources[1], []string{node0}, comp2)
+	callback2, comp2 := newCompCallback()
+	mutator.Upsert(typeURL, resources[1].Name, resources[1], []string{node0}, wg, callback2)
 	c.Assert(comp2, Not(IsCompleted))
 
 	// Version 2 was NACKed by the last request, so comp1 must NOT be completed ever.
@@ -1005,9 +995,8 @@ func (s *ServerSuite) TestNAckFromTheStart(c *C) {
 
 	// Create version 2 with resource 0.
 	time.Sleep(CacheUpdateDelay)
-	comp1 := wg.AddCompletion()
-	defer comp1.Complete(DeferredCompletion)
-	mutator.Upsert(typeURL, resources[0].Name, resources[0], []string{node0}, comp1)
+	callback1, comp1 := newCompCallback()
+	mutator.Upsert(typeURL, resources[0].Name, resources[0], []string{node0}, wg, callback1)
 	c.Assert(comp1, Not(IsCompleted))
 
 	// Request the next version of resources.
@@ -1050,9 +1039,8 @@ func (s *ServerSuite) TestNAckFromTheStart(c *C) {
 	wg = completion.NewWaitGroup(ctx)
 
 	// Create version 3 with resources 0 and 1.
-	comp2 := wg.AddCompletion()
-	defer comp2.Complete(DeferredCompletion)
-	mutator.Upsert(typeURL, resources[1].Name, resources[1], []string{node0}, comp2)
+	callback2, comp2 := newCompCallback()
+	mutator.Upsert(typeURL, resources[1].Name, resources[1], []string{node0}, wg, callback2)
 	c.Assert(comp2, Not(IsCompleted))
 
 	// Expecting a response with both resources.
@@ -1124,9 +1112,8 @@ func (s *ServerSuite) TestRequestHighVersionFromTheStart(c *C) {
 
 	// Create version 2 with resource 0.
 	time.Sleep(CacheUpdateDelay)
-	comp1 := wg.AddCompletion()
-	defer comp1.Complete(DeferredCompletion)
-	mutator.Upsert(typeURL, resources[0].Name, resources[0], []string{node0}, comp1)
+	callback1, comp1 := newCompCallback()
+	mutator.Upsert(typeURL, resources[0].Name, resources[0], []string{node0}, wg, callback1)
 	c.Assert(comp1, Not(IsCompleted))
 
 	// Request all resources, with a version higher than the version currently

--- a/pkg/envoy/xds/set.go
+++ b/pkg/envoy/xds/set.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/lock"
 
-	envoy_api_v2_core "github.com/cilium/proxy/go/envoy/api/v2/core"
 	"github.com/golang/protobuf/proto"
 )
 
@@ -34,7 +33,7 @@ type ResourceSource interface {
 	// If resourceNames is empty, all resources are returned.
 	// Should not be blocking.
 	GetResources(ctx context.Context, typeURL string, lastVersion uint64,
-		node *envoy_api_v2_core.Node, resourceNames []string) (*VersionedResources, error)
+		nodeIP string, resourceNames []string) (*VersionedResources, error)
 
 	// EnsureVersion increases this resource set's version to be at least the
 	// given version. If the current version is already higher than the

--- a/pkg/envoy/xds/set.go
+++ b/pkg/envoy/xds/set.go
@@ -63,43 +63,43 @@ type VersionedResources struct {
 // ResourceMutatorRevertFunc is a function which reverts the effects of an update on a
 // ResourceMutator.
 // The returned version value is the set's version after update.
-type ResourceMutatorRevertFunc func(force bool) (version uint64, updated bool)
+type ResourceMutatorRevertFunc func() (version uint64, updated bool)
 
 // ResourceMutator provides write access to a versioned set of resources.
 // A single version is associated to all the contained resources.
 // The version is monotonically increased for any change to the set.
 type ResourceMutator interface {
 	// Upsert inserts or updates a resource from this set by name.
-	// If force is true and/or the set is actually modified (the resource is
-	// actually inserted or updated), the set's version number is incremented
-	// atomically and the returned updated value is true.
+	// If the set is modified (the resource is actually inserted or updated),
+	// the set's version number is incremented atomically and the returned
+	// updated value is true.
 	// Otherwise, the version number is not modified and the returned updated
 	// value is false.
 	// The returned version value is the set's version after update.
 	// A call to the returned revert function reverts the effects of this
 	// method call.
-	Upsert(typeURL string, resourceName string, resource proto.Message, force bool) (version uint64, updated bool, revert ResourceMutatorRevertFunc)
+	Upsert(typeURL string, resourceName string, resource proto.Message) (version uint64, updated bool, revert ResourceMutatorRevertFunc)
 
 	// Delete deletes a resource from this set by name.
-	// If force is true and/or the set is actually modified (the resource is
-	// actually deleted), the set's version number is incremented
-	// atomically and the returned updated value is true.
+	// If the set is modified (the resource is actually deleted), the set's
+	// version number is incremented atomically and the returned updated value
+	// is true.
 	// Otherwise, the version number is not modified and the returned updated
 	// value is false.
 	// The returned version value is the set's version after update.
 	// A call to the returned revert function reverts the effects of this
 	// method call.
-	Delete(typeURL string, resourceName string, force bool) (version uint64, updated bool, revert ResourceMutatorRevertFunc)
+	Delete(typeURL string, resourceName string) (version uint64, updated bool, revert ResourceMutatorRevertFunc)
 
 	// Clear deletes all the resources of the given type from this set.
-	// If force is true and/or the set is actually modified (at least one
-	// resource is actually deleted), the set's version number is incremented
-	// atomically and the returned updated value is true.
+	// If the set is modified (at least one resource is actually deleted),
+	// the set's version number is incremented atomically and the returned
+	// updated value is true.
 	// Otherwise, the version number is not modified and the returned updated
 	// value is false.
 	// The returned version value is the set's version after update.
 	// This method call cannot be reverted.
-	Clear(typeURL string, force bool) (version uint64, updated bool)
+	Clear(typeURL string) (version uint64, updated bool)
 }
 
 // ResourceSet provides read-write access to a versioned set of resources.

--- a/pkg/envoy/xds/watcher.go
+++ b/pkg/envoy/xds/watcher.go
@@ -79,8 +79,8 @@ func (w *ResourceWatcher) HandleNewResourceVersion(typeURL string, version uint6
 
 	if version < w.version {
 		log.WithFields(logrus.Fields{
-			logfields.XDSVersionInfo: version,
-			logfields.XDSTypeURL:     typeURL,
+			logfields.XDSCachedVersion: version,
+			logfields.XDSTypeURL:       typeURL,
 		}).Panicf(fmt.Sprintf("decreasing version number found for resources of type %s: %d < %d",
 			typeURL, version, w.version))
 	}
@@ -104,9 +104,9 @@ func (w *ResourceWatcher) WatchResources(ctx context.Context, typeURL string, la
 	defer close(out)
 
 	watchLog := log.WithFields(logrus.Fields{
-		logfields.XDSVersionInfo: lastVersion,
-		logfields.XDSClientNode:  node,
-		logfields.XDSTypeURL:     typeURL,
+		logfields.XDSAckedVersion: lastVersion,
+		logfields.XDSClientNode:   node,
+		logfields.XDSTypeURL:      typeURL,
 	})
 
 	var res *VersionedResources

--- a/pkg/envoy/xds/watcher.go
+++ b/pkg/envoy/xds/watcher.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 
-	envoy_api_v2_core "github.com/cilium/proxy/go/envoy/api/v2/core"
 	"github.com/sirupsen/logrus"
 )
 
@@ -99,13 +98,13 @@ func (w *ResourceWatcher) HandleNewResourceVersion(typeURL string, version uint6
 // lastVersion is the last version successfully applied by the
 // client; nil if this is the first request for resources.
 // This method call must always close the out channel.
-func (w *ResourceWatcher) WatchResources(ctx context.Context, typeURL string, lastVersion uint64, node *envoy_api_v2_core.Node,
+func (w *ResourceWatcher) WatchResources(ctx context.Context, typeURL string, lastVersion uint64, nodeIP string,
 	resourceNames []string, out chan<- *VersionedResources) {
 	defer close(out)
 
 	watchLog := log.WithFields(logrus.Fields{
 		logfields.XDSAckedVersion: lastVersion,
-		logfields.XDSClientNode:   node,
+		logfields.XDSClientNode:   nodeIP,
 		logfields.XDSTypeURL:      typeURL,
 	})
 
@@ -156,7 +155,7 @@ func (w *ResourceWatcher) WatchResources(ctx context.Context, typeURL string, la
 		subCtx, cancel := context.WithTimeout(ctx, w.resourceAccessTimeout)
 		var err error
 		watchLog.Debugf("getting %d resources from set", len(resourceNames))
-		res, err = w.resourceSet.GetResources(subCtx, typeURL, lastVersion, node, resourceNames)
+		res, err = w.resourceSet.GetResources(subCtx, typeURL, lastVersion, nodeIP, resourceNames)
 		cancel()
 
 		if err != nil {

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -277,8 +277,11 @@ const (
 	// XDSStreamID is the ID of an xDS request stream.
 	XDSStreamID = "xdsStreamID"
 
-	// XDSVersionInfo is the version info of an xDS resource.
-	XDSVersionInfo = "xdsVersionInfo"
+	// XDSAckedVersion is the version of an xDS resource acked by Envoy.
+	XDSAckedVersion = "xdsAckedVersion"
+
+	// XDSCachedVersion is the version of an xDS resource currently in cache.
+	XDSCachedVersion = "xdsCachedVersion"
 
 	// XDSTypeURL is the URL that identifies an xDS resource type.
 	XDSTypeURL = "xdsTypeURL"

--- a/pkg/policy/l4_test.go
+++ b/pkg/policy/l4_test.go
@@ -50,9 +50,13 @@ func (s *PolicyTestSuite) TestCreateL4Filter(c *C) {
 		// or if it is based on specific labels.
 		filter := createL4IngressFilter(eps, false, portrule, tuple, tuple.Protocol, nil, testSelectorCache)
 		c.Assert(len(filter.L7RulesPerEp), Equals, 1)
+		c.Assert(filter.IsEnvoyRedirect(), Equals, true)
+		c.Assert(filter.IsProxylibRedirect(), Equals, false)
 
 		filter = createL4EgressFilter(eps, portrule, tuple, tuple.Protocol, nil, testSelectorCache, nil)
 		c.Assert(len(filter.L7RulesPerEp), Equals, 1)
+		c.Assert(filter.IsEnvoyRedirect(), Equals, true)
+		c.Assert(filter.IsProxylibRedirect(), Equals, false)
 	}
 }
 
@@ -222,4 +226,7 @@ func (s *PolicyTestSuite) TestJSONMarshal(c *C) {
 	for i := range expectedIngress {
 		c.Assert(model.Ingress[i].Rule, Equals, expectedIngress[i])
 	}
+
+	c.Assert(policy.HasEnvoyRedirect(), Equals, true)
+	c.Assert(policy.HasProxylibRedirect(), Equals, true)
 }

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -635,7 +635,12 @@ func (p *Proxy) UpdateRedirectMetrics() {
 	}
 }
 
-// UpdateProxyRedirect must update the redirect configuration of an endpoint in the proxy
+// UpdateNetworkPolicy must update the redirect configuration of an endpoint in the proxy
 func (p *Proxy) UpdateNetworkPolicy(ep logger.EndpointUpdater, policy *policy.L4Policy, ingressPolicyEnforced, egressPolicyEnforced bool, wg *completion.WaitGroup) (error, func() error) {
 	return p.XDSServer.UpdateNetworkPolicy(ep, policy, ingressPolicyEnforced, egressPolicyEnforced, wg)
+}
+
+// UseCurrentNetworkPolicy inserts a Completion to the WaitGroup if the current network policy has not yet been acked
+func (p *Proxy) UseCurrentNetworkPolicy(ep logger.EndpointUpdater, policy *policy.L4Policy, wg *completion.WaitGroup) {
+	p.XDSServer.UseCurrentNetworkPolicy(ep, policy, wg)
 }

--- a/proxylib/proxylib/instance.go
+++ b/proxylib/proxylib/instance.go
@@ -65,7 +65,7 @@ func NewInstance(nodeID string, accessLogger AccessLogger) *Instance {
 	instanceId++
 
 	if nodeID == "" {
-		nodeID = fmt.Sprintf("host~127.0.0.1~libcilium-%d~localdomain", instanceId)
+		nodeID = fmt.Sprintf("host~127.0.0.2~libcilium-%d~localdomain", instanceId)
 	}
 
 	// TODO: Sidecar instance id needs to be different.


### PR DESCRIPTION
Even when no policy change is needed, the endpoint may need to wait
for the current policy version to be acked by the proxy.

Use a different Envoy node ID for proxylib, so that proxylib ACK
arriving before the main Envoy ACK does not trigger DNS response to be
released to the source POD.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9395)
<!-- Reviewable:end -->
