### PR TITLE
daemon: Check for no selector update need earlier.

### DIFF
--- a/pkg/fqdn/name_manager.go
+++ b/pkg/fqdn/name_manager.go
@@ -303,8 +303,7 @@ func (n *NameManager) GenerateSelectorUpdates(fqdnSelectors map[api.FQDNSelector
 	n.Lock()
 	defer n.Unlock()
 
-	namesMissingIPs, selectorIPMapping = mapSelectorsToIPs(fqdnSelectors, n.cache)
-	return namesMissingIPs, selectorIPMapping
+	return mapSelectorsToIPs(fqdnSelectors, n.cache)
 }
 
 // updateIPsName will update the IPs for dnsName. It always retains a copy of


### PR DESCRIPTION
Check for the case of no work needed earlier in order to make it
obvious that no FQDN selector updates are done when we skip map and
policy updates.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9396)
<!-- Reviewable:end -->
