### PR TITLE
ENI IPAM: Fix pre-allocate in the documentation

### DIFF
--- a/Documentation/concepts/ipam/eni.rst
+++ b/Documentation/concepts/ipam/eni.rst
@@ -107,7 +107,7 @@ allocation:
 
   If unspecified, no minimum number of IPs is required.
 
-``spec.eni.preallocate``
+``spec.eni.pre-allocate``
   The number of IP addresses that must be available for allocation at all
   times.  It defines the buffer of addresses available immediately without
   requiring for the operator to get involved.
@@ -199,7 +199,7 @@ calculation is performed:
 
 .. code-block:: go
 
-     spec.eni.preallocate - (len(spec.ipam.available) - len(status.ipam.used))
+     spec.eni.pre-allocate - (len(spec.ipam.available) - len(status.ipam.used))
 
 Upon detection of a deficit, the node is added to the list of nodes which
 require IP address allocation. When a deficit is detected using the interval
@@ -240,7 +240,7 @@ ENI:
       min(AvailableOnSubnet, min(AvailableOnENI, NeededAddresses + spec.eni.max-above-watermark))
 
 This means that the number of IPs allocated in a single allocation cycle can be
-less than what is required to fulfill ``spec.eni.preallocate``.
+less than what is required to fulfill ``spec.eni.pre-allocate``.
 
 In order to allocate the IPs, the method ``AssignPrivateIpAddresses`` of the
 EC2 service API is called. When no more ENIs are available meeting the above


### PR DESCRIPTION
The doc says `preallocate` but the code uses `pre-allocate`
I could not find the source for `eni_arch.png` so I could not fix the arch png but we'll need to do that too (but the spec in the documentation now matches the code).

cc @tgraf

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9404)
<!-- Reviewable:end -->
