### PR TITLE
IPSEC: add upsert logs in debug mode

### DIFF
--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -444,6 +444,8 @@ func upsertIPsecLog(err error, spec string, loc, rem *net.IPNet, spi uint8) {
 	})
 	if err != nil {
 		scopedLog.WithError(err).Error("IPsec enable failed")
+	} else {
+		scopedLog.Debug("IPsec enable succeeded")
 	}
 }
 


### PR DESCRIPTION
Always log IPsec upserts in debug mode (simplifies debugging a lot to identify the source of an additional route/policy/state).

Example output:
```
level=debug msg="IPsec enable succeeded" local-ip=0.0.0.0/0 reason="CNI Out IPv4" remote-ip=10.0.128.0/18 spi=1 subsys=linux-datapath
level=debug msg="IPsec enable succeeded" local-ip=0.0.0.0/0 reason="CNI Out IPv4" remote-ip=10.0.192.0/18 spi=1 subsys=linux-datapath
level=debug msg="IPsec enable succeeded" local-ip=10.1.75.42/32 reason="EncryptNode IPv4" remote-ip=10.1.73.252/32 spi=1 subsys=linux-datapath
level=debug msg="IPsec enable succeeded" local-ip=10.1.75.42/32 reason="EncryptNode IPv4" remote-ip=10.1.73.110/32 spi=1 subsys=linux-datapath
```

cc @jrfastab

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9405)
<!-- Reviewable:end -->
