### PR TITLE
ENI IPAM: Ensure that DeleteOnTermination defaults to true

### DIFF
--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -369,10 +369,10 @@ func (n *Node) allocateENI(s *types.Subnet, a *allocatableResources) error {
 
 	scopedLog.Info("Attached ENI to instance")
 
-	if nodeResource.Spec.ENI.DeleteOnTermination {
+	if nodeResource.Spec.ENI.DeleteOnTermination == nil || *nodeResource.Spec.ENI.DeleteOnTermination {
 		// We have an attachment ID from the last API, which lets us mark the
 		// interface as delete on termination
-		err = n.manager.ec2API.ModifyNetworkInterface(eniID, attachmentID, n.resource.Spec.ENI.DeleteOnTermination)
+		err = n.manager.ec2API.ModifyNetworkInterface(eniID, attachmentID, true)
 		if err != nil {
 			delErr := n.manager.ec2API.DeleteNetworkInterface(eniID)
 			if delErr != nil {

--- a/pkg/k8s/apis/cilium.io/v2/types.go
+++ b/pkg/k8s/apis/cilium.io/v2/types.go
@@ -764,10 +764,11 @@ type ENISpec struct {
 	AvailabilityZone string `json:"availability-zone,omitempty"`
 
 	// DeleteOnTermination defines that the ENI should be deleted when the
-	// associated instance is terminated
+	// associated instance is terminated. If the parameter is not set the
+	// default behavior is to delete the ENI on instance termination.
 	//
 	// +optional
-	DeleteOnTermination bool `json:"delete-on-termination,omitempty"`
+	DeleteOnTermination *bool `json:"delete-on-termination,omitempty"`
 }
 
 // IPAMSpec is the IPAM specification of the node

--- a/pkg/k8s/apis/cilium.io/v2/zz_generated.deepcopy.go
+++ b/pkg/k8s/apis/cilium.io/v2/zz_generated.deepcopy.go
@@ -439,6 +439,11 @@ func (in *ENISpec) DeepCopyInto(out *ENISpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.DeleteOnTermination != nil {
+		in, out := &in.DeleteOnTermination, &out.DeleteOnTermination
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -276,7 +276,6 @@ func (n *NodeDiscovery) UpdateCiliumNodeResource(conf Configuration) {
 
 		nodeResource.Spec.ENI.VpcID = vpcID
 		nodeResource.Spec.ENI.FirstInterfaceIndex = 1
-		nodeResource.Spec.ENI.DeleteOnTermination = true
 		nodeResource.Spec.ENI.PreAllocate = defaults.ENIPreAllocation
 
 		if c := conf.GetNetConf(); c != nil {


### PR DESCRIPTION
In the documentation, DeleteOnTermination defaults to true. 

However when using `auto-create-cilium-node-resource` if the CNI config does not contain `delete-on-termination` it will be set to false and additional ENIs will not be deleted on node termination.

Here is what happens on the agent side
- `delete-on-termination` is set to false or not set (in the cni config)
- because of the `ENISpec` definition: `DeleteOnTermination bool json:"delete-on-termination,omitempty"`, the create/update API calls for the ciliumnode resource will not contain the `DeleteOnTermination` field
- the operator will understands this as the default value (`false`)

This PR addresses this by changing the field to an *bool. Here are the different scenarios in the agents (based on the cni config):
- `delete-on-termination` is not set. In that case, DeleteOnTermination==nil and the field does not show up in the ciliumnode resource
- `delete-on-termination` is set to true or false. Here DeleteOnTermination==true/false and the field appears in the ciliumnode resource

On the operator side, after decoding the ciliumnode resource, if DeleteOnTermination is nil or true we modify the interface attribute.

cc @tgraf

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9406)
<!-- Reviewable:end -->
