### PR TITLE
Add ability to create tags on the ENIs the cilium-operator creates

### DIFF
--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -27,6 +27,7 @@ cilium-operator [flags]
   -D, --debug                                  Enable debugging mode
       --enable-metrics                         Enable Prometheus metrics
       --eni-parallel-workers int               Maximum number of parallel workers used by ENI allocator (default 50)
+      --eni-tags map                           ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag) (default map[])
   -h, --help                                   help for cilium-operator
       --identity-allocation-mode string        Method to use for identity allocation (default "kvstore")
       --identity-gc-interval duration          GC interval for security identities (default 15m0s)

--- a/Documentation/concepts/ipam/eni.rst
+++ b/Documentation/concepts/ipam/eni.rst
@@ -159,7 +159,7 @@ Cache of ENIs, Subnets, and VPCs
 
 The operator maintains a list of all EC2 ENIs, VPCs and subnets associated with
 the AWS account in a cache. For this purpose, the operator performs the
-following two EC2 API operations:
+following three EC2 API operations:
 
  * ``DescribeNetworkInterfaces``
  * ``DescribeSubnets``
@@ -279,6 +279,8 @@ The security groups attached to the ENI will be equivalent to
 
      "Cilium-CNI (<EC2 instance ID>)"
 
+If the ENI tagging feature is enabled then the ENI will be tagged with the provided information.
+
 ENI Deletion Policy
 ===================
 
@@ -309,6 +311,10 @@ perform ENI creation and IP allocation:
  * ``AttachNetworkInterface``
  * ``ModifyNetworkInterface``
  * ``AssignPrivateIpAddresses``
+
+ Additionally if the ENI tagging feature is enabled it will require the following EC2 API operation as well:
+
+ * ``CreateTags``
 
 *******
 Metrics

--- a/operator/eni.go
+++ b/operator/eni.go
@@ -92,7 +92,7 @@ func ciliumNodeDeleted(nodeName string) {
 // startENIAllocator kicks of ENI allocation, the initial connection to AWS
 // APIs is done in a blocking manner, given that is successful, a controller is
 // started to manage allocation based on CiliumNode custom resources
-func startENIAllocator(awsClientQPSLimit float64, awsClientBurst int) error {
+func startENIAllocator(awsClientQPSLimit float64, awsClientBurst int, eniTags map[string]string) error {
 	log.Info("Starting ENI allocator...")
 
 	cfg, err := external.LoadDefaultAWSConfig()
@@ -124,7 +124,7 @@ func startENIAllocator(awsClientQPSLimit float64, awsClientBurst int) error {
 		ec2Client = ec2shim.NewClient(ec2.New(cfg), eniMetrics, awsClientQPSLimit, awsClientBurst)
 		log.Info("Connected to EC2 service API")
 		instances = eni.NewInstancesManager(ec2Client, eniMetrics)
-		nodeManager, err = eni.NewNodeManager(instances, ec2Client, &k8sAPI{}, eniMetrics, eniParallelWorkers)
+		nodeManager, err = eni.NewNodeManager(instances, ec2Client, &k8sAPI{}, eniMetrics, eniParallelWorkers, eniTags)
 		if err != nil {
 			return fmt.Errorf("unable to initialize ENI node manager: %s", err)
 		}
@@ -135,7 +135,7 @@ func startENIAllocator(awsClientQPSLimit float64, awsClientBurst int) error {
 		ec2Client = ec2shim.NewClient(ec2.New(cfg), noOpMetric, awsClientQPSLimit, awsClientBurst)
 		log.Info("Connected to EC2 service API")
 		instances = eni.NewInstancesManager(ec2Client, noOpMetric)
-		nodeManager, err = eni.NewNodeManager(instances, ec2Client, &k8sAPI{}, noOpMetric, eniParallelWorkers)
+		nodeManager, err = eni.NewNodeManager(instances, ec2Client, &k8sAPI{}, noOpMetric, eniParallelWorkers, eniTags)
 		if err != nil {
 			return fmt.Errorf("unable to initialize ENI node manager: %s", err)
 		}

--- a/pkg/aws/ec2/ec2.go
+++ b/pkg/aws/ec2/ec2.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/pkg/aws/types"
-	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/spanstat"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -396,4 +396,31 @@ func (c *Client) AssignPrivateIpAddresses(eniID string, addresses int64) error {
 	_, err := req.Send(context.TODO())
 	c.metricsAPI.ObserveEC2APICall("AssignPrivateIpAddresses", deriveStatus(req.Request, err), sinceStart.Seconds())
 	return err
+}
+
+// TagENI creates the specified tags on the ENI
+func (c *Client) TagENI(eniID string, eniTags map[string]string) error {
+	request := ec2.CreateTagsInput{
+		Resources: []string{eniID},
+		Tags:      createAWSTagSlice(eniTags),
+	}
+	c.rateLimit("CreateTags")
+	sinceStart := spanstat.Start()
+	req := c.ec2Client.CreateTagsRequest(&request)
+	_, err := req.Send(context.TODO())
+	c.metricsAPI.ObserveEC2APICall("CreateTags", deriveStatus(req.Request, err), sinceStart.Seconds())
+	return err
+}
+
+func createAWSTagSlice(tags map[string]string) []ec2.Tag {
+	awsTags := make([]ec2.Tag, 0, len(tags))
+	for k, v := range tags {
+		awsTag := ec2.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v),
+		}
+		awsTags = append(awsTags, awsTag)
+	}
+
+	return awsTags
 }

--- a/pkg/aws/ec2/mock/mock.go
+++ b/pkg/aws/ec2/mock/mock.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/pkg/aws/types"
-	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/uuid"
 
@@ -40,6 +40,7 @@ const (
 	AttachNetworkInterface
 	ModifyNetworkInterface
 	AssignPrivateIpAddresses
+	TagENI
 	MaxOperation
 )
 
@@ -334,4 +335,18 @@ func (e *API) GetSubnets() (types.SubnetMap, error) {
 		subnets[s.ID] = s
 	}
 	return subnets, nil
+}
+
+func (e *API) TagENI(eniID string, eniTags map[string]string) error {
+	e.rateLimit()
+	e.simulateDelay(TagENI)
+
+	e.mutex.RLock()
+	defer e.mutex.RUnlock()
+
+	if err, ok := e.errors[TagENI]; ok {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -388,6 +388,14 @@ func (n *Node) allocateENI(s *types.Subnet, a *allocatableResources) error {
 		}
 	}
 
+	if len(n.manager.eniTags) != 0 {
+		if err := n.manager.ec2API.TagENI(eniID, n.manager.eniTags); err != nil {
+			// treating above as a warn rather than error since it's not mandatory for ENI tagging to succeed
+			// given at this point given that it won't affect IPAM functionality
+			scopedLog.WithError(err).Warning("Unable to tag ENI")
+		}
+	}
+
 	// Add the information of the created ENI to the instances manager
 	n.manager.instancesAPI.UpdateENI(n.resource.Spec.ENI.InstanceID, eni)
 

--- a/pkg/aws/eni/node_manager.go
+++ b/pkg/aws/eni/node_manager.go
@@ -51,6 +51,7 @@ type ec2API interface {
 	AttachNetworkInterface(index int64, instanceID, eniID string) (string, error)
 	ModifyNetworkInterface(eniID, attachmentID string, deleteOnTermination bool) error
 	AssignPrivateIpAddresses(eniID string, addresses int64) error
+	TagENI(eniID string, eniTags map[string]string) error
 }
 
 type metricsAPI interface {
@@ -79,10 +80,11 @@ type NodeManager struct {
 	metricsAPI      metricsAPI
 	resyncTrigger   *trigger.Trigger
 	parallelWorkers int64
+	eniTags         map[string]string
 }
 
 // NewNodeManager returns a new NodeManager
-func NewNodeManager(instancesAPI nodeManagerAPI, ec2API ec2API, k8sAPI k8sAPI, metrics metricsAPI, parallelWorkers int64) (*NodeManager, error) {
+func NewNodeManager(instancesAPI nodeManagerAPI, ec2API ec2API, k8sAPI k8sAPI, metrics metricsAPI, parallelWorkers int64, eniTags map[string]string) (*NodeManager, error) {
 	if parallelWorkers < 1 {
 		parallelWorkers = 1
 	}
@@ -94,6 +96,7 @@ func NewNodeManager(instancesAPI nodeManagerAPI, ec2API ec2API, k8sAPI k8sAPI, m
 		k8sAPI:          k8sAPI,
 		metricsAPI:      metrics,
 		parallelWorkers: parallelWorkers,
+		eniTags:         eniTags,
 	}
 
 	resyncTrigger, err := trigger.NewTrigger(trigger.Parameters{

--- a/pkg/aws/eni/node_manager_test.go
+++ b/pkg/aws/eni/node_manager_test.go
@@ -45,13 +45,14 @@ var (
 	}
 	k8sapi     = &k8sMock{}
 	metricsapi = metricsmock.NewMockMetrics()
+	eniTags    = map[string]string{}
 )
 
 func (e *ENISuite) TestGetNodeNames(c *check.C) {
 	ec2api := ec2mock.NewAPI([]*types.Subnet{testSubnet}, []*types.Vpc{testVpc})
 	instances := NewInstancesManager(ec2api, metricsapi)
 	c.Assert(instances, check.Not(check.IsNil))
-	mngr, err := NewNodeManager(instances, ec2api, k8sapi, metricsapi, 10)
+	mngr, err := NewNodeManager(instances, ec2api, k8sapi, metricsapi, 10, eniTags)
 	c.Assert(err, check.IsNil)
 	c.Assert(mngr, check.Not(check.IsNil))
 
@@ -77,7 +78,7 @@ func (e *ENISuite) TestNodeManagerGet(c *check.C) {
 	ec2api := ec2mock.NewAPI([]*types.Subnet{testSubnet}, []*types.Vpc{testVpc})
 	instances := NewInstancesManager(ec2api, metricsapi)
 	c.Assert(instances, check.Not(check.IsNil))
-	mngr, err := NewNodeManager(instances, ec2api, k8sapi, metricsapi, 10)
+	mngr, err := NewNodeManager(instances, ec2api, k8sapi, metricsapi, 10, eniTags)
 	c.Assert(err, check.IsNil)
 	c.Assert(mngr, check.Not(check.IsNil))
 
@@ -167,7 +168,7 @@ func (e *ENISuite) TestNodeManagerDefaultAllocation(c *check.C) {
 	ec2api := ec2mock.NewAPI([]*types.Subnet{testSubnet}, []*types.Vpc{testVpc})
 	instances := NewInstancesManager(ec2api, metricsapi)
 	c.Assert(instances, check.Not(check.IsNil))
-	mngr, err := NewNodeManager(instances, ec2api, k8sapi, metricsapi, 10)
+	mngr, err := NewNodeManager(instances, ec2api, k8sapi, metricsapi, 10, eniTags)
 	c.Assert(err, check.IsNil)
 	c.Assert(mngr, check.Not(check.IsNil))
 
@@ -200,7 +201,7 @@ func (e *ENISuite) TestNodeManagerMinAllocate20(c *check.C) {
 	ec2api := ec2mock.NewAPI([]*types.Subnet{testSubnet}, []*types.Vpc{testVpc})
 	instances := NewInstancesManager(ec2api, metricsapi)
 	c.Assert(instances, check.Not(check.IsNil))
-	mngr, err := NewNodeManager(instances, ec2api, k8sapi, metricsapi, 10)
+	mngr, err := NewNodeManager(instances, ec2api, k8sapi, metricsapi, 10, eniTags)
 	c.Assert(err, check.IsNil)
 	c.Assert(mngr, check.Not(check.IsNil))
 
@@ -242,7 +243,7 @@ func (e *ENISuite) TestNodeManagerMinAllocateAndPreallocate(c *check.C) {
 	ec2api := ec2mock.NewAPI([]*types.Subnet{testSubnet}, []*types.Vpc{testVpc})
 	instances := NewInstancesManager(ec2api, metricsapi)
 	c.Assert(instances, check.Not(check.IsNil))
-	mngr, err := NewNodeManager(instances, ec2api, k8sapi, metricsapi, 10)
+	mngr, err := NewNodeManager(instances, ec2api, k8sapi, metricsapi, 10, eniTags)
 	c.Assert(err, check.IsNil)
 	c.Assert(mngr, check.Not(check.IsNil))
 
@@ -290,7 +291,7 @@ func (e *ENISuite) TestNodeManagerExceedENICapacity(c *check.C) {
 	ec2api := ec2mock.NewAPI([]*types.Subnet{testSubnet}, []*types.Vpc{testVpc})
 	instances := NewInstancesManager(ec2api, metricsapi)
 	c.Assert(instances, check.Not(check.IsNil))
-	mngr, err := NewNodeManager(instances, ec2api, k8sapi, metricsapi, 10)
+	mngr, err := NewNodeManager(instances, ec2api, k8sapi, metricsapi, 10, eniTags)
 	c.Assert(err, check.IsNil)
 	c.Assert(mngr, check.Not(check.IsNil))
 
@@ -342,7 +343,7 @@ func (e *ENISuite) TestNodeManagerManyNodes(c *check.C) {
 	metricsapi := metricsmock.NewMockMetrics()
 	instancesManager := NewInstancesManager(ec2api, metricsapi)
 	instancesManager.Resync()
-	mngr, err := NewNodeManager(instancesManager, ec2api, k8sapi, metricsapi, 10)
+	mngr, err := NewNodeManager(instancesManager, ec2api, k8sapi, metricsapi, 10, eniTags)
 	c.Assert(err, check.IsNil)
 	c.Assert(mngr, check.Not(check.IsNil))
 
@@ -398,7 +399,7 @@ func (e *ENISuite) TestNodeManagerInstanceNotRunning(c *check.C) {
 	metricsMock := metricsmock.NewMockMetrics()
 	instances := NewInstancesManager(ec2api, metricsapi)
 	c.Assert(instances, check.Not(check.IsNil))
-	mngr, err := NewNodeManager(instances, ec2api, k8sapi, metricsMock, 10)
+	mngr, err := NewNodeManager(instances, ec2api, k8sapi, metricsMock, 10, eniTags)
 	c.Assert(err, check.IsNil)
 	c.Assert(mngr, check.Not(check.IsNil))
 
@@ -433,7 +434,7 @@ func benchmarkAllocWorker(c *check.C, workers int64, delay time.Duration, rateLi
 	ec2api.SetLimiter(rateLimit, burst)
 	instances := NewInstancesManager(ec2api, metricsapi)
 	c.Assert(instances, check.Not(check.IsNil))
-	mngr, err := NewNodeManager(instances, ec2api, k8sapi, metricsapi, workers)
+	mngr, err := NewNodeManager(instances, ec2api, k8sapi, metricsapi, workers, eniTags)
 	c.Assert(err, check.IsNil)
 	c.Assert(mngr, check.Not(check.IsNil))
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -274,6 +274,15 @@ const (
 	// CiliumNode.Spec.ENI.PreAllocate if no value is set
 	ENIPreAllocation = 8
 
+	// ENIParallelWorkers is the default max number of workers that process ENI operations
+	ENIParallelWorkers = 50
+
+	// AWSClientBurst is the default burst value for the AWS client
+	AWSClientBurst = 4
+
+	// AWSClientQPSLimit is the default QPS limit for the AWS client
+	AWSClientQPSLimit = 20.0
+
 	// AutoCreateCiliumNodeResource enables automatic creation of a
 	// CiliumNode resource for the local node
 	AutoCreateCiliumNodeResource = true

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -574,6 +574,9 @@ const (
 	// AWSClientBurst is the burst value allowed for the AWS client used by the AWS ENI IPAM
 	AWSClientBurst = "aws-client-burst"
 
+	// ENITags are the tags that will be added to every ENI created by the AWS ENI IPAM
+	ENITags = "eni-tags"
+
 	// K8sClientQPSLimit is the queries per second limit for the K8s client. Defaults to k8s client defaults.
 	K8sClientQPSLimit = "k8s-client-qps"
 


### PR DESCRIPTION
<!-- Description of change -->
Add ability to create tags on the ENIs the cilium-operator creates. I opted to add the `eni-tags` cli flag to the `cilium-operator` thinking a user can pass `--eni-tags=k1=v1,k2=v2`. Related to the ENI subsystem I also moved some cli defaults to be in the `defaults` package just for consistency reasons.


```release-note
Add ability to create tags on the ENIs the cilium-operator creates.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9412)
<!-- Reviewable:end -->
