### PR TITLE
docs: Improve external etcd documentation wording

### DIFF
--- a/Documentation/gettingstarted/k8s-install-external-etcd.rst
+++ b/Documentation/gettingstarted/k8s-install-external-etcd.rst
@@ -39,7 +39,7 @@ when to use a kvstore:
 
 .. include:: requirements_intro.rst
 
-Configure the External Etcd
+Configure Cilium
 ===========================
 
 When using an external kvstore, the address of the external kvstore needs to be

--- a/Documentation/gettingstarted/k8s-install-external-etcd.rst
+++ b/Documentation/gettingstarted/k8s-install-external-etcd.rst
@@ -38,6 +38,7 @@ when to use a kvstore:
 .. _ds_deploy:
 
 .. include:: requirements_intro.rst
+You will also need an external kvstore such as etcd.
 
 Configure Cilium
 ===========================

--- a/Documentation/gettingstarted/k8s-install-external-etcd.rst
+++ b/Documentation/gettingstarted/k8s-install-external-etcd.rst
@@ -39,7 +39,7 @@ when to use a kvstore:
 
 .. include:: requirements_intro.rst
 
-Configure the External Etcd
+Configure Cilium
 ===========================
 
 When using an external kvstore, the address of the external kvstore needs to be
@@ -69,7 +69,7 @@ key and certificate of etcd:
 .. code:: bash
 
    kubectl create secret generic -n kube-system cilium-etcd-secrets \
-        --from-file=etcd-client-ca.crt=ca.crt \
+
         --from-file=etcd-client.key=client.key \
         --from-file=etcd-client.crt=client.crt
 

--- a/Documentation/gettingstarted/requirements_intro.rst
+++ b/Documentation/gettingstarted/requirements_intro.rst
@@ -6,7 +6,6 @@ Make sure your Kubernetes environment is meeting the requirements:
 * Kubernetes >= 1.9
 * Linux kernel >= 4.9
 * Kubernetes in CNI mode
-* Key-Value store etcd >= 3.1.0 or consul >= 0.6.4
 * Mounted BPF filesystem mounted on all worker nodes
 * Recommended: Enable PodCIDR allocation (``--allocate-node-cidrs``) in the ``kube-controller-manager`` (recommended)
 

--- a/Documentation/gettingstarted/requirements_intro.rst
+++ b/Documentation/gettingstarted/requirements_intro.rst
@@ -6,6 +6,7 @@ Make sure your Kubernetes environment is meeting the requirements:
 * Kubernetes >= 1.9
 * Linux kernel >= 4.9
 * Kubernetes in CNI mode
+* Key-Value store etcd >= 3.1.0 or consul >= 0.6.4
 * Mounted BPF filesystem mounted on all worker nodes
 * Recommended: Enable PodCIDR allocation (``--allocate-node-cidrs``) in the ``kube-controller-manager`` (recommended)
 

--- a/Documentation/gettingstarted/requirements_intro.rst
+++ b/Documentation/gettingstarted/requirements_intro.rst
@@ -7,6 +7,7 @@ Make sure your Kubernetes environment is meeting the requirements:
 * Linux kernel >= 4.9
 * Key-Value store etcd >= 3.1.0 or consul >= 0.6.4
 * Kubernetes in CNI mode
+* Key-Value store etcd >= 3.1.0 or consul >= 0.6.4
 * Mounted BPF filesystem mounted on all worker nodes
 * Recommended: Enable PodCIDR allocation (``--allocate-node-cidrs``) in the ``kube-controller-manager`` (recommended)
 

--- a/Documentation/gettingstarted/requirements_intro.rst
+++ b/Documentation/gettingstarted/requirements_intro.rst
@@ -5,6 +5,7 @@ Make sure your Kubernetes environment is meeting the requirements:
 
 * Kubernetes >= 1.9
 * Linux kernel >= 4.9
+* Key-Value store etcd >= 3.1.0 or consul >= 0.6.4
 * Kubernetes in CNI mode
 * Mounted BPF filesystem mounted on all worker nodes
 * Recommended: Enable PodCIDR allocation (``--allocate-node-cidrs``) in the ``kube-controller-manager`` (recommended)

--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -241,6 +241,8 @@ IMPORTANT: Changes required before upgrading to 1.7.0
    Do not upgrade to 1.7.0 before reading the following section and completing
    the required steps.
 
+* Cilium has bumped the minimal kubernetes version supported to v1.11.0.
+
 * If ``kvstore`` is setup with ``etcd`` **and** TLS is enabled, the field name
   ``ca-file`` will have its usage deprecated and will be removed in Cilium v1.8.0.
   The new field name, ``trusted-ca-file``, can be used since Cilium v1.1.0.


### PR DESCRIPTION
Changes to be committed:
	modified:   k8s-install-external-etcd.rst
	modified:   requirements_intro.rst

<!-- Description of change -->

Previously, having an available external etcd was not listed under the requirements section in the external etcd documentation. This was addressed by listing "Key-Value store etcd >= 3.1.0 or consul >= 0.6.4" under the requirements section. In addition, the section title "Configure the external etcd" referred to the configuration of Cilium and not an external etcd, thus the title was changed to "Configure Cilium" for clarity.

Fixes: #9401

Signed-off-by: Melissa Peiffer mbp83@nau.edu

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9415)
<!-- Reviewable:end -->
