### PR TITLE
pkg/k8s: consider node taints as part of node equalness

### DIFF
--- a/pkg/k8s/factory_functions.go
+++ b/pkg/k8s/factory_functions.go
@@ -239,6 +239,21 @@ func EqualV1Node(node1, node2 *types.Node) bool {
 			return false
 		}
 	}
+	if len(node1.SpecTaints) != len(node2.SpecTaints) {
+		return false
+	}
+	for i, taint2 := range node2.SpecTaints {
+		taint1 := node1.SpecTaints[i]
+		if !taint1.MatchTaint(&taint2) {
+			return false
+		}
+		if taint1.Value != taint2.Value {
+			return false
+		}
+		if !taint1.TimeAdded.Equal(taint2.TimeAdded) {
+			return false
+		}
+	}
 	return true
 }
 
@@ -488,6 +503,7 @@ func ConvertToNode(obj interface{}) interface{} {
 			StatusAddresses: concreteObj.Status.Addresses,
 			SpecPodCIDR:     concreteObj.Spec.PodCIDR,
 			SpecPodCIDRs:    concreteObj.Spec.PodCIDRs,
+			SpecTaints:      concreteObj.Spec.Taints,
 		}
 		*concreteObj = v1.Node{}
 		return p
@@ -504,6 +520,7 @@ func ConvertToNode(obj interface{}) interface{} {
 				StatusAddresses: node.Status.Addresses,
 				SpecPodCIDR:     node.Spec.PodCIDR,
 				SpecPodCIDRs:    node.Spec.PodCIDRs,
+				SpecTaints:      node.Spec.Taints,
 			},
 		}
 		*node = v1.Node{}

--- a/pkg/k8s/factory_functions_test.go
+++ b/pkg/k8s/factory_functions_test.go
@@ -17,6 +17,8 @@
 package k8s
 
 import (
+	"time"
+
 	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/checker"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -601,6 +603,105 @@ func (s *K8sSuite) Test_EqualV1Node(c *C) {
 				},
 			},
 			want: true,
+		},
+		{
+			name: "Nodes with the same taints and different specs should return true because he don't care about the spec",
+			args: args{
+				o1: &types.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "Node1",
+					},
+					SpecTaints: []core_v1.Taint{
+						{
+							Key:    "key",
+							Value:  "value",
+							Effect: "no-effect",
+						},
+					},
+					SpecPodCIDR: "192.168.0.0/10",
+				},
+				o2: &types.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "Node1",
+					},
+					SpecTaints: []core_v1.Taint{
+						{
+							Key:    "key",
+							Value:  "value",
+							Effect: "no-effect",
+						},
+					},
+					SpecPodCIDR: "127.0.0.1/10",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Nodes with the same taints and different specs should return true because he don't care about the spec",
+			args: args{
+				o1: &types.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "Node1",
+					},
+					SpecTaints: []core_v1.Taint{
+						{
+							Key:       "key",
+							Value:     "value",
+							Effect:    "no-effect",
+							TimeAdded: func() *metav1.Time { return &metav1.Time{Time: time.Unix(1, 1)} }(),
+						},
+					},
+					SpecPodCIDR: "192.168.0.0/10",
+				},
+				o2: &types.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "Node1",
+					},
+					SpecTaints: []core_v1.Taint{
+						{
+							Key:       "key",
+							Value:     "value",
+							Effect:    "no-effect",
+							TimeAdded: func() *metav1.Time { return &metav1.Time{Time: time.Unix(1, 1)} }(),
+						},
+					},
+					SpecPodCIDR: "127.0.0.1/10",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Nodes with the different taints and different specs should return true because he don't care about the spec",
+			args: args{
+				o1: &types.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "Node1",
+					},
+					SpecTaints: []core_v1.Taint{
+						{
+							Key:    "key",
+							Value:  "value",
+							Effect: "no-effect",
+						},
+					},
+					SpecPodCIDR: "192.168.0.0/10",
+				},
+				o2: &types.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "Node1",
+					},
+					SpecTaints: []core_v1.Taint{
+						{
+							Key:       "key",
+							Value:     "value",
+							Effect:    "no-effect",
+							TimeAdded: func() *metav1.Time { return &metav1.Time{Time: time.Unix(1, 1)} }(),
+						},
+					},
+					SpecPodCIDR: "127.0.0.1/10",
+				},
+			},
+			want: false,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/k8s/types/types.go
+++ b/pkg/k8s/types/types.go
@@ -65,6 +65,7 @@ type Node struct {
 	StatusAddresses []v1.NodeAddress
 	SpecPodCIDR     string
 	SpecPodCIDRs    []string
+	SpecTaints      []v1.Taint
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/k8s/types/zz_generated.deepcopy.go
+++ b/pkg/k8s/types/zz_generated.deepcopy.go
@@ -224,6 +224,13 @@ func (in *Node) DeepCopyInto(out *Node) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.SpecTaints != nil {
+		in, out := &in.SpecTaints, &out.SpecTaints
+		*out = make([]v1.Taint, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 


### PR DESCRIPTION
As kube-controller-manager can change node taints to notify if the node
is or is not reachable, Cilium should also take into account those
taints. In the eventuality of a node to be down for more than 15 minutes
it can be removed from the kvstore due lease expiration. That same node
won't be re-added because Cilium is only checking for the equalness of
annotations and node name. Checking for Taints equalness will make sure
the node will be re-added to the kvstore.

Signed-off-by: André Martins <andre@cilium.io>

Fixes https://github.com/cilium/cilium/issues/9422

```release-note
Re-add node to kv-store once it restarts after being down for more than 15 minutes
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9423)
<!-- Reviewable:end -->
