### PR TITLE
policy: correctly process "ANY" L4 protocol in annotation

### DIFF
--- a/pkg/policy/visibility_test.go
+++ b/pkg/policy/visibility_test.go
@@ -132,4 +132,16 @@ func (ds *PolicyTestSuite) TestVisibilityPolicyCreation(c *C) {
 	vp, err = NewVisibilityPolicy(anno)
 	c.Assert(vp, IsNil)
 	c.Assert(err, Not(IsNil))
+
+	anno = "<Egress/53/ANY/DNS>"
+	vp, err = NewVisibilityPolicy(anno)
+	c.Assert(err, IsNil)
+	c.Assert(len(vp.Egress), checker.Equals, 2)
+	udp, ok := vp.Egress["53/UDP"]
+	c.Assert(ok, Equals, true)
+	c.Assert(udp.Proto, Equals, u8proto.UDP)
+	tcp, ok := vp.Egress["53/TCP"]
+	c.Assert(tcp.Proto, Equals, u8proto.TCP)
+	c.Assert(ok, Equals, true)
+
 }


### PR DESCRIPTION
The datapath does not do wildcarding for L4 protocol when a policymap entry has
a non-zero port. The datapath only supports TCP/UDP for L4 protocols when paired
with an L4 port; generate both TCP/UDP entries in the visibility policy
accordingly when an annotation contains "ANY".

Fixes: #9394

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9425)
<!-- Reviewable:end -->
