### PR TITLE
docs: Fix clustermesh secrets namespace

### DIFF
--- a/Documentation/gettingstarted/clustermesh.rst
+++ b/Documentation/gettingstarted/clustermesh.rst
@@ -235,7 +235,7 @@ chapter into all of your clusters:
 
 .. code:: bash
 
-    kubectl apply -f clustermesh.yaml
+    kubectl -n kube-system apply -f clustermesh.yaml
 
 2. Restart the cilium-agent in all clusters so it picks up the new cluster
    name, cluster id and mounts the ``cilium-clustermesh`` secret. Cilium will


### PR DESCRIPTION
The other commands in this doc specify the namespace, but the creation
of the clustermesh configuration doesn't. I found that without
specifying this, the configuration was not properly mounted into the
cilium containers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9427)
<!-- Reviewable:end -->
