### PR TITLE
eni: Allow selecting subnet by Name tag

### DIFF
--- a/pkg/aws/ec2/ec2.go
+++ b/pkg/aws/ec2/ec2.go
@@ -284,9 +284,8 @@ func (c *Client) GetSubnets() (types.SubnetMap, error) {
 		for _, tag := range s.Tags {
 			if *tag.Key == "Name" {
 				subnet.Name = *tag.Value
-			} else {
-				subnet.Tags[*tag.Key] = *tag.Value
 			}
+			subnet.Tags[*tag.Key] = *tag.Value
 		}
 
 		subnets[subnet.ID] = subnet


### PR DESCRIPTION
Currently the subnet-tag with key "Name" is not treated as a tag so
we can't select a subnet by specifying a Name tag.
This allows to select subnet by Name tag.

Fixes: #9428

Signed-off-by: Jaff Cheng <jaff.cheng.sh@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9431)
<!-- Reviewable:end -->
