### PR TITLE
add context.Context to Daemon

### DIFF
--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -313,7 +313,7 @@ func LaunchAsEndpoint(baseCtx context.Context, owner regeneration.Owner, n *node
 	}
 
 	// Create the endpoint
-	ep, err := endpoint.NewEndpointFromChangeModel(owner, proxy, allocator, info)
+	ep, err := endpoint.NewEndpointFromChangeModel(baseCtx, owner, proxy, allocator, info)
 	if err != nil {
 		return nil, fmt.Errorf("Error while creating endpoint model: %s", err)
 	}

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -1181,7 +1181,7 @@ func runDaemon() {
 	iptablesManager := &iptables.IptablesManager{}
 	iptablesManager.Init()
 
-	d, restoredEndpoints, err := NewDaemon(linuxdatapath.NewDatapath(datapathConfig, iptablesManager), iptablesManager)
+	d, restoredEndpoints, err := NewDaemon(server.ServerCtx, linuxdatapath.NewDatapath(datapathConfig, iptablesManager), iptablesManager)
 	if err != nil {
 		log.WithError(err).Fatal("Error while creating daemon")
 		return
@@ -1280,14 +1280,14 @@ func runDaemon() {
 	bootstrapStats.initAPI.Start()
 	api := d.instantiateAPI()
 
-	server := server.NewServer(api)
-	server.EnabledListeners = []string{"unix"}
-	server.SocketPath = flags.Filename(option.Config.SocketPath)
-	server.ReadTimeout = apiTimeout
-	server.WriteTimeout = apiTimeout
-	defer server.Shutdown()
+	svr := server.NewServer(api)
+	svr.EnabledListeners = []string{"unix"}
+	svr.SocketPath = flags.Filename(option.Config.SocketPath)
+	svr.ReadTimeout = apiTimeout
+	svr.WriteTimeout = apiTimeout
+	defer svr.Shutdown()
 
-	server.ConfigureAPI()
+	svr.ConfigureAPI()
 	bootstrapStats.initAPI.End(true)
 
 	repr, err := monitorAPI.TimeRepr(time.Now())
@@ -1316,7 +1316,7 @@ func runDaemon() {
 	errs := make(chan error, 1)
 
 	go func() {
-		errs <- server.Serve()
+		errs <- svr.Serve()
 	}()
 
 	bootstrapStats.overall.End(true)

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -112,7 +112,7 @@ func (ds *DaemonSuite) SetUpTest(c *C) {
 	ds.oldPolicyEnabled = policy.GetPolicyEnabled()
 	policy.SetPolicyEnabled(option.DefaultEnforcement)
 
-	d, _, err := NewDaemon(fakedatapath.NewDatapath(), nil)
+	d, _, err := NewDaemon(context.Background(), fakedatapath.NewDatapath(), nil)
 	c.Assert(err, IsNil)
 	ds.d = d
 

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -179,7 +179,7 @@ func (d *Daemon) createEndpoint(ctx context.Context, epTemplate *models.Endpoint
 		epTemplate.DatapathConfiguration.RequireRouting = &disabled
 	}
 
-	ep, err := endpoint.NewEndpointFromChangeModel(d, d.l7Proxy, d.identityAllocator, epTemplate)
+	ep, err := endpoint.NewEndpointFromChangeModel(d.ctx, d, d.l7Proxy, d.identityAllocator, epTemplate)
 	if err != nil {
 		return invalidDataError(ep, fmt.Errorf("unable to parse endpoint parameters: %s", err))
 	}
@@ -362,7 +362,7 @@ func (h *patchEndpointID) Handle(params PatchEndpointIDParams) middleware.Respon
 
 	// Validate the template. Assignment afterwards is atomic.
 	// Note: newEp's labels are ignored.
-	newEp, err2 := endpoint.NewEndpointFromChangeModel(h.d, h.d.l7Proxy, h.d.identityAllocator, epTemplate)
+	newEp, err2 := endpoint.NewEndpointFromChangeModel(h.d.ctx, h.d, h.d.l7Proxy, h.d.identityAllocator, epTemplate)
 	if err2 != nil {
 		return api.Error(PutEndpointIDInvalidCode, err2)
 	}

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -142,7 +142,7 @@ func (d *Daemon) restoreOldEndpoints(dir string, clean bool) (*endpointRestoreSt
 	}
 	eptsID := endpoint.FilterEPDir(dirFiles)
 
-	possibleEPs := endpoint.ReadEPsFromDirNames(d, dir, eptsID)
+	possibleEPs := endpoint.ReadEPsFromDirNames(d.ctx, d, dir, eptsID)
 
 	if len(possibleEPs) == 0 {
 		log.Info("No old endpoints found.")

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -61,7 +61,7 @@ func (e *Endpoint) GetLabelsModel() (*models.LabelConfiguration, error) {
 }
 
 // NewEndpointFromChangeModel creates a new endpoint from a request
-func NewEndpointFromChangeModel(owner regeneration.Owner, proxy EndpointProxy, allocator cache.IdentityAllocator, base *models.EndpointChangeRequest) (*Endpoint, error) {
+func NewEndpointFromChangeModel(ctx context.Context, owner regeneration.Owner, proxy EndpointProxy, allocator cache.IdentityAllocator, base *models.EndpointChangeRequest) (*Endpoint, error) {
 	if base == nil {
 		return nil, nil
 	}
@@ -90,7 +90,7 @@ func NewEndpointFromChangeModel(owner regeneration.Owner, proxy EndpointProxy, a
 		allocator:        allocator,
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 	ep.aliveCancel = cancel
 	ep.aliveCtx = ctx
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -687,7 +687,7 @@ func FilterEPDir(dirFiles []os.FileInfo) []string {
 // common.CiliumCHeaderPrefix + common.Version + ":" + endpointBase64
 // Note that the parse'd endpoint's identity is only partially restored. The
 // caller must call `SetIdentity()` to make the returned endpoint's identity useful.
-func parseEndpoint(owner regeneration.Owner, strEp string) (*Endpoint, error) {
+func parseEndpoint(ctx context.Context, owner regeneration.Owner, strEp string) (*Endpoint, error) {
 	// TODO: Provide a better mechanism to update from old version once we bump
 	// TODO: cilium version.
 	strEpSlice := strings.Split(strEp, ":")
@@ -712,7 +712,7 @@ func parseEndpoint(owner regeneration.Owner, strEp string) (*Endpoint, error) {
 	ep.controllers = controller.NewManager()
 	ep.regenFailedChan = make(chan struct{}, 1)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 	ep.aliveCancel = cancel
 	ep.aliveCtx = ctx
 

--- a/pkg/endpoint/endpoint_status_test.go
+++ b/pkg/endpoint/endpoint_status_test.go
@@ -49,7 +49,7 @@ type endpointGeneratorSpec struct {
 }
 
 func (s *EndpointSuite) newEndpoint(c *check.C, spec endpointGeneratorSpec) *Endpoint {
-	e, err := NewEndpointFromChangeModel(s, &FakeEndpointProxy{}, s.mgr, &models.EndpointChangeRequest{
+	e, err := NewEndpointFromChangeModel(context.TODO(), s, &FakeEndpointProxy{}, s.mgr, &models.EndpointChangeRequest{
 		Addressing: &models.AddressPair{},
 		ID:         200,
 		Labels: models.Labels{

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -40,7 +40,7 @@ import (
 
 // ReadEPsFromDirNames returns a mapping of endpoint ID to endpoint of endpoints
 // from a list of directory names that can possible contain an endpoint.
-func ReadEPsFromDirNames(owner regeneration.Owner, basePath string, eptsDirNames []string) map[uint16]*Endpoint {
+func ReadEPsFromDirNames(ctx context.Context, owner regeneration.Owner, basePath string, eptsDirNames []string) map[uint16]*Endpoint {
 	possibleEPs := map[uint16]*Endpoint{}
 	for _, epDirName := range eptsDirNames {
 		epDir := filepath.Join(basePath, epDirName)
@@ -84,7 +84,7 @@ func ReadEPsFromDirNames(owner regeneration.Owner, basePath string, eptsDirNames
 			scopedLog.WithError(err).Warn("Unable to read the C header file")
 			continue
 		}
-		ep, err := parseEndpoint(owner, strEp)
+		ep, err := parseEndpoint(ctx, owner, strEp)
 		if err != nil {
 			scopedLog.WithError(err).Warn("Unable to parse the C header file")
 			continue

--- a/pkg/endpoint/restore_test.go
+++ b/pkg/endpoint/restore_test.go
@@ -17,6 +17,7 @@
 package endpoint
 
 import (
+	"context"
 	"encoding/binary"
 	"fmt"
 	"io/ioutil"
@@ -142,7 +143,7 @@ func (ds *EndpointSuite) TestReadEPsFromDirNames(c *C) {
 			epsNames = append(epsNames, ep.DirectoryPath())
 		}
 	}
-	eps := ReadEPsFromDirNames(ds, tmpDir, epsNames)
+	eps := ReadEPsFromDirNames(context.TODO(), ds, tmpDir, epsNames)
 	c.Assert(len(eps), Equals, len(epsWanted))
 
 	sort.Slice(epsWanted, func(i, j int) bool { return epsWanted[i].ID < epsWanted[j].ID })


### PR DESCRIPTION
 Add a context to the daemon which is canceled upon its termination. At runtime, this context is the `ServerContext` from the server. As a result of this being plumbed down to all Endpoints created during the lifecycle of the daemon, all ongoing requests for Endpoints will be canceled if the Endpoint's `aliveCtx` is canceled (i.e., the Endpoint is deleted), or if the daemon itself stops (i.e., the daemon receives a signal for which it is listening).

This functionality ensures that ongoing requests to the server are canceled when the daemon is stopped, and all operations are canceled for all Endpoints when the daemon is terminated as well.

This should help reduce the propensity of certain errors appearing when Cilium is stopped in our CI, including `JoinEP` failures, since our signal handling will cancel the contexts which are used in the regeneration path for Endpoints; in such cases, if contexts are canceled, we do not log such failures as context cancelation is not an "error".

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9437)
<!-- Reviewable:end -->
