### PR TITLE
policy: Connection-based toFQDNs IP expiration

### DIFF
--- a/api/v1/models/dns_lookup.go
+++ b/api/v1/models/dns_lookup.go
@@ -34,6 +34,9 @@ type DNSLookup struct {
 	// Format: date-time
 	LookupTime strfmt.DateTime `json:"lookup-time,omitempty"`
 
+	// The reason this FQDN IP association exists. Either a DNS lookup or an ongoing connection to an IP that was created by a DNS lookup.
+	Source string `json:"source,omitempty"`
+
 	// The TTL in the DNS response
 	TTL int64 `json:"ttl,omitempty"`
 }

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -2203,6 +2203,9 @@ definitions:
       endpoint-id:
         description: The endpoint that made this lookup, or 0 for the agent itself.
         type: integer
+      source:
+        description: The reason this FQDN IP association exists. Either a DNS lookup or an ongoing connection to an IP that was created by a DNS lookup.
+        type: string
   IPListEntry:
     description: IP entry with metadata
     type: object

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -1590,6 +1590,10 @@ func init() {
           "type": "string",
           "format": "date-time"
         },
+        "source": {
+          "description": "The reason this FQDN IP association exists. Either a DNS lookup or an ongoing connection to an IP that was created by a DNS lookup.",
+          "type": "string"
+        },
         "ttl": {
           "description": "The TTL in the DNS response",
           "type": "integer"
@@ -4842,6 +4846,10 @@ func init() {
           "description": "The absolute time when this data was recieved",
           "type": "string",
           "format": "date-time"
+        },
+        "source": {
+          "description": "The reason this FQDN IP association exists. Either a DNS lookup or an ongoing connection to an IP that was created by a DNS lookup.",
+          "type": "string"
         },
         "ttl": {
           "description": "The TTL in the DNS response",

--- a/cilium/cmd/fqdn.go
+++ b/cilium/cmd/fqdn.go
@@ -160,10 +160,11 @@ func listFQDNCache() {
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 5, 0, 3, ' ', 0)
-	fmt.Fprintln(w, "Endpoint\tFQDN\tTTL\tExpirationTime\tIPs\t")
+	fmt.Fprintln(w, "Endpoint\tSource\tFQDN\tTTL\tExpirationTime\tIPs\t")
 	for _, lookup := range lookups {
-		fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%s\t\n",
+		fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%s\t%s\t\n",
 			lookup.EndpointID,
+			lookup.Source,
 			lookup.Fqdn,
 			time.Duration(lookup.TTL)*time.Second,
 			lookup.ExpirationTime.String(),

--- a/cilium/cmd/fqdn.go
+++ b/cilium/cmd/fqdn.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -161,10 +162,10 @@ func listFQDNCache() {
 	w := tabwriter.NewWriter(os.Stdout, 5, 0, 3, ' ', 0)
 	fmt.Fprintln(w, "Endpoint\tFQDN\tTTL\tExpirationTime\tIPs\t")
 	for _, lookup := range lookups {
-		fmt.Fprintf(w, "%d\t%s\t%d\t%s\t%s\t\n",
+		fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%s\t\n",
 			lookup.EndpointID,
 			lookup.Fqdn,
-			lookup.TTL,
+			time.Duration(lookup.TTL)*time.Second,
 			lookup.ExpirationTime.String(),
 			strings.Join(lookup.Ips, ","))
 	}

--- a/daemon/fqdn.go
+++ b/daemon/fqdn.go
@@ -743,6 +743,9 @@ func deleteDNSLookups(globalCache *fqdn.DNSCache, pollerCache *fqdn.DNSCache, en
 		namesToRegen = append(namesToRegen, ep.DNSHistory.ForceExpire(expireLookupsBefore, nameMatcher)...)
 		namesToRegen = append(namesToRegen, ep.DNSCTHistory.ForceExpire(expireLookupsBefore, nameMatcher)...)
 		globalCache.UpdateFromCache(ep.DNSHistory, nil)
+		if err := ep.SyncEndpointHeaderFile(); err != nil {
+			ep.Logger("fqdn").Warn("Error triggering endpoint sync to disk. This will be retried at the next regeneration")
+		}
 	}
 
 	return namesToRegen, nil

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -81,6 +81,7 @@ func NewEndpointFromChangeModel(owner regeneration.Owner, proxy EndpointProxy, a
 		ifIndex:          int(base.InterfaceIndex),
 		OpLabels:         labels.NewOpLabels(),
 		DNSHistory:       fqdn.NewDNSCacheWithLimit(option.Config.ToFQDNsMinTTL, option.Config.ToFQDNsMaxIPsPerHost),
+		DNSCTHistory:     fqdn.NewDNSCache(1),
 		state:            "",
 		status:           NewEndpointStatus(),
 		hasBPFProgram:    make(chan struct{}, 0),

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -931,8 +931,9 @@ func (e *Endpoint) garbageCollectConntrack(filter *ctmap.GCFilter) {
 			}
 			return true
 		}
+		now := time.Now()
 		ctmap.GC(m, filter)
-		e.DNSCTHistory.ForceExpire(time.Now(), nil)
+		e.DNSCTHistory.ForceExpire(now, nil)
 	}
 }
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -194,6 +194,12 @@ type Endpoint struct {
 	// sure that restores when DNS policy is in there are correct
 	dnsHistoryTrigger *trigger.Trigger
 
+	// DNSCTHistory reflects existing connections of this endpoint to known FQDN
+	// names. It is populated during CT GC but used by the
+	// dns-garbage-collector-job in daemon/fqdn.go. The controller also issues
+	// expire calls on it, keeping it at a reasonable size.
+	DNSCTHistory *fqdn.DNSCache
+
 	// state is the state the endpoint is in. See setState()
 	state string
 
@@ -386,6 +392,7 @@ func NewEndpointWithState(owner regeneration.Owner, proxy EndpointProxy, allocat
 		OpLabels:        pkgLabels.NewOpLabels(),
 		status:          NewEndpointStatus(),
 		DNSHistory:      fqdn.NewDNSCacheWithLimit(option.Config.ToFQDNsMinTTL, option.Config.ToFQDNsMaxIPsPerHost),
+		DNSCTHistory:    fqdn.NewDNSCache(1), // TODO: The real TTLs will need to be set by the CT GC
 		state:           state,
 		hasBPFProgram:   make(chan struct{}, 0),
 		controllers:     controller.NewManager(),

--- a/pkg/endpoint/fqdn.go
+++ b/pkg/endpoint/fqdn.go
@@ -1,0 +1,69 @@
+// Copyright 2016-2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endpoint
+
+import (
+	"net"
+	"time"
+
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/sirupsen/logrus"
+)
+
+const logSubsys = "fqdn"
+
+// MarkDNSCTEntry records that dstIP is in use by a connection that is allowed
+// by toFQDNs policy. The reverse lookup is attempted in both DNSHistory and
+// DNSCTHistory, allowing short DNS TTLs but long-lived connections to
+// persisthere.DNSCTHistory is used to suppress delete handling of expired DNS
+// lookups (in DNSHistory) and it relies on pkg/maps/ctmap/gc to call this
+// function.
+// Internally, the lookupTime is used to checkpoint this update so that
+// dns-garbage-collector-job can correctly clear older connection data.
+func (e *Endpoint) MarkDNSCTEntry(dstIP net.IP, TTL time.Duration) {
+	if dstIP == nil {
+		e.Logger(logSubsys).Error("MarkDNSCTEntry called with nil IP")
+		return
+	}
+
+	var (
+		scopedLog  = e.Logger(logSubsys)
+		lookupTime = time.Now()
+		names      []string
+	)
+	// The DNS TTL may have expired, so use the DNS CT cache to roll forward a qname->IP mapping
+	// TODO: This misses cases where a FQDN IP is allowed due to another
+	// endpoint's lookup. Normally, that case is handled by pooling caches into
+	// the daemon-global DNS cache.
+	names = append(names, e.DNSCTHistory.LookupIP(dstIP)...)
+	names = append(names, e.DNSHistory.LookupIP(dstIP)...)
+
+	if len(names) == 0 {
+		scopedLog.WithFields(logrus.Fields{
+			logfields.IPAddr: dstIP,
+		}).Warn("Could not update endpoint DNS CT cache with IP. No DNS match found in cache.")
+		return
+	}
+
+	for _, qname := range names {
+		e.Logger(logSubsys).WithFields(logrus.Fields{
+			logfields.DNSName: qname,
+			logfields.IPAddr:  dstIP,
+		}).Debug("Updating ep DNS CT cache with qname->IP")
+		e.DNSCTHistory.Update(lookupTime, qname, []net.IP{dstIP}, int(TTL))
+	}
+
+	e.SyncEndpointHeaderFile()
+}

--- a/pkg/endpoint/fqdn.go
+++ b/pkg/endpoint/fqdn.go
@@ -62,7 +62,7 @@ func (e *Endpoint) MarkDNSCTEntry(dstIP net.IP, TTL time.Duration) {
 			logfields.DNSName: qname,
 			logfields.IPAddr:  dstIP,
 		}).Debug("Updating ep DNS CT cache with qname->IP")
-		e.DNSCTHistory.Update(lookupTime, qname, []net.IP{dstIP}, int(TTL))
+		e.DNSCTHistory.Update(lookupTime, qname, []net.IP{dstIP}, int(TTL.Seconds()))
 	}
 
 	e.SyncEndpointHeaderFile()

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -252,6 +252,7 @@ func (e *Endpoint) toSerializedEndpoint() *serializableEndpoint {
 		SecurityIdentity:      e.SecurityIdentity,
 		Options:               e.Options,
 		DNSHistory:            e.DNSHistory,
+		DNSCTHistory:          e.DNSCTHistory,
 		K8sPodName:            e.K8sPodName,
 		K8sNamespace:          e.K8sNamespace,
 		DatapathConfiguration: e.DatapathConfiguration,
@@ -327,6 +328,10 @@ type serializableEndpoint struct {
 	// this endpoint.
 	DNSHistory *fqdn.DNSCache
 
+	// DNSCTHistory reflects existing connections of this endpoint to known FQDN
+	// names.
+	DNSCTHistory *fqdn.DNSCache
+
 	// K8sPodName is the Kubernetes pod name of the endpoint
 	K8sPodName string
 
@@ -346,8 +351,9 @@ func (ep *Endpoint) UnmarshalJSON(raw []byte) error {
 	// We may have to populate structures in the Endpoint manually to do the
 	// translation from serializableEndpoint --> Endpoint.
 	restoredEp := &serializableEndpoint{
-		OpLabels:   labels.NewOpLabels(),
-		DNSHistory: fqdn.NewDNSCacheWithLimit(option.Config.ToFQDNsMinTTL, option.Config.ToFQDNsMaxIPsPerHost),
+		OpLabels:     labels.NewOpLabels(),
+		DNSHistory:   fqdn.NewDNSCacheWithLimit(option.Config.ToFQDNsMinTTL, option.Config.ToFQDNsMaxIPsPerHost),
+		DNSCTHistory: fqdn.NewDNSCache(1),
 	}
 	if err := json.Unmarshal(raw, restoredEp); err != nil {
 		return fmt.Errorf("error unmarshaling serializableEndpoint from base64 representation: %s", err)
@@ -378,6 +384,7 @@ func (ep *Endpoint) fromSerializedEndpoint(r *serializableEndpoint) {
 	ep.nodeMAC = r.NodeMAC
 	ep.SecurityIdentity = r.SecurityIdentity
 	ep.DNSHistory = r.DNSHistory
+	ep.DNSCTHistory = r.DNSCTHistory
 	ep.K8sPodName = r.K8sPodName
 	ep.K8sNamespace = r.K8sNamespace
 	ep.DatapathConfiguration = r.DatapathConfiguration

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -643,16 +643,8 @@ func calculateInterval(mapType bpf.MapType, prevInterval time.Duration, maxDelet
 		// as a new node may not be seeing workloads yet and thus the
 		// scan will return a low deletion ratio at first.
 		interval = time.Duration(float64(interval) * 1.5).Round(time.Second)
-
-		switch mapType {
-		case bpf.MapTypeLRUHash:
-			if interval > defaults.ConntrackGCMaxLRUInterval {
-				interval = defaults.ConntrackGCMaxLRUInterval
-			}
-		default:
-			if interval > defaults.ConntrackGCMaxInterval {
-				interval = defaults.ConntrackGCMaxInterval
-			}
+		if maxInterval := GetMaxInterval(mapType); interval > maxInterval {
+			interval = maxInterval
 		}
 	}
 
@@ -666,4 +658,13 @@ func calculateInterval(mapType bpf.MapType, prevInterval time.Duration, maxDelet
 	cachedGCInterval = interval
 
 	return
+}
+
+func GetMaxInterval(mapType bpf.MapType) (interval time.Duration) {
+	switch mapType {
+	case bpf.MapTypeLRUHash:
+		return defaults.ConntrackGCMaxLRUInterval
+	default:
+		return defaults.ConntrackGCMaxInterval
+	}
 }

--- a/pkg/maps/ctmap/gc/gc.go
+++ b/pkg/maps/ctmap/gc/gc.go
@@ -16,6 +16,7 @@ package gc
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"time"
 
@@ -34,6 +35,7 @@ var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "ct-gc")
 // globally exposed on the current node.
 type EndpointManager interface {
 	GetEndpoints() []*endpoint.Endpoint
+	LookupIP(net.IP) *endpoint.Endpoint
 }
 
 // Enable enables the connection tracking garbage collection.

--- a/pkg/maps/ctmap/gc/gc.go
+++ b/pkg/maps/ctmap/gc/gc.go
@@ -167,7 +167,6 @@ func runGC(e *endpoint.Endpoint, ipv4, ipv6 bool, filter *ctmap.GCFilter) (mapTy
 		defer m.Close()
 
 		mapType = m.MapInfo.MapType
-
 		deleted := ctmap.GC(m, filter)
 
 		if deleted > 0 {


### PR DESCRIPTION
Connections can outlive the DNS query that allowed them via toFQDNs
policies. We previously papered over this with a very high (1 week)
--tofqdns-min-ttl value. Mixed workloads where some connections are
long-lived and others are short-lived strain this model as the
short-lived connections' DNS cache entries accumulate.
We can consider the current state of the connection tracking table when
retiring IPs from the toFQDNs caches. We rely on the normal CT GC to
traverse the connections, and accumulate this information on each
endpoint. When expiring DNS cache entries, IPs that are still in-use and
are allowed due to a toFQDNs policy will not expire but continue being
used by toFQDNsSelectors until the connection is closed, or the selector
is deleted (via a policy change).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9452)
<!-- Reviewable:end -->
