### PR TITLE
endpoint: regeneration controller runs with `RegenerateWithDatapathRewrite`

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -578,6 +578,9 @@ func (e *Endpoint) startRegenerationFailureHandler() {
 				// context to a controller (e.g., endpoint.aliveCtx)?
 				ParentContext: ctx,
 				Reason:        reasonRegenRetry,
+				// Completely rewrite the endpoint - we don't know the nature
+				// of the failure, simply that something failed.
+				RegenerationLevel: regeneration.RegenerateWithDatapathRewrite,
 			}
 			if success := <-e.Regenerate(r); success {
 				return nil


### PR DESCRIPTION
The controller previously did not specify at which level the regeneration should
occur for the Endpoint, which meant that the level used was
`RegenerateWithoutDatapath`, which does not try to recompile or reload the
Endpoint's datapath program. This means that if a prior regeneration failed, and
the controller was invoked, the regeneration would "succeed", but the Endpoint's
programs would not be built, leaving it in a bad state. To fix this, always
ensure that we try to recompile the Endpoint's programs if a template has not
been built (`RegenerateWithDatapathRewrite`).

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9455)
<!-- Reviewable:end -->
