### PR TITLE
Documentation: improve CI documentation organization / remove stale information

### DIFF
--- a/Documentation/contributing/ci.rst
+++ b/Documentation/contributing/ci.rst
@@ -42,22 +42,9 @@ Cilium-PR-Ginkgo-Tests-k8s
 Runs the Kubernetes e2e tests against all Kubernetes versions that are not
 currently not tested as part of each pull-request, but which Cilium still
 supports, as well as the the most-recently-released versions of Kubernetes that
-that might not be declared stable by Kubernetes upstream:
-
-First stage.
-
-    - 1.10
-    - 1.11
-
-Second stage (other versions)
-
-    - 1.12
-    - 1.13
-
-Third stage
-
-    - 1.14
-    - beta versions (1.16-beta once it's out)
+that might not be declared stable by Kubernetes upstream. Check the contents of
+``ginkgo-kubernetes-all.Jenkinsfile`` in the branch of Cilium for which you are
+running tests to see which Kubernetes versions will be tested against.
 
 Ginkgo-CI-Tests-Pipeline
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/Documentation/contributing/ci.rst
+++ b/Documentation/contributing/ci.rst
@@ -92,6 +92,42 @@ as part of each pull-request, but that Cilium still supports.
 
 It also runs a variety of tests against Envoy to ensure that proxy functionality is working correctly.
 
+.. _packer_ci:
+
+Packer-CI-Build
+^^^^^^^^^^^^^^^
+
+As part of Cilium development, we use a custom base box with a bunch of
+pre-installed libraries and tools that we need to enhance our daily workflow.
+That base box is built with `Packer <https://www.packer.io/>`_ and it is hosted
+in the `packer-ci-build
+<https://jenkins.cilium.io/job/Vagrant-Master-Boxes-Packer-Build/>`_ GitHub
+repository.
+
+New versions of this box can be created via `Jenkins Packer Build
+<https://jenkins.cilium.io/job/Vagrant-Master-Boxes-Packer-Build/>`_, where
+new builds of the image will be pushed to  `Vagrant Cloud
+<https://app.vagrantup.com/cilium>`_ . The version of the image corresponds to
+the `BUILD_ID <https://qa.nuxeo.org/jenkins/pipeline-syntax/globals#env>`_
+environment variable in the Jenkins job. That version ID will be used in Cilium
+`Vagrantfiles
+<https://github.com/cilium/cilium/blob/master/test/Vagrantfile#L10>`_.
+
+Changes to this image are made via contributions to the packer-ci-build
+repository. Authorized GitHub users can trigger builds with a GitHub comment on
+the PR containing the trigger phrase ``build-me-please``. In case that a new box
+needs to be rebased with a different branch than master, authorized developers
+can run the build with custom parameters. To use a different Cilium branch in
+the `job <https://jenkins.cilium.io/job/Vagrant-Master-Boxes-Packer-Build/>`_ go
+to *Build with parameters* and a base branch can be set as the user needs.
+
+This box will need to be updated when a new developer needs a new dependency
+that is not installed in the current version of the box, or if a dependency that
+is cached within the box becomes stale.
+
+Make sure that you update vagrant box versions in `test Vagrantfile <https://github.com/cilium/cilium/blob/master/test/Vagrantfile>`__
+and `root Vagrantfile <https://github.com/cilium/cilium/blob/master/Vagrantfile>`__ after new box is built and tested.
+
 .. _trigger_phrases:
 
 Triggering Pull-Request Builds With Jenkins

--- a/Documentation/contributing/contributing.rst
+++ b/Documentation/contributing/contributing.rst
@@ -198,42 +198,6 @@ If for some reason, running of the provisioning script fails, you should bring t
 
     $ vagrant halt
 
-.. _packer_ci:
-
-Packer-CI-Build
-^^^^^^^^^^^^^^^
-
-As part of Cilium development, we use a custom base box with a bunch of
-pre-installed libraries and tools that we need to enhance our daily workflow.
-That base box is built with `Packer <https://www.packer.io/>`_ and it is hosted
-in the `packer-ci-build
-<https://jenkins.cilium.io/job/Vagrant-Master-Boxes-Packer-Build/>`_ GitHub
-repository.
-
-New versions of this box can be created via `Jenkins Packer Build
-<https://jenkins.cilium.io/job/Vagrant-Master-Boxes-Packer-Build/>`_, where
-new builds of the image will be pushed to  `Vagrant Cloud
-<https://app.vagrantup.com/cilium>`_ . The version of the image corresponds to
-the `BUILD_ID <https://qa.nuxeo.org/jenkins/pipeline-syntax/globals#env>`_
-environment variable in the Jenkins job. That version ID will be used in Cilium
-`Vagrantfiles
-<https://github.com/cilium/cilium/blob/master/test/Vagrantfile#L10>`_.
-
-Changes to this image are made via contributions to the packer-ci-build
-repository. Authorized GitHub users can trigger builds with a GitHub comment on
-the PR containing the trigger phrase ``build-me-please``. In case that a new box
-needs to be rebased with a different branch than master, authorized developers
-can run the build with custom parameters. To use a different Cilium branch in
-the `job <https://jenkins.cilium.io/job/Vagrant-Master-Boxes-Packer-Build/>`_ go
-to *Build with parameters* and a base branch can be set as the user needs.
-
-This box will need to be updated when a new developer needs a new dependency
-that is not installed in the current version of the box, or if a dependency that
-is cached within the box becomes stale.
-
-Make sure that you update vagrant box versions in `test Vagrantfile <https://github.com/cilium/cilium/blob/master/test/Vagrantfile>`__
-and `root Vagrantfile <https://github.com/cilium/cilium/blob/master/Vagrantfile>`__ after new box is built and tested.
-
 Development process
 -------------------
 


### PR DESCRIPTION
* Move the information about the Jenkins jobs for building the VMs used for testing to where information about other Jenkins jobs is stored in our documentation for more logical organization.
* The documentation is out-of-date with respect to which versions of Kubernetes are tested against in the `Cilium-PR-Ginkgo-Tests-K8s` job. To avoid the documentation becoming out of sync again, just refer to the Jenkinsfile itself which contains the actual versions which are tested against. This will not go out of sync, except if the file itself is moved.
    
Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9457)
<!-- Reviewable:end -->
