### PR TITLE
Disable endpoint connectivity health checking in chaining mode

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -55,6 +55,7 @@ cilium-agent [flags]
       --disable-k8s-services                                  Disable east-west K8s load balancing by cilium
   -e, --docker string                                         Path to docker runtime socket (DEPRECATED: use container-runtime-endpoint instead) (default "unix:///var/run/docker.sock")
       --egress-masquerade-interfaces string                   Limit egress masquerading to interface selector
+      --enable-endpoint-health-checking                       Enable connectivity health checking between virtual endpoints (default true)
       --enable-endpoint-routes                                Use per endpoint routes instead of routing via cilium_host
       --enable-health-checking                                Enable connectivity health checking (default true)
       --enable-host-reachable-services                        Enable reachability of services for host applications (beta)

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -273,6 +273,9 @@ func init() {
 	flags.Bool(option.EnableHealthChecking, defaults.EnableHealthChecking, "Enable connectivity health checking")
 	option.BindEnv(option.EnableHealthChecking)
 
+	flags.Bool(option.EnableEndpointHealthChecking, defaults.EnableEndpointHealthChecking, "Enable connectivity health checking between virtual endpoints")
+	option.BindEnv(option.EnableEndpointHealthChecking)
+
 	flags.Bool(option.EnableIPv4Name, defaults.EnableIPv4, "Enable IPv4 support")
 	option.BindEnv(option.EnableIPv4Name)
 

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -1229,9 +1229,10 @@ func runDaemon() {
 	restoreComplete := d.initRestore(restoredEndpoints)
 
 	if option.Config.IsFlannelMasterDeviceSet() {
-		// health checking is not supported by flannel
-		log.Warnf("Running Cilium in flannel mode doesn't support health checking. Changing %s mode to %t", option.EnableHealthChecking, false)
-		option.Config.EnableHealthChecking = false
+		if option.Config.EnableEndpointHealthChecking {
+			log.Warn("Running Cilium in flannel mode doesn't support endpoint connectivity health checking. Disabling endpoint connectivity health check.")
+			option.Config.EnableEndpointHealthChecking = false
+		}
 
 		err := node.SetInternalIPv4From(option.Config.FlannelMasterDevice)
 		if err != nil {

--- a/daemon/health.go
+++ b/daemon/health.go
@@ -46,6 +46,11 @@ func (d *Daemon) initHealth() {
 		d.ciliumHealth = ch
 	}
 
+	// If endpoint health checking is disabled, the virtual endpoint does not need to be launched
+	if !option.Config.EnableEndpointHealthChecking {
+		return
+	}
+
 	// Launch the cilium-health-responder as an endpoint, managed by cilium.
 	log.Info("Launching Cilium health endpoint")
 	if k8s.IsEnabled() {

--- a/daemon/ipam.go
+++ b/daemon/ipam.go
@@ -194,7 +194,7 @@ func (d *Daemon) allocateDatapathIPs(family datapath.NodeAddressingFamily) (rout
 
 func (d *Daemon) allocateHealthIPs() error {
 	bootstrapStats.healthCheck.Start()
-	if option.Config.EnableHealthChecking {
+	if option.Config.EnableHealthChecking && option.Config.EnableEndpointHealthChecking {
 		if option.Config.EnableIPv4 {
 			result, err := d.ipam.AllocateNextFamily(ipam.IPv4, "health")
 			if err != nil {

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -313,3 +313,7 @@ data:
 {{- if .Values.global.kubeConfigPath }}
   k8s-kubeconfig-path: {{ .Values.global.kubeConfigPath | quote }}
 {{- end }}
+{{- if.Values.global.chainingMode }}
+  # Chaining mode was enabled, disabling health checking
+  enable-endpoint-health-checking: "false"
+{{- end }}

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -165,6 +165,10 @@ const (
 	// EnableHealthChecking is the default value for EnableHealthChecking
 	EnableHealthChecking = true
 
+	// EnableEndpointHealthChecking is the default value for
+	// EnableEndpointHealthChecking
+	EnableEndpointHealthChecking = true
+
 	// AlignCheckerName is the BPF object name for the alignchecker.
 	AlignCheckerName = "bpf_alignchecker.o"
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -504,6 +504,9 @@ const (
 	// EnableHealthChecking is the name of the EnableHealthChecking option
 	EnableHealthChecking = "enable-health-checking"
 
+	// EnableEndpointHealthChecking is the name of the EnableEndpointHealthChecking option
+	EnableEndpointHealthChecking = "enable-endpoint-health-checking"
+
 	// PolicyQueueSize is the size of the queues utilized by the policy
 	// repository.
 	PolicyQueueSize = "policy-queue-size"
@@ -1089,6 +1092,10 @@ type DaemonConfig struct {
 	// health endpoints
 	EnableHealthChecking bool
 
+	// EnableEndpointHealthChecking enables health checking between virtual
+	// health endpoints
+	EnableEndpointHealthChecking bool
+
 	// KVstoreKeepAliveInterval is the interval in which the lease is being
 	// renewed. This must be set to a value lesser than the LeaseTTL ideally
 	// by a factor of 3.
@@ -1247,6 +1254,7 @@ var (
 		IPv6ClusterAllocCIDRBase:     defaults.IPv6ClusterAllocCIDRBase,
 		EnableHostIPRestore:          defaults.EnableHostIPRestore,
 		EnableHealthChecking:         defaults.EnableHealthChecking,
+		EnableEndpointHealthChecking: defaults.EnableEndpointHealthChecking,
 		EnableIPv4:                   defaults.EnableIPv4,
 		EnableIPv6:                   defaults.EnableIPv6,
 		ToFQDNsMaxIPsPerHost:         defaults.ToFQDNsMaxIPsPerHost,
@@ -1587,6 +1595,7 @@ func (c *DaemonConfig) Populate() {
 	c.EnableAutoDirectRouting = viper.GetBool(EnableAutoDirectRoutingName)
 	c.EnableEndpointRoutes = viper.GetBool(EnableEndpointRoutes)
 	c.EnableHealthChecking = viper.GetBool(EnableHealthChecking)
+	c.EnableEndpointHealthChecking = viper.GetBool(EnableEndpointHealthChecking)
 	c.EnablePolicy = strings.ToLower(viper.GetString(EnablePolicy))
 	c.EnableTracing = viper.GetBool(EnableTracing)
 	c.EnableNodePort = viper.GetBool(EnableNodePort)


### PR DESCRIPTION
Chaining mode means that we can't allocate IPs and thus the endpoint connectivity health checking must be disabled.

Fixes: #9260 
Fixes: #8743

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9460)
<!-- Reviewable:end -->
