### PR TITLE
.travis: disable go modules when installing dependencies

### DIFF
--- a/.travis/prepare.sh
+++ b/.travis/prepare.sh
@@ -14,6 +14,7 @@ rm $CLANG_FILE
 NEWPATH="/usr/local/clang/bin"
 export PATH="$NEWPATH:$PATH"
 
-go get github.com/cilium/go-bindata/go-bindata
-go get golang.org/x/tools/cmd/cover
-go get github.com/mattn/goveralls
+# disable go modules to avoid downloading all dependencies when doing go get
+GO111MODULE=off go get github.com/cilium/go-bindata/go-bindata
+GO111MODULE=off go get golang.org/x/tools/cmd/cover
+GO111MODULE=off go get github.com/mattn/goveralls

--- a/Makefile
+++ b/Makefile
@@ -323,7 +323,7 @@ gofmt:
 
 govet:
 	@$(ECHO_CHECK) vetting all GOFILES...
-	$(QUIET)$(GO) vet \
+	$(QUIET) $(GOLIST) $(GO) vet \
     ./api/... \
     ./bugtool/... \
     ./cilium/... \


### PR DESCRIPTION
Fixes: d1fecef5d46f ("vendor: add go-mod support")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9462)
<!-- Reviewable:end -->
