### PR TITLE
pkg/lock: fix StoppableWaitGroup tests

### DIFF
--- a/pkg/lock/stoppable_waitgroup_test.go
+++ b/pkg/lock/stoppable_waitgroup_test.go
@@ -182,9 +182,9 @@ func (s *SemaphoredMutexSuite) TestParallelism(c *C) {
 	}()
 	adds := int64(0)
 	var wg sync.WaitGroup
+	wg.Add(10)
 	for i := 0; i < 10; i++ {
 		go func() {
-			wg.Add(1)
 			defer wg.Done()
 			for a := range in {
 				if a == 0 {


### PR DESCRIPTION
As the WaitGroup Add function might be executed after Wait()
is called golang will return a panic.

> WaitGroup is reused before previous Wait has returned

To avoid doing it so, one must Add the number of go routines that will
execute Done() before those go routines are scheduled.

Fixes: a34e50160873 ("use StoppableWaitGroup to make sure k8s caches were synced with datapath")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9465)
<!-- Reviewable:end -->
