### PR TITLE
Documentation: remove stale GH issue link

### DIFF
--- a/Documentation/policy/index.rst
+++ b/Documentation/policy/index.rst
@@ -23,10 +23,6 @@ mechanisms:
   method does not automatically distribute policies to all agents. It is in the
   responsibility of the user to import the policy in all required agents.
 
-.. versionadded:: future
-   Use of the `KVstore to distribute security policies <https://github.com/cilium/cilium/issues/3554>`_
-   is on the roadmap but has not been implemented yet.
-
 .. toctree::
    :maxdepth: 1
    :glob:


### PR DESCRIPTION
The policy intro pointed to an issue which has since been closed; a closed issue
will not be added in a future version, so just remove the link.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9471)
<!-- Reviewable:end -->
