### PR TITLE
v1.4 backports 2019-10-22

### DIFF
--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -229,6 +229,7 @@ func copyCiliumInfoCommands(cmdDir string, k8sPods []string) []string {
 		"cilium status --verbose",
 		"cilium identity list",
 		"cilium-health status",
+		"cilium node list",
 	}
 	var commands []string
 


### PR DESCRIPTION
 * #9417 -- bugtool: add `cilium node list` output (@ianvernon)

Once this PR is merged, you can update the PR labels via:
```
$ for pr in 9417; do contrib/backporting/set-labels.py $pr done 1.4; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9474)
<!-- Reviewable:end -->
