### PR TITLE
v1.5 backports 2019-10-22

### DIFF
--- a/Documentation/gettingstarted/clustermesh.rst
+++ b/Documentation/gettingstarted/clustermesh.rst
@@ -235,7 +235,7 @@ chapter into all of your clusters:
 
 .. code:: bash
 
-    kubectl apply -f clustermesh.yaml
+    kubectl -n kube-system apply -f clustermesh.yaml
 
 2. Restart the cilium-agent in all clusters so it picks up the new cluster
    name, cluster id and mounts the ``cilium-clustermesh`` secret. Cilium will

--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -250,6 +250,7 @@ func copyCiliumInfoCommands(cmdDir string, k8sPods []string) []string {
 		"cilium status --verbose",
 		"cilium identity list",
 		"cilium-health status",
+		"cilium node list",
 	}
 	var commands []string
 

--- a/pkg/k8s/factory_functions.go
+++ b/pkg/k8s/factory_functions.go
@@ -223,6 +223,21 @@ func EqualV1Node(node1, node2 *types.Node) bool {
 			return false
 		}
 	}
+	if len(node1.SpecTaints) != len(node2.SpecTaints) {
+		return false
+	}
+	for i, taint2 := range node2.SpecTaints {
+		taint1 := node1.SpecTaints[i]
+		if !taint1.MatchTaint(&taint2) {
+			return false
+		}
+		if taint1.Value != taint2.Value {
+			return false
+		}
+		if !taint1.TimeAdded.Equal(taint2.TimeAdded) {
+			return false
+		}
+	}
 	return true
 }
 
@@ -471,6 +486,7 @@ func ConvertToNode(obj interface{}) interface{} {
 			ObjectMeta:      concreteObj.ObjectMeta,
 			StatusAddresses: concreteObj.Status.Addresses,
 			SpecPodCIDR:     concreteObj.Spec.PodCIDR,
+			SpecTaints:      concreteObj.Spec.Taints,
 		}
 		*concreteObj = v1.Node{}
 		return p
@@ -486,6 +502,7 @@ func ConvertToNode(obj interface{}) interface{} {
 				ObjectMeta:      node.ObjectMeta,
 				StatusAddresses: node.Status.Addresses,
 				SpecPodCIDR:     node.Spec.PodCIDR,
+				SpecTaints:      node.Spec.Taints,
 			},
 		}
 		*node = v1.Node{}

--- a/pkg/k8s/factory_functions_test.go
+++ b/pkg/k8s/factory_functions_test.go
@@ -17,6 +17,8 @@
 package k8s
 
 import (
+	"time"
+
 	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/checker"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -543,6 +545,105 @@ func (s *K8sSuite) Test_EqualV1Node(c *C) {
 				},
 			},
 			want: true,
+		},
+		{
+			name: "Nodes with the same taints and different specs should return true because he don't care about the spec",
+			args: args{
+				o1: &types.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "Node1",
+					},
+					SpecTaints: []core_v1.Taint{
+						{
+							Key:    "key",
+							Value:  "value",
+							Effect: "no-effect",
+						},
+					},
+					SpecPodCIDR: "192.168.0.0/10",
+				},
+				o2: &types.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "Node1",
+					},
+					SpecTaints: []core_v1.Taint{
+						{
+							Key:    "key",
+							Value:  "value",
+							Effect: "no-effect",
+						},
+					},
+					SpecPodCIDR: "127.0.0.1/10",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Nodes with the same taints and different specs should return true because he don't care about the spec",
+			args: args{
+				o1: &types.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "Node1",
+					},
+					SpecTaints: []core_v1.Taint{
+						{
+							Key:       "key",
+							Value:     "value",
+							Effect:    "no-effect",
+							TimeAdded: func() *metav1.Time { return &metav1.Time{Time: time.Unix(1, 1)} }(),
+						},
+					},
+					SpecPodCIDR: "192.168.0.0/10",
+				},
+				o2: &types.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "Node1",
+					},
+					SpecTaints: []core_v1.Taint{
+						{
+							Key:       "key",
+							Value:     "value",
+							Effect:    "no-effect",
+							TimeAdded: func() *metav1.Time { return &metav1.Time{Time: time.Unix(1, 1)} }(),
+						},
+					},
+					SpecPodCIDR: "127.0.0.1/10",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Nodes with the different taints and different specs should return true because he don't care about the spec",
+			args: args{
+				o1: &types.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "Node1",
+					},
+					SpecTaints: []core_v1.Taint{
+						{
+							Key:    "key",
+							Value:  "value",
+							Effect: "no-effect",
+						},
+					},
+					SpecPodCIDR: "192.168.0.0/10",
+				},
+				o2: &types.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "Node1",
+					},
+					SpecTaints: []core_v1.Taint{
+						{
+							Key:       "key",
+							Value:     "value",
+							Effect:    "no-effect",
+							TimeAdded: func() *metav1.Time { return &metav1.Time{Time: time.Unix(1, 1)} }(),
+						},
+					},
+					SpecPodCIDR: "127.0.0.1/10",
+				},
+			},
+			want: false,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/k8s/types/types.go
+++ b/pkg/k8s/types/types.go
@@ -64,6 +64,7 @@ type Node struct {
 	Type            v1.NodeAddressType
 	StatusAddresses []v1.NodeAddress
 	SpecPodCIDR     string
+	SpecTaints      []v1.Taint
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/k8s/types/zz_generated.deepcopy.go
+++ b/pkg/k8s/types/zz_generated.deepcopy.go
@@ -149,6 +149,13 @@ func (in *Node) DeepCopyInto(out *Node) {
 		*out = make([]v1.NodeAddress, len(*in))
 		copy(*out, *in)
 	}
+	if in.SpecTaints != nil {
+		in, out := &in.SpecTaints, &out.SpecTaints
+		*out = make([]v1.Taint, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 


### PR DESCRIPTION
 * #9417 -- bugtool: add `cilium node list` output (@ianvernon)
 * #9427 -- docs: Fix clustermesh secrets namespace (@joestringer)
 * #9423 -- pkg/k8s: consider node taints as part of node equalness (@aanm)

Once this PR is merged, you can update the PR labels via:
```
$ for pr in 9417 9427 9423; do contrib/backporting/set-labels.py $pr done 1.5; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9475)
<!-- Reviewable:end -->
