### PR TITLE
v1.6 backports 2019-10-22

### DIFF
--- a/pkg/aws/ec2/ec2.go
+++ b/pkg/aws/ec2/ec2.go
@@ -284,9 +284,8 @@ func (c *Client) GetSubnets() (types.SubnetMap, error) {
 		for _, tag := range s.Tags {
 			if *tag.Key == "Name" {
 				subnet.Name = *tag.Value
-			} else {
-				subnet.Tags[*tag.Key] = *tag.Value
 			}
+			subnet.Tags[*tag.Key] = *tag.Value
 		}
 
 		subnets[subnet.ID] = subnet

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -372,6 +372,9 @@ func decodeIPSecKey(keyRaw string) (int, []byte, error) {
 	// As we have released the v1.4.0 docs telling the users to write the
 	// k8s secret with the prefix "0x" we have to remove it if it is present,
 	// so we can decode the secret.
+	if keyRaw == "\"\"" {
+		return 0, nil, nil
+	}
 	keyTrimmed := strings.TrimPrefix(keyRaw, "0x")
 	key, err := hex.DecodeString(keyTrimmed)
 	return len(keyTrimmed), key, err

--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -37,7 +37,7 @@ var _ = Suite(&IPSecSuitePrivileged{})
 
 var (
 	path           = "ipsec_keys_test"
-	keysDat        = []byte("1 hmac(sha256) 0123456789abcdef0123456789abcdef cbc(aes) 0123456789abcdef0123456789abcdef\n1 hmac(sha256) 0123456789abcdef0123456789abcdef cbc(aes) 0123456789abcdef0123456789abcdef foobar\n")
+	keysDat        = []byte("1 hmac(sha256) 0123456789abcdef0123456789abcdef cbc(aes) 0123456789abcdef0123456789abcdef\n1 hmac(sha256) 0123456789abcdef0123456789abcdef cbc(aes) 0123456789abcdef0123456789abcdef foobar\n1 digest_null \"\" cipher_null \"\"\n")
 	keysAeadDat    = []byte("6 rfc4106(gcm(aes)) 44434241343332312423222114131211f4f3f2f1 128\n")
 	invalidKeysDat = []byte("1 test abcdefghijklmnopqrstuvwzyzABCDEF test abcdefghijklmnopqrstuvwzyzABCDEF\n")
 )

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -444,6 +444,8 @@ func upsertIPsecLog(err error, spec string, loc, rem *net.IPNet, spi uint8) {
 	})
 	if err != nil {
 		scopedLog.WithError(err).Error("IPsec enable failed")
+	} else {
+		scopedLog.Debug("IPsec enable succeeded")
 	}
 }
 

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -560,6 +560,9 @@ func (e *Endpoint) startRegenerationFailureHandler() {
 				// context to a controller (e.g., endpoint.aliveCtx)?
 				ParentContext: ctx,
 				Reason:        reasonRegenRetry,
+				// Completely rewrite the endpoint - we don't know the nature
+				// of the failure, simply that something failed.
+				RegenerationLevel: regeneration.RegenerateWithDatapathRewrite,
 			}
 			if success := <-e.Regenerate(r); success {
 				return nil


### PR DESCRIPTION
 * #9332 -- Support null encrytion/auth (@lbernail)
 * #9405 -- IPSEC: add upsert logs in debug mode (@lbernail)
 * #9431 -- eni: Allow selecting subnet by Name tag (@jaffcheng)
 * #9455 -- endpoint: regeneration controller runs with `RegenerateWithDatapathRewrite` (@ianvernon)

Once this PR is merged, you can update the PR labels via:
```
$ for pr in 9332 9405 9431 9455; do contrib/backporting/set-labels.py $pr done 1.6; done
```

Not backported due conflicts! @jrajahalme PTAL

 * #9395 -- xds: Allow endpoints to wait for the current policy version to be acked (@jrajahalme)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9476)
<!-- Reviewable:end -->
