### PR TITLE
docs: bump minimal k8s supported version to v1.11.0

### DIFF
--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -241,6 +241,8 @@ IMPORTANT: Changes required before upgrading to 1.7.0
    Do not upgrade to 1.7.0 before reading the following section and completing
    the required steps.
 
+* Cilium has bumped the minimal kubernetes version supported to v1.11.0.
+
 * If ``kvstore`` is setup with ``etcd`` **and** TLS is enabled, the field name
   ``ca-file`` will have its usage deprecated and will be removed in Cilium v1.8.0.
   The new field name, ``trusted-ca-file``, can be used since Cilium v1.1.0.


### PR DESCRIPTION
The replacement of the deprecated APIs in v1.16.0 are available since
v1.11.0. As Cilium uses the k8s client library of v1.16.0 and to prevent
further unknown bugs by the usage of both versions, Cilium needs to
increment the minimal supported version to v1.11.0.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9477)
<!-- Reviewable:end -->
