### PR TITLE
Documentation: Improve external etcd documentation wording

### DIFF
--- a/Documentation/gettingstarted/k8s-install-external-etcd.rst
+++ b/Documentation/gettingstarted/k8s-install-external-etcd.rst
@@ -39,7 +39,9 @@ when to use a kvstore:
 
 .. include:: requirements_intro.rst
 
-Configure the External Etcd
+You will also need an external kvstore such as etcd.
+
+Configure Cilium
 ===========================
 
 When using an external kvstore, the address of the external kvstore needs to be


### PR DESCRIPTION
Signed-off-by: Melissa Peiffer <mbp83@nau.edu>

Renamed 'Configure the External etcd' to 'Configure Cilium' for clarity.
Listed an external kvstroe such as etcd as a requirement for the
external etcd installation guide.

Fixes: #9401

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9478)
<!-- Reviewable:end -->
