### PR TITLE
endpoint: Check interface value of proxy field

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -78,7 +78,7 @@ func (e *Endpoint) updateNetworkPolicy(proxyWaitGroup *completion.WaitGroup) (re
 		return nil, nil
 	}
 
-	if e.proxy == nil {
+	if e.isProxyDisabled() {
 		return fmt.Errorf("can't update network policy, proxy disabled"), nil
 	}
 


### PR DESCRIPTION
Check a value of the `proxy` field when detecting whether the L7 proxy is disabled.

In Go, an interface value is nil, if both type and value of the interface are unset \[1\]. Therefore, when checking whether the proxy is enabled, we need to check also for its value.

Fixes the following error when running cilium-agent with `--install-iptables-rules=false` and `--masquerade=false`:

```
github.com/cilium/cilium/pkg/proxy.(*Proxy).UpdateNetworkPolicy(0x0, 0x38d1140, 0xc001078000, 0xc00005a640, 0xc000990000, 0xc00005a5c0, 0x5daf3749, 0x24358b28, 0x17432d246ba)
        /go/src/github.com/cilium/cilium/pkg/proxy/proxy.go:640 +0x26
github.com/cilium/cilium/pkg/endpoint.(*Endpoint).updateNetworkPolicy(0xc001078000, 0xc00005a5c0, 0x4ed36c0, 0x1, 0x1)
        /go/src/github.com/cilium/cilium/pkg/endpoint/policy.go:86 +0xa2
github.com/cilium/cilium/pkg/endpoint.(*Endpoint).runPreCompilationSteps(0xc001078000, 0xc00090a000, 0x0, 0x0)
        /go/src/github.com/cilium/cilium/pkg/endpoint/bpf.go:740 +0xb04
github.com/cilium/cilium/pkg/endpoint.(*Endpoint).regenerateBPF(0xc001078000, 0xc00090a000, 0x0, 0x0, 0x0, 0x0)
        /go/src/github.com/cilium/cilium/pkg/endpoint/bpf.go:503 +0x1e0
github.com/cilium/cilium/pkg/endpoint.(*Endpoint).regenerate(0xc001078000, 0xc00090a000, 0x0, 0x0)
        /go/src/github.com/cilium/cilium/pkg/endpoint/policy.go:341 +0xa5c
github.com/cilium/cilium/pkg/endpoint.(*EndpointRegenerationEvent).Handle(0xc000ebf560, 0xc0007dcb40)
        /go/src/github.com/cilium/cilium/pkg/endpoint/events.go:57 +0x459
github.com/cilium/cilium/pkg/eventqueue.(*EventQueue).Run.func1()
        /go/src/github.com/cilium/cilium/pkg/eventqueue/eventqueue.go:260 +0x187
```

\[1\]: https://golang.org/doc/faq#nil_error

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9479)
<!-- Reviewable:end -->
