### PR TITLE
toops/maptool: run GOCLEAN arguments as part of go clean

### DIFF
--- a/tools/maptool/Makefile
+++ b/tools/maptool/Makefile
@@ -11,7 +11,7 @@ all: $(TARGET)
 clean:
 	@$(ECHO_CLEAN)
 	-$(QUIET)rm -f $(TARGET)
-	$(QUIET)$(GO) clean
+	$(QUIET)$(GO) clean $(GOCLEAN)
 
 install:
 	$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)


### PR DESCRIPTION
To avoid downloading golang dependencies as part of go modules, go clean
should be using the argument -mod=vendor as dependencies are already
locally available.

Fixes: d1fecef5d46f ("vendor: add go-mod support")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9480)
<!-- Reviewable:end -->
