### PR TITLE
endpoint: Do not fail to regenerate endpoint when running w/o L7 proxy

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -63,6 +63,7 @@ cilium-agent [flags]
       --enable-ipv4                                           Enable IPv4 support (default true)
       --enable-ipv6                                           Enable IPv6 support (default true)
       --enable-k8s-event-handover                             Enable k8s event handover to kvstore for improved scalability
+      --enable-l7-proxy                                       Enable L7 proxy for L7 policy enforcement (default true)
       --enable-local-node-route                               Enable installation of the route which points the allocation prefix of the local node (default true)
       --enable-node-port                                      Enable NodePort type services by Cilium (beta)
       --enable-policy string                                  Enable policy enforcement (default "default")

--- a/Documentation/gettingstarted/ipvlan.rst
+++ b/Documentation/gettingstarted/ipvlan.rst
@@ -92,6 +92,7 @@ Example ConfigMap extract for ipvlan in pure L3 mode:
      --set global.ipvlan.masterDevice=bond0 \
      --set global.tunnel=disabled \
      --set global.installIptablesRules=false \
+     --set global.l7Proxy.enabled=false \
      --set global.autoDirectNodeRoutes=true \
      > cilium.yaml
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -433,11 +433,11 @@ func NewDaemon(ctx context.Context, dp datapath.Datapath) (*Daemon, *endpointRes
 	// daemon's proxy into each endpoint.
 	bootstrapStats.proxyStart.Start()
 	// FIXME: Make the port range configurable.
-	if option.Config.InstallIptRules {
+	if option.Config.EnableL7Proxy {
 		d.l7Proxy = proxy.StartProxySupport(10000, 20000, option.Config.RunDir,
 			option.Config.AccessLog, &d, option.Config.AgentLabels, d.datapath, d.endpointManager)
 	} else {
-		log.Warning("L7 proxies not supported when --install-iptables-rules=\"false\"")
+		log.Info("L7 proxies are disabled")
 	}
 	bootstrapStats.proxyStart.End(true)
 

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -332,7 +332,7 @@ func init() {
 	flags.String(option.EnablePolicy, option.DefaultEnforcement, "Enable policy enforcement")
 	option.BindEnv(option.EnablePolicy)
 
-	flags.Bool(option.EnableL7Proxy, true, "Enable L7 proxy for L7 policy enforcement")
+	flags.Bool(option.EnableL7Proxy, defaults.EnableL7Proxy, "Enable L7 proxy for L7 policy enforcement")
 	option.BindEnv(option.EnableL7Proxy)
 
 	flags.Bool(option.EnableTracing, false, "Enable tracing while determining policy (debugging)")

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -332,6 +332,9 @@ func init() {
 	flags.String(option.EnablePolicy, option.DefaultEnforcement, "Enable policy enforcement")
 	option.BindEnv(option.EnablePolicy)
 
+	flags.Bool(option.EnableL7Proxy, true, "Enable L7 proxy for L7 policy enforcement")
+	option.BindEnv(option.EnableL7Proxy)
+
 	flags.Bool(option.EnableTracing, false, "Enable tracing while determining policy (debugging)")
 	option.BindEnv(option.EnableTracing)
 
@@ -1014,6 +1017,10 @@ func initEnv(cmd *cobra.Command) {
 		}
 	default:
 		log.WithField(logfields.DatapathMode, option.Config.DatapathMode).Fatal("Invalid datapath mode")
+	}
+
+	if option.Config.EnableL7Proxy && !option.Config.InstallIptRules {
+		log.Fatal("L7 proxy requires iptables rules (--install-iptables-rules=\"true\")")
 	}
 
 	if option.Config.EnableIPSec && option.Config.Tunnel == option.TunnelDisabled && option.Config.EncryptInterface == "" {

--- a/daemon/fqdn.go
+++ b/daemon/fqdn.go
@@ -220,10 +220,10 @@ func (d *Daemon) bootstrapFQDN(restoredEndpoints *endpointRestoreState, preCache
 		}
 	}
 
-	// Do not start the proxy in dry mode or if iptables rules should not be installed.
+	// Do not start the proxy in dry mode or if L7 proxy is disabled.
 	// The proxy would not get any traffic in the dry mode anyway, and some of the socket
 	// operations require privileges not available in all unit tests.
-	if option.Config.DryMode || !option.Config.InstallIptRules {
+	if option.Config.DryMode || !option.Config.EnableL7Proxy {
 		return nil
 	}
 

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -193,6 +193,12 @@ data:
   flannel-manage-existing-containers: "{{ .Values.global.flannel.manageExistingContainers }}"
 {{- end }}
 
+{{- if .Values.global.l7Proxy }}
+
+  # Enables L7 proxy for L7 policy enforcement and visibility
+  enable-l7-proxy: {{ .Values.global.l7Proxy.enabled | quote }}
+{{- end }}
+
   # DNS Polling periodically issues a DNS lookup for each `matchName` from
   # cilium-agent. The result is used to regenerate endpoint policy.
   # DNS lookups are repeated with an interval of 5 seconds, and are made for

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -130,6 +130,9 @@ const (
 	// EnableIPv6 is the default value for IPv6 enablement
 	EnableIPv6 = true
 
+	// EnableL7Proxy is the default value for L7 proxy enablement
+	EnableL7Proxy = true
+
 	// PreAllocateMaps is the default value for BPF map preallocation
 	PreAllocateMaps = true
 

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -79,7 +79,7 @@ func (e *Endpoint) updateNetworkPolicy(proxyWaitGroup *completion.WaitGroup) (re
 	}
 
 	if e.isProxyDisabled() {
-		return fmt.Errorf("can't update network policy, proxy disabled"), nil
+		return nil, nil
 	}
 
 	// Publish the updated policy to L7 proxies.

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1271,6 +1271,7 @@ var (
 		EnableEndpointHealthChecking: defaults.EnableEndpointHealthChecking,
 		EnableIPv4:                   defaults.EnableIPv4,
 		EnableIPv6:                   defaults.EnableIPv6,
+		EnableL7Proxy:                defaults.EnableL7Proxy,
 		ToFQDNsMaxIPsPerHost:         defaults.ToFQDNsMaxIPsPerHost,
 		KVstorePeriodicSync:          defaults.KVstorePeriodicSync,
 		KVstoreConnectivityTimeout:   defaults.KVstoreConnectivityTimeout,

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -132,6 +132,9 @@ const (
 	// EnablePolicy enables policy enforcement in the agent.
 	EnablePolicy = "enable-policy"
 
+	// EnableL7Proxy is the name of the option to enable L7 proxy
+	EnableL7Proxy = "enable-l7-proxy"
+
 	// EnableTracing enables tracing mode in the agent.
 	EnableTracing = "enable-tracing"
 
@@ -977,6 +980,9 @@ type DaemonConfig struct {
 	// EnableIPv6 is true when IPv6 is enabled
 	EnableIPv6 bool
 
+	// EnableL7Proxy is the option to enable L7 proxy
+	EnableL7Proxy bool
+
 	// EnableIPSec is true when IPSec is enabled
 	EnableIPSec bool
 
@@ -1606,6 +1612,7 @@ func (c *DaemonConfig) Populate() {
 	c.EnableEndpointHealthChecking = viper.GetBool(EnableEndpointHealthChecking)
 	c.EnableLocalNodeRoute = viper.GetBool(EnableLocalNodeRoute)
 	c.EnablePolicy = strings.ToLower(viper.GetString(EnablePolicy))
+	c.EnableL7Proxy = viper.GetBool(EnableL7Proxy)
 	c.EnableTracing = viper.GetBool(EnableTracing)
 	c.EnableNodePort = viper.GetBool(EnableNodePort)
 	c.EncryptInterface = viper.GetString(EncryptInterface)

--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -15,12 +15,14 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
 	"strings"
 
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 const (
@@ -111,6 +113,10 @@ func (i *IngressRule) sanitize() error {
 		if l3Members[member] > 0 && len(i.ToPorts) > 0 && !l3DependentL4Support[member] {
 			return fmt.Errorf("Combining %s and ToPorts is not supported yet", member)
 		}
+	}
+
+	if len(l7Members) > 0 && !option.Config.EnableL7Proxy {
+		return errors.New("L7 policy is not supported since L7 proxy is not enabled")
 	}
 	for member := range l7Members {
 		if l7Members[member] > 0 && !l7IngressSupport[member] {
@@ -208,6 +214,10 @@ func (e *EgressRule) sanitize() error {
 		if l3Members[member] > 0 && len(e.ToPorts) > 0 && !l3DependentL4Support[member] {
 			return fmt.Errorf("Combining %s and ToPorts is not supported yet", member)
 		}
+	}
+
+	if len(l7Members) > 0 && !option.Config.EnableL7Proxy {
+		return errors.New("L7 policy is not supported since L7 proxy is not enabled")
 	}
 	for member := range l7Members {
 		if l7Members[member] > 0 && !l7EgressSupport[member] {


### PR DESCRIPTION
It is expected that in some deployments the L7 proxy will be disabled. Currently, it can be disabled when `--install-iptables-rules=false` is set which can happen when e.g.  running in the ipvlan mode or
w/o netfilter/iptables.

To play nicely with such deployments, do not fail the endpoint regeneration when the L7 proxy is disabled.

Fixes #9518

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9481)
<!-- Reviewable:end -->
