### PR TITLE
Unhide the Kubernetes namespace parameter

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -103,6 +103,7 @@ cilium-agent [flags]
       --ipvlan-master-device string                           Device facing external network acting as ipvlan master (default "undefined")
       --k8s-api-server string                                 Kubernetes API server URL
       --k8s-kubeconfig-path string                            Absolute path of the kubernetes kubeconfig file
+      --k8s-namespace string                                  Name of the Kubernetes namespace in which Cilium is deployed in
       --k8s-require-ipv4-pod-cidr                             Require IPv4 PodCIDR to be specified in node resource
       --k8s-require-ipv6-pod-cidr                             Require IPv6 PodCIDR to be specified in node resource
       --k8s-watcher-endpoint-selector string                  K8s endpoint watcher will watch for these k8s endpoints (default "metadata.name!=kube-scheduler,metadata.name!=kube-controller-manager,metadata.name!=etcd-operator,metadata.name!=gcp-controller-manager")

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -37,6 +37,7 @@ cilium-operator [flags]
       --k8s-client-burst int                   Burst value allowed for the K8s client
       --k8s-client-qps float32                 Queries per second limit for the K8s client
       --k8s-kubeconfig-path string             Absolute path of the kubernetes kubeconfig file
+      --k8s-namespace string                   Name of the Kubernetes namespace in which Cilium Operator is deployed in
       --kvstore string                         Key-value store type
       --kvstore-opt map                        Key-value store options (default map[])
       --metrics-address string                 Address to serve Prometheus metrics (default ":6942")

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -409,7 +409,6 @@ func init() {
 	option.BindEnv(option.K8sKubeConfigPath)
 
 	flags.String(option.K8sNamespaceName, "", "Name of the Kubernetes namespace in which Cilium is deployed in")
-	flags.MarkHidden(option.K8sNamespaceName)
 	option.BindEnv(option.K8sNamespaceName)
 
 	flags.Bool(option.K8sRequireIPv4PodCIDRName, false, "Require IPv4 PodCIDR to be specified in node resource")

--- a/operator/main.go
+++ b/operator/main.go
@@ -128,7 +128,6 @@ func init() {
 	flags.DurationVar(&kvNodeGCInterval, "nodes-gc-interval", time.Minute*2, "GC interval for nodes store in the kvstore")
 	flags.Int64Var(&eniParallelWorkers, "eni-parallel-workers", defaults.ENIParallelWorkers, "Maximum number of parallel workers used by ENI allocator")
 	flags.String(option.K8sNamespaceName, "", "Name of the Kubernetes namespace in which Cilium Operator is deployed in")
-	flags.MarkHidden(option.K8sNamespaceName)
 	option.BindEnv(option.K8sNamespaceName)
 
 	flags.IntVar(&unmanagedKubeDnsWatcherInterval, "unmanaged-pod-watcher-interval", 15, "Interval to check for unmanaged kube-dns pods (0 to disable)")


### PR DESCRIPTION
Due to its hidden nature, the parameter is not available in the [official documentation](https://docs.cilium.io/en/v1.6/cmdref/cilium-operator/). This makes it difficult to understanding its purpose, especially since the parameter shows up in the rendered output of the Helm charts.

Thus, the primary motivation for unhiding is to increase transparency and clarity.

I wasn't entirely sure what the purpose of hiding the parameter was in the first place when it was first introduced to the agent (seemingly in #6333) and later copied over to the operator (#8463). My guess is that this was to hide Kubernetes-specific details; however, at least the operator seems to expose other Kubernetes-related parameters already in addition to AWS ones, so to me it looks like exposure of the namespace flag would be more consistent at this point.

/cc @aanm who pointed me at the root cause [on Slack](https://cilium.slack.com/archives/C53TG4J4R/p1571825531024700).

Signed-off-by: Timo Reimann <ttr314@googlemail.com>

```release-note
Unhide --k8s-namespace parameter
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9485)
<!-- Reviewable:end -->
