### PR TITLE
daemon: cancel context for daemon before running cleanup functions

### DIFF
--- a/api/v1/server/configure_cilium.go
+++ b/api/v1/server/configure_cilium.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cilium/cilium/api/v1/server/restapi/policy"
 	"github.com/cilium/cilium/api/v1/server/restapi/prefilter"
 	"github.com/cilium/cilium/api/v1/server/restapi/service"
+	"github.com/cilium/cilium/pkg/logging"
 )
 
 //go:generate swagger generate server --target ../../v1 --name Cilium --spec ../openapi.yaml --api-package restapi --server-package server --default-scheme unix
@@ -254,6 +255,7 @@ func configureAPI(api *restapi.CiliumAPI) http.Handler {
 	}
 
 	api.ServerShutdown = func() {
+		logging.DefaultLogger.Debug("canceling server context")
 		serverCancel()
 	}
 

--- a/daemon/cleanup.go
+++ b/daemon/cleanup.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"os"
 	"os/signal"
 	"sync"
@@ -34,6 +35,8 @@ var (
 	cleanupFuncs = &cleanupFuncList{
 		funcs: make([]func(), 0),
 	}
+
+	sigHandlerCancel context.CancelFunc
 )
 
 type cleanupFuncList struct {
@@ -62,6 +65,8 @@ func registerSigHandler() <-chan struct{} {
 	go func() {
 		for s := range sig {
 			log.WithField("signal", s).Info("Exiting due to signal")
+			log.Debug("canceling context in signal handler")
+			sigHandlerCancel()
 			pidfile.Clean()
 			Clean()
 			cleanupFuncs.Run()


### PR DESCRIPTION
Cancel the context before we run `Clean`, which blocks on waiting on a
`sync.WaitGroup`. This should reduce the likelihood that we see `JoinEP`
failures in the logs from enpdoint regenerations which are in flight as Cilium
is being terminated. Add logs for easier debugging showing when contexts
associated with termination are canceled.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9487)
<!-- Reviewable:end -->
