### PR TITLE
daemon: move base program compile to loader pkg

### DIFF
--- a/daemon/config.go
+++ b/daemon/config.go
@@ -87,7 +87,7 @@ func (h *patchConfig) Handle(params PatchConfigParams) middleware.Responder {
 	if changes > 0 {
 		// Only recompile if configuration has changed.
 		log.Debug("daemon configuration has changed; recompiling base programs")
-		if err := d.Datapath().Loader().CompileBasePrograms(d.ctx, d, d.mtuConfig.GetDeviceMTU(), d.iptablesManager, d.l7Proxy, d.ipam); err != nil {
+		if err := d.Datapath().Loader().Reinitialize(d.ctx, d, d.mtuConfig.GetDeviceMTU(), d.iptablesManager, d.l7Proxy, d.ipam); err != nil {
 			msg := fmt.Errorf("Unable to recompile base programs: %s", err)
 			return api.Error(PatchConfigFailureCode, msg)
 		}

--- a/daemon/config.go
+++ b/daemon/config.go
@@ -87,7 +87,7 @@ func (h *patchConfig) Handle(params PatchConfigParams) middleware.Responder {
 	if changes > 0 {
 		// Only recompile if configuration has changed.
 		log.Debug("daemon configuration has changed; recompiling base programs")
-		if err := d.compileBase(); err != nil {
+		if err := d.Datapath().Loader().CompileBasePrograms(d.ctx, d, d.mtuConfig.GetDeviceMTU(), d.iptablesManager, d.l7Proxy, d.ipam); err != nil {
 			msg := fmt.Errorf("Unable to recompile base programs: %s", err)
 			return api.Error(PatchConfigFailureCode, msg)
 		}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -81,27 +81,6 @@ const (
 	AutoCIDR = "auto"
 )
 
-const (
-	initArgLib int = iota
-	initArgRundir
-	initArgIPv4NodeIP
-	initArgIPv6NodeIP
-	initArgMode
-	initArgDevice
-	initArgDevicePreFilter
-	initArgModePreFilter
-	initArgMTU
-	initArgIPSec
-	initArgMasquerade
-	initArgEncryptInterface
-	initArgHostReachableServices
-	initArgHostReachableServicesUDP
-	initArgCgroupRoot
-	initArgBpffsRoot
-	initArgNodePort
-	initArgMax
-)
-
 // Daemon is the cilium daemon that is in charge of perform all necessary plumbing,
 // monitoring when a LXC starts.
 type Daemon struct {
@@ -225,7 +204,7 @@ func (d *Daemon) init() error {
 			}
 		}
 
-		if err := d.compileBase(); err != nil {
+		if err := d.Datapath().Loader().CompileBasePrograms(d.ctx, d, d.mtuConfig.GetDeviceMTU(), d.iptablesManager, d.l7Proxy, d.ipam); err != nil {
 			return err
 		}
 
@@ -662,7 +641,7 @@ func (d *Daemon) attachExistingInfraContainers() {
 // endpoints may or may not have successfully regenerated.
 func (d *Daemon) TriggerReloadWithoutCompile(reason string) (*sync.WaitGroup, error) {
 	log.Debugf("BPF reload triggered from %s", reason)
-	if err := d.compileBase(); err != nil {
+	if err := d.Datapath().Loader().CompileBasePrograms(d.ctx, d, d.mtuConfig.GetDeviceMTU(), d.iptablesManager, d.l7Proxy, d.ipam); err != nil {
 		return nil, fmt.Errorf("Unable to recompile base programs from %s: %s", reason, err)
 	}
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -204,7 +204,7 @@ func (d *Daemon) init() error {
 			}
 		}
 
-		if err := d.Datapath().Loader().CompileBasePrograms(d.ctx, d, d.mtuConfig.GetDeviceMTU(), d.iptablesManager, d.l7Proxy, d.ipam); err != nil {
+		if err := d.Datapath().Loader().Reinitialize(d.ctx, d, d.mtuConfig.GetDeviceMTU(), d.iptablesManager, d.l7Proxy, d.ipam); err != nil {
 			return err
 		}
 
@@ -641,7 +641,7 @@ func (d *Daemon) attachExistingInfraContainers() {
 // endpoints may or may not have successfully regenerated.
 func (d *Daemon) TriggerReloadWithoutCompile(reason string) (*sync.WaitGroup, error) {
 	log.Debugf("BPF reload triggered from %s", reason)
-	if err := d.Datapath().Loader().CompileBasePrograms(d.ctx, d, d.mtuConfig.GetDeviceMTU(), d.iptablesManager, d.l7Proxy, d.ipam); err != nil {
+	if err := d.Datapath().Loader().Reinitialize(d.ctx, d, d.mtuConfig.GetDeviceMTU(), d.iptablesManager, d.l7Proxy, d.ipam); err != nil {
 		return nil, fmt.Errorf("Unable to recompile base programs from %s: %s", reason, err)
 	}
 

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -866,7 +866,7 @@ func initEnv(cmd *cobra.Command) {
 		scopedLog.Fatalf("Invalid %s value %d", option.MaxCtrlIntervalName, option.Config.MaxControllerInterval)
 	}
 
-	checkMinRequirements()
+	linuxdatapath.CheckMinRequirements()
 
 	if err := pidfile.Write(defaults.PidFilePath); err != nil {
 		log.WithField(logfields.Path, defaults.PidFilePath).WithError(err).Fatal("Failed to create Pidfile")

--- a/daemon/debuginfo.go
+++ b/daemon/debuginfo.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	restapi "github.com/cilium/cilium/api/v1/server/restapi/daemon"
 	"github.com/cilium/cilium/api/v1/server/restapi/endpoint"
+	"github.com/cilium/cilium/pkg/datapath/linux"
 	"github.com/cilium/cilium/pkg/debug"
 	"github.com/cilium/cilium/pkg/version"
 
@@ -43,7 +44,7 @@ func (h *getDebugInfo) Handle(params restapi.GetDebuginfoParams) middleware.Resp
 	d := h.daemon
 
 	dr.CiliumVersion = version.Version
-	if kver, err := getKernelVersion(); err != nil {
+	if kver, err := linux.GetKernelVersion(); err != nil {
 		dr.KernelVersion = fmt.Sprintf("Error: %s\n", err)
 	} else {
 		dr.KernelVersion = fmt.Sprintf("%s", kver)

--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -270,7 +270,7 @@ func (d *Daemon) policyAdd(sourceRules policyAPI.Rules, opts *policy.AddOptions,
 	if newPrefixLengths && !bpfIPCache.BackedByLPM() {
 		// Only recompile if configuration has changed.
 		logger.Debug("CIDR policy has changed; recompiling base programs")
-		if err := d.Datapath().Loader().CompileBasePrograms(d.ctx, d, d.mtuConfig.GetDeviceMTU(), d.iptablesManager, d.l7Proxy, d.ipam); err != nil {
+		if err := d.Datapath().Loader().Reinitialize(d.ctx, d, d.mtuConfig.GetDeviceMTU(), d.iptablesManager, d.l7Proxy, d.ipam); err != nil {
 			_ = d.prefixLengths.Delete(prefixes)
 			metrics.PolicyImportErrors.Inc()
 			err2 := fmt.Errorf("Unable to recompile base programs: %s", err)
@@ -576,7 +576,7 @@ func (d *Daemon) policyDelete(labels labels.LabelArray, res chan interface{}) {
 	if !bpfIPCache.BackedByLPM() && prefixesChanged {
 		// Only recompile if configuration has changed.
 		log.Debug("CIDR policy has changed; recompiling base programs")
-		if err := d.Datapath().Loader().CompileBasePrograms(d.ctx, d, d.mtuConfig.GetDeviceMTU(), d.iptablesManager, d.l7Proxy, d.ipam); err != nil {
+		if err := d.Datapath().Loader().Reinitialize(d.ctx, d, d.mtuConfig.GetDeviceMTU(), d.iptablesManager, d.l7Proxy, d.ipam); err != nil {
 			log.WithError(err).Error("Unable to recompile base programs")
 		}
 	}

--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -270,7 +270,7 @@ func (d *Daemon) policyAdd(sourceRules policyAPI.Rules, opts *policy.AddOptions,
 	if newPrefixLengths && !bpfIPCache.BackedByLPM() {
 		// Only recompile if configuration has changed.
 		logger.Debug("CIDR policy has changed; recompiling base programs")
-		if err := d.compileBase(); err != nil {
+		if err := d.Datapath().Loader().CompileBasePrograms(d.ctx, d, d.mtuConfig.GetDeviceMTU(), d.iptablesManager, d.l7Proxy, d.ipam); err != nil {
 			_ = d.prefixLengths.Delete(prefixes)
 			metrics.PolicyImportErrors.Inc()
 			err2 := fmt.Errorf("Unable to recompile base programs: %s", err)
@@ -576,7 +576,7 @@ func (d *Daemon) policyDelete(labels labels.LabelArray, res chan interface{}) {
 	if !bpfIPCache.BackedByLPM() && prefixesChanged {
 		// Only recompile if configuration has changed.
 		log.Debug("CIDR policy has changed; recompiling base programs")
-		if err := d.compileBase(); err != nil {
+		if err := d.Datapath().Loader().CompileBasePrograms(d.ctx, d, d.mtuConfig.GetDeviceMTU(), d.iptablesManager, d.l7Proxy, d.ipam); err != nil {
 			log.WithError(err).Error("Unable to recompile base programs")
 		}
 	}

--- a/pkg/datapath/fake/datapath.go
+++ b/pkg/datapath/fake/datapath.go
@@ -119,6 +119,11 @@ func (f *fakeLoader) CallsMapPath(id uint16) string {
 	return ""
 }
 
+// CompileBasePrograms does nothing.
+func (f *fakeLoader) CompileBasePrograms(ctx context.Context, o datapath.BaseProgramOwner, deviceMTU int, iptMgr datapath.RulesManager, p datapath.Proxy, r datapath.RouteReserver) error {
+	return nil
+}
+
 func (f *fakeDatapath) SetupIPVLAN(netNS string) (int, int, error) {
 	return 0, 0, nil
 }

--- a/pkg/datapath/fake/datapath.go
+++ b/pkg/datapath/fake/datapath.go
@@ -119,8 +119,8 @@ func (f *fakeLoader) CallsMapPath(id uint16) string {
 	return ""
 }
 
-// CompileBasePrograms does nothing.
-func (f *fakeLoader) CompileBasePrograms(ctx context.Context, o datapath.BaseProgramOwner, deviceMTU int, iptMgr datapath.RulesManager, p datapath.Proxy, r datapath.RouteReserver) error {
+// Reinitialize does nothing.
+func (f *fakeLoader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, deviceMTU int, iptMgr datapath.RulesManager, p datapath.Proxy, r datapath.RouteReserver) error {
 	return nil
 }
 

--- a/pkg/datapath/linux/datapath.go
+++ b/pkg/datapath/linux/datapath.go
@@ -53,7 +53,7 @@ func NewDatapath(cfg DatapathConfiguration, ruleManager rulesManager) datapath.D
 		nodeAddressing: NewNodeAddressing(),
 		config:         cfg,
 		ConfigWriter:   &config.HeaderfileWriter{},
-		loader:         &loader.Loader{},
+		loader:         loader.NewLoader(canDisableDwarfRelocations),
 		ruleManager:    ruleManager,
 	}
 

--- a/pkg/datapath/linux/requirements.go
+++ b/pkg/datapath/linux/requirements.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package linux
 
 import (
 	"fmt"
@@ -74,7 +74,8 @@ func parseKernelVersion(ver string) (go_version.Version, error) {
 	return versioncheck.Version(strings.Join(verStrs[:3], "."))
 }
 
-func getKernelVersion() (go_version.Version, error) {
+// GetKernelVersion returns the version of the Linux kernel running on this host.
+func GetKernelVersion() (go_version.Version, error) {
 	var unameBuf unix.Utsname
 	if err := unix.Uname(&unameBuf); err != nil {
 		log.WithError(err).Fatal("kernel version: NOT OK")
@@ -134,8 +135,8 @@ func checkBPFLogs(logType string, fatal bool) {
 	}
 }
 
-func checkMinRequirements() {
-	kernelVersion, err := getKernelVersion()
+func CheckMinRequirements() {
+	kernelVersion, err := GetKernelVersion()
 	if err != nil {
 		log.WithError(err).Fatal("kernel version: NOT OK")
 	}

--- a/pkg/datapath/linux/requirements.go
+++ b/pkg/datapath/linux/requirements.go
@@ -135,6 +135,8 @@ func checkBPFLogs(logType string, fatal bool) {
 	}
 }
 
+// CheckMinRequirements checks that minimum kernel requirements are met for
+// configuring the BPF datapath. If not, fatally exits.
 func CheckMinRequirements() {
 	kernelVersion, err := GetKernelVersion()
 	if err != nil {

--- a/pkg/datapath/linux/requirements_test.go
+++ b/pkg/datapath/linux/requirements_test.go
@@ -14,7 +14,7 @@
 
 // +build !privileged_tests
 
-package main
+package linux
 
 import (
 	"github.com/cilium/cilium/pkg/versioncheck"
@@ -23,7 +23,7 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func (ds *DaemonSuite) TestParseKernelVersion(c *C) {
+func (s *linuxTestSuite) TestParseKernelVersion(c *C) {
 	mustHaveVersion := func(v string) go_version.Version {
 		ver, err := versioncheck.Version(v)
 		c.Assert(err, IsNil)

--- a/pkg/datapath/loader.go
+++ b/pkg/datapath/loader.go
@@ -32,7 +32,7 @@ type Loader interface {
 	DeleteDatapath(ctx context.Context, ifName, direction string) error
 	Unload(ep Endpoint)
 	Init(d ConfigWriter, nodeCfg *LocalNodeConfiguration)
-	CompileBasePrograms(ctx context.Context, o BaseProgramOwner, deviceMTU int, iptMgr RulesManager, p Proxy, r RouteReserver) error
+	Reinitialize(ctx context.Context, o BaseProgramOwner, deviceMTU int, iptMgr RulesManager, p Proxy, r RouteReserver) error
 }
 
 // BaseProgramOwner is any type for which a loader is building base programs.

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -95,8 +95,11 @@ func writePreFilterHeader(preFilter *prefilter.PreFilter, dir string) error {
 	return fw.Flush()
 }
 
-// CompileBasePrograms compiles the base programs managed by this loader.
-func (l *Loader) CompileBasePrograms(ctx context.Context, o datapath.BaseProgramOwner, deviceMTU int, iptMgr datapath.RulesManager, p datapath.Proxy, r datapath.RouteReserver) error {
+// Reinitialize (re-)configures the base datapath configuration including global
+// BPF programs, netfilter rule configuration and reserving routes in IPAM for
+// locally detected prefixes. It may be run upon initial Cilium startup, after
+// restore from a previous Cilium run, or during regular Cilium operation.
+func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, deviceMTU int, iptMgr datapath.RulesManager, p datapath.Proxy, r datapath.RouteReserver) error {
 	var args []string
 	var mode string
 	var ret error

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -1,0 +1,303 @@
+// Copyright 2016-2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loader
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/cilium/cilium/common"
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/cgroups"
+	"github.com/cilium/cilium/pkg/command/exec"
+	"github.com/cilium/cilium/pkg/datapath"
+	"github.com/cilium/cilium/pkg/datapath/alignchecker"
+	"github.com/cilium/cilium/pkg/datapath/prefilter"
+	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/sysctl"
+	"github.com/sirupsen/logrus"
+	"github.com/vishvananda/netlink"
+)
+
+const (
+	initArgLib int = iota
+	initArgRundir
+	initArgIPv4NodeIP
+	initArgIPv6NodeIP
+	initArgMode
+	initArgDevice
+	initArgDevicePreFilter
+	initArgModePreFilter
+	initArgMTU
+	initArgIPSec
+	initArgMasquerade
+	initArgEncryptInterface
+	initArgHostReachableServices
+	initArgHostReachableServicesUDP
+	initArgCgroupRoot
+	initArgBpffsRoot
+	initArgNodePort
+	initArgMax
+)
+
+func (l *Loader) writeNetdevHeader(dir string, o datapath.BaseProgramOwner) error {
+	headerPath := filepath.Join(dir, common.NetdevHeaderFileName)
+	log.WithField(logfields.Path, headerPath).Debug("writing configuration")
+
+	f, err := os.Create(headerPath)
+	if err != nil {
+		return fmt.Errorf("failed to open file %s for writing: %s", headerPath, err)
+
+	}
+	defer f.Close()
+
+	if err := l.templateCache.WriteNetdevConfig(f, o); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Must be called with option.Config.EnablePolicyMU locked.
+func writePreFilterHeader(preFilter *prefilter.PreFilter, dir string) error {
+	headerPath := filepath.Join(dir, common.PreFilterHeaderFileName)
+	log.WithField(logfields.Path, headerPath).Debug("writing configuration")
+	f, err := os.Create(headerPath)
+	if err != nil {
+		return fmt.Errorf("failed to open file %s for writing: %s", headerPath, err)
+
+	}
+	defer f.Close()
+	fw := bufio.NewWriter(f)
+	fmt.Fprint(fw, "/*\n")
+	fmt.Fprintf(fw, " * XDP device: %s\n", option.Config.DevicePreFilter)
+	fmt.Fprintf(fw, " * XDP mode: %s\n", option.Config.ModePreFilter)
+	fmt.Fprint(fw, " */\n\n")
+	preFilter.WriteConfig(fw)
+	return fw.Flush()
+}
+
+// CompileBasePrograms compiles the base programs managed by this loader.
+func (l *Loader) CompileBasePrograms(ctx context.Context, o datapath.BaseProgramOwner, deviceMTU int, iptMgr datapath.RulesManager, p datapath.Proxy, r datapath.RouteReserver) error {
+	var args []string
+	var mode string
+	var ret error
+
+	type setting struct {
+		name      string
+		val       string
+		ignoreErr bool
+	}
+
+	args = make([]string, initArgMax)
+
+	sysSettings := []setting{
+		{"net.core.bpf_jit_enable", "1", true},
+		{"net.ipv4.conf.all.rp_filter", "0", false},
+		{"kernel.unprivileged_bpf_disabled", "1", true},
+	}
+
+	// Lock so that endpoints cannot be built while we are compile base programs.
+	o.GetCompilationLock().Lock()
+	defer o.GetCompilationLock().Unlock()
+
+	l.Init(o.Datapath(), o.LocalConfig())
+
+	if err := l.writeNetdevHeader("./", o); err != nil {
+		log.WithError(err).Warn("Unable to write netdev header")
+		return err
+	}
+
+	scopedLog := log.WithField(logfields.XDPDevice, option.Config.DevicePreFilter)
+	if option.Config.DevicePreFilter != "undefined" {
+		if err := prefilter.ProbePreFilter(option.Config.DevicePreFilter, option.Config.ModePreFilter); err != nil {
+			scopedLog.WithError(err).Warn("Turning off prefilter")
+			option.Config.DevicePreFilter = "undefined"
+		}
+	}
+	if option.Config.DevicePreFilter != "undefined" {
+		preFilter, err := prefilter.NewPreFilter()
+		if err != nil {
+			scopedLog.WithError(ret).Warn("Unable to init prefilter")
+			return ret
+		}
+
+		if err := writePreFilterHeader(preFilter, "./"); err != nil {
+			scopedLog.WithError(err).Warn("Unable to write prefilter header")
+			return err
+		}
+
+		o.SetPrefilter(preFilter)
+
+		args[initArgDevicePreFilter] = option.Config.DevicePreFilter
+		args[initArgModePreFilter] = option.Config.ModePreFilter
+	}
+
+	args[initArgLib] = option.Config.BpfDir
+	args[initArgRundir] = option.Config.StateDir
+	args[initArgCgroupRoot] = cgroups.GetCgroupRoot()
+	args[initArgBpffsRoot] = bpf.GetMapRoot()
+
+	if option.Config.EnableIPv4 {
+		args[initArgIPv4NodeIP] = node.GetInternalIPv4().String()
+	} else {
+		args[initArgIPv4NodeIP] = "<nil>"
+	}
+
+	if option.Config.EnableIPv6 {
+		args[initArgIPv6NodeIP] = node.GetIPv6().String()
+		// Docker <17.05 has an issue which causes IPv6 to be disabled in the initns for all
+		// interface (https://github.com/docker/libnetwork/issues/1720)
+		// Enable IPv6 for now
+		sysSettings = append(sysSettings,
+			setting{"net.ipv6.conf.all.disable_ipv6", "0", false})
+	} else {
+		args[initArgIPv6NodeIP] = "<nil>"
+	}
+
+	args[initArgMTU] = fmt.Sprintf("%d", deviceMTU)
+
+	if option.Config.EnableIPSec {
+		args[initArgIPSec] = "true"
+	} else {
+		args[initArgIPSec] = "false"
+	}
+
+	if !option.Config.InstallIptRules && option.Config.Masquerade {
+		args[initArgMasquerade] = "true"
+	} else {
+		args[initArgMasquerade] = "false"
+	}
+
+	if option.Config.EnableHostReachableServices {
+		args[initArgHostReachableServices] = "true"
+		if option.Config.EnableHostServicesUDP {
+			args[initArgHostReachableServicesUDP] = "true"
+		} else {
+			args[initArgHostReachableServicesUDP] = "false"
+		}
+	} else {
+		args[initArgHostReachableServices] = "false"
+		args[initArgHostReachableServicesUDP] = "false"
+	}
+
+	if option.Config.EncryptInterface != "" {
+		args[initArgEncryptInterface] = option.Config.EncryptInterface
+	}
+
+	if option.Config.Device != "undefined" {
+		_, err := netlink.LinkByName(option.Config.Device)
+		if err != nil {
+			log.WithError(err).WithField("device", option.Config.Device).Warn("Link does not exist")
+			return err
+		}
+
+		if option.Config.DatapathMode == option.DatapathModeIpvlan {
+			mode = "ipvlan"
+		} else {
+			mode = "direct"
+		}
+
+		args[initArgMode] = mode
+		if option.Config.EnableNodePort &&
+			strings.ToLower(option.Config.Tunnel) != "disabled" {
+			args[initArgMode] = option.Config.Tunnel
+		}
+		args[initArgDevice] = option.Config.Device
+	} else {
+		args[initArgMode] = option.Config.Tunnel
+
+		if option.Config.IsFlannelMasterDeviceSet() {
+			args[initArgMode] = "flannel"
+			args[initArgDevice] = option.Config.FlannelMasterDevice
+		}
+	}
+
+	if option.Config.EnableEndpointRoutes == true {
+		args[initArgMode] = "routed"
+	}
+
+	if option.Config.EnableNodePort {
+		args[initArgNodePort] = "true"
+	}
+
+	log.Info("Setting up base BPF datapath")
+
+	for _, s := range sysSettings {
+		log.Infof("Setting sysctl %s=%s", s.name, s.val)
+		if err := sysctl.Write(s.name, s.val); err != nil {
+			if !s.ignoreErr {
+				return fmt.Errorf("Failed to sysctl -w %s=%s: %s", s.name, s.val, err)
+			}
+			log.WithError(err).WithFields(logrus.Fields{
+				logfields.SysParamName:  s.name,
+				logfields.SysParamValue: s.val,
+			}).Warning("Failed to sysctl -w")
+		}
+	}
+
+	prog := filepath.Join(option.Config.BpfDir, "init.sh")
+	ctx, cancel := context.WithTimeout(ctx, defaults.ExecTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, prog, args...)
+	cmd.Env = bpf.Environment()
+	if _, err := cmd.CombinedOutput(log, true); err != nil {
+		return err
+	}
+
+	if l.canDisableDwarfRelocations {
+		// Validate alignments of C and Go equivalent structs
+		if err := alignchecker.CheckStructAlignments(defaults.AlignCheckerName); err != nil {
+			log.WithError(err).Fatal("C and Go structs alignment check failed")
+		}
+	} else {
+		log.Warning("Cannot check matching of C and Go common struct alignments due to old LLVM/clang version")
+	}
+
+	if !option.Config.IsFlannelMasterDeviceSet() {
+		r.ReserveLocalRoutes()
+	}
+
+	if err := o.Datapath().Node().NodeConfigurationChanged(*o.LocalConfig()); err != nil {
+		return err
+	}
+
+	if option.Config.InstallIptRules {
+		if err := iptMgr.TransientRulesStart(option.Config.HostDevice); err != nil {
+			return err
+		}
+	}
+	// Always remove masquerade rule and then re-add it if required
+	iptMgr.RemoveRules()
+	if option.Config.InstallIptRules {
+		err := iptMgr.InstallRules(option.Config.HostDevice)
+		iptMgr.TransientRulesEnd(false)
+		if err != nil {
+			return err
+		}
+	}
+	// Reinstall proxy rules for any running proxies
+	if p != nil {
+		p.ReinstallRules()
+	}
+
+	return nil
+}

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -56,6 +56,15 @@ type Loader struct {
 
 	// templateCache is the cache of pre-compiled datapaths.
 	templateCache *objectCache
+
+	canDisableDwarfRelocations bool
+}
+
+// NewLoader returns a new loader.
+func NewLoader(canDisableDwarfRelocations bool) *Loader {
+	return &Loader{
+		canDisableDwarfRelocations: canDisableDwarfRelocations,
+	}
 }
 
 // Init initializes the datapath cache with base program hashes derived from


### PR DESCRIPTION
This package is responsible for the management and compilation of datapath
programs for Endpoints, so logically collocating the compilation of base
programs within said package makes sense from an organizational perspective in
the code. Along with this, move the analysis of requirements for running the
daemon into `pkg/datapath/linux`.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9488)
<!-- Reviewable:end -->
