### PR TITLE
Fix cilium-health node updates

### DIFF
--- a/pkg/health/server/node.go
+++ b/pkg/health/server/node.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,11 +20,6 @@ import (
 
 type healthNode struct {
 	*models.NodeElement
-
-	// During setNodes(), we perform mark-and-sweep to get rid of IPs that
-	// should no longer be probed. If deletionMark is true after the set
-	// of nodes is updated, this node can be removed.
-	deletionMark bool
 }
 
 // NewHealthNode creates a new node structure based on the specified model.

--- a/pkg/health/server/prober_test.go
+++ b/pkg/health/server/prober_test.go
@@ -1,0 +1,174 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package server
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"sort"
+	"testing"
+
+	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/checker"
+
+	"gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) { check.TestingT(t) }
+
+type HealthServerTestSuite struct{}
+
+var _ = check.Suite(&HealthServerTestSuite{})
+
+func makeHealthNode(nodeIdx, healthIdx int) (healthNode, net.IP, net.IP) {
+	nodeIP := fmt.Sprintf("192.0.2.%d", nodeIdx)
+	healthIP := fmt.Sprintf("10.0.2.%d", healthIdx)
+	return healthNode{
+		NodeElement: &models.NodeElement{
+			Name: fmt.Sprintf("node-%d", nodeIdx),
+			PrimaryAddress: &models.NodeAddressing{
+				IPV4: &models.NodeAddressingElement{
+					IP:      nodeIP,
+					Enabled: true,
+				},
+				IPV6: &models.NodeAddressingElement{
+					Enabled: false,
+				},
+			},
+			HealthEndpointAddress: &models.NodeAddressing{
+				IPV4: &models.NodeAddressingElement{
+					IP:      healthIP,
+					Enabled: true,
+				},
+				IPV6: &models.NodeAddressingElement{
+					Enabled: false,
+				},
+			},
+		},
+	}, net.ParseIP(nodeIP), net.ParseIP(healthIP)
+}
+
+func sortNodes(nodes map[string][]*net.IPAddr) map[string][]*net.IPAddr {
+	for _, slice := range nodes {
+		sort.Slice(slice, func(i, j int) bool {
+			iLength := len(slice[i].IP)
+			jLength := len(slice[j].IP)
+			if iLength == jLength {
+				return bytes.Compare(slice[i].IP, slice[j].IP) < 0
+			}
+			return iLength < jLength
+		})
+	}
+	return nodes
+}
+
+func (s *HealthServerTestSuite) TestProbersetNodes(c *check.C) {
+	node1, node1IP, node1HealthIP := makeHealthNode(1, 1)
+	newNodes := nodeMap{
+		ipString(node1.Name): node1,
+	}
+
+	// First up: Just create a prober with some nodes.
+	prober := newProber(&Server{}, newNodes)
+	nodes := prober.getIPsByNode()
+	expected := map[string][]*net.IPAddr{
+		node1.Name: {{
+			IP: node1IP,
+		}, {
+			IP: node1HealthIP,
+		}},
+	}
+	c.Assert(sortNodes(nodes), checker.DeepEquals, sortNodes(expected))
+
+	// Update the health IP and observe that it is updated.
+	// Note that update consists of delete and add in setNodes().
+	node1, node1IP, node1HealthIP = makeHealthNode(1, 2)
+	modifiedNodes := nodeMap{
+		ipString(node1.Name): node1,
+	}
+	prober.setNodes(modifiedNodes, newNodes)
+	nodes = prober.getIPsByNode()
+	expected = map[string][]*net.IPAddr{
+		node1.Name: {{
+			IP: node1IP,
+		}, {
+			IP: node1HealthIP,
+		}},
+	}
+	c.Assert(sortNodes(nodes), checker.DeepEquals, sortNodes(expected))
+
+	// Remove the nodes; they shouldn't be there any more
+	prober.setNodes(nil, modifiedNodes)
+	nodes = prober.getIPsByNode()
+	expected = map[string][]*net.IPAddr{}
+	c.Assert(sortNodes(nodes), checker.DeepEquals, sortNodes(expected))
+
+	// Add back two nodes
+	node2, node2IP, node2HealthIP := makeHealthNode(2, 20)
+	updatedNodes := nodeMap{
+		ipString(node1.Name): node1,
+		ipString(node2.Name): node2,
+	}
+	prober.setNodes(updatedNodes, nil)
+	nodes = prober.getIPsByNode()
+	expected = map[string][]*net.IPAddr{
+		node1.Name: {{
+			IP: node1IP,
+		}, {
+			IP: node1HealthIP,
+		}},
+		node2.Name: {{
+			IP: node2IP,
+		}, {
+			IP: node2HealthIP,
+		}},
+	}
+	c.Assert(sortNodes(nodes), checker.DeepEquals, sortNodes(expected))
+
+	// Update node 1. Node 2 should remain unaffected.
+	modifiedNodesOld := nodeMap{
+		ipString(node1.Name): node1,
+	}
+	node1, node1IP, node1HealthIP = makeHealthNode(1, 5)
+	modifiedNodesNew := nodeMap{
+		ipString(node1.Name): node1,
+	}
+	prober.setNodes(modifiedNodesNew, modifiedNodesOld)
+	nodes = prober.getIPsByNode()
+	expected[node1.Name] = []*net.IPAddr{{
+		IP: node1IP,
+	}, {
+		IP: node1HealthIP,
+	}}
+	c.Assert(sortNodes(nodes), checker.DeepEquals, sortNodes(expected))
+
+	// Remove node 1. Again, Node 2 should remain.
+	removedNodes := nodeMap{
+		ipString(node1.Name): node1,
+	}
+	prober.setNodes(nil, removedNodes)
+	nodes = prober.getIPsByNode()
+	expected = map[string][]*net.IPAddr{
+		node2.Name: {{
+			IP: node2IP,
+		}, {
+			IP: node2HealthIP,
+		}},
+	}
+	c.Assert(sortNodes(nodes), checker.DeepEquals, sortNodes(expected))
+}


### PR DESCRIPTION
Fix the handling of updates for existing nodes in `cilium-health`. The first two commits are bugfixes; the last two are to unit-test the functionality. Read commit-by-commit for further details.

Broadly this PR removes the previous "mark-and-sweep" GC logic for nodes that previously existed in the `cilium-health` prober, because since PR #8300 we have had the exact context of added/removed nodes, meaning that we should not need to sweep the entire list.

There were two subtle bugs in the previous implementation:
* When a node is updated, `cilium-health` would continue to probe IPs that no longer correspond to the node
* Removal of a node would not disable TCP probing for all IPs corresponding to the node, it would only stop probing the primary IP of the node

Functionally when a node is updated (eg the health endpoint IP changes), the Cilium nodes API will propagate notifications that include the node in the `removed` nodes list as well as the `added` nodes list, and in this PR this will cause a reset of the node's cached prober results. It's not clear to me right now that there's any advantage to ensuring that the internally cached node representation inside the `cilium-health` prober would benefit from actually retaining the existing entry in the nodes map if the individual IP doesn't change; it's simpler to just handle the update in this scenario by actually deleting and adding the node. The following probe cycle will subsequently update the results for the IPs corresponding to the changed node. Strictly speaking this means there may be intermittent periods when nodes are updated where the `cilium-health` instance won't have prober results for the updated nodes. 

Related: #9103 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9491)
<!-- Reviewable:end -->
