### PR TITLE
plugins/cilium-cni: disable CNI debug messages by default

### DIFF
--- a/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
@@ -88,7 +88,8 @@ spec:
           postStart:
             exec:
               command:
-              - /cni-install.sh
+              - "/cni-install.sh"
+              -{{- if .Values.global.debug.enabled }} "--enable-debug=true"{{- else }} "--enable-debug=false"{{- end }}
           preStop:
             exec:
               command:

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -35,6 +35,18 @@ data:
   # that will be seen in monitor output.
   monitor-aggregation: medium
 
+  # The monitor aggregation interval governs the typical time between monitor
+  # notification events for each allowed connection.
+  #
+  # Only effective when monitor aggregation is set to "medium" or higher.
+  monitor-aggregation-interval: 5s
+
+  # The monitor aggregation flags determine which TCP flags which, upon the
+  # first observation, cause monitor notifications to be generated.
+  #
+  # Only effective when monitor aggregation is set to "medium" or higher.
+  monitor-aggregation-flags: all
+
   # ct-global-max-entries-* specifies the maximum number of connections
   # supported across all endpoints, split by protocol: tcp or other. One pair
   # of maps uses these values for IPv4 connections, and another pair of maps
@@ -368,7 +380,8 @@ spec:
           postStart:
             exec:
               command:
-              - /cni-install.sh
+              - "/cni-install.sh"
+              - "--enable-debug=true"
           preStop:
             exec:
               command:

--- a/plugins/cilium-cni/04-flannel-cilium-cni.conflist
+++ b/plugins/cilium-cni/04-flannel-cilium-cni.conflist
@@ -17,7 +17,8 @@
     },
     {
        "name": "cilium",
-       "type": "cilium-cni"
+       "type": "cilium-cni",
+       "enable-debug": true
     }
   ]
 }

--- a/plugins/cilium-cni/05-cilium-cni.conf
+++ b/plugins/cilium-cni/05-cilium-cni.conf
@@ -1,5 +1,6 @@
 {
     "cniVersion": "0.3.1",
     "name": "cilium",
-    "type": "cilium-cni"
+    "type": "cilium-cni",
+    "enable-debug": true
 }

--- a/plugins/cilium-cni/chaining/generic-veth/generic-veth.go
+++ b/plugins/cilium-cni/chaining/generic-veth/generic-veth.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	chainingapi "github.com/cilium/cilium/plugins/cilium-cni/chaining/api"
 
@@ -30,10 +29,6 @@ import (
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
-)
-
-var (
-	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "generic-veth")
 )
 
 type GenericVethChainer struct{}
@@ -84,7 +79,7 @@ func (f *GenericVethChainer) Add(ctx context.Context, pluginCtx chainingapi.Plug
 		}
 
 		for _, link := range links {
-			log.Debugf("Found interface in container %+v", link.Attrs())
+			pluginCtx.Logger.Debugf("Found interface in container %+v", link.Attrs())
 
 			if link.Type() != "veth" {
 				continue
@@ -201,7 +196,7 @@ func (f *GenericVethChainer) ImplementsDelete() bool {
 func (f *GenericVethChainer) Delete(ctx context.Context, pluginCtx chainingapi.PluginContext) (err error) {
 	id := endpointid.NewID(endpointid.ContainerIdPrefix, pluginCtx.Args.ContainerID)
 	if err := pluginCtx.Client.EndpointDelete(id); err != nil {
-		log.WithError(err).Warning("Errors encountered while deleting endpoint")
+		pluginCtx.Logger.WithError(err).Warning("Errors encountered while deleting endpoint")
 	}
 	return nil
 }

--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -275,8 +275,19 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 		c        *client.Client
 		netNs    ns.NetNS
 	)
-
 	logger := log.WithField("eventUUID", uuid.NewUUID())
+
+	n, err = types.LoadNetConf(args.StdinData)
+	if err != nil {
+		// In case of an error is helpful to always print the processing CNI
+		// ADD request.
+		logger.Infof("Processing CNI ADD request %#v", args)
+		err = fmt.Errorf("unable to parse CNI configuration \"%s\": %s", args.StdinData, err)
+		return
+	}
+	if !n.EnableDebug {
+		logger.Logger.SetLevel(logrus.InfoLevel)
+	}
 	logger.Debugf("Processing CNI ADD request %#v", args)
 
 	n, err = types.LoadNetConf(args.StdinData)
@@ -529,12 +540,20 @@ func cmdDel(args *skel.CmdArgs) error {
 	// are guaranteed to be recoverable.
 
 	logger := log.WithField("eventUUID", uuid.NewUUID())
-	logger.Debugf("Processing CNI DEL request %#v", args)
 
 	n, err := types.LoadNetConf(args.StdinData)
 	if err != nil {
+		// In case of an error is helpful to always print the processing CNI
+		// DEL request.
+		logger.Infof("Processing CNI DEL request %#v", args)
+		err = fmt.Errorf("unable to parse CNI configuration \"%s\": %s", args.StdinData, err)
 		return err
 	}
+	if !n.EnableDebug {
+		logger.Logger.SetLevel(logrus.InfoLevel)
+	}
+	logger.Debugf("Processing CNI DEL request %#v", args)
+
 	logger.Debugf("CNI NetConf: %#v", n)
 
 	cniArgs := types.ArgsSpec{}

--- a/plugins/cilium-cni/cni-install.sh
+++ b/plugins/cilium-cni/cni-install.sh
@@ -31,6 +31,19 @@ case "$CILIUM_CNI_CHAINING_MODE" in
 	;;
 esac
 
+ENABLE_DEBUG=false
+while test $# -gt 0; do
+  case "$1" in
+    --enable-debug*)
+      ENABLE_DEBUG=`echo $1 | sed -e 's/^[^=]*=//g'`
+      shift
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
 BIN_NAME=cilium-cni
 CNI_DIR=${CNI_DIR:-${HOST_PREFIX}/opt/cni}
 CILIUM_CNI_CONF=${CILIUM_CNI_CONF:-${HOST_PREFIX}/etc/cni/net.d/${CNI_CONF_NAME}}
@@ -86,7 +99,8 @@ case "$CILIUM_CNI_CHAINING_MODE" in
     },
     {
        "name": "cilium",
-       "type": "cilium-cni"
+       "type": "cilium-cni",
+       "enable-debug": ${ENABLE_DEBUG}
     }
   ]
 }
@@ -101,7 +115,8 @@ EOF
   "plugins": [
     {
        "name": "cilium",
-       "type": "cilium-cni"
+       "type": "cilium-cni",
+       "enable-debug": ${ENABLE_DEBUG}
     },
     {
       "type": "portmap",
@@ -130,7 +145,8 @@ EOF
     },
     {
        "name": "cilium",
-       "type": "cilium-cni"
+       "type": "cilium-cni",
+       "enable-debug": ${ENABLE_DEBUG}
     }
   ]
 }
@@ -142,7 +158,8 @@ EOF
 {
   "cniVersion": "0.3.1",
   "name": "cilium",
-  "type": "cilium-cni"
+  "type": "cilium-cni",
+  "enable-debug": ${ENABLE_DEBUG}
 }
 EOF
 	;;

--- a/plugins/cilium-cni/types/types.go
+++ b/plugins/cilium-cni/types/types.go
@@ -30,9 +30,10 @@ import (
 // NetConf is the Cilium specific CNI network configuration
 type NetConf struct {
 	cniTypes.NetConf
-	MTU  int              `json:"mtu"`
-	Args Args             `json:"args"`
-	ENI  ciliumv2.ENISpec `json:"eni,omitempty"`
+	MTU         int              `json:"mtu"`
+	Args        Args             `json:"args"`
+	ENI         ciliumv2.ENISpec `json:"eni,omitempty"`
+	EnableDebug bool             `json:"enable-debug"`
 }
 
 // NetConfList is a CNI chaining configuration


### PR DESCRIPTION
As debug messages can be verbose in production environments Cilium will
disable such messages by default. Turning them back on is as simple as
setting up the pod lifecycle postStart hook with `cni-install.sh
--enable-debug=true`

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9493)
<!-- Reviewable:end -->
