### PR TITLE
node/manager: Lock nodes slice during Subscribe

### DIFF
--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -105,11 +105,13 @@ func (m *Manager) Subscribe(nh datapath.NodeHandler) {
 	m.nodeHandlers[nh] = struct{}{}
 	m.nodeHandlersMu.Unlock()
 	// Add all nodes already received by the manager.
+	m.mutex.RLock()
 	for _, v := range m.nodes {
 		v.mutex.Lock()
 		nh.NodeAdd(v.node)
 		v.mutex.Unlock()
 	}
+	m.mutex.RUnlock()
 }
 
 // Unsubscribe unsubscribes the given node handler with node events.


### PR DESCRIPTION
Previously we didn't lock the nodes list for reading during
`Subscribe()`, so this iteration would not protect against concurrent
access/update of the nodes list during subscription.

Fix it using a readlock of the manager's RWMutex.

Found by code inspection.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9495)
<!-- Reviewable:end -->
