### PR TITLE
Connection-based DNS policy

### DIFF
--- a/api/v1/models/dns_lookup.go
+++ b/api/v1/models/dns_lookup.go
@@ -34,6 +34,9 @@ type DNSLookup struct {
 	// Format: date-time
 	LookupTime strfmt.DateTime `json:"lookup-time,omitempty"`
 
+	// The reason this FQDN IP association exists. Either a DNS lookup or an ongoing connection to an IP that was created by a DNS lookup.
+	Source string `json:"source,omitempty"`
+
 	// The TTL in the DNS response
 	TTL int64 `json:"ttl,omitempty"`
 }

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -2203,6 +2203,9 @@ definitions:
       endpoint-id:
         description: The endpoint that made this lookup, or 0 for the agent itself.
         type: integer
+      source:
+        description: The reason this FQDN IP association exists. Either a DNS lookup or an ongoing connection to an IP that was created by a DNS lookup.
+        type: string
   IPListEntry:
     description: IP entry with metadata
     type: object

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -1590,6 +1590,10 @@ func init() {
           "type": "string",
           "format": "date-time"
         },
+        "source": {
+          "description": "The reason this FQDN IP association exists. Either a DNS lookup or an ongoing connection to an IP that was created by a DNS lookup.",
+          "type": "string"
+        },
         "ttl": {
           "description": "The TTL in the DNS response",
           "type": "integer"
@@ -4842,6 +4846,10 @@ func init() {
           "description": "The absolute time when this data was recieved",
           "type": "string",
           "format": "date-time"
+        },
+        "source": {
+          "description": "The reason this FQDN IP association exists. Either a DNS lookup or an ongoing connection to an IP that was created by a DNS lookup.",
+          "type": "string"
         },
         "ttl": {
           "description": "The TTL in the DNS response",

--- a/cilium/cmd/fqdn.go
+++ b/cilium/cmd/fqdn.go
@@ -159,10 +159,11 @@ func listFQDNCache() {
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 5, 0, 3, ' ', 0)
-	fmt.Fprintln(w, "Endpoint\tFQDN\tTTL\tExpirationTime\tIPs\t")
+	fmt.Fprintln(w, "Endpoint\tSource\tFQDN\tTTL\tExpirationTime\tIPs\t")
 	for _, lookup := range lookups {
-		fmt.Fprintf(w, "%d\t%s\t%d\t%s\t%s\t\n",
+		fmt.Fprintf(w, "%d\t%s\t%s\t%d\t%s\t%s\t\n",
 			lookup.EndpointID,
+			lookup.Source,
 			lookup.Fqdn,
 			lookup.TTL,
 			lookup.ExpirationTime.String(),

--- a/daemon/fqdn.go
+++ b/daemon/fqdn.go
@@ -162,12 +162,12 @@ func (d *Daemon) bootstrapFQDN(restoredEndpoints *endpointRestoreState, preCache
 			)
 
 			// cleanup poller cache
-			namesToClean = append(namesToClean, d.dnsPoller.DNSHistory.GC(GCStart)...)
+			namesToClean = append(namesToClean, d.dnsPoller.DNSHistory.GC(GCStart, nil)...)
 
 			// cleanup caches for all existing endpoints as well.
 			endpoints := d.endpointManager.GetEndpoints()
 			for _, ep := range endpoints {
-				namesToClean = append(namesToClean, ep.DNSHistory.GC(GCStart)...)
+				namesToClean = append(namesToClean, ep.DNSHistory.GC(GCStart, nil)...)
 			}
 
 			namesToClean = fqdn.KeepUniqueNames(namesToClean)

--- a/daemon/fqdn.go
+++ b/daemon/fqdn.go
@@ -62,6 +62,9 @@ const (
 	metricErrorProxy   = "proxyErr"
 	metricErrorDenied  = "denied"
 	metricErrorAllow   = "allow"
+
+	dnsSourceLookup     = "lookup"
+	dnsSourceConnection = "connection"
 )
 
 func identitiesForFQDNSelectorIPs(selectorsWithIPsToUpdate map[policyApi.FQDNSelector][]net.IP, identityAllocator *secIDCache.CachingIdentityAllocator) (map[policyApi.FQDNSelector][]*identity.Identity, error) {
@@ -753,6 +756,7 @@ func extractDNSLookups(endpoints []*endpoint.Endpoint, CIDRStr, matchPatternStr 
 				TTL:            int64(lookup.TTL),
 				ExpirationTime: strfmt.DateTime(lookup.ExpirationTime),
 				EndpointID:     int64(ep.ID),
+				Source:         dnsSourceLookup,
 			})
 		}
 
@@ -774,6 +778,7 @@ func extractDNSLookups(endpoints []*endpoint.Endpoint, CIDRStr, matchPatternStr 
 					TTL:            0,
 					ExpirationTime: strfmt.DateTime(delete.AliveAt),
 					EndpointID:     int64(ep.ID),
+					Source:         dnsSourceConnection,
 				})
 			}
 		}

--- a/daemon/fqdn.go
+++ b/daemon/fqdn.go
@@ -156,15 +156,18 @@ func (d *Daemon) bootstrapFQDN(restoredEndpoints *endpointRestoreState, preCache
 	controller.NewManager().UpdateController(dnsGCJobName, controller.ControllerParams{
 		RunInterval: 1 * time.Minute,
 		DoFunc: func(ctx context.Context) error {
+			var (
+				GCStart      = time.Now()
+				namesToClean = []string{}
+			)
 
-			namesToClean := []string{}
 			// cleanup poller cache
-			namesToClean = append(namesToClean, d.dnsPoller.DNSHistory.GC()...)
+			namesToClean = append(namesToClean, d.dnsPoller.DNSHistory.GC(GCStart)...)
 
 			// cleanup caches for all existing endpoints as well.
 			endpoints := d.endpointManager.GetEndpoints()
 			for _, ep := range endpoints {
-				namesToClean = append(namesToClean, ep.DNSHistory.GC()...)
+				namesToClean = append(namesToClean, ep.DNSHistory.GC(GCStart)...)
 			}
 
 			namesToClean = fqdn.KeepUniqueNames(namesToClean)

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -81,6 +81,7 @@ func NewEndpointFromChangeModel(ctx context.Context, owner regeneration.Owner, p
 		ifIndex:          int(base.InterfaceIndex),
 		OpLabels:         labels.NewOpLabels(),
 		DNSHistory:       fqdn.NewDNSCacheWithLimit(option.Config.ToFQDNsMinTTL, option.Config.ToFQDNsMaxIPsPerHost),
+		DNSZombies:       fqdn.NewDNSZombieMappings(),
 		state:            "",
 		status:           NewEndpointStatus(),
 		hasBPFProgram:    make(chan struct{}, 0),

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -190,6 +190,11 @@ type Endpoint struct {
 	// this endpoint.
 	DNSHistory *fqdn.DNSCache
 
+	// DNSZombies is the collection of DNS IPs that have expired in or been
+	// evicted from DNSHistory. They are held back from deletion until we can
+	// confirm that no existing connection is using them.
+	DNSZombies *fqdn.DNSZombieMappings
+
 	// dnsHistoryTrigger is the trigger to write down the lxc_config.h to make
 	// sure that restores when DNS policy is in there are correct
 	dnsHistoryTrigger *trigger.Trigger
@@ -387,6 +392,7 @@ func NewEndpointWithState(owner regeneration.Owner, proxy EndpointProxy, allocat
 		OpLabels:        pkgLabels.NewOpLabels(),
 		status:          NewEndpointStatus(),
 		DNSHistory:      fqdn.NewDNSCacheWithLimit(option.Config.ToFQDNsMinTTL, option.Config.ToFQDNsMaxIPsPerHost),
+		DNSZombies:      fqdn.NewDNSZombieMappings(),
 		state:           state,
 		hasBPFProgram:   make(chan struct{}, 0),
 		controllers:     controller.NewManager(),

--- a/pkg/endpoint/fqdn.go
+++ b/pkg/endpoint/fqdn.go
@@ -1,0 +1,55 @@
+// Copyright 2016-2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endpoint
+
+import (
+	"net"
+	"time"
+)
+
+const logSubsys = "fqdn"
+
+// MarkDNSCTEntry records that dstIP is in use by a connection that is allowed
+// by toFQDNs policy. The reverse lookup is attempted in both DNSHistory and
+// DNSCTHistory, allowing short DNS TTLs but long-lived connections to
+// persist there.DNSCTHistory is used to suppress delete handling of expired DNS
+// lookups (in DNSHistory) and it relies on pkg/maps/ctmap/gc to call this
+// function.
+// Internally, the lookupTime is used to checkpoint this update so that
+// dns-garbage-collector-job can correctly clear older connection data.
+func (e *Endpoint) MarkDNSCTEntry(dstIP net.IP, now time.Time) {
+	if dstIP == nil {
+		e.Logger(logSubsys).Error("MarkDNSCTEntry called with nil IP")
+		return
+	}
+
+	e.DNSZombies.MarkAlive(now, dstIP)
+	e.SyncEndpointHeaderFile() // This is behind a rate-limit trigger
+}
+
+// MarkCTGCTime is the START time of a GC run. It is used by the DNS garbage
+// collector to determine whether a DNS zombie can be deleted. This is done by
+// comparing the timestamp of the start CT GC run with the ailve timestamps of
+// specific DNS zombies IPs marked with MarkDNSCTEntry.
+// NOTE: While the timestamp is ths start of the run, it should be set AFTER
+// the run completes. This avoids a race between the DNS garbage collector and
+// the CT GC. This would occur when a DNS zombie that has not been visited by
+// the CT GC run is seen by a concurrent DNS garbage collector run, and then
+// deleted.
+// The DNS garbage collector is in daemon/fqdn.go and the CT GC is in
+// pkg/maps/ctmap/gc/gc.go
+func (e *Endpoint) MarkCTGCTime(now time.Time) {
+	e.DNSZombies.SetCTGCTime(now)
+}

--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -408,7 +408,9 @@ func (c *DNSCache) lookupByRegexpByTime(now time.Time, re *regexp.Regexp) (match
 
 	for name, entry := range c.forward {
 		if re.MatchString(name) {
-			matches[name] = append(matches[name], entry.getIPs(now)...)
+			if ips := entry.getIPs(now); len(ips) > 0 {
+				matches[name] = append(matches[name], ips...)
+			}
 		}
 	}
 

--- a/pkg/fqdn/cache_test.go
+++ b/pkg/fqdn/cache_test.go
@@ -569,7 +569,7 @@ func (ds *DNSCacheTestSuite) TestOverlimitEntriesWithoutLimit(c *C) {
 		cache.Update(now, "test.com", []net.IP{net.ParseIP(fmt.Sprintf("1.1.1.%d", i))}, i)
 	}
 	c.Assert(cache.cleanupOverLimitEntries(), checker.DeepEquals, []string{})
-	c.Assert(cache.Lookup("test.com"), HasLen, 4)
+	c.Assert(cache.Lookup("test.com"), HasLen, 5)
 }
 
 func (ds *DNSCacheTestSuite) TestGCOverlimitAfterTTLCleanup(c *C) {

--- a/pkg/fqdn/helpers.go
+++ b/pkg/fqdn/helpers.go
@@ -80,13 +80,15 @@ func mapSelectorsToIPs(fqdnSelectors map[api.FQDNSelector]struct{}, cache *DNSCa
 			missing[ToFQDN] = struct{}{}
 
 			for name, ips := range lookupIPs {
-				log.WithFields(logrus.Fields{
-					"DNSName":      name,
-					"IPs":          ips,
-					"matchPattern": ToFQDN.MatchPattern,
-				}).Debug("Emitting matching DNS Name -> IPs for FQDNSelector")
-				delete(missing, ToFQDN)
-				ipsSelected = append(ipsSelected, ips...)
+				if len(ips) > 0 {
+					log.WithFields(logrus.Fields{
+						"DNSName":      name,
+						"IPs":          ips,
+						"matchPattern": ToFQDN.MatchPattern,
+					}).Debug("Emitting matching DNS Name -> IPs for FQDNSelector")
+					delete(missing, ToFQDN)
+					ipsSelected = append(ipsSelected, ips...)
+				}
 			}
 		}
 

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -219,11 +219,11 @@ type GCFilter struct {
 	// EmitCTEntry is called, when non-nil, if filtering by ValidIPs and MatchIPs
 	// passes. It has no impact on CT GC, but can be used to iterate over valid
 	// CT entries.
-	EmitCTEntryCB EmitCTEntryFunc
+	EmitCTEntryCB EmitCTEntryCBFunc
 }
 
-// EmitCTEntryFunc is the type used for the EmitCTEntry callback in GCFilter
-type EmitCTEntryFunc func(srcIP, dstIP net.IP, srcPort, dstPort uint16, nextHdr, flags uint8, entry *CtEntry)
+// EmitCTEntryCBFunc is the type used for the EmitCTEntryCB callback in GCFilter
+type EmitCTEntryCBFunc func(srcIP, dstIP net.IP, srcPort, dstPort uint16, nextHdr, flags uint8, entry *CtEntry)
 
 // ToString iterates through Map m and writes the values of the ct entries in m
 // to a string.


### PR DESCRIPTION
**Update 2019-11-04**
- A combo bug around how DNSCache.LookupByRegex returned names that didn't match (it returned an entry in the map with no IPs) caused cleanups to not happen when an IP finally expired out of zombies (and, previously, from the DNS caches). This is fixed in https://github.com/cilium/cilium/pull/9545. That commit is included here to simplify testing, but they should be merged separately, ideally.
- On startup the restore could use older versions of the cache, without GC happening (and the cascade to zombies). This is sorted out, although the code is a bit repetitive between the restore segment and dns-garbage-collector. I'm happy to refactor it, but it wasn't terribly clear how to do this while keeping the logic clear.

**Update 2019-11-01**
- renamed to DNSPendingDeletes DNSZombieMappings and switched the nomenclature to alive/dead instead of active/deletable
- DNSPendingDeletes.WantToDelete -> Upsert
  - DNSPendingDeletes.canDelete -> isAlive with the true/false sense switched around
 - Typo comment fixes
 - Added srcPort to matchCB/doFiltering in ctmap.gc
- Unit tests for DNSZombieMappings
- Reuse the set of Endpoints already obtained in the CT GC, avoiding repeated endpointmanager.LookupIP calls.


This PR adds deferring deleting IPs of allowed DNS names from the allowed list while a connection exists for that IP. Removing the policy will (I think) work as before, blocking the ongoing connection.
The general scheme here is to keep a list of to-delete IPs. When the CT GC runs, it marks active connections. If an IP is to-delete and marked active, it is not deleted. If a CT GC ends and an IP is not marked active, it is then deleted by the DNS GC controller `dns-garbage-collector-job`. 

Some things aren't working and I'll fix them before marking this pending:
- Policy doesn't regenerate on DNS expiration. This is a bug somewhere in how we propagate this event. I'll fix it in another PR. In the meantime, generating any other DNS lookup causes a regen.
- The delete lists need some cap. I might add that as a follow-up PR to limit the size of this one. Expect it to default to something large, like 10k IPs in the list, per endpoint. This means it would be a limit on ongoing connections for that particular endpoint once the DNS lookup for them has expired
- I need to change the minTTL defaults but I'll do this once this change is more baked in. The minimum is configurable today, so it's purely a sane defaults thing.

**`cilium fqdn cache list` output now shows**
```
Endpoint   Source       FQDN                   TTL   ExpirationTime             IPs
1865       lookup       flarg.cloudhmar.com.   27    2019-10-25T17:33:44.077Z   192.168.33.11
1865       connection   fleeg.cloudhmar.com.   0     2019-10-25T17:33:01.995Z   1.1.1.1
```

**Things to consider**
- The CT table entries are emitted by adding a callback to the GCFilter used. This is a hack. I originally passed a callback down the runGC callchain but it seemed more unwieldy overall.
- The CT scan can only mark active connections so deletions must happen indirectly to this loop.
- The Endpoint.DNSDeletes field should really live inside Endpoint.DNSHistory and the logic hidden there. This isn't possible because the JSON serialisation of DNSCache doesn't allow for new fields :/ (it is a list of the entries, and nothing else). Upgrades could work, but downgrades would not. Worse, these entries are immutable but the active-connection marking would make that untrue.
- We need to store the delete information on endpoints so that it is restored on startup. While we should be able to rebuild our state there is a race between the DNS GC controller, the CT GC goroutine, and the first regenerations of endpoints. Nonetheless, longer restart times might mean that DNS entries expire during the cilium-agent downtime. I've tried to account for this  (the first DNSHistory.GC call on each endpoint should do the right thing) but this may be racey.
- The refactoring of the cache expire logic to work in lockstep with DNSCache.GC calls means that the actual DNS expiration time has a minimum resolution of 1 minute. This is probably not an issue, but might cause confusion.


Fixes https://github.com/cilium/cilium/issues/9340

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9497)
<!-- Reviewable:end -->
