### PR TITLE
nodediscovery: remove need for `Configuration` interface

### DIFF
--- a/daemon/ipam.go
+++ b/daemon/ipam.go
@@ -343,6 +343,6 @@ func (d *Daemon) bootstrapIPAM() {
 	d.ipam = ipam.NewIPAM(d.datapath.LocalNodeAddressing(), ipam.Configuration{
 		EnableIPv4: option.Config.EnableIPv4,
 		EnableIPv6: option.Config.EnableIPv6,
-	}, d, d.k8sWatcher)
+	}, d.nodeDiscovery, d.k8sWatcher)
 	bootstrapStats.ipam.End(true)
 }

--- a/daemon/status_test.go
+++ b/daemon/status_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cilium/cilium/pkg/node/manager"
 	"github.com/cilium/cilium/pkg/nodediscovery"
 	"github.com/cilium/cilium/pkg/option"
+	cnitypes "github.com/cilium/cilium/plugins/cilium-cni/types"
 
 	"github.com/go-openapi/runtime/middleware"
 	. "gopkg.in/check.v1"
@@ -80,7 +81,7 @@ func (g *GetNodesSuite) Test_getNodesHandle(c *C) {
 		{
 			name: "create a client ID and store it locally",
 			setupArgs: func() args {
-				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, mtu.NewConfiguration(0, false, false, 0))
+				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, mtu.NewConfiguration(0, false, false, 0), &cnitypes.NetConf{})
 				nodeDiscovery.LocalNode.Name = "foo"
 				return args{
 					params: GetClusterNodesParams{
@@ -112,7 +113,7 @@ func (g *GetNodesSuite) Test_getNodesHandle(c *C) {
 		{
 			name: "retrieve nodes diff from a client that was already present",
 			setupArgs: func() args {
-				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, mtu.NewConfiguration(0, false, false, 0))
+				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, mtu.NewConfiguration(0, false, false, 0), &cnitypes.NetConf{})
 				nodeDiscovery.LocalNode.Name = "foo"
 				return args{
 					params: GetClusterNodesParams{
@@ -166,7 +167,7 @@ func (g *GetNodesSuite) Test_getNodesHandle(c *C) {
 		{
 			name: "retrieve nodes from an expired client, it should be ok because the clean up only happens when on insertion",
 			setupArgs: func() args {
-				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, mtu.NewConfiguration(0, false, false, 0))
+				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, mtu.NewConfiguration(0, false, false, 0), &cnitypes.NetConf{})
 				nodeDiscovery.LocalNode.Name = "foo"
 				return args{
 					params: GetClusterNodesParams{
@@ -221,7 +222,7 @@ func (g *GetNodesSuite) Test_getNodesHandle(c *C) {
 		{
 			name: "retrieve nodes for a new client, the expired client should be deleted",
 			setupArgs: func() args {
-				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, mtu.NewConfiguration(0, false, false, 0))
+				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, mtu.NewConfiguration(0, false, false, 0), &cnitypes.NetConf{})
 				nodeDiscovery.LocalNode.Name = "foo"
 				return args{
 					params: GetClusterNodesParams{
@@ -271,7 +272,7 @@ func (g *GetNodesSuite) Test_getNodesHandle(c *C) {
 		{
 			name: "retrieve nodes for a new client, however the randomizer allocated an existing clientID, so we should return a empty clientID",
 			setupArgs: func() args {
-				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, mtu.NewConfiguration(0, false, false, 0))
+				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, mtu.NewConfiguration(0, false, false, 0), &cnitypes.NetConf{})
 				nodeDiscovery.LocalNode.Name = "foo"
 				return args{
 					params: GetClusterNodesParams{
@@ -321,7 +322,7 @@ func (g *GetNodesSuite) Test_getNodesHandle(c *C) {
 		{
 			name: "retrieve nodes for a client that does not want to have diffs, leave all other stored clients alone",
 			setupArgs: func() args {
-				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, mtu.NewConfiguration(0, false, false, 0))
+				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, mtu.NewConfiguration(0, false, false, 0), &cnitypes.NetConf{})
 				nodeDiscovery.LocalNode.Name = "foo"
 				return args{
 					params: GetClusterNodesParams{},
@@ -431,7 +432,7 @@ func (g *GetNodesSuite) Test_cleanupClients(c *C) {
 		h := &getNodes{
 			clients: args.clients,
 			d: &Daemon{
-				nodeDiscovery: nodediscovery.NewNodeDiscovery(nm, mtu.NewConfiguration(0, false, false, 0)),
+				nodeDiscovery: nodediscovery.NewNodeDiscovery(nm, mtu.NewConfiguration(0, false, false, 0), &cnitypes.NetConf{}),
 			},
 		}
 		h.cleanupClients()


### PR DESCRIPTION
If we pass the netConf as a parameter to the constructor for a `NodeDiscovery`
then we can remove the interfaces needed for accessing it.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9499)
<!-- Reviewable:end -->
