### PR TITLE
controller: add `Context` to `ControllerParams`

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -221,6 +221,7 @@ func (d *Daemon) init() error {
 					return d.syncEndpointsAndHostIPs()
 				},
 				RunInterval: time.Minute,
+				Context:     d.ctx,
 			})
 	}
 

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -1123,6 +1123,7 @@ func (d *Daemon) initKVStore() {
 				return nil
 			},
 			RunInterval: defaults.KVStoreStaleLockTimeout,
+			Context:     d.ctx,
 		},
 	)
 

--- a/daemon/datapath.go
+++ b/daemon/datapath.go
@@ -352,6 +352,7 @@ func (d *Daemon) initMaps() error {
 		controller.ControllerParams{
 			DoFunc:      metricsmap.SyncMetricsMap,
 			RunInterval: 5 * time.Second,
+			Context:     d.ctx,
 		})
 
 	if !option.Config.RestoreState {

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -277,6 +277,7 @@ func (d *Daemon) createEndpoint(ctx context.Context, epTemplate *models.Endpoint
 						return nil
 					},
 					RunInterval: 30 * time.Second,
+					Context:     d.ctx,
 				},
 			)
 			go func() {

--- a/daemon/fqdn.go
+++ b/daemon/fqdn.go
@@ -193,6 +193,7 @@ func (d *Daemon) bootstrapFQDN(restoredEndpoints *endpointRestoreState, preCache
 			_, err := d.dnsNameManager.ForceGenerateDNS(context.TODO(), namesToClean)
 			return err
 		},
+		Context: d.ctx,
 	})
 
 	// Prefill the cache with the CLI provided pre-cache data. This allows various bridging arrangements during upgrades, or just ensure critical DNS mappings remain.

--- a/daemon/health.go
+++ b/daemon/health.go
@@ -98,6 +98,7 @@ func (d *Daemon) initHealth() {
 				return err
 			},
 			RunInterval: 60 * time.Second,
+			Context:     d.ctx,
 		},
 	)
 

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -365,6 +365,7 @@ func (d *Daemon) initRestore(restoredEndpoints *endpointRestoreState) chan struc
 						DoFunc: func(ctx context.Context) error {
 							return d.svc.SyncWithK8sFinished()
 						},
+						Context: d.ctx,
 					},
 				)
 			}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -82,6 +82,8 @@ type ControllerParams struct {
 
 	// NoErrorRetry when set to true, disabled retries on errors
 	NoErrorRetry bool
+
+	Context context.Context
 }
 
 // undefinedDoFunc is used when no DoFunc is set. controller.DoFunc is set to this

--- a/pkg/controller/manager.go
+++ b/pkg/controller/manager.go
@@ -105,7 +105,11 @@ func (m *Manager) updateController(name string, params ControllerParams) *Contro
 		ctrl.updateParamsLocked(params)
 		ctrl.getLogger().Debug("Starting new controller")
 
-		ctrl.ctxDoFunc, ctrl.cancelDoFunc = context.WithCancel(context.Background())
+		if params.Context == nil {
+			ctrl.ctxDoFunc, ctrl.cancelDoFunc = context.WithCancel(context.Background())
+		} else {
+			ctrl.ctxDoFunc, ctrl.cancelDoFunc = context.WithCancel(params.Context)
+		}
 		m.controllers[ctrl.name] = ctrl
 		m.mutex.Unlock()
 

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1248,6 +1248,7 @@ func (e *Endpoint) syncPolicyMapController() {
 				return e.syncPolicyMapWithDump()
 			},
 			RunInterval: 1 * time.Minute,
+			Context:     e.aliveCtx,
 		},
 	)
 }

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -298,6 +298,7 @@ func (e *Endpoint) SetAllocator(allocator cache.IdentityAllocator) {
 // UpdateController updates the controller with the specified name with the
 // provided list of parameters in endpoint's list of controllers.
 func (e *Endpoint) UpdateController(name string, params controller.ControllerParams) {
+	params.Context = e.aliveCtx
 	e.controllers.UpdateController(name, params)
 }
 
@@ -1600,6 +1601,7 @@ func (e *Endpoint) runLabelsResolver(ctx context.Context, myChangeRev int, block
 				}
 			},
 			RunInterval: 5 * time.Minute,
+			Context:     e.aliveCtx,
 		},
 	)
 }

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -588,6 +588,7 @@ func (e *Endpoint) startRegenerationFailureHandler() {
 			return fmt.Errorf("regeneration recovery failed")
 		},
 		ErrorRetryBaseDuration: 2 * time.Second,
+		Context:                e.aliveCtx,
 	})
 }
 
@@ -663,6 +664,7 @@ func (e *Endpoint) runIPIdentitySync(endpointIP addressing.CiliumIP) {
 				return nil
 			},
 			RunInterval: 5 * time.Minute,
+			Context:     e.aliveCtx,
 		},
 	)
 }


### PR DESCRIPTION
This allows for the context which is passed to the `DoFunc` from the controller
to be derived from a context other than `context.Background()`. Now that we are
using a single parent context derived from the daemon and passing that down to
all Endpoints to allow for cleanly shutting down of `cilium-agent`, it makes
sense to try to propagate said context down to controllers as well, so that if
`cilium-agent` terminates, the shutdown signal will be propagated across
controllers too.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9500)
<!-- Reviewable:end -->
