### PR TITLE
Makefile: remove patch for shell script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ TEST_UNITTEST_LDFLAGS= -ldflags "-X github.com/cilium/cilium/pkg/kvstore.consulD
 
 define generate_k8s_api
 	cd "./vendor/k8s.io/code-generator" && \
-	GO111MODULE=off ./generate-groups.sh $(1) \
+	GO111MODULE=off bash ./generate-groups.sh $(1) \
 	    github.com/cilium/cilium/pkg/k8s/client \
 	    $(2) \
 	    $(3) \
@@ -268,15 +268,7 @@ generate-health-api: api/v1/health/openapi.yaml
 	-$(SWAGGER) generate client -a restapi \
 		-t api/v1 -t api/v1/health/ -f api/v1/health/openapi.yaml
 
-revert-k8s-generator-patch:
-	patch -p1 -R < hack/82410.patch
-
-apply-k8s-generator-patch:
-	patch -p1 < hack/82410.patch
-
-generate-k8s-api: apply-k8s-generator-patch generate-k8s-api-patch revert-k8s-generator-patch
-
-generate-k8s-api-patch:
+generate-k8s-api:
 	$(call generate_k8s_api_all,github.com/cilium/cilium/pkg/k8s/apis,"cilium.io:v2")
 	$(call generate_k8s_api_deepcopy,github.com/cilium/cilium/pkg,"policy:api")
 	$(call generate_k8s_api_deepcopy,github.com/cilium/cilium,"pkg:node")

--- a/hack/82410.patch
+++ b/hack/82410.patch
@@ -1,3 +1,0 @@
-diff --git a/vendor/k8s.io/code-generator/generate-groups.sh b/vendor/k8s.io/code-generator/generate-groups.sh
-old mode 100644
-new mode 100755


### PR DESCRIPTION
As designed by go modules it's not intended for go modules to preserve
permission bits when copying files into the vendor directory. As an initial
workaround a patch was being applied to change the shell script file
into an executable file.

As executing the shell script file with bash is sufficient to produce
the same results, the initial workaround can be removed.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9501)
<!-- Reviewable:end -->
