### PR TITLE
Add enable-local-node-route option

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -63,6 +63,7 @@ cilium-agent [flags]
       --enable-ipv4                                           Enable IPv4 support (default true)
       --enable-ipv6                                           Enable IPv6 support (default true)
       --enable-k8s-event-handover                             Enable k8s event handover to kvstore for improved scalability
+      --enable-local-node-route                               Enable installation of the route which points the allocation prefix of the local node (default true)
       --enable-node-port                                      Enable NodePort type services by Cilium (beta)
       --enable-policy string                                  Enable policy enforcement (default "default")
       --enable-tracing                                        Enable tracing while determining policy (debugging)

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -277,6 +277,9 @@ func init() {
 	flags.Bool(option.EnableEndpointHealthChecking, defaults.EnableEndpointHealthChecking, "Enable connectivity health checking between virtual endpoints")
 	option.BindEnv(option.EnableEndpointHealthChecking)
 
+	flags.Bool(option.EnableLocalNodeRoute, defaults.EnableLocalNodeRoute, "Enable installation of the route which points the allocation prefix of the local node")
+	option.BindEnv(option.EnableLocalNodeRoute)
+
 	flags.Bool(option.EnableIPv4Name, defaults.EnableIPv4, "Enable IPv4 support")
 	option.BindEnv(option.EnableIPv4Name)
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -159,6 +159,9 @@ const (
 	// DatapathMode is the default value for the datapath mode.
 	DatapathMode = "veth"
 
+	// EnableLocalNodeRoute default value for EnableLocalNodeRoute
+	EnableLocalNodeRoute = true
+
 	// EnableAutoDirectRouting is the default value for EnableAutoDirectRouting
 	EnableAutoDirectRouting = false
 

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -59,7 +59,7 @@ type NodeDiscovery struct {
 }
 
 func enableLocalNodeRoute() bool {
-	return !option.Config.IsFlannelMasterDeviceSet() && option.Config.IPAM != option.IPAMENI
+	return option.Config.EnableLocalNodeRoute && !option.Config.IsFlannelMasterDeviceSet() && option.Config.IPAM != option.IPAMENI
 }
 
 // NewNodeDiscovery returns a pointer to new node discovery object

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -619,6 +619,10 @@ const (
 	// DisableCNPStatusUpdates disables updating of CNP NodeStatus in the CNP
 	// CRD.
 	DisableCNPStatusUpdates = "disable-cnp-status-updates"
+
+	// EnableLocalNodeRoute controls installation of the route which points
+	// the allocation prefix of the local node.
+	EnableLocalNodeRoute = "enable-local-node-route"
 )
 
 // Default string arguments
@@ -1087,6 +1091,10 @@ type DaemonConfig struct {
 	// EnableAutoDirectRouting enables installation of direct routes to
 	// other nodes when available
 	EnableAutoDirectRouting bool
+
+	// EnableLocalNodeRoute controls installation of the route which points
+	// the allocation prefix of the local node.
+	EnableLocalNodeRoute bool
 
 	// EnableHealthChecking enables health checking between nodes and
 	// health endpoints
@@ -1596,6 +1604,7 @@ func (c *DaemonConfig) Populate() {
 	c.EnableEndpointRoutes = viper.GetBool(EnableEndpointRoutes)
 	c.EnableHealthChecking = viper.GetBool(EnableHealthChecking)
 	c.EnableEndpointHealthChecking = viper.GetBool(EnableEndpointHealthChecking)
+	c.EnableLocalNodeRoute = viper.GetBool(EnableLocalNodeRoute)
 	c.EnablePolicy = strings.ToLower(viper.GetString(EnablePolicy))
 	c.EnableTracing = viper.GetBool(EnableTracing)
 	c.EnableNodePort = viper.GetBool(EnableNodePort)


### PR DESCRIPTION
Controls adding the route which points to the allocation prefix of the
local node. The option can be used to avoid adding the route when an
external process is managing the routes.

This basically plumbs `nodediscovery.enableLocalNodeRoute()` out to the CLI options.

It is a first step in being able to use cilium in generic-veth mode with the bridge cni plugin (and kube-router in CNI mode), since the `cni0` interface created by `bridge` already holds the route for the node's podCIDR (allocation prefix), in this case cilium shouldn't go about overriding that route.

Fixes: #9503

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9505)
<!-- Reviewable:end -->
