### PR TITLE
eni: Allow releasing excess IP addresses via option

### DIFF
--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -18,6 +18,7 @@ cilium-operator [flags]
       --api-server-port uint16                 Port on which the operator should serve API requests (default 9234)
       --aws-client-burst int                   Burst value allowed for the AWS client used by the AWS ENI IPAM (default 4)
       --aws-client-qps float                   Queries per second limit for the AWS client used by the AWS ENI IPAM (default 20)
+      --aws-release-excess-ips                 Enable releasing excess free IP addresses from AWS ENI.
       --cilium-endpoint-gc                     Enable CiliumEndpoint garbage collector (default true)
       --cilium-endpoint-gc-interval duration   GC interval for cilium endpoints (default 30m0s)
       --cluster-id int                         Unique identifier of the cluster

--- a/operator/eni.go
+++ b/operator/eni.go
@@ -146,7 +146,8 @@ func startENIAllocator(awsClientQPSLimit float64, awsClientBurst int, eniTags ma
 
 	// Start an interval based  background resync for safety, it will
 	// synchronize the state regularly and resolve eventual deficit if the
-	// event driven trigger fails
+	// event driven trigger fails, and also release excess IP addresses
+	// if release-excess-ips is enabled
 	go func() {
 		time.Sleep(time.Minute)
 		mngr := controller.NewManager()
@@ -178,12 +179,13 @@ type noOpMetrics struct{}
 // eni metricsAPI interface implementation
 func (m *noOpMetrics) IncENIAllocationAttempt(status, subnetID string)                           {}
 func (m *noOpMetrics) AddIPAllocation(subnetID string, allocated int64)                          {}
+func (m *noOpMetrics) AddIPRelease(subnetID string, released int64)                              {}
 func (m *noOpMetrics) SetAllocatedIPs(typ string, allocated int)                                 {}
 func (m *noOpMetrics) SetAvailableENIs(available int)                                            {}
 func (m *noOpMetrics) SetAvailableIPsPerSubnet(subnetID, availabilityZone string, available int) {}
 func (m *noOpMetrics) SetNodes(category string, nodes int)                                       {}
 func (m *noOpMetrics) IncResyncCount()                                                           {}
-func (m *noOpMetrics) DeficitResolverTrigger() trigger.MetricsObserver {
+func (m *noOpMetrics) PoolMaintainerTrigger() trigger.MetricsObserver {
 	return &noOpMetricsObserver{}
 }
 func (m *noOpMetrics) K8sSyncTrigger() trigger.MetricsObserver {

--- a/operator/main.go
+++ b/operator/main.go
@@ -116,6 +116,8 @@ func init() {
 	flags.Uint16Var(&apiServerPort, "api-server-port", 9234, "Port on which the operator should serve API requests")
 	flags.String(option.IPAM, "", "Backend to use for IPAM")
 	option.BindEnv(option.IPAM)
+	flags.Bool(option.AwsReleaseExcessIps, false, "Enable releasing excess free IP addresses from AWS ENI.")
+	option.BindEnv(option.AwsReleaseExcessIps)
 	flags.BoolVar(&enableMetrics, "enable-metrics", false, "Enable Prometheus metrics")
 	flags.StringVar(&metricsAddress, "metrics-address", ":6942", "Address to serve Prometheus metrics")
 	flags.BoolVar(&synchronizeServices, "synchronize-k8s-services", true, "Synchronize Kubernetes services to kvstore")
@@ -178,6 +180,7 @@ func initConfig() {
 	option.Config.ClusterID = viper.GetInt(option.ClusterIDName)
 	option.Config.DisableCiliumEndpointCRD = viper.GetBool(option.DisableCiliumEndpointCRDName)
 	option.Config.K8sNamespace = viper.GetString(option.K8sNamespaceName)
+	option.Config.AwsReleaseExcessIps = viper.GetBool(option.AwsReleaseExcessIps)
 
 	viper.SetEnvPrefix("cilium")
 	viper.SetConfigName("cilium-operator")

--- a/pkg/aws/ec2/ec2.go
+++ b/pkg/aws/ec2/ec2.go
@@ -397,6 +397,21 @@ func (c *Client) AssignPrivateIpAddresses(ctx context.Context, eniID string, add
 	return err
 }
 
+// UnassignPrivateIpAddresses unassigns specified IP addresses from ENI
+func (c *Client) UnassignPrivateIpAddresses(ctx context.Context, eniID string, addresses []string) error {
+	request := ec2.UnassignPrivateIpAddressesInput{
+		NetworkInterfaceId: &eniID,
+		PrivateIpAddresses: addresses,
+	}
+
+	c.rateLimit(ctx, "UnassignPrivateIpAddresses")
+	sinceStart := spanstat.Start()
+	req := c.ec2Client.UnassignPrivateIpAddressesRequest(&request)
+	_, err := req.Send(ctx)
+	c.metricsAPI.ObserveEC2APICall("UnassignPrivateIpAddresses", deriveStatus(req.Request, err), sinceStart.Seconds())
+	return err
+}
+
 // TagENI creates the specified tags on the ENI
 func (c *Client) TagENI(ctx context.Context, eniID string, eniTags map[string]string) error {
 	request := ec2.CreateTagsInput{

--- a/pkg/aws/ec2/mock/mock_test.go
+++ b/pkg/aws/ec2/mock/mock_test.go
@@ -96,6 +96,10 @@ func (e *MockSuite) TestSetMockError(c *check.C) {
 	err = api.AssignPrivateIpAddresses(context.TODO(), "e-1", 10)
 	c.Assert(err, check.Equals, mockError)
 
+	api.SetMockError(UnassignPrivateIpAddresses, mockError)
+	err = api.UnassignPrivateIpAddresses(context.TODO(), "e-1", []string{"10.0.0.10", "10.0.0.11"})
+	c.Assert(err, check.Equals, mockError)
+
 	api.SetMockError(ModifyNetworkInterface, mockError)
 	err = api.ModifyNetworkInterface(context.TODO(), "e-1", "a-1", true)
 	c.Assert(err, check.Equals, mockError)
@@ -111,6 +115,7 @@ func (e *MockSuite) TestSetDelay(c *check.C) {
 	c.Assert(api.delays[ModifyNetworkInterface], check.Equals, time.Second)
 	c.Assert(api.delays[AttachNetworkInterface], check.Equals, time.Second)
 	c.Assert(api.delays[AssignPrivateIpAddresses], check.Equals, time.Second)
+	c.Assert(api.delays[UnassignPrivateIpAddresses], check.Equals, time.Second)
 }
 
 func (e *MockSuite) TestSetLimiter(c *check.C) {

--- a/pkg/aws/eni/metrics/mock/mock.go
+++ b/pkg/aws/eni/metrics/mock/mock.go
@@ -26,6 +26,7 @@ type mockMetrics struct {
 	mutex                 lock.RWMutex
 	allocationAttempts    map[string]int64
 	ipAllocations         map[string]int64
+	ipReleases            map[string]int64
 	allocatedIPs          map[string]int
 	availableENIs         int
 	availableIPsPerSubnet map[string]int
@@ -40,6 +41,7 @@ func NewMockMetrics() *mockMetrics {
 	return &mockMetrics{
 		allocationAttempts:    map[string]int64{},
 		ipAllocations:         map[string]int64{},
+		ipReleases:            map[string]int64{},
 		allocatedIPs:          map[string]int{},
 		nodes:                 map[string]int{},
 		availableIPsPerSubnet: map[string]int{},
@@ -69,6 +71,12 @@ func (m *mockMetrics) IPAllocations(subnetID string) int64 {
 func (m *mockMetrics) AddIPAllocation(subnetID string, allocated int64) {
 	m.mutex.Lock()
 	m.ipAllocations["subnetId="+subnetID] += allocated
+	m.mutex.Unlock()
+}
+
+func (m *mockMetrics) AddIPRelease(subnetID string, released int64) {
+	m.mutex.Lock()
+	m.ipReleases["subnetId="+subnetID] += released
 	m.mutex.Unlock()
 }
 
@@ -150,7 +158,7 @@ func (m *mockMetrics) IncResyncCount() {
 	m.mutex.Unlock()
 }
 
-func (m *mockMetrics) DeficitResolverTrigger() trigger.MetricsObserver {
+func (m *mockMetrics) PoolMaintainerTrigger() trigger.MetricsObserver {
 	return nil
 }
 

--- a/pkg/aws/eni/node_test.go
+++ b/pkg/aws/eni/node_test.go
@@ -20,7 +20,7 @@ import (
 	"gopkg.in/check.v1"
 )
 
-type testDef struct {
+type testNeededDef struct {
 	available   int
 	used        int
 	preallocate int
@@ -28,7 +28,16 @@ type testDef struct {
 	result      int
 }
 
-var def = []testDef{
+type testExcessDef struct {
+	available         int
+	used              int
+	preallocate       int
+	minallocate       int
+	maxabovewatermark int
+	result            int
+}
+
+var neededDef = []testNeededDef{
 	{0, 0, 0, 16, 16},
 	{0, 0, 8, 16, 16},
 	{0, 0, 16, 8, 16},
@@ -38,9 +47,27 @@ var def = []testDef{
 	{8, 4, 8, 8, 4},
 }
 
+var excessDef = []testExcessDef{
+	{0, 0, 0, 16, 0, 0},
+	{15, 0, 8, 16, 8, 0},
+	{17, 0, 8, 16, 8, 1},
+	{20, 0, 8, 20, 8, 0},
+	{16, 1, 8, 16, 8, 0},
+	{20, 4, 8, 17, 8, 0},
+	{20, 4, 0, 0, 0, 8},
+	{20, 4, 0, 0, 8, 0},
+}
+
 func (e *ENISuite) TestCalculateNeededIPs(c *check.C) {
-	for _, d := range def {
+	for _, d := range neededDef {
 		result := calculateNeededIPs(d.available, d.used, d.preallocate, d.minallocate)
+		c.Assert(result, check.Equals, d.result)
+	}
+}
+
+func (e *ENISuite) TestCalculateExcessIPs(c *check.C) {
+	for _, d := range excessDef {
+		result := calculateExcessIPs(d.available, d.used, d.preallocate, d.minallocate, d.maxabovewatermark)
 		c.Assert(result, check.Equals, d.result)
 	}
 }

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -82,6 +82,11 @@ const (
 	// e.g. {"a1.medium": "2,4,4", "a2.custom2": "4,5,6"}
 	AwsInstanceLimitMapping = "aws-instance-limit-mapping"
 
+	// AwsReleaseExcessIps allows releasing excess free IP addresses from ENI.
+	// Enabling this option reduces waste of IP addresses but may increase
+	// the number of API calls to AWS EC2 service.
+	AwsReleaseExcessIps = "aws-release-excess-ips"
+
 	// BPFRoot is the Path to BPF filesystem
 	BPFRoot = "bpf-root"
 
@@ -1251,6 +1256,11 @@ type DaemonConfig struct {
 	// pkg/aws/eni/limits.go
 	// e.g. {"a1.medium": "2,4,4", "a2.custom2": "4,5,6"}
 	AwsInstanceLimitMapping map[string]string
+
+	// AwsReleaseExcessIps allows releasing excess free IP addresses from ENI.
+	// Enabling this option reduces waste of IP addresses but may increase
+	// the number of API calls to AWS EC2 service.
+	AwsReleaseExcessIps bool
 }
 
 var (
@@ -1870,6 +1880,7 @@ func (c *DaemonConfig) Populate() {
 	c.SelectiveRegeneration = viper.GetBool(SelectiveRegeneration)
 	c.SkipCRDCreation = viper.GetBool(SkipCRDCreation)
 	c.DisableCNPStatusUpdates = viper.GetBool(DisableCNPStatusUpdates)
+	c.AwsReleaseExcessIps = viper.GetBool(AwsReleaseExcessIps)
 }
 
 func sanitizeIntParam(paramName string, paramDefault int) int {


### PR DESCRIPTION
Allow releasing excess IP addresses from ENI via operator option
`--aws-release-excess-ips`
This option allows to reduce waste of IP addresses.

When set to true, cilium-operator checks the number of addresses
regularly and attempt to release some free addresses if:

available > min-allocate && available - used > preallocate + max-above-watermark

The check and action will be executed every minute when the
interval based backgroud resync is triggered. Release actions will
always be executed after allocations.

There is no limit on ENIs per subnet so ENIs are remained on the node.

Fixes: #9424

Signed-off-by: Jaff Cheng <jaff.cheng.sh@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9509)
<!-- Reviewable:end -->
