### PR TITLE
k8s: Provision NodePort services for LoadBalancer

### DIFF
--- a/pkg/k8s/service.go
+++ b/pkg/k8s/service.go
@@ -111,7 +111,7 @@ func ParseService(svc *types.Service) (ServiceID, *Service) {
 		// would introduce more complexity in already too complex LB codebase,
 		// so for now (until we have refactored the LB code) keep NodePort
 		// frontends in Service.NodePorts.
-		if svc.Spec.Type == v1.ServiceTypeNodePort {
+		if svc.Spec.Type == v1.ServiceTypeNodePort || svc.Spec.Type == v1.ServiceTypeLoadBalancer {
 			if option.Config.EnableNodePort {
 				if _, ok := svcInfo.NodePorts[portName]; !ok {
 					svcInfo.NodePorts[portName] =


### PR DESCRIPTION
Some k8s external loadbalancers expect a service of the `LoadBalancer` type to be reachable via a NodePort defined by the service.

Therefore, in the case of the NodePort BPF, for each k8s `LoadBalancer` service, we need to provision a BPF service for a NodePort defined in such service.

Will add integration tests once we have a proper `LoadBalancer` support.

Fix #9508

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9510)
<!-- Reviewable:end -->
