### PR TITLE
kvstore: plumb context

### DIFF
--- a/cilium/cmd/kvstore.go
+++ b/cilium/cmd/kvstore.go
@@ -15,6 +15,8 @@
 package cmd
 
 import (
+	"context"
+
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/option"
 
@@ -56,7 +58,7 @@ func setupKvstore() {
 		}
 	}
 
-	if err := kvstore.Setup(kvStore, kvStoreOpts, nil); err != nil {
+	if err := kvstore.Setup(context.TODO(), kvStore, kvStoreOpts, nil); err != nil {
 		Fatalf("Unable to setup kvstore: %s", err)
 	}
 }

--- a/cilium/cmd/kvstore_delete.go
+++ b/cilium/cmd/kvstore_delete.go
@@ -15,6 +15,8 @@
 package cmd
 
 import (
+	"context"
+
 	"github.com/cilium/cilium/pkg/kvstore"
 
 	"github.com/spf13/cobra"
@@ -32,11 +34,11 @@ var kvstoreDeleteCmd = &cobra.Command{
 		}
 
 		if recursive {
-			if err := kvstore.DeletePrefix(args[0]); err != nil {
+			if err := kvstore.DeletePrefix(context.TODO(), args[0]); err != nil {
 				Fatalf("Unable to delete keys: %s", err)
 			}
 		} else {
-			if err := kvstore.Delete(args[0]); err != nil {
+			if err := kvstore.Delete(context.TODO(), args[0]); err != nil {
 				Fatalf("Unable to delete key: %s", err)
 			}
 		}

--- a/cilium/cmd/kvstore_get.go
+++ b/cilium/cmd/kvstore_get.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -38,7 +39,7 @@ var kvstoreGetCmd = &cobra.Command{
 		}
 
 		if recursive {
-			pairs, err := kvstore.ListPrefix(key)
+			pairs, err := kvstore.ListPrefix(context.TODO(), key)
 			if err != nil {
 				Fatalf("Unable to list keys: %s", err)
 			}
@@ -52,7 +53,7 @@ var kvstoreGetCmd = &cobra.Command{
 				fmt.Printf("%s => %s\n", k, string(v.Data))
 			}
 		} else {
-			val, err := kvstore.Get(key)
+			val, err := kvstore.Get(context.TODO(), key)
 			if err != nil || val == nil {
 				Fatalf("Unable to retrieve key: %s", err)
 			}

--- a/cilium/cmd/kvstore_set.go
+++ b/cilium/cmd/kvstore_set.go
@@ -15,6 +15,8 @@
 package cmd
 
 import (
+	"context"
+
 	"github.com/cilium/cilium/pkg/kvstore"
 
 	"github.com/spf13/cobra"
@@ -36,7 +38,7 @@ var kvstoreSetCmd = &cobra.Command{
 
 		setupKvstore()
 
-		err := kvstore.Set(key, value)
+		err := kvstore.Set(context.TODO(), key, value)
 		if err != nil {
 			Fatalf("Unable to set key: %s", err)
 		}

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -1142,7 +1142,7 @@ func (d *Daemon) initKVStore() {
 		}
 	}
 
-	if err := kvstore.Setup(option.Config.KVStore, option.Config.KVStoreOpt, goopts); err != nil {
+	if err := kvstore.Setup(context.TODO(), option.Config.KVStore, option.Config.KVStoreOpt, goopts); err != nil {
 		addrkey := fmt.Sprintf("%s.address", option.Config.KVStore)
 		addr := option.Config.KVStoreOpt[addrkey]
 

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -116,8 +116,8 @@ func (ds *DaemonSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 	ds.d = d
 
-	kvstore.DeletePrefix(common.OperationalPath)
-	kvstore.DeletePrefix(kvstore.BaseKeyPrefix)
+	kvstore.DeletePrefix(context.TODO(), common.OperationalPath)
+	kvstore.DeletePrefix(context.TODO(), kvstore.BaseKeyPrefix)
 
 	ds.OnGetPolicyRepository = nil
 	ds.OnQueueEndpointBuild = nil
@@ -136,8 +136,8 @@ func (ds *DaemonSuite) TearDownTest(c *C) {
 	}
 
 	if ds.kvstoreInit {
-		kvstore.DeletePrefix(common.OperationalPath)
-		kvstore.DeletePrefix(kvstore.BaseKeyPrefix)
+		kvstore.DeletePrefix(context.TODO(), common.OperationalPath)
+		kvstore.DeletePrefix(context.TODO(), kvstore.BaseKeyPrefix)
 	}
 
 	// Restore the policy enforcement mode.

--- a/operator/k8s_node.go
+++ b/operator/k8s_node.go
@@ -74,7 +74,7 @@ func runNodeWatcher() error {
 				if n := k8s.CopyObjToV1Node(obj); n != nil {
 					serNodes.Enqueue(func() error {
 						nodeNew := k8s.ParseNode(n, source.Kubernetes)
-						ciliumNodeStore.UpdateKeySync(nodeNew)
+						ciliumNodeStore.UpdateKeySync(context.TODO(), nodeNew)
 						return nil
 					}, serializer.NoRetry)
 				}
@@ -88,7 +88,7 @@ func runNodeWatcher() error {
 
 						serNodes.Enqueue(func() error {
 							newNode := k8s.ParseNode(newNode, source.Kubernetes)
-							ciliumNodeStore.UpdateKeySync(newNode)
+							ciliumNodeStore.UpdateKeySync(context.TODO(), newNode)
 							return nil
 						}, serializer.NoRetry)
 					}
@@ -111,7 +111,7 @@ func runNodeWatcher() error {
 				}
 				serNodes.Enqueue(func() error {
 					deletedNode := k8s.ParseNode(n, source.Kubernetes)
-					ciliumNodeStore.DeleteLocalKey(deletedNode)
+					ciliumNodeStore.DeleteLocalKey(context.TODO(), deletedNode)
 					deleteCiliumNode(n.Name)
 					return nil
 				}, serializer.NoRetry)
@@ -154,7 +154,7 @@ func runNodeWatcher() error {
 
 			for _, kvStoreNode := range kvStoreNodes {
 				if strings.HasPrefix(kvStoreNode.GetKeyName(), option.Config.ClusterName) {
-					ciliumNodeStore.DeleteLocalKey(kvStoreNode)
+					ciliumNodeStore.DeleteLocalKey(context.TODO(), kvStoreNode)
 				}
 			}
 

--- a/operator/k8s_service_sync.go
+++ b/operator/k8s_service_sync.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"time"
 
 	"github.com/cilium/cilium/pkg/k8s"
@@ -60,16 +61,16 @@ func k8sServiceHandler() {
 
 		if !event.Service.Shared {
 			// The annotation may have been added, delete an eventual existing service
-			servicesStore.DeleteLocalKey(&svc)
+			servicesStore.DeleteLocalKey(context.TODO(), &svc)
 			return
 		}
 
 		switch event.Action {
 		case k8s.UpdateService:
-			servicesStore.UpdateLocalKeySync(&svc)
+			servicesStore.UpdateLocalKeySync(context.TODO(), &svc)
 
 		case k8s.DeleteService:
-			servicesStore.DeleteLocalKey(&svc)
+			servicesStore.DeleteLocalKey(context.TODO(), &svc)
 		}
 	}
 	for {

--- a/operator/main.go
+++ b/operator/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -288,7 +289,7 @@ func runOperator(cmd *cobra.Command) {
 			scopedLog.Info("cilium-operator running without service synchronization: automatic etcd service translation disabled")
 		}
 		scopedLog.Info("Connecting to kvstore...")
-		if err := kvstore.Setup(kvStore, kvStoreOpts, goopts); err != nil {
+		if err := kvstore.Setup(context.TODO(), kvStore, kvStoreOpts, goopts); err != nil {
 			scopedLog.WithError(err).Fatal("Unable to setup kvstore")
 		}
 

--- a/pkg/allocator/allocator.go
+++ b/pkg/allocator/allocator.go
@@ -443,7 +443,7 @@ func (a *Allocator) lockedAllocate(ctx context.Context, key AllocatorKey) (idpoo
 		return 0, false, err
 	}
 
-	defer lock.Unlock()
+	defer lock.Unlock(ctx)
 
 	// fetch first key that matches /value/<key> while ignoring the
 	// node suffix

--- a/pkg/allocator/allocator_test.go
+++ b/pkg/allocator/allocator_test.go
@@ -101,7 +101,7 @@ func (d *dummyBackend) AcquireReference(ctx context.Context, id idpool.ID, key A
 
 type dummyLock struct{}
 
-func (d *dummyLock) Unlock() error {
+func (d *dummyLock) Unlock(ctx context.Context) error {
 	return nil
 }
 

--- a/pkg/clustermesh/clustermesh_test.go
+++ b/pkg/clustermesh/clustermesh_test.go
@@ -17,6 +17,7 @@
 package clustermesh
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -142,7 +143,7 @@ func (s *ClusterMeshTestSuite) TestClusterMesh(c *C) {
 	for _, rc := range cm.clusters {
 		rc.mutex.RLock()
 		for _, name := range nodeNames {
-			err = rc.remoteNodes.UpdateLocalKeySync(&testNode{Name: name, Cluster: rc.name})
+			err = rc.remoteNodes.UpdateLocalKeySync(context.TODO(), &testNode{Name: name, Cluster: rc.name})
 			c.Assert(err, IsNil)
 		}
 		rc.mutex.RUnlock()

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -113,7 +113,7 @@ func (rc *remoteCluster) releaseOldConnection() {
 	}
 
 	if rc.remoteNodes != nil {
-		rc.remoteNodes.Close()
+		rc.remoteNodes.Close(context.TODO())
 		rc.remoteNodes = nil
 	}
 	if rc.remoteIdentityCache != nil {
@@ -121,7 +121,7 @@ func (rc *remoteCluster) releaseOldConnection() {
 		rc.remoteIdentityCache = nil
 	}
 	if rc.remoteServices != nil {
-		rc.remoteServices.Close()
+		rc.remoteServices.Close(context.TODO())
 		rc.remoteServices = nil
 	}
 	if rc.backend != nil {
@@ -140,7 +140,7 @@ func (rc *remoteCluster) restartRemoteConnection(allocator RemoteIdentityWatcher
 				}
 				rc.mutex.Unlock()
 
-				backend, errChan := kvstore.NewClient(kvstore.EtcdBackendName,
+				backend, errChan := kvstore.NewClient(context.TODO(), kvstore.EtcdBackendName,
 					map[string]string{
 						kvstore.EtcdOptionConfig: rc.configPath,
 					},
@@ -187,7 +187,7 @@ func (rc *remoteCluster) restartRemoteConnection(allocator RemoteIdentityWatcher
 					},
 				})
 				if err != nil {
-					remoteNodes.Close()
+					remoteNodes.Close(context.TODO())
 					backend.Close()
 					return err
 				}

--- a/pkg/ipcache/kvstore.go
+++ b/pkg/ipcache/kvstore.go
@@ -79,7 +79,7 @@ func (k kvstoreImplementation) upsert(ctx context.Context, key string, value str
 
 // release removes the specified key from the kvstore.
 func (k kvstoreImplementation) release(ctx context.Context, key string) error {
-	return kvstore.Delete(key)
+	return kvstore.Delete(ctx, key)
 }
 
 // kvReferenceCounter provides a thin wrapper around the kvstore which adds
@@ -212,7 +212,7 @@ func (iw *IPIdentityWatcher) Watch() {
 
 	var scopedLog *logrus.Entry
 restart:
-	watcher := iw.backend.ListAndWatch("endpointIPWatcher", IPIdentitiesPath, 512)
+	watcher := iw.backend.ListAndWatch(context.TODO(), "endpointIPWatcher", IPIdentitiesPath, 512)
 
 	for {
 		select {

--- a/pkg/k8s/identitybackend/identity.go
+++ b/pkg/k8s/identitybackend/identity.go
@@ -254,7 +254,7 @@ type crdLock struct{}
 
 // Unlock does not unlock a lock object. Locking is not supported with the k8s
 // CRD allocator. It is here to meet interface requirements.
-func (c *crdLock) Unlock() error {
+func (c *crdLock) Unlock(ctx context.Context) error {
 	return nil
 }
 

--- a/pkg/k8s/watchers/cilium_endpoint.go
+++ b/pkg/k8s/watchers/cilium_endpoint.go
@@ -15,6 +15,7 @@
 package watchers
 
 import (
+	"context"
 	"net"
 	"sync"
 
@@ -118,7 +119,7 @@ func (k *K8sWatcher) ciliumEndpointsInit(ciliumNPClient *k8s.K8sCiliumClient, se
 		k.k8sAPIGroups.addAPI(k8sAPIGroupCiliumEndpointV2)
 		go ciliumEndpointInformer.Run(isConnected)
 
-		<-kvstore.Client().Connected()
+		<-kvstore.Client().Connected(context.TODO())
 		close(isConnected)
 
 		log.Info("Connected to key-value store, stopping CiliumEndpoint watcher")

--- a/pkg/k8s/watchers/cilium_node.go
+++ b/pkg/k8s/watchers/cilium_node.go
@@ -15,6 +15,7 @@
 package watchers
 
 import (
+	"context"
 	"sync"
 
 	"github.com/cilium/cilium/pkg/k8s"
@@ -121,7 +122,7 @@ func (k *K8sWatcher) ciliumNodeInit(ciliumNPClient *k8s.K8sCiliumClient, serNode
 		k.k8sAPIGroups.addAPI(k8sAPIGroupCiliumNodeV2)
 		go ciliumNodeInformer.Run(isConnected)
 
-		<-kvstore.Client().Connected()
+		<-kvstore.Client().Connected(context.TODO())
 		close(isConnected)
 
 		log.Info("Connected to key-value store, stopping CiliumNode watcher")

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -15,6 +15,7 @@
 package watchers
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"sync"
@@ -128,7 +129,7 @@ func (k *K8sWatcher) podsInit(k8sClient kubernetes.Interface, serPods *serialize
 		// Replace pod controller by only receiving events from our own
 		// node once we are connected to the kvstore.
 
-		<-kvstore.Client().Connected()
+		<-kvstore.Client().Connected(context.TODO())
 		close(isConnected)
 
 		log.WithField(logfields.Node, node.GetName()).Info("Connected to KVStore, watching for pod events on node")

--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -101,6 +101,8 @@ type kvstoreBackend struct {
 	deleteInvalidPrefixes bool
 
 	keyType allocator.AllocatorKey
+
+	ctx context.Context
 }
 
 func locklessCapability() bool {
@@ -140,7 +142,8 @@ func (k *kvstoreBackend) lockPath(ctx context.Context, key string) (*kvstore.Loc
 
 // DeleteAllKeys will delete all keys
 func (k *kvstoreBackend) DeleteAllKeys() {
-	kvstore.DeletePrefix(k.basePrefix)
+	kvstore.DeletePrefix(context.TODO(), k.basePrefix)
+	kvstore.DeletePrefix(context.TODO(), k.basePrefix)
 }
 
 // AllocateID allocates a key->ID mapping in the kvstore.
@@ -217,7 +220,7 @@ func (k *kvstoreBackend) Get(ctx context.Context, key allocator.AllocatorKey) (i
 	//
 	// Only key1 should match
 	prefix := path.Join(k.valuePrefix, kvstore.Encode(key.GetKey()))
-	pairs, err := kvstore.ListPrefix(prefix)
+	pairs, err := kvstore.ListPrefix(ctx, prefix)
 	kvstore.Trace("ListPrefix", err, logrus.Fields{fieldPrefix: prefix, "entries": len(pairs)})
 	if err != nil {
 		return 0, err
@@ -254,7 +257,7 @@ func (k *kvstoreBackend) GetIfLocked(ctx context.Context, key allocator.Allocato
 	//
 	// Only key1 should match
 	prefix := path.Join(k.valuePrefix, kvstore.Encode(key.GetKey()))
-	pairs, err := kvstore.ListPrefixIfLocked(prefix, lock)
+	pairs, err := kvstore.ListPrefixIfLocked(ctx, prefix, lock)
 	kvstore.Trace("ListPrefixLocked", err, logrus.Fields{fieldPrefix: prefix, "entries": len(pairs)})
 	if err != nil {
 		return 0, err
@@ -275,7 +278,7 @@ func (k *kvstoreBackend) GetIfLocked(ctx context.Context, key allocator.Allocato
 // GetByID returns the key associated with an ID. Returns nil if no key is
 // associated with the ID.
 func (k *kvstoreBackend) GetByID(id idpool.ID) (allocator.AllocatorKey, error) {
-	v, err := kvstore.Get(path.Join(k.idPrefix, id.String()))
+	v, err := kvstore.Get(context.TODO(), path.Join(k.idPrefix, id.String()))
 	if err != nil {
 		return nil, err
 	}
@@ -381,7 +384,7 @@ func (k *kvstoreBackend) Release(ctx context.Context, key allocator.AllocatorKey
 
 	// does not need to be deleted with a lock as its protected by the
 	// Allocator.slaveKeysMutex
-	if err := kvstore.Delete(valueKey); err != nil {
+	if err := kvstore.Delete(ctx, valueKey); err != nil {
 		log.WithError(err).WithFields(logrus.Fields{fieldKey: key}).Warning("Ignoring node specific ID")
 		return err
 	}
@@ -398,7 +401,7 @@ func (k *kvstoreBackend) Release(ctx context.Context, key allocator.AllocatorKey
 // RunGC scans the kvstore for unused master keys and removes them
 func (k *kvstoreBackend) RunGC(staleKeysPrevRound map[string]uint64) (map[string]uint64, error) {
 	// fetch list of all /id/ keys
-	allocated, err := kvstore.ListPrefix(k.idPrefix)
+	allocated, err := kvstore.ListPrefix(context.TODO(), k.idPrefix)
 	if err != nil {
 		return nil, fmt.Errorf("list failed: %s", err)
 	}
@@ -411,7 +414,7 @@ func (k *kvstoreBackend) RunGC(staleKeysPrevRound map[string]uint64) (map[string
 		// FIXME: Add DeleteOnZeroCount support
 		// }
 
-		lock, err := k.lockPath(context.Background(), key)
+		lock, err := k.lockPath(context.TODO(), key)
 		if err != nil {
 			log.WithError(err).WithField(fieldKey, key).Warning("allocator garbage collector was unable to lock key")
 			continue
@@ -419,10 +422,10 @@ func (k *kvstoreBackend) RunGC(staleKeysPrevRound map[string]uint64) (map[string
 
 		// fetch list of all /value/<key> keys
 		valueKeyPrefix := path.Join(k.valuePrefix, string(v.Data))
-		pairs, err := kvstore.ListPrefixIfLocked(valueKeyPrefix, lock)
+		pairs, err := kvstore.ListPrefixIfLocked(context.TODO(), valueKeyPrefix, lock)
 		if err != nil {
 			log.WithError(err).WithField(fieldPrefix, valueKeyPrefix).Warning("allocator garbage collector was unable to list keys")
-			lock.Unlock()
+			lock.Unlock(context.TODO())
 			continue
 		}
 
@@ -442,7 +445,7 @@ func (k *kvstoreBackend) RunGC(staleKeysPrevRound map[string]uint64) (map[string
 			})
 			// Only delete if this key was previously marked as to be deleted
 			if modRev, ok := staleKeysPrevRound[key]; ok && modRev == v.ModRevision {
-				if err := kvstore.DeleteIfLocked(key, lock); err != nil {
+				if err := kvstore.DeleteIfLocked(context.TODO(), key, lock); err != nil {
 					scopedLog.WithError(err).Warning("Unable to delete unused allocator master key")
 				} else {
 					scopedLog.Info("Deleted unused allocator master key")
@@ -453,7 +456,7 @@ func (k *kvstoreBackend) RunGC(staleKeysPrevRound map[string]uint64) (map[string
 			}
 		}
 
-		lock.Unlock()
+		lock.Unlock(context.TODO())
 	}
 
 	return staleKeys, nil
@@ -478,7 +481,7 @@ func (k *kvstoreBackend) keyToID(key string) (id idpool.ID, err error) {
 }
 
 func (k *kvstoreBackend) ListAndWatch(handler allocator.CacheMutations, stopChan chan struct{}) {
-	watcher := kvstore.ListAndWatch(k.idPrefix, k.idPrefix, 512)
+	watcher := kvstore.ListAndWatch(context.TODO(), k.idPrefix, k.idPrefix, 512)
 
 	for {
 		select {
@@ -497,7 +500,7 @@ func (k *kvstoreBackend) ListAndWatch(handler allocator.CacheMutations, stopChan
 				log.WithError(err).WithField(fieldKey, event.Key).Warning("Invalid key")
 
 				if k.deleteInvalidPrefixes {
-					kvstore.Delete(event.Key)
+					kvstore.Delete(context.TODO(), event.Key)
 				}
 
 			case id != idpool.NoID:

--- a/pkg/kvstore/allocator/allocator_test.go
+++ b/pkg/kvstore/allocator/allocator_test.go
@@ -52,7 +52,7 @@ func (e *AllocatorEtcdSuite) SetUpTest(c *C) {
 }
 
 func (e *AllocatorEtcdSuite) TearDownTest(c *C) {
-	kvstore.DeletePrefix(testPrefix)
+	kvstore.DeletePrefix(context.TODO(), testPrefix)
 	kvstore.Close()
 }
 
@@ -67,7 +67,7 @@ func (e *AllocatorConsulSuite) SetUpTest(c *C) {
 }
 
 func (e *AllocatorConsulSuite) TearDownTest(c *C) {
-	kvstore.DeletePrefix(testPrefix)
+	kvstore.DeletePrefix(context.TODO(), testPrefix)
 	kvstore.Close()
 }
 
@@ -218,7 +218,7 @@ func testAllocator(c *C, maxID idpool.ID, allocatorName string, suffix string) {
 	staleKeysPreviousRound, err = a.RunGC(staleKeysPreviousRound)
 	c.Assert(err, IsNil)
 
-	v, err := kvstore.ListPrefix(path.Join(allocatorName, "id"))
+	v, err := kvstore.ListPrefix(context.TODO(), path.Join(allocatorName, "id"))
 	c.Assert(err, IsNil)
 	c.Assert(len(v), Equals, int(maxID))
 
@@ -233,7 +233,7 @@ func testAllocator(c *C, maxID idpool.ID, allocatorName string, suffix string) {
 	_, err = a.RunGC(staleKeysPreviousRound)
 	c.Assert(err, IsNil)
 
-	v, err = kvstore.ListPrefix(path.Join(allocatorName, "id"))
+	v, err = kvstore.ListPrefix(context.TODO(), path.Join(allocatorName, "id"))
 	c.Assert(err, IsNil)
 	c.Assert(len(v), Equals, 0)
 

--- a/pkg/kvstore/backwards_compat.go
+++ b/pkg/kvstore/backwards_compat.go
@@ -15,6 +15,8 @@
 package kvstore
 
 import (
+	"context"
+
 	"github.com/cilium/cilium/common"
 )
 
@@ -31,7 +33,7 @@ import (
 //    path must be created which automatically removes the old keys on successful
 //    translation.
 //
-func deleteLegacyPrefixes() {
+func deleteLegacyPrefixes(ctx context.Context) {
 	// Delete all keys in old services prefix
-	DeletePrefix(common.ServicePathV1)
+	DeletePrefix(ctx, common.ServicePathV1)
 }

--- a/pkg/kvstore/base_test.go
+++ b/pkg/kvstore/base_test.go
@@ -34,14 +34,14 @@ type BaseTests struct{}
 func (s *BaseTests) TestLock(c *C) {
 	prefix := "locktest/"
 
-	DeletePrefix(prefix)
-	defer DeletePrefix(prefix)
+	DeletePrefix(context.TODO(), prefix)
+	defer DeletePrefix(context.TODO(), prefix)
 
 	for i := 0; i < 10; i++ {
 		lock, err := LockPath(context.Background(), fmt.Sprintf("%sfoo/%d", prefix, i))
 		c.Assert(err, IsNil)
 		c.Assert(lock, Not(IsNil))
-		lock.Unlock()
+		lock.Unlock(context.TODO())
 	}
 }
 
@@ -57,8 +57,8 @@ func (s *BaseTests) TestGetSet(c *C) {
 	prefix := "unit-test/"
 	maxID := 256
 
-	DeletePrefix(prefix)
-	defer DeletePrefix(prefix)
+	DeletePrefix(context.TODO(), prefix)
+	defer DeletePrefix(context.TODO(), prefix)
 
 	key, val, err := GetPrefix(context.Background(), prefix)
 	c.Assert(err, IsNil)
@@ -66,7 +66,7 @@ func (s *BaseTests) TestGetSet(c *C) {
 	c.Assert(key, Equals, "")
 
 	for i := 0; i < maxID; i++ {
-		val, err = Get(testKey(prefix, i))
+		val, err = Get(context.TODO(), testKey(prefix, i))
 		c.Assert(err, IsNil)
 		c.Assert(val, IsNil)
 
@@ -75,21 +75,21 @@ func (s *BaseTests) TestGetSet(c *C) {
 		c.Assert(val, IsNil)
 		c.Assert(key, Equals, "")
 
-		c.Assert(Set(testKey(prefix, i), testValue(i)), IsNil)
+		c.Assert(Set(context.TODO(), testKey(prefix, i), testValue(i)), IsNil)
 
-		val, err = Get(testKey(prefix, i))
+		val, err = Get(context.TODO(), testKey(prefix, i))
 		c.Assert(err, IsNil)
 		c.Assert(*val, checker.DeepEquals, testValue(i))
 
-		val, err = Get(testKey(prefix, i))
+		val, err = Get(context.TODO(), testKey(prefix, i))
 		c.Assert(err, IsNil)
 		c.Assert(*val, checker.DeepEquals, testValue(i))
 	}
 
 	for i := 0; i < maxID; i++ {
-		c.Assert(Delete(testKey(prefix, i)), IsNil)
+		c.Assert(Delete(context.TODO(), testKey(prefix, i)), IsNil)
 
-		val, err = Get(testKey(prefix, i))
+		val, err = Get(context.TODO(), testKey(prefix, i))
 		c.Assert(err, IsNil)
 		c.Assert(val, IsNil)
 
@@ -108,8 +108,8 @@ func (s *BaseTests) TestGetSet(c *C) {
 func (s *BaseTests) TestGetPrefix(c *C) {
 	prefix := "unit-test/"
 
-	DeletePrefix(prefix)
-	defer DeletePrefix(prefix)
+	DeletePrefix(context.TODO(), prefix)
+	defer DeletePrefix(context.TODO(), prefix)
 
 	key, val, err := GetPrefix(context.Background(), prefix)
 	c.Assert(err, IsNil)
@@ -122,7 +122,7 @@ func (s *BaseTests) TestGetPrefix(c *C) {
 	testKey := fmt.Sprintf("%s%s/%010d", prefix, labelsLong, 0)
 	c.Assert(Update(context.Background(), testKey, testValue(0), true), IsNil)
 
-	val, err = Get(testKey)
+	val, err = Get(context.TODO(), testKey)
 	c.Assert(err, IsNil)
 	c.Assert(*val, checker.DeepEquals, testValue(0))
 
@@ -141,35 +141,35 @@ func (s *BaseTests) TestGetPrefix(c *C) {
 
 func (s *BaseTests) BenchmarkGet(c *C) {
 	prefix := "unit-test/"
-	DeletePrefix(prefix)
-	defer DeletePrefix(prefix)
+	DeletePrefix(context.TODO(), prefix)
+	defer DeletePrefix(context.TODO(), prefix)
 
 	key := testKey(prefix, 1)
-	c.Assert(Set(key, testValue(100)), IsNil)
+	c.Assert(Set(context.TODO(), key, testValue(100)), IsNil)
 
 	c.ResetTimer()
 	for i := 0; i < c.N; i++ {
-		Get(key)
+		Get(context.TODO(), key)
 	}
 }
 
 func (s *BaseTests) BenchmarkSet(c *C) {
 	prefix := "unit-test/"
-	DeletePrefix(prefix)
-	defer DeletePrefix(prefix)
+	DeletePrefix(context.TODO(), prefix)
+	defer DeletePrefix(context.TODO(), prefix)
 
 	key, val := testKey(prefix, 1), testValue(100)
 	c.ResetTimer()
 	for i := 0; i < c.N; i++ {
-		Set(key, val)
+		Set(context.TODO(), key, val)
 	}
 }
 
 func (s *BaseTests) TestUpdate(c *C) {
 	prefix := "unit-test/"
 
-	DeletePrefix(prefix)
-	defer DeletePrefix(prefix)
+	DeletePrefix(context.TODO(), prefix)
+	defer DeletePrefix(context.TODO(), prefix)
 
 	key, val, err := GetPrefix(context.Background(), prefix)
 	c.Assert(err, IsNil)
@@ -179,14 +179,14 @@ func (s *BaseTests) TestUpdate(c *C) {
 	// create
 	c.Assert(Update(context.Background(), testKey(prefix, 0), testValue(0), true), IsNil)
 
-	val, err = Get(testKey(prefix, 0))
+	val, err = Get(context.TODO(), testKey(prefix, 0))
 	c.Assert(err, IsNil)
 	c.Assert(*val, checker.DeepEquals, testValue(0))
 
 	// update
 	c.Assert(Update(context.Background(), testKey(prefix, 0), testValue(0), true), IsNil)
 
-	val, err = Get(testKey(prefix, 0))
+	val, err = Get(context.TODO(), testKey(prefix, 0))
 	c.Assert(err, IsNil)
 	c.Assert(*val, checker.DeepEquals, testValue(0))
 }
@@ -194,8 +194,8 @@ func (s *BaseTests) TestUpdate(c *C) {
 func (s *BaseTests) TestCreateOnly(c *C) {
 	prefix := "unit-test/"
 
-	DeletePrefix(prefix)
-	defer DeletePrefix(prefix)
+	DeletePrefix(context.TODO(), prefix)
+	defer DeletePrefix(context.TODO(), prefix)
 
 	key, val, err := GetPrefix(context.Background(), prefix)
 	c.Assert(err, IsNil)
@@ -206,7 +206,7 @@ func (s *BaseTests) TestCreateOnly(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(success, Equals, true)
 
-	val, err = Get(testKey(prefix, 0))
+	val, err = Get(context.TODO(), testKey(prefix, 0))
 	c.Assert(err, IsNil)
 	c.Assert(*val, checker.DeepEquals, testValue(0))
 
@@ -214,21 +214,21 @@ func (s *BaseTests) TestCreateOnly(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(success, Equals, false)
 
-	val, err = Get(testKey(prefix, 0))
+	val, err = Get(context.TODO(), testKey(prefix, 0))
 	c.Assert(err, IsNil)
 	c.Assert(*val, checker.DeepEquals, testValue(0))
 
 	// key 1 does not exist so CreateIfExists should fail
-	c.Assert(CreateIfExists(testKey(prefix, 1), testKey(prefix, 2), testValue(2), false), Not(IsNil))
+	c.Assert(CreateIfExists(context.TODO(), testKey(prefix, 1), testKey(prefix, 2), testValue(2), false), Not(IsNil))
 
-	val, err = Get(testKey(prefix, 2))
+	val, err = Get(context.TODO(), testKey(prefix, 2))
 	c.Assert(err, IsNil)
 	c.Assert(val, IsNil)
 
 	// key 0 exists so CreateIfExists should succeed
-	c.Assert(CreateIfExists(testKey(prefix, 0), testKey(prefix, 2), testValue(2), false), IsNil)
+	c.Assert(CreateIfExists(context.TODO(), testKey(prefix, 0), testKey(prefix, 2), testValue(2), false), IsNil)
 
-	val, err = Get(testKey(prefix, 2))
+	val, err = Get(context.TODO(), testKey(prefix, 2))
 	c.Assert(err, IsNil)
 	c.Assert(*val, checker.DeepEquals, testValue(2))
 }
@@ -255,14 +255,14 @@ func (s *BaseTests) TestListAndWatch(c *C) {
 	key1, key2 := "foo2/key1", "foo2/key2"
 	val1, val2 := "val1", "val2"
 
-	DeletePrefix("foo2/")
-	defer DeletePrefix("foo2/")
+	DeletePrefix(context.TODO(), "foo2/")
+	defer DeletePrefix(context.TODO(), "foo2/")
 
 	success, err := CreateOnly(context.Background(), key1, val1, false)
 	c.Assert(err, IsNil)
 	c.Assert(success, Equals, true)
 
-	w := ListAndWatch("testWatcher2", "foo2/", 100)
+	w := ListAndWatch(context.TODO(), "testWatcher2", "foo2/", 100)
 	c.Assert(c, Not(IsNil))
 
 	expectEvent(c, w, EventTypeCreate, key1, val1)
@@ -273,7 +273,7 @@ func (s *BaseTests) TestListAndWatch(c *C) {
 	c.Assert(success, Equals, true)
 	expectEvent(c, w, EventTypeCreate, key2, val2)
 
-	err = Delete(key1)
+	err = Delete(context.TODO(), key1)
 	c.Assert(err, IsNil)
 	expectEvent(c, w, EventTypeDelete, key1, val1)
 
@@ -282,11 +282,11 @@ func (s *BaseTests) TestListAndWatch(c *C) {
 	c.Assert(success, Equals, true)
 	expectEvent(c, w, EventTypeCreate, key1, val1)
 
-	err = Delete(key1)
+	err = Delete(context.TODO(), key1)
 	c.Assert(err, IsNil)
 	expectEvent(c, w, EventTypeDelete, key1, val1)
 
-	err = Delete(key2)
+	err = Delete(context.TODO(), key2)
 	c.Assert(err, IsNil)
 	expectEvent(c, w, EventTypeDelete, key2, val2)
 

--- a/pkg/kvstore/config.go
+++ b/pkg/kvstore/config.go
@@ -15,6 +15,7 @@
 package kvstore
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -81,7 +82,7 @@ var (
 	setupOnce sync.Once
 )
 
-func setup(selectedBackend string, opts map[string]string, goOpts *ExtraOptions) error {
+func setup(ctx context.Context, selectedBackend string, opts map[string]string, goOpts *ExtraOptions) error {
 	module := getBackend(selectedBackend)
 	if module == nil {
 		return fmt.Errorf("unknown key-value store type %q. See cilium.link/err-kvstore for details", selectedBackend)
@@ -97,16 +98,16 @@ func setup(selectedBackend string, opts map[string]string, goOpts *ExtraOptions)
 
 	selectedModule = module.getName()
 
-	return initClient(module, goOpts)
+	return initClient(ctx, module, goOpts)
 }
 
 // Setup sets up the key-value store specified in kvStore and configures it
 // with the options provided in opts
-func Setup(selectedBackend string, opts map[string]string, goOpts *ExtraOptions) error {
+func Setup(ctx context.Context, selectedBackend string, opts map[string]string, goOpts *ExtraOptions) error {
 	var err error
 
 	setupOnce.Do(func() {
-		err = setup(selectedBackend, opts, goOpts)
+		err = setup(ctx, selectedBackend, opts, goOpts)
 	})
 
 	return err

--- a/pkg/kvstore/consul_test.go
+++ b/pkg/kvstore/consul_test.go
@@ -17,6 +17,7 @@
 package kvstore
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"os"
@@ -76,7 +77,7 @@ func TestConsulClientOk(t *testing.T) {
 		close(doneC)
 	}
 
-	_, err := newConsulClient(&consulAPI.Config{
+	_, err := newConsulClient(context.TODO(), &consulAPI.Config{
 		Address: ":8000",
 	}, nil)
 

--- a/pkg/kvstore/dummy.go
+++ b/pkg/kvstore/dummy.go
@@ -14,6 +14,8 @@
 
 package kvstore
 
+import "context"
+
 // SetupDummy sets up kvstore for tests
 func SetupDummy(dummyBackend string) {
 	module := getBackend(dummyBackend)
@@ -23,7 +25,7 @@ func SetupDummy(dummyBackend string) {
 
 	module.setConfigDummy()
 
-	if err := initClient(module, nil); err != nil {
+	if err := initClient(context.TODO(), module, nil); err != nil {
 		log.WithError(err).Panic("Unable to initialize kvstore client")
 	}
 }

--- a/pkg/kvstore/etcd_test.go
+++ b/pkg/kvstore/etcd_test.go
@@ -398,7 +398,7 @@ func (e *EtcdLockedSuite) TestGetIfLocked(c *C) {
 				if err != nil {
 					return err
 				}
-				return args.lock.Unlock()
+				return args.lock.Unlock(context.TODO())
 			},
 		},
 		{
@@ -422,7 +422,7 @@ func (e *EtcdLockedSuite) TestGetIfLocked(c *C) {
 				}
 			},
 			cleanup: func(args args) error {
-				return args.lock.Unlock()
+				return args.lock.Unlock(context.TODO())
 			},
 		},
 		{
@@ -431,7 +431,7 @@ func (e *EtcdLockedSuite) TestGetIfLocked(c *C) {
 				key := randomPath + "foo"
 				kvlocker, err := Client().LockPath(context.Background(), "locks/"+key+"/.lock")
 				c.Assert(err, IsNil)
-				err = kvlocker.Unlock()
+				err = kvlocker.Unlock(context.TODO())
 				c.Assert(err, IsNil)
 
 				_, err = e.etcdClient.Put(context.Background(), key, "bar")
@@ -458,7 +458,7 @@ func (e *EtcdLockedSuite) TestGetIfLocked(c *C) {
 		c.Log(tt.name)
 		args := tt.setupArgs()
 		want := tt.setupWanted()
-		value, err := Client().GetIfLocked(args.key, args.lock)
+		value, err := Client().GetIfLocked(context.TODO(), args.key, args.lock)
 		c.Assert(err, Equals, want.err)
 		c.Assert(value, checker.DeepEquals, want.value)
 		err = tt.cleanup(args)
@@ -509,7 +509,7 @@ func (e *EtcdLockedSuite) TestGetPrefixIfLocked(c *C) {
 				if err != nil {
 					return err
 				}
-				return args.lock.Unlock()
+				return args.lock.Unlock(context.TODO())
 			},
 		},
 		{
@@ -531,7 +531,7 @@ func (e *EtcdLockedSuite) TestGetPrefixIfLocked(c *C) {
 				}
 			},
 			cleanup: func(args args) error {
-				return args.lock.Unlock()
+				return args.lock.Unlock(context.TODO())
 			},
 		},
 		{
@@ -540,7 +540,7 @@ func (e *EtcdLockedSuite) TestGetPrefixIfLocked(c *C) {
 				key := randomPath + "foo"
 				kvlocker, err := Client().LockPath(context.Background(), "locks/"+key+"/.lock")
 				c.Assert(err, IsNil)
-				err = kvlocker.Unlock()
+				err = kvlocker.Unlock(context.TODO())
 				c.Assert(err, IsNil)
 				_, err = e.etcdClient.Put(context.Background(), key, "bar")
 				c.Assert(err, IsNil)
@@ -616,7 +616,7 @@ func (e *EtcdLockedSuite) TestDeleteIfLocked(c *C) {
 				c.Assert(err, IsNil)
 				c.Assert(gr.Count, Equals, int64(0))
 
-				return args.lock.Unlock()
+				return args.lock.Unlock(context.TODO())
 			},
 		},
 		{
@@ -647,7 +647,7 @@ func (e *EtcdLockedSuite) TestDeleteIfLocked(c *C) {
 				c.Assert(err, IsNil)
 				c.Assert(gr.Count, Equals, int64(0))
 
-				return args.lock.Unlock()
+				return args.lock.Unlock(context.TODO())
 			},
 		},
 		{
@@ -658,7 +658,7 @@ func (e *EtcdLockedSuite) TestDeleteIfLocked(c *C) {
 				c.Assert(err, IsNil)
 				_, err = e.etcdClient.Put(context.Background(), key, "bar")
 				c.Assert(err, IsNil)
-				err = kvlocker.Unlock()
+				err = kvlocker.Unlock(context.TODO())
 				c.Assert(err, IsNil)
 
 				return args{
@@ -686,7 +686,7 @@ func (e *EtcdLockedSuite) TestDeleteIfLocked(c *C) {
 		c.Log(tt.name)
 		args := tt.setupArgs()
 		want := tt.setupWanted()
-		err := Client().DeleteIfLocked(args.key, args.lock)
+		err := Client().DeleteIfLocked(context.TODO(), args.key, args.lock)
 		c.Assert(err, Equals, want.err)
 		err = tt.cleanup(args)
 		c.Assert(err, IsNil)
@@ -738,7 +738,7 @@ func (e *EtcdLockedSuite) TestUpdateIfLocked(c *C) {
 				c.Assert(gr.Count, Equals, int64(1))
 				c.Assert(gr.Kvs[0].Value, checker.DeepEquals, []byte("newbar"))
 
-				return args.lock.Unlock()
+				return args.lock.Unlock(context.TODO())
 			},
 		},
 		{
@@ -770,7 +770,7 @@ func (e *EtcdLockedSuite) TestUpdateIfLocked(c *C) {
 				c.Assert(gr.Count, Equals, int64(1))
 				c.Assert(gr.Kvs[0].Value, checker.DeepEquals, []byte("newbar"))
 
-				return args.lock.Unlock()
+				return args.lock.Unlock(context.TODO())
 			},
 		},
 		{
@@ -781,7 +781,7 @@ func (e *EtcdLockedSuite) TestUpdateIfLocked(c *C) {
 				c.Assert(err, IsNil)
 				_, err = e.etcdClient.Put(context.Background(), key, "bar")
 				c.Assert(err, IsNil)
-				err = kvlocker.Unlock()
+				err = kvlocker.Unlock(context.TODO())
 				c.Assert(err, IsNil)
 
 				return args{
@@ -833,7 +833,7 @@ func (e *EtcdLockedSuite) TestUpdateIfLocked(c *C) {
 				c.Assert(gr.Count, Equals, int64(1))
 				c.Assert(gr.Kvs[0].Value, checker.DeepEquals, []byte("newbar"))
 
-				return args.lock.Unlock()
+				return args.lock.Unlock(context.TODO())
 			},
 		},
 		{
@@ -866,7 +866,7 @@ func (e *EtcdLockedSuite) TestUpdateIfLocked(c *C) {
 				c.Assert(gr.Count, Equals, int64(1))
 				c.Assert(gr.Kvs[0].Value, checker.DeepEquals, []byte("newbar"))
 
-				return args.lock.Unlock()
+				return args.lock.Unlock(context.TODO())
 			},
 		},
 		{
@@ -877,7 +877,7 @@ func (e *EtcdLockedSuite) TestUpdateIfLocked(c *C) {
 				c.Assert(err, IsNil)
 				_, err = e.etcdClient.Put(context.Background(), key, "bar")
 				c.Assert(err, IsNil)
-				err = kvlocker.Unlock()
+				err = kvlocker.Unlock(context.TODO())
 				c.Assert(err, IsNil)
 
 				return args{
@@ -961,7 +961,7 @@ func (e *EtcdLockedSuite) TestUpdateIfDifferentIfLocked(c *C) {
 				c.Assert(gr.Kvs[0].Value, checker.DeepEquals, []byte("newbar"))
 				_, err = e.etcdClient.Delete(context.Background(), key)
 				c.Assert(err, IsNil)
-				return args.lock.Unlock()
+				return args.lock.Unlock(context.TODO())
 			},
 		},
 		{
@@ -992,7 +992,7 @@ func (e *EtcdLockedSuite) TestUpdateIfDifferentIfLocked(c *C) {
 				c.Assert(gr.Count, Equals, int64(1))
 				c.Assert(gr.Kvs[0].Value, checker.DeepEquals, []byte("bar"))
 
-				return args.lock.Unlock()
+				return args.lock.Unlock(context.TODO())
 			},
 		},
 		{
@@ -1026,7 +1026,7 @@ func (e *EtcdLockedSuite) TestUpdateIfDifferentIfLocked(c *C) {
 				c.Assert(gr.Kvs[0].Value, checker.DeepEquals, []byte("newbar"))
 				_, err = e.etcdClient.Delete(context.Background(), key)
 				c.Assert(err, IsNil)
-				return args.lock.Unlock()
+				return args.lock.Unlock(context.TODO())
 			},
 		},
 		{
@@ -1037,7 +1037,7 @@ func (e *EtcdLockedSuite) TestUpdateIfDifferentIfLocked(c *C) {
 				c.Assert(err, IsNil)
 				_, err = e.etcdClient.Put(context.Background(), key, "bar")
 				c.Assert(err, IsNil)
-				err = kvlocker.Unlock()
+				err = kvlocker.Unlock(context.TODO())
 				c.Assert(err, IsNil)
 
 				return args{
@@ -1094,7 +1094,7 @@ func (e *EtcdLockedSuite) TestUpdateIfDifferentIfLocked(c *C) {
 				c.Assert(gr.Kvs[0].Value, checker.DeepEquals, []byte("newbar"))
 				_, err = e.etcdClient.Delete(context.Background(), key)
 				c.Assert(err, IsNil)
-				return args.lock.Unlock()
+				return args.lock.Unlock(context.TODO())
 			},
 		},
 		{
@@ -1131,7 +1131,7 @@ func (e *EtcdLockedSuite) TestUpdateIfDifferentIfLocked(c *C) {
 				_, err = e.etcdClient.Delete(context.Background(), key)
 				c.Assert(err, IsNil)
 
-				return args.lock.Unlock()
+				return args.lock.Unlock(context.TODO())
 			},
 		},
 		{
@@ -1165,7 +1165,7 @@ func (e *EtcdLockedSuite) TestUpdateIfDifferentIfLocked(c *C) {
 				c.Assert(gr.Kvs[0].Value, checker.DeepEquals, []byte("bar"))
 				_, err = e.etcdClient.Delete(context.Background(), key)
 				c.Assert(err, IsNil)
-				return args.lock.Unlock()
+				return args.lock.Unlock(context.TODO())
 			},
 		},
 		{
@@ -1176,7 +1176,7 @@ func (e *EtcdLockedSuite) TestUpdateIfDifferentIfLocked(c *C) {
 				c.Assert(err, IsNil)
 				_, err = e.etcdClient.Put(context.Background(), key, "bar")
 				c.Assert(err, IsNil)
-				err = kvlocker.Unlock()
+				err = kvlocker.Unlock(context.TODO())
 				c.Assert(err, IsNil)
 
 				return args{
@@ -1261,7 +1261,7 @@ func (e *EtcdLockedSuite) TestCreateOnlyIfLocked(c *C) {
 				c.Assert(gr.Count, Equals, int64(1))
 				c.Assert(gr.Kvs[0].Value, checker.DeepEquals, []byte("newbar"))
 
-				return args.lock.Unlock()
+				return args.lock.Unlock(context.TODO())
 			},
 		},
 		{
@@ -1294,7 +1294,7 @@ func (e *EtcdLockedSuite) TestCreateOnlyIfLocked(c *C) {
 				c.Assert(gr.Count, Equals, int64(1))
 				c.Assert(gr.Kvs[0].Value, checker.DeepEquals, []byte("bar"))
 
-				return args.lock.Unlock()
+				return args.lock.Unlock(context.TODO())
 			},
 		},
 		{
@@ -1305,7 +1305,7 @@ func (e *EtcdLockedSuite) TestCreateOnlyIfLocked(c *C) {
 				c.Assert(err, IsNil)
 				_, err = e.etcdClient.Delete(context.Background(), key)
 				c.Assert(err, IsNil)
-				err = kvlocker.Unlock()
+				err = kvlocker.Unlock(context.TODO())
 				c.Assert(err, IsNil)
 
 				return args{
@@ -1359,7 +1359,7 @@ func (e *EtcdLockedSuite) TestCreateOnlyIfLocked(c *C) {
 				c.Assert(gr.Count, Equals, int64(1))
 				c.Assert(gr.Kvs[0].Value, checker.DeepEquals, []byte("newbar"))
 
-				return args.lock.Unlock()
+				return args.lock.Unlock(context.TODO())
 			},
 		},
 		{
@@ -1393,7 +1393,7 @@ func (e *EtcdLockedSuite) TestCreateOnlyIfLocked(c *C) {
 				c.Assert(gr.Count, Equals, int64(1))
 				c.Assert(gr.Kvs[0].Value, checker.DeepEquals, []byte("bar"))
 
-				return args.lock.Unlock()
+				return args.lock.Unlock(context.TODO())
 			},
 		},
 		{
@@ -1404,7 +1404,7 @@ func (e *EtcdLockedSuite) TestCreateOnlyIfLocked(c *C) {
 				c.Assert(err, IsNil)
 				_, err = e.etcdClient.Delete(context.Background(), key)
 				c.Assert(err, IsNil)
-				err = kvlocker.Unlock()
+				err = kvlocker.Unlock(context.TODO())
 				c.Assert(err, IsNil)
 
 				return args{
@@ -1492,7 +1492,7 @@ func (e *EtcdLockedSuite) TestListPrefixIfLocked(c *C) {
 				if err != nil {
 					return err
 				}
-				return args.lock.Unlock()
+				return args.lock.Unlock(context.TODO())
 			},
 		},
 		{
@@ -1515,7 +1515,7 @@ func (e *EtcdLockedSuite) TestListPrefixIfLocked(c *C) {
 				}
 			},
 			cleanup: func(args args) error {
-				return args.lock.Unlock()
+				return args.lock.Unlock(context.TODO())
 			},
 		},
 		{
@@ -1528,7 +1528,7 @@ func (e *EtcdLockedSuite) TestListPrefixIfLocked(c *C) {
 				c.Assert(err, IsNil)
 				_, err = e.etcdClient.Put(context.Background(), key+"1", "bar1")
 				c.Assert(err, IsNil)
-				err = kvlocker.Unlock()
+				err = kvlocker.Unlock(context.TODO())
 				c.Assert(err, IsNil)
 
 				return args{
@@ -1551,7 +1551,7 @@ func (e *EtcdLockedSuite) TestListPrefixIfLocked(c *C) {
 		c.Log(tt.name)
 		args := tt.setupArgs()
 		want := tt.setupWanted()
-		kvPairs, err := Client().ListPrefixIfLocked(args.key, args.lock)
+		kvPairs, err := Client().ListPrefixIfLocked(context.TODO(), args.key, args.lock)
 		c.Assert(err, Equals, want.err)
 		for k, v := range kvPairs {
 			// We don't compare revision of the value because we can't predict

--- a/pkg/kvstore/events.go
+++ b/pkg/kvstore/events.go
@@ -15,6 +15,7 @@
 package kvstore
 
 import (
+	"context"
 	"sync"
 )
 
@@ -109,8 +110,8 @@ func (w *Watcher) String() string {
 //
 // Returns a watcher structure plus a channel that is closed when the initial
 // list operation has been completed
-func ListAndWatch(name, prefix string, chanSize int) *Watcher {
-	return Client().ListAndWatch(name, prefix, chanSize)
+func ListAndWatch(ctx context.Context, name, prefix string, chanSize int) *Watcher {
+	return Client().ListAndWatch(ctx, name, prefix, chanSize)
 }
 
 // Stop stops a watcher previously created and started with Watch()

--- a/pkg/kvstore/kvstore.go
+++ b/pkg/kvstore/kvstore.go
@@ -48,8 +48,8 @@ const (
 )
 
 // Get returns value of key
-func Get(key string) (*string, error) {
-	bv, err := Client().Get(key)
+func Get(ctx context.Context, key string) (*string, error) {
+	bv, err := Client().Get(ctx, key)
 	Trace("Get", err, logrus.Fields{fieldKey: key, fieldValue: string(bv)})
 	if bv == nil {
 		return nil, err
@@ -59,8 +59,8 @@ func Get(key string) (*string, error) {
 }
 
 // GetIfLocked returns value of key if the client is still holding the given lock.
-func GetIfLocked(key string, lock KVLocker) (*string, error) {
-	bv, err := Client().GetIfLocked(key, lock)
+func GetIfLocked(ctx context.Context, key string, lock KVLocker) (*string, error) {
+	bv, err := Client().GetIfLocked(ctx, key, lock)
 	Trace("GetIfLocked", err, logrus.Fields{fieldKey: key, fieldValue: string(bv)})
 	if bv == nil {
 		return nil, err
@@ -92,15 +92,15 @@ func GetPrefixIfLocked(ctx context.Context, prefix string, lock KVLocker) (strin
 }
 
 // ListPrefix returns the list of keys matching the prefix
-func ListPrefix(prefix string) (KeyValuePairs, error) {
-	v, err := Client().ListPrefix(prefix)
+func ListPrefix(ctx context.Context, prefix string) (KeyValuePairs, error) {
+	v, err := Client().ListPrefix(ctx, prefix)
 	Trace("ListPrefix", err, logrus.Fields{fieldPrefix: prefix, fieldNumEntries: len(v)})
 	return v, err
 }
 
 // ListPrefixIfLocked  returns a list of keys matching the prefix only if the client is still holding the given lock.
-func ListPrefixIfLocked(prefix string, lock KVLocker) (KeyValuePairs, error) {
-	v, err := Client().ListPrefixIfLocked(prefix, lock)
+func ListPrefixIfLocked(ctx context.Context, prefix string, lock KVLocker) (KeyValuePairs, error) {
+	v, err := Client().ListPrefixIfLocked(ctx, prefix, lock)
 	Trace("ListPrefixIfLocked", err, logrus.Fields{fieldPrefix: prefix, fieldNumEntries: len(v)})
 	return v, err
 }
@@ -159,36 +159,36 @@ func UpdateIfDifferentIfLocked(ctx context.Context, key string, value string, le
 }
 
 // CreateIfExists creates a key with the value only if key condKey exists
-func CreateIfExists(condKey, key string, value string, lease bool) error {
-	err := Client().CreateIfExists(condKey, key, []byte(value), lease)
+func CreateIfExists(ctx context.Context, condKey, key string, value string, lease bool) error {
+	err := Client().CreateIfExists(ctx, condKey, key, []byte(value), lease)
 	Trace("CreateIfExists", err, logrus.Fields{fieldKey: key, fieldValue: string(value), fieldCondition: condKey, fieldAttachLease: lease})
 	return err
 }
 
 // Set sets the value of a key
-func Set(key string, value string) error {
-	err := Client().Set(key, []byte(value))
+func Set(ctx context.Context, key string, value string) error {
+	err := Client().Set(ctx, key, []byte(value))
 	Trace("Set", err, logrus.Fields{fieldKey: key, fieldValue: string(value)})
 	return err
 }
 
 // Delete deletes a key
-func Delete(key string) error {
-	err := Client().Delete(key)
+func Delete(ctx context.Context, key string) error {
+	err := Client().Delete(ctx, key)
 	Trace("Delete", err, logrus.Fields{fieldKey: key})
 	return err
 }
 
 // DeleteIfLocked deletes a key if the client is still holding the given lock.
-func DeleteIfLocked(key string, lock KVLocker) error {
-	err := Client().DeleteIfLocked(key, lock)
+func DeleteIfLocked(ctx context.Context, key string, lock KVLocker) error {
+	err := Client().DeleteIfLocked(ctx, key, lock)
 	Trace("DeleteIfLocked", err, logrus.Fields{fieldKey: key})
 	return err
 }
 
 // DeletePrefix deletes all keys matching a prefix
-func DeletePrefix(prefix string) error {
-	err := Client().DeletePrefix(prefix)
+func DeletePrefix(ctx context.Context, prefix string) error {
+	err := Client().DeletePrefix(ctx, prefix)
 	Trace("DeletePrefix", err, logrus.Fields{fieldPrefix: prefix})
 	return err
 }

--- a/pkg/kvstore/lock.go
+++ b/pkg/kvstore/lock.go
@@ -43,7 +43,7 @@ var (
 )
 
 type KVLocker interface {
-	Unlock() error
+	Unlock(ctx context.Context) error
 	// Comparator returns an object that should be used by the KVStore to make
 	// sure if the lock is still valid for its client or nil if no such
 	// verification exists.
@@ -158,13 +158,13 @@ func RunLockGC() {
 }
 
 // Unlock unlocks a lock
-func (l *Lock) Unlock() error {
+func (l *Lock) Unlock(ctx context.Context) error {
 	if l == nil {
 		return nil
 	}
 
 	// Unlock kvstore mutex first
-	err := l.kvLock.Unlock()
+	err := l.kvLock.Unlock(ctx)
 	if err != nil {
 		log.WithError(err).WithField("path", l.path).Error("Unable to unlock kvstore lock")
 	}

--- a/pkg/node/store/store.go
+++ b/pkg/node/store/store.go
@@ -15,6 +15,7 @@
 package store
 
 import (
+	"context"
 	"path"
 
 	"github.com/cilium/cilium/pkg/kvstore"
@@ -105,7 +106,7 @@ func (nr *NodeRegistrar) RegisterNode(n *node.Node, manager NodeManager) error {
 		return err
 	}
 
-	if err = store.UpdateLocalKeySync(n); err != nil {
+	if err = store.UpdateLocalKeySync(context.TODO(), n); err != nil {
 		store.Release()
 		return err
 	}
@@ -118,5 +119,5 @@ func (nr *NodeRegistrar) RegisterNode(n *node.Node, manager NodeManager) error {
 // UpdateLocalKeySync synchronizes the local key for the node using the
 // SharedStore.
 func (nr *NodeRegistrar) UpdateLocalKeySync(n *node.Node) error {
-	return nr.SharedStore.UpdateLocalKeySync(n)
+	return nr.SharedStore.UpdateLocalKeySync(context.TODO(), n)
 }


### PR DESCRIPTION
etcd and consul both take in `context.Context` as inputs, but we did not always
pass down said type into invocations of their APIs. Update `pkg/kvstore` to take
in `context.Context`, and pass in `context.TODO()` into packages that use
functions that were updated to take in `context.Context` in the Cilium codebase.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9512)
<!-- Reviewable:end -->
