### PR TITLE
install: fix label used in ServiceMonitor to select cilium-agent

### DIFF
--- a/install/kubernetes/cilium/charts/agent/templates/servicemonitor.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/servicemonitor.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      k8s-app: cilium-agent
+      k8s-app: cilium
   namespaceSelector:
     matchNames:
     - {{ .Release.Namespace }}


### PR DESCRIPTION
The ServiceMonitor uses labels to select a Service resource, and the
corresponding Service resource is labeled with `k8s-app: cilium`.

```release-note
fix label used in ServiceMonitor to select cilium-agent
```

I was testing this out locally. I'm running cilium 1.6.3 and prometheus-operator chart 6.7.3 which runs prometheus-operator 0.31.1. Had to make this change to get metrics from cilium-agent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9514)
<!-- Reviewable:end -->
