### PR TITLE
datapath: make `Datapath` an `IptablesManager`

### DIFF
--- a/daemon/config.go
+++ b/daemon/config.go
@@ -87,7 +87,7 @@ func (h *patchConfig) Handle(params PatchConfigParams) middleware.Responder {
 	if changes > 0 {
 		// Only recompile if configuration has changed.
 		log.Debug("daemon configuration has changed; recompiling base programs")
-		if err := d.Datapath().Loader().Reinitialize(d.ctx, d, d.mtuConfig.GetDeviceMTU(), d.iptablesManager, d.l7Proxy, d.ipam); err != nil {
+		if err := d.Datapath().Loader().Reinitialize(d.ctx, d, d.mtuConfig.GetDeviceMTU(), d.Datapath(), d.l7Proxy, d.ipam); err != nil {
 			msg := fmt.Errorf("Unable to recompile base programs: %s", err)
 			return api.Error(PatchConfigFailureCode, msg)
 		}

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -1184,7 +1184,7 @@ func runDaemon() {
 	iptablesManager := &iptables.IptablesManager{}
 	iptablesManager.Init()
 
-	d, restoredEndpoints, err := NewDaemon(server.ServerCtx, linuxdatapath.NewDatapath(datapathConfig, iptablesManager), iptablesManager)
+	d, restoredEndpoints, err := NewDaemon(server.ServerCtx, linuxdatapath.NewDatapath(datapathConfig, iptablesManager))
 	if err != nil {
 		log.WithError(err).Fatal("Error while creating daemon")
 		return

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -112,7 +112,7 @@ func (ds *DaemonSuite) SetUpTest(c *C) {
 	ds.oldPolicyEnabled = policy.GetPolicyEnabled()
 	policy.SetPolicyEnabled(option.DefaultEnforcement)
 
-	d, _, err := NewDaemon(context.Background(), fakedatapath.NewDatapath(), nil)
+	d, _, err := NewDaemon(context.Background(), fakedatapath.NewDatapath())
 	c.Assert(err, IsNil)
 	ds.d = d
 

--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -270,7 +270,7 @@ func (d *Daemon) policyAdd(sourceRules policyAPI.Rules, opts *policy.AddOptions,
 	if newPrefixLengths && !bpfIPCache.BackedByLPM() {
 		// Only recompile if configuration has changed.
 		logger.Debug("CIDR policy has changed; recompiling base programs")
-		if err := d.Datapath().Loader().Reinitialize(d.ctx, d, d.mtuConfig.GetDeviceMTU(), d.iptablesManager, d.l7Proxy, d.ipam); err != nil {
+		if err := d.Datapath().Loader().Reinitialize(d.ctx, d, d.mtuConfig.GetDeviceMTU(), d.Datapath(), d.l7Proxy, d.ipam); err != nil {
 			_ = d.prefixLengths.Delete(prefixes)
 			metrics.PolicyImportErrors.Inc()
 			err2 := fmt.Errorf("Unable to recompile base programs: %s", err)
@@ -576,7 +576,7 @@ func (d *Daemon) policyDelete(labels labels.LabelArray, res chan interface{}) {
 	if !bpfIPCache.BackedByLPM() && prefixesChanged {
 		// Only recompile if configuration has changed.
 		log.Debug("CIDR policy has changed; recompiling base programs")
-		if err := d.Datapath().Loader().Reinitialize(d.ctx, d, d.mtuConfig.GetDeviceMTU(), d.iptablesManager, d.l7Proxy, d.ipam); err != nil {
+		if err := d.Datapath().Loader().Reinitialize(d.ctx, d, d.mtuConfig.GetDeviceMTU(), d.Datapath(), d.l7Proxy, d.ipam); err != nil {
 			log.WithError(err).Error("Unable to recompile base programs")
 		}
 	}

--- a/pkg/datapath/datapath.go
+++ b/pkg/datapath/datapath.go
@@ -19,6 +19,7 @@ package datapath
 // implementations
 type Datapath interface {
 	ConfigWriter
+	IptablesManager
 
 	// Node must return the handler for node events
 	Node() NodeHandler
@@ -26,19 +27,6 @@ type Datapath interface {
 	// LocalNodeAddressing must return the node addressing implementation
 	// of the local node
 	LocalNodeAddressing() NodeAddressing
-
-	// InstallProxyRules creates the necessary datapath config (e.g., iptables
-	// rules for redirecting host proxy traffic on a specific ProxyPort)
-	InstallProxyRules(proxyPort uint16, ingress bool, name string) error
-
-	// RemoveProxyRules creates the necessary datapath config (e.g., iptables
-	// rules for redirecting host proxy traffic on a specific ProxyPort)
-	RemoveProxyRules(proxyPort uint16, ingress bool, name string) error
-
-	// SupportsOriginalSourceAddr tells if the datapath supports
-	// use of original source addresses in proxy upstream
-	// connections.
-	SupportsOriginalSourceAddr() bool
 
 	// Loader must return the implementation of the loader, which is responsible
 	// for loading, reloading, and compiling datapath programs.

--- a/pkg/datapath/fake/datapath.go
+++ b/pkg/datapath/fake/datapath.go
@@ -80,6 +80,18 @@ func (f *fakeDatapath) SupportsOriginalSourceAddr() bool {
 	return false
 }
 
+func (f *fakeDatapath) RemoveRules() {}
+
+func (f *fakeDatapath) InstallRules(ifName string) error {
+	return nil
+}
+func (f *fakeDatapath) TransientRulesStart(ifName string) error {
+	return nil
+}
+func (f *fakeDatapath) TransientRulesEnd(quiet bool) {
+	return
+}
+
 func (f *fakeDatapath) Loader() datapath.Loader {
 	return f.loader
 }
@@ -116,7 +128,7 @@ func (f *fakeLoader) CallsMapPath(id uint16) string {
 }
 
 // Reinitialize does nothing.
-func (f *fakeLoader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, deviceMTU int, iptMgr datapath.RulesManager, p datapath.Proxy, r datapath.RouteReserver) error {
+func (f *fakeLoader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, deviceMTU int, iptMgr datapath.IptablesManager, p datapath.Proxy, r datapath.RouteReserver) error {
 	return nil
 }
 

--- a/pkg/datapath/loader.go
+++ b/pkg/datapath/loader.go
@@ -31,7 +31,7 @@ type Loader interface {
 	EndpointHash(cfg EndpointConfiguration) (string, error)
 	DeleteDatapath(ctx context.Context, ifName, direction string) error
 	Unload(ep Endpoint)
-	Reinitialize(ctx context.Context, o BaseProgramOwner, deviceMTU int, iptMgr RulesManager, p Proxy, r RouteReserver) error
+	Reinitialize(ctx context.Context, o BaseProgramOwner, deviceMTU int, iptMgr IptablesManager, p Proxy, r RouteReserver) error
 }
 
 // BaseProgramOwner is any type for which a loader is building base programs.
@@ -54,8 +54,20 @@ type Proxy interface {
 	ReinstallRules()
 }
 
-// RulesManager manages iptables rules.
-type RulesManager interface {
+// IptablesManager manages iptables rules.
+type IptablesManager interface {
+	// InstallProxyRules creates the necessary datapath config (e.g., iptables
+	// rules for redirecting host proxy traffic on a specific ProxyPort)
+	InstallProxyRules(proxyPort uint16, ingress bool, name string) error
+
+	// RemoveProxyRules creates the necessary datapath config (e.g., iptables
+	// rules for redirecting host proxy traffic on a specific ProxyPort)
+	RemoveProxyRules(proxyPort uint16, ingress bool, name string) error
+
+	// SupportsOriginalSourceAddr tells if the datapath supports
+	// use of original source addresses in proxy upstream
+	// connections.
+	SupportsOriginalSourceAddr() bool
 	RemoveRules()
 	InstallRules(ifName string) error
 	TransientRulesStart(ifName string) error

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -99,7 +99,7 @@ func writePreFilterHeader(preFilter *prefilter.PreFilter, dir string) error {
 // BPF programs, netfilter rule configuration and reserving routes in IPAM for
 // locally detected prefixes. It may be run upon initial Cilium startup, after
 // restore from a previous Cilium run, or during regular Cilium operation.
-func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, deviceMTU int, iptMgr datapath.RulesManager, p datapath.Proxy, r datapath.RouteReserver) error {
+func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, deviceMTU int, iptMgr datapath.IptablesManager, p datapath.Proxy, r datapath.RouteReserver) error {
 	var (
 		args []string
 		mode string


### PR DESCRIPTION
Now that reinitializing the datapath is part of `pkg/datapath`, we no longer need
the `iptablesManager` field in the `Daemon`. Change `Datapath` to be composed
of an `IptablesManager` interface as well.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9516)
<!-- Reviewable:end -->
