### PR TITLE
Cilium daemonset gets deleted every 40s on AKS.

### DIFF
--- a/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
@@ -3,14 +3,12 @@ kind: DaemonSet
 metadata:
   labels:
     k8s-app: cilium
-    kubernetes.io/cluster-service: "true"
   name: cilium
   namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:
       k8s-app: cilium
-      kubernetes.io/cluster-service: "true"
   template:
     metadata:
       annotations:
@@ -25,7 +23,6 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ""
       labels:
         k8s-app: cilium
-        kubernetes.io/cluster-service: "true"
     spec:
       containers:
       - args:

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -293,14 +293,12 @@ kind: DaemonSet
 metadata:
   labels:
     k8s-app: cilium
-    kubernetes.io/cluster-service: "true"
   name: cilium
   namespace: kube-system
 spec:
   selector:
     matchLabels:
       k8s-app: cilium
-      kubernetes.io/cluster-service: "true"
   template:
     metadata:
       annotations:
@@ -311,7 +309,6 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ""
       labels:
         k8s-app: cilium
-        kubernetes.io/cluster-service: "true"
     spec:
       containers:
       - args:
@@ -630,6 +627,7 @@ spec:
           initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 3
+
       hostNetwork: true
       restartPolicy: Always
       serviceAccount: cilium-operator


### PR DESCRIPTION
This patch deletes depreceted label that triggers AKS to delete cilium daemonset and breaks cluster networking.

Similar issue: https://github.com/kubernetes/kubernetes/issues/51376
The main issue looks to be this one: addon manager reads all deployments from api server with annotation cluster-service:true -> deletes all that do not exist as files

Fixes: #9464

Signed-off-by: Maksym Lushpenko <maksym.lushpenko@hal24k.com>

```release-note
Fix cilium daemonset deletion on AKS
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9519)
<!-- Reviewable:end -->
