### PR TITLE
CI: Fix typo setting kubeconfig variable from registry

### DIFF
--- a/ginkgo-kubernetes-all.Jenkinsfile
+++ b/ginkgo-kubernetes-all.Jenkinsfile
@@ -176,7 +176,7 @@ pipeline {
                         KUBECONFIG="${TESTDIR}/vagrant-kubeconfig"
                     }
                     steps {
-                        sh 'cd ${TESTDIR}; CILIUM_IMAGE=$(./print-node-ip.sh)/cilium/cilium:latest CILIUM_OPERATOR_IMAGE=$(./print-node-ip.sh)/cilium/operator:latest ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.kubeconfig=${KUBECONFIG}'
+                        sh 'cd ${TESTDIR}; ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.kubeconfig=${KUBECONFIG} -cilium.registry=$(./print-node-ip.sh)'
                     }
                     post {
                         always {
@@ -203,7 +203,7 @@ pipeline {
                         KUBECONFIG="${TESTDIR}/vagrant-kubeconfig"
                     }
                     steps {
-                        sh 'cd ${TESTDIR}; CILIUM_IMAGE=$(./print-node-ip.sh)/cilium/cilium:latest CILIUM_OPERATOR_IMAGE=$(./print-node-ip.sh)/cilium/operator:latest ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.kubeconfig=${KUBECONFIG}'
+                        sh 'cd ${TESTDIR}; ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.kubeconfig=${KUBECONFIG} -cilium.registry=$(./print-node-ip.sh)'
                     }
                     post {
                         always {

--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -228,7 +228,7 @@ pipeline {
                         K8S_VERSION="1.11"
                     }
                     steps {
-                        sh 'cd ${TESTDIR}; CILIUM_IMAGE=$(./print-node-ip.sh)/cilium/cilium:latest CILIUM_OPERATOR_IMAGE=$(./print-node-ip.sh)/cilium/operator:latest ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.kubeconfig=${TESTDIR}/vagrant-kubeconfig -cilium.passCLIEnvironment=true'
+                        sh 'cd ${TESTDIR}; ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.kubeconfig=${TESTDIR}/vagrant-kubeconfig -cilium.passCLIEnvironment=true -cilium.registry=$(./print-node-ip.sh)'
                     }
                     post {
                         always {
@@ -256,7 +256,7 @@ pipeline {
                         K8S_VERSION="1.16"
                     }
                     steps {
-                        sh 'cd ${TESTDIR}; CILIUM_IMAGE=$(./print-node-ip.sh)/cilium/cilium:latest CILIUM_OPERATOR_IMAGE=$(./print-node-ip.sh)/cilium/operator:latest ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.kubeconfig=${TESTDIR}/vagrant-kubeconfig -cilium.passCLIEnvironment=true'
+                        sh 'cd ${TESTDIR}; ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.kubeconfig=${TESTDIR}/vagrant-kubeconfig -cilium.passCLIEnvironment=true -cilium.registry=$(print-node-ip.sh)'
                     }
                     post {
                         always {

--- a/test/config/config.go
+++ b/test/config/config.go
@@ -70,5 +70,5 @@ func (c *CiliumTestConfigType) ParseFlags() {
 		"Specifies timeout for test run")
 	flag.StringVar(&c.Kubeconfig, "cilium.kubeconfig", "",
 		"Kubeconfig to be used for k8s tests")
-	flag.StringVar(&c.Kubeconfig, "cilium.registry", "k8s1:5000", "docker registry hostname for Cilium image")
+	flag.StringVar(&c.Registry, "cilium.registry", "k8s1:5000", "docker registry hostname for Cilium image")
 }

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -175,7 +175,7 @@ const (
 
 	CiliumStableVersion      = "v1.5"
 	CiliumStableImageVersion = "cilium/cilium:" + CiliumStableVersion
-	ciliumDeveloperImage     = "%s/cilium/cilium:latest"
+	ciliumDeveloperImage     = "%s/cilium/cilium-dev:latest"
 
 	MonitorLogFileName = "monitor.log"
 	microscopeManifest = "microscope.yaml"

--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -356,7 +356,7 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldVersion, newV
 
 		err = helpers.WithTimeout(
 			waitForUpdateImage(newVersion),
-			"Cilium Pods are not updating correctly",
+			fmt.Sprintf("Cilium Pods are not updating correctly to %s", newVersion),
 			&helpers.TimeoutConfig{Timeout: timeout})
 		ExpectWithOffset(1, err).To(BeNil(), "Pods are not updating")
 

--- a/test/provision/compile.sh
+++ b/test/provision/compile.sh
@@ -28,12 +28,12 @@ then
     # Only need to build on one host, since we can pull from the other host.
     if [[ "$(hostname)" == "k8s1" ]]; then
       ./test/provision/container-images.sh cilium_images .
-      if [[ "${CILIUM_IMAGE}" == "" && "${CILIUM_OPERATOR_IMAGE}" == "" ]]; then
+	  if [[ "${CILIUM_IMAGE}" == "" && "${CILIUM_OPERATOR_IMAGE}" == "" && "${CILIUM_REGISTRY}" == "" ]]; then
         echo "building cilium/cilium container image..."
         make LOCKDEBUG=1 docker-image-no-clean
 
         echo "building cilium/operator container image..."
-	make LOCKDEBUG=1 docker-operator-image&
+        make LOCKDEBUG=1 docker-operator-image&
         export OPERATORPID=$!
 
         echo "pushing cilium/cilium image to k8s1:5000/cilium/cilium-dev..."

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -62,6 +62,7 @@ sudo service serial-getty@ttyS0 start
 if [[ -f  "/etc/provision_finished" ]]; then
     sudo dpkg -l | grep kubelet
     echo "provision is finished, recompiling"
+    $PROVISIONSRC/compile.sh
     exit 0
 fi
 
@@ -244,11 +245,11 @@ case $K8S_VERSION in
             kubelet=${K8S_FULL_VERSION}* \
             kubeadm=${K8S_FULL_VERSION}* \
             kubectl=${K8S_FULL_VERSION}*
-		if [ $? -ne 0 ]; then
-			echo "falling back on binary k8s install"
-			set -e
-			install_k8s_using_binary "v${K8S_FULL_VERSION}" "v${KUBERNETES_CNI_VERSION}"
-		fi
+        if [ $? -ne 0 ]; then
+            echo "falling back on binary k8s install"
+            set -e
+            install_k8s_using_binary "v${K8S_FULL_VERSION}" "v${KUBERNETES_CNI_VERSION}"
+        fi
         ;;
 #   "1.16")
 #       install_k8s_using_binary "v${K8S_FULL_VERSION}" "v${KUBERNETES_CNI_VERSION}"
@@ -307,6 +308,7 @@ if [[ "${HOST}" == "k8s1" ]]; then
     kubectl -n kube-system delete -f ${PROVISIONSRC}/manifest/dns_deployment.yaml || true
     kubectl -n kube-system apply -f ${PROVISIONSRC}/manifest/dns_deployment.yaml
 
+    $PROVISIONSRC/compile.sh
 else
     if [[ "${SKIP_K8S_PROVISION}" == "false" ]]; then
       sudo -E bash -c 'echo "${KUBEADM_ADDR} k8s1" >> /etc/hosts'

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -230,6 +230,10 @@ var _ = BeforeAll(func() {
 			os.Setenv("CILIUM_OPERATOR_IMAGE", config.CiliumTestConfig.CiliumOperatorImage)
 		}
 
+		if config.CiliumTestConfig.Registry != "" {
+			os.Setenv("CILIUM_REGISTRY", config.CiliumTestConfig.Registry)
+		}
+
 		if config.CiliumTestConfig.ProvisionK8s == false {
 			os.Setenv("SKIP_K8S_PROVISION", "true")
 		}
@@ -265,6 +269,8 @@ var _ = BeforeAll(func() {
 			}
 		}
 		kubectl := helpers.CreateKubectl(helpers.K8s1VMName(), logger)
+
+		kubectl.LabelNodes()
 
 		kubectl.ApplyDefault(kubectl.GetFilePath("../examples/kubernetes/addons/prometheus/prometheus.yaml"))
 


### PR DESCRIPTION
This caused some off errors, particularly around how we determine
whether we are in the CI or running with a custom kubeconfig.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9520)
<!-- Reviewable:end -->
