### PR TITLE
Unit-test wildcard selector equality in rule creation

### DIFF
--- a/pkg/k8s/apis/cilium.io/v2/types.go
+++ b/pkg/k8s/apis/cilium.io/v2/types.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -172,8 +172,7 @@ func (r *CiliumNetworkPolicy) SpecEquals(o *CiliumNetworkPolicy) bool {
 	if o == nil {
 		return r == nil
 	}
-	return reflect.DeepEqual(r.Spec, o.Spec) &&
-		reflect.DeepEqual(r.Specs, o.Specs)
+	return r.Spec.DeepEquals(o.Spec) && r.Specs.DeepEquals(o.Specs)
 }
 
 // AnnotationsEquals returns true if ObjectMeta.Annotations of each

--- a/pkg/policy/api/rule.go
+++ b/pkg/policy/api/rule.go
@@ -15,6 +15,8 @@
 package api
 
 import (
+	"reflect"
+
 	"github.com/cilium/cilium/pkg/labels"
 )
 
@@ -65,6 +67,15 @@ type Rule struct {
 // NewRule builds a new rule with no selector and no policy.
 func NewRule() *Rule {
 	return &Rule{}
+}
+
+// DeepEquals returns true if the specified rule is deeply the same.
+func (r *Rule) DeepEquals(r2 *Rule) bool {
+	if reflect.DeepEqual(r, r2) {
+		return true
+	}
+
+	return false
 }
 
 // WithEndpointSelector configures the Rule with the specified selector.

--- a/pkg/policy/api/rules.go
+++ b/pkg/policy/api/rules.go
@@ -16,6 +16,7 @@ package api
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 )
 
@@ -34,4 +35,9 @@ func (rs Rules) String() string {
 	}
 
 	return "[" + strings.Join(strRules, ",\n") + "]"
+}
+
+// DeepEquals returns true if the specified rules are deeply the same.
+func (rs Rules) DeepEquals(rs2 Rules) bool {
+	return reflect.DeepEqual(rs, rs2)
 }

--- a/pkg/policy/api/rules_test.go
+++ b/pkg/policy/api/rules_test.go
@@ -1,0 +1,64 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package api
+
+import (
+	. "gopkg.in/check.v1"
+)
+
+// TestRulesDeepEquals tests that individual rules (via Rule.DeepEquals()) and
+// a collection of rules (via Rules.DeepEquals()) correctly validates the
+// equality of the rule or rules.
+func (s *PolicyAPITestSuite) TestRulesDeepEquals(c *C) {
+	var invalidRules Rules
+
+	c.Assert(invalidRules.DeepEquals(nil), Equals, true)
+	c.Assert(invalidRules.DeepEquals(invalidRules), Equals, true)
+
+	wcSelector1 := WildcardEndpointSelector
+	validPortRules := Rules{
+		NewRule().WithEndpointSelector(wcSelector1).
+			WithIngressRules([]IngressRule{{
+				FromEndpoints: []EndpointSelector{WildcardEndpointSelector},
+				ToPorts: []PortRule{{
+					Ports: []PortProtocol{
+						{Port: "80", Protocol: ProtoTCP},
+						{Port: "81", Protocol: ProtoTCP},
+					},
+					Rules: &L7Rules{
+						HTTP: []PortRuleHTTP{
+							{Method: "GET", Path: "/"},
+						},
+					},
+				}},
+			}}),
+	}
+
+	c.Assert(invalidRules.DeepEquals(validPortRules), Equals, false)
+	c.Assert(validPortRules.DeepEquals(invalidRules), Equals, false)
+	c.Assert(validPortRules.DeepEquals(nil), Equals, false)
+	c.Assert(validPortRules.DeepEquals(validPortRules), Equals, true)
+
+	// Same as WildcardEndpointSelector, but different pointer.
+	wcSelector2 := NewESFromLabels()
+	validPortRulesClone := Rules{
+		validPortRules[0].DeepCopy(),
+	}
+	validPortRulesClone[0].EndpointSelector = wcSelector2
+
+	c.Assert(validPortRules.DeepEquals(validPortRulesClone), Equals, true)
+}


### PR DESCRIPTION
Refactor the equality checks into functions, and unit-test those
functions with some basic wildcard selector equality checks.

These can be extended in future for more nuanced equality checks if necessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9521)
<!-- Reviewable:end -->
