### PR TITLE
Minor test documentation / make targets fixups

### DIFF
--- a/Documentation/contributing/testing/e2e.rst
+++ b/Documentation/contributing/testing/e2e.rst
@@ -38,8 +38,8 @@ determine which VMs are necessary to run particular tests. All test names
 Running End-To-End Tests
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Running All Tests
-^^^^^^^^^^^^^^^^^
+Running All Ginkgo Tests
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 Running all of the Ginkgo tests may take an hour or longer. To run all the
 ginkgo tests, invoke the make command as follows from the root of the cilium
@@ -47,7 +47,7 @@ repository:
 
 ::
 
-    $ sudo make -C test/
+    $ sudo make -C test/ test
 
 The first time that this is invoked, the testsuite will pull the
 `testing VMs <https://app.vagrantup.com/cilium/boxes/ginkgo>`_ and provision
@@ -234,6 +234,16 @@ If you want to run one specified test, there are a few options:
 
 This will focus on tests prefixed with "Run*", and within that focus, run any
 test that starts with "L7".
+
+Compiling the tests without running them
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To validate that the Go code you've written for testing is correct without
+needing to run the full test, you can build the test directory:
+
+::
+
+	make -C test/ build
 
 Test Reports
 ~~~~~~~~~~~~

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,8 +1,8 @@
 include ../Makefile.defs
 
 provision = true
-# If you set provision to false the test will run without compile the code
-# again.
+# If you set provision to false the test will run without bootstrapping the
+# cluster again.
 
 TEST_ARTIFACTS = ./tmp.yaml ./*_service_manifest.json ./*_manifest.yaml
 TEST_ARTIFACTS += ./*_policy.json ./k8s-*.xml ./runtime.xml ./test_results
@@ -28,6 +28,9 @@ run:
 
 k8s:
 	ginkgo --focus " K8s*" -v -- --cilium.provision=$(provision)
+
+nightly:
+	ginkgo --focus " Nightly*" -v -- --cilium.provision=$(provision)
 
 clean:
 	@$(ECHO_CLEAN)


### PR DESCRIPTION
Correct the docs description of how to run all tests and describe
compiling the tests without running them.

Add a make target for nightlies and fix some Makefile comments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9522)
<!-- Reviewable:end -->
