### PR TITLE
daemon: group cleanup-related variables into type

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -245,7 +245,7 @@ func NewDaemon(ctx context.Context, dp datapath.Datapath) (*Daemon, *endpointRes
 	dCtx, cancel := context.WithCancel(ctx)
 	// Pass the cancel to our signal handler directly so that it's canceled
 	// before we run the cleanup functions (see `cleanup.go` for implementation).
-	sigHandlerCancel = cancel
+	cleaner.SetCancelFunc(cancel)
 
 	var (
 		err           error
@@ -342,7 +342,7 @@ func NewDaemon(ctx context.Context, dp datapath.Datapath) (*Daemon, *endpointRes
 
 	// Cleanup on exit if running in tandem with Flannel.
 	if option.Config.FlannelUninstallOnExit {
-		cleanupFuncs.Add(func() {
+		cleaner.cleanupFuncs.Add(func() {
 			for _, ep := range d.endpointManager.GetEndpoints() {
 				ep.DeleteBPFProgramLocked()
 			}

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -125,7 +125,7 @@ func daemonMain() {
 		fmt.Println(errorString)
 		os.Exit(-1)
 	}
-	interruptCh := registerSigHandler()
+	interruptCh := cleaner.registerSigHandler()
 	if err := RootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(-1)
@@ -1201,7 +1201,7 @@ func runDaemon() {
 	}
 
 	if option.Config.IsFlannelMasterDeviceSet() && option.Config.FlannelUninstallOnExit {
-		cleanup.DeferTerminationCleanupFunction(cleanUPWg, cleanUPSig, func() {
+		cleanup.DeferTerminationCleanupFunction(cleaner.cleanUPWg, cleaner.cleanUPSig, func() {
 			d.compilationMutex.Lock()
 			d.Datapath().Loader().DeleteDatapath(context.Background(), option.FlannelMasterDevice, "egress")
 			d.compilationMutex.Unlock()

--- a/daemon/datapath.go
+++ b/daemon/datapath.go
@@ -168,7 +168,7 @@ func waitForHostDeviceWhenReady(ifaceName string) error {
 			break
 		}
 		select {
-		case <-cleanUPSig:
+		case <-cleaner.cleanUPSig:
 			return errors.New("clean up signal triggered")
 		default:
 			time.Sleep(time.Second)

--- a/daemon/health.go
+++ b/daemon/health.go
@@ -103,7 +103,7 @@ func (d *Daemon) initHealth() {
 	)
 
 	// Make sure to clean up the endpoint namespace when cilium-agent terminates
-	cleanup.DeferTerminationCleanupFunction(cleanUPWg, cleanUPSig, func() {
+	cleanup.DeferTerminationCleanupFunction(cleaner.cleanUPWg, cleaner.cleanUPSig, func() {
 		health.KillEndpoint()
 		health.CleanupEndpoint()
 	})


### PR DESCRIPTION
Group into a type, and also add a mutex to protect setting of the `sigHandlerCancel` variable,
which is set after the instance of the type is created. This ensures that if the daemon
is stopped, that access to setting / getting this variable is synchronized. Add a nil check to
when we try to invoke `sigHandlerCancel` in case it hasn't been set yet, as if it is not,
Cilium will panic:

```
Oct 29 20:08:58 runtime systemd[1]: Stopping cilium...
Oct 29 20:08:58 runtime cilium-agent[15285]: panic: runtime error: invalid memory address or nil pointer dereference
Oct 29 20:08:58 runtime cilium-agent[15285]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x2d4d098]
Oct 29 20:08:58 runtime cilium-agent[15285]: goroutine 29 [running]:
Oct 29 20:08:58 runtime cilium-agent[15285]: main.registerSigHandler.func1(0xc00044a600, 0xc0000ac5a0)
Oct 29 20:08:58 runtime cilium-agent[15285]: /home/vagrant/go/src/github.com/cilium/cilium/daemon/cleanup.go:69 +0x1f8
Oct 29 20:08:58 runtime cilium-agent[15285]: created by main.registerSigHandler
Oct 29 20:08:58 runtime cilium-agent[15285]: /home/vagrant/go/src/github.com/cilium/cilium/daemon/cleanup.go:65 +0x115
Oct 29 20:08:58 runtime systemd[1]: cilium.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
Oct 29 20:08:58 runtime systemd[1]: cilium.service: Failed with result 'exit-code'.
```

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9524)
<!-- Reviewable:end -->
