### PR TITLE
Added chart value for etcd-operator cluster domain

### DIFF
--- a/install/kubernetes/cilium/charts/managed-etcd/templates/cilium-etcd-operator-deployment.yaml
+++ b/install/kubernetes/cilium/charts/managed-etcd/templates/cilium-etcd-operator-deployment.yaml
@@ -30,7 +30,7 @@ spec:
         - /usr/bin/cilium-etcd-operator
         env:
         - name: CILIUM_ETCD_OPERATOR_CLUSTER_DOMAIN
-          value: "cluster.local"
+          value: "{{ .Values.global.etcd.clusterDomain }}"
         - name: CILIUM_ETCD_OPERATOR_ETCD_CLUSTER_SIZE
           value: "3"
         - name: CILIUM_ETCD_OPERATOR_NAMESPACE

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -33,6 +33,9 @@ global:
     # managed turns on managed etcd mode based on the cilium-etcd-operator
     managed: false
 
+    # sets cluster domain for cilium-etcd-operator
+    clusterDomain: cluster.local
+
     # endpoints is the list of etcd endpoints (not needed when using
     # managed=true)
     endpoints:


### PR DESCRIPTION
This adds a Helm value for customizing the `CILIUM_ETCD_OPERATOR_CLUSTER_DOMAIN` value

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9526)
<!-- Reviewable:end -->
