### PR TITLE
ipcache: remove global ipcache.IPCache object

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -44,6 +44,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	"github.com/cilium/cilium/pkg/ipam"
 	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/ipcache/watcher"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/k8s/endpointsynchronizer"
 	"github.com/cilium/cilium/pkg/k8s/watchers"
@@ -136,6 +137,8 @@ type Daemon struct {
 	identityAllocator *cache.CachingIdentityAllocator
 
 	k8sWatcher *watchers.K8sWatcher
+
+	ipcache *ipcache.IPCache
 }
 
 // GetPolicyRepository returns the policy repository of the daemon
@@ -281,7 +284,8 @@ func NewDaemon(ctx context.Context, dp datapath.Datapath) (*Daemon, *endpointRes
 
 	mtuConfig := mtu.NewConfiguration(authKeySize, option.Config.EnableIPSec, option.Config.Tunnel != option.TunnelDisabled, configuredMTU)
 
-	nodeMngr, err := nodemanager.NewManager("all", dp.Node())
+	ipc := ipcache.NewIPCache()
+	nodeMngr, err := nodemanager.NewManager("all", dp.Node(), ipc)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -304,11 +308,12 @@ func NewDaemon(ctx context.Context, dp datapath.Datapath) (*Daemon, *endpointRes
 		mtuConfig:        mtuConfig,
 		datapath:         dp,
 		nodeDiscovery:    nd,
+		ipcache:          ipc,
 	}
 
 	d.svc = service.NewService(&d)
 
-	d.identityAllocator = cache.NewCachingIdentityAllocator(&d)
+	d.identityAllocator = cache.NewCachingIdentityAllocator(&d, d.ipcache)
 	d.policy = policy.NewPolicyRepository(d.identityAllocator.GetIdentityCache(),
 		certificatemanager.NewManager(option.Config.CertDirectory, k8s.Client()))
 	d.policy.SetEnvoyRulesFunc(envoy.GetEnvoyHTTPRules)
@@ -318,7 +323,6 @@ func NewDaemon(ctx context.Context, dp datapath.Datapath) (*Daemon, *endpointRes
 	//
 	// TODO: convert these package level variables to types for easier unit
 	// testing in the future.
-	ipcache.IdentityAllocator = d.identityAllocator
 	proxy.Allocator = d.identityAllocator
 
 	d.endpointManager = endpointmanager.NewEndpointManager(&endpointsynchronizer.EndpointSynchronizer{
@@ -332,6 +336,8 @@ func NewDaemon(ctx context.Context, dp datapath.Datapath) (*Daemon, *endpointRes
 		&d,
 		d.policy,
 		d.svc,
+		d.identityAllocator,
+		d.ipcache,
 	)
 
 	bootstrapStats.daemonInit.End(true)
@@ -423,7 +429,7 @@ func NewDaemon(ctx context.Context, dp datapath.Datapath) (*Daemon, *endpointRes
 	// FIXME: Make the port range configurable.
 	if option.Config.EnableL7Proxy {
 		d.l7Proxy = proxy.StartProxySupport(10000, 20000, option.Config.RunDir,
-			option.Config.AccessLog, &d, option.Config.AgentLabels, d.datapath, d.endpointManager)
+			option.Config.AccessLog, &d, option.Config.AgentLabels, d.datapath, d.endpointManager, d.ipcache)
 	} else {
 		log.Info("L7 proxies are disabled")
 	}
@@ -503,7 +509,7 @@ func NewDaemon(ctx context.Context, dp datapath.Datapath) (*Daemon, *endpointRes
 	// Start watcher for endpoint IP --> identity mappings in key-value store.
 	// this needs to be done *after* init() for the daemon in that function,
 	// we populate the IPCache with the host's IP(s).
-	ipcache.InitIPIdentityWatcher()
+	watcher.InitIPIdentityWatcher(d.ipcache)
 	identitymanager.Subscribe(d.policy)
 
 	bootstrapStats.fqdn.Start()
@@ -536,6 +542,7 @@ func (d *Daemon) bootstrapClusterMesh(nodeMngr *nodemanager.Manager) {
 				ServiceMerger:         &d.k8sWatcher.K8sSvcCache,
 				NodeManager:           nodeMngr,
 				RemoteIdentityWatcher: d.identityAllocator,
+				IPC:                   d.ipcache,
 			})
 			if err != nil {
 				log.WithError(err).Fatal("Unable to initialize ClusterMesh")

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -1405,7 +1405,7 @@ func (d *Daemon) instantiateAPI() *restapi.CiliumAPI {
 	api.PolicyGetFqdnNamesHandler = NewGetFqdnNamesHandler(d)
 
 	// /ip/
-	api.PolicyGetIPHandler = NewGetIPHandler()
+	api.PolicyGetIPHandler = NewGetIPHandler(d.ipcache)
 
 	return api
 }

--- a/daemon/datapath.go
+++ b/daemon/datapath.go
@@ -266,7 +266,7 @@ func (d *Daemon) syncEndpointsAndHostIPs() error {
 
 		// Upsert will not propagate (reserved:foo->ID) mappings across the cluster,
 		// and we specifically don't want to do so.
-		ipcache.IPIdentityCache.Upsert(ipIDPair.PrefixString(), nil, hostKey, nil, ipcache.Identity{
+		d.ipcache.Upsert(ipIDPair.PrefixString(), nil, hostKey, nil, ipcache.Identity{
 			ID:     ipIDPair.ID,
 			Source: source.Local,
 		})
@@ -282,7 +282,7 @@ func (d *Daemon) syncEndpointsAndHostIPs() error {
 				log.Debugf("Removed outdated host ip %s from endpoint map", hostIP)
 			}
 
-			ipcache.IPIdentityCache.Delete(hostIP, source.Local)
+			d.ipcache.Delete(hostIP, source.Local)
 		}
 	}
 
@@ -342,8 +342,8 @@ func (d *Daemon) initMaps() error {
 	// Set up the list of IPCache listeners in the daemon, to be
 	// used by syncEndpointsAndHostIPs()
 	// xDS cache will be added later by calling AddListener(), but only if necessary.
-	ipcache.IPIdentityCache.SetListeners([]ipcache.IPIdentityMappingListener{
-		datapathIpcache.NewListener(d, d),
+	d.ipcache.SetListeners([]ipcache.IPIdentityMappingListener{
+		datapathIpcache.NewListener(d.ipcache, d, d),
 	})
 
 	// Start the controller for periodic sync of the metrics map with

--- a/daemon/fqdn.go
+++ b/daemon/fqdn.go
@@ -36,7 +36,6 @@ import (
 	"github.com/cilium/cilium/pkg/fqdn/matchpattern"
 	"github.com/cilium/cilium/pkg/identity"
 	secIDCache "github.com/cilium/cilium/pkg/identity/cache"
-	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/node"
@@ -84,7 +83,7 @@ func identitiesForFQDNSelectorIPs(selectorsWithIPsToUpdate map[policyApi.FQDNSel
 			"ips":          selectorIPs,
 		}).Debug("getting identities for IPs associated with FQDNSelector")
 		var currentlyAllocatedIdentities []*identity.Identity
-		if currentlyAllocatedIdentities, err = ipcache.AllocateCIDRsForIPs(selectorIPs); err != nil {
+		if currentlyAllocatedIdentities, err = identityAllocator.AllocateCIDRsForIPs(selectorIPs); err != nil {
 			identityAllocator.ReleaseSlice(context.TODO(), nil, usedIdentities)
 			log.WithError(err).WithField("prefixes", selectorIPs).Warn(
 				"failed to allocate identities for IPs")
@@ -146,7 +145,7 @@ func (d *Daemon) bootstrapFQDN(restoredEndpoints *endpointRestoreState, preCache
 		PollerResponseNotify: d.pollerResponseNotify,
 	}
 
-	rg := fqdn.NewNameManager(cfg)
+	rg := fqdn.NewNameManager(cfg, d.identityAllocator)
 	d.policy.GetSelectorCache().SetLocalIdentityNotifier(rg)
 	d.dnsNameManager = rg
 	d.dnsPoller = fqdn.NewDNSPoller(cfg, d.dnsNameManager)
@@ -532,7 +531,7 @@ func (d *Daemon) notifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epI
 					Identity:     uint64(serverEP.GetIdentity()),
 					Port:         uint16(serverPort),
 				}
-			} else if serverSecID, exists := ipcache.IPIdentityCache.LookupByIP(serverIP); exists {
+			} else if serverSecID, exists := d.ipcache.LookupByIP(serverIP); exists {
 				secID := d.identityAllocator.LookupIdentityByID(d.ctx, serverSecID.ID)
 				// TODO: handle IPv6
 				lr.LogRecord.DestinationEndpoint = accesslog.EndpointInfo{

--- a/daemon/ipcache.go
+++ b/daemon/ipcache.go
@@ -27,11 +27,13 @@ import (
 	"github.com/go-openapi/runtime/middleware"
 )
 
-type getIP struct{}
+type getIP struct {
+	ipc *ipcache.IPCache
+}
 
 // NewGetIPHandler for the global IP cache
-func NewGetIPHandler() GetIPHandler {
-	return &getIP{}
+func NewGetIPHandler(ipc *ipcache.IPCache) GetIPHandler {
+	return &getIP{ipc: ipc}
 }
 
 func (h *getIP) Handle(params GetIPParams) middleware.Responder {
@@ -43,9 +45,9 @@ func (h *getIP) Handle(params GetIPParams) middleware.Responder {
 		}
 		listener.cidrFilter = cidrFilter
 	}
-	ipcache.IPIdentityCache.RLock()
-	ipcache.IPIdentityCache.DumpToListenerLocked(listener)
-	ipcache.IPIdentityCache.RUnlock()
+	h.ipc.RLock()
+	h.ipc.DumpToListenerLocked(listener)
+	h.ipc.RUnlock()
 	if len(listener.entries) == 0 {
 		return NewGetIPNotFound()
 	}

--- a/daemon/policy.go
+++ b/daemon/policy.go
@@ -31,7 +31,6 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/eventqueue"
 	"github.com/cilium/cilium/pkg/identity/cache"
-	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	bpfIPCache "github.com/cilium/cilium/pkg/maps/ipcache"
@@ -293,7 +292,7 @@ func (d *Daemon) policyAdd(sourceRules policyAPI.Rules, opts *policy.AddOptions,
 		}
 	}
 
-	if _, err := ipcache.AllocateCIDRs(prefixes); err != nil {
+	if _, err := d.identityAllocator.AllocateCIDRs(prefixes); err != nil {
 		_ = d.prefixLengths.Delete(prefixes)
 		metrics.PolicyImportErrors.Inc()
 		logger.WithError(err).WithField("prefixes", prefixes).Warn(
@@ -379,7 +378,7 @@ func (d *Daemon) policyAdd(sourceRules policyAPI.Rules, opts *policy.AddOptions,
 	// and will trigger deletions for those that are no longer used.
 	if len(removedPrefixes) > 0 {
 		logger.WithField("prefixes", removedPrefixes).Debug("Decrementing replaced CIDR refcounts when adding rules")
-		ipcache.ReleaseCIDRs(removedPrefixes)
+		d.identityAllocator.ReleaseCIDRs(removedPrefixes)
 		d.prefixLengths.Delete(removedPrefixes)
 	}
 
@@ -579,7 +578,7 @@ func (d *Daemon) policyDelete(labels labels.LabelArray, res chan interface{}) {
 	// not appropriately performing garbage collection.
 	prefixes := policy.GetCIDRPrefixes(rules)
 	log.WithField("prefixes", prefixes).Debug("Policy deleted via API, found prefixes...")
-	ipcache.ReleaseCIDRs(prefixes)
+	d.identityAllocator.ReleaseCIDRs(prefixes)
 
 	prefixesChanged := d.prefixLengths.Delete(prefixes)
 	if !bpfIPCache.BackedByLPM() && prefixesChanged {

--- a/daemon/policy_test.go
+++ b/daemon/policy_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/testutils"
+	testutilallocator "github.com/cilium/cilium/pkg/testutils/allocator"
 
 	cilium "github.com/cilium/proxy/go/cilium/api"
 	envoy_api_v2_core "github.com/cilium/proxy/go/envoy/api/v2/core"
@@ -1237,7 +1238,8 @@ func (ds *DaemonSuite) Test_addCiliumNetworkPolicyV2(c *C) {
 
 		rules, policyImportErr := args.cnp.Parse()
 		c.Assert(policyImportErr, IsNil)
-		policyImportErr = k8s.PreprocessRules(rules, &ds.d.k8sWatcher.K8sSvcCache)
+		allo := &testutilallocator.FakeCIDRIdentityAllocator{}
+		policyImportErr = k8s.PreprocessRules(rules, &ds.d.k8sWatcher.K8sSvcCache, allo)
 		c.Assert(policyImportErr, IsNil)
 		_, policyImportErr = ds.d.PolicyAdd(rules, &policy.AddOptions{
 			ReplaceWithLabels: args.cnp.GetIdentityLabels(),

--- a/daemon/status_test.go
+++ b/daemon/status_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/cilium/cilium/api/v1/server/restapi/daemon"
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/datapath/fake"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/mtu"
 	"github.com/cilium/cilium/pkg/node/manager"
 	"github.com/cilium/cilium/pkg/nodediscovery"
@@ -48,7 +49,7 @@ func (g *GetNodesSuite) SetUpTest(c *C) {
 
 func (g *GetNodesSuite) SetUpSuite(c *C) {
 	var err error
-	nm, err = manager.NewManager("", fake.NewNodeHandler())
+	nm, err = manager.NewManager("", fake.NewNodeHandler(), ipcache.NewIPCache())
 	c.Assert(err, IsNil)
 }
 

--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/allocator"
 	"github.com/cilium/cilium/pkg/controller"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/lock"
@@ -63,6 +64,8 @@ type Configuration struct {
 	// RemoteIdentityWatcher provides identities that have been allocated on a
 	// remote cluster.
 	RemoteIdentityWatcher RemoteIdentityWatcher
+
+	IPC ipcache.IPCacheInterface
 }
 
 // RemoteIdentityWatcher is any type which provides identities that have been
@@ -171,7 +174,7 @@ func (cm *ClusterMesh) add(name, path string) {
 	log.WithField(fieldClusterName, name).Debug("Remote cluster configuration added")
 
 	if inserted {
-		cluster.onInsert(cm.conf.RemoteIdentityWatcher)
+		cluster.onInsert(cm.conf.RemoteIdentityWatcher, cm.conf.IPC)
 	} else {
 		// signal a change in configuration
 		cluster.changed <- true

--- a/pkg/clustermesh/clustermesh_test.go
+++ b/pkg/clustermesh/clustermesh_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/lock"
@@ -104,7 +105,7 @@ func (s *ClusterMeshTestSuite) TestClusterMesh(c *C) {
 
 	identity.InitWellKnownIdentities()
 	// The nils are only used by k8s CRD identities. We default to kvstore.
-	mgr := cache.NewCachingIdentityAllocator(&allocator.IdentityAllocatorOwnerMock{})
+	mgr := cache.NewCachingIdentityAllocator(&allocator.IdentityAllocatorOwnerMock{}, ipcache.NewIPCache())
 	<-mgr.InitIdentityAllocator(nil, nil)
 	defer mgr.Close()
 
@@ -128,6 +129,7 @@ func (s *ClusterMeshTestSuite) TestClusterMesh(c *C) {
 		NodeKeyCreator:        testNodeCreator,
 		nodeObserver:          &testObserver{},
 		RemoteIdentityWatcher: mgr,
+		IPC:                   ipcache.NewIPCache(),
 	})
 	c.Assert(err, IsNil)
 	c.Assert(cm, Not(IsNil))

--- a/pkg/clustermesh/config_test.go
+++ b/pkg/clustermesh/config_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/testutils"
 	"github.com/cilium/cilium/pkg/testutils/allocator"
 
@@ -70,7 +71,7 @@ func (s *ClusterMeshTestSuite) TestWatchConfigDirectory(c *C) {
 	createFile(c, file1)
 	createFile(c, file2)
 
-	mgr := cache.NewCachingIdentityAllocator(&allocator.IdentityAllocatorOwnerMock{})
+	mgr := cache.NewCachingIdentityAllocator(&allocator.IdentityAllocatorOwnerMock{}, ipcache.NewIPCache())
 	// The nils are only used by k8s CRD identities. We default to kvstore.
 	<-mgr.InitIdentityAllocator(nil, nil)
 
@@ -79,6 +80,7 @@ func (s *ClusterMeshTestSuite) TestWatchConfigDirectory(c *C) {
 		ConfigDirectory:       dir,
 		NodeKeyCreator:        testNodeCreator,
 		RemoteIdentityWatcher: mgr,
+		IPC:                   ipcache.NewIPCache(),
 	})
 	c.Assert(err, IsNil)
 	c.Assert(cm, Not(IsNil))

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/k8s/types"
 	"github.com/cilium/cilium/pkg/kvstore"
@@ -68,7 +69,7 @@ func (s *ClusterMeshServicesTestSuite) SetUpTest(c *C) {
 	s.svcCache = k8s.NewServiceCache()
 	identity.InitWellKnownIdentities()
 
-	mgr := cache.NewCachingIdentityAllocator(&allocator.IdentityAllocatorOwnerMock{})
+	mgr := cache.NewCachingIdentityAllocator(&allocator.IdentityAllocatorOwnerMock{}, ipcache.NewIPCache())
 	// The nils are only used by k8s CRD identities. We default to kvstore.
 	<-mgr.InitIdentityAllocator(nil, nil)
 	dir, err := ioutil.TempDir("", "multicluster")
@@ -90,6 +91,7 @@ func (s *ClusterMeshServicesTestSuite) SetUpTest(c *C) {
 		nodeObserver:          &testObserver{},
 		ServiceMerger:         &s.svcCache,
 		RemoteIdentityWatcher: mgr,
+		IPC:                   ipcache.NewIPCache(),
 	})
 	c.Assert(err, IsNil)
 	c.Assert(cm, Not(IsNil))

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cilium/cilium/pkg/eventqueue"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/ipcache"
 	ciliumio "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/labels"
@@ -105,7 +106,7 @@ func (s *EndpointSuite) SetUpTest(c *C) {
 	kvstore.SetupDummy("etcd")
 	identity.InitWellKnownIdentities()
 	// The nils are only used by k8s CRD identities. We default to kvstore.
-	mgr := cache.NewCachingIdentityAllocator(&allocator.IdentityAllocatorOwnerMock{})
+	mgr := cache.NewCachingIdentityAllocator(&allocator.IdentityAllocatorOwnerMock{}, ipcache.NewIPCache())
 	<-mgr.InitIdentityAllocator(nil, nil)
 	s.mgr = mgr
 }

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
@@ -133,7 +134,7 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 	identity.InitWellKnownIdentities()
 	idAllocatorOwner := &DummyIdentityAllocatorOwner{}
 
-	mgr := cache.NewCachingIdentityAllocator(idAllocatorOwner)
+	mgr := cache.NewCachingIdentityAllocator(idAllocatorOwner, ipcache.NewIPCache())
 	<-mgr.InitIdentityAllocator(nil, nil)
 	defer mgr.Close()
 

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -30,7 +30,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/fqdn"
 	"github.com/cilium/cilium/pkg/identity"
-	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/ipcache/watcher"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/mac"
@@ -212,7 +212,7 @@ func (e *Endpoint) restoreIdentity() error {
 			return err
 		}
 		if option.Config.KVStore != "" {
-			ipcache.WaitForKVStoreSync()
+			watcher.WaitForKVStoreSync()
 		}
 	}
 

--- a/pkg/envoy/envoy_test.go
+++ b/pkg/envoy/envoy_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cilium/cilium/pkg/envoy/xds"
 	"github.com/cilium/cilium/pkg/flowdebug"
 	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
@@ -84,7 +85,7 @@ func (s *EnvoySuite) TestEnvoy(c *C) {
 
 	log.Debugf("state log directory: %s", stateLogDir)
 
-	xdsServer := StartXDSServer(stateLogDir)
+	xdsServer := StartXDSServer(stateLogDir, ipcache.NewIPCache())
 	defer xdsServer.stop()
 	StartAccessLogServer(stateLogDir, xdsServer, &dummyEndpointInfoRegistry{})
 
@@ -156,7 +157,7 @@ func (s *EnvoySuite) TestEnvoyNACK(c *C) {
 
 	log.Debugf("state log directory: %s", stateLogDir)
 
-	xdsServer := StartXDSServer(stateLogDir)
+	xdsServer := StartXDSServer(stateLogDir, ipcache.NewIPCache())
 	defer xdsServer.stop()
 	StartAccessLogServer(stateLogDir, xdsServer, &dummyEndpointInfoRegistry{})
 

--- a/pkg/fqdn/dnspoller_test.go
+++ b/pkg/fqdn/dnspoller_test.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 
 	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/testutils/allocator"
 	"github.com/miekg/dns"
 
 	. "gopkg.in/check.v1"
@@ -148,7 +149,7 @@ func (ds *FQDNTestSuite) TestNameManagerSelectorHandling(c *C) {
 				},
 			}
 
-			nameManager = NewNameManager(cfg)
+			nameManager = NewNameManager(cfg, &allocator.FakeIdentityAllocator{})
 			poller      = NewDNSPoller(cfg, nameManager)
 		)
 

--- a/pkg/fqdn/name_manager_test.go
+++ b/pkg/fqdn/name_manager_test.go
@@ -22,7 +22,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/testutils/allocator"
 	"github.com/miekg/dns"
 
 	. "gopkg.in/check.v1"
@@ -57,7 +60,7 @@ func (ds *FQDNTestSuite) TestNameManagerCIDRGeneration(c *C) {
 				}
 				return &sync.WaitGroup{}, nil
 			},
-		})
+		}, cache.NewCachingIdentityAllocator(&allocator.IdentityAllocatorOwnerMock{}, ipcache.NewIPCache()))
 	)
 
 	// add rules
@@ -107,7 +110,7 @@ func (ds *FQDNTestSuite) TestNameManagerMultiIPUpdate(c *C) {
 				}
 				return &sync.WaitGroup{}, nil
 			},
-		})
+		}, cache.NewCachingIdentityAllocator(&allocator.IdentityAllocatorOwnerMock{}, ipcache.NewIPCache()))
 	)
 
 	// add rules

--- a/pkg/identity/cache/allocation_test.go
+++ b/pkg/identity/cache/allocation_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/idpool"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
@@ -43,7 +44,7 @@ func (s *IdentityCacheTestSuite) TestAllocateIdentityReserved(c *C) {
 		labels.IDNameHost: labels.NewLabel(labels.IDNameHost, "", labels.LabelSourceReserved),
 	}
 
-	mgr := NewCachingIdentityAllocator(newDummyOwner())
+	mgr := NewCachingIdentityAllocator(newDummyOwner(), ipcache.NewIPCache())
 	<-mgr.InitIdentityAllocator(nil, nil)
 
 	c.Assert(identity.IdentityAllocationIsLocal(lbls), Equals, true)
@@ -227,7 +228,7 @@ func (ias *IdentityAllocatorSuite) TestEventWatcherBatching(c *C) {
 func (ias *IdentityAllocatorSuite) TestGetIdentityCache(c *C) {
 	identity.InitWellKnownIdentities()
 	// The nils are only used by k8s CRD identities. We default to kvstore.
-	mgr := NewCachingIdentityAllocator(newDummyOwner())
+	mgr := NewCachingIdentityAllocator(newDummyOwner(), ipcache.NewIPCache())
 	<-mgr.InitIdentityAllocator(nil, nil)
 	defer mgr.Close()
 	defer mgr.IdentityAllocator.DeleteAllKeys()
@@ -245,7 +246,7 @@ func (ias *IdentityAllocatorSuite) TestAllocator(c *C) {
 	owner := newDummyOwner()
 	identity.InitWellKnownIdentities()
 	// The nils are only used by k8s CRD identities. We default to kvstore.
-	mgr := NewCachingIdentityAllocator(owner)
+	mgr := NewCachingIdentityAllocator(owner, ipcache.NewIPCache())
 	<-mgr.InitIdentityAllocator(nil, nil)
 	defer mgr.Close()
 	defer mgr.IdentityAllocator.DeleteAllKeys()
@@ -330,7 +331,7 @@ func (ias *IdentityAllocatorSuite) TestLocalAllocation(c *C) {
 	owner := newDummyOwner()
 	identity.InitWellKnownIdentities()
 	// The nils are only used by k8s CRD identities. We default to kvstore.
-	mgr := NewCachingIdentityAllocator(owner)
+	mgr := NewCachingIdentityAllocator(owner, ipcache.NewIPCache())
 	<-mgr.InitIdentityAllocator(nil, nil)
 	defer mgr.Close()
 	defer mgr.IdentityAllocator.DeleteAllKeys()

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cilium/cilium/pkg/allocator"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/idpool"
+	"github.com/cilium/cilium/pkg/ipcache"
 	clientset "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned"
 	"github.com/cilium/cilium/pkg/k8s/identitybackend"
 	"github.com/cilium/cilium/pkg/kvstore"
@@ -99,6 +100,8 @@ type CachingIdentityAllocator struct {
 	watcher identityWatcher
 
 	owner IdentityAllocatorOwner
+
+	ipc ipcache.IPCacheInterface
 }
 
 // IdentityAllocatorOwner is the interface the owner of an identity allocator
@@ -235,7 +238,7 @@ func (m *CachingIdentityAllocator) InitIdentityAllocator(client clientset.Interf
 
 // NewCachingIdentityAllocator creates a new instance of an
 // CachingIdentityAllocator.
-func NewCachingIdentityAllocator(owner IdentityAllocatorOwner) *CachingIdentityAllocator {
+func NewCachingIdentityAllocator(owner IdentityAllocatorOwner, ipc ipcache.IPCacheInterface) *CachingIdentityAllocator {
 	watcher := identityWatcher{
 		stopChan: make(chan bool),
 		owner:    owner,
@@ -247,6 +250,7 @@ func NewCachingIdentityAllocator(owner IdentityAllocatorOwner) *CachingIdentityA
 		owner:                              owner,
 		identitiesPath:                     IdentitiesPath,
 		watcher:                            watcher,
+		ipc:                                ipc,
 	}
 	return mgr
 }

--- a/pkg/identity/cache/cache_test.go
+++ b/pkg/identity/cache/cache_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/option"
 
@@ -58,7 +59,7 @@ func (s *IdentityCacheTestSuite) TestLookupReservedIdentity(c *C) {
 		option.Config.ClusterName = bak
 	}()
 
-	mgr := NewCachingIdentityAllocator(newDummyOwner())
+	mgr := NewCachingIdentityAllocator(newDummyOwner(), ipcache.NewIPCache())
 	<-mgr.InitIdentityAllocator(nil, nil)
 
 	hostID := identity.GetReservedID("host")

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -26,13 +26,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var (
-	// IPIdentityCache caches the mapping of endpoint IPs to their corresponding
-	// security identities across the entire cluster in which this instance of
-	// Cilium is running.
-	IPIdentityCache = NewIPCache()
-)
-
 // Identity is the identity representation of an IP<->Identity cache.
 type Identity struct {
 	// ID is the numeric identity
@@ -87,6 +80,16 @@ func NewIPCache() *IPCache {
 		v4PrefixLengths:   map[int]int{},
 		v6PrefixLengths:   map[int]int{},
 	}
+}
+
+// NotifyListenersGC runs `OnIPIdentityCacheGC` for all listeners for this
+// IPCache.
+func (ipc *IPCache) NotifyListenersGC() {
+	ipc.Lock()
+	for _, listener := range ipc.listeners {
+		listener.OnIPIdentityCacheGC()
+	}
+	ipc.Unlock()
 }
 
 // Lock locks the IPCache's mutex.

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -38,6 +38,8 @@ func Test(t *testing.T) {
 }
 
 func (s *IPCacheTestSuite) TestIPCache(c *C) {
+	IPIdentityCache := NewIPCache()
+
 	endpointIP := "10.0.0.15"
 	identity := (identityPkg.NumericIdentity(68))
 
@@ -190,71 +192,4 @@ func (s *IPCacheTestSuite) TestIPCache(c *C) {
 	c.Assert(len(IPIdentityCache.ipToIdentityCache), Equals, 0)
 	c.Assert(len(IPIdentityCache.identityToIPCache), Equals, 0)
 
-}
-
-func (s *IPCacheTestSuite) TestKeyToIPNet(c *C) {
-	// Valid IPv6.
-	validIPv6Key := "cilium/state/ip/v1/default/f00d::a00:0:0:c164"
-
-	_, expectedIPv6, err := net.ParseCIDR("f00d::a00:0:0:c164/128")
-	c.Assert(err, IsNil)
-
-	ipv6, isHost, err := keyToIPNet(validIPv6Key)
-	c.Assert(ipv6, Not(IsNil))
-	c.Assert(err, IsNil)
-	c.Assert(isHost, Equals, true)
-	c.Assert(ipv6, checker.DeepEquals, expectedIPv6)
-
-	// Valid IPv6 prefix.
-	validIPv6Key = "cilium/state/ip/v1/default/f00d::a00:0:0:0/64"
-
-	_, expectedIPv6, err = net.ParseCIDR("f00d::a00:0:0:0/64")
-	c.Assert(err, IsNil)
-
-	ipv6, isHost, err = keyToIPNet(validIPv6Key)
-	c.Assert(ipv6, Not(IsNil))
-	c.Assert(err, IsNil)
-	c.Assert(isHost, Equals, false)
-	c.Assert(ipv6, checker.DeepEquals, expectedIPv6)
-
-	// Valid IPv4.
-	validIPv4Key := "cilium/state/ip/v1/default/10.0.114.197"
-	_, expectedIPv4, err := net.ParseCIDR("10.0.114.197/32")
-	c.Assert(err, IsNil)
-	ipv4, isHost, err := keyToIPNet(validIPv4Key)
-	c.Assert(ipv4, Not(IsNil))
-	c.Assert(err, IsNil)
-	c.Assert(isHost, Equals, true)
-	c.Assert(ipv4, checker.DeepEquals, expectedIPv4)
-
-	// Valid IPv4 prefix.
-	validIPv4Key = "cilium/state/ip/v1/default/10.0.114.0/24"
-	_, expectedIPv4, err = net.ParseCIDR("10.0.114.0/24")
-	c.Assert(err, IsNil)
-	ipv4, isHost, err = keyToIPNet(validIPv4Key)
-	c.Assert(ipv4, Not(IsNil))
-	c.Assert(err, IsNil)
-	c.Assert(isHost, Equals, false)
-	c.Assert(ipv4, checker.DeepEquals, expectedIPv4)
-
-	// Invalid prefix.
-	invalidPrefixKey := "cilium/state/foobar/v1/default/f00d::a00:0:0:c164"
-	nilIP, isHost, err := keyToIPNet(invalidPrefixKey)
-	c.Assert(nilIP, IsNil)
-	c.Assert(err, Not(IsNil))
-	c.Assert(isHost, Equals, false)
-
-	// Invalid IP in key.
-	invalidIPKey := "cilium/state/ip/v1/default/10.abfd.114.197"
-	nilIP, isHost, err = keyToIPNet(invalidIPKey)
-	c.Assert(nilIP, IsNil)
-	c.Assert(err, Not(IsNil))
-	c.Assert(isHost, Equals, false)
-
-	// Invalid CIDR.
-	invalidIPKey = "cilium/state/ip/v1/default/192.0.2.3/54"
-	nilIP, isHost, err = keyToIPNet(invalidIPKey)
-	c.Assert(nilIP, IsNil)
-	c.Assert(err, Not(IsNil))
-	c.Assert(isHost, Equals, false)
 }

--- a/pkg/ipcache/types.go
+++ b/pkg/ipcache/types.go
@@ -1,0 +1,42 @@
+// Copyright 2019 Authors of Cilium
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipcache
+
+import (
+	"net"
+
+	"github.com/cilium/cilium/pkg/source"
+)
+
+// IPCacheInterface is an interface hiding the implementation of `IPCache`.
+type IPCacheInterface interface {
+
+	// Upsert inserts the information about the specified IP into the IPCache.
+	// Returns false if the ip is not owned by the specified source in
+	// `newIdentity`.
+	Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *K8sMetadata, newIdentity Identity) bool
+
+	// Delete removes the provided IP-to-security-identity mapping from the IPCache.
+	Delete(IP string, source source.Source)
+
+	// LookupByIP returns the corresponding security identity that endpoint IP maps
+	// to within the provided IPCache, as well as if the corresponding entry exists
+	// in the IPCache.
+	LookupByIP(IP string) (Identity, bool)
+
+	// NotifyListenersGC runs `OnIPIdentityCacheGC` for all listeners for this
+	// IPCache.
+	NotifyListenersGC()
+}

--- a/pkg/ipcache/watcher/log.go
+++ b/pkg/ipcache/watcher/log.go
@@ -1,0 +1,24 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package watcher
+
+import (
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+var (
+	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "ip-identity-watcher")
+)

--- a/pkg/ipcache/watcher/watcher_test.go
+++ b/pkg/ipcache/watcher/watcher_test.go
@@ -1,0 +1,101 @@
+// Copyright 2018-2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package watcher
+
+import (
+	"net"
+	"testing"
+
+	"github.com/cilium/cilium/pkg/checker"
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+type IPCacheTestSuite struct{}
+
+var _ = Suite(&IPCacheTestSuite{})
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+func (s *IPCacheTestSuite) TestKeyToIPNet(c *C) {
+	// Valid IPv6.
+	validIPv6Key := "cilium/state/ip/v1/default/f00d::a00:0:0:c164"
+
+	_, expectedIPv6, err := net.ParseCIDR("f00d::a00:0:0:c164/128")
+	c.Assert(err, IsNil)
+
+	ipv6, isHost, err := keyToIPNet(validIPv6Key)
+	c.Assert(ipv6, Not(IsNil))
+	c.Assert(err, IsNil)
+	c.Assert(isHost, Equals, true)
+	c.Assert(ipv6, checker.DeepEquals, expectedIPv6)
+
+	// Valid IPv6 prefix.
+	validIPv6Key = "cilium/state/ip/v1/default/f00d::a00:0:0:0/64"
+
+	_, expectedIPv6, err = net.ParseCIDR("f00d::a00:0:0:0/64")
+	c.Assert(err, IsNil)
+
+	ipv6, isHost, err = keyToIPNet(validIPv6Key)
+	c.Assert(ipv6, Not(IsNil))
+	c.Assert(err, IsNil)
+	c.Assert(isHost, Equals, false)
+	c.Assert(ipv6, checker.DeepEquals, expectedIPv6)
+
+	// Valid IPv4.
+	validIPv4Key := "cilium/state/ip/v1/default/10.0.114.197"
+	_, expectedIPv4, err := net.ParseCIDR("10.0.114.197/32")
+	c.Assert(err, IsNil)
+	ipv4, isHost, err := keyToIPNet(validIPv4Key)
+	c.Assert(ipv4, Not(IsNil))
+	c.Assert(err, IsNil)
+	c.Assert(isHost, Equals, true)
+	c.Assert(ipv4, checker.DeepEquals, expectedIPv4)
+
+	// Valid IPv4 prefix.
+	validIPv4Key = "cilium/state/ip/v1/default/10.0.114.0/24"
+	_, expectedIPv4, err = net.ParseCIDR("10.0.114.0/24")
+	c.Assert(err, IsNil)
+	ipv4, isHost, err = keyToIPNet(validIPv4Key)
+	c.Assert(ipv4, Not(IsNil))
+	c.Assert(err, IsNil)
+	c.Assert(isHost, Equals, false)
+	c.Assert(ipv4, checker.DeepEquals, expectedIPv4)
+
+	// Invalid prefix.
+	invalidPrefixKey := "cilium/state/foobar/v1/default/f00d::a00:0:0:c164"
+	nilIP, isHost, err := keyToIPNet(invalidPrefixKey)
+	c.Assert(nilIP, IsNil)
+	c.Assert(err, Not(IsNil))
+	c.Assert(isHost, Equals, false)
+
+	// Invalid IP in key.
+	invalidIPKey := "cilium/state/ip/v1/default/10.abfd.114.197"
+	nilIP, isHost, err = keyToIPNet(invalidIPKey)
+	c.Assert(nilIP, IsNil)
+	c.Assert(err, Not(IsNil))
+	c.Assert(isHost, Equals, false)
+
+	// Invalid CIDR.
+	invalidIPKey = "cilium/state/ip/v1/default/192.0.2.3/54"
+	nilIP, isHost, err = keyToIPNet(invalidIPKey)
+	c.Assert(nilIP, IsNil)
+	c.Assert(err, Not(IsNil))
+	c.Assert(isHost, Equals, false)
+}

--- a/pkg/k8s/rule_translate_test.go
+++ b/pkg/k8s/rule_translate_test.go
@@ -17,6 +17,9 @@
 package k8s
 
 import (
+	"net"
+
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/policy"
@@ -66,7 +69,9 @@ func (s *K8sSuite) TestTranslatorDirect(c *C) {
 		Labels: tag1,
 	}
 
-	translator := NewK8sTranslator(serviceInfo, endpointInfo, false, map[string]string{}, false)
+	allo := &FakeCIDRIdentityManager{}
+
+	translator := NewK8sTranslator(serviceInfo, endpointInfo, false, map[string]string{}, false, allo)
 
 	_, _, err := repo.Add(rule1, []policy.Endpoint{})
 	c.Assert(err, IsNil)
@@ -80,7 +85,7 @@ func (s *K8sSuite) TestTranslatorDirect(c *C) {
 	c.Assert(len(rule.ToCIDRSet), Equals, 1)
 	c.Assert(string(rule.ToCIDRSet[0].Cidr), Equals, epIP+"/32")
 
-	translator = NewK8sTranslator(serviceInfo, endpointInfo, true, map[string]string{}, false)
+	translator = NewK8sTranslator(serviceInfo, endpointInfo, true, map[string]string{}, false, allo)
 	result, err = repo.TranslateRules(translator)
 	c.Assert(result.NumToServicesRules, Equals, 1)
 
@@ -122,7 +127,8 @@ func (s *K8sSuite) TestServiceMatches(c *C) {
 		},
 	}
 
-	translator := NewK8sTranslator(serviceInfo, endpointInfo, false, svcLabels, false)
+	allo := &FakeCIDRIdentityManager{}
+	translator := NewK8sTranslator(serviceInfo, endpointInfo, false, svcLabels, false, allo)
 	c.Assert(translator.serviceMatches(service), Equals, true)
 }
 
@@ -169,7 +175,9 @@ func (s *K8sSuite) TestTranslatorLabels(c *C) {
 		Labels: tag1,
 	}
 
-	translator := NewK8sTranslator(serviceInfo, endpointInfo, false, svcLabels, false)
+	allo := &FakeCIDRIdentityManager{}
+
+	translator := NewK8sTranslator(serviceInfo, endpointInfo, false, svcLabels, false, allo)
 
 	_, _, err := repo.Add(rule1, []policy.Endpoint{})
 	c.Assert(err, IsNil)
@@ -183,7 +191,7 @@ func (s *K8sSuite) TestTranslatorLabels(c *C) {
 	c.Assert(len(rule.ToCIDRSet), Equals, 1)
 	c.Assert(string(rule.ToCIDRSet[0].Cidr), Equals, epIP+"/32")
 
-	translator = NewK8sTranslator(serviceInfo, endpointInfo, true, svcLabels, false)
+	translator = NewK8sTranslator(serviceInfo, endpointInfo, true, svcLabels, false, allo)
 	result, err = repo.TranslateRules(translator)
 
 	rule = repo.SearchRLocked(tag1)[0].Egress[0]
@@ -211,20 +219,22 @@ func (s *K8sSuite) TestGenerateToCIDRFromEndpoint(c *C) {
 		},
 	}
 
-	err := generateToCidrFromEndpoint(rule, endpointInfo, false)
+	allo := &FakeCIDRIdentityManager{}
+
+	err := generateToCidrFromEndpoint(rule, endpointInfo, false, allo)
 	c.Assert(err, IsNil)
 
 	c.Assert(len(rule.ToCIDRSet), Equals, 1)
 	c.Assert(string(rule.ToCIDRSet[0].Cidr), Equals, epIP+"/32")
 
 	// second run, to make sure there are no duplicates added
-	err = generateToCidrFromEndpoint(rule, endpointInfo, false)
+	err = generateToCidrFromEndpoint(rule, endpointInfo, false, allo)
 	c.Assert(err, IsNil)
 
 	c.Assert(len(rule.ToCIDRSet), Equals, 1)
 	c.Assert(string(rule.ToCIDRSet[0].Cidr), Equals, epIP+"/32")
 
-	err = deleteToCidrFromEndpoint(rule, endpointInfo, false)
+	err = deleteToCidrFromEndpoint(rule, endpointInfo, false, allo)
 	c.Assert(err, IsNil)
 	c.Assert(len(rule.ToCIDRSet), Equals, 0)
 }
@@ -280,11 +290,20 @@ func (s *K8sSuite) TestPreprocessRules(c *C) {
 
 	rules := api.Rules{&rule1}
 
-	err := PreprocessRules(rules, &cache)
+	allo := &FakeCIDRIdentityManager{}
+
+	err := PreprocessRules(rules, &cache, allo)
 	c.Assert(err, IsNil)
 
 	c.Assert(len(rule1.Egress[0].ToCIDRSet), Equals, 1)
 	c.Assert(string(rule1.Egress[0].ToCIDRSet[0].Cidr), Equals, epIP+"/32")
+}
+
+type FakeCIDRIdentityManager struct{}
+
+func (f *FakeCIDRIdentityManager) ReleaseCIDRs(prefixes []*net.IPNet) {}
+func (f *FakeCIDRIdentityManager) AllocateCIDRs(prefixes []*net.IPNet) ([]*identity.Identity, error) {
+	return nil, nil
 }
 
 func (s *K8sSuite) TestDontDeleteUserRules(c *C) {
@@ -312,20 +331,22 @@ func (s *K8sSuite) TestDontDeleteUserRules(c *C) {
 		},
 	}
 
-	err := generateToCidrFromEndpoint(rule, endpointInfo, false)
+	allocator := &FakeCIDRIdentityManager{}
+
+	err := generateToCidrFromEndpoint(rule, endpointInfo, false, allocator)
 	c.Assert(err, IsNil)
 
 	c.Assert(len(rule.ToCIDRSet), Equals, 2)
 	c.Assert(string(rule.ToCIDRSet[1].Cidr), Equals, epIP+"/32")
 
 	// second run, to make sure there are no duplicates added
-	err = generateToCidrFromEndpoint(rule, endpointInfo, false)
+	err = generateToCidrFromEndpoint(rule, endpointInfo, false, allocator)
 	c.Assert(err, IsNil)
 
 	c.Assert(len(rule.ToCIDRSet), Equals, 2)
 	c.Assert(string(rule.ToCIDRSet[1].Cidr), Equals, epIP+"/32")
 
-	err = deleteToCidrFromEndpoint(rule, endpointInfo, false)
+	err = deleteToCidrFromEndpoint(rule, endpointInfo, false, allocator)
 	c.Assert(err, IsNil)
 	c.Assert(len(rule.ToCIDRSet), Equals, 1)
 	c.Assert(string(rule.ToCIDRSet[0].Cidr), Equals, string(userCIDR))

--- a/pkg/k8s/watchers/cilium_endpoint.go
+++ b/pkg/k8s/watchers/cilium_endpoint.go
@@ -57,7 +57,7 @@ func (k *K8sWatcher) ciliumEndpointsInit(ciliumNPClient *k8s.K8sCiliumClient, se
 						swgCiliumEndpoints.Add()
 						serCiliumEndpoints.Enqueue(func() error {
 							defer swgCiliumEndpoints.Done()
-							endpointUpdated(endpoint)
+							k.endpointUpdated(endpoint)
 							k.K8sEventProcessed(metricCiliumEndpoint, metricCreate, true)
 							return nil
 						}, serializer.NoRetry)
@@ -72,7 +72,7 @@ func (k *K8sWatcher) ciliumEndpointsInit(ciliumNPClient *k8s.K8sCiliumClient, se
 						swgCiliumEndpoints.Add()
 						serCiliumEndpoints.Enqueue(func() error {
 							defer swgCiliumEndpoints.Done()
-							endpointUpdated(endpoint)
+							k.endpointUpdated(endpoint)
 							k.K8sEventProcessed(metricCiliumEndpoint, metricUpdate, true)
 							return nil
 						}, serializer.NoRetry)
@@ -99,7 +99,7 @@ func (k *K8sWatcher) ciliumEndpointsInit(ciliumNPClient *k8s.K8sCiliumClient, se
 					swgCiliumEndpoints.Add()
 					serCiliumEndpoints.Enqueue(func() error {
 						defer swgCiliumEndpoints.Done()
-						endpointDeleted(ciliumEndpoint)
+						k.endpointDeleted(ciliumEndpoint)
 						return nil
 					}, serializer.NoRetry)
 				},
@@ -134,7 +134,7 @@ func (k *K8sWatcher) ciliumEndpointsInit(ciliumNPClient *k8s.K8sCiliumClient, se
 	}
 }
 
-func endpointUpdated(endpoint *types.CiliumEndpoint) {
+func (k *K8sWatcher) endpointUpdated(endpoint *types.CiliumEndpoint) {
 	// default to the standard key
 	encryptionKey := node.GetIPsecKeyIdentity()
 
@@ -168,27 +168,27 @@ func endpointUpdated(endpoint *types.CiliumEndpoint) {
 
 		for _, pair := range endpoint.Networking.Addressing {
 			if pair.IPV4 != "" {
-				ipcache.IPIdentityCache.Upsert(pair.IPV4, nodeIP, encryptionKey, k8sMeta,
+				k.ipc.Upsert(pair.IPV4, nodeIP, encryptionKey, k8sMeta,
 					ipcache.Identity{ID: id, Source: source.CustomResource})
 			}
 
 			if pair.IPV6 != "" {
-				ipcache.IPIdentityCache.Upsert(pair.IPV6, nodeIP, encryptionKey, k8sMeta,
+				k.ipc.Upsert(pair.IPV6, nodeIP, encryptionKey, k8sMeta,
 					ipcache.Identity{ID: id, Source: source.CustomResource})
 			}
 		}
 	}
 }
 
-func endpointDeleted(endpoint *types.CiliumEndpoint) {
+func (k *K8sWatcher) endpointDeleted(endpoint *types.CiliumEndpoint) {
 	if endpoint.Networking != nil {
 		for _, pair := range endpoint.Networking.Addressing {
 			if pair.IPV4 != "" {
-				ipcache.IPIdentityCache.Delete(pair.IPV4, source.CustomResource)
+				k.ipc.Delete(pair.IPV4, source.CustomResource)
 			}
 
 			if pair.IPV6 != "" {
-				ipcache.IPIdentityCache.Delete(pair.IPV6, source.CustomResource)
+				k.ipc.Delete(pair.IPV6, source.CustomResource)
 			}
 		}
 	}

--- a/pkg/k8s/watchers/cilium_network_policy.go
+++ b/pkg/k8s/watchers/cilium_network_policy.go
@@ -205,7 +205,7 @@ func (k *K8sWatcher) addCiliumNetworkPolicyV2(ciliumNPClient clientset.Interface
 
 	rules, policyImportErr := cnp.Parse()
 	if policyImportErr == nil {
-		policyImportErr = k8s.PreprocessRules(rules, &k.K8sSvcCache)
+		policyImportErr = k8s.PreprocessRules(rules, &k.K8sSvcCache, k.idallocator)
 		// Replace all rules with the same name, namespace and
 		// resourceTypeCiliumNetworkPolicy
 		rev, policyImportErr = k.policyManager.PolicyAdd(rules, &policy.AddOptions{

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -317,7 +317,7 @@ func (k *K8sWatcher) updatePodHostIP(pod *types.Pod) (bool, error) {
 	// Initial mapping of podIP <-> hostIP <-> identity. The mapping is
 	// later updated once the allocator has determined the real identity.
 	// If the endpoint remains unmanaged, the identity remains untouched.
-	selfOwned := ipcache.IPIdentityCache.Upsert(pod.StatusPodIP, hostIP, hostKey, k8sMeta, ipcache.Identity{
+	selfOwned := k.ipc.Upsert(pod.StatusPodIP, hostIP, hostKey, k8sMeta, ipcache.Identity{
 		ID:     identity.ReservedIdentityUnmanaged,
 		Source: source.Kubernetes,
 	})
@@ -341,7 +341,7 @@ func (k *K8sWatcher) deletePodHostIP(pod *types.Pod) (bool, error) {
 	// a small race condition exists here as deletion could occur in
 	// parallel based on another event but it doesn't matter as the
 	// identity is going away
-	id, exists := ipcache.IPIdentityCache.LookupByIP(pod.StatusPodIP)
+	id, exists := k.ipc.LookupByIP(pod.StatusPodIP)
 	if !exists {
 		return true, fmt.Errorf("identity for IP does not exist in case")
 	}
@@ -350,7 +350,7 @@ func (k *K8sWatcher) deletePodHostIP(pod *types.Pod) (bool, error) {
 		return true, fmt.Errorf("ipcache entry not owned by kubernetes source")
 	}
 
-	ipcache.IPIdentityCache.Delete(pod.StatusPodIP, source.Kubernetes)
+	k.ipc.Delete(pod.StatusPodIP, source.Kubernetes)
 
 	return false, nil
 }

--- a/pkg/k8s/watchers/watcher_test.go
+++ b/pkg/k8s/watchers/watcher_test.go
@@ -237,6 +237,8 @@ func (s *K8sWatcherSuite) TestUpdateToServiceEndpointsGH9525(c *C) {
 		policyManager,
 		policyRepository,
 		nil,
+		nil,
+		nil,
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()
@@ -562,6 +564,8 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ClusterIP(c *C) {
 		policyManager,
 		policyRepository,
 		svcManager,
+		nil,
+		nil,
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()
@@ -1194,6 +1198,8 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_NodePort(c *C) {
 		policyManager,
 		policyRepository,
 		svcManager,
+		nil,
+		nil,
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()
@@ -1519,6 +1525,8 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_GH9576_1(c *C) {
 		policyManager,
 		policyRepository,
 		svcManager,
+		nil,
+		nil,
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()
@@ -1835,6 +1843,8 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_GH9576_2(c *C) {
 		policyManager,
 		policyRepository,
 		svcManager,
+		nil,
+		nil,
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/datapath/fake"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/source"
 
@@ -96,7 +97,7 @@ func (s *managerTestSuite) TestNodeLifecycle(c *check.C) {
 	dp.EnableNodeAddEvent = true
 	dp.EnableNodeUpdateEvent = true
 	dp.EnableNodeDeleteEvent = true
-	mngr, err := NewManager("test", dp)
+	mngr, err := NewManager("test", dp, ipcache.NewIPCache())
 	c.Assert(err, check.IsNil)
 
 	n1 := node.Node{Name: "node1", Cluster: "c1"}
@@ -165,7 +166,7 @@ func (s *managerTestSuite) TestMultipleSources(c *check.C) {
 	dp.EnableNodeAddEvent = true
 	dp.EnableNodeUpdateEvent = true
 	dp.EnableNodeDeleteEvent = true
-	mngr, err := NewManager("test", dp)
+	mngr, err := NewManager("test", dp, ipcache.NewIPCache())
 	c.Assert(err, check.IsNil)
 	defer mngr.Close()
 
@@ -234,7 +235,7 @@ func (s *managerTestSuite) TestMultipleSources(c *check.C) {
 }
 
 func (s *managerTestSuite) BenchmarkUpdateAndDeleteCycle(c *check.C) {
-	mngr, err := NewManager("test", fake.NewNodeHandler())
+	mngr, err := NewManager("test", fake.NewNodeHandler(), ipcache.NewIPCache())
 	c.Assert(err, check.IsNil)
 	defer mngr.Close()
 
@@ -252,7 +253,7 @@ func (s *managerTestSuite) BenchmarkUpdateAndDeleteCycle(c *check.C) {
 }
 
 func (s *managerTestSuite) TestClusterSizeDependantInterval(c *check.C) {
-	mngr, err := NewManager("test", fake.NewNodeHandler())
+	mngr, err := NewManager("test", fake.NewNodeHandler(), ipcache.NewIPCache())
 	c.Assert(err, check.IsNil)
 	defer mngr.Close()
 
@@ -277,7 +278,7 @@ func (s *managerTestSuite) TestBackgroundSync(c *check.C) {
 
 	signalNodeHandler := newSignalNodeHandler()
 	signalNodeHandler.EnableNodeValidateImplementationEvent = true
-	mngr, err := NewManager("test", signalNodeHandler)
+	mngr, err := NewManager("test", signalNodeHandler, ipcache.NewIPCache())
 	c.Assert(err, check.IsNil)
 	defer mngr.Close()
 

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -37,7 +38,7 @@ var (
 	toFoo        = &SearchContext{To: labels.ParseSelectLabelArray("foo")}
 
 	dummySelectorCacheUser = &DummySelectorCacheUser{}
-	c                      = cache.NewCachingIdentityAllocator(&allocator.IdentityAllocatorOwnerMock{})
+	c                      = cache.NewCachingIdentityAllocator(&allocator.IdentityAllocatorOwnerMock{}, ipcache.NewIPCache())
 	testSelectorCache      = NewSelectorCache(c.GetIdentityCache())
 
 	wildcardCachedSelector, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, api.WildcardEndpointSelector)

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -179,7 +180,7 @@ func (d DummyOwner) LookupRedirectPort(l4 *L4Filter) uint16 {
 }
 
 func bootstrapRepo(ruleGenFunc func(int) api.Rules, numRules int, c *C) *Repository {
-	mgr := cache.NewCachingIdentityAllocator(&allocator.IdentityAllocatorOwnerMock{})
+	mgr := cache.NewCachingIdentityAllocator(&allocator.IdentityAllocatorOwnerMock{}, ipcache.NewIPCache())
 	testRepo := NewPolicyRepository(mgr.GetIdentityCache(), nil)
 
 	var wg sync.WaitGroup

--- a/pkg/proxy/kafka_test.go
+++ b/pkg/proxy/kafka_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
@@ -60,7 +61,7 @@ type proxyTestSuite struct {
 var _ = Suite(&proxyTestSuite{})
 
 func (s *proxyTestSuite) SetUpSuite(c *C) {
-	Allocator = cache.NewCachingIdentityAllocator(&allocator.IdentityAllocatorOwnerMock{})
+	Allocator = cache.NewCachingIdentityAllocator(&allocator.IdentityAllocatorOwnerMock{}, ipcache.NewIPCache())
 	s.repo = policy.NewPolicyRepository(nil, nil)
 }
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -113,9 +113,9 @@ type Proxy struct {
 // and access log server.
 func StartProxySupport(minPort uint16, maxPort uint16, stateDir string,
 	accessLogFile string, accessLogNotifier logger.LogRecordNotifier, accessLogMetadata []string,
-	datapathUpdater DatapathUpdater, mgr EndpointLookup) *Proxy {
+	datapathUpdater DatapathUpdater, mgr EndpointLookup, ipc envoy.IPNotifier) *Proxy {
 	endpointManager = mgr
-	xdsServer := envoy.StartXDSServer(stateDir)
+	xdsServer := envoy.StartXDSServer(stateDir, ipc)
 
 	if accessLogFile != "" {
 		if err := logger.OpenLogfile(accessLogFile); err != nil {

--- a/pkg/testutils/allocator/allocator.go
+++ b/pkg/testutils/allocator/allocator.go
@@ -16,6 +16,7 @@ package allocator
 
 import (
 	"context"
+	"net"
 
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
@@ -32,6 +33,11 @@ func (i *IdentityAllocatorOwnerMock) GetNodeSuffix() string {
 
 // FakeIdentityAllocator is used as a mock identity allocator for unit tests.
 type FakeIdentityAllocator struct{}
+
+// AllocateCIDRsForIPs does nothing.
+func (f *FakeIdentityAllocator) AllocateCIDRsForIPs(prefixes []net.IP) ([]*identity.Identity, error) {
+	return nil, nil
+}
 
 // WaitForInitialGlobalIdentities does nothing.
 func (f *FakeIdentityAllocator) WaitForInitialGlobalIdentities(context.Context) error {
@@ -55,4 +61,11 @@ func (f *FakeIdentityAllocator) LookupIdentityByID(ctx context.Context, id ident
 		return identity
 	}
 	return nil
+}
+
+type FakeCIDRIdentityAllocator struct{}
+
+func (f *FakeCIDRIdentityAllocator) ReleaseCIDRs(prefixes []*net.IPNet) {}
+func (f *FakeCIDRIdentityAllocator) AllocateCIDRs(prefixes []*net.IPNet) ([]*identity.Identity, error) {
+	return nil, nil
 }

--- a/proxylib/npds/client_test.go
+++ b/proxylib/npds/client_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/envoy"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/proxylib/test"
 
 	"github.com/cilium/proxy/go/cilium/api"
@@ -98,7 +99,7 @@ func (s *ClientSuite) TestRequestAllResources(c *C) {
 
 	// Some wait before server is made available
 	time.Sleep(500 * time.Millisecond)
-	xdsServer := envoy.StartXDSServer(test.Tmpdir)
+	xdsServer := envoy.StartXDSServer(test.Tmpdir, ipcache.NewIPCache())
 	time.Sleep(500 * time.Millisecond)
 
 	// Create version 1 with resource 0.


### PR DESCRIPTION
* create a single ipcache and plumb it down into packages which consume the
ipcache. Along with this, remove the allocation of CIDRs to be part of
`pkg/ipcache`, and make this part of the `CachingIdentityAllocator`.
* factor watcher into separate package: the ipcache does not need to be aware of
how it is populated, which is the concern of the watcher. Decouple these two
types into separate packages accordingly.

Signed-off by: Ian Vernon <ian@cilium.io>

I found it quite hard to do this in multiple commits - given how 'global' the structure is, I felt it was sort of an all-or-none way to refactor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9528)
<!-- Reviewable:end -->
