### PR TITLE
Documentation: update to account for new CNPNodeStatus capabilities

### DIFF
--- a/Documentation/concepts/overview.rst
+++ b/Documentation/concepts/overview.rst
@@ -158,3 +158,5 @@ include:
 
 * Interaction with the AWS API for managing :ref:`ipam_eni`
 
+* Sending ``CiliumNetworkPolicyNodeStatus`` updates from the whole cluster for 
+  each CiliumNetworkPolicy to ``kube-apiserver``

--- a/Documentation/kvstore.rst
+++ b/Documentation/kvstore.rst
@@ -86,6 +86,23 @@ Key                                                           Value
 
 .. _identity.IPIdentityPair: https://godoc.org/github.com/cilium/cilium/pkg/identity#IPIdentityPair
 
+CiliumNetworkPolicyNodeStatus
+-----------------------------
+
+If handover to Kubernetes is enabled, then each ``cilium-agent`` will propagate
+the  state of whether it has realized a given CNP to the key-value store instead
+of directly writing to ``kube-apiserver``. ``cilium-operator`` will listen for 
+updates to this prefix from the key-value store, and will be the sole updater
+of statuses for CNPs in the cluster.
+
+================================================================ ====================
+Key                                                              Value
+================================================================ ====================
+``cilium/state/cnpstatuses/v2/<UID>/<namespace>/<name>/<node>``  k8s.CNPNSWithMeta_
+================================================================ ====================
+
+.. _k8s.CNPNSWithMeta: https://godoc.org/github.com/cilium/cilium/pkg/k8s#CNPNSWithMeta
+
 Leases
 ======
 


### PR DESCRIPTION
Recent work was merged to offload CNPNodeStatus updates to the key-value store, which will be streamed to `cilium-operator` and then sent to `kube-apiserver`. Add documentation about the new prefix which is used in the key-value store, as well as for `cilium-operator` to list this as one of its scalability capabilities.

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9531)
<!-- Reviewable:end -->
