### PR TITLE
docs: clarify usage of bpf fs mount

### DIFF
--- a/Documentation/kubernetes/requirements.rst
+++ b/Documentation/kubernetes/requirements.rst
@@ -42,15 +42,15 @@ the `Kubernets CNI network-plugins documentation <https://kubernetes.io/docs/con
 Mounted BPF filesystem
 ======================
 
-This step is optional but recommended. It allows the ``cilium-agent`` to pin
-BPF resources to a persistent filesystem and make them persistent across
-restarts of the agent. If the BPF filesystem is not mounted in the host
-filesystem, Cilium will automatically mount the filesystem but it will be
-unmounted and re-mounted when the Cilium pod is restarted. This in turn will
-cause BPF resources to be re-created which will cause network connectivity to
-be disrupted.  Mounting the BPF filesystem in the host mount namespace will
-ensure that the agent can be restarted without affecting connectivity of any
-pods.
+This step is **required for production** environments but optional for testing
+and development. It allows the ``cilium-agent`` to pin BPF resources to a
+persistent filesystem and make them persistent across restarts of the agent.
+If the BPF filesystem is not mounted in the host filesystem, Cilium will
+automatically mount the filesystem but it will be unmounted and re-mounted when
+the Cilium pod is restarted. This in turn will cause BPF resources to be
+re-created which will cause network connectivity to be disrupted. Mounting the
+BPF filesystem in the host mount namespace will ensure that the agent can be
+restarted without affecting connectivity of any pods.
 
 In order to mount the BPF filesystem, the following command must be run in the
 host mount namespace. The command must only be run once during the boot process


### PR DESCRIPTION
As serveral users often miss this optional but required steps in a
production environments, we should also change the instructions for
the bpf mount volume to be required instead of optional.

Signed-off-by: André Martins <andre@cilium.io>

More info: https://github.com/cilium/cilium/issues/8722#issuecomment-547927069

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9534)
<!-- Reviewable:end -->
