### PR TITLE
pkg/k8s: fix toServices policy update when service endpoints are modified

### DIFF
--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -90,11 +90,6 @@ var (
 		ruleImportMetadataMap: make(map[string]policyImportMetadata),
 	}
 
-	// local cache of Kubernetes Endpoints which relate to external services.
-	endpointMetadataCache = endpointImportMetadataCache{
-		endpointImportMetadataMap: make(map[string]endpointImportMetadata),
-	}
-
 	errIPCacheOwnedByNonK8s = fmt.Errorf("ipcache entry owned by kvstore or agent")
 )
 
@@ -167,43 +162,6 @@ func NewK8sWatcher(
 		policyRepository:    policyRepository,
 		svcManager:          svcManager,
 	}
-}
-
-// endpointImportMetadataCache maps the unique identifier of a Kubernetes
-// Endpoint (namespace and name) to metadata about whether translation of the
-// rules involving services that the endpoint corresponds to into the
-// agent's policy repository at the time said rule was imported (if any error
-// occurred while importing).
-type endpointImportMetadataCache struct {
-	mutex                     lock.RWMutex
-	endpointImportMetadataMap map[string]endpointImportMetadata
-}
-
-type endpointImportMetadata struct {
-	ruleTranslationError error
-}
-
-func (r *endpointImportMetadataCache) upsert(id k8s.ServiceID, ruleTranslationErr error) {
-	meta := endpointImportMetadata{
-		ruleTranslationError: ruleTranslationErr,
-	}
-
-	r.mutex.Lock()
-	r.endpointImportMetadataMap[id.String()] = meta
-	r.mutex.Unlock()
-}
-
-func (r *endpointImportMetadataCache) delete(id k8s.ServiceID) {
-	r.mutex.Lock()
-	delete(r.endpointImportMetadataMap, id.String())
-	r.mutex.Unlock()
-}
-
-func (r *endpointImportMetadataCache) get(id k8s.ServiceID) (endpointImportMetadata, bool) {
-	r.mutex.RLock()
-	endpointImportMeta, ok := r.endpointImportMetadataMap[id.String()]
-	r.mutex.RUnlock()
-	return endpointImportMeta, ok
 }
 
 // k8sAPIGroupsUsed is a lockable map to hold which k8s API Groups we have
@@ -451,25 +409,14 @@ func (k *K8sWatcher) k8sServiceHandler() {
 				return
 			}
 
-			serviceImportMeta, cacheOK := endpointMetadataCache.get(event.ID)
-
-			// If this is the first time adding this Endpoint, or there was an error
-			// adding it last time, then try to add translate it and its
-			// corresponding external service for any toServices rules which
-			// select said service.
-			if !cacheOK || (cacheOK && serviceImportMeta.ruleTranslationError != nil) {
-				translator := k8s.NewK8sTranslator(event.ID, *event.Endpoints, false, svc.Labels, true)
-				result, err := k.policyRepository.TranslateRules(translator)
-				endpointMetadataCache.upsert(event.ID, err)
-				if err != nil {
-					log.Errorf("Unable to repopulate egress policies from ToService rules: %v", err)
-					break
-				} else if result.NumToServicesRules > 0 {
-					// Only trigger policy updates if ToServices rules are in effect
-					k.policyManager.TriggerPolicyUpdates(true, "Kubernetes service endpoint added")
-				}
-			} else if serviceImportMeta.ruleTranslationError == nil {
-				k.policyManager.TriggerPolicyUpdates(true, "Kubernetes service endpoint updated")
+			translator := k8s.NewK8sTranslator(event.ID, *event.Endpoints, false, svc.Labels, true)
+			result, err := k.policyRepository.TranslateRules(translator)
+			if err != nil {
+				log.Errorf("Unable to repopulate egress policies from ToService rules: %v", err)
+				break
+			} else if result.NumToServicesRules > 0 {
+				// Only trigger policy updates if ToServices rules are in effect
+				k.policyManager.TriggerPolicyUpdates(true, "Kubernetes service endpoint added")
 			}
 
 		case k8s.DeleteService:
@@ -480,8 +427,6 @@ func (k *K8sWatcher) k8sServiceHandler() {
 			if !svc.IsExternal() {
 				return
 			}
-
-			endpointMetadataCache.delete(event.ID)
 
 			translator := k8s.NewK8sTranslator(event.ID, *event.Endpoints, true, svc.Labels, true)
 			result, err := k.policyRepository.TranslateRules(translator)

--- a/pkg/k8s/watchers/watcher_test.go
+++ b/pkg/k8s/watchers/watcher_test.go
@@ -1,0 +1,255 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package watchers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cilium/cilium/pkg/checker"
+	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/k8s"
+	"github.com/cilium/cilium/pkg/k8s/types"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/api"
+
+	. "gopkg.in/check.v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type K8sWatcherSuite struct{}
+
+var _ = Suite(&K8sWatcherSuite{})
+
+type fakeEndpointManager struct {
+	OnGetEndpoints                func() []*endpoint.Endpoint
+	OnLookupPodName               func(string) *endpoint.Endpoint
+	OnWaitForEndpointsAtPolicyRev func(ctx context.Context, rev uint64) error
+}
+
+func (f *fakeEndpointManager) GetEndpoints() []*endpoint.Endpoint {
+	if f.OnGetEndpoints != nil {
+		return f.OnGetEndpoints()
+	}
+	panic("OnGetEndpoints was called and is not set!")
+}
+
+func (f *fakeEndpointManager) LookupPodName(podName string) *endpoint.Endpoint {
+	if f.OnLookupPodName != nil {
+		return f.OnLookupPodName(podName)
+	}
+	panic("OnLookupPodName(string) was called and is not set!")
+}
+
+func (f *fakeEndpointManager) WaitForEndpointsAtPolicyRev(ctx context.Context, rev uint64) error {
+	if f.OnWaitForEndpointsAtPolicyRev != nil {
+		return f.OnWaitForEndpointsAtPolicyRev(ctx, rev)
+	}
+	panic("OnWaitForEndpointsAtPolicyRev(context.Context, uint64) was called and is not set!")
+}
+
+type fakeNodeDiscoverManager struct {
+	OnNodeDeleted                  func(n node.Node)
+	OnNodeUpdated                  func(n node.Node)
+	OnClusterSizeDependantInterval func(baseInterval time.Duration) time.Duration
+}
+
+func (f *fakeNodeDiscoverManager) NodeDeleted(n node.Node) {
+	if f.OnNodeDeleted != nil {
+		f.OnNodeDeleted(n)
+		return
+	}
+	panic("OnNodeDeleted(node) was called and is not set!")
+}
+
+func (f *fakeNodeDiscoverManager) NodeUpdated(n node.Node) {
+	if f.OnNodeUpdated != nil {
+		f.OnNodeUpdated(n)
+		return
+	}
+	panic("OnNodeUpdated(node) was called and is not set!")
+}
+
+func (f *fakeNodeDiscoverManager) ClusterSizeDependantInterval(baseInterval time.Duration) time.Duration {
+	if f.OnClusterSizeDependantInterval != nil {
+		return f.OnClusterSizeDependantInterval(baseInterval)
+	}
+	panic("OnClusterSizeDependantInterval(time.Duration) was called and is not set!")
+}
+
+type fakePolicyManager struct {
+	OnTriggerPolicyUpdates func(force bool, reason string)
+	OnPolicyAdd            func(rules api.Rules, opts *policy.AddOptions) (newRev uint64, err error)
+	OnPolicyDelete         func(labels labels.LabelArray) (newRev uint64, err error)
+}
+
+func (f *fakePolicyManager) TriggerPolicyUpdates(force bool, reason string) {
+	if f.OnTriggerPolicyUpdates != nil {
+		f.OnTriggerPolicyUpdates(force, reason)
+		return
+	}
+	panic("OnTriggerPolicyUpdates(force bool, reason string) was called and is not set!")
+}
+
+func (f *fakePolicyManager) PolicyAdd(rules api.Rules, opts *policy.AddOptions) (newRev uint64, err error) {
+	if f.OnPolicyAdd != nil {
+		return f.OnPolicyAdd(rules, opts)
+	}
+	panic("OnPolicyAdd(api.Rules, *policy.AddOptions) (uint64, error) was called and is not set!")
+}
+
+func (f *fakePolicyManager) PolicyDelete(labels labels.LabelArray) (newRev uint64, err error) {
+	if f.OnPolicyDelete != nil {
+		return f.OnPolicyDelete(labels)
+	}
+	panic("OnPolicyDelete(labels.LabelArray) (uint64, error) was called and is not set!")
+}
+
+type fakePolicyRepository struct {
+	OnTranslateRules func(translator policy.Translator) (*policy.TranslationResult, error)
+}
+
+func (f *fakePolicyRepository) TranslateRules(translator policy.Translator) (*policy.TranslationResult, error) {
+	if f.OnTranslateRules != nil {
+		return f.OnTranslateRules(translator)
+	}
+	panic("OnTranslateRules(policy.Translator) (*policy.TranslationResult, error) was called and is not set!")
+}
+
+type fakeSvcManager struct {
+	OnDeleteService func(frontend loadbalancer.L3n4Addr) (bool, error)
+	OnUpsertService func(frontend loadbalancer.L3n4AddrID, backends []loadbalancer.Backend, svcType loadbalancer.SVCType) (bool, loadbalancer.ID, error)
+}
+
+func (f *fakeSvcManager) DeleteService(frontend loadbalancer.L3n4Addr) (bool, error) {
+	if f.OnDeleteService != nil {
+		return f.OnDeleteService(frontend)
+	}
+	panic("OnDeleteService(loadbalancer.L3n4Addr) (bool, error) was called and is not set!")
+}
+
+func (f *fakeSvcManager) UpsertService(frontend loadbalancer.L3n4AddrID, backends []loadbalancer.Backend, svcType loadbalancer.SVCType) (bool, loadbalancer.ID, error) {
+	if f.OnUpsertService != nil {
+		return f.OnUpsertService(frontend, backends, svcType)
+	}
+	panic("OnUpsertService(loadbalancer.L3n4AddrID, []loadbalancer.Backend, loadbalancer.SVCType) (bool, loadbalancer.ID, error) was called and is not set!")
+}
+
+func (s *K8sWatcherSuite) TestUpdateToServiceEndpointsGH9525(c *C) {
+
+	ep1stApply := &types.Endpoints{
+		Endpoints: &v1.Endpoints{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "bar",
+			},
+			Subsets: []v1.EndpointSubset{
+				{
+					Addresses: []v1.EndpointAddress{{IP: "2.2.2.2"}},
+					Ports: []v1.EndpointPort{
+						{
+							Name:     "http-test-svc",
+							Port:     8080,
+							Protocol: v1.ProtocolTCP,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ep2ndApply := ep1stApply.DeepCopy()
+	ep2ndApply.Subsets[0].Addresses = append(
+		ep2ndApply.Subsets[0].Addresses,
+		v1.EndpointAddress{IP: "3.3.3.3"},
+	)
+
+	policyManagerCalls := 0
+	policyManager := &fakePolicyManager{
+		OnTriggerPolicyUpdates: func(force bool, reason string) {
+			policyManagerCalls++
+		},
+	}
+	policyRepositoryCalls := 0
+	policyRepository := &fakePolicyRepository{
+		OnTranslateRules: func(tr policy.Translator) (result *policy.TranslationResult, e error) {
+			rt, ok := tr.(k8s.RuleTranslator)
+			c.Assert(ok, Equals, true)
+			switch policyRepositoryCalls {
+			case 0:
+				_, parsedEPs := k8s.ParseEndpoints(ep1stApply)
+				c.Assert(rt.Endpoint.Backends, checker.DeepEquals, parsedEPs.Backends)
+			case 1:
+				_, parsedEPs := k8s.ParseEndpoints(ep2ndApply)
+				c.Assert(rt.Endpoint.Backends, checker.DeepEquals, parsedEPs.Backends)
+			default:
+				c.Assert(policyRepositoryCalls, Not(Equals), 0, Commentf("policy repository was called more times than expected!"))
+			}
+			policyRepositoryCalls++
+
+			return &policy.TranslationResult{NumToServicesRules: 1}, nil
+		},
+	}
+
+	w := NewK8sWatcher(
+		nil,
+		nil,
+		policyManager,
+		policyRepository,
+		nil,
+	)
+	go w.k8sServiceHandler()
+	swg := lock.NewStoppableWaitGroup()
+
+	k8sSvc := &types.Service{
+		Service: &v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "bar",
+				Labels: map[string]string{
+					"foo": "bar",
+				},
+			},
+			Spec: v1.ServiceSpec{
+				ClusterIP: "127.0.0.1",
+				Type:      v1.ServiceTypeClusterIP,
+			},
+		},
+	}
+
+	w.K8sSvcCache.UpdateService(k8sSvc, swg)
+	w.K8sSvcCache.UpdateEndpoints(ep1stApply, swg)
+	// Running a 2nd update should also trigger a new policy update
+	w.K8sSvcCache.UpdateEndpoints(ep2ndApply, swg)
+
+	swg.Stop()
+	swg.Wait()
+
+	c.Assert(policyRepositoryCalls, Equals, 2)
+	c.Assert(policyManagerCalls, Equals, 2)
+}


### PR DESCRIPTION
When a toServices policy was used, Cilium wouldn't update the policy
toCIDR whenever the endpoints selected by that service changed. This
could make Cilium block traffic for new endpoints added, and allowing
traffic for endpoints deleted for the service selected by the toServices
rule.

Signed-off-by: André Martins <andre@cilium.io>

Fixes: https://github.com/cilium/cilium/issues/9525

Marking for backport for 1.5 and 1.6 since it affects policy enforcement.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9535)
<!-- Reviewable:end -->
