### PR TITLE
KVStore and k8s bug fixes

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -620,8 +620,7 @@ func (e *Endpoint) FormatGlobalEndpointID() string {
 // This synchronizes the key-value store with a mapping of the endpoint's IP
 // with the numerical ID representing its security identity.
 func (e *Endpoint) runIPIdentitySync(endpointIP addressing.CiliumIP) {
-
-	if !endpointIP.IsSet() {
+	if option.Config.KVStore == "" || !endpointIP.IsSet() {
 		return
 	}
 

--- a/pkg/k8s/endpointsynchronizer/cep.go
+++ b/pkg/k8s/endpointsynchronizer/cep.go
@@ -226,6 +226,7 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 				// backoff and the Update* calls returned the current localCEP
 				case err != nil && k8serrors.IsConflict(err):
 					scopedLog.WithError(err).Warn("Cannot update CEP due to a revision conflict. The next controller execution will try again")
+					needInit = true
 					return nil
 
 				// Ensure we re-init when we see a generic error. This will recrate the


### PR DESCRIPTION
Please read per commit

```release-note
Don't try to update identity into kvstore if kvstore is not set
Re-fetch CEP from kube-apiserver in case of update conflict
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9537)
<!-- Reviewable:end -->
