### PR TITLE
health: Quieten health launch log

### DIFF
--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -307,7 +307,7 @@ func LaunchAsEndpoint(baseCtx context.Context, owner regeneration.Owner, n *node
 	args := []string{"netns", "exec", netNSName, binaryName, "--pidfile", pidfile}
 	cmd.SetTarget(prog)
 	cmd.SetArgs(args)
-	log.Infof("Spawning health endpoint with command %q %q", prog, args)
+	log.Debugf("Spawning health endpoint with command %q %q", prog, args)
 	if err := cmd.Run(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
There's already a log to state that the health endpoint is starting, we
don't need two. Shift this to debug level.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9538)
<!-- Reviewable:end -->
