### PR TITLE
Clean up endpoint labels resolver on endpoint removal

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1503,7 +1503,7 @@ func (e *Endpoint) ModifyIdentityLabels(addLabels, delLabels pkgLabels.Labels) e
 	e.unlock()
 
 	if changed {
-		e.runLabelsResolver(context.Background(), rev, false)
+		e.runIdentityResolver(context.Background(), rev, false)
 	}
 	return nil
 }
@@ -1540,7 +1540,7 @@ func (e *Endpoint) UpdateLabels(ctx context.Context, identityLabels, infoLabels 
 	rev := e.replaceIdentityLabels(identityLabels)
 	e.unlock()
 	if rev != 0 {
-		e.runLabelsResolver(ctx, rev, blocking)
+		e.runIdentityResolver(ctx, rev, blocking)
 	}
 }
 
@@ -1554,8 +1554,11 @@ func (e *Endpoint) identityResolutionIsObsolete(myChangeRev int) bool {
 	return false
 }
 
+// runIdentityResolver resolves the numeric identity for the set of labels that
+// are currently configured on the endpoint.
+//
 // Must be called with e.Mutex NOT held.
-func (e *Endpoint) runLabelsResolver(ctx context.Context, myChangeRev int, blocking bool) {
+func (e *Endpoint) runIdentityResolver(ctx context.Context, myChangeRev int, blocking bool) {
 	if err := e.rlockAlive(); err != nil {
 		// If a labels update and an endpoint delete API request arrive
 		// in quick succession, this could occur; in that case, there's


### PR DESCRIPTION
Move the labels resolution controller for an endpoint into the endpoint
package and run it under the manager for the endpoint. This way, when
the endpoint is removed, the controller will also be stopped.
    
The other minor change is that the context for the controller is now the
endpoint's aliveCtx rather than the daemon's context directly.
    
Fixes: #9540
Fixes: eb8df612c551 ("daemon: Start controller when pod labels resolution fails")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9541)
<!-- Reviewable:end -->
