### PR TITLE
docs: re-wrote wording for the behavior of 'fromEndpoints'

### DIFF
--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -406,8 +406,8 @@ Egress
 toCIDR
   List of destination prefixes/CIDRs that endpoints selected by
   ``endpointSelector`` are allowed to talk to. Note that endpoints which are
-  selected by a ``fromEndpoints`` are automatically allowed to talk to their
-  respective destination endpoints.
+  selected by a ``fromEndpoints`` are automatically allowed to reply back to
+  the respective destination endpoints.
 
 toCIDRSet
   List of destination prefixes/CIDRs that are allowed to talk to all endpoints


### PR DESCRIPTION
The wording "talk to" might give the impression that an endpoint is able
to talk to all `fromEndpoints` to initiate a connection which is not
entirely true. Since an endpoint is only able to reply to a connection
this commit changes the wording to be more specific.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9544)
<!-- Reviewable:end -->
