### PR TITLE
fqdn: DNSCache LookupByRegex functions don't return empty matches

### DIFF
--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -408,7 +408,9 @@ func (c *DNSCache) lookupByRegexpByTime(now time.Time, re *regexp.Regexp) (match
 
 	for name, entry := range c.forward {
 		if re.MatchString(name) {
-			matches[name] = append(matches[name], entry.getIPs(now)...)
+			if ips := entry.getIPs(now); len(ips) > 0 {
+				matches[name] = append(matches[name], ips...)
+			}
 		}
 	}
 

--- a/pkg/fqdn/helpers.go
+++ b/pkg/fqdn/helpers.go
@@ -80,13 +80,15 @@ func mapSelectorsToIPs(fqdnSelectors map[api.FQDNSelector]struct{}, cache *DNSCa
 			missing[ToFQDN] = struct{}{}
 
 			for name, ips := range lookupIPs {
-				log.WithFields(logrus.Fields{
-					"DNSName":      name,
-					"IPs":          ips,
-					"matchPattern": ToFQDN.MatchPattern,
-				}).Debug("Emitting matching DNS Name -> IPs for FQDNSelector")
-				delete(missing, ToFQDN)
-				ipsSelected = append(ipsSelected, ips...)
+				if len(ips) > 0 {
+					log.WithFields(logrus.Fields{
+						"DNSName":      name,
+						"IPs":          ips,
+						"matchPattern": ToFQDN.MatchPattern,
+					}).Debug("Emitting matching DNS Name -> IPs for FQDNSelector")
+					delete(missing, ToFQDN)
+					ipsSelected = append(ipsSelected, ips...)
+				}
 			}
 		}
 


### PR DESCRIPTION
Supports #https://github.com/cilium/cilium/pull/9497

An accident in the logic that collected IPs that matched regexes
would always add a name, but correctly return no ips for it. This caused
other code to perceive the name as matching-with-ips. This subsequently
meant that names that had all names expired would not be correctly
cleaned in the policy map until another update required it.

DNSCache.LookupByRegex doesn't return names with no matching IP, and
mapIPToSelectors guards against this more robustly, matching the code
for .MatchName fields.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9545)
<!-- Reviewable:end -->
