### PR TITLE
pkg/endpoint: start RegenerationFailureHandler after assign epID

### DIFF
--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -95,7 +95,6 @@ func NewEndpointFromChangeModel(ctx context.Context, owner regeneration.Owner, p
 	ep.aliveCancel = cancel
 	ep.aliveCtx = ctx
 
-	ep.startRegenerationFailureHandler()
 	ep.realizedPolicy = ep.desiredPolicy
 
 	if base.Mac != "" {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -407,7 +407,6 @@ func NewEndpointWithState(owner regeneration.Owner, proxy EndpointProxy, allocat
 	ctx, cancel := context.WithCancel(context.Background())
 	ep.aliveCancel = cancel
 	ep.aliveCtx = ctx
-	ep.startRegenerationFailureHandler()
 	ep.realizedPolicy = ep.desiredPolicy
 
 	ep.SetDefaultOpts(option.Config.Opts)
@@ -724,8 +723,6 @@ func parseEndpoint(ctx context.Context, owner regeneration.Owner, strEp string) 
 	ctx, cancel := context.WithCancel(ctx)
 	ep.aliveCancel = cancel
 	ep.aliveCtx = ctx
-
-	ep.startRegenerationFailureHandler()
 
 	// We need to check for nil in Status, CurrentStatuses and Log, since in
 	// some use cases, status will be not nil and Cilium will eventually

--- a/pkg/endpoint/manager.go
+++ b/pkg/endpoint/manager.go
@@ -46,6 +46,7 @@ func (e *Endpoint) Expose(mgr endpointManager) error {
 		logfields.EndpointID: e.ID,
 	})
 
+	e.startRegenerationFailureHandler()
 	// Now that the endpoint has its ID, it can be created with a name based on
 	// its ID, and its eventqueue can be safely started. Ensure that it is only
 	// started once it is exposed to the endpointmanager so that it will be


### PR DESCRIPTION
As an epID is only assigned at the time is exposed, we should only start
the regeneration failure handler after having an ID allocated to the
endpoint. This makes sure the controllers won't override each others
based on the same name (`endpoint-0-regeneration-recovery`).

Fixes: fa8a499aab9c ("endpoint: start a controller to retry regeneration")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9551)
<!-- Reviewable:end -->
