### PR TITLE
service: Store and expose service name and namespace

### DIFF
--- a/api/v1/models/service_spec.go
+++ b/api/v1/models/service_spec.go
@@ -139,6 +139,12 @@ func (m *ServiceSpec) UnmarshalBinary(b []byte) error {
 // swagger:model ServiceSpecFlags
 type ServiceSpecFlags struct {
 
+	// Service name  (e.g. Kubernetes service name)
+	Name string `json:"name,omitempty"`
+
+	// Service namespace  (e.g. Kubernetes namespace)
+	Namespace string `json:"namespace,omitempty"`
+
 	// Service type
 	// Enum: [ClusterIP NodePort]
 	Type string `json:"type,omitempty"`

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -1978,6 +1978,12 @@ definitions:
             enum:
             - ClusterIP
             - NodePort
+          name:
+            description: Service name  (e.g. Kubernetes service name)
+            type: string
+          namespace:
+            description: Service namespace  (e.g. Kubernetes namespace)
+            type: string
   ServiceStatus:
     description: Configuration of a service
     type: object

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -2848,6 +2848,14 @@ func init() {
           "description": "Optional service configuration flags",
           "type": "object",
           "properties": {
+            "name": {
+              "description": "Service name  (e.g. Kubernetes service name)",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Service namespace  (e.g. Kubernetes namespace)",
+              "type": "string"
+            },
             "type": {
               "description": "Service type",
               "type": "string",
@@ -6105,6 +6113,14 @@ func init() {
           "description": "Optional service configuration flags",
           "type": "object",
           "properties": {
+            "name": {
+              "description": "Service name  (e.g. Kubernetes service name)",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Service namespace  (e.g. Kubernetes namespace)",
+              "type": "string"
+            },
             "type": {
               "description": "Service type",
               "type": "string",

--- a/daemon/loadbalancer.go
+++ b/daemon/loadbalancer.go
@@ -60,7 +60,13 @@ func (h *putServiceID) Handle(params PutServiceIDParams) middleware.Responder {
 		backends = append(backends, *b)
 	}
 
-	created, id, err := h.svc.UpsertService(frontend, backends, loadbalancer.SVCTypeClusterIP)
+	var svcName, svcNamespace string
+	if params.Config.Flags != nil {
+		svcName = params.Config.Flags.Name
+		svcNamespace = params.Config.Flags.Namespace
+	}
+
+	created, id, err := h.svc.UpsertService(frontend, backends, loadbalancer.SVCTypeClusterIP, svcName, svcNamespace)
 	if err == nil && id != frontend.ID {
 		return api.Error(PutServiceIDInvalidFrontendCode,
 			fmt.Errorf("the service provided is already registered with ID %d, please use that ID instead of %d",

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -117,7 +117,8 @@ type policyRepository interface {
 
 type svcManager interface {
 	DeleteService(frontend loadbalancer.L3n4Addr) (bool, error)
-	UpsertService(frontend loadbalancer.L3n4AddrID, backends []loadbalancer.Backend, svcType loadbalancer.SVCType) (bool, loadbalancer.ID, error)
+	UpsertService(frontend loadbalancer.L3n4AddrID, backends []loadbalancer.Backend,
+		svcType loadbalancer.SVCType, svcName, svcNamespace string) (bool, loadbalancer.ID, error)
 }
 
 type K8sWatcher struct {
@@ -556,7 +557,8 @@ func (k *K8sWatcher) addK8sSVCs(svcID k8s.ServiceID, svc *k8s.Service, endpoints
 		}
 
 		for _, fe := range frontends {
-			if _, _, err := k.svcManager.UpsertService(*fe.addr, besValues, fe.svcType); err != nil {
+			if _, _, err := k.svcManager.UpsertService(*fe.addr, besValues,
+				fe.svcType, svcID.Name, svcID.Namespace); err != nil {
 				scopedLog.WithError(err).Error("Error while inserting service in LB map")
 			}
 		}

--- a/pkg/k8s/watchers/watcher_test.go
+++ b/pkg/k8s/watchers/watcher_test.go
@@ -143,7 +143,8 @@ func (f *fakePolicyRepository) TranslateRules(translator policy.Translator) (*po
 
 type fakeSvcManager struct {
 	OnDeleteService func(frontend loadbalancer.L3n4Addr) (bool, error)
-	OnUpsertService func(frontend loadbalancer.L3n4AddrID, backends []loadbalancer.Backend, svcType loadbalancer.SVCType) (bool, loadbalancer.ID, error)
+	OnUpsertService func(frontend loadbalancer.L3n4AddrID, backends []loadbalancer.Backend,
+		svcType loadbalancer.SVCType, svcName, svcNamespace string) (bool, loadbalancer.ID, error)
 }
 
 func (f *fakeSvcManager) DeleteService(frontend loadbalancer.L3n4Addr) (bool, error) {
@@ -153,11 +154,12 @@ func (f *fakeSvcManager) DeleteService(frontend loadbalancer.L3n4Addr) (bool, er
 	panic("OnDeleteService(loadbalancer.L3n4Addr) (bool, error) was called and is not set!")
 }
 
-func (f *fakeSvcManager) UpsertService(frontend loadbalancer.L3n4AddrID, backends []loadbalancer.Backend, svcType loadbalancer.SVCType) (bool, loadbalancer.ID, error) {
+func (f *fakeSvcManager) UpsertService(frontend loadbalancer.L3n4AddrID, backends []loadbalancer.Backend,
+	svcType loadbalancer.SVCType, svcName, svcNamespace string) (bool, loadbalancer.ID, error) {
 	if f.OnUpsertService != nil {
-		return f.OnUpsertService(frontend, backends, svcType)
+		return f.OnUpsertService(frontend, backends, svcType, svcName, svcNamespace)
 	}
-	panic("OnUpsertService(loadbalancer.L3n4AddrID, []loadbalancer.Backend, loadbalancer.SVCType) (bool, loadbalancer.ID, error) was called and is not set!")
+	panic("OnUpsertService(loadbalancer.L3n4AddrID, []loadbalancer.Backend, loadbalancer.SVCType, string, string) (bool, loadbalancer.ID, error) was called and is not set!")
 }
 
 func (s *K8sWatcherSuite) TestUpdateToServiceEndpointsGH9525(c *C) {

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -85,9 +85,11 @@ func (b *Backend) DeepCopy() *Backend {
 
 // SVC is a structure for storing service details.
 type SVC struct {
-	Frontend L3n4AddrID // SVC frontend addr and an allocated ID
-	Backends []Backend  // List of service backends
-	Type     SVCType    // Service type
+	Frontend  L3n4AddrID // SVC frontend addr and an allocated ID
+	Backends  []Backend  // List of service backends
+	Type      SVCType    // Service type
+	Name      string     // Service name
+	Namespace string     // Service namespace
 }
 
 func (s *SVC) GetModel() *models.Service {
@@ -106,7 +108,9 @@ func (s *SVC) GetModel() *models.Service {
 		FrontendAddress:  s.Frontend.GetModel(),
 		BackendAddresses: make([]*models.BackendAddress, len(s.Backends)),
 		Flags: &models.ServiceSpecFlags{
-			Type: string(s.Type),
+			Type:      string(s.Type),
+			Name:      s.Name,
+			Namespace: s.Namespace,
 		},
 	}
 

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -177,6 +177,9 @@ const (
 	// ServiceName is the orchestration framework name for a service
 	ServiceName = "serviceName"
 
+	// ServiceNamespace is the orchestration framework namespace of a service name
+	ServiceNamespace = "serviceNamespace"
+
 	// ClusterName is the name of the cluster
 	ClusterName = "clusterName"
 

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -170,11 +170,11 @@ func (m *ManagerTestSuite) TestSyncWithK8sFinished(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(len(m.svc.svcByID), Equals, 2)
 
-	// Imitate a situation where svc2 was deleted while we were down.
+	// Imitate a situation where svc1 was deleted while we were down.
 	// In real life, the following upsert is called by k8s_watcher during
 	// the sync period of the cilium-agent's k8s service cache which happens
 	// during the initialization of cilium-agent.
-	_, id1, err := m.svc.UpsertService(frontend2, backends2, lb.SVCTypeClusterIP)
+	_, id2, err := m.svc.UpsertService(frontend2, backends2, lb.SVCTypeClusterIP)
 	c.Assert(err, IsNil)
 
 	// cilium-agent finished the initialization, and thus SyncWithK8sFinished
@@ -182,8 +182,8 @@ func (m *ManagerTestSuite) TestSyncWithK8sFinished(c *C) {
 	err = m.svc.SyncWithK8sFinished()
 	c.Assert(err, IsNil)
 
-	// svc2 should be removed from cilium
+	// svc1 should be removed from cilium
 	c.Assert(len(m.svc.svcByID), Equals, 1)
-	_, found := m.svc.svcByID[id1]
+	_, found := m.svc.svcByID[id2]
 	c.Assert(found, Equals, true)
 }

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -61,13 +61,6 @@ var (
 )
 
 func (m *ManagerTestSuite) TestUpsertAndDeleteService(c *C) {
-	frontend1 := *lb.NewL3n4AddrID(lb.TCP, net.ParseIP("1.1.1.1"), 80, 0)
-	frontend2 := *lb.NewL3n4AddrID(lb.TCP, net.ParseIP("1.1.1.2"), 80, 0)
-	backends1 := []lb.Backend{
-		*lb.NewBackend(0, lb.TCP, net.ParseIP("10.0.0.1"), 8080),
-		*lb.NewBackend(0, lb.TCP, net.ParseIP("10.0.0.2"), 8080),
-	}
-
 	// Should create a new service with two backends
 	created, id1, err := m.svc.UpsertService(frontend1, backends1, lb.SVCTypeNodePort)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
Extends the user-space `service.Service` map with the service name and namespace. The goal is to expose these fields in the Cilium API such that external consumers can obtain the name of each service without having to consult other data sources. The BPF maps are left untouched, as they don't need to store these.

The name and namespace are both optional and are provided by the k8s watcher, though users of the Cilium API may also optionally provide them via `PUT /service/{id}`.

This PR also performs some minor clean-ups on the tests in the `service` package.

Can be reviewed per commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9554)
<!-- Reviewable:end -->
