### PR TITLE
backports 1.5 2019 11 05

### DIFF
--- a/Documentation/kubernetes/requirements.rst
+++ b/Documentation/kubernetes/requirements.rst
@@ -43,15 +43,15 @@ the `Kubernets CNI network-plugins documentation <https://kubernetes.io/docs/con
 Mounted BPF filesystem
 ======================
 
-This step is optional but recommended. It allows the ``cilium-agent`` to pin
-BPF resources to a persistent filesystem and make them persistent across
-restarts of the agent. If the BPF filesystem is not mounted in the host
-filesystem, Cilium will automatically mount the filesystem but it will be
-unmounted and re-mounted when the Cilium pod is restarted. This in turn will
-cause BPF resources to be re-created which will cause network connectivity to
-be disrupted.  Mounting the BPF filesystem in the host mount namespace will
-ensure that the agent can be restarted without affecting connectivity of any
-pods.
+This step is **required for production** environments but optional for testing
+and development. It allows the ``cilium-agent`` to pin BPF resources to a
+persistent filesystem and make them persistent across restarts of the agent.
+If the BPF filesystem is not mounted in the host filesystem, Cilium will
+automatically mount the filesystem but it will be unmounted and re-mounted when
+the Cilium pod is restarted. This in turn will cause BPF resources to be
+re-created which will cause network connectivity to be disrupted. Mounting the
+BPF filesystem in the host mount namespace will ensure that the agent can be
+restarted without affecting connectivity of any pods.
 
 In order to mount the BPF filesystem, the following command must be run in the
 host mount namespace. The command must only be run once during the boot process

--- a/pkg/k8s/endpointsynchronizer/cep.go
+++ b/pkg/k8s/endpointsynchronizer/cep.go
@@ -222,6 +222,7 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 				// backoff and the Update* calls returned the current localCEP
 				case err != nil && k8serrors.IsConflict(err):
 					scopedLog.WithError(err).Warn("Cannot update CEP due to a revision conflict. The next controller execution will try again")
+					needInit = true
 					return nil
 
 				// Ensure we re-init when we see a generic error. This will recrate the


### PR DESCRIPTION
v1.5 backports 2019-11-05

 * #9534 -- docs: clarify usage of bpf fs mount (@aanm)
 * #9537 -- KVStore and k8s bug fixes (@aanm)
only "k8s/endpointsynchronizer: re-fecth CEP in case of update conflict (f9d2bd09392a0638e7dade8efe2b3dc8949fa932)


Not backported
 * #9542 -- Envoy 1.12 update (@jrajahalme)
The `DeltaListener` function was missing, and that relied on an updated `envoy_api_v2`. I couldn't cleanly backport 6ffc545eb5f35e555ad0d4c0ca1cdbd5d8b5381e (where I think we did this). 

 * #9535 -- pkg/k8s: fix toServices policy update when service endpoints are modified (@aanm)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9555)
<!-- Reviewable:end -->
