### PR TITLE
contrib: Fix 'reset' variable declaration

### DIFF
--- a/contrib/shell/test.sh
+++ b/contrib/shell/test.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-readonly reset=$(tput sgr0)
+readonly t_reset=$(tput sgr0)
 readonly red=$(tput bold; tput setaf 1)
 readonly green=$(tput bold; tput setaf 2)
 readonly yellow=$(tput bold; tput setaf 3)
@@ -28,15 +28,15 @@ function watchdo
     shift
 
     if [ ! -z "$TESTPKGS" ]; then
-        echo -e "${yellow}Using TESTPKGS=\"$TESTPKGS\" for run.${reset}"
+        echo -e "${yellow}Using TESTPKGS=\"$TESTPKGS\" for run.${t_reset}"
     fi
-    echo -e "${yellow}Running \"$@\" on changes to \"$FILE\" ...${reset}"
+    echo -e "${yellow}Running \"$@\" on changes to \"$FILE\" ...${t_reset}"
     while inotifywait -q -r -e move $FILE; do
         eval "$@";
         if [ $? == 0 ] ; then
-            echo -e "${yellow}$@${reset}: ${green}✔${reset}"
+            echo -e "${yellow}$@${t_reset}: ${green}✔${t_reset}"
         else
-            echo -e "${yellow}$@${reset}: ${red}✘${reset}"
+            echo -e "${yellow}$@${t_reset}: ${red}✘${t_reset}"
         fi
     done
 }

--- a/contrib/shell/util.sh
+++ b/contrib/shell/util.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-readonly  reset=$(tput sgr0)
+readonly t_reset=$(tput sgr0)
 readonly  green=$(tput bold; tput setaf 2)
 readonly yellow=$(tput bold; tput setaf 3)
 readonly   blue=$(tput bold; tput setaf 6)
@@ -23,7 +23,7 @@ readonly ipv6regex='(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:
 
 function desc() {
     maybe_first_prompt
-    echo "$blue# $@$reset"
+    echo "$blue# $@$t_reset"
     prompt
 }
 
@@ -33,12 +33,12 @@ function desc_rate() {
     if [ -n "$DEMO_RUN_FAST" ]; then
       rate=1000
     fi
-    echo "$blue# $@$reset" | pv -qL $rate
+    echo "$blue# $@$t_reset" | pv -qL $rate
     prompt
 }
 
 function prompt() {
-    echo -n "$yellow\$ $reset"
+    echo -n "$yellow\$ $t_reset"
 }
 
 started=""
@@ -59,7 +59,7 @@ function run() {
     if [ -n "$DEMO_RUN_FAST" ]; then
       rate=1000
     fi
-    echo "$green$1$reset" | pv -qL $rate
+    echo "$green$1$t_reset" | pv -qL $rate
     if [ -n "$DEMO_RUN_FAST" ]; then
       sleep 0.5
     fi


### PR DESCRIPTION
Naming this readonly variable 'reset' causes conflicts in my
environment, prefix it with 't_' for 'terminal' to avoid this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9559)
<!-- Reviewable:end -->
