### PR TITLE
Add gops to cilium-cni

### DIFF
--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -51,6 +51,7 @@ import (
 	cniTypesVer "github.com/containernetworking/cni/pkg/types/current"
 	cniVersion "github.com/containernetworking/cni/pkg/version"
 	"github.com/containernetworking/plugins/pkg/ns"
+	gops "github.com/google/gops/agent"
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 
@@ -77,6 +78,10 @@ type CmdState struct {
 }
 
 func main() {
+	if err := gops.Listen(gops.Options{}); err != nil {
+		log.WithError(err).Warn("Unable to start gops")
+	}
+
 	skel.PluginMain(cmdAdd,
 		nil,
 		cmdDel,


### PR DESCRIPTION
Failure to start gops is considered non-fatal here since this feature
should be mostly useful to debug hangs or weird condition and trying to
avoid breaking container creation if gops init fails seems reasonable.

Signed-off by: Jean Raby <jean@raby.sh>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9568)
<!-- Reviewable:end -->
