### PR TITLE
service: Notify monitor about service updates

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -304,7 +304,6 @@ func NewDaemon(ctx context.Context, dp datapath.Datapath) (*Daemon, *endpointRes
 	d := Daemon{
 		ctx:              dCtx,
 		cancel:           cancel,
-		svc:              service.NewService(),
 		prefixLengths:    createPrefixLengthCounter(),
 		buildEndpointSem: semaphore.NewWeighted(int64(numWorkerThreads())),
 		compilationMutex: new(lock.RWMutex),
@@ -313,6 +312,8 @@ func NewDaemon(ctx context.Context, dp datapath.Datapath) (*Daemon, *endpointRes
 		datapath:         dp,
 		nodeDiscovery:    nd,
 	}
+
+	d.svc = service.NewService(&d)
 
 	d.identityAllocator = cache.NewCachingIdentityAllocator(&d)
 	d.policy = policy.NewPolicyRepository(d.identityAllocator.GetIdentityCache())

--- a/pkg/monitor/api/types.go
+++ b/pkg/monitor/api/types.go
@@ -171,6 +171,8 @@ const (
 	AgentNotifyEndpointDeleted
 	AgentNotifyIPCacheUpserted
 	AgentNotifyIPCacheDeleted
+	AgentNotifyServiceUpserted
+	AgentNotifyServiceDeleted
 )
 
 var notifyTable = map[AgentNotification]string{
@@ -185,6 +187,8 @@ var notifyTable = map[AgentNotification]string{
 	AgentNotifyIPCacheUpserted:           "IPCache entry upserted",
 	AgentNotifyPolicyUpdated:             "Policy updated",
 	AgentNotifyPolicyDeleted:             "Policy deleted",
+	AgentNotifyServiceDeleted:            "Service deleted",
+	AgentNotifyServiceUpserted:           "Service upserted",
 }
 
 func resolveAgentType(t AgentNotification) string {
@@ -352,6 +356,59 @@ type TimeNotification struct {
 func TimeRepr(t time.Time) (string, error) {
 	notification := TimeNotification{
 		Time: t.String(),
+	}
+	repr, err := json.Marshal(notification)
+	return string(repr), err
+}
+
+// ServiceUpsertNotificationAddr is part of ServiceUpsertNotification
+type ServiceUpsertNotificationAddr struct {
+	IP   net.IP `json:"ip"`
+	Port uint16 `json:"port"`
+}
+
+// ServiceUpsertNotification structures service upsert notifications
+type ServiceUpsertNotification struct {
+	ID uint32 `json:"id"`
+
+	Frontend ServiceUpsertNotificationAddr   `json:"frontend-address"`
+	Backends []ServiceUpsertNotificationAddr `json:"backend-addresses"`
+
+	Type      string `json:"type,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Namespace string `json:"namespace,,omitempty"`
+}
+
+// ServiceUpsertRepr returns string representation of monitor notification
+func ServiceUpsertRepr(
+	id uint32,
+	frontend ServiceUpsertNotificationAddr,
+	backends []ServiceUpsertNotificationAddr,
+	svcType, svcName, svcNamespace string,
+) (string, error) {
+	notification := ServiceUpsertNotification{
+		ID:        id,
+		Frontend:  frontend,
+		Backends:  backends,
+		Type:      svcType,
+		Name:      svcName,
+		Namespace: svcNamespace,
+	}
+	repr, err := json.Marshal(notification)
+	return string(repr), err
+}
+
+// ServiceDeleteNotification structures service delete notifications
+type ServiceDeleteNotification struct {
+	ID uint32 `json:"id"`
+}
+
+// ServiceDeleteRepr returns string representation of monitor notification
+func ServiceDeleteRepr(
+	id uint32,
+) (string, error) {
+	notification := ServiceDeleteNotification{
+		ID: id,
 	}
 	repr, err := json.Marshal(notification)
 	return string(repr), err

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -37,7 +37,7 @@ func (m *ManagerTestSuite) SetUpTest(c *C) {
 	serviceIDAlloc.resetLocalID()
 	backendIDAlloc.resetLocalID()
 
-	m.svc = NewService()
+	m.svc = NewService(nil)
 	m.svc.lbmap = lbmap.NewLBMockMap()
 	m.lbmap = m.svc.lbmap.(*lbmap.LBMockMap)
 }
@@ -137,7 +137,7 @@ func (m *ManagerTestSuite) TestRestoreServices(c *C) {
 
 	// Restart service, but keep the lbmap to restore services from
 	lbmap := m.svc.lbmap.(*lbmap.LBMockMap)
-	m.svc = NewService()
+	m.svc = NewService(nil)
 	m.svc.lbmap = lbmap
 	err = m.svc.RestoreServices()
 	c.Assert(err, IsNil)
@@ -167,7 +167,7 @@ func (m *ManagerTestSuite) TestSyncWithK8sFinished(c *C) {
 
 	// Restart service, but keep the lbmap to restore services from
 	lbmap := m.svc.lbmap.(*lbmap.LBMockMap)
-	m.svc = NewService()
+	m.svc = NewService(nil)
 	m.svc.lbmap = lbmap
 	err = m.svc.RestoreServices()
 	c.Assert(err, IsNil)


### PR DESCRIPTION
Hooks up `service.UpsertService` and `service.DeleteService` to emit monitor notifications. This allows downstream consumers of the Cilium monitor socket to react to changes in the service mappings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9574)
<!-- Reviewable:end -->
