### PR TITLE
HostToContainer propagation for /sys/fs/bpf

### DIFF
--- a/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
@@ -256,6 +256,8 @@ spec:
 {{- if not (eq .Values.global.containerRuntime.integration "crio") }}
         - mountPath: /sys/fs/bpf
           name: bpf-maps
+{{- /* Required for wait-bpf-mount to work */}}
+          mountPropagation: HostToContainer
 {{- end }}
         - mountPath: /var/run/cilium
           name: cilium-run

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -381,7 +381,7 @@ spec:
             exec:
               command:
               - "/cni-install.sh"
-              - "--enable-debug=true"
+              - "--enable-debug=false"
           preStop:
             exec:
               command:
@@ -473,6 +473,7 @@ spec:
         volumeMounts:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
+          mountPropagation: HostToContainer
         - mountPath: /var/run/cilium
           name: cilium-run
       restartPolicy: Always


### PR DESCRIPTION
By default, mount events from the host namespace are not propagated to a container  after a volume has been mounted into it.
Thus, the initContainer of the agent can never notice changes to /sys/fs/bpf (it cannot detect if the path became a mountpoint)

With mountPropagation: HostToContainer, the mount events are propagated to the container,
allowing the init container to correctly detect changes on /sys/fs/bpf, if it is mounted on the host while the script is blocked waiting for it to be mounted.

In other words, this makes wait-bpf-mount work as advertised.

Signed-off by: Jean Raby <jean@raby.sh>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9575)
<!-- Reviewable:end -->
