### PR TITLE
operator: do not rm kube-dns pods if unmanaged-pod-watcher-interval == 0

### DIFF
--- a/operator/main.go
+++ b/operator/main.go
@@ -241,7 +241,7 @@ func runOperator(cmd *cobra.Command) {
 	// etcd from reaching out kube-dns in EKS.
 	if option.Config.DisableCiliumEndpointCRD {
 		log.Infof("KubeDNS unmanaged pods controller disabled as %q option is set to 'disabled' in Cilium ConfigMap", option.DisableCiliumEndpointCRDName)
-	} else {
+	} else if unmanagedKubeDnsWatcherInterval != 0 {
 		enableUnmanagedKubeDNSController()
 	}
 


### PR DESCRIPTION
Signed-off-by: André Martins <andre@cilium.io>
Reported-by: Jean Raby <jean@raby.sh>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9581)
<!-- Reviewable:end -->
