### PR TITLE
unmanaged kube-dns: Delete one pod per iteration

### DIFF
--- a/operator/k8s_pod_controller.go
+++ b/operator/k8s_pod_controller.go
@@ -80,6 +80,9 @@ func enableUnmanagedKubeDNSController() {
 									log.WithError(err).Warningf("Unable to restart pod %s", podID)
 								} else {
 									lastPodRestart[podID] = time.Now()
+
+									// Delete a single pod per iteration to avoid killing all replicas at once
+									return nil
 								}
 
 							}


### PR DESCRIPTION
Under some circumstances, such as the initial deployment of cilium and
cilium operator in a cluster, the original code would iterate through
all kube-dns pods and delete them in a single pass, causing momentary
clusterwide DNS outage.

With this, a single kube-dns pod will be deleted per iteration.
It is still suboptimal, since it relies on hope and quick coredns
startup, but it is arguably better than taking down the DNS service for
a few seconds.

Another way to do this would be to avoid doing anything is there's a kube-dns pod that is not ready. There could be situations where the controller would never do anything if a pod is stuck in pending / NotReady.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9583)
<!-- Reviewable:end -->
