### PR TITLE
Make Agent Prometheus Exporter port configurable

### DIFF
--- a/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
@@ -15,7 +15,7 @@ spec:
     metadata:
       annotations:
 {{- if and .Values.global.prometheus.enabled (not .Values.global.prometheus.serviceMonitor.enabled) }}
-        prometheus.io/port: "9090"
+        prometheus.io/port: "{{ .Values.global.prometheus.port }}"
         prometheus.io/scrape: "true"
 {{- end }}
         # This annotation plus the CriticalAddonsOnly toleration makes
@@ -112,8 +112,8 @@ spec:
         name: cilium-agent
 {{- if .Values.global.prometheus.enabled }}
         ports:
-        - containerPort: 9090
-          hostPort: 9090
+        - containerPort: {{ .Values.global.prometheus.port }}
+          hostPort: {{ .Values.global.prometheus.port }}
           name: prometheus
           protocol: TCP
 {{- end }}

--- a/install/kubernetes/cilium/charts/agent/templates/svc.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/svc.yaml
@@ -11,7 +11,7 @@ spec:
   type: ClusterIP
   ports:
   - name: metrics
-    port: 9090
+    port: {{ .Values.global.prometheus.port }}
     protocol: TCP
     targetPort: prometheus
   selector:

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -56,7 +56,7 @@ data:
   # "cilium-metrics-config" ConfigMap
   # NOTE that this will open the port on ALL nodes where Cilium pods are
   # scheduled.
-  prometheus-serve-addr: ":9090"
+  prometheus-serve-addr: ":{{ .Values.global.prometheus.port }}"
 {{- end }}
 
   # Enable IPv4 addressing. If enabled, all endpoints are allocated an IPv4

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -72,6 +72,7 @@ global:
   # prometheus enables
   prometheus:
     enabled: false
+    port: 9090
     serviceMonitor:
       enabled: false
 


### PR DESCRIPTION
 via `.Values.global.prometheus.port` 

Signed-off-by: Andrey Voronkov <voronkovaa@gmail.com>

Tested on one of my clusters. If it is better to make operator port configurable also I can do that but you should decide on variable namings.

Fixes: #9543

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9584)
<!-- Reviewable:end -->
