### PR TITLE
vendor: fix stack corruption from retrieving veth peer index

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -93,8 +93,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.4.0
 	github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2 // indirect
-	github.com/vishvananda/netlink v1.0.1-0.20190924205746-ac5f4df04742
-	github.com/vishvananda/netns v0.0.0-20190625233234-7109fa855b0f // indirect
+	github.com/vishvananda/netlink v1.0.1-0.20191111102915-47ae870a10ed
 	go.etcd.io/etcd v0.5.0-alpha.5.0.20190911215424-9ed5f76dc03b
 	go.mongodb.org/mongo-driver v1.1.2 // indirect
 	go.uber.org/multierr v1.2.0 // indirect
@@ -512,7 +511,7 @@ replace (
 	github.com/ugorji/go => github.com/ugorji/go v1.1.4
 	github.com/urfave/cli => github.com/urfave/cli v1.20.0
 	github.com/urfave/negroni => github.com/urfave/negroni v1.0.0
-	github.com/vishvananda/netlink => github.com/vishvananda/netlink v1.0.1-0.20190924205746-ac5f4df04742
+	github.com/vishvananda/netlink => github.com/cilium/netlink v1.0.1-0.20191111102915-47ae870a10ed
 	github.com/vishvananda/netns => github.com/vishvananda/netns v0.0.0-20190625233234-7109fa855b0f
 	github.com/vmware/govmomi => github.com/vmware/govmomi v0.20.1
 	github.com/xiang90/probing => github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,8 @@ github.com/cilium/dns v1.1.4-0.20190417235132-8e25ec9a0ff3 h1:wenYMyWJ08dgEUUj0I
 github.com/cilium/dns v1.1.4-0.20190417235132-8e25ec9a0ff3/go.mod h1:cXN7jgo+gsGlNvQ7Vqu2ELdc3f7i7PPgupHqSkLzzBo=
 github.com/cilium/kafka v0.0.0-20180809090225-01ce283b732b h1:+bsFX/WOMIoaayXVyRem1awcpz3icz/HoL8Dxg/m6a4=
 github.com/cilium/kafka v0.0.0-20180809090225-01ce283b732b/go.mod h1:ktgizta3CPZBKz5uW272SJyjiro0vn4nOVP7Pk4RopA=
+github.com/cilium/netlink v1.0.1-0.20191111102915-47ae870a10ed h1:GD+ssW0e5SOX8M/+lbIhjaaEARzLuWeRt3myPj5q8YM=
+github.com/cilium/netlink v1.0.1-0.20191111102915-47ae870a10ed/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/cilium/proxy v0.0.0-20191103190817-c6d564bb0863 h1:SIWUaRDrtHZr+PQY9dgMY5it8ELWnGmXUrNsAySXyn0=
 github.com/cilium/proxy v0.0.0-20191103190817-c6d564bb0863/go.mod h1:lbRnBzpxwMP5KsTu99cM654ShwTWamyhrF6cCLuYqhE=
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible h1:C29Ae4G5GtYyYMm1aztcyj/J5ckgJm2zwdDajFbx1NY=
@@ -502,8 +504,6 @@ github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqri
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/negroni v1.0.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
-github.com/vishvananda/netlink v1.0.1-0.20190924205746-ac5f4df04742 h1:kOmOYZsgDa9K5a5G/qccmvTEN+puk9mP2/FUzres5Bo=
-github.com/vishvananda/netlink v1.0.1-0.20190924205746-ac5f4df04742/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
 github.com/vishvananda/netns v0.0.0-20190625233234-7109fa855b0f h1:nBX3nTcmxEtHSERBJaIo1Qa26VwRaopnZmfDQUXsF4I=
 github.com/vishvananda/netns v0.0.0-20190625233234-7109fa855b0f/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
 github.com/vmware/govmomi v0.20.1 h1:7b/SeTUB3tER8ZLGLLLH3xcnB2xeuLULXmfPFqPSRZA=

--- a/vendor/github.com/vishvananda/netlink/go.mod
+++ b/vendor/github.com/vishvananda/netlink/go.mod
@@ -1,0 +1,8 @@
+module github.com/vishvananda/netlink
+
+go 1.12
+
+require (
+	github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df
+	golang.org/x/sys v0.0.0-20190606203320-7fc4e5ec1444
+)

--- a/vendor/github.com/vishvananda/netlink/go.sum
+++ b/vendor/github.com/vishvananda/netlink/go.sum
@@ -1,0 +1,4 @@
+github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df h1:OviZH7qLw/7ZovXvuNyL3XQl8UFofeikI1NW1Gypu7k=
+github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
+golang.org/x/sys v0.0.0-20190606203320-7fc4e5ec1444 h1:/d2cWp6PSamH4jDPFLyO150psQdqvtoNX8Zjg3AQ31g=
+golang.org/x/sys v0.0.0-20190606203320-7fc4e5ec1444/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/vendor/github.com/vishvananda/netlink/ioctl_linux.go
+++ b/vendor/github.com/vishvananda/netlink/ioctl_linux.go
@@ -56,18 +56,10 @@ type ethtoolSset struct {
 	data     [1]uint32
 }
 
-// ethtoolGstrings is string set for data tagging
-type ethtoolGstrings struct {
-	cmd       uint32
-	stringSet uint32
-	length    uint32
-	data      [32]byte
-}
-
 type ethtoolStats struct {
 	cmd    uint32
 	nStats uint32
-	data   [1]uint64
+	// Followed by nStats * []uint64.
 }
 
 // newIocltSlaveReq returns filled IfreqSlave with proper interface names

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -471,10 +471,10 @@ github.com/spf13/pflag
 github.com/spf13/viper
 # github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2 => github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
 github.com/syndtr/gocapability/capability
-# github.com/vishvananda/netlink v1.0.1-0.20190924205746-ac5f4df04742 => github.com/vishvananda/netlink v1.0.1-0.20190924205746-ac5f4df04742
+# github.com/vishvananda/netlink v1.0.1-0.20191111102915-47ae870a10ed => github.com/cilium/netlink v1.0.1-0.20191111102915-47ae870a10ed
 github.com/vishvananda/netlink
 github.com/vishvananda/netlink/nl
-# github.com/vishvananda/netns v0.0.0-20190625233234-7109fa855b0f => github.com/vishvananda/netns v0.0.0-20190625233234-7109fa855b0f
+# github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df => github.com/vishvananda/netns v0.0.0-20190625233234-7109fa855b0f
 github.com/vishvananda/netns
 # go.etcd.io/etcd v0.5.0-alpha.5.0.20190911215424-9ed5f76dc03b => go.etcd.io/etcd v0.5.0-alpha.5.0.20190911215424-9ed5f76dc03b
 go.etcd.io/etcd/auth/authpb


### PR DESCRIPTION
```
Use local fork until https://github.com/vishvananda/netlink/pull/498 got
eventually merged.

Updated via following:

  In go.mod's replace section:
  [...]
  -       github.com/vishvananda/netlink => github.com/vishvananda/netlink v1.0.1-0.20190924205746-ac5f4df04742
  +       github.com/vishvananda/netlink => github.com/cilium/netlink 47ae870a10ed8f1ff19408861207ae4ddd59f8cd
  [...]
  $ ./contrib/go-mod/update-vendor.sh && git add vendor/ go.mod go.sum && git commit -sa

Reported-by: Jean Raby <jean@raby.sh>
Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>
```

```release-note
Fix vishvananda/netlink library's VethPeerIndex() stack corruption with 4.20+ kernels.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9588)
<!-- Reviewable:end -->
