### PR TITLE
cni: fix cni plugin error formatting when agent is not running

### DIFF
--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -314,7 +314,7 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 
 	c, err = client.NewDefaultClientWithTimeout(defaults.ClientConnectTimeout)
 	if err != nil {
-		err = fmt.Errorf("unable to connect to Cilium daemon: %s", err)
+		err = fmt.Errorf("unable to connect to Cilium daemon: %s", client.Hint(err))
 		return
 	}
 
@@ -570,7 +570,7 @@ func cmdDel(args *skel.CmdArgs) error {
 	c, err := client.NewDefaultClientWithTimeout(defaults.ClientConnectTimeout)
 	if err != nil {
 		// this error can be recovered from
-		return fmt.Errorf("unable to connect to Cilium daemon: %s", err)
+		return fmt.Errorf("unable to connect to Cilium daemon: %s", client.Hint(err))
 	}
 
 	if chainAction := chainingapi.Lookup(n.Name); chainAction != nil {


### PR DESCRIPTION
* Fixes #9190

The error formatting for the cni-plugin is now fixed showing the correct URI path without any missing formats.

![image](https://user-images.githubusercontent.com/21292343/68696276-a89e2a00-05a2-11ea-93f7-f110bed2d2f3.png)

Signed-off-by: Deepesh Pathak <deepshpathak@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9597)
<!-- Reviewable:end -->
