### PR TITLE
docs: fix spelling issues in clusterwide policy docs

### DIFF
--- a/Documentation/policy/index.rst
+++ b/Documentation/policy/index.rst
@@ -15,7 +15,7 @@ This chapter documents the policy language used to configure network policies
 in Cilium. Security policies can be specified and imported via the following
 mechanisms:
 
-* Using Kubernetes `NetworkPolicy` `CiliumNetworkPolicy` and `CiliumClusterwideNetworkPolicy`
+* Using Kubernetes `NetworkPolicy`, `CiliumNetworkPolicy` and `CiliumClusterwideNetworkPolicy`
   resources. See the section :ref:`k8s_policy` for more details. In this mode,
   Kubernetes will automatically distribute the policies to all agents.
 

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -21,6 +21,7 @@ Cheng
 Chewbacca
 Chun
 Cloudflare
+Clusterwide
 DDoS
 DMA'ed
 DNS
@@ -378,6 +379,7 @@ multicore
 multinode
 mysql
 namespace
+namespaced
 namespaces
 nat
 natively

--- a/README.rst
+++ b/README.rst
@@ -219,7 +219,7 @@ Further information about BPF and XDP targeted for developers can be found in
 the `BPF and XDP Reference Guide`_.
 
 To know more about Cilium, it's extensions and use cases around Cilium and BPF
-take a look at `Further Readings <FURTHER_READINGS.md>`_ section.
+take a look at `Further Readings <FURTHER_READINGS.rst>`_ section.
 
 Community
 =========


### PR DESCRIPTION
* Fixes spelling issues in cluster-wide policy documentation
* Fixes broken link to Further Readings section in readme.

Signed-off-by: Deepesh Pathak <deepshpathak@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9602)
<!-- Reviewable:end -->
