### PR TITLE
vendor: point vishvananda/netlink back to upstream

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -82,7 +82,7 @@ require (
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.4.0
-	github.com/vishvananda/netlink v1.0.1-0.20191111102915-47ae870a10ed
+	github.com/vishvananda/netlink v1.0.1-0.20191113183427-d71301a47b60
 	go.etcd.io/etcd v0.5.0-alpha.5.0.20190911215424-9ed5f76dc03b
 	go.mongodb.org/mongo-driver v1.1.2 // indirect
 	go.uber.org/multierr v1.2.0 // indirect
@@ -497,7 +497,7 @@ replace (
 	github.com/ugorji/go => github.com/ugorji/go v1.1.4
 	github.com/urfave/cli => github.com/urfave/cli v1.20.0
 	github.com/urfave/negroni => github.com/urfave/negroni v1.0.0
-	github.com/vishvananda/netlink => github.com/cilium/netlink v1.0.1-0.20191111102915-47ae870a10ed
+	github.com/vishvananda/netlink => github.com/vishvananda/netlink v1.0.1-0.20191113183427-d71301a47b60
 	github.com/vishvananda/netns => github.com/vishvananda/netns v0.0.0-20190625233234-7109fa855b0f
 	github.com/vmware/govmomi => github.com/vmware/govmomi v0.20.1
 	github.com/xiang90/probing => github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2

--- a/go.sum
+++ b/go.sum
@@ -90,8 +90,6 @@ github.com/cilium/dns v1.1.4-0.20190417235132-8e25ec9a0ff3 h1:wenYMyWJ08dgEUUj0I
 github.com/cilium/dns v1.1.4-0.20190417235132-8e25ec9a0ff3/go.mod h1:cXN7jgo+gsGlNvQ7Vqu2ELdc3f7i7PPgupHqSkLzzBo=
 github.com/cilium/kafka v0.0.0-20180809090225-01ce283b732b h1:+bsFX/WOMIoaayXVyRem1awcpz3icz/HoL8Dxg/m6a4=
 github.com/cilium/kafka v0.0.0-20180809090225-01ce283b732b/go.mod h1:ktgizta3CPZBKz5uW272SJyjiro0vn4nOVP7Pk4RopA=
-github.com/cilium/netlink v1.0.1-0.20191111102915-47ae870a10ed h1:GD+ssW0e5SOX8M/+lbIhjaaEARzLuWeRt3myPj5q8YM=
-github.com/cilium/netlink v1.0.1-0.20191111102915-47ae870a10ed/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/cilium/proxy v0.0.0-20191103190817-c6d564bb0863 h1:SIWUaRDrtHZr+PQY9dgMY5it8ELWnGmXUrNsAySXyn0=
 github.com/cilium/proxy v0.0.0-20191103190817-c6d564bb0863/go.mod h1:lbRnBzpxwMP5KsTu99cM654ShwTWamyhrF6cCLuYqhE=
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible h1:C29Ae4G5GtYyYMm1aztcyj/J5ckgJm2zwdDajFbx1NY=
@@ -486,6 +484,8 @@ github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqri
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/negroni v1.0.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
+github.com/vishvananda/netlink v1.0.1-0.20191113183427-d71301a47b60 h1:WvwBIIoPeIQoDfN7GXxbYBYdLc0FPCJWuUO9O8pq8P8=
+github.com/vishvananda/netlink v1.0.1-0.20191113183427-d71301a47b60/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netns v0.0.0-20190625233234-7109fa855b0f h1:nBX3nTcmxEtHSERBJaIo1Qa26VwRaopnZmfDQUXsF4I=
 github.com/vishvananda/netns v0.0.0-20190625233234-7109fa855b0f/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
 github.com/vmware/govmomi v0.20.1 h1:7b/SeTUB3tER8ZLGLLLH3xcnB2xeuLULXmfPFqPSRZA=

--- a/vendor/github.com/vishvananda/netlink/route_linux.go
+++ b/vendor/github.com/vishvananda/netlink/route_linux.go
@@ -599,7 +599,7 @@ func (h *Handle) routeHandle(route *Route, req *nl.NetlinkRequest, msg *nl.RtMsg
 			if nh.Encap != nil {
 				buf := make([]byte, 2)
 				native.PutUint16(buf, uint16(nh.Encap.Type()))
-				rtAttrs = append(rtAttrs, nl.NewRtAttr(unix.RTA_ENCAP_TYPE, buf))
+				children = append(children, nl.NewRtAttr(unix.RTA_ENCAP_TYPE, buf))
 				buf, err := nh.Encap.Encode()
 				if err != nil {
 					return err

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -378,7 +378,7 @@ github.com/spf13/jwalterweatherman
 github.com/spf13/pflag
 # github.com/spf13/viper v1.4.0 => github.com/spf13/viper v1.4.0
 github.com/spf13/viper
-# github.com/vishvananda/netlink v1.0.1-0.20191111102915-47ae870a10ed => github.com/cilium/netlink v1.0.1-0.20191111102915-47ae870a10ed
+# github.com/vishvananda/netlink v1.0.1-0.20191113183427-d71301a47b60 => github.com/vishvananda/netlink v1.0.1-0.20191113183427-d71301a47b60
 github.com/vishvananda/netlink
 github.com/vishvananda/netlink/nl
 # github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df => github.com/vishvananda/netns v0.0.0-20190625233234-7109fa855b0f


### PR DESCRIPTION
Given PR https://github.com/vishvananda/netlink/pull/498 has been
merged officially, move the repo back to upstream. Final follow-up
to 515654b58beb ("vendor: fix stack corruption from retrieving
veth peer index"). Re-performed same update as in 515654b58beb.

Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9606)
<!-- Reviewable:end -->
