### PR TITLE
Fixes kafka-v1.yaml file for compatibility

### DIFF
--- a/examples/kubernetes-istio/kafka-v1.yaml
+++ b/examples/kubernetes-istio/kafka-v1.yaml
@@ -59,11 +59,14 @@ specs:
           - apiKey: "offsetfetch"
           - apiKey: "heartbeat"
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: kafka-v1
 spec:
+  selector:
+    matchLabels:
+      app: kafka
   serviceName: kafka
   replicas: 1
   template:


### PR DESCRIPTION
Fixes:  Compatibility issue seen in the kafka-v1.yaml file while trying to test the Getting Started with Istio guide.
Based on the Kubernetes description for using StatefulSet  "You must set the .spec.selector field of a StatefulSet to match the labels of its .spec.template.metadata.labels. Prior to Kubernetes 1.8, the .spec.selector field was defaulted when omitted. In 1.8 and later versions, failing to specify a matching Pod Selector will result in a validation error during StatefulSet creation."

Fixes: #9603
Signed-off-by:  Swaminathan Vasudevan <svasudevan@suse.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9607)
<!-- Reviewable:end -->
