### PR TITLE
v1.5 backports 2019-11-14

### DIFF
--- a/operator/main.go
+++ b/operator/main.go
@@ -172,7 +172,7 @@ func runOperator(cmd *cobra.Command) {
 	// etcd from reaching out kube-dns in EKS.
 	if option.Config.DisableCiliumEndpointCRD {
 		log.Infof("KubeDNS unmanaged pods controller disabled as %q option is set to 'disabled' in Cilium ConfigMap", option.DisableCiliumEndpointCRDName)
-	} else {
+	} else if unmanagedKubeDnsWatcherInterval != 0 {
 		enableUnmanagedKubeDNSController()
 	}
 

--- a/pkg/k8s/service_cache.go
+++ b/pkg/k8s/service_cache.go
@@ -73,6 +73,9 @@ type ServiceEvent struct {
 	// Service is the service structure
 	Service *Service
 
+	// OldService is the service structure
+	OldService *Service
+
 	// Endpoints is the endpoints structured correlated with the service
 	Endpoints *Endpoints
 }
@@ -132,7 +135,8 @@ func (s *ServiceCache) UpdateService(k8sSvc *types.Service) ServiceID {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	if oldService, ok := s.services[svcID]; ok {
+	oldService, ok := s.services[svcID]
+	if ok {
 		if oldService.DeepEquals(newService) {
 			return svcID
 		}
@@ -144,10 +148,11 @@ func (s *ServiceCache) UpdateService(k8sSvc *types.Service) ServiceID {
 	endpoints, serviceReady := s.correlateEndpoints(svcID)
 	if serviceReady {
 		s.Events <- ServiceEvent{
-			Action:    UpdateService,
-			ID:        svcID,
-			Service:   newService,
-			Endpoints: endpoints,
+			Action:     UpdateService,
+			ID:         svcID,
+			Service:    newService,
+			OldService: oldService,
+			Endpoints:  endpoints,
 		}
 	}
 


### PR DESCRIPTION
 * #9577 -- Delete service ports from datapath if they are removed with a k8s update (@aanm)
 * #9581 -- operator: do not rm kube-dns pods if unmanaged-pod-watcher-interval == 0 (@aanm)

Once this PR is merged, you can update the PR labels via:
```
$ for pr in 9577 9581; do contrib/backporting/set-labels.py $pr done 1.5; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9609)
<!-- Reviewable:end -->
