### PR TITLE
aws/eni: do not resync node if semaphore Acquire fails

### DIFF
--- a/pkg/aws/eni/node_manager.go
+++ b/pkg/aws/eni/node_manager.go
@@ -299,7 +299,10 @@ func (n *NodeManager) Resync(ctx context.Context, syncTime time.Time) {
 	sem := semaphore.NewWeighted(n.parallelWorkers)
 
 	for _, node := range n.GetNodesByIPWatermark() {
-		sem.Acquire(ctx, 1)
+		err := sem.Acquire(ctx, 1)
+		if err != nil {
+			continue
+		}
 		go func(node *Node, stats *resyncStats) {
 			n.resyncNode(ctx, node, stats, syncTime)
 			sem.Release(1)


### PR DESCRIPTION
In case the semaphore fails to be acquired we should not continue
resyncing the node and eventually release that same semaphore as it
might cause the semaphore to panic due the number of 'Release' calls
is superior than the number of previous acquires.

Fixes: b96f90c15f48 ("eni: Support for parallel workers")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9611)
<!-- Reviewable:end -->
