### PR TITLE
cilium: fix disconnects on operator restarts when using ipsec

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -279,7 +279,7 @@ func NewDaemon(ctx context.Context, dp datapath.Datapath) (*Daemon, *endpointRes
 		}
 	}
 
-	authKeySize, err := setupIPSec()
+	authKeySize, encryptKeyID, err := setupIPSec()
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to setup encryption: %s", err)
 	}
@@ -458,6 +458,7 @@ func NewDaemon(ctx context.Context, dp datapath.Datapath) (*Daemon, *endpointRes
 		}).Info("Annotating k8s node")
 
 		err := k8s.Client().AnnotateNode(node.GetName(),
+			encryptKeyID,
 			node.GetIPv4AllocRange(), node.GetIPv6NodeRange(),
 			d.nodeDiscovery.LocalNode.IPv4HealthIP, d.nodeDiscovery.LocalNode.IPv6HealthIP,
 			node.GetInternalIPv4(), node.GetIPv6Router())

--- a/daemon/datapath.go
+++ b/daemon/datapath.go
@@ -364,21 +364,21 @@ func (d *Daemon) initMaps() error {
 	return nil
 }
 
-func setupIPSec() (int, error) {
+func setupIPSec() (int, uint8, error) {
 	if option.Config.EncryptNode == false {
 		ipsec.DeleteIPsecEncryptRoute()
 	}
 
 	if !option.Config.EnableIPSec {
-		return 0, nil
+		return 0, 0, nil
 	}
 
 	authKeySize, spi, err := ipsec.LoadIPSecKeysFile(option.Config.IPSecKeyFile)
 	if err != nil {
-		return 0, err
+		return 0, 0, err
 	}
 	node.SetIPsecKeyIdentity(spi)
-	return authKeySize, nil
+	return authKeySize, spi, nil
 }
 
 // Datapath returns a reference to the datapath implementation.

--- a/pkg/annotation/k8s.go
+++ b/pkg/annotation/k8s.go
@@ -45,6 +45,10 @@ const (
 	// of the cilium host interface in the node's annotation.
 	CiliumHostIPv6 = Prefix + ".network.ipv6-cilium-host"
 
+	// CiliumEncryptionKey is the annotation name used to store the encryption
+	// key of the cilium host interface in the node's annotation.
+	CiliumEncryptionKey = Prefix + ".network.encryption-key"
+
 	// GlobalService if set to true, marks a service to become a global
 	// service
 	GlobalService = Prefix + "/global-service"

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -86,6 +86,7 @@ func (s *K8sSuite) TestUseNodeCIDR(c *C) {
 	// IPv6 Node range is not checked because it shouldn't be changed.
 
 	err := k8sCli.AnnotateNode("node1",
+		0,
 		node.GetIPv4AllocRange(),
 		node.GetIPv6NodeRange(),
 		nil,
@@ -157,6 +158,7 @@ func (s *K8sSuite) TestUseNodeCIDR(c *C) {
 	c.Assert(node.GetIPv6NodeRange().String(), Equals, "aaaa:aaaa:aaaa:aaaa:beef:beef::/96")
 
 	err = k8sCli.AnnotateNode("node2",
+		0,
 		node.GetIPv4AllocRange(),
 		node.GetIPv6NodeRange(),
 		nil,

--- a/pkg/k8s/node.go
+++ b/pkg/k8s/node.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"strconv"
 
 	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/cidr"
@@ -110,11 +111,19 @@ func ParseNode(k8sNode *types.Node, source source.Source) *node.Node {
 	k8sNodeAddHostIP(annotation.CiliumHostIP)
 	k8sNodeAddHostIP(annotation.CiliumHostIPv6)
 
+	encryptKey := uint8(0)
+	if key, ok := k8sNode.Annotations[annotation.CiliumEncryptionKey]; ok {
+		if u, err := strconv.ParseUint(key, 10, 8); err == nil {
+			encryptKey = uint8(u)
+		}
+	}
+
 	newNode := &node.Node{
-		Name:        k8sNode.Name,
-		Cluster:     option.Config.ClusterName,
-		IPAddresses: addrs,
-		Source:      source,
+		Name:          k8sNode.Name,
+		Cluster:       option.Config.ClusterName,
+		IPAddresses:   addrs,
+		Source:        source,
+		EncryptionKey: encryptKey,
 	}
 
 	if len(k8sNode.SpecPodCIDRs) != 0 {


### PR DESCRIPTION
As reported by Laurent:

"
We noticed that on container restarts established TCP connections were
disconnected (under load). After some investigation we noticed these
events on the agent for all nodes:

- Received key update via kvstore with invalid EncryptionKey:0
- a few minutes later Received key update via kvstore with valid
  EncryptionKey:x

After looking into the code, it seems that on operator restart the node
Informer will add all nodes to the kvstore based on the k8s-node resource
which does not have the EncryptionKey info and will set it to 0. Watches
on the agents will then update the ipsec configuration and create the
issue. After a while, the agents update their kvstore resource to the the
good value and traffic can flow again (I haven't checked but I assume
there is a reconcile loop in the agents).
"

Andre suggest only updating the EncryptionState from NodeUpdated if a
valid key is provided. Its not valid to both have encryption enabled
and specify the null key for example. However, for rolling updates
disabling encryption we may have a state where locally encryption
is enabled but the remote node is disabling encryption, signaled by
sending a null encryption key.

So instead of checking in NodeUpdated lets push key into K8s annotation
then we can read it out correctly when an event is received and push
down stack to configure datapath correctly. This adds the new K8s
annotation CiliumEncryptionKey, ".network.encryption-key"

Fixes: 500fb2b5cd3e6 ("node: Discover other nodes based on CiliumNode custom resource")
Reported-by: Laurent Bernaille <laurent.bernaille@datadoghq.com>
Suggested-by: Andre Martins <andre@cilium.io>
Signed-off-by: John Fastabend <john.fastabend@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9612)
<!-- Reviewable:end -->
