### PR TITLE
policy: Keep cached selector references for L3-dependent L7 rules.

### DIFF
--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -806,7 +806,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RulePartiallyShadowedByL3AllowAll(c *
 		Protocol:        api.ProtoTCP,
 		U8Proto:         6,
 		allowsAllAtL3:   true,
-		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector},
+		CachedSelectors: CachedSelectorSlice{cachedSelectorA, wildcardCachedSelector},
 		L7Parser:        ParserTypeHTTP,
 		L7RulesPerEp: L7DataMap{
 			cachedSelectorA: api.L7Rules{
@@ -875,7 +875,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RulePartiallyShadowedByL3AllowAll(c *
 		Protocol:        api.ProtoTCP,
 		U8Proto:         6,
 		allowsAllAtL3:   true,
-		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector},
+		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector, cachedSelectorA},
 		L7Parser:        ParserTypeHTTP,
 		L7RulesPerEp: L7DataMap{
 			cachedSelectorA: api.L7Rules{
@@ -957,7 +957,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RuleShadowedByL3AllowAll(c *C) {
 		Protocol:        api.ProtoTCP,
 		U8Proto:         6,
 		allowsAllAtL3:   true,
-		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector},
+		CachedSelectors: CachedSelectorSlice{cachedSelectorA, wildcardCachedSelector},
 		L7Parser:        ParserTypeHTTP,
 		L7RulesPerEp: L7DataMap{
 			wildcardCachedSelector: api.L7Rules{
@@ -1035,7 +1035,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RuleShadowedByL3AllowAll(c *C) {
 		Protocol:        api.ProtoTCP,
 		U8Proto:         6,
 		allowsAllAtL3:   true,
-		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector},
+		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector, cachedSelectorA},
 		L7Parser:        ParserTypeHTTP,
 		L7RulesPerEp: L7DataMap{
 			wildcardCachedSelector: api.L7Rules{

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -79,18 +79,22 @@ func mergePortProto(ctx *SearchContext, existingFilter, filterToMerge *L4Filter,
 		// can now simply select all endpoints.
 		//
 		// Release references held by filterToMerge.CachedSelectors
-		selectorCache.RemoveSelectors(filterToMerge.CachedSelectors, filterToMerge)
-		filterToMerge.CachedSelectors = nil
+		if !filterToMerge.HasL3DependentL7Rules() {
+			selectorCache.RemoveSelectors(filterToMerge.CachedSelectors, filterToMerge)
+			filterToMerge.CachedSelectors = nil
+		}
 	} else {
 		// Case 2: Merge selectors from filterToMerge to the existingFilter.
 		if filterToMerge.AllowsAllAtL3() {
 			// Allowing all, release selectors from existingFilter
-			selectorCache.RemoveSelectors(existingFilter.CachedSelectors, existingFilter)
-			existingFilter.CachedSelectors = nil
+			if !existingFilter.HasL3DependentL7Rules() {
+				selectorCache.RemoveSelectors(existingFilter.CachedSelectors, existingFilter)
+				existingFilter.CachedSelectors = nil
+			}
 			existingFilter.allowsAllAtL3 = true
 		}
-		existingFilter.mergeCachedSelectors(filterToMerge, selectorCache)
 	}
+	existingFilter.mergeCachedSelectors(filterToMerge, selectorCache)
 
 	// Merge the L7-related data from the arguments provided to this function
 	// with the existing L7-related data already in the filter.

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -404,7 +404,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
 		Protocol:        api.ProtoTCP,
 		U8Proto:         6,
 		allowsAllAtL3:   true,
-		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector},
+		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector, cachedFooSelector},
 		L7Parser:        ParserTypeHTTP,
 		L7RulesPerEp: L7DataMap{
 			wildcardCachedSelector: api.L7Rules{
@@ -479,7 +479,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
 	expected = L4PolicyMap{"80/TCP": &L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		allowsAllAtL3:   true,
-		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector},
+		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector, cachedFooSelector},
 		L7Parser:        "kafka", L7RulesPerEp: l7map, Ingress: true,
 		DerivedFromRules: labels.LabelArrayList{nil, nil},
 	}}
@@ -564,7 +564,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
 	expected = L4PolicyMap{"80/TCP": &L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		allowsAllAtL3:   true,
-		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector},
+		CachedSelectors: CachedSelectorSlice{cachedFooSelector, wildcardCachedSelector},
 		L7Parser:        "kafka", L7RulesPerEp: l7map, Ingress: true,
 		DerivedFromRules: labels.LabelArrayList{nil, nil},
 	}}
@@ -606,7 +606,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 						},
 						Rules: &api.L7Rules{
 							HTTP: []api.PortRuleHTTP{
-								{Method: "GET", Path: "/"},
+								{Method: "GET", Path: "/public"},
 							},
 						},
 					}},
@@ -619,7 +619,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 						},
 						Rules: &api.L7Rules{
 							HTTP: []api.PortRuleHTTP{
-								{Method: "GET", Path: "/"},
+								{Method: "GET", Path: "/private"},
 							},
 						},
 					}},
@@ -631,14 +631,14 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 	expected := L4PolicyMap{"80/TCP": &L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		allowsAllAtL3:   true,
-		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector},
+		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector, cachedFooSelector},
 		L7Parser:        ParserTypeHTTP,
 		L7RulesPerEp: L7DataMap{
 			wildcardCachedSelector: api.L7Rules{
-				HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
+				HTTP: []api.PortRuleHTTP{{Path: "/public", Method: "GET"}},
 			},
 			cachedFooSelector: api.L7Rules{
-				HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
+				HTTP: []api.PortRuleHTTP{{Path: "/private", Method: "GET"}},
 			},
 		},
 		Ingress:          false,
@@ -705,7 +705,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 	expected = L4PolicyMap{"80/TCP": &L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		allowsAllAtL3:   true,
-		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector},
+		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector, cachedFooSelector},
 		L7Parser:        ParserTypeKafka,
 		L7RulesPerEp: L7DataMap{
 			wildcardCachedSelector: api.L7Rules{
@@ -792,7 +792,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 	expected = L4PolicyMap{"80/TCP": &L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		allowsAllAtL3:   true,
-		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector},
+		CachedSelectors: CachedSelectorSlice{cachedFooSelector, wildcardCachedSelector},
 		L7Parser:        "kafka", L7RulesPerEp: l7map, Ingress: false,
 		DerivedFromRules: labels.LabelArrayList{nil, nil},
 	}}
@@ -1745,8 +1745,9 @@ func (ds *PolicyTestSuite) TestL4WildcardMerge(c *C) {
 	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, true)
 
-	c.Assert(len(filter.CachedSelectors), Equals, 1)
-	c.Assert(filter.CachedSelectors[0], checker.Equals, wildcardCachedSelector)
+	c.Assert(len(filter.CachedSelectors), Equals, 2)
+	c.Assert(filter.CachedSelectors[0], checker.Equals, cachedSelectorC)
+	c.Assert(filter.CachedSelectors[1], checker.Equals, wildcardCachedSelector)
 
 	c.Assert(filter.L7Parser, Equals, ParserTypeHTTP)
 	c.Assert(len(filter.L7RulesPerEp), Equals, 2)
@@ -1796,8 +1797,9 @@ func (ds *PolicyTestSuite) TestL4WildcardMerge(c *C) {
 	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, true)
 
-	c.Assert(len(filter.CachedSelectors), Equals, 1)
+	c.Assert(len(filter.CachedSelectors), Equals, 2)
 	c.Assert(filter.CachedSelectors[0], checker.Equals, wildcardCachedSelector)
+	c.Assert(filter.CachedSelectors[1], checker.Equals, cachedSelectorC)
 
 	c.Assert(filter.L7Parser, Equals, ParserTypeHTTP)
 	c.Assert(len(filter.L7RulesPerEp), Equals, 2)
@@ -1845,7 +1847,7 @@ func (ds *PolicyTestSuite) TestL4WildcardMerge(c *C) {
 	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, true)
 
-	c.Assert(len(filter.CachedSelectors), Equals, 1)
+	c.Assert(len(filter.CachedSelectors), Equals, 2)
 	c.Assert(filter.L7Parser, Equals, ParserTypeHTTP)
 	c.Assert(len(filter.L7RulesPerEp), Equals, 2)
 	l4IngressPolicy.Detach(repo.GetSelectorCache())
@@ -1895,7 +1897,7 @@ func (ds *PolicyTestSuite) TestL4WildcardMerge(c *C) {
 	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, true)
 
-	c.Assert(len(filter.CachedSelectors), Equals, 1)
+	c.Assert(len(filter.CachedSelectors), Equals, 2)
 
 	c.Assert(filter.L7Parser, Equals, ParserTypeHTTP)
 	c.Assert(len(filter.L7RulesPerEp), Equals, 2)


### PR DESCRIPTION
Keep the selector cache references for selectors used as keys for
L3-dependent L7 rules, even when the filter applies to all L3
endpoints. This is required for FQDN selectors to be tracked by the
selector cache even when the rule is merged with another rule
wildcarding at L3.

Fixes bugs where FQDNs tend not to be learned when they're part of an L3-dependent L7 rule (they're not even in the selectorcache so DNS proxy can't find them), or alternatively if you set up a policy, then a new endpoint is created somewhere in the cluster which matches an existing L3-dependent L7 rule, then the policy regeneration may not properly plumb the BPF policymap entries for the identity of the new endpoint.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9617)
<!-- Reviewable:end -->
