### PR TITLE
Allow setting timeout on status command

### DIFF
--- a/Documentation/cmdref/cilium_status.md
+++ b/Documentation/cmdref/cilium_status.md
@@ -15,15 +15,16 @@ cilium status [flags]
 ### Options
 
 ```
-      --all-addresses     Show all allocated addresses, not just count
-      --all-controllers   Show all controllers, not just failing
-      --all-health        Show all health status, not just failing
-      --all-nodes         Show all nodes, not just localhost
-      --all-redirects     Show all redirects
-      --brief             Only print a one-line status message
-  -h, --help              help for status
-  -o, --output string     json| jsonpath='{}'
-      --verbose           Equivalent to --all-addresses --all-controllers --all-nodes --all-health
+      --all-addresses      Show all allocated addresses, not just count
+      --all-controllers    Show all controllers, not just failing
+      --all-health         Show all health status, not just failing
+      --all-nodes          Show all nodes, not just localhost
+      --all-redirects      Show all redirects
+      --brief              Only print a one-line status message
+  -h, --help               help for status
+  -o, --output string      json| jsonpath='{}'
+      --timeout duration   Sets the timeout to use when querying for health (default 30s)
+      --verbose            Equivalent to --all-addresses --all-controllers --all-nodes --all-health
 ```
 
 ### Options inherited from parent commands

--- a/cilium/cmd/status.go
+++ b/cilium/cmd/status.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"text/tabwriter"
+	"time"
 
 	"github.com/cilium/cilium/api/v1/client/daemon"
 	"github.com/cilium/cilium/api/v1/models"
@@ -43,6 +44,7 @@ var (
 	allNodes       bool
 	allRedirects   bool
 	brief          bool
+	timeout        time.Duration
 	healthLines    = 10
 )
 
@@ -55,6 +57,7 @@ func init() {
 	statusCmd.Flags().BoolVar(&allRedirects, "all-redirects", false, "Show all redirects")
 	statusCmd.Flags().BoolVar(&brief, "brief", false, "Only print a one-line status message")
 	statusCmd.Flags().BoolVar(&verbose, "verbose", false, "Equivalent to --all-addresses --all-controllers --all-nodes --all-health")
+	statusCmd.Flags().DurationVar(&timeout, "timeout", 30 * time.Second, "Sets the timeout to use when querying for health")
 	command.AddJSONOutput(statusCmd)
 }
 
@@ -78,7 +81,7 @@ func statusDaemon() {
 	if allHealth {
 		healthLines = 0
 	}
-	params := daemon.NewGetHealthzParams()
+	params := daemon.NewGetHealthzParamsWithTimeout(timeout)
 	params.SetBrief(&brief)
 	if resp, err := client.Daemon.GetHealthz(params); err != nil {
 		if brief {

--- a/cilium/cmd/status.go
+++ b/cilium/cmd/status.go
@@ -57,7 +57,7 @@ func init() {
 	statusCmd.Flags().BoolVar(&allRedirects, "all-redirects", false, "Show all redirects")
 	statusCmd.Flags().BoolVar(&brief, "brief", false, "Only print a one-line status message")
 	statusCmd.Flags().BoolVar(&verbose, "verbose", false, "Equivalent to --all-addresses --all-controllers --all-nodes --all-health")
-	statusCmd.Flags().DurationVar(&timeout, "timeout", 30 * time.Second, "Sets the timeout to use when querying for health")
+	statusCmd.Flags().DurationVar(&timeout, "timeout", 30*time.Second, "Sets the timeout to use when querying for health")
 	command.AddJSONOutput(statusCmd)
 }
 


### PR DESCRIPTION
```release-note
Allow setting timeout on cilium status command
```

We use `cilium status` as a liveness check and sometimes (due to other issues), the daemon can fail to respond to the health endpoint within a reasonable amount of time. If this is larger then the [liveness timeout of 5 seconds](https://github.com/cilium/cilium/blob/master/install/kubernetes/quick-install.yaml#L382) then this can cause the liveness check to timeout. 

In these scenarios, for exec liveness probes, the kubelet does not treat timeouts as failure. (It does do that for http/tcp liveness probes)

https://github.com/kubernetes/kubernetes/issues/82987 has more context on the k8s side.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9625)
<!-- Reviewable:end -->
