### PR TITLE
v1.6 backports 2019-11-16

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1555,7 +1555,7 @@
     "storage/v1beta1",
   ]
   pruneopts = "NUT"
-  revision = "kubernetes-1.16.2"
+  revision = "kubernetes-1.16.3"
 
 [[projects]]
   digest = "1:6aab404e4451f049e6c4dfdb102d43fb209b445cdac708f7e74b5e70b41ddd90"
@@ -1570,10 +1570,10 @@
     "pkg/client/clientset/clientset/typed/apiextensions/v1beta1",
   ]
   pruneopts = "NUT"
-  revision = "kubernetes-1.16.2"
+  revision = "kubernetes-1.16.3"
 
 [[projects]]
-  digest = "1:5d7c5239b2cecf625a9b8c5e2837ebe66193ff412723ea998832ea6d0d86b7b9"
+  digest = "1:fa7cf320ac00a2d71abc80ccfaa2a31a36e2f45844c62112efba697c177adeb3"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/equality",
@@ -1622,10 +1622,10 @@
     "third_party/forked/golang/reflect",
   ]
   pruneopts = "NUT"
-  revision = "kubernetes-1.16.2"
+  revision = "kubernetes-1.16.3"
 
 [[projects]]
-  digest = "1:c566f53f2829a9a9081a5ee4d29199b8218f527db97a5b04e38abe11cf153d2f"
+  digest = "1:58b186f541a10955b5758713576444a49cbbdf89f7e944789626e038fcd847ad"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -1737,7 +1737,7 @@
     "util/retry",
   ]
   pruneopts = "NUT"
-  revision = "6e3dcac6fbe46613c51dda7f4f8835b7a35cd2ff"
+  revision = "f525a083bcf58c32bb999ebfd678d70405ae28dd"
   source = "https://github.com/cilium/client-go"
 
 [[projects]]
@@ -1756,14 +1756,14 @@
     "pkg/util",
   ]
   pruneopts = "T"
-  revision = "kubernetes-1.16.2"
+  revision = "kubernetes-1.16.3"
 
 [[projects]]
   digest = "1:5e496d711fa03e4aaf3cab0d7de079634a9465ebf940613b69b34f5cc6513db8"
   name = "k8s.io/cri-api"
   packages = ["pkg/apis/runtime/v1alpha2"]
   pruneopts = "NUT"
-  revision = "kubernetes-1.16.2"
+  revision = "kubernetes-1.16.3"
 
 [[projects]]
   digest = "1:d233b263f74608ab5528c04453935d899a2b9fb0bf02b03d38a4a11f91442a5c"
@@ -1808,7 +1808,7 @@
     "pkg/registry/core/service/ipallocator",
   ]
   pruneopts = "NUT"
-  revision = "v1.16.2"
+  revision = "v1.16.3"
 
 [[projects]]
   digest = "1:99dbf7ef753ca02399778c93a4ed4b689b28668317134ecd1fabeb07be70f354"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -514,28 +514,28 @@ required = [
 
 [[constraint]]
   name = "k8s.io/api"
-  revision = "kubernetes-1.16.2"
+  revision = "kubernetes-1.16.3"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
 
 [[constraint]]
   name = "k8s.io/apiextensions-apiserver"
-  revision = "kubernetes-1.16.2"
+  revision = "kubernetes-1.16.3"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
 
 [[override]]
   name = "k8s.io/apiserver"
-  revision = "kubernetes-1.16.2"
+  revision = "kubernetes-1.16.3"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
 
 [[constraint]]
   name = "k8s.io/apimachinery"
-  revision = "kubernetes-1.16.2"
+  revision = "kubernetes-1.16.3"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
@@ -543,10 +543,10 @@ required = [
 [[constraint]]
   name = "k8s.io/client-go"
   source = "https://github.com/cilium/client-go"
-  revision = "6e3dcac6fbe46613c51dda7f4f8835b7a35cd2ff"
+  revision = "f525a083bcf58c32bb999ebfd678d70405ae28dd"
 
   # main-usage = "pkg/k8s"
-  # on-revision = "TODO @aanm is on 6e3dcac6fbe46613c51dda7f4f8835b7a35cd2ff as it contains the hotfix for the metrics path"
+  # on-revision = "TODO @aanm is on f525a083bcf58c32bb999ebfd678d70405ae28dd as it contains the hotfix for the metrics path"
 
 [[override]]
   name = "k8s.io/utils"
@@ -557,7 +557,7 @@ required = [
 
 [[constraint]]
   name = "k8s.io/code-generator"
-  revision = "kubernetes-1.16.2"
+  revision = "kubernetes-1.16.3"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
@@ -571,14 +571,14 @@ required = [
 
 [[constraint]]
   name = "k8s.io/kubernetes"
-  revision = "v1.16.2"
+  revision = "v1.16.3"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
 
 [[constraint]]
   name = "k8s.io/cri-api"
-  revision = "kubernetes-1.16.2"
+  revision = "kubernetes-1.16.3"
 
   # main-usage = "pkg/workloads"
   # on-revision = ""

--- a/examples/kubernetes-ingress/scripts/helpers.bash
+++ b/examples/kubernetes-ingress/scripts/helpers.bash
@@ -76,8 +76,8 @@ cluster_api_server_ip=${K8S_CLUSTER_API_SERVER_IP:-"172.20.0.1"}
 #cluster_dns_ip=${K8S_CLUSTER_DNS_IP:-"FD03::A"}
 #cluster_api_server_ip=${K8S_CLUSTER_API_SERVER_IP:-"FD03::1"}
 
-k8s_version="v1.16.0"
-etcd_version="v3.4.0"
+k8s_version="v1.16.3"
+etcd_version="v3.4.2"
 
 function restore_flag {
   check_num_params "$#" "2"

--- a/examples/kubernetes-istio/kafka-v1.yaml
+++ b/examples/kubernetes-istio/kafka-v1.yaml
@@ -59,11 +59,14 @@ specs:
           - apiKey: "offsetfetch"
           - apiKey: "heartbeat"
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: kafka-v1
 spec:
+  selector:
+    matchLabels:
+      app: kafka
   serviceName: kafka
   replicas: 1
   template:

--- a/pkg/aws/eni/node_manager.go
+++ b/pkg/aws/eni/node_manager.go
@@ -296,7 +296,10 @@ func (n *NodeManager) Resync(syncTime time.Time) {
 	sem := semaphore.NewWeighted(n.parallelWorkers)
 
 	for _, node := range n.GetNodesByIPWatermark() {
-		sem.Acquire(context.TODO(), 1)
+		err := sem.Acquire(context.TODO(), 1)
+		if err != nil {
+			continue
+		}
 		go func(node *Node, stats *resyncStats) {
 			n.resyncNode(node, stats, syncTime)
 			sem.Release(1)

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -804,7 +804,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RulePartiallyShadowedByL3AllowAll(c *
 		Protocol:        api.ProtoTCP,
 		U8Proto:         6,
 		allowsAllAtL3:   true,
-		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector},
+		CachedSelectors: CachedSelectorSlice{cachedSelectorA, wildcardCachedSelector},
 		L7Parser:        ParserTypeHTTP,
 		L7RulesPerEp: L7DataMap{
 			cachedSelectorA: api.L7Rules{
@@ -873,7 +873,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RulePartiallyShadowedByL3AllowAll(c *
 		Protocol:        api.ProtoTCP,
 		U8Proto:         6,
 		allowsAllAtL3:   true,
-		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector},
+		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector, cachedSelectorA},
 		L7Parser:        ParserTypeHTTP,
 		L7RulesPerEp: L7DataMap{
 			cachedSelectorA: api.L7Rules{
@@ -955,7 +955,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RuleShadowedByL3AllowAll(c *C) {
 		Protocol:        api.ProtoTCP,
 		U8Proto:         6,
 		allowsAllAtL3:   true,
-		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector},
+		CachedSelectors: CachedSelectorSlice{cachedSelectorA, wildcardCachedSelector},
 		L7Parser:        ParserTypeHTTP,
 		L7RulesPerEp: L7DataMap{
 			wildcardCachedSelector: api.L7Rules{
@@ -1033,7 +1033,7 @@ func (ds *PolicyTestSuite) TestL3RuleWithL7RuleShadowedByL3AllowAll(c *C) {
 		Protocol:        api.ProtoTCP,
 		U8Proto:         6,
 		allowsAllAtL3:   true,
-		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector},
+		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector, cachedSelectorA},
 		L7Parser:        ParserTypeHTTP,
 		L7RulesPerEp: L7DataMap{
 			wildcardCachedSelector: api.L7Rules{

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -79,18 +79,22 @@ func mergePortProto(ctx *SearchContext, existingFilter, filterToMerge *L4Filter,
 		// can now simply select all endpoints.
 		//
 		// Release references held by filterToMerge.CachedSelectors
-		selectorCache.RemoveSelectors(filterToMerge.CachedSelectors, filterToMerge)
-		filterToMerge.CachedSelectors = nil
+		if !filterToMerge.HasL3DependentL7Rules() {
+			selectorCache.RemoveSelectors(filterToMerge.CachedSelectors, filterToMerge)
+			filterToMerge.CachedSelectors = nil
+		}
 	} else {
 		// Case 2: Merge selectors from filterToMerge to the existingFilter.
 		if filterToMerge.AllowsAllAtL3() {
 			// Allowing all, release selectors from existingFilter
-			selectorCache.RemoveSelectors(existingFilter.CachedSelectors, existingFilter)
-			existingFilter.CachedSelectors = nil
+			if !existingFilter.HasL3DependentL7Rules() {
+				selectorCache.RemoveSelectors(existingFilter.CachedSelectors, existingFilter)
+				existingFilter.CachedSelectors = nil
+			}
 			existingFilter.allowsAllAtL3 = true
 		}
-		existingFilter.mergeCachedSelectors(filterToMerge, selectorCache)
 	}
+	existingFilter.mergeCachedSelectors(filterToMerge, selectorCache)
 
 	// Merge the L7-related data from the arguments provided to this function
 	// with the existing L7-related data already in the filter.

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -404,7 +404,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
 		Protocol:        api.ProtoTCP,
 		U8Proto:         6,
 		allowsAllAtL3:   true,
-		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector},
+		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector, cachedFooSelector},
 		L7Parser:        ParserTypeHTTP,
 		L7RulesPerEp: L7DataMap{
 			wildcardCachedSelector: api.L7Rules{
@@ -479,7 +479,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
 	expected = L4PolicyMap{"80/TCP": &L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		allowsAllAtL3:   true,
-		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector},
+		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector, cachedFooSelector},
 		L7Parser:        "kafka", L7RulesPerEp: l7map, Ingress: true,
 		DerivedFromRules: labels.LabelArrayList{nil, nil},
 	}}
@@ -564,7 +564,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyIngress(c *C) {
 	expected = L4PolicyMap{"80/TCP": &L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		allowsAllAtL3:   true,
-		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector},
+		CachedSelectors: CachedSelectorSlice{cachedFooSelector, wildcardCachedSelector},
 		L7Parser:        "kafka", L7RulesPerEp: l7map, Ingress: true,
 		DerivedFromRules: labels.LabelArrayList{nil, nil},
 	}}
@@ -606,7 +606,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 						},
 						Rules: &api.L7Rules{
 							HTTP: []api.PortRuleHTTP{
-								{Method: "GET", Path: "/"},
+								{Method: "GET", Path: "/public"},
 							},
 						},
 					}},
@@ -619,7 +619,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 						},
 						Rules: &api.L7Rules{
 							HTTP: []api.PortRuleHTTP{
-								{Method: "GET", Path: "/"},
+								{Method: "GET", Path: "/private"},
 							},
 						},
 					}},
@@ -631,14 +631,14 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 	expected := L4PolicyMap{"80/TCP": &L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		allowsAllAtL3:   true,
-		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector},
+		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector, cachedFooSelector},
 		L7Parser:        ParserTypeHTTP,
 		L7RulesPerEp: L7DataMap{
 			wildcardCachedSelector: api.L7Rules{
-				HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
+				HTTP: []api.PortRuleHTTP{{Path: "/public", Method: "GET"}},
 			},
 			cachedFooSelector: api.L7Rules{
-				HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
+				HTTP: []api.PortRuleHTTP{{Path: "/private", Method: "GET"}},
 			},
 		},
 		Ingress:          false,
@@ -705,7 +705,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 	expected = L4PolicyMap{"80/TCP": &L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		allowsAllAtL3:   true,
-		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector},
+		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector, cachedFooSelector},
 		L7Parser:        ParserTypeKafka,
 		L7RulesPerEp: L7DataMap{
 			wildcardCachedSelector: api.L7Rules{
@@ -792,7 +792,7 @@ func (ds *PolicyTestSuite) TestMergeL7PolicyEgress(c *C) {
 	expected = L4PolicyMap{"80/TCP": &L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		allowsAllAtL3:   true,
-		CachedSelectors: CachedSelectorSlice{wildcardCachedSelector},
+		CachedSelectors: CachedSelectorSlice{cachedFooSelector, wildcardCachedSelector},
 		L7Parser:        "kafka", L7RulesPerEp: l7map, Ingress: false,
 		DerivedFromRules: labels.LabelArrayList{nil, nil},
 	}}
@@ -1745,8 +1745,9 @@ func (ds *PolicyTestSuite) TestL4WildcardMerge(c *C) {
 	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, true)
 
-	c.Assert(len(filter.CachedSelectors), Equals, 1)
-	c.Assert(filter.CachedSelectors[0], checker.Equals, wildcardCachedSelector)
+	c.Assert(len(filter.CachedSelectors), Equals, 2)
+	c.Assert(filter.CachedSelectors[0], checker.Equals, cachedSelectorC)
+	c.Assert(filter.CachedSelectors[1], checker.Equals, wildcardCachedSelector)
 
 	c.Assert(filter.L7Parser, Equals, ParserTypeHTTP)
 	c.Assert(len(filter.L7RulesPerEp), Equals, 2)
@@ -1796,8 +1797,9 @@ func (ds *PolicyTestSuite) TestL4WildcardMerge(c *C) {
 	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, true)
 
-	c.Assert(len(filter.CachedSelectors), Equals, 1)
+	c.Assert(len(filter.CachedSelectors), Equals, 2)
 	c.Assert(filter.CachedSelectors[0], checker.Equals, wildcardCachedSelector)
+	c.Assert(filter.CachedSelectors[1], checker.Equals, cachedSelectorC)
 
 	c.Assert(filter.L7Parser, Equals, ParserTypeHTTP)
 	c.Assert(len(filter.L7RulesPerEp), Equals, 2)
@@ -1845,7 +1847,7 @@ func (ds *PolicyTestSuite) TestL4WildcardMerge(c *C) {
 	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, true)
 
-	c.Assert(len(filter.CachedSelectors), Equals, 1)
+	c.Assert(len(filter.CachedSelectors), Equals, 2)
 	c.Assert(filter.L7Parser, Equals, ParserTypeHTTP)
 	c.Assert(len(filter.L7RulesPerEp), Equals, 2)
 	l4IngressPolicy.Detach(repo.GetSelectorCache())
@@ -1895,7 +1897,7 @@ func (ds *PolicyTestSuite) TestL4WildcardMerge(c *C) {
 	c.Assert(filter.Port, Equals, 80)
 	c.Assert(filter.Ingress, Equals, true)
 
-	c.Assert(len(filter.CachedSelectors), Equals, 1)
+	c.Assert(len(filter.CachedSelectors), Equals, 2)
 
 	c.Assert(filter.L7Parser, Equals, ParserTypeHTTP)
 	c.Assert(len(filter.L7RulesPerEp), Equals, 2)

--- a/test/kubernetes-test.sh
+++ b/test/kubernetes-test.sh
@@ -52,6 +52,10 @@ test -d kubernetes && rm -rfv kubernetes
 git clone https://github.com/kubernetes/kubernetes.git -b ${KUBERNETES_VERSION} --depth 1
 cd kubernetes
 
+# Kubernetes is only compiling with golang 1.12 for versions <=1.16
+sudo rm -fr /usr/local/go
+curl https://dl.google.com/go/go1.12.13.linux-amd64.tar.gz > go1.12.13.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.12.13.linux-amd64.tar.gz
 make ginkgo
 make WHAT='test/e2e/e2e.test'
 

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -222,7 +222,7 @@ case $K8S_VERSION in
         ;;
     "1.16")
         KUBERNETES_CNI_VERSION="0.7.5"
-        K8S_FULL_VERSION="1.16.2"
+        K8S_FULL_VERSION="1.16.3"
         KUBEADM_OPTIONS="--ignore-preflight-errors=cri"
         KUBEADM_SLAVE_OPTIONS="--discovery-token-unsafe-skip-ca-verification --ignore-preflight-errors=cri,SystemVerification"
         sudo ln -sf $COREDNS_DEPLOYMENT $DNS_DEPLOYMENT

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -206,7 +206,7 @@ case $K8S_VERSION in
         ;;
     "1.14")
         KUBERNETES_CNI_VERSION="0.7.5"
-        K8S_FULL_VERSION="1.14.8"
+        K8S_FULL_VERSION="1.14.9"
         KUBEADM_OPTIONS="--ignore-preflight-errors=cri"
         KUBEADM_SLAVE_OPTIONS="--discovery-token-unsafe-skip-ca-verification --ignore-preflight-errors=cri,SystemVerification"
         sudo ln -sf $COREDNS_DEPLOYMENT $DNS_DEPLOYMENT
@@ -214,7 +214,7 @@ case $K8S_VERSION in
         ;;
     "1.15")
         KUBERNETES_CNI_VERSION="0.7.5"
-        K8S_FULL_VERSION="1.15.5"
+        K8S_FULL_VERSION="1.15.6"
         KUBEADM_OPTIONS="--ignore-preflight-errors=cri"
         KUBEADM_SLAVE_OPTIONS="--discovery-token-unsafe-skip-ca-verification --ignore-preflight-errors=cri,SystemVerification"
         sudo ln -sf $COREDNS_DEPLOYMENT $DNS_DEPLOYMENT

--- a/vendor/k8s.io/apimachinery/pkg/util/intstr/intstr.go
+++ b/vendor/k8s.io/apimachinery/pkg/util/intstr/intstr.go
@@ -45,7 +45,7 @@ type IntOrString struct {
 }
 
 // Type represents the stored type of IntOrString.
-type Type int
+type Type int64
 
 const (
 	Int    Type = iota // The IntOrString holds an int.

--- a/vendor/k8s.io/client-go/tools/cache/delta_fifo.go
+++ b/vendor/k8s.io/client-go/tools/cache/delta_fifo.go
@@ -295,26 +295,12 @@ func isDeletionDup(a, b *Delta) *Delta {
 	return b
 }
 
-// willObjectBeDeletedLocked returns true only if the last delta for the
-// given object is Delete. Caller must lock first.
-func (f *DeltaFIFO) willObjectBeDeletedLocked(id string) bool {
-	deltas := f.items[id]
-	return len(deltas) > 0 && deltas[len(deltas)-1].Type == Deleted
-}
-
 // queueActionLocked appends to the delta list for the object.
 // Caller must lock first.
 func (f *DeltaFIFO) queueActionLocked(actionType DeltaType, obj interface{}) error {
 	id, err := f.KeyOf(obj)
 	if err != nil {
 		return KeyError{obj, err}
-	}
-
-	// If object is supposed to be deleted (last event is Deleted),
-	// then we should ignore Sync events, because it would result in
-	// recreation of this object.
-	if actionType == Sync && f.willObjectBeDeletedLocked(id) {
-		return nil
 	}
 
 	newDeltas := append(f.items[id], Delta{actionType, obj})


### PR DESCRIPTION
 * #9561 -- iptables: Fix incorrect SNAT for externalTrafficPolicy=local (@tgraf)
 * #9611 -- aws/eni: do not resync node if semaphore Acquire fails (@aanm)
 * #9615 -- Fix kafka v1 yaml incompatibility (@soumynathan)
 * #9617 -- policy: Keep cached selector references for L3-dependent L7 rules. (@jrajahalme)
 * #9614 -- Update k8s to v1.16.3, 1.14.9 and 1.15.6 (@aanm)

Once this PR is merged, you can update the PR labels via:
```
$ for pr in 9561 9611 9615 9617 9614; do contrib/backporting/set-labels.py $pr done 1.6; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9627)
<!-- Reviewable:end -->
