### PR TITLE
make: Remove GOPATH from swagger command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ BPF_FILES ?= $(BPF_FILES_EVAL)
 BPF_SRCFILES := $(subst ../,,$(BPF_FILES))
 
 SWAGGER_VERSION := v0.20.1
-SWAGGER := $(CONTAINER_ENGINE_FULL) run --rm -v $(CURDIR):$(CURDIR) -w $(CURDIR) -e GOPATH=$(GOPATH) --entrypoint swagger quay.io/goswagger/swagger:$(SWAGGER_VERSION)
+SWAGGER := $(CONTAINER_ENGINE_FULL) run --rm -v $(CURDIR):$(CURDIR) -w $(CURDIR) --entrypoint swagger quay.io/goswagger/swagger:$(SWAGGER_VERSION)
 
 COVERPKG_EVAL := $(shell if [ $$(echo "$(TESTPKGS)" | wc -w) -gt 1 ]; then echo "./..."; else echo "$(TESTPKGS)"; fi)
 COVERPKG ?= $(COVERPKG_EVAL)
@@ -455,7 +455,7 @@ update-golang-dockerfiles:
 	$(QUIET) sed -i 's/GO_VERSION .*/GO_VERSION $(GO_VERSION)/g' Dockerfile.builder
 	$(QUIET) for fl in $(shell find . -name "*Dockerfile*") ; do sed -i 's/golang:.* /golang:$(GO_VERSION) as /g' $$fl ; done
 	@echo "Updated go version in Dockerfiles to $(GO_VERSION)"
-	
+
 update-travis-go-version:
 	$(QUIET) sed -e 's/TRAVIS_GO_VERSION/$(GO_VERSION)/g' .travis.yml.tmpl > .travis.yml
 	@echo "Updated go version in .travis.yml to $(GO_VERSION)"


### PR DESCRIPTION
Cilium repository used go.mod, so GOPATH is not required anymore. Using
`make generate-api` when Cilium is cloned in a regular directory and
GOPATH is not set, resulted in the following error:

```
2019/11/18 16:03:08 trying to read config from /home/mrostecki/repos/cilium/api/v1/cilium-server.yml
2019/11/18 16:03:08 validating spec /home/mrostecki/repos/cilium/api/v1/openapi.yaml
2019/11/18 16:03:10 preprocessing spec with option:  minimal flattening
2019/11/18 16:03:10 building a plan for generation
2019/11/18 16:03:10 lstat /root/go: no such file or directory
make: [Makefile:259: generate-api] Error 1 (ignored)
sudo podman run --rm -v /home/mrostecki/repos/cilium:/home/mrostecki/repos/cilium -w /home/mrostecki/repos/cilium -e GOPATH= --entrypoint swagger quay.io/goswagger/swagger:v0.20.1 generate client -a restapi \
	-t api/v1 -f api/v1/openapi.yaml
2019/11/18 16:03:12 validating spec api/v1/openapi.yaml
2019/11/18 16:03:14 preprocessing spec with option:  minimal flattening
2019/11/18 16:03:14 building a plan for generation
2019/11/18 16:03:14 lstat /root/go: no such file or directory
make: [Makefile:260: generate-api] Error 1 (ignored)
```

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9632)
<!-- Reviewable:end -->
