### PR TITLE
test: Add `vagrant-local-start.sh` with preloaded VM support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -59,7 +59,7 @@ test/*.xml
 tests/cilium-files
 test/test_results
 test/*.json
-test/.vagrant/
+test/.vagrant
 
 # Emacs backup files
 *~

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ test/*_service_manifest.json
 test/*_manifest.yaml
 test/*_policy.json
 test/*.xml
+test/.vagrant
 
 # Emacs backup files
 *~

--- a/test/Makefile
+++ b/test/Makefile
@@ -35,3 +35,4 @@ nightly:
 clean:
 	@$(ECHO_CLEAN)
 	-$(QUIET) rm -rf $(TEST_ARTIFACTS)
+	-$(QUIET) rm -f .vagrant/*.box

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -21,6 +21,7 @@ $CONTAINER_RUNTIME=(ENV['CONTAINER_RUNTIME'] || "docker")
 $CNI_INTEGRATION=(ENV['CNI_INTEGRATION'] || "")
 $CILIUM_IMAGE = ENV['CILIUM_IMAGE'] || ""
 $CILIUM_OPERATOR_IMAGE = ENV['CILIUM_OPERATOR_IMAGE'] || ""
+$PRELOAD_VM = ENV['PRELOAD_VM'] || "false"
 $SKIP_K8S_PROVISION = ENV['SKIP_K8S_PROVISION'] || "false"
 
 # RAM and CPU settings
@@ -116,6 +117,7 @@ Vagrant.configure("2") do |config|
                     "#{$IPv6}", "#{$CONTAINER_RUNTIME}", "#{$CNI_INTEGRATION}"]
                 sh.env = {"CILIUM_IMAGE" => "#{$CILIUM_IMAGE}",
                           "CILIUM_OPERATOR_IMAGE" => "#{$CILIUM_OPERATOR_IMAGE}",
+                          "PRELOAD_VM" => "#{$PRELOAD_VM}",
                           "SKIP_K8S_PROVISION" => "#{$SKIP_K8S_PROVISION}"}
             end
         end

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -3,6 +3,7 @@
 set -e
 
 HOST=$(hostname)
+export HELM_VERSION="2.14.2"
 export TOKEN="258062.5d84c017c9b2796c"
 export CILIUM_CONFIG_DIR="/opt/cilium"
 export PROVISIONSRC="/tmp/provision/"
@@ -42,9 +43,9 @@ source ${PROVISIONSRC}/helpers.bash
 sudo bash -c "echo MaxSessions 200 >> /etc/ssh/sshd_config"
 sudo systemctl restart ssh
 
-if [[ "${SKIP_K8S_PROVISION}" == "false" ]]; then
-  retry_function "wget https://get.helm.sh/helm-v2.14.2-linux-amd64.tar.gz"
-  tar xzvf helm-v2.14.2-linux-amd64.tar.gz
+if [[ ! $(helm version | grep ${HELM_VERSION}) ]]; then
+  retry_function "wget https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz"
+  tar xzvf helm-v${HELM_VERSION}-linux-amd64.tar.gz
   mv linux-amd64/helm /usr/local/bin/
 fi
 

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -280,7 +280,15 @@ sudo mkdir -p ${CILIUM_CONFIG_DIR}
 sudo cp "$SYSTEMD_SERVICES/$MOUNT_SYSTEMD" /etc/systemd/system/
 sudo systemctl enable $MOUNT_SYSTEMD
 sudo systemctl restart $MOUNT_SYSTEMD
-sudo rm -rfv /var/lib/kubelet
+sudo rm -rfv /var/lib/kubelet || true
+
+if [[ "${PRELOAD_VM}" == "true" ]]; then
+    cd ${SRC_FOLDER}
+    ./test/provision/container-images.sh test_images .
+    ./test/provision/container-images.sh cilium_images .
+    echo "VM preloading is finished, skipping the rest"
+    exit 0
+fi
 
 #check hostname to know if is kubernetes or runtime test
 if [[ "${HOST}" == "k8s1" ]]; then

--- a/test/vagrant-local-start.sh
+++ b/test/vagrant-local-start.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e
+
+export K8S_VERSION=${K8S_VERSION:-1.16}
+export LOCAL_BOX=k8s-box
+export LOCAL_BOXFILE=/tmp/${LOCAL_BOX}-package.box
+
+echo "destroying vms"
+vagrant destroy k8s1-${K8S_VERSION} k8s2-${K8S_VERSION} --force || true
+
+if [[ ! -f ${LOCAL_BOXFILE} ]]; then
+  echo "Updating vm image"
+  unset SERVER_BOX
+  unset SERVER_VERSION
+  export PRELOAD_VM=true
+  vagrant up k8s1-${K8S_VERSION} --provision
+  vagrant package k8s1-${K8S_VERSION} --output ${LOCAL_BOXFILE}
+  vagrant box add --name ${LOCAL_BOX} ${LOCAL_BOXFILE} --force
+  vagrant destroy k8s1-${K8S_VERSION} --force
+fi
+
+echo "starting vms"
+export SERVER_BOX=$LOCAL_BOX
+export SERVER_VERSION=0
+unset PRELOAD_VM
+vagrant up k8s1-${K8S_VERSION} k8s2-${K8S_VERSION} --provision
+
+echo "labeling nodes"
+vagrant ssh k8s1-${K8S_VERSION} -- kubectl label node k8s1 cilium.io/ci-node=k8s1 --overwrite
+vagrant ssh k8s1-${K8S_VERSION} -- kubectl label node k8s2 cilium.io/ci-node=k8s2 --overwrite

--- a/test/vagrant-local-start.sh
+++ b/test/vagrant-local-start.sh
@@ -5,7 +5,7 @@ set -e
 export K8S_VERSION=${K8S_VERSION:-1.16}
 export K8S_NODES=${K8S_NODES:-1}
 export LOCAL_BOX=k8s-box
-export LOCAL_BOXFILE=/tmp/${LOCAL_BOX}-package.box
+export LOCAL_BOXFILE=./.vagrant/${LOCAL_BOX}-package.box
 
 echo "destroying vms"
 for i in $( seq 1 ${K8S_NODES} )
@@ -31,11 +31,13 @@ export SERVER_VERSION=0
 unset PRELOAD_VM
 for i in $( seq 1 ${K8S_NODES} )
 do
+  echo "Starting k8s${i}-${K8S_VERSION}"
   vagrant up k8s${i}-${K8S_VERSION} --provision
 done
 
 echo "labeling nodes"
 for i in $( seq 1 ${K8S_NODES} )
 do
+  echo "Labeling k8s${i}-${K8S_VERSION}"
   vagrant ssh k8s1-${K8S_VERSION} -- kubectl label node k8s${i} cilium.io/ci-node=k8s${i} --overwrite
 done


### PR DESCRIPTION
Add a new script `test/vagrant-local-start.sh` that can be run in a
local development machine with minimal requirements.

Make image pulling more efficient by partially provisioning a new VM
image that is then duplicated for each k8s node. This way the
dependencies never need to be pulled more than once.

The local box file stored in `/tmp/` must be manually deleted for it
to be re-built on the next invocation of `vagrant-local-start.sh`.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9633)
<!-- Reviewable:end -->
