### PR TITLE
Improve 1.7 upgrade and nodeport documentation

### DIFF
--- a/Documentation/gettingstarted/nodeport.rst
+++ b/Documentation/gettingstarted/nodeport.rst
@@ -91,13 +91,6 @@ the cluster with the external IP (as destination IP), on the Service port,
 will be routed to one of the Service endpoints. ``externalIPs`` are not managed
 by Kubernetes and are the responsibility of the cluster administrator.
 
-If a service is defined with a ``externalIPs`` that belongs to the host where
-the service translation is being performed, the service translation is executed.
-In other words, if a pod tries to connect to an ``externalIP`` that does not
-belong to the host where it is hosted, the service translation does not occur
-and the traffic is sent to the external IP address without any service
-translation.
-
 Once configured, apply the DaemonSet file to deploy Cilium and verify that it
 has come up correctly:
 
@@ -132,3 +125,16 @@ deployed to see the routing being performed correctly:
     $ ip r a 192.0.2.233 via <node-ip>
     $ curl 192.0.2.233:82
     <html><body><h1>It works!</h1></body></html>
+
+
+Limitations
+###########
+
+Similar to kube-proxy, if a pod on a node attempts to initiate a connection to
+an ``externalIP`` and the external IP is assigned to a node in the cluster, the
+connection to the service will be translated and forwarded to a backend.
+However, if a pod attempts to initiate a connection to an ``externalIP`` which
+does not belong to a node in the cluster, the service will *NOT* be translated.
+Such traffic will be forwarded to the actual remote destination without
+translation. Incoming connections to a node are not affected by this logic and
+will perform service translation for all configured ``externalIP`` services.

--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -243,6 +243,24 @@ IMPORTANT: Changes required before upgrading to 1.7.0
 
 * Cilium has bumped the minimal kubernetes version supported to v1.11.0.
 
+* The ``kubernetes.io/cluster-service`` label has been removed from the Cilium
+  `DaemonSet` selector. Existing users must remove this label from their
+  `DaemonSet` specification to safely upgrade. If action is not taken to make
+  the selector labels consistent with the upgraded YAMLs, then the new
+  `DaemonSet` YAML which is created during upgrade will fail to apply.
+
+  *Highly recommended:*
+
+  The below instructions will remove the ``kubernetes.io/cluster-service``
+  label from the existing `DaemonSet` in the cluster without making any other
+  changes.
+
+  .. code:: bash
+
+     $ kubectl get ds -n kube-system cilium -o yaml > cilium-ds.yaml
+     $ sed -i '/kubernetes.io\/cluster-service: "true"/d' cilium-ds.yaml
+     $ kubectl apply -f cilium-ds.yaml --force
+
 * If ``kvstore`` is setup with ``etcd`` **and** TLS is enabled, the field name
   ``ca-file`` will have its usage deprecated and will be removed in Cilium v1.8.0.
   The new field name, ``trusted-ca-file``, can be used since Cilium v1.1.0.


### PR DESCRIPTION
* Document the steps necessary for handling the `kubernetes.io/cluster-service` label change in the Cilium `DaemonSet`
* Clarify the limitations on the `externalIP` service implementation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9634)
<!-- Reviewable:end -->
