### PR TITLE
Dockerfile: Use Envoy image that always resumes NPDS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:4c7b379792e67b2cf059cbe6509a6e56f4cda4f4 as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:7f6cab51ea2f4692a3e1067e1060f42818324bc2 as cilium-envoy
 
 #
 # Cilium incremental build. Should be fast given builder-deps is up-to-date!


### PR DESCRIPTION
Use an updated Envoy image that always resumes gRPC for NPDS after
having paused it for the duration of worker threads completing their
policy updates. This restores the earlier behavior of sending an ACK
for the NPDS also when the last listener is removed from Envoy.

Backporters: This depends on #9542 and #9608 being backported first.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9635)
<!-- Reviewable:end -->
