### PR TITLE
v1.6 backports 2019-11-19

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -758,6 +758,9 @@ type ApplyOptions struct {
 	FilePath  string
 	Namespace string
 	Force     bool
+	DryRun    bool
+	Output    string
+	Piped     string
 }
 
 // Apply applies the Kubernetes manifest located at path filepath.
@@ -768,14 +771,28 @@ func (kub *Kubectl) Apply(options ApplyOptions) *CmdRes {
 	} else {
 		force = "--force=false"
 	}
+
+	cmd := fmt.Sprintf("%s apply %s -f %s", KubectlCmd, force, options.FilePath)
+
+	if options.DryRun {
+		cmd = cmd + " --dry-run"
+	}
+
+	if len(options.Output) > 0 {
+		cmd = cmd + " -o " + options.Output
+	}
+
 	if len(options.Namespace) == 0 {
 		kub.logger.Debugf("applying %s", options.FilePath)
-		return kub.ExecMiddle(
-			fmt.Sprintf("%s apply %s -f %s", KubectlCmd, force, options.FilePath))
+	} else {
+		kub.logger.Debugf("applying %s in namespace %s", options.FilePath, options.Namespace)
+		cmd = cmd + " -n " + options.Namespace
 	}
-	kub.logger.Debugf("applying %s in namespace %s", options.FilePath, options.Namespace)
-	return kub.ExecMiddle(
-		fmt.Sprintf("%s apply %s -f  %s -n %s", KubectlCmd, force, options.FilePath, options.Namespace))
+
+	if len(options.Piped) > 0 {
+		cmd = options.Piped + " | " + cmd
+	}
+	return kub.ExecMiddle(cmd)
 }
 
 // ApplyDefault applies give filepath with other options set to default
@@ -952,9 +969,13 @@ func (kub *Kubectl) DeployPatch(original, patch string) error {
 		}
 	}
 
-	res = kub.ExecShort(fmt.Sprintf(
-		`%s patch --filename='%s' --patch "$(cat '%s')" --local -o yaml | kubectl apply -f -`,
-		KubectlCmd, original, patch))
+	res = kub.Apply(ApplyOptions{
+		FilePath: "-",
+		Force:    true,
+		Piped: fmt.Sprintf(
+			`%s patch --filename='%s' --patch "$(cat '%s')" --local -o yaml`,
+			KubectlCmd, original, patch),
+	})
 	if !res.WasSuccessful() {
 		debugYaml(original, patch)
 		return res.GetErr("Cilium manifest patch instalation failed")
@@ -989,11 +1010,18 @@ func (kub *Kubectl) ciliumInstall(dsPatchName, cmPatchName string, getK8sDescrip
 		// debugYaml only dumps the full created yaml file to the test output if
 		// the cilium manifest can not be created correctly.
 		debugYaml := func(original string) {
-			_ = kub.ExecMiddle(fmt.Sprintf("kubectl apply --filename='%s' --dry-run -o yaml", original))
+			kub.Apply(ApplyOptions{
+				FilePath: original,
+				DryRun:   true,
+				Output:   "yaml",
+			})
 		}
 
 		// validation 1st
-		res := kub.ExecMiddle(fmt.Sprintf("kubectl apply --filename='%s' --dry-run", original))
+		res := kub.Apply(ApplyOptions{
+			FilePath: original,
+			DryRun:   true,
+		})
 		if !res.WasSuccessful() {
 			debugYaml(original)
 			return res.GetErr("Cilium manifest validation fails")

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1416,7 +1416,7 @@ func (kub *Kubectl) WaitForCiliumInitContainerToFinish() error {
 		}
 		for _, pod := range podList.Items {
 			for _, v := range pod.Status.InitContainerStatuses {
-				if v.State.Terminated.Reason != "Completed" || v.State.Terminated.ExitCode != 0 {
+				if v.State.Terminated != nil && (v.State.Terminated.Reason != "Completed" || v.State.Terminated.ExitCode != 0) {
 					kub.logger.WithFields(logrus.Fields{
 						"podName":      pod.Name,
 						"currentState": v.State.String(),

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -421,7 +421,7 @@ func (kub *Kubectl) MicroscopeStart(microscopeOptions ...string) (error, func() 
 	cmd := fmt.Sprintf("%[1]s -ti -n %[2]s exec %[3]s -- %[4]s",
 		KubectlCmd, KubeSystemNamespace, microscope, microscopeCmdWithTimestamps)
 	microscopePath := ManifestGet(microscopeManifest)
-	_ = kub.Apply(microscopePath)
+	_ = kub.ApplyDefault(microscopePath)
 
 	err := kub.WaitforPods(
 		KubeSystemNamespace,
@@ -753,18 +753,27 @@ func (kub *Kubectl) Action(action ResourceLifeCycleAction, filePath string, name
 	return kub.ExecShort(fmt.Sprintf("%s %s -f %s -n %s", KubectlCmd, action, filePath, namespace[0]))
 }
 
-// Apply applies the Kubernetes manifest located at path filepath.
-func (kub *Kubectl) Apply(filePath string, namespace ...string) *CmdRes {
-	if len(namespace) == 0 {
-		kub.logger.Debugf("applying %s", filePath)
-		return kub.ExecMiddle(
-			fmt.Sprintf("%s apply -f  %s", KubectlCmd, filePath))
-	}
-	namespaceToApply := namespace[0]
-	kub.logger.Debugf("applying %s in namespace %s", filePath, namespaceToApply)
-	return kub.ExecMiddle(
-		fmt.Sprintf("%s apply -f  %s -n %s", KubectlCmd, filePath, namespaceToApply))
+// ApplyOptions stores options for kubectl apply command
+type ApplyOptions struct {
+	FilePath  string
+	Namespace string
+}
 
+// Apply applies the Kubernetes manifest located at path filepath.
+func (kub *Kubectl) Apply(options ApplyOptions) *CmdRes {
+	if len(options.Namespace) == 0 {
+		kub.logger.Debugf("applying %s", options.FilePath)
+		return kub.ExecMiddle(
+			fmt.Sprintf("%s apply -f %s", KubectlCmd, options.FilePath))
+	}
+	kub.logger.Debugf("applying %s in namespace %s", options.FilePath, options.Namespace)
+	return kub.ExecMiddle(
+		fmt.Sprintf("%s apply -f  %s -n %s", KubectlCmd, options.FilePath, options.Namespace))
+}
+
+// ApplyDefault applies give filepath with other options set to default
+func (kub *Kubectl) ApplyDefault(filePath string) *CmdRes {
+	return kub.Apply(ApplyOptions{FilePath: filePath})
 }
 
 // Create creates the Kubernetes kanifest located at path filepath.
@@ -983,7 +992,7 @@ func (kub *Kubectl) ciliumInstall(dsPatchName, cmPatchName string, getK8sDescrip
 			return res.GetErr("Cilium manifest validation fails")
 		}
 
-		res = kub.Apply(original)
+		res = kub.ApplyDefault(original)
 		if !res.WasSuccessful() {
 			debugYaml(original)
 			return res.GetErr("Cannot apply Cilium manifest")
@@ -1003,22 +1012,22 @@ func (kub *Kubectl) ciliumInstall(dsPatchName, cmPatchName string, getK8sDescrip
 		return err
 	}
 
-	cmdRes := kub.Apply(getK8sDescriptor(ciliumEtcdOperatorSA))
+	cmdRes := kub.ApplyDefault(getK8sDescriptor(ciliumEtcdOperatorSA))
 	if !cmdRes.WasSuccessful() {
 		return fmt.Errorf("Unable to deploy descriptor of etcd-operator SA %s: %s", ciliumEtcdOperatorSA, cmdRes.OutputPrettyPrint())
 	}
 
-	cmdRes = kub.Apply(getK8sDescriptor(ciliumEtcdOperatorRBAC))
+	cmdRes = kub.ApplyDefault(getK8sDescriptor(ciliumEtcdOperatorRBAC))
 	if !cmdRes.WasSuccessful() {
 		return fmt.Errorf("Unable to deploy descriptor of etcd-operator RBAC %s: %s", ciliumEtcdOperatorRBAC, cmdRes.OutputPrettyPrint())
 	}
 
-	cmdRes = kub.Apply(getK8sDescriptor(ciliumEtcdOperator))
+	cmdRes = kub.ApplyDefault(getK8sDescriptor(ciliumEtcdOperator))
 	if !cmdRes.WasSuccessful() {
 		return fmt.Errorf("Unable to deploy descriptor of etcd-operator %s: %s", ciliumEtcdOperator, cmdRes.OutputPrettyPrint())
 	}
 
-	_ = kub.Apply(getK8sDescriptor("cilium-operator-sa.yaml"))
+	_ = kub.ApplyDefault(getK8sDescriptor("cilium-operator-sa.yaml"))
 	err := kub.DeployPatch(getK8sDescriptor("cilium-operator.yaml"), getK8sDescriptorPatch("cilium-operator-patch.yaml"))
 	if err != nil {
 		return fmt.Errorf("Unable to deploy descriptor of cilium-operators: %s", err)
@@ -1069,7 +1078,7 @@ func (kub *Kubectl) ciliumInstallHelm(options []string) error {
 		return err
 	}
 
-	res := kub.Apply("cilium.yaml")
+	res := kub.ApplyDefault("cilium.yaml")
 	if !res.WasSuccessful() {
 		return res.GetErr("Unable to apply YAML")
 	}

--- a/test/helpers/policygen/models.go
+++ b/test/helpers/policygen/models.go
@@ -294,7 +294,7 @@ func (t *Target) CreateApplyManifest(spec *TestSpec) error {
 		t.PortNumber = 80
 		return nil
 	}
-	res := spec.Kub.Apply(manifestPath)
+	res := spec.Kub.ApplyDefault(manifestPath)
 	if !res.WasSuccessful() {
 		return fmt.Errorf("%s", res.CombineOutput())
 	}
@@ -490,7 +490,7 @@ func (t *TestSpec) ApplyManifest() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	res := t.Kub.Apply(t.GetManifestsPath())
+	res := t.Kub.ApplyDefault(t.GetManifestsPath())
 	if !res.WasSuccessful() {
 		return "", fmt.Errorf("%s", res.CombineOutput())
 	}
@@ -701,7 +701,7 @@ func (t *TestSpec) InvalidNetworkPolicyApply() (*cnpv2.CiliumNetworkPolicy, erro
 		return nil, fmt.Errorf("Network policy cannot be written prefix=%s: %s", t.Prefix, err)
 	}
 
-	res := t.Kub.Apply(filepath.Join(helpers.BasePath, t.NetworkPolicyName()))
+	res := t.Kub.ApplyDefault(filepath.Join(helpers.BasePath, t.NetworkPolicyName()))
 	if !res.WasSuccessful() {
 		return nil, fmt.Errorf("%s", res.CombineOutput())
 	}

--- a/test/k8sT/Chaos.go
+++ b/test/k8sT/Chaos.go
@@ -54,7 +54,7 @@ var _ = Describe("K8sChaosTest", func() {
 
 	Context("Connectivity demo application", func() {
 		BeforeEach(func() {
-			kubectl.Apply(demoDSPath).ExpectSuccess("DS deployment cannot be applied")
+			kubectl.ApplyDefault(demoDSPath).ExpectSuccess("DS deployment cannot be applied")
 
 			err := kubectl.WaitforPods(
 				helpers.DefaultNamespace, fmt.Sprintf("-l zgroup=testDS"), helpers.HelperTimeout)
@@ -178,7 +178,7 @@ var _ = Describe("K8sChaosTest", func() {
 		)
 
 		BeforeAll(func() {
-			kubectl.Apply(netperfManifest).ExpectSuccess("Netperf cannot be deployed")
+			kubectl.ApplyDefault(netperfManifest).ExpectSuccess("Netperf cannot be deployed")
 
 			err := kubectl.WaitforPods(
 				helpers.DefaultNamespace,

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -38,8 +38,8 @@ var _ = Describe("K8sDatapathConfig", func() {
 	})
 
 	BeforeEach(func() {
-		kubectl.Apply(demoDSPath).ExpectSuccess("cannot install Demo application")
-		kubectl.Apply(ipsecDSPath).ExpectSuccess("cannot install IPsec keys")
+		kubectl.ApplyDefault(demoDSPath).ExpectSuccess("cannot install Demo application")
+		kubectl.ApplyDefault(ipsecDSPath).ExpectSuccess("cannot install IPsec keys")
 		kubectl.NodeCleanMetadata()
 	})
 

--- a/test/k8sT/KafkaPolicies.go
+++ b/test/k8sT/KafkaPolicies.go
@@ -129,7 +129,7 @@ var _ = Describe("K8sKafkaPolicyTest", func() {
 			kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 			DeployCiliumAndDNS(kubectl)
 
-			kubectl.Apply(demoPath)
+			kubectl.ApplyDefault(demoPath)
 			err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=kafkaTestApp", helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Kafka Pods are not ready after timeout")
 

--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -299,14 +299,14 @@ var _ = Describe("NightlyEpsMeasurement", func() {
 		It("Test TCP Keepalive with L7 Policy", func() {
 			kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 			manifest := helpers.ManifestGet(netcatDsManifest)
-			kubectl.Apply(manifest).ExpectSuccess("Cannot apply netcat ds")
+			kubectl.ApplyDefault(manifest).ExpectSuccess("Cannot apply netcat ds")
 			defer kubectl.Delete(manifest)
 			testConnectivity()
 		})
 
 		It("Test TCP Keepalive without L7 Policy", func() {
 			manifest := helpers.ManifestGet(netcatDsManifest)
-			kubectl.Apply(manifest).ExpectSuccess("Cannot apply netcat ds")
+			kubectl.ApplyDefault(manifest).ExpectSuccess("Cannot apply netcat ds")
 			defer kubectl.Delete(manifest)
 			kubectl.Exec(fmt.Sprintf(
 				"%s delete --all cnp -n %s", helpers.KubectlCmd, helpers.DefaultNamespace))
@@ -375,7 +375,7 @@ var _ = Describe("NightlyExamples", func() {
 		})
 
 		AfterAll(func() {
-			_ = kubectl.Apply(helpers.DNSDeployment())
+			_ = kubectl.ApplyDefault(helpers.DNSDeployment())
 		})
 
 		for _, image := range helpers.NightlyStableUpgradesFrom {
@@ -415,7 +415,7 @@ var _ = Describe("NightlyExamples", func() {
 			clientPod := "terminal-87"
 
 			By("Testing the example config")
-			kubectl.Apply(AppManifest).ExpectSuccess("cannot install the GRPC application")
+			kubectl.ApplyDefault(AppManifest).ExpectSuccess("cannot install the GRPC application")
 
 			err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=grpcExample", helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Pods are not ready after timeout")

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -149,7 +149,7 @@ var _ = Describe("K8sPolicyTest", func() {
 		BeforeAll(func() {
 			namespaceForTest = helpers.GenerateNamespaceForTest()
 			kubectl.NamespaceCreate(namespaceForTest).ExpectSuccess("could not create namespace")
-			kubectl.Apply(demoPath, namespaceForTest).ExpectSuccess("could not create resource")
+			kubectl.Apply(helpers.ApplyOptions{FilePath: demoPath, Namespace: namespaceForTest}).ExpectSuccess("could not create resource")
 
 			err := kubectl.WaitforPods(namespaceForTest, "-l zgroup=testapp", helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Test pods are not ready after timeout")
@@ -266,7 +266,7 @@ var _ = Describe("K8sPolicyTest", func() {
 		It("Invalid Policy report status correctly", func() {
 			manifest := helpers.ManifestGet("invalid_cnp.yaml")
 			cnpName := "foo"
-			kubectl.Apply(manifest, namespaceForTest).ExpectSuccess("Cannot apply policy manifest")
+			kubectl.Apply(helpers.ApplyOptions{FilePath: manifest, Namespace: namespaceForTest}).ExpectSuccess("Cannot apply policy manifest")
 
 			body := func() bool {
 				cnp := kubectl.GetCNP(namespaceForTest, cnpName)
@@ -707,7 +707,7 @@ var _ = Describe("K8sPolicyTest", func() {
 		var err error
 
 		BeforeEach(func() {
-			kubectl.Apply(helpers.ManifestGet(deployment))
+			kubectl.ApplyDefault(helpers.ManifestGet(deployment))
 			ciliumPods, err := kubectl.GetCiliumPods(helpers.KubeSystemNamespace)
 			Expect(err).To(BeNil(), "cannot retrieve Cilium Pods")
 			Expect(ciliumPods).ShouldNot(BeEmpty(), "cannot retrieve Cilium pods")
@@ -879,10 +879,10 @@ EOF`, k, v)
 			res = kubectl.Exec(fmt.Sprintf("kubectl label namespaces/%[1]s nslabel=%[1]s", secondNS))
 			res.ExpectSuccess("cannot create namespace labels")
 
-			res = kubectl.Apply(demoManifest)
+			res = kubectl.ApplyDefault(demoManifest)
 			res.ExpectSuccess("unable to apply manifest")
 
-			res = kubectl.Apply(demoPath)
+			res = kubectl.ApplyDefault(demoPath)
 			res.ExpectSuccess("unable to apply manifest")
 
 			err := kubectl.WaitforPods(secondNS, "-l zgroup=testapp", helpers.HelperTimeout)

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -124,9 +124,9 @@ var _ = Describe("K8sServicesTest", func() {
 		)
 
 		BeforeEach(func() {
-			res := kubectl.Apply(demoYAML)
+			res := kubectl.ApplyDefault(demoYAML)
 			res.ExpectSuccess("unable to apply %s", demoYAML)
-			res = kubectl.Apply(echoSVCYAML)
+			res = kubectl.ApplyDefault(echoSVCYAML)
 			res.ExpectSuccess("unable to apply %s", echoSVCYAML)
 		})
 
@@ -178,7 +178,7 @@ var _ = Describe("K8sServicesTest", func() {
 		)
 
 		BeforeAll(func() {
-			res := kubectl.Apply(demoYAML)
+			res := kubectl.ApplyDefault(demoYAML)
 			res.ExpectSuccess("Unable to apply %s", demoYAML)
 		})
 
@@ -356,8 +356,8 @@ var _ = Describe("K8sServicesTest", func() {
 		)
 
 		BeforeAll(func() {
-			kubectl.Apply(servicePath).ExpectSuccess("cannot install external service")
-			kubectl.Apply(podPath).ExpectSuccess("cannot install pod path")
+			kubectl.ApplyDefault(servicePath).ExpectSuccess("cannot install external service")
+			kubectl.ApplyDefault(podPath).ExpectSuccess("cannot install pod path")
 
 			err := kubectl.WaitforPods(helpers.DefaultNamespace, "", helpers.HelperTimeout)
 			Expect(err).To(BeNil(), "Pods are not ready after timeout")
@@ -410,7 +410,7 @@ var _ = Describe("K8sServicesTest", func() {
 		}
 
 		It("To Services first endpoint creation", func() {
-			res := kubectl.Apply(endpointPath)
+			res := kubectl.ApplyDefault(endpointPath)
 			res.ExpectSuccess()
 
 			applyPolicy(policyPath)
@@ -423,7 +423,7 @@ var _ = Describe("K8sServicesTest", func() {
 
 		It("To Services first policy", func() {
 			applyPolicy(policyPath)
-			res := kubectl.Apply(endpointPath)
+			res := kubectl.ApplyDefault(endpointPath)
 			res.ExpectSuccess()
 
 			validateEgress()
@@ -435,7 +435,7 @@ var _ = Describe("K8sServicesTest", func() {
 
 		It("To Services first endpoint creation match service by labels", func() {
 			By("Creating Kubernetes Endpoint")
-			res := kubectl.Apply(endpointPath)
+			res := kubectl.ApplyDefault(endpointPath)
 			res.ExpectSuccess()
 
 			applyPolicy(policyLabeledPath)
@@ -451,7 +451,7 @@ var _ = Describe("K8sServicesTest", func() {
 			applyPolicy(policyLabeledPath)
 
 			By("Creating Kubernetes Endpoint")
-			res := kubectl.Apply(endpointPath)
+			res := kubectl.ApplyDefault(endpointPath)
 			res.ExpectSuccess()
 
 			validateEgress()

--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -180,7 +180,7 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldVersion, newV
 		Expect(err).To(BeNil(), "Cilium %q was not able to be deployed", oldVersion)
 
 		By("Installing kube-dns")
-		_ = kubectl.Apply(helpers.DNSDeployment())
+		_ = kubectl.ApplyDefault(helpers.DNSDeployment())
 
 		// Cilium is only ready if kvstore is ready, the kvstore is ready if
 		// kube-dns is running.
@@ -267,7 +267,7 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldVersion, newV
 
 		By("Creating some endpoints and L7 policy")
 
-		res := kubectl.Apply(demoPath)
+		res := kubectl.ApplyDefault(demoPath)
 		ExpectWithOffset(1, res).To(helpers.CMDSuccess(), "cannot apply dempo application")
 
 		err = kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=testapp", timeout)
@@ -281,12 +281,12 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldVersion, newV
 
 		By("Creating service and clients for migration")
 
-		res = kubectl.Apply(migrateSVCServer)
+		res = kubectl.ApplyDefault(migrateSVCServer)
 		ExpectWithOffset(1, res).To(helpers.CMDSuccess(), "cannot apply migrate-svc-server")
 		err = kubectl.WaitforPods(helpers.DefaultNamespace, "-l app=migrate-svc-server", timeout)
 		Expect(err).Should(BeNil(), "migrate-svc-server pods are not ready after timeout")
 
-		res = kubectl.Apply(migrateSVCClient)
+		res = kubectl.ApplyDefault(migrateSVCClient)
 		ExpectWithOffset(1, res).To(helpers.CMDSuccess(), "cannot apply migrate-svc-client")
 		err = kubectl.WaitforPods(helpers.DefaultNamespace, "-l app=migrate-svc-client", timeout)
 		Expect(err).Should(BeNil(), "migrate-svc-client pods are not ready after timeout")
@@ -329,7 +329,7 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldVersion, newV
 			"> cilium-preflight.yaml")
 		ExpectWithOffset(1, res).To(helpers.CMDSuccess(), "Unable to generate preflight YAML")
 
-		res = kubectl.Apply("cilium-preflight.yaml")
+		res = kubectl.ApplyDefault("cilium-preflight.yaml")
 		ExpectWithOffset(1, res).To(helpers.CMDSuccess(), "Unable to deploy preflight manifest")
 		ExpectCiliumPreFlightInstallReady(kubectl)
 

--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -108,9 +108,6 @@ func ExpectCiliumPreFlightInstallReady(vm *helpers.Kubectl) {
 
 // DeployCiliumAndDNS deploys DNS and cilium into the kubernetes cluster
 func DeployCiliumAndDNS(vm *helpers.Kubectl) {
-	By("Installing DNS Deployment")
-	_ = vm.Apply(helpers.DNSDeployment())
-
 	DeployCiliumOptionsAndDNS(vm, []string{})
 }
 
@@ -123,12 +120,12 @@ func DeployCiliumOptionsAndDNS(vm *helpers.Kubectl, options []string) {
 	ExpectCiliumRunning(vm)
 
 	By("Installing DNS Deployment")
-	_ = vm.Apply(helpers.DNSDeployment())
+	_ = vm.ApplyDefault(helpers.DNSDeployment())
 
 	switch helpers.GetCurrentIntegration() {
 	case helpers.CIIntegrationFlannel:
 		By("Installing Flannel")
-		vm.Apply(helpers.GetFilePath("../examples/kubernetes/addons/flannel/flannel.yaml"))
+		vm.ApplyDefault(helpers.GetFilePath("../examples/kubernetes/addons/flannel/flannel.yaml"))
 	default:
 	}
 

--- a/test/k8sT/demos.go
+++ b/test/k8sT/demos.go
@@ -99,10 +99,10 @@ var _ = Describe("K8sDemosTest", func() {
 
 		By("Applying deployments")
 
-		res := kubectl.Apply(deathStarYAMLLink)
+		res := kubectl.ApplyDefault(deathStarYAMLLink)
 		res.ExpectSuccess("unable to apply %s: %s", deathStarYAMLLink, res.CombineOutput())
 
-		res = kubectl.Apply(xwingYAMLLink)
+		res = kubectl.ApplyDefault(xwingYAMLLink)
 		res.ExpectSuccess("unable to apply %s: %s", xwingYAMLLink, res.CombineOutput())
 
 		By("Waiting for pods to be ready")

--- a/test/k8sT/fqdn.go
+++ b/test/k8sT/fqdn.go
@@ -51,11 +51,11 @@ var _ = Describe("K8sFQDNTest", func() {
 		By("Applying bind deployment")
 		bindManifest = helpers.ManifestGet("bind_deployment.yaml")
 
-		res := kubectl.Apply(bindManifest)
+		res := kubectl.ApplyDefault(bindManifest)
 		res.ExpectSuccess("Bind config cannot be deployed")
 
 		By("Applying demo manifest")
-		res = kubectl.Apply(demoManifest)
+		res = kubectl.ApplyDefault(demoManifest)
 		res.ExpectSuccess("Demo config cannot be deployed")
 
 		err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=testapp", helpers.HelperTimeout)

--- a/test/k8sT/istio.go
+++ b/test/k8sT/istio.go
@@ -93,7 +93,7 @@ var _ = Describe("K8sIstioTest", func() {
 
 		By("Creating the Istio CRDs")
 
-		res = kubectl.Apply(istioCRDYAMLPath)
+		res = kubectl.ApplyDefault(istioCRDYAMLPath)
 		res.ExpectSuccess("unable to create Istio CRDs")
 
 		By("Waiting for Istio CRDs to be ready")
@@ -103,7 +103,7 @@ var _ = Describe("K8sIstioTest", func() {
 
 		By("Creating the Istio system PODs")
 
-		res = kubectl.Apply(istioYAMLPath)
+		res = kubectl.ApplyDefault(istioYAMLPath)
 		res.ExpectSuccess("unable to create Istio resources")
 	})
 

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -254,7 +254,7 @@ var _ = BeforeAll(func() {
 		}
 		kubectl := helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 
-		kubectl.Apply(helpers.GetFilePath("../examples/kubernetes/addons/prometheus/prometheus.yaml"))
+		kubectl.ApplyDefault(helpers.GetFilePath("../examples/kubernetes/addons/prometheus/prometheus.yaml"))
 
 		go kubectl.PprofReport()
 	}


### PR DESCRIPTION
 * PR: 9552 -- [CI] Use force flag in Cilium install apply command (@nebril) --https://github.com/cilium/cilium/pull/9552
 * PR: 9573 -- Move missed kubectl apply calls to `Apply` calls (@nebril) -- https://github.com/cilium/cilium/pull/9573
 * PR: 9605 -- Add nil check for init container terminated state (@nebril) -- https://github.com/cilium/cilium/pull/9605

When you have backported the above commits, you can update the PR labels via this command:

```
$ for pr in 9519 9552 9573 9605; do contrib/backporting/set-labels.py $pr pending 1.6; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9636)
<!-- Reviewable:end -->
