### PR TITLE
pkg/endpoint: delete _next directories during restore

### DIFF
--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -179,6 +179,7 @@ boolean
 bpf
 bpftool
 bpftrace
+breakpoint
 browsable
 bugfix
 bugfixes

--- a/pkg/endpoint/directory.go
+++ b/pkg/endpoint/directory.go
@@ -26,6 +26,12 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	nextDirectorySuffix       = "_next"
+	nextFailedDirectorySuffix = "_next_fail"
+	backupDirectorySuffix     = "_stale"
+)
+
 // DirectoryPath returns the directory name for this endpoint bpf program.
 func (e *Endpoint) DirectoryPath() string {
 	return filepath.Join(".", fmt.Sprintf("%d", e.ID))
@@ -34,7 +40,7 @@ func (e *Endpoint) DirectoryPath() string {
 // FailedDirectoryPath returns the directory name for this endpoint bpf program
 // failed builds.
 func (e *Endpoint) FailedDirectoryPath() string {
-	return filepath.Join(".", fmt.Sprintf("%d%s", e.ID, "_next_fail"))
+	return filepath.Join(".", fmt.Sprintf("%d%s", e.ID, nextFailedDirectorySuffix))
 }
 
 // StateDirectoryPath returns the directory name for this endpoint bpf program.
@@ -45,11 +51,11 @@ func (e *Endpoint) StateDirectoryPath() string {
 // NextDirectoryPath returns the directory name for this endpoint bpf program
 // next bpf builds.
 func (e *Endpoint) NextDirectoryPath() string {
-	return filepath.Join(".", fmt.Sprintf("%d%s", e.ID, "_next"))
+	return filepath.Join(".", fmt.Sprintf("%d%s", e.ID, nextDirectorySuffix))
 }
 
 func (e *Endpoint) backupDirectoryPath() string {
-	return e.DirectoryPath() + "_stale"
+	return e.DirectoryPath() + backupDirectorySuffix
 }
 
 // synchronizeDirectories moves the files related to endpoint BPF program

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -683,7 +683,7 @@ func FilterEPDir(dirFiles []os.FileInfo) []string {
 	for _, file := range dirFiles {
 		if file.IsDir() {
 			_, err := strconv.ParseUint(file.Name(), 10, 16)
-			if err == nil || strings.HasSuffix(file.Name(), "_next") || strings.HasSuffix(file.Name(), "_next_fail") {
+			if err == nil || strings.HasSuffix(file.Name(), nextDirectorySuffix) || strings.HasSuffix(file.Name(), nextFailedDirectorySuffix) {
 				eptsID = append(eptsID, file.Name())
 			}
 		}


### PR DESCRIPTION
This patch detects and deletes during endpoint restoration,
endpoint directories that match `${EPID}_next` or `${EPID}_next_fail`
and for which there already exists an endpoint directory `${EPID}`.
The idea is to consider such a directory stale (e.g the process was
terminated while regenerating endpoint `${EPID}` - in which case
there is no need to attempt to restore an endpoint from them.

Fixes #9600

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9638)
<!-- Reviewable:end -->
