### PR TITLE
README: Add link to Hubble

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -147,6 +147,12 @@ tooling to provide:
 - Metrics export via Prometheus: Key metrics are exported via Prometheus for
   integration with your existing dashboards.
 
+- Hubble_: An observability platform specifically written for Cilium. It
+  provides service dependency maps, operational monitoring and alerting,
+  and application and security visibility based on flow logs.
+
+.. _Hubble: https://github.com/cilium/hubble/
+
 Integrations
 ------------
 


### PR DESCRIPTION
Adds a link to and a short description of Hubble in the *Monitoring and Troubleshooting* section of the README.

Suggestions regarding wording welcome.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9639)
<!-- Reviewable:end -->
