### PR TITLE
Pin kubectl version in ginkgo vms

### DIFF
--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -237,7 +237,7 @@ case $K8S_VERSION in
             kubernetes-cni=${KUBERNETES_CNI_VERSION}* \
             kubelet=${K8S_FULL_VERSION}* \
             kubeadm=${K8S_FULL_VERSION}* \
-            kubectl=${K8S_FULL_VERSION}*
+            kubectl="1.16.3"*
         ;;
 #   "1.16")
 #       install_k8s_using_binary "v${K8S_FULL_VERSION}" "v${KUBERNETES_CNI_VERSION}"


### PR DESCRIPTION
In master, we are using kubectl on host.

In 1.6 branch we are still using kubectl from inside the vm. This change
cause newer version of kubectl to be installed in ginkgo vms during
provisioning.

This is done to make use of bugfix for
https://github.com/kubernetes/kubernetes/issues/66390
which caused backports to fail our CI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9640)
<!-- Reviewable:end -->
