### PR TITLE
Add missing words to spelling_wordlist

### DIFF
--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -179,6 +179,7 @@ boolean
 bpf
 bpftool
 bpftrace
+breakpoint
 browsable
 bugfix
 bugfixes
@@ -396,6 +397,7 @@ newprotoparser
 nfp
 nftables
 nodeX
+observability
 onData
 onwards
 opcodes


### PR DESCRIPTION
Signed-off-by: Vlad Ungureanu <vladu@palantir.com>

When running `make` locally it throws:
```
make[2]: Entering directory '/home/vladu/code/go/src/github.com/cilium/cilium/Documentation'
(sphinx-build -b spelling -d "_build/doctrees" "." "_build/spelling" -q -E  2>&1 && touch check-build.ok) > _build/warnings.txt

Please fix the following spelling mistakes:
* Documentation/contributing/testing/e2e.rst:407: (breakpoint)
* Documentation/intro.rst:109: (observability)
If the words are not misspelled, run:
Documentation/update-spelling_wordlist.sh breakpoint observability

Makefile:68: recipe for target 'check-build' failed
make[2]: *** [check-build] Error 1
make[2]: Leaving directory '/home/vladu/code/go/src/github.com/cilium/cilium/Documentation'
Makefile:438: recipe for target 'check-docs' failed
make[1]: *** [check-docs] Error 2
make[1]: Leaving directory '/home/vladu/code/go/src/github.com/cilium/cilium'
Makefile:443: recipe for target 'postcheck' failed
make: *** [postcheck] Error 2
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9643)
<!-- Reviewable:end -->
