### PR TITLE
cilium: lock GC walks for global CT maps to serialize deletions

### DIFF
--- a/pkg/endpoint/fqdn.go
+++ b/pkg/endpoint/fqdn.go
@@ -36,7 +36,6 @@ func (e *Endpoint) MarkDNSCTEntry(dstIP net.IP, now time.Time) {
 	}
 
 	e.DNSZombies.MarkAlive(now, dstIP)
-	e.SyncEndpointHeaderFile() // This is behind a rate-limit trigger
 }
 
 // MarkCTGCTime is the START time of a GC run. It is used by the DNS garbage


### PR DESCRIPTION
We've seen reports where many goroutines walk the CT map concurrently in order to
erase data from it, namely (*Endpoint).scrubIPsInConntrackTableLocked() seems to
be called from i) REST API handler via (*PutEndpointID).ServeHTTP() ->
deleteEndpointQuiet() -> LeaveLocked(), and ii) (*Endpoint).runPreCompilationSteps().
This is suboptimal as iterations through the BPF map could evict keys the other
routines are currently holding and therefore enforcing restarts of the walk until
we hit the stats.MaxEntries limit of the map w/o having finished the regular walk
in DumpReliablyWithCallback().

Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9645)
<!-- Reviewable:end -->
