### PR TITLE
[1.6 test] cilium: lock GC walks for global CT maps to serialize deletions

### DIFF
--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/nat"
@@ -91,6 +92,8 @@ const (
 	metricsAlive   = "alive"
 	metricsDeleted = "deleted"
 )
+
+var globalDeleteLock [MapTypeMax]lock.Mutex
 
 type NatMap interface {
 	Open() error
@@ -325,8 +328,11 @@ func doGC6(m *Map, filter *GCFilter) gcStats {
 			log.Warningf("Encountered unknown type while scanning conntrack table: %v", reflect.TypeOf(key))
 		}
 	}
-	stats.dumpError = m.DumpReliablyWithCallback(filterCallback, stats.DumpStats)
 
+	// See doGC4() comment.
+	globalDeleteLock[m.mapType].Lock()
+	stats.dumpError = m.DumpReliablyWithCallback(filterCallback, stats.DumpStats)
+	globalDeleteLock[m.mapType].Unlock()
 	return stats
 }
 
@@ -399,8 +405,12 @@ func doGC4(m *Map, filter *GCFilter) gcStats {
 			log.Warningf("Encountered unknown type while scanning conntrack table: %v", reflect.TypeOf(key))
 		}
 	}
-	stats.dumpError = m.DumpReliablyWithCallback(filterCallback, stats.DumpStats)
 
+	// We serialize the deletions in order to avoid forced map walk restarts
+	// when keys are being evicted underneath us from concurrent go routines.
+	globalDeleteLock[m.mapType].Lock()
+	stats.dumpError = m.DumpReliablyWithCallback(filterCallback, stats.DumpStats)
+	globalDeleteLock[m.mapType].Unlock()
 	return stats
 }
 


### PR DESCRIPTION
We've seen reports where many goroutines walk the CT map concurrently in order to
erase data from it, namely (*Endpoint).scrubIPsInConntrackTableLocked() seems to
be called from i) REST API handler via (*PutEndpointID).ServeHTTP() ->
deleteEndpointQuiet() -> LeaveLocked(), and ii) (*Endpoint).runPreCompilationSteps().
This is suboptimal as iterations through the BPF map could evict keys the other
routines are currently holding and therefore enforcing restarts of the walk until
we hit the stats.MaxEntries limit of the map w/o having finished the regular walk
in DumpReliablyWithCallback().

Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9647)
<!-- Reviewable:end -->
