### PR TITLE
Connection aware DNS proxy fixups

### DIFF
--- a/daemon/fqdn.go
+++ b/daemon/fqdn.go
@@ -267,10 +267,11 @@ func (d *Daemon) bootstrapFQDN(restoredEndpoints *endpointRestoreState, preCache
 		// Upgrades from old ciliums have this nil
 		if restoredEP.DNSHistory != nil {
 			globalCache.UpdateFromCache(restoredEP.DNSHistory, []string{})
+
 			// GC any connections that have expired, but propagate it to the zombies
 			// list. DNSCache.GC can handle a nil DNSZombies parameter. We use the
 			// actual now time because we are checkpointing at restore time.
-			globalCache.GC(now, restoredEP.DNSZombies)
+			restoredEP.DNSHistory.GC(now, restoredEP.DNSZombies)
 		}
 
 		if restoredEP.DNSZombies != nil {


### PR DESCRIPTION
- Correctly GC endpoint DNS cache on restore 
The older code accidentally GCed the global cache, instead of the endpoint specific cache, during endpoint restore. This also caused the GC zombie cascade to happen incorrectly, as the global cache is already empty/GCed.

- Remove zombies when a new DNS lookup has the same IP
To avoid duplicating zombies with live DNS cache entries, when we insert a new DNS lookup into the cache, we also clear any zombies with the same name -> IP mapping.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9648)
<!-- Reviewable:end -->
