### PR TITLE
Deprecate/Delete support for monitor v1.0 socket

### DIFF
--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -311,6 +311,8 @@ Removed options
 * ``docker`` and ``e``: This flags has been removed as Cilium no longer requires
   container runtime integrations to manage containers' networks.
 
+* All code associated with ``monitor v1.0`` socket handling has been removed.
+
 .. _1.6_upgrade_notes:
 
 1.6 Upgrade Notes

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -55,11 +55,6 @@ const (
 	// SockPathEnv is the environment variable to overwrite SockPath
 	SockPathEnv = "CILIUM_SOCK"
 
-	// MonitorSockPath1_0 is the path to the UNIX domain socket used to
-	// distribute BPF and agent events to listeners.
-	// This is the 1.0 protocol version.
-	MonitorSockPath1_0 = RuntimePath + "/monitor.sock"
-
 	// MonitorSockPath1_2 is the path to the UNIX domain socket used to
 	// distribute BPF and agent events to listeners.
 	// This is the 1.2 protocol version.

--- a/pkg/monitor/agent/listener/listener.go
+++ b/pkg/monitor/agent/listener/listener.go
@@ -35,9 +35,6 @@ const (
 	// VersionUnsupported is here for use in error returns etc.
 	VersionUnsupported = Version("unsupported")
 
-	// Version1_0 is the API 1.0 version of the protocol (see above).
-	Version1_0 = Version("1.0")
-
 	// Version1_2 is the API 1.0 version of the protocol (see above).
 	Version1_2 = Version("1.2")
 )


### PR DESCRIPTION
The monitor v1.0 socket protocol has not been used since Cilium
v1.2, which is well past support so we should be able to remove
all code associated with monitor v1.0 socket handling as per
the recomendation.

Fixes: #8955

Signed-off-by: Swaminathan Vasudevan <svasudevan@suse.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9650)
<!-- Reviewable:end -->
