### PR TITLE
Lower default FQDN TTLs and update docs

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -149,7 +149,7 @@ cilium-agent [flags]
       --tofqdns-enable-poller                                 Enable proactive polling of DNS names in toFQDNs.matchName rules.
       --tofqdns-enable-poller-events                          Emit DNS responses seen by the DNS poller as Monitor events, if the poller is enabled. (default true)
       --tofqdns-endpoint-max-ip-per-hostname int              Maximum number of IPs to maintain per FQDN name for each endpoint (default 50)
-      --tofqdns-min-ttl int                                   The minimum time, in seconds, to use DNS data for toFQDNs policies. (default 3600 when --tofqdns-enable-poller, 604800 otherwise)
+      --tofqdns-min-ttl int                                   The minimum time, in seconds, to use DNS data for toFQDNs policies. (default 600 when --tofqdns-enable-poller, 3600 otherwise)
       --tofqdns-pre-cache string                              DNS cache data at this path is preloaded on agent startup
       --tofqdns-proxy-port int                                Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port.
       --tofqdns-proxy-response-max-delay duration             The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information. (default 50ms)

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -381,6 +381,7 @@ mul
 multi
 multicore
 multinode
+musl
 mysql
 namespace
 namespaced

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -90,12 +90,12 @@ const (
 
 	// ToFQDNsMinTTL is the default lower bound for TTLs used with ToFQDNs rules.
 	// This or ToFQDNsMinTTLPoller is used in DaemonConfig.Populate
-	ToFQDNsMinTTL = 604800 // 1 week in seconds
+	ToFQDNsMinTTL = 3600 // 1 hour in seconds
 
 	// ToFQDNsMinTTLPoller is the default lower bound for TTLs used with ToFQDNs
 	// rules when the poller is enabled.
 	// This or ToFQDNsMinTTL is used in DaemonConfig.Populate
-	ToFQDNsMinTTLPoller = 3600 // 1 hour in seconds
+	ToFQDNsMinTTLPoller = 600 // 10 minutes in seconds
 
 	// ToFQDNsMaxIPsPerHost defines the maximum number of IPs to maintain
 	// for each FQDN name in an endpoint's FQDN cache


### PR DESCRIPTION
The TTL can now be much shorter because we rely on the zombie management to keep in-use IPs around. I chose to lower it only to 1 hour but it can go much lower, and I'm happy to go further.

I also updated the docs to mention the zombies along with how to handle Alpine/musl and DNS Refused. I'm not sure that the latter is easy to find, though. The section is pretty non-descriptive :/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9653)
<!-- Reviewable:end -->
