### PR TITLE
misc: bump net-next vagrant box version

### DIFF
--- a/vagrant_box_defaults.rb
+++ b/vagrant_box_defaults.rb
@@ -3,6 +3,6 @@
 Vagrant.require_version ">= 2.2.0"
 
 $SERVER_BOX = "cilium/ubuntu-dev"
-$SERVER_VERSION= "166"
+$SERVER_VERSION= "167"
 $NETNEXT_SERVER_BOX= "cilium/ubuntu-next"
-$NETNEXT_SERVER_VERSION= "44"
+$NETNEXT_SERVER_VERSION= "45"


### PR DESCRIPTION
Add the latest net-next kernel to our CI in order to provide more test
exposure for the recently merged set [0].

  [0] https://lore.kernel.org/bpf/cover.1574452833.git.daniel@iogearbox.net/

Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9657)
<!-- Reviewable:end -->
