### PR TITLE
helm: Fix bug to disable health-checks in chaining mode

### DIFF
--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -292,7 +292,7 @@ data:
 {{- if .Values.global.kubeConfigPath }}
   k8s-kubeconfig-path: {{ .Values.global.kubeConfigPath | quote }}
 {{- end }}
-{{- if.Values.global.chainingMode }}
+{{- if not (eq .Values.global.cni.chainingMode "none") }}
   # Chaining mode was enabled, disabling health checking
   enable-endpoint-health-checking: "false"
 {{- end }}


### PR DESCRIPTION
Endpoint healthchecks fail in these modes and should be disabled. The
helm charts accounted for this but it was incorrectly triggered
previously.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9658)
<!-- Reviewable:end -->
