### PR TITLE
cosmetic: Improve identity / allocator logs

### DIFF
--- a/daemon/identity.go
+++ b/daemon/identity.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -61,6 +61,8 @@ func newGetIdentityIDHandler(c *cache.CachingIdentityAllocator) GetIdentityIDHan
 }
 
 func (h *getIdentityID) Handle(params GetIdentityIDParams) middleware.Responder {
+	log.WithField(logfields.Params, logfields.Repr(params)).Debug("GET /identity/<ID> request")
+
 	nid, err := identity.ParseNumericIdentity(params.ID)
 	if err != nil {
 		return NewGetIdentityIDBadRequest()

--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -377,7 +377,6 @@ func (k *kvstoreBackend) UpdateKeyIfLocked(ctx context.Context, id idpool.ID, ke
 // not guard against concurrent releases. This is currently guarded by
 // Allocator.slaveKeysMutex when called from pkg/allocator.Allocator.Release.
 func (k *kvstoreBackend) Release(ctx context.Context, key allocator.AllocatorKey) (err error) {
-	log.WithField(fieldKey, key).Info("Releasing key")
 	valueKey := path.Join(k.valuePrefix, kvstore.Encode(key.GetKey()), k.suffix)
 	log.WithField(fieldKey, key).Info("Released last local use of key, invoking global release")
 


### PR DESCRIPTION
The allocator log here was duplicated with one that follows two lines
down; and one of the identity API calls was missing a debug log for the
calls.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9662)
<!-- Reviewable:end -->
