### PR TITLE
.github: Clarify release-notes section

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,5 +14,5 @@ Please ensure your pull request adheres to the following guidelines:
 Fixes: #issue-number
 
 ```release-note
-<!-- Enter the release note text here if needed -->
+<!-- Enter the release note text here if needed or remove this section! -->
 ```


### PR DESCRIPTION
The release-notes section must either exist with a valid release note,
or be removed (so that the relnotes script pulls the PR title). If it
exists with the dummy text, then the relnotes script will populate the
release notes with this nonsense text instead of the PR title.

(Alternative would be to put a unique identifier in this line which the relnotes script could ignore, but I thought this might be easier as long as people actually pay attention to what it says..)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9664)
<!-- Reviewable:end -->
