### PR TITLE
test: Support external DNS lookups also for k8s-1.16

### DIFF
--- a/test/provision/manifest/1.16/coredns_deployment.yaml
+++ b/test/provision/manifest/1.16/coredns_deployment.yaml
@@ -63,6 +63,11 @@ metadata:
       addonmanager.kubernetes.io/mode: EnsureExists
 data:
   Corefile: |
+    cilium.test:53 {
+        forward . 10.96.0.100:53 {
+            max_fails 0
+        }
+    }
     .:53 {
         log
         errors
@@ -74,7 +79,7 @@ data:
             upstream
             fallthrough in-addr.arpa ip6.arpa
         }
-        forward cilium.test 10.96.0.100:53 {
+        forward . /etc/resolv.conf {
             max_fails 0
         }
         prometheus :9153


### PR DESCRIPTION
Allow coredns to proxy DNS lookups to external domains also in k8s 1.16.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9666)
<!-- Reviewable:end -->
