### PR TITLE
operator: add ccnp event watcher to cilium operator

### DIFF
--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -19,6 +19,7 @@ cilium-operator [flags]
       --aws-client-burst int                   Burst value allowed for the AWS client used by the AWS ENI IPAM (default 4)
       --aws-client-qps float                   Queries per second limit for the AWS client used by the AWS ENI IPAM (default 20)
       --aws-release-excess-ips                 Enable releasing excess free IP addresses from AWS ENI.
+      --ccnp-node-status-gc                    Enable CiliumClusterwideNetworkPolicy Status garbage collection for nodes which have been removed from the cluster (default true)
       --cilium-endpoint-gc                     Enable CiliumEndpoint garbage collector (default true)
       --cilium-endpoint-gc-interval duration   GC interval for cilium endpoints (default 30m0s)
       --cluster-id int                         Unique identifier of the cluster

--- a/Makefile
+++ b/Makefile
@@ -355,7 +355,7 @@ LOCAL_IMAGE_TAG=local
 LOCAL_IMAGE=localhost:32000/cilium/cilium:$(LOCAL_IMAGE_TAG)
 microk8s: check-microk8s
 	$(QUIET)$(MAKE) dev-docker-image DOCKER_IMAGE_TAG=$(LOCAL_IMAGE_TAG)
-	@echo "  DPLOY image to microk8s ($(LOCAL_IMAGE))"
+	@echo "  DEPLOY image to microk8s ($(LOCAL_IMAGE))"
 	$(CONTAINER_ENGINE_FULL) tag cilium/cilium-dev:$(LOCAL_IMAGE_TAG) $(LOCAL_IMAGE)
 	$(CONTAINER_ENGINE_FULL) push $(LOCAL_IMAGE)
 	$(QUIET)kubectl apply -f contrib/k8s/microk8s-prepull.yaml

--- a/install/kubernetes/cilium/charts/operator/templates/clusterrole.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/clusterrole.yaml
@@ -35,6 +35,8 @@ rules:
   resources:
   - ciliumnetworkpolicies
   - ciliumnetworkpolicies/status
+  - ciliumclusterwidenetworkpolicies
+  - ciliumclusterwidenetworkpolicies/status
   - ciliumendpoints
   - ciliumendpoints/status
   - ciliumnodes

--- a/operator/ccnp_event.go
+++ b/operator/ccnp_event.go
@@ -1,0 +1,140 @@
+// Copyright 2018-2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"time"
+
+	"github.com/cilium/cilium/pkg/controller"
+	"github.com/cilium/cilium/pkg/k8s"
+	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/informer"
+	k8sversion "github.com/cilium/cilium/pkg/k8s/version"
+	"github.com/cilium/cilium/pkg/kvstore/store"
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/policy/groups"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+)
+
+var (
+	// ccnpStatusUpdateInterval is the amount of time between status updates
+	// being sent to the K8s apiserver for a given CCNP.
+	ccnpStatusUpdateInterval time.Duration
+)
+
+// enableCCNPWatcher is similar to enableCNPWatcher but handles the watch events for
+// clusterwide policies. Since, internally Clusterwide policies are implemented
+// using CiliumNetworkPolicy itself, the entire implementation uses the methods
+// associcated with CiliumNetworkPolicy.
+func enableCCNPWatcher() error {
+	log.Info("Starting to garbage collect stale CiliumClusterwideNetworkPolicy status field entries...")
+
+	var (
+		ccnpConverterFunc informer.ConvertFunc
+	)
+	ccnpStore := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
+
+	switch {
+	case k8sversion.Capabilities().Patch:
+		// k8s >= 1.13 does not require a store to update CNP status so
+		// we don't even need to keep the status of a CNP with us.
+		ccnpConverterFunc = k8s.ConvertToCCNP
+	default:
+		ccnpConverterFunc = k8s.ConvertToCCNPWithStatus
+	}
+
+	ccnpSharedStore, err := store.JoinSharedStore(store.Configuration{
+		Prefix: k8s.CCNPStatusesPath,
+		KeyCreator: func() store.Key {
+			return &k8s.CNPNSWithMeta{}
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	ccnpStatusMgr := k8s.NewCCNPStatusEventHandler(ccnpSharedStore, ccnpStore, ccnpStatusUpdateInterval)
+
+	if kvstoreEnabled() {
+		go ccnpStatusMgr.WatchForCCNPStatusEvents()
+	}
+
+	ciliumV2Controller := informer.NewInformerWithStore(
+		cache.NewListWatchFromClient(k8s.CiliumClient().CiliumV2().RESTClient(),
+			"ciliumclusterwidenetworkpolicies", v1.NamespaceAll, fields.Everything()),
+		&cilium_v2.CiliumClusterwideNetworkPolicy{},
+		0,
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				metrics.EventTSK8s.SetToCurrentTime()
+				if cnp := k8s.CopyObjToV2CNP(obj); cnp != nil {
+					groups.AddDerivativeCNPIfNeeded(cnp.CiliumNetworkPolicy)
+					ccnpStatusMgr.StartStatusHandler(cnp)
+				}
+			},
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				metrics.EventTSK8s.SetToCurrentTime()
+				if oldCNP := k8s.CopyObjToV2CNP(oldObj); oldCNP != nil {
+					if newCNP := k8s.CopyObjToV2CNP(newObj); newCNP != nil {
+						if k8s.EqualV2CNP(oldCNP, newCNP) {
+							return
+						}
+						groups.UpdateDerivativeCNPIfNeeded(newCNP.CiliumNetworkPolicy, oldCNP.CiliumNetworkPolicy)
+					}
+				}
+			},
+			DeleteFunc: func(obj interface{}) {
+				metrics.EventTSK8s.SetToCurrentTime()
+				cnp := k8s.CopyObjToV2CNP(obj)
+				if cnp == nil {
+					deletedObj, ok := obj.(cache.DeletedFinalStateUnknown)
+					if !ok {
+						return
+					}
+					// Delete was not observed by the watcher but is
+					// removed from kube-apiserver. This is the last
+					// known state and the object no longer exists.
+					cnp = k8s.CopyObjToV2CNP(deletedObj.Obj)
+					if cnp == nil {
+						return
+					}
+				}
+				// The derivative policy will be deleted by the parent but need
+				// to delete the cnp from the pooling.
+				groups.DeleteDerivativeFromCache(cnp.CiliumNetworkPolicy)
+				ccnpStatusMgr.StopStatusHandler(cnp)
+			},
+		},
+		ccnpConverterFunc,
+		ccnpStore,
+	)
+	go ciliumV2Controller.Run(wait.NeverStop)
+
+	controller.NewManager().UpdateController("ccnp-to-groups",
+		controller.ControllerParams{
+			DoFunc: func(ctx context.Context) error {
+				groups.UpdateCNPInformation()
+				return nil
+			},
+			RunInterval: 5 * time.Minute,
+		})
+
+	return nil
+}

--- a/operator/main.go
+++ b/operator/main.go
@@ -326,6 +326,12 @@ func runOperator(cmd *cobra.Command) {
 			"Cannot connect to Kubernetes apiserver ")
 	}
 
+	err = enableCCNPWatcher()
+	if err != nil {
+		log.WithError(err).WithField("subsys", "CCNPWatcher").Fatal(
+			"Cannot connect to Kubernetes apiserver ")
+	}
+
 	log.Info("Initialization complete")
 
 	<-shutdownSignal

--- a/operator/main.go
+++ b/operator/main.go
@@ -151,6 +151,7 @@ func init() {
 	option.BindEnv(option.DisableCiliumEndpointCRDName)
 
 	flags.BoolVar(&enableCNPNodeStatusGC, "cnp-node-status-gc", true, "Enable CiliumNetworkPolicy Status garbage collection for nodes which have been removed from the cluster")
+	flags.BoolVar(&enableCCNPNodeStatusGC, "ccnp-node-status-gc", true, "Enable CiliumClusterwideNetworkPolicy Status garbage collection for nodes which have been removed from the cluster")
 	flags.DurationVar(&ciliumCNPNodeStatusGCInterval, "cnp-node-status-gc-interval", time.Minute*2, "GC interval for nodes which have been removed from the cluster in CiliumNetworkPolicy Status")
 
 	flags.DurationVar(&cnpStatusUpdateInterval, "cnp-status-update-interval", 1*time.Second, "interval between CNP status updates sent to the k8s-apiserver per-CNP")

--- a/pkg/k8s/ccnpstatus.go
+++ b/pkg/k8s/ccnpstatus.go
@@ -1,0 +1,68 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"context"
+	"path"
+	"time"
+
+	"github.com/cilium/cilium/pkg/k8s/types"
+	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/kvstore/store"
+
+	"k8s.io/client-go/tools/cache"
+)
+
+var CCNPStatusesPath = path.Join(kvstore.BaseKeyPrefix, "state", "ccnpstatuses", "v2")
+
+// CCNPStatusEventHandler handles status updates events for all the CCNPs
+// in the cluster. Upon creation of Clusterwide policies, it will start a
+// controller for that CNP which handles sending of updates for that CCNP to
+// the kubernetes API server. Upon receiving eventes from the key-value store
+// it will send the update for the CCNP corresponding to the status update to
+// the controller for that CCNP.
+type CCNPStatusEventHandler struct {
+	*CNPStatusEventHandler
+}
+
+// NewCCNPStatusEventHandler returns a new CCNPStatusEventHandler.
+// which is more or less a wrapper around the CNPStatusEventHandler itself.
+func NewCCNPStatusEventHandler(cnpStore *store.SharedStore, k8sStore cache.Store, updateInterval time.Duration) *CCNPStatusEventHandler {
+	return &CCNPStatusEventHandler{
+		CNPStatusEventHandler: NewCNPStatusEventHandler(cnpStore, k8sStore, updateInterval),
+	}
+}
+
+// WatchForCCNPStatusEvents starts a watcher for all the Clusterwide policy
+// updates from the key-value store.
+func (c *CCNPStatusEventHandler) WatchForCCNPStatusEvents() {
+	watcher := kvstore.Client().ListAndWatch(context.TODO(), "ccnpStatusWatcher", CCNPStatusesPath, 512)
+
+	// Loop and block for this network policy watch event.
+	for {
+		c.watchForCNPStatusEvents(watcher)
+	}
+}
+
+// StopStatusHandler signals that we need to stop managing the sending of
+// status updates to the Kubernetes APIServer for the given CCNP. It also cleans
+// up all status updates from the key-value store for this CCNP.
+func (c *CCNPStatusEventHandler) StopStatusHandler(cnp *types.SlimCNP) {
+	cnpKey := getKeyFromObjectMeta(cnp.ObjectMeta)
+	prefix := path.Join(CCNPStatusesPath, cnpKey)
+
+	c.stopStatusHandler(cnp, cnpKey, prefix)
+}

--- a/pkg/k8s/cnp.go
+++ b/pkg/k8s/cnp.go
@@ -565,6 +565,7 @@ func updateStatusesByCapabilities(client clientset.Interface, capabilities k8sve
 		if ns == "" {
 			ccnp := &cilium_v2.CiliumClusterwideNetworkPolicy{
 				CiliumNetworkPolicy: cnp.CiliumNetworkPolicy,
+				Status:              cnp.CiliumNetworkPolicy.Status,
 			}
 			_, err = client.CiliumV2().CiliumClusterwideNetworkPolicies().UpdateStatus(ccnp)
 		} else {
@@ -584,6 +585,7 @@ func updateStatusesByCapabilities(client clientset.Interface, capabilities k8sve
 		if ns == "" {
 			ccnp := &cilium_v2.CiliumClusterwideNetworkPolicy{
 				CiliumNetworkPolicy: cnp.CiliumNetworkPolicy,
+				Status:              cnp.CiliumNetworkPolicy.Status,
 			}
 			_, err = client.CiliumV2().CiliumClusterwideNetworkPolicies().Update(ccnp)
 		} else {


### PR DESCRIPTION
* Add kvstore status watcher for CiliumClusterwideNetworkPolicies
similar to that of CiliumNetworkPolicies.

Signed-off-by: Deepesh Pathak <deepshpathak@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9669)
<!-- Reviewable:end -->
