### PR TITLE
v1.6 backports 2019-11-26

### DIFF
--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -307,7 +307,7 @@ data:
 {{- if .Values.global.kubeConfigPath }}
   k8s-kubeconfig-path: {{ .Values.global.kubeConfigPath | quote }}
 {{- end }}
-{{- if.Values.global.chainingMode }}
+{{- if not (eq .Values.global.cni.chainingMode "none") }}
   # Chaining mode was enabled, disabling health checking
   enable-endpoint-health-checking: "false"
 {{- end }}


### PR DESCRIPTION

 * #9658 -- helm: Fix bug to disable health-checks in chaining mode (@raybejjani)

Once this PR is merged, you can update the PR labels via:
```
$ for pr in 9658; do contrib/backporting/set-labels.py $pr done 1.6; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9672)
<!-- Reviewable:end -->
