### PR TITLE
docs: Keep externalTrafficPolicy=Local limitation in NodePort BPF

### DIFF
--- a/Documentation/gettingstarted/nodeport.rst
+++ b/Documentation/gettingstarted/nodeport.rst
@@ -67,7 +67,10 @@ has come up correctly:
 Limitations
 ###########
 
-    * Service ``healthCheckNodePort`` is currently not supported.
+    * Both Service's ``externalTrafficPolicy: Local`` and ``healthCheckNodePort``
+      are currently not supported. See `GH issue 8698
+      <https://github.com/cilium/cilium/issues/8698>`_ and `GH issue 8699
+      <https://github.com/cilium/cilium/issues/8699>`_ for additional details.
     * NodePort services are currently exposed through the native device which has
       the default route on the host or a user specified device. In tunneling mode,
       they are additionally exposed through the tunnel interface (``cilium_vxlan``


### PR DESCRIPTION
The NodePort BPF hasn't added a support the `externalTrafficPolicy=Local` annotation yet. Therefore, keep the limitation in the docs.

https://github.com/cilium/cilium/pull/9561 has fixed only for the NodePort kube-proxy.

Fixes: 7629d9da814ca ("docs: Fix up nodeport limitations")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9674)
<!-- Reviewable:end -->
