### PR TITLE
CI Fixups for EKS

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -57,9 +57,7 @@ const (
 	// VM / Test suite constants.
 	K8s     = "k8s"
 	K8s1    = "k8s1"
-	K8s1Ip  = "192.168.36.11"
 	K8s2    = "k8s2"
-	K8s2Ip  = "192.168.36.12"
 	Runtime = "runtime"
 
 	Enabled  = "enabled"

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2417,6 +2417,11 @@ func (kub *Kubectl) ciliumControllersPreFlightCheck() error {
 }
 
 func (kub *Kubectl) ciliumHealthPreFlightCheck() error {
+	if IsIntegration(CIIntegrationEKS) {
+		ginkgoext.By("Skipping cilium-health --probe in EKS")
+		return nil
+	}
+
 	ginkgoext.By("Performing Cilium health check")
 	var nodesFilter = `{.nodes[*].name}`
 	var statusFilter = `{range .nodes[*]}{.name}{"="}{.host.primary-address.http.status}{"\n"}{end}`

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -165,6 +165,12 @@ func GetCurrentIntegration() string {
 	return ""
 }
 
+// IsIntegration returns true when integration matches the configuration of
+// this test run
+func IsIntegration(integration string) bool {
+	return GetCurrentIntegration() == integration
+}
+
 // Kubectl is a wrapper around an SSHMeta. It is used to run Kubernetes-specific
 // commands on the node which is accessible via the SSH metadata stored in its
 // SSHMeta.

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -200,7 +200,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 	Context("Encapsulation", func() {
 		BeforeEach(func() {
-			SkipIfFlannel()
+			SkipIfIntegration(helpers.CIIntegrationFlannel)
 		})
 
 		validateBPFTunnelMap := func() {
@@ -269,14 +269,14 @@ var _ = Describe("K8sDatapathConfig", func() {
 		}
 
 		It("Check connectivity with automatic direct nodes routes", func() {
-			SkipIfFlannel()
+			SkipIfIntegration(helpers.CIIntegrationFlannel)
 
 			deployCilium(directRoutingOptions)
 			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
 		})
 
 		It("Check direct connectivity with per endpoint routes", func() {
-			SkipIfFlannel()
+			SkipIfIntegration(helpers.CIIntegrationFlannel)
 
 			deployCilium(append(directRoutingOptions,
 				"--set global.endpointRoutes.enabled=true",
@@ -372,7 +372,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 	Context("Transparent encryption DirectRouting", func() {
 		It("Check connectivity with transparent encryption and direct routing", func() {
-			SkipIfFlannel()
+			SkipIfIntegration(helpers.CIIntegrationFlannel)
 
 			deployCilium([]string{
 				"--set global.tunnel=disabled",
@@ -387,7 +387,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 	Context("IPv4Only", func() {
 		It("Check connectivity with IPv6 disabled", func() {
 			// Flannel always disables IPv6, this test is a no-op in that case.
-			SkipIfFlannel()
+			SkipIfIntegration(helpers.CIIntegrationFlannel)
 
 			deployCilium([]string{
 				"--set global.ipv4.enabled=true",

--- a/test/k8sT/Health.go
+++ b/test/k8sT/Health.go
@@ -73,7 +73,7 @@ var _ = Describe("K8sHealthTest", func() {
 	}
 
 	It("checks cilium-health status between nodes", func() {
-		SkipIfFlannel()
+		SkipIfIntegration(helpers.CIIntegrationFlannel)
 
 		cilium1, cilium1IP := getCilium(helpers.K8s1)
 		cilium2, cilium2IP := getCilium(helpers.K8s2)

--- a/test/k8sT/Health.go
+++ b/test/k8sT/Health.go
@@ -74,6 +74,7 @@ var _ = Describe("K8sHealthTest", func() {
 
 	It("checks cilium-health status between nodes", func() {
 		SkipIfIntegration(helpers.CIIntegrationFlannel)
+		SkipIfIntegration(helpers.CIIntegrationEKS)
 
 		cilium1, cilium1IP := getCilium(helpers.K8s1)
 		cilium2, cilium2IP := getCilium(helpers.K8s2)

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -730,7 +730,7 @@ var _ = Describe("K8sServicesTest", func() {
 	//
 	// })
 
-	Context("Bookinfo Demo", func() {
+	SkipContextIf(func() bool { return helpers.IsIntegration(helpers.CIIntegrationEKS) }, "Bookinfo Demo", func() {
 
 		var (
 			bookinfoV1YAML, bookinfoV2YAML string

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -353,7 +353,7 @@ var _ = Describe("K8sServicesTest", func() {
 			testExternalTrafficPolicyLocal()
 		})
 
-		Context("with L7 policy", func() {
+		SkipContextIf(func() bool { return helpers.IsIntegration(helpers.CIIntegrationEKS) }, "with L7 policy", func() {
 			var (
 				demoPolicy string
 			)

--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -111,7 +111,7 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldVersion, newV
 		return func() {}, func() {}
 	}
 
-	SkipIfFlannel()
+	SkipIfIntegration(helpers.CIIntegrationFlannel)
 
 	apps := []string{helpers.App1, helpers.App2, helpers.App3}
 	app1Service := "app1-service"

--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -145,12 +145,13 @@ func SkipIfBenchmark() {
 	}
 }
 
-// SkipIfFlannel will skip the test if it's running over Flannel datapath mode.
-func SkipIfFlannel() {
-	if helpers.GetCurrentIntegration() == helpers.CIIntegrationFlannel {
+// SkipIfIntegration will skip a test if it's running with any of the specified
+// integration.
+func SkipIfIntegration(integration string) {
+	if helpers.IsIntegration(integration) {
 		Skip(fmt.Sprintf(
 			"This feature is not supported in Cilium %q mode. Skipping test.",
-			helpers.CIIntegrationFlannel))
+			integration))
 	}
 }
 


### PR DESCRIPTION
This PR skips test steps known to fail on EKS, like health checks, or tests that need more work. It also includes some new helpers to determine a node's name and IP from labels, as these are no longer fixed values.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9675)
<!-- Reviewable:end -->
