### PR TITLE
cilium: K8s CI testing for sockops

### DIFF
--- a/test/config/config.go
+++ b/test/config/config.go
@@ -38,6 +38,7 @@ type CiliumTestConfigType struct {
 	Timeout             time.Duration
 	Kubeconfig          string
 	Registry            string
+	Benchmarks          bool
 }
 
 // CiliumTestConfig holds the global configuration of commandline flags
@@ -71,4 +72,6 @@ func (c *CiliumTestConfigType) ParseFlags() {
 	flag.StringVar(&c.Kubeconfig, "cilium.kubeconfig", "",
 		"Kubeconfig to be used for k8s tests")
 	flag.StringVar(&c.Registry, "cilium.registry", "k8s1:5000", "docker registry hostname for Cilium image")
+	flag.BoolVar(&c.Benchmarks, "cilium.benchmarks", false,
+		"Specifies benchmark tests should be run which may increase test time")
 }

--- a/test/helpers/wrappers.go
+++ b/test/helpers/wrappers.go
@@ -24,6 +24,14 @@ const (
 	// For more information, consult : http://www.cs.kent.edu/~farrell/dist/ref/Netperf.html
 	TCP_RR = PerfTest("TCP_RR")
 
+	// TCP_STREAM represents a netperf test for TCP throughput performance.
+	// For more information, consult : http://www.cs.kent.edu/~farrell/dist/ref/Netperf.html
+	TCP_STREAM = PerfTest("TCP_STREAM")
+
+	// TCP_STREAM represents a netperf test that connects and sends single request/response
+	// For more information, consult : http://www.cs.kent.edu/~farrell/dist/ref/Netperf.html
+	TCP_CRR = PerfTest("TCP_CRR")
+
 	// UDP_RR represents a netperf test for UDP Request/Response performance.
 	// For more information, consult : http://www.cs.kent.edu/~farrell/dist/ref/Netperf.html
 	UDP_RR = PerfTest("UDP_RR")
@@ -73,8 +81,8 @@ func CurlWithHTTPCode(endpoint string, optionalValues ...interface{}) string {
 
 // Netperf returns the string representing the netperf command to use when testing
 // connectivity between endpoints.
-func Netperf(endpoint string, perfTest PerfTest) string {
-	return fmt.Sprintf("netperf -l 3 -t %s -H %s", perfTest, endpoint)
+func Netperf(endpoint string, perfTest PerfTest, options string) string {
+	return fmt.Sprintf("netperf -l 3 -t %s -H %s %s", perfTest, endpoint, options)
 }
 
 // Netcat returns the string representing the netcat command to the specified

--- a/test/helpers/wrappers.go
+++ b/test/helpers/wrappers.go
@@ -28,7 +28,7 @@ const (
 	// For more information, consult : http://www.cs.kent.edu/~farrell/dist/ref/Netperf.html
 	TCP_STREAM = PerfTest("TCP_STREAM")
 
-	// TCP_STREAM represents a netperf test that connects and sends single request/response
+	// TCP_CRR represents a netperf test that connects and sends single request/response
 	// For more information, consult : http://www.cs.kent.edu/~farrell/dist/ref/Netperf.html
 	TCP_CRR = PerfTest("TCP_CRR")
 
@@ -47,6 +47,11 @@ func Ping(endpoint string) string {
 // specified endpoint.
 func Ping6(endpoint string) string {
 	return fmt.Sprintf("ping6 -c %d %s", PingCount, endpoint)
+}
+
+// Wrk runs a standard wrk test for http
+func Wrk(endpoint string) string {
+	return fmt.Sprintf("wrk -t2 -c100 -d30s -R2000 http://%s", endpoint)
 }
 
 // CurlFail returns the string representing the curl command with `-s` and

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -301,6 +301,10 @@ var _ = Describe("K8sDatapathConfig", func() {
 			"--set global.autoDirectNodeRoutes=true",
 		}
 
+		BeforeEach(func() {
+			SkipIfBenchmark()
+		})
+
 		AfterEach(func() {
 			httpClients := helpers.ManifestGet(kubectl.BasePath(), "http-clients.yaml")
 			httpServers := helpers.ManifestGet(kubectl.BasePath(), "http-deployment.yaml")

--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/cilium/cilium/test/config"
 	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
 	. "github.com/onsi/gomega"
@@ -135,6 +136,13 @@ func DeployCiliumOptionsAndDNS(vm *helpers.Kubectl, options []string) {
 	ExpectCiliumReady(vm)
 	ExpectCiliumOperatorReady(vm)
 	ExpectKubeDNSReady(vm)
+}
+
+// SkipIfBenchmark will skip the test if benchmark is not specified
+func SkipIfBenchmark() {
+	if !config.CiliumTestConfig.Benchmarks {
+		Skip("Benchmarks are skipped, specify -cilium.Benchmarks")
+	}
 }
 
 // SkipIfFlannel will skip the test if it's running over Flannel datapath mode.

--- a/test/k8sT/manifests/http-clients.yaml
+++ b/test/k8sT/manifests/http-clients.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+kind: Deployment
+metadata:
+  name: http-client
+spec:
+  selector:
+    matchLabels:
+      app: http-client
+  replicas: 2 # tells deployment to run 2 pods matching the template
+  template:
+    metadata:
+      labels:
+        app: http-client
+        zgroup: http-client
+    spec:
+      containers:
+      - name: http-client
+        image: quay.io/isovalent/wrk2:latest
+        ports:
+        - containerPort: 80

--- a/test/k8sT/manifests/http-deployment.yaml
+++ b/test/k8sT/manifests/http-deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+kind: Deployment
+metadata:
+  name: http-server
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: 2 # tells deployment to run 2 pods matching the template
+  template:
+    metadata:
+      labels:
+        app: nginx
+        zgroup: http-server
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:latest
+        ports:
+        - containerPort: 80

--- a/test/runtime/connectivity.go
+++ b/test/runtime/connectivity.go
@@ -95,8 +95,8 @@ var runtimeConnectivityTest = func(datapathMode string) func() {
 		Context("Basic Connectivity test", func() {
 
 			BeforeEach(func() {
-				vm.ContainerCreate(helpers.Client, constants.NetperfImage, helpers.CiliumDockerNetwork, "-l id.client")
-				vm.ContainerCreate(helpers.Server, constants.NetperfImage, helpers.CiliumDockerNetwork, "-l id.server")
+				vm.ContainerCreate(helpers.Client, constants.NetperfImage, helpers.CiliumDockerNetwork, "-l id.client", "")
+				vm.ContainerCreate(helpers.Server, constants.NetperfImage, helpers.CiliumDockerNetwork, "-l id.server", "")
 				vm.PolicyDelAll()
 				vm.WaitEndpointsReady()
 				err := helpers.WithTimeout(func() bool {
@@ -506,25 +506,25 @@ var runtimeConntrackTest = func(datapathMode string) func() {
 
 				{
 					from:        helpers.Client,
-					to:          helpers.Netperf(serverDockerNetworking[helpers.IPv6], helpers.TCP_RR),
+					to:          helpers.Netperf(serverDockerNetworking[helpers.IPv6], helpers.TCP_RR, ""),
 					destination: helpers.Server,
 					assert:      BeTrue,
 				},
 				{
 					from:        helpers.Client,
-					to:          helpers.Netperf(serverDockerNetworking[helpers.IPv4], helpers.TCP_RR),
+					to:          helpers.Netperf(serverDockerNetworking[helpers.IPv4], helpers.TCP_RR, ""),
 					destination: helpers.Server,
 					assert:      BeTrue,
 				},
 				{
 					from:        helpers.Client,
-					to:          helpers.Netperf(serverDockerNetworking[helpers.IPv6], helpers.UDP_RR),
+					to:          helpers.Netperf(serverDockerNetworking[helpers.IPv6], helpers.UDP_RR, ""),
 					destination: helpers.Server,
 					assert:      BeTrue,
 				},
 				{
 					from:        helpers.Client,
-					to:          helpers.Netperf(serverDockerNetworking[helpers.IPv4], helpers.UDP_RR),
+					to:          helpers.Netperf(serverDockerNetworking[helpers.IPv4], helpers.UDP_RR, ""),
 					destination: helpers.Server,
 					assert:      BeTrue,
 				},
@@ -653,25 +653,25 @@ var runtimeConntrackTest = func(datapathMode string) func() {
 				},
 				{
 					from:        helpers.Client,
-					to:          helpers.Netperf(serverDockerNetworking[helpers.IPv6], helpers.TCP_RR),
+					to:          helpers.Netperf(serverDockerNetworking[helpers.IPv6], helpers.TCP_RR, ""),
 					destination: helpers.Server,
 					assert:      BeTrue,
 				},
 				{
 					from:        helpers.Client,
-					to:          helpers.Netperf(serverDockerNetworking[helpers.IPv4], helpers.TCP_RR),
+					to:          helpers.Netperf(serverDockerNetworking[helpers.IPv4], helpers.TCP_RR, ""),
 					destination: helpers.Server,
 					assert:      BeTrue,
 				},
 				{
 					from:        helpers.Client,
-					to:          helpers.Netperf(serverDockerNetworking[helpers.IPv6], helpers.UDP_RR),
+					to:          helpers.Netperf(serverDockerNetworking[helpers.IPv6], helpers.UDP_RR, ""),
 					destination: helpers.Server,
 					assert:      BeTrue,
 				},
 				{
 					from:        helpers.Client,
-					to:          helpers.Netperf(serverDockerNetworking[helpers.IPv4], helpers.UDP_RR),
+					to:          helpers.Netperf(serverDockerNetworking[helpers.IPv4], helpers.UDP_RR, ""),
 					destination: helpers.Server,
 					assert:      BeTrue,
 				},


### PR DESCRIPTION
To date we've had some basic tests for sockops negative case in k8s and some simple netperf runtime tests. This adds nertperf K8s tests and http tests using wrk.

After this we can add https tests to include ssl and contrib scripts to extract performance metrics over time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9685)
<!-- Reviewable:end -->
