### PR TITLE
k8s: Fix Service.DeepEquals for ExternalIP

### DIFF
--- a/pkg/k8s/service.go
+++ b/pkg/k8s/service.go
@@ -278,6 +278,10 @@ func (s *Service) DeepEquals(o *Service) bool {
 			}
 		}
 
+		if ((s.K8sExternalIPs == nil) != (o.K8sExternalIPs == nil)) ||
+			len(s.K8sExternalIPs) != len(o.K8sExternalIPs) {
+			return false
+		}
 		for k, v := range s.K8sExternalIPs {
 			vOther, ok := o.K8sExternalIPs[k]
 			if !ok || !v.Equal(vOther) {

--- a/pkg/k8s/service_test.go
+++ b/pkg/k8s/service_test.go
@@ -499,6 +499,48 @@ func TestService_Equals(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "external-ip was added",
+			fields: &Service{
+				FrontendIP: net.ParseIP("1.1.1.1"),
+				IsHeadless: false,
+				Ports: map[loadbalancer.FEPortName]*loadbalancer.L4Addr{
+					loadbalancer.FEPortName("foo"): {
+						Protocol: loadbalancer.NONE,
+						Port:     1,
+					},
+				},
+				K8sExternalIPs: nil,
+				Labels: map[string]string{
+					"foo": "bar",
+				},
+				Selector: map[string]string{
+					"baz": "foz",
+				},
+			},
+			args: args{
+				o: &Service{
+					FrontendIP: net.ParseIP("1.1.1.1"),
+					IsHeadless: false,
+					Ports: map[loadbalancer.FEPortName]*loadbalancer.L4Addr{
+						loadbalancer.FEPortName("foo"): {
+							Protocol: loadbalancer.NONE,
+							Port:     1,
+						},
+					},
+					K8sExternalIPs: map[string]net.IP{
+						"2.2.2.2": net.ParseIP("2.2.2.2"),
+					},
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+					Selector: map[string]string{
+						"baz": "foz",
+					},
+				},
+			},
+			want: false,
+		},
+		{
 			name: "both nil",
 			args: args{},
 			want: true,


### PR DESCRIPTION
Previously, the `DeepEquals()` method did not consider a change when an external IP had been added to a service which didn't have any externalIP assigned to it.

This prevented from updating such service, therefore no externalIP services were provisioned.

Fixes: a402a424b5 ("add externalIPs implementation in Cilium")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9690)
<!-- Reviewable:end -->
