### PR TITLE
k8s: Fix typo in io.cilium/shared-service annotation

### DIFF
--- a/pkg/annotation/k8s.go
+++ b/pkg/annotation/k8s.go
@@ -58,7 +58,7 @@ const (
 	// Setting the annotation SharedService to false while setting
 	// GlobalService to true allows to expose remote endpoints without
 	// sharing local endpoints.
-	SharedService = Prefix + "shared-service"
+	SharedService = Prefix + "/shared-service"
 
 	// ProxyVisibility is the annotation name used to indicate whether proxy
 	// visibility should be enabled for a given pod (i.e., all traffic for the

--- a/pkg/k8s/service_test.go
+++ b/pkg/k8s/service_test.go
@@ -53,6 +53,27 @@ func (s *K8sSuite) TestGetAnnotationIncludeExternal(c *check.C) {
 	c.Assert(getAnnotationIncludeExternal(svc), check.Equals, false)
 }
 
+func (s *K8sSuite) TestGetAnnotationShared(c *check.C) {
+	svc := &types.Service{Service: &v1.Service{ObjectMeta: metav1.ObjectMeta{
+		Name: "foo",
+	}}}
+	c.Assert(getAnnotationShared(svc), check.Equals, false)
+	svc = &types.Service{Service: &v1.Service{ObjectMeta: metav1.ObjectMeta{
+		Annotations: map[string]string{"io.cilium/global-service": "true"},
+	}}}
+	c.Assert(getAnnotationShared(svc), check.Equals, true)
+
+	svc = &types.Service{Service: &v1.Service{ObjectMeta: metav1.ObjectMeta{
+		Annotations: map[string]string{"io.cilium/shared-service": "True"},
+	}}}
+	c.Assert(getAnnotationShared(svc), check.Equals, true)
+
+	svc = &types.Service{Service: &v1.Service{ObjectMeta: metav1.ObjectMeta{
+		Annotations: map[string]string{"io.cilium/global-service": "true", "io.cilium/shared-service": "false"},
+	}}}
+	c.Assert(getAnnotationShared(svc), check.Equals, false)
+}
+
 func (s *K8sSuite) TestParseServiceID(c *check.C) {
 	svc := &types.Service{
 		Service: &v1.Service{


### PR DESCRIPTION
The annotation was misspelled as `io.ciliumshared-service`. This adds the missing slash and test cases for the annotation parser.
    
Since the annotation is not documented, no fallback to support the old spelling is introduced.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9691)
<!-- Reviewable:end -->
