### PR TITLE
Move --aws-instance-limit-mapping flag to be on the operator

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -22,7 +22,6 @@ cilium-agent [flags]
       --annotate-k8s-node                                     Annotate Kubernetes node (default true)
       --auto-create-cilium-node-resource                      Automatically create CiliumNode resource for own node on startup (default true)
       --auto-direct-node-routes                               Enable automatic L2 routing between nodes
-      --aws-instance-limit-mapping map                        Add or overwrite mappings of AWS instance limit in the form of {"AWS instance type": "Maximum Network Interfaces","IPv4 Addresses per Interface","IPv6 Addresses per Interface"}. cli example: --aws-instance-limit-mapping=a1.medium=2,4,4 --aws-instance-limit-mapping=a2.somecustomflavor=4,5,6 configmap example: {"a1.medium": "2,4,4", "a2.somecustomflavor": "4,5,6"} (default map[])
       --blacklist-conflicting-routes                          Don't blacklist IP allocations conflicting with local non-cilium routes (default true)
       --bpf-compile-debug                                     Enable debugging of the BPF compilation process
       --bpf-ct-global-any-max int                             Maximum number of entries in non-TCP CT table (default 262144)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -18,6 +18,7 @@ cilium-operator [flags]
       --api-server-port uint16                 Port on which the operator should serve API requests (default 9234)
       --aws-client-burst int                   Burst value allowed for the AWS client used by the AWS ENI IPAM (default 4)
       --aws-client-qps float                   Queries per second limit for the AWS client used by the AWS ENI IPAM (default 20)
+      --aws-instance-limit-mapping map         Add or overwrite mappings of AWS instance limit in the form of {"AWS instance type": "Maximum Network Interfaces","IPv4 Addresses per Interface","IPv6 Addresses per Interface"}. cli example: --aws-instance-limit-mapping=a1.medium=2,4,4 --aws-instance-limit-mapping=a2.somecustomflavor=4,5,6 configmap example: {"a1.medium": "2,4,4", "a2.somecustomflavor": "4,5,6"} (default map[])
       --aws-release-excess-ips                 Enable releasing excess free IP addresses from AWS ENI.
       --cilium-endpoint-gc                     Enable CiliumEndpoint garbage collector (default true)
       --cilium-endpoint-gc-interval duration   GC interval for cilium endpoints (default 30m0s)

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -30,7 +30,6 @@ import (
 	"github.com/cilium/cilium/api/v1/server/restapi"
 	"github.com/cilium/cilium/common"
 	_ "github.com/cilium/cilium/pkg/alignchecker"
-	"github.com/cilium/cilium/pkg/aws/eni"
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/cgroups"
 	"github.com/cilium/cilium/pkg/cleanup"
@@ -686,10 +685,6 @@ func init() {
 	flags.Bool(option.DisableCNPStatusUpdates, false, "Do not send CNP NodeStatus updates to the Kubernetes api-server (recommended to run with `cnp-node-status-gc=false` in cilium-operator)")
 	option.BindEnv(option.DisableCNPStatusUpdates)
 
-	flags.Var(option.NewNamedMapOptions(option.AwsInstanceLimitMapping, &option.Config.AwsInstanceLimitMapping, nil),
-		option.AwsInstanceLimitMapping, "Add or overwrite mappings of AWS instance limit in the form of {\"AWS instance type\": \"Maximum Network Interfaces\",\"IPv4 Addresses per Interface\",\"IPv6 Addresses per Interface\"}. cli example: --aws-instance-limit-mapping=a1.medium=2,4,4 --aws-instance-limit-mapping=a2.somecustomflavor=4,5,6 configmap example: {\"a1.medium\": \"2,4,4\", \"a2.somecustomflavor\": \"4,5,6\"}")
-	option.BindEnv(option.AwsInstanceLimitMapping)
-
 	viper.BindPFlags(flags)
 }
 
@@ -937,10 +932,6 @@ func initEnv(cmd *cobra.Command) {
 
 	if err := identity.AddUserDefinedNumericIdentitySet(option.Config.FixedIdentityMapping); err != nil {
 		log.Fatalf("Invalid fixed identities provided: %s", err)
-	}
-
-	if err := eni.UpdateLimitsFromUserDefinedMappings(option.Config.AwsInstanceLimitMapping); err != nil {
-		log.Fatalf("Parse aws-instance-limit-mapping failed: %s", err)
 	}
 
 	if !option.Config.EnableIPv4 && !option.Config.EnableIPv6 {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1305,7 +1305,6 @@ var (
 		AutoCreateCiliumNodeResource: defaults.AutoCreateCiliumNodeResource,
 		IdentityAllocationMode:       IdentityAllocationModeKVstore,
 		AllowICMPFragNeeded:          defaults.AllowICMPFragNeeded,
-		AwsInstanceLimitMapping:      make(map[string]string),
 	}
 )
 
@@ -1791,10 +1790,6 @@ func (c *DaemonConfig) Populate() {
 	c.MonitorAggregationFlags = ctMonitorReportFlags
 
 	// Map options
-	if m := viper.GetStringMapString(AwsInstanceLimitMapping); len(m) != 0 {
-		c.AwsInstanceLimitMapping = m
-	}
-
 	if m := viper.GetStringMapString(FixedIdentityMapping); len(m) != 0 {
 		c.FixedIdentityMapping = m
 	}


### PR DESCRIPTION
Via https://github.com/cilium/cilium/pull/9236 the option was added to
the agent CLI but all the code that evaluated the AWS instance limits
runs in the operator and not the agent. Moved the option to be in the
operator so the limit map to be updated there.

Signed-off-by: Vlad Ungureanu <vladu@palantir.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9693)
<!-- Reviewable:end -->
