### PR TITLE
k8s: Add support for LoadBalancer service when running w/o kube-proxy

### DIFF
--- a/pkg/k8s/service.go
+++ b/pkg/k8s/service.go
@@ -66,6 +66,7 @@ func ParseService(svc *types.Service) (ServiceID, *Service) {
 		logfields.K8sAPIVersion: svc.TypeMeta.APIVersion,
 		logfields.K8sSvcType:    svc.Spec.Type,
 	})
+	var loadBalancerIPs []string
 
 	svcID := ParseServiceID(svc)
 
@@ -91,7 +92,14 @@ func ParseService(svc *types.Service) (ServiceID, *Service) {
 	if strings.ToLower(svc.Spec.ClusterIP) == "none" {
 		headless = true
 	}
-	svcInfo := NewService(clusterIP, svc.Spec.ExternalIPs, headless, svc.Labels, svc.Spec.Selector)
+
+	for _, ip := range svc.Status.LoadBalancer.Ingress {
+		if ip.IP != "" {
+			loadBalancerIPs = append(loadBalancerIPs, ip.IP)
+		}
+	}
+
+	svcInfo := NewService(clusterIP, svc.Spec.ExternalIPs, loadBalancerIPs, headless, svc.Labels, svc.Spec.Selector)
 	svcInfo.IncludeExternal = getAnnotationIncludeExternal(svc)
 	svcInfo.Shared = getAnnotationShared(svc)
 
@@ -202,8 +210,10 @@ type Service struct {
 	// K8sExternalIPs stores mapping of the endpoint in a string format to the
 	// externalIP in net.IP format.
 	K8sExternalIPs map[string]net.IP
-	Labels         map[string]string
-	Selector       map[string]string
+	// LoadBalancerIPs stores LB IPs assigned to the service (string(IP) => IP).
+	LoadBalancerIPs map[string]net.IP
+	Labels          map[string]string
+	Selector        map[string]string
 }
 
 // String returns the string representation of a service resource
@@ -288,12 +298,23 @@ func (s *Service) DeepEquals(o *Service) bool {
 				return false
 			}
 		}
+
+		if ((s.LoadBalancerIPs == nil) != (o.LoadBalancerIPs == nil)) ||
+			len(s.LoadBalancerIPs) != len(o.LoadBalancerIPs) {
+			return false
+		}
+		for k, v := range s.LoadBalancerIPs {
+			vOther, ok := o.LoadBalancerIPs[k]
+			if !ok || !v.Equal(vOther) {
+				return false
+			}
+		}
 		return true
 	}
 	return false
 }
 
-func parseExternalIPs(externalIPs []string) map[string]net.IP {
+func parseIPs(externalIPs []string) map[string]net.IP {
 	m := map[string]net.IP{}
 	for _, externalIP := range externalIPs {
 		ip := net.ParseIP(externalIP)
@@ -305,19 +326,26 @@ func parseExternalIPs(externalIPs []string) map[string]net.IP {
 }
 
 // NewService returns a new Service with the Ports map initialized.
-func NewService(ip net.IP, externalIPs []string, headless bool, labels map[string]string, selector map[string]string) *Service {
+func NewService(ip net.IP, externalIPs []string, loadBalancerIPs []string, headless bool,
+	labels map[string]string, selector map[string]string) *Service {
+
 	var k8sExternalIPs map[string]net.IP
+	var k8sLoadBalancerIPs map[string]net.IP
+
 	if option.Config.EnableNodePort {
-		k8sExternalIPs = parseExternalIPs(externalIPs)
+		k8sExternalIPs = parseIPs(externalIPs)
+		k8sLoadBalancerIPs = parseIPs(loadBalancerIPs)
 	}
+
 	return &Service{
-		FrontendIP:     ip,
-		IsHeadless:     headless,
-		Ports:          map[loadbalancer.FEPortName]*loadbalancer.L4Addr{},
-		NodePorts:      map[loadbalancer.FEPortName]map[string]*loadbalancer.L3n4AddrID{},
-		K8sExternalIPs: k8sExternalIPs,
-		Labels:         labels,
-		Selector:       selector,
+		FrontendIP:      ip,
+		IsHeadless:      headless,
+		Ports:           map[loadbalancer.FEPortName]*loadbalancer.L4Addr{},
+		NodePorts:       map[loadbalancer.FEPortName]map[string]*loadbalancer.L3n4AddrID{},
+		K8sExternalIPs:  k8sExternalIPs,
+		LoadBalancerIPs: k8sLoadBalancerIPs,
+		Labels:          labels,
+		Selector:        selector,
 	}
 }
 

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -556,6 +556,10 @@ func (k *K8sWatcher) delK8sSVCs(svc k8s.ServiceID, svcInfo *k8s.Service, se *k8s
 		for _, k8sExternalIP := range svcInfo.K8sExternalIPs {
 			frontends = append(frontends, loadbalancer.NewL3n4Addr(svcPort.Protocol, k8sExternalIP, svcPort.Port))
 		}
+
+		for _, ip := range svcInfo.LoadBalancerIPs {
+			frontends = append(frontends, loadbalancer.NewL3n4Addr(svcPort.Protocol, ip, svcPort.Port))
+		}
 	}
 
 	for _, fe := range frontends {
@@ -625,6 +629,10 @@ func datapathSVCs(svc *k8s.Service, endpoints *k8s.Endpoints) (svcs []loadbalanc
 	}
 	if svc.FrontendIP != nil {
 		dpSVC := genCartesianProduct(svc.FrontendIP, loadbalancer.SVCTypeClusterIP, clusterIPPorts, endpoints)
+		svcs = append(svcs, dpSVC...)
+	}
+	for _, ip := range svc.LoadBalancerIPs {
+		dpSVC := genCartesianProduct(ip, loadbalancer.SVCTypeLoadBalancer, clusterIPPorts, endpoints)
 		svcs = append(svcs, dpSVC...)
 	}
 

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -34,10 +34,11 @@ var (
 type SVCType string
 
 const (
-	SVCTypeNone        = SVCType("NONE")
-	SVCTypeClusterIP   = SVCType("ClusterIP")
-	SVCTypeNodePort    = SVCType("NodePort")
-	SVCTypeExternalIPs = SVCType("ExternalIPs")
+	SVCTypeNone         = SVCType("NONE")
+	SVCTypeClusterIP    = SVCType("ClusterIP")
+	SVCTypeNodePort     = SVCType("NodePort")
+	SVCTypeExternalIPs  = SVCType("ExternalIPs")
+	SVCTypeLoadBalancer = SVCType("LoadBalancer")
 )
 
 // ServiceFlags is the datapath representation of the service flags that can be

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -384,11 +384,20 @@ func (s *Service) upsertServiceIntoLBMaps(svc *svcInfo, prevBackendCount int,
 	for i, b := range svc.backends {
 		backendIDs[i] = uint16(b.ID)
 	}
+
+	svcType := svc.svcType
+	// SVC of LoadBalancer type is identical to ExternalIP. However, currently
+	// datapath does not support the LoadBalancer type, only ExternalIP. So,
+	// for now set the ExternalIP type.
+	if svcType == lb.SVCTypeLoadBalancer {
+		svcType = lb.SVCTypeExternalIPs
+	}
+
 	err := s.lbmap.UpsertService(
 		uint16(svc.frontend.ID), svc.frontend.L3n4Addr.IP,
 		svc.frontend.L3n4Addr.L4Addr.Port,
 		backendIDs, prevBackendCount,
-		ipv6, svc.svcType)
+		ipv6, svcType)
 	if err != nil {
 		return err
 	}

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2563,8 +2563,9 @@ func (kub *Kubectl) ciliumServicePreFlightCheck() error {
 				k8sSvc.Spec.ClusterIP == v1.ClusterIPNone {
 				continue
 			}
-			// TODO(brb) check NodePort services
-			if k8sSvc.Spec.Type == v1.ServiceTypeNodePort {
+			// TODO(brb) check NodePort and LoadBalancer services
+			if k8sSvc.Spec.Type == v1.ServiceTypeNodePort ||
+				k8sSvc.Spec.Type == v1.ServiceTypeLoadBalancer {
 				continue
 			}
 			if _, ok := k8sServicesFound[key]; !ok {
@@ -2683,8 +2684,9 @@ func serviceKey(s v1.Service) string {
 func validateCiliumSvc(cSvc models.Service, k8sSvcs []v1.Service, k8sEps []v1.Endpoints, k8sServicesFound map[string]bool) error {
 	var k8sService *v1.Service
 
-	// TODO(brb) validate NodePort services
-	if cSvc.Status.Realized.Flags != nil && cSvc.Status.Realized.Flags.Type == "NodePort" {
+	// TODO(brb) validate NodePort and LoadBalancer services
+	if cSvc.Status.Realized.Flags != nil &&
+		(cSvc.Status.Realized.Flags.Type == "NodePort" || cSvc.Status.Realized.Flags.Type == "LoadBalancer") {
 		return nil
 	}
 

--- a/test/k8sT/manifests/demo_ds.yaml
+++ b/test/k8sT/manifests/demo_ds.yaml
@@ -64,7 +64,6 @@ spec:
   selector:
     zgroup: testDS
 ---
-
 apiVersion: v1
 kind: Service
 metadata:
@@ -73,6 +72,20 @@ spec:
   type: NodePort
   ports:
   - port: 10080
+    targetPort: 80
+    protocol: TCP
+    name: http
+  selector:
+    zgroup: testDS
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-lb
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 80
     targetPort: 80
     protocol: TCP
     name: http

--- a/test/k8sT/manifests/metallb.yaml
+++ b/test/k8sT/manifests/metallb.yaml
@@ -1,0 +1,306 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app: metallb
+  name: metallb-system
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  labels:
+    app: metallb
+  name: speaker
+  namespace: metallb-system
+spec:
+  allowPrivilegeEscalation: false
+  allowedCapabilities:
+  - NET_ADMIN
+  - NET_RAW
+  - SYS_ADMIN
+  fsGroup:
+    rule: RunAsAny
+  hostNetwork: true
+  hostPorts:
+  - max: 7472
+    min: 7472
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - '*'
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: metallb
+  name: controller
+  namespace: metallb-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: metallb
+  name: speaker
+  namespace: metallb-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: metallb
+  name: metallb-system:controller
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ''
+  resources:
+  - services/status
+  verbs:
+  - update
+- apiGroups:
+  - ''
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: metallb
+  name: metallb-system:speaker
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - services
+  - endpoints
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - extensions
+  resourceNames:
+  - speaker
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: metallb
+  name: config-watcher
+  namespace: metallb-system
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: metallb
+  name: metallb-system:controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: metallb-system:controller
+subjects:
+- kind: ServiceAccount
+  name: controller
+  namespace: metallb-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: metallb
+  name: metallb-system:speaker
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: metallb-system:speaker
+subjects:
+- kind: ServiceAccount
+  name: speaker
+  namespace: metallb-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: metallb
+  name: config-watcher
+  namespace: metallb-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: config-watcher
+subjects:
+- kind: ServiceAccount
+  name: controller
+- kind: ServiceAccount
+  name: speaker
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: metallb
+    component: speaker
+  name: speaker
+  namespace: metallb-system
+spec:
+  selector:
+    matchLabels:
+      app: metallb
+      component: speaker
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: '7472'
+        prometheus.io/scrape: 'true'
+      labels:
+        app: metallb
+        component: speaker
+    spec:
+      containers:
+      - args:
+        - --port=7472
+        - --config=config
+        env:
+        - name: METALLB_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: METALLB_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        image: metallb/speaker:v0.8.2
+        imagePullPolicy: IfNotPresent
+        name: speaker
+        ports:
+        - containerPort: 7472
+          name: monitoring
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_ADMIN
+            - NET_RAW
+            - SYS_ADMIN
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+      hostNetwork: true
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      serviceAccountName: speaker
+      terminationGracePeriodSeconds: 0
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: metallb
+    component: controller
+  name: controller
+  namespace: metallb-system
+spec:
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app: metallb
+      component: controller
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: '7472'
+        prometheus.io/scrape: 'true'
+      labels:
+        app: metallb
+        component: controller
+    spec:
+      containers:
+      - args:
+        - --port=7472
+        - --config=config
+        image: metallb/controller:v0.8.2
+        imagePullPolicy: IfNotPresent
+        name: controller
+        ports:
+        - containerPort: 7472
+          name: monitoring
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - all
+          readOnlyRootFilesystem: true
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+      serviceAccountName: controller
+      terminationGracePeriodSeconds: 0
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+    - name: default
+      protocol: layer2
+      addresses:
+      - 192.168.36.240-192.168.36.250


### PR DESCRIPTION
This PR adds a support for a service of the `LoadBalancer` type when running w/o kube-proxy.

Such service has an IP addr assigned by an external loadbalancer (e.g. MetalLB) which might be used to access a service from outside. The IP addr is assigned not immediately. Therefore, the provisioning of the service usually takes place after receiving a second update for the service object which contains the IP addr stored in the `Service.Status.LoadBalancer.Ingress` field (array).

The behavior of the service is identical to a service of the `ExternalIP` "type", therefore no changes are required in the BPF datapath.

```release-note
Adds a support for a service of the LoadBalancer type when running Cilium without kube-proxy.
```

Fixes #9116.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9694)
<!-- Reviewable:end -->
