### PR TITLE
doc: Disable masquerading in all chaining guides

### DIFF
--- a/Documentation/gettingstarted/cni-chaining-calico.rst
+++ b/Documentation/gettingstarted/cni-chaining-calico.rst
@@ -78,6 +78,7 @@ Generate the required YAML file and deploy it:
       --set global.cni.customConf=true \
       --set global.cni.configMap=cni-configuration \
       --set global.tunnel=disabled \
+      --set global.masquerade=false \
       > cilium.yaml
     kubectl create -f cilium.yaml
 

--- a/Documentation/gettingstarted/cni-chaining-generic-veth.rst
+++ b/Documentation/gettingstarted/cni-chaining-generic-veth.rst
@@ -83,5 +83,6 @@ Generate the required YAML file and deploy it:
       --set global.cni.customConf=true \
       --set global.cni.configMap=cni-configuration \
       --set global.tunnel=disabled \
+      --set global.masquerade=false \
       > cilium.yaml
     kubectl create -f cilium.yaml

--- a/Documentation/gettingstarted/cni-chaining-weave.rst
+++ b/Documentation/gettingstarted/cni-chaining-weave.rst
@@ -68,6 +68,7 @@ Generate the required YAML file and deploy it:
       --set global.cni.customConf=true \
       --set global.cni.configMap=cni-configuration \
       --set global.tunnel=disabled \
+      --set global.masquerade=false \
       > cilium.yaml
     kubectl create -f cilium.yaml
 

--- a/Documentation/gettingstarted/k8s-install-azure-cni-steps.rst
+++ b/Documentation/gettingstarted/k8s-install-azure-cni-steps.rst
@@ -67,6 +67,7 @@ Generate the required YAML file and deploy it:
      --set global.nodeinit.enabled=true \
      --set global.cni.configMap=cni-configuration \
      --set global.tunnel=disabled \
+     --set global.masquerade=false \
      > cilium.yaml
    kubectl create -f cilium.yaml
 


### PR DESCRIPTION
Not all chaining guides were properly disabling masquerading. In chaining mode,
the masquerade decision is delegated to the underlying plugin responsible for
the networking. Enabling chaining leads to unnecessary iptables rules being
installed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9695)
<!-- Reviewable:end -->
