### PR TITLE
policy: Disable well-known identities for non-managed etcd

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -65,6 +65,7 @@ cilium-agent [flags]
       --enable-node-port                                      Enable NodePort type services by Cilium (beta)
       --enable-policy string                                  Enable policy enforcement (default "default")
       --enable-tracing                                        Enable tracing while determining policy (debugging)
+      --enable-well-known-identities                          Enable well-known identities for known Kubernetes components (default true)
       --encrypt-interface string                              Transparent encryption interface
       --encrypt-node                                          Enables encrypting traffic from non-Cilium pods and host networking
       --endpoint-interface-name-prefix string                 Prefix of interface name shared by all endpoints (default "lxc+")

--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -302,6 +302,22 @@ IMPORTANT: Changes required before upgrading to 1.7.0
   ``container-runtime`` and ``container-runtime-endpoint`` will not have any
   effect and the flag removal is scheduled for v1.8.0
 
+New ConfigMap Options
+~~~~~~~~~~~~~~~~~~~~~
+
+  * ``enable-well-known-identities`` has been added to control the
+    initialization of the well-known identities. Well-known identities have
+    initially been added to support the managed etcd concept to allow the etcd
+    operator to bootstrap etcd while Cilium still waited on etcd to become
+    available. Cilium now uses CRDs by default which limits the use of
+    well-known identities to the managed etcd mode. With the addition of this
+    option, well-known identities are disabled by default in all new deployment
+    and only enabled if the Helm option ``etcd.managed=true`` is set. Consider
+    disabling this option if you are not using the etcd operator respectively
+    managed etcd mode to reduce the number of policy identities whitelisted for
+    each endpoint.
+
+
 Removed options
 ~~~~~~~~~~~~~~~~~~
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -292,8 +292,10 @@ func NewDaemon(ctx context.Context, dp datapath.Datapath) (*Daemon, *endpointRes
 	}
 
 	identity.UpdateReservedIdentitiesMetrics()
-	// Must be done before calling policy.NewPolicyRepository() below.
-	identity.InitWellKnownIdentities()
+	if option.Config.EnableWellKnownIdentities {
+		// Must be done before calling policy.NewPolicyRepository() below.
+		identity.InitWellKnownIdentities()
+	}
 
 	nd := nodediscovery.NewNodeDiscovery(nodeMngr, mtuConfig, netConf)
 

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -338,6 +338,9 @@ func init() {
 	flags.Bool(option.EnableTracing, false, "Enable tracing while determining policy (debugging)")
 	option.BindEnv(option.EnableTracing)
 
+	flags.Bool(option.EnableWellKnownIdentities, defaults.EnableWellKnownIdentities, "Enable well-known identities for known Kubernetes components")
+	option.BindEnv(option.EnableWellKnownIdentities)
+
 	flags.String(option.EnvoyLog, "", "Path to a separate Envoy log file, if any")
 	option.BindEnv(option.EnvoyLog)
 

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -296,3 +296,8 @@ data:
   # Chaining mode was enabled, disabling health checking
   enable-endpoint-health-checking: "false"
 {{- end }}
+{{- if or .Values.global.wellKnownIdentities.enabled .Values.global.etcd.managed }}
+  enable-well-known-identities: "true"
+{{- else }}
+  enable-well-known-identities: "false"
+{{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -301,3 +301,7 @@ global:
 
   daemon:
     runPath: "/var/run/cilium"
+
+  wellKnownIdentities:
+    # enabled enables the use of well-known identities
+    enabled: false

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -122,6 +122,7 @@ data:
   install-iptables-rules: "true"
   auto-direct-node-routes: "false"
   enable-node-port: "false"
+  enable-well-known-identities: "false"
 
 ---
 # Source: cilium/charts/agent/templates/serviceaccount.yaml
@@ -627,7 +628,6 @@ spec:
           initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 3
-
       hostNetwork: true
       restartPolicy: Always
       serviceAccount: cilium-operator
@@ -638,6 +638,7 @@ spec:
 
 ---
 # Source: cilium/charts/agent/templates/svc.yaml
+
 
 ---
 # Source: cilium/charts/operator/templates/servicemonitor.yaml

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -321,4 +321,8 @@ const (
 
 	// RestoreV6Addr is used as match for cilium_host v6 (router) address
 	RestoreV6Addr = "cilium.v6.internal.raw "
+
+	// EnableWellKnownIdentities is enabled by default as this is the
+	// original behavior. New default Helm templates will disable this.
+	EnableWellKnownIdentities = true
 )

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -639,6 +639,11 @@ const (
 	// EnableLocalNodeRoute controls installation of the route which points
 	// the allocation prefix of the local node.
 	EnableLocalNodeRoute = "enable-local-node-route"
+
+	// EnableWellKnownIdentities enables the use of well-known identities.
+	// This is requires if identiy resolution is required to bring up the
+	// control plane, e.g. when using the managed etcd feature
+	EnableWellKnownIdentities = "enable-well-known-identities"
 )
 
 // Default string arguments
@@ -1271,6 +1276,11 @@ type DaemonConfig struct {
 	// Enabling this option reduces waste of IP addresses but may increase
 	// the number of API calls to AWS EC2 service.
 	AwsReleaseExcessIps bool
+
+	// EnableWellKnownIdentities enables the use of well-known identities.
+	// This is requires if identiy resolution is required to bring up the
+	// control plane, e.g. when using the managed etcd feature
+	EnableWellKnownIdentities bool
 }
 
 var (
@@ -1305,6 +1315,7 @@ var (
 		AutoCreateCiliumNodeResource: defaults.AutoCreateCiliumNodeResource,
 		IdentityAllocationMode:       IdentityAllocationModeKVstore,
 		AllowICMPFragNeeded:          defaults.AllowICMPFragNeeded,
+		EnableWellKnownIdentities:    defaults.EnableEndpointRoutes,
 	}
 )
 
@@ -1601,6 +1612,7 @@ func (c *DaemonConfig) Populate() {
 	c.EnableIPv4 = getIPv4Enabled()
 	c.EnableIPv6 = viper.GetBool(EnableIPv6Name)
 	c.EnableIPSec = viper.GetBool(EnableIPSecName)
+	c.EnableWellKnownIdentities = viper.GetBool(EnableWellKnownIdentities)
 	c.EndpointInterfaceNamePrefix = viper.GetString(EndpointInterfaceNamePrefix)
 	c.DevicePreFilter = viper.GetString(PrefilterDevice)
 	c.DisableCiliumEndpointCRD = viper.GetBool(DisableCiliumEndpointCRDName)


### PR DESCRIPTION
Add an option --enable-well-known-identities to allow disabling well-known
identities for all new deployments which are not using managed etcd. This
reduces the number of security identities whitelisted for each endpoint.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9698)
<!-- Reviewable:end -->
