### PR TITLE
Rate limit ec2:DescribeSubnets

### DIFF
--- a/pkg/aws/ec2/ec2.go
+++ b/pkg/aws/ec2/ec2.go
@@ -245,6 +245,8 @@ func (c *Client) GetVpcs(ctx context.Context) (types.VpcMap, error) {
 
 // describeSubnets lists all subnets
 func (c *Client) describeSubnets(ctx context.Context) ([]ec2.Subnet, error) {
+	c.rateLimit(ctx, "DescribeSubnets")
+
 	sinceStart := spanstat.Start()
 	listReq := c.ec2Client.DescribeSubnetsRequest(&ec2.DescribeSubnetsInput{})
 	result, err := listReq.Send(ctx)


### PR DESCRIPTION
Signed-off-by: Vlad Ungureanu <vladu@palantir.com>

<!-- Description of change -->
Adds rate limiting to the ec2:DescribeSubnets calls. Looks like it was left out for this only one API call to EC2.

```release-note
Rate limit ec2:DescribeSubnets in the EC2 client
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9700)
<!-- Reviewable:end -->
