### PR TITLE
Allow selecting AWS ENI security groups by tags

### DIFF
--- a/Documentation/concepts/ipam/eni.rst
+++ b/Documentation/concepts/ipam/eni.rst
@@ -136,11 +136,18 @@ allocation:
   If unspecified, this value defaults to 1 which means that ``eth0`` will not
   be used for pod IPs.
 
-``spec.eni.security-groups``
-  The list of security groups to attach to any ENI that is created and attached
-  to the instance.
+``spec.eni.security-group-tags``
+  The list tags which will be used to filter the security groups to
+  attach to any ENI that is created and attached to the instance.
 
-  If unspecified, the security groups of ``eth0`` will be used.
+  If unspecified, the security group ids passed in
+  ``spec.eni.security-groups`` field will be used.
+
+``spec.eni.security-groups``
+  The list of security group ids to attach to any ENI that is created
+  and attached to the instance.
+
+  If unspecified, the security group ids of ``eth0`` will be used.
 
 ``spec.eni.subnet-tags``
   The tags used to select the AWS subnets for IP allocation. This is an
@@ -307,8 +314,17 @@ After determining the subnet and interface index, the ENI is created and
 attached to the EC2 instance using the methods ``CreateNetworkInterface`` and
 ``AttachNetworkInterface`` of the EC2 API.
 
-The security groups attached to the ENI will be equivalent to
-``spec.eni.security-groups``. The description will be in the following format:
+The security group ids attached to the ENI are computed in the following order:
+
+ 1. The field ``spec.eni.security-groups`` is consulted first. If this is set
+    then these will be the security group ids attached to the newly created ENI.
+ 2. The filed ``spec.eni.security-group-tags`` is consulted. If this is set then
+    the operator will list all security groups in the account and will attach to
+    the ENI the ones that match the list of tags passed.
+ 3. Finally if none of the above fields are set then the newly created ENI will
+    inherit the security group ids of ``eth0`` of the machine.
+
+The description will be in the following format:
 
 .. code-block:: go
 
@@ -342,6 +358,7 @@ perform ENI creation and IP allocation:
  * ``DescribeNetworkInterfaces``
  * ``DescribeSubnets``
  * ``DescribeVpcs``
+ * ``DescribeSecurityGroups``
  * ``CreateNetworkInterface``
  * ``AttachNetworkInterface``
  * ``ModifyNetworkInterface``

--- a/pkg/aws/ec2/mock/mock_test.go
+++ b/pkg/aws/ec2/mock/mock_test.go
@@ -36,7 +36,7 @@ type MockSuite struct{}
 var _ = check.Suite(&MockSuite{})
 
 func (e *MockSuite) TestMock(c *check.C) {
-	api := NewAPI([]*types.Subnet{{ID: "s-1", AvailableAddresses: 100}}, []*types.Vpc{{ID: "v-1"}})
+	api := NewAPI([]*types.Subnet{{ID: "s-1", AvailableAddresses: 100}}, []*types.Vpc{{ID: "v-1"}}, []*types.SecurityGroup{{ID: "sg-1"}})
 	c.Assert(api, check.Not(check.IsNil))
 
 	eniID1, _, err := api.CreateNetworkInterface(context.TODO(), 8, "s-1", "desc", []string{"sg1", "sg2"})
@@ -75,7 +75,7 @@ func (e *MockSuite) TestMock(c *check.C) {
 }
 
 func (e *MockSuite) TestSetMockError(c *check.C) {
-	api := NewAPI([]*types.Subnet{}, []*types.Vpc{})
+	api := NewAPI([]*types.Subnet{}, []*types.Vpc{}, []*types.SecurityGroup{})
 	c.Assert(api, check.Not(check.IsNil))
 
 	mockError := errors.New("error")
@@ -106,7 +106,7 @@ func (e *MockSuite) TestSetMockError(c *check.C) {
 }
 
 func (e *MockSuite) TestSetDelay(c *check.C) {
-	api := NewAPI([]*types.Subnet{}, []*types.Vpc{})
+	api := NewAPI([]*types.Subnet{}, []*types.Vpc{}, []*types.SecurityGroup{})
 	c.Assert(api, check.Not(check.IsNil))
 
 	api.SetDelay(AllOperations, time.Second)
@@ -119,7 +119,7 @@ func (e *MockSuite) TestSetDelay(c *check.C) {
 }
 
 func (e *MockSuite) TestSetLimiter(c *check.C) {
-	api := NewAPI([]*types.Subnet{{ID: "s-1", AvailableAddresses: 100}}, []*types.Vpc{{ID: "v-1"}})
+	api := NewAPI([]*types.Subnet{{ID: "s-1", AvailableAddresses: 100}}, []*types.Vpc{{ID: "v-1"}}, []*types.SecurityGroup{{ID: "sg-1"}})
 	c.Assert(api, check.Not(check.IsNil))
 
 	api.SetLimiter(10.0, 2)

--- a/pkg/aws/eni/instances_test.go
+++ b/pkg/aws/eni/instances_test.go
@@ -21,6 +21,7 @@ import (
 
 	metricsmock "github.com/cilium/cilium/pkg/aws/eni/metrics/mock"
 	"github.com/cilium/cilium/pkg/aws/types"
+	"github.com/cilium/cilium/pkg/checker"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 
 	"gopkg.in/check.v1"
@@ -258,7 +259,7 @@ func (e *ENISuite) TestGetSecurityGroupByTags(c *check.C) {
 	}
 	sgGroups = mngr.FindSecurityGroupByTags("vpc-1", reqTags)
 	c.Assert(sgGroups, check.HasLen, 1)
-	c.Assert(sgGroups[0].Tags, check.DeepEquals, reqTags)
+	c.Assert(sgGroups[0].Tags, checker.DeepEquals, reqTags)
 
 	// iteration 2
 	mngr.Resync(context.TODO())
@@ -267,7 +268,7 @@ func (e *ENISuite) TestGetSecurityGroupByTags(c *check.C) {
 	}
 	sgGroups = mngr.FindSecurityGroupByTags("vpc-1", reqTags)
 	c.Assert(sgGroups, check.HasLen, 1)
-	c.Assert(sgGroups[0].Tags, check.DeepEquals, reqTags)
+	c.Assert(sgGroups[0].Tags, checker.DeepEquals, reqTags)
 
 	// iteration 3
 	mngr.Resync(context.TODO())
@@ -276,8 +277,8 @@ func (e *ENISuite) TestGetSecurityGroupByTags(c *check.C) {
 	}
 	sgGroups = mngr.FindSecurityGroupByTags("vpc-1", reqTags)
 	c.Assert(sgGroups, check.HasLen, 2)
-	c.Assert(sgGroups[0].Tags, check.DeepEquals, reqTags)
-	c.Assert(sgGroups[1].Tags, check.DeepEquals, reqTags)
+	c.Assert(sgGroups[0].Tags, checker.DeepEquals, reqTags)
+	c.Assert(sgGroups[1].Tags, checker.DeepEquals, reqTags)
 }
 
 func (e *ENISuite) TestGetENIs(c *check.C) {

--- a/pkg/aws/eni/node_manager.go
+++ b/pkg/aws/eni/node_manager.go
@@ -41,6 +41,7 @@ type nodeManagerAPI interface {
 	GetSubnet(subnetID string) *types.Subnet
 	GetSubnets(ctx context.Context) types.SubnetMap
 	FindSubnetByTags(vpcID, availabilityZone string, required types.Tags) *types.Subnet
+	FindSecurityGroupByTags(vpcID string, required types.Tags) []*types.SecurityGroup
 	Resync(ctx context.Context) time.Time
 	UpdateENI(instanceID string, eni *v2.ENI)
 }

--- a/pkg/aws/eni/node_manager_test.go
+++ b/pkg/aws/eni/node_manager_test.go
@@ -25,6 +25,7 @@ import (
 	ec2mock "github.com/cilium/cilium/pkg/aws/ec2/mock"
 	metricsmock "github.com/cilium/cilium/pkg/aws/eni/metrics/mock"
 	"github.com/cilium/cilium/pkg/aws/types"
+	"github.com/cilium/cilium/pkg/checker"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/testutils"
@@ -301,7 +302,7 @@ func (e *ENISuite) TestNodeManagerENIWithSGTags(c *check.C) {
 	enis := node.ENIs()
 	delete(enis, eniID1)
 	for _, eni := range enis {
-		c.Assert(eni.SecurityGroups, check.DeepEquals, []string{"sg-1"})
+		c.Assert(eni.SecurityGroups, checker.DeepEquals, []string{"sg-1"})
 	}
 }
 

--- a/pkg/aws/types/types.go
+++ b/pkg/aws/types/types.go
@@ -15,7 +15,7 @@
 package types
 
 import (
-	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 )
 
 // Tags implements generic key value tags used by AWS
@@ -64,6 +64,18 @@ type Vpc struct {
 
 	// PrimaryCIDR is the primary IPv4 CIDR
 	PrimaryCIDR string
+}
+
+// SecurityGroup is the representation of an AWS Security Group
+type SecurityGroup struct {
+	// ID is the SecurityGroup ID
+	ID string
+
+	// VpcID is the VPC ID in which the security group resides
+	VpcID string
+
+	// Tags are the tags of the security group
+	Tags Tags
 }
 
 // instance is the minimal representation of an AWS instance as needed by the
@@ -120,3 +132,6 @@ type SubnetMap map[string]*Subnet
 
 // VpcMap indexes AWS VPCs by VPC ID
 type VpcMap map[string]*Vpc
+
+// SecurityGroupMap indexes AWS Security Groups by security group ID
+type SecurityGroupMap map[string]*SecurityGroup

--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -408,6 +408,10 @@ func createNodeCRD(clientset apiextensionsclient.Interface) error {
 												},
 											},
 										},
+										"security-group-tags": {
+											Type:        "object",
+											Description: "security-group-tags represents a filter to narrow down the security group ids which will be attached on the allocated ENI",
+										},
 										"subnet-tags": {
 											Type:        "object",
 											Description: "subnet-tags represents a filter to narrow down the available subnets in which the ENI will be allocated",

--- a/pkg/k8s/apis/cilium.io/v2/types.go
+++ b/pkg/k8s/apis/cilium.io/v2/types.go
@@ -803,6 +803,12 @@ type ENISpec struct {
 	// +optional
 	SecurityGroups []string `json:"security-groups,omitempty"`
 
+	// SecurityGroupTags is the list of tags to use when evaliating what
+	// AWS security groups to use for the ENI.
+	//
+	// +optional
+	SecurityGroupTags map[string]string `json:"security-group-tags,omitempty"`
+
 	// SubnetTags is the list of tags to use when evaluating what AWS
 	// subnets to use for ENI and IP allocation
 	//

--- a/pkg/k8s/apis/cilium.io/v2/zz_generated.deepcopy.go
+++ b/pkg/k8s/apis/cilium.io/v2/zz_generated.deepcopy.go
@@ -495,6 +495,13 @@ func (in *ENISpec) DeepCopyInto(out *ENISpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.SecurityGroupTags != nil {
+		in, out := &in.SecurityGroupTags, &out.SecurityGroupTags
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.SubnetTags != nil {
 		in, out := &in.SubnetTags, &out.SubnetTags
 		*out = make(map[string]string, len(*in))


### PR DESCRIPTION
<!-- Description of change -->
This PR adds a new field in the ENI spec called `security-group-tags` which will allow the user to specify a list of tags which will be used to filter down the AWS security groups that will be attached to the ENI subsequently created.

Added the main logic in the `InstancesManager` so we do not call AWS `ec2:DescribeSecurityGroups` at every ENI creation event. The `InstancesManager` controller runs and at every `Resync` will call `GetSecurityGroups` which stores the list locally.

Fixes: https://github.com/cilium/cilium/issues/9656

```release-note
Expands the CiliumNode ENI spec to include `security-group-tags` which allows selecting the security groups associated to the newly created ENI to be filtered by tags.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9702)
<!-- Reviewable:end -->
