### PR TITLE
CI: ExecInPods returns an error when no pods are found

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1946,10 +1946,14 @@ func (kub *Kubectl) GatherCiliumCoreDumps(ctx context.Context, ciliumPod string)
 }
 
 // ExecInFirstPod runs given command in one pod that matches given selector and namespace
+// An error is returned if no pods can be found
 func (kub *Kubectl) ExecInFirstPod(ctx context.Context, namespace, selector, cmd string, options ...ExecOptions) (result *CmdRes, err error) {
 	names, err := kub.GetPodNamesContext(ctx, namespace, selector)
 	if err != nil {
 		return nil, err
+	}
+	if len(names) == 0 {
+		return nil, fmt.Errorf("Cannot find pods matching %s to execute %s", selector, cmd)
 	}
 
 	for _, name := range names {


### PR DESCRIPTION
This is part of the work to run on EKS. See https://github.com/cilium/cilium/issues/9678 and https://github.com/cilium/cilium/pull/9675

Returning an error when no pods match should fix panics when nil error
returns imply a non-nil CmdRes. This occurred in some callers of
ExecInHostNS, itself a simple wrapper of ExecInPods.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9705)
<!-- Reviewable:end -->
