### PR TITLE
CI: Wait longer for monitor output in DataPathConfiguration

### DIFF
--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -19,6 +19,7 @@ import (
 	"io/ioutil"
 	"regexp"
 	"strconv"
+	"time"
 
 	"github.com/cilium/cilium/test/config"
 	. "github.com/cilium/cilium/test/ginkgo-ext"
@@ -559,6 +560,8 @@ func monitorConnectivityAcrossNodes(kubectl *helpers.Kubectl, monitorLog string)
 
 	By(fmt.Sprintf("Launching cilium monitor on %q", ciliumPodK8s1))
 	monitorStop := kubectl.MonitorStart(helpers.KubeSystemNamespace, ciliumPodK8s1, monitorLog)
+	By(fmt.Sprintf("Waiting 10s for monitor output to be collected"))
+	time.Sleep(10 * time.Second)
 	result, targetIP := testPodConnectivityAndReturnIP(kubectl, requireMultiNode, 2)
 	monitorStop()
 	ExpectWithOffset(1, result).Should(BeTrue(), "Connectivity test between nodes failed")


### PR DESCRIPTION
This is part of the work to run on EKS. See #9678 and #9675

When running on EKS, the timing seems different from the CI cluster.
Simple checks for the occurence of packets in the monitor output seem
racey and the monitor output being scanned seems truncated, as opposed
to missing the packets completely. The collection function now waits 10s
for the output. It would be better to parse the output live with a
timeout but that is a much larger refactor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9707)
<!-- Reviewable:end -->
