### PR TITLE
.github: add github actions to cilium

### DIFF
--- a/.github/cilium-actions-v1.6.yml
+++ b/.github/cilium-actions-v1.6.yml
@@ -1,0 +1,14 @@
+project: "https://github.com/cilium/cilium/projects/91"
+column: "In progress"
+auto-label:
+  - "kind/backports"
+  - "backport/1.6"
+require-msgs-in-commit:
+  - msg: "Signed-off-by"
+    helper: "https://docs.cilium.io/en/stable/contributing/contributing/#developer-s-certificate-of-origin"
+    set-labels:
+      - "dont-merge/needs-sign-off"
+block-pr-with:
+  labels-set:
+    - regex-label: "dont-merge/.*"
+      helper: "Blocking mergeability of PR as 'dont-merge/.*' labels are set"

--- a/.github/workflows/cilium-actions-v1.6.yml
+++ b/.github/workflows/cilium-actions-v1.6.yml
@@ -1,0 +1,27 @@
+name: maintainers-little-helper-v1.6
+
+on:
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+      - opened
+      - edited
+      - closed
+      - reopened
+      - synchronize
+      - ready_for_review
+      - locked
+      - unlocked
+    branches:
+      - v1.6
+
+jobs:
+  cilium-github-actions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Labeler
+        uses: docker://docker.io/cilium/github-actions:v0.1.0
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CONFIG_PATH: .github/cilium-actions-v1.6.yml


### PR DESCRIPTION
Make use of https://github.com/cilium/github-actions to automate PR
interactions in Cilium repository.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9711)
<!-- Reviewable:end -->
