### PR TITLE
Dockerfile runtime: add python3 dependency

### DIFF
--- a/contrib/packaging/docker/Dockerfile.runtime
+++ b/contrib/packaging/docker/Dockerfile.runtime
@@ -39,7 +39,9 @@ RUN \
 apt-get update && \
 apt-get install -y --no-install-recommends make git curl ca-certificates xz-utils \
 # Additional iproute2 build dependencies
-  gcc git pkg-config bison flex build-essential && \
+  gcc git pkg-config bison flex build-essential \
+# Additional bpftool dependencies
+  python3 && \
 #
 # iproute2
 #


### PR DESCRIPTION
It seems bpftool can't be build without python3 so we need to install
python3 in order to build it.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9715)
<!-- Reviewable:end -->
