### PR TITLE
doc: the namespace is wrong when validating cilium on Azure CNI

### DIFF
--- a/Documentation/gettingstarted/cni-chaining-azure-cni.rst
+++ b/Documentation/gettingstarted/cni-chaining-azure-cni.rst
@@ -35,7 +35,7 @@ them.
 If you are unsure if a pod is managed by Cilium or not, run ``kubectl get cep``
 in the respective namespace and see if the pod is listed.
 
-.. include:: k8s-install-validate.rst
+.. include:: k8s-install-azure-cni-validate.rst
 .. include:: hubble-install.rst
 .. include:: getting-started-next-steps.rst
 

--- a/Documentation/gettingstarted/k8s-install-azure-cni-validate.rst
+++ b/Documentation/gettingstarted/k8s-install-azure-cni-validate.rst
@@ -1,0 +1,46 @@
+Validate the Installation
+=========================
+
+You can monitor as Cilium and all required components are being installed:
+
+.. parsed-literal::
+
+    kubectl -n cilium get pods --watch
+    NAME                                    READY   STATUS              RESTARTS   AGE
+    cilium-operator-cb4578bc5-q52qk         0/1     Pending             0          8s
+    cilium-s8w5m                            0/1     PodInitializing     0          7s
+
+It may take a couple of minutes for all components to come up:
+
+.. parsed-literal::
+
+    cilium-operator-cb4578bc5-q52qk         1/1     Running   0          4m13s
+    cilium-s8w5m                            1/1     Running   0          4m12s
+
+Deploy the connectivity test
+----------------------------
+
+You can deploy the "connectivity-check" to test connectivity between pods.
+
+.. parsed-literal::
+
+    kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/connectivity-check/connectivity-check.yaml
+
+It will deploy a simple probe and echo server running with multiple replicas.
+The probe will only report readiness while it can successfully reach the echo
+server:
+
+.. code:: bash
+
+    kubectl get pods
+    NAME                     READY   STATUS    RESTARTS   AGE
+    echo-585798dd9d-ck5xc    1/1     Running   0          75s
+    echo-585798dd9d-jkdjx    1/1     Running   0          75s
+    echo-585798dd9d-mk5q8    1/1     Running   0          75s
+    echo-585798dd9d-tn9t4    1/1     Running   0          75s
+    echo-585798dd9d-xmr4p    1/1     Running   0          75s
+    probe-866bb6f696-9lhfw   1/1     Running   0          75s
+    probe-866bb6f696-br4dr   1/1     Running   0          75s
+    probe-866bb6f696-gv5kf   1/1     Running   0          75s
+    probe-866bb6f696-qg2b7   1/1     Running   0          75s
+    probe-866bb6f696-tb926   1/1     Running   0          75s


### PR DESCRIPTION
The namespace mentioned in the chaining.yaml is different from
the namespace queried using kubectl under validation section.
This seems to be an issue because we are re-using the file
k8s-install-validate.rst.

Fixes: #9710
Signed-off-by: Swaminathan Vasudevan <svasudevan@suse.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9717)
<!-- Reviewable:end -->
