### PR TITLE
Fix compilation issue when building cilium-runtime

### DIFF
--- a/contrib/packaging/docker/Dockerfile.runtime
+++ b/contrib/packaging/docker/Dockerfile.runtime
@@ -39,7 +39,7 @@ RUN \
 apt-get update && \
 apt-get install -y --no-install-recommends make git curl ca-certificates xz-utils \
 # Additional iproute2 build dependencies
-  gcc git pkg-config bison flex build-essential && \
+  gcc git pkg-config bison flex build-essential python3 && \
 #
 # iproute2
 #


### PR DESCRIPTION
Missing python3 causes the compilation of bpftool to fail
with the following error:
"/bin/sh: 1: /tmp/linux/scripts/bpf_helpers_doc.py: not found
Makefile:184: recipe for target 'bpf_helper_defs.h' failed"

Fixes: #9719
Signed-off-by: Jianlin Lv <Jianlin.Lv@arm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9720)
<!-- Reviewable:end -->
