### PR TITLE
cilium: encryption bugtool should remove aead, comp and auth-trunk keys

### DIFF
--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -96,7 +96,7 @@ func defaultCommands(confDir string, cmdDir string, k8sPods []string) []string {
 		"ip -6 route show table 200",
 		// xfrm
 		"ip xfrm policy",
-		"ip -s xfrm state | awk '!/auth|enc/'",
+		"ip -s xfrm state | awk '!/auth|enc|aead|auth-trunc|comp/'",
 		// gops
 		fmt.Sprintf("gops memstats $(pidof %s)", components.CiliumAgentName),
 		fmt.Sprintf("gops stack $(pidof %s)", components.CiliumAgentName),


### PR DESCRIPTION
Originally encryption only supported end and auth key types but we
have also added aead types now as well. This adds all the supported
ALGO types for stripping from bugtool this future proofs us if we
add more keys later and also removes the aead keys which is an algo
we support today.

Signed-off-by: John Fastabend <john.fastabend@gmail.com>

Please ensure your pull request adheres to the following guidelines:

```release-note
Fix bugtool support for aead encryption algorithm.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9722)
<!-- Reviewable:end -->
