### PR TITLE
test: Extend MetalLB test case

### DIFF
--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -216,6 +216,16 @@ var _ = Describe("K8sServicesTest", func() {
 			}
 		}
 
+		doRequestsFromOutsideClient := func(url string, count int) {
+			ssh := helpers.GetVagrantSSHMeta(helpers.K8s1VMName())
+			By("Making %d HTTP requests from outside cluster to %q", count, url)
+			for i := 1; i <= count; i++ {
+				res := ssh.ContainerExec("client-from-outside", helpers.CurlFail(url))
+				ExpectWithOffset(1, res).Should(helpers.CMDSuccess(),
+					"Can not connect to service %q from outside cluster", url)
+			}
+		}
+
 		testNodePort := func(bpfNodePort bool) {
 			var data v1.Service
 			getURL := func(host string, port int32) string {
@@ -369,6 +379,7 @@ var _ = Describe("K8sServicesTest", func() {
 						helpers.DefaultNamespace, "test-lb", 30*time.Second)
 					Expect(err).Should(BeNil(), "Cannot retrieve loadbalancer IP for test-lb")
 
+					doRequestsFromOutsideClient("http://"+lbIP, 10)
 					doRequests("http://"+lbIP, 10, helpers.K8s1)
 					doRequests("http://"+lbIP, 10, helpers.K8s2)
 				})

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -341,5 +341,7 @@ fi
 docker network create --subnet=192.168.9.0/24 outside
 docker run --net outside --ip 192.168.9.10 --restart=always -d docker.io/cilium/demo-httpd:latest
 docker run --net outside --ip 192.168.9.11 --restart=always -d docker.io/cilium/demo-httpd:latest
+docker run --name client-from-outside --net outside --ip 192.168.9.12 \
+            --restart=always -d docker.io/cilium/demo-client:latest
 
 sudo touch /etc/provision_finished


### PR DESCRIPTION
This PR:

* Starts `client-from-outside` Docker container on each VM. The containers are going to be used for testing cases when a connectivity from outside is required (e.g. accessing a LB provisioned by MetalLB).
* Extends the MetalLB case by sending requests to the LB from the `client-from-outside`. This corresponds to a case when a host outside a k8s cluster tries to send a request to a `LoadBalancer `service.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9723)
<!-- Reviewable:end -->
