### PR TITLE
Relax limits for maximum number of CIDR prefixes (40 -> unlimited)

### DIFF
--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -27,8 +27,6 @@ import (
 
 const (
 	maxPorts = 40
-	// MaxCIDRPrefixLengths is used to prevent compile failures at runtime.
-	MaxCIDRPrefixLengths = 40
 )
 
 type exists struct{}
@@ -166,12 +164,6 @@ func (i *IngressRule) sanitize() error {
 		}
 	}
 
-	// FIXME GH-1781 count coalesced CIDRs and restrict the number of
-	// prefix lengths based on the CIDRSet exclusions.
-	if l := len(prefixLengths); l > MaxCIDRPrefixLengths {
-		return fmt.Errorf("too many ingress CIDR prefix lengths %d/%d", l, MaxCIDRPrefixLengths)
-	}
-
 	i.SetAggregatedSelectors()
 
 	return nil
@@ -271,12 +263,6 @@ func (e *EgressRule) sanitize() error {
 		if err != nil {
 			return err
 		}
-	}
-
-	// FIXME GH-1781 count coalesced CIDRs and restrict the number of
-	// prefix lengths based on the CIDRSet exclusions.
-	if l := len(prefixLengths); l > MaxCIDRPrefixLengths {
-		return fmt.Errorf("too many egress CIDR prefix lengths %d/%d", l, MaxCIDRPrefixLengths)
 	}
 
 	e.SetAggregatedSelectors()

--- a/pkg/policy/l3.go
+++ b/pkg/policy/l3.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Authors of Cilium
+// Copyright 2016-2019 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,14 +15,12 @@
 package policy
 
 import (
-	"fmt"
 	"net"
 	"sort"
 	"strconv"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/labels"
-	"github.com/cilium/cilium/pkg/policy/api"
 )
 
 // CIDRPolicyMapRule holds a L3 (CIDR) prefix and the rule labels that allow it.
@@ -198,11 +196,5 @@ func (cp *CIDRPolicy) GetModel() *models.CIDRPolicy {
 
 // Validate returns error if the CIDR policy might lead to code generation failure
 func (cp *CIDRPolicy) Validate() error {
-	if cp == nil {
-		return nil
-	}
-	if l := len(cp.Ingress.IPv6PrefixCount); l > api.MaxCIDRPrefixLengths {
-		return fmt.Errorf("too many ingress CIDR prefix lengths %d/%d", l, api.MaxCIDRPrefixLengths)
-	}
 	return nil
 }

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -18,7 +18,6 @@ package policy
 
 import (
 	"bytes"
-	"fmt"
 	"net"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -967,26 +966,6 @@ func (ds *PolicyTestSuite) TestL3Policy(c *C) {
 			FromCIDR: []api.CIDR{"10.0.1.0/34"},
 		}},
 	}.Sanitize()
-	c.Assert(err, Not(IsNil))
-}
-
-func (ds *PolicyTestSuite) TestL3PolicyRestrictions(c *C) {
-	// Check rejection of too many prefix lengths
-	cidrs := []api.CIDR{}
-	for i := 1; i < 42; i++ {
-		cidrs = append(cidrs, api.CIDR(fmt.Sprintf("%d::/%d", i, i)))
-	}
-	apiRule2 := api.Rule{
-		EndpointSelector: barSelector,
-		Ingress:          []api.IngressRule{{FromCIDR: cidrs}},
-	}
-	err := apiRule2.Sanitize()
-	c.Assert(err, Not(IsNil))
-	apiRule3 := api.Rule{
-		EndpointSelector: barSelector,
-		Egress:           []api.EgressRule{{ToCIDR: cidrs}},
-	}
-	err = apiRule3.Sanitize()
 	c.Assert(err, Not(IsNil))
 }
 


### PR DESCRIPTION
This limit was arbitrary and should not apply to most deployments (on
kernels 4.11 or higher). Later code in the daemon will enforce this
limit based on whether the limit really needs to be here for the given
kernel version, so we can remove these checks entirely from the API
validation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9724)
<!-- Reviewable:end -->
