### PR TITLE
doc: update BPF instruction limit

### DIFF
--- a/Documentation/bpf.rst
+++ b/Documentation/bpf.rst
@@ -181,7 +181,8 @@ architectures in order to perform pointer arithmetics, pass pointers but also pa
 bit values into helper functions, and to allow for 64 bit atomic operations.
 
 The maximum instruction limit per program is restricted to 4096 BPF instructions,
-which, by design, means that any program will terminate quickly. Although the
+which, by design, means that any program will terminate quickly. For kernel newer
+than 5.1 this limit was lifted to 1 million BPF instructions. Although the
 instruction set contains forward as well as backward jumps, the in-kernel BPF
 verifier will forbid loops so that termination is always guaranteed. Since BPF
 programs run inside the kernel, the verifier's job is to make sure that these are


### PR DESCRIPTION
Signed-off-by: Lehner Florian <dev@der-flo.net>

Please ensure your pull request adheres to the following guidelines:

- [ x] For first time contributors, read [Submitting a pull request](http://docs.cilium.io/en/stable/contributing/contributing/#submitting-a-pull-request)
- [~] All code is covered by unit and/or runtime tests where feasible.
  _no code was changed_
- [~] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue. 
  _no code was changed_
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](http://docs.cilium.io/en/stable/contributing/contributing/#dev-coo).
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->

This PR updates the documentation of the BPF instruction limit. This limit was changed in [1] from 4096 to 1M.

[1] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=c04c0d2b968ac45d6ef020316808ef6c82325a82

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9727)
<!-- Reviewable:end -->
