### PR TITLE
Add externalTrafficPolicy=Local CI tests

### DIFF
--- a/test/k8sT/manifests/demo_ds.yaml
+++ b/test/k8sT/manifests/demo_ds.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: web
-        image: docker.io/cilium/demo-httpd:latest
+        image: docker.io/cilium/echoserver:1.10
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
@@ -61,6 +61,7 @@ metadata:
 spec:
   ports:
   - port: 80
+    targetPort: 80
   selector:
     zgroup: testDS
 ---
@@ -70,6 +71,21 @@ metadata:
   name: test-nodeport
 spec:
   type: NodePort
+  ports:
+  - port: 10080
+    targetPort: 80
+    protocol: TCP
+    name: http
+  selector:
+    zgroup: testDS
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-nodeport-local
+spec:
+  type: NodePort
+  externalTrafficPolicy: Local
   ports:
   - port: 10080
     targetPort: 80

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -341,7 +341,20 @@ fi
 docker network create --subnet=192.168.9.0/24 outside
 docker run --net outside --ip 192.168.9.10 --restart=always -d docker.io/cilium/demo-httpd:latest
 docker run --net outside --ip 192.168.9.11 --restart=always -d docker.io/cilium/demo-httpd:latest
-docker run --name client-from-outside --net outside --ip 192.168.9.12 \
-            --restart=always -d docker.io/cilium/demo-client:latest
+
+if [[ "${HOST}" == "k8s1" ]]; then
+    # To avoid SNAT'ing source IP, we create a network with masquerading disabled.
+    # Also, we install a route on each other node to make it possible a replies from
+    # remote nodes to reach containers attached to the network.
+    docker network create --subnet=192.168.10.0/24 \
+        --opt 'com.docker.network.bridge.enable_ip_masquerade=false' \
+        outside-no-masq
+    # NOTE: when changing "client-from-outside" IP addr, make sure that the IP addr
+    # is changed in the tests (grep for the IP addr).
+    docker run --name client-from-outside --net outside-no-masq --ip 192.168.10.10 \
+        --restart=always -d docker.io/cilium/demo-client:latest
+else
+    sudo ip route add 192.168.10.0/24 via 192.168.36.11 || true
+fi
 
 sudo touch /etc/provision_finished


### PR DESCRIPTION
This PR:

* Creates the `outside-no-masq` network and attaches the `client-from-outside` container to the network. The former is the Docker network with masquerading being disabled. The network (and the container) is created only on the "k8s1" host, as we want to avoid MASQ in the `externalTrafficPolicy=Local` test which checks for a real source IP addr of the client.
* Adds a test for `externalTrafficPolicy=Local` (for kube-proxy) which checks whether a source IP address of a client is preserved (not MASQ'd).
* Changes the `cilium-demo-httpd` image to the `echoserver`, as the latter returns a client IP addr which is used by the test ^^.

/cc @gandro

```release-note
Add tests for a service annotated with externalTrafficPolicy=Local
```

Fix #9284.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9728)
<!-- Reviewable:end -->
