### PR TITLE
eni: Fix AWS ENI allocation exceeding IP limits for smaller instances

### DIFF
--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -352,7 +352,8 @@ func (n *Node) allocateENI(ctx context.Context, s *types.Subnet, a *allocatableR
 	neededAddresses := n.stats.neededIPs
 
 	desc := "Cilium-CNI (" + n.resource.Spec.ENI.InstanceID + ")"
-	toAllocate := int64(math.IntMin(neededAddresses+nodeResource.Spec.ENI.MaxAboveWatermark, a.limits.IPv4))
+	// Must allocate secondary ENI IPs as needed, up to ENI instance limit - 1 (reserve 1 for primary IP)
+	toAllocate := int64(math.IntMin(neededAddresses+nodeResource.Spec.ENI.MaxAboveWatermark, a.limits.IPv4-1))
 	// Validate whether request has already been fulfilled in the meantime
 	if toAllocate == 0 {
 		n.mutex.RUnlock()


### PR DESCRIPTION
For instance types with ENI IP limits lower than the currently
configured spec.eni.pre-allocate, Node.allocateENI() was attempting to
allocate a number of secondary IPs equal to the ENI IP limit, not
accounting for the primary IP. This change causes it to allocate limit-1
secondary IP addresses instead.

This caused failures using default configuration for node groups in AWS
that used smaller instance sizes. For an instance type such as t3.small
with limit of 4 IPs, an ENI with 5 IPs (1 primary, 4 secondary)  would
be allocated which failed to attach.

Fixes: #9730

```release-note
eni: Fix AWS ENI allocation exceeding IP limits for smaller instances
```

Signed off by: Hunter Massey <humassey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9732)
<!-- Reviewable:end -->
