### PR TITLE
docs: Upgrade about tofqdns-min-ttl default and zombies

### DIFF
--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -302,6 +302,14 @@ IMPORTANT: Changes required before upgrading to 1.7.0
   ``container-runtime`` and ``container-runtime-endpoint`` will not have any
   effect and the flag removal is scheduled for v1.8.0
 
+* The default ``--tofqdns-min-ttl`` value has been reduced to 1 hour. Specific
+  IPs in DNS entries are no longer expired when in-use by existing connections
+  that are allowed by policy. Prior deployments that used the default value may
+  now experience denied new connections if endpoints reuse DNS data more than 1
+  hour after the initial lookup without making new lookups. Long lived
+  connections that previously outlived DNS entries are now better supported,
+  and will not be disconnected when the corresponding DNS entry expires.
+
 New ConfigMap Options
 ~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
We lowered the default value of tofqdns-min-ttl to 1 hour with the
introduction of zombies. This may be unexpected when upgrading,
especially as many would not have changed from the default.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9737)
<!-- Reviewable:end -->
