### PR TITLE
Add eks restart pods

### DIFF
--- a/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
@@ -152,6 +152,21 @@ spec:
               if grep -q 'docker' /etc/crictl.yaml; then
                 # Works for COS, ubuntu
                 for f in `find /var/lib/cni/networks/ -type f ! -name lock ! -name last_reserved_ip.0`; do docker rm -f $(cat $f) || true; done
+              elif [ -n "$(docker ps --format "{{.Image}}" | grep ^[0-9]*\.dkr\.ecr\.[a-z]*-[a-z]*-[0-9]*\.amazonaws\.com/amazon-k8s-cni)" ]; then
+                timeout=1
+                for i in $(seq 1 7); do
+                  echo "Checking introspection API"
+                  curl localhost:61679 && retry=false || retry=true
+                  if [ $retry == false ]; then break ; fi
+                  sleep "$timeout"
+                  timeout=$(($timeout * 2))
+                done
+
+                for pod in $(curl "localhost:61679/v1/pods" 2> /dev/null | jq -r '. | keys[]'); do
+                  container_id=$(echo "$pod" | awk -F_ ' { print $3 } ' | cut -c1-12)
+                  echo "Restarting ${container_id}"
+                  docker rm -f "${container_id}" || true
+                done
               else
                 # COS-beta (with containerd)
                 for f in `find /var/lib/cni/networks/ -type f ! -name lock ! -name last_reserved_ip.0`; do crictl stopp $(cat $f) || true; done


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](http://docs.cilium.io/en/stable/contributing/contributing/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue. 
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](http://docs.cilium.io/en/stable/contributing/contributing/#dev-coo).
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->
`restartPods` does not work for Kubernetes clusters using the aws vpc cni plugin. This adds functionality to check if the node is running the aws-node CNI plugin container. If this is the case it will attempt to kill all CNI managed containers by querying the AWS CNI plugin introspection API.

Fixes: #9571

```release-note
Added support for `restartPods` Helm chart option when running node-init on EKS.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9740)
<!-- Reviewable:end -->
