### PR TITLE
envoy: Update to 1.12.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:7f6cab51ea2f4692a3e1067e1060f42818324bc2 as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:9e8d7bb5e02d6038d6cf0ec3f28bf4019f3c7d79 as cilium-envoy
 
 #
 # Cilium incremental build. Should be fast given builder-deps is up-to-date!


### PR DESCRIPTION
Update to Envoy release 1.12.2 containing the security fixes released
on 12/10/2019.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

```release-note
Envoy is updated to release 1.12.2, including important security fixes.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9741)
<!-- Reviewable:end -->
