### PR TITLE
fqdn: Support setting tofqdns-min-ttl to 0

### DIFF
--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1739,10 +1739,9 @@ func (c *DaemonConfig) Populate() {
 	} else {
 		log.Fatal("tofqdns-max-deferred-connection-deletes must be positive, or 0 to disable deferred connection deletion")
 	}
-	userSetMinTTL := viper.GetInt(ToFQDNsMinTTL)
 	switch {
-	case userSetMinTTL != 0: // set by user
-		c.ToFQDNsMinTTL = userSetMinTTL
+	case viper.IsSet(ToFQDNsMinTTL): // set by user
+		c.ToFQDNsMinTTL = viper.GetInt(ToFQDNsMinTTL)
 	case c.ToFQDNsEnablePoller:
 		c.ToFQDNsMinTTL = defaults.ToFQDNsMinTTLPoller
 	default:


### PR DESCRIPTION
We treated a 0 value as unset and used the defaults. While a 0 TTL isn't
likely in a DNS response, a 0 lower bound is reasonable to use. This fix
should reduce confusion when setting 0 and then seeing the 1 week
default.

This can be backported to 1.6 but it poses a bit of an issue. In 1.7/master a 0 TTL DNS response would cascade into a zombie before being deleted. Furthermore, the DNS GC is fully tied to a 1-minute controller. 1.6 and earlier would omit expired entries in `.Lookup`. This allowed a consistent view without relying on GC. In the 1.6 case, a 0 TTL response would never propagate to the datapath since the update-lookup caused by the DNS response would already exclude it (since it expired after 0 seconds). I'm not sure which is worse: confusion that setting 0 results in the 1 week default, or blocked connections for domains with a real 0 DNS TTL.
I've marked it for backport since debugging the blocked connection is more obvious than knowing how we handle the option when parsing but I'm ok not doing that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9743)
<!-- Reviewable:end -->
