### PR TITLE
v1.5: node: Fix segfault in node equality check

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -295,14 +295,14 @@ func (n *Node) PublicAttrEquals(o *Node) bool {
 		if (n.IPv4AllocCIDR == nil) != (o.IPv4AllocCIDR == nil) {
 			return false
 		}
-		if n.IPv4AllocCIDR.String() != o.IPv4AllocCIDR.String() {
+		if n.IPv4AllocCIDR != nil && n.IPv4AllocCIDR.String() != o.IPv4AllocCIDR.String() {
 			return false
 		}
 
 		if (n.IPv6AllocCIDR == nil) != (o.IPv6AllocCIDR == nil) {
 			return false
 		}
-		if n.IPv6AllocCIDR.String() != o.IPv6AllocCIDR.String() {
+		if n.IPv6AllocCIDR != nil && n.IPv6AllocCIDR.String() != o.IPv6AllocCIDR.String() {
 			return false
 		}
 


### PR DESCRIPTION
Fix a segfault when attempting to compare nodes from updates for a k8s node.

Only affects v1.5, the code was removed in v1.6.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9746)
<!-- Reviewable:end -->
