### PR TITLE
v1.6 backports 2019-12-11

### DIFF
--- a/Documentation/gettingstarted/cni-chaining-calico.rst
+++ b/Documentation/gettingstarted/cni-chaining-calico.rst
@@ -78,6 +78,7 @@ Generate the required YAML file and deploy it:
       --set global.cni.customConf=true \
       --set global.cni.configMap=cni-configuration \
       --set global.tunnel=disabled \
+      --set global.masquerade=false \
       > cilium.yaml
     kubectl create -f cilium.yaml
 

--- a/Documentation/gettingstarted/cni-chaining-generic-veth.rst
+++ b/Documentation/gettingstarted/cni-chaining-generic-veth.rst
@@ -83,5 +83,6 @@ Generate the required YAML file and deploy it:
       --set global.cni.customConf=true \
       --set global.cni.configMap=cni-configuration \
       --set global.tunnel=disabled \
+      --set global.masquerade=false \
       > cilium.yaml
     kubectl create -f cilium.yaml

--- a/Documentation/gettingstarted/cni-chaining-weave.rst
+++ b/Documentation/gettingstarted/cni-chaining-weave.rst
@@ -68,6 +68,7 @@ Generate the required YAML file and deploy it:
       --set global.cni.customConf=true \
       --set global.cni.configMap=cni-configuration \
       --set global.tunnel=disabled \
+      --set global.masquerade=false \
       > cilium.yaml
     kubectl create -f cilium.yaml
 

--- a/Documentation/gettingstarted/k8s-install-aks.rst
+++ b/Documentation/gettingstarted/k8s-install-aks.rst
@@ -10,40 +10,48 @@
 Installation on Azure AKS
 *************************
 
-This guide covers installing Cilium into an Azure AKS environment running in
-`Advanced Networking Mode <https://docs.microsoft.com/en-us/azure/aks/concepts-network#azure-cni-advanced-networking>`_ .
+This guide covers installing Cilium into an Azure AKS environment. This guide
+will work when setting up AKS in both `Basic <https://docs.microsoft.com/en-us/azure/aks/concepts-network#kubenet-basic-networking>`_ and `Advanced 
+<https://docs.microsoft.com/en-us/azure/aks/concepts-network#azure-cni-advanced-networking>`_ networking mode.
 
-This is achieved using Cilium CNI chaining, with the Azure CNI plugin as the base CNI plugin and Cilium chaining
-on top to provide L3/L4/L7 visibility and enforcement, as well as other advanced features like transparent encryption.
-
+This is achieved using Cilium in CNI chaining mode, with the Azure CNI plugin
+as the base CNI plugin and Cilium chaining on top to provide L3-L7
+observability, network policy enforcement enforcement, Kubernetes services
+implementation, as well as other advanced features like transparent encryption
+and clustermesh.
 
 Prerequisites
 =============
 
-Ensure that you have the `azure cloud cli
+Ensure that you have the `Azure Cloud CLI 
 <https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest>`_ installed.
 
-To verify, confirm that the following command displays the set of available Kubernetes versions.
+To verify, confirm that the following command displays the set of available
+Kubernetes versions.
 
 .. code:: bash
 
         az aks get-versions -l westus -o table
 
-Create an AKS Cluster in Advanced Networking Mode
-=================================================
+Create an AKS Cluster
+=====================
 
-The full background on creating AKS clusters in advanced networking mode, see `this guide
-<https://docs.microsoft.com/en-us/azure/aks/configure-azure-cni>`_ .
+The full background on creating AKS clusters in advanced networking mode, see
+`this guide <https://docs.microsoft.com/en-us/azure/aks/configure-azure-cni>`_.
+You can use any method to create and deploy an AKS cluster with the exception
+of specifying the Network Policy option. Doing so will still work but will
+result in unwanted iptables rules being installed on all of your nodes.
 
-If you want to us the CLI to create a dedicated set of Azure resources (resource groups, networks, etc.)
-specifically for this tutorial, the following commands (borrowed from the AKS documentation)
-run as a script or manually all in the same terminal are sufficient.
+If you want to us the CLI to create a dedicated set of Azure resources
+(resource groups, networks, etc.) specifically for this tutorial, the following
+commands (borrowed from the AKS documentation) run as a script or manually all
+in the same terminal are sufficient.
 
-It can take 10+ minutes for the final command to be complete indicating that the cluster is ready.
+It can take 10+ minutes for the final command to be complete indicating that
+the cluster is ready.
 
 .. note:: **Do NOT specify the '--network-policy' flag** when creating the cluster,
     as this will cause the Azure CNI plugin to push down unwanted iptables rules:
-
 
 .. code:: bash
 
@@ -96,7 +104,6 @@ It can take 10+ minutes for the final command to be complete indicating that the
             --vnet-subnet-id $SUBNET_ID \
             --service-principal $SP_ID \
             --client-secret $SP_PASSWORD
-
 
 Configure kubectl to Point to Newly Created Cluster
 ===================================================

--- a/Documentation/gettingstarted/k8s-install-azure-cni-steps.rst
+++ b/Documentation/gettingstarted/k8s-install-azure-cni-steps.rst
@@ -67,6 +67,7 @@ Generate the required YAML file and deploy it:
      --set global.nodeinit.enabled=true \
      --set global.cni.configMap=cni-configuration \
      --set global.tunnel=disabled \
+     --set global.masquerade=false \
      > cilium.yaml
    kubectl create -f cilium.yaml
 

--- a/Documentation/gettingstarted/k8s-install-azure-cni-steps.rst
+++ b/Documentation/gettingstarted/k8s-install-azure-cni-steps.rst
@@ -20,7 +20,6 @@ desired CNI chaining configuration:
           "plugins": [
             {
               "type": "azure-vnet",
-              "mode": "transparent",
               "bridge": "azure0",
               "ipam": {
                  "type": "azure-vnet-ipam"
@@ -63,7 +62,6 @@ Generate the required YAML file and deploy it:
 
    helm template cilium \
      --namespace cilium \
-     --set nodeinit.azure=true \
      --set global.cni.chainingMode=generic-veth \
      --set global.cni.customConf=true \
      --set global.nodeinit.enabled=true \

--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -96,7 +96,7 @@ func defaultCommands(confDir string, cmdDir string, k8sPods []string) []string {
 		"ip -6 route show table 200",
 		// xfrm
 		"ip xfrm policy",
-		"ip -s xfrm state | awk '!/auth|enc/'",
+		"ip -s xfrm state | awk '!/auth|enc|aead|auth-trunc|comp/'",
 		// gops
 		fmt.Sprintf("gops memstats $(pidof %s)", components.CiliumAgentName),
 		fmt.Sprintf("gops stack $(pidof %s)", components.CiliumAgentName),

--- a/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
@@ -67,17 +67,6 @@ spec:
                 echo "Installed sys-fs-bpf.mount to /lib/systemd/system/"
               fi
 
-{{- if .Values.azure }}
-              # Azure specific:
-              until [ -f /var/run/azure-vnet.json ]; do
-                echo waiting for azure-vnet to be created
-                sleep 1s
-              done
-              if [ -f /var/run/azure-vnet.json ]; then
-                sed -i 's/"Mode": "bridge",/"Mode": "transparent",/g' /var/run/azure-vnet.json
-              fi
-{{- end }}
-
               # Ensure that filesystem gets mounted on next reboot
               systemctl enable sys-fs-bpf.mount
               systemctl start sys-fs-bpf.mount

--- a/pkg/annotation/k8s.go
+++ b/pkg/annotation/k8s.go
@@ -54,5 +54,5 @@ const (
 	// Setting the annotation SharedService to false while setting
 	// GlobalService to true allows to expose remote endpoints without
 	// sharing local endpoints.
-	SharedService = Prefix + "shared-service"
+	SharedService = Prefix + "/shared-service"
 )

--- a/pkg/endpoint/directory.go
+++ b/pkg/endpoint/directory.go
@@ -26,6 +26,12 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	nextDirectorySuffix       = "_next"
+	nextFailedDirectorySuffix = "_next_fail"
+	backupDirectorySuffix     = "_stale"
+)
+
 // DirectoryPath returns the directory name for this endpoint bpf program.
 func (e *Endpoint) DirectoryPath() string {
 	return filepath.Join(".", fmt.Sprintf("%d", e.ID))
@@ -34,7 +40,7 @@ func (e *Endpoint) DirectoryPath() string {
 // FailedDirectoryPath returns the directory name for this endpoint bpf program
 // failed builds.
 func (e *Endpoint) FailedDirectoryPath() string {
-	return filepath.Join(".", fmt.Sprintf("%d%s", e.ID, "_next_fail"))
+	return filepath.Join(".", fmt.Sprintf("%d%s", e.ID, nextFailedDirectorySuffix))
 }
 
 // StateDirectoryPath returns the directory name for this endpoint bpf program.
@@ -45,11 +51,11 @@ func (e *Endpoint) StateDirectoryPath() string {
 // NextDirectoryPath returns the directory name for this endpoint bpf program
 // next bpf builds.
 func (e *Endpoint) NextDirectoryPath() string {
-	return filepath.Join(".", fmt.Sprintf("%d%s", e.ID, "_next"))
+	return filepath.Join(".", fmt.Sprintf("%d%s", e.ID, nextDirectorySuffix))
 }
 
 func (e *Endpoint) backupDirectoryPath() string {
-	return e.DirectoryPath() + "_stale"
+	return e.DirectoryPath() + backupDirectorySuffix
 }
 
 // synchronizeDirectories moves the files related to endpoint BPF program

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1050,7 +1050,7 @@ func FilterEPDir(dirFiles []os.FileInfo) []string {
 	for _, file := range dirFiles {
 		if file.IsDir() {
 			_, err := strconv.ParseUint(file.Name(), 10, 16)
-			if err == nil || strings.HasSuffix(file.Name(), "_next") || strings.HasSuffix(file.Name(), "_next_fail") {
+			if err == nil || strings.HasSuffix(file.Name(), nextDirectorySuffix) || strings.HasSuffix(file.Name(), nextFailedDirectorySuffix) {
 				eptsID = append(eptsID, file.Name())
 			}
 		}

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -15,7 +15,9 @@
 package endpoint
 
 import (
+	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -28,8 +30,23 @@ import (
 // ReadEPsFromDirNames returns a mapping of endpoint ID to endpoint of endpoints
 // from a list of directory names that can possible contain an endpoint.
 func ReadEPsFromDirNames(owner regeneration.Owner, basePath string, eptsDirNames []string) map[uint16]*Endpoint {
+	completeEPDirNames, incompleteEPDirNames := partitionEPDirNamesByRestoreStatus(eptsDirNames)
+
+	if len(incompleteEPDirNames) > 0 {
+		for _, epDirName := range incompleteEPDirNames {
+			scopedLog := log.WithFields(logrus.Fields{
+				logfields.EndpointID: epDirName,
+			})
+			fullDirName := filepath.Join(basePath, epDirName)
+			scopedLog.Warning(fmt.Sprintf("Found incomplete restore directory %s. Removing it...", fullDirName))
+			if err := os.RemoveAll(epDirName); err != nil {
+				scopedLog.WithError(err).Warn(fmt.Sprintf("Error while removing directory %s. Ignoring it...", fullDirName))
+			}
+		}
+	}
+
 	possibleEPs := map[uint16]*Endpoint{}
-	for _, epDirName := range eptsDirNames {
+	for _, epDirName := range completeEPDirNames {
 		epDir := filepath.Join(basePath, epDirName)
 		readDir := func() string {
 			scopedLog := log.WithFields(logrus.Fields{
@@ -87,4 +104,37 @@ func ReadEPsFromDirNames(owner regeneration.Owner, basePath string, eptsDirNames
 		}
 	}
 	return possibleEPs
+}
+
+// partitionEPDirNamesByRestoreStatus partitions the provided list of directory
+// names that can possibly contain an endpoint, into two lists, containing those
+// names that represent an incomplete endpoint restore and those that do not.
+func partitionEPDirNamesByRestoreStatus(eptsDirNames []string) (complete []string, incomplete []string) {
+	dirNames := make(map[string]struct{})
+	for _, epDirName := range eptsDirNames {
+		dirNames[epDirName] = struct{}{}
+	}
+
+	incompleteSuffixes := []string{nextDirectorySuffix, nextFailedDirectorySuffix}
+	incompleteSet := make(map[string]struct{})
+
+	for _, epDirName := range eptsDirNames {
+		for _, suff := range incompleteSuffixes {
+			if strings.HasSuffix(epDirName, suff) {
+				if _, exists := dirNames[epDirName[:len(epDirName)-len(suff)]]; exists {
+					incompleteSet[epDirName] = struct{}{}
+				}
+			}
+		}
+	}
+
+	for epDirName := range dirNames {
+		if _, exists := incompleteSet[epDirName]; exists {
+			incomplete = append(incomplete, epDirName)
+		} else {
+			complete = append(complete, epDirName)
+		}
+	}
+
+	return
 }

--- a/pkg/k8s/factory_functions.go
+++ b/pkg/k8s/factory_functions.go
@@ -15,9 +15,7 @@
 package k8s
 
 import (
-	"net"
 	"reflect"
-	"strings"
 
 	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/comparator"
@@ -120,29 +118,22 @@ func EqualV1NetworkPolicy(np1, np2 *types.NetworkPolicy) bool {
 		reflect.DeepEqual(np1.Spec, np2.Spec)
 }
 
-func EqualV1Services(svc1, svc2 *types.Service) bool {
+func EqualV1Services(k8sSVC1, k8sSVC2 *types.Service) bool {
 	// Service annotations are used to mark services as global, shared, etc.
-	if !comparator.MapStringEquals(svc1.GetAnnotations(), svc2.GetAnnotations()) {
+	if !comparator.MapStringEquals(k8sSVC1.GetAnnotations(), k8sSVC2.GetAnnotations()) {
 		return false
 	}
 
-	clusterIP := net.ParseIP(svc1.Spec.ClusterIP)
-	headless := false
-	if strings.ToLower(svc1.Spec.ClusterIP) == "none" {
-		headless = true
-	}
-	si1 := NewService(clusterIP, headless, svc1.Labels, svc1.Spec.Selector)
+	svcID1, svc1 := ParseService(k8sSVC1)
+	svcID2, svc2 := ParseService(k8sSVC2)
 
-	clusterIP = net.ParseIP(svc2.Spec.ClusterIP)
-	headless = false
-	if strings.ToLower(svc2.Spec.ClusterIP) == "none" {
-		headless = true
+	if svcID1 != svcID2 {
+		return false
 	}
-	si2 := NewService(clusterIP, headless, svc2.Labels, svc2.Spec.Selector)
 
 	// Please write all the equalness logic inside the K8sServiceInfo.Equals()
 	// method.
-	return si1.DeepEquals(si2)
+	return svc1.DeepEquals(svc2)
 }
 
 func EqualV1Endpoints(ep1, ep2 *types.Endpoints) bool {

--- a/pkg/k8s/service_test.go
+++ b/pkg/k8s/service_test.go
@@ -53,6 +53,27 @@ func (s *K8sSuite) TestGetAnnotationIncludeExternal(c *check.C) {
 	c.Assert(getAnnotationIncludeExternal(svc), check.Equals, false)
 }
 
+func (s *K8sSuite) TestGetAnnotationShared(c *check.C) {
+	svc := &types.Service{Service: &v1.Service{ObjectMeta: metav1.ObjectMeta{
+		Name: "foo",
+	}}}
+	c.Assert(getAnnotationShared(svc), check.Equals, false)
+	svc = &types.Service{Service: &v1.Service{ObjectMeta: metav1.ObjectMeta{
+		Annotations: map[string]string{"io.cilium/global-service": "true"},
+	}}}
+	c.Assert(getAnnotationShared(svc), check.Equals, true)
+
+	svc = &types.Service{Service: &v1.Service{ObjectMeta: metav1.ObjectMeta{
+		Annotations: map[string]string{"io.cilium/shared-service": "True"},
+	}}}
+	c.Assert(getAnnotationShared(svc), check.Equals, true)
+
+	svc = &types.Service{Service: &v1.Service{ObjectMeta: metav1.ObjectMeta{
+		Annotations: map[string]string{"io.cilium/global-service": "true", "io.cilium/shared-service": "false"},
+	}}}
+	c.Assert(getAnnotationShared(svc), check.Equals, false)
+}
+
 func (s *K8sSuite) TestParseServiceID(c *check.C) {
 	svc := &types.Service{
 		Service: &v1.Service{


### PR DESCRIPTION
 * #9638 -- pkg/endpoint: delete _next directories during restore (@iffyio)
 * #9691 -- k8s: Fix typo in io.cilium/shared-service annotation (@gandro)
 * #9692 -- doc: Fix AKS installation guide (@tgraf)
 * #9695 -- doc: Disable masquerading in all chaining guides (@tgraf)
 * #9689 -- k8s: Use ParseService when comparing two services (@brb)
 * #9722 -- cilium: encryption bugtool should remove aead, comp and auth-trunk keys (@jrfastab)

NOTE: Some unit tests had to be dropped due to them extensively depending on non-backported (refactoring) commits.

Once this PR is merged, you can update the PR labels via:
```
$ for pr in 9638 9691 9692 9695 9689 9722; do contrib/backporting/set-labels.py $pr done 1.6; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9747)
<!-- Reviewable:end -->
