### PR TITLE
pkg/workloads: sleep 500ms before reconnecting to containerd

### DIFF
--- a/pkg/workloads/containerd.go
+++ b/pkg/workloads/containerd.go
@@ -160,6 +160,7 @@ func (c *containerDClient) EnableEventListener() (eventsCh chan<- *EventMessage,
 			eventsCh, errCh := c.Client.Subscribe(context.Background(), `topic~="/containers/create"`, `topic~="/containers/delete"`)
 			err := c.listenForContainerDEvents(ws, eventsCh, errCh)
 			log.WithError(err).Error("failed to listen events")
+			time.Sleep(500 * time.Millisecond)
 		}
 	}(ws)
 	return nil, nil


### PR DESCRIPTION
In case of a failure, cilium will try to reconnect to containerd
immediately after an error. This can cause lots of verbose error
messages to show up if containerd is not available. In order to fix
this, Cilium should sleep 500ms before attempting to reconnect to
containerd.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9752)
<!-- Reviewable:end -->
