### PR TITLE
v1.6 backports 2019-12-12

### DIFF
--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -414,6 +414,7 @@ nfp
 nftables
 Nic
 nodeX
+observability
 onData
 ons
 onwards


### PR DESCRIPTION
 * #9643 -- Add missing words to spelling_wordlist (@ungureanuvladvictor)
 * #9743 -- fqdn: Support setting tofqdns-min-ttl to 0 (@raybejjani)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 9643 9743; do contrib/backporting/set-labels.py $pr done 1.6; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9753)
<!-- Reviewable:end -->
