### PR TITLE
helm: Add deps for quick-install.yaml target in Makefile

### DIFF
--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -2,7 +2,7 @@ QUICK_INSTALL=quick-install.yaml
 
 all: $(QUICK_INSTALL)
 
-$(QUICK_INSTALL):
+$(QUICK_INSTALL): $(shell find cilium/ -type f)
 	helm template cilium --namespace=kube-system $(OPTS) > $(QUICK_INSTALL)
 
 clean:


### PR DESCRIPTION
Previously, the `quick-install.yaml` target didn't have any dependency. So, if the target was present and there was any update to a file from the `cilium/` dir, the target was not re-generated when running `make`.

Spotted by #9751.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9759)
<!-- Reviewable:end -->
