### PR TITLE
Improve policy documentation

### DIFF
--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -383,6 +383,11 @@ will apply to traffic where one side of the connection is:
 * The host network namespace where the pod is running.
 * Within the cluster prefix but the IP's networking is not provided by Cilium.
 
+Conversely, CIDR rules do not apply to traffic where both sides of the
+connection are either managed by Cilium or use an IP belonging to a node in the
+cluster (including host networking pods). This traffic may be allowed using
+labels, services or entities -based policies as described above.
+
 .. note::
 
    When running Cilium on Linux 4.10 or earlier, there are :ref:`cidr_limitations`.

--- a/Documentation/policy/lifecycle.rst
+++ b/Documentation/policy/lifecycle.rst
@@ -45,14 +45,23 @@ a change in identity, policy, or configuration.
 An endpoint transitions into the ``disconnecting`` state when it is
 being deleted, regardless of its current state.
 
-In some environments, notably Docker and Kubernetes, Cilium can't
-determine the labels of an endpoint immediately when the endpoint is
-created, and therefore can't allocate an identity for the endpoint at
-that point.  Until the endpoint's labels are known, Cilium temporarily
-associates a special single label ``reserved:init`` to the endpoint.
-When the endpoint's labels become known, Cilium then replaces that
-special label with the endpoint's labels and allocates a proper
-identity to the endpoint.
+.. _init_identity:
+
+Init Identity
+-------------
+
+In some situations, Cilium can't determine the labels of an endpoint
+immediately when the endpoint is created, and therefore can't allocate an
+identity for the endpoint at that point.  Until the endpoint's labels are
+known, Cilium temporarily associates a special single label ``reserved:init``
+to the endpoint. When the endpoint's labels become known, Cilium then replaces
+that special label with the endpoint's labels and allocates a proper identity
+to the endpoint.
+
+This may occur during endpoint creation in the following cases:
+* Running Cilium with docker via libnetwork
+* With Kubernetes when the Kubernetes API server is not available
+* In etcd or consul mode when the corresponding kvstore is not available
 
 To allow traffic to/from endpoints while they are initializing, you
 can create policy rules that select the ``reserved:init`` label,

--- a/daemon/endpoint.go
+++ b/daemon/endpoint.go
@@ -276,6 +276,8 @@ func (d *Daemon) createEndpoint(ctx context.Context, epTemplate *models.Endpoint
 		}
 	}
 
+	// The following docs describe the cases where the init identity is used:
+	// http://docs.cilium.io/en/latest/policy/lifecycle/#init-identity
 	if len(addLabels) == 0 {
 		// If the endpoint has no labels, give the endpoint a special identity with
 		// label reserved:init so we can generate a custom policy for it until we


### PR DESCRIPTION
Fix up some misc docs discrepancies:
* Init identity was documented in a way that implied stronger usage of it with kubernetes than its typical usage there.
* The limitations of what traffic CIDR/DNS policy applies to previously didn't include any examples of traffic it doesn't apply to. Document this behaviour.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9763)
<!-- Reviewable:end -->
