### PR TITLE
daemon: Decrease log level for svc not found msg

### DIFF
--- a/daemon/k8s_watcher.go
+++ b/daemon/k8s_watcher.go
@@ -1237,8 +1237,13 @@ func (d *Daemon) delK8sSVCs(svc k8s.ServiceID, svcInfo *k8s.Service, se *k8s.End
 		}
 
 		if err := d.svcDeleteByFrontend(&fe.L3n4Addr); err != nil {
-			scopedLog.WithError(err).WithField(logfields.Object, logfields.Repr(fe)).
-				Warn("Error deleting service by frontend")
+			l := scopedLog.WithError(err).WithField(logfields.Object, logfields.Repr(fe))
+			msg := "Error deleting service by frontend"
+			if _, ok := err.(*errSVCNotFound); ok {
+				l.Info(msg)
+			} else {
+				l.Warn(msg)
+			}
 			continue
 		} else {
 			scopedLog.Debugf("# cilium lb delete-service %s %d 0", fe.IP, fe.Port)

--- a/daemon/loadbalancer.go
+++ b/daemon/loadbalancer.go
@@ -31,6 +31,14 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+type errSVCNotFound struct {
+	frontend string
+}
+
+func (e *errSVCNotFound) Error() string {
+	return fmt.Sprintf("Service frontend not found: %s", e.frontend)
+}
+
 // addSVC2BPFMap adds the given bpf service to the bpf maps. If addRevNAT is set, adds the
 // RevNAT value (feCilium.L3n4Addr) to the lb's RevNAT map for the given feCilium.ID.
 func (d *Daemon) addSVC2BPFMap(feCilium loadbalancer.L3n4AddrID, feBPF lbmap.ServiceKey,
@@ -244,7 +252,7 @@ func (h *deleteServiceID) Handle(params DeleteServiceIDParams) middleware.Respon
 func (d *Daemon) svcDeleteByFrontendLocked(frontend *loadbalancer.L3n4Addr) error {
 	svc, ok := d.loadBalancer.SVCMap[frontend.SHA256Sum()]
 	if !ok {
-		return fmt.Errorf("Service frontend not found %+v", frontend)
+		return &errSVCNotFound{frontend: frontend.String()}
 	}
 	return d.svcDelete(&svc)
 }


### PR DESCRIPTION
This PR changes a log level from `"warn"` to `"info"` of a `"Service frontend not found"` message.

The SVC-related refactoring in v1.7 has fixed a few race conditions which could have been a culprit for the message. Unfortunately, it'd be quite difficult to backport the changes due to the heavy refactoring. Instead, we change the log level, as in (probably) most cases the warning is harmless.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9765)
<!-- Reviewable:end -->
