### PR TITLE
Add helm charts packaging steps to the release script

### DIFF
--- a/Documentation/contributing/release/stable.rst
+++ b/Documentation/contributing/release/stable.rst
@@ -47,6 +47,7 @@ If you intent to release a new feature release, see the
 #. Update Helm chart documentation
 
    #. Update versions in ``install/kubernetes/quick-install.yaml``
+   #. Update ``version`` and ``appVersion`` in ``install/kubernetes/cilium/Chart.yaml``
    #. Update version tag in ``install/kubernetes/cilium/values.yaml``
 
 #. Update the image tag versions in the examples:

--- a/contrib/release/uploadrev
+++ b/contrib/release/uploadrev
@@ -36,11 +36,13 @@ function configure_env() {
   ARCH=${ARCH:-"`uname -m`"}
   DOMAIN=${DOMAIN:-"releases.cilium.io"}
   REMOTE_DIR=${REMOTE_DIR:-"$REV"}
+  CHARTS_REMOTE_DIR=${CHARTS_REMOTE_DIR:-"charts"}
   PREPEND=${PREPEND:-"cilium-$REV/"}
   ZIP_FILE=${ZIP_FILE:-"$REV.zip"}
   TARBALL=${TARBALL:-"$REV.tar.gz"}
   DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
   TARGET_DIR=${TARGET_DIR:-"$DIR/../../_build/`basename $REMOTE_DIR`"}
+  CHARTS_TARGET_DIR=${CHARTS_TARGET_DIR:-"$DIR/../../_charts"}
   CILIUM_SOURCE=${CILIUM_SOURCE:-"$DIR/../../"}
   SKIP_UPLOAD=${SKIP_UPLOAD:-0}
 }
@@ -103,6 +105,13 @@ function copy_binaries() {
   generate_sha_digest_for_binaries
 }
 
+function copy_helm_chart() {
+  mkdir -pv $CHARTS_TARGET_DIR
+  helm package install/kubernetes/cilium/
+  mv cilium-${REV/v/}.tgz $CHARTS_TARGET_DIR
+  curl -f -o $CHARTS_TARGET_DIR/index.yaml http://$DOMAIN/$CHARTS_REMOTE_DIR/index.yaml || true
+  helm repo index $CHARTS_TARGET_DIR --url http://$DOMAIN/$CHARTS_REMOTE_DIR --merge $CHARTS_TARGET_DIR/index.yaml
+}
 
 function upload_all() {
   if [ $SKIP_UPLOAD == 1 ]; then
@@ -111,6 +120,7 @@ function upload_all() {
   fi
   # Upload all files
   aws s3 cp --recursive $TARGET_DIR s3://$DOMAIN/$REMOTE_DIR
+  aws s3 cp --recursive $CHARTS_TARGET_DIR s3://$DOMAIN/$CHARTS_REMOTE_DIR
 }
 
 function print_done() {
@@ -133,6 +143,7 @@ function main() {
   create_dir
   copy_source
   copy_binaries
+  copy_helm_chart
   upload_all
   print_done
 }


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](http://docs.cilium.io/en/stable/contributing/contributing/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue. 
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](http://docs.cilium.io/en/stable/contributing/contributing/#dev-coo).
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

This patch adds helm chart packaging and versioning steps to support
chart distribution via helm repository. Repository index is merged
with existing index (can be initially empty) to support single version
uploads. helm and curl binaries are required to execute these steps.

Related: #1564

I will do doc updates in a separate patch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9772)
<!-- Reviewable:end -->
