### PR TITLE
node: Remove the IPv6 prefix /96 constraint

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -98,7 +98,7 @@ cilium-agent [flags]
       --ipv6-cluster-alloc-cidr string                        IPv6 /64 CIDR used to allocate per node endpoint /96 CIDR (default "f00d::/64")
       --ipv6-node string                                      IPv6 address of node (default "auto")
       --ipv6-pod-subnets strings                              List of IPv6 pod subnets to preconfigure for encryption
-      --ipv6-range string                                     Per-node IPv6 endpoint prefix, must be /96, e.g. fd02:1:1::/96 (default "auto")
+      --ipv6-range string                                     Per-node IPv6 endpoint prefix, e.g. fd02:1:1::/96 (default "auto")
       --ipv6-service-range string                             Kubernetes IPv6 services CIDR if not inside cluster prefix (default "auto")
       --ipvlan-master-device string                           Device facing external network acting as ipvlan master (default "undefined")
       --k8s-api-server string                                 Kubernetes API server URL

--- a/common/addressing/ip.go
+++ b/common/addressing/ip.go
@@ -32,10 +32,7 @@ type CiliumIP interface {
 
 type CiliumIPv6 []byte
 
-// NewCiliumIPv6 returns a IPv6 if the given `address` is:
-// - An IPv6 address.
-// - Node ID, bits from 112 to 120, must be different than 0
-// - Endpoint ID, bits from 120 to 128, must be equal to 0
+// NewCiliumIPv6 returns a IPv6 if the given `address` is an IPv6 address.
 func NewCiliumIPv6(address string) (CiliumIPv6, error) {
 	ip, _, err := net.ParseCIDR(address)
 	if err != nil {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -452,7 +452,7 @@ func NewDaemon(ctx context.Context, dp datapath.Datapath) (*Daemon, *endpointRes
 		bootstrapStats.k8sInit.Start()
 		log.WithFields(logrus.Fields{
 			logfields.V4Prefix:       node.GetIPv4AllocRange(),
-			logfields.V6Prefix:       node.GetIPv6NodeRange(),
+			logfields.V6Prefix:       node.GetIPv6AllocRange(),
 			logfields.V4HealthIP:     d.nodeDiscovery.LocalNode.IPv4HealthIP,
 			logfields.V6HealthIP:     d.nodeDiscovery.LocalNode.IPv6HealthIP,
 			logfields.V4CiliumHostIP: node.GetInternalIPv4(),
@@ -461,7 +461,7 @@ func NewDaemon(ctx context.Context, dp datapath.Datapath) (*Daemon, *endpointRes
 
 		err := k8s.Client().AnnotateNode(node.GetName(),
 			encryptKeyID,
-			node.GetIPv4AllocRange(), node.GetIPv6NodeRange(),
+			node.GetIPv4AllocRange(), node.GetIPv6AllocRange(),
 			d.nodeDiscovery.LocalNode.IPv4HealthIP, d.nodeDiscovery.LocalNode.IPv6HealthIP,
 			node.GetInternalIPv4(), node.GetIPv6Router())
 		if err != nil {

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -399,7 +399,7 @@ func init() {
 	flags.String(option.IPv4Range, AutoCIDR, "Per-node IPv4 endpoint prefix, e.g. 10.16.0.0/16")
 	option.BindEnv(option.IPv4Range)
 
-	flags.String(option.IPv6Range, AutoCIDR, "Per-node IPv6 endpoint prefix, must be /96, e.g. fd02:1:1::/96")
+	flags.String(option.IPv6Range, AutoCIDR, "Per-node IPv6 endpoint prefix, e.g. fd02:1:1::/96")
 	option.BindEnv(option.IPv6Range)
 
 	flags.String(option.IPv6ClusterAllocCIDRName, defaults.IPv6ClusterAllocCIDR, "IPv6 /64 CIDR used to allocate per node endpoint /96 CIDR")

--- a/daemon/ipam.go
+++ b/daemon/ipam.go
@@ -251,7 +251,6 @@ func (d *Daemon) allocateIPs() error {
 	log.Infof("  Node-IPv6: %s", node.GetIPv6())
 
 	if option.Config.EnableIPv6 {
-		log.Infof("  IPv6 node prefix: %s", node.GetIPv6NodeRange())
 		log.Infof("  IPv6 allocation prefix: %s", node.GetIPv6AllocRange())
 		log.Infof("  IPv6 router address: %s", node.GetIPv6Router())
 

--- a/pkg/defaults/node.go
+++ b/pkg/defaults/node.go
@@ -19,9 +19,6 @@ import (
 )
 
 const (
-	// IPv6NodePrefixLen is the length used to allocate container IPv6 addresses from.
-	IPv6NodePrefixLen = 96
-
 	// DefaultIPv4Prefix is the prefix for all the IPv4 addresses.
 	// %d is substituted with the last byte of first global IPv4 address
 	// configured on the system.

--- a/pkg/defaults/node.go
+++ b/pkg/defaults/node.go
@@ -19,9 +19,6 @@ import (
 )
 
 const (
-	// IPv6NodeAllocPrefixLen is the length of the prefix used for allocation per node
-	IPv6NodeAllocPrefixLen = 112
-
 	// IPv6NodePrefixLen is the length used to allocate container IPv6 addresses from.
 	IPv6NodePrefixLen = 96
 

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -88,7 +88,7 @@ func (s *K8sSuite) TestUseNodeCIDR(c *C) {
 	err := k8sCli.AnnotateNode("node1",
 		0,
 		node.GetIPv4AllocRange(),
-		node.GetIPv6NodeRange(),
+		node.GetIPv6AllocRange(),
 		nil,
 		nil,
 		net.ParseIP("10.254.0.1"),
@@ -155,12 +155,12 @@ func (s *K8sSuite) TestUseNodeCIDR(c *C) {
 	// We use the node's annotation for the IPv4 and the PodCIDR for the
 	// IPv6.
 	c.Assert(node.GetIPv4AllocRange().String(), Equals, "10.254.0.0/16")
-	c.Assert(node.GetIPv6NodeRange().String(), Equals, "aaaa:aaaa:aaaa:aaaa:beef:beef::/96")
+	c.Assert(node.GetIPv6AllocRange().String(), Equals, "aaaa:aaaa:aaaa:aaaa:beef:beef::/96")
 
 	err = k8sCli.AnnotateNode("node2",
 		0,
 		node.GetIPv4AllocRange(),
-		node.GetIPv6NodeRange(),
+		node.GetIPv6AllocRange(),
 		nil,
 		nil,
 		net.ParseIP("10.254.0.1"),

--- a/pkg/node/node_address.go
+++ b/pkg/node/node_address.go
@@ -125,8 +125,7 @@ func InitDefaultPrefix(device string) {
 			// The IPv6 allocation should be derived from the IPv4 allocation.
 			ip := ipv4AllocRange.IP
 			v6range := fmt.Sprintf("%s%02x%02x:%02x%02x:0:0/%d",
-				option.Config.IPv6ClusterAllocCIDRBase, ip[0], ip[1], ip[2], ip[3],
-				defaults.IPv6NodePrefixLen)
+				option.Config.IPv6ClusterAllocCIDRBase, ip[0], ip[1], ip[2], ip[3], 96)
 
 			_, ip6net, err := net.ParseCIDR(v6range)
 			if err != nil {

--- a/pkg/node/node_address.go
+++ b/pkg/node/node_address.go
@@ -180,19 +180,6 @@ func GetIPv4AllocRange() *cidr.CIDR {
 
 // GetIPv6AllocRange returns the IPv6 allocation prefix of this node
 func GetIPv6AllocRange() *cidr.CIDR {
-	if ipv6AllocRange == nil {
-		return nil
-	}
-
-	mask := net.CIDRMask(defaults.IPv6NodeAllocPrefixLen, 128)
-	return cidr.NewCIDR(&net.IPNet{
-		IP:   ipv6AllocRange.IPNet.IP.Mask(mask),
-		Mask: mask,
-	})
-}
-
-// GetIPv6NodeRange returns the IPv6 allocation prefix of this node
-func GetIPv6NodeRange() *cidr.CIDR {
 	return ipv6AllocRange
 }
 
@@ -257,13 +244,10 @@ func GetNodePortIPv6() net.IP {
 
 // SetIPv6NodeRange sets the IPv6 address pool to be used on this node
 func SetIPv6NodeRange(net *net.IPNet) error {
-	if ones, _ := net.Mask.Size(); ones != defaults.IPv6NodePrefixLen {
-		return fmt.Errorf("prefix length must be /%d", defaults.IPv6NodePrefixLen)
-	}
-
 	copy := *net
 	ipv6AllocRange = cidr.NewCIDR(&copy)
 
+	// TODO(brb) rm error
 	return nil
 }
 


### PR DESCRIPTION
This PR removes the IPv6 `/96` prefix constraint which allows cilium to be used with k8s in the dual-stack mode.

Previously, the DSR for IPv6 (aka the `--lb` feature) required the `--ipv6-range` to be /96. This was because the 113-128 bits of an IPv6 addr were used to store a global reverse NAT ID, and the rest was a unique Pod IPv6 addr.

As the `--lb` feature was removed, the constraint is no longer needed (the new DSR implementation leverages IPv6 extension field to store a SVC IP addr and port).

Tested manually with kubeadm (`kubeadm init --skip-phases=addon/kube-proxy --pod-network-cidr=10.217.0.0/16,fc22::/48 --service-cidr=10.96.0.0/16,fc44::/112 --feature-gates IPv6DualStack=true --apiserver-advertise-address=192.168.34.11`).


```release-note
Remove /96 IPv6 CIDR constraint which makes cilium to work in k8s dual-stack mode
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9777)
<!-- Reviewable:end -->
