### PR TITLE
Fix service restoration and extend CI for externalTrafficPolicy=Local services

### DIFF
--- a/pkg/maps/lbmap/types.go
+++ b/pkg/maps/lbmap/types.go
@@ -148,23 +148,19 @@ type RevNatValue interface {
 	ToNetwork() RevNatValue
 }
 
-func svcFrontendAndBackends(svcKey ServiceKey, svcValue ServiceValue,
-	backendID loadbalancer.BackendID, backend BackendValue) (*loadbalancer.L3n4AddrID, *loadbalancer.Backend) {
-
-	var beBackend *loadbalancer.Backend
-
+func svcFrontend(svcKey ServiceKey, svcValue ServiceValue) *loadbalancer.L3n4AddrID {
 	feL3n4Addr := loadbalancer.NewL3n4Addr(loadbalancer.NONE, svcKey.GetAddress(), svcKey.GetPort())
 	feL3n4AddrID := &loadbalancer.L3n4AddrID{
 		L3n4Addr: *feL3n4Addr,
 		ID:       loadbalancer.ID(svcValue.GetRevNat()),
 	}
+	return feL3n4AddrID
+}
 
-	if backendID != 0 {
-		beIP := backend.GetAddress()
-		bePort := backend.GetPort()
-		beProto := loadbalancer.NONE
-		beBackend = loadbalancer.NewBackend(backendID, beProto, beIP, bePort)
-	}
-
-	return feL3n4AddrID, beBackend
+func svcBackend(backendID loadbalancer.BackendID, backend BackendValue) *loadbalancer.Backend {
+	beIP := backend.GetAddress()
+	bePort := backend.GetPort()
+	beProto := loadbalancer.NONE
+	beBackend := loadbalancer.NewBackend(backendID, beProto, beIP, bePort)
+	return beBackend
 }

--- a/test/k8sT/manifests/demo_ds.yaml
+++ b/test/k8sT/manifests/demo_ds.yaml
@@ -54,6 +54,34 @@ spec:
         args:
           - "1000h"
 ---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-k8s1
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      zgroup: test-k8s1
+  template:
+    metadata:
+      labels:
+        zgroup: test-k8s1
+    spec:
+      containers:
+      - name: web
+        image: docker.io/cilium/echoserver:1.10
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 80
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
+      terminationGracePeriodSeconds: 0
+      nodeSelector:
+        "cilium.io/ci-node": k8s1
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -93,6 +121,21 @@ spec:
     name: http
   selector:
     zgroup: testDS
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-nodeport-local-k8s1
+spec:
+  type: NodePort
+  externalTrafficPolicy: Local
+  ports:
+  - port: 10080
+    targetPort: 80
+    protocol: TCP
+    name: http
+  selector:
+    zgroup: test-k8s1
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
This PR extends the CI tests for `externalTrafficPolicy=Local` services and fixes a bug in the service cache restoration unconvered by said tests.

The new CI tests deploy a `NodePort` service with `externalTrafficPolicy=Local` where only a single node is running a service endpoint. It tests that only direct connections to that node will succeed, while any requests to a node without a local backend are dropped.

While the test itself worked as expected, the service entries on nodes without any backends caused subsequent Cilium CI status preflight checks to fail, as the new services were not garbage collected by cilium-agent after a restart. Commit 21e528037ac092de8f653d0c25b06dbf49abf653 fixes this issue by ensuring that backend-less services are also restored from the datapath. This allows cilium-agent to subsequently garbage collect these entries once it recognizes that these services have been removed from Kubernetes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9778)
<!-- Reviewable:end -->
