### PR TITLE
Use helm repository in docs

### DIFF
--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -77,11 +77,16 @@ branch = os.environ.get('READTHEDOCS_VERSION')
 if branch is None or branch == 'latest':
     branch = 'HEAD'
     archive_name = 'master'
+    chart_release = './cilium'
 elif branch == 'stable':
     branch = release
     archive_name = release
+    chart_release = 'cilium/cilium --version ' + release
+    tags.add('stable')
 else:
     archive_name = branch
+    chart_release = 'cilium/cilium --version ' + release
+    tags.add('stable')
 relinfo = semver.parse_version_info(release)
 next_release = '%d.%d' % (relinfo.major, relinfo.minor)
 if relinfo.patch == 90:
@@ -105,7 +110,8 @@ rst_epilog = """
 .. |SCM_ARCHIVE_LINK| replace:: \{l}
 .. |CURRENT_RELEASE| replace:: \{c}
 .. |NEXT_RELEASE| replace:: \{n}
-""".format(s=scm_web, b=branch, a=archive_name, f=archive_filename, l=archive_link, c=current_release, n=next_release)
+.. |CHART_RELEASE| replace:: \{h}
+""".format(s=scm_web, b=branch, a=archive_name, f=archive_filename, l=archive_link, c=current_release, n=next_release, h=chart_release)
 
 extlinks = {
     'git-tree': (scm_web + "/%s", ''),

--- a/Documentation/gettingstarted/aws-eni.rst
+++ b/Documentation/gettingstarted/aws-eni.rst
@@ -42,18 +42,16 @@ Prepare & Deploy Cilium
 
 .. include:: k8s-install-download-release.rst
 
-Generate the required YAML file and deploy it:
+Deploy Cilium release via Helm:
 
-.. code:: bash
+.. parsed-literal::
 
-   helm template cilium \
-     --namespace kube-system \
-     --set global.eni=true \
-     --set global.egressMasqueradeInterfaces=eth0 \
-     --set global.tunnel=disabled \
-     --set global.nodeinit.enabled=true \
-     > cilium.yaml
-   kubectl create -f cilium.yaml
+   helm install cilium |CHART_RELEASE| \\
+     --namespace kube-system \\
+     --set global.eni=true \\
+     --set global.egressMasqueradeInterfaces=eth0 \\
+     --set global.tunnel=disabled \\
+     --set global.nodeinit.enabled=true
 
 .. note::
 

--- a/Documentation/gettingstarted/clustermesh.rst
+++ b/Documentation/gettingstarted/clustermesh.rst
@@ -71,7 +71,7 @@ Repeat this step for each cluster.
 .. note::
 
    This can also be done by passing ``--set global.cluster.id=<id>`` and
-   ``--set global.cluster.name=<name>`` to ``helm template`` when installing or
+   ``--set global.cluster.name=<name>`` to ``helm install`` when installing or
    updating Cilium.
 
 Expose the Cilium etcd to other clusters

--- a/Documentation/gettingstarted/cni-chaining-aws-cni.rst
+++ b/Documentation/gettingstarted/cni-chaining-aws-cni.rst
@@ -31,18 +31,16 @@ done.
 
 .. include:: k8s-install-download-release.rst
 
-Generate the required YAML files and deploy them:
+Deploy Cilium release via Helm:
 
-.. code:: bash
+.. parsed-literal::
 
-   helm template cilium \
-     --namespace kube-system \
-     --set global.cni.chainingMode=aws-cni \
-     --set global.masquerade=false \
-     --set global.tunnel=disabled \
-     --set global.nodeinit.enabled=true \
-     > cilium.yaml
-   kubectl apply -f cilium.yaml
+   helm install cilium |CHART_RELEASE| \\
+     --namespace kube-system \\
+     --set global.cni.chainingMode=aws-cni \\
+     --set global.masquerade=false \\
+     --set global.tunnel=disabled \\
+     --set global.nodeinit.enabled=true
 
 This will enable chaining with the aws-cni plugin. It will also disable
 tunneling. Tunneling is not required as ENI IP addresses can be directly routed

--- a/Documentation/gettingstarted/cni-chaining-calico.rst
+++ b/Documentation/gettingstarted/cni-chaining-calico.rst
@@ -68,19 +68,17 @@ Deploy Cilium with the portmap plugin enabled
 
 .. include:: k8s-install-download-release.rst
 
-Generate the required YAML file and deploy it:
+Deploy Cilium release via Helm:
 
-.. code:: bash
+.. parsed-literal::
 
-    helm template cilium \
-      --namespace=kube-system \
-      --set global.cni.chainingMode=generic-veth \
-      --set global.cni.customConf=true \
-      --set global.cni.configMap=cni-configuration \
-      --set global.tunnel=disabled \
-      --set global.masquerade=false \
-      > cilium.yaml
-    kubectl create -f cilium.yaml
+    helm install cilium |CHART_RELEASE| \\
+      --namespace=kube-system \\
+      --set global.cni.chainingMode=generic-veth \\
+      --set global.cni.customConf=true \\
+      --set global.cni.configMap=cni-configuration \\
+      --set global.tunnel=disabled \\
+      --set global.masquerade=false
 
 .. note::
 

--- a/Documentation/gettingstarted/cni-chaining-generic-veth.rst
+++ b/Documentation/gettingstarted/cni-chaining-generic-veth.rst
@@ -73,16 +73,14 @@ Deploy Cilium with the portmap plugin enabled
 
 .. include:: k8s-install-download-release.rst
 
-Generate the required YAML file and deploy it:
+Deploy Cilium release via Helm:
 
-.. code:: bash
+.. parsed-literal::
 
-    helm template cilium \
-      --namespace=kube-system \
-      --set global.cni.chainingMode=generic-veth \
-      --set global.cni.customConf=true \
-      --set global.cni.configMap=cni-configuration \
-      --set global.tunnel=disabled \
-      --set global.masquerade=false \
-      > cilium.yaml
-    kubectl create -f cilium.yaml
+    helm install cilium |CHART_RELEASE| \\
+      --namespace=kube-system \\
+      --set global.cni.chainingMode=generic-veth \\
+      --set global.cni.customConf=true \\
+      --set global.cni.configMap=cni-configuration \\
+      --set global.tunnel=disabled \\
+      --set global.masquerade=false

--- a/Documentation/gettingstarted/cni-chaining-portmap.rst
+++ b/Documentation/gettingstarted/cni-chaining-portmap.rst
@@ -26,15 +26,13 @@ Deploy Cilium with the portmap plugin enabled
 
 .. include:: k8s-install-download-release.rst
 
-Generate the required YAML file and deploy it:
+Deploy Cilium release via Helm:
 
-.. code:: bash
+.. parsed-literal::
 
-    helm template cilium \
-      --namespace=kube-system \
-      --set global.cni.chainingMode=portmap \
-      > cilium.yaml
-    kubectl create -f cilium.yaml
+    helm install cilium |CHART_RELEASE| \\
+      --namespace=kube-system \\
+      --set global.cni.chainingMode=portmap
 
 .. note::
 

--- a/Documentation/gettingstarted/cni-chaining-weave.rst
+++ b/Documentation/gettingstarted/cni-chaining-weave.rst
@@ -58,19 +58,17 @@ Deploy Cilium with the portmap plugin enabled
 
 .. include:: k8s-install-download-release.rst
 
-Generate the required YAML file and deploy it:
+Deploy Cilium release via Helm:
 
-.. code:: bash
+.. parsed-literal::
 
-    helm template cilium \
-      --namespace=kube-system \
-      --set global.cni.chainingMode=generic-veth \
-      --set global.cni.customConf=true \
-      --set global.cni.configMap=cni-configuration \
-      --set global.tunnel=disabled \
-      --set global.masquerade=false \
-      > cilium.yaml
-    kubectl create -f cilium.yaml
+    helm install cilium |CHART_RELEASE| \\
+      --namespace=kube-system \\
+      --set global.cni.chainingMode=generic-veth \\
+      --set global.cni.customConf=true \\
+      --set global.cni.configMap=cni-configuration \\
+      --set global.tunnel=disabled \\
+      --set global.masquerade=false
 
 .. note::
 

--- a/Documentation/gettingstarted/encryption.rst
+++ b/Documentation/gettingstarted/encryption.rst
@@ -49,15 +49,17 @@ Enable Encryption in Cilium
 
 .. include:: k8s-install-download-release.rst
 
-Generate the required YAML files and deploy them:
+Deploy Cilium release via Helm:
 
-.. code:: bash
+.. parsed-literal::
 
-    helm template cilium \
-      --namespace cilium \
-      --set global.encryption.enabled=true \
-      --set global.encryption.nodeEncryption=false \
-      > cilium.yaml
+    helm install cilium |CHART_RELEASE| \\
+      --namespace cilium \\
+      --set global.encryption.enabled=true \\
+      --set global.encryption.nodeEncryption=false
+
+At this point the Cilium managed nodes will be using IPsec for all traffic. For further
+information on Cilium's transparent encryption, see :ref:`arch_guide`.
 
 Encryption interface
 --------------------
@@ -81,16 +83,6 @@ In order to enable node-to-node encryption, add:
     [...]
     --set global.encryption.enabled=true \
     --set global.encryption.nodeEncryption=true
-
-Deploy Cilium
--------------
-
-.. code:: bash
-
-    kubectl create -f cilium.yaml
-
-At this point the Cilium managed nodes will be using IPsec for all traffic. For further
-information on Cilium's transparent encryption, see :ref:`arch_guide`.
 
 Validate the Setup
 ==================

--- a/Documentation/gettingstarted/flannel-integration.rst
+++ b/Documentation/gettingstarted/flannel-integration.rst
@@ -49,26 +49,19 @@ Cilium installation
 
 .. include:: k8s-install-download-release.rst
 
-Generate the required YAML file and deploy it:
+Deploy Cilium release via Helm:
 
-.. code:: bash
+.. parsed-literal::
 
-   helm template cilium \
-     --namespace kube-system \
-     --set global.flannel.enabled=true \
-     > cilium.yaml
+   helm install cilium |CHART_RELEASE| \\
+     --namespace kube-system \\
+     --set global.flannel.enabled=true
 
 Set ``global.flannel.uninstallOnExit=true`` if you want Cilium to uninstall
 itself when the Cilium pod is stopped.
 
 If the Flannel bridge has a different name than ``cni0``, you must specify
 the name by setting ``global.flannel.masterDevice=...``.
-
-Once you have changed the ConfigMap accordingly, you can deploy Cilium.
-
-.. parsed-literal::
-
-   kubectl create -f cilium.yaml
 
 Cilium might not come up immediately on all nodes, since Flannel only sets up
 the bridge network interface that connects containers with the outside world

--- a/Documentation/gettingstarted/grafana.rst
+++ b/Documentation/gettingstarted/grafana.rst
@@ -49,15 +49,13 @@ value:
 
 .. include:: k8s-install-download-release.rst
 
-Generate the required YAML file and deploy it:
+Deploy Cilium release via Helm:
 
-.. code:: bash
+.. parsed-literal::
 
-   helm template cilium \
-      --namespace kube-system \
-      --set global.prometheus.enabled=true \
-      > cilium.yaml
-   kubectl create -f cilium.yaml
+   helm install cilium |CHART_RELEASE| \\
+      --namespace kube-system \\
+      --set global.prometheus.enabled=true
 
 .. note::
 

--- a/Documentation/gettingstarted/host-services.rst
+++ b/Documentation/gettingstarted/host-services.rst
@@ -29,25 +29,23 @@ reached from the host namespace.
 
 .. include:: k8s-install-download-release.rst
 
-Generate the required YAML file and deploy it:
+Deploy Cilium release via Helm:
 
-.. code:: bash
+.. parsed-literal::
 
-   helm template cilium \
-     --namespace kube-system \
-     --set global.hostServices.enabled=true \
-     > cilium.yaml
+   helm install cilium |CHART_RELEASE| \\
+     --namespace kube-system \\
+     --set global.hostServices.enabled=true
 
 If you can't run 4.19.57 but have 4.17.0 available you can restrict protocol
 support to TCP only:
 
-.. code:: bash
+.. parsed-literal::
 
-   helm template cilium \
-     --namespace kube-system \
-     --set global.hostServices.enabled=true \
-     --set global.hostServices.protocols=tcp \
-     > cilium.yaml
+   helm install cilium |CHART_RELEASE| \\
+     --namespace kube-system \\
+     --set global.hostServices.enabled=true \\
+     --set global.hostServices.protocols=tcp
 
 Host-reachable services act transparent to Cilium's lower layer datapath
 in that upon connect system call (TCP, connected UDP) or sendmsg as well
@@ -57,11 +55,10 @@ the application is assuming its connection to the service address, the
 corresponding kernel's socket is actually connected to the backend address
 and therefore no additional lower layer NAT is required.
 
-Deploy Cilium:
+Verify that it has come up correctly:
 
 .. code:: bash
 
-    kubectl create -f cilium.yaml
     kubectl -n kube-system get pods -l k8s-app=cilium
     NAME                READY     STATUS    RESTARTS   AGE
     cilium-crf7f        1/1       Running   0          10m

--- a/Documentation/gettingstarted/ipvlan.rst
+++ b/Documentation/gettingstarted/ipvlan.rst
@@ -34,16 +34,15 @@ datapath instead of the default veth-based one.
 
 .. include:: k8s-install-download-release.rst
 
-Generate the required YAML file and deploy it:
+Deploy Cilium release via Helm:
 
-.. code:: bash
+.. parsed-literal::
 
-   helm template cilium \
-     --namespace kube-system \
-     --set global.datapathMode=ipvlan \
-     --set global.ipvlan.masterDevice=eth0 \
-     --set global.tunnel=disabled \
-     > cilium.yaml
+   helm install cilium |CHART_RELEASE| \\
+     --namespace kube-system \\
+     --set global.datapathMode=ipvlan \\
+     --set global.ipvlan.masterDevice=eth0 \\
+     --set global.tunnel=disabled
 
 It is required to specify the master ipvlan device which typically points to a
 networking device that is facing the external network. This is done through
@@ -84,53 +83,48 @@ required for BPF-based masquerading.
 
 Example ConfigMap extract for ipvlan in pure L3 mode:
 
-.. code:: bash
+.. parsed-literal::
 
-   helm template ciliumn \
-     --namespace kube-system \
-     --set global.datapathMode=ipvlan \
-     --set global.ipvlan.masterDevice=bond0 \
-     --set global.tunnel=disabled \
-     --set global.installIptablesRules=false \
-     --set global.l7Proxy.enabled=false \
-     --set global.autoDirectNodeRoutes=true \
-     > cilium.yaml
+   helm install cilium |CHART_RELEASE| \\
+     --namespace kube-system \\
+     --set global.datapathMode=ipvlan \\
+     --set global.ipvlan.masterDevice=bond0 \\
+     --set global.tunnel=disabled \\
+     --set global.installIptablesRules=false \\
+     --set global.l7Proxy.enabled=false \\
+     --set global.autoDirectNodeRoutes=true
 
 Example ConfigMap extract for ipvlan in L3S mode with iptables
 masquerading all traffic leaving the node:
 
-.. code:: bash
+.. parsed-literal::
 
-   helm template cilium \
-     --namespace kube-system \
-     --set global.datapathMode=ipvlan \
-     --set global.ipvlan.masterDevice=bond0 \
-     --set global.tunnel=disabled \
-     --set global.masquerade=true \
-     --set global.autoDirectNodeRoutes=true \
-     > cilium.yaml
+   helm install cilium |CHART_RELEASE| \\
+     --namespace kube-system \\
+     --set global.datapathMode=ipvlan \\
+     --set global.ipvlan.masterDevice=bond0 \\
+     --set global.tunnel=disabled \\
+     --set global.masquerade=true \\
+     --set global.autoDirectNodeRoutes=true
 
 Example ConfigMap extract for ipvlan in L3 mode with more efficient
 BPF-based masquerading instead of iptables-based:
 
-.. code:: bash
+.. parsed-literal::
 
-   helm template cilium \
-     --namespace kube-system \
-     --set global.datapathMode=ipvlan \
-     --set global.ipvlan.masterDevice=bond0 \
-     --set global.tunnel=disabled \
-     --set global.masquerade=true \
-     --set global.installIptablesRules=false \
-     --set global.autoDirectNodeRoutes=true \
-     > cilium.yaml
+   helm install cilium |CHART_RELEASE| \\
+     --namespace kube-system \\
+     --set global.datapathMode=ipvlan \\
+     --set global.ipvlan.masterDevice=bond0 \\
+     --set global.tunnel=disabled \\
+     --set global.masquerade=true \\
+     --set global.installIptablesRules=false \\
+     --set global.autoDirectNodeRoutes=true
 
-Apply the DaemonSet file to deploy Cilium and verify that it has
-come up correctly:
+Verify that it has come up correctly:
 
 .. parsed-literal::
 
-    kubectl create -f ./cilium.yaml
     kubectl -n kube-system get pods -l k8s-app=cilium
     NAME                READY     STATUS    RESTARTS   AGE
     cilium-crf7f        1/1       Running   0          10m

--- a/Documentation/gettingstarted/k8s-install-azure-cni-steps.rst
+++ b/Documentation/gettingstarted/k8s-install-azure-cni-steps.rst
@@ -56,20 +56,18 @@ Prepare & Deploy Cilium
 
 .. include:: k8s-install-download-release.rst
 
-Generate the required YAML file and deploy it:
+Deploy Cilium release via Helm:
 
-.. code:: bash
+.. parsed-literal::
 
-   helm template cilium \
-     --namespace cilium \
-     --set global.cni.chainingMode=generic-veth \
-     --set global.cni.customConf=true \
-     --set global.nodeinit.enabled=true \
-     --set global.cni.configMap=cni-configuration \
-     --set global.tunnel=disabled \
-     --set global.masquerade=false \
-     > cilium.yaml
-   kubectl create -f cilium.yaml
+   helm install cilium |CHART_RELEASE| \\
+     --namespace cilium \\
+     --set global.cni.chainingMode=generic-veth \\
+     --set global.cni.customConf=true \\
+     --set global.nodeinit.enabled=true \\
+     --set global.cni.configMap=cni-configuration \\
+     --set global.tunnel=disabled \\
+     --set global.masquerade=false
 
 This will create both the main cilium daemonset, as well as the cilium-node-init daemonset, which handles tasks like mounting the BPF filesystem and updating the
 existing Azure CNI plugin to run in 'transparent' mode.

--- a/Documentation/gettingstarted/k8s-install-download-release.rst
+++ b/Documentation/gettingstarted/k8s-install-download-release.rst
@@ -1,12 +1,22 @@
-Download the Cilium release tarball and change to the kubernetes install directory:
-
-.. parsed-literal::
-
-    curl -LO |SCM_ARCHIVE_LINK|
-    tar xzvf |SCM_ARCHIVE_FILENAME|
-    cd |SCM_ARCHIVE_NAME|/install/kubernetes
-
 `Install Helm`_ to prepare generating the deployment artifacts based on the
 Helm templates.
 
 .. _Install Helm: https://helm.sh/docs/using_helm/#install-helm
+
+.. only:: stable
+
+   Setup helm repository:
+
+    .. code:: bash
+
+        helm repo add cilium https://helm.cilium.io/
+
+.. only:: not stable
+
+   Download the Cilium release tarball and change to the kubernetes install directory:
+
+    .. parsed-literal::
+
+        curl -LO |SCM_ARCHIVE_LINK|
+        tar xzvf |SCM_ARCHIVE_FILENAME|
+        cd |SCM_ARCHIVE_NAME|/install/kubernetes

--- a/Documentation/gettingstarted/k8s-install-eks.rst
+++ b/Documentation/gettingstarted/k8s-install-eks.rst
@@ -75,18 +75,16 @@ Prepare & Deploy Cilium
 
 .. include:: k8s-install-download-release.rst
 
-Generate the required YAML file and deploy it:
+Deploy Cilium release via Helm:
 
-.. code:: bash
+.. parsed-literal::
 
-   helm template cilium \
-     --namespace kube-system \
-     --set global.cni.chainingMode=aws-cni \
-     --set global.masquerade=false \
-     --set global.tunnel=disabled \
-     --set global.nodeinit.enabled=true \
-     > cilium.yaml
-   kubectl create -f cilium.yaml
+   helm install cilium |CHART_RELEASE| \\
+     --namespace kube-system \\
+     --set global.cni.chainingMode=aws-cni \\
+     --set global.masquerade=false \\
+     --set global.tunnel=disabled \\
+     --set global.nodeinit.enabled=true
 
 Scale up the cluster
 ====================

--- a/Documentation/gettingstarted/k8s-install-etcd-operator.rst
+++ b/Documentation/gettingstarted/k8s-install-etcd-operator.rst
@@ -33,16 +33,14 @@ Deploy Cilium + cilium-etcd-operator
 
 .. include:: k8s-install-download-release.rst
 
-Generate the required YAML file and deploy it:
+Deploy Cilium release via Helm:
 
-.. code:: bash
+.. parsed-literal::
 
-   helm template cilium \
-      --namespace kube-system \
-      --set global.etcd.enabled=true \
-      --set global.etcd.managed=true \
-      > cilium.yaml
-   kubectl create -f cilium.yaml
+   helm install cilium |CHART_RELEASE| \\
+      --namespace kube-system \\
+      --set global.etcd.enabled=true \\
+      --set global.etcd.managed=true
 
 
 Validate the Installation

--- a/Documentation/gettingstarted/k8s-install-external-etcd.rst
+++ b/Documentation/gettingstarted/k8s-install-external-etcd.rst
@@ -50,16 +50,15 @@ configured in the ConfigMap. Download the base YAML and configure it with
 
 .. include:: k8s-install-download-release.rst
 
-Change the etcd endpoints accordingly:
+Deploy Cilium release via Helm:
 
-.. code:: bash
+.. parsed-literal::
 
-    helm template cilium \
-      --namespace kube-system \
-      --set global.etcd.enabled=true \
-      --set global.etcd.endpoints[0]=http://etcd-endpoint1:2379 \
-      --set global.etcd.endpoints[1]=http://etcd-endpoint2:2379 \
-      > cilium.yaml
+    helm install cilium |CHART_RELEASE| \\
+      --namespace kube-system \\
+      --set global.etcd.enabled=true \\
+      --set global.etcd.endpoints[0]=http://etcd-endpoint1:2379 \\
+      --set global.etcd.endpoints[1]=http://etcd-endpoint2:2379
 
 
 Optional: Configure the SSL certificates
@@ -78,22 +77,14 @@ key and certificate of etcd:
 Adjust the helm template generation to enable SSL for etcd and use https instead
 of http for the etcd endpoint URLs:
 
-.. code:: bash
+.. parsed-literal::
 
-    helm template cilium \
-      --namespace kube-system \
-      --set global.etcd.enabled=true \
-      --set global.etcd.ssl=true \
-      --set global.etcd.endpoints[0]=https://etcd-endpoint1:2379 \
-      --set global.etcd.endpoints[1]=https://etcd-endpoint2:2379 \
-      > cilium.yaml
-
-Deploy Cilium
--------------
-
-.. code:: bash
-
-    kubectl create -f cilium.yaml
+    helm install cilium |CHART_RELEASE| \\
+      --namespace kube-system \\
+      --set global.etcd.enabled=true \\
+      --set global.etcd.ssl=true \\
+      --set global.etcd.endpoints[0]=https://etcd-endpoint1:2379 \\
+      --set global.etcd.endpoints[1]=https://etcd-endpoint2:2379
 
 Validate the Installation
 =========================

--- a/Documentation/gettingstarted/k8s-install-gke.rst
+++ b/Documentation/gettingstarted/k8s-install-gke.rst
@@ -62,19 +62,16 @@ Prepare & Deploy Cilium
 
 .. include:: k8s-install-download-release.rst
 
-Generate the required YAML files and deploy them:
+Deploy Cilium release via Helm:
 
-.. code:: bash
+.. parsed-literal::
 
-    helm template cilium \
-      --namespace cilium \
-      --set global.nodeinit.enabled=true \
-      --set nodeinit.reconfigureKubelet=true \
-      --set nodeinit.removeCbrBridge=true \
-      --set global.cni.binPath=/home/kubernetes/bin \
-      > cilium.yaml
-    kubectl create namespace cilium
-    kubectl create -f cilium.yaml
+    helm install cilium |CHART_RELEASE| \\
+      --namespace cilium \\
+      --set global.nodeinit.enabled=true \\
+      --set nodeinit.reconfigureKubelet=true \\
+      --set nodeinit.removeCbrBridge=true \\
+      --set global.cni.binPath=/home/kubernetes/bin
 
 The NodeInit DaemonSet is required to prepare the GKE nodes as nodes are added
 to the cluster. The NodeInit DaemonSet will perform the following actions:

--- a/Documentation/gettingstarted/kata-gce.rst
+++ b/Documentation/gettingstarted/kata-gce.rst
@@ -161,15 +161,13 @@ Deploy Cilium
 
 .. include:: k8s-install-download-release.rst
 
-Generate the required YAML file and deploy it:
+Deploy Cilium release via Helm:
 
-.. code:: bash
+.. parsed-literal::
 
-   helm template cilium \
-     --namespace kube-system \
-     --set global.containerRuntime.integration=crio \
-     > cilium.yaml
-   kubectl create -f cilium.yaml
+   helm install cilium |CHART_RELEASE| \\
+     --namespace kube-system \\
+     --set global.containerRuntime.integration=crio
 
 .. note::
 

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -69,15 +69,13 @@ Next, generate the required YAML files and deploy them. Replace ``$API_SERVER_IP
 and ``$API_SERVER_PORT`` with the control-plane node IP address and the kube-apiserver
 port number reported by ``kubeadm init`` (usually it is ``6443``).
 
-.. code:: bash
+.. parsed-literal::
 
-    helm template cilium \
-        --namespace kube-system \
-        --set global.nodePort.enabled=true \
-        --set global.k8sServiceHost=$API_SERVER_IP \
-        --set global.k8sServicePort=$API_SERVER_PORT \
-    > cilium.yaml
-    kubectl apply -f cilium.yaml
+    helm install cilium |CHART_RELEASE| \\
+        --namespace kube-system \\
+        --set global.nodePort.enabled=true \\
+        --set global.k8sServiceHost=$API_SERVER_IP \\
+        --set global.k8sServicePort=$API_SERVER_PORT
 
 This will install Cilium as a CNI plugin with the BPF kube-proxy replacement.
 See :ref:`nodeport` for requirements and configuration options for NodePort

--- a/Documentation/gettingstarted/nodeport.rst
+++ b/Documentation/gettingstarted/nodeport.rst
@@ -30,14 +30,13 @@ without ``kube-proxy``.
 
 .. include:: k8s-install-download-release.rst
 
-Generate the required YAML file and deploy it:
+Deploy Cilium release via Helm:
 
-.. code:: bash
+.. parsed-literal::
 
-   helm template cilium \
-     --namespace kube-system \
-     --set global.nodePort.enabled=true \
-     > cilium.yaml
+   helm install cilium |CHART_RELEASE| \\
+     --namespace kube-system \\
+     --set global.nodePort.enabled=true
 
 By default, a NodePort service will be accessible via an IP address of a native
 device which has a default route on the host. To change a device, set its name

--- a/Documentation/kubernetes/configuration.rst
+++ b/Documentation/kubernetes/configuration.rst
@@ -328,12 +328,11 @@ If you want to use CRIO, generate the YAML using:
 
 .. include:: ../gettingstarted/k8s-install-download-release.rst
 
-.. code:: bash
+.. parsed-literal::
 
-   helm template cilium \
-     --namespace kube-system \
-     --set global.containerRuntime.integration=crio \
-     > cilium.yaml
+   helm install cilium |CHART_RELEASE| \\
+     --namespace kube-system \\
+     --set global.containerRuntime.integration=crio
 
 Since CRI-O does not automatically detect that a new CNI plugin has been
 installed, you will need to restart the CRI-O daemon for it to pick up the


### PR DESCRIPTION
Switch to helm3 for generating YAMLs and installing Cilium.

Once helm repository is up it will be more convenient to use packaged
charts from the repository instead of pulling releases. This patch
updates docs to use helm repository in all relevant examples.

All occurrences of 'helm template' were replaced with corresponding
'helm install --version' and some additional re-wording were performed
where applicable.

This patch should only be merged once helm repository is up and tested.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9783)
<!-- Reviewable:end -->
