### PR TITLE
v1.6: install: Update the chart versions

### DIFF
--- a/install/kubernetes/cilium/Chart.yaml
+++ b/install/kubernetes/cilium/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cilium
-version: 1.6.90
-appVersion: 1.6.90
+version: 1.6.5
+appVersion: 1.6.5
 tillerVersion: ">=2.7.2-0"
 description: Helm chart for Cilium
 keywords:

--- a/install/kubernetes/cilium/charts/agent/Chart.yaml
+++ b/install/kubernetes/cilium/charts/agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: agent
-version: 1.6.90
-appVersion: 1.6.90
+version: 1.6.5
+appVersion: 1.6.5
 tillerVersion: ">=2.7.2"
 description: Helm chart for cilium-agent DaemonSet
 keywords:

--- a/install/kubernetes/cilium/charts/config/Chart.yaml
+++ b/install/kubernetes/cilium/charts/config/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: config
-version: 1.6.90
-appVersion: 1.6.90
+version: 1.6.5
+appVersion: 1.6.5
 tillerVersion: ">=2.7.2"
 description: Helm chart for Cilium configuration
 keywords:

--- a/install/kubernetes/cilium/charts/managed-etcd/Chart.yaml
+++ b/install/kubernetes/cilium/charts/managed-etcd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: managed-etcd
-version: 1.6.90
-appVersion: 1.6.90
+version: 1.6.5
+appVersion: 1.6.5
 tillerVersion: ">=2.7.2"
 description: Helm chart for managed etcd
 keywords:

--- a/install/kubernetes/cilium/charts/nodeinit/Chart.yaml
+++ b/install/kubernetes/cilium/charts/nodeinit/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: nodeinit
-version: 1.6.90
-appVersion: 1.6.90
+version: 1.6.5
+appVersion: 1.6.5
 tillerVersion: ">=2.7.2"
 description: Helm chart for node initialization
 keywords:

--- a/install/kubernetes/cilium/charts/operator/Chart.yaml
+++ b/install/kubernetes/cilium/charts/operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: operator
-version: 1.6.90
-appVersion: 1.6.90
+version: 1.6.5
+appVersion: 1.6.5
 tillerVersion: ">=2.7.2"
 description: Helm chart for cilium-operator deployment
 keywords:

--- a/install/kubernetes/cilium/charts/preflight/Chart.yaml
+++ b/install/kubernetes/cilium/charts/preflight/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: preflight
-version: 1.6.90
-appVersion: 1.6.90
+version: 1.6.5
+appVersion: 1.6.5
 tillerVersion: ">=2.7.2"
 description: Helm chart for pre-flight functionality
 keywords:

--- a/install/kubernetes/cilium/requirements.yaml
+++ b/install/kubernetes/cilium/requirements.yaml
@@ -1,19 +1,19 @@
 dependencies:
   - name: agent
-    version: 1.6.0
+    version: 1.6.5
     condition: agent.enabled
   - name: config
-    version: 1.6.0
+    version: 1.6.5
     condition: config.enabled
   - name: operator
-    version: 1.6.0
+    version: 1.6.5
     condition: operator.enabled
   - name: managed-etcd
-    version: 1.6.0
+    version: 1.6.5
     condition: global.etcd.managed
   - name: preflight
-    version: 1.6.0
+    version: 1.6.5
     condition: preflight.enabled
   - name: nodeinit
-    version: 1.6.0
+    version: 1.6.5
     condition: global.nodeinit.enabled


### PR DESCRIPTION
All of these chart versions should be updated to the latest v1.6
release, that is v1.6.5.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9788)
<!-- Reviewable:end -->
