### PR TITLE
test: Make helm fetch more quiet

### DIFF
--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -44,7 +44,7 @@ sudo bash -c "echo MaxSessions 200 >> /etc/ssh/sshd_config"
 sudo systemctl restart ssh
 
 if [[ ! $(helm version | grep ${HELM_VERSION}) ]]; then
-  retry_function "wget https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz"
+  retry_function "wget -nv https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz"
   tar xzvf helm-v${HELM_VERSION}-linux-amd64.tar.gz
   mv linux-amd64/helm /usr/local/bin/
 fi


### PR DESCRIPTION
Recent CI builds have consumed as many as 4300 lines of CLI output per
attempt to download the helm client, most of them empty, over the course
of about 6 seconds.

Use the `-nv` (no verbose) option to quieten this output to only
info/error/warnings; converts into about one line of output:

     $ wget -nv https://get.helm.sh/helm-v2.14.2-linux-amd64.tar.gz
     2019-12-23 10:00:32
     URL:https://get.helm.sh/helm-v2.14.2-linux-amd64.tar.gz
     [26534215/26534215] -> "helm-v2.14.2-linux-amd64.tar.gz" [1]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9799)
<!-- Reviewable:end -->
