### PR TITLE
Fix table markdown spacing issue

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ release notes:
 +-------------------------------------------------------+------------+-------------------------------------+---------------------------------------------------------------------------+------------------------------------------------------------------------+
 | `v1.5 <https://github.com/cilium/cilium/tree/v1.5>`__ | 2019-12-17 | ``docker.io/cilium/cilium:v1.5.11`` | `Release Notes <https://github.com/cilium/cilium/releases/tag/v1.5.11>`__ | `General Announcement <https://cilium.io/blog/2019/04/24/cilium-15>`__ |
 +-------------------------------------------------------+------------+-------------------------------------+---------------------------------------------------------------------------+------------------------------------------------------------------------+
-| `v1.4 <https://github.com/cilium/cilium/tree/v1.4>`__ | 2019-12-17 | ``docker.io/cilium/cilium:v1.4.10``  | `Release Notes <https://github.com/cilium/cilium/releases/tag/v1.4.10>`_ | `General Announcement <https://cilium.io/blog/2019/02/12/cilium-14>`__ |
+| `v1.4 <https://github.com/cilium/cilium/tree/v1.4>`__ | 2019-12-17 | ``docker.io/cilium/cilium:v1.4.10`` | `Release Notes <https://github.com/cilium/cilium/releases/tag/v1.4.10>`_  | `General Announcement <https://cilium.io/blog/2019/02/12/cilium-14>`__ |
 +-------------------------------------------------------+------------+-------------------------------------+---------------------------------------------------------------------------+------------------------------------------------------------------------+
 
 Functionality Overview


### PR DESCRIPTION
Columns on row 3 of the table were not getting seperated due to it.

Fixes: No related issues.
![Screenshot from 2019-12-24 15-58-42](https://user-images.githubusercontent.com/26240780/71409147-83eba680-2666-11ea-8341-4e747b13ebac.png)

Signed-off-by: dhsathiya <devarshisathiya5@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9801)
<!-- Reviewable:end -->
