### PR TITLE
Adding USERS directory to create a list of Cilium users

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -1,0 +1,42 @@
+Who is using Cilium?
+====================
+
+Sharing experiences and learning from other users is essential. We are
+frequently asked who is using a particular feature of Cilium to get in contact
+with other users to share experiences and best-practices. While the Slack
+community allows users to get in touch, it can be challenging to find users of
+a particular feature quickly.
+
+The following is a directory of users to help identify users of individual
+features. The users themselves directly maintain the list.
+
+Adding yourself as a user
+-------------------------
+
+If you are using Cilium, please consider adding yourself as a user with a quick
+description of your use case by opening a pull request to this file and adding
+a section describing your usage of Cilium. If you are open to others contacting
+you about your use of Cilium on Slack, add your Slack nick as well.
+
+    N: Name of user (company or individual)
+    D: Description
+    U: Usage of features
+    Q: Contacts available for questions
+
+Requirements to be listed
+-------------------------
+
+ * You must represent the user listed. Do *NOT* add entries on behalf of
+   other users.
+ * There is no minimum deployment size but we request to list permanent
+   deployments only, i.e., no demo or trial deployments. Commercial or
+   production use is not required. A well-done home lab setup can be equally
+   interesting as a large-scale commercial deployment.
+
+Users (Alphabetically)
+---------------------
+
+    * N: Cilium Example User Inc.
+      D: Cilium Example User Inc. is using Cilium for scientific purposes
+      U: ENI networking, DNS policies, ClusteMesh
+      Q: @slacknick1, @slacknick2


### PR DESCRIPTION
Sharing experiences and learning from other users is important. We are
frequently asked who is using a particular feature of Cilium in order to get in
contact with other users of a particular features to share experiences and
best-practices. While the Slack community allows users to get in touch, it can
be challenging to quickly find users of a particular feature.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9810)
<!-- Reviewable:end -->
