### PR TITLE
envoy: Increase max log token length to 1MB

### DIFF
--- a/pkg/envoy/envoy.go
+++ b/pkg/envoy/envoy.go
@@ -283,6 +283,7 @@ func StartEnvoy(stateDir, logPath string, baseID uint64) *Envoy {
 func newEnvoyLogPiper() io.WriteCloser {
 	reader, writer := io.Pipe()
 	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(nil, 1024 * 1024)
 	go func() {
 		scopedLog := log.WithFields(logrus.Fields{
 			logfields.LogSubsys: "unknown",


### PR DESCRIPTION
Long log lines currently stop the Envoy log scanner within
cilium-agent. Increase the max token size from the default 64kB to 1MB
as a stop-gap measure.

Fixes: #9591
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9814)
<!-- Reviewable:end -->
