### PR TITLE
Add cilium-monitor sidecar container for agent pods

### DIFF
--- a/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
@@ -179,6 +179,24 @@ spec:
           name: kube-config
           readOnly: true
 {{- end}}
+{{- if .Values.monitor.enabled }}
+      - name: cilium-monitor
+        command: ["cilium"]
+        args:
+        - monitor
+{{- range $type := .Values.monitor.eventTypes }}
+        - --type={{ $type }}
+{{- end }}
+{{- if contains "/" .Values.image }}
+        image: "{{ .Values.image }}"
+{{- else }}
+        image: "{{ .Values.global.registry }}/{{ .Values.image }}:{{ .Values.global.tag }}"
+{{- end }}
+        imagePullPolicy: {{ .Values.global.pullPolicy }}
+        volumeMounts:
+        - mountPath: /var/run/cilium
+          name: cilium-run
+{{- end }}
 {{- if .Values.global.etcd.managed }}
       # In managed etcd mode, Cilium must be able to resolve the DNS name of
       # the etcd service

--- a/install/kubernetes/cilium/charts/agent/values.yaml
+++ b/install/kubernetes/cilium/charts/agent/values.yaml
@@ -3,3 +3,8 @@ image: cilium
 # Specifies the maximum number of Pods that can be unavailable during the
 # update process.
 maxUnavailable: 2
+
+# Enables monitor sidecar container for specified event types
+monitor:
+  enabled: false
+  eventTypes: []


### PR DESCRIPTION
Cilium debugging across a cluster involves running cilium monitor
manually on every node of the cluster.

This MR introduces optional monitor sidecar container for agent's
daemon set. This will simplify monitor startup across a cluster and
will expose monitor event to the 'kubectl logs'. Monitor container is
disabled by default (monitor.enabled), event types can be adjusted via
monitor.eventTypes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9815)
<!-- Reviewable:end -->
