### PR TITLE
identity: require global identity for empty labels

### DIFF
--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -202,15 +202,18 @@ func (pair *IPIdentityPair) PrefixString() string {
 // RequiresGlobalIdentity returns true if the label combination requires a
 // global identity
 func RequiresGlobalIdentity(lbls labels.Labels) bool {
+	needsGlobal := true
+
 	for _, label := range lbls {
 		switch label.Source {
 		case labels.LabelSourceCIDR, labels.LabelSourceReserved:
+			needsGlobal = false
 		default:
 			return true
 		}
 	}
 
-	return false
+	return needsGlobal
 }
 
 // AddUserDefinedNumericIdentitySet adds all key-value pairs from the given map


### PR DESCRIPTION
See commit msg.

```release-note
Fix to allocate a global identity for an empty container label-set.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9821)
<!-- Reviewable:end -->
