### PR TITLE
docs: fix kubernetes configmap

### DIFF
--- a/Documentation/kubernetes/configuration.rst
+++ b/Documentation/kubernetes/configuration.rst
@@ -69,9 +69,19 @@ enabled.
       name: cilium-config
       namespace: kube-system
     data:
+      # The kvstore configuration is used to enable use of a kvstore for state
+      # storage. This can either be provided with an external kvstore or with the
+      # help of cilium-etcd-operator which operates an etcd cluster automatically.
+      kvstore: etcd
+      kvstore-opt: '{"etcd.config": "/var/lib/etcd-config/etcd.config"}'
+
+      # This etcd-config contains the etcd endpoints of your cluster. If you use
+      # TLS please make sure you follow the tutorial in https://cilium.link/etcd-config
+      etcd-config: |-
+        ---
         endpoints:
-        - https://node-1:31079
-        - https://node-2:31079
+          - https://node-1:31079
+          - https://node-2:31079
         #
         # In case you want to use TLS in etcd, uncomment the 'trusted-ca-file' line
         # and create a kubernetes secret by following the tutorial in


### PR DESCRIPTION
The ConfigMap is not correctly formated. This commit fixes it so that
users won't have problems using this configuration as an example for
their setups.

Signed-off-by: André Martins <andre@cilium.io>

Fixes #9818

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9824)
<!-- Reviewable:end -->
