### PR TITLE
Fix helm subchart versions

### DIFF
--- a/install/kubernetes/cilium/requirements.yaml
+++ b/install/kubernetes/cilium/requirements.yaml
@@ -1,19 +1,19 @@
 dependencies:
   - name: agent
-    version: 1.6.0
+    version: 1.6.90
     condition: agent.enabled
   - name: config
-    version: 1.6.0
+    version: 1.6.90
     condition: config.enabled
   - name: operator
-    version: 1.6.0
+    version: 1.6.90
     condition: operator.enabled
   - name: managed-etcd
-    version: 1.6.0
+    version: 1.6.90
     condition: global.etcd.managed
   - name: preflight
-    version: 1.6.0
+    version: 1.6.90
     condition: preflight.enabled
   - name: nodeinit
-    version: 1.6.0
+    version: 1.6.90
     condition: global.nodeinit.enabled


### PR DESCRIPTION
'helm dependency update' fails on master with:

Dependency agent at version 1.6.90 does not satisfy the constraint 1.6.0

This patch updates 'requirements.yaml' to use correct versions of the subcharts

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9826)
<!-- Reviewable:end -->
