### PR TITLE
v1.5 backports 2020-01-09

### DIFF
--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -185,13 +185,16 @@ func (pair *IPIdentityPair) PrefixString() string {
 // RequiresGlobalIdentity returns true if the label combination requires a
 // global identity
 func RequiresGlobalIdentity(lbls labels.Labels) bool {
+	needsGlobal := true
+
 	for _, label := range lbls {
 		switch label.Source {
 		case labels.LabelSourceCIDR, labels.LabelSourceReserved:
+			needsGlobal = false
 		default:
 			return true
 		}
 	}
 
-	return false
+	return needsGlobal
 }


### PR DESCRIPTION
 * #9821 -- identity: require global identity for empty labels (@borkmann)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 9821; do contrib/backporting/set-labels.py $pr done 1.5; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9829)
<!-- Reviewable:end -->
