### PR TITLE
v1.5 backports 2020-01-10

### DIFF
--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -1182,6 +1182,10 @@ func runDaemon() {
 		}
 	}
 
+	if err := enableIPForwarding(); err != nil {
+		log.WithError(err).Fatal("Error when enabling sysctl parameters")
+	}
+
 	iptablesManager := &iptables.IptablesManager{}
 	iptablesManager.Init()
 

--- a/daemon/sysctl_darwin.go
+++ b/daemon/sysctl_darwin.go
@@ -1,0 +1,21 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+// enableIPForwarding on OS X and Darwin is not doing anything. It just exists
+// to make compilation possible.
+func enableIPForwarding() error {
+	return nil
+}

--- a/daemon/sysctl_linux.go
+++ b/daemon/sysctl_linux.go
@@ -1,0 +1,32 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/cilium/cilium/pkg/sysctl"
+)
+
+func enableIPForwarding() error {
+	if err := sysctl.Enable("net.ipv4.ip_forward"); err != nil {
+		return err
+	}
+	if err := sysctl.Enable("net.ipv4.conf.all.forwarding"); err != nil {
+		return err
+	}
+	if err := sysctl.Enable("net.ipv6.conf.all.forwarding"); err != nil {
+		return err
+	}
+	return nil
+}

--- a/daemon/sysctl_linux_test.go
+++ b/daemon/sysctl_linux_test.go
@@ -1,0 +1,37 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux,privileged_tests
+
+package main
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type DaemonPrivilegedSuite struct{}
+
+var _ = Suite(&DaemonPrivilegedSuite{})
+
+func (s *DaemonPrivilegedSuite) TestInitSysctlParams(c *C) {
+	err := initSysctlParams()
+	c.Assert(err, IsNil)
+}

--- a/pkg/sysctl/doc.go
+++ b/pkg/sysctl/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package sysctl allows to change kernel parameters at runtime.
+package sysctl

--- a/pkg/sysctl/sysctl.go
+++ b/pkg/sysctl/sysctl.go
@@ -1,0 +1,15 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sysctl

--- a/pkg/sysctl/sysctl_darwin.go
+++ b/pkg/sysctl/sysctl_darwin.go
@@ -1,0 +1,31 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// +build darwin
+
+package sysctl
+
+// Disable disables the given sysctl parameter.
+// On OS X and Darwin it's not doing anything. It just exists to make compilation
+// possible.
+func Disable(name string) error {
+	return nil
+}
+
+// Enable enables the given sysctl parameter.
+// On OS X and Darwin it's not doing anything. It just exists to make compilation
+// possible.
+func Enable(name string) error {
+	return nil
+}

--- a/pkg/sysctl/sysctl_linux.go
+++ b/pkg/sysctl/sysctl_linux.go
@@ -1,0 +1,58 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// +build linux
+
+package sysctl
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	prefixDir = "/proc/sys"
+)
+
+func fullPath(name string) string {
+	return filepath.Join(prefixDir, strings.Replace(name, ".", "/", -1))
+}
+
+func writeSysctl(name string, value string) error {
+	fPath := fullPath(name)
+	f, err := os.OpenFile(fPath, os.O_RDWR, 0644)
+	if err != nil {
+		return fmt.Errorf("could not open the sysctl file %s: %s",
+			fPath, err)
+	}
+	defer f.Close()
+	if _, err := io.WriteString(f, value); err != nil {
+		return fmt.Errorf("could not write to the systctl file %s: %s",
+			fPath, err)
+	}
+	return nil
+}
+
+// Disable disables the given sysctl parameter.
+func Disable(name string) error {
+	return writeSysctl(name, "0")
+}
+
+// Enable enables the given sysctl parameter.
+func Enable(name string) error {
+	return writeSysctl(name, "1")
+}

--- a/pkg/sysctl/sysctl_linux_privileged_test.go
+++ b/pkg/sysctl/sysctl_linux_privileged_test.go
@@ -1,0 +1,110 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux,privileged_tests
+
+package sysctl
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type SysctlLinuxPrivilegedTestSuite struct{}
+
+var _ = Suite(&SysctlLinuxPrivilegedTestSuite{})
+
+func (s *SysctlLinuxPrivilegedTestSuite) TestWriteSysctl(c *C) {
+	testCases := []struct {
+		name        string
+		value       []byte
+		oldValue    []byte
+		expectedErr bool
+	}{
+		{
+			name:        "net.ipv4.ip_forward",
+			value:       "1",
+			expectedErr: false,
+		},
+		{
+			name:        "net.ipv4.conf.all.forwarding",
+			value:       "1",
+			expectedErr: false,
+		},
+		{
+			name:        "net.ipv6.conf.all.forwarding",
+			value:       "1",
+			expectedErr: false,
+		},
+		{
+			name:        "foo.bar",
+			value:       "1",
+			expectedErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		err := writeSysctl(tc.name, tc.value)
+		if tc.expectedErr {
+			c.Assert(err, NotNil)
+		} else {
+			c.Assert(err, IsNil)
+		}
+	}
+}
+
+func (s *SysctlLinuxPrivilegedTestSuite) TestDisableEnable(c *C) {
+	testCases := []struct {
+		name        string
+		expectedErr bool
+	}{
+		{
+			name:        "net.ipv4.ip_forward",
+			expectedErr: false,
+		},
+		{
+			name:        "net.ipv4.conf.all.forwarding",
+			expectedErr: false,
+		},
+		{
+			name:        "net.ipv6.conf.all.forwarding",
+			expectedErr: false,
+		},
+		{
+			name:        "foo.bar",
+			expectedErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		err := Enable(tc.name)
+		if tc.expectedErr {
+			c.Assert(err, NotNil)
+		} else {
+			c.Assert(err, IsNil)
+		}
+		err = Disable(tc.name)
+		if tc.expectedErr {
+			c.Assert(err, NotNil)
+		} else {
+			c.Assert(err, IsNil)
+		}
+	}
+}

--- a/pkg/sysctl/sysctl_linux_test.go
+++ b/pkg/sysctl/sysctl_linux_test.go
@@ -1,0 +1,60 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux
+
+package sysctl
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type SysctlLinuxTestSuite struct{}
+
+var _ = Suite(&SysctlLinuxTestSuite{})
+
+func (s *SysctlLinuxTestSuite) TestFullPath(c *C) {
+	testCases := []struct {
+		name     string
+		expected string
+	}{
+		{
+			name:     "net.ipv4.ip_forward",
+			expected: "/proc/sys/net/ipv4/ip_forward",
+		},
+		{
+			name:     "net.ipv4.conf.all.forwarding",
+			expected: "/proc/sys/net/ipv4/conf/all/forwarding",
+		},
+		{
+			name:     "net.ipv6.conf.all.forwarding",
+			expected: "/proc/sys/net/ipv6/conf/all/forwarding",
+		},
+		{
+			name:     "foo.bar",
+			expected: "/proc/sys/foo/bar",
+		},
+	}
+
+	for _, tc := range testCases {
+		c.Assert(fullPath(tc.name), Equals, tc.expected)
+	}
+}


### PR DESCRIPTION
 * #8954 -- Enable IP forwarding on daemon start (@mrostecki)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 8954; do contrib/backporting/set-labels.py $pr done 1.5; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9839)
<!-- Reviewable:end -->
