### PR TITLE
Fix issue that BPF system config check fail

### DIFF
--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -414,6 +414,8 @@ spec:
           readOnly: true
         - mountPath: /run/xtables.lock
           name: xtables-lock
+        - mountPath: /boot
+          name: boot
       hostNetwork: true
       initContainers:
       - command:
@@ -488,6 +490,10 @@ spec:
           path: /run/xtables.lock
           type: FileOrCreate
         name: xtables-lock
+        # To probe kernel config
+      - hostPath:
+          path: /boot
+        name: boot
         # To read the clustermesh configuration
       - name: clustermesh-secrets
         secret:


### PR DESCRIPTION
Bpftool can't open file:"/boot/config-% s"
the main reason is without mounting /boot into container,
thus bpftool skipping kernel config.

Signed-off-by: Jianlin Lv <Jianlin.Lv@arm.com>

Fixes: #9838

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9840)
<!-- Reviewable:end -->
