### PR TITLE
v1.6 backports 2020-01-10

### DIFF
--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -1385,6 +1385,10 @@ func runDaemon() {
 
 	option.Config.RunMonitorAgent = true
 
+	if err := enableIPForwarding(); err != nil {
+		log.WithError(err).Fatal("Error when enabling sysctl parameters")
+	}
+
 	iptablesManager := &iptables.IptablesManager{}
 	iptablesManager.Init()
 

--- a/daemon/sysctl_darwin.go
+++ b/daemon/sysctl_darwin.go
@@ -1,0 +1,21 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+// enableIPForwarding on OS X and Darwin is not doing anything. It just exists
+// to make compilation possible.
+func enableIPForwarding() error {
+	return nil
+}

--- a/daemon/sysctl_linux.go
+++ b/daemon/sysctl_linux.go
@@ -1,0 +1,32 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/cilium/cilium/pkg/sysctl"
+)
+
+func enableIPForwarding() error {
+	if err := sysctl.Enable("net.ipv4.ip_forward"); err != nil {
+		return err
+	}
+	if err := sysctl.Enable("net.ipv4.conf.all.forwarding"); err != nil {
+		return err
+	}
+	if err := sysctl.Enable("net.ipv6.conf.all.forwarding"); err != nil {
+		return err
+	}
+	return nil
+}

--- a/daemon/sysctl_linux_test.go
+++ b/daemon/sysctl_linux_test.go
@@ -1,0 +1,37 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux,privileged_tests
+
+package main
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type DaemonPrivilegedSuite struct{}
+
+var _ = Suite(&DaemonPrivilegedSuite{})
+
+func (s *DaemonPrivilegedSuite) TestInitSysctlParams(c *C) {
+	err := initSysctlParams()
+	c.Assert(err, IsNil)
+}


### PR DESCRIPTION
 * #8954 -- Enable IP forwarding on daemon start (@mrostecki)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 8954; do contrib/backporting/set-labels.py $pr done 1.6; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9841)
<!-- Reviewable:end -->
