### PR TITLE
test/packet: fix packet terraform scripts

### DIFF
--- a/test/packet/.gitignore
+++ b/test/packet/.gitignore
@@ -1,3 +1,4 @@
 .terraform.*
 .terraform/
 terraform.tfstate
+terraform.tfstate.backup

--- a/test/packet/main.tf
+++ b/test/packet/main.tf
@@ -20,23 +20,24 @@ variable "nodes" {
 }
 
 provider "packet" {
-  auth_token = "${var.packet_token}"
+  auth_token = var.packet_token
 }
 
 # Create a device and add it to tf_project_1
 resource "packet_device" "test" {
-    count            = "${var.nodes}"
+    count            = var.nodes
     hostname         = "test-${count.index}"
-    plan             = "${var.packet_plan}"
-    facility         = "${var.packet_location}"
-    operating_system = "ubuntu_18_04"
+    plan             = var.packet_plan
+    facilities       = [ var.packet_location ]
+    operating_system = "ubuntu_19_04"
     billing_cycle    = "hourly"
-    project_id       = "${var.packet_project_id}"
+    project_id       = var.packet_project_id
 
 	connection {
       type = "ssh"
+      host = packet_device.test[count.index].access_public_ipv4
       user = "root"
-      private_key = "${file("${var.private_key_path}")}"
+      private_key = file(var.private_key_path)
       agent = false
 	}
 

--- a/test/packet/scripts/add_vagrant_box.sh
+++ b/test/packet/scripts/add_vagrant_box.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+if [[ $# -ne 1 ]]; then
+    echo "usage: add-vagrant-boxes.sh [vagrant_box_defaults.rb path]"
+    exit 1
+fi
+
+path=$1
+
+for box in SERVER NETNEXT_SERVER; do
+    name=$(cat $path | grep "^\$${box}_BOX" | awk '{print $NF}' | sed 's/^"\(.*\)"$/\1/')
+    # we need non-dev images for CI
+    if [[ "$name" == "cilium/ubuntu-dev" ]]; then
+        name="cilium/ubuntu"
+    fi
+
+    if [[ "$name" == "" ]]; then
+        continue
+    fi
+
+    version=$(cat $path |grep "^\$${box}_VERSION" | awk '{print $NF}' | sed 's/^"\(.*\)"$/\1/')
+
+    set +e
+	vagrant box list | grep "$name " | grep $version
+	if [[ $? -eq 0 ]]; then
+		echo "box already exists, no need to preload"
+		continue
+	fi
+
+    curl --fail http://vagrant-cache.ci.cilium.io/$name/$version/lock
+    lock_exit_code=$?
+    # check for 404 error indicating that cache is up and lock file is not in place
+    if [ $lock_exit_code  -eq 22 ]; then
+        download_from_cache=true
+    else
+        # cache is down or box is locked
+        download_from_cache=false
+    fi
+
+    box_downloaded=false
+
+    if [[ $download_from_cache == true ]]; then
+        echo "adding box from cache"
+        curl --fail http://vagrant-cache.ci.cilium.io/$name/$version/metadata.json --output metadata.json
+        curl http://vagrant-cache.ci.cilium.io/$name/$version/package.box --output package.box
+        vagrant box add metadata.json
+        box_downloaded=$?
+    fi
+
+    set -e
+    if [[ $box_downloaded -ne 0 ]]; then
+        echo "box locked or unavailable, adding box from vagrant cloud"
+        vagrant box add $name --box-version $version
+    fi
+done

--- a/test/packet/scripts/install.sh
+++ b/test/packet/scripts/install.sh
@@ -5,7 +5,7 @@ set -e
 # Ensure no prompts from apt & co.
 export DEBIAN_FRONTEND=noninteractive
 
-GOLANG_VERSION="1.12.5"
+GOLANG_VERSION="1.13.5"
 VAGRANT_VERSION="2.2.4"
 PACKER_VERSION="1.3.5"
 VIRTUALBOX_VERSION="6.0"
@@ -39,8 +39,8 @@ dpkg -i vagrant_*.deb
 # this block will attempt to preload required vagrant boxes from the vagrant cache server
 # (it's configuration is in vagrant-cache directory in root of this repo).
 # vagrant cache server is a separate packet box which vagrant-cache.ci.cilium.io points to
-cp /provision/add_vagrant_box /usr/local/bin/
-chmod 755 /usr/local/bin/add_vagrant_box
+cp /provision/add_vagrant_box.sh /usr/local/bin/
+chmod 755 /usr/local/bin/add_vagrant_box.sh
 
 curl -s https://raw.githubusercontent.com/cilium/cilium/master/vagrant_box_defaults.rb > defaults.rb
 /usr/local/bin/add_vagrant_box defaults.rb


### PR DESCRIPTION
terraform scripts seem to be broken, this commit fixes them so
developers can use the scripts to create a VM similar to the one used in
the CI to run their own CI tests.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9850)
<!-- Reviewable:end -->
