### PR TITLE
CI fixups to run on GKE

### DIFF
--- a/jenkinsfiles/ginkgo-eks.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-eks.Jenkinsfile
@@ -105,7 +105,7 @@ pipeline {
         }
         stage ("BDD-Test-PR"){
             options {
-                timeout(time: 130, unit: 'MINUTES')
+                timeout(time: 250, unit: 'MINUTES')
             }
             environment {
                 FAILFAST=setIfLabel("ci/fail-fast", "true", "false")

--- a/jenkinsfiles/ginkgo-gke.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-gke.Jenkinsfile
@@ -109,7 +109,7 @@ pipeline {
         }
         stage ("BDD-Test-PR"){
             options {
-                timeout(time: 130, unit: 'MINUTES')
+                timeout(time: 250, unit: 'MINUTES')
             }
             environment {
                 FAILFAST=setIfLabel("ci/fail-fast", "true", "false")

--- a/test/helpers/cmd.go
+++ b/test/helpers/cmd.go
@@ -151,7 +151,7 @@ func (res *CmdRes) CombineOutput() *bytes.Buffer {
 
 // IntOutput returns the stdout of res as an integer
 func (res *CmdRes) IntOutput() (int, error) {
-	return strconv.Atoi(strings.Trim(res.stdout.String(), "\n\r"))
+	return strconv.Atoi(strings.TrimSpace(res.stdout.String()))
 }
 
 // FindResults filters res's stdout using the provided JSONPath filter. It

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -149,8 +149,10 @@ const (
 	// actually transfer data.
 	CurlMaxTimeout = 8
 
-	DefaultNamespace    = "default"
-	KubeSystemNamespace = "kube-system"
+	DefaultNamespace       = "default"
+	KubeSystemNamespace    = "kube-system"
+	CiliumNamespaceDefault = KubeSystemNamespace
+	CiliumNamespaceGKE     = "cilium"
 
 	TestResultsPath = "test_results/"
 	RunDir          = "/var/run/cilium"
@@ -208,6 +210,16 @@ const (
 
 	// HelmTemplate is the location of the Helm templates to install Cilium
 	HelmTemplate = "../install/kubernetes/cilium"
+)
+
+var (
+	// CiliumNamespace is where cilium should run. In some deployments this cannot
+	// be kube-system.
+	CiliumNamespace = GetCiliumNamespace(GetCurrentIntegration())
+
+	// LogGathererNamespace is where log-gatherer should run. It follows cilium
+	// for simplicity.
+	LogGathererNamespace = CiliumNamespace
 )
 
 // Re-definitions of stable constants in the API. The re-definition is on

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -65,6 +65,9 @@ const (
 	// CIIntegrationEKS contains the constants to be used when running tests on EKS.
 	CIIntegrationEKS = "eks"
 
+	// CIIntegrationGKE contains the constants to be used when running tests on GKE.
+	CIIntegrationGKE = "gke"
+
 	// CIIntegrationMicrok8s contains the constant to be used when running tests on microk8s.
 	CIIntegrationMicrok8s = "microk8s"
 
@@ -113,6 +116,14 @@ var (
 		"global.nodeinit.enabled":       "true",
 	}
 
+	gkeHelmOverrides = map[string]string{
+		"global.ipv6.enabled":         "false",
+		"global.nodeinit.enabled":     "true",
+		"nodeinit.reconfigureKubelet": "true",
+		"nodeinit.removeCbrBridge":    "true",
+		"global.cni.binPath":          "/home/kubernetes/bin",
+	}
+
 	microk8sHelmOverrides = map[string]string{
 		"global.cni.confPath":                 "/var/snap/microk8s/current/args/cni-network",
 		"global.cni.binPath":                  "/var/snap/microk8s/current/opt/cni/bin",
@@ -133,6 +144,7 @@ var (
 	helmOverrides = map[string]map[string]string{
 		CIIntegrationFlannel:  flannelHelmOverrides,
 		CIIntegrationEKS:      eksHelmOverrides,
+		CIIntegrationGKE:      gkeHelmOverrides,
 		CIIntegrationMicrok8s: microk8sHelmOverrides,
 		CIIntegrationMinikube: minikubeHelmOverrides,
 	}

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1309,19 +1309,14 @@ func (kub *Kubectl) ciliumInstall(dsPatchName, cmPatchName string, getK8sDescrip
 	return nil
 }
 
-func addIfNotOverwritten(options []string, field, value string) []string {
-	for _, s := range options {
-		if strings.HasPrefix(s, "--set "+field) {
-			return options
-		}
+func addIfNotOverwritten(options map[string]string, field, value string) map[string]string {
+	if _, ok := options[field]; !ok {
+		options[field] = value
 	}
-
-	options = append(options, "--set "+field+"="+value)
 	return options
 }
 
-func (kub *Kubectl) generateCiliumYaml(options []string, filename string) error {
-
+func (kub *Kubectl) generateCiliumYaml(options map[string]string, filename string) error {
 	for key, value := range defaultHelmOptions {
 		options = addIfNotOverwritten(options, key, value)
 	}
@@ -1357,17 +1352,15 @@ func (kub *Kubectl) generateCiliumYaml(options []string, filename string) error 
 
 	if integration := GetCurrentIntegration(); integration != "" {
 		overrides := helmOverrides[integration]
-		// Appending the options will override earlier options on CLI.
 		for k, v := range overrides {
-			options = append(options, fmt.Sprintf("--set %s=%s", k, v))
+			options[k] = v
 		}
 	}
 
 	// TODO GH-8753: Use helm rendering library instead of shelling out to
 	// helm template
 	helmTemplate := kub.GetFilePath(HelmTemplate)
-	res := kub.ExecMiddle(fmt.Sprintf("helm template %s --namespace=kube-system %s > %s",
-		helmTemplate, strings.Join(options, " "), filename))
+	res := kub.HelmTemplate(helmTemplate, "kube-system", filename, options)
 	if !res.WasSuccessful() {
 		return res.GetErr("Unable to generate YAML")
 	}
@@ -1376,7 +1369,7 @@ func (kub *Kubectl) generateCiliumYaml(options []string, filename string) error 
 }
 
 // ciliumInstallHelm installs Cilium with the Helm options provided.
-func (kub *Kubectl) ciliumInstallHelm(options []string) error {
+func (kub *Kubectl) ciliumInstallHelm(options map[string]string) error {
 	if err := kub.generateCiliumYaml(options, "cilium.yaml"); err != nil {
 		return err
 	}
@@ -1390,7 +1383,7 @@ func (kub *Kubectl) ciliumInstallHelm(options []string) error {
 }
 
 // ciliumUninstallHelm uninstalls Cilium with the Helm options provided.
-func (kub *Kubectl) ciliumUninstallHelm(options []string) error {
+func (kub *Kubectl) ciliumUninstallHelm(options map[string]string) error {
 	if err := kub.generateCiliumYaml(options, "cilium.yaml"); err != nil {
 		return err
 	}
@@ -1404,12 +1397,12 @@ func (kub *Kubectl) ciliumUninstallHelm(options []string) error {
 }
 
 // CiliumInstall installs Cilium with the provided Helm options.
-func (kub *Kubectl) CiliumInstall(options []string) error {
+func (kub *Kubectl) CiliumInstall(options map[string]string) error {
 	return kub.ciliumInstallHelm(options)
 }
 
 // CiliumUninstall uninstalls Cilium with the provided Helm options.
-func (kub *Kubectl) CiliumUninstall(options []string) error {
+func (kub *Kubectl) CiliumUninstall(options map[string]string) error {
 	return kub.ciliumUninstallHelm(options)
 }
 
@@ -2867,6 +2860,19 @@ func (kub *Kubectl) reportMapHost(ctx context.Context, path string, reportCmds m
 			log.WithError(err).Errorf("cannot create test results for command '%s'", cmd)
 		}
 	}
+}
+
+// HelmTemplate renders given helm template. TODO: use go helm library for that
+func (kub *Kubectl) HelmTemplate(chartDir, namespace, filename string, options map[string]string) *CmdRes {
+	optionsString := ""
+
+	for k, v := range options {
+		optionsString += fmt.Sprintf(" --set %s=%s ", k, v)
+	}
+
+	return kub.ExecMiddle("helm template " +
+		chartDir + " " +
+		fmt.Sprintf("--namespace=%s %s > %s", namespace, optionsString, filename))
 }
 
 func serviceKey(s v1.Service) string {

--- a/test/k8sT/Chaos.go
+++ b/test/k8sT/Chaos.go
@@ -41,7 +41,7 @@ var _ = Describe("K8sChaosTest", func() {
 	})
 
 	AfterFailed(func() {
-		kubectl.CiliumReport(helpers.KubeSystemNamespace,
+		kubectl.CiliumReport(helpers.CiliumNamespace,
 			"cilium service list",
 			"cilium endpoint list")
 	})
@@ -131,7 +131,7 @@ var _ = Describe("K8sChaosTest", func() {
 
 			By("Deleting cilium pods")
 			res := kubectl.Exec(fmt.Sprintf("%s -n %s delete pods -l k8s-app=cilium",
-				helpers.KubectlCmd, helpers.KubeSystemNamespace))
+				helpers.KubectlCmd, helpers.CiliumNamespace))
 			res.ExpectSuccess()
 
 			ExpectAllPodsTerminated(kubectl)
@@ -146,7 +146,7 @@ var _ = Describe("K8sChaosTest", func() {
 			By("Uninstall cilium pods")
 
 			res = kubectl.DeleteResource(
-				"ds", fmt.Sprintf("-n %s cilium", helpers.KubeSystemNamespace))
+				"ds", fmt.Sprintf("-n %s cilium", helpers.CiliumNamespace))
 			res.ExpectSuccess("Cilium DS cannot be deleted")
 
 			ExpectAllPodsTerminated(kubectl)
@@ -213,7 +213,7 @@ var _ = Describe("K8sChaosTest", func() {
 			By("Deleting all cilium pods")
 			res := kubectl.Exec(fmt.Sprintf(
 				"%s -n %s delete pods -l %s",
-				helpers.KubectlCmd, helpers.KubeSystemNamespace, ciliumFilter))
+				helpers.KubectlCmd, helpers.CiliumNamespace, ciliumFilter))
 			res.ExpectSuccess("Failed to delete cilium pods")
 
 			By("Waiting cilium pods to terminate")
@@ -221,7 +221,7 @@ var _ = Describe("K8sChaosTest", func() {
 
 			By("Waiting for cilium pods to be ready")
 			err := kubectl.WaitforPods(
-				helpers.KubeSystemNamespace, fmt.Sprintf("-l %s", ciliumFilter), helpers.HelperTimeout)
+				helpers.CiliumNamespace, fmt.Sprintf("-l %s", ciliumFilter), helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Pods are not ready after timeout")
 
 			err = kubectl.CiliumEndpointWaitReady()

--- a/test/k8sT/Chaos.go
+++ b/test/k8sT/Chaos.go
@@ -27,15 +27,17 @@ import (
 var _ = Describe("K8sChaosTest", func() {
 
 	var (
-		kubectl       *helpers.Kubectl
-		demoDSPath    string
-		testDSService = "testds-service"
+		kubectl        *helpers.Kubectl
+		demoDSPath     string
+		ciliumFilename string
+		testDSService  = "testds-service"
 	)
 
 	BeforeAll(func() {
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 		demoDSPath = helpers.ManifestGet(kubectl.BasePath(), "demo_ds.yaml")
-		DeployCiliumAndDNS(kubectl)
+		ciliumFilename = helpers.TimestampFilename("cilium.yaml")
+		DeployCiliumAndDNS(kubectl, ciliumFilename)
 	})
 
 	AfterFailed(func() {
@@ -154,7 +156,8 @@ var _ = Describe("K8sChaosTest", func() {
 
 			By("Install cilium pods")
 
-			err = kubectl.CiliumInstall(map[string]string{})
+			ciliumFilename := helpers.TimestampFilename("cilium.yaml")
+			err = kubectl.CiliumInstall(ciliumFilename, map[string]string{})
 			Expect(err).To(BeNil(), "Cilium cannot be installed")
 
 			ExpectCiliumReady(kubectl)

--- a/test/k8sT/Chaos.go
+++ b/test/k8sT/Chaos.go
@@ -154,7 +154,7 @@ var _ = Describe("K8sChaosTest", func() {
 
 			By("Install cilium pods")
 
-			err = kubectl.CiliumInstall([]string{})
+			err = kubectl.CiliumInstall(map[string]string{})
 			Expect(err).To(BeNil(), "Cilium cannot be installed")
 
 			ExpectCiliumReady(kubectl)

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -33,11 +33,13 @@ var _ = Describe("K8sDatapathConfig", func() {
 	var demoDSPath string
 	var ipsecDSPath string
 	var monitorLog = "monitor-aggregation.log"
+	var ciliumFilename string
 
 	BeforeAll(func() {
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 		demoDSPath = helpers.ManifestGet(kubectl.BasePath(), "demo_ds.yaml")
 		ipsecDSPath = helpers.ManifestGet(kubectl.BasePath(), "ipsec_ds.yaml")
+		ciliumFilename = helpers.TimestampFilename("cilium.yaml")
 
 		deleteCiliumDS(kubectl)
 	})
@@ -121,7 +123,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 	}
 
 	deployCilium := func(options map[string]string) {
-		DeployCiliumOptionsAndDNS(kubectl, options)
+		DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, options)
 
 		err := kubectl.WaitforPods(helpers.DefaultNamespace, "", helpers.HelperTimeout)
 		ExpectWithOffset(1, err).Should(BeNil(), "Pods are not ready after timeout")

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -59,7 +59,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 	})
 
 	AfterFailed(func() {
-		kubectl.CiliumReport(helpers.KubeSystemNamespace,
+		kubectl.CiliumReport(helpers.CiliumNamespace,
 			"cilium bpf tunnel list",
 			"cilium endpoint list")
 	})
@@ -207,7 +207,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 		validateBPFTunnelMap := func() {
 			By("Checking that BPF tunnels are in place")
-			ciliumPod, err := kubectl.GetCiliumPodOnNodeWithLabel(helpers.KubeSystemNamespace, helpers.K8s1)
+			ciliumPod, err := kubectl.GetCiliumPodOnNodeWithLabel(helpers.CiliumNamespace, helpers.K8s1)
 			ExpectWithOffset(1, err).Should(BeNil(), "Unable to determine cilium pod on node %s", helpers.K8s1)
 			status := kubectl.CiliumExec(ciliumPod, "cilium bpf tunnel list | wc -l")
 			status.ExpectSuccess()
@@ -569,11 +569,11 @@ func monitorConnectivityAcrossNodes(kubectl *helpers.Kubectl, monitorLog string)
 	// and add the labels "cilium.io/ci-node: k8s1" to the node.
 	requireMultiNode := true
 
-	ciliumPodK8s1, err := kubectl.GetCiliumPodOnNodeWithLabel(helpers.KubeSystemNamespace, helpers.K8s1)
+	ciliumPodK8s1, err := kubectl.GetCiliumPodOnNodeWithLabel(helpers.CiliumNamespace, helpers.K8s1)
 	ExpectWithOffset(1, err).Should(BeNil(), "Cannot get cilium pod on k8s1")
 
 	By(fmt.Sprintf("Launching cilium monitor on %q", ciliumPodK8s1))
-	monitorStop := kubectl.MonitorStart(helpers.KubeSystemNamespace, ciliumPodK8s1, monitorLog)
+	monitorStop := kubectl.MonitorStart(helpers.CiliumNamespace, ciliumPodK8s1, monitorLog)
 	result, targetIP := testPodConnectivityAndReturnIP(kubectl, requireMultiNode, 2)
 	monitorStop()
 	ExpectWithOffset(1, result).Should(BeTrue(), "Connectivity test between nodes failed")

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -46,7 +46,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 	BeforeEach(func() {
 		kubectl.ApplyDefault(demoDSPath).ExpectSuccess("cannot install Demo application")
-		kubectl.ApplyDefault(ipsecDSPath).ExpectSuccess("cannot install IPsec keys")
+		kubectl.Apply(helpers.ApplyOptions{FilePath: ipsecDSPath, Namespace: helpers.CiliumNamespace}).ExpectSuccess("cannot install IPsec keys")
 		kubectl.NodeCleanMetadata()
 	})
 

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -65,6 +65,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 	})
 
 	AfterAll(func() {
+		DeployCiliumAndDNS(kubectl, ciliumFilename)
 		kubectl.CloseSSHClient()
 	})
 

--- a/test/k8sT/Health.go
+++ b/test/k8sT/Health.go
@@ -37,7 +37,7 @@ var _ = Describe("K8sHealthTest", func() {
 	})
 
 	AfterFailed(func() {
-		kubectl.CiliumReport(helpers.KubeSystemNamespace,
+		kubectl.CiliumReport(helpers.CiliumNamespace,
 			"cilium endpoint list")
 	})
 
@@ -54,11 +54,11 @@ var _ = Describe("K8sHealthTest", func() {
 	})
 
 	getCilium := func(node string) (pod, ip string) {
-		pod, err := kubectl.GetCiliumPodOnNodeWithLabel(helpers.KubeSystemNamespace, node)
+		pod, err := kubectl.GetCiliumPodOnNodeWithLabel(helpers.CiliumNamespace, node)
 		Expect(err).Should(BeNil())
 
 		res, err := kubectl.Get(
-			helpers.KubeSystemNamespace,
+			helpers.CiliumNamespace,
 			fmt.Sprintf("pod %s", pod)).Filter("{.status.podIP}")
 		Expect(err).Should(BeNil())
 		ip = res.String()

--- a/test/k8sT/Health.go
+++ b/test/k8sT/Health.go
@@ -26,12 +26,14 @@ import (
 var _ = Describe("K8sHealthTest", func() {
 
 	var (
-		kubectl *helpers.Kubectl
+		kubectl        *helpers.Kubectl
+		ciliumFilename string
 	)
 
 	BeforeAll(func() {
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
-		DeployCiliumAndDNS(kubectl)
+		ciliumFilename = helpers.TimestampFilename("cilium.yaml")
+		DeployCiliumAndDNS(kubectl, ciliumFilename)
 	})
 
 	AfterFailed(func() {

--- a/test/k8sT/KafkaPolicies.go
+++ b/test/k8sT/KafkaPolicies.go
@@ -34,8 +34,9 @@ var _ = Describe("K8sKafkaPolicyTest", func() {
 		backgroundError  error
 
 		// these two are set in BeforeAll
-		l7Policy string
-		demoPath string
+		l7Policy       string
+		demoPath       string
+		ciliumFilename string
 
 		kafkaApp            = "kafka"
 		backupApp           = "empire-backup"
@@ -128,7 +129,8 @@ var _ = Describe("K8sKafkaPolicyTest", func() {
 			l7Policy = helpers.ManifestGet(kubectl.BasePath(), "kafka-sw-security-policy.yaml")
 			demoPath = helpers.ManifestGet(kubectl.BasePath(), "kafka-sw-app.yaml")
 
-			DeployCiliumAndDNS(kubectl)
+			ciliumFilename = helpers.TimestampFilename("cilium.yaml")
+			DeployCiliumAndDNS(kubectl, ciliumFilename)
 
 			kubectl.ApplyDefault(demoPath)
 			err := kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=kafkaTestApp", helpers.HelperTimeout)

--- a/test/k8sT/KafkaPolicies.go
+++ b/test/k8sT/KafkaPolicies.go
@@ -57,7 +57,7 @@ var _ = Describe("K8sKafkaPolicyTest", func() {
 	)
 
 	AfterFailed(func() {
-		kubectl.CiliumReport(helpers.KubeSystemNamespace,
+		kubectl.CiliumReport(helpers.CiliumNamespace,
 			"cilium service list",
 			"cilium endpoint list")
 	})

--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -72,7 +72,7 @@ var _ = Describe("NightlyEpsMeasurement", func() {
 	})
 
 	AfterFailed(func() {
-		kubectl.CiliumReport(helpers.KubeSystemNamespace,
+		kubectl.CiliumReport(helpers.CiliumNamespace,
 			"cilium service list",
 			"cilium endpoint list")
 	})
@@ -128,7 +128,7 @@ var _ = Describe("NightlyEpsMeasurement", func() {
 
 		log.WithFields(logrus.Fields{"pod creation time": waitForPodsTime}).Info("")
 
-		ciliumPods, err := kubectl.GetCiliumPods(helpers.KubeSystemNamespace)
+		ciliumPods, err := kubectl.GetCiliumPods(helpers.CiliumNamespace)
 		Expect(err).To(BeNil(), "Cannot retrieve cilium pods")
 
 		runtime := b.Time("Endpoint creation", func() {
@@ -335,7 +335,7 @@ var _ = Describe("NightlyExamples", func() {
 	})
 
 	AfterFailed(func() {
-		kubectl.CiliumReport(helpers.KubeSystemNamespace,
+		kubectl.CiliumReport(helpers.CiliumNamespace,
 			"cilium service list",
 			"cilium endpoint list")
 	})
@@ -365,7 +365,7 @@ var _ = Describe("NightlyExamples", func() {
 			_ = kubectl.Delete(helpers.DNSDeployment(kubectl.BasePath()))
 
 			_ = kubectl.DeleteResource(
-				"deploy", fmt.Sprintf("-n %s cilium-operator", helpers.KubeSystemNamespace))
+				"deploy", fmt.Sprintf("-n %s cilium-operator", helpers.CiliumNamespace))
 
 			// Delete etcd operator because sometimes when install from
 			// clean-state the quorum is lost.

--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -39,6 +39,7 @@ var (
 var _ = Describe("NightlyEpsMeasurement", func() {
 
 	var kubectl *helpers.Kubectl
+	var ciliumFilename string
 
 	endpointCount := 45
 	endpointsTimeout := endpointTimeout * time.Duration(endpointCount)
@@ -49,7 +50,8 @@ var _ = Describe("NightlyEpsMeasurement", func() {
 	BeforeAll(func() {
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 		vagrantManifestPath = path.Join(kubectl.BasePath(), manifestPath)
-		DeployCiliumAndDNS(kubectl)
+		ciliumFilename = helpers.TimestampFilename("cilium.yaml")
+		DeployCiliumAndDNS(kubectl, ciliumFilename)
 	})
 	deleteAll := func() {
 		ctx, cancel := context.WithTimeout(context.Background(), endpointsTimeout)
@@ -321,6 +323,7 @@ var _ = Describe("NightlyExamples", func() {
 	var kubectl *helpers.Kubectl
 	var demoPath string
 	var l3Policy, l7Policy string
+	var ciliumFilename string
 
 	BeforeAll(func() {
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
@@ -328,6 +331,7 @@ var _ = Describe("NightlyExamples", func() {
 		demoPath = helpers.ManifestGet(kubectl.BasePath(), "demo.yaml")
 		l3Policy = helpers.ManifestGet(kubectl.BasePath(), "l3-l4-policy.yaml")
 		l7Policy = helpers.ManifestGet(kubectl.BasePath(), "l7-policy.yaml")
+		ciliumFilename = helpers.TimestampFilename("cilium.yaml")
 	})
 
 	AfterFailed(func() {
@@ -384,7 +388,7 @@ var _ = Describe("NightlyExamples", func() {
 				It(fmt.Sprintf("Update Cilium from %s to master", version), func() {
 					var assertUpgradeSuccessful func()
 					assertUpgradeSuccessful, cleanupCallback = InstallAndValidateCiliumUpgrades(
-						kubectl, image, helpers.CiliumDevImage())
+						kubectl, ciliumFilename, image, helpers.CiliumDevImage())
 					assertUpgradeSuccessful()
 				})
 			}(image)
@@ -405,7 +409,8 @@ var _ = Describe("NightlyExamples", func() {
 			AppManifest = kubectl.GetFilePath(GRPCManifest)
 			PolicyManifest = kubectl.GetFilePath(GRPCPolicy)
 
-			DeployCiliumAndDNS(kubectl)
+			ciliumFilename = helpers.TimestampFilename("cilium.yaml")
+			DeployCiliumAndDNS(kubectl, ciliumFilename)
 		})
 
 		AfterAll(func() {

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -90,9 +90,9 @@ var _ = Describe("K8sPolicyTest", func() {
 		cnpMatchExpression = helpers.ManifestGet(kubectl.BasePath(), "cnp-matchexpressions.yaml")
 
 		deleteCiliumDS(kubectl)
-		DeployCiliumOptionsAndDNS(kubectl, []string{
-			"--set global.tls.secretsBackend=k8s",
-			"--set global.debug.verbose=flow",
+		DeployCiliumOptionsAndDNS(kubectl, map[string]string{
+			"global.tls.secretsBackend": "k8s",
+			"global.debug.verbose":      "flow",
 		})
 	})
 

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -38,6 +38,7 @@ var _ = Describe("K8sPolicyTest", func() {
 
 	var (
 		kubectl *helpers.Kubectl
+
 		// these are set in BeforeAll()
 		ciliumFilename       string
 		demoPath             string
@@ -103,7 +104,7 @@ var _ = Describe("K8sPolicyTest", func() {
 	})
 
 	AfterFailed(func() {
-		kubectl.CiliumReport(helpers.KubeSystemNamespace,
+		kubectl.CiliumReport(helpers.CiliumNamespace,
 			"cilium service list",
 			"cilium endpoint list")
 	})
@@ -193,7 +194,7 @@ var _ = Describe("K8sPolicyTest", func() {
 			err := kubectl.WaitforPods(namespaceForTest, "-l zgroup=testapp", helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Test pods are not ready after timeout")
 
-			ciliumPod, err = kubectl.GetCiliumPodOnNodeWithLabel(helpers.KubeSystemNamespace, helpers.K8s1)
+			ciliumPod, err = kubectl.GetCiliumPodOnNodeWithLabel(helpers.CiliumNamespace, helpers.K8s1)
 			Expect(err).Should(BeNil(), "cannot get CiliumPod")
 
 			clusterIP, _, err = kubectl.GetServiceHostPort(namespaceForTest, app1Service)
@@ -827,7 +828,7 @@ var _ = Describe("K8sPolicyTest", func() {
 
 				Expect(kubectl.WaitforPods("foo", "-l zgroup=testapp", helpers.HelperTimeout)).To(BeNil())
 				var podList v1.PodList
-				err = kubectl.GetPods(namespaceForTest, fmt.Sprintf("-n %s -l k8s-app=cilium --field-selector spec.nodeName=%s", helpers.KubeSystemNamespace, nodeName)).Unmarshal(&podList)
+				err = kubectl.GetPods(namespaceForTest, fmt.Sprintf("-n %s -l k8s-app=cilium --field-selector spec.nodeName=%s", helpers.CiliumNamespace, nodeName)).Unmarshal(&podList)
 				Expect(err).To(BeNil())
 
 				var app1PodModel v1.Pod
@@ -838,7 +839,7 @@ var _ = Describe("K8sPolicyTest", func() {
 				app1PodIP = app1PodModel.Status.PodIP
 				//var app1Ep *models.Endpoint
 				var endpoints []*models.Endpoint
-				err = kubectl.ExecPodCmd(helpers.KubeSystemNamespace, ciliumPod, "cilium endpoint list -o json").Unmarshal(&endpoints)
+				err = kubectl.ExecPodCmd(helpers.CiliumNamespace, ciliumPod, "cilium endpoint list -o json").Unmarshal(&endpoints)
 				Expect(err).To(BeNil())
 				for _, ep := range endpoints {
 					if ep.Status.Networking.Addressing[0].IPV4 == app1PodIP {
@@ -895,7 +896,7 @@ var _ = Describe("K8sPolicyTest", func() {
 				monitorFile := fmt.Sprintf(monitorFileName, uuid.NewUUID().String())
 
 				By("Starting monitor and generating traffic which should%s redirect to proxy", not)
-				monitorStop := kubectl.MonitorStart(helpers.KubeSystemNamespace, ciliumPod, monitorFile)
+				monitorStop := kubectl.MonitorStart(helpers.CiliumNamespace, ciliumPod, monitorFile)
 
 				// Let the monitor get started since it is started in the background.
 				time.Sleep(2 * time.Second)
@@ -994,7 +995,7 @@ var _ = Describe("K8sPolicyTest", func() {
 
 		BeforeEach(func() {
 			kubectl.ApplyDefault(helpers.ManifestGet(kubectl.BasePath(), deployment))
-			ciliumPods, err := kubectl.GetCiliumPods(helpers.KubeSystemNamespace)
+			ciliumPods, err := kubectl.GetCiliumPods(helpers.CiliumNamespace)
 			Expect(err).To(BeNil(), "cannot retrieve Cilium Pods")
 			Expect(ciliumPods).ShouldNot(BeEmpty(), "cannot retrieve Cilium pods")
 		})

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -39,6 +39,7 @@ var _ = Describe("K8sPolicyTest", func() {
 	var (
 		kubectl *helpers.Kubectl
 		// these are set in BeforeAll()
+		ciliumFilename       string
 		demoPath             string
 		l3Policy             string
 		l7Policy             string
@@ -68,6 +69,7 @@ var _ = Describe("K8sPolicyTest", func() {
 	BeforeAll(func() {
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 
+		ciliumFilename = helpers.TimestampFilename("cilium.yaml")
 		demoPath = helpers.ManifestGet(kubectl.BasePath(), "demo.yaml")
 		l3Policy = helpers.ManifestGet(kubectl.BasePath(), "l3-l4-policy.yaml")
 		l7Policy = helpers.ManifestGet(kubectl.BasePath(), "l7-policy.yaml")
@@ -90,7 +92,7 @@ var _ = Describe("K8sPolicyTest", func() {
 		cnpMatchExpression = helpers.ManifestGet(kubectl.BasePath(), "cnp-matchexpressions.yaml")
 
 		deleteCiliumDS(kubectl)
-		DeployCiliumOptionsAndDNS(kubectl, map[string]string{
+		DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
 			"global.tls.secretsBackend": "k8s",
 			"global.debug.verbose":      "flow",
 		})

--- a/test/k8sT/PoliciesNightly.go
+++ b/test/k8sT/PoliciesNightly.go
@@ -38,7 +38,7 @@ var _ = Describe("NightlyPolicies", func() {
 	})
 
 	AfterFailed(func() {
-		kubectl.CiliumReport(helpers.KubeSystemNamespace,
+		kubectl.CiliumReport(helpers.CiliumNamespace,
 			"cilium endpoint list",
 			"cilium service list")
 	})

--- a/test/k8sT/PoliciesNightly.go
+++ b/test/k8sT/PoliciesNightly.go
@@ -29,10 +29,12 @@ var _ = Describe("NightlyPolicies", func() {
 
 	var kubectl *helpers.Kubectl
 	var timeout = 10 * time.Minute
+	var ciliumFilename string
 
 	BeforeAll(func() {
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
-		DeployCiliumAndDNS(kubectl)
+		ciliumFilename = helpers.TimestampFilename("cilium.yaml")
+		DeployCiliumAndDNS(kubectl, ciliumFilename)
 	})
 
 	AfterFailed(func() {

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -71,12 +71,12 @@ var _ = Describe("K8sServicesTest", func() {
 		ciliumFilename = helpers.TimestampFilename("cilium.yaml")
 		DeployCiliumAndDNS(kubectl, ciliumFilename)
 
-		ciliumPodK8s1, err = kubectl.GetCiliumPodOnNodeWithLabel(helpers.KubeSystemNamespace, helpers.K8s1)
+		ciliumPodK8s1, err = kubectl.GetCiliumPodOnNodeWithLabel(helpers.CiliumNamespace, helpers.K8s1)
 		Expect(err).Should(BeNil(), "Cannot get cilium pod on k8s1")
 	})
 
 	AfterFailed(func() {
-		kubectl.CiliumReport(helpers.KubeSystemNamespace,
+		kubectl.CiliumReport(helpers.CiliumNamespace,
 			"cilium service list",
 			"cilium endpoint list")
 	})
@@ -163,7 +163,7 @@ var _ = Describe("K8sServicesTest", func() {
 			Expect(govalidator.IsIP(clusterIP)).Should(BeTrue(), "ClusterIP is not an IP")
 
 			By("testing connectivity via cluster IP %s", clusterIP)
-			monitorStop := kubectl.MonitorStart(helpers.KubeSystemNamespace, ciliumPodK8s1,
+			monitorStop := kubectl.MonitorStart(helpers.CiliumNamespace, ciliumPodK8s1,
 				"cluster-ip-same-node.log")
 			k8s1Name, _ := getNodeInfo(helpers.K8s1)
 			status, err := kubectl.ExecInHostNetNS(context.TODO(), k8s1Name,
@@ -172,7 +172,7 @@ var _ = Describe("K8sServicesTest", func() {
 			Expect(err).To(BeNil(), "Cannot run curl in host netns")
 
 			status.ExpectSuccess("cannot curl to service IP from host")
-			ciliumPods, err := kubectl.GetCiliumPods(helpers.KubeSystemNamespace)
+			ciliumPods, err := kubectl.GetCiliumPods(helpers.CiliumNamespace)
 			Expect(err).To(BeNil(), "Cannot get cilium pods")
 			for _, pod := range ciliumPods {
 				service := kubectl.CiliumExec(pod, "cilium service list")
@@ -418,7 +418,7 @@ var _ = Describe("K8sServicesTest", func() {
 				AfterAll(func() {
 					enableBackgroundReport = true
 					// Remove NodePort programs (GH#8873)
-					pods, err := kubectl.GetCiliumPods(helpers.KubeSystemNamespace)
+					pods, err := kubectl.GetCiliumPods(helpers.CiliumNamespace)
 					Expect(err).To(BeNil(), "Cannot retrieve Cilium pods")
 					for _, pod := range pods {
 						ret := kubectl.CiliumExec(pod, "tc filter del dev "+nativeDev+" ingress")
@@ -513,7 +513,7 @@ var _ = Describe("K8sServicesTest", func() {
 
 					// Test whether DSR NAT entries are evicted by GC
 
-					pod, err := kubectl.GetCiliumPodOnNode(helpers.KubeSystemNamespace, helpers.K8s2)
+					pod, err := kubectl.GetCiliumPodOnNode(helpers.CiliumNamespace, helpers.K8s2)
 					Expect(err).Should(BeNil(), fmt.Sprintf("Cannot determine cilium pod name"))
 					// "test-nodeport-k8s2" because we want to trigger SNAT with a single request:
 					// client -> k8s1 -> endpoint @ k8s2.
@@ -909,9 +909,9 @@ var _ = Describe("K8sServicesTest", func() {
 
 			By("Checking that policies were correctly imported into Cilium")
 
-			ciliumPodK8s1, err = kubectl.GetCiliumPodOnNodeWithLabel(helpers.KubeSystemNamespace, helpers.K8s1)
+			ciliumPodK8s1, err = kubectl.GetCiliumPodOnNodeWithLabel(helpers.CiliumNamespace, helpers.K8s1)
 			Expect(err).Should(BeNil(), "Cannot get cilium pod on k8s1")
-			res := kubectl.ExecPodCmd(helpers.KubeSystemNamespace, ciliumPodK8s1, policyCmd)
+			res := kubectl.ExecPodCmd(helpers.CiliumNamespace, ciliumPodK8s1, policyCmd)
 			res.ExpectSuccess("Policy %s is not imported", policyCmd)
 
 			By("Validating DNS with Policy loaded")

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -430,9 +430,9 @@ var _ = Describe("K8sServicesTest", func() {
 				Context("Tests with vxlan", func() {
 					BeforeAll(func() {
 						deleteCiliumDS(kubectl)
-						DeployCiliumOptionsAndDNS(kubectl, []string{
-							"--set global.nodePort.enabled=true",
-							"--set global.nodePort.device=" + nativeDev,
+						DeployCiliumOptionsAndDNS(kubectl, map[string]string{
+							"global.nodePort.enabled": "true",
+							"global.nodePort.device":  nativeDev,
 						})
 					})
 
@@ -448,11 +448,11 @@ var _ = Describe("K8sServicesTest", func() {
 				Context("Tests with direct routing", func() {
 					BeforeAll(func() {
 						deleteCiliumDS(kubectl)
-						DeployCiliumOptionsAndDNS(kubectl, []string{
-							"--set global.nodePort.enabled=true",
-							"--set global.nodePort.device=" + nativeDev,
-							"--set global.tunnel=disabled",
-							"--set global.autoDirectNodeRoutes=true",
+						DeployCiliumOptionsAndDNS(kubectl, map[string]string{
+							"global.nodePort.enabled":     "true",
+							"global.nodePort.device":      nativeDev,
+							"global.tunnel":               "disabled",
+							"global.autoDirectNodeRoutes": "true",
 						})
 					})
 
@@ -492,12 +492,12 @@ var _ = Describe("K8sServicesTest", func() {
 
 				It("Tests with direct routing and DSR", func() {
 					deleteCiliumDS(kubectl)
-					DeployCiliumOptionsAndDNS(kubectl, []string{
-						"--set global.nodePort.enabled=true",
-						"--set global.nodePort.device=" + nativeDev,
-						"--set global.nodePort.mode=dsr",
-						"--set global.tunnel=disabled",
-						"--set global.autoDirectNodeRoutes=true",
+					DeployCiliumOptionsAndDNS(kubectl, map[string]string{
+						"global.nodePort.enabled":     "true",
+						"global.nodePort.device":      nativeDev,
+						"global.nodePort.mode":        "dsr",
+						"global.tunnel":               "disabled",
+						"global.autoDirectNodeRoutes": "true",
 					})
 
 					var data v1.Service

--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -112,11 +112,11 @@ func ExpectCiliumPreFlightInstallReady(vm *helpers.Kubectl) {
 
 // DeployCiliumAndDNS deploys DNS and cilium into the kubernetes cluster
 func DeployCiliumAndDNS(vm *helpers.Kubectl) {
-	DeployCiliumOptionsAndDNS(vm, []string{})
+	DeployCiliumOptionsAndDNS(vm, map[string]string{})
 }
 
 // DeployCiliumOptionsAndDNS deploys DNS and cilium with options into the kubernetes cluster
-func DeployCiliumOptionsAndDNS(vm *helpers.Kubectl, options []string) {
+func DeployCiliumOptionsAndDNS(vm *helpers.Kubectl, options map[string]string) {
 	By("Installing Cilium")
 	err := vm.CiliumInstall(options)
 	Expect(err).To(BeNil(), "Cilium cannot be installed")

--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -111,14 +111,14 @@ func ExpectCiliumPreFlightInstallReady(vm *helpers.Kubectl) {
 }
 
 // DeployCiliumAndDNS deploys DNS and cilium into the kubernetes cluster
-func DeployCiliumAndDNS(vm *helpers.Kubectl) {
-	DeployCiliumOptionsAndDNS(vm, map[string]string{})
+func DeployCiliumAndDNS(vm *helpers.Kubectl, ciliumFilename string) {
+	DeployCiliumOptionsAndDNS(vm, ciliumFilename, map[string]string{})
 }
 
 // DeployCiliumOptionsAndDNS deploys DNS and cilium with options into the kubernetes cluster
-func DeployCiliumOptionsAndDNS(vm *helpers.Kubectl, options map[string]string) {
+func DeployCiliumOptionsAndDNS(vm *helpers.Kubectl, ciliumFilename string, options map[string]string) {
 	By("Installing Cilium")
-	err := vm.CiliumInstall(options)
+	err := vm.CiliumInstall(ciliumFilename, options)
 	Expect(err).To(BeNil(), "Cilium cannot be installed")
 
 	ExpectCiliumRunning(vm)

--- a/test/k8sT/demos.go
+++ b/test/k8sT/demos.go
@@ -38,7 +38,8 @@ func getStarWarsResourceLink(file string) string {
 var _ = Describe("K8sDemosTest", func() {
 
 	var (
-		kubectl *helpers.Kubectl
+		kubectl        *helpers.Kubectl
+		ciliumFilename string
 
 		backgroundCancel context.CancelFunc = func() { return }
 		backgroundError  error
@@ -50,7 +51,8 @@ var _ = Describe("K8sDemosTest", func() {
 
 	BeforeAll(func() {
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
-		DeployCiliumAndDNS(kubectl)
+		ciliumFilename = helpers.TimestampFilename("cilium.yaml")
+		DeployCiliumAndDNS(kubectl, ciliumFilename)
 	})
 
 	AfterFailed(func() {

--- a/test/k8sT/demos.go
+++ b/test/k8sT/demos.go
@@ -56,7 +56,7 @@ var _ = Describe("K8sDemosTest", func() {
 	})
 
 	AfterFailed(func() {
-		kubectl.CiliumReport(helpers.KubeSystemNamespace,
+		kubectl.CiliumReport(helpers.CiliumNamespace,
 			"cilium endpoint list",
 			"cilium service list")
 	})

--- a/test/k8sT/external_ips.go
+++ b/test/k8sT/external_ips.go
@@ -37,6 +37,7 @@ const (
 var _ = Describe("K8sKubeProxyFreeMatrix tests", func() {
 	var (
 		kubectl             *helpers.Kubectl
+		ciliumFilename      string
 		podNode1            string
 		podNode2            string
 		hostNetworkPodNode1 string
@@ -57,7 +58,7 @@ var _ = Describe("K8sKubeProxyFreeMatrix tests", func() {
 
 	// deploys cilium with the given options.
 	deployCilium := func(options map[string]string) {
-		DeployCiliumOptionsAndDNS(kubectl, options)
+		DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, options)
 
 		_, err := kubectl.CiliumNodesWait()
 		ExpectWithOffset(1, err).Should(BeNil(), "Failure while waiting for k8s nodes to be annotated by Cilium")
@@ -95,9 +96,9 @@ var _ = Describe("K8sKubeProxyFreeMatrix tests", func() {
 		if !helpers.RunsOnNetNext() {
 			return
 		}
-
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
-		DeployCiliumAndDNS(kubectl)
+		ciliumFilename = helpers.TimestampFilename("cilium.yaml")
+		DeployCiliumAndDNS(kubectl, ciliumFilename)
 
 		// create namespace used for this test
 		res := kubectl.NamespaceCreate(namespaceTest)

--- a/test/k8sT/external_ips.go
+++ b/test/k8sT/external_ips.go
@@ -56,7 +56,7 @@ var _ = Describe("K8sKubeProxyFreeMatrix tests", func() {
 	)
 
 	// deploys cilium with the given options.
-	deployCilium := func(options []string) {
+	deployCilium := func(options map[string]string) {
 		DeployCiliumOptionsAndDNS(kubectl, options)
 
 		_, err := kubectl.CiliumNodesWait()
@@ -236,11 +236,11 @@ var _ = Describe("K8sKubeProxyFreeMatrix tests", func() {
 		"DirectRouting", func() {
 			BeforeAll(func() {
 				deleteCiliumDS(kubectl)
-				deployCilium([]string{
-					"--set global.tunnel=disabled",
-					"--set global.autoDirectNodeRoutes=true",
-					"--set global.nodePort.device=" + external_ips.PublicInterfaceName,
-					"--set global.nodePort.enabled=true",
+				deployCilium(map[string]string{
+					"global.tunnel":               "disabled",
+					"global.autoDirectNodeRoutes": "true",
+					"global.nodePort.device":      external_ips.PublicInterfaceName,
+					"global.nodePort.enabled":     "true",
 				})
 			})
 			DescribeTable("From pod running on node-1 to services being backed by a pod running on node-1",
@@ -282,10 +282,10 @@ var _ = Describe("K8sKubeProxyFreeMatrix tests", func() {
 		"VxLANMode", func() {
 			BeforeAll(func() {
 				deleteCiliumDS(kubectl)
-				deployCilium([]string{
-					"--set global.tunnel=vxlan",
-					"--set global.nodePort.device=" + external_ips.PublicInterfaceName,
-					"--set global.nodePort.enabled=true",
+				deployCilium(map[string]string{
+					"global.tunnel":           "vxlan",
+					"global.nodePort.device":  external_ips.PublicInterfaceName,
+					"global.nodePort.enabled": "true",
 				})
 			})
 			DescribeTable("From pod running on node-1 to services being backed by a pod running on node-1",

--- a/test/k8sT/external_ips.go
+++ b/test/k8sT/external_ips.go
@@ -175,7 +175,7 @@ var _ = Describe("K8sKubeProxyFreeMatrix tests", func() {
 		if !helpers.RunsOnNetNext() {
 			return
 		}
-		kubectl.CiliumReport(helpers.KubeSystemNamespace,
+		kubectl.CiliumReport(helpers.CiliumNamespace,
 			"cilium service list",
 			"cilium endpoint list")
 	})

--- a/test/k8sT/fqdn.go
+++ b/test/k8sT/fqdn.go
@@ -71,7 +71,7 @@ var _ = Describe("K8sFQDNTest", func() {
 	})
 
 	AfterFailed(func() {
-		kubectl.CiliumReport(helpers.KubeSystemNamespace,
+		kubectl.CiliumReport(helpers.CiliumNamespace,
 			"cilium service list",
 			"cilium endpoint list")
 	})
@@ -153,7 +153,7 @@ var _ = Describe("K8sFQDNTest", func() {
 		By("Deleting cilium pods")
 
 		res := kubectl.Exec(fmt.Sprintf("%s -n %s delete pods -l k8s-app=cilium",
-			helpers.KubectlCmd, helpers.KubeSystemNamespace))
+			helpers.KubectlCmd, helpers.CiliumNamespace))
 		res.ExpectSuccess()
 
 		By("Testing connectivity when cilium is restoring using IPS without DNS")

--- a/test/k8sT/fqdn.go
+++ b/test/k8sT/fqdn.go
@@ -30,8 +30,9 @@ var _ = Describe("K8sFQDNTest", func() {
 		backgroundCancel context.CancelFunc = func() { return }
 		backgroundError  error
 
-		bindManifest = ""
-		demoManifest = ""
+		bindManifest   = ""
+		demoManifest   = ""
+		ciliumFilename string
 
 		apps    = []string{helpers.App2, helpers.App3}
 		appPods map[string]string
@@ -46,7 +47,8 @@ var _ = Describe("K8sFQDNTest", func() {
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 		bindManifest = helpers.ManifestGet(kubectl.BasePath(), "bind_deployment.yaml")
 		demoManifest = helpers.ManifestGet(kubectl.BasePath(), "demo.yaml")
-		DeployCiliumAndDNS(kubectl)
+		ciliumFilename = helpers.TimestampFilename("cilium.yaml")
+		DeployCiliumAndDNS(kubectl, ciliumFilename)
 
 		By("Applying bind deployment")
 		bindManifest = helpers.ManifestGet(kubectl.BasePath(), "bind_deployment.yaml")

--- a/test/k8sT/istio.go
+++ b/test/k8sT/istio.go
@@ -141,7 +141,7 @@ var _ = Describe("K8sIstioTest", func() {
 	})
 
 	AfterFailed(func() {
-		kubectl.CiliumReport(helpers.KubeSystemNamespace,
+		kubectl.CiliumReport(helpers.CiliumNamespace,
 			"cilium endpoint list",
 			"cilium bpf proxy list")
 	})

--- a/test/k8sT/istio.go
+++ b/test/k8sT/istio.go
@@ -74,6 +74,8 @@ var _ = Describe("K8sIstioTest", func() {
 		uptimeCancel context.CancelFunc
 
 		teardownTimeout = 10 * time.Minute
+
+		ciliumFilename string
 	)
 
 	BeforeAll(func() {
@@ -87,7 +89,9 @@ var _ = Describe("K8sIstioTest", func() {
 
 		istioCRDYAMLPath = helpers.ManifestGet(kubectl.BasePath(), "istio-crds.yaml")
 		istioYAMLPath = helpers.ManifestGet(kubectl.BasePath(), "istio-cilium.yaml")
-		DeployCiliumAndDNS(kubectl)
+
+		ciliumFilename = helpers.TimestampFilename("cilium.yaml")
+		DeployCiliumAndDNS(kubectl, ciliumFilename)
 
 		By("Creating the istio-system namespace")
 		res := kubectl.NamespaceCreate(istioSystemNamespace)

--- a/test/k8sT/manifests/bind/.helmignore
+++ b/test/k8sT/manifests/bind/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/test/k8sT/manifests/bind/Chart.yaml
+++ b/test/k8sT/manifests/bind/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: bind
+version: 0.1.0

--- a/test/k8sT/manifests/bind/templates/deployment.yaml
+++ b/test/k8sT/manifests/bind/templates/deployment.yaml
@@ -19,8 +19,8 @@ data:
     @               IN NS server
 
     server.cilium.test. IN A 127.0.0.1
-    world1.cilium.test. IN A 192.168.9.10
-    world2.cilium.test. IN A 192.168.9.11
+    world1.cilium.test. IN A {{ .Values.world1 }}
+    world2.cilium.test. IN A {{ .Values.world2 }}
 
   named.conf: |
     options {
@@ -108,7 +108,7 @@ metadata:
 spec:
   selector:
     zgroup: bind
-  clusterIP: 10.96.0.100
+  {{ if .Values.clusterIP }}clusterIP: {{ .Values.clusterIP }}{{ end }}
   ports:
   - name: dns
     port: 53

--- a/test/k8sT/manifests/bind/values.yaml
+++ b/test/k8sT/manifests/bind/values.yaml
@@ -1,0 +1,7 @@
+# Default values for bind.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+world1: 192.168.9.10
+world2: 192.168.9.11
+clusterIP: 10.96.0.100

--- a/test/k8sT/manifests/ipsec_ds.yaml
+++ b/test/k8sT/manifests/ipsec_ds.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: cilium-ipsec-keys
-  namespace: kube-system
 type: Opaque
 stringData:
   keys: "6 rfc4106(gcm(aes)) 44434241343332312423222114131211f4f3f2f1 128"

--- a/test/k8sT/manifests/log-gatherer.yaml
+++ b/test/k8sT/manifests/log-gatherer.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: log-gatherer
-  namespace: kube-system
   labels:
     k8s-app: cilium-test-logs
 spec:
@@ -41,7 +40,6 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       hostPID: true
-      priorityClassName: system-node-critical
       restartPolicy: Always
       serviceAccount: cilium
       serviceAccountName: cilium

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -279,6 +279,12 @@ var _ = BeforeAll(func() {
 
 		kubectl.ApplyDefault(kubectl.GetFilePath("../examples/kubernetes/addons/prometheus/prometheus.yaml"))
 
+		err := kubectl.InitFQDNManifests()
+		if err != nil {
+			ginkgoext.Fail(fmt.Sprintf(
+				"Failed to init fqdn manifests: %s", err.Error()), 1)
+		}
+
 		go kubectl.PprofReport()
 	}
 	return


### PR DESCRIPTION
_includes commits from https://github.com/cilium/cilium/pull/9703_

This PR is a collection of changes to the CI setup and tests that make it run on GKE. They are mostly removing hard-coded IPs and namespaces. The original #9703 changes included templating for the bind server used by FQDN tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9853)
<!-- Reviewable:end -->
