### PR TITLE
eni: Fix releases of excess IPs

### DIFF
--- a/pkg/aws/eni/node_test.go
+++ b/pkg/aws/eni/node_test.go
@@ -50,7 +50,9 @@ var neededDef = []testNeededDef{
 var excessDef = []testExcessDef{
 	{0, 0, 0, 16, 0, 0},
 	{15, 0, 8, 16, 8, 0},
-	{17, 0, 8, 16, 8, 1},
+	{17, 0, 8, 16, 0, 9}, // 17 used, 8 pre-allocate, 16 min-allocate => 1 excess
+	{20, 0, 8, 16, 4, 0}, // 20 used, 8 pre-allocate, 16 min-allocate, 4 max-above-watermark => 0 excess
+	{21, 0, 8, 0, 4, 9},  // 21 used, 8 pre-allocate, 4 max-above-watermark => 9 excess
 	{20, 0, 8, 20, 8, 0},
 	{16, 1, 8, 16, 8, 0},
 	{20, 4, 8, 17, 8, 0},


### PR DESCRIPTION
The release of excess IPs has been incorrect due to not taking into account the
max-above-watermark limit in combination with min-allocate. This bug was hidden
in the unit test as min-allocate was set to a value equal to the max IP limit
of the interface which rendered the value of max-above-watermark (4) to never
be taken into account as min-allocate had already maxed out the interface limit.

Fix the calculation of excess IPs to never fall below min-allocate +
max-above-watermark and change the unit tests to cover this scenario.

This fixes a bug where IPs would always be immediately released again if
min-allocate was greater than pre-allocate and the number of used IPs did not
make up for that gap.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9858)
<!-- Reviewable:end -->
