### PR TITLE
datapath: Return error if default route is not found

### DIFF
--- a/pkg/datapath/linux/route/route.go
+++ b/pkg/datapath/linux/route/route.go
@@ -93,6 +93,10 @@ func lookupDefaultRoute(family int) (netlink.Route, error) {
 		return netlink.Route{}, fmt.Errorf("Unable to list direct routes: %s", err)
 	}
 
+	if len(routes) == 0 {
+		return netlink.Route{}, fmt.Errorf("Default route not found for family %d", family)
+	}
+
 	for _, route := range routes {
 		if linkIndex != 0 && linkIndex != route.LinkIndex {
 			return netlink.Route{}, fmt.Errorf("Found default routes with different netdev ifindices: %v vs %v",


### PR DESCRIPTION
Previously, cilium-agent was panicking if no default route was found:

```
panic: runtime error: index out of range [0] with length 0

    goroutine 1 [running]:
    github.com/cilium/cilium/pkg/datapath/linux/route.lookupDefaultRoute(0xa,
    0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
            /go/src/github.com/cilium/cilium/pkg/datapath/linux/route/route.go:104
            +0x445
```

To fix this, return an error instead.

Fixes: 63297f3085 ("cilium, daemon: fix device detection for default route")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9859)
<!-- Reviewable:end -->
