### PR TITLE
vagrant: remove unnecessary print statements

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -270,7 +270,6 @@ Vagrant.configure(2) do |config|
                     user_mount_from = "~/" + user_mount_from
                 end
             end
-            puts "Mounting host directory #{user_mount_from} as #{user_mount_to}"
             if ENV["NFS"] then
                 config.vm.synced_folder "#{user_mount_from}", "#{user_mount_to}", type: "nfs", nfs_udp: false
             else


### PR DESCRIPTION
The Vagrant file currently prints a message for every user configured mountpoints whenever the caller sets the `USER_MOUNTS` environment variable.  When using any vagrant command, such as `vagrant status`, this message gets printed to stdout which feels a little redundant.
More importantly, this breaks the `vagrant.kubeconfig` file that is generated by `contrib/vagrant/start.sh` as these log messages are printed out to the file as well. This commit thus deletes the line that is responsible for printing out these statements.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9860)
<!-- Reviewable:end -->
