### PR TITLE
bpf: Compile bpf_netdev.c with build permutations

### DIFF
--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -4,8 +4,8 @@ include ../Makefile.defs
 
 SUBDIRS = sockops
 
-BPF_SIMPLE = bpf_netdev.o bpf_xdp.o bpf_ipsec.o bpf_network.o bpf_alignchecker.o bpf_hostdev_ingress.o
-BPF = bpf_lxc.o bpf_overlay.o bpf_sock.o $(BPF_SIMPLE)
+BPF_SIMPLE = bpf_xdp.o bpf_ipsec.o bpf_network.o bpf_alignchecker.o bpf_hostdev_ingress.o
+BPF = bpf_lxc.o bpf_overlay.o bpf_sock.o bpf_netdev.o $(BPF_SIMPLE)
 
 TARGET=cilium-map-migrate
 
@@ -90,6 +90,26 @@ bpf_overlay.ll: bpf_overlay.c $(LIB)
 	$(QUIET) ${CLANG} ${MAX_OVERLAY_OPTIONS} ${CLANG_FLAGS} -c $< -o $@
 
 bpf_overlay.o: bpf_overlay.ll
+	@$(ECHO_CC)
+	$(QUIET) ${LLC} ${LLC_FLAGS} -filetype=obj -o $@ $(patsubst %.o,%.ll,$@)
+
+NETDEV_OPTIONS = $(LB_OPTIONS) \
+	-DENABLE_IPV4:-DENABLE_IPV6:-DLB_L3:-DLB_L4:-DENABLE_HOST_SERVICES_UDP:-DENABLE_HOST_SERVICES_TCP:-DENABLE_NODEPORT:-DENABLE_EXTERNAL_IP:-DENABLE_MASQUERADE
+
+MAX_NETDEV_OPTIONS = $(MAX_LB_OPTIONS) -DENABLE_MASQUERADE
+
+bpf_netdev.ll: bpf_netdev.c $(LIB)
+	$(QUIET) set -e; \
+	if [ $(BUILD_PERMUTATIONS) != "" ]; then \
+		$(foreach OPTS,$(NETDEV_OPTIONS), \
+			$(ECHO_CC) " [$(subst :,$(space),$(OPTS))]"; \
+			${CLANG} $(subst :,$(space),$(OPTS)) ${CLANG_FLAGS} -c $< -o $@; \
+			${LLC} ${LLC_FLAGS} -o /dev/null $@; ) \
+	fi
+	@$(ECHO_CC)
+	$(QUIET) ${CLANG} ${MAX_NETDEV_OPTIONS} ${CLANG_FLAGS} -c $< -o $@
+
+bpf_netdev.o: bpf_netdev.ll
 	@$(ECHO_CC)
 	$(QUIET) ${LLC} ${LLC_FLAGS} -filetype=obj -o $@ $(patsubst %.o,%.ll,$@)
 


### PR DESCRIPTION
Add a make target for `bpf_netdev.c` to compile it against permutations of the most common options.

Helps to catch `bpf_netdev.c` compile errors faster than waiting until `cilium-agent -> bpf/init.sh` returns them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9861)
<!-- Reviewable:end -->
