### PR TITLE
service: Bind local frontend ports in BPF NodePort

### DIFF
--- a/pkg/service/socket.go
+++ b/pkg/service/socket.go
@@ -1,0 +1,51 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"net"
+	"syscall"
+)
+
+// socket is used to mock socket-related system calls
+type socket interface {
+	// Socket refers to syscall.Socket
+	Socket(domain, typ, proto int) (fd int, err error)
+	// Bind refers to syscall.Bind
+	Bind(fd int, sa syscall.Sockaddr) (err error)
+	// Close refers to syscall.Close
+	Close(fd int) (err error)
+	// InterfaceAddrs refers to net.InterfaceAddrs
+	InterfaceAddrs() (addrs []net.Addr, err error)
+}
+
+// nativeSocket forwards all calls to the native implementations
+type nativeSocket struct{}
+
+func (n *nativeSocket) Socket(domain, typ, proto int) (fd int, err error) {
+	return syscall.Socket(domain, typ, proto)
+}
+
+func (n *nativeSocket) Bind(fd int, sa syscall.Sockaddr) (err error) {
+	return syscall.Bind(fd, sa)
+}
+
+func (n *nativeSocket) Close(fd int) (err error) {
+	return syscall.Close(fd)
+}
+
+func (n *nativeSocket) InterfaceAddrs() (addrs []net.Addr, err error) {
+	return net.InterfaceAddrs()
+}

--- a/pkg/service/socket_test.go
+++ b/pkg/service/socket_test.go
@@ -1,0 +1,142 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package service
+
+import (
+	"net"
+	"syscall"
+
+	lb "github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/lock"
+)
+
+type sock struct {
+	domain int
+	typ    int
+	proto  int
+}
+
+type bound struct {
+	addr net.IP
+	port uint16
+}
+
+// fakeSocket mocks the socket interface
+type fakeSocket struct {
+	mutex   lock.Mutex
+	sockets map[int]sock
+	bound   map[int]bound
+	addrs   []net.Addr
+}
+
+func newMockSocket() socket {
+	return &fakeSocket{
+		sockets: map[int]sock{},
+		bound:   map[int]bound{},
+	}
+}
+
+func (f *fakeSocket) Socket(domain, typ, proto int) (fd int, err error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	fd = len(f.sockets)
+	f.sockets[fd] = sock{domain, typ, proto}
+	return fd, nil
+}
+
+func (f *fakeSocket) Bind(fd int, sa syscall.Sockaddr) (err error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	sock, ok := f.sockets[fd]
+	if !ok {
+		return syscall.EBADF
+	}
+
+	if _, ok := f.bound[fd]; ok {
+		return syscall.EINVAL
+	}
+
+	var b bound
+	switch sockaddr := sa.(type) {
+	case *syscall.SockaddrInet4:
+		b.addr = net.IP(sockaddr.Addr[:])
+		b.port = uint16(sockaddr.Port)
+	case *syscall.SockaddrInet6:
+		b.addr = net.IP(sockaddr.Addr[:])
+		b.port = uint16(sockaddr.Port)
+	default:
+		return syscall.EAFNOSUPPORT
+	}
+
+	// check for port conflicts
+	for ofd, o := range f.bound {
+		if b.port == o.port && sock == f.sockets[ofd] {
+			return syscall.EADDRINUSE
+		}
+	}
+
+	f.bound[fd] = b
+	return nil
+}
+
+func (f *fakeSocket) Close(fd int) (err error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	delete(f.bound, fd)
+	delete(f.sockets, fd)
+	return nil
+}
+
+func (f *fakeSocket) InterfaceAddrs() (addrs []net.Addr, err error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	addrs = append(addrs, f.addrs...)
+	return addrs, nil
+}
+
+func (f *fakeSocket) isBound(proto lb.L4Type, ip net.IP, port uint16) bool {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	var typ int
+	switch proto {
+	case lb.UDP:
+		typ = syscall.SOCK_DGRAM
+	case lb.TCP:
+		typ = syscall.SOCK_STREAM
+	default:
+		return false
+	}
+
+	for fd, b := range f.bound {
+		if b.addr.Equal(ip) && b.port == port && f.sockets[fd].typ == typ {
+			return true
+		}
+	}
+	return false
+}
+
+func (f *fakeSocket) addInterfaceAddr(cidr *net.IPNet) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	f.addrs = append(f.addrs, cidr)
+}


### PR DESCRIPTION
When upserting a NodePort, LoadBalancer or ExternalIP service which
frontend address may conflict with a process running on a local node,
we need to ensure that we do not accidentally hijack traffic for said
process.

Therefore this commit makes sure to first bind any local frontend ports
on the node, to ensure no other process may accidentally allocate the
same port. Binding the port also ensures that the service upsert fails
if the address is already in use.

The implementation comes with a few caveats:

  - As the current datapath implementation does not lookup the actual L4
    protocol, we conservatively bind both the TCP and UDP port for a
    given service.

  - In addition, because NodePort services are currently internally
    represented as multiple frontends, we bind the actual NodePort to
    either 0.0.0.0 or ::0 and reference count the corresponding socket.

  - An ExternalIP frontend can only conflict with a local process if the
    terminating external IP is actually assigned to a local interface.
    Therefore we check all local interfaces before binding a port of an
    ExternalIP service.

  - The socket is bound using Go's "syscall" package, to avoid having to
    actually listen on the port in unit-test. This commit also adds a mock
    implementation for the relevant system calls, to ensure the unit tests
    are not dependent on any system state. In addition, mocking the system
    calls makes checking if a port is really bound much easier.

Fixes: #9206

Signed-off-by: Sebastian Wicki <sebastian@isovalent.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9863)
<!-- Reviewable:end -->
