### PR TITLE
ipsec: Fix incorrect IPSec policy generation to adopt cilium_host IP changes

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -162,8 +162,8 @@ func ipSecReplacePolicyInFwd(src, dst *net.IPNet, dir netlink.Dir) error {
 
 	policy := ipSecNewPolicy()
 	policy.Dir = dir
-	policy.Src = src
-	policy.Dst = dst
+	policy.Src = &net.IPNet{IP: src.IP.Mask(src.Mask), Mask: src.Mask}
+	policy.Dst = &net.IPNet{IP: dst.IP.Mask(dst.Mask), Mask: dst.Mask}
 	policy.Mark = &netlink.XfrmMark{
 		Value: linux_defaults.RouteMarkDecrypt,
 		Mask:  linux_defaults.IPsecMarkMaskIn,
@@ -173,6 +173,7 @@ func ipSecReplacePolicyInFwd(src, dst *net.IPNet, dir netlink.Dir) error {
 }
 
 func ipSecReplacePolicyOut(src, dst, tmplSrc, tmplDst *net.IPNet, dir IPSecDir) error {
+	// TODO: Remove old policy pointing to target net
 	var spiWide uint32
 
 	key := getIPSecKeys(dst.IP)
@@ -187,9 +188,9 @@ func ipSecReplacePolicyOut(src, dst, tmplSrc, tmplDst *net.IPNet, dir IPSecDir) 
 		wildcardMask := net.IPv4Mask(0, 0, 0, 0)
 		policy.Src = &net.IPNet{IP: wildcardIP, Mask: wildcardMask}
 	} else {
-		policy.Src = src
+		policy.Src = &net.IPNet{IP: src.IP.Mask(src.Mask), Mask: src.Mask}
 	}
-	policy.Dst = dst
+	policy.Dst = &net.IPNet{IP: dst.IP.Mask(dst.Mask), Mask: dst.Mask}
 	policy.Dir = netlink.XFRM_DIR_OUT
 	policy.Mark = &netlink.XfrmMark{
 		Value: ((spiWide << 12) | linux_defaults.RouteMarkEncrypt),


### PR DESCRIPTION
This patch changes the IPSec policy generation to use correctly
masked src/dst addresses, e.g. changes 10.188.32.48/16 to 10.188.0.0/16 within
the IPSec policy.

This implies that an existing IPSec policy will be updated in-place instead
of a new policy being generated and therefore fixes connectivity issues
after node reboots.

Fixes: #9833

```release-note
ipsec: fix connectivity after node reboots
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9866)
<!-- Reviewable:end -->
