### PR TITLE
docs: remove disable container runtime documentation

### DIFF
--- a/Documentation/concepts/overview.rst
+++ b/Documentation/concepts/overview.rst
@@ -14,8 +14,8 @@ Component Overview
 A deployment of Cilium consists of the following components running on each
 Linux container node in the container cluster:
 
-* **Cilium Agent (Daemon):** Userspace daemon that interacts with the container runtime
-  and orchestration systems such as Kubernetes via Plugins to setup networking
+* **Cilium Agent (Daemon):** Userspace daemon that interacts with the
+  orchestration systems such as Kubernetes via Plugins to setup networking
   and security for containers running on the local server.  Provides an API for
   configuring network security policies, extracting network visibility data,
   etc.
@@ -52,7 +52,7 @@ Cilium Agent
 The Cilium agent (cilium-agent) runs on each Linux container host.  At a
 high-level, the agent accepts configuration that describes service-level
 network security and visibility policies.   It then listens to events in the
-container runtime to learn when containers are started or stopped, and it
+orchestration systems to learn when containers are started or stopped, and it
 creates custom BPF programs which the Linux kernel uses to control all network
 access in / out of those containers.  In more detail, the agent:
 

--- a/Documentation/kubernetes/configuration.rst
+++ b/Documentation/kubernetes/configuration.rst
@@ -359,21 +359,3 @@ Finally, you need to restart the Cilium pod so it can re-mount
 ::
 
     kubectl delete -n kube-system pod -l k8s-app=cilium
-
-Disable container runtime
--------------------------
-
-If you want to run the Cilium agent on a node that will not host any
-application containers, then that node may not have a container runtime
-installed at all. You may still want to run the Cilium agent on the node to
-ensure that local processes on that node can reach application containers on
-other nodes. The default behavior of Cilium on startup when no container
-runtime has been found is to abort startup. To avoid this abort, you can run
-the ``cilium-agent`` with the following option.
-
-.. code:: bash
-
-   helm template cilium \
-     --namespace kube-system \
-     --set global.containerRuntime.integration=none \
-     > cilium.yaml


### PR DESCRIPTION
Since container runtime integration has been removed from Cilium, we can
remove this part of the documentation as well.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9868)
<!-- Reviewable:end -->
