### PR TITLE
dev: set tcp for NFS in development VMs

### DIFF
--- a/Documentation/contributing/development/dev_setup.rst
+++ b/Documentation/contributing/development/dev_setup.rst
@@ -181,6 +181,18 @@ and ports to enable NFS.
    always fails when using VirtualBox on OSX, but it is safe to let
    the startup script to reset the prefix length to 16.
 
+.. note::
+
+   Make sure your host NFS configuration is setup to use tcp:
+   # cat /etc/nfs.conf
+   ...
+   [nfsd]
+   # grace-time=90
+   tcp=y
+   # vers2=n
+   # vers3=y
+   ...
+
 If for some reason, running of the provisioning script fails, you should bring the VM down before trying again:
 
 ::

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -398,6 +398,8 @@ netfilter
 newproto
 newprotoparser
 nfp
+nfs
+nfsd
 nftables
 nodeX
 observability
@@ -541,6 +543,7 @@ uuid
 vCPUs
 validator
 verifier
+vers
 versa
 versioning
 veth

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -127,47 +127,6 @@ Vagrant.configure(2) do |config|
         config.vm.box_version = $SERVER_VERSION
         vb.memory = ENV['VM_MEMORY'].to_i
         vb.cpus = ENV['VM_CPUS'].to_i
-        if ENV["NFS"] then
-            mount_type = "nfs"
-            # Don't forget to enable this ports on your host before starting the VM
-            # in order to have nfs working
-            # iptables -I INPUT -p udp -s 192.168.34.0/24 --dport 111 -j ACCEPT
-            # iptables -I INPUT -p udp -s 192.168.34.0/24 --dport 2049 -j ACCEPT
-            # iptables -I INPUT -p udp -s 192.168.34.0/24 --dport 20048 -j ACCEPT
-        else
-            mount_type = ""
-        end
-        config.vm.synced_folder '.', '/home/vagrant/go/src/github.com/cilium/cilium', type: mount_type
-        if ENV['USER_MOUNTS'] then
-            # Allow multiple mounts divided by commas
-            ENV['USER_MOUNTS'].split(",").each do |mnt|
-                # Split "<to>=<from>"
-                user_mount = mnt.split("=", 2)
-                # Only one element, assume a path relative to home directories in both ends
-                if user_mount.length == 1 then
-                    user_mount_to = "/home/vagrant/" + user_mount[0]
-                    user_mount_from = "~/" + user_mount[0]
-                else
-                    user_mount_to = user_mount[0]
-                    # Remove "~/" prefix if any.
-                    if user_mount_to.start_with?('~/') then
-                        user_mount_to[0..1] = ''
-                    end
-                    # Add home directory prefix for non-absolute paths
-                    if !user_mount_to.start_with?('/') then
-                        user_mount_to = "/home/vagrant/" + user_mount_to
-                    end
-                    user_mount_from = user_mount[1]
-                    # Add home prefix for host for any path in the project directory
-                    # as it is already mounted.
-                    if !user_mount_from.start_with?('/', '.', '~') then
-                        user_mount_from = "~/" + user_mount_from
-                    end
-                end
-                puts "Mounting host directory #{user_mount_from} as #{user_mount_to}"
-                config.vm.synced_folder "#{user_mount_from}", "#{user_mount_to}", type: mount_type
-            end
-        end
     end
 
     master_vm_name = "#{$vm_base_name}1#{$build_id_name}"
@@ -270,6 +229,52 @@ Vagrant.configure(2) do |config|
                         privileged: true,
                         path: k8sinstall
                 end
+            end
+        end
+    end
+    if ENV["NFS"] then
+        config.vm.synced_folder '.', '/home/vagrant/go/src/github.com/cilium/cilium', type: "nfs", nfs_udp: false
+        # Don't forget to enable this ports on your host before starting the VM
+        # in order to have nfs working
+        # iptables -I INPUT -p tcp -s 192.168.34.0/24 --dport 111 -j ACCEPT
+        # iptables -I INPUT -p tcp -s 192.168.34.0/24 --dport 2049 -j ACCEPT
+        # iptables -I INPUT -p tcp -s 192.168.34.0/24 --dport 20048 -j ACCEPT
+    else
+        mount_type = ""
+        config.vm.synced_folder '.', '/home/vagrant/go/src/github.com/cilium/cilium', type: mount_type
+    end
+
+    if ENV['USER_MOUNTS'] then
+        # Allow multiple mounts divided by commas
+        ENV['USER_MOUNTS'].split(",").each do |mnt|
+            # Split "<to>=<from>"
+            user_mount = mnt.split("=", 2)
+            # Only one element, assume a path relative to home directories in both ends
+            if user_mount.length == 1 then
+                user_mount_to = "/home/vagrant/" + user_mount[0]
+                user_mount_from = "~/" + user_mount[0]
+            else
+                user_mount_to = user_mount[0]
+                # Remove "~/" prefix if any.
+                if user_mount_to.start_with?('~/') then
+                    user_mount_to[0..1] = ''
+                end
+                # Add home directory prefix for non-absolute paths
+                if !user_mount_to.start_with?('/') then
+                    user_mount_to = "/home/vagrant/" + user_mount_to
+                end
+                user_mount_from = user_mount[1]
+                # Add home prefix for host for any path in the project directory
+                # as it is already mounted.
+                if !user_mount_from.start_with?('/', '.', '~') then
+                    user_mount_from = "~/" + user_mount_from
+                end
+            end
+            puts "Mounting host directory #{user_mount_from} as #{user_mount_to}"
+            if ENV["NFS"] then
+                config.vm.synced_folder "#{user_mount_from}", "#{user_mount_to}", type: "nfs", nfs_udp: false
+            else
+                config.vm.synced_folder "#{user_mount_from}", "#{user_mount_to}", type: mount_type
             end
         end
     end


### PR DESCRIPTION
As NFS in UDP can create fragmented IP packets and eBPF does not
currently supports it, when using cilium with `--enable-node-port`
option will make the fragmented IP packets to be dropped, making the NFS
connectivity to be lost. For this reason we will enable tcp in NFS
for the dev VM.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9879)
<!-- Reviewable:end -->
