### PR TITLE
cmd: replace deprecated Command.SetOutput()

### DIFF
--- a/cilium/cmd/root.go
+++ b/cilium/cmd/root.go
@@ -62,7 +62,8 @@ func init() {
 	flags.StringP("host", "H", "", "URI to server-side API")
 	viper.BindPFlags(flags)
 	rootCmd.AddCommand(newCmdCompletion(os.Stdout))
-	rootCmd.SetOutput(os.Stderr)
+	rootCmd.SetOut(os.Stderr)
+	rootCmd.SetErr(os.Stderr)
 }
 
 // initConfig reads in config file and ENV variables if set.


### PR DESCRIPTION
The function Command.SetOutput() is deprecated based on the cobra
document, replaces this function with Command.SetOut() and
Command.SetErr() as document recommanded.

Signed-off-by: Tony Lu <tonylu@linux.alibaba.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9881)
<!-- Reviewable:end -->
