### PR TITLE
cmd: add zsh as a option for completion

### DIFF
--- a/Documentation/cmdref/cilium.md
+++ b/Documentation/cmdref/cilium.md
@@ -21,7 +21,7 @@ CLI for interacting with the local Cilium Agent
 
 * [cilium bpf](../cilium_bpf)	 - Direct access to local BPF maps
 * [cilium cleanup](../cilium_cleanup)	 - Reset the agent state
-* [cilium completion](../cilium_completion)	 - Output shell completion code for bash
+* [cilium completion](../cilium_completion)	 - Output shell completion code
 * [cilium config](../cilium_config)	 - Cilium configuration options
 * [cilium debuginfo](../cilium_debuginfo)	 - Request available debugging information from agent
 * [cilium endpoint](../cilium_endpoint)	 - Manage endpoints

--- a/Documentation/cmdref/cilium_completion.md
+++ b/Documentation/cmdref/cilium_completion.md
@@ -2,14 +2,14 @@
 
 ## cilium completion
 
-Output shell completion code for bash
+Output shell completion code
 
 ### Synopsis
 
-Output shell completion code for bash
+Output shell completion code
 
 ```
-cilium completion [bash] [flags]
+cilium completion [shell] [flags]
 ```
 
 ### Examples
@@ -35,6 +35,18 @@ cilium completion [bash] [flags]
 	  source '$HOME/.cilium/completion.bash.inc'
 	  " >> $HOME/.bash_profile
 	source $HOME/.bash_profile
+
+
+# Installing zsh completion on Linux/macOS
+## Load the cilium completion code for zsh into the current shell
+	source <(cilium completion zsh)
+## Write zsh completion code to a file and source if from .zshrc
+	cilium completion zsh > ~/.cilium/completion.zsh.inc
+	printf "
+	  # Cilium shell completion
+	  source '$HOME/.cilium/completion.zsh.inc'
+	  " >> $HOME/.zshrc
+	source $HOME/.zshrc
 ```
 
 ### Options

--- a/cilium/cmd/root.go
+++ b/cilium/cmd/root.go
@@ -130,19 +130,31 @@ var (
 	  # Cilium shell completion
 	  source '$HOME/.cilium/completion.bash.inc'
 	  " >> $HOME/.bash_profile
-	source $HOME/.bash_profile`
+	source $HOME/.bash_profile
+
+
+# Installing zsh completion on Linux/macOS
+## Load the cilium completion code for zsh into the current shell
+	source <(cilium completion zsh)
+## Write zsh completion code to a file and source if from .zshrc
+	cilium completion zsh > ~/.cilium/completion.zsh.inc
+	printf "
+	  # Cilium shell completion
+	  source '$HOME/.cilium/completion.zsh.inc'
+	  " >> $HOME/.zshrc
+	source $HOME/.zshrc`
 )
 
 func newCmdCompletion(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "completion [bash]",
-		Short:   "Output shell completion code for bash",
+		Use:     "completion [shell]",
+		Short:   "Output shell completion code",
 		Long:    ``,
 		Example: completionExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			runCompletion(out, cmd, args)
 		},
-		ValidArgs: []string{"bash"},
+		ValidArgs: []string{"bash", "zsh"},
 	}
 
 	return cmd
@@ -155,6 +167,16 @@ func runCompletion(out io.Writer, cmd *cobra.Command, args []string) error {
 	if _, err := out.Write([]byte(copyRightHeader)); err != nil {
 		return err
 	}
+	if len(args) == 0 {
+		return cmd.Parent().GenBashCompletion(out)
+	}
 
-	return cmd.Parent().GenBashCompletion(out)
+	switch args[0] {
+	case "bash":
+		return cmd.Parent().GenBashCompletion(out)
+	case "zsh":
+		return cmd.Parent().GenZshCompletion(out)
+	}
+
+	return fmt.Errorf("Unexpected shell: %s.", args[0])
 }

--- a/cilium/cmd/root.go
+++ b/cilium/cmd/root.go
@@ -151,8 +151,8 @@ func newCmdCompletion(out io.Writer) *cobra.Command {
 		Short:   "Output shell completion code",
 		Long:    ``,
 		Example: completionExample,
-		Run: func(cmd *cobra.Command, args []string) {
-			runCompletion(out, cmd, args)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCompletion(out, cmd, args)
 		},
 		ValidArgs: []string{"bash", "zsh"},
 	}


### PR DESCRIPTION
This adds zsh as a option for command completion, for zsh is also
popular and cobra natively supports zsh.

This will not change the default behavior of "completion" command.
If no or "bash" argument specified, it generates the completion for
bash.

Signed-off-by: Tony Lu <tonylu@linux.alibaba.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9882)
<!-- Reviewable:end -->
