### PR TITLE
cmd: fix defer call in for loop

### DIFF
--- a/cilium/cmd/bpf_ct_flush.go
+++ b/cilium/cmd/bpf_ct_flush.go
@@ -69,8 +69,8 @@ func flushCt(eID string) {
 			}
 			continue
 		}
-		defer m.Close()
 		entries := m.Flush()
 		fmt.Printf("Flushed %d entries from %s\n", entries, path)
+		m.Close()
 	}
 }

--- a/cilium/cmd/bpf_ct_list.go
+++ b/cilium/cmd/bpf_ct_list.go
@@ -53,6 +53,7 @@ func dumpCt(eID string) {
 	}
 
 	for _, m := range maps {
+		m := m
 		path, err := m.Path()
 		if err == nil {
 			err = m.Open()

--- a/cilium/cmd/bpf_nat_flush.go
+++ b/cilium/cmd/bpf_nat_flush.go
@@ -53,8 +53,8 @@ func flushNat() {
 			fmt.Fprintf(os.Stderr, "Unable to open %s: %s", path, err)
 			continue
 		}
-		defer m.Close()
 		entries := m.Flush()
 		fmt.Printf("Flushed %d entries from %s\n", entries, path)
+		m.Close()
 	}
 }

--- a/cilium/cmd/bpf_nat_list.go
+++ b/cilium/cmd/bpf_nat_list.go
@@ -48,6 +48,7 @@ func dumpNat() {
 		if m == nil {
 			continue
 		}
+		m := m
 		path, err := m.Path()
 		if err == nil {
 			err = m.Open()


### PR DESCRIPTION
During Go's for loop, it uses the same local variables as iterators. It
means the values of iterators would become the last assignment after
loop. The defer statement executes before the function returns and
after loop. The variables in defer statements becomes the same value,
which are the same last assignment.

To avoid this, this patch removes defer in loop which have one exit
point and can exit safely, for which have one more exit points,
explicitly declaring a new local variable and assign it to defer.

Here is a brif example:

type M int

func (m *M) Do() { fmt.Printf("this is %d\n", *m) }

m := make([]M, 0, 3)
for i := 0; i < 3; i++ { m = append(m, M(i)) }

for _, v := range m {
	// v := v
	defer v.Do()
}

After go run, output is:

this is 2
this is 2
this is 2

which is unexpected. After uncommenting, output is:

this is 2
this is 1
this is 0

which is expected.

Signed-off-by: Tony Lu <tonylu@linux.alibaba.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9886)
<!-- Reviewable:end -->
