### PR TITLE
test: Use HTTP retries on external connections if needed

### DIFF
--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -49,6 +49,26 @@ data:
   debug-verbose: "{{ .Values.global.debug.verbose }}"
 {{- end }}
 
+{{- if .Values.global.proxy.httpIdleTimeout }}
+  http-idle-timeout: "{{ .Values.global.proxy.httpIdleTimeout }}"
+{{- end }}
+
+{{- if .Values.global.proxy.httpMaxGrpcTimeout }}
+  http-max-grpc-timeout: "{{ .Values.global.proxy.httpMaxGrpcTimeout }}"
+{{- end }}
+
+{{- if .Values.global.proxy.httpRequestTimeout }}
+  http-request-timeout: "{{ .Values.global.proxy.httpRequestTimeout }}"
+{{- end }}
+
+{{- if .Values.global.proxy.httpRetryCount }}
+  http-retry-count: "{{ .Values.global.proxy.httpRetryCount }}"
+{{- end }}
+
+{{- if .Values.global.proxy.httpRetryTimeout }}
+  http-retry-timeout: "{{ .Values.global.proxy.httpRetryTimeout }}"
+{{- end }}
+
 {{- if .Values.global.prometheus.enabled }}
   # If you want metrics enabled in all of your Cilium agents, set the port for
   # which the Cilium agents will have their metrics exposed.

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -69,6 +69,31 @@ global:
     # verbose allows additional levels of debug/trace messaging
     #verbose: flow
 
+  # L7 proxy options, which take effect only on traffic that is redirected
+  # to an L7 proxy due to either policy enforcement or visibility
+  # annotation.
+  proxy:
+    # Time after which a non-gRPC HTTP stream is considered failed unless
+    # traffic in the stream has been processed (in seconds);
+    # defaults to 0 (unlimited).
+    #httpIdleTimeout: 0
+
+    # Time after which a forwarded gRPC request is considered failed unless
+    # completed (in seconds). A "grpc-timeout" header may override this with
+    # a shorter value; defaults to 0 (unlimited).
+    #httpMaxGrpcTimeout: 0
+
+    # Time after which a forwarded HTTP request is considered failed unless
+    # completed (in seconds); Use 0 for unlimited (default 3600).
+    #httpRequestTimeout: 3600
+
+    # Number of retries performed after a forwarded request attempt fails (default 3).
+    #httpRetryCount: 3
+
+    # Time (in seconds) after which a forwarded but uncompleted request is retried.
+    # Connection failures are retried immediately. Defaults to 0 (never).
+    #httpRetryTimeout: 0
+
   # prometheus enables
   prometheus:
     enabled: false


### PR DESCRIPTION
Recently introduced tests using external sites cause intermittent CI failures. Enable Envoy HTTP retries for those tests.

Note that the current Envoy retries do not work properly on upstream connections which re-use the original source address and port, so this change alone would not fix these intermittent CI failures, but will not make them any worse either. Envoy side fix of retries on these cases is prepared separately.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

```release-note
helm: Add helm template option to set the upstream HTTP retry timeout for L7 HTTP visibility and enforcement (e.g., `--set global.proxy.httpRetryTimeout=7`). Without this option retries are only enabled for immediate connection errors. With this option retries are started after the upstream server does not respond within the given number of seconds.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9892)
<!-- Reviewable:end -->
