### PR TITLE
eni: Deep copy CiliumNode resource before storing it in the node

### DIFF
--- a/operator/cilium_node.go
+++ b/operator/cilium_node.go
@@ -42,14 +42,16 @@ func startSynchronizingCiliumNodes() {
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				if node, ok := obj.(*v2.CiliumNode); ok {
-					ciliumNodeUpdated(node.DeepCopy())
+					// node is deep copied before it is stored in pkg/aws/eni
+					ciliumNodeUpdated(node)
 				} else {
 					log.Warningf("Unknown CiliumNode object type %s received: %+v", reflect.TypeOf(obj), obj)
 				}
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
 				if node, ok := newObj.(*v2.CiliumNode); ok {
-					ciliumNodeUpdated(node.DeepCopy())
+					// node is deep copied before it is stored in pkg/aws/eni
+					ciliumNodeUpdated(node)
 				} else {
 					log.Warningf("Unknown CiliumNode object type %s received: %+v", reflect.TypeOf(newObj), newObj)
 				}

--- a/operator/eni.go
+++ b/operator/eni.go
@@ -79,6 +79,7 @@ func (k *k8sAPI) Update(node, origNode *v2.CiliumNode) (*v2.CiliumNode, error) {
 
 func ciliumNodeUpdated(resource *v2.CiliumNode) {
 	if nodeManager != nil {
+		// resource is deep copied before it is stored in pkg/aws/eni
 		nodeManager.Update(resource)
 	}
 }

--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -207,6 +207,11 @@ func calculateExcessIPs(availableIPs, usedIPs, preAllocate, minAllocate, maxAbov
 }
 
 func (n *Node) updatedResource(resource *v2.CiliumNode) bool {
+	// Deep copy the resource before storing it. This way we are
+	// not dependent on caller not using the resource after this
+	// call.
+	resource = resource.DeepCopy()
+
 	n.mutex.Lock()
 	// Any modification to the custom resource is seen as a sign that the
 	// instance is alive

--- a/pkg/aws/eni/node_manager.go
+++ b/pkg/aws/eni/node_manager.go
@@ -136,6 +136,7 @@ func (n *NodeManager) GetNames() (allNodeNames []string) {
 
 // Update is called whenever a CiliumNode resource has been updated in the
 // Kubernetes apiserver
+// 'resource' is deep copied before it is stored.
 func (n *NodeManager) Update(resource *v2.CiliumNode) bool {
 	n.mutex.Lock()
 	node, ok := n.nodes[resource.Name]


### PR DESCRIPTION
Deep copy the resource before storing it. This way we are
not dependent on caller not using the resource after this
call. This may help avoid panics seen in the unit tests.

Fixes: #9779 (hopefully)
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9893)
<!-- Reviewable:end -->
