### PR TITLE
Restore SVC type after restart

### DIFF
--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -79,6 +79,18 @@ func (s ServiceFlags) IsSvcType(svcType SVCType) bool {
 	return s&CreateSvcFlag(svcType) != 0
 }
 
+// ServiceFlags returns a service type from the flags
+func (s ServiceFlags) SVCType() SVCType {
+	switch {
+	case s&serviceFlagExternalIPs != 0:
+		return SVCTypeExternalIPs
+	case s&serviceFlagNodePort != 0:
+		return SVCTypeNodePort
+	default:
+		return SVCTypeClusterIP
+	}
+}
+
 // String returns the string implementation of ServiceFlags.
 func (s ServiceFlags) String() string {
 	var strTypes []string

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -276,9 +276,7 @@ func (*LBBPFMap) DumpServiceMaps() ([]*loadbalancer.SVC, []error) {
 		addrStr := svc.Frontend.IP.String()
 		portStr := strconv.Itoa(int(svc.Frontend.Port))
 		host := net.JoinHostPort(addrStr, portStr)
-		if flagsCache[host].IsSvcType(loadbalancer.SVCTypeExternalIPs) {
-			svc.Type = loadbalancer.SVCTypeExternalIPs
-		}
+		svc.Type = flagsCache[host].SVCType()
 		newSVCList = append(newSVCList, &svc)
 	}
 

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -506,9 +506,9 @@ func (s *Service) restoreServicesLocked() error {
 			frontend:      svc.Frontend,
 			backends:      svc.Backends,
 			backendByHash: map[string]*lb.Backend{},
-			// Correct service type and traffic policy will be restored by
-			// k8s_watcher after k8s service cache has been initialized
-			svcType:          lb.SVCTypeClusterIP,
+			// Correct traffic policy will be restored by k8s_watcher after k8s
+			// service cache has been initialized
+			svcType:          svc.Type,
 			svcTrafficPolicy: lb.SVCTrafficPolicyCluster,
 			// Indicate that the svc was restored from the BPF maps, so that
 			// SyncWithK8sFinished() could remove services which were restored


### PR DESCRIPTION
Since the b4e0402 "bpf, nodeport: add nodeport flag to nodeport services" commit we started to set a nodeport flag in the BPF LB maps. Because of that, we can determine service types when restore them from the maps.

This helps when running cilium-agent without k8s, as in this case a non-ClusterIP service type is lost after cilium-agent has been restarted.

There still one discrepancy: LoadBalancer type services are stored as ExternalIP in the BPF maps, so these service types are properly restored after receiving corresponding updates from k8s.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9896)
<!-- Reviewable:end -->
