### PR TITLE
Add support for HealthCheckNodePort in NodePort BPF

### DIFF
--- a/api/v1/models/service_spec.go
+++ b/api/v1/models/service_spec.go
@@ -139,6 +139,9 @@ func (m *ServiceSpec) UnmarshalBinary(b []byte) error {
 // swagger:model ServiceSpecFlags
 type ServiceSpecFlags struct {
 
+	// Service health check node port
+	HealthCheckNodePort uint16 `json:"healthCheckNodePort,omitempty"`
+
 	// Service name  (e.g. Kubernetes service name)
 	Name string `json:"name,omitempty"`
 

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -1988,6 +1988,10 @@ definitions:
             enum:
             - Cluster
             - Local
+          healthCheckNodePort:
+            description: Service health check node port
+            type: integer
+            format: uint16
           name:
             description: Service name  (e.g. Kubernetes service name)
             type: string

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -2852,6 +2852,11 @@ func init() {
           "description": "Optional service configuration flags",
           "type": "object",
           "properties": {
+            "healthCheckNodePort": {
+              "description": "Service health check node port",
+              "type": "integer",
+              "format": "uint16"
+            },
             "name": {
               "description": "Service name  (e.g. Kubernetes service name)",
               "type": "string"
@@ -6130,6 +6135,11 @@ func init() {
           "description": "Optional service configuration flags",
           "type": "object",
           "properties": {
+            "healthCheckNodePort": {
+              "description": "Service health check node port",
+              "type": "integer",
+              "format": "uint16"
+            },
             "name": {
               "description": "Service name  (e.g. Kubernetes service name)",
               "type": "string"

--- a/daemon/loadbalancer.go
+++ b/daemon/loadbalancer.go
@@ -78,13 +78,16 @@ func (h *putServiceID) Handle(params PutServiceIDParams) middleware.Responder {
 		svcTrafficPolicy = loadbalancer.SVCTrafficPolicyCluster
 	}
 
+	svcHealthCheckNodePort := params.Config.Flags.HealthCheckNodePort
+
 	var svcName, svcNamespace string
 	if params.Config.Flags != nil {
 		svcName = params.Config.Flags.Name
 		svcNamespace = params.Config.Flags.Namespace
 	}
 
-	created, id, err := h.svc.UpsertService(frontend, backends, svcType, svcTrafficPolicy, svcName, svcNamespace)
+	created, id, err := h.svc.UpsertService(frontend, backends, svcType, svcTrafficPolicy,
+		svcHealthCheckNodePort, svcName, svcNamespace)
 	if err == nil && id != frontend.ID {
 		return api.Error(PutServiceIDInvalidFrontendCode,
 			fmt.Errorf("the service provided is already registered with ID %d, please use that ID instead of %d",

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -121,7 +121,7 @@ type svcManager interface {
 	DeleteService(frontend loadbalancer.L3n4Addr) (bool, error)
 	UpsertService(frontend loadbalancer.L3n4AddrID, backends []loadbalancer.Backend,
 		svcType loadbalancer.SVCType, svcTrafficPolicy loadbalancer.SVCTrafficPolicy,
-		svcName, svcNamespace string) (bool, loadbalancer.ID, error)
+		svcHealthCheckNodePort uint16, svcName, svcNamespace string) (bool, loadbalancer.ID, error)
 }
 
 type K8sWatcher struct {
@@ -715,7 +715,7 @@ func (k *K8sWatcher) addK8sSVCs(svcID k8s.ServiceID, oldSvc, svc *k8s.Service, e
 
 	for _, dpSvc := range svcs {
 		if _, _, err := k.svcManager.UpsertService(dpSvc.Frontend, dpSvc.Backends, dpSvc.Type,
-			dpSvc.TrafficPolicy, svcID.Name, svcID.Namespace); err != nil {
+			dpSvc.TrafficPolicy, dpSvc.HealthCheckNodePort, svcID.Name, svcID.Namespace); err != nil {
 			scopedLog.WithError(err).Error("Error while inserting service in LB map")
 		}
 	}

--- a/pkg/k8s/watchers/watcher_test.go
+++ b/pkg/k8s/watchers/watcher_test.go
@@ -148,8 +148,12 @@ func (f *fakePolicyRepository) TranslateRules(translator policy.Translator) (*po
 
 type fakeSvcManager struct {
 	OnDeleteService func(frontend loadbalancer.L3n4Addr) (bool, error)
-	OnUpsertService func(frontend loadbalancer.L3n4AddrID, backends []loadbalancer.Backend, svcType loadbalancer.SVCType,
-		svcTrafficPolicy loadbalancer.SVCTrafficPolicy, svcName, svcNamespace string) (bool, loadbalancer.ID, error)
+	OnUpsertService func(frontend loadbalancer.L3n4AddrID,
+		backends []loadbalancer.Backend,
+		svcType loadbalancer.SVCType,
+		svcTrafficPolicy loadbalancer.SVCTrafficPolicy,
+		svcHealthCheckNodePort uint16,
+		svcName, svcNamespace string) (bool, loadbalancer.ID, error)
 }
 
 func (f *fakeSvcManager) DeleteService(frontend loadbalancer.L3n4Addr) (bool, error) {
@@ -159,12 +163,16 @@ func (f *fakeSvcManager) DeleteService(frontend loadbalancer.L3n4Addr) (bool, er
 	panic("OnDeleteService(loadbalancer.L3n4Addr) (bool, error) was called and is not set!")
 }
 
-func (f *fakeSvcManager) UpsertService(frontend loadbalancer.L3n4AddrID, backends []loadbalancer.Backend,
-	svcType loadbalancer.SVCType, svcTrafficPolicy loadbalancer.SVCTrafficPolicy, svcName, svcNamespace string) (bool, loadbalancer.ID, error) {
+func (f *fakeSvcManager) UpsertService(frontend loadbalancer.L3n4AddrID,
+	backends []loadbalancer.Backend,
+	svcType loadbalancer.SVCType,
+	svcTrafficPolicy loadbalancer.SVCTrafficPolicy,
+	svcHealthCheckNodePort uint16,
+	svcName, svcNamespace string) (bool, loadbalancer.ID, error) {
 	if f.OnUpsertService != nil {
-		return f.OnUpsertService(frontend, backends, svcType, svcTrafficPolicy, svcName, svcNamespace)
+		return f.OnUpsertService(frontend, backends, svcType, svcTrafficPolicy, svcHealthCheckNodePort, svcName, svcNamespace)
 	}
-	panic("OnUpsertService(loadbalancer.L3n4AddrID, []loadbalancer.Backend, loadbalancer.SVCType, loadbalancer.SVCTrafficPolicy string, string) (bool, loadbalancer.ID, error) was called and is not set!")
+	panic("OnUpsertService(loadbalancer.L3n4AddrID, []loadbalancer.Backend, loadbalancer.SVCType, loadbalancer.SVCTrafficPolicy, uint16, string, string) (bool, loadbalancer.ID, error) was called and is not set!")
 }
 
 func (s *K8sWatcherSuite) TestUpdateToServiceEndpointsGH9525(c *C) {
@@ -512,6 +520,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ClusterIP(c *C) {
 			bes []loadbalancer.Backend,
 			svcType loadbalancer.SVCType,
 			svcTrafficPolicy loadbalancer.SVCTrafficPolicy,
+			svcHealthCheckNodePort uint16,
 			svcName,
 			namespace string) (
 			b bool,
@@ -681,6 +690,7 @@ func (s *K8sWatcherSuite) TestChangeSVCPort(c *C) {
 			bes []loadbalancer.Backend,
 			svcType loadbalancer.SVCType,
 			svcTrafficPolicy loadbalancer.SVCTrafficPolicy,
+			svcHealthCheckNodePort uint16,
 			svcName,
 			namespace string) (
 			b bool,
@@ -1142,6 +1152,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_NodePort(c *C) {
 			bes []loadbalancer.Backend,
 			svcType loadbalancer.SVCType,
 			svcTrafficPolicy loadbalancer.SVCTrafficPolicy,
+			svcHealthCheckNodePort uint16,
 			svcName,
 			namespace string) (
 			b bool,
@@ -1465,6 +1476,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_GH9576_1(c *C) {
 			bes []loadbalancer.Backend,
 			svcType loadbalancer.SVCType,
 			svcTrafficPolicy loadbalancer.SVCTrafficPolicy,
+			svcHealthCheckNodePort uint16,
 			svcName,
 			namespace string) (
 			b bool,
@@ -1780,6 +1792,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_GH9576_2(c *C) {
 			bes []loadbalancer.Backend,
 			svcType loadbalancer.SVCType,
 			svcTrafficPolicy loadbalancer.SVCTrafficPolicy,
+			svcHealthCheckNodePort uint16,
 			svcName,
 			namespace string) (
 			b bool,
@@ -2649,6 +2662,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ExternalIPs(c *C) {
 			bes []loadbalancer.Backend,
 			svcType loadbalancer.SVCType,
 			svcTrafficPolicy loadbalancer.SVCTrafficPolicy,
+			svcHealthCheckNodePort uint16,
 			svcName,
 			namespace string) (
 			b bool,

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -144,12 +144,13 @@ func (b *Backend) String() string {
 
 // SVC is a structure for storing service details.
 type SVC struct {
-	Frontend      L3n4AddrID       // SVC frontend addr and an allocated ID
-	Backends      []Backend        // List of service backends
-	Type          SVCType          // Service type
-	TrafficPolicy SVCTrafficPolicy // Service traffic policy
-	Name          string           // Service name
-	Namespace     string           // Service namespace
+	Frontend            L3n4AddrID       // SVC frontend addr and an allocated ID
+	Backends            []Backend        // List of service backends
+	Type                SVCType          // Service type
+	TrafficPolicy       SVCTrafficPolicy // Service traffic policy
+	HealthCheckNodePort uint16           // Service health check node port
+	Name                string           // Service name
+	Namespace           string           // Service namespace
 }
 
 func (s *SVC) GetModel() *models.Service {
@@ -168,10 +169,12 @@ func (s *SVC) GetModel() *models.Service {
 		FrontendAddress:  s.Frontend.GetModel(),
 		BackendAddresses: make([]*models.BackendAddress, len(s.Backends)),
 		Flags: &models.ServiceSpecFlags{
-			Type:          string(s.Type),
-			TrafficPolicy: string(s.TrafficPolicy),
-			Name:          s.Name,
-			Namespace:     s.Namespace,
+			Type:                string(s.Type),
+			TrafficPolicy:       string(s.TrafficPolicy),
+			HealthCheckNodePort: s.HealthCheckNodePort,
+
+			Name:      s.Name,
+			Namespace: s.Namespace,
 		},
 	}
 

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -198,6 +198,9 @@ const (
 	// ServiceType is the type of the service
 	ServiceType = "svcType"
 
+	// ServiceHealthCheckNodePort is the port on which we serve health checks
+	ServiceHealthCheckNodePort = "svcHealthCheckNodePort"
+
 	// ServiceTrafficPolicy is the traffic policy of the service
 	ServiceTrafficPolicy = "svcTrafficPolicy"
 

--- a/pkg/service/healthserver/healthserver.go
+++ b/pkg/service/healthserver/healthserver.go
@@ -1,0 +1,228 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package healthserver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync/atomic"
+
+	"github.com/cilium/cilium/pkg/counter"
+	lb "github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+
+	"github.com/sirupsen/logrus"
+)
+
+var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "service-healthserver")
+
+// ServiceName is the name and namespace of the service
+type ServiceName struct {
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+}
+
+// Service represents the object returned by the health server
+type Service struct {
+	Service        ServiceName `json:"service"`
+	LocalEndpoints int         `json:"localEndpoints"`
+}
+
+// NewService creates a new service
+func NewService(ns, name string, localEndpoints int) *Service {
+	return &Service{
+		Service: ServiceName{
+			Namespace: ns,
+			Name:      name,
+		},
+		LocalEndpoints: localEndpoints,
+	}
+}
+
+// healthHTTPServer is a running HTTP health server for a certain service
+type healthHTTPServer interface {
+	updateService(*Service)
+	shutdown()
+}
+
+// healthHTTPServerFactory creates a new HTTP health server, used for mocking
+type healthHTTPServerFactory interface {
+	newHTTPHealthServer(port uint16, svc *Service) healthHTTPServer
+}
+
+// ServiceHealthServer manages HTTP health check ports. For each added service,
+// it opens a HTTP server on the specified HealthCheckNodePort and either
+// responds with 200 OK if there are local endpoints for the service, or with
+// 503 Service Unavailable if the service does not have any local endpoints.
+type ServiceHealthServer struct {
+	healthHTTPServerByPort  map[uint16]healthHTTPServer
+	portRefCount            counter.IntCounter
+	portByServiceID         map[lb.ID]uint16
+	healthHTTPServerFactory healthHTTPServerFactory
+}
+
+// New creates a new health service server which services health checks by
+// serving an HTTP endpoint for each service on the given HealthCheckNodePort.
+func New() *ServiceHealthServer {
+	return WithHealthHTTPServerFactory(&httpHealthHTTPServerFactory{})
+}
+
+// WithHealthHTTPServerFactory creates a new health server with a specific health
+// server factory for testing purposes.
+func WithHealthHTTPServerFactory(healthHTTPServerFactory healthHTTPServerFactory) *ServiceHealthServer {
+	return &ServiceHealthServer{
+		healthHTTPServerByPort:  map[uint16]healthHTTPServer{},
+		portRefCount:            counter.IntCounter{},
+		portByServiceID:         map[lb.ID]uint16{},
+		healthHTTPServerFactory: healthHTTPServerFactory,
+	}
+}
+
+func (s *ServiceHealthServer) removeHTTPListener(port uint16) {
+	if s.portRefCount.Delete(int(port)) {
+		srv, ok := s.healthHTTPServerByPort[port]
+		if !ok {
+			log.WithField(logfields.Port, port).Warn("Invalid refcount for service health check port")
+			return
+		}
+		srv.shutdown()
+		delete(s.healthHTTPServerByPort, port)
+	}
+}
+
+// UpsertService inserts or updates a service health check server on 'port'. If
+// 'port' is zero, the listener for the added service is stopped.
+// Access to this method is not synchronized. It is the caller's responsibility
+// to ensure this method is called in a thread-safe manner.
+func (s *ServiceHealthServer) UpsertService(svcID lb.ID, ns, name string, localEndpoints int, port uint16) {
+	oldPort, foundSvc := s.portByServiceID[svcID]
+	if foundSvc && oldPort != port {
+		// HealthCheckNodePort has changed, we treat this as a DeleteService
+		// followed by an Insert.
+		s.removeHTTPListener(oldPort)
+		delete(s.portByServiceID, svcID)
+		foundSvc = false
+	}
+
+	// Nothing to do for services without a health check port
+	if port == 0 {
+		return
+	}
+
+	// Since we have one lb.SVC per frontend, we may end up receiving
+	// multiple identical services per port. The following code assumes that
+	// two services with the same port also have the same name and amount of
+	// endpoints. We reference count the listeners to make sure we only have
+	// a single listener per port.
+
+	var srv healthHTTPServer
+	svc := NewService(ns, name, localEndpoints)
+	if !foundSvc {
+		// We only bump the reference count if this is a service ID we have
+		// not seen before
+		if s.portRefCount.Add(int(port)) {
+			s.healthHTTPServerByPort[port] = s.healthHTTPServerFactory.newHTTPHealthServer(port, svc)
+		}
+	}
+
+	srv, foundSrv := s.healthHTTPServerByPort[port]
+	if !foundSrv {
+		log.WithFields(logrus.Fields{
+			logfields.ServiceID:                  svcID,
+			logfields.ServiceNamespace:           ns,
+			logfields.ServiceName:                name,
+			logfields.ServiceHealthCheckNodePort: port,
+		}).Warn("Unable to find service health check listener")
+		return
+	}
+
+	srv.updateService(svc)
+	s.portByServiceID[svcID] = port
+}
+
+// DeleteService stops the health server for the given service with 'svcID'.
+// Access to this method is not synchronized. It is the caller's responsibility
+// to ensure this method is called in a thread-safe manner.
+func (s *ServiceHealthServer) DeleteService(svcID lb.ID) {
+	if port, ok := s.portByServiceID[svcID]; ok {
+		s.removeHTTPListener(port)
+		delete(s.portByServiceID, svcID)
+	}
+}
+
+type httpHealthServer struct {
+	http.Server
+	service atomic.Value
+}
+
+type httpHealthHTTPServerFactory struct{}
+
+func (h *httpHealthHTTPServerFactory) newHTTPHealthServer(port uint16, svc *Service) healthHTTPServer {
+	srv := &httpHealthServer{}
+	srv.service.Store(svc)
+	srv.Server = http.Server{
+		Addr:    fmt.Sprintf(":%d", port),
+		Handler: srv,
+	}
+
+	go func() {
+		log.WithFields(logrus.Fields{
+			logfields.ServiceName:                svc.Service.Name,
+			logfields.ServiceNamespace:           svc.Service.Namespace,
+			logfields.ServiceHealthCheckNodePort: port,
+		}).Debug("Starting new service health server")
+
+		if err := srv.ListenAndServe(); err != http.ErrServerClosed {
+			svc := srv.loadService()
+			log.WithError(err).WithFields(logrus.Fields{
+				logfields.ServiceName:                svc.Service.Name,
+				logfields.ServiceNamespace:           svc.Service.Namespace,
+				logfields.ServiceHealthCheckNodePort: port,
+			}).Error("ListenAndServe failed for service health server")
+		}
+	}()
+
+	return srv
+}
+
+func (h *httpHealthServer) loadService() *Service {
+	return h.service.Load().(*Service)
+}
+
+func (h *httpHealthServer) updateService(svc *Service) {
+	h.service.Store(svc)
+}
+
+func (h *httpHealthServer) shutdown() {
+	h.Server.Shutdown(context.Background())
+}
+
+func (h *httpHealthServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Use headers and JSON output compatible with kube-proxy
+	svc := h.loadService()
+	if svc.LocalEndpoints == 0 {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	} else {
+		w.WriteHeader(http.StatusOK)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	if err := json.NewEncoder(w).Encode(&svc); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}

--- a/pkg/service/healthserver/healthserver_mock.go
+++ b/pkg/service/healthserver/healthserver_mock.go
@@ -1,0 +1,59 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package healthserver
+
+// MockHealthHTTPServerFactory mocks the healthHTTPServerFactory interface
+type MockHealthHTTPServerFactory struct {
+	serversByPort map[uint16]*mockHealthServer
+}
+
+// NewMockHealthHTTPServerFactory creates a new health server factory for testing
+func NewMockHealthHTTPServerFactory() *MockHealthHTTPServerFactory {
+	return &MockHealthHTTPServerFactory{
+		serversByPort: map[uint16]*mockHealthServer{},
+	}
+}
+
+// ServiceByPort returns the service for a given health check node port
+func (m *MockHealthHTTPServerFactory) ServiceByPort(port uint16) *Service {
+	if srv, ok := m.serversByPort[port]; ok {
+		return srv.svc
+	}
+	return nil
+}
+
+func (m *MockHealthHTTPServerFactory) newHTTPHealthServer(port uint16, svc *Service) healthHTTPServer {
+	m.serversByPort[port] = &mockHealthServer{
+		port:    port,
+		svc:     svc,
+		factory: m,
+	}
+
+	return m.serversByPort[port]
+}
+
+type mockHealthServer struct {
+	port    uint16
+	svc     *Service
+	factory *MockHealthHTTPServerFactory
+}
+
+func (m *mockHealthServer) updateService(svc *Service) {
+	m.svc = svc
+}
+
+func (m *mockHealthServer) shutdown() {
+	delete(m.factory.serversByPort, m.port)
+}

--- a/pkg/service/healthserver/healthserver_test.go
+++ b/pkg/service/healthserver/healthserver_test.go
@@ -1,0 +1,114 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package healthserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+type ServiceHealthServerSuite struct{}
+
+var _ = Suite(&ServiceHealthServerSuite{})
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+func (s *ServiceHealthServerSuite) TestServiceHealthServer_UpsertService(c *C) {
+	f := NewMockHealthHTTPServerFactory()
+	h := WithHealthHTTPServerFactory(f)
+
+	// Insert svc1
+	h.UpsertService(1, "default", "svc1", 1, 32000)
+	c.Assert(f.ServiceByPort(32000).Service.Namespace, Equals, "default")
+	c.Assert(f.ServiceByPort(32000).Service.Name, Equals, "svc1")
+	c.Assert(f.ServiceByPort(32000).LocalEndpoints, Equals, 1)
+
+	// Disable svc1 port
+	h.UpsertService(1, "default", "svc1", 1, 0)
+	c.Assert(f.ServiceByPort(32000), IsNil)
+
+	// Re-enable svc1 port
+	h.UpsertService(1, "default", "svc1", 1, 32000)
+	c.Assert(f.ServiceByPort(32000).Service.Namespace, Equals, "default")
+	c.Assert(f.ServiceByPort(32000).Service.Name, Equals, "svc1")
+	c.Assert(f.ServiceByPort(32000).LocalEndpoints, Equals, 1)
+
+	// Change svc1 port
+	h.UpsertService(1, "default", "svc1", 2, 32001)
+	c.Assert(f.ServiceByPort(32000), IsNil)
+	c.Assert(f.ServiceByPort(32001).Service.Namespace, Equals, "default")
+	c.Assert(f.ServiceByPort(32001).Service.Name, Equals, "svc1")
+	c.Assert(f.ServiceByPort(32001).LocalEndpoints, Equals, 2)
+
+	// Update svc1 count
+	h.UpsertService(1, "default", "svc1", 3, 32001)
+	c.Assert(f.ServiceByPort(32001).Service.Namespace, Equals, "default")
+	c.Assert(f.ServiceByPort(32001).Service.Name, Equals, "svc1")
+	c.Assert(f.ServiceByPort(32001).LocalEndpoints, Equals, 3)
+
+	// Add svc1 clone (uses same port, must be ref-counted)
+	h.UpsertService(100, "default", "svc1", 3, 32001)
+	c.Assert(f.ServiceByPort(32001).Service.Namespace, Equals, "default")
+	c.Assert(f.ServiceByPort(32001).Service.Name, Equals, "svc1")
+	c.Assert(f.ServiceByPort(32001).LocalEndpoints, Equals, 3)
+
+	// Insert svc2
+	h.UpsertService(2, "default", "svc2", 0, 32002)
+	c.Assert(f.ServiceByPort(32002).Service.Namespace, Equals, "default")
+	c.Assert(f.ServiceByPort(32002).Service.Name, Equals, "svc2")
+	c.Assert(f.ServiceByPort(32002).LocalEndpoints, Equals, 0)
+
+	// Delete svc1 clone
+	h.DeleteService(100)
+	c.Assert(f.ServiceByPort(32001), Not(IsNil))
+	c.Assert(f.ServiceByPort(32002), Not(IsNil))
+
+	// Delete svc1
+	h.DeleteService(1)
+	c.Assert(f.ServiceByPort(32001), IsNil)
+	c.Assert(f.ServiceByPort(32002), Not(IsNil))
+
+	// Delete svc2
+	h.DeleteService(2)
+	c.Assert(f.ServiceByPort(32001), IsNil)
+	c.Assert(f.ServiceByPort(32002), IsNil)
+}
+
+func (s *ServiceHealthServerSuite) Test_httpHealthServer_ServeHTTP(c *C) {
+	h := &httpHealthServer{}
+	ts := httptest.NewServer(h)
+	defer ts.Close()
+
+	// Set local endpoints, server must respond with HTTP 200
+	h.updateService(NewService("default", "svc", 1))
+	resp, err := http.Get(ts.URL)
+	c.Assert(err, IsNil)
+	c.Assert(resp.StatusCode, Equals, http.StatusOK)
+	resp.Body.Close()
+
+	// Remove local endpoints, server must respond with HTTP 503
+	h.updateService(NewService("default", "svc", 0))
+	resp, err = http.Get(ts.URL)
+	c.Assert(err, IsNil)
+	c.Assert(resp.StatusCode, Equals, http.StatusServiceUnavailable)
+	resp.Body.Close()
+}

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -62,7 +62,7 @@ var (
 
 func (m *ManagerTestSuite) TestUpsertAndDeleteService(c *C) {
 	// Should create a new service with two backends
-	created, id1, err := m.svc.UpsertService(frontend1, backends1, lb.SVCTypeNodePort, lb.SVCTrafficPolicyCluster, "svc1", "ns1")
+	created, id1, err := m.svc.UpsertService(frontend1, backends1, lb.SVCTypeNodePort, lb.SVCTrafficPolicyCluster, 0, "svc1", "ns1")
 	c.Assert(err, IsNil)
 	c.Assert(created, Equals, true)
 	c.Assert(id1, Equals, lb.ID(1))
@@ -72,7 +72,7 @@ func (m *ManagerTestSuite) TestUpsertAndDeleteService(c *C) {
 	c.Assert(m.svc.svcByID[id1].svcNamespace, Equals, "ns1")
 
 	// Should update nothing
-	created, id1, err = m.svc.UpsertService(frontend1, backends1, lb.SVCTypeNodePort, lb.SVCTrafficPolicyCluster, "", "")
+	created, id1, err = m.svc.UpsertService(frontend1, backends1, lb.SVCTypeNodePort, lb.SVCTrafficPolicyCluster, 0, "", "")
 	c.Assert(err, IsNil)
 	c.Assert(created, Equals, false)
 	c.Assert(id1, Equals, lb.ID(1))
@@ -84,7 +84,7 @@ func (m *ManagerTestSuite) TestUpsertAndDeleteService(c *C) {
 	// TODO(brb) check that .backends =~ .backendsByHash
 
 	// Should remove one backend
-	created, id1, err = m.svc.UpsertService(frontend1, backends1[0:1], lb.SVCTypeNodePort, lb.SVCTrafficPolicyCluster, "", "")
+	created, id1, err = m.svc.UpsertService(frontend1, backends1[0:1], lb.SVCTypeNodePort, lb.SVCTrafficPolicyCluster, 0, "", "")
 	c.Assert(err, IsNil)
 	c.Assert(created, Equals, false)
 	c.Assert(id1, Equals, lb.ID(1))
@@ -94,7 +94,7 @@ func (m *ManagerTestSuite) TestUpsertAndDeleteService(c *C) {
 	c.Assert(m.svc.svcByID[id1].svcNamespace, Equals, "ns1")
 
 	// Should add another service
-	created, id2, err := m.svc.UpsertService(frontend2, backends1, lb.SVCTypeNodePort, lb.SVCTrafficPolicyCluster, "svc2", "ns2")
+	created, id2, err := m.svc.UpsertService(frontend2, backends1, lb.SVCTypeNodePort, lb.SVCTrafficPolicyCluster, 0, "svc2", "ns2")
 	c.Assert(err, IsNil)
 	c.Assert(created, Equals, true)
 	c.Assert(id2, Equals, lb.ID(2))
@@ -112,7 +112,7 @@ func (m *ManagerTestSuite) TestUpsertAndDeleteService(c *C) {
 	c.Assert(len(m.lbmap.BackendByID), Equals, 2)
 
 	// Should delete both backends of service
-	created, id2, err = m.svc.UpsertService(frontend2, nil, lb.SVCTypeNodePort, lb.SVCTrafficPolicyCluster, "", "")
+	created, id2, err = m.svc.UpsertService(frontend2, nil, lb.SVCTypeNodePort, lb.SVCTrafficPolicyCluster, 0, "", "")
 	c.Assert(err, IsNil)
 	c.Assert(created, Equals, false)
 	c.Assert(id2, Equals, lb.ID(2))
@@ -130,9 +130,9 @@ func (m *ManagerTestSuite) TestUpsertAndDeleteService(c *C) {
 }
 
 func (m *ManagerTestSuite) TestRestoreServices(c *C) {
-	_, id1, err := m.svc.UpsertService(frontend1, backends1, lb.SVCTypeNodePort, lb.SVCTrafficPolicyCluster, "", "")
+	_, id1, err := m.svc.UpsertService(frontend1, backends1, lb.SVCTypeNodePort, lb.SVCTrafficPolicyCluster, 0, "", "")
 	c.Assert(err, IsNil)
-	_, id2, err := m.svc.UpsertService(frontend2, backends2, lb.SVCTypeClusterIP, lb.SVCTrafficPolicyCluster, "", "")
+	_, id2, err := m.svc.UpsertService(frontend2, backends2, lb.SVCTypeClusterIP, lb.SVCTrafficPolicyCluster, 0, "", "")
 	c.Assert(err, IsNil)
 
 	// Restart service, but keep the lbmap to restore services from
@@ -159,9 +159,9 @@ func (m *ManagerTestSuite) TestRestoreServices(c *C) {
 }
 
 func (m *ManagerTestSuite) TestSyncWithK8sFinished(c *C) {
-	_, _, err := m.svc.UpsertService(frontend1, backends1, lb.SVCTypeNodePort, lb.SVCTrafficPolicyCluster, "", "")
+	_, _, err := m.svc.UpsertService(frontend1, backends1, lb.SVCTypeNodePort, lb.SVCTrafficPolicyCluster, 0, "", "")
 	c.Assert(err, IsNil)
-	_, _, err = m.svc.UpsertService(frontend2, backends2, lb.SVCTypeClusterIP, lb.SVCTrafficPolicyCluster, "", "")
+	_, _, err = m.svc.UpsertService(frontend2, backends2, lb.SVCTypeClusterIP, lb.SVCTrafficPolicyCluster, 0, "", "")
 	c.Assert(err, IsNil)
 	c.Assert(len(m.svc.svcByID), Equals, 2)
 
@@ -177,7 +177,7 @@ func (m *ManagerTestSuite) TestSyncWithK8sFinished(c *C) {
 	// In real life, the following upsert is called by k8s_watcher during
 	// the sync period of the cilium-agent's k8s service cache which happens
 	// during the initialization of cilium-agent.
-	_, id2, err := m.svc.UpsertService(frontend2, backends2, lb.SVCTypeClusterIP, lb.SVCTrafficPolicyCluster, "svc2", "ns2")
+	_, id2, err := m.svc.UpsertService(frontend2, backends2, lb.SVCTypeClusterIP, lb.SVCTrafficPolicyCluster, 0, "svc2", "ns2")
 	c.Assert(err, IsNil)
 
 	// cilium-agent finished the initialization, and thus SyncWithK8sFinished


### PR DESCRIPTION
This adds the `HealthCheckNodePort` field to the service manager package and related types and starts a HTTP server on that port if set. This feature is used by external loadbalancers to determine whether a certain node contains a local backend. When a service has local backends, the HTTP server on the specified port returns `HTTP 200`, otherwise it returns `503 Service Unavailable`. The implementation inside the new `service/healthserver` provides the same JSON output as `kube-proxy`.

The health check server is only enabled for a given service if it has a non-zero `HealthCheckNodePort`. This value may only be set in Kubernetes if a service has `externalTrafficPolicy=Local` and its type is `LoadBalancer`. Our current implementation is a bit more relaxed, it relies on the K8s API to enforce the constraint, since we do not know the original Kubernetes service type.

Review per commit. Ginkgo run-time tests will be added in a separate PR.

Fixes: #8699

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9906)
<!-- Reviewable:end -->
