### PR TITLE
ginkgo.Jenkinsfile: set k8s nodes back to 2

### DIFF
--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -133,7 +133,7 @@ pipeline {
                         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
                         NETNEXT="true"
                         K8S_VERSION="1.11"
-                        K8S_NODES="3"
+                        //K8S_NODES="3"
                         KUBECONFIG="vagrant-kubeconfig"
                         CILIUM_REGISTRY="localnode" //setting it here so we don't compile Cilium in vagrant nodes (already done on local node registry)
                     }


### PR DESCRIPTION
This will help easy the workload being currently set in the CI.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9908)
<!-- Reviewable:end -->
