### PR TITLE
cni: Fix IP leak when CNI ADD times out

### DIFF
--- a/api/v1/client/ipam/delete_ipam_ip_parameters.go
+++ b/api/v1/client/ipam/delete_ipam_ip_parameters.go
@@ -62,7 +62,7 @@ for the delete ipam IP operation typically these are written to a http.Request
 type DeleteIpamIPParams struct {
 
 	/*IP
-	  IP address
+	  IP address or owner name
 
 	*/
 	IP string

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -444,7 +444,7 @@ paths:
       tags:
       - ipam
       parameters:
-      - "$ref": "#/parameters/ipam-ip"
+      - "$ref": "#/parameters/ipam-release-arg"
       responses:
         '200':
           description: Success
@@ -934,6 +934,12 @@ parameters:
   ipam-ip:
     name: ip
     description: IP address
+    in: path
+    required: true
+    type: string
+  ipam-release-arg:
+    name: ip
+    description: IP address or owner name
     in: path
     required: true
     type: string

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -844,7 +844,7 @@ func init() {
         "summary": "Release an allocated IP address",
         "parameters": [
           {
-            "$ref": "#/parameters/ipam-ip"
+            "$ref": "#/parameters/ipam-release-arg"
           }
         ],
         "responses": {
@@ -3063,6 +3063,13 @@ func init() {
       "name": "owner",
       "in": "query"
     },
+    "ipam-release-arg": {
+      "type": "string",
+      "description": "IP address or owner name",
+      "name": "ip",
+      "in": "path",
+      "required": true
+    },
     "labels": {
       "description": "List of labels\n",
       "name": "labels",
@@ -4074,7 +4081,7 @@ func init() {
         "parameters": [
           {
             "type": "string",
-            "description": "IP address",
+            "description": "IP address or owner name",
             "name": "ip",
             "in": "path",
             "required": true
@@ -6340,6 +6347,13 @@ func init() {
       "type": "string",
       "name": "owner",
       "in": "query"
+    },
+    "ipam-release-arg": {
+      "type": "string",
+      "description": "IP address or owner name",
+      "name": "ip",
+      "in": "path",
+      "required": true
     },
     "labels": {
       "description": "List of labels\n",

--- a/api/v1/server/restapi/ipam/delete_ipam_ip_parameters.go
+++ b/api/v1/server/restapi/ipam/delete_ipam_ip_parameters.go
@@ -30,7 +30,7 @@ type DeleteIpamIPParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
-	/*IP address
+	/*IP address or owner name
 	  Required: true
 	  In: path
 	*/


### PR DESCRIPTION
When the endpoint create API call takes a long time, the CNI ADD caller can forcefully stop the cilium-cni binary. While the endpoint create API call will eventually time out or is forcefully interrupted due to a broken pipe, the error handler to release the previously allocated IP is never invoked. This will result in leaked IP addresses.

In order to resolve this, release all IPs via the pod name on CNI DEL in case the endpoint delete API call does not succeed. In the case of a successful endpoint delete call, the IPs were already released by deleting the endpoint.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9913)
<!-- Reviewable:end -->
