### PR TITLE
monitor: Refactor listener registration logic

### DIFF
--- a/pkg/monitor/agent/listener/listener.go
+++ b/pkg/monitor/agent/listener/listener.go
@@ -48,6 +48,9 @@ type MonitorListener interface {
 
 	// Version returns the API version of this listener
 	Version() Version
+
+	// Close closes the listener.
+	Close()
 }
 
 // IsDisconnected is a convenience function that wraps the absurdly long set of

--- a/pkg/monitor/agent/listener1_2_test.go
+++ b/pkg/monitor/agent/listener1_2_test.go
@@ -1,0 +1,48 @@
+// Copyright 2018-2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package agent
+
+import (
+	"net"
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/cilium/cilium/pkg/monitor/agent/listener"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type ListenerSuite struct{}
+
+var _ = Suite(&ListenerSuite{})
+
+func (m *ListenerSuite) TestListenerv1_2(c *C) {
+	closed := make(chan bool)
+	server, client := net.Pipe()
+	l := newListenerv1_2(client, 10, func(listener listener.MonitorListener) {
+		closed <- true
+	})
+	// Verify the listener version.
+	c.Assert(l.Version(), Equals, listener.Version1_2)
+	// Calling Close() multiple times shouldn't cause panic.
+	l.Close()
+	l.Close()
+	// Make sure the cleanup function gets called.
+	<-closed
+	server.Close()
+}


### PR DESCRIPTION
- Modify registerNewListener() to take MonitorListener as a parameter
  to allow arbitrary listener to be registered instead of assuming the
  type of listener is always listenerv1_2.
- Add Close() method to MonitorListener so that the Monitor can close
  listeners without knowing implementation details.

Ref #9925

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9924)
<!-- Reviewable:end -->
