### PR TITLE
pkg/ip: fix cilium status output for big CIDR ranges

### DIFF
--- a/pkg/ip/ip.go
+++ b/pkg/ip/ip.go
@@ -31,12 +31,17 @@ const (
 // CountIPsInCIDR takes a RFC4632/RFC4291-formatted IPv4/IPv6 CIDR and
 // determines how many IP addresses reside within that CIDR.
 // Returns 0 if the input CIDR cannot be parsed.
-func CountIPsInCIDR(ipnet *net.IPNet) int {
+func CountIPsInCIDR(ipnet *net.IPNet) *big.Int {
 	subnet, size := ipnet.Mask.Size()
 	if subnet == size {
-		return 1
+		return big.NewInt(1)
 	}
-	return 1<<uint(size-subnet) - 1
+	return big.NewInt(0).
+		Sub(
+			big.NewInt(2).Exp(big.NewInt(2),
+				big.NewInt(int64(size-subnet)), nil),
+			big.NewInt(1),
+		)
 }
 
 var (

--- a/pkg/ip/ip_test.go
+++ b/pkg/ip/ip_test.go
@@ -17,6 +17,7 @@
 package ip
 
 import (
+	"math/big"
 	"math/rand"
 	"net"
 	"sort"
@@ -37,20 +38,21 @@ func Test(t *testing.T) {
 }
 
 func (s *IPTestSuite) TestCountIPs(c *C) {
-	tests := map[string]int{
-		"192.168.0.1/32": 1,
-		"192.168.0.1/31": 1,
-		"192.168.0.1/30": 3,
-		"192.168.0.1/24": 255,
-		"192.168.0.1/16": 65535,
-		"::1/128":        1,
-		"::1/120":        255,
+	tests := map[string]*big.Int{
+		"192.168.0.1/32": big.NewInt(1),
+		"192.168.0.1/31": big.NewInt(1),
+		"192.168.0.1/30": big.NewInt(3),
+		"192.168.0.1/24": big.NewInt(255),
+		"192.168.0.1/16": big.NewInt(65535),
+		"::1/128":        big.NewInt(1),
+		"::1/120":        big.NewInt(255),
+		"fd02:1::/32":    big.NewInt(0).Sub(big.NewInt(2).Exp(big.NewInt(2), big.NewInt(96), nil), big.NewInt(1)),
 	}
 	for cidr, nIPs := range tests {
 		_, ipnet, err := net.ParseCIDR(cidr)
 		c.Assert(err, IsNil)
 		count := CountIPsInCIDR(ipnet)
-		c.Assert(count, Equals, nIPs)
+		c.Assert(count, checker.DeepEquals, nIPs)
 	}
 }
 

--- a/pkg/ipam/hostscope.go
+++ b/pkg/ipam/hostscope.go
@@ -83,7 +83,7 @@ func (h *hostScopeAllocator) Dump() (map[string]string, string) {
 	}
 
 	maxIPs := ip.CountIPsInCIDR(h.allocCIDR)
-	status := fmt.Sprintf("%d/%d allocated from %s", len(alloc), maxIPs, h.allocCIDR.String())
+	status := fmt.Sprintf("%d/%s allocated from %s", len(alloc), maxIPs.String(), h.allocCIDR.String())
 
 	return alloc, status
 }


### PR DESCRIPTION
Fix formatting issue for `cilium status` where the total number of IPs
allocated by a CIDR could be bigger than 2^32.

Before this commit the output of `cilium status` would be:
```
... IPv6: 4/-1 allocated from fd02:1::/32
```
With this commit the output of `cilium status` is:
```
... IPv6: 4/79228162514264337593543950335 allocated from fd02:1::/32
```

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9936)
<!-- Reviewable:end -->
