### PR TITLE
cni: Fix noisy warning "Unknown CNI chaining configuration"

### DIFF
--- a/plugins/cilium-cni/chaining/api/api.go
+++ b/plugins/cilium-cni/chaining/api/api.go
@@ -32,6 +32,12 @@ var (
 	mutex           lock.RWMutex
 )
 
+const (
+	// DefaultConfigName is the name used by default in the standard CNI
+	// configuration
+	DefaultConfigName = "cilium"
+)
+
 // PluginContext is the context given to chaining plugins
 type PluginContext struct {
 	Logger  *logrus.Entry
@@ -66,6 +72,10 @@ func Register(name string, p ChainingPlugin) error {
 	mutex.Lock()
 	defer mutex.Unlock()
 
+	if name == DefaultConfigName {
+		return fmt.Errorf("invalid chain name. '%s' is reserved", DefaultConfigName)
+	}
+
 	if _, ok := chainingPlugins[name]; ok {
 		return fmt.Errorf("chaining plugin with name %s already exists", name)
 	}
@@ -77,10 +87,6 @@ func Register(name string, p ChainingPlugin) error {
 
 // Lookup searches for a chaining plugin with a given name and returns it
 func Lookup(name string) ChainingPlugin {
-	if name == "cilium" {
-		return nil
-	}
-
 	mutex.RLock()
 	defer mutex.RUnlock()
 

--- a/plugins/cilium-cni/chaining/api/api_test.go
+++ b/plugins/cilium-cni/chaining/api/api_test.go
@@ -56,6 +56,9 @@ func (a *APISuite) TestRegistration(c *check.C) {
 
 	err = Register("foo", &pluginTest{})
 	c.Assert(err, check.Not(check.IsNil))
+
+	err = Register(DefaultConfigName, &pluginTest{})
+	c.Assert(err, check.Not(check.IsNil))
 }
 
 func (a *APISuite) TestNonChaining(c *check.C) {


### PR DESCRIPTION
The following warning has been printed for every CNI ADD and CNI DEL:

    Unknown CNI chaining configuration name 'cilium'

Prevent a chaining plugin to use the name "cilium" and only perform a chaining
plugin lookup if the configuration is different than the default name "cilium".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9937)
<!-- Reviewable:end -->
