### PR TITLE
test README: Fix the documentation link

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -1,3 +1,3 @@
 # Cilium Test Framework
 
-For information about how to run tests, check out [the developer contributing doucmentation](../Documentation/contributing.rst) .
+For information about how to run tests, check out [the testing documentation](https://docs.cilium.io/en/latest/contributing/testing/).


### PR DESCRIPTION
Before this patch, the test documentation link was broken.

Signed-off-by: Alexandre Perrin <alex@kaworu.ch>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9941)
<!-- Reviewable:end -->
