### PR TITLE
Add a new type of event for policy action notification. 

### DIFF
--- a/Documentation/cmdref/cilium_endpoint_config.md
+++ b/Documentation/cmdref/cilium_endpoint_config.md
@@ -15,7 +15,7 @@ cilium endpoint config <endpoint id> [<option>=(enable|disable) ...] [flags]
 ### Examples
 
 ```
-endpoint config 5421 DropNotification=false TraceNotification=false
+endpoint config 5421 DropNotification=false TraceNotification=false PolicyVerdictNotification=true
 ```
 
 ### Options

--- a/Documentation/cmdref/cilium_monitor.md
+++ b/Documentation/cmdref/cilium_monitor.md
@@ -10,6 +10,7 @@ The monitor displays notifications and events emitted by the BPF
 programs attached to endpoints and devices. This includes:
   * Dropped packet notifications
   * Captured packet traces
+  * Policy verdict notifications
   * Debugging information
 
 ```
@@ -26,7 +27,7 @@ cilium monitor [flags]
       --monitor-socket string   Configure monitor socket path
       --related-to []uint16     Filter by either source or destination endpoint id
       --to []uint16             Filter by destination endpoint id
-  -t, --type []string           Filter by event types [agent capture debug drop l7 trace]
+  -t, --type []string           Filter by event types [agent capture debug drop l7 policy-verdict trace]
   -v, --verbose                 Enable verbose output
 ```
 

--- a/bpf/bpf_alignchecker.c
+++ b/bpf/bpf_alignchecker.c
@@ -20,6 +20,7 @@
 #define DEBUG
 #define TRACE_NOTIFY
 #define DROP_NOTIFY
+#define POLICY_VERDICT_NOTIFY
 
 #include "node_config.h"
 #include "lib/conntrack.h"
@@ -29,6 +30,7 @@
 #include "lib/maps.h"
 #include "lib/nat.h"
 #include "lib/trace.h"
+#include "lib/policy_log.h"
 #include "sockops/bpf_sockops.h"
 
 // DECLARE_STRUCT declares a unique usage of the struct 'x' on the stack.
@@ -70,6 +72,7 @@ int main() {
     DECLARE_STRUCT(ipv6_nat_entry, iter);
     DECLARE_STRUCT(trace_notify, iter);
     DECLARE_STRUCT(drop_notify, iter);
+    DECLARE_STRUCT(policy_verdict_notify, iter);
     DECLARE_STRUCT(debug_msg, iter);
     DECLARE_STRUCT(debug_capture_msg, iter);
 

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -248,6 +248,19 @@ struct metrics_value {
      __u64	bytes;
 };
 
+enum {
+	POLICY_INGRESS = 1,
+	POLICY_EGRESS = 2,
+};
+
+
+enum {
+        POLICY_MATCH_NONE = 0,
+        POLICY_MATCH_L3_ONLY = 1,
+        POLICY_MATCH_L3_L4 = 2,
+        POLICY_MATCH_L4_ONLY = 3,
+        POLICY_MATCH_ALL = 4,
+};
 
 enum {
 	CILIUM_NOTIFY_UNSPEC,
@@ -255,6 +268,7 @@ enum {
 	CILIUM_NOTIFY_DBG_MSG,
 	CILIUM_NOTIFY_DBG_CAPTURE,
 	CILIUM_NOTIFY_TRACE,
+	CILIUM_NOTIFY_POLICY_VERDICT,
 };
 
 #define NOTIFY_COMMON_HDR \

--- a/bpf/lib/policy_log.h
+++ b/bpf/lib/policy_log.h
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2016-2019 Authors of Cilium
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+/*
+ * Policy verdict notification via perf event ring buffer.
+ *
+ * API:
+ * void send_policy_verdict_notify(skb, remote_label, dst_port, proto, dir, is_ipv6, verdict, match_type)
+ *
+ * If POLICY_VERDICT_NOTIFY is not defined, the API will be a non-op.
+ */
+
+#ifndef __LIB_POLICY_LOG__
+#define __LIB_POLICY_LOG__
+
+#include "common.h"
+
+#ifdef POLICY_VERDICT_NOTIFY
+struct policy_verdict_notify {
+	NOTIFY_CAPTURE_HDR
+	__u32	remote_label;
+	__s32	verdict;
+	__u16	dst_port;
+	__u8	proto;
+	__u8	dir:2,
+		ipv6:1,
+		match_type:3,
+		pad0:2;
+	__u32	pad1; // align with 64 bits
+};
+
+static inline void
+send_policy_verdict_notify(struct __sk_buff *skb, __u32 remote_label, __u16 dst_port, __u8 proto,
+                             __u8 dir, __u8 is_ipv6, int verdict, __u8 match_type)
+{
+	__u64 skb_len = (__u64)skb->len, cap_len = min((__u64)TRACE_PAYLOAD_LEN, (__u64)skb_len);
+	__u32 hash = get_hash_recalc(skb);
+	struct policy_verdict_notify msg = {
+		.type = CILIUM_NOTIFY_POLICY_VERDICT,
+		.source = EVENT_SOURCE,
+		.hash = hash,
+		.len_orig = skb_len,
+		.len_cap = cap_len,
+		.version = NOTIFY_CAPTURE_VER,
+		.remote_label = remote_label,
+		.verdict = verdict,
+		.dst_port = bpf_ntohs(dst_port),
+		.proto = proto,
+		.dir = dir,
+		.ipv6 = is_ipv6,
+		.match_type = match_type,
+		.pad0 = 0,
+		.pad1 = 0,
+	};
+
+	skb_event_output(skb, &EVENTS_MAP,
+			 (cap_len << 32) | BPF_F_CURRENT_CPU,
+			 &msg, sizeof(msg));
+}
+
+#else
+
+static inline void
+send_policy_verdict_notify(struct __sk_buff *skb, __u32 remote_label, __u16 dst_port, __u8 proto,
+                             __u8 dir, __u8 is_ipv6, int verdict, __u8 match_type)
+{
+}
+#endif /* POLICY_VERDICT_NOTIFY */
+
+#endif /* __LIB_POLICY_LOG__*/

--- a/bpf/lxc_config.h
+++ b/bpf/lxc_config.h
@@ -38,6 +38,7 @@ DEFINE_U32(SECLABEL_NB, 0xfffff);
 #endif
 #define DROP_NOTIFY
 #define TRACE_NOTIFY
+#define POLICY_VERDICT_NOTIFY
 #define CT_MAP_TCP6 test_cilium_ct_tcp6_65535
 #define CT_MAP_ANY6 test_cilium_ct_any6_65535
 #define CT_MAP_TCP4 test_cilium_ct_tcp4_65535

--- a/cilium/cmd/endpoint_config.go
+++ b/cilium/cmd/endpoint_config.go
@@ -31,7 +31,7 @@ var listOptions bool
 var endpointConfigCmd = &cobra.Command{
 	Use:     "config <endpoint id> [<option>=(enable|disable) ...]",
 	Short:   "View & modify endpoint configuration",
-	Example: "endpoint config 5421 DropNotification=false TraceNotification=false",
+	Example: "endpoint config 5421 DropNotification=false TraceNotification=false PolicyVerdictNotification=true",
 	Run: func(cmd *cobra.Command, args []string) {
 		if listOptions {
 			listEndpointOptions()

--- a/cilium/cmd/monitor.go
+++ b/cilium/cmd/monitor.go
@@ -48,6 +48,7 @@ var (
 programs attached to endpoints and devices. This includes:
   * Dropped packet notifications
   * Captured packet traces
+  * Policy verdict notifications
   * Debugging information`,
 		Run: func(cmd *cobra.Command, args []string) {
 			runMonitor(args)

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -936,6 +936,7 @@ func initEnv(cmd *cobra.Command) {
 	option.Config.Opts.SetBool(option.DebugLB, option.Config.Debug)
 	option.Config.Opts.SetBool(option.DropNotify, true)
 	option.Config.Opts.SetBool(option.TraceNotify, true)
+	option.Config.Opts.SetBool(option.PolicyVerdictNotify, true)
 	option.Config.Opts.SetBool(option.PolicyTracing, option.Config.EnableTracing)
 	option.Config.Opts.SetBool(option.Conntrack, !option.Config.DisableConntrack)
 	option.Config.Opts.SetBool(option.ConntrackAccounting, !option.Config.DisableConntrack)

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -92,6 +92,7 @@ func TestMain(m *testing.M) {
 	}
 	option.Config.Opts.SetBool(option.DropNotify, true)
 	option.Config.Opts.SetBool(option.TraceNotify, true)
+	option.Config.Opts.SetBool(option.PolicyVerdictNotify, true)
 
 	// Disable restore of host IPs for unit tests. There can be arbitrary
 	// state left on disk.

--- a/pkg/monitor/alignchecker/alignchecker.go
+++ b/pkg/monitor/alignchecker/alignchecker.go
@@ -26,10 +26,11 @@ import (
 func CheckStructAlignments(path string) error {
 	// Validate alignments of C and Go equivalent structs
 	toCheck := map[string][]reflect.Type{
-		"trace_notify":      {reflect.TypeOf(monitor.TraceNotify{})},
-		"drop_notify":       {reflect.TypeOf(monitor.DropNotify{})},
-		"debug_msg":         {reflect.TypeOf(monitor.DebugMsg{})},
-		"debug_capture_msg": {reflect.TypeOf(monitor.DebugCapture{})},
+		"trace_notify":          {reflect.TypeOf(monitor.TraceNotify{})},
+		"drop_notify":           {reflect.TypeOf(monitor.DropNotify{})},
+		"debug_msg":             {reflect.TypeOf(monitor.DebugMsg{})},
+		"debug_capture_msg":     {reflect.TypeOf(monitor.DebugCapture{})},
+		"policy_verdict_notify": {reflect.TypeOf(monitor.PolicyVerdictNotify{})},
 	}
 	return check.CheckStructAlignments(path, toCheck)
 }

--- a/pkg/monitor/api/types.go
+++ b/pkg/monitor/api/types.go
@@ -29,10 +29,26 @@ import (
 const (
 	// 0-128 are reserved for BPF datapath events
 	MessageTypeUnspec = iota
+
+	// MessageTypeDrop is a BPF datapath notification carrying a DropNotify
+	// which corresponds to drop_notify defined in bpf/lib/drop.h
 	MessageTypeDrop
+
+	// MessageTypeDebug is a BPF datapath notification carrying a DebugMsg
+	// which corresponds to debug_msg defined in bpf/lib/dbg.h
 	MessageTypeDebug
+
+	// MessageTypeCapture is a BPF datapath notification carrying a DebugCapture
+	// which corresponds to debug_capture_msg defined in bpf/lib/dbg.h
 	MessageTypeCapture
+
+	// MessageTypeTrace is a BPF datapath notification carrying a TraceNotify
+	// which corresponds to trace_notify defined in bpf/lib/trace.h
 	MessageTypeTrace
+
+	// MessageTypePolicyVerdict is a BPF datapath notification carrying a PolicyVerdictNotify
+	// which corresponds to policy_verdict_notify defined in bpf/lib/policy_log.h
+	MessageTypePolicyVerdict
 
 	// 129-255 are reserved for agent level events
 
@@ -44,12 +60,13 @@ const (
 )
 
 const (
-	MessageTypeNameDrop    = "drop"
-	MessageTypeNameDebug   = "debug"
-	MessageTypeNameCapture = "capture"
-	MessageTypeNameTrace   = "trace"
-	MessageTypeNameL7      = "l7"
-	MessageTypeNameAgent   = "agent"
+	MessageTypeNameDrop          = "drop"
+	MessageTypeNameDebug         = "debug"
+	MessageTypeNameCapture       = "capture"
+	MessageTypeNameTrace         = "trace"
+	MessageTypeNameL7            = "l7"
+	MessageTypeNameAgent         = "agent"
+	MessageTypeNamePolicyVerdict = "policy-verdict"
 )
 
 type MessageTypeFilter []int
@@ -57,12 +74,13 @@ type MessageTypeFilter []int
 var (
 	// MessageTypeNames is a map of all type names
 	MessageTypeNames = map[string]int{
-		MessageTypeNameDrop:    MessageTypeDrop,
-		MessageTypeNameDebug:   MessageTypeDebug,
-		MessageTypeNameCapture: MessageTypeCapture,
-		MessageTypeNameTrace:   MessageTypeTrace,
-		MessageTypeNameL7:      MessageTypeAccessLog,
-		MessageTypeNameAgent:   MessageTypeAgent,
+		MessageTypeNameDrop:          MessageTypeDrop,
+		MessageTypeNameDebug:         MessageTypeDebug,
+		MessageTypeNameCapture:       MessageTypeCapture,
+		MessageTypeNameTrace:         MessageTypeTrace,
+		MessageTypeNameL7:            MessageTypeAccessLog,
+		MessageTypeNameAgent:         MessageTypeAgent,
+		MessageTypeNamePolicyVerdict: MessageTypePolicyVerdict,
 	}
 )
 

--- a/pkg/monitor/datapath_policy.go
+++ b/pkg/monitor/datapath_policy.go
@@ -1,0 +1,128 @@
+// Copyright 2016-2017 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package monitor
+
+import (
+	"fmt"
+)
+
+const (
+	// PolicyVerdictNotifyLen is the amount of packet data provided in a Policy notification
+	PolicyVerdictNotifyLen = 32
+
+	// The values below are for parsing PolicyVerdictNotify. They need to be consistent
+	// with what are defined in data plane.
+
+	// PolicyVerdictNotifyFlagDirection is the bit mask in Flags that
+	// corresponds to the direction of a traffic
+	PolicyVerdictNotifyFlagDirection = 0x3
+
+	// PolicyVerdictNotifyFlagIsIPv6 is the bit mask in Flags that
+	// corresponds to wether the traffic is IPv6 or not
+	PolicyVerdictNotifyFlagIsIPv6 = 0x4
+
+	// PolicyVerdictNotifyFlagMatchType is the bit mask in Flags that
+	// corresponds to the policy match type
+	PolicyVerdictNotifyFlagMatchType = 0x38
+
+	// PolicyVerdictNotifyFlagMatchTypeBitOffset is the bit offset in Flags that
+	// corresponds to the policy match type
+	PolicyVerdictNotifyFlagMatchTypeBitOffset = 3
+
+	// PolicyIngress is the value of Flags&PolicyNotifyFlagDirection for ingress traffic
+	PolicyIngress = 1
+
+	// PolicyEgress is the value of Flags&PolicyNotifyFlagDirection for egress traffic
+	PolicyEgress = 2
+
+	// PolicyMatchNone is the value of MatchType indicatating no policy match
+	PolicyMatchNone = 0
+
+	// PolicyMatchL3Only is the value of MatchType indicating a L3-only match
+	PolicyMatchL3Only = 1
+
+	// PolicyMatchL3L4 is the value of MatchType indicating a L3+L4 match
+	PolicyMatchL3L4 = 2
+
+	// PolicyMatchL4Only is the value of MatchType indicating a L4-only match
+	PolicyMatchL4Only = 3
+
+	// PolicyMatchAll is the value of MatchType indicating an allow-all match
+	PolicyMatchAll = 4
+)
+
+// PolicyVerdictNotify is the message format of a policy verdict notification in the bpf ring buffer
+type PolicyVerdictNotify struct {
+	Type        uint8
+	SubType     uint8
+	Source      uint16
+	Hash        uint32
+	OrigLen     uint32
+	CapLen      uint16
+	Version     uint16
+	RemoteLabel uint32
+	Verdict     int32
+	DstPort     uint16
+	Proto       uint8
+	Flags       uint8
+	Pad2        uint32
+	// data
+}
+
+// IsTrafficIngress returns true if this notify is for an ingress traffic
+func (n *PolicyVerdictNotify) IsTrafficIngress() bool {
+	return n.Flags&PolicyVerdictNotifyFlagDirection == PolicyIngress
+}
+
+// IsTrafficIPv6 returns true if this notify is for IPv6 traffic
+func (n *PolicyVerdictNotify) IsTrafficIPv6() bool {
+	return (n.Flags&PolicyVerdictNotifyFlagIsIPv6 > 0)
+}
+
+// GetPolicyActionString returns the action string corresponding to the action
+func GetPolicyActionString(verdict int32) string {
+	if verdict < 0 {
+		return "deny"
+	} else if verdict > 0 {
+		return "redirect"
+	}
+	return "allow"
+}
+
+func getPolicyMatchTypeString(flag uint8) string {
+	matchType := (flag & PolicyVerdictNotifyFlagMatchType) >>
+		PolicyVerdictNotifyFlagMatchTypeBitOffset
+	switch matchType {
+	case PolicyMatchL3Only:
+		return "L3-Only"
+	case PolicyMatchL3L4:
+		return "L3-L4"
+	case PolicyMatchL4Only:
+		return "L4-Only"
+	case PolicyMatchAll:
+		return "all"
+	case PolicyMatchNone:
+		return "none"
+
+	}
+	return "unknown"
+}
+
+// DumpInfo prints a summary of the policy notify messages.
+func (n *PolicyVerdictNotify) DumpInfo(data []byte) {
+	fmt.Printf("Policy verdict log: flow %#x local EP ID %d, remote ID %d, dst port %d, proto %d, ingress %v, action %s, match %s, %s\n",
+		n.Hash, n.Source, n.RemoteLabel, n.DstPort, n.Proto, n.IsTrafficIngress(), GetPolicyActionString(n.Verdict),
+		getPolicyMatchTypeString(n.Flags), GetConnectionSummary(data[PolicyVerdictNotifyLen:]))
+}

--- a/pkg/monitor/format/format.go
+++ b/pkg/monitor/format/format.go
@@ -129,6 +129,18 @@ func (m *MonitorFormatter) traceEvents(prefix string, data []byte) {
 	}
 }
 
+func (m *MonitorFormatter) policyVerdictEvents(prefix string, data []byte) {
+	pn := monitor.PolicyVerdictNotify{}
+
+	if err := binary.Read(bytes.NewReader(data), byteorder.Native, &pn); err != nil {
+		fmt.Printf("Error while parsing policy notification message: %s\n", err)
+	}
+
+	if m.match(monitorAPI.MessageTypePolicyVerdict, pn.Source, uint16(pn.RemoteLabel)) {
+		pn.DumpInfo(data)
+	}
+}
+
 // debugEvents prints out all the debug messages.
 func (m *MonitorFormatter) debugEvents(prefix string, data []byte) {
 	dm := monitor.DebugMsg{}
@@ -228,6 +240,8 @@ func (m *MonitorFormatter) FormatSample(data []byte, cpu int) {
 		m.logRecordEvents(prefix, data)
 	case monitorAPI.MessageTypeAgent:
 		m.agentEvents(prefix, data)
+	case monitorAPI.MessageTypePolicyVerdict:
+		m.policyVerdictEvents(prefix, data)
 	default:
 		fmt.Printf("%s Unknown event: %+v\n", prefix, data)
 	}

--- a/pkg/option/daemon.go
+++ b/pkg/option/daemon.go
@@ -33,6 +33,7 @@ var (
 		DebugLB:             &specDebugLB,
 		DropNotify:          &specDropNotify,
 		TraceNotify:         &specTraceNotify,
+		PolicyVerdictNotify: &specPolicyVerdictNotify,
 		MonitorAggregation:  &specMonitorAggregation,
 		NAT46:               &specNAT46,
 	}

--- a/pkg/option/endpoint.go
+++ b/pkg/option/endpoint.go
@@ -23,6 +23,7 @@ var (
 		DebugLB:             &specDebugLB,
 		DropNotify:          &specDropNotify,
 		TraceNotify:         &specTraceNotify,
+		PolicyVerdictNotify: &specPolicyVerdictNotify,
 		MonitorAggregation:  &specMonitorAggregation,
 		NAT46:               &specNAT46,
 	}

--- a/pkg/option/runtime_options.go
+++ b/pkg/option/runtime_options.go
@@ -27,6 +27,7 @@ const (
 	DebugLB             = "DebugLB"
 	DropNotify          = "DropNotification"
 	TraceNotify         = "TraceNotification"
+	PolicyVerdictNotify = "PolicyVerdictNotification"
 	MonitorAggregation  = "MonitorAggregationLevel"
 	NAT46               = "NAT46"
 	AlwaysEnforce       = "always"
@@ -76,6 +77,11 @@ var (
 	specTraceNotify = Option{
 		Define:      "TRACE_NOTIFY",
 		Description: "Enable trace notifications",
+	}
+
+	specPolicyVerdictNotify = Option{
+		Define:      "POLICY_VERDICT_NOTIFY",
+		Description: "Enable policy verdict notifications",
 	}
 
 	specMonitorAggregation = Option{


### PR DESCRIPTION
A new event type for policy verdict is added in BPF. It can be turned on/off using endpoint build option PolicyVerdictNotification.  The event can be monitored with "cilium monitor -t policy-verdict"

Signed-off-by: Zang Li <zangli@google.com>
Fixes: #9914

```release-note
Add a new event type for policy verdicts
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9943)
<!-- Reviewable:end -->
