### PR TITLE
pkg/allocator: only release local keys if global key is released 

### DIFF
--- a/pkg/allocator/allocator.go
+++ b/pkg/allocator/allocator.go
@@ -684,13 +684,9 @@ func (a *Allocator) Release(ctx context.Context, key AllocatorKey) (lastUse bool
 
 	// release the key locally, if it was the last use, remove the node
 	// specific value key to remove the global reference mark
-	lastUse, err = a.localKeys.release(k)
-	if err != nil {
-		return lastUse, err
-	}
-	if lastUse {
-		a.backend.Release(ctx, key)
-	}
+	lastUse, err = a.localKeys.releaseWithFunc(k, func() error {
+		return a.backend.Release(ctx, key)
+	})
 
 	return lastUse, err
 }


### PR DESCRIPTION
If a global key is not released for any error condition, the local key
should not be released as well otherwise the reference counting will be
out of sync.

Fixes: 7ccf87701fc9 ("kvstore: New kvstore abstraction API")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9944)
<!-- Reviewable:end -->
