### PR TITLE
daemon: Exit early if NodePort BPF and IPSec is enabled

### DIFF
--- a/Documentation/gettingstarted/nodeport.rst
+++ b/Documentation/gettingstarted/nodeport.rst
@@ -76,6 +76,7 @@ Limitations
       or ``cilium_geneve``). Exposing services through multiple native devices
       will be supported in upcoming Cilium versions. See `GH issue 9620
       <https://github.com/cilium/cilium/issues/9620>`_ for additional details.
+    * NodePort BPF cannot currently be used with :ref:`encryption`.
 
 .. _external-ips:
 

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -1098,6 +1098,10 @@ func initEnv(cmd *cobra.Command) {
 		}
 	}
 
+	if option.Config.EnableNodePort && option.Config.EnableIPSec {
+		log.Fatal("IPSec cannot be used with NodePort BPF")
+	}
+
 	// If device has been specified, use it to derive better default
 	// allocation prefixes
 	if option.Config.Device != "undefined" {


### PR DESCRIPTION
Currently, both features are mutually exclusive. So, just panic during the initialization of cilium-agent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9946)
<!-- Reviewable:end -->
