### PR TITLE
node: Provide context in log when restoring router addresses

### DIFF
--- a/pkg/node/node_address.go
+++ b/pkg/node/node_address.go
@@ -29,6 +29,8 @@ import (
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
+
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -255,12 +257,10 @@ func AutoComplete() error {
 		ipv4GW, ipv6Router := getCiliumHostIPs()
 
 		if ipv4GW != nil && option.Config.EnableIPv4 {
-			log.Infof("Restored IPv4 internal node IP: %s", ipv4GW.String())
 			SetInternalIPv4(ipv4GW)
 		}
 
 		if ipv6Router != nil && option.Config.EnableIPv6 {
-			log.Infof("Restored IPv6 router IP: %s", ipv6Router.String())
 			SetIPv6Router(ipv6Router)
 		}
 	}
@@ -433,7 +433,12 @@ func getCiliumHostIPsFromFile(nodeConfig string) (ipv4GW, ipv6Router net.IP) {
 func getCiliumHostIPs() (ipv4GW, ipv6Router net.IP) {
 	nodeConfig := option.Config.GetNodeConfigPath()
 	ipv4GW, ipv6Router = getCiliumHostIPsFromFile(nodeConfig)
-	if ipv4GW != nil {
+	if ipv4GW != nil || ipv6Router != nil {
+		log.WithFields(logrus.Fields{
+			"ipv4": ipv4GW,
+			"ipv6": ipv6Router,
+			"file": nodeConfig,
+		}).Info("Restored router address from node_config")
 		return ipv4GW, ipv6Router
 	}
 	return getCiliumHostIPsFromNetDev(option.Config.HostDevice)

--- a/pkg/node/node_address_linux.go
+++ b/pkg/node/node_address_linux.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/ip"
 
+	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 )
 
@@ -184,6 +185,15 @@ func getCiliumHostIPsFromNetDev(devName string) (ipv4GW, ipv6Router net.IP) {
 			}
 		}
 	}
+
+	if ipv4GW != nil || ipv6Router != nil {
+		log.WithFields(logrus.Fields{
+			"ipv4":   ipv4GW,
+			"ipv6":   ipv6Router,
+			"device": devName,
+		}).Info("Restored router address from device")
+	}
+
 	return ipv4GW, ipv6Router
 }
 


### PR DESCRIPTION
The following log messages lacked context on how the address has been restored:

    cilium-agent[32467]: level=info msg="Restored IPv6 router IP: fc00::10ca:1" subsys=node

Provide the node_config file or netdevice context when restoring router addresses.

Fixes: #6776

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9947)
<!-- Reviewable:end -->
