### PR TITLE
node: Remove error return from SetIPv6NodeRange

### DIFF
--- a/daemon/ipam.go
+++ b/daemon/ipam.go
@@ -329,9 +329,7 @@ func (d *Daemon) bootstrapIPAM() {
 			log.WithError(err).WithField(logfields.V6Prefix, option.Config.IPv6Range).Fatal("Invalid IPv6 allocation prefix")
 		}
 
-		if err := node.SetIPv6NodeRange(net); err != nil {
-			log.WithError(err).WithField(logfields.V6Prefix, net).Fatal("Invalid per node IPv6 allocation prefix")
-		}
+		node.SetIPv6NodeRange(net)
 	}
 
 	if err := node.AutoComplete(); err != nil {

--- a/pkg/k8s/init.go
+++ b/pkg/k8s/init.go
@@ -106,12 +106,7 @@ func useNodeCIDR(n *node.Node) {
 		node.SetIPv4AllocRange(n.IPv4AllocCIDR)
 	}
 	if n.IPv6AllocCIDR != nil && option.Config.EnableIPv6 {
-		if err := node.SetIPv6NodeRange(n.IPv6AllocCIDR.IPNet); err != nil {
-			log.WithError(err).WithFields(logrus.Fields{
-				logfields.Node:     n.Name,
-				logfields.V6Prefix: n.IPv6AllocCIDR,
-			}).Warn("k8s: Can't use IPv6 CIDR range from k8s")
-		}
+		node.SetIPv6NodeRange(n.IPv6AllocCIDR.IPNet)
 	}
 }
 

--- a/pkg/node/node_address.go
+++ b/pkg/node/node_address.go
@@ -242,12 +242,9 @@ func GetNodePortIPv6() net.IP {
 }
 
 // SetIPv6NodeRange sets the IPv6 address pool to be used on this node
-func SetIPv6NodeRange(net *net.IPNet) error {
+func SetIPv6NodeRange(net *net.IPNet) {
 	copy := *net
 	ipv6AllocRange = cidr.NewCIDR(&copy)
-
-	// TODO(brb) rm error
-	return nil
 }
 
 // AutoComplete completes the parts of addressing that can be auto derived

--- a/pkg/policy/l3_test.go
+++ b/pkg/policy/l3_test.go
@@ -31,8 +31,7 @@ func (ds *PolicyTestSuite) SetUpTest(c *C) {
 	_, v6node, err := net.ParseCIDR("2001:DB8::/96")
 	c.Assert(err, IsNil)
 	v4node := cidr.MustParseCIDR("192.0.2.3/24")
-	err = node.SetIPv6NodeRange(v6node)
-	c.Assert(err, IsNil)
+	node.SetIPv6NodeRange(v6node)
 	node.SetIPv4AllocRange(v4node)
 }
 


### PR DESCRIPTION
The function can't fail. Remove the error return.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9954)
<!-- Reviewable:end -->
