### PR TITLE
Fix cilium installation in GCloud beta "rapid" channel

### DIFF
--- a/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
@@ -56,8 +56,8 @@ spec:
                       while crictl ps | grep -v "node-init" | grep -q "POD_cilium"; do sleep 1; done
                     fi
 
-                    systemctl disable sys-fs-bpf.mount
-                    systemctl stop sys-fs-bpf.mount
+                    systemctl disable sys-fs-bpf.mount || true
+                    systemctl stop sys-fs-bpf.mount || true
 
                     if ip link show cilium_host; then
                       echo "Deleting cilium_host interface..."
@@ -97,37 +97,38 @@ spec:
                 # Mount the filesystem until next reboot
                 echo "Mounting BPF filesystem..."
                 mount bpffs /sys/fs/bpf -t bpf
-              }
 
-              echo "Installing BPF filesystem mount"
-              cat >/tmp/sys-fs-bpf.mount <<EOF
-              [Unit]
-              Description=Mount BPF filesystem (Cilium)
-              Documentation=http://docs.cilium.io/
-              DefaultDependencies=no
-              Before=local-fs.target umount.target
-              After=swap.target
+                # Configure systemd to mount after next boot
+                echo "Installing BPF filesystem mount"
+                cat >/tmp/sys-fs-bpf.mount <<EOF
+                [Unit]
+                Description=Mount BPF filesystem (Cilium)
+                Documentation=http://docs.cilium.io/
+                DefaultDependencies=no
+                Before=local-fs.target umount.target
+                After=swap.target
 
-              [Mount]
-              What=bpffs
-              Where=/sys/fs/bpf
-              Type=bpf
+                [Mount]
+                What=bpffs
+                Where=/sys/fs/bpf
+                Type=bpf
 
-              [Install]
-              WantedBy=multi-user.target
+                [Install]
+                WantedBy=multi-user.target
               EOF
 
-              if [ -d "/etc/systemd/system/" ]; then
-                mv /tmp/sys-fs-bpf.mount /etc/systemd/system/
-                echo "Installed sys-fs-bpf.mount to /etc/systemd/system/"
-              elif [ -d "/lib/systemd/system/" ]; then
-                mv /tmp/sys-fs-bpf.mount /lib/systemd/system/
-                echo "Installed sys-fs-bpf.mount to /lib/systemd/system/"
-              fi
+                if [ -d "/etc/systemd/system/" ]; then
+                  mv /tmp/sys-fs-bpf.mount /etc/systemd/system/
+                  echo "Installed sys-fs-bpf.mount to /etc/systemd/system/"
+                elif [ -d "/lib/systemd/system/" ]; then
+                  mv /tmp/sys-fs-bpf.mount /lib/systemd/system/
+                  echo "Installed sys-fs-bpf.mount to /lib/systemd/system/"
+                fi
 
-              # Ensure that filesystem gets mounted on next reboot
-              systemctl enable sys-fs-bpf.mount
-              systemctl start sys-fs-bpf.mount
+                # Ensure that filesystem gets mounted on next reboot
+                systemctl enable sys-fs-bpf.mount
+                systemctl start sys-fs-bpf.mount
+              }
 
               echo "Link information:"
               ip link


### PR DESCRIPTION
If the nodeinit script runs somewhere where the BPFFS is already
mounted, then it is highly likely that existing infrastructure handles
the auto-mounting of the BPF filesystem to /sys/fs/bpf, for instance
because they are running systemd 239 or later.

In this case, don't always create the BPFFS mount unit configuration for
systemd, otherwise systemd may reject it with:

    Failed to start sys-fs-bpf.mount:
    Unit sys-fs-bpf.mount has a bad unit file setting.

This is because systemd has deemed the BPFFS mounting to be within its
own domain of control, and that others should not configure it.

This caused issues in beta gcloud environments where the nodeinit would
fail because the systemd mount unit would not mount. This prevented
configuration of the kubelet on each node, meaning that Cilium would not
be configured as the CNI in the environment. However, the Cilium DS
itself would run, leading to situations where pods would attempt to
connect to remote services (eg kube-dns to the APIserver) and fail to
connect in an environment where the Cilium agents themselves otherwise
appear to be healthy. A cursory investigation of `cilium endpoint list`
in such environments would clearly show that no pods are being managed
by Cilium.

Fixes: #9556

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9959)
<!-- Reviewable:end -->