### PR TITLE
Revert "[CI] add timeout to vm boot retries"

### DIFF
--- a/flannel.Jenkinsfile
+++ b/flannel.Jenkinsfile
@@ -59,12 +59,10 @@ pipeline {
             }
             steps {
                 retry(3){
-                    timeout(time: 20, unit: 'MINUTES'){
-                        sh 'cd ${TESTDIR}; K8S_VERSION=1.10 vagrant destroy --force'
-                        sh 'cd ${TESTDIR}; K8S_VERSION=1.13 vagrant destroy --force'
-                        sh 'cd ${TESTDIR}; K8S_VERSION=1.10 vagrant up --no-provision'
-                        sh 'cd ${TESTDIR}; K8S_VERSION=1.13 vagrant up --no-provision'
-                    }
+                    sh 'cd ${TESTDIR}; K8S_VERSION=1.10 vagrant destroy --force'
+                    sh 'cd ${TESTDIR}; K8S_VERSION=1.13 vagrant destroy --force'
+                    sh 'cd ${TESTDIR}; K8S_VERSION=1.10 vagrant up --no-provision'
+                    sh 'cd ${TESTDIR}; K8S_VERSION=1.13 vagrant up --no-provision'
                 }
             }
         }

--- a/ginkgo-kubernetes-all.Jenkinsfile
+++ b/ginkgo-kubernetes-all.Jenkinsfile
@@ -118,10 +118,8 @@ pipeline {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
                         retry(3) {
-                            timeout(time: 20, unit: 'MINUTES'){
-                                dir("${TESTDIR}") {
-                                    sh './vagrant-ci-start.sh'
-                                }
+                            dir("${TESTDIR}") {
+                                sh './vagrant-ci-start.sh'
                             }
                         }
                     }
@@ -147,10 +145,8 @@ pipeline {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
                         retry(3) {
-                            timeout(time: 20, unit: 'MINUTES'){
-                                dir("${TESTDIR}") {
-                                    sh './vagrant-ci-start.sh'
-                                }
+                            dir("${TESTDIR}") {
+                                sh './vagrant-ci-start.sh'
                             }
                         }
                     }
@@ -255,10 +251,8 @@ pipeline {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
                         retry(3) {
-                            timeout(time: 20, unit: 'MINUTES'){
-                                dir("${TESTDIR}") {
-                                    sh './vagrant-ci-start.sh'
-                                }
+                            dir("${TESTDIR}") {
+                                sh './vagrant-ci-start.sh'
                             }
                         }
                     }
@@ -284,10 +278,8 @@ pipeline {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
                         retry(3) {
-                            timeout(time: 20, unit: 'MINUTES'){
-                                dir("${TESTDIR}") {
-                                    sh './vagrant-ci-start.sh'
-                                }
+                            dir("${TESTDIR}") {
+                                sh './vagrant-ci-start.sh'
                             }
                         }
                     }
@@ -391,10 +383,8 @@ pipeline {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
                         retry(3) {
-                            timeout(time: 20, unit: 'MINUTES'){
-                                dir("${TESTDIR}") {
-                                    sh './vagrant-ci-start.sh'
-                                }
+                            dir("${TESTDIR}") {
+                                sh './vagrant-ci-start.sh'
                             }
                         }
                     }

--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -112,10 +112,8 @@ pipeline {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
                         retry(3) {
-                            timeout(time: 20, unit: 'MINUTES'){
-                                sh 'cd ${TESTDIR}; vagrant destroy runtime --force'
-                                sh 'cd ${TESTDIR}; vagrant up runtime --provision'
-                            }
+                            sh 'cd ${TESTDIR}; vagrant destroy runtime --force'
+                            sh 'cd ${TESTDIR}; vagrant up runtime --provision'
                         }
                     }
                     post {
@@ -144,10 +142,8 @@ pipeline {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
                         retry(3) {
-                            timeout(time: 20, unit: 'MINUTES'){
-                                dir("${TESTDIR}") {
-                                    sh './vagrant-ci-start.sh'
-                                }
+                            dir("${TESTDIR}") {
+                                sh './vagrant-ci-start.sh'
                             }
                         }
                     }
@@ -175,10 +171,8 @@ pipeline {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
                         retry(3) {
-                            timeout(time: 20, unit: 'MINUTES'){
-                                dir("${TESTDIR}") {
-                                    sh './vagrant-ci-start.sh'
-                                }
+                            dir("${TESTDIR}") {
+                                sh './vagrant-ci-start.sh'
                             }
                         }
                     }

--- a/kubernetes-upstream.Jenkinsfile
+++ b/kubernetes-upstream.Jenkinsfile
@@ -73,12 +73,10 @@ pipeline {
 
             steps {
                 retry(3){
-                    timeout(time: 20, unit: 'MINUTES'){
-                        sh 'cd ${TESTDIR}; vagrant destroy k8s1-${K8S_VERSION} --force'
-                        sh 'cd ${TESTDIR}; vagrant destroy k8s2-${K8S_VERSION} --force'
-                        sh 'cd ${TESTDIR}; vagrant up k8s1-${K8S_VERSION}'
-                        sh 'cd ${TESTDIR}; vagrant up k8s2-${K8S_VERSION}'
-                    }
+                    sh 'cd ${TESTDIR}; vagrant destroy k8s1-${K8S_VERSION} --force'
+                    sh 'cd ${TESTDIR}; vagrant destroy k8s2-${K8S_VERSION} --force'
+                    sh 'cd ${TESTDIR}; vagrant up k8s1-${K8S_VERSION}'
+                    sh 'cd ${TESTDIR}; vagrant up k8s2-${K8S_VERSION}'
                 }
             }
         }


### PR DESCRIPTION
This reverts commit cbeb7c18e85a52522a5cc29f61b67692895644c5.

Due recent CI image updated, provisioning the VM has been slower since
such CI image is not cached which takes it more time provisioning
because it has to download such CI image. For this reason we should
increase the provisioning by 40 minutes to avoid CI failures.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9967)
<!-- Reviewable:end -->
