### PR TITLE
Dockerfile: add support for building for ARM64 architecture.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 #
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:a3385205ad620550b35d3b0b651e40898386e6e3 as cilium-envoy
+ARG CILIUM_ENVOY_SHA=a3385205ad620550b35d3b0b651e40898386e6e3
+FROM quay.io/cilium/cilium-envoy:$CILIUM_ENVOY_SHA as cilium-envoy
 
 #
 # Cilium incremental build. Should be fast given builder-deps is up-to-date!

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -45,7 +45,7 @@ ifeq ($(NOSTRIP),)
 	GOLDFLAGS += -s -w
 endif
 
-CILIUM_ENVOY_SHA=$(shell grep -o "FROM.*cilium/cilium-envoy:[0-9a-fA-F]*" $(ROOT_DIR)/Dockerfile | cut -d : -f 2)
+CILIUM_ENVOY_SHA=$(shell grep -o "^ARG CILIUM_ENVOY_SHA=[a-f0-9A-F]*" $(ROOT_DIR)/Dockerfile | cut -d = -f 2)
 GOLDFLAGS += -X "github.com/cilium/cilium/pkg/envoy.RequiredEnvoyVersionSHA=$(CILIUM_ENVOY_SHA)"
 
 BPF_FILES_EVAL := $(shell git ls-files $(ROOT_DIR)/bpf/ | grep -v .gitignore | tr "\n" ' ')

--- a/contrib/packaging/docker/Dockerfile.runtime
+++ b/contrib/packaging/docker/Dockerfile.runtime
@@ -7,6 +7,13 @@ apt-get upgrade -y && \
 #
 # Prepackaged Cilium runtime dependencies
 #
+dpkgArch="$(dpkg --print-architecture)"; \
+case "${dpkgArch##*-}" in \
+  arm64) libcdev="" ;; \
+  amd64) libcdev="libc6-dev-i386" ;; \
+  i386) libcdev="libc6-dev-i386" ;; \
+  *) libcdev="" ;; \
+esac; \
 apt-get install -y --no-install-recommends \
 # Additional iproute2 runtime dependencies
     libelf1 libmnl0 \
@@ -48,10 +55,10 @@ cd iproute2 && \
 make -j `getconf _NPROCESSORS_ONLN` && \
 strip tc/tc && \
 strip ip/ip && \
-cd .. && \
 #
 # clang/llvm image with only BPF backend
 #
+cd /tmp && \
 git clone -b master https://github.com/llvm/llvm-project.git llvm && \
 mkdir -p llvm/llvm/build/install && \
 cd llvm/ && \
@@ -63,19 +70,26 @@ strip bin/clang && \
 strip bin/llc && \
 cp bin/clang /usr/bin/clang && \
 cp bin/llc /usr/bin/llc && \
-cd ../../../ && \
 #
 # bpftool
 #
+cd /tmp && \
 git clone --depth 1 -b master git://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git linux && \
 cd linux/tools/bpf/bpftool/ && \
 make -j `getconf _NPROCESSORS_ONLN` && \
 strip bpftool && \
-cd ../../../../ && \
 #
 # cni/loopback
 #
-curl -sS -L https://github.com/containernetworking/plugins/releases/download/v0.7.5/cni-plugins-amd64-v0.7.5.tgz -o cni.tar.gz && \
+cd /tmp && \
+dpkgArch="$(dpkg --print-architecture)"; \
+case "${dpkgArch##*-}" in \
+  amd64) arch="amd64" ;; \
+  arm64) arch="arm64" ;; \
+  armhf) arch="arm" ;; \
+  i386) arch="amd64" ;; \
+esac; \
+curl -sS -L https://github.com/containernetworking/plugins/releases/download/v0.7.5/cni-plugins-${arch}-v0.7.5.tgz -o cni.tar.gz && \
 tar -xvf cni.tar.gz ./loopback && \
 strip -s ./loopback && \
 #
@@ -102,8 +116,17 @@ RUN go get -d github.com/google/gops && \
 cd /go/src/github.com/google/gops && \
 git checkout -b v0.3.6 v0.3.6 && \
 go install && \
-strip /go/bin/gops
-
+strip /go/bin/gops && \
+#
+# bpf-map
+#
+mkdir -p /go/src/github.com/cilium && \
+  cd /go/src/github.com/cilium && \
+  curl -L https://github.com/cilium/bpf-map/archive/v1.0.tar.gz -o bpfmap.tar.gz && \
+  tar -xzf bpfmap.tar.gz && \
+  cd bpf-map-1.0 && \
+  go build && \
+  strip bpf-map-1.0
 #
 # Stripped cilium runtime base image
 #
@@ -113,6 +136,7 @@ WORKDIR /bin
 COPY --from=runtime-build /tmp/iproute2/tc/tc /tmp/iproute2/ip/ip ./
 COPY --from=runtime-build /tmp/linux/tools/bpf/bpftool/bpftool ./
 COPY --from=runtime-build /tmp/llvm/llvm/build/bin/clang /tmp/llvm/llvm/build/bin/llc ./
+COPY --from=runtime-gobuild /go/src/github.com/cilium/bpf-map-1.0/bpf-map-1.0 ./bpf-map
 COPY --from=runtime-gobuild /go/bin/gops ./
 WORKDIR /cni
 COPY --from=runtime-build /tmp/loopback ./


### PR DESCRIPTION
Dockerfiles do not have good support for architecture based decisions
so case statements need to be used.

The changes:
- no libc6-dev-i386 on ARM
- cilium/bpf-map is built from source rather than downloading the binary
  image
- add more RUN statements so the whole package does not have to be
  rebuilt when fixing individual build stages.

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](http://docs.cilium.io/en/stable/contributing/contributing/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue. 
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](http://docs.cilium.io/en/stable/contributing/contributing/#dev-coo).
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #9898 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9969)
<!-- Reviewable:end -->
