### PR TITLE
Implement policy audit mode for the daemon

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -133,6 +133,7 @@ cilium-agent [flags]
       --nat46-range string                            IPv6 prefix to map IPv4 addresses to (default "0:0:0:0:0:FFFF::/96")
       --node-port-mode string                         BPF NodePort mode ("snat", "dsr", "hybrid") (default "hybrid")
       --node-port-range strings                       Set the min/max NodePort port range (default [30000,32767])
+      --policy-audit-mode                             Enable policy audit (non-drop) mode
       --policy-queue-size int                         size of queues for policy-related events (default 100)
       --pprof                                         Enable serving the pprof debugging API
       --preallocate-bpf-maps                          Enable BPF map pre-allocation (default true)

--- a/bpf/lib/policy.h
+++ b/bpf/lib/policy.h
@@ -189,8 +189,10 @@ policy_can_access_ingress(struct __ctx_buff *ctx, __u32 src_identity,
 
 	cilium_dbg(ctx, DBG_POLICY_DENIED, src_identity, SECLABEL);
 
-#ifdef IGNORE_DROP
-	ret = CTX_ACT_OK;
+#ifdef POLICY_AUDIT_MODE
+	if (IS_ERR(ret)) {
+		ret = CTX_ACT_OK;
+	}
 #endif
 
 	return ret;
@@ -223,8 +225,10 @@ policy_can_egress(struct __ctx_buff *ctx, __u32 identity, __u16 dport, __u8 prot
 
 	cilium_dbg(ctx, DBG_POLICY_DENIED, SECLABEL, identity);
 
-#ifdef IGNORE_DROP
-	ret = CTX_ACT_OK;
+#ifdef POLICY_AUDIT_MODE
+	if (IS_ERR(ret)) {
+		ret = CTX_ACT_OK;
+	}
 #endif
 
 	return ret;

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -728,6 +728,9 @@ func init() {
 	flags.Bool(option.DisableCNPStatusUpdates, false, `Do not send CNP NodeStatus updates to the Kubernetes api-server (recommended to run with "cnp-node-status-gc=false" in cilium-operator)`)
 	option.BindEnv(option.DisableCNPStatusUpdates)
 
+	flags.Bool(option.PolicyAuditModeArg, false, "Enable policy audit (non-drop) mode")
+	option.BindEnv(option.PolicyAuditModeArg)
+
 	viper.BindPFlags(flags)
 }
 
@@ -900,6 +903,7 @@ func initEnv(cmd *cobra.Command) {
 	option.Config.Opts.SetBool(option.Conntrack, !option.Config.DisableConntrack)
 	option.Config.Opts.SetBool(option.ConntrackAccounting, !option.Config.DisableConntrack)
 	option.Config.Opts.SetBool(option.ConntrackLocal, false)
+	option.Config.Opts.SetBool(option.PolicyAuditMode, option.Config.PolicyAuditMode)
 
 	monitorAggregationLevel, err := option.ParseMonitorAggregationLevel(option.Config.MonitorAggregation)
 	if err != nil {

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -335,6 +335,7 @@ data:
   enable-remote-node-identity: {{ .Values.global.remoteNodeIdentity | quote }}
 
   synchronize-k8s-nodes: {{ .Values.global.synchronizeK8sNodes | quote }}
+  policy-audit-mode: {{ .Values.global.policyAuditMode | quote }}
 
 {{- if .Values.global.ipv4.enabled }}
   operator-api-serve-addr: '127.0.0.1:9234'

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -354,3 +354,8 @@ global:
   # psp creates and binds PodSecurityPolicies for the components that require it
   psp:
     enabled: false
+
+  # enables non-drop mode for installed policies. In audit mode
+  # packets affected by policies will not be dropped. Policy related
+  # decisions can be checked via the poicy verdict messages.
+  policyAuditMode: false

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -274,6 +274,10 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		ctmap.WriteBPFMacros(fw, nil)
 	}
 
+	if option.Config.PolicyAuditMode {
+		cDefinesMap["POLICY_AUDIT_MODE"] = "1"
+	}
+
 	// Since golang maps are unordered, we sort the keys in the map
 	// to get a consistent writtern format to the writer. This maintains
 	// the consistency when we try to calculate hash for a datapath after

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -756,6 +756,9 @@ const (
 
 	// AzureResourceGroup is the resource group of the nodes used for the cluster
 	AzureResourceGroup = "azure-resource-group"
+
+	// PolicyAuditModeArg argument enables policy audit mode.
+	PolicyAuditModeArg = "policy-audit-mode"
 )
 
 // Default string arguments
@@ -1527,6 +1530,11 @@ type DaemonConfig struct {
 
 	// AzureResourceGroup is the resource group of the nodes used for the cluster
 	AzureResourceGroup string
+
+	// PolicyAuditMode enables non-drop mode for installed policies. In
+	// audit mode packets affected by policies will not be dropped.
+	// Policy related decisions can be checked via the poicy verdict messages.
+	PolicyAuditMode bool
 }
 
 var (
@@ -1984,6 +1992,7 @@ func (c *DaemonConfig) Populate() {
 	c.CTMapEntriesTimeoutSVCAny = viper.GetDuration(CTMapEntriesTimeoutSVCAnyName)
 	c.CTMapEntriesTimeoutSYN = viper.GetDuration(CTMapEntriesTimeoutSYNName)
 	c.CTMapEntriesTimeoutFIN = viper.GetDuration(CTMapEntriesTimeoutFINName)
+	c.PolicyAuditMode = viper.GetBool(PolicyAuditModeArg)
 
 	if nativeCIDR := viper.GetString(IPv4NativeRoutingCIDR); nativeCIDR != "" {
 		c.ipv4NativeRoutingCIDR = cidr.MustParseCIDR(nativeCIDR)

--- a/pkg/option/daemon.go
+++ b/pkg/option/daemon.go
@@ -34,6 +34,7 @@ var (
 		DropNotify:          &specDropNotify,
 		TraceNotify:         &specTraceNotify,
 		PolicyVerdictNotify: &specPolicyVerdictNotify,
+		PolicyAuditMode:     &specPolicyAuditMode,
 		MonitorAggregation:  &specMonitorAggregation,
 		NAT46:               &specNAT46,
 	}

--- a/pkg/option/endpoint.go
+++ b/pkg/option/endpoint.go
@@ -24,6 +24,7 @@ var (
 		DropNotify:          &specDropNotify,
 		TraceNotify:         &specTraceNotify,
 		PolicyVerdictNotify: &specPolicyVerdictNotify,
+		PolicyAuditMode:     &specPolicyAuditMode,
 		MonitorAggregation:  &specMonitorAggregation,
 		NAT46:               &specNAT46,
 	}

--- a/pkg/option/runtime_options.go
+++ b/pkg/option/runtime_options.go
@@ -28,6 +28,7 @@ const (
 	DropNotify          = "DropNotification"
 	TraceNotify         = "TraceNotification"
 	PolicyVerdictNotify = "PolicyVerdictNotification"
+	PolicyAuditMode     = "PolicyAuditMode"
 	MonitorAggregation  = "MonitorAggregationLevel"
 	NAT46               = "NAT46"
 	AlwaysEnforce       = "always"
@@ -82,6 +83,11 @@ var (
 	specPolicyVerdictNotify = Option{
 		Define:      "POLICY_VERDICT_NOTIFY",
 		Description: "Enable policy verdict notifications",
+	}
+
+	specPolicyAuditMode = Option{
+		Define:      "POLICY_AUDIT_MODE",
+		Description: "Enable audit mode for policies",
 	}
 
 	specMonitorAggregation = Option{


### PR DESCRIPTION
Network policies upon installation cause all non-whitelisted traffic
to be blocked. This patch introduces audit mode for the daemon that
will cause packets to not be dropped due to installed policies. Policy
decisions could be tracked via policy verdict messages.  Helm charts
were updates to support new configmap value.

related #9580

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9970)
<!-- Reviewable:end -->
