### PR TITLE
Revert "Revert "[CI] add timeout to vm boot retries""

### DIFF
--- a/flannel.Jenkinsfile
+++ b/flannel.Jenkinsfile
@@ -59,10 +59,12 @@ pipeline {
             }
             steps {
                 retry(3){
-                    sh 'cd ${TESTDIR}; K8S_VERSION=1.10 vagrant destroy --force'
-                    sh 'cd ${TESTDIR}; K8S_VERSION=1.13 vagrant destroy --force'
-                    sh 'cd ${TESTDIR}; K8S_VERSION=1.10 vagrant up --no-provision'
-                    sh 'cd ${TESTDIR}; K8S_VERSION=1.13 vagrant up --no-provision'
+                    timeout(time: 20, unit: 'MINUTES'){
+                        sh 'cd ${TESTDIR}; K8S_VERSION=1.10 vagrant destroy --force'
+                        sh 'cd ${TESTDIR}; K8S_VERSION=1.13 vagrant destroy --force'
+                        sh 'cd ${TESTDIR}; K8S_VERSION=1.10 vagrant up --no-provision'
+                        sh 'cd ${TESTDIR}; K8S_VERSION=1.13 vagrant up --no-provision'
+                    }
                 }
             }
         }

--- a/ginkgo-kubernetes-all.Jenkinsfile
+++ b/ginkgo-kubernetes-all.Jenkinsfile
@@ -118,8 +118,10 @@ pipeline {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
                         retry(3) {
-                            dir("${TESTDIR}") {
-                                sh './vagrant-ci-start.sh'
+                            timeout(time: 20, unit: 'MINUTES'){
+                                dir("${TESTDIR}") {
+                                    sh './vagrant-ci-start.sh'
+                                }
                             }
                         }
                     }
@@ -145,8 +147,10 @@ pipeline {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
                         retry(3) {
-                            dir("${TESTDIR}") {
-                                sh './vagrant-ci-start.sh'
+                            timeout(time: 20, unit: 'MINUTES'){
+                                dir("${TESTDIR}") {
+                                    sh './vagrant-ci-start.sh'
+                                }
                             }
                         }
                     }
@@ -251,8 +255,10 @@ pipeline {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
                         retry(3) {
-                            dir("${TESTDIR}") {
-                                sh './vagrant-ci-start.sh'
+                            timeout(time: 20, unit: 'MINUTES'){
+                                dir("${TESTDIR}") {
+                                    sh './vagrant-ci-start.sh'
+                                }
                             }
                         }
                     }
@@ -278,8 +284,10 @@ pipeline {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
                         retry(3) {
-                            dir("${TESTDIR}") {
-                                sh './vagrant-ci-start.sh'
+                            timeout(time: 20, unit: 'MINUTES'){
+                                dir("${TESTDIR}") {
+                                    sh './vagrant-ci-start.sh'
+                                }
                             }
                         }
                     }
@@ -383,8 +391,10 @@ pipeline {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
                         retry(3) {
-                            dir("${TESTDIR}") {
-                                sh './vagrant-ci-start.sh'
+                            timeout(time: 20, unit: 'MINUTES'){
+                                dir("${TESTDIR}") {
+                                    sh './vagrant-ci-start.sh'
+                                }
                             }
                         }
                     }

--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -112,8 +112,10 @@ pipeline {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
                         retry(3) {
-                            sh 'cd ${TESTDIR}; vagrant destroy runtime --force'
-                            sh 'cd ${TESTDIR}; vagrant up runtime --provision'
+                            timeout(time: 20, unit: 'MINUTES'){
+                                sh 'cd ${TESTDIR}; vagrant destroy runtime --force'
+                                sh 'cd ${TESTDIR}; vagrant up runtime --provision'
+                            }
                         }
                     }
                     post {
@@ -141,8 +143,10 @@ pipeline {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
                         retry(3) {
-                            dir("${TESTDIR}") {
-                                sh './vagrant-ci-start.sh'
+                            timeout(time: 20, unit: 'MINUTES'){
+                                dir("${TESTDIR}") {
+                                    sh './vagrant-ci-start.sh'
+                                }
                             }
                         }
                     }
@@ -169,8 +173,10 @@ pipeline {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
                         retry(3) {
-                            dir("${TESTDIR}") {
-                                sh './vagrant-ci-start.sh'
+                            timeout(time: 20, unit: 'MINUTES'){
+                                dir("${TESTDIR}") {
+                                    sh './vagrant-ci-start.sh'
+                                }
                             }
                         }
                     }

--- a/kubernetes-upstream.Jenkinsfile
+++ b/kubernetes-upstream.Jenkinsfile
@@ -73,10 +73,12 @@ pipeline {
 
             steps {
                 retry(3){
-                    sh 'cd ${TESTDIR}; vagrant destroy k8s1-${K8S_VERSION} --force'
-                    sh 'cd ${TESTDIR}; vagrant destroy k8s2-${K8S_VERSION} --force'
-                    sh 'cd ${TESTDIR}; vagrant up k8s1-${K8S_VERSION}'
-                    sh 'cd ${TESTDIR}; vagrant up k8s2-${K8S_VERSION}'
+                    timeout(time: 20, unit: 'MINUTES'){
+                        sh 'cd ${TESTDIR}; vagrant destroy k8s1-${K8S_VERSION} --force'
+                        sh 'cd ${TESTDIR}; vagrant destroy k8s2-${K8S_VERSION} --force'
+                        sh 'cd ${TESTDIR}; vagrant up k8s1-${K8S_VERSION}'
+                        sh 'cd ${TESTDIR}; vagrant up k8s2-${K8S_VERSION}'
+                    }
                 }
             }
         }


### PR DESCRIPTION
This reverts commit 7a5e082106a7bad95fa0ae368af7bbcf8a6419db.
This revert can be reverted because provisioning bug which caused CI
builds to always download vagrant boxes from aws was fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9976)
<!-- Reviewable:end -->
