### PR TITLE
CI: Add test for healthCheckNodePort in NodePort BPF

### DIFF
--- a/Documentation/gettingstarted/nodeport.rst
+++ b/Documentation/gettingstarted/nodeport.rst
@@ -66,9 +66,6 @@ has come up correctly:
 Limitations
 ###########
 
-    * Service's ``healthCheckNodePort`` is currently not supported. See
-      `GH issue 8699 <https://github.com/cilium/cilium/issues/8699>`_ for
-      additional details.
     * NodePort services are currently exposed through the native device which has
       the default route on the host or a user specified device. In tunneling mode,
       they are additionally exposed through the tunnel interface (``cilium_vxlan``

--- a/test/k8sT/manifests/demo_ds.yaml
+++ b/test/k8sT/manifests/demo_ds.yaml
@@ -164,3 +164,18 @@ spec:
     name: http
   selector:
     zgroup: testDS
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-lb-local-k8s2
+spec:
+  type: LoadBalancer
+  externalTrafficPolicy: Local
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+    name: http
+  selector:
+    zgroup: test-k8s2


### PR DESCRIPTION
- Adds a test that the HTTP server running on `HealthCheckNodePort` returns the correct HTTP code. We add a new service for this, since only services with `Type=LoadBalancer` and `externalTrafficPolicy=Local` will have the `healthCheckNodePort` field set.
- Updates documentation to remove `healthCheckNodePort` from the list of NodePort BPF limitations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9977)
<!-- Reviewable:end -->
