### PR TITLE
test: Increase VM provisioning timeout for k8s-1.11 net-next job

### DIFF
--- a/ginkgo.Jenkinsfile
+++ b/ginkgo.Jenkinsfile
@@ -145,7 +145,7 @@ pipeline {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
                         sh 'cp -a ${WORKSPACE}/${PROJ_PATH} ${GOPATH}/${PROJ_PATH}'
                         retry(3) {
-                            timeout(time: 20, unit: 'MINUTES'){
+                            timeout(time: 30, unit: 'MINUTES'){
                                 dir("${TESTDIR}") {
                                     sh './vagrant-ci-start.sh'
                                 }


### PR DESCRIPTION
As we introduced the third VM to the job, provisioning takes longer. So, increment the timeout by 10min (previously, with two VMs it was 20min).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9980)
<!-- Reviewable:end -->
