### PR TITLE
test: set image tag of cilium/cilium-builder to 2020-01-14

### DIFF
--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     command: "etcd -name etcd0 -advertise-client-urls http://0.0.0.0:4002 -listen-client-urls http://0.0.0.0:4002 -initial-cluster-token etcd-cluster-1 -initial-cluster-state new"
     privileged: true
   base_image:
-    image: "quay.io/cilium/cilium-builder:2019-12-11"
+    image: "quay.io/cilium/cilium-builder:2020-01-14"
     volumes:
       - "./../:/go/src/github.com/cilium/cilium/"
     privileged: true


### PR DESCRIPTION
Fixes: 269d9df32074 ("golang: update to 1.13.6")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9983)
<!-- Reviewable:end -->
