### PR TITLE
daemon: Add --kube-proxy-replacement flag

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -54,6 +54,7 @@ cilium-agent [flags]
       --egress-masquerade-interfaces string                   Limit egress masquerading to interface selector
       --enable-endpoint-health-checking                       Enable connectivity health checking between virtual endpoints (default true)
       --enable-endpoint-routes                                Use per endpoint routes instead of routing via cilium_host
+      --enable-external-ips                                   Enable k8s service externalIPs feature (requires enabling enable-node-port) (default true)
       --enable-health-checking                                Enable connectivity health checking (default true)
       --enable-host-reachable-services                        Enable reachability of services for host applications (beta)
       --enable-ipsec                                          Enable IPSec support
@@ -61,7 +62,6 @@ cilium-agent [flags]
       --enable-ipv6                                           Enable IPv6 support (default true)
       --enable-k8s-endpoint-slice                             Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
       --enable-k8s-event-handover                             Enable k8s event handover to kvstore for improved scalability
-      --enable-k8s-external-ips                               Enable k8s externalIPs feature (Only enabled in conjunction with enable-node-port) (default true)
       --enable-l7-proxy                                       Enable L7 proxy for L7 policy enforcement (default true)
       --enable-local-node-route                               Enable installation of the route which points the allocation prefix of the local node (default true)
       --enable-node-port                                      Enable NodePort type services by Cilium (beta)

--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -113,6 +113,7 @@ cilium-agent [flags]
       --k8s-watcher-queue-size uint                           Queue size used to serialize each k8s event type (default 1024)
       --keep-bpf-templates                                    Do not restore BPF template files from binary
       --keep-config                                           When restoring state, keeps containers' configuration in place
+      --kube-proxy-replacement string                         auto-enable available features for kube-proxy replacement ("probe"), or enable only selected features (will panic if any selected feature cannot be enabled) ("partial") or enable all features (will panic if any feature cannot be enabled) ("strict"), or completely disable it (ignores any selected feature) ("disabled") (default "partial")
       --kvstore string                                        Key-value store type
       --kvstore-connectivity-timeout duration                 Time after which an incomplete kvstore operation  is considered failed (default 2m0s)
       --kvstore-opt map                                       Key-value store options (default map[])

--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -406,6 +406,18 @@ New ConfigMap Options
     modify those policy rules to explicitly allow the entity ``remote-node``
     and then enable this flag as you upgrade.
 
+  * ``kube-proxy-replacement`` has been added to control which features should
+    be enabled for the kube-proxy BPF replacement. The option is set to
+    ``probe`` by default for new deployments when generated via Helm. This
+    makes cilium-agent to probe for each feature support in a kernel, and
+    to enable only supported features. When the option is not set via Helm,
+    cilium-agent defaults to ``partial``. This makes ``cilium-agent`` to
+    enable only those features which user has explicitly enabled in their
+    ConfigMap. See :ref:`kubeproxy-free` for more option values.
+
+    For users who previously were running with ``nodePort.enabled=true`` it is
+    recommended to set the option to ``strict`` before upgrading.
+
 Removed options
 ~~~~~~~~~~~~~~~~~~
 

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -333,8 +333,8 @@ func init() {
 	flags.String(option.EnablePolicy, option.DefaultEnforcement, "Enable policy enforcement")
 	option.BindEnv(option.EnablePolicy)
 
-	flags.Bool(option.EnableK8sExternalIPs, defaults.EnableK8sExternalIPs, fmt.Sprintf("Enable k8s externalIPs feature (Only enabled in conjunction with %s)", option.EnableNodePort))
-	option.BindEnv(option.EnableK8sExternalIPs)
+	flags.Bool(option.EnableExternalIPs, defaults.EnableExternalIPs, fmt.Sprintf("Enable k8s service externalIPs feature (requires enabling %s)", option.EnableNodePort))
+	option.BindEnv(option.EnableExternalIPs)
 
 	flags.Bool(option.K8sEnableEndpointSlice, defaults.K8sEnableEndpointSlice, "Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it")
 	option.BindEnv(option.K8sEnableEndpointSlice)

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/datapath/iptables"
 	linuxdatapath "github.com/cilium/cilium/pkg/datapath/linux"
+	"github.com/cilium/cilium/pkg/datapath/linux/probes"
 	"github.com/cilium/cilium/pkg/datapath/maps"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/envoy"
@@ -481,6 +482,15 @@ func init() {
 
 	flags.StringSlice(option.Labels, []string{}, "List of label prefixes used to determine identity of an endpoint")
 	option.BindEnv(option.Labels)
+
+	flags.String(option.KubeProxyReplacement, option.KubeProxyReplacementPartial, fmt.Sprintf(
+		"auto-enable available features for kube-proxy replacement (%q), "+
+			"or enable only selected features (will panic if any selected feature cannot be enabled) (%q) "+
+			"or enable all features (will panic if any feature cannot be enabled) (%q), "+
+			"or completely disable it (ignores any selected feature) (%q)",
+		option.KubeProxyReplacementProbe, option.KubeProxyReplacementPartial,
+		option.KubeProxyReplacementStrict, option.KubeProxyReplacementDisabled))
+	option.BindEnv(option.KubeProxyReplacement)
 
 	flags.Bool(option.EnableNodePort, false, "Enable NodePort type services by Cilium (beta)")
 	option.BindEnv(option.EnableNodePort)
@@ -1055,7 +1065,7 @@ func initEnv(cmd *cobra.Command) {
 		}
 	}
 
-	initKubeProxyFreeOptions()
+	initKubeProxyReplacementOptions()
 
 	// If device has been specified, use it to derive better default
 	// allocation prefixes
@@ -1407,26 +1417,103 @@ func (d *Daemon) instantiateAPI() *restapi.CiliumAPI {
 	return api
 }
 
-func initKubeProxyFreeOptions() {
-	if option.Config.EnableNodePort &&
-		!(option.Config.EnableHostReachableServices &&
-			option.Config.EnableHostServicesTCP && option.Config.EnableHostServicesUDP) {
-		// We enable host reachable services in order to allow
-		// access to node port services from the host.
-		log.Info("Auto-enabling host reachable services for UDP and TCP as required by BPF NodePort.")
+func initKubeProxyReplacementOptions() {
+	if option.Config.KubeProxyReplacement != option.KubeProxyReplacementStrict &&
+		option.Config.KubeProxyReplacement != option.KubeProxyReplacementPartial &&
+		option.Config.KubeProxyReplacement != option.KubeProxyReplacementProbe &&
+		option.Config.KubeProxyReplacement != option.KubeProxyReplacementDisabled {
+		log.Fatalf("Invalid value for --%s: %s", option.KubeProxyReplacement, option.Config.KubeProxyReplacement)
+	}
+
+	if option.Config.KubeProxyReplacement == option.KubeProxyReplacementDisabled {
+		log.Infof("Auto-disabling %q, %q, %q features", option.EnableNodePort,
+			option.EnableExternalIPs, option.EnableHostReachableServices)
+
+		option.Config.EnableNodePort = false
+		option.Config.EnableExternalIPs = false
+		option.Config.EnableHostReachableServices = false
+		option.Config.EnableHostServicesTCP = false
+		option.Config.EnableHostServicesUDP = false
+		option.Config.DisableK8sServices = true
+
+		return
+	}
+
+	// strict denotes to panic if any to-be enabled feature cannot be enabled
+	strict := option.Config.KubeProxyReplacement != option.KubeProxyReplacementProbe
+
+	if option.Config.KubeProxyReplacement == option.KubeProxyReplacementProbe ||
+		option.Config.KubeProxyReplacement == option.KubeProxyReplacementStrict {
+
+		log.Infof("Auto-enabling %q, %q, %q features", option.EnableNodePort,
+			option.EnableExternalIPs, option.EnableHostReachableServices)
+
+		option.Config.EnableNodePort = true
+		option.Config.EnableExternalIPs = true
 		option.Config.EnableHostReachableServices = true
 		option.Config.EnableHostServicesTCP = true
 		option.Config.EnableHostServicesUDP = true
+		option.Config.DisableK8sServices = false
+	}
+
+	if option.Config.EnableNodePort {
+		if option.Config.EnableIPSec {
+			msg := "IPSec cannot be used with NodePort BPF."
+			if strict {
+				log.Fatal(msg)
+			} else {
+				option.Config.EnableNodePort = false
+				option.Config.EnableExternalIPs = false
+				log.Warn(msg + " Disabling the feature.")
+			}
+		}
+
+		if option.Config.NodePortMode != "dsr" && option.Config.NodePortMode != "snat" {
+			log.Fatalf("Invalid value for --%s: %s", option.NodePortMode, option.Config.NodePortMode)
+		}
+
+		if option.Config.NodePortMode == "dsr" && option.Config.Tunnel != option.TunnelDisabled {
+			// Currently, DSR does not work in the tunnel mode. Once it's fixed,
+			// the constraint can be removed.
+			log.Fatal("DSR cannot be used with tunnel")
+		}
+	}
+
+	if option.Config.EnableNodePort {
+		found := false
+		if h := probes.NewProbeManager().GetHelpers("sched_act"); h != nil {
+			if _, ok := h["bpf_fib_lookup"]; ok {
+				found = true
+			}
+		}
+		if !found {
+			msg := "BPF NodePort services needs kernel 4.17.0 or newer."
+			if strict {
+				log.Fatal(msg)
+			} else {
+				log.Warn(msg + " Disabling the feature.")
+				option.Config.EnableNodePort = false
+				option.Config.EnableExternalIPs = false
+			}
+		}
 	}
 
 	if option.Config.EnableNodePort && option.Config.Device == "undefined" {
 		device, err := linuxdatapath.NodeDeviceNameWithDefaultRoute()
 		if err != nil {
-			log.WithError(err).Fatal("BPF NodePort's external facing device could not be determined. Use --device to specify.")
+			msg := "BPF NodePort's external facing device could not be determined. Use --device to specify."
+			if strict {
+				log.WithError(err).Fatal(msg)
+			} else {
+				log.WithError(err).Warn(msg + " Disabling BPF NodePort feature.")
+				option.Config.EnableNodePort = false
+				option.Config.EnableExternalIPs = false
+			}
+		} else {
+			log.WithField(logfields.Interface, device).
+				Info("Using auto-derived device for BPF node port")
+			option.Config.Device = device
 		}
-		log.WithField(logfields.Interface, device).
-			Info("Using auto-derived device for BPF node port")
-		option.Config.Device = device
 	}
 
 	if option.Config.EnableHostReachableServices {
@@ -1437,26 +1524,27 @@ func initKubeProxyFreeOptions() {
 		if option.Config.EnableHostServicesTCP &&
 			(option.Config.EnableIPv4 && bpf.TestDummyProg(bpf.ProgTypeCgroupSockAddr, bpf.BPF_CGROUP_INET4_CONNECT) != nil ||
 				option.Config.EnableIPv6 && bpf.TestDummyProg(bpf.ProgTypeCgroupSockAddr, bpf.BPF_CGROUP_INET6_CONNECT) != nil) {
-			log.Fatal("BPF host reachable services for TCP needs kernel 4.17.0 or newer.")
+			msg := "BPF host reachable services for TCP needs kernel 4.17.0 or newer."
+			if strict {
+				log.Fatal(msg)
+			} else {
+				option.Config.EnableHostServicesTCP = false
+				log.Warn(msg + " Disabling the feature.")
+			}
 		}
 		if option.Config.EnableHostServicesUDP &&
 			(option.Config.EnableIPv4 && bpf.TestDummyProg(bpf.ProgTypeCgroupSockAddr, bpf.BPF_CGROUP_UDP4_RECVMSG) != nil ||
 				option.Config.EnableIPv6 && bpf.TestDummyProg(bpf.ProgTypeCgroupSockAddr, bpf.BPF_CGROUP_UDP6_RECVMSG) != nil) {
-			log.Fatal("BPF host reachable services for UDP needs kernel 4.19.57, 5.1.16, 5.2.0 or newer. If you run an older kernel and only need TCP, then specify: --host-reachable-services-protos=tcp")
+			msg := "BPF host reachable services for UDP needs kernel 4.19.57, 5.1.16, 5.2.0 or newer. If you run an older kernel and only need TCP, then specify: --host-reachable-services-protos=tcp"
+			if strict {
+				log.Fatal(msg)
+			} else {
+				option.Config.EnableHostServicesUDP = false
+				log.Warn(msg + " Disabling the feature.")
+			}
 		}
-	}
-
-	if option.Config.EnableNodePort {
-		if option.Config.NodePortMode != "dsr" && option.Config.NodePortMode != "snat" {
-			log.Fatalf("Invalid value for --node-port-mode option: %s", option.Config.NodePortMode)
+		if !option.Config.EnableHostServicesTCP && !option.Config.EnableHostServicesUDP {
+			option.Config.EnableHostReachableServices = false
 		}
-
-		if option.Config.NodePortMode == "dsr" && option.Config.Tunnel != option.TunnelDisabled {
-			log.Fatal("DSR cannot be used with tunnel")
-		}
-	}
-
-	if option.Config.EnableNodePort && option.Config.EnableIPSec {
-		log.Fatal("IPSec cannot be used with NodePort BPF")
 	}
 }

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -1055,60 +1055,7 @@ func initEnv(cmd *cobra.Command) {
 		}
 	}
 
-	if option.Config.EnableNodePort &&
-		!(option.Config.EnableHostReachableServices &&
-			option.Config.EnableHostServicesTCP && option.Config.EnableHostServicesUDP) {
-		// We enable host reachable services in order to allow
-		// access to node port services from the host.
-		log.Info("Auto-enabling host reachable services for UDP and TCP as required by BPF NodePort.")
-		option.Config.EnableHostReachableServices = true
-		option.Config.EnableHostServicesTCP = true
-		option.Config.EnableHostServicesUDP = true
-	}
-
-	if option.Config.EnableNodePort && option.Config.Device == "undefined" {
-		device, err := linuxdatapath.NodeDeviceNameWithDefaultRoute()
-		if err != nil {
-			log.WithError(err).Fatal("BPF NodePort's external facing device could not be determined. Use --device to specify.")
-		}
-		log.WithField(logfields.Interface, device).
-			Info("Using auto-derived device for BPF node port")
-		option.Config.Device = device
-	}
-
-	if option.Config.EnableHostReachableServices {
-		// Try to auto-load IPv6 module if it hasn't been done yet as there can
-		// be v4-in-v6 connections even if the agent has v6 support disabled.
-		probe.HaveIPv6Support()
-
-		if option.Config.EnableHostServicesTCP &&
-			(option.Config.EnableIPv4 && bpf.TestDummyProg(bpf.ProgTypeCgroupSockAddr, bpf.BPF_CGROUP_INET4_CONNECT) != nil ||
-				option.Config.EnableIPv6 && bpf.TestDummyProg(bpf.ProgTypeCgroupSockAddr, bpf.BPF_CGROUP_INET6_CONNECT) != nil) {
-			log.Fatal("BPF host reachable services for TCP needs kernel 4.17.0 or newer.")
-		}
-		// NOTE: as host-lb is a hard dependency for NodePort BPF, the following
-		//       probe will catch if the fib_lookup helper is missing (< 4.18),
-		//       which is another hard dependency for NodePort BPF.
-		if option.Config.EnableHostServicesUDP &&
-			(option.Config.EnableIPv4 && bpf.TestDummyProg(bpf.ProgTypeCgroupSockAddr, bpf.BPF_CGROUP_UDP4_RECVMSG) != nil ||
-				option.Config.EnableIPv6 && bpf.TestDummyProg(bpf.ProgTypeCgroupSockAddr, bpf.BPF_CGROUP_UDP6_RECVMSG) != nil) {
-			log.Fatal("BPF host reachable services for UDP needs kernel 4.19.57, 5.1.16, 5.2.0 or newer. If you run an older kernel and only need TCP, then specify: --host-reachable-services-protos=tcp")
-		}
-	}
-
-	if option.Config.EnableNodePort {
-		if option.Config.NodePortMode != "dsr" && option.Config.NodePortMode != "snat" {
-			log.Fatalf("Invalid value for --node-port-mode option: %s", option.Config.NodePortMode)
-		}
-
-		if option.Config.NodePortMode == "dsr" && option.Config.Tunnel != option.TunnelDisabled {
-			log.Fatal("DSR cannot be used with tunnel")
-		}
-	}
-
-	if option.Config.EnableNodePort && option.Config.EnableIPSec {
-		log.Fatal("IPSec cannot be used with NodePort BPF")
-	}
+	initKubeProxyFreeOptions()
 
 	// If device has been specified, use it to derive better default
 	// allocation prefixes
@@ -1458,4 +1405,58 @@ func (d *Daemon) instantiateAPI() *restapi.CiliumAPI {
 	api.PolicyGetIPHandler = NewGetIPHandler()
 
 	return api
+}
+
+func initKubeProxyFreeOptions() {
+	if option.Config.EnableNodePort &&
+		!(option.Config.EnableHostReachableServices &&
+			option.Config.EnableHostServicesTCP && option.Config.EnableHostServicesUDP) {
+		// We enable host reachable services in order to allow
+		// access to node port services from the host.
+		log.Info("Auto-enabling host reachable services for UDP and TCP as required by BPF NodePort.")
+		option.Config.EnableHostReachableServices = true
+		option.Config.EnableHostServicesTCP = true
+		option.Config.EnableHostServicesUDP = true
+	}
+
+	if option.Config.EnableNodePort && option.Config.Device == "undefined" {
+		device, err := linuxdatapath.NodeDeviceNameWithDefaultRoute()
+		if err != nil {
+			log.WithError(err).Fatal("BPF NodePort's external facing device could not be determined. Use --device to specify.")
+		}
+		log.WithField(logfields.Interface, device).
+			Info("Using auto-derived device for BPF node port")
+		option.Config.Device = device
+	}
+
+	if option.Config.EnableHostReachableServices {
+		// Try to auto-load IPv6 module if it hasn't been done yet as there can
+		// be v4-in-v6 connections even if the agent has v6 support disabled.
+		probe.HaveIPv6Support()
+
+		if option.Config.EnableHostServicesTCP &&
+			(option.Config.EnableIPv4 && bpf.TestDummyProg(bpf.ProgTypeCgroupSockAddr, bpf.BPF_CGROUP_INET4_CONNECT) != nil ||
+				option.Config.EnableIPv6 && bpf.TestDummyProg(bpf.ProgTypeCgroupSockAddr, bpf.BPF_CGROUP_INET6_CONNECT) != nil) {
+			log.Fatal("BPF host reachable services for TCP needs kernel 4.17.0 or newer.")
+		}
+		if option.Config.EnableHostServicesUDP &&
+			(option.Config.EnableIPv4 && bpf.TestDummyProg(bpf.ProgTypeCgroupSockAddr, bpf.BPF_CGROUP_UDP4_RECVMSG) != nil ||
+				option.Config.EnableIPv6 && bpf.TestDummyProg(bpf.ProgTypeCgroupSockAddr, bpf.BPF_CGROUP_UDP6_RECVMSG) != nil) {
+			log.Fatal("BPF host reachable services for UDP needs kernel 4.19.57, 5.1.16, 5.2.0 or newer. If you run an older kernel and only need TCP, then specify: --host-reachable-services-protos=tcp")
+		}
+	}
+
+	if option.Config.EnableNodePort {
+		if option.Config.NodePortMode != "dsr" && option.Config.NodePortMode != "snat" {
+			log.Fatalf("Invalid value for --node-port-mode option: %s", option.Config.NodePortMode)
+		}
+
+		if option.Config.NodePortMode == "dsr" && option.Config.Tunnel != option.TunnelDisabled {
+			log.Fatal("DSR cannot be used with tunnel")
+		}
+	}
+
+	if option.Config.EnableNodePort && option.Config.EnableIPSec {
+		log.Fatal("IPSec cannot be used with NodePort BPF")
+	}
 }

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -260,6 +260,9 @@ data:
 
   install-iptables-rules: {{ .Values.global.installIptablesRules | quote }}
   auto-direct-node-routes: {{ .Values.global.autoDirectNodeRoutes | quote }}
+{{- if .Values.global.kubeProxyReplacement }}
+  kube-proxy-replacement:  {{ .Values.global.kubeProxyReplacement | quote }}
+{{- end}}
 {{- if .Values.global.nodePort }}
   enable-node-port: {{ .Values.global.nodePort.enabled | quote }}
 {{- if .Values.global.nodePort.range }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -225,6 +225,9 @@ global:
     # protocols is the list of protocols to support
     protocols: tcp,udp
 
+  # kubeProxyReplacement enables kube-proxy replacement in Cilium BPF datapath
+  kubeProxyReplacement: "probe"
+
   # nodePort is the nodeport configuration
   nodePort:
     # enabled enables NodePort functionality

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -121,6 +121,7 @@ data:
 
   install-iptables-rules: "true"
   auto-direct-node-routes: "false"
+  kube-proxy-replacement:  "probe"
   enable-node-port: "false"
   enable-well-known-identities: "false"
   enable-remote-node-identity: "true"

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -247,7 +247,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 
 	if option.Config.EnableNodePort {
 		cDefinesMap["ENABLE_NODEPORT"] = "1"
-		if option.Config.EnableK8sExternalIPs {
+		if option.Config.EnableExternalIPs {
 			cDefinesMap["ENABLE_EXTERNAL_IP"] = "1"
 		}
 		cDefinesMap["NODEPORT_PORT_MIN"] = fmt.Sprintf("%d", option.Config.NodePortMin)

--- a/pkg/datapath/linux/probes/probes.go
+++ b/pkg/datapath/linux/probes/probes.go
@@ -119,6 +119,7 @@ type MapTypes struct {
 type Features struct {
 	SystemConfig `json:"system_config"`
 	MapTypes     `json:"map_types"`
+	Helpers      map[string][]string `json:"helpers"`
 }
 
 // ProbeManager is a manager of BPF feature checks.
@@ -198,4 +199,20 @@ func (p *ProbeManager) SystemConfigProbes() error {
 // GetMapTypes returns information about supported BPF map types.
 func (p *ProbeManager) GetMapTypes() *MapTypes {
 	return &p.features.MapTypes
+}
+
+// GetHelpers returns information about available BPF helpers for the given
+// program type.
+// If program type is not found, returns nil.
+func (p *ProbeManager) GetHelpers(prog string) map[string]struct{} {
+	for p, helpers := range p.features.Helpers {
+		if prog+"_available_helpers" == p {
+			ret := map[string]struct{}{}
+			for _, h := range helpers {
+				ret[h] = struct{}{}
+			}
+			return ret
+		}
+	}
+	return nil
 }

--- a/pkg/datapath/linux/probes/probes_privileged_test.go
+++ b/pkg/datapath/linux/probes/probes_privileged_test.go
@@ -42,3 +42,9 @@ func (s *ProbesPrivTestSuite) TestMapTypes(c *C) {
 	mapTypes := pm.GetMapTypes()
 	c.Assert(mapTypes, NotNil)
 }
+
+func (s *ProbesPrivTestSuite) TestHelpers(c *C) {
+	pm := NewProbeManager()
+	_, ok := pm.GetHelpers("sched_act")["bpf_map_lookup_elem"]
+	c.Assert(ok, Equals, true)
+}

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -132,8 +132,8 @@ const (
 	// EnableL7Proxy is the default value for L7 proxy enablement
 	EnableL7Proxy = true
 
-	// EnableK8sExternalIPs is the default value for k8s externalIPs feature.
-	EnableK8sExternalIPs = true
+	// EnableExternalIPs is the default value for k8s service with externalIPs feature.
+	EnableExternalIPs = true
 
 	// K8sEnableEndpointSlice is the default value for k8s EndpointSlice feature.
 	K8sEnableEndpointSlice = true

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -144,8 +144,8 @@ const (
 	// EnablePolicy enables policy enforcement in the agent.
 	EnablePolicy = "enable-policy"
 
-	// EnableK8sExternalIPs enables k8s external IPs feature into Cilium datapath.
-	EnableK8sExternalIPs = "enable-k8s-external-ips"
+	// EnableExternalIPs enables implementation of k8s services with externalIPs in datapath
+	EnableExternalIPs = "enable-external-ips"
 
 	// K8sEnableEndpointSlice enables the k8s EndpointSlice feature into Cilium
 	K8sEnableEndpointSlice = "enable-k8s-endpoint-slice"
@@ -1247,8 +1247,8 @@ type DaemonConfig struct {
 	// ("snat" or "dsr")
 	NodePortMode string
 
-	// EnableK8sExternalIPs enables k8s external IPs implementation in BPF
-	EnableK8sExternalIPs bool
+	// EnableExternalIPs enables implementation of k8s services with externalIPs in datapath
+	EnableExternalIPs bool
 
 	// K8sEnableEndpointSlice enables k8s endpoint slice feature that is used
 	// in kubernetes.
@@ -1669,7 +1669,7 @@ func (c *DaemonConfig) Populate() {
 	c.EnableEndpointHealthChecking = viper.GetBool(EnableEndpointHealthChecking)
 	c.EnableLocalNodeRoute = viper.GetBool(EnableLocalNodeRoute)
 	c.EnablePolicy = strings.ToLower(viper.GetString(EnablePolicy))
-	c.EnableK8sExternalIPs = viper.GetBool(EnableK8sExternalIPs)
+	c.EnableExternalIPs = viper.GetBool(EnableExternalIPs)
 	c.EnableL7Proxy = viper.GetBool(EnableL7Proxy)
 	c.EnableTracing = viper.GetBool(EnableTracing)
 	c.EnableNodePort = viper.GetBool(EnableNodePort)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -244,6 +244,10 @@ const (
 	// ("snat" or "dsr")
 	NodePortMode = "node-port-mode"
 
+	// KubeProxyReplacement controls how to enable kube-proxy replacement
+	// features in BPF datapath
+	KubeProxyReplacement = "kube-proxy-replacement"
+
 	// NodePortRange defines a custom range where to look up NodePort services
 	NodePortRange = "node-port-range"
 
@@ -755,6 +759,22 @@ const (
 
 	// NodePortMaxDefault is the maximum port to listen for NodePort requests
 	NodePortMaxDefault = 32767
+
+	// KubeProxyReplacementProbe specifies to auto-enable available features for
+	// kube-proxy replacement
+	KubeProxyReplacementProbe = "probe"
+
+	// KubeProxyReplacementPartial specifies to enable only selected kube-proxy
+	// replacement features (might panic)
+	KubeProxyReplacementPartial = "partial"
+
+	// KubeProxyReplacementStrict specifies to enable all kube-proxy replacement
+	// features (might panic)
+	KubeProxyReplacementStrict = "strict"
+
+	// KubeProxyReplacementDisabled specified to completely disable kube-proxy
+	// replacement
+	KubeProxyReplacementDisabled = "disabled"
 )
 
 // GetTunnelModes returns the list of all tunnel modes
@@ -1247,6 +1267,10 @@ type DaemonConfig struct {
 	// ("snat" or "dsr")
 	NodePortMode string
 
+	// KubeProxyReplacement controls how to enable kube-proxy replacement
+	// features in BPF datapath
+	KubeProxyReplacement string
+
 	// EnableExternalIPs enables implementation of k8s services with externalIPs in datapath
 	EnableExternalIPs bool
 
@@ -1674,6 +1698,7 @@ func (c *DaemonConfig) Populate() {
 	c.EnableTracing = viper.GetBool(EnableTracing)
 	c.EnableNodePort = viper.GetBool(EnableNodePort)
 	c.NodePortMode = viper.GetString(NodePortMode)
+	c.KubeProxyReplacement = viper.GetString(KubeProxyReplacement)
 	c.EncryptInterface = viper.GetString(EncryptInterface)
 	c.EncryptNode = viper.GetBool(EncryptNode)
 	c.EnvoyLogPath = viper.GetString(EnvoyLog)

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1362,10 +1362,10 @@ func (kub *Kubectl) generateCiliumYaml(options map[string]string, filename strin
 		}
 
 		opts := map[string]string{
-			"global.nodePort.device":  PrivateIface,
-			"global.nodePort.enabled": "true",
-			"global.k8sServiceHost":   nodeIP,
-			"global.k8sServicePort":   "6443",
+			"global.kubeProxyReplacement": "strict",
+			"global.nodePort.device":      PrivateIface,
+			"global.k8sServiceHost":       nodeIP,
+			"global.k8sServicePort":       "6443",
 		}
 		for key, value := range opts {
 			options = addIfNotOverwritten(options, key, value)


### PR DESCRIPTION
This PR:
- Introduces the agent's `--kube-proxy-replacement` flag. The flag controls what / how datapath features required for the kube-proxy replacement enabled. The possible outcomes depending on a value of the flag are the following:
    - "probe": auto-enable all available features for kube-proxy replacement (agent probes for features and tries to enable them without panicking if any cannot be enabled).
    - "strict": enable all features (panic if any cannot be enabled).
    - "partial": enable only selected by a user features (panic if any of the selected ones cannot be enabled).
    - "disabled": disable all kube-proxy replacement features (even those which user has enabled).

- Introduces the `kubeProxyReplacement` helm var (defaults to `"probe"`).
- Adds a probe for the NodePort feature.

The upgrade considerations:

- New users will have the kube-proxy replacement auto-enabled (`"probe"`) due to the helm var default value.
- Existing users are encouraged via the upgrade guide to set the option to `"strict"` if previously they were running with `enable-node-port=true`

Reviewable per commit.

The docs update and showing which features are enabled from `cilium status` will be added as a follow-up (once we finally decide on the flag name and its semantics).

```release-note
Add --kube-proxy-replacement flag to control enabling of kube-proxy replacement in BPF
```

Fixes #9729

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9992)
<!-- Reviewable:end -->
