### PR TITLE
test/K8sServices: Add Tests for UDP connectivity

### DIFF
--- a/test/helpers/wrappers.go
+++ b/test/helpers/wrappers.go
@@ -106,13 +106,22 @@ func Netcat(endpoint string, optionalValues ...interface{}) string {
 // PythonBind returns the string representing a python3 command which will try
 // to bind a socket on the given address and port. Python is available in the
 // log-gatherer pod.
-func PythonBind(addr string, port uint16) string {
-	family := "socket.AF_INET"
+func PythonBind(addr string, port uint16, proto string) string {
+	var opts []string
 	if strings.Contains(addr, ":") {
-		family = "socket.AF_INET6"
+		opts = append(opts, "family=socket.AF_INET6")
+	} else {
+		opts = append(opts, "family=socket.AF_INET")
+	}
+
+	switch strings.ToLower(proto) {
+	case "tcp":
+		opts = append(opts, "type=socket.SOCK_STREAM")
+	case "udp":
+		opts = append(opts, "type=socket.SOCK_DGRAM")
 	}
 
 	return fmt.Sprintf(
-		`/usr/bin/python3 -c 'import socket; socket.socket(family=%s).bind((%q, %d))`,
-		family, addr, port)
+		`/usr/bin/python3 -c 'import socket; socket.socket(%s).bind((%q, %d))`,
+		strings.Join(opts, ", "), addr, port)
 }

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -41,6 +41,7 @@ var _ = Describe("K8sServicesTest", func() {
 		ciliumPodK8s1          string
 		testDSClient           = "zgroup=testDSClient"
 		testDS                 = "zgroup=testDS"
+		testDSK8s2             = "zgroup=test-k8s2"
 		echoServiceName        = "echo"
 		echoPodLabel           = "name=echo"
 	)
@@ -121,7 +122,7 @@ var _ = Describe("K8sServicesTest", func() {
 	}
 
 	waitPodsDs := func() {
-		groups := []string{testDS, testDSClient}
+		groups := []string{testDS, testDSClient, testDSK8s2}
 		for _, pod := range groups {
 			err := kubectl.WaitforPods(helpers.DefaultNamespace, fmt.Sprintf("-l %s", pod), helpers.HelperTimeout)
 			ExpectWithOffset(1, err).Should(BeNil())

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -267,9 +267,10 @@ var _ = Describe("K8sServicesTest", func() {
 			}
 		}
 
-		failBind := func(addr string, port int32, fromPod string) {
+		failBind := func(addr string, port int32, proto, fromPod string) {
 			By("Trying to bind NodePort addr %q:%d on %s", addr, port, fromPod)
-			res, err := kubectl.ExecInHostNetNS(context.TODO(), fromPod, helpers.PythonBind(addr, uint16(port)))
+			res, err := kubectl.ExecInHostNetNS(context.TODO(), fromPod,
+				helpers.PythonBind(addr, uint16(port), proto))
 			ExpectWithOffset(1, err).To(BeNil(), "Cannot run python in host netns")
 			ExpectWithOffset(1, res).ShouldNot(helpers.CMDSuccess(),
 				"%s host unexpectedly was able to bind on %q:%d, it should fail", fromPod, addr, port)
@@ -444,12 +445,17 @@ var _ = Describe("K8sServicesTest", func() {
 				testCurlRequest(testDSClient, tftpURL)
 
 				// Ensure the NodePort cannot be bound from any redirected address
-				failBind(localCiliumHostIPv4, data.Spec.Ports[0].NodePort, k8s1Name)
-				failBind("127.0.0.1", data.Spec.Ports[0].NodePort, k8s1Name)
-				failBind("", data.Spec.Ports[0].NodePort, k8s1Name)
+				failBind(localCiliumHostIPv4, data.Spec.Ports[0].NodePort, "tcp", k8s1Name)
+				failBind(localCiliumHostIPv4, data.Spec.Ports[1].NodePort, "udp", k8s1Name)
+				failBind("127.0.0.1", data.Spec.Ports[0].NodePort, "tcp", k8s1Name)
+				failBind("127.0.0.1", data.Spec.Ports[1].NodePort, "udp", k8s1Name)
+				failBind("", data.Spec.Ports[0].NodePort, "tcp", k8s1Name)
+				failBind("", data.Spec.Ports[1].NodePort, "udp", k8s1Name)
 
-				failBind("::ffff:127.0.0.1", data.Spec.Ports[0].NodePort, k8s1Name)
-				failBind("::ffff:"+localCiliumHostIPv4, data.Spec.Ports[0].NodePort, k8s1Name)
+				failBind("::ffff:127.0.0.1", data.Spec.Ports[0].NodePort, "tcp", k8s1Name)
+				failBind("::ffff:127.0.0.1", data.Spec.Ports[1].NodePort, "udp", k8s1Name)
+				failBind("::ffff:"+localCiliumHostIPv4, data.Spec.Ports[0].NodePort, "tcp", k8s1Name)
+				failBind("::ffff:"+localCiliumHostIPv4, data.Spec.Ports[1].NodePort, "udp", k8s1Name)
 			}
 		}
 

--- a/test/k8sT/manifests/demo.yaml
+++ b/test/k8sT/manifests/demo.yaml
@@ -14,7 +14,12 @@ metadata:
   name: app1-service
 spec:
   ports:
-  - port: 80
+  - name: http
+    port: 80
+    protocol: TCP
+  - name: tftp
+    port: 69
+    protocol: UDP
   selector:
     id: app1
 ---
@@ -46,6 +51,12 @@ spec:
           httpGet:
             path: /
             port: 80
+      - name: udp
+        image: docker.io/cilium/echoserver-udp:v2020.01.30
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 69
+          protocol: UDP
       nodeSelector:
         "cilium.io/ci-node": k8s1
 ---

--- a/test/k8sT/manifests/demo_ds.yaml
+++ b/test/k8sT/manifests/demo_ds.yaml
@@ -23,6 +23,12 @@ spec:
           httpGet:
             path: /
             port: 80
+      - name: udp
+        image: docker.io/cilium/echoserver-udp:v2020.01.30
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 69
+          protocol: UDP
       terminationGracePeriodSeconds: 0
       tolerations:
       - effect: NoSchedule
@@ -78,6 +84,12 @@ spec:
           httpGet:
             path: /
             port: 80
+      - name: udp
+        image: docker.io/cilium/echoserver-udp:v2020.01.30
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 69
+          protocol: UDP
       terminationGracePeriodSeconds: 0
       nodeSelector:
         "cilium.io/ci-node": k8s2
@@ -88,8 +100,14 @@ metadata:
   name: testds-service
 spec:
   ports:
-  - port: 80
+  - name: http
+    port: 80
     targetPort: 80
+    protocol: TCP
+  - name: tftp
+    port: 69
+    targetPort: 69
+    protocol: UDP
   selector:
     zgroup: testDS
 ---
@@ -104,6 +122,10 @@ spec:
     targetPort: 80
     protocol: TCP
     name: http
+  - port: 10069
+    targetPort: 69
+    protocol: UDP
+    name: tftp
   selector:
     zgroup: testDS
 ---
@@ -119,6 +141,10 @@ spec:
     targetPort: 80
     protocol: TCP
     name: http
+  - port: 10069
+    targetPort: 69
+    protocol: UDP
+    name: tftp
   selector:
     zgroup: testDS
 ---
@@ -134,6 +160,10 @@ spec:
     targetPort: 80
     protocol: TCP
     name: http
+  - port: 10069
+    targetPort: 69
+    protocol: UDP
+    name: tftp
   selector:
     zgroup: test-k8s2
 ---
@@ -148,6 +178,10 @@ spec:
     targetPort: 80
     protocol: TCP
     name: http
+  - port: 10069
+    targetPort: 69
+    protocol: UDP
+    name: tftp
   selector:
     zgroup: test-k8s2
 ---

--- a/test/k8sT/manifests/echo-svc.yaml
+++ b/test/k8sT/manifests/echo-svc.yaml
@@ -31,6 +31,8 @@ spec:
             - -o
             - /dev/null
             - localhost
+      - name: echo-container-udp
+        image: docker.io/cilium/echoserver-udp:v2020.01.30
 ---
 apiVersion: v1
 kind: Service
@@ -39,6 +41,11 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-  - port: 80
+  - name: http
+    port: 80
+    protocol: TCP
+  - name: tftp
+    port: 69
+    protocol: UDP
   selector:
     name: echo

--- a/test/k8sT/manifests/l7-policy-demo.yaml
+++ b/test/k8sT/manifests/l7-policy-demo.yaml
@@ -15,3 +15,7 @@ spec:
       rules:
         http:
         - {}
+    - ports:
+      # we allow tftp traffic to bypass the proxy
+      - port: "69"
+        protocol: UDP


### PR DESCRIPTION
Adds an additional UDP echoserver to the pods and service definitions,
allowing us to check UDP connectivity alongside the existing TCP tests.

The new echoserver uses the TFTP protocol to serve a status page similar
to the existing HTTP server used for TCP tests. This allows us to reuse
the existing test infrastructure, e.g. curl has built-in support for
TFTP.

The deployed cilium/echoserver-udp is using the so-called "single-port"
mode of TFTP, where the server will always answer on the UDP port on
which it received the request. This is required for NAT to work.

Fixes: #9363

TODO:

- [x] Move container image to cilium/ namespace - edit: done; source https://github.com/cilium/echoserver-udp
- [x] Add `failBind` UDP tests for #9880

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/9997)
<!-- Reviewable:end -->
