### PR TITLE
VMs: bump development VM images

### DIFF
--- a/vagrant_box_defaults.rb
+++ b/vagrant_box_defaults.rb
@@ -3,6 +3,6 @@
 Vagrant.require_version ">= 2.2.0"
 
 $SERVER_BOX = "cilium/ubuntu-dev"
-$SERVER_VERSION= "164"
+$SERVER_VERSION= "166"
 $NETNEXT_SERVER_BOX= "cilium/ubuntu-next"
-$NETNEXT_SERVER_VERSION= "42"
+$NETNEXT_SERVER_VERSION= "44"


### PR DESCRIPTION
New image have the most recent golang version and the CI images will
have the more recent docker images cached.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10001)
<!-- Reviewable:end -->
