### PR TITLE
CI: Set CILIUM_REGISTRY in k8s provisioning scripts

### DIFF
--- a/ginkgo-kubernetes-all.Jenkinsfile
+++ b/ginkgo-kubernetes-all.Jenkinsfile
@@ -112,7 +112,7 @@ pipeline {
                         GOPATH="${WORKSPACE}/${K8S_VERSION}-gopath"
                         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
                         KUBECONFIG="vagrant-kubeconfig"
-                        CILIUM_REGISTRY="localnode" //setting it here so we don't compile Cilium in vagrant nodes (already done on local node registry)
+                        //setting it here so we don't compile Cilium in vagrant nodes (already done on local node registry)
                     }
                     steps {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
@@ -120,7 +120,7 @@ pipeline {
                         retry(3) {
                             timeout(time: 20, unit: 'MINUTES'){
                                 dir("${TESTDIR}") {
-                                    sh './vagrant-ci-start.sh'
+                                    sh 'CILIUM_REGISTRY="$(./print-node-ip)" ./vagrant-ci-start.sh'
                                 }
                             }
                         }
@@ -141,7 +141,7 @@ pipeline {
                         GOPATH="${WORKSPACE}/${K8S_VERSION}-gopath"
                         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
                         KUBECONFIG="vagrant-kubeconfig"
-                        CILIUM_REGISTRY="localnode" //setting it here so we don't compile Cilium in vagrant nodes (already done on local node registry)
+                        //setting it here so we don't compile Cilium in vagrant nodes (already done on local node registry)
                     }
                     steps {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
@@ -149,7 +149,7 @@ pipeline {
                         retry(3) {
                             timeout(time: 20, unit: 'MINUTES'){
                                 dir("${TESTDIR}") {
-                                    sh './vagrant-ci-start.sh'
+                                    sh 'CILIUM_REGISTRY="$(./print-node-ip)" ./vagrant-ci-start.sh'
                                 }
                             }
                         }
@@ -249,7 +249,7 @@ pipeline {
                         GOPATH="${WORKSPACE}/${K8S_VERSION}-gopath"
                         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
                         KUBECONFIG="vagrant-kubeconfig"
-                        CILIUM_REGISTRY="localnode" //setting it here so we don't compile Cilium in vagrant nodes (already done on local node registry)
+                        //setting it here so we don't compile Cilium in vagrant nodes (already done on local node registry)
                     }
                     steps {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
@@ -257,7 +257,7 @@ pipeline {
                         retry(3) {
                             timeout(time: 20, unit: 'MINUTES'){
                                 dir("${TESTDIR}") {
-                                    sh './vagrant-ci-start.sh'
+                                    sh 'CILIUM_REGISTRY="$(./print-node-ip)" ./vagrant-ci-start.sh'
                                 }
                             }
                         }
@@ -278,7 +278,7 @@ pipeline {
                         GOPATH="${WORKSPACE}/${K8S_VERSION}-gopath"
                         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
                         KUBECONFIG="vagrant-kubeconfig"
-                        CILIUM_REGISTRY="localnode" //setting it here so we don't compile Cilium in vagrant nodes (already done on local node registry)
+                        //setting it here so we don't compile Cilium in vagrant nodes (already done on local node registry)
                     }
                     steps {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
@@ -286,7 +286,7 @@ pipeline {
                         retry(3) {
                             timeout(time: 20, unit: 'MINUTES'){
                                 dir("${TESTDIR}") {
-                                    sh './vagrant-ci-start.sh'
+                                    sh 'CILIUM_REGISTRY="$(./print-node-ip)" ./vagrant-ci-start.sh'
                                 }
                             }
                         }
@@ -385,7 +385,7 @@ pipeline {
                         GOPATH="${WORKSPACE}/${K8S_VERSION}-gopath"
                         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
                         KUBECONFIG="vagrant-kubeconfig"
-                        CILIUM_REGISTRY="localnode" //setting it here so we don't compile Cilium in vagrant nodes (already done on local node registry)
+                        //setting it here so we don't compile Cilium in vagrant nodes (already done on local node registry)
                     }
                     steps {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
@@ -393,7 +393,7 @@ pipeline {
                         retry(3) {
                             timeout(time: 20, unit: 'MINUTES'){
                                 dir("${TESTDIR}") {
-                                    sh './vagrant-ci-start.sh'
+                                    sh 'CILIUM_REGISTRY="$(./print-node-ip)" ./vagrant-ci-start.sh'
                                 }
                             }
                         }

--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -338,7 +338,7 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, ciliumFilename, 
 		res = kubectl.HelmTemplate(helmTemplate, helpers.CiliumNamespace, preflightFile, opts)
 		ExpectWithOffset(1, res).To(helpers.CMDSuccess(), "Unable to generate preflight YAML")
 
-		res = kubectl.ApplyDefault("cilium-preflight.yaml")
+		res = kubectl.ApplyDefault(preflightFile)
 		ExpectWithOffset(1, res).To(helpers.CMDSuccess(), "Unable to deploy preflight manifest")
 		ExpectCiliumPreFlightInstallReady(kubectl)
 


### PR DESCRIPTION
Follow-up to #9991, applying its changes to the k8s Jenkinsfile as well.
This is required for the Cilium-PR-Ginkgo-Tests-K8s test suite to pass.

Blocks https://github.com/cilium/cilium/pull/9997#issuecomment-580393339

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10006)
<!-- Reviewable:end -->
