### PR TITLE
nodeinit/templates: fix indentation of sys-fs-bpf

### DIFF
--- a/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
@@ -101,20 +101,20 @@ spec:
                 # Configure systemd to mount after next boot
                 echo "Installing BPF filesystem mount"
                 cat >/tmp/sys-fs-bpf.mount <<EOF
-                [Unit]
-                Description=Mount BPF filesystem (Cilium)
-                Documentation=http://docs.cilium.io/
-                DefaultDependencies=no
-                Before=local-fs.target umount.target
-                After=swap.target
+              [Unit]
+              Description=Mount BPF filesystem (Cilium)
+              Documentation=http://docs.cilium.io/
+              DefaultDependencies=no
+              Before=local-fs.target umount.target
+              After=swap.target
 
-                [Mount]
-                What=bpffs
-                Where=/sys/fs/bpf
-                Type=bpf
+              [Mount]
+              What=bpffs
+              Where=/sys/fs/bpf
+              Type=bpf
 
-                [Install]
-                WantedBy=multi-user.target
+              [Install]
+              WantedBy=multi-user.target
               EOF
 
                 if [ -d "/etc/systemd/system/" ]; then


### PR DESCRIPTION
This is more of a cosmetic change since systemd is not picky enough to
fail running a systemd service with spaces in its configuration file.

Fixes: 1ab474df4206 ("helm: Make nodeinit systemd mountpoint conditional")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10008)
<!-- Reviewable:end -->
