### PR TITLE
[CI] Increase outer timeout of GKE job

### DIFF
--- a/jenkinsfiles/ginkgo-gke.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-gke.Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 240, unit: 'MINUTES')
+        timeout(time: 260, unit: 'MINUTES')
         timestamps()
         ansiColor('xterm')
     }


### PR DESCRIPTION
This change will cause the job to not close before cluster is properly
released

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10009)
<!-- Reviewable:end -->
