### PR TITLE
Makes k8s cert generation modular in vagrant startup scripts.

### DIFF
--- a/contrib/vagrant/scripts/00-create-certs.sh
+++ b/contrib/vagrant/scripts/00-create-certs.sh
@@ -3,6 +3,7 @@
 dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 source "${dir}/helpers.bash"
+source "${dir}/cert-gen-helpers.bash"
 
 set -e
 
@@ -11,7 +12,6 @@ mkdir -p "${certs_dir}"
 cd "${certs_dir}"
 
 master="k8s1"
-worker="k8s2"
 
 if [ -n "${INSTALL}" ]; then
     log "Downloading cfssl utility..."
@@ -26,286 +26,7 @@ if [ -n "${INSTALL}" ]; then
     sudo mv cfssljson_linux-amd64 /usr/bin/cfssljson
 fi
 
-#######################################
-# Generate the certificate authority certificates in the form of ca-name.pem
-# Arguments:
-#   name
-#######################################
-generate_ca_certs(){
-    if [ $# -ne 1 ]; then
-        echo "Invalid arguments: usage generate_ca_certs <name>"
-        exit
-    fi
-    name=${1}
-    cat > ${name}-config.json <<EOF
-{
-  "signing": {
-    "default": {
-      "expiry": "2191h"
-    },
-    "profiles": {
-      "${name}": {
-        "usages": ["signing", "key encipherment", "server auth", "client auth"],
-        "expiry": "2191h"
-      }
-    }
-  }
-}
-EOF
 
-    cat > ca-${name}-csr.json <<EOF
-{
-  "CN": "${name}",
-  "key": {
-    "algo": "rsa",
-    "size": 2048
-  },
-  "names": [
-    {
-      "C": "US",
-      "L": "San Francisco",
-      "O": "${name}",
-      "OU": "CI",
-      "ST": "California"
-    }
-  ]
-}
-EOF
-
-    cfssl gencert -initca ca-${name}-csr.json | cfssljson -bare ca-${name}
-
-    openssl x509 -in ca-${name}.pem -text -noout
-}
-
-#######################################
-# Generate server certificates in the form of cli-name.pem
-# Arguments:
-#   certificate-authority filename
-#   server/client filename
-#   server/client's hostname
-#######################################
-generate_server_certs() {
-    if [ $# -ne 3 ]; then
-        echo "Invalid arguments: usage generate_client_certs <ca-name> <cli-name> <hostname>"
-        exit
-    fi
-    ca_name=${1}
-    cli_name=${2}
-    master_hostname=${3}
-    cat > ${cli_name}-csr.json <<EOF
-{
-  "CN": "${cli_name}",
-  "hosts": [
-    "${master_hostname}",
-    "${master_ip}",
-    "${cluster_api_server_ip}",
-    "${cli_name}.cluster.default"
-  ],
-  "key": {
-    "algo": "rsa",
-    "size": 2048
-  },
-  "names": [
-    {
-      "C": "US",
-      "L": "San Francisco",
-      "O": "${ca_name}",
-      "OU": "CI",
-      "ST": "California"
-    }
-  ]
-}
-EOF
-
-    cfssl gencert \
-      -ca=ca-${ca_name}.pem \
-      -ca-key=ca-${ca_name}-key.pem \
-      -config=${ca_name}-config.json \
-      -profile=${ca_name} \
-      ${cli_name}-csr.json | cfssljson -bare ${cli_name}
-
-    openssl x509 -in ${cli_name}.pem -text -noout
-}
-
-#######################################
-# Generate kubelet client certificates in the form of "filename.pem"
-# Arguments:
-#   certificate-authority filename
-#   client name
-#   filename
-#######################################
-generate_kubelet_client_certs() {
-    if [ $# -ne 3 ]; then
-        echo "Invalid arguments: usage generate_client_certs <ca-name> <cli-name> <filename>"
-        exit
-    fi
-    ca_name=${1}
-    cli_name=${2}
-    filename=${3}
-    cat > ${filename}-csr.json <<EOF
-{
-  "CN": "${cli_name}",
-  "hosts": [],
-  "key": {
-    "algo": "rsa",
-    "size": 2048
-  },
-  "names": [
-    {
-      "C": "US",
-      "L": "San Francisco",
-      "O": "system:nodes",
-      "OU": "CI",
-      "ST": "California"
-    }
-  ]
-}
-EOF
-
-    cfssl gencert \
-      -ca=ca-${ca_name}.pem \
-      -ca-key=ca-${ca_name}-key.pem \
-      -config=${ca_name}-config.json \
-      -profile=${ca_name} \
-      ${filename}-csr.json | cfssljson -bare ${filename}
-
-    openssl x509 -in ${filename}.pem -text -noout
-}
-
-#######################################
-# Generate k8s component certificates in the form of "filename.pem"
-# Arguments:
-#   certificate-authority filename
-#   k8s component name
-#   filename
-#######################################
-generate_k8s_component_certs() {
-    if [ $# -ne 3 ]; then
-        echo "Invalid arguments: usage generate_k8s_component_certs <ca-name> <k8s-component-name> <filename>"
-        exit
-    fi
-    ca_name=${1}
-    k8s_name=${2}
-    cm_name=${3}
-    cat > ${cm_name}-csr.json <<EOF
-{
-  "CN": "${k8s_name}",
-  "hosts": [],
-  "key": {
-    "algo": "rsa",
-    "size": 2048
-  },
-  "names": [
-    {
-      "C": "US",
-      "L": "San Francisco",
-      "O": "${k8s_name}",
-      "OU": "CI",
-      "ST": "California"
-    }
-  ]
-}
-EOF
-
-    cfssl gencert \
-      -ca=ca-${ca_name}.pem \
-      -ca-key=ca-${ca_name}-key.pem \
-      -config=${ca_name}-config.json \
-      -profile=${ca_name} \
-      ${cm_name}-csr.json | cfssljson -bare ${cm_name}
-
-    openssl x509 -in ${cm_name}.pem -text -noout
-}
-
-#######################################
-# Generates kubectl admin certificates in the form of "filename.pem"
-# Arguments:
-#   certificate-authority filename
-#   username used in kubectl
-#   filename
-#######################################
-generate_kubectl_admin_certs() {
-    if [ $# -ne 3 ]; then
-        echo "Invalid arguments: usage generate_kubectl_admin_certs <ca-name> <username> <filename>"
-        exit
-    fi
-    ca_name=${1}
-    username=${2}
-    filename=${3}
-    cat > ${filename}-csr.json <<EOF
-{
-  "CN": "${username}",
-  "hosts": [],
-  "key": {
-    "algo": "rsa",
-    "size": 2048
-  },
-  "names": [
-    {
-      "C": "US",
-      "L": "San Francisco",
-      "O": "system:masters",
-      "OU": "CI",
-      "ST": "California"
-    }
-  ]
-}
-EOF
-
-    cfssl gencert \
-      -ca=ca-${ca_name}.pem \
-      -ca-key=ca-${ca_name}-key.pem \
-      -config=${ca_name}-config.json \
-      -profile=${ca_name} \
-      ${filename}-csr.json | cfssljson -bare ${filename}
-
-    openssl x509 -in ${filename}.pem -text -noout
-}
-
-#######################################
-# Generates etcd client certificates in the form of "filename.pem"
-# Arguments:
-#   certificate-authority filename
-#   client name used in etcd
-#   filename
-#######################################
-generate_etcd_client_certs() {
-    if [ $# -ne 3 ]; then
-        echo "Invalid arguments: usage generate_etcd_client_certs <ca-name> <client-name> <filename>"
-        exit
-    fi
-    ca_name=${1}
-    client_name=${2}
-    filename=${3}
-    cat > ${filename}-csr.json <<EOF
-{
-  "CN": "${client_name}",
-  "hosts": [],
-  "key": {
-    "algo": "rsa",
-    "size": 2048
-  },
-  "names": [
-    {
-      "C": "US",
-      "L": "San Francisco",
-      "O": "kubernetes",
-      "OU": "CI",
-      "ST": "California"
-    }
-  ]
-}
-EOF
-
-    cfssl gencert \
-      -ca=ca-${ca_name}.pem \
-      -ca-key=ca-${ca_name}-key.pem \
-      -config=${ca_name}-config.json \
-      -profile=${ca_name} \
-      ${filename}-csr.json | cfssljson -bare ${filename}
-
-    openssl x509 -in ${filename}.pem -text -noout
-}
 
 log "Generating certificates..."
 
@@ -327,10 +48,10 @@ generate_k8s_component_certs k8s controller-manager-sa k8s-controller-manager-sa
 
 # Generate kubelet certs so they are able to talk with api-server and have
 # the correct permissions to manage its own node
+# Leave the client cert generation to client node since master at this point
+# has no idea how many workers there are.
 generate_kubelet_client_certs k8s system:node:${master} k8s-kubelet-${master}
-generate_kubelet_client_certs k8s system:node:${worker} k8s-kubelet-${worker}
 generate_k8s_component_certs k8s system:kube-proxy k8s-kube-proxy-${master}
-generate_k8s_component_certs k8s system:kube-proxy k8s-kube-proxy-${worker}
 
 # Generate kubelet client certificate so kube-apiserver can talk with kubelets
 generate_k8s_component_certs k8s kubelet-api-server kubelet-api-server
@@ -339,8 +60,8 @@ generate_k8s_component_certs k8s kubelet-api-server kubelet-api-server
 generate_ca_certs kubelet
 
 # Generate kubelet serving certificates to use to serve its endpoints
+# Leave the client cert generation to client node.
 generate_k8s_component_certs kubelet ${master} kubelet-kubelet-${master}
-generate_k8s_component_certs kubelet ${worker} kubelet-kubelet-${worker}
 
 # Generate each components certs
 generate_k8s_component_certs k8s system:kube-controller-manager k8s-controller-manager

--- a/contrib/vagrant/scripts/cert-gen-helpers.bash
+++ b/contrib/vagrant/scripts/cert-gen-helpers.bash
@@ -1,0 +1,280 @@
+#######################################
+# Generate the certificate authority certificates in the form of ca-name.pem
+# Arguments:
+#   name
+#######################################
+generate_ca_certs(){
+    if [ $# -ne 1 ]; then
+        echo "Invalid arguments: usage generate_ca_certs <name>"
+        exit
+    fi
+    name=${1}
+    cat > ${name}-config.json <<EOF
+{
+  "signing": {
+    "default": {
+      "expiry": "2191h"
+    },
+    "profiles": {
+      "${name}": {
+        "usages": ["signing", "key encipherment", "server auth", "client auth"],
+        "expiry": "2191h"
+      }
+    }
+  }
+}
+EOF
+
+    cat > ca-${name}-csr.json <<EOF
+{
+  "CN": "${name}",
+  "key": {
+    "algo": "rsa",
+    "size": 2048
+  },
+  "names": [
+    {
+      "C": "US",
+      "L": "San Francisco",
+      "O": "${name}",
+      "OU": "CI",
+      "ST": "California"
+    }
+  ]
+}
+EOF
+
+    cfssl gencert -initca ca-${name}-csr.json | cfssljson -bare ca-${name}
+
+    openssl x509 -in ca-${name}.pem -text -noout
+}
+
+#######################################
+# Generate server certificates in the form of cli-name.pem
+# Arguments:
+#   certificate-authority filename
+#   server/client filename
+#   server/client's hostname
+#######################################
+generate_server_certs() {
+    if [ $# -ne 3 ]; then
+        echo "Invalid arguments: usage generate_client_certs <ca-name> <cli-name> <hostname>"
+        exit
+    fi
+    ca_name=${1}
+    cli_name=${2}
+    master_hostname=${3}
+    cat > ${cli_name}-csr.json <<EOF
+{
+  "CN": "${cli_name}",
+  "hosts": [
+    "${master_hostname}",
+    "${master_ip}",
+    "${cluster_api_server_ip}",
+    "${cli_name}.cluster.default"
+  ],
+  "key": {
+    "algo": "rsa",
+    "size": 2048
+  },
+  "names": [
+    {
+      "C": "US",
+      "L": "San Francisco",
+      "O": "${ca_name}",
+      "OU": "CI",
+      "ST": "California"
+    }
+  ]
+}
+EOF
+
+    cfssl gencert \
+      -ca=ca-${ca_name}.pem \
+      -ca-key=ca-${ca_name}-key.pem \
+      -config=${ca_name}-config.json \
+      -profile=${ca_name} \
+      ${cli_name}-csr.json | cfssljson -bare ${cli_name}
+
+    openssl x509 -in ${cli_name}.pem -text -noout
+}
+
+#######################################
+# Generate kubelet client certificates in the form of "filename.pem"
+# Arguments:
+#   certificate-authority filename
+#   client name
+#   filename
+#######################################
+generate_kubelet_client_certs() {
+    if [ $# -ne 3 ]; then
+        echo "Invalid arguments: usage generate_client_certs <ca-name> <cli-name> <filename>"
+        exit
+    fi
+    ca_name=${1}
+    cli_name=${2}
+    filename=${3}
+    cat > ${filename}-csr.json <<EOF
+{
+  "CN": "${cli_name}",
+  "hosts": [],
+  "key": {
+    "algo": "rsa",
+    "size": 2048
+  },
+  "names": [
+    {
+      "C": "US",
+      "L": "San Francisco",
+      "O": "system:nodes",
+      "OU": "CI",
+      "ST": "California"
+    }
+  ]
+}
+EOF
+
+    cfssl gencert \
+      -ca=ca-${ca_name}.pem \
+      -ca-key=ca-${ca_name}-key.pem \
+      -config=${ca_name}-config.json \
+      -profile=${ca_name} \
+      ${filename}-csr.json | cfssljson -bare ${filename}
+
+    openssl x509 -in ${filename}.pem -text -noout
+}
+
+#######################################
+# Generate k8s component certificates in the form of "filename.pem"
+# Arguments:
+#   certificate-authority filename
+#   k8s component name
+#   filename
+#######################################
+generate_k8s_component_certs() {
+    if [ $# -ne 3 ]; then
+        echo "Invalid arguments: usage generate_k8s_component_certs <ca-name> <k8s-component-name> <filename>"
+        exit
+    fi
+    ca_name=${1}
+    k8s_name=${2}
+    cm_name=${3}
+    cat > ${cm_name}-csr.json <<EOF
+{
+  "CN": "${k8s_name}",
+  "hosts": [],
+  "key": {
+    "algo": "rsa",
+    "size": 2048
+  },
+  "names": [
+    {
+      "C": "US",
+      "L": "San Francisco",
+      "O": "${k8s_name}",
+      "OU": "CI",
+      "ST": "California"
+    }
+  ]
+}
+EOF
+
+    cfssl gencert \
+      -ca=ca-${ca_name}.pem \
+      -ca-key=ca-${ca_name}-key.pem \
+      -config=${ca_name}-config.json \
+      -profile=${ca_name} \
+      ${cm_name}-csr.json | cfssljson -bare ${cm_name}
+
+    openssl x509 -in ${cm_name}.pem -text -noout
+}
+
+#######################################
+# Generates kubectl admin certificates in the form of "filename.pem"
+# Arguments:
+#   certificate-authority filename
+#   username used in kubectl
+#   filename
+#######################################
+generate_kubectl_admin_certs() {
+    if [ $# -ne 3 ]; then
+        echo "Invalid arguments: usage generate_kubectl_admin_certs <ca-name> <username> <filename>"
+        exit
+    fi
+    ca_name=${1}
+    username=${2}
+    filename=${3}
+    cat > ${filename}-csr.json <<EOF
+{
+  "CN": "${username}",
+  "hosts": [],
+  "key": {
+    "algo": "rsa",
+    "size": 2048
+  },
+  "names": [
+    {
+      "C": "US",
+      "L": "San Francisco",
+      "O": "system:masters",
+      "OU": "CI",
+      "ST": "California"
+    }
+  ]
+}
+EOF
+
+    cfssl gencert \
+      -ca=ca-${ca_name}.pem \
+      -ca-key=ca-${ca_name}-key.pem \
+      -config=${ca_name}-config.json \
+      -profile=${ca_name} \
+      ${filename}-csr.json | cfssljson -bare ${filename}
+
+    openssl x509 -in ${filename}.pem -text -noout
+}
+
+#######################################
+# Generates etcd client certificates in the form of "filename.pem"
+# Arguments:
+#   certificate-authority filename
+#   client name used in etcd
+#   filename
+#######################################
+generate_etcd_client_certs() {
+    if [ $# -ne 3 ]; then
+        echo "Invalid arguments: usage generate_etcd_client_certs <ca-name> <client-name> <filename>"
+        exit
+    fi
+    ca_name=${1}
+    client_name=${2}
+    filename=${3}
+    cat > ${filename}-csr.json <<EOF
+{
+  "CN": "${client_name}",
+  "hosts": [],
+  "key": {
+    "algo": "rsa",
+    "size": 2048
+  },
+  "names": [
+    {
+      "C": "US",
+      "L": "San Francisco",
+      "O": "kubernetes",
+      "OU": "CI",
+      "ST": "California"
+    }
+  ]
+}
+EOF
+
+    cfssl gencert \
+      -ca=ca-${ca_name}.pem \
+      -ca-key=ca-${ca_name}-key.pem \
+      -config=${ca_name}-config.json \
+      -profile=${ca_name} \
+      ${filename}-csr.json | cfssljson -bare ${filename}
+
+    openssl x509 -in ${filename}.pem -text -noout
+}


### PR DESCRIPTION
The oringal scripts that come with Cilium statically generates
certificates only on the master node and it limits the worker node
number to be <=1. If you try to bring up a cluster with two or more
worker nodes, the script will fail and the nodes (except for the master
and the first worker) won't be brought up correctly.

This moves the cert generation for k8s components and kubelets to the
worker nodes so that it will dynamically adapt to the number of workers
set with NWORKER.

Test: I can successfully bring up a cluster with 2 workers using
```
K8S=1 NWORKERS=2 contrib/vagrant/start.sh
```
The cluster passes the connectivity test with
```
kubectl apply -f https://raw.githubusercontent.com/cilium/cilium/1.6.5/examples/kubernetes/connectivity-check/connectivity-check.yaml
```

Fixes: #9527 

Signed-off-by: Weilong Cui <cuiwl@google.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10015)
<!-- Reviewable:end -->
