### PR TITLE
doc: update instructions about restarting pods after deployment

### DIFF
--- a/Documentation/gettingstarted/k8s-install-eks.rst
+++ b/Documentation/gettingstarted/k8s-install-eks.rst
@@ -86,6 +86,10 @@ Deploy Cilium release via Helm:
      --set global.tunnel=disabled \\
      --set global.nodeinit.enabled=true
 
+You might also want to pass the ``--set global.restartPods`` switch to the
+``helm`` command above. This will restart existing pods when initializing the
+node to force all pods to be managed by Cilium.
+
 Scale up the cluster
 ====================
 
@@ -101,6 +105,7 @@ Scale up the cluster
     [ℹ]  scaling nodegroup stack "eksctl-test-cluster-nodegroup-ng-25560078" in cluster eksctl-test-cluster-cluster
     [ℹ]  scaling nodegroup, desired capacity from 0 to 2
 
+.. include:: k8s-install-restart-pods.rst
 .. include:: k8s-install-validate.rst
 .. include:: hubble-install.rst
 .. include:: getting-started-next-steps.rst

--- a/Documentation/gettingstarted/k8s-install-gke.rst
+++ b/Documentation/gettingstarted/k8s-install-gke.rst
@@ -80,26 +80,11 @@ to the cluster. The NodeInit DaemonSet will perform the following actions:
 * Reconfigure kubelet to run in CNI mode
 * Mount the BPF filesystem
 
-Restart remaining pods
-======================
+You might also want to pass the ``--set global.restartPods`` switch to the
+``helm`` command above. This will restart existing pods when initializing the
+node to force all pods to be managed by Cilium.
 
-Once Cilium is up and running, restart all pods in ``kube-system`` so they can
-be managed by Cilium, similar to the steps that we have previously performed
-for ``kube-dns``
-
-::
-
-    $ kubectl delete pods -n kube-system $(kubectl get pods -n kube-system -o custom-columns=NAME:.metadata.name,HOSTNETWORK:.spec.hostNetwork --no-headers=true | grep '<none>' | awk '{ print $1 }')
-    pod "event-exporter-v0.2.3-f9c896d75-cbvcz" deleted
-    pod "fluentd-gcp-scaler-69d79984cb-nfwwk" deleted
-    pod "heapster-v1.6.0-beta.1-56d5d5d87f-qw8pv" deleted
-    pod "kube-dns-5f8689dbc9-2nzft" deleted
-    pod "kube-dns-5f8689dbc9-j7x5f" deleted
-    pod "kube-dns-autoscaler-76fcd5f658-22r72" deleted
-    pod "kube-state-metrics-7d9774bbd5-n6m5k" deleted
-    pod "l7-default-backend-6f8697844f-d2rq2" deleted
-    pod "metrics-server-v0.3.1-54699c9cc8-7l5w2" deleted
-
+.. include:: k8s-install-restart-pods.rst
 .. include:: k8s-install-validate.rst
 .. include:: hubble-install.rst
 .. include:: getting-started-next-steps.rst

--- a/Documentation/gettingstarted/k8s-install-restart-pods.rst
+++ b/Documentation/gettingstarted/k8s-install-restart-pods.rst
@@ -1,0 +1,22 @@
+Restart remaining pods
+======================
+
+Once Cilium is up and running, pods in the ``kube-system`` namespace need to be
+restarted to ensure that they can be managed by Cilium.
+
+If the  flag ``--set global.restartPods=true`` was provided to the ``helm``
+command during the deployment step, nothing should be required. Otherwise, they
+need to be restarted manually:
+
+::
+
+    $ kubectl delete pods -n kube-system $(kubectl get pods -n kube-system -o custom-columns=NAME:.metadata.name,HOSTNETWORK:.spec.hostNetwork --no-headers=true | grep '<none>' | awk '{ print $1 }')
+    pod "event-exporter-v0.2.3-f9c896d75-cbvcz" deleted
+    pod "fluentd-gcp-scaler-69d79984cb-nfwwk" deleted
+    pod "heapster-v1.6.0-beta.1-56d5d5d87f-qw8pv" deleted
+    pod "kube-dns-5f8689dbc9-2nzft" deleted
+    pod "kube-dns-5f8689dbc9-j7x5f" deleted
+    pod "kube-dns-autoscaler-76fcd5f658-22r72" deleted
+    pod "kube-state-metrics-7d9774bbd5-n6m5k" deleted
+    pod "l7-default-backend-6f8697844f-d2rq2" deleted
+    pod "metrics-server-v0.3.1-54699c9cc8-7l5w2" deleted

--- a/install/kubernetes/cilium/charts/nodeinit/values.yaml
+++ b/install/kubernetes/cilium/charts/nodeinit/values.yaml
@@ -1,5 +1,5 @@
 # Restart existing pods when initializing the node to force all pods being
-# managed by Cilium (GKE)
+# managed by Cilium (GKE, EKS)
 restartPods: false
 
 # Reconfigure Kubelet to run in CNI mode (GKE)


### PR DESCRIPTION
On GKE/EKS, pods are automatically restarted when the `--set global.restartPods=true` switch is passed to `helm` when deploying Cilium. If not, pods need to be manually restarted to ensure
that they are managed by Cilium.

Note that EKS restart pod support is pending in #9740.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10028)
<!-- Reviewable:end -->
