### PR TITLE
backporting: add 'upstream-prs' tag for code block

### DIFF
--- a/contrib/backporting/check-stable
+++ b/contrib/backporting/check-stable
@@ -201,7 +201,7 @@ if [[ ${#stable_prs[@]} > 0 ]]; then
   echo "$ for pr in ${stable_prs[@]}; do contrib/backporting/set-labels.py \$pr pending ${STABLE_BRANCH}; done"
   if [[ ! -z $SUMMARY_LOG ]]; then
     echo -e "\nOnce this PR is merged, you can update the PR labels via:" >> $SUMMARY_LOG
-    echo "\`\`\`" >> $SUMMARY_LOG
+    echo "\`\`\`upstream-prs" >> $SUMMARY_LOG
     echo "$ for pr in ${stable_prs[@]}; do contrib/backporting/set-labels.py \$pr done ${STABLE_BRANCH}; done" >> $SUMMARY_LOG
     echo "\`\`\`" >> $SUMMARY_LOG
   fi


### PR DESCRIPTION
This tag will be helpful to generate release notes automatically.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10033)
<!-- Reviewable:end -->
