### PR TITLE
docs: Fix up gke install guide

### DIFF
--- a/Documentation/gettingstarted/k8s-install-gke.rst
+++ b/Documentation/gettingstarted/k8s-install-gke.rst
@@ -66,6 +66,7 @@ Deploy Cilium release via Helm:
 
 .. parsed-literal::
 
+    kubectl create namespace cilium
     helm install cilium |CHART_RELEASE| \\
       --namespace cilium \\
       --set global.nodeinit.enabled=true \\


### PR DESCRIPTION
Commit f611334d4b7d ("Use helm repository in docs") inadvertently
dropped the instruction to create the 'cilium' namespace from the GKE
instructions, but this step is still required. Re-add it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10037)
<!-- Reviewable:end -->
