### PR TITLE
test: Remove cilium DS before installing a new one

### DIFF
--- a/test/k8sT/Chaos.go
+++ b/test/k8sT/Chaos.go
@@ -51,6 +51,7 @@ var _ = Describe("K8sChaosTest", func() {
 	})
 
 	AfterAll(func() {
+		kubectl.DeleteCiliumDS()
 		ExpectAllPodsTerminated(kubectl)
 		kubectl.CloseSSHClient()
 	})

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -40,8 +40,6 @@ var _ = Describe("K8sDatapathConfig", func() {
 		demoDSPath = helpers.ManifestGet(kubectl.BasePath(), "demo_ds.yaml")
 		ipsecDSPath = helpers.ManifestGet(kubectl.BasePath(), "ipsec_ds.yaml")
 		ciliumFilename = helpers.TimestampFilename("cilium.yaml")
-
-		deleteCiliumDS(kubectl)
 	})
 
 	BeforeEach(func() {
@@ -53,9 +51,8 @@ var _ = Describe("K8sDatapathConfig", func() {
 	AfterEach(func() {
 		kubectl.Delete(demoDSPath)
 		kubectl.Delete(ipsecDSPath)
+		kubectl.DeleteCiliumDS()
 		ExpectAllPodsTerminated(kubectl)
-
-		deleteCiliumDS(kubectl)
 	})
 
 	AfterFailed(func() {

--- a/test/k8sT/Health.go
+++ b/test/k8sT/Health.go
@@ -50,6 +50,8 @@ var _ = Describe("K8sHealthTest", func() {
 	})
 
 	AfterAll(func() {
+		kubectl.DeleteCiliumDS()
+		ExpectAllPodsTerminated(kubectl)
 		kubectl.CloseSSHClient()
 	})
 

--- a/test/k8sT/KafkaPolicies.go
+++ b/test/k8sT/KafkaPolicies.go
@@ -63,6 +63,8 @@ var _ = Describe("K8sKafkaPolicyTest", func() {
 	})
 
 	AfterAll(func() {
+		kubectl.DeleteCiliumDS()
+		ExpectAllPodsTerminated(kubectl)
 		kubectl.CloseSSHClient()
 	})
 

--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -67,6 +67,7 @@ var _ = Describe("NightlyEpsMeasurement", func() {
 	}
 	AfterAll(func() {
 		deleteAll()
+		kubectl.DeleteCiliumDS()
 		ExpectAllPodsTerminated(kubectl)
 		kubectl.CloseSSHClient()
 	})

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -92,7 +92,6 @@ var _ = Describe("K8sPolicyTest", func() {
 		knpAllowEgress = helpers.ManifestGet(kubectl.BasePath(), "knp-default-allow-egress.yaml")
 		cnpMatchExpression = helpers.ManifestGet(kubectl.BasePath(), "cnp-matchexpressions.yaml")
 
-		deleteCiliumDS(kubectl)
 		DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
 			"global.tls.secretsBackend": "k8s",
 			"global.debug.verbose":      "flow",
@@ -110,6 +109,7 @@ var _ = Describe("K8sPolicyTest", func() {
 	})
 
 	AfterAll(func() {
+		kubectl.DeleteCiliumDS()
 		ExpectAllPodsTerminated(kubectl)
 		kubectl.CloseSSHClient()
 	})

--- a/test/k8sT/PoliciesNightly.go
+++ b/test/k8sT/PoliciesNightly.go
@@ -52,6 +52,7 @@ var _ = Describe("NightlyPolicies", func() {
 		kubectl.Exec(fmt.Sprintf(
 			"%s delete pods,svc,cnp -n %s -l test=policygen",
 			helpers.KubectlCmd, helpers.DefaultNamespace))
+		kubectl.DeleteCiliumDS()
 		err := kubectl.WaitCleanAllTerminatingPods(timeout)
 		Expect(err).To(BeNil(), "Cannot clean pods during timeout")
 		kubectl.CloseSSHClient()

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -99,6 +99,8 @@ var _ = Describe("K8sServicesTest", func() {
 	})
 
 	AfterAll(func() {
+		kubectl.DeleteCiliumDS()
+		ExpectAllPodsTerminated(kubectl)
 		kubectl.CloseSSHClient()
 	})
 
@@ -581,14 +583,12 @@ var _ = Describe("K8sServicesTest", func() {
 						ret = kubectl.CiliumExec(pod, "tc filter del dev "+nativeDev+" egress")
 						Expect(ret.WasSuccessful()).Should(BeTrue(), "Cannot remove egress bpf_netdev on %s", pod)
 					}
-					deleteCiliumDS(kubectl)
 					// Deploy Cilium as the next test expects it to be up and running
 					DeployCiliumAndDNS(kubectl, ciliumFilename)
 				})
 
 				Context("Tests with vxlan", func() {
 					BeforeAll(func() {
-						deleteCiliumDS(kubectl)
 						DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
 							"global.nodePort.enabled": "true",
 							"global.nodePort.device":  nativeDev,
@@ -610,7 +610,6 @@ var _ = Describe("K8sServicesTest", func() {
 
 				Context("Tests with direct routing", func() {
 					BeforeAll(func() {
-						deleteCiliumDS(kubectl)
 						DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
 							"global.nodePort.enabled":     "true",
 							"global.nodePort.device":      nativeDev,
@@ -658,7 +657,6 @@ var _ = Describe("K8sServicesTest", func() {
 				})
 
 				SkipItIf(helpers.DoesNotExistNodeWithoutCilium, "Tests with direct routing and DSR", func() {
-					deleteCiliumDS(kubectl)
 					DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
 						"global.nodePort.enabled":     "true",
 						"global.nodePort.device":      nativeDev,

--- a/test/k8sT/demos.go
+++ b/test/k8sT/demos.go
@@ -82,6 +82,8 @@ var _ = Describe("K8sDemosTest", func() {
 	})
 
 	AfterAll(func() {
+		kubectl.DeleteCiliumDS()
+		ExpectAllPodsTerminated(kubectl)
 		kubectl.CloseSSHClient()
 	})
 

--- a/test/k8sT/external_ips.go
+++ b/test/k8sT/external_ips.go
@@ -185,6 +185,7 @@ var _ = Describe("K8sKubeProxyFreeMatrix tests", func() {
 			return
 		}
 		_ = kubectl.NamespaceDelete(namespaceTest)
+		kubectl.DeleteCiliumDS()
 		ExpectAllPodsTerminated(kubectl)
 		kubectl.CloseSSHClient()
 	})
@@ -236,7 +237,6 @@ var _ = Describe("K8sKubeProxyFreeMatrix tests", func() {
 		func() bool { return helpers.DoesNotRunOnNetNext() },
 		"DirectRouting", func() {
 			BeforeAll(func() {
-				deleteCiliumDS(kubectl)
 				deployCilium(map[string]string{
 					"global.tunnel":               "disabled",
 					"global.autoDirectNodeRoutes": "true",
@@ -282,7 +282,6 @@ var _ = Describe("K8sKubeProxyFreeMatrix tests", func() {
 		func() bool { return helpers.DoesNotRunOnNetNext() },
 		"VxLANMode", func() {
 			BeforeAll(func() {
-				deleteCiliumDS(kubectl)
 				deployCilium(map[string]string{
 					"global.tunnel":           "vxlan",
 					"global.nodePort.device":  external_ips.PublicInterfaceName,

--- a/test/k8sT/fqdn.go
+++ b/test/k8sT/fqdn.go
@@ -80,6 +80,7 @@ var _ = Describe("K8sFQDNTest", func() {
 
 	AfterAll(func() {
 		_ = kubectl.Delete(demoManifest)
+		kubectl.DeleteCiliumDS()
 		ExpectAllPodsTerminated(kubectl)
 		kubectl.CloseSSHClient()
 	})

--- a/test/k8sT/istio.go
+++ b/test/k8sT/istio.go
@@ -123,6 +123,7 @@ var _ = Describe("K8sIstioTest", func() {
 		By("Deleting the istio-system namespace")
 		_ = kubectl.NamespaceDelete(istioSystemNamespace)
 
+		kubectl.DeleteCiliumDS()
 		kubectl.WaitCleanAllTerminatingPods(teardownTimeout)
 
 		kubectl.CloseSSHClient()


### PR DESCRIPTION
Previously, when installing Cilium via `ciliumInstallHelm()`, changes to ConfigMap were not applied if Cilium DaemonSet had already been installed.

An example of such occurrence in test logs:

    time="2020-02-01T21:01:58Z" level=debug msg="running command: kubectl apply --force=true -f cilium-15ef6310fc44caf0.yaml -n kube-system" cmd: "kubectl apply --force=true -f cilium-15ef6310fc44caf0.yaml -n
    kube-system" exitCode: 0 duration: 118.450977ms stdout:
    configmap/cilium-config configured
    serviceaccount/cilium unchanged
    serviceaccount/cilium-operator unchanged
    clusterrole.rbac.authorization.k8s.io/cilium unchanged
    clusterrole.rbac.authorization.k8s.io/cilium-operator unchanged
    clusterrolebinding.rbac.authorization.k8s.io/cilium unchanged
    clusterrolebinding.rbac.authorization.k8s.io/cilium-operator unchanged
    daemonset.apps/cilium unchanged
    deployment.apps/cilium-operator configured

Missing removal of the Cilium DS was causing some flakes, e.g. when the test suite `k8sT/external_ips.go` was ran before `k8sT/Services.go`. The
former suite in some test cases were using `--device=enp0s9` instead of `--device=enp0s8`, and `k8sT/Services.go` required the latter device setting (otherwise, a wrong IP addr for NodePort services was selected)

Fixes  #10031

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10039)
<!-- Reviewable:end -->
