### PR TITLE
test: Improve skipping of k8sT/Services.go tests

### DIFF
--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -453,7 +453,7 @@ func RunsOnNetNext() bool {
 	return os.Getenv("NETNEXT") == "true"
 }
 
-// DoesNotRunOnNetNext is the inverse function of RunsOnNetNext.
+// DoesNotRunOnNetNext is the complement function of RunsOnNetNext.
 func DoesNotRunOnNetNext() bool {
 	return !RunsOnNetNext()
 }
@@ -473,6 +473,11 @@ func DoesNotHaveHosts(count int) func() bool {
 // RunsWithKubeProxy returns true if cilium runs together with k8s' kube-proxy.
 func RunsWithKubeProxy() bool {
 	return os.Getenv("KUBEPROXY") != "0"
+}
+
+// RunsWithoutKubeProxy is the complement function of RunsWithKubeProxy.
+func RunsWithoutKubeProxy() bool {
+	return !RunsWithKubeProxy()
 }
 
 // ExistNodeWithoutCilium returns true if there is a node in a cluster which does

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -486,6 +486,11 @@ func ExistNodeWithoutCilium() bool {
 	return GetNodeWithoutCilium() != ""
 }
 
+// DoesNotExistNodeWithoutCilium is the complement function of ExistNodeWithoutCilium
+func DoesNotExistNodeWithoutCilium() bool {
+	return !ExistNodeWithoutCilium()
+}
+
 // GetNodeWithoutCilium returns a name of a node which does not run cilium.
 func GetNodeWithoutCilium() string {
 	return os.Getenv("NO_CILIUM_ON_NODE")

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -486,7 +486,7 @@ var _ = Describe("K8sServicesTest", func() {
 			})
 
 		SkipContextIf(
-			func() bool { return helpers.DoesNotRunOnNetNext() || helpers.DoesNotHaveHosts(3)() },
+			helpers.DoesNotRunOnNetNext,
 			"Tests NodePort BPF", func() {
 				// TODO(brb) Add with L7 policy test cases after GH#8971 has been fixed
 
@@ -558,7 +558,7 @@ var _ = Describe("K8sServicesTest", func() {
 					})
 				})
 
-				Context("Tests with MetalLB", func() {
+				SkipContextIf(helpers.DoesNotExistNodeWithoutCilium, "Tests with MetalLB", func() {
 					var (
 						metalLB string
 					)
@@ -583,7 +583,7 @@ var _ = Describe("K8sServicesTest", func() {
 					})
 				})
 
-				It("Tests with direct routing and DSR", func() {
+				SkipItIf(helpers.DoesNotExistNodeWithoutCilium, "Tests with direct routing and DSR", func() {
 					deleteCiliumDS(kubectl)
 					DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
 						"global.nodePort.enabled":     "true",


### PR DESCRIPTION
This PR:
- Skips kube-proxy related tests when running w/o kube-proxy.
- Skips only one (instead of all) externalTrafficPolicy=Local tests when running without the third host.
- Skips only some (instead of all) kube-proxy-free tests when running without the third host.

Reviewable per commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10047)
<!-- Reviewable:end -->
