### PR TITLE
contrib/vagrant: only ssh to k8s1 if vagrant up suceeded

### DIFF
--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -601,9 +601,9 @@ elif [ -n "${PROVISION}" ]; then
     vagrant provision
 else
     vagrant up
-    if [ -n "${K8S}" ]; then
-		vagrant ssh k8s1 -- cat /home/vagrant/.kube/config | sed 's;server:.*:6443;server: https://k8s1:7443;g' > vagrant.kubeconfig
-		echo "Add '127.0.0.1 k8s1' to your /etc/hosts to use vagrant.kubeconfig file for kubectl"
-	fi
+    if [ "$?" -eq "0" -a "${K8S}" -eq "1" ]; then
+        vagrant ssh k8s1 -- cat /home/vagrant/.kube/config | sed 's;server:.*:6443;server: https://k8s1:7443;g' > vagrant.kubeconfig
+        echo "Add '127.0.0.1 k8s1' to your /etc/hosts to use vagrant.kubeconfig file for kubectl"
+    fi
 fi
 


### PR DESCRIPTION
In case `vagrant up` returned with non-zero status (e.g. due to being
canceled or the initial box download failing), the script would still
attempt to `vagrant ssh` to k8s1 and print a message in case $K8S is
non-zero. Fix this by only executing `vagrant ssh k8s1` if `vagrant up`
was successful. Also fix indentation.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10049)
<!-- Reviewable:end -->
