### PR TITLE
CI: PolicyTest toEntities All

### DIFF
--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -167,9 +167,10 @@ var _ = Describe("K8sPolicyTest", func() {
 					"ICMP egress connectivity to 8.8.8.8 from pod %q", pod)
 
 				By("DNS lookup of kubernetes.default.svc.cluster.local")
+				// -R3 retry 3 times, -N1 ndots set to 1, -t A only lookup A records
 				res = kubectl.ExecPodCmd(
 					namespaceForTest, pod,
-					"host -v kubernetes.default.svc.cluster.local")
+					"host -v -R3 -N1 -t A kubernetes.default.svc.cluster.local.")
 
 				// kube-dns is always whitelisted so this should always work
 				ExpectWithOffset(1, res).To(getMatcher(expectWorldSuccess || expectClusterSuccess),
@@ -615,9 +616,10 @@ var _ = Describe("K8sPolicyTest", func() {
 					helpers.Ping("8.8.8.8"))
 				res.ExpectSuccess("Egress ping connectivity should be allowed for pod %q", pod)
 
+				// -R3 retry 3 times, -N1 ndots set to 1, -t A only lookup A records
 				res = kubectl.ExecPodCmd(
 					namespaceForTest, pod,
-					"host kubernetes.default.svc.cluster.local")
+					"host -v -R3 -N1 -t A kubernetes.default.svc.cluster.local.")
 				res.ExpectSuccess("Egress DNS connectivity should be allowed for pod %q", pod)
 			}
 		})


### PR DESCRIPTION
Queries via host were iterating through the search list. This meant that
the first few attempts would always fail, and this seemed to fail
outright sometimes. This change forces 3 retries on the domain without
using the search list. This should mean that NXDomain should never
be returned as kubernetes.default.svc.cluster.local. is always defined.

May fix https://github.com/cilium/cilium/issues/10050

**Edit 2020-02-06**
Reviewers, this has passed pretty consistently. That doesn't mean that it fixes anything, but it doesn't seem to have broken the test. Should be mergeable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10051)
<!-- Reviewable:end -->
