### PR TITLE
kubernetes: Disable LocalNodeRoute while chaining

### DIFF
--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -226,6 +226,11 @@ data:
   #  - flannel
   #  - portmap (Enables HostPort support for Cilium)
   cni-chaining-mode: {{ .Values.global.cni.chainingMode }}
+
+  # Disable the PodCIDR route to the cilium_host interface as it is not
+  # required. While chaining, it is the responsibility of the underlying plugin
+  # to enable routing.
+  enable-local-node-route: "false"
 {{- end }}
 
   masquerade: {{ .Values.global.masquerade | quote }}


### PR DESCRIPTION
While chaining, a route covering the AllocCIDR was still being installed
pointing to the cilium_host interface. Ideally the k8s node resource populates
the PodCIDR information in which case this is harmless. If the PodCIDR is not
known, Cilium would fall back to allocate a PodCIDR using the standard
10.x.0.0/16 template which then had the potential to conflict witha PodCIDR of
another node.

In case of a conflict, the rp_filter protection could cause packet loss due to
conflicting routes.

Related: #9794

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10057)
<!-- Reviewable:end -->
