### PR TITLE
bpf: remove `Map.DeleteWithErrno()`

### DIFF
--- a/pkg/datapath/ipcache/listener.go
+++ b/pkg/datapath/ipcache/listener.go
@@ -177,7 +177,7 @@ func (l *BPFListener) OnIPIdentityCacheChange(modType ipcache.CacheModification,
 			}).Warning("unable to update bpf map")
 		}
 	case ipcache.Delete:
-		err := l.bpfMap.Delete(&key)
+		err := l.bpfMap.DeleteWithOverwrite(&key)
 		if err != nil {
 			scopedLog.WithError(err).WithFields(logrus.Fields{
 				"key":                  key.String(),
@@ -278,7 +278,7 @@ func (l *BPFListener) garbageCollect(ctx context.Context) (*sync.WaitGroup, erro
 		for _, k := range keysToRemove {
 			log.WithFields(logrus.Fields{logfields.BPFMapKey: k}).
 				Debug("deleting from ipcache BPF map")
-			if err := l.bpfMap.Delete(k); err != nil {
+			if err := l.bpfMap.DeleteWithOverwrite(k); err != nil {
 				return nil, fmt.Errorf("error deleting key %s from ipcache BPF map: %s", k, err)
 			}
 		}

--- a/pkg/maps/ipcache/ipcache.go
+++ b/pkg/maps/ipcache/ipcache.go
@@ -15,6 +15,7 @@
 package ipcache
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"sync"
@@ -181,21 +182,23 @@ func NewMap(name string) *Map {
 // If "overwrite" is true, then if delete is not supported the entry's value
 // will be overwritten with zeroes to signify that it's an invalid entry.
 func (m *Map) delete(k bpf.MapKey, overwrite bool) (bool, error) {
-	// Older kernels do not support deletion of LPM map entries so zero out
-	// the entry instead of attempting a deletion
-	err, errno := m.DeleteWithErrno(k)
-	if errno == unix.ENOSYS {
+	err := m.Delete(k)
+	var errno unix.Errno
+	if ok := errors.As(err, &errno); ok && errno == unix.ENOSYS {
 		if overwrite {
+			// Older kernels do not support deletion of LPM map entries so zero out
+			// the entry instead of attempting a deletion
 			return false, m.Update(k, &RemoteEndpointInfo{})
 		}
 		return false, nil
 	}
-
 	return true, err
 }
 
-// Delete removes a key from the ipcache BPF map
-func (m *Map) Delete(k bpf.MapKey) error {
+// DeleteWithOverwrite removes a key from the ipcache BPF map.
+// If delete is not supported, the entry's value will be overwritten with
+// zeroes to signify that it's an invalid entry.
+func (m *Map) DeleteWithOverwrite(k bpf.MapKey) error {
 	_, err := m.delete(k, true)
 	return err
 }

--- a/pkg/maps/policymap/policymap.go
+++ b/pkg/maps/policymap/policymap.go
@@ -17,7 +17,6 @@ package policymap
 import (
 	"bytes"
 	"fmt"
-	"syscall"
 	"unsafe"
 
 	"github.com/cilium/cilium/pkg/bpf"
@@ -199,9 +198,9 @@ func (pm *PolicyMap) Exists(id uint32, dport uint16, proto u8proto.U8proto, traf
 
 // DeleteKey deletes the key-value pair from the given PolicyMap with PolicyKey
 // k. Returns an error if deletion from the PolicyMap fails.
-func (pm *PolicyMap) DeleteKeyWithErrno(key PolicyKey) (error, syscall.Errno) {
+func (pm *PolicyMap) DeleteKey(key PolicyKey) error {
 	k := key.ToNetwork()
-	return pm.Map.DeleteWithErrno(&k)
+	return pm.Map.Delete(&k)
 }
 
 // Delete removes an entry from the PolicyMap for identity `id`

--- a/pkg/maps/policymap/policymap_privileged_test.go
+++ b/pkg/maps/policymap/policymap_privileged_test.go
@@ -17,9 +17,9 @@
 package policymap
 
 import (
+	"errors"
 	"fmt"
 	"os"
-	"syscall"
 	"testing"
 
 	"github.com/cilium/cilium/pkg/bpf"
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/u8proto"
 
+	"golang.org/x/sys/unix"
 	. "gopkg.in/check.v1"
 )
 
@@ -98,7 +99,9 @@ func (pm *PolicyMapTestSuite) TestPolicyMapDumpToSlice(c *C) {
 
 func (pm *PolicyMapTestSuite) TestDeleteNonexistentKey(c *C) {
 	key := newKey(27, 80, u8proto.ANY, trafficdirection.Ingress)
-	err, errno := testMap.Map.DeleteWithErrno(&key)
+	err := testMap.Map.Delete(&key)
 	c.Assert(err, Not(IsNil))
-	c.Assert(errno, Equals, syscall.ENOENT)
+	var errno unix.Errno
+	c.Assert(errors.As(err, &errno), Equals, true)
+	c.Assert(errno, Equals, unix.ENOENT)
 }


### PR DESCRIPTION
`Map.Delete()` now wraps the underlying errno when returning an error.

Therefore, `Map.DeleteWithErrno()` is rendered obsolete as checking for an error of type `syscall.Errno` can now be done using `errors.Is()` or `errors.As()` with the error returned by `Map.Delete()`.

Fixes #8324

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10058)
<!-- Reviewable:end -->
