### PR TITLE
ipam: Protect release from releasing alive IP

### DIFF
--- a/daemon/ipam.go
+++ b/daemon/ipam.go
@@ -110,6 +110,14 @@ func NewDeleteIPAMIPHandler(d *Daemon) ipamapi.DeleteIpamIPHandler {
 }
 
 func (h *deleteIPAMIP) Handle(params ipamapi.DeleteIpamIPParams) middleware.Responder {
+	// Release of an IP that is in use is not allowed
+	if ep := h.daemon.endpointManager.LookupIPv4(params.IP); ep != nil {
+		return api.Error(ipamapi.DeleteIpamIPFailureCode, fmt.Errorf("IP is in use by endpoint %d", ep.ID))
+	}
+	if ep := h.daemon.endpointManager.LookupIPv6(params.IP); ep != nil {
+		return api.Error(ipamapi.DeleteIpamIPFailureCode, fmt.Errorf("IP is in use by endpoint %d", ep.ID))
+	}
+
 	if err := h.daemon.ipam.ReleaseIPString(params.IP); err != nil {
 		return api.Error(ipamapi.DeleteIpamIPFailureCode, err)
 	}


### PR DESCRIPTION
It has been observed that kubelet calls CNI DELETE multiple times with
potentially stale CNI result information. This can lead to a race condition
where the initial CNI DELETE properly releases the IP in use which then gets
reused by a different pod. Any subsequent CNI DELETE with the stale IP will
then cause the IP of the live pod to be released. While the pod will continue
to function, the next scheduled pod will attempt to use that IP and
continuously fail to be scheduled due to a IP in use error.

This is a regression of commit ab61853 which introduced the ability for CNI
DELETE to release an IP even if the endpoint deletion fails which is required
to fix the race condition when the CNI binary gets killed in between allocating
an IP and creating the endpoint.

Fixes: ab61853ca3 ("cni: Release IP even when endpoint deletion fails")
Fixes: #10065

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10066)
<!-- Reviewable:end -->
