### PR TITLE
linux: check policy routing of running kernel

### DIFF
--- a/pkg/datapath/linux/requirements.go
+++ b/pkg/datapath/linux/requirements.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cilium/cilium/pkg/versioncheck"
 
 	go_version "github.com/blang/semver"
+	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 )
 
@@ -145,6 +146,12 @@ func CheckMinRequirements() {
 	if !isMinKernelVer(kernelVersion) {
 		log.Fatalf("kernel version: NOT OK: minimal supported kernel "+
 			"version is %s; kernel version that is running is: %s", minKernelVer, kernelVersion)
+	}
+
+	_, err = netlink.RuleList(netlink.FAMILY_V4)
+	if err == unix.EAFNOSUPPORT {
+		log.WithError(err).Error("Policy routing:NOT OK. " +
+			"Please enable kernel configuration item CONFIG_IP_MULTIPLE_TABLES")
 	}
 
 	if option.Config.EnableIPv6 {


### PR DESCRIPTION
Check the payload of the NLMSG_DONE type netlink
message for possible error, then determine whether
CONFIG_IP_MULTIPLE_TABLES is enabled.

Signed-off-by: Jianlin Lv <Jianlin.Lv@arm.com>

Fixes: #9834

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10068)
<!-- Reviewable:end -->
