### PR TITLE
CI: Local CI runs don't set CILIUM_REGISTRY

### DIFF
--- a/test/config/config.go
+++ b/test/config/config.go
@@ -71,7 +71,7 @@ func (c *CiliumTestConfigType) ParseFlags() {
 		"Specifies timeout for test run")
 	flag.StringVar(&c.Kubeconfig, "cilium.kubeconfig", "",
 		"Kubeconfig to be used for k8s tests")
-	flag.StringVar(&c.Registry, "cilium.registry", "k8s1:5000", "docker registry hostname for Cilium image")
+	flag.StringVar(&c.Registry, "cilium.registry", "", "docker registry hostname for Cilium image")
 	flag.BoolVar(&c.Benchmarks, "cilium.benchmarks", false,
 		"Specifies benchmark tests should be run which may increase test time")
 }


### PR DESCRIPTION
We need to indicate whether to build cilium. This is only relevant when
running tests locally and cilium needs to be compiled. Historically,
the image has been pushed to k8s1:5000, a repository that runs on the
k8s1 host. We now use the global.registry value, piped into
CILIUM_REGISTRY, to indicate whether to build cilium. This was being set
to a default of "k8s1:5000" thus forcing compile.sh into pulling a
prebuilt image from CILIUM_REGISTRY. This is the intended behaviour on
CI and when running on managed k8s. In this one case, however, it is
incorrect.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10077)
<!-- Reviewable:end -->
