### PR TITLE
ipcache: Fix ipcache pod IP update

### DIFF
--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2019 Authors of Cilium
+// Copyright 2018-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -455,5 +455,5 @@ func (m *K8sMetadata) Equal(o *K8sMetadata) bool {
 		return false
 	}
 
-	return m.Namespace == o.Namespace && m.PodName == m.PodName
+	return m.Namespace == o.Namespace && m.PodName == o.PodName
 }


### PR DESCRIPTION
If an IP was reused by another pod, then a bug in the pod/namespace
comparison logic would prevent the ipcache being updated for the pod.
Fix it.

Reported-at: https://lgtm.com/projects/g/cilium/cilium/alerts
Fixes: 348051e7aaaf ("ipcache: Associate IPs with K8s namespace and pod name")
Related: #10099 

Only affects v1.7 branch AFAICT.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10098)
<!-- Reviewable:end -->
