### PR TITLE
Add TODOs badge to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 |logo|
 
-|cii| |build-status| |pulls| |slack| |go-report| |go-doc| |rtd| |apache| |gpl|
+|cii| |build-status| |pulls| |slack| |go-report| |go-doc| |rtd| |apache| |gpl| |TODOs|
 
 Cilium is open source software for providing and transparently securing network
 connectivity and loadbalancing between application workloads such as
@@ -308,3 +308,7 @@ under the `General Public License, Version 2.0 <bpf/COPYING>`_.
 .. |pulls| image:: https://img.shields.io/docker/pulls/cilium/cilium.svg
     :alt: Cilium pulls
     :target: https://hub.docker.com/r/cilium/cilium/tags/
+    
+.. |TODOs| image:: https://badgen.net/https/api.tickgit.com/badgen/github.com/cilium/cilium
+    :alt: TODOs
+    :target: https://www.tickgit.com/browse?repo=github.com/cilium/cilium


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](http://docs.cilium.io/en/stable/contributing/contributing/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue. 
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](http://docs.cilium.io/en/stable/contributing/contributing/#dev-coo).
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->
This PR adds a badge to the README which displays the number of TODO comments found in this repository's source code. Please see the linked issue for more info. Hopefully, the badge and corresponding index can help contributors be more aware of TODO comments worth returning to in the codebase. TODOs are often forgotten, but they don't have to be!

Fixes: #10018

```release-note
Add TODOs badge to README
```

[![TODOs](https://badgen.net/https/api.tickgit.com/badgen/github.com/cilium/cilium)](https://www.tickgit.com/browse?repo=github.com/cilium/cilium)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10103)
<!-- Reviewable:end -->

Thank you for considering this PR. I understand not all badges are suitable for every repository and respect any decision regarding merging vs not.