### PR TITLE
alignchecker: split alignment checks for monitor types into own package

### DIFF
--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cilium/cilium/api/v1/server"
 	"github.com/cilium/cilium/api/v1/server/restapi"
 	"github.com/cilium/cilium/common"
-	_ "github.com/cilium/cilium/pkg/alignchecker"
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/cgroups"
 	"github.com/cilium/cilium/pkg/cleanup"

--- a/pkg/datapath/alignchecker/alignchecker.go
+++ b/pkg/datapath/alignchecker/alignchecker.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/maps/sockmap"
 	"github.com/cilium/cilium/pkg/maps/tunnel"
-	"github.com/cilium/cilium/pkg/monitor"
 )
 
 // CheckStructAlignments checks whether size and offsets of the C and Go
@@ -69,10 +68,6 @@ func CheckStructAlignments(path string) error {
 			reflect.TypeOf(eppolicymap.EndpointKey{}),
 			reflect.TypeOf(tunnel.TunnelEndpoint{}),
 		},
-		"trace_notify":      {reflect.TypeOf(monitor.TraceNotify{})},
-		"drop_notify":       {reflect.TypeOf(monitor.DropNotify{})},
-		"debug_msg":         {reflect.TypeOf(monitor.DebugMsg{})},
-		"debug_capture_msg": {reflect.TypeOf(monitor.DebugCapture{})},
 	}
 	return check.CheckStructAlignments(path, toCheck)
 }

--- a/pkg/monitor/alignchecker/alignchecker.go
+++ b/pkg/monitor/alignchecker/alignchecker.go
@@ -1,0 +1,35 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package alignchecker
+
+import (
+	"reflect"
+
+	check "github.com/cilium/cilium/pkg/alignchecker"
+	"github.com/cilium/cilium/pkg/monitor"
+)
+
+// See pkg/datapath/alignchecker/alignchecker.go:CheckStructAlignments()
+// comment.
+func CheckStructAlignments(path string) error {
+	// Validate alignments of C and Go equivalent structs
+	toCheck := map[string][]reflect.Type{
+		"trace_notify":      {reflect.TypeOf(monitor.TraceNotify{})},
+		"drop_notify":       {reflect.TypeOf(monitor.DropNotify{})},
+		"debug_msg":         {reflect.TypeOf(monitor.DebugMsg{})},
+		"debug_capture_msg": {reflect.TypeOf(monitor.DebugCapture{})},
+	}
+	return check.CheckStructAlignments(path, toCheck)
+}

--- a/pkg/monitor/alignchecker/doc.go
+++ b/pkg/monitor/alignchecker/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package alignchecker is a thin wrapper around pkg/alignchecker to validate
+// monitor object alignment.
+package alignchecker

--- a/tools/alignchecker/main.go
+++ b/tools/alignchecker/main.go
@@ -18,7 +18,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/cilium/cilium/pkg/datapath/alignchecker"
+	datapathchecker "github.com/cilium/cilium/pkg/datapath/alignchecker"
+	monitorchecker "github.com/cilium/cilium/pkg/monitor/alignchecker"
 )
 
 func main() {
@@ -32,8 +33,12 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Cannot check alignment against %s: %s\n", bpfObjPath, err)
 		os.Exit(1)
 	}
-	if err := alignchecker.CheckStructAlignments(bpfObjPath); err != nil {
-		fmt.Fprintf(os.Stderr, "C and Go structs alignment check failed: %s\n", err)
+	if err := datapathchecker.CheckStructAlignments(bpfObjPath); err != nil {
+		fmt.Fprintf(os.Stderr, "C and Go structs alignment check in datapath failed: %s\n", err)
+		os.Exit(1)
+	}
+	if err := monitorchecker.CheckStructAlignments(bpfObjPath); err != nil {
+		fmt.Fprintf(os.Stderr, "C and Go structs alignment check in monitor failed: %s\n", err)
 		os.Exit(1)
 	}
 	fmt.Fprintf(os.Stdout, "OK\n")


### PR DESCRIPTION
The `datapath/alignchecker` package also checks the monitor types for
proper alignment and thus needs to import the monitor package. These
types are not used in the agend but importing the package ends up
pulling in `github.com/google/gopacket` which adds quite a lot to the
binary size.
    
Thus, split out the alignment checks for the monitor types into its own
subpackage of package monitor, `monitor/alignchecker` and call the
corresponding `CheckStructAlignments` from `tools/alignchecker/main.go` as
well.
    
This reduces the binary size of cilium-agent by ~2MB.

Updates #10056
    
Signed-off-by: Tobias Klauser <tklauser@distanz.ch>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10107)
<!-- Reviewable:end -->
