### PR TITLE
test: Add Kubernetes Service CI tests for IPv6

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2796,6 +2796,43 @@ CILIUM_SERVICES:
 	return validateCiliumSvcLB(*ciliumService, ciliumLB)
 }
 
+// CiliumServiceAdd adds the given service on a 'pod' running Cilium
+func (kub *Kubectl) CiliumServiceAdd(pod string, id int64, frontend string, backends []string, svcType, trafficPolicy string) error {
+	var opts []string
+	switch strings.ToLower(svcType) {
+	case "nodeport":
+		opts = append(opts, "--k8s-node-port")
+	case "externalip":
+		opts = append(opts, "--k8s-external")
+	case "clusterip":
+		// this is the default
+	default:
+		return fmt.Errorf("invalid service type: %q", svcType)
+	}
+
+	trafficPolicy = strings.Title(strings.ToLower(trafficPolicy))
+	switch trafficPolicy {
+	case "Cluster", "Local":
+		opts = append(opts, "--k8s-traffic-policy "+trafficPolicy)
+	default:
+		return fmt.Errorf("invalid traffic policy: %q", svcType)
+	}
+
+	optsStr := strings.Join(opts, " ")
+	backendsStr := strings.Join(backends, ",")
+	ctx, cancel := context.WithTimeout(context.Background(), ShortCommandTimeout)
+	defer cancel()
+	return kub.CiliumExecContext(ctx, pod, fmt.Sprintf("cilium service update --id %d --frontend %q --backends %q %s",
+		id, frontend, backendsStr, optsStr)).GetErr("cilium service update")
+}
+
+// CiliumServiceDel deletes the service with 'id' on a 'pod' running Cilium
+func (kub *Kubectl) CiliumServiceDel(pod string, id int64) error {
+	ctx, cancel := context.WithTimeout(context.Background(), ShortCommandTimeout)
+	defer cancel()
+	return kub.CiliumExecContext(ctx, pod, fmt.Sprintf("cilium service delete %d", id)).GetErr("cilium service delete")
+}
+
 // ciliumServicePreFlightCheck checks that k8s service is plumbed correctly
 func (kub *Kubectl) ciliumServicePreFlightCheck() error {
 	ginkgoext.By("Performing Cilium service preflight check")

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1550,6 +1550,16 @@ func (kub *Kubectl) CiliumEndpointsStatus(pod string) map[string]string {
 		"cilium endpoint list -o jsonpath='%s'", filter)).KVOutput()
 }
 
+// CiliumEndpointIPv6 returns the IPv6 address of each endpoint which matches
+// the given endpoint selector.
+func (kub *Kubectl) CiliumEndpointIPv6(pod string, endpoint string) map[string]string {
+	filter := `{range [*]}{@.status.external-identifiers.pod-name}{"="}{@.status.networking.addressing[*].ipv6}{"\n"}{end}`
+	ctx, cancel := context.WithTimeout(context.Background(), ShortCommandTimeout)
+	defer cancel()
+	return kub.CiliumExecContext(ctx, pod, fmt.Sprintf(
+		"cilium endpoint get %s -o jsonpath='%s'", endpoint, filter)).KVOutput()
+}
+
 // CiliumEndpointWaitReady waits until all endpoints managed by all Cilium pod
 // are ready. Returns an error if the Cilium pods cannot be retrieved via
 // Kubernetes, or endpoints are not ready after a specified timeout

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -392,7 +392,10 @@ var _ = Describe("K8sServicesTest", func() {
 					ExpectWithOffset(1, res).Should(helpers.CMDSuccess(),
 						"Can not connect to service %q from outside cluster", url)
 					if checkSourceIP {
-						Expect(strings.TrimSpace(strings.Split(res.GetStdOut(), "=")[1])).To(Equal(clientIP))
+						// Parse the IPs to avoid issues with 4-in-6 formats
+						sourceIP := net.ParseIP(strings.TrimSpace(strings.Split(res.GetStdOut(), "=")[1]))
+						clientIP := net.ParseIP(clientIP)
+						Expect(sourceIP).To(Equal(clientIP))
 					}
 				}
 			}

--- a/test/k8sT/manifests/demo_ds.yaml
+++ b/test/k8sT/manifests/demo_ds.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: web
-        image: docker.io/cilium/echoserver:1.10
+        image: docker.io/cilium/echoserver:1.10.1
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
@@ -76,7 +76,7 @@ spec:
     spec:
       containers:
       - name: web
-        image: docker.io/cilium/echoserver:1.10
+        image: docker.io/cilium/echoserver:1.10.1
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80

--- a/test/k8sT/manifests/echo-svc.yaml
+++ b/test/k8sT/manifests/echo-svc.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: echo-container
-        image: docker.io/cilium/json-mock:1.1
+        image: docker.io/cilium/json-mock:1.2
         livenessProbe:
           exec:
             command:


### PR DESCRIPTION
This adds initial connectivity tests for IPv6 in the Kubernetes service test suite. The deployed Kubernetes is not yet running in dual-stack mode - therefore we install the Cilium service rules manually via CLI. Because of this, the IPv6 tests are only ran in kube-proxy-free mode, as kube-proxy only installs IPv4 rules.

NodePort and ExternalIP tests have yet to be implemented in a follow-up PR. This PR here lays the groundwork by upgrading all images to listen on IPv6, providing helpers to install services via Cilium CLI, and adding basic ClusterIP tests.

Ref #9362 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10115)
<!-- Reviewable:end -->
