### PR TITLE
test: Determine private / public iface dynamically

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -198,11 +198,6 @@ const (
 	// DockerBridgeIP is the IP on the docker0 bridge
 	DockerBridgeIP = "172.17.0.1"
 
-	// PrivateIface is the name of interface which is used to communicate with
-	// other cluster nodes
-	// FIXME Determine dynamically the iface
-	PrivateIface = "enp0s8"
-
 	// Logs messages that should not be in the cilium logs.
 	panicMessage      = "panic:"
 	deadLockHeader    = "POTENTIAL DEADLOCK:"       // from github.com/sasha-s/go-deadlock/deadlock.go:header

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -255,6 +255,10 @@ func CreateKubectl(vmName string, log *logrus.Entry) (k *Kubectl) {
 		ginkgoext.Fail(fmt.Sprintf("Cannot connect to k8s cluster, output:\n%s", res.CombineOutput().String()), 1)
 		return nil
 	}
+	if err := k.WaitforPods(LogGathererNamespace, "-l "+logGathererSelector(true), HelperTimeout); err != nil {
+		ginkgoext.Fail(fmt.Sprintf("Failed waiting for log-gatherer pods: %s", err), 1)
+		return nil
+	}
 
 	return k
 }

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -383,11 +383,14 @@ var _ = Describe("K8sDatapathConfig", func() {
 			SkipIfIntegration(helpers.CIIntegrationFlannel)
 			SkipItIfNoKubeProxy()
 
+			privateIface, err := kubectl.GetPrivateIface()
+			Expect(err).Should(BeNil(), "Unable to determine private iface")
+
 			deployCilium(map[string]string{
 				"global.tunnel":               "disabled",
 				"global.autoDirectNodeRoutes": "true",
 				"global.encryption.enabled":   "true",
-				"global.encryption.interface": "enp0s8",
+				"global.encryption.interface": privateIface,
 			})
 			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
 		})

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -59,7 +59,7 @@ var _ = Describe("K8sServicesTest", func() {
 		// Nodes are used in testNodePort and testExternalTrafficPolicyLocal below
 		nodeName, err := kubectl.GetNodeNameByLabel(label)
 		Expect(err).To(BeNil(), "Cannot get node by label "+label)
-		nodeIP, err = kubectl.GetNodeIPByLabel(label)
+		nodeIP, err = kubectl.GetNodeIPByLabel(label, false)
 		Expect(err).Should(BeNil(), "Can not retrieve Node IP for "+label)
 		return nodeName, nodeIP
 	}
@@ -677,8 +677,6 @@ var _ = Describe("K8sServicesTest", func() {
 			helpers.DoesNotRunOnNetNext,
 			"Tests NodePort BPF", func() {
 				// TODO(brb) Add with L7 policy test cases after GH#8971 has been fixed
-
-				nativeDev := "enp0s8"
 
 				BeforeAll(func() {
 					enableBackgroundReport = false

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -694,10 +694,7 @@ var _ = Describe("K8sServicesTest", func() {
 
 				Context("Tests with vxlan", func() {
 					BeforeAll(func() {
-						DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
-							"global.nodePort.enabled": "true",
-							"global.nodePort.device":  nativeDev,
-						})
+						DeployCiliumAndDNS(kubectl, ciliumFilename)
 					})
 
 					It("Tests NodePort", func() {
@@ -716,8 +713,6 @@ var _ = Describe("K8sServicesTest", func() {
 				Context("Tests with direct routing", func() {
 					BeforeAll(func() {
 						DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
-							"global.nodePort.enabled":     "true",
-							"global.nodePort.device":      nativeDev,
 							"global.tunnel":               "disabled",
 							"global.autoDirectNodeRoutes": "true",
 						})
@@ -763,8 +758,6 @@ var _ = Describe("K8sServicesTest", func() {
 
 				SkipItIf(helpers.DoesNotExistNodeWithoutCilium, "Tests with direct routing and DSR", func() {
 					DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
-						"global.nodePort.enabled":     "true",
-						"global.nodePort.device":      nativeDev,
 						"global.nodePort.mode":        "dsr",
 						"global.tunnel":               "disabled",
 						"global.autoDirectNodeRoutes": "true",

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -729,30 +729,30 @@ var _ = Describe("K8sServicesTest", func() {
 					It("Tests HealthCheckNodePort", func() {
 						testHealthCheckNodePort()
 					})
-				})
 
-				SkipContextIf(helpers.DoesNotExistNodeWithoutCilium, "Tests with MetalLB", func() {
-					var (
-						metalLB string
-					)
+					SkipContextIf(helpers.DoesNotExistNodeWithoutCilium, "Tests with MetalLB", func() {
+						var (
+							metalLB string
+						)
 
-					BeforeAll(func() {
-						// Will allocate LoadBalancer IPs from 192.168.36.{240-250} range
-						metalLB = helpers.ManifestGet(kubectl.BasePath(), "metallb.yaml")
-						res := kubectl.ApplyDefault(metalLB)
-						res.ExpectSuccess("Unable to apply %s", metalLB)
-					})
+						BeforeAll(func() {
+							// Will allocate LoadBalancer IPs from 192.168.36.{240-250} range
+							metalLB = helpers.ManifestGet(kubectl.BasePath(), "metallb.yaml")
+							res := kubectl.ApplyDefault(metalLB)
+							res.ExpectSuccess("Unable to apply %s", metalLB)
+						})
 
-					AfterAll(func() {
-						_ = kubectl.Delete(metalLB)
-					})
+						AfterAll(func() {
+							_ = kubectl.Delete(metalLB)
+						})
 
-					It("Connectivity to endpoint via LB", func() {
-						lbIP, err := kubectl.GetLoadBalancerIP(
-							helpers.DefaultNamespace, "test-lb", 30*time.Second)
-						Expect(err).Should(BeNil(), "Cannot retrieve loadbalancer IP for test-lb")
+						It("Connectivity to endpoint via LB", func() {
+							lbIP, err := kubectl.GetLoadBalancerIP(
+								helpers.DefaultNamespace, "test-lb", 30*time.Second)
+							Expect(err).Should(BeNil(), "Cannot retrieve loadbalancer IP for test-lb")
 
-						doRequestsFromThirdHost("http://"+lbIP, 10, false)
+							doRequestsFromThirdHost("http://"+lbIP, 10, false)
+						})
 					})
 				})
 

--- a/test/k8sT/manifests/log-gatherer.yaml
+++ b/test/k8sT/manifests/log-gatherer.yaml
@@ -1,3 +1,11 @@
+# ServiceAccount=cilium, which log-gatherer depends on, is created by
+# ciliumInstallHelm(). However, ciliumInstallHelm() depends on log-gatherer to
+# dynamically determine private / public ifaces. So, create it here as well.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cilium
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/test/k8sT/manifests/log-gatherer.yaml
+++ b/test/k8sT/manifests/log-gatherer.yaml
@@ -30,7 +30,7 @@ spec:
         - "10000"
         command:
         - sleep
-        image: nebril/systemd:latest #TODO: move to cilium org
+        image: docker.io/cilium/log-gatherer:v1.0
         imagePullPolicy: Always
         name: log-gatherer
         securityContext:


### PR DESCRIPTION
This PR:

- Determines private / public ifaces (used by NodePort or IPSec) dynamically.
- Removes unnecessary `nodePort.enabled=true` from `k8sT/Services.go`.
- Moves the MetalLB test case into the direct routing context to avoid accidentally changing the datapath configuration of the test case.
- Use log-gatherer from https://github.com/cilium/log-gatherer. Also, add `ServiceAccount=cilium` for it.

Reviewable per commit.

TODO:

- [x] Rebase #10087 once it's been merged.
- [x] Add iproute2 to log-gatherer Docker image.
- [ ] ~Use dynamic iface retriever in the kube-proxy matrix tests.~ Will do it in a separate PR, as it requires provisioning k8s nodes with ExternalIP.

```release-note
Dynamically determine native dev iface for NodePort/externalIPs
```

Fix #10023.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10119)
<!-- Reviewable:end -->
