### PR TITLE
datapath/linux,maps/ipcache: consistently use BackedByLPM() helper

### DIFF
--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Authors of Cilium
+// Copyright 2019-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,7 +33,6 @@ import (
 	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/maps/encrypt"
 	"github.com/cilium/cilium/pkg/maps/eppolicymap"
-	"github.com/cilium/cilium/pkg/maps/ipcache"
 	ipcachemap "github.com/cilium/cilium/pkg/maps/ipcache"
 	"github.com/cilium/cilium/pkg/maps/lbmap"
 	"github.com/cilium/cilium/pkg/maps/lxcmap"
@@ -317,7 +316,7 @@ func (h *HeaderfileWriter) writeNetdevConfig(w io.Writer, cfg datapath.DeviceCon
 
 	// In case the Linux kernel doesn't support LPM map type, pass the set
 	// of prefix length for the datapath to lookup the map.
-	if ipcache.IPCache.MapType != bpf.BPF_MAP_TYPE_LPM_TRIE {
+	if !ipcachemap.BackedByLPM() {
 		ipcachePrefixes6, ipcachePrefixes4 := cfg.GetCIDRPrefixLengths()
 
 		fmt.Fprint(w, "#define IPCACHE6_PREFIXES ")

--- a/pkg/maps/ipcache/ipcache.go
+++ b/pkg/maps/ipcache/ipcache.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 Authors of Cilium
+// Copyright 2016-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -203,7 +203,7 @@ func (m *Map) Delete(k bpf.MapKey) error {
 // GetMaxPrefixLengths determines how many unique prefix lengths are supported
 // simultaneously based on the underlying BPF map type in use.
 func (m *Map) GetMaxPrefixLengths() (ipv6, ipv4 int) {
-	if IPCache.MapType == bpf.BPF_MAP_TYPE_LPM_TRIE {
+	if BackedByLPM() {
 		return net.IPv6len*8 + 1, net.IPv4len*8 + 1
 	}
 	return maxPrefixLengths6, maxPrefixLengths4


### PR DESCRIPTION
This commit introduces no functional changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10122)
<!-- Reviewable:end -->
