### PR TITLE
Documentation: Switch EKS documentation to default to ENI

### DIFF
--- a/Documentation/gettingstarted/k8s-install-eks.rst
+++ b/Documentation/gettingstarted/k8s-install-eks.rst
@@ -69,6 +69,15 @@ You should see something like this:
 	[...]
 	[✔]  EKS cluster "test-cluster" in "us-west-2" region is ready
 
+Disable the aws-node DaemonSet (EKS only)
+=========================================
+
+If you are running an EKS cluster, disable the ``aws-node`` DaemonSet so it
+does not interfere with the ENIs managed by Cilium:
+
+.. code:: bash
+
+   kubectl -n kube-system set image daemonset/aws-node aws-node=docker.io/spaster/alpine-sleep
 
 Prepare & Deploy Cilium
 =======================
@@ -81,14 +90,10 @@ Deploy Cilium release via Helm:
 
    helm install cilium |CHART_RELEASE| \\
      --namespace kube-system \\
-     --set global.cni.chainingMode=aws-cni \\
-     --set global.masquerade=false \\
+     --set global.eni=true \\
+     --set global.egressMasqueradeInterfaces=eth0 \\
      --set global.tunnel=disabled \\
      --set global.nodeinit.enabled=true
-
-You might also want to pass the ``--set global.restartPods`` switch to the
-``helm`` command above. This will restart existing pods when initializing the
-node to force all pods to be managed by Cilium.
 
 Scale up the cluster
 ====================
@@ -105,7 +110,6 @@ Scale up the cluster
     [ℹ]  scaling nodegroup stack "eksctl-test-cluster-nodegroup-ng-25560078" in cluster eksctl-test-cluster-cluster
     [ℹ]  scaling nodegroup, desired capacity from 0 to 2
 
-.. include:: k8s-install-restart-pods.rst
 .. include:: k8s-install-validate.rst
 .. include:: hubble-install.rst
 .. include:: getting-started-next-steps.rst


### PR DESCRIPTION
ENI has been rock-solid and it is time to point the default EKS documentation
to use ENI mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10126)
<!-- Reviewable:end -->
