### PR TITLE
pkg/eventqueue: fix concurrent access of waitConsumeOffQueue

### DIFF
--- a/pkg/eventqueue/eventqueue.go
+++ b/pkg/eventqueue/eventqueue.go
@@ -144,7 +144,7 @@ type eventStatistics struct {
 	durationStat spanstat.SpanStat
 
 	// waitConsumeOffQueue shows how long it took for the event to be consumed
-	// off of the queue.
+	// plus the time it the event waited in the queue.
 	waitConsumeOffQueue spanstat.SpanStat
 }
 
@@ -213,9 +213,9 @@ func (q *EventQueue) Enqueue(ev *Event) (<-chan interface{}, error) {
 		// event is processed, then it will be cancelled.
 
 		ev.stats.waitEnqueue.Start()
+		ev.stats.waitConsumeOffQueue.Start()
 		q.events <- ev
 		ev.stats.waitEnqueue.End(true)
-		ev.stats.waitConsumeOffQueue.Start()
 		return ev.eventResults, nil
 	}
 }


### PR DESCRIPTION
spanStart of waitConsumeOffQueue could be read before being written in
case the buffered event was executed before the execution of
waitConsumeOffQueue.Start() in the modified lines of this commit. To fix
this we should execute waitConsumeOffQueue.Start() even before the event
is put into the queue. Although it does not give the correct span stat,
the developer or user can derieve it by subtracting the waitEnqueue span
to retrieve the real waitConsumeOffQueue span.

Fixes: add0d65b0a90 ("add eventqueue package")
Signed-off-by: André Martins <andre@cilium.io>

```release-note
Fix concurrent access of a variable used for metrics
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10137)
<!-- Reviewable:end -->
