### PR TITLE
test: use curl -O instead of output redirection

### DIFF
--- a/test/kubernetes-test.sh
+++ b/test/kubernetes-test.sh
@@ -54,7 +54,7 @@ cd kubernetes
 
 # Kubernetes is only compiling with golang 1.13.4 for versions >=1.17
 sudo rm -fr /usr/local/go
-curl https://dl.google.com/go/go1.13.7.linux-amd64.tar.gz > go1.13.7.linux-amd64.tar.gz
+curl -LO https://dl.google.com/go/go1.13.7.linux-amd64.tar.gz
 sudo tar -C /usr/local -xzf go1.13.7.linux-amd64.tar.gz
 GO111MODULE=off make ginkgo
 GO111MODULE=off make WHAT='test/e2e/e2e.test'


### PR DESCRIPTION
This avoid the duplication of the file name. Also specify the -L option
so redirects would be followed.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10139)
<!-- Reviewable:end -->
