### PR TITLE
pkg/endpoint: access endpoint state safely across go routines

### DIFF
--- a/pkg/endpoint/manager.go
+++ b/pkg/endpoint/manager.go
@@ -146,7 +146,7 @@ func (e *Endpoint) Unexpose(mgr endpointManager) <-chan struct{} {
 			// While endpoint is disconnecting, ID is already available in ID cache.
 			//
 			// Avoid irritating warning messages.
-			state := ep.getState()
+			state := ep.GetState()
 			if state != StateRestoring && state != StateDisconnecting {
 				log.WithError(err).WithField("state", state).Warning("Unable to release endpoint ID")
 			}


### PR DESCRIPTION
getState function should only be called when the endpoint mutex is being
held which was not always the case. Changed the function call so that it
can be accessed concurrently for the data race detected bellow:

```
==================
WARNING: DATA RACE
Write at 0x00c000544f30 by goroutine 56:
  github.com/cilium/cilium/pkg/endpoint.(*Endpoint).SetStateLocked()
      /go/src/github.com/cilium/cilium/pkg/endpoint/endpoint.go:1641 +0xe9
  github.com/cilium/cilium/pkg/endpoint.(*Endpoint).LeaveLocked()
      /go/src/github.com/cilium/cilium/pkg/endpoint/endpoint.go:1386 +0x333
  main.(*Daemon).deleteEndpointQuiet()
      /go/src/github.com/cilium/cilium/daemon/endpoint.go:651 +0x3e4
  main.(*Daemon).regenerateRestoredEndpoints.func2()
      /go/src/github.com/cilium/cilium/daemon/state.go:388 +0x49

Previous read at 0x00c000544f30 by goroutine 165:
  github.com/cilium/cilium/pkg/endpointmanager.releaseID()
      /go/src/github.com/cilium/cilium/pkg/endpoint/endpoint.go:1549 +0xb5
  github.com/cilium/cilium/pkg/endpointmanager.Remove.func1()
      /go/src/github.com/cilium/cilium/pkg/endpointmanager/manager.go:335 +0x88

Goroutine 56 (running) created at:
  main.(*Daemon).regenerateRestoredEndpoints()
      /go/src/github.com/cilium/cilium/daemon/state.go:382 +0x916
  main.(*Daemon).initRestore()
      /go/src/github.com/cilium/cilium/daemon/state.go:454 +0xf3
  main.runDaemon()
      /go/src/github.com/cilium/cilium/daemon/daemon_main.go:1441 +0xa17
  main.NewDaemon()
      /go/src/github.com/cilium/cilium/daemon/daemon.go:894 +0x23a4
  main.runDaemon()
      /go/src/github.com/cilium/cilium/daemon/daemon_main.go:1396 +0x314
  main.glob..func1()
      /go/src/github.com/cilium/cilium/daemon/daemon_main.go:121 +0xbf
  github.com/cilium/cilium/vendor/github.com/spf13/cobra.(*Command).execute()
      /go/src/github.com/cilium/cilium/vendor/github.com/spf13/cobra/command.go:766 +0x8eb
  github.com/cilium/cilium/vendor/github.com/spf13/cobra.(*Command).ExecuteC()
      /go/src/github.com/cilium/cilium/vendor/github.com/spf13/cobra/command.go:850 +0x41b
  main.daemonMain()
      /go/src/github.com/cilium/cilium/vendor/github.com/spf13/cobra/command.go:800 +0x237
  main.main()
      /go/src/github.com/cilium/cilium/daemon/main.go:18 +0x2f

Goroutine 165 (finished) created at:
  github.com/cilium/cilium/pkg/endpointmanager.Remove()
      /go/src/github.com/cilium/cilium/pkg/endpointmanager/manager.go:324 +0x121
  main.(*Daemon).deleteEndpointQuiet()
      /go/src/github.com/cilium/cilium/daemon/endpoint.go:614 +0x1a8
  main.(*Daemon).regenerateRestoredEndpoints.func2()
      /go/src/github.com/cilium/cilium/daemon/state.go:388 +0x49
==================
```

Fixes: f71d87a71c99 ("endpointmanager: signal when work is done")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10140)
<!-- Reviewable:end -->
