### PR TITLE
docs: fixed padding after code blocks

### DIFF
--- a/Documentation/_static/copybutton.css
+++ b/Documentation/_static/copybutton.css
@@ -2,6 +2,10 @@ div.code-wrapper {
   position: relative !important;
 }
 
+.section > div.code-wrapper {
+  margin-bottom: 24px !important;
+}
+
 div.code-wrapper pre {
   padding-top: 25px !important;
 }


### PR DESCRIPTION
Signed-off-by: Dmitry Kharitonov <geakstr@me.com>

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10143)
<!-- Reviewable:end -->
