### PR TITLE
ipcache: Add probe to check for dump capability to support delete

### DIFF
--- a/pkg/datapath/ipcache/listener.go
+++ b/pkg/datapath/ipcache/listener.go
@@ -248,11 +248,11 @@ func shuffleMaps(realized, backup, pending string) error {
 
 // garbageCollect implements GC of the ipcache map in one of two ways:
 //
-// On Linux 4.9, 4.10 or 4.15 and later:
+// On Linux 4.9, 4.10 or 4.16 and later:
 //   Periodically sweep through every element in the BPF map and check it
 //   against the in-memory copy of the map. If it doesn't exist in memory,
 //   delete the entry.
-// On Linux 4.11 to 4.14:
+// On Linux 4.11 to 4.15:
 //   Create a brand new map, populate it with all of the IPCache entries from
 //   the in-memory cache, delete the old map, and trigger regeneration of all
 //   BPF programs so that they pick up the new map.

--- a/pkg/maps/ipcache/ipcache.go
+++ b/pkg/maps/ipcache/ipcache.go
@@ -215,6 +215,16 @@ func (m *Map) supportsDelete() bool {
 		invalidEntry := &Key{}
 		m.deleteSupport, _ = m.delete(invalidEntry, false)
 		log.Debugf("Detected IPCache delete operation support: %t", m.deleteSupport)
+
+		// In addition to delete support, ability to dump the map is
+		// also required in order to run the garbage collector which
+		// will iterate over the map and delete entries.
+		if m.deleteSupport {
+			err := m.Dump(map[string][]string{})
+			m.deleteSupport = err == nil
+			log.Debugf("Detected IPCache dump operation support: %t", m.deleteSupport)
+		}
+
 		if !m.deleteSupport {
 			log.Infof("Periodic IPCache map swap will occur due to lack of kernel support for LPM delete operation. Upgrade to Linux 4.15 or higher to avoid this.")
 		}


### PR DESCRIPTION
Besides the ability to delete, the ipcache garbage collector also requires the
ability to dump the table. Add this to the existing probe which feeds
`SupportsDelete()`.

	level=debug msg="Detected IPCache delete operation support: true" subsys=map-ipcache
	level=debug msg="Detected IPCache dump operation support: true" subsys=map-ipcache

Fixes: #10080

``` release-note
Fix ipcache garbage collection on Linux 4.15
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10144)
<!-- Reviewable:end -->
