### PR TITLE
test: Remove runtime ipvlan tests

### DIFF
--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -905,11 +905,6 @@ func (s *SSHMeta) SetUpCiliumWithSockops() error {
 	return s.SetUpCiliumWithOptions("--sockops-enable --tofqdns-enable-poller=true")
 }
 
-// SetUpCiliumInIpvlanMode starts cilium-agent in the ipvlan mode
-func (s *SSHMeta) SetUpCiliumInIpvlanMode(ipvlanMasterDevice string) error {
-	return s.SetUpCiliumWithOptions("--tunnel=disabled --datapath-mode=ipvlan --ipvlan-master-device=" + ipvlanMasterDevice)
-}
-
 // WaitUntilReady waits until the output of `cilium status` returns with code
 // zero. Returns an error if the output of `cilium status` returns a nonzero
 // return code after the specified timeout duration has elapsed.


### PR DESCRIPTION
https://github.com/cilium/cilium/pull/9447 removed the container runtime support which was required to set up properly ipvlan when running with libnetwork. This made tests obsolete.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10145)
<!-- Reviewable:end -->
