### PR TITLE
client, identity: remove unnecessary guards around delete()

### DIFF
--- a/pkg/client/endpoint.go
+++ b/pkg/client/endpoint.go
@@ -143,9 +143,7 @@ func (c *Client) EndpointLabelsPatch(id string, toAdd, toDelete models.Labels) e
 	}
 	for _, lbl := range toDelete {
 		lblParsed := labels.ParseLabel(lbl)
-		if _, found := userLbl[lblParsed.Key]; found {
-			delete(userLbl, lblParsed.Key)
-		}
+		delete(userLbl, lblParsed.Key)
 	}
 	currentCfg.Spec.User = userLbl.GetModel()
 

--- a/pkg/identity/cache/cache.go
+++ b/pkg/identity/cache/cache.go
@@ -116,9 +116,7 @@ func collectEvent(event allocator.AllocatorEvent, added, deleted IdentityCache) 
 			// Un-delete the added ID if previously
 			// 'deleted' so that collected events can be
 			// processed in any order.
-			if _, exists := deleted[id]; exists {
-				delete(deleted, id)
-			}
+			delete(deleted, id)
 			added[id] = gi.LabelArray
 			return true
 		}
@@ -127,9 +125,7 @@ func collectEvent(event allocator.AllocatorEvent, added, deleted IdentityCache) 
 		return false
 	}
 	// Reverse an add when subsequently deleted
-	if _, exists := added[id]; exists {
-		delete(added, id)
-	}
+	delete(added, id)
 	// record the id deleted even if an add was reversed, as the
 	// id may also have previously existed, in which case the
 	// result is not no-op!


### PR DESCRIPTION
From https://golang.org/pkg/builtin/#delete

> If the map is nil or there is no such element, delete is a no-op.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10148)
<!-- Reviewable:end -->
