### PR TITLE
docs: Minor improvements to GKE guide

### DIFF
--- a/Documentation/gettingstarted/k8s-install-azure-cni-validate.rst
+++ b/Documentation/gettingstarted/k8s-install-azure-cni-validate.rst
@@ -17,34 +17,4 @@ It may take a couple of minutes for all components to come up:
     cilium-operator-cb4578bc5-q52qk         1/1     Running   0          4m13s
     cilium-s8w5m                            1/1     Running   0          4m12s
 
-Deploy the connectivity test
-----------------------------
-
-You can deploy the "connectivity-check" to test connectivity between pods.
-
-.. parsed-literal::
-
-    kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/connectivity-check/connectivity-check.yaml
-
-It will deploy a series of deployments which will use various connectivity
-paths to connect to each other. Connectivity paths include with and without
-service load-balancing and various network policy combinations. The pod name
-indicates the connectivity variant and the readiness and liveness gate
-indicates success or failure of the test:
-
-.. code:: bash
-
-    kubectl get pods
-    NAME                                                     READY   STATUS             RESTARTS   AGE
-    echo-a-9b85dd869-292s2                                   1/1     Running            0          8m37s
-    echo-b-c7d9f4686-gdwcs                                   1/1     Running            0          8m37s
-    host-to-b-multi-node-clusterip-6d496f7cf9-956jb          1/1     Running            0          8m37s
-    host-to-b-multi-node-headless-bd589bbcf-jwbh2            1/1     Running            0          8m37s
-    pod-to-a-7cc4b6c5b8-9jfjb                                1/1     Running            0          8m36s
-    pod-to-a-allowed-cnp-6cc776bb4d-2cszk                    1/1     Running            0          8m36s
-    pod-to-a-external-1111-5c75bd66db-sxfck                  1/1     Running            0          8m35s
-    pod-to-a-l3-denied-cnp-7fdd9975dd-2pp96                  1/1     Running            0          8m36s
-    pod-to-b-intra-node-9d9d4d6f9-qccfs                      1/1     Running            0          8m35s
-    pod-to-b-multi-node-clusterip-5956c84b7c-hwzfg           1/1     Running            0          8m35s
-    pod-to-b-multi-node-headless-6698899447-xlhfw            1/1     Running            0          8m35s
-    pod-to-external-fqdn-allow-google-cnp-667649bbf6-v6rf8   0/1     Running            0          8m35s
+.. include:: k8s-install-connectivity-test.rst

--- a/Documentation/gettingstarted/k8s-install-connectivity-test.rst
+++ b/Documentation/gettingstarted/k8s-install-connectivity-test.rst
@@ -1,0 +1,31 @@
+Deploy the connectivity test
+----------------------------
+
+You can deploy the "connectivity-check" to test connectivity between pods.
+
+.. parsed-literal::
+
+    kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/connectivity-check/connectivity-check.yaml
+
+It will deploy a series of deployments which will use various connectivity
+paths to connect to each other. Connectivity paths include with and without
+service load-balancing and various network policy combinations. The pod name
+indicates the connectivity variant and the readiness and liveness gate
+indicates success or failure of the test:
+
+.. code:: bash
+
+    kubectl get pods
+    NAME                                                     READY   STATUS             RESTARTS   AGE
+    echo-a-9b85dd869-292s2                                   1/1     Running            0          8m37s
+    echo-b-c7d9f4686-gdwcs                                   1/1     Running            0          8m37s
+    host-to-b-multi-node-clusterip-6d496f7cf9-956jb          1/1     Running            0          8m37s
+    host-to-b-multi-node-headless-bd589bbcf-jwbh2            1/1     Running            0          8m37s
+    pod-to-a-7cc4b6c5b8-9jfjb                                1/1     Running            0          8m36s
+    pod-to-a-allowed-cnp-6cc776bb4d-2cszk                    1/1     Running            0          8m36s
+    pod-to-a-external-1111-5c75bd66db-sxfck                  1/1     Running            0          8m35s
+    pod-to-a-l3-denied-cnp-7fdd9975dd-2pp96                  1/1     Running            0          8m36s
+    pod-to-b-intra-node-9d9d4d6f9-qccfs                      1/1     Running            0          8m35s
+    pod-to-b-multi-node-clusterip-5956c84b7c-hwzfg           1/1     Running            0          8m35s
+    pod-to-b-multi-node-headless-6698899447-xlhfw            1/1     Running            0          8m35s
+    pod-to-external-fqdn-allow-google-cnp-667649bbf6-v6rf8   0/1     Running            0          8m35s

--- a/Documentation/gettingstarted/k8s-install-gke-validate.rst
+++ b/Documentation/gettingstarted/k8s-install-gke-validate.rst
@@ -1,0 +1,54 @@
+Validate the Installation
+=========================
+
+You can monitor as Cilium and all required components are being installed:
+
+.. parsed-literal::
+
+    kubectl -n cilium get pods --watch
+    NAME                                    READY   STATUS              RESTARTS   AGE
+    cilium-operator-cb4578bc5-q52qk         0/1     Pending             0          8s
+    cilium-s8w5m                            0/1     PodInitializing     0          7s
+    coredns-86c58d9df4-4g7dd                0/1     ContainerCreating   0          8m57s
+    coredns-86c58d9df4-4l6b2                0/1     ContainerCreating   0          8m57s
+
+It may take a couple of minutes for all components to come up:
+
+.. parsed-literal::
+
+    cilium-operator-cb4578bc5-q52qk         1/1     Running   0          4m13s
+    cilium-s8w5m                            1/1     Running   0          4m12s
+    coredns-86c58d9df4-4g7dd                1/1     Running   0          13m
+    coredns-86c58d9df4-4l6b2                1/1     Running   0          13m
+
+Deploy the connectivity test
+----------------------------
+
+You can deploy the "connectivity-check" to test connectivity between pods.
+
+.. parsed-literal::
+
+    kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/connectivity-check/connectivity-check.yaml
+
+It will deploy a series of deployments which will use various connectivity
+paths to connect to each other. Connectivity paths include with and without
+service load-balancing and various network policy combinations. The pod name
+indicates the connectivity variant and the readiness and liveness gate
+indicates success or failure of the test:
+
+.. code:: bash
+
+    kubectl get pods
+    NAME                                                     READY   STATUS             RESTARTS   AGE
+    echo-a-9b85dd869-292s2                                   1/1     Running            0          8m37s
+    echo-b-c7d9f4686-gdwcs                                   1/1     Running            0          8m37s
+    host-to-b-multi-node-clusterip-6d496f7cf9-956jb          1/1     Running            0          8m37s
+    host-to-b-multi-node-headless-bd589bbcf-jwbh2            1/1     Running            0          8m37s
+    pod-to-a-7cc4b6c5b8-9jfjb                                1/1     Running            0          8m36s
+    pod-to-a-allowed-cnp-6cc776bb4d-2cszk                    1/1     Running            0          8m36s
+    pod-to-a-external-1111-5c75bd66db-sxfck                  1/1     Running            0          8m35s
+    pod-to-a-l3-denied-cnp-7fdd9975dd-2pp96                  1/1     Running            0          8m36s
+    pod-to-b-intra-node-9d9d4d6f9-qccfs                      1/1     Running            0          8m35s
+    pod-to-b-multi-node-clusterip-5956c84b7c-hwzfg           1/1     Running            0          8m35s
+    pod-to-b-multi-node-headless-6698899447-xlhfw            1/1     Running            0          8m35s
+    pod-to-external-fqdn-allow-google-cnp-667649bbf6-v6rf8   0/1     Running            0          8m35s

--- a/Documentation/gettingstarted/k8s-install-gke-validate.rst
+++ b/Documentation/gettingstarted/k8s-install-gke-validate.rst
@@ -21,34 +21,4 @@ It may take a couple of minutes for all components to come up:
     coredns-86c58d9df4-4g7dd                1/1     Running   0          13m
     coredns-86c58d9df4-4l6b2                1/1     Running   0          13m
 
-Deploy the connectivity test
-----------------------------
-
-You can deploy the "connectivity-check" to test connectivity between pods.
-
-.. parsed-literal::
-
-    kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/connectivity-check/connectivity-check.yaml
-
-It will deploy a series of deployments which will use various connectivity
-paths to connect to each other. Connectivity paths include with and without
-service load-balancing and various network policy combinations. The pod name
-indicates the connectivity variant and the readiness and liveness gate
-indicates success or failure of the test:
-
-.. code:: bash
-
-    kubectl get pods
-    NAME                                                     READY   STATUS             RESTARTS   AGE
-    echo-a-9b85dd869-292s2                                   1/1     Running            0          8m37s
-    echo-b-c7d9f4686-gdwcs                                   1/1     Running            0          8m37s
-    host-to-b-multi-node-clusterip-6d496f7cf9-956jb          1/1     Running            0          8m37s
-    host-to-b-multi-node-headless-bd589bbcf-jwbh2            1/1     Running            0          8m37s
-    pod-to-a-7cc4b6c5b8-9jfjb                                1/1     Running            0          8m36s
-    pod-to-a-allowed-cnp-6cc776bb4d-2cszk                    1/1     Running            0          8m36s
-    pod-to-a-external-1111-5c75bd66db-sxfck                  1/1     Running            0          8m35s
-    pod-to-a-l3-denied-cnp-7fdd9975dd-2pp96                  1/1     Running            0          8m36s
-    pod-to-b-intra-node-9d9d4d6f9-qccfs                      1/1     Running            0          8m35s
-    pod-to-b-multi-node-clusterip-5956c84b7c-hwzfg           1/1     Running            0          8m35s
-    pod-to-b-multi-node-headless-6698899447-xlhfw            1/1     Running            0          8m35s
-    pod-to-external-fqdn-allow-google-cnp-667649bbf6-v6rf8   0/1     Running            0          8m35s
+.. include:: k8s-install-connectivity-test.rst

--- a/Documentation/gettingstarted/k8s-install-gke.rst
+++ b/Documentation/gettingstarted/k8s-install-gke.rst
@@ -13,7 +13,7 @@ Installation on Google GKE
 GKE Requirements
 ================
 
-1. Install the Google Cloud SDK (``gcloud``) see [Installing Google Cloud SDK](https://cloud.google.com/sdk/install)
+1. Install the Google Cloud SDK (``gcloud``) see `Installing Google Cloud SDK <https://cloud.google.com/sdk/install>`_.
 
 2. Create a project or use an existing one
 

--- a/Documentation/gettingstarted/k8s-install-gke.rst
+++ b/Documentation/gettingstarted/k8s-install-gke.rst
@@ -87,7 +87,7 @@ You might also want to pass the ``--set global.restartPods`` switch to the
 node to force all pods to be managed by Cilium.
 
 .. include:: k8s-install-restart-pods.rst
-.. include:: k8s-install-validate.rst
+.. include:: k8s-install-gke-validate.rst
 .. include:: hubble-install.rst
 .. include:: getting-started-next-steps.rst
 

--- a/Documentation/gettingstarted/k8s-install-gke.rst
+++ b/Documentation/gettingstarted/k8s-install-gke.rst
@@ -66,6 +66,10 @@ Prepare & Deploy Cilium
 
 Deploy Cilium release via Helm:
 
+If you are ready to restart existing pods when initializing the node, you can
+also pass the ``--set global.restartPods`` flag to the ``helm`` command
+below. This will ensure all pods are managed by Cilium.
+
 .. parsed-literal::
 
     kubectl create namespace cilium
@@ -81,10 +85,6 @@ to the cluster. The NodeInit DaemonSet will perform the following actions:
 
 * Reconfigure kubelet to run in CNI mode
 * Mount the BPF filesystem
-
-You might also want to pass the ``--set global.restartPods`` switch to the
-``helm`` command above. This will restart existing pods when initializing the
-node to force all pods to be managed by Cilium.
 
 .. include:: k8s-install-restart-pods.rst
 .. include:: k8s-install-gke-validate.rst

--- a/Documentation/gettingstarted/k8s-install-restart-pods.rst
+++ b/Documentation/gettingstarted/k8s-install-restart-pods.rst
@@ -1,12 +1,9 @@
 Restart remaining pods
 ======================
 
-Once Cilium is up and running, pods in the ``kube-system`` namespace need to be
-restarted to ensure that they can be managed by Cilium.
-
-If the  flag ``--set global.restartPods=true`` was provided to the ``helm``
-command during the deployment step, nothing should be required. Otherwise, they
-need to be restarted manually:
+If you did not use the ``--set global.restartPods=true`` flag above, you will
+need to restart pods in the ``kube-system`` namespace manually at a later time,
+to ensure they can be managed by Cilium:
 
 ::
 

--- a/Documentation/gettingstarted/k8s-install-validate.rst
+++ b/Documentation/gettingstarted/k8s-install-validate.rst
@@ -21,34 +21,4 @@ It may take a couple of minutes for all components to come up:
     coredns-86c58d9df4-4g7dd                1/1     Running   0          13m
     coredns-86c58d9df4-4l6b2                1/1     Running   0          13m
 
-Deploy the connectivity test
-----------------------------
-
-You can deploy the "connectivity-check" to test connectivity between pods.
-
-.. parsed-literal::
-
-    kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/connectivity-check/connectivity-check.yaml
-
-It will deploy a series of deployments which will use various connectivity
-paths to connect to each other. Connectivity paths include with and without
-service load-balancing and various network policy combinations. The pod name
-indicates the connectivity variant and the readiness and liveness gate
-indicates success or failure of the test:
-
-.. code:: bash
-
-    kubectl get pods
-    NAME                                                     READY   STATUS             RESTARTS   AGE
-    echo-a-9b85dd869-292s2                                   1/1     Running            0          8m37s
-    echo-b-c7d9f4686-gdwcs                                   1/1     Running            0          8m37s
-    host-to-b-multi-node-clusterip-6d496f7cf9-956jb          1/1     Running            0          8m37s
-    host-to-b-multi-node-headless-bd589bbcf-jwbh2            1/1     Running            0          8m37s
-    pod-to-a-7cc4b6c5b8-9jfjb                                1/1     Running            0          8m36s
-    pod-to-a-allowed-cnp-6cc776bb4d-2cszk                    1/1     Running            0          8m36s
-    pod-to-a-external-1111-5c75bd66db-sxfck                  1/1     Running            0          8m35s
-    pod-to-a-l3-denied-cnp-7fdd9975dd-2pp96                  1/1     Running            0          8m36s
-    pod-to-b-intra-node-9d9d4d6f9-qccfs                      1/1     Running            0          8m35s
-    pod-to-b-multi-node-clusterip-5956c84b7c-hwzfg           1/1     Running            0          8m35s
-    pod-to-b-multi-node-headless-6698899447-xlhfw            1/1     Running            0          8m35s
-    pod-to-external-fqdn-allow-google-cnp-667649bbf6-v6rf8   0/1     Running            0          8m35s
+.. include:: k8s-install-connectivity-test.rst


### PR DESCRIPTION
I found a couple nits with @qmonnet while using the GKE doc.

For the `global.restartPods` change (third commit), I'm not sure I got the right fix. The current version feels really frustrating though: we explain to the user that there's one more option we could have given helm at step n, and because we did not, we need to perform an additional step n+1. I'm guessing (?) the intent was to highlight that the pod restarts are optional and I tried to change the text accordingly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10150)
<!-- Reviewable:end -->
