### PR TITLE
Fix off-by-one warning from LGTM and add tests for NodePort range

### DIFF
--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -16,6 +16,7 @@ package option
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -1828,22 +1829,9 @@ func (c *DaemonConfig) Populate() {
 	}
 	c.IPv6PodSubnets = subnets
 
-	nodePortRange := viper.GetStringSlice(NodePortRange)
-	if len(nodePortRange) > 0 {
-		if len(nodePortRange) != 2 {
-			log.Fatal("Unable to parse min/max port for NodePort range!")
-		}
-		c.NodePortMin, err = strconv.Atoi(nodePortRange[0])
-		if err != nil {
-			log.WithError(err).Fatal("Unable to parse min port value for NodePort range!")
-		}
-		c.NodePortMax, err = strconv.Atoi(nodePortRange[1])
-		if err != nil {
-			log.WithError(err).Fatal("Unable to parse max port value for NodePort range!")
-		}
-		if c.NodePortMax <= c.NodePortMin {
-			log.Fatal("NodePort range min port must be smaller than max port!")
-		}
+	err = c.populateNodePortRange()
+	if err != nil {
+		log.WithError(err).Fatal("NodePortRange can not be parsed.")
 	}
 
 	hostServicesProtos := viper.GetStringSlice(HostReachableServicesProtos)
@@ -1957,6 +1945,30 @@ func (c *DaemonConfig) Populate() {
 	c.SkipCRDCreation = viper.GetBool(SkipCRDCreation)
 	c.DisableCNPStatusUpdates = viper.GetBool(DisableCNPStatusUpdates)
 	c.AwsReleaseExcessIps = viper.GetBool(AwsReleaseExcessIps)
+}
+
+func (c *DaemonConfig) populateNodePortRange() error {
+	nodePortRange := viper.GetStringSlice(NodePortRange)
+	if len(nodePortRange) > 0 {
+		if len(nodePortRange) != 2 {
+			return errors.New("Unable to parse min/max port for NodePort range!")
+		}
+
+		var err error
+
+		c.NodePortMin, err = strconv.Atoi(nodePortRange[0])
+		if err != nil {
+			return fmt.Errorf("Unable to parse min port value for NodePort range: %s", err.Error())
+		}
+		c.NodePortMax, err = strconv.Atoi(nodePortRange[1])
+		if err != nil {
+			return fmt.Errorf("Unable to parse max port value for NodePort range: %s", err.Error())
+		}
+		if c.NodePortMax <= c.NodePortMin {
+			return errors.New("NodePort range min port must be smaller than max port!")
+		}
+	}
+	return nil
 }
 
 func sanitizeIntParam(paramName string, paramDefault int) int {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1949,11 +1949,8 @@ func (c *DaemonConfig) Populate() {
 
 func (c *DaemonConfig) populateNodePortRange() error {
 	nodePortRange := viper.GetStringSlice(NodePortRange)
-	if len(nodePortRange) > 0 {
-		if len(nodePortRange) != 2 {
-			return errors.New("Unable to parse min/max port for NodePort range!")
-		}
-
+	switch len(nodePortRange) {
+	case 2:
 		var err error
 
 		c.NodePortMin, err = strconv.Atoi(nodePortRange[0])
@@ -1967,7 +1964,12 @@ func (c *DaemonConfig) populateNodePortRange() error {
 		if c.NodePortMax <= c.NodePortMin {
 			return errors.New("NodePort range min port must be smaller than max port!")
 		}
+	case 0:
+		log.Warning("NodePort range was set but is empty.")
+	default:
+		return errors.New("Unable to parse min/max port value for NodePort range!")
 	}
+
 	return nil
 }
 

--- a/pkg/option/config_test.go
+++ b/pkg/option/config_test.go
@@ -351,11 +351,12 @@ func Test_populateNodePortRange(t *testing.T) {
 			},
 		},
 		{
+			// We simply just want to warn the user in this case.
 			name: "NodePortRange passed as empty",
 			want: want{
 				wantMin: 0,
 				wantMax: 0,
-				wantErr: true,
+				wantErr: false,
 			},
 			preTestRun: func() {
 				viper.Reset()
@@ -365,10 +366,7 @@ func Test_populateNodePortRange(t *testing.T) {
 				fs := flag.NewFlagSet(NodePortRange, flag.ContinueOnError)
 				fs.StringSlice(
 					NodePortRange,
-					[]string{
-						fmt.Sprintf("%d", NodePortMinDefault),
-						fmt.Sprintf("%d", NodePortMaxDefault),
-					},
+					[]string{}, // Explicity has no defaults.
 					"")
 
 				BindEnv(NodePortRange)


### PR DESCRIPTION
<!-- Description of change -->

Fixes warning as seen here: https://lgtm.com/projects/g/cilium/cilium/snapshot/5770266093fca7b394682a3a2ba6a21f92ec07da/files/pkg/option/config.go?sort=name&dir=ASC&mode=heatmap#xd94e5a86fe539522:1

https://github.com/cilium/cilium/blob/dd534bc55947d54b8071ae067238ae9cdbe1b66b/pkg/option/config.go#L1654

Side note: I was looking to add test coverage relevant to the change and noticed that [DaemonConfig.Populate()](https://github.com/cilium/cilium/blob/dd534bc55947d54b8071ae067238ae9cdbe1b66b/pkg/option/config.go#L1654) is not tested. After investigating a bit, I came to the conclusion that I'll cover it in a separate PR. This is because `Populate()` does not return an error and instead does `log.Fatal` when something goes wrong. This made writing unit tests to cover non-happy path more difficult. If refactoring `Populate()` to return an `error` seems reasonable, I will go ahead with that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10151)
<!-- Reviewable:end -->
