### PR TITLE
test: bpf: Fix load for cgroups progs

### DIFF
--- a/test/bpf/verifier-test.sh
+++ b/test/bpf/verifier-test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2018-2019 Authors of Cilium
+# Copyright 2018-2020 Authors of Cilium
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -177,11 +177,13 @@ function load_sockops_prog {
 	prog="$1"
 	pinpath="$2"
 
+	# cilium_signals is omitted from this list, because the sockops progs
+	# don't support BPF_MAP_TYPE_PERF_EVENT_ARRAY for now.
 	ALL_MAPS="cilium_ipcache cilium_ep_to_policy cilium_lxc sock_ops_map	\
 		cilium_metrics cilium_tunnel_map cilium_encrypt_state		\
 		cilium_lb6_reverse_nat cilium_lb6_services cilium_lb6_backends	\
 		cilium_lb4_reverse_nat cilium_lb4_services cilium_lb4_backends	\
-		cilium_events cilium_signals"
+		cilium_events"
 
 	map_args=""
 	for map in $ALL_MAPS; do


### PR DESCRIPTION
Fix the following failure:

    $ TC=/path/to/cilium/tc/binary sudo -E test/bpf/verifier-test.sh
    ...
    => Loading sockops/bpf_sockops.c:sockops...
    ...
    Error: unable to find map 'test_cilium_signals

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10156)
<!-- Reviewable:end -->
