### PR TITLE
Replace almost all uses of 'syscall' with 'unix' pkg.

### DIFF
--- a/api/v1/server.gotmpl
+++ b/api/v1/server.gotmpl
@@ -18,7 +18,6 @@ import (
 	"strconv"
 	"sync"
 	"sync/atomic"
-	"syscall"
 	"time"
 
 
@@ -29,6 +28,7 @@ import (
   {{ if .UsePFlags }}flag "github.com/spf13/pflag"
   {{ end -}}
   "golang.org/x/net/netutil"
+  "golang.org/x/sys/unix"
 
   {{ range .DefaultImports }}{{ printf "%q" . }}
   {{ end }}
@@ -634,5 +634,5 @@ func handleInterrupt(once *sync.Once, s *Server) {
 }
 
 func signalNotify(interrupt chan<- os.Signal) {
-	signal.Notify(interrupt, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(interrupt, unix.SIGINT, unix.SIGTERM)
 }

--- a/cilium-health/responder/main.go
+++ b/cilium-health/responder/main.go
@@ -19,12 +19,12 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"syscall"
 
 	"github.com/cilium/cilium/pkg/health/probe/responder"
 	"github.com/cilium/cilium/pkg/pidfile"
 
 	flag "github.com/spf13/pflag"
+	"golang.org/x/sys/unix"
 )
 
 func cancelOnSignal(cancel context.CancelFunc, sig ...os.Signal) {
@@ -47,7 +47,7 @@ func main() {
 
 	// Shutdown gracefully to halt server and remove pidfile
 	ctx, cancel := context.WithCancel(context.Background())
-	cancelOnSignal(cancel, syscall.SIGINT, syscall.SIGHUP, syscall.SIGTERM, syscall.SIGQUIT)
+	cancelOnSignal(cancel, unix.SIGINT, unix.SIGHUP, unix.SIGTERM, unix.SIGQUIT)
 
 	srv := responder.NewServer(listen)
 	defer srv.Shutdown()

--- a/cilium/cmd/cleanup.go
+++ b/cilium/cmd/cleanup.go
@@ -22,7 +22,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall"
 
 	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/pkg/bpf"
@@ -34,6 +33,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 )
 
 // configCmd represents the config command
@@ -323,7 +323,7 @@ func unmountCgroup() error {
 	}
 
 	log.Info("Trying to unmount ", cgroupRoot)
-	if err := syscall.Unmount(cgroupRoot, syscall.MNT_FORCE); err != nil {
+	if err := unix.Unmount(cgroupRoot, unix.MNT_FORCE); err != nil {
 		return fmt.Errorf("Failed to unmount %s: %s", cgroupRoot, err)
 	}
 	return nil

--- a/daemon/cleanup.go
+++ b/daemon/cleanup.go
@@ -19,10 +19,11 @@ import (
 	"os"
 	"os/signal"
 	"sync"
-	"syscall"
 
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/pidfile"
+
+	"golang.org/x/sys/unix"
 )
 
 var cleaner = &daemonCleanup{
@@ -67,7 +68,7 @@ func (c *cleanupFuncList) Run() {
 
 func (d *daemonCleanup) registerSigHandler() <-chan struct{} {
 	sig := make(chan os.Signal, 1)
-	signal.Notify(sig, syscall.SIGQUIT, syscall.SIGINT, syscall.SIGHUP, syscall.SIGTERM)
+	signal.Notify(sig, unix.SIGQUIT, unix.SIGINT, unix.SIGHUP, unix.SIGTERM)
 	interrupt := make(chan struct{})
 	go func() {
 		for s := range sig {

--- a/operator/main.go
+++ b/operator/main.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"syscall"
 
 	"github.com/cilium/cilium/pkg/aws/eni"
 	"github.com/cilium/cilium/pkg/k8s"
@@ -36,6 +35,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"golang.org/x/sys/unix"
 	"google.golang.org/grpc"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -66,7 +66,7 @@ var (
 
 func main() {
 	signals := make(chan os.Signal, 1)
-	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(signals, unix.SIGINT, unix.SIGTERM)
 
 	go func() {
 		<-signals

--- a/pkg/bpf/bpffs_linux.go
+++ b/pkg/bpf/bpffs_linux.go
@@ -21,11 +21,12 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
-	"syscall"
 
 	"github.com/cilium/cilium/pkg/components"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/mountinfo"
+
+	"golang.org/x/sys/unix"
 )
 
 var (
@@ -154,7 +155,7 @@ func mountFS(printWarning bool) error {
 		return fmt.Errorf("%s is a file which is not a directory", mapRoot)
 	}
 
-	if err := syscall.Mount(mapRoot, mapRoot, "bpf", 0, ""); err != nil {
+	if err := unix.Mount(mapRoot, mapRoot, "bpf", 0, ""); err != nil {
 		return fmt.Errorf("failed to mount %s: %s", mapRoot, err)
 	}
 	return nil

--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -18,12 +18,13 @@ import (
 	"fmt"
 	"os"
 	"sync"
-	"syscall"
 
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/mountinfo"
+
+	"golang.org/x/sys/unix"
 )
 
 var (
@@ -61,7 +62,7 @@ func mountCgroup() error {
 		return fmt.Errorf("%s is a file which is not a directory", cgroupRoot)
 	}
 
-	if err := syscall.Mount("none", cgroupRoot, mountinfo.FilesystemTypeCgroup2, 0, ""); err != nil {
+	if err := unix.Mount("none", cgroupRoot, mountinfo.FilesystemTypeCgroup2, 0, ""); err != nil {
 		return fmt.Errorf("failed to mount %s: %s", cgroupRoot, err)
 	}
 

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"syscall"
 
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/datapath"
@@ -34,6 +33,7 @@ import (
 	"github.com/cilium/arping"
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -877,14 +877,14 @@ func (n *linuxNodeHandler) removeEncryptRules() error {
 
 	rule.Mark = linux_defaults.RouteMarkDecrypt
 	if err := route.DeleteRuleIPv6(rule); err != nil {
-		if !os.IsNotExist(err) && err != syscall.EAFNOSUPPORT {
+		if !os.IsNotExist(err) && err != unix.EAFNOSUPPORT {
 			return fmt.Errorf("Delete previous IPv6 decrypt rule failed: %s", err)
 		}
 	}
 
 	rule.Mark = linux_defaults.RouteMarkEncrypt
 	if err := route.DeleteRuleIPv6(rule); err != nil {
-		if !os.IsNotExist(err) && err != syscall.EAFNOSUPPORT {
+		if !os.IsNotExist(err) && err != unix.EAFNOSUPPORT {
 			return fmt.Errorf("Delete previous IPv6 encrypt rule failed: %s", err)
 		}
 	}

--- a/pkg/datapath/prefilter/prefilter.go
+++ b/pkg/datapath/prefilter/prefilter.go
@@ -20,7 +20,6 @@ import (
 	"net"
 	"os/exec"
 	"path"
-	"syscall"
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/lock"
@@ -28,6 +27,8 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/cidrmap"
 	"github.com/cilium/cilium/pkg/probe"
+
+	"golang.org/x/sys/unix"
 )
 
 type preFilterMapType int
@@ -269,7 +270,7 @@ func ProbePreFilter(device, mode string) error {
 	}
 	if err := cmd.Wait(); err != nil {
 		if exiterr, ok := err.(*exec.ExitError); ok {
-			if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
+			if status, ok := exiterr.Sys().(unix.WaitStatus); ok {
 				switch status.ExitStatus() {
 				case 2:
 					return fmt.Errorf("Mode %s not supported on device %s", mode, device)

--- a/pkg/envoy/accesslog_server.go
+++ b/pkg/envoy/accesslog_server.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/cilium/cilium/pkg/flowdebug"
@@ -30,6 +29,7 @@ import (
 	"github.com/cilium/proxy/go/cilium/api"
 	"github.com/golang/protobuf/proto"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
 )
 
 func getAccessLogPath(stateDir string) string {
@@ -102,7 +102,7 @@ func (s *accessLogServer) accessLogger(conn *net.UnixConn) {
 			}
 			break
 		}
-		if flags&syscall.MSG_TRUNC != 0 {
+		if flags&unix.MSG_TRUNC != 0 {
 			log.Warning("Envoy: Discarded truncated access log message")
 			continue
 		}

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -23,7 +23,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/cilium/cilium/pkg/bpf"
@@ -52,6 +51,7 @@ import (
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/golang/protobuf/ptypes/duration"
 	"github.com/golang/protobuf/ptypes/wrappers"
+	"golang.org/x/sys/unix"
 )
 
 var (
@@ -363,8 +363,8 @@ func (s *XDSServer) AddListener(name string, kind policy.L7ParserType, port uint
 		Transparent: &wrappers.BoolValue{Value: true},
 		SocketOptions: []*envoy_api_v2_core.SocketOption{{
 			Description: "Listener socket mark",
-			Level:       syscall.SOL_SOCKET,
-			Name:        syscall.SO_MARK,
+			Level:       unix.SOL_SOCKET,
+			Name:        unix.SO_MARK,
 			Value:       &envoy_api_v2_core.SocketOption_IntValue{IntValue: socketMark},
 			State:       envoy_api_v2_core.SocketOption_STATE_PREBIND,
 		}},

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -23,7 +23,6 @@ package metrics
 
 import (
 	"net/http"
-	"syscall"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/version"
@@ -31,6 +30,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	dto "github.com/prometheus/client_model/go"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -1197,8 +1197,8 @@ func Error2Outcome(err error) string {
 	return LabelValueOutcomeSuccess
 }
 
-// Errno2Outcome converts a syscall.Errno to LabelOutcome
-func Errno2Outcome(errno syscall.Errno) string {
+// Errno2Outcome converts a unix.Errno to LabelOutcome
+func Errno2Outcome(errno unix.Errno) string {
 	if errno != 0 {
 		return LabelValueOutcomeFail
 	}

--- a/pkg/monitor/agent/listener/listener.go
+++ b/pkg/monitor/agent/listener/listener.go
@@ -17,9 +17,10 @@ package listener
 import (
 	"net"
 	"os"
-	"syscall"
 
 	"github.com/cilium/cilium/pkg/monitor/payload"
+
+	"golang.org/x/sys/unix"
 )
 
 // Version is the version of a node-monitor listener client. There are
@@ -70,6 +71,6 @@ func IsDisconnected(err error) bool {
 		return false
 	}
 
-	errn := syscerr.Err.(syscall.Errno)
-	return errn == syscall.EPIPE
+	errn := syscerr.Err.(unix.Errno)
+	return errn == unix.EPIPE
 }

--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -16,10 +16,11 @@ package probe
 
 import (
 	"fmt"
-	"syscall"
 	"unsafe"
 
 	"github.com/cilium/cilium/pkg/bpf"
+
+	"golang.org/x/sys/unix"
 )
 
 type probeKey struct {
@@ -68,10 +69,10 @@ func HaveFullLPM() bool {
 // also implicitly auto-load IPv6 kernel module if available and not yet
 // loaded.
 func HaveIPv6Support() bool {
-	fd, err := syscall.Socket(syscall.AF_INET6, syscall.SOCK_STREAM, 0)
-	if err == syscall.EAFNOSUPPORT || err == syscall.EPROTONOSUPPORT {
+	fd, err := unix.Socket(unix.AF_INET6, unix.SOCK_STREAM, 0)
+	if err == unix.EAFNOSUPPORT || err == unix.EPROTONOSUPPORT {
 		return false
 	}
-	syscall.Close(fd)
+	unix.Close(fd)
 	return true
 }

--- a/pkg/proxy/dialer.go
+++ b/pkg/proxy/dialer.go
@@ -18,8 +18,9 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"syscall"
 	"time"
+
+	"golang.org/x/sys/unix"
 )
 
 // ProxyKeepAlivePeriod is the time used for sending periodic keepalives on
@@ -46,12 +47,12 @@ func ciliumDialer(identity int, network, address string) (net.Conn, error) {
 		return nil, fmt.Errorf("unable resolve address %s/%s: %s", network, address, err)
 	}
 
-	family := syscall.AF_INET
+	family := unix.AF_INET
 	if addr.IP.To4() == nil {
-		family = syscall.AF_INET6
+		family = unix.AF_INET6
 	}
 
-	fd, err := syscall.Socket(family, syscall.SOCK_STREAM, 0)
+	fd, err := unix.Socket(family, unix.SOCK_STREAM, 0)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create socket: %s", err)
 	}
@@ -74,12 +75,12 @@ func ciliumDialer(identity int, network, address string) (net.Conn, error) {
 		return nil, fmt.Errorf("unable to create sockaddr: %s", err)
 	}
 
-	if err := syscall.SetNonblock(fd, false); err != nil {
+	if err := unix.SetNonblock(fd, false); err != nil {
 		c.Close()
 		return nil, fmt.Errorf("unable to put socket in blocking mode: %s", err)
 	}
 
-	if err := syscall.Connect(fd, sockAddr); err != nil {
+	if err := unix.Connect(fd, sockAddr); err != nil {
 		c.Close()
 		return nil, fmt.Errorf("unable to connect: %s", err)
 	}

--- a/pkg/proxy/ipsock_posix.go
+++ b/pkg/proxy/ipsock_posix.go
@@ -8,12 +8,13 @@ package proxy
 
 import (
 	"net"
-	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
-func ipToSockaddr(family int, ip net.IP, port int, zone string) (syscall.Sockaddr, error) {
+func ipToSockaddr(family int, ip net.IP, port int, zone string) (unix.Sockaddr, error) {
 	switch family {
-	case syscall.AF_INET:
+	case unix.AF_INET:
 		if len(ip) == 0 {
 			ip = net.IPv4zero
 		}
@@ -21,10 +22,10 @@ func ipToSockaddr(family int, ip net.IP, port int, zone string) (syscall.Sockadd
 		if ip4 == nil {
 			return nil, &net.AddrError{Err: "non-IPv4 address", Addr: ip.String()}
 		}
-		sa := &syscall.SockaddrInet4{Port: port}
+		sa := &unix.SockaddrInet4{Port: port}
 		copy(sa.Addr[:], ip4)
 		return sa, nil
-	case syscall.AF_INET6:
+	case unix.AF_INET6:
 		// In general, an IP wildcard address, which is either
 		// "0.0.0.0" or "::", means the entire IP addressing
 		// space. For some historical reason, it is used to
@@ -44,7 +45,7 @@ func ipToSockaddr(family int, ip net.IP, port int, zone string) (syscall.Sockadd
 		if ip6 == nil {
 			return nil, &net.AddrError{Err: "non-IPv6 address", Addr: ip.String()}
 		}
-		sa := &syscall.SockaddrInet6{Port: port, ZoneId: 0}
+		sa := &unix.SockaddrInet6{Port: port, ZoneId: 0}
 		copy(sa.Addr[:], ip6)
 		return sa, nil
 	}

--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"runtime"
 	"sort"
-	"syscall"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/common/addressing"
@@ -54,7 +53,6 @@ import (
 	gops "github.com/google/gops/agent"
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
-
 	"golang.org/x/sys/unix"
 )
 
@@ -130,7 +128,7 @@ func addIPConfigToLink(ip addressing.CiliumIP, routes []route.Route, link netlin
 
 	addr := &netlink.Addr{IPNet: ip.EndpointPrefix()}
 	if ip.IsIPv6() {
-		addr.Flags = syscall.IFA_F_NODAD
+		addr.Flags = unix.IFA_F_NODAD
 	}
 	if err := netlink.AddrAdd(link, addr); err != nil {
 		return fmt.Errorf("failed to add addr to %q: %v", ifName, err)

--- a/proxylib/test/accesslog_server.go
+++ b/proxylib/test/accesslog_server.go
@@ -21,12 +21,13 @@ import (
 	"path/filepath"
 	"strings"
 	"sync/atomic"
-	"syscall"
 	"time"
 
 	"github.com/cilium/proxy/go/cilium/api"
+
 	"github.com/golang/protobuf/proto"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
 )
 
 type AccessLogServer struct {
@@ -142,7 +143,7 @@ func (s *AccessLogServer) accessLogger(conn *net.UnixConn) {
 			}
 			break
 		}
-		if flags&syscall.MSG_TRUNC != 0 {
+		if flags&unix.MSG_TRUNC != 0 {
 			log.Warning("Discarded truncated access log message")
 			continue
 		}

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -26,16 +26,16 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/cilium/cilium/pkg/versioncheck"
 	"github.com/cilium/cilium/test/config"
-	"github.com/cilium/cilium/test/ginkgo-ext"
+	ginkgoext "github.com/cilium/cilium/test/ginkgo-ext"
 
 	go_version "github.com/blang/semver"
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"golang.org/x/sys/unix"
 )
 
 func init() {
@@ -219,14 +219,14 @@ func GetAppPods(apps []string, namespace string, kubectl *Kubectl, appFmt string
 // directly from test code to assist troubleshooting and test development.
 func HoldEnvironment(description ...string) {
 	test := ginkgo.CurrentGinkgoTestDescription()
-	pid := syscall.Getpid()
+	pid := unix.Getpid()
 
 	fmt.Fprintf(os.Stdout, "\n---\n%s", test.FullTestText)
 	fmt.Fprintf(os.Stdout, "\nat %s:%d", test.FileName, test.LineNumber)
 	fmt.Fprintf(os.Stdout, "\n\n%s", description)
 	fmt.Fprintf(os.Stdout, "\n\nPausing test for debug, use vagrant to access test setup.")
 	fmt.Fprintf(os.Stdout, "\nRun \"kill -SIGCONT %d\" to continue.\n", pid)
-	syscall.Kill(pid, syscall.SIGSTOP)
+	unix.Kill(pid, unix.SIGSTOP)
 }
 
 // Fail is a Ginkgo failure handler which raises a SIGSTOP for the test process


### PR DESCRIPTION
`golang.org/x/sys/unix` package is replacement for `syscall` which has
been deprecated since Go 1.4.

> Deprecated: this package is locked down. Callers should use the corresponding package in the golang.org/x/sys repository instead. That is also where updates required by new systems or versions should be applied. See https://golang.org/s/go1.4-syscall for more information.

While the changes do touch a lot of files, all of the modifications are
simply replacing imports of the `syscall` package, with `x/sys/unix`
implementations. No functionality changes, so no new tests added.

There is one case of `syscall` remaining in the cilium dnsproxy. There
is currently [no good replacement](https://github.com/cilium/cilium/issues/10116#issuecomment-584838627) listening for UDP traffic.

Fixes: https://github.com/cilium/cilium/issues/10116

Signed-off-by: Joshua Roppo <joshroppo@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10158)
<!-- Reviewable:end -->
