### PR TITLE
docs: Use kube-system namespace consistently in Encryption guide

### DIFF
--- a/Documentation/gettingstarted/encryption.rst
+++ b/Documentation/gettingstarted/encryption.rst
@@ -55,7 +55,7 @@ Deploy Cilium release via Helm:
 .. parsed-literal::
 
     helm install cilium |CHART_RELEASE| \\
-      --namespace cilium \\
+      --namespace kube-system \\
       --set global.encryption.enabled=true \\
       --set global.encryption.nodeEncryption=false
 
@@ -120,10 +120,10 @@ To replace cilium-ipsec-keys secret with a new keys,
 
 .. code-block:: shell-session
 
-    KEYID=$(kubectl get secret -n cilium cilium-ipsec-keys -o yaml|grep keys: | awk '{print $2}' | base64 -d | awk '{print $1}')
+    KEYID=$(kubectl get secret -n kube-system cilium-ipsec-keys -o yaml|grep keys: | awk '{print $2}' | base64 -d | awk '{print $1}')
     if [[ $KEYID -gt 15 ]]; then KEYID=0; fi
     data=$(echo "{\"stringData\":{\"keys\":\"$((($KEYID+1))) "rfc4106\(gcm\(aes\)\)" $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null| xxd -p -c 64)) 128\"}}")
-    kubectl patch secret -n cilium cilium-ipsec-keys -p="${data}" -v=1
+    kubectl patch secret -n kube-system cilium-ipsec-keys -p="${data}" -v=1
 
 Then restart cilium agents to transition to the new key. During transition the
 new and old keys will be in use. The cilium agent keeps per endpoint data on


### PR DESCRIPTION
The Transparent Encryption guide refers to the `kube-system` namespace twice, then switches to use `cilium`. Most of our installation guides deploy Cilium in the `kube-system` namespace so let's use that one.

We can also switch to using a env variable for the namespace name if we want to make it easier for the user to switch deployment namespaces.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10162)
<!-- Reviewable:end -->
