### PR TITLE
datapath: Filter out bpftool probes emitting dmesg messages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN make LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 V=$V LIBNETWORK_PLUGIN=$LIBNETWORK_PLU
 # built while allowing the new versions to make changes that are not
 # backwards compatible.
 #
-FROM quay.io/cilium/cilium-runtime:2020-01-29
+FROM quay.io/cilium/cilium-runtime:2020-02-12
 LABEL maintainer="maintainer@cilium.io"
 COPY --from=builder /tmp/install /
 COPY --from=cilium-envoy / /

--- a/contrib/packaging/docker/Dockerfile.runtime
+++ b/contrib/packaging/docker/Dockerfile.runtime
@@ -55,7 +55,7 @@ cd .. && \
 #
 # bpftool
 #
-git clone --depth 1 -b master git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git && \
+git clone --depth 1 -b bpftool https://github.com/cilium/linux.git && \
 cd linux/tools/bpf/bpftool/ && \
 make -j `getconf _NPROCESSORS_ONLN` && \
 strip bpftool && \

--- a/pkg/datapath/linux/probes/probes.go
+++ b/pkg/datapath/linux/probes/probes.go
@@ -133,8 +133,10 @@ func NewProbeManager() *ProbeManager {
 	newProbeManager := func() {
 		var features Features
 		out, err := exec.WithTimeout(
-			defaults.ExecTimeout, "bpftool", "-j", "feature").CombinedOutput(
-			log, true)
+			defaults.ExecTimeout, "bpftool", "-j", "feature",
+			"probe", "filter_out",
+			"\\(trace\\|write_user\\)",
+		).CombinedOutput(log, true)
 		if err != nil {
 			log.WithError(err).Fatal("could not run bpftool")
 		}

--- a/test/provision/bpftool.sh
+++ b/test/provision/bpftool.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# NOTE(mrostecki): Temporary hack until either:
+# 1) https://github.com/cilium/packer-ci-build/pull/187 gets merged.
+# 2) `bpftool feature filter_in/filter_out` gets upstreamed.
+
+set -e
+
+git clone --depth 1 -b bpftool https://github.com/cilium/linux.git $HOME/k-bpftool
+cd $HOME/k-bpftool/tools/bpf/bpftool
+make
+sudo make install

--- a/test/provision/runtime_install.sh
+++ b/test/provision/runtime_install.sh
@@ -12,5 +12,9 @@ sudo bash -c "echo MaxSessions 200 >> /etc/ssh/sshd_config"
 sudo systemctl restart ssh
 
 "${PROVISIONSRC}"/dns.sh
+# NOTE(mrostecki): Temporary hack until either:
+# 1) https://github.com/cilium/packer-ci-build/pull/187 gets merged.
+# 2) `bpftool feature filter_in/filter_out` gets upstreamed.
+"${PROVISIONSRC}"/bpftool.sh
 "${PROVISIONSRC}"/compile.sh
 "${PROVISIONSRC}"/wait-cilium.sh


### PR DESCRIPTION
bpftool feature probes related to trace, perf and write_user helpers are
emitting dmesg messages with warnings which may be confusing for
operators running Cilium on production environments. After this change,
those probes will be not performed.

Fixes #10048

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>

```release-note
Filter out bpftool probes emitting dmesg messages
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10164)
<!-- Reviewable:end -->
