### PR TITLE
make: strip symbol tables from all binaries by default

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -33,6 +33,15 @@ endif
 BUILD = $(VERSION) $(GIT_VERSION) $(shell $(GO) version)
 GOLDFLAGS = -X "github.com/cilium/cilium/pkg/version.Version=$(BUILD)"
 
+ifeq ($(NOSTRIP),)
+	# Note: these options will not remove annotations needed for stack
+	# traces, so panic backtraces will still be readable.
+	#
+	# -w: Omit the DWARF symbol table.
+	# -s: Omit the symbol table and debug information.
+	GOLDFLAGS += -s -w
+endif
+
 CILIUM_ENVOY_SHA=$(shell grep -o "FROM.*cilium/cilium-envoy:[0-9a-fA-F]*" $(ROOT_DIR)/Dockerfile | cut -d : -f 2)
 GOLDFLAGS += -X "github.com/cilium/cilium/pkg/envoy.RequiredEnvoyVersionSHA=$(CILIUM_ENVOY_SHA)"
 

--- a/cilium-docker-plugin.Dockerfile
+++ b/cilium-docker-plugin.Dockerfile
@@ -5,7 +5,6 @@ WORKDIR /go/src/github.com/cilium/cilium/plugins/cilium-docker
 ARG LOCKDEBUG
 ARG V
 RUN make CGO_ENABLED=0 GOOS=linux LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 EXTRA_GOBUILD_FLAGS="-a -installsuffix cgo"
-RUN strip cilium-docker
 
 FROM scratch
 LABEL maintainer="maintainer@cilium.io"

--- a/cilium-operator.Dockerfile
+++ b/cilium-operator.Dockerfile
@@ -5,7 +5,6 @@ WORKDIR /go/src/github.com/cilium/cilium/operator
 ARG LOCKDEBUG
 ARG V
 RUN make CGO_ENABLED=0 GOOS=linux LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 EXTRA_GOBUILD_FLAGS="-a -installsuffix cgo"
-RUN strip cilium-operator
 
 FROM docker.io/library/alpine:3.9.3 as certs
 RUN apk --update add ca-certificates

--- a/cilium/Makefile
+++ b/cilium/Makefile
@@ -7,7 +7,6 @@ SOURCES := $(shell find ../api ../daemon ../common ../pkg cmd . \( -name '*.go' 
 $(TARGET): $(SOURCES)
 	@$(ECHO_GO)
 	$(QUIET)$(GO) build $(GOBUILD) -o $(TARGET)
-	strip $(TARGET)
 
 all: $(TARGET)
 


### PR DESCRIPTION
Marked RFC because I'm not sure this is something we want or should do by default. While it doesn't break panic backtraces it makes debugging of production systems harder or even impossible.

Feedback appreciated @tgraf @aanm @joestringer @raybejjani

---

Strip the symbol tables and debug information from all binaries by
default. This will not remove annotations needed for stack traces, so
panic backtraces will still be readable.

If debug information and symbol tables are needed during debugging, use
`make NOSTRIP=1` to compile.

This reduces the binary sizes as follows:

before:

    -rwxr-xr-x 1 tklauser tklauser 45M Feb 27 12:35 cilium/cilium
    -rwxr-xr-x 1 tklauser tklauser 20M Feb 27 12:35 cilium-health/cilium-health
    -rwxr-xr-x 1 tklauser tklauser 70M Feb 27 12:35 daemon/cilium-agent
    -rwxr-xr-x 1 tklauser tklauser 74M Feb 27 12:35 operator/cilium-operator
    -rwxr-xr-x 1 tklauser tklauser 20M Feb 27 12:35 plugins/cilium-cni/cilium-cni
    
after:
    
    -rwxr-xr-x 1 tklauser tklauser 45M Feb 27 12:37 cilium/cilium
    -rwxr-xr-x 1 tklauser tklauser 15M Feb 27 12:37 cilium-health/cilium-health
    -rwxr-xr-x 1 tklauser tklauser 51M Feb 27 12:37 daemon/cilium-agent
    -rwxr-xr-x 1 tklauser tklauser 54M Feb 27 12:37 operator/cilium-operator
    -rwxr-xr-x 1 tklauser tklauser 15M Feb 27 12:37 plugins/cilium-cni/cilium-cni
    
summary:
    
    cilium           0MB (already stripped previously, see 8596bd9c)
    cilium-agent    ~19MB
    cilium-health   ~5MB
    cilium-operator ~20MB
    cilium-cni      ~5MB

Also see https://blog.filippo.io/shrink-your-go-binaries-with-this-one-weird-trick/

Updates #6099
Updates #10056

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10167)
<!-- Reviewable:end -->
