### PR TITLE
pkg/bpf: Protect each uintptr with runtime.KeepAlive

### DIFF
--- a/pkg/bpf/bpf_linux.go
+++ b/pkg/bpf/bpf_linux.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"syscall"
 	"unsafe"
 
@@ -68,6 +69,7 @@ func CreateMap(mapType int, keySize, valueSize, maxEntries, flags, innerID uint3
 		uintptr(unsafe.Pointer(&uba)),
 		unsafe.Sizeof(uba),
 	)
+	runtime.KeepAlive(&uba)
 	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
 		metrics.BPFSyscallDuration.WithLabelValues(metricOpCreate, metrics.Errno2Outcome(err)).Observe(duration.End(err == 0).Total().Seconds())
 	}
@@ -98,7 +100,7 @@ type bpfAttrMapOpElem struct {
 // bpf.BPF_ANY to create new element or update existing;
 // bpf.BPF_NOEXIST to create new element if it didn't exist;
 // bpf.BPF_EXIST to update existing element.
-func UpdateElementFromPointers(fd int, structPtr, sizeOfStruct uintptr) error {
+func UpdateElementFromPointers(fd int, structPtr unsafe.Pointer, sizeOfStruct uintptr) error {
 	var duration *spanstat.SpanStat
 	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
 		duration = spanstat.Start()
@@ -106,9 +108,10 @@ func UpdateElementFromPointers(fd int, structPtr, sizeOfStruct uintptr) error {
 	ret, _, err := unix.Syscall(
 		unix.SYS_BPF,
 		BPF_MAP_UPDATE_ELEM,
-		structPtr,
+		uintptr(structPtr),
 		sizeOfStruct,
 	)
+	runtime.KeepAlive(structPtr)
 	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
 		metrics.BPFSyscallDuration.WithLabelValues(metricOpUpdate, metrics.Errno2Outcome(err)).Observe(duration.End(err == 0).Total().Seconds())
 	}
@@ -134,12 +137,15 @@ func UpdateElement(fd int, key, value unsafe.Pointer, flags uint64) error {
 		flags: uint64(flags),
 	}
 
-	return UpdateElementFromPointers(fd, uintptr(unsafe.Pointer(&uba)), unsafe.Sizeof(uba))
+	ret := UpdateElementFromPointers(fd, unsafe.Pointer(&uba), unsafe.Sizeof(uba))
+	runtime.KeepAlive(key)
+	runtime.KeepAlive(value)
+	return ret
 }
 
 // LookupElement looks up for the map value stored in fd with the given key. The value
 // is stored in the value unsafe.Pointer.
-func LookupElementFromPointers(fd int, structPtr, sizeOfStruct uintptr) error {
+func LookupElementFromPointers(fd int, structPtr unsafe.Pointer, sizeOfStruct uintptr) error {
 	var duration *spanstat.SpanStat
 	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
 		duration = spanstat.Start()
@@ -147,9 +153,10 @@ func LookupElementFromPointers(fd int, structPtr, sizeOfStruct uintptr) error {
 	ret, _, err := unix.Syscall(
 		unix.SYS_BPF,
 		BPF_MAP_LOOKUP_ELEM,
-		structPtr,
+		uintptr(structPtr),
 		sizeOfStruct,
 	)
+	runtime.KeepAlive(structPtr)
 	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
 		metrics.BPFSyscallDuration.WithLabelValues(metricOpLookup, metrics.Errno2Outcome(err)).Observe(duration.End(err == 0).Total().Seconds())
 	}
@@ -171,7 +178,10 @@ func LookupElement(fd int, key, value unsafe.Pointer) error {
 		value: uint64(uintptr(value)),
 	}
 
-	return LookupElementFromPointers(fd, uintptr(unsafe.Pointer(&uba)), unsafe.Sizeof(uba))
+	ret := LookupElementFromPointers(fd, unsafe.Pointer(&uba), unsafe.Sizeof(uba))
+	runtime.KeepAlive(key)
+	runtime.KeepAlive(value)
+	return ret
 }
 
 func deleteElement(fd int, key unsafe.Pointer) (uintptr, syscall.Errno) {
@@ -189,6 +199,8 @@ func deleteElement(fd int, key unsafe.Pointer) (uintptr, syscall.Errno) {
 		uintptr(unsafe.Pointer(&uba)),
 		unsafe.Sizeof(uba),
 	)
+	runtime.KeepAlive(key)
+	runtime.KeepAlive(&uba)
 	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
 		metrics.BPFSyscallDuration.WithLabelValues(metricOpDelete, metrics.Errno2Outcome(err)).Observe(duration.End(err == 0).Total().Seconds())
 	}
@@ -209,8 +221,7 @@ func DeleteElement(fd int, key unsafe.Pointer) error {
 
 // GetNextKeyFromPointers stores, in nextKey, the next key after the key of the
 // map in fd. When there are no more keys, io.EOF is returned.
-func GetNextKeyFromPointers(fd int, structPtr, sizeOfStruct uintptr) error {
-
+func GetNextKeyFromPointers(fd int, structPtr unsafe.Pointer, sizeOfStruct uintptr) error {
 	var duration *spanstat.SpanStat
 	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
 		duration = spanstat.Start()
@@ -218,9 +229,10 @@ func GetNextKeyFromPointers(fd int, structPtr, sizeOfStruct uintptr) error {
 	ret, _, err := unix.Syscall(
 		unix.SYS_BPF,
 		BPF_MAP_GET_NEXT_KEY,
-		structPtr,
+		uintptr(structPtr),
 		sizeOfStruct,
 	)
+	runtime.KeepAlive(structPtr)
 	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
 		metrics.BPFSyscallDuration.WithLabelValues(metricOpGetNextKey, metrics.Errno2Outcome(err)).Observe(duration.End(err == 0).Total().Seconds())
 	}
@@ -247,7 +259,10 @@ func GetNextKey(fd int, key, nextKey unsafe.Pointer) error {
 		value: uint64(uintptr(nextKey)),
 	}
 
-	return GetNextKeyFromPointers(fd, uintptr(unsafe.Pointer(&uba)), unsafe.Sizeof(uba))
+	ret := GetNextKeyFromPointers(fd, unsafe.Pointer(&uba), unsafe.Sizeof(uba))
+	runtime.KeepAlive(key)
+	runtime.KeepAlive(nextKey)
+	return ret
 }
 
 // GetFirstKey fetches the first key in the map. If there are no keys in the
@@ -259,7 +274,9 @@ func GetFirstKey(fd int, nextKey unsafe.Pointer) error {
 		value: uint64(uintptr(nextKey)),
 	}
 
-	return GetNextKeyFromPointers(fd, uintptr(unsafe.Pointer(&uba)), unsafe.Sizeof(uba))
+	ret := GetNextKeyFromPointers(fd, unsafe.Pointer(&uba), unsafe.Sizeof(uba))
+	runtime.KeepAlive(nextKey)
+	return ret
 }
 
 // This struct must be in sync with union bpf_attr's anonymous struct used by
@@ -288,6 +305,9 @@ func ObjPin(fd int, pathname string) error {
 		uintptr(unsafe.Pointer(&uba)),
 		unsafe.Sizeof(uba),
 	)
+	runtime.KeepAlive(&pathStr)
+	runtime.KeepAlive(&uba)
+
 	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
 		metrics.BPFSyscallDuration.WithLabelValues(metricOpObjPin, metrics.Errno2Outcome(err)).Observe(duration.End(err == 0).Total().Seconds())
 	}
@@ -316,6 +336,8 @@ func ObjGet(pathname string) (int, error) {
 		uintptr(unsafe.Pointer(&uba)),
 		unsafe.Sizeof(uba),
 	)
+	runtime.KeepAlive(&pathStr)
+	runtime.KeepAlive(&uba)
 	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
 		metrics.BPFSyscallDuration.WithLabelValues(metricOpObjGet, metrics.Errno2Outcome(err)).Observe(duration.End(err == 0).Total().Seconds())
 	}
@@ -353,6 +375,7 @@ func MapFdFromID(id int) (int, error) {
 		uintptr(unsafe.Pointer(&uba)),
 		unsafe.Sizeof(uba),
 	)
+	runtime.KeepAlive(&uba)
 	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
 		metrics.BPFSyscallDuration.WithLabelValues(metricOpGetFDByID, metrics.Errno2Outcome(err)).Observe(duration.End(err == 0).Total().Seconds())
 	}
@@ -602,5 +625,10 @@ func TestDummyProg(progType ProgType, attachType uint32) error {
 		}
 		return nil
 	}
+
+	runtime.KeepAlive(&insns)
+	runtime.KeepAlive(&license)
+	runtime.KeepAlive(&bpfAttr)
+
 	return errno
 }

--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -570,7 +570,7 @@ func (m *Map) DumpWithCallback(cb DumpCallback) error {
 		key:   uint64(uintptr(unsafe.Pointer(&key[0]))),
 		value: uint64(uintptr(unsafe.Pointer(&nextKey[0]))),
 	}
-	bpfCurrentKeyPtr := uintptr(unsafe.Pointer(&bpfCurrentKey))
+	bpfCurrentKeyPtr := unsafe.Pointer(&bpfCurrentKey)
 	bpfCurrentKeySize := unsafe.Sizeof(bpfCurrentKey)
 
 	bpfNextKey := bpfAttrMapOpElem{
@@ -579,7 +579,7 @@ func (m *Map) DumpWithCallback(cb DumpCallback) error {
 		value: uint64(uintptr(unsafe.Pointer(&value[0]))),
 	}
 
-	bpfNextKeyPtr := uintptr(unsafe.Pointer(&bpfNextKey))
+	bpfNextKeyPtr := unsafe.Pointer(&bpfNextKey)
 	bpfNextKeySize := unsafe.Sizeof(bpfNextKey)
 
 	for {
@@ -666,7 +666,7 @@ func (m *Map) DumpReliablyWithCallback(cb DumpCallback, stats *DumpStats) error 
 		key:   uint64(uintptr(unsafe.Pointer(&currentKey[0]))),
 		value: uint64(uintptr(unsafe.Pointer(&value[0]))),
 	}
-	bpfCurrentKeyPtr := uintptr(unsafe.Pointer(&bpfCurrentKey))
+	bpfCurrentKeyPtr := unsafe.Pointer(&bpfCurrentKey)
 	bpfCurrentKeySize := unsafe.Sizeof(bpfCurrentKey)
 
 	bpfNextKey := bpfAttrMapOpElem{
@@ -675,7 +675,7 @@ func (m *Map) DumpReliablyWithCallback(cb DumpCallback, stats *DumpStats) error 
 		value: uint64(uintptr(unsafe.Pointer(&nextKey[0]))),
 	}
 
-	bpfNextKeyPtr := uintptr(unsafe.Pointer(&bpfNextKey))
+	bpfNextKeyPtr := unsafe.Pointer(&bpfNextKey)
 	bpfNextKeySize := unsafe.Sizeof(bpfNextKey)
 
 	// maxLookup is an upper bound limit to prevent backtracking forever
@@ -740,6 +740,7 @@ func (m *Map) DumpReliablyWithCallback(cb DumpCallback, stats *DumpStats) error 
 		// continue from the next key
 		copy(currentKey, nextKey)
 	}
+
 	return ErrMaxLookup
 }
 

--- a/pkg/bpf/prog_linux.go
+++ b/pkg/bpf/prog_linux.go
@@ -18,6 +18,7 @@ package bpf
 
 import (
 	"fmt"
+	"runtime"
 	"unsafe"
 
 	"github.com/cilium/cilium/pkg/metrics"
@@ -78,6 +79,7 @@ func GetProgNextID(current uint32) (uint32, error) {
 		duration = spanstat.Start()
 	}
 	ret, _, err := unix.Syscall(unix.SYS_BPF, BPF_PROG_GET_NEXT_ID, uintptr(unsafe.Pointer(&attr)), unsafe.Sizeof(attr))
+	runtime.KeepAlive(&attr)
 	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
 		metrics.BPFSyscallDuration.WithLabelValues(metricOpProgGetNextID, metrics.Errno2Outcome(err)).Observe(duration.End(err == 0).Total().Seconds())
 	}
@@ -95,6 +97,7 @@ func GetProgFDByID(id uint32) (int, error) {
 	}
 
 	fd, _, err := unix.Syscall(unix.SYS_BPF, BPF_PROG_GET_FD_BY_ID, uintptr(unsafe.Pointer(&attr)), unsafe.Sizeof(attr))
+	runtime.KeepAlive(&attr)
 	if fd < 0 || err != 0 {
 		return int(fd), fmt.Errorf("Unable to get fd for program id %d: %v", id, err)
 	}
@@ -122,6 +125,8 @@ func GetProgInfoByFD(fd int) (ProgInfo, error) {
 		duration = spanstat.Start()
 	}
 	ret, _, err := unix.Syscall(unix.SYS_BPF, BPF_OBJ_GET_INFO_BY_FD, uintptr(unsafe.Pointer(&attr)), unsafe.Sizeof(attr))
+	runtime.KeepAlive(&info)
+	runtime.KeepAlive(&attrInfo)
 	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
 		metrics.BPFSyscallDuration.WithLabelValues(metricOpObjGetInfoByFD, metrics.Errno2Outcome(err)).Observe(duration.End(err == 0).Total().Seconds())
 	}

--- a/pkg/endpoint/connector/ipvlan.go
+++ b/pkg/endpoint/connector/ipvlan.go
@@ -16,6 +16,7 @@ package connector
 
 import (
 	"fmt"
+	"runtime"
 	"strings"
 	"unsafe"
 
@@ -66,6 +67,9 @@ func loadEntryProg(mapFd int) (int, error) {
 	fd, _, errno := unix.Syscall(unix.SYS_BPF, 5, /* BPF_PROG_LOAD */
 		uintptr(unsafe.Pointer(&bpfAttr)),
 		unsafe.Sizeof(bpfAttr))
+	runtime.KeepAlive(&insns)
+	runtime.KeepAlive(&license)
+	runtime.KeepAlive(&bpfAttr)
 	if errno != 0 {
 		return 0, errno
 	}
@@ -106,6 +110,7 @@ func createTailCallMap() (int, int, error) {
 	fd, _, errno := unix.Syscall(unix.SYS_BPF, 0, /* BPF_MAP_CREATE */
 		uintptr(unsafe.Pointer(&bpfAttr)),
 		unsafe.Sizeof(bpfAttr))
+	runtime.KeepAlive(&bpfAttr)
 	if int(fd) < 0 || errno != 0 {
 		return 0, 0, errno
 	}
@@ -124,6 +129,8 @@ func createTailCallMap() (int, int, error) {
 	ret, _, errno := unix.Syscall(unix.SYS_BPF, 15, /* BPF_OBJ_GET_INFO_BY_FD */
 		uintptr(unsafe.Pointer(&bpfAttr2)),
 		unsafe.Sizeof(bpfAttr2))
+	runtime.KeepAlive(&info)
+	runtime.KeepAlive(&bpfAttr2)
 	if ret != 0 || errno != 0 {
 		unix.Close(int(fd))
 		return 0, 0, errno


### PR DESCRIPTION
The Go's GC is unable to track objects referred by `uintptr` \[1\] \[2\].

A consequence of this is that the GC might collect such objects when a blocking syscall is executed. This might corrupt memory of other Go objects e.g. if the reclaimed memory is used for new objects and the kernel modifies the objects in the context of the blocking syscall.

To prevent from this, we protect each pointer to objects with `runtime.KeepAlive()` which marks the objects as alive at least until `runtime.KeepAlive()` has been called.

**FOR REVIEWERS**:
- Please double-check (I might have missed, and I don't see any SA tool which can check this) that each reference to objects which references are converted to `uintptr` and then passed to `Syscall*()` is protected with `runtime.KeepAlive()`.
- For v1.6 and v1.5 I need to create an additional backport to fix `perf_linux.go` which in v1.7 was replaced by `cilium/ebpf`. I will do it once this PR gets backported.

\[1\]: https://github.com/golang/go/issues/13372#issuecomment-160655731
\[2\]: https://utcc.utoronto.ca/~cks/space/blog/programming/GoUintptrVsUnsafePointer

Developed together with @aanm and @borkmann.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10168)
<!-- Reviewable:end -->
