### PR TITLE
charts: Generate versions from VERSION file

### DIFF
--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -1,9 +1,41 @@
-QUICK_INSTALL=quick-install.yaml
+include ../../Makefile.defs
+include $(ROOT_DIR)/Makefile.quiet
 
-all: $(QUICK_INSTALL)
+MANAGED_ETCD_VERSION := "v2.0.7"
+
+QUICK_INSTALL := "$(ROOT_DIR)/$(RELATIVE_DIR)/quick-install.yaml"
+MANAGED_ETCD_PATH := "$(ROOT_DIR)/$(RELATIVE_DIR)/cilium/charts/managed-etcd/values.yaml"
+CILIUM_CHARTS := "$(ROOT_DIR)/$(RELATIVE_DIR)/cilium/"
+CILIUM_VALUES := "$(CILIUM_CHARTS)/values.yaml"
+
+VERSION_REGEX := '[0-9]\+\.[0-9]\+\.[0-9]\+.*'
+DEV_VERSION_REGEX := '[0-9]\+\.[0-9]\+\.90'
+CILIUM_CHART_REGEX := '\([vV]ersion:\) '$(VERSION_REGEX)
+CILIUM_TAG_REGEX := '\(tag:\) \(v'$(VERSION_REGEX)'\|latest\)'
+CILIUM_PULLPOLICY_REGEX := '\(pullPolicy:\) .*'
+
+all: update-versions $(QUICK_INSTALL)
 
 $(QUICK_INSTALL): $(shell find cilium/ -type f)
-	helm template cilium --namespace=kube-system $(OPTS) > $(QUICK_INSTALL)
+	$(QUIET)helm template cilium --namespace=kube-system $(OPTS) > $(QUICK_INSTALL)
+
+update-versions:
+	$(ECHO_GEN) " -> Updating version to $(VERSION)"
+	@# Update chart versions to point to the current version.
+	$(QUIET)grep -lRZ -e "version:" -e "appVersion:" $(CILIUM_CHARTS) | \
+		xargs -0 -l sed -i -e 's/'$(CILIUM_CHART_REGEX)'/\1 $(VERSION)/g'
+	@# Fix up the cilium tag
+	$(QUIET)if echo $(VERSION) | grep -q $(DEV_VERSION_REGEX); then \
+			sed -i 's/'$(CILIUM_TAG_REGEX)'/\1 latest/' $(CILIUM_VALUES); \
+			sed -i 's/'$(CILIUM_PULLPOLICY_REGEX)'/\1 Always/' $(CILIUM_VALUES); \
+		else \
+			sed -i 's/'$(CILIUM_TAG_REGEX)'/\1 v$(VERSION)/' $(CILIUM_VALUES); \
+			sed -i 's/'$(CILIUM_PULLPOLICY_REGEX)'/\1 IfNotPresent/' $(CILIUM_VALUES); \
+		fi
+	@# Fix up the managed etcd version, as that has its own scheme
+	$(QUIET)sed -i 's/'$(VERSION)'/'$(MANAGED_ETCD_VERSION)'/' $(MANAGED_ETCD_PATH)
 
 clean:
 	$(RM) $(QUICK_INSTALL)
+
+.phony: all clean update-versions


### PR DESCRIPTION
Use the top-of-tree VERSION file to generate the chart versions and
update the pull policy using the following rules:

  * Set the helm chart versions to the VERSION in the file
  * If the VERSION file ends with ".90":
    - Set the cilium tag to 'latest'
    - Set the pullPolicy to 'Always'
  * If the VERSION file does not end with ".90":
    - Set the cilium tag to the VERSION in the file
    - Set the pullPolicy to 'IfNotPresent'
  * Set the managed-etcd version tag to the version specified at the top
    of this Makefile. This must be manually bumped, it does not appear
    to follow the standard Cilium docker image tag process.

Usage:

```
$ make -C install/kubernetes
  GEN   install/kubernetes/  -> Updating version to 1.7.0-rc4
```

(diff is now made in the tree).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10171)
<!-- Reviewable:end -->
