### PR TITLE
bpf: Fix space hack in Makefile

### DIFF
--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -25,8 +25,8 @@ $(BPF_SIMPLE): %.o: %.ll
 	$(QUIET) ${LLC} ${LLC_FLAGS} -filetype=obj -o $@ $(patsubst %.o,%.ll,$@)
 
 # Hack to get make to replace : with a space
-space :=
-space += 
+null :=
+space := ${null} ${null}
 
 # The following option combinations are compile tested
 LB_OPTIONS = \


### PR DESCRIPTION
Fix the space hack which stopped working with make v4.3 (works with v4.2 though):

    [..]
    " [-DENABLE_HOST_REDIRECT-DENABLE_IPV4-DENABLE_IPV6-DENABLE_NAT46]";
    clang -DENABLE_HOST_REDIRECT-DENABLE_IPV4-DENABLE_IPV6-DENABLE_NAT46
    -I/home/brb/sandbox/gopath/src/github.com/cilium/cilium/bpf/include
    -I/home/brb/sandbox/gopath/src/github.com/cilium/cilium/bpf
    -D__NR_CPUS__=8 -O2 -g -target bpf -emit-llvm -Wall -Werror
    -Wno-address-of-packed-member -Wno-unknown-warning-option -c bpf_lxc.c
    -o bpf_lxc.ll; llc -march=bpf -mcpu=probe -mattr=dwarfris -o /dev/null
    bpf_lxc.ll;  \
    fi
    In file included from <built-in>:323:
    <command line>:1:20: error: ISO C99 requires whitespace after the macro
    name [-Werror,-Wc99-extensions]
    #define ENABLE_IPV4-DHAVE_LPM_MAP_TYPE 1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10173)
<!-- Reviewable:end -->
