### PR TITLE
datapath: convert global variables to consts where possible

### DIFF
--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -36,7 +36,7 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-var (
+const (
 	wildcardIPv4 = "0.0.0.0"
 	wildcardIPv6 = "0::0"
 )

--- a/pkg/datapath/loader/cache.go
+++ b/pkg/datapath/loader/cache.go
@@ -34,32 +34,30 @@ import (
 	"gopkg.in/fsnotify.v1"
 )
 
-var (
-	templateWatcherQueueSize = 10
+const templateWatcherQueueSize = 10
 
-	ignoredELFPrefixes = []string{
-		"2/",                    // Calls within the endpoint
-		"HOST_IP",               // Global
-		"IPV6_NODEPORT",         // Global
-		"ROUTER_IP",             // Global
-		"SNAT_IPV6_EXTERNAL",    // Global
-		"cilium_ct",             // All CT maps, including local
-		"cilium_encrypt_state",  // Global
-		"cilium_events",         // Global
-		"cilium_ipcache",        // Global
-		"cilium_lb",             // Global
-		"cilium_lxc",            // Global
-		"cilium_metrics",        // Global
-		"cilium_nodeport_neigh", // All nodeport neigh maps
-		"cilium_policy",         // Global
-		"cilium_proxy",          // Global
-		"cilium_signals",        // Global
-		"cilium_snat",           // All SNAT maps
-		"cilium_tunnel",         // Global
-		"from-container",        // Prog name
-		"to-container",          // Prog name
-	}
-)
+var ignoredELFPrefixes = []string{
+	"2/",                    // Calls within the endpoint
+	"HOST_IP",               // Global
+	"IPV6_NODEPORT",         // Global
+	"ROUTER_IP",             // Global
+	"SNAT_IPV6_EXTERNAL",    // Global
+	"cilium_ct",             // All CT maps, including local
+	"cilium_encrypt_state",  // Global
+	"cilium_events",         // Global
+	"cilium_ipcache",        // Global
+	"cilium_lb",             // Global
+	"cilium_lxc",            // Global
+	"cilium_metrics",        // Global
+	"cilium_nodeport_neigh", // All nodeport neigh maps
+	"cilium_policy",         // Global
+	"cilium_proxy",          // Global
+	"cilium_signals",        // Global
+	"cilium_snat",           // All SNAT maps
+	"cilium_tunnel",         // Global
+	"from-container",        // Prog name
+	"to-container",          // Prog name
+}
 
 // RestoreTemplates populates the object cache from templates on the filesystem
 // at the specified path.

--- a/pkg/datapath/loader/compile.go
+++ b/pkg/datapath/loader/compile.go
@@ -39,6 +39,15 @@ const (
 	outputObject   = OutputType("obj")
 	outputAssembly = OutputType("asm")
 	outputSource   = OutputType("c")
+
+	compiler = "clang"
+	linker   = "llc"
+
+	endpointPrefix   = "bpf_lxc"
+	endpointProg     = endpointPrefix + "." + string(outputSource)
+	endpointObj      = endpointPrefix + ".o"
+	endpointObjDebug = endpointPrefix + ".dbg.o"
+	endpointAsm      = endpointPrefix + string(outputAssembly)
 )
 
 // progInfo describes a program to be compiled with the expected output format
@@ -64,18 +73,10 @@ type directoryInfo struct {
 }
 
 var (
-	compiler       = "clang"
-	linker         = "llc"
 	standardCFlags = []string{"-O2", "-target", "bpf",
 		fmt.Sprintf("-D__NR_CPUS__=%d", runtime.NumCPU()),
 		"-Wno-address-of-packed-member", "-Wno-unknown-warning-option"}
 	standardLDFlags = []string{"-march=bpf", "-mcpu=probe"}
-
-	endpointPrefix   = "bpf_lxc"
-	endpointProg     = fmt.Sprintf("%s.%s", endpointPrefix, outputSource)
-	endpointObj      = fmt.Sprintf("%s.o", endpointPrefix)
-	endpointObjDebug = fmt.Sprintf("%s.dbg.o", endpointPrefix)
-	endpointAsm      = fmt.Sprintf("%s.%s", endpointPrefix, outputAssembly)
 
 	// testIncludes allows the unit tests to inject additional include
 	// paths into the compile command at test time. It is usually nil.

--- a/pkg/datapath/loader/doc_test.go
+++ b/pkg/datapath/loader/doc_test.go
@@ -35,6 +35,6 @@ func Test(t *testing.T) {
 
 func (s *LoaderTestSuite) SetUpTest(c *C) {
 	node.InitDefaultPrefix("")
-	node.SetInternalIPv4(TemplateIPv4)
-	node.SetIPv4Loopback(TemplateIPv4)
+	node.SetInternalIPv4(templateIPv4)
+	node.SetIPv4Loopback(templateIPv4)
 }

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -36,18 +36,17 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-var (
-	Subsystem = "datapath-loader"
-	log       = logging.DefaultLogger.WithField(logfields.LogSubsys, Subsystem)
-)
-
 const (
+	Subsystem = "datapath-loader"
+
 	symbolFromEndpoint = "from-container"
 	symbolToEndpoint   = "to-container"
 
 	dirIngress = "ingress"
 	dirEgress  = "egress"
 )
+
+var log = logging.DefaultLogger.WithField(logfields.LogSubsys, Subsystem)
 
 // Loader is a wrapper structure around operations related to compiling,
 // loading, and reloading datapath programs.


### PR DESCRIPTION
Also unexport consts/vars not used outside the package.

This also slightly reduces the binary size of cilium-agent:

```
== daemon/cilium-agent ==
bss                                7752192     7752128         -64
data                                894041      893913        -128
dec                               64553770    64551603       -2167
hex                                3d9032a     3d8fab3        -877
text                              55907537    55905562       -1975
```

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10176)
<!-- Reviewable:end -->
