### PR TITLE
Makefile: move cscope.files generation to its own target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,9 +178,11 @@ clean-tags:
 	@$(ECHO_CLEAN) tags
 	@-rm -f cscope.out cscope.in.out cscope.po.out cscope.files tags
 
+cscope.files: $(GOLANG_SRCFILES) $(BPF_SRCFILES)
+	@echo $(GOLANG_SRCFILES) $(BPF_SRCFILES) | sed 's/ /\n/g' | sort > cscope.files
+
 tags: $(GOLANG_SRCFILES) $(BPF_SRCFILES) cscope.files
-	ctags $(GOLANG_SRCFILES) $(BPF_SRCFILES)
-	@ echo $(GOLANG_SRCFILES) $(BPF_SRCFILES) | sed 's/ /\n/g' | sort > cscope.files
+	@ctags $(GOLANG_SRCFILES) $(BPF_SRCFILES)
 	cscope -R -b -q
 
 clean-container:


### PR DESCRIPTION
Commit 6c66fe9df9f6 ("Makefile: Fix duplicates in cscope output") added cscope.files as a dependency to the "tags" target. However, this is the very target supposed to be used to build cscope.files in the first place, so running "make tags" for the first time (when cscope.files is not present) fails.

Let's keep cscope.files as a dependency for "tags", but move the generation of that file to its own target.

Also silence the "ctags" command when creating tags.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10182)
<!-- Reviewable:end -->
