### PR TITLE
Add apiserver heartbeat with conntrack

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -109,6 +109,7 @@ cilium-agent [flags]
       --ipv6-service-range string                     Kubernetes IPv6 services CIDR if not inside cluster prefix (default "auto")
       --ipvlan-master-device string                   Device facing external network acting as ipvlan master (default "undefined")
       --k8s-api-server string                         Kubernetes API server URL
+      --k8s-heartbeat-timeout duration                Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                    Absolute path of the kubernetes kubeconfig file
       --k8s-namespace string                          Name of the Kubernetes namespace in which Cilium is deployed in
       --k8s-require-ipv4-pod-cidr                     Require IPv4 PodCIDR to be specified in node resource

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -38,6 +38,7 @@ cilium-operator [flags]
       --k8s-api-server string                   Kubernetes API server URL
       --k8s-client-burst int                    Burst value allowed for the K8s client
       --k8s-client-qps float32                  Queries per second limit for the K8s client
+      --k8s-heartbeat-timeout duration          Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string              Absolute path of the kubernetes kubeconfig file
       --k8s-namespace string                    Name of the Kubernetes namespace in which Cilium Operator is deployed in
       --kvstore string                          Key-value store type

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -744,6 +744,9 @@ func init() {
 	flags.StringSlice(option.HubbleMetrics, []string{}, "List of Hubble metrics to enable.")
 	option.BindEnv(option.HubbleMetrics)
 
+	flags.Duration(option.K8sHeartbeatTimeout, 30*time.Second, "Configures the timeout for api-server heartbeat, set to 0 to disable")
+	option.BindEnv(option.K8sHeartbeatTimeout)
+
 	viper.BindPFlags(flags)
 }
 

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -196,6 +196,9 @@ func init() {
 	flags.MarkHidden(option.CMDRef)
 	option.BindEnv(option.CMDRef)
 
+	flags.Duration(option.K8sHeartbeatTimeout, 30*time.Second, "Configures the timeout for api-server heartbeat, set to 0 to disable")
+	option.BindEnv(option.K8sHeartbeatTimeout)
+
 	viper.BindPFlags(flags)
 
 	// Make sure that klog logging variables are initialized so that we can

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -776,6 +776,9 @@ const (
 
 	// HubbleMetrics specifies enabled metrics and their configuration options.
 	HubbleMetrics = "hubble-metrics"
+
+	// K8sHeartbeatTimeout configures the timeout for apiserver heartbeat
+	K8sHeartbeatTimeout = "k8s-heartbeat-timeout"
 )
 
 // Default string arguments
@@ -1563,6 +1566,9 @@ type DaemonConfig struct {
 
 	// HubbleMetrics specifies enabled metrics and their configuration options.
 	HubbleMetrics []string
+
+	// K8sHeartbeatTimeout configures the timeout for apiserver heartbeat
+	K8sHeartbeatTimeout time.Duration
 }
 
 var (
@@ -1935,6 +1941,7 @@ func (c *DaemonConfig) Populate() {
 	c.EgressMasqueradeInterfaces = viper.GetString(EgressMasqueradeInterfaces)
 	c.EnableHostReachableServices = viper.GetBool(EnableHostReachableServices)
 	c.EnableRemoteNodeIdentity = viper.GetBool(EnableRemoteNodeIdentity)
+	c.K8sHeartbeatTimeout = viper.GetDuration(K8sHeartbeatTimeout)
 	c.DockerEndpoint = viper.GetString(Docker)
 	c.EnableXTSocketFallback = viper.GetBool(EnableXTSocketFallbackName)
 	c.EnableAutoDirectRouting = viper.GetBool(EnableAutoDirectRoutingName)


### PR DESCRIPTION
:warning: :warning: **aanm note to reviewers / backporters**: This fixes a bug that needs to be backported to 1.7/1.6 but we should only do it after heavily testing it.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](http://docs.cilium.io/en/stable/contributing/contributing/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue. 
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](http://docs.cilium.io/en/stable/contributing/contributing/#dev-coo).
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

Adding a periodic heartbeat to check for stale connections to the apiserver. If a request takes too long then client-go's conntrack dialer close connections function is called for all client types.

Fixes: #9792

```release-note
When running in Kubernetes, Cilium will run a periodic heartbeat and close all open Kubernetes client connections if the active connections become unresponsive. 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10184)
<!-- Reviewable:end -->
