### PR TITLE
vagrant: Install temporary forked bpftool

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -110,6 +110,10 @@ ENV["LC_ALL"] = "en_US.UTF-8"
 ENV["LC_CTYPE"] = "en_US.UTF-8"
 
 Vagrant.configure(2) do |config|
+    if ENV['CILIUM_TEMP'] then
+        # Temporarily install forked bpftool
+        config.vm.provision "shell", path: "#{ENV['CILIUM_TEMP']}/../../test/provision/bpftool.sh"
+    end
     config.vm.provision "bootstrap", type: "shell", inline: $bootstrap
     config.vm.provision "build", type: "shell", run: "always", privileged: false, inline: $build
     config.vm.provision "install", type: "shell", run: "always", privileged: false, inline: $install


### PR DESCRIPTION
Provisioning of the Vagrant development environment fails due to the missing forked bpftool:
```
$ ./contrib/vagrant/start.sh
[...]
runtime1: Feb 13 17:26:23 runtime1 cilium-agent[20863]: level=error msg="Command execution failed" cmd="[bpftool -j feature probe filter_out \\(trace\\|write_user\\)]" error="exit status 255" subsys=probes
runtime1: Feb 13 17:26:23 runtime1 cilium-agent[20863]: level=warning msg="{\"error\":\"expected no more arguments, 'kernel', 'dev', 'macros' or 'prefix', got: 'filter_out'?\"}" subsys=probes
runtime1: Feb 13 17:26:23 runtime1 cilium-agent[20863]: level=fatal msg="could not run bpftool" error="exit status 255" subsys=probes
runtime1: Cilium failed to start
[...]
```
This provisioning failure was introduced by #10164. Cilium now expects bpftool to be Cilium's (temporary) forked version, but the VirtualBox VM has the upstream bpftool. This commit installs the forked bpftool as part of the Vagrant provisioning.

/cc @mrostecki @qmonnet

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10186)
<!-- Reviewable:end -->
