### PR TITLE
daemon: remove unused type rulesManager

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -230,13 +230,6 @@ func createPrefixLengthCounter() *counter.PrefixLengthCounter {
 	return counter.DefaultPrefixLengthCounter(max6, max4)
 }
 
-type rulesManager interface {
-	RemoveRules()
-	InstallRules(ifName string) error
-	TransientRulesStart(ifName string) error
-	TransientRulesEnd(quiet bool)
-}
-
 // NewDaemon creates and returns a new Daemon with the parameters set in c.
 func NewDaemon(ctx context.Context, dp datapath.Datapath) (*Daemon, *endpointRestoreState, error) {
 


### PR DESCRIPTION
It's been unused since commit 5882053964eb ("datapath: make `Datapath` an
`IptablesManager`")

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10188)
<!-- Reviewable:end -->
