### PR TITLE
pkg/maps/encrypt: allocate BPF map in MapCreate only if EnableIPSec is set

### DIFF
--- a/daemon/datapath.go
+++ b/daemon/datapath.go
@@ -365,7 +365,7 @@ func (d *Daemon) initMaps() error {
 }
 
 func setupIPSec() (int, uint8, error) {
-	if option.Config.EncryptNode == false {
+	if !option.Config.EncryptNode {
 		ipsec.DeleteIPsecEncryptRoute()
 	}
 


### PR DESCRIPTION


Allocate encryptMap in MapCreate which is only called if EnableIPSec is
true (default is false) to avoid unnecessarily allocating memory for the
map.

Updates #10056

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10189)
<!-- Reviewable:end -->
