### PR TITLE
bugtool: Dump NAT BPF maps entries with bpftool

### DIFF
--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -78,6 +78,8 @@ func defaultCommands(confDir string, cmdDir string, k8sPods []string) []string {
 		"bpftool map dump pinned /sys/fs/bpf/tc/globals/cilium_lb6_reverse_nat",
 		"bpftool map dump pinned /sys/fs/bpf/tc/globals/cilium_ct6_global",
 		"bpftool map dump pinned /sys/fs/bpf/tc/globals/cilium_ct_any6_global",
+		"bpftool map dump pinned /sys/fs/bpf/tc/globals/cilium_snat_v4_external",
+		"bpftool map dump pinned /sys/fs/bpf/tc/globals/cilium_snat_v6_external",
 		// Versions
 		"docker version",
 		"docker info",


### PR DESCRIPTION
If `cilium bpf nat list` fails, then we will be able to resort to the raw dumps when debugging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10190)
<!-- Reviewable:end -->
