### PR TITLE
maps/nat: return NatEntry6 for NatKey6 NewValue() instead of NatEntry4

### DIFF
--- a/pkg/maps/nat/types.go
+++ b/pkg/maps/nat/types.go
@@ -81,7 +81,7 @@ type NatKey6 struct {
 }
 
 // NewValue creates a new bpf.MapValue.
-func (k *NatKey6) NewValue() bpf.MapValue { return &NatEntry4{} }
+func (k *NatKey6) NewValue() bpf.MapValue { return &NatEntry6{} }
 
 // ToNetwork converts ports to network byte order.
 //


### PR DESCRIPTION
When Cilium performs a connection tracking garbage collection it will
also purge NAT entries from the NAT bpf map. To perform this action,
Cilium will execute BPF map lookups from userspace by giving the memory
location of a golang structure, previously NatEntry4 now NatEntry6. The
kernel will then write into this memory location the value of the NAT
entry being looked up. As the size of NatEntry4 is only 38 bytes, as
oppose the NatEntry6 which is 50 bytes, the kernel would then write 12
bytes in random memory locations of the Cilium agent. This could cause
Cilium agent to crash or to have errors such as:

```
msg="Cannot create CEP" ... error="CiliumEndpoint.cilium.io \"��\\x00\\x00\\x00\\x00\\x00\\x00-multi-node-headless-854b65674d-lj45r\" is invalid: metadata.name: Invalid value: \"��\\x00\\x00\\x00\\x00\\x00\\x00-multi-node-headless-854b65674d-lj45r\":
```

Fixes: b9d2a0a9dcbd ("maps/nat: Add NatKey{4,6} types")
Signed-off-by: André Martins <andre@cilium.io>

This PR, in conjunction with https://github.com/cilium/cilium/pull/10168 will likely fix https://github.com/cilium/cilium/issues/8816 and so, that GH issue will be closed once this PR is merged.

Fixes https://github.com/cilium/cilium/issues/8816

```release-note
Fix memory corruption on clusters with IPv6 and NodePort enabled
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10192)
<!-- Reviewable:end -->
