### PR TITLE
cli: Do not panic if BPF map does not exist

### DIFF
--- a/cilium/cmd/bpf_ct_flush.go
+++ b/cilium/cmd/bpf_ct_flush.go
@@ -62,12 +62,15 @@ func flushCt(eID string) {
 			err = m.Open()
 		}
 		if err != nil {
-			if err == os.ErrNotExist {
-				Fatalf("Unable to open %s: %s: please try using \"cilium bpf ct flush global\"", path, err)
-			} else {
-				Fatalf("Unable to open %s: %s", path, err)
+			if os.IsNotExist(err) {
+				msg := "Unable to open %s: %s."
+				if eID != "global" {
+					msg = "Unable to open %s: %s: please try using \"cilium bpf ct flush global\"."
+				}
+				fmt.Fprintf(os.Stderr, msg+" Skipping.\n", path, err)
+				continue
 			}
-			continue
+			Fatalf("Unable to open %s: %s", path, err)
 		}
 		defer m.Close()
 		entries := m.Flush()

--- a/cilium/cmd/bpf_ct_list.go
+++ b/cilium/cmd/bpf_ct_list.go
@@ -58,11 +58,15 @@ func dumpCt(eID string) {
 			err = m.Open()
 		}
 		if err != nil {
-			if err == os.ErrNotExist {
-				Fatalf("Unable to open %s: %s: please try using \"cilium bpf ct list global\"", path, err)
-			} else {
-				Fatalf("Unable to open %s: %s", path, err)
+			if os.IsNotExist(err) {
+				msg := "Unable to open %s: %s."
+				if eID != "global" {
+					msg = "Unable to open %s: %s: please try using \"cilium bpf ct list global\"."
+				}
+				fmt.Fprintf(os.Stderr, msg+" Skipping.\n", path, err)
+				continue
 			}
+			Fatalf("Unable to open %s: %s", path, err)
 		}
 		defer m.Close()
 		if command.OutputJSON() {

--- a/cilium/cmd/bpf_nat_flush.go
+++ b/cilium/cmd/bpf_nat_flush.go
@@ -50,8 +50,11 @@ func flushNat() {
 			err = m.Open()
 		}
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Unable to open %s: %s", path, err)
-			continue
+			if os.IsNotExist(err) {
+				fmt.Fprintf(os.Stderr, "Unable to open %s: %s. Skipping.\n", path, err)
+				continue
+			}
+			Fatalf("Unable to open %s: %s", path, err)
 		}
 		defer m.Close()
 		entries := m.Flush()

--- a/cilium/cmd/bpf_nat_list.go
+++ b/cilium/cmd/bpf_nat_list.go
@@ -53,11 +53,11 @@ func dumpNat() {
 			err = m.Open()
 		}
 		if err != nil {
-			if err == os.ErrNotExist {
-				fmt.Fprintf(os.Stderr, "Unable to open %s: %s: please try using \"cilium bpf nat list\"", path, err)
-			} else {
-				Fatalf("Unable to open %s: %s", path, err)
+			if os.IsNotExist(err) {
+				fmt.Fprintf(os.Stderr, "Unable to open %s: %s. Skipping.\n", path, err)
+				continue
 			}
+			Fatalf("Unable to open %s: %s", path, err)
 		}
 		defer m.Close()
 		if command.OutputJSON() {


### PR DESCRIPTION
This commit changes the behavior of the following cmds:

- `cilium bpf ct flush`
- `cilium bpf ct list`
- `cilium bpf nat list`
- `cilium bpf nat flush`

The change makes the cmds not to fail if a map does not exist, and
instead to continue processing a next map.

This was observed when a user was running in the ipv6-only mode, and
the listed cmds failed to process ipv6 maps due to missing ipv4 maps.

```release-note
Make cilium bpf {ct, nat} {list, flush} to work when running in ipv6-only mode 
```

Fixes: #10191

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10193)
<!-- Reviewable:end -->
