### PR TITLE
agent: Remove awareness of IPv4 cluster-range

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -92,7 +92,6 @@ cilium-agent [flags]
       --ip-allocation-timeout duration                        Time after which an incomplete CIDR allocation is considered failed (default 2m0s)
       --ipam string                                           Backend to use for IPAM
       --ipsec-key-file string                                 Path to IPSec key file
-      --ipv4-cluster-cidr-mask-size int                       Mask size for the cluster wide CIDR (default 8)
       --ipv4-node string                                      IPv4 address of node (default "auto")
       --ipv4-pod-subnets strings                              List of IPv4 pod subnets to preconfigure for encryption
       --ipv4-range string                                     Per-node IPv4 endpoint prefix, e.g. 10.16.0.0/16 (default "auto")

--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -291,6 +291,35 @@ Annotations:
    upgrade. Connections should successfully re-establish without requiring
    clients to reconnect.
 
+.. _1.8_upgrade_notes:
+
+1.8 Upgrade Notes
+-----------------
+
+.. _1.8_upgrade_notes:
+
+IMPORTANT: Changes required before upgrading to 1.8.0
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. warning::
+
+   Do not upgrade to 1.8.0 before reading the following section and completing
+   the required steps.
+
+* While operating in direct-routing mode (``--tunnel=disabled``), traffic with
+  a destination address matching a particular CIDR is automatically excluded
+  from being masqueraded. So far, this CIDR consisted of
+  ``<alloc-cidr>/<size>`` where the size could be set with the option
+  ``--ipv4-cluster-cidr-mask-size``. This was not always desirable and
+  limiting, therefore Cilium 1.6 had already introduced the option
+  ``--native-routing-cidr`` allowing to explicitly specify the CIDR for native
+  routing. With Cilium 1.8, the option ``--ipv4-cluster-cidr-mask-size`` is
+  being deprecated and all users must use the option ``--native-routing-cidr``
+  instead.
+
+  .. note:: The ENI IPAM mode automatically derives the native routing CIDR so
+            no action is required.
+
 .. _1.7_upgrade_notes:
 
 1.7 Upgrade Notes

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -403,6 +403,7 @@ func init() {
 
 	flags.Int(option.IPv4ClusterCIDRMaskSize, 8, "Mask size for the cluster wide CIDR")
 	option.BindEnv(option.IPv4ClusterCIDRMaskSize)
+	flags.MarkDeprecated(option.IPv4ClusterCIDRMaskSize, "This option is no longer supported and will be removed in v1.9")
 
 	flags.String(option.IPv4Range, AutoCIDR, "Per-node IPv4 endpoint prefix, e.g. 10.16.0.0/16")
 	option.BindEnv(option.IPv4Range)

--- a/daemon/ipam.go
+++ b/daemon/ipam.go
@@ -276,7 +276,6 @@ func (d *Daemon) allocateIPs() error {
 	log.Infof("  Internal-Node IPv4: %s", node.GetInternalIPv4())
 
 	if option.Config.EnableIPv4 {
-		log.Infof("  Cluster IPv4 prefix: %s", node.GetIPv4ClusterRange())
 		log.Infof("  IPv4 allocation prefix: %s", node.GetIPv4AllocRange())
 
 		if c := option.Config.IPv4NativeRoutingCIDR(); c != nil {
@@ -320,8 +319,6 @@ func (d *Daemon) bootstrapIPAM() {
 	// or IPv4 alloc prefix, respectively, retrieved by k8s node annotations.
 	bootstrapStats.ipam.Start()
 	log.Info("Initializing node addressing")
-
-	node.SetIPv4ClusterCidrMaskSize(option.Config.IPv4ClusterCIDRMaskSize)
 
 	if option.Config.IPv4Range != AutoCIDR {
 		allocCIDR, err := cidr.ParseCIDR(option.Config.IPv4Range)

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -644,9 +644,6 @@ func (m *IptablesManager) remoteSnatDstAddrExclusion() string {
 	case option.Config.IPv4NativeRoutingCIDR() != nil:
 		return option.Config.IPv4NativeRoutingCIDR().String()
 
-	case option.Config.Tunnel == option.TunnelDisabled:
-		return node.GetIPv4ClusterRange().String()
-
 	default:
 		return node.GetIPv4AllocRange().String()
 	}

--- a/pkg/defaults/node.go
+++ b/pkg/defaults/node.go
@@ -27,9 +27,6 @@ const (
 	// DefaultIPv4PrefixLen is the length used to allocate container IPv4 addresses from.
 	DefaultIPv4PrefixLen = 16
 
-	// DefaultIPv4ClusterPrefixLen is the IPv4 prefix length of the entire cluster.
-	DefaultIPv4ClusterPrefixLen = 8
-
 	// DefaultNAT46Prefix is the IPv6 prefix to represent NATed IPv4 addresses.
 	DefaultNAT46Prefix = "0:0:0:0:0:FFFF::/96"
 

--- a/pkg/node/node_address.go
+++ b/pkg/node/node_address.go
@@ -34,8 +34,6 @@ import (
 )
 
 var (
-	ipv4ClusterCidrMaskSize = defaults.DefaultIPv4ClusterPrefixLen
-
 	ipv4Loopback        net.IP
 	ipv4ExternalAddress net.IP
 	ipv4InternalAddress net.IP
@@ -57,11 +55,6 @@ func makeIPv6HostIP() net.IP {
 	}
 
 	return ip
-}
-
-// SetIPv4ClusterCidrMaskSize sets the size of the mask of the IPv4 cluster prefix
-func SetIPv4ClusterCidrMaskSize(size int) {
-	ipv4ClusterCidrMaskSize = size
 }
 
 // InitDefaultPrefix initializes the node address and allocation prefixes with
@@ -148,19 +141,6 @@ func InitDefaultPrefix(device string) {
 				ipv6NodePortAddress = ip
 			}
 		}
-	}
-}
-
-// GetIPv4ClusterRange returns the IPv4 prefix of the cluster
-func GetIPv4ClusterRange() *net.IPNet {
-	if ipv4AllocRange == nil {
-		return nil
-	}
-
-	mask := net.CIDRMask(ipv4ClusterCidrMaskSize, 32)
-	return &net.IPNet{
-		IP:   ipv4AllocRange.IPNet.IP.Mask(mask),
-		Mask: mask,
 	}
 }
 
@@ -289,16 +269,8 @@ func ValidatePostInit() error {
 		}
 	}
 
-	if option.Config.EnableIPv4 {
-		if ipv4InternalAddress == nil {
-			return fmt.Errorf("BUG: Internal IPv4 node address was not configured")
-		}
-
-		ones, _ := ipv4AllocRange.Mask.Size()
-		if ipv4ClusterCidrMaskSize > ones {
-			return fmt.Errorf("IPv4 per node allocation prefix (%s) must be inside cluster prefix (%s)",
-				ipv4AllocRange, GetIPv4ClusterRange())
-		}
+	if option.Config.EnableIPv4 && ipv4InternalAddress == nil {
+		return fmt.Errorf("BUG: Internal IPv4 node address was not configured")
 	}
 
 	return nil

--- a/pkg/node/node_address_test.go
+++ b/pkg/node/node_address_test.go
@@ -31,24 +31,10 @@ import (
 
 func (s *NodeSuite) TestMaskCheck(c *C) {
 	InitDefaultPrefix("")
-	SetIPv4ClusterCidrMaskSize(24)
 
 	allocCIDR := cidr.MustParseCIDR("1.1.1.1/16")
 	SetIPv4AllocRange(allocCIDR)
-
-	// must fail, cluster /24 > per node alloc prefix /16
-	c.Assert(ValidatePostInit(), Not(IsNil))
-
 	SetInternalIPv4(allocCIDR.IP)
-
-	// OK, cluster /16 == per node alloc prefix /16
-	SetIPv4ClusterCidrMaskSize(16)
-	c.Assert(ValidatePostInit(), IsNil)
-
-	// OK, cluster /8 < per node alloc prefix /16
-	SetIPv4ClusterCidrMaskSize(8)
-	c.Assert(ValidatePostInit(), IsNil)
-
 	c.Assert(IsHostIPv4(GetInternalIPv4()), Equals, true)
 	c.Assert(IsHostIPv4(GetExternalIPv4()), Equals, true)
 	c.Assert(IsHostIPv6(GetIPv6()), Equals, true)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1071,7 +1071,6 @@ type DaemonConfig struct {
 	DisableEnvoyVersionCheck      bool
 	FixedIdentityMapping          map[string]string
 	FixedIdentityMappingValidator func(val string) (string, error)
-	IPv4ClusterCIDRMaskSize       int
 	IPv4Range                     string
 	IPv6Range                     string
 	IPv4ServiceRange              string
@@ -1709,7 +1708,6 @@ func (c *DaemonConfig) Populate() {
 	c.HTTPRequestTimeout = viper.GetInt(HTTPRequestTimeout)
 	c.HTTPRetryCount = viper.GetInt(HTTPRetryCount)
 	c.HTTPRetryTimeout = viper.GetInt(HTTPRetryTimeout)
-	c.IPv4ClusterCIDRMaskSize = viper.GetInt(IPv4ClusterCIDRMaskSize)
 	c.IdentityChangeGracePeriod = viper.GetDuration(IdentityChangeGracePeriod)
 	c.IPAM = viper.GetString(IPAM)
 	c.IPv4Range = viper.GetString(IPv4Range)


### PR DESCRIPTION
While operating in direct-routing mode (`--tunnel=disabled`), traffic with a
destination address matching a particular CIDR is automatically excluded from
being masqueraded. So far, this CIDR consisted of `<alloc-cidr>/<size>` where
the size could be set with the option `--ipv4-cluster-cidr-mask-size`. This was
not always desirable and limiting, therefore Cilium 1.6 had already introduced
the option `--native-routing-cidr` allowing to explicitly specify the CIDR for
native routing. With Cilium 1.8, the option `--ipv4-cluster-cidr-mask-size` is
being deprecated and all users must use the option `--native-routing-cidr`
instead.

Updates: #9919

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10194)
<!-- Reviewable:end -->
