### PR TITLE
datapath: use net.IP.IsLoopback instead of string comparison

### DIFF
--- a/pkg/datapath/linux/node_addressing.go
+++ b/pkg/datapath/linux/node_addressing.go
@@ -45,8 +45,7 @@ func listLocalAddresses(family int) ([]net.IP, error) {
 		if ip.IsExcluded(ipsToExclude, addr.IP) {
 			continue
 		}
-		switch addr.IP.String() {
-		case "127.0.0.1", "::1":
+		if addr.IP.IsLoopback() {
 			continue
 		}
 


### PR DESCRIPTION
Signed-off-by: Tobias Klauser <tklauser@distanz.ch>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10195)
<!-- Reviewable:end -->
