### PR TITLE
agent: Remove leftovers from IPv6 /96 prefix requirement

### DIFF
--- a/pkg/defaults/node.go
+++ b/pkg/defaults/node.go
@@ -41,19 +41,8 @@ const (
 var (
 	// Default addressing schema
 	//
-	// cluster:		    beef:beef:beef:beef::/64
 	// node:                    beef:beef:beef:beef:<node>:<node>:/96
-	// state:                   beef:beef:beef:beef:<node>:<node>:<state>:/112
-	// lxc:                     beef:beef:beef:beef:<node>:<node>:<state>:<lxc>/128
-
-	// ClusterIPv6Mask represents the CIDR Mask for an entire cluster.
-	ClusterIPv6Mask = net.CIDRMask(64, 128)
-
-	// NodeIPv6Mask represents the CIDR Mask for the cilium node.
-	NodeIPv6Mask = net.CIDRMask(96, 128)
-
-	// StateIPv6Mask represents the CIDR Mask for the state position.
-	StateIPv6Mask = net.CIDRMask(112, 128)
+	// lxc:                     beef:beef:beef:beef:<node>:<node>::<lxc>/128
 
 	// ContainerIPv6Mask is the IPv6 prefix length for address assigned to
 	// container. The default is L3 only and thus /128.


### PR DESCRIPTION
The requirement for the Kubernetes `-node-cidr-mask-size` to be a /96 has been
lifted a while ago but there were still some remaining leftovers hinting that
it exists. Remove them.

Fixes: #6804

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10196)
<!-- Reviewable:end -->
