### PR TITLE
test: bpf: Fix check for xdp support in ip

### DIFF
--- a/test/bpf/verifier-test.sh
+++ b/test/bpf/verifier-test.sh
@@ -232,8 +232,7 @@ function load_cg {
 }
 
 function load_xdp {
-	if $IPROUTE2 link set help 2>&1 | grep -q xdpgeneric; then
-		$IPROUTE2 link set dev ${DEV} xdpgeneric off
+	if $IPROUTE2 link set dev ${DEV} xdpgeneric off 2>/dev/null; then
 		for p in ${XDP_PROGS}; do
 			load_prog_dev "$IPROUTE2 link set" "xdpgeneric" ${p}
 		done


### PR DESCRIPTION
ip's help output wasn't updated when support for xdpgeneric was added, so grep xdpgeneric on ip help doesn't return anything and XDP programs are never loaded. In addition, because we set pipefail and `ip link set help` returns a non-0 error code, the piped command always returns a non-0
error code anyway.

This PR fixes both issues by using the output of the `set dev xdpgeneric off` command directly to determine if ip supports xdpgeneric.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10198)
<!-- Reviewable:end -->
