### PR TITLE
clustermesh: Ignore ..data directory of secrets mount

### DIFF
--- a/pkg/clustermesh/config.go
+++ b/pkg/clustermesh/config.go
@@ -80,7 +80,7 @@ func (cdw *configDirectoryWatcher) watch() error {
 		// lrwxrwxrwx. 1 root root 12 Jul 21 16:32 test7 -> ..data/test7
 		//
 		// Ignore all backing files and only read the symlinks
-		if strings.HasPrefix(f.Name(), "..") {
+		if strings.HasPrefix(f.Name(), "..") || f.IsDir() {
 			continue
 		}
 


### PR DESCRIPTION
Skip any directory present in the config directory to avoid warnings like these:
```
level=warning msg="Unable to establish etcd connection to remote cluser" clusterName=..data config=/var/lib/cilium/clustermesh/..data error="read /var/lib/cilium/clustermesh/..data: is a directory" kvstoreErr="<nil>" kvstoreStatus= subsys=clustermesh
```

Fixes: #6408

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10200)
<!-- Reviewable:end -->
