### PR TITLE
policy: fix innermap's flag error in eppolicymap

### DIFF
--- a/pkg/maps/eppolicymap/eppolicymap.go
+++ b/pkg/maps/eppolicymap/eppolicymap.go
@@ -61,11 +61,13 @@ var (
 // for testing purposes.
 func CreateWithName(mapName string) error {
 	buildMap.Do(func() {
+		mapType := bpf.MapType(bpf.BPF_MAP_TYPE_HASH)
 		fd, err := bpf.CreateMap(bpf.BPF_MAP_TYPE_HASH,
 			uint32(unsafe.Sizeof(policymap.PolicyKey{})),
 			uint32(unsafe.Sizeof(policymap.PolicyEntry{})),
 			uint32(policymap.MaxEntries),
-			0, 0, innerMapName)
+			bpf.GetPreAllocateMapFlags(mapType),
+			0, innerMapName)
 
 		if err != nil {
 			log.WithError(err).Warning("unable to create EP to policy map")


### PR DESCRIPTION
The policymap is created with BPF_F_NO_PREALLOC flag, but the innermap
in eppolicymap uses a flag 0. When enable sockops, the eppolicymap
will be update failed because of the different bpf-map metadatas.

This commit changes the innermap's flag and fixes it.

Signed-off-by: Zhiyuan Hou <zhiyuan2048@linux.alibaba.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10201)
<!-- Reviewable:end -->
