### PR TITLE
pkg/bpf: Protect attr in perf_linux.go with runtime.KeepAlive

### DIFF
--- a/pkg/bpf/perf_linux.go
+++ b/pkg/bpf/perf_linux.go
@@ -336,6 +336,7 @@ func PerfEventOpen(config *PerfEventConfig, pid int, cpu int, groupFD int, flags
 		uintptr(cpu),
 		uintptr(groupFD),
 		uintptr(flags), 0)
+	runtime.KeepAlive(&attr)
 	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
 		metrics.BPFSyscallDuration.WithLabelValues(metricOpPerfEventOpen, metrics.Errno2Outcome(err)).Observe(duration.EndError(err).Total().Seconds())
 	}


### PR DESCRIPTION
Otherwise, the Go's GC might collect it while the syscall is being executed. See https://github.com/cilium/cilium/pull/10168 for more context.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10205)
<!-- Reviewable:end -->
