### PR TITLE
Fix regression to avoid freeing alive IPs

### DIFF
--- a/api/v1/client/ipam/post_ipam_parameters.go
+++ b/api/v1/client/ipam/post_ipam_parameters.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	cr "github.com/go-openapi/runtime/client"
+	"github.com/go-openapi/swag"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -61,6 +62,8 @@ for the post ipam operation typically these are written to a http.Request
 */
 type PostIpamParams struct {
 
+	/*Expiration*/
+	Expiration *bool
 	/*Family*/
 	Family *string
 	/*Owner*/
@@ -104,6 +107,17 @@ func (o *PostIpamParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
+// WithExpiration adds the expiration to the post ipam params
+func (o *PostIpamParams) WithExpiration(expiration *bool) *PostIpamParams {
+	o.SetExpiration(expiration)
+	return o
+}
+
+// SetExpiration adds the expiration to the post ipam params
+func (o *PostIpamParams) SetExpiration(expiration *bool) {
+	o.Expiration = expiration
+}
+
 // WithFamily adds the family to the post ipam params
 func (o *PostIpamParams) WithFamily(family *string) *PostIpamParams {
 	o.SetFamily(family)
@@ -133,6 +147,15 @@ func (o *PostIpamParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Regi
 		return err
 	}
 	var res []error
+
+	if o.Expiration != nil {
+
+		// header param expiration
+		if err := r.SetHeaderParam("expiration", swag.FormatBool(*o.Expiration)); err != nil {
+			return err
+		}
+
+	}
 
 	if o.Family != nil {
 

--- a/api/v1/models/address_pair.go
+++ b/api/v1/models/address_pair.go
@@ -18,8 +18,14 @@ type AddressPair struct {
 	// IPv4 address
 	IPV4 string `json:"ipv4,omitempty"`
 
+	// UUID of IPv4 expiration timer
+	IPV4ExpirationUUID string `json:"ipv4-expiration-uuid,omitempty"`
+
 	// IPv6 address
 	IPV6 string `json:"ipv6,omitempty"`
+
+	// UUID of IPv6 expiration timer
+	IPV6ExpirationUUID string `json:"ipv6-expiration-uuid,omitempty"`
 }
 
 // Validate validates this address pair

--- a/api/v1/models/ip_a_m_address_response.go
+++ b/api/v1/models/ip_a_m_address_response.go
@@ -18,6 +18,11 @@ type IPAMAddressResponse struct {
 	// List of CIDRs out of which IPs are allocated
 	Cidrs []string `json:"cidrs"`
 
+	// The UUID for the expiration timer. Set when expiration has been
+	// enabled while allocating.
+	//
+	ExpirationUUID string `json:"expiration-uuid,omitempty"`
+
 	// IP of gateway
 	Gateway string `json:"gateway,omitempty"`
 

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -404,6 +404,7 @@ paths:
       parameters:
       - "$ref": "#/parameters/ipam-family"
       - "$ref": "#/parameters/ipam-owner"
+      - "$ref": "#/parameters/ipam-expiration"
       responses:
         '201':
           description: Success
@@ -954,6 +955,10 @@ parameters:
     name: owner
     in: query
     type: string
+  ipam-expiration:
+    name: expiration
+    in: header
+    type: boolean
   map-name:
     name: name
     description: Name of map
@@ -1383,6 +1388,11 @@ definitions:
       master-mac:
         type: string
         description: MAC of master interface if address is a slave/secondary of a master interface
+      expiration-uuid:
+        type: string
+        description: |
+          The UUID for the expiration timer. Set when expiration has been
+          enabled while allocating.
   AddressPair:
     description: Addressing information of an endpoint
     type: object
@@ -1390,8 +1400,14 @@ definitions:
       ipv4:
         description: IPv4 address
         type: string
+      ipv4-expiration-uuid:
+        description: UUID of IPv4 expiration timer
+        type: string
       ipv6:
         description: IPv6 address
+        type: string
+      ipv6-expiration-uuid:
+        description: UUID of IPv6 expiration timer
         type: string
   Address:
     description: IP address

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -779,6 +779,9 @@ func init() {
           },
           {
             "$ref": "#/parameters/ipam-owner"
+          },
+          {
+            "$ref": "#/parameters/ipam-expiration"
           }
         ],
         "responses": {
@@ -1295,8 +1298,16 @@ func init() {
           "description": "IPv4 address",
           "type": "string"
         },
+        "ipv4-expiration-uuid": {
+          "description": "UUID of IPv4 expiration timer",
+          "type": "string"
+        },
         "ipv6": {
           "description": "IPv6 address",
+          "type": "string"
+        },
+        "ipv6-expiration-uuid": {
+          "description": "UUID of IPv6 expiration timer",
           "type": "string"
         }
       }
@@ -2220,6 +2231,10 @@ func init() {
           "items": {
             "type": "string"
           }
+        },
+        "expiration-uuid": {
+          "description": "The UUID for the expiration timer. Set when expiration has been\nenabled while allocating.\n",
+          "type": "string"
         },
         "gateway": {
           "description": "IP of gateway",
@@ -3195,6 +3210,11 @@ func init() {
       "name": "id",
       "in": "path",
       "required": true
+    },
+    "ipam-expiration": {
+      "type": "boolean",
+      "name": "expiration",
+      "in": "header"
     },
     "ipam-family": {
       "enum": [
@@ -4163,6 +4183,11 @@ func init() {
             "type": "string",
             "name": "owner",
             "in": "query"
+          },
+          {
+            "type": "boolean",
+            "name": "expiration",
+            "in": "header"
           }
         ],
         "responses": {
@@ -4734,8 +4759,16 @@ func init() {
           "description": "IPv4 address",
           "type": "string"
         },
+        "ipv4-expiration-uuid": {
+          "description": "UUID of IPv4 expiration timer",
+          "type": "string"
+        },
         "ipv6": {
           "description": "IPv6 address",
+          "type": "string"
+        },
+        "ipv6-expiration-uuid": {
+          "description": "UUID of IPv6 expiration timer",
           "type": "string"
         }
       }
@@ -5659,6 +5692,10 @@ func init() {
           "items": {
             "type": "string"
           }
+        },
+        "expiration-uuid": {
+          "description": "The UUID for the expiration timer. Set when expiration has been\nenabled while allocating.\n",
+          "type": "string"
         },
         "gateway": {
           "description": "IP of gateway",
@@ -6634,6 +6671,11 @@ func init() {
       "name": "id",
       "in": "path",
       "required": true
+    },
+    "ipam-expiration": {
+      "type": "boolean",
+      "name": "expiration",
+      "in": "header"
     },
     "ipam-family": {
       "enum": [

--- a/api/v1/server/restapi/ipam/post_ipam_parameters.go
+++ b/api/v1/server/restapi/ipam/post_ipam_parameters.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
+	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
 
 	strfmt "github.com/go-openapi/strfmt"
@@ -33,6 +34,10 @@ type PostIpamParams struct {
 	HTTPRequest *http.Request `json:"-"`
 
 	/*
+	  In: header
+	*/
+	Expiration *bool
+	/*
 	  In: query
 	*/
 	Family *string
@@ -53,6 +58,10 @@ func (o *PostIpamParams) BindRequest(r *http.Request, route *middleware.MatchedR
 
 	qs := runtime.Values(r.URL.Query())
 
+	if err := o.bindExpiration(r.Header[http.CanonicalHeaderKey("expiration")], true, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
 	qFamily, qhkFamily, _ := qs.GetOK("family")
 	if err := o.bindFamily(qFamily, qhkFamily, route.Formats); err != nil {
 		res = append(res, err)
@@ -66,6 +75,28 @@ func (o *PostIpamParams) BindRequest(r *http.Request, route *middleware.MatchedR
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+// bindExpiration binds and validates parameter Expiration from header.
+func (o *PostIpamParams) bindExpiration(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+
+	value, err := swag.ConvertBool(raw)
+	if err != nil {
+		return errors.InvalidType("expiration", "header", "bool", raw)
+	}
+	o.Expiration = &value
+
 	return nil
 }
 

--- a/daemon/ipam.go
+++ b/daemon/ipam.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,12 +18,14 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
 	ipamapi "github.com/cilium/cilium/api/v1/server/restapi/ipam"
 	"github.com/cilium/cilium/pkg/api"
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/datapath"
+	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/ipam"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/node"
@@ -46,7 +48,11 @@ func NewPostIPAMHandler(d *Daemon) ipamapi.PostIpamHandler {
 func (h *postIPAM) Handle(params ipamapi.PostIpamParams) middleware.Responder {
 	family := strings.ToLower(swag.StringValue(params.Family))
 	owner := swag.StringValue(params.Owner)
-	ipv4Result, ipv6Result, err := h.daemon.ipam.AllocateNext(family, owner)
+	var expirationTimeout time.Duration
+	if swag.BoolValue(params.Expiration) {
+		expirationTimeout = defaults.IPAMExpiration
+	}
+	ipv4Result, ipv6Result, err := h.daemon.ipam.AllocateNextWithExpiration(family, owner, expirationTimeout)
 	if err != nil {
 		return api.Error(ipamapi.PostIpamFailureCode, err)
 	}
@@ -59,20 +65,22 @@ func (h *postIPAM) Handle(params ipamapi.PostIpamParams) middleware.Responder {
 	if ipv4Result != nil {
 		resp.Address.IPV4 = ipv4Result.IP.String()
 		resp.IPV4 = &models.IPAMAddressResponse{
-			Cidrs:     ipv4Result.CIDRs,
-			IP:        ipv4Result.IP.String(),
-			MasterMac: ipv4Result.Master,
-			Gateway:   ipv4Result.GatewayIP,
+			Cidrs:          ipv4Result.CIDRs,
+			IP:             ipv4Result.IP.String(),
+			MasterMac:      ipv4Result.Master,
+			Gateway:        ipv4Result.GatewayIP,
+			ExpirationUUID: ipv4Result.ExpirationUUID,
 		}
 	}
 
 	if ipv6Result != nil {
 		resp.Address.IPV6 = ipv6Result.IP.String()
 		resp.IPV6 = &models.IPAMAddressResponse{
-			Cidrs:     ipv6Result.CIDRs,
-			IP:        ipv6Result.IP.String(),
-			MasterMac: ipv6Result.Master,
-			Gateway:   ipv6Result.GatewayIP,
+			Cidrs:          ipv6Result.CIDRs,
+			IP:             ipv6Result.IP.String(),
+			MasterMac:      ipv6Result.Master,
+			Gateway:        ipv6Result.GatewayIP,
+			ExpirationUUID: ipv6Result.ExpirationUUID,
 		}
 	}
 

--- a/pkg/client/ipam.go
+++ b/pkg/client/ipam.go
@@ -26,7 +26,7 @@ const (
 )
 
 // IPAMAllocate allocates an IP address out of address family specific pool.
-func (c *Client) IPAMAllocate(family, owner string) (*models.IPAMResponse, error) {
+func (c *Client) IPAMAllocate(family, owner string, expiration bool) (*models.IPAMResponse, error) {
 	params := ipam.NewPostIpamParams().WithTimeout(api.ClientTimeout)
 
 	if family != "" {
@@ -36,6 +36,8 @@ func (c *Client) IPAMAllocate(family, owner string) (*models.IPAMResponse, error
 	if owner != "" {
 		params.SetOwner(&owner)
 	}
+
+	params.SetExpiration(&expiration)
 
 	resp, err := c.Ipam.PostIpam(params)
 	if err != nil {

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -346,4 +346,8 @@ const (
 
 	// NodePortMode is the default value for option.NodePortMode
 	NodePortMode = "snat"
+
+	// IPAMExpiration is the timeout after which an IP subject to expiratio
+	// is being released again if no endpoint is being created in time.
+	IPAMExpiration = 3 * time.Minute
 )

--- a/pkg/ipam/allocator.go
+++ b/pkg/ipam/allocator.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,8 +19,10 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"time"
 
 	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/uuid"
 
 	"github.com/sirupsen/logrus"
 )
@@ -182,10 +184,7 @@ func (ipam *IPAM) AllocateNext(family, owner string) (ipv4Result, ipv6Result *Al
 	return
 }
 
-// ReleaseIP release a IP address.
-func (ipam *IPAM) ReleaseIP(ip net.IP) error {
-	ipam.allocatorMutex.Lock()
-	defer ipam.allocatorMutex.Unlock()
+func (ipam *IPAM) releaseIPLocked(ip net.IP) error {
 	family := familyIPv4
 	if ip.To4() != nil {
 		if ipam.IPv4Allocator == nil {
@@ -212,9 +211,17 @@ func (ipam *IPAM) ReleaseIP(ip net.IP) error {
 		"owner": owner,
 	}).Debugf("Released IP")
 	delete(ipam.owner, ip.String())
+	delete(ipam.expirationTimers, ip.String())
 
 	metrics.IpamEvent.WithLabelValues(metricRelease, family).Inc()
 	return nil
+}
+
+// ReleaseIP release a IP address.
+func (ipam *IPAM) ReleaseIP(ip net.IP) error {
+	ipam.allocatorMutex.Lock()
+	defer ipam.allocatorMutex.Unlock()
+	return ipam.releaseIPLocked(ip)
 }
 
 // ReleaseIPString is identical to ReleaseIP but takes a string and supports
@@ -276,4 +283,74 @@ func (ipam *IPAM) Dump() (allocv4 map[string]string, allocv6 map[string]string, 
 	}
 
 	return
+}
+
+// StartExpirationTimer installs an expiration timer for a previously allocated
+// IP. Unless StopExpirationTimer is called in time, the IP will be released
+// again after expiration of the specified timeout. The function will return a
+// UUID representing the unique allocation attempt. The same UUID must be
+// passed into StopExpirationTimer again.
+//
+// This function is to be used as allocation and use of an IP can be controlled
+// by an external entity and that external entity can disappear. Therefore such
+// users should register an expiration timer before returning the IP and then
+// stop the expiration timer when the IP has been used.
+func (ipam *IPAM) StartExpirationTimer(ip net.IP, timeout time.Duration) (string, error) {
+	ipam.allocatorMutex.Lock()
+	defer ipam.allocatorMutex.Unlock()
+
+	ipString := ip.String()
+	if _, ok := ipam.expirationTimers[ipString]; ok {
+		return "", fmt.Errorf("expiration timer already registered")
+	}
+
+	allocationUUID := uuid.NewUUID().String()
+	ipam.expirationTimers[ipString] = allocationUUID
+
+	go func(ip net.IP, allocationUUID string, timeout time.Duration) {
+		ipString := ip.String()
+		time.Sleep(timeout)
+
+		ipam.allocatorMutex.Lock()
+		defer ipam.allocatorMutex.Unlock()
+
+		if currentUUID, ok := ipam.expirationTimers[ipString]; ok {
+			if currentUUID == allocationUUID {
+				scopedLog := log.WithFields(logrus.Fields{"ip": ipString, "uuid": allocationUUID})
+				if err := ipam.releaseIPLocked(ip); err != nil {
+					scopedLog.WithError(err).Warning("Unable to release IP after expiration")
+				} else {
+					scopedLog.Warning("Released IP after expiration")
+				}
+			} else {
+				// This is an obsolete expiration timer. The IP
+				// was reused and a new expiration timer is
+				// already attached
+			}
+		} else {
+			// Expiration timer was removed. No action is required
+		}
+	}(ip, allocationUUID, timeout)
+
+	return allocationUUID, nil
+}
+
+// StopExpirationTimer will remove the expiration timer for a particular IP.
+// The UUID returned by the symmetric StartExpirationTimer must be provided.
+// The expiration timer will only be removed if the UUIDs match. Releasing an
+// IP will also stop the expiration timer.
+func (ipam *IPAM) StopExpirationTimer(ip net.IP, allocationUUID string) error {
+	ipam.allocatorMutex.Lock()
+	defer ipam.allocatorMutex.Unlock()
+
+	ipString := ip.String()
+	if currentUUID, ok := ipam.expirationTimers[ipString]; !ok {
+		return fmt.Errorf("no expiration timer registered")
+	} else if currentUUID != allocationUUID {
+		return fmt.Errorf("UUID mismatch, not stopping expiration timer")
+	}
+
+	delete(ipam.expirationTimers, ipString)
+
+	return nil
 }

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -78,9 +78,10 @@ type K8sEventRegister interface {
 // NewIPAM returns a new IP address manager
 func NewIPAM(nodeAddressing datapath.NodeAddressing, c Configuration, owner Owner, k8sEventReg K8sEventRegister) *IPAM {
 	ipam := &IPAM{
-		nodeAddressing: nodeAddressing,
-		config:         c,
-		owner:          map[string]string{},
+		nodeAddressing:   nodeAddressing,
+		config:           c,
+		owner:            map[string]string{},
+		expirationTimers: map[string]string{},
 		blacklist: IPBlacklist{
 			ips: map[string]string{},
 		},

--- a/pkg/ipam/types.go
+++ b/pkg/ipam/types.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -92,6 +92,11 @@ type IPAM struct {
 
 	// owner maps an IP to the owner
 	owner map[string]string
+
+	// expirationTimers is a map of all expiration timers. Each entry
+	// represents a IP allocation which is protected by an expiration
+	// timer.
+	expirationTimers map[string]string
 
 	// mutex covers access to all members of this struct
 	allocatorMutex lock.RWMutex

--- a/pkg/ipam/types.go
+++ b/pkg/ipam/types.go
@@ -44,6 +44,10 @@ type AllocationResult struct {
 	// If the allocated IP is derived from a VPC, then the gateway
 	// represented the gateway of the VPC or VPC subnet.
 	GatewayIP string
+
+	// ExpirationUUID is the UUID of the expiration timer. This field is
+	// only set if AllocateNextWithExpiration is used.
+	ExpirationUUID string
 }
 
 // Allocator is the interface for an IP allocator implementation

--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -432,7 +432,7 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 	}
 
 	podName := string(cniArgs.K8S_POD_NAMESPACE) + "/" + string(cniArgs.K8S_POD_NAME)
-	ipam, err = c.IPAMAllocate("", podName)
+	ipam, err = c.IPAMAllocate("", podName, true)
 	if err != nil {
 		err = fmt.Errorf("unable to allocate IP via local cilium agent: %s", err)
 		return
@@ -471,6 +471,7 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 
 	if ipv6IsEnabled(ipam) {
 		ep.Addressing.IPV6 = ipam.Address.IPV6
+		ep.Addressing.IPV6ExpirationUUID = ipam.IPV6.ExpirationUUID
 
 		ipConfig, routes, err = prepareIP(ep.Addressing.IPV6, true, &state, int(conf.RouteMTU))
 		if err != nil {
@@ -483,6 +484,7 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 
 	if ipv4IsEnabled(ipam) {
 		ep.Addressing.IPV4 = ipam.Address.IPV4
+		ep.Addressing.IPV4ExpirationUUID = ipam.IPV4.ExpirationUUID
 
 		ipConfig, routes, err = prepareIP(ep.Addressing.IPV4, false, &state, int(conf.RouteMTU))
 		if err != nil {
@@ -602,20 +604,6 @@ func cmdDel(args *skel.CmdArgs) error {
 		//                         the endpoint is always deleted though, no
 		//                         need to retry
 		log.WithError(err).Warning("Errors encountered while deleting endpoint")
-
-		// Endpoint deletion has failed. We can't be sure whether the
-		// CNI ADD was interrupted in between the IP allocation and the
-		// endpoint creation. In order to guarantee to never leak IP
-		// addresses, delete any IP addresses associated with the pod
-		// being deleted. This task is only done manually on endpoint
-		// delete failure as all IPs of an endpoint are released when
-		// the endpoint is deleted.
-		log.Info("Releasing IPs manually due to inability to delete endpoint")
-		podName := string(cniArgs.K8S_POD_NAMESPACE) + "/" + string(cniArgs.K8S_POD_NAME)
-		err = c.IPAMReleaseIP(podName)
-		if err != nil {
-			log.WithError(err).WithField("pod", podName).Warning("Unable to manually release IPs of pod")
-		}
 	}
 
 	netNs, err := ns.GetNS(args.Netns)

--- a/plugins/cilium-docker/driver/ipam.go
+++ b/plugins/cilium-docker/driver/ipam.go
@@ -116,7 +116,7 @@ func (driver *driver) requestAddress(w http.ResponseWriter, r *http.Request) {
 		family = client.AddressFamilyIPv6
 	}
 
-	ipam, err := driver.client.IPAMAllocate(family, "docker-ipam")
+	ipam, err := driver.client.IPAMAllocate(family, "docker-ipam", false)
 	if err != nil {
 		sendError(w, fmt.Sprintf("Could not allocate IP address: %s", err), http.StatusBadRequest)
 		return


### PR DESCRIPTION
This is a replacement fix for ab61853ca3 which turned out to be racy, leading
to alive PodIPs to be freed. Instead of attempting to reconstruct the context
for potential release in CNI DEL for any failure scenarios, introduce an
expiration timer that is enabled when any IP is allocated via the CNI plugin.
The expiration timer must be explicitly stopped by the endpoint creation
following the allocation to avoid releasing the IP again after a timeout. This
ensures that IPs are always either used or released without requiring any
cleanup from the CNI plugin itself.

In the event that an IP is released due to expiration but then the endpoint
still succeeds to be created, the endpoint creation will fail, triggering a
re-creation of the endpoint.

Fixes: #10065

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10207)
<!-- Reviewable:end -->
