### PR TITLE
test: Fix getNodeInfo in NodePort tests

### DIFF
--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -432,7 +432,7 @@ var _ = Describe("K8sServicesTest", func() {
 		testNodePort := func(bpfNodePort bool) {
 			var data v1.Service
 			k8s1Name, k8s1IP := getNodeInfo(helpers.K8s1)
-			k8s2Name, k8s2IP := getNodeInfo(helpers.K8s1)
+			k8s2Name, k8s2IP := getNodeInfo(helpers.K8s2)
 
 			waitPodsDs()
 


### PR DESCRIPTION
The k8s1 node was used to determine k8s2{Name,IP}, sigh.

Commit 8333039e1f71 ("test: Fix externalTrafficPolicy=Local test cases")
fixed the other occurence some time ago from 11bb75df1d76.

Fixes: 11bb75df1d76 ("CI: Add GetNodeNameByLabel helpers")
Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10211)
<!-- Reviewable:end -->
