### PR TITLE
test: Reduce length of log filenames

### DIFF
--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -792,7 +792,7 @@ var _ = Describe("K8sPolicyTest", func() {
 			})
 		})
 
-		Context("Redirects traffic to proxy when no policy is applied with proxy-visibility annotation", func() {
+		Context("Traffic redirections to proxy", func() {
 
 			var (
 				// track which app1 pod we care about, and its corresponding

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -1542,7 +1542,7 @@ var _ = Describe("RuntimePolicies", func() {
 		})
 	})
 
-	Context("Test Policy Generation for Already-Allocated Identities", func() {
+	Context("Tests for Already-Allocated Identities", func() {
 		var (
 			newContainerName = fmt.Sprintf("%s-already-allocated-id", helpers.Httpd1)
 		)
@@ -1559,7 +1559,7 @@ var _ = Describe("RuntimePolicies", func() {
 			vm.ContainerRm(newContainerName)
 		})
 
-		It("Tests L4 Policy is Generated for Endpoint whose identity has already been allocated", func() {
+		It("Tests L4 policy is generated for endpoint with already-allocated identity", func() {
 			// Create a new container which has labels which have already been
 			// allocated an identity from the key-value store.
 			By("Creating new container with label id.httpd1, which has already " +


### PR DESCRIPTION
With some filesystems (e.g., ecryptfs), the maximum filename length is lower than 255, that of ext4.  On these filesystems, the tests fail with the following error because log filenames are too long:

    K8sPolicyTest Basic Test Redirects traffic to proxy when no policy is applied with proxy-visibility annotation Tests HTTP proxy visibility without policy
    at /cilium/cilium/test/ginkgo-ext/scopes.go:430

    [Could not read monitor log
    Expected
        <*os.PathError | 0xc000e1fec0>: {
            Op: "open",
            Path: "test_results/117-/K8sPolicyTest_Basic_Test_Redirects_traffic_to_proxy_when_no_policy_is_applied_with_proxy-visibility_annotation_Tests_HTTP_proxy_visibility_without_policy/monitor-13f3cf9b-4f30-11ea-b222-60f262b6c493.log",
            Err: 0x24,
        }
    to be nil]

This pull request updates the name of the test, from which the log filename is derived, to be consistent with other tests' names.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10213)
<!-- Reviewable:end -->
