### PR TITLE
Avoid reallocations in loops

### DIFF
--- a/cilium/cmd/policy_trace.go
+++ b/cilium/cmd/policy_trace.go
@@ -143,9 +143,7 @@ If multiple sources and / or destinations are provided, each source is tested wh
 			if err != nil {
 				Fatalf("%s", err)
 			}
-			for _, v := range srcYamlSlices {
-				srcSlices = append(srcSlices, v)
-			}
+			srcSlices = append(srcSlices, srcYamlSlices...)
 		}
 
 		if dstK8sYaml != "" {
@@ -153,9 +151,7 @@ If multiple sources and / or destinations are provided, each source is tested wh
 			if err != nil {
 				Fatalf("%s", err)
 			}
-			for _, v := range dstYamlSlices {
-				dstSlices = append(dstSlices, v)
-			}
+			dstSlices = append(dstSlices, dstYamlSlices...)
 		}
 
 		for _, v := range srcSlices {

--- a/daemon/fqdn.go
+++ b/daemon/fqdn.go
@@ -74,8 +74,8 @@ func identitiesForFQDNSelectorIPs(selectorsWithIPsToUpdate map[policyApi.FQDNSel
 	// AllocateCIDRs. If we for some reason cannot allocate new CIDRs,
 	// we have to undo all of our changes and release the identities.
 	// This is best effort, as releasing can fail as well.
-	usedIdentities := make([]*identity.Identity, 0)
-	selectorIdentitySliceMapping := make(map[policyApi.FQDNSelector][]*identity.Identity)
+	usedIdentities := make([]*identity.Identity, 0, len(selectorsWithIPsToUpdate))
+	selectorIdentitySliceMapping := make(map[policyApi.FQDNSelector][]*identity.Identity, len(selectorsWithIPsToUpdate))
 
 	// Allocate identities for each IPNet and then map to selector
 	for selector, selectorIPs := range selectorsWithIPsToUpdate {

--- a/pkg/alignchecker/alignchecker.go
+++ b/pkg/alignchecker/alignchecker.go
@@ -84,7 +84,7 @@ func getStructInfosFromDWARF(d *dwarf.Data, toCheck map[string][]reflect.Type) (
 
 		if _, found := toCheck[st.StructName]; found {
 			unionCount := 0
-			offsets := make(map[string]int64)
+			offsets := make(map[string]int64, len(st.Field))
 			for _, field := range st.Field {
 				n := field.Name
 				// Create surrogate names ($union0, $union1, etc) for unnamed

--- a/pkg/aws/ec2/ec2.go
+++ b/pkg/aws/ec2/ec2.go
@@ -303,9 +303,7 @@ func (c *Client) CreateNetworkInterface(ctx context.Context, toAllocate int64, s
 		SecondaryPrivateIpAddressCount: &toAllocate,
 		SubnetId:                       &subnetID,
 	}
-	for _, grp := range groups {
-		createReq.Groups = append(createReq.Groups, grp)
-	}
+	createReq.Groups = append(createReq.Groups, groups...)
 
 	c.rateLimit(ctx, "CreateNetworkInterface")
 	sinceStart := spanstat.Start()

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -122,7 +122,7 @@ func ReadEPsFromDirNames(ctx context.Context, owner regeneration.Owner, basePath
 // names that can possibly contain an endpoint, into two lists, containing those
 // names that represent an incomplete endpoint restore and those that do not.
 func partitionEPDirNamesByRestoreStatus(eptsDirNames []string) (complete []string, incomplete []string) {
-	dirNames := make(map[string]struct{})
+	dirNames := make(map[string]struct{}, len(eptsDirNames))
 	for _, epDirName := range eptsDirNames {
 		dirNames[epDirName] = struct{}{}
 	}

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -129,7 +129,7 @@ func (c *Collector) GetStaleProbes() map[string]time.Time {
 	c.RLock()
 	defer c.RUnlock()
 
-	probes := make(map[string]time.Time)
+	probes := make(map[string]time.Time, len(c.staleProbes))
 
 	for p := range c.staleProbes {
 		probes[p] = c.probeStartTime[p]

--- a/test/helpers/cmd.go
+++ b/test/helpers/cmd.go
@@ -171,9 +171,7 @@ func (res *CmdRes) FindResults(filter string) ([]reflect.Value, error) {
 	parser.Parse(filter)
 	fullResults, _ := parser.FindResults(data)
 	for _, res := range fullResults {
-		for _, val := range res {
-			result = append(result, val)
-		}
+		result = append(result, res...)
 	}
 	return result, nil
 }


### PR DESCRIPTION
Avoid reallocations in loops in case a map capacity is known or if two slices can be concatenated.

Updates #10056

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10224)
<!-- Reviewable:end -->
