### PR TITLE
node: Remove permanent ARP entry when remote node is deleted

### DIFF
--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -689,8 +689,8 @@ func (n *linuxNodeHandler) nodeUpdate(oldNode, newNode *node.Node, firstAddition
 		newKey = newNode.EncryptionKey
 	}
 
-	if option.Config.EnableNodePort ||
-		(n.nodeConfig.EnableIPSec && option.Config.Tunnel == option.TunnelDisabled) {
+	if n.nodeConfig.EnableIPv4 && (option.Config.EnableNodePort ||
+		(n.nodeConfig.EnableIPSec && option.Config.Tunnel == option.TunnelDisabled)) {
 		var ifaceName string
 		if option.Config.EnableNodePort {
 			ifaceName = option.Config.Device


### PR DESCRIPTION
When IPsec or NodePort is enabled, we add a permanent ARP entry (remote node IP => remote node MAC addr) upon receiving a NodeUpdate event. The entry is needed to facilitate calls to `fib_lookup()` from the datapath.

Up until now, the permanent entry was not removed when the remote node was deleted. This could lead to a problem, when a packet destined to a new node which reused the IP addr of the deleted node was dropped due to the wrong MAC addr until NodeUpdate event for the new node had been received.

This PR fixes the problem by removing obsolete ARP entries.

Tested manually.

Reviewable per commit.

Fixes #10197.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10227)
<!-- Reviewable:end -->
