### PR TITLE
datapath/loader: always set all args to bpf/init.sh

### DIFF
--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -529,7 +529,7 @@ else
 fi
 
 if [ "$MODE" = "direct" ] || [ "$MODE" = "ipvlan" ] || [ "$MODE" = "routed" ] || [ "$NODE_PORT" = "true" ] ; then
-	if [ -z "$NATIVE_DEV" ]; then
+	if [ "$NATIVE_DEV" == "<nil>" ]; then
 		echo "No device specified for $MODE mode, ignoring..."
 	else
 		if [ "$IP6_HOST" != "<nil>" ]; then
@@ -631,7 +631,7 @@ bpf_load $HOST_DEV1 "" "ingress" bpf_hostdev_ingress.c bpf_hostdev_ingress.o to-
 # bpf_ipsec.o is also needed by proxy redirects, so we load it unconditionally
 bpf_load $HOST_DEV2 "" "ingress" bpf_ipsec.c bpf_ipsec.o from-netdev $CALLS_MAP
 if [ "$IPSEC" == "true" ]; then
-	if [ $ENCRYPT_DEV != "" ]; then
+	if [ "$ENCRYPT_DEV" != "<nil>" ]; then
 		bpf_load $ENCRYPT_DEV "" "ingress" bpf_network.c bpf_network.o from-network $CALLS_MAP
 	fi
 fi
@@ -639,7 +639,7 @@ if [ "$HOST_DEV1" != "$HOST_DEV2" ]; then
 	bpf_unload $HOST_DEV2 "egress"
 fi
 
-if [ -n "$XDP_DEV" ]; then
+if [ "$XDP_DEV" != "<nil>" ]; then
 	CIDR_MAP="cilium_cidr_v*"
 	COPTS=""
 	xdp_load $XDP_DEV $XDP_MODE "$COPTS" bpf_xdp.c bpf_xdp.o from-netdev $CIDR_MAP

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -154,6 +154,9 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 
 		args[initArgDevicePreFilter] = option.Config.DevicePreFilter
 		args[initArgModePreFilter] = option.Config.ModePreFilter
+	} else {
+		args[initArgDevicePreFilter] = "<nil>"
+		args[initArgModePreFilter] = "<nil>"
 	}
 
 	args[initArgLib] = option.Config.BpfDir
@@ -206,6 +209,8 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 
 	if option.Config.EncryptInterface != "" {
 		args[initArgEncryptInterface] = option.Config.EncryptInterface
+	} else {
+		args[initArgEncryptInterface] = "<nil>"
 	}
 
 	if option.Config.Device != "undefined" {
@@ -229,6 +234,7 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 		args[initArgDevice] = option.Config.Device
 	} else {
 		args[initArgMode] = option.Config.Tunnel
+		args[initArgDevice] = "<nil>"
 
 		if option.Config.IsFlannelMasterDeviceSet() {
 			args[initArgMode] = "flannel"
@@ -242,6 +248,8 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 
 	if option.Config.EnableNodePort {
 		args[initArgNodePort] = "true"
+	} else {
+		args[initArgNodePort] = "false"
 	}
 
 	log.Info("Setting up base BPF datapath")
@@ -256,6 +264,12 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 				logfields.SysParamName:  s.name,
 				logfields.SysParamValue: s.val,
 			}).Warning("Failed to sysctl -w")
+		}
+	}
+
+	for i, arg := range args {
+		if arg == "" {
+			log.Warningf("empty argument passed to bpf/init.sh at position %d", i)
 		}
 	}
 

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -200,11 +200,12 @@ const (
 
 	// Logs messages that should not be in the cilium logs.
 	panicMessage      = "panic:"
-	deadLockHeader    = "POTENTIAL DEADLOCK:"       // from github.com/sasha-s/go-deadlock/deadlock.go:header
-	segmentationFault = "segmentation fault"        // from https://github.com/cilium/cilium/issues/3233
-	NACKreceived      = "NACK received for version" // from https://github.com/cilium/cilium/issues/4003
-	RunInitFailed     = "JoinEP: "                  // from https://github.com/cilium/cilium/pull/5052
-	sizeMismatch      = "size mismatch for BPF map" // from https://github.com/cilium/cilium/issues/7851
+	deadLockHeader    = "POTENTIAL DEADLOCK:"                  // from github.com/sasha-s/go-deadlock/deadlock.go:header
+	segmentationFault = "segmentation fault"                   // from https://github.com/cilium/cilium/issues/3233
+	NACKreceived      = "NACK received for version"            // from https://github.com/cilium/cilium/issues/4003
+	RunInitFailed     = "JoinEP: "                             // from https://github.com/cilium/cilium/pull/5052
+	sizeMismatch      = "size mismatch for BPF map"            // from https://github.com/cilium/cilium/issues/7851
+	emptyBPFInitArg   = "empty argument passed to bpf/init.sh" // from https://github.com/cilium/cilium/issues/10228
 
 	// HelmTemplate is the location of the Helm templates to install Cilium
 	HelmTemplate = "../install/kubernetes/cilium"
@@ -257,6 +258,7 @@ var badLogMessages = map[string][]string{
 	NACKreceived:      nil,
 	RunInitFailed:     {"signal: terminated", "signal: killed"},
 	sizeMismatch:      nil,
+	emptyBPFInitArg:   nil,
 }
 
 var ciliumCLICommands = map[string]string{


### PR DESCRIPTION
Passing empty strings to `bpf/init.sh` will lead to arguments being
misinterpreted as their index is no longer correct. This can e.g. lead
to the MTU not being set in `vxlan` mode as seen in #10228. Thus, always
set all 17 (current value `initArgMax`) arguments top non-empty values.
Use `<nil>` as a default empty value if the arg is not used by
`bpf/init.sh`.

Fixes #10228

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10230)
<!-- Reviewable:end -->
