### PR TITLE
[1.6] Fix regression to avoid freeing alive IPs

### DIFF
--- a/api/v1/client/ipam/delete_ip_a_m_ip_parameters.go
+++ b/api/v1/client/ipam/delete_ip_a_m_ip_parameters.go
@@ -62,7 +62,7 @@ for the delete IP a m IP operation typically these are written to a http.Request
 type DeleteIPAMIPParams struct {
 
 	/*IP
-	  IP address
+	  IP address or owner name
 
 	*/
 	IP string

--- a/api/v1/client/ipam/post_ip_a_m_parameters.go
+++ b/api/v1/client/ipam/post_ip_a_m_parameters.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	cr "github.com/go-openapi/runtime/client"
+	"github.com/go-openapi/swag"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -61,6 +62,8 @@ for the post IP a m operation typically these are written to a http.Request
 */
 type PostIPAMParams struct {
 
+	/*Expiration*/
+	Expiration *bool
 	/*Family*/
 	Family *string
 	/*Owner*/
@@ -104,6 +107,17 @@ func (o *PostIPAMParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
+// WithExpiration adds the expiration to the post IP a m params
+func (o *PostIPAMParams) WithExpiration(expiration *bool) *PostIPAMParams {
+	o.SetExpiration(expiration)
+	return o
+}
+
+// SetExpiration adds the expiration to the post IP a m params
+func (o *PostIPAMParams) SetExpiration(expiration *bool) {
+	o.Expiration = expiration
+}
+
 // WithFamily adds the family to the post IP a m params
 func (o *PostIPAMParams) WithFamily(family *string) *PostIPAMParams {
 	o.SetFamily(family)
@@ -133,6 +147,15 @@ func (o *PostIPAMParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Regi
 		return err
 	}
 	var res []error
+
+	if o.Expiration != nil {
+
+		// header param expiration
+		if err := r.SetHeaderParam("expiration", swag.FormatBool(*o.Expiration)); err != nil {
+			return err
+		}
+
+	}
 
 	if o.Family != nil {
 

--- a/api/v1/models/address_pair.go
+++ b/api/v1/models/address_pair.go
@@ -18,8 +18,14 @@ type AddressPair struct {
 	// IPv4 address
 	IPV4 string `json:"ipv4,omitempty"`
 
+	// UUID of IPv4 expiration timer
+	IPV4ExpirationUUID string `json:"ipv4-expiration-uuid,omitempty"`
+
 	// IPv6 address
 	IPV6 string `json:"ipv6,omitempty"`
+
+	// UUID of IPv6 expiration timer
+	IPV6ExpirationUUID string `json:"ipv6-expiration-uuid,omitempty"`
 }
 
 // Validate validates this address pair

--- a/api/v1/models/ip_a_m_address_response.go
+++ b/api/v1/models/ip_a_m_address_response.go
@@ -18,6 +18,11 @@ type IPAMAddressResponse struct {
 	// List of CIDRs out of which IPs are allocated
 	Cidrs []string `json:"cidrs"`
 
+	// The UUID for the expiration timer. Set when expiration has been
+	// enabled while allocating.
+	//
+	ExpirationUUID string `json:"expiration-uuid,omitempty"`
+
 	// IP of gateway
 	Gateway string `json:"gateway,omitempty"`
 

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -404,6 +404,7 @@ paths:
       parameters:
       - "$ref": "#/parameters/ipam-family"
       - "$ref": "#/parameters/ipam-owner"
+      - "$ref": "#/parameters/ipam-expiration"
       responses:
         '201':
           description: Success
@@ -914,6 +915,10 @@ parameters:
     name: owner
     in: query
     type: string
+  ipam-expiration:
+    name: expiration
+    in: header
+    type: boolean
   map-name:
     name: name
     description: Name of map
@@ -1343,6 +1348,11 @@ definitions:
       master-mac:
         type: string
         description: MAC of master interface if address is a slave/secondary of a master interface
+      expiration-uuid:
+        type: string
+        description: |
+          The UUID for the expiration timer. Set when expiration has been
+          enabled while allocating.
   AddressPair:
     description: Addressing information of an endpoint
     type: object
@@ -1350,8 +1360,14 @@ definitions:
       ipv4:
         description: IPv4 address
         type: string
+      ipv4-expiration-uuid:
+        description: UUID of IPv4 expiration timer
+        type: string
       ipv6:
         description: IPv6 address
+        type: string
+      ipv6-expiration-uuid:
+        description: UUID of IPv6 expiration timer
         type: string
   Address:
     description: IP address

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -722,6 +722,9 @@ func init() {
           },
           {
             "$ref": "#/parameters/ipam-owner"
+          },
+          {
+            "$ref": "#/parameters/ipam-expiration"
           }
         ],
         "responses": {
@@ -1238,8 +1241,16 @@ func init() {
           "description": "IPv4 address",
           "type": "string"
         },
+        "ipv4-expiration-uuid": {
+          "description": "UUID of IPv4 expiration timer",
+          "type": "string"
+        },
         "ipv6": {
           "description": "IPv6 address",
+          "type": "string"
+        },
+        "ipv6-expiration-uuid": {
+          "description": "UUID of IPv6 expiration timer",
           "type": "string"
         }
       }
@@ -2145,6 +2156,10 @@ func init() {
             "type": "string"
           }
         },
+        "expiration-uuid": {
+          "description": "The UUID for the expiration timer. Set when expiration has been\nenabled while allocating.\n",
+          "type": "string"
+        },
         "gateway": {
           "description": "IP of gateway",
           "type": "string"
@@ -2886,6 +2901,11 @@ func init() {
       "name": "id",
       "in": "path",
       "required": true
+    },
+    "ipam-expiration": {
+      "type": "boolean",
+      "name": "expiration",
+      "in": "header"
     },
     "ipam-family": {
       "enum": [
@@ -3794,6 +3814,11 @@ func init() {
             "type": "string",
             "name": "owner",
             "in": "query"
+          },
+          {
+            "type": "boolean",
+            "name": "expiration",
+            "in": "header"
           }
         ],
         "responses": {
@@ -4365,8 +4390,16 @@ func init() {
           "description": "IPv4 address",
           "type": "string"
         },
+        "ipv4-expiration-uuid": {
+          "description": "UUID of IPv4 expiration timer",
+          "type": "string"
+        },
         "ipv6": {
           "description": "IPv6 address",
+          "type": "string"
+        },
+        "ipv6-expiration-uuid": {
+          "description": "UUID of IPv6 expiration timer",
           "type": "string"
         }
       }
@@ -5272,6 +5305,10 @@ func init() {
             "type": "string"
           }
         },
+        "expiration-uuid": {
+          "description": "The UUID for the expiration timer. Set when expiration has been\nenabled while allocating.\n",
+          "type": "string"
+        },
         "gateway": {
           "description": "IP of gateway",
           "type": "string"
@@ -6013,6 +6050,11 @@ func init() {
       "name": "id",
       "in": "path",
       "required": true
+    },
+    "ipam-expiration": {
+      "type": "boolean",
+      "name": "expiration",
+      "in": "header"
     },
     "ipam-family": {
       "enum": [

--- a/api/v1/server/restapi/ipam/post_ip_a_m_parameters.go
+++ b/api/v1/server/restapi/ipam/post_ip_a_m_parameters.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
+	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
 
 	strfmt "github.com/go-openapi/strfmt"
@@ -33,6 +34,10 @@ type PostIPAMParams struct {
 	HTTPRequest *http.Request `json:"-"`
 
 	/*
+	  In: header
+	*/
+	Expiration *bool
+	/*
 	  In: query
 	*/
 	Family *string
@@ -53,6 +58,10 @@ func (o *PostIPAMParams) BindRequest(r *http.Request, route *middleware.MatchedR
 
 	qs := runtime.Values(r.URL.Query())
 
+	if err := o.bindExpiration(r.Header[http.CanonicalHeaderKey("expiration")], true, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
 	qFamily, qhkFamily, _ := qs.GetOK("family")
 	if err := o.bindFamily(qFamily, qhkFamily, route.Formats); err != nil {
 		res = append(res, err)
@@ -66,6 +75,28 @@ func (o *PostIPAMParams) BindRequest(r *http.Request, route *middleware.MatchedR
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+// bindExpiration binds and validates parameter Expiration from header.
+func (o *PostIPAMParams) bindExpiration(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+
+	value, err := swag.ConvertBool(raw)
+	if err != nil {
+		return errors.InvalidType("expiration", "header", "bool", raw)
+	}
+	o.Expiration = &value
+
 	return nil
 }
 

--- a/pkg/client/ipam.go
+++ b/pkg/client/ipam.go
@@ -26,7 +26,7 @@ const (
 )
 
 // IPAMAllocate allocates an IP address out of address family specific pool.
-func (c *Client) IPAMAllocate(family, owner string) (*models.IPAMResponse, error) {
+func (c *Client) IPAMAllocate(family, owner string, expiration bool) (*models.IPAMResponse, error) {
 	params := ipam.NewPostIPAMParams().WithTimeout(api.ClientTimeout)
 
 	if family != "" {
@@ -36,6 +36,8 @@ func (c *Client) IPAMAllocate(family, owner string) (*models.IPAMResponse, error
 	if owner != "" {
 		params.SetOwner(&owner)
 	}
+
+	params.SetExpiration(&expiration)
 
 	resp, err := c.IPAM.PostIPAM(params)
 	if err != nil {

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -306,4 +306,8 @@ const (
 
 	// RestoreV6Addr is used as match for cilium_host v6 (router) address
 	RestoreV6Addr = "cilium.v6.internal.raw "
+
+	// IPAMExpiration is the timeout after which an IP subject to expiratio
+	// is being released again if no endpoint is being created in time.
+	IPAMExpiration = 3 * time.Minute
 )

--- a/pkg/ipam/allocator.go
+++ b/pkg/ipam/allocator.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,8 +19,10 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"time"
 
 	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/uuid"
 
 	"github.com/sirupsen/logrus"
 )
@@ -182,10 +184,7 @@ func (ipam *IPAM) AllocateNext(family, owner string) (ipv4Result, ipv6Result *Al
 	return
 }
 
-// ReleaseIP release a IP address.
-func (ipam *IPAM) ReleaseIP(ip net.IP) error {
-	ipam.allocatorMutex.Lock()
-	defer ipam.allocatorMutex.Unlock()
+func (ipam *IPAM) releaseIPLocked(ip net.IP) error {
 	family := familyIPv4
 	if ip.To4() != nil {
 		if ipam.IPv4Allocator == nil {
@@ -212,9 +211,17 @@ func (ipam *IPAM) ReleaseIP(ip net.IP) error {
 		"owner": owner,
 	}).Debugf("Released IP")
 	delete(ipam.owner, ip.String())
+	delete(ipam.expirationTimers, ip.String())
 
 	metrics.IpamEvent.WithLabelValues(metricRelease, family).Inc()
 	return nil
+}
+
+// ReleaseIP release a IP address.
+func (ipam *IPAM) ReleaseIP(ip net.IP) error {
+	ipam.allocatorMutex.Lock()
+	defer ipam.allocatorMutex.Unlock()
+	return ipam.releaseIPLocked(ip)
 }
 
 // ReleaseIPString is identical to ReleaseIP but takes a string and supports
@@ -276,4 +283,74 @@ func (ipam *IPAM) Dump() (allocv4 map[string]string, allocv6 map[string]string, 
 	}
 
 	return
+}
+
+// StartExpirationTimer installs an expiration timer for a previously allocated
+// IP. Unless StopExpirationTimer is called in time, the IP will be released
+// again after expiration of the specified timeout. The function will return a
+// UUID representing the unique allocation attempt. The same UUID must be
+// passed into StopExpirationTimer again.
+//
+// This function is to be used as allocation and use of an IP can be controlled
+// by an external entity and that external entity can disappear. Therefore such
+// users should register an expiration timer before returning the IP and then
+// stop the expiration timer when the IP has been used.
+func (ipam *IPAM) StartExpirationTimer(ip net.IP, timeout time.Duration) (string, error) {
+	ipam.allocatorMutex.Lock()
+	defer ipam.allocatorMutex.Unlock()
+
+	ipString := ip.String()
+	if _, ok := ipam.expirationTimers[ipString]; ok {
+		return "", fmt.Errorf("expiration timer already registered")
+	}
+
+	allocationUUID := uuid.NewUUID().String()
+	ipam.expirationTimers[ipString] = allocationUUID
+
+	go func(ip net.IP, allocationUUID string, timeout time.Duration) {
+		ipString := ip.String()
+		time.Sleep(timeout)
+
+		ipam.allocatorMutex.Lock()
+		defer ipam.allocatorMutex.Unlock()
+
+		if currentUUID, ok := ipam.expirationTimers[ipString]; ok {
+			if currentUUID == allocationUUID {
+				scopedLog := log.WithFields(logrus.Fields{"ip": ipString, "uuid": allocationUUID})
+				if err := ipam.releaseIPLocked(ip); err != nil {
+					scopedLog.WithError(err).Warning("Unable to release IP after expiration")
+				} else {
+					scopedLog.Warning("Released IP after expiration")
+				}
+			} else {
+				// This is an obsolete expiration timer. The IP
+				// was reused and a new expiration timer is
+				// already attached
+			}
+		} else {
+			// Expiration timer was removed. No action is required
+		}
+	}(ip, allocationUUID, timeout)
+
+	return allocationUUID, nil
+}
+
+// StopExpirationTimer will remove the expiration timer for a particular IP.
+// The UUID returned by the symmetric StartExpirationTimer must be provided.
+// The expiration timer will only be removed if the UUIDs match. Releasing an
+// IP will also stop the expiration timer.
+func (ipam *IPAM) StopExpirationTimer(ip net.IP, allocationUUID string) error {
+	ipam.allocatorMutex.Lock()
+	defer ipam.allocatorMutex.Unlock()
+
+	ipString := ip.String()
+	if currentUUID, ok := ipam.expirationTimers[ipString]; !ok {
+		return fmt.Errorf("no expiration timer registered")
+	} else if currentUUID != allocationUUID {
+		return fmt.Errorf("UUID mismatch, not stopping expiration timer")
+	}
+
+	delete(ipam.expirationTimers, ipString)
+
+	return nil
 }

--- a/pkg/ipam/allocator_test.go
+++ b/pkg/ipam/allocator_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package ipam
 
 import (
 	"net"
+	"time"
 
 	"github.com/cilium/cilium/common/addressing"
 	"github.com/cilium/cilium/pkg/datapath/fake"
@@ -58,4 +59,71 @@ func (s *IPAMSuite) TestAllocatedIPDump(c *C) {
 	for ip := range allocv6 {
 		c.Assert(net.ParseIP(ip), NotNil)
 	}
+}
+
+func (s *IPAMSuite) TestExpirationTimer(c *C) {
+	ip := net.ParseIP("1.1.1.1")
+	timeout := 50 * time.Millisecond
+
+	fakeAddressing := fake.NewNodeAddressing()
+	ipam := NewIPAM(fakeAddressing, Configuration{EnableIPv4: true, EnableIPv6: true}, &ownerMock{})
+
+	err := ipam.AllocateIP(ip, "foo")
+	c.Assert(err, IsNil)
+
+	uuid, err := ipam.StartExpirationTimer(ip, timeout)
+	c.Assert(err, IsNil)
+	c.Assert(uuid, Not(Equals), "")
+	// must fail, already registered
+	uuid, err = ipam.StartExpirationTimer(ip, timeout)
+	c.Assert(err, Not(IsNil))
+	c.Assert(uuid, Equals, "")
+	// must fail, already in use
+	err = ipam.AllocateIP(ip, "foo")
+	c.Assert(err, Not(IsNil))
+	// Let expiration timer expire
+	time.Sleep(2 * timeout)
+	// Must suceed, IP must be released again
+	err = ipam.AllocateIP(ip, "foo")
+	c.Assert(err, IsNil)
+	// register new expiration timer
+	uuid, err = ipam.StartExpirationTimer(ip, timeout)
+	c.Assert(err, IsNil)
+	c.Assert(uuid, Not(Equals), "")
+	// attempt to stop with an invalid uuid, must fail
+	err = ipam.StopExpirationTimer(ip, "unknown-uuid")
+	c.Assert(err, Not(IsNil))
+	// stop expiration with valid uuid
+	err = ipam.StopExpirationTimer(ip, uuid)
+	c.Assert(err, IsNil)
+	// Let expiration timer expire
+	time.Sleep(2 * timeout)
+	// must fail as IP is properly in use now
+	err = ipam.AllocateIP(ip, "foo")
+	c.Assert(err, Not(IsNil))
+	// release IP for real
+	err = ipam.ReleaseIP(ip)
+	c.Assert(err, IsNil)
+
+	// allocate IP again
+	err = ipam.AllocateIP(ip, "foo")
+	c.Assert(err, IsNil)
+	// register expiration timer
+	uuid, err = ipam.StartExpirationTimer(ip, timeout)
+	c.Assert(err, IsNil)
+	c.Assert(uuid, Not(Equals), "")
+	// release IP, must also stop expiration timer
+	err = ipam.ReleaseIP(ip)
+	c.Assert(err, IsNil)
+	// allocate same IP again
+	err = ipam.AllocateIP(ip, "foo")
+	c.Assert(err, IsNil)
+	// register expiration timer must succeed even though stop was never called
+	uuid, err = ipam.StartExpirationTimer(ip, timeout)
+	c.Assert(err, IsNil)
+	c.Assert(uuid, Not(Equals), "")
+	// release IP
+	err = ipam.ReleaseIP(ip)
+	c.Assert(err, IsNil)
+
 }

--- a/pkg/ipam/allocator_test.go
+++ b/pkg/ipam/allocator_test.go
@@ -127,3 +127,54 @@ func (s *IPAMSuite) TestExpirationTimer(c *C) {
 	c.Assert(err, IsNil)
 
 }
+
+func (s *IPAMSuite) TestAllocateNextWithExpiration(c *C) {
+	timeout := 50 * time.Millisecond
+
+	fakeAddressing := fake.NewNodeAddressing()
+	ipam := NewIPAM(fakeAddressing, Configuration{EnableIPv4: true, EnableIPv6: true}, &ownerMock{})
+
+	ipv4, ipv6, err := ipam.AllocateNextWithExpiration("", "foo", timeout)
+	c.Assert(err, IsNil)
+
+	// IPv4 address must be in use
+	err = ipam.AllocateIP(ipv4.IP, "foo")
+	c.Assert(err, Not(IsNil))
+	// IPv6 address must be in use
+	err = ipam.AllocateIP(ipv6.IP, "foo")
+	c.Assert(err, Not(IsNil))
+	// Let expiration timer expire
+	time.Sleep(2 * timeout)
+	// IPv4 address must be available again
+	err = ipam.AllocateIP(ipv4.IP, "foo")
+	c.Assert(err, IsNil)
+	// IPv6 address must be available again
+	err = ipam.AllocateIP(ipv6.IP, "foo")
+	c.Assert(err, IsNil)
+	// Release IPs
+	err = ipam.ReleaseIP(ipv4.IP)
+	c.Assert(err, IsNil)
+	err = ipam.ReleaseIP(ipv6.IP)
+	c.Assert(err, IsNil)
+
+	// Allocate IPs again and test stopping the expiration timer
+	ipv4, ipv6, err = ipam.AllocateNextWithExpiration("", "foo", timeout)
+	c.Assert(err, IsNil)
+
+	// Stop expiration timer for IPv4 address
+	err = ipam.StopExpirationTimer(ipv4.IP, ipv4.ExpirationUUID)
+	c.Assert(err, IsNil)
+
+	// Let expiration timer expire
+	time.Sleep(2 * timeout)
+
+	// IPv4 address must be in use
+	err = ipam.AllocateIP(ipv4.IP, "foo")
+	c.Assert(err, Not(IsNil))
+	// IPv6 address must be available again
+	err = ipam.AllocateIP(ipv6.IP, "foo")
+	c.Assert(err, IsNil)
+	// Release IPv4 address
+	err = ipam.ReleaseIP(ipv4.IP)
+	c.Assert(err, IsNil)
+}

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -76,9 +76,10 @@ type Owner interface {
 // NewIPAM returns a new IP address manager
 func NewIPAM(nodeAddressing datapath.NodeAddressing, c Configuration, owner Owner) *IPAM {
 	ipam := &IPAM{
-		nodeAddressing: nodeAddressing,
-		config:         c,
-		owner:          map[string]string{},
+		nodeAddressing:   nodeAddressing,
+		config:           c,
+		owner:            map[string]string{},
+		expirationTimers: map[string]string{},
 		blacklist: IPBlacklist{
 			ips: map[string]string{},
 		},

--- a/pkg/ipam/types.go
+++ b/pkg/ipam/types.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -92,6 +92,11 @@ type IPAM struct {
 
 	// owner maps an IP to the owner
 	owner map[string]string
+
+	// expirationTimers is a map of all expiration timers. Each entry
+	// represents a IP allocation which is protected by an expiration
+	// timer.
+	expirationTimers map[string]string
 
 	// mutex covers access to all members of this struct
 	allocatorMutex lock.RWMutex

--- a/pkg/ipam/types.go
+++ b/pkg/ipam/types.go
@@ -44,6 +44,10 @@ type AllocationResult struct {
 	// If the allocated IP is derived from a VPC, then the gateway
 	// represented the gateway of the VPC or VPC subnet.
 	GatewayIP string
+
+	// ExpirationUUID is the UUID of the expiration timer. This field is
+	// only set if AllocateNextWithExpiration is used.
+	ExpirationUUID string
 }
 
 // Allocator is the interface for an IP allocator implementation

--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -416,7 +416,7 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 	}
 
 	podName := string(cniArgs.K8S_POD_NAMESPACE) + "/" + string(cniArgs.K8S_POD_NAME)
-	ipam, err = c.IPAMAllocate("", podName)
+	ipam, err = c.IPAMAllocate("", podName, true)
 	if err != nil {
 		err = fmt.Errorf("unable to allocate IP via local cilium agent: %s", err)
 		return
@@ -455,6 +455,7 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 
 	if ipv6IsEnabled(ipam) {
 		ep.Addressing.IPV6 = ipam.Address.IPV6
+		ep.Addressing.IPV6ExpirationUUID = ipam.IPV6.ExpirationUUID
 
 		ipConfig, routes, err = prepareIP(ep.Addressing.IPV6, true, &state, int(conf.RouteMTU))
 		if err != nil {
@@ -467,6 +468,7 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 
 	if ipv4IsEnabled(ipam) {
 		ep.Addressing.IPV4 = ipam.Address.IPV4
+		ep.Addressing.IPV4ExpirationUUID = ipam.IPV4.ExpirationUUID
 
 		ipConfig, routes, err = prepareIP(ep.Addressing.IPV4, false, &state, int(conf.RouteMTU))
 		if err != nil {
@@ -578,20 +580,6 @@ func cmdDel(args *skel.CmdArgs) error {
 		//                         the endpoint is always deleted though, no
 		//                         need to retry
 		log.WithError(err).Warning("Errors encountered while deleting endpoint")
-
-		// Endpoint deletion has failed. We can't be sure whether the
-		// CNI ADD was interrupted in between the IP allocation and the
-		// endpoint creation. In order to guarantee to never leak IP
-		// addresses, delete any IP addresses associated with the pod
-		// being deleted. This task is only done manually on endpoint
-		// delete failure as all IPs of an endpoint are released when
-		// the endpoint is deleted.
-		log.Info("Releasing IPs manually due to inability to delete endpoint")
-		podName := string(cniArgs.K8S_POD_NAMESPACE) + "/" + string(cniArgs.K8S_POD_NAME)
-		err = c.IPAMReleaseIP(podName)
-		if err != nil {
-			log.WithError(err).WithField("pod", podName).Warning("Unable to manually release IPs of pod")
-		}
 	}
 
 	netNs, err := ns.GetNS(args.Netns)

--- a/plugins/cilium-docker/driver/ipam.go
+++ b/plugins/cilium-docker/driver/ipam.go
@@ -116,7 +116,7 @@ func (driver *driver) requestAddress(w http.ResponseWriter, r *http.Request) {
 		family = client.AddressFamilyIPv6
 	}
 
-	ipam, err := driver.client.IPAMAllocate(family, "docker-ipam")
+	ipam, err := driver.client.IPAMAllocate(family, "docker-ipam", false)
 	if err != nil {
 		sendError(w, fmt.Sprintf("Could not allocate IP address: %s", err), http.StatusBadRequest)
 		return


### PR DESCRIPTION
Backport of https://github.com/cilium/cilium/pull/10207

```upstream-prs
$ for pr in 10207; do contrib/backporting/set-labels.py $pr done 1.6; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10237)
<!-- Reviewable:end -->
