### PR TITLE
service: Fix HealthCheckNodePort not displayed in API

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -80,12 +80,13 @@ func (svc *svcInfo) deepCopyToLBSVC() *lb.SVC {
 		backends[i] = *backend.DeepCopy()
 	}
 	return &lb.SVC{
-		Frontend:      *svc.frontend.DeepCopy(),
-		Backends:      backends,
-		Type:          svc.svcType,
-		TrafficPolicy: svc.svcTrafficPolicy,
-		Name:          svc.svcName,
-		Namespace:     svc.svcNamespace,
+		Frontend:            *svc.frontend.DeepCopy(),
+		Backends:            backends,
+		Type:                svc.svcType,
+		TrafficPolicy:       svc.svcTrafficPolicy,
+		HealthCheckNodePort: svc.svcHealthCheckNodePort,
+		Name:                svc.svcName,
+		Namespace:           svc.svcNamespace,
 	}
 }
 


### PR DESCRIPTION
The `HealthCheckNodePort` field was not copied in `deepCopyToLBSVC`,
thus causing the field to never show up in the Cilium API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10240)
<!-- Reviewable:end -->
