### PR TITLE
proxy: remove write-only members from type Redirect

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -424,8 +424,6 @@ func (p *Proxy) CreateOrUpdateRedirect(l4 policy.ProxyPolicy, id string, localEn
 			}
 			revertStack.Push(implUpdateRevertFunc)
 
-			redir.lastUpdated = time.Now()
-
 			scopedLog.WithField(logfields.Object, logfields.Repr(redir)).
 				Debug("updated existing ", l4.GetL7Parser(), " proxy instance")
 

--- a/pkg/proxy/redirect.go
+++ b/pkg/proxy/redirect.go
@@ -15,8 +15,6 @@
 package proxy
 
 import (
-	"time"
-
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/policy"
@@ -48,14 +46,12 @@ type Redirect struct {
 	dstPort        uint16
 	endpointID     uint64
 	localEndpoint  logger.EndpointUpdater
-	created        time.Time
 	implementation RedirectImplementation
 
 	// The following fields are updated while the redirect is alive, the
 	// mutex must be held to read and write these fields
-	mutex       lock.RWMutex
-	lastUpdated time.Time
-	rules       policy.L7DataMap
+	mutex lock.RWMutex
+	rules policy.L7DataMap
 }
 
 func newRedirect(localEndpoint logger.EndpointUpdater, listener *ProxyPort, dstPort uint16) *Redirect {
@@ -64,8 +60,6 @@ func newRedirect(localEndpoint logger.EndpointUpdater, listener *ProxyPort, dstP
 		dstPort:       dstPort,
 		endpointID:    localEndpoint.GetID(),
 		localEndpoint: localEndpoint,
-		created:       time.Now(),
-		lastUpdated:   time.Now(),
 	}
 }
 


### PR DESCRIPTION
The `created` and `lastUpdated` timestamps in `type Redirect struct` are only
written but never read. Remove them.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10242)
<!-- Reviewable:end -->
