### PR TITLE
Fixups for Correct clustermesh identity sync kvstore backend usage

### DIFF
--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -140,7 +140,7 @@ func NewKVStoreBackend(basePath, suffix string, typ allocator.AllocatorKey, back
 // lockPath locks a key in the scope of an allocator
 func (k *kvstoreBackend) lockPath(ctx context.Context, key string) (*kvstore.Lock, error) {
 	suffix := strings.TrimPrefix(key, k.basePrefix)
-	return kvstore.LockPath(ctx, path.Join(k.lockPrefix, suffix))
+	return kvstore.LockPath(ctx, k.backend, path.Join(k.lockPrefix, suffix))
 }
 
 // DeleteAllKeys will delete all keys
@@ -198,7 +198,7 @@ func (k *kvstoreBackend) createValueNodeKey(ctx context.Context, key string, new
 // Lock locks a key in the scope of an allocator
 func (k *kvstoreBackend) lock(ctx context.Context, key string) (*kvstore.Lock, error) {
 	suffix := strings.TrimPrefix(key, k.basePrefix)
-	return kvstore.LockPath(ctx, path.Join(k.lockPrefix, suffix))
+	return kvstore.LockPath(ctx, k.backend, path.Join(k.lockPrefix, suffix))
 }
 
 // Lock locks a key in the scope of an allocator

--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -145,7 +145,7 @@ func (k *kvstoreBackend) lockPath(ctx context.Context, key string) (*kvstore.Loc
 
 // DeleteAllKeys will delete all keys
 func (k *kvstoreBackend) DeleteAllKeys(ctx context.Context) {
-	kvstore.Client().DeletePrefix(ctx, k.basePrefix)
+	k.backend.DeletePrefix(ctx, k.basePrefix)
 }
 
 // AllocateID allocates a key->ID mapping in the kvstore.

--- a/pkg/kvstore/base_test.go
+++ b/pkg/kvstore/base_test.go
@@ -38,7 +38,7 @@ func (s *BaseTests) TestLock(c *C) {
 	defer Client().DeletePrefix(context.TODO(), prefix)
 
 	for i := 0; i < 10; i++ {
-		lock, err := LockPath(context.Background(), fmt.Sprintf("%sfoo/%d", prefix, i))
+		lock, err := LockPath(context.Background(), Client(), fmt.Sprintf("%sfoo/%d", prefix, i))
 		c.Assert(err, IsNil)
 		c.Assert(lock, Not(IsNil))
 		lock.Unlock(context.TODO())

--- a/pkg/kvstore/consul.go
+++ b/pkg/kvstore/consul.go
@@ -658,7 +658,7 @@ func (c *consulClient) createIfExists(ctx context.Context, condKey, key string, 
 	//
 	// Lock the conditional key to serialize all CreateIfExists() calls
 
-	l, err := LockPath(ctx, condKey)
+	l, err := LockPath(ctx, c, condKey)
 	if err != nil {
 		return fmt.Errorf("unable to lock condKey for CreateIfExists: %s", err)
 	}

--- a/pkg/kvstore/lock.go
+++ b/pkg/kvstore/lock.go
@@ -132,13 +132,13 @@ type Lock struct {
 // returned also contains a patch specific local Mutex which will be held.
 //
 // It is required to call Unlock() on the returned Lock to unlock
-func LockPath(ctx context.Context, path string) (l *Lock, err error) {
+func LockPath(ctx context.Context, backend BackendOperations, path string) (l *Lock, err error) {
 	id, err := kvstoreLocks.lock(ctx, path)
 	if err != nil {
 		return nil, err
 	}
 
-	lock, err := Client().LockPath(ctx, path)
+	lock, err := backend.LockPath(ctx, path)
 	if err != nil {
 		kvstoreLocks.unlock(path, id)
 		Trace("Failed to lock", err, logrus.Fields{fieldKey: path})


### PR DESCRIPTION
I missed some things:
- 1 instance where the global kvstore client was used instead of the per-allocator one. This was in DeleteAllKeys, mostly used in tests.
- kvstore locks used the global client and could create the lock in the wrong place. This should never happen, as clustermesh is the only case of multiple kvstores and we only lock keys in the default, global client.

fixes https://github.com/cilium/cilium/pull/10185

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10243)
<!-- Reviewable:end -->
