### PR TITLE
test: Consider IPv6 enablement when checking tunnel map entries

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -147,6 +147,16 @@ var (
 	}
 )
 
+// HelmOverride returns the value of a Helm override option for the currently
+// enabled CNI_INTEGRATION
+func HelmOverride(option string) string {
+	integration := strings.ToLower(os.Getenv("CNI_INTEGRATION"))
+	if overrides, exists := helmOverrides[integration]; exists {
+		return overrides[option]
+	}
+	return ""
+}
+
 func init() {
 	// Copy over envronment variables that are passed in.
 	for envVar, helmVar := range map[string]string{


### PR DESCRIPTION
Depending on whether IPv6 is enabled or not, the number of tunnel map entries will vary

Fixes: #10026

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10247)
<!-- Reviewable:end -->
