### PR TITLE
test: Disable Geneve encapsulation tests on GKE

### DIFF
--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -245,6 +245,9 @@ var _ = Describe("K8sDatapathConfig", func() {
 		}, 600)
 
 		It("Check connectivity with Geneve encapsulation", func() {
+			// Geneve is currently not supported on GKE
+			SkipIfIntegration(helpers.CIIntegrationGKE)
+
 			deployCilium(map[string]string{
 				"global.tunnel": "geneve",
 			})


### PR DESCRIPTION
GKE currently doesn't support Geneve:
```
level=warning msg="+ ip link add name cilium_geneve address a6:04:9c:c0:d2:5b mtu 1460 type geneve external" subsys=datapath-loader
level=warning msg="RTNETLINK answers: Operation not supported" subsys=datapath-loader
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10248)
<!-- Reviewable:end -->
