### PR TITLE
test: Skip autoDirectNodeRoutes on GKE

### DIFF
--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -264,21 +264,22 @@ var _ = Describe("K8sDatapathConfig", func() {
 	})
 
 	Context("DirectRouting", func() {
+		BeforeEach(func() {
+			SkipIfIntegration(helpers.CIIntegrationFlannel)
+			SkipIfIntegration(helpers.CIIntegrationGKE)
+		})
+
 		directRoutingOptions := map[string]string{
 			"global.tunnel":               "disabled",
 			"global.autoDirectNodeRoutes": "true",
 		}
 
 		It("Check connectivity with automatic direct nodes routes", func() {
-			SkipIfIntegration(helpers.CIIntegrationFlannel)
-
 			deployCilium(directRoutingOptions)
 			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
 		})
 
 		It("Check direct connectivity with per endpoint routes", func() {
-			SkipIfIntegration(helpers.CIIntegrationFlannel)
-
 			directRoutingOptions["global.endpointRoutes.enabled"] = "true"
 			directRoutingOptions["global.ipv6.enabled"] = "false"
 			deployCilium(directRoutingOptions)


### PR DESCRIPTION
GKE on GCE dosn't guarantee a flat L2 network so autoDirectNodeRoute tests need
to be disabled.

Fixes: #10030

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10249)
<!-- Reviewable:end -->
