### PR TITLE
[WIP] A new IPVlan CNI chain to work with Terway (Alibaba Cloud CNI Plugin)

### DIFF
--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -543,13 +543,13 @@ func (h *HeaderfileWriter) writeTemplateConfig(fw *bufio.Writer, e datapath.Endp
 		}
 	}
 
-	if !e.HasIpvlanDataPath() {
-		if e.RequireARPPassthrough() {
-			fmt.Fprint(fw, "#define ENABLE_ARP_PASSTHROUGH 1\n")
-		} else {
-			fmt.Fprint(fw, "#define ENABLE_ARP_RESPONDER 1\n")
-		}
+	if e.RequireARPPassthrough() {
+		fmt.Fprint(fw, "#define ENABLE_ARP_PASSTHROUGH 1\n")
+	} else {
+		fmt.Fprint(fw, "#define ENABLE_ARP_RESPONDER 1\n")
+	}
 
+	if !e.HasIpvlanDataPath() {
 		fmt.Fprint(fw, "#define ENABLE_HOST_REDIRECT 1\n")
 		if option.Config.IsFlannelMasterDeviceSet() {
 			fmt.Fprint(fw, "#define HOST_REDIRECT_TO_INGRESS 1\n")

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -286,7 +286,7 @@ func (l *Loader) reloadDatapath(ctx context.Context, ep datapath.Endpoint, dirs 
 			return err
 		}
 	} else if ep.HasIpvlanDataPath() {
-		if err := graftDatapath(ctx, ep.MapPath(), objPath, symbolFromEndpoint); err != nil {
+		if err := graftDatapath(ctx, ep.MapPath(), objPath, symbolFromEndpoint, 0); err != nil {
 			scopedLog := ep.Logger(Subsystem).WithFields(logrus.Fields{
 				logfields.Path: objPath,
 			})
@@ -297,6 +297,20 @@ func (l *Loader) reloadDatapath(ctx context.Context, ep datapath.Endpoint, dirs 
 				scopedLog.WithError(err).Warn("JoinEP: Failed to load program")
 			}
 			return err
+		}
+		if ep.RequireEgressProg() {
+			if err := graftDatapath(ctx, ep.MapPath(), objPath, symbolToEndpoint, 1); err != nil {
+				scopedLog := ep.Logger(Subsystem).WithFields(logrus.Fields{
+					logfields.Path: objPath,
+				})
+				// Don't log an error here if the context was canceled or timed out;
+				// this log message should only represent failures with respect to
+				// loading the program.
+				if ctx.Err() == nil {
+					scopedLog.WithError(err).Warn("JoinEP: Failed to load program")
+				}
+				return err
+			}
 		}
 	} else {
 		if err := l.replaceDatapath(ctx, ep.InterfaceName(), objPath, symbolFromEndpoint, dirIngress); err != nil {

--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -17,6 +17,7 @@ package loader
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/command/exec"
@@ -94,7 +95,7 @@ func (l *Loader) replaceDatapath(ctx context.Context, ifName, objPath, progSec, 
 }
 
 // graftDatapath replaces obj in tail call map
-func graftDatapath(ctx context.Context, mapPath, objPath, progSec string) error {
+func graftDatapath(ctx context.Context, mapPath, objPath, progSec string, key int) error {
 	var err error
 
 	// FIXME: Replace cilium-map-migrate with Golang map migration
@@ -117,8 +118,7 @@ func graftDatapath(ctx context.Context, mapPath, objPath, progSec string) error 
 	}()
 
 	// FIXME: replace exec with native call
-	// FIXME: only key 0 right now, could be made more flexible
-	args := []string{"exec", "bpf", "graft", mapPath, "key", "0",
+	args := []string{"exec", "bpf", "graft", mapPath, "key", strconv.FormatInt(int64(key), 10),
 		"obj", objPath, "sec", progSec,
 	}
 	cmd = exec.CommandContext(ctx, "tc", args...).WithFilters(libbpfFixupMsg)

--- a/plugins/cilium-cni/chaining/terway/terway.go
+++ b/plugins/cilium-cni/chaining/terway/terway.go
@@ -1,0 +1,183 @@
+// Copyright 2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package terway
+
+import (
+	"context"
+	"fmt"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/datapath/connector"
+	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	chainingapi "github.com/cilium/cilium/plugins/cilium-cni/chaining/api"
+	cniTypesVer "github.com/containernetworking/cni/pkg/types/current"
+	cniVersion "github.com/containernetworking/cni/pkg/version"
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/sirupsen/logrus"
+	"github.com/vishvananda/netlink"
+)
+
+var (
+	name             = "terway-chainer"
+	log              = logging.DefaultLogger.WithField(logfields.LogSubsys, name)
+	vpcNetGatewayMac = "ee:ff:ff:ff:ff:ff"
+)
+
+// TerwayChainer is terway chain object
+type TerwayChainer struct{}
+
+// ImplementsAdd returns true if method 'add' is available
+func (f *TerwayChainer) ImplementsAdd() bool {
+	return true
+}
+
+// Add setups the ipvlan port's tc-bpf
+func (f *TerwayChainer) Add(ctx context.Context, pluginCtx chainingapi.PluginContext) (res *cniTypesVer.Result, err error) {
+	err = cniVersion.ParsePrevResult(&pluginCtx.NetConf.NetConf)
+	if err != nil {
+		err = fmt.Errorf("unable to understand network config: %s", err)
+		return
+	}
+
+	var prevRes *cniTypesVer.Result
+	prevRes, err = cniTypesVer.NewResultFromResult(pluginCtx.NetConf.PrevResult)
+	if err != nil {
+		err = fmt.Errorf("unable to get previous network result: %s", err)
+		return
+	}
+	defer func() {
+		if err != nil {
+			pluginCtx.Logger.WithError(err).
+				WithFields(logrus.Fields{"cni-pre-result": pluginCtx.NetConf.PrevResult.String()}).
+				Errorf("Unable to create endpoint")
+		}
+	}()
+
+	netNs, err := ns.GetNS(pluginCtx.Args.Netns)
+	if err != nil {
+		err = fmt.Errorf("failed to open netns %q: %s", pluginCtx.Args.Netns, err)
+		return
+	}
+	defer netNs.Close()
+
+	var (
+		ifName                    = ""
+		disabled                  = false
+		containerIP, containerMac string
+		containerIfIndex          int
+		hostMac                   = vpcNetGatewayMac
+	)
+
+	if err = netNs.Do(func(_ ns.NetNS) error {
+		links, err := netlink.LinkList()
+		if err != nil {
+			return fmt.Errorf("failed to list link %s", pluginCtx.Args.Netns)
+		}
+		for _, link := range links {
+			if link.Type() != "ipvlan" {
+				continue
+			}
+
+			ifName = link.Attrs().Name
+			containerMac = link.Attrs().HardwareAddr.String()
+
+			addrs, err := netlink.AddrList(link, netlink.FAMILY_V4)
+			if err != nil {
+				return fmt.Errorf("unable to list addresses for link %s: %s", link.Attrs().Name, err)
+			}
+			if len(addrs) < 1 {
+				return fmt.Errorf("no address configured inside container")
+			}
+
+			containerIP = addrs[0].IPNet.IP.String()
+			return nil
+		}
+
+		return fmt.Errorf("no link found inside container")
+	}); err != nil {
+		return
+	}
+
+	var (
+		mapFD, mapID int
+	)
+
+	// set bpf
+	mapFD, mapID, err = connector.SetupIpvlanInRemoteNsWithBPF(netNs, ifName, ifName, true, true)
+	if err != nil {
+		pluginCtx.Logger.WithError(err).Warn("Unable to set ipvlan ebpf")
+		return
+	}
+	defer unix.Close(mapFD)
+
+	// create endpoint
+	ep := &models.EndpointChangeRequest{
+		Addressing: &models.AddressPair{
+			IPV4: containerIP,
+		},
+		ContainerID:       pluginCtx.Args.ContainerID,
+		State:             models.EndpointStateWaitingForIdentity,
+		HostMac:           hostMac,
+		InterfaceIndex:    int64(containerIfIndex),
+		Mac:               containerMac,
+		InterfaceName:     ifName,
+		K8sPodName:        string(pluginCtx.CniArgs.K8S_POD_NAME),
+		K8sNamespace:      string(pluginCtx.CniArgs.K8S_POD_NAMESPACE),
+		SyncBuildEndpoint: true,
+		DatapathMapID:     int64(mapID),
+		DatapathConfiguration: &models.EndpointDatapathConfiguration{
+			RequireArpPassthrough: true,
+			RequireEgressProg:     true,
+			ExternalIpam:          true,
+			RequireRouting:        &disabled,
+		},
+	}
+
+	err = pluginCtx.Client.EndpointCreate(ep)
+	if err != nil {
+		pluginCtx.Logger.WithError(err).WithFields(logrus.Fields{
+			logfields.ContainerID: ep.ContainerID}).Warn("Unable to create endpoint")
+		err = fmt.Errorf("unable to create endpoint: %s", err)
+		return
+	}
+
+	pluginCtx.Logger.WithFields(logrus.Fields{
+		logfields.ContainerID: ep.ContainerID}).Debug("Endpoint successfully created")
+
+	res = prevRes
+	return
+}
+
+// ImplementsDelete return true if method 'delete' is available
+func (f *TerwayChainer) ImplementsDelete() bool {
+	return true
+}
+
+// Delete deletes cilium endpoint
+func (f *TerwayChainer) Delete(ctx context.Context, pluginCtx chainingapi.PluginContext) (err error) {
+	id := endpointid.NewID(endpointid.ContainerIdPrefix, pluginCtx.Args.ContainerID)
+	if err := pluginCtx.Client.EndpointDelete(id); err != nil {
+		log.WithError(err).Warning("Errors encountered while deleting endpoint")
+	}
+	return nil
+}
+
+func init() {
+	chainingapi.Register(name, &TerwayChainer{})
+}

--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -44,6 +44,7 @@ import (
 	_ "github.com/cilium/cilium/plugins/cilium-cni/chaining/flannel"
 	_ "github.com/cilium/cilium/plugins/cilium-cni/chaining/generic-veth"
 	_ "github.com/cilium/cilium/plugins/cilium-cni/chaining/portmap"
+	_ "github.com/cilium/cilium/plugins/cilium-cni/chaining/terway"
 	"github.com/cilium/cilium/plugins/cilium-cni/types"
 
 	"github.com/containernetworking/cni/pkg/skel"


### PR DESCRIPTION
Hi maintainers, this merge request add a new ipvlan cni chain to work with [Terway](https://github.com/AliyunContainerService/terway), a Alibaba Cloud VPC/ENI CNI. With help of cilium, we implement service network and network policy for IPVlan l2 datapath in Terway.

Terway has two different datapath modes: VPC Mode and ENI Secondary IP. In ENI Secondary IP, one eni (Elastic Network Interfaces) has multi ips. With these ips, We can create multi IPVLan l2 slave ports to support more pods. IPVlan L2 mode offers almost the same performance as the eni. But the one problem is that IPVlan cannot support the service network and network policy. 

This merge request introduces a IPVLan L2 cni chain. In the cni chain, terway creates IPVlan datapath and allocs ips from vpc, and cilium attaches bpf to slave port  to provide service network and network policy ability.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10251)
<!-- Reviewable:end -->
