### PR TITLE
v1.5 backport 2020-02-18

### DIFF
--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -20,8 +20,8 @@ $(BPF_SIMPLE): %.o: %.ll
 	$(QUIET) ${LLC} ${LLC_FLAGS} -filetype=obj -o $@ $(patsubst %.o,%.ll,$@)
 
 # Hack to get make to replace : with a space
-space :=
-space += 
+null :=
+space := ${null} ${null}
 
 # The following option combinations are compile tested
 LB_OPTIONS = \

--- a/pkg/bpf/bpf_linux.go
+++ b/pkg/bpf/bpf_linux.go
@@ -24,6 +24,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"runtime"
 	"syscall"
 	"unsafe"
 
@@ -71,6 +72,7 @@ func CreateMap(mapType int, keySize, valueSize, maxEntries, flags, innerID uint3
 		uintptr(unsafe.Pointer(&uba)),
 		unsafe.Sizeof(uba),
 	)
+	runtime.KeepAlive(&uba)
 	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
 		metrics.BPFSyscallDuration.WithLabelValues(metricOpCreate, metrics.Errno2Outcome(err)).Observe(duration.End(err == 0).Total().Seconds())
 	}
@@ -119,6 +121,9 @@ func UpdateElement(fd int, key, value unsafe.Pointer, flags uint64) error {
 		uintptr(unsafe.Pointer(&uba)),
 		unsafe.Sizeof(uba),
 	)
+	runtime.KeepAlive(&uba)
+	runtime.KeepAlive(key)
+	runtime.KeepAlive(value)
 	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
 		metrics.BPFSyscallDuration.WithLabelValues(metricOpUpdate, metrics.Errno2Outcome(err)).Observe(duration.End(err == 0).Total().Seconds())
 	}
@@ -149,6 +154,9 @@ func LookupElement(fd int, key, value unsafe.Pointer) error {
 		uintptr(unsafe.Pointer(&uba)),
 		unsafe.Sizeof(uba),
 	)
+	runtime.KeepAlive(&uba)
+	runtime.KeepAlive(key)
+	runtime.KeepAlive(value)
 	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
 		metrics.BPFSyscallDuration.WithLabelValues(metricOpLookup, metrics.Errno2Outcome(err)).Observe(duration.End(err == 0).Total().Seconds())
 	}
@@ -175,6 +183,8 @@ func deleteElement(fd int, key unsafe.Pointer) (uintptr, syscall.Errno) {
 		uintptr(unsafe.Pointer(&uba)),
 		unsafe.Sizeof(uba),
 	)
+	runtime.KeepAlive(key)
+	runtime.KeepAlive(&uba)
 	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
 		metrics.BPFSyscallDuration.WithLabelValues(metricOpDelete, metrics.Errno2Outcome(err)).Observe(duration.End(err == 0).Total().Seconds())
 	}
@@ -211,6 +221,9 @@ func GetNextKey(fd int, key, nextKey unsafe.Pointer) error {
 		uintptr(unsafe.Pointer(&uba)),
 		unsafe.Sizeof(uba),
 	)
+	runtime.KeepAlive(&uba)
+	runtime.KeepAlive(key)
+	runtime.KeepAlive(nextKey)
 	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
 		metrics.BPFSyscallDuration.WithLabelValues(metricOpGetNextKey, metrics.Errno2Outcome(err)).Observe(duration.End(err == 0).Total().Seconds())
 	}
@@ -249,6 +262,8 @@ func ObjPin(fd int, pathname string) error {
 		uintptr(unsafe.Pointer(&uba)),
 		unsafe.Sizeof(uba),
 	)
+	runtime.KeepAlive(&uba)
+	runtime.KeepAlive(&pathStr)
 	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
 		metrics.BPFSyscallDuration.WithLabelValues(metricOpObjPin, metrics.Errno2Outcome(err)).Observe(duration.End(err == 0).Total().Seconds())
 	}
@@ -278,6 +293,8 @@ func ObjGet(pathname string) (int, error) {
 		uintptr(unsafe.Pointer(&uba)),
 		unsafe.Sizeof(uba),
 	)
+	runtime.KeepAlive(&pathStr)
+	runtime.KeepAlive(&uba)
 	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
 		metrics.BPFSyscallDuration.WithLabelValues(metricOpObjGet, metrics.Errno2Outcome(err)).Observe(duration.End(err == 0).Total().Seconds())
 	}
@@ -315,6 +332,7 @@ func MapFdFromID(id int) (int, error) {
 		uintptr(unsafe.Pointer(&uba)),
 		unsafe.Sizeof(uba),
 	)
+	runtime.KeepAlive(&uba)
 	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
 		metrics.BPFSyscallDuration.WithLabelValues(metricOpGetFDByID, metrics.Errno2Outcome(err)).Observe(duration.End(err == 0).Total().Seconds())
 	}

--- a/pkg/bpf/prog_linux.go
+++ b/pkg/bpf/prog_linux.go
@@ -18,6 +18,7 @@ package bpf
 
 import (
 	"fmt"
+	"runtime"
 	"unsafe"
 
 	"github.com/cilium/cilium/pkg/metrics"
@@ -78,6 +79,7 @@ func GetProgNextID(current uint32) (uint32, error) {
 		duration = spanstat.Start()
 	}
 	ret, _, err := unix.Syscall(unix.SYS_BPF, BPF_PROG_GET_NEXT_ID, uintptr(unsafe.Pointer(&attr)), unsafe.Sizeof(attr))
+	runtime.KeepAlive(&attr)
 	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
 		metrics.BPFSyscallDuration.WithLabelValues(metricOpProgGetNextID, metrics.Errno2Outcome(err)).Observe(duration.End(err == 0).Total().Seconds())
 	}
@@ -95,6 +97,7 @@ func GetProgFDByID(id uint32) (int, error) {
 	}
 
 	fd, _, err := unix.Syscall(unix.SYS_BPF, BPF_PROG_GET_FD_BY_ID, uintptr(unsafe.Pointer(&attr)), unsafe.Sizeof(attr))
+	runtime.KeepAlive(&attr)
 	if fd < 0 || err != 0 {
 		return int(fd), fmt.Errorf("Unable to get fd for program id %d: %v", id, err)
 	}
@@ -122,6 +125,9 @@ func GetProgInfoByFD(fd int) (ProgInfo, error) {
 		duration = spanstat.Start()
 	}
 	ret, _, err := unix.Syscall(unix.SYS_BPF, BPF_OBJ_GET_INFO_BY_FD, uintptr(unsafe.Pointer(&attr)), unsafe.Sizeof(attr))
+	runtime.KeepAlive(&attr)
+	runtime.KeepAlive(&attrInfo)
+	runtime.KeepAlive(&info)
 	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
 		metrics.BPFSyscallDuration.WithLabelValues(metricOpObjGetInfoByFD, metrics.Errno2Outcome(err)).Observe(duration.End(err == 0).Total().Seconds())
 	}

--- a/pkg/endpoint/connector/ipvlan.go
+++ b/pkg/endpoint/connector/ipvlan.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"math"
 	"path/filepath"
+	"runtime"
 	"unsafe"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -68,6 +69,9 @@ func loadEntryProg(mapFd int) (int, error) {
 	fd, _, errno := unix.Syscall(unix.SYS_BPF, 5, /* BPF_PROG_LOAD */
 		uintptr(unsafe.Pointer(&bpfAttr)),
 		unsafe.Sizeof(bpfAttr))
+	runtime.KeepAlive(&insns)
+	runtime.KeepAlive(&license)
+	runtime.KeepAlive(&bpfAttr)
 	if errno != 0 {
 		return 0, errno
 	}
@@ -108,6 +112,7 @@ func createTailCallMap() (int, int, error) {
 	fd, _, errno := unix.Syscall(unix.SYS_BPF, 0, /* BPF_MAP_CREATE */
 		uintptr(unsafe.Pointer(&bpfAttr)),
 		unsafe.Sizeof(bpfAttr))
+	runtime.KeepAlive(&bpfAttr)
 	if int(fd) < 0 || errno != 0 {
 		return 0, 0, errno
 	}
@@ -126,6 +131,8 @@ func createTailCallMap() (int, int, error) {
 	ret, _, errno := unix.Syscall(unix.SYS_BPF, 15, /* BPF_OBJ_GET_INFO_BY_FD */
 		uintptr(unsafe.Pointer(&bpfAttr2)),
 		unsafe.Sizeof(bpfAttr2))
+	runtime.KeepAlive(&info)
+	runtime.KeepAlive(&bpfAttr2)
 	if ret != 0 || errno != 0 {
 		unix.Close(int(fd))
 		return 0, 0, errno


### PR DESCRIPTION
PRs:
#10168 "pkg/bpf: Protect each uintptr with runtime.KeepAlive"
#10173 "bpf: Fix space hack in Makefile "

PR #10168 does not apply so wrote more or less by hand.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10252)
<!-- Reviewable:end -->
