### PR TITLE
v1.7 backports 2020-02-19

### DIFF
--- a/cilium/cmd/bpf_ct_flush.go
+++ b/cilium/cmd/bpf_ct_flush.go
@@ -62,12 +62,15 @@ func flushCt(eID string) {
 			err = m.Open()
 		}
 		if err != nil {
-			if err == os.ErrNotExist {
-				Fatalf("Unable to open %s: %s: please try using \"cilium bpf ct flush global\"", path, err)
-			} else {
-				Fatalf("Unable to open %s: %s", path, err)
+			if os.IsNotExist(err) {
+				msg := "Unable to open %s: %s."
+				if eID != "global" {
+					msg = "Unable to open %s: %s: please try using \"cilium bpf ct flush global\"."
+				}
+				fmt.Fprintf(os.Stderr, msg+" Skipping.\n", path, err)
+				continue
 			}
-			continue
+			Fatalf("Unable to open %s: %s", path, err)
 		}
 		defer m.Close()
 		entries := m.Flush()

--- a/cilium/cmd/bpf_ct_list.go
+++ b/cilium/cmd/bpf_ct_list.go
@@ -58,11 +58,15 @@ func dumpCt(eID string) {
 			err = m.Open()
 		}
 		if err != nil {
-			if err == os.ErrNotExist {
-				Fatalf("Unable to open %s: %s: please try using \"cilium bpf ct list global\"", path, err)
-			} else {
-				Fatalf("Unable to open %s: %s", path, err)
+			if os.IsNotExist(err) {
+				msg := "Unable to open %s: %s."
+				if eID != "global" {
+					msg = "Unable to open %s: %s: please try using \"cilium bpf ct list global\"."
+				}
+				fmt.Fprintf(os.Stderr, msg+" Skipping.\n", path, err)
+				continue
 			}
+			Fatalf("Unable to open %s: %s", path, err)
 		}
 		defer m.Close()
 		if command.OutputJSON() {

--- a/cilium/cmd/bpf_nat_flush.go
+++ b/cilium/cmd/bpf_nat_flush.go
@@ -50,8 +50,11 @@ func flushNat() {
 			err = m.Open()
 		}
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Unable to open %s: %s", path, err)
-			continue
+			if os.IsNotExist(err) {
+				fmt.Fprintf(os.Stderr, "Unable to open %s: %s. Skipping.\n", path, err)
+				continue
+			}
+			Fatalf("Unable to open %s: %s", path, err)
 		}
 		defer m.Close()
 		entries := m.Flush()

--- a/cilium/cmd/bpf_nat_list.go
+++ b/cilium/cmd/bpf_nat_list.go
@@ -53,11 +53,11 @@ func dumpNat() {
 			err = m.Open()
 		}
 		if err != nil {
-			if err == os.ErrNotExist {
-				fmt.Fprintf(os.Stderr, "Unable to open %s: %s: please try using \"cilium bpf nat list\"", path, err)
-			} else {
-				Fatalf("Unable to open %s: %s", path, err)
+			if os.IsNotExist(err) {
+				fmt.Fprintf(os.Stderr, "Unable to open %s: %s. Skipping.\n", path, err)
+				continue
 			}
+			Fatalf("Unable to open %s: %s", path, err)
 		}
 		defer m.Close()
 		if command.OutputJSON() {

--- a/pkg/maps/eppolicymap/eppolicymap.go
+++ b/pkg/maps/eppolicymap/eppolicymap.go
@@ -61,11 +61,13 @@ var (
 // for testing purposes.
 func CreateWithName(mapName string) error {
 	buildMap.Do(func() {
+		mapType := bpf.MapType(bpf.BPF_MAP_TYPE_HASH)
 		fd, err := bpf.CreateMap(bpf.BPF_MAP_TYPE_HASH,
 			uint32(unsafe.Sizeof(policymap.PolicyKey{})),
 			uint32(unsafe.Sizeof(policymap.PolicyEntry{})),
 			uint32(policymap.MaxEntries),
-			0, 0, innerMapName)
+			bpf.GetPreAllocateMapFlags(mapType),
+			0, innerMapName)
 
 		if err != nil {
 			log.WithError(err).Warning("unable to create EP to policy map")

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -80,12 +80,13 @@ func (svc *svcInfo) deepCopyToLBSVC() *lb.SVC {
 		backends[i] = *backend.DeepCopy()
 	}
 	return &lb.SVC{
-		Frontend:      *svc.frontend.DeepCopy(),
-		Backends:      backends,
-		Type:          svc.svcType,
-		TrafficPolicy: svc.svcTrafficPolicy,
-		Name:          svc.svcName,
-		Namespace:     svc.svcNamespace,
+		Frontend:            *svc.frontend.DeepCopy(),
+		Backends:            backends,
+		Type:                svc.svcType,
+		TrafficPolicy:       svc.svcTrafficPolicy,
+		HealthCheckNodePort: svc.svcHealthCheckNodePort,
+		Name:                svc.svcName,
+		Namespace:           svc.svcNamespace,
 	}
 }
 


### PR DESCRIPTION
v1.7 backports 2020-02-19

 * #10193 -- cli: Do not panic if BPF map does not exist (@brb)
 * #10201 -- policy: fix innermap's flag error in eppolicymap (@zhiyuan0x)
 * #10240 -- service: Fix HealthCheckNodePort not displayed in API (@gandro)

```upstream-prs
$ for pr in 10193 10201 10240 ; do contrib/backporting/set-labels.py $pr done 1.7; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10254)
<!-- Reviewable:end -->
