### PR TITLE
daemon: remove deprecated --enable-legacy-services option

### DIFF
--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -325,7 +325,13 @@ Deprecated options
 
 * ``keep-bpf-templates``: This option no longer has any effect due to the BPF
   assets not being compiled into the cilium-agent binary anymore. The option is
-  deprecated and will be removed in v1.9.
+  deprecated and will be removed in Cilium 1.9.
+
+Removed options
+~~~~~~~~~~~~~~~
+
+* ``enable-legacy-services``: This option was deprecated in Cilium 1.6 and is
+  now removed.
 
 .. _1.7_upgrade_notes:
 

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -328,10 +328,6 @@ func init() {
 	flags.StringSlice(option.HostReachableServicesProtos, []string{option.HostServicesTCP, option.HostServicesUDP}, "Only enable reachability of services for host applications for specific protocols")
 	option.BindEnv(option.HostReachableServicesProtos)
 
-	flags.Bool(option.DeprecatedEnableLegacyServices, false, "Enable legacy (prior-v1.5) services")
-	flags.MarkDeprecated(option.DeprecatedEnableLegacyServices, "this option is deprecated as of v1.6")
-	option.BindEnv(option.DeprecatedEnableLegacyServices)
-
 	flags.Bool(option.EnableAutoDirectRoutingName, defaults.EnableAutoDirectRouting, "Enable automatic L2 routing between nodes")
 	option.BindEnv(option.EnableAutoDirectRoutingName)
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -638,9 +638,6 @@ const (
 	// subject to egress masquerading
 	EgressMasqueradeInterfaces = "egress-masquerade-interfaces"
 
-	// DeprecatedEnableLegacyServices enables the legacy services
-	DeprecatedEnableLegacyServices = "enable-legacy-services"
-
 	// PolicyTriggerInterval is the amount of time between triggers of policy
 	// updates are invoked.
 	PolicyTriggerInterval = "policy-trigger-interval"


### PR DESCRIPTION
The option was announced to be deprecated in Cilium 1.6 with commit
6eb4d1d89e6a ("daemon: Deprecate `enable-legacy-services` option"). It
no longer had any effect, so remove it now.

```release-note
The deprecared `--enable-legacy-service` option was removed.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10255)
<!-- Reviewable:end -->
