### PR TITLE
GKE CI: Fix K8sDatapathConfig* tests

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -147,6 +147,16 @@ var (
 	}
 )
 
+// HelmOverride returns the value of a Helm override option for the currently
+// enabled CNI_INTEGRATION
+func HelmOverride(option string) string {
+	integration := strings.ToLower(os.Getenv("CNI_INTEGRATION"))
+	if overrides, exists := helmOverrides[integration]; exists {
+		return overrides[option]
+	}
+	return ""
+}
+
 func init() {
 	// Copy over envronment variables that are passed in.
 	for envVar, helmVar := range map[string]string{

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -272,21 +272,22 @@ var _ = Describe("K8sDatapathConfig", func() {
 	})
 
 	Context("DirectRouting", func() {
+		BeforeEach(func() {
+			SkipIfIntegration(helpers.CIIntegrationFlannel)
+			SkipIfIntegration(helpers.CIIntegrationGKE)
+		})
+
 		directRoutingOptions := map[string]string{
 			"global.tunnel":               "disabled",
 			"global.autoDirectNodeRoutes": "true",
 		}
 
 		It("Check connectivity with automatic direct nodes routes", func() {
-			SkipIfIntegration(helpers.CIIntegrationFlannel)
-
 			deployCilium(directRoutingOptions)
 			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
 		})
 
 		It("Check direct connectivity with per endpoint routes", func() {
-			SkipIfIntegration(helpers.CIIntegrationFlannel)
-
 			directRoutingOptions["global.endpointRoutes.enabled"] = "true"
 			directRoutingOptions["global.ipv6.enabled"] = "false"
 			deployCilium(directRoutingOptions)
@@ -319,6 +320,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 		BeforeEach(func() {
 			SkipIfBenchmark()
+			SkipIfIntegration(helpers.CIIntegrationGKE)
 		})
 
 		AfterEach(func() {
@@ -389,6 +391,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 	Context("Transparent encryption DirectRouting", func() {
 		It("Check connectivity with transparent encryption and direct routing", func() {
 			SkipIfIntegration(helpers.CIIntegrationFlannel)
+			SkipIfIntegration(helpers.CIIntegrationGKE)
 			SkipItIfNoKubeProxy()
 
 			privateIface, err := kubectl.GetPrivateIface()

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -253,6 +253,9 @@ var _ = Describe("K8sDatapathConfig", func() {
 		}, 600)
 
 		It("Check connectivity with Geneve encapsulation", func() {
+			// Geneve is currently not supported on GKE
+			SkipIfIntegration(helpers.CIIntegrationGKE)
+
 			deployCilium(map[string]string{
 				"global.tunnel": "geneve",
 			})


### PR DESCRIPTION
* IPv6 is not enabled on GKE for now so some test expectations need to be adjusted
* autoDirectNodeRoutes is not compatible so tests must be disabled

Fixes: #10030
Fixes: #10026

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10259)
<!-- Reviewable:end -->
