### PR TITLE
daemon: Check nodePortMax < ephemeralPortMin in agent

### DIFF
--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -456,8 +456,8 @@ case "${MODE}" in
 		CILIUM_IDX=$(cat /sys/class/net/${HOST_DEV1}/ifindex)
 		echo "#define CILIUM_IFINDEX $CILIUM_IDX" >> $RUNDIR/globals/node_config.h
 
-		CILIUM_EPHERMERAL_MIN=$(cat /proc/sys/net/ipv4/ip_local_port_range | awk '{print $1}')
-		echo "#define EPHERMERAL_MIN $CILIUM_EPHERMERAL_MIN" >> $RUNDIR/globals/node_config.h
+		CILIUM_EPHEMERAL_MIN=$(cat /proc/sys/net/ipv4/ip_local_port_range | awk '{print $1}')
+		echo "#define EPHEMERAL_MIN $CILIUM_EPHEMERAL_MIN" >> $RUNDIR/globals/node_config.h
 
 		if [ "$NODE_PORT" = "true" ]; then
 			sed -i '/^#.*NATIVE_DEV_IFINDEX.*$/d' $RUNDIR/globals/node_config.h

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -520,7 +520,7 @@ enum {
 #ifdef ENABLE_NODEPORT
 #define NAT_MIN_EGRESS		NODEPORT_PORT_MIN_NAT
 #else
-#define NAT_MIN_EGRESS		EPHERMERAL_MIN
+#define NAT_MIN_EGRESS		EPHEMERAL_MIN
 #endif
 
 enum {

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1268,7 +1268,7 @@ static __always_inline int nodeport_nat_rev(struct __sk_buff *skb,
 		build_bug_on(!(NODEPORT_PORT_MIN_NAT < NODEPORT_PORT_MAX_NAT));
 		build_bug_on(!(NODEPORT_PORT_MIN     < NODEPORT_PORT_MAX));
 		build_bug_on(!(NODEPORT_PORT_MAX     < NODEPORT_PORT_MIN_NAT));
-		build_bug_on(!(NODEPORT_PORT_MAX     < EPHERMERAL_MIN));
+		build_bug_on(!(NODEPORT_PORT_MAX     < EPHEMERAL_MIN));
 		break;
 	}
 	return TC_ACT_OK;

--- a/bpf/node_config.h
+++ b/bpf/node_config.h
@@ -122,7 +122,7 @@ DEFINE_IPV6(SNAT_IPV6_EXTERNAL, 0xbe, 0xef, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0
 #define MONITOR_AGGREGATION 5
 #define MTU 1500
 #define ENABLE_IPSEC
-#define EPHERMERAL_MIN 32768
+#define EPHEMERAL_MIN 32768
 #ifdef ENABLE_MASQUERADE
 #define CT_MAP_TCP6 test_cilium_ct_tcp6_65535
 #define CT_MAP_ANY6 test_cilium_ct_any6_65535

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -23,6 +23,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -58,6 +59,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/pprof"
 	"github.com/cilium/cilium/pkg/probe"
+	"github.com/cilium/cilium/pkg/sysctl"
 	"github.com/cilium/cilium/pkg/version"
 
 	"github.com/go-openapi/loads"
@@ -1499,6 +1501,16 @@ func initKubeProxyReplacementOptions() {
 				option.Config.EnableExternalIPs = false
 			}
 		}
+
+		if err := checkNodePortAndEphemeralPortRanges(); err != nil {
+			if strict {
+				log.Fatal(err)
+			} else {
+				log.Warn(fmt.Sprintf("%s Disabling the feature.", err))
+				option.Config.EnableNodePort = false
+				option.Config.EnableExternalIPs = false
+			}
+		}
 	}
 
 	if option.Config.EnableNodePort && option.Config.Device == "undefined" {
@@ -1557,4 +1569,26 @@ func initKubeProxyReplacementOptions() {
 	if !option.Config.EnableNodePort {
 		option.Config.EnableExternalIPs = false
 	}
+}
+
+func checkNodePortAndEphemeralPortRanges() error {
+	val, err := sysctl.Read("net.ipv4.ip_local_port_range")
+	if err != nil {
+		return fmt.Errorf("Unable to read net.ipv4.ip_local_port_range")
+	}
+	ephemeralPortRange := strings.Split(val, "\t")
+	if len(ephemeralPortRange) != 2 {
+		return fmt.Errorf("Invalid ephemeral port range: %s", val)
+	}
+	ephemeralPortMin, err := strconv.Atoi(ephemeralPortRange[0])
+	if err != nil {
+		return fmt.Errorf("Unable to parse min port value %s for ephemeral range", ephemeralPortRange[0])
+	}
+	if !(option.Config.NodePortMax < ephemeralPortMin) {
+		msg := `NodePort range (%d-%d) max port must be smaller than ephemeral range (%s-%s) min port. ` +
+			`Adjust ephemeral range port with "sysctl -w net.ipv4.ip_local_port_range='MIN MAX'".`
+		return fmt.Errorf(msg, option.Config.NodePortMin, option.Config.NodePortMax,
+			ephemeralPortRange[0], ephemeralPortRange[1])
+	}
+	return nil
 }

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/sysctl"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
@@ -1830,7 +1831,7 @@ func (c *DaemonConfig) Populate() {
 
 	err = c.populateNodePortRange()
 	if err != nil {
-		log.WithError(err).Fatal("NodePortRange can not be parsed.")
+		log.WithError(err).Fatal("Failed to populate NodePortRange")
 	}
 
 	hostServicesProtos := viper.GetStringSlice(HostReachableServicesProtos)
@@ -1960,12 +1961,30 @@ func (c *DaemonConfig) populateNodePortRange() error {
 			return fmt.Errorf("Unable to parse max port value for NodePort range: %s", err.Error())
 		}
 		if c.NodePortMax <= c.NodePortMin {
-			return errors.New("NodePort range min port must be smaller than max port!")
+			return errors.New("NodePort range min port must be smaller than max port")
 		}
 	case 0:
 		log.Warning("NodePort range was set but is empty.")
 	default:
-		return errors.New("Unable to parse min/max port value for NodePort range!")
+		return fmt.Errorf("Unable to parse min/max port value for NodePort range: %s", NodePortRange)
+	}
+
+	val, err := sysctl.Read("net.ipv4.ip_local_port_range")
+	if err != nil {
+		return fmt.Errorf("Unable to read net.ipv4.ip_local_port_range")
+	}
+	ephermeralPortRange := strings.Split(val, "\t")
+	if len(ephermeralPortRange) != 2 {
+		return fmt.Errorf("Invalid ephermeral port range: %s", val)
+	}
+	ephermeralPortMin, err := strconv.Atoi(ephermeralPortRange[0])
+	if err != nil {
+		return fmt.Errorf("Unable to parse min port value %s for ephermeral range", ephermeralPortRange[0])
+	}
+	if !(c.NodePortMax < ephermeralPortMin) {
+		msg := `NodePort range (%s-%s) max port must be smaller than ephermeral range (%s-%s) min port. ` +
+			`Adjust ephermeral range port with "sysctl -w net.ipv4.ip_local_port_range='MIN MAX'".`
+		return fmt.Errorf(msg, nodePortRange[0], nodePortRange[1], ephermeralPortRange[0], ephermeralPortRange[1])
 	}
 
 	return nil

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -37,7 +37,6 @@ import (
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
-	"github.com/cilium/cilium/pkg/sysctl"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
@@ -1967,24 +1966,6 @@ func (c *DaemonConfig) populateNodePortRange() error {
 		log.Warning("NodePort range was set but is empty.")
 	default:
 		return fmt.Errorf("Unable to parse min/max port value for NodePort range: %s", NodePortRange)
-	}
-
-	val, err := sysctl.Read("net.ipv4.ip_local_port_range")
-	if err != nil {
-		return fmt.Errorf("Unable to read net.ipv4.ip_local_port_range")
-	}
-	ephemeralPortRange := strings.Split(val, "\t")
-	if len(ephemeralPortRange) != 2 {
-		return fmt.Errorf("Invalid ephemeral port range: %s", val)
-	}
-	ephemeralPortMin, err := strconv.Atoi(ephemeralPortRange[0])
-	if err != nil {
-		return fmt.Errorf("Unable to parse min port value %s for ephemeral range", ephemeralPortRange[0])
-	}
-	if !(c.NodePortMax < ephemeralPortMin) {
-		msg := `NodePort range (%s-%s) max port must be smaller than ephemeral range (%s-%s) min port. ` +
-			`Adjust ephemeral range port with "sysctl -w net.ipv4.ip_local_port_range='MIN MAX'".`
-		return fmt.Errorf(msg, nodePortRange[0], nodePortRange[1], ephemeralPortRange[0], ephemeralPortRange[1])
 	}
 
 	return nil

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1973,18 +1973,18 @@ func (c *DaemonConfig) populateNodePortRange() error {
 	if err != nil {
 		return fmt.Errorf("Unable to read net.ipv4.ip_local_port_range")
 	}
-	ephermeralPortRange := strings.Split(val, "\t")
-	if len(ephermeralPortRange) != 2 {
-		return fmt.Errorf("Invalid ephermeral port range: %s", val)
+	ephemeralPortRange := strings.Split(val, "\t")
+	if len(ephemeralPortRange) != 2 {
+		return fmt.Errorf("Invalid ephemeral port range: %s", val)
 	}
-	ephermeralPortMin, err := strconv.Atoi(ephermeralPortRange[0])
+	ephemeralPortMin, err := strconv.Atoi(ephemeralPortRange[0])
 	if err != nil {
-		return fmt.Errorf("Unable to parse min port value %s for ephermeral range", ephermeralPortRange[0])
+		return fmt.Errorf("Unable to parse min port value %s for ephemeral range", ephemeralPortRange[0])
 	}
-	if !(c.NodePortMax < ephermeralPortMin) {
-		msg := `NodePort range (%s-%s) max port must be smaller than ephermeral range (%s-%s) min port. ` +
-			`Adjust ephermeral range port with "sysctl -w net.ipv4.ip_local_port_range='MIN MAX'".`
-		return fmt.Errorf(msg, nodePortRange[0], nodePortRange[1], ephermeralPortRange[0], ephermeralPortRange[1])
+	if !(c.NodePortMax < ephemeralPortMin) {
+		msg := `NodePort range (%s-%s) max port must be smaller than ephemeral range (%s-%s) min port. ` +
+			`Adjust ephemeral range port with "sysctl -w net.ipv4.ip_local_port_range='MIN MAX'".`
+		return fmt.Errorf(msg, nodePortRange[0], nodePortRange[1], ephemeralPortRange[0], ephemeralPortRange[1])
 	}
 
 	return nil

--- a/pkg/sysctl/sysctl.go
+++ b/pkg/sysctl/sysctl.go
@@ -17,6 +17,7 @@ package sysctl
 import (
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -58,4 +59,15 @@ func Enable(name string) error {
 // Write writes the given sysctl parameter.
 func Write(name string, val string) error {
 	return writeSysctl(name, val)
+}
+
+// Read reads the given sysctl parameter.
+func Read(name string) (string, error) {
+	fPath := fullPath(name)
+	val, err := ioutil.ReadFile(fPath)
+	if err != nil {
+		return "", fmt.Errorf("Failed to read %s: %s", fPath, val)
+	}
+
+	return strings.TrimRight(string(val), "\n"), nil
 }

--- a/pkg/sysctl/sysctl_linux_privileged_test.go
+++ b/pkg/sysctl/sysctl_linux_privileged_test.go
@@ -99,12 +99,20 @@ func (s *SysctlLinuxPrivilegedTestSuite) TestDisableEnable(c *C) {
 			c.Assert(err, NotNil)
 		} else {
 			c.Assert(err, IsNil)
+
+			val, err := Read(tc.name)
+			c.Assert(err, IsNil)
+			c.Assert(val, Equals, "1")
 		}
 		err = Disable(tc.name)
 		if tc.expectedErr {
 			c.Assert(err, NotNil)
 		} else {
 			c.Assert(err, IsNil)
+
+			val, err := Read(tc.name)
+			c.Assert(err, IsNil)
+			c.Assert(val, Equals, "0")
 		}
 	}
 }


### PR DESCRIPTION
Previously, if the ephermeral range min port was not greater than the nodeport range max port, the compilation of bpf_netdev was failing with a cryptic message:

        level=warning msg="In file included from /var/lib/cilium/bpf/bpf_overlay.c:39:" subsys=daemon
        level=warning msg="/var/lib/cilium/bpf/lib/nodeport.h:898:3: error: array size is negative" subsys=daemon
        level=warning msg="                build_bug_on(!(NODEPORT_PORT_MAX < EPHERMERAL_MIN));" subsys=daemon
        level=warning msg="
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~" subsys=daemon
        level=warning msg="/var/lib/cilium/bpf/lib/utils.h:124:45: note: expanded from macro 'build_bug_on'" subsys=daemon
        level=warning msg="# define build_bug_on(e) ((void)sizeof(char[1 - 2*!!(e)]))" subsys=daemon
        level=warning msg=" ^~~~~~~~~~~" subsys=daemon
        level=warning msg="3 warnings and 1 error generated." subsys=daemon

Fix this by checking the constraint in the agent, and log a helpful message how to fix it. E.g.:

    level=fatal msg="Failed to populate NodePortRange." error="NodePort range (30000-32768) max port must be smaller than ephemeral range (32768-60999) min port. Adjust ephemeral range port with \"sysctl -w net.ipv4.ip_local_port_range='MIN MAX'\"" subsys=config

Also, when running in the non-strict mode (`kubeProxyReplacement=probe`), we should not panic if the constraint is not met, and just disable the feature.

Keeping the `build_bug_on(!(NODEPORT_PORT_MAX < EPHERMERAL_MIN))` check in the datapath code, as it helps readers to understand the NodePort/SNAT code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10260)
<!-- Reviewable:end -->
