### PR TITLE
cilium: encryption, segfaults if existing non-Cilium xfrm policy without mark set exists

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -364,6 +364,9 @@ func DeleteIPsecEndpoint(remote *net.IPNet) {
 }
 
 func isXfrmPolicyCilium(policy netlink.XfrmPolicy) bool {
+	if policy.Mark == nil {
+		return false
+	}
 	if policy.Mark.Mask != linux_defaults.RouteMarkMask {
 		return false
 	}
@@ -375,6 +378,9 @@ func isXfrmPolicyCilium(policy netlink.XfrmPolicy) bool {
 }
 
 func isXfrmStateCilium(state netlink.XfrmState) bool {
+	if state.Mark == nil {
+		return false
+	}
 	if state.Mark.Mask != linux_defaults.RouteMarkMask {
 		return false
 	}


### PR DESCRIPTION
If an existing encryption (ipsec) is in place and that policy does not
have a mark field in the netlink message set then the policy list API
will have a nil mark pointer.

However, we immediately dereference that pointer to check if its a
Cilium installed policy without checking for nil first. The result
is the following segfault.

[signal SIGSEGV: segmentation violation code=0x1 addr=0x4 pc=0x1c853df]
goroutine 1 [running]:
github.com/cilium/cilium/pkg/datapath/linux/ipsec.isXfrmPolicyCilium(...)
        /go/src/github.com/cilium/cilium/pkg/datapath/linux/ipsec/ipsec_linux.go:367
github.com/cilium/cilium/pkg/datapath/linux/ipsec.DeleteXfrm()
        /go/src/github.com/cilium/cilium/pkg/datapath/linux/ipsec/ipsec_linux.go:393 +0x10f
github.com/cilium/cilium/pkg/datapath/linux.(*linuxNodeHandler).NodeConfigur

Add nil pointer checks here to resolve this.

Signed-off-by: John Fastabend <john.fastabend@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10268)
<!-- Reviewable:end -->
