### PR TITLE
contrib/vagrant: Fix warning when K8S is unset

### DIFF
--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -601,7 +601,7 @@ elif [ -n "${PROVISION}" ]; then
     vagrant provision
 else
     vagrant up
-    if [ "$?" -eq "0" -a "${K8S}" -eq "1" ]; then
+    if [ "$?" -eq "0" -a -n "${K8S}" ]; then
         vagrant ssh k8s1 -- cat /home/vagrant/.kube/config | sed 's;server:.*:6443;server: https://k8s1:7443;g' > vagrant.kubeconfig
         echo "Add '127.0.0.1 k8s1' to your /etc/hosts to use vagrant.kubeconfig file for kubectl"
     fi


### PR DESCRIPTION
Pull request #10049 changed the way `K8S` is checked at the end of the `start.sh` script to try and enable the `K8S=0` syntax to disable the Kubernetes build.  This change results in the following warning when `K8S` is unset:
```
./contrib/vagrant/start.sh: line 607: [: : integer expression expected
```
This commit reverts that specific change.  `K8S` should be `1` or unset to enable or disable the Kubernetes build respectively.

/cc @tklauser @Rolinh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10280)
<!-- Reviewable:end -->
