### PR TITLE
iptables: de-duplicate code for forward chain rules

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -695,6 +695,60 @@ func getDeliveryInterface(ifName string) string {
 	return deliveryInterface
 }
 
+func (m *IptablesManager) installForwardChainRules(localDeliveryInterface, forwardChain string) error {
+	transient := ""
+	if forwardChain == ciliumTransientForwardChain {
+		transient = " (transient)"
+	}
+
+	// While kube-proxy does change the policy of the iptables FORWARD chain
+	// it doesn't seem to handle all cases, e.g. host network pods that use
+	// the node IP which would still end up in default DENY. Similarly, for
+	// plain Docker setup, we would otherwise hit default DENY in FORWARD chain.
+	// Also, k8s 1.15 introduced "-m conntrack --ctstate INVALID -j DROP" which
+	// in the direct routing case can drop EP replies.
+	//
+	// Therefore, add three rules below to avoid having a user to manually opt-in.
+	// See also: https://github.com/kubernetes/kubernetes/issues/39823
+	// In here can only be basic ACCEPT rules, nothing more complicated.
+	//
+	// The second rule is for the case of nodeport traffic where the backend is
+	// remote. The traffic flow in FORWARD is as follows:
+	//
+	//  - Node serving nodeport request:
+	//      IN=eno1 OUT=cilium_host
+	//      IN=cilium_host OUT=eno1
+	//
+	//  - Node running backend:
+	//       IN=eno1 OUT=cilium_host
+	//       IN=lxc... OUT=eno1
+	if err := runProg("iptables", append(
+		m.waitArgs,
+		"-A", forwardChain,
+		"-o", localDeliveryInterface,
+		"-m", "comment", "--comment", "cilium"+transient+": any->cluster on "+localDeliveryInterface+" forward accept",
+		"-j", "ACCEPT"), false); err != nil {
+		return err
+	}
+	if err := runProg("iptables", append(
+		m.waitArgs,
+		"-A", forwardChain,
+		"-i", localDeliveryInterface,
+		"-m", "comment", "--comment", "cilium"+transient+": cluster->any on "+localDeliveryInterface+" forward accept (nodeport)",
+		"-j", "ACCEPT"), false); err != nil {
+		return err
+	}
+	if err := runProg("iptables", append(
+		m.waitArgs,
+		"-A", forwardChain,
+		"-i", "lxc+",
+		"-m", "comment", "--comment", "cilium"+transient+": cluster->any on lxc+ forward accept",
+		"-j", "ACCEPT"), false); err != nil {
+		return err
+	}
+	return nil
+}
+
 // TransientRulesStart installs iptables rules for Cilium that need to be
 // kept in-tact during agent restart which removes/installs its main rules.
 // Transient rules are then removed once iptables rule update cycle has
@@ -708,50 +762,8 @@ func (m *IptablesManager) TransientRulesStart(ifName string) error {
 		if err := transientChain.add(m.waitArgs); err != nil {
 			return fmt.Errorf("cannot add custom chain %s: %s", transientChain.name, err)
 		}
-		// While kube-proxy does change the policy of the iptables FORWARD chain
-		// it doesn't seem to handle all cases, e.g. host network pods that use
-		// the node IP which would still end up in default DENY. Similarly, for
-		// plain Docker setup, we would otherwise hit default DENY in FORWARD chain.
-		// Also, k8s 1.15 introduced "-m conntrack --ctstate INVALID -j DROP" which
-		// in the direct routing case can drop EP replies.
-		//
-		// Therefore, add three rules below to avoid having a user to manually opt-in.
-		// See also: https://github.com/kubernetes/kubernetes/issues/39823
-		// In here can only be basic ACCEPT rules, nothing more complicated.
-		//
-		// The second rule is for the case of nodeport traffic where the backend is
-		// remote. The traffic flow in FORWARD is as follows:
-		//
-		//  - Node serving nodeport request:
-		//      IN=eno1 OUT=cilium_host
-		//      IN=cilium_host OUT=eno1
-		//
-		//  - Node running backend:
-		//       IN=eno1 OUT=cilium_host
-		//       IN=lxc... OUT=eno1
-		if err := runProg("iptables", append(
-			m.waitArgs,
-			"-A", ciliumTransientForwardChain,
-			"-o", localDeliveryInterface,
-			"-m", "comment", "--comment", "cilium (transient): any->cluster on "+localDeliveryInterface+" forward accept",
-			"-j", "ACCEPT"), false); err != nil {
-			return err
-		}
-		if err := runProg("iptables", append(
-			m.waitArgs,
-			"-A", ciliumTransientForwardChain,
-			"-i", localDeliveryInterface,
-			"-m", "comment", "--comment", "cilium (transient): cluster->any on "+localDeliveryInterface+" forward accept (nodeport)",
-			"-j", "ACCEPT"), false); err != nil {
-			return err
-		}
-		if err := runProg("iptables", append(
-			m.waitArgs,
-			"-A", ciliumTransientForwardChain,
-			"-i", "lxc+",
-			"-m", "comment", "--comment", "cilium (transient): cluster->any on lxc+ forward accept",
-			"-j", "ACCEPT"), false); err != nil {
-			return err
+		if err := m.installForwardChainRules(localDeliveryInterface, transientChain.name); err != nil {
+			return fmt.Errorf("cannot install forward chain rules to %s: %s", transientChain.name, err)
 		}
 		if err := transientChain.installFeeder(m.waitArgs); err != nil {
 			return fmt.Errorf("cannot install feeder rule %s: %s", transientChain.feederArgs, err)
@@ -773,7 +785,6 @@ func (m *IptablesManager) TransientRulesEnd(quiet bool) {
 func (m *IptablesManager) InstallRules(ifName string) error {
 	matchFromIPSecEncrypt := fmt.Sprintf("%#08x/%#08x", linux_defaults.RouteMarkDecrypt, linux_defaults.RouteMarkMask)
 	matchFromIPSecDecrypt := fmt.Sprintf("%#08x/%#08x", linux_defaults.RouteMarkEncrypt, linux_defaults.RouteMarkMask)
-	localDeliveryInterface := getDeliveryInterface(ifName)
 
 	for _, c := range ciliumChains {
 		if err := c.add(m.waitArgs); err != nil {
@@ -789,31 +800,11 @@ func (m *IptablesManager) InstallRules(ifName string) error {
 		return err
 	}
 
+	localDeliveryInterface := getDeliveryInterface(ifName)
+
 	if option.Config.EnableIPv4 {
-		// See kube-proxy comment in TransientRules().
-		if err := runProg("iptables", append(
-			m.waitArgs,
-			"-A", ciliumForwardChain,
-			"-o", localDeliveryInterface,
-			"-m", "comment", "--comment", "cilium: any->cluster on "+localDeliveryInterface+" forward accept",
-			"-j", "ACCEPT"), false); err != nil {
-			return err
-		}
-		if err := runProg("iptables", append(
-			m.waitArgs,
-			"-A", ciliumForwardChain,
-			"-i", localDeliveryInterface,
-			"-m", "comment", "--comment", "cilium: cluster->any on "+localDeliveryInterface+" forward accept (nodeport)",
-			"-j", "ACCEPT"), false); err != nil {
-			return err
-		}
-		if err := runProg("iptables", append(
-			m.waitArgs,
-			"-A", ciliumForwardChain,
-			"-i", "lxc+",
-			"-m", "comment", "--comment", "cilium: cluster->any on lxc+ forward accept",
-			"-j", "ACCEPT"), false); err != nil {
-			return err
+		if err := m.installForwardChainRules(localDeliveryInterface, ciliumForwardChain); err != nil {
+			return fmt.Errorf("cannot install forward chain rules to %s: %s", transientChain.name, err)
 		}
 
 		// Mark all packets sourced from processes running on the host with a

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -968,21 +968,15 @@ func (m *IptablesManager) ciliumNoTrackXfrmRules(prog, input string) error {
 	matchFromIPSecEncrypt := fmt.Sprintf("%#08x/%#08x", linux_defaults.RouteMarkDecrypt, linux_defaults.RouteMarkMask)
 	matchFromIPSecDecrypt := fmt.Sprintf("%#08x/%#08x", linux_defaults.RouteMarkEncrypt, linux_defaults.RouteMarkMask)
 
-	if err := runProg(prog, append(
-		m.waitArgs,
-		"-t", "raw", input, ciliumPreRawChain,
-		"-m", "mark", "--mark", matchFromIPSecDecrypt,
-		"-m", "comment", "--comment", xfrmDescription,
-		"-j", "NOTRACK"), false); err != nil {
-		return err
-	}
-	if err := runProg(prog, append(
-		m.waitArgs,
-		"-t", "raw", input, ciliumPreRawChain,
-		"-m", "mark", "--mark", matchFromIPSecEncrypt,
-		"-m", "comment", "--comment", xfrmDescription,
-		"-j", "NOTRACK"), false); err != nil {
-		return err
+	for _, match := range []string{matchFromIPSecDecrypt, matchFromIPSecEncrypt} {
+		if err := runProg(prog, append(
+			m.waitArgs,
+			"-t", "raw", input, ciliumPreRawChain,
+			"-m", "mark", "--mark", match,
+			"-m", "comment", "--comment", xfrmDescription,
+			"-j", "NOTRACK"), false); err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Move the installation of the forward chain rules into a separate
function which is called from `(*IptablesManager).TransientRulesStart` and
`(*IptablesManager).InstallRules`.

De-duplicate code in `(*IptablesManager).ciliumNoTrackXfrmRules`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10281)
<!-- Reviewable:end -->
