### PR TITLE
Use -F flag in git log in check-stable script

### DIFF
--- a/contrib/backporting/check-stable
+++ b/contrib/backporting/check-stable
@@ -152,7 +152,7 @@ generate_commit_list_for_pr () {
     entry_id=${entry_array[0]}
     entry_sha=${entry_array[1]}
     entry_sub=${entry_array[@]:2}
-    upstream="$(git log --since="1year" --pretty="%H" --no-merges --grep "$entry_sub" $REMOTE/master)"
+    upstream="$(git log -F --since="1year" --pretty="%H" --no-merges --grep "$entry_sub" $REMOTE/master)"
     upstream="$(git show $upstream | git patch-id)"
     upstream=($upstream)
     if [ "$entry_id" == "${upstream[0]}" ]; then


### PR DESCRIPTION
If commit message is not a proper regular expression, check-stable
script crashes (`bpf,option: Fix EPHE**R**MERAL typo` is an example).

This change causes `git log` to not use commit message header as a
regex, but rather use simple string comparison.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10283)
<!-- Reviewable:end -->
