### PR TITLE
Add priority class to operator deployment

### DIFF
--- a/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
@@ -173,6 +173,9 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
 {{- end }}
       restartPolicy: Always
+{{- if and (eq .Release.Namespace "kube-system") (or (gt .Capabilities.KubeVersion.Minor "10") (gt .Capabilities.KubeVersion.Major "1"))}}
+      priorityClassName: system-cluster-critical
+{{- end }}
       serviceAccount: cilium-operator
       serviceAccountName: cilium-operator
 {{- if or .Values.global.etcd.enabled .Values.global.kubeConfigPath }}


### PR DESCRIPTION
Fixes: #10284

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](http://docs.cilium.io/en/stable/contributing/contributing/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue. 
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](http://docs.cilium.io/en/stable/contributing/contributing/#dev-coo).
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

Adds a priorityClassName to the operator deployment in the helm chart

Fixes: #10284 

```release-note
Add priorityClassName to operator deployment in helm chart
```

Please give feedback on the chosen `priorityClass` (see #10284). The `if` construct is taken from the [agent chart](https://github.com/cilium/cilium/blob/master/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml#L291), I can remove it if it's not required.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10285)
<!-- Reviewable:end -->
