### PR TITLE
.github: fix doc links in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,11 @@
 Please ensure your pull request adheres to the following guidelines:
 
-- [ ] For first time contributors, read [Submitting a pull request](http://docs.cilium.io/en/stable/contributing/contributing/#submitting-a-pull-request)
+- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
 - [ ] All code is covered by unit and/or runtime tests where feasible.
 - [ ] All commits contain a well written commit description including a title,
       description and a `Fixes: #XXX` line if the commit addresses a particular
-      GitHub issue. 
-- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](http://docs.cilium.io/en/stable/contributing/contributing/#dev-coo).
+      GitHub issue.
+- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
 - [ ] Provide a title or release-note blurb suitable for the release notes.
 - [ ] Thanks for contributing!
 


### PR DESCRIPTION
Adjust the links to their new location and change them to https.

Reported-by: Maximilian Bischoff <maximilian.bischoff@inovex.de> (in #10285)
Signed-off-by: Tobias Klauser <tklauser@distanz.ch>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10287)
<!-- Reviewable:end -->
