### PR TITLE
pkg/bpf: Fix KeepAlive usage for pathStr

### DIFF
--- a/pkg/bpf/bpf_linux.go
+++ b/pkg/bpf/bpf_linux.go
@@ -305,7 +305,7 @@ func ObjPin(fd int, pathname string) error {
 		uintptr(unsafe.Pointer(&uba)),
 		unsafe.Sizeof(uba),
 	)
-	runtime.KeepAlive(&pathStr)
+	runtime.KeepAlive(pathStr)
 	runtime.KeepAlive(&uba)
 
 	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
@@ -336,7 +336,7 @@ func ObjGet(pathname string) (int, error) {
 		uintptr(unsafe.Pointer(&uba)),
 		unsafe.Sizeof(uba),
 	)
-	runtime.KeepAlive(&pathStr)
+	runtime.KeepAlive(pathStr)
 	runtime.KeepAlive(&uba)
 	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
 		metrics.BPFSyscallDuration.WithLabelValues(metricOpObjGet, metrics.Errno2Outcome(err)).Observe(duration.End(err == 0).Total().Seconds())


### PR DESCRIPTION
`pathStr` is a pointer to a memory location which we want to protect. Previously, we were protecting a location which stores the pointer instead.

Fixes: 9f492a1b9 ("bpf: Protect each uintptr with runtime.KeepAlive")

It was manually fixed in `v1.5`, so no backport to it is needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10288)
<!-- Reviewable:end -->
