### PR TITLE
option: reduce default number for TCP CT max entries

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -24,14 +24,14 @@ cilium-agent [flags]
       --blacklist-conflicting-routes                  Don't blacklist IP allocations conflicting with local non-cilium routes (default true)
       --bpf-compile-debug                             Enable debugging of the BPF compilation process
       --bpf-ct-global-any-max int                     Maximum number of entries in non-TCP CT table (default 262144)
-      --bpf-ct-global-tcp-max int                     Maximum number of entries in TCP CT table (default 1000000)
+      --bpf-ct-global-tcp-max int                     Maximum number of entries in TCP CT table (default 524288)
       --bpf-ct-timeout-regular-any duration           Timeout for entries in non-TCP CT table (default 1m0s)
       --bpf-ct-timeout-regular-tcp duration           Timeout for established entries in TCP CT table (default 6h0m0s)
       --bpf-ct-timeout-regular-tcp-fin duration       Teardown timeout for entries in TCP CT table (default 10s)
       --bpf-ct-timeout-regular-tcp-syn duration       Establishment timeout for entries in TCP CT table (default 1m0s)
       --bpf-ct-timeout-service-any duration           Timeout for service entries in non-TCP CT table (default 1m0s)
       --bpf-ct-timeout-service-tcp duration           Timeout for established service entries in TCP CT table (default 6h0m0s)
-      --bpf-nat-global-max int                        Maximum number of entries for the global BPF NAT table (default 841429)
+      --bpf-nat-global-max int                        Maximum number of entries for the global BPF NAT table (default 524288)
       --bpf-policy-map-max int                        Maximum number of entries in endpoint policy map (per endpoint) (default 16384)
       --bpf-root string                               Path to BPF filesystem
       --certificates-directory string                 Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -123,7 +123,7 @@ data:
   # Only effective when monitor aggregation is set to "medium" or higher.
   monitor-aggregation-flags: {{ .Values.global.bpf.monitorFlags }}
 
-  # ct-global-max-entries-* specifies the maximum number of connections
+  # bpf-ct-global-*-max specifies the maximum number of connections
   # supported across all endpoints, split by protocol: tcp or other. One pair
   # of maps uses these values for IPv4 connections, and another pair of maps
   # use these values for IPv6 connections.
@@ -133,7 +133,7 @@ data:
   # policy drops or a change in loadbalancing decisions for a connection.
   #
   # For users upgrading from Cilium 1.2 or earlier, to minimize disruption
-  # during the upgrade process, comment out these options.
+  # during the upgrade process, set bpf-ct-global-tcp-max to 1000000.
   bpf-ct-global-tcp-max: "{{ .Values.global.bpf.ctTcpMax }}"
   bpf-ct-global-any-max: "{{ .Values.global.bpf.ctAnyMax }}"
 

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -203,7 +203,7 @@ global:
     ctAnyMax: 262144
 
     # natMax is the maximum number of entries for the NAT table
-    natMax: 841429
+    natMax: 524288
 
     # montiorAggregation is the level of aggregation for datapath trace events
     monitorAggregation: medium

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -71,7 +71,7 @@ data:
   # policy drops or a change in loadbalancing decisions for a connection.
   #
   # For users upgrading from Cilium 1.2 or earlier, to minimize disruption
-  # during the upgrade process, comment out these options.
+  # during the upgrade process, set bpf-ct-global-tcp-max to 1000000.
   bpf-ct-global-tcp-max: "524288"
   bpf-ct-global-any-max: "262144"
 

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -54,7 +54,7 @@ var (
 		metrics.LabelDatapathFamily: "ipv4",
 	}
 
-	mapInfo = make(map[mapType]mapAttributes)
+	mapInfo map[mapType]mapAttributes
 )
 
 const (
@@ -130,7 +130,7 @@ func setupMapInfo(m mapType, define string, mapKey bpf.MapKey, keySize int, maxE
 // combination of L3/L4 protocols, using the specified limits on TCP vs non-TCP
 // maps.
 func InitMapInfo(tcpMaxEntries, anyMaxEntries int, v4, v6 bool) {
-	mapInfo = make(map[mapType]mapAttributes)
+	mapInfo = make(map[mapType]mapAttributes, mapTypeMax)
 
 	global4Map, global6Map := nat.GlobalMaps(v4, v6)
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -488,12 +488,22 @@ const (
 	// BPFCompileDebugName is the name of the option to enable BPF compiliation debugging
 	BPFCompileDebugName = "bpf-compile-debug"
 
-	// CTMapEntriesGlobalTCP retains the Cilium 1.2 (or earlier) size to
+	// CTMapEntriesGlobalTCPDefault is the default maximum number of entries
+	// in the TCP CT table. It retains the Cilium 1.2 (or earlier) size to
 	// minimize disruption during upgrade.
 	CTMapEntriesGlobalTCPDefault = 1000000
+
+	// CTMapEntriesGlobalAnyDefault is the default maximum number of entries
+	// in the non-TCP CT table.
 	CTMapEntriesGlobalAnyDefault = 2 << 17 // 256Ki
-	CTMapEntriesGlobalTCPName    = "bpf-ct-global-tcp-max"
-	CTMapEntriesGlobalAnyName    = "bpf-ct-global-any-max"
+
+	// CTMapEntriesGlobalTCPName configures max entries for the TCP CT
+	// table.
+	CTMapEntriesGlobalTCPName = "bpf-ct-global-tcp-max"
+
+	// CTMapEntriesGlobalAnyName configures max entries for the non-TCP CT
+	// table.
+	CTMapEntriesGlobalAnyName = "bpf-ct-global-any-max"
 
 	// CTMapEntriesTimeout* name option and default value mappings
 	CTMapEntriesTimeoutSYNName    = "bpf-ct-timeout-regular-tcp-syn"

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -489,9 +489,8 @@ const (
 	BPFCompileDebugName = "bpf-compile-debug"
 
 	// CTMapEntriesGlobalTCPDefault is the default maximum number of entries
-	// in the TCP CT table. It retains the Cilium 1.2 (or earlier) size to
-	// minimize disruption during upgrade.
-	CTMapEntriesGlobalTCPDefault = 1000000
+	// in the TCP CT table.
+	CTMapEntriesGlobalTCPDefault = 2 << 18 // 512Ki
 
 	// CTMapEntriesGlobalAnyDefault is the default maximum number of entries
 	// in the non-TCP CT table.


### PR DESCRIPTION
Commit e824a86bba21 ("daemon: Allow configuration of CT max entries")
bumped the default value to 1000000 in order to ease upgrades from
Cilium 1.2. In the helm charts, the value was again set to 512KB via the
`ct-global-max-entries-tcp` option. However, if Cilium is not deployed
via helm charts (e.g. when running as a systemd service in the devel
VM) the large default number of entries is used.

Set the default value for `bpf-ct-global-tcp-max` to 512KB again and
instead advise users in the helm chart comments to set it to 1000000 in
case they're upgrading or changed the size manually using Helm.

Since the default value of `bpf-nat-global-max` for the NAT table size
is derived from the default for `bpf-ct-global-tcp-max`, this commit
will also decrease the the NAT table size to 512K.
    
Document possible consequences of upgrading Cilium installations with
larger TCP CT and NAT table sizes.

This saves about ~150MB of memory at runtime.

Updates #10056

```release-note
The default maximum number of entries in the BPF TCP ctmap is reduced to 512K.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10289)
<!-- Reviewable:end -->
