### PR TITLE
clustermesh: Emit identity-change events for remote clusters

### DIFF
--- a/pkg/allocator/allocator.go
+++ b/pkg/allocator/allocator.go
@@ -367,6 +367,13 @@ func WithoutGC() AllocatorOption {
 	return func(a *Allocator) { a.disableGC = true }
 }
 
+// GetEvents returns the events channel given to the allocator when
+// constructed.
+// Note: This channel is not owned by the allocator!
+func (a *Allocator) GetEvents() AllocatorEventChan {
+	return a.events
+}
+
 // Delete deletes an allocator and stops the garbage collector
 func (a *Allocator) Delete() {
 	close(a.stopGC)

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -443,7 +443,7 @@ func (m *CachingIdentityAllocator) WatchRemoteIdentities(backend kvstore.Backend
 		return nil, fmt.Errorf("Error setting up remote allocator backend: %s", err)
 	}
 
-	remoteAlloc, err := allocator.NewAllocator(GlobalIdentity{}, remoteAllocatorBackend)
+	remoteAlloc, err := allocator.NewAllocator(GlobalIdentity{}, remoteAllocatorBackend, allocator.WithEvents(m.IdentityAllocator.GetEvents()))
 	if err != nil {
 		return nil, fmt.Errorf("Unable to initialize remote Identity Allocator: %s", err)
 	}


### PR DESCRIPTION
We redid how remote clusters are handled and watched in
f28f6cd887f6699bc023fdee9e5f5be51429a31c (PR #10185) but did not connect
to the events channel used to update selectors. We now re-use the main
allocator's events channel as the remote clusters are treated as child
allocators and only accessed through the primary.

fixes f28f6cd887f6699bc023fdee9e5f5be51429a31c

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10290)
<!-- Reviewable:end -->
