### PR TITLE
v1.6 backports 2020-02-21

### DIFF
--- a/cilium/cmd/bpf_ct_flush.go
+++ b/cilium/cmd/bpf_ct_flush.go
@@ -62,12 +62,15 @@ func flushCt(eID string) {
 			err = m.Open()
 		}
 		if err != nil {
-			if err == os.ErrNotExist {
-				Fatalf("Unable to open %s: %s: please try using \"cilium bpf ct flush global\"", path, err)
-			} else {
-				Fatalf("Unable to open %s: %s", path, err)
+			if os.IsNotExist(err) {
+				msg := "Unable to open %s: %s."
+				if eID != "global" {
+					msg = "Unable to open %s: %s: please try using \"cilium bpf ct flush global\"."
+				}
+				fmt.Fprintf(os.Stderr, msg+" Skipping.\n", path, err)
+				continue
 			}
-			continue
+			Fatalf("Unable to open %s: %s", path, err)
 		}
 		defer m.Close()
 		entries := m.Flush()

--- a/cilium/cmd/bpf_ct_list.go
+++ b/cilium/cmd/bpf_ct_list.go
@@ -58,11 +58,15 @@ func dumpCt(eID string) {
 			err = m.Open()
 		}
 		if err != nil {
-			if err == os.ErrNotExist {
-				Fatalf("Unable to open %s: %s: please try using \"cilium bpf ct list global\"", path, err)
-			} else {
-				Fatalf("Unable to open %s: %s", path, err)
+			if os.IsNotExist(err) {
+				msg := "Unable to open %s: %s."
+				if eID != "global" {
+					msg = "Unable to open %s: %s: please try using \"cilium bpf ct list global\"."
+				}
+				fmt.Fprintf(os.Stderr, msg+" Skipping.\n", path, err)
+				continue
 			}
+			Fatalf("Unable to open %s: %s", path, err)
 		}
 		defer m.Close()
 		if command.OutputJSON() {

--- a/cilium/cmd/bpf_nat_flush.go
+++ b/cilium/cmd/bpf_nat_flush.go
@@ -50,8 +50,11 @@ func flushNat() {
 			err = m.Open()
 		}
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Unable to open %s: %s", path, err)
-			continue
+			if os.IsNotExist(err) {
+				fmt.Fprintf(os.Stderr, "Unable to open %s: %s. Skipping.\n", path, err)
+				continue
+			}
+			Fatalf("Unable to open %s: %s", path, err)
 		}
 		defer m.Close()
 		entries := m.Flush()

--- a/cilium/cmd/bpf_nat_list.go
+++ b/cilium/cmd/bpf_nat_list.go
@@ -53,11 +53,11 @@ func dumpNat() {
 			err = m.Open()
 		}
 		if err != nil {
-			if err == os.ErrNotExist {
-				fmt.Fprintf(os.Stderr, "Unable to open %s: %s: please try using \"cilium bpf nat list\"", path, err)
-			} else {
-				Fatalf("Unable to open %s: %s", path, err)
+			if os.IsNotExist(err) {
+				fmt.Fprintf(os.Stderr, "Unable to open %s: %s. Skipping.\n", path, err)
+				continue
 			}
+			Fatalf("Unable to open %s: %s", path, err)
 		}
 		defer m.Close()
 		if command.OutputJSON() {

--- a/contrib/backporting/check-stable
+++ b/contrib/backporting/check-stable
@@ -152,7 +152,7 @@ generate_commit_list_for_pr () {
     entry_id=${entry_array[0]}
     entry_sha=${entry_array[1]}
     entry_sub=${entry_array[@]:2}
-    upstream="$(git log --since="1year" --pretty="%H" --no-merges --grep "$entry_sub" $REMOTE/master)"
+    upstream="$(git log -F --since="1year" --pretty="%H" --no-merges --grep "$entry_sub" $REMOTE/master)"
     upstream="$(git show $upstream | git patch-id)"
     upstream=($upstream)
     if [ "$entry_id" == "${upstream[0]}" ]; then

--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -138,7 +138,7 @@ func NewKVStoreBackend(basePath, suffix string, typ allocator.AllocatorKey, back
 // lockPath locks a key in the scope of an allocator
 func (k *kvstoreBackend) lockPath(ctx context.Context, key string) (*kvstore.Lock, error) {
 	suffix := strings.TrimPrefix(key, k.basePrefix)
-	return kvstore.LockPath(ctx, path.Join(k.lockPrefix, suffix))
+	return kvstore.LockPath(ctx, k.backend, path.Join(k.lockPrefix, suffix))
 }
 
 // DeleteAllKeys will delete all keys
@@ -198,7 +198,7 @@ func (k *kvstoreBackend) createValueNodeKey(ctx context.Context, key string, new
 // Lock locks a key in the scope of an allocator
 func (k *kvstoreBackend) lock(ctx context.Context, key string) (*kvstore.Lock, error) {
 	suffix := strings.TrimPrefix(key, k.basePrefix)
-	return kvstore.LockPath(ctx, path.Join(k.lockPrefix, suffix))
+	return kvstore.LockPath(ctx, k.backend, path.Join(k.lockPrefix, suffix))
 }
 
 // Lock locks a key in the scope of an allocator

--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -143,7 +143,7 @@ func (k *kvstoreBackend) lockPath(ctx context.Context, key string) (*kvstore.Loc
 
 // DeleteAllKeys will delete all keys
 func (k *kvstoreBackend) DeleteAllKeys() {
-	kvstore.Client().DeletePrefix(k.basePrefix)
+	k.backend.DeletePrefix(k.basePrefix)
 }
 
 func (k *kvstoreBackend) encodeKey(key allocator.AllocatorKey) []byte {

--- a/pkg/kvstore/base_test.go
+++ b/pkg/kvstore/base_test.go
@@ -38,7 +38,7 @@ func (s *BaseTests) TestLock(c *C) {
 	defer Client().DeletePrefix(prefix)
 
 	for i := 0; i < 10; i++ {
-		lock, err := LockPath(context.Background(), fmt.Sprintf("%sfoo/%d", prefix, i))
+		lock, err := LockPath(context.Background(), Client(), fmt.Sprintf("%sfoo/%d", prefix, i))
 		c.Assert(err, IsNil)
 		c.Assert(lock, Not(IsNil))
 		lock.Unlock()

--- a/pkg/kvstore/consul.go
+++ b/pkg/kvstore/consul.go
@@ -642,7 +642,7 @@ func (c *consulClient) createIfExists(condKey, key string, value []byte, lease b
 	//
 	// Lock the conditional key to serialize all CreateIfExists() calls
 
-	l, err := LockPath(context.Background(), condKey)
+	l, err := LockPath(context.Background(), c, condKey)
 	if err != nil {
 		return fmt.Errorf("unable to lock condKey for CreateIfExists: %s", err)
 	}

--- a/pkg/kvstore/lock.go
+++ b/pkg/kvstore/lock.go
@@ -132,13 +132,13 @@ type Lock struct {
 // returned also contains a patch specific local Mutex which will be held.
 //
 // It is required to call Unlock() on the returned Lock to unlock
-func LockPath(ctx context.Context, path string) (l *Lock, err error) {
+func LockPath(ctx context.Context, backend BackendOperations, path string) (l *Lock, err error) {
 	id, err := kvstoreLocks.lock(ctx, path)
 	if err != nil {
 		return nil, err
 	}
 
-	lock, err := Client().LockPath(ctx, path)
+	lock, err := backend.LockPath(ctx, path)
 	if err != nil {
 		kvstoreLocks.unlock(path, id)
 		Trace("Failed to lock", err, logrus.Fields{fieldKey: path})

--- a/pkg/maps/eppolicymap/eppolicymap.go
+++ b/pkg/maps/eppolicymap/eppolicymap.go
@@ -68,11 +68,13 @@ var (
 // to avoid having multiple inner maps.
 func CreateEPPolicyMap() {
 	buildMap.Do(func() {
+		mapType := bpf.MapType(bpf.BPF_MAP_TYPE_HASH)
 		fd, err := bpf.CreateMap(bpf.BPF_MAP_TYPE_HASH,
 			uint32(unsafe.Sizeof(policymap.PolicyKey{})),
 			uint32(unsafe.Sizeof(policymap.PolicyEntry{})),
 			uint32(policymap.MaxEntries),
-			0, 0, innerMapName)
+			bpf.GetPreAllocateMapFlags(mapType),
+			0, innerMapName)
 
 		if err != nil {
 			log.WithError(err).Warning("unable to create EP to policy map")

--- a/pkg/service/id_kvstore.go
+++ b/pkg/service/id_kvstore.go
@@ -211,7 +211,7 @@ func acquireGlobalID(l3n4Addr loadbalancer.L3n4Addr, baseID uint32) (*loadbalanc
 	svcPath := path.Join(common.ServicesKeyPath, sha256Sum)
 
 	// Lock that sha256Sum
-	lockKey, err := kvstore.LockPath(context.Background(), svcPath)
+	lockKey, err := kvstore.LockPath(context.Background(), kvstore.Client(), svcPath)
 	if err != nil {
 		return nil, err
 	}
@@ -294,7 +294,7 @@ func deleteL3n4AddrIDBySHA256(sha256Sum string) error {
 	}
 	svcPath := path.Join(common.ServicesKeyPath, sha256Sum)
 	// Lock that sha256Sum
-	lockKey, err := kvstore.LockPath(context.Background(), svcPath)
+	lockKey, err := kvstore.LockPath(context.Background(), kvstore.Client(), svcPath)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
 * #10193 -- cli: Do not panic if BPF map does not exist (@brb)
 * #10201 -- policy: fix innermap's flag error in eppolicymap (@zhiyuan0x)
 * #10243 -- Fixups for Correct clustermesh identity sync kvstore backend usage (@raybejjani)
 * #10283 -- Use -F flag in git log in check-stable script (@nebril)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 10193 10201 10243 10283; do contrib/backporting/set-labels.py $pr done 1.6; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10291)
<!-- Reviewable:end -->
