### PR TITLE
policy: Track source policy rules in MapStateEntry

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
+	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/loadinfo"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
@@ -224,7 +225,7 @@ func (e *Endpoint) addNewRedirectsFromDesiredPolicy(ingress bool, desiredRedirec
 				} else {
 					insertedDesiredMapState[keyFromFilter] = struct{}{}
 				}
-				if entry != policy.NoRedirectEntry {
+				if entry.IsRedirectEntry() {
 					entry.ProxyPort = redirectPort
 				}
 				e.desiredPolicy.PolicyMapState[keyFromFilter] = entry
@@ -336,6 +337,11 @@ func (e *Endpoint) addVisibilityRedirects(ingress bool, desiredRedirects map[str
 
 		e.desiredPolicy.PolicyMapState[newKey] = policy.MapStateEntry{
 			ProxyPort: redirectPort,
+			DerivedFromRules: labels.LabelArrayList{
+				labels.LabelArray{
+					labels.NewLabel(policy.LabelKeyPolicyDerivedFrom, policy.LabelVisibilityAnnotation, labels.LabelSourceReserved),
+				},
+			},
 		}
 
 		insertedDesiredMapState[newKey] = struct{}{}
@@ -1068,7 +1074,7 @@ func (e *Endpoint) applyPolicyMapChanges() (proxyChanges bool, err error) {
 
 	for keyToAdd, entry := range adds {
 		// Keep the existing proxy port, if any
-		if entry != policy.NoRedirectEntry {
+		if entry.IsRedirectEntry() {
 			entry.ProxyPort = e.realizedRedirects[policy.ProxyIDFromKey(e.ID, keyToAdd)]
 			if entry.ProxyPort != 0 {
 				proxyChanges = true
@@ -1143,7 +1149,7 @@ func (e *Endpoint) addPolicyMapDelta() error {
 	errors := 0
 
 	for keyToAdd, entry := range e.desiredPolicy.PolicyMapState {
-		if oldEntry, ok := e.realizedPolicy.PolicyMapState[keyToAdd]; !ok || oldEntry != entry {
+		if oldEntry, ok := e.realizedPolicy.PolicyMapState[keyToAdd]; !ok || !oldEntry.Equal(&entry) {
 			if !e.addPolicyKey(keyToAdd, entry, false) {
 				errors++
 			}

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -751,3 +751,21 @@ func (e *Endpoint) UpdateVisibilityPolicy(annoCB AnnotationsResolverCB) {
 	}
 	<-ch
 }
+
+// GetRealizedPolicyRuleLabelsForKey returns the list of policy rule labels
+// which match a given flow key (in host byte-order)
+func (e *Endpoint) GetRealizedPolicyRuleLabelsForKey(key policy.Key) (
+	derivedFrom labels.LabelArrayList,
+	revision uint64,
+	ok bool,
+) {
+	e.mutex.RLock()
+	defer e.mutex.RUnlock()
+
+	entry, ok := e.realizedPolicy.PolicyMapState[key]
+	if !ok {
+		return nil, 0, false
+	}
+
+	return entry.DerivedFromRules.DeepCopy(), e.policyRevision, true
+}

--- a/pkg/labels/arraylist.go
+++ b/pkg/labels/arraylist.go
@@ -40,3 +40,16 @@ func (ls LabelArrayList) GetModel() [][]string {
 	}
 	return res
 }
+
+// Same returns true if the label arrays lists have the same label arrays in the same order.
+func (ls LabelArrayList) Same(b LabelArrayList) bool {
+	if len(ls) != len(b) {
+		return false
+	}
+	for l := range ls {
+		if !ls[l].Same(b[l]) {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -16,6 +16,7 @@ package policy
 
 import (
 	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
@@ -30,6 +31,14 @@ var (
 		Identity:         identity.ReservedIdentityHost.Uint32(),
 		TrafficDirection: trafficdirection.Ingress.Uint8(),
 	}
+)
+
+const (
+	LabelKeyPolicyDerivedFrom  = "io.cilium.policy.derived-from"
+	LabelAllowLocalHostIngress = "allow-localhost-ingress"
+	LabelAllowAnyIngress       = "allow-any-ingress"
+	LabelAllowAnyEgress        = "allow-any-egress"
+	LabelVisibilityAnnotation  = "visibility-annotation"
 )
 
 // MapState is a state of a policy map.
@@ -68,22 +77,47 @@ type MapStateEntry struct {
 	// If 0 (default), there is no proxy redirection for the corresponding
 	// Key. Any other value signifies proxy redirection.
 	ProxyPort uint16
+
+	// DerivedFromRules tracks the policy rules this entry derives from
+	DerivedFromRules labels.LabelArrayList
 }
 
-// NoRedirectEntry is a special MapStateEntry used to signify that the
-// entry is not redirecting to a proxy.
-var NoRedirectEntry = MapStateEntry{ProxyPort: 0}
+// NewPlaceholderEntry creates a map state entry. If redirect is true, the
+// caller is expected to replace the ProxyPort field before it is added to
+// the actual BPF map.
+func NewPlaceholderEntry(derivedFrom labels.LabelArrayList, redirect bool) MapStateEntry {
+	var proxyPort uint16
+	if redirect {
+		// Any non-zero value will do, as the callers replace this with the
+		// actual proxy listening port number before the entry is added to the
+		// actual bpf map.
+		proxyPort = 1
+	}
 
-// redirectEntry is a MapStateEntry used to signify that the entry
-// must redirect to a proxy. Any non-zero value would do, as the
-// callers replace this with the actual proxy listening port number
-// before the entry is added to the actual bpf map.
-var redirectEntry = MapStateEntry{ProxyPort: 1}
+	return MapStateEntry{
+		ProxyPort:        proxyPort,
+		DerivedFromRules: derivedFrom,
+	}
+}
+
+// IsRedirectEntry returns true if e contains a redirect
+func (e *MapStateEntry) IsRedirectEntry() bool {
+	return e.ProxyPort != 0
+}
+
+// Equal returns true of two entries are equal
+func (e *MapStateEntry) Equal(o *MapStateEntry) bool {
+	if e == nil || o == nil {
+		return e == o
+	}
+
+	return e.ProxyPort == o.ProxyPort && e.DerivedFromRules.Same(o.DerivedFromRules)
+}
 
 // RedirectPreferredInsert inserts a new entry giving priority to L7-redirects by
 // not overwriting a L7-redirect entry with a non-redirect entry
 func (keys MapState) RedirectPreferredInsert(key Key, entry MapStateEntry) {
-	if entry == NoRedirectEntry {
+	if !entry.IsRedirectEntry() {
 		if _, ok := keys[key]; ok {
 			// Key already exist, keep the existing entry so that
 			// a redirect entry is never overwritten by a non-redirect
@@ -100,7 +134,12 @@ func (keys MapState) RedirectPreferredInsert(key Key, entry MapStateEntry) {
 // endpoint.
 func (keys MapState) DetermineAllowLocalhostIngress(l4Policy *L4Policy) {
 	if option.Config.AlwaysAllowLocalhost() {
-		keys[localHostKey] = MapStateEntry{}
+		keys[localHostKey] = MapStateEntry{
+			DerivedFromRules: labels.LabelArrayList{
+				labels.LabelArray{
+					labels.NewLabel(LabelKeyPolicyDerivedFrom, LabelAllowLocalHostIngress, labels.LabelSourceReserved),
+				},
+			}}
 	}
 }
 
@@ -115,7 +154,13 @@ func (keys MapState) AllowAllIdentities(ingress, egress bool) {
 			Nexthdr:          0,
 			TrafficDirection: trafficdirection.Ingress.Uint8(),
 		}
-		keys[keyToAdd] = MapStateEntry{}
+		keys[keyToAdd] = MapStateEntry{
+			DerivedFromRules: labels.LabelArrayList{
+				labels.LabelArray{
+					labels.NewLabel(LabelKeyPolicyDerivedFrom, LabelAllowAnyIngress, labels.LabelSourceReserved),
+				},
+			},
+		}
 	}
 	if egress {
 		keyToAdd := Key{
@@ -124,7 +169,13 @@ func (keys MapState) AllowAllIdentities(ingress, egress bool) {
 			Nexthdr:          0,
 			TrafficDirection: trafficdirection.Egress.Uint8(),
 		}
-		keys[keyToAdd] = MapStateEntry{}
+		keys[keyToAdd] = MapStateEntry{
+			DerivedFromRules: labels.LabelArrayList{
+				labels.LabelArray{
+					labels.NewLabel(LabelKeyPolicyDerivedFrom, LabelAllowAnyEgress, labels.LabelSourceReserved),
+				},
+			},
+		}
 	}
 }
 
@@ -147,7 +198,8 @@ type MapChanges struct {
 // cases where an identity is first added and then deleted, or first
 // deleted and then added.
 func (mc *MapChanges) AccumulateMapChanges(adds, deletes []identity.NumericIdentity,
-	port uint16, proto uint8, direction trafficdirection.TrafficDirection, redirect bool) {
+	port uint16, proto uint8, direction trafficdirection.TrafficDirection,
+	redirect bool, derivedFrom labels.LabelArrayList) {
 	key := Key{
 		// The actual identity is set in the loops below
 		Identity: 0,
@@ -156,10 +208,8 @@ func (mc *MapChanges) AccumulateMapChanges(adds, deletes []identity.NumericIdent
 		Nexthdr:          proto,
 		TrafficDirection: direction.Uint8(),
 	}
-	var value MapStateEntry // defaults to ProxyPort 0 == no redirect
-	if redirect {
-		value = redirectEntry // Special entry to mark the need for redirection
-	}
+
+	value := NewPlaceholderEntry(derivedFrom, redirect)
 
 	if option.Config.Debug {
 		log.WithFields(logrus.Fields{

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -157,13 +157,13 @@ func (p *EndpointPolicy) computeDirectionL4PolicyMapEntries(l4PolicyMap L4Policy
 		keysFromFilter := filter.ToMapState(direction)
 		for keyFromFilter, entry := range keysFromFilter {
 			// Fix up the proxy port for entries that need proxy redirection
-			if entry != NoRedirectEntry {
+			if entry.IsRedirectEntry() {
 				entry.ProxyPort = p.PolicyOwner.LookupRedirectPort(filter)
 				// If the currently allocated proxy port is 0, this is a new
 				// redirect, for which no port has been allocated yet. Ignore
 				// it for now. This will be configured by
 				// e.addNewRedirectsFromDesiredPolicy() once the port has been allocated.
-				if entry == NoRedirectEntry {
+				if !entry.IsRedirectEntry() {
 					continue
 				}
 			}


### PR DESCRIPTION
This commit allows us to track the policies for which a certain policy
map entry has been created.

It is implemented by copying over the `DerivedFromRules` from the
merged ingress/egress filters to the user-space representation of
the policy map state. Default entries such as `AllowAnyIngress`,
`AllowAnyEgress` and `AllowLocalHostIngress` are annotated with
artificial labels (of label source `reserved`).

The entries are copied over into `realizedPolicy` of each endpoint when
the policy maps are synced. This enables us to expose this information
in the newly introduced `GetRealizedPolicyRuleLabelsForKey` getter.

Signed-off-by: Sebastian Wicki <sebastian@isovalent.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10293)
<!-- Reviewable:end -->
