### PR TITLE
Make resources in agent and operator helm chart configurable

### DIFF
--- a/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
@@ -143,6 +143,8 @@ spec:
               command:
               - /cni-uninstall.sh
 {{- end }}
+        resources:
+          {{- toYaml .Values.resources | trim | nindent 10 }}
         name: cilium-agent
 {{- if .Values.global.prometheus.enabled }}
         ports:
@@ -222,6 +224,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/cilium
           name: cilium-run
+        resources:
+          {{- toYaml .Values.monitor.resources | trim | nindent 10 }}
 {{- end }}
 {{- if .Values.global.etcd.managed }}
       # In managed etcd mode, Cilium must be able to resolve the DNS name of
@@ -286,6 +290,8 @@ spec:
 {{- end }}
         - mountPath: /var/run/cilium
           name: cilium-run
+        resources:
+          {{- toYaml .Values.initResources | trim | nindent 10 }}
       restartPolicy: Always
 {{- if and (eq .Release.Namespace "kube-system") (or (gt .Capabilities.KubeVersion.Minor "10") (gt .Capabilities.KubeVersion.Major "1"))}}
       priorityClassName: system-node-critical

--- a/install/kubernetes/cilium/charts/agent/values.yaml
+++ b/install/kubernetes/cilium/charts/agent/values.yaml
@@ -8,3 +8,14 @@ maxUnavailable: 2
 monitor:
   enabled: false
   eventTypes: []
+  # Specifies the resources for the monitor sidecar container if activated
+  resources: {}
+
+# Specifies the resources for the agent container
+resources: {}
+
+# Specifies the resources for the clean-cilium-state init container
+initResources:
+  requests:
+    cpu: "100m"
+    memory: "100Mi"

--- a/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
@@ -166,6 +166,8 @@ spec:
           name: kube-config
           readOnly: true
 {{- end}}
+        resources:
+          {{- toYaml .Values.resources | trim | nindent 10 }}
       hostNetwork: true
 {{- if .Values.global.etcd.managed }}
       # In managed etcd mode, Cilium must be able to resolve the DNS name of

--- a/install/kubernetes/cilium/charts/operator/values.yaml
+++ b/install/kubernetes/cilium/charts/operator/values.yaml
@@ -1,2 +1,5 @@
 image: operator
 synchronizeK8sNodes: true
+
+# Specifies the resources for the operator container
+resources: {}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

Enables users of the  helm chart to provide resource requests and limits to the containers of the agent and operator deployment/daemonset. Also provides default requests for the agent's initContainer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10296)
<!-- Reviewable:end -->
