### PR TITLE
monitor: Don't close the queue explicitly

### DIFF
--- a/pkg/monitor/agent/listener1_2.go
+++ b/pkg/monitor/agent/listener1_2.go
@@ -86,6 +86,5 @@ func (ml *listenerv1_2) Version() listener.Version {
 func (ml *listenerv1_2) Close() {
 	ml.once.Do(func() {
 		ml.conn.Close()
-		close(ml.queue)
 	})
 }

--- a/pkg/monitor/agent/listener1_2_test.go
+++ b/pkg/monitor/agent/listener1_2_test.go
@@ -42,6 +42,8 @@ func (m *ListenerSuite) TestListenerv1_2(c *C) {
 	// Calling Close() multiple times shouldn't cause panic.
 	l.Close()
 	l.Close()
+	// Explicitly close the queue here so that the defer function inside drainQueue gets called.
+	close(l.queue)
 	// Make sure the cleanup function gets called.
 	<-closed
 	server.Close()


### PR DESCRIPTION
The explict close was added to unblock drainQueue() in unit test.
This made the listener unsafe to be used from multiple goroutines
since Enqueue() doesn't check if the channel is closed. This PR
removes the close(), letting the GC do the cleanup instead.

Ref #10258

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10297)
<!-- Reviewable:end -->
