### PR TITLE
iptables: Add a fallback to missing xt_socket module.

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -69,6 +69,7 @@ cilium-agent [flags]
       --enable-remote-node-identity                           Enable use of remote node identity
       --enable-tracing                                        Enable tracing while determining policy (debugging)
       --enable-well-known-identities                          Enable well-known identities for known Kubernetes components (default true)
+      --enable-xt-socket-fallback                             Enable fallback for missing xt_socket module (default true)
       --encrypt-interface string                              Transparent encryption interface
       --encrypt-node                                          Enables encrypting traffic from non-Cilium pods and host networking
       --endpoint-interface-name-prefix string                 Prefix of interface name shared by all endpoints (default "lxc+")

--- a/Documentation/install/system_requirements.rst
+++ b/Documentation/install/system_requirements.rst
@@ -79,7 +79,7 @@ Linux Kernel
 
 Cilium leverages and builds on the kernel BPF functionality as well as various
 subsystems which integrate with BPF. Therefore, host systems are required to
-run Linux kernel version 4.8.0 or later to run a Cilium agent. More recent
+run Linux kernel version 4.9.17 or later to run a Cilium agent. More recent
 kernels may provide additional BPF functionality that Cilium will automatically
 detect and use on agent start.
 
@@ -103,6 +103,34 @@ linked, either choice is valid.
 
    Users running Linux 4.10 or earlier with Cilium CIDR policies may face
    :ref:`cidr_limitations`.
+
+L7 proxy redirection currently uses ``TPROXY`` iptables actions as well
+as ``socket`` matches. For L7 redirection to work as intended kernel
+configuration must include the following modules:
+
+.. code:: bash
+
+        CONFIG_NETFILTER_XT_TARGET_TPROXY=m
+        CONFIG_NETFILTER_XT_MATCH_MARK=m
+        CONFIG_NETFILTER_XT_MATCH_SOCKET=m
+
+When ``xt_socket`` kernel module is missing the forwarding of
+redirected L7 traffic does not work in non-tunneled datapath
+modes. Since some notable kernels (e.g., COS) are shipping without
+``xt_socket`` module, Cilium implements a fallback compatibility mode
+to allow L7 policies and visibility to be used with those
+kernels. Currently this fallback disables ``ip_early_demux`` kernel
+feature in non-tunneled datapath modes, which may decrease system
+networking performance. This guarantees HTTP and Kafka redirection
+works as intended.  However, if HTTP or Kafka enforcement policies or
+visibility annotations are never used, this behavior can be turned off
+by adding the following to the helm configuration command line:
+
+.. parsed-literal::
+
+   helm install cilium |CHART_RELEASE| \\
+     ...
+     --set global.enableXTSocketFallback=false
 
 .. _req_kvstore:
 

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -333,6 +333,9 @@ func init() {
 	flags.Bool(option.EnableAutoDirectRoutingName, defaults.EnableAutoDirectRouting, "Enable automatic L2 routing between nodes")
 	option.BindEnv(option.EnableAutoDirectRoutingName)
 
+	flags.Bool(option.EnableXTSocketFallbackName, defaults.EnableXTSocketFallback, "Enable fallback for missing xt_socket module")
+	option.BindEnv(option.EnableXTSocketFallbackName)
+
 	flags.String(option.EnablePolicy, option.DefaultEnforcement, "Enable policy enforcement")
 	option.BindEnv(option.EnablePolicy)
 

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -254,6 +254,9 @@ data:
   ipvlan-master-device: {{ .Values.global.ipvlan.masterDevice }}
 {{- end }}
 {{- end }}
+{{- if .Values.global.enableXTSocketFallback }}
+  enable-xt-socket-fallback: {{ .Values.global.enableXTSocketFallback | quote }}
+{{- end}}
   install-iptables-rules: {{ .Values.global.installIptablesRules | quote }}
   auto-direct-node-routes: {{ .Values.global.autoDirectNodeRoutes | quote }}
 

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -82,6 +82,13 @@ global:
     serviceMonitor:
       enabled: false
 
+  # enableXTSocketFallback enables the fallback compatibility solution
+  # when the xt_socket kernel module is missing and it is needed for
+  # the datapath L7 redirection to work properly.  See documentation
+  # for details on when this can be disabled:
+  # http://docs.cilium.io/en/latest/install/system_requirements/#admin-kernel-version.
+  enableXTSocketFallback: true
+
   # installIptablesRules enables installation of iptables rules to allow for
   # TPROXY (L7 proxy injection), itpables based masquerading and compatibility
   # with kube-proxy. See documentation for details on when this can be

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -167,6 +167,9 @@ const (
 	// DatapathMode is the default value for the datapath mode.
 	DatapathMode = "veth"
 
+	// EnableXTSocketFallback is the default value for EnableXTSocketFallback
+	EnableXTSocketFallback = true
+
 	// EnableLocalNodeRoute default value for EnableLocalNodeRoute
 	EnableLocalNodeRoute = true
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -513,6 +513,9 @@ const (
 	// PreAllocateMapsName is the name of the option PreAllocateMaps
 	PreAllocateMapsName = "preallocate-bpf-maps"
 
+	// EnableXTSocketFallbackName is the name of the EnableXTSocketFallback option
+	EnableXTSocketFallbackName = "enable-xt-socket-fallback"
+
 	// EnableAutoDirectRoutingName is the name for the EnableAutoDirectRouting option
 	EnableAutoDirectRoutingName = "auto-direct-node-routes"
 
@@ -1148,6 +1151,10 @@ type DaemonConfig struct {
 	// Cilium on all interfaces created by the flannel.
 	FlannelUninstallOnExit bool
 
+	// EnableXTSocketFallback allows disabling of kernel's ip_early_demux
+	// sysctl option if `xt_socket` kernel module is not available.
+	EnableXTSocketFallback bool
+
 	// EnableAutoDirectRouting enables installation of direct routes to
 	// other nodes when available
 	EnableAutoDirectRouting bool
@@ -1685,6 +1692,7 @@ func (c *DaemonConfig) Populate() {
 	c.EnableHostReachableServices = viper.GetBool(EnableHostReachableServices)
 	c.EnableRemoteNodeIdentity = viper.GetBool(EnableRemoteNodeIdentity)
 	c.DockerEndpoint = viper.GetString(Docker)
+	c.EnableXTSocketFallback = viper.GetBool(EnableXTSocketFallbackName)
 	c.EnableAutoDirectRouting = viper.GetBool(EnableAutoDirectRoutingName)
 	c.EnableEndpointRoutes = viper.GetBool(EnableEndpointRoutes)
 	c.EnableHealthChecking = viper.GetBool(EnableHealthChecking)


### PR DESCRIPTION
In non-tunneled datapath modes a missing xt_socket module breaks proxy
redirection traffic. xt_socket is needed due to
interaction between kernel's ip early demux logic and an explicit drop
for skbs with a socket set in ip_forward(). If xt_socket is not
available we can work around this problem by disabling ip early demux.

Add a cilium configuration option 'enable-xt-socket-fallback' which is
'true' by default, meaning that cilium-agent is allowed to disable ip
early demux if needed. This new option can be set to false to retain
the current behavior (== ip early demux is not disabled, but Cilium
policy enforcement may not function correctly in all datapath modes
with L7 enforcement or visibility.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

```release-note
Fallback mode for a missing `xt_socket` kernel module is added where kernel's IP early demux functionality is disabled. This fallback is enabled by default if it is needed for correct policy enforcement and visibility functionality. This fallback may be disabled by setting `enable-xt-socket-fallback=false`.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10299)
<!-- Reviewable:end -->
