### PR TITLE
monitor: Remove listener from monitor before calling Close()

### DIFF
--- a/pkg/monitor/agent/listener1_2.go
+++ b/pkg/monitor/agent/listener1_2.go
@@ -58,7 +58,6 @@ func (ml *listenerv1_2) Enqueue(pl *payload.Payload) {
 // intended to be a goroutine.
 func (ml *listenerv1_2) drainQueue() {
 	defer func() {
-		ml.Close()
 		ml.cleanupFn(ml)
 	}()
 

--- a/pkg/monitor/agent/monitor.go
+++ b/pkg/monitor/agent/monitor.go
@@ -141,11 +141,13 @@ func (m *Monitor) removeListener(ml listener.MonitorListener) {
 	m.Lock()
 	defer m.Unlock()
 
+	// Remove the listener and close it.
 	delete(m.listeners, ml)
 	log.WithFields(logrus.Fields{
 		"count.listener": len(m.listeners),
 		"version":        ml.Version(),
 	}).Debug("Removed listener")
+	ml.Close()
 
 	// If this was the final listener, shutdown the perf reader and unmap our
 	// ring buffer readers. This tells the kernel to not emit this data.


### PR DESCRIPTION
Otherwise monitor events might get sent to a closed queue.

Fixes: #10258

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10300)
<!-- Reviewable:end -->
