### PR TITLE
test/provision: Fix cilium.provision on running VM

### DIFF
--- a/test/provision/bpftool.sh
+++ b/test/provision/bpftool.sh
@@ -6,7 +6,12 @@
 
 set -e
 
-git clone --depth 1 -b bpftool https://github.com/cilium/linux.git $HOME/k-bpftool
+if [ -d "$HOME/k-bpftool" ]; then
+    cd $HOME/k-bpftool
+    git pull origin bpftool
+else
+    git clone --depth 1 -b bpftool https://github.com/cilium/linux.git $HOME/k-bpftool
+fi
 cd $HOME/k-bpftool/tools/bpf/bpftool
 make
 sudo make install


### PR DESCRIPTION
When launching the tests with `-cilium.provision=true` on an already running VM, it fails with the following error:
```
fatal: destination path 'k-bpftool' already exists and is not an empty directory.
```
This commit fixes it by detecting if the bpftool fork's repository already exists and avoiding trying to re-clone it.

Fixes: c4b6095d6 ("ci: Install bpftool from Cilium fork of the kernel")

/cc @mrostecki

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10301)
<!-- Reviewable:end -->
