### PR TITLE
backport v1.7 2020 02 24 fixes

### DIFF
--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -275,9 +275,15 @@ func (rc *remoteCluster) status() *models.RemoteCluster {
 	rc.mutex.RLock()
 	defer rc.mutex.RUnlock()
 
-	backendStatus, backendError := rc.backend.Status()
-	if backendError != nil {
-		backendStatus = backendError.Error()
+	// This can happen when the controller in restartRemoteConnection is waiting
+	// for the first connection to succeed.
+	var backendStatus = "Backend not initialized"
+	if rc.backend != nil {
+		var backendError error
+		backendStatus, backendError = rc.backend.Status()
+		if backendError != nil {
+			backendStatus = backendError.Error()
+		}
 	}
 
 	return &models.RemoteCluster{


### PR DESCRIPTION
This was fixed then reverted in e01dd97f943ca5417b3410a4fecdda5bf4ef0bb4
(from https://github.com/cilium/cilium/pull/10212) due to a commit
ordering accident.

Fixes https://github.com/cilium/cilium/issues/10302

```release-note
Correct accidental partial revert of https://github.com/cilium/cilium/pull/10185 when reporting cluster status.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10303)
<!-- Reviewable:end -->
