### PR TITLE
doc: Fix AKS guide regression

### DIFF
--- a/Documentation/gettingstarted/k8s-install-aks.rst
+++ b/Documentation/gettingstarted/k8s-install-aks.rst
@@ -36,8 +36,6 @@ Kubernetes versions.
 Create an AKS Cluster
 =====================
 
-The full background on creating AKS clusters in advanced networking mode, see
-`this guide <https://docs.microsoft.com/en-us/azure/aks/configure-azure-cni>`_.
 You can use any method to create and deploy an AKS cluster with the exception
 of specifying the Network Policy option. Doing so will still work but will
 result in unwanted iptables rules being installed on all of your nodes.
@@ -55,55 +53,17 @@ the cluster is ready.
 
 .. code:: bash
 
-        export SP_PASSWORD=mySecurePassword
-        export RESOURCE_GROUP_NAME=myResourceGroup-NP
-        export CLUSTER_NAME=myAKSCluster
+        export RESOURCE_GROUP_NAME=group1
+        export CLUSTER_NAME=aks-test1
         export LOCATION=westus
 
-        # Create a resource group
         az group create --name $RESOURCE_GROUP_NAME --location $LOCATION
-
-        # Create a virtual network and subnet
-        az network vnet create \
-            --resource-group $RESOURCE_GROUP_NAME \
-            --name myVnet \
-            --address-prefixes 10.0.0.0/8 \
-            --subnet-name myAKSSubnet \
-            --subnet-prefix 10.240.0.0/16
-
-        # Create a service principal and read in the application ID
-        SP_ID_PASSWORD=$(az ad sp create-for-rbac --skip-assignment --query [appId,password] -o tsv)
-        SP_ID=$(echo ${SP_ID_PASSWORD} | sed -e 's/ .*//g')
-        SP_PASSWORD=$(echo ${SP_ID_PASSWORD} | sed -e 's/.* //g')
-        unset SP_ID_PASSWORD
-
-        # Wait 15 seconds to make sure that service principal has propagated
-        echo "Waiting for service principal to propagate..."
-        sleep 15
-
-        # Get the virtual network resource ID
-        VNET_ID=$(az network vnet show --resource-group $RESOURCE_GROUP_NAME --name myVnet --query id -o tsv)
-
-        # Assign the service principal Contributor permissions to the virtual network resource
-        az role assignment create --assignee $SP_ID --scope $VNET_ID --role Contributor
-
-        # Get the virtual network subnet resource ID
-        SUBNET_ID=$(az network vnet subnet show --resource-group $RESOURCE_GROUP_NAME --vnet-name myVnet --name myAKSSubnet --query id -o tsv)
-
-        # Create the AKS cluster and specify the virtual network and service principal information
-        # Enable network policy by using the `--network-policy` parameter
         az aks create \
             --resource-group $RESOURCE_GROUP_NAME \
             --name $CLUSTER_NAME \
-            --node-count 1 \
+            --node-count 2 \
             --generate-ssh-keys \
-            --network-plugin azure \
-            --service-cidr 10.0.0.0/16 \
-            --dns-service-ip 10.0.0.10 \
-            --docker-bridge-address 172.17.0.1/16 \
-            --vnet-subnet-id $SUBNET_ID \
-            --service-principal $SP_ID \
-            --client-secret $SP_PASSWORD
+            --network-plugin azure
 
 Configure kubectl to Point to Newly Created Cluster
 ===================================================
@@ -114,12 +74,6 @@ AKS cluster:
 .. code:: bash
 
     az aks get-credentials --resource-group $RESOURCE_GROUP_NAME --name $CLUSTER_NAME
-
-
-.. code:: bash
-
-    export KUBECONFIG=/Users/danwent/.kube/config
-
 
 To verify, you should see AKS in the name of the nodes when you run:
 

--- a/Documentation/gettingstarted/k8s-install-azure-cni-steps.rst
+++ b/Documentation/gettingstarted/k8s-install-azure-cni-steps.rst
@@ -1,11 +1,3 @@
-Limitations
-===========
-
-* Due to the architecture of the Azure CNI plugin, Layer 7 network policies and
-  visibility including FQDN policies are currently not supported in this
-  chaining mode.  The upcoming native Azure IPAM mode will support all L7
-  network policies.
-
 Create an AKS + Cilium CNI configuration
 ========================================
 
@@ -28,6 +20,7 @@ desired CNI chaining configuration:
           "plugins": [
             {
               "type": "azure-vnet",
+              "mode": "transparent",
               "bridge": "azure0",
               "ipam": {
                  "type": "azure-vnet-ipam"
@@ -73,6 +66,7 @@ Deploy Cilium release via Helm:
      --set global.cni.chainingMode=generic-veth \\
      --set global.cni.customConf=true \\
      --set global.nodeinit.enabled=true \\
+     --set nodeinit.azure=true \\
      --set global.cni.configMap=cni-configuration \\
      --set global.tunnel=disabled \\
      --set global.masquerade=false

--- a/Documentation/gettingstarted/k8s-install-connectivity-test.rst
+++ b/Documentation/gettingstarted/k8s-install-connectivity-test.rst
@@ -28,4 +28,4 @@ indicates success or failure of the test:
     pod-to-b-intra-node-9d9d4d6f9-qccfs                      1/1     Running            0          8m35s
     pod-to-b-multi-node-clusterip-5956c84b7c-hwzfg           1/1     Running            0          8m35s
     pod-to-b-multi-node-headless-6698899447-xlhfw            1/1     Running            0          8m35s
-    pod-to-external-fqdn-allow-google-cnp-667649bbf6-v6rf8   0/1     Running            0          8m35s
+    pod-to-external-fqdn-allow-google-cnp-667649bbf6-v6rf8   1/1     Running            0          8m35s

--- a/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
@@ -56,6 +56,18 @@ spec:
                       while crictl ps | grep -v "node-init" | grep -q "POD_cilium"; do sleep 1; done
                     fi
 
+{{- if .Values.azure }}
+                    # Azure specific: Transparent bridge mode is required in
+                    # order for proxy-redirection to work
+                    until [ -f /var/run/azure-vnet.json ]; do
+                      echo waiting for azure-vnet to be created
+                      sleep 1s
+                    done
+                    if [ -f /var/run/azure-vnet.json ]; then
+                      sed -i 's/"Mode": "bridge",/"Mode": "transparent",/g' /var/run/azure-vnet.json
+                    fi
+{{- end }}
+
                     systemctl disable sys-fs-bpf.mount || true
                     systemctl stop sys-fs-bpf.mount || true
 


### PR DESCRIPTION
The commit 112dcb85c7f has removed the nodeinit code to put the Azure bridge
into transparent mode. While this worked for all routing operations, it broke
proxy redirection. Partially undo 112dcb85c7f and simplify the AKS guide.

Fixes: 112dcb85c7f ("doc: Fix AKS installation guide")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10308)
<!-- Reviewable:end -->
