### PR TITLE
doc: Add helm version requirements updated install URL to GKE install guide

### DIFF
--- a/Documentation/gettingstarted/k8s-install-download-release.rst
+++ b/Documentation/gettingstarted/k8s-install-download-release.rst
@@ -1,5 +1,5 @@
-`Install Helm`_ to prepare generating the deployment artifacts based on the
-Helm templates.
+`Install Helm`_ version 3.0.0 or higher to prepare generating the deployment
+artifacts based on the Helm templates.
 
 .. _Install Helm: https://helm.sh/docs/using_helm/#install-helm
 


### PR DESCRIPTION
doc: Add helm version requirements updated install URL to GKE install guide

users have reported not being able to complete the installation guide on GKE
using helm version 2.x however, the guide assumes version 3.x or higher. The installation
guide for Helm CLI version 3.x has moved to a new URL.

Fixes: #10314

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10315)
<!-- Reviewable:end -->
