### PR TITLE
ci: No error if there are no terminating ns

### DIFF
--- a/test/gke/delete-terminating-namespaces.sh
+++ b/test/gke/delete-terminating-namespaces.sh
@@ -2,4 +2,6 @@
 
 # because of https://github.com/kubernetes/kubernetes/issues/60807 , we may end up with garbage terminating
 # namespaces leftovers after tests. This is a hacky workaround
-kubectl get ns | grep Terminating | awk '{print $1}' | xargs -n 1 bash -c 'kubectl get ns -o json $1 | tr -d "\n" | sed "s/\"finalizers\": \[[^]]\+\]/\"finalizers\": []/" | kubectl replace --raw /api/v1/namespaces/$1/finalize -f -' -
+kubectl get ns | \
+	awk '/Terminating/ {print $1}' | \
+   	xargs -n 1 bash -c 'if [ "$#" -ne 1 ]; then exit 0; fi; kubectl get ns -o json $1 | tr -d "\n" | sed "s/\"finalizers\": \[[^]]\+\]/\"finalizers\": []/" | kubectl replace --raw /api/v1/namespaces/$1/finalize -f -' -


### PR DESCRIPTION
test/gke/delete-terminating-namespaces.sh was erroring out when there
were not terminating namespaces in cluster.

This change adds a check to the script that fixes that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10318)
<!-- Reviewable:end -->
