### PR TITLE
docs: Drop k8s 1.10 from supported/tested versions

### DIFF
--- a/Documentation/kubernetes/requirements.rst
+++ b/Documentation/kubernetes/requirements.rst
@@ -16,7 +16,6 @@ Kubernetes Version
 The following Kubernetes versions have been tested in the continuous integration
 system for this version of Cilium:
 
-* 1.10
 * 1.11
 * 1.12
 * 1.13


### PR DESCRIPTION
k8s 1.10 is no longer run in the CI, so don't say so in the docs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10319)
<!-- Reviewable:end -->
