### PR TITLE
doc: Fix links to contributing guide 

### DIFF
--- a/.github/cilium-actions.yml
+++ b/.github/cilium-actions.yml
@@ -33,7 +33,7 @@ move-to-projects-for-labels-xored:
       column: "Backport done to v1.5"
 require-msgs-in-commit:
   - msg: "Signed-off-by"
-    helper: "https://docs.cilium.io/en/stable/contributing/contributing/#developer-s-certificate-of-origin"
+    helper: "https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#developer-s-certificate-of-origin"
     set-labels:
       - "dont-merge/needs-sign-off"
 block-pr-with:

--- a/.github/cilium-actions.yml
+++ b/.github/cilium-actions.yml
@@ -33,7 +33,7 @@ move-to-projects-for-labels-xored:
       column: "Backport done to v1.5"
 require-msgs-in-commit:
   - msg: "Signed-off-by"
-    helper: "http://docs.cilium.io/en/stable/contributing/development/contributing_guide/#developer-s-certificate-of-origin"
+    helper: "https://docs.cilium.io/en/stable/contributing/contributing/#developer-s-certificate-of-origin"
     set-labels:
       - "dont-merge/needs-sign-off"
 block-pr-with:

--- a/.github/cilium-actions.yml
+++ b/.github/cilium-actions.yml
@@ -33,7 +33,7 @@ move-to-projects-for-labels-xored:
       column: "Backport done to v1.5"
 require-msgs-in-commit:
   - msg: "Signed-off-by"
-    helper: "https://docs.cilium.io/en/stable/contributing/contributing/#developer-s-certificate-of-origin"
+    helper: "http://docs.cilium.io/en/stable/contributing/development/contributing_guide/#developer-s-certificate-of-origin"
     set-labels:
       - "dont-merge/needs-sign-off"
 block-pr-with:

--- a/README.rst
+++ b/README.rst
@@ -266,7 +266,7 @@ under the `General Public License, Version 2.0 <bpf/COPYING>`_.
 .. _`Architecture and Concepts`: http://docs.cilium.io/en/stable/concepts/
 .. _`Installing Cilium`: http://docs.cilium.io/en/stable/gettingstarted/#installation
 .. _`Frequently Asked Questions`: https://github.com/cilium/cilium/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3Akind%2Fquestion+
-.. _Contributing: http://docs.cilium.io/en/stable/contributing/contributing/
+.. _Contributing: http://docs.cilium.io/en/stable/contributing/development/
 .. _Prerequisites: http://docs.cilium.io/en/doc-1.0/install/system_requirements
 .. _`BPF and XDP Reference Guide`: http://docs.cilium.io/en/stable/bpf/
 


### PR DESCRIPTION
Fixes the link to the contributing guide in the main README.rst and cilium-actions.yaml
The previous link pointed to a folder structure that had changed recently.
Fixes: #10316

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10322)
<!-- Reviewable:end -->
