### PR TITLE
Add PodSecurityPolicies to helm chart

### DIFF
--- a/install/kubernetes/cilium/charts/agent/templates/podsecuritypolicy.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/podsecuritypolicy.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.global.psp.enabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: cilium-psp
+spec:
+  privileged: true
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+    - NET_ADMIN
+    - SYS_MODULE
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'hostPath'
+  hostNetwork: true
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cilium-psp
+rules:
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - cilium-psp
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cilium-psp
+roleRef:
+  kind: ClusterRole
+  name: cilium-psp
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: cilium
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/install/kubernetes/cilium/charts/operator/templates/podsecuritypolicy.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/podsecuritypolicy.yaml
@@ -1,0 +1,59 @@
+{{- if .Values.global.psp.enabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: cilium-operator-psp
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+    - ALL
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+  hostNetwork: true
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cilium-operator-psp
+rules:
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - cilium-operator-psp
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cilium-operator-psp
+roleRef:
+  kind: ClusterRole
+  name: cilium-operator-psp
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: cilium-operator
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -291,7 +291,7 @@ global:
     # enabled enables go pprof debugging
     enabled: false
 
-  # logSytemLoad enables logging of system load 
+  # logSytemLoad enables logging of system load
   logSystemLoad: false
 
   # sockops is the BPF socket operations configuration
@@ -342,3 +342,7 @@ global:
   remoteNodeIdentity: true
 
   synchronizeK8sNodes: true
+
+  # psp creates and binds PodSecurityPolicies for the components that require it
+  psp:
+    enabled: false

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -97,6 +97,7 @@ var (
 		"global.etcd.leaseTTL":          "30s",
 		"global.ipv4.enabled":           "true",
 		"global.ipv6.enabled":           "true",
+		"global.psp.enabled":            "true",
 	}
 
 	flannelHelmOverrides = map[string]string{

--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -143,11 +143,11 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldHelmChartVers
 		_ = kubectl.ExecMiddle("helm delete cilium --namespace=" + helpers.CiliumNamespace)
 		_ = kubectl.ExecMiddle(fmt.Sprintf("kubectl delete configmap --namespace=%s cilium-config", helpers.CiliumNamespace))
 		_ = kubectl.ExecMiddle(fmt.Sprintf("kubectl delete serviceaccount --namespace=%s cilium cilium-operator", helpers.CiliumNamespace))
-		_ = kubectl.ExecMiddle(fmt.Sprintf("kubectl delete clusterrole --namespace=%s cilium cilium-operator cilium-psp cilium-operator-psp", helpers.CiliumNamespace))
-		_ = kubectl.ExecMiddle(fmt.Sprintf("kubectl delete clusterrolebinding --namespace=%s cilium cilium-operator cilium-psp cilium-operator-psp", helpers.CiliumNamespace))
+		_ = kubectl.ExecMiddle("kubectl delete clusterrole cilium cilium-operator cilium-psp cilium-operator-psp")
+		_ = kubectl.ExecMiddle("kubectl delete clusterrolebinding cilium cilium-operator cilium-psp cilium-operator-psp")
 		_ = kubectl.ExecMiddle(fmt.Sprintf("kubectl delete daemonset --namespace=%s cilium", helpers.CiliumNamespace))
 		_ = kubectl.ExecMiddle(fmt.Sprintf("kubectl delete deployment --namespace=%s cilium-operator", helpers.CiliumNamespace))
-		_ = kubectl.ExecMiddle(fmt.Sprintf("kubectl delete podsecuritypolicy --namespace=%s cilium-psp cilium-operator-psp", helpers.CiliumNamespace))
+		_ = kubectl.ExecMiddle("kubectl delete podsecuritypolicy cilium-psp cilium-operator-psp")
 		ExpectAllPodsTerminated(kubectl)
 		opts := map[string]string{
 			"global.cleanState":    "true",

--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -143,10 +143,11 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldHelmChartVers
 		_ = kubectl.ExecMiddle("helm delete cilium --namespace=" + helpers.CiliumNamespace)
 		_ = kubectl.ExecMiddle(fmt.Sprintf("kubectl delete configmap --namespace=%s cilium-config", helpers.CiliumNamespace))
 		_ = kubectl.ExecMiddle(fmt.Sprintf("kubectl delete serviceaccount --namespace=%s cilium cilium-operator", helpers.CiliumNamespace))
-		_ = kubectl.ExecMiddle(fmt.Sprintf("kubectl delete clusterrole --namespace=%s cilium cilium-operator", helpers.CiliumNamespace))
-		_ = kubectl.ExecMiddle(fmt.Sprintf("kubectl delete clusterrolebinding --namespace=%s cilium cilium-operator", helpers.CiliumNamespace))
+		_ = kubectl.ExecMiddle(fmt.Sprintf("kubectl delete clusterrole --namespace=%s cilium cilium-operator cilium-psp cilium-operator-psp", helpers.CiliumNamespace))
+		_ = kubectl.ExecMiddle(fmt.Sprintf("kubectl delete clusterrolebinding --namespace=%s cilium cilium-operator cilium-psp cilium-operator-psp", helpers.CiliumNamespace))
 		_ = kubectl.ExecMiddle(fmt.Sprintf("kubectl delete daemonset --namespace=%s cilium", helpers.CiliumNamespace))
 		_ = kubectl.ExecMiddle(fmt.Sprintf("kubectl delete deployment --namespace=%s cilium-operator", helpers.CiliumNamespace))
+		_ = kubectl.ExecMiddle(fmt.Sprintf("kubectl delete podsecuritypolicy --namespace=%s cilium-psp cilium-operator-psp", helpers.CiliumNamespace))
 		ExpectAllPodsTerminated(kubectl)
 		opts := map[string]string{
 			"global.cleanState":    "true",

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -248,8 +248,8 @@ case $K8S_VERSION in
         KUBEADM_SLAVE_OPTIONS="--discovery-token-unsafe-skip-ca-verification --ignore-preflight-errors=cri,SystemVerification"
         sudo ln -sf $COREDNS_DEPLOYMENT $DNS_DEPLOYMENT
         KUBEADM_CONFIG="${KUBEADM_CONFIG_ALPHA3}"
-        CONTROLLER_FEATURE_GATES="EndpointSlice=true"
-        API_SERVER_FEATURE_GATES="EndpointSlice=true"
+        CONTROLLER_FEATURE_GATES="EndpointSlice=true,PodSecurityPolicy=true"
+        API_SERVER_FEATURE_GATES="EndpointSlice=true,PodSecurityPolicy=true"
         ;;
 esac
 


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

Adds PodSecurityPolicies for each the operator and the agent granting
minimal privileges to run them to their respective ServiceAccounts. Also
adds a new value global.psp.enabled for enabling the PSPs which defaults
to false (no PSP is deployed).

Fixes: #9978

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10330)
<!-- Reviewable:end -->
