### PR TITLE
daemon: Do not auto enable hybrid DSR mode

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -130,7 +130,7 @@ cilium-agent [flags]
       --monitor-queue-size int                                Size of the event queue when reading monitor events
       --mtu int                                               Overwrite auto-detected MTU of underlying network
       --nat46-range string                                    IPv6 prefix to map IPv4 addresses to (default "0:0:0:0:0:FFFF::/96")
-      --node-port-mode string                                 BPF NodePort mode ("snat", "dsr", "hybrid") (default "snat")
+      --node-port-mode string                                 BPF NodePort mode ("snat", "dsr", "hybrid") (default "hybrid")
       --node-port-range strings                               Set the min/max NodePort port range (default [30000,32767])
       --policy-queue-size int                                 size of queues for policy-related events (default 100)
       --pprof                                                 Enable serving the pprof debugging API

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -284,15 +284,12 @@ Hybrid DSR and SNAT Mode
 
 Cilium also supports a hybrid DSR and SNAT mode, that is, DSR is performed for TCP
 and SNAT for UDP connections. This has the advantage that it removes the need for
-manual MTU changes in the network while still benefitting from the latency improvements
+manual MTU changes in the network while still benefiting from the latency improvements
 through the removed extra hop for replies, in particular, when TCP is the main transport
 for workloads.
 
 The mode setting ``global.nodePort.mode`` allows to control the behavior through the
-options ``dsr``, ``snat`` and ``hybrid``. While Cilium's BPF NodePort implementation
-operates in SNAT mode by default, the ``hybrid`` mode is automatically enabled for the
-``global.kubeProxyReplacement`` settings with value ``probe`` or ``strict`` in order to
-transparently benefit from the optimization.
+options ``dsr``, ``snat`` and ``hybrid``.
 
 A helm example configuration in a kube-proxy-free environment with DSR enabled in hybrid
 mode would look as follows:

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -499,7 +499,7 @@ func init() {
 	flags.Bool(option.EnableNodePort, false, "Enable NodePort type services by Cilium (beta)")
 	option.BindEnv(option.EnableNodePort)
 
-	flags.String(option.NodePortMode, defaults.NodePortMode, "BPF NodePort mode (\"snat\", \"dsr\", \"hybrid\")")
+	flags.String(option.NodePortMode, option.NodePortModeHybrid, "BPF NodePort mode (\"snat\", \"dsr\", \"hybrid\")")
 	option.BindEnv(option.NodePortMode)
 
 	flags.StringSlice(option.NodePortRange, []string{fmt.Sprintf("%d", option.NodePortMinDefault), fmt.Sprintf("%d", option.NodePortMaxDefault)}, fmt.Sprintf("Set the min/max NodePort port range"))
@@ -1450,12 +1450,6 @@ func initKubeProxyReplacementOptions() {
 		log.Infof("Auto-enabling %q, %q, %q features", option.EnableNodePort,
 			option.EnableExternalIPs, option.EnableHostReachableServices)
 
-		if option.Config.Tunnel == option.TunnelDisabled {
-			log.Infof("Auto-enabling NodePort's %q mode feature to enable DSR for TCP",
-				option.NodePortModeHybrid)
-			option.Config.NodePortMode = option.NodePortModeHybrid
-		}
-
 		option.Config.EnableNodePort = true
 		option.Config.EnableExternalIPs = true
 		option.Config.EnableHostReachableServices = true
@@ -1480,15 +1474,6 @@ func initKubeProxyReplacementOptions() {
 			option.Config.NodePortMode != option.NodePortModeDSR &&
 			option.Config.NodePortMode != option.NodePortModeHybrid {
 			log.Fatalf("Invalid value for --%s: %s", option.NodePortMode, option.Config.NodePortMode)
-		}
-
-		if (option.Config.NodePortMode == option.NodePortModeDSR ||
-			option.Config.NodePortMode == option.NodePortModeHybrid) &&
-			option.Config.Tunnel != option.TunnelDisabled {
-			// Currently, DSR does not work in the tunnel mode. Once it's fixed,
-			// the constraint can be removed. Also hybrid can be set to default
-			// in tunnel mode for the probe case above.
-			log.Fatal("DSR cannot be used with tunnel")
 		}
 	}
 
@@ -1576,6 +1561,14 @@ func initKubeProxyReplacementOptions() {
 
 	if !option.Config.EnableNodePort {
 		option.Config.EnableExternalIPs = false
+	} else {
+		if option.Config.Tunnel != option.TunnelDisabled &&
+			option.Config.NodePortMode != option.NodePortModeSNAT {
+
+			log.Warnf("Disabling NodePort's %q mode feature due to tunneling mode being enabled",
+				option.Config.NodePortMode)
+			option.Config.NodePortMode = option.NodePortModeSNAT
+		}
 	}
 }
 

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -245,8 +245,8 @@ global:
     # device is the name of the device handling NodePort requests
     # device:
 
-    # dsr enables direct server return for NodePort services
-    dsr: false
+    # mode is the mode of NodePort feature
+    mode: "hybrid"
 
   # externalIPs is the configuration for ExternalIPs service handling
   externalIPs:

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -344,9 +344,6 @@ const (
 	// EnableRemoteNodeIdentity is the default value for option.EnableRemoteNodeIdentity
 	EnableRemoteNodeIdentity = false
 
-	// NodePortMode is the default value for option.NodePortMode
-	NodePortMode = "snat"
-
 	// IPAMExpiration is the timeout after which an IP subject to expiratio
 	// is being released again if no endpoint is being created in time.
 	IPAMExpiration = 3 * time.Minute


### PR DESCRIPTION
This commit removes auto-enabling of the hybrid DSR mode to allow users to opt-out from any DSR mode when running in strict/probe mode.

Instead, default to the hybrid mode, and disable it w/o panicking if running with a tunnel being enabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10332)
<!-- Reviewable:end -->
