### PR TITLE
bpf: convert datapath over to generic ctx type

### DIFF
--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -4,7 +4,7 @@ include ../Makefile.defs
 
 SUBDIRS = sockops
 
-BPF_SIMPLE = bpf_xdp.o bpf_ipsec.o bpf_network.o bpf_alignchecker.o bpf_hostdev_ingress.o
+BPF_SIMPLE = bpf_prefilter.o bpf_ipsec.o bpf_network.o bpf_alignchecker.o bpf_hostdev_ingress.o
 BPF = bpf_lxc.o bpf_overlay.o bpf_sock.o bpf_netdev.o $(BPF_SIMPLE)
 
 TARGET=cilium-map-migrate

--- a/bpf/bpf_alignchecker.c
+++ b/bpf/bpf_alignchecker.c
@@ -22,6 +22,9 @@
 #define DROP_NOTIFY
 #define POLICY_VERDICT_NOTIFY
 
+#include <bpf/ctx/unspec.h>
+#include <bpf/api.h>
+
 #include "node_config.h"
 #include "lib/conntrack.h"
 #include "lib/dbg.h"

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -15,15 +15,15 @@
  *  along with this program; if not, write to the Free Software
  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
+#include <bpf/ctx/skb.h>
+#include <bpf/api.h>
+
 #include <node_config.h>
 #include <lxc_config.h>
 
-#define EVENT_SOURCE LXC_ID
-
-#include <bpf/api.h>
-
 #include <linux/icmpv6.h>
-#include <linux/if_packet.h>
+
+#define EVENT_SOURCE LXC_ID
 
 #include "lib/tailcall.h"
 #include "lib/utils.h"
@@ -64,7 +64,7 @@ static inline bool redirect_to_proxy(int verdict, __u8 dir)
 #endif
 
 #ifdef ENABLE_IPV6
-static inline int ipv6_l3_from_lxc(struct __sk_buff *skb,
+static inline int ipv6_l3_from_lxc(struct __ctx_buff *ctx,
 				   struct ipv6_ct_tuple *tuple, int l3_off,
 				   struct ipv6hdr *ip6, __u32 *dstID)
 {
@@ -91,13 +91,13 @@ static inline int ipv6_l3_from_lxc(struct __sk_buff *skb,
 	ipv6_addr_copy(&tuple->daddr, (union v6addr *) &ip6->daddr);
 	ipv6_addr_copy(&tuple->saddr, (union v6addr *) &ip6->saddr);
 
-	hdrlen = ipv6_hdrlen(skb, l3_off, &tuple->nexthdr);
+	hdrlen = ipv6_hdrlen(ctx, l3_off, &tuple->nexthdr);
 	if (hdrlen < 0)
 		return hdrlen;
 
 	l4_off = l3_off + hdrlen;
 
-	ret = lb6_extract_key(skb, tuple, l4_off, &key, &csum_off, CT_EGRESS);
+	ret = lb6_extract_key(ctx, tuple, l4_off, &key, &csum_off, CT_EGRESS);
 	if (IS_ERR(ret)) {
 		if (ret == DROP_UNKNOWN_L4)
 			goto skip_service_lookup;
@@ -119,8 +119,8 @@ static inline int ipv6_l3_from_lxc(struct __sk_buff *skb,
 	{
 		struct lb6_service *svc;
 
-		if ((svc = lb6_lookup_service(skb, &key)) != NULL) {
-			ret = lb6_local(get_ct_map6(tuple), skb, l3_off, l4_off,
+		if ((svc = lb6_lookup_service(ctx, &key)) != NULL) {
+			ret = lb6_local(get_ct_map6(tuple), ctx, l3_off, l4_off,
 					&csum_off, &key, tuple, svc, &ct_state_new);
 			if (IS_ERR(ret))
 				return ret;
@@ -147,7 +147,7 @@ skip_service_lookup:
 	 * entry to allow reverse packets and return set cb[CB_POLICY] to
 	 * POLICY_SKIP if the packet is a reply packet to an existing
 	 * incoming connection. */
-	ret = ct_lookup6(get_ct_map6(tuple), tuple, skb, l4_off, CT_EGRESS,
+	ret = ct_lookup6(get_ct_map6(tuple), tuple, ctx, l4_off, CT_EGRESS,
 			 &ct_state, &monitor);
 	if (ret < 0) {
 		return ret;
@@ -158,10 +158,10 @@ skip_service_lookup:
 	// Check it this is return traffic to an ingress proxy.
 	if ((ret == CT_REPLY || ret == CT_RELATED) && ct_state.proxy_redirect) {
 		// Stack will do a socket match and deliver locally
-		return skb_redirect_to_proxy(skb, 0);
+		return ctx_redirect_to_proxy(ctx, 0);
 	}
 
-	if (!revalidate_data(skb, &data, &data_end, &ip6))
+	if (!revalidate_data(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 
 	/* Determine the destination category for policy fallback. */
@@ -177,23 +177,23 @@ skip_service_lookup:
 			*dstID = WORLD_ID;
 		}
 
-		cilium_dbg(skb, info ? DBG_IP_ID_MAP_SUCCEED6 : DBG_IP_ID_MAP_FAILED6,
+		cilium_dbg(ctx, info ? DBG_IP_ID_MAP_SUCCEED6 : DBG_IP_ID_MAP_FAILED6,
 			   orig_dip.p4, *dstID);
 	}
 
 	/* If the packet is in the establishing direction and it's destined
 	 * within the cluster, it must match policy or be dropped. If it's
 	 * bound for the host/outside, perform the CIDR policy check. */
-	verdict = policy_can_egress6(skb, tuple, *dstID, &policy_match_type);
+	verdict = policy_can_egress6(ctx, tuple, *dstID, &policy_match_type);
 	if (ret != CT_REPLY && ret != CT_RELATED && verdict < 0) {
-		send_policy_verdict_notify(skb, *dstID, tuple->dport, tuple->nexthdr,
+		send_policy_verdict_notify(ctx, *dstID, tuple->dport, tuple->nexthdr,
 						POLICY_EGRESS, 1, verdict, policy_match_type);
 		return verdict;
 	}
 
 	switch (ret) {
 	case CT_NEW:
-		send_policy_verdict_notify(skb, *dstID, tuple->dport, tuple->nexthdr,
+		send_policy_verdict_notify(ctx, *dstID, tuple->dport, tuple->nexthdr,
 						POLICY_EGRESS, 1, verdict, policy_match_type);
 ct_recreate6:
 		/* New connection implies that rev_nat_index remains untouched
@@ -202,7 +202,7 @@ ct_recreate6:
 		 * reverse NAT.
 		 */
 		ct_state_new.src_sec_id = SECLABEL;
-		ret = ct_create6(get_ct_map6(tuple), tuple, skb, CT_EGRESS, &ct_state_new, verdict > 0);
+		ret = ct_create6(get_ct_map6(tuple), tuple, ctx, CT_EGRESS, &ct_state_new, verdict > 0);
 		if (IS_ERR(ret))
 			return ret;
 		monitor = TRACE_PAYLOAD_LEN;
@@ -211,39 +211,39 @@ ct_recreate6:
 	case CT_ESTABLISHED:
 		/* Did we end up at a stale non-service entry? Recreate if so. */
 		if (unlikely(ct_state.rev_nat_index != ct_state_new.rev_nat_index)) {
-			ct_delete6(get_ct_map6(tuple), tuple, skb);
+			ct_delete6(get_ct_map6(tuple), tuple, ctx);
 			goto ct_recreate6;
 		}
 		break;
 
 	case CT_RELATED:
 	case CT_REPLY:
-		policy_mark_skip(skb);
+		policy_mark_skip(ctx);
 
 #ifdef ENABLE_NODEPORT
 		/* See comment in handle_ipv4_from_lxc(). */
 		if (ct_state.node_port) {
-			skb->tc_index |= TC_INDEX_F_SKIP_RECIRCULATION;
-			ep_tail_call(skb, CILIUM_CALL_IPV6_NODEPORT_REVNAT);
+			ctx->tc_index |= TC_INDEX_F_SKIP_RECIRCULATION;
+			ep_tail_call(ctx, CILIUM_CALL_IPV6_NODEPORT_REVNAT);
 			return DROP_MISSED_TAIL_CALL;
 		}
 # ifdef ENABLE_DSR
 		if (ct_state.dsr) {
-			ret = xlate_dsr_v6(skb, tuple, l4_off);
+			ret = xlate_dsr_v6(ctx, tuple, l4_off);
 			if (ret != 0)
 				return ret;
 		}
 # endif /* ENABLE_DSR */
 #endif /* ENABLE_NODEPORT */
 		if (ct_state.rev_nat_index) {
-			ret = lb6_rev_nat(skb, l4_off, &csum_off,
+			ret = lb6_rev_nat(ctx, l4_off, &csum_off,
 					  ct_state.rev_nat_index, tuple, 0);
 			if (IS_ERR(ret))
 				return ret;
 
 			/* A reverse translate packet is always allowed except for delivery
 			 * on the local node in which case this marking is cleared again. */
-			policy_mark_skip(skb);
+			policy_mark_skip(ctx);
 		}
 		break;
 
@@ -255,12 +255,12 @@ ct_recreate6:
 
 	if (redirect_to_proxy(verdict, reason)) {
 		// Trace the packet before its forwarded to proxy
-		send_trace_notify(skb, TRACE_TO_PROXY, SECLABEL, 0,
+		send_trace_notify(ctx, TRACE_TO_PROXY, SECLABEL, 0,
 				  0, 0, reason, monitor);
-		return skb_redirect_to_proxy(skb, verdict);
+		return ctx_redirect_to_proxy(ctx, verdict);
 	}
 
-	if (!revalidate_data(skb, &data, &data_end, &ip6))
+	if (!revalidate_data(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 
 	daddr = (union v6addr *)&ip6->daddr;
@@ -285,8 +285,8 @@ ct_recreate6:
 #endif
 			}
 #endif /* ENABLE_ROUTING */
-			policy_clear_mark(skb);
-			return ipv6_local_delivery(skb, l3_off, l4_off, SECLABEL,
+			policy_clear_mark(ctx);
+			return ipv6_local_delivery(ctx, l3_off, l4_off, SECLABEL,
 						   ip6, tuple->nexthdr, ep,
 						   METRIC_EGRESS);
 		}
@@ -311,10 +311,10 @@ ct_recreate6:
 
 		/* Three cases exist here either (a) the encap and redirect could
 		 * not find the tunnel so fallthrough to nat46 and stack, (b)
-		 * the packet needs IPSec encap so push skb to stack for encap, or
+		 * the packet needs IPSec encap so push ctx to stack for encap, or
 		 * (c) packet was redirected to tunnel device so return.
 		 */
-		ret = encap_and_redirect_lxc(skb, tunnel_endpoint, encrypt_key, &key, SECLABEL, monitor);
+		ret = encap_and_redirect_lxc(ctx, tunnel_endpoint, encrypt_key, &key, SECLABEL, monitor);
 		if (ret == IPSEC_ENDPOINT)
 			goto pass_to_stack;
 		else if (ret != DROP_NO_TUNNEL_ENDPOINT)
@@ -324,7 +324,7 @@ ct_recreate6:
 
 #ifdef ENABLE_NAT46
 	if (unlikely(ipv6_addr_is_mapped(daddr))) {
-		ep_tail_call(skb, CILIUM_CALL_NAT64);
+		ep_tail_call(ctx, CILIUM_CALL_NAT64);
 		return DROP_MISSED_TAIL_CALL;
 	}
 #endif
@@ -335,55 +335,55 @@ to_host:
 	if (is_defined(ENABLE_HOST_REDIRECT)) {
 		union macaddr host_mac = HOST_IFINDEX_MAC;
 
-		ret = ipv6_l3(skb, l3_off, (__u8 *) &router_mac.addr, (__u8 *) &host_mac.addr, METRIC_EGRESS);
-		if (ret != TC_ACT_OK)
+		ret = ipv6_l3(ctx, l3_off, (__u8 *) &router_mac.addr, (__u8 *) &host_mac.addr, METRIC_EGRESS);
+		if (ret != CTX_ACT_OK)
 			return ret;
 
-		send_trace_notify(skb, TRACE_TO_HOST, SECLABEL, HOST_ID, 0,
+		send_trace_notify(ctx, TRACE_TO_HOST, SECLABEL, HOST_ID, 0,
 				  HOST_IFINDEX, reason, monitor);
 
-		cilium_dbg_capture(skb, DBG_CAPTURE_DELIVERY, HOST_IFINDEX);
+		cilium_dbg_capture(ctx, DBG_CAPTURE_DELIVERY, HOST_IFINDEX);
 		return redirect(HOST_IFINDEX, 0);
 	}
 #endif
 
 pass_to_stack:
 #ifdef ENABLE_ROUTING
-	ret = ipv6_l3(skb, l3_off, NULL, (__u8 *) &router_mac.addr, METRIC_EGRESS);
-	if (unlikely(ret != TC_ACT_OK))
+	ret = ipv6_l3(ctx, l3_off, NULL, (__u8 *) &router_mac.addr, METRIC_EGRESS);
+	if (unlikely(ret != CTX_ACT_OK))
 		return ret;
 #endif
 
-	if (ipv6_store_flowlabel(skb, l3_off, SECLABEL_NB) < 0)
+	if (ipv6_store_flowlabel(ctx, l3_off, SECLABEL_NB) < 0)
 		return DROP_WRITE_ERROR;
 
-	send_trace_notify(skb, TRACE_TO_STACK, SECLABEL, *dstID, 0, 0,
+	send_trace_notify(ctx, TRACE_TO_STACK, SECLABEL, *dstID, 0, 0,
 			  reason, monitor);
 
-	cilium_dbg_capture(skb, DBG_CAPTURE_DELIVERY, 0);
+	cilium_dbg_capture(ctx, DBG_CAPTURE_DELIVERY, 0);
 #ifndef ENCAP_IFINDEX
 #ifdef ENABLE_IPSEC
 	if (encrypt_key && tunnel_endpoint) {
-		set_encrypt_key(skb, encrypt_key);
+		set_encrypt_key(ctx, encrypt_key);
 #ifdef IP_POOLS
-		set_encrypt_dip(skb, tunnel_endpoint);
+		set_encrypt_dip(ctx, tunnel_endpoint);
 #else
-		set_identity(skb, SECLABEL);
+		set_identity(ctx, SECLABEL);
 #endif
 	}
 #endif
 #endif
-	return TC_ACT_OK;
+	return CTX_ACT_OK;
 }
 
-static inline int __inline__ handle_ipv6(struct __sk_buff *skb, __u32 *dstID)
+static inline int __inline__ handle_ipv6(struct __ctx_buff *ctx, __u32 *dstID)
 {
 	struct ipv6_ct_tuple tuple = {};
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
 	int ret;
 
-	if (!revalidate_data(skb, &data, &data_end, &ip6))
+	if (!revalidate_data(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 
 	/* Handle special ICMPv6 messages. This includes echo requests to the
@@ -395,25 +395,25 @@ static inline int __inline__ handle_ipv6(struct __sk_buff *skb, __u32 *dstID)
 			return DROP_INVALID;
 		}
 
-		ret = icmp6_handle(skb, ETH_HLEN, ip6, METRIC_EGRESS);
+		ret = icmp6_handle(ctx, ETH_HLEN, ip6, METRIC_EGRESS);
 		if (IS_ERR(ret))
 			return ret;
 	}
 
 	/* Perform L3 action on the frame */
 	tuple.nexthdr = ip6->nexthdr;
-	return ipv6_l3_from_lxc(skb, &tuple, ETH_HLEN, ip6, dstID);
+	return ipv6_l3_from_lxc(ctx, &tuple, ETH_HLEN, ip6, dstID);
 }
 
 declare_tailcall_if(__and(is_defined(ENABLE_IPV4), is_defined(ENABLE_IPV6)), CILIUM_CALL_IPV6_FROM_LXC)
-int tail_handle_ipv6(struct __sk_buff *skb)
+int tail_handle_ipv6(struct __ctx_buff *ctx)
 {
 	__u32 dstID = 0;
-	int ret = handle_ipv6(skb, &dstID);
+	int ret = handle_ipv6(ctx, &dstID);
 
 	if (IS_ERR(ret)) {
 		relax_verifier();
-		return send_drop_notify(skb, SECLABEL, dstID, 0, ret, TC_ACT_SHOT,
+		return send_drop_notify(ctx, SECLABEL, dstID, 0, ret, CTX_ACT_DROP,
 		                        METRIC_EGRESS);
 	}
 
@@ -422,7 +422,7 @@ int tail_handle_ipv6(struct __sk_buff *skb)
 #endif /* ENABLE_IPV6 */
 
 #ifdef ENABLE_IPV4
-static inline int handle_ipv4_from_lxc(struct __sk_buff *skb, __u32 *dstID)
+static inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx, __u32 *dstID)
 {
 	struct ipv4_ct_tuple tuple = {};
 #ifdef ENABLE_ROUTING
@@ -443,7 +443,7 @@ static inline int handle_ipv4_from_lxc(struct __sk_buff *skb, __u32 *dstID)
 	bool hairpin_flow = false; // endpoint wants to access itself via service IP
 	__u8 policy_match_type = POLICY_MATCH_NONE;
 
-	if (!revalidate_data(skb, &data, &data_end, &ip4))
+	if (!revalidate_data(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
 
 	tuple.nexthdr = ip4->protocol;
@@ -456,7 +456,7 @@ static inline int handle_ipv4_from_lxc(struct __sk_buff *skb, __u32 *dstID)
 
 	l4_off = l3_off + ipv4_hdrlen(ip4);
 
-	ret = lb4_extract_key(skb, &tuple, l4_off, &key, &csum_off, CT_EGRESS);
+	ret = lb4_extract_key(ctx, &tuple, l4_off, &key, &csum_off, CT_EGRESS);
 	if (IS_ERR(ret)) {
 		if (ret == DROP_UNKNOWN_L4)
 			goto skip_service_lookup;
@@ -470,8 +470,8 @@ static inline int handle_ipv4_from_lxc(struct __sk_buff *skb, __u32 *dstID)
 	{
 		struct lb4_service *svc;
 
-		if ((svc = lb4_lookup_service(skb, &key)) != NULL) {
-			ret = lb4_local(get_ct_map4(&tuple), skb, l3_off, l4_off, &csum_off,
+		if ((svc = lb4_lookup_service(ctx, &key)) != NULL) {
+			ret = lb4_local(get_ct_map4(&tuple), ctx, l3_off, l4_off, &csum_off,
 					&key, &tuple, svc, &ct_state_new, ip4->saddr);
 			if (IS_ERR(ret))
 				return ret;
@@ -497,7 +497,7 @@ skip_service_lookup:
 	 * entry to allow reverse packets and return set cb[CB_POLICY] to
 	 * POLICY_SKIP if the packet is a reply packet to an existing
 	 * incoming connection. */
-	ret = ct_lookup4(get_ct_map4(&tuple), &tuple, skb, l4_off, CT_EGRESS,
+	ret = ct_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off, CT_EGRESS,
 			 &ct_state, &monitor);
 	if (ret < 0)
 		return ret;
@@ -507,7 +507,7 @@ skip_service_lookup:
 	// Check it this is return traffic to an ingress proxy.
 	if ((ret == CT_REPLY || ret == CT_RELATED) && ct_state.proxy_redirect) {
 		// Stack will do a socket match and deliver locally
-		return skb_redirect_to_proxy(skb, 0);
+		return ctx_redirect_to_proxy(ctx, 0);
 	}
 
 	/* Determine the destination category for policy fallback. */
@@ -523,24 +523,24 @@ skip_service_lookup:
 			*dstID = WORLD_ID;
 		}
 
-		cilium_dbg(skb, info ? DBG_IP_ID_MAP_SUCCEED4 : DBG_IP_ID_MAP_FAILED4,
+		cilium_dbg(ctx, info ? DBG_IP_ID_MAP_SUCCEED4 : DBG_IP_ID_MAP_FAILED4,
 			   orig_dip, *dstID);
 	}
 
 	/* If the packet is in the establishing direction and it's destined
 	 * within the cluster, it must match policy or be dropped. If it's
 	 * bound for the host/outside, perform the CIDR policy check. */
-	verdict = policy_can_egress4(skb, &tuple, *dstID, &policy_match_type);
+	verdict = policy_can_egress4(ctx, &tuple, *dstID, &policy_match_type);
 
 	if (ret != CT_REPLY && ret != CT_RELATED && verdict < 0) {
-		send_policy_verdict_notify(skb, *dstID, tuple.dport, tuple.nexthdr,
+		send_policy_verdict_notify(ctx, *dstID, tuple.dport, tuple.nexthdr,
 						POLICY_EGRESS, 0, verdict, policy_match_type);
 		return verdict;
 	}
 
 	switch (ret) {
 	case CT_NEW:
-		send_policy_verdict_notify(skb, *dstID, tuple.dport, tuple.nexthdr,
+		send_policy_verdict_notify(ctx, *dstID, tuple.dport, tuple.nexthdr,
 						POLICY_EGRESS, 0, verdict, policy_match_type);
 ct_recreate4:
 		/* New connection implies that rev_nat_index remains untouched
@@ -549,7 +549,7 @@ ct_recreate4:
 		 * reverse NAT.
 		 */
 		ct_state_new.src_sec_id = SECLABEL;
-		ret = ct_create4(get_ct_map4(&tuple), &tuple, skb, CT_EGRESS,
+		ret = ct_create4(get_ct_map4(&tuple), &tuple, ctx, CT_EGRESS,
 				 &ct_state_new, verdict > 0);
 		if (IS_ERR(ret))
 			return ret;
@@ -558,14 +558,14 @@ ct_recreate4:
 	case CT_ESTABLISHED:
 		/* Did we end up at a stale non-service entry? Recreate if so. */
 		if (unlikely(ct_state.rev_nat_index != ct_state_new.rev_nat_index)) {
-			ct_delete4(get_ct_map4(&tuple), &tuple, skb);
+			ct_delete4(get_ct_map4(&tuple), &tuple, ctx);
 			goto ct_recreate4;
 		}
 		break;
 
 	case CT_RELATED:
 	case CT_REPLY:
-		policy_mark_skip(skb);
+		policy_mark_skip(ctx);
 
 #ifdef ENABLE_NODEPORT
 		/* This handles reply traffic for the case where the nodeport EP
@@ -573,13 +573,13 @@ ct_recreate4:
 		 * perform the reverse DNAT.
 		 */
 		if (ct_state.node_port) {
-			skb->tc_index |= TC_INDEX_F_SKIP_RECIRCULATION;
-			ep_tail_call(skb, CILIUM_CALL_IPV4_NODEPORT_REVNAT);
+			ctx->tc_index |= TC_INDEX_F_SKIP_RECIRCULATION;
+			ep_tail_call(ctx, CILIUM_CALL_IPV4_NODEPORT_REVNAT);
 			return DROP_MISSED_TAIL_CALL;
 		}
 # ifdef ENABLE_DSR
 		if (ct_state.dsr) {
-			ret = xlate_dsr_v4(skb, &tuple, l4_off);
+			ret = xlate_dsr_v4(ctx, &tuple, l4_off);
 			if (ret != 0)
 				return ret;
 		}
@@ -587,7 +587,7 @@ ct_recreate4:
 #endif /* ENABLE_NODEPORT */
 
 		if (ct_state.rev_nat_index) {
-			ret = lb4_rev_nat(skb, l3_off, l4_off, &csum_off,
+			ret = lb4_rev_nat(ctx, l3_off, l4_off, &csum_off,
 					  &ct_state, &tuple, 0);
 			if (IS_ERR(ret)) {
 				relax_verifier();
@@ -604,13 +604,13 @@ ct_recreate4:
 
 	if (redirect_to_proxy(verdict, reason)) {
 		// Trace the packet before its forwarded to proxy
-		send_trace_notify(skb, TRACE_TO_PROXY, SECLABEL, 0,
+		send_trace_notify(ctx, TRACE_TO_PROXY, SECLABEL, 0,
 				  0, 0, reason, monitor);
-		return skb_redirect_to_proxy(skb, verdict);
+		return ctx_redirect_to_proxy(ctx, verdict);
 	}
 
 	/* After L4 write in port mapping: revalidate for direct packet access */
-	if (!revalidate_data(skb, &data, &data_end, &ip4))
+	if (!revalidate_data(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
 
 	orig_dip = ip4->daddr;
@@ -639,8 +639,8 @@ ct_recreate4:
 #endif
 			}
 #endif /* ENABLE_ROUTING */
-			policy_clear_mark(skb);
-			return ipv4_local_delivery(skb, l3_off, l4_off, SECLABEL,
+			policy_clear_mark(ctx);
+			return ipv4_local_delivery(ctx, l3_off, l4_off, SECLABEL,
 						   ip4, ep, METRIC_EGRESS);
 		}
 	}
@@ -652,7 +652,7 @@ ct_recreate4:
 		key.ip4 = orig_dip & IPV4_MASK;
 		key.family = ENDPOINT_KEY_IPV4;
 
-		ret = encap_and_redirect_lxc(skb, tunnel_endpoint, encrypt_key, &key, SECLABEL, monitor);
+		ret = encap_and_redirect_lxc(ctx, tunnel_endpoint, encrypt_key, &key, SECLABEL, monitor);
 		if (ret == DROP_NO_TUNNEL_ENDPOINT)
 			goto pass_to_stack;
 		/* If not redirected noteably due to IPSEC then pass up to stack
@@ -661,7 +661,7 @@ ct_recreate4:
 		else if (ret == IPSEC_ENDPOINT)
 			goto pass_to_stack;
 		/* This is either redirect by encap code or an error has occured
-		 * either way return and stack will consume skb.
+		 * either way return and stack will consume ctx.
 		 */
 		else
 			return ret;
@@ -675,14 +675,14 @@ to_host:
 	if (is_defined(ENABLE_HOST_REDIRECT)) {
 		union macaddr host_mac = HOST_IFINDEX_MAC;
 
-		ret = ipv4_l3(skb, l3_off, (__u8 *) &router_mac.addr, (__u8 *) &host_mac.addr, ip4);
-		if (ret != TC_ACT_OK)
+		ret = ipv4_l3(ctx, l3_off, (__u8 *) &router_mac.addr, (__u8 *) &host_mac.addr, ip4);
+		if (ret != CTX_ACT_OK)
 			return ret;
 
-		send_trace_notify(skb, TRACE_TO_HOST, SECLABEL, HOST_ID, 0, HOST_IFINDEX,
+		send_trace_notify(ctx, TRACE_TO_HOST, SECLABEL, HOST_ID, 0, HOST_IFINDEX,
 				  reason, monitor);
 
-		cilium_dbg_capture(skb, DBG_CAPTURE_DELIVERY, HOST_IFINDEX);
+		cilium_dbg_capture(ctx, DBG_CAPTURE_DELIVERY, HOST_IFINDEX);
 #ifdef HOST_REDIRECT_TO_INGRESS
 		return redirect(HOST_IFINDEX, BPF_F_INGRESS);
 #else
@@ -693,8 +693,8 @@ to_host:
 
 pass_to_stack:
 #ifdef ENABLE_ROUTING
-	ret = ipv4_l3(skb, l3_off, NULL, (__u8 *) &router_mac.addr, ip4);
-	if (unlikely(ret != TC_ACT_OK))
+	ret = ipv4_l3(ctx, l3_off, NULL, (__u8 *) &router_mac.addr, ip4);
+	if (unlikely(ret != CTX_ACT_OK))
 		return ret;
 #endif
 
@@ -703,32 +703,32 @@ pass_to_stack:
 	 * network.
 	 */
 
-	send_trace_notify(skb, TRACE_TO_STACK, SECLABEL, *dstID, 0, 0,
+	send_trace_notify(ctx, TRACE_TO_STACK, SECLABEL, *dstID, 0, 0,
 			  reason, monitor);
 #ifndef ENCAP_IFINDEX
 #ifdef ENABLE_IPSEC
 	if (encrypt_key && tunnel_endpoint) {
-		set_encrypt_key(skb, encrypt_key);
+		set_encrypt_key(ctx, encrypt_key);
 #ifdef IP_POOLS
-		set_encrypt_dip(skb, tunnel_endpoint);
+		set_encrypt_dip(ctx, tunnel_endpoint);
 #else
-		set_identity(skb, SECLABEL);
+		set_identity(ctx, SECLABEL);
 #endif
 	}
 #endif
 #endif
-	cilium_dbg_capture(skb, DBG_CAPTURE_DELIVERY, 0);
-	return TC_ACT_OK;
+	cilium_dbg_capture(ctx, DBG_CAPTURE_DELIVERY, 0);
+	return CTX_ACT_OK;
 }
 
 declare_tailcall_if(__and(is_defined(ENABLE_IPV4), is_defined(ENABLE_IPV6)), CILIUM_CALL_IPV4_FROM_LXC)
-int tail_handle_ipv4(struct __sk_buff *skb)
+int tail_handle_ipv4(struct __ctx_buff *ctx)
 {
 	__u32 dstID = 0;
-	int ret = handle_ipv4_from_lxc(skb, &dstID);
+	int ret = handle_ipv4_from_lxc(ctx, &dstID);
 
 	if (IS_ERR(ret))
-		return send_drop_notify(skb, SECLABEL, dstID, 0, ret, TC_ACT_SHOT,
+		return send_drop_notify(ctx, SECLABEL, dstID, 0, ret, CTX_ACT_DROP,
 		                        METRIC_EGRESS);
 
 	return ret;
@@ -739,27 +739,27 @@ int tail_handle_ipv4(struct __sk_buff *skb)
  * ARP responder for ARP requests from container
  * Respond to IPV4_GATEWAY with NODE_MAC
  */
-__section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_ARP) int tail_handle_arp(struct __sk_buff *skb)
+__section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_ARP) int tail_handle_arp(struct __ctx_buff *ctx)
 {
 	union macaddr mac = NODE_MAC;
-	return arp_respond(skb, &mac, 0);
+	return arp_respond(ctx, &mac, 0);
 }
 #endif /* ENABLE_ARP_RESPONDER */
 #endif /* ENABLE_IPV4 */
 
 /* Attachment/entry point is ingress for veth, egress for ipvlan. */
 __section("from-container")
-int handle_xgress(struct __sk_buff *skb)
+int handle_xgress(struct __ctx_buff *ctx)
 {
 	__u16 proto;
 	int ret;
 
-	bpf_clear_cb(skb);
+	bpf_clear_cb(ctx);
 
-	send_trace_notify(skb, TRACE_FROM_LXC, SECLABEL, 0, 0, 0, 0,
+	send_trace_notify(ctx, TRACE_FROM_LXC, SECLABEL, 0, 0, 0, 0,
 			  TRACE_PAYLOAD_LEN);
 
-	if (!validate_ethertype(skb, &proto)) {
+	if (!validate_ethertype(ctx, &proto)) {
 		ret = DROP_UNSUPPORTED_L2;
 		goto out;
 	}
@@ -778,11 +778,11 @@ int handle_xgress(struct __sk_buff *skb)
 		break;
 #ifdef ENABLE_ARP_PASSTHROUGH
 	case bpf_htons(ETH_P_ARP):
-		ret = TC_ACT_OK;
+		ret = CTX_ACT_OK;
 		break;
 #elif defined ENABLE_ARP_RESPONDER
 	case bpf_htons(ETH_P_ARP):
-		ep_tail_call(skb, CILIUM_CALL_ARP);
+		ep_tail_call(ctx, CILIUM_CALL_ARP);
 		ret = DROP_MISSED_TAIL_CALL;
 		break;
 #endif /* ENABLE_ARP_RESPONDER */
@@ -793,14 +793,14 @@ int handle_xgress(struct __sk_buff *skb)
 
 out:
 	if (IS_ERR(ret))
-		return send_drop_notify(skb, SECLABEL, 0, 0, ret, TC_ACT_SHOT,
+		return send_drop_notify(ctx, SECLABEL, 0, 0, ret, CTX_ACT_DROP,
 					METRIC_EGRESS);
 	return ret;
 }
 
 #ifdef ENABLE_IPV6
 static inline int __inline__
-ipv6_policy(struct __sk_buff *skb, int ifindex, __u32 src_label, __u8 *reason, __u16 *proxy_port)
+ipv6_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label, __u8 *reason, __u16 *proxy_port)
 {
 	struct ipv6_ct_tuple tuple = {};
 	void *data, *data_end;
@@ -814,10 +814,10 @@ ipv6_policy(struct __sk_buff *skb, int ifindex, __u32 src_label, __u8 *reason, _
 	__u32 monitor = 0;
 	__u8 policy_match_type = POLICY_MATCH_NONE;
 
-	if (!revalidate_data(skb, &data, &data_end, &ip6))
+	if (!revalidate_data(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 
-	policy_clear_mark(skb);
+	policy_clear_mark(ctx);
 	tuple.nexthdr = ip6->nexthdr;
 
 	ipv6_addr_copy(&tuple.daddr, (union v6addr *) &ip6->daddr);
@@ -827,16 +827,16 @@ ipv6_policy(struct __sk_buff *skb, int ifindex, __u32 src_label, __u8 *reason, _
 
 	/* If packet is coming from the ingress proxy we have to skip
 	 * redirection to the ingress proxy as we would loop forever. */
-	skip_ingress_proxy = tc_index_skip_ingress_proxy(skb);
+	skip_ingress_proxy = tc_index_skip_ingress_proxy(ctx);
 
-	hdrlen = ipv6_hdrlen(skb, ETH_HLEN, &tuple.nexthdr);
+	hdrlen = ipv6_hdrlen(ctx, ETH_HLEN, &tuple.nexthdr);
 	if (hdrlen < 0)
 		return hdrlen;
 
 	l4_off = ETH_HLEN + hdrlen;
 	csum_l4_offset_and_flags(tuple.nexthdr, &csum_off);
 
-	ret = ct_lookup6(get_ct_map6(&tuple), &tuple, skb, l4_off, CT_INGRESS,
+	ret = ct_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off, CT_INGRESS,
 			 &ct_state, &monitor);
 	if (ret < 0)
 		return ret;
@@ -846,10 +846,10 @@ ipv6_policy(struct __sk_buff *skb, int ifindex, __u32 src_label, __u8 *reason, _
 	// Check it this is return traffic to an egress proxy.
 	// Do not redirect again if the packet is coming from the egress proxy.
 	if ((ret == CT_REPLY || ret == CT_RELATED) && ct_state.proxy_redirect &&
-	    !tc_index_skip_egress_proxy(skb)) {
+	    !tc_index_skip_egress_proxy(ctx)) {
 		// This is a reply, the proxy port does not need to be embedded
-		// into skb->mark and *proxy_port can be left unset.
-		send_trace_notify6(skb, TRACE_TO_PROXY, src_label, SECLABEL, &orig_sip,
+		// into ctx->mark and *proxy_port can be left unset.
+		send_trace_notify6(ctx, TRACE_TO_PROXY, src_label, SECLABEL, &orig_sip,
 				  0, ifindex, 0, monitor);
 		return POLICY_ACT_PROXY_REDIRECT;
 	}
@@ -857,19 +857,19 @@ ipv6_policy(struct __sk_buff *skb, int ifindex, __u32 src_label, __u8 *reason, _
 	if (unlikely(ct_state.rev_nat_index)) {
 		int ret2;
 
-		ret2 = lb6_rev_nat(skb, l4_off, &csum_off,
+		ret2 = lb6_rev_nat(ctx, l4_off, &csum_off,
 				   ct_state.rev_nat_index, &tuple, 0);
 		if (IS_ERR(ret2))
 			return ret2;
 	}
 
-	verdict = policy_can_access_ingress(skb, src_label, tuple.dport,
+	verdict = policy_can_access_ingress(ctx, src_label, tuple.dport,
 			tuple.nexthdr, false, &policy_match_type);
 
 	/* Reply packets and related packets are allowed, all others must be
 	 * permitted by policy */
 	if (ret != CT_REPLY && ret != CT_RELATED && verdict < 0) {
-		send_policy_verdict_notify(skb, src_label, tuple.dport, tuple.nexthdr,
+		send_policy_verdict_notify(ctx, src_label, tuple.dport, tuple.nexthdr,
 						 POLICY_INGRESS, 1, verdict, policy_match_type);
 		return verdict;
 	}
@@ -878,12 +878,12 @@ ipv6_policy(struct __sk_buff *skb, int ifindex, __u32 src_label, __u8 *reason, _
 		verdict = 0;
 
 	if (ret == CT_NEW) {
-		send_policy_verdict_notify(skb, src_label, tuple.dport, tuple.nexthdr,
+		send_policy_verdict_notify(ctx, src_label, tuple.dport, tuple.nexthdr,
 						 POLICY_INGRESS, 1, verdict, policy_match_type);
 #ifdef ENABLE_DSR
 		bool dsr = false;
 
-		ret = handle_dsr_v6(skb, &dsr);
+		ret = handle_dsr_v6(ctx, &dsr);
 		if (ret != 0)
 			return ret;
 
@@ -893,67 +893,67 @@ ipv6_policy(struct __sk_buff *skb, int ifindex, __u32 src_label, __u8 *reason, _
 		ct_state_new.orig_dport = tuple.dport;
 		ct_state_new.src_sec_id = src_label;
 		ct_state_new.node_port = ct_state.node_port;
-		ret = ct_create6(get_ct_map6(&tuple), &tuple, skb, CT_INGRESS, &ct_state_new, verdict > 0);
+		ret = ct_create6(get_ct_map6(&tuple), &tuple, ctx, CT_INGRESS, &ct_state_new, verdict > 0);
 		if (IS_ERR(ret))
 			return ret;
 
 		/* NOTE: tuple has been invalidated after this */
 	}
 
-	if (!revalidate_data(skb, &data, &data_end, &ip6))
+	if (!revalidate_data(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 
 	if (redirect_to_proxy(verdict, *reason)) {
 		*proxy_port = verdict;
-		send_trace_notify6(skb, TRACE_TO_PROXY, src_label, SECLABEL, &orig_sip,
+		send_trace_notify6(ctx, TRACE_TO_PROXY, src_label, SECLABEL, &orig_sip,
 				  0, ifindex, *reason, monitor);
 		return POLICY_ACT_PROXY_REDIRECT;
 	} else { // Not redirected to host / proxy.
-		send_trace_notify6(skb, TRACE_TO_LXC, src_label, SECLABEL, &orig_sip,
+		send_trace_notify6(ctx, TRACE_TO_LXC, src_label, SECLABEL, &orig_sip,
 				  LXC_ID, ifindex, *reason, monitor);
 	}
 
-	ifindex = skb->cb[CB_IFINDEX];
+	ifindex = ctx->cb[CB_IFINDEX];
 	if (ifindex)
 		return redirect_peer(ifindex, 0);
 
-	return TC_ACT_OK;
+	return CTX_ACT_OK;
 }
 
 declare_tailcall_if(__and(is_defined(ENABLE_IPV4), is_defined(ENABLE_IPV6)), CILIUM_CALL_IPV6_TO_LXC_POLICY_ONLY)
-int tail_ipv6_policy(struct __sk_buff *skb)
+int tail_ipv6_policy(struct __ctx_buff *ctx)
 {
-	int ret, ifindex = skb->cb[CB_IFINDEX];
-	__u32 src_label = skb->cb[CB_SRC_LABEL];
+	int ret, ifindex = ctx->cb[CB_IFINDEX];
+	__u32 src_label = ctx->cb[CB_SRC_LABEL];
 	__u16 proxy_port = 0;
 	__u8 reason = 0;
 
 
-	skb->cb[CB_SRC_LABEL] = 0;
-	ret = ipv6_policy(skb, ifindex, src_label, &reason, &proxy_port);
+	ctx->cb[CB_SRC_LABEL] = 0;
+	ret = ipv6_policy(ctx, ifindex, src_label, &reason, &proxy_port);
 
 	if (ret == POLICY_ACT_PROXY_REDIRECT)
-		ret = skb_redirect_to_proxy(skb, proxy_port);
+		ret = ctx_redirect_to_proxy(ctx, proxy_port);
 
 	if (IS_ERR(ret))
-		return send_drop_notify(skb, src_label, SECLABEL, LXC_ID,
-					ret, TC_ACT_SHOT, METRIC_INGRESS);
+		return send_drop_notify(ctx, src_label, SECLABEL, LXC_ID,
+					ret, CTX_ACT_DROP, METRIC_INGRESS);
 
-	skb->cb[0] = skb->mark; // essential for proxy ingress, see bpf_ipsec.c
+	ctx->cb[0] = ctx->mark; // essential for proxy ingress, see bpf_ipsec.c
 	return ret;
 }
 
 declare_tailcall_if(__and(is_defined(ENABLE_IPV4), is_defined(ENABLE_IPV6)), CILIUM_CALL_IPV6_TO_ENDPOINT)
-int tail_ipv6_to_endpoint(struct __sk_buff *skb)
+int tail_ipv6_to_endpoint(struct __ctx_buff *ctx)
 {
-	__u32 src_identity = skb->cb[CB_SRC_LABEL];
+	__u32 src_identity = ctx->cb[CB_SRC_LABEL];
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
 	__u16 proxy_port = 0;
 	__u8 reason;
 	int ret;
 
-	if (!revalidate_data(skb, &data, &data_end, &ip6)) {
+	if (!revalidate_data(ctx, &data, &data_end, &ip6)) {
 		ret = DROP_INVALID;
 		goto out;
 	}
@@ -979,26 +979,26 @@ int tail_ipv6_to_endpoint(struct __sk_buff *skb)
 					src_identity = sec_label;
 			}
 		}
-		cilium_dbg(skb, info ? DBG_IP_ID_MAP_SUCCEED6 : DBG_IP_ID_MAP_FAILED6,
+		cilium_dbg(ctx, info ? DBG_IP_ID_MAP_SUCCEED6 : DBG_IP_ID_MAP_FAILED6,
 			   ((__u32 *) src)[3], src_identity);
 	}
 
-	cilium_dbg(skb, DBG_LOCAL_DELIVERY, LXC_ID, SECLABEL);
+	cilium_dbg(ctx, DBG_LOCAL_DELIVERY, LXC_ID, SECLABEL);
 
 #if defined LOCAL_DELIVERY_METRICS
-	update_metrics(skb->len, METRIC_INGRESS, REASON_FORWARDED);
+	update_metrics(ctx->len, METRIC_INGRESS, REASON_FORWARDED);
 #endif
 
-	skb->cb[CB_SRC_LABEL] = 0;
-	ret = ipv6_policy(skb, 0, src_identity, &reason, &proxy_port);
+	ctx->cb[CB_SRC_LABEL] = 0;
+	ret = ipv6_policy(ctx, 0, src_identity, &reason, &proxy_port);
 
 	if (ret == POLICY_ACT_PROXY_REDIRECT)
-		ret = skb_redirect_to_proxy_hairpin(skb, proxy_port);
+		ret = ctx_redirect_to_proxy_hairpin(ctx, proxy_port);
 
 out:
 	if (IS_ERR(ret))
-		return send_drop_notify(skb, src_identity, SECLABEL, LXC_ID,
-					ret, TC_ACT_SHOT, METRIC_INGRESS);
+		return send_drop_notify(ctx, src_identity, SECLABEL, LXC_ID,
+					ret, CTX_ACT_DROP, METRIC_INGRESS);
 
 	return ret;
 }
@@ -1007,7 +1007,7 @@ out:
 
 #ifdef ENABLE_IPV4
 static inline int __inline__
-ipv4_policy(struct __sk_buff *skb, int ifindex, __u32 src_label, __u8 *reason, __u16 *proxy_port)
+ipv4_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label, __u8 *reason, __u16 *proxy_port)
 {
 	struct ipv4_ct_tuple tuple = {};
 	void *data, *data_end;
@@ -1022,15 +1022,15 @@ ipv4_policy(struct __sk_buff *skb, int ifindex, __u32 src_label, __u8 *reason, _
 	__u32 monitor = 0;
 	__u8 policy_match_type = POLICY_MATCH_NONE;
 
-	if (!revalidate_data(skb, &data, &data_end, &ip4))
+	if (!revalidate_data(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
 
-	policy_clear_mark(skb);
+	policy_clear_mark(ctx);
 	tuple.nexthdr = ip4->protocol;
 
 	/* If packet is coming from the ingress proxy we have to skip
 	 * redirection to the inggress proxy as we would loop forever. */
-	skip_ingress_proxy = tc_index_skip_ingress_proxy(skb);
+	skip_ingress_proxy = tc_index_skip_ingress_proxy(ctx);
 
 	tuple.daddr = ip4->daddr;
 	tuple.saddr = ip4->saddr;
@@ -1041,7 +1041,7 @@ ipv4_policy(struct __sk_buff *skb, int ifindex, __u32 src_label, __u8 *reason, _
 	csum_l4_offset_and_flags(tuple.nexthdr, &csum_off);
 	is_fragment = ipv4_is_fragment(ip4);
 
-	ret = ct_lookup4(get_ct_map4(&tuple), &tuple, skb, l4_off, CT_INGRESS, &ct_state,
+	ret = ct_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off, CT_INGRESS, &ct_state,
 			 &monitor);
 	if (ret < 0)
 		return ret;
@@ -1051,17 +1051,17 @@ ipv4_policy(struct __sk_buff *skb, int ifindex, __u32 src_label, __u8 *reason, _
 	// Check it this is return traffic to an egress proxy.
 	// Do not redirect again if the packet is coming from the egress proxy.
 	if ((ret == CT_REPLY || ret == CT_RELATED) && ct_state.proxy_redirect &&
-	    !tc_index_skip_egress_proxy(skb)) {
+	    !tc_index_skip_egress_proxy(ctx)) {
 		// This is a reply, the proxy port does not need to be embedded
-		// into skb->mark and *proxy_port can be left unset.
-		send_trace_notify4(skb, TRACE_TO_PROXY, src_label, SECLABEL, orig_sip,
+		// into ctx->mark and *proxy_port can be left unset.
+		send_trace_notify4(ctx, TRACE_TO_PROXY, src_label, SECLABEL, orig_sip,
 				  0, ifindex, 0, monitor);
 		return POLICY_ACT_PROXY_REDIRECT;
 	}
 
 #ifdef ENABLE_NAT46
-	if (skb->cb[CB_NAT46_STATE] == NAT46) {
-		ep_tail_call(skb, CILIUM_CALL_NAT46);
+	if (ctx->cb[CB_NAT46_STATE] == NAT46) {
+		ep_tail_call(ctx, CILIUM_CALL_NAT46);
 		return DROP_MISSED_TAIL_CALL;
 	}
 #endif
@@ -1070,21 +1070,21 @@ ipv4_policy(struct __sk_buff *skb, int ifindex, __u32 src_label, __u8 *reason, _
 		     !ct_state.loopback)) {
 		int ret2;
 
-		ret2 = lb4_rev_nat(skb, l3_off, l4_off, &csum_off,
+		ret2 = lb4_rev_nat(ctx, l3_off, l4_off, &csum_off,
 				   &ct_state, &tuple,
 				   REV_NAT_F_TUPLE_SADDR);
 		if (IS_ERR(ret2))
 			return ret2;
 	}
 
-	verdict = policy_can_access_ingress(skb, src_label, tuple.dport,
+	verdict = policy_can_access_ingress(ctx, src_label, tuple.dport,
 					    tuple.nexthdr,
 					    is_fragment, &policy_match_type);
 
 	/* Reply packets and related packets are allowed, all others must be
 	 * permitted by policy */
 	if (ret != CT_REPLY && ret != CT_RELATED && verdict < 0) {
-		send_policy_verdict_notify(skb, src_label, tuple.dport, tuple.nexthdr,
+		send_policy_verdict_notify(ctx, src_label, tuple.dport, tuple.nexthdr,
 						 POLICY_INGRESS, 0, verdict, policy_match_type);
 		return verdict;
 	}
@@ -1093,12 +1093,12 @@ ipv4_policy(struct __sk_buff *skb, int ifindex, __u32 src_label, __u8 *reason, _
 		verdict = 0;
 
 	if (ret == CT_NEW) {
-		send_policy_verdict_notify(skb, src_label, tuple.dport, tuple.nexthdr,
+		send_policy_verdict_notify(ctx, src_label, tuple.dport, tuple.nexthdr,
 						 POLICY_INGRESS, 0, verdict, policy_match_type);
 #ifdef ENABLE_DSR
 		bool dsr = false;
 
-		ret = handle_dsr_v4(skb, &dsr);
+		ret = handle_dsr_v4(ctx, &dsr);
 		if (ret != 0)
 			return ret;
 
@@ -1108,66 +1108,66 @@ ipv4_policy(struct __sk_buff *skb, int ifindex, __u32 src_label, __u8 *reason, _
 		ct_state_new.orig_dport = tuple.dport;
 		ct_state_new.src_sec_id = src_label;
 		ct_state_new.node_port = ct_state.node_port;
-		ret = ct_create4(get_ct_map4(&tuple), &tuple, skb, CT_INGRESS, &ct_state_new, verdict > 0);
+		ret = ct_create4(get_ct_map4(&tuple), &tuple, ctx, CT_INGRESS, &ct_state_new, verdict > 0);
 		if (IS_ERR(ret))
 			return ret;
 
 		/* NOTE: tuple has been invalidated after this */
 	}
 
-	if (!revalidate_data(skb, &data, &data_end, &ip4))
+	if (!revalidate_data(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
 
 	if (redirect_to_proxy(verdict, *reason)) {
 		*proxy_port = verdict;
-		send_trace_notify4(skb, TRACE_TO_PROXY, src_label, SECLABEL, orig_sip,
+		send_trace_notify4(ctx, TRACE_TO_PROXY, src_label, SECLABEL, orig_sip,
 				  0, ifindex, *reason, monitor);
 		return POLICY_ACT_PROXY_REDIRECT;
 	} else { // Not redirected to host / proxy.
-		send_trace_notify4(skb, TRACE_TO_LXC, src_label, SECLABEL, orig_sip,
+		send_trace_notify4(ctx, TRACE_TO_LXC, src_label, SECLABEL, orig_sip,
 				  LXC_ID, ifindex, *reason, monitor);
 	}
 
-	ifindex = skb->cb[CB_IFINDEX];
+	ifindex = ctx->cb[CB_IFINDEX];
 	if (ifindex)
 		return redirect_peer(ifindex, 0);
 
-	return TC_ACT_OK;
+	return CTX_ACT_OK;
 }
 
 declare_tailcall_if(__and(is_defined(ENABLE_IPV4), is_defined(ENABLE_IPV6)), CILIUM_CALL_IPV4_TO_LXC_POLICY_ONLY)
-int tail_ipv4_policy(struct __sk_buff *skb)
+int tail_ipv4_policy(struct __ctx_buff *ctx)
 {
-	int ret, ifindex = skb->cb[CB_IFINDEX];
-	__u32 src_label = skb->cb[CB_SRC_LABEL];
+	int ret, ifindex = ctx->cb[CB_IFINDEX];
+	__u32 src_label = ctx->cb[CB_SRC_LABEL];
 	__u16 proxy_port = 0;
 	__u8 reason = 0;
 
-	skb->cb[CB_SRC_LABEL] = 0;
-	ret = ipv4_policy(skb, ifindex, src_label, &reason, &proxy_port);
+	ctx->cb[CB_SRC_LABEL] = 0;
+	ret = ipv4_policy(ctx, ifindex, src_label, &reason, &proxy_port);
 
 	if (ret == POLICY_ACT_PROXY_REDIRECT)
-		ret = skb_redirect_to_proxy(skb, proxy_port);
+		ret = ctx_redirect_to_proxy(ctx, proxy_port);
 
 	if (IS_ERR(ret))
-		return send_drop_notify(skb, src_label, SECLABEL, LXC_ID,
-					ret, TC_ACT_SHOT, METRIC_INGRESS);
+		return send_drop_notify(ctx, src_label, SECLABEL, LXC_ID,
+					ret, CTX_ACT_DROP, METRIC_INGRESS);
 
-	skb->cb[0] = skb->mark; // essential for proxy ingress, see bpf_ipsec.c
+	ctx->cb[0] = ctx->mark; // essential for proxy ingress, see bpf_ipsec.c
 	return ret;
 }
 
 declare_tailcall_if(__and(is_defined(ENABLE_IPV4), is_defined(ENABLE_IPV6)), CILIUM_CALL_IPV4_TO_ENDPOINT)
-int tail_ipv4_to_endpoint(struct __sk_buff *skb)
+int tail_ipv4_to_endpoint(struct __ctx_buff *ctx)
 {
-	__u32 src_identity = skb->cb[CB_SRC_LABEL];
+	__u32 src_identity = ctx->cb[CB_SRC_LABEL];
 	void *data, *data_end;
 	struct iphdr *ip4;
 	__u16 proxy_port = 0;
 	__u8 reason;
 	int ret;
 
-	if (!revalidate_data(skb, &data, &data_end, &ip4)) {
+	if (!revalidate_data(ctx, &data, &data_end, &ip4)) {
 		ret = DROP_INVALID;
 		goto out;
 	}
@@ -1192,26 +1192,26 @@ int tail_ipv4_to_endpoint(struct __sk_buff *skb)
 					src_identity = sec_label;
 			}
 		}
-		cilium_dbg(skb, info ? DBG_IP_ID_MAP_SUCCEED4 : DBG_IP_ID_MAP_FAILED4,
+		cilium_dbg(ctx, info ? DBG_IP_ID_MAP_SUCCEED4 : DBG_IP_ID_MAP_FAILED4,
 			   ip4->saddr, src_identity);
 	}
 
-	cilium_dbg(skb, DBG_LOCAL_DELIVERY, LXC_ID, SECLABEL);
+	cilium_dbg(ctx, DBG_LOCAL_DELIVERY, LXC_ID, SECLABEL);
 
 #if defined LOCAL_DELIVERY_METRICS
-	update_metrics(skb->len, METRIC_INGRESS, REASON_FORWARDED);
+	update_metrics(ctx->len, METRIC_INGRESS, REASON_FORWARDED);
 #endif
 
-	skb->cb[CB_SRC_LABEL] = 0;
-	ret = ipv4_policy(skb, 0, src_identity, &reason, &proxy_port);
+	ctx->cb[CB_SRC_LABEL] = 0;
+	ret = ipv4_policy(ctx, 0, src_identity, &reason, &proxy_port);
 
 	if (ret == POLICY_ACT_PROXY_REDIRECT)
-		ret = skb_redirect_to_proxy_hairpin(skb, proxy_port);
+		ret = ctx_redirect_to_proxy_hairpin(ctx, proxy_port);
 
 out:
 	if (IS_ERR(ret))
-		return send_drop_notify(skb, src_identity, SECLABEL, LXC_ID,
-					ret, TC_ACT_SHOT, METRIC_INGRESS);
+		return send_drop_notify(ctx, src_identity, SECLABEL, LXC_ID,
+					ret, CTX_ACT_DROP, METRIC_INGRESS);
 
 	return ret;
 }
@@ -1220,17 +1220,17 @@ out:
 /* Handle policy decisions as the packet makes its way towards the endpoint.
  * Previously, the packet may have come from another local endpoint, another
  * endpoint in the cluster, or from the big blue room (as identified by the
- * contents of skb->cb[CB_SRC_LABEL]). Determine whether the traffic may be
+ * contents of ctx->cb[CB_SRC_LABEL]). Determine whether the traffic may be
  * passed into the endpoint or if it needs further inspection by a userspace
  * proxy.
  */
-__section_tail(CILIUM_MAP_POLICY, TEMPLATE_LXC_ID) int handle_policy(struct __sk_buff *skb)
+__section_tail(CILIUM_MAP_POLICY, TEMPLATE_LXC_ID) int handle_policy(struct __ctx_buff *ctx)
 {
-	__u32 src_label = skb->cb[CB_SRC_LABEL];
+	__u32 src_label = ctx->cb[CB_SRC_LABEL];
 	__u16 proto;
 	int ret;
 
-	if (!validate_ethertype(skb, &proto)) {
+	if (!validate_ethertype(ctx, &proto)) {
 		ret = DROP_UNSUPPORTED_L2;
 		goto out;
 	}
@@ -1255,52 +1255,52 @@ __section_tail(CILIUM_MAP_POLICY, TEMPLATE_LXC_ID) int handle_policy(struct __sk
 
 out:
 	if (IS_ERR(ret))
-		return send_drop_notify(skb, src_label, SECLABEL, LXC_ID,
-					ret, TC_ACT_SHOT, METRIC_INGRESS);
+		return send_drop_notify(ctx, src_label, SECLABEL, LXC_ID,
+					ret, CTX_ACT_DROP, METRIC_INGRESS);
 
 	return ret;
 }
 
 #ifdef ENABLE_NAT46
-__section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_NAT64) int tail_ipv6_to_ipv4(struct __sk_buff *skb)
+__section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_NAT64) int tail_ipv6_to_ipv4(struct __ctx_buff *ctx)
 {
-	int ret = ipv6_to_ipv4(skb, 14, LXC_IPV4);
+	int ret = ipv6_to_ipv4(ctx, 14, LXC_IPV4);
 	if (IS_ERR(ret))
-		return  send_drop_notify(skb, SECLABEL, 0, 0, ret, TC_ACT_SHOT,
+		return  send_drop_notify(ctx, SECLABEL, 0, 0, ret, CTX_ACT_DROP,
 				METRIC_EGRESS);
 
-	cilium_dbg_capture(skb, DBG_CAPTURE_AFTER_V64, skb->ingress_ifindex);
+	cilium_dbg_capture(ctx, DBG_CAPTURE_AFTER_V64, ctx->ingress_ifindex);
 
-	skb->cb[CB_NAT46_STATE] = NAT64;
+	ctx->cb[CB_NAT46_STATE] = NAT64;
 
 	invoke_tailcall_if(__and(is_defined(ENABLE_IPV4), is_defined(ENABLE_IPV6)),
 			   CILIUM_CALL_IPV4_FROM_LXC, tail_handle_ipv4);
 	return ret;
 }
 
-static inline int __inline__ handle_ipv4_to_ipv6(struct __sk_buff *skb)
+static inline int __inline__ handle_ipv4_to_ipv6(struct __ctx_buff *ctx)
 {
 	union v6addr dp = {};
 	void *data, *data_end;
 	struct iphdr *ip4;
 
-	if (!revalidate_data(skb, &data, &data_end, &ip4))
+	if (!revalidate_data(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
 
 	BPF_V6(dp, LXC_IP);
-	return ipv4_to_ipv6(skb, ip4, 14, &dp);
+	return ipv4_to_ipv6(ctx, ip4, 14, &dp);
 
 }
 
-__section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_NAT46) int tail_ipv4_to_ipv6(struct __sk_buff *skb)
+__section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_NAT46) int tail_ipv4_to_ipv6(struct __ctx_buff *ctx)
 {
-	int ret = handle_ipv4_to_ipv6(skb);
+	int ret = handle_ipv4_to_ipv6(ctx);
 
 	if (IS_ERR(ret))
-		return send_drop_notify(skb, SECLABEL, 0, 0, ret, TC_ACT_SHOT,
+		return send_drop_notify(ctx, SECLABEL, 0, 0, ret, CTX_ACT_DROP,
 				METRIC_INGRESS);
 
-	cilium_dbg_capture(skb, DBG_CAPTURE_AFTER_V46, skb->ingress_ifindex);
+	cilium_dbg_capture(ctx, DBG_CAPTURE_AFTER_V46, ctx->ingress_ifindex);
 
 	invoke_tailcall_if(__and(is_defined(ENABLE_IPV4), is_defined(ENABLE_IPV6)),
 			   CILIUM_CALL_IPV6_TO_LXC_POLICY_ONLY, tail_ipv6_policy);
@@ -1310,31 +1310,31 @@ __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_NAT46) int tail_ipv4_to_ipv6(struct
 BPF_LICENSE("GPL");
 
 __section("to-container")
-int handle_to_container(struct __sk_buff *skb)
+int handle_to_container(struct __ctx_buff *ctx)
 {
 	int ret, trace = TRACE_FROM_STACK;
 	__u32 identity = 0;
 	__u16 proto;
 
-	if (!validate_ethertype(skb, &proto)) {
+	if (!validate_ethertype(ctx, &proto)) {
 		ret = DROP_UNSUPPORTED_L2;
 		goto out;
 	}
 
-	bpf_clear_cb(skb);
+	bpf_clear_cb(ctx);
 
-	if (inherit_identity_from_host(skb, &identity))
+	if (inherit_identity_from_host(ctx, &identity))
 		trace = TRACE_FROM_PROXY;
 
-	send_trace_notify(skb, trace, identity, 0, 0,
-			  skb->ingress_ifindex, 0, TRACE_PAYLOAD_LEN);
+	send_trace_notify(ctx, trace, identity, 0, 0,
+			  ctx->ingress_ifindex, 0, TRACE_PAYLOAD_LEN);
 
-	skb->cb[CB_SRC_LABEL] = identity;
+	ctx->cb[CB_SRC_LABEL] = identity;
 
 	switch (proto) {
 #if defined ENABLE_ARP_PASSTHROUGH || defined ENABLE_ARP_RESPONDER
 	case bpf_htons(ETH_P_ARP):
-		ret = TC_ACT_OK;
+		ret = CTX_ACT_OK;
 		break;
 #endif
 #ifdef ENABLE_IPV6
@@ -1356,8 +1356,8 @@ int handle_to_container(struct __sk_buff *skb)
 
 out:
 	if (IS_ERR(ret))
-		return send_drop_notify(skb, identity, SECLABEL, LXC_ID,
-					ret, TC_ACT_SHOT, METRIC_INGRESS);
+		return send_drop_notify(ctx, identity, SECLABEL, LXC_ID,
+					ret, CTX_ACT_DROP, METRIC_INGRESS);
 
 	return ret;
 }

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -15,12 +15,11 @@
  *  along with this program; if not, write to the Free Software
  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
-#include <node_config.h>
-#include <netdev_config.h>
-
+#include <bpf/ctx/skb.h>
 #include <bpf/api.h>
 
-#include <linux/if_packet.h>
+#include <node_config.h>
+#include <netdev_config.h>
 
 #include "lib/tailcall.h"
 #include "lib/utils.h"
@@ -36,7 +35,7 @@
 #include "lib/nodeport.h"
 
 #ifdef ENABLE_IPV6
-static inline int handle_ipv6(struct __sk_buff *skb, __u32 *identity)
+static inline int handle_ipv6(struct __ctx_buff *ctx, __u32 *identity)
 {
 	int ret, l4_off, l3_off = ETH_HLEN, hdrlen;
 	void *data_end, *data;
@@ -46,27 +45,27 @@ static inline int handle_ipv6(struct __sk_buff *skb, __u32 *identity)
 	bool decrypted;
 
 	/* verifier workaround (dereference of modified ctx ptr) */
-	if (!revalidate_data_first(skb, &data, &data_end, &ip6))
+	if (!revalidate_data_first(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 #ifdef ENABLE_NODEPORT
-	if (!bpf_skip_nodeport(skb)) {
-		int ret = nodeport_lb6(skb, *identity);
+	if (!bpf_skip_nodeport(ctx)) {
+		int ret = nodeport_lb6(ctx, *identity);
 		if (ret < 0)
 			return ret;
 	}
 #endif
-	ret = encap_remap_v6_host_address(skb, false);
+	ret = encap_remap_v6_host_address(ctx, false);
 	if (unlikely(ret < 0))
 		return ret;
 
-	if (!revalidate_data(skb, &data, &data_end, &ip6))
+	if (!revalidate_data(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 
-	decrypted = ((skb->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_DECRYPT);
+	decrypted = ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_DECRYPT);
 	if (decrypted) {
-		*identity = get_identity(skb);
+		*identity = get_identity(ctx);
 	} else {
-		if (unlikely(skb_get_tunnel_key(skb, &key, sizeof(key), 0) < 0))
+		if (unlikely(ctx_get_tunnel_key(ctx, &key, sizeof(key), 0) < 0))
 			return DROP_NO_TUNNEL_KEY;
 		*identity = key.tunnel_id;
 
@@ -78,7 +77,7 @@ static inline int handle_ipv6(struct __sk_buff *skb, __u32 *identity)
 		}
 	}
 
-	cilium_dbg(skb, DBG_DECAP, key.tunnel_id, key.tunnel_label);
+	cilium_dbg(ctx, DBG_DECAP, key.tunnel_id, key.tunnel_label);
 
 #ifdef ENABLE_IPSEC
 	if (!decrypted) {
@@ -86,24 +85,24 @@ static inline int handle_ipv6(struct __sk_buff *skb, __u32 *identity)
 		 * so for now just handle normally
 		 */
 		if (ip6->nexthdr != IPPROTO_ESP) {
-			update_metrics(skb->len, METRIC_INGRESS, REASON_PLAINTEXT);
+			update_metrics(ctx->len, METRIC_INGRESS, REASON_PLAINTEXT);
 			goto not_esp;
 		}
 
 		/* Decrypt "key" is determined by SPI */
-		skb->mark = MARK_MAGIC_DECRYPT;
-		set_identity(skb, key.tunnel_id);
+		ctx->mark = MARK_MAGIC_DECRYPT;
+		set_identity(ctx, key.tunnel_id);
 		/* To IPSec stack on cilium_vxlan we are going to pass
 		 * this up the stack but eth_type_trans has already labeled
 		 * this as an OTHERHOST type packet. To avoid being dropped
 		 * by IP stack before IPSec can be processed mark as a HOST
 		 * packet.
 		 */
-		skb_change_type(skb, PACKET_HOST);
-		return TC_ACT_OK;
+		ctx_change_type(ctx, PACKET_HOST);
+		return CTX_ACT_OK;
 	} else {
-		key.tunnel_id = get_identity(skb);
-		skb->mark = 0;
+		key.tunnel_id = get_identity(ctx);
+		ctx->mark = 0;
 	}
 not_esp:
 #endif
@@ -116,12 +115,12 @@ not_esp:
 			goto to_host;
 
 		__u8 nexthdr = ip6->nexthdr;
-		hdrlen = ipv6_hdrlen(skb, l3_off, &nexthdr);
+		hdrlen = ipv6_hdrlen(ctx, l3_off, &nexthdr);
 		if (hdrlen < 0)
 			return hdrlen;
 
 		l4_off = l3_off + hdrlen;
-		return ipv6_local_delivery(skb, l3_off, l4_off, key.tunnel_id, ip6, nexthdr, ep, METRIC_INGRESS);
+		return ipv6_local_delivery(ctx, l3_off, l4_off, key.tunnel_id, ip6, nexthdr, ep, METRIC_INGRESS);
 	}
 
 to_host:
@@ -131,32 +130,32 @@ to_host:
 		union macaddr router_mac = NODE_MAC;
 		int ret;
 
-		ret = ipv6_l3(skb, ETH_HLEN, (__u8 *) &router_mac.addr, (__u8 *) &host_mac.addr, METRIC_INGRESS);
-		if (ret != TC_ACT_OK)
+		ret = ipv6_l3(ctx, ETH_HLEN, (__u8 *) &router_mac.addr, (__u8 *) &host_mac.addr, METRIC_INGRESS);
+		if (ret != CTX_ACT_OK)
 			return ret;
 
-		cilium_dbg_capture(skb, DBG_CAPTURE_DELIVERY, HOST_IFINDEX);
+		cilium_dbg_capture(ctx, DBG_CAPTURE_DELIVERY, HOST_IFINDEX);
 		return redirect(HOST_IFINDEX, 0);
 	}
 #else
-	return TC_ACT_OK;
+	return CTX_ACT_OK;
 #endif
 }
 
-__section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV6_FROM_LXC) int tail_handle_ipv6(struct __sk_buff *skb)
+__section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV6_FROM_LXC) int tail_handle_ipv6(struct __ctx_buff *ctx)
 {
 	__u32 src_identity = 0;
-	int ret = handle_ipv6(skb, &src_identity);
+	int ret = handle_ipv6(ctx, &src_identity);
 
 	if (IS_ERR(ret))
-		return send_drop_notify_error(skb, src_identity, ret, TC_ACT_SHOT, METRIC_INGRESS);
+		return send_drop_notify_error(ctx, src_identity, ret, CTX_ACT_DROP, METRIC_INGRESS);
 
 	return ret;
 }
 #endif /* ENABLE_IPV6 */
 
 #ifdef ENABLE_IPV4
-static inline int handle_ipv4(struct __sk_buff *skb, __u32 *identity)
+static inline int handle_ipv4(struct __ctx_buff *ctx, __u32 *identity)
 {
 	void *data_end, *data;
 	struct iphdr *ip4;
@@ -166,24 +165,24 @@ static inline int handle_ipv4(struct __sk_buff *skb, __u32 *identity)
 	int l4_off;
 
 	/* verifier workaround (dereference of modified ctx ptr) */
-	if (!revalidate_data_first(skb, &data, &data_end, &ip4))
+	if (!revalidate_data_first(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
 #ifdef ENABLE_NODEPORT
-	if (!bpf_skip_nodeport(skb)) {
-		int ret = nodeport_lb4(skb, *identity);
+	if (!bpf_skip_nodeport(ctx)) {
+		int ret = nodeport_lb4(ctx, *identity);
 		if (ret < 0)
 			return ret;
 	}
 #endif
-	if (!revalidate_data(skb, &data, &data_end, &ip4))
+	if (!revalidate_data(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
 
-	decrypted = ((skb->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_DECRYPT);
+	decrypted = ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_DECRYPT);
 	/* If packets are decrypted the key has already been pushed into metadata. */
 	if (decrypted) {
-		*identity = get_identity(skb);
+		*identity = get_identity(ctx);
 	} else {
-		if (unlikely(skb_get_tunnel_key(skb, &key, sizeof(key), 0) < 0))
+		if (unlikely(ctx_get_tunnel_key(ctx, &key, sizeof(key), 0) < 0))
 			return DROP_NO_TUNNEL_KEY;
 		*identity = key.tunnel_id;
 
@@ -199,23 +198,23 @@ static inline int handle_ipv4(struct __sk_buff *skb, __u32 *identity)
 		 * so for now just handle normally
 		 */
 		if (ip4->protocol != IPPROTO_ESP) {
-			update_metrics(skb->len, METRIC_INGRESS, REASON_PLAINTEXT);
+			update_metrics(ctx->len, METRIC_INGRESS, REASON_PLAINTEXT);
 			goto not_esp;
 		}
 
-		skb->mark = MARK_MAGIC_DECRYPT;
-		set_identity(skb, key.tunnel_id);
+		ctx->mark = MARK_MAGIC_DECRYPT;
+		set_identity(ctx, key.tunnel_id);
 		/* To IPSec stack on cilium_vxlan we are going to pass
 		 * this up the stack but eth_type_trans has already labeled
 		 * this as an OTHERHOST type packet. To avoid being dropped
 		 * by IP stack before IPSec can be processed mark as a HOST
 		 * packet.
 		 */
-		skb_change_type(skb, PACKET_HOST);
-		return TC_ACT_OK;
+		ctx_change_type(ctx, PACKET_HOST);
+		return CTX_ACT_OK;
 	} else {
-		key.tunnel_id = get_identity(skb);
-		skb->mark = 0;
+		key.tunnel_id = get_identity(ctx);
+		ctx->mark = 0;
 	}
 not_esp:
 #endif
@@ -227,7 +226,7 @@ not_esp:
 		if (ep->flags & ENDPOINT_F_HOST)
 			goto to_host;
 
-		return ipv4_local_delivery(skb, ETH_HLEN, l4_off, key.tunnel_id, ip4, ep, METRIC_INGRESS);
+		return ipv4_local_delivery(ctx, ETH_HLEN, l4_off, key.tunnel_id, ip4, ep, METRIC_INGRESS);
 	}
 
 to_host:
@@ -237,61 +236,61 @@ to_host:
 		union macaddr router_mac = NODE_MAC;
 		int ret;
 
-		ret = ipv4_l3(skb, ETH_HLEN, (__u8 *) &router_mac.addr, (__u8 *) &host_mac.addr, ip4);
-		if (ret != TC_ACT_OK)
+		ret = ipv4_l3(ctx, ETH_HLEN, (__u8 *) &router_mac.addr, (__u8 *) &host_mac.addr, ip4);
+		if (ret != CTX_ACT_OK)
 			return ret;
 
-		cilium_dbg_capture(skb, DBG_CAPTURE_DELIVERY, HOST_IFINDEX);
+		cilium_dbg_capture(ctx, DBG_CAPTURE_DELIVERY, HOST_IFINDEX);
 		return redirect(HOST_IFINDEX, 0);
 	}
 #else
-	return TC_ACT_OK;
+	return CTX_ACT_OK;
 #endif
 }
 
-__section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV4_FROM_LXC) int tail_handle_ipv4(struct __sk_buff *skb)
+__section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV4_FROM_LXC) int tail_handle_ipv4(struct __ctx_buff *ctx)
 {
 	__u32 src_identity = 0;
-	int ret = handle_ipv4(skb, &src_identity);
+	int ret = handle_ipv4(ctx, &src_identity);
 
 	if (IS_ERR(ret))
-		return send_drop_notify_error(skb, src_identity, ret, TC_ACT_SHOT, METRIC_INGRESS);
+		return send_drop_notify_error(ctx, src_identity, ret, CTX_ACT_DROP, METRIC_INGRESS);
 
 	return ret;
 }
 #endif /* ENABLE_IPV4 */
 
 __section("from-overlay")
-int from_overlay(struct __sk_buff *skb)
+int from_overlay(struct __ctx_buff *ctx)
 {
 	__u16 proto;
 	int ret;
 
-	bpf_clear_cb(skb);
-	bpf_clear_nodeport(skb);
+	bpf_clear_cb(ctx);
+	bpf_clear_nodeport(ctx);
 
-	if (!validate_ethertype(skb, &proto)) {
+	if (!validate_ethertype(ctx, &proto)) {
 		/* Pass unknown traffic to the stack */
-		ret = TC_ACT_OK;
+		ret = CTX_ACT_OK;
 		goto out;
 	}
 
 #ifdef ENABLE_IPSEC
-	if ((skb->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_DECRYPT) {
-		send_trace_notify(skb, TRACE_FROM_OVERLAY, get_identity(skb), 0, 0,
-				  skb->ingress_ifindex,
+	if ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_DECRYPT) {
+		send_trace_notify(ctx, TRACE_FROM_OVERLAY, get_identity(ctx), 0, 0,
+				  ctx->ingress_ifindex,
 				  TRACE_REASON_ENCRYPTED, TRACE_PAYLOAD_LEN);
 	} else
 #endif
 	{
-		send_trace_notify(skb, TRACE_FROM_OVERLAY, 0, 0, 0,
-				  skb->ingress_ifindex, 0, TRACE_PAYLOAD_LEN);
+		send_trace_notify(ctx, TRACE_FROM_OVERLAY, 0, 0, 0,
+				  ctx->ingress_ifindex, 0, TRACE_PAYLOAD_LEN);
 	}
 
 	switch (proto) {
 	case bpf_htons(ETH_P_IPV6):
 #ifdef ENABLE_IPV6
-		ep_tail_call(skb, CILIUM_CALL_IPV6_FROM_LXC);
+		ep_tail_call(ctx, CILIUM_CALL_IPV6_FROM_LXC);
 		ret = DROP_MISSED_TAIL_CALL;
 #else
 		ret = DROP_UNKNOWN_L3;
@@ -300,7 +299,7 @@ int from_overlay(struct __sk_buff *skb)
 
 	case bpf_htons(ETH_P_IP):
 #ifdef ENABLE_IPV4
-		ep_tail_call(skb, CILIUM_CALL_IPV4_FROM_LXC);
+		ep_tail_call(ctx, CILIUM_CALL_IPV4_FROM_LXC);
 		ret = DROP_MISSED_TAIL_CALL;
 #else
 		ret = DROP_UNKNOWN_L3;
@@ -309,33 +308,33 @@ int from_overlay(struct __sk_buff *skb)
 
 	default:
 		/* Pass unknown traffic to the stack */
-		ret = TC_ACT_OK;
+		ret = CTX_ACT_OK;
 	}
 out:
 	if (IS_ERR(ret))
-		return send_drop_notify_error(skb, 0, ret, TC_ACT_SHOT, METRIC_INGRESS);
+		return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP, METRIC_INGRESS);
 	return ret;
 }
 
 #ifdef ENABLE_NODEPORT
 declare_tailcall_if(is_defined(ENABLE_IPV6), CILIUM_CALL_ENCAP_NODEPORT_NAT)
-int tail_handle_nat_fwd(struct __sk_buff *skb)
+int tail_handle_nat_fwd(struct __ctx_buff *ctx)
 {
 	int ret;
 
-	if ((skb->mark & MARK_MAGIC_SNAT_DONE) == MARK_MAGIC_SNAT_DONE)
-		return TC_ACT_OK;
-	ret = nodeport_nat_fwd(skb, true);
+	if ((ctx->mark & MARK_MAGIC_SNAT_DONE) == MARK_MAGIC_SNAT_DONE)
+		return CTX_ACT_OK;
+	ret = nodeport_nat_fwd(ctx, true);
 	if (IS_ERR(ret))
-		return send_drop_notify_error(skb, 0, ret, TC_ACT_SHOT, METRIC_EGRESS);
+		return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP, METRIC_EGRESS);
 	return ret;
 }
 #endif
 
 __section("to-overlay")
-int to_overlay(struct __sk_buff *skb)
+int to_overlay(struct __ctx_buff *ctx)
 {
-	int ret = encap_remap_v6_host_address(skb, true);
+	int ret = encap_remap_v6_host_address(ctx, true);
 	if (unlikely(ret < 0))
 		goto out;
 #ifdef ENABLE_NODEPORT
@@ -344,7 +343,7 @@ int to_overlay(struct __sk_buff *skb)
 #endif
 out:
 	if (IS_ERR(ret))
-		return send_drop_notify_error(skb, 0, ret, TC_ACT_SHOT, METRIC_EGRESS);
+		return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP, METRIC_EGRESS);
 	return ret;
 }
 

--- a/bpf/bpf_prefilter.c
+++ b/bpf/bpf_prefilter.c
@@ -15,16 +15,16 @@
  *  along with this program; if not, write to the Free Software
  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
-#define SKIP_CALLS_MAP
+#include <bpf/ctx/xdp.h>
+#include <bpf/api.h>
 
 #include <node_config.h>
 #include <netdev_config.h>
 #include <filter_config.h>
 
-#include <bpf/api.h>
-
-#include <linux/bpf.h>
 #include <linux/if_ether.h>
+
+#define SKIP_CALLS_MAP
 
 #include "lib/utils.h"
 #include "lib/common.h"

--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -15,11 +15,11 @@
  *  along with this program; if not, write to the Free Software
  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
+#include <bpf/ctx/unspec.h>
+#include <bpf/api.h>
 
 #include <node_config.h>
 #include <netdev_config.h>
-
-#include <bpf/api.h>
 
 #define SKIP_POLICY_MAP	1
 #define SKIP_CALLS_MAP	1

--- a/bpf/include/bpf/api.h
+++ b/bpf/include/bpf/api.h
@@ -10,6 +10,7 @@
 
 #include <linux/types.h>
 #include <linux/byteorder.h>
+#include <linux/if_packet.h>
 #include <linux/bpf.h>
 
 #include <iproute2/bpf_elf.h>
@@ -198,6 +199,8 @@ static int BPF_FUNC(skb_set_tunnel_opt, struct __sk_buff *skb,
 
 /* Events for user space */
 static int BPF_FUNC2(skb_event_output, struct __sk_buff *skb, void *map, __u64 index,
+		     const void *data, __u32 size) = (void *)BPF_FUNC_perf_event_output;
+static int BPF_FUNC2(xdp_event_output, struct xdp_md *xdp, void *map, __u64 index,
 		     const void *data, __u32 size) = (void *)BPF_FUNC_perf_event_output;
 
 /* Sockops and SK_MSG helpers */

--- a/bpf/include/bpf/ctx/common.h
+++ b/bpf/include/bpf/ctx/common.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2019 Authors of Cilium
+ *  Copyright (C) 2020 Authors of Cilium
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -15,24 +15,22 @@
  *  along with this program; if not, write to the Free Software
  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
-#include <bpf/ctx/skb.h>
-#include <bpf/api.h>
+#ifndef __BPF_CTX_COMMON_H_
+#define __BPF_CTX_COMMON_H_
 
-#include <node_config.h>
-#include <netdev_config.h>
+#include <linux/types.h>
+#include <linux/bpf.h>
 
-#include "lib/common.h"
+#ifndef __maybe_unused
+# define __maybe_unused		__attribute__((__unused__))
+#endif
 
-__section("to-host")
-int to_host(struct __ctx_buff *ctx)
-{
-	// Upper 16 bits may carry proxy port number, clear it out
-	__u32 magic = ctx->cb[0] & 0xFFFF;
-	if (magic == MARK_MAGIC_TO_PROXY) {
-		ctx->mark = ctx->cb[0];
-		ctx->cb[0] = 0;
-	}
-	return CTX_ACT_OK;
-}
+#ifndef __always_inline
+# define __always_inline	__attribute__((always_inline))
+#endif
 
-BPF_LICENSE("GPL");
+#ifndef __overloadable
+# define __overloadable		__attribute__((overloadable))
+#endif
+
+#endif /* __BPF_CTX_COMMON_H_ */

--- a/bpf/include/bpf/ctx/ctx.h
+++ b/bpf/include/bpf/ctx/ctx.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2019 Authors of Cilium
+ *  Copyright (C) 2020 Authors of Cilium
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -15,24 +15,11 @@
  *  along with this program; if not, write to the Free Software
  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
-#include <bpf/ctx/skb.h>
-#include <bpf/api.h>
+#ifndef __BPF_CTX_CTX_H_
+#define __BPF_CTX_CTX_H_
 
-#include <node_config.h>
-#include <netdev_config.h>
+#ifndef __ctx_buff
+# error "No __ctx_buff context defined. Please either include 'bpf/ctx/skb.h' or 'bpf/ctx/xdp.h'."
+#endif
 
-#include "lib/common.h"
-
-__section("to-host")
-int to_host(struct __ctx_buff *ctx)
-{
-	// Upper 16 bits may carry proxy port number, clear it out
-	__u32 magic = ctx->cb[0] & 0xFFFF;
-	if (magic == MARK_MAGIC_TO_PROXY) {
-		ctx->mark = ctx->cb[0];
-		ctx->cb[0] = 0;
-	}
-	return CTX_ACT_OK;
-}
-
-BPF_LICENSE("GPL");
+#endif /* __BPF_CTX_CTX_H_ */

--- a/bpf/include/bpf/ctx/skb.h
+++ b/bpf/include/bpf/ctx/skb.h
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (C) 2020 Authors of Cilium
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+#ifndef __BPF_CTX_SKB_H_
+#define __BPF_CTX_SKB_H_
+
+#include "common.h"
+
+#define __ctx_buff	__sk_buff
+
+#define CTX_ACT_OK	TC_ACT_OK
+#define CTX_ACT_DROP	TC_ACT_SHOT
+
+#define ctx_under_cgroup	skb_under_cgroup
+#define ctx_load_bytes_relative	skb_load_bytes_relative
+#define ctx_load_bytes		skb_load_bytes
+#define ctx_store_bytes		skb_store_bytes
+#define ctx_adjust_room		skb_adjust_room
+#define ctx_change_type		skb_change_type
+#define ctx_change_proto	skb_change_proto
+#define ctx_change_tail		skb_change_tail
+#define ctx_pull_data		skb_pull_data
+#define ctx_vlan_push		skb_vlan_push
+#define ctx_vlan_pop		skb_vlan_pop
+#define ctx_get_tunnel_key	skb_get_tunnel_key
+#define ctx_set_tunnel_key	skb_set_tunnel_key
+#define ctx_get_tunnel_opt	skb_get_tunnel_opt
+#define ctx_set_tunnel_opt	skb_set_tunnel_opt
+#define ctx_event_output	skb_event_output
+
+static __always_inline __maybe_unused __overloadable __u32
+ctx_full_len(struct __sk_buff *ctx)
+{
+	return ctx->len;
+}
+
+#endif /* __BPF_CTX_SKB_H_ */

--- a/bpf/include/bpf/ctx/unspec.h
+++ b/bpf/include/bpf/ctx/unspec.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2019 Authors of Cilium
+ *  Copyright (C) 2020 Authors of Cilium
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -15,24 +15,12 @@
  *  along with this program; if not, write to the Free Software
  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
-#include <bpf/ctx/skb.h>
-#include <bpf/api.h>
+#ifndef __BPF_CTX_UNSPEC_H_
+#define __BPF_CTX_UNSPEC_H_
 
-#include <node_config.h>
-#include <netdev_config.h>
+/* We do not care which context we need in this case, but it must be
+ * something compilable, thus we reuse skb ctx here.
+ */
+#include "skb.h"
 
-#include "lib/common.h"
-
-__section("to-host")
-int to_host(struct __ctx_buff *ctx)
-{
-	// Upper 16 bits may carry proxy port number, clear it out
-	__u32 magic = ctx->cb[0] & 0xFFFF;
-	if (magic == MARK_MAGIC_TO_PROXY) {
-		ctx->mark = ctx->cb[0];
-		ctx->cb[0] = 0;
-	}
-	return CTX_ACT_OK;
-}
-
-BPF_LICENSE("GPL");
+#endif /* __BPF_CTX_UNSPEC_H_ */

--- a/bpf/include/bpf/ctx/xdp.h
+++ b/bpf/include/bpf/ctx/xdp.h
@@ -1,0 +1,68 @@
+/*
+ *  Copyright (C) 2020 Authors of Cilium
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+#ifndef __BPF_CTX_XDP_H_
+#define __BPF_CTX_XDP_H_
+
+#include "common.h"
+
+#define __ctx_buff	xdp_md
+
+#define CTX_ACT_OK	XDP_PASS
+#define CTX_ACT_DROP	XDP_DROP
+
+#define ctx_pull_data(ctx, ...)		do { /* Already linear. */ } while (0)
+#define ctx_event_output		xdp_event_output
+
+/* Empty stubs below. */
+#ifndef ENOTSUPP
+# define ENOTSUPP			524
+#endif
+
+#define ctx_under_cgroup(...)		({ -ENOTSUPP; })
+#define ctx_load_bytes_relative(...)	({ -ENOTSUPP; })
+#define ctx_store_bytes(...)		({ -ENOTSUPP; })
+#define ctx_adjust_room(...)		({ -ENOTSUPP; })
+#define ctx_change_type(...)		({ -ENOTSUPP; })
+#define ctx_change_proto(...)		({ -ENOTSUPP; })
+#define ctx_change_tail(...)		({ -ENOTSUPP; })
+#define ctx_vlan_push(...)		({ -ENOTSUPP; })
+#define ctx_vlan_pop(...)		({ -ENOTSUPP; })
+#define ctx_get_tunnel_key(...)		({ -ENOTSUPP; })
+#define ctx_set_tunnel_key(...)		({ -ENOTSUPP; })
+#define ctx_get_tunnel_opt(...)		({ -ENOTSUPP; })
+#define ctx_set_tunnel_opt(...)		({ -ENOTSUPP; })
+
+#define get_hash_recalc(ctx)		0
+
+static __always_inline __maybe_unused int
+ctx_load_bytes(struct xdp_md *xdp, __u32 off, void *to, __u32 len)
+{
+	/* Dummy stub. */
+	__builtin_memset(to, 0, len);
+	return -ENOTSUPP;
+}
+
+static __always_inline __maybe_unused __overloadable __u32
+ctx_full_len(struct xdp_md *ctx)
+{
+	/* No non-linear section. */
+	return (unsigned long)(__u32)ctx->data_end -
+	       (unsigned long)(__u32)ctx->data;
+}
+
+#endif /* __BPF_CTX_SKB_H_ */

--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -161,7 +161,7 @@ function setup_proxy_rules()
 
 	# Any packet to an ingress or egress proxy uses a separate routing table
 	# that routes the packet to the loopback device regardless of the destination
-	# address in the packet. For this to work the skb must have a socket set
+	# address in the packet. For this to work the ctx must have a socket set
 	# (e.g., via TPROXY).
 	to_proxy_rulespec="fwmark 0x200/0xF00 pref 9 lookup $TO_PROXY_RT_TABLE"
 
@@ -645,7 +645,7 @@ fi
 if [ "$XDP_DEV" != "<nil>" ]; then
 	CIDR_MAP="cilium_cidr_v*"
 	COPTS=""
-	xdp_load $XDP_DEV $XDP_MODE "$COPTS" bpf_xdp.c bpf_xdp.o from-netdev $CIDR_MAP
+	xdp_load $XDP_DEV $XDP_MODE "$COPTS" bpf_prefilter.c bpf_prefilter.o from-netdev $CIDR_MAP
 fi
 
 # Compile dummy BPF file containing all shared struct definitions used by

--- a/bpf/lib/arp.h
+++ b/bpf/lib/arp.h
@@ -42,7 +42,7 @@ static inline int arp_check(struct ethhdr *eth, struct arphdr *arp,
 	       (eth_is_bcast(dmac) || !eth_addrcmp(dmac, mac));
 }
 
-static inline int arp_prepare_response(struct __sk_buff *skb, struct ethhdr *eth,
+static inline int arp_prepare_response(struct __ctx_buff *ctx, struct ethhdr *eth,
 				       struct arp_eth *arp_eth, __be32 ip,
 				       union macaddr *mac)
 {
@@ -50,47 +50,47 @@ static inline int arp_prepare_response(struct __sk_buff *skb, struct ethhdr *eth
 	__be32 sip = arp_eth->ar_sip;
 	__be16 arpop = bpf_htons(ARPOP_REPLY);
 
-	if (eth_store_saddr(skb, mac->addr, 0) < 0 ||
-	    eth_store_daddr(skb, smac.addr, 0) < 0 ||
-	    skb_store_bytes(skb, 20, &arpop, sizeof(arpop), 0) < 0 ||
-	    skb_store_bytes(skb, 22, mac, 6, 0) < 0 ||
-	    skb_store_bytes(skb, 28, &ip, 4, 0) < 0 ||
-	    skb_store_bytes(skb, 32, &smac, sizeof(smac), 0) < 0 ||
-	    skb_store_bytes(skb, 38, &sip, sizeof(sip), 0) < 0)
+	if (eth_store_saddr(ctx, mac->addr, 0) < 0 ||
+	    eth_store_daddr(ctx, smac.addr, 0) < 0 ||
+	    ctx_store_bytes(ctx, 20, &arpop, sizeof(arpop), 0) < 0 ||
+	    ctx_store_bytes(ctx, 22, mac, 6, 0) < 0 ||
+	    ctx_store_bytes(ctx, 28, &ip, 4, 0) < 0 ||
+	    ctx_store_bytes(ctx, 32, &smac, sizeof(smac), 0) < 0 ||
+	    ctx_store_bytes(ctx, 38, &sip, sizeof(sip), 0) < 0)
 		return DROP_WRITE_ERROR;
 
 	return 0;
 }
 
-static inline int arp_respond(struct __sk_buff *skb, union macaddr *mac, int direction)
+static inline int arp_respond(struct __ctx_buff *ctx, union macaddr *mac, int direction)
 {
-	void *data_end = (void *) (long) skb->data_end;
-	void *data = (void *) (long) skb->data;
+	void *data_end = (void *) (long) ctx->data_end;
+	void *data = (void *) (long) ctx->data;
 	struct arphdr *arp = data + ETH_HLEN;
 	struct ethhdr *eth = data;
 	struct arp_eth *arp_eth;
 	int ret;
 
 	if (data + ETH_HLEN + sizeof(*arp) + sizeof(*arp_eth) > data_end)
-		return TC_ACT_OK;
+		return CTX_ACT_OK;
 
 	arp_eth = data + ETH_HLEN + sizeof(*arp);
 
 	if (arp_check(eth, arp, arp_eth, mac)) {
 		__be32 target_ip = arp_eth->ar_tip;
-		ret = arp_prepare_response(skb, eth, arp_eth, target_ip, mac);
+		ret = arp_prepare_response(ctx, eth, arp_eth, target_ip, mac);
 		if (unlikely(ret != 0))
 			goto error;
 
-		cilium_dbg_capture(skb, DBG_CAPTURE_DELIVERY, skb->ifindex);
-		return redirect(skb->ifindex, direction);
+		cilium_dbg_capture(ctx, DBG_CAPTURE_DELIVERY, ctx->ifindex);
+		return redirect(ctx->ifindex, direction);
 	}
 
 	/* Pass any unknown ARP requests to the Linux stack */
-	return TC_ACT_OK;
+	return CTX_ACT_OK;
 
 error:
-	return send_drop_notify_error(skb, 0, ret, TC_ACT_SHOT, METRIC_EGRESS);
+	return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP, METRIC_EGRESS);
 }
 
 #endif /* __LIB_ARP__ */

--- a/bpf/lib/csum.h
+++ b/bpf/lib/csum.h
@@ -65,17 +65,17 @@ static inline void csum_l4_offset_and_flags(__u8 nexthdr, struct csum_offset *of
 
 /**
  * Helper to change L4 checksum
- * @arg skb	Packet
+ * @arg ctx	Packet
  * @arg l4_off	Offset to L4 header
  * @arg csum	Pointer to csum_offset as extracted by csum_l4_offset_and_flags()
  * @arg from	From value or 0 if to contains csum diff
  * @arg to	To value or a csum diff
  * @arg flags	Additional flags to be passed to l4_csum_replace()
  */
-static inline int csum_l4_replace(struct __sk_buff *skb, int l4_off, struct csum_offset *csum,
+static inline int csum_l4_replace(struct __ctx_buff *ctx, int l4_off, struct csum_offset *csum,
 				  __be32 from, __be32 to, int flags)
 {
-	return l4_csum_replace(skb, l4_off + csum->offset, from, to, flags | csum->flags);
+	return l4_csum_replace(ctx, l4_off + csum->offset, from, to, flags | csum->flags);
 }
 
 #endif /* __LB_H_ */

--- a/bpf/lib/drop.h
+++ b/bpf/lib/drop.h
@@ -19,8 +19,8 @@
  * Drop & error notification via perf event ring buffer
  *
  * API:
- * int send_drop_notify(skb, src, dst, dst_id, reason, exitcode, __u8 direction)
- * int send_drop_notify_error(skb, error, exitcode, __u8 direction)
+ * int send_drop_notify(ctx, src, dst, dst_id, reason, exitcode, __u8 direction)
+ * int send_drop_notify_error(ctx, error, exitcode, __u8 direction)
  *
  * If DROP_NOTIFY is not defined, the API will be compiled in as a NOP.
  */
@@ -44,40 +44,40 @@ struct drop_notify {
 	__u32		unused;
 };
 
-__section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_DROP_NOTIFY) int __send_drop_notify(struct __sk_buff *skb)
+__section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_DROP_NOTIFY) int __send_drop_notify(struct __ctx_buff *ctx)
 {
-	__u64 skb_len = (__u64)skb->len, cap_len = min((__u64)TRACE_PAYLOAD_LEN, (__u64)skb_len);
-	__u32 hash = get_hash_recalc(skb);
+	__u64 ctx_len = (__u64)ctx->len, cap_len = min((__u64)TRACE_PAYLOAD_LEN, (__u64)ctx_len);
+	__u32 hash = get_hash_recalc(ctx);
 	struct drop_notify msg = {
 		.type = CILIUM_NOTIFY_DROP,
 		.source = EVENT_SOURCE,
 		.hash = hash,
-		.len_orig = skb_len,
+		.len_orig = ctx_len,
 		.len_cap = cap_len,
 		.version = NOTIFY_CAPTURE_VER,
-		.src_label = skb->cb[0],
-		.dst_label = skb->cb[1],
-		.dst_id = skb->cb[3],
+		.src_label = ctx->cb[0],
+		.dst_label = ctx->cb[1],
+		.dst_id = ctx->cb[3],
 		.unused = 0,
 	};
 	// mask needed to calm verifier
-	int error = skb->cb[2] & 0xFFFFFFFF;
+	int error = ctx->cb[2] & 0xFFFFFFFF;
 
 	if (error < 0)
 		error = -error;
 
 	msg.subtype = error;
 
-	skb_event_output(skb, &EVENTS_MAP,
+	ctx_event_output(ctx, &EVENTS_MAP,
 			 (cap_len << 32) | BPF_F_CURRENT_CPU,
 			 &msg, sizeof(msg));
 
-	return skb->cb[4];
+	return ctx->cb[4];
 }
 
 /**
  * send_drop_notify
- * @skb:	socket buffer
+ * @ctx:	socket buffer
  * @src:	source identity
  * @dst:	destination identity
  * @dst_id:	designated destination endpoint ID
@@ -88,37 +88,37 @@ __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_DROP_NOTIFY) int __send_drop_notify
  *
  * NOTE: This is terminal function and will cause the BPF program to exit
  */
-static inline int send_drop_notify(struct __sk_buff *skb, __u32 src, __u32 dst,
+static inline int send_drop_notify(struct __ctx_buff *ctx, __u32 src, __u32 dst,
 				   __u32 dst_id, int reason, int exitcode, __u8 direction)
 {
-	skb->cb[0] = src;
-	skb->cb[1] = dst;
-	skb->cb[2] = reason;
-	skb->cb[3] = dst_id;
-	skb->cb[4] = exitcode;
+	ctx->cb[0] = src;
+	ctx->cb[1] = dst;
+	ctx->cb[2] = reason;
+	ctx->cb[3] = dst_id;
+	ctx->cb[4] = exitcode;
 
-	update_metrics(skb->len, direction, -reason);
+	update_metrics(ctx->len, direction, -reason);
 
-	ep_tail_call(skb, CILIUM_CALL_DROP_NOTIFY);
+	ep_tail_call(ctx, CILIUM_CALL_DROP_NOTIFY);
 
 	return exitcode;
 }
 
 #else
 
-static inline int send_drop_notify(struct __sk_buff *skb, __u32 src, __u32 dst,
+static inline int send_drop_notify(struct __ctx_buff *ctx, __u32 src, __u32 dst,
 				   __u32 dst_id, int reason, int exitcode, __u8 direction)
 {
-	update_metrics(skb->len, direction, -reason);
+	update_metrics(ctx->len, direction, -reason);
 	return exitcode;
 }
 
 #endif
 
-static inline int send_drop_notify_error(struct __sk_buff *skb, __u32 src, int error,
+static inline int send_drop_notify_error(struct __ctx_buff *ctx, __u32 src, int error,
                                          int exitcode, __u8 direction)
 {
-	return send_drop_notify(skb, src, 0, 0, error, exitcode, direction);
+	return send_drop_notify(ctx, src, 0, 0, error, exitcode, direction);
 }
 
 #endif /* __LIB_DROP__ */

--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -24,7 +24,7 @@
 #ifdef ENCAP_IFINDEX
 #ifdef ENABLE_IPSEC
 static inline int __inline__
-enacap_and_redirect_nomark_ipsec(struct __sk_buff *skb, __u32 tunnel_endpoint, __u8 key,
+enacap_and_redirect_nomark_ipsec(struct __ctx_buff *ctx, __u32 tunnel_endpoint, __u8 key,
 			 __u32 seclabel)
 {
 	/* Traffic from local host in tunnel mode will be passed to
@@ -34,20 +34,20 @@ enacap_and_redirect_nomark_ipsec(struct __sk_buff *skb, __u32 tunnel_endpoint, _
 	 * cb[4] hints will not survive a veth pair xmit to ingress
 	 * however so below encap_and_redirect_ipsec will not work.
 	 * Instead pass hints via cb[0], cb[4] (cb is not cleared
-	 * by dev_skb_forward) and catch hints with bpf_ipsec prog
+	 * by dev_ctx_forward) and catch hints with bpf_ipsec prog
 	 * that will populate mark/cb as expected by xfrm and 2nd
 	 * traversal into bpf_netdev. Remember we can't use cb[0-3]
 	 * in both cases because xfrm layer would overwrite them. We
 	 * use cb[4] here so it doesn't need to be reset by bpf_ipsec.
 	 */
-	skb->cb[0] = or_encrypt_key(key);
-	skb->cb[1] = seclabel;
-	skb->cb[4] = tunnel_endpoint;
+	ctx->cb[0] = or_encrypt_key(key);
+	ctx->cb[1] = seclabel;
+	ctx->cb[4] = tunnel_endpoint;
 	return IPSEC_ENDPOINT;
 }
 
 static inline int __inline__
-encap_and_redirect_ipsec(struct __sk_buff *skb, __u32 tunnel_endpoint, __u8 key,
+encap_and_redirect_ipsec(struct __ctx_buff *ctx, __u32 tunnel_endpoint, __u8 key,
 			 __u32 seclabel)
 {
 	/* IPSec is performed by the stack on any packets with the
@@ -55,17 +55,17 @@ encap_and_redirect_ipsec(struct __sk_buff *skb, __u32 tunnel_endpoint, __u8 key,
 	 * lose the lxc context (seclabel and tunnel endpoint). The
 	 * tunnel endpoint can be looked up from daddr but the sec
 	 * label is stashed in the mark and extracted in bpf_netdev
-	 * to send skb onto tunnel for encap.
+	 * to send ctx onto tunnel for encap.
 	 */
-	set_encrypt_key(skb, key);
-	set_identity(skb, seclabel);
-	skb->cb[4] = tunnel_endpoint;
+	set_encrypt_key(ctx, key);
+	set_identity(ctx, seclabel);
+	ctx->cb[4] = tunnel_endpoint;
 	return IPSEC_ENDPOINT;
 }
 #endif
 
 static inline int __inline__
-encap_remap_v6_host_address(struct __sk_buff *skb, const bool egress)
+encap_remap_v6_host_address(struct __ctx_buff *ctx, const bool egress)
 {
 #ifdef ENABLE_ENCAP_HOST_REMAP
 	struct csum_offset csum = {};
@@ -79,10 +79,10 @@ encap_remap_v6_host_address(struct __sk_buff *skb, const bool egress)
 	__be32 sum;
 	int ret;
 
-	validate_ethertype(skb, &proto);
+	validate_ethertype(ctx, &proto);
 	if (proto != bpf_htons(ETH_P_IPV6))
 		return 0;
-	if (!revalidate_data(skb, &data, &data_end, &ip6))
+	if (!revalidate_data(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 	/* For requests routed via tunnel with external v6 node IP
 	 * we need to remap their source address to the router address
@@ -99,7 +99,7 @@ encap_remap_v6_host_address(struct __sk_buff *skb, const bool egress)
 	if (ipv6_addrcmp(which, &host_ip))
 		return 0;
 	nexthdr = ip6->nexthdr;
-	ret = ipv6_hdrlen(skb, ETH_HLEN, &nexthdr);
+	ret = ipv6_hdrlen(ctx, ETH_HLEN, &nexthdr);
 	if (ret < 0)
 		return ret;
 	off = ((void *)ip6 - data) + ret;
@@ -112,17 +112,17 @@ encap_remap_v6_host_address(struct __sk_buff *skb, const bool egress)
 	}
 	sum = csum_diff(which, 16, &host_ip, 16, 0);
 	csum_l4_offset_and_flags(nexthdr, &csum);
-	if (skb_store_bytes(skb, noff, &host_ip, 16, 0) < 0)
+	if (ctx_store_bytes(ctx, noff, &host_ip, 16, 0) < 0)
 		return DROP_WRITE_ERROR;
 	if (csum.offset &&
-	    csum_l4_replace(skb, off, &csum, 0, sum, BPF_F_PSEUDO_HDR) < 0)
+	    csum_l4_replace(ctx, off, &csum, 0, sum, BPF_F_PSEUDO_HDR) < 0)
 		return DROP_CSUM_L4;
 #endif /* ENABLE_ENCAP_HOST_REMAP */
 	return 0;
 }
 
 static inline int __inline__
-__encap_with_nodeid(struct __sk_buff *skb, __u32 tunnel_endpoint,
+__encap_with_nodeid(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
 		    __u32 seclabel, __u32 monitor)
 {
 	struct bpf_tunnel_key key = {};
@@ -139,65 +139,65 @@ __encap_with_nodeid(struct __sk_buff *skb, __u32 tunnel_endpoint,
 	key.tunnel_id = seclabel;
 	key.remote_ipv4 = node_id;
 
-	cilium_dbg(skb, DBG_ENCAP, node_id, seclabel);
+	cilium_dbg(ctx, DBG_ENCAP, node_id, seclabel);
 
-	ret = skb_set_tunnel_key(skb, &key, sizeof(key), BPF_F_ZERO_CSUM_TX);
+	ret = ctx_set_tunnel_key(ctx, &key, sizeof(key), BPF_F_ZERO_CSUM_TX);
 	if (unlikely(ret < 0))
 		return DROP_WRITE_ERROR;
 
-	send_trace_notify(skb, TRACE_TO_OVERLAY, seclabel, 0, 0, ENCAP_IFINDEX,
+	send_trace_notify(ctx, TRACE_TO_OVERLAY, seclabel, 0, 0, ENCAP_IFINDEX,
 			  0, monitor);
 	return 0;
 }
 
 static inline int __inline__
-__encap_and_redirect_with_nodeid(struct __sk_buff *skb, __u32 tunnel_endpoint,
+__encap_and_redirect_with_nodeid(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
 				 __u32 seclabel, __u32 monitor)
 {
-	int ret = __encap_with_nodeid(skb, tunnel_endpoint, seclabel, monitor);
+	int ret = __encap_with_nodeid(ctx, tunnel_endpoint, seclabel, monitor);
 	if (ret != 0)
 		return ret;
 	return redirect(ENCAP_IFINDEX, 0);
 }
 
-/* encap_and_redirect_with_nodeid returns IPSEC_ENDPOINT after skb meta-data is
- * set when IPSec is enabled. Caller should pass the skb to the stack at this
+/* encap_and_redirect_with_nodeid returns IPSEC_ENDPOINT after ctx meta-data is
+ * set when IPSec is enabled. Caller should pass the ctx to the stack at this
  * point. Otherwise returns TC_ACT_REDIRECT on successful redirect to tunnel
- * device. On error returns TC_ACT_SHOT, DROP_NO_TUNNEL_ENDPOINT or
+ * device. On error returns CTX_ACT_DROP, DROP_NO_TUNNEL_ENDPOINT or
  * DROP_WRITE_ERROR.
  */
 static inline int __inline__
-encap_and_redirect_with_nodeid(struct __sk_buff *skb, __u32 tunnel_endpoint,
+encap_and_redirect_with_nodeid(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
 			       __u8 key, __u32 seclabel, __u32 monitor)
 {
 #ifdef ENABLE_IPSEC
 	if (key)
-		return enacap_and_redirect_nomark_ipsec(skb, tunnel_endpoint, key, seclabel);
+		return enacap_and_redirect_nomark_ipsec(ctx, tunnel_endpoint, key, seclabel);
 #endif
-	return __encap_and_redirect_with_nodeid(skb, tunnel_endpoint, seclabel, monitor);
+	return __encap_and_redirect_with_nodeid(ctx, tunnel_endpoint, seclabel, monitor);
 }
 
 /* encap_and_redirect based on ENABLE_IPSEC flag and from_host bool will decide
  * which version of code to call. With IPSec enabled and from_host set use the
  * IPSec branch which configures metadata for IPSec kernel stack. Otherwise
- * packet is redirected to output tunnel device and skb will not be seen by
+ * packet is redirected to output tunnel device and ctx will not be seen by
  * IP stack.
  *
- * Returns IPSEC_ENDPOINT when skb needs to be handed to IP stack for IPSec
- * handling, TC_ACT_SHOT, DROP_NO_TUNNEL_ENDPOINT or DROP_WRITE_ERROR on error,
+ * Returns IPSEC_ENDPOINT when ctx needs to be handed to IP stack for IPSec
+ * handling, CTX_ACT_DROP, DROP_NO_TUNNEL_ENDPOINT or DROP_WRITE_ERROR on error,
  * and finally on successful redirect returns TC_ACT_REDIRECT.
  */
 static inline int __inline__
-encap_and_redirect_lxc(struct __sk_buff *skb, __u32 tunnel_endpoint, __u8 encrypt_key, struct endpoint_key *key, __u32 seclabel, __u32 monitor)
+encap_and_redirect_lxc(struct __ctx_buff *ctx, __u32 tunnel_endpoint, __u8 encrypt_key, struct endpoint_key *key, __u32 seclabel, __u32 monitor)
 {
 	struct endpoint_key *tunnel;
 
 	if (tunnel_endpoint) {
 #ifdef ENABLE_IPSEC
 		if (encrypt_key)
-			return encap_and_redirect_ipsec(skb, tunnel_endpoint, encrypt_key, seclabel);
+			return encap_and_redirect_ipsec(ctx, tunnel_endpoint, encrypt_key, seclabel);
 #endif
-		return __encap_and_redirect_with_nodeid(skb, tunnel_endpoint, seclabel, monitor);
+		return __encap_and_redirect_with_nodeid(ctx, tunnel_endpoint, seclabel, monitor);
 	}
 
 	if ((tunnel = map_lookup_elem(&TUNNEL_MAP, key)) == NULL) {
@@ -208,16 +208,16 @@ encap_and_redirect_lxc(struct __sk_buff *skb, __u32 tunnel_endpoint, __u8 encryp
 	if (tunnel->key) {
 		__u8 min_encrypt_key = get_min_encrypt_key(tunnel->key);
 
-		return encap_and_redirect_ipsec(skb, tunnel->ip4,
+		return encap_and_redirect_ipsec(ctx, tunnel->ip4,
 						min_encrypt_key,
 						seclabel);
 	}
 #endif
-	return __encap_and_redirect_with_nodeid(skb, tunnel->ip4, seclabel, monitor);
+	return __encap_and_redirect_with_nodeid(ctx, tunnel->ip4, seclabel, monitor);
 }
 
 static inline int __inline__
-encap_and_redirect_netdev(struct __sk_buff *skb, struct endpoint_key *k, __u32 seclabel, __u32 monitor)
+encap_and_redirect_netdev(struct __ctx_buff *ctx, struct endpoint_key *k, __u32 seclabel, __u32 monitor)
 {
 	struct endpoint_key *tunnel;
 
@@ -229,11 +229,11 @@ encap_and_redirect_netdev(struct __sk_buff *skb, struct endpoint_key *k, __u32 s
 	if (tunnel->key) {
 		__u8 key = get_min_encrypt_key(tunnel->key);
 
-		return enacap_and_redirect_nomark_ipsec(skb, tunnel->ip4,
+		return enacap_and_redirect_nomark_ipsec(ctx, tunnel->ip4,
 						       key, seclabel);
 	}
 #endif
-	return __encap_and_redirect_with_nodeid(skb, tunnel->ip4, seclabel, monitor);
+	return __encap_and_redirect_with_nodeid(ctx, tunnel->ip4, seclabel, monitor);
 }
 #endif /* ENCAP_IFINDEX */
 #endif /* __LIB_ENCAP_H_ */

--- a/bpf/lib/eth.h
+++ b/bpf/lib/eth.h
@@ -60,24 +60,24 @@ static inline int eth_is_bcast(const union macaddr *a)
 		return 0;
 }
 
-static inline int eth_load_saddr(struct __sk_buff *skb, __u8 *mac, int off)
+static inline int eth_load_saddr(struct __ctx_buff *ctx, __u8 *mac, int off)
 {
-	return skb_load_bytes(skb, off + ETH_ALEN, mac, ETH_ALEN);
+	return ctx_load_bytes(ctx, off + ETH_ALEN, mac, ETH_ALEN);
 }
 
-static inline int eth_store_saddr(struct __sk_buff *skb, __u8 *mac, int off)
+static inline int eth_store_saddr(struct __ctx_buff *ctx, __u8 *mac, int off)
 {
-	return skb_store_bytes(skb, off + ETH_ALEN, mac, ETH_ALEN, 0);
+	return ctx_store_bytes(ctx, off + ETH_ALEN, mac, ETH_ALEN, 0);
 }
 
-static inline int eth_load_daddr(struct __sk_buff *skb, __u8 *mac, int off)
+static inline int eth_load_daddr(struct __ctx_buff *ctx, __u8 *mac, int off)
 {
-	return skb_load_bytes(skb, off, mac, ETH_ALEN);
+	return ctx_load_bytes(ctx, off, mac, ETH_ALEN);
 }
 
-static inline int eth_store_daddr(struct __sk_buff *skb, __u8 *mac, int off)
+static inline int eth_store_daddr(struct __ctx_buff *ctx, __u8 *mac, int off)
 {
-	return skb_store_bytes(skb, off, mac, ETH_ALEN, 0);
+	return ctx_store_bytes(ctx, off, mac, ETH_ALEN, 0);
 }
 
 #endif /* __LIB_ETH__ */

--- a/bpf/lib/icmp6.h
+++ b/bpf/lib/icmp6.h
@@ -35,64 +35,64 @@
 #define ACTION_UNKNOWN_ICMP6_NS DROP_UNKNOWN_TARGET
 #endif
 
-static inline __u8 icmp6_load_type(struct __sk_buff *skb, int nh_off)
+static inline __u8 icmp6_load_type(struct __ctx_buff *ctx, int nh_off)
 {
 	__u8 type;
-	skb_load_bytes(skb, nh_off + ICMP6_TYPE_OFFSET, &type, sizeof(type));
+	ctx_load_bytes(ctx, nh_off + ICMP6_TYPE_OFFSET, &type, sizeof(type));
 	return type;
 }
 
-static inline int __inline__ icmp6_send_reply(struct __sk_buff *skb, int nh_off)
+static inline int __inline__ icmp6_send_reply(struct __ctx_buff *ctx, int nh_off)
 {
 	union macaddr smac, dmac = NODE_MAC;
 	const int csum_off = nh_off + ICMP6_CSUM_OFFSET;
 	union v6addr sip, dip, router_ip;
 	__be32 sum;
 
-	if (ipv6_load_saddr(skb, nh_off, &sip) < 0 ||
-	    ipv6_load_daddr(skb, nh_off, &dip) < 0)
+	if (ipv6_load_saddr(ctx, nh_off, &sip) < 0 ||
+	    ipv6_load_daddr(ctx, nh_off, &dip) < 0)
 		return DROP_INVALID;
 
 	BPF_V6(router_ip, ROUTER_IP);
-	/* skb->saddr = skb->daddr */
-	if (ipv6_store_saddr(skb, router_ip.addr, nh_off) < 0)
+	/* ctx->saddr = ctx->daddr */
+	if (ipv6_store_saddr(ctx, router_ip.addr, nh_off) < 0)
 		return DROP_WRITE_ERROR;
-	/* skb->daddr = skb->saddr */
-	if (ipv6_store_daddr(skb, sip.addr, nh_off) < 0)
+	/* ctx->daddr = ctx->saddr */
+	if (ipv6_store_daddr(ctx, sip.addr, nh_off) < 0)
 		return DROP_WRITE_ERROR;
 
 	/* fixup checksums */
 	sum = csum_diff(sip.addr, 16, router_ip.addr, 16, 0);
-	if (l4_csum_replace(skb, csum_off, 0, sum, BPF_F_PSEUDO_HDR) < 0)
+	if (l4_csum_replace(ctx, csum_off, 0, sum, BPF_F_PSEUDO_HDR) < 0)
 		return DROP_CSUM_L4;
 
 	sum = csum_diff(dip.addr, 16, sip.addr, 16, 0);
-	if (l4_csum_replace(skb, csum_off, 0, sum, BPF_F_PSEUDO_HDR) < 0)
+	if (l4_csum_replace(ctx, csum_off, 0, sum, BPF_F_PSEUDO_HDR) < 0)
 		return DROP_CSUM_L4;
 
 	/* dmac = smac, smac = dmac */
-	if (eth_load_saddr(skb, smac.addr, 0) < 0)
+	if (eth_load_saddr(ctx, smac.addr, 0) < 0)
 		return DROP_INVALID;
 
-	// eth_load_daddr(skb, dmac.addr, 0);
-	if (eth_store_daddr(skb, smac.addr, 0) < 0 ||
-	    eth_store_saddr(skb, dmac.addr, 0) < 0)
+	// eth_load_daddr(ctx, dmac.addr, 0);
+	if (eth_store_daddr(ctx, smac.addr, 0) < 0 ||
+	    eth_store_saddr(ctx, dmac.addr, 0) < 0)
 		return DROP_WRITE_ERROR;
 
-	cilium_dbg_capture(skb, DBG_CAPTURE_DELIVERY, skb->ifindex);
+	cilium_dbg_capture(ctx, DBG_CAPTURE_DELIVERY, ctx->ifindex);
 
-	return redirect_self(skb);
+	return redirect_self(ctx);
 }
 
-static inline int __icmp6_send_echo_reply(struct __sk_buff *skb, int nh_off)
+static inline int __icmp6_send_echo_reply(struct __ctx_buff *ctx, int nh_off)
 {
 	struct icmp6hdr icmp6hdr = {}, icmp6hdr_old;
 	int csum_off = nh_off + ICMP6_CSUM_OFFSET;
 	__be32 sum;
 
-	cilium_dbg(skb, DBG_ICMP6_REQUEST, nh_off, 0);
+	cilium_dbg(ctx, DBG_ICMP6_REQUEST, nh_off, 0);
 
-	if (skb_load_bytes(skb, nh_off + sizeof(struct ipv6hdr), &icmp6hdr_old,
+	if (ctx_load_bytes(ctx, nh_off + sizeof(struct ipv6hdr), &icmp6hdr_old,
 			   sizeof(icmp6hdr_old)) < 0)
 		return DROP_INVALID;
 
@@ -104,7 +104,7 @@ static inline int __icmp6_send_echo_reply(struct __sk_buff *skb, int nh_off)
 	icmp6hdr.icmp6_identifier = icmp6hdr_old.icmp6_identifier;
 	icmp6hdr.icmp6_sequence = icmp6hdr_old.icmp6_sequence;
 
-	if (skb_store_bytes(skb, nh_off + sizeof(struct ipv6hdr), &icmp6hdr,
+	if (ctx_store_bytes(ctx, nh_off + sizeof(struct ipv6hdr), &icmp6hdr,
 			    sizeof(icmp6hdr), 0) < 0)
 		return DROP_WRITE_ERROR;
 
@@ -112,45 +112,45 @@ static inline int __icmp6_send_echo_reply(struct __sk_buff *skb, int nh_off)
 	sum = csum_diff(&icmp6hdr_old, sizeof(icmp6hdr_old),
 			&icmp6hdr, sizeof(icmp6hdr), 0);
 
-	if (l4_csum_replace(skb, csum_off, 0, sum, BPF_F_PSEUDO_HDR) < 0)
+	if (l4_csum_replace(ctx, csum_off, 0, sum, BPF_F_PSEUDO_HDR) < 0)
 		return DROP_CSUM_L4;
 
-	return icmp6_send_reply(skb, nh_off);
+	return icmp6_send_reply(ctx, nh_off);
 }
 
-__section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_SEND_ICMP6_ECHO_REPLY) int tail_icmp6_send_echo_reply(struct __sk_buff *skb)
+__section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_SEND_ICMP6_ECHO_REPLY) int tail_icmp6_send_echo_reply(struct __ctx_buff *ctx)
 {
-	int ret, nh_off = skb->cb[0];
-	__u8 direction  = skb->cb[1];
+	int ret, nh_off = ctx->cb[0];
+	__u8 direction  = ctx->cb[1];
 
-	skb->cb[0] = 0;
-	ret = __icmp6_send_echo_reply(skb, nh_off);
+	ctx->cb[0] = 0;
+	ret = __icmp6_send_echo_reply(ctx, nh_off);
 	if (IS_ERR(ret))
-		return send_drop_notify_error(skb, 0, ret, TC_ACT_SHOT, direction);
+		return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP, direction);
 
 	return ret;
 }
 
 /*
  * icmp6_send_echo_reply
- * @skb:	socket buffer
+ * @ctx:	socket buffer
  * @nh_off:	offset to the IPv6 header
  *
  * Send an ICMPv6 echo reply in return to an ICMPv6 echo reply.
  *
  * NOTE: This is terminal function and will cause the BPF program to exit
  */
-static inline int icmp6_send_echo_reply(struct __sk_buff *skb, int nh_off,
+static inline int icmp6_send_echo_reply(struct __ctx_buff *ctx, int nh_off,
 					__u8 direction)
 {
-	skb->cb[0] = nh_off;
-	skb->cb[1] = direction;
-	ep_tail_call(skb, CILIUM_CALL_SEND_ICMP6_ECHO_REPLY);
+	ctx->cb[0] = nh_off;
+	ctx->cb[1] = direction;
+	ep_tail_call(ctx, CILIUM_CALL_SEND_ICMP6_ECHO_REPLY);
 
 	return DROP_MISSED_TAIL_CALL;
 }
 
-static inline int send_icmp6_ndisc_adv(struct __sk_buff *skb, int nh_off,
+static inline int send_icmp6_ndisc_adv(struct __ctx_buff *ctx, int nh_off,
 				       union macaddr *mac)
 {
 	struct icmp6hdr icmp6hdr = {}, icmp6hdr_old;
@@ -158,7 +158,7 @@ static inline int send_icmp6_ndisc_adv(struct __sk_buff *skb, int nh_off,
 	const int csum_off = nh_off + ICMP6_CSUM_OFFSET;
 	__be32 sum;
 
-	if (skb_load_bytes(skb, nh_off + sizeof(struct ipv6hdr), &icmp6hdr_old,
+	if (ctx_load_bytes(ctx, nh_off + sizeof(struct ipv6hdr), &icmp6hdr_old,
 			   sizeof(icmp6hdr_old)) < 0)
 		return DROP_INVALID;
 
@@ -171,17 +171,17 @@ static inline int send_icmp6_ndisc_adv(struct __sk_buff *skb, int nh_off,
 	icmp6hdr.icmp6_solicited = 1;
 	icmp6hdr.icmp6_override = 0;
 
-	if (skb_store_bytes(skb, nh_off + sizeof(struct ipv6hdr), &icmp6hdr, sizeof(icmp6hdr), 0) < 0)
+	if (ctx_store_bytes(ctx, nh_off + sizeof(struct ipv6hdr), &icmp6hdr, sizeof(icmp6hdr), 0) < 0)
 		return DROP_WRITE_ERROR;
 
 	/* fixup checksums */
 	sum = csum_diff(&icmp6hdr_old, sizeof(icmp6hdr_old),
 			&icmp6hdr, sizeof(icmp6hdr), 0);
-	if (l4_csum_replace(skb, csum_off, 0, sum, BPF_F_PSEUDO_HDR) < 0)
+	if (l4_csum_replace(ctx, csum_off, 0, sum, BPF_F_PSEUDO_HDR) < 0)
 		return DROP_CSUM_L4;
 
 	/* get old options */
-	if (skb_load_bytes(skb, nh_off + ICMP6_ND_OPTS, opts_old, sizeof(opts_old)) < 0)
+	if (ctx_load_bytes(ctx, nh_off + ICMP6_ND_OPTS, opts_old, sizeof(opts_old)) < 0)
 		return DROP_INVALID;
 
 	opts[0] = 2;
@@ -194,15 +194,15 @@ static inline int send_icmp6_ndisc_adv(struct __sk_buff *skb, int nh_off,
 	opts[7] = mac->addr[5];
 
 	/* store ND_OPT_TARGET_LL_ADDR option */
-	if (skb_store_bytes(skb, nh_off + ICMP6_ND_OPTS, opts, sizeof(opts), 0) < 0)
+	if (ctx_store_bytes(ctx, nh_off + ICMP6_ND_OPTS, opts, sizeof(opts), 0) < 0)
 		return DROP_WRITE_ERROR;
 
 	/* fixup checksum */
 	sum = csum_diff(opts_old, sizeof(opts_old), opts, sizeof(opts), 0);
-	if (l4_csum_replace(skb, csum_off, 0, sum, BPF_F_PSEUDO_HDR) < 0)
+	if (l4_csum_replace(ctx, csum_off, 0, sum, BPF_F_PSEUDO_HDR) < 0)
 		return DROP_CSUM_L4;
 
-	return icmp6_send_reply(skb, nh_off);
+	return icmp6_send_reply(ctx, nh_off);
 }
 
 static inline __be32 compute_icmp6_csum(char data[80], __u16 payload_len,
@@ -221,7 +221,7 @@ static inline __be32 compute_icmp6_csum(char data[80], __u16 payload_len,
 }
 
 #ifdef HAVE_SKB_CHANGE_TAIL
-static inline int __icmp6_send_time_exceeded(struct __sk_buff *skb, int nh_off)
+static inline int __icmp6_send_time_exceeded(struct __ctx_buff *ctx, int nh_off)
 {
 	/* FIXME: Fix code below to not require this init */
         char data[80] = {};
@@ -245,50 +245,50 @@ static inline int __icmp6_send_time_exceeded(struct __sk_buff *skb, int nh_off)
         icmp6hoplim->icmp6_cksum = 0;
         icmp6hoplim->icmp6_dataun.un_data32[0] = 0;
 
-	cilium_dbg(skb, DBG_ICMP6_TIME_EXCEEDED, 0, 0);
+	cilium_dbg(ctx, DBG_ICMP6_TIME_EXCEEDED, 0, 0);
 
         /* read original v6 hdr into offset 8 */
-        if (skb_load_bytes(skb, nh_off, ipv6hdr, sizeof(*ipv6hdr)) < 0)
+        if (ctx_load_bytes(ctx, nh_off, ipv6hdr, sizeof(*ipv6hdr)) < 0)
 		return DROP_INVALID;
 
-	if (ipv6_store_nexthdr(skb, &icmp6_nexthdr, nh_off) < 0)
+	if (ipv6_store_nexthdr(ctx, &icmp6_nexthdr, nh_off) < 0)
 		return DROP_WRITE_ERROR;
 
         /* read original v6 payload into offset 48 */
         switch (ipv6hdr->nexthdr) {
         case IPPROTO_ICMPV6:
         case IPPROTO_UDP:
-                if (skb_load_bytes(skb, nh_off + sizeof(struct ipv6hdr),
+                if (ctx_load_bytes(ctx, nh_off + sizeof(struct ipv6hdr),
                                    upper, 8) < 0)
 			return DROP_INVALID;
 		sum = compute_icmp6_csum(data, 56, ipv6hdr);
 		payload_len = bpf_htons(56);
 		trimlen = 56 - bpf_ntohs(ipv6hdr->payload_len);
-		if (skb_change_tail(skb, skb->len + trimlen, 0) < 0)
+		if (ctx_change_tail(ctx, ctx->len + trimlen, 0) < 0)
 			return DROP_WRITE_ERROR;
 		/* trim or expand buffer and copy data buffer after ipv6 header */
-		if (skb_store_bytes(skb, nh_off + sizeof(struct ipv6hdr),
+		if (ctx_store_bytes(ctx, nh_off + sizeof(struct ipv6hdr),
 				    data, 56, 0) < 0)
 			return DROP_WRITE_ERROR;
-		if (ipv6_store_paylen(skb, nh_off, &payload_len) < 0)
+		if (ipv6_store_paylen(ctx, nh_off, &payload_len) < 0)
 			return DROP_WRITE_ERROR;
 
                 break;
         /* copy header without options */
         case IPPROTO_TCP:
-                if (skb_load_bytes(skb, nh_off + sizeof(struct ipv6hdr),
+                if (ctx_load_bytes(ctx, nh_off + sizeof(struct ipv6hdr),
                                    upper, 20) < 0)
                         return DROP_INVALID;
 		sum = compute_icmp6_csum(data, 68, ipv6hdr);
 		payload_len = bpf_htons(68);
 		/* trim or expand buffer and copy data buffer after ipv6 header */
 		trimlen = 68 - bpf_ntohs(ipv6hdr->payload_len);
-		if (skb_change_tail(skb, skb->len + trimlen, 0) < 0)
+		if (ctx_change_tail(ctx, ctx->len + trimlen, 0) < 0)
 			return DROP_WRITE_ERROR;
-		if (skb_store_bytes(skb, nh_off + sizeof(struct ipv6hdr),
+		if (ctx_store_bytes(ctx, nh_off + sizeof(struct ipv6hdr),
 				    data, 68, 0) < 0)
 			return DROP_WRITE_ERROR;
-		if (ipv6_store_paylen(skb, nh_off, &payload_len) < 0)
+		if (ipv6_store_paylen(ctx, nh_off, &payload_len) < 0)
 			return DROP_WRITE_ERROR;
 
                 break;
@@ -296,23 +296,23 @@ static inline int __icmp6_send_time_exceeded(struct __sk_buff *skb, int nh_off)
                 return DROP_UNKNOWN_L4;
         }
 
-        if (l4_csum_replace(skb, csum_off, 0, sum, BPF_F_PSEUDO_HDR) < 0)
+        if (l4_csum_replace(ctx, csum_off, 0, sum, BPF_F_PSEUDO_HDR) < 0)
 		return DROP_CSUM_L4;
 
-        return icmp6_send_reply(skb, nh_off);
+        return icmp6_send_reply(ctx, nh_off);
 }
 #endif
 
-__section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_SEND_ICMP6_TIME_EXCEEDED) int tail_icmp6_send_time_exceeded(struct __sk_buff *skb)
+__section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_SEND_ICMP6_TIME_EXCEEDED) int tail_icmp6_send_time_exceeded(struct __ctx_buff *ctx)
 {
 #ifdef HAVE_SKB_CHANGE_TAIL
-	int ret, nh_off = skb->cb[0];
-	__u8 direction  = skb->cb[1];
+	int ret, nh_off = ctx->cb[0];
+	__u8 direction  = ctx->cb[1];
 
-	skb->cb[0] = 0;
-	ret = __icmp6_send_time_exceeded(skb, nh_off);
+	ctx->cb[0] = 0;
+	ret = __icmp6_send_time_exceeded(ctx, nh_off);
 	if (IS_ERR(ret))
-		return send_drop_notify_error(skb, 0, ret, TC_ACT_SHOT, direction);
+		return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP, direction);
 
 	return ret;
 #else
@@ -322,60 +322,60 @@ __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_SEND_ICMP6_TIME_EXCEEDED) int tail_
 
 /*
  * icmp6_send_time_exceeded
- * @skb:	socket buffer
+ * @ctx:	socket buffer
  * @nh_off:	offset to the IPv6 header
  * @direction:  direction of packet (can be ingress or egress)
  * Send a ICMPv6 time exceeded in response to an IPv6 frame.
  *
  * NOTE: This is terminal function and will cause the BPF program to exit
  */
-static inline int icmp6_send_time_exceeded(struct __sk_buff *skb, int nh_off, __u8 direction)
+static inline int icmp6_send_time_exceeded(struct __ctx_buff *ctx, int nh_off, __u8 direction)
 {
-	skb->cb[0] = nh_off;
-	skb->cb[1] = direction;
+	ctx->cb[0] = nh_off;
+	ctx->cb[1] = direction;
 
-	ep_tail_call(skb, CILIUM_CALL_SEND_ICMP6_TIME_EXCEEDED);
+	ep_tail_call(ctx, CILIUM_CALL_SEND_ICMP6_TIME_EXCEEDED);
 
 	return DROP_MISSED_TAIL_CALL;
 }
 
-static inline int __icmp6_handle_ns(struct __sk_buff *skb, int nh_off)
+static inline int __icmp6_handle_ns(struct __ctx_buff *ctx, int nh_off)
 {
 	union v6addr target, router;
 
-	if (skb_load_bytes(skb, nh_off + ICMP6_ND_TARGET_OFFSET, target.addr,
+	if (ctx_load_bytes(ctx, nh_off + ICMP6_ND_TARGET_OFFSET, target.addr,
 			   sizeof(((struct ipv6hdr *)NULL)->saddr)) < 0)
 		return DROP_INVALID;
 
-	cilium_dbg(skb, DBG_ICMP6_NS, target.p3, target.p4);
+	cilium_dbg(ctx, DBG_ICMP6_NS, target.p3, target.p4);
 
 	BPF_V6(router, ROUTER_IP);
 	if (ipv6_addrcmp(&target, &router) == 0) {
 		union macaddr router_mac = NODE_MAC;
 
-		return send_icmp6_ndisc_adv(skb, nh_off, &router_mac);
+		return send_icmp6_ndisc_adv(ctx, nh_off, &router_mac);
 	} else {
 		/* Unknown target address, drop */
 		return ACTION_UNKNOWN_ICMP6_NS;
 	}
 }
 
-__section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_HANDLE_ICMP6_NS) int tail_icmp6_handle_ns(struct __sk_buff *skb)
+__section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_HANDLE_ICMP6_NS) int tail_icmp6_handle_ns(struct __ctx_buff *ctx)
 {
-	int ret, nh_off = skb->cb[0];
-	__u8 direction  = skb->cb[1];
+	int ret, nh_off = ctx->cb[0];
+	__u8 direction  = ctx->cb[1];
 
-	skb->cb[0] = 0;
-	ret = __icmp6_handle_ns(skb, nh_off);
+	ctx->cb[0] = 0;
+	ret = __icmp6_handle_ns(ctx, nh_off);
 	if (IS_ERR(ret))
-		return send_drop_notify_error(skb, 0, ret, TC_ACT_SHOT, direction);
+		return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP, direction);
 
 	return ret;
 }
 
 /*
  * icmp6_handle_ns
- * @skb:	socket buffer
+ * @ctx:	socket buffer
  * @nh_off:	offset to the IPv6 header
  * @direction:  direction of packet(ingress or egress)
  *
@@ -383,31 +383,31 @@ __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_HANDLE_ICMP6_NS) int tail_icmp6_han
  *
  * NOTE: This is terminal function and will cause the BPF program to exit
  */
-static inline int icmp6_handle_ns(struct __sk_buff *skb, int nh_off, __u8 direction)
+static inline int icmp6_handle_ns(struct __ctx_buff *ctx, int nh_off, __u8 direction)
 {
-	skb->cb[0] = nh_off;
-	skb->cb[1] = direction;
+	ctx->cb[0] = nh_off;
+	ctx->cb[1] = direction;
 
-	ep_tail_call(skb, CILIUM_CALL_HANDLE_ICMP6_NS);
+	ep_tail_call(ctx, CILIUM_CALL_HANDLE_ICMP6_NS);
 
 	return DROP_MISSED_TAIL_CALL;
 }
 
-static inline int icmp6_handle(struct __sk_buff *skb, int nh_off,
+static inline int icmp6_handle(struct __ctx_buff *ctx, int nh_off,
 			       struct ipv6hdr *ip6, __u8 direction)
 {
 	union v6addr router_ip;
-	__u8 type = icmp6_load_type(skb, nh_off);
+	__u8 type = icmp6_load_type(ctx, nh_off);
 
-	cilium_dbg(skb, DBG_ICMP6_HANDLE, type, 0);
+	cilium_dbg(ctx, DBG_ICMP6_HANDLE, type, 0);
 	BPF_V6(router_ip, ROUTER_IP);
 
 	switch(type) {
 	case 135:
-		return icmp6_handle_ns(skb, nh_off, direction);
+		return icmp6_handle_ns(ctx, nh_off, direction);
 	case ICMPV6_ECHO_REQUEST:
 		if (!ipv6_addrcmp((union v6addr *) &ip6->daddr, &router_ip))
-			return icmp6_send_echo_reply(skb, nh_off, direction);
+			return icmp6_send_echo_reply(ctx, nh_off, direction);
 		break;
 	}
 

--- a/bpf/lib/identity.h
+++ b/bpf/lib/identity.h
@@ -43,27 +43,27 @@ static inline bool identity_is_reserved(__u32 identity)
 	return identity < UNMANAGED_ID || identity == REMOTE_NODE_ID;
 }
 
-static inline bool __inline__ inherit_identity_from_host(struct __sk_buff *skb, __u32 *identity)
+static inline bool __inline__ inherit_identity_from_host(struct __ctx_buff *ctx, __u32 *identity)
 {
-	__u32 magic = skb->mark & MARK_MAGIC_HOST_MASK;
+	__u32 magic = ctx->mark & MARK_MAGIC_HOST_MASK;
 	bool from_proxy = false;
 
 	/* Packets from the ingress proxy must skip the proxy when the
 	 * destination endpoint evaluates the policy. As the packet
 	 * would loop and/or the connection be reset otherwise. */
 	if (magic == MARK_MAGIC_PROXY_INGRESS) {
-		*identity = get_identity(skb);
-		skb->tc_index |= TC_INDEX_F_SKIP_INGRESS_PROXY;
+		*identity = get_identity(ctx);
+		ctx->tc_index |= TC_INDEX_F_SKIP_INGRESS_PROXY;
 		from_proxy = true;
 	/* (Return) packets from the egress proxy must skip the
 	 * redirection to the proxy, as the packet would loop and/or
 	 * the connection be reset otherwise. */
 	} else if (magic == MARK_MAGIC_PROXY_EGRESS) {
-		*identity = get_identity(skb);
-		skb->tc_index |= TC_INDEX_F_SKIP_EGRESS_PROXY;
+		*identity = get_identity(ctx);
+		ctx->tc_index |= TC_INDEX_F_SKIP_EGRESS_PROXY;
 		from_proxy = true;
 	} else if (magic == MARK_MAGIC_IDENTITY) {
-		*identity = get_identity(skb);
+		*identity = get_identity(ctx);
 	} else if (magic == MARK_MAGIC_HOST) {
 		*identity = HOST_ID;
 	} else {
@@ -71,8 +71,8 @@ static inline bool __inline__ inherit_identity_from_host(struct __sk_buff *skb, 
 	}
 
 	/* Reset packet mark to avoid hitting routing rules again */
-	skb->mark = 0;
-	cilium_dbg(skb, DBG_INHERIT_IDENTITY, *identity, 0);
+	ctx->mark = 0;
+	cilium_dbg(ctx, DBG_INHERIT_IDENTITY, *identity, 0);
 
 	return from_proxy;
 }

--- a/bpf/lib/ipv4.h
+++ b/bpf/lib/ipv4.h
@@ -22,12 +22,12 @@
 
 #include "dbg.h"
 
-static inline int ipv4_load_daddr(struct __sk_buff *skb, int off, __u32 *dst)
+static inline int ipv4_load_daddr(struct __ctx_buff *ctx, int off, __u32 *dst)
 {
-	return skb_load_bytes(skb, off + offsetof(struct iphdr, daddr), dst, 4);
+	return ctx_load_bytes(ctx, off + offsetof(struct iphdr, daddr), dst, 4);
 }
 
-static inline int ipv4_dec_ttl(struct __sk_buff *skb, int off, struct iphdr *ip4)
+static inline int ipv4_dec_ttl(struct __ctx_buff *ctx, int off, struct iphdr *ip4)
 {
 	__u8 new_ttl, ttl = ip4->ttl;
 
@@ -36,8 +36,8 @@ static inline int ipv4_dec_ttl(struct __sk_buff *skb, int off, struct iphdr *ip4
 
 	new_ttl = ttl - 1;
 	/* l3_csum_replace() takes at min 2 bytes, zero extended. */
-	l3_csum_replace(skb, off + offsetof(struct iphdr, check), ttl, new_ttl, 2);
-	skb_store_bytes(skb, off + offsetof(struct iphdr, ttl), &new_ttl, sizeof(new_ttl), 0);
+	l3_csum_replace(ctx, off + offsetof(struct iphdr, check), ttl, new_ttl, 2);
+	ctx_store_bytes(ctx, off + offsetof(struct iphdr, ttl), &new_ttl, sizeof(new_ttl), 0);
 
 	return 0;
 }

--- a/bpf/lib/ipv6.h
+++ b/bpf/lib/ipv6.h
@@ -58,7 +58,7 @@ static inline int ipv6_authlen(struct ipv6_opt_hdr *opthdr)
 	return (opthdr->hdrlen + 2) << 2;
 }
 
-static inline int __inline__ ipv6_hdrlen(struct __sk_buff *skb, int l3_off, __u8 *nexthdr)
+static inline int __inline__ ipv6_hdrlen(struct __ctx_buff *ctx, int l3_off, __u8 *nexthdr)
 {
 	int i, len = sizeof(struct ipv6hdr);
 	struct ipv6_opt_hdr opthdr;
@@ -77,7 +77,7 @@ static inline int __inline__ ipv6_hdrlen(struct __sk_buff *skb, int l3_off, __u8
 		case NEXTHDR_ROUTING:
 		case NEXTHDR_AUTH:
 		case NEXTHDR_DEST:
-			if (skb_load_bytes(skb, l3_off + len, &opthdr, sizeof(opthdr)) < 0)
+			if (ctx_load_bytes(ctx, l3_off + len, &opthdr, sizeof(opthdr)) < 0)
 				return DROP_INVALID;
 
 			nh = opthdr.nexthdr;
@@ -151,83 +151,83 @@ static inline int ipv6_match_prefix_64(const union v6addr *addr, const union v6a
 	return !tmp;
 }
 
-static inline int ipv6_dec_hoplimit(struct __sk_buff *skb, int off)
+static inline int ipv6_dec_hoplimit(struct __ctx_buff *ctx, int off)
 {
 	__u8 hl;
 
-	skb_load_bytes(skb, off + offsetof(struct ipv6hdr, hop_limit),
+	ctx_load_bytes(ctx, off + offsetof(struct ipv6hdr, hop_limit),
 		       &hl, sizeof(hl));
 	if (hl <= 1)
 		return 1;
 	hl--;
-	if (skb_store_bytes(skb, off + offsetof(struct ipv6hdr, hop_limit),
+	if (ctx_store_bytes(ctx, off + offsetof(struct ipv6hdr, hop_limit),
 			    &hl, sizeof(hl), BPF_F_RECOMPUTE_CSUM) < 0)
 		return DROP_WRITE_ERROR;
 	return 0;
 }
 
-static inline int ipv6_load_saddr(struct __sk_buff *skb, int off, union v6addr *dst)
+static inline int ipv6_load_saddr(struct __ctx_buff *ctx, int off, union v6addr *dst)
 {
-	return skb_load_bytes(skb, off + offsetof(struct ipv6hdr, saddr), dst->addr,
+	return ctx_load_bytes(ctx, off + offsetof(struct ipv6hdr, saddr), dst->addr,
 			      sizeof(((struct ipv6hdr *)NULL)->saddr));
 }
 
 /* Assumes that caller fixes checksum csum_diff() and l4_csum_replace() */
-static inline int ipv6_store_saddr(struct __sk_buff *skb, __u8 *addr, int off)
+static inline int ipv6_store_saddr(struct __ctx_buff *ctx, __u8 *addr, int off)
 {
-	return skb_store_bytes(skb, off + offsetof(struct ipv6hdr, saddr), addr, 16, 0);
+	return ctx_store_bytes(ctx, off + offsetof(struct ipv6hdr, saddr), addr, 16, 0);
 }
 
-static inline int ipv6_load_daddr(struct __sk_buff *skb, int off, union v6addr *dst)
+static inline int ipv6_load_daddr(struct __ctx_buff *ctx, int off, union v6addr *dst)
 {
-	return skb_load_bytes(skb, off + offsetof(struct ipv6hdr, daddr), dst->addr,
+	return ctx_load_bytes(ctx, off + offsetof(struct ipv6hdr, daddr), dst->addr,
 			      sizeof(((struct ipv6hdr *)NULL)->daddr));
 }
 
 /* Assumes that caller fixes checksum csum_diff() and l4_csum_replace() */
-static inline int ipv6_store_daddr(struct __sk_buff *skb, __u8 *addr, int off)
+static inline int ipv6_store_daddr(struct __ctx_buff *ctx, __u8 *addr, int off)
 {
-	return skb_store_bytes(skb, off + offsetof(struct ipv6hdr, daddr), addr, 16, 0);
+	return ctx_store_bytes(ctx, off + offsetof(struct ipv6hdr, daddr), addr, 16, 0);
 }
 
-static inline int ipv6_load_nexthdr(struct __sk_buff *skb, int off, __u8 *nexthdr)
+static inline int ipv6_load_nexthdr(struct __ctx_buff *ctx, int off, __u8 *nexthdr)
 {
-	return skb_load_bytes(skb, off + offsetof(struct ipv6hdr, nexthdr), nexthdr,
+	return ctx_load_bytes(ctx, off + offsetof(struct ipv6hdr, nexthdr), nexthdr,
 			      sizeof(__u8));
 }
 
 /* Assumes that caller fixes checksum csum_diff() and l4_csum_replace() */
-static inline int ipv6_store_nexthdr(struct __sk_buff *skb, __u8 *nexthdr, int off)
+static inline int ipv6_store_nexthdr(struct __ctx_buff *ctx, __u8 *nexthdr, int off)
 {
-	return skb_store_bytes(skb, off + offsetof(struct ipv6hdr, nexthdr), nexthdr,
+	return ctx_store_bytes(ctx, off + offsetof(struct ipv6hdr, nexthdr), nexthdr,
 			      sizeof(__u8), 0);
 }
 
-static inline int ipv6_load_paylen(struct __sk_buff *skb, int off, __be16 *len)
+static inline int ipv6_load_paylen(struct __ctx_buff *ctx, int off, __be16 *len)
 {
-	return skb_load_bytes(skb, off + offsetof(struct ipv6hdr, payload_len),
+	return ctx_load_bytes(ctx, off + offsetof(struct ipv6hdr, payload_len),
 			      len, sizeof(*len));
 }
 
 /* Assumes that caller fixes checksum csum_diff() and l4_csum_replace() */
-static inline int ipv6_store_paylen(struct __sk_buff *skb, int off, __be16 *len)
+static inline int ipv6_store_paylen(struct __ctx_buff *ctx, int off, __be16 *len)
 {
-	return skb_store_bytes(skb, off + offsetof(struct ipv6hdr, payload_len),
+	return ctx_store_bytes(ctx, off + offsetof(struct ipv6hdr, payload_len),
 			       len, sizeof(*len), 0);
 }
 
-static inline int ipv6_store_flowlabel(struct __sk_buff *skb, int off, __be32 label)
+static inline int ipv6_store_flowlabel(struct __ctx_buff *ctx, int off, __be32 label)
 {
 	__be32 old;
 
 	/* use traffic class from packet */
-	if (skb_load_bytes(skb, off, &old, 4) < 0)
+	if (ctx_load_bytes(ctx, off, &old, 4) < 0)
 		return DROP_INVALID;
 
 	old &= IPV6_TCLASS_MASK;
 	old = bpf_htonl(0x60000000) | label | old;
 
-	if (skb_store_bytes(skb, off, &old, 4, BPF_F_RECOMPUTE_CSUM) < 0)
+	if (ctx_store_bytes(ctx, off, &old, 4, BPF_F_RECOMPUTE_CSUM) < 0)
 		return DROP_WRITE_ERROR;
 
 	return 0;

--- a/bpf/lib/l3.h
+++ b/bpf/lib/l3.h
@@ -29,62 +29,62 @@
 #include "csum.h"
 
 #ifdef ENABLE_IPV6
-static inline int __inline__ ipv6_l3(struct __sk_buff *skb, int l3_off,
+static inline int __inline__ ipv6_l3(struct __ctx_buff *ctx, int l3_off,
 				     __u8 *smac, __u8 *dmac, __u8 direction)
 {
 	int ret;
 
-	ret = ipv6_dec_hoplimit(skb, l3_off);
+	ret = ipv6_dec_hoplimit(ctx, l3_off);
 	if (IS_ERR(ret))
 		return ret;
 
 	if (ret > 0) {
 		/* Hoplimit was reached */
-		return icmp6_send_time_exceeded(skb, l3_off, direction);
+		return icmp6_send_time_exceeded(ctx, l3_off, direction);
 	}
 
-	if (smac && eth_store_saddr(skb, smac, 0) < 0)
+	if (smac && eth_store_saddr(ctx, smac, 0) < 0)
 		return DROP_WRITE_ERROR;
 
-	if (eth_store_daddr(skb, dmac, 0) < 0)
+	if (eth_store_daddr(ctx, dmac, 0) < 0)
 		return DROP_WRITE_ERROR;
 
-	return TC_ACT_OK;
+	return CTX_ACT_OK;
 }
 #endif /* ENABLE_IPV6 */
 
-static inline int __inline__ ipv4_l3(struct __sk_buff *skb, int l3_off,
+static inline int __inline__ ipv4_l3(struct __ctx_buff *ctx, int l3_off,
 				     __u8 *smac, __u8 *dmac, struct iphdr *ip4)
 {
-	if (ipv4_dec_ttl(skb, l3_off, ip4)) {
+	if (ipv4_dec_ttl(ctx, l3_off, ip4)) {
 		/* FIXME: Send ICMP TTL */
 		return DROP_INVALID;
 	}
 
-	if (smac && eth_store_saddr(skb, smac, 0) < 0)
+	if (smac && eth_store_saddr(ctx, smac, 0) < 0)
 		return DROP_WRITE_ERROR;
 
-	if (eth_store_daddr(skb, dmac, 0) < 0)
+	if (eth_store_daddr(ctx, dmac, 0) < 0)
 		return DROP_WRITE_ERROR;
 
-	return TC_ACT_OK;
+	return CTX_ACT_OK;
 }
 
 #ifdef ENABLE_IPV6
-static inline int ipv6_local_delivery(struct __sk_buff *skb, int l3_off, int l4_off,
+static inline int ipv6_local_delivery(struct __ctx_buff *ctx, int l3_off, int l4_off,
 				      __u32 seclabel, struct ipv6hdr *ip6, __u8 nexthdr,
 				      struct endpoint_info *ep, __u8 direction)
 {
 	int ret;
 
-	cilium_dbg(skb, DBG_LOCAL_DELIVERY, ep->lxc_id, seclabel);
+	cilium_dbg(ctx, DBG_LOCAL_DELIVERY, ep->lxc_id, seclabel);
 
 	mac_t lxc_mac = ep->mac;
 	mac_t router_mac = ep->node_mac;
 
 	/* This will invalidate the size check */
-	ret = ipv6_l3(skb, l3_off, (__u8 *) &router_mac, (__u8 *) &lxc_mac, direction);
-	if (ret != TC_ACT_OK)
+	ret = ipv6_l3(ctx, l3_off, (__u8 *) &router_mac, (__u8 *) &lxc_mac, direction);
+	if (ret != CTX_ACT_OK)
 		return ret;
 
 #if defined LOCAL_DELIVERY_METRICS
@@ -93,34 +93,34 @@ static inline int ipv6_local_delivery(struct __sk_buff *skb, int l3_off, int l4_
 	 * Note that the packet could still be dropped but it would show up
 	 * as an ingress drop counter in metrics.
 	 */
-	update_metrics(skb->len, direction, REASON_FORWARDED);
+	update_metrics(ctx->len, direction, REASON_FORWARDED);
 #endif
 
 #if defined USE_BPF_PROG_FOR_INGRESS_POLICY && !defined FORCE_LOCAL_POLICY_EVAL_AT_SOURCE
-	skb->mark = (seclabel << 16) | MARK_MAGIC_IDENTITY;
+	ctx->mark = (seclabel << 16) | MARK_MAGIC_IDENTITY;
 	return redirect_peer(ep->ifindex, 0);
 #else
-	skb->cb[CB_SRC_LABEL] = seclabel;
-	skb->cb[CB_IFINDEX] = ep->ifindex;
-	tail_call(skb, &POLICY_CALL_MAP, ep->lxc_id);
+	ctx->cb[CB_SRC_LABEL] = seclabel;
+	ctx->cb[CB_IFINDEX] = ep->ifindex;
+	tail_call(ctx, &POLICY_CALL_MAP, ep->lxc_id);
 	return DROP_MISSED_TAIL_CALL;
 #endif
 }
 #endif /* ENABLE_IPV6 */
 
-static inline int __inline__ ipv4_local_delivery(struct __sk_buff *skb, int l3_off, int l4_off,
+static inline int __inline__ ipv4_local_delivery(struct __ctx_buff *ctx, int l3_off, int l4_off,
 						 __u32 seclabel, struct iphdr *ip4,
 						 struct endpoint_info *ep, __u8 direction)
 {
 	int ret;
 
-	cilium_dbg(skb, DBG_LOCAL_DELIVERY, ep->lxc_id, seclabel);
+	cilium_dbg(ctx, DBG_LOCAL_DELIVERY, ep->lxc_id, seclabel);
 
 	mac_t lxc_mac = ep->mac;
 	mac_t router_mac = ep->node_mac;
 
-	ret = ipv4_l3(skb, l3_off, (__u8 *) &router_mac, (__u8 *) &lxc_mac, ip4);
-	if (ret != TC_ACT_OK)
+	ret = ipv4_l3(ctx, l3_off, (__u8 *) &router_mac, (__u8 *) &lxc_mac, ip4);
+	if (ret != CTX_ACT_OK)
 		return ret;
 
 #if defined LOCAL_DELIVERY_METRICS
@@ -129,16 +129,16 @@ static inline int __inline__ ipv4_local_delivery(struct __sk_buff *skb, int l3_o
 	 * Note that the packet could still be dropped but it would show up
 	 * as an ingress drop counter in metrics.
 	 */
-	update_metrics(skb->len, direction, REASON_FORWARDED);
+	update_metrics(ctx->len, direction, REASON_FORWARDED);
 #endif
 
 #if defined USE_BPF_PROG_FOR_INGRESS_POLICY && !defined FORCE_LOCAL_POLICY_EVAL_AT_SOURCE
-	skb->mark = (seclabel << 16) | MARK_MAGIC_IDENTITY;
+	ctx->mark = (seclabel << 16) | MARK_MAGIC_IDENTITY;
 	return redirect_peer(ep->ifindex, 0);
 #else
-	skb->cb[CB_SRC_LABEL] = seclabel;
-	skb->cb[CB_IFINDEX] = ep->ifindex;
-	tail_call(skb, &POLICY_CALL_MAP, ep->lxc_id);
+	ctx->cb[CB_SRC_LABEL] = seclabel;
+	ctx->cb[CB_IFINDEX] = ep->ifindex;
+	tail_call(ctx, &POLICY_CALL_MAP, ep->lxc_id);
 	return DROP_MISSED_TAIL_CALL;
 #endif
 }

--- a/bpf/lib/l4.h
+++ b/bpf/lib/l4.h
@@ -32,7 +32,7 @@
 
 /**
  * Modify L4 port and correct checksum
- * @arg skb:      packet
+ * @arg ctx:      packet
  * @arg l4_off:   offset to L4 header
  * @arg off:      offset from L4 header to source or destination port
  * @arg csum_off: offset from L4 header to 16bit checksum field in L4 header
@@ -40,27 +40,27 @@
  * @arg old_port: old port value (for checksum correction)
  *
  * Overwrites a TCP or UDP port with new value and fixes up the checksum
- * in the L4 header and of skb->csum.
+ * in the L4 header and of ctx->csum.
  *
  * NOTE: Calling this function will invalidate any pkt context offset
  * validation for direct packet access.
  *
  * Return 0 on success or a negative DROP_* reason
  */
-static inline int l4_modify_port(struct __sk_buff *skb, int l4_off, int off,
+static inline int l4_modify_port(struct __ctx_buff *ctx, int l4_off, int off,
 				 struct csum_offset *csum_off, __be16 port, __be16 old_port)
 {
-	if (csum_l4_replace(skb, l4_off, csum_off, old_port, port, sizeof(port)) < 0)
+	if (csum_l4_replace(ctx, l4_off, csum_off, old_port, port, sizeof(port)) < 0)
 		return DROP_CSUM_L4;
 
-	if (skb_store_bytes(skb, l4_off + off, &port, sizeof(port), 0) < 0)
+	if (ctx_store_bytes(ctx, l4_off + off, &port, sizeof(port), 0) < 0)
 		return DROP_WRITE_ERROR;
 
 	return 0;
 }
 
-static inline int l4_load_port(struct __sk_buff *skb, int off, __be16 *port)
+static inline int l4_load_port(struct __ctx_buff *ctx, int off, __be16 *port)
 {
-        return skb_load_bytes(skb, off, port, sizeof(__be16));
+        return ctx_load_bytes(ctx, off, port, sizeof(__be16));
 }
 #endif

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -151,7 +151,7 @@ static inline int lb4_select_slave(__u16 count)
 	return (get_prandom_u32() % count) + 1;
 }
 
-static inline int __inline__ extract_l4_port(struct __sk_buff *skb, __u8 nexthdr,
+static inline int __inline__ extract_l4_port(struct __ctx_buff *ctx, __u8 nexthdr,
 					     int l4_off, __be16 *port)
 {
 	int ret;
@@ -160,7 +160,7 @@ static inline int __inline__ extract_l4_port(struct __sk_buff *skb, __u8 nexthdr
 	case IPPROTO_TCP:
 	case IPPROTO_UDP:
 		/* Port offsets for UDP and TCP are the same */
-		ret = l4_load_port(skb, l4_off + TCP_DPORT_OFF, port);
+		ret = l4_load_port(ctx, l4_off + TCP_DPORT_OFF, port);
 		if (IS_ERR(ret))
 			return ret;
 		break;
@@ -177,7 +177,7 @@ static inline int __inline__ extract_l4_port(struct __sk_buff *skb, __u8 nexthdr
 	return 0;
 }
 
-static inline int __inline__ reverse_map_l4_port(struct __sk_buff *skb, __u8 nexthdr,
+static inline int __inline__ reverse_map_l4_port(struct __ctx_buff *ctx, __u8 nexthdr,
 						 __be16 port, int l4_off,
 						 struct csum_offset *csum_off)
 {
@@ -189,12 +189,12 @@ static inline int __inline__ reverse_map_l4_port(struct __sk_buff *skb, __u8 nex
 			int ret;
 
 			/* Port offsets for UDP and TCP are the same */
-			ret = l4_load_port(skb, l4_off + TCP_SPORT_OFF, &old_port);
+			ret = l4_load_port(ctx, l4_off + TCP_SPORT_OFF, &old_port);
 			if (IS_ERR(ret))
 				return ret;
 
 			if (port != old_port) {
-				ret = l4_modify_port(skb, l4_off, TCP_SPORT_OFF,
+				ret = l4_modify_port(ctx, l4_off, TCP_SPORT_OFF,
 						     csum_off, port, old_port);
 				if (IS_ERR(ret))
 					return ret;
@@ -214,7 +214,7 @@ static inline int __inline__ reverse_map_l4_port(struct __sk_buff *skb, __u8 nex
 }
 
 #ifdef ENABLE_IPV6
-static inline int __inline__ __lb6_rev_nat(struct __sk_buff *skb, int l4_off,
+static inline int __inline__ __lb6_rev_nat(struct __ctx_buff *ctx, int l4_off,
 					 struct csum_offset *csum_off,
 					 struct ipv6_ct_tuple *tuple, int flags,
 					 struct lb6_reverse_nat *nat)
@@ -225,10 +225,10 @@ static inline int __inline__ __lb6_rev_nat(struct __sk_buff *skb, int l4_off,
 	__be32 sum;
 	int ret;
 
-	cilium_dbg_lb(skb, DBG_LB6_REVERSE_NAT, nat->address.p4, nat->port);
+	cilium_dbg_lb(ctx, DBG_LB6_REVERSE_NAT, nat->address.p4, nat->port);
 
 	if (nat->port) {
-		ret = reverse_map_l4_port(skb, tuple->nexthdr, nat->port, l4_off, csum_off);
+		ret = reverse_map_l4_port(ctx, tuple->nexthdr, nat->port, l4_off, csum_off);
 		if (IS_ERR(ret))
 			return ret;
 	}
@@ -238,26 +238,26 @@ static inline int __inline__ __lb6_rev_nat(struct __sk_buff *skb, int l4_off,
 		ipv6_addr_copy(&tuple->saddr, &nat->address);
 		new_saddr = tuple->saddr.addr;
 	} else {
-		if (ipv6_load_saddr(skb, ETH_HLEN, &old_saddr) < 0)
+		if (ipv6_load_saddr(ctx, ETH_HLEN, &old_saddr) < 0)
 			return DROP_INVALID;
 
 		ipv6_addr_copy(&tmp, &nat->address);
 		new_saddr = tmp.addr;
 	}
 
-	ret = ipv6_store_saddr(skb, new_saddr, ETH_HLEN);
+	ret = ipv6_store_saddr(ctx, new_saddr, ETH_HLEN);
 	if (IS_ERR(ret))
 		return DROP_WRITE_ERROR;
 
 	sum = csum_diff(old_saddr.addr, 16, new_saddr, 16, 0);
-	if (csum_l4_replace(skb, l4_off, csum_off, 0, sum, BPF_F_PSEUDO_HDR) < 0)
+	if (csum_l4_replace(ctx, l4_off, csum_off, 0, sum, BPF_F_PSEUDO_HDR) < 0)
 		return DROP_CSUM_L4;
 
 	return 0;
 }
 
 /** Perform IPv6 reverse NAT based on reverse NAT index
- * @arg skb		packet
+ * @arg ctx		packet
  * @arg l4_off		offset to L4
  * @arg csum_off	offset to L4 checksum field
  * @arg csum_flags	checksum flags
@@ -265,37 +265,37 @@ static inline int __inline__ __lb6_rev_nat(struct __sk_buff *skb, int l4_off,
  * @arg tuple		tuple
  * @arg saddr_tuple	If set, tuple address will be updated with new source address
  */
-static inline int __inline__ lb6_rev_nat(struct __sk_buff *skb, int l4_off,
+static inline int __inline__ lb6_rev_nat(struct __ctx_buff *ctx, int l4_off,
 					 struct csum_offset *csum_off, __u16 index,
 					 struct ipv6_ct_tuple *tuple, int flags)
 {
 	struct lb6_reverse_nat *nat;
 
-	cilium_dbg_lb(skb, DBG_LB6_REVERSE_NAT_LOOKUP, index, 0);
+	cilium_dbg_lb(ctx, DBG_LB6_REVERSE_NAT_LOOKUP, index, 0);
 	nat = map_lookup_elem(&LB6_REVERSE_NAT_MAP, &index);
 	if (nat == NULL)
 		return 0;
 
-	return __lb6_rev_nat(skb, l4_off, csum_off, tuple, flags, nat);
+	return __lb6_rev_nat(ctx, l4_off, csum_off, tuple, flags, nat);
 }
 
 /** Extract IPv6 LB key from packet
- * @arg skb		Packet
+ * @arg ctx		Packet
  * @arg tuple		Tuple
  * @arg l4_off		Offset to L4 header
  * @arg key		Pointer to store LB key in
  * @arg csum_off	Pointer to store L4 checksum field offset and flags
  * @arg dir		Flow direction
  *
- * Expects the skb to be validated for direct packet access up to L4. Fills
+ * Expects the ctx to be validated for direct packet access up to L4. Fills
  * lb6_key based on L4 nexthdr.
  *
  * Returns:
- *   - TC_ACT_OK on successful extraction
+ *   - CTX_ACT_OK on successful extraction
  *   - DROP_UNKNOWN_L4 if packet should be ignore (sent to stack)
  *   - Negative error code
  */
-static inline int __inline__ lb6_extract_key(struct __sk_buff *skb,
+static inline int __inline__ lb6_extract_key(struct __ctx_buff *ctx,
 					     struct ipv6_ct_tuple *tuple,
 					     int l4_off,
 					     struct lb6_key *key,
@@ -310,7 +310,7 @@ static inline int __inline__ lb6_extract_key(struct __sk_buff *skb,
 	csum_l4_offset_and_flags(tuple->nexthdr, csum_off);
 
 #ifdef LB_L4
-	return extract_l4_port(skb, tuple->nexthdr, l4_off, &key->dport);
+	return extract_l4_port(ctx, tuple->nexthdr, l4_off, &key->dport);
 #else
 	return 0;
 #endif
@@ -325,7 +325,7 @@ struct lb6_service *__lb6_lookup_service(struct lb6_key *key)
 		struct lb6_service *svc;
 
 		/* FIXME: The verifier barks on these calls right now for some reason */
-		/* cilium_dbg_lb(skb, DBG_LB4_LOOKUP_MASTER, key->address, key->dport); */
+		/* cilium_dbg_lb(ctx, DBG_LB4_LOOKUP_MASTER, key->address, key->dport); */
 		svc = map_lookup_elem(&LB6_SERVICES_MAP_V2, key);
 		if (svc && svc->count != 0)
 			return svc;
@@ -339,7 +339,7 @@ struct lb6_service *__lb6_lookup_service(struct lb6_key *key)
 		struct lb6_service *svc;
 
 		/* FIXME: The verifier barks on these calls right now for some reason */
-		/* cilium_dbg_lb(skb, DBG_LB4_LOOKUP_MASTER, key->address, key->dport); */
+		/* cilium_dbg_lb(ctx, DBG_LB4_LOOKUP_MASTER, key->address, key->dport); */
 		svc = map_lookup_elem(&LB6_SERVICES_MAP_V2, key);
 		if (svc && svc->count != 0)
 			return svc;
@@ -349,14 +349,14 @@ struct lb6_service *__lb6_lookup_service(struct lb6_key *key)
 }
 
 static inline
-struct lb6_service *lb6_lookup_service(struct __sk_buff *skb,
+struct lb6_service *lb6_lookup_service(struct __ctx_buff *ctx,
 				       struct lb6_key *key)
 {
 	struct lb6_service *svc = __lb6_lookup_service(key);
 
 
 	if (!svc)
-		cilium_dbg_lb(skb, DBG_LB6_LOOKUP_MASTER_FAIL, 0, 0);
+		cilium_dbg_lb(ctx, DBG_LB6_LOOKUP_MASTER_FAIL, 0, 0);
 
 	return svc;
 }
@@ -366,14 +366,14 @@ static inline struct lb6_backend *__lb6_lookup_backend(__u16 backend_id)
 	return map_lookup_elem(&LB6_BACKEND_MAP, &backend_id);
 }
 
-static inline struct lb6_backend *lb6_lookup_backend(struct __sk_buff *skb,
+static inline struct lb6_backend *lb6_lookup_backend(struct __ctx_buff *ctx,
 						     __u16 backend_id)
 {
 	struct lb6_backend *backend;
 
 	backend = __lb6_lookup_backend(backend_id);
 	if (!backend) {
-		cilium_dbg_lb(skb, DBG_LB6_LOOKUP_BACKEND_FAIL, backend_id, 0);
+		cilium_dbg_lb(ctx, DBG_LB6_LOOKUP_BACKEND_FAIL, backend_id, 0);
 	}
 
 	return backend;
@@ -386,24 +386,24 @@ struct lb6_service *__lb6_lookup_slave(struct lb6_key *key)
 }
 
 static inline
-struct lb6_service *lb6_lookup_slave(struct __sk_buff *skb,
+struct lb6_service *lb6_lookup_slave(struct __ctx_buff *ctx,
 				     struct lb6_key *key, __u16 slave)
 {
 	struct lb6_service *svc;
 
 	key->slave = slave;
-	cilium_dbg_lb(skb, DBG_LB6_LOOKUP_SLAVE, key->slave, key->dport);
+	cilium_dbg_lb(ctx, DBG_LB6_LOOKUP_SLAVE, key->slave, key->dport);
 	svc = __lb6_lookup_slave(key);
 	if (svc != NULL) {
 		return svc;
 	}
 
-	cilium_dbg_lb(skb, DBG_LB6_LOOKUP_SLAVE_V2_FAIL, key->slave, key->dport);
+	cilium_dbg_lb(ctx, DBG_LB6_LOOKUP_SLAVE_V2_FAIL, key->slave, key->dport);
 
 	return NULL;
 }
 
-static inline int __inline__ lb6_xlate(struct __sk_buff *skb,
+static inline int __inline__ lb6_xlate(struct __ctx_buff *ctx,
 				       union v6addr *new_dst, __u8 nexthdr,
 				       int l3_off, int l4_off,
 				       struct csum_offset *csum_off,
@@ -411,11 +411,11 @@ static inline int __inline__ lb6_xlate(struct __sk_buff *skb,
 				       struct lb6_service *svc,
 				       struct lb6_backend *backend)
 {
-	ipv6_store_daddr(skb, new_dst->addr, l3_off);
+	ipv6_store_daddr(ctx, new_dst->addr, l3_off);
 
 	if (csum_off) {
 		__be32 sum = csum_diff(key->address.addr, 16, new_dst->addr, 16, 0);
-		if (csum_l4_replace(skb, l4_off, csum_off, 0, sum, BPF_F_PSEUDO_HDR) < 0)
+		if (csum_l4_replace(ctx, l4_off, csum_off, 0, sum, BPF_F_PSEUDO_HDR) < 0)
 			return DROP_CSUM_L4;
 	}
 
@@ -426,16 +426,16 @@ static inline int __inline__ lb6_xlate(struct __sk_buff *skb,
 		int ret;
 
 		/* Port offsets for UDP and TCP are the same */
-		ret = l4_modify_port(skb, l4_off, TCP_DPORT_OFF, csum_off, tmp, key->dport);
+		ret = l4_modify_port(ctx, l4_off, TCP_DPORT_OFF, csum_off, tmp, key->dport);
 		if (IS_ERR(ret))
 			return ret;
 	}
 #endif
 
-	return TC_ACT_OK;
+	return CTX_ACT_OK;
 }
 
-static inline int __inline__ lb6_local(void *map, struct __sk_buff *skb,
+static inline int __inline__ lb6_local(void *map, struct __ctx_buff *ctx,
 				       int l3_off, int l4_off,
 				       struct csum_offset *csum_off,
 				       struct lb6_key *key,
@@ -453,20 +453,20 @@ static inline int __inline__ lb6_local(void *map, struct __sk_buff *skb,
 
 	/* See lb4_local comments re svc endpoint lookup process */
 
-	ret = ct_lookup6(map, tuple, skb, l4_off, CT_SERVICE, state, &monitor);
+	ret = ct_lookup6(map, tuple, ctx, l4_off, CT_SERVICE, state, &monitor);
 	switch(ret) {
 	case CT_NEW:
 		slave = lb6_select_slave(svc->count);
-		if ((slave_svc = lb6_lookup_slave(skb, key, slave)) == NULL) {
+		if ((slave_svc = lb6_lookup_slave(ctx, key, slave)) == NULL) {
 			goto drop_no_service;
 		}
-		backend = lb6_lookup_backend(skb, slave_svc->backend_id);
+		backend = lb6_lookup_backend(ctx, slave_svc->backend_id);
 		if (backend == NULL) {
 			goto drop_no_service;
 		}
 		state->backend_id = slave_svc->backend_id;
 		state->rev_nat_index = svc->rev_nat_index;
-		ret = ct_create6(map, tuple, skb, CT_SERVICE, state, false);
+		ret = ct_create6(map, tuple, ctx, CT_SERVICE, state, false);
 		/* Fail closed, if the conntrack entry create fails drop
 		 * service lookup.
 		 */
@@ -489,10 +489,10 @@ static inline int __inline__ lb6_local(void *map, struct __sk_buff *skb,
 
 	// See lb4_local comment
 	if (state->rev_nat_index != svc->rev_nat_index) {
-		cilium_dbg_lb(skb, DBG_LB_STALE_CT, svc->rev_nat_index,
+		cilium_dbg_lb(ctx, DBG_LB_STALE_CT, svc->rev_nat_index,
 			      state->rev_nat_index);
 		slave = lb6_select_slave(svc->count);
-		if (!(slave_svc = lb6_lookup_slave(skb, key, slave))) {
+		if (!(slave_svc = lb6_lookup_slave(ctx, key, slave))) {
 			goto drop_no_service;
 		}
 		state->backend_id = slave_svc->backend_id;
@@ -504,16 +504,16 @@ static inline int __inline__ lb6_local(void *map, struct __sk_buff *skb,
 	 * underneath us. To resolve this fall back to hash. If this is a TCP
 	 * session we are likely to get a TCP RST.
 	 */
-	if (!(backend = lb6_lookup_backend(skb, state->backend_id))) {
+	if (!(backend = lb6_lookup_backend(ctx, state->backend_id))) {
 		key->slave = 0;
-		if (!(svc = lb6_lookup_service(skb, key))) {
+		if (!(svc = lb6_lookup_service(ctx, key))) {
 			goto drop_no_service;
 		}
 		slave = lb6_select_slave(svc->count);
-		if (!(slave_svc = lb6_lookup_slave(skb, key, slave))) {
+		if (!(slave_svc = lb6_lookup_slave(ctx, key, slave))) {
 			goto drop_no_service;
 		}
-		backend = lb6_lookup_backend(skb, slave_svc->backend_id);
+		backend = lb6_lookup_backend(ctx, slave_svc->backend_id);
 		if (backend == NULL) {
 			goto drop_no_service;
 		}
@@ -530,7 +530,7 @@ update_state:
 	addr = &tuple->daddr;
 	state->rev_nat_index = svc->rev_nat_index;
 
-	return lb6_xlate(skb, addr, tuple->nexthdr, l3_off, l4_off,
+	return lb6_xlate(ctx, addr, tuple->nexthdr, l3_off, l4_off,
 			 csum_off, key, svc, backend);
 
 drop_no_service:
@@ -560,7 +560,7 @@ static inline struct lb6_backend *__lb6_lookup_backend(__u16 backend_id)
 #endif /* ENABLE_IPV6 */
 
 #ifdef ENABLE_IPV4
-static inline int __inline__ __lb4_rev_nat(struct __sk_buff *skb, int l3_off, int l4_off,
+static inline int __inline__ __lb4_rev_nat(struct __ctx_buff *ctx, int l3_off, int l4_off,
 					 struct csum_offset *csum_off,
 					 struct ipv4_ct_tuple *tuple, int flags,
 					 struct lb4_reverse_nat *nat,
@@ -569,10 +569,10 @@ static inline int __inline__ __lb4_rev_nat(struct __sk_buff *skb, int l3_off, in
 	__be32 old_sip, new_sip, sum = 0;
 	int ret;
 
-	cilium_dbg_lb(skb, DBG_LB4_REVERSE_NAT, nat->address, nat->port);
+	cilium_dbg_lb(ctx, DBG_LB4_REVERSE_NAT, nat->address, nat->port);
 
 	if (nat->port) {
-		ret = reverse_map_l4_port(skb, tuple->nexthdr, nat->port, l4_off, csum_off);
+		ret = reverse_map_l4_port(ctx, tuple->nexthdr, nat->port, l4_off, csum_off);
 		if (IS_ERR(ret))
 			return ret;
 	}
@@ -581,7 +581,7 @@ static inline int __inline__ __lb4_rev_nat(struct __sk_buff *skb, int l3_off, in
 		old_sip = tuple->saddr;
 		tuple->saddr = new_sip = nat->address;
 	} else {
-		ret = skb_load_bytes(skb, l3_off + offsetof(struct iphdr, saddr), &old_sip, 4);
+		ret = ctx_load_bytes(ctx, l3_off + offsetof(struct iphdr, saddr), &old_sip, 4);
 		if (IS_ERR(ret))
 			return ret;
 
@@ -596,13 +596,13 @@ static inline int __inline__ __lb4_rev_nat(struct __sk_buff *skb, int l3_off, in
 		 * address the new destination address */
 		__be32 old_dip;
 
-		ret = skb_load_bytes(skb, l3_off + offsetof(struct iphdr, daddr), &old_dip, 4);
+		ret = ctx_load_bytes(ctx, l3_off + offsetof(struct iphdr, daddr), &old_dip, 4);
 		if (IS_ERR(ret))
 			return ret;
 
-		cilium_dbg_lb(skb, DBG_LB4_LOOPBACK_SNAT_REV, old_dip, old_sip);
+		cilium_dbg_lb(ctx, DBG_LB4_LOOPBACK_SNAT_REV, old_dip, old_sip);
 
-		ret = skb_store_bytes(skb, l3_off + offsetof(struct iphdr, daddr), &old_sip, 4, 0);
+		ret = ctx_store_bytes(ctx, l3_off + offsetof(struct iphdr, daddr), &old_sip, 4, 0);
 		if (IS_ERR(ret))
 			return DROP_WRITE_ERROR;
 
@@ -612,16 +612,16 @@ static inline int __inline__ __lb4_rev_nat(struct __sk_buff *skb, int l3_off, in
 		tuple->saddr = old_sip;
 	}
 
-        ret = skb_store_bytes(skb, l3_off + offsetof(struct iphdr, saddr), &new_sip, 4, 0);
+        ret = ctx_store_bytes(ctx, l3_off + offsetof(struct iphdr, saddr), &new_sip, 4, 0);
 	if (IS_ERR(ret))
 		return DROP_WRITE_ERROR;
 
 	sum = csum_diff(&old_sip, 4, &new_sip, 4, sum);
-	if (l3_csum_replace(skb, l3_off + offsetof(struct iphdr, check), 0, sum, 0) < 0)
+	if (l3_csum_replace(ctx, l3_off + offsetof(struct iphdr, check), 0, sum, 0) < 0)
 		return DROP_CSUM_L3;
 
 	if (csum_off->offset &&
-	    csum_l4_replace(skb, l4_off, csum_off, 0, sum, BPF_F_PSEUDO_HDR) < 0)
+	    csum_l4_replace(ctx, l4_off, csum_off, 0, sum, BPF_F_PSEUDO_HDR) < 0)
 		return DROP_CSUM_L4;
 
 	return 0;
@@ -629,7 +629,7 @@ static inline int __inline__ __lb4_rev_nat(struct __sk_buff *skb, int l3_off, in
 
 
 /** Perform IPv4 reverse NAT based on reverse NAT index
- * @arg skb		packet
+ * @arg ctx		packet
  * @arg l3_off		offset to L3
  * @arg l4_off		offset to L4
  * @arg csum_off	offset to L4 checksum field
@@ -637,24 +637,24 @@ static inline int __inline__ __lb4_rev_nat(struct __sk_buff *skb, int l3_off, in
  * @arg index		reverse NAT index
  * @arg tuple		tuple
  */
-static inline int __inline__ lb4_rev_nat(struct __sk_buff *skb, int l3_off, int l4_off,
+static inline int __inline__ lb4_rev_nat(struct __ctx_buff *ctx, int l3_off, int l4_off,
 					 struct csum_offset *csum_off,
 					 struct ct_state *ct_state,
 					 struct ipv4_ct_tuple *tuple, int flags)
 {
 	struct lb4_reverse_nat *nat;
 
-	cilium_dbg_lb(skb, DBG_LB4_REVERSE_NAT_LOOKUP, ct_state->rev_nat_index, 0);
+	cilium_dbg_lb(ctx, DBG_LB4_REVERSE_NAT_LOOKUP, ct_state->rev_nat_index, 0);
 	nat = map_lookup_elem(&LB4_REVERSE_NAT_MAP, &ct_state->rev_nat_index);
 	if (nat == NULL)
 		return 0;
 
-	return __lb4_rev_nat(skb, l3_off, l4_off, csum_off, tuple, flags, nat,
+	return __lb4_rev_nat(ctx, l3_off, l4_off, csum_off, tuple, flags, nat,
 			     ct_state);
 }
 
 /** Extract IPv4 LB key from packet
- * @arg skb		Packet
+ * @arg ctx		Packet
  * @arg tuple		Tuple
  * @arg l4_off		Offset to L4 header
  * @arg key		Pointer to store LB key in
@@ -662,11 +662,11 @@ static inline int __inline__ lb4_rev_nat(struct __sk_buff *skb, int l3_off, int 
  * @arg dir		Flow direction
  *
  * Returns:
- *   - TC_ACT_OK on successful extraction
+ *   - CTX_ACT_OK on successful extraction
  *   - DROP_UNKNOWN_L4 if packet should be ignore (sent to stack)
  *   - Negative error code
  */
-static inline int __inline__ lb4_extract_key(struct __sk_buff *skb,
+static inline int __inline__ lb4_extract_key(struct __ctx_buff *ctx,
 					     struct ipv4_ct_tuple *tuple,
 					     int l4_off,
 					     struct lb4_key *key,
@@ -679,7 +679,7 @@ static inline int __inline__ lb4_extract_key(struct __sk_buff *skb,
 	csum_l4_offset_and_flags(tuple->nexthdr, csum_off);
 
 #ifdef LB_L4
-	return extract_l4_port(skb, tuple->nexthdr, l4_off, &key->dport);
+	return extract_l4_port(ctx, tuple->nexthdr, l4_off, &key->dport);
 #else
 	return 0;
 #endif
@@ -694,7 +694,7 @@ struct lb4_service *__lb4_lookup_service(struct lb4_key *key)
 		struct lb4_service *svc;
 
 		/* FIXME: The verifier barks on these calls right now for some reason */
-		/* cilium_dbg_lb(skb, DBG_LB4_LOOKUP_MASTER, key->address, key->dport); */
+		/* cilium_dbg_lb(ctx, DBG_LB4_LOOKUP_MASTER, key->address, key->dport); */
 		svc = map_lookup_elem(&LB4_SERVICES_MAP_V2, key);
 		if (svc && svc->count != 0)
 			return svc;
@@ -708,7 +708,7 @@ struct lb4_service *__lb4_lookup_service(struct lb4_key *key)
 		struct lb4_service *svc;
 
 		/* FIXME: The verifier barks on these calls right now for some reason */
-		/* cilium_dbg_lb(skb, DBG_LB4_LOOKUP_MASTER, key->address, key->dport); */
+		/* cilium_dbg_lb(ctx, DBG_LB4_LOOKUP_MASTER, key->address, key->dport); */
 		svc = map_lookup_elem(&LB4_SERVICES_MAP_V2, key);
 		if (svc && svc->count != 0)
 			return svc;
@@ -718,13 +718,13 @@ struct lb4_service *__lb4_lookup_service(struct lb4_key *key)
 }
 
 static inline
-struct lb4_service *lb4_lookup_service(struct __sk_buff *skb,
+struct lb4_service *lb4_lookup_service(struct __ctx_buff *ctx,
 				       struct lb4_key *key)
 {
 	struct lb4_service *svc = __lb4_lookup_service(key);
 
 	if (!svc)
-		cilium_dbg_lb(skb, DBG_LB4_LOOKUP_MASTER_FAIL, 0, 0);
+		cilium_dbg_lb(ctx, DBG_LB4_LOOKUP_MASTER_FAIL, 0, 0);
 
 	return svc;
 }
@@ -734,14 +734,14 @@ static inline struct lb4_backend *__lb4_lookup_backend(__u16 backend_id)
 	return map_lookup_elem(&LB4_BACKEND_MAP, &backend_id);
 }
 
-static inline struct lb4_backend *lb4_lookup_backend(struct __sk_buff *skb,
+static inline struct lb4_backend *lb4_lookup_backend(struct __ctx_buff *ctx,
 						     __u16 backend_id)
 {
 	struct lb4_backend *backend;
 
 	backend = __lb4_lookup_backend(backend_id);
 	if (!backend) {
-		cilium_dbg_lb(skb, DBG_LB4_LOOKUP_BACKEND_FAIL, backend_id, 0);
+		cilium_dbg_lb(ctx, DBG_LB4_LOOKUP_BACKEND_FAIL, backend_id, 0);
 	}
 
 	return backend;
@@ -754,25 +754,25 @@ struct lb4_service *__lb4_lookup_slave(struct lb4_key *key)
 }
 
 static inline
-struct lb4_service *lb4_lookup_slave(struct __sk_buff *skb,
+struct lb4_service *lb4_lookup_slave(struct __ctx_buff *ctx,
 					   struct lb4_key *key, __u16 slave)
 {
 	struct lb4_service *svc;
 
 	key->slave = slave;
-	cilium_dbg_lb(skb, DBG_LB4_LOOKUP_SLAVE, key->slave, key->dport);
+	cilium_dbg_lb(ctx, DBG_LB4_LOOKUP_SLAVE, key->slave, key->dport);
 	svc = __lb4_lookup_slave(key);
 	if (svc != NULL) {
 		return svc;
 	}
 
-	cilium_dbg_lb(skb, DBG_LB4_LOOKUP_SLAVE_V2_FAIL, key->slave, key->dport);
+	cilium_dbg_lb(ctx, DBG_LB4_LOOKUP_SLAVE_V2_FAIL, key->slave, key->dport);
 
 	return NULL;
 }
 
 static inline int __inline__
-lb4_xlate(struct __sk_buff *skb, __be32 *new_daddr, __be32 *new_saddr,
+lb4_xlate(struct __ctx_buff *ctx, __be32 *new_daddr, __be32 *new_saddr,
 	     __be32 *old_saddr, __u8 nexthdr, int l3_off, int l4_off,
 	     struct csum_offset *csum_off, struct lb4_key *key,
 	     struct lb4_service *svc, struct lb4_backend *backend)
@@ -780,26 +780,26 @@ lb4_xlate(struct __sk_buff *skb, __be32 *new_daddr, __be32 *new_saddr,
 	int ret;
 	__be32 sum;
 
-	ret = skb_store_bytes(skb, l3_off + offsetof(struct iphdr, daddr), new_daddr, 4, 0);
+	ret = ctx_store_bytes(ctx, l3_off + offsetof(struct iphdr, daddr), new_daddr, 4, 0);
 	if (ret < 0)
 		return DROP_WRITE_ERROR;
 
 	sum = csum_diff(&key->address, 4, new_daddr, 4, 0);
 
 	if (new_saddr && *new_saddr) {
-		cilium_dbg_lb(skb, DBG_LB4_LOOPBACK_SNAT, *old_saddr, *new_saddr);
-		ret = skb_store_bytes(skb, l3_off + offsetof(struct iphdr, saddr), new_saddr, 4, 0);
+		cilium_dbg_lb(ctx, DBG_LB4_LOOPBACK_SNAT, *old_saddr, *new_saddr);
+		ret = ctx_store_bytes(ctx, l3_off + offsetof(struct iphdr, saddr), new_saddr, 4, 0);
 		if (ret < 0)
 			return DROP_WRITE_ERROR;
 
 		sum = csum_diff(old_saddr, 4, new_saddr, 4, sum);
 	}
 
-	if (l3_csum_replace(skb, l3_off + offsetof(struct iphdr, check), 0, sum, 0) < 0)
+	if (l3_csum_replace(ctx, l3_off + offsetof(struct iphdr, check), 0, sum, 0) < 0)
 		return DROP_CSUM_L3;
 
 	if (csum_off->offset) {
-		if (csum_l4_replace(skb, l4_off, csum_off, 0, sum, BPF_F_PSEUDO_HDR) < 0)
+		if (csum_l4_replace(ctx, l4_off, csum_off, 0, sum, BPF_F_PSEUDO_HDR) < 0)
 			return DROP_CSUM_L4;
 	}
 
@@ -808,16 +808,16 @@ lb4_xlate(struct __sk_buff *skb, __be32 *new_daddr, __be32 *new_saddr,
 	    (nexthdr == IPPROTO_TCP || nexthdr == IPPROTO_UDP)) {
 		__be16 tmp = backend->port;
 		/* Port offsets for UDP and TCP are the same */
-		ret = l4_modify_port(skb, l4_off, TCP_DPORT_OFF, csum_off, tmp, key->dport);
+		ret = l4_modify_port(ctx, l4_off, TCP_DPORT_OFF, csum_off, tmp, key->dport);
 		if (IS_ERR(ret))
 			return ret;
 	}
 #endif
 
-	return TC_ACT_OK;
+	return CTX_ACT_OK;
 }
 
-static inline int __inline__ lb4_local(void *map, struct __sk_buff *skb,
+static inline int __inline__ lb4_local(void *map, struct __ctx_buff *ctx,
 				       int l3_off, int l4_off,
 				       struct csum_offset *csum_off,
 				       struct lb4_key *key,
@@ -833,21 +833,21 @@ static inline int __inline__ lb4_local(void *map, struct __sk_buff *skb,
 	int slave;
 	int ret;
 
-	ret = ct_lookup4(map, tuple, skb, l4_off, CT_SERVICE, state, &monitor);
+	ret = ct_lookup4(map, tuple, ctx, l4_off, CT_SERVICE, state, &monitor);
 	switch(ret) {
 	case CT_NEW:
 		/* No CT entry has been found, so select a svc endpoint */
 		slave = lb4_select_slave(svc->count);
-		if ((slave_svc = lb4_lookup_slave(skb, key, slave)) == NULL) {
+		if ((slave_svc = lb4_lookup_slave(ctx, key, slave)) == NULL) {
 			goto drop_no_service;
 		}
-		backend = lb4_lookup_backend(skb, slave_svc->backend_id);
+		backend = lb4_lookup_backend(ctx, slave_svc->backend_id);
 		if (backend == NULL) {
 			goto drop_no_service;
 		}
 		state->backend_id = slave_svc->backend_id;
 		state->rev_nat_index = svc->rev_nat_index;
-		ret = ct_create4(map, tuple, skb, CT_SERVICE, state, false);
+		ret = ct_create4(map, tuple, ctx, CT_SERVICE, state, false);
 		/* Fail closed, if the conntrack entry create fails drop
 		 * service lookup.
 		 */
@@ -879,10 +879,10 @@ static inline int __inline__ lb4_local(void *map, struct __sk_buff *skb,
 	// To avoid this, check that reverse NAT indices match. If not,
 	// select a new backend.
 	if (state->rev_nat_index != svc->rev_nat_index) {
-		cilium_dbg_lb(skb, DBG_LB_STALE_CT, svc->rev_nat_index,
+		cilium_dbg_lb(ctx, DBG_LB_STALE_CT, svc->rev_nat_index,
 			      state->rev_nat_index);
 		slave = lb4_select_slave(svc->count);
-		if (!(slave_svc = lb4_lookup_slave(skb, key, slave))) {
+		if (!(slave_svc = lb4_lookup_slave(ctx, key, slave))) {
 			goto drop_no_service;
 		}
 		state->backend_id = slave_svc->backend_id;
@@ -894,16 +894,16 @@ static inline int __inline__ lb4_local(void *map, struct __sk_buff *skb,
 	 * underneath us. To resolve this fall back to hash. If this is a TCP
 	 * session we are likely to get a TCP RST.
 	 */
-	if (!(backend = lb4_lookup_backend(skb, state->backend_id))) {
+	if (!(backend = lb4_lookup_backend(ctx, state->backend_id))) {
 		key->slave = 0;
-		if (!(svc = lb4_lookup_service(skb, key))) {
+		if (!(svc = lb4_lookup_service(ctx, key))) {
 			goto drop_no_service;
 		}
 		slave = lb4_select_slave(svc->count);
-		if (!(slave_svc = lb4_lookup_slave(skb, key, slave))) {
+		if (!(slave_svc = lb4_lookup_slave(ctx, key, slave))) {
 			goto drop_no_service;
 		}
-		backend = lb4_lookup_backend(skb, slave_svc->backend_id);
+		backend = lb4_lookup_backend(ctx, slave_svc->backend_id);
 		if (backend == NULL) {
 			goto drop_no_service;
 		}
@@ -938,7 +938,7 @@ update_state:
 	if (!state->loopback)
 		tuple->daddr = backend->address;
 
-	return lb4_xlate(skb, &new_daddr, &new_saddr, &saddr,
+	return lb4_xlate(ctx, &new_daddr, &new_saddr, &saddr,
 			 tuple->nexthdr, l3_off, l4_off, csum_off, key,
 			 svc, backend);
 

--- a/bpf/lib/lxc.h
+++ b/bpf/lib/lxc.h
@@ -66,23 +66,23 @@ static inline int is_valid_lxc_src_ipv4(struct iphdr *ip4)
 #endif
 
 /**
- * skb_redirect_to_proxy configures the skb with the proxy mark and proxy port
+ * ctx_redirect_to_proxy configures the ctx with the proxy mark and proxy port
  * number to ensure that the stack redirects the packet into the proxy.
  *
  * It is called from both ingress and egress side of endpoint devices.
  *
  * In regular veth mode:
  * * To apply egress policy, the egressing endpoint configures the mark,
- *   which returns TC_ACT_OK to pass the packet to the stack in the context
+ *   which returns CTX_ACT_OK to pass the packet to the stack in the context
  *   of the source device (stack ingress).
  * * To apply ingress policy, the egressing endpoint or netdev program tail
  *   calls into the policy program which configures the mark here, which
- *   returns TC_ACT_OK to pass the packet to the stack in the context of the
+ *   returns CTX_ACT_OK to pass the packet to the stack in the context of the
  *   source device (netdev or egress endpoint device, stack ingress).
  *
  * In chaining mode with bridged endpoint devices:
  * * To apply egress policy, the egressing endpoint configures the mark,
- *   which is propagated to skb->cb[] in the caller. The redirect() call here
+ *   which is propagated to ctx->cb[] in the caller. The redirect() call here
  *   redirects the packet to the ingress TC filter configured on the bridge
  *   master device.
  * * To apply ingress policy, the stack transmits the packet into the bridge
@@ -95,47 +95,47 @@ static inline int is_valid_lxc_src_ipv4(struct iphdr *ip4)
  *   before passing the traffic up to the stack towards the proxy.
  */
 static inline int __inline__
-skb_redirect_to_proxy(struct __sk_buff *skb, __be16 proxy_port)
+ctx_redirect_to_proxy(struct __ctx_buff *ctx, __be16 proxy_port)
 {
-	skb->mark = MARK_MAGIC_TO_PROXY | proxy_port << 16;
+	ctx->mark = MARK_MAGIC_TO_PROXY | proxy_port << 16;
 
 #ifdef HOST_REDIRECT_TO_INGRESS
-	cilium_dbg_capture(skb, DBG_CAPTURE_PROXY_PRE, proxy_port);
+	cilium_dbg_capture(ctx, DBG_CAPTURE_PROXY_PRE, proxy_port);
 	/* In this case, the DBG_CAPTURE_PROXY_POST will be sent from the
 	 * programm attached to HOST_IFINDEX. */
 	return redirect(HOST_IFINDEX, BPF_F_INGRESS);
 #else
-	cilium_dbg_capture(skb, DBG_CAPTURE_PROXY_POST, proxy_port);
-	skb_change_type(skb, PACKET_HOST); // Required for ingress packets from overlay
-	return TC_ACT_OK;
+	cilium_dbg_capture(ctx, DBG_CAPTURE_PROXY_POST, proxy_port);
+	ctx_change_type(ctx, PACKET_HOST); // Required for ingress packets from overlay
+	return CTX_ACT_OK;
 #endif
 }
 
 /**
- * skb_redirect_to_proxy_hairpin redirects to the proxy by hairpining the
+ * ctx_redirect_to_proxy_hairpin redirects to the proxy by hairpining the
  * packet out the incoming interface
  */
 static inline int __inline__
-skb_redirect_to_proxy_hairpin(struct __sk_buff *skb, __be16 proxy_port)
+ctx_redirect_to_proxy_hairpin(struct __ctx_buff *ctx, __be16 proxy_port)
 {
 	union macaddr host_mac = HOST_IFINDEX_MAC;
 	union macaddr router_mac = NODE_MAC;
-	void *data_end = (void *) (long) skb->data_end;
-	void *data = (void *) (long) skb->data;
+	void *data_end = (void *) (long) ctx->data_end;
+	void *data = (void *) (long) ctx->data;
 	struct iphdr *ip4;
 	int ret;
 
-	skb->cb[0] = MARK_MAGIC_TO_PROXY | (proxy_port << 16);
+	ctx->cb[0] = MARK_MAGIC_TO_PROXY | (proxy_port << 16);
 	bpf_barrier(); /* verifier workaround */
 
-	if (!revalidate_data(skb, &data, &data_end, &ip4))
+	if (!revalidate_data(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
 
-	ret = ipv4_l3(skb, ETH_HLEN, (__u8 *) &router_mac, (__u8 *) &host_mac, ip4);
+	ret = ipv4_l3(ctx, ETH_HLEN, (__u8 *) &router_mac, (__u8 *) &host_mac, ip4);
 	if (IS_ERR(ret))
 		return ret;
 
-	cilium_dbg_capture(skb, DBG_CAPTURE_PROXY_POST, proxy_port);
+	cilium_dbg_capture(ctx, DBG_CAPTURE_PROXY_POST, proxy_port);
 
 	return redirect(HOST_IFINDEX, 0);
 }
@@ -143,12 +143,12 @@ skb_redirect_to_proxy_hairpin(struct __sk_buff *skb, __be16 proxy_port)
 /**
  * tc_index_skip_ingress_proxy - returns true if packet originates from ingress proxy
  */
-static inline bool __inline__ tc_index_skip_ingress_proxy(struct __sk_buff *skb)
+static inline bool __inline__ tc_index_skip_ingress_proxy(struct __ctx_buff *ctx)
 {
-	volatile __u32 tc_index = skb->tc_index;
+	volatile __u32 tc_index = ctx->tc_index;
 #ifdef DEBUG
 	if (tc_index & TC_INDEX_F_SKIP_INGRESS_PROXY)
-		cilium_dbg(skb, DBG_SKIP_PROXY, tc_index, 0);
+		cilium_dbg(ctx, DBG_SKIP_PROXY, tc_index, 0);
 #endif
 
 	return tc_index & TC_INDEX_F_SKIP_INGRESS_PROXY;
@@ -157,12 +157,12 @@ static inline bool __inline__ tc_index_skip_ingress_proxy(struct __sk_buff *skb)
 /**
  * tc_index_skip_egress_proxy - returns true if packet originates from egress proxy
  */
-static inline bool __inline__ tc_index_skip_egress_proxy(struct __sk_buff *skb)
+static inline bool __inline__ tc_index_skip_egress_proxy(struct __ctx_buff *ctx)
 {
-	volatile __u32 tc_index = skb->tc_index;
+	volatile __u32 tc_index = ctx->tc_index;
 #ifdef DEBUG
 	if (tc_index & TC_INDEX_F_SKIP_EGRESS_PROXY)
-		cilium_dbg(skb, DBG_SKIP_PROXY, tc_index, 0);
+		cilium_dbg(ctx, DBG_SKIP_PROXY, tc_index, 0);
 #endif
 
 	return tc_index & TC_INDEX_F_SKIP_EGRESS_PROXY;

--- a/bpf/lib/maps.h
+++ b/bpf/lib/maps.h
@@ -168,9 +168,9 @@ struct bpf_elf_map __section_maps ENCRYPT_MAP = {
 };
 
 #ifndef SKIP_CALLS_MAP
-static __always_inline void ep_tail_call(struct __sk_buff *skb, __u32 index)
+static __always_inline void ep_tail_call(struct __ctx_buff *ctx, __u32 index)
 {
-	tail_call(skb, &CALLS_MAP, index);
+	tail_call(ctx, &CALLS_MAP, index);
 }
 #endif /* SKIP_CALLS_MAP */
 #endif

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -67,10 +67,10 @@ struct dsr_opt_v6 {
 #endif /* ENABLE_IPV6 */
 #endif /* ENABLE_NODEPORT */
 
-static inline void bpf_clear_nodeport(struct __sk_buff *skb)
+static inline void bpf_clear_nodeport(struct __ctx_buff *ctx)
 {
 #ifdef ENABLE_NODEPORT
-	skb->tc_index &= ~TC_INDEX_F_SKIP_NODEPORT;
+	ctx->tc_index &= ~TC_INDEX_F_SKIP_NODEPORT;
 #endif
 }
 
@@ -88,10 +88,10 @@ static __always_inline bool nodeport_uses_dsr(__u8 nexthdr)
 # endif
 }
 
-static inline bool __inline__ bpf_skip_nodeport(struct __sk_buff *skb)
+static inline bool __inline__ bpf_skip_nodeport(struct __ctx_buff *ctx)
 {
-	volatile __u32 tc_index = skb->tc_index;
-	skb->tc_index &= ~TC_INDEX_F_SKIP_NODEPORT;
+	volatile __u32 tc_index = ctx->tc_index;
+	ctx->tc_index &= ~TC_INDEX_F_SKIP_NODEPORT;
 	return tc_index & TC_INDEX_F_SKIP_NODEPORT;
 }
 #endif /* ENABLE_NODEPORT */
@@ -103,20 +103,20 @@ static inline bool nodeport_uses_dsr6(const struct ipv6_ct_tuple *tuple)
 	return nodeport_uses_dsr(tuple->nexthdr);
 }
 
-static __always_inline bool nodeport_nat_ipv6_needed(struct __sk_buff *skb,
+static __always_inline bool nodeport_nat_ipv6_needed(struct __ctx_buff *ctx,
 						     union v6addr *addr, int dir)
 {
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
 
-	if (!revalidate_data(skb, &data, &data_end, &ip6))
+	if (!revalidate_data(ctx, &data, &data_end, &ip6))
 		return false;
 #ifdef ENABLE_DSR_HYBRID
 	{
 		__u8 nexthdr = ip6->nexthdr;
 		int ret;
 
-		ret = ipv6_hdrlen(skb, ETH_HLEN, &nexthdr);
+		ret = ipv6_hdrlen(ctx, ETH_HLEN, &nexthdr);
 		if (ret > 0) {
 			if (nodeport_uses_dsr(nexthdr))
 				return false;
@@ -137,27 +137,27 @@ static __always_inline bool nodeport_nat_ipv6_needed(struct __sk_buff *skb,
 			.max_port = 65535,					\
 		};								\
 		ipv6_addr_copy(&target.addr, (ADDR));				\
-		int ____ret = nodeport_nat_ipv6_needed(skb, (ADDR), (NDIR)) ?	\
-			      snat_v6_process(skb, (NDIR), &target) : TC_ACT_OK;\
+		int ____ret = nodeport_nat_ipv6_needed(ctx, (ADDR), (NDIR)) ?	\
+			      snat_v6_process(ctx, (NDIR), &target) : CTX_ACT_OK;\
 		if (____ret == NAT_PUNT_TO_STACK)				\
-			____ret = TC_ACT_OK;					\
+			____ret = CTX_ACT_OK;					\
 		____ret;							\
 	})
 
-static __always_inline int nodeport_nat_ipv6_fwd(struct __sk_buff *skb,
+static __always_inline int nodeport_nat_ipv6_fwd(struct __ctx_buff *ctx,
 						 union v6addr *addr)
 {
 	return NODEPORT_DO_NAT_IPV6(addr, NAT_DIR_EGRESS);
 }
 
-static __always_inline int nodeport_nat_ipv6_rev(struct __sk_buff *skb,
+static __always_inline int nodeport_nat_ipv6_rev(struct __ctx_buff *ctx,
 						 union v6addr *addr)
 {
 	return NODEPORT_DO_NAT_IPV6(addr, NAT_DIR_INGRESS);
 }
 
 # ifdef ENABLE_DSR
-static __always_inline int set_dsr_ext6(struct __sk_buff *skb,
+static __always_inline int set_dsr_ext6(struct __ctx_buff *ctx,
 					struct ipv6hdr *ip6,
 					union v6addr *svc_addr, __be32 svc_port)
 {
@@ -173,16 +173,16 @@ static __always_inline int set_dsr_ext6(struct __sk_buff *skb,
 	ipv6_addr_copy(&opt.addr, svc_addr);
 	opt.port = svc_port;
 
-	if (skb_adjust_room(skb, sizeof(opt), BPF_ADJ_ROOM_NET, 0))
+	if (ctx_adjust_room(ctx, sizeof(opt), BPF_ADJ_ROOM_NET, 0))
 		return DROP_INVALID;
 
-	if (skb_store_bytes(skb, ETH_HLEN + sizeof(*ip6), &opt, sizeof(opt), 0) < 0)
+	if (ctx_store_bytes(ctx, ETH_HLEN + sizeof(*ip6), &opt, sizeof(opt), 0) < 0)
 		return DROP_INVALID;
 
 	return 0;
 }
 
-static __always_inline int find_dsr_v6(struct __sk_buff *skb, __u8 nexthdr,
+static __always_inline int find_dsr_v6(struct __ctx_buff *ctx, __u8 nexthdr,
 				       struct dsr_opt_v6 *dsr_opt, bool *found)
 {
 	int i, len = sizeof(struct ipv6hdr);
@@ -202,11 +202,11 @@ static __always_inline int find_dsr_v6(struct __sk_buff *skb, __u8 nexthdr,
 		case NEXTHDR_ROUTING:
 		case NEXTHDR_AUTH:
 		case NEXTHDR_DEST:
-			if (skb_load_bytes(skb, ETH_HLEN + len, &opthdr, sizeof(opthdr)) < 0)
+			if (ctx_load_bytes(ctx, ETH_HLEN + len, &opthdr, sizeof(opthdr)) < 0)
 				return DROP_INVALID;
 
 			if (nh == NEXTHDR_DEST && opthdr.hdrlen == DSR_IPV6_EXT_LEN) {
-				if (skb_load_bytes(skb, ETH_HLEN + len, dsr_opt,
+				if (ctx_load_bytes(ctx, ETH_HLEN + len, dsr_opt,
 						   sizeof(*dsr_opt)) < 0)
 					return DROP_INVALID;
 				if (dsr_opt->opt_type == DSR_IPV6_OPT_TYPE &&
@@ -232,29 +232,29 @@ static __always_inline int find_dsr_v6(struct __sk_buff *skb, __u8 nexthdr,
 	return DROP_INVALID_EXTHDR;
 }
 
-static __always_inline int handle_dsr_v6(struct __sk_buff *skb, bool *dsr)
+static __always_inline int handle_dsr_v6(struct __ctx_buff *ctx, bool *dsr)
 {
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
 	struct dsr_opt_v6 opt = {};
 	int ret;
 
-	if (!revalidate_data(skb, &data, &data_end, &ip6))
+	if (!revalidate_data(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 
-	ret = find_dsr_v6(skb, ip6->nexthdr, &opt, dsr);
+	ret = find_dsr_v6(ctx, ip6->nexthdr, &opt, dsr);
 	if (ret != 0)
 		return ret;
 
 	if (*dsr) {
-		if (snat_v6_create_dsr(skb, &opt.addr, opt.port) < 0)
+		if (snat_v6_create_dsr(ctx, &opt.addr, opt.port) < 0)
 			return DROP_INVALID;
 	}
 
 	return 0;
 }
 
-static __always_inline int xlate_dsr_v6(struct __sk_buff *skb,
+static __always_inline int xlate_dsr_v6(struct __ctx_buff *ctx,
 					struct ipv6_ct_tuple *tuple,
 					int l4_off)
 {
@@ -268,12 +268,12 @@ static __always_inline int xlate_dsr_v6(struct __sk_buff *skb,
 
 	entry = snat_v6_lookup(&nat_tup);
 	if (entry)
-		ret = snat_v6_rewrite_egress(skb, &nat_tup, entry, l4_off);
+		ret = snat_v6_rewrite_egress(ctx, &nat_tup, entry, l4_off);
 	return ret;
 }
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV6_NODEPORT_DSR)
-int tail_nodeport_ipv6_dsr(struct __sk_buff *skb)
+int tail_nodeport_ipv6_dsr(struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
@@ -281,19 +281,19 @@ int tail_nodeport_ipv6_dsr(struct __sk_buff *skb)
 	struct bpf_fib_lookup fib_params = {};
 	int ret;
 
-	if (!revalidate_data(skb, &data, &data_end, &ip6))
+	if (!revalidate_data(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 
-	__be32 dport = skb->cb[CB_SVC_PORT];
-	addr.p1 = skb->cb[CB_SVC_ADDR_V6_1];
-	addr.p2 = skb->cb[CB_SVC_ADDR_V6_2];
-	addr.p3 = skb->cb[CB_SVC_ADDR_V6_3];
-	addr.p4 = skb->cb[CB_SVC_ADDR_V6_4];
-	ret = set_dsr_ext6(skb, ip6, &addr, dport);
+	__be32 dport = ctx->cb[CB_SVC_PORT];
+	addr.p1 = ctx->cb[CB_SVC_ADDR_V6_1];
+	addr.p2 = ctx->cb[CB_SVC_ADDR_V6_2];
+	addr.p3 = ctx->cb[CB_SVC_ADDR_V6_3];
+	addr.p4 = ctx->cb[CB_SVC_ADDR_V6_4];
+	ret = set_dsr_ext6(ctx, ip6, &addr, dport);
 	if (ret)
 		return ret;
 
-	if (!revalidate_data(skb, &data, &data_end, &ip6))
+	if (!revalidate_data(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 
 	fib_params.family = AF_INET6;
@@ -301,14 +301,14 @@ int tail_nodeport_ipv6_dsr(struct __sk_buff *skb)
 	ipv6_addr_copy((union v6addr *) &fib_params.ipv6_src, (union v6addr *) &ip6->saddr);
 	ipv6_addr_copy((union v6addr *) &fib_params.ipv6_dst, (union v6addr *) &ip6->daddr);
 
-	ret = fib_lookup(skb, &fib_params, sizeof(fib_params),
+	ret = fib_lookup(ctx, &fib_params, sizeof(fib_params),
 			 BPF_FIB_LOOKUP_DIRECT | BPF_FIB_LOOKUP_OUTPUT);
 	if (ret != 0)
 		return DROP_NO_FIB;
 
-	if (eth_store_daddr(skb, fib_params.dmac, 0) < 0)
+	if (eth_store_daddr(ctx, fib_params.dmac, 0) < 0)
 		return DROP_WRITE_ERROR;
-	if (eth_store_saddr(skb, fib_params.smac, 0) < 0)
+	if (eth_store_saddr(ctx, fib_params.smac, 0) < 0)
 		return DROP_WRITE_ERROR;
 
 	return redirect(fib_params.ifindex, 0);
@@ -316,9 +316,9 @@ int tail_nodeport_ipv6_dsr(struct __sk_buff *skb)
 # endif /* ENABLE_DSR */
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV6_NODEPORT_NAT)
-int tail_nodeport_nat_ipv6(struct __sk_buff *skb)
+int tail_nodeport_nat_ipv6(struct __ctx_buff *ctx)
 {
-	int ifindex = NATIVE_DEV_IFINDEX, ret, dir = skb->cb[CB_NAT];
+	int ifindex = NATIVE_DEV_IFINDEX, ret, dir = ctx->cb[CB_NAT];
 	struct bpf_fib_lookup fib_params = {};
 	struct ipv6_nat_target target = {
 		.min_port = NODEPORT_PORT_MIN_NAT,
@@ -334,13 +334,13 @@ int tail_nodeport_nat_ipv6(struct __sk_buff *skb)
 		struct remote_endpoint_info *info;
 		union v6addr *dst;
 
-		if (!revalidate_data(skb, &data, &data_end, &ip6))
+		if (!revalidate_data(ctx, &data, &data_end, &ip6))
 			return DROP_INVALID;
 
 		dst = (union v6addr *)&ip6->daddr;
 		info = ipcache_lookup6(&IPCACHE_MAP, dst, V6_CACHE_KEY_LEN);
 		if (info != NULL && info->tunnel_endpoint != 0) {
-			int ret = __encap_with_nodeid(skb, info->tunnel_endpoint,
+			int ret = __encap_with_nodeid(ctx, info->tunnel_endpoint,
 						      SECLABEL, TRACE_PAYLOAD_LEN);
 			if (ret)
 				return ret;
@@ -349,14 +349,14 @@ int tail_nodeport_nat_ipv6(struct __sk_buff *skb)
 			ifindex = ENCAP_IFINDEX;
 
 			/* fib lookup not necessary when going over tunnel. */
-			if (eth_store_daddr(skb, fib_params.dmac, 0) < 0)
+			if (eth_store_daddr(ctx, fib_params.dmac, 0) < 0)
 				return DROP_WRITE_ERROR;
-			if (eth_store_saddr(skb, fib_params.smac, 0) < 0)
+			if (eth_store_saddr(ctx, fib_params.smac, 0) < 0)
 				return DROP_WRITE_ERROR;
 		}
 	}
 #endif
-	ret = snat_v6_process(skb, dir, &target);
+	ret = snat_v6_process(ctx, dir, &target);
 	if (IS_ERR(ret)) {
 		/* In case of no mapping, recircle back to main path. SNAT is very
 		 * expensive in terms of instructions (since we don't have BPF to
@@ -364,19 +364,19 @@ int tail_nodeport_nat_ipv6(struct __sk_buff *skb)
 		 * done inside a tail call here.
 		 */
 		if (dir == NAT_DIR_INGRESS) {
-			skb->tc_index |= TC_INDEX_F_SKIP_NODEPORT;
-			ep_tail_call(skb, CILIUM_CALL_IPV6_FROM_LXC);
+			ctx->tc_index |= TC_INDEX_F_SKIP_NODEPORT;
+			ep_tail_call(ctx, CILIUM_CALL_IPV6_FROM_LXC);
 			ret = DROP_MISSED_TAIL_CALL;
 		}
 		if (ret == NAT_PUNT_TO_STACK)
-			ret = TC_ACT_OK;
+			ret = CTX_ACT_OK;
 		else
 			goto drop_err;
 	}
 
-	skb->mark |= MARK_MAGIC_SNAT_DONE;
+	ctx->mark |= MARK_MAGIC_SNAT_DONE;
 	if (dir == NAT_DIR_INGRESS) {
-		ep_tail_call(skb, CILIUM_CALL_IPV6_NODEPORT_REVNAT);
+		ep_tail_call(ctx, CILIUM_CALL_IPV6_NODEPORT_REVNAT);
 		ret = DROP_MISSED_TAIL_CALL;
 		goto drop_err;
 	}
@@ -384,7 +384,7 @@ int tail_nodeport_nat_ipv6(struct __sk_buff *skb)
 	if (ifindex == ENCAP_IFINDEX)
 		goto out_send;
 #endif
-	if (!revalidate_data(skb, &data, &data_end, &ip6)) {
+	if (!revalidate_data(ctx, &data, &data_end, &ip6)) {
 		ret = DROP_INVALID;
 		goto drop_err;
 	}
@@ -394,18 +394,18 @@ int tail_nodeport_nat_ipv6(struct __sk_buff *skb)
 	ipv6_addr_copy((union v6addr *) &fib_params.ipv6_src, (union v6addr *) &ip6->saddr);
 	ipv6_addr_copy((union v6addr *) &fib_params.ipv6_dst, (union v6addr *) &ip6->daddr);
 
-	ret = fib_lookup(skb, &fib_params, sizeof(fib_params),
+	ret = fib_lookup(ctx, &fib_params, sizeof(fib_params),
 			 BPF_FIB_LOOKUP_DIRECT | BPF_FIB_LOOKUP_OUTPUT);
 	if (ret != 0) {
 		ret = DROP_NO_FIB;
 		goto drop_err;
 	}
 
-	if (eth_store_daddr(skb, fib_params.dmac, 0) < 0) {
+	if (eth_store_daddr(ctx, fib_params.dmac, 0) < 0) {
 		ret = DROP_WRITE_ERROR;
 		goto drop_err;
 	}
-	if (eth_store_saddr(skb, fib_params.smac, 0) < 0) {
+	if (eth_store_saddr(ctx, fib_params.smac, 0) < 0) {
 		ret = DROP_WRITE_ERROR;
 		goto drop_err;
 	}
@@ -413,13 +413,13 @@ int tail_nodeport_nat_ipv6(struct __sk_buff *skb)
 out_send:
 	return redirect(ifindex, 0);
 drop_err:
-	return send_drop_notify_error(skb, 0, ret, TC_ACT_SHOT,
+	return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP,
 				      dir == NAT_DIR_INGRESS ?
 				      METRIC_INGRESS : METRIC_EGRESS);
 }
 
 /* See nodeport_lb4(). */
-static inline int nodeport_lb6(struct __sk_buff *skb, __u32 src_identity)
+static inline int nodeport_lb6(struct __ctx_buff *ctx, __u32 src_identity)
 {
 	int ret, l3_off = ETH_HLEN, l4_off, hdrlen;
 	struct ipv6_ct_tuple tuple = {};
@@ -434,29 +434,29 @@ static inline int nodeport_lb6(struct __sk_buff *skb, __u32 src_identity)
 	__u32 monitor = 0;
 	union macaddr smac;
 
-	if (!revalidate_data(skb, &data, &data_end, &ip6))
+	if (!revalidate_data(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 
 	tuple.nexthdr = ip6->nexthdr;
 	ipv6_addr_copy(&tuple.daddr, (union v6addr *) &ip6->daddr);
 	ipv6_addr_copy(&tuple.saddr, (union v6addr *) &ip6->saddr);
 
-	hdrlen = ipv6_hdrlen(skb, l3_off, &tuple.nexthdr);
+	hdrlen = ipv6_hdrlen(ctx, l3_off, &tuple.nexthdr);
 	if (hdrlen < 0)
 		return hdrlen;
 
 	l4_off = l3_off + hdrlen;
 
-	ret = lb6_extract_key(skb, &tuple, l4_off, &key, &csum_off, CT_EGRESS);
+	ret = lb6_extract_key(ctx, &tuple, l4_off, &key, &csum_off, CT_EGRESS);
 	if (IS_ERR(ret)) {
 		if (ret == DROP_UNKNOWN_L4)
-			return TC_ACT_OK;
+			return CTX_ACT_OK;
 		else
 			return ret;
 	}
 
-	if ((svc = lb6_lookup_service(skb, &key)) != NULL) {
-		ret = lb6_local(get_ct_map6(&tuple), skb, l3_off, l4_off,
+	if ((svc = lb6_lookup_service(ctx, &key)) != NULL) {
+		ret = lb6_local(get_ct_map6(&tuple), ctx, l3_off, l4_off,
 				&csum_off, &key, &tuple, svc, &ct_state_new);
 		if (IS_ERR(ret))
 			return ret;
@@ -467,20 +467,20 @@ static inline int nodeport_lb6(struct __sk_buff *skb, __u32 src_identity)
 			return DROP_IS_CLUSTER_IP;
 
 		if (nodeport_uses_dsr6(&tuple)) {
-			return TC_ACT_OK;
+			return CTX_ACT_OK;
 		} else {
-			skb->cb[CB_NAT] = NAT_DIR_INGRESS;
-			skb->cb[CB_SRC_IDENTITY] = src_identity;
-			ep_tail_call(skb, CILIUM_CALL_IPV6_NODEPORT_NAT);
+			ctx->cb[CB_NAT] = NAT_DIR_INGRESS;
+			ctx->cb[CB_SRC_IDENTITY] = src_identity;
+			ep_tail_call(ctx, CILIUM_CALL_IPV6_NODEPORT_NAT);
 			return DROP_MISSED_TAIL_CALL;
 		}
 	}
 
-	ret = ct_lookup6(get_ct_map6(&tuple), &tuple, skb, l4_off, CT_EGRESS,
+	ret = ct_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off, CT_EGRESS,
 			 &ct_state, &monitor);
 	if (ret < 0)
 		return ret;
-	if (!revalidate_data(skb, &data, &data_end, &ip6))
+	if (!revalidate_data(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 
 	backend_local = lookup_ip6_endpoint(ip6);
@@ -489,7 +489,7 @@ static inline int nodeport_lb6(struct __sk_buff *skb, __u32 src_identity)
 	case CT_NEW:
 		ct_state_new.src_sec_id = SECLABEL;
 		ct_state_new.node_port = 1;
-		ret = ct_create6(get_ct_map6(&tuple), &tuple, skb, CT_EGRESS,
+		ret = ct_create6(get_ct_map6(&tuple), &tuple, ctx, CT_EGRESS,
 				 &ct_state_new, false);
 		if (IS_ERR(ret))
 			return ret;
@@ -497,7 +497,7 @@ static inline int nodeport_lb6(struct __sk_buff *skb, __u32 src_identity)
 			ct_flip_tuple_dir6(&tuple);
 redo:
 			ct_state_new.rev_nat_index = 0;
-			ret = ct_create6(get_ct_map6(&tuple), &tuple, skb,
+			ret = ct_create6(get_ct_map6(&tuple), &tuple, ctx,
 					 CT_INGRESS, &ct_state_new, false);
 			if (IS_ERR(ret))
 				return ret;
@@ -521,9 +521,9 @@ redo:
 		return DROP_UNKNOWN_CT;
 	}
 
-	if (!revalidate_data(skb, &data, &data_end, &ip6))
+	if (!revalidate_data(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
-	if (eth_load_saddr(skb, smac.addr, 0) < 0)
+	if (eth_load_saddr(ctx, smac.addr, 0) < 0)
 		return DROP_INVALID;
 	ret = map_update_elem(&NODEPORT_NEIGH6, &ip6->saddr, &smac, 0);
 	if (ret < 0) {
@@ -532,24 +532,24 @@ redo:
 
 	if (!backend_local) {
 		if (nodeport_uses_dsr6(&tuple)) {
-			skb->cb[CB_SVC_PORT] = key.dport;
-			skb->cb[CB_SVC_ADDR_V6_1] = key.address.p1;
-			skb->cb[CB_SVC_ADDR_V6_2] = key.address.p2;
-			skb->cb[CB_SVC_ADDR_V6_3] = key.address.p3;
-			skb->cb[CB_SVC_ADDR_V6_4] = key.address.p4;
-			ep_tail_call(skb, CILIUM_CALL_IPV6_NODEPORT_DSR);
+			ctx->cb[CB_SVC_PORT] = key.dport;
+			ctx->cb[CB_SVC_ADDR_V6_1] = key.address.p1;
+			ctx->cb[CB_SVC_ADDR_V6_2] = key.address.p2;
+			ctx->cb[CB_SVC_ADDR_V6_3] = key.address.p3;
+			ctx->cb[CB_SVC_ADDR_V6_4] = key.address.p4;
+			ep_tail_call(ctx, CILIUM_CALL_IPV6_NODEPORT_DSR);
 		} else {
-			skb->cb[CB_NAT] = NAT_DIR_EGRESS;
-			ep_tail_call(skb, CILIUM_CALL_IPV6_NODEPORT_NAT);
+			ctx->cb[CB_NAT] = NAT_DIR_EGRESS;
+			ep_tail_call(ctx, CILIUM_CALL_IPV6_NODEPORT_NAT);
 		}
 		return DROP_MISSED_TAIL_CALL;
 	}
 
-	return TC_ACT_OK;
+	return CTX_ACT_OK;
 }
 
 /* See comment in tail_rev_nodeport_lb4(). */
-static inline int rev_nodeport_lb6(struct __sk_buff *skb, int *ifindex,
+static inline int rev_nodeport_lb6(struct __ctx_buff *ctx, int *ifindex,
                                     union macaddr *mac)
 {
 	int ret, ret2, l3_off = ETH_HLEN, l4_off, hdrlen;
@@ -562,33 +562,33 @@ static inline int rev_nodeport_lb6(struct __sk_buff *skb, int *ifindex,
 	union macaddr *dmac;
 	__u32 monitor = 0;
 
-	if (!revalidate_data(skb, &data, &data_end, &ip6))
+	if (!revalidate_data(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 
 	tuple.nexthdr = ip6->nexthdr;
 	ipv6_addr_copy(&tuple.daddr, (union v6addr *) &ip6->daddr);
 	ipv6_addr_copy(&tuple.saddr, (union v6addr *) &ip6->saddr);
 
-	hdrlen = ipv6_hdrlen(skb, l3_off, &tuple.nexthdr);
+	hdrlen = ipv6_hdrlen(ctx, l3_off, &tuple.nexthdr);
 	if (hdrlen < 0)
 		return hdrlen;
 
 	l4_off = l3_off + hdrlen;
 	csum_l4_offset_and_flags(tuple.nexthdr, &csum_off);
 
-	ret = ct_lookup6(get_ct_map6(&tuple), &tuple, skb, l4_off, CT_INGRESS, &ct_state,
+	ret = ct_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off, CT_INGRESS, &ct_state,
 			 &monitor);
 
 	if (ret == CT_REPLY && ct_state.node_port == 1 && ct_state.rev_nat_index != 0) {
-		ret2 = lb6_rev_nat(skb, l4_off, &csum_off, ct_state.rev_nat_index,
+		ret2 = lb6_rev_nat(ctx, l4_off, &csum_off, ct_state.rev_nat_index,
 				   &tuple, REV_NAT_F_TUPLE_SADDR);
 		if (IS_ERR(ret2))
 			return ret2;
 
-		if (!revalidate_data(skb, &data, &data_end, &ip6))
+		if (!revalidate_data(ctx, &data, &data_end, &ip6))
 			return DROP_INVALID;
 
-		skb->mark |= MARK_MAGIC_SNAT_DONE;
+		ctx->mark |= MARK_MAGIC_SNAT_DONE;
 #ifdef ENCAP_IFINDEX
 		{
 			union v6addr *dst = (union v6addr *)&ip6->daddr;
@@ -596,7 +596,7 @@ static inline int rev_nodeport_lb6(struct __sk_buff *skb, int *ifindex,
 
 			info = ipcache_lookup6(&IPCACHE_MAP, dst, V6_CACHE_KEY_LEN);
 			if (info != NULL && info->tunnel_endpoint != 0) {
-				int ret = __encap_with_nodeid(skb, info->tunnel_endpoint,
+				int ret = __encap_with_nodeid(ctx, info->tunnel_endpoint,
 							      SECLABEL, TRACE_PAYLOAD_LEN);
 				if (ret)
 					return ret;
@@ -604,21 +604,21 @@ static inline int rev_nodeport_lb6(struct __sk_buff *skb, int *ifindex,
 				*ifindex = ENCAP_IFINDEX;
 
 				/* fib lookup not necessary when going over tunnel. */
-				if (eth_store_daddr(skb, fib_params.dmac, 0) < 0)
+				if (eth_store_daddr(ctx, fib_params.dmac, 0) < 0)
 					return DROP_WRITE_ERROR;
-				if (eth_store_saddr(skb, fib_params.smac, 0) < 0)
+				if (eth_store_saddr(ctx, fib_params.smac, 0) < 0)
 					return DROP_WRITE_ERROR;
 
-				return TC_ACT_OK;
+				return CTX_ACT_OK;
 			}
 		}
 #endif
 
 		dmac = map_lookup_elem(&NODEPORT_NEIGH6, &tuple.daddr);
 		if (dmac) {
-			if (eth_store_daddr(skb, dmac->addr, 0) < 0)
+			if (eth_store_daddr(ctx, dmac->addr, 0) < 0)
 				return DROP_WRITE_ERROR;
-			if (eth_store_saddr(skb, mac->addr, 0) < 0)
+			if (eth_store_saddr(ctx, mac->addr, 0) < 0)
 				return DROP_WRITE_ERROR;
 		} else {
 			fib_params.family = AF_INET6;
@@ -627,37 +627,37 @@ static inline int rev_nodeport_lb6(struct __sk_buff *skb, int *ifindex,
 			ipv6_addr_copy((union v6addr *) &fib_params.ipv6_src, &tuple.saddr);
 			ipv6_addr_copy((union v6addr *) &fib_params.ipv6_dst, &tuple.daddr);
 
-			int rc = fib_lookup(skb, &fib_params, sizeof(fib_params),
+			int rc = fib_lookup(ctx, &fib_params, sizeof(fib_params),
 					BPF_FIB_LOOKUP_DIRECT | BPF_FIB_LOOKUP_OUTPUT);
 			if (rc != 0)
 				return DROP_NO_FIB;
 
-			if (eth_store_daddr(skb, fib_params.dmac, 0) < 0)
+			if (eth_store_daddr(ctx, fib_params.dmac, 0) < 0)
 				return DROP_WRITE_ERROR;
-			if (eth_store_saddr(skb, fib_params.smac, 0) < 0)
+			if (eth_store_saddr(ctx, fib_params.smac, 0) < 0)
 				return DROP_WRITE_ERROR;
 		}
 	} else {
-		if (!(skb->tc_index & TC_INDEX_F_SKIP_RECIRCULATION)) {
-			skb->tc_index |= TC_INDEX_F_SKIP_NODEPORT;
-			ep_tail_call(skb, CILIUM_CALL_IPV6_FROM_LXC);
+		if (!(ctx->tc_index & TC_INDEX_F_SKIP_RECIRCULATION)) {
+			ctx->tc_index |= TC_INDEX_F_SKIP_NODEPORT;
+			ep_tail_call(ctx, CILIUM_CALL_IPV6_FROM_LXC);
 			return DROP_MISSED_TAIL_CALL;
 		}
 	}
 
-	return TC_ACT_OK;
+	return CTX_ACT_OK;
 }
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV6_NODEPORT_REVNAT)
-int tail_rev_nodeport_lb6(struct __sk_buff *skb)
+int tail_rev_nodeport_lb6(struct __ctx_buff *ctx)
 {
 	int ifindex = NATIVE_DEV_IFINDEX;
 	union macaddr mac = NATIVE_DEV_MAC;
 	int ret = 0;
 
-	ret = rev_nodeport_lb6(skb, &ifindex, &mac);
+	ret = rev_nodeport_lb6(ctx, &ifindex, &mac);
 	if (IS_ERR(ret))
-		return send_drop_notify_error(skb, 0, ret, TC_ACT_SHOT, METRIC_EGRESS);
+		return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP, METRIC_EGRESS);
 	return redirect(ifindex, 0);
 }
 #endif /* ENABLE_IPV6 */
@@ -668,13 +668,13 @@ static inline bool nodeport_uses_dsr4(const struct ipv4_ct_tuple *tuple)
 	return nodeport_uses_dsr(tuple->nexthdr);
 }
 
-static __always_inline bool nodeport_nat_ipv4_needed(struct __sk_buff *skb,
+static __always_inline bool nodeport_nat_ipv4_needed(struct __ctx_buff *ctx,
 						     __be32 addr, int dir)
 {
 	void *data, *data_end;
 	struct iphdr *ip4;
 
-	if (!revalidate_data(skb, &data, &data_end, &ip4))
+	if (!revalidate_data(ctx, &data, &data_end, &ip4))
 		return false;
 #ifdef ENABLE_DSR_HYBRID
 	if (nodeport_uses_dsr(ip4->protocol))
@@ -697,20 +697,20 @@ static __always_inline bool nodeport_nat_ipv4_needed(struct __sk_buff *skb,
 			.max_port = 65535,					\
 			.addr = (ADDR),						\
 		};								\
-		int ____ret = nodeport_nat_ipv4_needed(skb, (ADDR), (NDIR)) ?	\
-			      snat_v4_process(skb, (NDIR), &target) : TC_ACT_OK;\
+		int ____ret = nodeport_nat_ipv4_needed(ctx, (ADDR), (NDIR)) ?	\
+			      snat_v4_process(ctx, (NDIR), &target) : CTX_ACT_OK;\
 		if (____ret == NAT_PUNT_TO_STACK)				\
-			____ret = TC_ACT_OK;					\
+			____ret = CTX_ACT_OK;					\
 		____ret;							\
 	})
 
-static __always_inline int nodeport_nat_ipv4_fwd(struct __sk_buff *skb,
+static __always_inline int nodeport_nat_ipv4_fwd(struct __ctx_buff *ctx,
 						 const __be32 addr)
 {
 	return NODEPORT_DO_NAT_IPV4(addr, NAT_DIR_EGRESS);
 }
 
-static __always_inline int nodeport_nat_ipv4_rev(struct __sk_buff *skb,
+static __always_inline int nodeport_nat_ipv4_rev(struct __ctx_buff *ctx,
 						 const __be32 addr)
 {
 	return NODEPORT_DO_NAT_IPV4(addr, NAT_DIR_INGRESS);
@@ -720,7 +720,7 @@ static __always_inline int nodeport_nat_ipv4_rev(struct __sk_buff *skb,
 /* Helper function to set the IPv4 option for DSR when a backend is remote.
  * NOTE: Revalidate data after calling the function.
  */
-static __always_inline int set_dsr_opt4(struct __sk_buff *skb,
+static __always_inline int set_dsr_opt4(struct __ctx_buff *ctx,
 					struct iphdr *ip4,
 					__be32 svc_addr, __be32 svc_port)
 {
@@ -729,7 +729,7 @@ static __always_inline int set_dsr_opt4(struct __sk_buff *skb,
 	__u32 iph_old, iph_new;
 
 	if (ip4->protocol == IPPROTO_TCP) {
-		if (skb_load_bytes(skb, ETH_HLEN + sizeof(*ip4) + 12,
+		if (ctx_load_bytes(ctx, ETH_HLEN + sizeof(*ip4) + 12,
 				   &tcp_flags, 2) < 0)
 			return DROP_CT_INVALID_HDR;
 		// Setting the option is required only for the first packet
@@ -751,17 +751,17 @@ static __always_inline int set_dsr_opt4(struct __sk_buff *skb,
 	sum = csum_diff(NULL, 0, &opt1, sizeof(opt1), sum);
 	sum = csum_diff(NULL, 0, &opt2, sizeof(opt2), sum);
 
-	if (skb_adjust_room(skb, 0x8, BPF_ADJ_ROOM_NET, 0))
+	if (ctx_adjust_room(ctx, 0x8, BPF_ADJ_ROOM_NET, 0))
 		return DROP_INVALID;
 
-	if (skb_store_bytes(skb, ETH_HLEN + sizeof(*ip4),
+	if (ctx_store_bytes(ctx, ETH_HLEN + sizeof(*ip4),
 			    &opt1, sizeof(opt1), 0) < 0)
 		return DROP_INVALID;
-	if (skb_store_bytes(skb, ETH_HLEN + sizeof(*ip4) + sizeof(opt1),
+	if (ctx_store_bytes(ctx, ETH_HLEN + sizeof(*ip4) + sizeof(opt1),
 			    &opt2, sizeof(opt2), 0) < 0)
 		return DROP_INVALID;
 
-	if (l3_csum_replace(skb, ETH_HLEN + offsetof(struct iphdr, check),
+	if (l3_csum_replace(ctx, ETH_HLEN + offsetof(struct iphdr, check),
 	    0, sum, 0) < 0) {
 		return DROP_CSUM_L3;
 	}
@@ -769,12 +769,12 @@ static __always_inline int set_dsr_opt4(struct __sk_buff *skb,
 	return 0;
 }
 
-static __always_inline int handle_dsr_v4(struct __sk_buff *skb, bool *dsr)
+static __always_inline int handle_dsr_v4(struct __ctx_buff *ctx, bool *dsr)
 {
 	void *data, *data_end;
 	struct iphdr *ip4;
 
-	if (!revalidate_data(skb, &data, &data_end, &ip4))
+	if (!revalidate_data(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
 
 	// Check whether IPv4 header contains a 64-bit option (IPv4 header
@@ -783,13 +783,13 @@ static __always_inline int handle_dsr_v4(struct __sk_buff *skb, bool *dsr)
 		__u32 opt1 = 0;
 		__u32 opt2 = 0;
 
-		if (skb_load_bytes(skb, ETH_HLEN + sizeof(struct iphdr),
+		if (ctx_load_bytes(ctx, ETH_HLEN + sizeof(struct iphdr),
 				   &opt1, sizeof(opt1)) < 0)
 			return DROP_INVALID;
 
 		opt1 = bpf_ntohl(opt1);
 		if ((opt1 & DSR_IPV4_OPT_MASK) == DSR_IPV4_OPT_32) {
-			if (skb_load_bytes(skb, ETH_HLEN +
+			if (ctx_load_bytes(ctx, ETH_HLEN +
 					   sizeof(struct iphdr) +
 					   sizeof(opt1),
 					   &opt2, sizeof(opt2)) < 0)
@@ -801,7 +801,7 @@ static __always_inline int handle_dsr_v4(struct __sk_buff *skb, bool *dsr)
 			__be32 address = opt2;
 			*dsr = true;
 
-			if (snat_v4_create_dsr(skb, address, dport) < 0)
+			if (snat_v4_create_dsr(ctx, address, dport) < 0)
 				return DROP_INVALID;
 		}
 	}
@@ -809,7 +809,7 @@ static __always_inline int handle_dsr_v4(struct __sk_buff *skb, bool *dsr)
 	return 0;
 }
 
-static __always_inline int xlate_dsr_v4(struct __sk_buff *skb,
+static __always_inline int xlate_dsr_v4(struct __ctx_buff *ctx,
 					struct ipv4_ct_tuple *tuple,
 					int l4_off)
 {
@@ -823,29 +823,29 @@ static __always_inline int xlate_dsr_v4(struct __sk_buff *skb,
 
 	entry = snat_v4_lookup(&nat_tup);
 	if (entry)
-		ret = snat_v4_rewrite_egress(skb, &nat_tup, entry, l4_off);
+		ret = snat_v4_rewrite_egress(ctx, &nat_tup, entry, l4_off);
 	return ret;
 }
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV4_NODEPORT_DSR)
-int tail_nodeport_ipv4_dsr(struct __sk_buff *skb)
+int tail_nodeport_ipv4_dsr(struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
 	struct iphdr *ip4;
 	struct bpf_fib_lookup fib_params = {};
 	int ret;
 
-	__be16 dport = skb->cb[CB_SVC_PORT];
-	__be32 address = skb->cb[CB_SVC_ADDR_V4];
+	__be16 dport = ctx->cb[CB_SVC_PORT];
+	__be32 address = ctx->cb[CB_SVC_ADDR_V4];
 
-	if (!revalidate_data(skb, &data, &data_end, &ip4))
+	if (!revalidate_data(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
 
-	ret = set_dsr_opt4(skb, ip4, address, dport);
+	ret = set_dsr_opt4(ctx, ip4, address, dport);
 	if (ret != 0)
 		return DROP_INVALID;
 
-	if (!revalidate_data(skb, &data, &data_end, &ip4))
+	if (!revalidate_data(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
 
 	fib_params.family = AF_INET;
@@ -853,14 +853,14 @@ int tail_nodeport_ipv4_dsr(struct __sk_buff *skb)
 	fib_params.ipv4_src = ip4->saddr;
 	fib_params.ipv4_dst = ip4->daddr;
 
-	ret = fib_lookup(skb, &fib_params, sizeof(fib_params),
+	ret = fib_lookup(ctx, &fib_params, sizeof(fib_params),
 			 BPF_FIB_LOOKUP_DIRECT | BPF_FIB_LOOKUP_OUTPUT);
 	if (ret != 0)
 		return DROP_NO_FIB;
 
-	if (eth_store_daddr(skb, fib_params.dmac, 0) < 0)
+	if (eth_store_daddr(ctx, fib_params.dmac, 0) < 0)
 		return DROP_WRITE_ERROR;
-	if (eth_store_saddr(skb, fib_params.smac, 0) < 0)
+	if (eth_store_saddr(ctx, fib_params.smac, 0) < 0)
 		return DROP_WRITE_ERROR;
 
 	return redirect(fib_params.ifindex, 0);
@@ -868,9 +868,9 @@ int tail_nodeport_ipv4_dsr(struct __sk_buff *skb)
 # endif /* ENABLE_DSR */
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV4_NODEPORT_NAT)
-int tail_nodeport_nat_ipv4(struct __sk_buff *skb)
+int tail_nodeport_nat_ipv4(struct __ctx_buff *ctx)
 {
-	int ifindex = NATIVE_DEV_IFINDEX, ret, dir = skb->cb[CB_NAT];
+	int ifindex = NATIVE_DEV_IFINDEX, ret, dir = ctx->cb[CB_NAT];
 	struct bpf_fib_lookup fib_params = {};
 	struct ipv4_nat_target target = {
 		.min_port = NODEPORT_PORT_MIN_NAT,
@@ -885,12 +885,12 @@ int tail_nodeport_nat_ipv4(struct __sk_buff *skb)
 	if (dir == NAT_DIR_EGRESS) {
 		struct remote_endpoint_info *info;
 
-		if (!revalidate_data(skb, &data, &data_end, &ip4))
+		if (!revalidate_data(ctx, &data, &data_end, &ip4))
 			return DROP_INVALID;
 
 		info = ipcache_lookup4(&IPCACHE_MAP, ip4->daddr, V4_CACHE_KEY_LEN);
 		if (info != NULL && info->tunnel_endpoint != 0) {
-			int ret = __encap_with_nodeid(skb, info->tunnel_endpoint,
+			int ret = __encap_with_nodeid(ctx, info->tunnel_endpoint,
 						      SECLABEL, TRACE_PAYLOAD_LEN);
 			if (ret)
 				return ret;
@@ -899,14 +899,14 @@ int tail_nodeport_nat_ipv4(struct __sk_buff *skb)
 			ifindex = ENCAP_IFINDEX;
 
 			/* fib lookup not necessary when going over tunnel. */
-			if (eth_store_daddr(skb, fib_params.dmac, 0) < 0)
+			if (eth_store_daddr(ctx, fib_params.dmac, 0) < 0)
 				return DROP_WRITE_ERROR;
-			if (eth_store_saddr(skb, fib_params.smac, 0) < 0)
+			if (eth_store_saddr(ctx, fib_params.smac, 0) < 0)
 				return DROP_WRITE_ERROR;
 		}
 	}
 #endif
-	ret = snat_v4_process(skb, dir, &target);
+	ret = snat_v4_process(ctx, dir, &target);
 	if (IS_ERR(ret)) {
 		/* In case of no mapping, recircle back to main path. SNAT is very
 		 * expensive in terms of instructions (since we don't have BPF to
@@ -914,19 +914,19 @@ int tail_nodeport_nat_ipv4(struct __sk_buff *skb)
 		 * done inside a tail call here.
 		 */
 		if (dir == NAT_DIR_INGRESS) {
-			skb->tc_index |= TC_INDEX_F_SKIP_NODEPORT;
-			ep_tail_call(skb, CILIUM_CALL_IPV4_FROM_LXC);
+			ctx->tc_index |= TC_INDEX_F_SKIP_NODEPORT;
+			ep_tail_call(ctx, CILIUM_CALL_IPV4_FROM_LXC);
 			ret = DROP_MISSED_TAIL_CALL;
 		}
 		if (ret == NAT_PUNT_TO_STACK)
-			ret = TC_ACT_OK;
+			ret = CTX_ACT_OK;
 		else
 			goto drop_err;
 	}
 
-	skb->mark |= MARK_MAGIC_SNAT_DONE;
+	ctx->mark |= MARK_MAGIC_SNAT_DONE;
 	if (dir == NAT_DIR_INGRESS) {
-		ep_tail_call(skb, CILIUM_CALL_IPV4_NODEPORT_REVNAT);
+		ep_tail_call(ctx, CILIUM_CALL_IPV4_NODEPORT_REVNAT);
 		ret = DROP_MISSED_TAIL_CALL;
 		goto drop_err;
 	}
@@ -935,7 +935,7 @@ int tail_nodeport_nat_ipv4(struct __sk_buff *skb)
 		goto out_send;
 #endif
 
-	if (!revalidate_data(skb, &data, &data_end, &ip4)) {
+	if (!revalidate_data(ctx, &data, &data_end, &ip4)) {
 		ret = DROP_INVALID;
 		goto drop_err;
 	}
@@ -945,18 +945,18 @@ int tail_nodeport_nat_ipv4(struct __sk_buff *skb)
 	fib_params.ipv4_src = ip4->saddr;
 	fib_params.ipv4_dst = ip4->daddr;
 
-	ret = fib_lookup(skb, &fib_params, sizeof(fib_params),
+	ret = fib_lookup(ctx, &fib_params, sizeof(fib_params),
 			 BPF_FIB_LOOKUP_DIRECT | BPF_FIB_LOOKUP_OUTPUT);
 	if (ret != 0) {
 		ret = DROP_NO_FIB;
 		goto drop_err;
 	}
 
-	if (eth_store_daddr(skb, fib_params.dmac, 0) < 0) {
+	if (eth_store_daddr(ctx, fib_params.dmac, 0) < 0) {
 		ret = DROP_WRITE_ERROR;
 		goto drop_err;
 	}
-	if (eth_store_saddr(skb, fib_params.smac, 0) < 0) {
+	if (eth_store_saddr(ctx, fib_params.smac, 0) < 0) {
 		ret = DROP_WRITE_ERROR;
 		goto drop_err;
 	}
@@ -964,7 +964,7 @@ int tail_nodeport_nat_ipv4(struct __sk_buff *skb)
 out_send:
 	return redirect(ifindex, 0);
 drop_err:
-	return send_drop_notify_error(skb, 0, ret, TC_ACT_SHOT,
+	return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP,
 				      dir == NAT_DIR_INGRESS ?
 				      METRIC_INGRESS : METRIC_EGRESS);
 }
@@ -973,7 +973,7 @@ drop_err:
  * which handles the case of: i) backend is local EP, ii) backend is remote EP,
  * iii) reply from remote backend EP.
  */
-static inline int nodeport_lb4(struct __sk_buff *skb, __u32 src_identity)
+static inline int nodeport_lb4(struct __ctx_buff *ctx, __u32 src_identity)
 {
 	struct ipv4_ct_tuple tuple = {};
 	void *data, *data_end;
@@ -988,7 +988,7 @@ static inline int nodeport_lb4(struct __sk_buff *skb, __u32 src_identity)
 	__u32 monitor = 0;
 	union macaddr smac;
 
-	if (!revalidate_data(skb, &data, &data_end, &ip4))
+	if (!revalidate_data(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
 
 	tuple.nexthdr = ip4->protocol;
@@ -997,16 +997,16 @@ static inline int nodeport_lb4(struct __sk_buff *skb, __u32 src_identity)
 
 	l4_off = l3_off + ipv4_hdrlen(ip4);
 
-	ret = lb4_extract_key(skb, &tuple, l4_off, &key, &csum_off, CT_EGRESS);
+	ret = lb4_extract_key(ctx, &tuple, l4_off, &key, &csum_off, CT_EGRESS);
 	if (IS_ERR(ret)) {
 		if (ret == DROP_UNKNOWN_L4)
-			return TC_ACT_OK;
+			return CTX_ACT_OK;
 		else
 			return ret;
 	}
 
-	if ((svc = lb4_lookup_service(skb, &key)) != NULL) {
-		ret = lb4_local(get_ct_map4(&tuple), skb, l3_off, l4_off, &csum_off,
+	if ((svc = lb4_lookup_service(ctx, &key)) != NULL) {
+		ret = lb4_local(get_ct_map4(&tuple), ctx, l3_off, l4_off, &csum_off,
 				&key, &tuple, svc, &ct_state_new, ip4->saddr);
 		if (IS_ERR(ret))
 			return ret;
@@ -1017,20 +1017,21 @@ static inline int nodeport_lb4(struct __sk_buff *skb, __u32 src_identity)
 			return DROP_IS_CLUSTER_IP;
 
 		if (nodeport_uses_dsr4(&tuple)) {
-			return TC_ACT_OK;
+			return CTX_ACT_OK;
 		} else {
-			skb->cb[CB_NAT] = NAT_DIR_INGRESS;
-			skb->cb[CB_SRC_IDENTITY] = src_identity;
-			ep_tail_call(skb, CILIUM_CALL_IPV4_NODEPORT_NAT);
+			// TODO
+			ctx->cb[CB_NAT] = NAT_DIR_INGRESS;
+			ctx->cb[CB_SRC_IDENTITY] = src_identity;
+			ep_tail_call(ctx, CILIUM_CALL_IPV4_NODEPORT_NAT);
 			return DROP_MISSED_TAIL_CALL;
 		}
 	}
 
-	ret = ct_lookup4(get_ct_map4(&tuple), &tuple, skb, l4_off, CT_EGRESS,
+	ret = ct_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off, CT_EGRESS,
 			 &ct_state, &monitor);
 	if (ret < 0)
 		return ret;
-	if (!revalidate_data(skb, &data, &data_end, &ip4))
+	if (!revalidate_data(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
 
 	backend_local = lookup_ip4_endpoint(ip4);
@@ -1039,7 +1040,7 @@ static inline int nodeport_lb4(struct __sk_buff *skb, __u32 src_identity)
 	case CT_NEW:
 		ct_state_new.src_sec_id = SECLABEL;
 		ct_state_new.node_port = 1;
-		ret = ct_create4(get_ct_map4(&tuple), &tuple, skb, CT_EGRESS,
+		ret = ct_create4(get_ct_map4(&tuple), &tuple, ctx, CT_EGRESS,
 				 &ct_state_new, false);
 		if (IS_ERR(ret))
 			return ret;
@@ -1047,7 +1048,7 @@ static inline int nodeport_lb4(struct __sk_buff *skb, __u32 src_identity)
 			ct_flip_tuple_dir4(&tuple);
 redo:
 			ct_state_new.rev_nat_index = 0;
-			ret = ct_create4(get_ct_map4(&tuple), &tuple, skb,
+			ret = ct_create4(get_ct_map4(&tuple), &tuple, ctx,
 					 CT_INGRESS, &ct_state_new, false);
 			if (IS_ERR(ret))
 				return ret;
@@ -1071,9 +1072,9 @@ redo:
 		return DROP_UNKNOWN_CT;
 	}
 
-	if (!revalidate_data(skb, &data, &data_end, &ip4))
+	if (!revalidate_data(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
-	if (eth_load_saddr(skb, smac.addr, 0) < 0)
+	if (eth_load_saddr(ctx, smac.addr, 0) < 0)
 		return DROP_INVALID;
 	ret = map_update_elem(&NODEPORT_NEIGH4, &ip4->saddr, &smac, 0);
 	if (ret < 0) {
@@ -1082,17 +1083,18 @@ redo:
 
 	if (!backend_local) {
 		if (nodeport_uses_dsr4(&tuple)) {
-			skb->cb[CB_SVC_PORT] = key.dport;
-			skb->cb[CB_SVC_ADDR_V4] = key.address;
-			ep_tail_call(skb, CILIUM_CALL_IPV4_NODEPORT_DSR);
+			// TODO
+			ctx->cb[CB_SVC_PORT] = key.dport;
+			ctx->cb[CB_SVC_ADDR_V4] = key.address;
+			ep_tail_call(ctx, CILIUM_CALL_IPV4_NODEPORT_DSR);
 		} else {
-			skb->cb[CB_NAT] = NAT_DIR_EGRESS;
-			ep_tail_call(skb, CILIUM_CALL_IPV4_NODEPORT_NAT);
+			ctx->cb[CB_NAT] = NAT_DIR_EGRESS;
+			ep_tail_call(ctx, CILIUM_CALL_IPV4_NODEPORT_NAT);
 		}
 		return DROP_MISSED_TAIL_CALL;
 	}
 
-	return TC_ACT_OK;
+	return CTX_ACT_OK;
 }
 
 /* Reverse NAT handling of node-port traffic for the case where the
@@ -1103,7 +1105,7 @@ redo:
  * CILIUM_CALL_IPV{4,6}_NODEPORT_REVNAT is plugged into CILIUM_MAP_CALLS
  * of the bpf_netdev, bpf_overlay and of the bpf_lxc.
  */
-static inline int rev_nodeport_lb4(struct __sk_buff *skb, int *ifindex,
+static inline int rev_nodeport_lb4(struct __ctx_buff *ctx, int *ifindex,
 				   union macaddr *mac)
 {
 	struct ipv4_ct_tuple tuple = {};
@@ -1116,7 +1118,7 @@ static inline int rev_nodeport_lb4(struct __sk_buff *skb, int *ifindex,
 	union macaddr *dmac;
 	__u32 monitor = 0;
 
-	if (!revalidate_data(skb, &data, &data_end, &ip4))
+	if (!revalidate_data(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
 
 	tuple.nexthdr = ip4->protocol;
@@ -1126,27 +1128,27 @@ static inline int rev_nodeport_lb4(struct __sk_buff *skb, int *ifindex,
 	l4_off = l3_off + ipv4_hdrlen(ip4);
 	csum_l4_offset_and_flags(tuple.nexthdr, &csum_off);
 
-	ret = ct_lookup4(get_ct_map4(&tuple), &tuple, skb, l4_off, CT_INGRESS, &ct_state,
+	ret = ct_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off, CT_INGRESS, &ct_state,
 			 &monitor);
 
 	if (ret == CT_REPLY && ct_state.node_port == 1 && ct_state.rev_nat_index != 0) {
-		ret2 = lb4_rev_nat(skb, l3_off, l4_off, &csum_off,
+		ret2 = lb4_rev_nat(ctx, l3_off, l4_off, &csum_off,
 				   &ct_state, &tuple,
 				   REV_NAT_F_TUPLE_SADDR);
 		if (IS_ERR(ret2))
 			return ret2;
 
-		if (!revalidate_data(skb, &data, &data_end, &ip4))
+		if (!revalidate_data(ctx, &data, &data_end, &ip4))
 			return DROP_INVALID;
 
-		skb->mark |= MARK_MAGIC_SNAT_DONE;
+		ctx->mark |= MARK_MAGIC_SNAT_DONE;
 #ifdef ENCAP_IFINDEX
 		{
 			struct remote_endpoint_info *info;
 
 			info = ipcache_lookup4(&IPCACHE_MAP, ip4->daddr, V4_CACHE_KEY_LEN);
 			if (info != NULL && info->tunnel_endpoint != 0) {
-				int ret = __encap_with_nodeid(skb, info->tunnel_endpoint,
+				int ret = __encap_with_nodeid(ctx, info->tunnel_endpoint,
 							      SECLABEL, TRACE_PAYLOAD_LEN);
 				if (ret)
 					return ret;
@@ -1154,21 +1156,21 @@ static inline int rev_nodeport_lb4(struct __sk_buff *skb, int *ifindex,
 				*ifindex = ENCAP_IFINDEX;
 
 				/* fib lookup not necessary when going over tunnel. */
-				if (eth_store_daddr(skb, fib_params.dmac, 0) < 0)
+				if (eth_store_daddr(ctx, fib_params.dmac, 0) < 0)
 					return DROP_WRITE_ERROR;
-				if (eth_store_saddr(skb, fib_params.smac, 0) < 0)
+				if (eth_store_saddr(ctx, fib_params.smac, 0) < 0)
 					return DROP_WRITE_ERROR;
 
-				return TC_ACT_OK;
+				return CTX_ACT_OK;
 			}
 		}
 #endif
 
 		dmac = map_lookup_elem(&NODEPORT_NEIGH4, &ip4->daddr);
 		if (dmac) {
-		    if (eth_store_daddr(skb, dmac->addr, 0) < 0)
+		    if (eth_store_daddr(ctx, dmac->addr, 0) < 0)
 			return DROP_WRITE_ERROR;
-		    if (eth_store_saddr(skb, mac->addr, 0) < 0)
+		    if (eth_store_saddr(ctx, mac->addr, 0) < 0)
 			return DROP_WRITE_ERROR;
 		} else {
 		    fib_params.family = AF_INET;
@@ -1177,48 +1179,48 @@ static inline int rev_nodeport_lb4(struct __sk_buff *skb, int *ifindex,
 		    fib_params.ipv4_src = ip4->saddr;
 		    fib_params.ipv4_dst = ip4->daddr;
 
-		    int rc = fib_lookup(skb, &fib_params, sizeof(fib_params),
+		    int rc = fib_lookup(ctx, &fib_params, sizeof(fib_params),
 				BPF_FIB_LOOKUP_DIRECT | BPF_FIB_LOOKUP_OUTPUT);
 		    if (rc != 0)
 			return DROP_NO_FIB;
 
-		    if (eth_store_daddr(skb, fib_params.dmac, 0) < 0)
+		    if (eth_store_daddr(ctx, fib_params.dmac, 0) < 0)
 			return DROP_WRITE_ERROR;
-		    if (eth_store_saddr(skb, fib_params.smac, 0) < 0)
+		    if (eth_store_saddr(ctx, fib_params.smac, 0) < 0)
 			return DROP_WRITE_ERROR;
 		}
 	} else {
-		if (!(skb->tc_index & TC_INDEX_F_SKIP_RECIRCULATION)) {
-			skb->tc_index |= TC_INDEX_F_SKIP_NODEPORT;
-			ep_tail_call(skb, CILIUM_CALL_IPV4_FROM_LXC);
+		if (!(ctx->tc_index & TC_INDEX_F_SKIP_RECIRCULATION)) {
+			ctx->tc_index |= TC_INDEX_F_SKIP_NODEPORT;
+			ep_tail_call(ctx, CILIUM_CALL_IPV4_FROM_LXC);
 			return DROP_MISSED_TAIL_CALL;
 		}
 	}
 
-	return TC_ACT_OK;
+	return CTX_ACT_OK;
 }
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV4_NODEPORT_REVNAT)
-int tail_rev_nodeport_lb4(struct __sk_buff *skb)
+int tail_rev_nodeport_lb4(struct __ctx_buff *ctx)
 {
 	int ifindex = NATIVE_DEV_IFINDEX;
 	union macaddr mac = NATIVE_DEV_MAC;
 	int ret = 0;
 
-	ret = rev_nodeport_lb4(skb, &ifindex, &mac);
+	ret = rev_nodeport_lb4(ctx, &ifindex, &mac);
 	if (IS_ERR(ret))
-		return send_drop_notify_error(skb, 0, ret, TC_ACT_SHOT, METRIC_EGRESS);
+		return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP, METRIC_EGRESS);
 	return redirect(ifindex, 0);
 }
 #endif /* ENABLE_IPV4 */
 
-static __always_inline int nodeport_nat_fwd(struct __sk_buff *skb,
+static __always_inline int nodeport_nat_fwd(struct __ctx_buff *ctx,
 					    const bool encap)
 {
 	__u16 proto;
 
-	if (!validate_ethertype(skb, &proto))
-		return TC_ACT_OK;
+	if (!validate_ethertype(ctx, &proto))
+		return CTX_ACT_OK;
 	switch (proto) {
 #ifdef ENABLE_IPV4
 	case bpf_htons(ETH_P_IP): {
@@ -1229,7 +1231,7 @@ static __always_inline int nodeport_nat_fwd(struct __sk_buff *skb,
 		else
 #endif
 			addr = IPV4_NODEPORT;
-		return nodeport_nat_ipv4_fwd(skb, addr);
+		return nodeport_nat_ipv4_fwd(ctx, addr);
 	}
 #endif /* ENABLE_IPV4 */
 #ifdef ENABLE_IPV6
@@ -1241,22 +1243,22 @@ static __always_inline int nodeport_nat_fwd(struct __sk_buff *skb,
 		else
 #endif
 			BPF_V6(addr, IPV6_NODEPORT);
-		return nodeport_nat_ipv6_fwd(skb, &addr);
+		return nodeport_nat_ipv6_fwd(ctx, &addr);
 	}
 #endif /* ENABLE_IPV6 */
 	default:
 		break;
 	}
-	return TC_ACT_OK;
+	return CTX_ACT_OK;
 }
 
-static __always_inline int nodeport_nat_rev(struct __sk_buff *skb,
+static __always_inline int nodeport_nat_rev(struct __ctx_buff *ctx,
 					    const bool encap)
 {
 	__u16 proto;
 
-	if (!validate_ethertype(skb, &proto))
-		return TC_ACT_OK;
+	if (!validate_ethertype(ctx, &proto))
+		return CTX_ACT_OK;
 	switch (proto) {
 #ifdef ENABLE_IPV4
 	case bpf_htons(ETH_P_IP): {
@@ -1267,7 +1269,7 @@ static __always_inline int nodeport_nat_rev(struct __sk_buff *skb,
 		else
 #endif
 			addr = IPV4_NODEPORT;
-		return nodeport_nat_ipv4_rev(skb, addr);
+		return nodeport_nat_ipv4_rev(ctx, addr);
 	}
 #endif /* ENABLE_IPV4 */
 #ifdef ENABLE_IPV6
@@ -1279,7 +1281,7 @@ static __always_inline int nodeport_nat_rev(struct __sk_buff *skb,
 		else
 #endif
 			BPF_V6(addr, IPV6_NODEPORT);
-		return nodeport_nat_ipv6_rev(skb, &addr);
+		return nodeport_nat_ipv6_rev(ctx, &addr);
 	}
 #endif /* ENABLE_IPV6 */
 	default:
@@ -1289,7 +1291,7 @@ static __always_inline int nodeport_nat_rev(struct __sk_buff *skb,
 		build_bug_on(!(NODEPORT_PORT_MAX     < EPHEMERAL_MIN));
 		break;
 	}
-	return TC_ACT_OK;
+	return CTX_ACT_OK;
 }
 #endif /* ENABLE_NODEPORT */
 #endif /* __NODEPORT_H_ */

--- a/bpf/lib/overloadable.h
+++ b/bpf/lib/overloadable.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2019 Authors of Cilium
+ *  Copyright (C) 2020 Authors of Cilium
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -15,24 +15,10 @@
  *  along with this program; if not, write to the Free Software
  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
-#include <bpf/ctx/skb.h>
-#include <bpf/api.h>
+#ifndef __LIB_OVERLOADABLE_H_
+#define __LIB_OVERLOADABLE_H_
 
-#include <node_config.h>
-#include <netdev_config.h>
+#include "lib/overloadable_skb.h"
+#include "lib/overloadable_xdp.h"
 
-#include "lib/common.h"
-
-__section("to-host")
-int to_host(struct __ctx_buff *ctx)
-{
-	// Upper 16 bits may carry proxy port number, clear it out
-	__u32 magic = ctx->cb[0] & 0xFFFF;
-	if (magic == MARK_MAGIC_TO_PROXY) {
-		ctx->mark = ctx->cb[0];
-		ctx->cb[0] = 0;
-	}
-	return CTX_ACT_OK;
-}
-
-BPF_LICENSE("GPL");
+#endif /* __LIB_OVERLOADABLE_H_ */

--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -1,0 +1,95 @@
+/*
+ *  Copyright (C) 2020 Authors of Cilium
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+#ifndef __LIB_OVERLOADABLE_SKB_H_
+#define __LIB_OVERLOADABLE_SKB_H_
+
+static __always_inline __maybe_unused __overloadable void
+bpf_clear_cb(struct __sk_buff *ctx)
+{
+	__u32 zero = 0;
+
+	ctx->cb[0] = zero;
+	ctx->cb[1] = zero;
+	ctx->cb[2] = zero;
+	ctx->cb[3] = zero;
+	ctx->cb[4] = zero;
+}
+
+/**
+ * get_identity - returns source identity from the mark field
+ */
+static __always_inline __maybe_unused __overloadable int
+get_identity(struct __sk_buff *ctx)
+{
+	return ((ctx->mark & 0xFF) << 16) | ctx->mark >> 16;
+}
+
+static __always_inline __maybe_unused __overloadable void
+set_encrypt_dip(struct __sk_buff *ctx, __u32 ip_endpoint)
+{
+	ctx->cb[4] = ip_endpoint;
+}
+
+/**
+ * set_identity - pushes 24 bit identity into ctx mark value.
+ */
+static __always_inline __maybe_unused __overloadable void
+set_identity(struct __sk_buff *ctx, __u32 identity)
+{
+	ctx->mark = ctx->mark & MARK_MAGIC_KEY_MASK;
+	ctx->mark |= ((identity & 0xFFFF) << 16) | ((identity & 0xFF0000) >> 16);
+}
+
+static __always_inline __maybe_unused __overloadable void
+set_identity_cb(struct __sk_buff *ctx, __u32 identity)
+{
+	ctx->cb[1] = identity;
+}
+
+/**
+ * set_encrypt_key - pushes 8 bit key and encryption marker into ctx mark value.
+ */
+static __always_inline __maybe_unused __overloadable void
+set_encrypt_key(struct __sk_buff *ctx, __u8 key)
+{
+	ctx->mark = or_encrypt_key(key);
+}
+
+static __always_inline __maybe_unused __overloadable void
+set_encrypt_key_cb(struct __sk_buff *ctx, __u8 key)
+{
+	ctx->cb[0] = or_encrypt_key(key);
+}
+
+static __always_inline __maybe_unused __overloadable int
+redirect_self(struct __sk_buff *ctx)
+{
+	/* Looping back the packet into the originating netns. In
+	 * case of veth, it's xmit'ing into the hosts' veth device
+	 * such that we end up on ingress in the peer. For ipvlan
+	 * slave it's redirect to ingress as we are attached on the
+	 * slave in netns already.
+	 */
+#ifdef ENABLE_HOST_REDIRECT
+	return redirect(ctx->ifindex, 0);
+#else
+	return redirect(ctx->ifindex, BPF_F_INGRESS);
+#endif
+}
+
+#endif /* __LIB_OVERLOADABLE_SKB_H_ */

--- a/bpf/lib/overloadable_xdp.h
+++ b/bpf/lib/overloadable_xdp.h
@@ -1,0 +1,63 @@
+/*
+ *  Copyright (C) 2020 Authors of Cilium
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+#ifndef __LIB_OVERLOADABLE_XDP_H_
+#define __LIB_OVERLOADABLE_XDP_H_
+
+static __always_inline __maybe_unused __overloadable void
+bpf_clear_cb(struct xdp_md *ctx)
+{
+}
+
+static __always_inline __maybe_unused __overloadable int
+get_identity(struct xdp_md *ctx)
+{
+	return 0;
+}
+
+static __always_inline __maybe_unused __overloadable void
+set_encrypt_dip(struct xdp_md *ctx, __u32 ip_endpoint)
+{
+}
+
+static __always_inline __maybe_unused __overloadable void
+set_identity(struct xdp_md *ctx, __u32 identity)
+{
+}
+
+static __always_inline __maybe_unused __overloadable void
+set_identity_cb(struct xdp_md *ctx, __u32 identity)
+{
+}
+
+static __always_inline __maybe_unused __overloadable void
+set_encrypt_key(struct xdp_md *ctx, __u8 key)
+{
+}
+
+static __always_inline __maybe_unused __overloadable void
+set_encrypt_key_cb(struct xdp_md *ctx, __u8 key)
+{
+}
+
+static __always_inline __maybe_unused __overloadable int
+redirect_self(struct xdp_md *ctx)
+{
+	return -ENOTSUP;
+}
+
+#endif /* __LIB_OVERLOADABLE_XDP_H_ */

--- a/bpf/lib/signal.h
+++ b/bpf/lib/signal.h
@@ -46,20 +46,20 @@ struct signal_msg {
 	};
 };
 
-static inline void send_signal(struct __sk_buff *skb, struct signal_msg *msg)
+static inline void send_signal(struct __ctx_buff *ctx, struct signal_msg *msg)
 {
-	skb_event_output(skb, &SIGNAL_MAP, BPF_F_CURRENT_CPU,
+	ctx_event_output(ctx, &SIGNAL_MAP, BPF_F_CURRENT_CPU,
 			 msg, sizeof(*msg));
 }
 
-static inline void send_signal_nat_fill_up(struct __sk_buff *skb, __u32 proto)
+static inline void send_signal_nat_fill_up(struct __ctx_buff *ctx, __u32 proto)
 {
 	struct signal_msg msg = {
 		.signal_nr	= SIGNAL_NAT_FILL_UP,
 		.proto		= proto,
 	};
 
-	send_signal(skb, &msg);
+	send_signal(ctx, &msg);
 }
 
 #endif /* __LIB_SIGNAL_H_ */

--- a/bpf/lib/tailcall.h
+++ b/bpf/lib/tailcall.h
@@ -33,7 +33,7 @@
  *
  * declare_tailcall_if(__and(is_defined(ENABLE_IPV4), is_defined(ENABLE_IPV6)),
  *                     CILIUM_CALL_FOO)
- * int foo_fn(struct __sk_buff *skb)
+ * int foo_fn(struct __ctx_buff *ctx)
  * {
  *    [...]
  * }
@@ -51,13 +51,13 @@
  * set, then above emits a tail call as follows:
  *
  * __attribute__((section("2" "/" "10"), used))
- * int foo_fn(struct __sk_buff *skb)
+ * int foo_fn(struct __ctx_buff *ctx)
  * {
  *    [...]
  * }
  *
  * [...]
- * do { ep_tail_call(skb, 10); ret = -140; } while (0);
+ * do { ep_tail_call(ctx, 10); ret = -140; } while (0);
  * [...]
  *
  * The fall-through side sets DROP_MISSED_TAIL_CALL as ret.
@@ -66,13 +66,13 @@
  * of them, then the code emission looks like:
  *
  * static __inline __attribute__ ((__always_inline__))
- * int foo_fn(struct __sk_buff *skb)
+ * int foo_fn(struct __ctx_buff *ctx)
  * {
  *    [...]
  * }
  *
  * [...]
- * return foo_fn(skb);
+ * return foo_fn(ctx);
  * [...]
  *
  * Selectors can be single is_defined(), or multiple ones
@@ -88,10 +88,10 @@
 	__eval(__declare_tailcall_if_, COND)(NAME)
 
 #define __invoke_tailcall_if_0(NAME, FUNC)    \
-	return FUNC(skb)
+	return FUNC(ctx)
 #define __invoke_tailcall_if_1(NAME, FUNC)    \
 	do {                                  \
-		ep_tail_call(skb, NAME);      \
+		ep_tail_call(ctx, NAME);      \
 		ret = DROP_MISSED_TAIL_CALL;  \
 	} while (0)
 #define invoke_tailcall_if(COND, NAME, FUNC)  \

--- a/bpf/lib/utils.h
+++ b/bpf/lib/utils.h
@@ -18,6 +18,7 @@
 #ifndef __LIB_UTILS_H_
 #define __LIB_UTILS_H_
 
+#include <bpf/ctx/ctx.h>
 #include <bpf/api.h>
 
 #define min(x, y)		\
@@ -60,17 +61,6 @@ static inline void bpf_barrier(void)
 # define WRITE_ONCE(x, v)	\
 	({ typeof(x) __val = (v); __WRITE_ONCE(x, __val); bpf_barrier(); __val; })
 #endif
-
-/* Clear CB values */
-static inline void bpf_clear_cb(struct __sk_buff *skb)
-{
-	__u32 zero = 0;
-	skb->cb[0] = zero;
-	skb->cb[1] = zero;
-	skb->cb[2] = zero;
-	skb->cb[3] = zero;
-	skb->cb[4] = zero;
-}
 
 #define NSEC_PER_SEC	1000000000UL
 

--- a/bpf/run_probes.sh
+++ b/bpf/run_probes.sh
@@ -87,7 +87,7 @@ echo "#ifndef BPF_FEATURES_H_"  > "$FEATURE_FILE"
 echo "#define BPF_FEATURES_H_" >> "$FEATURE_FILE"
 echo "" >> "$FEATURE_FILE"
 
-#probe_run_tc "skb_change_tail.c" "HAVE_SKB_CHANGE_TAIL"
+#probe_run_tc "ctx_change_tail.c" "HAVE_SKB_CHANGE_TAIL"
 probe_run_ll
 
 echo "#endif /* BPF_FEATURES_H_ */" >> "$FEATURE_FILE"

--- a/bpf/sockops/bpf_redir.c
+++ b/bpf/sockops/bpf_redir.c
@@ -15,15 +15,15 @@
  *  along with this program; if not, write to the Free Software
  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
+#include <bpf/ctx/unspec.h>
+#include <bpf/api.h>
+
+#include <node_config.h>
+
+#include <linux/if_ether.h>
 
 #define SKIP_CALLS_MAP 1
 #define SKIP_POLICY_MAP 1
-
-#include <node_config.h>
-#include <bpf/api.h>
-
-#include <linux/bpf.h>
-#include <linux/if_ether.h>
 
 #define SOCKMAP 1
 

--- a/bpf/sockops/bpf_sockops.c
+++ b/bpf/sockops/bpf_sockops.c
@@ -15,15 +15,17 @@
  *  along with this program; if not, write to the Free Software
  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
-#define SKIP_CALLS_MAP 1
-#define SKIP_POLICY_MAP 1
-#define SOCKMAP 1
-
-#include <node_config.h>
+#include <bpf/ctx/unspec.h>
 #include <bpf/api.h>
 
-#include <linux/bpf.h>
+#include <node_config.h>
+
 #include <linux/if_ether.h>
+
+#define SKIP_CALLS_MAP 1
+#define SKIP_POLICY_MAP 1
+
+#define SOCKMAP 1
 
 #include "../lib/utils.h"
 #include "../lib/common.h"

--- a/test/bpf/elf-demo.c
+++ b/test/bpf/elf-demo.c
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0
 // Copyright (c) 2018-2019 Authors of Cilium
-#include <linux/bpf.h>
+
+#include <bpf/ctx/skb.h>
+#include <bpf/api.h>
 
 #include "lib/utils.h"
 #include "lib/common.h"

--- a/test/bpf/unit-test.c
+++ b/test/bpf/unit-test.c
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0
 // Copyright (c) 2018-2019 Authors of Cilium
+
+#include <bpf/ctx/skb.h>
+#include <bpf/api.h>
+
 #include <assert.h>
-#include <string.h>
 
 #include "lib/utils.h"
 #include "lib/common.h"

--- a/test/bpf/verifier-test.sh
+++ b/test/bpf/verifier-test.sh
@@ -23,7 +23,7 @@ ALL_TC_PROGS="bpf_hostdev_ingress bpf_ipsec bpf_lxc bpf_netdev bpf_network bpf_o
 TC_PROGS=${TC_PROGS:-$ALL_TC_PROGS}
 ALL_CG_PROGS="bpf_sock sockops/bpf_sockops sockops/bpf_redir"
 CG_PROGS=${CG_PROGS:-$ALL_CG_PROGS}
-ALL_XDP_PROGS="bpf_xdp"
+ALL_XDP_PROGS="bpf_prefilter"
 XDP_PROGS=${XDP_PROGS:-$ALL_XDP_PROGS}
 IGNORED_PROGS="bpf_alignchecker"
 ALL_PROGS="${IGNORED_PROGS} ${ALL_CG_PROGS} ${ALL_TC_PROGS} ${ALL_XDP_PROGS}"
@@ -237,7 +237,7 @@ function load_xdp {
 			load_prog_dev "$IPROUTE2 link set" "xdpgeneric" ${p}
 		done
 	else
-		echo "=> Skipping ${DIR}/bpf_xdp.c."
+		echo "=> Skipping ${DIR}/bpf_prefilter.c."
 		echo "Ensure you have linux >= 4.12 and recent iproute2 to test XDP." 1>&2
 	fi
 }


### PR DESCRIPTION
One-time conversion of whole datapath to generic ctx type. Whether the
underlying type is skb or xdp based is controlled via bpf/ctx/{skb,xdp}.h.

Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10333)
<!-- Reviewable:end -->
