### PR TITLE
cilium-health: avoid allocating in loop

### DIFF
--- a/cilium-health/launch/launcher.go
+++ b/cilium-health/launch/launcher.go
@@ -113,11 +113,12 @@ func (ch *CiliumHealth) runServer() {
 		scopedLog.WithError(err).Fatal("Cannot set default permissions on socket")
 	}
 
+	status := &models.Status{}
+
 	// Periodically fetch status from cilium-health server
 	for {
-		status := &models.Status{
-			State: models.StatusStateOk,
-		}
+		status.Msg = ""
+		status.State = models.StatusStateOk
 
 		_, err := ch.client.Restapi.GetHealthz(nil)
 		if err != nil {


### PR DESCRIPTION
Instead of allocating a new instance of models.Status, just change the
existing one.

Updates #10056

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10335)
<!-- Reviewable:end -->
