### PR TITLE
helm: Allow disabling xt_socket fallback

### DIFF
--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -254,9 +254,7 @@ data:
   ipvlan-master-device: {{ .Values.global.ipvlan.masterDevice }}
 {{- end }}
 {{- end }}
-{{- if .Values.global.enableXTSocketFallback }}
   enable-xt-socket-fallback: {{ .Values.global.enableXTSocketFallback | quote }}
-{{- end}}
   install-iptables-rules: {{ .Values.global.installIptablesRules | quote }}
   auto-direct-node-routes: {{ .Values.global.autoDirectNodeRoutes | quote }}
 


### PR DESCRIPTION
Helm cannot distinguish between empty and false value, so previously used if-statement prevented from disabling the fallback when "--set global.enableXTSocketFallback=false" was set.

Fixes: 68858fcf95b ("iptables: Add a fallback to missing xt_socket module.")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10342)
<!-- Reviewable:end -->
