### PR TITLE
test/provision: copy all services before enabling/restarting

### DIFF
--- a/test/provision/compile.sh
+++ b/test/provision/compile.sh
@@ -28,7 +28,7 @@ then
     # Only need to build on one host, since we can pull from the other host.
     if [[ "$(hostname)" == "k8s1" && "${CILIUM_REGISTRY}" == "" ]]; then
       ./test/provision/container-images.sh cilium_images .
-	  if [[ "${CILIUM_IMAGE}" == "" && "${CILIUM_OPERATOR_IMAGE}" == "" ]]; then
+      if [[ "${CILIUM_IMAGE}" == "" && "${CILIUM_OPERATOR_IMAGE}" == "" ]]; then
         echo "building cilium/cilium container image..."
         make LOCKDEBUG=1 docker-image-no-clean
 
@@ -73,12 +73,17 @@ else
     make install
     mkdir -p /etc/sysconfig/
     cp -f contrib/systemd/cilium /etc/sysconfig/cilium
-    for svc in $(ls -1 ./contrib/systemd/*.*); do
-        cp -f "${svc}"  /etc/systemd/system/
+    services=$(ls -1 ./contrib/systemd/*.*)
+    for svc in ${services}; do
+        cp -f "${svc}" /etc/systemd/system/
+    done
+    for svc in ${services}; do
         service=$(echo "$svc" | sed -E -n 's/.*\/(.*?).(service|mount)/\1.\2/p')
-        echo "service $service"
-        systemctl enable $service || echo "service $service failed"
-        systemctl restart $service || echo "service $service failed to restart"
+        if [ -n "$service" ] ; then
+          echo "installing service $service"
+          systemctl enable $service || echo "service $service failed"
+          systemctl restart $service || echo "service $service failed to restart"
+        fi
     done
     echo "running \"sudo adduser vagrant cilium\" "
     sudo adduser vagrant cilium


### PR DESCRIPTION
Observed on https://jenkins.cilium.io/job/Cilium-PR-Ginkgo-Tests-Validated/17500/consoleFull

```
15:03:41      runtime: service cilium-docker.service
15:03:41      runtime: Created symlink /etc/systemd/system/multi-user.target.wants/cilium-docker.service -> /etc/systemd/system/cilium-docker.service.
15:03:41      runtime: service cilium-etcd.service
15:03:41      runtime: Created symlink /etc/systemd/system/multi-user.target.wants/cilium-etcd.service -> /etc/systemd/system/cilium-etcd.service.
15:03:43      runtime: service cilium-operator.service
15:03:43      runtime: Created symlink /etc/systemd/system/multi-user.target.wants/cilium-operator.service -> /etc/systemd/system/cilium-operator.service.
15:03:43      runtime: Failed to restart cilium-operator.service: Unit cilium.service not found.
15:03:43      runtime: service cilium-operator.service failed to restart
15:03:43      runtime: service cilium.service
15:03:43      runtime: Created symlink /etc/systemd/system/multi-user.target.wants/cilium.service -> /etc/systemd/system/cilium.service.
15:03:43      runtime: service
15:03:43      runtime: Too few arguments.
15:03:43      runtime: service  failed
15:03:43      runtime: Too few arguments.
15:03:43      runtime: service  failed to restart
15:03:43      runtime: service sys-fs-bpf.mount
15:03:43      runtime: Created symlink /etc/systemd/system/multi-user.target.wants/sys-fs-bpf.mount -> /etc/systemd/system/sys-fs-bpf.mount.
```

Since the system services are listed in lexicographic order,
`cilium-operator.service` is copied, enabled and restarted before
`cilium.service`. However, `cilium-operator.service` depends on
`cilium.service`, thus leading to the above errors.

Circumvent this by copying the service files in a separate step and only
then enabling and restarting the services. Also, for some reason
`$service` is empty in one iteration. Avoid systemctl error messages by
only enabling/restarting in case of non-empty `$service`.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10346)
<!-- Reviewable:end -->
