### PR TITLE
Fix eks restart pods helm

### DIFF
--- a/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
@@ -164,7 +164,7 @@ spec:
               if grep -q 'docker' /etc/crictl.yaml; then
                 # Works for COS, ubuntu
                 for f in `find /var/lib/cni/networks/ -type f ! -name lock ! -name last_reserved_ip.0`; do docker rm -f $(cat $f) || true; done
-              elif [ -n "$(docker ps --format "{{.Image}}" | grep ^[0-9]*\.dkr\.ecr\.[a-z]*-[a-z]*-[0-9]*\.amazonaws\.com/amazon-k8s-cni)" ]; then
+              elif [ -n "$(docker ps --format '{{ "{{" }}.Image{{ "}}" }}' | grep ^[0-9]*\.dkr\.ecr\.[a-z]*-[a-z]*-[0-9]*\.amazonaws\.com/amazon-k8s-cni)" ]; then
                 timeout=1
                 for i in $(seq 1 7); do
                   echo "Checking introspection API"
@@ -177,7 +177,7 @@ spec:
                 for pod in $(curl "localhost:61679/v1/pods" 2> /dev/null | jq -r '. | keys[]'); do
                   container_id=$(echo "$pod" | awk -F_ ' { print $3 } ' | cut -c1-12)
                   echo "Restarting ${container_id}"
-                  docker rm -f "${container_id}" || true
+                  docker kill "${container_id}" || true
                 done
               else
                 # COS-beta (with containerd)


### PR DESCRIPTION
Signed-off-by: Tom Hadlaw <thomas.hadlaw@hootsuite.com>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

Follow up bugfix's for my previous pull request. One problem is that helm actually breaks the docker `--format` argument value as it considers it a template value. This causes the conditional to always be false and for the container restart to never happen on EKS nodes.
Secondly, upon further testing, it seems like kubelet can fail due if the container is removed: (`rpc error: code = Unknown desc = unable to inspect docker image ...`).

I'm not exactly sure why this didn't happen during my first round of testing but I propose to just kill the container and let Kubelet manage the remaining container state (docker kill just sends sigkill to the container process, wheraes rm removes all the container state as well). The container does get cleaned up afterwards.

fixes: #9571

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10351)
<!-- Reviewable:end -->
