### PR TITLE
v1.7 backports 2020-02-26

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_template.md
@@ -34,8 +34,8 @@ security@cilium.io - first, before disclosing them in any public forums.
 - Orchestration system version in use (e.g. `kubectl version`, Mesos, ...)
 - Link to relevant artifacts (policies, deployments scripts, ...)
 - Upload a system dump (run `curl -sLO
-releases.cilium.io/tools/cluster-diagnosis.zip &&
-python cluster-diagnosis.zip sysdump` and then attach the generated zip file)
+https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip &&
+python cilium-sysdump.zip` and then attach the generated zip file)
 
 **How to reproduce the issue**
 

--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -69,6 +69,7 @@ cilium-agent [flags]
       --enable-remote-node-identity                           Enable use of remote node identity
       --enable-tracing                                        Enable tracing while determining policy (debugging)
       --enable-well-known-identities                          Enable well-known identities for known Kubernetes components (default true)
+      --enable-xt-socket-fallback                             Enable fallback for missing xt_socket module (default true)
       --encrypt-interface string                              Transparent encryption interface
       --encrypt-node                                          Enables encrypting traffic from non-Cilium pods and host networking
       --endpoint-interface-name-prefix string                 Prefix of interface name shared by all endpoints (default "lxc+")

--- a/Documentation/gettingstarted/k8s-install-aks.rst
+++ b/Documentation/gettingstarted/k8s-install-aks.rst
@@ -36,8 +36,6 @@ Kubernetes versions.
 Create an AKS Cluster
 =====================
 
-The full background on creating AKS clusters in advanced networking mode, see
-`this guide <https://docs.microsoft.com/en-us/azure/aks/configure-azure-cni>`_.
 You can use any method to create and deploy an AKS cluster with the exception
 of specifying the Network Policy option. Doing so will still work but will
 result in unwanted iptables rules being installed on all of your nodes.
@@ -55,55 +53,17 @@ the cluster is ready.
 
 .. code:: bash
 
-        export SP_PASSWORD=mySecurePassword
-        export RESOURCE_GROUP_NAME=myResourceGroup-NP
-        export CLUSTER_NAME=myAKSCluster
+        export RESOURCE_GROUP_NAME=group1
+        export CLUSTER_NAME=aks-test1
         export LOCATION=westus
 
-        # Create a resource group
         az group create --name $RESOURCE_GROUP_NAME --location $LOCATION
-
-        # Create a virtual network and subnet
-        az network vnet create \
-            --resource-group $RESOURCE_GROUP_NAME \
-            --name myVnet \
-            --address-prefixes 10.0.0.0/8 \
-            --subnet-name myAKSSubnet \
-            --subnet-prefix 10.240.0.0/16
-
-        # Create a service principal and read in the application ID
-        SP_ID_PASSWORD=$(az ad sp create-for-rbac --skip-assignment --query [appId,password] -o tsv)
-        SP_ID=$(echo ${SP_ID_PASSWORD} | sed -e 's/ .*//g')
-        SP_PASSWORD=$(echo ${SP_ID_PASSWORD} | sed -e 's/.* //g')
-        unset SP_ID_PASSWORD
-
-        # Wait 15 seconds to make sure that service principal has propagated
-        echo "Waiting for service principal to propagate..."
-        sleep 15
-
-        # Get the virtual network resource ID
-        VNET_ID=$(az network vnet show --resource-group $RESOURCE_GROUP_NAME --name myVnet --query id -o tsv)
-
-        # Assign the service principal Contributor permissions to the virtual network resource
-        az role assignment create --assignee $SP_ID --scope $VNET_ID --role Contributor
-
-        # Get the virtual network subnet resource ID
-        SUBNET_ID=$(az network vnet subnet show --resource-group $RESOURCE_GROUP_NAME --vnet-name myVnet --name myAKSSubnet --query id -o tsv)
-
-        # Create the AKS cluster and specify the virtual network and service principal information
-        # Enable network policy by using the `--network-policy` parameter
         az aks create \
             --resource-group $RESOURCE_GROUP_NAME \
             --name $CLUSTER_NAME \
-            --node-count 1 \
+            --node-count 2 \
             --generate-ssh-keys \
-            --network-plugin azure \
-            --service-cidr 10.0.0.0/16 \
-            --dns-service-ip 10.0.0.10 \
-            --docker-bridge-address 172.17.0.1/16 \
-            --vnet-subnet-id $SUBNET_ID \
-            --service-principal $SP_ID \
-            --client-secret $SP_PASSWORD
+            --network-plugin azure
 
 Configure kubectl to Point to Newly Created Cluster
 ===================================================
@@ -114,12 +74,6 @@ AKS cluster:
 .. code:: bash
 
     az aks get-credentials --resource-group $RESOURCE_GROUP_NAME --name $CLUSTER_NAME
-
-
-.. code:: bash
-
-    export KUBECONFIG=/Users/danwent/.kube/config
-
 
 To verify, you should see AKS in the name of the nodes when you run:
 

--- a/Documentation/gettingstarted/k8s-install-azure-cni-steps.rst
+++ b/Documentation/gettingstarted/k8s-install-azure-cni-steps.rst
@@ -1,11 +1,3 @@
-Limitations
-===========
-
-* Due to the architecture of the Azure CNI plugin, Layer 7 network policies and
-  visibility including FQDN policies are currently not supported in this
-  chaining mode.  The upcoming native Azure IPAM mode will support all L7
-  network policies.
-
 Create an AKS + Cilium CNI configuration
 ========================================
 
@@ -28,6 +20,7 @@ desired CNI chaining configuration:
           "plugins": [
             {
               "type": "azure-vnet",
+              "mode": "transparent",
               "bridge": "azure0",
               "ipam": {
                  "type": "azure-vnet-ipam"
@@ -73,6 +66,7 @@ Deploy Cilium release via Helm:
      --set global.cni.chainingMode=generic-veth \\
      --set global.cni.customConf=true \\
      --set global.nodeinit.enabled=true \\
+     --set nodeinit.azure=true \\
      --set global.cni.configMap=cni-configuration \\
      --set global.tunnel=disabled \\
      --set global.masquerade=false

--- a/Documentation/gettingstarted/k8s-install-connectivity-test.rst
+++ b/Documentation/gettingstarted/k8s-install-connectivity-test.rst
@@ -28,4 +28,4 @@ indicates success or failure of the test:
     pod-to-b-intra-node-9d9d4d6f9-qccfs                      1/1     Running            0          8m35s
     pod-to-b-multi-node-clusterip-5956c84b7c-hwzfg           1/1     Running            0          8m35s
     pod-to-b-multi-node-headless-6698899447-xlhfw            1/1     Running            0          8m35s
-    pod-to-external-fqdn-allow-google-cnp-667649bbf6-v6rf8   0/1     Running            0          8m35s
+    pod-to-external-fqdn-allow-google-cnp-667649bbf6-v6rf8   1/1     Running            0          8m35s

--- a/Documentation/gettingstarted/k8s-install-download-release.rst
+++ b/Documentation/gettingstarted/k8s-install-download-release.rst
@@ -1,5 +1,5 @@
-`Install Helm`_ to prepare generating the deployment artifacts based on the
-Helm templates.
+`Install Helm`_ version 3.0.0 or higher to prepare generating the deployment
+artifacts based on the Helm templates.
 
 .. _Install Helm: https://helm.sh/docs/using_helm/#install-helm
 

--- a/Documentation/install/system_requirements.rst
+++ b/Documentation/install/system_requirements.rst
@@ -20,7 +20,6 @@ When running Cilium using the container image ``cilium/cilium``, the host
 system must meet these requirements:
 
 - `Linux kernel`_ >= 4.9.17
-- :ref:`req_kvstore` etcd >= 3.1.0 or consul >= 0.6.4
 
 When running Cilium as a native process on your host (i.e. **not** running the
 ``cilium/cilium`` container image) these additional requirements must be met:
@@ -30,6 +29,11 @@ When running Cilium as a native process on your host (i.e. **not** running the
 
 .. _`clang+LLVM`: https://llvm.org
 .. _iproute2: https://www.kernel.org/pub/linux/utils/net/iproute2/
+
+When running Cilium without Kubernetes these additional requirements
+must be met:
+
+- :ref:`req_kvstore` etcd >= 3.1.0 or consul >= 0.6.4
 
 ======================== ========================== ===================
 Requirement              Minimum Version            In cilium container
@@ -137,12 +141,18 @@ by adding the following to the helm configuration command line:
 Key-Value store
 ===============
 
-Cilium uses a distributed Key-Value store to manage, synchronize and distribute
-security identities across all cluster nodes. The following Key-Value stores
-are currently supported:
+Cilium optionally uses a distributed Key-Value store to manage,
+synchronize and distribute security identities across all cluster
+nodes. The following Key-Value stores are currently supported:
 
 - etcd >= 3.1.0
 - consul >= 0.6.4
+
+Cilium can be used without a Key-Value store when CRD-based state
+management is used with Kubernetes. This is the default for new Cilium
+installations. Larger clusters will perform better with a Key-Value
+store backed identity management instead, see :ref:`k8s_quick_install`
+for more details.
 
 See :ref:`install_kvstore` for details on how to configure the
 ``cilium-agent`` to use a Key-Value store.

--- a/Documentation/install/system_requirements.rst
+++ b/Documentation/install/system_requirements.rst
@@ -79,7 +79,7 @@ Linux Kernel
 
 Cilium leverages and builds on the kernel BPF functionality as well as various
 subsystems which integrate with BPF. Therefore, host systems are required to
-run Linux kernel version 4.8.0 or later to run a Cilium agent. More recent
+run Linux kernel version 4.9.17 or later to run a Cilium agent. More recent
 kernels may provide additional BPF functionality that Cilium will automatically
 detect and use on agent start.
 
@@ -103,6 +103,34 @@ linked, either choice is valid.
 
    Users running Linux 4.10 or earlier with Cilium CIDR policies may face
    :ref:`cidr_limitations`.
+
+L7 proxy redirection currently uses ``TPROXY`` iptables actions as well
+as ``socket`` matches. For L7 redirection to work as intended kernel
+configuration must include the following modules:
+
+.. code:: bash
+
+        CONFIG_NETFILTER_XT_TARGET_TPROXY=m
+        CONFIG_NETFILTER_XT_MATCH_MARK=m
+        CONFIG_NETFILTER_XT_MATCH_SOCKET=m
+
+When ``xt_socket`` kernel module is missing the forwarding of
+redirected L7 traffic does not work in non-tunneled datapath
+modes. Since some notable kernels (e.g., COS) are shipping without
+``xt_socket`` module, Cilium implements a fallback compatibility mode
+to allow L7 policies and visibility to be used with those
+kernels. Currently this fallback disables ``ip_early_demux`` kernel
+feature in non-tunneled datapath modes, which may decrease system
+networking performance. This guarantees HTTP and Kafka redirection
+works as intended.  However, if HTTP or Kafka enforcement policies or
+visibility annotations are never used, this behavior can be turned off
+by adding the following to the helm configuration command line:
+
+.. parsed-literal::
+
+   helm install cilium |CHART_RELEASE| \\
+     ...
+     --set global.enableXTSocketFallback=false
 
 .. _req_kvstore:
 

--- a/Documentation/kubernetes/requirements.rst
+++ b/Documentation/kubernetes/requirements.rst
@@ -16,7 +16,6 @@ Kubernetes Version
 The following Kubernetes versions have been tested in the continuous integration
 system for this version of Cilium:
 
-* 1.10
 * 1.11
 * 1.12
 * 1.13

--- a/Documentation/troubleshooting.rst
+++ b/Documentation/troubleshooting.rst
@@ -293,54 +293,6 @@ Opening the ``status``, we can drill down through ``policy.realized.l4``. Do you
 ``ingress`` and ``egress`` rules match what you expect? If not, the reference to the errant
 rules can be found in the ``derived-from-rules`` node.
 
-Automatic Diagnosis
-===================
-
-The ``cluster-diagnosis`` tool can help identify the most commonly encountered
-issues in Cilium deployments. The tool currently supports Kubernetes
-and Minikube clusters only.
-
-The tool performs various checks and provides hints to fix specific
-issues that it has identified.
-
-The following is a list of prerequisites:
-
-* Requires Python >= 2.7.*
-* Requires ``kubectl``.
-* ``kubectl`` should be pointing to your cluster before running the tool.
-
-You can download the latest version of the cluster-diagnosis.zip file
-using the following command:
-
-::
-
-    curl -sLO releases.cilium.io/tools/cluster-diagnosis.zip
-
-Command to run the cluster-diagnosis tool:
-
-.. code:: bash
-
-    python cluster-diagnosis.zip
-
-Command to collect the system dump using the cluster-diagnosis tool:
-
-.. code:: bash
-
-    python cluster-diagnosis.zip sysdump
-
-You can specify from which nodes to collect the system dumps by passing
-node IP addresses via the ``--nodes`` argument:
-
-.. code:: bash
-
-    python cluster-diagnosis.zip sysdump --nodes=$NODE1_IP,$NODE2_IP2
-
-Use ``--help`` to see more options:
-
-.. code:: bash
-
-    python cluster-diagnosis.zip sysdump --help
-
 Symptom Library
 ===============
 
@@ -470,13 +422,26 @@ The script has the following list of prerequisites:
 * Requires ``kubectl``.
 * ``kubectl`` should be pointing to your cluster before running the tool.
 
-You can download the latest version of the cluster-diagnosis.zip file
-using the following command:
+You can download the latest version of the ``cilium-sysdump`` tool using the
+following command:
 
 .. code:: bash
 
-    $ curl -sLO releases.cilium.io/tools/cluster-diagnosis.zip
-    $ python cluster-diagnosis.zip sysdump
+    curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
+    python cilium-sysdump.zip
+
+You can specify from which nodes to collect the system dumps by passing
+node IP addresses via the ``--nodes`` argument:
+
+.. code:: bash
+
+    python cilium-sysdump.zip --nodes=$NODE1_IP,$NODE2_IP2
+
+Use ``--help`` to see more options:
+
+.. code:: bash
+
+    python cilium-sysdump.zip --help
 
 Single Node Bugtool
 ~~~~~~~~~~~~~~~~~~~

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -329,6 +329,9 @@ func init() {
 	flags.Bool(option.EnableAutoDirectRoutingName, defaults.EnableAutoDirectRouting, "Enable automatic L2 routing between nodes")
 	option.BindEnv(option.EnableAutoDirectRoutingName)
 
+	flags.Bool(option.EnableXTSocketFallbackName, defaults.EnableXTSocketFallback, "Enable fallback for missing xt_socket module")
+	option.BindEnv(option.EnableXTSocketFallbackName)
+
 	flags.String(option.EnablePolicy, option.DefaultEnforcement, "Enable policy enforcement")
 	option.BindEnv(option.EnablePolicy)
 

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -254,6 +254,9 @@ data:
   ipvlan-master-device: {{ .Values.global.ipvlan.masterDevice }}
 {{- end }}
 {{- end }}
+{{- if .Values.global.enableXTSocketFallback }}
+  enable-xt-socket-fallback: {{ .Values.global.enableXTSocketFallback | quote }}
+{{- end}}
   install-iptables-rules: {{ .Values.global.installIptablesRules | quote }}
   auto-direct-node-routes: {{ .Values.global.autoDirectNodeRoutes | quote }}
 

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -254,9 +254,7 @@ data:
   ipvlan-master-device: {{ .Values.global.ipvlan.masterDevice }}
 {{- end }}
 {{- end }}
-{{- if .Values.global.enableXTSocketFallback }}
   enable-xt-socket-fallback: {{ .Values.global.enableXTSocketFallback | quote }}
-{{- end}}
   install-iptables-rules: {{ .Values.global.installIptablesRules | quote }}
   auto-direct-node-routes: {{ .Values.global.autoDirectNodeRoutes | quote }}
 

--- a/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
@@ -56,6 +56,18 @@ spec:
                       while crictl ps | grep -v "node-init" | grep -q "POD_cilium"; do sleep 1; done
                     fi
 
+{{- if .Values.azure }}
+                    # Azure specific: Transparent bridge mode is required in
+                    # order for proxy-redirection to work
+                    until [ -f /var/run/azure-vnet.json ]; do
+                      echo waiting for azure-vnet to be created
+                      sleep 1s
+                    done
+                    if [ -f /var/run/azure-vnet.json ]; then
+                      sed -i 's/"Mode": "bridge",/"Mode": "transparent",/g' /var/run/azure-vnet.json
+                    fi
+{{- end }}
+
                     systemctl disable sys-fs-bpf.mount || true
                     systemctl stop sys-fs-bpf.mount || true
 

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -82,6 +82,13 @@ global:
     serviceMonitor:
       enabled: false
 
+  # enableXTSocketFallback enables the fallback compatibility solution
+  # when the xt_socket kernel module is missing and it is needed for
+  # the datapath L7 redirection to work properly.  See documentation
+  # for details on when this can be disabled:
+  # http://docs.cilium.io/en/latest/install/system_requirements/#admin-kernel-version.
+  enableXTSocketFallback: true
+
   # installIptablesRules enables installation of iptables rules to allow for
   # TPROXY (L7 proxy injection), itpables based masquerading and compatibility
   # with kube-proxy. See documentation for details on when this can be

--- a/pkg/allocator/allocator.go
+++ b/pkg/allocator/allocator.go
@@ -367,6 +367,13 @@ func WithoutGC() AllocatorOption {
 	return func(a *Allocator) { a.disableGC = true }
 }
 
+// GetEvents returns the events channel given to the allocator when
+// constructed.
+// Note: This channel is not owned by the allocator!
+func (a *Allocator) GetEvents() AllocatorEventChan {
+	return a.events
+}
+
 // Delete deletes an allocator and stops the garbage collector
 func (a *Allocator) Delete() {
 	close(a.stopGC)

--- a/pkg/bpf/bpf_linux.go
+++ b/pkg/bpf/bpf_linux.go
@@ -305,7 +305,7 @@ func ObjPin(fd int, pathname string) error {
 		uintptr(unsafe.Pointer(&uba)),
 		unsafe.Sizeof(uba),
 	)
-	runtime.KeepAlive(&pathStr)
+	runtime.KeepAlive(pathStr)
 	runtime.KeepAlive(&uba)
 
 	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
@@ -336,7 +336,7 @@ func ObjGet(pathname string) (int, error) {
 		uintptr(unsafe.Pointer(&uba)),
 		unsafe.Sizeof(uba),
 	)
-	runtime.KeepAlive(&pathStr)
+	runtime.KeepAlive(pathStr)
 	runtime.KeepAlive(&uba)
 	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
 		metrics.BPFSyscallDuration.WithLabelValues(metricOpObjGet, metrics.Errno2Outcome(err)).Observe(duration.End(err == 0).Total().Seconds())

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -42,12 +42,14 @@ var (
 )
 
 type linuxNodeHandler struct {
-	mutex          lock.Mutex
-	isInitialized  bool
-	nodeConfig     datapath.LocalNodeConfiguration
-	nodeAddressing datapath.NodeAddressing
-	datapathConfig DatapathConfiguration
-	nodes          map[node.Identity]*node.Node
+	mutex                lock.Mutex
+	isInitialized        bool
+	nodeConfig           datapath.LocalNodeConfiguration
+	nodeAddressing       datapath.NodeAddressing
+	datapathConfig       DatapathConfiguration
+	nodes                map[node.Identity]*node.Node
+	enableNeighDiscovery bool
+	neighByNode          map[node.Identity]*netlink.Neigh
 }
 
 // NewNodeHandler returns a new node handler to handle node events and
@@ -57,6 +59,7 @@ func NewNodeHandler(datapathConfig DatapathConfiguration, nodeAddressing datapat
 		nodeAddressing: nodeAddressing,
 		datapathConfig: datapathConfig,
 		nodes:          map[node.Identity]*node.Node{},
+		neighByNode:    map[node.Identity]*netlink.Neigh{},
 	}
 }
 
@@ -556,7 +559,7 @@ func neighborLog(spec, iface string, err error, ip *net.IP, hwAddr *net.Hardware
 	scopedLog := log.WithFields(logrus.Fields{
 		logfields.Reason: spec,
 		"Interface":      iface,
-		"IP":             ip,
+		logfields.IPAddr: ip,
 		"HardwareAddr":   hwAddr,
 		"LinkIndex":      link,
 	})
@@ -605,8 +608,26 @@ func (n *linuxNodeHandler) insertNeighbor(newNode *node.Node, ifaceName string) 
 		}
 		err := netlink.NeighSet(&neigh)
 		neighborLog("insertNeighbor NeighSet", ifaceName, err, &ciliumIPv4, &hwAddr, link)
+		if err == nil {
+			n.neighByNode[newNode.Identity()] = &neigh
+		}
 	} else {
 		neighborLog("insertNeighbor arping failed", ifaceName, err, &ciliumIPv4, &hwAddr, link)
+	}
+}
+
+func (n *linuxNodeHandler) deleteNeighbor(oldNode *node.Node) {
+	neigh, ok := n.neighByNode[oldNode.Identity()]
+	if !ok {
+		return
+	}
+
+	if err := netlink.NeighDel(neigh); err != nil {
+		log.WithFields(logrus.Fields{
+			logfields.IPAddr: neigh.IP,
+			"HardwareAddr":   neigh.HardwareAddr,
+			"LinkIndex":      neigh.LinkIndex,
+		}).WithError(err).Warn("Failed to remove neighbor entry")
 	}
 }
 
@@ -689,8 +710,7 @@ func (n *linuxNodeHandler) nodeUpdate(oldNode, newNode *node.Node, firstAddition
 		newKey = newNode.EncryptionKey
 	}
 
-	if n.nodeConfig.EnableIPv4 && (option.Config.EnableNodePort ||
-		(n.nodeConfig.EnableIPSec && option.Config.Tunnel == option.TunnelDisabled)) {
+	if n.enableNeighDiscovery {
 		var ifaceName string
 		if option.Config.EnableNodePort {
 			ifaceName = option.Config.Device
@@ -789,6 +809,10 @@ func (n *linuxNodeHandler) nodeDelete(oldNode *node.Node) error {
 			n.deleteNodeRoute(oldNode.IPv4AllocCIDR)
 			n.deleteNodeRoute(oldNode.IPv6AllocCIDR)
 		}
+	}
+
+	if n.enableNeighDiscovery {
+		n.deleteNeighbor(oldNode)
 	}
 
 	if n.nodeConfig.EnableIPSec {
@@ -1087,6 +1111,10 @@ func (n *linuxNodeHandler) NodeConfigurationChanged(newConfig datapath.LocalNode
 
 	prevConfig := n.nodeConfig
 	n.nodeConfig = newConfig
+
+	n.enableNeighDiscovery = n.nodeConfig.EnableIPv4 &&
+		(option.Config.EnableNodePort ||
+			(n.nodeConfig.EnableIPSec && option.Config.Tunnel == option.TunnelDisabled))
 
 	n.updateOrRemoveNodeRoutes(prevConfig.AuxiliaryPrefixes, newConfig.AuxiliaryPrefixes)
 

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -689,8 +689,8 @@ func (n *linuxNodeHandler) nodeUpdate(oldNode, newNode *node.Node, firstAddition
 		newKey = newNode.EncryptionKey
 	}
 
-	if option.Config.EnableNodePort ||
-		(n.nodeConfig.EnableIPSec && option.Config.Tunnel == option.TunnelDisabled) {
+	if n.nodeConfig.EnableIPv4 && (option.Config.EnableNodePort ||
+		(n.nodeConfig.EnableIPSec && option.Config.Tunnel == option.TunnelDisabled)) {
 		var ifaceName string
 		if option.Config.EnableNodePort {
 			ifaceName = option.Config.Device

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -167,6 +167,9 @@ const (
 	// DatapathMode is the default value for the datapath mode.
 	DatapathMode = "veth"
 
+	// EnableXTSocketFallback is the default value for EnableXTSocketFallback
+	EnableXTSocketFallback = true
+
 	// EnableLocalNodeRoute default value for EnableLocalNodeRoute
 	EnableLocalNodeRoute = true
 

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -443,7 +443,7 @@ func (m *CachingIdentityAllocator) WatchRemoteIdentities(backend kvstore.Backend
 		return nil, fmt.Errorf("Error setting up remote allocator backend: %s", err)
 	}
 
-	remoteAlloc, err := allocator.NewAllocator(GlobalIdentity{}, remoteAllocatorBackend)
+	remoteAlloc, err := allocator.NewAllocator(GlobalIdentity{}, remoteAllocatorBackend, allocator.WithEvents(m.IdentityAllocator.GetEvents()))
 	if err != nil {
 		return nil, fmt.Errorf("Unable to initialize remote Identity Allocator: %s", err)
 	}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -510,6 +510,9 @@ const (
 	// PreAllocateMapsName is the name of the option PreAllocateMaps
 	PreAllocateMapsName = "preallocate-bpf-maps"
 
+	// EnableXTSocketFallbackName is the name of the EnableXTSocketFallback option
+	EnableXTSocketFallbackName = "enable-xt-socket-fallback"
+
 	// EnableAutoDirectRoutingName is the name for the EnableAutoDirectRouting option
 	EnableAutoDirectRoutingName = "auto-direct-node-routes"
 
@@ -1147,6 +1150,10 @@ type DaemonConfig struct {
 	// Cilium on all interfaces created by the flannel.
 	FlannelUninstallOnExit bool
 
+	// EnableXTSocketFallback allows disabling of kernel's ip_early_demux
+	// sysctl option if `xt_socket` kernel module is not available.
+	EnableXTSocketFallback bool
+
 	// EnableAutoDirectRouting enables installation of direct routes to
 	// other nodes when available
 	EnableAutoDirectRouting bool
@@ -1684,6 +1691,7 @@ func (c *DaemonConfig) Populate() {
 	c.EnableHostReachableServices = viper.GetBool(EnableHostReachableServices)
 	c.EnableRemoteNodeIdentity = viper.GetBool(EnableRemoteNodeIdentity)
 	c.DockerEndpoint = viper.GetString(Docker)
+	c.EnableXTSocketFallback = viper.GetBool(EnableXTSocketFallbackName)
 	c.EnableAutoDirectRouting = viper.GetBool(EnableAutoDirectRoutingName)
 	c.EnableEndpointRoutes = viper.GetBool(EnableEndpointRoutes)
 	c.EnableHealthChecking = viper.GetBool(EnableHealthChecking)

--- a/test/k8sT/istio.go
+++ b/test/k8sT/istio.go
@@ -120,11 +120,14 @@ var _ = Describe("K8sIstioTest", func() {
 		By("Deleting the Istio CRDs")
 		_ = kubectl.Delete(istioCRDYAMLPath)
 
+		By("Waiting all terminating PODs to disappear")
+		err := kubectl.WaitCleanAllTerminatingPods(teardownTimeout)
+		ExpectWithOffset(1, err).To(BeNil(), "terminating Istio PODs are not deleted after timeout")
+
 		By("Deleting the istio-system namespace")
 		_ = kubectl.NamespaceDelete(istioSystemNamespace)
 
 		kubectl.DeleteCiliumDS()
-		kubectl.WaitCleanAllTerminatingPods(teardownTimeout)
 
 		kubectl.CloseSSHClient()
 	})

--- a/test/provision/bpftool.sh
+++ b/test/provision/bpftool.sh
@@ -6,7 +6,12 @@
 
 set -e
 
-git clone --depth 1 -b bpftool https://github.com/cilium/linux.git $HOME/k-bpftool
+if [ -d "$HOME/k-bpftool" ]; then
+    cd $HOME/k-bpftool
+    git pull origin bpftool
+else
+    git clone --depth 1 -b bpftool https://github.com/cilium/linux.git $HOME/k-bpftool
+fi
 cd $HOME/k-bpftool/tools/bpf/bpftool
 make
 sudo make install


### PR DESCRIPTION
* #10288 -- pkg/bpf: Fix KeepAlive usage for pathStr (@brb)
 * #10301 -- test/provision: Fix cilium.provision on running VM (@pchaigno)
 * #10165 -- doc: Adjust documentation to renamed cilium-sysdump tool (@tgraf)
 * #10319 -- docs: Drop k8s 1.10 from supported/tested versions (@jrajahalme)
 * #10325 -- test: Wait for Istio POD termination before deleting istio-system or cilium (@jrajahalme)
 * #10315 -- doc: Add helm version requirements updated install URL to GKE install guide (@CybrPunk)
 * #10308 -- doc: Fix AKS guide regression (@tgraf)
 * #10290 -- clustermesh: Emit identity-change events for remote clusters (@raybejjani)
 * #10299 -- iptables: Add a fallback to missing xt_socket module. (@jrajahalme)
 * #10227 -- node: Remove permanent ARP entry when remote node is deleted (@brb)
 * #10342 -- helm: Allow disabling xt_socket fallback (@brb)
 * #10321 -- docs: Mention that a kv-store is optional with k8s. (@jrajahalme)

Clean backport (no changes necessary)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 10288 10301 10165 10319 10325 10315 10308 10290 10299 10227 10342 10321; do contrib/backporting/set-labels.py $pr done 1.7; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10354)
<!-- Reviewable:end -->
