### PR TITLE
install: Add resources into helm templates

### DIFF
--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -404,6 +404,8 @@ spec:
             exec:
               command:
               - /cni-uninstall.sh
+        resources:
+          {}
         name: cilium-agent
         securityContext:
           capabilities:
@@ -469,6 +471,10 @@ spec:
           mountPropagation: HostToContainer
         - mountPath: /var/run/cilium
           name: cilium-run
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
       restartPolicy: Always
       priorityClassName: system-node-critical
       serviceAccount: cilium
@@ -643,6 +649,8 @@ spec:
           initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 3
+        resources:
+          {}
       hostNetwork: true
       restartPolicy: Always
       serviceAccount: cilium-operator


### PR DESCRIPTION
Recent changes neglected to run `make -C install/kubernetes` so some files were out of date. Compared to #10356, these changes are not being backported.

Fixes: e075f8c5b206 ("Make resources in agent and operator helm chart configurable")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10357)
<!-- Reviewable:end -->
