### PR TITLE
v1.6 backports 2020-02-27

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_template.md
@@ -34,8 +34,8 @@ security@cilium.io - first, before disclosing them in any public forums.
 - Orchestration system version in use (e.g. `kubectl version`, Mesos, ...)
 - Link to relevant artifacts (policies, deployments scripts, ...)
 - Upload a system dump (run `curl -sLO
-releases.cilium.io/tools/cluster-diagnosis.zip &&
-python cluster-diagnosis.zip sysdump` and then attach the generated zip file)
+https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip &&
+python cilium-sysdump.zip` and then attach the generated zip file)
 
 **How to reproduce the issue**
 

--- a/.github/cilium-actions.yml
+++ b/.github/cilium-actions.yml
@@ -5,7 +5,7 @@ auto-label:
   - "backport/1.6"
 require-msgs-in-commit:
   - msg: "Signed-off-by"
-    helper: "https://docs.cilium.io/en/stable/contributing/contributing/#developer-s-certificate-of-origin"
+    helper: "https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#developer-s-certificate-of-origin"
     set-labels:
       - "dont-merge/needs-sign-off"
 block-pr-with:

--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -65,6 +65,7 @@ cilium-agent [flags]
       --enable-node-port                                      Enable NodePort type services by Cilium (beta)
       --enable-policy string                                  Enable policy enforcement (default "default")
       --enable-tracing                                        Enable tracing while determining policy (debugging)
+      --enable-xt-socket-fallback                             Enable fallback for missing xt_socket module (default true)
       --encrypt-interface string                              Transparent encryption interface
       --encrypt-node                                          Enables encrypting traffic from non-Cilium pods and host networking
       --endpoint-interface-name-prefix string                 Prefix of interface name shared by all endpoints (default "lxc+")

--- a/Documentation/install/system_requirements.rst
+++ b/Documentation/install/system_requirements.rst
@@ -79,7 +79,7 @@ Linux Kernel
 
 Cilium leverages and builds on the kernel BPF functionality as well as various
 subsystems which integrate with BPF. Therefore, host systems are required to
-run Linux kernel version 4.8.0 or later to run a Cilium agent. More recent
+run Linux kernel version 4.9.17 or later to run a Cilium agent. More recent
 kernels may provide additional BPF functionality that Cilium will automatically
 detect and use on agent start.
 
@@ -103,6 +103,35 @@ linked, either choice is valid.
 
    Users running Linux 4.10 or earlier with Cilium CIDR policies may face
    :ref:`cidr_limitations`.
+
+L7 proxy redirection currently uses ``TPROXY`` iptables actions as well
+as ``socket`` matches. For L7 redirection to work as intended kernel
+configuration must include the following modules:
+
+.. code:: bash
+
+        CONFIG_NETFILTER_XT_TARGET_TPROXY=m
+        CONFIG_NETFILTER_XT_MATCH_MARK=m
+        CONFIG_NETFILTER_XT_MATCH_SOCKET=m
+
+When ``xt_socket`` kernel module is missing the forwarding of
+redirected L7 traffic does not work in non-tunneled datapath
+modes. Since some notable kernels (e.g., COS) are shipping without
+``xt_socket`` module, Cilium implements a fallback compatibility mode
+to allow L7 policies and visibility to be used with those
+kernels. Currently this fallback disables ``ip_early_demux`` kernel
+feature in non-tunneled datapath modes, which may decrease system
+networking performance. This guarantees HTTP and Kafka redirection
+works as intended.  However, if HTTP or Kafka enforcement policies or
+visibility annotations are never used, this behavior can be turned off
+by adding the following to the helm configuration command line:
+
+.. parsed-literal::
+
+   helm template cilium \
+     ...
+     --set global.enableXTSocketFallback=false
+   > cilium.yaml
 
 .. _req_kvstore:
 

--- a/Documentation/troubleshooting.rst
+++ b/Documentation/troubleshooting.rst
@@ -291,54 +291,6 @@ Opening the ``status``, we can drill down through ``policy.realized.l4``. Do you
 ``ingress`` and ``egress`` rules match what you expect? If not, the reference to the errant
 rules can be found in the ``derived-from-rules`` node.
 
-Automatic Diagnosis
-===================
-
-The ``cluster-diagnosis`` tool can help identify the most commonly encountered
-issues in Cilium deployments. The tool currently supports Kubernetes
-and Minikube clusters only.
-
-The tool performs various checks and provides hints to fix specific
-issues that it has identified.
-
-The following is a list of prerequisites:
-
-* Requires Python >= 2.7.*
-* Requires ``kubectl``.
-* ``kubectl`` should be pointing to your cluster before running the tool.
-
-You can download the latest version of the cluster-diagnosis.zip file
-using the following command:
-
-::
-
-    curl -sLO releases.cilium.io/tools/cluster-diagnosis.zip
-
-Command to run the cluster-diagnosis tool:
-
-.. code:: bash
-
-    python cluster-diagnosis.zip
-
-Command to collect the system dump using the cluster-diagnosis tool:
-
-.. code:: bash
-
-    python cluster-diagnosis.zip sysdump
-
-You can specify from which nodes to collect the system dumps by passing
-node IP addresses via the ``--nodes`` argument:
-
-.. code:: bash
-
-    python cluster-diagnosis.zip sysdump --nodes=$NODE1_IP,$NODE2_IP2
-
-Use ``--help`` to see more options:
-
-.. code:: bash
-
-    python cluster-diagnosis.zip sysdump --help
-
 Symptom Library
 ===============
 
@@ -468,13 +420,26 @@ The script has the following list of prerequisites:
 * Requires ``kubectl``.
 * ``kubectl`` should be pointing to your cluster before running the tool.
 
-You can download the latest version of the cluster-diagnosis.zip file
-using the following command:
+You can download the latest version of the ``cilium-sysdump`` tool using the
+following command:
 
 .. code:: bash
 
-    $ curl -sLO releases.cilium.io/tools/cluster-diagnosis.zip
-    $ python cluster-diagnosis.zip sysdump
+    curl -sLO https://github.com/cilium/cilium-sysdump/releases/latest/download/cilium-sysdump.zip
+    python cilium-sysdump.zip
+
+You can specify from which nodes to collect the system dumps by passing
+node IP addresses via the ``--nodes`` argument:
+
+.. code:: bash
+
+    python cilium-sysdump.zip --nodes=$NODE1_IP,$NODE2_IP2
+
+Use ``--help`` to see more options:
+
+.. code:: bash
+
+    python cilium-sysdump.zip --help
 
 Single Node Bugtool
 ~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -281,7 +281,7 @@ under the `General Public License, Version 2.0 <bpf/COPYING>`_.
 .. _`Architecture and Concepts`: http://docs.cilium.io/en/stable/concepts/
 .. _`Installing Cilium`: http://docs.cilium.io/en/stable/gettingstarted/#installation
 .. _`Frequently Asked Questions`: https://github.com/cilium/cilium/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3Akind%2Fquestion+
-.. _Contributing: http://docs.cilium.io/en/stable/contributing
+.. _Contributing: http://docs.cilium.io/en/stable/contributing/development/
 .. _Prerequisites: http://docs.cilium.io/en/doc-1.0/install/system_requirements
 .. _`BPF and XDP Reference Guide`: http://docs.cilium.io/en/stable/bpf/
 

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -505,6 +505,9 @@ func init() {
 	flags.Bool(option.EnableAutoDirectRoutingName, defaults.EnableAutoDirectRouting, "Enable automatic L2 routing between nodes")
 	option.BindEnv(option.EnableAutoDirectRoutingName)
 
+	flags.Bool(option.EnableXTSocketFallbackName, defaults.EnableXTSocketFallback, "Enable fallback for missing xt_socket module")
+	option.BindEnv(option.EnableXTSocketFallbackName)
+
 	flags.String(option.EnablePolicy, option.DefaultEnforcement, "Enable policy enforcement")
 	option.BindEnv(option.EnablePolicy)
 

--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -9,7 +9,8 @@ CILIUM_CHARTS := "$(ROOT_DIR)/$(RELATIVE_DIR)/cilium/"
 CILIUM_VALUES := "$(CILIUM_CHARTS)/values.yaml"
 
 VERSION_REGEX := '[0-9]\+\.[0-9]\+\.[0-9]\+.*'
-DEV_VERSION_REGEX := '[0-9]\+\.[0-9]\+\.90'
+LATEST_VERSION_REGEX := '[0-9]\+\.[0-9]\+\.90'
+DEV_VERSION_REGEX := '[0-9]\+\.[0-9]\+\.[0-9]\+-dev'
 CILIUM_CHART_REGEX := '\([vV]ersion:\) '$(VERSION_REGEX)
 CILIUM_TAG_REGEX := '\(tag:\) \(v'$(VERSION_REGEX)'\|latest\)'
 CILIUM_PULLPOLICY_REGEX := '\(pullPolicy:\) .*'
@@ -25,12 +26,16 @@ update-versions:
 	$(QUIET)grep -lRZ -e "version:" -e "appVersion:" $(CILIUM_CHARTS) | \
 		xargs -0 -l sed -i -e 's/'$(CILIUM_CHART_REGEX)'/\1 $(VERSION)/g'
 	@# Fix up the cilium tag
-	$(QUIET)if echo $(VERSION) | grep -q $(DEV_VERSION_REGEX); then \
-			sed -i 's/'$(CILIUM_TAG_REGEX)'/\1 latest/' $(CILIUM_VALUES); \
-			sed -i 's/'$(CILIUM_PULLPOLICY_REGEX)'/\1 Always/' $(CILIUM_VALUES); \
-		else \
-			sed -i 's/'$(CILIUM_TAG_REGEX)'/\1 v$(VERSION)/' $(CILIUM_VALUES); \
-			sed -i 's/'$(CILIUM_PULLPOLICY_REGEX)'/\1 IfNotPresent/' $(CILIUM_VALUES); \
+	$(QUIET)if echo $(VERSION) | grep -q $(LATEST_VERSION_REGEX); then				\
+			sed -i 's/'$(CILIUM_TAG_REGEX)'/\1 latest/' $(CILIUM_VALUES);			\
+			sed -i 's/'$(CILIUM_PULLPOLICY_REGEX)'/\1 Always/' $(CILIUM_VALUES);		\
+		elif echo $(VERSION) | grep -q $(DEV_VERSION_REGEX); then				\
+			DEV_BRANCH=$$(echo $(VERSION) | sed 's/-dev//')					\
+			sed -i 's/'$(CILIUM_TAG_REGEX)'/\1 $(DEV_BRANCH)/' $(CILIUM_VALUES);		\
+			sed -i 's/'$(CILIUM_PULLPOLICY_REGEX)'/\1 Always/' $(CILIUM_VALUES);		\
+		else											\
+			sed -i 's/'$(CILIUM_TAG_REGEX)'/\1 v$(VERSION)/' $(CILIUM_VALUES);		\
+			sed -i 's/'$(CILIUM_PULLPOLICY_REGEX)'/\1 IfNotPresent/' $(CILIUM_VALUES);	\
 		fi
 	@# Fix up the managed etcd version, as that has its own scheme
 	$(QUIET)sed -i 's/'$(VERSION)'/'$(MANAGED_ETCD_VERSION)'/' $(MANAGED_ETCD_PATH)

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -273,6 +273,9 @@ data:
 {{- end }}
 {{- end }}
 
+{{- if .Values.global.enableXTSocketFallback }}
+  enable-xt-socket-fallback: {{ .Values.global.enableXTSocketFallback | quote }}
+{{- end}}
   install-iptables-rules: {{ .Values.global.installIptablesRules | quote }}
   auto-direct-node-routes: {{ .Values.global.autoDirectNodeRoutes | quote }}
 {{- if .Values.global.nodePort }}

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -273,9 +273,7 @@ data:
 {{- end }}
 {{- end }}
 
-{{- if .Values.global.enableXTSocketFallback }}
   enable-xt-socket-fallback: {{ .Values.global.enableXTSocketFallback | quote }}
-{{- end}}
   install-iptables-rules: {{ .Values.global.installIptablesRules | quote }}
   auto-direct-node-routes: {{ .Values.global.autoDirectNodeRoutes | quote }}
 {{- if .Values.global.nodePort }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -79,6 +79,13 @@ global:
     serviceMonitor:
       enabled: false
 
+  # enableXTSocketFallback enables the fallback compatibility solution
+  # when the xt_socket kernel module is missing and it is needed for
+  # the datapath L7 redirection to work properly.  See documentation
+  # for details on when this can be disabled:
+  # http://docs.cilium.io/en/latest/install/system_requirements/#admin-kernel-version.
+  enableXTSocketFallback: true
+
   # installIptablesRules enables installation of iptables rules to allow for
   # TPROXY (L7 proxy injection), itpables based masquerading and compatibility
   # with kube-proxy. See documentation for details on when this can be

--- a/pkg/allocator/allocator.go
+++ b/pkg/allocator/allocator.go
@@ -367,6 +367,13 @@ func WithoutGC() AllocatorOption {
 	return func(a *Allocator) { a.disableGC = true }
 }
 
+// GetEvents returns the events channel given to the allocator when
+// constructed.
+// Note: This channel is not owned by the allocator!
+func (a *Allocator) GetEvents() AllocatorEventChan {
+	return a.events
+}
+
 // Delete deletes an allocator and stops the garbage collector
 func (a *Allocator) Delete() {
 	close(a.stopGC)

--- a/pkg/bpf/bpf_linux.go
+++ b/pkg/bpf/bpf_linux.go
@@ -297,7 +297,7 @@ func ObjPin(fd int, pathname string) error {
 		uintptr(unsafe.Pointer(&uba)),
 		unsafe.Sizeof(uba),
 	)
-	runtime.KeepAlive(&pathStr)
+	runtime.KeepAlive(pathStr)
 	runtime.KeepAlive(&uba)
 
 	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
@@ -328,7 +328,7 @@ func ObjGet(pathname string) (int, error) {
 		uintptr(unsafe.Pointer(&uba)),
 		unsafe.Sizeof(uba),
 	)
-	runtime.KeepAlive(&pathStr)
+	runtime.KeepAlive(pathStr)
 	runtime.KeepAlive(&uba)
 	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {
 		metrics.BPFSyscallDuration.WithLabelValues(metricOpObjGet, metrics.Errno2Outcome(err)).Observe(duration.End(err == 0).Total().Seconds())

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cilium/cilium/pkg/modules"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/sysctl"
 	"github.com/cilium/cilium/pkg/versioncheck"
 
 	go_version "github.com/hashicorp/go-version"
@@ -322,9 +323,10 @@ var transientChain = customChain{
 
 // IptablesManager manages the iptables-related configuration for Cilium.
 type IptablesManager struct {
-	haveIp6tables   bool
-	haveSocketMatch bool
-	waitArgs        []string
+	haveIp6tables        bool
+	haveSocketMatch      bool
+	ipEarlyDemuxDisabled bool
+	waitArgs             []string
 }
 
 // Init initializes the iptables manager and checks for iptables kernel modules
@@ -355,9 +357,40 @@ func (m *IptablesManager) Init() {
 	m.haveIp6tables = ip6tables
 
 	if err := modulesManager.FindOrLoadModules("xt_socket"); err != nil {
-		log.WithError(err).Warning("xt_socket kernel module could not be loaded")
 		if option.Config.Tunnel == option.TunnelDisabled {
-			log.Warning("Traffic to endpoints with L7 ingress policy may be dropped unexpectedly")
+			// xt_socket module is needed to circumvent an explicit drop in ip_forward()
+			// logic for packets for which a local socket is found by ip early
+			// demux. xt_socket performs a local socket match and sets an skb mark on
+			// match, which will divert the packet to the local stack using our policy
+			// routing rule, thus avoiding being processed by ip_forward() at all.
+			//
+			// If xt_socket module does not exist we can disable ip early demux to to
+			// avoid the explicit drop in ip_forward(). This is not needed in tunneling
+			// modes, as then we'll set the skb mark in the bpf logic before the policy
+			// routing stage so that the packet is routed locally instead of being
+			// forwarded by ip_forward().
+			//
+			// We would not need the xt_socket at all if the datapath universally would
+			// set the "to proxy" skb mark bits on before the packet hits policy routing
+			// stage. Currently this is not true for endpoint routing modes.
+			log.WithError(err).Warning("xt_socket kernel module could not be loaded")
+
+			if option.Config.EnableXTSocketFallback {
+				v4disabled := true
+				v6disabled := true
+				if option.Config.EnableIPv4 {
+					v4disabled = sysctl.Disable("net.ipv4.ip_early_demux") == nil
+				}
+				if option.Config.EnableIPv6 {
+					v6disabled = sysctl.Disable("net.ipv6.ip_early_demux") == nil
+				}
+				if v4disabled && v6disabled {
+					m.ipEarlyDemuxDisabled = true
+					log.Warning("Disabled ip_early_demux to allow proxy redirection with original source/destination address without xt_socket support also in non-tunneled datapath modes.")
+				} else {
+					log.WithError(err).Warning("Could not disable ip_early_demux, traffic redirected due to an HTTP policy or visibility may be dropped unexpectedly")
+				}
+			}
 		}
 	} else {
 		m.haveSocketMatch = true
@@ -374,8 +407,13 @@ func (m *IptablesManager) Init() {
 	}
 }
 
+// SupportsOriginalSourceAddr tells if an L7 proxy can use POD's original source address and port in
+// the upstream connection to allow the destination to properly derive the source security ID from
+// the source IP address.
 func (m *IptablesManager) SupportsOriginalSourceAddr() bool {
-	return m.haveSocketMatch
+	// Original source address use works if xt_socket match is supported, or if ip early demux
+	// is disabled, or if the datapath is in a tunneling mode.
+	return m.haveSocketMatch || m.ipEarlyDemuxDisabled || option.Config.Tunnel != option.TunnelDisabled
 }
 
 // RemoveRules removes iptables rules installed by Cilium.

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -689,8 +689,8 @@ func (n *linuxNodeHandler) nodeUpdate(oldNode, newNode *node.Node, firstAddition
 		newKey = newNode.EncryptionKey
 	}
 
-	if option.Config.EnableNodePort ||
-		(n.nodeConfig.EnableIPSec && option.Config.Tunnel == option.TunnelDisabled) {
+	if n.nodeConfig.EnableIPv4 && (option.Config.EnableNodePort ||
+		(n.nodeConfig.EnableIPSec && option.Config.Tunnel == option.TunnelDisabled)) {
 		var ifaceName string
 		if option.Config.EnableNodePort {
 			ifaceName = option.Config.Device

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -162,6 +162,9 @@ const (
 	// DatapathMode is the default value for the datapath mode.
 	DatapathMode = "veth"
 
+	// EnableXTSocketFallback is the default value for EnableXTSocketFallback
+	EnableXTSocketFallback = true
+
 	// EnableAutoDirectRouting is the default value for EnableAutoDirectRouting
 	EnableAutoDirectRouting = false
 

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -401,7 +401,7 @@ func WatchRemoteIdentities(backend kvstore.BackendOperations) (*allocator.Remote
 		return nil, fmt.Errorf("Error setting up remote allocator backend: %s", err)
 	}
 
-	remoteAlloc, err := allocator.NewAllocator(GlobalIdentity{}, remoteAllocatorBackend)
+	remoteAlloc, err := allocator.NewAllocator(GlobalIdentity{}, remoteAllocatorBackend, allocator.WithEvents(IdentityAllocator.GetEvents()))
 	if err != nil {
 		return nil, fmt.Errorf("Unable to initialize remote Identity Allocator: %s", err)
 	}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -476,6 +476,9 @@ const (
 	// PreAllocateMapsName is the name of the option PreAllocateMaps
 	PreAllocateMapsName = "preallocate-bpf-maps"
 
+	// EnableXTSocketFallbackName is the name of the EnableXTSocketFallback option
+	EnableXTSocketFallbackName = "enable-xt-socket-fallback"
+
 	// EnableAutoDirectRoutingName is the name for the EnableAutoDirectRouting option
 	EnableAutoDirectRoutingName = "auto-direct-node-routes"
 
@@ -1073,6 +1076,10 @@ type DaemonConfig struct {
 	// Cilium to be running in the hostPID.
 	FlannelManageExistingContainers bool
 
+	// EnableXTSocketFallback allows disabling of kernel's ip_early_demux
+	// sysctl option if `xt_socket` kernel module is not available.
+	EnableXTSocketFallback bool
+
 	// EnableAutoDirectRouting enables installation of direct routes to
 	// other nodes when available
 	EnableAutoDirectRouting bool
@@ -1581,6 +1588,7 @@ func (c *DaemonConfig) Populate() {
 	c.EgressMasqueradeInterfaces = viper.GetString(EgressMasqueradeInterfaces)
 	c.EnableHostReachableServices = viper.GetBool(EnableHostReachableServices)
 	c.DockerEndpoint = viper.GetString(Docker)
+	c.EnableXTSocketFallback = viper.GetBool(EnableXTSocketFallbackName)
 	c.EnableAutoDirectRouting = viper.GetBool(EnableAutoDirectRoutingName)
 	c.EnableEndpointRoutes = viper.GetBool(EnableEndpointRoutes)
 	c.EnableHealthChecking = viper.GetBool(EnableHealthChecking)

--- a/test/k8sT/istio.go
+++ b/test/k8sT/istio.go
@@ -114,10 +114,12 @@ var _ = Describe("K8sIstioTest", func() {
 		By("Deleting the Istio CRDs")
 		_ = kubectl.Delete(istioCRDYAMLPath)
 
+		By("Waiting all terminating PODs to disappear")
+		err := kubectl.WaitCleanAllTerminatingPods(teardownTimeout)
+		ExpectWithOffset(1, err).To(BeNil(), "terminating Istio PODs are not deleted after timeout")
+
 		By("Deleting the istio-system namespace")
 		_ = kubectl.NamespaceDelete(istioSystemNamespace)
-
-		kubectl.WaitCleanAllTerminatingPods(teardownTimeout)
 
 		kubectl.CloseSSHClient()
 	})


### PR DESCRIPTION
v1.6 backports 2020-02-27

 * #10288 -- pkg/bpf: Fix KeepAlive usage for pathStr (@brb)
 * #10165 -- doc: Adjust documentation to renamed cilium-sysdump tool (@tgraf)
 * #10325 -- test: Wait for Istio POD termination before deleting istio-system or cilium (@jrajahalme)
 * #10299 -- iptables: Add a fallback to missing xt_socket module. (@jrajahalme)
 * #10227 -- node: Remove permanent ARP entry when remote node is deleted (@brb)
 * #10342 -- helm: Allow disabling xt_socket fallback (@brb)
 * #10322 -- doc: Fix links to contributing guide  (@CybrPunk)
 * #10355 -- install: Support generating vX.Y-dev charts (@joestringer)
 * #10290 -- clustermesh: Emit identity-change events for remote clusters (@raybejjani)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 10288 10165 10325 10299 10227 10342 10322 10355; do contrib/backporting/set-labels.py $pr done 1.6; done
```

- ~@jrfastab: Judging from https://github.com/cilium/cilium/pull/10291#discussion_r383680560, will you backport #10218 and #10268 manually by youself?~ (yes, John will backport).
- @jrajahalme: There were merge conflicts for #10325 and #10299. Please double-check whether I've resolved them correctly.
- @tgraf: I couldn't backport #10308, as it depends on #9757 which was not backported to v1.6.
- ~@raybejjani: I had to drop #10290, because `WatchRemoteIdentities` was converted into method only in v1.7 (https://github.com/cilium/cilium/pull/9066), and your change requires it to be a method.~ (resolved).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10361)
<!-- Reviewable:end -->
