### PR TITLE
fqdn: DNS proxy compresses DNS responses

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -150,6 +150,7 @@ cilium-agent [flags]
       --sockops-enable                                        Enable sockops when kernel supported
       --state-dir string                                      Directory path to store runtime state (default "/var/run/cilium")
       --tofqdns-dns-reject-response-code string               DNS response code for rejecting DNS requests, available options are '[nameError refused]' (default "refused")
+      --tofqdns-enable-dns-compression                        Allow the DNS proxy to compress responses to endpoints that are larger than 512 Bytes or the EDNS0 option, if present (default true)
       --tofqdns-enable-poller                                 Enable proactive polling of DNS names in toFQDNs.matchName rules.
       --tofqdns-enable-poller-events                          Emit DNS responses seen by the DNS poller as Monitor events, if the poller is enabled. (default true)
       --tofqdns-endpoint-max-ip-per-hostname int              Maximum number of IPs to maintain per FQDN name for each endpoint (default 50)

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -702,6 +702,9 @@ func init() {
 	flags.String(option.ToFQDNsPreCache, defaults.ToFQDNsPreCache, "DNS cache data at this path is preloaded on agent startup")
 	option.BindEnv(option.ToFQDNsPreCache)
 
+	flags.Bool(option.ToFQDNsEnableDNSCompression, defaults.ToFQDNsEnableDNSCompression, "Allow the DNS proxy to compress responses to endpoints that are larger than 512 Bytes or the EDNS0 option, if present")
+	option.BindEnv(option.ToFQDNsEnableDNSCompression)
+
 	flags.Int(option.PolicyQueueSize, defaults.PolicyQueueSize, "size of queues for policy-related events")
 	option.BindEnv(option.PolicyQueueSize)
 

--- a/daemon/fqdn.go
+++ b/daemon/fqdn.go
@@ -301,7 +301,7 @@ func (d *Daemon) bootstrapFQDN(restoredEndpoints *endpointRestoreState, preCache
 	if err != nil {
 		return err
 	}
-	proxy.DefaultDNSProxy, err = dnsproxy.StartDNSProxy("", port, d.lookupEPByIP, d.lookupSecIDByIP, d.notifyOnDNSMsg)
+	proxy.DefaultDNSProxy, err = dnsproxy.StartDNSProxy("", port, option.Config.ToFQDNsEnableDNSCompression, d.lookupEPByIP, d.lookupSecIDByIP, d.notifyOnDNSMsg)
 	if err == nil {
 		// Increase the ProxyPort reference count so that it will never get released.
 		err = d.l7Proxy.SetProxyPort(listenerName, proxy.DefaultDNSProxy.BindPort)

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -105,6 +105,10 @@ const (
 	// The file is not re-read after agent start.
 	ToFQDNsPreCache = ""
 
+	// ToFQDNsEnableDNSCompression allows the DNS proxy to compress responses to
+	// endpoints that are larger than 512 Bytes or the EDNS0 option, if present.
+	ToFQDNsEnableDNSCompression = true
+
 	// IdentityChangeGracePeriod is the default value for
 	// option.IdentityChangeGracePeriod
 	IdentityChangeGracePeriod = 5 * time.Second

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -173,7 +173,7 @@ func (s *DNSProxyTestSuite) SetUpSuite(c *C) {
 	s.dnsServer = setupServer(c)
 	c.Assert(s.dnsServer, Not(IsNil), Commentf("unable to setup DNS server"))
 
-	proxy, err := StartDNSProxy("", 0,
+	proxy, err := StartDNSProxy("", 0, true, // any address, any port, enable compression
 		// LookupEPByIP
 		func(ip net.IP) (*endpoint.Endpoint, error) {
 			return endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &allocator.FakeIdentityAllocator{}, uint16(epID1), endpoint.StateReady), nil

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -413,6 +413,10 @@ const (
 	// The file is not re-read after agent start.
 	ToFQDNsPreCache = "tofqdns-pre-cache"
 
+	// ToFQDNsEnableDNSCompression allows the DNS proxy to compress responses to
+	// endpoints that are larger than 512 Bytes or the EDNS0 option, if present.
+	ToFQDNsEnableDNSCompression = "tofqdns-enable-dns-compression"
+
 	// UnmanagedPodWatcherInterval is the interval to check for unmanaged kube-dns pods (0 to disable)
 	UnmanagedPodWatcherInterval = "unmanaged-pod-watcher-interval"
 
@@ -1213,6 +1217,10 @@ type DaemonConfig struct {
 	// Path to a file with DNS cache data to preload on startup
 	ToFQDNsPreCache string
 
+	// ToFQDNsEnableDNSCompression allows the DNS proxy to compress responses to
+	// endpoints that are larger than 512 Bytes or the EDNS0 option, if present.
+	ToFQDNsEnableDNSCompression bool
+
 	// HostDevice will be device used by Cilium to connect to the outside world.
 	HostDevice string
 
@@ -1979,6 +1987,7 @@ func (c *DaemonConfig) Populate() {
 	}
 	c.ToFQDNsProxyPort = viper.GetInt(ToFQDNsProxyPort)
 	c.ToFQDNsPreCache = viper.GetString(ToFQDNsPreCache)
+	c.ToFQDNsEnableDNSCompression = viper.GetBool(ToFQDNsEnableDNSCompression)
 
 	// Convert IP strings into net.IPNet types
 	subnets, invalid := ip.ParseCIDRs(viper.GetStringSlice(IPv4PodSubnets))


### PR DESCRIPTION
DNS allows compression and can make responses considerably smaller. This
has not been enabled by default in the proxy but should be safe to use
as it is a requirement for all clients in the original DNS RFCs.
Since the proxy re-seraializes responses it can remove compression when
the original response used it and retransmit responses larger than the
client expects. It now compresses messages that would go over the
original 512 Byte limit, or the EDNS0 option indicating acceptable
response size, if present. A CLI option is present to force disable this
behaviour if needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10366)
<!-- Reviewable:end -->
