### PR TITLE
daemon: Make build depend on Makefiles and Dockerfile

### DIFF
--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -4,7 +4,7 @@ include ../Makefile.defs
 TARGET=cilium-agent
 LINKS=cilium-node-monitor
 SOURCES := $(shell find ../api ../common ../daemon ../pkg . \( -name '*.go'  ! -name '*_test.go' \))
-$(TARGET): $(SOURCES)
+$(TARGET): $(SOURCES) ../Dockerfile ../Makefile ../Makefile.defs Makefile
 	@$(ECHO_GO)
 	$(QUIET) CGO_ENABLED=0 $(GO) build $(GOBUILD) -o $(TARGET)
 


### PR DESCRIPTION
Re-build may be needed due to changes in Makefiles or the Dockerfile.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10367)
<!-- Reviewable:end -->
