### PR TITLE
Do not listen on any port by default for cilium-operator

### DIFF
--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -15,7 +15,6 @@ cilium-operator [flags]
 ### Options
 
 ```
-      --api-server-port uint16                  Port on which the operator should serve API requests (default 9234)
       --aws-client-burst int                    Burst value allowed for the AWS client used by the AWS ENI IPAM (default 4)
       --aws-client-qps float                    Queries per second limit for the AWS client used by the AWS ENI IPAM (default 20)
       --aws-instance-limit-mapping map          Add or overwrite mappings of AWS instance limit in the form of {"AWS instance type": "Maximum Network Interfaces","IPv4 Addresses per Interface","IPv6 Addresses per Interface"}. cli example: --aws-instance-limit-mapping=a1.medium=2,4,4 --aws-instance-limit-mapping=a2.somecustomflavor=4,5,6 configmap example: {"a1.medium": "2,4,4", "a2.somecustomflavor": "4,5,6"} (default map[])
@@ -45,6 +44,7 @@ cilium-operator [flags]
       --kvstore string                          Key-value store type
       --kvstore-opt map                         Key-value store options (default map[])
       --nodes-gc-interval duration              GC interval for nodes store in the kvstore (default 2m0s)
+      --operator-api-serve-addr string          Address to serve API requests (default "localhost:9234")
       --operator-prometheus-serve-addr string   Address to serve Prometheus metrics (default ":6942")
       --synchronize-k8s-nodes                   Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)
       --synchronize-k8s-services                Synchronize Kubernetes services to kvstore (default true)

--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -347,6 +347,11 @@ Deprecated cilium-operator options
   endpoint GC can be done with ``cilium-endpoint-gc-interval=0``.
   This old option will be removed in Cilium 1.9
 
+* ``api-server-port``: This option is being deprecated. The API Server address
+  and port can be enabled with ``operator-api-serve-addr=127.0.0.1:9234``
+  or ``operator-api-serve-addr=[::1]:9234`` for IPv6-only clusters.
+  This old option will be removed in Cilium 1.9
+
 Removed options
 ~~~~~~~~~~~~~~~
 

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -325,3 +325,9 @@ data:
   enable-remote-node-identity: {{ .Values.global.remoteNodeIdentity | quote }}
 
   synchronize-k8s-nodes: {{ .Values.global.synchronizeK8sNodes | quote }}
+
+{{- if .Values.global.ipv4.enabled }}
+  operator-api-serve-addr: '127.0.0.1:9234'
+{{- else }}
+  operator-api-serve-addr: '[::1]:9234'
+{{- end }}

--- a/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
@@ -93,6 +93,11 @@ spec:
 {{- end }}
         livenessProbe:
           httpGet:
+{{- if .Values.global.ipv4.enabled }}
+            host: '127.0.0.1'
+{{- else }}
+            host: '[::1]'
+{{- end }}
             path: /healthz
             port: 9234
             scheme: HTTP

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -1,4 +1,18 @@
 ---
+# Source: cilium/charts/agent/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cilium
+  namespace: kube-system
+---
+# Source: cilium/charts/operator/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+---
 # Source: cilium/charts/config/templates/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -129,20 +143,7 @@ data:
   enable-remote-node-identity: "true"
 
   synchronize-k8s-nodes: "true"
----
-# Source: cilium/charts/agent/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: cilium
-  namespace: kube-system
----
-# Source: cilium/charts/operator/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: cilium-operator
-  namespace: kube-system
+  operator-api-serve-addr: '127.0.0.1:9234'
 ---
 # Source: cilium/charts/agent/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -603,6 +604,7 @@ spec:
         name: cilium-operator
         livenessProbe:
           httpGet:
+            host: '127.0.0.1'
             path: /healthz
             port: 9234
             scheme: HTTP

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -154,6 +154,9 @@ func init() {
 	flags.String(option.OperatorPrometheusServeAddr, ":6942", "Address to serve Prometheus metrics")
 	option.BindEnv(option.OperatorPrometheusServeAddr)
 
+	flags.String(option.OperatorAPIServeAddr, "localhost:9234", "Address to serve API requests")
+	option.BindEnv(option.OperatorAPIServeAddr)
+
 	flags.Bool(option.SyncK8sServices, true, "Synchronize Kubernetes services to kvstore")
 	option.BindEnv(option.SyncK8sServices)
 
@@ -166,8 +169,9 @@ func init() {
 	flags.Bool(option.Version, false, "Print version information")
 	option.BindEnv(option.Version)
 
-	// TODO: Urgent fix
+	// Deprecated, remove in 1.9
 	flags.Uint16Var(&apiServerPort, "api-server-port", 9234, "Port on which the operator should serve API requests")
+	flags.MarkDeprecated("api-server-port", fmt.Sprintf("Please use %s instead", option.OperatorAPIServeAddr))
 
 	// Deprecated, remove in 1.9
 	flags.StringVar(&metricsAddress, "metrics-address", ":6942", "Address to serve Prometheus metrics")

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -379,6 +379,9 @@ const (
 	// OperatorPrometheusServeAddr IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
 	OperatorPrometheusServeAddr = "operator-prometheus-serve-addr"
 
+	// OperatorAPIServeAddr IP:Port on which to serve api requests in operator (pass ":Port" to bind on all interfaces, "" is off)
+	OperatorAPIServeAddr = "operator-api-serve-addr"
+
 	// PrometheusServeAddrDeprecated IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
 	PrometheusServeAddrDeprecated = "prometheus-serve-addr-deprecated"
 
@@ -1175,6 +1178,7 @@ type DaemonConfig struct {
 	PProf                       bool
 	PrometheusServeAddr         string
 	OperatorPrometheusServeAddr string
+	OperatorAPIServeAddr        string
 	ToFQDNsMinTTL               int
 
 	// ToFQDNsProxyPort is the user-configured global, shared, DNS listen port used
@@ -1922,6 +1926,7 @@ func (c *DaemonConfig) Populate() {
 	c.PrependIptablesChains = viper.GetBool(PrependIptablesChainsName)
 	c.PrometheusServeAddr = getPrometheusServerAddr()
 	c.OperatorPrometheusServeAddr = viper.GetString(OperatorPrometheusServeAddr)
+	c.OperatorAPIServeAddr = viper.GetString(OperatorAPIServeAddr)
 	c.ProxyConnectTimeout = viper.GetInt(ProxyConnectTimeout)
 	c.BlacklistConflictingRoutes = viper.GetBool(BlacklistConflictingRoutes)
 	c.ReadCNIConfiguration = viper.GetString(ReadCNIConfiguration)


### PR DESCRIPTION
Since Cilium operator is running in the host network, we should not open any port by default as similar behavior is performed for the cilium-agent.

I'll perform the backports manually for 1.6 and 1.7

We can still keep the default port for prometheus since we have a dedicated flag to enable or disable prometheus metrics.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10368)
<!-- Reviewable:end -->
