### PR TITLE
[v1.7] operator: stop listening on all interfaces for api-server-port

### DIFF
--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -298,6 +298,17 @@ Annotations:
 
 .. _1.7_required_changes:
 
+IMPORTANT: Changes required before upgrading to 1.7.1
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. warning::
+
+   Do not upgrade to 1.7.1 before reading the following sections and completing
+   the required steps for both 1.7.0 and 1.7.1.
+
+* ``api-server-port``: This flag, available in cilium-operator deployment only,
+  changed its behavior. The old behavior was opening that port on all interfaces,
+  the new behavior is opening that port on ``127.0.0.1`` and ``::1`` only.
+
 IMPORTANT: Changes required before upgrading to 1.7.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
@@ -142,6 +142,11 @@ spec:
 {{- end }}
         livenessProbe:
           httpGet:
+{{- if .Values.global.ipv4.enabled }}
+            host: '127.0.0.1'
+{{- else }}
+            host: '[::1]'
+{{- end }}
             path: /healthz
             port: 9234
             scheme: HTTP

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -1,4 +1,18 @@
 ---
+# Source: cilium/charts/agent/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cilium
+  namespace: kube-system
+---
+# Source: cilium/charts/operator/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+---
 # Source: cilium/charts/config/templates/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -126,20 +140,6 @@ data:
   enable-node-port: "false"
   enable-well-known-identities: "false"
   enable-remote-node-identity: "true"
----
-# Source: cilium/charts/agent/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: cilium
-  namespace: kube-system
----
-# Source: cilium/charts/operator/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: cilium-operator
-  namespace: kube-system
 ---
 # Source: cilium/charts/agent/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -637,6 +637,7 @@ spec:
         name: cilium-operator
         livenessProbe:
           httpGet:
+            host: '127.0.0.1'
             path: /healthz
             port: 9234
             scheme: HTTP

--- a/operator/main.go
+++ b/operator/main.go
@@ -208,6 +208,10 @@ func kvstoreEnabled() bool {
 		synchronizeNodes
 }
 
+func getAPIServerAddr() []string {
+	return []string{fmt.Sprintf("127.0.0.1:%d", apiServerPort), fmt.Sprintf("[::1]:%d", apiServerPort)}
+}
+
 func runOperator(cmd *cobra.Command) {
 	logging.SetupLogging([]string{}, map[string]string{}, "cilium-operator", viper.GetBool("debug"))
 
@@ -222,7 +226,7 @@ func runOperator(cmd *cobra.Command) {
 
 	log.Infof("Cilium Operator %s", version.Version)
 	k8sInitDone := make(chan struct{})
-	go startServer(fmt.Sprintf(":%d", apiServerPort), shutdownSignal, k8sInitDone)
+	go startServer(shutdownSignal, k8sInitDone, getAPIServerAddr()...)
 
 	if enableMetrics {
 		registerMetrics()


### PR DESCRIPTION
We should not open this port on all interfaces since cilium-operator is
running in the host network.

For now we will open on both IPv4 and IPv6 localhost addresses since the
user might run the operator on IPv6-only clusters, or vice-versa, we
don't want the operator to not being able from listening on a port on
the IP version not available on the cluster.

Signed-off-by: André Martins <andre@cilium.io>

```release-note
Do not listen on any port by default for cilium-operator
```

backport of https://github.com/cilium/cilium/pull/10368

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10370)
<!-- Reviewable:end -->
