### PR TITLE
operator: populate CLI flags from cilium-operator

### DIFF
--- a/operator/main.go
+++ b/operator/main.go
@@ -22,6 +22,7 @@ import (
 	"syscall"
 
 	"github.com/cilium/cilium/pkg/aws/eni"
+	"github.com/cilium/cilium/pkg/components"
 	"github.com/cilium/cilium/pkg/k8s"
 	clientset "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned"
 	"github.com/cilium/cilium/pkg/k8s/types"
@@ -29,6 +30,7 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/version"
 
@@ -53,6 +55,7 @@ var (
 				genMarkdown(cmd, cmdRefDir)
 				os.Exit(0)
 			}
+			initEnv()
 			runOperator(cmd)
 		},
 	}
@@ -63,6 +66,19 @@ var (
 
 	ciliumK8sClient clientset.Interface
 )
+
+func initEnv() {
+	// Prepopulate option.Config with options from CLI.
+	option.Config.Populate()
+
+	// add hooks after setting up metrics in the option.Confog
+	logging.DefaultLogger.Hooks.Add(metrics.NewLoggingHook(components.CiliumOperatortName))
+
+	// Logging should always be bootstrapped first. Do not add any code above this!
+	logging.SetupLogging(option.Config.LogDriver, option.Config.LogOpt, "cilium-operator", option.Config.Debug)
+
+	option.LogRegisteredOptions(log)
+}
 
 func main() {
 	signals := make(chan os.Signal, 1)
@@ -113,7 +129,6 @@ func getAPIServerAddr() []string {
 }
 
 func runOperator(cmd *cobra.Command) {
-	logging.SetupLogging([]string{}, map[string]string{}, "cilium-operator", viper.GetBool("debug"))
 
 	log.Infof("Cilium Operator %s", version.Version)
 	k8sInitDone := make(chan struct{})

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,6 +22,8 @@ import (
 const (
 	// CiliumAgentName is the name of cilium-agent (daemon) process name.
 	CiliumAgentName = "cilium-agent"
+	// CiliumOperatortName is the name of cilium-operator process name.
+	CiliumOperatortName = "cilium-operator"
 	// CiliumDaemonTestName is the name of test binary for daemon package.
 	CiliumDaemonTestName = "daemon.test"
 )

--- a/pkg/metrics/logging_hook.go
+++ b/pkg/metrics/logging_hook.go
@@ -42,6 +42,8 @@ func NewLoggingHook(component string) *LoggingHook {
 	switch component {
 	case components.CiliumAgentName:
 		metric = ErrorsWarnings
+	case components.CiliumOperatortName:
+		metric = ErrorsWarnings
 	default:
 		panic(fmt.Sprintf("component %s is unsupported by LoggingHook", component))
 	}


### PR DESCRIPTION
This commit fixes the ability to read the CLI flags by the operator.

Fixes: 67b147c3f273 ("operator: add ability to ready options from a config directory")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10372)
<!-- Reviewable:end -->
