### PR TITLE
Improve pod restarts on GKE

### DIFF
--- a/Documentation/gettingstarted/k8s-install-gke.rst
+++ b/Documentation/gettingstarted/k8s-install-gke.rst
@@ -67,7 +67,7 @@ Prepare & Deploy Cilium
 Deploy Cilium release via Helm:
 
 If you are ready to restart existing pods when initializing the node, you can
-also pass the ``--set global.restartPods`` flag to the ``helm`` command
+also pass the ``--set nodeinit.restartPods`` flag to the ``helm`` command
 below. This will ensure all pods are managed by Cilium.
 
 .. parsed-literal::

--- a/Documentation/gettingstarted/k8s-install-restart-pods.rst
+++ b/Documentation/gettingstarted/k8s-install-restart-pods.rst
@@ -1,7 +1,7 @@
 Restart remaining pods
 ======================
 
-If you did not use the ``--set global.restartPods=true`` flag above, you will
+If you did not use the ``--set nodeinit.restartPods=true`` flag above, you will
 need to restart pods in the ``kube-system`` namespace manually at a later time,
 to ensure they can be managed by Cilium:
 

--- a/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
@@ -159,6 +159,19 @@ spec:
               fi
 {{- end }}
 
+{{- if .Values.reconfigureKubelet }}
+              # GKE: Alter the kubelet configuration to run in CNI mode
+              echo "Changing kubelet configuration to --network-plugin=cni --cni-bin-dir={{ .Values.global.cni.binPath }}"
+              mkdir -p {{ .Values.global.cni.binPath }}
+              sed -i "s:--network-plugin=kubenet:--network-plugin=cni\ --cni-bin-dir={{ .Values.global.cni.binPath }}:g" /etc/default/kubelet
+              echo "Restarting kubelet..."
+              systemctl restart kubelet
+{{- end }}
+
+{{- if not (eq .Values.global.nodeinit.bootstrapFile "") }}
+              date > {{ .Values.global.nodeinit.bootstrapFile }}
+{{- end }}
+
 {{- if .Values.restartPods }}
               echo "Restarting kubenet managed pods"
               if grep -q 'docker' /etc/crictl.yaml; then
@@ -183,19 +196,6 @@ spec:
                 # COS-beta (with containerd)
                 for f in `find /var/lib/cni/networks/ -type f ! -name lock ! -name last_reserved_ip.0`; do crictl stopp $(cat $f) || true; done
               fi
-{{- end }}
-
-{{- if .Values.reconfigureKubelet }}
-              # GKE: Alter the kubelet configuration to run in CNI mode
-              echo "Changing kubelet configuration to --network-plugin=cni --cni-bin-dir={{ .Values.global.cni.binPath }}"
-              mkdir -p {{ .Values.global.cni.binPath }}
-              sed -i "s:--network-plugin=kubenet:--network-plugin=cni\ --cni-bin-dir={{ .Values.global.cni.binPath }}:g" /etc/default/kubelet
-              echo "Restarting kubelet..."
-              systemctl restart kubelet
-{{- end }}
-
-{{- if not (eq .Values.global.nodeinit.bootstrapFile "") }}
-              date > {{ .Values.global.nodeinit.bootstrapFile }}
 {{- end }}
 
 {{- if .Values.revertReconfigureKubelet }}


### PR DESCRIPTION
Pod restart from node init supposed to happen once kubelet is
reconfigured, but order is opposite in the helm chart. It's also
unnecessary to hold off cilium agent pod till pods are restarted. This
patch moves pod restart to the last operation in node init. This patch
also fixes typo in the GKE docs: 'global.restartPods' ->
'nodeinit.restartPods'.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10377)
<!-- Reviewable:end -->
