### PR TITLE
test: Install Helm 3

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -86,6 +86,7 @@ var (
 	defaultHelmOptions = map[string]string{
 		"global.registry":               "k8s1:5000/cilium",
 		"agent.image":                   "cilium-dev",
+		"preflight.image":               "cilium-dev",
 		"global.tag":                    "latest",
 		"operator.image":                "operator",
 		"managed-etcd.registry":         "docker.io/cilium",

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -3,7 +3,7 @@
 set -e
 
 HOST=$(hostname)
-export HELM_VERSION="2.14.2"
+export HELM_VERSION="3.1.1"
 export TOKEN="258062.5d84c017c9b2796c"
 export CILIUM_CONFIG_DIR="/opt/cilium"
 export PROVISIONSRC="/tmp/provision/"
@@ -48,6 +48,7 @@ if [[ ! $(helm version | grep ${HELM_VERSION}) ]]; then
   tar xzvf helm-v${HELM_VERSION}-linux-amd64.tar.gz
   mv linux-amd64/helm /usr/local/bin/
 fi
+helm version
 
 # Install serial ttyS0 server
 cat <<EOF > /etc/systemd/system/serial-getty@ttyS0.service


### PR DESCRIPTION
Install Helm 3 instead of Helm 2. Use the "cilium-dev" image also for preflight as "cilium" image is not available for the local build.

Fixes: #10374

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10378)
<!-- Reviewable:end -->
