### PR TITLE
AKS: Fix dynamic reconfiguration of bridge mode

### DIFF
--- a/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
@@ -56,18 +56,6 @@ spec:
                       while crictl ps | grep -v "node-init" | grep -q "POD_cilium"; do sleep 1; done
                     fi
 
-{{- if .Values.azure }}
-                    # Azure specific: Transparent bridge mode is required in
-                    # order for proxy-redirection to work
-                    until [ -f /var/run/azure-vnet.json ]; do
-                      echo waiting for azure-vnet to be created
-                      sleep 1s
-                    done
-                    if [ -f /var/run/azure-vnet.json ]; then
-                      sed -i 's/"Mode": "bridge",/"Mode": "transparent",/g' /var/run/azure-vnet.json
-                    fi
-{{- end }}
-
                     systemctl disable sys-fs-bpf.mount || true
                     systemctl stop sys-fs-bpf.mount || true
 
@@ -151,6 +139,18 @@ spec:
               echo "Addressing:"
               ip -4 a
               ip -6 a
+
+{{- if .Values.azure }}
+              # Azure specific: Transparent bridge mode is required in order
+              # for proxy-redirection to work
+              until [ -f /var/run/azure-vnet.json ]; do
+                echo waiting for azure-vnet to be created
+                sleep 1s
+              done
+              if [ -f /var/run/azure-vnet.json ]; then
+                sed -i 's/"Mode": "bridge",/"Mode": "transparent",/g' /var/run/azure-vnet.json
+              fi
+{{- end }}
 
 {{- if .Values.removeCbrBridge }}
               if ip link show cbr0; then


### PR DESCRIPTION
Commit 0b70117b96 ("doc: Fix AKS guide regression") has re-introduced the
dynamic reconfiguration of the Azure bridge into transport mode in order to
enable transparent proxy operations. The commit has incorrectly done so by
adding the reconfiguration step in the preStop instead of the postStart hook.
This required the Cilium pod to restart once in order to reconfigure the bridge
and thus delayed the bootstrapping time.

Fixes: 0b70117b96 ("doc: Fix AKS guide regression") has re-introduced the

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10383)
<!-- Reviewable:end -->
