### PR TITLE
bpf: Fix typo in max options for bpf_lb

### DIFF
--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -51,7 +51,7 @@ LB_OPTIONS = \
 # These options are intended to max out the BPF program complexity. it is load
 # tested as well.
 MAX_LB_OPTIONS = -DENABLE_IPV4 -DENABLE_IPV6 -DLB_L3 -DLB_L4 \
-	-DENABLE_HOST_SERVICES_TCP -DENABLE_HOST_SERVICES_TCP -DENABLE_NODEPORT \
+	-DENABLE_HOST_SERVICES_TCP -DENABLE_HOST_SERVICES_UDP -DENABLE_NODEPORT \
 	-DENABLE_EXTERNAL_IP
 
 bpf_sock.ll: bpf_sock.c $(LIB)


### PR DESCRIPTION
`ENABLE_HOST_SERVICES_UDP` wasn't set when trying to max out the BPF program complexity.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10386)
<!-- Reviewable:end -->
