### PR TITLE
test: Avoid using global map for Cilium configuration

### DIFF
--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -280,20 +280,23 @@ var _ = Describe("K8sDatapathConfig", func() {
 			SkipIfIntegration(helpers.CIIntegrationGKE)
 		})
 
-		directRoutingOptions := map[string]string{
-			"global.tunnel":               "disabled",
-			"global.autoDirectNodeRoutes": "true",
-		}
-
 		It("Check connectivity with automatic direct nodes routes", func() {
-			deployCilium(directRoutingOptions)
+			deployCilium(map[string]string{
+				"global.tunnel":               "disabled",
+				"global.autoDirectNodeRoutes": "true",
+			})
+
 			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
 		})
 
 		It("Check direct connectivity with per endpoint routes", func() {
-			directRoutingOptions["global.endpointRoutes.enabled"] = "true"
-			directRoutingOptions["global.ipv6.enabled"] = "false"
-			deployCilium(directRoutingOptions)
+			deployCilium(map[string]string{
+				"global.tunnel":                 "disabled",
+				"global.autoDirectNodeRoutes":   "true",
+				"global.endpointRoutes.enabled": "true",
+				"global.ipv6.enabled":           "false",
+			})
+
 			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
 		})
 


### PR DESCRIPTION
The same instance of the configuration map is shared among the tests. So, any modification to the map might unintentionally influence a non-related test case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10388)
<!-- Reviewable:end -->
