### PR TITLE
test: Avoid panics due to dereferencing a nil error

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -852,11 +852,11 @@ func (kub *Kubectl) NamespaceDelete(name string) *CmdRes {
 	ginkgoext.By("Deleting namespace %s", name)
 	res := kub.DeleteAllInNamespace(name)
 	if !res.WasSuccessful() {
-		kub.Logger().Infof("Error while deleting all objects from %s ns: %s", name, res.GetError().Error())
+		kub.Logger().Infof("Error while deleting all objects from %s ns: %s", name, res.GetError())
 	}
 	res = kub.ExecShort(fmt.Sprintf("%s delete namespace %s", KubectlCmd, name))
 	if !res.WasSuccessful() {
-		kub.Logger().Infof("Error while deleting ns %s: %s", name, res.GetError().Error())
+		kub.Logger().Infof("Error while deleting ns %s: %s", name, res.GetError())
 	}
 	return kub.ExecShort(fmt.Sprintf(
 		"%[1]s get namespace %[2]s -o json | tr -d \"\\n\" | sed \"s/\\\"finalizers\\\": \\[[^]]\\+\\]/\\\"finalizers\\\": []/\" | %[1]s replace --raw /api/v1/namespaces/%[2]s/finalize -f -", KubectlCmd, name))

--- a/test/helpers/node.go
+++ b/test/helpers/node.go
@@ -229,8 +229,8 @@ func (s *SSHMeta) ExecContext(ctx context.Context, cmd string, options ...ExecOp
 		} else {
 			// Log other error types. They are likely from SSH or the network
 			log.WithError(err).Errorf("Error executing command '%s'", cmd)
-			res.err = err
 		}
+		res.err = err
 	}
 
 	res.SendToLog(ops.SkipLog)
@@ -305,6 +305,9 @@ func (s *SSHMeta) ExecInBackground(ctx context.Context, cmd string, options ...E
 				if res.exitcode == 130 {
 					res.success = true
 				}
+			}
+			if !res.success {
+				res.err = err
 			}
 		} else {
 			res.success = true


### PR DESCRIPTION
Set 'CmdRes.err' to a non-nil value when command is not
successful. Also avoid calling 'Error()' on an error explicitly, so
that no panics are caused when the error is 'nil'.

This avoids test failures like this:

STEP: Deleting namespace 2020022720301k8spolicytestclusterwidepoliciestestclusterwidecon

! Panic in Spec Setup (BeforeEach) [38.899 seconds]
K8sPolicyTest
/Users/jarno/go/src/github.com/cilium/cilium/test/ginkgo-ext/scopes.go:395
  Clusterwide policies
  /Users/jarno/go/src/github.com/cilium/cilium/test/ginkgo-ext/scopes.go:395
    Test clusterwide connectivity with policies [BeforeEach]
    /Users/jarno/go/src/github.com/cilium/cilium/test/ginkgo-ext/scopes.go:430

    Test Panicked
    runtime error: invalid memory address or nil pointer dereference
    /Users/jarno/go/src/github.com/cilium/cilium/test/ginkgo-ext/scopes.go:374

    Full Stack Trace
    github.com/cilium/cilium/test/ginkgo-ext.BeforeEach.func1.1(0xc000448900)
    	/Users/jarno/go/src/github.com/cilium/cilium/test/ginkgo-ext/scopes.go:374 +0x5e
    panic(0x26993c0, 0x3ba0bd0)
    	/usr/local/Cellar/go/1.13.8/libexec/src/runtime/panic.go:679 +0x1b2
    github.com/cilium/cilium/test/helpers.(*Kubectl).NamespaceDelete(0xc000384e40, 0xc000811aa0, 0x3f, 0x2)
    	/Users/jarno/go/src/github.com/cilium/cilium/test/helpers/kubectl.go:859 +0x2eb
    github.com/cilium/cilium/test/k8sT.glob..func7.11.1()
    	/Users/jarno/go/src/github.com/cilium/cilium/test/k8sT/Policies.go:1375 +0x5b1
    github.com/cilium/cilium/test/ginkgo-ext.BeforeEach.func1()

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10390)
<!-- Reviewable:end -->
