### PR TITLE
proxy: Remove access-log option

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -15,7 +15,6 @@ cilium-agent [flags]
 ### Options
 
 ```
-      --access-log string                             Path to access log of supported L7 requests observed
       --agent-labels strings                          Additional labels to identify this agent
       --allow-icmp-frag-needed                        Allow ICMP Fragmentation Needed type packets for purposes like TCP Path MTU. (default true)
       --allow-localhost string                        Policy when to allow local stack to reach local endpoints { auto | always | policy } (default "auto")

--- a/Documentation/envoy/extensions.rst
+++ b/Documentation/envoy/extensions.rst
@@ -523,10 +523,7 @@ and adding the ''--debug-verbose=flow'' flag.
 
   $ sudo service cilium stop 
   
-  $ sudo /usr/bin/cilium-agent --debug --auto-direct-node-routes --ipv4-range 10.11.0.0/16 --kvstore-opt consul.address=192.168.33.11:8500 --kvstore consul --container-runtime=docker --container-runtime-endpoint=unix:///var/run/docker.sock -t vxlan --fixed-identity-mapping=128=kv-store --fixed-identity-mapping=129=kube-dns --debug-verbose=flow --access-log=/var/log/cilium-access.log
-
-
-The cilium access log is accessible from within the developer VM at ''/var/log/cilium-access.log''
+  $ sudo /usr/bin/cilium-agent --debug --auto-direct-node-routes --ipv4-range 10.11.0.0/16 --kvstore-opt consul.address=192.168.33.11:8500 --kvstore consul --container-runtime=docker --container-runtime-endpoint=unix:///var/run/docker.sock -t vxlan --fixed-identity-mapping=128=kv-store --fixed-identity-mapping=129=kube-dns --debug-verbose=flow
 
 
 Step 13: Add Runtime Tests

--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -326,6 +326,8 @@ Deprecated options
 * ``keep-bpf-templates``: This option no longer has any effect due to the BPF
   assets not being compiled into the cilium-agent binary anymore. The option is
   deprecated and will be removed in Cilium 1.9.
+* ``access-log``: L7 access logs have been available via Hubble since Cilium
+  1.6. The ``access-log`` option to log to a file has been removed.
 
 Renamed Metrics
 ~~~~~~~~~~~~~~~

--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -339,7 +339,6 @@ EOF
     esac
 
     cilium_options+=" ${TUNNEL_MODE_STRING}"
-    cilium_options+=" --access-log=/var/log/cilium-access.log"
 
 cat <<EOF >> "$filename"
 sleep 2s

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -424,7 +424,7 @@ func NewDaemon(ctx context.Context, dp datapath.Datapath) (*Daemon, *endpointRes
 	// FIXME: Make the port range configurable.
 	if option.Config.EnableL7Proxy {
 		d.l7Proxy = proxy.StartProxySupport(10000, 20000, option.Config.RunDir,
-			option.Config.AccessLog, &d, option.Config.AgentLabels, d.datapath, d.endpointManager)
+			&d, option.Config.AgentLabels, d.datapath, d.endpointManager)
 	} else {
 		log.Info("L7 proxies are disabled")
 	}

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -194,9 +194,6 @@ func init() {
 	})
 
 	// Env bindings
-	flags.String(option.AccessLog, "", "Path to access log of supported L7 requests observed")
-	option.BindEnv(option.AccessLog)
-
 	flags.StringSlice(option.AgentLabels, []string{}, "Additional labels to identify this agent")
 	option.BindEnv(option.AgentLabels)
 

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -75,7 +75,6 @@ func setupTestDirectories() {
 	option.Config.Device = "undefined"
 	option.Config.RunDir = tempRunDir
 	option.Config.StateDir = tempRunDir
-	option.Config.AccessLog = filepath.Join(tempRunDir, "cilium-access.log")
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -48,9 +48,6 @@ var (
 )
 
 const (
-	// AccessLog is the path to access log of supported L7 requests observed
-	AccessLog = "access-log"
-
 	// AgentLabels are additional labels to identify this agent
 	AgentLabels = "agent-labels"
 
@@ -986,9 +983,6 @@ type DaemonConfig struct {
 	// Monitor contains the configuration for the node monitor.
 	Monitor *models.MonitorStatus
 
-	// AccessLog is the path to the access log of supported L7 requests observed.
-	AccessLog string
-
 	// AgentLabels contains additional labels to identify this agent in monitor events.
 	AgentLabels []string
 
@@ -1838,7 +1832,6 @@ func (c *DaemonConfig) parseExcludedLocalAddresses(s []string) error {
 func (c *DaemonConfig) Populate() {
 	var err error
 
-	c.AccessLog = viper.GetString(AccessLog)
 	c.AgentLabels = viper.GetStringSlice(AgentLabels)
 	c.AllowICMPFragNeeded = viper.GetBool(AllowICMPFragNeeded)
 	c.AllowLocalhost = viper.GetString(AllowLocalhost)

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -112,17 +112,10 @@ type Proxy struct {
 // StartProxySupport starts the servers to support L7 proxies: xDS GRPC server
 // and access log server.
 func StartProxySupport(minPort uint16, maxPort uint16, stateDir string,
-	accessLogFile string, accessLogNotifier logger.LogRecordNotifier, accessLogMetadata []string,
+	accessLogNotifier logger.LogRecordNotifier, accessLogMetadata []string,
 	datapathUpdater DatapathUpdater, mgr EndpointLookup) *Proxy {
 	endpointManager = mgr
 	xdsServer := envoy.StartXDSServer(stateDir)
-
-	if accessLogFile != "" {
-		if err := logger.OpenLogfile(accessLogFile); err != nil {
-			log.WithError(err).WithField(logfields.Path, accessLogFile).
-				Warn("Cannot open L7 access log")
-		}
-	}
 
 	if accessLogNotifier != nil {
 		logger.SetNotifier(accessLogNotifier)


### PR DESCRIPTION
L7 flow logging has been supported via Hubble for a while. The file logging is
no longer required.

**Review comment:**
* The option `access-log` has been removed on purpose without marking it deprecated. Action must be taken and a warning in the log files will unlikely cause users to change the option. Ignoring the option would likely keep an old accesslog file around without ever updating it again and the situation could be left unnoticed for a long time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10393)
<!-- Reviewable:end -->
