### PR TITLE
bpf, maps: consistently use MapType

### DIFF
--- a/pkg/bpf/bpf.go
+++ b/pkg/bpf/bpf.go
@@ -28,29 +28,6 @@ var (
 )
 
 const (
-	// BPF map type constants. Must match enum bpf_map_type from linux/bpf.h
-	BPF_MAP_TYPE_UNSPEC              = 0
-	BPF_MAP_TYPE_HASH                = 1
-	BPF_MAP_TYPE_ARRAY               = 2
-	BPF_MAP_TYPE_PROG_ARRAY          = 3
-	BPF_MAP_TYPE_PERF_EVENT_ARRAY    = 4
-	BPF_MAP_TYPE_PERCPU_HASH         = 5
-	BPF_MAP_TYPE_PERCPU_ARRAY        = 6
-	BPF_MAP_TYPE_STACK_TRACE         = 7
-	BPF_MAP_TYPE_CGROUP_ARRAY        = 8
-	BPF_MAP_TYPE_LRU_HASH            = 9
-	BPF_MAP_TYPE_LRU_PERCPU_HASH     = 10
-	BPF_MAP_TYPE_LPM_TRIE            = 11
-	BPF_MAP_TYPE_ARRAY_OF_MAPS       = 12
-	BPF_MAP_TYPE_HASH_OF_MAPS        = 13
-	BPF_MAP_TYPE_DEVMAP              = 14
-	BPF_MAP_TYPE_SOCKMAP             = 15
-	BPF_MAP_TYPE_CPUMAP              = 16
-	BPF_MAP_TYPE_XSKMAP              = 17
-	BPF_MAP_TYPE_SOCKHASH            = 18
-	BPF_MAP_TYPE_CGROUP_STORAGE      = 19
-	BPF_MAP_TYPE_REUSEPORT_SOCKARRAY = 20
-
 	// BPF syscall command constants. Must match enum bpf_cmd from linux/bpf.h
 	BPF_MAP_CREATE          = 0
 	BPF_MAP_LOOKUP_ELEM     = 1

--- a/pkg/bpf/bpf_linux.go
+++ b/pkg/bpf/bpf_linux.go
@@ -40,7 +40,7 @@ import (
 // When mapType is the type HASH_OF_MAPS an innerID is required to point at a
 // map fd which has the same type/keySize/valueSize/maxEntries as expected map
 // entries. For all other mapTypes innerID is ignored and should be zeroed.
-func CreateMap(mapType int, keySize, valueSize, maxEntries, flags, innerID uint32, path string) (int, error) {
+func CreateMap(mapType MapType, keySize, valueSize, maxEntries, flags, innerID uint32, path string) (int, error) {
 	// This struct must be in sync with union bpf_attr's anonymous struct
 	// used by the BPF_MAP_CREATE command
 	uba := struct {
@@ -403,7 +403,7 @@ func ObjClose(fd int) error {
 	return nil
 }
 
-func objCheck(fd int, path string, mapType int, keySize, valueSize, maxEntries, flags uint32) bool {
+func objCheck(fd int, path string, mapType MapType, keySize, valueSize, maxEntries, flags uint32) bool {
 	info, err := GetMapInfo(os.Getpid(), fd)
 	if err != nil {
 		return false
@@ -412,10 +412,10 @@ func objCheck(fd int, path string, mapType int, keySize, valueSize, maxEntries, 
 	scopedLog := log.WithField(logfields.Path, path)
 	mismatch := false
 
-	if int(info.MapType) != mapType {
+	if info.MapType != mapType {
 		scopedLog.WithFields(logrus.Fields{
 			"old": info.MapType,
-			"new": MapType(mapType),
+			"new": mapType,
 		}).Warning("Map type mismatch for BPF map")
 		mismatch = true
 	}
@@ -468,7 +468,7 @@ func objCheck(fd int, path string, mapType int, keySize, valueSize, maxEntries, 
 	return false
 }
 
-func OpenOrCreateMap(path string, mapType int, keySize, valueSize, maxEntries, flags uint32, innerID uint32, pin bool) (int, bool, error) {
+func OpenOrCreateMap(path string, mapType MapType, keySize, valueSize, maxEntries, flags uint32, innerID uint32, pin bool) (int, bool, error) {
 	var fd int
 
 	redo := false

--- a/pkg/bpf/bpf_test.go
+++ b/pkg/bpf/bpf_test.go
@@ -21,17 +21,17 @@ import (
 )
 
 func (s *BPFTestSuite) TestDefaultMapFlags(c *C) {
-	c.Assert(GetPreAllocateMapFlags(BPF_MAP_TYPE_LPM_TRIE), Equals, uint32(BPF_F_NO_PREALLOC))
-	c.Assert(GetPreAllocateMapFlags(BPF_MAP_TYPE_ARRAY), Equals, uint32(0))
-	c.Assert(GetPreAllocateMapFlags(BPF_MAP_TYPE_LRU_HASH), Equals, uint32(0))
+	c.Assert(GetPreAllocateMapFlags(MapTypeLPMTrie), Equals, uint32(BPF_F_NO_PREALLOC))
+	c.Assert(GetPreAllocateMapFlags(MapTypeArray), Equals, uint32(0))
+	c.Assert(GetPreAllocateMapFlags(MapTypeLRUHash), Equals, uint32(0))
 
-	c.Assert(GetPreAllocateMapFlags(BPF_MAP_TYPE_HASH), Equals, uint32(BPF_F_NO_PREALLOC))
+	c.Assert(GetPreAllocateMapFlags(MapTypeHash), Equals, uint32(BPF_F_NO_PREALLOC))
 	EnableMapPreAllocation()
-	c.Assert(GetPreAllocateMapFlags(BPF_MAP_TYPE_HASH), Equals, uint32(0))
+	c.Assert(GetPreAllocateMapFlags(MapTypeHash), Equals, uint32(0))
 
-	c.Assert(GetPreAllocateMapFlags(BPF_MAP_TYPE_LPM_TRIE), Equals, uint32(BPF_F_NO_PREALLOC))
-	c.Assert(GetPreAllocateMapFlags(BPF_MAP_TYPE_ARRAY), Equals, uint32(0))
-	c.Assert(GetPreAllocateMapFlags(BPF_MAP_TYPE_LRU_HASH), Equals, uint32(0))
+	c.Assert(GetPreAllocateMapFlags(MapTypeLPMTrie), Equals, uint32(BPF_F_NO_PREALLOC))
+	c.Assert(GetPreAllocateMapFlags(MapTypeArray), Equals, uint32(0))
+	c.Assert(GetPreAllocateMapFlags(MapTypeLRUHash), Equals, uint32(0))
 }
 
 func (s *BPFTestSuite) TestPreallocationFlags(c *C) {

--- a/pkg/bpf/map.go
+++ b/pkg/bpf/map.go
@@ -25,7 +25,7 @@ import (
 // MapType is an enumeration for valid BPF map types
 type MapType int
 
-// This enumeration must be in sync with enum bpf_prog_type in <linux/bpf.h>
+// This enumeration must be in sync with enum bpf_map_type in <linux/bpf.h>
 const (
 	MapTypeUnspec MapType = iota
 	MapTypeHash

--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -74,8 +74,7 @@ type MapInfo struct {
 	KeySize  uint32
 	MapValue MapValue
 	// ReadValueSize is the value size that is used to read from the BPF maps
-	// this value an the ValueSize values can be different for BPF_MAP_TYPE_PERCPU_HASH
-	// for example.
+	// this value and the ValueSize values can be different for MapTypePerCPUHash.
 	ReadValueSize uint32
 	ValueSize     uint32
 	MaxEntries    uint32
@@ -159,7 +158,7 @@ func NewMap(name string, mapType MapType, mapKey MapKey, keySize int, mapValue M
 func NewPerCPUHashMap(name string, mapKey MapKey, keySize int, mapValue MapValue, valueSize, cpus, maxEntries int, flags uint32, innerID uint32, dumpParser DumpParser) *Map {
 	m := &Map{
 		MapInfo: MapInfo{
-			MapType:       BPF_MAP_TYPE_PERCPU_HASH,
+			MapType:       MapTypePerCPUHash,
 			MapKey:        mapKey,
 			KeySize:       uint32(keySize),
 			MapValue:      mapValue,
@@ -470,7 +469,7 @@ func (m *Map) openOrCreate(pin bool) (bool, error) {
 
 	mapType := GetMapType(m.MapType)
 	flags := m.Flags | GetPreAllocateMapFlags(mapType)
-	fd, isNew, err := OpenOrCreateMap(m.path, int(mapType), m.KeySize, m.ValueSize, m.MaxEntries, flags, m.InnerID, pin)
+	fd, isNew, err := OpenOrCreateMap(m.path, mapType, m.KeySize, m.ValueSize, m.MaxEntries, flags, m.InnerID, pin)
 	if err != nil {
 		return false, err
 	}
@@ -1088,7 +1087,7 @@ func (m *Map) CheckAndUpgrade(desired *MapInfo) bool {
 	return objCheck(
 		m.fd,
 		m.path,
-		int(desiredMapType),
+		desiredMapType,
 		desired.KeySize,
 		desired.ValueSize,
 		desired.MaxEntries,

--- a/pkg/maps/cidrmap/cidrmap.go
+++ b/pkg/maps/cidrmap/cidrmap.go
@@ -164,11 +164,11 @@ func OpenMap(path string, prefixlen int, prefixdyn bool) (*CIDRMap, bool, error)
 
 // OpenMapElems is the same as OpenMap only with defined maxelem as argument.
 func OpenMapElems(path string, prefixlen int, prefixdyn bool, maxelem uint32) (*CIDRMap, bool, error) {
-	var typeMap = bpf.BPF_MAP_TYPE_LPM_TRIE
-	var prefix = 0
+	typeMap := bpf.MapTypeLPMTrie
+	prefix := 0
 
-	if prefixdyn == false {
-		typeMap = bpf.BPF_MAP_TYPE_HASH
+	if !prefixdyn {
+		typeMap = bpf.MapTypeHash
 		prefix = prefixlen
 	}
 	if prefixlen <= 0 {
@@ -186,7 +186,7 @@ func OpenMapElems(path string, prefixlen int, prefixdyn bool, maxelem uint32) (*
 
 	if err != nil {
 		log.Debug("Kernel does not support CIDR maps, using hash table instead.")
-		typeMap = bpf.BPF_MAP_TYPE_HASH
+		typeMap = bpf.MapTypeHash
 		fd, isNewMap, err = bpf.OpenOrCreateMap(
 			path,
 			typeMap,
@@ -213,7 +213,7 @@ func OpenMapElems(path string, prefixlen int, prefixdyn bool, maxelem uint32) (*
 	log.WithFields(logrus.Fields{
 		logfields.Path: path,
 		"fd":           fd,
-		"LPM":          typeMap == bpf.BPF_MAP_TYPE_LPM_TRIE,
+		"LPM":          typeMap == bpf.MapTypeLPMTrie,
 	}).Debug("Created CIDR map")
 
 	return m, isNewMap, nil

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -146,35 +146,35 @@ func InitMapInfo(tcpMaxEntries, anyMaxEntries int, v4, v6 bool) {
 		MapTypeIPv6AnyGlobal: global6Map,
 	}
 
-	setupMapInfo(MapType(MapTypeIPv4TCPLocal), "CT_MAP_TCP4",
+	setupMapInfo(MapTypeIPv4TCPLocal, "CT_MAP_TCP4",
 		&CtKey4{}, int(unsafe.Sizeof(CtKey4{})),
 		MapNumEntriesLocal, natMaps[MapTypeIPv4TCPLocal])
 
-	setupMapInfo(MapType(MapTypeIPv6TCPLocal), "CT_MAP_TCP6",
+	setupMapInfo(MapTypeIPv6TCPLocal, "CT_MAP_TCP6",
 		&CtKey6{}, int(unsafe.Sizeof(CtKey6{})),
 		MapNumEntriesLocal, natMaps[MapTypeIPv6TCPLocal])
 
-	setupMapInfo(MapType(MapTypeIPv4TCPGlobal), "CT_MAP_TCP4",
+	setupMapInfo(MapTypeIPv4TCPGlobal, "CT_MAP_TCP4",
 		&CtKey4Global{}, int(unsafe.Sizeof(CtKey4Global{})),
 		tcpMaxEntries, natMaps[MapTypeIPv4TCPGlobal])
 
-	setupMapInfo(MapType(MapTypeIPv6TCPGlobal), "CT_MAP_TCP6",
+	setupMapInfo(MapTypeIPv6TCPGlobal, "CT_MAP_TCP6",
 		&CtKey6Global{}, int(unsafe.Sizeof(CtKey6Global{})),
 		tcpMaxEntries, natMaps[MapTypeIPv6TCPGlobal])
 
-	setupMapInfo(MapType(MapTypeIPv4AnyLocal), "CT_MAP_ANY4",
+	setupMapInfo(MapTypeIPv4AnyLocal, "CT_MAP_ANY4",
 		&CtKey4{}, int(unsafe.Sizeof(CtKey4{})),
 		MapNumEntriesLocal, natMaps[MapTypeIPv4AnyLocal])
 
-	setupMapInfo(MapType(MapTypeIPv6AnyLocal), "CT_MAP_ANY6",
+	setupMapInfo(MapTypeIPv6AnyLocal, "CT_MAP_ANY6",
 		&CtKey6{}, int(unsafe.Sizeof(CtKey6{})),
 		MapNumEntriesLocal, natMaps[MapTypeIPv6AnyLocal])
 
-	setupMapInfo(MapType(MapTypeIPv4AnyGlobal), "CT_MAP_ANY4",
+	setupMapInfo(MapTypeIPv4AnyGlobal, "CT_MAP_ANY4",
 		&CtKey4Global{}, int(unsafe.Sizeof(CtKey4Global{})),
 		anyMaxEntries, natMaps[MapTypeIPv4AnyGlobal])
 
-	setupMapInfo(MapType(MapTypeIPv6AnyGlobal), "CT_MAP_ANY6",
+	setupMapInfo(MapTypeIPv6AnyGlobal, "CT_MAP_ANY6",
 		&CtKey6Global{}, int(unsafe.Sizeof(CtKey6Global{})),
 		anyMaxEntries, natMaps[MapTypeIPv6AnyGlobal])
 }

--- a/pkg/maps/eppolicymap/doc.go
+++ b/pkg/maps/eppolicymap/doc.go
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package eppolicymap represents the map from an endpoint ID to its
-// policy map. This map is of type BPF_MAP_TYPES_HASH_OF_MAPS where
-// as noted above the key is the endpoint ID. It is used to lookup
-// the policy from the socket context where unlike in the L2/L3 context,
-// where the program has a direct lookup of the policy because each
-// program is attached to an endpoint, socket programs run on all sockets
+// Package eppolicymap represents the map from an endpoint ID to its policy map.
+// This map is of type bpf.MapTypeHashOfMaps where the key is the endpoint ID.
+// It is used to lookup the policy from the socket context where unlike in the
+// L2/L3 context, where the program has a direct lookup of the policy because
+// each program is attached to an endpoint, socket programs run on all sockets
 // regardless of endpoint.
 // +groupName=maps
 package eppolicymap

--- a/pkg/maps/eppolicymap/eppolicymap.go
+++ b/pkg/maps/eppolicymap/eppolicymap.go
@@ -60,8 +60,8 @@ var (
 // for testing purposes.
 func CreateWithName(mapName string) error {
 	buildMap.Do(func() {
-		mapType := bpf.MapType(bpf.BPF_MAP_TYPE_HASH)
-		fd, err := bpf.CreateMap(bpf.BPF_MAP_TYPE_HASH,
+		mapType := bpf.MapTypeHash
+		fd, err := bpf.CreateMap(mapType,
 			uint32(unsafe.Sizeof(policymap.PolicyKey{})),
 			uint32(unsafe.Sizeof(policymap.PolicyEntry{})),
 			uint32(policymap.MaxEntries),

--- a/pkg/maps/eppolicymap/eppolicymap_test.go
+++ b/pkg/maps/eppolicymap/eppolicymap_test.go
@@ -61,7 +61,7 @@ func (e *EPPolicyMapTestSuite) TestWriteEndpoint(c *C) {
 	bpf.CheckOrMountFS("", false)
 	keys := make([]*lxcmap.EndpointKey, 1)
 	many := make([]*lxcmap.EndpointKey, 256)
-	fd, err := bpf.CreateMap(bpf.BPF_MAP_TYPE_HASH,
+	fd, err := bpf.CreateMap(bpf.MapTypeHash,
 		uint32(unsafe.Sizeof(policymap.PolicyKey{})),
 		uint32(unsafe.Sizeof(policymap.PolicyEntry{})), 1024, 0, 0,
 		"ep-policy-inner-map")
@@ -87,7 +87,7 @@ func (e *EPPolicyMapTestSuite) TestWriteEndpointFails(c *C) {
 	option.Config.SockopsEnable = true
 	bpf.CheckOrMountFS("", false)
 	keys := make([]*lxcmap.EndpointKey, 1)
-	_, err := bpf.CreateMap(bpf.BPF_MAP_TYPE_HASH,
+	_, err := bpf.CreateMap(bpf.MapTypeHash,
 		uint32(unsafe.Sizeof(policymap.PolicyKey{})),
 		uint32(unsafe.Sizeof(policymap.PolicyEntry{})), 1024, 0, 0,
 		"ep-policy-inner-map")
@@ -103,7 +103,7 @@ func (e *EPPolicyMapTestSuite) TestWriteEndpointDisabled(c *C) {
 	option.Config.SockopsEnable = false
 	bpf.CheckOrMountFS("", false)
 	keys := make([]*lxcmap.EndpointKey, 1)
-	fd, err := bpf.CreateMap(bpf.BPF_MAP_TYPE_HASH,
+	fd, err := bpf.CreateMap(bpf.MapTypeHash,
 		uint32(unsafe.Sizeof(policymap.PolicyKey{})),
 		uint32(unsafe.Sizeof(policymap.PolicyEntry{})), 1024, 0, 0,
 		"ep-policy-inner-map")

--- a/pkg/maps/ipcache/ipcache.go
+++ b/pkg/maps/ipcache/ipcache.go
@@ -162,7 +162,7 @@ func NewMap(name string) *Map {
 	return &Map{
 		Map: *bpf.NewMap(
 			name,
-			bpf.BPF_MAP_TYPE_LPM_TRIE,
+			bpf.MapTypeLPMTrie,
 			&Key{},
 			int(unsafe.Sizeof(Key{})),
 			&RemoteEndpointInfo{},
@@ -244,7 +244,7 @@ func SupportsDelete() bool {
 // BackedByLPM returns true if the IPCache is backed by a proper LPM
 // implementation (provided by Linux kernels 4.11 or later), false otherwise.
 func BackedByLPM() bool {
-	return IPCache.MapType == bpf.BPF_MAP_TYPE_LPM_TRIE
+	return IPCache.MapType == bpf.MapTypeLPMTrie
 }
 
 var (

--- a/pkg/maps/policymap/policymap.go
+++ b/pkg/maps/policymap/policymap.go
@@ -252,7 +252,7 @@ func (pm *PolicyMap) DumpToSlice() (PolicyEntriesDump, error) {
 }
 
 func newMap(path string) *PolicyMap {
-	mapType := bpf.MapType(bpf.BPF_MAP_TYPE_HASH)
+	mapType := bpf.MapTypeHash
 	flags := bpf.GetPreAllocateMapFlags(mapType)
 	return &PolicyMap{
 		Map: bpf.NewMap(


### PR DESCRIPTION
Use the `MapType*` consts to specify map type all over the place instead
of casting between MapType and int. This allows the compiler to check
for type safety.

Also remove the `BPF_MAP_TYPE_*` consts which are now unused.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10394)
<!-- Reviewable:end -->
