### PR TITLE
daemon: create directory with correct permissions in prepareEndpointDirs

### DIFF
--- a/daemon/policy_test.go
+++ b/daemon/policy_test.go
@@ -191,7 +191,7 @@ func (ds *DaemonSuite) getXDSNetworkPolicies(c *C, resourceNames []string) map[s
 
 func prepareEndpointDirs() (cleanup func(), err error) {
 	testEPDir := fmt.Sprintf("%d", testEndpointID)
-	if err = os.Mkdir(testEPDir, 755); err != nil {
+	if err = os.Mkdir(testEPDir, 0755); err != nil {
 		return func() {}, err
 	}
 	return func() {


### PR DESCRIPTION
Pass permissions as octal instead of decimal value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10397)
<!-- Reviewable:end -->
