### PR TITLE
vagrant: Allow running several dev VMs concurrently

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -132,7 +132,7 @@ Vagrant.configure(2) do |config|
     master_vm_name = "#{$vm_base_name}1#{$build_id_name}"
     config.vm.define master_vm_name, primary: true do |cm|
         node_ip = "#{$master_ip}"
-		cm.vm.network "forwarded_port", guest: 6443, host: 7443
+		cm.vm.network "forwarded_port", guest: 6443, host: 7443, auto_correct: true
         cm.vm.network "private_network", ip: "#{$master_ip}",
             virtualbox__intnet: "cilium-test-#{$build_id}",
             :libvirt__guest_ipv6 => "yes",

--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -602,7 +602,8 @@ elif [ -n "${PROVISION}" ]; then
 else
     vagrant up
     if [ "$?" -eq "0" -a -n "${K8S}" ]; then
-        vagrant ssh k8s1 -- cat /home/vagrant/.kube/config | sed 's;server:.*:6443;server: https://k8s1:7443;g' > vagrant.kubeconfig
+        host_port=$(vagrant port --guest 6443)
+        vagrant ssh k8s1 -- cat /home/vagrant/.kube/config | sed "s;server:.*:6443;server: https://k8s1:$host_port;g" > vagrant.kubeconfig
         echo "Add '127.0.0.1 k8s1' to your /etc/hosts to use vagrant.kubeconfig file for kubectl"
     fi
 fi


### PR DESCRIPTION
This pull request solves the conflict on the forwarded port of the dev VM to allow running several instances concurrently.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10400)
<!-- Reviewable:end -->
