### PR TITLE
pkg/bpf: remove outdated godoc for UpdateElementFromPointers

### DIFF
--- a/pkg/bpf/bpf_linux.go
+++ b/pkg/bpf/bpf_linux.go
@@ -95,10 +95,6 @@ type bpfAttrMapOpElem struct {
 }
 
 // UpdateElementFromPointers updates the map in fd with the given value in the given key.
-// The flags can have the following values:
-// bpf.BPF_ANY to create new element or update existing;
-// bpf.BPF_NOEXIST to create new element if it didn't exist;
-// bpf.BPF_EXIST to update existing element.
 func UpdateElementFromPointers(fd int, structPtr unsafe.Pointer, sizeOfStruct uintptr) error {
 	var duration *spanstat.SpanStat
 	if option.Config.MetricsConfig.BPFSyscallDurationEnabled {


### PR DESCRIPTION
Commit 55276eea4f62 ("pkg/bpf: add newer LookupElement, GetNextKey and
UpdateElement functions") added UpdateElementFromPointers but seemd to
have copied the godoc from UpdateElement. However,
UpdateElementFromPointers does not have a flags argument so adjust its
godoc comment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10403)
<!-- Reviewable:end -->
