### PR TITLE
Remove leftover in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -235,9 +235,6 @@ docker-plugin-image: GIT_VERSION
 	$(QUIET)echo "Push like this when ready:"
 	$(QUIET)echo "docker push cilium/docker-plugin:$(DOCKER_IMAGE_TAG)"
 
-docker-image-init:
-	$(QUIET)cd contrib/packaging/docker && ${CONTAINER_ENGINE} build -t "cilium/cilium-init:$(UTC_DATE)" -f Dockerfile.init .
-
 docker-image-runtime:
 	cd contrib/packaging/docker && ${CONTAINER_ENGINE} build -t "cilium/cilium-runtime:$(UTC_DATE)" -f Dockerfile.runtime .
 


### PR DESCRIPTION
docker-image-init target is a leftover that should have been removed
when this patch was merged:

https://github.com/cilium/cilium/pull/8522/files

Signed-off-by: Manuel Buil <mbuil@suse.com>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [:)] Thanks for contributing!

<!-- Description of change -->

docker-image-init target is a leftover that should have been removed
when this patch was merged:

https://github.com/cilium/cilium/pull/8522/files

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10410)
<!-- Reviewable:end -->
