### PR TITLE
daemon: fix cilium-agent helper message for disable-cnp-status-updates

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -15,153 +15,153 @@ cilium-agent [flags]
 ### Options
 
 ```
-      --access-log string                                     Path to access log of supported L7 requests observed
-      --agent-labels strings                                  Additional labels to identify this agent
-      --allow-icmp-frag-needed                                Allow ICMP Fragmentation Needed type packets for purposes like TCP Path MTU. (default true)
-      --allow-localhost string                                Policy when to allow local stack to reach local endpoints { auto | always | policy } (default "auto")
-      --annotate-k8s-node                                     Annotate Kubernetes node (default true)
-      --auto-create-cilium-node-resource                      Automatically create CiliumNode resource for own node on startup (default true)
-      --auto-direct-node-routes                               Enable automatic L2 routing between nodes
-      --blacklist-conflicting-routes                          Don't blacklist IP allocations conflicting with local non-cilium routes (default true)
-      --bpf-compile-debug                                     Enable debugging of the BPF compilation process
-      --bpf-ct-global-any-max int                             Maximum number of entries in non-TCP CT table (default 262144)
-      --bpf-ct-global-tcp-max int                             Maximum number of entries in TCP CT table (default 1000000)
-      --bpf-ct-timeout-regular-any duration                   Timeout for entries in non-TCP CT table (default 1m0s)
-      --bpf-ct-timeout-regular-tcp duration                   Timeout for established entries in TCP CT table (default 6h0m0s)
-      --bpf-ct-timeout-regular-tcp-fin duration               Teardown timeout for entries in TCP CT table (default 10s)
-      --bpf-ct-timeout-regular-tcp-syn duration               Establishment timeout for entries in TCP CT table (default 1m0s)
-      --bpf-ct-timeout-service-any duration                   Timeout for service entries in non-TCP CT table (default 1m0s)
-      --bpf-ct-timeout-service-tcp duration                   Timeout for established service entries in TCP CT table (default 6h0m0s)
-      --bpf-nat-global-max int                                Maximum number of entries for the global BPF NAT table (default 841429)
-      --bpf-policy-map-max int                                Maximum number of entries in endpoint policy map (per endpoint) (default 16384)
-      --bpf-root string                                       Path to BPF filesystem
-      --certificates-directory string                         Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
-      --cgroup-root string                                    Path to Cgroup2 filesystem
-      --cluster-id int                                        Unique identifier of the cluster
-      --cluster-name string                                   Name of the cluster (default "default")
-      --clustermesh-config string                             Path to the ClusterMesh configuration directory
-      --config string                                         Configuration file (default "$HOME/ciliumd.yaml")
-      --config-dir string                                     Configuration directory that contains a file for each option
-      --conntrack-gc-interval duration                        Overwrite the connection-tracking garbage collection interval
-      --datapath-mode string                                  Datapath mode name (default "veth")
-  -D, --debug                                                 Enable debugging mode
-      --debug-verbose strings                                 List of enabled verbose debug groups
-  -d, --device string                                         Device facing cluster/external network for direct L3 (non-overlay mode) (default "undefined")
-      --disable-cnp-status-updates cnp-node-status-gc=false   Do not send CNP NodeStatus updates to the Kubernetes api-server (recommended to run with cnp-node-status-gc=false in cilium-operator)
-      --disable-conntrack                                     Disable connection tracking
-      --disable-endpoint-crd                                  Disable use of CiliumEndpoint CRD
-      --disable-k8s-services                                  Disable east-west K8s load balancing by cilium
-      --egress-masquerade-interfaces string                   Limit egress masquerading to interface selector
-      --enable-endpoint-health-checking                       Enable connectivity health checking between virtual endpoints (default true)
-      --enable-endpoint-routes                                Use per endpoint routes instead of routing via cilium_host
-      --enable-external-ips                                   Enable k8s service externalIPs feature (requires enabling enable-node-port) (default true)
-      --enable-health-checking                                Enable connectivity health checking (default true)
-      --enable-host-reachable-services                        Enable reachability of services for host applications (beta)
-      --enable-ipsec                                          Enable IPSec support
-      --enable-ipv4                                           Enable IPv4 support (default true)
-      --enable-ipv6                                           Enable IPv6 support (default true)
-      --enable-k8s-endpoint-slice                             Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
-      --enable-k8s-event-handover                             Enable k8s event handover to kvstore for improved scalability
-      --enable-l7-proxy                                       Enable L7 proxy for L7 policy enforcement (default true)
-      --enable-local-node-route                               Enable installation of the route which points the allocation prefix of the local node (default true)
-      --enable-node-port                                      Enable NodePort type services by Cilium (beta)
-      --enable-policy string                                  Enable policy enforcement (default "default")
-      --enable-remote-node-identity                           Enable use of remote node identity
-      --enable-tracing                                        Enable tracing while determining policy (debugging)
-      --enable-well-known-identities                          Enable well-known identities for known Kubernetes components (default true)
-      --enable-xt-socket-fallback                             Enable fallback for missing xt_socket module (default true)
-      --encrypt-interface string                              Transparent encryption interface
-      --encrypt-node                                          Enables encrypting traffic from non-Cilium pods and host networking
-      --endpoint-interface-name-prefix string                 Prefix of interface name shared by all endpoints (default "lxc+")
-      --endpoint-queue-size int                               size of EventQueue per-endpoint (default 25)
-      --envoy-log string                                      Path to a separate Envoy log file, if any
-      --exclude-local-address strings                         Exclude CIDR from being recognized as local address
-      --fixed-identity-mapping map                            Key-value for the fixed identity mapping which allows to use reserved label for fixed identities (default map[])
-      --flannel-master-device string                          Installs a BPF program to allow for policy enforcement in the given network interface. Allows to run Cilium on top of other CNI plugins that provide networking, e.g. flannel, where for flannel, this value should be set with 'cni0'. [EXPERIMENTAL]
-      --flannel-uninstall-on-exit                             When used along the flannel-master-device flag, it cleans up all BPF programs installed when Cilium agent is terminated.
-      --force-local-policy-eval-at-source                     Force policy evaluation of all local communication at the source endpoint (default true)
-  -h, --help                                                  help for cilium-agent
-      --host-reachable-services-protos strings                Only enable reachability of services for host applications for specific protocols (default [tcp,udp])
-      --http-idle-timeout uint                                Time after which a non-gRPC HTTP stream is considered failed unless traffic in the stream has been processed (in seconds); defaults to 0 (unlimited)
-      --http-max-grpc-timeout uint                            Time after which a forwarded gRPC request is considered failed unless completed (in seconds). A "grpc-timeout" header may override this with a shorter value; defaults to 0 (unlimited)
-      --http-request-timeout uint                             Time after which a forwarded HTTP request is considered failed unless completed (in seconds); Use 0 for unlimited (default 3600)
-      --http-retry-count uint                                 Number of retries performed after a forwarded request attempt fails (default 3)
-      --http-retry-timeout uint                               Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
-      --identity-allocation-mode string                       Method to use for identity allocation (default "kvstore")
-      --identity-change-grace-period duration                 Time to wait before using new identity on endpoint identity change (default 5s)
-      --install-iptables-rules                                Install base iptables rules for cilium to mainly interact with kube-proxy (and masquerading) (default true)
-      --ip-allocation-timeout duration                        Time after which an incomplete CIDR allocation is considered failed (default 2m0s)
-      --ipam string                                           Backend to use for IPAM
-      --ipsec-key-file string                                 Path to IPSec key file
-      --ipv4-node string                                      IPv4 address of node (default "auto")
-      --ipv4-pod-subnets strings                              List of IPv4 pod subnets to preconfigure for encryption
-      --ipv4-range string                                     Per-node IPv4 endpoint prefix, e.g. 10.16.0.0/16 (default "auto")
-      --ipv4-service-loopback-address string                  IPv4 address for service loopback SNAT (default "169.254.42.1")
-      --ipv4-service-range string                             Kubernetes IPv4 services CIDR if not inside cluster prefix (default "auto")
-      --ipv6-cluster-alloc-cidr string                        IPv6 /64 CIDR used to allocate per node endpoint /96 CIDR (default "f00d::/64")
-      --ipv6-node string                                      IPv6 address of node (default "auto")
-      --ipv6-pod-subnets strings                              List of IPv6 pod subnets to preconfigure for encryption
-      --ipv6-range string                                     Per-node IPv6 endpoint prefix, e.g. fd02:1:1::/96 (default "auto")
-      --ipv6-service-range string                             Kubernetes IPv6 services CIDR if not inside cluster prefix (default "auto")
-      --ipvlan-master-device string                           Device facing external network acting as ipvlan master (default "undefined")
-      --k8s-api-server string                                 Kubernetes API server URL
-      --k8s-kubeconfig-path string                            Absolute path of the kubernetes kubeconfig file
-      --k8s-namespace string                                  Name of the Kubernetes namespace in which Cilium is deployed in
-      --k8s-require-ipv4-pod-cidr                             Require IPv4 PodCIDR to be specified in node resource
-      --k8s-require-ipv6-pod-cidr                             Require IPv6 PodCIDR to be specified in node resource
-      --k8s-watcher-endpoint-selector string                  K8s endpoint watcher will watch for these k8s endpoints (default "metadata.name!=kube-scheduler,metadata.name!=kube-controller-manager,metadata.name!=etcd-operator,metadata.name!=gcp-controller-manager")
-      --k8s-watcher-queue-size uint                           Queue size used to serialize each k8s event type (default 1024)
-      --keep-config                                           When restoring state, keeps containers' configuration in place
-      --kube-proxy-replacement string                         auto-enable available features for kube-proxy replacement ("probe"), or enable only selected features (will panic if any selected feature cannot be enabled) ("partial") or enable all features (will panic if any feature cannot be enabled) ("strict"), or completely disable it (ignores any selected feature) ("disabled") (default "partial")
-      --kvstore string                                        Key-value store type
-      --kvstore-connectivity-timeout duration                 Time after which an incomplete kvstore operation  is considered failed (default 2m0s)
-      --kvstore-opt map                                       Key-value store options (default map[])
-      --kvstore-periodic-sync duration                        Periodic KVstore synchronization interval (default 5m0s)
-      --label-prefix-file string                              Valid label prefixes file path
-      --labels strings                                        List of label prefixes used to determine identity of an endpoint
-      --lib-dir string                                        Directory path to store runtime build environment (default "/var/lib/cilium")
-      --log-driver strings                                    Logging endpoints to use for example syslog
-      --log-opt map                                           Log driver options for cilium (default map[])
-      --log-system-load                                       Enable periodic logging of system load
-      --masquerade                                            Masquerade packets from endpoints leaving the host (default true)
-      --metrics strings                                       Metrics that should be enabled or disabled from the default metric list. (+metric_foo to enable metric_foo , -metric_bar to disable metric_bar)
-      --monitor-aggregation string                            Level of monitor aggregation for traces from the datapath (default "None")
-      --monitor-aggregation-flags strings                     TCP flags that trigger monitor reports when monitor aggregation is enabled (default [syn,fin,rst])
-      --monitor-aggregation-interval duration                 Monitor report interval when monitor aggregation is enabled (default 5s)
-      --monitor-queue-size int                                Size of the event queue when reading monitor events
-      --mtu int                                               Overwrite auto-detected MTU of underlying network
-      --nat46-range string                                    IPv6 prefix to map IPv4 addresses to (default "0:0:0:0:0:FFFF::/96")
-      --node-port-mode string                                 BPF NodePort mode ("snat", "dsr", "hybrid") (default "hybrid")
-      --node-port-range strings                               Set the min/max NodePort port range (default [30000,32767])
-      --policy-queue-size int                                 size of queues for policy-related events (default 100)
-      --pprof                                                 Enable serving the pprof debugging API
-      --preallocate-bpf-maps                                  Enable BPF map pre-allocation (default true)
-      --prefilter-device string                               Device facing external network for XDP prefiltering (default "undefined")
-      --prefilter-mode string                                 Prefilter mode { native | generic } (default: native) (default "native")
-      --prepend-iptables-chains                               Prepend custom iptables chains instead of appending (default true)
-      --prometheus-serve-addr string                          IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
-      --proxy-connect-timeout uint                            Time after which a TCP connect attempt is considered failed unless completed (in seconds) (default 1)
-      --read-cni-conf string                                  Read to the CNI configuration at specified path to extract per node configuration
-      --restore                                               Restores state, if possible, from previous daemon (default true)
-      --sidecar-istio-proxy-image string                      Regular expression matching compatible Istio sidecar istio-proxy container image names (default "cilium/istio_proxy")
-      --single-cluster-route                                  Use a single cluster route instead of per node routes
-      --skip-crd-creation                                     Skip Kubernetes Custom Resource Definitions creations
-      --socket-path string                                    Sets daemon's socket path to listen for connections (default "/var/run/cilium/cilium.sock")
-      --sockops-enable                                        Enable sockops when kernel supported
-      --state-dir string                                      Directory path to store runtime state (default "/var/run/cilium")
-      --tofqdns-dns-reject-response-code string               DNS response code for rejecting DNS requests, available options are '[nameError refused]' (default "refused")
-      --tofqdns-enable-dns-compression                        Allow the DNS proxy to compress responses to endpoints that are larger than 512 Bytes or the EDNS0 option, if present (default true)
-      --tofqdns-enable-poller                                 Enable proactive polling of DNS names in toFQDNs.matchName rules.
-      --tofqdns-enable-poller-events                          Emit DNS responses seen by the DNS poller as Monitor events, if the poller is enabled. (default true)
-      --tofqdns-endpoint-max-ip-per-hostname int              Maximum number of IPs to maintain per FQDN name for each endpoint (default 50)
-      --tofqdns-max-deferred-connection-deletes int           Maximum number of IPs to retain for expired DNS lookups with still-active connections (default 10000)
-      --tofqdns-min-ttl int                                   The minimum time, in seconds, to use DNS data for toFQDNs policies. (default 600 when --tofqdns-enable-poller, 3600 otherwise)
-      --tofqdns-pre-cache string                              DNS cache data at this path is preloaded on agent startup
-      --tofqdns-proxy-port int                                Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port.
-      --tofqdns-proxy-response-max-delay duration             The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information. (default 100ms)
-      --trace-payloadlen int                                  Length of payload to capture when tracing (default 128)
-  -t, --tunnel string                                         Tunnel mode {vxlan, geneve, disabled} (default "vxlan" for the "veth" datapath mode)
-      --version                                               Print version information
-      --write-cni-conf-when-ready string                      Write the CNI configuration as specified via --read-cni-conf to path when agent is ready
+      --access-log string                             Path to access log of supported L7 requests observed
+      --agent-labels strings                          Additional labels to identify this agent
+      --allow-icmp-frag-needed                        Allow ICMP Fragmentation Needed type packets for purposes like TCP Path MTU. (default true)
+      --allow-localhost string                        Policy when to allow local stack to reach local endpoints { auto | always | policy } (default "auto")
+      --annotate-k8s-node                             Annotate Kubernetes node (default true)
+      --auto-create-cilium-node-resource              Automatically create CiliumNode resource for own node on startup (default true)
+      --auto-direct-node-routes                       Enable automatic L2 routing between nodes
+      --blacklist-conflicting-routes                  Don't blacklist IP allocations conflicting with local non-cilium routes (default true)
+      --bpf-compile-debug                             Enable debugging of the BPF compilation process
+      --bpf-ct-global-any-max int                     Maximum number of entries in non-TCP CT table (default 262144)
+      --bpf-ct-global-tcp-max int                     Maximum number of entries in TCP CT table (default 1000000)
+      --bpf-ct-timeout-regular-any duration           Timeout for entries in non-TCP CT table (default 1m0s)
+      --bpf-ct-timeout-regular-tcp duration           Timeout for established entries in TCP CT table (default 6h0m0s)
+      --bpf-ct-timeout-regular-tcp-fin duration       Teardown timeout for entries in TCP CT table (default 10s)
+      --bpf-ct-timeout-regular-tcp-syn duration       Establishment timeout for entries in TCP CT table (default 1m0s)
+      --bpf-ct-timeout-service-any duration           Timeout for service entries in non-TCP CT table (default 1m0s)
+      --bpf-ct-timeout-service-tcp duration           Timeout for established service entries in TCP CT table (default 6h0m0s)
+      --bpf-nat-global-max int                        Maximum number of entries for the global BPF NAT table (default 841429)
+      --bpf-policy-map-max int                        Maximum number of entries in endpoint policy map (per endpoint) (default 16384)
+      --bpf-root string                               Path to BPF filesystem
+      --certificates-directory string                 Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
+      --cgroup-root string                            Path to Cgroup2 filesystem
+      --cluster-id int                                Unique identifier of the cluster
+      --cluster-name string                           Name of the cluster (default "default")
+      --clustermesh-config string                     Path to the ClusterMesh configuration directory
+      --config string                                 Configuration file (default "$HOME/ciliumd.yaml")
+      --config-dir string                             Configuration directory that contains a file for each option
+      --conntrack-gc-interval duration                Overwrite the connection-tracking garbage collection interval
+      --datapath-mode string                          Datapath mode name (default "veth")
+  -D, --debug                                         Enable debugging mode
+      --debug-verbose strings                         List of enabled verbose debug groups
+  -d, --device string                                 Device facing cluster/external network for direct L3 (non-overlay mode) (default "undefined")
+      --disable-cnp-status-updates                    Do not send CNP NodeStatus updates to the Kubernetes api-server (recommended to run with "cnp-node-status-gc=false" in cilium-operator)
+      --disable-conntrack                             Disable connection tracking
+      --disable-endpoint-crd                          Disable use of CiliumEndpoint CRD
+      --disable-k8s-services                          Disable east-west K8s load balancing by cilium
+      --egress-masquerade-interfaces string           Limit egress masquerading to interface selector
+      --enable-endpoint-health-checking               Enable connectivity health checking between virtual endpoints (default true)
+      --enable-endpoint-routes                        Use per endpoint routes instead of routing via cilium_host
+      --enable-external-ips                           Enable k8s service externalIPs feature (requires enabling enable-node-port) (default true)
+      --enable-health-checking                        Enable connectivity health checking (default true)
+      --enable-host-reachable-services                Enable reachability of services for host applications (beta)
+      --enable-ipsec                                  Enable IPSec support
+      --enable-ipv4                                   Enable IPv4 support (default true)
+      --enable-ipv6                                   Enable IPv6 support (default true)
+      --enable-k8s-endpoint-slice                     Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
+      --enable-k8s-event-handover                     Enable k8s event handover to kvstore for improved scalability
+      --enable-l7-proxy                               Enable L7 proxy for L7 policy enforcement (default true)
+      --enable-local-node-route                       Enable installation of the route which points the allocation prefix of the local node (default true)
+      --enable-node-port                              Enable NodePort type services by Cilium (beta)
+      --enable-policy string                          Enable policy enforcement (default "default")
+      --enable-remote-node-identity                   Enable use of remote node identity
+      --enable-tracing                                Enable tracing while determining policy (debugging)
+      --enable-well-known-identities                  Enable well-known identities for known Kubernetes components (default true)
+      --enable-xt-socket-fallback                     Enable fallback for missing xt_socket module (default true)
+      --encrypt-interface string                      Transparent encryption interface
+      --encrypt-node                                  Enables encrypting traffic from non-Cilium pods and host networking
+      --endpoint-interface-name-prefix string         Prefix of interface name shared by all endpoints (default "lxc+")
+      --endpoint-queue-size int                       size of EventQueue per-endpoint (default 25)
+      --envoy-log string                              Path to a separate Envoy log file, if any
+      --exclude-local-address strings                 Exclude CIDR from being recognized as local address
+      --fixed-identity-mapping map                    Key-value for the fixed identity mapping which allows to use reserved label for fixed identities (default map[])
+      --flannel-master-device string                  Installs a BPF program to allow for policy enforcement in the given network interface. Allows to run Cilium on top of other CNI plugins that provide networking, e.g. flannel, where for flannel, this value should be set with 'cni0'. [EXPERIMENTAL]
+      --flannel-uninstall-on-exit                     When used along the flannel-master-device flag, it cleans up all BPF programs installed when Cilium agent is terminated.
+      --force-local-policy-eval-at-source             Force policy evaluation of all local communication at the source endpoint (default true)
+  -h, --help                                          help for cilium-agent
+      --host-reachable-services-protos strings        Only enable reachability of services for host applications for specific protocols (default [tcp,udp])
+      --http-idle-timeout uint                        Time after which a non-gRPC HTTP stream is considered failed unless traffic in the stream has been processed (in seconds); defaults to 0 (unlimited)
+      --http-max-grpc-timeout uint                    Time after which a forwarded gRPC request is considered failed unless completed (in seconds). A "grpc-timeout" header may override this with a shorter value; defaults to 0 (unlimited)
+      --http-request-timeout uint                     Time after which a forwarded HTTP request is considered failed unless completed (in seconds); Use 0 for unlimited (default 3600)
+      --http-retry-count uint                         Number of retries performed after a forwarded request attempt fails (default 3)
+      --http-retry-timeout uint                       Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
+      --identity-allocation-mode string               Method to use for identity allocation (default "kvstore")
+      --identity-change-grace-period duration         Time to wait before using new identity on endpoint identity change (default 5s)
+      --install-iptables-rules                        Install base iptables rules for cilium to mainly interact with kube-proxy (and masquerading) (default true)
+      --ip-allocation-timeout duration                Time after which an incomplete CIDR allocation is considered failed (default 2m0s)
+      --ipam string                                   Backend to use for IPAM
+      --ipsec-key-file string                         Path to IPSec key file
+      --ipv4-node string                              IPv4 address of node (default "auto")
+      --ipv4-pod-subnets strings                      List of IPv4 pod subnets to preconfigure for encryption
+      --ipv4-range string                             Per-node IPv4 endpoint prefix, e.g. 10.16.0.0/16 (default "auto")
+      --ipv4-service-loopback-address string          IPv4 address for service loopback SNAT (default "169.254.42.1")
+      --ipv4-service-range string                     Kubernetes IPv4 services CIDR if not inside cluster prefix (default "auto")
+      --ipv6-cluster-alloc-cidr string                IPv6 /64 CIDR used to allocate per node endpoint /96 CIDR (default "f00d::/64")
+      --ipv6-node string                              IPv6 address of node (default "auto")
+      --ipv6-pod-subnets strings                      List of IPv6 pod subnets to preconfigure for encryption
+      --ipv6-range string                             Per-node IPv6 endpoint prefix, e.g. fd02:1:1::/96 (default "auto")
+      --ipv6-service-range string                     Kubernetes IPv6 services CIDR if not inside cluster prefix (default "auto")
+      --ipvlan-master-device string                   Device facing external network acting as ipvlan master (default "undefined")
+      --k8s-api-server string                         Kubernetes API server URL
+      --k8s-kubeconfig-path string                    Absolute path of the kubernetes kubeconfig file
+      --k8s-namespace string                          Name of the Kubernetes namespace in which Cilium is deployed in
+      --k8s-require-ipv4-pod-cidr                     Require IPv4 PodCIDR to be specified in node resource
+      --k8s-require-ipv6-pod-cidr                     Require IPv6 PodCIDR to be specified in node resource
+      --k8s-watcher-endpoint-selector string          K8s endpoint watcher will watch for these k8s endpoints (default "metadata.name!=kube-scheduler,metadata.name!=kube-controller-manager,metadata.name!=etcd-operator,metadata.name!=gcp-controller-manager")
+      --k8s-watcher-queue-size uint                   Queue size used to serialize each k8s event type (default 1024)
+      --keep-config                                   When restoring state, keeps containers' configuration in place
+      --kube-proxy-replacement string                 auto-enable available features for kube-proxy replacement ("probe"), or enable only selected features (will panic if any selected feature cannot be enabled) ("partial") or enable all features (will panic if any feature cannot be enabled) ("strict"), or completely disable it (ignores any selected feature) ("disabled") (default "partial")
+      --kvstore string                                Key-value store type
+      --kvstore-connectivity-timeout duration         Time after which an incomplete kvstore operation  is considered failed (default 2m0s)
+      --kvstore-opt map                               Key-value store options (default map[])
+      --kvstore-periodic-sync duration                Periodic KVstore synchronization interval (default 5m0s)
+      --label-prefix-file string                      Valid label prefixes file path
+      --labels strings                                List of label prefixes used to determine identity of an endpoint
+      --lib-dir string                                Directory path to store runtime build environment (default "/var/lib/cilium")
+      --log-driver strings                            Logging endpoints to use for example syslog
+      --log-opt map                                   Log driver options for cilium (default map[])
+      --log-system-load                               Enable periodic logging of system load
+      --masquerade                                    Masquerade packets from endpoints leaving the host (default true)
+      --metrics strings                               Metrics that should be enabled or disabled from the default metric list. (+metric_foo to enable metric_foo , -metric_bar to disable metric_bar)
+      --monitor-aggregation string                    Level of monitor aggregation for traces from the datapath (default "None")
+      --monitor-aggregation-flags strings             TCP flags that trigger monitor reports when monitor aggregation is enabled (default [syn,fin,rst])
+      --monitor-aggregation-interval duration         Monitor report interval when monitor aggregation is enabled (default 5s)
+      --monitor-queue-size int                        Size of the event queue when reading monitor events
+      --mtu int                                       Overwrite auto-detected MTU of underlying network
+      --nat46-range string                            IPv6 prefix to map IPv4 addresses to (default "0:0:0:0:0:FFFF::/96")
+      --node-port-mode string                         BPF NodePort mode ("snat", "dsr", "hybrid") (default "hybrid")
+      --node-port-range strings                       Set the min/max NodePort port range (default [30000,32767])
+      --policy-queue-size int                         size of queues for policy-related events (default 100)
+      --pprof                                         Enable serving the pprof debugging API
+      --preallocate-bpf-maps                          Enable BPF map pre-allocation (default true)
+      --prefilter-device string                       Device facing external network for XDP prefiltering (default "undefined")
+      --prefilter-mode string                         Prefilter mode { native | generic } (default: native) (default "native")
+      --prepend-iptables-chains                       Prepend custom iptables chains instead of appending (default true)
+      --prometheus-serve-addr string                  IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
+      --proxy-connect-timeout uint                    Time after which a TCP connect attempt is considered failed unless completed (in seconds) (default 1)
+      --read-cni-conf string                          Read to the CNI configuration at specified path to extract per node configuration
+      --restore                                       Restores state, if possible, from previous daemon (default true)
+      --sidecar-istio-proxy-image string              Regular expression matching compatible Istio sidecar istio-proxy container image names (default "cilium/istio_proxy")
+      --single-cluster-route                          Use a single cluster route instead of per node routes
+      --skip-crd-creation                             Skip Kubernetes Custom Resource Definitions creations
+      --socket-path string                            Sets daemon's socket path to listen for connections (default "/var/run/cilium/cilium.sock")
+      --sockops-enable                                Enable sockops when kernel supported
+      --state-dir string                              Directory path to store runtime state (default "/var/run/cilium")
+      --tofqdns-dns-reject-response-code string       DNS response code for rejecting DNS requests, available options are '[nameError refused]' (default "refused")
+      --tofqdns-enable-dns-compression                Allow the DNS proxy to compress responses to endpoints that are larger than 512 Bytes or the EDNS0 option, if present (default true)
+      --tofqdns-enable-poller                         Enable proactive polling of DNS names in toFQDNs.matchName rules.
+      --tofqdns-enable-poller-events                  Emit DNS responses seen by the DNS poller as Monitor events, if the poller is enabled. (default true)
+      --tofqdns-endpoint-max-ip-per-hostname int      Maximum number of IPs to maintain per FQDN name for each endpoint (default 50)
+      --tofqdns-max-deferred-connection-deletes int   Maximum number of IPs to retain for expired DNS lookups with still-active connections (default 10000)
+      --tofqdns-min-ttl int                           The minimum time, in seconds, to use DNS data for toFQDNs policies. (default 600 when --tofqdns-enable-poller, 3600 otherwise)
+      --tofqdns-pre-cache string                      DNS cache data at this path is preloaded on agent startup
+      --tofqdns-proxy-port int                        Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port.
+      --tofqdns-proxy-response-max-delay duration     The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information. (default 100ms)
+      --trace-payloadlen int                          Length of payload to capture when tracing (default 128)
+  -t, --tunnel string                                 Tunnel mode {vxlan, geneve, disabled} (default "vxlan" for the "veth" datapath mode)
+      --version                                       Print version information
+      --write-cni-conf-when-ready string              Write the CNI configuration as specified via --read-cni-conf to path when agent is ready
 ```
 

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -725,7 +725,7 @@ func init() {
 	flags.MarkHidden(option.PolicyTriggerInterval)
 	option.BindEnv(option.PolicyTriggerInterval)
 
-	flags.Bool(option.DisableCNPStatusUpdates, false, "Do not send CNP NodeStatus updates to the Kubernetes api-server (recommended to run with `cnp-node-status-gc=false` in cilium-operator)")
+	flags.Bool(option.DisableCNPStatusUpdates, false, `Do not send CNP NodeStatus updates to the Kubernetes api-server (recommended to run with "cnp-node-status-gc=false" in cilium-operator)`)
 	option.BindEnv(option.DisableCNPStatusUpdates)
 
 	viper.BindPFlags(flags)


### PR DESCRIPTION
The helper message seems to print a string in front of it that should
not have been printed.

Fixes: 3aacf41d784e ("add capability to disable CNP NodeStatus updates")
Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10414)
<!-- Reviewable:end -->
