### PR TITLE
kubernetes: do not disable node routes for portmap

### DIFF
--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -243,10 +243,12 @@ data:
   #  - portmap (Enables HostPort support for Cilium)
   cni-chaining-mode: {{ .Values.global.cni.chainingMode }}
 
+{{- if ne .Values.global.cni.chainingMode "portmap" }}
   # Disable the PodCIDR route to the cilium_host interface as it is not
   # required. While chaining, it is the responsibility of the underlying plugin
   # to enable routing.
   enable-local-node-route: "false"
+{{- end }}
 {{- end }}
 
   masquerade: {{ .Values.global.masquerade | quote }}


### PR DESCRIPTION
Since not all CNIs handle routing, e.g. portmap, we should still keep
`enable-local-node-route` set to true in the portmap case as this CNI
does not create any routes automatically.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10415)
<!-- Reviewable:end -->
