### PR TITLE
Fix dead link in 1.4->1.5 upgrade documentation

### DIFF
--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -686,37 +686,37 @@ Upgrading from >=1.4.0 to 1.5.y
 
         .. parsed-literal::
 
-          $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.10/cilium-pre-flight-with-rm-svc-v2.yaml
+          $ kubectl apply -f https://raw.githubusercontent.com/cilium/cilium/v1.5/examples/kubernetes/1.10/cilium-pre-flight-with-rm-svc-v2.yaml
 
       .. group-tab:: K8s 1.11
 
         .. parsed-literal::
 
-          $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.11/cilium-pre-flight-with-rm-svc-v2.yaml
+          $ kubectl apply -f https://raw.githubusercontent.com/cilium/cilium/v1.5/examples/kubernetes/1.11/cilium-pre-flight-with-rm-svc-v2.yaml
 
       .. group-tab:: K8s 1.12
 
         .. parsed-literal::
 
-          $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.12/cilium-pre-flight-with-rm-svc-v2.yaml
+          $ kubectl apply -f https://raw.githubusercontent.com/cilium/cilium/v1.5/examples/kubernetes/1.12/cilium-pre-flight-with-rm-svc-v2.yaml
 
       .. group-tab:: K8s 1.13
 
         .. parsed-literal::
 
-          $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.13/cilium-pre-flight-with-rm-svc-v2.yaml
+          $ kubectl apply -f https://raw.githubusercontent.com/cilium/cilium/v1.5/examples/kubernetes/1.13/cilium-pre-flight-with-rm-svc-v2.yaml
 
       .. group-tab:: K8s 1.14
 
         .. parsed-literal::
 
-          $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.14/cilium-pre-flight-with-rm-svc-v2.yaml
+          $ kubectl apply -f https://raw.githubusercontent.com/cilium/cilium/v1.5/examples/kubernetes/1.14/cilium-pre-flight-with-rm-svc-v2.yaml
 
       .. group-tab:: K8s 1.15
 
         .. parsed-literal::
 
-          $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.15/cilium-pre-flight-with-rm-svc-v2.yaml
+          $ kubectl apply -f https://raw.githubusercontent.com/cilium/cilium/v1.5/examples/kubernetes/1.15/cilium-pre-flight-with-rm-svc-v2.yaml
 
 
    See :ref:`pre_flight` for instructions how to run, validate and remove


### PR DESCRIPTION
The broken link was caused by using the 'latest' URL domain and path as
root. \ |SCM_WEB|\/examples/kubernetes/1.10/cilium-pre-flight-with-rm-svc-v2.yaml 
Therefore the URL picked up the most recent tags, and post 1.5.12 the
path `/examples/kubernetes/1.X` were removed, so all newly built URLs were broken.
eg: `...githubusercontent.com/cilium/cilium/1.7.0/examples/kubernetes/1.10...`, all /1.1X/ do 
not exist in tags newer than 1.5.12. 

This change makes the URL static to the release path of `1.5.12`. If
there are other options to keep the URL tagged within the `1.5.x` minor
versions; I'm interested in learning about it, but this is a quick fix.

Fixes: #10391

Signed-off-by: Joshua Roppo joshroppo@gmail.com

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10416)
<!-- Reviewable:end -->
