### PR TITLE
Documentation: Lock dependency to fix build

### DIFF
--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -8,6 +8,7 @@ imagesize==1.1.0
 Jinja2==2.10.1
 jsonschema==2.6.0
 MarkupSafe==1.0
+pyenchant==2.0.0
 Pygments==2.4.2
 pytz==2018.7
 PyYAML==4.2b1


### PR DESCRIPTION
A dependency for building docs imports the PyEnchant library.
Which by default pulls in the 'latest' version, this was updated from
2.0.0 to 3.0.1 on 2020/03/01.

Using PyEnchant 3.0.1 `make html` fails to build locally as well as in
the [test-docs-please](https://jenkins.cilium.io/job/Cilium-PR-Doc-Tests/1921/console) command/build.

This change locks PyEnchant at 2.0.0 for the time being until there's a
reason to figure out the dependency problems. The root cause isn't
obvious, PyEnchant claims `The 'enchant' C library was not found` but
it is being installed by `apk` in the container. Potentially file
locations have changed in a newer version of the C library and newer
PyEnchant expects new locations.

[PR inspiring this fix](https://github.com/cilium/cilium/pull/10416)

Related: #10391

Signed-off-by: Joshua Roppo <joshroppo@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10419)
<!-- Reviewable:end -->
