### PR TITLE
CI: Upgrade test on GKE

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -86,7 +86,7 @@ var (
 	defaultHelmOptions = map[string]string{
 		"global.registry":               "k8s1:5000/cilium",
 		"agent.image":                   "cilium-dev",
-		"preflight.image":               "cilium-dev",
+		"preflight.image":               "cilium-dev", // Set again in init to match agent.image!
 		"global.tag":                    "latest",
 		"operator.image":                "operator",
 		"managed-etcd.registry":         "docker.io/cilium",
@@ -182,6 +182,9 @@ func init() {
 			defaultHelmOptions[helmVar] = v
 		}
 	}
+
+	// preflight must match the cilium agent image (that's the point)
+	defaultHelmOptions["preflight.image"] = defaultHelmOptions["agent.image"]
 }
 
 // GetCurrentK8SEnv returns the value of K8S_VERSION from the OS environment.

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -158,6 +158,19 @@ func HelmOverride(option string) string {
 }
 
 func init() {
+	// Set defaults to match passed-in fully-qualified image
+	// If these are further set via CLI, they will be overwritten below
+	if v := os.Getenv("agent.image"); v != "" {
+		registry, image, version, isFullyQualified := SplitContainerURL(v)
+		if isFullyQualified {
+			defaultHelmOptions["global.tag"] = version
+			// This always works because SplitContainerURL would not return
+			// isFullyQualified == true otherwise
+			parts := strings.SplitN(image, "/", 1)
+			defaultHelmOptions["global.registry"] = registry + "/" + parts[0]
+		}
+	}
+
 	// Copy over envronment variables that are passed in.
 	for envVar, helmVar := range map[string]string{
 		"CILIUM_REGISTRY":       "global.registry",

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1400,6 +1400,13 @@ func addIfNotOverwritten(options map[string]string, field, value string) map[str
 }
 
 func (kub *Kubectl) overwriteHelmOptions(options map[string]string) error {
+	if integration := GetCurrentIntegration(); integration != "" {
+		overrides := helmOverrides[integration]
+		for key, value := range overrides {
+			options = addIfNotOverwritten(options, key, value)
+		}
+
+	}
 	for key, value := range defaultHelmOptions {
 		options = addIfNotOverwritten(options, key, value)
 	}
@@ -1438,12 +1445,6 @@ func (kub *Kubectl) overwriteHelmOptions(options map[string]string) error {
 		}
 	}
 
-	if integration := GetCurrentIntegration(); integration != "" {
-		overrides := helmOverrides[integration]
-		for k, v := range overrides {
-			options[k] = v
-		}
-	}
 	return nil
 }
 

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -24,6 +24,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -494,4 +495,35 @@ func DoesNotExistNodeWithoutCilium() bool {
 // GetNodeWithoutCilium returns a name of a node which does not run cilium.
 func GetNodeWithoutCilium() string {
 	return os.Getenv("NO_CILIUM_ON_NODE")
+}
+
+// ContainerURLRE matches and splits container image URLs. The protocol and tag
+// are optional.
+// Note: The groups can be simplified but that is less readable.
+// Group #    Contains
+//    1       http protocol
+//    2       registry domain
+//    3       registry path
+//    4       - tag w/ ":"
+//    5       tag
+var containerURLRE = regexp.MustCompile(`(https?://)?([^/]+)/([^:]+)(:(.+))?`)
+
+// SplitContainerURL returns url split into the registry (with protocol), image
+// path and tag.
+// If this split is successful success is true.
+// Note: tag may be empty when not present. success is true in this case.
+func SplitContainerURL(url string) (registry, image, tag string, success bool) {
+	parts := containerURLRE.FindStringSubmatch(url)
+	if parts == nil {
+		return "", "", "", false
+	}
+
+	registryProto := parts[1]
+	registryDomain := parts[2]
+	registry = registryProto + registryDomain
+
+	image = parts[3]
+	tag = parts[5]
+
+	return registry, image, tag, true
 }

--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -377,7 +377,6 @@ var _ = Describe("NightlyExamples", func() {
 			l7Policy = helpers.ManifestGet(kubectl.BasePath(), "l7-policy.yaml")
 			migrateSVCClient = helpers.ManifestGet(kubectl.BasePath(), "migrate-svc-client.yaml")
 			migrateSVCServer = helpers.ManifestGet(kubectl.BasePath(), "migrate-svc-server.yaml")
-			_ = kubectl.Delete(helpers.DNSDeployment(kubectl.BasePath()))
 
 			kubectl.Delete(migrateSVCClient)
 			kubectl.Delete(migrateSVCServer)

--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -147,6 +147,7 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldHelmChartVers
 		_ = kubectl.ExecMiddle(fmt.Sprintf("kubectl delete daemonset --namespace=%s cilium", helpers.CiliumNamespace))
 		_ = kubectl.ExecMiddle(fmt.Sprintf("kubectl delete deployment --namespace=%s cilium-operator", helpers.CiliumNamespace))
 		_ = kubectl.ExecMiddle("kubectl delete podsecuritypolicy cilium-psp cilium-operator-psp")
+		_ = kubectl.ExecMiddle(fmt.Sprintf("kubectl delete daemonset --namespace=%s cilium-node-init", helpers.CiliumNamespace))
 		ExpectAllPodsTerminated(kubectl)
 		opts := map[string]string{
 			"global.cleanState":    "true",
@@ -380,11 +381,12 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldHelmChartVers
 			newHelmChartVersion,
 			helpers.CiliumNamespace,
 			map[string]string{
-				"preflight.enabled": "true ",
-				"agent.enabled":     "false ",
-				"config.enabled":    "false ",
-				"operator.enabled":  "false ",
-				"global.tag":        newImageVersion,
+				"preflight.enabled":       "true ",
+				"agent.enabled":           "false ",
+				"config.enabled":          "false ",
+				"operator.enabled":        "false ",
+				"global.tag":              newImageVersion,
+				"global.nodeinit.enabled": "false",
 			},
 		)
 		ExpectWithOffset(1, err).To(BeNil(), "Unable to deploy preflight manifest")

--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -138,6 +138,7 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldHelmChartVers
 	app1Service := "app1-service"
 
 	cleanupCiliumState := func(helmPath, chartVersion, imageName, imageTag, registry string) {
+		_ = kubectl.ExecMiddle("helm delete cilium-preflight --namespace=" + helpers.CiliumNamespace)
 		_ = kubectl.ExecMiddle("helm delete cilium --namespace=" + helpers.CiliumNamespace)
 		_ = kubectl.ExecMiddle(fmt.Sprintf("kubectl delete configmap --namespace=%s cilium-config", helpers.CiliumNamespace))
 		_ = kubectl.ExecMiddle(fmt.Sprintf("kubectl delete serviceaccount --namespace=%s cilium cilium-operator", helpers.CiliumNamespace))
@@ -158,6 +159,7 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldHelmChartVers
 		}
 		if imageName != "" {
 			opts["agent.image"] = imageName
+			opts["preflight.image"] = imageName // preflight must match the target agent image
 		}
 		cmd, err := kubectl.RunHelm(
 			"install",

--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -107,7 +107,11 @@ func DeployCiliumOptionsAndDNS(vm *helpers.Kubectl, ciliumFilename string, optio
 			"Assuming that microk8s already has DNS deployed...",
 			"Use 'microk8s.enable dns' to create deployment"))
 	default:
-		_ = vm.ApplyDefault(helpers.DNSDeployment(vm.BasePath()))
+		vm.ApplyDefault(helpers.DNSDeployment(vm.BasePath()))
+		By("Restarting DNS Pods")
+		if res := vm.DeleteResource("pod", fmt.Sprintf("-n %s -l k8s-app=kube-dns", helpers.KubeSystemNamespace)); !res.WasSuccessful() {
+			log.Warningf("Unable to delete DNS pods: %s", res.OutputPrettyPrint())
+		}
 	}
 
 	switch helpers.GetCurrentIntegration() {


### PR DESCRIPTION
The commits are somewhat independent.
- Prefer helm options passed into RunHelm. This allows overriding the global overrides (e.g. force node-init to off when running preflight).
  - Ensure node-init is off when running preflight in the Update/Upgrade tests
- Parse the agent.image tag and set registry and tag, if they are not otherwise set and .image is a full image URL.
- Ensure preflight.image always matches agent.image. This accounts for overrides of the image.
- Cleanup left-over preflight pods in the Update/Upgrade tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10422)
<!-- Reviewable:end -->
