### PR TITLE
install/kubernetes: re-generate quick-install.yaml

### DIFF
--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -139,6 +139,7 @@ data:
   enable-host-reachable-services: "false"
   enable-external-ips: "false"
   enable-node-port: "false"
+  node-port-mode: "hybrid"
   enable-well-known-identities: "false"
   enable-remote-node-identity: "true"
 
@@ -619,6 +620,7 @@ spec:
           {}
       hostNetwork: true
       restartPolicy: Always
+      priorityClassName: system-cluster-critical
       serviceAccount: cilium-operator
       serviceAccountName: cilium-operator
       volumes:


### PR DESCRIPTION
quick-install.yaml wasn't re-generated after commit b676c4c6c7dd ("Add
priority class to operator deployment") and commit 2ace4f7deee8
("daemon: Replace --enable-dsr with --node-port-mode"). Do so now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10424)
<!-- Reviewable:end -->
