### PR TITLE
docs: fix inconsistent ipv6 usage in getting started docker docs

### DIFF
--- a/Documentation/gettingstarted/docker.rst
+++ b/Documentation/gettingstarted/docker.rst
@@ -115,7 +115,7 @@ named 'cilium-net' for all containers:
 
 ::
 
-    $ docker network create --ipv6 --subnet ::1/112 --driver cilium --ipam-driver cilium cilium-net
+    $ docker network create --driver cilium --ipam-driver cilium cilium-net
 
 
 Step 6: Start an Example Service with Docker


### PR DESCRIPTION
Fixes #10396

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10428)
<!-- Reviewable:end -->
