### PR TITLE
vagrant: Stop provisioning VM if one step fails

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,6 +32,10 @@ END
 end
 
 $bootstrap = <<SCRIPT
+set -o errexit
+set -o nounset
+set -o pipefail
+
 echo "----------------------------------------------------------------"
 export PATH=/home/vagrant/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games
 
@@ -53,12 +57,20 @@ mv bpf-map /usr/bin
 SCRIPT
 
 $build = <<SCRIPT
+set -o errexit
+set -o nounset
+set -o pipefail
+
 export PATH=/home/vagrant/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games
 ~/go/src/github.com/cilium/cilium/common/build.sh
 rm -fr ~/go/bin/cilium*
 SCRIPT
 
 $install = <<SCRIPT
+set -o errexit
+set -o nounset
+set -o pipefail
+
 sudo -E make -C /home/vagrant/go/src/github.com/cilium/cilium/ install
 
 sudo mkdir -p /etc/sysconfig

--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -93,7 +93,11 @@ function write_netcfg_header(){
     filename="${3}"
     cat <<EOF > "${filename}"
 #!/usr/bin/env bash
+set -o errexit
+set -o nounset
+set -o pipefail
 
+K8S=${K8S:-}
 if [ -n "${K8S}" ]; then
     export K8S="1"
 fi
@@ -175,8 +179,9 @@ function write_k8s_header(){
     filename="${2}"
     cat <<EOF > "${filename}"
 #!/usr/bin/env bash
-
-set -e
+set -o errexit
+set -o nounset
+set -o pipefail
 
 # K8s installation
 sudo apt-get -y install curl
@@ -254,6 +259,10 @@ EOF
 
     cat <<EOF > "${filename_2nd_half}"
 #!/usr/bin/env bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
 # K8s installation 2nd half
 k8s_path="/home/vagrant/go/src/github.com/cilium/cilium/contrib/vagrant/scripts"
 export IPV6_EXT="${IPV6_EXT}"


### PR DESCRIPTION
Currently, if for example the build provisioning step of the development Vagrant VM fails, vagrant continues with subsequent steps and ultimately fails to install and start cilium. This pull request updates the `Vagrantfile` and associated scripts to fail early.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10430)
<!-- Reviewable:end -->
