### PR TITLE
daemon: remove deprecated and hidden --sidecar-http-proxy option

### DIFF
--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -569,10 +569,6 @@ func init() {
 	flags.Bool(option.Restore, true, "Restores state, if possible, from previous daemon")
 	option.BindEnv(option.Restore)
 
-	flags.Bool(option.SidecarHTTPProxy, false, "Disable host HTTP proxy, assuming proxies in sidecar containers")
-	flags.MarkHidden(option.SidecarHTTPProxy)
-	option.BindEnv(option.SidecarHTTPProxy)
-
 	flags.String(option.SidecarIstioProxyImage, k8s.DefaultSidecarIstioProxyImageRegexp,
 		"Regular expression matching compatible Istio sidecar istio-proxy container image names")
 	option.BindEnv(option.SidecarIstioProxyImage)
@@ -1042,10 +1038,6 @@ func initEnv(cmd *cobra.Command) {
 		} else {
 			node.SetExternalIPv4(ip)
 		}
-	}
-
-	if option.Config.SidecarHTTPProxy {
-		log.Warn(`"sidecar-http-proxy" flag is deprecated and has no effect`)
 	}
 
 	k8s.SidecarIstioProxyImageRegexp, err = regexp.Compile(option.Config.SidecarIstioProxyImage)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -333,9 +333,6 @@ const (
 	// Restore restores state, if possible, from previous daemon
 	Restore = "restore"
 
-	// SidecarHTTPProxy disable host HTTP proxy, assuming proxies in sidecar containers
-	SidecarHTTPProxy = "sidecar-http-proxy"
-
 	// SidecarIstioProxyImage regular expression matching compatible Istio sidecar istio-proxy container image names
 	SidecarIstioProxyImage = "sidecar-istio-proxy-image"
 
@@ -1194,7 +1191,6 @@ type DaemonConfig struct {
 	PreAllocateMaps             bool
 	IPv6NodeAddr                string
 	IPv4NodeAddr                string
-	SidecarHTTPProxy            bool
 	SidecarIstioProxyImage      string
 	SocketPath                  string
 	TracePayloadlen             int
@@ -2156,7 +2152,6 @@ func (c *DaemonConfig) Populate() {
 	c.DisableEnvoyVersionCheck = viper.GetBool(DisableEnvoyVersionCheck)
 	c.K8sNamespace = viper.GetString(K8sNamespaceName)
 	c.MaxControllerInterval = viper.GetInt(MaxCtrlIntervalName)
-	c.SidecarHTTPProxy = viper.GetBool(SidecarHTTPProxy)
 	c.PolicyQueueSize = sanitizeIntParam(PolicyQueueSize, defaults.PolicyQueueSize)
 	c.EndpointQueueSize = sanitizeIntParam(EndpointQueueSize, defaults.EndpointQueueSize)
 	c.SelectiveRegeneration = viper.GetBool(SelectiveRegeneration)


### PR DESCRIPTION
The `--sidecar-http-proxy` has been hidden and deprecated since Cilium
1.2. Using it has no effect apart from a warning being logged. It's
also hidden and doesn't appear in documentation anymore, so remove it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10432)
<!-- Reviewable:end -->
