### PR TITLE
Remove unused function arguments in bpf programs.

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -273,8 +273,7 @@ ct_recreate6:
 			}
 #endif /* ENABLE_ROUTING */
 			policy_clear_mark(ctx);
-			return ipv6_local_delivery(ctx, l3_off, l4_off, SECLABEL,
-						   ip6, tuple->nexthdr, ep,
+			return ipv6_local_delivery(ctx, l3_off, SECLABEL, ep,
 						   METRIC_EGRESS);
 		}
 	}

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -627,7 +627,7 @@ ct_recreate4:
 			}
 #endif /* ENABLE_ROUTING */
 			policy_clear_mark(ctx);
-			return ipv4_local_delivery(ctx, l3_off, l4_off, SECLABEL,
+			return ipv4_local_delivery(ctx, l3_off, SECLABEL,
 						   ip4, ep, METRIC_EGRESS);
 		}
 	}

--- a/bpf/bpf_netdev.c
+++ b/bpf/bpf_netdev.c
@@ -103,7 +103,7 @@ static __always_inline int handle_ipv6(struct __ctx_buff *ctx,
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
 	union v6addr *dst;
-	int ret, l4_off, l3_off = ETH_HLEN, hdrlen;
+	int ret, l3_off = ETH_HLEN, hdrlen;
 	struct endpoint_info *ep;
 	__u8 nexthdr;
 	__u32 secctx;
@@ -130,8 +130,6 @@ static __always_inline int handle_ipv6(struct __ctx_buff *ctx,
 	hdrlen = ipv6_hdrlen(ctx, l3_off, &nexthdr);
 	if (hdrlen < 0)
 		return hdrlen;
-
-	l4_off = l3_off + hdrlen;
 
 #ifdef HANDLE_NS
 	if (unlikely(nexthdr == IPPROTO_ICMPV6)) {
@@ -185,7 +183,7 @@ static __always_inline int handle_ipv6(struct __ctx_buff *ctx,
 		if (ep->flags & ENDPOINT_F_HOST)
 			return CTX_ACT_OK;
 
-		return ipv6_local_delivery(ctx, l3_off, l4_off, secctx, ip6, nexthdr, ep, METRIC_INGRESS);
+		return ipv6_local_delivery(ctx, l3_off, secctx, ep, METRIC_INGRESS);
 	}
 
 #ifdef ENCAP_IFINDEX

--- a/bpf/bpf_netdev.c
+++ b/bpf/bpf_netdev.c
@@ -277,7 +277,6 @@ static __always_inline int handle_ipv4(struct __ctx_buff *ctx,
 	struct endpoint_info *ep;
 	void *data, *data_end;
 	struct iphdr *ip4;
-	int l4_off;
 	__u32 secctx;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip4))
@@ -302,7 +301,6 @@ static __always_inline int handle_ipv4(struct __ctx_buff *ctx,
 		return DROP_INVALID;
 #endif /* ENABLE_NODEPORT */
 
-	l4_off = ETH_HLEN + ipv4_hdrlen(ip4);
 	secctx = derive_ipv4_sec_ctx(ctx, ip4);
 	tuple.nexthdr = ip4->protocol;
 
@@ -361,7 +359,7 @@ static __always_inline int handle_ipv4(struct __ctx_buff *ctx,
 			return CTX_ACT_OK;
 #endif
 
-		return ipv4_local_delivery(ctx, ETH_HLEN, l4_off, secctx, ip4, ep, METRIC_INGRESS);
+		return ipv4_local_delivery(ctx, ETH_HLEN, secctx, ip4, ep, METRIC_INGRESS);
 	}
 
 #ifdef ENCAP_IFINDEX

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -148,7 +148,6 @@ static __always_inline int handle_ipv4(struct __ctx_buff *ctx, __u32 *identity)
 	struct endpoint_info *ep;
 	struct bpf_tunnel_key key = {};
 	bool decrypted;
-	int l4_off;
 
 	/* verifier workaround (dereference of modified ctx ptr) */
 	if (!revalidate_data_first(ctx, &data, &data_end, &ip4))
@@ -177,7 +176,6 @@ static __always_inline int handle_ipv4(struct __ctx_buff *ctx, __u32 *identity)
 		}
 	}
 
-	l4_off = ETH_HLEN + ipv4_hdrlen(ip4);
 #ifdef ENABLE_IPSEC
 	if (!decrypted) {
 		/* IPSec is not currently enforce (feature coming soon)
@@ -212,7 +210,7 @@ not_esp:
 		if (ep->flags & ENDPOINT_F_HOST)
 			goto to_host;
 
-		return ipv4_local_delivery(ctx, ETH_HLEN, l4_off, key.tunnel_id, ip4, ep, METRIC_INGRESS);
+		return ipv4_local_delivery(ctx, ETH_HLEN, key.tunnel_id, ip4, ep, METRIC_INGRESS);
 	}
 
 to_host:

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -24,7 +24,7 @@
 static __always_inline int handle_ipv6(struct __ctx_buff *ctx,
 				       __u32 *identity)
 {
-	int ret, l4_off, l3_off = ETH_HLEN, hdrlen;
+	int ret, l3_off = ETH_HLEN, hdrlen;
 	void *data_end, *data;
 	struct ipv6hdr *ip6;
 	struct bpf_tunnel_key key = {};
@@ -106,8 +106,7 @@ not_esp:
 		if (hdrlen < 0)
 			return hdrlen;
 
-		l4_off = l3_off + hdrlen;
-		return ipv6_local_delivery(ctx, l3_off, l4_off, key.tunnel_id, ip6, nexthdr, ep, METRIC_INGRESS);
+		return ipv6_local_delivery(ctx, l3_off, key.tunnel_id, ep, METRIC_INGRESS);
 	}
 
 to_host:

--- a/bpf/lib/arp.h
+++ b/bpf/lib/arp.h
@@ -19,7 +19,7 @@ struct arp_eth {
 
 /* Check if packet is ARP request for IP */
 static __always_inline int arp_check(struct ethhdr *eth, struct arphdr *arp,
-				     struct arp_eth *arp_eth, union macaddr *mac)
+				     union macaddr *mac)
 {
 	union macaddr *dmac = (union macaddr *) &eth->h_dest;
 
@@ -63,7 +63,7 @@ static __always_inline int arp_respond(struct __ctx_buff *ctx, union macaddr *ma
 
 	arp_eth = data + ETH_HLEN + sizeof(*arp);
 
-	if (arp_check(eth, arp, arp_eth, mac)) {
+	if (arp_check(eth, arp, mac)) {
 		__be32 target_ip = arp_eth->ar_tip;
 		ret = arp_prepare_response(ctx, eth, arp_eth, target_ip, mac);
 		if (unlikely(ret != 0))

--- a/bpf/lib/l3.h
+++ b/bpf/lib/l3.h
@@ -58,8 +58,7 @@ static __always_inline int ipv4_l3(struct __ctx_buff *ctx, int l3_off,
 
 #ifdef ENABLE_IPV6
 static __always_inline int ipv6_local_delivery(struct __ctx_buff *ctx, int l3_off,
-					       int l4_off, __u32 seclabel,
-					       struct ipv6hdr *ip6, __u8 nexthdr,
+					       __u32 seclabel,
 					       struct endpoint_info *ep,
 					       __u8 direction)
 {

--- a/bpf/lib/l3.h
+++ b/bpf/lib/l3.h
@@ -95,7 +95,7 @@ static __always_inline int ipv6_local_delivery(struct __ctx_buff *ctx, int l3_of
 }
 #endif /* ENABLE_IPV6 */
 
-static __always_inline int ipv4_local_delivery(struct __ctx_buff *ctx, int l3_off, int l4_off,
+static __always_inline int ipv4_local_delivery(struct __ctx_buff *ctx, int l3_off,
 					       __u32 seclabel, struct iphdr *ip4,
 					       struct endpoint_info *ep, __u8 direction)
 {

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -387,12 +387,11 @@ struct lb6_service *lb6_lookup_slave(struct __ctx_buff *ctx,
 }
 
 static __always_inline int lb6_xlate(struct __ctx_buff *ctx,
-				     union v6addr *new_dst, __u8 nexthdr,
+				     union v6addr *new_dst, __u8 nexthdr __maybe_unused,
 				     int l3_off, int l4_off,
 				     struct csum_offset *csum_off,
 				     struct lb6_key *key,
-				     struct lb6_service *svc,
-				     struct lb6_backend *backend)
+				     struct lb6_backend *backend __maybe_unused)
 {
 	ipv6_store_daddr(ctx, new_dst->addr, l3_off);
 
@@ -514,7 +513,7 @@ update_state:
 	state->rev_nat_index = svc->rev_nat_index;
 
 	return lb6_xlate(ctx, addr, tuple->nexthdr, l3_off, l4_off,
-			 csum_off, key, svc, backend);
+			 csum_off, key, backend);
 
 drop_no_service:
 	tuple->flags = flags;

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -756,9 +756,10 @@ struct lb4_service *lb4_lookup_slave(struct __ctx_buff *ctx,
 
 static __always_inline int
 lb4_xlate(struct __ctx_buff *ctx, __be32 *new_daddr, __be32 *new_saddr,
-	     __be32 *old_saddr, __u8 nexthdr, int l3_off, int l4_off,
+	     __be32 *old_saddr, __u8 nexthdr __maybe_unused,
+	     int l3_off, int l4_off,
 	     struct csum_offset *csum_off, struct lb4_key *key,
-	     struct lb4_service *svc, struct lb4_backend *backend)
+	     struct lb4_backend *backend __maybe_unused)
 {
 	int ret;
 	__be32 sum;
@@ -923,7 +924,7 @@ update_state:
 
 	return lb4_xlate(ctx, &new_daddr, &new_saddr, &saddr,
 			 tuple->nexthdr, l3_off, l4_off, csum_off, key,
-			 svc, backend);
+			 backend);
 
 drop_no_service:
 		tuple->flags = flags;

--- a/bpf/lib/policy.h
+++ b/bpf/lib/policy.h
@@ -197,8 +197,7 @@ policy_can_access_ingress(struct __ctx_buff *ctx, __u32 src_identity,
 }
 
 #ifdef ENCAP_IFINDEX
-static __always_inline bool
-is_encap(struct __ctx_buff *ctx, __u16 dport, __u8 proto)
+static __always_inline bool is_encap(__u16 dport, __u8 proto)
 {
 	return proto == IPPROTO_UDP &&
 		(dport == bpf_htons(PORT_UDP_VXLAN) ||
@@ -212,7 +211,7 @@ policy_can_egress(struct __ctx_buff *ctx, __u32 identity, __u16 dport, __u8 prot
 		  __u8 *match_type)
 {
 #ifdef ENCAP_IFINDEX
-	if (is_encap(ctx, dport, proto))
+	if (is_encap(dport, proto))
 		return DROP_ENCAP_PROHIBITED;
 #endif
 


### PR DESCRIPTION
Remove various unused function arguments in bpf programs. This saves a few bytes in the resulting object file. Found by adding `-Wunused-parameters` and `-Wextra` to `CFLAGS` (not yet enabled in this PR though, as there are other issues).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10433)
<!-- Reviewable:end -->
