### PR TITLE
v1.5 docs target fix

### DIFF
--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -8,6 +8,7 @@ imagesize==1.1.0
 Jinja2==2.10.1
 jsonschema==2.6.0
 MarkupSafe==1.0
+pyenchant==2.0.0
 Pygments==2.2.0
 pytz==2018.7
 PyYAML==4.2b1


### PR DESCRIPTION
* #10419 -- Documentation: Lock dependency to fix build (@Ropes)

Needed minor rebase but the end-resulting added lines were identical to upstream.

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 10419; do contrib/backporting/set-labels.py $pr done 1.5; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10439)
<!-- Reviewable:end -->
