### PR TITLE
maps/ctmap: unexport NewMap, MapType type and related consts

### DIFF
--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -54,7 +54,7 @@ var (
 		metrics.LabelDatapathFamily: "ipv4",
 	}
 
-	mapInfo = make(map[MapType]mapAttributes)
+	mapInfo = make(map[mapType]mapAttributes)
 )
 
 const (
@@ -76,7 +76,7 @@ const (
 	MapNameAny6Global = MapNameAny6 + "global"
 	MapNameAny4Global = MapNameAny4 + "global"
 
-	MapNumEntriesLocal = 64000
+	mapNumEntriesLocal = 64000
 
 	TUPLE_F_OUT     = 0
 	TUPLE_F_IN      = 1
@@ -93,7 +93,7 @@ const (
 	metricsDeleted = "deleted"
 )
 
-var globalDeleteLock [MapTypeMax]lock.Mutex
+var globalDeleteLock [mapTypeMax]lock.Mutex
 
 type NatMap interface {
 	Open() error
@@ -112,8 +112,8 @@ type mapAttributes struct {
 	natMap     NatMap
 }
 
-func setupMapInfo(mapType MapType, define string, mapKey bpf.MapKey, keySize int, maxEntries int, nat NatMap) {
-	mapInfo[mapType] = mapAttributes{
+func setupMapInfo(m mapType, define string, mapKey bpf.MapKey, keySize int, maxEntries int, nat NatMap) {
+	mapInfo[m] = mapAttributes{
 		bpfDefine: define,
 		mapKey:    mapKey,
 		keySize:   keySize,
@@ -130,53 +130,53 @@ func setupMapInfo(mapType MapType, define string, mapKey bpf.MapKey, keySize int
 // combination of L3/L4 protocols, using the specified limits on TCP vs non-TCP
 // maps.
 func InitMapInfo(tcpMaxEntries, anyMaxEntries int, v4, v6 bool) {
-	mapInfo = make(map[MapType]mapAttributes)
+	mapInfo = make(map[mapType]mapAttributes)
 
 	global4Map, global6Map := nat.GlobalMaps(v4, v6)
 
 	// SNAT also only works if the CT map is global so all local maps will be nil
-	natMaps := map[MapType]NatMap{
-		MapTypeIPv4TCPLocal:  nil,
-		MapTypeIPv6TCPLocal:  nil,
-		MapTypeIPv4TCPGlobal: global4Map,
-		MapTypeIPv6TCPGlobal: global6Map,
-		MapTypeIPv4AnyLocal:  nil,
-		MapTypeIPv6AnyLocal:  nil,
-		MapTypeIPv4AnyGlobal: global4Map,
-		MapTypeIPv6AnyGlobal: global6Map,
+	natMaps := map[mapType]NatMap{
+		mapTypeIPv4TCPLocal:  nil,
+		mapTypeIPv6TCPLocal:  nil,
+		mapTypeIPv4TCPGlobal: global4Map,
+		mapTypeIPv6TCPGlobal: global6Map,
+		mapTypeIPv4AnyLocal:  nil,
+		mapTypeIPv6AnyLocal:  nil,
+		mapTypeIPv4AnyGlobal: global4Map,
+		mapTypeIPv6AnyGlobal: global6Map,
 	}
 
-	setupMapInfo(MapTypeIPv4TCPLocal, "CT_MAP_TCP4",
+	setupMapInfo(mapTypeIPv4TCPLocal, "CT_MAP_TCP4",
 		&CtKey4{}, int(unsafe.Sizeof(CtKey4{})),
-		MapNumEntriesLocal, natMaps[MapTypeIPv4TCPLocal])
+		mapNumEntriesLocal, natMaps[mapTypeIPv4TCPLocal])
 
-	setupMapInfo(MapTypeIPv6TCPLocal, "CT_MAP_TCP6",
+	setupMapInfo(mapTypeIPv6TCPLocal, "CT_MAP_TCP6",
 		&CtKey6{}, int(unsafe.Sizeof(CtKey6{})),
-		MapNumEntriesLocal, natMaps[MapTypeIPv6TCPLocal])
+		mapNumEntriesLocal, natMaps[mapTypeIPv6TCPLocal])
 
-	setupMapInfo(MapTypeIPv4TCPGlobal, "CT_MAP_TCP4",
+	setupMapInfo(mapTypeIPv4TCPGlobal, "CT_MAP_TCP4",
 		&CtKey4Global{}, int(unsafe.Sizeof(CtKey4Global{})),
-		tcpMaxEntries, natMaps[MapTypeIPv4TCPGlobal])
+		tcpMaxEntries, natMaps[mapTypeIPv4TCPGlobal])
 
-	setupMapInfo(MapTypeIPv6TCPGlobal, "CT_MAP_TCP6",
+	setupMapInfo(mapTypeIPv6TCPGlobal, "CT_MAP_TCP6",
 		&CtKey6Global{}, int(unsafe.Sizeof(CtKey6Global{})),
-		tcpMaxEntries, natMaps[MapTypeIPv6TCPGlobal])
+		tcpMaxEntries, natMaps[mapTypeIPv6TCPGlobal])
 
-	setupMapInfo(MapTypeIPv4AnyLocal, "CT_MAP_ANY4",
+	setupMapInfo(mapTypeIPv4AnyLocal, "CT_MAP_ANY4",
 		&CtKey4{}, int(unsafe.Sizeof(CtKey4{})),
-		MapNumEntriesLocal, natMaps[MapTypeIPv4AnyLocal])
+		mapNumEntriesLocal, natMaps[mapTypeIPv4AnyLocal])
 
-	setupMapInfo(MapTypeIPv6AnyLocal, "CT_MAP_ANY6",
+	setupMapInfo(mapTypeIPv6AnyLocal, "CT_MAP_ANY6",
 		&CtKey6{}, int(unsafe.Sizeof(CtKey6{})),
-		MapNumEntriesLocal, natMaps[MapTypeIPv6AnyLocal])
+		mapNumEntriesLocal, natMaps[mapTypeIPv6AnyLocal])
 
-	setupMapInfo(MapTypeIPv4AnyGlobal, "CT_MAP_ANY4",
+	setupMapInfo(mapTypeIPv4AnyGlobal, "CT_MAP_ANY4",
 		&CtKey4Global{}, int(unsafe.Sizeof(CtKey4Global{})),
-		anyMaxEntries, natMaps[MapTypeIPv4AnyGlobal])
+		anyMaxEntries, natMaps[mapTypeIPv4AnyGlobal])
 
-	setupMapInfo(MapTypeIPv6AnyGlobal, "CT_MAP_ANY6",
+	setupMapInfo(mapTypeIPv6AnyGlobal, "CT_MAP_ANY6",
 		&CtKey6Global{}, int(unsafe.Sizeof(CtKey6Global{})),
-		anyMaxEntries, natMaps[MapTypeIPv6AnyGlobal])
+		anyMaxEntries, natMaps[mapTypeIPv6AnyGlobal])
 }
 
 func init() {
@@ -193,7 +193,7 @@ type CtEndpoint interface {
 type Map struct {
 	bpf.Map
 
-	mapType MapType
+	mapType mapType
 	// define maps to the macro used in the datapath portion for the map
 	// name, for example 'CT_MAP4'.
 	define string
@@ -247,21 +247,21 @@ func (m *Map) DumpEntries() (string, error) {
 	return buffer.String(), err
 }
 
-// NewMap creates a new CT map of the specified type with the specified name.
-func NewMap(mapName string, mapType MapType) *Map {
+// newMap creates a new CT map of the specified type with the specified name.
+func newMap(mapName string, m mapType) *Map {
 	result := &Map{
 		Map: *bpf.NewMap(mapName,
 			bpf.MapTypeLRUHash,
-			mapInfo[mapType].mapKey,
-			mapInfo[mapType].keySize,
-			mapInfo[mapType].mapValue,
-			mapInfo[mapType].valueSize,
-			mapInfo[mapType].maxEntries,
+			mapInfo[m].mapKey,
+			mapInfo[m].keySize,
+			mapInfo[m].mapValue,
+			mapInfo[m].valueSize,
+			mapInfo[m].maxEntries,
 			0, 0,
-			mapInfo[mapType].parser,
+			mapInfo[m].parser,
 		),
-		mapType: mapType,
-		define:  mapInfo[mapType].bpfDefine,
+		mapType: m,
+		define:  mapInfo[m].bpfDefine,
 	}
 	return result
 }
@@ -529,25 +529,25 @@ func maps(e CtEndpoint, ipv4, ipv6 bool) []*Map {
 	result := make([]*Map, 0, mapCount)
 	if e == nil {
 		if ipv4 {
-			result = append(result, NewMap(MapNameTCP4Global, MapTypeIPv4TCPGlobal))
-			result = append(result, NewMap(MapNameAny4Global, MapTypeIPv4AnyGlobal))
+			result = append(result, newMap(MapNameTCP4Global, mapTypeIPv4TCPGlobal))
+			result = append(result, newMap(MapNameAny4Global, mapTypeIPv4AnyGlobal))
 		}
 		if ipv6 {
-			result = append(result, NewMap(MapNameTCP6Global, MapTypeIPv6TCPGlobal))
-			result = append(result, NewMap(MapNameAny6Global, MapTypeIPv6AnyGlobal))
+			result = append(result, newMap(MapNameTCP6Global, mapTypeIPv6TCPGlobal))
+			result = append(result, newMap(MapNameAny6Global, mapTypeIPv6AnyGlobal))
 		}
 	} else {
 		if ipv4 {
-			result = append(result, NewMap(bpf.LocalMapName(MapNameTCP4, uint16(e.GetID())),
-				MapTypeIPv4TCPLocal))
-			result = append(result, NewMap(bpf.LocalMapName(MapNameAny4, uint16(e.GetID())),
-				MapTypeIPv4AnyLocal))
+			result = append(result, newMap(bpf.LocalMapName(MapNameTCP4, uint16(e.GetID())),
+				mapTypeIPv4TCPLocal))
+			result = append(result, newMap(bpf.LocalMapName(MapNameAny4, uint16(e.GetID())),
+				mapTypeIPv4AnyLocal))
 		}
 		if ipv6 {
-			result = append(result, NewMap(bpf.LocalMapName(MapNameTCP6, uint16(e.GetID())),
-				MapTypeIPv6TCPLocal))
-			result = append(result, NewMap(bpf.LocalMapName(MapNameAny6, uint16(e.GetID())),
-				MapTypeIPv6AnyLocal))
+			result = append(result, newMap(bpf.LocalMapName(MapNameTCP6, uint16(e.GetID())),
+				mapTypeIPv6TCPLocal))
+			result = append(result, newMap(bpf.LocalMapName(MapNameAny6, uint16(e.GetID())),
+				mapTypeIPv6AnyLocal))
 		}
 	}
 	return result

--- a/pkg/maps/ctmap/ctmap_privileged_test.go
+++ b/pkg/maps/ctmap/ctmap_privileged_test.go
@@ -38,7 +38,7 @@ func Test(t *testing.T) {
 }
 
 func (k *CTMapTestSuite) Benchmark_MapUpdate(c *C) {
-	m := NewMap(MapNameTCP4Global+"_test", MapTypeIPv4TCPGlobal)
+	m := newMap(MapNameTCP4Global+"_test", mapTypeIPv4TCPGlobal)
 	_, err := m.OpenOrCreate()
 	defer m.Map.Unpin()
 	c.Assert(err, IsNil)

--- a/pkg/maps/ctmap/ctmap_test.go
+++ b/pkg/maps/ctmap/ctmap_test.go
@@ -41,7 +41,7 @@ func Test(t *testing.T) {
 
 func (t *CTMapTestSuite) TestInit(c *C) {
 	InitMapInfo(option.CTMapEntriesGlobalTCPDefault, option.CTMapEntriesGlobalAnyDefault, true, true)
-	for mapType := MapType(0); mapType < MapTypeMax; mapType++ {
+	for mapType := mapType(0); mapType < mapTypeMax; mapType++ {
 		info := mapInfo[mapType]
 		if mapType.isIPv6() {
 			c.Assert(info.keySize, Equals, int(unsafe.Sizeof(tuple.TupleKey6{})))
@@ -57,7 +57,7 @@ func (t *CTMapTestSuite) TestInit(c *C) {
 			c.Assert(strings.Contains(info.bpfDefine, "ANY"), Equals, true)
 		}
 		if mapType.isLocal() {
-			c.Assert(info.maxEntries, Equals, MapNumEntriesLocal)
+			c.Assert(info.maxEntries, Equals, mapNumEntriesLocal)
 		}
 		if mapType.isGlobal() {
 			if mapType.isTCP() {

--- a/pkg/maps/ctmap/types.go
+++ b/pkg/maps/ctmap/types.go
@@ -24,84 +24,84 @@ import (
 	"github.com/cilium/cilium/pkg/tuple"
 )
 
+// mapType is a type of connection tracking map.
+type mapType int
+
 const (
-	// MapTypeIPv4TCPLocal and friends are MapTypes which correspond to a
+	// mapTypeIPv4TCPLocal and friends are map types which correspond to a
 	// combination of the following attributes:
 	// * IPv4 or IPv6;
 	// * TCP or non-TCP (shortened to Any)
 	// * Local (endpoint-specific) or global (endpoint-oblivious).
-	MapTypeIPv4TCPLocal = iota
-	MapTypeIPv6TCPLocal
-	MapTypeIPv4TCPGlobal
-	MapTypeIPv6TCPGlobal
-	MapTypeIPv4AnyLocal
-	MapTypeIPv6AnyLocal
-	MapTypeIPv4AnyGlobal
-	MapTypeIPv6AnyGlobal
-	MapTypeMax
+	mapTypeIPv4TCPLocal mapType = iota
+	mapTypeIPv6TCPLocal
+	mapTypeIPv4TCPGlobal
+	mapTypeIPv6TCPGlobal
+	mapTypeIPv4AnyLocal
+	mapTypeIPv6AnyLocal
+	mapTypeIPv4AnyGlobal
+	mapTypeIPv6AnyGlobal
+	mapTypeMax
 )
 
-// MapType is a type of connection tracking map.
-type MapType int
-
 // String renders the map type into a user-readable string.
-func (m MapType) String() string {
+func (m mapType) String() string {
 	switch m {
-	case MapTypeIPv4TCPLocal:
+	case mapTypeIPv4TCPLocal:
 		return "Local IPv4 TCP CT map"
-	case MapTypeIPv6TCPLocal:
+	case mapTypeIPv6TCPLocal:
 		return "Local IPv6 TCP CT map"
-	case MapTypeIPv4TCPGlobal:
+	case mapTypeIPv4TCPGlobal:
 		return "Global IPv4 TCP CT map"
-	case MapTypeIPv6TCPGlobal:
+	case mapTypeIPv6TCPGlobal:
 		return "Global IPv6 TCP CT map"
-	case MapTypeIPv4AnyLocal:
+	case mapTypeIPv4AnyLocal:
 		return "Local IPv4 non-TCP CT map"
-	case MapTypeIPv6AnyLocal:
+	case mapTypeIPv6AnyLocal:
 		return "Local IPv6 non-TCP CT map"
-	case MapTypeIPv4AnyGlobal:
+	case mapTypeIPv4AnyGlobal:
 		return "Global IPv4 non-TCP CT map"
-	case MapTypeIPv6AnyGlobal:
+	case mapTypeIPv6AnyGlobal:
 		return "Global IPv6 non-TCP CT map"
 	}
 	return fmt.Sprintf("Unknown (%d)", int(m))
 }
 
-func (m MapType) isIPv4() bool {
+func (m mapType) isIPv4() bool {
 	switch m {
-	case MapTypeIPv4TCPLocal, MapTypeIPv4TCPGlobal, MapTypeIPv4AnyLocal, MapTypeIPv4AnyGlobal:
+	case mapTypeIPv4TCPLocal, mapTypeIPv4TCPGlobal, mapTypeIPv4AnyLocal, mapTypeIPv4AnyGlobal:
 		return true
 	}
 	return false
 }
 
-func (m MapType) isIPv6() bool {
+func (m mapType) isIPv6() bool {
 	switch m {
-	case MapTypeIPv6TCPLocal, MapTypeIPv6TCPGlobal, MapTypeIPv6AnyLocal, MapTypeIPv6AnyGlobal:
+	case mapTypeIPv6TCPLocal, mapTypeIPv6TCPGlobal, mapTypeIPv6AnyLocal, mapTypeIPv6AnyGlobal:
 		return true
 	}
 	return false
 }
 
-func (m MapType) isLocal() bool {
+func (m mapType) isLocal() bool {
 	switch m {
-	case MapTypeIPv4TCPLocal, MapTypeIPv6TCPLocal, MapTypeIPv4AnyLocal, MapTypeIPv6AnyLocal:
+	case mapTypeIPv4TCPLocal, mapTypeIPv6TCPLocal, mapTypeIPv4AnyLocal, mapTypeIPv6AnyLocal:
 		return true
 	}
 	return false
 }
 
-func (m MapType) isGlobal() bool {
+func (m mapType) isGlobal() bool {
 	switch m {
-	case MapTypeIPv4TCPGlobal, MapTypeIPv6TCPGlobal, MapTypeIPv4AnyGlobal, MapTypeIPv6AnyGlobal:
+	case mapTypeIPv4TCPGlobal, mapTypeIPv6TCPGlobal, mapTypeIPv4AnyGlobal, mapTypeIPv6AnyGlobal:
 		return true
 	}
 	return false
 }
 
-func (m MapType) isTCP() bool {
+func (m mapType) isTCP() bool {
 	switch m {
-	case MapTypeIPv4TCPLocal, MapTypeIPv6TCPLocal, MapTypeIPv4TCPGlobal, MapTypeIPv6TCPGlobal:
+	case mapTypeIPv4TCPLocal, mapTypeIPv6TCPLocal, mapTypeIPv4TCPGlobal, mapTypeIPv6TCPGlobal:
 		return true
 	}
 	return false


### PR DESCRIPTION
All of these are not used outside the `ctmap` package.

Also make the `mapTypeIP*` consts typed to avoid type conversions when
using them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10440)
<!-- Reviewable:end -->
