### PR TITLE
v1.6 backports 2020-03-04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:9e8d7bb5e02d6038d6cf0ec3f28bf4019f3c7d79 as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:63de0bd958d05d82e2396125dcf6286d92464c56 as cilium-envoy
 
 #
 # Cilium incremental build. Should be fast given builder-deps is up-to-date!

--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -374,37 +374,37 @@ Upgrading from >=1.4.0 to 1.5.y
 
         .. parsed-literal::
 
-          $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.10/cilium-pre-flight-with-rm-svc-v2.yaml
+          $ kubectl apply -f https://raw.githubusercontent.com/cilium/cilium/v1.5/examples/kubernetes/1.10/cilium-pre-flight-with-rm-svc-v2.yaml
 
       .. group-tab:: K8s 1.11
 
         .. parsed-literal::
 
-          $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.11/cilium-pre-flight-with-rm-svc-v2.yaml
+          $ kubectl apply -f https://raw.githubusercontent.com/cilium/cilium/v1.5/examples/kubernetes/1.11/cilium-pre-flight-with-rm-svc-v2.yaml
 
       .. group-tab:: K8s 1.12
 
         .. parsed-literal::
 
-          $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.12/cilium-pre-flight-with-rm-svc-v2.yaml
+          $ kubectl apply -f https://raw.githubusercontent.com/cilium/cilium/v1.5/examples/kubernetes/1.12/cilium-pre-flight-with-rm-svc-v2.yaml
 
       .. group-tab:: K8s 1.13
 
         .. parsed-literal::
 
-          $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.13/cilium-pre-flight-with-rm-svc-v2.yaml
+          $ kubectl apply -f https://raw.githubusercontent.com/cilium/cilium/v1.5/examples/kubernetes/1.13/cilium-pre-flight-with-rm-svc-v2.yaml
 
       .. group-tab:: K8s 1.14
 
         .. parsed-literal::
 
-          $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.14/cilium-pre-flight-with-rm-svc-v2.yaml
+          $ kubectl apply -f https://raw.githubusercontent.com/cilium/cilium/v1.5/examples/kubernetes/1.14/cilium-pre-flight-with-rm-svc-v2.yaml
 
       .. group-tab:: K8s 1.15
 
         .. parsed-literal::
 
-          $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/1.15/cilium-pre-flight-with-rm-svc-v2.yaml
+          $ kubectl apply -f https://raw.githubusercontent.com/cilium/cilium/v1.5/examples/kubernetes/1.15/cilium-pre-flight-with-rm-svc-v2.yaml
 
 
    See :ref:`pre_flight` for instructions how to run, validate and remove

--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -329,11 +329,15 @@ func (c *DNSCache) UpdateFromCache(update *DNSCache, namesToUpdate []string) {
 		return
 	}
 
+	c.Lock()
+	defer c.Unlock()
+	c.updateFromCache(update, namesToUpdate)
+}
+
+func (c *DNSCache) updateFromCache(update *DNSCache, namesToUpdate []string) {
 	update.RLock()
 	defer update.RUnlock()
 
-	c.Lock()
-	defer c.Unlock()
 	if len(namesToUpdate) == 0 {
 		for name := range update.forward {
 			namesToUpdate = append(namesToUpdate, name)
@@ -347,6 +351,23 @@ func (c *DNSCache) UpdateFromCache(update *DNSCache, namesToUpdate []string) {
 		for _, newEntry := range newEntries {
 			c.updateWithEntry(newEntry)
 		}
+	}
+}
+
+// ReplaceFromCacheByNames operates as an atomic combination of ForceExpire and
+// multiple UpdateFromCache invocations. The result is to collect all entries
+// for DNS names in namesToUpdate from each DNSCache in updates, replacing the
+// current entries for each of those names.
+func (c *DNSCache) ReplaceFromCacheByNames(namesToUpdate []string, updates ...*DNSCache) {
+	c.Lock()
+	defer c.Unlock()
+
+	// Remove any DNS name in namesToUpdate with a lookup before "now". This
+	// effectively deletes all lookups because we're holding the lock.
+	c.forceExpireByNames(time.Now(), namesToUpdate)
+
+	for _, update := range updates {
+		c.updateFromCache(update, namesToUpdate)
 	}
 }
 
@@ -532,6 +553,11 @@ func (c *DNSCache) ForceExpire(expireLookupsBefore time.Time, nameMatch *regexp.
 func (c *DNSCache) ForceExpireByNames(expireLookupsBefore time.Time, names []string) (namesAffected []string) {
 	c.Lock()
 	defer c.Unlock()
+
+	return c.forceExpireByNames(expireLookupsBefore, names)
+}
+
+func (c *DNSCache) forceExpireByNames(expireLookupsBefore time.Time, names []string) (namesAffected []string) {
 	for _, name := range names {
 		entries, exists := c.forward[name]
 		if !exists {


### PR DESCRIPTION
 * #9483 -- fqdn: Avoid races when updating global cache on GC (@raybejjani)
 * #10416 -- Fix dead link in 1.4->1.5 upgrade documentation (@Ropes)
 * #10434 -- Envoy: Apply CVE fixes 2020-03-03 (@jrajahalme)

*Not backported as these depend on other changes not backported to v1.6:*
 * #10218 -- cilium: encryption + tunnel improvements and fixes (@jrfastab)
 * #10268 -- cilium: encryption, segfaults if existing non-Cilium xfrm policy without mark set exists (@jrfastab)
 * #10388 -- test: Avoid using global map for Cilium configuration (@brb)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 9483 10416 10434; do contrib/backporting/set-labels.py $pr done 1.6; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10443)
<!-- Reviewable:end -->
