### PR TITLE
v1.5 backports 2020-03-04

### DIFF
--- a/.github/cilium-actions.yml
+++ b/.github/cilium-actions.yml
@@ -5,7 +5,7 @@ auto-label:
   - "backport/1.5"
 require-msgs-in-commit:
   - msg: "Signed-off-by"
-    helper: "https://docs.cilium.io/en/stable/contributing/contributing/#developer-s-certificate-of-origin"
+    helper: "https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#developer-s-certificate-of-origin"
     set-labels:
       - "dont-merge/needs-sign-off"
 block-pr-with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:9e8d7bb5e02d6038d6cf0ec3f28bf4019f3c7d79 as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:63de0bd958d05d82e2396125dcf6286d92464c56 as cilium-envoy
 
 #
 # Cilium incremental build. Should be fast given builder-deps is up-to-date!

--- a/README.rst
+++ b/README.rst
@@ -281,7 +281,7 @@ under the `General Public License, Version 2.0 <bpf/COPYING>`_.
 .. _`Architecture and Concepts`: http://docs.cilium.io/en/stable/concepts/
 .. _`Installing Cilium`: http://docs.cilium.io/en/stable/install/guides/
 .. _`Frequently Asked Questions`: https://github.com/cilium/cilium/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3Akind%2Fquestion+
-.. _Contributing: http://docs.cilium.io/en/stable/contributing
+.. _Contributing: http://docs.cilium.io/en/stable/contributing/development/
 .. _Prerequisites: http://docs.cilium.io/en/doc-1.0/install/system_requirements
 .. _`BPF and XDP Reference Guide`: http://docs.cilium.io/en/stable/bpf/
 

--- a/contrib/backporting/check-stable
+++ b/contrib/backporting/check-stable
@@ -152,7 +152,7 @@ generate_commit_list_for_pr () {
     entry_id=${entry_array[0]}
     entry_sha=${entry_array[1]}
     entry_sub=${entry_array[@]:2}
-    upstream="$(git log --since="1year" --pretty="%H" --no-merges --grep "$entry_sub" $REMOTE/master)"
+    upstream="$(git log -F --since="1year" --pretty="%H" --no-merges --grep "$entry_sub" $REMOTE/master)"
     upstream="$(git show $upstream | git patch-id)"
     upstream=($upstream)
     if [ "$entry_id" == "${upstream[0]}" ]; then

--- a/test/k8sT/istio.go
+++ b/test/k8sT/istio.go
@@ -114,10 +114,12 @@ var _ = Describe("K8sIstioTest", func() {
 		By("Deleting the Istio CRDs")
 		_ = kubectl.Delete(istioCRDYAMLPath)
 
+		By("Waiting all terminating PODs to disappear")
+		err := kubectl.WaitCleanAllTerminatingPods(teardownTimeout)
+		ExpectWithOffset(1, err).To(BeNil(), "terminating Istio PODs are not deleted after timeout")
+
 		By("Deleting the istio-system namespace")
 		_ = kubectl.NamespaceDelete(istioSystemNamespace)
-
-		kubectl.WaitCleanAllTerminatingPods(teardownTimeout)
 
 		kubectl.CloseSSHClient()
 	})


### PR DESCRIPTION
 * #10283 -- Use -F flag in git log in check-stable script (@nebril)
 * #10325 -- test: Wait for Istio POD termination before deleting istio-system or cilium (@jrajahalme)
 * #10322 -- doc: Fix links to contributing guide  (@CybrPunk)
 * #10434 -- Envoy: Apply CVE fixes 2020-03-03 (@jrajahalme)

*Not backported due to dependencies to non-backported commits:*

 * #10207 -- Fix regression to avoid freeing alive IPs (@tgraf)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 10283 10325 10322 10434; do contrib/backporting/set-labels.py $pr done 1.5; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10445)
<!-- Reviewable:end -->
