### PR TITLE
docs: fix section heading level in upgrade guide

### DIFF
--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -216,7 +216,7 @@ configuration options for each minor version.
    DaemonSet, Deployment and RBAC definitions.
 
 Step 3: Rolling Back
-====================
+--------------------
 
 Occasionally, it may be necessary to undo the rollout because a step was missed
 or something went wrong during upgrade. To undo the rollout run:


### PR DESCRIPTION
The "Step 3: Rolling Back" heading should have the same heading level (4
instead of 3) as the other steps.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10456)
<!-- Reviewable:end -->
