### PR TITLE
docs: fix spelling of "primarily" in Kubernetes IPAM docs

### DIFF
--- a/Documentation/concepts/ipam/kubernetes.rst
+++ b/Documentation/concepts/ipam/kubernetes.rst
@@ -38,6 +38,6 @@ Annotation                          Description
 ``io.cilium.network.ipv6-pod-cidr`` IPv6 PodCIDR range
 =================================== ============================================================
 
-.. note:: The annotation-based mechanism is primiarly useful in combination with
+.. note:: The annotation-based mechanism is primarily useful in combination with
 	  older Kubernetes versions which do not support ``Spec.PodCIDRs`` yet
 	  but support for both IPv4 and IPv6 is enabled.


### PR DESCRIPTION
This was introduced by #10407 and currently makes the spell checker fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10458)
<!-- Reviewable:end -->
