### PR TITLE
doc: Update EKS documentation to delete aws-node

### DIFF
--- a/Documentation/gettingstarted/aws-eni.rst
+++ b/Documentation/gettingstarted/aws-eni.rst
@@ -27,15 +27,12 @@ EKS cluster using ``eksctl``, see the section :ref:`k8s_install_eks`.
 
    eksctl create cluster -n eni-cluster -N 0
 
-Disable the aws-node DaemonSet (EKS only)
-=========================================
+Disable VPC CNI (``aws-node`` DaemonSet) (EKS only)
+===================================================
 
-If you are running an EKS cluster, disable the ``aws-node`` DaemonSet so it
-does not interfere with the ENIs managed by Cilium:
+If you are running an EKS cluster, you should delete the ``aws-node`` DaemonSet.
 
-.. code:: bash
-
-   kubectl -n kube-system set image daemonset/aws-node aws-node=docker.io/spaster/alpine-sleep
+.. include:: k8s-install-remove-aws-node.rst
 
 Prepare & Deploy Cilium
 =======================

--- a/Documentation/gettingstarted/k8s-install-eks.rst
+++ b/Documentation/gettingstarted/k8s-install-eks.rst
@@ -69,15 +69,10 @@ You should see something like this:
 	[...]
 	[✔]  EKS cluster "test-cluster" in "us-west-2" region is ready
 
-Disable the aws-node DaemonSet (EKS only)
-=========================================
+Delete VPC CNI (``aws-node`` DaemonSet)
+=======================================
 
-If you are running an EKS cluster, disable the ``aws-node`` DaemonSet so it
-does not interfere with the ENIs managed by Cilium:
-
-.. code:: bash
-
-   kubectl -n kube-system set image daemonset/aws-node aws-node=docker.io/spaster/alpine-sleep
+.. include:: k8s-install-remove-aws-node.rst
 
 Deploy Cilium
 =============

--- a/Documentation/gettingstarted/k8s-install-remove-aws-node.rst
+++ b/Documentation/gettingstarted/k8s-install-remove-aws-node.rst
@@ -1,0 +1,10 @@
+Cilium will manage ENIs instead of VPC CNI, so the ``aws-node`` DaemonSet
+has to be deleted to prevent conflict behavior.
+
+.. note::
+
+   Once ``aws-node`` DaemonSet is deleted, EKS will not try to restore it.
+
+.. code:: bash
+
+   kubectl -n kube-system delete daemonset aws-node


### PR DESCRIPTION
It has been confirmed that VPC CNI can be delete and EKS will not try to restore it.

Fixes: #10420

```release-note
doc: Update EKS documentation to delete aws-node
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10461)
<!-- Reviewable:end -->
