### PR TITLE
update: fix preflight step in upgrade test

### DIFF
--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -323,6 +323,7 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldVersion, newV
 			helpers.HelmTemplate + " " +
 			"--namespace=kube-system " +
 			"--set preflight.enabled=true " +
+			fmt.Sprintf("--set preflight.image=%s ", helpers.CiliumDeveloperImage) +
 			"--set agent.enabled=false " +
 			"--set config.enabled=false " +
 			"--set operator.enabled=false " +


### PR DESCRIPTION
The pre-flight image should be pulling the image version that is being
generated locally and not the image stored in the helm charts.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10472)
<!-- Reviewable:end -->
