### PR TITLE
docs: fix bird dashboard image scale

### DIFF
--- a/Documentation/gettingstarted/bird.rst
+++ b/Documentation/gettingstarted/bird.rst
@@ -201,7 +201,6 @@ It also provides a simple Grafana dashboard, but you could also create your
 own, e.g. `Trip.com's <https://ctripcloud.github.io/cilium/network/2020/01/19/trip-first-step-towards-cloud-native-networking.html>`_ looks like this:
 
 .. image:: images/bird_dashboard.png
-   :scale: 95%
 
 Advanced Configurations
 #######################


### PR DESCRIPTION
Due the `scale` parameter the image is stretched and has a bad
layout in the documentation.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10480)
<!-- Reviewable:end -->
