### PR TITLE
test: Fix possible race in waitForNPods helper function

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -260,7 +260,6 @@ func CreateKubectl(vmName string, log *logrus.Entry) (k *Kubectl) {
 	}
 
 	res := k.Apply(ApplyOptions{FilePath: filepath.Join(k.BasePath(), manifestsPath, "log-gatherer.yaml"), Namespace: LogGathererNamespace})
-
 	if !res.WasSuccessful() {
 		ginkgoext.Fail(fmt.Sprintf("Cannot connect to k8s cluster, output:\n%s", res.CombineOutput().String()), 1)
 		return nil
@@ -936,6 +935,10 @@ func (kub *Kubectl) waitForNPods(checkStatus checkPodStatusFunc, namespace strin
 		err := kub.GetPods(namespace, filter).Unmarshal(podList)
 		if err != nil {
 			kub.Logger().Infof("Error while getting PodList: %s", err)
+			return false
+		}
+
+		if len(podList.Items) == 0 {
 			return false
 		}
 

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -827,7 +827,7 @@ var _ = Describe("K8sPolicyTest", func() {
 					break
 				}
 
-				Expect(kubectl.WaitforPods("foo", "-l zgroup=testapp", helpers.HelperTimeout)).To(BeNil())
+				Expect(kubectl.WaitforPods(namespaceForTest, "-l zgroup=testapp", helpers.HelperTimeout)).To(BeNil())
 				var podList v1.PodList
 				err = kubectl.GetPods(namespaceForTest, fmt.Sprintf("-n %s -l k8s-app=cilium --field-selector spec.nodeName=%s", helpers.CiliumNamespace, nodeName)).Unmarshal(&podList)
 				Expect(err).To(BeNil())

--- a/test/k8sT/fqdn.go
+++ b/test/k8sT/fqdn.go
@@ -67,9 +67,6 @@ var _ = Describe("K8sFQDNTest", func() {
 		Expect(err).Should(BeNil(), "Testapp is not ready after timeout")
 
 		appPods = helpers.GetAppPods(apps, helpers.DefaultNamespace, kubectl, "id")
-
-		err = kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=bind", helpers.HelperTimeout)
-		Expect(err).Should(BeNil(), "Bind app is not ready after timeout")
 	})
 
 	AfterFailed(func() {


### PR DESCRIPTION
Previously, `WaitforPods()` could prematurely return when `GetPods()` returned no pods (e.g. `WaitforPods()` had been immediately called after sending a create pods request).

To avoid this, we should wait (by returning `false`) when the pod list is empty instead of setting the `minRequired`.

This makes the function to fail when a user intentionally set `minRequired` to `0` in `WaitforNPodsRunning()`, but I don't see any sane use case where setting `minRequired` to `0` would make sense.

Example of such race:
```
time="2020-02-29T13:05:44Z" level=debug msg="applying /home/jenkins/workspace/Cilium-PR-Ginkgo-Tests-Validated/k8s-1.11-gopath/src/github.com/cilium/cilium/test/k8sT/manifests/log-gatherer.yaml in namespace kube-system"
time="2020-02-29T13:05:44Z" level=debug msg="running command: kubectl apply --force=false -f /home/jenkins/workspace/Cilium-PR-Ginkgo-Tests-Validated/k8s-1.11-gopath/src/github.com/cilium/cilium/test/k8sT/manifests/log-gatherer.yaml -n kube-system"
cmd: "kubectl apply --force=false -f /home/jenkins/workspace/Cilium-PR-Ginkgo-Tests-Validated/k8s-1.11-gopath/src/github.com/cilium/cilium/test/k8sT/manifests/log-gatherer.yaml -n kube-system" exitCode: 0 duration: 92.720906ms stdout:
serviceaccount/cilium unchanged
daemonset.apps/log-gatherer unchanged

time="2020-02-29T13:05:44Z" level=debug msg="running command: kubectl -n kube-system get pods -l k8s-app=cilium-test-logs -o json"
cmd: "kubectl -n kube-system get pods -l k8s-app=cilium-test-logs -o json" exitCode: 0 duration: 43.672802ms stdout:
{
    "apiVersion": "v1",
    "items": [],
    "kind": "List",
    "metadata": {
        "resourceVersion": "",
        "selfLink": ""
    }
}
```

Fix #10277.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10481)
<!-- Reviewable:end -->
