### PR TITLE
cni: fix interface sandbox in cmdAdd return value

### DIFF
--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -519,7 +519,7 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 	res.Interfaces = append(res.Interfaces, &cniTypesVer.Interface{
 		Name:    args.IfName,
 		Mac:     macAddrStr,
-		Sandbox: "/proc/" + args.Netns + "/ns/net",
+		Sandbox: args.Netns,
 	})
 
 	// Specify that endpoint must be regenerated synchronously. See GH-4409.


### PR DESCRIPTION
args.Netns is the absolute path of sandbox netns, just use it as is.

Signed-off-by: Jaff Cheng <jaff.cheng.sh@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10482)
<!-- Reviewable:end -->
