### PR TITLE
option: re-use ToFQDNsMaxDeferredConnectionDeletes const in fatal log

### DIFF
--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2062,7 +2062,8 @@ func (c *DaemonConfig) Populate() {
 	if maxZombies := viper.GetInt(ToFQDNsMaxDeferredConnectionDeletes); maxZombies >= 0 {
 		c.ToFQDNsMaxDeferredConnectionDeletes = viper.GetInt(ToFQDNsMaxDeferredConnectionDeletes)
 	} else {
-		log.Fatal("tofqdns-max-deferred-connection-deletes must be positive, or 0 to disable deferred connection deletion")
+		log.Fatalf("%s must be positive, or 0 to disable deferred connection deletion",
+			ToFQDNsMaxDeferredConnectionDeletes)
 	}
 	switch {
 	case viper.IsSet(ToFQDNsMinTTL): // set by user


### PR DESCRIPTION
Re-use ToFQDNsMaxDeferredConnectionDeletes in the fatal log message
instead of spelling out the option name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10483)
<!-- Reviewable:end -->
