### PR TITLE
hubble: Change the default event queue size

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -86,7 +86,7 @@ cilium-agent [flags]
       --http-request-timeout uint                     Time after which a forwarded HTTP request is considered failed unless completed (in seconds); Use 0 for unlimited (default 3600)
       --http-retry-count uint                         Number of retries performed after a forwarded request attempt fails (default 3)
       --http-retry-timeout uint                       Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
-      --hubble-event-queue-size int                   Buffer size of the channel to receive monitor events. (default 128)
+      --hubble-event-queue-size int                   Buffer size of the channel to receive monitor events.
       --hubble-flow-buffer-size int                   Maximum number of flows in Hubble's buffer. The actual buffer size gets rounded up to the next power of 2, e.g. 4095 => 4096 (default 4095)
       --hubble-listen-addresses strings               List of unix domain sockets for Hubble server to listen to.
       --hubble-metrics strings                        List of Hubble metrics to enable.

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -735,7 +735,7 @@ func init() {
 	flags.Int(option.HubbleFlowBufferSize, 4095, "Maximum number of flows in Hubble's buffer. The actual buffer size gets rounded up to the next power of 2, e.g. 4095 => 4096")
 	option.BindEnv(option.HubbleFlowBufferSize)
 
-	flags.Int(option.HubbleEventQueueSize, 128, "Buffer size of the channel to receive monitor events.")
+	flags.Int(option.HubbleEventQueueSize, 0, "Buffer size of the channel to receive monitor events.")
 	option.BindEnv(option.HubbleEventQueueSize)
 
 	flags.String(option.HubbleMetricsServer, "", "Address to serve Hubble metrics on.")

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -348,7 +348,8 @@ data:
   # set.
   hubble-listen-addresses: {{ .Values.global.hubble.listenAddresses | join " " | quote }}
 {{ if .Values.global.hubble.eventQueueSize }}
-  # Buffer size of the channel for Hubble to receive monitor events.
+  # Buffer size of the channel for Hubble to receive monitor events. If this field is not set,
+  # the buffer size is set to the default monitor queue size.
   hubble-event-queue-size: {{ .Values.global.hubble.eventQueueSize | quote }}
 {{- end }}
 {{ if .Values.global.hubble.flowBufferSize }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -373,7 +373,8 @@ global:
     #
     # Hubble is disabled if the list is empty.
     listenAddresses: []
-    # Buffer size of the channel Hubble uses to receive monitor events. Defaults to 128.
+    # Buffer size of the channel Hubble uses to receive monitor events. If this value is not set,
+    # the queue size is set to the default monitor queue size.
     eventQueueSize: ~
     # Number of recent flows for Hubble to cache. Defaults to 4096.
     flowBufferSize: ~

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2165,10 +2165,7 @@ func (c *DaemonConfig) Populate() {
 	}
 
 	if c.MonitorQueueSize == 0 {
-		c.MonitorQueueSize = runtime.NumCPU() * defaults.MonitorQueueSizePerCPU
-		if c.MonitorQueueSize > defaults.MonitorQueueSizePerCPUMaximum {
-			c.MonitorQueueSize = defaults.MonitorQueueSizePerCPUMaximum
-		}
+		c.MonitorQueueSize = getDefaultMonitorQueueSize(runtime.NumCPU())
 	}
 
 	// Metrics Setup
@@ -2228,6 +2225,9 @@ func (c *DaemonConfig) Populate() {
 	c.HubbleListenAddresses = viper.GetStringSlice(HubbleListenAddresses)
 	c.HubbleFlowBufferSize = viper.GetInt(HubbleFlowBufferSize)
 	c.HubbleEventQueueSize = viper.GetInt(HubbleEventQueueSize)
+	if c.HubbleEventQueueSize == 0 {
+		c.HubbleEventQueueSize = getDefaultMonitorQueueSize(runtime.NumCPU())
+	}
 	c.HubbleMetricsServer = viper.GetString(HubbleMetricsServer)
 	c.HubbleMetrics = viper.GetStringSlice(HubbleMetrics)
 
@@ -2385,4 +2385,12 @@ func InitConfig(configName string) func() {
 			log.WithField(logfields.Reason, err).Info("Skipped reading configuration file")
 		}
 	}
+}
+
+func getDefaultMonitorQueueSize(numCPU int) int {
+	monitorQueueSize := numCPU * defaults.MonitorQueueSizePerCPU
+	if monitorQueueSize > defaults.MonitorQueueSizePerCPUMaximum {
+		monitorQueueSize = defaults.MonitorQueueSizePerCPUMaximum
+	}
+	return monitorQueueSize
 }

--- a/pkg/option/config_test.go
+++ b/pkg/option/config_test.go
@@ -25,6 +25,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/cilium/cilium/pkg/defaults"
 	flag "github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	. "gopkg.in/check.v1"
@@ -414,4 +415,9 @@ func Test_populateNodePortRange(t *testing.T) {
 			}
 		})
 	}
+}
+
+func (s *OptionSuite) TestGetDefaultMonitorQueueSize(c *C) {
+	c.Assert(getDefaultMonitorQueueSize(4), Equals, 4*defaults.MonitorQueueSizePerCPU)
+	c.Assert(getDefaultMonitorQueueSize(1000), Equals, defaults.MonitorQueueSizePerCPUMaximum)
 }


### PR DESCRIPTION
Use the logic to calculate the default monitor queue size to get the
default event queue size for Hubble instead of hardcoding the default
to be 128.

Ref https://github.com/cilium/hubble/issues/161
Ref https://github.com/cilium/cilium/pull/10358/files/fd9f75ca92a8cd9cc0446b5dea13f4f9894cd90b#r388162620

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10488)
<!-- Reviewable:end -->
