### PR TITLE
fqdn: Correct race when the DNS proxy updates FQDN selectors

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -150,7 +150,7 @@ cilium-agent [flags]
       --tofqdns-min-ttl int                                   The minimum time, in seconds, to use DNS data for toFQDNs policies. (default 3600 when --tofqdns-enable-poller, 604800 otherwise)
       --tofqdns-pre-cache string                              DNS cache data at this path is preloaded on agent startup
       --tofqdns-proxy-port int                                Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port.
-      --tofqdns-proxy-response-max-delay duration             The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information. (default 50ms)
+      --tofqdns-proxy-response-max-delay duration             The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information. (default 100ms)
       --trace-payloadlen int                                  Length of payload to capture when tracing (default 128)
   -t, --tunnel string                                         Tunnel mode {vxlan, geneve, disabled} (default "vxlan" for the "veth" datapath mode)
       --version                                               Print version information

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -829,7 +829,7 @@ func init() {
 	flags.Int(option.ToFQDNsMaxIPsPerHost, defaults.ToFQDNsMaxIPsPerHost, "Maximum number of IPs to maintain per FQDN name for each endpoint")
 	option.BindEnv(option.ToFQDNsMaxIPsPerHost)
 
-	flags.DurationVar(&option.Config.FQDNProxyResponseMaxDelay, option.FQDNProxyResponseMaxDelay, 50*time.Millisecond, "The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information.")
+	flags.DurationVar(&option.Config.FQDNProxyResponseMaxDelay, option.FQDNProxyResponseMaxDelay, 100*time.Millisecond, "The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information.")
 	option.BindEnv(option.FQDNProxyResponseMaxDelay)
 
 	flags.String(option.ToFQDNsPreCache, defaults.ToFQDNsPreCache, "DNS cache data at this path is preloaded on agent startup")

--- a/pkg/fqdn/dnspoller.go
+++ b/pkg/fqdn/dnspoller.go
@@ -113,8 +113,8 @@ func (poller *DNSPoller) LookupUpdateDNS(ctx context.Context) error {
 		poller.config.PollerResponseNotify(lookupTime, qname, response)
 	}
 
-	_, err := poller.ruleManager.UpdateGenerateDNS(ctx, lookupTime, updatedDNSIPs)
-	return err
+	errCh := poller.ruleManager.UpdateGenerateDNS(ctx, lookupTime, updatedDNSIPs)
+	return <-errCh
 }
 
 // noopPollerResponseNotify is used when no PollerResponseNotify is set.

--- a/pkg/fqdn/name_manager_test.go
+++ b/pkg/fqdn/name_manager_test.go
@@ -68,8 +68,8 @@ func (ds *FQDNTestSuite) TestNameManagerCIDRGeneration(c *C) {
 	// poll DNS once, check that we only generate 1 rule (for 1 IP) and that we
 	// still have 1 ToFQDN rule, and that the IP is correct
 	selIPMap = make(map[api.FQDNSelector][]net.IP)
-	_, err := nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{dns.Fqdn("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}}})
-	c.Assert(err, IsNil, Commentf("Error mapping selectors to IPs"))
+	errCh := nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{dns.Fqdn("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}}})
+	c.Assert(<-errCh, IsNil, Commentf("Error mapping selectors to IPs"))
 	c.Assert(len(selIPMap), Equals, 1, Commentf("Incorrect length for testCase with single ToFQDNs entry"))
 
 	expectedIPs := []net.IP{net.ParseIP("1.1.1.1")}
@@ -80,8 +80,8 @@ func (ds *FQDNTestSuite) TestNameManagerCIDRGeneration(c *C) {
 	// inserted) and that we still have 1 ToFQDN rule, and that the IP, now
 	// different, is correct
 	selIPMap = make(map[api.FQDNSelector][]net.IP)
-	_, err = nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{dns.Fqdn("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("2.2.2.2")}}})
-	c.Assert(err, IsNil, Commentf("Error generating IP CIDR rules"))
+	errCh = nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{dns.Fqdn("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("2.2.2.2")}}})
+	c.Assert(<-errCh, IsNil, Commentf("Error generating IP CIDR rules"))
 	c.Assert(len(selIPMap), Equals, 1, Commentf("Only one entry per FQDNSelector should be present"))
 	expectedIPs = []net.IP{net.ParseIP("1.1.1.1"), net.ParseIP("2.2.2.2")}
 	c.Assert(selIPMap[ciliumIOSel][0].Equal(expectedIPs[0]), Equals, true)
@@ -119,17 +119,17 @@ func (ds *FQDNTestSuite) TestNameManagerMultiIPUpdate(c *C) {
 
 	// poll DNS once, check that we only generate 1 IP for cilium.io
 	selIPMap = make(map[api.FQDNSelector][]net.IP)
-	_, err := nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{dns.Fqdn("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}}})
-	c.Assert(err, IsNil, Commentf("Error mapping selectors to IPs"))
+	errCh := nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{dns.Fqdn("cilium.io"): {TTL: 60, IPs: []net.IP{net.ParseIP("1.1.1.1")}}})
+	c.Assert(<-errCh, IsNil, Commentf("Error mapping selectors to IPs"))
 	c.Assert(len(selIPMap), Equals, 1, Commentf("Incorrect number of plumbed FQDN selectors"))
 	c.Assert(selIPMap[ciliumIOSel][0].Equal(net.ParseIP("1.1.1.1")), Equals, true)
 
 	// poll DNS once, check that we only generate 3 IPs, 2 cached from before and 1 new one for github.com
 	selIPMap = make(map[api.FQDNSelector][]net.IP)
-	_, err = nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{
+	errCh = nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{
 		dns.Fqdn("cilium.io"):  {TTL: 60, IPs: []net.IP{net.ParseIP("2.2.2.2")}},
 		dns.Fqdn("github.com"): {TTL: 60, IPs: []net.IP{net.ParseIP("3.3.3.3")}}})
-	c.Assert(err, IsNil, Commentf("Error mapping selectors to IPs"))
+	c.Assert(<-errCh, IsNil, Commentf("Error mapping selectors to IPs"))
 	c.Assert(len(selIPMap), Equals, 2, Commentf("More than 2 FQDN selectors while only 2 were added"))
 	c.Assert(len(selIPMap[ciliumIOSel]), Equals, 2, Commentf("Incorrect number of IPs for cilium.io selector"))
 	c.Assert(len(selIPMap[githubSel]), Equals, 1, Commentf("Incorrect number of IPs for github.com selector"))
@@ -139,10 +139,10 @@ func (ds *FQDNTestSuite) TestNameManagerMultiIPUpdate(c *C) {
 
 	// poll DNS once, check that we only generate 4 IPs, 2 cilium.io cached IPs, 1 cached github.com IP, 1 new github.com IP
 	selIPMap = make(map[api.FQDNSelector][]net.IP)
-	_, err = nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{
+	errCh = nameManager.UpdateGenerateDNS(context.Background(), time.Now(), map[string]*DNSIPRecords{
 		dns.Fqdn("cilium.io"):  {TTL: 60, IPs: []net.IP{net.ParseIP("2.2.2.2")}},
 		dns.Fqdn("github.com"): {TTL: 60, IPs: []net.IP{net.ParseIP("4.4.4.4")}}})
-	c.Assert(err, IsNil, Commentf("Error mapping selectors to IPs"))
+	c.Assert(<-errCh, IsNil, Commentf("Error mapping selectors to IPs"))
 	c.Assert(len(selIPMap[ciliumIOSel]), Equals, 2, Commentf("Incorrect number of IPs for cilium.io selector"))
 	c.Assert(len(selIPMap[githubSel]), Equals, 2, Commentf("Incorrect number of IPs for github.com selector"))
 	c.Assert(selIPMap[ciliumIOSel][0].Equal(net.ParseIP("1.1.1.1")), Equals, true, Commentf("Incorrect IP mapping to FQDN"))


### PR DESCRIPTION
Edit 2020-03-06-15:40 UTC: I pulled out the original test change that was this PR since it wasn't clear to me that it was testing the issue correctly. I'll have to revisit it. I included the "fix" here in one commit, since doing just locking or queueing in 2 commits broke.


UpdateGenerateDNS updated the cache and generate selector updates as two
separate lock-holding sections. When updates happened concurrently, via
DNS lookups, DNS GC, or endpoint restores, the snapshot of data that
eventually updated the selectors could be out-of-order. This created an
A-B-A race for selectors that needed an update and those that needed to
be cleared.

These races have been observed on agent starts with pending pods but may
manifest between multiple pods making DNS updates or the DNS garbage
collector controller and any pod.

The code now holds the NameManager lock for the entirety of
UpdateGenerateDNS and ForceRegenerateDNS. This forces the update to
complete in its entirety before allowing another to modify the FQDN
cache or registered selectors.

The more aggressive locking, alone, causes a deadlock with the
config.updateSelectors callback (actually daemon.UpdateSelectors). These
calls syncronously update NameManager via RegisterForIdentityUpdates and
UnregisterForIdentityUpdates, taking the NameManager lock. This
deadlocks with UpdateGenerateDNS and ForceGenerateDNS, which are still
waiting to release the locks.

The deadlock is mitigated by serializing updates in UpdateGenerateDNS
and ForceGenerateDNS but keeping the ability to wait on them to
complete. This was previously implemented with a sync.WaitGroup but is
now simply an error channel (which carries errors that, previously,
would be returned immediately by UpdateGenerateDNS).

Note: This will lengthen the time DNS updates take internally,
ultimately also slowing the amount of time the DNS proxy must wait
before responding with a DNS response. A timeout of 50ms already exists
for this with warnings when it happens, so it should be apparent if it
does.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10489)
<!-- Reviewable:end -->
