### PR TITLE
k8s: Disable several CiliumEndpoint status sections by default

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -72,6 +72,7 @@ cilium-agent [flags]
       --encrypt-node                                  Enables encrypting traffic from non-Cilium pods and host networking
       --endpoint-interface-name-prefix string         Prefix of interface name shared by all endpoints (default "lxc+")
       --endpoint-queue-size int                       size of EventQueue per-endpoint (default 25)
+      --endpoint-status strings                       Enable additional CiliumEndpoint status features (controllers,health,log,policy,state)
       --envoy-log string                              Path to a separate Envoy log file, if any
       --exclude-local-address strings                 Exclude CIDR from being recognized as local address
       --fixed-identity-mapping map                    Key-value for the fixed identity mapping which allows to use reserved label for fixed identities (default map[])

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -287,6 +287,10 @@ func init() {
 	flags.Bool(option.EnableHealthChecking, defaults.EnableHealthChecking, "Enable connectivity health checking")
 	option.BindEnv(option.EnableHealthChecking)
 
+	flags.StringSlice(option.EndpointStatus, []string{},
+		"Enable additional CiliumEndpoint status features ("+strings.Join(option.EndpointStatusValues(), ",")+")")
+	option.BindEnv(option.EndpointStatus)
+
 	flags.Bool(option.EnableEndpointHealthChecking, defaults.EnableEndpointHealthChecking, "Enable connectivity health checking between virtual endpoints")
 	option.BindEnv(option.EnableEndpointHealthChecking)
 

--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -103,7 +103,8 @@ func TestMain(m *testing.M) {
 
 type dummyEpSyncher struct{}
 
-func (epSync *dummyEpSyncher) RunK8sCiliumEndpointSync(e *endpoint.Endpoint) {}
+func (epSync *dummyEpSyncher) RunK8sCiliumEndpointSync(e *endpoint.Endpoint, conf endpoint.EndpointStatusConfiguration) {
+}
 
 func (ds *DaemonSuite) SetUpTest(c *C) {
 

--- a/daemon/cmd/policy_test.go
+++ b/daemon/cmd/policy_test.go
@@ -807,7 +807,7 @@ func (d *dummyManager) AllocateID(id uint16) (uint16, error) {
 	return uint16(1), nil
 }
 
-func (d *dummyManager) RunK8sCiliumEndpointSync(*endpoint.Endpoint) {
+func (d *dummyManager) RunK8sCiliumEndpointSync(*endpoint.Endpoint, endpoint.EndpointStatusConfiguration) {
 }
 
 func (d *dummyManager) UpdateReferences(map[id.PrefixType]string, *endpoint.Endpoint) {

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -669,7 +669,7 @@ func (d *dummyManager) AllocateID(id uint16) (uint16, error) {
 	return uint16(1), nil
 }
 
-func (d *dummyManager) RunK8sCiliumEndpointSync(*Endpoint) {
+func (d *dummyManager) RunK8sCiliumEndpointSync(*Endpoint, EndpointStatusConfiguration) {
 }
 
 func (d *dummyManager) UpdateReferences(map[id.PrefixType]string, *Endpoint) {

--- a/pkg/endpoint/manager.go
+++ b/pkg/endpoint/manager.go
@@ -25,7 +25,7 @@ import (
 
 type endpointManager interface {
 	AllocateID(id uint16) (uint16, error)
-	RunK8sCiliumEndpointSync(*Endpoint)
+	RunK8sCiliumEndpointSync(*Endpoint, EndpointStatusConfiguration)
 	UpdateReferences(map[id.PrefixType]string, *Endpoint)
 	UpdateIDReference(*Endpoint)
 	RemoveReferences(map[id.PrefixType]string)
@@ -64,7 +64,7 @@ func (e *Endpoint) Expose(mgr endpointManager) error {
 
 	e.getLogger().Info("New endpoint")
 
-	mgr.RunK8sCiliumEndpointSync(e)
+	mgr.RunK8sCiliumEndpointSync(e, option.Config)
 	return nil
 }
 

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -61,7 +61,7 @@ type EndpointManager struct {
 // EndpointResourceSynchronizer is an interface which synchronizes CiliumEndpoint
 // resources with Kubernetes.
 type EndpointResourceSynchronizer interface {
-	RunK8sCiliumEndpointSync(ep *endpoint.Endpoint)
+	RunK8sCiliumEndpointSync(ep *endpoint.Endpoint, conf endpoint.EndpointStatusConfiguration)
 }
 
 // NewEndpointManager creates a new EndpointManager.

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -95,7 +95,8 @@ func (d *DummyRuleCacheOwner) ClearPolicyConsumers(id uint16) *sync.WaitGroup {
 
 type dummyEpSyncher struct{}
 
-func (epSync *dummyEpSyncher) RunK8sCiliumEndpointSync(e *endpoint.Endpoint) {}
+func (epSync *dummyEpSyncher) RunK8sCiliumEndpointSync(e *endpoint.Endpoint, conf endpoint.EndpointStatusConfiguration) {
+}
 
 func (s *EndpointManagerSuite) TestLookup(c *C) {
 	ep := endpoint.NewEndpointWithState(s, &endpoint.FakeEndpointProxy{}, &allocator.FakeIdentityAllocator{}, 10, endpoint.StateReady)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -789,6 +789,25 @@ const (
 
 	// K8sHeartbeatTimeout configures the timeout for apiserver heartbeat
 	K8sHeartbeatTimeout = "k8s-heartbeat-timeout"
+
+	// EndpointStatus enables population of information in the
+	// CiliumEndpoint.Status resource
+	EndpointStatus = "endpoint-status"
+
+	// EndpointStatusPolicy enables CiliumEndpoint.Status.Policy
+	EndpointStatusPolicy = "policy"
+
+	// EndpointStatusHealth enables CilliumEndpoint.Status.Health
+	EndpointStatusHealth = "health"
+
+	// EndpointStatusControllers enables CiliumEndpoint.Status.Controllers
+	EndpointStatusControllers = "controllers"
+
+	// EndpointStatusLog enables CiliumEndpoint.Status.Log
+	EndpointStatusLog = "log"
+
+	// EndpointStatusState enables CiliumEndpoint.Status.State
+	EndpointStatusState = "state"
 )
 
 // Default string arguments
@@ -1579,6 +1598,10 @@ type DaemonConfig struct {
 
 	// K8sHeartbeatTimeout configures the timeout for apiserver heartbeat
 	K8sHeartbeatTimeout time.Duration
+
+	// EndpointStatus enables population of information in the
+	// CiliumEndpoint.Status resource
+	EndpointStatus map[string]struct{}
 }
 
 var (
@@ -1595,6 +1618,7 @@ var (
 		EnableIPv4:                   defaults.EnableIPv4,
 		EnableIPv6:                   defaults.EnableIPv6,
 		EnableL7Proxy:                defaults.EnableL7Proxy,
+		EndpointStatus:               make(map[string]struct{}),
 		ENITags:                      make(map[string]string),
 		ToFQDNsMaxIPsPerHost:         defaults.ToFQDNsMaxIPsPerHost,
 		KVstorePeriodicSync:          defaults.KVstorePeriodicSync,
@@ -1712,6 +1736,13 @@ func (c *DaemonConfig) IsFlannelMasterDeviceSet() bool {
 	return len(c.FlannelMasterDevice) != 0
 }
 
+// EndpointStatusIsEnabled returns true if a particular EndpointStatus* feature
+// is enabled
+func (c *DaemonConfig) EndpointStatusIsEnabled(option string) bool {
+	_, ok := c.EndpointStatus[option]
+	return ok
+}
+
 func (c *DaemonConfig) validateIPv6ClusterAllocCIDR() error {
 	ip, cidr, err := net.ParseCIDR(c.IPv6ClusterAllocCIDR)
 	if err != nil {
@@ -1819,6 +1850,13 @@ func (c *DaemonConfig) Validate() error {
 	if c.EnableHostReachableServices && !c.EnableHostServicesUDP && !c.EnableHostServicesTCP {
 		return fmt.Errorf("%s must be at minimum one of [%s,%s]",
 			HostReachableServicesProtos, HostServicesTCP, HostServicesUDP)
+	}
+
+	allowedEndpointStatusValues := EndpointStatusValuesMap()
+	for enabledEndpointStatus := range c.EndpointStatus {
+		if _, ok := allowedEndpointStatusValues[enabledEndpointStatus]; !ok {
+			return fmt.Errorf("unknown endpoint-status option '%s'", enabledEndpointStatus)
+		}
 	}
 
 	return nil
@@ -2181,6 +2219,10 @@ func (c *DaemonConfig) Populate() {
 		c.IPAMAPIBurst = viper.GetInt(IPAMAPIBurst)
 	}
 
+	for _, option := range viper.GetStringSlice(EndpointStatus) {
+		c.EndpointStatus[option] = struct{}{}
+	}
+
 	if c.MonitorQueueSize == 0 {
 		c.MonitorQueueSize = getDefaultMonitorQueueSize(runtime.NumCPU())
 	}
@@ -2419,4 +2461,24 @@ func getDefaultMonitorQueueSize(numCPU int) int {
 		monitorQueueSize = defaults.MonitorQueueSizePerCPUMaximum
 	}
 	return monitorQueueSize
+}
+
+// EndpointStatusValues returns all available EndpointStatus option values
+func EndpointStatusValues() []string {
+	return []string{
+		EndpointStatusControllers,
+		EndpointStatusHealth,
+		EndpointStatusLog,
+		EndpointStatusPolicy,
+		EndpointStatusState,
+	}
+}
+
+// EndpointStatusValuesMap returns all EndpointStatus option values as a map
+func EndpointStatusValuesMap() (values map[string]struct{}) {
+	values = map[string]struct{}{}
+	for _, v := range EndpointStatusValues() {
+		values[v] = struct{}{}
+	}
+	return
 }

--- a/pkg/option/config_test.go
+++ b/pkg/option/config_test.go
@@ -250,6 +250,15 @@ func (s *OptionSuite) TestLocalAddressExclusion(c *C) {
 	c.Assert(d.IsExcludedLocalAddress(net.ParseIP("f00d::2")), Equals, false)
 }
 
+func (s *OptionSuite) TestEndpointStatusIsEnabled(c *C) {
+
+	d := DaemonConfig{}
+	d.EndpointStatus = map[string]struct{}{EndpointStatusHealth: {}, EndpointStatusPolicy: {}}
+	c.Assert(d.EndpointStatusIsEnabled(EndpointStatusHealth), Equals, true)
+	c.Assert(d.EndpointStatusIsEnabled(EndpointStatusPolicy), Equals, true)
+	c.Assert(d.EndpointStatusIsEnabled(EndpointStatusLog), Equals, false)
+}
+
 func Test_populateNodePortRange(t *testing.T) {
 	type want struct {
 		wantMin int
@@ -420,4 +429,13 @@ func Test_populateNodePortRange(t *testing.T) {
 func (s *OptionSuite) TestGetDefaultMonitorQueueSize(c *C) {
 	c.Assert(getDefaultMonitorQueueSize(4), Equals, 4*defaults.MonitorQueueSizePerCPU)
 	c.Assert(getDefaultMonitorQueueSize(1000), Equals, defaults.MonitorQueueSizePerCPUMaximum)
+}
+
+func (s *OptionSuite) TestEndpointStatusValues(c *C) {
+	c.Assert(len(EndpointStatusValues()), Not(Equals), 0)
+	c.Assert(len(EndpointStatusValuesMap()), Not(Equals), 0)
+	for _, v := range EndpointStatusValues() {
+		_, ok := EndpointStatusValuesMap()[v]
+		c.Assert(ok, Equals, true)
+	}
 }

--- a/pkg/proxy/kafka_test.go
+++ b/pkg/proxy/kafka_test.go
@@ -234,7 +234,8 @@ func (m *metadataTester) Handler() RequestHandler {
 
 type dummyEpSyncher struct{}
 
-func (epSync *dummyEpSyncher) RunK8sCiliumEndpointSync(e *endpoint.Endpoint) {}
+func (epSync *dummyEpSyncher) RunK8sCiliumEndpointSync(e *endpoint.Endpoint, conf endpoint.EndpointStatusConfiguration) {
+}
 
 func (s *proxyTestSuite) TestKafkaRedirect(c *C) {
 	server := NewServer()

--- a/test/k8sT/KafkaPolicies.go
+++ b/test/k8sT/KafkaPolicies.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
 
@@ -200,40 +199,6 @@ var _ = Describe("K8sKafkaPolicyTest", func() {
 				helpers.DefaultNamespace, l7Policy,
 				helpers.KubectlApply, helpers.HelperTimeout)
 			Expect(err).To(BeNil(), "L7 policy cannot be imported correctly")
-
-			By("validate that CEP is updated with correct enforcement mode")
-
-			desiredPolicyStatus := map[string]models.EndpointPolicyEnabled{
-				backupApp:   models.EndpointPolicyEnabledNone,
-				empireHqApp: models.EndpointPolicyEnabledNone,
-				kafkaApp:    models.EndpointPolicyEnabledBoth,
-				outpostApp:  models.EndpointPolicyEnabledNone,
-			}
-
-			body := func() bool {
-				for app, policy := range desiredPolicyStatus {
-					cep := kubectl.CepGet(helpers.DefaultNamespace, appPods[app])
-					if cep == nil {
-						return false
-					}
-					state := models.EndpointPolicyEnabledNone
-					switch {
-					case cep.Policy.Egress.Enforcing && cep.Policy.Ingress.Enforcing:
-						state = models.EndpointPolicyEnabledBoth
-					case cep.Policy.Egress.Enforcing:
-						state = models.EndpointPolicyEnabledIngress
-					case cep.Policy.Ingress.Enforcing:
-						state = models.EndpointPolicyEnabledEgress
-					}
-
-					if state != policy {
-						return false
-					}
-				}
-				return true
-			}
-			err = helpers.WithTimeout(body, "CEP policy enforcement", &helpers.TimeoutConfig{Timeout: helpers.HelperTimeout})
-			Expect(err).To(BeNil(), "CEP not updated with correct policy enforcement")
 
 			By("Testing Kafka L7 policy enforcement status")
 			err = kubectl.ExecKafkaPodCmd(

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -797,7 +797,6 @@ var _ = Describe("K8sServicesTest", func() {
 
 		var (
 			expectedCIDR = "198.49.23.144/32"
-			podName      = "toservices"
 
 			endpointPath      string
 			podPath           string
@@ -837,32 +836,20 @@ var _ = Describe("K8sServicesTest", func() {
 		})
 
 		validateEgress := func() {
-			By("Checking that toServices CIDR is plumbed into CEP")
+			By("Checking that toServices CIDR is plumbed into the policy")
 			Eventually(func() string {
-				res := kubectl.Exec(fmt.Sprintf(
-					"%s -n %s get cep %s -o json",
-					helpers.KubectlCmd,
-					helpers.DefaultNamespace,
-					podName))
-				ExpectWithOffset(1, res).Should(helpers.CMDSuccess(), "cannot get Cilium endpoint")
-				data, err := res.Filter(`{.status.policy.egress}`)
-				ExpectWithOffset(1, err).To(BeNil(), "unable to get endpoint %s metadata", podName)
-				return data.String()
+				output, err := kubectl.LoadedPolicyInFirstAgent()
+				ExpectWithOffset(1, err).To(BeNil(), "unable to retrieve policy")
+				return output
 			}, 2*time.Minute, 2*time.Second).Should(ContainSubstring(expectedCIDR))
 		}
 
 		validateEgressAfterDeletion := func() {
-			By("Checking that toServices CIDR is no longer plumbed into CEP")
+			By("Checking that toServices CIDR is no longer plumbed into the policy")
 			Eventually(func() string {
-				res := kubectl.Exec(fmt.Sprintf(
-					"%s -n %s get cep %s -o json",
-					helpers.KubectlCmd,
-					helpers.DefaultNamespace,
-					podName))
-				ExpectWithOffset(1, res).Should(helpers.CMDSuccess(), "cannot get Cilium endpoint")
-				data, err := res.Filter(`{.status.policy.egress}`)
-				ExpectWithOffset(1, err).To(BeNil(), "unable to get endpoint %s metadata", podName)
-				return data.String()
+				output, err := kubectl.LoadedPolicyInFirstAgent()
+				ExpectWithOffset(1, err).To(BeNil(), "unable to retrieve policy")
+				return output
 			}, 2*time.Minute, 2*time.Second).ShouldNot(ContainSubstring(expectedCIDR))
 		}
 


### PR DESCRIPTION
The PATCH'ing of the status field of the CiliumEndpoint is often the bottleneck
in scalability. However, most of the frequently changing status sections
provided are not required for operation and only provide additional visibility.

Disable several CiliumEndpoint status sections by default to improve the
scalability of the CRD-backed identity allocation mode. Introduce a flag
--endpoint-status to re-enable individual status sections.

Fixes: #10413

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10490)
<!-- Reviewable:end -->
