### PR TITLE
test: Fix cleanup after PolicyAuditMode test

### DIFF
--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2019 Authors of Cilium
+// Copyright 2017-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1469,6 +1469,10 @@ var _ = Describe("RuntimePolicies", func() {
 		Context("With PolicyAuditMode", func() {
 			BeforeEach(func() {
 				vm.ExecCilium("config PolicyAuditMode=Enabled").ExpectSuccess("unable to change daemon configuration")
+			})
+
+			AfterAll(func() {
+				vm.ExecCilium("config PolicyAuditMode=Disabled").ExpectSuccess("unable to change daemon configuration")
 			})
 
 			It("tests ingress", func() {


### PR DESCRIPTION
This test set the PolicyAuditMode, but didn't revert it afterwards. This
meant that subsequent tests could potentially fail because they didn't
expect this setting to be configured.

Fix it by adding an AfterAll() that turns the feature back off.

Fixes: 6cd69ed7d79a ("Implement policy audit mode for the daemon")
Fixes: #10486

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10493)
<!-- Reviewable:end -->
