### PR TITLE
daemon: Improve error msg for endpoint IP reallocation

### DIFF
--- a/daemon/state.go
+++ b/daemon/state.go
@@ -326,7 +326,7 @@ func (d *Daemon) allocateIPsLocked(ep *endpoint.Endpoint) error {
 	if option.Config.EnableIPv6 && ep.IPv6 != nil {
 		err = d.ipam.AllocateIP(ep.IPv6.IP(), ep.HumanStringLocked()+" [restored]")
 		if err != nil {
-			return fmt.Errorf("unable to reallocate IPv6 address: %s", err)
+			return fmt.Errorf("unable to reallocate %s IPv6 address: %s", ep.IPv6.IP(), err)
 		}
 
 		defer func() {
@@ -338,7 +338,7 @@ func (d *Daemon) allocateIPsLocked(ep *endpoint.Endpoint) error {
 
 	if option.Config.EnableIPv4 && ep.IPv4 != nil {
 		if err = d.ipam.AllocateIP(ep.IPv4.IP(), ep.HumanStringLocked()+" [restored]"); err != nil {
-			return fmt.Errorf("unable to reallocate IPv4 address: %s", err)
+			return fmt.Errorf("unable to reallocate %s IPv4 address: %s", ep.IPv4.IP(), err)
 		}
 	}
 


### PR DESCRIPTION
Previously, when restoring endpoints, if the reallocation of an IP addr of an endpoint failed, the error log message didn't include that IP. E.g.:

    level=warning msg="Unable to restore endpoint, ignoring" endpointID=2930
    error="Failed to re-allocate IP of endpoint: unable to reallocate IPv6
    address: provided IP is not in the valid range. The range of valid IPs
    is f00d::a0c:0:0:0/96" k8sPodName=default/testds-l87pp subsys=daemon

This commit includes IP addr in the error msg for a better troubleshooting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10494)
<!-- Reviewable:end -->
