### PR TITLE
v1.6 backports 2020-03-06

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -677,6 +677,10 @@ func (kub *Kubectl) waitForNPods(checkStatus checkPodStatusFunc, namespace strin
 			return false
 		}
 
+		if len(podList.Items) == 0 {
+			return false
+		}
+
 		var required int
 
 		if minRequired == 0 {

--- a/test/k8sT/fqdn.go
+++ b/test/k8sT/fqdn.go
@@ -62,10 +62,6 @@ var _ = Describe("K8sFQDNTest", func() {
 		Expect(err).Should(BeNil(), "Testapp is not ready after timeout")
 
 		appPods = helpers.GetAppPods(apps, helpers.DefaultNamespace, kubectl, "id")
-
-		err = kubectl.WaitforPods(helpers.DefaultNamespace, "-l zgroup=bind", helpers.HelperTimeout)
-		Expect(err).Should(BeNil(), "Bind app is not ready after timeout")
-
 	})
 
 	AfterFailed(func() {


### PR DESCRIPTION
 * #10481 -- test: Fix possible race in waitForNPods helper function (@brb)

**NOTE:** commit 2449dfb3da3f6a99adfe1a402a5e8b7cb9cfd3b6 was not needed, there is no such test in 1.6

*Not backported as these depend on other changes not backported to v1.6:*

 * #10268 -- cilium: encryption, segfaults if existing non-Cilium xfrm policy without mark set exists (@jrfastab)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 10481; do contrib/backporting/set-labels.py $pr done 1.6; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10499)
<!-- Reviewable:end -->
