### PR TITLE
policy: Keep NameManager locked during SelectorCache operations

### DIFF
--- a/pkg/fqdn/dnspoller_test.go
+++ b/pkg/fqdn/dnspoller_test.go
@@ -152,9 +152,11 @@ func (ds *FQDNTestSuite) TestNameManagerSelectorHandling(c *C) {
 			poller      = NewDNSPoller(cfg, nameManager)
 		)
 
+		nameManager.Lock()
 		for _, fqdnSel := range testCase.selectorsToAdd {
-			nameManager.RegisterForIdentityUpdates(fqdnSel)
+			nameManager.RegisterForIdentityUpdatesLocked(fqdnSel)
 		}
+		nameManager.Unlock()
 		for i := testCase.lookupIterationsAfterAdd; i > 0; i-- {
 			err := poller.LookupUpdateDNS(context.Background())
 			c.Assert(err, IsNil, Commentf("Error running DNS lookups"))
@@ -162,9 +164,11 @@ func (ds *FQDNTestSuite) TestNameManagerSelectorHandling(c *C) {
 
 		// delete rules listed in the test case (note: we don't delete any unless
 		// they are listed)
+		nameManager.Lock()
 		for _, fqdnSel := range testCase.selectorsToDelete {
-			nameManager.UnregisterForIdentityUpdates(fqdnSel)
+			nameManager.UnregisterForIdentityUpdatesLocked(fqdnSel)
 		}
+		nameManager.Unlock()
 		for i := testCase.lookupIterationsAfterDelete; i > 0; i-- {
 			err := poller.LookupUpdateDNS(context.Background())
 			c.Assert(err, IsNil, Commentf("Error running DNS lookups"))

--- a/pkg/fqdn/name_manager.go
+++ b/pkg/fqdn/name_manager.go
@@ -87,20 +87,29 @@ func (n *NameManager) GetModel() *models.NameManager {
 	}
 }
 
-// RegisterForIdentityUpdates exposes this FQDNSelector so that identities
+// Lock must be held during any calls to RegisterForIdentityUpdatesLocked or
+// UnregisterForIdentityUpdatesLocked.
+func (n *NameManager) Lock() {
+	n.Mutex.Lock()
+}
+
+// Unlock must be called after calls to RegisterForIdentityUpdatesLocked or
+// UnregisterForIdentityUpdatesLocked are done.
+func (n *NameManager) Unlock() {
+	n.Mutex.Unlock()
+}
+
+// RegisterForIdentityUpdatesLocked exposes this FQDNSelector so that identities
 // for IPs contained in a DNS response that matches said selector can be
 // propagated back to the SelectorCache via `UpdateFQDNSelector`. All DNS names
 // contained within the NameManager's cache are iterated over to see if they match
 // the FQDNSelector. All IPs which correspond to the DNS names which match this
 // Selector will be returned as CIDR identities, as other DNS Names which have
 // already been resolved may match this FQDNSelector.
-func (n *NameManager) RegisterForIdentityUpdates(selector api.FQDNSelector) []identity.NumericIdentity {
-
-	n.Mutex.Lock()
+func (n *NameManager) RegisterForIdentityUpdatesLocked(selector api.FQDNSelector) []identity.NumericIdentity {
 	_, exists := n.allSelectors[selector]
 	if exists {
-		log.WithField("fqdnSelector", selector).Error("FQDNSelector was already registered for updates, returning without any identities")
-		n.Mutex.Unlock()
+		log.WithField("fqdnSelector", selector).Warning("FQDNSelector was already registered for updates, returning without any identities")
 		return nil
 	}
 
@@ -109,7 +118,6 @@ func (n *NameManager) RegisterForIdentityUpdates(selector api.FQDNSelector) []id
 	regex, err := selector.ToRegex()
 	if err != nil {
 		log.WithError(err).WithField("fqdnSelector", selector).Error("FQDNSelector did not compile to valid regex")
-		n.Mutex.Unlock()
 		return nil
 	}
 
@@ -120,7 +128,6 @@ func (n *NameManager) RegisterForIdentityUpdates(selector api.FQDNSelector) []id
 
 	n.allSelectors[selector] = regex
 	_, selectorIPMapping := mapSelectorsToIPs(map[api.FQDNSelector]struct{}{selector: {}}, n.cache)
-	n.Mutex.Unlock()
 
 	// Allocate identities for each IPNet and then map to selector
 	selectorIPs := selectorIPMapping[selector]
@@ -142,16 +149,14 @@ func (n *NameManager) RegisterForIdentityUpdates(selector api.FQDNSelector) []id
 	return numIDs
 }
 
-// UnregisterForIdentityUpdates removes this FQDNSelector from the set of
+// UnregisterForIdentityUpdatesLocked removes this FQDNSelector from the set of
 // FQDNSelectors which are being tracked by the NameManager. No more updates for IPs
 // which correspond to said selector are propagated.
-func (n *NameManager) UnregisterForIdentityUpdates(selector api.FQDNSelector) {
-	n.Mutex.Lock()
+func (n *NameManager) UnregisterForIdentityUpdatesLocked(selector api.FQDNSelector) {
 	delete(n.allSelectors, selector)
 	if len(selector.MatchName) > 0 {
 		delete(n.namesToPoll, prepareMatchName(selector.MatchName))
 	}
-	n.Mutex.Unlock()
 }
 
 // NewNameManager creates an initialized NameManager.
@@ -198,8 +203,11 @@ func (n *NameManager) GetDNSNames() (dnsNames []string) {
 // have changed for a name, store which rules must be updated in rulesToUpdate,
 // regenerate them, and emit via UpdateSelectors.
 func (n *NameManager) UpdateGenerateDNS(ctx context.Context, lookupTime time.Time, updatedDNSIPs map[string]*DNSIPRecords) (wg *sync.WaitGroup, err error) {
+	n.Mutex.Lock()
+	defer n.Mutex.Unlock()
+
 	// Update IPs in n
-	fqdnSelectorsToUpdate, updatedDNSNames := n.UpdateDNSIPs(lookupTime, updatedDNSIPs)
+	fqdnSelectorsToUpdate, updatedDNSNames := n.updateDNSIPs(lookupTime, updatedDNSIPs)
 	for dnsName, IPs := range updatedDNSNames {
 		log.WithFields(logrus.Fields{
 			"matchName":             dnsName,
@@ -208,7 +216,7 @@ func (n *NameManager) UpdateGenerateDNS(ctx context.Context, lookupTime time.Tim
 		}).Debug("Updated FQDN with new IPs")
 	}
 
-	namesMissingIPs, selectorIPMapping := n.GenerateSelectorUpdates(fqdnSelectorsToUpdate)
+	namesMissingIPs, selectorIPMapping := n.generateSelectorUpdates(fqdnSelectorsToUpdate)
 	if len(namesMissingIPs) != 0 {
 		log.WithField(logfields.DNSName, namesMissingIPs).
 			Debug("No IPs to insert when generating DNS name selected by ToFQDN rule")
@@ -222,6 +230,8 @@ func (n *NameManager) UpdateGenerateDNS(ctx context.Context, lookupTime time.Tim
 // matchNames that match them will cause these rules to regenerate.
 func (n *NameManager) ForceGenerateDNS(ctx context.Context, namesToRegen []string) (wg *sync.WaitGroup, err error) {
 	n.Mutex.Lock()
+	defer n.Mutex.Unlock()
+
 	affectedFQDNSels := make(map[api.FQDNSelector]struct{}, 0)
 	for _, dnsName := range namesToRegen {
 		for fqdnSel, fqdnRegEx := range n.allSelectors {
@@ -236,7 +246,6 @@ func (n *NameManager) ForceGenerateDNS(ctx context.Context, namesToRegen []strin
 		log.WithField(logfields.DNSName, namesMissingIPs).
 			Debug("No IPs to insert when generating DNS name selected by ToFQDN rule")
 	}
-	n.Mutex.Unlock()
 
 	// emit the new rules
 	return n.config.
@@ -249,17 +258,14 @@ func (n *NameManager) CompleteBootstrap() {
 	n.Unlock()
 }
 
-// UpdateDNSIPs updates the IPs for each DNS name in updatedDNSIPs.
+// updateDNSIPs updates the IPs for each DNS name in updatedDNSIPs.
 // It returns:
 // affectedSelectors: a set of all FQDNSelectors which match DNS Names whose
 // corresponding set of IPs has changed.
 // updatedNames: a map of DNS names to all the valid IPs we store for each.
-func (n *NameManager) UpdateDNSIPs(lookupTime time.Time, updatedDNSIPs map[string]*DNSIPRecords) (affectedSelectors map[api.FQDNSelector]struct{}, updatedNames map[string][]net.IP) {
+func (n *NameManager) updateDNSIPs(lookupTime time.Time, updatedDNSIPs map[string]*DNSIPRecords) (affectedSelectors map[api.FQDNSelector]struct{}, updatedNames map[string][]net.IP) {
 	updatedNames = make(map[string][]net.IP, len(updatedDNSIPs))
 	affectedSelectors = make(map[api.FQDNSelector]struct{}, len(updatedDNSIPs))
-
-	n.Lock()
-	defer n.Unlock()
 
 perDNSName:
 	for dnsName, lookupIPs := range updatedDNSIPs {
@@ -295,14 +301,11 @@ perDNSName:
 	return affectedSelectors, updatedNames
 }
 
-// GenerateSelectorUpdates iterates over all names in the DNS cache managed by
+// generateSelectorUpdates iterates over all names in the DNS cache managed by
 // gen and figures out to which FQDNSelectors managed by the cache these names
 // map. Returns the set of FQDNSelectors which map to no IPs, and a mapping
 // of FQDNSelectors to IPs.
-func (n *NameManager) GenerateSelectorUpdates(fqdnSelectors map[api.FQDNSelector]struct{}) (namesMissingIPs []api.FQDNSelector, selectorIPMapping map[api.FQDNSelector][]net.IP) {
-	n.Lock()
-	defer n.Unlock()
-
+func (n *NameManager) generateSelectorUpdates(fqdnSelectors map[api.FQDNSelector]struct{}) (namesMissingIPs []api.FQDNSelector, selectorIPMapping map[api.FQDNSelector][]net.IP) {
 	return mapSelectorsToIPs(fqdnSelectors, n.cache)
 }
 

--- a/pkg/ipcache/cidr.go
+++ b/pkg/ipcache/cidr.go
@@ -71,6 +71,9 @@ func allocateCIDRs(prefixes []*net.IPNet) ([]*identity.Identity, error) {
 		allocateCtx, cancel := context.WithTimeout(context.Background(), option.Config.IPAllocationTimeout)
 		defer cancel()
 
+		if IdentityAllocator == nil {
+			return nil, fmt.Errorf("IdentityAllocator not initialized!")
+		}
 		id, isNew, err := IdentityAllocator.AllocateIdentity(allocateCtx, cidr.GetCIDRLabels(prefix), false)
 		if err != nil {
 			IdentityAllocator.ReleaseSlice(context.Background(), nil, usedIdentities)

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/testutils"
 
 	. "gopkg.in/check.v1"
 	v1 "k8s.io/api/core/v1"
@@ -100,6 +101,12 @@ var (
 
 type DummySelectorCacheUser struct{}
 
+func testNewPolicyRepository() *policy.Repository {
+	repo := policy.NewPolicyRepository(nil, nil)
+	repo.GetSelectorCache().SetLocalIdentityNotifier(testutils.NewDummyIdentityNotifier())
+	return repo
+}
+
 func (d *DummySelectorCacheUser) IdentitySelectionUpdated(selector policy.CachedSelector, selections, added, deleted []identity.NumericIdentity) {
 }
 
@@ -160,7 +167,7 @@ func (s *K8sSuite) TestParseNetworkPolicyIngress(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(len(rules), Equals, 1)
 
-	repo := policy.NewPolicyRepository(nil, nil)
+	repo := testNewPolicyRepository()
 
 	repo.AddList(rules)
 	c.Assert(repo.AllowsIngressRLocked(&ctx), Equals, api.Denied)
@@ -288,7 +295,7 @@ func (s *K8sSuite) TestParseNetworkPolicyMultipleSelectors(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(len(rules), Equals, 1)
 
-	repo := policy.NewPolicyRepository(nil, nil)
+	repo := testNewPolicyRepository()
 	repo.AddList(rules)
 
 	endpointLabels := labels.LabelArray{
@@ -486,7 +493,7 @@ func (s *K8sSuite) TestParseNetworkPolicyEgress(c *C) {
 		Trace: policy.TRACE_VERBOSE,
 	}
 
-	repo := policy.NewPolicyRepository(nil, nil)
+	repo := testNewPolicyRepository()
 	repo.AddList(rules)
 	// Because search context did not contain port-specific policy, deny is
 	// expected.
@@ -540,7 +547,7 @@ func (s *K8sSuite) TestParseNetworkPolicyEgress(c *C) {
 }
 
 func parseAndAddRules(c *C, p *networkingv1.NetworkPolicy) *policy.Repository {
-	repo := policy.NewPolicyRepository(nil, nil)
+	repo := testNewPolicyRepository()
 	rules, err := ParseNetworkPolicy(p)
 	c.Assert(err, IsNil)
 	rev := repo.GetRevision()
@@ -698,7 +705,7 @@ func (s *K8sSuite) TestParseNetworkPolicyEmptyFrom(c *C) {
 		Trace: policy.TRACE_VERBOSE,
 	}
 
-	repo := policy.NewPolicyRepository(nil, nil)
+	repo := testNewPolicyRepository()
 	repo.AddList(rules)
 	c.Assert(repo.AllowsIngressRLocked(&ctx), Equals, api.Allowed)
 
@@ -722,7 +729,7 @@ func (s *K8sSuite) TestParseNetworkPolicyEmptyFrom(c *C) {
 	rules, err = ParseNetworkPolicy(netPolicy2)
 	c.Assert(err, IsNil)
 	c.Assert(len(rules), Equals, 1)
-	repo = policy.NewPolicyRepository(nil, nil)
+	repo = testNewPolicyRepository()
 	repo.AddList(rules)
 	c.Assert(repo.AllowsIngressRLocked(&ctx), Equals, api.Allowed)
 }
@@ -753,7 +760,7 @@ func (s *K8sSuite) TestParseNetworkPolicyDenyAll(c *C) {
 		Trace: policy.TRACE_VERBOSE,
 	}
 
-	repo := policy.NewPolicyRepository(nil, nil)
+	repo := testNewPolicyRepository()
 	repo.AddList(rules)
 	c.Assert(repo.AllowsIngressRLocked(&ctx), Equals, api.Denied)
 }
@@ -864,7 +871,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(len(rules), Equals, 1)
 
-	repo := policy.NewPolicyRepository(nil, nil)
+	repo := testNewPolicyRepository()
 	repo.AddList(rules)
 	ctx := policy.SearchContext{
 		From: labels.LabelArray{
@@ -998,7 +1005,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(len(rules), Equals, 1)
 
-	repo = policy.NewPolicyRepository(nil, nil)
+	repo = testNewPolicyRepository()
 	repo.AddList(rules)
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
@@ -1066,7 +1073,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(len(rules), Equals, 1)
 
-	repo = policy.NewPolicyRepository(nil, nil)
+	repo = testNewPolicyRepository()
 	repo.AddList(rules)
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
@@ -1205,7 +1212,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(len(rules), Equals, 1)
 
-	repo = policy.NewPolicyRepository(nil, nil)
+	repo = testNewPolicyRepository()
 	// add example 4
 	repo.AddList(rules)
 

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -329,7 +329,7 @@ func Test_MergeL3(t *testing.T) {
 		identity.NumericIdentity(identityFoo): labelsFoo,
 		identity.NumericIdentity(identityBar): labelsBar,
 	}
-	selectorCache := NewSelectorCache(identityCache)
+	selectorCache := testNewSelectorCache(identityCache)
 
 	tests := []struct {
 		test   int
@@ -368,7 +368,7 @@ func Test_MergeRules(t *testing.T) {
 	identityCache := cache.IdentityCache{
 		identity.NumericIdentity(identityFoo): labelsFoo,
 	}
-	selectorCache := NewSelectorCache(identityCache)
+	selectorCache := testNewSelectorCache(identityCache)
 
 	tests := []struct {
 		test   int
@@ -441,7 +441,7 @@ func Test_AllowAll(t *testing.T) {
 		identity.NumericIdentity(identityFoo): labelsFoo,
 		identity.NumericIdentity(identityBar): labelsBar,
 	}
-	selectorCache := NewSelectorCache(identityCache)
+	selectorCache := testNewSelectorCache(identityCache)
 
 	tests := []struct {
 		test     int

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -333,7 +333,8 @@ func (l4 *L4Filter) ToMapState(direction trafficdirection.TrafficDirection) MapS
 }
 
 // IdentitySelectionUpdated implements CachedSelectionUser interface
-// This call is made while holding selector cache lock, must beware of deadlocking!
+// This call is made while holding name manager and selector cache
+// locks, must beware of deadlocking!
 //
 // The caller is responsible for making sure the same identity is not
 // present in both 'added' and 'deleted'.

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -38,7 +38,7 @@ var (
 
 	dummySelectorCacheUser = &DummySelectorCacheUser{}
 	c                      = cache.NewCachingIdentityAllocator(&allocator.IdentityAllocatorOwnerMock{})
-	testSelectorCache      = NewSelectorCache(c.GetIdentityCache())
+	testSelectorCache      = testNewSelectorCache(c.GetIdentityCache())
 
 	wildcardCachedSelector, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, api.WildcardEndpointSelector)
 

--- a/pkg/testutils/identitynotifier.go
+++ b/pkg/testutils/identitynotifier.go
@@ -1,0 +1,68 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutils
+
+import (
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/policy/api"
+)
+
+type DummyIdentityNotifier struct {
+	mutex     lock.Mutex
+	selectors map[api.FQDNSelector][]identity.NumericIdentity
+}
+
+func NewDummyIdentityNotifier() *DummyIdentityNotifier {
+	return &DummyIdentityNotifier{
+		selectors: make(map[api.FQDNSelector][]identity.NumericIdentity),
+	}
+}
+
+// Lock must be held during any calls to RegisterForIdentityUpdatesLocked or
+// UnregisterForIdentityUpdatesLocked.
+func (d *DummyIdentityNotifier) Lock() {
+	d.mutex.Lock()
+}
+
+// Unlock must be called after calls to RegisterForIdentityUpdatesLocked or
+// UnregisterForIdentityUpdatesLocked are done.
+func (d *DummyIdentityNotifier) Unlock() {
+	d.mutex.Unlock()
+}
+
+// RegisterForIdentityUpdatesLocked starts managing this selector.
+func (d *DummyIdentityNotifier) RegisterForIdentityUpdatesLocked(selector api.FQDNSelector) (identities []identity.NumericIdentity) {
+	ids, ok := d.selectors[selector]
+	if !ok {
+		d.selectors[selector] = []identity.NumericIdentity{}
+	}
+	return ids
+}
+
+// UnregisterForIdentityUpdatesLocked stops managing this selector.
+func (d *DummyIdentityNotifier) UnregisterForIdentityUpdatesLocked(selector api.FQDNSelector) {
+	delete(d.selectors, selector)
+}
+
+func (d *DummyIdentityNotifier) InjectIdentitiesForSelector(fqdnSel api.FQDNSelector, ids []identity.NumericIdentity) {
+	d.selectors[fqdnSel] = ids
+}
+
+// IsRegistered returns whether this selector is being managed.
+func (d *DummyIdentityNotifier) IsRegistered(selector api.FQDNSelector) bool {
+	_, ok := d.selectors[selector]
+	return ok
+}


### PR DESCRIPTION
UpdateGenerateDNS updated the cache and generate selector updates as two
separate lock-holding sections. When updates happened concurrently, via
DNS lookups, DNS GC, or endpoint restores, the snapshot of data that
eventually updated the selectors could be out-of-order. This created an
A-B-A race for selectors that needed an update and those that needed to
be cleared.

These races have been observed on agent starts with pending pods but may
manifest between multiple pods making DNS updates or the DNS garbage
collector controller and any pod.

The code now holds the NameManager lock for the entirety of
UpdateGenerateDNS and ForceRegenerateDNS. This forces the update to
complete in its entirety before allowing another to modify the FQDN
cache or registered selectors.

The locking order between the NameManager lock and the SelectorCache
lock has been accidental so far. When removing a selector user from
the cache, the SelectorCache lock is taken, and if an FQDN selector
has no more users, the NameManager is notified of this, which
internally takes the NameManager lock. Reverse this by explicitly
locking NamaManager for the duration of selector cache operations.

From now on, if the two locks are to be held at the same time, the
NameManager mutex MUST be taken first, the SelectorCache mutex second,
as the name manager is a higher level construct than the selector
cache.

Exposing 'Lock()' and 'Unlock()' operations in an interface is not
ideal, but it helps make the lockinng order explicit, so it also
serves as documentation on the required locking order.

NameManager now return IDs also if the selector has already been
registered. This should help not get into a state where FQDNs are not
passed to the selector cache in case of a race condition.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10501)
<!-- Reviewable:end -->
