### PR TITLE
Docs: Add step for mounting bpf filesystem on k3s installations

### DIFF
--- a/Documentation/gettingstarted/k3s.rst
+++ b/Documentation/gettingstarted/k3s.rst
@@ -50,6 +50,12 @@ Should you encounter any issues during the installation, please refer to the
 Please consult the Kubernetes :ref:`k8s_requirements` for information on  how
 you need to configure your Kubernetes cluster to operate with Cilium.
 
+Mount the BPF Filesystem
+========================
+On each node, run the following to mount the BPF Filesystem:
+::
+
+     sudo mount bpffs -t bpf /sys/fs/bpf
 
 Install Cilium
 ==============


### PR DESCRIPTION
Add documentation step for adding a bpf filesystem mount on k3s installations
Fixes: #10507

Signed-off-by: Sean Winn <sean@isovalent.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10508)
<!-- Reviewable:end -->
