### PR TITLE
Allow to configure bpf-nat-global-max using Helm

### DIFF
--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -136,6 +136,10 @@ data:
   bpf-ct-global-tcp-max: "{{ .Values.global.bpf.ctTcpMax }}"
   bpf-ct-global-any-max: "{{ .Values.global.bpf.ctAnyMax }}"
 
+  # bpf-nat-global-max specified the maximum number of entries in the BPF NAT
+  # table.
+  bpf-nat-global-max: "{{ .Values.global.bpf.natMax }}"
+
   # Pre-allocation of map entries allows per-packet latency to be reduced, at
   # the expense of up-front memory allocation for the entries in the maps. The
   # default value below will minimize memory usage in the default installation;

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -202,6 +202,9 @@ global:
     # tracking table
     ctAnyMax: 262144
 
+    # natMax is the maximum number of entries for the NAT table
+    natMax: 841429
+
     # montiorAggregation is the level of aggregation for datapath trace events
     monitorAggregation: medium
 

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -75,6 +75,10 @@ data:
   bpf-ct-global-tcp-max: "524288"
   bpf-ct-global-any-max: "262144"
 
+  # bpf-nat-global-max specified the maximum number of entries in the BPF NAT
+  # table.
+  bpf-nat-global-max: "841429"
+
   # Pre-allocation of map entries allows per-packet latency to be reduced, at
   # the expense of up-front memory allocation for the entries in the maps. The
   # default value below will minimize memory usage in the default installation;

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -144,6 +144,7 @@ data:
   enable-remote-node-identity: "true"
 
   synchronize-k8s-nodes: "true"
+  policy-audit-mode: "false"
   operator-api-serve-addr: '127.0.0.1:9234'
 ---
 # Source: cilium/charts/agent/templates/clusterrole.yaml


### PR DESCRIPTION
Allow to configure the `bpf-nat-global-max` option using Helm. Set the value to the current value of `option.NATMapEntriesGlobalDefault`. This will allow to reduce it in PR #10289 in accordance with `bpf-ct-global-tcp-max`.

Also, as a preparatory commit re-generate quick-install.yaml after PR #9970 for the newly added `policy-audit-node` option.

To be merged before PR #10289

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10511)
<!-- Reviewable:end -->
