### PR TITLE
policy: Track policy rule labels from which map entries are derived from

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -751,3 +751,23 @@ func (e *Endpoint) UpdateVisibilityPolicy(annoCB AnnotationsResolverCB) {
 	}
 	<-ch
 }
+
+// GetRealizedPolicyRuleLabelsForKey returns the list of policy rule labels
+// which match a given flow key (in host byte-order). The returned
+// LabelArrayList must not be modified. This function is exported to be
+// accessed by code outside of the Cilium code base (e.g. Hubble).
+func (e *Endpoint) GetRealizedPolicyRuleLabelsForKey(key policy.Key) (
+	derivedFrom labels.LabelArrayList,
+	revision uint64,
+	ok bool,
+) {
+	e.mutex.RLock()
+	defer e.mutex.RUnlock()
+
+	entry, ok := e.realizedPolicy.PolicyMapState[key]
+	if !ok {
+		return nil, 0, false
+	}
+
+	return entry.DerivedFromRules, e.policyRevision, true
+}

--- a/pkg/labels/array.go
+++ b/pkg/labels/array.go
@@ -225,3 +225,36 @@ func (ls LabelArray) Equals(b LabelArray) bool {
 	}
 	return true
 }
+
+// Less returns true if ls comes before b in the lexicographical order.
+// Assumes both ls and b are already sorted.
+func (ls LabelArray) Less(b LabelArray) bool {
+	lsLen, bLen := len(ls), len(b)
+
+	minLen := lsLen
+	if bLen < minLen {
+		minLen = bLen
+	}
+
+	for i := 0; i < minLen; i++ {
+		switch {
+		// Key
+		case ls[i].Key < b[i].Key:
+			return true
+		case ls[i].Key > b[i].Key:
+			return false
+		// Value
+		case ls[i].Value < b[i].Value:
+			return true
+		case ls[i].Value > b[i].Value:
+			return false
+		// Source
+		case ls[i].Source < b[i].Source:
+			return true
+		case ls[i].Source > b[i].Source:
+			return false
+		}
+	}
+
+	return lsLen < bLen
+}

--- a/pkg/labels/array.go
+++ b/pkg/labels/array.go
@@ -213,8 +213,8 @@ func (ls LabelArray) StringMap() map[string]string {
 	return o
 }
 
-// Same returns true if the label arrays are the same, i.e., have the same labels in the same order.
-func (ls LabelArray) Same(b LabelArray) bool {
+// Equals returns true if the label arrays are the same, i.e., have the same labels in the same order.
+func (ls LabelArray) Equals(b LabelArray) bool {
 	if len(ls) != len(b) {
 		return false
 	}

--- a/pkg/labels/array_test.go
+++ b/pkg/labels/array_test.go
@@ -84,7 +84,7 @@ func (s *LabelsSuite) TestHas(c *C) {
 	}
 }
 
-func (s *LabelsSuite) TestSame(c *C) {
+func (s *LabelsSuite) TestEquals(c *C) {
 	lbls1 := LabelArray{
 		NewLabel("env", "devel", LabelSourceAny),
 		NewLabel("user", "bob", LabelSourceContainer),
@@ -105,47 +105,48 @@ func (s *LabelsSuite) TestSame(c *C) {
 	}
 	lbls6 := LabelArray{}
 
-	c.Assert(lbls1.Same(lbls1), Equals, true)
-	c.Assert(lbls1.Same(lbls2), Equals, true)
-	c.Assert(lbls1.Same(lbls3), Equals, false) // inverted order
-	c.Assert(lbls1.Same(lbls4), Equals, false) // different count
-	c.Assert(lbls1.Same(lbls5), Equals, false)
-	c.Assert(lbls1.Same(lbls6), Equals, false)
+	c.Assert(lbls1.Equals(lbls1), Equals, true)
+	c.Assert(lbls1.Equals(lbls2), Equals, true)
+	c.Assert(lbls1.Equals(lbls3), Equals, false) // inverted order
+	c.Assert(lbls1.Equals(lbls4), Equals, false) // different count
+	c.Assert(lbls1.Equals(lbls5), Equals, false)
+	c.Assert(lbls1.Equals(lbls6), Equals, false)
 
-	c.Assert(lbls2.Same(lbls1), Equals, true)
-	c.Assert(lbls2.Same(lbls2), Equals, true)
-	c.Assert(lbls2.Same(lbls3), Equals, false) // inverted order
-	c.Assert(lbls2.Same(lbls4), Equals, false) // different count
-	c.Assert(lbls2.Same(lbls5), Equals, false)
-	c.Assert(lbls2.Same(lbls6), Equals, false)
+	c.Assert(lbls2.Equals(lbls1), Equals, true)
+	c.Assert(lbls2.Equals(lbls2), Equals, true)
+	c.Assert(lbls2.Equals(lbls3), Equals, false) // inverted order
+	c.Assert(lbls2.Equals(lbls4), Equals, false) // different count
+	c.Assert(lbls2.Equals(lbls5), Equals, false)
+	c.Assert(lbls2.Equals(lbls6), Equals, false)
 
-	c.Assert(lbls3.Same(lbls1), Equals, false)
-	c.Assert(lbls3.Same(lbls2), Equals, false)
-	c.Assert(lbls3.Same(lbls3), Equals, true)
-	c.Assert(lbls3.Same(lbls4), Equals, false)
-	c.Assert(lbls3.Same(lbls5), Equals, false)
-	c.Assert(lbls3.Same(lbls6), Equals, false)
+	c.Assert(lbls3.Equals(lbls1), Equals, false)
+	c.Assert(lbls3.Equals(lbls2), Equals, false)
+	c.Assert(lbls3.Equals(lbls3), Equals, true)
+	c.Assert(lbls3.Equals(lbls4), Equals, false)
+	c.Assert(lbls3.Equals(lbls5), Equals, false)
+	c.Assert(lbls3.Equals(lbls6), Equals, false)
 
-	c.Assert(lbls4.Same(lbls1), Equals, false)
-	c.Assert(lbls4.Same(lbls2), Equals, false)
-	c.Assert(lbls4.Same(lbls3), Equals, false)
-	c.Assert(lbls4.Same(lbls4), Equals, true)
-	c.Assert(lbls4.Same(lbls5), Equals, false)
-	c.Assert(lbls4.Same(lbls6), Equals, false)
+	c.Assert(lbls4.Equals(lbls1), Equals, false)
+	c.Assert(lbls4.Equals(lbls2), Equals, false)
+	c.Assert(lbls4.Equals(lbls3), Equals, false)
+	c.Assert(lbls4.Equals(lbls4), Equals, true)
+	c.Assert(lbls4.Equals(lbls5), Equals, false)
+	c.Assert(lbls4.Equals(lbls6), Equals, false)
 
-	c.Assert(lbls5.Same(lbls1), Equals, false)
-	c.Assert(lbls5.Same(lbls2), Equals, false)
-	c.Assert(lbls5.Same(lbls3), Equals, false)
-	c.Assert(lbls5.Same(lbls4), Equals, false)
-	c.Assert(lbls5.Same(lbls5), Equals, true)
-	c.Assert(lbls5.Same(lbls6), Equals, false)
+	c.Assert(lbls5.Equals(lbls1), Equals, false)
+	c.Assert(lbls5.Equals(lbls2), Equals, false)
+	c.Assert(lbls5.Equals(lbls3), Equals, false)
+	c.Assert(lbls5.Equals(lbls4), Equals, false)
+	c.Assert(lbls5.Equals(lbls5), Equals, true)
+	c.Assert(lbls5.Equals(lbls6), Equals, false)
 
-	c.Assert(lbls6.Same(lbls1), Equals, false)
-	c.Assert(lbls6.Same(lbls2), Equals, false)
-	c.Assert(lbls6.Same(lbls3), Equals, false)
-	c.Assert(lbls6.Same(lbls4), Equals, false)
-	c.Assert(lbls6.Same(lbls5), Equals, false)
-	c.Assert(lbls6.Same(lbls6), Equals, true)
+	c.Assert(lbls6.Equals(lbls1), Equals, false)
+	c.Assert(lbls6.Equals(lbls2), Equals, false)
+	c.Assert(lbls6.Equals(lbls3), Equals, false)
+	c.Assert(lbls6.Equals(lbls4), Equals, false)
+	c.Assert(lbls6.Equals(lbls5), Equals, false)
+	c.Assert(lbls6.Equals(lbls6), Equals, true)
+}
 }
 
 // TestOutputConversions tests the various ways a LabelArray can be converted

--- a/pkg/labels/array_test.go
+++ b/pkg/labels/array_test.go
@@ -147,6 +147,107 @@ func (s *LabelsSuite) TestEquals(c *C) {
 	c.Assert(lbls6.Equals(lbls5), Equals, false)
 	c.Assert(lbls6.Equals(lbls6), Equals, true)
 }
+
+func (s *LabelsSuite) TestLess(c *C) {
+	// lbls1-lbls8 are defined in lexical order
+	lbls1 := LabelArray(nil)
+	lbls2 := LabelArray{
+		NewLabel("env", "devel", LabelSourceAny),
+	}
+	lbls3 := LabelArray{
+		NewLabel("env", "devel", LabelSourceReserved),
+	}
+	lbls4 := LabelArray{
+		NewLabel("env", "prod", LabelSourceAny),
+	}
+	lbls5 := LabelArray{
+		NewLabel("env", "prod", LabelSourceAny),
+		NewLabel("user", "bob", LabelSourceContainer),
+	}
+	lbls6 := LabelArray{
+		NewLabel("env", "prod", LabelSourceAny),
+		NewLabel("user", "bob", LabelSourceContainer),
+	}
+	lbls7 := LabelArray{
+		NewLabel("env", "prod", LabelSourceAny),
+		NewLabel("user", "bob", LabelSourceContainer),
+		NewLabel("xyz", "", LabelSourceAny),
+	}
+	lbls8 := LabelArray{
+		NewLabel("foo", "bar", LabelSourceAny),
+	}
+
+	c.Assert(lbls1.Less(lbls1), Equals, false)
+	c.Assert(lbls1.Less(lbls2), Equals, true)
+	c.Assert(lbls1.Less(lbls3), Equals, true)
+	c.Assert(lbls1.Less(lbls4), Equals, true)
+	c.Assert(lbls1.Less(lbls5), Equals, true)
+	c.Assert(lbls1.Less(lbls6), Equals, true)
+	c.Assert(lbls1.Less(lbls7), Equals, true)
+	c.Assert(lbls1.Less(lbls8), Equals, true)
+
+	c.Assert(lbls2.Less(lbls1), Equals, false)
+	c.Assert(lbls2.Less(lbls2), Equals, false)
+	c.Assert(lbls2.Less(lbls3), Equals, true)
+	c.Assert(lbls2.Less(lbls4), Equals, true)
+	c.Assert(lbls2.Less(lbls5), Equals, true)
+	c.Assert(lbls2.Less(lbls6), Equals, true)
+	c.Assert(lbls2.Less(lbls7), Equals, true)
+	c.Assert(lbls2.Less(lbls8), Equals, true)
+
+	c.Assert(lbls3.Less(lbls1), Equals, false)
+	c.Assert(lbls3.Less(lbls2), Equals, false)
+	c.Assert(lbls3.Less(lbls3), Equals, false)
+	c.Assert(lbls3.Less(lbls4), Equals, true)
+	c.Assert(lbls3.Less(lbls5), Equals, true)
+	c.Assert(lbls3.Less(lbls6), Equals, true)
+	c.Assert(lbls3.Less(lbls7), Equals, true)
+	c.Assert(lbls3.Less(lbls8), Equals, true)
+
+	c.Assert(lbls4.Less(lbls1), Equals, false)
+	c.Assert(lbls4.Less(lbls2), Equals, false)
+	c.Assert(lbls4.Less(lbls3), Equals, false)
+	c.Assert(lbls4.Less(lbls4), Equals, false)
+	c.Assert(lbls4.Less(lbls5), Equals, true)
+	c.Assert(lbls4.Less(lbls6), Equals, true)
+	c.Assert(lbls4.Less(lbls7), Equals, true)
+	c.Assert(lbls4.Less(lbls8), Equals, true)
+
+	c.Assert(lbls5.Less(lbls1), Equals, false)
+	c.Assert(lbls5.Less(lbls2), Equals, false)
+	c.Assert(lbls5.Less(lbls3), Equals, false)
+	c.Assert(lbls5.Less(lbls4), Equals, false)
+	c.Assert(lbls5.Less(lbls5), Equals, false)
+	c.Assert(lbls5.Less(lbls6), Equals, false)
+	c.Assert(lbls5.Less(lbls7), Equals, true)
+	c.Assert(lbls5.Less(lbls8), Equals, true)
+
+	c.Assert(lbls6.Less(lbls1), Equals, false)
+	c.Assert(lbls6.Less(lbls2), Equals, false)
+	c.Assert(lbls6.Less(lbls3), Equals, false)
+	c.Assert(lbls6.Less(lbls4), Equals, false)
+	c.Assert(lbls6.Less(lbls5), Equals, false)
+	c.Assert(lbls6.Less(lbls6), Equals, false)
+	c.Assert(lbls6.Less(lbls7), Equals, true)
+	c.Assert(lbls6.Less(lbls8), Equals, true)
+
+	c.Assert(lbls7.Less(lbls1), Equals, false)
+	c.Assert(lbls7.Less(lbls2), Equals, false)
+	c.Assert(lbls7.Less(lbls3), Equals, false)
+	c.Assert(lbls7.Less(lbls4), Equals, false)
+	c.Assert(lbls7.Less(lbls5), Equals, false)
+	c.Assert(lbls7.Less(lbls6), Equals, false)
+	c.Assert(lbls7.Less(lbls7), Equals, false)
+	c.Assert(lbls7.Less(lbls8), Equals, true)
+
+	c.Assert(lbls8.Less(lbls1), Equals, false)
+	c.Assert(lbls8.Less(lbls2), Equals, false)
+	c.Assert(lbls8.Less(lbls3), Equals, false)
+	c.Assert(lbls8.Less(lbls4), Equals, false)
+	c.Assert(lbls8.Less(lbls5), Equals, false)
+	c.Assert(lbls8.Less(lbls6), Equals, false)
+	c.Assert(lbls8.Less(lbls7), Equals, false)
+	c.Assert(lbls8.Less(lbls8), Equals, false)
 }
 
 // TestOutputConversions tests the various ways a LabelArray can be converted

--- a/pkg/labels/arraylist.go
+++ b/pkg/labels/arraylist.go
@@ -14,6 +14,8 @@
 
 package labels
 
+import "sort"
+
 // LabelArrayList is an array of LabelArrays. It is primarily intended as a
 // simple collection
 type LabelArrayList []LabelArray
@@ -39,4 +41,28 @@ func (ls LabelArrayList) GetModel() [][]string {
 		res = append(res, v.GetModel())
 	}
 	return res
+}
+
+// Equals returns true if the label arrays lists have the same label arrays in the same order.
+func (ls LabelArrayList) Equals(b LabelArrayList) bool {
+	if len(ls) != len(b) {
+		return false
+	}
+	for l := range ls {
+		if !ls[l].Equals(b[l]) {
+			return false
+		}
+	}
+	return true
+}
+
+// Sort sorts the LabelArrayList in-place, but also returns the sorted list
+// for convenience. The LabelArrays themselves must already be sorted. This is
+// true for all constructors of LabelArray.
+func (ls LabelArrayList) Sort() LabelArrayList {
+	sort.Slice(ls, func(i, j int) bool {
+		return ls[i].Less(ls[j])
+	})
+
+	return ls
 }

--- a/pkg/labels/arraylist_test.go
+++ b/pkg/labels/arraylist_test.go
@@ -1,0 +1,176 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package labels
+
+import (
+	"github.com/cilium/cilium/pkg/checker"
+	. "gopkg.in/check.v1"
+)
+
+func (s *LabelsSuite) TestLabelArrayListEquals(c *C) {
+	list1 := LabelArrayList{
+		{
+			NewLabel("env", "devel", LabelSourceAny),
+			NewLabel("user", "bob", LabelSourceContainer),
+		},
+		{
+			NewLabel("foo", "bar", LabelSourceAny),
+		},
+	}
+	list2 := LabelArrayList{
+		{
+			NewLabel("env", "devel", LabelSourceAny),
+			NewLabel("user", "bob", LabelSourceContainer),
+		},
+		{
+			NewLabel("foo", "bar", LabelSourceAny),
+		},
+	}
+	list3 := LabelArrayList{
+		{
+			NewLabel("foo", "bar", LabelSourceAny),
+		},
+		{
+			NewLabel("env", "devel", LabelSourceAny),
+			NewLabel("user", "bob", LabelSourceContainer),
+		},
+	}
+	list4 := LabelArrayList{
+		{
+			NewLabel("env", "devel", LabelSourceAny),
+			NewLabel("user", "bob", LabelSourceContainer),
+		},
+	}
+	list5 := LabelArrayList(nil)
+	list6 := LabelArrayList{}
+
+	c.Assert(list1.Equals(list1), Equals, true)
+	c.Assert(list1.Equals(list2), Equals, true)
+	c.Assert(list1.Equals(list3), Equals, false)
+	c.Assert(list1.Equals(list4), Equals, false)
+	c.Assert(list1.Equals(list5), Equals, false)
+	c.Assert(list1.Equals(list6), Equals, false)
+
+	c.Assert(list2.Equals(list1), Equals, true)
+	c.Assert(list2.Equals(list2), Equals, true)
+	c.Assert(list2.Equals(list3), Equals, false)
+	c.Assert(list2.Equals(list4), Equals, false)
+	c.Assert(list2.Equals(list5), Equals, false)
+	c.Assert(list2.Equals(list6), Equals, false)
+
+	c.Assert(list3.Equals(list1), Equals, false)
+	c.Assert(list3.Equals(list2), Equals, false)
+	c.Assert(list3.Equals(list3), Equals, true)
+	c.Assert(list3.Equals(list4), Equals, false)
+	c.Assert(list3.Equals(list5), Equals, false)
+	c.Assert(list3.Equals(list6), Equals, false)
+
+	c.Assert(list4.Equals(list1), Equals, false)
+	c.Assert(list4.Equals(list2), Equals, false)
+	c.Assert(list4.Equals(list3), Equals, false)
+	c.Assert(list4.Equals(list4), Equals, true)
+	c.Assert(list4.Equals(list5), Equals, false)
+	c.Assert(list4.Equals(list6), Equals, false)
+
+	c.Assert(list5.Equals(list1), Equals, false)
+	c.Assert(list5.Equals(list2), Equals, false)
+	c.Assert(list5.Equals(list3), Equals, false)
+	c.Assert(list5.Equals(list4), Equals, false)
+	c.Assert(list5.Equals(list5), Equals, true)
+	c.Assert(list5.Equals(list6), Equals, true)
+
+	c.Assert(list6.Equals(list1), Equals, false)
+	c.Assert(list6.Equals(list2), Equals, false)
+	c.Assert(list6.Equals(list3), Equals, false)
+	c.Assert(list6.Equals(list4), Equals, false)
+	c.Assert(list6.Equals(list5), Equals, true)
+	c.Assert(list6.Equals(list6), Equals, true)
+}
+
+func (s *LabelsSuite) TestLabelArrayListSort(c *C) {
+	c.Assert(LabelArrayList(nil).Sort(), checker.DeepEquals, LabelArrayList(nil))
+	c.Assert(LabelArrayList{}.Sort(), checker.DeepEquals, LabelArrayList{})
+
+	list1 := LabelArrayList{
+		{
+			NewLabel("env", "devel", LabelSourceAny),
+			NewLabel("user", "bob", LabelSourceContainer),
+		},
+		{
+			NewLabel("aaa", "", LabelSourceReserved),
+		},
+		{
+			NewLabel("env", "devel", LabelSourceAny),
+			NewLabel("user", "bob", LabelSourceContainer),
+			NewLabel("xyz", "", LabelSourceAny),
+		},
+		{
+			NewLabel("env", "devel", LabelSourceAny),
+		},
+		nil,
+		{
+			NewLabel("foo", "bar", LabelSourceAny),
+		},
+	}
+	expected1 := LabelArrayList{
+		nil,
+		{
+			NewLabel("aaa", "", LabelSourceReserved),
+		},
+		{
+			NewLabel("env", "devel", LabelSourceAny),
+		},
+		{
+			NewLabel("env", "devel", LabelSourceAny),
+			NewLabel("user", "bob", LabelSourceContainer),
+		},
+		{
+			NewLabel("env", "devel", LabelSourceAny),
+			NewLabel("user", "bob", LabelSourceContainer),
+			NewLabel("xyz", "", LabelSourceAny),
+		},
+		{
+			NewLabel("foo", "bar", LabelSourceAny),
+		},
+	}
+
+	c.Assert(list1.Sort(), checker.DeepEquals, expected1)
+
+	list2 := LabelArrayList{
+		{
+			NewLabel("aaa", "", LabelSourceReserved),
+		},
+		{
+			NewLabel("env", "devel", LabelSourceAny),
+		},
+		{
+			NewLabel("aaa", "", LabelSourceAny),
+		},
+	}
+	expected2 := LabelArrayList{
+		{
+			NewLabel("aaa", "", LabelSourceAny),
+		},
+		{
+			NewLabel("aaa", "", LabelSourceReserved),
+		},
+		{
+			NewLabel("env", "devel", LabelSourceAny),
+		},
+	}
+	c.Assert(list2.Sort(), checker.DeepEquals, expected2)
+}

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -157,13 +157,13 @@ func (p *EndpointPolicy) computeDirectionL4PolicyMapEntries(l4PolicyMap L4Policy
 		keysFromFilter := filter.ToMapState(direction)
 		for keyFromFilter, entry := range keysFromFilter {
 			// Fix up the proxy port for entries that need proxy redirection
-			if entry != NoRedirectEntry {
+			if entry.IsRedirectEntry() {
 				entry.ProxyPort = p.PolicyOwner.LookupRedirectPort(filter)
 				// If the currently allocated proxy port is 0, this is a new
 				// redirect, for which no port has been allocated yet. Ignore
 				// it for now. This will be configured by
 				// e.addNewRedirectsFromDesiredPolicy() once the port has been allocated.
-				if entry == NoRedirectEntry {
+				if !entry.IsRedirectEntry() {
 					continue
 				}
 			}

--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -791,7 +791,7 @@ func (sc *SelectorCache) UpdateIdentities(added, deleted cache.IdentityCache) {
 			// order is different, but identity labels are
 			// sorted for the kv-store, so there should
 			// not be too many false negatives.
-			if lbls.Same(old.lbls) {
+			if lbls.Equals(old.lbls) {
 				log.WithFields(logrus.Fields{logfields.Identity: numericID}).Debug("UpdateIdentities: Skipping add of an existing identical identity")
 				delete(added, numericID)
 				continue


### PR DESCRIPTION
This PR allows us to track the policies for which a certain policy map entry has been created.

It is implemented by copying over the `DerivedFromRules` from the merged ingress/egress filters to the user-space representation of the policy map state. These entries are then moved over into the `realizedPolicy` of each endpoint when the policy maps are synced.

Since the order of the `DerivedFromRules` rules is not deterministic, we create a sorted copy of each `LabelArrayList`. Default entries such as `AllowAnyIngress`, `AllowAnyEgress` and `AllowLocalHostIngress` are annotated with artificial labels (of label source `reserved`).

---

Note to reviewer: This is the successor PR to #10293 - but with proper test coverage this time and hopefully addresses the feedback given in the other PR. Review per commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10512)
<!-- Reviewable:end -->
