### PR TITLE
Add new cilium docker file target for linux developers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,6 +205,15 @@ install-container: install-bpf
 GIT_VERSION: .git
 	echo "$(GIT_VERSION)" >GIT_VERSION
 
+docker-cilium-image-for-developers:
+	# DOCKER_BUILDKIT allows for faster build as well as the ability to use
+	# a dedicated dockerignore file per Dockerfile.
+	DOCKER_BUILDKIT=1 $(CONTAINER_ENGINE_FULL) build \
+	     --build-arg LOCKDEBUG=\
+	     --build-arg V=\
+	     --build-arg LIBNETWORK_PLUGIN=\
+	     -t "cilium/cilium-dev:"latest"" . -f ./cilium-dev.Dockerfile
+
 docker-image: clean docker-image-no-clean docker-operator-image docker-plugin-image
 
 docker-image-no-clean: GIT_VERSION

--- a/cilium-dev.Dockerfile
+++ b/cilium-dev.Dockerfile
@@ -1,0 +1,35 @@
+# This image tag should only be used for development when developers
+# want to generate a docker image based on the binaries available in their
+# development environmennt
+FROM quay.io/cilium/cilium-envoy:63de0bd958d05d82e2396125dcf6286d92464c56 as cilium-envoy
+
+FROM quay.io/cilium/cilium-runtime:2020-02-27
+LABEL maintainer="maintainer@cilium.io"
+RUN apt-get install make -y
+WORKDIR /go/src/github.com/cilium/cilium
+ARG LOCKDEBUG
+ARG V
+ARG LIBNETWORK_PLUGIN
+COPY --from=cilium-envoy / /
+COPY plugins/cilium-cni/cni-install.sh /cni-install.sh
+COPY plugins/cilium-cni/cni-uninstall.sh /cni-uninstall.sh
+COPY contrib/packaging/docker/init-container.sh /init-container.sh
+COPY ./envoy ./envoy
+COPY ./bpf ./bpf
+COPY ./bugtool ./bugtool
+COPY ./cilium-health ./cilium-health
+COPY ./cilium ./cilium
+COPY ./daemon ./daemon
+COPY ./plugins/cilium-cni ./plugins/cilium-cni
+COPY ./proxylib ./proxylib
+COPY ./Makefile* ./
+RUN for i in proxylib envoy plugins/cilium-cni bpf cilium daemon cilium-health bugtool; \
+     do LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 V=$V LIBNETWORK_PLUGIN=$LIBNETWORK_PLUGIN \
+            SKIP_DOCS=true DESTDIR= \
+            make -C $i install; done
+RUN cd /root && groupadd -f cilium \
+	&& echo ". /etc/profile.d/bash_completion.sh" >> /root/.bashrc \
+    && cilium completion bash >> /root/.bashrc \
+    && sysctl -w kernel.core_pattern=/tmp/core.%e.%p.%t
+ENV INITSYSTEM="SYSTEMD"
+CMD ["/usr/bin/cilium"]

--- a/cilium-dev.Dockerfile.dockerignore
+++ b/cilium-dev.Dockerfile.dockerignore
@@ -1,0 +1,82 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# LLVM IR files
+*.ll
+*.ll-*
+
+# Folders
+_obj
+_test
+_build/
+hack/
+
+.git/objects/
+vendor/
+examples/
+api/
+Documentation/
+
+
+# Architecture specific extensions/prefixes
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+*.swn
+*.swp
+.vagrant/
+vagrant.kubeconfig
+coverage.out
+coverage-all.out
+coverage-all.html
+
+.DS_Store
+.idea/
+*.plist
+
+cilium/bash_autocomplete
+*.swo
+outgoing
+
+*cscope.files
+*cscope.out
+*cscope.in.out
+*cscope.po.out
+*tags
+
+man/
+
+# Test files
+test/tmp.yaml
+test/*_service_manifest.json
+test/*_manifest.yaml
+test/*_policy.json
+test/*.xml
+tests/cilium-files
+test/test_results
+test/*.json
+test/.vagrant
+
+# Emacs backup files
+*~
+
+# Automatically generated when needed
+.dockerignore
+
+# Temporary files that allow build containers/VMs work without git
+
+test/bpf/_results
+
+# generated from make targets
+*.ok


### PR DESCRIPTION
This new target allows for developers to iterate faster when requiring a
new docker image.

The developer workflow would be
1. Modify source code file
2. Run `make` to generate the binaries
3. Run `make docker-cilium-image-for-developers` to generate the new Cilium
   image.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10513)
<!-- Reviewable:end -->
