### PR TITLE
Helm-charts: Fix the values.yaml comment that was misleading

### DIFF
--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -282,9 +282,9 @@ global:
     # enabled enables use of the IPVLAN datapath
     enabled: false
 
-    # primaryDevice is the name of the device to use to attach secondary IPVLAN
+    # masterDevice is the name of the device to use to attach secondary IPVLAN
     # devices
-    # primaryDevice: eth0
+    # masterDevice: eth0
 
   # pprof is the GO pprof configuration
   pprof:


### PR DESCRIPTION
This patch fixes the values.yaml comment for the 'ipvlan'
related key (primaryDevice instead of masterDevice) that mismatches
with the code and the documentation.

Singed-off-by: Swaminathan Vasudevan <svasudevan@suse.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10515)
<!-- Reviewable:end -->
