### PR TITLE
bpf: significantly improve capacity of TCP CT tables

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -188,7 +188,8 @@ ct_recreate6:
 		 * reverse NAT.
 		 */
 		ct_state_new.src_sec_id = SECLABEL;
-		ret = ct_create6(get_ct_map6(tuple), tuple, ctx, CT_EGRESS, &ct_state_new, verdict > 0);
+		ret = ct_create6(get_ct_map6(tuple), &CT_MAP_ANY6, tuple, ctx,
+				 CT_EGRESS, &ct_state_new, verdict > 0);
 		if (IS_ERR(ret))
 			return ret;
 		monitor = TRACE_PAYLOAD_LEN;
@@ -537,8 +538,11 @@ ct_recreate4:
 		 * reverse NAT.
 		 */
 		ct_state_new.src_sec_id = SECLABEL;
-		ret = ct_create4(get_ct_map4(&tuple), &tuple, ctx, CT_EGRESS,
-				 &ct_state_new, verdict > 0);
+		/* We could avoid creating related entries for legacy ClusterIP
+		 * handling here, but turns out that verifier cannot handle it.
+		 */
+		ret = ct_create4(get_ct_map4(&tuple), &CT_MAP_ANY4, &tuple, ctx,
+				 CT_EGRESS, &ct_state_new, verdict > 0);
 		if (IS_ERR(ret))
 			return ret;
 		break;
@@ -884,7 +888,8 @@ ipv6_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label, __u8 *reason,
 
 		ct_state_new.src_sec_id = src_label;
 		ct_state_new.node_port = ct_state.node_port;
-		ret = ct_create6(get_ct_map6(&tuple), &tuple, ctx, CT_INGRESS, &ct_state_new, verdict > 0);
+		ret = ct_create6(get_ct_map6(&tuple), &CT_MAP_ANY6, &tuple, ctx, CT_INGRESS,
+				 &ct_state_new, verdict > 0);
 		if (IS_ERR(ret))
 			return ret;
 
@@ -1091,7 +1096,8 @@ ipv4_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label, __u8 *reason,
 
 		ct_state_new.src_sec_id = src_label;
 		ct_state_new.node_port = ct_state.node_port;
-		ret = ct_create4(get_ct_map4(&tuple), &tuple, ctx, CT_INGRESS, &ct_state_new, verdict > 0);
+		ret = ct_create4(get_ct_map4(&tuple), &CT_MAP_ANY4, &tuple, ctx, CT_INGRESS,
+				 &ct_state_new, verdict > 0);
 		if (IS_ERR(ret))
 			return ret;
 

--- a/bpf/include/bpf/helpers.h
+++ b/bpf/include/bpf/helpers.h
@@ -31,10 +31,10 @@
 #endif
 
 /* Map access/manipulation */
-static void *BPF_FUNC(map_lookup_elem, void *map, const void *key);
-static int BPF_FUNC(map_update_elem, void *map, const void *key,
+static void *BPF_FUNC(map_lookup_elem, const void *map, const void *key);
+static int BPF_FUNC(map_update_elem, const void *map, const void *key,
 		    const void *value, __u32 flags);
-static int BPF_FUNC(map_delete_elem, void *map, const void *key);
+static int BPF_FUNC(map_delete_elem, const void *map, const void *key);
 
 /* Time access */
 static __u64 BPF_FUNC(ktime_get_ns);

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -459,7 +459,7 @@ static __always_inline int lb6_local(void *map, struct __ctx_buff *ctx,
 		}
 		state->backend_id = slave_svc->backend_id;
 		state->rev_nat_index = svc->rev_nat_index;
-		ret = ct_create6(map, tuple, ctx, CT_SERVICE, state, false);
+		ret = ct_create6(map, NULL, tuple, ctx, CT_SERVICE, state, false);
 		/* Fail closed, if the conntrack entry create fails drop
 		 * service lookup.
 		 */
@@ -830,7 +830,7 @@ static __always_inline int lb4_local(void *map, struct __ctx_buff *ctx,
 		}
 		state->backend_id = slave_svc->backend_id;
 		state->rev_nat_index = svc->rev_nat_index;
-		ret = ct_create4(map, tuple, ctx, CT_SERVICE, state, false);
+		ret = ct_create4(map, NULL, tuple, ctx, CT_SERVICE, state, false);
 		/* Fail closed, if the conntrack entry create fails drop
 		 * service lookup.
 		 */

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -280,8 +280,8 @@ static __always_inline int snat_v4_track_local(struct __ctx_buff *ctx,
 	if (ret < 0) {
 		return ret;
 	} else if (ret == CT_NEW) {
-		ret = ct_create4(get_ct_map4(&tmp), &tmp, ctx, where,
-				 &ct_state, false);
+		ret = ct_create4(get_ct_map4(&tmp), NULL, &tmp, ctx,
+				 where, &ct_state, false);
 		if (IS_ERR(ret))
 			return ret;
 	}
@@ -748,7 +748,7 @@ static __always_inline int snat_v6_track_local(struct __ctx_buff *ctx,
 	if (ret < 0) {
 		return ret;
 	} else if (ret == CT_NEW) {
-		ret = ct_create6(get_ct_map6(&tmp), &tmp, ctx, where,
+		ret = ct_create6(get_ct_map6(&tmp), NULL, &tmp, ctx, where,
 				 &ct_state, false);
 		if (IS_ERR(ret))
 			return ret;

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -508,15 +508,15 @@ static __always_inline int nodeport_lb6(struct __ctx_buff *ctx,
 	case CT_NEW:
 		ct_state_new.src_sec_id = SECLABEL;
 		ct_state_new.node_port = 1;
-		ret = ct_create6(get_ct_map6(&tuple), &tuple, ctx, CT_EGRESS,
-				 &ct_state_new, false);
+		ret = ct_create6(get_ct_map6(&tuple), NULL, &tuple, ctx,
+				 CT_EGRESS, &ct_state_new, false);
 		if (IS_ERR(ret))
 			return ret;
 		if (backend_local) {
 			ct_flip_tuple_dir6(&tuple);
 redo:
 			ct_state_new.rev_nat_index = 0;
-			ret = ct_create6(get_ct_map6(&tuple), &tuple, ctx,
+			ret = ct_create6(get_ct_map6(&tuple), NULL, &tuple, ctx,
 					 CT_INGRESS, &ct_state_new, false);
 			if (IS_ERR(ret))
 				return ret;
@@ -1066,15 +1066,15 @@ static __always_inline int nodeport_lb4(struct __ctx_buff *ctx,
 	case CT_NEW:
 		ct_state_new.src_sec_id = SECLABEL;
 		ct_state_new.node_port = 1;
-		ret = ct_create4(get_ct_map4(&tuple), &tuple, ctx, CT_EGRESS,
-				 &ct_state_new, false);
+		ret = ct_create4(get_ct_map4(&tuple), NULL, &tuple, ctx,
+				 CT_EGRESS, &ct_state_new, false);
 		if (IS_ERR(ret))
 			return ret;
 		if (backend_local) {
 			ct_flip_tuple_dir4(&tuple);
 redo:
 			ct_state_new.rev_nat_index = 0;
-			ret = ct_create4(get_ct_map4(&tuple), &tuple, ctx,
+			ret = ct_create4(get_ct_map4(&tuple), NULL, &tuple, ctx,
 					 CT_INGRESS, &ct_state_new, false);
 			if (IS_ERR(ret))
 				return ret;


### PR DESCRIPTION
ct_create{4,6}() inserts related entries into the TCP CT tables given
the map is usually in the form of ct_create4(get_ct_map4(&tuple)) or
ct_create6(get_ct_map6(&tuple)). Similarly, the lookup parts are in
form of ct_lookup4(get_ct_map4(&tuple)) or ct_lookup6(get_ct_map6(&tuple)).

However, the tuples' nexthdr usually points to the one in the packet.
This means, we can /never/ find a related entry since it sits in the TCP
CT tables, but their lookup is always in the ANY table instead.

Fix the insertions by adding to the CT_MAP_ANY{4,6} tables and by that
implicityly double the capacity of TCP CT tables.

Go even beyond that by not creating related entries for CT_SERVICE entries.

It does not make sense to create CT_SERVICE entries with related flag
since we don't translate ICMP there anyway. Save overhead and don't add
them to the maps (same for NodePort/NAT related ones).

Fixes: 750b3f9e58c4 ("bpf: Split connection tracking for TCP and non-TCP")
Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10518)
<!-- Reviewable:end -->
