### PR TITLE
operator: fix bugs on reading configuration from config-map

### DIFF
--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -160,11 +160,7 @@ func init() {
 		return
 	}
 
-	if viper.GetBool("version") {
-		fmt.Printf("Cilium %s\n", version.Version)
-		os.Exit(0)
-	}
-	cobra.OnInitialize(option.InitConfig("ciliumd"))
+	cobra.OnInitialize(option.InitConfig("Cilium", "ciliumd"))
 
 	// Reset the help function to also exit, as we block elsewhere in interrupts
 	// and would not exit when called with -h.

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -19,14 +19,17 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/spf13/viper"
-	"k8s.io/klog"
-
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/option"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"k8s.io/klog"
 )
 
 func init() {
+	cobra.OnInitialize(option.InitConfig("Cilium-Operator", "cilium-operator"))
+
 	flags := rootCmd.Flags()
 
 	flags.Int(option.AWSClientBurstDeprecated, defaults.IPAMAPIBurst, "")

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"k8s.io/klog"
 
@@ -28,8 +27,6 @@ import (
 )
 
 func init() {
-	cobra.OnInitialize(initConfig)
-
 	flags := rootCmd.Flags()
 
 	flags.Int(option.AWSClientBurstDeprecated, defaults.IPAMAPIBurst, "")

--- a/operator/main.go
+++ b/operator/main.go
@@ -102,8 +102,8 @@ func main() {
 	}
 }
 
-// initConfig reads in config file and ENV variables if set.
-func initConfig() {
+// init reads in config file and ENV variables if set.
+func init() {
 	if viper.GetBool("version") {
 		fmt.Printf("Cilium-Operator %s\n", version.Version)
 		os.Exit(0)

--- a/operator/main.go
+++ b/operator/main.go
@@ -102,15 +102,6 @@ func main() {
 	}
 }
 
-// init reads in config file and ENV variables if set.
-func init() {
-	if viper.GetBool("version") {
-		fmt.Printf("Cilium-Operator %s\n", version.Version)
-		os.Exit(0)
-	}
-	cobra.OnInitialize(option.InitConfig("cilium-operator"))
-}
-
 func kvstoreEnabled() bool {
 	if option.Config.KVStore == "" {
 		return false

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/version"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
@@ -2340,8 +2341,13 @@ func getHostDevice() string {
 }
 
 // InitConfig reads in config file and ENV variables if set.
-func InitConfig(configName string) func() {
+func InitConfig(programName, configName string) func() {
 	return func() {
+		if viper.GetBool("version") {
+			fmt.Printf("%s %s\n", programName, version.Version)
+			os.Exit(0)
+		}
+
 		if viper.GetString(CMDRef) != "" {
 			return
 		}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2269,7 +2269,9 @@ func (c *DaemonConfig) populateNodePortRange() error {
 			return errors.New("NodePort range min port must be smaller than max port")
 		}
 	case 0:
-		log.Warning("NodePort range was set but is empty.")
+		if viper.IsSet(NodePortRange) {
+			log.Warning("NodePort range was set but is empty.")
+		}
 	default:
 		return fmt.Errorf("Unable to parse min/max port value for NodePort range: %s", NodePortRange)
 	}
@@ -2306,11 +2308,13 @@ func (c *DaemonConfig) populateHostServicesProtos() error {
 func sanitizeIntParam(paramName string, paramDefault int) int {
 	intParam := viper.GetInt(paramName)
 	if intParam <= 0 {
-		log.WithFields(
-			logrus.Fields{
-				"parameter":    paramName,
-				"defaultValue": paramDefault,
-			}).Warning("user-provided parameter had value <= 0 , which is invalid ; setting to default")
+		if !viper.IsSet(paramName) {
+			log.WithFields(
+				logrus.Fields{
+					"parameter":    paramName,
+					"defaultValue": paramDefault,
+				}).Warning("user-provided parameter had value <= 0 , which is invalid ; setting to default")
+		}
 		return paramDefault
 	}
 	return intParam

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2801,7 +2801,7 @@ func (kub *Kubectl) ciliumHealthPreFlightCheck() error {
 		if len(ciliumPods) != len(nodeCount) {
 			return fmt.Errorf(
 				"cilium-agent '%s': Only %d/%d nodes appeared in cilium-health status. nodes = '%+v'",
-				pod, len(nodeCount), len(ciliumPods), nodeCount)
+				pod, len(ciliumPods), len(nodeCount), nodeCount)
 		}
 
 		healthStatus, err := status.Filter(statusFilter)


### PR DESCRIPTION
`cobra.OnInitialize` should be called directly in the init function.

Due refactoring, `cilium-agent --version` and `cilium-operator --version` no longer work, this PR also fixes this bug by rewriting the code.

Also, stop executing flag validation if flags are not set

Fixes: 67b147c3f273 ("operator: add ability to ready options from a config directory")
Signed-off-by: André Martins <andre@cilium.io>

Fixes https://github.com/cilium/cilium/issues/10384


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10520)
<!-- Reviewable:end -->
