### PR TITLE
bpf: switch csum_l4_replace and ipv4_dec_ttl to csum_diff

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -92,7 +92,7 @@ static __always_inline int ipv6_l3_from_lxc(struct __ctx_buff *ctx,
 	 */
 #ifdef ENABLE_SERVICES
 # if !defined(ENABLE_HOST_SERVICES_FULL) || \
-     (defined(ENABLE_EXTERNAL_IP) && !defined(ENABLE_HOST_SERVICES_NETNS))
+     (defined(ENABLE_EXTERNAL_IP) && !defined(BPF_HAVE_NETNS_COOKIE))
 	{
 		struct lb6_service *svc;
 		struct lb6_key key = {};
@@ -115,7 +115,7 @@ static __always_inline int ipv6_l3_from_lxc(struct __ctx_buff *ctx,
 	}
 
 skip_service_lookup:
-# endif /* !ENABLE_HOST_SERVICES_FULL || ENABLE_EXTERNAL_IP && !ENABLE_HOST_SERVICES_NETNS */
+# endif /* !ENABLE_HOST_SERVICES_FULL || ENABLE_EXTERNAL_IP && !BPF_HAVE_NETNS_COOKIE */
 #endif /* ENABLE_SERVICES */
 
 	/* The verifier wants to see this assignment here in case the above goto
@@ -446,7 +446,7 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx,
 
 #ifdef ENABLE_SERVICES
 # if !defined(ENABLE_HOST_SERVICES_FULL) || \
-     (defined(ENABLE_EXTERNAL_IP) && !defined(ENABLE_HOST_SERVICES_NETNS))
+     (defined(ENABLE_EXTERNAL_IP) && !defined(BPF_HAVE_NETNS_COOKIE))
 	{
 		struct lb4_service *svc;
 		struct lb4_key key = {};
@@ -470,7 +470,7 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx,
 	}
 
 skip_service_lookup:
-# endif /* !ENABLE_HOST_SERVICES_FULL || ENABLE_EXTERNAL_IP && !ENABLE_HOST_SERVICES_NETNS */
+# endif /* !ENABLE_HOST_SERVICES_FULL || ENABLE_EXTERNAL_IP && !BPF_HAVE_NETNS_COOKIE */
 #endif /* ENABLE_SERVICES */
 
 	/* The verifier wants to see this assignment here in case the above goto

--- a/bpf/bpf_netdev.c
+++ b/bpf/bpf_netdev.c
@@ -516,7 +516,7 @@ do_netdev_encrypt_fib(struct __ctx_buff *ctx __maybe_unused,
 		      int *encrypt_iface __maybe_unused)
 {
 	int ret = 0;
-#if HAVE_PROG_TYPE_HELPER(sched_cls, bpf_fib_lookup)
+#ifdef BPF_HAVE_FIB_LOOKUP
 	struct bpf_fib_lookup fib_params = {};
 	void *data, *data_end;
 	int err;
@@ -563,7 +563,7 @@ do_netdev_encrypt_fib(struct __ctx_buff *ctx __maybe_unused,
 	}
 	*encrypt_iface = fib_params.ifindex;
 drop_err_fib:
-#endif /* HAVE_PROG_TYPE_HELPER(sched_cls, bpf_fib_lookup) */
+#endif /* BPF_HAVE_FIB_LOOKUP */
 	return ret;
 }
 
@@ -572,7 +572,7 @@ static __always_inline int do_netdev_encrypt(struct __ctx_buff *ctx, __u16 proto
 	int encrypt_iface = 0;
 	int ret = 0;
 
-#if defined(ENCRYPT_NODE) || HAVE_PROG_TYPE_HELPER(sched_cls, bpf_fib_lookup)
+#if defined(ENCRYPT_NODE) || defined(BPF_HAVE_FIB_LOOKUP)
 	encrypt_iface = ENCRYPT_IFACE;
 #endif
 	ret = do_netdev_encrypt_pools(ctx);
@@ -584,7 +584,7 @@ static __always_inline int do_netdev_encrypt(struct __ctx_buff *ctx, __u16 proto
 		return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP, METRIC_INGRESS);
 
 	bpf_clear_cb(ctx);
-#if defined(ENCRYPT_NODE) || HAVE_PROG_TYPE_HELPER(sched_cls, bpf_fib_lookup)
+#if defined(ENCRYPT_NODE) || defined(BPF_HAVE_FIB_LOOKUP)
 	return redirect(encrypt_iface, 0);
 #else
 	return CTX_ACT_OK;

--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -79,7 +79,7 @@ void ctx_set_port(struct bpf_sock_addr *ctx, __be16 dport)
 static __always_inline __maybe_unused bool
 ctx_in_hostns(void *ctx __maybe_unused)
 {
-#ifdef ENABLE_HOST_SERVICES_NETNS
+#ifdef BPF_HAVE_NETNS_COOKIE
 	return get_netns_cookie(ctx) == get_netns_cookie(NULL);
 #else
 	return true;
@@ -89,7 +89,7 @@ ctx_in_hostns(void *ctx __maybe_unused)
 static __always_inline __maybe_unused
 __u64 sock_local_cookie(struct bpf_sock_addr *ctx)
 {
-#if HAVE_PROG_TYPE_HELPER(cgroup_sock_addr, bpf_get_socket_cookie)
+#ifdef BPF_HAVE_SOCKET_COOKIE
 	/* prandom() breaks down on UDP, hence preference is on
 	 * socket cookie as built-in selector. On older kernels,
 	 * get_socket_cookie() provides a unique per netns cookie

--- a/bpf/include/bpf/ctx/unspec.h
+++ b/bpf/include/bpf/ctx/unspec.h
@@ -7,6 +7,12 @@
 /* We do not care which context we need in this case, but it must be
  * something compilable, thus we reuse skb ctx here.
  */
+
+#ifdef __non_bpf_context
+/* Do not include BPF feature header. */
+# define __BPF_FEATURES_SKB__	1
+#endif
+
 #include "skb.h"
 
 #endif /* __BPF_CTX_UNSPEC_H_ */

--- a/bpf/include/bpf/features.h
+++ b/bpf/include/bpf/features.h
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Copyright (C) 2020 Authors of Cilium */
+
+#ifndef ____BPF_FEATURES____
+#define ____BPF_FEATURES____
+
+#include <bpf_features.h>
+
+/* Neither skb nor xdp related features. */
+
+/* Testing both here since both were added to the same kernel release
+ * and we need to ensure both are enabled.
+ */
+#if HAVE_PROG_TYPE_HELPER(cgroup_sock_addr, bpf_get_netns_cookie) && \
+    HAVE_PROG_TYPE_HELPER(cgroup_sock,      bpf_get_netns_cookie)
+# define BPF_HAVE_NETNS_COOKIE 1
+#endif
+
+#if HAVE_PROG_TYPE_HELPER(cgroup_sock_addr, bpf_get_socket_cookie)
+# define BPF_HAVE_SOCKET_COOKIE 1
+#endif
+
+#endif /* ____BPF_FEATURES____ */

--- a/bpf/include/bpf/features_skb.h
+++ b/bpf/include/bpf/features_skb.h
@@ -1,0 +1,19 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Copyright (C) 2020 Authors of Cilium */
+
+#ifndef __BPF_FEATURES_SKB__
+#define __BPF_FEATURES_SKB__
+
+#include "features.h"
+
+/* Only skb related features. */
+
+#if HAVE_PROG_TYPE_HELPER(sched_cls, bpf_skb_change_tail)
+# define BPF_HAVE_CHANGE_TAIL 1
+#endif
+
+#if HAVE_PROG_TYPE_HELPER(sched_cls, bpf_fib_lookup)
+# define BPF_HAVE_FIB_LOOKUP 1
+#endif
+
+#endif /* __BPF_FEATURES_SKB__ */

--- a/bpf/include/bpf/features_xdp.h
+++ b/bpf/include/bpf/features_xdp.h
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Copyright (C) 2020 Authors of Cilium */
+
+#ifndef __BPF_FEATURES_XDP__
+#define __BPF_FEATURES_XDP__
+
+#include "features.h"
+
+/* Only xdp related features. */
+
+#if HAVE_PROG_TYPE_HELPER(xdp, bpf_fib_lookup)
+# define BPF_HAVE_FIB_LOOKUP 1
+#endif
+
+#endif /* __BPF_FEATURES_XDP__ */

--- a/bpf/include/bpf/helpers_skb.h
+++ b/bpf/include/bpf/helpers_skb.h
@@ -8,6 +8,7 @@
 
 #include "compiler.h"
 #include "helpers.h"
+#include "features_skb.h"
 
 /* Only used helpers in Cilium go below. */
 

--- a/bpf/include/bpf/helpers_xdp.h
+++ b/bpf/include/bpf/helpers_xdp.h
@@ -8,6 +8,7 @@
 
 #include "compiler.h"
 #include "helpers.h"
+#include "features_xdp.h"
 
 /* Only used helpers in Cilium go below. */
 

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -11,8 +11,6 @@
 #include <linux/ipv6.h>
 #include <linux/in.h>
 
-#include <bpf_features.h>
-
 // FIXME: GH-3239 LRU logic is not handling timeouts gracefully enough
 // #ifndef HAVE_LRU_HASH_MAP_TYPE
 // #define NEEDS_TIMEOUT 1
@@ -46,11 +44,6 @@
 # ifdef ENABLE_IPV6
 #  define ENABLE_ENCAP_HOST_REMAP 1
 # endif
-#endif
-
-#if HAVE_PROG_TYPE_HELPER(cgroup_sock_addr, bpf_get_netns_cookie) && \
-    HAVE_PROG_TYPE_HELPER(cgroup_sock,      bpf_get_netns_cookie)
-# define ENABLE_HOST_SERVICES_NETNS 1
 #endif
 
 /* These are shared with test/bpf/check-complexity.sh, when modifying any of

--- a/bpf/lib/icmp6.h
+++ b/bpf/lib/icmp6.h
@@ -205,7 +205,7 @@ static __always_inline __be32 compute_icmp6_csum(char data[80], __u16 payload_le
 	return sum;
 }
 
-#if HAVE_PROG_TYPE_HELPER(sched_cls, bpf_skb_change_tail)
+#ifdef BPF_HAVE_CHANGE_TAIL
 static __always_inline int __icmp6_send_time_exceeded(struct __ctx_buff *ctx,
 						      int nh_off)
 {
@@ -292,7 +292,7 @@ static __always_inline int __icmp6_send_time_exceeded(struct __ctx_buff *ctx,
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_SEND_ICMP6_TIME_EXCEEDED)
 int tail_icmp6_send_time_exceeded(struct __ctx_buff *ctx)
 {
-#if HAVE_PROG_TYPE_HELPER(sched_cls, bpf_skb_change_tail)
+#ifdef BPF_HAVE_CHANGE_TAIL
 	int ret, nh_off = ctx_load_meta(ctx, 0);
 	__u8 direction  = ctx_load_meta(ctx, 1);
 

--- a/bpf/lib/icmp6.h
+++ b/bpf/lib/icmp6.h
@@ -290,7 +290,7 @@ static __always_inline int __icmp6_send_time_exceeded(struct __ctx_buff *ctx,
 #endif
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_SEND_ICMP6_TIME_EXCEEDED)
-int tail_icmp6_send_time_exceeded(struct __ctx_buff *ctx)
+int tail_icmp6_send_time_exceeded(struct __ctx_buff *ctx __maybe_unused)
 {
 #ifdef BPF_HAVE_CHANGE_TAIL
 	int ret, nh_off = ctx_load_meta(ctx, 0);
@@ -299,7 +299,8 @@ int tail_icmp6_send_time_exceeded(struct __ctx_buff *ctx)
 	ctx_store_meta(ctx, 0, 0);
 	ret = __icmp6_send_time_exceeded(ctx, nh_off);
 	if (IS_ERR(ret))
-		return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP, direction);
+		return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP,
+					      direction);
 	return ret;
 #else
 	return 0;

--- a/bpf/lib/l3.h
+++ b/bpf/lib/l3.h
@@ -56,6 +56,7 @@ static __always_inline int ipv4_l3(struct __ctx_buff *ctx, int l3_off,
 	return CTX_ACT_OK;
 }
 
+#ifndef SKIP_POLICY_MAP
 #ifdef ENABLE_IPV6
 static __always_inline int ipv6_local_delivery(struct __ctx_buff *ctx, int l3_off,
 					       __u32 seclabel,
@@ -130,6 +131,7 @@ static __always_inline int ipv4_local_delivery(struct __ctx_buff *ctx, int l3_of
 	return DROP_MISSED_TAIL_CALL;
 #endif
 }
+#endif /* SKIP_POLICY_MAP */
 
 static __always_inline __u8 get_encrypt_key(__u32 ctx)
 {

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -86,7 +86,8 @@ static __always_inline bool nodeport_uses_dsr(__u8 nexthdr __maybe_unused)
 # endif
 }
 
-static __always_inline void bpf_mark_snat_done(struct __ctx_buff *ctx)
+static __always_inline void
+bpf_mark_snat_done(struct __ctx_buff *ctx __maybe_unused)
 {
 	/* From XDP layer, we do not go through an egress hook from
 	 * here, hence nothing to be done.
@@ -96,7 +97,8 @@ static __always_inline void bpf_mark_snat_done(struct __ctx_buff *ctx)
 #endif
 }
 
-static __always_inline bool bpf_skip_recirculation(struct __ctx_buff *ctx)
+static __always_inline bool
+bpf_skip_recirculation(struct __ctx_buff *ctx __maybe_unused)
 {
 	/* From XDP layer, we do not go through an egress hook from
 	 * here, hence nothing to be skipped.


### PR DESCRIPTION
Moved out of #10491, since it is blocked by #10517.

Another option is to drop it and implement the 2 byte diff in XDP at the expense of more complexity. Need to double check on 4.19.57+ kernels.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10521)
<!-- Reviewable:end -->
