### PR TITLE
bpf: Fix pointer-to-int-cast warning in newer Clang

### DIFF
--- a/bpf/include/bpf/compiler.h
+++ b/bpf/include/bpf/compiler.h
@@ -43,7 +43,7 @@
 #endif
 
 #ifndef __fetch
-# define __fetch(X)		(__u32)(&(X))
+# define __fetch(X)		(__u32)(__u64)(&(X))
 #endif
 
 #ifndef build_bug_on


### PR DESCRIPTION
Latest Clang ([`9658d895 "[Sema] Adds the pointer-to-int-cast diagnostic"`](https://github.com/llvm/llvm-project/commit/9658d895c81aeb849b412b9332c88769588c7660)) emits the following warning for our `__fetch` code:

    In file included from bpf_lxc.c:18:
    In file included from /home/paul/cilium/bpf/lib/maps.h:8:
    In file included from /home/paul/cilium/bpf/lib/ipv6.h:9:
    /home/paul/cilium/bpf/lib/dbg.h:155:13: error: cast to smaller integer type '__u32' (aka 'unsigned int') from '__u32 *' (aka 'unsigned int *') [-Werror,-Wpointer-to-int-cast]
                    .source = EVENT_SOURCE,
                              ^~~~~~~~~~~~
    bpf_lxc.c:12:22: note: expanded from macro 'EVENT_SOURCE'
    #define EVENT_SOURCE LXC_ID
                         ^~~~~~
    /home/paul/cilium/bpf/lxc_config.h:14:16: note: expanded from macro 'LXC_ID'
    #define LXC_ID fetch_u32(LXC_ID)
                   ^~~~~~~~~~~~~~~~~
    /home/paul/cilium/bpf/lib/static_data.h:11:22: note: expanded from macro 'fetch_u32'
    #define fetch_u32(x) __fetch(x)
                         ^~~~~~~~~~
    /home/paul/cilium/bpf/include/bpf/ctx/../compiler.h:46:22: note: expanded from macro '__fetch'
    # define __fetch(X)             (__u32)(&(X))
                                    ^~~~~~~~~~~~~
Fix it by casting to `__u64` first.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10522)
<!-- Reviewable:end -->
