### PR TITLE
.travis: fix issue that etcd exited on Arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ JOB_BASE_NAME ?= cilium_test
 UTC_DATE=$(shell date -u "+%Y-%m-%d")
 
 GO_VERSION := $(shell cat GO_VERSION)
+GOARCH := $(shell $(GO) env GOARCH)
 
 # Since there's a bug with NFS or the kernel, the flock syscall hangs the documentation
 # build in the developer VM. For this reason the documentation build is skipped if NFS
@@ -100,6 +101,7 @@ ifeq ($(SKIP_KVSTORES),"false")
 	@echo Starting key-value store containers...
 	-$(CONTAINER_ENGINE_FULL) rm -f "cilium-etcd-test-container" 2> /dev/null
 	$(CONTAINER_ENGINE_FULL) run -d \
+		-e ETCD_UNSUPPORTED_ARCH=$(GOARCH) \
 		--name "cilium-etcd-test-container" \
 		-p 4002:4001 \
 		$(ETCD_IMAGE) \


### PR DESCRIPTION
Set env variables ETCD_UNSUPPORTED_ARCH=$(ARCH)

Signed-off-by: Jianlin Lv <Jianlin.Lv@arm.com>

Related: #9898

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10527)
<!-- Reviewable:end -->
