### PR TITLE
v1.6 backports 2020-03-10

### DIFF
--- a/pkg/fqdn/dnspoller_test.go
+++ b/pkg/fqdn/dnspoller_test.go
@@ -152,9 +152,11 @@ func (ds *FQDNTestSuite) TestNameManagerSelectorHandling(c *C) {
 			poller      = NewDNSPoller(cfg, nameManager)
 		)
 
+		nameManager.Lock()
 		for _, fqdnSel := range testCase.selectorsToAdd {
-			nameManager.RegisterForIdentityUpdates(fqdnSel)
+			nameManager.RegisterForIdentityUpdatesLocked(fqdnSel)
 		}
+		nameManager.Unlock()
 		for i := testCase.lookupIterationsAfterAdd; i > 0; i-- {
 			err := poller.LookupUpdateDNS(context.Background())
 			c.Assert(err, IsNil, Commentf("Error running DNS lookups"))
@@ -162,9 +164,11 @@ func (ds *FQDNTestSuite) TestNameManagerSelectorHandling(c *C) {
 
 		// delete rules listed in the test case (note: we don't delete any unless
 		// they are listed)
+		nameManager.Lock()
 		for _, fqdnSel := range testCase.selectorsToDelete {
-			nameManager.UnregisterForIdentityUpdates(fqdnSel)
+			nameManager.UnregisterForIdentityUpdatesLocked(fqdnSel)
 		}
+		nameManager.Unlock()
 		for i := testCase.lookupIterationsAfterDelete; i > 0; i-- {
 			err := poller.LookupUpdateDNS(context.Background())
 			c.Assert(err, IsNil, Commentf("Error running DNS lookups"))

--- a/pkg/fqdn/name_manager.go
+++ b/pkg/fqdn/name_manager.go
@@ -58,20 +58,29 @@ type NameManager struct {
 	bootstrapCompleted bool
 }
 
-// RegisterForIdentityUpdates exposes this FQDNSelector so that identities
+// Lock must be held during any calls to RegisterForIdentityUpdatesLocked or
+// UnregisterForIdentityUpdatesLocked.
+func (n *NameManager) Lock() {
+	n.Mutex.Lock()
+}
+
+// Unlock must be called after calls to RegisterForIdentityUpdatesLocked or
+// UnregisterForIdentityUpdatesLocked are done.
+func (n *NameManager) Unlock() {
+	n.Mutex.Unlock()
+}
+
+// RegisterForIdentityUpdatesLocked exposes this FQDNSelector so that identities
 // for IPs contained in a DNS response that matches said selector can be
 // propagated back to the SelectorCache via `UpdateFQDNSelector`. All DNS names
 // contained within the NameManager's cache are iterated over to see if they match
 // the FQDNSelector. All IPs which correspond to the DNS names which match this
 // Selector will be returned as CIDR identities, as other DNS Names which have
 // already been resolved may match this FQDNSelector.
-func (n *NameManager) RegisterForIdentityUpdates(selector api.FQDNSelector) []identity.NumericIdentity {
-
-	n.Mutex.Lock()
+func (n *NameManager) RegisterForIdentityUpdatesLocked(selector api.FQDNSelector) []identity.NumericIdentity {
 	_, exists := n.allSelectors[selector]
 	if exists {
-		log.WithField("fqdnSelector", selector).Error("FQDNSelector was already registered for updates, returning without any identities")
-		n.Mutex.Unlock()
+		log.WithField("fqdnSelector", selector).Warning("FQDNSelector was already registered for updates, returning without any identities")
 		return nil
 	}
 
@@ -80,7 +89,6 @@ func (n *NameManager) RegisterForIdentityUpdates(selector api.FQDNSelector) []id
 	regex, err := selector.ToRegex()
 	if err != nil {
 		log.WithError(err).WithField("fqdnSelector", selector).Error("FQDNSelector did not compile to valid regex")
-		n.Mutex.Unlock()
 		return nil
 	}
 
@@ -91,7 +99,6 @@ func (n *NameManager) RegisterForIdentityUpdates(selector api.FQDNSelector) []id
 
 	n.allSelectors[selector] = regex
 	_, selectorIPMapping := mapSelectorsToIPs(map[api.FQDNSelector]struct{}{selector: {}}, n.cache)
-	n.Mutex.Unlock()
 
 	// Allocate identities for each IPNet and then map to selector
 	selectorIPs := selectorIPMapping[selector]
@@ -113,16 +120,14 @@ func (n *NameManager) RegisterForIdentityUpdates(selector api.FQDNSelector) []id
 	return numIDs
 }
 
-// UnregisterForIdentityUpdates removes this FQDNSelector from the set of
+// UnregisterForIdentityUpdatesLocked removes this FQDNSelector from the set of
 // FQDNSelectors which are being tracked by the NameManager. No more updates for IPs
 // which correspond to said selector are propagated.
-func (n *NameManager) UnregisterForIdentityUpdates(selector api.FQDNSelector) {
-	n.Mutex.Lock()
+func (n *NameManager) UnregisterForIdentityUpdatesLocked(selector api.FQDNSelector) {
 	delete(n.allSelectors, selector)
 	if len(selector.MatchName) > 0 {
 		delete(n.namesToPoll, prepareMatchName(selector.MatchName))
 	}
-	n.Mutex.Unlock()
 }
 
 // NewNameManager creates an initialized NameManager.
@@ -169,8 +174,11 @@ func (n *NameManager) GetDNSNames() (dnsNames []string) {
 // have changed for a name, store which rules must be updated in rulesToUpdate,
 // regenerate them, and emit via UpdateSelectors.
 func (n *NameManager) UpdateGenerateDNS(ctx context.Context, lookupTime time.Time, updatedDNSIPs map[string]*DNSIPRecords) (wg *sync.WaitGroup, err error) {
+	n.Mutex.Lock()
+	defer n.Mutex.Unlock()
+
 	// Update IPs in n
-	fqdnSelectorsToUpdate, updatedDNSNames := n.UpdateDNSIPs(lookupTime, updatedDNSIPs)
+	fqdnSelectorsToUpdate, updatedDNSNames := n.updateDNSIPs(lookupTime, updatedDNSIPs)
 	for dnsName, IPs := range updatedDNSNames {
 		log.WithFields(logrus.Fields{
 			"matchName":             dnsName,
@@ -179,7 +187,7 @@ func (n *NameManager) UpdateGenerateDNS(ctx context.Context, lookupTime time.Tim
 		}).Debug("Updated FQDN with new IPs")
 	}
 
-	namesMissingIPs, selectorIPMapping := n.GenerateSelectorUpdates(fqdnSelectorsToUpdate)
+	namesMissingIPs, selectorIPMapping := n.generateSelectorUpdates(fqdnSelectorsToUpdate)
 	if len(namesMissingIPs) != 0 {
 		log.WithField(logfields.DNSName, namesMissingIPs).
 			Debug("No IPs to insert when generating DNS name selected by ToFQDN rule")
@@ -193,6 +201,8 @@ func (n *NameManager) UpdateGenerateDNS(ctx context.Context, lookupTime time.Tim
 // matchNames that match them will cause these rules to regenerate.
 func (n *NameManager) ForceGenerateDNS(ctx context.Context, namesToRegen []string) (wg *sync.WaitGroup, err error) {
 	n.Mutex.Lock()
+	defer n.Mutex.Unlock()
+
 	affectedFQDNSels := make(map[api.FQDNSelector]struct{}, 0)
 	for _, dnsName := range namesToRegen {
 		for fqdnSel, fqdnRegEx := range n.allSelectors {
@@ -207,7 +217,6 @@ func (n *NameManager) ForceGenerateDNS(ctx context.Context, namesToRegen []strin
 		log.WithField(logfields.DNSName, namesMissingIPs).
 			Debug("No IPs to insert when generating DNS name selected by ToFQDN rule")
 	}
-	n.Mutex.Unlock()
 
 	// emit the new rules
 	return n.config.
@@ -220,17 +229,14 @@ func (n *NameManager) CompleteBootstrap() {
 	n.Unlock()
 }
 
-// UpdateDNSIPs updates the IPs for each DNS name in updatedDNSIPs.
+// updateDNSIPs updates the IPs for each DNS name in updatedDNSIPs.
 // It returns:
 // affectedSelectors: a set of all FQDNSelectors which match DNS Names whose
 // corresponding set of IPs has changed.
 // updatedNames: a map of DNS names to all the valid IPs we store for each.
-func (n *NameManager) UpdateDNSIPs(lookupTime time.Time, updatedDNSIPs map[string]*DNSIPRecords) (affectedSelectors map[api.FQDNSelector]struct{}, updatedNames map[string][]net.IP) {
+func (n *NameManager) updateDNSIPs(lookupTime time.Time, updatedDNSIPs map[string]*DNSIPRecords) (affectedSelectors map[api.FQDNSelector]struct{}, updatedNames map[string][]net.IP) {
 	updatedNames = make(map[string][]net.IP, len(updatedDNSIPs))
 	affectedSelectors = make(map[api.FQDNSelector]struct{}, len(updatedDNSIPs))
-
-	n.Lock()
-	defer n.Unlock()
 
 perDNSName:
 	for dnsName, lookupIPs := range updatedDNSIPs {
@@ -266,16 +272,12 @@ perDNSName:
 	return affectedSelectors, updatedNames
 }
 
-// GenerateSelectorUpdates iterates over all names in the DNS cache managed by
+// generateSelectorUpdates iterates over all names in the DNS cache managed by
 // gen and figures out to which FQDNSelectors managed by the cache these names
 // map. Returns the set of FQDNSelectors which map to no IPs, and a mapping
 // of FQDNSelectors to IPs.
-func (n *NameManager) GenerateSelectorUpdates(fqdnSelectors map[api.FQDNSelector]struct{}) (namesMissingIPs []api.FQDNSelector, selectorIPMapping map[api.FQDNSelector][]net.IP) {
-	n.Lock()
-	defer n.Unlock()
-
-	namesMissingIPs, selectorIPMapping = mapSelectorsToIPs(fqdnSelectors, n.cache)
-	return namesMissingIPs, selectorIPMapping
+func (n *NameManager) generateSelectorUpdates(fqdnSelectors map[api.FQDNSelector]struct{}) (namesMissingIPs []api.FQDNSelector, selectorIPMapping map[api.FQDNSelector][]net.IP) {
+	return mapSelectorsToIPs(fqdnSelectors, n.cache)
 }
 
 // updateIPsName will update the IPs for dnsName. It always retains a copy of

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/testutils"
 
 	. "gopkg.in/check.v1"
 	v1 "k8s.io/api/core/v1"
@@ -100,6 +101,12 @@ var (
 
 type DummySelectorCacheUser struct{}
 
+func testNewPolicyRepository() *policy.Repository {
+	repo := policy.NewPolicyRepository()
+	repo.GetSelectorCache().SetLocalIdentityNotifier(testutils.NewDummyIdentityNotifier())
+	return repo
+}
+
 func (d *DummySelectorCacheUser) IdentitySelectionUpdated(selector policy.CachedSelector, selections, added, deleted []identity.NumericIdentity) {
 }
 
@@ -160,7 +167,7 @@ func (s *K8sSuite) TestParseNetworkPolicyIngress(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(len(rules), Equals, 1)
 
-	repo := policy.NewPolicyRepository()
+	repo := testNewPolicyRepository()
 
 	repo.AddList(rules)
 	c.Assert(repo.AllowsIngressRLocked(&ctx), Equals, api.Denied)
@@ -289,7 +296,7 @@ func (s *K8sSuite) TestParseNetworkPolicyMultipleSelectors(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(len(rules), Equals, 1)
 
-	repo := policy.NewPolicyRepository()
+	repo := testNewPolicyRepository()
 	repo.AddList(rules)
 
 	endpointLabels := labels.LabelArray{
@@ -487,7 +494,7 @@ func (s *K8sSuite) TestParseNetworkPolicyEgress(c *C) {
 		Trace: policy.TRACE_VERBOSE,
 	}
 
-	repo := policy.NewPolicyRepository()
+	repo := testNewPolicyRepository()
 	repo.AddList(rules)
 	// Because search context did not contain port-specific policy, deny is
 	// expected.
@@ -542,7 +549,7 @@ func (s *K8sSuite) TestParseNetworkPolicyEgress(c *C) {
 }
 
 func parseAndAddRules(c *C, p *networkingv1.NetworkPolicy) *policy.Repository {
-	repo := policy.NewPolicyRepository()
+	repo := testNewPolicyRepository()
 	rules, err := ParseNetworkPolicy(p)
 	c.Assert(err, IsNil)
 	rev := repo.GetRevision()
@@ -700,7 +707,7 @@ func (s *K8sSuite) TestParseNetworkPolicyEmptyFrom(c *C) {
 		Trace: policy.TRACE_VERBOSE,
 	}
 
-	repo := policy.NewPolicyRepository()
+	repo := testNewPolicyRepository()
 	repo.AddList(rules)
 	c.Assert(repo.AllowsIngressRLocked(&ctx), Equals, api.Allowed)
 
@@ -724,7 +731,7 @@ func (s *K8sSuite) TestParseNetworkPolicyEmptyFrom(c *C) {
 	rules, err = ParseNetworkPolicy(netPolicy2)
 	c.Assert(err, IsNil)
 	c.Assert(len(rules), Equals, 1)
-	repo = policy.NewPolicyRepository()
+	repo = testNewPolicyRepository()
 	repo.AddList(rules)
 	c.Assert(repo.AllowsIngressRLocked(&ctx), Equals, api.Allowed)
 }
@@ -755,7 +762,7 @@ func (s *K8sSuite) TestParseNetworkPolicyDenyAll(c *C) {
 		Trace: policy.TRACE_VERBOSE,
 	}
 
-	repo := policy.NewPolicyRepository()
+	repo := testNewPolicyRepository()
 	repo.AddList(rules)
 	c.Assert(repo.AllowsIngressRLocked(&ctx), Equals, api.Denied)
 }
@@ -866,7 +873,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(len(rules), Equals, 1)
 
-	repo := policy.NewPolicyRepository()
+	repo := testNewPolicyRepository()
 	repo.AddList(rules)
 	ctx := policy.SearchContext{
 		From: labels.LabelArray{
@@ -1000,7 +1007,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(len(rules), Equals, 1)
 
-	repo = policy.NewPolicyRepository()
+	repo = testNewPolicyRepository()
 	repo.AddList(rules)
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
@@ -1068,7 +1075,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(len(rules), Equals, 1)
 
-	repo = policy.NewPolicyRepository()
+	repo = testNewPolicyRepository()
 	repo.AddList(rules)
 	ctx = policy.SearchContext{
 		From: labels.LabelArray{
@@ -1207,7 +1214,7 @@ func (s *K8sSuite) TestNetworkPolicyExamples(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(len(rules), Equals, 1)
 
-	repo = policy.NewPolicyRepository()
+	repo = testNewPolicyRepository()
 	// add example 4
 	repo.AddList(rules)
 

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -368,7 +368,7 @@ func Test_MergeL3(t *testing.T) {
 		identity.NumericIdentity(identityFoo): labelsFoo,
 		identity.NumericIdentity(identityBar): labelsBar,
 	}
-	selectorCache := NewSelectorCache(identityCache)
+	selectorCache := testNewSelectorCache(identityCache)
 
 	tests := []struct {
 		test   int
@@ -407,7 +407,7 @@ func Test_MergeRules(t *testing.T) {
 	identityCache := cache.IdentityCache{
 		identity.NumericIdentity(identityFoo): labelsFoo,
 	}
-	selectorCache := NewSelectorCache(identityCache)
+	selectorCache := testNewSelectorCache(identityCache)
 
 	tests := []struct {
 		test   int
@@ -482,7 +482,7 @@ func Test_AllowAll(t *testing.T) {
 		identity.NumericIdentity(identityFoo): labelsFoo,
 		identity.NumericIdentity(identityBar): labelsBar,
 	}
-	selectorCache := NewSelectorCache(identityCache)
+	selectorCache := testNewSelectorCache(identityCache)
 
 	tests := []struct {
 		test     int

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -219,7 +219,8 @@ func (l4 *L4Filter) ToKeys(direction trafficdirection.TrafficDirection) []Key {
 }
 
 // IdentitySelectionUpdated implements CachedSelectionUser interface
-// This call is made while holding selector cache lock, must beware of deadlocking!
+// This call is made while holding name manager and selector cache
+// locks, must beware of deadlocking!
 //
 // The caller is responsible for making sure the same identity is not
 // present in both 'added' and 'deleted'.

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -34,7 +34,7 @@ var (
 	toFoo        = &SearchContext{To: labels.ParseSelectLabelArray("foo")}
 
 	dummySelectorCacheUser = &DummySelectorCacheUser{}
-	testSelectorCache      = NewSelectorCache(cache.GetIdentityCache())
+	testSelectorCache      = testNewSelectorCache(cache.GetIdentityCache())
 
 	wildcardCachedSelector, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, api.WildcardEndpointSelector)
 

--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -90,7 +90,7 @@ func (s *CachedSelectorSlice) Insert(cs CachedSelector) bool {
 // the CachedSelectors pushed by it.
 type CachedSelectionUser interface {
 	// IdentitySelectionUpdated implementations MUST NOT call back
-	// to selector cache while executing this function!
+	// to the name manager or the selector cache while executing this function!
 	//
 	// The caller is responsible for making sure the same identity is not
 	// present in both 'added' and 'deleted'.
@@ -131,8 +131,13 @@ type CachedSelectionUser interface {
 type identitySelector interface {
 	CachedSelector
 	addUser(CachedSelectionUser) (added bool)
-	removeUser(CachedSelectionUser) (last bool)
+
+	// Called with NameManager and SelectorCache locks held
+	removeUser(CachedSelectionUser, identityNotifier) (last bool)
+
+	// This may be called while the NameManager lock is held
 	notifyUsers(added, deleted []identity.NumericIdentity)
+
 	numUsers() int
 }
 
@@ -290,18 +295,19 @@ func (s *selectorManager) addUser(user CachedSelectionUser) (added bool) {
 }
 
 // lock must be held
-func (s *selectorManager) removeUser(user CachedSelectionUser) (last bool) {
+func (s *selectorManager) removeUser(user CachedSelectionUser, dnsProxy identityNotifier) (last bool) {
 	delete(s.users, user)
 	return len(s.users) == 0
 }
 
-func (f *fqdnSelector) removeUser(user CachedSelectionUser) (last bool) {
+// locks must be held for the dnsProxy and the SelectorCache
+func (f *fqdnSelector) removeUser(user CachedSelectionUser, dnsProxy identityNotifier) (last bool) {
 	delete(f.users, user)
-	removed := len(f.users) == 0
-	if removed {
-		f.dnsProxy.UnregisterForIdentityUpdates(f.selector)
+	if len(f.users) == 0 {
+		dnsProxy.UnregisterForIdentityUpdatesLocked(f.selector)
+		return true
 	}
-	return removed
+	return false
 }
 
 // lock must be held
@@ -350,8 +356,6 @@ func (s *selectorManager) setSelections(selections *[]identity.NumericIdentity) 
 type fqdnSelector struct {
 	selectorManager
 	selector api.FQDNSelector
-	// dnsProxy updates the set of identities which correspond to this selector.
-	dnsProxy identityNotifier
 }
 
 // identityNotifier provides a means for other subsystems to be made aware of a
@@ -362,7 +366,15 @@ type fqdnSelector struct {
 // relationship is contained only via DNS responses, which are handled
 // externally.
 type identityNotifier interface {
-	// RegisterForIdentityUpdates exposes this FQDNSelector so that identities
+	// Lock must be held during any calls to RegisterForIdentityUpdatesLocked or
+	// UnregisterForIdentityUpdatesLocked.
+	Lock()
+
+	// Unlock must be called after calls to RegisterForIdentityUpdatesLocked or
+	// UnregisterForIdentityUpdatesLocked are done.
+	Unlock()
+
+	// RegisterForIdentityUpdatesLocked exposes this FQDNSelector so that identities
 	// for IPs contained in a DNS response that matches said selector can be
 	// propagated back to the SelectorCache via `UpdateFQDNSelector`. When called,
 	// implementers (currently `pkg/fqdn/RuleGen`) should iterate over all DNS
@@ -377,15 +389,15 @@ type identityNotifier interface {
 	// set of CIDR identities which match this FQDNSelector already from the
 	// identityNotifier on the first pass; any subsequent updates will eventually
 	// call `UpdateFQDNSelector`.
-	RegisterForIdentityUpdates(selector api.FQDNSelector) (identities []identity.NumericIdentity)
+	RegisterForIdentityUpdatesLocked(selector api.FQDNSelector) (identities []identity.NumericIdentity)
 
-	// UnregisterForIdentityUpdates removes this FQDNSelector from the set of
+	// UnregisterForIdentityUpdatesLocked removes this FQDNSelector from the set of
 	// FQDNSelectors which are being tracked by the identityNotifier. The result
 	// of this is that no more updates for IPs which correspond to said selector
 	// are propagated back to the SelectorCache via `UpdateFQDNSelector`.
 	// This occurs when there are no more users of a given FQDNSelector for the
 	// SelectorCache.
-	UnregisterForIdentityUpdates(selector api.FQDNSelector)
+	UnregisterForIdentityUpdatesLocked(selector api.FQDNSelector)
 }
 
 type labelIdentitySelector struct {
@@ -450,7 +462,6 @@ func (sc *SelectorCache) updateFQDNSelector(fqdnSelec api.FQDNSelector, identiti
 				cachedSelections: make(map[identity.NumericIdentity]struct{}),
 			},
 			selector: fqdnSelec,
-			dnsProxy: sc.localIdentityNotifier,
 		}
 		sc.selectors[fqdnKey] = fqdnSel
 	} else {
@@ -530,6 +541,10 @@ func (sc *SelectorCache) updateFQDNSelector(fqdnSelec api.FQDNSelector, identiti
 func (sc *SelectorCache) AddFQDNSelector(user CachedSelectionUser, fqdnSelec api.FQDNSelector) (cachedSelector CachedSelector, added bool) {
 	key := fqdnSelec.String()
 
+	// Lock NameManager before the SelectorCache
+	sc.localIdentityNotifier.Lock()
+	defer sc.localIdentityNotifier.Unlock()
+
 	// If the selector already exists, use it.
 	sc.mutex.Lock()
 	fqdnSel, exists := sc.selectors[key]
@@ -550,7 +565,6 @@ func (sc *SelectorCache) AddFQDNSelector(user CachedSelectionUser, fqdnSelec api
 			cachedSelections: make(map[identity.NumericIdentity]struct{}),
 		},
 		selector: fqdnSelec,
-		dnsProxy: sc.localIdentityNotifier,
 	}
 
 	// Make the FQDN subsystem aware of this selector and fetch identities
@@ -564,7 +578,7 @@ func (sc *SelectorCache) AddFQDNSelector(user CachedSelectionUser, fqdnSelec api
 	// If this is called twice, one of the results will arbitrarily contain
 	// a real slice of ids, while the other will receive nil. We must fold
 	// them together below.
-	ids := newFQDNSel.dnsProxy.RegisterForIdentityUpdates(newFQDNSel.selector)
+	ids := sc.localIdentityNotifier.RegisterForIdentityUpdatesLocked(newFQDNSel.selector)
 
 	// Do not go through the identity cache to see what identities "match" this
 	// selector. This has to be updated via whatever is getting the CIDR identities
@@ -670,11 +684,12 @@ func (sc *SelectorCache) AddIdentitySelector(user CachedSelectionUser, selector 
 	return newIDSel, true
 }
 
+// lock must be held
 func (sc *SelectorCache) removeSelectorLocked(selector CachedSelector, user CachedSelectionUser) {
 	key := selector.String()
 	sel, exists := sc.selectors[key]
 	if exists {
-		if sel.removeUser(user) {
+		if sel.removeUser(user, sc.localIdentityNotifier) {
 			delete(sc.selectors, key)
 		}
 	}
@@ -682,18 +697,22 @@ func (sc *SelectorCache) removeSelectorLocked(selector CachedSelector, user Cach
 
 // RemoveSelector removes CachedSelector for the user.
 func (sc *SelectorCache) RemoveSelector(selector CachedSelector, user CachedSelectionUser) {
+	sc.localIdentityNotifier.Lock()
 	sc.mutex.Lock()
 	sc.removeSelectorLocked(selector, user)
 	sc.mutex.Unlock()
+	sc.localIdentityNotifier.Unlock()
 }
 
 // RemoveSelectors removes CachedSelectorSlice for the user.
 func (sc *SelectorCache) RemoveSelectors(selectors CachedSelectorSlice, user CachedSelectionUser) {
+	sc.localIdentityNotifier.Lock()
 	sc.mutex.Lock()
 	for _, selector := range selectors {
 		sc.removeSelectorLocked(selector, user)
 	}
 	sc.mutex.Unlock()
+	sc.localIdentityNotifier.Unlock()
 }
 
 // ChangeUser changes the CachedSelectionUser that gets updates on the
@@ -706,7 +725,8 @@ func (sc *SelectorCache) ChangeUser(selector CachedSelector, from, to CachedSele
 		// Add before remove so that the count does not dip to zero in between,
 		// as this causes FQDN unregistration (if applicable).
 		idSel.addUser(to)
-		idSel.removeUser(from)
+		// ignoring the return value as we have just added a user above
+		idSel.removeUser(from, sc.localIdentityNotifier)
 	}
 	sc.mutex.Unlock()
 }

--- a/pkg/testutils/identitynotifier.go
+++ b/pkg/testutils/identitynotifier.go
@@ -1,0 +1,68 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutils
+
+import (
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/policy/api"
+)
+
+type DummyIdentityNotifier struct {
+	mutex     lock.Mutex
+	selectors map[api.FQDNSelector][]identity.NumericIdentity
+}
+
+func NewDummyIdentityNotifier() *DummyIdentityNotifier {
+	return &DummyIdentityNotifier{
+		selectors: make(map[api.FQDNSelector][]identity.NumericIdentity),
+	}
+}
+
+// Lock must be held during any calls to RegisterForIdentityUpdatesLocked or
+// UnregisterForIdentityUpdatesLocked.
+func (d *DummyIdentityNotifier) Lock() {
+	d.mutex.Lock()
+}
+
+// Unlock must be called after calls to RegisterForIdentityUpdatesLocked or
+// UnregisterForIdentityUpdatesLocked are done.
+func (d *DummyIdentityNotifier) Unlock() {
+	d.mutex.Unlock()
+}
+
+// RegisterForIdentityUpdatesLocked starts managing this selector.
+func (d *DummyIdentityNotifier) RegisterForIdentityUpdatesLocked(selector api.FQDNSelector) (identities []identity.NumericIdentity) {
+	ids, ok := d.selectors[selector]
+	if !ok {
+		d.selectors[selector] = []identity.NumericIdentity{}
+	}
+	return ids
+}
+
+// UnregisterForIdentityUpdatesLocked stops managing this selector.
+func (d *DummyIdentityNotifier) UnregisterForIdentityUpdatesLocked(selector api.FQDNSelector) {
+	delete(d.selectors, selector)
+}
+
+func (d *DummyIdentityNotifier) InjectIdentitiesForSelector(fqdnSel api.FQDNSelector, ids []identity.NumericIdentity) {
+	d.selectors[fqdnSel] = ids
+}
+
+// IsRegistered returns whether this selector is being managed.
+func (d *DummyIdentityNotifier) IsRegistered(selector api.FQDNSelector) bool {
+	_, ok := d.selectors[selector]
+	return ok
+}


### PR DESCRIPTION
 * #10501 -- policy: Keep NameManager locked during SelectorCache operations (@jrajahalme)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 10501; do contrib/backporting/set-labels.py $pr done 1.6; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10532)
<!-- Reviewable:end -->
