### PR TITLE
docs: Clarify wording for cluster and init entities

### DIFF
--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -300,12 +300,13 @@ remote-node
     nodes. (Requires the option ``enable-remote-node-identity`` to be enabled)
 cluster
     Cluster is the logical group of all network endpoints inside of the local
-    cluster. This includes all Cilium-managed endpoints of the local cluster.
-    It also includes the host entity to cover host networking containers as
-    well as the init entity to include endpoints currently being bootstrapped.
+    cluster. This includes all Cilium-managed endpoints of the local cluster,
+    unmanaged endpoints in the local cluster, as well as the host,
+    remote-node, and init identities.
 init
     The init entity contains all endpoints in bootstrap phase for which the
-    security identity has not been resolved yet. See section
+    security identity has not been resolved yet. This is typically only
+    observed in non-Kubernetes environments. See section
     :ref:`endpoint_lifecycle` for details.
 world
     The world entity corresponds to all endpoints outside of the cluster.


### PR DESCRIPTION
cf. pkg/policy/api/entity.go

'cluster' includes 'remote-node'. Also, 'init' is rarely seen in
practice these days since we fetch the labels from k8s during endpoint
creation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10536)
<!-- Reviewable:end -->
