### PR TITLE
helm: enable prometheus metrics in cilium-operator

### DIFF
--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -65,6 +65,7 @@ data:
   # NOTE that this will open the port on the nodes where Cilium operator pod
   # is scheduled.
   operator-prometheus-serve-addr: ":{{ .Values.global.operatorPrometheus.port }}"
+  enable-metrics: "true"
 {{- end }}
 
   # Enable IPv4 addressing. If enabled, all endpoints are allocated an IPv4


### PR DESCRIPTION
Cilium operator also needs the option metrics-enabled to be set in order
for its prometheus metrics be made available.

Signed-off-by: André Martins <andre@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10539)
<!-- Reviewable:end -->
