### PR TITLE
hubble-proxy: add initial skeleton

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,6 +9,7 @@
 # @cilium/docs          Documentation, examples
 # @cilium/endpoint      Endpoint package
 # @cilium/health        Cilium cluster health tool
+# @cilium/hubble        Hubble integration
 # @cilium/kubernetes    K8s integration, K8s CNI plugin
 # @cilium/kvstore       Key/Value store: Consul, etcd
 # @cilium/loadbalancer  Load balancer
@@ -19,10 +20,9 @@
 # @cilium/vendor        Vendoring, dependency management
 #
 # Specific code owners:
-# @eloycoto                       Debian packaging
-# @aanm @ianvernon                Docker packaging
-# @scanf @borkmann                BPF documentation
-# @gandro @glibsm @michi-covalent Hubble
+# @eloycoto             Debian packaging
+# @aanm @ianvernon      Docker packaging
+# @scanf @borkmann      BPF documentation
 
 # The following filepaths should be sorted so that more specific paths occur
 # after the less specific paths, otherwise the ownership for the specific paths
@@ -65,6 +65,7 @@ ginkgo.Jenkinsfile @cilium/ci
 kubernetes-upstream.Jenkinsfile @cilium/ci
 ginkgo-all.Jenkinsfile @cilium/ci
 ginkgo-kubernetes-all.Jenkinsfile @cilium/ci
+hubble-proxy/ @cilium/hubble
 install/kubernetes/ @cilium/kubernetes
 jenkinsfiles @cilium/ci
 Jenkinsfile @cilium/ci
@@ -91,7 +92,7 @@ pkg/endpointmanager/ @cilium/endpoint
 pkg/envoy/ @cilium/proxy
 pkg/fqdn/ @cilium/agent
 pkg/health/ @cilium/health
-pkg/hubble/ @gandro @glibsm @michi-covalent
+pkg/hubble/ @cilium/hubble
 pkg/identity @cilium/policy
 pkg/ipcache/ @cilium/ipcache
 pkg/k8s/ @cilium/kubernetes

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SUBDIRS_CILIUM_CONTAINER := proxylib envoy plugins/cilium-cni bpf cilium daemon 
 ifdef LIBNETWORK_PLUGIN
 SUBDIRS_CILIUM_CONTAINER += plugins/cilium-docker
 endif
-SUBDIRS := $(SUBDIRS_CILIUM_CONTAINER) operator plugins tools
+SUBDIRS := $(SUBDIRS_CILIUM_CONTAINER) operator plugins tools hubble-proxy
 GOFILES_EVAL := $(subst _$(ROOT_DIR)/,,$(shell $(CGO_DISABLED) $(GOLIST) $(GO) list -e ./...))
 GOFILES ?= $(GOFILES_EVAL)
 TESTPKGS_EVAL := $(subst github.com/cilium/cilium/,,$(shell $(CGO_DISABLED) $(GOLIST) $(GO) list -e ./... | grep -v '/api/v1\|/vendor\|/contrib' | grep -v -P 'test(?!/helpers/logutils)'))

--- a/hubble-proxy/.gitignore
+++ b/hubble-proxy/.gitignore
@@ -1,0 +1,2 @@
+hubble-proxy
+bash_autocomplete

--- a/hubble-proxy/Makefile
+++ b/hubble-proxy/Makefile
@@ -1,0 +1,27 @@
+include ../Makefile.quiet
+include ../Makefile.defs
+
+TARGET=hubble-proxy
+SOURCES := $(shell find . ../pkg/hubble \( -name '*.go' ! -name '*_test.go' \))
+
+
+all: $(TARGET)
+
+$(TARGET): $(SOURCES)
+	@$(ECHO_GO)
+	$(QUIET)$(GO) build $(GOBUILD) -o $(TARGET)
+	strip $(TARGET)
+
+clean:
+	@$(ECHO_CLEAN) $(notdir $(shell pwd))
+	-$(QUIET)rm -f $(TARGET)
+	$(QUIET)$(GO) clean $(GOCLEAN)
+
+install:
+	$(QUIET)$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)
+	$(QUIET)$(INSTALL) -m 0755 $(TARGET) $(DESTDIR)$(BINDIR)
+	$(QUIET)$(INSTALL) -m 0755 -d $(DESTDIR)$(CONFDIR)/bash_completion.d
+	./$(TARGET) completion bash > bash_autocomplete
+	$(QUIET)$(INSTALL) -m 0644 -T bash_autocomplete $(DESTDIR)$(CONFDIR)/bash_completion.d/hubble-proxy
+
+.PHONY: clean install

--- a/hubble-proxy/cmd/completion/completion.go
+++ b/hubble-proxy/cmd/completion/completion.go
@@ -1,0 +1,104 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package completion
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+)
+
+// New creates a new shell completion command.
+func New() *cobra.Command {
+	return &cobra.Command{
+		Use:     "completion [shell]",
+		Short:   "Output shell completion code",
+		Long:    "Output shell completion code for bash and zsh",
+		Example: completionExample,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCompletion(cmd.OutOrStdout(), cmd, args)
+		},
+		ValidArgs: []string{"bash", "zsh"},
+	}
+}
+
+func runCompletion(out io.Writer, cmd *cobra.Command, args []string) error {
+	if len(args) > 1 {
+		return fmt.Errorf("too many arguments; expected only the shell type: %s", args)
+	}
+
+	if len(args) == 0 || args[0] == "bash" {
+		if _, err := out.Write([]byte(copyRightHeader)); err != nil {
+			return err
+		}
+		return cmd.Root().GenBashCompletion(out)
+	}
+	if args[0] == "zsh" {
+		if _, err := out.Write([]byte(copyRightHeader)); err != nil {
+			return err
+		}
+		return cmd.Root().GenZshCompletion(out)
+	}
+	return fmt.Errorf("unsupported shell: %s", args[0])
+}
+
+const (
+	copyRightHeader = `// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+`
+	completionExample = `
+# Installing bash completion on macOS using homebrew
+## If running Bash 3.2 included with macOS
+	brew install bash-completion
+## or, if running Bash 4.1+
+	brew install bash-completion@2
+## afterwards you only need to run
+	hubble-proxy completion bash > $(brew --prefix)/etc/bash_completion.d/hubble-proxy
+
+
+# Installing bash completion on Linux
+## Load the hubble-proxy completion code for bash into the current shell
+	source <(hubble-proxy completion bash)
+## Write bash completion code to a file and source if from .bash_profile
+	hubble-proxy completion bash > ~/.hubble-proxy/completion.bash.inc
+	printf "
+	  # hubble-proxy shell completion
+	  source '$HOME/.hubble-proxy/completion.bash.inc'
+	  " >> $HOME/.bash_profile
+	source $HOME/.bash_profile
+
+# Installing zsh completion on Linux/macOS
+## Load the hubble-proxy completion code for zsh into the current shell
+        source <(hubble-proxy completion zsh)
+## Write zsh completion code to a file and source if from .zshrc
+        hubble-proxy completion zsh > ~/.hubble-proxy/completion.zsh.inc
+        printf "
+          # hubble-proxy shell completion
+          source '$HOME/.hubble-proxy/completion.zsh.inc'
+          " >> $HOME/.zshrc
+        source $HOME/.zshrc`
+)

--- a/hubble-proxy/cmd/root.go
+++ b/hubble-proxy/cmd/root.go
@@ -1,0 +1,40 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"github.com/cilium/cilium/hubble-proxy/cmd/completion"
+	"github.com/cilium/cilium/hubble-proxy/cmd/version"
+	v "github.com/cilium/cilium/pkg/version"
+
+	"github.com/spf13/cobra"
+)
+
+// New creates a new hubble-proxy command.
+func New() *cobra.Command {
+	rootCmd := &cobra.Command{
+		Use:          "hubble-proxy",
+		Short:        "hubble-proxy is a proxy server for the hubble API",
+		Long:         "hubble-proxy is a proxy server for the hubble API.",
+		SilenceUsage: true,
+		Version:      v.GetCiliumVersion().Version,
+	}
+	rootCmd.AddCommand(
+		completion.New(),
+		version.New(),
+	)
+	rootCmd.SetVersionTemplate("{{with .Name}}{{printf \"%s \" .}}{{end}}{{printf \"v%s\" .Version}}\n")
+	return rootCmd
+}

--- a/hubble-proxy/cmd/version/version.go
+++ b/hubble-proxy/cmd/version/version.go
@@ -1,0 +1,40 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/cilium/cilium/pkg/version"
+
+	"github.com/spf13/cobra"
+)
+
+// New creates a new version command.
+func New() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Display detailed version information",
+		Long:  `Displays information about the version of this software.`,
+		Run: func(cmd *cobra.Command, _ []string) {
+			runVersion(cmd.OutOrStdout())
+		},
+	}
+}
+
+func runVersion(out io.Writer) {
+	fmt.Fprintf(out, "Hubble-proxy: %s\n", version.Version)
+}

--- a/hubble-proxy/main.go
+++ b/hubble-proxy/main.go
@@ -1,0 +1,27 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+
+	"github.com/cilium/cilium/hubble-proxy/cmd"
+)
+
+func main() {
+	if err := cmd.New().Execute(); err != nil {
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
This commit adds code to create a binary, `hubble-proxy`, for the new
hubble proxy. This component is a new component that will be required
for hubble's multi-node feature.

Notably, the introduction of hubble proxy  will:

 - Allow sharing the hubble API externally via load balancer or ingress
   rules.
 - Give flexibility in terms of scheduling and resource allocation.
 - Make it easy to discover from Hubble UI (k8s service) or other
   clients such as the hubble CLI.
 - Make it potentially easier to implement API rate limiting to protect
   the cluster.
 - Decouple security from Cilium (CNPs can be applied).

The hubble proxy will talk directly with the hubble API on the cilium
agent running on the same node. This will allow initial hubble peers
discovery but also to monitor for peers joining/leaving the cluster or
to get information about which peer to connect to to get flows based on
the request (typically for long running requests). The hubble proxy will
connect to hubble peers in order to get relevant flows according to the
flow request to process.

Ref: https://github.com/cilium/hubble/issues/89

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10545)
<!-- Reviewable:end -->
