### PR TITLE
idpool: don't initialize ID cache in random order

### DIFF
--- a/pkg/idpool/idpool.go
+++ b/pkg/idpool/idpool.go
@@ -15,9 +15,7 @@
 package idpool
 
 import (
-	"math/rand"
 	"strconv"
-	"time"
 
 	"github.com/cilium/cilium/pkg/lock"
 )
@@ -170,10 +168,7 @@ func newIDCache(minID ID, maxID ID) *idCache {
 		leased: make(map[ID]struct{}),
 	}
 
-	random := rand.New(rand.NewSource(time.Now().UnixNano()))
-	seq := random.Perm(n)
-	for i := 0; i < n; i++ {
-		id := ID(seq[i]) + minID
+	for id := minID; id < maxID+1; id++ {
 		c.ids[id] = struct{}{}
 	}
 


### PR DESCRIPTION
There is no need to initialize the ID cache in random order. All that we
care about is that the IDs are allocated in random order. This is
ensured by `(*idCache).allocateID` iterating over a map which in Go is
guaranteed to be in random order.

For #10056, this saves the peek allocation of the permutation slice
during initialization, which in the worst case of `pkg/identity/allocator`
is 512K (64k IDs * sizeof int).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10546)
<!-- Reviewable:end -->
