### PR TITLE
Allow for non default runtime socket path

### DIFF
--- a/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
@@ -181,6 +181,17 @@ spec:
           name: cni-path
         - mountPath: {{ .Values.global.cni.hostConfDirMountPath }}
           name: etc-cni-netd
+{{- if and (.Values.global.containerRuntime.socketPath) (not (eq .Values.global.containerRuntime.integration "none")) }}
+{{- if or (eq .Values.global.containerRuntime.integration "docker") (eq .Values.global.containerRuntime.integration "auto") }}
+        - mountPath: /var/run/docker.sock
+          readOnly: true
+{{- else if eq .Values.global.containerRuntime.integration "crio" }}
+        - mountPath: /var/run/crio/crio.sock
+{{- else if eq .Values.global.containerRuntime.integration "containerd" }}
+        - mountPath: /var/run/containerd/containerd.sock
+{{- end }}
+          name: runtime-socket
+{{- end }}
 {{- if .Values.global.etcd.enabled }}
         - mountPath: /var/lib/etcd-config
           name: etcd-config-path
@@ -329,7 +340,14 @@ spec:
           type: DirectoryOrCreate
         name: bpf-maps
 {{- end }}
-      # To install cilium cni plugin in the host
+{{- if and (.Values.global.containerRuntime.socketPath) (not (eq .Values.global.containerRuntime.integration "none")) }}
+        # To read container runtime events from the node
+      - hostPath:
+          path: {{ .Values.global.containerRuntime.socketPath }}
+          type: Socket
+        name: runtime-socket
+{{- end }}
+        # To install cilium cni plugin in the host
       - hostPath:
           path:  {{ .Values.global.cni.binPath }}
           type: DirectoryOrCreate


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->

global.containerRuntime.socketPath is used to set a non default
runtime socket path. This property should not be ignored as it was
working on v1.6. This PR ensures that if a socket path is set and
the runtime is not set to none the socket path is set in the
daemonset manifest.
    
Fixes: #10544

```release-note
Allow for non default runtime socket path in k8s installation
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10547)
<!-- Reviewable:end -->
