### PR TITLE
vagrant: Ignore failures of "chown -R vagrant:vagrant" command

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -50,7 +50,7 @@ echo "done configuring journald"
 
 sudo service docker restart
 echo 'cd ~/go/src/github.com/cilium/cilium' >> /home/vagrant/.bashrc
-sudo chown -R vagrant:vagrant /home/vagrant 2>/dev/null
+sudo chown -R vagrant:vagrant /home/vagrant 2>/dev/null || true
 curl -SsL https://github.com/cilium/bpf-map/releases/download/v1.0/bpf-map -o bpf-map
 chmod +x bpf-map
 mv bpf-map /usr/bin


### PR DESCRIPTION
For unknown reason, that command sometimes fails and prints the
following stderr message:

```
changing ownership of 'test/k8s1-1.17-ttyS0.sock'
: Input/output error
```

That can be ignored.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10549)
<!-- Reviewable:end -->
