### PR TITLE
Deprecate --disable-k8s-services cilium-agent flag

### DIFF
--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -302,6 +302,8 @@ Deprecated options
   deprecated and will be removed in Cilium 1.9.
 * ``access-log``: L7 access logs have been available via Hubble since Cilium
   1.6. The ``access-log`` option to log to a file has been removed.
+* ``--disable-k8s-services`` option from cilium-agent has been deprecated
+  and will be removed in Cilium 1.9. 
 
 Renamed Metrics
 ~~~~~~~~~~~~~~~

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -323,6 +323,7 @@ func init() {
 
 	flags.Bool(option.DisableK8sServices, false, "Disable east-west K8s load balancing by cilium")
 	option.BindEnv(option.DisableK8sServices)
+	flags.MarkDeprecated(option.DisableK8sServices, "This option is no longer supported and will be removed in v1.9")
 
 	flags.String(option.EgressMasqueradeInterfaces, "", "Limit egress masquerading to interface selector")
 	option.BindEnv(option.EgressMasqueradeInterfaces)
@@ -411,7 +412,7 @@ func init() {
 
 	flags.Int(option.IPv4ClusterCIDRMaskSize, 8, "Mask size for the cluster wide CIDR")
 	option.BindEnv(option.IPv4ClusterCIDRMaskSize)
-	flags.MarkDeprecated(option.IPv4ClusterCIDRMaskSize, "This option is no longer supported and will be removed in v1.9")
+	flags.MarkDeprecated(option.IPv4ClusterCIDRMaskSize, "This option has been deprecated and will be removed in v1.9")
 
 	flags.String(option.IPv4Range, AutoCIDR, "Per-node IPv4 endpoint prefix, e.g. 10.16.0.0/16")
 	option.BindEnv(option.IPv4Range)


### PR DESCRIPTION
This patch deprecates the use of --disable-k8s-services option
in cilium-agent to disable the Kube-proxy, since it is redundant
to --kube-proxy-replacement option.

Fixes: #10525
Signed-off-by: Swaminathan Vasudevan <svasudevan@suse.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10552)
<!-- Reviewable:end -->
