### PR TITLE
Doc: Fix ipam crd backend getting started guide

### DIFF
--- a/Documentation/gettingstarted/ipam-crd.rst
+++ b/Documentation/gettingstarted/ipam-crd.rst
@@ -50,11 +50,10 @@ Create a CiliumNode CR
              name: "k8s1"
            spec:
              ipam:
-               available:
-                 192.168.1.1: {}
-                 192.168.1.2: {}
-                 192.168.1.3: {}
-                 192.168.1.4: {}
+               192.168.1.1: {}
+               192.168.1.2: {}
+               192.168.1.3: {}
+               192.168.1.4: {}
 
 #. Validate that Cilium has started up correctly
 
@@ -80,11 +79,10 @@ Create a CiliumNode CR
          [...]
        spec:
          ipam:
-           available:
-             192.168.1.1: {}
-             192.168.1.2: {}
-             192.168.1.3: {}
-             192.168.1.4: {}
+           192.168.1.1: {}
+           192.168.1.2: {}
+           192.168.1.3: {}
+           192.168.1.4: {}
        status:
          ipam:
            used:


### PR DESCRIPTION
The documentation is not correct as the "available" field does not
exist in cilium node for ipam crd.

Fixes: #10495
Signed-off-by: Swaminathan Vasudevan <svasudevan@suse.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10553)
<!-- Reviewable:end -->
