### PR TITLE
pkg/monitor: Add missing drop reasons

### DIFF
--- a/pkg/monitor/api/drop.go
+++ b/pkg/monitor/api/drop.go
@@ -74,6 +74,8 @@ var errors = map[uint8]string{
 	170: "Encapsulation traffic is prohibited",
 	171: "Invalid identity",
 	172: "Unknown sender",
+	173: "NAT not needed",
+	174: "Is a ClusterIP",
 }
 
 // DropReason prints the drop reason in a human readable string


### PR DESCRIPTION
Hi,
`pgk/monitor` is missing some error codes, and thus results in monitor logs like these without human readable error codes:

```
xx drop (174) flow 0xb81f5557 to endpoint 0, identity 0->0: [xxxx:yyyy:0:cccc:8000::6d9]:50508 -> [xxxx:yyyy:caca:1035:4::ffa3]:12000 tcp SYN
```

Cheers and thanks ;-)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10554)
<!-- Reviewable:end -->
