### PR TITLE
bpf: Declare config. variables as volatile

### DIFF
--- a/bpf/lib/static_data.h
+++ b/bpf/lib/static_data.h
@@ -14,8 +14,8 @@
 #define fetch_mac(x) { { fetch_u32_i(x, 1), (__u16)fetch_u32_i(x, 2) } }
 
 /* DEFINE_* macros help to declare static data. */
-#define DEFINE_U32(NAME, value) __u32 NAME = value
-#define DEFINE_U32_I(NAME, i) __u32 NAME ## _ ## i
+#define DEFINE_U32(NAME, value) volatile __u32 NAME = value
+#define DEFINE_U32_I(NAME, i) volatile __u32 NAME ## _ ## i
 #define DEFINE_IPV6(NAME, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16)	\
 DEFINE_U32_I(NAME, 1) = bpf_htonl( (a1) << 24 |  (a2) << 16 |  (a3) << 8 |  (a4));			\
 DEFINE_U32_I(NAME, 2) = bpf_htonl( (a5) << 24 |  (a6) << 16 |  (a7) << 8 |  (a8));			\


### PR DESCRIPTION
This commit declares config. variables as volatile to prevent the compiler from optimizing code based on the value of those variables if/when we start using them in conditions. Declaring them as volatile does not currently result in any changes in the generated bytecodes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10557)
<!-- Reviewable:end -->
