### PR TITLE
cli: do not output shell completion copyright header on error

### DIFF
--- a/cilium/cmd/root.go
+++ b/cilium/cmd/root.go
@@ -95,8 +95,7 @@ func initConfig() {
 	}
 }
 
-const copyRightHeader = `
-# Copyright 2017 Authors of Cilium
+const copyRightHeader = `# Copyright 2017-2020 Authors of Cilium
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -163,21 +162,20 @@ func newCmdCompletion(out io.Writer) *cobra.Command {
 
 func runCompletion(out io.Writer, cmd *cobra.Command, args []string) error {
 	if len(args) > 1 {
-		return fmt.Errorf("Too many arguments. Expected only the shell type.")
-	}
-	if _, err := out.Write([]byte(copyRightHeader)); err != nil {
-		return err
-	}
-	if len(args) == 0 {
-		return cmd.Parent().GenBashCompletion(out)
+		return fmt.Errorf("too many arguments; expected only the shell type: %s", args)
 	}
 
-	switch args[0] {
-	case "bash":
-		return cmd.Parent().GenBashCompletion(out)
-	case "zsh":
-		return cmd.Parent().GenZshCompletion(out)
+	if len(args) == 0 || args[0] == "bash" {
+		if _, err := out.Write([]byte(copyRightHeader)); err != nil {
+			return err
+		}
+		return cmd.Root().GenBashCompletion(out)
 	}
-
-	return fmt.Errorf("Unexpected shell: %s.", args[0])
+	if args[0] == "zsh" {
+		if _, err := out.Write([]byte(copyRightHeader)); err != nil {
+			return err
+		}
+		return cmd.Root().GenZshCompletion(out)
+	}
+	return fmt.Errorf("unsupported shell: %s", args[0])
 }


### PR DESCRIPTION
Before this commit, the copyright header was always displayed when running `cilium completion ...`, even on error such as when an invalid argument is provided.
This commit ensures that the copyright header is printed out only when shell completion is actually printed out.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10558)
<!-- Reviewable:end -->
