### PR TITLE
vagrant: Fix missing doc. dependency error

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -61,6 +61,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+pip3 install -r ~/go/src/github.com/cilium/cilium/Documentation/requirements.txt
+
 export PATH=/home/vagrant/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games
 ~/go/src/github.com/cilium/cilium/common/build.sh
 rm -fr ~/go/bin/cilium*


### PR DESCRIPTION
The dev. VM provisioning currently fails with the following error because of a missing documentation dependency:
```
    runtime1: make[1]: Leaving directory '/home/vagrant/go/src/github.com/cilium/cilium/Documentation'
    runtime1: contrib/scripts/lock-check.sh
    runtime1: make[1]: Entering directory '/home/vagrant/go/src/github.com/cilium/cilium'
    runtime1: (make -C Documentation/ dummy SPHINXOPTS="" 2>&1 && touch check-docs.ok) \
    runtime1: 	| grep -v "tabs assets"
    runtime1: make[2]: Entering directory '/home/vagrant/go/src/github.com/cilium/cilium/Documentation'
    runtime1: Documentation dependency 'pyenchant' not found.
    runtime1: Run 'pip3 install --user -r Documentation/requirements.txt'
    runtime1: Makefile:27: recipe for target 'check-requirements' failed
    runtime1: make[2]: *** [check-requirements] Error 2
    runtime1: make[2]: Leaving directory '/home/vagrant/go/src/github.com/cilium/cilium/Documentation'
    runtime1: Makefile:451: recipe for target 'check-docs' failed
    runtime1: make[1]: Leaving directory '/home/vagrant/go/src/github.com/cilium/cilium'
    runtime1: Makefile:456: recipe for target 'postcheck' failed
    runtime1: make[1]: *** [check-docs] Error 2
    runtime1: make: *** [postcheck] Error 2
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
```
There's already cilium/packer-ci-build#196 open to add the missing dependency to the upstream VM image, but we need to add it to the Vagrant provisioning as well to fix the error until we build a new image.

/cc @mrostecki

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10562)
<!-- Reviewable:end -->
