### PR TITLE
kubernetes: do not set enable-endpoint-health-checking=false with portmap

### DIFF
--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -328,8 +328,11 @@ data:
 {{- if .Values.global.kubeConfigPath }}
   k8s-kubeconfig-path: {{ .Values.global.kubeConfigPath | quote }}
 {{- end }}
-{{- if not (eq .Values.global.cni.chainingMode "none") }}
-  # Chaining mode was enabled, disabling health checking
+{{- if or (eq .Values.global.cni.chainingMode "portmap") (eq .Values.global.cni.chainingMode "none") }}
+  # Chaining mode is set to portmap, enable health checking
+  enable-endpoint-health-checking: "true"
+{{- else}}
+  # Disable health checking, when chaining mode is not set to portmap or none
   enable-endpoint-health-checking: "false"
 {{- end }}
 {{- if or .Values.global.wellKnownIdentities.enabled .Values.global.etcd.managed }}


### PR DESCRIPTION
This patch sets the 'enable-endpoint-health-checking=true' when
portmap is set for cni-chaining mode and for the rest it is set to
'false'.

Fixes: #10455
Signed-off-by: Swaminathan Vasudevan <svasudevan@suse.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10566)
<!-- Reviewable:end -->
