### PR TITLE
CI: GKE terminating namespace hack find orphaned objects

### DIFF
--- a/test/gke/delete-terminating-namespaces.sh
+++ b/test/gke/delete-terminating-namespaces.sh
@@ -5,3 +5,33 @@
 kubectl get ns | \
 	awk '/Terminating/ {print $1}' | \
    	xargs -n 1 bash -c 'if [ "$#" -ne 1 ]; then exit 0; fi; kubectl get ns -o json $1 | tr -d "\n" | sed "s/\"finalizers\": \[[^]]\+\]/\"finalizers\": []/" | kubectl replace --raw /api/v1/namespaces/$1/finalize -f -' -
+
+# Note: This can be removed once GKE stops having the issue with namespaces no
+# deleting.
+# because of the hack above, we may end up with orphaned pods etc. We need to
+# delete any here. We do this after the hack above to simplify the logic (i.e.
+# don't look for the terminating namespaces twice). We also cannot rely on the
+# list of terminating namespaces because another run deleted them, leaving
+# orphans.
+# The commands mimic the DeleteAllInNamespace function in test/helpers/kubectl.go
+
+# Get all namespaces that exist. Terminating ones have been cleared above.
+NAMESPACES=$( kubectl get ns -o jsonpath='{range .items[*]}{@.metadata.name}{" "}')
+
+# Get all namespaced types in the k8s system
+TYPES=$(kubectl api-resources --namespaced=true --verbs=delete -o name | tr '\n' ',' | sed -e 's/,$//')
+
+# Get all objects of namespaced types
+# We use '|' to delimit namespace and type/name since / is already used
+OBJECTS=$(kubectl get $TYPES --all-namespaces -o jsonpath="{range .items[*]}{@.metadata.namespace}{'|'}{@.kind}{'/'}{@.metadata.name}{' '}{end}")
+
+# For each object, check if the namespace it is in exists. If the namespace
+# does not, delete the object.
+for pair in $OBJECTS; do
+  IFS='|' read ns obj <<<"$pair"
+  #echo "Checking if $ns/$obj ($pair) is present in $NAMESPACES"
+  if ! $(echo "$NAMESPACES" | grep -q "$ns" - ) ; then
+    echo "Object $obj in $ns is a namespace orphan; deleting"
+    kubectl delete -n $ns $obj
+  fi
+done


### PR DESCRIPTION
We can force delete namespaces but this leaves their contents behind.
Our tests can fail if unexpected pods and deploys are hanging about,
left over by the force-delete of the namespace.

We now check each object of each namespaced k8s kind to see if the
namespace exists, deleting those in namespaces that don't.

An example of cleaning can be found in https://jenkins.cilium.io/job/Cilium-PR-K8s-GKE/145/console
An example of cleaning left-overs from other tests https://jenkins.cilium.io/job/Cilium-PR-K8s-GKE/144/consoleFull (this will happen until this code runs on all GKE CI clusters)
`is a namespace orphan`


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10570)
<!-- Reviewable:end -->
