### PR TITLE
all: don't use global PRNG state from math/rand

### DIFF
--- a/daemon/status.go
+++ b/daemon/status.go
@@ -50,9 +50,7 @@ const (
 	k8sMinimumEventHearbeat = time.Minute
 )
 
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
+var randGen = rand.New(rand.NewSource(time.Now().UnixNano()))
 
 type k8sVersion struct {
 	version          string
@@ -288,7 +286,7 @@ func (h *getNodes) Handle(params GetClusterNodesParams) middleware.Responder {
 	if exists {
 		clientID = *params.ClientID
 	} else {
-		clientID = rand.Int63()
+		clientID = randGen.Int63()
 		// make sure we haven't allocated an existing client ID nor the
 		// randomizer has allocated ID 0, if we have then we will return
 		// clientID 0.

--- a/daemon/status_test.go
+++ b/daemon/status_test.go
@@ -17,7 +17,6 @@
 package main
 
 import (
-	"math/rand"
 	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -55,12 +54,12 @@ func (g *GetNodesSuite) SetUpSuite(c *C) {
 func (g *GetNodesSuite) Test_getNodesHandle(c *C) {
 	// Set seed so we can have the same pseudorandom client IDs.
 	// The seed is set to 0 for each unit test.
-	rand.Seed(0)
+	randGen.Seed(0)
 	const numberOfClients = 10
 
 	clientIDs := make([]int64, 0, numberOfClients)
 	for i := 0; i < numberOfClients; i++ {
-		clientIDs = append(clientIDs, rand.Int63())
+		clientIDs = append(clientIDs, randGen.Int63())
 	}
 
 	var zero int64
@@ -371,7 +370,7 @@ func (g *GetNodesSuite) Test_getNodesHandle(c *C) {
 
 	for _, tt := range tests {
 		c.Log(tt.name)
-		rand.Seed(0)
+		randGen.Seed(0)
 		args := tt.setupArgs()
 		want := tt.setupWanted()
 		h := &getNodes{

--- a/pkg/fqdn/lookup.go
+++ b/pkg/fqdn/lookup.go
@@ -17,16 +17,11 @@ package fqdn
 import (
 	"fmt"
 	"math"
-	"math/rand"
 	"net"
 	"time"
 
 	"github.com/miekg/dns"
 )
-
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
 
 // DNSIPRecords mimics the RR data from an A or AAAA response.
 // My kingdom for a DNS IP RR type that isn't hidden in the stdlib or has a

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -64,11 +64,9 @@ var (
 	// ErrLockLeaseExpired is an error whenever the lease of the lock does not
 	// exist or it was expired.
 	ErrLockLeaseExpired = errors.New("transaction did not succeed: lock lease expired")
-)
 
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
+	randGen = rand.New(rand.NewSource(time.Now().UnixNano()))
+)
 
 type etcdModule struct {
 	opts   backendOptions
@@ -362,7 +360,7 @@ func (e *etcdClient) waitForInitLock(ctx context.Context) <-chan bool {
 
 			// Generate a random number so that we can acquire a lock even
 			// if other agents are killed while locking this path.
-			randNumber := strconv.FormatUint(rand.Uint64(), 16)
+			randNumber := strconv.FormatUint(randGen.Uint64(), 16)
 			locker, err := e.LockPath(ctx, InitLockPath+"/"+randNumber)
 			if err == nil {
 				locker.Unlock(context.Background())

--- a/pkg/lock/stoppable_waitgroup_test.go
+++ b/pkg/lock/stoppable_waitgroup_test.go
@@ -167,13 +167,13 @@ func (s *SemaphoredMutexSuite) TestWaitChannel(c *C) {
 func (s *SemaphoredMutexSuite) TestParallelism(c *C) {
 	l := NewStoppableWaitGroup()
 
-	rand.Seed(time.Now().Unix())
+	randGen := rand.New(rand.NewSource(time.Now().UnixNano()))
 	in := make(chan int)
 	stop := make(chan struct{})
 	go func() {
 		for {
 			select {
-			case in <- rand.Intn(1 - 0):
+			case in <- randGen.Intn(1 - 0):
 			case <-stop:
 				close(in)
 				return
@@ -198,7 +198,7 @@ func (s *SemaphoredMutexSuite) TestParallelism(c *C) {
 		}()
 	}
 
-	time.Sleep(time.Duration(rand.Intn(3-0)) * time.Second)
+	time.Sleep(time.Duration(randGen.Intn(3-0)) * time.Second)
 	close(stop)
 	wg.Wait()
 	add := atomic.LoadInt64(&adds)

--- a/pkg/testutils/rand_name.go
+++ b/pkg/testutils/rand_name.go
@@ -21,11 +21,12 @@ import (
 
 // Stolen from:
 // https://stackoverflow.com/questions/22892120/how-to-generate-a-random-string-of-a-fixed-length-in-golang
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
 
-var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+var (
+	randGen = rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+)
 
 // RandomRuneWithPrefix returns a random name string with fixed prefix
 func RandomRuneWithPrefix(prefix string, n int) string {
@@ -36,7 +37,7 @@ func RandomRuneWithPrefix(prefix string, n int) string {
 func RandomRuneWithLen(n int) string {
 	b := make([]rune, n)
 	for i := range b {
-		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+		b[i] = letterRunes[randGen.Intn(len(letterRunes))]
 	}
 	return string(b)
 }

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -38,10 +38,8 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func init() {
-	// ensure that our random numbers are seeded differently on each run
-	rand.Seed(time.Now().UnixNano())
-}
+// ensure that our random numbers are seeded differently on each run
+var randGen = rand.New(rand.NewSource(time.Now().UnixNano()))
 
 // IsRunningOnJenkins detects if the currently running Ginkgo application is
 // most likely running in a Jenkins environment. Returns true if certain
@@ -81,7 +79,7 @@ func CountValues(key string, data []string) (int, int) {
 
 // MakeUID returns a randomly generated string.
 func MakeUID() string {
-	return fmt.Sprintf("%08x", rand.Uint32())
+	return fmt.Sprintf("%08x", randGen.Uint32())
 }
 
 // RenderTemplateToFile renders a text/template string into a target filename

--- a/test/runtime/monitor.go
+++ b/test/runtime/monitor.go
@@ -27,10 +27,8 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func init() {
-	// ensure that our random numbers are seeded differently on each run
-	rand.Seed(time.Now().UnixNano())
-}
+// ensure that our random numbers are seeded differently on each run
+var randGen = rand.New(rand.NewSource(time.Now().UnixNano()))
 
 const (
 	// MonitorDropNotification represents the DropNotification configuration


### PR DESCRIPTION
Some packages initialize the global PRNG state in package math/rand
using the Seed func in their init func. This might influence the PRNG
state for other packages by solely loaded the former package.

Switch to use a per package rand.Rand instance which can then be safely
initialized and used in each package. This also makes it more obvious in
tests which PRNG state is explicitly seeded to a known value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10575)
<!-- Reviewable:end -->
