### PR TITLE
test: Fix some minor microk8s integration issues

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -124,12 +124,10 @@ var (
 	}
 
 	microk8sHelmOverrides = map[string]string{
-		"global.cni.confPath":                 "/var/snap/microk8s/current/args/cni-network",
-		"global.cni.binPath":                  "/var/snap/microk8s/current/opt/cni/bin",
-		"global.cni.customConf":               "true",
-		"global.containerRuntime.integration": "containerd",
-		"global.containerRuntime.socketPath":  "/var/snap/microk8s/common/run/containerd.sock",
-		"global.daemon.runPath":               "/var/snap/microk8s/current/var/run/cilium",
+		"global.cni.confPath":   "/var/snap/microk8s/current/args/cni-network",
+		"global.cni.binPath":    "/var/snap/microk8s/current/opt/cni/bin",
+		"global.cni.customConf": "true",
+		"global.daemon.runPath": "/var/snap/microk8s/current/var/run/cilium",
 	}
 	minikubeHelmOverrides = map[string]string{
 		"global.ipv6.enabled":           "false",

--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -101,7 +101,14 @@ func DeployCiliumOptionsAndDNS(vm *helpers.Kubectl, ciliumFilename string, optio
 	ExpectCiliumRunning(vm)
 
 	By("Installing DNS Deployment")
-	_ = vm.ApplyDefault(helpers.DNSDeployment(vm.BasePath()))
+	switch helpers.GetCurrentIntegration() {
+	case helpers.CIIntegrationMicrok8s:
+		By(fmt.Sprintf("%s (hint: %s)",
+			"Assuming that microk8s already has DNS deployed...",
+			"Use 'microk8s.enable dns' to create deployment"))
+	default:
+		_ = vm.ApplyDefault(helpers.DNSDeployment(vm.BasePath()))
+	}
 
 	switch helpers.GetCurrentIntegration() {
 	case helpers.CIIntegrationFlannel:


### PR DESCRIPTION
* The runtime integration is not necessary any more since v1.7, and in
  fact causes problems trying to deploy Cilium properly to microk8s.
* The coredns deployment in the CI tree assumes that you can fall back
  to /etc/resolv.conf, but in microk8s environments the resolv.conf will
  use coredns to resolve k8s DNS names, so this causes a loop which
  triggers havoc. Instead of deploying coredns, just assume that coredns
  is already deployed. The check for coredns later on will timeout if
  this is not true. At some point we may need to patch up the microk8s
  coredns config for cilium test domains, but I'm deferring that for
  now since it's not required for minimal CI deployment in microk8s.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10577)
<!-- Reviewable:end -->
