### PR TITLE
test: Fix configuring the Cilium agent in dev VM

### DIFF
--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2019 Authors of Cilium
+// Copyright 2017-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -884,13 +884,15 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
 CILIUM_OPTS=--kvstore consul --kvstore-opt consul.address=127.0.0.1:8500 --debug --pprof=true --log-system-load %s
 INITSYSTEM=SYSTEMD`
 
-	err := RenderTemplateToFile("cilium", fmt.Sprintf(systemdTemplate, ciliumOpts), os.ModePerm)
+	ciliumConfig := "cilium.conf.ginkgo"
+	err := RenderTemplateToFile(ciliumConfig, fmt.Sprintf(systemdTemplate, ciliumOpts), os.ModePerm)
 	if err != nil {
 		return err
 	}
 	defer os.Remove("cilium")
 
-	res := s.Exec("sudo cp /vagrant/cilium /etc/sysconfig/cilium")
+	confPath := filepath.Join("/home/vagrant/go/src/github.com/cilium/cilium/test", ciliumConfig)
+	res := s.Exec(fmt.Sprintf("sudo cp %s /etc/sysconfig/cilium", confPath))
 	if !res.WasSuccessful() {
 		return fmt.Errorf("%s", res.CombineOutput())
 	}


### PR DESCRIPTION
The helpers file was assuming that the test path is mounted into the
target VM at the location "/vagrant", but this is not the case for the
developer VM so if you attempt to run the ginkgo runtime CI against the
dev VM you'll hit this error:

      Expected
          <*errors.errorString | 0xc0004b0900>: {
              s: "cp: cannot stat '/vagrant/cilium': No such file or directory\n",
          }
      to be nil

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10578)
<!-- Reviewable:end -->
