### PR TITLE
doc: Upgrade MarkupSafe to 1.1.1

### DIFF
--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -7,7 +7,7 @@ idna==2.7
 imagesize==1.1.0
 Jinja2==2.10.1
 jsonschema==2.6.0
-MarkupSafe==1.0
+MarkupSafe==1.1.1
 pyenchant==2.0.0
 Pygments==2.4.2
 pytz==2018.7


### PR DESCRIPTION
Installing MarkupSafe 1.0.0 with setuptools 44.0.0 results in the
following error:

```
Complete output (5 lines):
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/tmp/pip-install-0jhff9bc/MarkupSafe/setup.py", line 6, in <module>
    from setuptools import setup, Extension, Feature
ImportError: cannot import name 'Feature' from 'setuptools'
```

Upgrading MarkupSafe to 1.1.1 solves the problem.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10579)
<!-- Reviewable:end -->
