### PR TITLE
CI: Extend runtime tests to validate fromCIDR policy

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2019 Authors of Cilium
+// Copyright 2017-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -92,16 +92,22 @@ const (
 	// HostDockerNetwork is the name of the host network driver.
 	HostDockerNetwork = "host"
 
+	// WorldDockerNetwork is the name of the docker network that is *not*
+	// managed by Cilium, intended to be treated as "world" for identity
+	// purposes (for policy tests).
+	WorldDockerNetwork = "world"
+
 	// Names of commonly used containers in tests.
-	Httpd1 = "httpd1"
-	Httpd2 = "httpd2"
-	Httpd3 = "httpd3"
-	App1   = "app1"
-	App2   = "app2"
-	App3   = "app3"
-	Client = "client"
-	Server = "server"
-	Host   = "host"
+	Httpd1      = "httpd1"
+	Httpd2      = "httpd2"
+	Httpd3      = "httpd3"
+	App1        = "app1"
+	App2        = "app2"
+	App3        = "app3"
+	Client      = "client"
+	Server      = "server"
+	Host        = "host"
+	WorldHttpd1 = "WorldHttpd1"
 	// Container lifecycle actions.
 	Create = "create"
 	Delete = "delete"


### PR DESCRIPTION
This series extends the runtime CI tests to validate that `fromCIDR` policy works correctly using a local docker network, similar to how existing FQDN tests do.

Review patch-by-patch, there is some large refactoring of the CIDR tests in policy but it's mostly kept to one non-functional patch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10580)
<!-- Reviewable:end -->
