### PR TITLE
set explicit liveness/readiness probe timeout for deny connectivity checks

### DIFF
--- a/examples/kubernetes/connectivity-check/connectivity-check.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check.yaml
@@ -218,9 +218,11 @@ spec:
         command: ["/bin/ash", "-c", "sleep 1000000000"]
         imagePullPolicy: IfNotPresent
         livenessProbe:
+          timeoutSeconds: 7
           exec:
             command: ["ash", "-c", "! curl -sS --connect-timeout 5 -o /dev/null echo-a"]
         readinessProbe:
+          timeoutSeconds: 7
           exec:
             command: ["ash", "-c", "! curl -sS --connect-timeout 5 -o /dev/null echo-a"]
 ---


### PR DESCRIPTION
examples/kubernetes/connectivity-check.yaml includes a test that is expected to result in L3 denies if Cilium is operating correctly.  It validates this with liveness/readiness problems that use bash to return the negation of the value returned by curl (i.e., if curl exits with an "error", this is the correct result, and so the bash command returns 0 and the readiness/liveness probe succeeds).    

The curl command has an explicit 5 second timeout, however, the liveness + readiness problems have a default 1 second timeout.  This means that if curl does not exit within 1 second, kubernetes will give up on the readiness/liveness probe and declare it to have failed.   

With this patch we explicitly set the readiness/liveness probe timeouts to 7 seconds, so that curl has time to have its timeout timer (set to 5 seconds) to trigger.    This allows the probe to keep running long enough for the curl command to return a non-zero exit code, which because of the bash negation, will cause the probe to succeed.  

Note: it is not clear to me why the lack of this explicit timeout does not cause issues in all k8s environments, but it seems like the failures only happen in specific environments.   However, in these specific environments, the failures happen reliably.   It may be due to differences in DNS or other configuration in those environments.  For examples, EKS with bottlerocket OS (https://github.com/weaveworks/eksctl/blob/master/examples/20-bottlerocket.yaml) shows this behavior.  

Signed-off-by: Dan Wendlandt <dan@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10581)
<!-- Reviewable:end -->
