### PR TITLE
Add more PriorityClassName fields in Helm charts

### DIFF
--- a/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
@@ -307,7 +307,7 @@ spec:
           {{- toYaml .Values.initResources | trim | nindent 10 }}
 {{- end }}
       restartPolicy: Always
-{{- if or (and (eq .Release.Namespace "kube-system") (gt .Capabilities.KubeVersion.Minor "10")) (gt .Capabilities.KubeVersion.Minor "16") (gt .Capabilities.KubeVersion.Major "1"))}}
+{{- if or (and (eq .Release.Namespace "kube-system") (gt .Capabilities.KubeVersion.Minor "10")) (gt .Capabilities.KubeVersion.Minor "16") (gt .Capabilities.KubeVersion.Major "1")}}
       priorityClassName: system-node-critical
 {{- end }}
       serviceAccount: cilium

--- a/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
@@ -307,7 +307,7 @@ spec:
           {{- toYaml .Values.initResources | trim | nindent 10 }}
 {{- end }}
       restartPolicy: Always
-{{- if and (eq .Release.Namespace "kube-system") (or (gt .Capabilities.KubeVersion.Minor "10") (gt .Capabilities.KubeVersion.Major "1"))}}
+{{- if or (and (eq .Release.Namespace "kube-system") (gt .Capabilities.KubeVersion.Minor "10")) (gt .Capabilities.KubeVersion.Minor "16") (gt .Capabilities.KubeVersion.Major "1"))}}
       priorityClassName: system-node-critical
 {{- end }}
       serviceAccount: cilium

--- a/install/kubernetes/cilium/charts/managed-etcd/templates/cilium-etcd-operator-deployment.yaml
+++ b/install/kubernetes/cilium/charts/managed-etcd/templates/cilium-etcd-operator-deployment.yaml
@@ -67,6 +67,9 @@ spec:
         name: cilium-etcd-operator
       dnsPolicy: ClusterFirst
       hostNetwork: true
+{{- if or (and (eq .Release.Namespace "kube-system") (gt .Capabilities.KubeVersion.Minor "10")) (gt .Capabilities.KubeVersion.Minor "16") (gt .Capabilities.KubeVersion.Major "1"))}}
+      priorityClassName: system-cluster-critical
+{{- end }}
       restartPolicy: Always
       serviceAccount: cilium-etcd-operator
       serviceAccountName: cilium-etcd-operator

--- a/install/kubernetes/cilium/charts/managed-etcd/templates/cilium-etcd-operator-deployment.yaml
+++ b/install/kubernetes/cilium/charts/managed-etcd/templates/cilium-etcd-operator-deployment.yaml
@@ -67,7 +67,7 @@ spec:
         name: cilium-etcd-operator
       dnsPolicy: ClusterFirst
       hostNetwork: true
-{{- if or (and (eq .Release.Namespace "kube-system") (gt .Capabilities.KubeVersion.Minor "10")) (gt .Capabilities.KubeVersion.Minor "16") (gt .Capabilities.KubeVersion.Major "1"))}}
+{{- if or (and (eq .Release.Namespace "kube-system") (gt .Capabilities.KubeVersion.Minor "10")) (gt .Capabilities.KubeVersion.Minor "16") (gt .Capabilities.KubeVersion.Major "1")}}
       priorityClassName: system-cluster-critical
 {{- end }}
       restartPolicy: Always

--- a/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
@@ -18,6 +18,9 @@ spec:
       - operator: Exists
       hostPID: true
       hostNetwork: true
+{{- if or (and (eq .Release.Namespace "kube-system") (gt .Capabilities.KubeVersion.Minor "10")) (gt .Capabilities.KubeVersion.Minor "16") (gt .Capabilities.KubeVersion.Major "1"))}}
+      priorityClassName: system-node-critical
+{{- end }}
       containers:
         - name: node-init
           image: gcr.io/google-containers/startup-script:v1

--- a/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
@@ -18,7 +18,7 @@ spec:
       - operator: Exists
       hostPID: true
       hostNetwork: true
-{{- if or (and (eq .Release.Namespace "kube-system") (gt .Capabilities.KubeVersion.Minor "10")) (gt .Capabilities.KubeVersion.Minor "16") (gt .Capabilities.KubeVersion.Major "1"))}}
+{{- if or (and (eq .Release.Namespace "kube-system") (gt .Capabilities.KubeVersion.Minor "10")) (gt .Capabilities.KubeVersion.Minor "16") (gt .Capabilities.KubeVersion.Major "1")}}
       priorityClassName: system-node-critical
 {{- end }}
       containers:

--- a/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
@@ -154,7 +154,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
 {{- end }}
       restartPolicy: Always
-{{- if or (and (eq .Release.Namespace "kube-system") (gt .Capabilities.KubeVersion.Minor "10")) (gt .Capabilities.KubeVersion.Minor "16") (gt .Capabilities.KubeVersion.Major "1"))}}
+{{- if or (and (eq .Release.Namespace "kube-system") (gt .Capabilities.KubeVersion.Minor "10")) (gt .Capabilities.KubeVersion.Minor "16") (gt .Capabilities.KubeVersion.Major "1")}}
       priorityClassName: system-cluster-critical
 {{- end }}
       serviceAccount: cilium-operator

--- a/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/deployment.yaml
@@ -154,7 +154,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
 {{- end }}
       restartPolicy: Always
-{{- if and (eq .Release.Namespace "kube-system") (or (gt .Capabilities.KubeVersion.Minor "10") (gt .Capabilities.KubeVersion.Major "1"))}}
+{{- if or (and (eq .Release.Namespace "kube-system") (gt .Capabilities.KubeVersion.Minor "10")) (gt .Capabilities.KubeVersion.Minor "16") (gt .Capabilities.KubeVersion.Major "1"))}}
       priorityClassName: system-cluster-critical
 {{- end }}
       serviceAccount: cilium-operator


### PR DESCRIPTION
Set `priorityClassName` when installing outside the `kube-system` namespace on Kubernetes 1.17 or higher. Add some `priorityClassName` fields that were missing.

Fixes #10504 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10583)
<!-- Reviewable:end -->
