### PR TITLE
docs: Fix documentation postchecks

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -49,7 +49,6 @@ cilium-agent [flags]
       --disable-cnp-status-updates                    Do not send CNP NodeStatus updates to the Kubernetes api-server (recommended to run with "cnp-node-status-gc=false" in cilium-operator)
       --disable-conntrack                             Disable connection tracking
       --disable-endpoint-crd                          Disable use of CiliumEndpoint CRD
-      --disable-k8s-services                          Disable east-west K8s load balancing by cilium
       --egress-masquerade-interfaces string           Limit egress masquerading to interface selector
       --enable-endpoint-health-checking               Enable connectivity health checking between virtual endpoints (default true)
       --enable-endpoint-routes                        Use per endpoint routes instead of routing via cilium_host


### PR DESCRIPTION
The `Runtime*` tests are failing with the following error.
```
 runtime: make[1]: Leaving directory '/home/vagrant/go/src/github.com/cilium/cilium/Documentation'
runtime: diff -x '*.rst' -r ./Documentation/cmdref/cilium-agent.md /tmp/tmp.TrZz6y7HNu/cilium-agent.md
runtime: 52d51
runtime: <       --disable-k8s-services                          Disable east-west K8s load balancing by cilium
runtime: Detected a difference in the cmdref directory
runtime: diff -r: diff -r ./Documentation/cmdref/cilium-agent.md /tmp/tmp.TrZz6y7HNu/cilium-agent.md
runtime: 52d51
runtime: <       --disable-k8s-services                          Disable east-west K8s load balancing by cilium
runtime: Only in ./Documentation/cmdref: cli_index.rst
runtime: Only in ./Documentation/cmdref: index.rst
runtime: Only in ./Documentation/cmdref: kvstore.rst
runtime: Please rerun 'make -C Documentation cmdref' and commit your changes
runtime: Makefile:456: recipe for target 'postcheck' failed
runtime: make: *** [postcheck] Error 1
```
Fixes: #10552

/cc @soumynathan

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10585)
<!-- Reviewable:end -->
