### PR TITLE
test: Enable K8sUpdates for kube-proxy-free CI job

### DIFF
--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -103,21 +103,19 @@ var _ = Describe("K8sUpdates", func() {
 		cleanupCallback()
 		ExpectAllPodsTerminated(kubectl)
 	})
-	// FIXME don't skip once stable becomes v1.6 (v1.5 doesn't implement the kube-proxy
-	// replacement)
-	SkipItIf(func() bool { return !helpers.RunsWithKubeProxy() },
-		"Tests upgrade and downgrade from a Cilium stable image to master", func() {
-			var assertUpgradeSuccessful func()
-			assertUpgradeSuccessful, cleanupCallback =
-				InstallAndValidateCiliumUpgrades(
-					kubectl,
-					helpers.CiliumStableHelmChartVersion,
-					helpers.CiliumStableVersion,
-					helpers.CiliumLatestHelmChartVersion,
-					helpers.CiliumLatestImageVersion,
-				)
-			assertUpgradeSuccessful()
-		})
+
+	It("Tests upgrade and downgrade from a Cilium stable image to master", func() {
+		var assertUpgradeSuccessful func()
+		assertUpgradeSuccessful, cleanupCallback =
+			InstallAndValidateCiliumUpgrades(
+				kubectl,
+				helpers.CiliumStableHelmChartVersion,
+				helpers.CiliumStableVersion,
+				helpers.CiliumLatestHelmChartVersion,
+				helpers.CiliumLatestImageVersion,
+			)
+		assertUpgradeSuccessful()
+	})
 })
 
 // InstallAndValidateCiliumUpgrades installs and tests if the oldVersion can be


### PR DESCRIPTION
The stable version has been bumped (no longer v1.5), so we can re-enable the test for kube-proxy-free builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10586)
<!-- Reviewable:end -->
