### PR TITLE
policy: Fix incorrect comment

### DIFF
--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -412,8 +412,8 @@ func (r ruleSlice) UpdateRulesEndpointsCaches(endpointsToBumpRevision, endpoints
 			endpointsToRegenerate.Insert(epp)
 		}
 		// If we could not evaluate the rules against the current endpoint, or
-		// the endpoint is not selected by the rules, remove it from the set
-		// of endpoints to bump the revision. If the error is non-nil, the
+		// the endpoint is selected by the rules, remove it from the set of
+		// endpoints to bump the revision. If the error is non-nil, the
 		// endpoint is no longer in either set (endpointsToBumpRevision or
 		// endpointsToRegenerate, as we could not determine what to do for the
 		// endpoint). This is usually the case when the endpoint is no longer


### PR DESCRIPTION
Small fix for a confusing comment that didn't match the code. The original commit, 889b7fa, provides some more context.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10588)
<!-- Reviewable:end -->
