### PR TITLE
Trying to figure out the managed etcd failure flake

### DIFF
--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -437,6 +437,9 @@ var _ = Describe("K8sDatapathConfig", func() {
 			}
 			if helpers.ExistNodeWithoutCilium() {
 				opts["operator.synchronizeK8sNodes"] = "false"
+				opts["global.synchronizeK8sNodes"] = "false"
+			} else {
+				By("ExistNodeWithoutCilium is false")
 			}
 			deployCilium(opts)
 			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")


### PR DESCRIPTION
This seems related to cilium-operator not reading the config-map correctly, where node sync is supposed to be off for k8s3. From what I can tell, the configmap isn't updated to begin with.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10590)
<!-- Reviewable:end -->
