### PR TITLE
test: Fix operator param in ManagedEtcd suite

### DIFF
--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -436,7 +436,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 				"global.etcd.managed": "true",
 			}
 			if helpers.ExistNodeWithoutCilium() {
-				opts["operator.synchronizeK8sNodes"] = "false"
+				opts["global.synchronizeK8sNodes"] = "false"
 			}
 			deployCilium(opts)
 			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")


### PR DESCRIPTION
The commit 0d7533fc5 ("install/kubernetes: removed env variables in Cilium-operator") removed the `--synchronize-k8s-nodes` param from the operator helm
template. So, `--set operator.synchronizeK8sNodes=false` was ineffective which made the operator to propagate the CiliumNode object of k8s3 node which didn't run cilium-agent.

Fix the issue by setting `global.synchronizeK8sNodes` instead.

Fixes: 0d7533fc5 ("install/kubernetes: removed env variables in Cilium-operator")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10593)
<!-- Reviewable:end -->
