### PR TITLE
daemon: Move files into own go package

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -38,19 +38,19 @@ contrib/packaging/deb/ @eloycoto
 contrib/packaging/docker/ @aanm @ianvernon
 contrib/vagrant @cilium/ci
 daemon/ @cilium/agent
-daemon/datapath.* @cilium/bpf
-daemon/endpoint.* @cilium/endpoint
-daemon/health.* @cilium/health
-daemon/ipcache.* @cilium/ipcache
-daemon/k8s_watcher.* @cilium/kubernetes
-daemon/loadbalancer.* @cilium/loadbalancer
-daemon/metrics.* @cilium/metrics
-daemon/policy.* @cilium/policy
-daemon/prefilter.go @cilium/bpf
-daemon/proxy.go @cilium/proxy
-daemon/requirements.go @cilium/bpf
-daemon/state.go @cilium/endpoint
-daemon/sysctl.* @cilium/bpf
+daemon/cmd/datapath.* @cilium/bpf
+daemon/cmd/endpoint.* @cilium/endpoint
+daemon/cmd/health.* @cilium/health
+daemon/cmd/ipcache.* @cilium/ipcache
+daemon/cmd/k8s_watcher.* @cilium/kubernetes
+daemon/cmd/loadbalancer.* @cilium/loadbalancer
+daemon/cmd/metrics.* @cilium/metrics
+daemon/cmd/policy.* @cilium/policy
+daemon/cmd/prefilter.go @cilium/bpf
+daemon/cmd/proxy.go @cilium/proxy
+daemon/cmd/requirements.go @cilium/bpf
+daemon/cmd/state.go @cilium/endpoint
+daemon/cmd/sysctl.* @cilium/bpf
 Documentation/ @cilium/docs
 Documentation/bpf.rst @scanf @borkmann
 Documentation/contributing/ @cilium/contributing

--- a/daemon/cmd/cleanup.go
+++ b/daemon/cmd/cleanup.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2019 Authors of Cilium
+// Copyright 2018-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package cmd
 
 import (
 	"context"

--- a/daemon/cmd/cmdref.go
+++ b/daemon/cmd/cmdref.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Authors of Cilium
+// Copyright 2016-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package cmd
 
 import (
 	"fmt"

--- a/daemon/cmd/config.go
+++ b/daemon/cmd/config.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 Authors of Cilium
+// Copyright 2016-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package cmd
 
 import (
 	"fmt"

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 Authors of Cilium
+// Copyright 2016-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package cmd
 
 import (
 	"context"

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package cmd
 
 import (
 	"context"
@@ -128,7 +128,10 @@ func init() {
 	)
 }
 
-func daemonMain() {
+// Execute sets up gops, installs the cleanup signal handler and invokes
+// the root command. This function only returns when an interrupt
+// signal has been received. This is intended to be called by main.main().
+func Execute() {
 	bootstrapStats.overall.Start()
 
 	// Open socket for using gops to get stacktraces of the agent.
@@ -143,7 +146,6 @@ func daemonMain() {
 		os.Exit(-1)
 	}
 	<-interruptCh
-	os.Exit(0)
 }
 
 func skipInit(basePath string) bool {

--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 Authors of Cilium
+// Copyright 2016-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 
 // +build !privileged_tests
 
-package main
+package cmd
 
 import (
 	"context"

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 Authors of Cilium
+// Copyright 2016-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package cmd
 
 import (
 	"errors"

--- a/daemon/cmd/debuginfo.go
+++ b/daemon/cmd/debuginfo.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 Authors of Cilium
+// Copyright 2017-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package cmd
 
 import (
 	"fmt"

--- a/daemon/cmd/debuginfo_test.go
+++ b/daemon/cmd/debuginfo_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 Authors of Cilium
+// Copyright 2018-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,14 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+// +build !privileged_tests
+
+package cmd
 
 import (
-	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
-	"github.com/cilium/cilium/pkg/proxy/logger"
+	"os"
+
+	. "gopkg.in/check.v1"
 )
 
-// NewProxyLogRecord is invoked by the proxy accesslog on each new access log entry
-func (d *Daemon) NewProxyLogRecord(l *logger.LogRecord) error {
-	return d.monitorAgent.SendEvent(monitorAPI.MessageTypeAccessLog, l.LogRecord)
+func (s *DaemonSuite) TestMemoryMap(c *C) {
+	pid := os.Getpid()
+	m := memoryMap(pid)
+	c.Assert(m, Not(Equals), "")
 }

--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package cmd
 
 import (
 	"context"

--- a/daemon/cmd/endpoint_test.go
+++ b/daemon/cmd/endpoint_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 
 // +build !privileged_tests
 
-package main
+package cmd
 
 import (
 	"context"

--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Authors of Cilium
+// Copyright 2019-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package cmd
 
 import (
 	"context"

--- a/daemon/cmd/fqdn_test.go
+++ b/daemon/cmd/fqdn_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Authors of Cilium
+// Copyright 2019-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 
 // +build !privileged_tests
 
-package main
+package cmd
 
 import (
 	"fmt"

--- a/daemon/cmd/health.go
+++ b/daemon/cmd/health.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 Authors of Cilium
+// Copyright 2016-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package cmd
 
 import (
 	"context"

--- a/daemon/cmd/identity.go
+++ b/daemon/cmd/identity.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 Authors of Cilium
+// Copyright 2016-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package cmd
 
 import (
 	"github.com/cilium/cilium/api/v1/models"

--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package cmd
 
 import (
 	"fmt"

--- a/daemon/cmd/ipcache.go
+++ b/daemon/cmd/ipcache.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Authors of Cilium
+// Copyright 2019-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package cmd
 
 import (
 	"net"

--- a/daemon/cmd/ipcache_test.go
+++ b/daemon/cmd/ipcache_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Authors of Cilium
+// Copyright 2019-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 
 // +build !privileged_tests
 
-package main
+package cmd
 
 import (
 	"net"

--- a/daemon/cmd/loadbalancer.go
+++ b/daemon/cmd/loadbalancer.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 Authors of Cilium
+// Copyright 2016-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package cmd
 
 import (
 	"fmt"

--- a/daemon/cmd/map.go
+++ b/daemon/cmd/map.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package cmd
 
 import (
 	"github.com/cilium/cilium/api/v1/models"

--- a/daemon/cmd/metrics.go
+++ b/daemon/cmd/metrics.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2019 Authors of Cilium
+// Copyright 2018-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package cmd
 
 import (
 	"fmt"

--- a/daemon/cmd/policy.go
+++ b/daemon/cmd/policy.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 Authors of Cilium
+// Copyright 2016-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package cmd
 
 import (
 	"bytes"

--- a/daemon/cmd/policy_test.go
+++ b/daemon/cmd/policy_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 Authors of Cilium
+// Copyright 2016-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 
 // +build !privileged_tests
 
-package main
+package cmd
 
 import (
 	"context"

--- a/daemon/cmd/prefilter.go
+++ b/daemon/cmd/prefilter.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Authors of Cilium
+// Copyright 2017-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package cmd
 
 import (
 	"fmt"

--- a/daemon/cmd/proxy.go
+++ b/daemon/cmd/proxy.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Authors of Cilium
+// Copyright 2016-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,24 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package cmd
 
 import (
-	"github.com/cilium/cilium/pkg/option"
-	"github.com/cilium/cilium/pkg/sysctl"
+	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
+	"github.com/cilium/cilium/pkg/proxy/logger"
 )
 
-func enableIPForwarding() error {
-	if err := sysctl.Enable("net.ipv4.ip_forward"); err != nil {
-		return err
-	}
-	if err := sysctl.Enable("net.ipv4.conf.all.forwarding"); err != nil {
-		return err
-	}
-	if option.Config.EnableIPv6 {
-		if err := sysctl.Enable("net.ipv6.conf.all.forwarding"); err != nil {
-			return err
-		}
-	}
-	return nil
+// NewProxyLogRecord is invoked by the proxy accesslog on each new access log entry
+func (d *Daemon) NewProxyLogRecord(l *logger.LogRecord) error {
+	return d.monitorAgent.SendEvent(monitorAPI.MessageTypeAccessLog, l.LogRecord)
 }

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 Authors of Cilium
+// Copyright 2016-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package cmd
 
 import (
 	"context"

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 Authors of Cilium
+// Copyright 2016-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package cmd
 
 import (
 	"context"

--- a/daemon/cmd/status_test.go
+++ b/daemon/cmd/status_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 Authors of Cilium
+// Copyright 2016-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 
 // +build !privileged_tests
 
-package main
+package cmd
 
 import (
 	"time"

--- a/daemon/cmd/sysctl_darwin.go
+++ b/daemon/cmd/sysctl_darwin.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Authors of Cilium
+// Copyright 2019-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package cmd
 
 // enableIPForwarding on OS X and Darwin is not doing anything. It just exists
 // to make compilation possible.

--- a/daemon/cmd/sysctl_linux.go
+++ b/daemon/cmd/sysctl_linux.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2019-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,18 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !privileged_tests
-
-package main
+package cmd
 
 import (
-	"os"
-
-	. "gopkg.in/check.v1"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/sysctl"
 )
 
-func (s *DaemonSuite) TestMemoryMap(c *C) {
-	pid := os.Getpid()
-	m := memoryMap(pid)
-	c.Assert(m, Not(Equals), "")
+func enableIPForwarding() error {
+	if err := sysctl.Enable("net.ipv4.ip_forward"); err != nil {
+		return err
+	}
+	if err := sysctl.Enable("net.ipv4.conf.all.forwarding"); err != nil {
+		return err
+	}
+	if option.Config.EnableIPv6 {
+		if err := sysctl.Enable("net.ipv6.conf.all.forwarding"); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/daemon/cmd/sysctl_linux_test.go
+++ b/daemon/cmd/sysctl_linux_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Authors of Cilium
+// Copyright 2019-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 
 // +build linux,privileged_tests
 
-package main
+package cmd
 
 import (
 	"testing"

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 Authors of Cilium
+// Copyright 2016-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,6 +14,10 @@
 
 package main
 
+import (
+	"github.com/cilium/cilium/daemon/cmd"
+)
+
 func main() {
-	daemonMain()
+	cmd.Execute()
 }

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -25,7 +25,7 @@ const (
 	// CiliumOperatortName is the name of cilium-operator process name.
 	CiliumOperatortName = "cilium-operator"
 	// CiliumDaemonTestName is the name of test binary for daemon package.
-	CiliumDaemonTestName = "daemon.test"
+	CiliumDaemonTestName = "cmd.test"
 )
 
 // IsCiliumAgent checks whether the current process is cilium-agent (daemon).


### PR DESCRIPTION
Moves the Go files of the cilium-agent daemon into its own Go package. This unifies the structure of the cilium-agent source code with other command-line programs in the source, i.e. `cilium`, `cilium-health` and `bugtool` already use this structure. This commit contains no functional change.

In addition, this also allows downstream consumers to import the daemon main via Go modules.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10594)
<!-- Reviewable:end -->
