### PR TITLE
bpf: Fix build warning in conntrack test

### DIFF
--- a/bpf/lib/conntrack_test.h
+++ b/bpf/lib/conntrack_test.h
@@ -13,7 +13,7 @@ static struct ct_entry __ipv4_map[] = {
 static void *__map_lookup_elem(void *map, void *tuple)
 {
 	if (map == __ipv4_map) {
-		int idx = (int)tuple;
+		__u64 idx = (__u64)tuple;
 		if (idx == __TUPLE_EXIST)
 			return &__ipv4_map[idx];
 	}


### PR DESCRIPTION
Fix this build warning:
```
  $ make -C test
    GINKG testbuild
  Compiling test...
      compiled test.test
    CC    test/bpf/elf-demo.o
    CC    test/bpf/unit-test
  In file included from unit-test.c:20:
  ../../bpf/lib/conntrack_test.h:16:13: warning: cast to smaller integer type 'int' from 'void *' [-Wvoid-pointer-to-int-cast]
                  int idx = (int)tuple;
                            ^~~~~~~~~~
  1 warning generated.
```

The value is a dummy here anyway because it's unit-testing, I'm not too worried about weird bugs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10598)
<!-- Reviewable:end -->
