### PR TITLE
helm: re-generate quick-install.yaml after PR #10289

### DIFF
--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -61,7 +61,7 @@ data:
   # Only effective when monitor aggregation is set to "medium" or higher.
   monitor-aggregation-flags: all
 
-  # ct-global-max-entries-* specifies the maximum number of connections
+  # bpf-ct-global-*-max specifies the maximum number of connections
   # supported across all endpoints, split by protocol: tcp or other. One pair
   # of maps uses these values for IPv4 connections, and another pair of maps
   # use these values for IPv6 connections.
@@ -77,7 +77,7 @@ data:
 
   # bpf-nat-global-max specified the maximum number of entries in the BPF NAT
   # table.
-  bpf-nat-global-max: "841429"
+  bpf-nat-global-max: "524288"
 
   # Pre-allocation of map entries allows per-packet latency to be reduced, at
   # the expense of up-front memory allocation for the entries in the maps. The


### PR DESCRIPTION
quick-install.yaml wasn't re-generated in PR #10289 which reduced the
default NAT table size. This lead to the following error when
installing/upgrading from quick-install.yaml:

```
level=fatal msg="Error while creating daemon" error="invalid daemon configuration: specified NAT tables size 841429 must not exceed maximum CT table size 786432" subsys=daemon
```

Fix it by re-generating quick-install.yaml so the new default NAT table
size is used.

Reported-by: Michi Mutsuzaki <michi@isovalent.com>
Reported-by: Martynas Pumputis <m@lambda.lt>
Signed-off-by: Tobias Klauser <tklauser@distanz.ch>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10604)
<!-- Reviewable:end -->
