### PR TITLE
bpf: Fix build warning for unused parameter

### DIFF
--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -742,7 +742,8 @@ int sock6_xlate(struct bpf_sock_addr *ctx)
 }
 
 #ifdef ENABLE_HOST_SERVICES_UDP
-static __always_inline int sock6_xlate_snd_v4_in_v6(struct bpf_sock_addr *ctx)
+static __always_inline int
+sock6_xlate_snd_v4_in_v6(struct bpf_sock_addr *ctx __maybe_unused)
 {
 #ifdef ENABLE_IPV4
 	struct bpf_sock_addr fake_ctx;
@@ -837,7 +838,8 @@ static __always_inline int sock6_xlate_snd(struct bpf_sock_addr *ctx)
 	return SYS_PROCEED;
 }
 
-static __always_inline int sock6_xlate_rcv_v4_in_v6(struct bpf_sock_addr *ctx)
+static __always_inline int
+sock6_xlate_rcv_v4_in_v6(struct bpf_sock_addr *ctx __maybe_unused)
 {
 #ifdef ENABLE_IPV4
 	struct bpf_sock_addr fake_ctx;


### PR DESCRIPTION
This pull request fixes the following warnings:
```
bpf_sock.c:719:75: error: unused parameter 'ctx' [-Werror,-Wunused-parameter]
static __always_inline int sock6_xlate_snd_v4_in_v6(struct bpf_sock_addr *ctx)
                                                                          ^
bpf_sock.c:814:75: error: unused parameter 'ctx' [-Werror,-Wunused-parameter]
static __always_inline int sock6_xlate_rcv_v4_in_v6(struct bpf_sock_addr *ctx)
                                                                          ^
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10611)
<!-- Reviewable:end -->
