### PR TITLE
.github: Tweak the release note label message

### DIFF
--- a/.github/cilium-actions.yml
+++ b/.github/cilium-actions.yml
@@ -39,7 +39,7 @@ require-msgs-in-commit:
 block-pr-with:
   labels-unset:
     - regex-label: "release-note/.*"
-      helper: "Release note label not set, please set the appropriate release note."
+      helper: "Please set the appropriate release note label."
       set-labels:
         - "dont-merge/needs-release-note"
   labels-set:


### PR DESCRIPTION
Several first-time contributors (myself included) seem to understand the current message as "you need to set a release note in the original post for the bot to set a release note label" (e.g., #10552 and #10454). This commit tweaks the message to try and avoid that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10617)
<!-- Reviewable:end -->
