### PR TITLE
Dockerfile:Add arm64 support for building images

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -6,6 +6,8 @@ FROM docker.io/library/ubuntu:18.04
 
 LABEL maintainer="maintainer@cilium.io"
 
+ARG ARCH=amd64
+
 WORKDIR /go/src/github.com/cilium/cilium
 
 #
@@ -32,7 +34,6 @@ RUN apt-get update \
 		git \
 		iproute2 \
 		libc6-dev \
-		libc6-dev-i386 \
 		libelf-dev \
 		llvm-7 \
 		m4 \
@@ -52,6 +53,6 @@ RUN apt-get update \
 #
 # Install Go
 #
-RUN curl -sfL https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz | tar -xzC /usr/local && \
+RUN curl -sfL https://dl.google.com/go/go${GO_VERSION}.linux-${ARCH}.tar.gz | tar -xzC /usr/local && \
         GO111MODULE=on go get github.com/gordonklaus/ineffassign@1003c8bd00dc2869cb5ca5282e6ce33834fed514 && \
         go clean -cache -modcache

--- a/Makefile
+++ b/Makefile
@@ -267,7 +267,7 @@ docker-plugin-manifest:
 	$(QUIET) contrib/scripts/push_manifest.sh docker-plugin $(DOCKER_IMAGE_TAG)
 
 docker-image-runtime:
-	cd contrib/packaging/docker && ${CONTAINER_ENGINE} build -t "cilium/cilium-runtime:$(UTC_DATE)" -f Dockerfile.runtime .
+	cd contrib/packaging/docker && ${CONTAINER_ENGINE} build --build-arg ARCH=$(GOARCH) -t "cilium/cilium-runtime:$(UTC_DATE)" -f Dockerfile.runtime .
 	${CONTAINER_ENGINE} tag cilium/cilium-runtime:$(UTC_DATE) cilium/cilium-runtime:$(UTC_DATE)-${GOARCH}
 
 docker-cilium-runtime-manifest:
@@ -275,7 +275,7 @@ docker-cilium-runtime-manifest:
 	$(QUIET) contrib/scripts/push_manifest.sh cilium-runtime $(UTC_DATE)
 
 docker-image-builder:
-	${CONTAINER_ENGINE_FULL} build -t "cilium/cilium-builder:$(UTC_DATE)" -f Dockerfile.builder .
+	${CONTAINER_ENGINE_FULL} build --build-arg ARCH=$(GOARCH) -t "cilium/cilium-builder:$(UTC_DATE)" -f Dockerfile.builder .
 	${CONTAINER_ENGINE_FULL} tag cilium/cilium-builder:$(UTC_DATE) cilium/cilium-builder:$(UTC_DATE)-${GOARCH}
 
 docker-cilium-builder-manifest:

--- a/contrib/packaging/docker/Dockerfile.runtime
+++ b/contrib/packaging/docker/Dockerfile.runtime
@@ -24,6 +24,7 @@ rm -rf /var/lib/apt/lists/*
 # Build Cilium runtime dependencies.
 #
 FROM runtime-base as runtime-build
+ARG ARCH=amd64
 WORKDIR /tmp
 RUN \
 #
@@ -75,7 +76,7 @@ cd ../../../../ && \
 #
 # cni/loopback
 #
-curl -sS -L https://github.com/containernetworking/plugins/releases/download/v0.7.5/cni-plugins-amd64-v0.7.5.tgz -o cni.tar.gz && \
+curl -sS -L https://github.com/containernetworking/plugins/releases/download/v0.7.5/cni-plugins-${ARCH}-v0.7.5.tgz -o cni.tar.gz && \
 tar -xvf cni.tar.gz ./loopback && \
 strip -s ./loopback && \
 #


### PR DESCRIPTION
Add arm64 support for cilium-runtime and  cilium-builder

Signed-off-by: Jianlin Lv <Jianlin.Lv@arm.com>

Related: #9898

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cilium/10618)
<!-- Reviewable:end -->
