### PR TITLE
Add benchmark for pkg/bpf/binary

### DIFF
--- a/pkg/bpf/bpf_test.go
+++ b/pkg/bpf/bpf_test.go
@@ -32,6 +32,7 @@ func (s *BPFTestSuite) TestDefaultMapFlags(c *C) {
 	c.Assert(GetPreAllocateMapFlags(MapTypeLPMTrie), Equals, uint32(BPF_F_NO_PREALLOC))
 	c.Assert(GetPreAllocateMapFlags(MapTypeArray), Equals, uint32(0))
 	c.Assert(GetPreAllocateMapFlags(MapTypeLRUHash), Equals, uint32(0))
+	DisableMapPreAllocation()
 }
 
 func (s *BPFTestSuite) TestPreallocationFlags(c *C) {

--- a/pkg/bpf/map_test.go
+++ b/pkg/bpf/map_test.go
@@ -17,6 +17,12 @@
 package bpf
 
 import (
+	"encoding/binary"
+	"fmt"
+	"unsafe"
+
+	"github.com/cilium/cilium/pkg/byteorder"
+
 	. "gopkg.in/check.v1"
 )
 
@@ -39,4 +45,42 @@ func (s *BPFTestSuite) TestExtractCommonName(c *C) {
 	c.Assert(extractCommonName("cilium_policy_reserved_1"), Equals, "policy")
 	c.Assert(extractCommonName("cilium_proxy4"), Equals, "proxy4")
 	c.Assert(extractCommonName("cilium_tunnel_map"), Equals, "tunnel_map")
+}
+
+type BenchKey struct {
+	Key uint32
+}
+type BenchValue struct {
+	Value uint32
+}
+
+func (k *BenchKey) String() string            { return fmt.Sprintf("key=%d", k.Key) }
+func (k *BenchKey) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(k) }
+func (k *BenchKey) NewValue() MapValue        { return &BenchValue{} }
+func (k *BenchKey) DeepCopyMapKey() MapKey    { return &BenchKey{k.Key} }
+
+func (v *BenchValue) String() string              { return fmt.Sprintf("value=%d", v.Value) }
+func (v *BenchValue) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(v) }
+func (v *BenchValue) DeepCopyMapValue() MapValue  { return &BenchValue{v.Value} }
+
+func (s *BPFTestSuite) BenchmarkConvertKeyValue(c *C) {
+	bk := []byte{0x21, 0x09, 0x40, 0xff}
+	bv := []byte{0x18, 0x2d, 0x44, 0x54}
+	k := &BenchKey{}
+	v := &BenchValue{}
+	wantK := uint32(0xff400921)
+	wantV := uint32(0x54442d18)
+	if byteorder.Native == binary.BigEndian {
+		wantK = 0x210940ff
+		wantV = 0x182d5554
+	}
+	c.ResetTimer()
+	for i := 0; i < c.N; i++ {
+		ConvertKeyValue(bk, bv, k, v)
+	}
+	c.StopTimer()
+	if c.N > 0 {
+		c.Assert(k.Key, Equals, wantK)
+		c.Assert(v.Value, Equals, wantV)
+	}
 }

--- a/pkg/maps/ctmap/ctmap_privileged_test.go
+++ b/pkg/maps/ctmap/ctmap_privileged_test.go
@@ -76,12 +76,12 @@ func (k *CTMapTestSuite) Benchmark_MapUpdate(c *C) {
 		c.Assert(err, IsNil)
 	}
 
-	a1 := make([]tuple.TupleKey, 1)
+	a1 := make([]CtKey, 1)
 	a2 := make([]*CtEntry, 1)
 
 	// Also account the cost of casting from MapKey to TupleKey
 	cb := func(k bpf.MapKey, v bpf.MapValue) {
-		key := k.(tuple.TupleKey)
+		key := k.(CtKey)
 		value := v.(*CtEntry)
 		a1[0] = key
 		a2[0] = value


### PR DESCRIPTION
This can be used to compare performance of `encoding.Read` from
`pkg/bpf/binary` vs. stdlib `encoding/binary` for #10331
    
Current performance is between ~80ns/op and ~90ns/op (using `go test -check.b -check.bmem -count=10`):
    
```
PASS: map_test.go:66: BPFTestSuite.BenchmarkConvertKeyValue     20000000                73.8 ns/op             0 B/op          0 allocs/op
OK: 1 passed
PASS: map_test.go:66: BPFTestSuite.BenchmarkConvertKeyValue     20000000                72.6 ns/op             0 B/op          0 allocs/op
OK: 1 passed
PASS: map_test.go:66: BPFTestSuite.BenchmarkConvertKeyValue     20000000                69.0 ns/op             0 B/op          0 allocs/op
OK: 1 passed
PASS: map_test.go:66: BPFTestSuite.BenchmarkConvertKeyValue     20000000                70.9 ns/op             0 B/op          0 allocs/op
OK: 1 passed
PASS: map_test.go:66: BPFTestSuite.BenchmarkConvertKeyValue     20000000                71.9 ns/op             0 B/op          0 allocs/op
OK: 1 passed
PASS: map_test.go:66: BPFTestSuite.BenchmarkConvertKeyValue     20000000                74.1 ns/op             0 B/op          0 allocs/op
OK: 1 passed
PASS: map_test.go:66: BPFTestSuite.BenchmarkConvertKeyValue     20000000                72.2 ns/op             0 B/op          0 allocs/op
OK: 1 passed
PASS: map_test.go:66: BPFTestSuite.BenchmarkConvertKeyValue     20000000                70.1 ns/op             0 B/op          0 allocs/op
OK: 1 passed
PASS: map_test.go:66: BPFTestSuite.BenchmarkConvertKeyValue     50000000                71.8 ns/op             0 B/op          0 allocs/op
OK: 1 passed
PASS: map_test.go:66: BPFTestSuite.BenchmarkConvertKeyValue     20000000                70.0 ns/op             0 B/op          0 allocs/op
OK: 1 passed
PASS
ok      github.com/cilium/cilium/pkg/bpf        17.361s
```
