### PR TITLE
endpoint: Require WaitForPolicyRevision() to wait for initial build

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -386,6 +386,9 @@ func (e *Endpoint) updateRealizedState(stats *regenerationStatistics, origDir st
 	// Set realized state to desired state.
 	e.realizedPolicy = e.desiredPolicy
 
+	// the initial build is guaranteed to be successful at this point
+	e.initialBuildComplete = true
+
 	// Mark the endpoint to be running the policy revision it was
 	// compiled for
 	e.setPolicyRevision(revision)


### PR DESCRIPTION
Policy revisions can potentially get bumped even before the initial
build has happened. This is not the intent of WaitForPolicyRevision()
which indicates when an endpoint is *implementing* a particular policy
revision.

Updates: #10337
