### PR TITLE
Add check for IPv6 before generating bpf headers

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -97,14 +97,16 @@ func (e *Endpoint) writeInformationalComments(w io.Writer) error {
 		fmt.Fprintf(fw, " * Container ID: %s\n", e.containerID)
 	}
 
+	if option.Config.EnableIPv6 {
+		fmt.Fprintf(fw, " * IPv6 address: %s\n", e.IPv6.String())
+	}
 	fmt.Fprintf(fw, ""+
-		" * IPv6 address: %s\n"+
 		" * IPv4 address: %s\n"+
 		" * Identity: %d\n"+
 		" * PolicyMap: %s\n"+
 		" * NodeMAC: %s\n"+
 		" */\n\n",
-		e.IPv6.String(), e.IPv4.String(),
+		e.IPv4.String(),
 		e.GetIdentity(), bpf.LocalMapName(policymap.MapName, e.ID),
 		e.nodeMAC)
 

--- a/pkg/testutils/endpoint.go
+++ b/pkg/testutils/endpoint.go
@@ -36,6 +36,7 @@ type TestEndpoint struct {
 	Identity *identity.Identity
 	Opts     *option.IntOptions
 	MAC      mac.MAC
+	IPv6     addressing.CiliumIPv6
 }
 
 func NewTestEndpoint() TestEndpoint {
@@ -69,8 +70,7 @@ func (e *TestEndpoint) IPv4Address() addressing.CiliumIPv4 {
 	return addr
 }
 func (e *TestEndpoint) IPv6Address() addressing.CiliumIPv6 {
-	addr, _ := addressing.NewCiliumIPv6("2001:db08:0bad:cafe:600d:bee2:0bad:cafe")
-	return addr
+	return e.IPv6
 }
 
 func (e *TestEndpoint) InterfaceName() string {


### PR DESCRIPTION
When IPv6 is disabled (passing --enable-ipv6=false), this commit prevents writing IPv6-related data to bpf header files.

The files that are affected from this change are the following:

```
<cilium state dir>/globals/node_config.h
<cilium state dir>/<endpoint ID>/lxc_config.h
```

In theory we would need to make a similar change for when IPv4 is disabled, but that is not likely in practice. It is something we can explore in the future.

Fixes #8032

Signed-off-by: Chris Tarazi <chris@isovalent.com>