### PR TITLE
hubble-proxy: fix completion code

### DIFF
--- a/hubble-proxy/cmd/completion/completion.go
+++ b/hubble-proxy/cmd/completion/completion.go
@@ -56,19 +56,19 @@ func runCompletion(out io.Writer, cmd *cobra.Command, args []string) error {
 }
 
 const (
-	copyRightHeader = `// Copyright 2020 Authors of Cilium
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+	copyRightHeader = `# Copyright 2020 Authors of Cilium
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 `
 	completionExample = `
 # Installing bash completion on macOS using homebrew


### PR DESCRIPTION
This commit updates the copyright header so that it uses a valid comment character for bash and zsh ('#' instead of '//').
