### PR TITLE
v1.7 backports 2020-03-19

### DIFF
--- a/Documentation/policy/visibility.rst
+++ b/Documentation/policy/visibility.rst
@@ -10,15 +10,15 @@
 L7 Protocol Visibility
 **********************
 
-While :ref:`monitor` provides introspection into datapath state, by default it 
-will only provide visibility into L3/L4 packet events. If :ref:`l7_policy` is 
+While :ref:`monitor` provides introspection into datapath state, by default it
+will only provide visibility into L3/L4 packet events. If :ref:`l7_policy` is
 configured, one can get visibility into L7 protocols, but this requires the full
 policy for each selected endpoint to be written. To get more visibility into the
 application without configuring a full policy, Cilium provides a means of
 prescribing visibility via `annotations <https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/>`_
 when running in tandem with Kubernetes.
 
-Visibility information is represented by a comma-separated list of tuples in 
+Visibility information is represented by a comma-separated list of tuples in
 the annotation:
 
 ``<{Traffic Direction}/{L4 Port}/{L4 Protocol}/{L7 Protocol}>``
@@ -27,7 +27,7 @@ For example:
 
 ::
 
-  <Ingress/53/UDP/DNS>,<Egress/80/TCP/HTTP>
+  <Egress/53/UDP/DNS>,<Egress/80/TCP/HTTP>
 
 
 To do this, you can provide the annotation in your Kubernetes YAMLs, or via the
@@ -35,10 +35,10 @@ command line, e.g.:
 
 .. code:: bash
 
-    kubectl annotate pod foo -n bar io.cilium.proxy-visibility="<Ingress/53/UDP/DNS>,<Egress/80/TCP/HTTP>"
+    kubectl annotate pod foo -n bar io.cilium.proxy-visibility="<Egress/53/UDP/DNS>,<Egress/80/TCP/HTTP>"
 
-Cilium will pick up that pods have received these annotations, and will 
-transparently redirect traffic to the proxy such that the output of 
+Cilium will pick up that pods have received these annotations, and will
+transparently redirect traffic to the proxy such that the output of
 ``cilium monitor`` shows traffic being redirected to the proxy, e.g.:
 
 ::
@@ -55,19 +55,37 @@ endpoint of that pod, for example:
         NAME                       ENDPOINT ID   IDENTITY ID   INGRESS ENFORCEMENT   EGRESS ENFORCEMENT   VISIBILITY POLICY   ENDPOINT STATE   IPV4           IPV6
         coredns-7d7f5b7685-wvzwb   1959          104           false                 false                                    ready            10.16.75.193   f00d::a10:0:0:2c77
         $
-        $ kubectl annotate pod -n kube-system coredns-7d7f5b7685-wvzwb io.cilium.proxy-visibility="<Ingress/53/UDP/DNS>,<Egress/80/TCP/HTTP>"
-        pod/coredns-7d7f5b7685-wvzwb annotated
-        $
-        $ kubectl get cep -n kube-system
-        NAME                       ENDPOINT ID   IDENTITY ID   INGRESS ENFORCEMENT   EGRESS ENFORCEMENT   VISIBILITY POLICY                        ENDPOINT STATE   IPV4           IPV6
-        coredns-7d7f5b7685-wvzwb   1959          104           false                 false                dns not allowed with direction Ingress   ready            10.16.75.193   f00d::a10:0:0:2c77
-        $
         $ kubectl annotate pod -n kube-system coredns-7d7f5b7685-wvzwb io.cilium.proxy-visibility="<Egress/53/UDP/DNS>,<Egress/80/TCP/HTTP>" --overwrite
         pod/coredns-7d7f5b7685-wvzwb annotated
         $
         $ kubectl get cep -n kube-system
         NAME                       ENDPOINT ID   IDENTITY ID   INGRESS ENFORCEMENT   EGRESS ENFORCEMENT   VISIBILITY POLICY   ENDPOINT STATE   IPV4           IPV6
         coredns-7d7f5b7685-wvzwb   1959          104           false                 false                OK                  ready            10.16.75.193   f00d::a10:0:0:2c7
+
+Troubleshooting
+---------------
+
+If L7 visibility is not appearing in ``cilium monitor`` or Hubble components,
+it is worth double-checking that:
+
+ * No enforcement policy is applied in the direction specified in the
+   annotation
+ * The "Visibility Policy" column in the CiliumEndpoint shows ``OK``. If it
+   is blank, then no annotation is configured; if it shows an error then there
+   is a problem with the visibility annotation.
+
+The following example deliberately misconfigures the annotation to demonstrate
+that the CiliumEndpoint for the pod presents an error when the visibility
+annotation cannot be implemented:
+
+::
+
+        $ kubectl annotate pod -n kube-system coredns-7d7f5b7685-wvzwb io.cilium.proxy-visibility="<Ingress/53/UDP/DNS>,<Egress/80/TCP/HTTP>"
+        pod/coredns-7d7f5b7685-wvzwb annotated
+        $
+        $ kubectl get cep -n kube-system
+        NAME                       ENDPOINT ID   IDENTITY ID   INGRESS ENFORCEMENT   EGRESS ENFORCEMENT   VISIBILITY POLICY                        ENDPOINT STATE   IPV4           IPV6
+        coredns-7d7f5b7685-wvzwb   1959          104           false                 false                dns not allowed with direction Ingress   ready            10.16.75.193   f00d::a10:0:0:2c77
 
 Limitations
 -----------

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -389,6 +389,7 @@ microk
 microservice
 microservices
 minikube
+misconfigures
 mlx
 mov
 mul

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 Authors of Cilium
+// Copyright 2016-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -590,7 +590,8 @@ func (e *Endpoint) regenerateBPF(regenContext *regenerationContext) (revnum uint
 		return 0, compilationExecuted, fmt.Errorf("unable to regenerate policy because PolicyMap synchronization failed: %s", err)
 	}
 
-	return datapathRegenCtxt.epInfoCache.revision, compilationExecuted, err
+	stateDirComplete := compilationExecuted
+	return datapathRegenCtxt.epInfoCache.revision, stateDirComplete, err
 }
 
 func (e *Endpoint) realizeBPFState(regenContext *regenerationContext) (compilationExecuted bool, err error) {

--- a/pkg/endpoint/directory.go
+++ b/pkg/endpoint/directory.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -64,7 +64,7 @@ func (e *Endpoint) backupDirectoryPath() string {
 // Returns the original regenerationError if regenerationError was non-nil,
 // or if any updates to directories for the endpoint's directories fails.
 // Must be called with endpoint.Mutex held.
-func (e *Endpoint) synchronizeDirectories(origDir string, compilationExecuted bool) error {
+func (e *Endpoint) synchronizeDirectories(origDir string, stateDirComplete bool) error {
 	scopedLog := e.getLogger()
 	scopedLog.Debug("synchronizing directories")
 
@@ -115,8 +115,8 @@ func (e *Endpoint) synchronizeDirectories(origDir string, compilationExecuted bo
 
 		// If the compilation was skipped then we need to copy the old
 		// bpf objects into the new directory
-		if !compilationExecuted {
-			scopedLog.Debug("compilation was skipped; moving old BPF objects into new directory")
+		if !stateDirComplete {
+			scopedLog.Debug("some BPF state files were not recreated; moving old BPF objects into new directory")
 			err := common.MoveNewFilesTo(backupDir, origDir)
 			if err != nil {
 				log.WithError(err).Debugf("unable to copy old bpf object "+

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -124,12 +124,10 @@ var (
 	}
 
 	microk8sHelmOverrides = map[string]string{
-		"global.cni.confPath":                 "/var/snap/microk8s/current/args/cni-network",
-		"global.cni.binPath":                  "/var/snap/microk8s/current/opt/cni/bin",
-		"global.cni.customConf":               "true",
-		"global.containerRuntime.integration": "containerd",
-		"global.containerRuntime.socketPath":  "/var/snap/microk8s/common/run/containerd.sock",
-		"global.daemon.runPath":               "/var/snap/microk8s/current/var/run/cilium",
+		"global.cni.confPath":   "/var/snap/microk8s/current/args/cni-network",
+		"global.cni.binPath":    "/var/snap/microk8s/current/opt/cni/bin",
+		"global.cni.customConf": "true",
+		"global.daemon.runPath": "/var/snap/microk8s/current/var/run/cilium",
 	}
 	minikubeHelmOverrides = map[string]string{
 		"global.ipv6.enabled":           "false",

--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -101,7 +101,14 @@ func DeployCiliumOptionsAndDNS(vm *helpers.Kubectl, ciliumFilename string, optio
 	ExpectCiliumRunning(vm)
 
 	By("Installing DNS Deployment")
-	_ = vm.ApplyDefault(helpers.DNSDeployment(vm.BasePath()))
+	switch helpers.GetCurrentIntegration() {
+	case helpers.CIIntegrationMicrok8s:
+		By(fmt.Sprintf("%s (hint: %s)",
+			"Assuming that microk8s already has DNS deployed...",
+			"Use 'microk8s.enable dns' to create deployment"))
+	default:
+		_ = vm.ApplyDefault(helpers.DNSDeployment(vm.BasePath()))
+	}
 
 	switch helpers.GetCurrentIntegration() {
 	case helpers.CIIntegrationFlannel:


### PR DESCRIPTION
 * #10597 -- docs: Improve policy visibility docs (@joestringer)
 * #10551 -- cilium: encryption, additional mtu fix for non-default 1500B MTU  (@jrfastab)
 * #10577 -- test: Fix some minor microk8s integration issues (@joestringer)
 * #10630 -- Fix issue where lxc_config.h header disappears after some regenerations (@joestringer)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 10597 10551 10577 10630; do contrib/backporting/set-labels.py $pr done 1.7; done
```