### PR TITLE
Fetch MTU from the nodeIP interface

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -289,7 +289,13 @@ func NewDaemon(ctx context.Context, dp datapath.Datapath) (*Daemon, *endpointRes
 		return nil, nil, fmt.Errorf("unable to setup encryption: %s", err)
 	}
 
-	mtuConfig := mtu.NewConfiguration(authKeySize, option.Config.EnableIPSec, option.Config.Tunnel != option.TunnelDisabled, configuredMTU)
+	var mtuConfig mtu.Configuration
+	externalIP := node.GetExternalIPv4()
+	if externalIP == nil {
+		externalIP = node.GetIPv6()
+	}
+	// ExternalIP could be nil but we are covering that case inside NewConfiguration
+	mtuConfig = mtu.NewConfiguration(authKeySize, option.Config.EnableIPSec, option.Config.Tunnel != option.TunnelDisabled, configuredMTU, externalIP)
 
 	nodeMngr, err := nodemanager.NewManager("all", dp.Node(), ipcache.IPIdentityCache, option.Config)
 	if err != nil {

--- a/daemon/cmd/status_test.go
+++ b/daemon/cmd/status_test.go
@@ -82,7 +82,7 @@ func (g *GetNodesSuite) Test_getNodesHandle(c *C) {
 		{
 			name: "create a client ID and store it locally",
 			setupArgs: func() args {
-				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, mtu.NewConfiguration(0, false, false, 0), &cnitypes.NetConf{})
+				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, mtu.NewConfiguration(0, false, false, 0, nil), &cnitypes.NetConf{})
 				nodeDiscovery.LocalNode.Name = "foo"
 				return args{
 					params: GetClusterNodesParams{
@@ -114,7 +114,7 @@ func (g *GetNodesSuite) Test_getNodesHandle(c *C) {
 		{
 			name: "retrieve nodes diff from a client that was already present",
 			setupArgs: func() args {
-				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, mtu.NewConfiguration(0, false, false, 0), &cnitypes.NetConf{})
+				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, mtu.NewConfiguration(0, false, false, 0, nil), &cnitypes.NetConf{})
 				nodeDiscovery.LocalNode.Name = "foo"
 				return args{
 					params: GetClusterNodesParams{
@@ -168,7 +168,7 @@ func (g *GetNodesSuite) Test_getNodesHandle(c *C) {
 		{
 			name: "retrieve nodes from an expired client, it should be ok because the clean up only happens when on insertion",
 			setupArgs: func() args {
-				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, mtu.NewConfiguration(0, false, false, 0), &cnitypes.NetConf{})
+				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, mtu.NewConfiguration(0, false, false, 0, nil), &cnitypes.NetConf{})
 				nodeDiscovery.LocalNode.Name = "foo"
 				return args{
 					params: GetClusterNodesParams{
@@ -223,7 +223,7 @@ func (g *GetNodesSuite) Test_getNodesHandle(c *C) {
 		{
 			name: "retrieve nodes for a new client, the expired client should be deleted",
 			setupArgs: func() args {
-				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, mtu.NewConfiguration(0, false, false, 0), &cnitypes.NetConf{})
+				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, mtu.NewConfiguration(0, false, false, 0, nil), &cnitypes.NetConf{})
 				nodeDiscovery.LocalNode.Name = "foo"
 				return args{
 					params: GetClusterNodesParams{
@@ -273,7 +273,7 @@ func (g *GetNodesSuite) Test_getNodesHandle(c *C) {
 		{
 			name: "retrieve nodes for a new client, however the randomizer allocated an existing clientID, so we should return a empty clientID",
 			setupArgs: func() args {
-				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, mtu.NewConfiguration(0, false, false, 0), &cnitypes.NetConf{})
+				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, mtu.NewConfiguration(0, false, false, 0, nil), &cnitypes.NetConf{})
 				nodeDiscovery.LocalNode.Name = "foo"
 				return args{
 					params: GetClusterNodesParams{
@@ -323,7 +323,7 @@ func (g *GetNodesSuite) Test_getNodesHandle(c *C) {
 		{
 			name: "retrieve nodes for a client that does not want to have diffs, leave all other stored clients alone",
 			setupArgs: func() args {
-				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, mtu.NewConfiguration(0, false, false, 0), &cnitypes.NetConf{})
+				nodeDiscovery := nodediscovery.NewNodeDiscovery(nm, mtu.NewConfiguration(0, false, false, 0, nil), &cnitypes.NetConf{})
 				nodeDiscovery.LocalNode.Name = "foo"
 				return args{
 					params: GetClusterNodesParams{},
@@ -433,7 +433,7 @@ func (g *GetNodesSuite) Test_cleanupClients(c *C) {
 		h := &getNodes{
 			clients: args.clients,
 			d: &Daemon{
-				nodeDiscovery: nodediscovery.NewNodeDiscovery(nm, mtu.NewConfiguration(0, false, false, 0), &cnitypes.NetConf{}),
+				nodeDiscovery: nodediscovery.NewNodeDiscovery(nm, mtu.NewConfiguration(0, false, false, 0, nil), &cnitypes.NetConf{}),
 			},
 		}
 		h.cleanupClients()

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -71,7 +71,7 @@ const (
 func (s *linuxPrivilegedBaseTestSuite) SetUpTest(c *check.C, addressing datapath.NodeAddressing, enableIPv6, enableIPv4 bool) {
 	bpf.ConfigureResourceLimits()
 	s.nodeAddressing = addressing
-	s.mtuConfig = mtu.NewConfiguration(0, false, false, 1500)
+	s.mtuConfig = mtu.NewConfiguration(0, false, false, 1500, nil)
 	s.enableIPv6 = enableIPv6
 	s.enableIPv4 = enableIPv4
 

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -168,6 +168,9 @@ const (
 	// CIDR is a IPv4/IPv4 subnet/CIDR
 	CIDR = "cidr"
 
+	// MTU is the maximum transmission unit of one interface
+	MTU = "mtu"
+
 	// Interface is an interface id/name on the system
 	Interface = "interface"
 

--- a/pkg/mtu/detect_darwin.go
+++ b/pkg/mtu/detect_darwin.go
@@ -16,6 +16,12 @@
 
 package mtu
 
+import "net"
+
 func autoDetect() (int, error) {
+	return EthernetMTU, nil
+}
+
+func getMTUFromIf(net.IP) (int, error) {
 	return EthernetMTU, nil
 }

--- a/pkg/mtu/mtu.go
+++ b/pkg/mtu/mtu.go
@@ -14,6 +14,8 @@
 
 package mtu
 
+import "net"
+
 const (
 	// MaxMTU is the highest MTU that can be used for devices and routes
 	// handled by Cilium. It will typically be used to configure inbound
@@ -96,13 +98,17 @@ type Configuration struct {
 // specified, otherwise it will be automatically detected. if encapEnabled is
 // true, the MTU is adjusted to account for encapsulation overhead for all
 // routes involved in node to node communication.
-func NewConfiguration(authKeySize int, encryptEnabled bool, encapEnabled bool, mtu int) Configuration {
+func NewConfiguration(authKeySize int, encryptEnabled bool, encapEnabled bool, mtu int, mtuDetectIP net.IP) Configuration {
 	encryptOverhead := 0
 
 	if mtu == 0 {
 		var err error
 
-		mtu, err = autoDetect()
+		if mtuDetectIP != nil {
+			mtu, err = getMTUFromIf(mtuDetectIP)
+		} else {
+			mtu, err = autoDetect()
+		}
 		if err != nil {
 			log.WithError(err).Warning("Unable to automatically detect MTU")
 			mtu = EthernetMTU

--- a/pkg/mtu/mtu_test.go
+++ b/pkg/mtu/mtu_test.go
@@ -17,6 +17,7 @@
 package mtu
 
 import (
+	"net"
 	"testing"
 
 	. "gopkg.in/check.v1"
@@ -30,48 +31,63 @@ var _ = Suite(&MTUSuite{})
 
 func (m *MTUSuite) TestNewConfiguration(c *C) {
 	// Add routes with no encryption or tunnel
-	conf := NewConfiguration(0, false, false, 0)
+	conf := NewConfiguration(0, false, false, 0, nil)
 	c.Assert(conf.GetDeviceMTU(), Not(Equals), 0)
 	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU())
 
 	// Add routes with no encryption or tunnel and set MTU
-	conf = NewConfiguration(0, false, false, 1400)
+	conf = NewConfiguration(0, false, false, 1400, nil)
 	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
 	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU())
 
 	// Add routes with tunnel
-	conf = NewConfiguration(0, false, true, 1400)
+	conf = NewConfiguration(0, false, true, 1400, nil)
 	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
 	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU()-TunnelOverhead)
 
 	// Add routes with tunnel and set MTU
-	conf = NewConfiguration(0, false, true, 1400)
+	conf = NewConfiguration(0, false, true, 1400, nil)
 	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
 	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU()-TunnelOverhead)
 
 	// Add routes with encryption and set MTU using standard 128bit, larger 256bit and smaller 96bit ICVlen keys
-	conf = NewConfiguration(16, true, false, 1400)
+	conf = NewConfiguration(16, true, false, 1400, nil)
 	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
 	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU()-EncryptionIPsecOverhead)
 
-	conf = NewConfiguration(32, true, false, 1400)
+	conf = NewConfiguration(32, true, false, 1400, nil)
 	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
 	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU()-(EncryptionIPsecOverhead+16))
 
-	conf = NewConfiguration(12, true, false, 1400)
+	conf = NewConfiguration(12, true, false, 1400, nil)
 	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
 	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU()-(EncryptionIPsecOverhead-4))
 
 	// Add routes with encryption and tunnels using standard 128bit, larger 256bit and smaller 96bit ICVlen keys
-	conf = NewConfiguration(16, true, true, 1400)
+	conf = NewConfiguration(16, true, true, 1400, nil)
 	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
 	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU()-(TunnelOverhead+EncryptionIPsecOverhead))
 
-	conf = NewConfiguration(32, true, true, 1400)
+	conf = NewConfiguration(32, true, true, 1400, nil)
 	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
 	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU()-(TunnelOverhead+EncryptionIPsecOverhead+16))
 
-	conf = NewConfiguration(32, true, true, 1400)
+	conf = NewConfiguration(32, true, true, 1400, nil)
 	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
 	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU()-(TunnelOverhead+EncryptionIPsecOverhead+16))
+
+	testIP1 := net.IPv4(0, 0, 0, 0)
+	testIP2 := net.IPv4(127, 0, 0, 1)
+	result, _ := getMTUFromIf(testIP1)
+	c.Assert(result, Equals, 0)
+
+	conf = NewConfiguration(0, true, true, 1400, testIP1)
+	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
+
+	conf = NewConfiguration(0, true, true, 0, testIP1)
+	c.Assert(conf.GetDeviceMTU(), Equals, 1500)
+
+	// Assuming loopback interface always exists and has mtu=65536
+	conf = NewConfiguration(0, true, true, 0, testIP2)
+	c.Assert(conf.GetDeviceMTU(), Equals, 65536)
 }


### PR DESCRIPTION
The detected MTU is always the one belonging to the interface that acts
as gateway. That interface does not necessarily need to be the one that
holds nodeIP and thus the one that Cilium will use to send traffic
inside the k8s cluster. This patch fixes this and detects the mtu of the
interface used for cluster communications

Fixes: #10309
Signed-off-by: Manuel Buil <mbuil@suse.com>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->

The detected MTU is always the one belonging to the interface that acts
as gateway. That interface does not necessarily need to be the one that
holds nodeIP and thus the one that Cilium will use to send traffic
inside the k8s cluster. This patch fixes this and detects the mtu of the
interface used for cluster communications

Fixes: #10309

```release-note
Autodetection of the mtu correctly detects the mtu of the interface used for the kubernetes cluster communication. The mtu was incorrectly detected in cases where multiple interfaces were present and the gateway interface was not the one used for kubernetes cluster communication
```
