### PR TITLE
daemon: add option to disable some feeder tables

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -49,6 +49,7 @@ cilium-agent [flags]
       --disable-cnp-status-updates                    Do not send CNP NodeStatus updates to the Kubernetes api-server (recommended to run with "cnp-node-status-gc=false" in cilium-operator)
       --disable-conntrack                             Disable connection tracking
       --disable-endpoint-crd                          Disable use of CiliumEndpoint CRD
+      --disable-iptables-feeder-rules strings         Chains to ignore when installing feeder rules.
       --egress-masquerade-interfaces string           Limit egress masquerading to interface selector
       --enable-endpoint-health-checking               Enable connectivity health checking between virtual endpoints (default true)
       --enable-endpoint-routes                        Use per endpoint routes instead of routing via cilium_host

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -751,6 +751,9 @@ func init() {
 	flags.StringSlice(option.HubbleMetrics, []string{}, "List of Hubble metrics to enable.")
 	option.BindEnv(option.HubbleMetrics)
 
+	flags.StringSlice(option.DisableIptablesFeederRules, []string{}, "Chains to ignore when installing feeder rules.")
+	option.BindEnv(option.DisableIptablesFeederRules)
+
 	flags.Duration(option.K8sHeartbeatTimeout, 30*time.Second, "Configures the timeout for api-server heartbeat, set to 0 to disable")
 	option.BindEnv(option.K8sHeartbeatTimeout)
 

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -374,4 +374,7 @@ data:
   # https://github.com/cilium/hubble/blob/master/Documentation/metrics.md
   hubble-metrics: {{ .Values.global.hubble.metrics | join " " | quote }}
   {{- end }}
+
+  # A space separated list of iptables chains to disable when installing feeder rules.
+  disable-iptables-feeder-rules: {{ .Values.global.disableIptablesFeederRules | join " " | quote }}
 {{- end }}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -790,6 +790,10 @@ const (
 	// HubbleMetrics specifies enabled metrics and their configuration options.
 	HubbleMetrics = "hubble-metrics"
 
+	// DisableIptablesFeederRules specifies which chains will be excluded
+	// when installing the feeder rules
+	DisableIptablesFeederRules = "disable-iptables-feeder-rules"
+
 	// K8sHeartbeatTimeout configures the timeout for apiserver heartbeat
 	K8sHeartbeatTimeout = "k8s-heartbeat-timeout"
 
@@ -1608,6 +1612,10 @@ type DaemonConfig struct {
 	// EndpointStatus enables population of information in the
 	// CiliumEndpoint.Status resource
 	EndpointStatus map[string]struct{}
+
+	// DisableIptablesFeederRules specifies which chains will be excluded
+	// when installing the feeder rules
+	DisableIptablesFeederRules []string
 }
 
 var (
@@ -2295,6 +2303,7 @@ func (c *DaemonConfig) Populate() {
 	}
 	c.HubbleMetricsServer = viper.GetString(HubbleMetricsServer)
 	c.HubbleMetrics = viper.GetStringSlice(HubbleMetrics)
+	c.DisableIptablesFeederRules = viper.GetStringSlice(DisableIptablesFeederRules)
 
 	// Hidden options
 	c.ConfigFile = viper.GetString(ConfigFile)


### PR DESCRIPTION
Signed-off-by: Patrik Cyvoct <patrik@ptrk.io>

```release-note
Add a flag to disable feeder installation on certain iptables tables
```

context: https://cilium.slack.com/archives/C1MATJ5U5/p1584555081075700
motivation:
We are using a VPN that links the k8s masters to the workers (so k8s is not aware of these master). 
Each master connects randomly to 1 worker in the cluster to send traffic to the overlay.
However when using network policies, cilium drop the traffic from the master. 

The solution is some iptables magic to allow the vpn range on the workers. So by inserting a rule in FORWARD and nat POSTROUTING it works. However when cilium restars, it will insert its rules on top of the custom one.

The naive solution would be to tell cilium to append instead of insert but then it would appear after the k8s iptables rules which is really not ideal.

This flag will allow the user to ensure the rules like `-A FORWARD -J CILIUM_FORWARD` on his side, in order to insert some custom rules above and still make it work when cilium restarts

cc @joestringer 