### PR TITLE
[1.6] Fix issue where lxc_config.h header disappears after some regenerations

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 Authors of Cilium
+// Copyright 2016-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -468,7 +468,8 @@ func (e *Endpoint) regenerateBPF(regenContext *regenerationContext) (revnum uint
 		return 0, compilationExecuted, fmt.Errorf("unable to regenerate policy because PolicyMap synchronization failed: %s", err)
 	}
 
-	return datapathRegenCtxt.epInfoCache.revision, compilationExecuted, err
+	stateDirComplete := compilationExecuted
+	return datapathRegenCtxt.epInfoCache.revision, stateDirComplete, err
 }
 
 func (e *Endpoint) realizeBPFState(regenContext *regenerationContext) (compilationExecuted bool, err error) {

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -357,13 +357,16 @@ func (e *Endpoint) removeOldRedirects(desiredRedirects map[string]bool, proxyWai
 // specified endpoint.
 // ReloadDatapath forces the datapath programs to be reloaded. It does
 // not guarantee recompilation of the programs.
-// Must be called with endpoint.Mutex not held and endpoint.BuildMutex held.
-// Returns the policy revision number when the regeneration has called, a
-// boolean if the BPF compilation was executed and an error in case of an error.
-func (e *Endpoint) regenerateBPF(regenContext *regenerationContext) (revnum uint64, compiled bool, reterr error) {
+// Must be called with endpoint.Mutex not held and endpoint.buildMutex held.
+//
+// Returns the policy revision number when the regeneration has called,
+// Whether the new state dir is populated with all new BPF state files, and
+// and an error if something failed.
+func (e *Endpoint) regenerateBPF(regenContext *regenerationContext) (revnum uint64, stateDirComplete bool, reterr error) {
 	var (
 		err                 error
 		compilationExecuted bool
+		headerfileChanged   bool
 	)
 
 	stats := &regenContext.Stats
@@ -380,7 +383,7 @@ func (e *Endpoint) regenerateBPF(regenContext *regenerationContext) (revnum uint
 	datapathRegenCtxt.prepareForProxyUpdates(regenContext.parentContext)
 	defer datapathRegenCtxt.completionCancel()
 
-	err = e.runPreCompilationSteps(regenContext)
+	headerfileChanged, err = e.runPreCompilationSteps(regenContext)
 
 	// Keep track of the side-effects of the regeneration that need to be
 	// reverted in case of failure.
@@ -468,7 +471,7 @@ func (e *Endpoint) regenerateBPF(regenContext *regenerationContext) (revnum uint
 		return 0, compilationExecuted, fmt.Errorf("unable to regenerate policy because PolicyMap synchronization failed: %s", err)
 	}
 
-	stateDirComplete := compilationExecuted
+	stateDirComplete = headerfileChanged && compilationExecuted
 	return datapathRegenCtxt.epInfoCache.revision, stateDirComplete, err
 }
 
@@ -523,7 +526,9 @@ func (e *Endpoint) realizeBPFState(regenContext *regenerationContext) (compilati
 // runPreCompilationSteps runs all of the regeneration steps that are necessary
 // right before compiling the BPF for the given endpoint.
 // The endpoint mutex must not be held.
-func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (preCompilationError error) {
+//
+// Returns whether the headerfile changed and/or an error.
+func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (headerfileChanged bool, preCompilationError error) {
 	stats := &regenContext.Stats
 	datapathRegenCtxt := regenContext.datapathRegenerationContext
 
@@ -531,7 +536,7 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (pr
 	err := e.LockAlive()
 	stats.waitingForLock.End(err == nil)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	defer e.Unlock()
@@ -566,7 +571,7 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (pr
 
 		// Compute policy for this endpoint.
 		if err = e.regeneratePolicy(); err != nil {
-			return fmt.Errorf("Unable to regenerate policy: %s", err)
+			return false, fmt.Errorf("Unable to regenerate policy: %s", err)
 		}
 
 		_ = e.updateAndOverrideEndpointOptions(nil)
@@ -574,27 +579,27 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (pr
 		// Dry mode needs Network Policy Updates, but the proxy wait group must
 		// not be initialized, as there is no proxy ACKing the changes.
 		if err, _ = e.updateNetworkPolicy(nil); err != nil {
-			return err
+			return false, err
 		}
 
 		if err = e.writeHeaderfile(nextDir); err != nil {
-			return fmt.Errorf("Unable to write header file: %s", err)
+			return false, fmt.Errorf("Unable to write header file: %s", err)
 		}
 
 		log.WithField(logfields.EndpointID, e.ID).Debug("Skipping bpf updates due to dry mode")
-		return nil
+		return false, nil
 	}
 
 	if e.PolicyMap == nil {
 		e.PolicyMap, _, err = policymap.OpenOrCreate(e.PolicyMapPathLocked())
 		if err != nil {
-			return err
+			return false, err
 		}
 		// Clean up map contents
 		e.getLogger().Debug("flushing old PolicyMap")
 		err = e.PolicyMap.DeleteAll()
 		if err != nil {
-			return err
+			return false, err
 		}
 
 		// Also reset the in-memory state of the realized state as the
@@ -605,7 +610,7 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (pr
 	if e.bpfConfigMap == nil {
 		e.bpfConfigMap, _, err = bpfconfig.OpenMapWithName(e.BPFConfigMapPath())
 		if err != nil {
-			return err
+			return false, err
 		}
 		// Also reset the in-memory state of the realized state as the
 		// BPF map content is guaranteed to be empty right now.
@@ -619,7 +624,7 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (pr
 		err = e.regeneratePolicy()
 		stats.policyCalculation.End(err == nil)
 		if err != nil {
-			return fmt.Errorf("unable to regenerate policy for '%s': %s", e.StringID(), err)
+			return false, fmt.Errorf("unable to regenerate policy for '%s': %s", e.StringID(), err)
 		}
 
 		_ = e.updateAndOverrideEndpointOptions(nil)
@@ -631,7 +636,7 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (pr
 		err, networkPolicyRevertFunc := e.updateNetworkPolicy(datapathRegenCtxt.proxyWaitGroup)
 		stats.proxyPolicyCalculation.End(err == nil)
 		if err != nil {
-			return err
+			return false, err
 		}
 		datapathRegenCtxt.revertStack.Push(networkPolicyRevertFunc)
 
@@ -646,7 +651,7 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (pr
 			desiredRedirects, err, finalizeFunc, revertFunc = e.addNewRedirects(e.desiredPolicy.L4Policy, datapathRegenCtxt.proxyWaitGroup)
 			stats.proxyConfiguration.End(err == nil)
 			if err != nil {
-				return err
+				return false, err
 			}
 			datapathRegenCtxt.finalizeList.Append(finalizeFunc)
 			datapathRegenCtxt.revertStack.Push(revertFunc)
@@ -666,7 +671,7 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (pr
 		err = e.syncPolicyMap()
 		stats.mapSync.End(err == nil)
 		if err != nil {
-			return fmt.Errorf("unable to regenerate policy because PolicyMap synchronization failed: %s", err)
+			return false, fmt.Errorf("unable to regenerate policy because PolicyMap synchronization failed: %s", err)
 		}
 
 		// Synchronously update the BPF ConfigMap for this endpoint.
@@ -676,7 +681,7 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (pr
 		// ELF file, but there's no solution to this just yet.
 		if err = e.bpfConfigMap.Update(e.desiredBPFConfig); err != nil {
 			e.getLogger().WithError(err).Error("unable to update BPF config map")
-			return err
+			return false, err
 		}
 
 		datapathRegenCtxt.revertStack.Push(func() error {
@@ -700,21 +705,20 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (pr
 
 	// Avoid BPF program compilation and installation if the headerfile for the endpoint
 	// or the node have not changed.
-	var changed bool
 	datapathRegenCtxt.bpfHeaderfilesHash, err = loader.EndpointHash(e)
 	if err != nil {
 		e.getLogger().WithError(err).Warn("Unable to hash header file")
 		datapathRegenCtxt.bpfHeaderfilesHash = ""
-		changed = true
+		headerfileChanged = true
 	} else {
-		changed = (datapathRegenCtxt.bpfHeaderfilesHash != e.bpfHeaderfileHash)
+		headerfileChanged = (datapathRegenCtxt.bpfHeaderfilesHash != e.bpfHeaderfileHash)
 		e.getLogger().WithField(logfields.BPFHeaderfileHash, datapathRegenCtxt.bpfHeaderfilesHash).
 			Debugf("BPF header file hashed (was: %q)", e.bpfHeaderfileHash)
 	}
-	if changed {
+	if headerfileChanged {
 		datapathRegenCtxt.regenerationLevel = regeneration.RegenerateWithDatapathRewrite
 		if err = e.writeHeaderfile(nextDir); err != nil {
-			return fmt.Errorf("unable to write header file: %s", err)
+			return false, fmt.Errorf("unable to write header file: %s", err)
 		}
 	}
 
@@ -725,10 +729,10 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (pr
 		datapathRegenCtxt.epInfoCache = e.createEpInfoCache(currentDir)
 	}
 	if datapathRegenCtxt.epInfoCache == nil {
-		return fmt.Errorf("Unable to cache endpoint information")
+		return headerfileChanged, fmt.Errorf("Unable to cache endpoint information")
 	}
 
-	return nil
+	return headerfileChanged, nil
 }
 
 func (e *Endpoint) finalizeProxyState(regenContext *regenerationContext, err error) {

--- a/pkg/endpoint/directory.go
+++ b/pkg/endpoint/directory.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Authors of Cilium
+// Copyright 2018-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -64,7 +64,7 @@ func (e *Endpoint) backupDirectoryPath() string {
 // Returns the original regenerationError if regenerationError was non-nil,
 // or if any updates to directories for the endpoint's directories fails.
 // Must be called with endpoint.Mutex held.
-func (e *Endpoint) synchronizeDirectories(origDir string, compilationExecuted bool) error {
+func (e *Endpoint) synchronizeDirectories(origDir string, stateDirComplete bool) error {
 	scopedLog := e.getLogger()
 	scopedLog.Debug("synchronizing directories")
 
@@ -115,8 +115,8 @@ func (e *Endpoint) synchronizeDirectories(origDir string, compilationExecuted bo
 
 		// If the compilation was skipped then we need to copy the old
 		// bpf objects into the new directory
-		if !compilationExecuted {
-			scopedLog.Debug("compilation was skipped; moving old BPF objects into new directory")
+		if !stateDirComplete {
+			scopedLog.Debug("some BPF state files were not recreated; moving old BPF objects into new directory")
 			err := common.MoveNewFilesTo(backupDir, origDir)
 			if err != nil {
 				log.WithError(err).Debugf("unable to copy old bpf object "+

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 Authors of Cilium
+// Copyright 2016-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -241,7 +241,7 @@ func (e *Endpoint) updateAndOverrideEndpointOptions(opts option.OptionMap) (opts
 // Called with e.Mutex UNlocked
 func (e *Endpoint) regenerate(context *regenerationContext) (retErr error) {
 	var revision uint64
-	var compilationExecuted bool
+	var stateDirComplete bool
 	var err error
 
 	context.Stats = regenerationStatistics{}
@@ -332,7 +332,7 @@ func (e *Endpoint) regenerate(context *regenerationContext) (retErr error) {
 		e.Unlock()
 	}()
 
-	revision, compilationExecuted, err = e.regenerateBPF(context)
+	revision, stateDirComplete, err = e.regenerateBPF(context)
 	if err != nil {
 		failDir := e.FailedDirectoryPath()
 		e.getLogger().WithFields(logrus.Fields{
@@ -345,13 +345,13 @@ func (e *Endpoint) regenerate(context *regenerationContext) (retErr error) {
 		return err
 	}
 
-	return e.updateRealizedState(stats, origDir, revision, compilationExecuted)
+	return e.updateRealizedState(stats, origDir, revision, stateDirComplete)
 }
 
 // updateRealizedState sets any realized state fields within the endpoint to
 // be the desired state of the endpoint. This is only called after a successful
 // regeneration of the endpoint.
-func (e *Endpoint) updateRealizedState(stats *regenerationStatistics, origDir string, revision uint64, compilationExecuted bool) error {
+func (e *Endpoint) updateRealizedState(stats *regenerationStatistics, origDir string, revision uint64, stateDirComplete bool) error {
 	// Update desired policy for endpoint because policy has now been realized
 	// in the datapath. PolicyMap state is not updated here, because that is
 	// performed in endpoint.syncPolicyMap().
@@ -367,7 +367,7 @@ func (e *Endpoint) updateRealizedState(stats *regenerationStatistics, origDir st
 	// Depending upon result of BPF regeneration (compilation executed),
 	// shift endpoint directories to match said BPF regeneration
 	// results.
-	err = e.synchronizeDirectories(origDir, compilationExecuted)
+	err = e.synchronizeDirectories(origDir, stateDirComplete)
 	if err != nil {
 		return fmt.Errorf("error synchronizing endpoint BPF program directories: %s", err)
 	}


### PR DESCRIPTION
* #10630 -- Fix issue where lxc_config.h header disappears after some regenerations (@joestringer)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 10630; do contrib/backporting/set-labels.py $pr done 1.6; done
```