### PR TITLE
Add helm NOTES file

### DIFF
--- a/install/kubernetes/cilium/charts/agent/templates/NOTES.txt
+++ b/install/kubernetes/cilium/charts/agent/templates/NOTES.txt
@@ -1,0 +1,5 @@
+You have successfully installed Cilium {{ .Chart.Name }}
+
+Your release version is {{ .Chart.Version }}
+
+For any further help, visit https://docs.cilium.io/en/v{{ substr 0 3 .Chart.Version }}/gettinghelp

--- a/install/kubernetes/cilium/charts/config/templates/NOTES.txt
+++ b/install/kubernetes/cilium/charts/config/templates/NOTES.txt
@@ -1,0 +1,5 @@
+You have successfully installed Cilium {{ .Chart.Name }}
+
+Your release version is {{ .Chart.Version }}
+
+For any further help, visit https://docs.cilium.io/en/v{{ substr 0 3 .Chart.Version }}/gettinghelp

--- a/install/kubernetes/cilium/charts/managed-etcd/templates/NOTES.txt
+++ b/install/kubernetes/cilium/charts/managed-etcd/templates/NOTES.txt
@@ -1,0 +1,5 @@
+You have successfully installed Cilium {{ .Chart.Name }}
+
+Your release version is {{ .Chart.Version }}
+
+For any further help, visit https://docs.cilium.io/en/v{{ substr 0 3 .Chart.Version }}/gettinghelp

--- a/install/kubernetes/cilium/charts/nodeinit/templates/NOTES.txt
+++ b/install/kubernetes/cilium/charts/nodeinit/templates/NOTES.txt
@@ -1,0 +1,5 @@
+You have successfully installed Cilium {{ .Chart.Name }}
+
+Your release version is {{ .Chart.Version }}
+
+For any further help, visit https://docs.cilium.io/en/v{{ substr 0 3 .Chart.Version }}/gettinghelp

--- a/install/kubernetes/cilium/charts/operator/templates/NOTES.txt
+++ b/install/kubernetes/cilium/charts/operator/templates/NOTES.txt
@@ -1,0 +1,5 @@
+You have successfully installed Cilium {{ .Chart.Name }}
+
+Your release version is {{ .Chart.Version }}
+
+For any further help, visit https://docs.cilium.io/en/v{{ substr 0 3 .Chart.Version }}/gettinghelp

--- a/install/kubernetes/cilium/charts/preflight/templates/NOTES.txt
+++ b/install/kubernetes/cilium/charts/preflight/templates/NOTES.txt
@@ -1,0 +1,4 @@
+You have successfully completed the preflight check
+
+For any further help, visit https://docs.cilium.io/en/v{{ substr 0 3 .Chart.Version }}/gettinghelp
+


### PR DESCRIPTION
This patch adds helm NOTES file to the respective template folders.

Fixes: #10070
Signed-off-by: Swaminathan Vasudevan <svasudevan@suse.com>
