### PR TITLE
contrib: Add backport submission script

### DIFF
--- a/Documentation/contributing/release/backports.rst
+++ b/Documentation/contributing/release/backports.rst
@@ -152,8 +152,20 @@ Creating the backports branch
 Creating the backport pull request
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The backport pull-request may be created via the GitHub web interface, or
-alternatively you can use CLI tools to achieve these steps.
+The backport pull-request may be created via CLI tools, or alternatively
+you can use the GitHub web interface to achieve these steps.
+
+Via command-line tools
+^^^^^^^^^^^^^^^^^^^^^^
+
+These steps require all of the tools described in the :ref:`backport_setup`
+section above. It pushes the git tree, creates the pull request and updates
+the labels for the PRs that are backported, based on the
+``vRELEASE-backport-YYYY-MM-DD.txt`` file in the current directory.
+
+   .. code-block:: bash
+
+      # contrib/backporting/submit-backport
 
 Via GitHub web interface
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -174,20 +186,6 @@ Via GitHub web interface
    can be done with the command printed out at the bottom of the output from
    the ``start-backport`` script above (``GITHUB_TOKEN`` needs to be set for
    this to work).
-
-Via command-line tools
-^^^^^^^^^^^^^^^^^^^^^^
-
-These steps require all of the tools described in the :ref:`backport_setup`
-section above. Note that the list of PRs to pass to the ``set-labels.py``
-script are listed at the end of the ``vRELEASE-backport-YYYY-MM-DD.txt`` file.
-
-   .. code-block:: bash
-
-      # Create a pull-request on Github
-      $ gh pull-request -b vX.Y -l backport/vX.Y -F vRELEASE-backport-YYYY-MM-DD.txt
-      # Set PR 1234's v1.0 backporting labels to pending
-      $ contrib/backporting/set-labels.py 1234 pending 1.0
 
 After the backports are merged
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/contrib/backporting/submit-backport
+++ b/contrib/backporting/submit-backport
@@ -1,0 +1,67 @@
+#!/bin/bash
+#
+# Copyright 2020 Authors of Cilium
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DIR=$(dirname $(readlink -ne $BASH_SOURCE))
+source $DIR/../release/lib/common.sh
+source $DIR/common.sh
+
+BRANCH="${1:-}"
+if [ "$BRANCH" = "" ]; then
+    BRANCH=$(git symbolic-ref --short HEAD | sed 's/.*\(v[0-9]\.[0-9]\).*/\1/')
+fi
+BRANCH=$(echo "$BRANCH" | sed 's/^v//')
+
+SUMMARY=${2:-}
+if [ "$SUMMARY" = "" ]; then
+    SUMMARY="v$BRANCH-backport-$(date --rfc-3339=date).txt"
+fi
+
+if ! git branch -a | grep -q "origin/v$BRANCH$" || [ ! -e $SUMMARY ]; then
+    echo "usage: $0 [branch version] [pr-summary]" 1>&2
+    echo 1>&2
+    echo "Ensure 'branch version' is available in 'origin' and the summary file exists" 1>&2
+    exit 1
+fi
+
+if ! gh help | grep -q "pull-request"; then
+    echo "This tool relies on 'gh' from https://github.com/node-gh/gh ." 1>&2
+    echo "Please install this tool first."
+    exit 1
+fi
+
+echo -e "Sending PR for branch v$BRANCH:\n" 1>&2
+cat $SUMMARY 1>&2
+echo -e "\nSending pull request..." 2>&1
+git push origin
+gh pull-request -b "v$BRANCH" -l kind/backports,backport/$BRANCH,requires-janitor-review -F $SUMMARY
+
+prs=$(sed -e 's/^.*#\([0-9]\+\) .*$/\1/g' -e '/^[^0-9]\+/d' $SUMMARY | tr '\n' ' ')
+echo -e "\nUpdating labels for PRs $prs\n" 2>&1
+echo -n "Set labels for all PRs above? [y/N] "
+read set_all_labels
+for pr in $prs; do
+    if [ "$set_all_labels" = "y" ]; then
+        echo -n "Setting labels for PR $pr... "
+        $DIR/set-labels.py $pr pending $BRANCH;
+    else
+        echo -n "Set labels for $pr? [y/N] "
+        read setlabels
+        if [ "$setlabels" = "y" ]; then
+            $DIR/set-labels.py $pr pending $BRANCH;
+        fi
+    fi
+    echo "✓"
+done


### PR DESCRIPTION
This is the counterpart to `contrib/backporting/start-backport` that I've
been sitting on for a while, finally put into a regular shell script form.

Usage:

  $ contrib/backporting/submit-backport [branch version] [pr-summary]

If branch version and pr summary are not specified, they will be
autodetected from branch name and local file as generated by
`contrib/backporting/start-backport` .

This currently only works with the node-gh github CLI which is the one
that the cilium backporting docs point to; it should be a minimal change
in future to switch this over to the official github CLI client as it
stabilizes.

While we're at it, update the docs and move this higher to make it the
default path for handling backport submission.