### PR TITLE
Allow for defining the size of the managed 'etcd' cluster.

### DIFF
--- a/install/kubernetes/cilium/charts/managed-etcd/templates/cilium-etcd-operator-deployment.yaml
+++ b/install/kubernetes/cilium/charts/managed-etcd/templates/cilium-etcd-operator-deployment.yaml
@@ -36,7 +36,7 @@ spec:
         - name: CILIUM_ETCD_OPERATOR_CLUSTER_DOMAIN
           value: "{{ .Values.global.etcd.clusterDomain }}"
         - name: CILIUM_ETCD_OPERATOR_ETCD_CLUSTER_SIZE
-          value: "3"
+          value: "{{ .Values.global.etcd.clusterSize }}"
         - name: CILIUM_ETCD_OPERATOR_NAMESPACE
           valueFrom:
             fieldRef:

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -45,6 +45,9 @@ global:
     # sets cluster domain for cilium-etcd-operator
     clusterDomain: cluster.local
 
+    # defines the size of the etcd cluster
+    clusterSize: 3
+
     # endpoints is the list of etcd endpoints (not needed when using
     # managed=true)
     endpoints:


### PR DESCRIPTION
This PR allows for overriding the size of the managed `etcd` cluster.

```release-note
helm: Allow for overriding the size of the managed `etcd` cluster.
```
