### PR TITLE
vagrant: Re-download corrupted cached files

### DIFF
--- a/contrib/vagrant/scripts/01-install-etcd.sh
+++ b/contrib/vagrant/scripts/01-install-etcd.sh
@@ -29,11 +29,9 @@ cp "${certs_dir}/etcd-server.pem" \
    /etc/etcd/
 
 if [ -n "${INSTALL}" ]; then
-    download_to "${cache_dir}/etcd" "etcd-${etcd_version}-linux-amd64.tar.gz" \
-        "https://github.com/coreos/etcd/releases/download/${etcd_version}/etcd-${etcd_version}-linux-amd64.tar.gz"
-
-    cp "${cache_dir}/etcd/etcd-${etcd_version}-linux-amd64.tar.gz" .
-    tar -xvf etcd-${etcd_version}-linux-amd64.tar.gz
+    download_and_decompress_to "${cache_dir}/etcd" "etcd-${etcd_version}-linux-amd64.tar.gz" \
+        "https://github.com/coreos/etcd/releases/download/${etcd_version}/etcd-${etcd_version}-linux-amd64.tar.gz" \
+        "./"
 
     sudo mv etcd-${etcd_version}-linux-amd64/etcd* /usr/bin/
 fi

--- a/contrib/vagrant/scripts/03-install-kubernetes-worker.sh
+++ b/contrib/vagrant/scripts/03-install-kubernetes-worker.sh
@@ -31,13 +31,11 @@ EOF
 function install_containerd() {
     sudo service docker stop
     sudo apt remove containerd* -y
-    download_to "${cache_dir}/containerd" "containerd-1.2.1.linux-amd64.tar.gz" \
-       "https://github.com/containerd/containerd/releases/download/v1.2.1/containerd-1.2.1.linux-amd64.tar.gz"
-
-    cp "${cache_dir}/containerd/containerd-1.2.1.linux-amd64.tar.gz" .
+    download_and_decompress_to "${cache_dir}/containerd" "containerd-1.2.1.linux-amd64.tar.gz" \
+       "https://github.com/containerd/containerd/releases/download/v1.2.1/containerd-1.2.1.linux-amd64.tar.gz" \
+       "/"
 
     sudo apt-get install runc -y
-    sudo tar -xvf containerd-1.2.1.linux-amd64.tar.gz -C / --no-same-owner
 
     sudo rm -f /etc/systemd/system/containerd.service
     sudo ln -s /bin/containerd /usr/local/bin/containerd
@@ -92,12 +90,9 @@ if [ -n "${INSTALL}" ]; then
         cp "${k8s_cache_dir}/${component}" .
     done
 
-    download_to "${cache_dir}/cni" "cni-plugins-amd64-v0.7.5.tgz" \
-        "https://github.com/containernetworking/plugins/releases/download/v0.7.5/cni-plugins-amd64-v0.7.5.tgz"
-
-    cp "${cache_dir}/cni/cni-plugins-amd64-v0.7.5.tgz" .
-
-    sudo tar -xvf cni-plugins-amd64-v0.7.5.tgz -C /opt/cni/bin
+    download_and_decompress_to "${cache_dir}/cni" "cni-plugins-amd64-v0.7.5.tgz" \
+        "https://github.com/containernetworking/plugins/releases/download/v0.7.5/cni-plugins-amd64-v0.7.5.tgz" \
+        "/opt/cni/bin"
 
     chmod +x kubelet kubectl kube-proxy
 

--- a/contrib/vagrant/scripts/helpers.bash
+++ b/contrib/vagrant/scripts/helpers.bash
@@ -112,6 +112,22 @@ function download_to {
     fi
 }
 
+function download_and_decompress_to {
+  local cache_dir="${1}"
+  local component="${2}"
+  local url="${3}"
+  local dest="${4}"
+  local noretry=${5}
+
+  download_to "${cache_dir}" "${component}" "${url}"
+  cp "${cache_dir}/${component}" .
+  if ! sudo tar -xvf "${component}" -C "${dest}" 2>/dev/null && [ -z "${noretry}" ] ; then
+    log "Decompressing ${component} from cache failed, retrying..."
+    rm "${cache_dir}/${component}"
+    download_and_decompress_to "$@" "noretry"
+  fi
+}
+
 function log {
   local save=$-
   set +u


### PR DESCRIPTION
During VM provisioning, we cache some downloaded files outside the VM, to speed up subsequent provisionings. If a cached file is present we consider that it's safe to reuse. That is however not the case when the download was interrupted (e.g., because of a network error or because VM provisioning was interrupted). Ideally we would check the signature of downloaded files, but the associated projects have different ways of exposing the signatures.

This commit abstract the common download+decompress case behind `download_and_decompress_to()` and extends that function to re-download the file on decompress errors.