### PR TITLE
daemon: Handle ClusterIP svc if kube-proxy-replacement=disabled

### DIFF
--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -516,7 +516,9 @@ This section therefore elaborates on the various ``global.kubeProxyReplacement``
         --set global.externalIPs.enabled=true
 
 - ``global.kubeProxyReplacement=disabled``: This option disables any Kubernetes service
-  handling by fully relying on kube-proxy instead.
+  handling by fully relying on kube-proxy instead, except for ClusterIP services
+  accessed from pods if cilium-agent's flag ``--disable-k8s-services`` is set to
+  ``false`` (pre-v1.6 behavior).
 
 In Cilium's helm chart, the default mode is ``global.kubeProxyReplacement=probe`` for
 new deployments.

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1403,7 +1403,7 @@ func initKubeProxyReplacementOptions() {
 
 	if option.Config.DisableK8sServices {
 		if option.Config.KubeProxyReplacement != option.KubeProxyReplacementDisabled {
-			log.Infof("Service handling disabled. Auto-disabling --%s from \"%s\" to \"%s\"",
+			log.Warnf("Service handling disabled. Auto-disabling --%s from \"%s\" to \"%s\"",
 				option.KubeProxyReplacement, option.Config.KubeProxyReplacement,
 				option.KubeProxyReplacementDisabled)
 			option.Config.KubeProxyReplacement = option.KubeProxyReplacementDisabled
@@ -1421,7 +1421,6 @@ func initKubeProxyReplacementOptions() {
 		option.Config.EnableHostReachableServices = false
 		option.Config.EnableHostServicesTCP = false
 		option.Config.EnableHostServicesUDP = false
-		option.Config.DisableK8sServices = true
 
 		return
 	}


### PR DESCRIPTION
We got a few reports from confused users saying that setting
"--kube-proxy-replacement" to "disabled" disabled ClusterIP
services handling done by Cilium regardless whether
"--disable-k8s-services" was set to "false".

This is an expected behavior for us, but probably less expected
for users who previously had the ClusterIP handling enabled by default
due to "--disable-k8s-services" defaulting to "false".

To minimize the confusion, handle ClusterIP services with the old
mechanism (pre-v1.6) even if the "--kube-proxy-replacement" is set to
"disabled". Once we deprecate the "--disable-k8s-services" flag (in v1.9),
we can disable handling of all types of services with the former flag.

```release-note
Keep Cluster IP service handling when accessed from pods when kubeProxyReplacement is set to "disabled" (pre-v1.6 behavior).
```