### PR TITLE
test: fix k8s provisioning with feature gates

### DIFF
--- a/test/k8sT/manifests/1.11/external_endpoint.yaml
+++ b/test/k8sT/manifests/1.11/external_endpoint.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: external-service
+  namespace: default
+subsets:
+- addresses:
+  - ip: 198.49.23.144
+  ports:
+  - port: 80
+    protocol: TCP

--- a/test/k8sT/manifests/1.12/external_endpoint.yaml
+++ b/test/k8sT/manifests/1.12/external_endpoint.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: external-service
+  namespace: default
+subsets:
+- addresses:
+  - ip: 198.49.23.144
+  ports:
+  - port: 80
+    protocol: TCP

--- a/test/k8sT/manifests/1.13/external_endpoint.yaml
+++ b/test/k8sT/manifests/1.13/external_endpoint.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: external-service
+  namespace: default
+subsets:
+- addresses:
+  - ip: 198.49.23.144
+  ports:
+  - port: 80
+    protocol: TCP

--- a/test/k8sT/manifests/1.14/external_endpoint.yaml
+++ b/test/k8sT/manifests/1.14/external_endpoint.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: external-service
+  namespace: default
+subsets:
+- addresses:
+  - ip: 198.49.23.144
+  ports:
+  - port: 80
+    protocol: TCP

--- a/test/k8sT/manifests/1.15/external_endpoint.yaml
+++ b/test/k8sT/manifests/1.15/external_endpoint.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: external-service
+  namespace: default
+subsets:
+- addresses:
+  - ip: 198.49.23.144
+  ports:
+  - port: 80
+    protocol: TCP

--- a/test/k8sT/manifests/1.16/external_endpoint.yaml
+++ b/test/k8sT/manifests/1.16/external_endpoint.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: external-service
+  namespace: default
+subsets:
+- addresses:
+  - ip: 198.49.23.144
+  ports:
+  - port: 80
+    protocol: TCP

--- a/test/k8sT/manifests/external_endpoint.yaml
+++ b/test/k8sT/manifests/external_endpoint.yaml
@@ -1,11 +1,16 @@
-apiVersion: v1
-kind: Endpoints
+apiVersion: discovery.k8s.io/v1beta1
+kind: EndpointSlice
+addressType: IPv4
+endpoints:
+- addresses:
+  - 198.49.23.144
+  conditions:
+    ready: true
 metadata:
   name: external-service
   namespace: default
-subsets:
-- addresses:
-  - ip: 198.49.23.144
-  ports:
-  - port: 80
-    protocol: TCP
+  labels:
+    kubernetes.io/service-name: external-service
+ports:
+- port: 80
+  protocol: TCP

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -27,6 +27,8 @@ export KUBEADM_CRI_SOCKET="/var/run/dockershim.sock"
 export KUBEADM_SLAVE_OPTIONS=""
 export KUBEADM_OPTIONS=""
 export K8S_FULL_VERSION=""
+export CONTROLLER_FEATURE_GATES=""
+export API_SERVER_FEATURE_GATES=""
 export DNS_DEPLOYMENT="${PROVISIONSRC}/manifest/dns_deployment.yaml"
 export KUBEDNS_DEPLOYMENT="${PROVISIONSRC}/manifest/kubedns_deployment.yaml"
 export COREDNS_DEPLOYMENT="${PROVISIONSRC}/manifest/${K8S_VERSION}/coredns_deployment.yaml"
@@ -145,12 +147,6 @@ bootstrapTokens:
   - authentication
 nodeRegistration:
   criSocket: "{{ .KUBEADM_CRI_SOCKET }}"
-controllerManager:
-  extraArgs:
-    "feature-gates": "{{ .CONTROLLER_FEATURE_GATES }}"
-apiServer:
-  extraArgs:
-    "feature-gates": "{{ .API_SERVER_FEATURE_GATES }}"
 ---
 apiVersion: kubeadm.k8s.io/v1beta1
 kind: ClusterConfiguration
@@ -160,6 +156,12 @@ networking:
   podSubnet: "{{ .KUBEADM_POD_NETWORK }}/{{ .KUBEADM_POD_CIDR}}"
   serviceSubnet: "{{ .KUBEADM_SVC_CIDR }}"
 controlPlaneEndpoint: "k8s1:6443"
+controllerManager:
+  extraArgs:
+    "feature-gates": "{{ .CONTROLLER_FEATURE_GATES }}"
+apiServer:
+  extraArgs:
+    "feature-gates": "{{ .API_SERVER_FEATURE_GATES }}"
 EOF
 )
 
@@ -249,8 +251,8 @@ case $K8S_VERSION in
         KUBEADM_SLAVE_OPTIONS="--discovery-token-unsafe-skip-ca-verification --ignore-preflight-errors=cri,SystemVerification"
         sudo ln -sf $COREDNS_DEPLOYMENT $DNS_DEPLOYMENT
         KUBEADM_CONFIG="${KUBEADM_CONFIG_ALPHA3}"
-        CONTROLLER_FEATURE_GATES="EndpointSlice=true,PodSecurityPolicy=true"
-        API_SERVER_FEATURE_GATES="EndpointSlice=true,PodSecurityPolicy=true"
+        CONTROLLER_FEATURE_GATES="EndpointSlice=true"
+        API_SERVER_FEATURE_GATES="EndpointSlice=true"
         ;;
 esac
 


### PR DESCRIPTION
both `CONTROLLER_FEATURE_GATES` and `API_SERVER_FEATURE_GATES` were not
used when setting up a cluster with these environment variables set as
one needs to export them for `envtpl` to use them.

Fixes: e6df0487227f ("test/provision: enable k8s EndpointSlice by default in 1.17")
Signed-off-by: André Martins <andre@cilium.io>

A follow up PR needs to be done to fix the PSP in the CI.