### PR TITLE
vagrant: Improvements to provisioning

### DIFF
--- a/Documentation/contributing/development/dev_setup.rst
+++ b/Documentation/contributing/development/dev_setup.rst
@@ -110,6 +110,7 @@ brought up by vagrant:
 * ``VM_SET_PROXY=https://127.0.0.1:80/`` Sets up VM's ``https_proxy``.
 * ``INSTALL=1``: Restarts the installation of Cilium, Kubernetes, etc. Only
   useful when the installation was interrupted.
+* ``MAKECLEAN=1``: Execute ``make clean`` before building cilium in the VM.
 
 If you want to start the VM with cilium enabled with ``containerd``, with
 kubernetes installed and plus a worker, run:

--- a/Documentation/contributing/development/dev_setup.rst
+++ b/Documentation/contributing/development/dev_setup.rst
@@ -108,6 +108,8 @@ brought up by vagrant:
   set, it defaults to ``docker``.
 * ``VAGRANT_DEFAULT_PROVIDER={virtualbox \| libvirt \| ...}``
 * ``VM_SET_PROXY=https://127.0.0.1:80/`` Sets up VM's ``https_proxy``.
+* ``INSTALL=1``: Restarts the installation of Cilium, Kubernetes, etc. Only
+  useful when the installation was interrupted.
 
 If you want to start the VM with cilium enabled with ``containerd``, with
 kubernetes installed and plus a worker, run:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -56,6 +56,7 @@ chmod +x bpf-map
 mv bpf-map /usr/bin
 SCRIPT
 
+$makeclean = ENV['MAKECLEAN'] ? "export MAKECLEAN=1" : ""
 $build = <<SCRIPT
 set -o errexit
 set -o nounset
@@ -64,6 +65,7 @@ set -o pipefail
 pip3 install -r ~/go/src/github.com/cilium/cilium/Documentation/requirements.txt
 
 export PATH=/home/vagrant/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games
+#{$makeclean}
 ~/go/src/github.com/cilium/cilium/common/build.sh
 rm -fr ~/go/bin/cilium*
 SCRIPT

--- a/common/build.sh
+++ b/common/build.sh
@@ -8,7 +8,9 @@ popd > /dev/null
 
 cd "$P"
 go install ./... 2> /dev/null || true
-make clean
+if [ -n "${MAKECLEAN}" ]; then
+    make clean
+fi
 
 # Compile with deadlock detection during runtime tests. See GH-1654.
 LOCKDEBUG=1 make

--- a/contrib/vagrant/scripts/00-create-certs.sh
+++ b/contrib/vagrant/scripts/00-create-certs.sh
@@ -14,16 +14,14 @@ cd "${certs_dir}"
 master="k8s1"
 
 if [ -n "${INSTALL}" ]; then
-    log "Downloading cfssl utility..."
-    cfssl_url="https://pkg.cfssl.org/R1.2/cfssl_linux-amd64"
-    cfssljson_url="https://pkg.cfssl.org/R1.2/cfssljson_linux-amd64"
-    ${WGET} -nv ${cfssl_url}
-    ${WGET} -nv ${cfssljson_url}
-    log "Downloading cfssl utility... Done!"
-    chmod +x cfssl_linux-amd64
-    sudo mv cfssl_linux-amd64 /usr/bin/cfssl
-    chmod +x cfssljson_linux-amd64
-    sudo mv cfssljson_linux-amd64 /usr/bin/cfssljson
+    download_to "${cache_dir}/cfssl" "cfssl_linux-amd64" \
+        "https://pkg.cfssl.org/R1.2/cfssl_linux-amd64"
+    chmod +x "${cache_dir}/cfssl/cfssl_linux-amd64"
+    sudo mv "${cache_dir}/cfssl/cfssl_linux-amd64" /usr/bin/cfssl
+    download_to "${cache_dir}/cfssl" "cfssljson_linux-amd64" \
+        "https://pkg.cfssl.org/R1.2/cfssljson_linux-amd64"
+    chmod +x "${cache_dir}/cfssl/cfssljson_linux-amd64"
+    sudo mv "${cache_dir}/cfssl/cfssljson_linux-amd64" /usr/bin/cfssljson
 fi
 
 

--- a/contrib/vagrant/scripts/helpers.bash
+++ b/contrib/vagrant/scripts/helpers.bash
@@ -106,7 +106,10 @@ function download_to {
     if [ ! -f "${cache_dir}/${component}" ]; then
         log "Downloading ${component}..."
 
-        ${WGET} -O "${cache_dir}/${component}" -nv "${url}"
+        rm -f "/tmp/${component}"
+        ${WGET} -O "/tmp/${component}" -nv "${url}"
+        # Hide 'failed to preserve ownership' error
+        mv "/tmp/${component}" "${cache_dir}/${component}" 2>/dev/null
 
         log "Downloading ${component}... Done!"
     fi

--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -227,7 +227,8 @@ export K8S_SERVICE_CLUSTER_IP_RANGE="${k8s_service_cluster_ip_range}"
 export K8S_CLUSTER_API_SERVER_IP="${k8s_cluster_api_server_ip}"
 export K8S_CLUSTER_DNS_IP="${k8s_cluster_dns_ip}"
 export RUNTIME="${RUNTIME}"
-# Only do installation if RELOAD is not set
+export INSTALL="${INSTALL}"
+# Always do installation if RELOAD is not set
 if [ -z "${RELOAD}" ]; then
     export INSTALL="1"
 fi
@@ -274,7 +275,8 @@ export K8S_CLUSTER_DNS_IP="${k8s_cluster_dns_ip}"
 export RUNTIME="${RUNTIME}"
 export K8STAG="${VM_BASENAME}"
 export NWORKERS="${NWORKERS}"
-# Only do installation if RELOAD is not set
+export INSTALL="${INSTALL}"
+# Always do installation if RELOAD is not set
 if [ -z "${RELOAD}" ]; then
     export INSTALL="1"
 fi


### PR DESCRIPTION
This pull request makes a few adjustments to provisioning, mostly to speed it up and ease restarts after interruptions:
1. Prevent partial downloaded files from ending up in the cache.
0. Cache `cfssl` binaries.
0. Allow restarting an interrupted installation.
0. Allow skipping `make clean` for Cilium.

Details in commit messages.