### PR TITLE
make: silence sub-make output when building in quiet mode

### DIFF
--- a/Makefile.quiet
+++ b/Makefile.quiet
@@ -11,6 +11,7 @@ ifeq ($(V),0)
 	ECHO_GINKGO=echo "  GINKG $(RELATIVE_DIR)"
 	ECHO_CLEAN=echo "  CLEAN $(RELATIVE_DIR)"
 	SPHINXOPTS+="-q"
+	SUBMAKEOPTS="-s"
 else
 	# The whitespace at below EOLs is required for verbose case!
 	ECHO_CC=: 
@@ -19,5 +20,6 @@ else
 	ECHO_CHECK=: 
 	ECHO_GINKGO=: 
 	ECHO_CLEAN=: 
+	SUBMAKEOPTS=
 endif
 

--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -16,7 +16,7 @@ all: $(BPF) $(TARGET) subdirs
 
 build_all:
 	@$(ECHO_CHECK)/*.c BUILD_PERMUTATIONS=1
-	$(MAKE) all BUILD_PERMUTATIONS=1
+	$(QUIET) $(MAKE) $(SUBMAKEOPTS) all BUILD_PERMUTATIONS=1
 
 BUILD_PERMUTATIONS ?= ""
 
@@ -152,8 +152,8 @@ bpf_lxc.o: bpf_lxc.ll
 	$(QUIET) ${LLC} ${LLC_FLAGS} -filetype=obj -o $@ $(patsubst %.o,%.ll,$@)
 
 subdirs: $(SUBDIRS)
-	$(foreach TARGET,$(SUBDIRS), \
-		$(MAKE) -C $(TARGET))
+	$(QUIET) $(foreach TARGET,$(SUBDIRS), \
+		$(MAKE) $(SUBMAKEOPTS) -C $(TARGET))
 
 else
 all: $(TARGET)
@@ -170,6 +170,6 @@ install:
 clean:
 	@$(ECHO_CLEAN)
 	$(QUIET) $(foreach TARGET,$(SUBDIRS), \
-		$(MAKE) -C $(TARGET) clean)
+		$(MAKE) $(SUBMAKEOPTS) -C $(TARGET) clean)
 	$(QUIET)rm -fr *.o *.ll *.i *.s
 	$(QUIET)rm -f $(TARGET)

--- a/bpf/Makefile.bpf
+++ b/bpf/Makefile.bpf
@@ -32,15 +32,15 @@ check:
 	$(QUIET) sparse -Wsparse-all ${FLAGS} $(ROOT_DIR)/$(RELATIVE_DIR)/*.c
 	$(QUIET) $(CLANG) ${CLANG_FLAGS} --analyze $(ROOT_DIR)/$(RELATIVE_DIR)/*.c
 	$(QUIET) $(foreach SUBDIR,$(SUBDIRS), \
-		$(MAKE) -C $(SUBDIR) $@)
+		$(MAKE) $(SUBMAKEOPTS) -C $(SUBDIR) $@)
 
 preprocess: $(LIB)
 	$(QUIET) $(foreach TARGET,$(shell find $(ROOT_DIR)/$(RELATIVE_DIR)/ -name 'bpf_*.c'), \
 		echo "  GEN   $(patsubst %.c,%.i,${TARGET})"; \
 		${CLANG} $(FLAGS) -E -target bpf -c ${TARGET} -o $(patsubst %.c,%.i,${TARGET}); )
 	$(QUIET) $(foreach SUBDIR,$(SUBDIRS), \
-		$(MAKE) -C $(SUBDIR) $@)
+		$(MAKE) $(SUBMAKEOPTS) -C $(SUBDIR) $@)
 
 assembly: $(BPF_C) $(LIB) $(BPF_ASM)
 	$(QUIET) $(foreach SUBDIR,$(SUBDIRS), \
-		$(MAKE) -C $(SUBDIR) $@)
+		$(MAKE) $(SUBMAKEOPTS) -C $(SUBDIR) $@)


### PR DESCRIPTION
Avoid printing sub-make directories and commands when building with
`make V=0`.