### PR TITLE
datapath: Do not log if svc is not found

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -106,7 +106,7 @@ static __always_inline int ipv6_l3_from_lxc(struct __ctx_buff *ctx,
 	{
 		struct lb6_service *svc;
 
-		if ((svc = lb6_lookup_service(ctx, &key)) != NULL) {
+		if ((svc = lb6_lookup_service(&key)) != NULL) {
 			ret = lb6_local(get_ct_map6(tuple), ctx, l3_off, l4_off,
 					&csum_off, &key, tuple, svc, &ct_state_new);
 			if (IS_ERR(ret))
@@ -457,7 +457,7 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx,
 	{
 		struct lb4_service *svc;
 
-		if ((svc = lb4_lookup_service(ctx, &key)) != NULL) {
+		if ((svc = lb4_lookup_service(&key)) != NULL) {
 			ret = lb4_local(get_ct_map4(&tuple), ctx, l3_off, l4_off, &csum_off,
 					&key, &tuple, svc, &ct_state_new, ip4->saddr);
 			if (IS_ERR(ret))

--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -225,7 +225,7 @@ struct lb4_service *sock4_nodeport_wildcard_lookup(struct lb4_key *key __maybe_u
 	return NULL;
 wildcard_lookup:
 	key->address = 0;
-	return __lb4_lookup_service(key);
+	return lb4_lookup_service(key);
 #else
 	return NULL;
 #endif /* ENABLE_NODEPORT */
@@ -250,7 +250,7 @@ static __always_inline int __sock4_xlate(struct bpf_sock_addr *ctx,
 	 * nodeport services. If latter fails, we try wildcarded
 	 * lookup for nodeport services.
 	 */
-	svc = __lb4_lookup_service(&key);
+	svc = lb4_lookup_service(&key);
 	if (!svc) {
 		key.dport = ctx_dst_port(ctx);
 
@@ -316,7 +316,7 @@ static __always_inline int __sock4_post_bind(struct bpf_sock *ctx)
 	if (!sock_proto_enabled(ctx->protocol))
 		return 0;
 
-	svc = __lb4_lookup_service(&key);
+	svc = lb4_lookup_service(&key);
 	if (!svc) {
 		/* Perform a wildcard lookup for the case where the caller tries
 		 * to bind to loopback or an address with host identity
@@ -358,7 +358,7 @@ static __always_inline int __sock4_xlate_snd(struct bpf_sock_addr *ctx,
 	struct lb4_service *svc;
 	struct lb4_service *slave_svc;
 
-	svc = __lb4_lookup_service(&lkey);
+	svc = lb4_lookup_service(&lkey);
 	if (!svc) {
 		lkey.dport = ctx_dst_port(ctx);
 		svc = sock4_nodeport_wildcard_lookup(&lkey, true);
@@ -422,7 +422,7 @@ static __always_inline int __sock4_xlate_rcv(struct bpf_sock_addr *ctx,
 			.dport		= rval->port,
 		};
 
-		svc = __lb4_lookup_service(&lkey);
+		svc = lb4_lookup_service(&lkey);
 		if (!svc || svc->rev_nat_index != rval->rev_nat_index) {
 			map_delete_elem(&LB4_REVERSE_NAT_SK_MAP, &rkey);
 			update_metrics(0, METRIC_INGRESS, REASON_LB_REVNAT_STALE);
@@ -578,7 +578,7 @@ sock6_nodeport_wildcard_lookup(struct lb6_key *key __maybe_unused,
 	return NULL;
 wildcard_lookup:
 	__builtin_memset(&key->address, 0, sizeof(key->address));
-	return __lb6_lookup_service(key);
+	return lb6_lookup_service(key);
 #else
 	return NULL;
 #endif /* ENABLE_NODEPORT */
@@ -647,7 +647,7 @@ static __always_inline int __sock6_post_bind(struct bpf_sock *ctx)
 
 	ctx_get_v6_src_address(ctx, &key.address);
 
-	svc = __lb6_lookup_service(&key);
+	svc = lb6_lookup_service(&key);
 	if (!svc) {
 		key.dport = ctx_src_port(ctx);
 		svc = sock6_nodeport_wildcard_lookup(&key, false);
@@ -688,7 +688,7 @@ static __always_inline int __sock6_xlate(struct bpf_sock_addr *ctx)
 	ctx_get_v6_address(ctx, &key.address);
 	v6_orig = key.address;
 
-	svc = __lb6_lookup_service(&key);
+	svc = lb6_lookup_service(&key);
 	if (!svc) {
 		key.dport = ctx_dst_port(ctx);
 
@@ -786,7 +786,7 @@ static __always_inline int __sock6_xlate_snd(struct bpf_sock_addr *ctx)
 	ctx_get_v6_address(ctx, &lkey.address);
 	v6_orig = lkey.address;
 
-	svc = __lb6_lookup_service(&lkey);
+	svc = lb6_lookup_service(&lkey);
 	if (!svc) {
 		lkey.dport = ctx_dst_port(ctx);
 
@@ -886,7 +886,7 @@ static __always_inline int __sock6_xlate_rcv(struct bpf_sock_addr *ctx)
 			.dport		= rval->port,
 		};
 
-		svc = __lb6_lookup_service(&lkey);
+		svc = lb6_lookup_service(&lkey);
 		if (!svc || svc->rev_nat_index != rval->rev_nat_index) {
 			map_delete_elem(&LB6_REVERSE_NAT_SK_MAP, &rkey);
 			update_metrics(0, METRIC_INGRESS, REASON_LB_REVNAT_STALE);

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -324,7 +324,7 @@ static __always_inline int lb6_extract_key(struct __ctx_buff *ctx __maybe_unused
 }
 
 static __always_inline
-struct lb6_service *__lb6_lookup_service(struct lb6_key *key)
+struct lb6_service *lb6_lookup_service(struct lb6_key *key)
 {
 	key->slave = 0;
 #ifdef LB_L4
@@ -353,19 +353,6 @@ struct lb6_service *__lb6_lookup_service(struct lb6_key *key)
 	}
 #endif
 	return NULL;
-}
-
-static __always_inline
-struct lb6_service *lb6_lookup_service(struct __ctx_buff *ctx __maybe_unused,
-				       struct lb6_key *key)
-{
-	struct lb6_service *svc = __lb6_lookup_service(key);
-
-
-	if (!svc)
-		cilium_dbg_lb(ctx, DBG_LB6_LOOKUP_MASTER_FAIL, 0, 0);
-
-	return svc;
 }
 
 static __always_inline struct lb6_backend *__lb6_lookup_backend(__u16 backend_id)
@@ -512,7 +499,7 @@ static __always_inline int lb6_local(void *map, struct __ctx_buff *ctx,
 	 */
 	if (!(backend = lb6_lookup_backend(ctx, state->backend_id))) {
 		key->slave = 0;
-		if (!(svc = lb6_lookup_service(ctx, key))) {
+		if (!(svc = lb6_lookup_service(key))) {
 			goto drop_no_service;
 		}
 		slave = lb6_select_slave(svc->count);
@@ -548,7 +535,7 @@ drop_no_service:
  * additional map management.
  */
 static __always_inline
-struct lb6_service *__lb6_lookup_service(struct lb6_key *key __maybe_unused)
+struct lb6_service *lb6_lookup_service(struct lb6_key *key __maybe_unused)
 {
 	return NULL;
 }
@@ -693,7 +680,7 @@ static __always_inline int lb4_extract_key(struct __ctx_buff *ctx __maybe_unused
 }
 
 static __always_inline
-struct lb4_service *__lb4_lookup_service(struct lb4_key *key)
+struct lb4_service *lb4_lookup_service(struct lb4_key *key)
 {
 	key->slave = 0;
 #ifdef LB_L4
@@ -722,18 +709,6 @@ struct lb4_service *__lb4_lookup_service(struct lb4_key *key)
 	}
 #endif
 	return NULL;
-}
-
-static __always_inline
-struct lb4_service *lb4_lookup_service(struct __ctx_buff *ctx __maybe_unused,
-				       struct lb4_key *key)
-{
-	struct lb4_service *svc = __lb4_lookup_service(key);
-
-	if (!svc)
-		cilium_dbg_lb(ctx, DBG_LB4_LOOKUP_MASTER_FAIL, 0, 0);
-
-	return svc;
 }
 
 static __always_inline struct lb4_backend *__lb4_lookup_backend(__u16 backend_id)
@@ -904,7 +879,7 @@ static __always_inline int lb4_local(void *map, struct __ctx_buff *ctx,
 	 */
 	if (!(backend = lb4_lookup_backend(ctx, state->backend_id))) {
 		key->slave = 0;
-		if (!(svc = lb4_lookup_service(ctx, key))) {
+		if (!(svc = lb4_lookup_service(key))) {
 			goto drop_no_service;
 		}
 		slave = lb4_select_slave(svc->count);

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -470,7 +470,7 @@ static __always_inline int nodeport_lb6(struct __ctx_buff *ctx,
 			return ret;
 	}
 
-	if ((svc = lb6_lookup_service(ctx, &key)) != NULL) {
+	if ((svc = lb6_lookup_service(&key)) != NULL) {
 		ret = lb6_local(get_ct_map6(&tuple), ctx, l3_off, l4_off,
 				&csum_off, &key, &tuple, svc, &ct_state_new);
 		if (IS_ERR(ret))
@@ -1028,7 +1028,7 @@ static __always_inline int nodeport_lb4(struct __ctx_buff *ctx,
 			return ret;
 	}
 
-	if ((svc = lb4_lookup_service(ctx, &key)) != NULL) {
+	if ((svc = lb4_lookup_service(&key)) != NULL) {
 		ret = lb4_local(get_ct_map4(&tuple), ctx, l3_off, l4_off, &csum_off,
 				&key, &tuple, svc, &ct_state_new, ip4->saddr);
 		if (IS_ERR(ret))

--- a/bpf/sockops/bpf_sockops.c
+++ b/bpf/sockops/bpf_sockops.c
@@ -66,7 +66,7 @@ static inline void bpf_sock_ops_ipv4(struct bpf_sock_ops *skops)
 	 * pulled in as needed.
 	 */
 	sk_lb4_key(&lb4_key, &key);
-	svc = __lb4_lookup_service(&lb4_key);
+	svc = lb4_lookup_service(&lb4_key);
 	if (svc)
 		return;
 


### PR DESCRIPTION
We used to log (via cilium_dbg) when a packet dst IP + port did not
match any service, e.g:

    CPU 20: MARK 0xbc243a3b FROM 0 DEBUG: Master service lookup failed, addr.p2=0 addr.p3=0

This added a lot of noise to `cilium monitor -D` output, especially when
bpf_netdev.o was attached to a native device (e.g when BPF NodePort was
enabled), as any inbound packet does a service lookup.

This commit removes the logging when a svc is not found. The fact that
a svc is not found can be deduced from a missing lookup svc endpoint log
message.