### PR TITLE
bpf: check for cilium-map-migrate instead of cilium CLI client in ini…

### DIFF
--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -45,8 +45,8 @@ set -e
 set -x
 set -o pipefail
 
-if [[ ! $(command -v cilium) ]]; then
-	echo "Can't be initialized because 'cilium' is not in the path."
+if [[ ! $(command -v cilium-map-migrate) ]]; then
+	echo "Can't be initialized because 'cilium-map-migrate' is not in the path."
 	exit 1
 fi
 


### PR DESCRIPTION
The `cilium` CLI is no longer used by init.sh since commit 1c18d1da0526
("cache: Support looking up reserved identities"). Instead check for
cilium-map-migrate which is used in several places.