### PR TITLE
bpf: Remove unused code

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -92,8 +92,6 @@ static __always_inline int ipv6_l3_from_lxc(struct __ctx_buff *ctx,
 			return ret;
 	}
 
-	ct_state_new.orig_dport = key.dport;
-
 	/*
 	 * Check if the destination address is among the address that should be
 	 * load balanced. This operation is performed before we go through the
@@ -451,7 +449,6 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx,
 			return ret;
 	}
 
-	ct_state_new.orig_dport = key.dport;
 #ifdef ENABLE_SERVICES
 # if !defined(ENABLE_HOST_SERVICES_FULL) || defined(ENABLE_EXTERNAL_IP)
 	{
@@ -879,7 +876,6 @@ ipv6_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label, __u8 *reason,
 		ct_state_new.dsr = dsr;
 #endif /* ENABLE_DSR */
 
-		ct_state_new.orig_dport = tuple.dport;
 		ct_state_new.src_sec_id = src_label;
 		ct_state_new.node_port = ct_state.node_port;
 		ret = ct_create6(get_ct_map6(&tuple), &tuple, ctx, CT_INGRESS, &ct_state_new, verdict > 0);
@@ -1088,7 +1084,6 @@ ipv4_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label, __u8 *reason,
 		ct_state_new.dsr = dsr;
 #endif /* ENABLE_DSR */
 
-		ct_state_new.orig_dport = tuple.dport;
 		ct_state_new.src_sec_id = src_label;
 		ct_state_new.node_port = ct_state.node_port;
 		ret = ct_create4(get_ct_map4(&tuple), &tuple, ctx, CT_INGRESS, &ct_state_new, verdict > 0);

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -60,7 +60,6 @@ static __always_inline int ipv6_l3_from_lxc(struct __ctx_buff *ctx,
 #endif
 	int ret, verdict, l4_off, hdrlen;
 	struct csum_offset csum_off = {};
-	struct lb6_key key = {};
 	struct ct_state ct_state_new = {};
 	struct ct_state ct_state = {};
 	void *data, *data_end;
@@ -84,14 +83,6 @@ static __always_inline int ipv6_l3_from_lxc(struct __ctx_buff *ctx,
 
 	l4_off = l3_off + hdrlen;
 
-	ret = lb6_extract_key(ctx, tuple, l4_off, &key, &csum_off, CT_EGRESS);
-	if (IS_ERR(ret)) {
-		if (ret == DROP_UNKNOWN_L4)
-			goto skip_service_lookup;
-		else
-			return ret;
-	}
-
 	/*
 	 * Check if the destination address is among the address that should be
 	 * load balanced. This operation is performed before we go through the
@@ -103,6 +94,15 @@ static __always_inline int ipv6_l3_from_lxc(struct __ctx_buff *ctx,
 # if !defined(ENABLE_HOST_SERVICES_FULL) || defined(ENABLE_EXTERNAL_IP)
 	{
 		struct lb6_service *svc;
+		struct lb6_key key = {};
+
+		ret = lb6_extract_key(ctx, tuple, l4_off, &key, &csum_off, CT_EGRESS);
+		if (IS_ERR(ret)) {
+			if (ret == DROP_UNKNOWN_L4)
+				goto skip_service_lookup;
+			else
+				return ret;
+		}
 
 		if ((svc = lb6_lookup_service(ctx, &key)) != NULL) {
 			ret = lb6_local(get_ct_map6(tuple), ctx, l3_off, l4_off,
@@ -112,10 +112,11 @@ static __always_inline int ipv6_l3_from_lxc(struct __ctx_buff *ctx,
 			hairpin_flow |= ct_state_new.loopback;
 		}
 	}
+
+skip_service_lookup:
 # endif /* !ENABLE_HOST_SERVICES_FULL || ENABLE_EXTERNAL_IP*/
 #endif /* ENABLE_SERVICES */
 
-skip_service_lookup:
 	/* The verifier wants to see this assignment here in case the above goto
 	 * skip_service_lookup is hit. However, in the case the packet
 	 * is _not_ TCP or UDP we should not be using proxy logic anyways. For
@@ -417,7 +418,6 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx,
 	struct iphdr *ip4;
 	int ret, verdict, l3_off = ETH_HLEN, l4_off;
 	struct csum_offset csum_off = {};
-	struct lb4_key key = {};
 	struct ct_state ct_state_new = {};
 	struct ct_state ct_state = {};
 	__be32 orig_dip;
@@ -441,18 +441,20 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx,
 
 	l4_off = l3_off + ipv4_hdrlen(ip4);
 
-	ret = lb4_extract_key(ctx, &tuple, l4_off, &key, &csum_off, CT_EGRESS);
-	if (IS_ERR(ret)) {
-		if (ret == DROP_UNKNOWN_L4)
-			goto skip_service_lookup;
-		else
-			return ret;
-	}
-
 #ifdef ENABLE_SERVICES
 # if !defined(ENABLE_HOST_SERVICES_FULL) || defined(ENABLE_EXTERNAL_IP)
 	{
 		struct lb4_service *svc;
+		struct lb4_key key = {};
+
+		ret = lb4_extract_key(ctx, &tuple, l4_off, &key, &csum_off,
+				      CT_EGRESS);
+		if (IS_ERR(ret)) {
+			if (ret == DROP_UNKNOWN_L4)
+				goto skip_service_lookup;
+			else
+				return ret;
+		}
 
 		if ((svc = lb4_lookup_service(ctx, &key)) != NULL) {
 			ret = lb4_local(get_ct_map4(&tuple), ctx, l3_off, l4_off, &csum_off,
@@ -462,10 +464,11 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx,
 			hairpin_flow |= ct_state_new.loopback;
 		}
 	}
+
+skip_service_lookup:
 # endif /* !ENABLE_HOST_SERVICES_FULL || ENABLE_EXTERNAL_IP */
 #endif /* ENABLE_SERVICES */
 
-skip_service_lookup:
 	/* The verifier wants to see this assignment here in case the above goto
 	 * skip_service_lookup is hit. However, in the case the packet
 	 * is _not_ TCP or UDP we should not be using proxy logic anyways. For

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -619,7 +619,6 @@ struct ct_state {
 	      proxy_redirect:1, // Connection is redirected to a proxy
 	      dsr:1,
 	      reserved:12;
-	__be16 orig_dport;
 	__be32 addr;
 	__be32 svc_addr;
 	__u32 src_sec_id;


### PR DESCRIPTION
The first commit removes the `orig_dport` field of `struct ct_state`, which seems unused. The second commit moves the `lb{4,6}_extract_key()` call inside the `# if !defined(ENABLE_HOST_SERVICES_FULL) || defined(ENABLE_EXTERNAL_IP)` section; the call is unnecessary if those conditions are not met.