### PR TITLE
contrib, docs: fixes for the backporting guide and script README

### DIFF
--- a/Documentation/contributing/release/backports.rst
+++ b/Documentation/contributing/release/backports.rst
@@ -1,5 +1,5 @@
 .. only:: not (epub or latex or html)
-  
+
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
     http://docs.cilium.io
@@ -15,7 +15,7 @@ Backport Criteria
 -----------------
 
 Committers may nominate PRs that have been merged into master as candidates for
-backport into stable_releases if they affect the stable production usage
+backport into stable releases if they affect the stable production usage
 of community users.
 
 Backport criteria for current minor release
@@ -55,8 +55,8 @@ process for backporting these PRs:
 One-time setup
 ~~~~~~~~~~~~~~
 
-#. The scripts referred to below need to be run in Linux, they do not
-   work on OSX.  You can use the cilium dev VM for this, but you need
+#. The scripts referred to below need to be run on Linux, they do not
+   work on macOS. You can use the cilium dev VM for this, but you need
    to configure git to have your name and email address to be used in
    the commit messages:
 
@@ -65,8 +65,8 @@ One-time setup
       $ git config --global user.name "John Doe"
       $ git config --global user.email johndoe@example.com
 
-#. Make sure you have your a GitHub developer access token
-   available. For details, see `contrib/backporting/README.md
+#. Make sure you have a GitHub developer access token with the ``public_repos``
+   scope available. For details, see `contrib/backporting/README.md
    <https://github.com/cilium/cilium/blob/master/contrib/backporting/README.md>`_
 
 #. This guide makes use of several tools to automate the backporting process.
@@ -79,6 +79,8 @@ One-time setup
    | bash                                                         | Yes       | N/A (OS-specific)                                       |
    +--------------------------------------------------------------+-----------+---------------------------------------------------------+
    | git                                                          | Yes       | N/A (OS-specific)                                       |
+   +--------------------------------------------------------------+-----------+---------------------------------------------------------+
+   | jq                                                           | Yes       | N/A (OS-specific)                                       |
    +--------------------------------------------------------------+-----------+---------------------------------------------------------+
    | python3                                                      | No        | `Python Downloads <https://www.python.org/downloads/>`_ |
    +--------------------------------------------------------------+-----------+---------------------------------------------------------+

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -329,6 +329,7 @@ jgt
 jle
 jlt
 jne
+jq
 js
 jset
 jsge

--- a/contrib/backporting/README.md
+++ b/contrib/backporting/README.md
@@ -17,11 +17,11 @@ branch is then needed for backporting into downstream with the help of the
 ## Example
 
 1. Generate a GitHub developer access token.
-   You can access directly from https://github.com/settings/tokens or
-   by open GitHub page and then: User Profile -> Settings ->
+   You can do this directly from https://github.com/settings/tokens or
+   by opening GitHub and then navigating to: User Profile -> Settings ->
    Developer Settings -> Personal access token -> Generate new token
 
-   The access token requires access to `public_repo`.
+   The access token requires access to the `public_repo` scope.
 
    If not already done, install `jq` on your system.
 


### PR DESCRIPTION
Add `jq` to backport one-time setup dependencies. It is used in the
`contrib/backporting/check-stable` script.

Also fix some minor grammatical issues.