### PR TITLE
Improve k8s client heartbeat capability

### DIFF
--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -113,11 +113,14 @@ func CreateConfig() (*rest.Config, error) {
 }
 
 func setDialer(config *rest.Config) func() {
-	context := (&net.Dialer{
+	if option.Config.K8sHeartbeatTimeout == 0 {
+		return func() {}
+	}
+	ctx := (&net.Dialer{
 		Timeout:   option.Config.K8sHeartbeatTimeout,
 		KeepAlive: option.Config.K8sHeartbeatTimeout,
 	}).DialContext
-	dialer := connrotation.NewDialer(context)
+	dialer := connrotation.NewDialer(ctx)
 	config.Dial = dialer.DialContext
 	return dialer.CloseAll
 }

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -17,19 +17,23 @@
 package k8s
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net"
+	"net/http"
 	"time"
 
 	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/checker"
+	k8smetrics "github.com/cilium/cilium/pkg/k8s/metrics"
 	"github.com/cilium/cilium/pkg/k8s/types"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/source"
 
 	. "gopkg.in/check.v1"
 	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
@@ -173,5 +177,127 @@ func (s *K8sSuite) TestUseNodeCIDR(c *C) {
 	case <-time.Tick(10 * time.Second):
 		c.Errorf("d.fakeK8sClient.CoreV1().Nodes().Update() was not called")
 		c.FailNow()
+	}
+}
+
+func (s *K8sSuite) Test_runHeartbeat(c *C) {
+	// k8s api server never replied back in the expected time. We should close all connections
+	k8smetrics.LastSuccessInteraction.Reset()
+	time.Sleep(2 * time.Millisecond)
+
+	called := make(chan struct{})
+	runHeartbeat(
+		func(ctx context.Context) error {
+			<-ctx.Done()
+			return nil
+		},
+		time.Millisecond,
+		func() {
+			close(called)
+		},
+	)
+
+	select {
+	case <-time.After(5 * time.Millisecond):
+		c.Error("Heartbeat should have closed all connections")
+	case <-called:
+	}
+
+	// There are some connectivity issues, cilium is trying to reach kube-apiserver
+	// but it's only receiving errors. We should close all connections!
+
+	// Wait the double amount of time than the timeout to make sure
+	// LastSuccessInteraction is not taken into account and we will see that we
+	// will close all connections.
+	time.Sleep(200 * time.Millisecond)
+
+	called = make(chan struct{})
+	runHeartbeat(
+		func(ctx context.Context) error {
+			<-ctx.Done()
+			return nil
+		},
+		100*time.Millisecond,
+		func() {
+			close(called)
+		},
+	)
+
+	select {
+	case <-time.After(200 * time.Millisecond):
+		c.Error("Heartbeat should have closed all connections")
+	case <-called:
+	}
+
+	// Cilium is successfully talking with kube-apiserver, we should not do
+	// anything.
+	k8smetrics.LastSuccessInteraction.Reset()
+
+	called = make(chan struct{})
+	runHeartbeat(
+		func(ctx context.Context) error {
+			close(called)
+			return nil
+		},
+		100*time.Millisecond,
+		func() {
+			c.Error("This should not have been called!")
+		},
+	)
+
+	select {
+	case <-time.After(200 * time.Millisecond):
+	case <-called:
+		c.Error("Heartbeat should have closed all connections")
+	}
+
+	// Cilium had the last interaction with kube-apiserver a long time ago.
+	// We should perform a heartbeat
+	k8smetrics.LastInteraction.Reset()
+	time.Sleep(500 * time.Millisecond)
+
+	called = make(chan struct{})
+	runHeartbeat(
+		func(ctx context.Context) error {
+			close(called)
+			return nil
+		},
+		100*time.Millisecond,
+		func() {
+			c.Error("This should not have been called!")
+		},
+	)
+
+	select {
+	case <-time.After(200 * time.Millisecond):
+		c.Error("Heartbeat should have closed all connections")
+	case <-called:
+	}
+
+	// Cilium had the last interaction with kube-apiserver a long time ago.
+	// We should perform a heartbeat but the heart beat will return
+	// an error so we should close all connections
+	k8smetrics.LastInteraction.Reset()
+	time.Sleep(500 * time.Millisecond)
+
+	called = make(chan struct{})
+	runHeartbeat(
+		func(ctx context.Context) error {
+			return &errors.StatusError{
+				ErrStatus: metav1.Status{
+					Code: http.StatusRequestTimeout,
+				},
+			}
+		},
+		100*time.Millisecond,
+		func() {
+			close(called)
+		},
+	)
+
+	select {
+	case <-time.After(200 * time.Millisecond):
+		c.Error("Heartbeat should have closed all connections")
+	case <-called:
 	}
 }

--- a/pkg/k8s/init.go
+++ b/pkg/k8s/init.go
@@ -113,7 +113,7 @@ func useNodeCIDR(n *node.Node) {
 // Init initializes the Kubernetes package. It is required to call Configure()
 // beforehand.
 func Init() error {
-	closeAllDefaultClientConns, err := createDefaultClient()
+	k8sRestClient, closeAllDefaultClientConns, err := createDefaultClient()
 	if err != nil {
 		return fmt.Errorf("unable to create k8s client: %s", err)
 	}
@@ -123,10 +123,12 @@ func Init() error {
 		return fmt.Errorf("unable to create cilium k8s client: %s", err)
 	}
 
-	runHeartbeat([]func(){
-		closeAllDefaultClientConns,
-		closeAllCiliumClientConns,
-	}, make(chan struct{}))
+	runHeartbeat(
+		k8sRestClient,
+		[]func(){
+			closeAllDefaultClientConns,
+			closeAllCiliumClientConns,
+		}, make(chan struct{}))
 
 	if err := k8sversion.Update(Client()); err != nil {
 		return err

--- a/pkg/k8s/init.go
+++ b/pkg/k8s/init.go
@@ -134,20 +134,22 @@ func Init() error {
 		return res.Error()
 	}
 
-	controller.NewManager().UpdateController("k8s-heartbeat",
-		controller.ControllerParams{
-			DoFunc: func(context.Context) error {
-				runHeartbeat(
-					heartBeat,
-					option.Config.K8sHeartbeatTimeout,
-					closeAllDefaultClientConns,
-					closeAllCiliumClientConns,
-				)
-				return nil
+	if option.Config.K8sHeartbeatTimeout != 0 {
+		controller.NewManager().UpdateController("k8s-heartbeat",
+			controller.ControllerParams{
+				DoFunc: func(context.Context) error {
+					runHeartbeat(
+						heartBeat,
+						option.Config.K8sHeartbeatTimeout,
+						closeAllDefaultClientConns,
+						closeAllCiliumClientConns,
+					)
+					return nil
+				},
+				RunInterval: option.Config.K8sHeartbeatTimeout,
 			},
-			RunInterval: option.Config.K8sHeartbeatTimeout,
-		},
-	)
+		)
+	}
 
 	if err := k8sversion.Update(Client()); err != nil {
 		return err

--- a/pkg/k8s/metrics/metrics.go
+++ b/pkg/k8s/metrics/metrics.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Authors of Cilium
+// Copyright 2019-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,6 +24,9 @@ var (
 	// LastInteraction is the time at which the last apiserver interaction
 	// occurred
 	LastInteraction eventTimestamper
+	// LastSuccessInteraction is the time at which we have received a successful
+	// k8s apiserver reply (i.e. a response code 2xx or 4xx).
+	LastSuccessInteraction eventTimestamper
 )
 
 type eventTimestamper struct {


### PR DESCRIPTION
Switched the heartbeat to be done on `/healthz` instead of doing a get
on kube-system namespace which has higher overhead than `/heatlhz`.

If Cilium has interactions with k8s, Cilium does not need to
perform heatbeats to the kube-apiserver. Unless those interactions
result in an error for which we should perform a heartbeat to
kube-apiserver to check if the connection is still alive. In case the
response from kube-apiserver is an error Cilium should then close all
connections with the kube-apiserver.

Read per commit for more details

follow up of https://github.com/cilium/cilium/pull/10184