### PR TITLE
Decrease CRD setup API calls when starting cilium-agent

### DIFF
--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -533,7 +533,9 @@ func createUpdateCRD(clientset apiextensionsclient.Interface, CRDName string, cr
 	}
 
 	scopedLog.Debug("Checking if CRD (CustomResourceDefinition) needs update...")
-	if needsUpdate(clusterCRD) {
+	if crd.Spec.Validation != nil &&
+		clusterCRD.Labels[CustomResourceDefinitionSchemaVersionKey] != "" &&
+		needsUpdate(clusterCRD) {
 		scopedLog.Info("Updating CRD (CustomResourceDefinition)...")
 		// Update the CRD with the validation schema.
 		err = wait.Poll(500*time.Millisecond, 60*time.Second, func() (bool, error) {

--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -572,11 +572,7 @@ func createUpdateCRD(clientset apiextensionsclient.Interface, CRDName string, cr
 	// wait for the CRD to be established
 	scopedLog.Debug("Waiting for CRD (CustomResourceDefinition) to be available...")
 	err = wait.Poll(500*time.Millisecond, 60*time.Second, func() (bool, error) {
-		crd, err := clientset.ApiextensionsV1beta1().CustomResourceDefinitions().Get(context.TODO(), crd.ObjectMeta.Name, metav1.GetOptions{})
-		if err != nil {
-			return false, err
-		}
-		for _, cond := range crd.Status.Conditions {
+		for _, cond := range clusterCRD.Status.Conditions {
 			switch cond.Type {
 			case apiextensionsv1beta1.Established:
 				if cond.Status == apiextensionsv1beta1.ConditionTrue {
@@ -588,6 +584,10 @@ func createUpdateCRD(clientset apiextensionsclient.Interface, CRDName string, cr
 					return false, err
 				}
 			}
+		}
+		clusterCRD, err = clientset.ApiextensionsV1beta1().CustomResourceDefinitions().Get(context.TODO(), crd.ObjectMeta.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
 		}
 		return false, err
 	})


### PR DESCRIPTION
This commit reduces the number of unnecessary API calls being executed when initializing Cilium.

Number of API calls made when starting before this PR (10 GETs and 2 PUTs):
```
GET /apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/ciliumnetworkpolicies.cilium.io
GET /apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/ciliumnetworkpolicies.cilium.io
GET /apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/ciliumclusterwidenetworkpolicies.cilium.io
GET /apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/ciliumclusterwidenetworkpolicies.cilium.io
GET /apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/ciliumendpoints.cilium.io
GET /apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/ciliumendpoints.cilium.io
PUT /apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/ciliumendpoints.cilium.io
GET /apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/ciliumendpoints.cilium.io
GET /apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/ciliumnodes.cilium.io
GET /apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/ciliumnodes.cilium.io
PUT /apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/ciliumnodes.cilium.io
GET /apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/ciliumnodes.cilium.io
```


Number of API calls made when starting after this PR (4 GETs):
```
GET /apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/ciliumnetworkpolicies.cilium.io
GET /apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/ciliumclusterwidenetworkpolicies.cilium.io
GET /apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/ciliumendpoints.cilium.io
GET /apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/ciliumnodes.cilium.io
```