### PR TITLE
Use arbitrary non-root user in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,5 +50,4 @@ RUN groupadd -f cilium \
     && cilium completion bash >> /root/.bashrc \
     && sysctl -w kernel.core_pattern=/tmp/core.%e.%p.%t
 ENV INITSYSTEM="SYSTEMD"
-USER 65534
 CMD ["/usr/bin/cilium"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,4 +50,5 @@ RUN groupadd -f cilium \
     && cilium completion bash >> /root/.bashrc \
     && sysctl -w kernel.core_pattern=/tmp/core.%e.%p.%t
 ENV INITSYSTEM="SYSTEMD"
+USER 65534
 CMD ["/usr/bin/cilium"]

--- a/install/kubernetes/cilium/charts/agent/templates/podsecuritypolicy.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/podsecuritypolicy.yaml
@@ -20,7 +20,12 @@ spec:
   hostIPC: false
   hostPID: false
   runAsUser:
+    # Require the container to run without root privileges.
+    {{- if and .Values.global.psp .Values.runAsUnprivilegedUser}}  
+    rule: 'MustRunAsNonRoot'
+    {{else }}
     rule: 'RunAsAny'
+    {{end}}
   seLinux:
     rule: RunAsAny
   supplementalGroups:

--- a/install/kubernetes/cilium/charts/operator/templates/podsecuritypolicy.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/podsecuritypolicy.yaml
@@ -18,7 +18,12 @@ spec:
   hostIPC: false
   hostPID: false
   runAsUser:
+    # Require the container to run without root privileges.
+    {{- if and .Values.global.psp .Values.runAsUnprivilegedUser}} 
+    rule: 'MustRunAsNonRoot'
+    {{else }}
     rule: 'RunAsAny'
+    {{end}}
   seLinux:
     rule: 'RunAsAny'
   supplementalGroups:

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -372,6 +372,7 @@ global:
   # psp creates and binds PodSecurityPolicies for the components that require it
   psp:
     enabled: false
+    runAsUnprivilegedUser: true 
 
   # enables non-drop mode for installed policies. In audit mode
   # packets affected by policies will not be dropped. Policy related


### PR DESCRIPTION
As a minor security improment this PR is introducing to use a arbitrary ( > `UID` 0) non-root user for launching processes in the container. 