### PR TITLE
v1.6 backports 2020-03-24

### DIFF
--- a/Documentation/cmdref/cilium-bugtool.md
+++ b/Documentation/cmdref/cilium-bugtool.md
@@ -31,18 +31,21 @@ cilium-bugtool [OPTIONS] [flags]
 ### Options
 
 ```
-      --archive                 Create archive when false skips deletion of the output directory (default true)
-      --archive-prefix string   String to prefix to name of archive if created (e.g., with cilium pod-name)
-  -o, --archiveType string      Archive type: tar | gz (default "tar")
-      --config string           Configuration to decide what should be run (default "./.cilium-bugtool.config")
-      --dry-run                 Create configuration file of all commands that would have been executed
-      --enable-markdown         Dump output of commands in markdown format
-      --exec-timeout duration   The default timeout for any cmd execution in seconds (default 30s)
-  -h, --help                    help for cilium-bugtool
-  -H, --host string             URI to server-side API
-      --k8s-label string        Kubernetes label for Cilium pod (default "k8s-app=cilium")
-      --k8s-mode                Require Kubernetes pods to be found or fail
-      --k8s-namespace string    Kubernetes namespace for Cilium pod (default "kube-system")
-  -t, --tmp string              Path to store extracted files (default "/tmp")
+      --archive                   Create archive when false skips deletion of the output directory (default true)
+      --archive-prefix string     String to prefix to name of archive if created (e.g., with cilium pod-name)
+  -o, --archiveType string        Archive type: tar | gz (default "tar")
+      --config string             Configuration to decide what should be run (default "./.cilium-bugtool.config")
+      --dry-run                   Create configuration file of all commands that would have been executed
+      --enable-markdown           Dump output of commands in markdown format
+      --exec-timeout duration     The default timeout for any cmd execution in seconds (default 30s)
+      --get-pprof                 When set, only gets the pprof traces from the cilium-agent binary
+  -h, --help                      help for cilium-bugtool
+  -H, --host string               URI to server-side API
+      --k8s-label string          Kubernetes label for Cilium pod (default "k8s-app=cilium")
+      --k8s-mode                  Require Kubernetes pods to be found or fail
+      --k8s-namespace string      Kubernetes namespace for Cilium pod (default "kube-system")
+      --pprof-port int            Port on which pprof server is exposed (default 6060)
+      --pprof-trace-seconds int   Amount of seconds used for pprof CPU traces (default 180)
+  -t, --tmp string                Path to store extracted files (default "/tmp")
 ```
 

--- a/Documentation/install/system_requirements.rst
+++ b/Documentation/install/system_requirements.rst
@@ -50,23 +50,34 @@ Linux Distribution Compatibility Matrix
 The following table lists Linux distributions that are known to work
 well with Cilium.
 
-===================== ====================
-Distribution          Minimum Version
-===================== ====================
-CoreOS_               stable (>= 1298.5.0)
-Debian_               >= 9 Stretch
-`Fedora Atomic/Core`_ >= 25
-LinuxKit_             all
-Ubuntu_               >= 16.04.2, >= 16.10
-Opensuse_             Tumbleweed, >=Leap 15.0
-===================== ====================
+========================== ====================
+Distribution               Minimum Version
+========================== ====================
+`Amazon Linux 2`_          all
+`Container-Optimized OS`_  all
+`CentOS`_                  >= 7.0 [#centos_foot]_
+CoreOS_                    stable (>= 1298.5.0)
+Debian_                    >= 9 Stretch
+`Fedora Atomic/Core`_      >= 25
+LinuxKit_                  all
+`RedHat Enterprise Linux`_ >= 8.0
+Ubuntu_                    >= 16.04.2, >= 16.10
+Opensuse_                  Tumbleweed, >=Leap 15.0
+========================== ====================
 
+.. _Amazon Linux 2: https://aws.amazon.com/amazon-linux-2/
+.. _CentOS: https://centos.org
+.. _Container-Optimized OS: https://cloud.google.com/container-optimized-os/docs
 .. _CoreOS: https://coreos.com/releases/
 .. _Debian: https://wiki.debian.org/DebianStretch
 .. _Fedora Atomic/Core: http://www.projectatomic.io/blog/2017/03/fedora_atomic_2week_2/
 .. _LinuxKit: https://github.com/linuxkit/linuxkit/tree/master/kernel
+.. _RedHat Enterprise Linux: https://www.redhat.com/en/technologies/linux-platforms/enterprise-linux
 .. _Ubuntu: https://wiki.ubuntu.com/YakketyYak/ReleaseNotes#Linux_kernel_4.8
 .. _Opensuse: https://www.opensuse.org/
+
+.. [#centos_foot] CentOS 7 requires a third-party kernel provided by `ElRepo <http://elrepo.org/tiki/tiki-index.php>`_
+    whereas CentOS 8 ships with a supported kernel.
 
 .. note:: The above list is based on feedback by users. If you find an unlisted
           Linux distribution that works well, please let us know by opening a
@@ -132,6 +143,22 @@ by adding the following to the helm configuration command line:
      ...
      --set global.enableXTSocketFallback=false
    > cilium.yaml
+
+Advanced Features and Required Kernel Version
+=============================================
+Cilium requires Linux kernel 4.9.17 or higher, however development on additional
+kernel features and functionality continues to progress in the Linux community.
+Some Cilium features and functionality are dependent on newer kernel versions.
+These additional Cilium features and functionality are enabled by upgrading to
+a later kernel version as detailed below:
+
+======================= ===============================
+Cilium Feature          Minimum Kernel Version
+======================= ===============================
+:ref:`cidr_limitations` >= 4.11
+:ref:`host-services`    >= 4.19.57, >= 5.1.16,  >= 5.2
+:ref:`kubeproxy-free`   >= 4.19.57, >= 5.1.16,  >= 5.2
+======================= ===============================
 
 .. _req_kvstore:
 
@@ -246,9 +273,9 @@ ICMP 8/0                 egress          ``worker-sg`` (self) health checks
 2379-2380/tcp            egress          ``master-sg``        etcd access
 ======================== =============== ==================== ===============
 
-.. note:: If you use a shared SG for the masters and workers, you can condense 
-          these rules into ingress/egress to self. If you are using Direct 
-          Routing mode, you can condense all rules into ingress/egress ANY 
+.. note:: If you use a shared SG for the masters and workers, you can condense
+          these rules into ingress/egress to self. If you are using Direct
+          Routing mode, you can condense all rules into ingress/egress ANY
           port/protocol to/from self.
 
 Privileges

--- a/bugtool/cmd/root.go
+++ b/bugtool/cmd/root.go
@@ -17,7 +17,9 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"io"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -25,6 +27,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cilium/cilium/pkg/components"
 	"github.com/cilium/cilium/pkg/defaults"
 
 	"github.com/spf13/cobra"
@@ -72,10 +75,16 @@ var (
 	dryRunMode     bool
 	enableMarkdown bool
 	archivePrefix  string
+	getPProf       bool
+	pprofPort      int
+	traceSeconds   int
 )
 
 func init() {
 	BugtoolRootCmd.Flags().BoolVar(&archive, "archive", true, "Create archive when false skips deletion of the output directory")
+	BugtoolRootCmd.Flags().BoolVar(&getPProf, "get-pprof", false, "When set, only gets the pprof traces from the cilium-agent binary")
+	BugtoolRootCmd.Flags().IntVar(&pprofPort, "pprof-port", 6060, "Port on which pprof server is exposed")
+	BugtoolRootCmd.Flags().IntVar(&traceSeconds, "pprof-trace-seconds", 180, "Amount of seconds used for pprof CPU traces")
 	BugtoolRootCmd.Flags().StringVarP(&archiveType, "archiveType", "o", "tar", "Archive type: tar | gz")
 	BugtoolRootCmd.Flags().BoolVar(&k8s, "k8s-mode", false, "Require Kubernetes pods to be found or fail")
 	BugtoolRootCmd.Flags().BoolVar(&dryRunMode, "dry-run", false, "Create configuration file of all commands that would have been executed")
@@ -180,18 +189,26 @@ func runTool() {
 		return
 	}
 
-	// Check if there is a user supplied configuration
-	if config, _ := loadConfigFile(configPath); config != nil {
-		// All of of the commands run are from the configuration file
-		commands = config.Commands
-	}
-	if len(commands) == 0 {
-		// Found no configuration file or empty so fall back to default commands.
-		commands = defaultCommands(confDir, cmdDir, k8sPods)
-	}
-	defer printDisclaimer()
+	if getPProf {
+		err := pprofTraces(cmdDir)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to create debug directory %s\n", err)
+			os.Exit(1)
+		}
+	} else {
+		// Check if there is a user supplied configuration
+		if config, _ := loadConfigFile(configPath); config != nil {
+			// All of of the commands run are from the configuration file
+			commands = config.Commands
+		}
+		if len(commands) == 0 {
+			// Found no configuration file or empty so fall back to default commands.
+			commands = defaultCommands(confDir, cmdDir, k8sPods)
+		}
+		defer printDisclaimer()
 
-	runAll(commands, cmdDir, k8sPods)
+		runAll(commands, cmdDir, k8sPods)
+	}
 
 	removeIfEmpty(cmdDir)
 	removeIfEmpty(confDir)
@@ -411,4 +428,65 @@ func getCiliumPods(namespace, label string) ([]string, error) {
 	}
 
 	return ciliumPods, nil
+}
+
+func pprofTraces(rootDir string) error {
+	var wg sync.WaitGroup
+	var profileErr error
+	pprofHost := fmt.Sprintf("localhost:%d", pprofPort)
+	wg.Add(1)
+	go func() {
+		url := fmt.Sprintf("http://%s/debug/pprof/profile?seconds=%d", pprofHost, traceSeconds)
+		dir := filepath.Join(rootDir, "pprof-cpu")
+		profileErr = downloadToFile(url, dir)
+		wg.Done()
+	}()
+
+	url := fmt.Sprintf("http://%s/debug/pprof/trace?seconds=%d", pprofHost, traceSeconds)
+	dir := filepath.Join(rootDir, "pprof-trace")
+	err := downloadToFile(url, dir)
+	if err != nil {
+		return err
+	}
+
+	url = fmt.Sprintf("http://%s/debug/pprof/heap?debug=1", pprofHost)
+	dir = filepath.Join(rootDir, "pprof-heap")
+	err = downloadToFile(url, dir)
+	if err != nil {
+		return err
+	}
+
+	cmd := fmt.Sprintf("gops stack $(pidof %s)", components.CiliumAgentName)
+	writeCmdToFile(rootDir, cmd, nil, enableMarkdown)
+
+	cmd = fmt.Sprintf("gops stats $(pidof %s)", components.CiliumAgentName)
+	writeCmdToFile(rootDir, cmd, nil, enableMarkdown)
+
+	cmd = fmt.Sprintf("gops memstats $(pidof %s)", components.CiliumAgentName)
+	writeCmdToFile(rootDir, cmd, nil, enableMarkdown)
+
+	wg.Wait()
+	if profileErr != nil {
+		return profileErr
+	}
+	return nil
+}
+
+func downloadToFile(url, file string) error {
+	out, err := os.Create(file)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("bad status: %s", resp.Status)
+	}
+	_, err = io.Copy(out, resp.Body)
+	return err
 }

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -308,7 +308,10 @@ data:
 {{- if .Values.global.kubeConfigPath }}
   k8s-kubeconfig-path: {{ .Values.global.kubeConfigPath | quote }}
 {{- end }}
-{{- if not (eq .Values.global.cni.chainingMode "none") }}
-  # Chaining mode was enabled, disabling health checking
+{{- if or (eq .Values.global.cni.chainingMode "portmap") (eq .Values.global.cni.chainingMode "none") }}
+  # Chaining mode is set to portmap, enable health checking
+  enable-endpoint-health-checking: "true"
+{{- else}}
+  # Disable health checking, when chaining mode is not set to portmap or none
   enable-endpoint-health-checking: "false"
 {{- end }}


### PR DESCRIPTION
 * #10566 -- kubernetes: do not set enable-endpoint-health-checking=false with portmap (@soumynathan)
 * #10537 -- Adds details about required kernel versions above 4.9.17, supported OS update (@seanmwinn)
 * #10666 -- bugtool: add mode to retrieve pprof traces (@aanm)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 10566 10537 10666; do contrib/backporting/set-labels.py $pr done 1.6; done
```