### PR TITLE
test: Print message when tests resume

### DIFF
--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -226,6 +226,8 @@ func HoldEnvironment(description ...string) {
 	fmt.Fprintf(os.Stdout, "\n\nPausing test for debug, use vagrant to access test setup.")
 	fmt.Fprintf(os.Stdout, "\nRun \"kill -SIGCONT %d\" to continue.\n", pid)
 	unix.Kill(pid, unix.SIGSTOP)
+	time.Sleep(time.Millisecond)
+	fmt.Fprintf(os.Stdout, "Test resumed.\n")
 }
 
 // Fail is a Ginkgo failure handler which raises a SIGSTOP for the test process


### PR DESCRIPTION
When tests are put on hold after a failure, the user can restart them with a SIGCONT signal. However, it's often takes a while before any new output is displayed. This long silence can be disturbing for new users who may think the SIGCONT signal failed (or at least that's what the author of this pull request first thought).

This commit prints a simple message to clarify that tests were resumed. The short sleep before the message display ensures the process is stopped before the message is displayed.