### PR TITLE
test: Extend "Checks service on same node" test case

### DIFF
--- a/test/k8sT/manifests/demo.yaml
+++ b/test/k8sT/manifests/demo.yaml
@@ -87,6 +87,8 @@ spec:
         command: [ "sleep" ]
         args:
           - "1000h"
+      # k8sT/Services.go:"Checks service on same node" requires the pod to be
+      # scheduled on the same node as app1
       nodeSelector:
         "cilium.io/ci-node": k8s1
 ---


### PR DESCRIPTION
Extend the test case by adding a check whether sending a request from a pod to a service endpoint on the same node via ClusterIP works.

Fix: #10568.
