### PR TITLE
operator: Change AWS policy group provider registration

### DIFF
--- a/cilium-operator.Dockerfile
+++ b/cilium-operator.Dockerfile
@@ -4,7 +4,7 @@ ADD . /go/src/github.com/cilium/cilium
 WORKDIR /go/src/github.com/cilium/cilium/operator
 ARG LOCKDEBUG
 ARG V
-RUN make CGO_ENABLED=0 GOOS=linux LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 EXTRA_GOBUILD_FLAGS="-a -installsuffix cgo"
+RUN make CGO_ENABLED=0 GOOS=linux LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 EXTRA_GOBUILD_FLAGS="-a -installsuffix cgo -tags operator_aws"
 
 FROM docker.io/library/alpine:3.9.3 as certs
 RUN apk --update add ca-certificates

--- a/operator/provider_aws.go
+++ b/operator/provider_aws.go
@@ -1,4 +1,5 @@
-// Copyright 2017-2018 Authors of Cilium
+//+build operator_aws
+// Copyright 2017-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,9 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package groups
+package main
 
-// Empty imports to register providers
 import (
-	_ "github.com/cilium/cilium/pkg/policy/groups/aws" // AWS import to be able to register the provider.
+	_ "github.com/cilium/cilium/pkg/policy/groups/aws" // Register AWS policy group provider.
 )


### PR DESCRIPTION
This is a simple change towards #9920.

- Move AWS policy groups provider registration into operator,
  as it's not used anywhere else
- Add `operator_aws` build tag to exclude this dependency in
  non-AWS builds (see #9920)