### PR TITLE
Update k8s-install-etcd-operator.rst

### DIFF
--- a/Documentation/gettingstarted/k8s-install-etcd-operator.rst
+++ b/Documentation/gettingstarted/k8s-install-etcd-operator.rst
@@ -98,9 +98,10 @@ Troubleshooting
 
    * ``kube-dns`` or ``coredns``
    * ``cilium-xxx``
+   * ``cilium-operator-xxx``
    * ``cilium-etcd-operator``
    * ``etcd-operator``
-   * ``etcd-xxx``
+   * ``cilium-etcd-xxx``
 
    All timeouts are configured that this will typically work out smoothly even
    if some of the pods restart once or twice. In case any of the above pods get


### PR DESCRIPTION
The docs may not up-to-date "Add cilium-operator;  Change etcd-xxx to cilium-etcd-xxx".

