### PR TITLE
docs: Minor adjustments to the development dependencies

### DIFF
--- a/Documentation/contributing/development/dev_setup.rst
+++ b/Documentation/contributing/development/dev_setup.rst
@@ -38,8 +38,17 @@ contribute to Cilium:
 +----------------------------------------------------------------------------------+-----------------------------+-------------------------------------------------------------------------------+
 + `Docker-Compose <https://docs.docker.com/compose/install/>`_                     | OS-Dependent                | N/A (OS-specific)                                                             |
 +----------------------------------------------------------------------------------+-----------------------------+-------------------------------------------------------------------------------+
++ python3-pip                                                                      | latest                      | N/A (OS-specific)                                                             |
++----------------------------------------------------------------------------------+-----------------------------+-------------------------------------------------------------------------------+
 
-To run Cilium locally on VMs, you need:
+
+To build the documentation, you will need to install its dependencies:
+
+::
+
+    $ sudo pip3 install -r Documentation/requirements.txt
+
+Finally, in order to run Cilium locally on VMs, you need:
 
 +----------------------------------------------------------------------------------+-----------------------+--------------------------------------------------------------------------------+
 | Dependency                                                                       | Version / Commit ID   | Download Command                                                               |
@@ -48,12 +57,6 @@ To run Cilium locally on VMs, you need:
 +----------------------------------------------------------------------------------+-----------------------+--------------------------------------------------------------------------------+
 | `VirtualBox <https://www.virtualbox.org/wiki/Downloads>`_ (if not using libvirt) | >= 5.2                | N/A (OS-specific)                                                              |
 +----------------------------------------------------------------------------------+-----------------------+--------------------------------------------------------------------------------+
-
-Finally, in order to build the documentation, you should have Sphinx installed:
-
-::
-
-    $ sudo pip install sphinx
 
 You should start with the `gs_guide`, which walks you through the set-up, such
 as installing Vagrant, getting the Cilium sources, and going through some

--- a/Documentation/contributing/development/dev_setup.rst
+++ b/Documentation/contributing/development/dev_setup.rst
@@ -41,6 +41,7 @@ contribute to Cilium:
 + python3-pip                                                                      | latest                      | N/A (OS-specific)                                                             |
 +----------------------------------------------------------------------------------+-----------------------------+-------------------------------------------------------------------------------+
 
+For `unit_testing`, you will need to run ``docker`` without privileges. You can usually achieve this by adding your current user to the ``docker`` group.
 
 To build the documentation, you will need to install its dependencies:
 


### PR DESCRIPTION
First commit reworks documentation dependencies, second clarifies need to use docker as non-root user for unit tests.