### PR TITLE
test: Fail in case of log buffer too small warning

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -206,13 +206,14 @@ const (
 
 	// Logs messages that should not be in the cilium logs.
 	panicMessage      = "panic:"
-	deadLockHeader    = "POTENTIAL DEADLOCK:"                  // from github.com/sasha-s/go-deadlock/deadlock.go:header
-	segmentationFault = "segmentation fault"                   // from https://github.com/cilium/cilium/issues/3233
-	NACKreceived      = "NACK received for version"            // from https://github.com/cilium/cilium/issues/4003
-	RunInitFailed     = "JoinEP: "                             // from https://github.com/cilium/cilium/pull/5052
-	sizeMismatch      = "size mismatch for BPF map"            // from https://github.com/cilium/cilium/issues/7851
-	emptyBPFInitArg   = "empty argument passed to bpf/init.sh" // from https://github.com/cilium/cilium/issues/10228
-	removingMap       = "Removing map to allow for property upgrade"
+	deadLockHeader    = "POTENTIAL DEADLOCK:"                        // from github.com/sasha-s/go-deadlock/deadlock.go:header
+	segmentationFault = "segmentation fault"                         // from https://github.com/cilium/cilium/issues/3233
+	NACKreceived      = "NACK received for version"                  // from https://github.com/cilium/cilium/issues/4003
+	RunInitFailed     = "JoinEP: "                                   // from https://github.com/cilium/cilium/pull/5052
+	sizeMismatch      = "size mismatch for BPF map"                  // from https://github.com/cilium/cilium/issues/7851
+	emptyBPFInitArg   = "empty argument passed to bpf/init.sh"       // from https://github.com/cilium/cilium/issues/10228
+	removingMap       = "Removing map to allow for property upgrade" // from https://github.com/cilium/cilium/pull/10626
+	logBufferMessage  = "Log buffer too small to dump verifier log"  // from https://github.com/cilium/cilium/issues/10517
 
 	// HelmTemplate is the location of the Helm templates to install Cilium
 	HelmTemplate = "../install/kubernetes/cilium"
@@ -267,6 +268,7 @@ var badLogMessages = map[string][]string{
 	sizeMismatch:      nil,
 	emptyBPFInitArg:   nil,
 	removingMap:       nil,
+	logBufferMessage:  nil,
 }
 
 var ciliumCLICommands = map[string]string{


### PR DESCRIPTION
This refers to a potential BPF verifier complexity issue, so fail if
such warning has been seen in our CI since it is not expected to show
up in tests.

Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>
