### PR TITLE
vagrant: bump server VM image for clang/llvm

### DIFF
--- a/vagrant_box_defaults.rb
+++ b/vagrant_box_defaults.rb
@@ -3,7 +3,7 @@
 Vagrant.require_version ">= 2.2.0"
 
 $SERVER_BOX = "cilium/ubuntu-dev"
-$SERVER_VERSION= "167"
+$SERVER_VERSION= "169"
 $NETNEXT_SERVER_BOX= "cilium/ubuntu-next"
 $NETNEXT_SERVER_VERSION= "48"
 @v419_SERVER_BOX= "cilium/ubuntu-4-19"


### PR DESCRIPTION
Follow-up to cfc5e8c836c3 ("vagrant: bump development VM images
for clang/llvm") in order to bump the SERVER_VERSION.

Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>