### PR TITLE
docker, runtime: remove apt cache from runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN make LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 V=$V LIBNETWORK_PLUGIN=$LIBNETWORK_PLU
 # built while allowing the new versions to make changes that are not
 # backwards compatible.
 #
-FROM quay.io/cilium/cilium-runtime:2020-03-23
+FROM quay.io/cilium/cilium-runtime:2020-03-25
 LABEL maintainer="maintainer@cilium.io"
 COPY --from=builder /tmp/install /
 COPY --from=cilium-envoy / /

--- a/contrib/packaging/docker/Dockerfile.runtime
+++ b/contrib/packaging/docker/Dockerfile.runtime
@@ -17,7 +17,8 @@ apt-get install -y --no-install-recommends \
 # Additional misc runtime dependencies
     iptables kmod ca-certificates && \
 apt-get purge --auto-remove && \
-apt-get clean
+apt-get clean && \
+rm -rf /var/lib/apt/lists/*
 
 #
 # Build Cilium runtime dependencies.
@@ -89,7 +90,8 @@ apt-get purge --auto-remove -y \
   python3 \
 # Additional clang/llvm dependencies
   cmake ninja-build && \
-apt-get clean
+apt-get clean && \
+rm -rf /var/lib/apt/lists/*
 
 #
 # Go-based tools we need at runtime


### PR DESCRIPTION
Do as suggested in the Dockerfile best practices [1].  This further
reduces the footprint of the cilium-runtime image by ~26MB.

[1] https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run