### PR TITLE
cilium, docker: shrink copy layers, split off llvm, and more

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN make LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 V=$V LIBNETWORK_PLUGIN=$LIBNETWORK_PLU
 # built while allowing the new versions to make changes that are not
 # backwards compatible.
 #
-FROM quay.io/cilium/cilium-runtime:2020-03-23
+FROM quay.io/cilium/cilium-runtime:2020-03-25
 LABEL maintainer="maintainer@cilium.io"
 COPY --from=builder /tmp/install /
 COPY --from=cilium-envoy / /

--- a/contrib/packaging/docker/Dockerfile.runtime
+++ b/contrib/packaging/docker/Dockerfile.runtime
@@ -108,9 +108,7 @@ strip /go/bin/gops
 FROM runtime-base
 LABEL maintainer="maintainer@cilium.io"
 WORKDIR /bin
-COPY --from=runtime-build /tmp/iproute2/tc/tc /tmp/iproute2/ip/ip ./
-COPY --from=runtime-build /tmp/linux/tools/bpf/bpftool/bpftool ./
-COPY --from=runtime-build /tmp/llvm/llvm/build/bin/clang /tmp/llvm/llvm/build/bin/llc ./
+COPY --from=runtime-build /tmp/iproute2/tc/tc /tmp/iproute2/ip/ip /tmp/linux/tools/bpf/bpftool/bpftool /tmp/llvm/llvm/build/bin/clang /tmp/llvm/llvm/build/bin/llc ./
 COPY --from=runtime-gobuild /go/bin/gops ./
 WORKDIR /cni
 COPY --from=runtime-build /tmp/loopback ./


### PR DESCRIPTION
For after apt-cache removal. Noticed via dive tool (says potential wasted space: `~13M`).

TODO:
 - [X] reduce layers seen on dive
 - [x] Update LLVM to 10.0 release and split off dependency build
 - [x] can we remove libgcc-5-dev from cilium-runtime?
 - [x] See if there is a clean way to separate LLVM build