### PR TITLE
contrib: Add script to bump stable releases

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -40,9 +40,7 @@ assignees: ''
 
 ## Post-release
 
-- [ ] Prepare post-release changes to master branch
-  - [ ] Update [Stable releases] section of the README
-  - [ ] Update the project pointers in `.github/cilium-actions.yml`
+- [ ] Prepare post-release changes to master branch using `contrib/release/bump-readme.sh`
 - [ ] Update the `stable` tags for each Cilium image on Docker Hub (if applicable)
 - [ ] Update external tools and guides to point to the new Cilium version:
   - [ ] [kops]

--- a/contrib/release/bump-readme.sh
+++ b/contrib/release/bump-readme.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2020 Authors of Cilium
+
+DIR=$(dirname $(readlink -ne $BASH_SOURCE))
+source $DIR/lib/common.sh
+source $DIR/../backporting/common.sh
+
+MAJ_REGEX='[0-9]\+\.[0-9]\+'
+MIN_REGEX='[0-9]\+\.[0-9]\+\.[0-9]\+'
+REGEX_FILTER_DATE='s/^\([-0-9]\+\).*/\1/'
+PROJECTS_REGEX='s/.*projects\/\([0-9]\+\).*/\1/'
+ACTS_YAML=".github/cilium-actions.yml"
+REMOTE="$(get_remote)"
+
+for release in $(grep "General Announcement" README.rst \
+                 | sed 's/.*tree\/\(v'"$MAJ_REGEX"'\).*/\1/'); do
+    latest=$(git describe --tags $REMOTE/$release \
+             | sed 's/v//' | sed 's/\('"$MIN_REGEX"'\).*/\1/')
+    if grep -q $latest README.rst; then
+        continue
+    fi
+
+    current=$(grep $release README.rst \
+              | sed 's/.*\('"$MIN_REGEX"'\).*/\1/')
+    old_date=$(git log -1 -s --format="%cI" $current | sed "$REGEX_FILTER_DATE")
+    new_date=$(git log -1 -s --format="%cI" $latest | sed "$REGEX_FILTER_DATE")
+    elease=$(echo $release | sed 's/v//')
+    old_proj=$(grep "$elease" -A 1 $ACTS_YAML | grep projects | sort | uniq \
+               | sed "$PROJECTS_REGEX")
+    new_proj=$(git show $REMOTE/$release:$ACTS_YAML | grep project \
+               | sed "$PROJECTS_REGEX")
+
+    echo "Updating $release:"
+    echo "  $current on $old_date with project $old_proj to"
+    echo "  $latest on $new_date with project $new_proj"
+    sed -i 's/\('$release'.*\)'$old_date'/\1'$new_date'/g' README.rst
+    sed -i 's/'$current'/'$latest'/g' README.rst
+    sed -i 's/\(projects\/\)'$old_proj'/\1'$new_proj'/g' $ACTS_YAML
+done
+
+git add README.rst $ACTS_YAML
+git commit -s -m "Update stable releases"


### PR DESCRIPTION
Add a script to create a new commit bumping the README and github
actions for newly released versions.

Usage:
```
$ git fetch origin
$ git checkout -b pr/bump-readme-$(date --rfc-3339=date) origin/master
$ ./contrib/release/bump-readme
$ git push
<open PR>
```
Used to create #10710.