### PR TITLE
ci: Run GKE jobs only on gke nodes

### DIFF
--- a/jenkinsfiles/ginkgo-gke.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-gke.Jenkinsfile
@@ -2,7 +2,7 @@
 
 pipeline {
     agent {
-        label 'baremetal'
+        label 'gke'
     }
 
     environment {


### PR DESCRIPTION
We are isolating this job to separate node pool which will have multiple
executors, so we don't lock regular baremetal nodes needed for builds
using vagrant