### PR TITLE
test: Fix kubectl log retrieval for badLogMessages

### DIFF
--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -650,7 +650,8 @@ func (s *SSHMeta) ValidateNoErrorsInLogs(duration time.Duration) {
 		}
 	}()
 
-	failIfContainsBadLogMsg(logs)
+	blacklist := GetBadLogMessages()
+	failIfContainsBadLogMsg(logs, blacklist)
 
 	fmt.Fprintf(CheckLogs, logutils.LogErrorsSummary(logs))
 }

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -212,7 +212,7 @@ const (
 	RunInitFailed     = "JoinEP: "                                   // from https://github.com/cilium/cilium/pull/5052
 	sizeMismatch      = "size mismatch for BPF map"                  // from https://github.com/cilium/cilium/issues/7851
 	emptyBPFInitArg   = "empty argument passed to bpf/init.sh"       // from https://github.com/cilium/cilium/issues/10228
-	removingMap       = "Removing map to allow for property upgrade" // from https://github.com/cilium/cilium/pull/10626
+	RemovingMapMsg    = "Removing map to allow for property upgrade" // from https://github.com/cilium/cilium/pull/10626
 	logBufferMessage  = "Log buffer too small to dump verifier log"  // from https://github.com/cilium/cilium/issues/10517
 
 	// HelmTemplate is the location of the Helm templates to install Cilium
@@ -267,7 +267,7 @@ var badLogMessages = map[string][]string{
 	RunInitFailed:     {"signal: terminated", "signal: killed"},
 	sizeMismatch:      nil,
 	emptyBPFInitArg:   nil,
-	removingMap:       nil,
+	RemovingMapMsg:    nil,
 	logBufferMessage:  nil,
 }
 
@@ -318,4 +318,16 @@ func K8s1VMName() string {
 // K8s2VMName is the name of the Kubernetes worker node when running K8s tests.
 func K8s2VMName() string {
 	return fmt.Sprintf("k8s2-%s", GetCurrentK8SEnv())
+}
+
+// GetBadLogMessages returns a deep copy of badLogMessages to allow removing
+// messages for specific tests.
+func GetBadLogMessages() map[string][]string {
+	mapCopy := make(map[string][]string, len(badLogMessages))
+	for badMsg, exceptions := range badLogMessages {
+		exceptionsCopy := make([]string, len(exceptions))
+		copy(exceptionsCopy, exceptions)
+		mapCopy[badMsg] = exceptionsCopy
+	}
+	return mapCopy
 }

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2342,7 +2342,7 @@ func (kub *Kubectl) ValidateNoErrorsInLogs(duration time.Duration) {
 	defer cancel()
 
 	var logs string
-	cmd := fmt.Sprintf("%s -n %s logs --timestamps=true -l k8s-app=cilium --since=%vs",
+	cmd := fmt.Sprintf("%s -n %s logs --tail=-1 --timestamps=true -l k8s-app=cilium --since=%vs",
 		KubectlCmd, GetCiliumNamespace(GetCurrentIntegration()), duration.Seconds())
 	res := kub.ExecContext(ctx, fmt.Sprintf("%s --previous", cmd), ExecOptions{SkipLog: true})
 	if res.WasSuccessful() {

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2332,11 +2332,18 @@ func (kub *Kubectl) CiliumCheckReport(ctx context.Context) {
 	}
 }
 
-// ValidateNoErrorsInLogs checks in cilium logs since the given duration (By
-// default `CurrentGinkgoTestDescription().Duration`) do not contain `panic`,
-// `deadlocks` or `segmentation faults` messages. In case of any of these
-// messages, it'll mark the test as failed.
+// ValidateNoErrorsInLogs checks that cilium logs since the given duration (By
+// default `CurrentGinkgoTestDescription().Duration`) do not contain any of the
+// known-bad messages (e.g., `deadlocks` or `segmentation faults`). In case of
+// any of these messages, it'll mark the test as failed.
 func (kub *Kubectl) ValidateNoErrorsInLogs(duration time.Duration) {
+	blacklist := GetBadLogMessages()
+	kub.ValidateListOfErrorsInLogs(duration, blacklist)
+}
+
+// ValidateListOfErrorsInLogs is similar to ValidateNoErrorsInLogs, but
+// takes a blacklist of bad log messages instead of using the default list.
+func (kub *Kubectl) ValidateListOfErrorsInLogs(duration time.Duration, blacklist map[string][]string) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
@@ -2368,7 +2375,7 @@ func (kub *Kubectl) ValidateNoErrorsInLogs(duration time.Duration) {
 		}
 	}()
 
-	failIfContainsBadLogMsg(logs)
+	failIfContainsBadLogMsg(logs, blacklist)
 
 	fmt.Fprintf(CheckLogs, logutils.LogErrorsSummary(logs))
 }

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -428,11 +428,11 @@ func CanRunK8sVersion(ciliumVersion, k8sVersionStr string) (bool, error) {
 }
 
 // failIfContainsBadLogMsg makes a test case to fail if any message from
-// given log messages contains an entry from badLogMessages (map key) AND
+// given log messages contains an entry from the blacklist (map key) AND
 // does not contain ignore messages (map value).
-func failIfContainsBadLogMsg(logs string) {
+func failIfContainsBadLogMsg(logs string, blacklist map[string][]string) {
 	for _, msg := range strings.Split(logs, "\n") {
-		for fail, ignoreMessages := range badLogMessages {
+		for fail, ignoreMessages := range blacklist {
 			if strings.Contains(msg, fail) {
 				ok := false
 				for _, ignore := range ignoreMessages {

--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -96,7 +96,9 @@ var _ = Describe("K8sUpdates", func() {
 	})
 
 	JustAfterEach(func() {
-		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
+		blacklist := helpers.GetBadLogMessages()
+		delete(blacklist, helpers.RemovingMapMsg)
+		kubectl.ValidateListOfErrorsInLogs(CurrentGinkgoTestDescription().Duration, blacklist)
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
After each test case, we retrieve Cilium logs to look for known-bad log messages. Daniel recently noticed that tests containing known-bad message logs are passing.

The issue is in the kubectl logs command we use to retrieve the logs. Its behavior seems to have changed at some point. When used with a label selector---as we do---the option `--tail` has a default value of 10 instead of -1. We are therefore only seeing the 10 last lines of each Cilium pod, regardless of the `--since` option's value.

The second commit whitelists map removal log messages for up/downgrade tests, for which they are expected.

/cc @borkmann 