### PR TITLE
modules, mountinfo: check scanner.Err after scanner.Scan

### DIFF
--- a/pkg/modules/modules_linux.go
+++ b/pkg/modules/modules_linux.go
@@ -49,6 +49,10 @@ func parseModulesFile(r io.Reader) ([]string, error) {
 		result = append(result, moduleInfoSeparated[0])
 	}
 
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
 	return result, nil
 }
 

--- a/pkg/mountinfo/mountinfo.go
+++ b/pkg/mountinfo/mountinfo.go
@@ -110,6 +110,10 @@ func parseMountInfoFile(r io.Reader) ([]*MountInfo, error) {
 		})
 	}
 
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
 	return result, nil
 }
 


### PR DESCRIPTION
Check for any non-EOF errors after `scanner.Scan`.