### PR TITLE
CI: K8sKafkaPolicyTest kafka-broker starts up without errors

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -358,7 +358,7 @@ func (kub *Kubectl) CopyFileToPod(namespace string, pod string, fromFile, toFile
 // leads to TopicAuthorizationException or any other error. Hence the
 // function needs to also take into account the stderr messages returned.
 func (kub *Kubectl) ExecKafkaPodCmd(namespace string, pod string, arg string) error {
-	command := fmt.Sprintf("%s exec -n %s %s sh -- %s", KubectlCmd, namespace, pod, arg)
+	command := fmt.Sprintf("%s exec -n %s %s -- %s", KubectlCmd, namespace, pod, arg)
 	res := kub.Exec(command)
 	if !res.WasSuccessful() {
 		return fmt.Errorf("ExecKafkaPodCmd: command '%s' failed %s",

--- a/test/k8sT/KafkaPolicies.go
+++ b/test/k8sT/KafkaPolicies.go
@@ -47,12 +47,12 @@ var _ = Describe("K8sKafkaPolicyTest", func() {
 		topicDeathstarPlans = "deathstar-plans"
 		topicTest           = "test-topic"
 
-		prodHqAnnounce    = `-c "echo 'Happy 40th Birthday to General Tagge' | ./kafka-produce.sh --topic empire-announce"`
-		conOutpostAnnoune = `-c "./kafka-consume.sh --topic empire-announce --from-beginning --max-messages 1"`
-		prodHqDeathStar   = `-c "echo 'deathstar reactor design v3' | ./kafka-produce.sh --topic deathstar-plans"`
-		conOutDeathStar   = `-c "./kafka-consume.sh --topic deathstar-plans --from-beginning --max-messages 1"`
-		prodBackAnnounce  = `-c "echo 'Happy 40th Birthday to General Tagge' | ./kafka-produce.sh --topic empire-announce"`
-		prodOutAnnounce   = `-c "echo 'Vader Booed at Empire Karaoke Party' | ./kafka-produce.sh --topic empire-announce"`
+		prodHqAnnounce    = `sh -c "echo 'Happy 40th Birthday to General Tagge' | ./kafka-produce.sh --topic empire-announce"`
+		conOutpostAnnoune = `sh -c "./kafka-consume.sh --topic empire-announce --from-beginning --max-messages 1"`
+		prodHqDeathStar   = `sh -c "echo 'deathstar reactor design v3' | ./kafka-produce.sh --topic deathstar-plans"`
+		conOutDeathStar   = `sh -c "./kafka-consume.sh --topic deathstar-plans --from-beginning --max-messages 1"`
+		prodBackAnnounce  = `sh -c "echo 'Happy 40th Birthday to General Tagge' | ./kafka-produce.sh --topic empire-announce"`
+		prodOutAnnounce   = `sh -c "echo 'Vader Booed at Empire Karaoke Party' | ./kafka-produce.sh --topic empire-announce"`
 	)
 
 	AfterFailed(func() {

--- a/test/k8sT/manifests/kafka-sw-app.yaml
+++ b/test/k8sT/manifests/kafka-sw-app.yaml
@@ -28,6 +28,14 @@ spec:
           value: kafka-service
         - name: ADVERTISED_PORT
           value: "9092"
+        - name: CONSUMER_THREADS
+          value: "1"
+        - name: ZK_CONNECT
+          value: "zk.connect=localhost:2181/root/path"
+        - name: GROUP_ID
+          value: "groupid=test"
+        - name: TOPICS
+          value: "empire-announce,deathstar-plans,test-topic"
         livenessProbe:
           tcpSocket:
             port: 9092


### PR DESCRIPTION
It's unclear to me how this ever passed. The kafka-broken container
would error out since the wrapper script was missing a number of
parameters. This then exits and the in-container supervisord halts the
startup. Oddly, the test fails if I remove the policy so it definitely
tests something!
We now include the required parameters and there don't seem to be any
errors from the broker.

Separately, we also execed with `kubectl exec podname sh -- -c other things` and I'm not sure how that ever parsed. This is also changed to `-c sh ...`

This is failing regularly in the CI pipeline, and every time on GKE.