### PR TITLE
Misc vagrant dev VM improvements

### DIFF
--- a/Documentation/contributing/development/dev_setup.rst
+++ b/Documentation/contributing/development/dev_setup.rst
@@ -98,6 +98,8 @@ brought up by vagrant:
   default 0.
 * ``RELOAD=1``: Issue a ``vagrant reload`` instead of ``vagrant up``, useful
   to resume halted VMs.
+* ``NO_PROVISION=1``: Avoid provisioning Cilium inside the VM. Supports quick
+  restart without recompiling all of Cilium.
 * ``NFS=1``: Use NFS for vagrant shared directories instead of rsync.
 * ``K8S=1``: Build & install kubernetes on the nodes. ``k8s1`` is the master
   node, which contains both master components: etcd, kube-controller-manager,

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -48,6 +48,8 @@ echo "getting status of systemd-journald"
 sudo service systemd-journald status
 echo "done configuring journald"
 
+pip3 install -r ~/go/src/github.com/cilium/cilium/Documentation/requirements.txt
+
 sudo service docker restart
 echo 'cd ~/go/src/github.com/cilium/cilium' >> /home/vagrant/.bashrc
 sudo chown -R vagrant:vagrant /home/vagrant 2>/dev/null || true
@@ -61,8 +63,6 @@ $build = <<SCRIPT
 set -o errexit
 set -o nounset
 set -o pipefail
-
-pip3 install -r ~/go/src/github.com/cilium/cilium/Documentation/requirements.txt
 
 export PATH=/home/vagrant/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games
 #{$makeclean}

--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -603,14 +603,16 @@ create_k8s_config
 
 cd "${dir}/../.."
 
+PROVISION_ARGS=""
+if [ -n "${NO_PROVISION}" ]; then
+    PROVISION_ARGS="--no-provision"
+fi
 if [ -n "${RELOAD}" ]; then
-    vagrant reload
-elif [ -n "${NO_PROVISION}" ]; then
-    vagrant up --no-provision
+    vagrant reload $PROVISION_ARGS
 elif [ -n "${PROVISION}" ]; then
     vagrant provision
 else
-    vagrant up
+    vagrant up $PROVISION_ARGS
     if [ "$?" -eq "0" -a -n "${K8S}" ]; then
         host_port=$(vagrant port --guest 6443)
         vagrant ssh k8s1 -- cat /home/vagrant/.kube/config | sed "s;server:.*:6443;server: https://k8s1:$host_port;g" > vagrant.kubeconfig


### PR DESCRIPTION
* Move Documentation dependencies install to bootstrap vagrant target
* Support `NO_PROVISION=1` with `RELOAD=1`
* Add documentation for `NO_PROVISION=1`

I manually tested this; I don't think that any CI target will validate them.