### PR TITLE
Makefiles: Disable CGO globally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ endif
 	$(QUIET) echo "mode: count" > coverage-all-tmp.out
 	$(QUIET) echo "mode: count" > coverage.out
 	$(QUIET)$(foreach pkg,$(patsubst %,github.com/cilium/cilium/%,$(TESTPKGS)),\
-		$(GO) test $(GOFLAGS) $(TEST_UNITTEST_LDFLAGS) $(pkg) $(GOTEST_BASE) $(GOTEST_COVER_OPTS) || exit 1; \
+		$(_GO) test $(GOFLAGS) $(TEST_UNITTEST_LDFLAGS) $(pkg) $(GOTEST_BASE) $(GOTEST_COVER_OPTS) || exit 1; \
 		tail -n +2 coverage.out >> coverage-all-tmp.out;)
 	$(MAKE) generate-cov
 	@rmdir ./daemon/1 ./daemon/1_backup 2> /dev/null || true
@@ -359,7 +359,7 @@ gofmt:
 
 govet:
 	@$(ECHO_CHECK) vetting all GOFILES...
-	$(QUIET) $(GOLIST) $(GO) vet \
+	$(QUIET) $(GOLIST) $(_GO) vet \
     ./api/... \
     ./bugtool/... \
     ./cilium/... \

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -14,14 +14,17 @@ LOCALSTATEDIR?=/var
 RUNDIR?=/var/run
 CONFDIR?=/etc
 
+CGO_DISABLED = CGO_ENABLED=0
 GOLIST ?= GO111MODULE=off
 ifeq ($(GO),)
-	GO = go
+	GO = $(CGO_DISABLED) go
+	_GO = go
+else
+	_GO = $(GO)
 endif
 
 INSTALL = install
 
-CGO_DISABLED = CGO_ENABLED=0
 VERSION = $(shell cat $(dir $(lastword $(MAKEFILE_LIST)))/VERSION)
 VERSION_MAJOR = $(shell cat $(dir $(lastword $(MAKEFILE_LIST)))/VERSION | cut -d. -f1)
 # Use git only if in a Git repo

--- a/bugtool/Makefile
+++ b/bugtool/Makefile
@@ -18,7 +18,7 @@ TARGET=cilium-bugtool
 SOURCES := $(shell find ../common . -name '*.go')
 $(TARGET): $(SOURCES)
 	@$(ECHO_GO)
-	$(QUIET)CGO_ENABLED=0 $(GO) build $(GOBUILD) -o $(TARGET)
+	$(QUIET)$(GO) build $(GOBUILD) -o $(TARGET)
 
 all: $(TARGET)
 

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -6,7 +6,7 @@ LINKS=cilium-node-monitor
 SOURCES := $(shell find ../api ../common ../daemon ../pkg . \( -name '*.go'  ! -name '*_test.go' \))
 $(TARGET): $(SOURCES) ../Dockerfile ../Makefile ../Makefile.defs Makefile
 	@$(ECHO_GO)
-	$(QUIET) CGO_ENABLED=0 $(GO) build $(GOBUILD) -o $(TARGET)
+	$(QUIET)$(GO) build $(GOBUILD) -o $(TARGET)
 
 all: $(TARGET) links
 

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -5,7 +5,7 @@ TARGET=cilium-operator
 SOURCES := $(shell find ../pkg . \( -name '*.go'  ! -name '*_test.go' \))
 $(TARGET): $(SOURCES)
 	@$(ECHO_GO)
-	$(QUIET) CGO_ENABLED=0 $(GO) build $(GOBUILD) -o $(TARGET)
+	$(QUIET)$(GO) build $(GOBUILD) -o $(TARGET)
 
 all: $(TARGET)
 

--- a/plugins/cilium-cni/Makefile
+++ b/plugins/cilium-cni/Makefile
@@ -14,7 +14,7 @@ SOURCES := $(shell find ../../api/v1/models ../../common ../../pkg/client ../../
 $(TARGET): $(SOURCES)
 	@$(ECHO_GO)
 	# Compile without cgo to allow use of cilium-cni on non-glibc platforms - see GH-5055
-	$(QUIET)CGO_ENABLED=0 $(GO) build $(GOBUILD) -o $(TARGET)
+	$(QUIET)$(GO) build $(GOBUILD) -o $(TARGET)
 
 install:
 	$(QUIET)$(INSTALL) -m 0755 -d $(DESTDIR)$(CNICONFDIR)

--- a/plugins/cilium-docker/Makefile
+++ b/plugins/cilium-docker/Makefile
@@ -8,7 +8,7 @@ SOURCES := $(shell find ../../api/v1 ../../common ../../pkg/client ../../pkg/end
 
 $(TARGET): $(SOURCES)
 	@$(ECHO_GO)
-	$(QUIET) CGO_ENABLED=0 $(GO) build $(GOBUILD) -o $(TARGET)
+	$(QUIET)$(GO) build $(GOBUILD) -o $(TARGET)
 
 run:
 	./cilium-docker -d

--- a/proxylib/Makefile
+++ b/proxylib/Makefile
@@ -8,7 +8,7 @@ TARGET=libcilium.so
 DEPS := $(shell find ../pkg accesslog npds test . \( -name '*.go' ! -name '*_test.go' \))
 $(TARGET): $(DEPS)
 	@$(ECHO_GO)
-	$(QUIET)$(GO) build $(GOBUILD) $(PROXYLIB_GOBUILD) -o $@.$(VERSION_MAJOR) -buildmode=c-shared
+	$(QUIET)$(_GO) build $(GOBUILD) $(PROXYLIB_GOBUILD) -o $@.$(VERSION_MAJOR) -buildmode=c-shared
 	$(QUIET)ln -sf $@.$(VERSION_MAJOR) $@ || cp $@.$(VERSION_MAJOR) $@
 
 all: $(TARGET)
@@ -16,7 +16,7 @@ all: $(TARGET)
 clean:
 	@$(ECHO_CLEAN)
 	-$(QUIET)rm -f $(TARGET)
-	$(QUIET)$(GO) clean $(GOCLEAN)
+	$(QUIET)$(_GO) clean $(GOCLEAN)
 
 install:
 	$(QUIET)$(INSTALL) -m 0755 -d $(DESTDIR)$(LIBDIR)


### PR DESCRIPTION
CGo is not necessary for any Cilium binaries (only proxylib), and with
the new docs builder image it's causing build issues like the following
on master for some developers:

      GEN   Documentation/cmdref
    Error relocating /src/cilium/cilium: __vfprintf_chk: symbol not found
    Error relocating /src/cilium/cilium: __fprintf_chk: symbol not found

Fix this by just disabling it for all targets that use $GO.