### PR TITLE
test: Add bash aliases and completion for kubectl

### DIFF
--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -406,6 +406,21 @@ else
     sudo systemctl stop etcd
 fi
 
+# Add aliases and bash completion for kubectl
+cat <<EOF >> /home/vagrant/.bashrc
+
+# kubectl
+source <(kubectl completion bash)
+alias k='kubectl'
+complete -F __start_kubectl k
+alias ks='kubectl -n kube-system'
+complete -F __start_kubectl ks
+cilium_pod() {
+    kubectl -n kube-system get pods -l k8s-app=cilium \
+            -o jsonpath="{.items[?(@.spec.nodeName == \"\$1\")].metadata.name}"
+}
+EOF
+
 # Create world network
 docker network create --subnet=192.168.9.0/24 outside
 docker run --net outside --ip 192.168.9.10 --restart=always -d docker.io/cilium/demo-httpd:latest


### PR DESCRIPTION
This commit adds the following to the test VMs:

* Alias `k` for `kubectl`
* Alias `ks` for `kubectl -n kube-system`
* Shell function `cilium_pod $NODE_NAME` for getting cilium-agent pod name
* Bash completion for `kubectl`