### PR TITLE
Fix incorrect name in sysctl_linux_test.go

### DIFF
--- a/daemon/cmd/sysctl_linux_test.go
+++ b/daemon/cmd/sysctl_linux_test.go
@@ -31,7 +31,7 @@ type DaemonPrivilegedSuite struct{}
 
 var _ = Suite(&DaemonPrivilegedSuite{})
 
-func (s *DaemonPrivilegedSuite) TestInitSysctlParams(c *C) {
+func (s *DaemonPrivilegedSuite) TestEnableIPForwarding(c *C) {
 	err := enableIPForwarding()
 	c.Assert(err, IsNil)
 }


### PR DESCRIPTION
Found while working on  #10628. This needs to be merged before said PR is merged in order for privileged unit tests to pass.