### PR TITLE
test: Fix KubeProxyFree tests for Network unreachable case

### DIFF
--- a/test/k8sT/external_ips.go
+++ b/test/k8sT/external_ips.go
@@ -206,6 +206,7 @@ var _ = Describe("K8sKubeProxyFreeMatrix tests", func() {
 			case bytes.Contains(b, []byte("Connection refused")):
 				got = "connection refused"
 			case bytes.Contains(b, []byte("No route to host")),
+				bytes.Contains(b, []byte("Network unreachable")),
 				bytes.Contains(b, []byte("Host is unreachable")),
 				bytes.Contains(b, []byte("Connection timed out")):
 				got = "No route to host / connection timed out"


### PR DESCRIPTION
Depending on your network, it is possible that a router answers with Network unreachable for TEST-NET-1 IP addresses before the 2 seconds timeout triggers. This case makes all KubeProxyFree tests using such IP addresses fail with the following error:

    kubectl exec -n external-ips-test app3-59d6d685d4-kt8jb -c curl -- curl --connect-timeout 2 -v 192.0.2.233:30002
    Expected
      <string>: None?
      *   Trying 192.0.2.233:30002...
      * TCP_NODELAY set
      % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
      Dload  Upload   Total   Spent    Left  Speed
      0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
      * connect to 192.0.2.233 port 30002 failed: Network unreachable
      * Failed to connect to 192.0.2.233 port 30002: Network unreachable
      0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
      * Closing connection 0
      curl: (7) Failed to connect to 192.0.2.233 port 30002: Network unreachable
      command terminated with exit code 7
    to equal
      <string>: No route to host / connection timed out