### PR TITLE
test: Enable ipv6 in direct connectivity with per endpoint routes check

### DIFF
--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -294,7 +294,6 @@ var _ = Describe("K8sDatapathConfig", func() {
 				"global.tunnel":                 "disabled",
 				"global.autoDirectNodeRoutes":   "true",
 				"global.endpointRoutes.enabled": "true",
-				"global.ipv6.enabled":           "false",
 			})
 
 			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")


### PR DESCRIPTION
Previously, when ipv6 was enabled, the check was failing due to the verifier complexity limit being hit.

Re-enable ipv6 as we started build cilium (https://github.com/cilium/cilium/pull/10542) in tests with LLVM 10 which should have resolved the complexity issue.