### PR TITLE
make: pick up all privileged tests in `make tests-privileged`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ clean-jenkins-precheck:
 	# remove the networks
 	docker-compose -f test/docker-compose.yml -p $(JOB_BASE_NAME)-$$BUILD_NUMBER down
 
-PRIV_TEST_PKGS_EVAL := $(shell for pkg in $(TESTPKGS); do echo $(pkg); done | xargs grep --include='*.go' -ril '+build privileged_tests' | xargs dirname | sort | uniq)
+PRIV_TEST_PKGS_EVAL := $(shell for pkg in $(TESTPKGS); do echo $(pkg); done | xargs grep --include='*.go' -ril '+build [^!]*privileged_tests' | xargs dirname | sort | uniq)
 PRIV_TEST_PKGS ?= $(PRIV_TEST_PKGS_EVAL)
 tests-privileged:
 	# cilium-map-migrate is a dependency of some unit tests.

--- a/daemon/cmd/sysctl_linux_test.go
+++ b/daemon/cmd/sysctl_linux_test.go
@@ -32,6 +32,6 @@ type DaemonPrivilegedSuite struct{}
 var _ = Suite(&DaemonPrivilegedSuite{})
 
 func (s *DaemonPrivilegedSuite) TestInitSysctlParams(c *C) {
-	err := initSysctlParams()
+	err := enableIPForwarding()
 	c.Assert(err, IsNil)
 }

--- a/pkg/sysctl/sysctl_linux_privileged_test.go
+++ b/pkg/sysctl/sysctl_linux_privileged_test.go
@@ -34,8 +34,7 @@ var _ = Suite(&SysctlLinuxPrivilegedTestSuite{})
 func (s *SysctlLinuxPrivilegedTestSuite) TestWriteSysctl(c *C) {
 	testCases := []struct {
 		name        string
-		value       []byte
-		oldValue    []byte
+		value       string
 		expectedErr bool
 	}{
 		{


### PR DESCRIPTION
As seen in #10729 some privileged tests currently aren't picked up by
the `tests-privileged` rule because it expects the `privileged_tests`
build tag to directly follow `+build`. However, some `*_test.go` files
use additional build tags before that. Account for that when evaluating
the privileged tests to run. At current `HEAD` this will pick up 3 more
privileged test packages:

```
% grep --include='*.go' -ril '+build privileged_tests' . | wc -l
16
% grep --include='*.go' -ril '+build [^!]*privileged_tests' . | wc -l
19
```

To be merged after #10729

/cc @joestringer @christarazi 