### PR TITLE
Fix bpf unit test build in dev VM

### DIFF
--- a/bpf/lib/conntrack_test.h
+++ b/bpf/lib/conntrack_test.h
@@ -85,7 +85,7 @@ static void test___ct_update_timeout()
 static void test___ct_lookup()
 {
 	void *map = __ipv4_map;
-	struct ct_entry *entry = &map[0];
+	struct ct_entry *entry = &__ipv4_map[0];
 	struct __ctx_buff ctx = {};
 	void *tuple = (void *)__TUPLE_EXIST;
 

--- a/test/bpf/Makefile
+++ b/test/bpf/Makefile
@@ -8,6 +8,7 @@ LIB := $(shell find ../../bpf/ -name '*.h')
 
 CLANG ?= $(QUIET) clang
 LLC ?= llc
+GCC ?= $(QUIET) gcc
 
 BPF_TARGETS := elf-demo.o
 TARGETS := $(BPF_TARGETS) unit-test
@@ -19,7 +20,7 @@ elf-demo.o: elf-demo.c
 
 %: %.c $(LIB)
 	@$(ECHO_CC)
-	$(CLANG) $(FLAGS) -I../../bpf/ $< -o $@
+	$(GCC) $(FLAGS) -I../../bpf/ $< -o $@
 
 clean:
 	@$(ECHO_CLEAN)


### PR DESCRIPTION
With the recent changes in #10703 the dev VM no longer ships a general
purpose `clang` with all targets, but only one with the `bpf` target.
This leads to the build in `test/bpf` to fail:
    
```
clang -I../../bpf/ -I../../bpf/include -I. -D__NR_CPUS__=2 -O2 -I../../bpf/ unit-test.c -o unit-test
error: unable to create target: 'No available targets are compatible with triple "x86_64-unknown-linux-gnu"'
```

To fix this, use `gcc` to build non-bpf binaries. Also fix a GCC warning in `bpf/lib/conntrack_test.h`.