### PR TITLE
Revert "ci: Run GKE jobs only on gke nodes"

### DIFF
--- a/jenkinsfiles/ginkgo-gke.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-gke.Jenkinsfile
@@ -2,7 +2,7 @@
 
 pipeline {
     agent {
-        label 'gke'
+        label 'baremetal'
     }
 
     environment {


### PR DESCRIPTION
This reverts commit 7067dcb3cbe893d3ecee9e3cdf311bb6ef6e40cb.

Due to misconfiguration this change failed completely. Fix incoming, in the meantime let's get back to regular nodes.