### PR TITLE
cilium: set encrypt node route mtu in encryption table

### DIFF
--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -915,7 +915,7 @@ func (n *linuxNodeHandler) createNodeIPSecOutRoute(ip *net.IPNet) route.Route {
 		Device:  n.datapathConfig.HostDevice,
 		Prefix:  *ip,
 		Table:   linux_defaults.RouteTableIPSec,
-		MTU:     n.nodeConfig.MtuConfig.GetRouteTunnelMTU(),
+		MTU:     n.nodeConfig.MtuConfig.GetRoutePostEncryptMTU(),
 	}
 }
 
@@ -930,6 +930,7 @@ func (n *linuxNodeHandler) createNodeExternalIPSecOutRoute(ip *net.IPNet, dflt b
 	} else {
 		tbl = linux_defaults.RouteTableIPSec
 		dev = n.datapathConfig.HostDevice
+		mtu = n.nodeConfig.MtuConfig.GetRoutePostEncryptMTU()
 	}
 
 	// The default routing table accounts for encryption overhead for encrypt-node traffic

--- a/pkg/mtu/mtu.go
+++ b/pkg/mtu/mtu.go
@@ -131,10 +131,10 @@ func NewConfiguration(authKeySize int, encryptEnabled bool, encapEnabled bool, m
 	return conf
 }
 
-// GetRouteTunnelMTU return the MTU to be used on the encryption routing
+// GetRoutePostEncryptMTU return the MTU to be used on the encryption routing
 // table. This is the MTU without encryption overhead and in the tunnel
 // case accounts for the tunnel overhead.
-func (c *Configuration) GetRouteTunnelMTU() int {
+func (c *Configuration) GetRoutePostEncryptMTU() int {
 	if c.encapEnabled {
 		if c.postEncryptMTU == 0 {
 			return EthernetMTU - TunnelOverhead


### PR DESCRIPTION
We recently made a set of fixes to ensure the route mtu in the encryption
routing table (table 200) also sets a correct route mtu in both the direct
routing and tunnel case.

This fixes the last case I am aware of when encrypt node is set we add
a route for remote node IPs. The same as cilium_host IPs these also
need to use a route MTU. This is only important when the host MTU is
not the standard MTU (1500B). And in this case TCP traffic should
should discover correct MSS but still its not ideal to depend on this
and further not all traffic is TCP.

To reflect GetRouteTunnelMTU is now used in direct routing cases as
well rename, GetRoutePostEncryptMTU.

Signed-off-by: John Fastabend <john.fastabend@gmail.com>