### PR TITLE
Fix NodePort when endpoint is in host netns

### DIFF
--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -554,5 +554,8 @@ Limitations
     * Cilium's DSR NodePort mode currently does not operate well in environments with
       TCP Fast Open (TFO) enabled. It is recommended to switch to ``snat`` mode in this
       situation.
+    * Cilium's DSR NodePort does not work with services endpoints which run in
+      the host network namespace (``hostNetwork: true``). This will be addressed via
+      `GH issue 10789 <https://github.com/cilium/cilium/issues/10789>`__.
     * Kubernetes Service sessionAffinity is currently not implemented.
       This will be addressed via `GH issue 9076 <https://github.com/cilium/cilium/issues/9076>`__.

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -210,9 +210,7 @@ ct_recreate6:
 #ifdef ENABLE_NODEPORT
 		/* See comment in handle_ipv4_from_lxc(). */
 		if (ct_state.node_port) {
-			ctx->tc_index |= TC_INDEX_F_SKIP_RECIRCULATION;
-			ep_tail_call(ctx, CILIUM_CALL_IPV6_NODEPORT_REVNAT);
-			return DROP_MISSED_TAIL_CALL;
+			return ctx_redirect(ctx, NATIVE_DEV_IFINDEX, 0);
 		}
 # ifdef ENABLE_DSR
 		if (ct_state.dsr) {
@@ -564,11 +562,8 @@ ct_recreate4:
 		 * is local to the node. We'll redirect to bpf_netdev egress to
 		 * perform the reverse DNAT.
 		 */
-		if (ct_state.node_port) {
-			ctx->tc_index |= TC_INDEX_F_SKIP_RECIRCULATION;
-			ep_tail_call(ctx, CILIUM_CALL_IPV4_NODEPORT_REVNAT);
-			return DROP_MISSED_TAIL_CALL;
-		}
+		if (ct_state.node_port)
+			return ctx_redirect(ctx, NATIVE_DEV_IFINDEX, 0);
 # ifdef ENABLE_DSR
 		if (ct_state.dsr) {
 			ret = xlate_dsr_v4(ctx, &tuple, l4_off);

--- a/test/k8sT/manifests/demo_ds.yaml
+++ b/test/k8sT/manifests/demo_ds.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: web
-        image: docker.io/cilium/echoserver:1.10.1
+        image: docker.io/cilium/echoserver:1.10.2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
@@ -76,7 +76,7 @@ spec:
     spec:
       containers:
       - name: web
-        image: docker.io/cilium/echoserver:1.10.1
+        image: docker.io/cilium/echoserver:1.10.2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80

--- a/test/k8sT/manifests/echo-hostnetns-svc.yaml
+++ b/test/k8sT/manifests/echo-hostnetns-svc.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: echo-hostnetns
+spec:
+  selector:
+    matchLabels:
+      name: echo-hostnetns
+  template:
+    metadata:
+      labels:
+        name: echo-hostnetns
+    spec:
+      hostNetwork: true
+      containers:
+      - name: echo-container
+        image: docker.io/cilium/echoserver:1.10.2
+        env:
+        - name: PORT
+          value: "6666"
+        livenessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - -o
+            - /dev/null
+            - localhost:6666
+        readinessProbe:
+          exec:
+            command:
+            - curl
+            - -sS
+            - -o
+            - /dev/null
+            - localhost:6666
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo-hostnetns
+spec:
+  type: NodePort
+  ports:
+  - name: http
+    port: 6666
+    protocol: TCP
+  selector:
+    name: echo-hostnetns


### PR DESCRIPTION
Previously, the reverse DNAT translation for a reply from a local
NodePort endpoint was done only in bpf_lxc via the
`CILIUM_CALL_IPV{4,6}_NODEPORT_REVNAT` tail call.

This was breaking a case when a NodePort endpoint was running in the
host netns (bpf_lxc is not attached to endpoint in the host netns).
Therefore, a reply from such endpoint was never rev-DNAT xlated.

Fix this by performing the xlation from bpf_netdev's `to-netdev` (egress).

Fix #10402.