### PR TITLE
pre-flight: Correct tofqdns-precache container name

### DIFF
--- a/install/kubernetes/cilium/charts/preflight/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/preflight/templates/daemonset.yaml
@@ -82,7 +82,7 @@ spec:
         - image: "{{ .Values.global.registry }}/{{ .Values.image }}:{{ .Values.global.tag }}"
 {{- end }}
           imagePullPolicy: {{ .Values.global.pullPolicy }}
-          name: cilium-pre-flight-check
+          name: cilium-pre-flight-fqdn-precache
           command: ["/bin/sh"]
           args:
           - -c


### PR DESCRIPTION
We accidentally duplicated the container name when we separated the init
container into two. We don't refer to this anywhere directly so any
other name should be fine.

fixes 52a12df9c4d3cc88197048e34c0e5805e66e58f4
fixes https://github.com/cilium/cilium/issues/10745