### PR TITLE
ipam: Ensure the package builds on macOS

### DIFF
--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -19,13 +19,11 @@ import (
 
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/datapath"
-	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
 
 	"github.com/sirupsen/logrus"
-	"github.com/vishvananda/netlink"
 )
 
 var (
@@ -141,44 +139,6 @@ func nextIP(ip net.IP) {
 		if ip[j] > 0 {
 			break
 		}
-	}
-}
-
-func (ipam *IPAM) reserveLocalRoutes() {
-	log.Debug("Checking local routes for conflicts...")
-
-	link, err := netlink.LinkByName(defaults.HostDevice)
-	if err != nil || link == nil {
-		log.WithError(err).Warnf("Unable to find net_device %s", defaults.HostDevice)
-		return
-	}
-
-	routes, err := netlink.RouteList(nil, netlink.FAMILY_V4)
-	if err != nil {
-		log.WithError(err).Warn("Unable to retrieve local routes")
-		return
-	}
-
-	for _, r := range routes {
-		// ignore routes which point to defaults.HostDevice
-		if r.LinkIndex == link.Attrs().Index {
-			log.WithField("route", r).Debugf("Ignoring route: points to %s", defaults.HostDevice)
-			continue
-		}
-
-		if r.Dst == nil {
-			log.WithField("route", r).Debug("Ignoring route: no destination address")
-			continue
-		}
-
-		// ignore black hole route
-		if r.Src == nil && r.Gw == nil {
-			log.WithField("route", r).Debugf("Ignoring route: black hole")
-			continue
-		}
-
-		log.WithField("route", r.Dst).Info("Blacklisting local route as no-alloc")
-		ipam.BlacklistIPNet(*r.Dst, "local route: "+r.Dst.String())
 	}
 }
 

--- a/pkg/ipam/ipam_local_linux.go
+++ b/pkg/ipam/ipam_local_linux.go
@@ -1,0 +1,61 @@
+// Copyright 2017-2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//+build linux
+
+package ipam
+
+import (
+	"github.com/cilium/cilium/pkg/defaults"
+
+	"github.com/vishvananda/netlink"
+)
+
+func (ipam *IPAM) reserveLocalRoutes() {
+	log.Debug("Checking local routes for conflicts...")
+
+	link, err := netlink.LinkByName(defaults.HostDevice)
+	if err != nil || link == nil {
+		log.WithError(err).Warnf("Unable to find net_device %s", defaults.HostDevice)
+		return
+	}
+
+	routes, err := netlink.RouteList(nil, netlink.FAMILY_V4)
+	if err != nil {
+		log.WithError(err).Warn("Unable to retrieve local routes")
+		return
+	}
+
+	for _, r := range routes {
+		// ignore routes which point to defaults.HostDevice
+		if r.LinkIndex == link.Attrs().Index {
+			log.WithField("route", r).Debugf("Ignoring route: points to %s", defaults.HostDevice)
+			continue
+		}
+
+		if r.Dst == nil {
+			log.WithField("route", r).Debug("Ignoring route: no destination address")
+			continue
+		}
+
+		// ignore black hole route
+		if r.Src == nil && r.Gw == nil {
+			log.WithField("route", r).Debugf("Ignoring route: black hole")
+			continue
+		}
+
+		log.WithField("route", r.Dst).Info("Blacklisting local route as no-alloc")
+		ipam.BlacklistIPNet(*r.Dst, "local route: "+r.Dst.String())
+	}
+}

--- a/pkg/ipam/ipam_local_unimplemented.go
+++ b/pkg/ipam/ipam_local_unimplemented.go
@@ -1,0 +1,22 @@
+// Copyright 2017-2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//+build !linux
+
+package ipam
+
+func (ipam *IPAM) reserveLocalRoutes() {
+	log.Fatal("Unable to retrieve local routes - no implemented")
+	return
+}


### PR DESCRIPTION
~Change constant to use a cross-platform version, as it turns out netlink constant is only an alias to [`unix.AF_INET`]( https://github.com/vishvananda/netlink/blob/c79a4b7b40668c3f7867bf256b80b6b2dc65e58e/nl/nl_linux.go#L22).~