### PR TITLE
operator: Refactor AWS and Azure allocators

### DIFF
--- a/cilium-operator.Dockerfile
+++ b/cilium-operator.Dockerfile
@@ -4,7 +4,7 @@ ADD . /go/src/github.com/cilium/cilium
 WORKDIR /go/src/github.com/cilium/cilium/operator
 ARG LOCKDEBUG
 ARG V
-RUN make CGO_ENABLED=0 GOOS=linux LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 EXTRA_GOBUILD_FLAGS="-a -installsuffix cgo -tags operator_aws"
+RUN make CGO_ENABLED=0 GOOS=linux LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 EXTRA_GOBUILD_FLAGS="-a -installsuffix cgo -tags operator_aws,operator_azure"
 
 FROM docker.io/library/alpine:3.9.3 as certs
 RUN apk --update add ca-certificates

--- a/operator/allocator_providers.go
+++ b/operator/allocator_providers.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 Authors of Cilium
+// Copyright 2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,16 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build operator_aws
-
 package main
 
 import (
-	// These dependencies should be included only when this file is included in the build.
-	allocatorAWS "github.com/cilium/cilium/pkg/ipam/allocator/aws" // AWS allocator.
-	_ "github.com/cilium/cilium/pkg/policy/groups/aws"             // Register AWS policy group provider.
+	"github.com/cilium/cilium/pkg/ipam/allocator"
 )
 
-func init() {
-	allocatorProviders["aws"] = &allocatorAWS.AllocatorAWS{}
-}
+var (
+	allocatorProviders = make(map[string]allocator.AllocatorProvider)
+)

--- a/operator/azure.go
+++ b/operator/azure.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	operatorMetrics "github.com/cilium/cilium/operator/metrics"
 	apiMetrics "github.com/cilium/cilium/pkg/api/metrics"
 	azureAPI "github.com/cilium/cilium/pkg/azure/api"
 	azureIPAM "github.com/cilium/cilium/pkg/azure/ipam"
@@ -44,8 +45,8 @@ func startAzureAllocator(clientQPSLimit float64, clientBurst int) (*ipam.NodeMan
 	}
 
 	if option.Config.EnableMetrics {
-		azMetrics = apiMetrics.NewPrometheusMetrics(metricNamespace, "azure", registry)
-		iMetrics = ipamMetrics.NewPrometheusMetrics(metricNamespace, registry)
+		azMetrics = apiMetrics.NewPrometheusMetrics(operatorMetrics.Namespace, "azure", operatorMetrics.Registry)
+		iMetrics = ipamMetrics.NewPrometheusMetrics(operatorMetrics.Namespace, operatorMetrics.Registry)
 	} else {
 		azMetrics = &apiMetrics.NoOpMetrics{}
 		iMetrics = &ipamMetrics.NoOpMetrics{}

--- a/operator/eni.go
+++ b/operator/eni.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	operatorMetrics "github.com/cilium/cilium/operator/metrics"
 	apiMetrics "github.com/cilium/cilium/pkg/api/metrics"
 	ec2shim "github.com/cilium/cilium/pkg/aws/ec2"
 	"github.com/cilium/cilium/pkg/aws/eni"
@@ -62,8 +63,8 @@ func startENIAllocator(awsClientQPSLimit float64, awsClientBurst int, eniTags ma
 	cfg.Region = instance.Region
 
 	if option.Config.EnableMetrics {
-		aMetrics = apiMetrics.NewPrometheusMetrics("ipam", metricNamespace, registry)
-		iMetrics = ipamMetrics.NewPrometheusMetrics(metricNamespace, registry)
+		aMetrics = apiMetrics.NewPrometheusMetrics("ipam", operatorMetrics.Namespace, operatorMetrics.Registry)
+		iMetrics = ipamMetrics.NewPrometheusMetrics(operatorMetrics.Namespace, operatorMetrics.Registry)
 	} else {
 		aMetrics = &apiMetrics.NoOpMetrics{}
 		iMetrics = &ipamMetrics.NoOpMetrics{}

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"time"
 
+	operatorMetrics "github.com/cilium/cilium/operator/metrics"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/option"
 
@@ -189,7 +190,7 @@ func init() {
 	flags.MarkDeprecated("api-server-port", fmt.Sprintf("Please use %s instead", option.OperatorAPIServeAddr))
 
 	// Deprecated, remove in 1.9
-	flags.StringVar(&metricsAddress, "metrics-address", ":6942", "Address to serve Prometheus metrics")
+	flags.StringVar(&operatorMetrics.Address, "metrics-address", ":6942", "Address to serve Prometheus metrics")
 	flags.MarkDeprecated("metrics-address", fmt.Sprintf("Please use %s instead", option.OperatorPrometheusServeAddr))
 
 	flags.String(option.CMDRef, "", "Path to cmdref output directory")

--- a/operator/main.go
+++ b/operator/main.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"os/signal"
 
+	operatorMetrics "github.com/cilium/cilium/operator/metrics"
 	"github.com/cilium/cilium/pkg/aws/eni"
 	"github.com/cilium/cilium/pkg/components"
 	"github.com/cilium/cilium/pkg/ipam"
@@ -127,7 +128,7 @@ func runOperator(cmd *cobra.Command) {
 	go startServer(shutdownSignal, k8sInitDone, getAPIServerAddr()...)
 
 	if option.Config.EnableMetrics {
-		registerMetrics()
+		operatorMetrics.Register()
 	}
 
 	k8s.Configure(

--- a/operator/main.go
+++ b/operator/main.go
@@ -21,7 +21,6 @@ import (
 	"os/signal"
 
 	operatorMetrics "github.com/cilium/cilium/operator/metrics"
-	"github.com/cilium/cilium/pkg/aws/eni"
 	"github.com/cilium/cilium/pkg/components"
 	"github.com/cilium/cilium/pkg/ipam"
 	"github.com/cilium/cilium/pkg/k8s"
@@ -165,26 +164,32 @@ func runOperator(cmd *cobra.Command) {
 
 	switch option.Config.IPAM {
 	case option.IPAMENI:
-		if err := eni.UpdateLimitsFromUserDefinedMappings(option.Config.AwsInstanceLimitMapping); err != nil {
-			log.WithError(err).Fatal("Parse aws-instance-limit-mapping failed")
+		ipamAllocatorAWS, providerBuiltin := allocatorProviders["aws"]
+		if !providerBuiltin {
+			log.WithError(err).Fatal("AWS ENI allocator is not supported by this version of cilium-operator")
 		}
-		if option.Config.UpdateEC2AdapterLimitViaAPI {
-			if err := eni.UpdateLimitsFromEC2API(context.TODO()); err != nil {
-				log.WithError(err).Error("Unable to update instance type to adapter limits from EC2 API")
-			}
+
+		if err := ipamAllocatorAWS.Init(); err != nil {
+			log.WithError(err).Fatal("Unable to init AWS ENI allocator")
 		}
-		nodeManager, err = startENIAllocator(
-			option.Config.IPAMAPIQPSLimit,
-			option.Config.IPAMAPIBurst,
-			option.Config.ENITags)
+
+		nodeManager, err = ipamAllocatorAWS.Start(&ciliumNodeUpdateImplementation{})
 		if err != nil {
-			log.WithError(err).Fatal("Unable to start ENI allocator")
+			log.WithError(err).Fatal("Unable to start AWS ENI allocator")
 		}
 
 		startSynchronizingCiliumNodes(nodeManager)
-
 	case option.IPAMAzure:
-		nodeManager, err = startAzureAllocator(option.Config.IPAMAPIQPSLimit, option.Config.IPAMAPIBurst)
+		ipamAllocatorAzure, providerBuiltin := allocatorProviders["azure"]
+		if !providerBuiltin {
+			log.WithError(err).Fatal("Azure allocator is not supported by this version of cilium-operator")
+		}
+
+		if err := ipamAllocatorAzure.Init(); err != nil {
+			log.WithError(err).Fatal("Unable to init Azure allocator")
+		}
+
+		nodeManager, err = ipamAllocatorAzure.Start(&ciliumNodeUpdateImplementation{})
 		if err != nil {
 			log.WithError(err).Fatal("Unable to start Azure allocator")
 		}

--- a/operator/metrics/metrics.go
+++ b/operator/metrics/metrics.go
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package metrics
 
 import (
+	"log"
 	"net/http"
 
 	"github.com/cilium/cilium/pkg/option"
@@ -23,28 +24,28 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-const metricNamespace = "cilium_operator"
+const Namespace = "cilium_operator"
 
 var (
-	registry *prometheus.Registry
+	Registry *prometheus.Registry
 
-	metricsAddress string
+	Address string
 )
 
-func registerMetrics() {
-	registry = prometheus.NewPedanticRegistry()
-	registry.MustRegister(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{Namespace: metricNamespace}))
+func Register() {
+	Registry = prometheus.NewPedanticRegistry()
+	Registry.MustRegister(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{Namespace: Namespace}))
 	go func() {
 		// The Handler function provides a default handler to expose metrics
 		// via an HTTP server. "/metrics" is the usual endpoint for that.
-		http.Handle("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
+		http.Handle("/metrics", promhttp.HandlerFor(Registry, promhttp.HandlerOpts{}))
 		log.Fatal(http.ListenAndServe(getPrometheusServerAddr(), nil))
 	}()
 }
 
 func getPrometheusServerAddr() string {
 	if option.Config.OperatorPrometheusServeAddr == "" {
-		return metricsAddress
+		return Address
 	}
 	return option.Config.OperatorPrometheusServeAddr
 }

--- a/operator/provider_azure.go
+++ b/operator/provider_azure.go
@@ -12,16 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build operator_aws
+//+build operator_azure
 
 package main
 
 import (
 	// These dependencies should be included only when this file is included in the build.
-	allocatorAWS "github.com/cilium/cilium/pkg/ipam/allocator/aws" // AWS allocator.
-	_ "github.com/cilium/cilium/pkg/policy/groups/aws"             // Register AWS policy group provider.
+	allocatorAzure "github.com/cilium/cilium/pkg/ipam/allocator/azure" // Azure allocator task.
 )
 
 func init() {
-	allocatorProviders["aws"] = &allocatorAWS.AllocatorAWS{}
+	allocatorProviders["azure"] = &allocatorAzure.AllocatorAzure{}
 }

--- a/pkg/ipam/allocator/provider.go
+++ b/pkg/ipam/allocator/provider.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 Authors of Cilium
+// Copyright 2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,16 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build operator_aws
-
-package main
+package allocator
 
 import (
-	// These dependencies should be included only when this file is included in the build.
-	allocatorAWS "github.com/cilium/cilium/pkg/ipam/allocator/aws" // AWS allocator.
-	_ "github.com/cilium/cilium/pkg/policy/groups/aws"             // Register AWS policy group provider.
+	"github.com/cilium/cilium/pkg/ipam"
 )
 
-func init() {
-	allocatorProviders["aws"] = &allocatorAWS.AllocatorAWS{}
+// AllocatorProvider defines the functions of IPAM provider front-end
+// these are implemented by e.g. pkg/ipam/allocator/{aws,azure}.
+
+type AllocatorProvider interface {
+	Init() error
+	Start(getterUpdater ipam.CiliumNodeGetterUpdater) (*ipam.NodeManager, error)
 }

--- a/pkg/ipam/node_manager.go
+++ b/pkg/ipam/node_manager.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/controller"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
-	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/trigger"
 
@@ -31,9 +31,9 @@ import (
 	"golang.org/x/sync/semaphore"
 )
 
-// k8sImplementation defines the interface used to interact with the k8s
+// CiliumNodeGetterUpdater defines the interface used to interact with the k8s
 // apiserver to retrieve and update the CiliumNode custom resource
-type k8sImplementation interface {
+type CiliumNodeGetterUpdater interface {
 	Update(origResource, newResource *v2.CiliumNode) (*v2.CiliumNode, error)
 	UpdateStatus(origResource, newResource *v2.CiliumNode) (*v2.CiliumNode, error)
 	Get(name string) (*v2.CiliumNode, error)
@@ -131,7 +131,7 @@ type NodeManager struct {
 	mutex            lock.RWMutex
 	nodes            nodeMap
 	instancesAPI     AllocationImplementation
-	k8sAPI           k8sImplementation
+	k8sAPI           CiliumNodeGetterUpdater
 	metricsAPI       MetricsAPI
 	resyncTrigger    *trigger.Trigger
 	parallelWorkers  int64
@@ -139,7 +139,7 @@ type NodeManager struct {
 }
 
 // NewNodeManager returns a new NodeManager
-func NewNodeManager(instancesAPI AllocationImplementation, k8sAPI k8sImplementation, metrics MetricsAPI, parallelWorkers int64, releaseExcessIPs bool) (*NodeManager, error) {
+func NewNodeManager(instancesAPI AllocationImplementation, k8sAPI CiliumNodeGetterUpdater, metrics MetricsAPI, parallelWorkers int64, releaseExcessIPs bool) (*NodeManager, error) {
 	if parallelWorkers < 1 {
 		parallelWorkers = 1
 	}


### PR DESCRIPTION
This is the first step towards #9920.
```
$ tags=("operator_aws,operator_azure" "operator_aws" "operator_azure" "")
$ for t in "${tags[@]}" ; do (echo "building with -tags ${t}..." ; go build -tags "${t}" && du -hs operator) ; done
building with -tags operator_aws,operator_azure...
 83M    operator
building with -tags operator_aws...
 80M    operator
building with -tags operator_azure...
 60M    operator
building with -tags ...
 58M    operator
$ for t in "${tags[@]}" ; do (echo "[stripped] building with -tags ${t}..." ; go build -tags "${t}" -ldflags '-s -w' && du -hs operator) ; done
[stripped] building with -tags operator_aws,operator_azure...
 63M    operator
[stripped] building with -tags operator_aws...
 61M    operator
[stripped] building with -tags operator_azure...
 50M    operator
[stripped] building with -tags ...
 48M    operator
$
```