### PR TITLE
v1.6 backport 2020-03-30

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ clean-jenkins-precheck:
 	# remove the networks
 	docker-compose -f test/docker-compose.yml -p $(JOB_BASE_NAME)-$$BUILD_NUMBER down
 
-PRIV_TEST_PKGS_EVAL := $(shell for pkg in $(TESTPKGS); do echo $(pkg); done | xargs grep --include='*.go' -ril '+build privileged_tests' | xargs dirname | sort | uniq)
+PRIV_TEST_PKGS_EVAL := $(shell for pkg in $(TESTPKGS); do echo $(pkg); done | xargs grep --include='*.go' -ril '+build [^!]*privileged_tests' | xargs dirname | sort | uniq)
 PRIV_TEST_PKGS ?= $(PRIV_TEST_PKGS_EVAL)
 tests-privileged:
 	# cilium-map-migrate is a dependency of some unit tests.

--- a/contrib/backporting/check-stable
+++ b/contrib/backporting/check-stable
@@ -201,7 +201,7 @@ if [[ ${#stable_prs[@]} > 0 ]]; then
   echo "$ for pr in ${stable_prs[@]}; do contrib/backporting/set-labels.py \$pr pending ${STABLE_BRANCH}; done"
   if [[ ! -z $SUMMARY_LOG ]]; then
     echo -e "\nOnce this PR is merged, you can update the PR labels via:" >> $SUMMARY_LOG
-    echo "\`\`\`" >> $SUMMARY_LOG
+    echo "\`\`\`upstream-prs" >> $SUMMARY_LOG
     echo "$ for pr in ${stable_prs[@]}; do contrib/backporting/set-labels.py \$pr done ${STABLE_BRANCH}; done" >> $SUMMARY_LOG
     echo "\`\`\`" >> $SUMMARY_LOG
   fi

--- a/pkg/sysctl/sysctl_linux_privileged_test.go
+++ b/pkg/sysctl/sysctl_linux_privileged_test.go
@@ -34,8 +34,7 @@ var _ = Suite(&SysctlLinuxPrivilegedTestSuite{})
 func (s *SysctlLinuxPrivilegedTestSuite) TestWriteSysctl(c *C) {
 	testCases := []struct {
 		name        string
-		value       []byte
-		oldValue    []byte
+		value       string
 		expectedErr bool
 	}{
 		{

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -175,7 +175,7 @@ func (kub *Kubectl) GetNumNodes() int {
 // leads to TopicAuthorizationException or any other error. Hence the
 // function needs to also take into account the stderr messages returned.
 func (kub *Kubectl) ExecKafkaPodCmd(namespace string, pod string, arg string) error {
-	command := fmt.Sprintf("%s exec -n %s %s sh -- %s", KubectlCmd, namespace, pod, arg)
+	command := fmt.Sprintf("%s exec -n %s %s -- %s", KubectlCmd, namespace, pod, arg)
 	res := kub.Exec(command)
 	if !res.WasSuccessful() {
 		return fmt.Errorf("ExecKafkaPodCmd: command '%s' failed %s",

--- a/test/k8sT/KafkaPolicies.go
+++ b/test/k8sT/KafkaPolicies.go
@@ -46,12 +46,12 @@ var _ = Describe("K8sKafkaPolicyTest", func() {
 		topicDeathstarPlans = "deathstar-plans"
 		topicTest           = "test-topic"
 
-		prodHqAnnounce    = `-c "echo 'Happy 40th Birthday to General Tagge' | ./kafka-produce.sh --topic empire-announce"`
-		conOutpostAnnoune = `-c "./kafka-consume.sh --topic empire-announce --from-beginning --max-messages 1"`
-		prodHqDeathStar   = `-c "echo 'deathstar reactor design v3' | ./kafka-produce.sh --topic deathstar-plans"`
-		conOutDeathStar   = `-c "./kafka-consume.sh --topic deathstar-plans --from-beginning --max-messages 1"`
-		prodBackAnnounce  = `-c "echo 'Happy 40th Birthday to General Tagge' | ./kafka-produce.sh --topic empire-announce"`
-		prodOutAnnounce   = `-c "echo 'Vader Booed at Empire Karaoke Party' | ./kafka-produce.sh --topic empire-announce"`
+		prodHqAnnounce    = `sh -c "echo 'Happy 40th Birthday to General Tagge' | ./kafka-produce.sh --topic empire-announce"`
+		conOutpostAnnoune = `sh -c "./kafka-consume.sh --topic empire-announce --from-beginning --max-messages 1"`
+		prodHqDeathStar   = `sh -c "echo 'deathstar reactor design v3' | ./kafka-produce.sh --topic deathstar-plans"`
+		conOutDeathStar   = `sh -c "./kafka-consume.sh --topic deathstar-plans --from-beginning --max-messages 1"`
+		prodBackAnnounce  = `sh -c "echo 'Happy 40th Birthday to General Tagge' | ./kafka-produce.sh --topic empire-announce"`
+		prodOutAnnounce   = `sh -c "echo 'Vader Booed at Empire Karaoke Party' | ./kafka-produce.sh --topic empire-announce"`
 	)
 
 	AfterFailed(func() {

--- a/test/k8sT/manifests/kafka-sw-app.yaml
+++ b/test/k8sT/manifests/kafka-sw-app.yaml
@@ -28,6 +28,14 @@ spec:
           value: kafka-service
         - name: ADVERTISED_PORT
           value: "9092"
+        - name: CONSUMER_THREADS
+          value: "1"
+        - name: ZK_CONNECT
+          value: "zk.connect=localhost:2181/root/path"
+        - name: GROUP_ID
+          value: "groupid=test"
+        - name: TOPICS
+          value: "empire-announce,deathstar-plans,test-topic"
         livenessProbe:
           tcpSocket:
             port: 9092


### PR DESCRIPTION
 * PR: 10033 -- backporting: add 'upstream-prs' tag for code block (@aanm) -- https://github.com/cilium/cilium/pull/10033

 * PR: 10721 -- CI: K8sKafkaPolicyTest kafka-broker starts up without errors (@raybejjani) -- https://github.com/cilium/cilium/pull/10721

 * PR: 10734 -- make: pick up all privileged tests in `make tests-privileged` (@tklauser) -- https://github.com/cilium/cilium/pull/10734

When you have backported the above commits, you can update the PR labels via this command:
```upstream-prs
$ for pr in 10033 10721 10734; do contrib/backporting/set-labels.py $pr done 1.6; done
```