### PR TITLE
azure: retrieve subscriptionID/resourceGroupName from Azure IMS

### DIFF
--- a/pkg/azure/api/metadata.go
+++ b/pkg/azure/api/metadata.go
@@ -1,0 +1,77 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+)
+
+const (
+	metadataURL = "http://169.254.169.254/metadata"
+	// current version of the metadata/instance service
+	metadataAPIVersion = "2019-06-01"
+)
+
+// GetSubscriptionID retrieves the Azure subscriptionID from the Azure Instance Metadata Service
+func GetSubscriptionID(ctx context.Context) (string, error) {
+	return getMetadataString(ctx, "instance/compute/subscriptionId")
+}
+
+// GetResourceGroupName retrieves the current resource group name in which the host running the Cilium Operator is located
+// This is retrieved via the Azure Instance Metadata Service
+func GetResourceGroupName(ctx context.Context) (string, error) {
+	return getMetadataString(ctx, "instance/compute/resourceGroupName")
+}
+
+// getMetadataString returns the text represantation of a field from the Azure IMS (instance metadata service)
+// more can be found at https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service#instance-api
+func getMetadataString(ctx context.Context, path string) (string, error) {
+	client := &http.Client{
+		Timeout: time.Second * 10,
+	}
+	url := fmt.Sprintf("%s/%s", metadataURL, path)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", nil
+	}
+
+	query := req.URL.Query()
+	query.Add("api-version", metadataAPIVersion)
+	query.Add("format", "text")
+
+	req.URL.RawQuery = query.Encode()
+	req.Header.Add("Metadata", "true")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Errorf("Failed to close body for request %s: %+v", url, err)
+		}
+	}()
+
+	respBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(respBytes), nil
+}

--- a/pkg/ipam/allocator/azure/azure.go
+++ b/pkg/ipam/allocator/azure/azure.go
@@ -56,6 +56,7 @@ func (*AllocatorAzure) Start(getterUpdater ipam.CiliumNodeGetterUpdater) (*ipam.
 			return nil, errors.Wrap(err, "Azure subscription ID was not specified via CLI and retrieving it from the Azure IMS was not possible")
 		}
 		subscriptionID = subID
+		log.WithField("subscriptionID", subscriptionID).Debug("Detected subscriptionID via Azure IMS")
 	}
 
 	resourceGroupName := option.Config.AzureResourceGroup
@@ -66,6 +67,7 @@ func (*AllocatorAzure) Start(getterUpdater ipam.CiliumNodeGetterUpdater) (*ipam.
 			return nil, errors.Wrap(err, "Azure resource group name was not specified via CLI and retrieving it from the Azure IMS was not possible")
 		}
 		resourceGroupName = rgName
+		log.WithField("resourceGroupName", resourceGroupName).Debug("Detected resource group name via Azure IMS")
 	}
 
 	if option.Config.EnableMetrics {

--- a/pkg/ipam/allocator/azure/azure.go
+++ b/pkg/ipam/allocator/azure/azure.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/pkg/errors"
 )
 
 var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "ipam-allocator-azure")
@@ -47,12 +48,24 @@ func (*AllocatorAzure) Start(getterUpdater ipam.CiliumNodeGetterUpdater) (*ipam.
 
 	log.Info("Starting Azure IP allocator...")
 
-	if option.Config.AzureSubscriptionID == "" {
-		return nil, fmt.Errorf("Azure subscription ID not specified")
+	subscriptionID := option.Config.AzureSubscriptionID
+	if subscriptionID == "" {
+		log.Debug("SubscriptionID was not specified via CLI, retrieving it via Azure IMS")
+		subID, err := azureAPI.GetSubscriptionID(context.TODO())
+		if err != nil {
+			return nil, errors.Wrap(err, "Azure subscription ID was not specified via CLI and retrieving it from the Azure IMS was not possible")
+		}
+		subscriptionID = subID
 	}
 
-	if option.Config.AzureResourceGroup == "" {
-		return nil, fmt.Errorf("Azure resource group not specified")
+	resourceGroupName := option.Config.AzureResourceGroup
+	if resourceGroupName == "" {
+		log.Debug("ResourceGroupName was not specified via CLI, retrieving it via Azure IMS")
+		rgName, err := azureAPI.GetResourceGroupName(context.TODO())
+		if err != nil {
+			return nil, errors.Wrap(err, "Azure resource group name was not specified via CLI and retrieving it from the Azure IMS was not possible")
+		}
+		resourceGroupName = rgName
 	}
 
 	if option.Config.EnableMetrics {
@@ -63,8 +76,7 @@ func (*AllocatorAzure) Start(getterUpdater ipam.CiliumNodeGetterUpdater) (*ipam.
 		iMetrics = &ipamMetrics.NoOpMetrics{}
 	}
 
-	azureClient, err := azureAPI.NewClient(option.Config.AzureSubscriptionID,
-		option.Config.AzureResourceGroup, azMetrics, option.Config.IPAMAPIQPSLimit, option.Config.IPAMAPIBurst)
+	azureClient, err := azureAPI.NewClient(subscriptionID, resourceGroupName, azMetrics, option.Config.IPAMAPIQPSLimit, option.Config.IPAMAPIBurst)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create Azure client: %w", err)
 	}


### PR DESCRIPTION
Signed-off-by: Vlad Ungureanu <vladu@palantir.com>

<!-- Description of change -->
azure: retrieve subscriptionID/resourceGroupName from Azure IMS if not provided via CLI flags. If the cilium-operator is host network then most probably the VM where it is running has access to the Azure IMS (https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service#instance-api). In this case let's make config a bit easier and pull those 2 pieces of info for the user. If they are provided explicitly then we will use them.

```release-note
azure: retrieve subscriptionID/resourceGroupName from Azure IMS if not provided via CLI flags
```
