### PR TITLE
k8s: Defer marking node as ready to just API is served

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1276,6 +1276,12 @@ func runDaemon() {
 		errs <- srv.Serve()
 	}()
 
+	if k8s.IsEnabled() {
+		bootstrapStats.k8sInit.Start()
+		k8s.Client().MarkNodeReady(node.GetName())
+		bootstrapStats.k8sInit.End(true)
+	}
+
 	bootstrapStats.overall.End(true)
 	bootstrapStats.updateMetrics()
 	d.launchHubble()

--- a/pkg/k8s/annotate.go
+++ b/pkg/k8s/annotate.go
@@ -111,9 +111,8 @@ func (k8sCli K8sClient) AnnotateNode(nodeName string, encryptKey uint8, v4CIDR, 
 				err := updateNodeAnnotation(k8sCli, nodeName, encryptKey, v4CIDR, v6CIDR, v4HealthIP, v6HealthIP, v4CiliumHostIP, v6CiliumHostIP)
 				if err != nil {
 					scopedLog.WithFields(logrus.Fields{}).WithError(err).Warn("Unable to patch node resource with annotation")
-					return err
 				}
-				return SetNodeNetworkUnavailableFalse(k8sCli, nodeName)
+				return err
 			},
 		})
 

--- a/pkg/k8s/node.go
+++ b/pkg/k8s/node.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/cidr"
+	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/k8s/types"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/node"
@@ -213,10 +214,10 @@ func GetNode(c kubernetes.Interface, nodeName string) (*v1.Node, error) {
 	return c.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
 }
 
-// SetNodeNetworkUnavailableFalse sets Kubernetes NodeNetworkUnavailable to
+// setNodeNetworkUnavailableFalse sets Kubernetes NodeNetworkUnavailable to
 // false as Cilium is managing the network connectivity.
 // https://kubernetes.io/docs/concepts/architecture/nodes/#condition
-func SetNodeNetworkUnavailableFalse(c kubernetes.Interface, nodeName string) error {
+func setNodeNetworkUnavailableFalse(c kubernetes.Interface, nodeName string) error {
 	condition := v1.NodeCondition{
 		Type:               v1.NodeNetworkUnavailable,
 		Status:             v1.ConditionFalse,
@@ -232,4 +233,17 @@ func SetNodeNetworkUnavailableFalse(c kubernetes.Interface, nodeName string) err
 	patch := []byte(fmt.Sprintf(`{"status":{"conditions":%s}}`, raw))
 	_, err = c.CoreV1().Nodes().PatchStatus(context.TODO(), nodeName, patch)
 	return err
+}
+
+// MarkNodeReady marks the Kubernetes node resource as ready from a networking
+// perspective
+func (k8sCli K8sClient) MarkNodeReady(nodeName string) {
+	log.WithField(logfields.NodeName, nodeName).Debug("Setting NetworkUnavailable=false")
+
+	controller.NewManager().UpdateController("mark-k8s-node-as-available",
+		controller.ControllerParams{
+			DoFunc: func(_ context.Context) error {
+				return setNodeNetworkUnavailableFalse(k8sCli, nodeName)
+			},
+		})
 }


### PR DESCRIPTION
The Kubernetes node was marked as ready after the daemon was finished
initializing. There were still several operations that could fail after
that point which could lead to a situation in which a node was marked
ready while the Cilium agent then later errored out, leading to a ready
but failing node.

Move the marking of the node readiness to the very end of the
bootstrapping.

Fixes: #10762
