### PR TITLE
bpf: Fix name for example map

### DIFF
--- a/bpf/node_config.h
+++ b/bpf/node_config.h
@@ -58,7 +58,7 @@ DEFINE_IPV6(HOST_IP, 0xbe, 0xef, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0xa, 0x
 #define IPV4_LOOPBACK 0x1ffff50a
 #ifdef ENABLE_MASQUERADE
 #define SNAT_IPV4_EXTERNAL IPV4_GATEWAY
-#define SNAT_MAPPING_IPV4 cilium_snat_v4_external
+#define SNAT_MAPPING_IPV4 test_cilium_snat_v4_external
 #define SNAT_MAPPING_IPV4_SIZE 524288
 #endif /* ENABLE_MASQUERADE */
 #endif /* ENABLE_IPV4 */
@@ -66,7 +66,7 @@ DEFINE_IPV6(HOST_IP, 0xbe, 0xef, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0xa, 0x
 #ifdef ENABLE_IPV6
 #ifdef ENABLE_MASQUERADE
 DEFINE_IPV6(SNAT_IPV6_EXTERNAL, 0xbe, 0xef, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x1, 0x0, 0x1, 0x0, 0x0);
-#define SNAT_MAPPING_IPV6 cilium_snat_v6_external
+#define SNAT_MAPPING_IPV6 test_cilium_snat_v6_external
 #define SNAT_MAPPING_IPV6_SIZE 524288
 #endif /* ENABLE_MASQUERADE */
 #endif /* ENABLE_IPV6 */
@@ -85,12 +85,12 @@ DEFINE_IPV6(SNAT_IPV6_EXTERNAL, 0xbe, 0xef, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0
 #define LB6_REVERSE_NAT_MAP test_cilium_lb6_reverse_nat
 #define LB6_SERVICES_MAP_V2 test_cilium_lb6_services
 #define LB6_BACKEND_MAP test_cilium_lb6_backends
-#define LB6_REVERSE_NAT_SK_MAP cilium_lb6_reverse_sk
+#define LB6_REVERSE_NAT_SK_MAP test_cilium_lb6_reverse_sk
 #define LB6_REVERSE_NAT_SK_MAP_SIZE 262144
 #define LB4_REVERSE_NAT_MAP test_cilium_lb4_reverse_nat
 #define LB4_SERVICES_MAP_V2 test_cilium_lb4_services
 #define LB4_BACKEND_MAP test_cilium_lb4_backends
-#define LB4_REVERSE_NAT_SK_MAP cilium_lb4_reverse_sk
+#define LB4_REVERSE_NAT_SK_MAP test_cilium_lb4_reverse_sk
 #define LB4_REVERSE_NAT_SK_MAP_SIZE 262144
 #define ENABLE_ARP_RESPONDER
 #define TUNNEL_ENDPOINT_MAP_SIZE 65536


### PR DESCRIPTION
These map names were the same as the ones in Cilium, which is explicitly
what we *don't* want, as that can cause local testing to interfere with
real Cilium agent instances. This was picked up by running Cilium then
running test/bpf/verifier-test.sh This was picked up by running Cilium
then running test/bpf/verifier-test.sh, which fails due to the maps
already existing on the filesystem.