### PR TITLE
datapath: Clarify loader interfaces

### DIFF
--- a/pkg/datapath/config.go
+++ b/pkg/datapath/config.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Authors of Cilium
+// Copyright 2019-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -37,11 +37,9 @@ type DeviceConfiguration interface {
 	GetOptions() *option.IntOptions
 }
 
-// EndpointConfiguration provides datapath implementations a clean interface
-// to access endpoint-specific configuration when configuring the datapath.
-type EndpointConfiguration interface {
-	DeviceConfiguration
-
+// LoadTimeConfiguration provides datapath implementations a clean interface
+// to access endpoint-specific configuration that can be changed at load time.
+type LoadTimeConfiguration interface {
 	// GetID returns a locally-significant endpoint identification number.
 	GetID() uint64
 	// StringID returns the string-formatted version of the ID from GetID().
@@ -52,6 +50,13 @@ type EndpointConfiguration interface {
 	IPv4Address() addressing.CiliumIPv4
 	IPv6Address() addressing.CiliumIPv6
 	GetNodeMAC() mac.MAC
+}
+
+// CompileTimeConfiguration provides datapath implementations a clean interface
+// to access endpoint-specific configuration that can only be changed at
+// compile time.
+type CompileTimeConfiguration interface {
+	DeviceConfiguration
 
 	// TODO: Move this detail into the datapath
 	HasIpvlanDataPath() bool
@@ -77,6 +82,13 @@ type EndpointConfiguration interface {
 
 	// GetPolicyVerdictLogFilter returns the PolicyVerdictLogFilter for the endpoint
 	GetPolicyVerdictLogFilter() uint32
+}
+
+// EndpointConfiguration provides datapath implementations a clean interface
+// to access endpoint-specific configuration when configuring the datapath.
+type EndpointConfiguration interface {
+	CompileTimeConfiguration
+	LoadTimeConfiguration
 }
 
 // ConfigWriter is anything which writes the configuration for various datapath

--- a/pkg/datapath/loader/template.go
+++ b/pkg/datapath/loader/template.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Authors of Cilium
+// Copyright 2019-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -70,7 +70,10 @@ var (
 // program directly to a device, that there are no unintended consequences such
 // as allowing traffic to leak out with routable addresses.
 type templateCfg struct {
-	datapath.EndpointConfiguration
+	// CompileTimeConfiguration passes through directly to the underlying
+	// endpoint configuration, while the rest of the EndpointConfiguration
+	// interface is implemented directly here through receiver functions.
+	datapath.CompileTimeConfiguration
 	stats *metrics.SpanStat
 }
 
@@ -129,13 +132,13 @@ func (t *templateCfg) GetPolicyVerdictLogFilter() uint32 {
 // it inside a templateCfg which hides static data from callers that wish to
 // generate header files based on the configuration, substituting it for
 // template data.
-func wrap(cfg datapath.EndpointConfiguration, stats *metrics.SpanStat) *templateCfg {
+func wrap(cfg datapath.CompileTimeConfiguration, stats *metrics.SpanStat) *templateCfg {
 	if stats == nil {
 		stats = &metrics.SpanStat{}
 	}
 	return &templateCfg{
-		EndpointConfiguration: cfg,
-		stats:                 stats,
+		CompileTimeConfiguration: cfg,
+		stats:                    stats,
 	}
 }
 


### PR DESCRIPTION
Split the EndpointConfiguration datapath interface into
CompileTimeConfiguration and LoadTimeConfiguration. This makes it
clearer to developers how the settings must be applied, and also allows
us to ensure that the template structure is correctly updated to
templatize global data (because extending LoadTimeConfiguration forces
developers to also extend the templateCfg structure).