### PR TITLE
vagrant: Fix bootstrap commands

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -40,19 +40,19 @@ echo "----------------------------------------------------------------"
 export PATH=/home/vagrant/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games
 
 echo "editing journald configuration"
-sudo bash -c "echo RateLimitIntervalSec=1s >> /etc/systemd/journald.conf"
-sudo bash -c "echo RateLimitBurst=10000 >> /etc/systemd/journald.conf"
+bash -c "echo RateLimitIntervalSec=1s >> /etc/systemd/journald.conf"
+bash -c "echo RateLimitBurst=10000 >> /etc/systemd/journald.conf"
 echo "restarting systemd-journald"
-sudo systemctl restart systemd-journald
+systemctl restart systemd-journald
 echo "getting status of systemd-journald"
-sudo service systemd-journald status
+service systemd-journald status
 echo "done configuring journald"
 
-pip3 install -r ~/go/src/github.com/cilium/cilium/Documentation/requirements.txt
+pip3 install -r /home/vagrant/go/src/github.com/cilium/cilium/Documentation/requirements.txt
 
-sudo service docker restart
+service docker restart
 echo 'cd ~/go/src/github.com/cilium/cilium' >> /home/vagrant/.bashrc
-sudo chown -R vagrant:vagrant /home/vagrant 2>/dev/null || true
+chown -R vagrant:vagrant /home/vagrant 2>/dev/null || true
 curl -SsL https://github.com/cilium/bpf-map/releases/download/v1.0/bpf-map -o bpf-map
 chmod +x bpf-map
 mv bpf-map /usr/bin


### PR DESCRIPTION
The bootstrap phase runs as root. This means that we do not need prefix
commands with sudo, and that we need to use the concrete path when
referring to the home directory (instead of '~').

Fixes: #10772
Fixes: c04e0cf932fe ("vagrant: Install docs dependency install on bootstrap")
