### PR TITLE
daemon: add option to dynamically size BPF maps based on system memory

### DIFF
--- a/Documentation/architecture.rst
+++ b/Documentation/architecture.rst
@@ -45,7 +45,7 @@ hook see :ref:`bpf_guide`.
   tc ingress hook can be coupled with above XDP hook. When this is done it
   is reasonable to assume that the majority of the traffic at this
   point is legitimate and destined for the host.
-  
+
   Containers typically use a virtual device called a veth pair which acts
   as a virtual wire connecting the container to the host. By attaching to
   the TC ingress hook of the host side of this veth pair Cilium can monitor
@@ -54,7 +54,7 @@ hook see :ref:`bpf_guide`.
   network traffic to the host side virtual devices with another BPF program
   attached to the tc ingress hook as well Cilium can monitor and enforce
   policy on all traffic entering or exiting the node.
-  
+
   Depending on the use case, containers may also be connected through ipvlan
   devices instead of a veth pair. In this mode, the physical device in the
   host is the ipvlan master where virtual ipvlan devices in slave mode are
@@ -258,6 +258,17 @@ Proxy Map                node             512k            Max 512k concurrent re
 Tunnel                   node             64k             Max 32k nodes (IPv4+IPv6) or 64k nodes (IPv4 or IPv6) across all clusters
 IPv4 Fragmentation       node             8k              Max 8k fragmented datagrams in flight simultaneously on the node
 ======================== ================ =============== =====================================================
+
+For some BPF maps, the upper capacity limit can be overridden using command
+line options for ``cilium-agent``. A given capacity can be set using
+``--bpf-ct-global-tcp-max``, ``--bpf-ct-global-any-max``,
+``--bpf-nat-global-max``, ``--bpf-policy-map-max``, and
+``--bpf-fragments-map-max``.
+
+Using ``--bpf-map-dynamic-size-ratio`` the upper capacity limits of the
+connection tracking, NAT, and policy maps are determined at agent startup based
+on the given ratio of the total system memory. For example a given ratio of 0.03
+leads to 3% of the total system memory to be used for these maps.
 
 Kubernetes Integration
 ======================

--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -32,6 +32,7 @@ cilium-agent [flags]
       --bpf-ct-timeout-service-any duration           Timeout for service entries in non-TCP CT table (default 1m0s)
       --bpf-ct-timeout-service-tcp duration           Timeout for established service entries in TCP CT table (default 6h0m0s)
       --bpf-fragments-map-max int                     Maximum number of entries in fragments tracking map (default 8192)
+      --bpf-map-dynamic-size-ratio float              Ratio (0.0-1.0) of total system memory to use for dynamic sizing of CT, NAT and policy BPF maps. Set to 0.0 to disable dynamic BPF map sizing (default: 0.0)
       --bpf-nat-global-max int                        Maximum number of entries for the global BPF NAT table (default 524288)
       --bpf-policy-map-max int                        Maximum number of entries in endpoint policy map (per endpoint) (default 16384)
       --bpf-root string                               Path to BPF filesystem

--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -434,6 +434,24 @@ Upgrading from >=1.7.0 to 1.8.y
       helm upgrade cilium --namespace=kube-system \\
       --set global.bpf.natMax=841429
 
+New ConfigMap Options
+~~~~~~~~~~~~~~~~~~~~~
+
+  * ``bpf-map-dynamic-size-ratio`` has been added to allow sizing of the TCP CT,
+    non-TCP CT, NAT and policy BPF maps based on the total system memory. This
+    option allows to specify a ratio (0.0-1.0) of total system memory to use for
+    these maps. On new installations, this ratio is set to 0.03 by default,
+    leading to 3% of the total system memory to be allocated for these maps. On
+    a node with 4 GiB of total system memory this ratio corresponds
+    approximately to the default BPF map sizes. A value of 0.0 will disable
+    sizing of the BPF maps based on system memory. Any BPF map sizes configured
+    manually using the ``ctTcpMax``, ``ctAnyMax``, ``natMax`` options will take
+    precedence over the dynamically determined value.
+
+    On upgrades of existing installations, this option is disable by default,
+    i.e. it is set to 0.0. Users wanting to use this feature need to enable it
+    explicitly in their `ConfigMap`, see section :ref:`upgrade_configmap`.
+
 Deprecated options
 ~~~~~~~~~~~~~~~~~~
 

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -40,6 +40,7 @@ Fastabend
 GCE
 Gartrell
 Geneve
+GiB
 Github
 Golang
 Gospodarek

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -152,6 +152,10 @@ data:
   # table.
   bpf-nat-global-max: "{{ .Values.global.bpf.natMax }}"
 
+  # Specifies the ratio (0.0-1.0) of total system memory to use for dynamic
+  # sizing of the TCP CT, non-TCP CT, NAT and policy BPF maps.
+  bpf-map-dynamic-size-ratio: "{{ .Values.global.bpf.mapDynamicSizeRatio }}"
+
   # Pre-allocation of map entries allows per-packet latency to be reduced, at
   # the expense of up-front memory allocation for the entries in the maps. The
   # default value below will minimize memory usage in the default installation;

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -224,7 +224,14 @@ global:
     # natMax is the maximum number of entries for the NAT table
     natMax: 524288
 
-    # montiorAggregation is the level of aggregation for datapath trace events
+    # mapDynamicSizeRatio is the ratio (0.0-1.0) of total system memory to use
+    # for dynamic sizing of CT, NAT and policy BPF maps. If set to 0.0, dynamic
+    # sizing of BPF maps is disabled. The default value of 0.03 (3%) leads to
+    # approximately the default BPF map sizes on a node with 4 GiB of total
+    # system memory.
+    mapDynamicSizeRatio: 0.03
+
+    # monitorAggregation is the level of aggregation for datapath trace events
     monitorAggregation: medium
 
     # monitorInterval is the typical time between monitor notifications for

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -86,6 +86,10 @@ data:
   # table.
   bpf-nat-global-max: "524288"
 
+  # Specifies the ratio (0.0-1.0) of total system memory to use for dynamic
+  # sizing of the TCP CT, non-TCP CT, NAT and policy BPF maps.
+  bpf-map-dynamic-size-ratio: "0.03"
+
   # Pre-allocation of map entries allows per-packet latency to be reduced, at
   # the expense of up-front memory allocation for the entries in the maps. The
   # default value below will minimize memory usage in the default installation;

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -141,7 +141,7 @@ func setupMapInfo(m mapType, define string, mapKey bpf.MapKey, keySize int, maxE
 		keySize:   keySize,
 		// the value type is CtEntry for all CT maps
 		mapValue:   &CtEntry{},
-		valueSize:  int(unsafe.Sizeof(CtEntry{})),
+		valueSize:  SizeofCtEntry,
 		maxEntries: maxEntries,
 		parser:     bpf.ConvertKeyValue,
 		natMap:     nat,

--- a/pkg/maps/ctmap/types.go
+++ b/pkg/maps/ctmap/types.go
@@ -381,6 +381,8 @@ type CtKey6Global struct {
 	tuple.TupleKey6Global
 }
 
+const SizeofCtKey6Global = int(unsafe.Sizeof(CtKey6Global{}))
+
 // NewValue creates a new bpf.MapValue.
 func (k *CtKey6Global) NewValue() bpf.MapValue { return &CtEntry{} }
 
@@ -482,6 +484,8 @@ type CtEntry struct {
 	LastTxReport     uint32 `align:"last_tx_report"`
 	LastRxReport     uint32 `align:"last_rx_report"`
 }
+
+const SizeofCtEntry = int(unsafe.Sizeof(CtEntry{}))
 
 // GetValuePtr returns the unsafe.Pointer for s.
 func (c *CtEntry) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(c) }

--- a/pkg/maps/nat/ipv4.go
+++ b/pkg/maps/nat/ipv4.go
@@ -35,6 +35,9 @@ type NatEntry4 struct {
 	Port      uint16     `align:"to_sport"`
 }
 
+// SizeofNatEntry4 is the size of the NatEntry4 type in bytes.
+const SizeofNatEntry4 = int(unsafe.Sizeof(NatEntry4{}))
+
 // GetValuePtr returns the unsafe.Pointer for n.
 func (n *NatEntry4) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(n) }
 

--- a/pkg/maps/nat/ipv6.go
+++ b/pkg/maps/nat/ipv6.go
@@ -35,6 +35,9 @@ type NatEntry6 struct {
 	Port      uint16     `align:"to_sport"`
 }
 
+// SizeofNatEntry6 is the size of the NatEntry6 type in bytes.
+const SizeofNatEntry6 = int(unsafe.Sizeof(NatEntry6{}))
+
 // GetValuePtr returns the unsafe.Pointer for n.
 func (n *NatEntry6) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(n) }
 

--- a/pkg/maps/nat/nat.go
+++ b/pkg/maps/nat/nat.go
@@ -94,14 +94,14 @@ func NewMap(name string, v4 bool, entries int) *Map {
 
 	if v4 {
 		mapKey = &NatKey4{}
-		sizeKey = int(unsafe.Sizeof(NatKey4{}))
+		sizeKey = SizeofNatKey4
 		mapValue = &NatEntry4{}
-		sizeVal = int(unsafe.Sizeof(NatEntry4{}))
+		sizeVal = SizeofNatEntry4
 	} else {
 		mapKey = &NatKey6{}
-		sizeKey = int(unsafe.Sizeof(NatKey6{}))
+		sizeKey = SizeofNatKey6
 		mapValue = &NatEntry6{}
-		sizeVal = int(unsafe.Sizeof(NatEntry6{}))
+		sizeVal = SizeofNatEntry6
 	}
 	return &Map{
 		Map: *bpf.NewMap(

--- a/pkg/maps/nat/types.go
+++ b/pkg/maps/nat/types.go
@@ -45,6 +45,9 @@ type NatKey4 struct {
 	tuple.TupleKey4Global
 }
 
+// SizeofNatKey4 is the size of the NatKey4 type in bytes.
+const SizeofNatKey4 = int(unsafe.Sizeof(NatKey4{}))
+
 // NewValue creates a new bpf.MapValue.
 func (k *NatKey4) NewValue() bpf.MapValue { return &NatEntry4{} }
 
@@ -79,6 +82,9 @@ func (k *NatKey4) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(k) }
 type NatKey6 struct {
 	tuple.TupleKey6Global
 }
+
+// SizeofNatKey6 is the size of the NatKey6 type in bytes.
+const SizeofNatKey6 = int(unsafe.Sizeof(NatKey6{}))
 
 // NewValue creates a new bpf.MapValue.
 func (k *NatKey6) NewValue() bpf.MapValue { return &NatEntry6{} }

--- a/pkg/maps/policymap/policymap.go
+++ b/pkg/maps/policymap/policymap.go
@@ -72,6 +72,9 @@ type PolicyKey struct {
 	TrafficDirection uint8  `align:"egress"`
 }
 
+// SizeofPolicyKey is the size of type PolicyKey.
+const SizeofPolicyKey = int(unsafe.Sizeof(PolicyKey{}))
+
 // PolicyEntry represents an entry in the BPF policy map for an endpoint. It must
 // match the layout of policy_entry in bpf/lib/common.h.
 // +k8s:deepcopy-gen=true
@@ -84,6 +87,9 @@ type PolicyEntry struct {
 	Packets   uint64 `align:"packets"`
 	Bytes     uint64 `align:"bytes"`
 }
+
+// SizeofPolicyEntry is the size of type PolicyEntry.
+const SizeofPolicyEntry = int(unsafe.Sizeof(PolicyEntry{}))
 
 // CallKey is the index into the prog array map.
 // +k8s:deepcopy-gen=true
@@ -290,9 +296,9 @@ func newMap(path string) *PolicyMap {
 			path,
 			mapType,
 			&PolicyKey{},
-			int(unsafe.Sizeof(PolicyKey{})),
+			SizeofPolicyKey,
 			&PolicyEntry{},
-			int(unsafe.Sizeof(PolicyEntry{})),
+			SizeofPolicyEntry,
 			MaxEntries,
 			flags, 0,
 			bpf.ConvertKeyValue,

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cilium/cilium/pkg/version"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/shirou/gopsutil/mem"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
@@ -513,6 +514,11 @@ const (
 	// NATMapEntriesGlobalDefault holds the default size of the NAT map
 	// and is 2/3 of the full CT size as a heuristic
 	NATMapEntriesGlobalDefault = int((CTMapEntriesGlobalTCPDefault + CTMapEntriesGlobalAnyDefault) * 2 / 3)
+
+	// MapEntriesGlobalDynamicSizeRatioName is the name of the option to
+	// set the ratio of total system memory to use for dynamic sizing of the
+	// CT, NAT and policy BPF maps.
+	MapEntriesGlobalDynamicSizeRatioName = "bpf-map-dynamic-size-ratio"
 
 	// LimitTableMin defines the minimum CT or NAT table limit
 	LimitTableMin = 1 << 10 // 1Ki entries
@@ -1931,6 +1937,16 @@ type DaemonConfig struct {
 	// that can simultaneously be tracked in order to retrieve their L4
 	// ports for all fragments.
 	FragmentsMapEntries int
+
+	// sizeofCTElement is the size of an element (key + value) in the CT map.
+	sizeofCTElement int
+
+	// sizeofNATElement is the size of an element (key + value) in the NAT map.
+	sizeofNATElement int
+
+	// sizeofPolicyElement is the size of an element (key + value) in the
+	// policy map.
+	sizeofPolicyElement int
 }
 
 var (
@@ -2283,9 +2299,6 @@ func (c *DaemonConfig) Populate() {
 	c.AzureSubscriptionID = viper.GetString(AzureSubscriptionID)
 	c.AzureResourceGroup = viper.GetString(AzureResourceGroup)
 	c.BPFCompilationDebug = viper.GetBool(BPFCompileDebugName)
-	c.CTMapEntriesGlobalTCP = viper.GetInt(CTMapEntriesGlobalTCPName)
-	c.CTMapEntriesGlobalAny = viper.GetInt(CTMapEntriesGlobalAnyName)
-	c.NATMapEntriesGlobal = viper.GetInt(NATMapEntriesGlobalName)
 	c.BPFRoot = viper.GetString(BPFRoot)
 	c.CertDirectory = viper.GetString(CertsDirectory)
 	c.CGroupRoot = viper.GetString(CGroupRoot)
@@ -2392,7 +2405,6 @@ func (c *DaemonConfig) Populate() {
 	c.NodesGCInterval = viper.GetDuration(NodesGCInterval)
 	c.FlannelMasterDevice = viper.GetString(FlannelMasterDevice)
 	c.FlannelUninstallOnExit = viper.GetBool(FlannelUninstallOnExit)
-	c.PolicyMapEntries = viper.GetInt(PolicyMapEntriesName)
 	c.PProf = viper.GetBool(PProf)
 	c.PreAllocateMaps = viper.GetBool(PreAllocateMapsName)
 	c.PrependIptablesChains = viper.GetBool(PrependIptablesChainsName)
@@ -2429,6 +2441,10 @@ func (c *DaemonConfig) Populate() {
 
 	if nativeCIDR := viper.GetString(IPv4NativeRoutingCIDR); nativeCIDR != "" {
 		c.ipv4NativeRoutingCIDR = cidr.MustParseCIDR(nativeCIDR)
+	}
+
+	if err := c.calculateBPFMapSizes(); err != nil {
+		log.Fatal(err)
 	}
 
 	// toFQDNs options
@@ -2749,6 +2765,118 @@ func (c *DaemonConfig) checkMapSizeLimits() error {
 	}
 
 	return nil
+}
+
+func (c *DaemonConfig) calculateBPFMapSizes() error {
+	// BPF map size options
+	// Any map size explicitly set via option will override the dynamic
+	// sizing.
+	c.CTMapEntriesGlobalTCP = viper.GetInt(CTMapEntriesGlobalTCPName)
+	c.CTMapEntriesGlobalAny = viper.GetInt(CTMapEntriesGlobalAnyName)
+	c.NATMapEntriesGlobal = viper.GetInt(NATMapEntriesGlobalName)
+	c.PolicyMapEntries = viper.GetInt(PolicyMapEntriesName)
+
+	// Don't attempt dynamic sizing if any of the sizeof members was not
+	// populated by the daemon (or any other caller).
+	if c.sizeofCTElement == 0 || c.sizeofNATElement == 0 || c.sizeofPolicyElement == 0 {
+		return nil
+	}
+
+	// Allow the range (0.0, 1.0] because the dynamic size will anyway be
+	// clamped to the table limits. Thus, a ratio of e.g. 0.98 will not lead
+	// to 98% of the total memory being allocated for BPF maps.
+	dynamicSizeRatio := viper.GetFloat64(MapEntriesGlobalDynamicSizeRatioName)
+	if 0.0 < dynamicSizeRatio && dynamicSizeRatio <= 1.0 {
+		vms, err := mem.VirtualMemory()
+		if err != nil || vms == nil {
+			log.WithError(err).Fatal("Failed to get system memory")
+		}
+		c.calculateDynamicBPFMapSizes(vms.Total, dynamicSizeRatio)
+	} else if dynamicSizeRatio < 0.0 {
+		return fmt.Errorf("specified dynamic map size ratio %f must be ≥ 0.0", dynamicSizeRatio)
+	} else if dynamicSizeRatio > 1.0 {
+		return fmt.Errorf("specified dynamic map size ratio %f must be ≤ 1.0", dynamicSizeRatio)
+	}
+	return nil
+}
+
+// SetMapElementSizes sets the BPF map element sizes (key + value) used for
+// dynamic BPF map size calculations in calculateDynamicBPFMapSizes.
+func (c *DaemonConfig) SetMapElementSizes(sizeofCTElement, sizeofNATElement, sizeofPolicyElement int) {
+	c.sizeofCTElement = sizeofCTElement
+	c.sizeofNATElement = sizeofNATElement
+	c.sizeofPolicyElement = sizeofPolicyElement
+}
+
+func (c *DaemonConfig) calculateDynamicBPFMapSizes(totalMemory uint64, dynamicSizeRatio float64) {
+	// Heuristic:
+	// Distribute relative to map default entries among the different maps.
+	// Cap each map size by the maximum. Map size provided by the user will
+	// override the calculated value and also the max. There will be a check
+	// for maximum size later on in DaemonConfig.Validate()
+	//
+	// Calculation examples:
+	//
+	// Memory   CT TCP  CT Any      NAT  Policy
+	//
+	//  512MB    33140   16570    33140    1035
+	//    1GB    66280   33140    66280    2071
+	//    4GB   265121  132560   265121    8285
+	//   16GB  1060485  530242  1060485   33140
+	memoryAvailableForMaps := int(float64(totalMemory) * dynamicSizeRatio)
+	log.Debugf("Memory available for map entries (%.3f of %d): %d", dynamicSizeRatio, totalMemory, memoryAvailableForMaps)
+	totalMapMemoryDefault := CTMapEntriesGlobalTCPDefault*c.sizeofCTElement +
+		CTMapEntriesGlobalAnyDefault*c.sizeofCTElement +
+		NATMapEntriesGlobalDefault*c.sizeofNATElement +
+		defaults.PolicyMapEntries*c.sizeofPolicyElement
+	log.Debugf("Total memory for default map entries: %d", totalMapMemoryDefault)
+
+	getEntries := func(entriesDefault, min, max int) int {
+		entries := (entriesDefault * memoryAvailableForMaps) / totalMapMemoryDefault
+		if entries < min {
+			entries = min
+		} else if entries > max {
+			log.Debugf("clamped from %d to %d", entries, max)
+			entries = max
+		}
+		return entries
+	}
+
+	// If value for a particular map was explicitly set by an
+	// option, disable dynamic sizing for this map and use the
+	// provided size.
+	if !viper.IsSet(CTMapEntriesGlobalTCPName) {
+		c.CTMapEntriesGlobalTCP =
+			getEntries(CTMapEntriesGlobalTCPDefault, LimitTableMin, LimitTableMax)
+		log.Debugf("option %s set by dynamic sizing to %v (default %v)",
+			CTMapEntriesGlobalTCPName, c.CTMapEntriesGlobalTCP, CTMapEntriesGlobalTCPDefault)
+	} else {
+		log.Debugf("option %s set by user to %v", CTMapEntriesGlobalTCPName, c.CTMapEntriesGlobalTCP)
+	}
+	if !viper.IsSet(CTMapEntriesGlobalAnyName) {
+		c.CTMapEntriesGlobalAny =
+			getEntries(CTMapEntriesGlobalAnyDefault, LimitTableMin, LimitTableMax)
+		log.Debugf("option %s set by dynamic sizing to %v (default %v)",
+			CTMapEntriesGlobalAnyName, c.CTMapEntriesGlobalAny, CTMapEntriesGlobalAnyDefault)
+	} else {
+		log.Debugf("option %s set by user to %v", CTMapEntriesGlobalAnyName, c.CTMapEntriesGlobalAny)
+	}
+	if !viper.IsSet(NATMapEntriesGlobalName) {
+		c.NATMapEntriesGlobal =
+			getEntries(NATMapEntriesGlobalDefault, LimitTableMin, LimitTableMax)
+		log.Debugf("option %s set by dynamic sizing to %v (default %v)",
+			NATMapEntriesGlobalName, c.NATMapEntriesGlobal, NATMapEntriesGlobalDefault)
+	} else {
+		log.Debugf("option %s set by user to %v", NATMapEntriesGlobalName, c.NATMapEntriesGlobal)
+	}
+	if !viper.IsSet(PolicyMapEntriesName) {
+		c.PolicyMapEntries =
+			getEntries(defaults.PolicyMapEntries, PolicyMapMin, PolicyMapMax)
+		log.Debugf("option %s set by dynamic sizing to %v (default %v)",
+			PolicyMapEntriesName, c.PolicyMapEntries, defaults.PolicyMapEntries)
+	} else {
+		log.Debugf("option %s set by user to %v", PolicyMapEntriesName, c.PolicyMapEntries)
+	}
 }
 
 func sanitizeIntParam(paramName string, paramDefault int) int {


### PR DESCRIPTION
Add the new `bpf-map-dynamic-size` option which will size the large BPF
maps (currently CT TCP and non-TCP, NAT and Policy) based on the
total system memory.

If enabled, approximately 1% of the total system memory will be used to
allocate the BPF maps. This factor was chosen heuristically such that on
a node with 4GB of memory, the maps will have roughly the default size.
The amount of memory will be distributed

If the user specifies any of the map sizes explicitly using an option,
that value will take precedence over the dynamically determined size for
that particular map, i.e. when using

```
cilium-agent --bpf-map-dynamic-size --bpf-ct-global-tcp-max 100000
```

the TCP conntrack BPF map will be allocated for a maximum of 100000
entries while the non-TCP conntrack, NAT and Policy maps will have their
size determined dynamically based on total system memory.

As with the manually specified sizes, the dynamically determined map
sizes are always capped by respective minimum and maximum number of
entires for each map.

Updates #10056

```release-note
Add command line option to dynamically size BPF maps based on total system memory.
```
