### PR TITLE
Drop ephemeral port range check for NodePort from datapath

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -51,6 +51,7 @@ cilium-agent [flags]
       --disable-endpoint-crd                          Disable use of CiliumEndpoint CRD
       --disable-iptables-feeder-rules strings         Chains to ignore when installing feeder rules.
       --egress-masquerade-interfaces string           Limit egress masquerading to interface selector
+      --enable-auto-protect-node-port-range           Append NodePort range to net.ipv4.ip_local_reserved_ports if it overlaps with ephemeral port range (net.ipv4.ip_local_port_range) (default true)
       --enable-endpoint-health-checking               Enable connectivity health checking between virtual endpoints (default true)
       --enable-endpoint-routes                        Use per endpoint routes instead of routing via cilium_host
       --enable-external-ips                           Enable k8s service externalIPs feature (requires enabling enable-node-port) (default true)

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -322,6 +322,15 @@ then the same range must be passed to Cilium via the ``global.nodePort.range``
 option, for example, as ``--set global.nodePort.range="10000\,32767"`` for a
 range of ``10000-32767``. The default Kubernetes NodePort range is ``30000-32767``.
 
+If the NodePort port range overlaps with the ephemeral port range
+(``net.ipv4.ip_local_port_range``), Cilium will append the NodePort range to
+the reserved ports (``net.ipv4.ip_local_reserved_ports``). This is needed to
+prevent a NodePort service from hijacking traffic of a host local application
+which source port matches the service port. To disable the modification of
+the reserved ports, set ``global.nodePort.autoProtectPortRanges`` to ``false``.
+
+
+
 Container hostPort support
 **************************
 

--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -612,6 +612,13 @@ New ConfigMap Options
     For users who previously were running with ``nodePort.enabled=true`` it is
     recommended to set the option to ``strict`` before upgrading.
 
+  * ``enable-auto-protect-node-port-range`` has been added to enable
+    auto-appending of a NodePort port range to
+    ``net.ipv4.ip_local_reserved_ports`` if it overlaps with an ephemeral port
+    range from ``net.ipv4.ip_local_port_range``. The option is enabled by
+    default. See :ref:`kubeproxy-free` for the explanation why the overlap can
+    be harmful.
+
 Removed options
 ~~~~~~~~~~~~~~~~~~
 

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1313,7 +1313,6 @@ static __always_inline int nodeport_nat_rev(struct __ctx_buff *ctx,
 		build_bug_on(!(NODEPORT_PORT_MIN_NAT < NODEPORT_PORT_MAX_NAT));
 		build_bug_on(!(NODEPORT_PORT_MIN     < NODEPORT_PORT_MAX));
 		build_bug_on(!(NODEPORT_PORT_MAX     < NODEPORT_PORT_MIN_NAT));
-		build_bug_on(!(NODEPORT_PORT_MAX     < EPHEMERAL_MIN));
 		break;
 	}
 	return CTX_ACT_OK;

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -511,6 +511,11 @@ func init() {
 	flags.String(option.NodePortMode, option.NodePortModeHybrid, "BPF NodePort mode (\"snat\", \"dsr\", \"hybrid\")")
 	option.BindEnv(option.NodePortMode)
 
+	flags.Bool(option.EnableAutoProtectNodePortRange, true,
+		"Append NodePort range to net.ipv4.ip_local_reserved_ports if it overlaps "+
+			"with ephemeral port range (net.ipv4.ip_local_port_range)")
+	option.BindEnv(option.EnableAutoProtectNodePortRange)
+
 	flags.StringSlice(option.NodePortRange, []string{fmt.Sprintf("%d", option.NodePortMinDefault), fmt.Sprintf("%d", option.NodePortMaxDefault)}, fmt.Sprintf("Set the min/max NodePort port range"))
 	option.BindEnv(option.NodePortRange)
 
@@ -1569,24 +1574,97 @@ func initKubeProxyReplacementOptions() {
 	}
 }
 
+// checkNodePortAndEphemeralPortRanges checks whether the ephemeral port range
+// does not clash with the nodeport range to prevent the BPF nodeport from
+// hijacking an existing connection on the local host which source port is
+// the same as a nodeport service.
+//
+// If it clashes, check whether the nodeport range is listed in ip_local_reserved_ports.
+// If it isn't and EnableAutoProtectNodePortRange == false, then return an error
+// making cilium-agent to stop.
+// Otherwise, if EnableAutoProtectNodePortRange == true, then append the nodeport
+// range to ip_local_reserved_ports.
 func checkNodePortAndEphemeralPortRanges() error {
-	val, err := sysctl.Read("net.ipv4.ip_local_port_range")
+	ephemeralPortRangeStr, err := sysctl.Read("net.ipv4.ip_local_port_range")
 	if err != nil {
 		return fmt.Errorf("Unable to read net.ipv4.ip_local_port_range")
 	}
-	ephemeralPortRange := strings.Split(val, "\t")
+	ephemeralPortRange := strings.Split(ephemeralPortRangeStr, "\t")
 	if len(ephemeralPortRange) != 2 {
-		return fmt.Errorf("Invalid ephemeral port range: %s", val)
+		return fmt.Errorf("Invalid ephemeral port range: %s", ephemeralPortRangeStr)
 	}
 	ephemeralPortMin, err := strconv.Atoi(ephemeralPortRange[0])
 	if err != nil {
 		return fmt.Errorf("Unable to parse min port value %s for ephemeral range", ephemeralPortRange[0])
 	}
-	if !(option.Config.NodePortMax < ephemeralPortMin) {
-		msg := `NodePort range (%d-%d) max port must be smaller than ephemeral range (%s-%s) min port. ` +
-			`Adjust ephemeral range port with "sysctl -w net.ipv4.ip_local_port_range='MIN MAX'".`
-		return fmt.Errorf(msg, option.Config.NodePortMin, option.Config.NodePortMax,
-			ephemeralPortRange[0], ephemeralPortRange[1])
+	ephemeralPortMax, err := strconv.Atoi(ephemeralPortRange[1])
+	if err != nil {
+		return fmt.Errorf("Unable to parse max port value %s for ephemeral range", ephemeralPortRange[1])
 	}
+
+	if option.Config.NodePortMax < ephemeralPortMin {
+		// ephemeral port range does not clash with nodeport range
+		return nil
+	}
+
+	nodePortRangeStr := fmt.Sprintf("%d-%d", option.Config.NodePortMin,
+		option.Config.NodePortMax)
+
+	if option.Config.NodePortMin > ephemeralPortMax {
+		return fmt.Errorf("NodePort port range (%s) is not allowed to be after ephemeral port range (%s)",
+			nodePortRangeStr, ephemeralPortRangeStr)
+	}
+
+	reservedPortsStr, err := sysctl.Read("net.ipv4.ip_local_reserved_ports")
+	if err != nil {
+		return fmt.Errorf("Unable to read net.ipv4.ip_local_reserved_ports")
+	}
+	for _, portRange := range strings.Split(reservedPortsStr, ",") {
+		if portRange == "" {
+			break
+		}
+		ports := strings.Split(portRange, "-")
+		if len(ports) == 0 {
+			return fmt.Errorf("Invalid reserved ports range")
+		}
+		from, err := strconv.Atoi(ports[0])
+		if err != nil {
+			return fmt.Errorf("Unable to parse reserved port %q", ports[0])
+		}
+		to := from
+		if len(ports) == 2 {
+			if to, err = strconv.Atoi(ports[1]); err != nil {
+				return fmt.Errorf("Unable to parse reserved port %q", ports[1])
+			}
+		}
+
+		if from <= option.Config.NodePortMin && to >= option.Config.NodePortMax {
+			// nodeport range is protected by reserved port range
+			return nil
+		}
+
+		if from > option.Config.NodePortMax {
+			break
+		}
+	}
+
+	if !option.Config.EnableAutoProtectNodePortRange {
+		msg := `NodePort port range (%s) must not clash with ephemeral port range (%s). ` +
+			`Adjust ephemeral range port with "sysctl -w net.ipv4.ip_local_port_range='MIN MAX'", or ` +
+			`protect the NodePort range by appending it to "net.ipv4.ip_local_reserved_ports", or ` +
+			`set --%s=true to auto-append the range to "net.ipv4.ip_local_reserved_ports"`
+		return fmt.Errorf(msg, nodePortRangeStr, ephemeralPortRangeStr,
+			option.EnableAutoProtectNodePortRange)
+	}
+
+	if reservedPortsStr != "" {
+		reservedPortsStr += ","
+	}
+	reservedPortsStr += fmt.Sprintf("%d-%d", option.Config.NodePortMin, option.Config.NodePortMax)
+	if err := sysctl.Write("net.ipv4.ip_local_reserved_ports", reservedPortsStr); err != nil {
+		return fmt.Errorf("Unable to addend nodeport range (%s) to net.ipv4.ip_local_reserved_ports: %s",
+			nodePortRangeStr, err)
+	}
+
 	return nil
 }

--- a/daemon/cmd/nodeport_linux_test.go
+++ b/daemon/cmd/nodeport_linux_test.go
@@ -1,0 +1,93 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux,privileged_tests
+
+package cmd
+
+import (
+	"fmt"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/sysctl"
+)
+
+type NodePortSuite struct {
+	prevEphemeralPortRange string
+	prevReservedPortRanges string
+}
+
+var _ = Suite(&NodePortSuite{})
+
+func (s *NodePortSuite) SetUpTest(c *C) {
+	prevEphemeralPortRange, err := sysctl.Read("net.ipv4.ip_local_port_range")
+	c.Assert(err, IsNil)
+	s.prevEphemeralPortRange = prevEphemeralPortRange
+	prevReservedPortRanges, err := sysctl.Read("net.ipv4.ip_local_reserved_ports")
+	c.Assert(err, IsNil)
+	s.prevReservedPortRanges = prevReservedPortRanges
+}
+
+func (s *NodePortSuite) TearDownTest(c *C) {
+	err := sysctl.Write("net.ipv4.ip_local_port_range", s.prevEphemeralPortRange)
+	c.Assert(err, IsNil)
+	err = sysctl.Write("net.ipv4.ip_local_reserved_ports", s.prevReservedPortRanges)
+	c.Assert(err, IsNil)
+}
+
+func (s *NodePortSuite) TestCheckNodePortAndEphemeralPortRanges(c *C) {
+	cases := []struct {
+		npMin       int
+		npMax       int
+		epMin       int
+		epMax       int
+		resPorts    string
+		autoProtect bool
+
+		expResPorts string
+		expErr      bool
+		expErrMatch string
+	}{
+		{32000, 32999, 10000, 40000, "\n", true, "32000-32999", false, ""},
+		{32000, 32999, 10000, 40000, "\n", false, "", true, ".* must not clash.*"},
+		{32000, 32999, 10000, 40000, "32000-32500\n", true, "32000-32999", false, ""},
+		{32000, 32999, 10000, 40000, "32000-33000\n", false, "32000-33000", false, ""},
+		{32000, 32999, 33000, 40000, "\n", false, "", false, ""},
+		{32000, 32999, 10000, 40000, "20000\n", true, "20000,32000-32999", false, ""},
+		{32000, 32999, 10000, 20000, "\n", true, "", true, ".* after ephemeral.*"},
+	}
+
+	for _, test := range cases {
+		option.Config.NodePortMin = test.npMin
+		option.Config.NodePortMax = test.npMax
+		option.Config.EnableAutoProtectNodePortRange = test.autoProtect
+		err := sysctl.Write("net.ipv4.ip_local_port_range",
+			fmt.Sprintf("%d %d", test.epMin, test.epMax))
+		c.Assert(err, IsNil)
+		err = sysctl.Write("net.ipv4.ip_local_reserved_ports", test.resPorts)
+		c.Assert(err, IsNil)
+
+		err = checkNodePortAndEphemeralPortRanges()
+		if test.expErr {
+			c.Assert(err, ErrorMatches, test.expErrMatch)
+		} else {
+			c.Assert(err, IsNil)
+			resPorts, err := sysctl.Read("net.ipv4.ip_local_reserved_ports")
+			c.Assert(err, IsNil)
+			c.Assert(resPorts, Equals, test.expResPorts)
+		}
+	}
+}

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -314,6 +314,7 @@ data:
 {{- if .Values.global.nodePort.mode }}
   node-port-mode: {{ .Values.global.nodePort.mode | quote }}
 {{- end }}
+  enable-auto-protect-node-port-range: {{ .Values.global.nodePort.autoProtectPortRange | quote }}
 {{- end }}
 
 {{- if and .Values.global.pprof .Values.global.pprof.enabled }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -273,6 +273,10 @@ global:
     # mode is the mode of NodePort feature
     mode: "hybrid"
 
+    # Append NodePort range to ip_local_reserved_ports if clash with ephemeral
+    # ports is detected
+    autoProtectPortRange: true
+
   # hostPort is the configuration for container hostPort mapping
   hostPort:
     # enabled enables the hostPort functionality

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -152,6 +152,7 @@ data:
   enable-external-ips: "false"
   enable-node-port: "false"
   node-port-mode: "hybrid"
+  enable-auto-protect-node-port-range: "true"
   # Chaining mode is set to portmap, enable health checking
   enable-endpoint-health-checking: "true"
   enable-well-known-identities: "false"

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -297,6 +297,11 @@ const (
 	// ("snat", "dsr" or "hybrid")
 	NodePortMode = "node-port-mode"
 
+	// EnableAutoProtectNodePortRange enables appending NodePort range to
+	// net.ipv4.ip_local_reserved_ports if it overlaps with ephemeral port
+	// range (net.ipv4.ip_local_port_range)
+	EnableAutoProtectNodePortRange = "enable-auto-protect-node-port-range"
+
 	// KubeProxyReplacement controls how to enable kube-proxy replacement
 	// features in BPF datapath
 	KubeProxyReplacement = "kube-proxy-replacement"
@@ -1437,6 +1442,11 @@ type DaemonConfig struct {
 	// ("snat", "dsr" or "hybrid")
 	NodePortMode string
 
+	// EnableAutoProtectNodePortRange enables appending NodePort range to
+	// net.ipv4.ip_local_reserved_ports if it overlaps with ephemeral port
+	// range (net.ipv4.ip_local_port_range)
+	EnableAutoProtectNodePortRange bool
+
 	// KubeProxyReplacement controls how to enable kube-proxy replacement
 	// features in BPF datapath
 	KubeProxyReplacement string
@@ -2029,6 +2039,7 @@ func (c *DaemonConfig) Populate() {
 	c.EnableTracing = viper.GetBool(EnableTracing)
 	c.EnableNodePort = viper.GetBool(EnableNodePort)
 	c.NodePortMode = viper.GetString(NodePortMode)
+	c.EnableAutoProtectNodePortRange = viper.GetBool(EnableAutoProtectNodePortRange)
 	c.KubeProxyReplacement = viper.GetString(KubeProxyReplacement)
 	c.EnableCEPGC = viper.GetBool(EnableCEPGC)
 	c.EnableCNPNodeStatusGC = viper.GetBool(EnableCNPNodeStatusGC)


### PR DESCRIPTION
This PR:

- Removes the ephemeral port range check from the NodePort BPF.
- Checks the NodePort range against `net.ipv4.ip_local_reserved_ports`. Modifies it if overlap with the ephemeral range is detected.
- Introduces `--enable-auto-protect-node-port-range` (`global.nodePort.autoProtectPortRange` in helm) flag do disable the behavior ^^.
- Extends the kube-proxy-free docs about the range check.

Reviewable per commit.

```release-note
Protect NodePort port range by appending it to net.ipv4.ip_local_reserved_ports if the range clashes with ephemeral port range
```

Fix #10261.