### PR TITLE
[WIP] Enable unsafe.Pointer use with checkptr flag in CI test binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,14 +18,16 @@ LABEL maintainer="maintainer@cilium.io"
 WORKDIR /go/src/github.com/cilium/cilium
 COPY . ./
 ARG LOCKDEBUG
+ARG CHECKPTR
 ARG V
 ARG LIBNETWORK_PLUGIN
 #
 # Please do not add any dependency updates before the 'make install' here,
 # as that will mess with caching for incremental builds!
 #
-RUN make LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 V=$V LIBNETWORK_PLUGIN=$LIBNETWORK_PLUGIN \
-    SKIP_DOCS=true DESTDIR=/tmp/install clean-container build-container install-container
+RUN make LOCKDEBUG=$LOCKDEBUG CHECKPTR=$CHECKPTR PKG_BUILD=1 V=$V \
+    LIBNETWORK_PLUGIN=$LIBNETWORK_PLUGIN SKIP_DOCS=true DESTDIR=/tmp/install \
+    clean-container build-container install-container
 
 #
 # Cilium runtime install.

--- a/Makefile
+++ b/Makefile
@@ -207,6 +207,7 @@ docker-cilium-image-for-developers:
 	# a dedicated dockerignore file per Dockerfile.
 	DOCKER_BUILDKIT=1 $(CONTAINER_ENGINE_FULL) build \
 	     --build-arg LOCKDEBUG=\
+	     --build-arg CHECKPTR=\
 	     --build-arg V=\
 	     --build-arg LIBNETWORK_PLUGIN=\
 	     -t "cilium/cilium-dev:"latest"" . -f ./cilium-dev.Dockerfile
@@ -216,6 +217,7 @@ docker-image: clean docker-image-no-clean docker-operator-image docker-plugin-im
 docker-image-no-clean: GIT_VERSION
 	$(CONTAINER_ENGINE_FULL) build \
 		--build-arg LOCKDEBUG=${LOCKDEBUG} \
+		--build-arg CHECKPTR=${CHECKPTR} \
 		--build-arg V=${V} \
 		--build-arg LIBNETWORK_PLUGIN=${LIBNETWORK_PLUGIN} \
 		-t "cilium/cilium:$(DOCKER_IMAGE_TAG)" .
@@ -230,6 +232,7 @@ docker-cilium-manifest:
 dev-docker-image: GIT_VERSION
 	$(CONTAINER_ENGINE_FULL) build \
 		--build-arg LOCKDEBUG=${LOCKDEBUG} \
+		--build-arg CHECKPTR=${CHECKPTR} \
 		--build-arg V=${V} \
 		--build-arg LIBNETWORK_PLUGIN=${LIBNETWORK_PLUGIN} \
 		-t "cilium/cilium-dev:$(DOCKER_IMAGE_TAG)" .
@@ -242,7 +245,10 @@ docker-cilium-dev-manifest:
 	$(QUIET) contrib/scripts/push_manifest.sh cilium-dev $(DOCKER_IMAGE_TAG)
 
 docker-operator-image: GIT_VERSION
-	$(CONTAINER_ENGINE_FULL) build --build-arg LOCKDEBUG=${LOCKDEBUG} -f cilium-operator.Dockerfile -t "cilium/operator:$(DOCKER_IMAGE_TAG)" .
+	$(CONTAINER_ENGINE_FULL) build \
+		--build-arg LOCKDEBUG=${LOCKDEBUG} \
+		--build-arg CHECKPTR=${CHECKPTR} \
+		-f cilium-operator.Dockerfile -t "cilium/operator:$(DOCKER_IMAGE_TAG)" .
 	$(CONTAINER_ENGINE_FULL) tag cilium/operator:$(DOCKER_IMAGE_TAG) cilium/operator:$(DOCKER_IMAGE_TAG)-${GOARCH}
 	$(QUIET)echo "Push like this when ready:"
 	$(QUIET)echo "docker push cilium/operator:$(DOCKER_IMAGE_TAG)-${GOARCH}"
@@ -252,7 +258,10 @@ docker-operator-manifest:
 	$(QUIET) contrib/scripts/push_manifest.sh operator $(DOCKER_IMAGE_TAG)
 
 docker-plugin-image: GIT_VERSION
-	$(CONTAINER_ENGINE_FULL) build --build-arg LOCKDEBUG=${LOCKDEUBG} -f cilium-docker-plugin.Dockerfile -t "cilium/docker-plugin:$(DOCKER_IMAGE_TAG)" .
+	$(CONTAINER_ENGINE_FULL) build \
+		--build-arg LOCKDEBUG=${LOCKDEBUG} \
+		--build-arg CHECKPTR=${CHECKPTR} \
+		-f cilium-docker-plugin.Dockerfile -t "cilium/docker-plugin:$(DOCKER_IMAGE_TAG)" .
 	$(CONTAINER_ENGINE_FULL) tag cilium/docker-plugin:$(DOCKER_IMAGE_TAG) cilium/docker-plugin:$(DOCKER_IMAGE_TAG)-${GOARCH}
 	$(QUIET)echo "Push like this when ready:"
 	$(QUIET)echo "docker push cilium/docker-plugin:$(DOCKER_IMAGE_TAG)-${GOARCH}"

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -81,11 +81,13 @@ GOBUILD = $(GOFLAGS) -ldflags '$(GOLDFLAGS)' $(EXTRA_GOBUILD_FLAGS)
 # Uncomment to enable race detection
 #GOBUILD += -race
 
-# Uncomment to enable deadlock detection
-#GOBUILD += -tags lockdebug
-
 ifneq ($(LOCKDEBUG),)
     GOBUILD += -tags lockdebug
+endif
+
+ifneq ($(CHECKPTR),)
+    # Enable unsafe.Pointer instrumentation, see https://tip.golang.org/doc/go1.14#compiler
+    GOBUILD += -gcflags=all=-d=checkptr
 endif
 
 # Container engine

--- a/cilium-dev.Dockerfile
+++ b/cilium-dev.Dockerfile
@@ -8,6 +8,7 @@ LABEL maintainer="maintainer@cilium.io"
 RUN apt-get install make -y
 WORKDIR /go/src/github.com/cilium/cilium
 ARG LOCKDEBUG
+ARG CHECKPTR
 ARG V
 ARG LIBNETWORK_PLUGIN
 COPY --from=cilium-envoy / /
@@ -24,7 +25,7 @@ COPY ./plugins/cilium-cni ./plugins/cilium-cni
 COPY ./proxylib ./proxylib
 COPY ./Makefile* ./
 RUN for i in proxylib envoy plugins/cilium-cni bpf cilium daemon cilium-health bugtool; \
-     do LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 V=$V LIBNETWORK_PLUGIN=$LIBNETWORK_PLUGIN \
+     do LOCKDEBUG=$LOCKDEBUG CHECKPTR=$CHECKPTR PKG_BUILD=1 V=$V LIBNETWORK_PLUGIN=$LIBNETWORK_PLUGIN \
             SKIP_DOCS=true DESTDIR= \
             make -C $i install; done
 RUN groupadd -f cilium \

--- a/cilium-docker-plugin.Dockerfile
+++ b/cilium-docker-plugin.Dockerfile
@@ -3,8 +3,9 @@ LABEL maintainer="maintainer@cilium.io"
 ADD . /go/src/github.com/cilium/cilium
 WORKDIR /go/src/github.com/cilium/cilium/plugins/cilium-docker
 ARG LOCKDEBUG
+ARG CHECKPTR
 ARG V
-RUN make CGO_ENABLED=0 GOOS=linux LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 EXTRA_GOBUILD_FLAGS="-a -installsuffix cgo"
+RUN make CGO_ENABLED=0 GOOS=linux LOCKDEBUG=$LOCKDEBUG CHECKPTR=$CHECKPTR PKG_BUILD=1 EXTRA_GOBUILD_FLAGS="-a -installsuffix cgo"
 
 FROM scratch
 LABEL maintainer="maintainer@cilium.io"

--- a/cilium-operator.Dockerfile
+++ b/cilium-operator.Dockerfile
@@ -3,8 +3,9 @@ LABEL maintainer="maintainer@cilium.io"
 ADD . /go/src/github.com/cilium/cilium
 WORKDIR /go/src/github.com/cilium/cilium/operator
 ARG LOCKDEBUG
+ARG CHECKPTR
 ARG V
-RUN make CGO_ENABLED=0 GOOS=linux LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 EXTRA_GOBUILD_FLAGS="-a -installsuffix cgo -tags operator_aws"
+RUN make CGO_ENABLED=0 GOOS=linux LOCKDEBUG=$LOCKDEBUG CHECKPTR=$CHECKPTR PKG_BUILD=1 EXTRA_GOBUILD_FLAGS="-a -installsuffix cgo -tags operator_aws"
 
 FROM docker.io/library/alpine:3.9.3 as certs
 RUN apk --update add ca-certificates

--- a/test/provision/compile.sh
+++ b/test/provision/compile.sh
@@ -30,10 +30,10 @@ then
       ./test/provision/container-images.sh cilium_images .
       if [[ "${CILIUM_IMAGE}" == "" && "${CILIUM_OPERATOR_IMAGE}" == "" ]]; then
         echo "building cilium/cilium container image..."
-        make LOCKDEBUG=1 docker-image-no-clean
+        make LOCKDEBUG=1 CHECKPTR=1 docker-image-no-clean
 
         echo "building cilium/operator container image..."
-        make LOCKDEBUG=1 docker-operator-image&
+        make LOCKDEBUG=1 CHECKPTR=1 docker-operator-image&
         export OPERATORPID=$!
 
         echo "pushing cilium/cilium image to k8s1:5000/cilium/cilium-dev..."
@@ -72,7 +72,7 @@ then
     fi
 else
     echo "compiling cilium..."
-    sudo -u vagrant -H -E make LOCKDEBUG=1 SKIP_DOCS=true
+    sudo -u vagrant -H -E make LOCKDEBUG=1 CHECKPTR=1 SKIP_DOCS=true
     echo "installing cilium..."
     make install
     mkdir -p /etc/sysconfig/

--- a/test/provision/helpers.bash
+++ b/test/provision/helpers.bash
@@ -95,7 +95,7 @@ function pull_image_and_push_to_local_registry {
 
 function build_cilium_image {
   echo "building cilium image..."
-  make LOCKDEBUG=1 docker-image-no-clean
+  make LOCKDEBUG=1 CHECKPTR=1 docker-image-no-clean
   echo "tagging cilium image..."
   docker tag cilium/cilium k8s1:5000/cilium/cilium-dev
   echo "pushing cilium image..."
@@ -105,7 +105,7 @@ function build_cilium_image {
 function build_operator_image {
   # build cilium-operator image
   echo "building cilium-operator image..."
-  make LOCKDEBUG=1 docker-operator-image
+  make LOCKDEBUG=1 CHECKPTR=1 docker-operator-image
   echo "tagging cilium-operator image..."
   docker tag cilium/operator k8s1:5000/cilium/operator
   echo "pushing cilium-operator image..."


### PR DESCRIPTION
DO NOT MERGE, testing only.

Check `unsafe.Pointer` using the Go 1.14 `-d=checkptr` compiler option
in CI test builds.

For #10133