### PR TITLE
pkg/ipam: added a max-allocate flag

### DIFF
--- a/Documentation/concepts/ipam/eni.rst
+++ b/Documentation/concepts/ipam/eni.rst
@@ -105,6 +105,14 @@ allocation:
 
   If unspecified, no minimum number of IPs is required.
 
+``spec.ipam.max-allocate``
+  The maximum number of IPs that can be allocated to the node.
+  When the current amount of allocated IPs will approach this value,
+  the considered value for PreAllocate will decrease down to 0 in order to
+  not attempt to allocate more addresses than defined.
+
+  If unspecified, no maximum number of IPs will be enforced.
+
 ``spec.ipam.pre-allocate``
   The number of IP addresses that must be available for allocation at all
   times.  It defines the buffer of addresses available immediately without

--- a/pkg/ipam/node_test.go
+++ b/pkg/ipam/node_test.go
@@ -25,6 +25,7 @@ type testNeededDef struct {
 	used        int
 	preallocate int
 	minallocate int
+	maxallocate int
 	result      int
 }
 
@@ -38,13 +39,16 @@ type testExcessDef struct {
 }
 
 var neededDef = []testNeededDef{
-	{0, 0, 0, 16, 16},
-	{0, 0, 8, 16, 16},
-	{0, 0, 16, 8, 16},
-	{0, 0, 16, 0, 16},
-	{8, 0, 0, 16, 8},
-	{8, 4, 8, 0, 4},
-	{8, 4, 8, 8, 4},
+	{0, 0, 0, 16, 0, 16},
+	{0, 0, 8, 16, 0, 16},
+	{0, 0, 16, 8, 0, 16},
+	{0, 0, 16, 0, 0, 16},
+	{8, 0, 0, 16, 0, 8},
+	{8, 4, 8, 0, 0, 4},
+	{8, 4, 8, 8, 0, 4},
+	{8, 4, 8, 8, 6, 0},
+	{8, 4, 8, 0, 8, 0},
+	{4, 4, 8, 0, 8, 4},
 }
 
 var excessDef = []testExcessDef{
@@ -62,7 +66,7 @@ var excessDef = []testExcessDef{
 
 func (e *IPAMSuite) TestCalculateNeededIPs(c *check.C) {
 	for _, d := range neededDef {
-		result := calculateNeededIPs(d.available, d.used, d.preallocate, d.minallocate)
+		result := calculateNeededIPs(d.available, d.used, d.preallocate, d.minallocate, d.maxallocate)
 		c.Assert(result, check.Equals, d.result)
 	}
 }

--- a/pkg/ipam/types/types.go
+++ b/pkg/ipam/types/types.go
@@ -84,6 +84,14 @@ type IPAMSpec struct {
 	// +optional
 	MinAllocate int `json:"min-allocate,omitempty"`
 
+	// MaxAllocate is the maximum number of IPs that can be allocated to the
+	// node. When the current amount of allocated IPs will approach this value,
+	// the considered value for PreAllocate will decrease down to 0 in order to
+	// not attempt to allocate more addresses than defined.
+	//
+	// +optional
+	MaxAllocate int `json:"max-allocate,omitempty"`
+
 	// PreAllocate defines the number of IP addresses that must be
 	// available for allocation in the IPAMspec. It defines the buffer of
 	// addresses available immediately without requiring cilium-operator to

--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -408,18 +408,24 @@ func createNodeCRD(clientset apiextensionsclient.Interface) error {
 									Type: "object",
 									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
 										"min-allocate": {
-											Type:    "integer",
-											Minimum: getFloat64(0),
-											Description: "min-allocate is the minimum number of IPs that will be allocated before" +
-												" the cilium-agent will write the CNI config.",
+											Type:        "integer",
+											Minimum:     getFloat64(0),
+											Description: "min-allocate is the minimum number of IPs that will be allocated before the cilium-agent will write the CNI config.",
+										},
+										"max-allocate": {
+											Type:        "integer",
+											Minimum:     getFloat64(0),
+											Description: "max-allocate is the maximum number of IPs that will be allocated to the node.",
 										},
 										"pre-allocate": {
-											Type:    "integer",
-											Minimum: getFloat64(0),
+											Type:        "integer",
+											Minimum:     getFloat64(0),
+											Description: "pre-allocate defines the number of IP addresses that must be available for allocation at all times.",
 										},
 										"max-above-watermark": {
-											Type:    "integer",
-											Minimum: getFloat64(0),
+											Type:        "integer",
+											Minimum:     getFloat64(0),
+											Description: "max-above-watermark defines the number of addresses to allocate beyond what is needed to reach the PreAllocate watermark.",
 										},
 										"first-interface-index": {
 											Type:        "integer",
@@ -461,18 +467,24 @@ func createNodeCRD(clientset apiextensionsclient.Interface) error {
 									Type: "object",
 									Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
 										"min-allocate": {
-											Type:    "integer",
-											Minimum: getFloat64(0),
-											Description: "min-allocate is the minimum number of IPs that will be allocated before" +
-												" the cilium-agent will write the CNI config.",
+											Type:        "integer",
+											Minimum:     getFloat64(0),
+											Description: "min-allocate is the minimum number of IPs that will be allocated before the cilium-agent will write the CNI config.",
+										},
+										"max-allocate": {
+											Type:        "integer",
+											Minimum:     getFloat64(0),
+											Description: "max-allocate is the maximum number of IPs that will be allocated to the node.",
 										},
 										"pre-allocate": {
-											Type:    "integer",
-											Minimum: getFloat64(0),
+											Type:        "integer",
+											Minimum:     getFloat64(0),
+											Description: "pre-allocate is number of IP addresses that must be available for allocation at all times.",
 										},
 										"max-above-watermark": {
-											Type:    "integer",
-											Minimum: getFloat64(0),
+											Type:        "integer",
+											Minimum:     getFloat64(0),
+											Description: "max-above-watermark defines the number of addresses to allocate beyond what is needed to reach the PreAllocate watermark.",
 										},
 									},
 								},


### PR DESCRIPTION
The current behaviour of the IPAM is to always attempt to allocate IP addresses according to the `pre-allocate` flag. This change will allow endusers to override this behaviour if they want to by specifying a `max-allocate` flag.

This could prevent the **cilium-operator** from looping when there is no ENIs/IPs that can possibly allocated when a node is approaching its limits. 

Example using a t3a.medium with 15 pods running and pre-allocate set to 8 (default):

```
level=info msg="Synchronized ENI information" numENIs=6 numSecurityGroups=5 numSubnets=12 numVPCs=1 subsys=eni
level=info msg="Resolving IP deficit of node" available=18 instanceID=i-xxxxxxx name=ip-10-0-0-0.eu-west-1.compute.internal remainingInterfaces=0 subsys=eni toAlloc=5 used=15
level=info msg="Synchronized ENI information" numENIs=6 numSecurityGroups=5 numSubnets=12 numVPCs=1 subsys=eni
level=info msg="Resolving IP deficit of node" available=18 instanceID=i-xxxxxxx name=ip-10-0-0-0.eu-west-1.compute.internal remainingInterfaces=0 subsys=eni toAlloc=5 used=15
level=info msg="Synchronized ENI information" numENIs=6 numSecurityGroups=5 numSubnets=12 numVPCs=1 subsys=eni
level=info msg="Resolving IP deficit of node" available=18 instanceID=i-xxxxxxx name=ip-10-0-0-0.eu-west-1.compute.internal remainingInterfaces=0 subsys=eni toAlloc=5 used=15
level=info msg="Synchronized ENI information" numENIs=6 numSecurityGroups=5 numSubnets=12 numVPCs=1 subsys=eni
level=info msg="Resolving IP deficit of node" available=18 instanceID=i-xxxxxxx name=ip-10-0-0-0.eu-west-1.compute.internal remainingInterfaces=0 subsys=eni toAlloc=5 used=15
```

```release-note
added a `max-allocate` flag on **pkg/ipam** to control the maximum amount of IPs being allocated to a node
```
