### PR TITLE
Improve 'cilium-agent --help'

### DIFF
--- a/daemon/cmd/cmdhelp_template.go
+++ b/daemon/cmd/cmdhelp_template.go
@@ -1,0 +1,98 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// Reset the help function to also exit, as we block elsewhere in interrupts
+// and would not exit when called with -h.
+func ResetHelpandExit(appCmd *cobra.Command) {
+	oldHelpFunc := appCmd.HelpFunc()
+	appCmd.SetHelpFunc(func(c *cobra.Command, a []string) {
+		oldHelpFunc(c, a)
+		os.Exit(0)
+	})
+}
+
+// CustomCommandHelp is a function which sets the Usage Template for any
+// command by providing separation of sections for the 'Flags:'.
+func CustomCommandHelpFormat(appCmd *cobra.Command, customtemplate []option.FlagsSection) {
+	origTemplate := appCmd.UsageTemplate()
+	appCmd.SetUsageTemplate(CustomCommandHelpTemplate(origTemplate, appCmd, customtemplate))
+}
+
+// CommandCustomHelpTemplate provides a custom Help template for any command
+func CustomCommandHelpTemplate(orig string, cmd *cobra.Command, sections []option.FlagsSection) string {
+	fi := strings.Index(orig, "Flags:")
+	gfi := strings.Index(orig, "Global Flags:")
+
+	var b bytes.Buffer
+	var seen []string // what flags have already been processed
+
+	// go through all sections defined in the config in order
+	for _, s := range sections {
+		fmt.Fprintf(&b, "%s:\n", s.Name)
+		if s.Desc != "" {
+			fmt.Fprintf(&b, "\n%s\n\n", s.Desc)
+		}
+
+		fs := &pflag.FlagSet{SortFlags: true}
+		for _, f := range s.Flags {
+			// extract the actual command flag by name and add to the set
+			flag := cmd.Flags().Lookup(f)
+			if flag == nil {
+				continue
+			}
+			fs.AddFlag(flag)
+			seen = append(seen, f)
+		}
+
+		// print the usages in the section
+		fmt.Fprintln(&b, fs.FlagUsagesWrapped(120))
+	}
+
+	haveSeen := func(f string) bool {
+		for _, s := range seen {
+			if s == f {
+				return true
+			}
+		}
+		return false
+	}
+
+	// go through the rest of the flags and include them down at the bottom
+	rest := &pflag.FlagSet{SortFlags: true}
+	cmd.LocalFlags().VisitAll(func(f *pflag.Flag) {
+		if haveSeen(f.Name) {
+			return // ignore seen flags
+		}
+		rest.AddFlag(f)
+	})
+	if rest.HasFlags() {
+		fmt.Fprintln(&b, "Other common flags:")
+		fmt.Fprintln(&b, rest.FlagUsagesWrapped(120))
+	}
+
+	return orig[:fi] + b.String() + orig[gfi:]
+}

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -158,14 +158,6 @@ func init() {
 
 	cobra.OnInitialize(option.InitConfig("Cilium", "ciliumd"))
 
-	// Reset the help function to also exit, as we block elsewhere in interrupts
-	// and would not exit when called with -h.
-	oldHelpFunc := RootCmd.HelpFunc()
-	RootCmd.SetHelpFunc(func(c *cobra.Command, a []string) {
-		oldHelpFunc(c, a)
-		os.Exit(0)
-	})
-
 	flags := RootCmd.Flags()
 
 	// Validators
@@ -762,6 +754,12 @@ func init() {
 	option.BindEnv(option.K8sHeartbeatTimeout)
 
 	viper.BindPFlags(flags)
+
+	CustomCommandHelpFormat(RootCmd, option.HelpFlagSections)
+
+	// Reset the help function to also exit, as we block elsewhere in interrupts
+	// and would not exit when called with -h.
+	ResetHelpandExit(RootCmd)
 }
 
 // restoreExecPermissions restores file permissions to 0740 of all files inside

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -48,6 +48,12 @@ var (
 	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "config")
 )
 
+type FlagsSection struct {
+	Name  string   // short one-liner to describe the section
+	Desc  string   // optional paragraph to explain a section
+	Flags []string // names of flags to include in the section
+}
+
 const (
 	// AgentLabels are additional labels to identify this agent
 	AgentLabels = "agent-labels"
@@ -827,6 +833,239 @@ const (
 	// EndpointStatusState enables CiliumEndpoint.Status.State
 	EndpointStatusState = "state"
 )
+
+// HelpFlagSections to format the Cilium Agent help template.
+// Developers please make sure to add the new flags to
+// the respective sections or create a new section.
+var HelpFlagSections = []FlagsSection{
+	{
+		Name: "BPF flags",
+		Flags: []string{
+			BPFRoot,
+			KeepBPFTemplates,
+			CTMapEntriesGlobalTCPName,
+			CTMapEntriesGlobalAnyName,
+			CTMapEntriesTimeoutSYNName,
+			CTMapEntriesTimeoutFINName,
+			CTMapEntriesTimeoutTCPName,
+			CTMapEntriesTimeoutAnyName,
+			CTMapEntriesTimeoutSVCTCPName,
+			CTMapEntriesTimeoutSVCAnyName,
+			NATMapEntriesGlobalName,
+			PolicyMapEntriesName,
+			PreAllocateMapsName,
+			BPFCompileDebugName,
+		},
+	},
+	{
+		Name: "DNS policy flags",
+		Flags: []string{
+			FQDNRejectResponseCode,
+			ToFQDNsEnablePoller,
+			ToFQDNsEnablePollerEvents,
+			ToFQDNsMaxIPsPerHost,
+			ToFQDNsMinTTL,
+			ToFQDNsPreCache,
+			ToFQDNsProxyPort,
+			FQDNProxyResponseMaxDelay,
+			ToFQDNsEnableDNSCompression,
+			ToFQDNsMaxDeferredConnectionDeletes,
+		},
+	},
+	{
+		Name: "Kubernetes flags",
+		Flags: []string{
+			K8sAPIServer,
+			K8sKubeConfigPath,
+			K8sNamespaceName,
+			K8sRequireIPv4PodCIDRName,
+			K8sRequireIPv6PodCIDRName,
+			K8sWatcherEndpointSelector,
+			K8sWatcherQueueSize,
+			K8sEventHandover,
+			DisableK8sServices,
+			AnnotateK8sNode,
+			K8sForceJSONPatch,
+			DisableCiliumEndpointCRDName,
+			K8sHeartbeatTimeout,
+			EnableExternalIPs,
+			K8sEnableEndpointSlice,
+			EnableHostPort,
+			AutoCreateCiliumNodeResource,
+			DisableCNPStatusUpdates,
+			ReadCNIConfiguration,
+			WriteCNIConfigurationWhenReady,
+			EndpointStatus,
+			SkipCRDCreation,
+			FlannelMasterDevice,
+			FlannelUninstallOnExit,
+			EnableWellKnownIdentities,
+		},
+	},
+	{
+		Name: "Clustermesh flags",
+		Flags: []string{
+			ClusterIDName,
+			ClusterName,
+			ClusterMeshConfigName,
+		},
+	},
+	{
+		Name: "Route flags",
+		Flags: []string{
+			SingleClusterRouteName,
+			EnableEndpointRoutes,
+			EnableLocalNodeRoute,
+			BlacklistConflictingRoutes,
+			EnableAutoDirectRoutingName,
+		},
+	},
+	{
+		Name: "Proxy flags",
+		Flags: []string{
+			HTTPIdleTimeout,
+			HTTPMaxGRPCTimeout,
+			HTTPRequestTimeout,
+			HTTPRetryCount,
+			HTTPRetryTimeout,
+			ProxyConnectTimeout,
+			SidecarIstioProxyImage,
+		},
+	},
+	{
+		Name: "Debug, logging and trace flags",
+		Flags: []string{
+			DebugArg,
+			DebugVerbose,
+			EnableTracing,
+			LogDriver,
+			LogOpt,
+			LogSystemLoadConfigName,
+			EnvoyLog,
+			EnableEndpointHealthChecking,
+			EnableHealthChecking,
+			TracePayloadlen,
+			PProf,
+		},
+	},
+	{
+		Name: "Metrics and monitoring flags",
+		Flags: []string{
+			Metrics,
+			MonitorAggregationName,
+			MonitorAggregationFlags,
+			MonitorAggregationInterval,
+			MonitorQueueSizeName,
+			PrometheusServeAddr,
+		},
+	},
+	{
+		Name: "IP flags",
+		Flags: []string{
+			EnableIPv4Name,
+			EnableIPv6Name,
+			IPAllocationTimeout,
+			IPAM,
+			IPv4ClusterCIDRMaskSize,
+			IPv4NodeAddr,
+			IPv6NodeAddr,
+			IPv4PodSubnets,
+			IPv6PodSubnets,
+			IPv4ServiceRange,
+			IPv6ServiceRange,
+			IPv4Range,
+			IPv6Range,
+			LoopbackIPv4,
+			IPv6ClusterAllocCIDRName,
+			MTUName,
+			NAT46Range,
+		},
+	},
+	{
+		Name: "KVstore flags",
+		Flags: []string{
+			KVStore,
+			KVStoreOpt,
+			KVstoreConnectivityTimeout,
+			KVstorePeriodicSync,
+		},
+	},
+	{
+		Name: "Encryption flags",
+		Flags: []string{
+			EncryptInterface,
+			EncryptNode,
+			EnableIPSecName,
+			IPSecKeyFileName,
+		},
+	},
+	{
+		Name: "Policy flags",
+		Flags: []string{
+			AllowLocalhost,
+			AllowICMPFragNeeded,
+			EnablePolicy,
+			ExcludeLocalAddress,
+			ForceLocalPolicyEvalAtSource,
+			PolicyQueueSize,
+			PolicyAuditModeArg,
+			EnableL7Proxy,
+			IdentityAllocationMode,
+			IdentityChangeGracePeriod,
+			FixedIdentityMapping,
+			CertsDirectory,
+		},
+	},
+	{
+		Name: "Hubble flags",
+		Flags: []string{
+			EnableHubble,
+			HubbleSocketPath,
+			HubbleListenAddresses,
+			HubbleFlowBufferSize,
+			HubbleEventQueueSize,
+			HubbleMetricsServer,
+			HubbleMetrics,
+		},
+	},
+	{
+		Name: "Services and address translation flags",
+		Flags: []string{
+			EgressMasqueradeInterfaces,
+			Masquerade,
+			KubeProxyReplacement,
+			EnableNodePort,
+			NodePortMode,
+			NodePortRange,
+			EnableHostReachableServices,
+			HostReachableServicesProtos,
+		},
+	},
+	{
+		Name: "IPtables flags",
+		Flags: []string{
+			PrependIptablesChainsName,
+			InstallIptRules,
+			DisableIptablesFeederRules,
+		},
+	},
+	{
+		Name: "Networking flags",
+		Flags: []string{
+			Device,
+			DatapathMode,
+			ConntrackGCInterval,
+			DisableConntrack,
+			EnableAutoProtectNodePortRange,
+			TunnelName,
+			SockopsEnableName,
+			PrefilterDevice,
+			PrefilterMode,
+			EnableXTSocketFallbackName,
+			IpvlanMasterDevice,
+		},
+	},
+}
 
 // Default string arguments
 var (


### PR DESCRIPTION
This patch adds in a ciliumAgentHelpTemplate to customize the
sections in the help with proper description and heading.

Fixes: #10706
Signed-off-by: Swaminathan Vasudevan <svasudevan@suse.com>

