### PR TITLE
Add note about Cilium with CRIO on minikube

### DIFF
--- a/Documentation/gettingstarted/minikube.rst
+++ b/Documentation/gettingstarted/minikube.rst
@@ -61,6 +61,10 @@ Install Cilium as `DaemonSet
 your new Kubernetes cluster. The DaemonSet will automatically install itself as
 Kubernetes CNI plugin.
 
+.. note::
+
+   In case of installing Cilium with CRIO, please see :ref:`crio-instructions` instructions.
+
 .. parsed-literal::
 
     kubectl create -f \ |SCM_WEB|\/install/kubernetes/quick-install.yaml

--- a/Documentation/kubernetes/configuration.rst
+++ b/Documentation/kubernetes/configuration.rst
@@ -321,6 +321,8 @@ filesystems, the mount point path must be reflected in the unit filename.
 Container Runtimes
 ==================
 
+.. _crio-instructions:
+
 CRIO
 ----
 


### PR DESCRIPTION
This updates the "Getting Started" docs for minikube. This commit was
added to address issue #10624 

-----

I was able to reproduce the issue very easily. I think it would be helpful to have a small note about it because it is not obvious at all what could be going wrong, even though "Getting Started" docs are supposed to be concise. 

Fixes #10624 