### PR TITLE
helm: Remove dsr option leftover from values.yaml

### DIFF
--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -252,9 +252,6 @@ global:
     # device is the name of the device handling NodePort requests
     # device:
 
-    # dsr enables direct server return for NodePort services
-    dsr: false
-
   # externalIPs is the configuration for ExternalIPs service handling
   externalIPs:
     # enabled enables ExternalIPs functionality


### PR DESCRIPTION
To enable DSR, `--set global.nodePort.mode=dsr` is used.

Reported-by: Travis Glenn Hansen (via Slack)

Fix: #10797 