### PR TITLE
cilium, bpf: select v3 BPF CPU in llc for 5.7+ kernels

### DIFF
--- a/pkg/datapath/loader/compile.go
+++ b/pkg/datapath/loader/compile.go
@@ -121,10 +121,18 @@ func GetBPFCPU() string {
 		if !option.Config.DryMode {
 			// We can probe the availability of BPF instructions indirectly
 			// based on what kernel helpers are available since both were
-			// added in the same release, that is, 4.14.
+			// added in the same release, that is, 4.14 for v2 CPU.
 			if h := probes.NewProbeManager().GetHelpers("xdp"); h != nil {
 				if _, ok := h["bpf_redirect_map"]; ok {
 					nameBPFCPU = "v2"
+				}
+			}
+			// For 5.7 select v3 CPU. We could do it also for earlier kernels
+			// but the jmp/alu32 handling is not suited for pre 5.7 due to
+			// lack of 32 bit subreg tracking.
+			if h := probes.NewProbeManager().GetHelpers("cgroup_sock_addr"); h != nil {
+				if _, ok := h["bpf_get_netns_cookie"]; ok {
+					nameBPFCPU = "v3"
 				}
 			}
 		}


### PR DESCRIPTION
Given this kernel has full 32bit subregister tracking, enable llc to
emit instructions for those which also helps us to reduce complexity
on the verifier.

See also complexity comparison in recent commit 4baaa2ceb866 ("docker,
runtime: upgrade to recent clang/llvm image in runtime").

From CI side, we are good as well here since test-me-please runs for:

 - 4.9      kernel compiles with v1 CPU
 - 4.19     kernel compiles with v2 CPU
 - bpf-next kernel compiles with v3 CPU

Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>