### PR TITLE
cilium, contrib: tighten permissions on systemd bpffs mount unit file

### DIFF
--- a/Documentation/kubernetes/configuration.rst
+++ b/Documentation/kubernetes/configuration.rst
@@ -313,6 +313,7 @@ filesystems, the mount point path must be reflected in the unit filename.
         What=bpffs
         Where=/sys/fs/bpf
         Type=bpf
+        Options=rw,nosuid,nodev,noexec,relatime,mode=700
 
         [Install]
         WantedBy=multi-user.target

--- a/contrib/systemd/sys-fs-bpf.mount
+++ b/contrib/systemd/sys-fs-bpf.mount
@@ -9,6 +9,7 @@ After=swap.target
 What=bpffs
 Where=/sys/fs/bpf
 Type=bpf
+Options=rw,nosuid,nodev,noexec,relatime,mode=700
 
 [Install]
 WantedBy=multi-user.target

--- a/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/nodeinit/templates/daemonset.yaml
@@ -112,6 +112,7 @@ spec:
               What=bpffs
               Where=/sys/fs/bpf
               Type=bpf
+              Options=rw,nosuid,nodev,noexec,relatime,mode=700
 
               [Install]
               WantedBy=multi-user.target


### PR DESCRIPTION
Given bpf fs wasn't mounted before, then mount it with stricter
permissions than the default ones (777). Also add few other options
as discussed in #10793 such as `nosuid,nodev,noexec` though at least
from bpf fs side these are ignored.

Fixes: #10793
Reported-by: Travis Glenn Hansen <travisghansen@yahoo.com>
Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>