### PR TITLE
CI: Increase GKE/EKS ginkgo timeout to 3 hours

### DIFF
--- a/jenkinsfiles/ginkgo-eks.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-eks.Jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
 
     environment {
         PROJ_PATH = "src/github.com/cilium/cilium"
-        GINKGO_TIMEOUT="108m"
+        GINKGO_TIMEOUT="180m"
         TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
         GOPATH="${WORKSPACE}"
         AWS_ACCESS_KEY_ID=credentials('eks-secret-key-id')

--- a/jenkinsfiles/ginkgo-gke.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-gke.Jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
 
     environment {
         PROJ_PATH = "src/github.com/cilium/cilium"
-        GINKGO_TIMEOUT="108m"
+        GINKGO_TIMEOUT="180m"
         TESTDIR="${WORKSPACE}/${PROJ_PATH}/test"
         GOPATH="${WORKSPACE}"
         GKE_KEY=credentials('gke-key')


### PR DESCRIPTION
_amusingly, as I make this, we are at the max 5 GKE jobs allowed. This doesn't fix that, and it may fail with "cannot select cluster" instead_

We've been seeing more timeouts on GKE when our CI is under load and
jobs wait in the queue for a free executor. The ginkgo timeout is
intended to be shorter than the jenkins timeout so that cleanups can
happen and so ginkgo can correctly log the timeout (instead of just
being terminated).