### PR TITLE
pkg/option: do not log warnings if flag is not set

### DIFF
--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2395,7 +2395,7 @@ func (c *DaemonConfig) populateHostServicesProtos() error {
 func sanitizeIntParam(paramName string, paramDefault int) int {
 	intParam := viper.GetInt(paramName)
 	if intParam <= 0 {
-		if !viper.IsSet(paramName) {
+		if viper.IsSet(paramName) {
 			log.WithFields(
 				logrus.Fields{
 					"parameter":    paramName,


### PR DESCRIPTION
The condition was not correct, this commit should fix it.

Fixes: e41b96574d89 ("pkg/option: ignore warnings if flags are not set")
Signed-off-by: André Martins <andre@cilium.io>