### PR TITLE
pkg/bpf: remove unused metrics labels

### DIFF
--- a/pkg/bpf/metrics.go
+++ b/pkg/bpf/metrics.go
@@ -15,17 +15,12 @@
 package bpf
 
 const (
-	metricOpCreate           = "create"
-	metricOpUpdate           = "update"
-	metricOpLookup           = "lookup"
-	metricOpDelete           = "delete"
-	metricOpGetNextKey       = "getNextKey"
-	metricOpObjPin           = "objPin"
-	metricOpObjGet           = "objGet"
-	metricOpGetFDByID        = "getFDByID"
-	metricOpProgGetNextID    = "progGetNextID"
-	metricOpObjGetInfoByFD   = "getInfoByFD"
-	metricOpPerfEventOpen    = "perfEventOpen"
-	metricOpPerfEventEnable  = "perfEventEnable"
-	metricOpPerfEventDisable = "perfEventDisable"
+	metricOpCreate     = "create"
+	metricOpUpdate     = "update"
+	metricOpLookup     = "lookup"
+	metricOpDelete     = "delete"
+	metricOpGetNextKey = "getNextKey"
+	metricOpObjPin     = "objPin"
+	metricOpObjGet     = "objGet"
+	metricOpGetFDByID  = "getFDByID"
 )


### PR DESCRIPTION
These are unused since commits 48327b9726f0 ("bpf: remove unused
GetProgNextID and GetProgFDByID") and ae53f9cf7913 ("bpf: Delete perf
event reader implementation"), respectively.