### PR TITLE
pkg/ipam: dynamically fetch the allocatable ipv4 addresses amount from instance limits

### DIFF
--- a/pkg/aws/eni/node_test.go
+++ b/pkg/aws/eni/node_test.go
@@ -1,0 +1,44 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package eni
+
+import (
+	"gopkg.in/check.v1"
+)
+
+func (e *ENISuite) TestGetMaximumAllocatableIPv4(c *check.C) {
+	n := &Node{}
+
+	// With no k8sObj defined, it should return 0
+	c.Assert(n.GetMaximumAllocatableIPv4(), check.Equals, 0)
+
+	// With instance-type = m5.large and first-interface-index = 0, we should be able to allocate up to 30 addresses
+	n.k8sObj = newCiliumNode("node", "i-testnode", "m5.large", "eu-west-1", "test-vpc", 0, 0, 0, 0)
+	c.Assert(n.GetMaximumAllocatableIPv4(), check.Equals, 30)
+
+	// With instance-type = m5.large and first-interface-index = 1, we should be able to allocate up to 20 addresses
+	n.k8sObj = newCiliumNode("node", "i-testnode", "m5.large", "eu-west-1", "test-vpc", 1, 0, 0, 0)
+	c.Assert(n.GetMaximumAllocatableIPv4(), check.Equals, 20)
+
+	// With instance-type = m5.large and first-interface-index = 4, we should return 0 as there is only 3 interfaces
+	n.k8sObj = newCiliumNode("node", "i-testnode", "m5.large", "eu-west-1", "test-vpc", 4, 0, 0, 0)
+	c.Assert(n.GetMaximumAllocatableIPv4(), check.Equals, 0)
+
+	// With instance-type = foo we should return 0
+	n.k8sObj = newCiliumNode("node", "i-testnode", "foo", "eu-west-1", "test-vpc", 0, 0, 0, 0)
+	c.Assert(n.GetMaximumAllocatableIPv4(), check.Equals, 0)
+}

--- a/pkg/azure/ipam/node.go
+++ b/pkg/azure/ipam/node.go
@@ -175,3 +175,11 @@ func (n *Node) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *logrus.Ent
 
 	return available, nil
 }
+
+// GetMaximumAllocatableIPv4 returns the maximum amount of IPv4 addresses
+// that can be allocated to the instance
+func (n *Node) GetMaximumAllocatableIPv4() int {
+	// An Azure node can allocate up to 256 private IP addresses
+	// source: https://github.com/MicrosoftDocs/azure-docs/blob/master/includes/azure-virtual-network-limits.md#networking-limits---azure-resource-manager
+	return types.InterfaceAddressLimit
+}

--- a/pkg/azure/ipam/node_test.go
+++ b/pkg/azure/ipam/node_test.go
@@ -1,0 +1,27 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package ipam
+
+import (
+	"github.com/cilium/cilium/pkg/azure/types"
+	"gopkg.in/check.v1"
+)
+
+func (e *IPAMSuite) TestGetMaximumAllocatableIPv4(c *check.C) {
+	n := &Node{}
+	c.Assert(n.GetMaximumAllocatableIPv4(), check.Equals, types.InterfaceAddressLimit)
+}

--- a/pkg/ipam/node.go
+++ b/pkg/ipam/node.go
@@ -210,7 +210,15 @@ func (n *Node) getMinAllocate() int {
 
 // getMaxAllocate returns the maximum-allocation setting of an AWS node
 func (n *Node) getMaxAllocate() int {
-	return n.resource.Spec.IPAM.MaxAllocate
+	instanceMax := n.ops.GetMaximumAllocatableIPv4()
+	if n.resource.Spec.IPAM.MaxAllocate > 0 {
+		if n.resource.Spec.IPAM.MaxAllocate > instanceMax {
+			n.loggerLocked().Warningf("max-allocate (%d) is higher than the instance type limits (%d)", n.resource.Spec.IPAM.MaxAllocate, instanceMax)
+		}
+		return n.resource.Spec.IPAM.MaxAllocate
+	}
+
+	return instanceMax
 }
 
 // GetNeededAddresses returns the number of needed addresses that need to be

--- a/pkg/ipam/node_manager.go
+++ b/pkg/ipam/node_manager.go
@@ -86,6 +86,10 @@ type NodeOperations interface {
 	// ReleaseIPs is called after invoking PrepareIPRelease and needs to
 	// perform the release of IPs.
 	ReleaseIPs(ctx context.Context, release *ReleaseAction) error
+
+	// GetMaximumAllocatableIPv4 returns the maximum amount of IPv4 addresses
+	// that can be allocated to the instance
+	GetMaximumAllocatableIPv4() int
 }
 
 // AllocationImplementation is the interface an implementation must provide.

--- a/pkg/ipam/node_manager_test.go
+++ b/pkg/ipam/node_manager_test.go
@@ -153,6 +153,10 @@ func (n *nodeOperationsMock) ReleaseIPs(ctx context.Context, release *ReleaseAct
 	return nil
 }
 
+func (n *nodeOperationsMock) GetMaximumAllocatableIPv4() int {
+	return 0
+}
+
 func (e *IPAMSuite) TestGetNodeNames(c *check.C) {
 	am := newAllocationImplementationMock()
 	c.Assert(am, check.Not(check.IsNil))


### PR DESCRIPTION
This PR is a follow-up of #10786 

It primarily focuses on AWS, dynamically figuring out how many addresses we could potentially be allocated to an instance. This will ensure the `cilium-operator` does not go into a IP deficit loop whenever all the IPv4s of have been allocated and used.


```release-note
IPAM: dynamically fetch the allocatable ipv4 addresses amount from instance limits (AWS)
```
