### PR TITLE
helm: Move disable-iptables-feeder-rules out of Hubble section

### DIFF
--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -385,7 +385,9 @@ data:
   # https://github.com/cilium/hubble/blob/master/Documentation/metrics.md
   hubble-metrics: {{ .Values.global.hubble.metrics | join " " | quote }}
   {{- end }}
+{{- end }}
 
+{{- if .Values.global.disableIptablesFeederRules }}
   # A space separated list of iptables chains to disable when installing feeder rules.
   disable-iptables-feeder-rules: {{ .Values.global.disableIptablesFeederRules | join " " | quote }}
 {{- end }}


### PR DESCRIPTION
Before this change, disable-iptables-feeder-rules variable in the
configmap template was included under the if statement covering Hubble
configuration. If Hubble addresses were not defined,
disable-iptable-feeder-rules was not included in the config map. This
change fixes that by moving it in its own if statement.

Fixes: ae4fbbed82e2 ("daemon: add option to disable some feeder tables")
Fixes: #10826

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>