### PR TITLE
Makefile: Fix --yaml arg for microk8s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -390,7 +390,7 @@ check-microk8s:
 	@$(ECHO_CHECK) microk8s is ready...
 	$(QUIET)microk8s.status >/dev/null \
 		|| (echo "Error: Microk8s is not running" && exit 1)
-	$(QUIET)microk8s.status -o yaml | grep -q "registry.*enabled" \
+	$(QUIET)microk8s.status --yaml | grep -q "registry.*enabled" \
 		|| (echo "Error: Microk8s registry must be enabled" && exit 1)
 
 LOCAL_IMAGE_TAG=local


### PR DESCRIPTION
Newer microk8s requires the yaml arg to be specified as `--yaml`, not
`-o yaml`. Fix the target.

Related: https://github.com/ubuntu/microk8s/pull/1042