### PR TITLE
bpf: Fix reversed ENABLE_EXTRA_HOST_DEV condition

### DIFF
--- a/bpf/bpf_netdev.c
+++ b/bpf/bpf_netdev.c
@@ -281,7 +281,7 @@ resolve_srcid_ipv4(struct __ctx_buff *ctx, struct iphdr *ip4,
 				 * can ignore the ipcache if it reports the
 				 * source as HOST_ID.
 				 */
-#ifdef ENABLE_EXTRA_HOST_DEV
+#ifndef ENABLE_EXTRA_HOST_DEV
 				if (sec_label != HOST_ID)
 #endif
 					srcid_from_ipcache = sec_label;


### PR DESCRIPTION
I reversed the `ENABLE_EXTRA_HOST_DEV` condition in #10776 by error because I had initially removed it, thinking it wasn't required anymore. This was using an `#ifndef` [before](https://github.com/cilium/cilium/blob/d573a91f1ab7d241e692b0c671d31d17d86f499a/bpf/bpf_netdev.c#L326).