### PR TITLE
daemon: Remove old policy call map

### DIFF
--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -302,13 +302,14 @@ func (d *Daemon) initMaps() error {
 		return nil
 	}
 
-	// Delete old proxymaps if left over from an upgrade.
-	// TODO: Remove this code when Cilium 1.6 is the oldest supported release
-	for _, name := range []string{"cilium_proxy4", "cilium_proxy6"} {
+	// Delete old maps if left over from an upgrade.
+	// TODO: Remove proxymaps when Cilium 1.6 is the oldest supported release.
+	// TODO: Remove policy map when Cilium 1.8 is the oldest supported release.
+	for _, name := range []string{"cilium_proxy4", "cilium_proxy6", "cilium_policy"} {
 		path := bpf.MapPath(name)
 		if _, err := os.Stat(path); err == nil {
 			if err = os.RemoveAll(path); err == nil {
-				log.Infof("removed legacy proxymap file %s", path)
+				log.Infof("removed legacy map file %s", path)
 			}
 		}
 	}


### PR DESCRIPTION
The policy call map was renamed in commit 5d6b669 from `cilium_policy` to `cilium_call_policy`, but the code to remove the old reference in case of upgrade is missing.

Related: #10626
Fixes: #10781.