### PR TITLE
Docs policy title rename

### DIFF
--- a/Documentation/gettingstarted/http.rst
+++ b/Documentation/gettingstarted/http.rst
@@ -6,9 +6,9 @@
 
 .. _gs_http:
 
-********************************
-HTTP/REST API call authorization
-********************************
+************************************************
+Identity-Aware and HTTP-Aware Policy Enforcement
+************************************************
 
 .. include:: gsg_requirements.rst
 

--- a/Documentation/gettingstarted/index.rst
+++ b/Documentation/gettingstarted/index.rst
@@ -29,8 +29,8 @@ Installation
    k8s-installers
    cni-chaining
 
-Security Tutorials
-------------------
+Network Policy Security Tutorials
+---------------------------------
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
We do not have a separate policy tutorial that covers basic identity-aware network policy, but the title of the star wars demo just talks about HTTP, despite the fact that it covers both label-based identity policies as well as HTTP-aware policies.   Just make the title reflect this.  