### PR TITLE
cli: Clarify help of 'cilium map'

### DIFF
--- a/Documentation/cmdref/cilium.md
+++ b/Documentation/cmdref/cilium.md
@@ -28,7 +28,7 @@ CLI for interacting with the local Cilium Agent
 * [cilium fqdn](../cilium_fqdn)	 - Manage fqdn proxy
 * [cilium identity](../cilium_identity)	 - Manage security identities
 * [cilium kvstore](../cilium_kvstore)	 - Direct access to the kvstore
-* [cilium map](../cilium_map)	 - Access BPF maps
+* [cilium map](../cilium_map)	 - Access userspace cached content of BPF maps
 * [cilium metrics](../cilium_metrics)	 - Access metric status
 * [cilium monitor](../cilium_monitor)	 - Display BPF program events
 * [cilium node](../cilium_node)	 - Manage cluster nodes

--- a/Documentation/cmdref/cilium_map.md
+++ b/Documentation/cmdref/cilium_map.md
@@ -2,11 +2,11 @@
 
 ## cilium map
 
-Access BPF maps
+Access userspace cached content of BPF maps
 
 ### Synopsis
 
-Access BPF maps
+Access userspace cached content of BPF maps
 
 ### Options
 
@@ -25,6 +25,6 @@ Access BPF maps
 ### SEE ALSO
 
 * [cilium](../cilium)	 - CLI
-* [cilium map get](../cilium_map_get)	 - Display BPF map information
+* [cilium map get](../cilium_map_get)	 - Display cached content of given BPF map
 * [cilium map list](../cilium_map_list)	 - List all open BPF maps
 

--- a/Documentation/cmdref/cilium_map_get.md
+++ b/Documentation/cmdref/cilium_map_get.md
@@ -2,11 +2,11 @@
 
 ## cilium map get
 
-Display BPF map information
+Display cached content of given BPF map
 
 ### Synopsis
 
-Display BPF map information
+Display cached content of given BPF map
 
 ```
 cilium map get <name> [flags]
@@ -35,5 +35,5 @@ cilium map get cilium_ipcache
 
 ### SEE ALSO
 
-* [cilium map](../cilium_map)	 - Access BPF maps
+* [cilium map](../cilium_map)	 - Access userspace cached content of BPF maps
 

--- a/Documentation/cmdref/cilium_map_list.md
+++ b/Documentation/cmdref/cilium_map_list.md
@@ -36,5 +36,5 @@ cilium map list
 
 ### SEE ALSO
 
-* [cilium map](../cilium_map)	 - Access BPF maps
+* [cilium map](../cilium_map)	 - Access userspace cached content of BPF maps
 

--- a/cilium/cmd/map.go
+++ b/cilium/cmd/map.go
@@ -21,7 +21,7 @@ import (
 // mapCmd represents the map command
 var mapCmd = &cobra.Command{
 	Use:   "map",
-	Short: "Access BPF maps",
+	Short: "Access userspace cached content of BPF maps",
 }
 
 func init() {

--- a/cilium/cmd/map_get.go
+++ b/cilium/cmd/map_get.go
@@ -30,7 +30,7 @@ import (
 // mapGetCmd represents the map_get command
 var mapGetCmd = &cobra.Command{
 	Use:     "get <name>",
-	Short:   "Display BPF map information",
+	Short:   "Display cached content of given BPF map",
 	Example: "cilium map get cilium_ipcache",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {


### PR DESCRIPTION
This commit clarifies that `cilium map get [name]` returns a userspace cache of the map content and not the actual map content.