### PR TITLE
all: remove unnecessary use of fmt.Sprintf

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -516,7 +516,7 @@ func init() {
 			"with ephemeral port range (net.ipv4.ip_local_port_range)")
 	option.BindEnv(option.EnableAutoProtectNodePortRange)
 
-	flags.StringSlice(option.NodePortRange, []string{fmt.Sprintf("%d", option.NodePortMinDefault), fmt.Sprintf("%d", option.NodePortMaxDefault)}, fmt.Sprintf("Set the min/max NodePort port range"))
+	flags.StringSlice(option.NodePortRange, []string{fmt.Sprintf("%d", option.NodePortMinDefault), fmt.Sprintf("%d", option.NodePortMaxDefault)}, "Set the min/max NodePort port range")
 	option.BindEnv(option.NodePortRange)
 
 	flags.String(option.LibDir, defaults.LibraryPath, "Directory path to store runtime build environment")

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -155,7 +155,7 @@ func init() {
 	flags.Float32(option.K8sClientQPSLimit, defaults.K8sClientQPSLimit, "Queries per second limit for the K8s client")
 	flags.Int(option.K8sClientBurst, defaults.K8sClientBurst, "Burst value allowed for the K8s client")
 
-	flags.Bool(option.K8sEnableEndpointSlice, defaults.K8sEnableEndpointSlice, fmt.Sprintf("Enables k8s EndpointSlice feature into Cilium-Operator if the k8s cluster supports it"))
+	flags.Bool(option.K8sEnableEndpointSlice, defaults.K8sEnableEndpointSlice, "Enables k8s EndpointSlice feature into Cilium-Operator if the k8s cluster supports it")
 	option.BindEnv(option.K8sEnableEndpointSlice)
 
 	flags.String(option.K8sNamespaceName, "", "Name of the Kubernetes namespace in which Cilium Operator is deployed in")

--- a/pkg/ipam/hostscope.go
+++ b/pkg/ipam/hostscope.go
@@ -85,7 +85,7 @@ func (h *hostScopeAllocator) Dump() (map[string]string, string) {
 	alloc := map[string]string{}
 	_, data, err := h.allocator.Snapshot()
 	if err != nil {
-		return nil, fmt.Sprintf("Unable to get a snapshot of the allocator")
+		return nil, "Unable to get a snapshot of the allocator"
 	}
 	if h.allocCIDR.IP.To4() != nil {
 		origIP = big.NewInt(0).SetBytes(h.allocCIDR.IP.To4())

--- a/pkg/maps/ipcache/ipcache.go
+++ b/pkg/maps/ipcache/ipcache.go
@@ -90,7 +90,7 @@ func (k Key) String() string {
 		ipStr := k.IP.String()
 		return fmt.Sprintf("%s/%d", ipStr, prefixLen)
 	}
-	return fmt.Sprintf("<unknown>")
+	return "<unknown>"
 }
 
 // getPrefixLen determines the length that should be set inside the Key so that

--- a/pkg/maps/lxcmap/lxcmap.go
+++ b/pkg/maps/lxcmap/lxcmap.go
@@ -175,7 +175,7 @@ func (v *EndpointInfo) IsHost() bool {
 // String returns the human readable representation of an EndpointInfo
 func (v *EndpointInfo) String() string {
 	if v.Flags&EndpointFlagHost != 0 {
-		return fmt.Sprintf("(localhost)")
+		return "(localhost)"
 	}
 
 	return fmt.Sprintf("id=%-5d flags=0x%04X ifindex=%-3d mac=%s nodemac=%s",

--- a/pkg/maps/neighborsmap/neighborsmap.go
+++ b/pkg/maps/neighborsmap/neighborsmap.go
@@ -15,7 +15,6 @@
 package neighborsmap
 
 import (
-	"fmt"
 	"unsafe"
 
 	"github.com/cilium/cilium/common/types"
@@ -62,13 +61,13 @@ func (k *Key6) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(k) }
 func (v *Value) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(v) }
 
 // String converts the key into a human readable string format.
-func (k *Key4) String() string { return fmt.Sprintf("%s", k.ipv4) }
+func (k *Key4) String() string { return k.ipv4.String() }
 
 // String converts the key into a human readable string format.
-func (k *Key6) String() string { return fmt.Sprintf("%s", k.ipv6) }
+func (k *Key6) String() string { return k.ipv6.String() }
 
 // String converts the value into a human readable string format.
-func (v *Value) String() string { return fmt.Sprintf("%s", v.macaddr) }
+func (v *Value) String() string { return v.macaddr.String() }
 
 // NewValue returns a new empty instance of the structure representing the BPF
 // map value.

--- a/pkg/monitor/datapath_debug.go
+++ b/pkg/monitor/datapath_debug.go
@@ -275,7 +275,7 @@ func (n *DebugMsg) subTypeString() string {
 	case DbgIcmp6Ns:
 		return fmt.Sprintf("ICMPv6 neighbour soliciation for address %x:%x", n.Arg1, n.Arg2)
 	case DbgIcmp6TimeExceeded:
-		return fmt.Sprintf("Sending ICMPv6 time exceeded")
+		return "Sending ICMPv6 time exceeded"
 	case DbgDecap:
 		return fmt.Sprintf("Tunnel decap: id=%d flowlabel=%x", n.Arg1, n.Arg2)
 	case DbgPortMap:
@@ -309,7 +309,7 @@ func (n *DebugMsg) subTypeString() string {
 	case DbgLb4LookupMaster:
 		return fmt.Sprintf("Master service lookup, addr=%s key.dport=%d", ip4Str(n.Arg1), byteorder.NetworkToHost(uint16(n.Arg2)))
 	case DbgLb4LookupMasterFail:
-		return fmt.Sprintf("Master service lookup failed")
+		return "Master service lookup failed"
 	case DbgLb4LookupSlaveSuccess:
 		return fmt.Sprintf("Slave service lookup result: target=%s port=%d", ip4Str(n.Arg1), byteorder.NetworkToHost(uint16(n.Arg2)))
 	case DbgLb4ReverseNat:

--- a/pkg/monitor/datapath_trace.go
+++ b/pkg/monitor/datapath_trace.go
@@ -138,7 +138,7 @@ func DecodeTraceNotify(data []byte, tn *TraceNotify) error {
 
 func (n *TraceNotify) encryptReason() string {
 	if (n.Reason & TraceReasonEncryptMask) != 0 {
-		return fmt.Sprintf("encrypted ")
+		return "encrypted "
 	}
 	return ""
 }

--- a/pkg/option/option.go
+++ b/pkg/option/option.go
@@ -183,9 +183,9 @@ func (o *IntOptions) GetMutableModel() *models.ConfigurationMap {
 		if config != nil {
 			if config.Format == nil {
 				if v == OptionDisabled {
-					mutableCfg[k] = fmt.Sprintf("Disabled")
+					mutableCfg[k] = "Disabled"
 				} else {
-					mutableCfg[k] = fmt.Sprintf("Enabled")
+					mutableCfg[k] = "Enabled"
 				}
 			} else {
 				mutableCfg[k] = config.Format(v)

--- a/pkg/proxy/kafka.go
+++ b/pkg/proxy/kafka.go
@@ -331,7 +331,7 @@ func (k *kafkaRedirect) handleRequest(pair *connectionPair, req *kafka.RequestMe
 		}
 
 		record.log(accesslog.VerdictDenied,
-			kafka.ErrTopicAuthorizationFailed, fmt.Sprint("Kafka request is denied by policy"))
+			kafka.ErrTopicAuthorizationFailed, "Kafka request is denied by policy")
 
 		pair.Rx.Enqueue(resp.GetRaw())
 		return

--- a/pkg/tuple/tuple.go
+++ b/pkg/tuple/tuple.go
@@ -16,7 +16,6 @@ package tuple
 
 import (
 	"bytes"
-	"fmt"
 	"unsafe"
 
 	"github.com/cilium/cilium/pkg/bpf"
@@ -66,5 +65,5 @@ func (t *TupleValStub) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(t) }
 
 // String stub method.
 func (t *TupleValStub) String() string {
-	return fmt.Sprintf("<TupleValStub>")
+	return "<TupleValStub>"
 }

--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -161,7 +161,7 @@ func (s *SSHMeta) WaitEndpointsDeleted() bool {
 	// cilium-health endpoint is always running.
 	desiredState := "1"
 	body := func() bool {
-		cmd := fmt.Sprintf(`cilium endpoint list -o json | jq '. | length'`)
+		cmd := `cilium endpoint list -o json | jq '. | length'`
 		res := s.Exec(cmd)
 		numEndpointsRunning := strings.TrimSpace(res.GetStdOut())
 		if numEndpointsRunning == desiredState {
@@ -419,7 +419,7 @@ func (s *SSHMeta) SetPolicyEnforcement(status string) *CmdRes {
 	// We check before setting PolicyEnforcement; if we do not, EndpointWait
 	// will fail due to the status of the endpoints not changing.
 	log.Infof("setting %s=%s", PolicyEnforcement, status)
-	res := s.ExecCilium(fmt.Sprintf("config -o json | jq -r '.status.realized[\"policy-enforcement\"]'"))
+	res := s.ExecCilium("config -o json | jq -r '.status.realized[\"policy-enforcement\"]'")
 	if res.SingleOut() == status {
 		return res
 	}

--- a/test/k8sT/Chaos.go
+++ b/test/k8sT/Chaos.go
@@ -61,7 +61,7 @@ var _ = Describe("K8sChaosTest", func() {
 			kubectl.ApplyDefault(demoDSPath).ExpectSuccess("DS deployment cannot be applied")
 
 			err := kubectl.WaitforPods(
-				helpers.DefaultNamespace, fmt.Sprintf("-l zgroup=testDS"), helpers.HelperTimeout)
+				helpers.DefaultNamespace, "-l zgroup=testDS", helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Pods are not ready after timeout")
 		})
 
@@ -121,7 +121,7 @@ var _ = Describe("K8sChaosTest", func() {
 			By("Waiting for deployed pods to be ready")
 			err := kubectl.WaitforPods(
 				helpers.DefaultNamespace,
-				fmt.Sprintf("-l zgroup=testDSClient"), helpers.HelperTimeout)
+				"-l zgroup=testDSClient", helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Pods are not ready after timeout")
 
 			err = kubectl.CiliumEndpointWaitReady()
@@ -190,7 +190,7 @@ var _ = Describe("K8sChaosTest", func() {
 
 			err := kubectl.WaitforPods(
 				helpers.DefaultNamespace,
-				fmt.Sprintf("-l zgroup=testapp"), helpers.HelperTimeout)
+				"-l zgroup=testapp", helpers.HelperTimeout)
 			Expect(err).Should(BeNil(), "Pods are not ready after timeout")
 
 			podsIps, err = kubectl.GetPodsIPs(helpers.DefaultNamespace, "zgroup=testapp")

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -84,7 +84,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 		err := kubectl.WaitforPods(
 			helpers.DefaultNamespace,
-			fmt.Sprintf("-l zgroup=testapp"), helpers.HelperTimeout)
+			"-l zgroup=testapp", helpers.HelperTimeout)
 		Expect(err).Should(BeNil(), "Pods are not ready after timeout")
 
 		_, err = kubectl.GetPodsIPs(helpers.DefaultNamespace, "zgroup=testapp")
@@ -100,7 +100,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 		err := kubectl.WaitforPods(
 			helpers.DefaultNamespace,
-			fmt.Sprintf("-l zgroup=http-server"), helpers.HelperTimeout)
+			"-l zgroup=http-server", helpers.HelperTimeout)
 		Expect(err).Should(BeNil(), "Pods are not ready after timeout")
 
 		_, err = kubectl.GetPodsIPs(helpers.DefaultNamespace, "zgroup=http-server")
@@ -113,7 +113,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 		err := kubectl.WaitforPods(
 			helpers.DefaultNamespace,
-			fmt.Sprintf("-l zgroup=http-clients"), helpers.HelperTimeout)
+			"-l zgroup=http-clients", helpers.HelperTimeout)
 		Expect(err).Should(BeNil(), "Pods are not ready after timeout")
 
 		_, err = kubectl.GetPodsIPs(helpers.DefaultNamespace, "zgroup=http-clients")

--- a/test/k8sT/Health.go
+++ b/test/k8sT/Health.go
@@ -69,7 +69,7 @@ var _ = Describe("K8sHealthTest", func() {
 	}
 
 	checkIP := func(pod, ip string) {
-		jsonpath := fmt.Sprintf("{.nodes[*].host.primary-address.ip}")
+		jsonpath := "{.nodes[*].host.primary-address.ip}"
 		ciliumCmd := fmt.Sprintf("cilium-health status -o jsonpath='%s'", jsonpath)
 
 		err := kubectl.CiliumExecUntilMatch(pod, ciliumCmd, ip)
@@ -90,7 +90,7 @@ var _ = Describe("K8sHealthTest", func() {
 		checkIP(cilium2, cilium2IP)
 
 		By("checking that `cilium-health --probe` succeeds")
-		healthCmd := fmt.Sprintf("cilium-health status --probe -o json")
+		healthCmd := "cilium-health status --probe -o json"
 		status := kubectl.CiliumExec(cilium1, healthCmd)
 		Expect(status.Output()).ShouldNot(ContainSubstring("error"))
 		status.ExpectSuccess()

--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -104,7 +104,7 @@ var _ = Describe("NightlyEpsMeasurement", func() {
 	getServices := func() map[string]string {
 		// getServices returns a map of services, where service name is the key
 		// and the ClusterIP is the value.
-		services, err := kubectl.Get(helpers.DefaultNamespace, fmt.Sprintf("services -l zgroup=testapp")).Filter(
+		services, err := kubectl.Get(helpers.DefaultNamespace, "services -l zgroup=testapp").Filter(
 			`{range .items[*]}{.metadata.name}{"="}{.spec.clusterIP}{"\n"}{end}`)
 		ExpectWithOffset(1, err).To(BeNil(), "cannot retrieve testapp services")
 		result := make(map[string]string)

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -870,7 +870,7 @@ var _ = Describe("K8sPolicyTest", func() {
 
 				switch parser {
 				case policy.ParserTypeDNS:
-					reStr := fmt.Sprintf("Request dns from.*Forwarded DNS Query:.*")
+					reStr := "Request dns from.*Forwarded DNS Query:.*"
 					re = regexp.MustCompile(reStr)
 					curlCmd = helpers.CurlFail(resource)
 				case policy.ParserTypeHTTP:

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -645,7 +645,7 @@ var _ = Describe("K8sServicesTest", func() {
 			count := 10
 
 			pod, err := kubectl.GetCiliumPodOnNode(helpers.CiliumNamespace, helpers.K8s2)
-			Expect(err).Should(BeNil(), fmt.Sprintf("Cannot determine cilium pod name"))
+			Expect(err).Should(BeNil(), "Cannot determine cilium pod name")
 
 			res := kubectl.CiliumExec(pod, "cilium service list | grep "+k8s2IP+":"+httpHostPortStr+" | grep HostPort")
 			Expect(res.GetStdOut()).ShouldNot(BeEmpty(), "No HostPort entry for "+k8s2IP+":"+httpHostPortStr)
@@ -828,7 +828,7 @@ var _ = Describe("K8sServicesTest", func() {
 					// Test whether DSR NAT entries are evicted by GC
 
 					pod, err := kubectl.GetCiliumPodOnNode(helpers.CiliumNamespace, helpers.K8s2)
-					Expect(err).Should(BeNil(), fmt.Sprintf("Cannot determine cilium pod name"))
+					Expect(err).Should(BeNil(), "Cannot determine cilium pod name")
 					// "test-nodeport-k8s2" because we want to trigger SNAT with a single request:
 					// client -> k8s1 -> endpoint @ k8s2.
 					err = kubectl.Get(helpers.DefaultNamespace, "service test-nodeport-k8s2").Unmarshal(&data)

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -1177,7 +1177,7 @@ var _ = Describe("RuntimePolicies", func() {
 			// docker network inspect bridge | jq -r '.[0]."IPAM"."Config"[0]."Gateway"'
 			res = vm.NetworkGet("bridge")
 			res.ExpectSuccess("No docker bridge available for testing egress CIDR within host")
-			filter := fmt.Sprintf(`{ [0].IPAM.Config[0].Gateway }`)
+			filter := `{ [0].IPAM.Config[0].Gateway }`
 			obj, err := res.FindResults(filter)
 			Expect(err).NotTo(HaveOccurred(), "Error occurred while finding docker bridge IP")
 			Expect(obj).To(HaveLen(1), "Unexpectedly found more than one IPAM config element for docker bridge")
@@ -1681,11 +1681,11 @@ var _ = Describe("RuntimePolicyImportTests", func() {
 		}
 		By("Invalid Json")
 
-		invalidJSON := fmt.Sprintf(`
+		invalidJSON := `
 		[{
 			"endpointSelector": {
 				"matchLabels":{"id.httpd1":""}
-			},`)
+			},`
 		testInvalidPolicy(invalidJSON)
 	})
 
@@ -1758,7 +1758,7 @@ var _ = Describe("RuntimePolicyImportTests", func() {
 
 		By("Importing policy that allows ingress to %q from the host and %q", httpd1Label, httpd2Label)
 
-		allowHttpd1IngressHostHttpd2 := fmt.Sprintf(`
+		allowHttpd1IngressHostHttpd2 := `
 			[{
     			"endpointSelector": {"matchLabels":{"id.httpd1":""}},
     			"ingress": [{
@@ -1767,7 +1767,7 @@ var _ = Describe("RuntimePolicyImportTests", func() {
             			{"matchLabels":{"id.httpd2":""}}
 					]
     			}]
-			}]`)
+			}]`
 
 		_, err := vm.PolicyRenderAndImport(allowHttpd1IngressHostHttpd2)
 		Expect(err).Should(BeNil(), "Error importing policy: %s", err)
@@ -1822,7 +1822,7 @@ var _ = Describe("RuntimePolicyImportTests", func() {
 		res = vm.PolicyDelAll()
 		res.ExpectSuccess("Unable to delete all policies")
 
-		allowHttpd1IngressHttpd2 := fmt.Sprintf(`
+		allowHttpd1IngressHttpd2 := `
 			[{
     			"endpointSelector": {"matchLabels":{"id.httpd1":""}},
     			"ingress": [{
@@ -1830,7 +1830,7 @@ var _ = Describe("RuntimePolicyImportTests", func() {
             			{"matchLabels":{"id.httpd2":""}}
 					]
     			}]
-			}]`)
+			}]`
 
 		_, err = vm.PolicyRenderAndImport(allowHttpd1IngressHttpd2)
 		Expect(err).Should(BeNil(), "Error importing policy: %s", err)


### PR DESCRIPTION
Found using `staticcheck -checks S1039 ./...`