### PR TITLE
CI monitor reading

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -729,22 +729,8 @@ func (kub *Kubectl) MonitorStart(namespace, pod, filename string) func() error {
 	cb := func() error {
 		cancel()
 		<-ctx.Done()
-		testPath, err := CreateReportDirectory()
-		if err != nil {
-			kub.Logger().WithError(err).Errorf(
-				"cannot create test results path '%s'", testPath)
-			return err
-		}
 
-		err = WriteOrAppendToFile(
-			filepath.Join(testPath, filename),
-			res.CombineOutput().Bytes(),
-			LogPerm)
-		if err != nil {
-			log.WithError(err).Errorf("cannot create monitor log file %s", filename)
-			return err
-		}
-		return nil
+		return WriteToReportFile(res.CombineOutput().Bytes(), filename)
 	}
 
 	return cb

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -719,21 +719,14 @@ func (kub *Kubectl) Logs(namespace string, pod string) *CmdRes {
 		fmt.Sprintf("%s -n %s logs %s", KubectlCmd, namespace, pod))
 }
 
-// MonitorStart runs cilium monitor in the background and dumps the contents
-// into a log file for later debugging
-func (kub *Kubectl) MonitorStart(namespace, pod, filename string) func() error {
+// MonitorStart runs cilium monitor in the background and returns the command
+// result, CmdRes, along with a cancel function. The cancel function is used to
+// stop the monitor.
+func (kub *Kubectl) MonitorStart(namespace, pod string) (res *CmdRes, cancel func()) {
 	cmd := fmt.Sprintf("%s exec -n %s %s -- cilium monitor -vv", KubectlCmd, namespace, pod)
 	ctx, cancel := context.WithCancel(context.Background())
-	res := kub.ExecInBackground(ctx, cmd, ExecOptions{SkipLog: true})
 
-	cb := func() error {
-		cancel()
-		<-ctx.Done()
-
-		return WriteToReportFile(res.CombineOutput().Bytes(), filename)
-	}
-
-	return cb
+	return kub.ExecInBackground(ctx, cmd, ExecOptions{SkipLog: true}), cancel
 }
 
 // BackgroundReport dumps the result of the given commands on cilium pods each

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -283,6 +283,25 @@ func CreateLogFile(filename string, data []byte) error {
 	return err
 }
 
+// WriteToReportFile writes data to filename. It appends to existing files.
+func WriteToReportFile(data []byte, filename string) error {
+	testPath, err := CreateReportDirectory()
+	if err != nil {
+		log.WithError(err).Errorf("cannot create test results path '%s'", testPath)
+		return err
+	}
+
+	err = WriteOrAppendToFile(
+		filepath.Join(testPath, filename),
+		data,
+		LogPerm)
+	if err != nil {
+		log.WithError(err).Errorf("cannot create monitor log file %s", filename)
+		return err
+	}
+	return nil
+}
+
 // reportMap saves the output of the given commands to the specified filename.
 // Function needs a directory path where the files are going to be written and
 // a *SSHMeta instance to execute the commands

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -17,8 +17,6 @@ package k8sTest
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
-	"regexp"
 	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -855,7 +853,7 @@ var _ = Describe("K8sPolicyTest", func() {
 			checkProxyRedirection := func(resource string, redirected bool, parser policy.L7ParserType) {
 				var (
 					not     = " "
-					re      *regexp.Regexp
+					reStr   string
 					curlCmd string
 				)
 
@@ -865,12 +863,10 @@ var _ = Describe("K8sPolicyTest", func() {
 
 				switch parser {
 				case policy.ParserTypeDNS:
-					reStr := "Request dns from.*Forwarded DNS Query:.*"
-					re = regexp.MustCompile(reStr)
+					reStr = "Request dns from.*Forwarded DNS Query:.*"
 					curlCmd = helpers.CurlFail(resource)
 				case policy.ParserTypeHTTP:
-					reStr := fmt.Sprintf("verdict Forwarded GET http://%s/public", resource)
-					re = regexp.MustCompile(reStr)
+					reStr = fmt.Sprintf("verdict Forwarded GET http://%s/public", resource)
 					curlCmd = helpers.CurlFail(fmt.Sprintf("http://%s/public", resource))
 				default:
 					Fail(fmt.Sprintf("invalid parser type for proxy visibility: %s", parser))
@@ -879,7 +875,12 @@ var _ = Describe("K8sPolicyTest", func() {
 				monitorFile := fmt.Sprintf(monitorFileName, uuid.NewUUID().String())
 
 				By("Starting monitor and generating traffic which should%s redirect to proxy", not)
-				monitorStop := kubectl.MonitorStart(helpers.CiliumNamespace, ciliumPod, monitorFile)
+				monitorRes, monitorCancel := kubectl.MonitorStart(helpers.CiliumNamespace, ciliumPod)
+				defer func() {
+					monitorCancel()
+					monitorRes.WaitUntilFinish()
+					helpers.WriteToReportFile(monitorRes.CombineOutput().Bytes(), monitorFile)
+				}()
 
 				// Let the monitor get started since it is started in the background.
 				time.Sleep(2 * time.Second)
@@ -888,19 +889,14 @@ var _ = Describe("K8sPolicyTest", func() {
 					curlCmd)
 				// Give time for the monitor to be notified of the proxy flow.
 				time.Sleep(2 * time.Second)
-				monitorStop()
 				res.ExpectSuccess("%q cannot curl %q", appPods[helpers.App2], resource)
-				monitorPath := fmt.Sprintf("%s/%s", helpers.ReportDirectoryPath(), monitorFile)
-				By("Reading the monitor log at %s", monitorPath)
-				monitorOutput, err := ioutil.ReadFile(monitorPath)
-				ExpectWithOffset(1, err).To(BeNil(), "Could not read monitor log")
 
 				By("Checking that aforementioned traffic was%sredirected to the proxy", not)
-				out := re.Find(monitorOutput)
+				err := monitorRes.WaitUntilMatchRegexp(reStr)
 				if redirected {
-					ExpectWithOffset(1, out).ToNot(BeNil(), "traffic was not redirected to the proxy when it should have been")
+					ExpectWithOffset(1, err).To(BeNil(), "traffic was not redirected to the proxy when it should have been")
 				} else {
-					ExpectWithOffset(1, out).To(BeNil(), "traffic was redirected to the proxy when it should have not been redirected")
+					ExpectWithOffset(1, err).ToNot(BeNil(), "traffic was redirected to the proxy when it should have not been redirected")
 				}
 			}
 

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -210,9 +210,11 @@ var _ = Describe("K8sServicesTest", func() {
 			Expect(govalidator.IsIP(clusterIP)).Should(BeTrue(), "ClusterIP is not an IP")
 
 			By("testing connectivity via cluster IP %s", clusterIP)
-			monitorStop := kubectl.MonitorStart(helpers.CiliumNamespace, ciliumPodK8s1,
-				"cluster-ip-same-node.log")
-			defer monitorStop()
+			monitorRes, monitorCancel := kubectl.MonitorStart(helpers.CiliumNamespace, ciliumPodK8s1)
+			defer func() {
+				monitorCancel()
+				helpers.WriteToReportFile(monitorRes.CombineOutput().Bytes(), "cluster-ip-same-node.log")
+			}()
 
 			httpSVCURL := fmt.Sprintf("http://%s/", clusterIP)
 			tftpSVCURL := fmt.Sprintf("tftp://%s/hello", clusterIP)


### PR DESCRIPTION
We see flakes in tests that read from monitor. These are structured to search monitor output for specific substrings. Since monitor may take some time to start up, we can change how we read its output. The 3 tests now read this incrementally, and fail on a timeout. This should allow it to pass when monitor was simply slow to print.

I haven't seen the specific flake in a bunch of testing with this PR. Most test runs have failed, however, often in other tests. I'm fairly confident that I didn't break anything but I would prefer more clean passes. It does do better on GKE and that is where we see the flake the most, however.

@joestringer I think we once discussed this flake in a PR, so I pulled you in for review. Feel free to unassign yourself.
