### PR TITLE
Fix corrupted bpf_features.h

### DIFF
--- a/pkg/datapath/linux/probes/probes.go
+++ b/pkg/datapath/linux/probes/probes.go
@@ -252,7 +252,7 @@ func (p *ProbeManager) writeHeaders(featuresFile io.Writer) error {
 	io.WriteString(writer, "#ifndef BPF_FEATURES_H_\n")
 	io.WriteString(writer, "#define BPF_FEATURES_H_\n\n")
 
-	go io.Copy(writer, stdoutPipe)
+	io.Copy(writer, stdoutPipe)
 	if err := cmd.Wait(); err != nil {
 		stderr, err := ioutil.ReadAll(stderrPipe)
 		if err != nil {

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -213,6 +213,8 @@ const (
 	emptyBPFInitArg   = "empty argument passed to bpf/init.sh"       // from https://github.com/cilium/cilium/issues/10228
 	RemovingMapMsg    = "Removing map to allow for property upgrade" // from https://github.com/cilium/cilium/pull/10626
 	logBufferMessage  = "Log buffer too small to dump verifier log"  // from https://github.com/cilium/cilium/issues/10517
+	ClangErrorsMsg    = " errors generated."                         // from https://github.com/cilium/cilium/issues/10857
+	ClangErrorMsg     = "1 error generated."                         // from https://github.com/cilium/cilium/issues/10857
 
 	// HelmTemplate is the location of the Helm templates to install Cilium
 	HelmTemplate = "../install/kubernetes/cilium"
@@ -268,6 +270,8 @@ var badLogMessages = map[string][]string{
 	emptyBPFInitArg:   nil,
 	RemovingMapMsg:    nil,
 	logBufferMessage:  nil,
+	ClangErrorsMsg:    nil,
+	ClangErrorMsg:     nil,
 }
 
 var ciliumCLICommands = map[string]string{

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -19,6 +19,7 @@ import (
 	"io/ioutil"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/cilium/cilium/test/config"
 	. "github.com/cilium/cilium/test/ginkgo-ext"
@@ -73,7 +74,12 @@ var _ = Describe("K8sDatapathConfig", func() {
 				"Service is deleted")
 		}
 
-		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
+		blacklist := helpers.GetBadLogMessages()
+		if strings.Contains(CurrentGinkgoTestDescription().TestText, "sockops") {
+			delete(blacklist, helpers.ClangErrorsMsg)
+			delete(blacklist, helpers.ClangErrorMsg)
+		}
+		kubectl.ValidateListOfErrorsInLogs(CurrentGinkgoTestDescription().Duration, blacklist)
 	})
 
 	deployNetperf := func() {


### PR DESCRIPTION
When copying the output of bpftool into the `bpf_features.h` file, although we wait for the bpftool command to finish, we don't wait for the consumer goroutine. This issue can lead to corrupted `bpf_features.h` files. We however do not need a goroutine to copy bpftool's output.

The first commit adds two new messages to `badLogMessages` to fail tests with compilation errors. These new log messages must however be whitelisted for sockops tests for which they are expected on older kernels. The second commit removes the goroutine to copy bpftool's output.

Fixes: #10857
Fixes: #10019