### PR TITLE
monitor: rename and use traceNotifyV[12]Len consts

### DIFF
--- a/pkg/monitor/datapath_trace.go
+++ b/pkg/monitor/datapath_trace.go
@@ -30,10 +30,10 @@ import (
 const (
 	// traceNotifyCommonLen is the minimum length required to determine the version of the TN event.
 	traceNotifyCommonLen = 16
-	// traceNotifyV1Len is the amount of packet data provided in a trace notification v1
-	traceNotifyV1Len = 32
-	// traceNotifyV2Len is the amount of packet data provided in a trace notification v2
-	traceNotifyV2Len = 48
+	// traceNotifyV0Len is the amount of packet data provided in a trace notification v0.
+	traceNotifyV0Len = 32
+	// traceNotifyV1Len is the amount of packet data provided in a trace notification v1.
+	traceNotifyV1Len = 48
 	// TraceReasonEncryptMask is the bit used to indicate encryption or not
 	TraceReasonEncryptMask uint8 = 0x80
 )
@@ -79,8 +79,8 @@ type TraceNotify TraceNotifyV1
 
 var (
 	traceNotifyLength = map[uint16]uint{
-		TraceNotifyVersion0: 32, // unsafe.Sizeof(&TraceNotifyV0{})
-		TraceNotifyVersion1: 48, // unsafe.Sizeof(&TraceNotifyV1{})
+		TraceNotifyVersion0: traceNotifyV0Len,
+		TraceNotifyVersion1: traceNotifyV1Len,
 	}
 )
 


### PR DESCRIPTION
Rename the consts so they match the corresponding type and use them in
the definition of the traceNotifyLength map.