### PR TITLE
README: Fix release date for v1.7.2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Listed below are the actively maintained release branches along with their lates
 minor release, corresponding image pull tags and their release notes:
 
 +-------------------------------------------------------+------------+-------------------------------------+---------------------------------------------------------------------------+------------------------------------------------------------------------+
-| `v1.7 <https://github.com/cilium/cilium/tree/v1.7>`__ | 2020-03-04 | ``docker.io/cilium/cilium:v1.7.2``  | `Release Notes <https://github.com/cilium/cilium/releases/tag/v1.7.2>`__  | `General Announcement <https://cilium.io/blog/2020/02/18/cilium-17>`__ |
+| `v1.7 <https://github.com/cilium/cilium/tree/v1.7>`__ | 2020-04-03 | ``docker.io/cilium/cilium:v1.7.2``  | `Release Notes <https://github.com/cilium/cilium/releases/tag/v1.7.2>`__  | `General Announcement <https://cilium.io/blog/2020/02/18/cilium-17>`__ |
 +-------------------------------------------------------+------------+-------------------------------------+---------------------------------------------------------------------------+------------------------------------------------------------------------+
 | `v1.6 <https://github.com/cilium/cilium/tree/v1.6>`__ | 2020-03-25 | ``docker.io/cilium/cilium:v1.6.8``  | `Release Notes <https://github.com/cilium/cilium/releases/tag/v1.6.8>`__  | `General Announcement <https://cilium.io/blog/2019/08/20/cilium-16>`__ |
 +-------------------------------------------------------+------------+-------------------------------------+---------------------------------------------------------------------------+------------------------------------------------------------------------+


### PR DESCRIPTION
The script didn't pick up the last date because it was manually added
and therefore didn't use UTC. Assuming we keep using bump-readme.sh we
shouldn't hit this again as we'll use the UTC date here.