### PR TITLE
test: Extend RunsOnNetNext helper family

### DIFF
--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -450,15 +450,17 @@ func failIfContainsBadLogMsg(logs string, blacklist map[string][]string) {
 	}
 }
 
-// RunsOnNetNext checks whether a test case is running on the net next machine
-// which means running on the latest (probably) unreleased kernel
-func RunsOnNetNext() bool {
-	return os.Getenv("NETNEXT") == "true"
+// RunsOnNetNextOr419Kernel checks whether a test case is running on the net-next
+// kernel (depending on the image, it's the latest kernel either from net-next.git
+// or bpf-next.git tree), or on the > 4.19.57 kernel.
+func RunsOnNetNextOr419Kernel() bool {
+	return os.Getenv("NETNEXT") == "true" || os.Getenv("KERNEL") == "419"
 }
 
-// DoesNotRunOnNetNext is the complement function of RunsOnNetNext.
-func DoesNotRunOnNetNext() bool {
-	return !RunsOnNetNext()
+// DoesNotRunOnNetNextOr419Kernel is the complement function of
+// RunsOnNetNextOr419Kernel.
+func DoesNotRunOnNetNextOr419Kernel() bool {
+	return !RunsOnNetNextOr419Kernel()
 }
 
 // DoesNotHaveHosts returns a function which returns true if a CI job

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -221,8 +221,8 @@ var _ = Describe("K8sDatapathConfig", func() {
 		}
 
 		It("Check connectivity with transparent encryption and VXLAN encapsulation", func() {
-			if !helpers.RunsOnNetNext() {
-				Skip("Skipping test because it is not running with the net-next kernel")
+			if !helpers.RunsOnNetNextOr419Kernel() {
+				Skip("Skipping test because it is not running with the net-next kernel or 4.19 kernel")
 				return
 			}
 			SkipItIfNoKubeProxy()

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -723,7 +723,7 @@ var _ = Describe("K8sServicesTest", func() {
 			})
 
 		SkipContextIf(
-			helpers.DoesNotRunOnNetNext,
+			helpers.DoesNotRunOnNetNextOr419Kernel,
 			"Tests NodePort BPF", func() {
 				// TODO(brb) Add with L7 policy test cases after GH#8971 has been fixed
 

--- a/test/k8sT/external_ips.go
+++ b/test/k8sT/external_ips.go
@@ -93,7 +93,7 @@ var _ = Describe("K8sKubeProxyFreeMatrix tests", func() {
 	}
 
 	BeforeAll(func() {
-		if !helpers.RunsOnNetNext() {
+		if !helpers.RunsOnNetNextOr419Kernel() {
 			return
 		}
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
@@ -172,7 +172,7 @@ var _ = Describe("K8sKubeProxyFreeMatrix tests", func() {
 	})
 
 	AfterFailed(func() {
-		if !helpers.RunsOnNetNext() {
+		if !helpers.RunsOnNetNextOr419Kernel() {
 			return
 		}
 		kubectl.CiliumReport(helpers.CiliumNamespace,
@@ -181,7 +181,7 @@ var _ = Describe("K8sKubeProxyFreeMatrix tests", func() {
 	})
 
 	AfterAll(func() {
-		if !helpers.RunsOnNetNext() {
+		if !helpers.RunsOnNetNextOr419Kernel() {
 			return
 		}
 		_ = kubectl.NamespaceDelete(namespaceTest)
@@ -235,7 +235,7 @@ var _ = Describe("K8sKubeProxyFreeMatrix tests", func() {
 	}
 
 	SkipContextIf(
-		func() bool { return helpers.DoesNotRunOnNetNext() },
+		func() bool { return helpers.DoesNotRunOnNetNextOr419Kernel() },
 		"DirectRouting", func() {
 			BeforeAll(func() {
 				deployCilium(map[string]string{
@@ -280,7 +280,7 @@ var _ = Describe("K8sKubeProxyFreeMatrix tests", func() {
 	)
 
 	SkipContextIf(
-		func() bool { return helpers.DoesNotRunOnNetNext() },
+		func() bool { return helpers.DoesNotRunOnNetNextOr419Kernel() },
 		"VxLANMode", func() {
 			BeforeAll(func() {
 				deployCilium(map[string]string{


### PR DESCRIPTION
This commit extends the `RunsOnNetNext` and `DoesNotRunOnNetNext` helpers by adding a check whether a test case is running on the 4.19 kernel.

This enables the kube-proxy-free related test suite to be run on the 4.19 CI job.

/cc @borkmann 