### PR TITLE
Cleanups in `pkg/maps`

### DIFF
--- a/pkg/maps/cidrmap/cidrmap.go
+++ b/pkg/maps/cidrmap/cidrmap.go
@@ -154,14 +154,6 @@ func (cm *CIDRMap) Close() error {
 	return bpf.ObjClose(cm.Fd)
 }
 
-// OpenMap opens a new CIDRMap. 'bool' returns 'true' if the map was
-// created, and 'false' if the map already existed. prefixdyn denotes
-// whether element's prefixlen can vary and we thus need to use a LPM
-// trie instead of hash table.
-func OpenMap(path string, prefixlen int, prefixdyn bool) (*CIDRMap, bool, error) {
-	return OpenMapElems(path, prefixlen, prefixdyn, MaxEntries)
-}
-
 // OpenMapElems is the same as OpenMap only with defined maxelem as argument.
 func OpenMapElems(path string, prefixlen int, prefixdyn bool, maxelem uint32) (*CIDRMap, bool, error) {
 	typeMap := bpf.MapTypeLPMTrie

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -86,11 +86,15 @@ const (
 	// MaxTime specifies the last possible time for GCFilter.Time
 	MaxTime = math.MaxUint32
 
-	noAction = iota
-	deleteEntry
-
 	metricsAlive   = "alive"
 	metricsDeleted = "deleted"
+)
+
+type action int
+
+const (
+	noAction action = iota
+	deleteEntry
 )
 
 var globalDeleteLock [mapTypeMax]lock.Mutex
@@ -426,7 +430,7 @@ func doGC4(m *Map, filter *GCFilter) gcStats {
 	return stats
 }
 
-func (f *GCFilter) doFiltering(srcIP, dstIP net.IP, srcPort, dstPort uint16, nextHdr, flags uint8, entry *CtEntry) (action int) {
+func (f *GCFilter) doFiltering(srcIP, dstIP net.IP, srcPort, dstPort uint16, nextHdr, flags uint8, entry *CtEntry) action {
 	if f.RemoveExpired && entry.Lifetime < f.Time {
 		return deleteEntry
 	}

--- a/pkg/maps/ctmap/metrics.go
+++ b/pkg/maps/ctmap/metrics.go
@@ -43,7 +43,7 @@ type gcStats struct {
 type gcFamily int
 
 const (
-	gcFamilyIPv4 = iota
+	gcFamilyIPv4 gcFamily = iota
 	gcFamilyIPv6
 )
 
@@ -61,7 +61,7 @@ func (g gcFamily) String() string {
 type gcProtocol int
 
 const (
-	gcProtocolAny = iota
+	gcProtocolAny gcProtocol = iota
 	gcProtocolTCP
 )
 

--- a/pkg/maps/lbmap/ipv4.go
+++ b/pkg/maps/lbmap/ipv4.go
@@ -131,16 +131,6 @@ func (v *RevNat4Value) String() string {
 	return fmt.Sprintf("%s:%d", v.Address, v.Port)
 }
 
-func NewRevNat4Value(ip net.IP, port uint16) *RevNat4Value {
-	revNat := RevNat4Value{
-		Port: port,
-	}
-
-	copy(revNat.Address[:], ip.To4())
-
-	return &revNat
-}
-
 type pad3uint8 [3]uint8
 
 // DeepCopyInto is a deepcopy function, copying the receiver, writing into out. in must be non-nil.
@@ -208,16 +198,6 @@ type Service4Value struct {
 	RevNat    uint16 `align:"rev_nat_index"`
 	Flags     uint8
 	Pad       pad3uint8 `align:"pad"`
-}
-
-func NewService4Value(count uint16, backendID loadbalancer.BackendID, revNat uint16) *Service4Value {
-	svc := Service4Value{
-		BackendID: uint32(backendID),
-		Count:     count,
-		RevNat:    revNat,
-	}
-
-	return &svc
 }
 
 func (s *Service4Value) String() string {

--- a/pkg/maps/lbmap/ipv6.go
+++ b/pkg/maps/lbmap/ipv6.go
@@ -119,16 +119,6 @@ type RevNat6Value struct {
 	Port    uint16     `align:"port"`
 }
 
-func NewRevNat6Value(ip net.IP, port uint16) *RevNat6Value {
-	revNat := RevNat6Value{
-		Port: port,
-	}
-
-	copy(revNat.Address[:], ip.To16())
-
-	return &revNat
-}
-
 func (v *RevNat6Value) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(v) }
 func (v *RevNat6Value) String() string              { return fmt.Sprintf("%s:%d", v.Address, v.Port) }
 
@@ -198,16 +188,6 @@ type Service6Value struct {
 	RevNat    uint16 `align:"rev_nat_index"`
 	Flags     uint8
 	Pad       pad3uint8 `align:"pad"`
-}
-
-func NewService6Value(count uint16, backendID loadbalancer.BackendID, revNat uint16) *Service6Value {
-	svc := Service6Value{
-		Count:     count,
-		BackendID: uint32(backendID),
-		RevNat:    revNat,
-	}
-
-	return &svc
 }
 
 func (s *Service6Value) String() string {

--- a/pkg/maps/sockmap/sockmap.go
+++ b/pkg/maps/sockmap/sockmap.go
@@ -16,7 +16,6 @@ package sockmap
 
 import (
 	"fmt"
-	"net"
 	"sync"
 	"unsafe"
 
@@ -65,31 +64,6 @@ func (k *SockmapKey) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(k) }
 // NewValue returns a new empty instance of the structure representing the BPF
 // map value
 func (k SockmapKey) NewValue() bpf.MapValue { return &SockmapValue{} }
-
-// NewSockmapKey returns a new key using 5-tuple input.
-func NewSockmapKey(dip, sip net.IP, sport, dport uint32) SockmapKey {
-	result := SockmapKey{}
-
-	if sip4 := sip.To4(); sip4 != nil {
-		result.Family = bpf.EndpointKeyIPv4
-		copy(result.SIP[:], sip4)
-	} else {
-		result.Family = bpf.EndpointKeyIPv6
-		copy(result.SIP[:], sip)
-	}
-
-	if dip4 := dip.To4(); dip4 != nil {
-		result.Family = bpf.EndpointKeyIPv4
-		copy(result.SIP[:], dip4)
-	} else {
-		result.Family = bpf.EndpointKeyIPv6
-		copy(result.DIP[:], dip)
-	}
-
-	result.DPort = dport
-	result.SPort = sport
-	return result
-}
 
 var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "sockmap")
 


### PR DESCRIPTION
Small janitorial cleanups in `pkg/maps`: remove unused exported funcs and introduce typed consts where appropriate. See individual commits for details.