### PR TITLE
test: Pass KERNEL env param in ginkgo-kernel job

### DIFF
--- a/jenkinsfiles/ginkgo-kernel.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-kernel.Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
         K8S_VERSION="1.17"
         TESTED_SUITE="k8s-${K8S_VERSION}"
         GINKGO_TIMEOUT="300m"
-        DEFAULT_KERNEL="419"
+        KERNEL="419"
     }
 
     options {
@@ -117,7 +117,7 @@ pipeline {
                 retry(3) {
                     timeout(time: 45, unit: 'MINUTES'){
                         dir("${TESTDIR}") {
-                            sh 'KERNEL=$(python get-gh-comment-info.py "${ghprbCommentBody}" --retrieve=version | sed "s/^$/${DEFAULT_KERNEL}/") CILIUM_REGISTRY="$(./print-node-ip.sh)" ./vagrant-ci-start.sh'
+                            sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" ./vagrant-ci-start.sh'
                         }
                     }
                 }

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -111,7 +111,8 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 			cDefinesMap["IPV4_NODEPORT"] = fmt.Sprintf("%#x", byteorder.HostSliceToNetwork(ipv4NP, reflect.Uint32).(uint32))
 		}
 
-		if option.Config.EnableIPv4FragmentsTracking {
+		if false {
+			//if option.Config.EnableIPv4FragmentsTracking {
 			cDefinesMap["ENABLE_IPV4_FRAGMENTS"] = "1"
 			cDefinesMap["IPV4_FRAG_DATAGRAMS_MAP"] = fragmap.MapName
 			cDefinesMap["CILIUM_IPV4_FRAG_MAP_MAX_ENTRIES"] = fmt.Sprintf("%d", option.Config.FragmentsMapEntries)

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1556,6 +1556,15 @@ func (kub *Kubectl) overwriteHelmOptions(options map[string]string) error {
 			"global.k8sServiceHost":       nodeIP,
 			"global.k8sServicePort":       "6443",
 		}
+
+		if os.Getenv("KERNEL") == "419" {
+			// On 4.19 kernel we need to disable debug mode, as otherwise the BPF
+			// datapath programs are hitting the 4k verifier complexity limit when
+			// the BPF NodePort is enabled.
+			// TODO(brb): Determine kernel version via uname; keep agent in debug mode
+			opts["global.debug.enabled"] = "false"
+		}
+
 		for key, value := range opts {
 			options = addIfNotOverwritten(options, key, value)
 		}


### PR DESCRIPTION
Otherwise, the `RunsOnNetNextOr419Kernel()` returns `false` on the 4.19 build, which makes to skip some kube-proxy replacement related tests.

Also, disable the dynamic kernel vsn selection, as we currently run the job only on the 4.19 kernel.

Fixes: 72fe87afb80a ("test: Extend RunsOnNetNext helper family")