### PR TITLE
Allow specifying on which interface the Azure IPAM should allocate IPs on

### DIFF
--- a/pkg/azure/types/types.go
+++ b/pkg/azure/types/types.go
@@ -36,6 +36,23 @@ const (
 	StateSucceeded = "succeeded"
 )
 
+// AzureSpec is the Azure specification of a node running via the Azure IPAM
+//
+// The Azure specification can either be provided explicitly by the user or the
+// cilium agent running on the node can be instructed to create the CiliumNode
+// custom resource along with an Azure specification when the node registers
+// itself to the Kubernetes cluster.
+// This struct is embedded into v2.CiliumNode
+//
+// +k8s:deepcopy-gen=true
+type AzureSpec struct {
+	// InterfaceName is the name of the interface the cilium-operator
+	// will use to allocate all the IPs on
+	//
+	// +optional
+	InterfaceName string `json:"interface-name,omitempty"`
+}
+
 // AzureStatus is the status of Azure addressing of the node
 //
 // This struct is embedded into v2.CiliumNode

--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -398,6 +398,10 @@ func createNodeCRD(clientset apiextensionsclient.Interface) error {
 											Type:        "string",
 											Description: "instance-id is the Azure specific identifier of the node",
 										},
+										"interface-name": {
+											Type:        "string",
+											Description: "interface-name represents the name of the interface on which additional IP addreses will be allocated",
+										},
 									},
 								},
 								"eni": {

--- a/pkg/k8s/apis/cilium.io/v2/types.go
+++ b/pkg/k8s/apis/cilium.io/v2/types.go
@@ -673,6 +673,11 @@ type NodeSpec struct {
 	// +optional
 	ENI eniTypes.ENISpec `json:"eni,omitempty"`
 
+	// Azure is the Azure IPAM specific configuration
+	//
+	// +optional
+	Azure azureTypes.AzureSpec `json:"azure,omitempty"`
+
 	// IPAM is the address management specification. This section can be
 	// populated by a user or it can be automatically populated by an IPAM
 	// operator

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -332,6 +332,18 @@ func (n *NodeDiscovery) UpdateCiliumNodeResource() {
 		// returned by the Azure API. Convert it to lower case for
 		// consistent results.
 		nodeResource.Spec.InstanceID = strings.ToLower(strings.TrimPrefix(providerID, azureTypes.ProviderPrefix))
+
+		if c := n.NetConf; c != nil {
+			if c.IPAM.MinAllocate != 0 {
+				nodeResource.Spec.IPAM.MinAllocate = c.IPAM.MinAllocate
+			}
+			if c.IPAM.PreAllocate != 0 {
+				nodeResource.Spec.IPAM.PreAllocate = c.IPAM.PreAllocate
+			}
+			if c.Azure.InterfaceName != "" {
+				nodeResource.Spec.Azure.InterfaceName = c.Azure.InterfaceName
+			}
+		}
 	}
 
 	if performUpdate {

--- a/plugins/cilium-cni/types/types.go
+++ b/plugins/cilium-cni/types/types.go
@@ -21,6 +21,7 @@ import (
 	"net"
 
 	eniTypes "github.com/cilium/cilium/pkg/aws/eni/types"
+	azureTypes "github.com/cilium/cilium/pkg/azure/types"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 
 	cniTypes "github.com/containernetworking/cni/pkg/types"
@@ -31,11 +32,12 @@ import (
 // NetConf is the Cilium specific CNI network configuration
 type NetConf struct {
 	cniTypes.NetConf
-	MTU         int                `json:"mtu"`
-	Args        Args               `json:"args"`
-	ENI         eniTypes.ENISpec   `json:"eni,omitempty"`
-	IPAM        ipamTypes.IPAMSpec `json:"ipam,omitempty"`
-	EnableDebug bool               `json:"enable-debug"`
+	MTU         int                  `json:"mtu"`
+	Args        Args                 `json:"args"`
+	ENI         eniTypes.ENISpec     `json:"eni,omitempty"`
+	Azure       azureTypes.AzureSpec `json:"azure,omitempty"`
+	IPAM        ipamTypes.IPAMSpec   `json:"ipam,omitempty"`
+	EnableDebug bool                 `json:"enable-debug"`
 }
 
 // NetConfList is a CNI chaining configuration

--- a/plugins/cilium-cni/types/types_test.go
+++ b/plugins/cilium-cni/types/types_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	eniTypes "github.com/cilium/cilium/pkg/aws/eni/types"
+	azureTypes "github.com/cilium/cilium/pkg/azure/types"
 	"github.com/cilium/cilium/pkg/checker"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 
@@ -206,6 +207,40 @@ func (t *CNITypesSuite) TestReadCNIConfENIv2WithPlugins(c *check.C) {
 			SubnetTags: map[string]string{
 				"foo": "true",
 			},
+		},
+		IPAM: ipamTypes.IPAMSpec{
+			PreAllocate: 5,
+		},
+	}
+	testConfRead(c, confFile1, &netConf1)
+}
+
+func (t *CNITypesSuite) TestReadCNIConfAzurev2WithPlugins(c *check.C) {
+	confFile1 := `
+{
+  "cniVersion":"0.3.1",
+  "name":"cilium",
+  "plugins": [
+    {
+      "cniVersion":"0.3.1",
+      "type":"cilium-cni",
+      "azure": {
+        "interface-name": "eth1"
+      },
+      "ipam": {
+        "pre-allocate": 5
+      }
+    }
+  ]
+}
+`
+	netConf1 := NetConf{
+		NetConf: cnitypes.NetConf{
+			CNIVersion: "0.3.1",
+			Type:       "cilium-cni",
+		},
+		Azure: azureTypes.AzureSpec{
+			InterfaceName: "eth1",
 		},
 		IPAM: ipamTypes.IPAMSpec{
 			PreAllocate: 5,


### PR DESCRIPTION
Signed-off-by: Vlad Ungureanu <vladu@palantir.com>

Add an `azure` field to the `CiliumNode` which should hold Azure specific IPAM settings. Starting with `interface-name` which should be used to override on which interface on the VM the Azure IPAM will allocate IPs. Currently it walks the interfaces in order and picks where it has space. This is useful in situations where the interfaces are in different subnets.

Doing it the same way as the AWS IPAM is configured -- passing the interface name via the cni config which the agent can read when it registers the `CiliumNode` in the k8s apiserver.

```release-note
Allow specifying on which interface the Azure IPAM should allocate IPs on
```
