### PR TITLE
Add support for file based authorizer for Azure

### DIFF
--- a/pkg/azure/api/api.go
+++ b/pkg/azure/api/api.go
@@ -70,10 +70,13 @@ func NewClient(subscriptionID, resourceGroup string, metrics MetricsAPI, rateLim
 		limiter:         helpers.NewApiLimiter(metrics, rateLimit, burst),
 	}
 
-	// Authorizer based on environment variables
-	authorizer, err := auth.NewAuthorizerFromEnvironment()
+	// Authorizer based on file first and then environment variables
+	authorizer, err := auth.NewAuthorizerFromFile(compute.DefaultBaseURI)
 	if err != nil {
-		return nil, err
+		authorizer, err = auth.NewAuthorizerFromEnvironment()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	c.interfaces.Authorizer = authorizer


### PR DESCRIPTION
This adds support for file based credentials when using Azure. 

This PR prefers file based first and then falls back to environment based if that fails, but we could also reverse that if that's preferable.

Upstream Azure docs for file based auth live here: https://docs.microsoft.com/en-us/azure/developer/go/azure-sdk-authorization#use-file-based-authentication