### PR TITLE
cilium: initial xdp-based nodeport implementation

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -141,6 +141,7 @@ cilium-agent [flags]
       --monitor-queue-size int                        Size of the event queue when reading monitor events
       --mtu int                                       Overwrite auto-detected MTU of underlying network
       --nat46-range string                            IPv6 prefix to map IPv4 addresses to (default "0:0:0:0:0:FFFF::/96")
+      --node-port-acceleration string                 BPF NodePort acceleration via XDP ("none", "generic", "native") (default "none")
       --node-port-mode string                         BPF NodePort mode ("snat", "dsr", "hybrid") (default "hybrid")
       --node-port-range strings                       Set the min/max NodePort port range (default [30000,32767])
       --policy-audit-mode                             Enable policy audit (non-drop) mode

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -498,6 +498,7 @@ sig
 skb
 sockmap
 src
+SR-IOV
 ssl
 stacktrace
 stap

--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -4,8 +4,8 @@ include ../Makefile.defs
 
 SUBDIRS = sockops
 
-BPF_SIMPLE = bpf_prefilter.o bpf_network.o bpf_alignchecker.o bpf_hostdev_ingress.o
-BPF = bpf_lxc.o bpf_overlay.o bpf_sock.o bpf_netdev.o $(BPF_SIMPLE)
+BPF_SIMPLE = bpf_network.o bpf_alignchecker.o bpf_hostdev_ingress.o
+BPF = bpf_lxc.o bpf_overlay.o bpf_sock.o bpf_netdev.o bpf_xdp.o $(BPF_SIMPLE)
 
 TARGET=cilium-map-migrate
 
@@ -52,7 +52,8 @@ LB_OPTIONS = \
 	-DENABLE_IPV4:-DENABLE_IPV6:-DLB_L3:-DLB_L4:-DENABLE_HOST_SERVICES_UDP:-DENABLE_HOST_SERVICES_TCP \
 	-DENABLE_IPV4:-DENABLE_IPV6:-DLB_L3:-DLB_L4:-DENABLE_HOST_SERVICES_UDP:-DENABLE_HOST_SERVICES_TCP:-DENABLE_NODEPORT \
 	-DENABLE_IPV4:-DENABLE_IPV6:-DLB_L3:-DLB_L4:-DENABLE_HOST_SERVICES_UDP:-DENABLE_HOST_SERVICES_TCP:-DENABLE_NODEPORT:-DENABLE_EXTERNAL_IP \
-	-DENABLE_IPV4:-DENABLE_IPV6:-DENABLE_IPSEC:-DLB_L3:-DLB_L4:-DENABLE_HOST_SERVICES_UDP:-DENABLE_HOST_SERVICES_TCP:-DENABLE_NODEPORT:-DENABLE_EXTERNAL_IP
+	-DENABLE_IPV4:-DENABLE_IPV6:-DENABLE_IPSEC:-DLB_L3:-DLB_L4:-DENABLE_HOST_SERVICES_UDP:-DENABLE_HOST_SERVICES_TCP:-DENABLE_NODEPORT:-DENABLE_EXTERNAL_IP \
+	-DENABLE_IPV4:-DENABLE_IPV6:-DENABLE_IPSEC:-DLB_L3:-DLB_L4:-DENABLE_HOST_SERVICES_UDP:-DENABLE_HOST_SERVICES_TCP:-DENABLE_NODEPORT:-DENABLE_EXTERNAL_IP:-DENABLE_NODEPORT_ACCELERATION
 
 # These options are intended to max out the BPF program complexity. it is load
 # tested as well.
@@ -122,6 +123,21 @@ bpf_netdev.ll: bpf_netdev.c $(LIB)
 	$(QUIET) ${CLANG} ${MAX_NETDEV_OPTIONS} ${CLANG_FLAGS} -c $< -o $@
 
 bpf_netdev.o: bpf_netdev.ll
+	@$(ECHO_CC)
+	$(QUIET) ${LLC} ${LLC_FLAGS} -filetype=obj -o $@ $(patsubst %.o,%.ll,$@)
+
+bpf_xdp.ll: bpf_xdp.c $(LIB)
+	$(QUIET) set -e; \
+	if [ $(BUILD_PERMUTATIONS) != "" ]; then \
+		$(foreach OPTS,$(NETDEV_OPTIONS), \
+			$(ECHO_CC) " [$(subst :,$(space),$(OPTS))]"; \
+			${CLANG} $(subst :,$(space),$(OPTS)) ${CLANG_FLAGS} -c $< -o $@; \
+			${LLC} ${LLC_FLAGS} -o /dev/null $@; ) \
+	fi
+	@$(ECHO_CC)
+	$(QUIET) ${CLANG} ${MAX_NETDEV_OPTIONS} ${CLANG_FLAGS} -c $< -o $@
+
+bpf_xdp.o: bpf_xdp.ll
 	@$(ECHO_CC)
 	$(QUIET) ${LLC} ${LLC_FLAGS} -filetype=obj -o $@ $(patsubst %.o,%.ll,$@)
 

--- a/bpf/bpf_xdp.c
+++ b/bpf/bpf_xdp.c
@@ -8,15 +8,14 @@
 #include <netdev_config.h>
 #include <filter_config.h>
 
-#include <linux/if_ether.h>
-
-#define SKIP_CALLS_MAP
+#define SKIP_POLICY_MAP 1
 
 #include "lib/utils.h"
 #include "lib/common.h"
 #include "lib/maps.h"
 #include "lib/eps.h"
 #include "lib/events.h"
+#include "lib/nodeport.h"
 
 #ifndef HAVE_LPM_TRIE_MAP_TYPE
 # undef CIDR4_LPM_PREFILTER
@@ -82,13 +81,35 @@ struct bpf_elf_map __section_maps CIDR6_LMAP_NAME = {
 #endif /* CIDR6_LPM_PREFILTER */
 #endif /* CIDR6_FILTER */
 
-static __always_inline int check_v4_endpoint(struct iphdr *ipv4_hdr)
+#ifdef ENABLE_IPV4
+#ifdef ENABLE_NODEPORT_ACCELERATION
+__section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV4_FROM_LXC)
+int tail_lb_ipv4(struct __ctx_buff *ctx)
 {
-	if (lookup_ip4_endpoint(ipv4_hdr))
-		return CTX_ACT_OK;
+	int ret = CTX_ACT_OK;
 
-	return CTX_ACT_DROP;
+	if (!bpf_skip_nodeport(ctx)) {
+		ret = nodeport_lb4(ctx, 0);
+		if (IS_ERR(ret))
+			return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP,
+						      METRIC_INGRESS);
+	}
+
+	return ret;
 }
+
+static __always_inline int check_v4_lb(struct __ctx_buff *ctx)
+{
+	ep_tail_call(ctx, CILIUM_CALL_IPV4_FROM_LXC);
+	return send_drop_notify_error(ctx, 0, DROP_MISSED_TAIL_CALL, CTX_ACT_DROP,
+				      METRIC_INGRESS);
+}
+#else
+static __always_inline int check_v4_lb(struct __ctx_buff *ctx __maybe_unused)
+{
+	return CTX_ACT_OK;
+}
+#endif /* ENABLE_NODEPORT_ACCELERATION */
 
 static __always_inline int check_v4(struct __ctx_buff *ctx)
 {
@@ -110,19 +131,42 @@ static __always_inline int check_v4(struct __ctx_buff *ctx)
 	else
 #endif /* CIDR4_LPM_PREFILTER */
 		return map_lookup_elem(&CIDR4_HMAP_NAME, &pfx) ?
-		       CTX_ACT_DROP : check_v4_endpoint(ipv4_hdr);
+		       CTX_ACT_DROP : check_v4_lb(ctx);
 #else
-	return check_v4_endpoint(ipv4_hdr);
+	return check_v4_lb(ctx);
 #endif /* CIDR4_FILTER */
 }
+#endif /* ENABLE_IPV4 */
 
-static __always_inline int check_v6_endpoint(struct ipv6hdr *ipv6_hdr)
+#ifdef ENABLE_IPV6
+#ifdef ENABLE_NODEPORT
+__section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV6_FROM_LXC)
+int tail_lb_ipv6(struct __ctx_buff *ctx)
 {
-	if (lookup_ip6_endpoint(ipv6_hdr))
-		return CTX_ACT_OK;
+	int ret = CTX_ACT_OK;
 
-	return CTX_ACT_DROP;
+	if (!bpf_skip_nodeport(ctx)) {
+		ret = nodeport_lb6(ctx, 0);
+		if (IS_ERR(ret))
+			return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP,
+						      METRIC_INGRESS);
+	}
+
+	return ret;
 }
+
+static __always_inline int check_v6_lb(struct __ctx_buff *ctx)
+{
+	ep_tail_call(ctx, CILIUM_CALL_IPV6_FROM_LXC);
+	return send_drop_notify_error(ctx, 0, DROP_MISSED_TAIL_CALL, CTX_ACT_DROP,
+				      METRIC_INGRESS);
+}
+#else
+static __always_inline int check_v6_lb(struct __ctx_buff *ctx __maybe_unused)
+{
+	return CTX_ACT_OK;
+}
+#endif /* ENABLE_NODEPORT */
 
 static __always_inline int check_v6(struct __ctx_buff *ctx)
 {
@@ -144,36 +188,45 @@ static __always_inline int check_v6(struct __ctx_buff *ctx)
 	else
 #endif /* CIDR6_LPM_PREFILTER */
 		return map_lookup_elem(&CIDR6_HMAP_NAME, &pfx) ?
-		       CTX_ACT_DROP : check_v6_endpoint(ipv6_hdr);
+		       CTX_ACT_DROP : check_v6_lb(ctx);
 #else
-	return check_v6_endpoint(ipv6_hdr);
+	return check_v6_lb(ctx);
 #endif /* CIDR6_FILTER */
 }
+#endif /* ENABLE_IPV6 */
 
 static __always_inline int check_filters(struct __ctx_buff *ctx)
 {
-	void *data_end = ctx_data_end(ctx);
-	void *data = ctx_data(ctx);
-	struct ethhdr *eth = data;
+	int ret = CTX_ACT_OK;
 	__u16 proto;
 
-	if (ctx_no_room(eth + 1, data_end))
-		return CTX_ACT_DROP;
-
-	proto = eth->h_proto;
-	if (proto == bpf_htons(ETH_P_IP))
-		return check_v4(ctx);
-	else if (proto == bpf_htons(ETH_P_IPV6))
-		return check_v6(ctx);
-	else
-		/* Pass the rest to stack, we might later do more
-		 * fine-grained filtering here.
-		 */
+	if (!validate_ethertype(ctx, &proto))
 		return CTX_ACT_OK;
+	if (ctx_adjust_meta(ctx, -META_PIVOT))
+		return CTX_ACT_OK;
+
+	bpf_skip_nodeport_clear(ctx);
+
+	switch (proto) {
+#ifdef ENABLE_IPV4
+	case bpf_htons(ETH_P_IP):
+		ret = check_v4(ctx);
+		break;
+#endif /* ENABLE_IPV4 */
+#ifdef ENABLE_IPV6
+	case bpf_htons(ETH_P_IPV6):
+		ret = check_v6(ctx);
+		break;
+#endif /* ENABLE_IPV6 */
+	default:
+		break;
+	}
+
+	return ret;
 }
 
 __section("from-netdev")
-int prefilter_start(struct __ctx_buff *ctx)
+int bpf_xdp_entry(struct __ctx_buff *ctx)
 {
 	return check_filters(ctx);
 }

--- a/bpf/include/bpf/helpers_xdp.h
+++ b/bpf/include/bpf/helpers_xdp.h
@@ -12,8 +12,9 @@
 
 /* Only used helpers in Cilium go below. */
 
-/* Packet misc meta data */
+/* Packet misc meta data & encapsulation helper */
 static int BPF_FUNC(xdp_adjust_meta, struct xdp_md *xdp, int delta);
+static int BPF_FUNC(xdp_adjust_head, struct xdp_md *xdp, int delta);
 
 /* Packet redirection */
 static int BPF_STUB(redirect, int ifindex, __u32 flags);

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -73,6 +73,19 @@ struct dsr_opt_v6 {
 };
 #endif /* ENABLE_IPV6 */
 
+static __always_inline bool nodeport_must_drop_remote(void)
+{
+#if defined(ENABLE_NODEPORT_ACCELERATION) && !defined(FROM_ENCAP_DEV) && \
+    __ctx_is == __ctx_skb
+	/* We already handled remote backends on XDP layer. Anything
+	 * landing here that is remote is a bug.
+	 */
+	return true;
+#else
+	return false;
+#endif
+}
+
 static __always_inline bool nodeport_uses_dsr(__u8 nexthdr __maybe_unused)
 {
 # if defined(ENABLE_DSR) && !defined(ENABLE_DSR_HYBRID)
@@ -503,7 +516,8 @@ static __always_inline int nodeport_lb6(struct __ctx_buff *ctx,
 		return DROP_INVALID;
 
 	backend_local = lookup_ip6_endpoint(ip6);
-	if (lb6_svc_is_hostport(svc) && !backend_local)
+	if (!backend_local && (lb6_svc_is_hostport(svc) ||
+			       nodeport_must_drop_remote()))
 		return DROP_INVALID;
 
 	switch (ret) {
@@ -1061,7 +1075,8 @@ static __always_inline int nodeport_lb4(struct __ctx_buff *ctx,
 		return DROP_INVALID;
 
 	backend_local = lookup_ip4_endpoint(ip4);
-	if (lb4_svc_is_hostport(svc) && !backend_local)
+	if (!backend_local && (lb4_svc_is_hostport(svc) ||
+			       nodeport_must_drop_remote()))
 		return DROP_INVALID;
 
 	switch (ret) {

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/iptables"
 	linuxdatapath "github.com/cilium/cilium/pkg/datapath/linux"
 	"github.com/cilium/cilium/pkg/datapath/linux/probes"
+	"github.com/cilium/cilium/pkg/datapath/loader"
 	"github.com/cilium/cilium/pkg/datapath/maps"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/envoy"
@@ -511,6 +512,9 @@ func init() {
 	flags.StringSlice(option.NodePortRange, []string{fmt.Sprintf("%d", option.NodePortMinDefault), fmt.Sprintf("%d", option.NodePortMaxDefault)}, "Set the min/max NodePort port range")
 	option.BindEnv(option.NodePortRange)
 
+	flags.String(option.NodePortAcceleration, option.NodePortAccelerationNone, "BPF NodePort acceleration via XDP (\"none\", \"generic\", \"native\")")
+	option.BindEnv(option.NodePortAcceleration)
+
 	flags.String(option.LibDir, defaults.LibraryPath, "Directory path to store runtime build environment")
 	option.BindEnv(option.LibDir)
 
@@ -894,14 +898,23 @@ func initEnv(cmd *cobra.Command) {
 	}
 
 	option.Config.ModePreFilter = strings.ToLower(option.Config.ModePreFilter)
-	switch option.Config.ModePreFilter {
-	case option.ModePreFilterNative:
-		option.Config.ModePreFilter = "xdpdrv"
-	case option.ModePreFilterGeneric:
-		option.Config.ModePreFilter = "xdpgeneric"
-	default:
+	if option.Config.ModePreFilter != option.ModePreFilterNative &&
+		option.Config.ModePreFilter != option.ModePreFilterGeneric {
 		log.Fatalf("Invalid setting for --prefilter-mode, must be { %s, %s }",
 			option.ModePreFilterNative, option.ModePreFilterGeneric)
+	}
+
+	if option.Config.DevicePreFilter != "undefined" {
+		if option.Config.XDPDevice != "undefined" &&
+			option.Config.XDPDevice != option.Config.DevicePreFilter {
+			log.Fatalf("Cannot set Prefilter device: mismatch between NodePort device %s and Prefilter device %s",
+				option.Config.XDPDevice, option.Config.DevicePreFilter)
+		}
+
+		option.Config.XDPDevice = option.Config.DevicePreFilter
+		if err := loader.SetXDPMode(option.Config.ModePreFilter); err != nil {
+			scopedLog.WithError(err).Fatal("Cannot set prefilter XDP mode")
+		}
 	}
 
 	scopedLog = log.WithField(logfields.Path, option.Config.SocketPath)
@@ -1471,6 +1484,12 @@ func initKubeProxyReplacementOptions() {
 			option.Config.NodePortMode != option.NodePortModeHybrid {
 			log.Fatalf("Invalid value for --%s: %s", option.NodePortMode, option.Config.NodePortMode)
 		}
+
+		if option.Config.NodePortAcceleration != option.NodePortAccelerationNone &&
+			option.Config.NodePortAcceleration != option.NodePortAccelerationGeneric &&
+			option.Config.NodePortAcceleration != option.NodePortAccelerationNative {
+			log.Fatalf("Invalid value for --%s: %s", option.NodePortAcceleration, option.Config.NodePortAcceleration)
+		}
 	}
 
 	if option.Config.EnableNodePort {
@@ -1520,6 +1539,19 @@ func initKubeProxyReplacementOptions() {
 			log.WithField(logfields.Interface, device).
 				Info("Using auto-derived device for BPF node port")
 			option.Config.Device = device
+		}
+	}
+
+	if option.Config.EnableNodePort &&
+		option.Config.NodePortAcceleration != option.NodePortAccelerationNone {
+		if option.Config.XDPDevice != "undefined" &&
+			option.Config.XDPDevice != option.Config.Device {
+			log.Fatalf("Cannot set NodePort acceleration device: mismatch between Prefilter device %s and NodePort device %s",
+				option.Config.XDPDevice, option.Config.Device)
+		}
+		option.Config.XDPDevice = option.Config.Device
+		if err := loader.SetXDPMode(option.Config.NodePortAcceleration); err != nil {
+			log.WithError(err).Fatal("Cannot set NodePort acceleration")
 		}
 	}
 

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -314,6 +314,9 @@ data:
 {{- if .Values.global.nodePort.mode }}
   node-port-mode: {{ .Values.global.nodePort.mode | quote }}
 {{- end }}
+{{- if .Values.global.nodePort.acceleration }}
+  node-port-acceleration: {{ .Values.global.nodePort.acceleration | quote }}
+{{- end }}
   enable-auto-protect-node-port-range: {{ .Values.global.nodePort.autoProtectPortRange | quote }}
 {{- end }}
 

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -277,6 +277,9 @@ global:
     # mode is the mode of NodePort feature
     mode: "hybrid"
 
+    # acceleration is the option to accelerate NodePort via XDP
+    acceleration: "none"
+
     # Append NodePort range to ip_local_reserved_ports if clash with ephemeral
     # ports is detected
     autoProtectPortRange: true

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -226,6 +226,9 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 				cDefinesMap["ENABLE_DSR_HYBRID"] = "1"
 			}
 		}
+		if option.Config.NodePortAcceleration != option.NodePortAccelerationNone {
+			cDefinesMap["ENABLE_NODEPORT_ACCELERATION"] = "1"
+		}
 		if option.Config.EnableExternalIPs {
 			cDefinesMap["ENABLE_EXTERNAL_IP"] = "1"
 		}

--- a/pkg/datapath/loader/link.go
+++ b/pkg/datapath/loader/link.go
@@ -1,0 +1,71 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loader
+
+import (
+	"fmt"
+	"os/exec"
+
+	"github.com/cilium/cilium/pkg/option"
+
+	"golang.org/x/sys/unix"
+)
+
+func SetXDPMode(mode string) error {
+	switch mode {
+	case option.XDPModeNative:
+		if option.Config.XDPMode == option.XDPModeLinkNone ||
+			option.Config.XDPMode == option.XDPModeLinkDriver {
+			option.Config.XDPMode = option.XDPModeLinkDriver
+		} else {
+			return fmt.Errorf("XDP Mode conflict: current mode is %s, trying to set conflicting %s",
+				option.Config.XDPMode, option.XDPModeLinkDriver)
+		}
+	case option.XDPModeGeneric:
+		if option.Config.XDPMode == option.XDPModeLinkNone ||
+			option.Config.XDPMode == option.XDPModeLinkGeneric {
+			option.Config.XDPMode = option.XDPModeLinkGeneric
+		} else {
+			return fmt.Errorf("XDP Mode conflict: current mode is %s, trying to set conflicting %s",
+				option.Config.XDPMode, option.XDPModeLinkGeneric)
+		}
+	case option.XDPModeNone:
+		break
+	}
+	return nil
+}
+
+// ProbeXDP checks whether a given XDP mode is supported for the specified device
+func ProbeXDP(device, mode string) error {
+	cmd := exec.Command("ip", "-force", "link", "set", "dev", device, mode, "off")
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("Cannot run ip command: %v", err)
+	}
+	if err := cmd.Wait(); err != nil {
+		if exiterr, ok := err.(*exec.ExitError); ok {
+			if status, ok := exiterr.Sys().(unix.WaitStatus); ok {
+				switch status.ExitStatus() {
+				case 2:
+					return fmt.Errorf("Mode %s not supported on device %s", mode, device)
+				default:
+					return fmt.Errorf("XDP not supported on OS")
+				}
+			}
+		} else {
+			return fmt.Errorf("Cannot wait for ip command: %v", err)
+		}
+	}
+	return nil
+}

--- a/pkg/datapath/prefilter/prefilter.go
+++ b/pkg/datapath/prefilter/prefilter.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"os/exec"
 	"path"
 
 	"github.com/cilium/cilium/pkg/bpf"
@@ -27,8 +26,6 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/cidrmap"
 	"github.com/cilium/cilium/pkg/probe"
-
-	"golang.org/x/sys/unix"
 )
 
 type preFilterMapType int
@@ -260,29 +257,6 @@ func (p *PreFilter) init() (*PreFilter, error) {
 		}
 	}
 	return p, nil
-}
-
-// ProbePreFilter checks whether XDP mode is supported on given device
-func ProbePreFilter(device, mode string) error {
-	cmd := exec.Command("ip", "-force", "link", "set", "dev", device, mode, "off")
-	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("Cannot run ip command: %v", err)
-	}
-	if err := cmd.Wait(); err != nil {
-		if exiterr, ok := err.(*exec.ExitError); ok {
-			if status, ok := exiterr.Sys().(unix.WaitStatus); ok {
-				switch status.ExitStatus() {
-				case 2:
-					return fmt.Errorf("Mode %s not supported on device %s", mode, device)
-				default:
-					return fmt.Errorf("Prefilter not supported on OS")
-				}
-			}
-		} else {
-			return fmt.Errorf("Cannot wait for ip command: %v", err)
-		}
-	}
-	return nil
 }
 
 // NewPreFilter returns prefilter handle

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -236,10 +236,10 @@ const (
 	IPv6ServiceRange = "ipv6-service-range"
 
 	// ModePreFilterNative for loading progs with xdpdrv
-	ModePreFilterNative = "native"
+	ModePreFilterNative = XDPModeNative
 
 	// ModePreFilterGeneric for loading progs with xdpgeneric
-	ModePreFilterGeneric = "generic"
+	ModePreFilterGeneric = XDPModeGeneric
 
 	// NodesGCInterval is the duration for which the nodes are GC in the KVStore.
 	NodesGCInterval = "nodes-gc-interval"
@@ -303,6 +303,13 @@ const (
 	// ("snat", "dsr" or "hybrid")
 	NodePortMode = "node-port-mode"
 
+	// NodePortAcceleration indicates whether NodePort should be accelerated
+	// via XDP ("none", "generic" or "native")
+	NodePortAcceleration = "node-port-acceleration"
+
+	// NodePortRange defines a custom range where to look up NodePort services
+	NodePortRange = "node-port-range"
+
 	// EnableAutoProtectNodePortRange enables appending NodePort range to
 	// net.ipv4.ip_local_reserved_ports if it overlaps with ephemeral port
 	// range (net.ipv4.ip_local_port_range)
@@ -311,9 +318,6 @@ const (
 	// KubeProxyReplacement controls how to enable kube-proxy replacement
 	// features in BPF datapath
 	KubeProxyReplacement = "kube-proxy-replacement"
-
-	// NodePortRange defines a custom range where to look up NodePort services
-	NodePortRange = "node-port-range"
 
 	// LibDir enables the directory path to store runtime build environment
 	LibDir = "lib-dir"
@@ -727,6 +731,24 @@ const (
 
 	// UpdateEC2AdapterLimitViaAPI configures the operator to use the EC2 API to fill out the instnacetype to adapter limit mapping
 	UpdateEC2AdapterLimitViaAPI = "update-ec2-apdater-limit-via-api"
+
+	// XDPModeNative for loading progs with XDPModeLinkDriver
+	XDPModeNative = "native"
+
+	// XDPModeGeneric for loading progs with XDPModeLinkGeneric
+	XDPModeGeneric = "generic"
+
+	// XDPModeNone for not having XDP enabled
+	XDPModeNone = "none"
+
+	// XDPModeLinkDriver is the tc selector for native XDP
+	XDPModeLinkDriver = "xdpdrv"
+
+	// XDPModeLinkGeneric is the tc selector for generic XDP
+	XDPModeLinkGeneric = "xdpgeneric"
+
+	// XDPModeLinkNone for not having XDP enabled
+	XDPModeLinkNone = XDPModeNone
 
 	// K8sClientQPSLimit is the queries per second limit for the K8s client. Defaults to k8s client defaults.
 	K8sClientQPSLimit = "k8s-client-qps"
@@ -1165,6 +1187,15 @@ const (
 	// NodePortModeHybrid is a dual mode of the above, that is, DSR for TCP and SNAT for UDP
 	NodePortModeHybrid = "hybrid"
 
+	// NodePortAccelerationNone means we do not accelerate NodePort via XDP
+	NodePortAccelerationNone = XDPModeNone
+
+	// NodePortAccelerationGeneric means we accelerate NodePort via generic XDP
+	NodePortAccelerationGeneric = XDPModeGeneric
+
+	// NodePortAccelerationNative means we accelerate NodePort via native XDP in the driver (preferred)
+	NodePortAccelerationNative = XDPModeNative
+
 	// KubeProxyReplacementProbe specifies to auto-enable available features for
 	// kube-proxy replacement
 	KubeProxyReplacementProbe = "probe"
@@ -1255,8 +1286,10 @@ type DaemonConfig struct {
 	RunDir           string     // Cilium runtime directory
 	NAT46Prefix      *net.IPNet // NAT46 IPv6 Prefix
 	Device           string     // Receive device
-	DevicePreFilter  string     // XDP device
-	ModePreFilter    string     // XDP mode, values: { native | generic }
+	DevicePreFilter  string     // Prefilter device
+	ModePreFilter    string     // Prefilter mode
+	XDPDevice        string     // XDP device
+	XDPMode          string     // XDP mode, values: { xdpdrv | xdpgeneric | none }
 	HostV4Addr       net.IP     // Host v4 address of the snooping device
 	HostV6Addr       net.IP     // Host v6 address of the snooping device
 	EncryptInterface string     // Set with name of network facing interface to encrypt
@@ -1680,6 +1713,10 @@ type DaemonConfig struct {
 	// NodePortMode indicates in which mode NodePort implementation should run
 	// ("snat", "dsr" or "hybrid")
 	NodePortMode string
+
+	// NodePortAcceleration indicates whether NodePort should be accelerated
+	// via XDP ("none", "generic" or "native")
+	NodePortAcceleration string
 
 	// EnableAutoProtectNodePortRange enables appending NodePort range to
 	// net.ipv4.ip_local_reserved_ports if it overlaps with ephemeral port
@@ -2278,6 +2315,7 @@ func (c *DaemonConfig) Populate() {
 	c.EnableTracing = viper.GetBool(EnableTracing)
 	c.EnableNodePort = viper.GetBool(EnableNodePort)
 	c.NodePortMode = viper.GetString(NodePortMode)
+	c.NodePortAcceleration = viper.GetString(NodePortAcceleration)
 	c.EnableAutoProtectNodePortRange = viper.GetBool(EnableAutoProtectNodePortRange)
 	c.KubeProxyReplacement = viper.GetString(KubeProxyReplacement)
 	c.EnableCEPGC = viper.GetBool(EnableCEPGC)
@@ -2426,6 +2464,9 @@ func (c *DaemonConfig) Populate() {
 			}).Warning("IPv6PodSubnets parameter can not be parsed.")
 	}
 	c.IPv6PodSubnets = subnets
+
+	c.XDPDevice = "undefined"
+	c.XDPMode = XDPModeLinkNone
 
 	err = c.populateNodePortRange()
 	if err != nil {

--- a/test/bpf/verifier-test.sh
+++ b/test/bpf/verifier-test.sh
@@ -23,7 +23,7 @@ ALL_TC_PROGS="bpf_hostdev_ingress bpf_lxc bpf_netdev bpf_network bpf_overlay"
 TC_PROGS=${TC_PROGS:-$ALL_TC_PROGS}
 ALL_CG_PROGS="bpf_sock sockops/bpf_sockops sockops/bpf_redir"
 CG_PROGS=${CG_PROGS:-$ALL_CG_PROGS}
-ALL_XDP_PROGS="bpf_prefilter"
+ALL_XDP_PROGS="bpf_xdp"
 XDP_PROGS=${XDP_PROGS:-$ALL_XDP_PROGS}
 IGNORED_PROGS="bpf_alignchecker"
 ALL_PROGS="${IGNORED_PROGS} ${ALL_CG_PROGS} ${ALL_TC_PROGS} ${ALL_XDP_PROGS}"
@@ -237,7 +237,7 @@ function load_xdp {
 			load_prog_dev "$IPROUTE2 link set" "xdpgeneric" ${p}
 		done
 	else
-		echo "=> Skipping ${DIR}/bpf_prefilter.c."
+		echo "=> Skipping ${DIR}/bpf_xdp.c."
 		echo "Ensure you have linux >= 4.12 and recent iproute2 to test XDP." 1>&2
 	fi
 }


### PR DESCRIPTION
See commits.

```release-note
XDP-based NodePort LB handling for BPF-based DSR, SNAT and Hybrid mode. 
```