### PR TITLE
Remove netlink package dependency from the ip package

### DIFF
--- a/pkg/datapath/linux/node_addressing.go
+++ b/pkg/datapath/linux/node_addressing.go
@@ -30,7 +30,7 @@ import (
 // code should really move into this package.
 
 func listLocalAddresses(family int) ([]net.IP, error) {
-	ipsToExclude := ip.GetExcludedIPs()
+	ipsToExclude := node.GetExcludedIPs()
 	addrs, err := netlink.AddrList(nil, family)
 	if err != nil {
 		return nil, err

--- a/pkg/ip/ip.go
+++ b/pkg/ip/ip.go
@@ -755,11 +755,8 @@ func initPrivatePrefixes() {
 	}
 }
 
-var excludedIPs []net.IP
-
 func init() {
 	initPrivatePrefixes()
-	initExcludedIPs()
 }
 
 // IsExcluded returns whether a given IP is must be excluded
@@ -782,12 +779,6 @@ func IsPublicAddr(ip net.IP) bool {
 		}
 	}
 	return true
-}
-
-// GetExcludedIPs returns a list of IPs from netdevices that Cilium
-// needs to exclude to operate
-func GetExcludedIPs() []net.IP {
-	return excludedIPs
 }
 
 // GetCIDRPrefixesFromIPs returns all of the ips as a slice of *net.IPNet.

--- a/pkg/node/ip.go
+++ b/pkg/node/ip.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2019 Authors of Cilium
+// Copyright 2017-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,6 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ip
+package node
 
-func initExcludedIPs() {}
+import "net"
+
+var excludedIPs []net.IP
+
+// GetExcludedIPs returns a list of IPs from netdevices that Cilium
+// needs to exclude to operate
+func GetExcludedIPs() []net.IP {
+	return excludedIPs
+}

--- a/pkg/node/ip_linux.go
+++ b/pkg/node/ip_linux.go
@@ -12,13 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ip
+package node
 
 import (
 	"strings"
 
 	"github.com/vishvananda/netlink"
 )
+
+func init() {
+	initExcludedIPs()
+}
 
 func initExcludedIPs() {
 	// We exclude below bad device prefixes from address selection ...

--- a/pkg/node/node_address_linux.go
+++ b/pkg/node/node_address_linux.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Authors of Cilium
+// Copyright 2016-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ func firstGlobalAddr(intf string, preferredIP net.IP, family int) (net.IP, error
 	var ipLen int
 	var err error
 
-	ipsToExclude := ip.GetExcludedIPs()
+	ipsToExclude := GetExcludedIPs()
 	linkScopeMax := unix.RT_SCOPE_UNIVERSE
 	if family == netlink.FAMILY_V4 {
 		ipLen = 4


### PR DESCRIPTION


Signed-off-by: Nate Sweet <nathanjsweet@pm.me>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->
Remove netlink package dependency from the ip package
so that common code no longer needs to be Linux specific.

```release-note
Removed  the netlink package dependency from the ip package
to decouple common code from being linux specific.
```
