### PR TITLE
pkg/ipam: Don't let ENI IPAM override native-routing-cidr

### DIFF
--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -26,6 +26,7 @@ import (
 
 	eniTypes "github.com/cilium/cilium/pkg/aws/eni/types"
 	"github.com/cilium/cilium/pkg/cidr"
+	"github.com/cilium/cilium/pkg/ip"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	"github.com/cilium/cilium/pkg/k8s"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -241,7 +242,24 @@ func (n *nodeStore) hasMinimumIPsInPool() (minimumReached bool, required, numAva
 
 		if n.conf.IPAMMode() == option.IPAMENI {
 			if vpcCIDR := deriveVpcCIDR(n.ownNode); vpcCIDR != nil {
-				n.conf.SetIPv4NativeRoutingCIDR(vpcCIDR)
+				if nativeCIDR := n.conf.IPv4NativeRoutingCIDR(); nativeCIDR != nil {
+					logFields := logrus.Fields{
+						"vpc-cidr":                   vpcCIDR.String(),
+						option.IPv4NativeRoutingCIDR: nativeCIDR.String(),
+					}
+
+					ranges4, _ := ip.CoalesceCIDRs([]*net.IPNet{nativeCIDR.IPNet, vpcCIDR.IPNet})
+					if len(ranges4) != 1 {
+						log.WithFields(logFields).Fatal("Native routing CIDR does not contain VPC CIDR.")
+					} else {
+						log.WithFields(logFields).Info("Ignoring autodetected VPC CIDR.")
+					}
+				} else {
+					log.WithFields(logrus.Fields{
+						"vpc-cidr": vpcCIDR.String(),
+					}).Info("Using autodetected VPC CIDR.")
+					n.conf.SetIPv4NativeRoutingCIDR(vpcCIDR)
+				}
 			} else {
 				minimumReached = false
 			}

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -71,6 +71,10 @@ type Configuration interface {
 	// SetIPv4NativeRoutingCIDR is called by the IPAM module to announce
 	// the native IPv4 routing CIDR if it exists
 	SetIPv4NativeRoutingCIDR(cidr *cidr.CIDR)
+
+	// IPv4NativeRoutingCIDR is called by the IPAM module retrieve
+	// the native IPv4 routing CIDR if it exists
+	IPv4NativeRoutingCIDR() *cidr.CIDR
 }
 
 // Owner is the interface the owner of an IPAM allocator has to implement

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -56,6 +56,7 @@ func (t *testConfiguration) HealthCheckingEnabled() bool              { return t
 func (t *testConfiguration) IPAMMode() string                         { return option.IPAMHostScopeLegacy }
 func (t *testConfiguration) BlacklistConflictingRoutesEnabled() bool  { return false }
 func (t *testConfiguration) SetIPv4NativeRoutingCIDR(cidr *cidr.CIDR) {}
+func (t *testConfiguration) IPv4NativeRoutingCIDR() *cidr.CIDR        { return nil }
 
 func (s *IPAMSuite) TestLock(c *C) {
 	fakeAddressing := fake.NewNodeAddressing()


### PR DESCRIPTION
When using VPC Peering or similar, the L2 domain can be larger than the VPC CIDR from the ec2 instance's primary ENI. 

The cilium agent has the `--native-routing-cidr` flag which can be used to manually configure this. However, when using ENI for IPAM, it always overwrites the configured value.

This PR changes this behavior, deferring to what the configured value for `native-routing-cidr`, and verifies that the `native-routing-cidr` is valid by checking that the VPC CIDR is a subnet of it.

Signed-off-by: John Watson <johnw@planetscale.com>
