### PR TITLE
Pass native-routing-cidr to ENI CNI for route rules

### DIFF
--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -464,6 +464,10 @@ func (a *crdAllocator) buildAllocationResult(ip net.IP, ipInfo *ipamTypes.Alloca
 				result.Master = eni.MAC
 				result.CIDRs = []string{eni.VPC.PrimaryCIDR}
 				result.CIDRs = append(result.CIDRs, eni.VPC.CIDRs...)
+				// Add manually configured Native Routing CIDR
+				if a.conf.IPv4NativeRoutingCIDR() != nil {
+					result.CIDRs = append(result.CIDRs, a.conf.IPv4NativeRoutingCIDR().String())
+				}
 				if eni.Subnet.CIDR != "" {
 					result.GatewayIP = deriveGatewayIP(eni)
 				}

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -71,6 +71,10 @@ type Configuration interface {
 	// SetIPv4NativeRoutingCIDR is called by the IPAM module to announce
 	// the native IPv4 routing CIDR if it exists
 	SetIPv4NativeRoutingCIDR(cidr *cidr.CIDR)
+
+	// IPv4NativeRoutingCIDR is called by the IPAM module retrieve
+	// the native IPv4 routing CIDR if it exists
+	IPv4NativeRoutingCIDR() *cidr.CIDR
 }
 
 // Owner is the interface the owner of an IPAM allocator has to implement

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -56,6 +56,7 @@ func (t *testConfiguration) HealthCheckingEnabled() bool              { return t
 func (t *testConfiguration) IPAMMode() string                         { return option.IPAMHostScopeLegacy }
 func (t *testConfiguration) BlacklistConflictingRoutesEnabled() bool  { return false }
 func (t *testConfiguration) SetIPv4NativeRoutingCIDR(cidr *cidr.CIDR) {}
+func (t *testConfiguration) IPv4NativeRoutingCIDR() *cidr.CIDR        { return nil }
 
 func (s *IPAMSuite) TestLock(c *C) {
 	fakeAddressing := fake.NewNodeAddressing()


### PR DESCRIPTION
When using a configured `native-routing-cidr` that encompasses the VPC subnet, due to using VPC Peering or similar, the Linux routing rules need to be configured to properly route back out the ENI which the IP is attached when masquerade is disabled.

This PR adds `native-routing-cidr` to the IPAM CRD AllocationResult. In the ENI cilium-cni plugin it coalesces all returned CIDRs into the minimum set needed for the Linux routing rules.

Signed-off-by: John Watson <johnw@planetscale.com>
