### PR TITLE
make: silence more sub-make output in quiet mode

### DIFF
--- a/cilium-health/Makefile
+++ b/cilium-health/Makefile
@@ -14,16 +14,16 @@ $(TARGET): $(SOURCES)
 	$(QUIET)$(GO) build $(GOBUILD) -o $(TARGET)
 
 $(SUBDIRS): force
-	@ $(MAKE) -C $@ all
+	@ $(MAKE) $(SUBMAKEOPTS) -C $@ all
 
 clean:
 	@$(ECHO_CLEAN)
-	$(QUIET)for i in $(SUBDIRS); do $(MAKE) -C $$i clean; done
+	$(QUIET)for i in $(SUBDIRS); do $(MAKE) $(SUBMAKEOPTS) -C $$i clean; done
 	-$(QUIET)rm -f $(TARGET)
 	$(QUIET)$(GO) clean $(GOCLEAN)
 
 install:
-	$(QUIET)for i in $(SUBDIRS); do $(MAKE) -C $$i install; done
+	$(QUIET)for i in $(SUBDIRS); do $(MAKE) $(SUBMAKEOPTS) -C $$i install; done
 	$(QUIET)$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)
 	$(QUIET)$(INSTALL) -m 0755 $(TARGET) $(DESTDIR)$(BINDIR)
 

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -17,7 +17,7 @@ clean:
 	@$(ECHO_CLEAN)
 	$(QUIET)rm -f $(TARGET)
 	$(QUIET)$(GO) clean $(GOCLEAN)
-	$(foreach link,$(LINKS), rm -f $(link);)
+	$(foreach link,$(LINKS), $(QUIET)rm -f $(link);)
 
 ifeq ("$(PKG_BUILD)","")
 

--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -5,13 +5,13 @@ SUBDIRS = cilium-docker cilium-cni
 all: $(SUBDIRS)
 
 $(SUBDIRS): force
-	@ $(MAKE) -C $@ all
+	@ $(MAKE) $(SUBMAKEOPTS) -C $@ all
 
 clean:
-	for i in $(SUBDIRS); do $(MAKE) -C $$i clean; done
+	$(QUIET)for i in $(SUBDIRS); do $(MAKE) $(SUBMAKEOPTS) -C $$i clean; done
 
 install:
-	for i in $(SUBDIRS); do $(MAKE) -C $$i install; done
+	$(QUIET)for i in $(SUBDIRS); do $(MAKE) $(SUBMAKEOPTS) -C $$i install; done
 
 .PHONY: force
 force :;


### PR DESCRIPTION
These were missing in commit 25b7b779a197 ("make: silence sub-make
output when building in quiet mode"), PR #10664.

Avoid printing sub-make directories and commands when building with
`make V=0`.