### PR TITLE
identity: Factor out model handling

### DIFF
--- a/cilium/cmd/bpf_policy_get.go
+++ b/cilium/cmd/bpf_policy_get.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/command"
 	"github.com/cilium/cilium/pkg/identity"
+	identitymodel "github.com/cilium/cilium/pkg/identity/model"
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/u8proto"
@@ -138,7 +139,7 @@ func formatMap(w io.Writer, statsMap []policymap.PolicyEntryDump) {
 				fmt.Fprintf(os.Stderr, "Was impossible to retrieve label ID %d: %s\n",
 					id, err)
 			} else {
-				labelsID[id] = identity.NewIdentityFromModel(lbls)
+				labelsID[id] = identitymodel.NewIdentityFromModel(lbls)
 			}
 		}
 

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -43,6 +43,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
+	identitymodel "github.com/cilium/cilium/pkg/identity/model"
 	"github.com/cilium/cilium/pkg/ipam"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s"
@@ -649,7 +650,7 @@ func (d *Daemon) GetIdentity(securityIdentity uint64) (*models.Identity, error) 
 	if ident == nil {
 		return nil, fmt.Errorf("identity %d not found", securityIdentity)
 	}
-	return ident.GetModel(), nil
+	return identitymodel.CreateModel(ident), nil
 }
 
 // GetEndpointInfo returns endpoint info for a given IP address. Hubble uses this function to populate

--- a/daemon/cmd/identity.go
+++ b/daemon/cmd/identity.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
+	identitymodel "github.com/cilium/cilium/pkg/identity/model"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 
@@ -46,7 +47,7 @@ func (h *getIdentity) Handle(params GetIdentityParams) middleware.Responder {
 			return NewGetIdentityIDNotFound()
 		}
 
-		identities = append(identities, identity.GetModel())
+		identities = append(identities, identitymodel.CreateModel(identity))
 	}
 
 	return NewGetIdentityOK().WithPayload(identities)
@@ -73,7 +74,7 @@ func (h *getIdentityID) Handle(params GetIdentityIDParams) middleware.Responder 
 		return NewGetIdentityIDNotFound()
 	}
 
-	return NewGetIdentityIDOK().WithPayload(identity.GetModel())
+	return NewGetIdentityIDOK().WithPayload(identitymodel.CreateModel(identity))
 }
 
 type getIdentityEndpoints struct{}

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/fqdn"
 	"github.com/cilium/cilium/pkg/identity/cache"
+	identitymodel "github.com/cilium/cilium/pkg/identity/model"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/labels/model"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -197,7 +198,7 @@ func (e *Endpoint) GetModelRLocked() *models.Endpoint {
 			// FIXME GH-3280 When we begin implementing revision numbers this will
 			// diverge from models.Endpoint.Spec to reflect the in-datapath config
 			Realized: spec,
-			Identity: e.SecurityIdentity.GetModel(),
+			Identity: identitymodel.CreateModel(e.SecurityIdentity),
 			Labels:   lblMdl,
 			Networking: &models.EndpointNetworking{
 				Addressing: []*models.AddressPair{{

--- a/pkg/identity/cache/cache.go
+++ b/pkg/identity/cache/cache.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/allocator"
 	"github.com/cilium/cilium/pkg/identity"
+	identitymodel "github.com/cilium/cilium/pkg/identity/model"
 	"github.com/cilium/cilium/pkg/idpool"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/labels"
@@ -84,17 +85,17 @@ func (m *CachingIdentityAllocator) GetIdentities() IdentitiesModel {
 	m.IdentityAllocator.ForeachCache(func(id idpool.ID, val allocator.AllocatorKey) {
 		if gi, ok := val.(GlobalIdentity); ok {
 			identity := identity.NewIdentityFromLabelArray(identity.NumericIdentity(id), gi.LabelArray)
-			identities = append(identities, identity.GetModel())
+			identities = append(identities, identitymodel.CreateModel(identity))
 		}
 
 	})
 	// append user reserved identities
 	for _, v := range identity.ReservedIdentityCache {
-		identities = append(identities, v.GetModel())
+		identities = append(identities, identitymodel.CreateModel(v))
 	}
 
 	for _, v := range m.localIdentities.GetIdentities() {
-		identities = append(identities, v.GetModel())
+		identities = append(identities, identitymodel.CreateModel(v))
 	}
 
 	return identities

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/labels"
 )
 
@@ -70,24 +69,6 @@ type IPIdentityPair struct {
 	K8sPodName   string          `json:"K8sPodName,omitempty"`
 }
 
-func NewIdentityFromModel(base *models.Identity) *Identity {
-	if base == nil {
-		return nil
-	}
-
-	id := &Identity{
-		ID:     NumericIdentity(base.ID),
-		Labels: make(labels.Labels),
-	}
-	for _, v := range base.Labels {
-		lbl := labels.ParseLabel(v)
-		id.Labels[lbl.Key] = lbl
-	}
-	id.Sanitize()
-
-	return id
-}
-
 // Sanitize takes a partially initialized Identity (for example, deserialized
 // from json) and reconstitutes the full object from what has been restored.
 func (id *Identity) Sanitize() {
@@ -114,24 +95,6 @@ func (id *Identity) StringID() string {
 // StringID returns the identity identifier as string
 func (id *Identity) String() string {
 	return id.ID.StringID()
-}
-
-func (id *Identity) GetModel() *models.Identity {
-	if id == nil {
-		return nil
-	}
-
-	ret := &models.Identity{
-		ID:           int64(id.ID),
-		Labels:       []string{},
-		LabelsSHA256: "",
-	}
-
-	for _, v := range id.Labels {
-		ret.Labels = append(ret.Labels, v.String())
-	}
-	ret.LabelsSHA256 = id.GetLabelsSHA256()
-	return ret
 }
 
 // IsReserved returns whether the identity represents a reserved identity

--- a/pkg/identity/identitymanager/manager.go
+++ b/pkg/identity/identitymanager/manager.go
@@ -17,6 +17,7 @@ package identitymanager
 import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/identity/model"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 
@@ -187,7 +188,7 @@ func (idm *IdentityManager) GetIdentityModels() []*models.IdentityEndpoints {
 
 	for _, v := range idm.identities {
 		identities = append(identities, &models.IdentityEndpoints{
-			Identity: v.identity.GetModel(),
+			Identity: model.CreateModel(v.identity),
 			RefCount: int64(v.refCount),
 		})
 	}

--- a/pkg/identity/model/identity.go
+++ b/pkg/identity/model/identity.go
@@ -1,0 +1,57 @@
+// Copyright 2018-2019 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/labels"
+)
+
+func NewIdentityFromModel(base *models.Identity) *identity.Identity {
+	if base == nil {
+		return nil
+	}
+
+	id := &identity.Identity{
+		ID:     identity.NumericIdentity(base.ID),
+		Labels: make(labels.Labels),
+	}
+	for _, v := range base.Labels {
+		lbl := labels.ParseLabel(v)
+		id.Labels[lbl.Key] = lbl
+	}
+	id.Sanitize()
+
+	return id
+}
+
+func CreateModel(id *identity.Identity) *models.Identity {
+	if id == nil {
+		return nil
+	}
+
+	ret := &models.Identity{
+		ID:           int64(id.ID),
+		Labels:       []string{},
+		LabelsSHA256: "",
+	}
+
+	for _, v := range id.Labels {
+		ret.Labels = append(ret.Labels, v.String())
+	}
+	ret.LabelsSHA256 = id.GetLabelsSHA256()
+	return ret
+}

--- a/pkg/testutils/endpoint.go
+++ b/pkg/testutils/endpoint.go
@@ -15,9 +15,9 @@
 package testutils
 
 import (
-	identityMdl "github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/common/addressing"
 	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/mac"
 	"github.com/cilium/cilium/pkg/option"
 
@@ -25,10 +25,7 @@ import (
 )
 
 var (
-	defaultIdentity = identity.NewIdentityFromModel(&identityMdl.Identity{
-		ID:     42,
-		Labels: []string{"foo"},
-	})
+	defaultIdentity = identity.NewIdentity(42, labels.NewLabelsFromModel([]string{"foo"}))
 )
 
 type TestEndpoint struct {
@@ -82,10 +79,7 @@ func (e *TestEndpoint) Logger(subsystem string) *logrus.Entry {
 }
 
 func (e *TestEndpoint) SetIdentity(secID int64, newEndpoint bool) {
-	e.Identity = identity.NewIdentityFromModel(&identityMdl.Identity{
-		ID:     secID,
-		Labels: []string{"bar"},
-	})
+	e.Identity = identity.NewIdentity(identity.NumericIdentity(secID), labels.NewLabelsFromModel([]string{"bar"}))
 }
 
 func (e *TestEndpoint) StateDir() string {


### PR DESCRIPTION
The models dependency blows up the dependency chain of pkg/identity
which is otherwise representing a basic type. Move it into a sub
package.