### PR TITLE
endpoint: Move id allocation out of pkg/endpoint/id

### DIFF
--- a/pkg/endpointmanager/idallocator/allocator.go
+++ b/pkg/endpointmanager/idallocator/allocator.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package id
+package idallocator
 
 import (
 	"fmt"

--- a/pkg/endpointmanager/idallocator/allocator_test.go
+++ b/pkg/endpointmanager/idallocator/allocator_test.go
@@ -14,11 +14,20 @@
 //
 // +build !privileged_tests
 
-package id
+package idallocator
 
 import (
+	"testing"
+
 	. "gopkg.in/check.v1"
 )
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) { TestingT(t) }
+
+type IDSuite struct{}
+
+var _ = Suite(&IDSuite{})
 
 func (s *IDSuite) TestAllocation(c *C) {
 	ReallocatePool()

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint"
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
+	"github.com/cilium/cilium/pkg/endpointmanager/idallocator"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -156,12 +157,12 @@ func (mgr *EndpointManager) InitMetrics() {
 func (mgr *EndpointManager) AllocateID(currID uint16) (uint16, error) {
 	var newID uint16
 	if currID != 0 {
-		if err := endpointid.Reuse(currID); err != nil {
+		if err := idallocator.Reuse(currID); err != nil {
 			return 0, fmt.Errorf("unable to reuse endpoint ID: %s", err)
 		}
 		newID = currID
 	} else {
-		id := endpointid.Allocate()
+		id := idallocator.Allocate()
 		if id == uint16(0) {
 			return 0, fmt.Errorf("no more endpoint IDs available")
 		}
@@ -278,7 +279,7 @@ func (mgr *EndpointManager) LookupPodName(name string) *endpoint.Endpoint {
 // ReleaseID releases the ID of the specified endpoint from the EndpointManager.
 // Returns an error if the ID cannot be released.
 func (mgr *EndpointManager) ReleaseID(ep *endpoint.Endpoint) error {
-	return endpointid.Release(ep.ID)
+	return idallocator.Release(ep.ID)
 }
 
 // WaitEndpointRemoved waits until all operations associated with Remove of
@@ -291,7 +292,7 @@ func (mgr *EndpointManager) WaitEndpointRemoved(ep *endpoint.Endpoint) {
 func (mgr *EndpointManager) RemoveAll() {
 	mgr.mutex.Lock()
 	defer mgr.mutex.Unlock()
-	endpointid.ReallocatePool()
+	idallocator.ReallocatePool()
 	mgr.endpoints = map[uint16]*endpoint.Endpoint{}
 	mgr.endpointsAux = map[string]*endpoint.Endpoint{}
 }


### PR DESCRIPTION
All users of pkg/endpoint/id except for one are using the package to use
helpers around endpoint IDs. The ID allocation pulls in additional
dependencies, split them apart and move the id allocation into
pkg/endpointmanager where it is used.