### PR TITLE
Add helm NOTES to the root folder

### DIFF
--- a/install/kubernetes/cilium/templates/NOTES.txt
+++ b/install/kubernetes/cilium/templates/NOTES.txt
@@ -1,0 +1,5 @@
+You have successfully installed {{ title .Chart.Name }}.
+
+Your release version is {{ .Chart.Version }}.
+
+For any further help, visit https://docs.cilium.io/en/v{{ substr 0 3 .Chart.Version }}/gettinghelp


### PR DESCRIPTION
This patch adds helm NOTES file to the root folder.

Fixes: #10070
Signed-off-by: Swaminathan Vasudevan <svasudevan@suse.com>