### PR TITLE
cli: Fix JSON output for BPF conntrack & NAT tables dump

### DIFF
--- a/cilium/cmd/bpf_ct_list.go
+++ b/cilium/cmd/bpf_ct_list.go
@@ -34,8 +34,13 @@ var bpfCtListCmd = &cobra.Command{
 	Short:   "List connection tracking entries",
 	PreRun:  requireEndpointIDorGlobal,
 	Run: func(cmd *cobra.Command, args []string) {
+		maps := getMaps(args[0])
+		ctMaps := make([]ctmap.CtMap, len(maps))
+		for i, m := range maps {
+			ctMaps[i] = m
+		}
 		common.RequireRootPrivilege("cilium bpf ct list")
-		dumpCt(args[0])
+		dumpCt(ctMaps, args[0])
 	},
 }
 
@@ -44,14 +49,15 @@ func init() {
 	command.AddJSONOutput(bpfCtListCmd)
 }
 
-func dumpCt(eID string) {
-	var maps []*ctmap.Map
+func getMaps(eID string) []*ctmap.Map {
 	if eID == "global" {
-		maps = ctmap.GlobalMaps(true, true)
-	} else {
-		id, _ := strconv.Atoi(eID)
-		maps = ctmap.LocalMaps(&dummyEndpoint{ID: id}, true, true)
+		return ctmap.GlobalMaps(true, true)
 	}
+	id, _ := strconv.Atoi(eID)
+	return ctmap.LocalMaps(&dummyEndpoint{ID: id}, true, true)
+}
+
+func dumpCt(maps []ctmap.CtMap, eID string) {
 	entries := make([]ctmap.CtMapRecord, 0)
 
 	for _, m := range maps {

--- a/cilium/cmd/bpf_ct_list_test.go
+++ b/cilium/cmd/bpf_ct_list_test.go
@@ -1,0 +1,198 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/cilium/cilium/common/types"
+	"github.com/cilium/cilium/pkg/byteorder"
+	"github.com/cilium/cilium/pkg/checker"
+	"github.com/cilium/cilium/pkg/command"
+	"github.com/cilium/cilium/pkg/maps/ctmap"
+	"github.com/cilium/cilium/pkg/tuple"
+
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type BPFCtListSuite struct{}
+
+var _ = Suite(&BPFCtListSuite{})
+
+var (
+	srcAddr4 = types.IPv4{10, 10, 10, 2}
+	ctKey4   = ctmap.CtKey4{
+		TupleKey4: tuple.TupleKey4{
+			DestAddr:   types.IPv4{10, 10, 10, 1},
+			SourceAddr: srcAddr4,
+			DestPort:   byteorder.HostToNetwork(uint16(80)).(uint16),
+			SourcePort: byteorder.HostToNetwork(uint16(13579)).(uint16),
+			NextHeader: 6,
+			Flags:      123,
+		},
+	}
+	srcAddr6 = types.IPv6{1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 121, 98, 219, 61}
+	ctKey6   = ctmap.CtKey6{
+		TupleKey6: tuple.TupleKey6{
+			DestAddr:   types.IPv6{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+			SourceAddr: srcAddr6,
+			DestPort:   byteorder.HostToNetwork(uint16(443)).(uint16),
+			SourcePort: byteorder.HostToNetwork(uint16(7878)).(uint16),
+			NextHeader: 17,
+			Flags:      31,
+		},
+	}
+	ctValue = ctmap.CtEntry{
+		RxPackets:        1,
+		RxBytes:          512,
+		TxPackets:        4,
+		TxBytes:          2048,
+		Lifetime:         12345,
+		Flags:            3,
+		RevNAT:           byteorder.HostToNetwork(uint16(27)).(uint16),
+		TxFlagsSeen:      88,
+		RxFlagsSeen:      99,
+		SourceSecurityID: 6789,
+		LastTxReport:     0,
+		LastRxReport:     7777,
+	}
+)
+
+type ctRecord4 struct {
+	Key   tuple.TupleKey4
+	Value ctmap.CtEntry
+}
+
+type ctRecord6 struct {
+	Key   tuple.TupleKey6
+	Value ctmap.CtEntry
+}
+
+func dumpAndRead(maps []ctmap.CtMap, c *C) string {
+	// dumpCt() prints to standard output. Let's redirect it to a pipe, and
+	// read the dump from there.
+	stdout := os.Stdout
+	readEnd, writeEnd, err := os.Pipe()
+	c.Assert(err, IsNil, Commentf("failed to create pipe: '%s'", err))
+	os.Stdout = writeEnd
+	defer func() { os.Stdout = stdout }()
+
+	command.ForceJSON()
+	dumpCt(maps, "")
+
+	channel := make(chan string)
+	go func() {
+		var buf bytes.Buffer
+		_, err = io.Copy(&buf, readEnd)
+		channel <- buf.String()
+	}()
+
+	writeEnd.Close()
+	// Even though we have a defer, restore os.Stdout already if we can
+	// (for the assert)
+	os.Stdout = stdout
+	rawDump := <-channel
+	c.Assert(err, IsNil, Commentf("failed to read data: '%s'", err))
+
+	return rawDump
+}
+
+func (s *BPFCtListSuite) TestDumpCt4(c *C) {
+
+	ctMaps := [2]ctmap.CtMap{
+		ctmap.NewCtMockMap(
+			[]ctmap.CtMapRecord{
+				{
+					Key:   &ctKey4,
+					Value: ctValue,
+				},
+				{
+					Key:   &ctKey4,
+					Value: ctValue,
+				},
+			},
+		),
+		ctmap.NewCtMockMap(
+			[]ctmap.CtMapRecord{
+				{
+					Key:   &ctKey4,
+					Value: ctValue,
+				},
+			},
+		),
+	}
+
+	rawDump := dumpAndRead(ctMaps[:], c)
+
+	var ctDump []ctRecord4
+	err := json.Unmarshal([]byte(rawDump), &ctDump)
+	c.Assert(err, IsNil, Commentf("invalid JSON output: '%s', '%s'", err, rawDump))
+
+	// JSON output may reorder the entries, but in our case they are all
+	// the same.
+	ctRecordDump := ctmap.CtMapRecord{
+		Key:   &ctmap.CtKey4{TupleKey4: ctDump[0].Key},
+		Value: ctDump[0].Value,
+	}
+	c.Assert(ctRecordDump, checker.DeepEquals, ctMaps[0].(*ctmap.CtMockMap).Entries[0])
+}
+
+func (s *BPFCtListSuite) TestDumpCt6(c *C) {
+
+	ctMaps := [2]ctmap.CtMap{
+		ctmap.NewCtMockMap(
+			[]ctmap.CtMapRecord{
+				{
+					Key:   &ctKey6,
+					Value: ctValue,
+				},
+				{
+					Key:   &ctKey6,
+					Value: ctValue,
+				},
+			},
+		),
+		ctmap.NewCtMockMap(
+			[]ctmap.CtMapRecord{
+				{
+					Key:   &ctKey6,
+					Value: ctValue,
+				},
+			},
+		),
+	}
+
+	rawDump := dumpAndRead(ctMaps[:], c)
+
+	var ctDump []ctRecord6
+	err := json.Unmarshal([]byte(rawDump), &ctDump)
+	c.Assert(err, IsNil, Commentf("invalid JSON output: '%s', '%s'", err, rawDump))
+
+	// JSON output may reorder the entries, but in our case they are all
+	// the same.
+	ctRecordDump := ctmap.CtMapRecord{
+		Key:   &ctmap.CtKey6{TupleKey6: ctDump[0].Key},
+		Value: ctDump[0].Value,
+	}
+	c.Assert(ctRecordDump, checker.DeepEquals, ctMaps[0].(*ctmap.CtMockMap).Entries[0])
+}

--- a/cilium/cmd/bpf_nat_list_test.go
+++ b/cilium/cmd/bpf_nat_list_test.go
@@ -1,0 +1,170 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package cmd
+
+import (
+	"encoding/json"
+
+	"github.com/cilium/cilium/common/types"
+	"github.com/cilium/cilium/pkg/byteorder"
+	"github.com/cilium/cilium/pkg/checker"
+	"github.com/cilium/cilium/pkg/maps/nat"
+	"github.com/cilium/cilium/pkg/tuple"
+
+	. "gopkg.in/check.v1"
+)
+
+type BPFNatListSuite struct{}
+
+var _ = Suite(&BPFNatListSuite{})
+
+var (
+	natKey4 = nat.NatKey4{
+		TupleKey4Global: tuple.TupleKey4Global{
+			TupleKey4: tuple.TupleKey4{
+				DestAddr:   types.IPv4{10, 10, 10, 1},
+				SourceAddr: types.IPv4{10, 10, 10, 2},
+				DestPort:   byteorder.HostToNetwork(uint16(80)).(uint16),
+				SourcePort: byteorder.HostToNetwork(uint16(13579)).(uint16),
+				NextHeader: 6,
+				Flags:      123,
+			},
+		},
+	}
+	natKey6 = nat.NatKey6{
+		TupleKey6Global: tuple.TupleKey6Global{
+			TupleKey6: tuple.TupleKey6{
+				DestAddr:   types.IPv6{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+				SourceAddr: types.IPv6{1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 121, 98, 219, 61},
+				DestPort:   byteorder.HostToNetwork(uint16(443)).(uint16),
+				SourcePort: byteorder.HostToNetwork(uint16(7878)).(uint16),
+				NextHeader: 17,
+				Flags:      31,
+			},
+		},
+	}
+	natValue4 = nat.NatEntry4{
+		Created:   12345,
+		HostLocal: 6789,
+		Addr:      types.IPv4{10, 10, 10, 3},
+		Port:      byteorder.HostToNetwork(uint16(53)).(uint16),
+	}
+	natValue6 = nat.NatEntry6{
+		Created:   12345,
+		HostLocal: 6789,
+		Addr:      types.IPv6{2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53},
+		Port:      byteorder.HostToNetwork(uint16(53)).(uint16),
+	}
+)
+
+type natRecord4 struct {
+	Key   tuple.TupleKey4
+	Value *nat.NatEntry4
+}
+
+type natRecord6 struct {
+	Key   tuple.TupleKey6
+	Value *nat.NatEntry6
+}
+
+func (s *BPFNatListSuite) TestDumpNat4(c *C) {
+
+	natMaps := [2]nat.NatMap{
+		nat.NewNatMockMap(
+			[]nat.NatMapRecord{
+				{
+					Key:   &natKey4,
+					Value: &natValue4,
+				},
+				{
+					Key:   &natKey4,
+					Value: &natValue4,
+				},
+			},
+		),
+		nat.NewNatMockMap(
+			[]nat.NatMapRecord{
+				{
+					Key:   &natKey4,
+					Value: &natValue4,
+				},
+			},
+		),
+	}
+
+	maps := make([]interface{}, len(natMaps))
+	for i, m := range natMaps {
+		maps[i] = m
+	}
+	rawDump := dumpAndRead(maps, dumpNat, c)
+
+	var natDump []natRecord4
+	err := json.Unmarshal([]byte(rawDump), &natDump)
+	c.Assert(err, IsNil, Commentf("invalid JSON output: '%s', '%s'", err, rawDump))
+
+	// JSON output may reorder the entries, but in our case they are all
+	// the same.
+	natRecordDump := nat.NatMapRecord{
+		Key:   &nat.NatKey4{TupleKey4Global: tuple.TupleKey4Global{TupleKey4: natDump[0].Key}},
+		Value: natDump[0].Value,
+	}
+	c.Assert(natRecordDump, checker.DeepEquals, natMaps[0].(*nat.NatMockMap).Entries[0])
+}
+
+func (s *BPFNatListSuite) TestDumpNat6(c *C) {
+
+	natMaps := [2]nat.NatMap{
+		nat.NewNatMockMap(
+			[]nat.NatMapRecord{
+				{
+					Key:   &natKey6,
+					Value: &natValue6,
+				},
+				{
+					Key:   &natKey6,
+					Value: &natValue6,
+				},
+			},
+		),
+		nat.NewNatMockMap(
+			[]nat.NatMapRecord{
+				{
+					Key:   &natKey6,
+					Value: &natValue6,
+				},
+			},
+		),
+	}
+
+	maps := make([]interface{}, len(natMaps))
+	for i, m := range natMaps {
+		maps[i] = m
+	}
+	rawDump := dumpAndRead(maps, dumpNat, c)
+
+	var natDump []natRecord6
+	err := json.Unmarshal([]byte(rawDump), &natDump)
+	c.Assert(err, IsNil, Commentf("invalid JSON output: '%s', '%s'", err, rawDump))
+
+	// JSON output may reorder the entries, but in our case they are all
+	// the same.
+	natRecordDump := nat.NatMapRecord{
+		Key:   &nat.NatKey6{TupleKey6Global: tuple.TupleKey6Global{TupleKey6: natDump[0].Key}},
+		Value: natDump[0].Value,
+	}
+	c.Assert(natRecordDump, checker.DeepEquals, natMaps[0].(*nat.NatMockMap).Entries[0])
+}

--- a/pkg/command/output.go
+++ b/pkg/command/output.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Authors of Cilium
+// Copyright 2016-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -38,6 +38,11 @@ func OutputJSON() bool {
 //AddJSONOutput adds the -o|--output option to any cmd to export to json
 func AddJSONOutput(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&outputOpt, "output", "o", "", "json| jsonpath='{}'")
+}
+
+//ForceJSON sets output mode to JSON (for unit tests)
+func ForceJSON() {
+	outputOpt = "json"
 }
 
 //PrintOutput receives an interface and dump the data using the --output flag.

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -116,6 +116,14 @@ type mapAttributes struct {
 	natMap     NatMap
 }
 
+// A "Record" designates a map entry (key + value), but avoid "entry" because of
+// possible confusion with "CtEntry" (actually the value part).
+// This type is used for JSON dump.
+type CtMapRecord struct {
+	Key   CtKey
+	Value CtEntry
+}
+
 func setupMapInfo(m mapType, define string, mapKey bpf.MapKey, keySize int, maxEntries int, nat NatMap) {
 	mapInfo[m] = mapAttributes{
 		bpfDefine: define,

--- a/pkg/maps/ctmap/ctmap_mock.go
+++ b/pkg/maps/ctmap/ctmap_mock.go
@@ -1,0 +1,63 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ctmap
+
+import (
+	"github.com/cilium/cilium/pkg/bpf"
+)
+
+// CtMockMap implements the CtMap interface and can be used for unit tests.
+type CtMockMap struct {
+	Entries []CtMapRecord
+}
+
+// NewCtMockMap is a constructor for a CtMockMap.
+func NewCtMockMap(records []CtMapRecord) *CtMockMap {
+	m := &CtMockMap{}
+	m.Entries = records
+	return m
+}
+
+// Open does nothing, mock maps need not be opened.
+func (m *CtMockMap) Open() error {
+	return nil
+}
+
+// Close does nothing, mock maps need not be closed either.
+func (m *CtMockMap) Close() error {
+	return nil
+}
+
+// Path returns a mock path for the mock map.
+func (m *CtMockMap) Path() (string, error) {
+	return "/this/is/a/mock/map", nil
+}
+
+// DumpEntries iterates through Map m and writes the values of the ct entries
+// in m to a string.
+func (m *CtMockMap) DumpEntries() (string, error) {
+	return doDumpEntries(m)
+}
+
+// DumpWithCallback runs the callback on each entry of the mock map.
+func (m *CtMockMap) DumpWithCallback(cb bpf.DumpCallback) error {
+	if cb == nil {
+		return nil
+	}
+	for _, e := range m.Entries {
+		cb(e.Key, &e.Value)
+	}
+	return nil
+}

--- a/pkg/maps/nat/nat.go
+++ b/pkg/maps/nat/nat.go
@@ -59,6 +59,14 @@ type NatEntry interface {
 	Dump(key NatKey, start uint64) string
 }
 
+// A "Record" designates a map entry (key + value), but avoid "entry" because of
+// possible confusion with "NatEntry" (actually the value part).
+// This type is used for JSON dump.
+type NatMapRecord struct {
+	Key   NatKey
+	Value NatEntry
+}
+
 // NatDumpCreated returns time in seconds when NAT entry was created.
 func NatDumpCreated(dumpStart, entryCreated uint64) string {
 	tsecCreated := entryCreated / 1000000000

--- a/pkg/maps/nat/nat_mock.go
+++ b/pkg/maps/nat/nat_mock.go
@@ -1,0 +1,63 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nat
+
+import (
+	"github.com/cilium/cilium/pkg/bpf"
+)
+
+// NatMockMap implements the NatMap interface and can be used for unit tests.
+type NatMockMap struct {
+	Entries []NatMapRecord
+}
+
+// NewNatMockMap is a constructor for a NatMockMap.
+func NewNatMockMap(records []NatMapRecord) *NatMockMap {
+	m := &NatMockMap{}
+	m.Entries = records
+	return m
+}
+
+// Open does nothing, mock maps need not be opened.
+func (m *NatMockMap) Open() error {
+	return nil
+}
+
+// Close does nothing, mock maps need not be closed either.
+func (m *NatMockMap) Close() error {
+	return nil
+}
+
+// Path returns a mock path for the mock map.
+func (m *NatMockMap) Path() (string, error) {
+	return "/this/is/a/mock/map", nil
+}
+
+// DumpEntries iterates through Map m and writes the values of the ct entries
+// in m to a string.
+func (m *NatMockMap) DumpEntries() (string, error) {
+	return doDumpEntries(m)
+}
+
+// DumpWithCallback runs the callback on each entry of the mock map.
+func (m *NatMockMap) DumpWithCallback(cb bpf.DumpCallback) error {
+	if cb == nil {
+		return nil
+	}
+	for _, e := range m.Entries {
+		cb(e.Key, e.Value)
+	}
+	return nil
+}


### PR DESCRIPTION
JSON output is broken for conntrack and NAT tables dump with the cli (See #2976). Let's fix it. Dump arrays containing key/value tuples, so we can let the JSON parser decompose the entries into atomic values.
