### PR TITLE
Refactor proxy handling and improve monitor messages

### DIFF
--- a/bpf/bpf_hostdev_ingress.c
+++ b/bpf/bpf_hostdev_ingress.c
@@ -9,6 +9,7 @@
 
 #include "lib/common.h"
 #include "lib/dbg.h"
+#include "lib/proxy.h"
 #include "lib/trace.h"
 
 /* CB_PROXY_MAGIC overlaps with CB_ENCRYPT_MAGIC */
@@ -30,10 +31,8 @@ int to_host(struct __ctx_buff *ctx)
 		/* Upper 16 bits may carry proxy port number */
 		__be16 port = magic >> 16;
 
-		ctx->mark = magic;
 		ctx_store_meta(ctx, 0, CB_PROXY_MAGIC);
-		ctx_change_type(ctx, PACKET_HOST);
-		cilium_dbg_capture(ctx, DBG_CAPTURE_PROXY_POST, port);
+		ctx_redirect_to_proxy_first(ctx, port);
 		/* We already traced this in the previous prog with
 		 * more background context, skip trace here. */
 		traced = true;

--- a/bpf/bpf_hostdev_ingress.c
+++ b/bpf/bpf_hostdev_ingress.c
@@ -10,20 +10,25 @@
 #include "lib/common.h"
 #include "lib/dbg.h"
 
+/* CB_PROXY_MAGIC overlaps with CB_ENCRYPT_MAGIC */
+#define ENCRYPT_OR_PROXY_MAGIC 0
+
 __section("to-host")
 int to_host(struct __ctx_buff *ctx)
 {
-	__u32 magic = ctx_load_meta(ctx, 0);
+	__u32 magic = ctx_load_meta(ctx, ENCRYPT_OR_PROXY_MAGIC);
+	__u32 src_label = 0;
 
 	if ((magic & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_ENCRYPT) {
-		ctx->mark = magic;
-		set_identity_mark(ctx, ctx_load_meta(ctx, 1));
+		ctx->mark = magic; // CB_ENCRYPT_MAGIC
+		src_label = ctx_load_meta(ctx, CB_ENCRYPT_IDENTITY);
+		set_identity_mark(ctx, src_label);
 	} else if ((magic & 0xFFFF) == MARK_MAGIC_TO_PROXY) {
 		/* Upper 16 bits may carry proxy port number */
 		__be16 port = magic >> 16;
 
 		ctx->mark = magic;
-		ctx_store_meta(ctx, 0, 0);
+		ctx_store_meta(ctx, 0, CB_PROXY_MAGIC);
 		ctx_change_type(ctx, PACKET_HOST);
 		cilium_dbg_capture(ctx, DBG_CAPTURE_PROXY_POST, port);
 	}

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -145,7 +145,7 @@ skip_service_lookup:
 	// Check it this is return traffic to an ingress proxy.
 	if ((ret == CT_REPLY || ret == CT_RELATED) && ct_state.proxy_redirect) {
 		// Stack will do a socket match and deliver locally
-		return ctx_redirect_to_proxy(ctx, 0);
+		return ctx_redirect_to_proxy(ctx, 0, false);
 	}
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip6))
@@ -244,7 +244,7 @@ ct_recreate6:
 		// Trace the packet before its forwarded to proxy
 		send_trace_notify(ctx, TRACE_TO_PROXY, SECLABEL, 0,
 				  0, 0, reason, monitor);
-		return ctx_redirect_to_proxy(ctx, verdict);
+		return ctx_redirect_to_proxy(ctx, verdict, false);
 	}
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip6))
@@ -274,7 +274,7 @@ ct_recreate6:
 #endif /* ENABLE_ROUTING */
 			policy_clear_mark(ctx);
 			return ipv6_local_delivery(ctx, l3_off, SECLABEL, ep,
-						   METRIC_EGRESS);
+						   METRIC_EGRESS, false);
 		}
 	}
 
@@ -502,7 +502,7 @@ skip_service_lookup:
 	// Check it this is return traffic to an ingress proxy.
 	if ((ret == CT_REPLY || ret == CT_RELATED) && ct_state.proxy_redirect) {
 		// Stack will do a socket match and deliver locally
-		return ctx_redirect_to_proxy(ctx, 0);
+		return ctx_redirect_to_proxy(ctx, 0, false);
 	}
 
 	/* Determine the destination category for policy fallback. */
@@ -603,7 +603,7 @@ ct_recreate4:
 		// Trace the packet before its forwarded to proxy
 		send_trace_notify(ctx, TRACE_TO_PROXY, SECLABEL, 0,
 				  0, 0, reason, monitor);
-		return ctx_redirect_to_proxy(ctx, verdict);
+		return ctx_redirect_to_proxy(ctx, verdict, false);
 	}
 
 	/* After L4 write in port mapping: revalidate for direct packet access */
@@ -637,8 +637,8 @@ ct_recreate4:
 			}
 #endif /* ENABLE_ROUTING */
 			policy_clear_mark(ctx);
-			return ipv4_local_delivery(ctx, l3_off, SECLABEL,
-						   ip4, ep, METRIC_EGRESS);
+			return ipv4_local_delivery(ctx, l3_off, SECLABEL, ip4,
+						   ep, METRIC_EGRESS, false);
 		}
 	}
 
@@ -928,14 +928,16 @@ int tail_ipv6_policy(struct __ctx_buff *ctx)
 {
 	int ret, ifindex = ctx_load_meta(ctx, CB_IFINDEX);
 	__u32 src_label = ctx_load_meta(ctx, CB_SRC_LABEL);
+	bool from_host = ctx_load_meta(ctx, CB_FROM_HOST);
 	__u16 proxy_port = 0;
 	__u8 reason = 0;
 
 	ctx_store_meta(ctx, CB_SRC_LABEL, 0);
+	ctx_store_meta(ctx, CB_FROM_HOST, 0);
 
 	ret = ipv6_policy(ctx, ifindex, src_label, &reason, &proxy_port);
 	if (ret == POLICY_ACT_PROXY_REDIRECT)
-		ret = ctx_redirect_to_proxy(ctx, proxy_port);
+		ret = ctx_redirect_to_proxy(ctx, proxy_port, from_host);
 	if (IS_ERR(ret))
 		return send_drop_notify(ctx, src_label, SECLABEL, LXC_ID,
 					ret, CTX_ACT_DROP, METRIC_INGRESS);
@@ -1143,14 +1145,16 @@ int tail_ipv4_policy(struct __ctx_buff *ctx)
 {
 	int ret, ifindex = ctx_load_meta(ctx, CB_IFINDEX);
 	__u32 src_label = ctx_load_meta(ctx, CB_SRC_LABEL);
+	bool from_host = ctx_load_meta(ctx, CB_FROM_HOST);
 	__u16 proxy_port = 0;
 	__u8 reason = 0;
 
 	ctx_store_meta(ctx, CB_SRC_LABEL, 0);
+	ctx_store_meta(ctx, CB_FROM_HOST, 0);
 
 	ret = ipv4_policy(ctx, ifindex, src_label, &reason, &proxy_port);
 	if (ret == POLICY_ACT_PROXY_REDIRECT)
-		ret = ctx_redirect_to_proxy(ctx, proxy_port);
+		ret = ctx_redirect_to_proxy(ctx, proxy_port, from_host);
 	if (IS_ERR(ret))
 		return send_drop_notify(ctx, src_label, SECLABEL, LXC_ID,
 					ret, CTX_ACT_DROP, METRIC_INGRESS);

--- a/bpf/bpf_netdev.c
+++ b/bpf/bpf_netdev.c
@@ -685,8 +685,13 @@ static __always_inline int do_netdev(struct __ctx_buff *ctx, __u16 proto)
 	return ret;
 }
 
-__section("from-netdev")
-int from_netdev(struct __ctx_buff *ctx)
+/**
+ * handle_netdev
+ * @ctx		The packet context for this program
+ *
+ * Handle netdev traffic coming towards the Cilium-managed network.
+ */
+int __always_inline handle_netdev(struct __ctx_buff *ctx)
 {
 	int ret = ret;
 	__u16 proto;
@@ -699,6 +704,18 @@ int from_netdev(struct __ctx_buff *ctx)
 	}
 
 	return do_netdev(ctx, proto);
+}
+
+__section("from-netdev")
+int from_netdev(struct __ctx_buff *ctx)
+{
+	return handle_netdev(ctx);
+}
+
+__section("from-host")
+int from_host(struct __ctx_buff *ctx)
+{
+	return handle_netdev(ctx);
 }
 
 __section("to-netdev")

--- a/bpf/bpf_netdev.c
+++ b/bpf/bpf_netdev.c
@@ -691,9 +691,12 @@ int from_netdev(struct __ctx_buff *ctx)
 	int ret = ret;
 	__u16 proto;
 
-	if (!validate_ethertype(ctx, &proto))
+	if (!validate_ethertype(ctx, &proto)) {
+		send_trace_notify(ctx, TRACE_TO_STACK, HOST_ID, 0, 0, 0,
+				  REASON_FORWARDED, 0);
 		/* Pass unknown traffic to the stack */
 		return CTX_ACT_OK;
+	}
 
 	return do_netdev(ctx, proto);
 }

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -105,7 +105,8 @@ not_esp:
 		if (hdrlen < 0)
 			return hdrlen;
 
-		return ipv6_local_delivery(ctx, l3_off, *identity, ep, METRIC_INGRESS);
+		return ipv6_local_delivery(ctx, l3_off, *identity, ep,
+					   METRIC_INGRESS, false);
 	}
 
 to_host:
@@ -211,7 +212,8 @@ not_esp:
 		if (ep->flags & ENDPOINT_F_HOST)
 			goto to_host;
 
-		return ipv4_local_delivery(ctx, ETH_HLEN, *identity, ip4, ep, METRIC_INGRESS);
+		return ipv4_local_delivery(ctx, ETH_HLEN, *identity, ip4, ep,
+					   METRIC_INGRESS, false);
 	}
 
 to_host:

--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -631,7 +631,7 @@ COPTS="-DFROM_HOST -DSECLABEL=${ID_HOST}"
 if [ "$MODE" == "ipvlan" ]; then
 	COPTS+=" -DENABLE_EXTRA_HOST_DEV"
 fi
-bpf_load $HOST_DEV1 "$COPTS" "egress" bpf_netdev.c bpf_host.o from-netdev $CALLS_MAP
+bpf_load $HOST_DEV1 "$COPTS" "egress" bpf_netdev.c bpf_host.o from-host $CALLS_MAP
 bpf_load $HOST_DEV1 "" "ingress" bpf_hostdev_ingress.c bpf_hostdev_ingress.o to-host $CALLS_MAP
 bpf_load $HOST_DEV2 "" "ingress" bpf_hostdev_ingress.c bpf_hostdev_ingress.o to-host $CALLS_MAP
 if [ "$IPSEC" == "true" ]; then

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -450,9 +450,12 @@ static __always_inline __u32 or_encrypt_key(__u8 key)
 enum {
 	CB_SRC_LABEL,
 #define	CB_SVC_PORT		CB_SRC_LABEL	/* Alias, non-overlapping */
+#define	CB_PROXY_MAGIC		CB_SRC_LABEL	/* Alias, non-overlapping */
+#define	CB_ENCRYPT_MAGIC	CB_SRC_LABEL	/* Alias, non-overlapping */
 	CB_IFINDEX,
 #define	CB_SVC_ADDR_V4		CB_IFINDEX	/* Alias, non-overlapping */
 #define	CB_SVC_ADDR_V6_1	CB_IFINDEX	/* Alias, non-overlapping */
+#define	CB_ENCRYPT_IDENTITY	CB_IFINDEX	/* Alias, non-overlapping */
 	CB_POLICY,
 #define	CB_SVC_ADDR_V6_2	CB_POLICY	/* Alias, non-overlapping */
 	CB_NAT46_STATE,
@@ -460,6 +463,8 @@ enum {
 #define	CB_SVC_ADDR_V6_3	CB_NAT46_STATE	/* Alias, non-overlapping */
 	CB_CT_STATE,
 #define	CB_SVC_ADDR_V6_4	CB_CT_STATE	/* Alias, non-overlapping */
+#define	CB_ENCRYPT_DST		CB_CT_STATE	/* Alias, non-overlapping,
+						   Not used by xfrm. */
 };
 
 /* State values for NAT46 */

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -461,6 +461,7 @@ enum {
 	CB_NAT46_STATE,
 #define CB_NAT			CB_NAT46_STATE	/* Alias, non-overlapping */
 #define	CB_SVC_ADDR_V6_3	CB_NAT46_STATE	/* Alias, non-overlapping */
+#define	CB_FROM_HOST		CB_NAT46_STATE	/* Alias, non-overlapping */
 	CB_CT_STATE,
 #define	CB_SVC_ADDR_V6_4	CB_CT_STATE	/* Alias, non-overlapping */
 #define	CB_ENCRYPT_DST		CB_CT_STATE	/* Alias, non-overlapping,

--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -29,9 +29,9 @@ encap_and_redirect_nomark_ipsec(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
 	 * use cb[4] here so it doesn't need to be reset by
 	 * bpf_hostdev_ingress.
 	 */
-	ctx_store_meta(ctx, 0, or_encrypt_key(key));
-	ctx_store_meta(ctx, 1, seclabel);
-	ctx_store_meta(ctx, 4, tunnel_endpoint);
+	ctx_store_meta(ctx, CB_ENCRYPT_MAGIC, or_encrypt_key(key));
+	ctx_store_meta(ctx, CB_ENCRYPT_IDENTITY, seclabel);
+	ctx_store_meta(ctx, CB_ENCRYPT_DST, tunnel_endpoint);
 	return IPSEC_ENDPOINT;
 }
 
@@ -48,7 +48,7 @@ encap_and_redirect_ipsec(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
 	 */
 	set_encrypt_key_mark(ctx, key);
 	set_identity_mark(ctx, seclabel);
-	ctx_store_meta(ctx, 4, tunnel_endpoint);
+	ctx_store_meta(ctx, CB_ENCRYPT_DST, tunnel_endpoint);
 	return IPSEC_ENDPOINT;
 }
 #endif /* ENABLE_IPSEC */

--- a/bpf/lib/l3.h
+++ b/bpf/lib/l3.h
@@ -61,7 +61,8 @@ static __always_inline int ipv4_l3(struct __ctx_buff *ctx, int l3_off,
 static __always_inline int ipv6_local_delivery(struct __ctx_buff *ctx, int l3_off,
 					       __u32 seclabel,
 					       const struct endpoint_info *ep,
-					       __u8 direction)
+					       __u8 direction,
+					       bool from_host __maybe_unused)
 {
 	int ret;
 
@@ -91,6 +92,7 @@ static __always_inline int ipv6_local_delivery(struct __ctx_buff *ctx, int l3_of
 #else
 	ctx_store_meta(ctx, CB_SRC_LABEL, seclabel);
 	ctx_store_meta(ctx, CB_IFINDEX, ep->ifindex);
+	ctx_store_meta(ctx, CB_FROM_HOST, from_host ? 1 : 0);
 	tail_call(ctx, &POLICY_CALL_MAP, ep->lxc_id);
 	return DROP_MISSED_TAIL_CALL;
 #endif
@@ -100,7 +102,8 @@ static __always_inline int ipv6_local_delivery(struct __ctx_buff *ctx, int l3_of
 static __always_inline int ipv4_local_delivery(struct __ctx_buff *ctx, int l3_off,
 					       __u32 seclabel, struct iphdr *ip4,
 					       const struct endpoint_info *ep,
-					       __u8 direction __maybe_unused)
+					       __u8 direction __maybe_unused,
+					       bool from_host __maybe_unused)
 {
 	int ret;
 
@@ -129,6 +132,7 @@ static __always_inline int ipv4_local_delivery(struct __ctx_buff *ctx, int l3_of
 #else
 	ctx_store_meta(ctx, CB_SRC_LABEL, seclabel);
 	ctx_store_meta(ctx, CB_IFINDEX, ep->ifindex);
+	ctx_store_meta(ctx, CB_FROM_HOST, from_host ? 1 : 0);
 	tail_call(ctx, &POLICY_CALL_MAP, ep->lxc_id);
 	return DROP_MISSED_TAIL_CALL;
 #endif

--- a/bpf/lib/lxc.h
+++ b/bpf/lib/lxc.h
@@ -70,7 +70,8 @@ ctx_redirect_to_proxy_hairpin(struct __ctx_buff *ctx, __be16 proxy_port)
 	struct iphdr *ip4;
 	int ret;
 
-	ctx_store_meta(ctx, 0, MARK_MAGIC_TO_PROXY | (proxy_port << 16));
+	ctx_store_meta(ctx, CB_PROXY_MAGIC,
+		       MARK_MAGIC_TO_PROXY | (proxy_port << 16));
 	bpf_barrier(); /* verifier workaround */
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip4))

--- a/bpf/lib/lxc.h
+++ b/bpf/lib/lxc.h
@@ -13,6 +13,7 @@
 #include "trace.h"
 #include "csum.h"
 #include "l4.h"
+#include "proxy.h"
 
 #define TEMPLATE_LXC_ID 0xffff
 
@@ -56,52 +57,6 @@ int is_valid_lxc_src_ipv4(struct iphdr *ip4 __maybe_unused)
 #endif
 
 /**
- * ctx_redirect_to_proxy configures the ctx with the proxy mark and proxy port
- * number to ensure that the stack redirects the packet into the proxy.
- *
- * It is called from both ingress and egress side of endpoint devices.
- *
- * In regular veth mode:
- * * To apply egress policy, the egressing endpoint configures the mark,
- *   which returns CTX_ACT_OK to pass the packet to the stack in the context
- *   of the source device (stack ingress).
- * * To apply ingress policy, the egressing endpoint or netdev program tail
- *   calls into the policy program which configures the mark here, which
- *   returns CTX_ACT_OK to pass the packet to the stack in the context of the
- *   source device (netdev or egress endpoint device, stack ingress).
- *
- * In chaining mode with bridged endpoint devices:
- * * To apply egress policy, the egressing endpoint configures the mark,
- *   which is propagated via ctx_store_meta() in the caller. The redirect() call
- *   here redirects the packet to the ingress TC filter configured on the bridge
- *   master device.
- * * To apply ingress policy, the stack transmits the packet into the bridge
- *   master device which tail calls into the policy program for the ingress
- *   endpoint, which configures mark and cb[] as described for the egress path.
- *   The redirect() call here redirects the packet to the ingress TC filter
- *   configured on the bridge master device.
- * * In both cases for bridged endpoint devices, the bridge master device has
- *   a BPF program configured upon ingress to transfer the cb[] to the mark
- *   before passing the traffic up to the stack towards the proxy.
- */
-static __always_inline int
-ctx_redirect_to_proxy(struct __ctx_buff *ctx, __be16 proxy_port)
-{
-	ctx->mark = MARK_MAGIC_TO_PROXY | proxy_port << 16;
-
-#ifdef HOST_REDIRECT_TO_INGRESS
-	cilium_dbg_capture(ctx, DBG_CAPTURE_PROXY_PRE, proxy_port);
-	/* In this case, the DBG_CAPTURE_PROXY_POST will be sent from the
-	 * programm attached to HOST_IFINDEX. */
-	return redirect(HOST_IFINDEX, BPF_F_INGRESS);
-#else
-	cilium_dbg_capture(ctx, DBG_CAPTURE_PROXY_POST, proxy_port);
-	ctx_change_type(ctx, PACKET_HOST); // Required for ingress packets from overlay
-	return CTX_ACT_OK;
-#endif
-}
-
-/**
  * ctx_redirect_to_proxy_hairpin redirects to the proxy by hairpining the
  * packet out the incoming interface
  */
@@ -130,31 +85,4 @@ ctx_redirect_to_proxy_hairpin(struct __ctx_buff *ctx, __be16 proxy_port)
 	return redirect(HOST_IFINDEX, 0);
 }
 
-/**
- * tc_index_skip_ingress_proxy - returns true if packet originates from ingress proxy
- */
-static __always_inline bool tc_index_skip_ingress_proxy(struct __ctx_buff *ctx)
-{
-	volatile __u32 tc_index = ctx->tc_index;
-#ifdef DEBUG
-	if (tc_index & TC_INDEX_F_SKIP_INGRESS_PROXY)
-		cilium_dbg(ctx, DBG_SKIP_PROXY, tc_index, 0);
-#endif
-
-	return tc_index & TC_INDEX_F_SKIP_INGRESS_PROXY;
-}
-
-/**
- * tc_index_skip_egress_proxy - returns true if packet originates from egress proxy
- */
-static __always_inline bool tc_index_skip_egress_proxy(struct __ctx_buff *ctx)
-{
-	volatile __u32 tc_index = ctx->tc_index;
-#ifdef DEBUG
-	if (tc_index & TC_INDEX_F_SKIP_EGRESS_PROXY)
-		cilium_dbg(ctx, DBG_SKIP_PROXY, tc_index, 0);
-#endif
-
-	return tc_index & TC_INDEX_F_SKIP_EGRESS_PROXY;
-}
 #endif /* __LIB_LXC_H_ */

--- a/bpf/lib/lxc.h
+++ b/bpf/lib/lxc.h
@@ -81,7 +81,7 @@ ctx_redirect_to_proxy_hairpin(struct __ctx_buff *ctx, __be16 proxy_port)
 	if (IS_ERR(ret))
 		return ret;
 
-	cilium_dbg_capture(ctx, DBG_CAPTURE_PROXY_POST, proxy_port);
+	cilium_dbg(ctx, DBG_CAPTURE_PROXY_POST, proxy_port, 0);
 
 	return redirect(HOST_IFINDEX, 0);
 }

--- a/bpf/lib/proxy.h
+++ b/bpf/lib/proxy.h
@@ -45,12 +45,13 @@ ctx_redirect_to_proxy(struct __ctx_buff *ctx, __be16 proxy_port)
 	ctx->mark = MARK_MAGIC_TO_PROXY | proxy_port << 16;
 
 #ifdef HOST_REDIRECT_TO_INGRESS
-	cilium_dbg_capture(ctx, DBG_CAPTURE_PROXY_PRE, proxy_port);
+	cilium_dbg(ctx, DBG_CAPTURE_PROXY_PRE, proxy_port, 0);
 	/* In this case, the DBG_CAPTURE_PROXY_POST will be sent from the
 	 * programm attached to HOST_IFINDEX. */
 	return redirect(HOST_IFINDEX, BPF_F_INGRESS);
 #else
-	cilium_dbg_capture(ctx, DBG_CAPTURE_PROXY_POST, proxy_port);
+	cilium_dbg(ctx, DBG_CAPTURE_PROXY_PRE, proxy_port, 0);
+
 	ctx_change_type(ctx, PACKET_HOST); // Required for ingress packets from overlay
 	return CTX_ACT_OK;
 #endif

--- a/bpf/lib/proxy.h
+++ b/bpf/lib/proxy.h
@@ -57,6 +57,19 @@ ctx_redirect_to_proxy(struct __ctx_buff *ctx, __be16 proxy_port)
 }
 
 /**
+ * ctx_redirect_to_proxy_first() applies changes to the context to forward
+ * the packet towards the proxy. It is designed to run as the first function
+ * that accesses the context from the current BPF program.
+ */
+static __always_inline void
+ctx_redirect_to_proxy_first(struct __ctx_buff *ctx, __be16 proxy_port)
+{
+	cilium_dbg(ctx, DBG_CAPTURE_PROXY_POST, proxy_port, 0);
+	ctx->mark = MARK_MAGIC_TO_PROXY | (proxy_port << 16);
+	ctx_change_type(ctx, PACKET_HOST);
+}
+
+/**
  * tc_index_skip_ingress_proxy - returns true if packet originates from ingress proxy
  */
 static __always_inline bool tc_index_skip_ingress_proxy(struct __ctx_buff *ctx)

--- a/bpf/lib/proxy.h
+++ b/bpf/lib/proxy.h
@@ -1,0 +1,86 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Copyright (C) 2016-2020 Authors of Cilium */
+
+#ifndef __LIB_PROXY_H_
+#define __LIB_PROXY_H_
+
+#include "conntrack.h"
+
+#if !(__ctx_is == __ctx_skb)
+#error "Proxy redirection is only supported from skb context"
+#endif
+
+/**
+ * ctx_redirect_to_proxy configures the ctx with the proxy mark and proxy port
+ * number to ensure that the stack redirects the packet into the proxy.
+ *
+ * It is called from both ingress and egress side of endpoint devices.
+ *
+ * In regular veth mode:
+ * * To apply egress policy, the egressing endpoint configures the mark,
+ *   which returns CTX_ACT_OK to pass the packet to the stack in the context
+ *   of the source device (stack ingress).
+ * * To apply ingress policy, the egressing endpoint or netdev program tail
+ *   calls into the policy program which configures the mark here, which
+ *   returns CTX_ACT_OK to pass the packet to the stack in the context of the
+ *   source device (netdev or egress endpoint device, stack ingress).
+ *
+ * In chaining mode with bridged endpoint devices:
+ * * To apply egress policy, the egressing endpoint configures the mark,
+ *   which is propagated via ctx_store_meta() in the caller. The redirect() call
+ *   here redirects the packet to the ingress TC filter configured on the bridge
+ *   master device.
+ * * To apply ingress policy, the stack transmits the packet into the bridge
+ *   master device which tail calls into the policy program for the ingress
+ *   endpoint, which configures mark and cb[] as described for the egress path.
+ *   The redirect() call here redirects the packet to the ingress TC filter
+ *   configured on the bridge master device.
+ * * In both cases for bridged endpoint devices, the bridge master device has
+ *   a BPF program configured upon ingress to transfer the cb[] to the mark
+ *   before passing the traffic up to the stack towards the proxy.
+ */
+static __always_inline int
+ctx_redirect_to_proxy(struct __ctx_buff *ctx, __be16 proxy_port)
+{
+	ctx->mark = MARK_MAGIC_TO_PROXY | proxy_port << 16;
+
+#ifdef HOST_REDIRECT_TO_INGRESS
+	cilium_dbg_capture(ctx, DBG_CAPTURE_PROXY_PRE, proxy_port);
+	/* In this case, the DBG_CAPTURE_PROXY_POST will be sent from the
+	 * programm attached to HOST_IFINDEX. */
+	return redirect(HOST_IFINDEX, BPF_F_INGRESS);
+#else
+	cilium_dbg_capture(ctx, DBG_CAPTURE_PROXY_POST, proxy_port);
+	ctx_change_type(ctx, PACKET_HOST); // Required for ingress packets from overlay
+	return CTX_ACT_OK;
+#endif
+}
+
+/**
+ * tc_index_skip_ingress_proxy - returns true if packet originates from ingress proxy
+ */
+static __always_inline bool tc_index_skip_ingress_proxy(struct __ctx_buff *ctx)
+{
+	volatile __u32 tc_index = ctx->tc_index;
+#ifdef DEBUG
+	if (tc_index & TC_INDEX_F_SKIP_INGRESS_PROXY)
+		cilium_dbg(ctx, DBG_SKIP_PROXY, tc_index, 0);
+#endif
+
+	return tc_index & TC_INDEX_F_SKIP_INGRESS_PROXY;
+}
+
+/**
+ * tc_index_skip_egress_proxy - returns true if packet originates from egress proxy
+ */
+static __always_inline bool tc_index_skip_egress_proxy(struct __ctx_buff *ctx)
+{
+	volatile __u32 tc_index = ctx->tc_index;
+#ifdef DEBUG
+	if (tc_index & TC_INDEX_F_SKIP_EGRESS_PROXY)
+		cilium_dbg(ctx, DBG_SKIP_PROXY, tc_index, 0);
+#endif
+
+	return tc_index & TC_INDEX_F_SKIP_EGRESS_PROXY;
+}
+#endif /* __LIB_PROXY_H_ */

--- a/bpf/lib/proxy.h
+++ b/bpf/lib/proxy.h
@@ -40,7 +40,8 @@
  *   before passing the traffic up to the stack towards the proxy.
  */
 static __always_inline int
-ctx_redirect_to_proxy(struct __ctx_buff *ctx, __be16 proxy_port)
+ctx_redirect_to_proxy(struct __ctx_buff *ctx, __be16 proxy_port,
+		      bool from_host __maybe_unused)
 {
 	ctx->mark = MARK_MAGIC_TO_PROXY | proxy_port << 16;
 


### PR DESCRIPTION
Suggested review commit-by-commit.

Intended functional changes:
* Improved output of trace messages in cases where there were no trace messages before, eg when delivering a packet to the stack from the bpf_hostdev_ingress program, or when unknown protos short-circuit packet handling logic leading to delivery to the stack.
* Avoid always printing the "to proxy port" messages. Use debug messages instead.
* Split bpf_netdev programs into clear "from_netdev" vs. "from_host" to apply at TC ingress / TC egress.
* Defer the functional preparation of the skb to deliver to proxy so it doesn't happen at the original BPF program (eg bpf_netdev attached at cilium_host) but is instead prepared in the bpf_hostdev_ingress program.

These changes are intermediate refactors to simplify the upcoming BPF tproxy PR, also to help bisect any potential regressions.

Related: #9921 