### PR TITLE
vagrant: bump net-next vagrant image

### DIFF
--- a/vagrant_box_defaults.rb
+++ b/vagrant_box_defaults.rb
@@ -3,8 +3,8 @@
 Vagrant.require_version ">= 2.2.0"
 
 $SERVER_BOX = "cilium/ubuntu-dev"
-$SERVER_VERSION= "169"
+$SERVER_VERSION= "170"
 $NETNEXT_SERVER_BOX= "cilium/ubuntu-next"
-$NETNEXT_SERVER_VERSION= "50"
+$NETNEXT_SERVER_VERSION= "52"
 @v419_SERVER_BOX= "cilium/ubuntu-4-19"
-@v419_SERVER_VERSION= "11"
+@v419_SERVER_VERSION= "12"


### PR DESCRIPTION
Each builds contains:

- Bump of cached Istio container images

net-next build also contains latest bpf tree on track for 5.7:

- Fixes for BPF TPROXY