### PR TITLE
Fix hubble metricsServer label in values.yaml

### DIFF
--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -411,7 +411,7 @@ global:
     flowBufferSize: ~
     # Specifies the address the metric server listens to (e.g. ":12345"). The metric server is
     # disabled if this value is empty.
-    metricServer: ~
+    metricsServer: ~
     # List of metrics to collect, for example:
     #
     #   metrics:


### PR DESCRIPTION
This patch fixes metricsServer label under hubble in values.yaml
file which had a mismatch on configmap.yaml on conditional checks
as shown below:
.Values.global.hubble.metricsServer

Signed-off-by: Swaminathan Vasudevan <svasudevan@suse.com>