### PR TITLE
all: fix remaining prealloc issues

### DIFF
--- a/bugtool/cmd/root.go
+++ b/bugtool/cmd/root.go
@@ -412,10 +412,9 @@ func getCiliumPods(namespace, label string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	var ciliumPods []string
 
 	lines := strings.Split(output, "\n")
-
+	ciliumPods := make([]string, 0, len(lines))
 	for _, l := range lines {
 		if !strings.HasPrefix(l, "cilium") {
 			continue

--- a/cilium/cmd/bpf_ipcache_get.go
+++ b/cilium/cmd/bpf_ipcache_get.go
@@ -102,7 +102,7 @@ func getLPMValue(ip net.IP, entries map[string][]string) (interface{}, bool) {
 		ip = ip.To4()
 	}
 
-	var lpmEntries []lpmEntry
+	lpmEntries := make([]lpmEntry, 0, len(entries))
 	for cidr, identity := range entries {
 		currIP, subnet, err := net.ParseCIDR(cidr)
 

--- a/daemon/cmd/fqdn_test.go
+++ b/daemon/cmd/fqdn_test.go
@@ -41,7 +41,7 @@ func makeIPs(count uint32) []net.IP {
 func (ds *DaemonSuite) BenchmarkFqdnCache(c *C) {
 	c.StopTimer()
 
-	var endpoints []*endpoint.Endpoint
+	endpoints := make([]*endpoint.Endpoint, 0, c.N)
 	for i := 0; i < c.N; i++ {
 		lookupTime := time.Now()
 		ep := &endpoint.Endpoint{} // only works because we only touch .DNSHistory

--- a/pkg/azure/api/api.go
+++ b/pkg/azure/api/api.go
@@ -214,8 +214,6 @@ func (c *Client) GetInstances(ctx context.Context) (*ipamTypes.InstanceMap, erro
 
 // describeVpcs lists all VPCs
 func (c *Client) describeVpcs(ctx context.Context) ([]network.VirtualNetwork, error) {
-	var vpcs []network.VirtualNetwork
-
 	c.limiter.Limit(ctx, "VirtualNetworks.List")
 
 	sinceStart := spanstat.Start()
@@ -225,6 +223,7 @@ func (c *Client) describeVpcs(ctx context.Context) ([]network.VirtualNetwork, er
 		return nil, err
 	}
 
+	var vpcs []network.VirtualNetwork
 	for result.NotDone() {
 		if err != nil {
 			return nil, err

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -263,7 +263,6 @@ func (e *Endpoint) addVisibilityRedirects(ingress bool, desiredRedirects map[str
 		policyEnabled           bool
 		finalizeList            revert.FinalizeList
 		revertStack             revert.RevertStack
-		updatedStats            []*models.ProxyStatistics
 		insertedDesiredMapState = make(map[policy.Key]struct{})
 	)
 
@@ -289,6 +288,7 @@ func (e *Endpoint) addVisibilityRedirects(ingress bool, desiredRedirects map[str
 		return nil, finalizeList.Finalize, revertStack.Revert
 	}
 
+	updatedStats := make([]*models.ProxyStatistics, 0, len(visPolicy))
 	for _, visMeta := range visPolicy {
 		// Create a redirect for every entry in the visibility policy.
 		if e.hasSidecarProxy && visMeta.Parser == policy.ParserTypeHTTP {

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -1028,7 +1028,7 @@ func (s *XDSServer) UpdateNetworkPolicy(ep logger.EndpointUpdater, policy *polic
 		ep.GetIPv6Address(),
 		ep.GetIPv4Address(),
 	}
-	var policies []*cilium.NetworkPolicy
+	policies := make([]*cilium.NetworkPolicy, 0, len(ips))
 	for _, ip := range ips {
 		if ip == "" {
 			continue

--- a/proxylib/cassandra/cassandraparser.go
+++ b/proxylib/cassandra/cassandraparser.go
@@ -106,11 +106,12 @@ func (rule *CassandraRule) Matches(data interface{}) bool {
 // CassandraRuleParser parses protobuf L7 rules to enforcement objects
 // May panic
 func CassandraRuleParser(rule *cilium.PortNetworkPolicyRule) []L7NetworkPolicyRule {
-	var rules []L7NetworkPolicyRule
 	l7Rules := rule.GetL7Rules()
 	if l7Rules == nil {
-		return rules
+		return nil
 	}
+
+	rules := make([]L7NetworkPolicyRule, 0, len(l7Rules.GetL7Rules()))
 	for _, l7Rule := range l7Rules.GetL7Rules() {
 		var cr CassandraRule
 		for k, v := range l7Rule.Rule {

--- a/proxylib/memcached/parser.go
+++ b/proxylib/memcached/parser.go
@@ -112,11 +112,12 @@ func (rule *Rule) matchOpcode(code byte) bool {
 // L7RuleParser parses protobuf L7 rules to and array of Rule
 // May panic
 func L7RuleParser(rule *cilium.PortNetworkPolicyRule) []proxylib.L7NetworkPolicyRule {
-	var rules []proxylib.L7NetworkPolicyRule
 	l7Rules := rule.GetL7Rules()
 	if l7Rules == nil {
-		return rules
+		return nil
 	}
+
+	rules := make([]proxylib.L7NetworkPolicyRule, 0, len(l7Rules.GetL7Rules()))
 	for _, l7Rule := range l7Rules.GetL7Rules() {
 		var br Rule
 		var commandFound = false

--- a/proxylib/proxylib/test_util.go
+++ b/proxylib/proxylib/test_util.go
@@ -30,7 +30,7 @@ func (ins *Instance) CheckInsertPolicyText(c *C, version string, policies []stri
 
 func (ins *Instance) InsertPolicyText(version string, policies []string, expectFail string) error {
 	typeUrl := "type.googleapis.com/cilium.NetworkPolicy"
-	var resources []*any.Any
+	resources := make([]*any.Any, 0, len(policies))
 
 	for _, policy := range policies {
 		pb := new(cilium.NetworkPolicy)

--- a/proxylib/r2d2/r2d2parser.go
+++ b/proxylib/r2d2/r2d2parser.go
@@ -88,10 +88,11 @@ func (rule *r2d2Rule) Matches(data interface{}) bool {
 // May panic
 func ruleParser(rule *cilium.PortNetworkPolicyRule) []proxylib.L7NetworkPolicyRule {
 	l7Rules := rule.GetL7Rules()
-	var rules []proxylib.L7NetworkPolicyRule
 	if l7Rules == nil {
-		return rules
+		return nil
 	}
+
+	rules := make([]proxylib.L7NetworkPolicyRule, 0, len(l7Rules.GetL7Rules()))
 	for _, l7Rule := range l7Rules.GetL7Rules() {
 		var rr r2d2Rule
 		for k, v := range l7Rule.Rule {

--- a/proxylib/testparsers/headerparser.go
+++ b/proxylib/testparsers/headerparser.go
@@ -68,11 +68,12 @@ func (rule *HeaderRule) Matches(data interface{}) bool {
 
 // L7HeaderRuleParser parses protobuf L7 rules to and array of HeaderRules
 func L7HeaderRuleParser(rule *cilium.PortNetworkPolicyRule) []L7NetworkPolicyRule {
-	var rules []L7NetworkPolicyRule
 	l7Rules := rule.GetL7Rules()
 	if l7Rules == nil {
-		return rules
+		return nil
 	}
+
+	rules := make([]L7NetworkPolicyRule, 0, len(l7Rules.GetL7Rules()))
 	for _, l7Rule := range l7Rules.GetL7Rules() {
 		var hr HeaderRule
 		for k, v := range l7Rule.Rule {

--- a/test/runtime/fqdn.go
+++ b/test/runtime/fqdn.go
@@ -1100,7 +1100,7 @@ INITSYSTEM=SYSTEMD`
 func getMapValues(m map[string]string) []interface{} {
 
 	values := make([]interface{}, len(m))
-	var keys []string
+	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)
 	}


### PR DESCRIPTION
As discussed previously, this check shouldn't be run by default as part
of the `precheck` Makfile target due to the possibility of false
positives (see #10806 for the previous approach). Thus, we'll run
`prealloc` manually once at the end of a release cycle and manually
review its results and thix them where appropriate.