### PR TITLE
Remove function queues from k8s watchers

### DIFF
--- a/operator/ccnp_event.go
+++ b/operator/ccnp_event.go
@@ -80,7 +80,7 @@ func enableCCNPWatcher() error {
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				metrics.EventTSK8s.SetToCurrentTime()
-				if cnp := k8s.CopyObjToV2CNP(obj); cnp != nil {
+				if cnp := k8s.ObjToSlimCNP(obj); cnp != nil {
 					groups.AddDerivativeCNPIfNeeded(cnp.CiliumNetworkPolicy)
 					if kvstoreEnabled() {
 						ccnpStatusMgr.StartStatusHandler(cnp)
@@ -89,8 +89,8 @@ func enableCCNPWatcher() error {
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
 				metrics.EventTSK8s.SetToCurrentTime()
-				if oldCNP := k8s.CopyObjToV2CNP(oldObj); oldCNP != nil {
-					if newCNP := k8s.CopyObjToV2CNP(newObj); newCNP != nil {
+				if oldCNP := k8s.ObjToSlimCNP(oldObj); oldCNP != nil {
+					if newCNP := k8s.ObjToSlimCNP(newObj); newCNP != nil {
 						if k8s.EqualV2CNP(oldCNP, newCNP) {
 							return
 						}
@@ -100,7 +100,7 @@ func enableCCNPWatcher() error {
 			},
 			DeleteFunc: func(obj interface{}) {
 				metrics.EventTSK8s.SetToCurrentTime()
-				cnp := k8s.CopyObjToV2CNP(obj)
+				cnp := k8s.ObjToSlimCNP(obj)
 				if cnp == nil {
 					deletedObj, ok := obj.(cache.DeletedFinalStateUnknown)
 					if !ok {
@@ -109,7 +109,7 @@ func enableCCNPWatcher() error {
 					// Delete was not observed by the watcher but is
 					// removed from kube-apiserver. This is the last
 					// known state and the object no longer exists.
-					cnp = k8s.CopyObjToV2CNP(deletedObj.Obj)
+					cnp = k8s.ObjToSlimCNP(deletedObj.Obj)
 					if cnp == nil {
 						return
 					}

--- a/operator/cnp_event.go
+++ b/operator/cnp_event.go
@@ -88,7 +88,7 @@ func enableCNPWatcher() error {
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				metrics.EventTSK8s.SetToCurrentTime()
-				if cnp := k8s.CopyObjToV2CNP(obj); cnp != nil {
+				if cnp := k8s.ObjToSlimCNP(obj); cnp != nil {
 					groups.AddDerivativeCNPIfNeeded(cnp.CiliumNetworkPolicy)
 					if kvstoreEnabled() {
 						cnpStatusMgr.StartStatusHandler(cnp)
@@ -97,8 +97,8 @@ func enableCNPWatcher() error {
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
 				metrics.EventTSK8s.SetToCurrentTime()
-				if oldCNP := k8s.CopyObjToV2CNP(oldObj); oldCNP != nil {
-					if newCNP := k8s.CopyObjToV2CNP(newObj); newCNP != nil {
+				if oldCNP := k8s.ObjToSlimCNP(oldObj); oldCNP != nil {
+					if newCNP := k8s.ObjToSlimCNP(newObj); newCNP != nil {
 						if k8s.EqualV2CNP(oldCNP, newCNP) {
 							return
 						}
@@ -108,7 +108,7 @@ func enableCNPWatcher() error {
 			},
 			DeleteFunc: func(obj interface{}) {
 				metrics.EventTSK8s.SetToCurrentTime()
-				cnp := k8s.CopyObjToV2CNP(obj)
+				cnp := k8s.ObjToSlimCNP(obj)
 				if cnp == nil {
 					deletedObj, ok := obj.(cache.DeletedFinalStateUnknown)
 					if !ok {
@@ -117,7 +117,7 @@ func enableCNPWatcher() error {
 					// Delete was not observed by the watcher but is
 					// removed from kube-apiserver. This is the last
 					// known state and the object no longer exists.
-					cnp = k8s.CopyObjToV2CNP(deletedObj.Obj)
+					cnp = k8s.ObjToSlimCNP(deletedObj.Obj)
 					if cnp == nil {
 						return
 					}

--- a/pkg/k8s/factory_functions.go
+++ b/pkg/k8s/factory_functions.go
@@ -50,24 +50,24 @@ func CopyObjToV1Services(obj interface{}) *types.Service {
 	return svc.DeepCopy()
 }
 
-func CopyObjToV1Endpoints(obj interface{}) *types.Endpoints {
+func ObjToV1Endpoints(obj interface{}) *types.Endpoints {
 	ep, ok := obj.(*types.Endpoints)
 	if !ok {
 		log.WithField(logfields.Object, logfields.Repr(obj)).
 			Warn("Ignoring invalid k8s v1 Endpoints")
 		return nil
 	}
-	return ep.DeepCopy()
+	return ep
 }
 
-func CopyObjToV1EndpointSlice(obj interface{}) *types.EndpointSlice {
+func ObjToV1EndpointSlice(obj interface{}) *types.EndpointSlice {
 	ep, ok := obj.(*types.EndpointSlice)
 	if !ok {
 		log.WithField(logfields.Object, logfields.Repr(obj)).
 			Warn("Ignoring invalid k8s v1 EndpointSlice")
 		return nil
 	}
-	return ep.DeepCopy()
+	return ep
 }
 
 func ObjToSlimCNP(obj interface{}) *types.SlimCNP {

--- a/pkg/k8s/factory_functions.go
+++ b/pkg/k8s/factory_functions.go
@@ -30,14 +30,14 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-func CopyObjToV1NetworkPolicy(obj interface{}) *types.NetworkPolicy {
+func ObjToV1NetworkPolicy(obj interface{}) *types.NetworkPolicy {
 	k8sNP, ok := obj.(*types.NetworkPolicy)
 	if !ok {
 		log.WithField(logfields.Object, logfields.Repr(obj)).
 			Warn("Ignoring invalid k8s v1 NetworkPolicy")
 		return nil
 	}
-	return k8sNP.DeepCopy()
+	return k8sNP
 }
 
 func ObjToV1Services(obj interface{}) *types.Service {

--- a/pkg/k8s/factory_functions.go
+++ b/pkg/k8s/factory_functions.go
@@ -738,16 +738,16 @@ func ConvertToCiliumNode(obj interface{}) interface{} {
 	}
 }
 
-// CopyObjToCiliumNode attempts to cast object to a CiliumNode object and
+// ObjToCiliumNode attempts to cast object to a CiliumNode object and
 // returns a deep copy if the castin succeeds. Otherwise, nil is returned.
-func CopyObjToCiliumNode(obj interface{}) *cilium_v2.CiliumNode {
+func ObjToCiliumNode(obj interface{}) *cilium_v2.CiliumNode {
 	cn, ok := obj.(*cilium_v2.CiliumNode)
 	if !ok {
 		log.WithField(logfields.Object, logfields.Repr(obj)).
 			Warn("Ignoring invalid CiliumNode")
 		return nil
 	}
-	return cn.DeepCopy()
+	return cn
 }
 
 // ConvertToCiliumEndpoint converts a *cilium_v2.CiliumEndpoint into a

--- a/pkg/k8s/factory_functions.go
+++ b/pkg/k8s/factory_functions.go
@@ -80,14 +80,14 @@ func ObjToSlimCNP(obj interface{}) *types.SlimCNP {
 	return cnp
 }
 
-func CopyObjToV1Pod(obj interface{}) *types.Pod {
+func ObjTov1Pod(obj interface{}) *types.Pod {
 	pod, ok := obj.(*types.Pod)
 	if !ok {
 		log.WithField(logfields.Object, logfields.Repr(obj)).
 			Warn("Ignoring invalid k8s v1 Pod")
 		return nil
 	}
-	return pod.DeepCopy()
+	return pod
 }
 
 func CopyObjToV1Node(obj interface{}) *types.Node {

--- a/pkg/k8s/factory_functions.go
+++ b/pkg/k8s/factory_functions.go
@@ -90,14 +90,14 @@ func ObjTov1Pod(obj interface{}) *types.Pod {
 	return pod
 }
 
-func CopyObjToV1Node(obj interface{}) *types.Node {
+func ObjToV1Node(obj interface{}) *types.Node {
 	node, ok := obj.(*types.Node)
 	if !ok {
 		log.WithField(logfields.Object, logfields.Repr(obj)).
 			Warn("Ignoring invalid k8s v1 Node")
 		return nil
 	}
-	return node.DeepCopy()
+	return node
 }
 
 func ObjToV1Namespace(obj interface{}) *types.Namespace {

--- a/pkg/k8s/factory_functions.go
+++ b/pkg/k8s/factory_functions.go
@@ -789,14 +789,14 @@ func ConvertToCiliumEndpoint(obj interface{}) interface{} {
 	}
 }
 
-// CopyObjToCiliumEndpoint attempts to cast object to a CiliumEndpoint object
+// ObjToCiliumEndpoint attempts to cast object to a CiliumEndpoint object
 // and returns a deep copy if the castin succeeds. Otherwise, nil is returned.
-func CopyObjToCiliumEndpoint(obj interface{}) *types.CiliumEndpoint {
+func ObjToCiliumEndpoint(obj interface{}) *types.CiliumEndpoint {
 	ce, ok := obj.(*types.CiliumEndpoint)
 	if !ok {
 		log.WithField(logfields.Object, logfields.Repr(obj)).
 			Warn("Ignoring invalid CiliumEndpoint")
 		return nil
 	}
-	return ce.DeepCopy()
+	return ce
 }

--- a/pkg/k8s/factory_functions.go
+++ b/pkg/k8s/factory_functions.go
@@ -40,14 +40,14 @@ func CopyObjToV1NetworkPolicy(obj interface{}) *types.NetworkPolicy {
 	return k8sNP.DeepCopy()
 }
 
-func CopyObjToV1Services(obj interface{}) *types.Service {
+func ObjToV1Services(obj interface{}) *types.Service {
 	svc, ok := obj.(*types.Service)
 	if !ok {
 		log.WithField(logfields.Object, logfields.Repr(obj)).
 			Warn("Ignoring invalid k8s v1 Service")
 		return nil
 	}
-	return svc.DeepCopy()
+	return svc
 }
 
 func ObjToV1Endpoints(obj interface{}) *types.Endpoints {

--- a/pkg/k8s/factory_functions.go
+++ b/pkg/k8s/factory_functions.go
@@ -70,14 +70,14 @@ func CopyObjToV1EndpointSlice(obj interface{}) *types.EndpointSlice {
 	return ep.DeepCopy()
 }
 
-func CopyObjToV2CNP(obj interface{}) *types.SlimCNP {
+func ObjToSlimCNP(obj interface{}) *types.SlimCNP {
 	cnp, ok := obj.(*types.SlimCNP)
 	if !ok {
 		log.WithField(logfields.Object, logfields.Repr(obj)).
 			Warn("Ignoring invalid k8s v2 CiliumNetworkPolicy")
 		return nil
 	}
-	return cnp.DeepCopy()
+	return cnp
 }
 
 func CopyObjToV1Pod(obj interface{}) *types.Pod {

--- a/pkg/k8s/factory_functions.go
+++ b/pkg/k8s/factory_functions.go
@@ -100,14 +100,14 @@ func CopyObjToV1Node(obj interface{}) *types.Node {
 	return node.DeepCopy()
 }
 
-func CopyObjToV1Namespace(obj interface{}) *types.Namespace {
+func ObjToV1Namespace(obj interface{}) *types.Namespace {
 	ns, ok := obj.(*types.Namespace)
 	if !ok {
 		log.WithField(logfields.Object, logfields.Repr(obj)).
 			Warn("Ignoring invalid k8s v1 Namespace")
 		return nil
 	}
-	return ns.DeepCopy()
+	return ns
 }
 
 func EqualV1NetworkPolicy(np1, np2 *types.NetworkPolicy) bool {

--- a/pkg/k8s/informer/benchmarks/informer_benchmarks_test.go
+++ b/pkg/k8s/informer/benchmarks/informer_benchmarks_test.go
@@ -24,10 +24,10 @@ import (
 	"testing"
 
 	"github.com/cilium/cilium/pkg/annotation"
+	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/k8s/informer"
 
-	"github.com/cilium/cilium/pkg/defaults"
 	. "gopkg.in/check.v1"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -458,8 +458,8 @@ func (k *K8sIntegrationSuite) benchmarkInformer(nCycles int, newInformer bool, c
 			cache.ResourceEventHandlerFuncs{
 				AddFunc: func(obj interface{}) {},
 				UpdateFunc: func(oldObj, newObj interface{}) {
-					if oldK8sNP := k8s.CopyObjToV1Node(oldObj); oldK8sNP != nil {
-						if newK8sNP := k8s.CopyObjToV1Node(newObj); newK8sNP != nil {
+					if oldK8sNP := k8s.ObjToV1Node(oldObj); oldK8sNP != nil {
+						if newK8sNP := k8s.ObjToV1Node(newObj); newK8sNP != nil {
 							if k8s.EqualV1Node(oldK8sNP, newK8sNP) {
 								return
 							}
@@ -467,7 +467,7 @@ func (k *K8sIntegrationSuite) benchmarkInformer(nCycles int, newInformer bool, c
 					}
 				},
 				DeleteFunc: func(obj interface{}) {
-					k8sNP := k8s.CopyObjToV1Node(obj)
+					k8sNP := k8s.ObjToV1Node(obj)
 					if k8sNP == nil {
 						deletedObj, ok := obj.(cache.DeletedFinalStateUnknown)
 						if !ok {
@@ -476,7 +476,7 @@ func (k *K8sIntegrationSuite) benchmarkInformer(nCycles int, newInformer bool, c
 						// Delete was not observed by the watcher but is
 						// removed from kube-apiserver. This is the last
 						// known state and the object no longer exists.
-						k8sNP = k8s.CopyObjToV1Node(deletedObj.Obj)
+						k8sNP = k8s.ObjToV1Node(deletedObj.Obj)
 						if k8sNP == nil {
 							return
 						}

--- a/pkg/k8s/watchers/cilium_node.go
+++ b/pkg/k8s/watchers/cilium_node.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 Authors of Cilium
+// Copyright 2016-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,14 +24,13 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/node"
-	"github.com/cilium/cilium/pkg/serializer"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/tools/cache"
 )
 
-func (k *K8sWatcher) ciliumNodeInit(ciliumNPClient *k8s.K8sCiliumClient, serNodes *serializer.FunctionQueue, asyncControllers *sync.WaitGroup) {
+func (k *K8sWatcher) ciliumNodeInit(ciliumNPClient *k8s.K8sCiliumClient, asyncControllers *sync.WaitGroup) {
 
 	// CiliumNode objects are used for node discovery until the key-value
 	// store is connected
@@ -53,13 +52,8 @@ func (k *K8sWatcher) ciliumNodeInit(ciliumNPClient *k8s.K8sCiliumClient, serNode
 						if n.IsLocal() {
 							return
 						}
-						swgNodes.Add()
-						serNodes.Enqueue(func() error {
-							defer swgNodes.Done()
-							k.nodeDiscoverManager.NodeUpdated(n)
-							k.K8sEventProcessed(metricCiliumNode, metricCreate, true)
-							return nil
-						}, serializer.NoRetry)
+						k.nodeDiscoverManager.NodeUpdated(n)
+						k.K8sEventProcessed(metricCiliumNode, metricCreate, true)
 					}
 				},
 				UpdateFunc: func(oldObj, newObj interface{}) {
@@ -67,23 +61,19 @@ func (k *K8sWatcher) ciliumNodeInit(ciliumNPClient *k8s.K8sCiliumClient, serNode
 					defer func() { k.K8sEventReceived(metricCiliumNode, metricUpdate, valid, equal) }()
 					if ciliumNode, ok := newObj.(*cilium_v2.CiliumNode); ok {
 						valid = true
+						// TODO add DeepEqual here
 						n := node.ParseCiliumNode(ciliumNode)
 						if n.IsLocal() {
 							return
 						}
-						swgNodes.Add()
-						serNodes.Enqueue(func() error {
-							defer swgNodes.Done()
-							k.nodeDiscoverManager.NodeUpdated(n)
-							k.K8sEventProcessed(metricCiliumNode, metricUpdate, true)
-							return nil
-						}, serializer.NoRetry)
+						k.nodeDiscoverManager.NodeUpdated(n)
+						k.K8sEventProcessed(metricCiliumNode, metricUpdate, true)
 					}
 				},
 				DeleteFunc: func(obj interface{}) {
 					var valid, equal bool
 					defer func() { k.K8sEventReceived(metricCiliumNode, metricDelete, valid, equal) }()
-					ciliumNode := k8s.CopyObjToCiliumNode(obj)
+					ciliumNode := k8s.ObjToCiliumNode(obj)
 					if ciliumNode == nil {
 						deletedObj, ok := obj.(cache.DeletedFinalStateUnknown)
 						if !ok {
@@ -92,19 +82,14 @@ func (k *K8sWatcher) ciliumNodeInit(ciliumNPClient *k8s.K8sCiliumClient, serNode
 						// Delete was not observed by the watcher but is
 						// removed from kube-apiserver. This is the last
 						// known state and the object no longer exists.
-						ciliumNode = k8s.CopyObjToCiliumNode(deletedObj.Obj)
+						ciliumNode = k8s.ObjToCiliumNode(deletedObj.Obj)
 						if ciliumNode == nil {
 							return
 						}
 					}
 					valid = true
 					n := node.ParseCiliumNode(ciliumNode)
-					swgNodes.Add()
-					serNodes.Enqueue(func() error {
-						defer swgNodes.Done()
-						k.nodeDiscoverManager.NodeDeleted(n)
-						return nil
-					}, serializer.NoRetry)
+					k.nodeDiscoverManager.NodeDeleted(n)
 				},
 			},
 			k8s.ConvertToCiliumNode,

--- a/pkg/k8s/watchers/namespace.go
+++ b/pkg/k8s/watchers/namespace.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 Authors of Cilium
+// Copyright 2016-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,17 +18,14 @@ import (
 	"errors"
 	"sync"
 
-	"github.com/cilium/cilium/pkg/comparator"
 	"github.com/cilium/cilium/pkg/k8s"
 	ciliumio "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/k8s/informer"
 	"github.com/cilium/cilium/pkg/k8s/types"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/labelsfilter"
-	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/policy"
-	"github.com/cilium/cilium/pkg/serializer"
 
 	v1 "k8s.io/api/core/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
@@ -40,9 +37,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-func (k *K8sWatcher) namespacesInit(k8sClient kubernetes.Interface, serNamespaces *serializer.FunctionQueue, asyncControllers *sync.WaitGroup) {
-
-	swgNamespaces := lock.NewStoppableWaitGroup()
+func (k *K8sWatcher) namespacesInit(k8sClient kubernetes.Interface, asyncControllers *sync.WaitGroup) {
 	namespaceStore, namespaceController := informer.NewInformer(
 		cache.NewListWatchFromClient(k8sClient.CoreV1().RESTClient(),
 			"namespaces", v1.NamespaceAll, fields.Everything()),
@@ -56,21 +51,16 @@ func (k *K8sWatcher) namespacesInit(k8sClient kubernetes.Interface, serNamespace
 			UpdateFunc: func(oldObj, newObj interface{}) {
 				var valid, equal bool
 				defer func() { k.K8sEventReceived(metricNS, metricUpdate, valid, equal) }()
-				if oldNS := k8s.CopyObjToV1Namespace(oldObj); oldNS != nil {
-					valid = true
-					if newNS := k8s.CopyObjToV1Namespace(newObj); newNS != nil {
+				if oldNS := k8s.ObjToV1Namespace(oldObj); oldNS != nil {
+					if newNS := k8s.ObjToV1Namespace(newObj); newNS != nil {
+						valid = true
 						if k8s.EqualV1Namespace(oldNS, newNS) {
 							equal = true
 							return
 						}
 
-						swgNamespaces.Add()
-						serNamespaces.Enqueue(func() error {
-							defer swgNamespaces.Done()
-							err := k.updateK8sV1Namespace(oldNS, newNS)
-							k.K8sEventProcessed(metricNS, metricUpdate, err == nil)
-							return nil
-						}, serializer.NoRetry)
+						err := k.updateK8sV1Namespace(oldNS, newNS)
+						k.K8sEventProcessed(metricNS, metricUpdate, err == nil)
 					}
 				}
 			},
@@ -79,22 +69,13 @@ func (k *K8sWatcher) namespacesInit(k8sClient kubernetes.Interface, serNamespace
 	)
 
 	k.namespaceStore = namespaceStore
-	k.blockWaitGroupToSyncResources(wait.NeverStop, swgNamespaces, namespaceController, k8sAPIGroupNamespaceV1Core)
+	k.blockWaitGroupToSyncResources(wait.NeverStop, nil, namespaceController, k8sAPIGroupNamespaceV1Core)
 	k.k8sAPIGroups.addAPI(k8sAPIGroupNamespaceV1Core)
 	asyncControllers.Done()
 	namespaceController.Run(wait.NeverStop)
 }
 
 func (k *K8sWatcher) updateK8sV1Namespace(oldNS, newNS *types.Namespace) error {
-	if oldNS == nil || newNS == nil {
-		return nil
-	}
-
-	// We only care about label updates
-	if comparator.MapStringEquals(oldNS.GetLabels(), newNS.GetLabels()) {
-		return nil
-	}
-
 	oldNSLabels := map[string]string{}
 	newNSLabels := map[string]string{}
 

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -428,9 +428,8 @@ func (k *K8sWatcher) EnableK8sWatcher(queueSize uint) error {
 	k.networkPoliciesInit(k8s.Client(), serKNPs, swgKNP)
 
 	// kubernetes services
-	serSvcs := serializer.NewFunctionQueue(queueSize)
 	swgSvcs := lock.NewStoppableWaitGroup()
-	k.servicesInit(k8s.Client(), serSvcs, swgSvcs)
+	k.servicesInit(k8s.Client(), swgSvcs)
 
 	// kubernetes endpoints
 	swgEps := lock.NewStoppableWaitGroup()

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -423,9 +423,8 @@ func (k *K8sWatcher) EnableK8sWatcher(queueSize uint) error {
 	asyncControllers := &sync.WaitGroup{}
 
 	// kubernetes network policies
-	serKNPs := serializer.NewFunctionQueue(queueSize)
 	swgKNP := lock.NewStoppableWaitGroup()
-	k.networkPoliciesInit(k8s.Client(), serKNPs, swgKNP)
+	k.networkPoliciesInit(k8s.Client(), swgKNP)
 
 	// kubernetes services
 	swgSvcs := lock.NewStoppableWaitGroup()

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -433,20 +433,19 @@ func (k *K8sWatcher) EnableK8sWatcher(queueSize uint) error {
 	k.servicesInit(k8s.Client(), serSvcs, swgSvcs)
 
 	// kubernetes endpoints
-	serEps := serializer.NewFunctionQueue(queueSize)
 	swgEps := lock.NewStoppableWaitGroup()
 
 	// We only enable either "Endpoints" or "EndpointSlice"
 	switch {
 	case k8s.SupportsEndpointSlice():
-		connected := k.endpointSlicesInit(k8s.Client(), serEps, swgEps)
+		connected := k.endpointSlicesInit(k8s.Client(), swgEps)
 		// the cluster has endpoint slices so we should not check for v1.Endpoints
 		if connected {
 			break
 		}
 		fallthrough
 	default:
-		k.endpointsInit(k8s.Client(), serEps, swgEps)
+		k.endpointsInit(k8s.Client(), swgEps)
 	}
 
 	// cilium network policies

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -462,8 +462,7 @@ func (k *K8sWatcher) EnableK8sWatcher(queueSize uint) error {
 
 	// cilium endpoints
 	asyncControllers.Add(1)
-	serCiliumEndpoints := serializer.NewFunctionQueue(queueSize)
-	go k.ciliumEndpointsInit(ciliumNPClient, serCiliumEndpoints, asyncControllers)
+	go k.ciliumEndpointsInit(ciliumNPClient, asyncControllers)
 
 	// kubernetes pods
 	asyncControllers.Add(1)

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -468,8 +468,7 @@ func (k *K8sWatcher) EnableK8sWatcher(queueSize uint) error {
 
 	// kubernetes namespaces
 	asyncControllers.Add(1)
-	serNamespaces := serializer.NewFunctionQueue(queueSize)
-	go k.namespacesInit(k8s.Client(), serNamespaces, asyncControllers)
+	go k.namespacesInit(k8s.Client(), asyncControllers)
 
 	asyncControllers.Wait()
 	close(k.controllersStarted)

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -39,7 +39,6 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
-	"github.com/cilium/cilium/pkg/serializer"
 
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/runtime"
@@ -462,8 +461,7 @@ func (k *K8sWatcher) EnableK8sWatcher(queueSize uint) error {
 
 	// kubernetes pods
 	asyncControllers.Add(1)
-	serPods := serializer.NewFunctionQueue(queueSize)
-	go k.podsInit(k8s.Client(), serPods, asyncControllers)
+	go k.podsInit(k8s.Client(), asyncControllers)
 
 	// kubernetes namespaces
 	asyncControllers.Add(1)

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -457,8 +457,7 @@ func (k *K8sWatcher) EnableK8sWatcher(queueSize uint) error {
 
 	// cilium nodes
 	asyncControllers.Add(1)
-	serNodes := serializer.NewFunctionQueue(queueSize)
-	go k.ciliumNodeInit(ciliumNPClient, serNodes, asyncControllers)
+	go k.ciliumNodeInit(ciliumNPClient, asyncControllers)
 
 	// cilium endpoints
 	asyncControllers.Add(1)

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -308,8 +308,10 @@ func (k *K8sWatcher) blockWaitGroupToSyncResources(
 			k.k8sResourceSyncedStopWait[resourceName] = true
 			k.k8sResourceSyncedMu.Unlock()
 		}
-		swg.Stop()
-		swg.Wait()
+		if swg != nil {
+			swg.Stop()
+			swg.Wait()
+		}
 		close(ch)
 	}()
 }
@@ -448,14 +450,10 @@ func (k *K8sWatcher) EnableK8sWatcher(queueSize uint) error {
 	}
 
 	// cilium network policies
-	serCNPs := serializer.NewFunctionQueue(queueSize)
-	swgCNPs := lock.NewStoppableWaitGroup()
-	k.ciliumNetworkPoliciesInit(ciliumNPClient, serCNPs, swgCNPs)
+	k.ciliumNetworkPoliciesInit(ciliumNPClient)
 
 	// cilium clusterwide network policy
-	serCCNPs := serializer.NewFunctionQueue(queueSize)
-	swgCCNPs := lock.NewStoppableWaitGroup()
-	k.ciliumClusterwideNetworkPoliciesInit(ciliumNPClient, serCCNPs, swgCCNPs)
+	k.ciliumClusterwideNetworkPoliciesInit(ciliumNPClient)
 
 	// cilium nodes
 	asyncControllers.Add(1)


### PR DESCRIPTION
k8s watcher library already provides a queue for each watcher so we
don't need our function queue implementation on top of it.

This means we will process all events upon initialization which can slow
down the initialization of the Cilium API. Some benchmarks were 
performed with the simulation of 50k pods and 2k nodes to see and Cilium took around 46 
seconds to initialize. Of course this highly depends in the network and
the compute power available to Cilium. This benchmarks were executed on
a VM with 2 CPUs and a kube-apiserver available in the same machine 
where the VM was executed.

**First 10 seconds of a pprof trace capture for a cilium-agent initialization with 10k simulated pods and 1k simulated nodes simulated. (top is master, bottom is this branch)** (the number of GC calls were smaller and took less amount of time):

<img width="837" alt="1" src="https://user-images.githubusercontent.com/5714066/78893669-00669180-7a6c-11ea-98da-e50617e9ea2b.png">


**mem stats of a cilium-agent with 50k simulated pods and 2k simulated nodes. (top is master, bottom is this branch)** (the `total-alloc` decreased from `3GB` to `2.62GB`, sys decreased from `1.52GB` to `1.25GB`:
```
alloc: 706.19MB (740493104 bytes)
total-alloc: 3.03GB (3255584776 bytes)
sys: 1.52GB (1629220187 bytes)
lookups: 0
mallocs: 16221287
frees: 10367753
heap-alloc: 706.19MB (740493104 bytes)
heap-sys: 1.43GB (1535016960 bytes)
heap-idle: 638.75MB (669777920 bytes)
heap-in-use: 825.16MB (865239040 bytes)
heap-released: 39.98MB (41918464 bytes)
heap-objects: 5853534
stack-in-use: 8.09MB (8486912 bytes)
stack-sys: 8.09MB (8486912 bytes)
stack-mspan-inuse: 11.61MB (12173632 bytes)
stack-mspan-sys: 19.52MB (20463616 bytes)
stack-mcache-inuse: 3.39KB (3472 bytes)
stack-mcache-sys: 16.00KB (16384 bytes)
other-sys: 3.04MB (3185883 bytes)
gc-sys: 57.56MB (60357048 bytes)
next-gc: when heap-alloc >= 1.31GB (1402045504 bytes)
last-gc: 2020-04-09 11:38:22.480860164 +0000 UTC
gc-pause-total: 8.854325ms
gc-pause: 53084
num-gc: 26
enable-gc: true
debug-gc: false
```
```
alloc: 929.25MB (974393088 bytes)
total-alloc: 2.62GB (2809877984 bytes)
sys: 1.25GB (1341604411 bytes)
lookups: 0
mallocs: 14733085
frees: 5617388
heap-alloc: 929.25MB (974393088 bytes)
heap-sys: 1.18GB (1265664000 bytes)
heap-idle: 265.45MB (278347776 bytes)
heap-in-use: 941.58MB (987316224 bytes)
heap-released: 52.50MB (55050240 bytes)
heap-objects: 9115697
stack-in-use: 8.97MB (9404416 bytes)
stack-sys: 8.97MB (9404416 bytes)
stack-mspan-inuse: 12.73MB (13349760 bytes)
stack-mspan-sys: 12.78MB (13402112 bytes)
stack-mcache-inuse: 3.39KB (3472 bytes)
stack-mcache-sys: 16.00KB (16384 bytes)
other-sys: 2.15MB (2255667 bytes)
gc-sys: 46.90MB (49174936 bytes)
next-gc: when heap-alloc >= 1.38GB (1481919792 bytes)
last-gc: 2020-04-09 11:40:58.910320185 +0000 UTC
gc-pause-total: 8.815899ms
gc-pause: 771468
num-gc: 26
enable-gc: true
debug-gc: false
```

Those benchmarks were primarily testing the increasing number of Pods and the removal of function queues for all other watchers were based on the assumption the memory optimization will be similar to the one seen with the removal of the Pod's watcher function queues.