### PR TITLE
test: Fix -cilium.holdEnvironment on badLogMessages

### DIFF
--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -443,7 +443,7 @@ func failIfContainsBadLogMsg(logs string, blacklist map[string][]string) {
 				}
 				if !ok {
 					fmt.Fprintf(CheckLogs, "⚠️  Found a %q in logs\n", fail)
-					ginkgoext.Fail(fmt.Sprintf("Found a %q in Cilium Logs", fail))
+					Fail(fmt.Sprintf("Found a %q in Cilium Logs", fail))
 				}
 			}
 		}


### PR DESCRIPTION
The `-cilium.holdEnvironment=true` option is ineffective when the test fails because of the `badLogMessages` check. This commit fixes it by using our own `Fail()` wrapper.