### PR TITLE
helm: add option to enable automatic etcd name resolution

### DIFF
--- a/Documentation/cmdref/kvstore.rst
+++ b/Documentation/cmdref/kvstore.rst
@@ -55,6 +55,10 @@ etcd endpoints:
 +---------------------+---------+---------------------------------------------------+
 | etcd.address        | Address | Address of etcd endpoint                          |
 +---------------------+---------+---------------------------------------------------+
+|                     |         | When set to true, Cilium will resolve the domain  |
+| etcd.operator       | Boolean | name of the etcd server from the associated k8s   |
+|                     |         | service deployed.                                 |
++---------------------+---------+---------------------------------------------------+
 | etcd.config         | Path    | Path to an etcd configuration file.               |
 +---------------------+---------+---------------------------------------------------+
 

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -9,7 +9,11 @@ data:
   # storage. This can either be provided with an external kvstore or with the
   # help of cilium-etcd-operator which operates an etcd cluster automatically.
   kvstore: etcd
+{{- if .Values.global.etcd.k8sService }}
+  kvstore-opt: '{"etcd.config": "/var/lib/etcd-config/etcd.config", "etcd.operator": "true"}'
+{{- else }}
   kvstore-opt: '{"etcd.config": "/var/lib/etcd-config/etcd.config"}'
+{{- end }}
 
   # This etcd-config contains the etcd endpoints of your cluster. If you use
   # TLS please make sure you follow the tutorial in https://cilium.link/etcd-config

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -43,6 +43,11 @@ global:
     # enabled enables use of etcd
     enabled: false
 
+    # If etcd is behind a k8s service set this option to true so that Cilium
+    # does the service translation automatically without requiring a DNS to be
+    # running. Requires disable-k8s-services=false
+    k8sService: false
+
     # managed turns on managed etcd mode based on the cilium-etcd-operator
     managed: false
 

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -152,6 +152,7 @@ data:
   enable-external-ips: "false"
   enable-node-port: "false"
   node-port-mode: "hybrid"
+  node-port-acceleration: "none"
   enable-auto-protect-node-port-range: "true"
   # Chaining mode is set to portmap, enable health checking
   enable-endpoint-health-checking: "true"
@@ -161,6 +162,10 @@ data:
   synchronize-k8s-nodes: "true"
   policy-audit-mode: "false"
   operator-api-serve-addr: '127.0.0.1:9234'
+
+
+  # A space separated list of iptables chains to disable when installing feeder rules.
+  disable-iptables-feeder-rules: ""
 ---
 # Source: cilium/charts/agent/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
This feature is useful if users want to deploy an k8s service
that translates to an etcd cluster. As already implemented in Cilium, it
will perform the service translation internally without having to reach
a DNS to perform this translation. This will work by relying on the
watching mechanism that we have for k8s for which it is required that
`disabled-k8s-services` is set to `false`

Signed-off-by: André Martins <andre@cilium.io>