### PR TITLE
cli: Introduce hubble/cilium hybrid client binary

### DIFF
--- a/cilium/.gitignore
+++ b/cilium/.gitignore
@@ -1,2 +1,3 @@
 cilium
+hubble
 bash_autocomplete

--- a/cilium/Makefile
+++ b/cilium/Makefile
@@ -2,22 +2,29 @@ include ../Makefile.quiet
 include ../Makefile.defs
 
 TARGET=cilium
+LINKS=hubble
 SOURCES := $(shell find ../api ../daemon ../common ../pkg cmd . \( -name '*.go' ! -name '*_test.go' \))
 
 $(TARGET): $(SOURCES)
 	@$(ECHO_GO)
 	$(QUIET)$(GO) build $(GOBUILD) -o $(TARGET)
 
-all: $(TARGET)
+all: $(TARGET) links
+
+links:
+	$(foreach link,$(LINKS), ln -f -s $(TARGET) $(link) || cp $(TARGET) $(link);)
 
 clean:
 	@$(ECHO_CLEAN) $(notdir $(shell pwd))
 	-$(QUIET)rm -f $(TARGET)
 	$(QUIET)$(GO) clean $(GOCLEAN)
+	$(foreach link,$(LINKS), $(QUIET)rm -f $(link);)
 
 install:
 	$(QUIET)$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)
 	$(QUIET)$(INSTALL) -m 0755 $(TARGET) $(DESTDIR)$(BINDIR)
 	$(QUIET)$(INSTALL) -m 0755 -d $(DESTDIR)$(CONFDIR)/bash_completion.d
 	./$(TARGET) completion bash > bash_autocomplete
+	$(foreach link,$(LINKS),./$(link) completion bash >> bash_autocomplete;)
 	$(QUIET)$(INSTALL) -m 0644 -T bash_autocomplete $(DESTDIR)$(CONFDIR)/bash_completion.d/cilium
+	$(foreach link,$(LINKS),ln -f -s $(TARGET) $(DESTDIR)$(BINDIR)/$(link) || cp $(TARGET) $(DESTDIR)$(BINDIR)/$(link);)

--- a/cilium/main.go
+++ b/cilium/main.go
@@ -15,9 +15,18 @@
 package main
 
 import (
-	"github.com/cilium/cilium/cilium/cmd"
+	"os"
+	"path"
+
+	cilium "github.com/cilium/cilium/cilium/cmd"
+	hubble "github.com/cilium/hubble/cmd"
 )
 
 func main() {
-	cmd.Execute()
+	switch path.Base(os.Args[0]) {
+	case "hubble":
+		hubble.Execute()
+	default:
+		cilium.Execute()
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/c9s/goprocinfo v0.0.0-20190309065803-0b2ad9ac246b
 	github.com/cilium/arping v1.0.1-0.20190728065459-c5eaf8d7a710
 	github.com/cilium/ebpf v0.0.0-20191113100448-d9fb101ca1fb
+	github.com/cilium/hubble v0.5.1-0.20200409144652-24bc03bef1db
 	github.com/cilium/ipam v0.0.0-20200217195329-a46f8d55f9db
 	github.com/cilium/proxy v0.0.0-20200309181938-3cf80fe45d03
 	github.com/containernetworking/cni v0.7.1

--- a/go.sum
+++ b/go.sum
@@ -94,12 +94,15 @@ github.com/cespare/xxhash/v2 v2.1.0 h1:yTUvW7Vhb89inJ+8irsUqiWjh8iT6sQPZiQzI6ReG
 github.com/cespare/xxhash/v2 v2.1.0/go.mod h1:dgIUBU3pDso/gPgZ1osOZ0iQf77oPR28Tjxl5dIMyVM=
 github.com/cilium/arping v1.0.1-0.20190728065459-c5eaf8d7a710 h1:htVjkajqUYy6JmLMGlZYxfZ4urQq7rDvgUfmSJX7fSg=
 github.com/cilium/arping v1.0.1-0.20190728065459-c5eaf8d7a710/go.mod h1:ohfPr9hSb4vRsw5UEjCs3OoWD38U0z8EfSgZPbIe/+M=
+github.com/cilium/cilium v1.7.0-rc2.0.20200409062440-f5425fec71bf/go.mod h1:pFDY4wmSvvZER2b/uBOJnRnp6xU0pfPr99DwqSnSEhs=
 github.com/cilium/client-go v0.0.0-20200326103132-fe7bd31c2794 h1:hI6C1C+Z/OQA2y9jrgq3z1sBBr7F5KwmpiwEH8XENgM=
 github.com/cilium/client-go v0.0.0-20200326103132-fe7bd31c2794/go.mod h1:uQSYDYs4WhVZ9i6AIoEZuwUggLVEF64HOD37boKAtF8=
 github.com/cilium/dns v1.1.4-0.20190417235132-8e25ec9a0ff3 h1:wenYMyWJ08dgEUUj0Ija8qdK/V9vL3ThAD5sjOYlFlg=
 github.com/cilium/dns v1.1.4-0.20190417235132-8e25ec9a0ff3/go.mod h1:cXN7jgo+gsGlNvQ7Vqu2ELdc3f7i7PPgupHqSkLzzBo=
 github.com/cilium/ebpf v0.0.0-20191113100448-d9fb101ca1fb h1:bQ0NJ9dAB8vsw7ffajBDX/7Wr64BdLWeJkYY36UkeRY=
 github.com/cilium/ebpf v0.0.0-20191113100448-d9fb101ca1fb/go.mod h1:MA5e5Lr8slmEg9bt0VpxxWqJlO4iwu3FBdHUzV7wQVg=
+github.com/cilium/hubble v0.5.1-0.20200409144652-24bc03bef1db h1:zdaOIAF+LpB2Lzw7HT2YzaNFlHeqRdJ8yx4cniYNFZY=
+github.com/cilium/hubble v0.5.1-0.20200409144652-24bc03bef1db/go.mod h1:HWFxG69JBVB4wJNmc2gOieu3Q9jK3zqoPSJUUmZzVag=
 github.com/cilium/ipam v0.0.0-20200217195329-a46f8d55f9db h1:pW/jw3e14kOrad7wNZRKdnSDRStOcJ02A7uIpTsa5f8=
 github.com/cilium/ipam v0.0.0-20200217195329-a46f8d55f9db/go.mod h1:URWgSDyRFKKBgnY4Svj37siCG145nu3qJt6oHlZRdqU=
 github.com/cilium/kafka v0.0.0-20180809090225-01ce283b732b h1:+bsFX/WOMIoaayXVyRem1awcpz3icz/HoL8Dxg/m6a4=

--- a/vendor/github.com/cilium/hubble/LICENSE
+++ b/vendor/github.com/cilium/hubble/LICENSE
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} Authors of Hubble
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/vendor/github.com/cilium/hubble/cmd/observe/observe.go
+++ b/vendor/github.com/cilium/hubble/cmd/observe/observe.go
@@ -1,0 +1,432 @@
+// Copyright 2019 Authors of Hubble
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observe
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"time"
+
+	pb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/api/v1/observer"
+	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
+	"github.com/cilium/hubble/pkg/defaults"
+	hubprinter "github.com/cilium/hubble/pkg/printer"
+	hubtime "github.com/cilium/hubble/pkg/time"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/timestamp"
+	"github.com/spf13/cobra"
+	"golang.org/x/sys/unix"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+var (
+	last               uint64
+	sinceVar, untilVar string
+
+	jsonOutput            bool
+	compactOutput         bool
+	dictOutput            bool
+	output                string
+	follow                bool
+	ignoreStderr          bool
+	enableIPTranslation   bool
+	enablePortTranslation bool
+
+	printer *hubprinter.Printer
+
+	allTypes = []string{
+		monitorAPI.MessageTypeNameL7,
+		monitorAPI.MessageTypeNameDrop,
+		monitorAPI.MessageTypeNameTrace,
+		// Currently we don't parse the following three as they are deemed too
+		// noisy:
+		// monitorAPI.MessageTypeDebug,
+		// monitorAPI.MessageTypeCapture,
+		// monitorAPI.MessageTypeAgent,
+	}
+
+	serverURL     string
+	serverTimeout time.Duration
+
+	numeric bool
+)
+
+func eventTypes() (l []string) {
+	for t := range monitorAPI.MessageTypeNames {
+		l = append(l, t)
+	}
+	return
+}
+
+// New observer command.
+func New() *cobra.Command {
+	return newObserveCmd(newObserveFilter())
+}
+
+func newObserveCmd(ofilter *observeFilter) *cobra.Command {
+	observerCmd := &cobra.Command{
+		Use:   "observe",
+		Short: "Display BPF program events running in the local node",
+		Long: `The hubble observer displays notifications and events emitted by the BPF
+programs attached to endpoints and devices. This includes:
+  * Dropped packet notifications
+  * Captured packet traces
+  * Debugging information`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := handleArgs(ofilter); err != nil {
+				return err
+			}
+
+			if err := runObserve(serverURL, ofilter); err != nil {
+				msg := err.Error()
+				// extract custom error message from failed grpc call
+				if s, ok := status.FromError(err); ok && s.Code() == codes.Unknown {
+					msg = s.Message()
+				}
+				return errors.New(msg)
+			}
+			return nil
+		},
+	}
+	observerCmd.Flags().StringVarP(&serverURL,
+		"server", "", defaults.DefaultSocketPath,
+		"URL to connect to server")
+	observerCmd.Flags().DurationVar(&serverTimeout,
+		"timeout", defaults.DefaultDialTimeout,
+		"How long to wait before giving up on server dialing")
+	observerCmd.Flags().VarP(filterVarP(
+		"type", "t", ofilter, allTypes,
+		fmt.Sprintf("Filter by event types TYPE[:SUBTYPE] (%v)", eventTypes())))
+
+	observerCmd.Flags().Uint64Var(&last, "last", 0, "Get last N flows stored in the hubble")
+	observerCmd.Flags().BoolVarP(&follow, "follow", "f", false, "Follow flows output")
+	observerCmd.Flags().StringVar(&sinceVar, "since", "", "Filter flows since a specific date (relative or RFC3339)")
+	observerCmd.Flags().StringVar(&untilVar, "until", "", "Filter flows until a specific date (relative or RFC3339)")
+
+	observerCmd.Flags().Var(filterVar(
+		"not", ofilter,
+		"Reverses the next filter to be blacklist i.e. --not --from-ip 2.2.2.2"))
+	observerCmd.Flags().Lookup("not").NoOptDefVal = "true"
+
+	observerCmd.Flags().Var(filterVar(
+		"from-fqdn", ofilter,
+		"Show all flows originating at the given fully qualified domain name (e.g. \"*.cilium.io\")."))
+	observerCmd.Flags().Var(filterVar(
+		"fqdn", ofilter,
+		"Show all flows related to the given fully qualified domain name (e.g. \"*.cilium.io\")."))
+	observerCmd.Flags().Var(filterVar(
+		"to-fqdn", ofilter,
+		"Show all flows terminating at the given fully qualified domain name (e.g. \"*.cilium.io\")."))
+
+	observerCmd.Flags().Var(filterVar(
+		"from-ip", ofilter,
+		"Show all flows originating at the given IP address."))
+	observerCmd.Flags().Var(filterVar(
+		"ip", ofilter,
+		"Show all flows related to the given IP address."))
+	observerCmd.Flags().Var(filterVar(
+		"to-ip", ofilter,
+		"Show all flows terminating at the given IP address."))
+
+	observerCmd.Flags().Var(filterVar(
+		"from-pod", ofilter,
+		"Show all flows originating in the given pod name ([namespace/]<pod-name>). If namespace is not provided, 'default' is used"))
+	observerCmd.Flags().Var(filterVar(
+		"pod", ofilter,
+		"Show all flows related to the given pod name ([namespace/]<pod-name>). If namespace is not provided, 'default' is used"))
+	observerCmd.Flags().Var(filterVar(
+		"to-pod", ofilter,
+		"Show all flows terminating in the given pod name ([namespace/]<pod-name>). If namespace is not provided, 'default' is used"))
+
+	observerCmd.Flags().Var(filterVar(
+		"from-namespace", ofilter,
+		"Show all flows originating in the given Kubernetes namespace."))
+	observerCmd.Flags().VarP(filterVarP(
+		"namespace", "n", ofilter, nil,
+		"Show all flows related to the given Kubernetes namespace."))
+	observerCmd.Flags().Var(filterVar(
+		"to-namespace", ofilter,
+		"Show all flows terminating in the given Kubernetes namespace."))
+
+	observerCmd.Flags().Var(filterVar(
+		"from-label", ofilter,
+		"Show only flows originating in an endpoint with the given labels (e.g. \"key1=value1\", \"reserved:world\")"))
+	observerCmd.Flags().VarP(filterVarP(
+		"label", "l", ofilter, nil,
+		"Show only flows related to an endpoint with the given labels (e.g. \"key1=value1\", \"reserved:world\")"))
+	observerCmd.Flags().Var(filterVar(
+		"to-label", ofilter,
+		"Show only flows terminating in an endpoint with given labels (e.g. \"key1=value1\", \"reserved:world\")"))
+
+	observerCmd.Flags().Var(filterVar(
+		"from-service", ofilter,
+		"Show all flows originating in the given service ([namespace/]<svc-name>). If namespace is not provided, 'default' is used"))
+	observerCmd.Flags().Var(filterVar(
+		"service", ofilter,
+		"Show all flows related to the given service ([namespace/]<svc-name>). If namespace is not provided, 'default' is used"))
+	observerCmd.Flags().Var(filterVar(
+		"to-service", ofilter,
+		"Show all flows terminating in the given service ([namespace/]<svc-name>). If namespace is not provided, 'default' is used"))
+
+	observerCmd.Flags().Var(filterVar(
+		"verdict", ofilter,
+		fmt.Sprintf("Show only flows with this verdict [%v, %v]", pb.Verdict_FORWARDED, pb.Verdict_DROPPED)))
+
+	observerCmd.Flags().Var(filterVar(
+		"http-status", ofilter,
+		"Show only flows which match this HTTP status code prefix (e.g. \"404\", \"5+\")"))
+
+	observerCmd.Flags().Var(filterVar(
+		"protocol", ofilter,
+		"Show only flows which match the given L4/L7 flow protocol (e.g. \"udp\", \"http\")"))
+
+	observerCmd.Flags().Var(filterVar(
+		"from-port", ofilter,
+		"Show only flows with the given source port (e.g. 8080)"))
+	observerCmd.Flags().Var(filterVar(
+		"port", ofilter,
+		"Show only flows with given port in either source or destination (e.g. 8080)"))
+	observerCmd.Flags().Var(filterVar(
+		"to-port", ofilter,
+		"Show only flows with the given destination port (e.g. 8080)"))
+
+	observerCmd.Flags().Var(filterVar(
+		"from-identity", ofilter,
+		"Show all flows originating at an endpoint with the given security identity"))
+	observerCmd.Flags().Var(filterVar(
+		"identity", ofilter,
+		"Show all flows related to an endpoint with the given security identity"))
+	observerCmd.Flags().Var(filterVar(
+		"to-identity", ofilter,
+		"Show all flows terminating at an endpoint with the given security identity"))
+
+	observerCmd.Flags().BoolVarP(
+		&jsonOutput, "json", "j", false, "Deprecated. Use '--output json' instead.",
+	)
+	observerCmd.Flags().BoolVar(
+		&compactOutput, "compact", false, "Deprecated. Use '--output compact' instead.",
+	)
+	observerCmd.Flags().BoolVar(
+		&dictOutput, "dict", false, "Deprecated. Use '--output dict' instead.",
+	)
+	observerCmd.Flags().StringVarP(
+		&output, "output", "o", "",
+		"Specify the output format, one of:\n -compact:\tcompact output\n -dict:\teach flow is shown as KEY:VALUE pair\n -json:\tJSON encoding\n -table:\ttab-aligned columns",
+	)
+	observerCmd.Flags().BoolVarP(
+		&ignoreStderr, "silent-errors", "s", false, "Silently ignores errors and warnings")
+
+	observerCmd.Flags().BoolVar(
+		&numeric,
+		"numeric",
+		false,
+		"Display all information in numeric form",
+	)
+
+	observerCmd.Flags().BoolVar(
+		&enablePortTranslation,
+		"port-translation",
+		true,
+		"Translate port numbers to names",
+	)
+
+	observerCmd.Flags().BoolVar(
+		&enableIPTranslation,
+		"ip-translation",
+		true,
+		"Translate IP addresses to logical names such as pod name, FQDN, ...",
+	)
+
+	customObserverHelp(observerCmd)
+
+	return observerCmd
+}
+
+func handleArgs(ofilter *observeFilter) (err error) {
+	if ofilter.blacklisting {
+		return errors.New("trailing --not found in the arguments")
+	}
+
+	// initialize the printer with any options that were passed in
+	var opts []hubprinter.Option
+
+	if output == "" { // support deprecated output flags if provided
+		if jsonOutput {
+			output = "json"
+		} else if dictOutput {
+			output = "dict"
+		} else if compactOutput {
+			output = "compact"
+		}
+	}
+
+	switch output {
+	case "compact":
+		opts = append(opts, hubprinter.Compact())
+	case "dict":
+		opts = append(opts, hubprinter.Dict())
+	case "json", "JSON":
+		opts = append(opts, hubprinter.JSON())
+	case "tab", "table":
+		if follow {
+			return fmt.Errorf("table output format is not compatible with follow mode")
+		}
+		opts = append(opts, hubprinter.Tab())
+	case "":
+		// no format specified, choose most appropriate format based on
+		// user provided flags
+		if follow {
+			opts = append(opts, hubprinter.Compact())
+		} else {
+			opts = append(opts, hubprinter.Tab())
+		}
+	default:
+		return fmt.Errorf("invalid output format: %s", output)
+	}
+	if ignoreStderr {
+		opts = append(opts, hubprinter.IgnoreStderr())
+	}
+	if numeric {
+		enableIPTranslation = false
+		enablePortTranslation = false
+	}
+	if enableIPTranslation {
+		opts = append(opts, hubprinter.WithIPTranslation())
+	}
+	if enablePortTranslation {
+		opts = append(opts, hubprinter.WithPortTranslation())
+	}
+	printer = hubprinter.New(opts...)
+	return nil
+}
+
+func runObserve(serverURL string, ofilter *observeFilter) error {
+	ctx, cancel := context.WithTimeout(context.Background(), serverTimeout)
+	defer cancel()
+	conn, err := grpc.DialContext(ctx, serverURL, grpc.WithInsecure(), grpc.WithBlock())
+	if err != nil {
+		return fmt.Errorf("failed to dial grpc: %v", err)
+	}
+	defer conn.Close()
+
+	// convert sinceVar into a param for GetFlows
+	var since, until *timestamp.Timestamp
+	if sinceVar != "" {
+		st, err := hubtime.FromString(sinceVar)
+		if err != nil {
+			return fmt.Errorf("failed to parse the since time: %v", err)
+		}
+
+		since, err = ptypes.TimestampProto(st)
+		if err != nil {
+			return fmt.Errorf("failed to convert `since` timestamp to proto: %v", err)
+		}
+		// Set the until field if both --since and --until options are specified and --follow
+		// is not specified. If --since is specified but --until is not, the server sets the
+		// --until option to the current timestamp.
+		if untilVar != "" && !follow {
+			ut, err := hubtime.FromString(untilVar)
+			if err != nil {
+				return fmt.Errorf("failed to parse the until time: %v", err)
+			}
+			until, err = ptypes.TimestampProto(ut)
+			if err != nil {
+				return fmt.Errorf("failed to convert `until` timestamp to proto: %v", err)
+			}
+		}
+	}
+
+	// no specific parameters were provided, just a vanilla `hubble observe`
+	if last == 0 && since == nil && until == nil {
+		// assume --last 20
+		last = 20
+	}
+
+	var (
+		wl []*pb.FlowFilter
+		bl []*pb.FlowFilter
+	)
+	if ofilter.whitelist != nil {
+		wl = ofilter.whitelist.flowFilters()
+	}
+	if ofilter.blacklist != nil {
+		bl = ofilter.blacklist.flowFilters()
+	}
+
+	client := observer.NewObserverClient(conn)
+	req := &observer.GetFlowsRequest{
+		Number:    last,
+		Follow:    follow,
+		Whitelist: wl,
+		Blacklist: bl,
+		Since:     since,
+		Until:     until,
+	}
+
+	return getFlows(client, req)
+}
+
+func getFlows(client observer.ObserverClient, req *observer.GetFlowsRequest) error {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	b, err := client.GetFlows(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		sigs := make(chan os.Signal, 1)
+		signal.Notify(sigs, unix.SIGINT, unix.SIGTERM)
+		select {
+		case <-sigs:
+		case <-ctx.Done():
+			signal.Stop(sigs)
+		}
+		cancel()
+	}()
+
+	defer printer.Close()
+
+	for {
+		getFlowResponse, err := b.Recv()
+		switch err {
+		case io.EOF, context.Canceled:
+			return nil
+		case nil:
+		default:
+			if status.Code(err) == codes.Canceled {
+				return nil
+			}
+			return err
+		}
+
+		flow := getFlowResponse.GetFlow()
+		if flow == nil {
+			continue
+		}
+
+		err = printer.WriteProtoFlow(flow)
+		if err != nil {
+			return err
+		}
+	}
+}

--- a/vendor/github.com/cilium/hubble/cmd/observe/observe_filter.go
+++ b/vendor/github.com/cilium/hubble/cmd/observe/observe_filter.go
@@ -1,0 +1,499 @@
+// Copyright 2019 Authors of Hubble
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observe
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	pb "github.com/cilium/cilium/api/v1/flow"
+	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
+	"github.com/golang/protobuf/proto"
+	"github.com/spf13/pflag"
+)
+
+type (
+	flagName  = string
+	flagDesc  = string
+	shortName = string
+)
+
+type filterTracker struct {
+	// the resulting filter will be `left OR right`
+	left, right *pb.FlowFilter
+
+	// which values were touched by the user. This is important because all of
+	// the defaults need to be wiped the first time user touches a []string
+	// value.
+	changed []string
+}
+
+func (f *filterTracker) add(name string) bool {
+	for _, exists := range f.changed {
+		if name == exists {
+			return false
+		}
+	}
+
+	// wipe the existing values if this is the first time usage of this
+	// flag, otherwise defaults creep into the final set.
+	f.changed = append(f.changed, name)
+
+	return true
+}
+
+func (f *filterTracker) apply(update func(*pb.FlowFilter)) {
+	f.applyLeft(update)
+	f.applyRight(update)
+}
+
+func (f *filterTracker) applyLeft(update func(*pb.FlowFilter)) {
+	if f.left == nil {
+		f.left = &pb.FlowFilter{}
+	}
+	update(f.left)
+}
+
+func (f *filterTracker) applyRight(update func(*pb.FlowFilter)) {
+	if f.right == nil {
+		f.right = &pb.FlowFilter{}
+	}
+	update(f.right)
+}
+
+func (f *filterTracker) flowFilters() []*pb.FlowFilter {
+	if f.left == nil && f.right == nil {
+		return nil
+	} else if proto.Equal(f.left, f.right) {
+		return []*pb.FlowFilter{f.left}
+	}
+
+	filters := []*pb.FlowFilter{}
+	if f.left != nil {
+		filters = append(filters, f.left)
+	}
+	if f.right != nil {
+		filters = append(filters, f.right)
+	}
+	return filters
+}
+
+// Implements pflag.Value
+type observeFilter struct {
+	whitelist *filterTracker
+	blacklist *filterTracker
+
+	// tracks if the next dispatched filter is going into blacklist or
+	// whitelist. Blacklist is only triggered by `--not` and has to be set for
+	// every blacklisted filter, i.e. `--not pod-ip 127.0.0.1 --not pod-ip
+	// 2.2.2.2`.
+	blacklisting bool
+
+	conflicts [][]string // conflict config
+}
+
+func newObserveFilter() *observeFilter {
+	return &observeFilter{
+		conflicts: [][]string{
+			{"from-fqdn", "from-ip", "from-namespace", "from-pod", "fqdn", "ip", "namespace", "pod"},
+			{"to-fqdn", "to-ip", "to-namespace", "to-pod", "fqdn", "ip", "namespace", "pod"},
+			{"label", "from-label"},
+			{"label", "to-label"},
+			{"service", "from-service"},
+			{"service", "to-service"},
+			{"verdict"},
+			{"type"},
+			{"http-status"},
+			{"protocol"},
+			{"port", "to-port"},
+			{"port", "from-port"},
+			{"identity", "to-identity"},
+			{"identity", "from-identity"},
+		},
+	}
+}
+
+func (of *observeFilter) hasChanged(list []string, name string) bool {
+	for _, c := range list {
+		if c == name {
+			return true
+		}
+	}
+	return false
+}
+
+func (of *observeFilter) checkConflict(t *filterTracker, name, val string) error {
+	// check for conflicts
+	for _, group := range of.conflicts {
+		for _, flag := range group {
+			if of.hasChanged(t.changed, flag) {
+				for _, conflict := range group {
+					if flag != conflict && of.hasChanged(t.changed, conflict) {
+						return fmt.Errorf(
+							"filters --%s and --%s cannot be combined",
+							flag, conflict,
+						)
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (of *observeFilter) Set(name, val string, track bool) error {
+	// --not simply toggles the destination of the next filter into blacklist
+	if name == "not" {
+		if of.blacklisting {
+			return errors.New("consecutive --not statements")
+		}
+		of.blacklisting = true
+		return nil
+	}
+
+	if of.blacklisting {
+		// --not only applies to a single filter so we turn off blacklisting
+		of.blacklisting = false
+
+		// lazy init blacklist
+		if of.blacklist == nil {
+			of.blacklist = &filterTracker{
+				changed: []string{},
+			}
+		}
+		return of.set(of.blacklist, name, val, track)
+	}
+
+	// lazy init whitelist
+	if of.whitelist == nil {
+		of.whitelist = &filterTracker{
+			changed: []string{},
+		}
+	}
+
+	return of.set(of.whitelist, name, val, track)
+}
+
+func (of *observeFilter) set(f *filterTracker, name, val string, track bool) error {
+	// track the change if this is non-default user operation
+	wipe := false
+	if track {
+		wipe = f.add(name)
+
+		if err := of.checkConflict(f, name, val); err != nil {
+			return err
+		}
+	}
+
+	switch name {
+	// fqdn filters
+	case "fqdn":
+		f.applyLeft(func(f *pb.FlowFilter) {
+			f.SourceFqdn = append(f.SourceFqdn, val)
+		})
+		f.applyRight(func(f *pb.FlowFilter) {
+			f.DestinationFqdn = append(f.DestinationFqdn, val)
+		})
+	case "from-fqdn":
+		f.apply(func(f *pb.FlowFilter) {
+			f.SourceFqdn = append(f.SourceFqdn, val)
+		})
+	case "to-fqdn":
+		f.apply(func(f *pb.FlowFilter) {
+			f.DestinationFqdn = append(f.DestinationFqdn, val)
+		})
+
+	// pod filters
+	case "pod":
+		f.applyLeft(func(f *pb.FlowFilter) {
+			f.SourcePod = append(f.SourcePod, val)
+		})
+		f.applyRight(func(f *pb.FlowFilter) {
+			f.DestinationPod = append(f.DestinationPod, val)
+		})
+	case "from-pod":
+		f.apply(func(f *pb.FlowFilter) {
+			f.SourcePod = append(f.SourcePod, val)
+		})
+	case "to-pod":
+		f.apply(func(f *pb.FlowFilter) {
+			f.DestinationPod = append(f.DestinationPod, val)
+		})
+	// ip filters
+	case "ip":
+		f.applyLeft(func(f *pb.FlowFilter) {
+			f.SourceIp = append(f.SourceIp, val)
+		})
+		f.applyRight(func(f *pb.FlowFilter) {
+			f.DestinationIp = append(f.DestinationIp, val)
+		})
+	case "from-ip":
+		f.apply(func(f *pb.FlowFilter) {
+			f.SourceIp = append(f.SourceIp, val)
+		})
+	case "to-ip":
+		f.apply(func(f *pb.FlowFilter) {
+			f.DestinationIp = append(f.DestinationIp, val)
+		})
+	// label filters
+	case "label":
+		f.applyLeft(func(f *pb.FlowFilter) {
+			f.SourceLabel = append(f.SourceLabel, val)
+		})
+		f.applyRight(func(f *pb.FlowFilter) {
+			f.DestinationLabel = append(f.DestinationLabel, val)
+		})
+	case "from-label":
+		f.apply(func(f *pb.FlowFilter) {
+			f.SourceLabel = append(f.SourceLabel, val)
+		})
+	case "to-label":
+		f.apply(func(f *pb.FlowFilter) {
+			f.DestinationLabel = append(f.DestinationLabel, val)
+		})
+
+	// namespace filters (translated to pod filters)
+	case "namespace":
+		f.applyLeft(func(f *pb.FlowFilter) {
+			f.SourcePod = append(f.SourcePod, val+"/")
+		})
+		f.applyRight(func(f *pb.FlowFilter) {
+			f.DestinationPod = append(f.DestinationPod, val+"/")
+		})
+	case "from-namespace":
+		f.apply(func(f *pb.FlowFilter) {
+			f.SourcePod = append(f.SourcePod, val+"/")
+		})
+	case "to-namespace":
+		f.apply(func(f *pb.FlowFilter) {
+			f.DestinationPod = append(f.DestinationPod, val+"/")
+		})
+	// service filters
+	case "service":
+		f.applyLeft(func(f *pb.FlowFilter) {
+			f.SourceService = append(f.SourceService, val)
+		})
+		f.applyRight(func(f *pb.FlowFilter) {
+			f.DestinationService = append(f.DestinationService, val)
+		})
+	case "from-service":
+		f.apply(func(f *pb.FlowFilter) {
+			f.SourceService = append(f.SourceService, val)
+		})
+	case "to-service":
+		f.apply(func(f *pb.FlowFilter) {
+			f.DestinationService = append(f.DestinationService, val)
+		})
+
+	// port filters
+	case "port":
+		f.applyLeft(func(f *pb.FlowFilter) {
+			f.SourcePort = append(f.SourcePort, val)
+		})
+		f.applyRight(func(f *pb.FlowFilter) {
+			f.DestinationPort = append(f.DestinationPort, val)
+		})
+	case "from-port":
+		f.apply(func(f *pb.FlowFilter) {
+			f.SourcePort = append(f.SourcePort, val)
+		})
+	case "to-port":
+		f.apply(func(f *pb.FlowFilter) {
+			f.DestinationPort = append(f.DestinationPort, val)
+		})
+
+	case "verdict":
+		if wipe {
+			f.apply(func(f *pb.FlowFilter) {
+				f.Verdict = nil
+			})
+		}
+
+		vv, ok := pb.Verdict_value[val]
+		if !ok {
+			return fmt.Errorf("invalid --verdict value: %v", val)
+		}
+		f.apply(func(f *pb.FlowFilter) {
+			f.Verdict = append(f.Verdict, pb.Verdict(vv))
+		})
+
+	case "http-status":
+		if wipe {
+			f.apply(func(f *pb.FlowFilter) {
+				f.HttpStatusCode = nil
+			})
+		}
+		f.apply(func(f *pb.FlowFilter) {
+			// TODO: auto-check L7?
+			f.HttpStatusCode = append(f.HttpStatusCode, val)
+		})
+
+	case "type":
+		if wipe {
+			f.apply(func(f *pb.FlowFilter) {
+				f.EventType = nil
+			})
+		}
+
+		typeFilter := &pb.EventTypeFilter{}
+
+		s := strings.SplitN(val, ":", 2)
+		t, ok := monitorAPI.MessageTypeNames[s[0]]
+		if ok {
+			typeFilter.Type = int32(t)
+		} else {
+			t, err := strconv.ParseUint(s[0], 10, 32)
+			if err != nil {
+				return fmt.Errorf("unable to parse type '%s', not a known type name and unable to parse as numeric value: %s", s[0], err)
+			}
+			typeFilter.Type = int32(t)
+		}
+
+		if len(s) > 1 {
+		OUTER:
+			switch t {
+			case monitorAPI.MessageTypeTrace:
+				for k, v := range monitorAPI.TraceObservationPoints {
+					if s[1] == v {
+						typeFilter.MatchSubType = true
+						typeFilter.SubType = int32(k)
+						break OUTER
+					}
+				}
+				// fallthrough to parse subtype as integer
+				fallthrough
+			default:
+				t, err := strconv.ParseUint(s[1], 10, 32)
+				if err != nil {
+					return fmt.Errorf("unable to parse event sub-type '%s', not a known sub-type name and unable to parse as numeric value: %s", s[1], err)
+				}
+				typeFilter.MatchSubType = true
+				typeFilter.SubType = int32(t)
+			}
+		}
+		f.apply(func(f *pb.FlowFilter) {
+			f.EventType = append(f.EventType, typeFilter)
+		})
+	case "protocol":
+		f.apply(func(f *pb.FlowFilter) {
+			f.Protocol = append(f.Protocol, val)
+		})
+
+	// identity filters
+	case "identity":
+		identity, err := strconv.ParseUint(val, 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid security identity: %s: %s", val, err)
+		}
+		f.applyLeft(func(f *pb.FlowFilter) {
+			f.SourceIdentity = append(f.SourceIdentity, identity)
+		})
+		f.applyRight(func(f *pb.FlowFilter) {
+			f.DestinationIdentity = append(f.DestinationIdentity, identity)
+		})
+	case "from-identity":
+		identity, err := strconv.ParseUint(val, 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid security identity: %s: %s", val, err)
+		}
+		f.apply(func(f *pb.FlowFilter) {
+			f.SourceIdentity = append(f.SourceIdentity, identity)
+		})
+	case "to-identity":
+		identity, err := strconv.ParseUint(val, 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid security identity: %s: %s", val, err)
+		}
+		f.apply(func(f *pb.FlowFilter) {
+			f.DestinationIdentity = append(f.DestinationIdentity, identity)
+		})
+	}
+
+	return nil
+}
+
+func (of observeFilter) Type() string {
+	return "filter"
+}
+
+// Small dispatcher on top of a filter that allows all the filter arguments to
+// flow through the same object. By default, Cobra doesn't call `Set()` with the
+// name of the argument, only it's value.
+type filterDispatch struct {
+	*observeFilter
+
+	name string
+	def  []string
+}
+
+func (d filterDispatch) Set(s string) error {
+	return d.observeFilter.Set(d.name, s, true)
+}
+
+// for some reason String() is used for default value in pflag/cobra
+func (d filterDispatch) String() string {
+	if len(d.def) == 0 {
+		return ""
+	}
+
+	var b bytes.Buffer
+	first := true
+	b.WriteString("[")
+	for _, def := range d.def {
+		if first {
+			first = false
+		} else {
+			// if not first, write a comma
+			b.WriteString(",")
+		}
+		b.WriteString(def)
+	}
+	b.WriteString("]")
+
+	return b.String()
+}
+
+func filterVar(
+	name string,
+	of *observeFilter,
+	desc string,
+) (pflag.Value, flagName, flagDesc) {
+	return &filterDispatch{
+		name:          name,
+		observeFilter: of,
+	}, name, desc
+}
+
+func filterVarP(
+	name string,
+	short string,
+	of *observeFilter,
+	def []string,
+	desc string,
+) (pflag.Value, flagName, shortName, flagDesc) {
+	d := &filterDispatch{
+		name:          name,
+		def:           def,
+		observeFilter: of,
+	}
+	for _, val := range def {
+		d.observeFilter.Set(name, val, false /* do not track */)
+
+	}
+	return d, name, short, desc
+}

--- a/vendor/github.com/cilium/hubble/cmd/observe/observe_usage.go
+++ b/vendor/github.com/cilium/hubble/cmd/observe/observe_usage.go
@@ -1,0 +1,117 @@
+// Copyright 2019 Authors of Hubble
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observe
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type flagsSection struct {
+	name  string   // short one-liner to describe the section
+	desc  string   // optional paragraph to preface and deeper explain a section
+	flags []string // names of flags to include in the section
+}
+
+// customObserverHelp is a function which modifies the usage template
+// **specifically** for the `hubble observe` command by providing separation of
+// sections for the `Flags:`.
+func customObserverHelp(observerCmd *cobra.Command) {
+	origTpl := observerCmd.UsageTemplate()
+	observerCmd.SetUsageTemplate(modifyTemplate(origTpl, observerCmd))
+}
+
+func modifyTemplate(orig string, cmd *cobra.Command) string {
+	// prepare to take out the `Flags:` section completely
+	fi := strings.Index(orig, "Flags:")
+	gfi := strings.Index(orig, "Global Flags:")
+
+	sections := []flagsSection{
+		{
+			name: "Selectors (retrieve data from hubble)",
+			flags: []string{
+				"last", "since", "until", "follow",
+			},
+		},
+		{
+			name: "Filters (limit result set, not all are compatible with each other)",
+			flags: []string{
+				"not",
+				"ip", "to-ip", "from-ip",
+				"pod", "to-pod", "from-pod",
+				"fqdn", "to-fqdn", "from-fqdn",
+				"label", "to-label", "from-label",
+				"namespace", "to-namespace", "from-namespace",
+				"service", "to-service", "from-service",
+				"port", "to-port", "from-port",
+				"type", "verdict", "http-status", "protocol",
+				"identity", "to-identity", "from-identity",
+			},
+		},
+	}
+
+	var b bytes.Buffer
+	var seen []string // what flags have already been processed
+
+	// go through all sections defined in the config in order
+	for _, s := range sections {
+		fmt.Fprintf(&b, "%s:\n", s.name)
+		if s.desc != "" {
+			fmt.Fprintf(&b, "\n%s\n\n", s.desc)
+		}
+
+		fs := &pflag.FlagSet{SortFlags: true}
+		for _, f := range s.flags {
+			// extract the actual command flag by name and add to the set
+			flag := cmd.Flags().Lookup(f)
+			if flag == nil {
+				continue
+			}
+			fs.AddFlag(flag)
+			seen = append(seen, f)
+		}
+
+		// print the usages in the section
+		fmt.Fprintln(&b, fs.FlagUsages())
+	}
+
+	haveSeen := func(f string) bool {
+		for _, s := range seen {
+			if s == f {
+				return true
+			}
+		}
+		return false
+	}
+
+	// go through the rest of the flags and include them down at the bottom
+	rest := &pflag.FlagSet{SortFlags: true}
+	cmd.LocalFlags().VisitAll(func(f *pflag.Flag) {
+		if haveSeen(f.Name) {
+			return // ignore seen flags
+		}
+		rest.AddFlag(f)
+	})
+	if rest.HasFlags() {
+		fmt.Fprintln(&b, "Other Flags:")
+		fmt.Fprintln(&b, rest.FlagUsages())
+	}
+
+	return orig[:fi] + b.String() + orig[gfi:]
+}

--- a/vendor/github.com/cilium/hubble/cmd/root.go
+++ b/vendor/github.com/cilium/hubble/cmd/root.go
@@ -1,0 +1,223 @@
+// Copyright 2017-2020 Authors of Hubble
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"runtime"
+	"runtime/pprof"
+
+	"github.com/cilium/hubble/cmd/observe"
+	"github.com/cilium/hubble/cmd/status"
+	"github.com/cilium/hubble/cmd/version"
+	"github.com/cilium/hubble/pkg"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var (
+	cfgFile                        string
+	cpuprofile, memprofile         string
+	cpuprofileFile, memprofileFile *os.File
+)
+
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = &cobra.Command{
+	Use:           "hubble",
+	Short:         "CLI",
+	Long:          `Hubble is a utility to observe and inspect recent Cilium routed traffic in a cluster.`,
+	SilenceErrors: true, // this is being handled in main, no need to duplicate error messages
+	SilenceUsage:  true,
+	Version:       pkg.Version,
+	PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
+		return pprofInit()
+	},
+	PersistentPostRunE: func(_ *cobra.Command, _ []string) error {
+		return pprofTearDown()
+	},
+}
+
+func pprofInit() error {
+	var err error
+	if cpuprofile != "" {
+		cpuprofileFile, err = os.Create(cpuprofile)
+		if err != nil {
+			return fmt.Errorf("failed to create cpu profile: %v", err)
+		}
+		pprof.StartCPUProfile(cpuprofileFile)
+	}
+	if memprofile != "" {
+		memprofileFile, err = os.Create(memprofile)
+		if err != nil {
+			return fmt.Errorf("failed to create memory profile: %v", err)
+		}
+	}
+	return nil
+}
+
+func pprofTearDown() error {
+	if cpuprofileFile != nil {
+		pprof.StopCPUProfile()
+		cpuprofileFile.Close()
+	}
+	if memprofileFile != nil {
+		runtime.GC() // get up-to-date statistics
+		if err := pprof.WriteHeapProfile(memprofileFile); err != nil {
+			return fmt.Errorf("failed to write memory profile: %v", err)
+		}
+		memprofileFile.Close()
+	}
+	return nil
+}
+
+// Execute adds all child commands to the root command sets flags
+// appropriately. This is called by main.main(). It only needs to happen once
+// to the rootCmd.
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	cobra.OnInitialize(initConfig)
+	flags := rootCmd.PersistentFlags()
+	flags.StringVar(&cfgFile, "config", "", "config file (default is $HOME/.hubble.yaml)")
+	flags.BoolP("debug", "D", false, "Enable debug messages")
+	viper.BindPFlags(flags)
+	rootCmd.AddCommand(newCmdCompletion(os.Stdout))
+	rootCmd.SetErr(os.Stderr)
+
+	rootCmd.PersistentFlags().StringVar(&cpuprofile,
+		"cpuprofile", "", "Enable CPU profiling",
+	)
+	rootCmd.PersistentFlags().StringVar(&memprofile,
+		"memprofile", "", "Enable memory profiling",
+	)
+	rootCmd.PersistentFlags().Lookup("cpuprofile").Hidden = true
+	rootCmd.PersistentFlags().Lookup("memprofile").Hidden = true
+
+	rootCmd.SetVersionTemplate("{{with .Name}}{{printf \"%s \" .}}{{end}}{{printf \"v%s\" .Version}}\n")
+
+	// initialize all subcommands
+	rootCmd.AddCommand(observe.New())
+	rootCmd.AddCommand(version.New())
+	rootCmd.AddCommand(status.New())
+}
+
+// initConfig reads in config file and ENV variables if set.
+func initConfig() {
+	if cfgFile != "" { // enable ability to specify config file via flag
+		viper.SetConfigFile(cfgFile)
+	}
+
+	viper.SetEnvPrefix("hubble")
+	viper.SetConfigName(".hubble") // name of config file (without extension)
+	viper.AddConfigPath("$HOME")   // adding home directory as first search path
+	viper.AutomaticEnv()           // read in environment variables that match
+
+	// If a config file is found, read it in.
+	if err := viper.ReadInConfig(); err == nil {
+		fmt.Println("Using config file:", viper.ConfigFileUsed())
+	}
+}
+
+const copyRightHeader = `
+# Copyright 2019 Authors of Hubble
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+`
+
+var (
+	completionExample = `
+# Installing bash completion on macOS using homebrew
+## If running Bash 3.2 included with macOS
+	brew install bash-completion
+## or, if running Bash 4.1+
+	brew install bash-completion@2
+## afterwards you only need to run
+	hubble completion bash > $(brew --prefix)/etc/bash_completion.d/hubble
+
+
+# Installing bash completion on Linux
+## Load the hubble completion code for bash into the current shell
+	source <(hubble completion bash)
+## Write bash completion code to a file and source if from .bash_profile
+	hubble completion bash > ~/.hubble/completion.bash.inc
+	printf "
+	  # Hubble shell completion
+	  source '$HOME/.hubble/completion.bash.inc'
+	  " >> $HOME/.bash_profile
+	source $HOME/.bash_profile
+
+# Installing zsh completion on Linux/macOS
+## Load the hubble completion code for zsh into the current shell
+        source <(hubble completion zsh)
+## Write zsh completion code to a file and source if from .zshrc
+        hubble completion zsh > ~/.hubble/completion.zsh.inc
+        printf "
+          # Hubble shell completion
+          source '$HOME/.hubble/completion.zsh.inc'
+          " >> $HOME/.zshrc
+        source $HOME/.zshrc`
+)
+
+func newCmdCompletion(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "completion [shell]",
+		Short:   "Output shell completion code",
+		Long:    ``,
+		Example: completionExample,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCompletion(out, cmd, args)
+		},
+		ValidArgs: []string{"bash", "zsh"},
+	}
+
+	return cmd
+}
+
+func runCompletion(out io.Writer, cmd *cobra.Command, args []string) error {
+	if len(args) > 1 {
+		return fmt.Errorf("too many arguments; expected only the shell type")
+	}
+	if _, err := out.Write([]byte(copyRightHeader)); err != nil {
+		return err
+	}
+
+	if len(args) == 0 {
+		return cmd.Parent().GenBashCompletion(out)
+	}
+
+	switch args[0] {
+	case "bash":
+		return cmd.Parent().GenBashCompletion(out)
+	case "zsh":
+		return cmd.Parent().GenZshCompletion(out)
+	}
+
+	return fmt.Errorf("unsupported shell type: %s", args[0])
+}

--- a/vendor/github.com/cilium/hubble/cmd/status/status.go
+++ b/vendor/github.com/cilium/hubble/cmd/status/status.go
@@ -1,0 +1,115 @@
+// Copyright 2019 Authors of Hubble
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/cilium/cilium/api/v1/observer"
+	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/hubble/pkg/defaults"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"google.golang.org/grpc"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+)
+
+var (
+	serverURL string
+)
+
+// New status command.
+func New() *cobra.Command {
+	statusCmd := &cobra.Command{
+		Use:   "status",
+		Short: "Display status of hubble server",
+		Long: `Displays the status of the hubble server. This is
+		intended as a basic connectivity health check`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runStatus()
+		},
+	}
+
+	statusCmd.Flags().StringVarP(&serverURL,
+		"server", "", defaults.DefaultSocketPath, "URL to connect to server")
+	viper.BindEnv("server", "HUBBLE_SOCK")
+	return statusCmd
+}
+
+func runStatus() error {
+	// get the standard GRPC health check to see if the server is up
+	healthy, status, err := getHC(serverURL)
+	if err != nil {
+		return fmt.Errorf("failed getting status: %v", err)
+	}
+	fmt.Printf("Healthcheck (via %s): %s\n", serverURL, status)
+	if !healthy {
+		return errors.New("not healthy")
+	}
+
+	// if the server is up, lets try to get hubble specific status
+	ss, err := getStatus(serverURL)
+	if err != nil {
+		return fmt.Errorf("failed to get hubble server status: %v", err)
+	}
+	fmt.Println("Max Flows:", ss.MaxFlows)
+	fmt.Printf(
+		"Current Flows: %v (%.2f%%) \n",
+		ss.NumFlows,
+		(float64(ss.NumFlows)/float64(ss.MaxFlows))*100,
+	)
+	return nil
+}
+
+func getHC(s string) (healthy bool, status string, err error) {
+	conn, err := grpc.Dial(s, grpc.WithInsecure())
+	if err != nil {
+		return false, "", err
+	}
+	defer conn.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaults.DefaultRequestTimeout)
+	defer cancel()
+
+	req := &healthpb.HealthCheckRequest{Service: v1.ObserverServiceName}
+	resp, err := healthpb.NewHealthClient(conn).Check(ctx, req)
+	if err != nil {
+		return false, "", err
+	}
+	if st := resp.GetStatus(); st != healthpb.HealthCheckResponse_SERVING {
+		return false, fmt.Sprintf("Unavailable: %s", st), nil
+	}
+	return true, "Ok", nil
+}
+
+func getStatus(s string) (*observer.ServerStatusResponse, error) {
+	conn, err := grpc.Dial(s, grpc.WithInsecure())
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaults.DefaultRequestTimeout)
+	defer cancel()
+
+	req := &observer.ServerStatusRequest{}
+	res, err := observer.NewObserverClient(conn).ServerStatus(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}

--- a/vendor/github.com/cilium/hubble/cmd/version/version.go
+++ b/vendor/github.com/cilium/hubble/cmd/version/version.go
@@ -1,0 +1,43 @@
+// Copyright 2020 Authors of Hubble
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/cilium/hubble/pkg"
+
+	"github.com/spf13/cobra"
+)
+
+// New version command.
+func New() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Display detailed version information",
+		Long:  `Displays information about the version of this software.`,
+		Run: func(cmd *cobra.Command, _ []string) {
+			var gitInfo string
+			switch {
+			case pkg.GitBranch != "" && pkg.GitHash != "":
+				gitInfo = fmt.Sprintf("@%s-%s", pkg.GitBranch, pkg.GitHash)
+			case pkg.GitHash != "":
+				gitInfo = fmt.Sprintf("@%s", pkg.GitHash)
+			}
+			fmt.Printf("%s v%s%s compiled with %v on %v/%v\n", cmd.Root().Name(), pkg.Version, gitInfo, runtime.Version(), runtime.GOOS, runtime.GOARCH)
+		},
+	}
+}

--- a/vendor/github.com/cilium/hubble/pkg/defaults/defaults.go
+++ b/vendor/github.com/cilium/hubble/pkg/defaults/defaults.go
@@ -1,0 +1,28 @@
+// Copyright 2020 Authors of Hubble
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package defaults
+
+import "time"
+
+const (
+	// DefaultSocketPath on which to connect to the local hubble observer
+	DefaultSocketPath = "unix:///var/run/cilium/hubble.sock"
+
+	// DefaultDialTimeout is the timeout for dialing the server
+	DefaultDialTimeout = 5 * time.Second
+
+	// DefaultRequestTimeout is the timeout for client requests
+	DefaultRequestTimeout = 12 * time.Second
+)

--- a/vendor/github.com/cilium/hubble/pkg/printer/options.go
+++ b/vendor/github.com/cilium/hubble/pkg/printer/options.go
@@ -1,0 +1,103 @@
+// Copyright 2019 Authors of Hubble
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package printer
+
+import (
+	"io"
+	"io/ioutil"
+)
+
+// Output enum of the printer.
+type Output int
+
+const (
+	// TabOutput prints flows in even tab-aligned columns.
+	TabOutput Output = iota
+	// JSONOutput prints flows as json.
+	JSONOutput
+	// CompactOutput prints flows as compact as possible (similar to monitor).
+	CompactOutput
+	// DictOutput presents the same information as TabOutput, but each flow is
+	// presented as a key:value dictionary, similar to \G output of mysql.
+	DictOutput
+)
+
+// Options for the printer.
+type Options struct {
+	output                Output
+	w                     io.Writer
+	werr                  io.Writer
+	enablePortTranslation bool
+	enableIPTranslation   bool
+}
+
+// Option ...
+type Option func(*Options)
+
+// JSON encoded output from the printer.
+func JSON() Option {
+	return func(opts *Options) {
+		opts.output = JSONOutput
+	}
+}
+
+// Compact ...
+func Compact() Option {
+	return func(opts *Options) {
+		opts.output = CompactOutput
+	}
+}
+
+// Dict ...
+func Dict() Option {
+	return func(opts *Options) {
+		opts.output = DictOutput
+	}
+}
+
+// Tab prints flows in even tab-aligned columns.
+func Tab() Option {
+	return func(opts *Options) {
+		opts.output = TabOutput
+	}
+}
+
+// Writer sets the custom destination for where the bytes are sent.
+func Writer(w io.Writer) Option {
+	return func(opts *Options) {
+		opts.w = w
+	}
+}
+
+// IgnoreStderr configures the output to not print any
+func IgnoreStderr() Option {
+	return func(opts *Options) {
+		opts.werr = ioutil.Discard
+	}
+}
+
+// WithPortTranslation enables translation from port numbers to port names, i.e. `80` becomes `80(http)`.
+func WithPortTranslation() Option {
+	return func(opts *Options) {
+		opts.enablePortTranslation = true
+	}
+}
+
+// WithIPTranslation enables translation from IPs to pod names, FQDNs, and service names.
+func WithIPTranslation() Option {
+	return func(opts *Options) {
+		opts.enableIPTranslation = true
+	}
+}

--- a/vendor/github.com/cilium/hubble/pkg/printer/printer.go
+++ b/vendor/github.com/cilium/hubble/pkg/printer/printer.go
@@ -1,0 +1,316 @@
+// Copyright 2019 Authors of Hubble
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package printer
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	pb "github.com/cilium/cilium/api/v1/flow"
+	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/monitor/api"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/google/gopacket/layers"
+)
+
+// additional named ports that are related to hubble and cilium, which do
+// not appear in the "well known" list of Golang ports... yet.
+var namedPorts = map[int]string{
+	4240: "cilium-health",
+}
+
+// Printer for flows.
+type Printer struct {
+	opts        Options
+	line        int
+	tw          *tabwriter.Writer
+	jsonEncoder *json.Encoder
+}
+
+// New Printer.
+func New(fopts ...Option) *Printer {
+	// default options
+	opts := Options{
+		output: TabOutput,
+		w:      os.Stdout,
+		werr:   os.Stderr,
+	}
+
+	// apply optional parameters
+	for _, fopt := range fopts {
+		fopt(&opts)
+	}
+
+	p := &Printer{
+		opts: opts,
+	}
+
+	switch opts.output {
+	case TabOutput:
+		// initialize tabwriter since it's going to be needed
+		p.tw = tabwriter.NewWriter(opts.w, 2, 0, 3, ' ', 0)
+	case JSONOutput:
+		p.jsonEncoder = json.NewEncoder(p.opts.w)
+	}
+
+	return p
+}
+
+const (
+	tab     = "\t"
+	newline = "\n"
+)
+
+// Close any outstanding operations going on in the printer.
+func (p *Printer) Close() error {
+	if p.tw != nil {
+		return p.tw.Flush()
+	}
+
+	return nil
+}
+
+// WriteErr returns the given msg into the err writer defined in the printer.
+func (p *Printer) WriteErr(msg string) error {
+	_, err := fmt.Fprint(p.opts.werr, fmt.Sprintf("%s\n", msg))
+	return err
+}
+
+// GetPorts returns source and destination port of a flow.
+func (p *Printer) GetPorts(f v1.Flow) (string, string) {
+	l4 := f.GetL4()
+	if l4 == nil {
+		return "", ""
+	}
+	switch l4.Protocol.(type) {
+	case *pb.Layer4_TCP:
+		return p.TCPPort(layers.TCPPort(l4.GetTCP().SourcePort)), p.TCPPort(layers.TCPPort(l4.GetTCP().DestinationPort))
+	case *pb.Layer4_UDP:
+		return p.UDPPort(layers.UDPPort(l4.GetUDP().SourcePort)), p.UDPPort(layers.UDPPort(l4.GetUDP().DestinationPort))
+	default:
+		return "", ""
+	}
+}
+
+// GetHostNames returns source and destination hostnames of a flow.
+func (p *Printer) GetHostNames(f v1.Flow) (string, string) {
+	var srcNamespace, dstNamespace, srcPodName, dstPodName, srcSvcName, dstSvcName string
+	if f == nil || f.GetIP() == nil {
+		return "", ""
+	}
+	if src := f.GetSource(); src != nil {
+		srcNamespace = src.Namespace
+		srcPodName = src.PodName
+	}
+	if dst := f.GetDestination(); dst != nil {
+		dstNamespace = dst.Namespace
+		dstPodName = dst.PodName
+	}
+	if svc := f.GetSourceService(); svc != nil {
+		srcNamespace = svc.Namespace
+		srcSvcName = svc.Name
+	}
+	if svc := f.GetDestinationService(); svc != nil {
+		dstNamespace = svc.Namespace
+		dstSvcName = svc.Name
+	}
+	srcPort, dstPort := p.GetPorts(f)
+	src := p.Hostname(f.GetIP().Source, srcPort, srcNamespace, srcPodName, srcSvcName, f.GetSourceNames())
+	dst := p.Hostname(f.GetIP().Destination, dstPort, dstNamespace, dstPodName, dstSvcName, f.GetDestinationNames())
+	return src, dst
+}
+
+func getTimestamp(f v1.Flow) string {
+	if f == nil {
+		return "N/A"
+	}
+	ts, err := ptypes.Timestamp(f.GetTime())
+
+	if err != nil {
+		return "N/A"
+	}
+	return MaybeTime(&ts)
+}
+
+// GetFlowType returns the type of a flow as a string.
+func GetFlowType(f v1.Flow) string {
+	if l7 := f.GetL7(); l7 != nil {
+		l7Protocol := "l7"
+		l7Type := strings.ToLower(l7.Type.String())
+		switch l7.GetRecord().(type) {
+		case *pb.Layer7_Http:
+			l7Protocol = "http"
+		case *pb.Layer7_Dns:
+			l7Protocol = "dns"
+		case *pb.Layer7_Kafka:
+			l7Protocol = "kafka"
+		}
+		return l7Protocol + "-" + l7Type
+	}
+
+	switch f.GetEventType().GetType() {
+	case api.MessageTypeTrace:
+		return api.TraceObservationPoint(uint8(f.GetEventType().GetSubType()))
+	case api.MessageTypeDrop:
+		return api.DropReason(uint8(f.GetEventType().GetSubType()))
+	case api.MessageTypePolicyVerdict:
+		switch f.GetVerdict() {
+		case pb.Verdict_FORWARDED:
+			return api.PolicyMatchType(f.GetPolicyMatchType()).String()
+		case pb.Verdict_DROPPED:
+			return api.DropReason(uint8(f.GetDropReason()))
+		}
+	}
+
+	return "UNKNOWN"
+}
+
+// WriteProtoFlow writes v1.Flow into the output writer.
+func (p *Printer) WriteProtoFlow(f v1.Flow) error {
+	switch p.opts.output {
+	case TabOutput:
+		if p.line == 0 {
+			_, err := fmt.Fprint(p.tw,
+				"TIMESTAMP", tab,
+				"SOURCE", tab,
+				"DESTINATION", tab,
+				"TYPE", tab,
+				"VERDICT", tab,
+				"SUMMARY", newline,
+			)
+			if err != nil {
+				return err
+			}
+		}
+		src, dst := p.GetHostNames(f)
+		_, err := fmt.Fprint(p.tw,
+			getTimestamp(f), tab,
+			src, tab,
+			dst, tab,
+			GetFlowType(f), tab,
+			f.GetVerdict().String(), tab,
+			f.GetSummary(), newline,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to write out packet: %v", err)
+		}
+	case DictOutput:
+		if p.line != 0 {
+			// TODO: line length?
+			_, err := fmt.Fprintln(p.opts.w, "------------")
+			if err != nil {
+				return err
+			}
+		}
+		src, dst := p.GetHostNames(f)
+		// this is a little crude, but will do for now. should probably find the
+		// longest header and auto-format the keys
+		_, err := fmt.Fprint(p.opts.w,
+			"  TIMESTAMP: ", getTimestamp(f), newline,
+			"     SOURCE: ", src, newline,
+			"DESTINATION: ", dst, newline,
+			"       TYPE: ", GetFlowType(f), newline,
+			"    VERDICT: ", f.GetVerdict().String(), newline,
+			"    SUMMARY: ", f.GetSummary(), newline,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to write out packet: %v", err)
+		}
+	case CompactOutput:
+		src, dst := p.GetHostNames(f)
+		_, err := fmt.Fprintf(p.opts.w,
+			"%s [%s]: %s -> %s %s %s (%s)\n",
+			getTimestamp(f),
+			f.GetNodeName(),
+			src,
+			dst,
+			GetFlowType(f),
+			f.GetVerdict().String(),
+			f.GetSummary(),
+		)
+		if err != nil {
+			return fmt.Errorf("failed to write out packet: %v", err)
+		}
+	case JSONOutput:
+		return p.jsonEncoder.Encode(f)
+	}
+	p.line++
+	return nil
+}
+
+// MaybeTime returns a Millisecond precision timestamp, or "N/A" if nil.
+func MaybeTime(t *time.Time) string {
+	if t != nil {
+		// TODO: support more date formats through options to `hubble observe`
+		return t.Format(time.StampMilli)
+	}
+	return "N/A"
+}
+
+// UDPPort ...
+func (p *Printer) UDPPort(port layers.UDPPort) string {
+	i := int(port)
+	if !p.opts.enablePortTranslation {
+		return strconv.Itoa(i)
+	}
+	if name, ok := namedPorts[i]; ok {
+		return fmt.Sprintf("%v(%v)", i, name)
+	}
+	return port.String()
+}
+
+// TCPPort ...
+func (p *Printer) TCPPort(port layers.TCPPort) string {
+	i := int(port)
+	if !p.opts.enablePortTranslation {
+		return strconv.Itoa(i)
+	}
+	if name, ok := namedPorts[i]; ok {
+		return fmt.Sprintf("%v(%v)", i, name)
+	}
+	return port.String()
+}
+
+// Hostname returns a "host:ip" formatted pair for the given ip and port. If
+// port is empty, only the host is returned. The host part is either the pod or
+// service name (if set), or a comma-separated list of domain names (if set),
+// or just the ip address if EnableIPTranslation is false and/or there are no
+// pod nor service name and domain names.
+func (p *Printer) Hostname(ip, port string, ns, pod, svc string, names []string) (host string) {
+	host = ip
+	if p.opts.enableIPTranslation {
+		if pod != "" {
+			// path.Join omits the slash if ns is empty
+			host = path.Join(ns, pod)
+		} else if svc != "" {
+			host = path.Join(ns, svc)
+		} else if len(names) != 0 {
+			host = strings.Join(names, ",")
+		}
+	}
+
+	if port != "" && port != "0" {
+		return net.JoinHostPort(host, port)
+	}
+
+	return host
+}

--- a/vendor/github.com/cilium/hubble/pkg/time/time.go
+++ b/vendor/github.com/cilium/hubble/pkg/time/time.go
@@ -1,0 +1,46 @@
+// Copyright 2019 Authors of Hubble
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package time
+
+import (
+	"fmt"
+	"time"
+)
+
+var (
+	// Now is a hijackable function for time.Now() that makes unit testing a lot
+	// easier for stuff that relies on relative time.
+	Now = time.Now
+)
+
+// FromString takes as input a string in either RFC3339 or time.Duration
+// format in the past and converts it to a time.Time.
+func FromString(input string) (time.Time, error) {
+	// try as relative duration first
+	d, err := time.ParseDuration(input)
+	if err == nil {
+		return Now().Add(-d), nil
+	}
+
+	// try as rfc3339
+	t, err := time.Parse(time.RFC3339, input)
+	if err == nil {
+		return t, nil
+	}
+
+	return time.Time{}, fmt.Errorf(
+		"failed to convert %s to time", input,
+	)
+}

--- a/vendor/github.com/cilium/hubble/pkg/version.go
+++ b/vendor/github.com/cilium/hubble/pkg/version.go
@@ -1,0 +1,26 @@
+// Copyright 2020 Authors of Hubble
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkg
+
+// Version is the software version.
+const Version = "0.6.0-dev"
+
+// The following variables are set at compile time via LDFLAGS.
+var (
+	// GitBranch is the name of the git branch HEAD points to.
+	GitBranch string
+	// GitHash is the git checksum of the most recent commit in HEAD.
+	GitHash string
+)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -84,6 +84,16 @@ github.com/cilium/ebpf/asm
 github.com/cilium/ebpf/internal
 github.com/cilium/ebpf/internal/unix
 github.com/cilium/ebpf/perf
+# github.com/cilium/hubble v0.5.1-0.20200409144652-24bc03bef1db
+## explicit
+github.com/cilium/hubble/cmd
+github.com/cilium/hubble/cmd/observe
+github.com/cilium/hubble/cmd/status
+github.com/cilium/hubble/cmd/version
+github.com/cilium/hubble/pkg
+github.com/cilium/hubble/pkg/defaults
+github.com/cilium/hubble/pkg/printer
+github.com/cilium/hubble/pkg/time
 # github.com/cilium/ipam v0.0.0-20200217195329-a46f8d55f9db
 ## explicit
 github.com/cilium/ipam/service/allocator


### PR DESCRIPTION
This PR adds the `hubble` client binary to the Cilium docker image. This is achieved by making the cilium client command-line interface a hybrid binary. This means that depending on the name of the binary, it dispatches to either the Cilium or Hubble client CLI logic. To expose this, we also introduce a `hubble` symlink which points to the `cilium` binary.

This change increases the overall binary size of the client by roughly 650K (before: 46480K, after: 47132K).

Unfortunately, this change also re-introduces the cyclic dependency between the `github.com/cilium/cilium` and `github.com/cilium/hubble` modules which was removed in #10860. Cyclic go modules are supported, but sometimes yields unexpected results when updating the dependencies.