### PR TITLE
Clarify CRI-O installation

### DIFF
--- a/Documentation/kubernetes/configuration.rst
+++ b/Documentation/kubernetes/configuration.rst
@@ -355,9 +355,3 @@ After that you can restart CRI-O:
 
     minikube ssh -- sudo systemctl restart crio
 
-Finally, you need to restart the Cilium pod so it can re-mount
-``/var/run/crio/crio.sock`` which was recreated by CRI-O
-
-::
-
-    kubectl delete -n kube-system pod -l k8s-app=cilium

--- a/Documentation/kubernetes/configuration.rst
+++ b/Documentation/kubernetes/configuration.rst
@@ -331,6 +331,11 @@ If you want to use CRIO, generate the YAML using:
 
 .. include:: ../gettingstarted/k8s-install-download-release.rst
 
+.. note::
+
+   The helm ``--set global.containerRuntime.integration=crio`` might not be
+   required for your setup. For more info see :ref:`crio-known-issues`.
+
 .. parsed-literal::
 
    helm install cilium |CHART_RELEASE| \\
@@ -355,3 +360,27 @@ After that you can restart CRI-O:
 
     minikube ssh -- sudo systemctl restart crio
 
+.. _crio-known-issues:
+
+Common CRIO issues
+------------------
+
+Some CRI-O environments automatically mount the bpf filesystem in the pods,
+which is something that Cilium avoids doing when
+``--set global.containerRuntime.integration=crio`` is set. However, some
+CRI-O environments do not mount the bpf filesystem automatically which causes
+Cilium to print the follow message:
+
+.. parsed-literal::
+
+        level=warning msg="BPF system config check: NOT OK." error="CONFIG_BPF kernel parameter is required" subsys=linux-datapath
+        level=warning msg="================================= WARNING ==========================================" subsys=bpf
+        level=warning msg="BPF filesystem is not mounted. This will lead to network disruption when Cilium pods" subsys=bpf
+        level=warning msg="are restarted. Ensure that the BPF filesystem is mounted in the host." subsys=bpf
+        level=warning msg="https://docs.cilium.io/en/stable/kubernetes/requirements/#mounted-bpf-filesystem" subsys=bpf
+        level=warning msg="====================================================================================" subsys=bpf
+        level=info msg="Mounting BPF filesystem at /sys/fs/bpf" subsys=bpf
+
+If you see this warning in the Cilium pod logs with your CRI-O environment,
+please remove the flag ``--set global.containerRuntime.integration=crio`` from
+your helm setup and redeploy Cilium.


### PR DESCRIPTION
This will help users deploying Cilium on CRI-O environments so they can easily choose if they should either use `--set global.containerRuntime.integration=crio` or not since we can't perform that detection automatically.


Fixes https://github.com/cilium/cilium/issues/10852