### PR TITLE
Makefile: fix deepcopy generation for pkg/service/store

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -318,7 +318,6 @@ generate-k8s-api:
 	$(call generate_k8s_api_deepcopy,github.com/cilium/cilium,"pkg:loadbalancer")
 	$(call generate_k8s_api_deepcopy,github.com/cilium/cilium,"pkg:k8s")
 	$(call generate_k8s_api_deepcopy,github.com/cilium/cilium,"pkg:node")
-	$(call generate_k8s_api_deepcopy,github.com/cilium/cilium,"pkg:service")
 	$(call generate_k8s_api_deepcopy,github.com/cilium/cilium/api,"v1:models")
 	$(call generate_k8s_api_deepcopy,github.com/cilium/cilium/pkg,"k8s:types")
 	$(call generate_k8s_api_deepcopy,github.com/cilium/cilium/pkg,"maps:policymap")
@@ -336,6 +335,7 @@ generate-k8s-api:
 	$(call generate_k8s_api_deepcopy,github.com/cilium/cilium/pkg,"maps:signalmap")
 	$(call generate_k8s_api_deepcopy,github.com/cilium/cilium/pkg,"maps:neighborsmap")
 	$(call generate_k8s_api_deepcopy,github.com/cilium/cilium/pkg,"maps:fragmap")
+	$(call generate_k8s_api_deepcopy,github.com/cilium/cilium/pkg,"service:store")
 	$(call generate_k8s_api_deepcopy,github.com/cilium/cilium,"pkg:tuple")
 	$(call generate_k8s_api_deepcopy,github.com/cilium/cilium,"pkg:bpf")
 


### PR DESCRIPTION
Due recent refactoring the deepcopy generation of this new package was
not happening as it should.

Fixes: 9f73528e2d ("service: Isolate store sub-package")
Signed-off-by: André Martins <andre@cilium.io>
