### PR TITLE
docs: Fix "make render-docs" permissions issue

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -39,6 +39,9 @@ epub latex html: builder-image
 DOCS_PORT = 9081
 
 run-server: stop-server
+	# Work around Docker issue where this directory is created as root in
+	# the `--volume` parameter below. See also GH-10869.
+	$(QUIET)mkdir -p $(CURDIR)/_build/html/
 	$(QUIET)docker container run --rm \
 		--detach \
 		--interactive \


### PR DESCRIPTION
Some versions of docker, when passed the `--volume` flag, will create
the directory *as root* before launching the container, which caused
`make render-docs` to fail with a permissions issue like the following:

  Exception occurred:
    File "/usr/local/lib/python3.7/os.py", line 221, in makedirs
      mkdir(name, mode)
  PermissionError: [Errno 13] Permission denied: '/src/Documentation/_build/doctrees'

Fix it by creating the directory as the current user first.

Fixes: #10869