### PR TITLE
k8s/identitybackend: log error if AcquireReference fails

### DIFF
--- a/pkg/k8s/identitybackend/identity.go
+++ b/pkg/k8s/identitybackend/identity.go
@@ -217,10 +217,9 @@ func (c *crdBackend) RunGC(ctx context.Context, staleKeysPrevRound map[string]ui
 // reliablyMissing is true.
 // Note: the lock field is not supported with the k8s CRD allocator.
 func (c *crdBackend) UpdateKey(ctx context.Context, id idpool.ID, key allocator.AllocatorKey, reliablyMissing bool) error {
-	var err error
-
-	if err := c.AcquireReference(ctx, id, key, nil); err == nil {
-		log.WithError(err).WithFields(logrus.Fields{
+	err := c.AcquireReference(ctx, id, key, nil)
+	if err == nil {
+		log.WithFields(logrus.Fields{
 			logfields.Identity: id,
 			logfields.Labels:   key,
 		}).Debug("Acquired reference for identity")
@@ -229,7 +228,7 @@ func (c *crdBackend) UpdateKey(ctx context.Context, id idpool.ID, key allocator.
 
 	// The CRD (aka the master key) is missing. Try to recover by recreating it
 	// if reliablyMissing is set.
-	log.WithFields(logrus.Fields{
+	log.WithError(err).WithFields(logrus.Fields{
 		logfields.Identity: id,
 		logfields.Labels:   key,
 	}).Warning("Unable update CRD identity information with a reference for this node")


### PR DESCRIPTION
There has been occasions where Cilium would print the following warning:
`Unable update CRD identity information with a reference for this node`.
Unfortunately the underlying error was not printed so we need to add log
for it so we can have more information about the exact reason why this
warning is displayed.

Fixes: 8822c1d650f0 ("k8s: Add CRD Identities as an identity allocator backend")
Signed-off-by: André Martins <andre@cilium.io>

```release-note
Log more information for error 'Unable update CRD identity information with a reference for this node'
```