### PR TITLE
datapath/iptables: Masquerade hairpin traffic that traversed the stack

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -319,7 +319,7 @@ ct_recreate6:
 
 #ifdef ENABLE_ROUTING
 to_host:
-	if (is_defined(ENABLE_HOST_REDIRECT)) {
+	if (is_defined(HOST_REDIRECT_TO_INGRESS)) {
 		union macaddr host_mac = HOST_IFINDEX_MAC;
 
 		ret = ipv6_l3(ctx, l3_off, (__u8 *) &router_mac.addr, (__u8 *) &host_mac.addr, METRIC_EGRESS);
@@ -330,7 +330,7 @@ to_host:
 				  HOST_IFINDEX, reason, monitor);
 
 		cilium_dbg_capture(ctx, DBG_CAPTURE_DELIVERY, HOST_IFINDEX);
-		return redirect(HOST_IFINDEX, 0);
+		return redirect(HOST_IFINDEX, BPF_F_INGRESS);
 	}
 #endif
 
@@ -671,7 +671,7 @@ ct_recreate4:
 
 #ifdef ENABLE_ROUTING
 to_host:
-	if (is_defined(ENABLE_HOST_REDIRECT)) {
+	if (is_defined(HOST_REDIRECT_TO_INGRESS)) {
 		union macaddr host_mac = HOST_IFINDEX_MAC;
 
 		ret = ipv4_l3(ctx, l3_off, (__u8 *) &router_mac.addr, (__u8 *) &host_mac.addr, ip4);
@@ -682,11 +682,7 @@ to_host:
 				  reason, monitor);
 
 		cilium_dbg_capture(ctx, DBG_CAPTURE_DELIVERY, HOST_IFINDEX);
-#ifdef HOST_REDIRECT_TO_INGRESS
 		return redirect(HOST_IFINDEX, BPF_F_INGRESS);
-#else
-		return redirect(HOST_IFINDEX, 0);
-#endif
 	}
 #endif
 

--- a/examples/kubernetes/connectivity-check/connectivity-check.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check.yaml
@@ -73,9 +73,61 @@ spec:
       - name: echo-container
         image: docker.io/cilium/json-mock:1.0
         imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 80
+          hostPort: 40000
         readinessProbe:
           exec:
             command: ["curl", "-sS", "--fail", "-o", "/dev/null", "localhost"]
+---
+# The echo-b-host pod runs in host networking on the same node as echo-b.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: echo-b-host
+spec:
+  selector:
+    matchLabels:
+      name: echo-b-host
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: echo-b-host
+    spec:
+      hostNetwork: true
+      containers:
+      - name: echo-container
+        image: docker.io/cilium/json-mock:1.0
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: PORT
+          value: "41000"
+        readinessProbe:
+          exec:
+            command: ["curl", "-sS", "--fail", "-o", "/dev/null", "localhost:41000"]
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: name
+                operator: In
+                values:
+                - echo-b
+            topologyKey: "kubernetes.io/hostname"
+---
+# Connecting to "echo-b-host-headless" will provide service discovery to the
+# node IP on which echo-b* is running
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo-b-host-headless
+spec:
+  type: ClusterIP
+  clusterIP: None
+  selector:
+    name: echo-b-host
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -286,6 +338,45 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  name: pod-to-b-intra-node-hostport
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: pod-to-b-intra-node-hostport
+  template:
+    metadata:
+      labels:
+        name: pod-to-b-intra-node-hostport
+    spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: name
+                operator: In
+                values:
+                - echo-b
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - command:
+        - /bin/ash
+        - -c
+        - sleep 1000000000
+        image: docker.io/byrnedo/alpine-curl:0.1.8
+        imagePullPolicy: IfNotPresent 
+        livenessProbe:
+          exec:
+            command: [ "curl", "-sS", "--fail", "-o", "/dev/null", "echo-b-host-headless:40000" ]
+        readinessProbe:
+          exec:
+            command: [ "curl", "-sS", "--fail", "-o", "/dev/null", "echo-b-host-headless:40000" ]
+        name: pod-to-b-intra-node-hostport
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
   name: pod-to-b-intra-node
 spec:
   selector:
@@ -381,6 +472,45 @@ spec:
                 values:
                 - echo-b
             topologyKey: "kubernetes.io/hostname"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pod-to-b-multi-node-hostport
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: pod-to-b-multi-node-hostport
+  template:
+    metadata:
+      labels:
+        name: pod-to-b-multi-node-hostport
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: name
+                operator: In
+                values:
+                - echo-b
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - command:
+        - /bin/ash
+        - -c
+        - sleep 1000000000
+        image: docker.io/byrnedo/alpine-curl:0.1.8
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          exec:
+            command: [ "curl", "-sS", "--fail", "-o", "/dev/null", "echo-b-host-headless:40000" ]
+        readinessProbe:
+          exec:
+            command: [ "curl", "-sS", "--fail", "-o", "/dev/null", "echo-b-host-headless:40000" ]
+        name: pod-to-b-multi-node-hostport
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/examples/kubernetes/connectivity-check/echo-b.yaml
+++ b/examples/kubernetes/connectivity-check/echo-b.yaml
@@ -39,6 +39,58 @@ spec:
       - name: echo-container
         image: docker.io/cilium/json-mock:1.0
         imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 80
+          hostPort: 40000
         readinessProbe:
           exec:
             command: ["curl", "-sS", "--fail", "-o", "/dev/null", "localhost"]
+---
+# The echo-b-host pod runs in host networking on the same node as echo-b.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: echo-b-host
+spec:
+  selector:
+    matchLabels:
+      name: echo-b-host
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: echo-b-host
+    spec:
+      hostNetwork: true
+      containers:
+      - name: echo-container
+        image: docker.io/cilium/json-mock:1.0
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: PORT
+          value: "41000"
+        readinessProbe:
+          exec:
+            command: ["curl", "-sS", "--fail", "-o", "/dev/null", "localhost:41000"]
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: name
+                operator: In
+                values:
+                - echo-b
+            topologyKey: "kubernetes.io/hostname"
+---
+# Connecting to "echo-b-host-headless" will provide service discovery to the
+# node IP on which echo-b* is running
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo-b-host-headless
+spec:
+  type: ClusterIP
+  clusterIP: None
+  selector:
+    name: echo-b-host

--- a/examples/kubernetes/connectivity-check/pod-to-b-intra-node-hostport.yaml
+++ b/examples/kubernetes/connectivity-check/pod-to-b-intra-node-hostport.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pod-to-b-intra-node-hostport
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: pod-to-b-intra-node-hostport
+  template:
+    metadata:
+      labels:
+        name: pod-to-b-intra-node-hostport
+    spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: name
+                operator: In
+                values:
+                - echo-b
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - command:
+        - /bin/ash
+        - -c
+        - sleep 1000000000
+        image: docker.io/byrnedo/alpine-curl:0.1.8
+        imagePullPolicy: IfNotPresent 
+        livenessProbe:
+          exec:
+            command: [ "curl", "-sS", "--fail", "-o", "/dev/null", "echo-b-host-headless:40000" ]
+        readinessProbe:
+          exec:
+            command: [ "curl", "-sS", "--fail", "-o", "/dev/null", "echo-b-host-headless:40000" ]
+        name: pod-to-b-intra-node-hostport

--- a/examples/kubernetes/connectivity-check/pod-to-b-multi-node-hostport.yaml
+++ b/examples/kubernetes/connectivity-check/pod-to-b-multi-node-hostport.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pod-to-b-multi-node-hostport
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: pod-to-b-multi-node-hostport
+  template:
+    metadata:
+      labels:
+        name: pod-to-b-multi-node-hostport
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: name
+                operator: In
+                values:
+                - echo-b
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - command:
+        - /bin/ash
+        - -c
+        - sleep 1000000000
+        image: docker.io/byrnedo/alpine-curl:0.1.8
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          exec:
+            command: [ "curl", "-sS", "--fail", "-o", "/dev/null", "echo-b-host-headless:40000" ]
+        readinessProbe:
+          exec:
+            command: [ "curl", "-sS", "--fail", "-o", "/dev/null", "echo-b-host-headless:40000" ]
+        name: pod-to-b-multi-node-hostport

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -959,6 +959,35 @@ func (m *IptablesManager) InstallRules(ifName string) error {
 				"-j", "SNAT", "--to-source", node.GetHostMasqueradeIPv4().String()), false); err != nil {
 				return err
 			}
+
+			// Masquerade all traffic that originated from a local
+			// pod and thus carries a security identity and that
+			// was also DNAT'ed. It must be masqueraded to ensure
+			// that reverse NAT can be performed. Otherwise the
+			// reply traffic would be sent directly to the pod
+			// without traversing the Linux stack again.
+			//
+			// This is only done if EnableEndpointRoutes is
+			// disabled, if EnableEndpointRoutes is enabled, then
+			// all traffic always passes through the stack anyway.
+			//
+			// This is required for:
+			//  - portmap/host if both source and destination are
+			//    on the same node
+			//  - kiam if source and server are on the same node
+			if !option.Config.EnableEndpointRoutes {
+				if err := runProg("iptables", append(
+					m.waitArgs,
+					"-t", "nat",
+					"-A", ciliumPostNatChain,
+					"-m", "mark", "--mark", fmt.Sprintf("%#08x/%#08x", linux_defaults.MagicMarkIdentity, linux_defaults.MagicMarkHostMask),
+					"-o", localDeliveryInterface,
+					"-m", "conntrack", "--ctstate", "DNAT",
+					"-m", "comment", "--comment", "hairpin traffic that originated from a local pod",
+					"-j", "SNAT", "--to-source", node.GetHostMasqueradeIPv4().String()), false); err != nil {
+					return err
+				}
+			}
 		}
 	}
 

--- a/pkg/datapath/linux/linux_defaults/mark.go
+++ b/pkg/datapath/linux/linux_defaults/mark.go
@@ -67,6 +67,11 @@ const (
 	// MagicMarkHost determines that the traffic is sourced from the local
 	// host and not from a proxy.
 	MagicMarkHost int = 0x0C00
+
+	// MagicMarkIdentity determines that the traffic carries a security
+	// identity in the skb->mark
+	MagicMarkIdentity int = 0x0F00
+
 	// MagicMarkK8sMasq determines that the traffic should be masqueraded
 	// by kube-proxy in kubernetes environments.
 	MagicMarkK8sMasq int = 0x4000

--- a/test/k8sT/Conformance.go
+++ b/test/k8sT/Conformance.go
@@ -1,0 +1,86 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8sTest
+
+import (
+	. "github.com/cilium/cilium/test/ginkgo-ext"
+	"github.com/cilium/cilium/test/helpers"
+
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("K8sConformance", func() {
+	var kubectl *helpers.Kubectl
+	var ciliumFilename string
+	var connectivityCheckYaml string
+
+	BeforeAll(func() {
+		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
+		connectivityCheckYaml = kubectl.GetFilePath("../examples/kubernetes/connectivity-check/connectivity-check.yaml")
+		ciliumFilename = helpers.TimestampFilename("cilium.yaml")
+	})
+
+	BeforeEach(func() {
+		kubectl.NodeCleanMetadata()
+	})
+
+	AfterEach(func() {
+		kubectl.Delete(connectivityCheckYaml)
+		kubectl.DeleteCiliumDS()
+		ExpectAllPodsTerminated(kubectl)
+	})
+
+	AfterFailed(func() {
+		kubectl.CiliumReport(helpers.CiliumNamespace,
+			"cilium endpoint list")
+	})
+
+	AfterAll(func() {
+		DeployCiliumAndDNS(kubectl, ciliumFilename)
+		kubectl.CloseSSHClient()
+	})
+
+	JustAfterEach(func() {
+		blacklist := helpers.GetBadLogMessages()
+		kubectl.ValidateListOfErrorsInLogs(CurrentGinkgoTestDescription().Duration, blacklist)
+	})
+
+	deployCilium := func(options map[string]string) {
+		DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, options)
+
+		_, err := kubectl.CiliumNodesWait()
+		ExpectWithOffset(1, err).Should(BeNil(), "Failure while waiting for k8s nodes to be annotated by Cilium")
+
+		By("Making sure all endpoints are in ready state")
+		err = kubectl.CiliumEndpointWaitReady()
+		ExpectWithOffset(1, err).To(BeNil(), "Failure while waiting for all cilium endpoints to reach ready state")
+	}
+
+	Context("Portmap Chaining", func() {
+		It("Check connectivity-check compliance with portmap chaining", func() {
+			SkipIfIntegration(helpers.CIIntegrationFlannel)
+			SkipItIfNoKubeProxy()
+
+			deployCilium(map[string]string{
+				"global.cni.chainingMode": "portmap",
+			})
+
+			kubectl.ApplyDefault(connectivityCheckYaml).ExpectSuccess("cannot install connectivity-check")
+
+			err := kubectl.WaitforPods(helpers.DefaultNamespace, "", helpers.HelperTimeout)
+			ExpectWithOffset(1, err).Should(BeNil(), "connectivity-check pods are not ready after timeout")
+		})
+	})
+})


### PR DESCRIPTION
This PR builds on https://github.com/cilium/cilium/pull/10926

The traffic is sent to the stack and hairpin'ed back into a local pod
after a component on the stack has applied a DNAT rule, the traffic must
be SNATed to ensure the reverse NAT can take place. This can happen if
portmap or kiam is being used and redirection happens to a local
destination.

The masquerade filter must be limited as not all DNAT traffic may be
affected. NodePort traffic from a non-local source must remain
unmasqueraded in order for trafficPolicy=local to continue working.

Also, when EnableEndpointRoutes is enabled, traffic always traverses the
stack and must not be masqueraded either.

Fixes: #9784
Requires: #10926 