### PR TITLE
loader: Fix "Skipping symbol substitution" warnings

### DIFF
--- a/pkg/datapath/loader/cache.go
+++ b/pkg/datapath/loader/cache.go
@@ -37,27 +37,28 @@ import (
 const templateWatcherQueueSize = 10
 
 var ignoredELFPrefixes = []string{
-	"2/",                    // Calls within the endpoint
-	"HOST_IP",               // Global
-	"IPV6_NODEPORT",         // Global
-	"ROUTER_IP",             // Global
-	"SNAT_IPV6_EXTERNAL",    // Global
-	"cilium_call_policy",    // Global
-	"cilium_ct",             // All CT maps, including local
-	"cilium_encrypt_state",  // Global
-	"cilium_events",         // Global
-	"cilium_ipcache",        // Global
-	"cilium_lb",             // Global
-	"cilium_lxc",            // Global
-	"cilium_metrics",        // Global
-	"cilium_nodeport_neigh", // All nodeport neigh maps
-	"cilium_policy",         // All policy maps
-	"cilium_proxy",          // Global
-	"cilium_signals",        // Global
-	"cilium_snat",           // All SNAT maps
-	"cilium_tunnel",         // Global
-	"from-container",        // Prog name
-	"to-container",          // Prog name
+	"2/",                         // Calls within the endpoint
+	"HOST_IP",                    // Global
+	"IPV6_NODEPORT",              // Global
+	"ROUTER_IP",                  // Global
+	"SNAT_IPV6_EXTERNAL",         // Global
+	"cilium_call_policy",         // Global
+	"cilium_ct",                  // All CT maps, including local
+	"cilium_encrypt_state",       // Global
+	"cilium_events",              // Global
+	"cilium_ipcache",             // Global
+	"cilium_lb",                  // Global
+	"cilium_lxc",                 // Global
+	"cilium_metrics",             // Global
+	"cilium_nodeport_neigh",      // All nodeport neigh maps
+	"cilium_policy",              // All policy maps
+	"cilium_proxy",               // Global
+	"cilium_signals",             // Global
+	"cilium_snat",                // All SNAT maps
+	"cilium_tunnel",              // Global
+	"cilium_ipv4_frag_datagrams", // Global
+	"from-container",             // Prog name
+	"to-container",               // Prog name
 }
 
 // RestoreTemplates populates the object cache from templates on the filesystem

--- a/pkg/datapath/loader/cache.go
+++ b/pkg/datapath/loader/cache.go
@@ -59,6 +59,10 @@ var ignoredELFPrefixes = []string{
 	"cilium_ipv4_frag_datagrams", // Global
 	"from-container",             // Prog name
 	"to-container",               // Prog name
+	// Endpoint IPv6 address. It's possible for the template object to have
+	// these symbols while the endpoint doesn't, if IPv6 was just enabled and
+	// the endpoint restored.
+	"LXC_IP_",
 }
 
 // RestoreTemplates populates the object cache from templates on the filesystem

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -75,9 +75,6 @@ func (l *Loader) init(dp datapath.ConfigWriter, nodeCfg *datapath.LocalNodeConfi
 		if !option.Config.EnableIPv4 {
 			ignorePrefixes = append(ignorePrefixes, "LXC_IPV4")
 		}
-		if !option.Config.EnableIPv6 {
-			ignorePrefixes = append(ignorePrefixes, "LXC_IP_")
-		}
 		elf.IgnoreSymbolPrefixes(ignorePrefixes)
 	})
 	l.templateCache.Update(nodeCfg)

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -204,17 +204,18 @@ const (
 	DockerBridgeIP = "172.17.0.1"
 
 	// Logs messages that should not be in the cilium logs.
-	panicMessage      = "panic:"
-	deadLockHeader    = "POTENTIAL DEADLOCK:"                        // from github.com/sasha-s/go-deadlock/deadlock.go:header
-	segmentationFault = "segmentation fault"                         // from https://github.com/cilium/cilium/issues/3233
-	NACKreceived      = "NACK received for version"                  // from https://github.com/cilium/cilium/issues/4003
-	RunInitFailed     = "JoinEP: "                                   // from https://github.com/cilium/cilium/pull/5052
-	sizeMismatch      = "size mismatch for BPF map"                  // from https://github.com/cilium/cilium/issues/7851
-	emptyBPFInitArg   = "empty argument passed to bpf/init.sh"       // from https://github.com/cilium/cilium/issues/10228
-	RemovingMapMsg    = "Removing map to allow for property upgrade" // from https://github.com/cilium/cilium/pull/10626
-	logBufferMessage  = "Log buffer too small to dump verifier log"  // from https://github.com/cilium/cilium/issues/10517
-	ClangErrorsMsg    = " errors generated."                         // from https://github.com/cilium/cilium/issues/10857
-	ClangErrorMsg     = "1 error generated."                         // from https://github.com/cilium/cilium/issues/10857
+	panicMessage       = "panic:"
+	deadLockHeader     = "POTENTIAL DEADLOCK:"                        // from github.com/sasha-s/go-deadlock/deadlock.go:header
+	segmentationFault  = "segmentation fault"                         // from https://github.com/cilium/cilium/issues/3233
+	NACKreceived       = "NACK received for version"                  // from https://github.com/cilium/cilium/issues/4003
+	RunInitFailed      = "JoinEP: "                                   // from https://github.com/cilium/cilium/pull/5052
+	sizeMismatch       = "size mismatch for BPF map"                  // from https://github.com/cilium/cilium/issues/7851
+	emptyBPFInitArg    = "empty argument passed to bpf/init.sh"       // from https://github.com/cilium/cilium/issues/10228
+	RemovingMapMsg     = "Removing map to allow for property upgrade" // from https://github.com/cilium/cilium/pull/10626
+	logBufferMessage   = "Log buffer too small to dump verifier log"  // from https://github.com/cilium/cilium/issues/10517
+	ClangErrorsMsg     = " errors generated."                         // from https://github.com/cilium/cilium/issues/10857
+	ClangErrorMsg      = "1 error generated."                         // from https://github.com/cilium/cilium/issues/10857
+	symbolSubstitution = "Skipping symbol substitution"
 
 	// HelmTemplate is the location of the Helm templates to install Cilium
 	HelmTemplate = "../install/kubernetes/cilium"
@@ -261,17 +262,18 @@ const CiliumConfigMapPatchKvstoreAllocator = "cilium-cm-kvstore-allocator-patch.
 // badLogMessages is a map which key is a part of a log message which indicates
 // a failure if the message does not contain any part from value list.
 var badLogMessages = map[string][]string{
-	panicMessage:      nil,
-	deadLockHeader:    nil,
-	segmentationFault: nil,
-	NACKreceived:      nil,
-	RunInitFailed:     {"signal: terminated", "signal: killed"},
-	sizeMismatch:      nil,
-	emptyBPFInitArg:   nil,
-	RemovingMapMsg:    nil,
-	logBufferMessage:  nil,
-	ClangErrorsMsg:    nil,
-	ClangErrorMsg:     nil,
+	panicMessage:       nil,
+	deadLockHeader:     nil,
+	segmentationFault:  nil,
+	NACKreceived:       nil,
+	RunInitFailed:      {"signal: terminated", "signal: killed"},
+	sizeMismatch:       nil,
+	emptyBPFInitArg:    nil,
+	RemovingMapMsg:     nil,
+	logBufferMessage:   nil,
+	ClangErrorsMsg:     nil,
+	ClangErrorMsg:      nil,
+	symbolSubstitution: nil,
 }
 
 var ciliumCLICommands = map[string]string{


### PR DESCRIPTION
This pull request adds symbol substitution warnings to `badLogMessages` and fixes two occurrences in tests, namely `cilium_ipv4_frag_datagrams` and `LXC_IP_`. See commit messages for details.