### PR TITLE
endpoint: Avoid transient drops during policy map update

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1085,6 +1085,7 @@ func (e *Endpoint) applyPolicyMapChanges() (proxyChanges bool, err error) {
 	//  from the desired policy here.
 	adds, deletes := e.desiredPolicy.ConsumeMapChanges()
 
+	// Add policy map entries before deleting to avoid transient drops
 	for keyToAdd, entry := range adds {
 		// Keep the existing proxy port, if any
 		if entry.IsRedirectEntry() {
@@ -1124,6 +1125,12 @@ func (e *Endpoint) syncPolicyMap() error {
 	if e.realizedPolicy != e.desiredPolicy {
 		errors := 0
 
+		// Add policy map entries before deleting to avoid transient drops
+		err := e.addPolicyMapDelta()
+		if err != nil {
+			errors++
+		}
+
 		// Delete policy keys present in the realized state, but not present in the desired state
 		for keyToDelete := range e.realizedPolicy.PolicyMapState {
 			// If key that is in realized state is not in desired state, just remove it.
@@ -1132,11 +1139,6 @@ func (e *Endpoint) syncPolicyMap() error {
 					errors++
 				}
 			}
-		}
-
-		err := e.addPolicyMapDelta()
-		if err != nil {
-			errors++
 		}
 
 		if errors > 0 {


### PR DESCRIPTION
Always add new map entries before deleting old ones to make sure that
packets allowed by both old and new policy are not dropped while
updating the policy maps.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
