### PR TITLE
Use feature probes to detect kernel support for sockops

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -193,15 +193,11 @@ func (d *Daemon) init() error {
 		}
 
 		if option.Config.SockopsEnable {
-			disableSockops := func(err error) {
-				option.Config.SockopsEnable = false
-				log.WithError(err).Warn("Disabled '--sockops-enable' due to missing BPF kernel support")
-			}
 			eppolicymap.CreateEPPolicyMap()
 			if err := sockops.SockmapEnable(); err != nil {
-				disableSockops(err)
+				log.WithError(err).Error("Failed to enable Sockmap")
 			} else if err := sockops.SkmsgEnable(); err != nil {
-				disableSockops(err)
+				log.WithError(err).Error("Failed to enable Sockmsg")
 			} else {
 				sockmap.SockmapCreate()
 			}

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1086,6 +1086,7 @@ func initEnv(cmd *cobra.Command) {
 	}
 
 	initKubeProxyReplacementOptions()
+	initSockmapOption()
 
 	// If device has been specified, use it to derive better default
 	// allocation prefixes
@@ -1449,6 +1450,21 @@ func (d *Daemon) instantiateAPI() *restapi.CiliumAPI {
 	restAPI.PolicyGetIPHandler = NewGetIPHandler()
 
 	return restAPI
+}
+
+func initSockmapOption() {
+	if !option.Config.SockopsEnable {
+		return
+	}
+	if probes.NewProbeManager().GetMapTypes().HaveSockhashMapType {
+		k := probes.NewProbeManager().GetHelpers("sock_ops")
+		h := probes.NewProbeManager().GetHelpers("sk_msg")
+		if h != nil && k != nil {
+			return
+		}
+	}
+	log.Warn("BPF Sock ops not supported by kernel. Disabling '--sockops-enable' feature.")
+	option.Config.SockopsEnable = false
 }
 
 func initKubeProxyReplacementOptions() {

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
-	"strings"
 
 	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
@@ -67,12 +66,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 	})
 
 	JustAfterEach(func() {
-		blacklist := helpers.GetBadLogMessages()
-		if strings.Contains(CurrentGinkgoTestDescription().TestText, "sockops") {
-			delete(blacklist, helpers.ClangErrorsMsg)
-			delete(blacklist, helpers.ClangErrorMsg)
-		}
-		kubectl.ValidateListOfErrorsInLogs(CurrentGinkgoTestDescription().Duration, blacklist)
+		kubectl.ValidateNoErrorsInLogs(CurrentGinkgoTestDescription().Duration)
 	})
 
 	deployNetperf := func() {


### PR DESCRIPTION
This patch probes the kernel for bpf sockops support and validates
the user configuration for SockopsEnable.

Fixes: #10931
Signed-off-by: Swaminathan Vasudevan <svasudevan@suse.com>