### PR TITLE
endpoint: Do not skip datapath rewrites on duplicate regenerations

### DIFF
--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/cilium/pkg/api"
 	"github.com/cilium/cilium/pkg/endpoint"
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/k8s"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/labels"
@@ -294,9 +295,16 @@ func (d *Daemon) createEndpoint(ctx context.Context, epTemplate *models.Endpoint
 		}
 	}
 
+	// e.ID assigned here
 	err = d.endpointManager.AddEndpoint(d, ep, "Create endpoint from API PUT")
 	if err != nil {
 		return d.errorDuringCreation(ep, fmt.Errorf("unable to insert endpoint into manager: %s", err))
+	}
+
+	// Now that we have ep.ID we can pin the map from this point. This
+	// also has to happen before the first build takes place.
+	if err = ep.PinDatapathMap(); err != nil {
+		return d.errorDuringCreation(ep, fmt.Errorf("unable to pin datapath maps: %s", err))
 	}
 
 	// We need to update the the visibility policy after adding the endpoint in
@@ -314,7 +322,7 @@ func (d *Daemon) createEndpoint(ctx context.Context, epTemplate *models.Endpoint
 		})
 	}
 
-	ep.UpdateLabels(ctx, addLabels, infoLabels, true)
+	regenTriggered := ep.UpdateLabels(ctx, addLabels, infoLabels, true)
 
 	select {
 	case <-ctx.Done():
@@ -322,14 +330,25 @@ func (d *Daemon) createEndpoint(ctx context.Context, epTemplate *models.Endpoint
 	default:
 	}
 
-	// Now that we have ep.ID we can pin the map from this point. This
-	// also has to happen before the first build took place.
-	if err = ep.PinDatapathMap(); err != nil {
-		return d.errorDuringCreation(ep, fmt.Errorf("unable to pin datapath maps: %s", err))
+	if !regenTriggered {
+		regenMetadata := &regeneration.ExternalRegenerationMetadata{
+			Reason:            "Initial build on endpoint creation",
+			ParentContext:     ctx,
+			RegenerationLevel: regeneration.RegenerateWithDatapathRewrite,
+		}
+		build, err := ep.SetRegenerateStateIfAlive(regenMetadata)
+		if err != nil {
+			return d.errorDuringCreation(ep, err)
+		}
+		if build {
+			ep.Regenerate(regenMetadata)
+		}
 	}
 
-	if err := ep.RegenerateAfterCreation(ctx, epTemplate.SyncBuildEndpoint); err != nil {
-		return d.errorDuringCreation(ep, err)
+	if epTemplate.SyncBuildEndpoint {
+		if err := ep.WaitForFirstRegeneration(ctx); err != nil {
+			return d.errorDuringCreation(ep, err)
+		}
 	}
 
 	// The endpoint has been successfully created, stop the expiration
@@ -440,8 +459,14 @@ func (h *patchEndpointID) Handle(params PatchEndpointIDParams) middleware.Respon
 	}
 
 	if reason != "" {
-		if err := ep.RegenerateWait(reason); err != nil {
-			return api.Error(PatchEndpointIDFailedCode, err)
+		regenMetadata := &regeneration.ExternalRegenerationMetadata{
+			Reason:            reason,
+			RegenerationLevel: regeneration.RegenerateWithDatapathRewrite,
+		}
+		if !<-ep.Regenerate(regenMetadata) {
+			return api.Error(PatchEndpointIDFailedCode,
+				fmt.Errorf("error while regenerating endpoint."+
+					" For more info run: 'cilium endpoint get %d'", ep.ID))
 		}
 		// FIXME: Special return code to indicate regeneration happened?
 	}

--- a/daemon/cmd/policy.go
+++ b/daemon/cmd/policy.go
@@ -68,7 +68,10 @@ func (d *Daemon) policyUpdateTrigger(reasons []string) {
 	log.Debugf("Regenerating all endpoints")
 	reason := strings.Join(reasons, ", ")
 
-	regenerationMetadata := &regeneration.ExternalRegenerationMetadata{Reason: reason}
+	regenerationMetadata := &regeneration.ExternalRegenerationMetadata{
+		Reason:            reason,
+		RegenerationLevel: regeneration.RegenerateWithoutDatapath,
+	}
 	d.endpointManager.RegenerateAllEndpoints(regenerationMetadata)
 }
 
@@ -461,7 +464,10 @@ func reactToRuleUpdates(epsToBumpRevision, epsToRegen *policy.EndpointSet, rev u
 	})
 
 	// Regenerate all other endpoints.
-	regenMetadata := &regeneration.ExternalRegenerationMetadata{Reason: "policy rules added"}
+	regenMetadata := &regeneration.ExternalRegenerationMetadata{
+		Reason:            "policy rules added",
+		RegenerationLevel: regeneration.RegenerateWithoutDatapath,
+	}
 	epsToRegen.ForEachGo(&enqueueWaitGroup, func(ep policy.Endpoint) {
 		if ep != nil {
 			switch e := ep.(type) {

--- a/daemon/cmd/policy_test.go
+++ b/daemon/cmd/policy_test.go
@@ -71,7 +71,8 @@ var (
 	testEndpointID = uint16(1)
 
 	regenerationMetadata = &regeneration.ExternalRegenerationMetadata{
-		Reason: "test",
+		Reason:            "test",
+		RegenerationLevel: regeneration.RegenerateWithoutDatapath,
 	}
 
 	CNPAllowTCP80 = api.PortRule{

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -553,6 +553,12 @@ func (e *Endpoint) ProcessChangeRequest(newEp *Endpoint, validPatchTransitionSta
 			reason = "Waiting on endpoint regeneration because identity is known while handling API PATCH"
 		case StateWaitingForIdentity:
 			reason = "Waiting on endpoint initial program regeneration while handling API PATCH"
+		default:
+			// Caller skips regeneration if reason == "". Bump the skipped regeneration level so that next
+			// regeneration will realise endpoint changes.
+			if e.skippedRegenerationLevel < regeneration.RegenerateWithDatapathRewrite {
+				e.skippedRegenerationLevel = regeneration.RegenerateWithDatapathRewrite
+			}
 		}
 	}
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -279,6 +279,12 @@ type Endpoint struct {
 
 	eventQueue *eventqueue.EventQueue
 
+	// skippedRegenerationLevel is the DatapathRegenerationLevel of the regeneration event that
+	// was skipped due to another regeneration event already being queued, as indicated by
+	// state. A lower-level current regeneration is bumped to this level to cover for the
+	// skipped regeneration levels.
+	skippedRegenerationLevel regeneration.DatapathRegenerationLevel
+
 	// DatapathConfiguration is the endpoint's datapath configuration as
 	// passed in via the plugin that created the endpoint, e.g. the CNI
 	// plugin which performed the plumbing will enable certain datapath
@@ -866,19 +872,14 @@ func (e *Endpoint) Update(cfg *models.EndpointConfigurationSpec) error {
 		for {
 			select {
 			case <-ticker.C:
-				if err := e.lockAlive(); err != nil {
+				regen, err := e.SetRegenerateStateIfAlive(regenCtx)
+				if err != nil {
 					return err
 				}
-				// Check endpoint state before attempting configuration update because
-				// configuration updates can only be applied when the endpoint is in
-				// specific states. See GH-3058.
-				stateTransitionSucceeded := e.setState(StateWaitingToRegenerate, regenCtx.Reason)
-				if stateTransitionSucceeded {
-					e.unlock()
+				if regen {
 					e.Regenerate(regenCtx)
 					return nil
 				}
-				e.unlock()
 			case <-timeout:
 				e.getLogger().Warning("timed out waiting for endpoint state to change")
 				return UpdateStateChangeError{fmt.Sprintf("unable to regenerate endpoint program because state transition to %s was unsuccessful; check `cilium endpoint log %d` for more information", StateWaitingToRegenerate, e.ID)}
@@ -1021,19 +1022,6 @@ func (e *Endpoint) leaveLocked(proxyWaitGroup *completion.WaitGroup, conf Delete
 	e.getLogger().Info("Removed endpoint")
 
 	return errors
-}
-
-// RegenerateWait should only be called when endpoint's state has successfully
-// been changed to "waiting-to-regenerate"
-func (e *Endpoint) RegenerateWait(reason string) error {
-	if !<-e.Regenerate(&regeneration.ExternalRegenerationMetadata{
-		Reason:            reason,
-		RegenerationLevel: regeneration.RegenerateWithDatapathRewrite,
-	}) {
-		return fmt.Errorf("error while regenerating endpoint."+
-			" For more info run: 'cilium endpoint get %d'", e.ID)
-	}
-	return nil
 }
 
 // GetContainerName returns the name of the container for the endpoint.
@@ -1571,9 +1559,11 @@ func (e *Endpoint) IsInit() bool {
 // container runtime layer will periodically synchronize labels.
 //
 // If a net label changed was performed, the endpoint will receive a new
-// identity and will be regenerated. Both of these operations will happen in
-// the background.
-func (e *Endpoint) UpdateLabels(ctx context.Context, identityLabels, infoLabels pkgLabels.Labels, blocking bool) {
+// security identity and will be regenerated. Both of these operations will
+// run first synchronously if 'blocking' is true, and then in the background.
+//
+// Returns 'true' if endpoint regeneration was triggered.
+func (e *Endpoint) UpdateLabels(ctx context.Context, identityLabels, infoLabels pkgLabels.Labels, blocking bool) (regenTriggered bool) {
 	log.WithFields(logrus.Fields{
 		logfields.ContainerID:    e.GetShortContainerID(),
 		logfields.EndpointID:     e.StringID(),
@@ -1583,7 +1573,7 @@ func (e *Endpoint) UpdateLabels(ctx context.Context, identityLabels, infoLabels 
 
 	if err := e.lockAlive(); err != nil {
 		e.logDisconnectedMutexAction(err, "when trying to refresh endpoint labels")
-		return
+		return false
 	}
 
 	e.replaceInformationLabels(infoLabels)
@@ -1591,8 +1581,10 @@ func (e *Endpoint) UpdateLabels(ctx context.Context, identityLabels, infoLabels 
 	rev := e.replaceIdentityLabels(identityLabels)
 	e.unlock()
 	if rev != 0 {
-		e.runIdentityResolver(ctx, rev, blocking)
+		return e.runIdentityResolver(ctx, rev, blocking)
 	}
+
+	return false
 }
 
 func (e *Endpoint) identityResolutionIsObsolete(myChangeRev int) bool {
@@ -1609,13 +1601,14 @@ func (e *Endpoint) identityResolutionIsObsolete(myChangeRev int) bool {
 // are currently configured on the endpoint.
 //
 // Must be called with e.Mutex NOT held.
-func (e *Endpoint) runIdentityResolver(ctx context.Context, myChangeRev int, blocking bool) {
-	if err := e.rlockAlive(); err != nil {
+func (e *Endpoint) runIdentityResolver(ctx context.Context, myChangeRev int, blocking bool) (regenTriggered bool) {
+	err := e.rlockAlive()
+	if err != nil {
 		// If a labels update and an endpoint delete API request arrive
 		// in quick succession, this could occur; in that case, there's
 		// no point updating the controller.
 		e.getLogger().WithError(err).Info("Cannot run labels resolver")
-		return
+		return false
 	}
 	newLabels := e.OpLabels.IdentityLabels()
 	e.runlock()
@@ -1624,14 +1617,14 @@ func (e *Endpoint) runIdentityResolver(ctx context.Context, myChangeRev int, blo
 	// If we are certain we can resolve the identity without accessing the KV
 	// store, do it first synchronously right now. This can reduce the number
 	// of regenerations for the endpoint during its initialization.
+	regenTriggered = false
 	if blocking || identity.IdentityAllocationIsLocal(newLabels) {
 		scopedLog.Info("Resolving identity labels (blocking)")
-
-		err := e.identityLabelsChanged(ctx, myChangeRev)
+		regenTriggered, err = e.identityLabelsChanged(ctx, myChangeRev)
 		switch err {
 		case ErrNotAlive:
 			scopedLog.Debug("not changing endpoint identity because endpoint is in process of being removed")
-			return
+			return false
 		default:
 			if err != nil {
 				scopedLog.WithError(err).Warn("Error changing endpoint identity")
@@ -1645,7 +1638,7 @@ func (e *Endpoint) runIdentityResolver(ctx context.Context, myChangeRev int, blo
 	e.controllers.UpdateController(ctrlName,
 		controller.ControllerParams{
 			DoFunc: func(ctx context.Context) error {
-				err := e.identityLabelsChanged(ctx, myChangeRev)
+				_, err := e.identityLabelsChanged(ctx, myChangeRev)
 				switch err {
 				case ErrNotAlive:
 					e.getLogger().Debug("not changing endpoint identity because endpoint is in process of being removed")
@@ -1658,11 +1651,14 @@ func (e *Endpoint) runIdentityResolver(ctx context.Context, myChangeRev int, blo
 			Context:     e.aliveCtx,
 		},
 	)
+
+	return regenTriggered
 }
 
-func (e *Endpoint) identityLabelsChanged(ctx context.Context, myChangeRev int) error {
-	if err := e.rlockAlive(); err != nil {
-		return ErrNotAlive
+func (e *Endpoint) identityLabelsChanged(ctx context.Context, myChangeRev int) (regenTriggered bool, err error) {
+	// e.setState() called below, can't take a read lock.
+	if err := e.lockAlive(); err != nil {
+		return false, ErrNotAlive
 	}
 	newLabels := e.OpLabels.IdentityLabels()
 	elog := e.getLogger().WithFields(logrus.Fields{
@@ -1672,9 +1668,9 @@ func (e *Endpoint) identityLabelsChanged(ctx context.Context, myChangeRev int) e
 
 	// Since we unlocked the endpoint and re-locked, the label update may already be obsolete
 	if e.identityResolutionIsObsolete(myChangeRev) {
-		e.runlock()
+		e.unlock()
 		elog.Debug("Endpoint identity has changed, aborting resolution routine in favour of new one")
-		return nil
+		return false, nil
 	}
 
 	if e.SecurityIdentity != nil && e.SecurityIdentity.Labels.Equals(newLabels) {
@@ -1682,13 +1678,13 @@ func (e *Endpoint) identityLabelsChanged(ctx context.Context, myChangeRev int) e
 		if e.getState() == StateWaitingForIdentity {
 			e.setState(StateReady, "Set identity for this endpoint")
 		}
-		e.runlock()
+		e.unlock()
 		elog.Debug("Endpoint labels unchanged, skipping resolution of identity")
-		return nil
+		return false, nil
 	}
 
 	// Unlock the endpoint mutex for the possibly long lasting kvstore operation
-	e.runlock()
+	e.unlock()
 	elog.Debug("Resolving identity for labels")
 
 	allocateCtx, cancel := context.WithTimeout(context.Background(), option.Config.KVstoreConnectivityTimeout)
@@ -1698,7 +1694,7 @@ func (e *Endpoint) identityLabelsChanged(ctx context.Context, myChangeRev int) e
 	if err != nil {
 		err = fmt.Errorf("unable to resolve identity: %s", err)
 		e.LogStatus(Other, Warning, fmt.Sprintf("%s (will retry)", err.Error()))
-		return err
+		return false, err
 	}
 
 	// When releasing identities after allocation due to either failure of
@@ -1720,7 +1716,7 @@ func (e *Endpoint) identityLabelsChanged(ctx context.Context, myChangeRev int) e
 
 	if err := e.lockAlive(); err != nil {
 		releaseNewlyAllocatedIdentity()
-		return err
+		return false, err
 	}
 
 	// Since we unlocked the endpoint and re-locked, the label update may already be obsolete
@@ -1729,7 +1725,7 @@ func (e *Endpoint) identityLabelsChanged(ctx context.Context, myChangeRev int) e
 
 		releaseNewlyAllocatedIdentity()
 
-		return nil
+		return false, nil
 	}
 
 	// If endpoint has an old identity, defer release of it to the end of
@@ -1752,14 +1748,14 @@ func (e *Endpoint) identityLabelsChanged(ctx context.Context, myChangeRev int) e
 
 			if err := e.lockAlive(); err != nil {
 				releaseNewlyAllocatedIdentity()
-				return err
+				return false, err
 			}
 
 			// Since we unlocked the endpoint and re-locked, the label update may already be obsolete
 			if e.identityResolutionIsObsolete(myChangeRev) {
 				e.unlock()
 				releaseNewlyAllocatedIdentity()
-				return nil
+				return false, nil
 			}
 		}
 	}
@@ -1778,6 +1774,10 @@ func (e *Endpoint) identityLabelsChanged(ctx context.Context, myChangeRev int) e
 	}
 
 	readyToRegenerate := false
+	regenMetadata := &regeneration.ExternalRegenerationMetadata{
+		Reason:            "updated security labels",
+		RegenerationLevel: regeneration.RegenerateWithDatapathRewrite,
+	}
 
 	// Regeneration is only triggered once the endpoint ID has been
 	// assigned. This ensures that on the initial creation, the endpoint is
@@ -1788,7 +1788,7 @@ func (e *Endpoint) identityLabelsChanged(ctx context.Context, myChangeRev int) e
 	// called, the controller calling identityLabelsChanged() will trigger
 	// the regeneration as soon as the identity is known.
 	if e.ID != 0 {
-		readyToRegenerate = e.setState(StateWaitingToRegenerate, "Triggering regeneration due to new identity")
+		readyToRegenerate = e.setRegenerateStateLocked(regenMetadata)
 	}
 
 	// Unconditionally force policy recomputation after a new identity has been
@@ -1798,13 +1798,10 @@ func (e *Endpoint) identityLabelsChanged(ctx context.Context, myChangeRev int) e
 	e.unlock()
 
 	if readyToRegenerate {
-		e.Regenerate(&regeneration.ExternalRegenerationMetadata{
-			Reason:            "updated security labels",
-			RegenerationLevel: regeneration.RegenerateWithDatapathRewrite,
-		})
+		e.Regenerate(regenMetadata)
 	}
 
-	return nil
+	return readyToRegenerate, nil
 }
 
 // SetPolicyRevision sets the endpoint's policy revision with the given
@@ -2114,57 +2111,11 @@ func (e *Endpoint) GetProxyInfoByFields() (uint64, string, string, []string, str
 	return e.GetID(), e.GetIPv4Address(), e.GetIPv6Address(), e.GetLabels(), e.GetLabelsSHA(), uint64(e.GetIdentity()), err
 }
 
-// RegenerateAfterCreation handles the first regeneration of an endpoint after
-// it is created.
-// After a call to `Regenerate` on the endpoint is made, `endpointStartFunc`
-// is invoked - this can be used as a callback to expose the endpoint to other
-// subsystems if needed.
-// If syncBuild is true, this function waits for specific conditions until
-// returning:
+// WaitForFirstRegeneration waits for specific conditions before returning:
 // * if the endpoint has a sidecar proxy, it waits for the endpoint's BPF
 // program to be generated for the first time.
 // * otherwise, waits for the endpoint to complete its first full regeneration.
-func (e *Endpoint) RegenerateAfterCreation(ctx context.Context, syncBuild bool) error {
-	if err := e.lockAlive(); err != nil {
-		return fmt.Errorf("endpoint was deleted while processing the request")
-	}
-
-	build := e.getState() == StateReady
-	if build {
-		e.setState(StateWaitingToRegenerate, "Identity is known at endpoint creation time")
-	}
-	e.unlock()
-
-	if build {
-		// Do not synchronously regenerate the endpoint when first creating it.
-		// We have custom logic later for waiting for specific checkpoints to be
-		// reached upon regeneration later (checking for when BPF programs have
-		// been compiled), as opposed to waiting for the entire regeneration to
-		// be complete (including proxies being configured). This is done to
-		// avoid a chicken-and-egg problem with L7 policies are imported which
-		// select the endpoint being generated, as when such policies are
-		// imported, regeneration blocks on waiting for proxies to be
-		// configured. When Cilium is used with Istio, though, the proxy is
-		// started as a sidecar, and is not launched yet when this specific code
-		// is executed; if we waited for regeneration to be complete, including
-		// proxy configuration, this code would effectively deadlock addition
-		// of endpoints.
-		e.Regenerate(&regeneration.ExternalRegenerationMetadata{
-			Reason:            "Initial build on endpoint creation",
-			ParentContext:     ctx,
-			RegenerationLevel: regeneration.RegenerateWithDatapathRewrite,
-		})
-	}
-
-	// Wait for endpoint to be in "ready" state if specified in API call.
-	if !syncBuild {
-		return nil
-	}
-
-	return e.waitForFirstRegeneration(ctx)
-}
-
-func (e *Endpoint) waitForFirstRegeneration(ctx context.Context) error {
+func (e *Endpoint) WaitForFirstRegeneration(ctx context.Context) error {
 	e.getLogger().Info("Waiting for endpoint to be generated")
 
 	// Default timeout for PUT /endpoint/{id} is 60 seconds, so put timeout

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -833,7 +833,8 @@ func (e *Endpoint) Update(cfg *models.EndpointConfigurationSpec) error {
 	// Note: This "retry" behaviour is better suited to a controller, and can be
 	// moved there once we have an endpoint regeneration controller.
 	regenCtx := &regeneration.ExternalRegenerationMetadata{
-		Reason: "endpoint was updated via API",
+		Reason:            "endpoint was updated via API",
+		RegenerationLevel: regeneration.RegenerateWithoutDatapath,
 	}
 
 	// If configuration options are provided, we only regenerate if necessary.
@@ -1025,7 +1026,10 @@ func (e *Endpoint) leaveLocked(proxyWaitGroup *completion.WaitGroup, conf Delete
 // RegenerateWait should only be called when endpoint's state has successfully
 // been changed to "waiting-to-regenerate"
 func (e *Endpoint) RegenerateWait(reason string) error {
-	if !<-e.Regenerate(&regeneration.ExternalRegenerationMetadata{Reason: reason}) {
+	if !<-e.Regenerate(&regeneration.ExternalRegenerationMetadata{
+		Reason:            reason,
+		RegenerationLevel: regeneration.RegenerateWithDatapathRewrite,
+	}) {
 		return fmt.Errorf("error while regenerating endpoint."+
 			" For more info run: 'cilium endpoint get %d'", e.ID)
 	}
@@ -1794,7 +1798,10 @@ func (e *Endpoint) identityLabelsChanged(ctx context.Context, myChangeRev int) e
 	e.unlock()
 
 	if readyToRegenerate {
-		e.Regenerate(&regeneration.ExternalRegenerationMetadata{Reason: "updated security labels"})
+		e.Regenerate(&regeneration.ExternalRegenerationMetadata{
+			Reason:            "updated security labels",
+			RegenerationLevel: regeneration.RegenerateWithDatapathRewrite,
+		})
 	}
 
 	return nil
@@ -2143,8 +2150,9 @@ func (e *Endpoint) RegenerateAfterCreation(ctx context.Context, syncBuild bool) 
 		// proxy configuration, this code would effectively deadlock addition
 		// of endpoints.
 		e.Regenerate(&regeneration.ExternalRegenerationMetadata{
-			Reason:        "Initial build on endpoint creation",
-			ParentContext: ctx,
+			Reason:            "Initial build on endpoint creation",
+			ParentContext:     ctx,
+			RegenerationLevel: regeneration.RegenerateWithDatapathRewrite,
 		})
 	}
 

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -442,7 +442,7 @@ func (e *Endpoint) RegenerateIfAlive(regenMetadata *regeneration.ExternalRegener
 		state := e.getState()
 		switch state {
 		case StateRestoring, StateWaitingToRegenerate:
-			e.setState(state, fmt.Sprintf("Skipped duplicate endpoint regeneration trigger due to %s", regenMetadata.Reason))
+			e.logStatusLocked(Other, OK, fmt.Sprintf("Skipped duplicate endpoint regeneration trigger due to %s", regenMetadata.Reason))
 			regen = false
 		default:
 			regen = e.setState(StateWaitingToRegenerate, fmt.Sprintf("Triggering endpoint regeneration due to %s", regenMetadata.Reason))

--- a/pkg/endpoint/regeneration/regeneration_context.go
+++ b/pkg/endpoint/regeneration/regeneration_context.go
@@ -23,9 +23,12 @@ import (
 type DatapathRegenerationLevel int
 
 const (
+	// Invalid is the default level to enforce explicit setting of
+	// the regeneration level.
+	Invalid DatapathRegenerationLevel = iota
 	// RegenerateWithoutDatapath indicates that datapath rebuild or reload
 	// is not required to implement this regeneration.
-	RegenerateWithoutDatapath DatapathRegenerationLevel = iota
+	RegenerateWithoutDatapath
 	// RegenerateWithDatapathLoad indicates that the datapath must be
 	// reloaded but not recompiled to implement this regeneration.
 	RegenerateWithDatapathLoad
@@ -40,6 +43,8 @@ const (
 // String converts a DatapathRegenerationLevel into a human-readable string.
 func (r DatapathRegenerationLevel) String() string {
 	switch r {
+	case Invalid:
+		return "invalid"
 	case RegenerateWithoutDatapath:
 		return "no-rebuild"
 	case RegenerateWithDatapathLoad:

--- a/pkg/endpoint/regenerationcontext.go
+++ b/pkg/endpoint/regenerationcontext.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/revert"
 )
 
@@ -46,6 +47,10 @@ type regenerationContext struct {
 }
 
 func ParseExternalRegenerationMetadata(ctx context.Context, c context.CancelFunc, e *regeneration.ExternalRegenerationMetadata) *regenerationContext {
+	if e.RegenerationLevel == regeneration.Invalid {
+		log.WithField(logfields.Reason, e.Reason).Errorf("Uninitialized regeneration level")
+	}
+
 	return &regenerationContext{
 		Reason: e.Reason,
 		datapathRegenerationContext: &datapathRegenerationContext{

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -166,7 +166,8 @@ func (e *Endpoint) RegenerateAfterRestore() error {
 	scopedLog := log.WithField(logfields.EndpointID, e.ID)
 
 	regenerationMetadata := &regeneration.ExternalRegenerationMetadata{
-		Reason: "syncing state to host",
+		Reason:            "syncing state to host",
+		RegenerationLevel: regeneration.RegenerateWithDatapathRewrite,
 	}
 	if buildSuccess := <-e.Regenerate(regenerationMetadata); !buildSuccess {
 		scopedLog.Warn("Failed while regenerating endpoint")

--- a/pkg/endpoint/restore_test.go
+++ b/pkg/endpoint/restore_test.go
@@ -90,7 +90,8 @@ func (ds *EndpointSuite) endpointCreator(id uint16, secID identity.NumericIdenti
 
 var (
 	regenerationMetadata = &regeneration.ExternalRegenerationMetadata{
-		Reason: "test",
+		Reason:            "test",
+		RegenerationLevel: regeneration.RegenerateWithoutDatapath,
 	}
 )
 

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -242,15 +242,16 @@ func (k *K8sWatcher) updateK8sPodV1(oldK8sPod, newK8sPod *types.Pod) error {
 }
 
 func realizePodAnnotationUpdate(podEP *endpoint.Endpoint) {
+	regenMetadata := &regeneration.ExternalRegenerationMetadata{
+		Reason:            "annotations updated",
+		RegenerationLevel: regeneration.RegenerateWithoutDatapath,
+	}
 	// No need to log an error if the state transition didn't succeed,
 	// if it didn't succeed that means the endpoint is being deleted, or
 	// another regeneration has already been queued up for this endpoint.
-	stateTransitionSucceeded := podEP.SetState(endpoint.StateWaitingToRegenerate, "annotations updated")
-	if stateTransitionSucceeded {
-		podEP.Regenerate(&regeneration.ExternalRegenerationMetadata{
-			Reason:            "annotations updated",
-			RegenerationLevel: regeneration.RegenerateWithoutDatapath,
-		})
+	regen, _ := podEP.SetRegenerateStateIfAlive(regenMetadata)
+	if regen {
+		podEP.Regenerate(regenMetadata)
 	}
 }
 

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -215,7 +215,8 @@ const (
 	logBufferMessage   = "Log buffer too small to dump verifier log"  // from https://github.com/cilium/cilium/issues/10517
 	ClangErrorsMsg     = " errors generated."                         // from https://github.com/cilium/cilium/issues/10857
 	ClangErrorMsg      = "1 error generated."                         // from https://github.com/cilium/cilium/issues/10857
-	symbolSubstitution = "Skipping symbol substitution"
+	symbolSubstitution = "Skipping symbol substitution"               //
+	uninitializedRegen = "Uninitialized regeneration level"           // from https://github.com/cilium/cilium/pull/10949
 
 	// HelmTemplate is the location of the Helm templates to install Cilium
 	HelmTemplate = "../install/kubernetes/cilium"
@@ -274,6 +275,7 @@ var badLogMessages = map[string][]string{
 	ClangErrorsMsg:     nil,
 	ClangErrorMsg:      nil,
 	symbolSubstitution: nil,
+	uninitializedRegen: nil,
 }
 
 var ciliumCLICommands = map[string]string{


### PR DESCRIPTION
Store the highest skipped regeneration level when skipping a duplicate endpoint regeneration, so that the queued regeneration can be performed on the required level.

```release-note
Do not skip datapath rewrites when an otherwise duplicate endpoint regeneration requires it.
```
