### PR TITLE
Fix issue where --enable-remote-node-identity=false was not respected

### DIFF
--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -178,6 +178,8 @@ static __always_inline int handle_ipv4(struct __ctx_buff *ctx, __u32 *identity)
 		}
 	}
 
+	cilium_dbg(ctx, DBG_DECAP, key.tunnel_id, key.tunnel_label);
+
 #ifdef ENABLE_IPSEC
 	if (!decrypted) {
 		/* IPSec is not currently enforce (feature coming soon)

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -50,7 +50,7 @@ static __always_inline int handle_ipv6(struct __ctx_buff *ctx,
 
 	decrypted = ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_DECRYPT);
 	if (decrypted) {
-		*identity = get_identity(ctx);
+		*identity = key.tunnel_id = get_identity(ctx);
 	} else {
 		if (unlikely(ctx_get_tunnel_key(ctx, &key, sizeof(key), 0) < 0))
 			return DROP_NO_TUNNEL_KEY;
@@ -59,9 +59,8 @@ static __always_inline int handle_ipv6(struct __ctx_buff *ctx,
 		/* Any node encapsulating will map any HOST_ID source to be
 		 * presented as REMOTE_NODE_ID, therefore any attempt to signal
 		 * HOST_ID as source from a remote node can be droppped. */
-		if (*identity == HOST_ID) {
+		if (*identity == HOST_ID)
 			return DROP_INVALID_IDENTITY;
-		}
 	}
 
 	cilium_dbg(ctx, DBG_DECAP, key.tunnel_id, key.tunnel_label);
@@ -79,7 +78,7 @@ static __always_inline int handle_ipv6(struct __ctx_buff *ctx,
 
 		/* Decrypt "key" is determined by SPI */
 		ctx->mark = MARK_MAGIC_DECRYPT;
-		set_identity_mark(ctx, key.tunnel_id);
+		set_identity_mark(ctx, *identity);
 		/* To IPSec stack on cilium_vxlan we are going to pass
 		 * this up the stack but eth_type_trans has already labeled
 		 * this as an OTHERHOST type packet. To avoid being dropped
@@ -89,7 +88,7 @@ static __always_inline int handle_ipv6(struct __ctx_buff *ctx,
 		ctx_change_type(ctx, PACKET_HOST);
 		return CTX_ACT_OK;
 	} else {
-		key.tunnel_id = get_identity(ctx);
+		*identity = get_identity(ctx);
 		ctx->mark = 0;
 	}
 not_esp:
@@ -107,7 +106,7 @@ not_esp:
 		if (hdrlen < 0)
 			return hdrlen;
 
-		return ipv6_local_delivery(ctx, l3_off, key.tunnel_id, ep, METRIC_INGRESS);
+		return ipv6_local_delivery(ctx, l3_off, *identity, ep, METRIC_INGRESS);
 	}
 
 to_host:
@@ -167,15 +166,14 @@ static __always_inline int handle_ipv4(struct __ctx_buff *ctx, __u32 *identity)
 	decrypted = ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_DECRYPT);
 	/* If packets are decrypted the key has already been pushed into metadata. */
 	if (decrypted) {
-		*identity = get_identity(ctx);
+		*identity = key.tunnel_id = get_identity(ctx);
 	} else {
 		if (unlikely(ctx_get_tunnel_key(ctx, &key, sizeof(key), 0) < 0))
 			return DROP_NO_TUNNEL_KEY;
 		*identity = key.tunnel_id;
 
-		if (*identity == HOST_ID) {
+		if (*identity == HOST_ID)
 			return DROP_INVALID_IDENTITY;
-		}
 	}
 
 	cilium_dbg(ctx, DBG_DECAP, key.tunnel_id, key.tunnel_label);
@@ -192,7 +190,7 @@ static __always_inline int handle_ipv4(struct __ctx_buff *ctx, __u32 *identity)
 		}
 
 		ctx->mark = MARK_MAGIC_DECRYPT;
-		set_identity_mark(ctx, key.tunnel_id);
+		set_identity_mark(ctx, *identity);
 		/* To IPSec stack on cilium_vxlan we are going to pass
 		 * this up the stack but eth_type_trans has already labeled
 		 * this as an OTHERHOST type packet. To avoid being dropped
@@ -202,7 +200,7 @@ static __always_inline int handle_ipv4(struct __ctx_buff *ctx, __u32 *identity)
 		ctx_change_type(ctx, PACKET_HOST);
 		return CTX_ACT_OK;
 	} else {
-		key.tunnel_id = get_identity(ctx);
+		*identity = get_identity(ctx);
 		ctx->mark = 0;
 	}
 not_esp:
@@ -215,7 +213,7 @@ not_esp:
 		if (ep->flags & ENDPOINT_F_HOST)
 			goto to_host;
 
-		return ipv4_local_delivery(ctx, ETH_HLEN, key.tunnel_id, ip4, ep, METRIC_INGRESS);
+		return ipv4_local_delivery(ctx, ETH_HLEN, *identity, ip4, ep, METRIC_INGRESS);
 	}
 
 to_host:

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -205,6 +205,10 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		cDefinesMap["ENABLE_SERVICES"] = "1"
 	}
 
+	if option.Config.EnableRemoteNodeIdentity {
+		cDefinesMap["ENABLE_REMOTE_NODE_ID"] = "1"
+	}
+
 	if option.Config.EnableHostReachableServices {
 		if option.Config.EnableHostServicesTCP {
 			cDefinesMap["ENABLE_HOST_SERVICES_TCP"] = "1"


### PR DESCRIPTION
Review commit-by-commit.

First two patches are minor observability / refactoring changes to prepare for the third patch. Here's the third patch commit message:

    bpf: Fix traffic drop due to remote node identity
    
    Previously, it was possible for a remote node to set the remote-node
    identity and transmit the packet through the tunnel to the destination,
    which would make a policy check using this as the source, *even if
    --enable-remote-node-identity was set to false*.
    
    This patch aims to continue to transmit the remote-node identity on the
    wire for source verification purposes, but if the user has configured
    --enable-remote-node-identity to false, then when the traffic is
    received with this identity as the source, it will replace it with the
    host identity and run through policy for the host. This is expected to
    be equivalent to the host identity logic in Cilium v1.6 or earlier.
    
    Note that the decap debug message will continue to report the real
    source identity originally seen in the packet, but subsequent debug,
    policy, and drop notifications (and policy logic) will consider the
    identity to be 'host'.
    
Fixes: #10702