### PR TITLE
Redirect lxc tx packets directly to the host device

### DIFF
--- a/bpf/lib/eth.h
+++ b/bpf/lib/eth.h
@@ -71,4 +71,12 @@ static __always_inline int eth_store_daddr(struct __ctx_buff *ctx, __u8 *mac,
 	return ctx_store_bytes(ctx, off, mac, ETH_ALEN, 0);
 }
 
+static __always_inline int _eth_store_from_fib(struct __ctx_buff *ctx, struct bpf_fib_lookup *fib_params) {
+	if (eth_store_daddr(ctx, fib_params->dmac, 0) < 0)
+		return DROP_WRITE_ERROR;
+	if (eth_store_saddr(ctx, fib_params->smac, 0) < 0)
+		return DROP_WRITE_ERROR;
+	return 0;
+}
+
 #endif /* __LIB_ETH__ */


### PR DESCRIPTION

Signed-off-by: Nate Sweet <nathanjsweet@pm.me>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->
 Redirect packets that are egressing from a container directly to the host network device so that they can skip most of the network stack.

```release-note
Added fib lookups to egressing container traffic to route it to the correct device more quickly than traversing the Linux network datapath would by default.
```
