### PR TITLE
daemon: Fix TriggerReloadWithoutCompile comment

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -571,6 +571,7 @@ func (d *Daemon) Close() {
 	d.nodeDiscovery.Close()
 }
 
+// TriggerReloadWithoutCompile causes all BPF programs and maps to be reloaded,
 // without recompiling the datapath logic for each endpoint. It first attempts
 // to recompile the base programs, and if this fails returns an error. If base
 // program load is successful, it subsequently triggers regeneration of all


### PR DESCRIPTION
An earlier commit unintentionally dropped the first line of description
for this function, bring it back.

Fixes: 532ad9d44a6f ("rm pkg/workloads")