### PR TITLE
docker, runtime: only build clang and llc targets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN make LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 V=$V LIBNETWORK_PLUGIN=$LIBNETWORK_PLU
 # built while allowing the new versions to make changes that are not
 # backwards compatible.
 #
-FROM quay.io/cilium/cilium-runtime:2020-03-25
+FROM quay.io/cilium/cilium-runtime:2020-04-14
 LABEL maintainer="maintainer@cilium.io"
 COPY --from=builder /tmp/install /
 COPY --from=cilium-envoy / /

--- a/contrib/packaging/docker/Dockerfile.runtime
+++ b/contrib/packaging/docker/Dockerfile.runtime
@@ -58,7 +58,7 @@ cd llvm/ && \
 git checkout -b d941df363d1cb621a3836b909c37d79f2a3e27e2 d941df363d1cb621a3836b909c37d79f2a3e27e2 && \
 cd llvm/build && \
 cmake .. -G "Ninja" -DLLVM_TARGETS_TO_BUILD="BPF" -DLLVM_ENABLE_PROJECTS="clang" -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DLLVM_BUILD_RUNTIME=OFF && \
-ninja && \
+ninja clang llc && \
 strip bin/clang && \
 strip bin/llc && \
 cp bin/clang /usr/bin/clang && \

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -155,6 +155,18 @@ var _ = Describe("K8sServicesTest", func() {
 		}
 	}
 
+	testCurlRequestFail := func(clientPodLabel, url string) {
+		pods, err := kubectl.GetPodNames(helpers.DefaultNamespace, clientPodLabel)
+		ExpectWithOffset(1, err).Should(BeNil(), "cannot retrieve pod names by filter %q", testDSClient)
+		for _, pod := range pods {
+			res := kubectl.ExecPodCmd(
+				helpers.DefaultNamespace, pod,
+				helpers.CurlFail(url))
+			ExpectWithOffset(1, res).ShouldNot(helpers.CMDSuccess(),
+				"Pod %q can unexpectedly connect to service %q", pod, url)
+		}
+	}
+
 	waitPodsDs := func() {
 		groups := []string{testDS, testDSClient, testDSK8s2}
 		for _, pod := range groups {
@@ -659,13 +671,13 @@ var _ = Describe("K8sServicesTest", func() {
 				// From pod via loopback (host reachable services)
 				httpURL = getHTTPLink("127.0.0.1", data.Spec.Ports[0].NodePort)
 				tftpURL = getTFTPLink("127.0.0.1", data.Spec.Ports[1].NodePort)
-				testCurlRequest(testDSClient, httpURL)
-				testCurlRequest(testDSClient, tftpURL)
+				testCurlRequestFail(testDSClient, httpURL)
+				testCurlRequestFail(testDSClient, tftpURL)
 
 				httpURL = getHTTPLink("::ffff:127.0.0.1", data.Spec.Ports[0].NodePort)
 				tftpURL = getTFTPLink("::ffff:127.0.0.1", data.Spec.Ports[1].NodePort)
-				testCurlRequest(testDSClient, httpURL)
-				testCurlRequest(testDSClient, tftpURL)
+				testCurlRequestFail(testDSClient, httpURL)
+				testCurlRequestFail(testDSClient, tftpURL)
 
 				// From pod via local cilium_host
 				httpURL = getHTTPLink(localCiliumHostIPv4, data.Spec.Ports[0].NodePort)
@@ -874,10 +886,6 @@ var _ = Describe("K8sServicesTest", func() {
 				Expect(err).Should(BeNil(), "Cannot retrieve local cilium_host ipv4")
 				remoteCiliumHostIPv4, err := kubectl.GetCiliumHostIPv4(context.TODO(), k8s2Name)
 				Expect(err).Should(BeNil(), "Cannot retrieve remote cilium_host ipv4")
-
-				// From pod via loopback (host reachable services)
-				doFragmentedRequest(clientPod, clientIP, helpers.K8s1, serverPort, "127.0.0.1", nodePort)
-				doFragmentedRequest(clientPod, clientIP, helpers.K8s1, serverPort, "::ffff:127.0.0.1", nodePort)
 
 				// From pod via local cilium_host
 				doFragmentedRequest(clientPod, clientIP, helpers.K8s1, serverPort, localCiliumHostIPv4, nodePort)


### PR DESCRIPTION
Specify only the targets we need from the llvm build, namely `clang` and
`llc`. This reduces the amount of objects to build by ~300 and thus
also reduces build time a bit.

(Edit from @borkmann: added the test update commit which fixes below issue)

Fixes: #10882