### PR TITLE
Preparatory refactoring for dynamic BPF map sizing

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -273,7 +273,7 @@ func NewDaemon(ctx context.Context, dp datapath.Datapath) (*Daemon, *endpointRes
 	ctmap.InitMapInfo(option.Config.CTMapEntriesGlobalTCP, option.Config.CTMapEntriesGlobalAny,
 		option.Config.EnableIPv4, option.Config.EnableIPv6,
 	)
-	policymap.InitMapInfo(option.Config.PolicyMapMaxEntries)
+	policymap.InitMapInfo(option.Config.PolicyMapEntries)
 	fragmap.InitMapInfo(option.Config.FragmentsMapEntries)
 
 	if option.Config.DryMode == false {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -540,6 +540,18 @@ const (
 	// LimitTableMax defines the maximum CT or NAT table limit
 	LimitTableMax = 1 << 24 // 16Mi entries (~1GiB of entries per map)
 
+	// PolicyMapMin defines the minimum policy map limit.
+	PolicyMapMin = 1 << 8
+
+	// PolicyMapMax defines the maximum policy map limit.
+	PolicyMapMax = 1 << 16
+
+	// FragmentsMapMin defines the minimum fragments map limit.
+	FragmentsMapMin = 1 << 8
+
+	// FragmentsMapMax defines the maximum fragments map limit.
+	FragmentsMapMax = 1 << 16
+
 	// NATMapEntriesGlobalName configures max entries for BPF NAT table
 	NATMapEntriesGlobalName = "bpf-nat-global-max"
 
@@ -2170,26 +2182,24 @@ func (c *DaemonConfig) Validate() error {
 		}
 	}
 
-	policyMapMin := (1 << 8)
-	policyMapMax := (1 << 16)
-	if c.PolicyMapMaxEntries < policyMapMin {
+	if c.PolicyMapMaxEntries < PolicyMapMin {
 		return fmt.Errorf("specified PolicyMap max entries %d must exceed minimum %d",
-			c.PolicyMapMaxEntries, policyMapMin)
+			c.PolicyMapMaxEntries, PolicyMapMin)
 	}
-	if c.PolicyMapMaxEntries > policyMapMax {
+	if c.PolicyMapMaxEntries > PolicyMapMax {
 		return fmt.Errorf("specified PolicyMap max entries %d must not exceed maximum %d",
-			c.PolicyMapMaxEntries, policyMapMax)
+			c.PolicyMapMaxEntries, PolicyMapMax)
 	}
-	fragmentsMapMin := (1 << 8)
-	fragmentsMapMax := (1 << 16)
-	if c.FragmentsMapEntries < fragmentsMapMin {
+
+	if c.FragmentsMapEntries < FragmentsMapMin {
 		return fmt.Errorf("specified fragments tracking map max entries %d must exceed minimum %d",
-			c.FragmentsMapEntries, fragmentsMapMin)
+			c.FragmentsMapEntries, FragmentsMapMin)
 	}
-	if c.FragmentsMapEntries > fragmentsMapMax {
+	if c.FragmentsMapEntries > FragmentsMapMax {
 		return fmt.Errorf("specified fragments tracking map max entries %d must not exceed maximum %d",
-			c.FragmentsMapEntries, fragmentsMapMax)
+			c.FragmentsMapEntries, FragmentsMapMax)
 	}
+
 	// Validate that the KVStore Lease TTL value lies between a particular range.
 	if c.KVstoreLeaseTTL > defaults.KVstoreLeaseMaxTTL || c.KVstoreLeaseTTL < defaults.LockLeaseTTL {
 		return fmt.Errorf("KVstoreLeaseTTL does not lie in required range(%ds, %ds)",

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1431,9 +1431,9 @@ type DaemonConfig struct {
 	// in the BPF NAT table
 	NATMapEntriesGlobal int
 
-	// PolicyMapMaxEntries is the maximum number of peer identities that an
+	// PolicyMapEntries is the maximum number of peer identities that an
 	// endpoint may allow traffic to exchange traffic with.
-	PolicyMapMaxEntries int
+	PolicyMapEntries int
 
 	// DisableCiliumEndpointCRD disables the use of CiliumEndpoint CRD
 	DisableCiliumEndpointCRD bool
@@ -2182,13 +2182,13 @@ func (c *DaemonConfig) Validate() error {
 		}
 	}
 
-	if c.PolicyMapMaxEntries < PolicyMapMin {
+	if c.PolicyMapEntries < PolicyMapMin {
 		return fmt.Errorf("specified PolicyMap max entries %d must exceed minimum %d",
-			c.PolicyMapMaxEntries, PolicyMapMin)
+			c.PolicyMapEntries, PolicyMapMin)
 	}
-	if c.PolicyMapMaxEntries > PolicyMapMax {
+	if c.PolicyMapEntries > PolicyMapMax {
 		return fmt.Errorf("specified PolicyMap max entries %d must not exceed maximum %d",
-			c.PolicyMapMaxEntries, PolicyMapMax)
+			c.PolicyMapEntries, PolicyMapMax)
 	}
 
 	if c.FragmentsMapEntries < FragmentsMapMin {
@@ -2435,7 +2435,7 @@ func (c *DaemonConfig) Populate() {
 	c.NodesGCInterval = viper.GetDuration(NodesGCInterval)
 	c.FlannelMasterDevice = viper.GetString(FlannelMasterDevice)
 	c.FlannelUninstallOnExit = viper.GetBool(FlannelUninstallOnExit)
-	c.PolicyMapMaxEntries = viper.GetInt(PolicyMapEntriesName)
+	c.PolicyMapEntries = viper.GetInt(PolicyMapEntriesName)
 	c.PProf = viper.GetBool(PProf)
 	c.PreAllocateMaps = viper.GetBool(PreAllocateMapsName)
 	c.PrependIptablesChains = viper.GetBool(PrependIptablesChainsName)


### PR DESCRIPTION
Some preparatory refactoring before the next iteration of #10780.

This moves the checking of the map size limits to its own, testable function and adds accompanying tests.

Reviewable by commit.