### PR TITLE
bpf: atomically replace XDP program when in same XDP mode

### DIFF
--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -132,13 +132,6 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 		return err
 	}
 
-	scopedLog := log.WithField(logfields.XDPDevice, option.Config.XDPDevice)
-	if option.Config.XDPDevice != "undefined" {
-		if err := ProbeXDP(option.Config.XDPDevice, option.Config.XDPMode); err != nil {
-			scopedLog.WithError(err).Warn("Turning off XDP acceleration")
-			option.Config.XDPDevice = "undefined"
-		}
-	}
 	if option.Config.XDPDevice != "undefined" {
 		args[initArgXDPDevice] = option.Config.XDPDevice
 		args[initArgXDPMode] = option.Config.XDPMode
@@ -148,6 +141,8 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 	}
 
 	if option.Config.DevicePreFilter != "undefined" {
+		scopedLog := log.WithField(logfields.XDPDevice, option.Config.XDPDevice)
+
 		preFilter, err := prefilter.NewPreFilter()
 		if err != nil {
 			scopedLog.WithError(ret).Warn("Unable to init prefilter")

--- a/pkg/datapath/loader/link.go
+++ b/pkg/datapath/loader/link.go
@@ -16,11 +16,8 @@ package loader
 
 import (
 	"fmt"
-	"os/exec"
 
 	"github.com/cilium/cilium/pkg/option"
-
-	"golang.org/x/sys/unix"
 )
 
 func SetXDPMode(mode string) error {
@@ -43,29 +40,6 @@ func SetXDPMode(mode string) error {
 		}
 	case option.XDPModeNone:
 		break
-	}
-	return nil
-}
-
-// ProbeXDP checks whether a given XDP mode is supported for the specified device
-func ProbeXDP(device, mode string) error {
-	cmd := exec.Command("ip", "-force", "link", "set", "dev", device, mode, "off")
-	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("Cannot run ip command: %v", err)
-	}
-	if err := cmd.Wait(); err != nil {
-		if exiterr, ok := err.(*exec.ExitError); ok {
-			if status, ok := exiterr.Sys().(unix.WaitStatus); ok {
-				switch status.ExitStatus() {
-				case 2:
-					return fmt.Errorf("Mode %s not supported on device %s", mode, device)
-				default:
-					return fmt.Errorf("XDP not supported on OS")
-				}
-			}
-		} else {
-			return fmt.Errorf("Cannot wait for ip command: %v", err)
-		}
 	}
 	return nil
 }


### PR DESCRIPTION
So far we've just been blindly removing the XDP program from the specified
networking device before loading it. This is really suboptimal as for native
XDP this will cause an down/up cycle of the device and therefore leads to
loss of traffic and service interruption upon agent restart or upgrade.

Instead, just test whether the XDP mode mismatches and if that is the case
only then remove the pre-existing programs from the device.

This also means we need to remove the ProbeXDP() function since it tried to
crudely probe whether the given mode was supported by removing a preexisting
program before executing the init.sh setup script.

Also, it is better to fail hard here anyway instead of just probing XDP and
then turning it off in the daemon via warning. If users opted-in, then the
expectation should be that either everything loads fine or we fail hard.

Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>
