### PR TITLE
Refactor pkg/identity to minimize dependencies

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -300,7 +300,7 @@ func NewDaemon(ctx context.Context, dp datapath.Datapath) (*Daemon, *endpointRes
 	})
 	if option.Config.EnableWellKnownIdentities {
 		// Must be done before calling policy.NewPolicyRepository() below.
-		num := identity.InitWellKnownIdentities()
+		num := identity.InitWellKnownIdentities(option.Config)
 		metrics.IdentityCount.Add(float64(num))
 	}
 

--- a/pkg/clustermesh/clustermesh_test.go
+++ b/pkg/clustermesh/clustermesh_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/lock"
+	fakeConfig "github.com/cilium/cilium/pkg/option/fake"
 	"github.com/cilium/cilium/pkg/testutils"
 	"github.com/cilium/cilium/pkg/testutils/allocator"
 
@@ -102,7 +103,7 @@ func (s *ClusterMeshTestSuite) TestClusterMesh(c *C) {
 	kvstore.SetupDummy("etcd")
 	defer kvstore.Client().Close()
 
-	identity.InitWellKnownIdentities()
+	identity.InitWellKnownIdentities(&fakeConfig.Config{})
 	// The nils are only used by k8s CRD identities. We default to kvstore.
 	mgr := cache.NewCachingIdentityAllocator(&allocator.IdentityAllocatorOwnerMock{})
 	<-mgr.InitIdentityAllocator(nil, nil)

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/lock"
+	fakeConfig "github.com/cilium/cilium/pkg/option/fake"
 	"github.com/cilium/cilium/pkg/rand"
 	"github.com/cilium/cilium/pkg/testutils"
 	"github.com/cilium/cilium/pkg/testutils/allocator"
@@ -68,7 +69,7 @@ func (s *ClusterMeshServicesTestSuite) SetUpTest(c *C) {
 
 	kvstore.Client().DeletePrefix(context.TODO(), "cilium/state/services/v1/"+s.randomName)
 	s.svcCache = k8s.NewServiceCache(fakeDatapath.NewNodeAddressing())
-	identity.InitWellKnownIdentities()
+	identity.InitWellKnownIdentities(&fakeConfig.Config{})
 
 	mgr := cache.NewCachingIdentityAllocator(&allocator.IdentityAllocatorOwnerMock{})
 	// The nils are only used by k8s CRD identities. We default to kvstore.

--- a/pkg/clustermesh/types/types.go
+++ b/pkg/clustermesh/types/types.go
@@ -1,0 +1,23 @@
+// Copyright 2016-2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+const (
+	// ClusterIDMin is the minimum value of the cluster ID
+	ClusterIDMin = 0
+
+	// ClusterIDMax is the maximum value of the cluster ID
+	ClusterIDMax = 255
+)

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/option"
+	fakeConfig "github.com/cilium/cilium/pkg/option/fake"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/testutils/allocator"
@@ -103,7 +104,7 @@ func (s *EndpointSuite) Datapath() datapath.Datapath {
 func (s *EndpointSuite) SetUpTest(c *C) {
 	/* Required to test endpoint CEP policy model */
 	kvstore.SetupDummy("etcd")
-	identity.InitWellKnownIdentities()
+	identity.InitWellKnownIdentities(&fakeConfig.Config{})
 	// The nils are only used by k8s CRD identities. We default to kvstore.
 	mgr := cache.NewCachingIdentityAllocator(&allocator.IdentityAllocatorOwnerMock{})
 	<-mgr.InitIdentityAllocator(nil, nil)

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
+	fakeConfig "github.com/cilium/cilium/pkg/option/fake"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/proxy/logger"
@@ -130,7 +131,7 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 	kvstore.SetupDummy("etcd")
 	defer kvstore.Client().Close()
 
-	identity.InitWellKnownIdentities()
+	identity.InitWellKnownIdentities(&fakeConfig.Config{})
 	idAllocatorOwner := &DummyIdentityAllocatorOwner{}
 
 	mgr := cache.NewCachingIdentityAllocator(idAllocatorOwner)

--- a/pkg/identity/cache/allocation_test.go
+++ b/pkg/identity/cache/allocation_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
+	fakeConfig "github.com/cilium/cilium/pkg/option/fake"
 
 	. "gopkg.in/check.v1"
 )
@@ -225,7 +226,7 @@ func (ias *IdentityAllocatorSuite) TestEventWatcherBatching(c *C) {
 }
 
 func (ias *IdentityAllocatorSuite) TestGetIdentityCache(c *C) {
-	identity.InitWellKnownIdentities()
+	identity.InitWellKnownIdentities(&fakeConfig.Config{})
 	// The nils are only used by k8s CRD identities. We default to kvstore.
 	mgr := NewCachingIdentityAllocator(newDummyOwner())
 	<-mgr.InitIdentityAllocator(nil, nil)
@@ -243,7 +244,7 @@ func (ias *IdentityAllocatorSuite) TestAllocator(c *C) {
 	lbls3 := labels.NewLabelsFromSortedList("id=bar;user=susan")
 
 	owner := newDummyOwner()
-	identity.InitWellKnownIdentities()
+	identity.InitWellKnownIdentities(&fakeConfig.Config{})
 	// The nils are only used by k8s CRD identities. We default to kvstore.
 	mgr := NewCachingIdentityAllocator(owner)
 	<-mgr.InitIdentityAllocator(nil, nil)
@@ -328,7 +329,7 @@ func (ias *IdentityAllocatorSuite) TestLocalAllocation(c *C) {
 	lbls1 := labels.NewLabelsFromSortedList("cidr:192.0.2.3/32")
 
 	owner := newDummyOwner()
-	identity.InitWellKnownIdentities()
+	identity.InitWellKnownIdentities(&fakeConfig.Config{})
 	// The nils are only used by k8s CRD identities. We default to kvstore.
 	mgr := NewCachingIdentityAllocator(owner)
 	<-mgr.InitIdentityAllocator(nil, nil)

--- a/pkg/identity/cache/cache_test.go
+++ b/pkg/identity/cache/cache_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
-	"github.com/cilium/cilium/pkg/option"
+	fakeConfig "github.com/cilium/cilium/pkg/option/fake"
 
 	. "gopkg.in/check.v1"
 )
@@ -47,17 +47,7 @@ type IdentityCacheTestSuite struct{}
 
 var _ = Suite(&IdentityCacheTestSuite{})
 
-func (s *IdentityCacheTestSuite) SetUpTest(c *C) {
-	option.Config.K8sNamespace = "kube-system"
-}
-
 func (s *IdentityCacheTestSuite) TestLookupReservedIdentity(c *C) {
-	bak := option.Config.ClusterName
-	option.Config.ClusterName = "default"
-	defer func() {
-		option.Config.ClusterName = bak
-	}()
-
 	mgr := NewCachingIdentityAllocator(newDummyOwner())
 	<-mgr.InitIdentityAllocator(nil, nil)
 
@@ -75,7 +65,7 @@ func (s *IdentityCacheTestSuite) TestLookupReservedIdentity(c *C) {
 	c.Assert(id, Not(IsNil))
 	c.Assert(id.ID, Equals, worldID)
 
-	identity.InitWellKnownIdentities()
+	identity.InitWellKnownIdentities(&fakeConfig.Config{})
 
 	id = mgr.LookupIdentity(context.TODO(), kvstoreLabels)
 	c.Assert(id, Not(IsNil))

--- a/pkg/identity/numericidentity_test.go
+++ b/pkg/identity/numericidentity_test.go
@@ -17,7 +17,7 @@
 package identity
 
 import (
-	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/clustermesh/types"
 
 	. "gopkg.in/check.v1"
 )
@@ -26,7 +26,7 @@ func (s *IdentityTestSuite) TestLocalIdentity(c *C) {
 	localID := NumericIdentity(LocalIdentityFlag | 1)
 	c.Assert(localID.HasLocalScope(), Equals, true)
 
-	maxClusterID := NumericIdentity(option.ClusterIDMax | 1)
+	maxClusterID := NumericIdentity(types.ClusterIDMax | 1)
 	c.Assert(maxClusterID.HasLocalScope(), Equals, false)
 
 	c.Assert(ReservedIdentityWorld.HasLocalScope(), Equals, false)
@@ -54,12 +54,12 @@ func (s *IdentityTestSuite) TestClusterID(c *C) {
 			clusterID: 255,
 		},
 		{ // make sure we support min/max configuration values
-			identity:  option.ClusterIDMin << 16,
-			clusterID: option.ClusterIDMin,
+			identity:  types.ClusterIDMin << 16,
+			clusterID: types.ClusterIDMin,
 		},
 		{
-			identity:  option.ClusterIDMax << 16,
-			clusterID: option.ClusterIDMax,
+			identity:  types.ClusterIDMax << 16,
+			clusterID: types.ClusterIDMax,
 		},
 	}
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/common"
 	"github.com/cilium/cilium/pkg/cidr"
+	clustermeshTypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/lock"
@@ -493,12 +494,6 @@ const (
 
 	// ClusterIDName is the name of the ClusterID option
 	ClusterIDName = "cluster-id"
-
-	// ClusterIDMin is the minimum value of the cluster ID
-	ClusterIDMin = 0
-
-	// ClusterIDMax is the maximum value of the cluster ID
-	ClusterIDMax = 255
 
 	// ClusterMeshConfigName is the name of the ClusterMeshConfig option
 	ClusterMeshConfigName = "clustermesh-config"
@@ -2087,6 +2082,17 @@ func (c *DaemonConfig) EndpointStatusIsEnabled(option string) bool {
 	return ok
 }
 
+// LocalClusterName returns the name of the cluster Cilium is deployed in
+func (c *DaemonConfig) LocalClusterName() string {
+	return c.ClusterName
+}
+
+// CiliumNamespaceName returns the name of the namespace in which Cilium is
+// deployed in
+func (c *DaemonConfig) CiliumNamespaceName() string {
+	return c.K8sNamespace
+}
+
 func (c *DaemonConfig) validateIPv6ClusterAllocCIDR() error {
 	ip, cidr, err := net.ParseCIDR(c.IPv6ClusterAllocCIDR)
 	if err != nil {
@@ -2132,9 +2138,9 @@ func (c *DaemonConfig) Validate() error {
 		return fmt.Errorf("invalid tunnel mode '%s', valid modes = {%s}", c.Tunnel, GetTunnelModes())
 	}
 
-	if c.ClusterID < ClusterIDMin || c.ClusterID > ClusterIDMax {
+	if c.ClusterID < clustermeshTypes.ClusterIDMin || c.ClusterID > clustermeshTypes.ClusterIDMax {
 		return fmt.Errorf("invalid cluster id %d: must be in range %d..%d",
-			c.ClusterID, ClusterIDMin, ClusterIDMax)
+			c.ClusterID, clustermeshTypes.ClusterIDMin, clustermeshTypes.ClusterIDMax)
 	}
 
 	if c.ClusterID != 0 {

--- a/pkg/option/fake/config.go
+++ b/pkg/option/fake/config.go
@@ -1,0 +1,28 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fake
+
+type Config struct{}
+
+// LocalClusterName returns the name of the cluster Cilium is deployed in
+func (f *Config) LocalClusterName() string {
+	return "default"
+}
+
+// CiliumNamespaceName returns the name of the namespace in which Cilium is
+// deployed in
+func (f *Config) CiliumNamespaceName() string {
+	return "kube-system"
+}


### PR DESCRIPTION
This helps remove the dependencies `pkg/option` and `pkg/metrics` for the majority of users of the identity type.