### PR TITLE
pkg/logging: redirect klog output to logrus

### DIFF
--- a/operator/flags.go
+++ b/operator/flags.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"time"
 
@@ -25,7 +24,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"k8s.io/klog"
 )
 
 func init() {
@@ -207,13 +205,4 @@ func init() {
 	option.BindEnv(option.K8sHeartbeatTimeout)
 
 	viper.BindPFlags(flags)
-
-	// Make sure that klog logging variables are initialized so that we can
-	// update them from this file.
-	klog.InitFlags(nil)
-
-	// Make sure klog (used by the client-go dependency) logs to stderr, as it
-	// will try to log to directories that may not exist in the cilium-operator
-	// container (/tmp) and cause the cilium-operator to exit.
-	flag.Set("logtostderr", "true")
 }

--- a/pkg/hubble/container/ring_reader_test.go
+++ b/pkg/hubble/container/ring_reader_test.go
@@ -154,7 +154,11 @@ func TestRingReader_Next(t *testing.T) {
 }
 
 func TestRingReader_NextFollow(t *testing.T) {
-	defer goleak.VerifyNone(t)
+	defer goleak.VerifyNone(
+		t,
+		// ignore go routines started by the redirect we do from klog to logrus
+		goleak.IgnoreTopFunction("k8s.io/klog.(*loggingT).flushDaemon"),
+		goleak.IgnoreTopFunction("io.(*pipe).Read"))
 	ring := NewRing(15)
 	for i := 0; i < 15; i++ {
 		ring.Write(&v1.Event{Timestamp: &timestamp.Timestamp{Seconds: int64(i)}})

--- a/pkg/hubble/container/ring_test.go
+++ b/pkg/hubble/container/ring_test.go
@@ -560,7 +560,11 @@ func TestRingFunctionalitySerialized(t *testing.T) {
 }
 
 func TestRing_ReadFrom_Test_1(t *testing.T) {
-	defer goleak.VerifyNone(t)
+	defer goleak.VerifyNone(
+		t,
+		// ignore go routines started by the redirect we do from klog to logrus
+		goleak.IgnoreTopFunction("k8s.io/klog.(*loggingT).flushDaemon"),
+		goleak.IgnoreTopFunction("io.(*pipe).Read"))
 	r := NewRing(0xf)
 	if len(r.data) != 0x10 {
 		t.Errorf("r.data should have a lenght of 0x10. Got %x", len(r.data))
@@ -613,7 +617,11 @@ func TestRing_ReadFrom_Test_1(t *testing.T) {
 }
 
 func TestRing_ReadFrom_Test_2(t *testing.T) {
-	defer goleak.VerifyNone(t)
+	defer goleak.VerifyNone(
+		t,
+		// ignore go routines started by the redirect we do from klog to logrus
+		goleak.IgnoreTopFunction("k8s.io/klog.(*loggingT).flushDaemon"),
+		goleak.IgnoreTopFunction("io.(*pipe).Read"))
 	r := NewRing(0xf)
 	if len(r.data) != 0x10 {
 		t.Errorf("r.data should have a length of 0x10. Got %x", len(r.data))
@@ -691,7 +699,11 @@ func TestRing_ReadFrom_Test_2(t *testing.T) {
 }
 
 func TestRing_ReadFrom_Test_3(t *testing.T) {
-	defer goleak.VerifyNone(t)
+	defer goleak.VerifyNone(
+		t,
+		// ignore go routines started by the redirect we do from klog to logrus
+		goleak.IgnoreTopFunction("k8s.io/klog.(*loggingT).flushDaemon"),
+		goleak.IgnoreTopFunction("io.(*pipe).Read"))
 	r := NewRing(0xf)
 	if len(r.data) != 0x10 {
 		t.Errorf("r.data should have a length of 0x10. Got %x", len(r.data))


### PR DESCRIPTION
klog currently redirects all of its output to stderr which might
prevent users from detecting potentially error messages generated by
klog since the logging format is different from logrus. Redirecting klog
output to logrus will make the logging messages consistent.

Master:
```
level=info msg="Waiting until all pre-existing resources related to policy have been received" subsys=k8s-watcher
W0410 09:55:21.017837   31587 reflector.go:402] githu....
```
With commit:
```
level=info msg="Waiting until all pre-existing resources related to policy have been received" subsys=k8s-watcher
level=warning msg="github.com/cilium/cilium/pkg/k8s/watchers/network_p...
level=info msg="github.com/cilium/cilium/pkg/k8s/watchers/network_p...
```

Unfortunately, klog as a bug / feature that prints the each log level
message on each writer. This will be fixed upstream.

Candidate to backport this to 1.7?