### PR TITLE
CI: Actually read in CILIUM_IMAGE when splitting it

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -160,7 +160,7 @@ func HelmOverride(option string) string {
 func init() {
 	// Set defaults to match passed-in fully-qualified image
 	// If these are further set via CLI, they will be overwritten below
-	if v := os.Getenv("agent.image"); v != "" {
+	if v := os.Getenv("CILIUM_IMAGE"); v != "" {
 		registry, image, version, isFullyQualified := SplitContainerURL(v)
 		if isFullyQualified {
 			defaultHelmOptions["global.tag"] = version


### PR DESCRIPTION
_As the branch name suggests, I was going to revert this outright but part of the commit is in-use by other code so I corrected the one mistake instead_


We added setting the component parts of the image (registry and tag) to
ensure that these are consistent. This is currently only relevant to the
upgrade test but may be needed in the future as we set more of these
variables via the CILIUM_IMAGE variable.

fixes 1b75c08cc5f12758e7d5e92121d04a25da854c0f
