### PR TITLE
policymap, fragmap: clean up doc, map size configuration

### DIFF
--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -592,10 +592,6 @@ Limitations
       which uses BPF cgroup hooks to implement the service translation. The getpeername(2)
       hook is currently missing which will be addressed for newer kernels. It is known
       to currently not work with libceph deployments.
-    * Cilium in general currently does not support IP de-/fragmentation. This also includes
-      the BPF kube-proxy replacement. Meaning, while the first packet with L4 header will
-      reach the backend, all subsequent packets will not due to service lookup failing.
-      This will be addressed via `GH issue 10076 <https://github.com/cilium/cilium/issues/10076>`__.
     * Cilium's DSR NodePort mode currently does not operate well in environments with
       TCP Fast Open (TFO) enabled. It is recommended to switch to ``snat`` mode in this
       situation.

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -56,7 +56,6 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/maps/eppolicymap"
-	"github.com/cilium/cilium/pkg/maps/fragmap"
 	ipcachemap "github.com/cilium/cilium/pkg/maps/ipcache"
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/maps/sockmap"
@@ -275,7 +274,6 @@ func NewDaemon(ctx context.Context, dp datapath.Datapath) (*Daemon, *endpointRes
 		option.Config.EnableIPv4, option.Config.EnableIPv6,
 	)
 	policymap.InitMapInfo(option.Config.PolicyMapEntries)
-	fragmap.InitMapInfo(option.Config.FragmentsMapEntries)
 
 	if option.Config.DryMode == false {
 		if err := bpf.ConfigureResourceLimits(); err != nil {

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -405,7 +405,7 @@ func (d *Daemon) initMaps() error {
 	}
 
 	if option.Config.EnableIPv4FragmentsTracking {
-		if err := fragmap.InitMap(); err != nil {
+		if err := fragmap.InitMap(option.Config.FragmentsMapEntries); err != nil {
 			return err
 		}
 	}

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -114,7 +114,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		if option.Config.EnableIPv4FragmentsTracking {
 			cDefinesMap["ENABLE_IPV4_FRAGMENTS"] = "1"
 			cDefinesMap["IPV4_FRAG_DATAGRAMS_MAP"] = fragmap.MapName
-			cDefinesMap["CILIUM_IPV4_FRAG_MAP_MAX_ENTRIES"] = fmt.Sprintf("%d", fragmap.MaxEntries)
+			cDefinesMap["CILIUM_IPV4_FRAG_MAP_MAX_ENTRIES"] = fmt.Sprintf("%d", option.Config.FragmentsMapEntries)
 		}
 	}
 

--- a/pkg/maps/eppolicymap/eppolicymap.go
+++ b/pkg/maps/eppolicymap/eppolicymap.go
@@ -69,7 +69,7 @@ func CreateWithName(mapName string) error {
 			0, innerMapName)
 
 		if err != nil {
-			log.WithError(err).Warning("unable to create EP to policy map")
+			log.WithError(err).Fatal("unable to create EP to policy map")
 			return
 		}
 

--- a/pkg/maps/fragmap/fragmap.go
+++ b/pkg/maps/fragmap/fragmap.go
@@ -28,11 +28,6 @@ const (
 	MapName = "cilium_ipv4_frag_datagrams"
 )
 
-var (
-	// MaxEntries is the number of entries in the LRU map
-	MaxEntries = 8192
-)
-
 // FragmentKey must match 'struct ipv4_frag_id' in "bpf/lib/ipv4.h".
 // +k8s:deepcopy-gen=true
 // +k8s:deepcopy-gen:interfaces=github.com/cilium/cilium/pkg/bpf.MapKey
@@ -72,20 +67,15 @@ func (v *FragmentValue) String() string {
 // map value.
 func (k FragmentKey) NewValue() bpf.MapValue { return &FragmentValue{} }
 
-// InitMapInfo updates the map info defaults for policy maps.
-func InitMapInfo(maxEntries int) {
-	MaxEntries = maxEntries
-}
-
 // InitMap creates the signal map in the kernel.
-func InitMap() error {
+func InitMap(mapEntries int) error {
 	fragMap := bpf.NewMap(MapName,
 		bpf.MapTypeLRUHash,
 		&FragmentKey{},
 		int(unsafe.Sizeof(FragmentKey{})),
 		&FragmentValue{},
 		int(unsafe.Sizeof(FragmentValue{})),
-		MaxEntries,
+		mapEntries,
 		0,
 		0,
 		bpf.ConvertKeyValue,

--- a/pkg/maps/policymap/policymap.go
+++ b/pkg/maps/policymap/policymap.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/byteorder"
+	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
@@ -49,8 +50,9 @@ const (
 
 var (
 	// MaxEntries is the upper limit of entries in the per endpoint policy
-	// table
-	MaxEntries = 16384
+	// table. It is set by InitMapInfo(), but unit tests use the initial
+	// value below.
+	MaxEntries = defaults.PolicyMapEntries
 )
 
 type PolicyMap struct {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2749,11 +2749,11 @@ func (c *DaemonConfig) checkMapSizeLimits() error {
 	}
 
 	if c.FragmentsMapEntries < FragmentsMapMin {
-		return fmt.Errorf("specified fragments tracking map max entries %d must exceed minimum %d",
+		return fmt.Errorf("specified max entries %d for fragment-tracking map must exceed minimum %d",
 			c.FragmentsMapEntries, FragmentsMapMin)
 	}
 	if c.FragmentsMapEntries > FragmentsMapMax {
-		return fmt.Errorf("specified fragments tracking map max entries %d must not exceed maximum %d",
+		return fmt.Errorf("specified max entries %d for fragment-tracking map must not exceed maximum %d",
 			c.FragmentsMapEntries, FragmentsMapMax)
 	}
 


### PR DESCRIPTION
More clean-up following the introduction of IPv4 fragment tracking.

Follow-up on #10927.

First commit updates the doc for kubeproxy-free (removes note about missing fragmentation support).

Second commit cleans up the way we configure map size for policymap and fragmap, and falls back to limit values if the user passes unreasonable values. No lower limit for fragmap (other than 0), maybe we could remove it for policymap as well but I'm unsure if the lower limit is used elsewhere as an assumption. Anyway it's already possible to ask for as few as 256 entries in policy map, not sure it's worth trying to allow fewer than that.
