### PR TITLE
CI: GKE more cleaning

### DIFF
--- a/test/gke/release-cluster.sh
+++ b/test/gke/release-cluster.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 
 export KUBECONFIG=gke-kubeconfig
+cluster=$(cat cluster-name)
+
+# Create a function to unlock the cluster. We then execute this on script exit.
+# This should occur even if the script is interrupted, by a jenkins timeout,
+# for example.
+unlock() {    
+    echo "releasing cluster lock from $cluster"
+    kubectl annotate deployment lock lock-
+}
+trap unlock EXIT
 
 # We leak istio pods for an unknown reason (these tests do cleanup). This may
 # be related to timeouts or other failures. In any case, we delete them here to
@@ -13,12 +23,8 @@ echo "deleting terminating namespaces"
 ./delete-terminating-namespaces.sh
 
 set -e
-
-cluster=$(cat cluster-name)
+    
 echo "scaling $cluster ng to 0"
 yes | gcloud container clusters resize $cluster --node-pool default-pool --num-nodes 0 --zone $GKE_ZONE
 
-echo "releasing cluster lock from $cluster"
-kubectl annotate deployment lock lock-
-
-rm cluster-name
+rm -f cluster-name

--- a/test/gke/release-cluster.sh
+++ b/test/gke/release-cluster.sh
@@ -2,6 +2,13 @@
 
 export KUBECONFIG=gke-kubeconfig
 
+# We leak istio pods for an unknown reason (these tests do cleanup). This may
+# be related to timeouts or other failures. In any case, we delete them here to
+# be sure.
+echo "deleting istio-system namespace and contents"
+kubectl delete all -n istio-system --all
+kubectl delete ns istio-system
+
 echo "deleting terminating namespaces"
 ./delete-terminating-namespaces.sh
 


### PR DESCRIPTION
- Despite having cleanup logic the istio tests seem to leak. This is
likely because these tests are hard-interrupted. We clean up in our
release script since we know that these pods should no longer exist.

soooo
- We are interrupted by jenkins on timeouts, and this can happen while we
scale the cluster down. We now unlock in an exit trap and this should,
hopefully, leave the cluster reusable, if not well cleaned.