### PR TITLE
cilium: add visibility for all flags in CT dump

### DIFF
--- a/pkg/maps/ctmap/types.go
+++ b/pkg/maps/ctmap/types.go
@@ -487,12 +487,15 @@ type CtEntry struct {
 func (c *CtEntry) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(c) }
 
 const (
-	RxClosing  = 1 << 0
-	TxClosing  = 1 << 1
-	Nat64      = 1 << 2
-	LBLoopback = 1 << 3
-	SeenNonSyn = 1 << 4
-	NodePort   = 1 << 5
+	RxClosing = 1 << iota
+	TxClosing
+	Nat64
+	LBLoopback
+	SeenNonSyn
+	NodePort
+	ProxyRedirect
+	DSR
+	MaxFlags
 )
 
 func (c *CtEntry) flagsString() string {
@@ -516,6 +519,18 @@ func (c *CtEntry) flagsString() string {
 	}
 	if (c.Flags & NodePort) != 0 {
 		buffer.WriteString("NodePort ")
+	}
+	if (c.Flags & ProxyRedirect) != 0 {
+		buffer.WriteString("ProxyRedirect ")
+	}
+	if (c.Flags & DSR) != 0 {
+		buffer.WriteString("DSR ")
+	}
+
+	unknownFlags := c.Flags
+	unknownFlags &^= MaxFlags - 1
+	if unknownFlags != 0 {
+		buffer.WriteString(fmt.Sprintf("Unknown=%#04x ", unknownFlags))
 	}
 	buffer.WriteString("]")
 	return buffer.String()

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -144,13 +144,15 @@ var _ = Describe("K8sServicesTest", func() {
 		// service connectivity is correct we tried 10 times, so balance in the
 		// two nodes
 		for _, pod := range pods {
-			By("Making ten curl requests from %q to %q", pod, url)
-			for i := 1; i <= 10; i++ {
+			tries := 10
+			By("Making %d curl requests from %q to %q", tries, pod, url)
+			for i := 1; i <= tries; i++ {
 				res := kubectl.ExecPodCmd(
 					helpers.DefaultNamespace, pod,
 					helpers.CurlFail(url))
 				ExpectWithOffset(1, res).Should(helpers.CMDSuccess(),
-					"Pod %q can not connect to service %q", pod, url)
+					"Pod %q can not connect to service %q (failed in request %d/%d)",
+					pod, url, i, tries)
 			}
 		}
 	}
@@ -385,7 +387,8 @@ var _ = Describe("K8sServicesTest", func() {
 				res, err := kubectl.ExecInHostNetNS(context.TODO(), fromPod, helpers.CurlFail(url))
 				ExpectWithOffset(1, err).To(BeNil(), "Cannot run curl in host netns")
 				ExpectWithOffset(1, res).Should(helpers.CMDSuccess(),
-					"%s host can not connect to service %q", fromPod, url)
+					"%s host can not connect to service %q (failed in request %d/%d)",
+					fromPod, url, i, count)
 			}
 		}
 


### PR DESCRIPTION
While debugging #10942, I noticed that not all flags are currently
dumped in our bugtool report's CT list. Fix it by adding the missing
ones as well.

Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>