### PR TITLE
docs: fix issue link in k8s policy docs

### DIFF
--- a/Documentation/kubernetes/policy.rst
+++ b/Documentation/kubernetes/policy.rst
@@ -50,7 +50,7 @@ Known missing features for Kubernetes Network Policy:
 +==============================+==============================================+
 | Use of named ports           | https://github.com/cilium/cilium/issues/2942 |
 +------------------------------+----------------------------------------------+
-| Ingress CIDR-based L4 policy | https://github.com/cilium/cilium/issues/1684 |
+| Ingress CIDR-based L4 policy | https://github.com/cilium/cilium/issues/4129 |
 +------------------------------+----------------------------------------------+
 
 .. _CiliumNetworkPolicy:


### PR DESCRIPTION
Support for CIDR-based L4 ingress policies is tracked in #4129 since it
was split out of #1684 after CIDR-based L4 egress policies were
implemented.

Fixes: 468457e89852 ("api: Allow egress CIDR+L4 rules")
Signed-off-by: Tobias Klauser <tklauser@distanz.ch>