### PR TITLE
Remove the deprecated `CiliumExec` method

### DIFF
--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -15,6 +15,7 @@
 package k8sTest
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"regexp"
@@ -213,8 +214,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 			By("Checking that BPF tunnels are in place")
 			ciliumPod, err := kubectl.GetCiliumPodOnNodeWithLabel(helpers.CiliumNamespace, helpers.K8s1)
 			ExpectWithOffset(1, err).Should(BeNil(), "Unable to determine cilium pod on node %s", helpers.K8s1)
-			status := kubectl.CiliumExec(ciliumPod, "cilium bpf tunnel list | wc -l")
-			status.ExpectSuccess()
+			status := kubectl.CiliumExecMustSucceed(context.TODO(), ciliumPod, "cilium bpf tunnel list | wc -l")
 
 			// ipv4+ipv6: 2 entries for each remote node + 1 header row
 			numEntries := (kubectl.GetNumCiliumNodes()-1)*2 + 1

--- a/test/k8sT/Health.go
+++ b/test/k8sT/Health.go
@@ -15,6 +15,7 @@
 package k8sTest
 
 import (
+	"context"
 	"fmt"
 
 	. "github.com/cilium/cilium/test/ginkgo-ext"
@@ -91,9 +92,8 @@ var _ = Describe("K8sHealthTest", func() {
 
 		By("checking that `cilium-health --probe` succeeds")
 		healthCmd := "cilium-health status --probe -o json"
-		status := kubectl.CiliumExec(cilium1, healthCmd)
+		status := kubectl.CiliumExecMustSucceed(context.TODO(), cilium1, healthCmd)
 		Expect(status.Output()).ShouldNot(ContainSubstring("error"))
-		status.ExpectSuccess()
 
 		apiPaths := []string{
 			"endpoint.icmp",
@@ -103,8 +103,7 @@ var _ = Describe("K8sHealthTest", func() {
 		}
 		for node := 0; node <= 1; node++ {
 			healthCmd := "cilium-health status -o json"
-			status := kubectl.CiliumExec(cilium1, healthCmd)
-			status.ExpectSuccess("Cannot retrieve health status")
+			status := kubectl.CiliumExecMustSucceed(context.TODO(), cilium1, healthCmd, "Cannot retrieve health status")
 			for _, path := range apiPaths {
 				filter := fmt.Sprintf("{.nodes[%d].%s}", node, path)
 				By("checking API response for %q", filter)

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -213,10 +213,9 @@ var _ = Describe("K8sPolicyTest", func() {
 		})
 
 		BeforeEach(func() {
-			status := kubectl.CiliumExec(
+			kubectl.CiliumExecMustSucceed(context.TODO(),
 				ciliumPod, fmt.Sprintf("cilium config %s=%s",
 					helpers.PolicyEnforcement, helpers.PolicyEnforcementDefault))
-			status.ExpectSuccess()
 
 			err := kubectl.CiliumEndpointWaitReady()
 			Expect(err).To(BeNil(), "Endpoints are not ready after timeout")
@@ -246,16 +245,14 @@ var _ = Describe("K8sPolicyTest", func() {
 				Expect(err).Should(BeNil())
 			}
 
-			trace := kubectl.CiliumExec(ciliumPod, fmt.Sprintf(
+			trace := kubectl.CiliumExecMustSucceed(context.TODO(), ciliumPod, fmt.Sprintf(
 				"cilium policy trace --src-k8s-pod %s:%s --dst-k8s-pod %s:%s --dport 80/TCP",
 				namespaceForTest, appPods[helpers.App2], namespaceForTest, appPods[helpers.App1]))
-			trace.ExpectSuccess(trace.CombineOutput().String())
 			trace.ExpectContains("Final verdict: ALLOWED", "Policy trace output mismatch")
 
-			trace = kubectl.CiliumExec(ciliumPod, fmt.Sprintf(
+			trace = kubectl.CiliumExecMustSucceed(context.TODO(), ciliumPod, fmt.Sprintf(
 				"cilium policy trace --src-k8s-pod %s:%s --dst-k8s-pod %s:%s",
 				namespaceForTest, appPods[helpers.App3], namespaceForTest, appPods[helpers.App1]))
-			trace.ExpectSuccess(trace.CombineOutput().String())
 			trace.ExpectContains("Final verdict: DENIED", "Policy trace output mismatch")
 
 			res := kubectl.ExecPodCmd(
@@ -389,16 +386,14 @@ var _ = Describe("K8sPolicyTest", func() {
 				Expect(err).Should(BeNil())
 			}
 
-			trace := kubectl.CiliumExec(ciliumPod, fmt.Sprintf(
+			trace := kubectl.CiliumExecMustSucceed(context.TODO(), ciliumPod, fmt.Sprintf(
 				"cilium policy trace --src-k8s-pod %s:%s --dst-k8s-pod %s:%s --dport 80/TCP",
 				namespaceForTest, appPods[helpers.App2], namespaceForTest, appPods[helpers.App1]))
-			trace.ExpectSuccess(trace.CombineOutput().String())
 			trace.ExpectContains("Final verdict: ALLOWED", "Policy trace output mismatch")
 
-			trace = kubectl.CiliumExec(ciliumPod, fmt.Sprintf(
+			trace = kubectl.CiliumExecMustSucceed(context.TODO(), ciliumPod, fmt.Sprintf(
 				"cilium policy trace --src-k8s-pod %s:%s --dst-k8s-pod %s:%s",
 				namespaceForTest, appPods[helpers.App3], namespaceForTest, appPods[helpers.App1]))
-			trace.ExpectSuccess(trace.CombineOutput().String())
 			trace.ExpectContains("Final verdict: DENIED", "Policy trace output mismatch")
 
 			res := kubectl.ExecPodCmd(


### PR DESCRIPTION
Signed-off-by: Nate Sweet <nathanjsweet@pm.me>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->
Remove the deprecated `CiliumExec` in favor of the updated method
that takes a context object. Also, added a `MustSucceed` version of
the helper function to make it easy to call exec without onerous
boilerplate.