### PR TITLE
endpoint: Avoid logging about disconnected EPs during restore

### DIFF
--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -171,8 +171,11 @@ func (d *Daemon) restoreOldEndpoints(dir string, clean bool) (*endpointRestoreSt
 
 		restore, err := d.validateEndpoint(ep)
 		if err != nil {
-			scopedLog.WithError(err).Warningf("Unable to restore endpoint, ignoring")
-			failed++
+			// Disconnected EPs are not failures, clean them silently below
+			if !ep.IsDisconnecting() {
+				scopedLog.WithError(err).Warningf("Unable to restore endpoint, ignoring")
+				failed++
+			}
 		}
 		if !restore {
 			if clean {

--- a/pkg/endpoint/manager.go
+++ b/pkg/endpoint/manager.go
@@ -147,7 +147,7 @@ func (e *Endpoint) Unexpose(mgr endpointManager) <-chan struct{} {
 			//
 			// Avoid irritating warning messages.
 			state := ep.GetState()
-			if state != StateRestoring && state != StateDisconnecting {
+			if state != StateRestoring && state != StateDisconnecting && state != StateDisconnected {
 				log.WithError(err).WithField("state", state).Warning("Unable to release endpoint ID")
 			}
 		}

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -284,6 +284,7 @@ func (mgr *EndpointManager) ReleaseID(ep *endpoint.Endpoint) error {
 
 // WaitEndpointRemoved waits until all operations associated with Remove of
 // the endpoint have been completed.
+// Note: only used for unit tests
 func (mgr *EndpointManager) WaitEndpointRemoved(ep *endpoint.Endpoint) {
 	<-ep.Unexpose(mgr)
 }


### PR DESCRIPTION
Do not log a warning when can't release the ID of a disconnected endpoint.

These changes remove warning logs like:

msg="Unable to restore endpoint, ignoring" endpointID=1925 error="interface lxc18d62e89ea16 could not be found" k8sPodName=default/spaceship-d5d56b59-6c582 subsys=daemon
msg="Unable to release endpoint ID" error="Unable to release endpoint ID 1925" state=disconnected subsys=endpoint

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
