### PR TITLE
travis: Disable arm64 failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ arch:
   - amd64
   - arm64
 
+jobs:
+  allow_failures:
+  - arch: arm64
+
 if: branch = master OR type = pull_request
 
 addons:


### PR DESCRIPTION
Travis is recently failing a lot for ARM builds with issues like:

* https://github.com/cilium/cilium/issues/10945
* https://github.com/cilium/cilium/issues/10977

Allow failures for the moment while we triage these so that all PRs are
not affected by these known issues.

/cc @Jianlin-lv 