### PR TITLE
maps: remove old map names

### DIFF
--- a/pkg/bpf/map_test.go
+++ b/pkg/bpf/map_test.go
@@ -32,7 +32,6 @@ func (s *BPFTestSuite) TestExtractCommonName(c *C) {
 	c.Assert(extractCommonName("cilium_calls_overlay_2"), Equals, "calls")
 	c.Assert(extractCommonName("cilium_ct4_global"), Equals, "ct4_global")
 	c.Assert(extractCommonName("cilium_ct_any4_global"), Equals, "ct_any4_global")
-	c.Assert(extractCommonName("cilium_ep_config_1157"), Equals, "ep_config")
 	c.Assert(extractCommonName("cilium_events"), Equals, "events")
 	c.Assert(extractCommonName("cilium_ipcache"), Equals, "ipcache")
 	c.Assert(extractCommonName("cilium_lb4_reverse_nat"), Equals, "lb4_reverse_nat")

--- a/pkg/datapath/loader/loader_test.go
+++ b/pkg/datapath/loader/loader_test.go
@@ -78,13 +78,6 @@ func (s *LoaderTestSuite) TearDownSuite(c *C) {
 }
 
 func (s *LoaderTestSuite) TearDownTest(c *C) {
-	// Old map names as created by older versions of these tests
-	//
-	// FIXME GH-6701: Remove for 1.5.0
-	os.Remove("/sys/fs/bpf/tc/globals/cilium_policy_foo")
-	os.Remove("/sys/fs/bpf/tc/globals/cilium_calls_111")
-	os.Remove("/sys/fs/bpf/tc/globals/cilium_ep_config_111")
-
 	files, err := filepath.Glob("/sys/fs/bpf/tc/globals/test_*")
 	if err != nil {
 		panic(err)

--- a/pkg/datapath/maps/map.go
+++ b/pkg/datapath/maps/map.go
@@ -101,8 +101,6 @@ func (ms *MapSweeper) walk(path string, _ os.FileInfo, _ error) error {
 		ctmap.MapNameAny6,
 		ctmap.MapNameAny4,
 		loader.CallsMapName,
-		// Remove this line after v1.7
-		"cilium_ep_config_",
 		endpoint.IpvlanMapName,
 	}
 

--- a/pkg/datapath/maps/map_test.go
+++ b/pkg/datapath/maps/map_test.go
@@ -93,7 +93,6 @@ func (s *MapTestSuite) TestCollectStaleMapGarbage(c *C) {
 				"cilium_ct4_00001",
 				"cilium_ct_any6_00001",
 				"cilium_ct_any4_00001",
-				"cilium_ep_config_00001",
 			},
 			removedPaths:    []string{},
 			removedMappings: []int{},
@@ -110,7 +109,6 @@ func (s *MapTestSuite) TestCollectStaleMapGarbage(c *C) {
 				"cilium_ct4_00001",
 				"cilium_ct_any6_00001",
 				"cilium_ct_any4_00001",
-				"cilium_ep_config_00001",
 			},
 			removedPaths: []string{
 				"cilium_policy_00001",
@@ -118,7 +116,6 @@ func (s *MapTestSuite) TestCollectStaleMapGarbage(c *C) {
 				"cilium_ct4_00001",
 				"cilium_ct_any6_00001",
 				"cilium_ct_any4_00001",
-				"cilium_ep_config_00001",
 			},
 			removedMappings: []int{
 				1,
@@ -136,7 +133,6 @@ func (s *MapTestSuite) TestCollectStaleMapGarbage(c *C) {
 				"cilium_ct4_00001",
 				"cilium_ct_any6_00001",
 				"cilium_ct_any4_00001",
-				"cilium_ep_config_00001",
 			},
 			removedPaths: []string{
 				"cilium_policy_00042",
@@ -155,7 +151,6 @@ func (s *MapTestSuite) TestCollectStaleMapGarbage(c *C) {
 				"cilium_ct4_00001",
 				"cilium_ct_any6_00001",
 				"cilium_ct_any4_00001",
-				"cilium_ep_config_00001",
 			},
 			removedPaths: []string{
 				"cilium_policy_00001",
@@ -164,7 +159,6 @@ func (s *MapTestSuite) TestCollectStaleMapGarbage(c *C) {
 				"cilium_ct4_00001",
 				"cilium_ct_any6_00001",
 				"cilium_ct_any4_00001",
-				"cilium_ep_config_00001",
 			},
 			removedMappings: []int{
 				1,
@@ -184,14 +178,12 @@ func (s *MapTestSuite) TestCollectStaleMapGarbage(c *C) {
 				"cilium_ct4_1",
 				"cilium_ct_any6_1",
 				"cilium_ct_any4_1",
-				"cilium_ep_config_1",
 				"cilium_policy_00001",
 				"cilium_policy_00042",
 				"cilium_ct6_00001",
 				"cilium_ct4_00001",
 				"cilium_ct_any6_00001",
 				"cilium_ct_any4_00001",
-				"cilium_ep_config_00001",
 			},
 			removedPaths: []string{
 				"cilium_policy_1",
@@ -200,7 +192,6 @@ func (s *MapTestSuite) TestCollectStaleMapGarbage(c *C) {
 				"cilium_ct4_1",
 				"cilium_ct_any6_1",
 				"cilium_ct_any4_1",
-				"cilium_ep_config_1",
 			},
 			removedMappings: []int{},
 		},


### PR DESCRIPTION
Remove leftover map names `cilium_ep_config_*` from tests, as per the comment in pkg/datapath/maps/map.go. This prefix is no longer used.

Also remove old map names created in earlier versions of the tests, as per the comment in pkg/datapath/loader/loader_test.go (see also issue referenced below).

Fixes: #6701