### PR TITLE
Add and use concurrency-safe PRNG source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -475,6 +475,8 @@ postcheck: build
 	$(QUIET)$(MAKE) $(SUBMAKEOPTS) -C Documentation update-cmdref check
 	@$(ECHO_CHECK) contrib/scripts/lock-check.sh
 	$(QUIET) contrib/scripts/lock-check.sh
+	@$(ECHO_CHECK) contrib/scripts/rand-check.sh
+	$(QUIET) contrib/scripts/rand-check.sh
 
 minikube:
 	$(QUIET) contrib/scripts/minikube.sh

--- a/contrib/scripts/rand-check.sh
+++ b/contrib/scripts/rand-check.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2020 Authors of Cilium
+
+# Make sure pkg/rand is used instead of math/rand, see
+# https://github.com/cilium/cilium/issues/10988. It's fine to use math/rand in
+# tests though.
+for l in rand\.NewSource; do
+  m=$(find . -name "*.go" \
+	  -not -name "*_test.go" \
+	  -not -path "./contrib/*" \
+	  -not -path "./pkg/rand/*" \
+	  -not -path "./vendor/*" \
+	  -not -path "./test/*" \
+	  -print0 \
+	  | xargs -0 grep --exclude NewSafeSource "$l")
+  if [[ ! -z "$m" ]] ; then
+    echo "Found $l usage. Please use pkg/rand instead for a concurrency-safe implementation:"
+    echo $m
+    exit 1
+  fi
+done

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -17,7 +17,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"strings"
 	"time"
 
@@ -32,6 +31,7 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/rand"
 	"github.com/cilium/cilium/pkg/status"
 
 	"github.com/go-openapi/runtime/middleware"
@@ -50,7 +50,7 @@ const (
 	k8sMinimumEventHearbeat = time.Minute
 )
 
-var randGen = rand.New(rand.NewSource(time.Now().UnixNano()))
+var randGen = rand.NewSafeRand(time.Now().UnixNano())
 
 type k8sVersion struct {
 	version          string

--- a/pkg/allocator/allocator_test.go
+++ b/pkg/allocator/allocator_test.go
@@ -205,7 +205,7 @@ func (t TestAllocatorKey) PutKeyFromMap(m map[string]string) AllocatorKey {
 }
 
 func randomTestName() string {
-	return rand.RandomRuneWithPrefix(testPrefix, 12)
+	return rand.RandomStringWithPrefix(testPrefix, 12)
 }
 
 func (s *AllocatorSuite) TestSelectID(c *C) {

--- a/pkg/azure/api/api.go
+++ b/pkg/azure/api/api.go
@@ -290,7 +290,7 @@ func (c *Client) GetVpcsAndSubnets(ctx context.Context) (ipamTypes.VirtualNetwor
 }
 
 func generateIpConfigName() string {
-	return "Cilium-" + rand.RandomRuneWithLen(8)
+	return rand.RandomStringWithPrefix("Cilium-", 8)
 }
 
 // AssignPrivateIpAddresses assigns the IPs to the interface as specified by

--- a/pkg/backoff/backoff.go
+++ b/pkg/backoff/backoff.go
@@ -18,17 +18,21 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"math/rand"
 	"time"
 
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/rand"
 	"github.com/cilium/cilium/pkg/uuid"
 
 	"github.com/sirupsen/logrus"
 )
 
-var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "backoff")
+var (
+	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "backoff")
+
+	randGen = rand.NewSafeRand(time.Now().UnixNano())
+)
 
 // NodeManager is the interface required to implement cluster size dependent
 // intervals
@@ -78,7 +82,7 @@ func CalculateDuration(min, max time.Duration, factor float64, jitter bool, fail
 	}
 
 	if jitter {
-		t = rand.Float64()*(t-minFloat) + minFloat
+		t = randGen.Float64()*(t-minFloat) + minFloat
 	}
 
 	return time.Duration(t)

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -65,7 +65,7 @@ var (
 func (s *ClusterMeshServicesTestSuite) SetUpTest(c *C) {
 	kvstore.SetupDummy("etcd")
 
-	s.randomName = rand.RandomRune()
+	s.randomName = rand.RandomString()
 
 	kvstore.Client().DeletePrefix(context.TODO(), "cilium/state/services/v1/"+s.randomName)
 	s.svcCache = k8s.NewServiceCache(fakeDatapath.NewNodeAddressing())

--- a/pkg/datapath/connector/add.go
+++ b/pkg/datapath/connector/add.go
@@ -17,12 +17,12 @@ package connector
 import (
 	"crypto/sha256"
 	"fmt"
-	"math/rand"
 	"net"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/rand"
 	"github.com/cilium/cilium/pkg/sysctl"
 
 	"github.com/containernetworking/plugins/pkg/ns"
@@ -53,22 +53,12 @@ func Endpoint2TempIfName(endpointID string) string {
 	return temporaryInterfacePrefix + truncateString(endpointID, 5)
 }
 
-func randIfStr(num int) string {
-	str := make([]rune, num)
-	for i := range str {
-		str[i] = ifChars[rand.Intn(len(ifChars))]
-	}
-	return string(str)
-}
-
 // Endpoint2TempRandIfName returns a random, temporary interface name for the
 // given endpointID. This is similar to Endpoint2TempIfName() but uses a
 // random string instead of endpoint ID.
 func Endpoint2TempRandIfName() string {
-	return temporaryInterfacePrefix + "_" + randIfStr(5)
+	return temporaryInterfacePrefix + "_" + rand.RandomLowercaseStringWithLen(5)
 }
-
-var ifChars = []rune("abcdefghijklmnopqrstuvwxyz")
 
 func truncateString(epID string, maxLen uint) string {
 	if maxLen <= uint(len(epID)) {

--- a/pkg/kvstore/allocator/allocator_test.go
+++ b/pkg/kvstore/allocator/allocator_test.go
@@ -96,7 +96,7 @@ func (t TestAllocatorKey) PutKeyFromMap(m map[string]string) allocator.Allocator
 }
 
 func randomTestName() string {
-	return rand.RandomRuneWithPrefix(testPrefix, 12)
+	return rand.RandomStringWithPrefix(testPrefix, 12)
 }
 
 func (s *AllocatorSuite) BenchmarkAllocate(c *C) {

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"math/rand"
 	"net/url"
 	"os"
 	"strconv"
@@ -32,6 +31,7 @@ import (
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/rand"
 	"github.com/cilium/cilium/pkg/spanstat"
 	"github.com/cilium/cilium/pkg/versioncheck"
 
@@ -65,7 +65,7 @@ var (
 	// exist or it was expired.
 	ErrLockLeaseExpired = errors.New("transaction did not succeed: lock lease expired")
 
-	randGen = rand.New(rand.NewSource(time.Now().UnixNano()))
+	randGen = rand.NewSafeRand(time.Now().UnixNano())
 )
 
 type etcdModule struct {

--- a/pkg/kvstore/store/store_test.go
+++ b/pkg/kvstore/store/store_test.go
@@ -142,19 +142,19 @@ func (s *StoreSuite) TestStoreCreation(c *C) {
 	c.Assert(store, IsNil)
 
 	// Missing KeyCreator must result in error
-	store, err = JoinSharedStore(Configuration{Prefix: rand.RandomRune()})
+	store, err = JoinSharedStore(Configuration{Prefix: rand.RandomString()})
 	c.Assert(err, ErrorMatches, "KeyCreator must be specified")
 	c.Assert(store, IsNil)
 
 	// Basic creation should result in default values
-	store, err = JoinSharedStore(Configuration{Prefix: rand.RandomRune(), KeyCreator: newTestType})
+	store, err = JoinSharedStore(Configuration{Prefix: rand.RandomString(), KeyCreator: newTestType})
 	c.Assert(err, IsNil)
 	c.Assert(store, Not(IsNil))
 	c.Assert(store.conf.SynchronizationInterval, Equals, option.Config.KVstorePeriodicSync)
 	store.Close(context.TODO())
 
 	// Test with kvstore client specified
-	store, err = JoinSharedStore(Configuration{Prefix: rand.RandomRune(), KeyCreator: newTestType, Backend: kvstore.Client()})
+	store, err = JoinSharedStore(Configuration{Prefix: rand.RandomString(), KeyCreator: newTestType, Backend: kvstore.Client()})
 	c.Assert(err, IsNil)
 	c.Assert(store, Not(IsNil))
 	c.Assert(store.conf.SynchronizationInterval, Equals, option.Config.KVstorePeriodicSync)
@@ -178,7 +178,7 @@ func expect(check func() bool) error {
 
 func (s *StoreSuite) TestStoreOperations(c *C) {
 	// Basic creation should result in default values
-	store, err := JoinSharedStore(Configuration{Prefix: rand.RandomRune(), KeyCreator: newTestType, Observer: &observer{}})
+	store, err := JoinSharedStore(Configuration{Prefix: rand.RandomString(), KeyCreator: newTestType, Observer: &observer{}})
 	c.Assert(err, IsNil)
 	c.Assert(store, Not(IsNil))
 	defer store.Close(context.TODO())
@@ -221,7 +221,7 @@ func (s *StoreSuite) TestStoreOperations(c *C) {
 func (s *StoreSuite) TestStorePeriodicSync(c *C) {
 	// Create a store with a very short periodic sync interval
 	store, err := JoinSharedStore(Configuration{
-		Prefix:                  rand.RandomRune(),
+		Prefix:                  rand.RandomString(),
 		KeyCreator:              newTestType,
 		SynchronizationInterval: 10 * time.Millisecond,
 		Observer:                &observer{},
@@ -250,7 +250,7 @@ func (s *StoreSuite) TestStorePeriodicSync(c *C) {
 
 func (s *StoreSuite) TestStoreLocalKeyProtection(c *C) {
 	store, err := JoinSharedStore(Configuration{
-		Prefix:                  rand.RandomRune(),
+		Prefix:                  rand.RandomString(),
 		KeyCreator:              newTestType,
 		SynchronizationInterval: time.Hour, // ensure that periodic sync does not interfer
 		Observer:                &observer{},
@@ -302,12 +302,12 @@ func setupStoreCollaboration(c *C, storePrefix, keyPrefix string) *SharedStore {
 }
 
 func (s *StoreSuite) TestStoreCollaboration(c *C) {
-	storePrefix := rand.RandomRune()
+	storePrefix := rand.RandomString()
 
-	collab1 := setupStoreCollaboration(c, storePrefix, rand.RandomRune())
+	collab1 := setupStoreCollaboration(c, storePrefix, rand.RandomString())
 	defer collab1.Close(context.TODO())
 
-	collab2 := setupStoreCollaboration(c, storePrefix, rand.RandomRune())
+	collab2 := setupStoreCollaboration(c, storePrefix, rand.RandomString())
 	defer collab2.Close(context.TODO())
 
 	c.Assert(expect(func() bool {

--- a/pkg/lock/stoppable_waitgroup_test.go
+++ b/pkg/lock/stoppable_waitgroup_test.go
@@ -167,6 +167,8 @@ func (s *SemaphoredMutexSuite) TestWaitChannel(c *C) {
 func (s *SemaphoredMutexSuite) TestParallelism(c *C) {
 	l := NewStoppableWaitGroup()
 
+	// use math/rand instead of pkg/rand to avoid a test import cycle which
+	// go vet would complain about.
 	randGen := rand.New(rand.NewSource(time.Now().UnixNano()))
 	in := make(chan int)
 	stop := make(chan struct{})

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -17,7 +17,6 @@ package proxy
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -30,6 +29,7 @@ import (
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy/logger"
+	"github.com/cilium/cilium/pkg/rand"
 	"github.com/cilium/cilium/pkg/revert"
 
 	"github.com/sirupsen/logrus"
@@ -144,7 +144,7 @@ var (
 	// allocatedPorts is the map of all allocated proxy ports
 	allocatedPorts = make(map[uint16]struct{})
 
-	portRandomizer = rand.New(rand.NewSource(time.Now().UnixNano()))
+	portRandomizer = rand.NewSafeRand(time.Now().UnixNano())
 
 	// proxyPorts is a slice of all supported proxy ports
 	// The number and order of entries are fixed, and the fields

--- a/pkg/rand/rand_name.go
+++ b/pkg/rand/rand_name.go
@@ -15,7 +15,6 @@
 package rand
 
 import (
-	"math/rand"
 	"time"
 )
 
@@ -23,7 +22,7 @@ import (
 // https://stackoverflow.com/questions/22892120/how-to-generate-a-random-string-of-a-fixed-length-in-golang
 
 var (
-	randGen = rand.New(rand.NewSource(time.Now().UnixNano()))
+	randGen = NewSafeRand(time.Now().UnixNano())
 
 	letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 )

--- a/pkg/rand/rand_name.go
+++ b/pkg/rand/rand_name.go
@@ -34,14 +34,24 @@ func RandomStringWithPrefix(prefix string, n int) string {
 	return prefix + RandomStringWithLen(n)
 }
 
+func randomStringFromSliceWithLen(runes []rune, n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letterRunes[randGen.Intn(len(runes))]
+	}
+	return string(b)
+}
+
 // RandomStringWithLen returns a random string of specified length containing
 // upper- and lowercase runes.
 func RandomStringWithLen(n int) string {
-	b := make([]rune, n)
-	for i := range b {
-		b[i] = letterRunes[randGen.Intn(len(letterRunes))]
-	}
-	return string(b)
+	return randomStringFromSliceWithLen(letterRunes, n)
+}
+
+// RandomLowercaseStringWithLen returns a random string of specified length
+// containing lowercase runes.
+func RandomLowercaseStringWithLen(n int) string {
+	return randomStringFromSliceWithLen(letterRunes[:26], n)
 }
 
 // RandomString returns a random string with a predefined length of 12.

--- a/pkg/rand/rand_name.go
+++ b/pkg/rand/rand_name.go
@@ -28,13 +28,15 @@ var (
 	letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 )
 
-// RandomRuneWithPrefix returns a random name string with fixed prefix
-func RandomRuneWithPrefix(prefix string, n int) string {
-	return prefix + RandomRuneWithLen(n)
+// RandomStringWithPrefix returns a random string of length n + len(prefix) with
+// the given prefix, containing upper- and lowercase runes.
+func RandomStringWithPrefix(prefix string, n int) string {
+	return prefix + RandomStringWithLen(n)
 }
 
-// RandomRuneWithLen returns a random name of specified length
-func RandomRuneWithLen(n int) string {
+// RandomStringWithLen returns a random string of specified length containing
+// upper- and lowercase runes.
+func RandomStringWithLen(n int) string {
 	b := make([]rune, n)
 	for i := range b {
 		b[i] = letterRunes[randGen.Intn(len(letterRunes))]
@@ -42,7 +44,7 @@ func RandomRuneWithLen(n int) string {
 	return string(b)
 }
 
-// RandomRune returns a random name with a predefined length of 12
-func RandomRune() string {
-	return RandomRuneWithLen(12)
+// RandomString returns a random string with a predefined length of 12.
+func RandomString() string {
+	return RandomStringWithLen(12)
 }

--- a/pkg/rand/rand_name_test.go
+++ b/pkg/rand/rand_name_test.go
@@ -40,4 +40,8 @@ func (s *RandSuite) TestRandomString(c *C) {
 	s0 := RandomStringWithPrefix("foo", 12)
 	c.Assert(len(s0), Equals, len("foo")+12)
 	c.Assert(strings.HasPrefix(s0, "foo"), Equals, true)
+
+	s1 := RandomLowercaseStringWithLen(15)
+	c.Assert(len(s1), Equals, 15)
+	c.Assert(strings.ToLower(s1), Equals, s1)
 }

--- a/pkg/rand/rand_name_test.go
+++ b/pkg/rand/rand_name_test.go
@@ -31,13 +31,13 @@ type RandSuite struct{}
 
 var _ = Suite(&RandSuite{})
 
-func (s *RandSuite) TestRandomRune(c *C) {
-	c.Assert(len(RandomRune()), Equals, 12)
+func (s *RandSuite) TestRandomString(c *C) {
+	c.Assert(len(RandomString()), Equals, 12)
 
-	c.Assert(len(RandomRuneWithLen(12)), Equals, 12)
-	c.Assert(len(RandomRuneWithLen(0)), Equals, 0)
+	c.Assert(len(RandomStringWithLen(12)), Equals, 12)
+	c.Assert(len(RandomStringWithLen(0)), Equals, 0)
 
-	str := RandomRuneWithPrefix("foo", 12)
-	c.Assert(len(str), Equals, 15)
-	c.Assert(strings.HasPrefix(str, "foo"), Equals, true)
+	s0 := RandomStringWithPrefix("foo", 12)
+	c.Assert(len(s0), Equals, len("foo")+12)
+	c.Assert(strings.HasPrefix(s0, "foo"), Equals, true)
 }

--- a/pkg/rand/safe_rand.go
+++ b/pkg/rand/safe_rand.go
@@ -1,0 +1,85 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rand
+
+import (
+	"math/rand"
+
+	"github.com/cilium/cilium/pkg/lock"
+)
+
+// safeRand is a concurrency-safe source of pseudo-random numbers. The Go
+// stdlib's math/rand.Source is not concurrency-safe. The global source in
+// math/rand would be concurrency safe (due to its internal use of
+// lockedSource), but it is prone to inter-package interference with the PRNG
+// state.
+// Also see https://github.com/cilium/cilium/issues/10988
+type safeRand struct {
+	mu lock.Mutex
+	r  *rand.Rand
+}
+
+func NewSafeRand(seed int64) safeRand {
+	return safeRand{r: rand.New(rand.NewSource(seed))}
+}
+
+func (sr *safeRand) Seed(seed int64) {
+	sr.mu.Lock()
+	sr.r.Seed(seed)
+	sr.mu.Unlock()
+}
+
+func (sr *safeRand) Int63() int64 {
+	sr.mu.Lock()
+	v := sr.r.Int63()
+	sr.mu.Unlock()
+	return v
+}
+
+func (sr *safeRand) Uint32() uint32 {
+	sr.mu.Lock()
+	v := sr.r.Uint32()
+	sr.mu.Unlock()
+	return v
+}
+
+func (sr *safeRand) Uint64() uint64 {
+	sr.mu.Lock()
+	v := sr.r.Uint64()
+	sr.mu.Unlock()
+	return v
+}
+
+func (sr *safeRand) Intn(n int) int {
+	sr.mu.Lock()
+	v := sr.r.Intn(n)
+	sr.mu.Unlock()
+	return v
+}
+
+func (sr *safeRand) Float64() float64 {
+	sr.mu.Lock()
+	v := sr.r.Float64()
+	sr.mu.Unlock()
+	return v
+}
+
+func (sr *safeRand) Perm(n int) []int {
+	sr.mu.Lock()
+	v := sr.r.Perm(n)
+	sr.mu.Unlock()
+	return v
+
+}

--- a/pkg/rand/safe_rand_test.go
+++ b/pkg/rand/safe_rand_test.go
@@ -1,0 +1,36 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package rand
+
+import (
+	"testing"
+)
+
+func TestIntn(t *testing.T) {
+	r0 := NewSafeRand(1)
+	r1 := NewSafeRand(1)
+
+	n := 10
+	for i := 0; i < 100; i++ {
+		v0 := r0.Intn(n)
+		v1 := r1.Intn(n)
+
+		if v0 != v1 {
+			t.Errorf("Intn() returned different values at iteration %d: %d != %d", i, v0, v1)
+		}
+	}
+}

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -21,7 +21,6 @@ import (
 	"html/template"
 	"io"
 	"io/ioutil"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -29,6 +28,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cilium/cilium/pkg/rand"
 	"github.com/cilium/cilium/pkg/versioncheck"
 	"github.com/cilium/cilium/test/config"
 	ginkgoext "github.com/cilium/cilium/test/ginkgo-ext"
@@ -40,7 +40,7 @@ import (
 )
 
 // ensure that our random numbers are seeded differently on each run
-var randGen = rand.New(rand.NewSource(time.Now().UnixNano()))
+var randGen = rand.NewSafeRand(time.Now().UnixNano())
 
 // IsRunningOnJenkins detects if the currently running Ginkgo application is
 // most likely running in a Jenkins environment. Returns true if certain

--- a/test/runtime/monitor.go
+++ b/test/runtime/monitor.go
@@ -17,18 +17,13 @@ package RuntimeTest
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"strings"
-	"time"
 
 	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
 
 	. "github.com/onsi/gomega"
 )
-
-// ensure that our random numbers are seeded differently on each run
-var randGen = rand.New(rand.NewSource(time.Now().UnixNano()))
 
 const (
 	// MonitorDropNotification represents the DropNotification configuration


### PR DESCRIPTION
    rand: add and use concurrency-safe PRNG source
The first 3 commits are preparatory cleanup and refactoring.

The main part is in the last commit:

    The godoc comment for package `math/rand` states:
    
      The default Source is safe for concurrent use by multiple goroutines, but
      Sources created by NewSource are not.
    
    The global source in `math/rand` would be concurrency-safe, but its
    state may be interfered with from unrelated packages, e.g.
    
    ```
    package a
    
    func init() {
            math.Seed(time.Now().UnixNano()
    }
    ```
    
    and
    
    ```
    package b
    
    func init() {
            math.Seed(0)
    }
    ```
    
    Depending on the package load order, the PRNG state would be predictable
    for all users (i.e.  always seeded using the fixed value 0), including
    `package a`.
    
    To fix this, provide a concurrency-safe wrapper around `math/rand.Rand`
    in `pkg/rand` and use it to replace all existing users of
    `math/rand.New(rand.NewSource(...))`

Fixes: #10988