### PR TITLE
test: Check kubectl with 'which' instead of 'dpkg -l'

### DIFF
--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -64,7 +64,8 @@ sudo service serial-getty@ttyS0 start
 
 # TODO: Check if the k8s version is the same
 if [[ -f  "/etc/provision_finished" ]]; then
-    sudo dpkg -l | grep kubelet
+    echo "Checking that kubelet exists in path"
+    which kubelet
     echo "provision is finished, recompiling"
     $PROVISIONSRC/compile.sh
     exit 0


### PR DESCRIPTION
When k8s install falls back to binary install kubelet does not exist
as a package, but exists in the path. Use 'which kubelet' to check k8s
install instead of 'dpkg -l' to cover both install methods.

This change fixes the failure to run ginkgo again on an already
running set of k8s nodes when k8s has been installed as binaries.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

