### PR TITLE
Docs fix for mounting bpf fs

### DIFF
--- a/Documentation/kubernetes/requirements.rst
+++ b/Documentation/kubernetes/requirements.rst
@@ -45,6 +45,16 @@ the `Kubernets CNI network-plugins documentation <https://kubernetes.io/docs/con
 Mounted BPF filesystem
 ======================
 
+.. Note::
+
+        Some distributions mount the bpf filesystem automatically. Check if the
+        bpf filesystem is mounted by running the command.
+
+        .. code:: shell-session
+
+                  mount | grep /sys/fs/bpf
+                  # if present should output, e.g. "none on /sys/fs/bpf type bpf"...
+
 This step is **required for production** environments but optional for testing
 and development. It allows the ``cilium-agent`` to pin BPF resources to a
 persistent filesystem and make them persistent across restarts of the agent.


### PR DESCRIPTION

Signed-off-by: Nate Sweet <nathanjsweet@pm.me>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->
Attempting to mount the bpf file system twice will result in error messages.
These messages confuse users into thinking they've done something incorrect.
A note of warning is added to the documentation so that users know when
they can skip mounting the bpf file system.

Fixes: #10955

