### PR TITLE
Makefile: fix test selection for privileged tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ clean-jenkins-precheck:
 	# remove the networks
 	docker-compose -f test/docker-compose.yml -p $(JOB_BASE_NAME)-$$BUILD_NUMBER down
 
-PRIV_TEST_PKGS_EVAL := $(shell for pkg in $(TESTPKGS); do echo $(pkg); done | xargs grep --include='*.go' -ril '+build [^!]*privileged_tests' | xargs dirname | sort | uniq)
+PRIV_TEST_PKGS_EVAL := $(shell for pkg in $(TESTPKGS); do echo $$pkg; done | xargs grep --include='*.go' -ril '+build [^!]*privileged_tests' | xargs dirname | sort | uniq)
 PRIV_TEST_PKGS ?= $(PRIV_TEST_PKGS_EVAL)
 tests-privileged:
 	# cilium-map-migrate is a dependency of some unit tests.


### PR DESCRIPTION
Because of a small mistake in the Makefile (`$(pkg)` to evaluate the variable with make, when it is a shell variable and should really be `$$pkg`), passing `TESTPKGS=pkg/foo/bar` when running `make tests-privileged` does not behave as expected and runs all test instead. Indeed, the shell command does not pass anything to xargs, and the grep is done recursively with no directory argument, so it applies to the entire cilium repository. Let's fix it.