### PR TITLE
bpf: remap MARK_MAGIC_SNAT_DONE marker to avoid conflicts

### DIFF
--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -379,7 +379,10 @@ enum {
 #define MARK_MAGIC_KEY_ID		0xF000
 #define MARK_MAGIC_KEY_MASK		0xFF00
 
-#define MARK_MAGIC_SNAT_DONE		0x0500
+/* IPSec cannot be configured with NodePort BPF today, hence non-conflicting
+ * overlap with MARK_MAGIC_KEY_ID.
+ */
+#define MARK_MAGIC_SNAT_DONE		0x1500
 
 /* IPv4 option used to carry service addr and port for DSR. Lower 16bits set to
  * zero so that they can be OR'd with service port.

--- a/pkg/datapath/linux/linux_defaults/mark.go
+++ b/pkg/datapath/linux/linux_defaults/mark.go
@@ -37,12 +37,7 @@ package linux_defaults
 //
 // Cilium Mark (4 bits):
 // M M M M
-// 1 0 1 0 Ingress proxy
-// 1 0 1 1 Egress proxy
-// 1 1 0 0 From host
-// 0 0 1 0 To Ingress Proxy
-// 0 0 1 1 To Egress proxy
-// 0 1 0 1 BPF SNAT done
+// (see MARK_MAGIC_* in bpf/lib/common.h)
 const (
 	// MagicMarkHostMask can be used to fetch the host/proxy-relevant magic
 	// bits from a mark.


### PR DESCRIPTION
See commit msg.

Fixes: #10942
Fixes: f25d8b97e908 ("bpf: Preserve source identity for hairpin via stack")
Reported-by: Martynas Pumputis <m@lambda.lt>
Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>