### PR TITLE
Handle audit mode in cilium endpoint list and kubectl get cep

### DIFF
--- a/api/v1/models/endpoint_policy_enabled.go
+++ b/api/v1/models/endpoint_policy_enabled.go
@@ -31,6 +31,15 @@ const (
 
 	// EndpointPolicyEnabledBoth captures enum value "both"
 	EndpointPolicyEnabledBoth EndpointPolicyEnabled = "both"
+
+	// EndpointPolicyEnabledAuditIngress captures enum value "audit-ingress"
+	EndpointPolicyEnabledAuditIngress EndpointPolicyEnabled = "audit-ingress"
+
+	// EndpointPolicyEnabledAuditEgress captures enum value "audit-egress"
+	EndpointPolicyEnabledAuditEgress EndpointPolicyEnabled = "audit-egress"
+
+	// EndpointPolicyEnabledAuditBoth captures enum value "audit-both"
+	EndpointPolicyEnabledAuditBoth EndpointPolicyEnabled = "audit-both"
 )
 
 // for schema
@@ -38,7 +47,7 @@ var endpointPolicyEnabledEnum []interface{}
 
 func init() {
 	var res []EndpointPolicyEnabled
-	if err := json.Unmarshal([]byte(`["none","ingress","egress","both"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["none","ingress","egress","both","audit-ingress","audit-egress","audit-both"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/cilium/cmd/endpoint_list.go
+++ b/cilium/cmd/endpoint_list.go
@@ -30,6 +30,7 @@ import (
 const (
 	PolicyEnabled  = "Enabled"
 	PolicyDisabled = "Disabled"
+	PolicyAudit    = "Disabled (Audit)"
 	UnknownState   = "Unknown"
 )
 
@@ -65,6 +66,12 @@ func endpointPolicyMode(ep *models.Endpoint) (string, string) {
 		return PolicyEnabled, PolicyDisabled
 	case models.EndpointPolicyEnabledEgress:
 		return PolicyDisabled, PolicyEnabled
+	case models.EndpointPolicyEnabledAuditBoth:
+		return PolicyAudit, PolicyAudit
+	case models.EndpointPolicyEnabledAuditIngress:
+		return PolicyAudit, PolicyDisabled
+	case models.EndpointPolicyEnabledAuditEgress:
+		return PolicyDisabled, PolicyAudit
 	}
 
 	return UnknownState, UnknownState

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -440,6 +440,18 @@ func (e *Endpoint) policyStatus() models.EndpointPolicyEnabled {
 	case e.realizedPolicy.EgressPolicyEnabled:
 		policyEnabled = models.EndpointPolicyEnabledEgress
 	}
+
+	if e.Options.IsEnabled(option.PolicyAuditMode) {
+		switch policyEnabled {
+		case models.EndpointPolicyEnabledIngress:
+			return models.EndpointPolicyEnabledAuditIngress
+		case models.EndpointPolicyEnabledEgress:
+			return models.EndpointPolicyEnabledAuditEgress
+		case models.EndpointPolicyEnabledBoth:
+			return models.EndpointPolicyEnabledAuditBoth
+		}
+	}
+
 	return policyEnabled
 }
 

--- a/pkg/endpoint/endpoint_status.go
+++ b/pkg/endpoint/endpoint_status.go
@@ -228,10 +228,10 @@ func (e *Endpoint) getEndpointPolicy() (policy *cilium_v2.EndpointPolicy) {
 	if e.desiredPolicy != nil {
 		policy = &cilium_v2.EndpointPolicy{
 			Ingress: &cilium_v2.EndpointPolicyDirection{
-				Enforcing: e.desiredPolicy.IngressPolicyEnabled,
+				Enforcing: !e.Options.IsEnabled(option.PolicyAuditMode) && e.desiredPolicy.IngressPolicyEnabled,
 			},
 			Egress: &cilium_v2.EndpointPolicyDirection{
-				Enforcing: e.desiredPolicy.EgressPolicyEnabled,
+				Enforcing: !e.Options.IsEnabled(option.PolicyAuditMode) && e.desiredPolicy.EgressPolicyEnabled,
 			},
 		}
 

--- a/pkg/endpoint/metrics.go
+++ b/pkg/endpoint/metrics.go
@@ -156,10 +156,13 @@ func (epPolicyMaps *endpointPolicyStatusMap) Remove(endpointID uint16) {
 // UpdateMetrics update the policy enforcement metrics statistics for the endpoints.
 func (epPolicyMaps *endpointPolicyStatusMap) UpdateMetrics() {
 	policyStatus := map[models.EndpointPolicyEnabled]float64{
-		models.EndpointPolicyEnabledNone:    0,
-		models.EndpointPolicyEnabledEgress:  0,
-		models.EndpointPolicyEnabledIngress: 0,
-		models.EndpointPolicyEnabledBoth:    0,
+		models.EndpointPolicyEnabledNone:         0,
+		models.EndpointPolicyEnabledEgress:       0,
+		models.EndpointPolicyEnabledIngress:      0,
+		models.EndpointPolicyEnabledBoth:         0,
+		models.EndpointPolicyEnabledAuditEgress:  0,
+		models.EndpointPolicyEnabledAuditIngress: 0,
+		models.EndpointPolicyEnabledAuditBoth:    0,
 	}
 
 	epPolicyMaps.mutex.Lock()

--- a/test/helpers/cmd.go
+++ b/test/helpers/cmd.go
@@ -120,6 +120,14 @@ func (res *CmdRes) ExpectContains(data string, optionalDescription ...interface{
 		gomega.ContainSubstring(data), optionalDescription...)
 }
 
+// ExpectMatchesRegexp asserts that the stdout of the executed command
+// matches the regexp. It accepts an optional parameter that can be
+// used to annotate failure messages.
+func (res *CmdRes) ExpectMatchesRegexp(regexp string, optionalDescription ...interface{}) bool {
+	return gomega.ExpectWithOffset(1, res.Output().String()).To(
+		gomega.MatchRegexp(regexp), optionalDescription...)
+}
+
 // ExpectDoesNotContain asserts that a string is not contained in the stdout of
 // the executed command. It accepts an optional parameter that can be used to
 // annotate failure messages.

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -1496,6 +1496,10 @@ var _ = Describe("RuntimePolicies", func() {
 					"No ingress policy log record",
 				)
 				monitorRes.ExpectContains(fmt.Sprintf("-> endpoint %s ", endpointID), "No ingress traffic to endpoint")
+
+				By("Testing cilium endpoint list output")
+				res = vm.Exec("cilium endpoint list")
+				res.ExpectMatchesRegexp(endpointID+"\\s*Disabled \\(Audit\\)\\s*Disabled \\(Audit\\)", "Endpoint is not in audit mode")
 			})
 
 			It("tests egress", func() {
@@ -1515,6 +1519,10 @@ var _ = Describe("RuntimePolicies", func() {
 					"No egress policy log record",
 				)
 				monitorRes.ExpectContains(fmt.Sprintf("-> endpoint %s ", endpointID), "No reply traffic to endpoint")
+
+				By("Testing cilium endpoint list output")
+				res := vm.Exec("cilium endpoint list")
+				res.ExpectMatchesRegexp(endpointID+"\\s*Disabled \\(Audit\\)\\s*Disabled \\(Audit\\)", "Endpoint is not in audit mode")
 			})
 		})
 	})


### PR DESCRIPTION
This patch improve enforcement status reporting for
'cilium endpoint list' and 'kubectl get cep'. Former will have a new
audit status and later will show Enforcing=false when policy audit
mode is enabled.

`cilium endpoint list`:
```
ENDPOINT   POLICY (ingress)   POLICY (egress)   IDENTITY   LABELS (source:key[=value])                                                                   IPv6   IPv4           STATUS   
           ENFORCEMENT        ENFORCEMENT                                                                                                                                      
144        Audit              Disabled          52972      k8s:app=review-with-maste-d9llml                                                                     10.111.0.90    ready   
                                                           k8s:io.cilium.k8s.namespace.labels.app.gitlab.com/app=gitlab-org-defend-network-policy-demo                                 
                                                           k8s:io.cilium.k8s.namespace.labels.app.gitlab.com/env=review-with-maste-d9llml                                              
                                                           k8s:io.cilium.k8s.policy.cluster=default                                                                                    
                                                           k8s:io.cilium.k8s.policy.serviceaccount=default                                                                             
                                                           k8s:io.kubernetes.pod.namespace=network-policy-demo-15787276-review-with-maste-d9llml                                       
                                                           k8s:release=review-with-maste-d9llml                                                                                        
                                                           k8s:tier=web                                                                                                                
                                                           k8s:track=stable                                                                                                            
```

`kubectl get cep`:
```
NAME                                        ENDPOINT ID   IDENTITY ID   INGRESS ENFORCEMENT   EGRESS ENFORCEMENT   VISIBILITY POLICY   ENDPOINT STATE   IPV4          IPV6
review-with-maste-d9llml-769d6d66d5-vvqx4   144           52972         false                 false                                    ready            10.111.0.90   
```