### PR TITLE
daemon: Fatal on startup when Identity CRD is enabled without k8s

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -852,6 +852,12 @@ func initEnv(cmd *cobra.Command) {
 		}
 	}
 
+	// This check is here instead of in DaemonConfig.Populate (invoked at the
+	// start of this function as option.Config.Populate) to avoid an import loop.
+	if option.Config.IdentityAllocationMode == option.IdentityAllocationModeCRD && !k8s.IsEnabled() {
+		log.Fatal("CRD Identity allocation mode requires k8s to be configured.")
+	}
+
 	if option.Config.PProf {
 		pprof.Enable()
 	}

--- a/operator/main.go
+++ b/operator/main.go
@@ -280,6 +280,10 @@ func runOperator(cmd *cobra.Command) {
 
 	switch option.Config.IdentityAllocationMode {
 	case option.IdentityAllocationModeCRD:
+		if !k8s.IsEnabled() {
+			log.Fatal("CRD Identity allocation mode requires k8s to be configured.")
+		}
+
 		startManagingK8sIdentities()
 
 		if option.Config.IdentityGCInterval != 0 {


### PR DESCRIPTION
We've seen panics where it seems k8s isn't setup correctly but CRD
relation operations occur, and segfault. This occurs when the kubernetes
service is not ready  by the time cilium starts up and so it misses the
KUBERNETES_SERVICE_{HOST,PORT} settings.
See https://github.com/kubernetes/kubernetes/issues/40973

This is mostly a testing issue because we mark tests as failed if panics occur.
