### PR TITLE
pkg/k8s: detect k8s mode if env variable K8S_NODE_NAME is set

### DIFF
--- a/pkg/k8s/config.go
+++ b/pkg/k8s/config.go
@@ -80,5 +80,6 @@ func IsEnabled() bool {
 	return config.APIServerURL != "" ||
 		config.KubeconfigPath != "" ||
 		(os.Getenv("KUBERNETES_SERVICE_HOST") != "" &&
-			os.Getenv("KUBERNETES_SERVICE_PORT") != "")
+			os.Getenv("KUBERNETES_SERVICE_PORT") != "") ||
+		os.Getenv("K8S_NODE_NAME") != ""
 }


### PR DESCRIPTION
Since the k8s service is only created after the container is started,
kubelet is not fast enough to set `KUBERNETES_SERVICE_HOST` nor
`KUBERNETES_SERVICE_PORT` in a container which can result in Cilium
having non-expected behaviors such as: panicking upon initialization; use
an autogenerated IPv4 allocated IP as Cilium won't detect which podCIDR
the k8s node has set; Re-allocate cilium_host router IP address which
can cause network disruption; Inability to restore endpoints since their
IP do not belong to the autogenerated CIDR.

As all Cilium DaemonSets have the K8S_NODE_NAME environment variable set
we can detect if Cilium is running in k8s mode by also checking if this
flag is set and not depend on `KUBERNETES_SERVICE_HOST` nor
`KUBERNETES_SERVICE_PORT` for this detection.

More info: https://github.com/kubernetes/kubernetes/issues/40973

Signed-off-by: André Martins <andre@cilium.io>

```release-note
Do not depend on `KUBERNETES_SERVICE_HOST` nor
`KUBERNETES_SERVICE_PORT` environment variables to detect if cilium is running in k8s mode
```
