### PR TITLE
examples/getting-started: add bind mount for docker socket to docker-compose.yml

### DIFF
--- a/examples/getting-started/docker-compose.yml
+++ b/examples/getting-started/docker-compose.yml
@@ -24,6 +24,7 @@ services:
     image: docker.io/cilium/docker-plugin:${CILIUM_TAG}
     command: cilium-docker
     volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
       - /var/run/cilium:/var/run/cilium
       - /run/docker/plugins:/run/docker/plugins
     network_mode: "host"


### PR DESCRIPTION
The cilium-docker plugin needs access to the docker socket, thus a bind
mount is needed.

Fixes #10962

```release-note
Fix Docker getting started guide example.
```
