### PR TITLE
pkg/endpoint: Simplify search for C header file during restore

### DIFF
--- a/common/utils.go
+++ b/common/utils.go
@@ -50,17 +50,6 @@ func C2GoArray(str string) []byte {
 	return ret
 }
 
-// FindEPConfigCHeader returns the full path of the file that is the CHeaderFileName from
-// the slice of files
-func FindEPConfigCHeader(basePath string, epFiles []os.FileInfo) string {
-	for _, epFile := range epFiles {
-		if epFile.Name() == CHeaderFileName {
-			return filepath.Join(basePath, epFile.Name())
-		}
-	}
-	return ""
-}
-
 // GetCiliumVersionString returns the first line containing CiliumCHeaderPrefix.
 func GetCiliumVersionString(epCHeaderFilePath string) (string, error) {
 	f, err := os.Open(epCHeaderFilePath)

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -217,6 +217,7 @@ const (
 	ClangErrorMsg      = "1 error generated."                         // from https://github.com/cilium/cilium/issues/10857
 	symbolSubstitution = "Skipping symbol substitution"               //
 	uninitializedRegen = "Uninitialized regeneration level"           // from https://github.com/cilium/cilium/pull/10949
+	unstableStat       = "BUG: stat() has unstable behavior"          // from https://github.com/cilium/cilium/pull/11028
 
 	// HelmTemplate is the location of the Helm templates to install Cilium
 	HelmTemplate = "../install/kubernetes/cilium"
@@ -276,6 +277,7 @@ var badLogMessages = map[string][]string{
 	ClangErrorMsg:      nil,
 	symbolSubstitution: nil,
 	uninitializedRegen: nil,
+	unstableStat:       nil,
 }
 
 var ciliumCLICommands = map[string]string{


### PR DESCRIPTION
Since we know the C header filename, we don't need to list the endpoint directory's content. We can simply check if the file exists.

*Extracted from the host firewall branch.*

@aanm Do you remember if there was a reason for listing the directory content instead of checking if the file exists? I feel like I'm missing something here. Commit [`2365922`](https://github.com/cilium/cilium/commit/2365922a02c83053fa08b4bd268861e71435e863#diff-bf5ec19662b7a3700c86fda28d3f305aR69) introduced this code.