### PR TITLE
examples/getting-started: revert bind mount for /var/lib/cilium

### DIFF
--- a/examples/getting-started/docker-compose.yml
+++ b/examples/getting-started/docker-compose.yml
@@ -7,7 +7,6 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /var/run/cilium:/var/run/cilium
-      - /var/lib/cilium:/var/lib/cilium
       - /sys/fs/bpf:/sys/fs/bpf
       # To access Docker container netns:
       - /var/run/docker/netns:/var/run/docker/netns:rshared


### PR DESCRIPTION
PR #11022 broke running Cilium in Docker on master. The bind mount is
actually not needed as the files are installed within the container.

This reverts commit eca8c985aab1 ("examples/getting-started: add bind
mount for /var/lib/cilium to docker-compose.yml")

Verified that the gsg still runs on master (using `CILIUM_TAG=latest CILIUM_VERSION=latest vagrant up`) and on 1.7 with this change.