### PR TITLE
cilium: fix cell alignment in status output

### DIFF
--- a/cilium/cmd/status.go
+++ b/cilium/cmd/status.go
@@ -107,9 +107,9 @@ func statusDaemon() {
 		sr := resp.Payload
 		w := tabwriter.NewWriter(os.Stdout, 2, 0, 3, ' ', 0)
 		pkg.FormatStatusResponse(w, sr, allAddresses, allControllers, allNodes, allRedirects, allClusters)
-		w.Flush()
 
 		if isUnhealthy(sr) {
+			w.Flush()
 			os.Exit(1)
 		}
 


### PR DESCRIPTION
On a healthy cluster, status output looks something like the following:

    KVStore:                Ok         Consul: 172.18.0.2:8300
    Kubernetes:             Disabled
    Cilium:                 Ok         OK
    NodeMonitor:            Disabled
    Cilium health daemon:   Ok
    IPAM:                   IPv4: 2/65535 allocated from 10.15.0.0/16,
    Controller Status:      14/14 healthy
    Proxy Status:           OK, ip 10.15.225.211, 0 redirects active on ports 10000-20000
    Hubble:                 Disabled
    Cluster health:   1/1 reachable   (2020-04-17T11:28:03Z)

Note that in the last line (`Cluster health`), the second cell is not
aligned with the others. This due to the fact that the `tabwriter.Writer`
is flushed before calling `healthPkg.GetAndFormatHealthStatus` which is
formatting the last line. Fix it by moving the first, unconditional
flush within the `isUnhealthy(sr)` condition, leading to the following
output:

    KVStore:                Ok         Consul: 172.18.0.2:8300
    Kubernetes:             Disabled
    Cilium:                 Ok         OK
    NodeMonitor:            Disabled
    Cilium health daemon:   Ok
    IPAM:                   IPv4: 2/65535 allocated from 10.15.0.0/16,
    Controller Status:      14/14 healthy
    Proxy Status:           OK, ip 10.15.225.211, 0 redirects active on ports 10000-20000
    Hubble:                 Disabled
    Cluster health:         1/1 reachable   (2020-04-17T11:43:03Z)