### PR TITLE
CRD: fix allocation logic of identities with the same set of labels

### DIFF
--- a/operator/k8s_identity.go
+++ b/operator/k8s_identity.go
@@ -49,6 +49,8 @@ func deleteIdentity(identity *types.Identity) error {
 		})
 	if err != nil {
 		log.WithError(err).Error("Unable to delete identity")
+	} else {
+		log.WithFields(logrus.Fields{"identity": identity.GetName()}).Info("Garbage collected identity")
 	}
 
 	return err

--- a/pkg/allocator/allocator.go
+++ b/pkg/allocator/allocator.go
@@ -596,15 +596,6 @@ func (a *Allocator) Allocate(ctx context.Context, key AllocatorKey) (idpool.ID, 
 		return 0, false, fmt.Errorf("allocation was cancelled while waiting for initial key list to be received: %s", ctx.Err())
 	}
 
-	// Check our list of local keys already in use and increment the
-	// refcnt. The returned key must be released afterwards. No kvstore
-	// operation was performed for this allocation
-	if val := a.localKeys.use(k); val != idpool.NoID {
-		kvstore.Trace("Reusing local id", nil, logrus.Fields{fieldID: val, fieldKey: key})
-		a.mainCache.insert(key, val)
-		return val, false, nil
-	}
-
 	kvstore.Trace("Allocating from kvstore", nil, logrus.Fields{fieldKey: key})
 
 	// make a copy of the template and customize it
@@ -612,6 +603,19 @@ func (a *Allocator) Allocate(ctx context.Context, key AllocatorKey) (idpool.ID, 
 	boff.Name = key.String()
 
 	for attempt := 0; attempt < maxAllocAttempts; attempt++ {
+		// Check our list of local keys already in use and increment the
+		// refcnt. The returned key must be released afterwards. No kvstore
+		// operation was performed for this allocation.
+		// We also do this on every loop as a different Allocate call might have
+		// allocated the key while we are attempting to allocate in this
+		// execution thread. It does not hurt to check if localKeys contains a
+		// reference for the key that we are attempting to allocate.
+		if val := a.localKeys.use(k); val != idpool.NoID {
+			kvstore.Trace("Reusing local id", nil, logrus.Fields{fieldID: val, fieldKey: key})
+			a.mainCache.insert(key, val)
+			return val, false, nil
+		}
+
 		// FIXME: Add non-locking variant
 		value, isNew, err = a.lockedAllocate(ctx, key)
 		if err == nil {
@@ -624,16 +628,6 @@ func (a *Allocator) Allocate(ctx context.Context, key AllocatorKey) (idpool.ID, 
 			fieldKey:          key,
 			logfields.Attempt: attempt,
 		})
-
-		// A different Allocate call might have allocated the key while we were
-		// attempting to allocate in this execution thread. It does not hurt
-		// to check if localKeys contains a reference for the key that we are
-		// attempting to allocate.
-		if val := a.localKeys.use(k); val != idpool.NoID {
-			kvstore.Trace("Reusing local id", nil, logrus.Fields{fieldID: val, fieldKey: key})
-			a.mainCache.insert(key, val)
-			return val, false, nil
-		}
 
 		select {
 		case <-ctx.Done():

--- a/pkg/allocator/allocator.go
+++ b/pkg/allocator/allocator.go
@@ -703,7 +703,7 @@ func (a *Allocator) Release(ctx context.Context, key AllocatorKey) (lastUse bool
 
 	// release the key locally, if it was the last use, remove the node
 	// specific value key to remove the global reference mark
-	lastUse, err = a.localKeys.release(k)
+	lastUse, _, err = a.localKeys.release(k)
 	if err != nil {
 		return lastUse, err
 	}

--- a/pkg/allocator/allocator.go
+++ b/pkg/allocator/allocator.go
@@ -206,7 +206,7 @@ type Backend interface {
 	// Release releases the use of an ID associated with the provided key. It
 	// does not guard against concurrent calls to
 	// releases.Release(ctx context.Context, key AllocatorKey) (err error)
-	Release(ctx context.Context, key AllocatorKey) (err error)
+	Release(ctx context.Context, id idpool.ID, key AllocatorKey) (err error)
 
 	// UpdateKey refreshes the record that this node is using this key -> id
 	// mapping. When reliablyMissing is set it will also recreate missing master or
@@ -703,12 +703,17 @@ func (a *Allocator) Release(ctx context.Context, key AllocatorKey) (lastUse bool
 
 	// release the key locally, if it was the last use, remove the node
 	// specific value key to remove the global reference mark
-	lastUse, _, err = a.localKeys.release(k)
+	var id idpool.ID
+	lastUse, id, err = a.localKeys.release(k)
 	if err != nil {
 		return lastUse, err
 	}
 	if lastUse {
-		a.backend.Release(ctx, key)
+		// Since in CRD mode we don't have a way to map which identity is being
+		// used by a node, we need to also pass the ID to the release function.
+		// This allows the CRD store to find the right identity by its ID and
+		// remove the node reference on that identity.
+		a.backend.Release(ctx, id, key)
 	}
 
 	return lastUse, err

--- a/pkg/allocator/allocator_test.go
+++ b/pkg/allocator/allocator_test.go
@@ -148,11 +148,12 @@ func (d *dummyBackend) GetByID(ctx context.Context, id idpool.ID) (AllocatorKey,
 	return nil, nil
 }
 
-func (d *dummyBackend) Release(ctx context.Context, key AllocatorKey) error {
+func (d *dummyBackend) Release(ctx context.Context, id idpool.ID, key AllocatorKey) error {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
-	for id, k := range d.identities {
-		if k.GetKey() == key.GetKey() {
+	for idtyID, k := range d.identities {
+		if k.GetKey() == key.GetKey() &&
+			idtyID == id {
 			delete(d.identities, id)
 			if d.handler != nil {
 				d.handler.OnDelete(id, k)

--- a/pkg/allocator/localkeys.go
+++ b/pkg/allocator/localkeys.go
@@ -129,9 +129,10 @@ func (lk *localKeys) use(key string) idpool.ID {
 	return idpool.NoID
 }
 
-// release releases the refcnt of a key. When the last reference was released,
-// the key is deleted and the returned lastUse value is true.
-func (lk *localKeys) release(key string) (lastUse bool, err error) {
+// release releases the refcnt of a key. It returns the ID associated with the
+// given key. When the last reference was released, the key is deleted and the
+// returned lastUse value is true.
+func (lk *localKeys) release(key string) (lastUse bool, id idpool.ID, err error) {
 	lk.Lock()
 	defer lk.Unlock()
 	if k, ok := lk.keys[key]; ok {
@@ -140,13 +141,13 @@ func (lk *localKeys) release(key string) (lastUse bool, err error) {
 		if k.refcnt == 0 {
 			delete(lk.keys, key)
 			delete(lk.ids, k.val)
-			return true, nil
+			return true, k.val, nil
 		}
 
-		return false, nil
+		return false, k.val, nil
 	}
 
-	return false, fmt.Errorf("unable to find key in local cache")
+	return false, idpool.NoID, fmt.Errorf("unable to find key in local cache")
 }
 
 func (lk *localKeys) getVerifiedIDs() map[idpool.ID]AllocatorKey {

--- a/pkg/k8s/identitybackend/identity.go
+++ b/pkg/k8s/identitybackend/identity.go
@@ -267,6 +267,8 @@ func (c *crdLock) Comparator() interface{} {
 	return nil
 }
 
+// get returns the first identity found for the given set of labels as we might
+// have duplicated entries identities for the same set of labels.
 func (c *crdBackend) get(ctx context.Context, key allocator.AllocatorKey) *types.Identity {
 	if c.Store == nil {
 		return nil
@@ -286,7 +288,7 @@ func (c *crdBackend) get(ctx context.Context, key allocator.AllocatorKey) *types
 	return nil
 }
 
-// Get returns the ID which is allocated to a key in the identity CRDs in
+// Get returns the first ID which is allocated to a key in the identity CRDs in
 // kubernetes.
 // Note: the lock field is not supported with the k8s CRD allocator.
 func (c *crdBackend) Get(ctx context.Context, key allocator.AllocatorKey) (idpool.ID, error) {

--- a/pkg/k8s/identitybackend/identity.go
+++ b/pkg/k8s/identitybackend/identity.go
@@ -33,8 +33,8 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/sirupsen/logrus"
 
+	"github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -307,12 +307,11 @@ func (c *crdBackend) GetIfLocked(ctx context.Context, key allocator.AllocatorKey
 	return c.Get(ctx, key)
 }
 
-// GetByID returns the key associated with an ID. Returns nil if no key is
-// associated with the ID.
-// Note: the lock field is not supported with the k8s CRD allocator.
-func (c *crdBackend) GetByID(ctx context.Context, id idpool.ID) (allocator.AllocatorKey, error) {
+// getById fetches the identities from the local store. Returns a nil `err` and
+// false `exists` if an Identity is not found for the given `id`.
+func (c *crdBackend) getById(ctx context.Context, id idpool.ID) (idty *types.Identity, exists bool, err error) {
 	if c.Store == nil {
-		return nil, fmt.Errorf("store is not available yet")
+		return nil, false, fmt.Errorf("store is not available yet")
 	}
 
 	identityTemplate := &types.Identity{
@@ -325,15 +324,29 @@ func (c *crdBackend) GetByID(ctx context.Context, id idpool.ID) (allocator.Alloc
 
 	obj, exists, err := c.Store.Get(identityTemplate)
 	if err != nil {
-		return nil, err
+		return nil, exists, err
 	}
 	if !exists {
-		return nil, nil
+		return nil, exists, nil
 	}
 
 	identity, ok := obj.(*types.Identity)
 	if !ok {
-		return nil, fmt.Errorf("invalid object")
+		return nil, false, fmt.Errorf("invalid object")
+	}
+	return identity, true, nil
+}
+
+// GetByID returns the key associated with an ID. Returns nil if no key is
+// associated with the ID.
+// Note: the lock field is not supported with the k8s CRD allocator.
+func (c *crdBackend) GetByID(ctx context.Context, id idpool.ID) (allocator.AllocatorKey, error) {
+	identity, exists, err := c.getById(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, nil
 	}
 
 	return c.KeyType.PutKeyFromMap(identity.SecurityLabels), nil

--- a/pkg/k8s/identitybackend/identity.go
+++ b/pkg/k8s/identitybackend/identity.go
@@ -129,15 +129,17 @@ type JSONPatch struct {
 // being garbage collected.
 // Note: the lock field is not supported with the k8s CRD allocator.
 func (c *crdBackend) AcquireReference(ctx context.Context, id idpool.ID, key allocator.AllocatorKey, lock kvstore.KVLocker) error {
-	identity := c.get(ctx, key)
-	if identity == nil {
+	identity, exists, err := c.getById(ctx, id)
+	if err != nil {
+		return err
+	}
+	if !exists {
 		return fmt.Errorf("identity does not exist")
 	}
 
 	capabilities := k8sversion.Capabilities()
 	identityOps := c.Client.CiliumV2().CiliumIdentities()
 
-	var err error
 	if capabilities.Patch {
 		var patch []byte
 		patch, err = json.Marshal([]JSONPatch{

--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -370,7 +370,7 @@ func (k *kvstoreBackend) UpdateKeyIfLocked(ctx context.Context, id idpool.ID, ke
 // Release releases the use of an ID associated with the provided key.  It does
 // not guard against concurrent releases. This is currently guarded by
 // Allocator.slaveKeysMutex when called from pkg/allocator.Allocator.Release.
-func (k *kvstoreBackend) Release(ctx context.Context, key allocator.AllocatorKey) (err error) {
+func (k *kvstoreBackend) Release(ctx context.Context, _ idpool.ID, key allocator.AllocatorKey) (err error) {
 	valueKey := path.Join(k.valuePrefix, k.backend.Encode([]byte(key.GetKey())), k.suffix)
 	log.WithField(fieldKey, key).Info("Released last local use of key, invoking global release")
 


### PR DESCRIPTION
Please read per commit, the overall idea is that in CRD mode we don't map which node has a particular identity and without this mapping it becomes tricky knowing which identity a particular node should hold or release the reference of.
