### PR TITLE
bump k8s dependencies and test to v1.16.9

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1555,7 +1555,7 @@
     "storage/v1beta1",
   ]
   pruneopts = "NUT"
-  revision = "kubernetes-1.16.8"
+  revision = "kubernetes-1.16.9"
 
 [[projects]]
   digest = "1:7febd5a0e29d26b0732a8f65d8034d9ff88b44dc05ca0de69af775649c31aeaa"
@@ -1570,10 +1570,10 @@
     "pkg/client/clientset/clientset/typed/apiextensions/v1beta1",
   ]
   pruneopts = "NUT"
-  revision = "kubernetes-1.16.8"
+  revision = "kubernetes-1.16.9"
 
 [[projects]]
-  digest = "1:fa7cf320ac00a2d71abc80ccfaa2a31a36e2f45844c62112efba697c177adeb3"
+  digest = "1:9bd695d818c8395c2cb263d1e442496f5c3cf86d6447e864e1dca6d38fb23542"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/equality",
@@ -1622,10 +1622,10 @@
     "third_party/forked/golang/reflect",
   ]
   pruneopts = "NUT"
-  revision = "kubernetes-1.16.8"
+  revision = "kubernetes-1.16.9"
 
 [[projects]]
-  digest = "1:1a23e311003e30ef1554b08a7c23f71cd8358656ebd9fc4d1f5dc2eb63ff0a9e"
+  digest = "1:421721461ab2987bb721dd8ecb397b7ab1aafb3ed2bbcda185af0db2f8b1099e"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -1737,7 +1737,7 @@
     "util/retry",
   ]
   pruneopts = "NUT"
-  revision = "b48fb58e4bc35877de8c0d65b56824823774a8ed"
+  revision = "0481265146a5db11d297ba153a6772809c800887"
   source = "https://github.com/cilium/client-go"
 
 [[projects]]
@@ -1756,14 +1756,14 @@
     "pkg/util",
   ]
   pruneopts = "T"
-  revision = "kubernetes-1.16.8"
+  revision = "kubernetes-1.16.9"
 
 [[projects]]
   digest = "1:5e496d711fa03e4aaf3cab0d7de079634a9465ebf940613b69b34f5cc6513db8"
   name = "k8s.io/cri-api"
   packages = ["pkg/apis/runtime/v1alpha2"]
   pruneopts = "NUT"
-  revision = "kubernetes-1.16.8"
+  revision = "kubernetes-1.16.9"
 
 [[projects]]
   digest = "1:d233b263f74608ab5528c04453935d899a2b9fb0bf02b03d38a4a11f91442a5c"
@@ -1808,7 +1808,7 @@
     "pkg/registry/core/service/ipallocator",
   ]
   pruneopts = "NUT"
-  revision = "v1.16.8"
+  revision = "v1.16.9"
 
 [[projects]]
   digest = "1:99dbf7ef753ca02399778c93a4ed4b689b28668317134ecd1fabeb07be70f354"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -514,28 +514,28 @@ required = [
 
 [[constraint]]
   name = "k8s.io/api"
-  revision = "kubernetes-1.16.8"
+  revision = "kubernetes-1.16.9"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
 
 [[constraint]]
   name = "k8s.io/apiextensions-apiserver"
-  revision = "kubernetes-1.16.8"
+  revision = "kubernetes-1.16.9"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
 
 [[override]]
   name = "k8s.io/apiserver"
-  revision = "kubernetes-1.16.8"
+  revision = "kubernetes-1.16.9"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
 
 [[constraint]]
   name = "k8s.io/apimachinery"
-  revision = "kubernetes-1.16.8"
+  revision = "kubernetes-1.16.9"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
@@ -543,10 +543,10 @@ required = [
 [[constraint]]
   name = "k8s.io/client-go"
   source = "https://github.com/cilium/client-go"
-  revision = "b48fb58e4bc35877de8c0d65b56824823774a8ed"
+  revision = "0481265146a5db11d297ba153a6772809c800887"
 
   # main-usage = "pkg/k8s"
-  # on-revision = "TODO @aanm is on b48fb58e4bc35877de8c0d65b56824823774a8ed as it contains the hotfix for the metrics path"
+  # on-revision = "TODO @aanm is on 0481265146a5db11d297ba153a6772809c800887 as it contains the hotfix for the metrics path"
 
 [[override]]
   name = "k8s.io/utils"
@@ -557,7 +557,7 @@ required = [
 
 [[constraint]]
   name = "k8s.io/code-generator"
-  revision = "kubernetes-1.16.8"
+  revision = "kubernetes-1.16.9"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
@@ -571,14 +571,14 @@ required = [
 
 [[constraint]]
   name = "k8s.io/kubernetes"
-  revision = "v1.16.8"
+  revision = "v1.16.9"
 
   # main-usage = "pkg/k8s"
   # on-revision = ""
 
 [[constraint]]
   name = "k8s.io/cri-api"
-  revision = "kubernetes-1.16.8"
+  revision = "kubernetes-1.16.9"
 
   # main-usage = "pkg/workloads"
   # on-revision = ""

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -17,7 +17,7 @@ CONTAINER_RUNTIME=$5
 CNI_INTEGRATION=$6
 # Pinned to the last version of k8s 1.16 branch so we can do
 # kubectl apply on older k8s test frameworks
-K8S_KUBECTL_APPLY_FORCE="1.16.8"
+K8S_KUBECTL_APPLY_FORCE="1.16.9"
 
 # Kubeadm default parameters
 export KUBEADM_ADDR='192.168.36.11'

--- a/vendor/k8s.io/apimachinery/pkg/util/net/http.go
+++ b/vendor/k8s.io/apimachinery/pkg/util/net/http.go
@@ -55,6 +55,12 @@ func JoinPreservingTrailingSlash(elem ...string) string {
 	return result
 }
 
+// IsTimeout returns true if the given error is a network timeout error
+func IsTimeout(err error) bool {
+	neterr, ok := err.(net.Error)
+	return ok && neterr != nil && neterr.Timeout()
+}
+
 // IsProbableEOF returns true if the given error resembles a connection termination
 // scenario that would justify assuming that the watch is empty.
 // These errors are what the Go http stack returns back to us which are general

--- a/vendor/k8s.io/apimachinery/pkg/watch/streamwatcher.go
+++ b/vendor/k8s.io/apimachinery/pkg/watch/streamwatcher.go
@@ -113,7 +113,7 @@ func (sw *StreamWatcher) receive() {
 			case io.ErrUnexpectedEOF:
 				klog.V(1).Infof("Unexpected EOF during watch stream event decoding: %v", err)
 			default:
-				if net.IsProbableEOF(err) {
+				if net.IsProbableEOF(err) || net.IsTimeout(err) {
 					klog.V(5).Infof("Unable to decode an event from the watch stream: %v", err)
 				} else {
 					sw.result <- Event{

--- a/vendor/k8s.io/client-go/rest/request.go
+++ b/vendor/k8s.io/client-go/rest/request.go
@@ -607,7 +607,7 @@ func (r *Request) WatchWithSpecificDecoders(wrapperDecoderFn func(io.ReadCloser)
 	if err != nil {
 		// The watch stream mechanism handles many common partial data errors, so closed
 		// connections can be retried in many cases.
-		if net.IsProbableEOF(err) {
+		if net.IsProbableEOF(err) || net.IsTimeout(err) {
 			return watch.NewEmptyWatch(), nil
 		}
 		return nil, err

--- a/vendor/k8s.io/client-go/tools/cache/reflector.go
+++ b/vendor/k8s.io/client-go/tools/cache/reflector.go
@@ -269,6 +269,8 @@ func (r *Reflector) ListAndWatch(stopCh <-chan struct{}) error {
 			AllowWatchBookmarks: true,
 		}
 
+		// start the clock before sending the request, since some proxies won't flush headers until after the first watch event is sent
+		start := r.clock.Now()
 		w, err := r.listerWatcher.Watch(options)
 		if err != nil {
 			switch err {
@@ -290,7 +292,7 @@ func (r *Reflector) ListAndWatch(stopCh <-chan struct{}) error {
 			return nil
 		}
 
-		if err := r.watchHandler(w, &resourceVersion, resyncerrc, stopCh); err != nil {
+		if err := r.watchHandler(start, w, &resourceVersion, resyncerrc, stopCh); err != nil {
 			if err != errorStopRequested {
 				switch {
 				case apierrs.IsResourceExpired(err):
@@ -314,8 +316,7 @@ func (r *Reflector) syncWith(items []runtime.Object, resourceVersion string) err
 }
 
 // watchHandler watches w and keeps *resourceVersion up to date.
-func (r *Reflector) watchHandler(w watch.Interface, resourceVersion *string, errc chan error, stopCh <-chan struct{}) error {
-	start := r.clock.Now()
+func (r *Reflector) watchHandler(start time.Time, w watch.Interface, resourceVersion *string, errc chan error, stopCh <-chan struct{}) error {
 	eventCount := 0
 
 	// Stopping the watcher should be idempotent and if we return from this function there's no way

--- a/vendor/k8s.io/kubernetes/.bazelversion
+++ b/vendor/k8s.io/kubernetes/.bazelversion
@@ -1,0 +1,1 @@
+build/root/.bazelversion


### PR DESCRIPTION
Signed-off-by: André Martins <andre@cilium.io>

Changelog includes a regression fix in the client-go library that was created in k8s 1.15.

>client-go: resolves an issue with informers falling back to full list requests when timeouts are encountered, rather than re-establishing a watch.

https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.16.md#changelog-since-v1168