### PR TITLE
hostport: read the hostport setting from viper

### DIFF
--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2332,6 +2332,7 @@ func (c *DaemonConfig) Populate() {
 	c.EnableL7Proxy = viper.GetBool(EnableL7Proxy)
 	c.EnableTracing = viper.GetBool(EnableTracing)
 	c.EnableNodePort = viper.GetBool(EnableNodePort)
+	c.EnableHostPort = viper.GetBool(EnableHostPort)
 	c.NodePortMode = viper.GetString(NodePortMode)
 	c.NodePortAcceleration = viper.GetString(NodePortAcceleration)
 	c.EnableAutoProtectNodePortRange = viper.GetBool(EnableAutoProtectNodePortRange)


### PR DESCRIPTION
Previously, it may lost hostport setting if we do not set
kube-proxy-replacement as strict or probe.

Fixes: 7fcf660ba6ed ("cilium, bpf: add native HostPort mapping support")
Signed-off-by: Wang Li <wangli09@kuaishou.com>

release-note/bug