### PR TITLE
tests: disable base tests in xdp/tc nodeport lb test

### DIFF
--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -709,7 +709,7 @@ var _ = Describe("K8sServicesTest", func() {
 			doRequestsFromThirdHost(tftpURL, 10, checkUDP)
 
 			// Make sure all the rest works as expected as well
-			testNodePort(true)
+			//testNodePort(true)
 
 			// Clear CT tables on both Cilium nodes
 			pod, err := kubectl.GetCiliumPodOnNode(helpers.CiliumNamespace, helpers.K8s1)


### PR DESCRIPTION
Flaky once in a while, so disable for now until we have found
the cause for it.

Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>
