### PR TITLE
daemon: Fix the "close of closed channel" panic

### DIFF
--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -77,7 +77,8 @@ type nodeStore struct {
 	allocationPoolSize map[Family]int
 
 	// signal for completion of restoration
-	restoreFinished chan bool
+	restoreFinished  chan bool
+	restoreCloseOnce sync.Once
 
 	conf Configuration
 }
@@ -623,5 +624,7 @@ func (a *crdAllocator) Dump() (map[string]string, string) {
 
 // RestoreFinished marks the status of restoration as done
 func (a *crdAllocator) RestoreFinished() {
-	close(a.store.restoreFinished)
+	a.store.restoreCloseOnce.Do(func() {
+		close(a.store.restoreFinished)
+	})
 }


### PR DESCRIPTION
When enable ipv4&ipv6 with crd ipam option，cilium panic after restoring
old endpoint because of "close of closed channel"

We should check whether or not the channel has been closed, before we do
the action.

Signed-off-by: yangxingwu <yangxingwu@kuaishou.com>
Signed-off-by: huangxuesen <huangxuesen@kuaishou.com>
