### PR TITLE
Restore node IP behavior of Cilium < 1.7

### DIFF
--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -631,17 +631,29 @@ New ConfigMap Options
 ~~~~~~~~~~~~~~~~~~~~~
 
   * ``enable-remote-node-identity`` has been added to enable a new identity
-    for remote cluster nodes. This allows for network policies that distinguish
-    between connections from host networking pods or other processes on the local
-    Kubernetes worker node from those on remote worker nodes.  This is important
-    because Kubernetes Network Policy dictates that network connectivity from the
-    local host must always be allowed, even for pods that have a default deny rule for
-    ingress connectivity.   This is so that network liveness and readiness
-    probes from kubelet will not be dropped by network policy.  Prior to 1.7.x,
-    Cilium achieved this by always allowing ingress host network connectivity from any
-    host in the cluster.  With 1.7 and ``enable-remote-node-identity=true``, Cilium
-    will only automatically allow connectivity from the local node, thereby providing
-    a better default security posture.
+    for remote cluster nodes and to associate all IPs of a node with that new
+    identity. This allows for network policies that distinguish between
+    connections from host networking pods or other processes on the local
+    Kubernetes worker node from those on remote worker nodes.
+
+    After enabling this option, all communication to and from non-local
+    Kubernetes nodes must be whitelisted with a ``toEntity`` or ``fromEntity``
+    rule listing the entity ``remote-node``. The existing entity ``cluster``
+    continues to work and now includes the entity ``remote-node``.  Existing
+    policy rules whitelisting ``host`` will only affect the local node going
+    forward. Existing CIDR-based rules to whitelist node IPs other than the
+    Cilium internal IP (IP assigned to the ``cilium_host`` interface), will no
+    longer take effect.
+
+    This is important because Kubernetes Network Policy dictates that network
+    connectivity from the local host must always be allowed, even for pods that
+    have a default deny rule for ingress connectivity.   This is so that
+    network liveness and readiness probes from kubelet will not be dropped by
+    network policy.  Prior to 1.7.x, Cilium achieved this by always allowing
+    ingress host network connectivity from any host in the cluster.  With 1.7
+    and ``enable-remote-node-identity=true``, Cilium will only automatically
+    allow connectivity from the local node, thereby providing a better default
+    security posture.
 
     The option is enabled by default for new deployments when generated via
     Helm, in order to gain the benefits of improved security. The Helm option

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -291,7 +291,7 @@ func NewDaemon(ctx context.Context, dp datapath.Datapath) (*Daemon, *endpointRes
 
 	mtuConfig := mtu.NewConfiguration(authKeySize, option.Config.EnableIPSec, option.Config.Tunnel != option.TunnelDisabled, configuredMTU)
 
-	nodeMngr, err := nodemanager.NewManager("all", dp.Node())
+	nodeMngr, err := nodemanager.NewManager("all", dp.Node(), ipcache.IPIdentityCache, option.Config)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/daemon/cmd/status_test.go
+++ b/daemon/cmd/status_test.go
@@ -23,10 +23,12 @@ import (
 	. "github.com/cilium/cilium/api/v1/server/restapi/daemon"
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/datapath/fake"
+	fakeIPCache "github.com/cilium/cilium/pkg/ipcache/fake"
 	"github.com/cilium/cilium/pkg/mtu"
 	"github.com/cilium/cilium/pkg/node/manager"
 	"github.com/cilium/cilium/pkg/nodediscovery"
 	"github.com/cilium/cilium/pkg/option"
+	fakeConfig "github.com/cilium/cilium/pkg/option/fake"
 	cnitypes "github.com/cilium/cilium/plugins/cilium-cni/types"
 
 	"github.com/go-openapi/runtime/middleware"
@@ -47,7 +49,7 @@ func (g *GetNodesSuite) SetUpTest(c *C) {
 
 func (g *GetNodesSuite) SetUpSuite(c *C) {
 	var err error
-	nm, err = manager.NewManager("", fake.NewNodeHandler())
+	nm, err = manager.NewManager("", fake.NewNodeHandler(), fakeIPCache.NewIPCache(false), &fakeConfig.Config{})
 	c.Assert(err, IsNil)
 }
 

--- a/pkg/ipcache/fake/ipcache.go
+++ b/pkg/ipcache/fake/ipcache.go
@@ -1,0 +1,55 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package fake
+
+import (
+	"net"
+
+	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/source"
+)
+
+const (
+	EventUpsert = "upsert"
+	EventDelete = "delete"
+)
+
+type NodeEvent struct {
+	event string
+	ip    net.IP
+}
+
+type IPCache struct {
+	eventsEnabled bool
+	Events        chan NodeEvent
+}
+
+func NewIPCache(events bool) *IPCache {
+	return &IPCache{
+		eventsEnabled: events,
+		Events:        make(chan NodeEvent, 1024),
+	}
+}
+
+func (i *IPCache) Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *ipcache.K8sMetadata, newIdentity ipcache.Identity) bool {
+	i.Events <- NodeEvent{EventUpsert, net.ParseIP(ip)}
+	return true
+}
+
+func (i *IPCache) Delete(IP string, source source.Source) {
+	i.Events <- NodeEvent{EventDelete, net.ParseIP(IP)}
+}

--- a/pkg/ipcache/fake/ipcache_test.go
+++ b/pkg/ipcache/fake/ipcache_test.go
@@ -1,0 +1,58 @@
+// Copyright 2018-2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package fake
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/cilium/cilium/pkg/checker"
+	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/source"
+
+	"gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	check.TestingT(t)
+}
+
+type fakeIPCacheSuite struct{}
+
+var _ = check.Suite(&fakeIPCacheSuite{})
+
+func (s *fakeIPCacheSuite) TestFakeIPCache(c *check.C) {
+	ipcacheMock := NewIPCache(true)
+
+	ipcacheMock.Upsert("1.1.1.1", net.ParseIP("2.2.2.2"), 0, nil, ipcache.Identity{ID: 1, Source: source.Local})
+	select {
+	case event := <-ipcacheMock.Events:
+		c.Assert(event, checker.DeepEquals, NodeEvent{EventUpsert, net.ParseIP("1.1.1.1")})
+	case <-time.After(5 * time.Second):
+		c.Errorf("timeout while waiting for ipcache upsert for IP 1.1.1.1")
+	}
+
+	ipcacheMock.Delete("1.1.1.1", source.Local)
+
+	select {
+	case event := <-ipcacheMock.Events:
+		c.Assert(event, checker.DeepEquals, NodeEvent{EventDelete, net.ParseIP("1.1.1.1")})
+	case <-time.After(5 * time.Second):
+		c.Errorf("timeout while waiting for ipcache delete for IP 1.1.1.1")
+	}
+}

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 Authors of Cilium
+// Copyright 2016-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,7 +26,6 @@ import (
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/node/addressing"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
-	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -47,6 +46,19 @@ type nodeEntry struct {
 	// Manager.mutex must *always* be acquired first.
 	mutex lock.Mutex
 	node  nodeTypes.Node
+}
+
+// IPCache is the set of interactions the node manager performs with the ipcache
+type IPCache interface {
+	Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *ipcache.K8sMetadata, newIdentity ipcache.Identity) bool
+	Delete(IP string, source source.Source)
+}
+
+// Configuration is the set of configuration options the node manager depends
+// on
+type Configuration interface {
+	RemoteNodeIdentitiesEnabled() bool
+	NodeEncryptionEnabled() bool
 }
 
 // Manager is the entity that manages a collection of nodes
@@ -97,6 +109,13 @@ type Manager struct {
 	// metricDatapathValidations is the prometheus metric to track the
 	// number of datapath node validation calls
 	metricDatapathValidations prometheus.Counter
+
+	// conf is the configuration of the caller passed in via NewManager.
+	// This field is immutable after NewManager()
+	conf Configuration
+
+	// ipcache is the set operations performed against the ipcache
+	ipcache IPCache
 }
 
 // Subscribe subscribes the given node handler to node events.
@@ -132,10 +151,12 @@ func (m *Manager) Iter(f func(nh datapath.NodeHandler)) {
 }
 
 // NewManager returns a new node manager
-func NewManager(name string, dp datapath.NodeHandler) (*Manager, error) {
+func NewManager(name string, dp datapath.NodeHandler, ipcache IPCache, c Configuration) (*Manager, error) {
 	m := &Manager{
 		name:         name,
 		nodes:        map[nodeTypes.Identity]*nodeEntry{},
+		conf:         c,
+		ipcache:      ipcache,
 		nodeHandlers: map[datapath.NodeHandler]struct{}{},
 		closeChan:    make(chan struct{}),
 	}
@@ -273,6 +294,19 @@ func (m *Manager) backgroundSync() {
 	}
 }
 
+// legacyNodeIpBehavior returns true if the agent is still running in legacy
+// mode regarding node IPs
+func (m *Manager) legacyNodeIpBehavior() bool {
+	// Cilium < 1.7 only exposed the Cilium internalIP to the ipcache
+	// unless encryption was enabled. This meant that for the majority of
+	// node IPs, CIDR policy rules would apply. With the introduction of
+	// remote-node identities, all node IPs were suddenly added to the
+	// ipcache. This resulted in a behavioral change. New deployments will
+	// provide this behavior out of the gate, existing deployments will
+	// have to opt into this by enabling remote-node identities.
+	return !m.conf.NodeEncryptionEnabled() && !m.conf.RemoteNodeIdentitiesEnabled()
+}
+
 // NodeUpdated is called after the information of a node has been updated. The
 // node in the manager is added or updated if the source is allowed to update
 // the node. If an update or addition has occurred, NodeUpdate() of the datapath
@@ -284,17 +318,21 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 	nodeIP := n.GetNodeIP(false)
 
 	remoteHostIdentity := identity.ReservedIdentityHost
-	if option.Config.EnableRemoteNodeIdentity && n.Source != source.Local {
+	if m.conf.RemoteNodeIdentitiesEnabled() && n.Source != source.Local {
 		remoteHostIdentity = identity.ReservedIdentityRemoteNode
 	}
 
 	for _, address := range n.IPAddresses {
 		var tunnelIP net.IP
-		if address.Type == addressing.NodeCiliumInternalIP || option.Config.EncryptNode {
+		if address.Type == addressing.NodeCiliumInternalIP || m.conf.NodeEncryptionEnabled() {
 			tunnelIP = nodeIP
 		}
 
-		isOwning := ipcache.IPIdentityCache.Upsert(address.IP.String(), tunnelIP, n.EncryptionKey, nil, ipcache.Identity{
+		if m.legacyNodeIpBehavior() && address.Type != addressing.NodeCiliumInternalIP {
+			continue
+		}
+
+		isOwning := m.ipcache.Upsert(address.IP.String(), tunnelIP, n.EncryptionKey, nil, ipcache.Identity{
 			ID:     remoteHostIdentity,
 			Source: n.Source,
 		})
@@ -312,7 +350,7 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 		if address == nil {
 			continue
 		}
-		isOwning := ipcache.IPIdentityCache.Upsert(address.String(), nodeIP, n.EncryptionKey, nil, ipcache.Identity{
+		isOwning := m.ipcache.Upsert(address.String(), nodeIP, n.EncryptionKey, nil, ipcache.Identity{
 			ID:     identity.ReservedIdentityHealth,
 			Source: n.Source,
 		})
@@ -392,7 +430,7 @@ func (m *Manager) NodeDeleted(n nodeTypes.Node) {
 	}
 
 	for _, address := range entry.node.IPAddresses {
-		ipcache.IPIdentityCache.Delete(address.IP.String(), n.Source)
+		m.ipcache.Delete(address.IP.String(), n.Source)
 	}
 
 	m.metricNumNodes.Dec()

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -430,6 +430,10 @@ func (m *Manager) NodeDeleted(n nodeTypes.Node) {
 	}
 
 	for _, address := range entry.node.IPAddresses {
+		if m.legacyNodeIpBehavior() && address.Type != addressing.NodeCiliumInternalIP {
+			continue
+		}
+
 		m.ipcache.Delete(address.IP.String(), n.Source)
 	}
 

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -437,6 +437,12 @@ func (m *Manager) NodeDeleted(n nodeTypes.Node) {
 		m.ipcache.Delete(address.IP.String(), n.Source)
 	}
 
+	for _, address := range []net.IP{entry.node.IPv4HealthIP, entry.node.IPv6HealthIP} {
+		if address != nil {
+			m.ipcache.Delete(address.String(), n.Source)
+		}
+	}
+
 	m.metricNumNodes.Dec()
 
 	entry.mutex.Lock()

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -396,6 +396,80 @@ func (s *managerTestSuite) TestIpcache(c *check.C) {
 	}
 }
 
+func (s *managerTestSuite) TestIpcacheHealthIP(c *check.C) {
+	ipcacheMock := newIPcacheMock()
+	mngr, err := NewManager("test", newSignalNodeHandler(), ipcacheMock, &configMock{})
+	c.Assert(err, check.IsNil)
+	defer mngr.Close()
+
+	n1 := nodeTypes.Node{
+		Name:    "node1",
+		Cluster: "c1",
+		IPAddresses: []nodeTypes.Address{
+			{Type: addressing.NodeCiliumInternalIP, IP: net.ParseIP("1.1.1.1")},
+		},
+		IPv4HealthIP: net.ParseIP("4.4.4.4"),
+		IPv6HealthIP: net.ParseIP("f00d::4"),
+	}
+	mngr.NodeUpdated(n1)
+
+	select {
+	case event := <-ipcacheMock.events:
+		c.Assert(event, checker.DeepEquals, nodeEvent{event: "upsert", ip: net.ParseIP("1.1.1.1")})
+	case <-time.After(5 * time.Second):
+		c.Errorf("timeout while waiting for ipcache upsert for IP 1.1.1.1")
+	}
+
+	select {
+	case event := <-ipcacheMock.events:
+		c.Assert(event, checker.DeepEquals, nodeEvent{event: "upsert", ip: net.ParseIP("4.4.4.4")})
+	case <-time.After(5 * time.Second):
+		c.Errorf("timeout while waiting for ipcache upsert for IP 4.4.4.4")
+	}
+
+	select {
+	case event := <-ipcacheMock.events:
+		c.Assert(event, checker.DeepEquals, nodeEvent{event: "upsert", ip: net.ParseIP("f00d::4")})
+	case <-time.After(5 * time.Second):
+		c.Errorf("timeout while waiting for ipcache upsert for IP f00d::4")
+	}
+
+	select {
+	case event := <-ipcacheMock.events:
+		c.Errorf("unexected ipcache interaction %+v", event)
+	default:
+	}
+
+	mngr.NodeDeleted(n1)
+
+	select {
+	case event := <-ipcacheMock.events:
+		c.Assert(event, checker.DeepEquals, nodeEvent{event: "delete", ip: net.ParseIP("1.1.1.1")})
+	case <-time.After(5 * time.Second):
+		c.Errorf("timeout while waiting for ipcache delete for IP 1.1.1.1")
+	}
+
+	select {
+	case event := <-ipcacheMock.events:
+		c.Assert(event, checker.DeepEquals, nodeEvent{event: "delete", ip: net.ParseIP("4.4.4.4")})
+	case <-time.After(5 * time.Second):
+		c.Errorf("timeout while waiting for ipcache delete for IP 4.4.4.4")
+	}
+
+	select {
+	case event := <-ipcacheMock.events:
+		c.Assert(event, checker.DeepEquals, nodeEvent{event: "delete", ip: net.ParseIP("f00d::4")})
+	case <-time.After(5 * time.Second):
+		c.Errorf("timeout while waiting for ipcache delete for IP f00d::4")
+	}
+
+	select {
+	case event := <-ipcacheMock.events:
+		c.Errorf("unexected ipcache interaction %+v", event)
+	default:
+	}
+}
+
 func (s *managerTestSuite) TestRemoteNodeIdentities(c *check.C) {
 	ipcacheMock := newIPcacheMock()
 	mngr, err := NewManager("test", newSignalNodeHandler(), ipcacheMock, &configMock{RemoteNodeIdentity: true})

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -388,6 +388,12 @@ func (s *managerTestSuite) TestIpcache(c *check.C) {
 	case <-time.After(5 * time.Second):
 		c.Errorf("timeout while waiting for ipcache delete for IP 1.1.1.1")
 	}
+
+	select {
+	case event := <-ipcacheMock.events:
+		c.Errorf("unexected ipcache interaction %+v", event)
+	default:
+	}
 }
 
 func (s *managerTestSuite) TestRemoteNodeIdentities(c *check.C) {
@@ -456,6 +462,12 @@ func (s *managerTestSuite) TestRemoteNodeIdentities(c *check.C) {
 	case <-time.After(5 * time.Second):
 		c.Errorf("timeout while waiting for ipcache delete for IP f00d::1")
 	}
+
+	select {
+	case event := <-ipcacheMock.events:
+		c.Errorf("unexected ipcache interaction %+v", event)
+	default:
+	}
 }
 
 func (s *managerTestSuite) TestNodeEncryption(c *check.C) {
@@ -523,5 +535,11 @@ func (s *managerTestSuite) TestNodeEncryption(c *check.C) {
 		c.Assert(event, checker.DeepEquals, nodeEvent{event: "delete", ip: net.ParseIP("f00d::1")})
 	case <-time.After(5 * time.Second):
 		c.Errorf("timeout while waiting for ipcache delete for IP f00d::1")
+	}
+
+	select {
+	case event := <-ipcacheMock.events:
+		c.Errorf("unexected ipcache interaction %+v", event)
+	default:
 	}
 }

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2019 Authors of Cilium
+// Copyright 2018-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package manager
 
 import (
 	"fmt"
+	"net"
 	"sync"
 	"testing"
 	"time"
@@ -25,6 +26,8 @@ import (
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/datapath/fake"
+	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/node/addressing"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/source"
 
@@ -38,6 +41,43 @@ func Test(t *testing.T) {
 type managerTestSuite struct{}
 
 var _ = check.Suite(&managerTestSuite{})
+
+type configMock struct {
+	RemoteNodeIdentity bool
+	NodeEncryption     bool
+}
+
+func (c *configMock) RemoteNodeIdentitiesEnabled() bool {
+	return c.RemoteNodeIdentity
+}
+
+func (c *configMock) NodeEncryptionEnabled() bool {
+	return c.NodeEncryption
+}
+
+type nodeEvent struct {
+	event string
+	ip    net.IP
+}
+
+type ipcacheMock struct {
+	events chan nodeEvent
+}
+
+func newIPcacheMock() *ipcacheMock {
+	return &ipcacheMock{
+		events: make(chan nodeEvent, 1024),
+	}
+}
+
+func (i *ipcacheMock) Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *ipcache.K8sMetadata, newIdentity ipcache.Identity) bool {
+	i.events <- nodeEvent{"upsert", net.ParseIP(ip)}
+	return true
+}
+
+func (i *ipcacheMock) Delete(IP string, source source.Source) {
+	i.events <- nodeEvent{"delete", net.ParseIP(IP)}
+}
 
 type signalNodeHandler struct {
 	EnableNodeAddEvent                    bool
@@ -96,7 +136,7 @@ func (s *managerTestSuite) TestNodeLifecycle(c *check.C) {
 	dp.EnableNodeAddEvent = true
 	dp.EnableNodeUpdateEvent = true
 	dp.EnableNodeDeleteEvent = true
-	mngr, err := NewManager("test", dp)
+	mngr, err := NewManager("test", dp, newIPcacheMock(), &configMock{})
 	c.Assert(err, check.IsNil)
 
 	n1 := nodeTypes.Node{Name: "node1", Cluster: "c1"}
@@ -165,7 +205,7 @@ func (s *managerTestSuite) TestMultipleSources(c *check.C) {
 	dp.EnableNodeAddEvent = true
 	dp.EnableNodeUpdateEvent = true
 	dp.EnableNodeDeleteEvent = true
-	mngr, err := NewManager("test", dp)
+	mngr, err := NewManager("test", dp, newIPcacheMock(), &configMock{})
 	c.Assert(err, check.IsNil)
 	defer mngr.Close()
 
@@ -234,7 +274,7 @@ func (s *managerTestSuite) TestMultipleSources(c *check.C) {
 }
 
 func (s *managerTestSuite) BenchmarkUpdateAndDeleteCycle(c *check.C) {
-	mngr, err := NewManager("test", fake.NewNodeHandler())
+	mngr, err := NewManager("test", fake.NewNodeHandler(), newIPcacheMock(), &configMock{})
 	c.Assert(err, check.IsNil)
 	defer mngr.Close()
 
@@ -252,7 +292,7 @@ func (s *managerTestSuite) BenchmarkUpdateAndDeleteCycle(c *check.C) {
 }
 
 func (s *managerTestSuite) TestClusterSizeDependantInterval(c *check.C) {
-	mngr, err := NewManager("test", fake.NewNodeHandler())
+	mngr, err := NewManager("test", fake.NewNodeHandler(), newIPcacheMock(), &configMock{})
 	c.Assert(err, check.IsNil)
 	defer mngr.Close()
 
@@ -277,7 +317,7 @@ func (s *managerTestSuite) TestBackgroundSync(c *check.C) {
 
 	signalNodeHandler := newSignalNodeHandler()
 	signalNodeHandler.EnableNodeValidateImplementationEvent = true
-	mngr, err := NewManager("test", signalNodeHandler)
+	mngr, err := NewManager("test", signalNodeHandler, newIPcacheMock(), &configMock{})
 	c.Assert(err, check.IsNil)
 	defer mngr.Close()
 
@@ -308,4 +348,180 @@ func (s *managerTestSuite) TestBackgroundSync(c *check.C) {
 	}
 
 	allNodeValidateCallsReceived.Wait()
+}
+
+func (s *managerTestSuite) TestIpcache(c *check.C) {
+	ipcacheMock := newIPcacheMock()
+	mngr, err := NewManager("test", newSignalNodeHandler(), ipcacheMock, &configMock{})
+	c.Assert(err, check.IsNil)
+	defer mngr.Close()
+
+	n1 := nodeTypes.Node{
+		Name:    "node1",
+		Cluster: "c1",
+		IPAddresses: []nodeTypes.Address{
+			{Type: addressing.NodeCiliumInternalIP, IP: net.ParseIP("1.1.1.1")},
+			{Type: addressing.NodeInternalIP, IP: net.ParseIP("2.2.2.2")},
+			{Type: addressing.NodeExternalIP, IP: net.ParseIP("f00d::1")},
+		},
+	}
+	mngr.NodeUpdated(n1)
+
+	select {
+	case event := <-ipcacheMock.events:
+		c.Assert(event, checker.DeepEquals, nodeEvent{event: "upsert", ip: net.ParseIP("1.1.1.1")})
+	case <-time.After(5 * time.Second):
+		c.Errorf("timeout while waiting for ipcache upsert for IP 1.1.1.1")
+	}
+
+	select {
+	case event := <-ipcacheMock.events:
+		c.Errorf("unexected ipcache interaction %+v", event)
+	default:
+	}
+
+	mngr.NodeDeleted(n1)
+
+	select {
+	case event := <-ipcacheMock.events:
+		c.Assert(event, checker.DeepEquals, nodeEvent{event: "delete", ip: net.ParseIP("1.1.1.1")})
+	case <-time.After(5 * time.Second):
+		c.Errorf("timeout while waiting for ipcache delete for IP 1.1.1.1")
+	}
+}
+
+func (s *managerTestSuite) TestRemoteNodeIdentities(c *check.C) {
+	ipcacheMock := newIPcacheMock()
+	mngr, err := NewManager("test", newSignalNodeHandler(), ipcacheMock, &configMock{RemoteNodeIdentity: true})
+	c.Assert(err, check.IsNil)
+	defer mngr.Close()
+
+	n1 := nodeTypes.Node{
+		Name:    "node1",
+		Cluster: "c1",
+		IPAddresses: []nodeTypes.Address{
+			{Type: addressing.NodeCiliumInternalIP, IP: net.ParseIP("1.1.1.1")},
+			{Type: addressing.NodeInternalIP, IP: net.ParseIP("2.2.2.2")},
+			{Type: addressing.NodeExternalIP, IP: net.ParseIP("f00d::1")},
+		},
+	}
+	mngr.NodeUpdated(n1)
+
+	select {
+	case event := <-ipcacheMock.events:
+		c.Assert(event, checker.DeepEquals, nodeEvent{event: "upsert", ip: net.ParseIP("1.1.1.1")})
+	case <-time.After(5 * time.Second):
+		c.Errorf("timeout while waiting for ipcache upsert for IP 1.1.1.1")
+	}
+
+	select {
+	case event := <-ipcacheMock.events:
+		c.Assert(event, checker.DeepEquals, nodeEvent{event: "upsert", ip: net.ParseIP("2.2.2.2")})
+	case <-time.After(5 * time.Second):
+		c.Errorf("timeout while waiting for ipcache upsert for IP 2.2.2.2")
+	}
+
+	select {
+	case event := <-ipcacheMock.events:
+		c.Assert(event, checker.DeepEquals, nodeEvent{event: "upsert", ip: net.ParseIP("f00d::1")})
+	case <-time.After(5 * time.Second):
+		c.Errorf("timeout while waiting for ipcache upsert for IP f00d::1")
+	}
+
+	select {
+	case event := <-ipcacheMock.events:
+		c.Errorf("unexected ipcache interaction %+v", event)
+	default:
+	}
+
+	mngr.NodeDeleted(n1)
+
+	select {
+	case event := <-ipcacheMock.events:
+		c.Assert(event, checker.DeepEquals, nodeEvent{event: "delete", ip: net.ParseIP("1.1.1.1")})
+	case <-time.After(5 * time.Second):
+		c.Errorf("timeout while waiting for ipcache delete for IP 1.1.1.1")
+	}
+
+	select {
+	case event := <-ipcacheMock.events:
+		c.Assert(event, checker.DeepEquals, nodeEvent{event: "delete", ip: net.ParseIP("2.2.2.2")})
+	case <-time.After(5 * time.Second):
+		c.Errorf("timeout while waiting for ipcache delete for IP 2.2.2.2")
+	}
+
+	select {
+	case event := <-ipcacheMock.events:
+		c.Assert(event, checker.DeepEquals, nodeEvent{event: "delete", ip: net.ParseIP("f00d::1")})
+	case <-time.After(5 * time.Second):
+		c.Errorf("timeout while waiting for ipcache delete for IP f00d::1")
+	}
+}
+
+func (s *managerTestSuite) TestNodeEncryption(c *check.C) {
+	ipcacheMock := newIPcacheMock()
+	mngr, err := NewManager("test", newSignalNodeHandler(), ipcacheMock, &configMock{NodeEncryption: true})
+	c.Assert(err, check.IsNil)
+	defer mngr.Close()
+
+	n1 := nodeTypes.Node{
+		Name:    "node1",
+		Cluster: "c1",
+		IPAddresses: []nodeTypes.Address{
+			{Type: addressing.NodeCiliumInternalIP, IP: net.ParseIP("1.1.1.1")},
+			{Type: addressing.NodeInternalIP, IP: net.ParseIP("2.2.2.2")},
+			{Type: addressing.NodeExternalIP, IP: net.ParseIP("f00d::1")},
+		},
+	}
+	mngr.NodeUpdated(n1)
+
+	select {
+	case event := <-ipcacheMock.events:
+		c.Assert(event, checker.DeepEquals, nodeEvent{event: "upsert", ip: net.ParseIP("1.1.1.1")})
+	case <-time.After(5 * time.Second):
+		c.Errorf("timeout while waiting for ipcache upsert for IP 1.1.1.1")
+	}
+
+	select {
+	case event := <-ipcacheMock.events:
+		c.Assert(event, checker.DeepEquals, nodeEvent{event: "upsert", ip: net.ParseIP("2.2.2.2")})
+	case <-time.After(5 * time.Second):
+		c.Errorf("timeout while waiting for ipcache upsert for IP 2.2.2.2")
+	}
+
+	select {
+	case event := <-ipcacheMock.events:
+		c.Assert(event, checker.DeepEquals, nodeEvent{event: "upsert", ip: net.ParseIP("f00d::1")})
+	case <-time.After(5 * time.Second):
+		c.Errorf("timeout while waiting for ipcache upsert for IP f00d::1")
+	}
+
+	select {
+	case event := <-ipcacheMock.events:
+		c.Errorf("unexected ipcache interaction %+v", event)
+	default:
+	}
+
+	mngr.NodeDeleted(n1)
+
+	select {
+	case event := <-ipcacheMock.events:
+		c.Assert(event, checker.DeepEquals, nodeEvent{event: "delete", ip: net.ParseIP("1.1.1.1")})
+	case <-time.After(5 * time.Second):
+		c.Errorf("timeout while waiting for ipcache delete for IP 1.1.1.1")
+	}
+
+	select {
+	case event := <-ipcacheMock.events:
+		c.Assert(event, checker.DeepEquals, nodeEvent{event: "delete", ip: net.ParseIP("2.2.2.2")})
+	case <-time.After(5 * time.Second):
+		c.Errorf("timeout while waiting for ipcache delete for IP 2.2.2.2")
+	}
+
+	select {
+	case event := <-ipcacheMock.events:
+		c.Assert(event, checker.DeepEquals, nodeEvent{event: "delete", ip: net.ParseIP("f00d::1")})
+	case <-time.After(5 * time.Second):
+		c.Errorf("timeout while waiting for ipcache delete for IP f00d::1")
+	}
 }

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2050,6 +2050,17 @@ func (c *DaemonConfig) AlwaysAllowLocalhost() bool {
 	}
 }
 
+// RemoteNodeIdentitiesEnabled returns true if the remote-node identity feature
+// is enabled
+func (c *DaemonConfig) RemoteNodeIdentitiesEnabled() bool {
+	return c.EnableRemoteNodeIdentity
+}
+
+// NodeEncryptionEnabled returns true if node encryption is enabled
+func (c *DaemonConfig) NodeEncryptionEnabled() bool {
+	return c.EncryptNode
+}
+
 // IPv4Enabled returns true if IPv4 is enabled
 func (c *DaemonConfig) IPv4Enabled() bool {
 	return c.EnableIPv4

--- a/pkg/option/fake/config.go
+++ b/pkg/option/fake/config.go
@@ -26,3 +26,14 @@ func (f *Config) LocalClusterName() string {
 func (f *Config) CiliumNamespaceName() string {
 	return "kube-system"
 }
+
+// RemoteNodeIdentitiesEnabled returns true if the remote-node identity feature
+// is enabled
+func (f *Config) RemoteNodeIdentitiesEnabled() bool {
+	return true
+}
+
+// NodeEncryptionEnabled returns true if node encryption is enabled
+func (f *Config) NodeEncryptionEnabled() bool {
+	return true
+}


### PR DESCRIPTION
This restores the exact node IP behavior unless remote-node identities are enabled. It also fixes two bugs in separate commits that have been discovered by the unit tests added as part of this work.