### PR TITLE
hubble-proxy: remove explicit binary stripping

### DIFF
--- a/hubble-proxy/Makefile
+++ b/hubble-proxy/Makefile
@@ -12,7 +12,6 @@ all: $(TARGET)
 $(TARGET):
 	@$(ECHO_GO)
 	$(QUIET)$(GO_BUILD) -o $@
-	strip $(TARGET)
 
 clean:
 	@$(ECHO_CLEAN)


### PR DESCRIPTION
Since commit 508fee9d557c ("make: strip symbol tables from all binaries
by default") all cilium binaries are stripped by default using Go linker
options `-s` and `-w`, unless `NOSTRIP` is set. Thus, don't unconditionally
strip the `hubble-proxy` binary but rely on the global behavior.