### PR TITLE
CI: K8sPolicyTest Shorter timeout for successful redirection policy tests

### DIFF
--- a/test/helpers/cmd.go
+++ b/test/helpers/cmd.go
@@ -297,7 +297,7 @@ func (res *CmdRes) WaitUntilMatch(substr string) error {
 
 // WaitUntilMatchRegexp waits until the `CmdRes.stdout` matches the given regexp.
 // If the timeout is reached it will return an error.
-func (res *CmdRes) WaitUntilMatchRegexp(expr string) error {
+func (res *CmdRes) WaitUntilMatchRegexp(expr string, timeout time.Duration) error {
 	r := regexp.MustCompile(expr)
 	body := func() bool {
 		return r.Match(res.Output().Bytes())
@@ -306,7 +306,7 @@ func (res *CmdRes) WaitUntilMatchRegexp(expr string) error {
 	return WithTimeout(
 		body,
 		fmt.Sprintf("The output doesn't match regexp %q after timeout", expr),
-		&TimeoutConfig{Timeout: HelperTimeout})
+		&TimeoutConfig{Timeout: timeout})
 }
 
 // WaitUntilFinish waits until the command context completes correctly

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -854,9 +854,10 @@ var _ = Describe("K8sPolicyTest", func() {
 
 			checkProxyRedirection := func(resource string, redirected bool, parser policy.L7ParserType) {
 				var (
-					not     = " "
-					reStr   string
-					curlCmd string
+					not                  = " "
+					reStr                string
+					curlCmd              string
+					monitorOutputTimeout = 10 * time.Second
 				)
 
 				if !redirected {
@@ -894,7 +895,7 @@ var _ = Describe("K8sPolicyTest", func() {
 				res.ExpectSuccess("%q cannot curl %q", appPods[helpers.App2], resource)
 
 				By("Checking that aforementioned traffic was%sredirected to the proxy", not)
-				err := monitorRes.WaitUntilMatchRegexp(reStr)
+				err := monitorRes.WaitUntilMatchRegexp(reStr, monitorOutputTimeout)
 				if redirected {
 					ExpectWithOffset(1, err).To(BeNil(), "traffic was not redirected to the proxy when it should have been")
 				} else {

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -1559,7 +1559,7 @@ var _ = Describe("RuntimePolicies", func() {
 			res.ExpectSuccess("Cannot ping endpoint with init policy")
 
 			By("Testing cilium monitor output")
-			err = monitorRes.WaitUntilMatchRegexp(fmt.Sprintf(`-> endpoint %s flow [^ ]+ identity 1->`, endpointID))
+			err = monitorRes.WaitUntilMatchRegexp(fmt.Sprintf(`-> endpoint %s flow [^ ]+ identity 1->`, endpointID), helpers.HelperTimeout)
 			Expect(err).To(BeNil(), "Allow on ingress failed")
 			monitorRes.ExpectDoesNotMatchRegexp(fmt.Sprintf(`xx drop \(Policy denied\) flow [^ ]+ to endpoint %s, identity 1->[^0]`, endpointID), "Unexpected drop")
 		})
@@ -1584,7 +1584,7 @@ var _ = Describe("RuntimePolicies", func() {
 			Expect(egressEpModel).NotTo(BeNil(), "nil model returned for endpoint %s", endpointID)
 
 			By("Testing cilium monitor output")
-			err = monitorRes.WaitUntilMatchRegexp(fmt.Sprintf(`-> endpoint %s flow [^ ]+ identity 1->`, endpointID))
+			err = monitorRes.WaitUntilMatchRegexp(fmt.Sprintf(`-> endpoint %s flow [^ ]+ identity 1->`, endpointID), helpers.HelperTimeout)
 			Expect(err).To(BeNil(), "Allow on egress failed")
 			monitorRes.ExpectDoesNotMatchRegexp(fmt.Sprintf(`xx drop \(Policy denied\) flow [^ ]+ to endpoint %s, identity 1->[^0]`, endpointID), "Unexpected drop")
 		})


### PR DESCRIPTION
_this should improve the timeouts we're seeing in the pipeline. Points to aanm for pointing this out to me_

We switched to polling for monitor output. This caused the successful
path in these tests, which does not see a specific output, to take the
full HelperTimeout (4 Minutes). WaitForRegexp now takes the timeout as a
parameter, allowing these tests to proceed faster.

fixes 9fbd82092def7ced2d520408435f61d6f6408848
