### PR TITLE
Remove deprecated --container-runtime{,-endpoint} options

### DIFF
--- a/Documentation/envoy/extensions.rst
+++ b/Documentation/envoy/extensions.rst
@@ -523,7 +523,7 @@ and adding the ''--debug-verbose=flow'' flag.
 
   $ sudo service cilium stop 
   
-  $ sudo /usr/bin/cilium-agent --debug --auto-direct-node-routes --ipv4-range 10.11.0.0/16 --kvstore-opt consul.address=192.168.33.11:8500 --kvstore consul --container-runtime=docker --container-runtime-endpoint=unix:///var/run/docker.sock -t vxlan --fixed-identity-mapping=128=kv-store --fixed-identity-mapping=129=kube-dns --debug-verbose=flow
+  $ sudo /usr/bin/cilium-agent --debug --auto-direct-node-routes --ipv4-range 10.11.0.0/16 --kvstore-opt consul.address=192.168.33.11:8500 --kvstore consul -t vxlan --fixed-identity-mapping=128=kv-store --fixed-identity-mapping=129=kube-dns --debug-verbose=flow
 
 
 Step 13: Add Runtime Tests

--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -501,6 +501,8 @@ Removed options
 
 * ``enable-legacy-services``: This option was deprecated in Cilium 1.6 and is
   now removed.
+* The options ``container-runtime`` and ``container-runtime-endpoint`` were
+  deprecated in Cilium 1.7 and are now removed.
 
 Removed helm options
 ~~~~~~~~~~~~~~~~~~~~

--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -333,21 +333,6 @@ function write_cilium_cfg() {
         cilium_options+=" --kvstore consul"
         cilium_operator_options+=" --kvstore consul"
     fi
-    # container runtime options
-    case "${RUNTIME}" in
-        "containerd" | "containerD")
-            cilium_options+=" --container-runtime=containerd --container-runtime-endpoint=containerd=/var/run/containerd/containerd.sock"
-            cat <<EOF >> "$filename"
-sed -i '4s+.*++' /lib/systemd/system/cilium.service
-EOF
-            ;;
-        "crio" | "cri-o")
-            cilium_options+=" --container-runtime=crio --container-runtime-endpoint=crio=/var/run/crio/crio.sock"
-            ;;
-        *)
-            cilium_options+=" --container-runtime=docker --container-runtime-endpoint=docker=unix:///var/run/docker.sock"
-            ;;
-    esac
 
     cilium_options+=" ${TUNNEL_MODE_STRING}"
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -236,15 +236,6 @@ func init() {
 	flags.Duration(option.ConntrackGCInterval, time.Duration(0), "Overwrite the connection-tracking garbage collection interval")
 	option.BindEnv(option.ConntrackGCInterval)
 
-	flags.StringSlice(option.ContainerRuntime, option.ContainerRuntimeAuto, `Sets the container runtime(s) used by Cilium { containerd | crio | docker | none | auto } ( "auto" uses the container runtime found in the order: "docker", "containerd", "crio" )`)
-	option.BindEnv(option.ContainerRuntime)
-	flags.MarkDeprecated(option.ContainerRuntime, "This option is no longer supported and will be removed in v1.8")
-
-	flags.Var(option.NewNamedMapOptions(option.ContainerRuntimeEndpoint, &map[string]string{}, nil),
-		option.ContainerRuntimeEndpoint, `Container runtime(s) endpoint(s).`)
-	option.BindEnv(option.ContainerRuntimeEndpoint)
-	flags.MarkDeprecated(option.ContainerRuntimeEndpoint, "This option is no longer supported and will be removed in v1.8")
-
 	flags.BoolP(option.DebugArg, "D", false, "Enable debugging mode")
 	option.BindEnv(option.DebugArg)
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -126,18 +126,6 @@ const (
 	// ConntrackGCInterval is the name of the ConntrackGCInterval option
 	ConntrackGCInterval = "conntrack-gc-interval"
 
-	// ContainerRuntime sets the container runtime(s) used by Cilium
-	// { containerd | crio | docker | none | auto } ( "auto" uses the container
-	// runtime found in the order: "docker", "containerd", "crio" )
-	// Deprecated: This option is no longer available since cilium-daemon does
-	//             not have any direct interaction with container runtimes.
-	ContainerRuntime = "container-runtime"
-
-	// ContainerRuntimeEndpoint set the container runtime(s) endpoint(s)
-	// Deprecated: This option is no longer available since cilium-daemon does
-	//             not have any direct interaction with container runtimes.
-	ContainerRuntimeEndpoint = "container-runtime-endpoint"
-
 	// DebugArg is the argument enables debugging mode
 	DebugArg = "debug"
 
@@ -152,9 +140,6 @@ const (
 
 	// DisableEnvoyVersionCheck do not perform Envoy binary version check on startup
 	DisableEnvoyVersionCheck = "disable-envoy-version-check"
-
-	// Docker is the path to docker runtime socket (DEPRECATED: use container-runtime-endpoint instead)
-	Docker = "docker"
 
 	// EnableCEPGC enables CiliumEndpoint garbage collector
 	// Deprecated: use EndpointGCInterval and remove in 1.9
@@ -1115,10 +1100,6 @@ var HelpFlagSections = []FlagsSection{
 var (
 	FQDNRejectOptions = []string{FQDNProxyDenyWithNameError, FQDNProxyDenyWithRefused}
 
-	// ContainerRuntimeAuto is the configuration for autodetecting the
-	// container runtime backends that Cilium should use.
-	ContainerRuntimeAuto = []string{"auto"}
-
 	// MonitorAggregationFlagsDefault ensure that all TCP flags trigger
 	// monitor notifications even under medium monitor aggregation.
 	MonitorAggregationFlagsDefault = []string{"syn", "fin", "rst"}
@@ -1521,7 +1502,6 @@ type DaemonConfig struct {
 	EnableHostReachableServices   bool
 	EnableHostServicesTCP         bool
 	EnableHostServicesUDP         bool
-	DockerEndpoint                string
 	EnablePolicy                  string
 	EnableTracing                 bool
 	EnvoyLog                      string
@@ -2320,7 +2300,6 @@ func (c *DaemonConfig) Populate() {
 	c.EnableHostReachableServices = viper.GetBool(EnableHostReachableServices)
 	c.EnableRemoteNodeIdentity = viper.GetBool(EnableRemoteNodeIdentity)
 	c.K8sHeartbeatTimeout = viper.GetDuration(K8sHeartbeatTimeout)
-	c.DockerEndpoint = viper.GetString(Docker)
 	c.EnableXTSocketFallback = viper.GetBool(EnableXTSocketFallbackName)
 	c.EnableAutoDirectRouting = viper.GetBool(EnableAutoDirectRoutingName)
 	c.EnableEndpointRoutes = viper.GetBool(EnableEndpointRoutes)


### PR DESCRIPTION
These no longer have any effect, were deprecated in 1.7 and announced to
be removed in the upcoming 1.8.

Also remove remains of the --docker command line option which is no
longer supported since commit 532ad9d44a6f ("rm pkg/workloads")