### PR TITLE
hubble: Populate traffic direction for trace and drop events

### DIFF
--- a/pkg/hubble/parser/threefour/parser.go
+++ b/pkg/hubble/parser/threefour/parser.go
@@ -413,7 +413,7 @@ func decodeICMPv6(icmp *layers.ICMPv6) *pb.Layer4 {
 }
 
 func decodeIsReply(tn *monitor.TraceNotify) bool {
-	return tn != nil && tn.Reason == monitor.TraceReasonCtReply
+	return tn != nil && tn.Reason & ^monitor.TraceReasonEncryptMask == monitor.TraceReasonCtReply
 }
 
 func decodeCiliumEventType(eventType, eventSubType uint8) *pb.CiliumEventType {


### PR DESCRIPTION
Where possible, populate the `TrafficDirection` field from the trace
and drop notifications. This is done by comparing the `Source`
endpoint field of the trace/drop event with source address of the
captured IP packet.

For drop notifications, we assume there are no ongoing connections
which this packet belongs to and just compare the source address. For
trace notifications however, we do assume that there might an ongoing
connection. Therefore, we rely on the connection tracking state to
revert the traffic direction for reply packages. For trace observation
points without connection tracking, we do not assign any traffic
direction.

Pulling in the datapath team for a quick review as well to confirm that.

/cc @michi-covalent 