### PR TITLE
Use left-shift instead of math.Pow where appropriate

### DIFF
--- a/pkg/azure/ipam/ipam_test.go
+++ b/pkg/azure/ipam/ipam_test.go
@@ -19,7 +19,6 @@ package ipam
 import (
 	"context"
 	"fmt"
-	"math"
 	"testing"
 	"time"
 
@@ -279,7 +278,7 @@ func (e *IPAMSuite) TestIpamMinAllocate10(c *check.C) {
 
 	quota := instances.GetPoolQuota()
 	c.Assert(len(quota), check.Equals, 1)
-	c.Assert(quota["subnet-1"].AvailableIPs, check.Equals, int(math.Pow(2.0, 16.0)-16))
+	c.Assert(quota["subnet-1"].AvailableIPs, check.Equals, (1<<16)-16)
 }
 
 type nodeState struct {

--- a/pkg/cidr/cidr.go
+++ b/pkg/cidr/cidr.go
@@ -16,7 +16,6 @@ package cidr
 
 import (
 	"fmt"
-	"math"
 	"net"
 )
 
@@ -53,7 +52,7 @@ func (n *CIDR) DeepCopy() *CIDR {
 // AvailableIPs returns the number of IPs available in a CIDR
 func (n *CIDR) AvailableIPs() int {
 	ones, bits := n.Mask.Size()
-	return int(math.Pow(2.0, float64(bits-ones)))
+	return 1 << (bits - ones)
 }
 
 // ParseCIDR parses the CIDR string using net.ParseCIDR

--- a/pkg/ipam/allocator/group_test.go
+++ b/pkg/ipam/allocator/group_test.go
@@ -17,7 +17,6 @@
 package allocator
 
 import (
-	"math"
 	"net"
 
 	"github.com/cilium/cilium/pkg/cidr"
@@ -37,8 +36,8 @@ func (e *AllocatorSuite) TestPoolGroupAllocator(c *check.C) {
 	c.Assert(g.PoolExists("s2"), check.Equals, true)
 	c.Assert(g.PoolExists("s3"), check.Equals, false)
 	quota := g.GetPoolQuota()
-	c.Assert(quota["s1"].AvailableIPs, check.Equals, int(math.Pow(2.0, 16.0))-2)
-	c.Assert(quota["s2"].AvailableIPs, check.Equals, int(math.Pow(2.0, 16.0))-2)
+	c.Assert(quota["s1"].AvailableIPs, check.Equals, 1<<16-2)
+	c.Assert(quota["s2"].AvailableIPs, check.Equals, 1<<16-2)
 }
 
 func (e *AllocatorSuite) TestPoolGroupAllocatorLimit(c *check.C) {
@@ -50,7 +49,7 @@ func (e *AllocatorSuite) TestPoolGroupAllocatorLimit(c *check.C) {
 	c.Assert(g, check.Not(check.IsNil))
 
 	// .0 is reserved
-	maxAvailablePerPool := int(math.Pow(2.0, 8.0)) - 2
+	maxAvailablePerPool := 1<<8 - 2
 	quota := g.GetPoolQuota()
 	c.Assert(quota["s1"].AvailableIPs, check.Equals, maxAvailablePerPool)
 	c.Assert(quota["s2"].AvailableIPs, check.Equals, maxAvailablePerPool)
@@ -83,7 +82,7 @@ func (e *AllocatorSuite) TestPoolGroupAllocatorAllocate(c *check.C) {
 	c.Assert(g, check.Not(check.IsNil))
 
 	// .0 is reserved
-	maxAvailablePerPool := int(math.Pow(2.0, 8.0)) - 2
+	maxAvailablePerPool := 1<<8 - 2
 	quota := g.GetPoolQuota()
 	c.Assert(quota["s1"].AvailableIPs, check.Equals, maxAvailablePerPool)
 	c.Assert(quota["s2"].AvailableIPs, check.Equals, maxAvailablePerPool)
@@ -139,7 +138,7 @@ func (e *AllocatorSuite) TestPoolGroupAllocatorReserve(c *check.C) {
 	g.ReserveAddresses(allocatorTestIPs{"s1": []string{"10.10.0.1", "10.10.0.128", "1.1.1.1"}})
 
 	// .0 is reserved
-	maxAvailablePerPool := int(math.Pow(2.0, 8.0)) - 2
+	maxAvailablePerPool := 1<<8 - 2
 	quota := g.GetPoolQuota()
 
 	// 2 IPs should be reserved in s-1

--- a/pkg/ipam/allocator/pool_allocator_test.go
+++ b/pkg/ipam/allocator/pool_allocator_test.go
@@ -17,7 +17,6 @@
 package allocator
 
 import (
-	"math"
 	"net"
 
 	"github.com/cilium/cilium/pkg/cidr"
@@ -42,7 +41,7 @@ func (e *AllocatorSuite) TestPoolAllocator(c *check.C) {
 	c.Assert(s, check.Not(check.IsNil))
 
 	// .0 is reserved
-	maxAvailable := int(math.Pow(2.0, 16.0)) - 2
+	maxAvailable := 1<<16 - 2
 	c.Assert(s.Free(), check.Equals, maxAvailable)
 
 	// Allocate the next available IP
@@ -61,7 +60,7 @@ func (e *AllocatorSuite) TestPoolAllocatorLimit(c *check.C) {
 	c.Assert(s, check.Not(check.IsNil))
 
 	// .0 is reserved
-	maxAvailable := int(math.Pow(2.0, 8.0)) - 2
+	maxAvailable := 1<<8 - 2
 	c.Assert(s.Free(), check.Equals, maxAvailable)
 
 	// Allocate all available IPs
@@ -89,7 +88,7 @@ func (e *AllocatorSuite) TestPoolAllocatorRelease(c *check.C) {
 	c.Assert(s, check.Not(check.IsNil))
 
 	// .0 is reserved
-	maxAvailable := int(math.Pow(2.0, 8.0)) - 2
+	maxAvailable := 1<<8 - 2
 	c.Assert(s.Free(), check.Equals, maxAvailable)
 
 	// Allocate all available IPs


### PR DESCRIPTION
Replace `int(math.Pow(2.0, n))` by `1<<n` where appropriate. This avoids a
type conversion to `float64` and back and in some tests allows calculating
the value as a const at compile time.