### PR TITLE
test: disable istio tests in k8s 1.14 and 1.15

### DIFF
--- a/test/k8sT/istio.go
+++ b/test/k8sT/istio.go
@@ -59,7 +59,7 @@ var _ = Describe("K8sIstioTest", func() {
 	BeforeAll(func() {
 		k8sVersion := helpers.GetCurrentK8SEnv()
 		switch k8sVersion {
-		case "1.7", "1.8", "1.9", "1.10", "1.11", "1.12", "1.13":
+		case "1.7", "1.8", "1.9", "1.10", "1.11", "1.12", "1.13", "1.14", "1.15":
 			Skip(fmt.Sprintf("Istio 1.5.1 doesn't support K8S %s", k8sVersion))
 		}
 


### PR DESCRIPTION
Similarly to k8s 1.12 and 1.13, istio does not seem to work in k8s 1.14
and 1.15. For these reason we will skip Istio tests for these versions.

Fixes: a754a0c6f2d9 ("test: Update Istio integration to release 1.5.1")
Signed-off-by: André Martins <andre@cilium.io>

Fixes #11063