### PR TITLE
metrics: Do not rely on global HTTP server

### DIFF
--- a/pkg/hubble/metrics/metrics.go
+++ b/pkg/hubble/metrics/metrics.go
@@ -56,8 +56,13 @@ func Init(address string, enabled api.Map) (<-chan error, error) {
 	errChan := make(chan error, 1)
 
 	go func() {
-		http.Handle("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
-		errChan <- http.ListenAndServe(address, nil)
+		mux := http.NewServeMux()
+		mux.Handle("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
+		srv := http.Server{
+			Addr:    address,
+			Handler: mux,
+		}
+		errChan <- srv.ListenAndServe()
 	}()
 
 	return errChan, nil

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1123,8 +1123,13 @@ func Enable(addr string) <-chan error {
 	go func() {
 		// The Handler function provides a default handler to expose metrics
 		// via an HTTP server. "/metrics" is the usual endpoint for that.
-		http.Handle("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
-		errs <- http.ListenAndServe(addr, nil)
+		mux := http.NewServeMux()
+		mux.Handle("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
+		srv := http.Server{
+			Addr:    addr,
+			Handler: mux,
+		}
+		errs <- srv.ListenAndServe()
 	}()
 
 	return errs


### PR DESCRIPTION
This moves away from the global Golang HTTP server for serving the metrics for both Hubble and Cilium. Instead, a local instance is created, which allows the two metrics server to run concurrently.

Going forward, there also needs to be a discussion if we really want to have two different metrics server running inside cilium-agent. We either might want to move it out to `hubble-relay` (formerly `hubble-proxy`) or integrate the Hubble metrics with the Cilium ones.

This PR simply sidesteps that discussion by fixing the referenced bug in the simplest way possible.

Fixes: #11066
