### PR TITLE
test: Run kubectl in test VM for older K8s releases

### DIFF
--- a/jenkinsfiles/ginkgo-kubernetes-all.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-kubernetes-all.Jenkinsfile
@@ -130,7 +130,7 @@ pipeline {
                         retry(3) {
                             timeout(time: 20, unit: 'MINUTES'){
                                 dir("${TESTDIR}") {
-                                    sh 'CILIUM_REGISTRY="$(./print-node-ip)" ./vagrant-ci-start.sh'
+                                    sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" ./vagrant-ci-start.sh'
                                 }
                             }
                         }
@@ -159,7 +159,7 @@ pipeline {
                         retry(3) {
                             timeout(time: 20, unit: 'MINUTES'){
                                 dir("${TESTDIR}") {
-                                    sh 'CILIUM_REGISTRY="$(./print-node-ip)" ./vagrant-ci-start.sh'
+                                    sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" ./vagrant-ci-start.sh'
                                 }
                             }
                         }
@@ -267,7 +267,7 @@ pipeline {
                         retry(3) {
                             timeout(time: 20, unit: 'MINUTES'){
                                 dir("${TESTDIR}") {
-                                    sh 'CILIUM_REGISTRY="$(./print-node-ip)" ./vagrant-ci-start.sh'
+                                    sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" ./vagrant-ci-start.sh'
                                 }
                             }
                         }
@@ -296,7 +296,7 @@ pipeline {
                         retry(3) {
                             timeout(time: 20, unit: 'MINUTES'){
                                 dir("${TESTDIR}") {
-                                    sh 'CILIUM_REGISTRY="$(./print-node-ip)" ./vagrant-ci-start.sh'
+                                    sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" ./vagrant-ci-start.sh'
                                 }
                             }
                         }
@@ -403,7 +403,7 @@ pipeline {
                         retry(3) {
                             timeout(time: 20, unit: 'MINUTES'){
                                 dir("${TESTDIR}") {
-                                    sh 'CILIUM_REGISTRY="$(./print-node-ip)" ./vagrant-ci-start.sh'
+                                    sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" ./vagrant-ci-start.sh'
                                 }
                             }
                         }
@@ -432,7 +432,7 @@ pipeline {
                         retry(3) {
                             timeout(time: 20, unit: 'MINUTES'){
                                 dir("${TESTDIR}") {
-                                    sh 'CILIUM_REGISTRY="$(./print-node-ip)" ./vagrant-ci-start.sh'
+                                    sh 'CILIUM_REGISTRY="$(./print-node-ip.sh)" ./vagrant-ci-start.sh'
                                 }
                             }
                         }

--- a/jenkinsfiles/ginkgo-kubernetes-all.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-kubernetes-all.Jenkinsfile
@@ -121,8 +121,6 @@ pipeline {
                         K8S_VERSION="1.12"
                         GOPATH="${WORKSPACE}/${K8S_VERSION}-gopath"
                         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
-                        KUBECONFIG="vagrant-kubeconfig"
-                        //setting it here so we don't compile Cilium in vagrant nodes (already done on local node registry)
                     }
                     steps {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
@@ -150,8 +148,6 @@ pipeline {
                         K8S_VERSION="1.13"
                         GOPATH="${WORKSPACE}/${K8S_VERSION}-gopath"
                         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
-                        KUBECONFIG="vagrant-kubeconfig"
-                        //setting it here so we don't compile Cilium in vagrant nodes (already done on local node registry)
                     }
                     steps {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
@@ -189,10 +185,9 @@ pipeline {
                         K8S_VERSION="1.12"
                         GOPATH="${WORKSPACE}/${K8S_VERSION}-gopath"
                         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
-                        KUBECONFIG="${TESTDIR}/vagrant-kubeconfig"
                     }
                     steps {
-                        sh 'cd ${TESTDIR}; ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.kubeconfig=${KUBECONFIG} -cilium.registry=$(./print-node-ip.sh)'
+                        sh 'cd ${TESTDIR}; ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.registry=$(./print-node-ip.sh)'
                     }
                     post {
                         always {
@@ -216,10 +211,9 @@ pipeline {
                         K8S_VERSION="1.13"
                         GOPATH="${WORKSPACE}/${K8S_VERSION}-gopath"
                         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
-                        KUBECONFIG="${TESTDIR}/vagrant-kubeconfig"
                     }
                     steps {
-                        sh 'cd ${TESTDIR}; ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.kubeconfig=${KUBECONFIG} -cilium.registry=$(./print-node-ip.sh)'
+                        sh 'cd ${TESTDIR}; ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.registry=$(./print-node-ip.sh)'
                     }
                     post {
                         always {
@@ -258,8 +252,6 @@ pipeline {
                         K8S_VERSION="1.14"
                         GOPATH="${WORKSPACE}/${K8S_VERSION}-gopath"
                         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
-                        KUBECONFIG="vagrant-kubeconfig"
-                        //setting it here so we don't compile Cilium in vagrant nodes (already done on local node registry)
                     }
                     steps {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
@@ -287,8 +279,6 @@ pipeline {
                         K8S_VERSION="1.15"
                         GOPATH="${WORKSPACE}/${K8S_VERSION}-gopath"
                         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
-                        KUBECONFIG="vagrant-kubeconfig"
-                        //setting it here so we don't compile Cilium in vagrant nodes (already done on local node registry)
                     }
                     steps {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
@@ -326,10 +316,9 @@ pipeline {
                         K8S_VERSION="1.14"
                         GOPATH="${WORKSPACE}/${K8S_VERSION}-gopath"
                         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
-                        KUBECONFIG="${TESTDIR}/vagrant-kubeconfig"
                     }
                     steps {
-                        sh 'cd ${TESTDIR}; ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.kubeconfig=${KUBECONFIG} -cilium.registry=$(./print-node-ip.sh)'
+                        sh 'cd ${TESTDIR}; ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.registry=$(./print-node-ip.sh)'
                     }
                     post {
                         always {
@@ -353,10 +342,9 @@ pipeline {
                         K8S_VERSION="1.15"
                         GOPATH="${WORKSPACE}/${K8S_VERSION}-gopath"
                         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
-                        KUBECONFIG="${TESTDIR}/vagrant-kubeconfig"
                     }
                     steps {
-                        sh 'cd ${TESTDIR}; ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.kubeconfig=${KUBECONFIG} -cilium.registry=$(./print-node-ip.sh)'
+                        sh 'cd ${TESTDIR}; ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.registry=$(./print-node-ip.sh)'
                     }
                     post {
                         always {
@@ -394,8 +382,6 @@ pipeline {
                         K8S_VERSION="1.16"
                         GOPATH="${WORKSPACE}/${K8S_VERSION}-gopath"
                         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
-                        KUBECONFIG="vagrant-kubeconfig"
-                        //setting it here so we don't compile Cilium in vagrant nodes (already done on local node registry)
                     }
                     steps {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
@@ -423,8 +409,6 @@ pipeline {
                         K8S_VERSION="1.17"
                         GOPATH="${WORKSPACE}/${K8S_VERSION}-gopath"
                         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
-                        KUBECONFIG="vagrant-kubeconfig"
-                        //setting it here so we don't compile Cilium in vagrant nodes (already done on local node registry)
                     }
                     steps {
                         sh 'mkdir -p ${GOPATH}/src/github.com/cilium'
@@ -462,10 +446,9 @@ pipeline {
                         K8S_VERSION="1.16"
                         GOPATH="${WORKSPACE}/${K8S_VERSION}-gopath"
                         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
-                        KUBECONFIG="${TESTDIR}/vagrant-kubeconfig"
                     }
                     steps {
-                        sh 'cd ${TESTDIR}; ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.kubeconfig=${KUBECONFIG} -cilium.registry=$(./print-node-ip.sh)'
+                        sh 'cd ${TESTDIR}; ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.registry=$(./print-node-ip.sh)'
                     }
                     post {
                         always {
@@ -489,10 +472,9 @@ pipeline {
                         K8S_VERSION="1.17"
                         GOPATH="${WORKSPACE}/${K8S_VERSION}-gopath"
                         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
-                        KUBECONFIG="${TESTDIR}/vagrant-kubeconfig"
                     }
                     steps {
-                        sh 'cd ${TESTDIR}; ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.kubeconfig=${KUBECONFIG} -cilium.registry=$(./print-node-ip.sh)'
+                        sh 'cd ${TESTDIR}; ginkgo --focus=" K8s*" -v --failFast=${FAILFAST} -- -cilium.provision=false -cilium.timeout=${GINKGO_TIMEOUT} -cilium.registry=$(./print-node-ip.sh)'
                     }
                     post {
                         always {

--- a/test/get-vagrant-kubeconfig.sh
+++ b/test/get-vagrant-kubeconfig.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-K8S_VERSION_NO_DOTS=$(echo $K8S_VERSION | sed "s/\.//g")
-
 config=$(vagrant ssh k8s1-${K8S_VERSION} -- sudo cat /etc/kubernetes/admin.conf)
 port=$(cat .vagrant/machines/k8s1-${K8S_VERSION}/virtualbox/id | xargs vboxmanage showvminfo --machinereadable | grep 'Forwarding.*6443' | awk -F ',' '{print $4}')
 echo "$config" | sed "s/6443/$port/g"

--- a/test/print-node-ip.sh
+++ b/test/print-node-ip.sh
@@ -2,4 +2,7 @@
 
 set -e
 
-hostname -I | awk '{print $1}'
+case "$(uname -s)" in
+    Darwin*) ipconfig getifaddr en0 ;;
+    *)       hostname -I | cut -d " " -f 1
+esac


### PR DESCRIPTION
kubectl is guaranteed to be compatible with limited number of earlier
releases:

> kubectl is supported within one minor version (older or newer) of
> kube-apiserver.

So far we have been using the latest kubectl in the host (now 1.18) to
control clusters from K8s 1.11 to 1.18. This did not work any more
with 'istioctl', which complained about "kubectl not being found in
$PATH". When pairing istioctl with the same version of kubectl as the
cluster this started working again.

Downgrading kubectl in the test hosts may not be practical, but the CI
infra also supports running kubectl in the cluster's master node
(k8s1). This is triggered via the value of the Ginkgo
'cilium.kubeconfig' option. When 'cilium.kubeconfig' is non-empty, it
is assumed to be a path to a valid kubeconfig for connecting kubectl
in the host to the test cluster. When 'cilium.kubeconfig' is empty, CI
Ginkgo helpers assume that kubectl should be run on
"k8s1". 'test/vagrant-ci-start.sh' expects KUBECONFIG environment
variable to be set to the path to the file into which the kubeconfig
fetched from the test cluster should be stored. Modify
'test/vagrant-ci-start.sh' to accept undefined KUBECONFIG to signify
the need to run kubectl in the test cluster's master node (k8s1).

Finally, remove setting of both the KUBECONFIG environment variable
before calling 'vagrant-ci-start.sh' and the Ginkgo option
'cilium.kubeconfig' in 'ginkgo-kubernetes-all.Jenkinsfile' which is
used to run the CI K8s test suite on k8s versions from 1.11 to
1.17. This way we always use the kubectl installed as part of the
testing cluster itself, in the master node. This solves the
compatibility problem with istioctl and should help guard that we have
not introduced any kubectl syntax that would not be compatible with
the target k8s version.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
