### PR TITLE
docs: fix hyperlinks and other minor issues

### DIFF
--- a/Documentation/api.rst
+++ b/Documentation/api.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _api_ref:
 

--- a/Documentation/architecture.rst
+++ b/Documentation/architecture.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _arch_guide:
 

--- a/Documentation/architecture.rst
+++ b/Documentation/architecture.rst
@@ -228,7 +228,7 @@ with e.g. ``--datapath-mode=ipvlan --ipvlan-master-device=bond0`` where the
 latter typically specifies the physical networking device which then also acts
 as the ipvlan master device. Note that in case ipvlan datapath mode is deployed
 in L3S mode with Kubernetes, make sure to have a stable kernel running with the
-following ipvlan fix included: `d5256083f62e <https://git.kernel.org/pub/scm/linux/kernel/git/davem/net.git/commit/?id=d5256083f62e2720f75bb3c5a928a0afe47d6bc3>`_.
+following ipvlan fix included: `d5256083f62e <https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net.git/commit/?id=d5256083f62e2720f75bb3c5a928a0afe47d6bc3>`_.
 
 This completes the datapath overview. More BPF specifics can be found in the
 :ref:`bpf_guide`. Additional details on how to extend the L7 Policy

--- a/Documentation/bpf.rst
+++ b/Documentation/bpf.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _bpf_guide:
 

--- a/Documentation/bpf.rst
+++ b/Documentation/bpf.rst
@@ -4911,7 +4911,7 @@ related to BPF and XDP:
      OpenSourceDays, Copenhagen,
      XDP - eXpress Data Path, Used for DDoS protection,
      Jesper Dangaard Brouer,
-     https://github.com/iovisor/bpf-docs/raw/master/XDP_Inside_and_Out.pdf
+     http://people.netfilter.org/hawk/presentations/OpenSourceDays2017/XDP_DDoS_protecting_osd2017.pdf
 
 32. Mar 2017,
      source{d}, Infrastructure 2017, Madrid,

--- a/Documentation/bpf.rst
+++ b/Documentation/bpf.rst
@@ -816,7 +816,7 @@ the kernel source for the ``net-next`` tree through git:
 
 ::
 
-    $ git clone git://git.kernel.org/pub/scm/linux/kernel/git/davem/net-next.git
+    $ git clone git://git.kernel.org/pub/scm/linux/kernel/git/netdev/net-next.git
 
 If the git commit history is not of interest, then ``--depth 1`` will clone the
 tree much faster by truncating the git history only to the most recent commit.
@@ -825,7 +825,7 @@ In case the ``net`` tree is of interest, it can be cloned from this url:
 
 ::
 
-    $ git clone git://git.kernel.org/pub/scm/linux/kernel/git/davem/net.git
+    $ git clone git://git.kernel.org/pub/scm/linux/kernel/git/netdev/net.git
 
 There are dozens of tutorials in the Internet on how to build Linux kernels, one
 good resource is the Kernel Newbies website (https://kernelnewbies.org/KernelBuild)
@@ -1091,9 +1091,9 @@ following commands can be used:
 
 ::
 
-    $ git clone http://llvm.org/git/llvm.git
+    $ git clone https://git.llvm.org/git/llvm.git
     $ cd llvm/tools
-    $ git clone --depth 1 http://llvm.org/git/clang.git
+    $ git clone --depth 1 https://git.llvm.org/git/clang.git
     $ cd ..; mkdir build; cd build
     $ cmake .. -DLLVM_TARGETS_TO_BUILD="BPF;X86" -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DLLVM_BUILD_RUNTIME=OFF
     $ make -j $(getconf _NPROCESSORS_ONLN)
@@ -3814,7 +3814,7 @@ Migrating their production infrastructure away from netfilter's IPVS
 to their previous IPVS setup. This was first presented at the netdev 2.1
 conference:
 
-* Slides: https://www.netdevconf.org/2.1/slides/apr6/zhou-netdev-xdp-2017.pdf
+* Slides: https://netdevconf.info/2.1/slides/apr6/zhou-netdev-xdp-2017.pdf
 * Video: https://youtu.be/YEU2ClcGqts
 
 Another example is the integration of XDP into Cloudflare's DDoS mitigation
@@ -3826,7 +3826,7 @@ to busy poll the NIC and expensive packet re-injection into the kernel's stack.
 The migration over to eBPF and XDP combined best of both worlds by having
 high-performance programmable packet processing directly inside the kernel:
 
-* Slides: https://www.netdevconf.org/2.1/slides/apr6/bertin_Netdev-XDP.pdf
+* Slides: https://netdevconf.info/2.1/slides/apr6/bertin_Netdev-XDP.pdf
 * Video: https://youtu.be/7OuOukmuivg
 
 **XDP operation modes**
@@ -4568,7 +4568,7 @@ legacy cBPF:
   assembly for cases where programs are rather small and simple without needing the
   clang / LLVM toolchain.
 
-  https://github.com/solarflarecom/ebpf_asm
+  https://github.com/Xilinx-CNS/ebpf_asm
 
 ..
 
@@ -4608,7 +4608,7 @@ surrounding ecosystem in user space.
 
 All BPF update newsletters (01 - 12) can be found here:
 
-     https://cilium.io/blog/categories/BPF%20Newsletter
+     https://cilium.io/blog/categories/bpf%20newsletter/
 
 Podcasts
 --------
@@ -4620,8 +4620,8 @@ Incomplete list:
      Linux Networking Update from Netdev Conference,
      Thomas Graf,
      Software Gone Wild, Show 71,
-     http://blog.ipspace.net/2017/02/linux-networking-update-from-netdev.html
-     http://media.blubrry.com/ipspace/stream.ipspace.net/nuggets/podcast/Show_71-NetDev_Update.mp3
+     https://blog.ipspace.net/2017/02/linux-networking-update-from-netdev.html
+     https://www.ipspace.net/nuggets/podcast/Show_71-NetDev_Update.mp3
 
 4. Jan 2017,
      The IO Visor Project,
@@ -4634,8 +4634,8 @@ Incomplete list:
      Fast Linux Packet Forwarding,
      Thomas Graf,
      Software Gone Wild, Show 64,
-     http://blog.ipspace.net/2016/10/fast-linux-packet-forwarding-with.html
-     http://media.blubrry.com/ipspace/stream.ipspace.net/nuggets/podcast/Show_64-Cilium_with_Thomas_Graf.mp3
+     https://blog.ipspace.net/2016/10/fast-linux-packet-forwarding-with.html
+     https://www.ipspace.net/nuggets/podcast/Show_64-Cilium_with_Thomas_Graf.mp3
 
 2. Aug 2016,
      P4 on the Edge,
@@ -4649,7 +4649,7 @@ Incomplete list:
      Thomas Graf,
      OVS Orbit, Episode 4,
      https://ovsorbit.org/#e4
-     https://ovsorbit.benpfaff.org/episode-4.mp3
+     https://ovsorbit.org/episode-4.mp3
 
 Blog posts
 ----------
@@ -4679,7 +4679,7 @@ The following (incomplete) list includes blog posts around BPF, XDP and related 
 30. Apr 2017,
      Liveblog: Cilium for Network and Application Security with BPF and XDP,
      Scott Lowe,
-     http://blog.scottlowe.org//2017/04/18/black-belt-cilium/
+     https://blog.scottlowe.org/2017/04/18/black-belt-cilium/
 
 29. Apr 2017,
      eBPF, part 1: Past, Present, and Future,
@@ -4754,7 +4754,7 @@ The following (incomplete) list includes blog posts around BPF, XDP and related 
 15. Sep 2016,
      Suricata bypass feature,
      Eric Leblond,
-     https://www.stamus-networks.com/2016/09/28/suricata-bypass-feature/
+     https://www.stamus-networks.com/blog/2016/09/28/suricata-bypass-feature
 
 14. Aug 2016,
      Introducing the p0f BPF compiler,
@@ -4864,7 +4864,7 @@ related to BPF and XDP:
      Polytechnique Montreal,
      Trace Aggregation and Collection with eBPF,
      Suchakra Sharma,
-     http://step.polymtl.ca/~suchakra/eBPF-5May2017.pdf
+     https://nova.polymtl.ca/~suchakra/eBPF-5May2017.pdf
 
 40. Apr 2017,
      DockerCon, Austin,
@@ -4876,25 +4876,25 @@ related to BPF and XDP:
      NetDev 2.1, Montreal,
      XDP Mythbusters,
      David S. Miller,
-     https://www.netdevconf.org/2.1/slides/apr7/miller-XDP-MythBusters.pdf
+     https://netdevconf.info/2.1/slides/apr7/miller-XDP-MythBusters.pdf
 
 38. Apr 2017,
      NetDev 2.1, Montreal,
      Droplet: DDoS countermeasures powered by BPF + XDP,
      Huapeng Zhou, Doug Porter, Ryan Tierney, Nikita Shirokov,
-     https://www.netdevconf.org/2.1/slides/apr6/zhou-netdev-xdp-2017.pdf
+     https://netdevconf.info/2.1/slides/apr6/zhou-netdev-xdp-2017.pdf
 
 37. Apr 2017,
      NetDev 2.1, Montreal,
      XDP in practice: integrating XDP in our DDoS mitigation pipeline,
      Gilberto Bertin,
-     https://www.netdevconf.org/2.1/slides/apr6/bertin_Netdev-XDP.pdf
+     https://netdevconf.info/2.1/slides/apr6/bertin_Netdev-XDP.pdf
 
 36. Apr 2017,
      NetDev 2.1, Montreal,
      XDP for the Rest of Us,
      Andy Gospodarek, Jesper Dangaard Brouer,
-     https://www.netdevconf.org/2.1/slides/apr7/gospodarek-Netdev2.1-XDP-for-the-Rest-of-Us_Final.pdf
+     https://netdevconf.info/2.1/slides/apr7/gospodarek-Netdev2.1-XDP-for-the-Rest-of-Us_Final.pdf
 
 35. Mar 2017,
      SCALE15x, Pasadena,
@@ -4905,7 +4905,7 @@ related to BPF and XDP:
 34. Mar 2017,
      XDP Inside and Out,
      David S. Miller,
-     https://github.com/iovisor/bpf-docs/raw/master/XDP_Inside_and_Out.pdf
+     https://raw.githubusercontent.com/iovisor/bpf-docs/master/XDP_Inside_and_Out.pdf
 
 33. Mar 2017,
      OpenSourceDays, Copenhagen,
@@ -4923,7 +4923,7 @@ related to BPF and XDP:
      FOSDEM 2017, Brussels,
      Stateful packet processing with eBPF, an implementation of OpenState interface,
      Quentin Monnet,
-     https://fosdem.org/2017/schedule/event/stateful_ebpf/
+     https://archive.fosdem.org/2017/schedule/event/stateful_ebpf/
 
 30. Feb 2017,
      FOSDEM 2017, Brussels,
@@ -4935,7 +4935,7 @@ related to BPF and XDP:
      FOSDEM 2017, Brussels,
      Cilium - BPF & XDP for containers,
      Thomas Graf,
-     https://fosdem.org/2017/schedule/event/cilium/
+     https://archive.fosdem.org/2017/schedule/event/cilium/
 
 28. Jan 2017,
      linuxconf.au, Hobart,
@@ -4953,13 +4953,13 @@ related to BPF and XDP:
      Linux Plumbers, Santa Fe,
      Cilium: Networking & Security for Containers with BPF & XDP,
      Thomas Graf,
-     http://www.slideshare.net/ThomasGraf5/clium-container-networking-with-bpf-xdp
+     https://www.slideshare.net/ThomasGraf5/clium-container-networking-with-bpf-xdp
 
 25. Nov 2016,
      OVS Conference, Santa Clara,
      Offloading OVS Flow Processing using eBPF,
      William (Cheng-Chun) Tu,
-     http://openvswitch.org/support/ovscon2016/7/1120-tu.pdf
+     http://www.openvswitch.org/support/ovscon2016/7/1120-tu.pdf
 
 24. Oct 2016,
      One.com, Copenhagen,
@@ -4971,31 +4971,31 @@ related to BPF and XDP:
      Docker Distributed Systems Summit, Berlin,
      Cilium: Networking & Security for Containers with BPF & XDP,
      Thomas Graf,
-     http://www.slideshare.net/Docker/cilium-bpf-xdp-for-containers-66969823
+     https://www.slideshare.net/Docker/cilium-bpf-xdp-for-containers-66969823
 
 22. Oct 2016,
      NetDev 1.2, Tokyo,
      Data center networking stack,
      Tom Herbert,
-     http://netdevconf.org/1.2/session.html?tom-herbert
+     https://netdevconf.info/1.2/session.html?tom-herbert
 
 21. Oct 2016,
      NetDev 1.2, Tokyo,
      Fast Programmable Networks & Encapsulated Protocols,
      David S. Miller,
-     http://netdevconf.org/1.2/session.html?david-miller-keynote
+     https://netdevconf.info/1.2/session.html?david-miller-keynote
 
 20. Oct 2016,
      NetDev 1.2, Tokyo,
      XDP workshop - Introduction, experience, and future development,
      Tom Herbert,
-     http://netdevconf.org/1.2/session.html?herbert-xdp-workshop
+     https://netdevconf.info/1.2/session.html?herbert-xdp-workshop
 
 19. Oct 2016,
      NetDev1.2, Tokyo,
      The adventures of a Suricate in eBPF land,
      Eric Leblond,
-     http://netdevconf.org/1.2/slides/oct6/10_suricata_ebpf.pdf
+     https://netdevconf.info/1.2/slides/oct6/10_suricata_ebpf.pdf
 
 18. Oct 2016,
      NetDev1.2, Tokyo,
@@ -5008,13 +5008,13 @@ related to BPF and XDP:
      Advanced programmability and recent updates with tc’s cls_bpf,
      Daniel Borkmann,
      http://borkmann.ch/talks/2016_netdev2.pdf
-     http://www.netdevconf.org/1.2/papers/borkmann.pdf
+     https://netdevconf.info/1.2/papers/borkmann.pdf
 
 16. Oct 2016,
      NetDev 1.2, Tokyo,
      eBPF/XDP hardware offload to SmartNICs,
      Jakub Kicinski, Nic Viljoen,
-     http://netdevconf.org/1.2/papers/eBPF_HW_OFFLOAD.pdf
+     https://netdevconf.info/1.2/papers/eBPF_HW_OFFLOAD.pdf
 
 15. Aug 2016,
      LinuxCon, Toronto,
@@ -5037,13 +5037,13 @@ related to BPF and XDP:
      Linux Meetup, Santa Clara,
      eXpress Data Path,
      Brenden Blanco,
-     http://www.slideshare.net/IOVisor/express-data-path-linux-meetup-santa-clara-july-2016
+     https://www.slideshare.net/IOVisor/express-data-path-linux-meetup-santa-clara-july-2016
 
 11. Jul 2016,
      Linux Meetup, Santa Clara,
      CETH for XDP,
      Yan Chan, Yunsong Lu,
-     http://www.slideshare.net/IOVisor/ceth-for-xdp-linux-meetup-santa-clara-july-2016
+     https://www.slideshare.net/IOVisor/ceth-for-xdp-linux-meetup-santa-clara-july-2016
 
 10. May 2016,
      P4 workshop, Stanford,
@@ -5060,14 +5060,14 @@ related to BPF and XDP:
 8. Mar 2016,
     eXpress Data Path,
     Tom Herbert, Alexei Starovoitov,
-    https://github.com/iovisor/bpf-docs/raw/master/Express_Data_Path.pdf
+    https://raw.githubusercontent.com/iovisor/bpf-docs/master/Express_Data_Path.pdf
 
 7. Feb 2016,
     NetDev1.1, Seville,
     On getting tc classifier fully programmable with cls_bpf,
     Daniel Borkmann,
     http://borkmann.ch/talks/2016_netdev.pdf
-    http://www.netdevconf.org/1.1/proceedings/papers/On-getting-tc-classifier-fully-programmable-with-cls-bpf.pdf
+    https://netdevconf.info/1.1/proceedings/papers/On-getting-tc-classifier-fully-programmable-with-cls-bpf.pdf
 
 6. Jan 2016,
     FOSDEM 2016, Brussels,
@@ -5085,7 +5085,7 @@ related to BPF and XDP:
     Tracing Summit, Seattle,
     LLTng's Trace Filtering and beyond (with some eBPF goodness, of course!),
     Suchakra Sharma,
-    https://github.com/iovisor/bpf-docs/raw/master/ebpf_excerpt_20Aug2015.pdf
+    https://raw.githubusercontent.com/iovisor/bpf-docs/master/ebpf_excerpt_20Aug2015.pdf
 
 3. Jun 2015,
     LinuxCon Japan, Tokyo,
@@ -5103,7 +5103,7 @@ related to BPF and XDP:
     NetDev 0.1, Ottawa,
     BPF: In-kernel Virtual Machine,
     Alexei Starovoitov,
-    http://netdevconf.org/0.1/sessions/15.html
+    https://netdevconf.info/0.1/sessions/15.html
 
 0. Feb 2014,
     DevConf.cz, Brno,

--- a/Documentation/cheatsheet.rst
+++ b/Documentation/cheatsheet.rst
@@ -62,7 +62,7 @@ output, to get the JSON output you can use the global option ``-o json``
     $ cilium endpoint list -o json
 
 Moreover, Cilium also provides a `JSONPath
-<http://goessner.net/articles/JsonPath/>`_ support, so detailed information can
+<https://goessner.net/articles/JsonPath/>`_ support, so detailed information can
 be extracted. JSONPath template reference can be found in `Kubernetes
 documentation <https://kubernetes.io/docs/reference/kubectl/jsonpath/>`_
 
@@ -242,7 +242,7 @@ Check cluster Connectivity
 	cilium-health status
 
 There is also a `blog post
-<https://cilium.io/blog/2018/2/6/cilium-troubleshooting-cluster-health-monitor>`_
+<https://cilium.io/blog/2018/2/6/cilium-troubleshooting-cluster-health-monitor/>`_
 related to this tool.
 
 Endpoints
@@ -326,7 +326,7 @@ Kubernetes examples:
 If you running Cilium on top of Kubernetes you may also want a way to list all
 cilium endpoints or policies from a single Kubectl commands. Cilium provides all
 this information to the user by using `Kubernetes Resource Definitions
-<https://kubernetes.io/docs/concepts/api-extension/custom-resources/>`_:
+<https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/>`_:
 
 Policies
 ---------

--- a/Documentation/cheatsheet.rst
+++ b/Documentation/cheatsheet.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 ******************
 Command Cheatsheet

--- a/Documentation/cmdref/cli_index.rst
+++ b/Documentation/cmdref/cli_index.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 cilium
 ======

--- a/Documentation/cmdref/index.rst
+++ b/Documentation/cmdref/index.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 Command Reference
 =================

--- a/Documentation/cmdref/kvstore.rst
+++ b/Documentation/cmdref/kvstore.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _install_kvstore:
 

--- a/Documentation/commit-access.rst
+++ b/Documentation/commit-access.rst
@@ -7,8 +7,8 @@
 ..       This has been bluntly copied from the excellent committer guidelines
          written for the Open vSwitch project and has then been adapted. It is
          based on the following files:
-         https://github.com/openvswitch/ovs/blob/master/Documentation/committer-grant-revocation.rst
-         https://github.com/openvswitch/ovs/blob/master/Documentation/committer-responsibilities.rst
+         https://github.com/openvswitch/ovs/blob/master/Documentation/internals/committer-grant-revocation.rst
+         https://github.com/openvswitch/ovs/blob/master/Documentation/internals/committer-responsibilities.rst
 
 ..       Licensed under the Apache License, Version 2.0 (the "License"); you may
          not use this file except in compliance with the License. You may obtain

--- a/Documentation/commit-access.rst
+++ b/Documentation/commit-access.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 ..       This has been bluntly copied from the excellent committer guidelines
          written for the Open vSwitch project and has then been adapted. It is

--- a/Documentation/community.rst
+++ b/Documentation/community.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 Special Interest Groups
 =======================

--- a/Documentation/concepts/datapath.rst
+++ b/Documentation/concepts/datapath.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _concepts_datapath:
 

--- a/Documentation/concepts/failure_behavior.rst
+++ b/Documentation/concepts/failure_behavior.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 ****************
 Failure Behavior

--- a/Documentation/concepts/index.rst
+++ b/Documentation/concepts/index.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _concepts:
 

--- a/Documentation/concepts/ipam/azure.rst
+++ b/Documentation/concepts/ipam/azure.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _ipam_azure:
 

--- a/Documentation/concepts/ipam/crd.rst
+++ b/Documentation/concepts/ipam/crd.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _concepts_ipam_crd:
 

--- a/Documentation/concepts/ipam/eni.rst
+++ b/Documentation/concepts/ipam/eni.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _ipam_eni:
 

--- a/Documentation/concepts/ipam/hostscope.rst
+++ b/Documentation/concepts/ipam/hostscope.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 ####################
 Host Scope (default)

--- a/Documentation/concepts/ipam/index.rst
+++ b/Documentation/concepts/ipam/index.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _address_management:
 

--- a/Documentation/concepts/ipam/kubernetes.rst
+++ b/Documentation/concepts/ipam/kubernetes.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 #####################
 Kubernetes Host Scope

--- a/Documentation/concepts/networking.rst
+++ b/Documentation/concepts/networking.rst
@@ -107,8 +107,8 @@ This is typically achieved using two methods:
           GitHub issue if you experience any problems.
 
 
-.. _AWS VPC Route Tables: http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Route_Tables.html
-.. _GCE Routes: https://cloud.google.com/compute/docs/reference/latest/routes
+.. _AWS VPC Route Tables: https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Route_Tables.html
+.. _GCE Routes: https://cloud.google.com/compute/docs/reference/rest/v1/routes
 
 There are two possible approaches to performing network forwarding for
 container-to-container traffic:

--- a/Documentation/concepts/networking.rst
+++ b/Documentation/concepts/networking.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _arch_ip_connectivity:
 .. _multi host networking:

--- a/Documentation/concepts/overview.rst
+++ b/Documentation/concepts/overview.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 ******************
 Component Overview

--- a/Documentation/concepts/security.rst
+++ b/Documentation/concepts/security.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _concepts_security:
 

--- a/Documentation/concepts/terminology.rst
+++ b/Documentation/concepts/terminology.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 ***********
 Terminology

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -91,10 +91,11 @@ else:
     chart_release = 'cilium/cilium --version ' + release
     tags.add('stable')
 relinfo = semver.parse_version_info(release)
-next_release = '%d.%d' % (relinfo.major, relinfo.minor)
+current_release = '%d.%d' % (relinfo.major, relinfo.minor)
 if relinfo.patch == 90:
     next_release = '%d.%d' % (relinfo.major, relinfo.minor + 1)
-current_release = release[0:3]
+else:
+    next_release = current_release
 githubusercontent = 'https://raw.githubusercontent.com/cilium/cilium/'
 scm_web = githubusercontent + branch
 jenkins_branch = 'https://jenkins.cilium.io/view/Cilium-v' + current_release

--- a/Documentation/configuration/metrics.rst
+++ b/Documentation/configuration/metrics.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _metrics:
 

--- a/Documentation/contributing/development/contributing_guide.rst
+++ b/Documentation/contributing/development/contributing_guide.rst
@@ -13,7 +13,7 @@ How To Contribute
 Clone and Provision Environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-#. Make sure you have a `GitHub account <https://github.com/signup/free>`_
+#. Make sure you have a `GitHub account <https://github.com/join>`_
 #. Clone the cilium repository
 
    ::
@@ -31,7 +31,7 @@ Submitting a pull request
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Contributions must be submitted in the form of pull requests against the github
-repository at: `<https://github.com/cilium/cilium>`_
+repository at: https://github.com/cilium/cilium.
 
 #. Fork the Cilium repository to your own personal GitHub space or request
    access to a Cilium developer account on Slack

--- a/Documentation/contributing/development/contributing_guide.rst
+++ b/Documentation/contributing/development/contributing_guide.rst
@@ -68,7 +68,7 @@ requirements have been met:
 
         Fixes: #4191
 
-        Signed-off-by: Joe Stringer <joe@covalent.io>
+        Signed-off-by: Joe Stringer <joe@cilium.io>
 
    .. note:
 

--- a/Documentation/contributing/development/contributing_guide.rst
+++ b/Documentation/contributing/development/contributing_guide.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 
 .. _howto_contribute:

--- a/Documentation/contributing/development/dev_setup.rst
+++ b/Documentation/contributing/development/dev_setup.rst
@@ -2,7 +2,7 @@
   
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _dev_env:
 

--- a/Documentation/contributing/development/images.rst
+++ b/Documentation/contributing/development/images.rst
@@ -147,4 +147,3 @@ Nightly images are stored on dockerhub tagged with following format: ``YYYYMMDD-
 Job number is added to tag for the unlikely event of two consecutive nightly builds being built on the same date.
 
 .. _cilium/nightly: https://hub.docker.com/r/cilium/nightly/
-.. _Cilium-Nightly-Tests Job: https://jenkins.cilium.io/job/Cilium-Master-Nightly-Tests-All/

--- a/Documentation/contributing/development/images.rst
+++ b/Documentation/contributing/development/images.rst
@@ -2,7 +2,7 @@
   
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _container_images:
 

--- a/Documentation/contributing/development/index.rst
+++ b/Documentation/contributing/development/index.rst
@@ -2,7 +2,7 @@
   
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _dev_guide:
 

--- a/Documentation/contributing/release/backports.rst
+++ b/Documentation/contributing/release/backports.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _backport_process:
 

--- a/Documentation/contributing/release/feature.rst
+++ b/Documentation/contributing/release/feature.rst
@@ -86,7 +86,7 @@ On Freeze date
 
 #. Set the branch as "Active" and the "Privacy Level" to "Private" in the
    readthedocs Admin page. (Replace ``v1.2`` with the right branch)
-   ``https://readthedocs.org/dashboard/cilium/version/v1.2``
+   ``https://readthedocs.org/dashboard/cilium/version/v1.2/``
 
 #. Since this is the first release being made from a new branch, please
    follow the :ref:`generic_release_process` to release ``v1.2.0-rc1``.

--- a/Documentation/contributing/release/feature.rst
+++ b/Documentation/contributing/release/feature.rst
@@ -2,7 +2,7 @@
   
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _minor_release_process:
 

--- a/Documentation/contributing/release/index.rst
+++ b/Documentation/contributing/release/index.rst
@@ -2,7 +2,7 @@
   
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _release_management:
 

--- a/Documentation/contributing/release/organization.rst
+++ b/Documentation/contributing/release/organization.rst
@@ -2,7 +2,7 @@
   
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 Organization
 ============

--- a/Documentation/contributing/release/rc.rst
+++ b/Documentation/contributing/release/rc.rst
@@ -2,7 +2,7 @@
   
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _release_candidate_process:
 

--- a/Documentation/contributing/release/stable.rst
+++ b/Documentation/contributing/release/stable.rst
@@ -181,7 +181,7 @@ If you intent to release a new feature release, see the
 
 #. Update the external tools and guides to point to the released Cilium version:
 
-    * `kubeadm <https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/>`_
+    * `kubeadm <https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/>`_
     * `kops <https://github.com/kubernetes/kops/>`_
     * `kubespray <https://github.com/kubernetes-sigs/kubespray/>`_
 

--- a/Documentation/contributing/release/stable.rst
+++ b/Documentation/contributing/release/stable.rst
@@ -2,7 +2,7 @@
   
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _generic_release_process:
 

--- a/Documentation/contributing/testing/ci.rst
+++ b/Documentation/contributing/testing/ci.rst
@@ -208,7 +208,7 @@ There are some feature flags based on Pull Requests labels, the list of labels
 are the following:
 
 - ``area/containerd``: Enable containerd runtime on all Kubernetes test.
-- ``ci/next-next``: Run tests on net-next kernel. This causes the
+- ``ci/net-next``: Run tests on net-next kernel. This causes the
   ``test-me-please`` target to only run on the net-next kernel. It is purely
   for testing on a different kernel, to merge a PR it must pass the CI
   without this flag.

--- a/Documentation/contributing/testing/ci.rst
+++ b/Documentation/contributing/testing/ci.rst
@@ -200,7 +200,8 @@ illustrating which subset of tests the job runs.
 +----------------------------------------------------------------------------------------------------------------+-------------------+--------------------+
 | `Cilium-PR-Flannel <https://jenkins.cilium.io/job/Cilium-PR-Flannel/>`_                                        | test-flannel      | No                 |
 +----------------------------------------------------------------------------------------------------------------+-------------------+--------------------+
-| `Cilium-PR-K8s-GKE <https://jenkins.cilium.io/job/Cilium-PR-K8s-GKE/>`_                                        | test-gke          | Yes                |
+| `Cilium-PR-K8s-GKE <https://jenkins.cilium.io/job/Cilium-PR-K8s-GKE/>`_                                        | test-me-please,   | Yes                |
+|                                                                                                                | test-gke          |                    |
 +----------------------------------------------------------------------------------------------------------------+-------------------+--------------------+
 
 There are some feature flags based on Pull Requests labels, the list of labels

--- a/Documentation/contributing/testing/ci.rst
+++ b/Documentation/contributing/testing/ci.rst
@@ -2,7 +2,7 @@
   
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _ci_jenkins:
 

--- a/Documentation/contributing/testing/ci.rst
+++ b/Documentation/contributing/testing/ci.rst
@@ -78,13 +78,13 @@ Cilium-Nightly-Tests-PR
 Runs long-lived tests which take extended time. Some of these tests have an
 expected failure rate.
 
-Nightly tests run once per day in the ``Cilium-Nightly-Tests Job``.  The
+Nightly tests run once per day in the `Cilium-Nightly-Tests-PR`_ job.  The
 configuration for this job is stored in ``Jenkinsfile.nightly``.
 
 To see the results of these tests, you can view the JUnit Report for an individual job:
 
 1. Click on the build number you wish to get test results from on the left hand
-   side of the ``Cilium-Nightly-Tests Job``.
+   side of the `Cilium-Nightly-Tests-PR`_ job.
 2. Click on 'Test Results' on the left side of the page to view the results from the build.
    This will give you a report of which tests passed and failed. You can click on each test
    to view its corresponding output created from Ginkgo.
@@ -198,7 +198,7 @@ illustrating which subset of tests the job runs.
 +----------------------------------------------------------------------------------------------------------------+-------------------+--------------------+
 | `Cilium-PR-Kubernetes-Upstream <https://jenkins.cilium.io/view/PR/job/Cilium-PR-Kubernetes-Upstream/>`_        | test-upstream-k8s | No                 |
 +----------------------------------------------------------------------------------------------------------------+-------------------+--------------------+
-| `Cilium-PR-Flannel <https://jenkins.cilium.io/job/Cilium-PR-Flannel/>`_                                        | test-flannel      | No                 |
+| `Cilium-PR-Flannel <https://jenkins.cilium.io/job/Cilium-PR-Flannel-hook/>`_                                   | test-flannel      | No                 |
 +----------------------------------------------------------------------------------------------------------------+-------------------+--------------------+
 | `Cilium-PR-K8s-GKE <https://jenkins.cilium.io/job/Cilium-PR-K8s-GKE/>`_                                        | test-me-please,   | Yes                |
 |                                                                                                                | test-gke          |                    |

--- a/Documentation/contributing/testing/ci.rst
+++ b/Documentation/contributing/testing/ci.rst
@@ -116,7 +116,7 @@ New versions of this box can be created via `Jenkins Packer Build
 <https://jenkins.cilium.io/job/Vagrant-Master-Boxes-Packer-Build/>`_, where
 new builds of the image will be pushed to  `Vagrant Cloud
 <https://app.vagrantup.com/cilium>`_ . The version of the image corresponds to
-the `BUILD_ID <https://qa.nuxeo.org/jenkins/pipeline-syntax/globals#env>`_
+the `BUILD_ID <https://wiki.jenkins.io/display/JENKINS/Building+a+software+project#Buildingasoftwareproject-below>`_
 environment variable in the Jenkins job. That version ID will be used in Cilium
 `Vagrantfiles
 <https://github.com/cilium/cilium/blob/master/test/Vagrantfile#L10>`_.

--- a/Documentation/contributing/testing/ci.rst
+++ b/Documentation/contributing/testing/ci.rst
@@ -70,7 +70,7 @@ running tests to see which Kubernetes versions will be tested against.
 Ginkgo-CI-Tests-Pipeline
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-https://jenkins.cilium.io/job/Ginkgo-CI-Tests-Pipeline/
+`Ginkgo-CI-Tests-Pipeline`_
 
 Cilium-Nightly-Tests-PR
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -108,12 +108,9 @@ Packer-CI-Build
 As part of Cilium development, we use a custom base box with a bunch of
 pre-installed libraries and tools that we need to enhance our daily workflow.
 That base box is built with `Packer <https://www.packer.io/>`_ and it is hosted
-in the `packer-ci-build
-<https://jenkins.cilium.io/job/Vagrant-Master-Boxes-Packer-Build/>`_ GitHub
-repository.
+in the `packer-ci-build`_ GitHub repository.
 
-New versions of this box can be created via `Jenkins Packer Build
-<https://jenkins.cilium.io/job/Vagrant-Master-Boxes-Packer-Build/>`_, where
+New versions of this box can be created via `Jenkins Packer Build`_, where
 new builds of the image will be pushed to  `Vagrant Cloud
 <https://app.vagrantup.com/cilium>`_ . The version of the image corresponds to
 the `BUILD_ID <https://wiki.jenkins.io/display/JENKINS/Building+a+software+project#Buildingasoftwareproject-below>`_
@@ -126,8 +123,8 @@ repository. Authorized GitHub users can trigger builds with a GitHub comment on
 the PR containing the trigger phrase ``build-me-please``. In case that a new box
 needs to be rebased with a different branch than master, authorized developers
 can run the build with custom parameters. To use a different Cilium branch in
-the `job <https://jenkins.cilium.io/job/Vagrant-Master-Boxes-Packer-Build/>`_ go
-to *Build with parameters* and a base branch can be set as the user needs.
+the `job`_ go to *Build with parameters* and a base branch can be set as the
+user needs.
 
 This box will need to be updated when a new developer needs a new dependency
 that is not installed in the current version of the box, or if a dependency that
@@ -141,6 +138,8 @@ Once you change the image versions locally, create a branch named
 It is important that you use that branch name so the VM images are cached into
 packet.net before the branch is merged.
 
+.. _Jenkins Packer Build: Vagrant-Master-Boxes-Packer-Build_
+.. _job: Vagrant-Master-Boxes-Packer-Build_
 
 Testing matrix
 ^^^^^^^^^^^^^^
@@ -292,7 +291,7 @@ GitHub issues using the process below:
 +---------------------------------------+------------------------------------------------------------------+
 | `Master-Nightly`_                     | Runs durability tests every night                                |
 +---------------------------------------+------------------------------------------------------------------+
-| `Vagrant-Master-Boxes-Packer-Build`_  | Runs on merge into `github.com/cilium/packer-ci-build`_.         |
+| `Vagrant-Master-Boxes-Packer-Build`_  | Runs on merge into `packer-ci-build`_ repository.                |
 +---------------------------------------+------------------------------------------------------------------+
 | :jenkins-branch:`Release-branch <>`   | Runs various Ginkgo tests on merge into branch "\ |SCM_BRANCH|"  |
 +---------------------------------------+------------------------------------------------------------------+
@@ -301,7 +300,7 @@ GitHub issues using the process below:
 .. _Ginkgo-CI-Tests-Pipeline: https://jenkins.cilium.io/job/Ginkgo-CI-Tests-Pipeline/
 .. _Master-Nightly: https://jenkins.cilium.io/job/Cilium-Master-Nightly/
 .. _Vagrant-Master-Boxes-Packer-Build: https://jenkins.cilium.io/job/Vagrant-Master-Boxes-Packer-Build/
-.. _github.com/cilium/packer-ci-build: https://github.com/cilium/packer-ci-build/
+.. _packer-ci-build: https://github.com/cilium/packer-ci-build/
 
 Triage process
 ^^^^^^^^^^^^^^
@@ -350,7 +349,7 @@ Triage process
       tests. A zipfile for all tests is also available.
    #. Check how much time has passed since the last reported occurrence of this
       failure and move this issue to the correct column in the `CI flakes
-      project <https://github.com/cilium/cilium/projects/8>`_ board.
+      project`_ board.
 
 #. If no existing GitHub issue was found, file a `new GitHub issue <https://github.com/cilium/cilium/issues/new>`_:
 
@@ -368,7 +367,7 @@ Triage process
          eventually deleted).
       #. Attach zipfile downloaded from Jenkins with logs from failing test
       #. Include the test name and whole Stacktrace section to help others find this issue.
-      #. Add issue to `CI flakes project <https://github.com/cilium/cilium/projects/8>`_
+      #. Add issue to `CI flakes project`_.
 
    .. note::
 
@@ -400,6 +399,7 @@ Triage process
 * ``CI-Bug, K8sValidatedPolicyTest: Namespaces, pod not ready, #9939``
 * ``Regression, k8s host policy, #1111``
 
+.. _CI flakes project: https://github.com/cilium/cilium/projects/8
 
 Bisect process
 ^^^^^^^^^^^^^^

--- a/Documentation/contributing/testing/documentation.rst
+++ b/Documentation/contributing/testing/documentation.rst
@@ -2,7 +2,7 @@
   
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 Documentation
 =============

--- a/Documentation/contributing/testing/e2e.rst
+++ b/Documentation/contributing/testing/e2e.rst
@@ -2,7 +2,7 @@
   
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _testsuite:
 

--- a/Documentation/contributing/testing/e2e.rst
+++ b/Documentation/contributing/testing/e2e.rst
@@ -12,7 +12,7 @@ End-To-End Testing Framework
 Introduction
 ~~~~~~~~~~~~
 
-Cilium uses `Ginkgo <https://onsi.github.io/ginkgo>`_ as a testing framework for
+Cilium uses `Ginkgo <https://onsi.github.io/ginkgo/>`_ as a testing framework for
 writing end-to-end tests which test Cilium all the way from the API level (e.g.
 importing policies, CLI) to the datapath (i.e, whether policy that is imported
 is enforced accordingly in the datapath).  The tests in the ``test`` directory
@@ -533,7 +533,7 @@ mapping with the constant and the helm settings.
 4- For cases where a test should be skipped use the ``SkipIfIntegration``. To
 skip whole contexts, use ``SkipContextIf``. More complex logic can be expressed
 with functions like ``IsIntegration``. These functions are all part of the
-`test/helpers <https://github.com/cilium/cilium/blob/26dec4c4f4311df2b1a6c909b27ff7fe6e46929f/test/helpers>`_
+`test/helpers <https://github.com/cilium/cilium/tree/26dec4c4f4311df2b1a6c909b27ff7fe6e46929f/test/helpers>`_
 package.
 
 Running End-To-End Tests In Other Environments via SSH

--- a/Documentation/contributing/testing/e2e.rst
+++ b/Documentation/contributing/testing/e2e.rst
@@ -12,7 +12,7 @@ End-To-End Testing Framework
 Introduction
 ~~~~~~~~~~~~
 
-Cilium uses `Ginkgo <https://onsi.github.io/ginkgo/>`_ as a testing framework for
+Cilium uses `Ginkgo`_ as a testing framework for
 writing end-to-end tests which test Cilium all the way from the API level (e.g.
 importing policies, CLI) to the datapath (i.e, whether policy that is imported
 is enforced accordingly in the datapath).  The tests in the ``test`` directory
@@ -26,7 +26,7 @@ well as running `example tests
 Ginkgo workflow.
 
 These test scripts will invoke ``vagrant`` to create virtual machine(s) to
-run the tests. The tests make heavy use of the Ginkgo `focus <https://onsi.github.io/ginkgo/#focused-specs>`_ concept to
+run the tests. The tests make heavy use of the Ginkgo `focus`_ concept to
 determine which VMs are necessary to run particular tests. All test names
 *must* begin with one of the following prefixes:
 
@@ -34,6 +34,9 @@ determine which VMs are necessary to run particular tests. All test names
 * ``K8s``: Create a small multi-node kubernetes environment for testing
   features beyond a single host, and for testing kubernetes-specific features.
 * ``Nightly``: sets up a multinode Kubernetes cluster to run scale, performance, and chaos testing for Cilium.
+
+.. _Ginkgo: https://onsi.github.io/ginkgo/
+.. _focus: `Focused Specs`_
 
 Running End-To-End Tests
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -207,14 +210,19 @@ framework in the ``test/`` directory and interact with ginkgo directly:
     
 
 For more information about other built-in options to Ginkgo, consult the
-`Ginkgo documentation <https://onsi.github.io/ginkgo/>`_.
+`Ginkgo documentation`_.
+
+.. _Ginkgo documentation: Ginkgo_
 
 Running Specific Tests Within a Test Suite
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If you want to run one specified test, there are a few options:
 
-* By modifying code: add the prefix "FIt" on the test you want to run; this marks the test as focused. Ginkgo will skip other tests and will only run the "focused" test. For more information, consult the `Focused Specs <https://onsi.github.io/ginkgo/#focused-specs>`_ documentation from Ginkgo.
+* By modifying code: add the prefix "FIt" on the test you want to run; this
+  marks the test as focused. Ginkgo will skip other tests and will only run the
+  "focused" test. For more information, consult the `Focused Specs`_
+  documentation from Ginkgo.
 
 ::
 
@@ -236,6 +244,8 @@ If you want to run one specified test, there are a few options:
 
 This will focus on tests prefixed with "Run*", and within that focus, run any
 test that starts with "L7".
+
+.. _Focused Specs: https://onsi.github.io/ginkgo/#focused-specs
 
 Compiling the tests without running them
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -279,20 +289,17 @@ useful for testing Cilium.
 BeforeAll
 ^^^^^^^^^
 
-This function will run before all `BeforeEach
-<https://onsi.github.io/ginkgo/#extracting-common-setup-beforeeach>`_ within a
-`Describe or Context
-<https://onsi.github.io/ginkgo/#organizing-specs-with-containers-describe-and-context>`_.
+This function will run before all `BeforeEach`_ within a `Describe or Context`_.
 This method is an equivalent to ``SetUp`` or initialize functions in common
 unit test frameworks.
+
+.. _BeforeEach: https://onsi.github.io/ginkgo/#extracting-common-setup-beforeeach
+.. _Describe or Context: https://onsi.github.io/ginkgo/#organizing-specs-with-containers-describe-and-context
 
 AfterAll
 ^^^^^^^^
 
-This method will run after all `AfterEach
-<https://onsi.github.io/ginkgo/#extracting-common-setup-beforeeach>`_ functions
-defined in a `Describe or Context
-<https://onsi.github.io/ginkgo/#organizing-specs-with-containers-describe-and-context>`_.
+This method will run after all `AfterEach`_ functions defined in a `Describe or Context`_.
 This method is used for tearing down objects created which are used by all
 ``Its`` within the given ``Context`` or ``Describe``. It is ran after all Its
 have ran, this method is a equivalent to ``tearDown`` or ``finalize`` methods in
@@ -300,6 +307,8 @@ common unit test frameworks.
 
 A good use case for using ``AfterAll`` method is to remove containers or pods
 that are needed for multiple ``Its`` in the given ``Context`` or ``Describe``.
+
+.. _AfterEach: BeforeEach_
 
 JustAfterEach
 ^^^^^^^^^^^^^

--- a/Documentation/contributing/testing/index.rst
+++ b/Documentation/contributing/testing/index.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _testing_guide:
 

--- a/Documentation/contributing/testing/unit.rst
+++ b/Documentation/contributing/testing/unit.rst
@@ -2,7 +2,7 @@
   
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _unit_testing:
 

--- a/Documentation/docker/index.rst
+++ b/Documentation/docker/index.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 ******
 Docker

--- a/Documentation/docker/index.rst
+++ b/Documentation/docker/index.rst
@@ -40,5 +40,5 @@ Follow this guide for a step by step introduction on how to use Cilium with
    ../gettingstarted/docker
 
 
-.. _libnetwork: https://github.com/docker/libnetwork/blob/master/docs/design.md
+.. _libnetwork: https://github.com/moby/libnetwork/blob/master/docs/design.md
 .. _`Docker Compose`: https://docs.docker.com/compose/

--- a/Documentation/envoy/extensions.rst
+++ b/Documentation/envoy/extensions.rst
@@ -79,7 +79,7 @@ These specs help you understand protocol aspects like:
   
 Sometimes, the protocol spec does not give you a full sense of the set of commands that can be sent over the protocol.  In that 
 case, looking at higher-level user documentation can fill in some of these knowledge gaps.  Here are examples for 
-`Redis Commands <https://redis.io/commands>`_ and `Cassandra CQL Commands  <https://docs.datastax.com/en/cql/3.1/cql/cql_reference/cqlCommandsTOC.html>`_ .  
+`Redis Commands <https://redis.io/commands>`_ and `Cassandra CQL Commands <https://docs.datastax.com/en/archived/cql/3.1/cql/cql_reference/cqlCommandsTOC.html>`_ .
  
 Another great trick is to use `Wireshark <https://www.wireshark.org>`_  to capture raw packet data between
 a client and server.   For many protocols, the `Wireshark Sample Captures <https://wiki.wireshark.org/SampleCaptures>`_ 

--- a/Documentation/envoy/extensions.rst
+++ b/Documentation/envoy/extensions.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 *******************
 Envoy Go Extensions

--- a/Documentation/further_reading.rst
+++ b/Documentation/further_reading.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 ###############
 Further Reading

--- a/Documentation/gettinghelp.rst
+++ b/Documentation/gettinghelp.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _getting_help:
 

--- a/Documentation/gettinghelp.rst
+++ b/Documentation/gettinghelp.rst
@@ -36,7 +36,7 @@ GitHub
 **Bug Tracker**: All the issues are addressed in the `GitHub issue tracker
 <https://github.com/cilium/cilium/issues>`_.  If you want to report a bug or a
 new feature please file the issue according to the `GitHub template
-<https://github.com/cilium/cilium/blob/master/.github/issue_template.md>`_.
+<https://github.com/cilium/cilium/blob/master/.github/ISSUE_TEMPLATE/issue_template.md>`_.
 
 **Contributing**: If you want to contribute, reading the :ref:`dev_guide` should
 help you.

--- a/Documentation/gettingstarted/aws-eni.rst
+++ b/Documentation/gettingstarted/aws-eni.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _k8s_aws_eni:
 

--- a/Documentation/gettingstarted/aws.rst
+++ b/Documentation/gettingstarted/aws.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 ***********************************************
 Locking down external access using AWS metadata

--- a/Documentation/gettingstarted/bird.rst
+++ b/Documentation/gettingstarted/bird.rst
@@ -11,8 +11,9 @@ Using BIRD to run BGP
 
 `BIRD is an open-source implementation for routing Internet Protocol
 packets on Unix-like operating systems <https://en.wikipedia.org/wiki/Bird_Internet_routing_daemon>`_.
-If you are not familiar with it, you had best have a glance at the `User's Guide
-<https://bird.network.cz/?get_doc&f=bird.html&v=20>`_ first.
+If you are not familiar with it, you had best have a glance at the `User's Guide`_ first.
+
+.. _`User's Guide`: https://bird.network.cz/?get_doc&f=bird.html&v=20
 
 `BIRD <https://bird.network.cz>`_ maintains two release families at present:
 ``1.x`` and ``2.x``, and the configuration format varies a lot between them.
@@ -207,7 +208,7 @@ Advanced Configurations
 
 You may need some advanced configurations to make your BGP scheme production-ready.
 This section lists some of these parameters, but we will not dive into details,
-that's BIRD `User's Guide <https://bird.network.cz/?get_doc&f=bird.html&v=20>`_'s responsibility.
+that's BIRD `User's Guide`_'s responsibility.
 
 BFD
 ----

--- a/Documentation/gettingstarted/bird.rst
+++ b/Documentation/gettingstarted/bird.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 
 ****************************

--- a/Documentation/gettingstarted/cassandra.rst
+++ b/Documentation/gettingstarted/cassandra.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _gs_cassandra:
 

--- a/Documentation/gettingstarted/cassandra.rst
+++ b/Documentation/gettingstarted/cassandra.rst
@@ -26,7 +26,7 @@ Deploy the Demo Application
 
 Now that we have Cilium deployed and ``kube-dns`` operating correctly we can
 deploy our demo Cassandra application.  Since our first
-`HTTP-aware Cilium  Star Wars demo <https://www.cilium.io/blog/2017/5/4/demo-may-the-force-be-with-you>`_
+`HTTP-aware Cilium  Star Wars demo <https://cilium.io/blog/2017/5/4/demo-may-the-force-be-with-you/>`_
 showed how the Galactic Empire used HTTP-aware security policies to protect the Death Star from the
 Rebel Alliance, this Cassandra demo is Star Wars-themed as well.
 

--- a/Documentation/gettingstarted/cni-chaining-aws-cni.rst
+++ b/Documentation/gettingstarted/cni-chaining-aws-cni.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 *******
 AWS-CNI

--- a/Documentation/gettingstarted/cni-chaining-azure-cni.rst
+++ b/Documentation/gettingstarted/cni-chaining-azure-cni.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 *********
 Azure CNI

--- a/Documentation/gettingstarted/cni-chaining-calico.rst
+++ b/Documentation/gettingstarted/cni-chaining-calico.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 ******
 Calico

--- a/Documentation/gettingstarted/cni-chaining-generic-veth.rst
+++ b/Documentation/gettingstarted/cni-chaining-generic-veth.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 *********************
 Generic Veth Chaining

--- a/Documentation/gettingstarted/cni-chaining-portmap.rst
+++ b/Documentation/gettingstarted/cni-chaining-portmap.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 
 .. _k8s_install_portmap:

--- a/Documentation/gettingstarted/cni-chaining-weave.rst
+++ b/Documentation/gettingstarted/cni-chaining-weave.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 *********
 Weave Net

--- a/Documentation/gettingstarted/cni-chaining.rst
+++ b/Documentation/gettingstarted/cni-chaining.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _cni_chaining:
 

--- a/Documentation/gettingstarted/dns.rst
+++ b/Documentation/gettingstarted/dns.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _gs_dns:
 

--- a/Documentation/gettingstarted/docker.rst
+++ b/Documentation/gettingstarted/docker.rst
@@ -57,9 +57,10 @@ it will print:
 
 If the script exits with an error message, do not attempt to proceed with the
 tutorial, as later steps will not work properly.   Instead, contact us on the
-`Cilium Slack channel <https://cilium.herokuapp.com>`_.
+`Cilium Slack channel`_.
 
 .. _`Docker Compose`: https://docs.docker.com/compose/
+.. _Cilium Slack channel: https://cilium.herokuapp.com
 
 Step 3: Accessing the VM
 ========================
@@ -305,7 +306,7 @@ microservices.
 
 We hope you enjoyed the tutorial.  Feel free to play more with the setup, read
 the rest of the documentation, and reach out to us on the `Cilium
-Slack channel <https://cilium.herokuapp.com>`_ with any questions!
+Slack channel`_ with any questions!
 
 
 Step 10: Clean-Up

--- a/Documentation/gettingstarted/docker.rst
+++ b/Documentation/gettingstarted/docker.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _gsg_docker:
 

--- a/Documentation/gettingstarted/elasticsearch.rst
+++ b/Documentation/gettingstarted/elasticsearch.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 **************************************
 Getting Started Securing Elasticsearch

--- a/Documentation/gettingstarted/encryption.rst
+++ b/Documentation/gettingstarted/encryption.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _encryption:
 

--- a/Documentation/gettingstarted/flannel-integration.rst
+++ b/Documentation/gettingstarted/flannel-integration.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _flannel-integration:
 

--- a/Documentation/gettingstarted/grafana.rst
+++ b/Documentation/gettingstarted/grafana.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _install_metrics:
 

--- a/Documentation/gettingstarted/grpc.rst
+++ b/Documentation/gettingstarted/grpc.rst
@@ -31,7 +31,7 @@ Deploy the Demo Application
 Now that we have Cilium deployed and ``kube-dns`` operating correctly we can
 deploy our demo gRPC application.  Since our first demo of Cilium + HTTP-aware security
 policies was Star Wars-themed, we decided to do the same for gRPC. While the
-`HTTP-aware Cilium  Star Wars demo <https://www.cilium.io/blog/2017/5/4/demo-may-the-force-be-with-you>`_
+`HTTP-aware Cilium  Star Wars demo <https://cilium.io/blog/2017/5/4/demo-may-the-force-be-with-you/>`_
 showed how the Galactic Empire used HTTP-aware security policies to protect the Death Star from the
 Rebel Alliance, this gRPC demo shows how the lack of gRPC-aware security policies allowed Leia, Chewbacca, Lando, C-3PO, and R2-D2 to escape from Cloud City, which had been overtaken by
 empire forces.

--- a/Documentation/gettingstarted/grpc.rst
+++ b/Documentation/gettingstarted/grpc.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 ******************
 How to secure gRPC

--- a/Documentation/gettingstarted/host-services.rst
+++ b/Documentation/gettingstarted/host-services.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _host-services:
 

--- a/Documentation/gettingstarted/http.rst
+++ b/Documentation/gettingstarted/http.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _gs_http:
 

--- a/Documentation/gettingstarted/index.rst
+++ b/Documentation/gettingstarted/index.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _gs_guide:
 

--- a/Documentation/gettingstarted/ipam-crd.rst
+++ b/Documentation/gettingstarted/ipam-crd.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _gsg_ipam_crd:
 

--- a/Documentation/gettingstarted/ipam.rst
+++ b/Documentation/gettingstarted/ipam.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _gsg_ipam:
 

--- a/Documentation/gettingstarted/ipvlan.rst
+++ b/Documentation/gettingstarted/ipvlan.rst
@@ -66,7 +66,7 @@ ipvlan is operated in L3S mode such that netfilter in host namespace
 is not bypassed. Optionally, the agent can also be set up for masquerading
 all traffic leaving the ipvlan master device if ``global.masquerade`` is set
 to ``"true"``. Note that in order for L3S mode to work correctly, a kernel
-with the following fix is required: `d5256083f62e <https://git.kernel.org/pub/scm/linux/kernel/git/davem/net.git/commit/?id=d5256083f62e2720f75bb3c5a928a0afe47d6bc3>`_ .
+with the following fix is required: `d5256083f62e <https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net.git/commit/?id=d5256083f62e2720f75bb3c5a928a0afe47d6bc3>`_ .
 This fix is included in stable kernels ``v4.9.155``, ``4.14.98``, ``4.19.20``,
 ``4.20.6`` or higher. Without this kernel fix, ipvlan in L3S mode cannot
 connect to kube-apiserver.

--- a/Documentation/gettingstarted/ipvlan.rst
+++ b/Documentation/gettingstarted/ipvlan.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _ipvlan:
 

--- a/Documentation/gettingstarted/istio.rst
+++ b/Documentation/gettingstarted/istio.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 ***************************
 Getting Started Using Istio

--- a/Documentation/gettingstarted/istio.rst
+++ b/Documentation/gettingstarted/istio.rst
@@ -68,7 +68,7 @@ Step 3: Deploy the Bookinfo Application V1
 
 Now that we have Cilium and Istio deployed, we can deploy version
 ``v1`` of the services of the `Istio Bookinfo sample application
-<https://istio.io/docs/examples/bookinfo.html>`_.
+<https://istio.io/docs/examples/bookinfo/>`_.
 
 While the upstream `Istio Bookinfo Application example for Kubernetes
 <https://istio.io/docs/examples/bookinfo/#if-you-are-running-on-kubernetes>`_

--- a/Documentation/gettingstarted/k3s.rst
+++ b/Documentation/gettingstarted/k3s.rst
@@ -10,8 +10,8 @@
 Getting Started Using K3s
 *************************
 
-This guide walks you through installation of Cilium on `K3s <http://k3s.io>`_, a
-highly available, certified Kubernetes distribution designed for production
+This guide walks you through installation of Cilium on `K3s <https://k3s.io/>`_,
+a highly available, certified Kubernetes distribution designed for production
 workloads in unattended, resource-constrained, remote locations or inside IoT
 appliances.
 

--- a/Documentation/gettingstarted/k3s.rst
+++ b/Documentation/gettingstarted/k3s.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _k3s_install:
 

--- a/Documentation/gettingstarted/k8s-install-aks.rst
+++ b/Documentation/gettingstarted/k8s-install-aks.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _k8s_install_aks:
 

--- a/Documentation/gettingstarted/k8s-install-azure.rst
+++ b/Documentation/gettingstarted/k8s-install-azure.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _k8s_azure:
 

--- a/Documentation/gettingstarted/k8s-install-default.rst
+++ b/Documentation/gettingstarted/k8s-install-default.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _k8s_quick_install:
 

--- a/Documentation/gettingstarted/k8s-install-download-release.rst
+++ b/Documentation/gettingstarted/k8s-install-download-release.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. note::
 

--- a/Documentation/gettingstarted/k8s-install-eks.rst
+++ b/Documentation/gettingstarted/k8s-install-eks.rst
@@ -22,7 +22,7 @@ Prerequisites
 -------------
 
 Ensure your AWS credentials are located in ``~/.aws/credentials`` or are stored
-as `environment variables <https://docs.aws.amazon.com/cli/latest/userguide/cli-environment.html>`_ .
+as `environment variables <https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html>`_ .
 
 Next, install `eksctl <https://github.com/weaveworks/eksctl>`_ :
 

--- a/Documentation/gettingstarted/k8s-install-eks.rst
+++ b/Documentation/gettingstarted/k8s-install-eks.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _k8s_install_eks:
 

--- a/Documentation/gettingstarted/k8s-install-eks.rst
+++ b/Documentation/gettingstarted/k8s-install-eks.rst
@@ -24,7 +24,7 @@ Prerequisites
 Ensure your AWS credentials are located in ``~/.aws/credentials`` or are stored
 as `environment variables <https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html>`_ .
 
-Next, install `eksctl <https://github.com/weaveworks/eksctl>`_ :
+Next, install `eksctl`_ :
 
 .. tabs::
   .. group-tab:: Linux
@@ -49,12 +49,13 @@ Ensure that aws-iam-authenticator is installed and in the executable path:
 If not, install it based on the `AWS IAM authenticator documentation
 <https://docs.aws.amazon.com/eks/latest/userguide/install-aws-iam-authenticator.html>`_ .
 
+.. _eksctl: https://github.com/weaveworks/eksctl
+
 Create the cluster
 ------------------
 
-Create an EKS cluster with ``eksctl`` see the `eksctl Documentation
-<https://github.com/weaveworks/eksctl>`_ for details on how to set credentials,
-change region, VPC, cluster size, etc.
+Create an EKS cluster with ``eksctl`` see the `eksctl Documentation`_ for
+details on how to set credentials, change region, VPC, cluster size, etc.
 
    .. code:: bash
 
@@ -68,6 +69,8 @@ You should see something like this:
 	[ℹ]  setting availability zones to [us-west-2b us-west-2a us-west-2c]
 	[...]
 	[✔]  EKS cluster "test-cluster" in "us-west-2" region is ready
+
+.. _eksctl Documentation: eksctl_
 
 Delete VPC CNI (``aws-node`` DaemonSet)
 =======================================

--- a/Documentation/gettingstarted/k8s-install-etcd-operator.rst
+++ b/Documentation/gettingstarted/k8s-install-etcd-operator.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _k8s_install_etcd_operator:
 

--- a/Documentation/gettingstarted/k8s-install-external-etcd.rst
+++ b/Documentation/gettingstarted/k8s-install-external-etcd.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _admin_install_daemonset:
 .. _k8s_install_etcd:

--- a/Documentation/gettingstarted/k8s-install-gke.rst
+++ b/Documentation/gettingstarted/k8s-install-gke.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _k8s_install_gke:
 

--- a/Documentation/gettingstarted/k8s-install-kops.rst
+++ b/Documentation/gettingstarted/k8s-install-kops.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _kops_guide:
 .. _k8s_install_kops:

--- a/Documentation/gettingstarted/k8s-install-kops.rst
+++ b/Documentation/gettingstarted/k8s-install-kops.rst
@@ -21,7 +21,7 @@ Prerequisites
 =============
 
 * `aws cli <https://aws.amazon.com/cli/>`_
-* `kubectl <https://kubernetes.io/docs/tasks/tools/install-kubectl>`_
+* `kubectl <https://kubernetes.io/docs/tasks/tools/install-kubectl/>`_
 * aws account with permissions:
   * AmazonEC2FullAccess
   * AmazonRoute53FullAccess

--- a/Documentation/gettingstarted/k8s-install-kubeadm.rst
+++ b/Documentation/gettingstarted/k8s-install-kubeadm.rst
@@ -8,4 +8,4 @@ Installation using kubeadm
 ==========================
 
 Instructions about installing Cilium on Kubernetes cluster deployed by kubeadm
-are available in the `official Kubernetes documentation <https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/#pod-network>`__.
+are available in the `official Kubernetes documentation <https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/#pod-network>`_.

--- a/Documentation/gettingstarted/k8s-install-kubeadm.rst
+++ b/Documentation/gettingstarted/k8s-install-kubeadm.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 Installation using kubeadm
 ==========================

--- a/Documentation/gettingstarted/k8s-install-kubespray.rst
+++ b/Documentation/gettingstarted/k8s-install-kubespray.rst
@@ -14,10 +14,11 @@ The guide is to use Kubespray for creating an AWS Kubernetes cluster running
 Cilium as the CNI. The guide uses:
 
   - Kubespray v2.6.0
-  - Latest `Cilium released version <https://github.com/cilium/cilium/releases>`__ (instructions for using the version are mentioned below)
+  - Latest `Cilium released version`_ (instructions for using the version are mentioned below)
 
 Please consult `Kubespray Prerequisites <https://github.com/kubernetes-sigs/kubespray#requirements>`__ and Cilium :ref:`admin_system_reqs`. 
 
+.. _Cilium released version: `latest released Cilium version`_
 
 Installing Kubespray
 ====================
@@ -140,13 +141,14 @@ Installing Kubernetes cluster with Cilium as CNI
 
 Kubespray uses Ansible as its substrate for provisioning and orchestration. Once the infrastructure is created, you can run the Ansible playbook to install Kubernetes and all the required dependencies. Execute the below command in the kubespray clone repo, providing the correct path of the AWS EC2 ssh private key in ``ansible_ssh_private_key_file=<path to EC2 SSH private key file>``
 
-We recommend using the `latest released Cilium version <https://github.com/cilium/cilium/releases>`__ by editing ``roles/download/defaults/main.yml``. Open the file, search for ``cilium_version``, and replace the version with the latest released. As an example, the updated version entry will look like: ``cilium_version: "v1.2.0"``.
+We recommend using the `latest released Cilium version`_ by editing ``roles/download/defaults/main.yml``. Open the file, search for ``cilium_version``, and replace the version with the latest released. As an example, the updated version entry will look like: ``cilium_version: "v1.2.0"``.
 
 
 .. code:: bash
 
   $ ansible-playbook -i ./inventory/hosts ./cluster.yml -e ansible_user=core -e bootstrap_os=coreos -e kube_network_plugin=cilium -b --become-user=root --flush-cache  -e ansible_ssh_private_key_file=<path to EC2 SSH private key file>
 
+.. _latest released Cilium version: https://github.com/cilium/cilium/releases
 
 Validate Cluster
 ================

--- a/Documentation/gettingstarted/k8s-install-kubespray.rst
+++ b/Documentation/gettingstarted/k8s-install-kubespray.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _k8s_install_kubespray:
 

--- a/Documentation/gettingstarted/k8s-install-kubespray.rst
+++ b/Documentation/gettingstarted/k8s-install-kubespray.rst
@@ -24,7 +24,7 @@ Installing Kubespray
 
 .. code:: bash
 
-  $ git clone --branch v2.6.0 https://github.com/kubernetes-incubator/kubespray 
+  $ git clone --branch v2.6.0 https://github.com/kubernetes-sigs/kubespray
 
 Install dependencies from ``requirements.txt``
 

--- a/Documentation/gettingstarted/k8s-install-managed.rst
+++ b/Documentation/gettingstarted/k8s-install-managed.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 ******************
 Managed Kubernetes

--- a/Documentation/gettingstarted/k8s-install-remove-aws-node.rst
+++ b/Documentation/gettingstarted/k8s-install-remove-aws-node.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 Cilium will manage ENIs instead of VPC CNI, so the ``aws-node`` DaemonSet
 has to be deleted to prevent conflict behavior.

--- a/Documentation/gettingstarted/k8s-install-sandbox.rst
+++ b/Documentation/gettingstarted/k8s-install-sandbox.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 Creating a Sandbox environment
 ==============================

--- a/Documentation/gettingstarted/k8s-install-self-managed.rst
+++ b/Documentation/gettingstarted/k8s-install-self-managed.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 Self-Managed Kubernetes
 =======================

--- a/Documentation/gettingstarted/k8s-installers.rst
+++ b/Documentation/gettingstarted/k8s-installers.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 **********************
 Installer Integrations

--- a/Documentation/gettingstarted/kafka.rst
+++ b/Documentation/gettingstarted/kafka.rst
@@ -23,7 +23,7 @@ Deploy the Demo Application
 Now that we have Cilium deployed and ``kube-dns`` operating correctly we can
 deploy our demo Kafka application.  Since our first demo of Cilium + HTTP-aware security
 policies was Star Wars-themed we decided to do the same for Kafka.  While the
-`HTTP-aware Cilium  Star Wars demo <https://www.cilium.io/blog/2017/5/4/demo-may-the-force-be-with-you>`_
+`HTTP-aware Cilium  Star Wars demo <https://cilium.io/blog/2017/5/4/demo-may-the-force-be-with-you/>`_
 showed how the Galactic Empire used HTTP-aware security policies to protect the Death Star from the
 Rebel Alliance, this Kafka demo shows how the lack of Kafka-aware security policies allowed the
 Rebels to steal the Death Star plans in the first place.
@@ -46,7 +46,7 @@ To keep the setup small, we will just launch a small number of pods to represent
   (label app=kafka).
 - *empire-hq* : A pod representing the Empire's Headquarters, which is the only pod that should
   produce messages to *empire-announce* or *deathstar-plans* (label app=empire-hq).
-- *empire-backup* : A secure backup facility located in `Scarif <http://starwars.wikia.com/wiki/Scarif_vault>`_ ,
+- *empire-backup* : A secure backup facility located in `Scarif <https://starwars.fandom.com/wiki/Scarif_vault>`_ ,
   which is allowed to "consume" from the secret *deathstar-plans* topic (label app=empire-backup).
 - *empire-outpost-8888* : A random outpost in the empire.  It needs to "consume" messages from
   the *empire-announce* topic (label app=empire-outpost).

--- a/Documentation/gettingstarted/kafka.rst
+++ b/Documentation/gettingstarted/kafka.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _gs_kafka:
 

--- a/Documentation/gettingstarted/kata-gce.rst
+++ b/Documentation/gettingstarted/kata-gce.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _kata-gce:
 

--- a/Documentation/gettingstarted/kube-router.rst
+++ b/Documentation/gettingstarted/kube-router.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _kube-router:
 

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -15,7 +15,7 @@ and to use Cilium to fully replace it. For simplicity, we will use ``kubeadm`` t
 bootstrap the cluster.
 
 For installing ``kubeadm`` and for more provisioning options please refer to
-`the official kubeadm documentation <https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm>`__.
+`the official kubeadm documentation <https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/>`_.
 
 .. note::
 

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _kubeproxy-free:
 

--- a/Documentation/gettingstarted/memcached.rst
+++ b/Documentation/gettingstarted/memcached.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 **********************************
 Getting Started Securing Memcached

--- a/Documentation/gettingstarted/memcached.rst
+++ b/Documentation/gettingstarted/memcached.rst
@@ -30,7 +30,7 @@ Step 2: Deploy the Demo Application
 
 Now that we have Cilium deployed and ``kube-dns`` operating correctly we can
 deploy our demo memcached application.  Since our first
-`HTTP-aware Cilium demo <https://www.cilium.io/blog/2017/5/4/demo-may-the-force-be-with-you>`_ was based on Star Wars, we continue with the theme for the memcached demo as well.
+`HTTP-aware Cilium demo <https://cilium.io/blog/2017/5/4/demo-may-the-force-be-with-you/>`_ was based on Star Wars, we continue with the theme for the memcached demo as well.
 
 Ever wonder how the Alliance Fleet manages the changing positions of their ships? The Alliance Fleet uses memcached to store the coordinates of their ships. The Alliance Fleet leverages the memcached-svc service implemented as a memcached server. Each ship in the fleet constantly updates its coordinates and has the ability to get the coordinates of other ships in the Alliance Fleet.
 

--- a/Documentation/gettingstarted/mesos.rst
+++ b/Documentation/gettingstarted/mesos.rst
@@ -75,7 +75,9 @@ When the script completes successfully, it will print:
 
 If the script exits with an error message, do not attempt to proceed with the
 tutorial, as later steps will not work properly.   Instead, contact us on the
-`Cilium Slack channel <https://cilium.herokuapp.com>`_.
+`Cilium Slack channel`_.
+
+.. _Cilium Slack channel: https://cilium.herokuapp.com
 
 Step 3: Accessing the VM
 ========================
@@ -354,4 +356,4 @@ Troubleshooting
 ===============
 
 For assistance on any of the Getting Started Guides, please reach out and ask a question on the `Cilium
-Slack channel <https://cilium.herokuapp.com>`_.
+Slack channel`_.

--- a/Documentation/gettingstarted/mesos.rst
+++ b/Documentation/gettingstarted/mesos.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _gsg_mesos:
 

--- a/Documentation/gettingstarted/microk8s.rst
+++ b/Documentation/gettingstarted/microk8s.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _gs_microk8s:
 

--- a/Documentation/gettingstarted/minikube.rst
+++ b/Documentation/gettingstarted/minikube.rst
@@ -10,7 +10,7 @@
 Getting Started Using Minikube
 ******************************
 
-This guide uses `minikube <https://kubernetes.io/docs/getting-started-guides/minikube/>`_
+This guide uses `minikube <https://kubernetes.io/docs/setup/learning-environment/minikube/>`_
 to demonstrate deployment and operation of Cilium in a single-node Kubernetes cluster.
 The minikube VM requires approximately 5GB of RAM and supports hypervisors like VirtualBox
 that run on Linux, macOS, and Windows.

--- a/Documentation/gettingstarted/minikube.rst
+++ b/Documentation/gettingstarted/minikube.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _gs_minikube:
 

--- a/Documentation/gettingstarted/tls-visibility.rst
+++ b/Documentation/gettingstarted/tls-visibility.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _gs_tls_inspection:
 

--- a/Documentation/glossary.rst
+++ b/Documentation/glossary.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _glossary:
 

--- a/Documentation/glossary.rst
+++ b/Documentation/glossary.rst
@@ -34,13 +34,13 @@ with words you expected to see here.
      https://www.kernel.org/pub/linux/utils/net/iproute2/
 
    llvm
-     http://releases.llvm.org/
+     https://releases.llvm.org/
 
    Linux kernel
      https://www.kernel.org/
 
    DaemonSet
-     https://kubernetes.io/docs/admin/daemons/
+     https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
 
    ConfigMap
      https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/
@@ -49,7 +49,7 @@ with words you expected to see here.
      https://github.com/containernetworking/cni
 
    RBAC
-     https://kubernetes.io/docs/admin/authorization/rbac/
+     https://kubernetes.io/docs/reference/access-authn-authz/rbac/
 
    NodeSelector
      https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
@@ -71,7 +71,7 @@ with words you expected to see here.
      https://kubernetes.io/docs/concepts/services-networking/service/
 
    CustomResourceDefinition
-     https://kubernetes.io/docs/concepts/api-extension/custom-resources/#customresourcedefinitions
+     https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#customresourcedefinitions
 
    HeadlessServices
      https://kubernetes.io/docs/concepts/services-networking/service/#headless-services

--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 Welcome to Cilium's documentation!
 ==================================

--- a/Documentation/install/system_requirements.rst
+++ b/Documentation/install/system_requirements.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _admin_system_reqs:
 

--- a/Documentation/install/upgrade-warning.rst
+++ b/Documentation/install/upgrade-warning.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. warning::
 

--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _admin_upgrade:
 

--- a/Documentation/intro.rst
+++ b/Documentation/intro.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _intro:
 

--- a/Documentation/istio/index.rst
+++ b/Documentation/istio/index.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 *****
 Istio

--- a/Documentation/kubernetes/ciliumendpoint.rst
+++ b/Documentation/kubernetes/ciliumendpoint.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 ************
 Endpoint CRD

--- a/Documentation/kubernetes/compatibility.rst
+++ b/Documentation/kubernetes/compatibility.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 :orphan:
 

--- a/Documentation/kubernetes/compatibility.rst
+++ b/Documentation/kubernetes/compatibility.rst
@@ -23,4 +23,4 @@ All Kubernetes versions listed are compatible with Cilium:
 | 1.12, 1.13, 1.14, 1.15, 1.16, 1.17, 1.18 | * `networking.k8s.io/v1`_ | `CustomResourceDefinition` |
 +------------------------------------------+---------------------------+----------------------------+
 
-.. _networking.k8s.io/v1: https://kubernetes.io/docs/api-reference/v1.8/#networkpolicy-v1-networking
+.. _networking.k8s.io/v1: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#networkpolicy-v1-networking-k8s-io

--- a/Documentation/kubernetes/concepts.rst
+++ b/Documentation/kubernetes/concepts.rst
@@ -70,7 +70,7 @@ Default Ingress Allow from Local Host
 =====================================
 
 Kubernetes has functionality to indicate to users the current health of their
-applications via `Liveness Probes and Readiness Probes <https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/>`_.
+applications via `Liveness Probes and Readiness Probes <https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/>`_.
 In order for ``kubelet`` to run these health checks for each pod, by default,
 Cilium will always allow all ingress traffic from the local host to each pod. 
  

--- a/Documentation/kubernetes/concepts.rst
+++ b/Documentation/kubernetes/concepts.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 ******************
 Concepts

--- a/Documentation/kubernetes/configuration.rst
+++ b/Documentation/kubernetes/configuration.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _k8s_configuration:
 
@@ -304,7 +304,7 @@ filesystems, the mount point path must be reflected in the unit filename.
         cat <<EOF | sudo tee /etc/systemd/system/sys-fs-bpf.mount
         [Unit]
         Description=Cilium BPF mounts
-        Documentation=http://docs.cilium.io/
+        Documentation=https://docs.cilium.io/
         DefaultDependencies=no
         Before=local-fs.target umount.target
         After=swap.target

--- a/Documentation/kubernetes/index.rst
+++ b/Documentation/kubernetes/index.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _kubernetes:
 

--- a/Documentation/kubernetes/intro.rst
+++ b/Documentation/kubernetes/intro.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _k8s_intro:
 

--- a/Documentation/kubernetes/intro.rst
+++ b/Documentation/kubernetes/intro.rst
@@ -64,7 +64,7 @@ and services addition and removal on the kube-master which allows it to to
 apply the necessary enforcement on iptables. Thus, the received and sent
 traffic from and to the pods are properly routed to the node and port serving
 for that service. For more information you can check out the kubernetes user
-guide for `Services  <http://kubernetes.io/docs/user-guide/services>`__.
+guide for `Services <https://kubernetes.io/docs/concepts/services-networking/service/>`_.
 
 When implementing ClusterIP, Cilium acts on the same principles as kube-proxy,
 it watches for services addition or removal, but instead of doing the
@@ -79,6 +79,6 @@ The Kubernetes documentation contains more background on the `Kubernetes
 Networking Model
 <https://kubernetes.io/docs/concepts/cluster-administration/networking/>`_ and
 `Kubernetes Network Plugins
-<https://kubernetes.io/docs/concepts/cluster-administration/network-plugins/>`_
+<https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/>`_
 .
 

--- a/Documentation/kubernetes/policy.rst
+++ b/Documentation/kubernetes/policy.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _k8s_policy:
 

--- a/Documentation/kubernetes/requirements.rst
+++ b/Documentation/kubernetes/requirements.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _k8s_requirements:
 

--- a/Documentation/kubernetes/troubleshooting.rst
+++ b/Documentation/kubernetes/troubleshooting.rst
@@ -59,5 +59,5 @@ Apiserver outside of cluster
 If you are running Kubernetes Apiserver outside of your cluster for some reason (like keeping master nodes behind a firewall), make sure that you run Cilium on master nodes too.
 Otherwise Kubernetes pod proxies created by Apiserver will not be able to route to pod IPs and you may encounter errors when trying to proxy traffic to pods.
 
-You may run Cilium as a `static pod <https://kubernetes.io/docs/tasks/administer-cluster/static-pod/>`_ or set `tolerations <https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/>`_ for Cilium DaemonSet to ensure
+You may run Cilium as a `static pod <https://kubernetes.io/docs/tasks/configure-pod-container/static-pod/>`_ or set `tolerations <https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/>`_ for Cilium DaemonSet to ensure
 that Cilium pods will be scheduled on your master nodes. The exact way to do it depends on your setup.

--- a/Documentation/kubernetes/troubleshooting.rst
+++ b/Documentation/kubernetes/troubleshooting.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _troubleshooting_k8s:
 

--- a/Documentation/mesos/index.rst
+++ b/Documentation/mesos/index.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _mesos:
 

--- a/Documentation/policy/index.rst
+++ b/Documentation/policy/index.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _network_policy:
 .. _Network Policies:

--- a/Documentation/policy/intro.rst
+++ b/Documentation/policy/intro.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _policy_guide:
 

--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _policy_examples:
 

--- a/Documentation/policy/lifecycle.rst
+++ b/Documentation/policy/lifecycle.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _endpoint_lifecycle:
 .. _Endpoint Lifecycle:

--- a/Documentation/policy/troubleshooting.rst
+++ b/Documentation/policy/troubleshooting.rst
@@ -21,7 +21,7 @@ verify if and what policy rules apply between two
 endpoints. We can use the ``cilium policy trace`` to simulate a policy decision 
 between the source and destination endpoints.
 
-We will use the example from the `Minikube Getting Started Guide <http://cilium.readthedocs.io/en/latest/gettingstarted/minikube/#getting-started-using-minikube>`_ to trace the policy. In this example, there is:
+We will use the example from the `Minikube Getting Started Guide <https://cilium.readthedocs.io/en/latest/gettingstarted/minikube/#getting-started-using-minikube>`_ to trace the policy. In this example, there is:
 
 * ``deathstar`` service identified by labels: ``org=empire, class=deathstar``. The service is backed by two pods.
 * ``tiefighter`` spaceship client pod with labels: ``org=empire, class=tiefighter``

--- a/Documentation/policy/troubleshooting.rst
+++ b/Documentation/policy/troubleshooting.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _policy_troubleshooting:
 

--- a/Documentation/policy/visibility.rst
+++ b/Documentation/policy/visibility.rst
@@ -2,7 +2,7 @@
   
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _proxy_visibility:
 

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -1,6 +1,7 @@
 Alemayhu
 Ansible
 Apiserver
+artii
 BPF
 Backport
 Backporting
@@ -300,6 +301,7 @@ hardcoded
 hardcoding
 hashtable
 hashtables
+herokuapp
 hexData
 hoc
 hostPort
@@ -533,7 +535,6 @@ supergalatic
 superset
 svc
 sw
-swapi
 sys
 syscall
 sysctl

--- a/Documentation/troubleshooting.rst
+++ b/Documentation/troubleshooting.rst
@@ -2,7 +2,7 @@
 
     WARNING: You are looking at unreleased Cilium documentation.
     Please use the official rendered version released here:
-    http://docs.cilium.io
+    https://docs.cilium.io
 
 .. _admin_guide:
 

--- a/Documentation/troubleshooting.rst
+++ b/Documentation/troubleshooting.rst
@@ -56,7 +56,7 @@ context of that pod:
 .. code:: bash
 
     $ kubectl -n kube-system exec -ti cilium-2hq5z -- cilium status
-    KVStore:                Ok   etcd: 1/1 connected: http://demo-etcd-lab--a.etcd.tgraf.test1.lab.corp.covalent.link:2379 - 3.2.5 (Leader)
+    KVStore:                Ok   etcd: 1/1 connected: http://demo-etcd-lab--a.etcd.tgraf.test1.lab.corp.isovalent.link:2379 - 3.2.5 (Leader)
     ContainerRuntime:       Ok   docker daemon: OK
     Kubernetes:             Ok   OK
     Kubernetes APIs:        ["cilium/v2::CiliumNetworkPolicy", "networking.k8s.io/v1::NetworkPolicy", "core/v1::Service", "core/v1::Endpoint", "core/v1::Node", "CustomResourceDefinition"]

--- a/Documentation/troubleshooting.rst
+++ b/Documentation/troubleshooting.rst
@@ -569,7 +569,7 @@ reproduce the issue.
 
 .. _Slack channel: https://cilium.herokuapp.com
 .. _NodeSelector: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
-.. _RBAC: https://kubernetes.io/docs/admin/authorization/rbac/
+.. _RBAC: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
 .. _CNI: https://github.com/containernetworking/cni
 .. _Volumes: https://kubernetes.io/docs/tasks/configure-pod-container/configure-volume-storage/
 

--- a/Documentation/troubleshooting.rst
+++ b/Documentation/troubleshooting.rst
@@ -562,10 +562,9 @@ visiting `Slack <https://cilium.herokuapp.com/>`_.
 Report an issue via GitHub
 --------------------------
 
-If you believe to have found an issue in Cilium, please report a `GitHub issue
-<https://github.com/cilium/cilium/issues>`_ and make sure to attach a system
-dump as described above to ensure that developers have the best chance to
-reproduce the issue.
+If you believe to have found an issue in Cilium, please report a
+`GitHub issue`_ and make sure to attach a system dump as described above to
+ensure that developers have the best chance to reproduce the issue.
 
 .. _Slack channel: https://cilium.herokuapp.com
 .. _NodeSelector: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
@@ -576,3 +575,4 @@ reproduce the issue.
 .. _Cilium Frequently Asked Questions (FAQ): https://github.com/cilium/cilium/issues?utf8=%E2%9C%93&q=label%3Akind%2Fquestion%20
 
 .. _issue tracker: https://github.com/cilium/cilium/issues
+.. _GitHub issue: `issue tracker`_

--- a/examples/kubernetes-tls-inspection/l7-visibility-tls.yaml
+++ b/examples/kubernetes-tls-inspection/l7-visibility-tls.yaml
@@ -10,7 +10,7 @@ spec:
       class: mediabot
   egress:
   - toFQDNs:
-    - matchName: "swapi.co"
+    - matchName: "artii.herokuapp.com"
     toPorts:
     - ports:
       - port: "443"
@@ -18,7 +18,7 @@ spec:
       terminatingTLS:
         secret:
           namespace: "kube-system"
-          name: "swapi-tls-data"
+          name: "artii-tls-data"
       originatingTLS:
         secret:
           namespace: "kube-system"

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -45,8 +45,8 @@ var _ = Describe("K8sPolicyTest", func() {
 		l7PolicyKafka        string
 		l7PolicyTLS          string
 		TLSCaCerts           string
-		TLSSWapiCrt          string
-		TLSSWapiKey          string
+		TLSArtiiCrt          string
+		TLSArtiiKey          string
 		TLSLyftCrt           string
 		TLSLyftKey           string
 		TLSCa                string
@@ -76,8 +76,8 @@ var _ = Describe("K8sPolicyTest", func() {
 		l7PolicyKafka = helpers.ManifestGet(kubectl.BasePath(), "l7-policy-kafka.yaml")
 		l7PolicyTLS = helpers.ManifestGet(kubectl.BasePath(), "l7-policy-TLS.yaml")
 		TLSCaCerts = helpers.ManifestGet(kubectl.BasePath(), "testCA.crt")
-		TLSSWapiCrt = helpers.ManifestGet(kubectl.BasePath(), "internal-swapi.crt")
-		TLSSWapiKey = helpers.ManifestGet(kubectl.BasePath(), "internal-swapi.key")
+		TLSArtiiCrt = helpers.ManifestGet(kubectl.BasePath(), "internal-artii.crt")
+		TLSArtiiKey = helpers.ManifestGet(kubectl.BasePath(), "internal-artii.key")
 		TLSLyftCrt = helpers.ManifestGet(kubectl.BasePath(), "internal-lyft.crt")
 		TLSLyftKey = helpers.ManifestGet(kubectl.BasePath(), "internal-lyft.key")
 		TLSCa = helpers.ManifestGet(kubectl.BasePath(), "ca.crt")
@@ -310,8 +310,8 @@ var _ = Describe("K8sPolicyTest", func() {
 			res = kubectl.CreateSecret("generic", "test-client", "default", "--from-file="+TLSCa)
 			res.ExpectSuccess("Cannot create secret %s", "test-client")
 
-			res = kubectl.CreateSecret("tls", "swapi-server", "default", "--cert="+TLSSWapiCrt+" --key="+TLSSWapiKey)
-			res.ExpectSuccess("Cannot create secret %s", "swapi-server")
+			res = kubectl.CreateSecret("tls", "artii-server", "default", "--cert="+TLSArtiiCrt+" --key="+TLSArtiiKey)
+			res.ExpectSuccess("Cannot create secret %s", "artii-server")
 
 			res = kubectl.CreateSecret("tls", "lyft-server", "default", "--cert="+TLSLyftCrt+" --key="+TLSLyftKey)
 			res.ExpectSuccess("Cannot create secret %s", "lyft-server")
@@ -325,14 +325,14 @@ var _ = Describe("K8sPolicyTest", func() {
 
 			res = kubectl.ExecPodCmd(
 				namespaceForTest, appPods[helpers.App2],
-				helpers.CurlFail("--retry 5 -4 --max-time 15 %s https://swapi.co:443/api/planets/1/", "-v --cacert /cacert.pem"))
-			res.ExpectSuccess("Cannot connect from %q to 'https://swapi.co:443/api/planets/1/'",
+				helpers.CurlFail("--retry 5 -4 --max-time 15 %s 'https://artii.herokuapp.com/make?text=cilium&font=univers'", "-v --cacert /cacert.pem"))
+			res.ExpectSuccess("Cannot connect from %q to 'https://artii.herokuapp.com/make?text=cilium&font=univers'",
 				appPods[helpers.App2])
 
 			res = kubectl.ExecPodCmd(
 				namespaceForTest, appPods[helpers.App2],
-				helpers.CurlFail("--retry 5 -4 %s https://swapi.co:443/api/planets/2/", "-v --cacert /cacert.pem"))
-			res.ExpectFailWithError("403 Forbidden", "Unexpected connection from %q to 'https://swapi.co:443/api/planets/2/'",
+				helpers.CurlFail("--retry 5 -4 %s 'https://artii.herokuapp.com:443/fonts_list'", "-v --cacert /cacert.pem"))
+			res.ExpectFailWithError("403 Forbidden", "Unexpected connection from %q to 'https://artii.herokuapp.com:443/fonts_list'",
 				appPods[helpers.App2])
 
 			res = kubectl.ExecPodCmd(

--- a/test/k8sT/manifests/l7-policy-TLS.yaml
+++ b/test/k8sT/manifests/l7-policy-TLS.yaml
@@ -16,7 +16,7 @@ spec:
         dns:
           - matchPattern: "*"
   - toFQDNs:
-    - matchPattern: "swapi.co"
+    - matchPattern: "artii.herokuapp.com"
     toPorts:
     - ports:
       - port: "443"
@@ -24,7 +24,7 @@ spec:
       terminatingTLS:
         secret:
           namespace: "default"
-          name: "swapi-server"
+          name: "artii-server"
       originatingTLS:
         secret:
           namespace: "default"
@@ -32,7 +32,7 @@ spec:
       rules:
         http:
         - method: "GET"
-          path: "/api/planets/1/"
+          path: "^/make(\?.*)?$"
           headerMatches:
           - mismatch: REPLACE
             name: "User-Agent"


### PR DESCRIPTION
This is a fix for hyperlinks under `Documentation/`, and for other (mostly) related issue. I ran [a tool](https://github.com/dkhamsing/awesome_bot) to check links on documentation, and found a number of dead link. This tool also reported links pointing to redirections, or duplicate links in source files. Let's try to fix all of this:

- Fix broken links (404)
- Fix links pointing to wrong targets
- Use final destination for (most) links pointing to redirections (two commits, one is just for `docs.cilium.io` in file headers)
- Avoid duplicated links as much as possible, use names hyperlinks instead
- While at it, replace references to “covalent” in links, let's avoid any confusion for the readers

The STAR WARS API used in the documentation, tests and examples for TLS visibility has been taken down. Let's replace it with something else (https://artii.herokuapp.com), cc  @danwent.

Additional miscellaneous fixes:

- Fix a typo in CI doc (`ct/next-next`, sounds funny but is unused)
- Fix retrieval of current release number in Python script, due to break some day otherwise
- Add `test-me-please` to the list of keywords triggering GKE tests in CI
- Move URL and update name for `Cilium-Nightly-Tests Job`, fix link for Flannel job, in CI doc. **Please double check this commit, I am not 100% sure the change is correct.**

After this PR, I still observe **broken links for bisects on Jenkins** (CI doc). I am unsure if the links are broken or if I simply lack permission to access them, can someone please check and let me know?