### PR TITLE
vagrant: Only set K8S_NODE_NAME if K8S=1

### DIFF
--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -338,7 +338,9 @@ function write_cilium_cfg() {
 
 cat <<EOF >> "$filename"
 sleep 2s
-echo "K8S_NODE_NAME=\$(hostname)" >> /etc/sysconfig/cilium
+if [ -n "\${K8S}" ]; then
+    echo "K8S_NODE_NAME=\$(hostname)" >> /etc/sysconfig/cilium
+fi
 echo 'CILIUM_OPTS="${cilium_options}"' >> /etc/sysconfig/cilium
 echo 'CILIUM_OPERATOR_OPTS="${cilium_operator_options}"' >> /etc/sysconfig/cilium
 echo 'PATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin' >> /etc/sysconfig/cilium


### PR DESCRIPTION
This allows Cilium to start without K8s in the Dev VM started with './contrib/vagrant/start.sh'.

Fixes: #11021
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
