### PR TITLE
helm: Update hubble related configuration

### DIFF
--- a/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
@@ -121,11 +121,6 @@ spec:
               key: custom-cni-conf
               name: cilium-config
               optional: true
-{{- if .Values.global.hubble.enabled }}
-        # Default Hubble gRPC endpoint for observe/status commands.
-        - name: HUBBLE_DEFAULT_SOCKET_PATH
-          value: unix://{{ .Values.global.hubble.socketPath }}
-{{- end }}
 {{- if .Values.global.k8sServiceHost }}
         - name: KUBERNETES_SERVICE_HOST
           value: {{ .Values.global.k8sServiceHost | quote }}

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -368,26 +368,27 @@ data:
 {{- else }}
   operator-api-serve-addr: '[::1]:9234'
 {{- end }}
-{{ if .Values.global.hubble.enabled }}
-  enable-hubble: "true"
+
+  # Enable Hubble gRPC service.
+  enable-hubble: {{ .Values.global.hubble.enabled  | quote }}
+{{- if .Values.global.hubble.enabled }}
   # UNIX domain socket for Hubble server to listen to.
   hubble-socket-path:  {{ .Values.global.hubble.socketPath | quote }}
   # A space separated list of additional addresses for Hubble server to listen to.
   hubble-listen-addresses: {{ .Values.global.hubble.listenAddresses | join " " | quote }}
-{{ if .Values.global.hubble.eventQueueSize }}
+{{- if .Values.global.hubble.eventQueueSize }}
   # Buffer size of the channel for Hubble to receive monitor events. If this field is not set,
   # the buffer size is set to the default monitor queue size.
   hubble-event-queue-size: {{ .Values.global.hubble.eventQueueSize | quote }}
 {{- end }}
-{{ if .Values.global.hubble.flowBufferSize }}
+{{- if .Values.global.hubble.flowBufferSize }}
   # Size of the buffer to store recent flows.
   hubble-flow-buffer-size: {{ .Values.global.hubble.flowBufferSize | quote }}
 {{- end }}
-{{ if .Values.global.hubble.metricsServer }}
+{{- if .Values.global.hubble.metricsServer }}
   # Address to expose Hubble metrics (e.g. ":7070"). Metrics server will be disabled if this
   # field is not set.
   hubble-metrics-server: {{ .Values.global.hubble.metricsServer | quote }}
-
   # A space separated list of metrics to enable. See [0] for available metrics.
   #
   # https://github.com/cilium/hubble/blob/master/Documentation/metrics.md

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -163,6 +163,8 @@ data:
   policy-audit-mode: "false"
   operator-api-serve-addr: '127.0.0.1:9234'
 
+  # Enable Hubble gRPC service.
+  enable-hubble: "false"
 
   # A space separated list of iptables chains to disable when installing feeder rules.
   disable-iptables-feeder-rules: ""


### PR DESCRIPTION
- Remove HUBBLE_DEFAULT_SOCKET_PATH environment variable from Cilium
  daemontset. The observe command has been removed from the CLI, so
  this variable is no longer used.
- Include `enable-hubble` field in the configmap regardless of whether
  it's enabled so that the configuration parameter is more visible.
- Fix spacing so that the hubble section in the configmap shows up
  as one block.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>