### PR TITLE
hostport: Add an option host-port-only-local

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -86,6 +86,7 @@ cilium-agent [flags]
       --flannel-uninstall-on-exit                     When used along the flannel-master-device flag, it cleans up all BPF programs installed when Cilium agent is terminated.
       --force-local-policy-eval-at-source             Force policy evaluation of all local communication at the source endpoint (default true)
   -h, --help                                          help for cilium-agent
+      --host-port-only-local                          Only generate hostPort mapping on local node (requires enabling enable-host-port)
       --host-reachable-services-protos strings        Only enable reachability of services for host applications for specific protocols (default [tcp,udp])
       --http-idle-timeout uint                        Time after which a non-gRPC HTTP stream is considered failed unless traffic in the stream has been processed (in seconds); defaults to 0 (unlimited)
       --http-max-grpc-timeout uint                    Time after which a forwarded gRPC request is considered failed unless completed (in seconds). A "grpc-timeout" header may override this with a shorter value; defaults to 0 (unlimited)

--- a/api/v1/models/kube_proxy_replacement.go
+++ b/api/v1/models/kube_proxy_replacement.go
@@ -304,6 +304,9 @@ type KubeProxyReplacementFeaturesHostPort struct {
 
 	// enabled
 	Enabled bool `json:"enabled,omitempty"`
+
+	// local
+	Local bool `json:"local,omitempty"`
 }
 
 // Validate validates this kube proxy replacement features host port

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -1701,6 +1701,8 @@ definitions:
             properties:
               enabled:
                 type: boolean
+              local:
+                type: boolean
           externalIPs:
             type: object
             properties:

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -2513,6 +2513,9 @@ func init() {
               "properties": {
                 "enabled": {
                   "type": "boolean"
+                },
+                "local": {
+                  "type": "boolean"
                 }
               }
             },
@@ -6061,6 +6064,9 @@ func init() {
               "type": "object",
               "properties": {
                 "enabled": {
+                  "type": "boolean"
+                },
+                "local": {
                   "type": "boolean"
                 }
               }

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -490,6 +490,9 @@ func init() {
 	flags.Bool(option.EnableHostPort, true, fmt.Sprintf("Enable k8s hostPort mapping feature (requires enabling %s)", option.EnableNodePort))
 	option.BindEnv(option.EnableHostPort)
 
+	flags.Bool(option.HostPortOnlyLocal, false, fmt.Sprintf("Only generate hostPort mapping on local node (requires enabling %s)", option.EnableHostPort))
+	option.BindEnv(option.HostPortOnlyLocal)
+
 	flags.Bool(option.EnableNodePort, false, "Enable NodePort type services by Cilium (beta)")
 	option.BindEnv(option.EnableNodePort)
 

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -144,6 +144,9 @@ func (d *Daemon) getKubeProxyReplacementStatus() *models.KubeProxyReplacement {
 	}
 	if option.Config.EnableHostPort {
 		features.HostPort.Enabled = true
+		if option.Config.HostPortOnlyLocal {
+			features.HostPort.Local = true
+		}
 	}
 	if option.Config.EnableExternalIPs {
 		features.ExternalIPs.Enabled = true

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -303,6 +303,7 @@ data:
 {{- end }}
 {{- if .Values.global.hostPort }}
   enable-host-port: {{ .Values.global.hostPort.enabled | quote }}
+  host-port-only-local: {{ .Values.global.hostPort.onlyLocal | quote }}
 {{- end }}
 {{- if .Values.global.externalIPs }}
   enable-external-ips: {{ .Values.global.externalIPs.enabled | quote }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -294,6 +294,9 @@ global:
     # enabled enables the hostPort functionality
     enabled: false
 
+    # onlyLocal indicates to generate service mapping only for local node
+    onlyLocal: false
+
   # externalIPs is the configuration for ExternalIPs service handling
   externalIPs:
     # enabled enables ExternalIPs functionality

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -274,7 +274,11 @@ func FormatStatusResponse(w io.Writer, sr *models.StatusResponse, allAddresses, 
 			}
 
 			if sr.KubeProxyReplacement.Features.HostPort.Enabled {
-				features = append(features, "HostPort")
+				if sr.KubeProxyReplacement.Features.HostPort.Local {
+					features = append(features, "HostPort (only local)")
+				} else {
+					features = append(features, "HostPort")
+				}
 			}
 
 			if sr.KubeProxyReplacement.Features.ExternalIPs.Enabled {

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -245,6 +245,9 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		}
 		if option.Config.EnableHostPort {
 			cDefinesMap["ENABLE_HOSTPORT"] = "1"
+			if option.Config.HostPortOnlyLocal {
+				cDefinesMap["HOSTPORT_ONLY_LOCAL"] = "1"
+			}
 		}
 
 		cDefinesMap["NODEPORT_PORT_MIN"] = fmt.Sprintf("%d", option.Config.NodePortMin)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -282,6 +282,9 @@ const (
 	// EnableHostPort enables HostPort forwarding implemented by Cilium in BPF
 	EnableHostPort = "enable-host-port"
 
+	// HostPortOnlyLocal only generates HostPort mapping on local node
+	HostPortOnlyLocal = "host-port-only-local"
+
 	// EnableNodePort enables NodePort services implemented by Cilium in BPF
 	EnableNodePort = "enable-node-port"
 
@@ -1712,6 +1715,9 @@ type DaemonConfig struct {
 	// EnableHostPort enables k8s Pod's hostPort mapping through BPF
 	EnableHostPort bool
 
+	// HostPortOnlyLocal only generates hostport mapping on local node
+	HostPortOnlyLocal bool
+
 	// NodePortMode indicates in which mode NodePort implementation should run
 	// ("snat", "dsr" or "hybrid")
 	NodePortMode string
@@ -2321,8 +2327,9 @@ func (c *DaemonConfig) Populate() {
 	c.EnableExternalIPs = viper.GetBool(EnableExternalIPs)
 	c.EnableL7Proxy = viper.GetBool(EnableL7Proxy)
 	c.EnableTracing = viper.GetBool(EnableTracing)
-	c.EnableNodePort = viper.GetBool(EnableNodePort)
 	c.EnableHostPort = viper.GetBool(EnableHostPort)
+	c.HostPortOnlyLocal = viper.GetBool(HostPortOnlyLocal)
+	c.EnableNodePort = viper.GetBool(EnableNodePort)
 	c.NodePortMode = viper.GetString(NodePortMode)
 	c.NodePortAcceleration = viper.GetString(NodePortAcceleration)
 	c.EnableAutoProtectNodePortRange = viper.GetBool(EnableAutoProtectNodePortRange)


### PR DESCRIPTION
Enable option host-port-only-local expects same behavior as kube-proxy, that is
almost same with the iptable rule 'ADDRTYPE match dst-type LOCAL'. And means not
do the destination pod ip translation locally.

Yes, the present implementation has better performance for pod to pod traffics
inside cluster, but in some special cases we still need this option to keep same
behavior with kube-proxy, and if all the traffics come from outside, we do not
need thousands of service mapping entries on each nodes.

Fixes: 7fcf660ba6ed ("cilium, bpf: add native HostPort mapping support")

Example:
--host-port-only-local=false (by default, no changes)
8    10.44.76.162:9000    HostPort       1 => 172.30.0.74:8000
9    10.44.75.162:9000    HostPort       1 => 172.30.2.178:8000
10   10.44.74.162:9000    HostPort       1 => 172.30.3.29:8000
11   10.44.76.150:9000    HostPort       1 => 172.30.1.34:8000

--host-port-only-local=true
8    10.44.76.162:9000    HostPort       1 => 172.30.0.74:8000

Signed-off-by: yangxingwu <yangxingwu@kuaishou.com>
Signed-off-by: huangxuesen <huangxuesen@kuaishou.com>
Signed-off-by: Wang Li <wangli09@kuaishou.com>
