### PR TITLE
policy/api: add ability to select reserved:health entity from CCNP and / or CNP

### DIFF
--- a/pkg/policy/api/entity.go
+++ b/pkg/policy/api/entity.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 Authors of Cilium
+// Copyright 2016-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -45,6 +45,9 @@ const (
 	// EntityRemoteNode is an entity that represents all remote nodes
 	EntityRemoteNode Entity = "remote-node"
 
+	// EntityHealth is an entity that represents all health endpoints.
+	EntityHealth Entity = "health"
+
 	// EntityNone is an entity that can be selected but never exist
 	EntityNone Entity = "none"
 )
@@ -58,6 +61,8 @@ var (
 
 	endpointSelectorRemoteNode = NewESFromLabels(labels.NewLabel(labels.IDNameRemoteNode, "", labels.LabelSourceReserved))
 
+	endpointSelectorHealth = NewESFromLabels(labels.NewLabel(labels.IDNameHealth, "", labels.LabelSourceReserved))
+
 	EndpointSelectorNone = NewESFromLabels(labels.NewLabel(labels.IDNameNone, "", labels.LabelSourceReserved))
 
 	endpointSelectorUnmanaged = NewESFromLabels(labels.NewLabel(labels.IDNameUnmanaged, "", labels.LabelSourceReserved))
@@ -70,6 +75,7 @@ var (
 		EntityHost:       {endpointSelectorHost},
 		EntityInit:       {endpointSelectorInit},
 		EntityRemoteNode: {endpointSelectorRemoteNode},
+		EntityHealth:     {endpointSelectorHealth},
 		EntityNone:       {EndpointSelectorNone},
 
 		// EntityCluster is populated with an empty entry to allow the


### PR DESCRIPTION
With the introduction of CiliumClusterwideNetworkPolicies a policy has
the ability to select the 'reserved:health' endpoints. If a user applies
a policy such as [0], it will block all connectivity for the health
endpoints. As this does not seem expected, since Cilium will report that
the connectivity across Cilium pods is not working, the user will need to
deploy a CCNP that allows connectivity between health endpoints. This
can be done with [1].

This commit introduces 'reserved:health' as an entity that can be
selected by CNP and / or CCNP.

[0]
```
---
apiVersion: cilium.io/v2
kind: CiliumClusterwideNetworkPolicy
metadata:
  name: ingress-deny-all
spec:
  endpointSelector:
    matchLabels: {}
  ingress:
  - {}
---
apiVersion: cilium.io/v2
kind: CiliumClusterwideNetworkPolicy
metadata:
  name: egress-deny-all
spec:
  endpointSelector:
    matchLabels: {}
  egress:
  - {}
```

[1]
```
apiVersion: "cilium.io/v2"
kind: CiliumClusterwideNetworkPolicy
metadata:
  name: "allow-reserved-health"
spec:
  endpointSelector:
    matchLabels:
      'reserved:health': ""
  ingress:
    - fromEntities:
      - health
```

Signed-off-by: André Martins <andre@cilium.io>