### PR TITLE
CI: GKE build only prunes docker images older than 6h

### DIFF
--- a/test/clean-local-registry-tag.sh
+++ b/test/clean-local-registry-tag.sh
@@ -21,4 +21,4 @@ docker push $1/cilium/cilium:$2
 docker push $1/cilium/cilium-dev:$2
 docker push $1/cilium/operator:$2
 
-docker system prune -f
+docker system prune -f --filter "until=6h"


### PR DESCRIPTION
We're seeing missing images in some GKE failures. This is probably
because we introduced a prune in each GKE run and this clobber
intermediate images in other builds. By limiting the prune to older
images we allow for other builds to complete. This may still not work
in cases were a common image changes rarely.

fixes b4c1fb5172dee6b4a27f2b1b6f6ae73aa930552b
