### PR TITLE
daemon: set k8s options as soon as possible

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -394,9 +394,6 @@ func NewDaemon(ctx context.Context, dp datapath.Datapath) (*Daemon, *endpointRes
 	debug.RegisterStatusObject("k8s-service-cache", &d.k8sWatcher.K8sSvcCache)
 	debug.RegisterStatusObject("ipam", d.ipam)
 
-	bootstrapStats.k8sInit.Start()
-	k8s.Configure(option.Config.K8sAPIServer, option.Config.K8sKubeConfigPath, defaults.K8sClientQPSLimit, defaults.K8sClientBurst)
-	bootstrapStats.k8sInit.End(true)
 	d.k8sWatcher.RunK8sServiceHandler()
 	treatRemoteNodeAsHost := option.Config.AlwaysAllowLocalhost() && !option.Config.EnableRemoteNodeIdentity
 	policyApi.InitEntities(option.Config.ClusterName, treatRemoteNodeAsHost)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -802,6 +802,12 @@ func initEnv(cmd *cobra.Command) {
 
 	option.LogRegisteredOptions(log)
 
+	// Configure k8s as soon as possible so that k8s.IsEnabled() has the right
+	// behavior.
+	bootstrapStats.k8sInit.Start()
+	k8s.Configure(option.Config.K8sAPIServer, option.Config.K8sKubeConfigPath, defaults.K8sClientQPSLimit, defaults.K8sClientBurst)
+	bootstrapStats.k8sInit.End(true)
+
 	for _, grp := range option.Config.DebugVerbose {
 		switch grp {
 		case argDebugVerboseFlow:


### PR DESCRIPTION
Configure k8s as soon as possible so that k8s.IsEnabled() has the right
behavior from the start of the Cilium agent initialization.

Fixes: 604dab4a4440 ("pkg/k8s: detect k8s mode if env variable K8S_NODE_NAME is set")
Signed-off-by: André Martins <andre@cilium.io>

Fixes https://github.com/cilium/cilium/issues/11097