### PR TITLE
ci: Gather commands from local node

### DIFF
--- a/test/helpers/local_node.go
+++ b/test/helpers/local_node.go
@@ -168,6 +168,7 @@ func (s *LocalExecutor) ExecContext(ctx context.Context, cmd string, options ...
 	}
 
 	log.Debugf("running command: %s", cmd)
+	fmt.Fprintln(SSHMetaLogs, cmd)
 	stdout := new(Buffer)
 	stderr := new(Buffer)
 	start := time.Now()


### PR DESCRIPTION
While implementing `LocalExecutor` I failed to send executed commands
into a log file.

This change reuses the same buffer as `SSHMeta` for `LocalExecutor`,
so all commands are logged in the same
log file as if they would be while being executed by `SSHMeta`.