### PR TITLE
test: Run GKE tests with NodePort in SNAT mode

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -123,6 +123,7 @@ var (
 		"nodeinit.reconfigureKubelet": "true",
 		"nodeinit.removeCbrBridge":    "true",
 		"global.cni.binPath":          "/home/kubernetes/bin",
+		"global.nodePort.mode":        "snat",
 	}
 
 	microk8sHelmOverrides = map[string]string{


### PR DESCRIPTION
As we bump the CI to GKE v1.15, it will bring kernel 4.19 which will automatically enable BPF DSR. Unfortunately, DSR packets are dropped by the fabric right now. Disable DSR in the overrides to make sure we are not hit by accident.