### PR TITLE
test/helpers: add Unable to restore endpoint as bad log msgs

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -218,6 +218,7 @@ const (
 	symbolSubstitution = "Skipping symbol substitution"               //
 	uninitializedRegen = "Uninitialized regeneration level"           // from https://github.com/cilium/cilium/pull/10949
 	unstableStat       = "BUG: stat() has unstable behavior"          // from https://github.com/cilium/cilium/pull/11028
+	unableToRestoreEP  = "Unable to restore endpoint, ignoring"       // from https://github.com/cilium/cilium/pull/11028
 
 	// HelmTemplate is the location of the Helm templates to install Cilium
 	HelmTemplate = "../install/kubernetes/cilium"
@@ -278,6 +279,7 @@ var badLogMessages = map[string][]string{
 	symbolSubstitution: nil,
 	uninitializedRegen: nil,
 	unstableStat:       nil,
+	unableToRestoreEP:  nil,
 }
 
 var ciliumCLICommands = map[string]string{


### PR DESCRIPTION
If Cilium was unable to restore an endpoint we should find out why and
not let the CI pass as this might hide underlying issues.

Signed-off-by: André Martins <andre@cilium.io>