### PR TITLE
hubble: Enable grpc reflection

### DIFF
--- a/pkg/hubble/server/server.go
+++ b/pkg/hubble/server/server.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/reflection"
 )
 
 // Server is hubble's gRPC server.
@@ -57,6 +58,7 @@ func (s *Server) initGRPCServer() {
 		peerpb.RegisterPeerServer(srv, *s.opts.PeerService)
 	}
 	s.srv = srv
+	reflection.Register(s.srv)
 }
 
 // Serve starts the hubble server. It accepts new connections on configured


### PR DESCRIPTION
This is useful for discovering the API without the .proto files

    % grpcurl --plaintext localhost:55555 describe .observer.GetFlowsRequest
    observer.GetFlowsRequest is a message:
    message GetFlowsRequest {
      uint64 number = 1;
      bool follow = 3;
      repeated .flow.FlowFilter blacklist = 5;
      repeated .flow.FlowFilter whitelist = 6;
      .google.protobuf.Timestamp since = 7;
      .google.protobuf.Timestamp until = 8;
    }

Ref: https://github.com/grpc/grpc-go/blob/master/Documentation/server-reflection-tutorial.md

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>