### PR TITLE
CI: Test with net-next and kube-proxy

### DIFF
--- a/jenkinsfiles/ginkgo.Jenkinsfile
+++ b/jenkinsfiles/ginkgo.Jenkinsfile
@@ -151,7 +151,7 @@ pipeline {
                         K8S_VERSION="1.11"
                         K8S_NODES="3"
                         NO_CILIUM_ON_NODE="k8s3"
-                        KUBEPROXY="0"
+                        KUBEPROXY="1"
                         KUBECONFIG="vagrant-kubeconfig"
                     }
                     steps {
@@ -250,7 +250,7 @@ pipeline {
                         KUBECONFIG="${TESTDIR}/vagrant-kubeconfig"
                         K8S_VERSION="1.11"
                         K8S_NODES="3"
-                        KUBEPROXY="0"
+                        KUBEPROXY="1"
                         NO_CILIUM_ON_NODE="k8s3"
                     }
                     steps {

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -903,7 +903,10 @@ var _ = Describe("K8sServicesTest", func() {
 			})
 
 		SkipContextIf(
-			helpers.DoesNotRunOnNetNextOr419Kernel,
+			func() bool {
+				return helpers.DoesNotRunOnNetNextOr419Kernel() ||
+					!helpers.RunsWithoutKubeProxy()
+			},
 			"Tests NodePort BPF", func() {
 				// TODO(brb) Add with L7 policy test cases after GH#8971 has been fixed
 

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -968,7 +968,7 @@ var _ = Describe("K8sServicesTest", func() {
 						testHostPort()
 					})
 
-					It("Tests GH#10983", func() {
+					SkipItIf(helpers.DoesNotExistNodeWithoutCilium, "Tests GH#10983", func() {
 						var data v1.Service
 						_, k8s2IP := kubectl.GetNodeInfo(helpers.K8s2)
 


### PR DESCRIPTION
Testing this particular setup as I found a couple flakes locally when doing so (e.g., fragment tracking test).