### PR TITLE
move bpf nodeport from hybrid to snat by default

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -144,7 +144,7 @@ cilium-agent [flags]
       --mtu int                                       Overwrite auto-detected MTU of underlying network
       --nat46-range string                            IPv6 prefix to map IPv4 addresses to (default "0:0:0:0:0:FFFF::/96")
       --node-port-acceleration string                 BPF NodePort acceleration via XDP ("native", "none") (default "none")
-      --node-port-mode string                         BPF NodePort mode ("snat", "dsr", "hybrid") (default "hybrid")
+      --node-port-mode string                         BPF NodePort mode ("snat", "dsr", "hybrid") (default "snat")
       --node-port-range strings                       Set the min/max NodePort port range (default [30000,32767])
       --policy-audit-mode                             Enable policy audit (non-drop) mode
       --policy-queue-size int                         size of queues for policy-related events (default 100)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -493,7 +493,7 @@ func init() {
 	flags.Bool(option.EnableNodePort, false, "Enable NodePort type services by Cilium (beta)")
 	option.BindEnv(option.EnableNodePort)
 
-	flags.String(option.NodePortMode, option.NodePortModeHybrid, "BPF NodePort mode (\"snat\", \"dsr\", \"hybrid\")")
+	flags.String(option.NodePortMode, option.NodePortModeSNAT, "BPF NodePort mode (\"snat\", \"dsr\", \"hybrid\")")
 	option.BindEnv(option.NodePortMode)
 
 	flags.Bool(option.EnableAutoProtectNodePortRange, true,

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -296,19 +296,27 @@ data:
   kube-proxy-replacement:  {{ .Values.global.kubeProxyReplacement | quote }}
 {{- end}}
 {{- if .Values.global.hostServices }}
+{{- if .Values.global.hostServices.enabled }}
   enable-host-reachable-services: {{ .Values.global.hostServices.enabled | quote }}
+{{- end }}
 {{- if ne .Values.global.hostServices.protocols "tcp,udp" }}
   host-reachable-services-protos: {{ .Values.global.hostServices.protocols }}
 {{- end }}
 {{- end }}
 {{- if .Values.global.hostPort }}
+{{- if eq .Values.global.kubeProxyReplacement "partial" }}
   enable-host-port: {{ .Values.global.hostPort.enabled | quote }}
 {{- end }}
+{{- end }}
 {{- if .Values.global.externalIPs }}
+{{- if eq .Values.global.kubeProxyReplacement "partial" }}
   enable-external-ips: {{ .Values.global.externalIPs.enabled | quote }}
 {{- end }}
+{{- end }}
 {{- if .Values.global.nodePort }}
+{{- if eq .Values.global.kubeProxyReplacement "partial" }}
   enable-node-port: {{ .Values.global.nodePort.enabled | quote }}
+{{- end }}
 {{- if .Values.global.nodePort.range }}
   node-port-range: {{ .Values.global.nodePort.range | quote }}
 {{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -280,10 +280,10 @@ global:
     # device:
 
     # mode is the mode of NodePort feature
-    mode: "hybrid"
+    # mode:
 
     # acceleration is the option to accelerate NodePort via XDP
-    acceleration: "none"
+    # acceleration:
 
     # Append NodePort range to ip_local_reserved_ports if clash with ephemeral
     # ports is detected

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -147,12 +147,6 @@ data:
   install-iptables-rules: "true"
   auto-direct-node-routes: "false"
   kube-proxy-replacement:  "probe"
-  enable-host-reachable-services: "false"
-  enable-host-port: "false"
-  enable-external-ips: "false"
-  enable-node-port: "false"
-  node-port-mode: "hybrid"
-  node-port-acceleration: "none"
   enable-auto-protect-node-port-range: "true"
   # Chaining mode is set to portmap, enable health checking
   enable-endpoint-health-checking: "true"


### PR DESCRIPTION
See commit msg. Given hybrid was not released yet (target for 1.8), move the default back to snat.