### PR TITLE
docs: Pin Hubble version to v0.5 branch

### DIFF
--- a/Documentation/gettingstarted/getting-started-next-steps.rst
+++ b/Documentation/gettingstarted/getting-started-next-steps.rst
@@ -2,6 +2,6 @@ Next Steps
 ==========
 
 
-* `Enable DNS Visibility <https://github.com/cilium/hubble/blob/master/Documentation/dns_visibility.md>`_.
-* `Enable HTTP/L7 Visibility <https://github.com/cilium/hubble/blob/master/Documentation/http_visibility.md>`_.
-* `Visit Hubble Tutorials <https://github.com/cilium/hubble/blob/master/tutorials/README.md>`_.
+* `Enable DNS Visibility <https://github.com/cilium/hubble/blob/v0.5/Documentation/dns_visibility.md>`_.
+* `Enable HTTP/L7 Visibility <https://github.com/cilium/hubble/blob/v0.5/Documentation/http_visibility.md>`_.
+* `Visit Hubble Tutorials <https://github.com/cilium/hubble/blob/v0.5/tutorials/README.md>`_.

--- a/Documentation/gettingstarted/hubble-install.rst
+++ b/Documentation/gettingstarted/hubble-install.rst
@@ -10,7 +10,7 @@ Deploy Hubble using Helm:
 
 .. code:: bash
 
-    git clone https://github.com/cilium/hubble.git
+    git clone https://github.com/cilium/hubble.git --branch v0.5
     cd hubble/install/kubernetes
 
     helm install hubble ./hubble \


### PR DESCRIPTION
Hubble is undergoing some big architectural changes with Cilium 1.8
which will also impact the way it is deployed. Notably, Hubble v0.5
will be the last version of Hubble to support Cilium 1.7.

Therefore, the documentation in Cilium 1.7 needs to be updated to point
to the v0.5 branch, as the master branch of `github.com/cilium/hubble`
will not contain the Hubble stand-alone server Helm charts (required
to run Hubble with Cilium 1.7) going forward.

The Hubble documentation will need a significant overhaul for the
Cilium 1.8 release. However, this is going to be done at a later
date and is out of scope for this PR. This PR is solely intended to
ensure the Cilium 1.7 documentation will stay functional going
forward. Hubble v0.5 is compatible with Cilium 1.8, therefore
the `latest` docs are remaining functional as well.