### PR TITLE
rename hubble-proxy to hubble-relay

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -59,7 +59,7 @@ examples/ @cilium/docs
 examples/kubernetes/ @cilium/kubernetes
 examples/minikube/ @cilium/kubernetes
 *.Jenkinsfile @cilium/ci
-hubble-proxy/ @cilium/hubble
+hubble-relay/ @cilium/hubble
 install/kubernetes/ @cilium/kubernetes
 jenkinsfiles @cilium/ci
 Jenkinsfile.nightly @cilium/ci

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ SUBDIRS_CILIUM_CONTAINER := proxylib envoy plugins/cilium-cni bpf cilium daemon 
 ifdef LIBNETWORK_PLUGIN
 SUBDIRS_CILIUM_CONTAINER += plugins/cilium-docker
 endif
-SUBDIRS := $(SUBDIRS_CILIUM_CONTAINER) operator plugins tools hubble-proxy
+SUBDIRS := $(SUBDIRS_CILIUM_CONTAINER) operator plugins tools hubble-relay
 GOFILES_EVAL := $(subst _$(ROOT_DIR)/,,$(shell $(GO_LIST) -e ./...))
 GOFILES ?= $(GOFILES_EVAL)
 TESTPKGS_EVAL := $(subst github.com/cilium/cilium/,,$(shell $(GO_LIST) -e ./... | grep -v '/api/v1\|/vendor\|/contrib' | grep -v -P 'test(?!/helpers/logutils)'))

--- a/hubble-proxy/.gitignore
+++ b/hubble-proxy/.gitignore
@@ -1,1 +1,0 @@
-hubble-proxy

--- a/hubble-relay/.gitignore
+++ b/hubble-relay/.gitignore
@@ -1,0 +1,1 @@
+hubble-relay

--- a/hubble-relay/Makefile
+++ b/hubble-relay/Makefile
@@ -3,7 +3,7 @@
 
 include ../Makefile.defs
 
-TARGET := hubble-proxy
+TARGET := hubble-relay
 
 .PHONY: all $(TARGET) clean install
 

--- a/hubble-relay/cmd/completion/completion.go
+++ b/hubble-relay/cmd/completion/completion.go
@@ -77,28 +77,28 @@ const (
 ## or, if running Bash 4.1+
 	brew install bash-completion@2
 ## afterwards you only need to run
-	hubble-proxy completion bash > $(brew --prefix)/etc/bash_completion.d/hubble-proxy
+	hubble-relay completion bash > $(brew --prefix)/etc/bash_completion.d/hubble-relay
 
 
 # Installing bash completion on Linux
-## Load the hubble-proxy completion code for bash into the current shell
-	source <(hubble-proxy completion bash)
+## Load the hubble-relay completion code for bash into the current shell
+	source <(hubble-relay completion bash)
 ## Write bash completion code to a file and source if from .bash_profile
-	hubble-proxy completion bash > ~/.hubble-proxy/completion.bash.inc
+	hubble-relay completion bash > ~/.hubble-relay/completion.bash.inc
 	printf "
-	  # hubble-proxy shell completion
-	  source '$HOME/.hubble-proxy/completion.bash.inc'
+	  # hubble-relay shell completion
+	  source '$HOME/.hubble-relay/completion.bash.inc'
 	  " >> $HOME/.bash_profile
 	source $HOME/.bash_profile
 
 # Installing zsh completion on Linux/macOS
-## Load the hubble-proxy completion code for zsh into the current shell
-        source <(hubble-proxy completion zsh)
+## Load the hubble-relay completion code for zsh into the current shell
+        source <(hubble-relay completion zsh)
 ## Write zsh completion code to a file and source if from .zshrc
-        hubble-proxy completion zsh > ~/.hubble-proxy/completion.zsh.inc
+        hubble-relay completion zsh > ~/.hubble-relay/completion.zsh.inc
         printf "
-          # hubble-proxy shell completion
-          source '$HOME/.hubble-proxy/completion.zsh.inc'
+          # hubble-relay shell completion
+          source '$HOME/.hubble-relay/completion.zsh.inc'
           " >> $HOME/.zshrc
         source $HOME/.zshrc`
 )

--- a/hubble-relay/cmd/root.go
+++ b/hubble-relay/cmd/root.go
@@ -15,20 +15,20 @@
 package cmd
 
 import (
-	"github.com/cilium/cilium/hubble-proxy/cmd/completion"
-	"github.com/cilium/cilium/hubble-proxy/cmd/serve"
-	"github.com/cilium/cilium/hubble-proxy/cmd/version"
+	"github.com/cilium/cilium/hubble-relay/cmd/completion"
+	"github.com/cilium/cilium/hubble-relay/cmd/serve"
+	"github.com/cilium/cilium/hubble-relay/cmd/version"
 	v "github.com/cilium/cilium/pkg/version"
 
 	"github.com/spf13/cobra"
 )
 
-// New creates a new hubble-proxy command.
+// New creates a new hubble-relay command.
 func New() *cobra.Command {
 	rootCmd := &cobra.Command{
-		Use:          "hubble-proxy",
-		Short:        "hubble-proxy is a proxy server for the hubble API",
-		Long:         "hubble-proxy is a proxy server for the hubble API.",
+		Use:          "hubble-relay",
+		Short:        "hubble-relay is a proxy server for the hubble API",
+		Long:         "hubble-relay is a proxy server for the hubble API.",
 		SilenceUsage: true,
 		Version:      v.GetCiliumVersion().Version,
 	}

--- a/hubble-relay/cmd/serve/serve.go
+++ b/hubble-relay/cmd/serve/serve.go
@@ -20,7 +20,7 @@ import (
 	"os"
 	"os/signal"
 
-	"github.com/cilium/cilium/pkg/hubble/proxy"
+	"github.com/cilium/cilium/pkg/hubble/relay"
 	"golang.org/x/sys/unix"
 
 	"github.com/spf13/cobra"
@@ -39,9 +39,9 @@ func New() *cobra.Command {
 }
 
 func runServe() error {
-	srv, err := proxy.NewServer()
+	srv, err := relay.NewServer()
 	if err != nil {
-		return fmt.Errorf("cannot create proxy server: %v", err)
+		return fmt.Errorf("cannot create hubble-relay server: %v", err)
 	}
 
 	if err := srv.Serve(); err != nil {

--- a/hubble-relay/cmd/version/version.go
+++ b/hubble-relay/cmd/version/version.go
@@ -12,19 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package proxyoption
+package version
 
 import (
 	"fmt"
-	"time"
+	"io"
 
-	"github.com/cilium/cilium/pkg/defaults"
-	hubbledefaults "github.com/cilium/cilium/pkg/hubble/defaults"
+	"github.com/cilium/cilium/pkg/version"
+
+	"github.com/spf13/cobra"
 )
 
-// Default is the reference point for default values.
-var Default = Options{
-	HubbleTarget:  "unix://" + defaults.HubbleSockPath,
-	DialTimeout:   5 * time.Second,
-	ListenAddress: fmt.Sprintf(":%d", hubbledefaults.ProxyPort),
+// New creates a new version command.
+func New() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Display detailed version information",
+		Long:  `Displays information about the version of this software.`,
+		Run: func(cmd *cobra.Command, _ []string) {
+			runVersion(cmd.OutOrStdout())
+		},
+	}
+}
+
+func runVersion(out io.Writer) {
+	fmt.Fprintf(out, "Hubble-relay: %s\n", version.Version)
 }

--- a/hubble-relay/main.go
+++ b/hubble-relay/main.go
@@ -17,7 +17,7 @@ package main
 import (
 	"os"
 
-	"github.com/cilium/cilium/hubble-proxy/cmd"
+	"github.com/cilium/cilium/hubble-relay/cmd"
 )
 
 func main() {

--- a/pkg/hubble/defaults/defaults.go
+++ b/pkg/hubble/defaults/defaults.go
@@ -19,6 +19,6 @@ const (
 	// listen address does not include one.
 	ServerPort = 4244
 
-	// ProxyPort is the default port for hubble's proxy service.
-	ProxyPort = 4245
+	// RelayPort is the default port for the hubble-relay server.
+	RelayPort = 4245
 )

--- a/pkg/hubble/relay/relayoption/defaults.go
+++ b/pkg/hubble/relay/relayoption/defaults.go
@@ -12,29 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package version
+package relayoption
 
 import (
 	"fmt"
-	"io"
+	"time"
 
-	"github.com/cilium/cilium/pkg/version"
-
-	"github.com/spf13/cobra"
+	"github.com/cilium/cilium/pkg/defaults"
+	hubbledefaults "github.com/cilium/cilium/pkg/hubble/defaults"
 )
 
-// New creates a new version command.
-func New() *cobra.Command {
-	return &cobra.Command{
-		Use:   "version",
-		Short: "Display detailed version information",
-		Long:  `Displays information about the version of this software.`,
-		Run: func(cmd *cobra.Command, _ []string) {
-			runVersion(cmd.OutOrStdout())
-		},
-	}
-}
-
-func runVersion(out io.Writer) {
-	fmt.Fprintf(out, "Hubble-proxy: %s\n", version.Version)
+// Default is the reference point for default values.
+var Default = Options{
+	HubbleTarget:  "unix://" + defaults.HubbleSockPath,
+	DialTimeout:   5 * time.Second,
+	ListenAddress: fmt.Sprintf(":%d", hubbledefaults.RelayPort),
 }

--- a/pkg/hubble/relay/relayoption/option.go
+++ b/pkg/hubble/relay/relayoption/option.go
@@ -12,21 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package proxyoption
+package relayoption
 
 import (
 	"strings"
 	"time"
 )
 
-// Options stores all the configuration values for the hubble proxy server.
+// Options stores all the configuration values for the hubble-relay server.
 type Options struct {
 	HubbleTarget  string
 	DialTimeout   time.Duration
 	ListenAddress string
 }
 
-// Option customizes the configuration of the hubble proxy server.
+// Option customizes the configuration of the hubble-relay server.
 type Option func(o *Options) error
 
 // WithHubbleTarget sets the URL of the hubble server instance to connect to.
@@ -49,7 +49,7 @@ func WithDialTimeout(t time.Duration) Option {
 	}
 }
 
-// WithListenAddress sets the listen address for the hubble proxy server.
+// WithListenAddress sets the listen address for the hubble-relay server.
 func WithListenAddress(a string) Option {
 	return func(o *Options) error {
 		o.ListenAddress = a

--- a/pkg/hubble/relay/server.go
+++ b/pkg/hubble/relay/server.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package proxy
+package relay
 
 import (
 	"context"
@@ -22,7 +22,7 @@ import (
 
 	observerpb "github.com/cilium/cilium/api/v1/observer"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
-	"github.com/cilium/cilium/pkg/hubble/proxy/proxyoption"
+	"github.com/cilium/cilium/pkg/hubble/relay/relayoption"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -36,12 +36,12 @@ import (
 type Server struct {
 	client observerpb.ObserverClient
 	server *grpc.Server
-	opts   proxyoption.Options
+	opts   relayoption.Options
 }
 
-// NewServer creates a new proxy Server.
-func NewServer(options ...proxyoption.Option) (*Server, error) {
-	opts := proxyoption.Default
+// NewServer creates a new hubble-relay Server.
+func NewServer(options ...relayoption.Option) (*Server, error) {
+	opts := relayoption.Default
 	for _, opt := range options {
 		if err := opt(&opts); err != nil {
 			return nil, fmt.Errorf("failed to apply option: %v", err)
@@ -55,7 +55,7 @@ func NewServer(options ...proxyoption.Option) (*Server, error) {
 // ensure that GRPCServer implements the observer.ObserverServer interface.
 var _ observerpb.ObserverServer = (*Server)(nil)
 
-// Serve starts the hubble proxy server. Serve does not return unless a
+// Serve starts the hubble-relay server. Serve does not return unless a
 // listening fails with fatal errors. Serve will return a non-nil error if
 // Stop() is not called.
 func (s *Server) Serve() error {
@@ -85,13 +85,13 @@ func (s *Server) connectClient() error {
 	return nil
 }
 
-// Stop terminates the hubble proxy server.
+// Stop terminates the hubble-relay server.
 func (s *Server) Stop() {
 	s.server.Stop()
 }
 
 // GetFlows implements observer.ObserverServer.GetFlows by proxying requests to
-// the hubble instance the proxy is connected to.
+// the hubble instance hubble-relay is connected to.
 func (s *Server) GetFlows(req *observerpb.GetFlowsRequest, server observerpb.Observer_GetFlowsServer) error {
 	c, err := s.client.GetFlows(context.Background(), req)
 	if err != nil {
@@ -116,7 +116,7 @@ func (s *Server) GetFlows(req *observerpb.GetFlowsRequest, server observerpb.Obs
 }
 
 // ServerStatus implements observer.ObserverServer.ServerStatus by proxying
-// requests to the hubble instance the proxy is connected to.
+// requests to the hubble instance hubble-relay is connected to.
 func (s *Server) ServerStatus(ctx context.Context, req *observerpb.ServerStatusRequest) (*observerpb.ServerStatusResponse, error) {
 	return s.client.ServerStatus(ctx, req)
 }


### PR DESCRIPTION
The scope of this component goes beyond simply proxying requests.
As such, it was decided to rename it to "hubble-relay". This is what this commit does, without any functional changes.
