### PR TITLE
[WIP] ci: Enable Hubble by default for K8sPolicy tests 

### DIFF
--- a/install/kubernetes/cilium/charts/hubble-cli/values.yaml
+++ b/install/kubernetes/cilium/charts/hubble-cli/values.yaml
@@ -11,6 +11,11 @@ image:
 args:
   - observe
   - --follow
+  - --type=trace
+  - --type=drop
+  - --type=l7
+  - --type=policy-verdict
+  - --output=json
 
 # Specifies the resources for the hubble-cli container
 resources: {}

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2689,6 +2689,21 @@ func (kub *Kubectl) GetCiliumPodOnNode(namespace string, node string) (string, e
 	return res.Output().String(), nil
 }
 
+// GetCiliumPodOnNode returns the name of the Hubble client pod that is running
+// on / in the specified node / namespace.
+func (kub *Kubectl) GetHubbleClientPodOnNode(namespace string, node string) (string, error) {
+	filter := fmt.Sprintf(
+		"-o jsonpath='{.items[?(@.spec.nodeName == \"%s\")].metadata.name}'", node)
+
+	res := kub.ExecShort(fmt.Sprintf(
+		"%s -n %s get pods -l k8s-app=hubble-cli %s", KubectlCmd, namespace, filter))
+	if !res.WasSuccessful() {
+		return "", fmt.Errorf("Cilium pod not found on node '%s'", node)
+	}
+
+	return res.Output().String(), nil
+}
+
 // GetNodeInfo provides the node name and IP address based on the label
 // (eg helpers.K8s1 or helpers.K8s2)
 func (kub *Kubectl) GetNodeInfo(label string) (nodeName, nodeIP string) {
@@ -2707,6 +2722,17 @@ func (kub *Kubectl) GetCiliumPodOnNodeWithLabel(namespace string, label string) 
 	}
 
 	return kub.GetCiliumPodOnNode(namespace, node)
+}
+
+// GetHubbleClientPodOnNodeWithLabel returns the name of the Hubble client pod
+// that is running on node with cilium.io/ci-node label
+func (kub *Kubectl) GetHubbleClientPodOnNodeWithLabel(namespace string, label string) (string, error) {
+	node, err := kub.GetNodeNameByLabel(label)
+	if err != nil {
+		return "", fmt.Errorf("Unable to get nodes with label '%s': %s", label, err)
+	}
+
+	return kub.GetHubbleClientPodOnNode(namespace, node)
 }
 
 func (kub *Kubectl) ciliumPreFlightCheck() error {

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -94,6 +94,8 @@ var _ = Describe("K8sPolicyTest", func() {
 		daemonCfg = map[string]string{
 			"global.tls.secretsBackend": "k8s",
 			"global.debug.verbose":      "flow",
+			"global.hubble.enabled":     "true",
+			"global.hubble.cli.enabled": "true",
 		}
 		DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, daemonCfg)
 	})
@@ -109,7 +111,7 @@ var _ = Describe("K8sPolicyTest", func() {
 	})
 
 	AfterAll(func() {
-		kubectl.DeleteCiliumDS()
+		kubectl.Delete(ciliumFilename)
 		ExpectAllPodsTerminated(kubectl)
 		kubectl.CloseSSHClient()
 	})

--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -87,6 +87,14 @@ func ExpectCiliumPreFlightInstallReady(vm *helpers.Kubectl) {
 	Expect(err).To(BeNil(), "cilium pre-flight check is not ready after timeout, pods status:\n %s", warningMessage)
 }
 
+// ExpectHubbleClientReady is a wrapper around helpers/WaitForPods. It asserts
+// that the error returned by that function is nil.
+func ExpectHubbleClientReady(vm *helpers.Kubectl) {
+	By("Waiting for Hubble client to be ready")
+	err := vm.WaitforPods(helpers.CiliumNamespace, "-l k8s-app=hubble-cli", longTimeout)
+	ExpectWithOffset(1, err).Should(BeNil(), "Hubble client was not able to get into ready state")
+}
+
 // DeployCiliumAndDNS deploys DNS and cilium into the kubernetes cluster
 func DeployCiliumAndDNS(vm *helpers.Kubectl, ciliumFilename string) {
 	DeployCiliumOptionsAndDNS(vm, ciliumFilename, map[string]string{"global.debug.verbose": "flow"})
@@ -108,6 +116,7 @@ func RedeployCilium(vm *helpers.Kubectl, ciliumFilename string, options map[stri
 	redeployCilium(vm, ciliumFilename, options)
 	ExpectCiliumReady(vm)
 	ExpectCiliumOperatorReady(vm)
+	ExpectHubbleClientReady(vm)
 }
 
 // DeployCiliumOptionsAndDNS deploys DNS and cilium with options into the kubernetes cluster
@@ -137,6 +146,7 @@ func DeployCiliumOptionsAndDNS(vm *helpers.Kubectl, ciliumFilename string, optio
 
 	ExpectCiliumReady(vm)
 	ExpectCiliumOperatorReady(vm)
+	ExpectHubbleClientReady(vm)
 	ExpectKubeDNSReady(vm)
 }
 

--- a/test/k8sT/hubble.go
+++ b/test/k8sT/hubble.go
@@ -123,9 +123,7 @@ var _ = Describe("K8sHubbleTest", func() {
 			"global.hubble.cli.enabled": "true",
 		})
 
-		err := kubectl.WaitforPods(hubbleNamespace, hubbleSelector, helpers.HelperTimeout)
-		Expect(err).Should(BeNil(), "hubble-cli pods did not become ready")
-
+		var err error
 		hubblePodK8s1, err = hubbleGetPodOnNodeWithLabel(hubbleNamespace, helpers.K8s1)
 		Expect(err).Should(BeNil(), "unable to find hubble-cli pod on %s", helpers.K8s1)
 	})

--- a/test/k8sT/hubble.go
+++ b/test/k8sT/hubble.go
@@ -34,7 +34,6 @@ var _ = Describe("K8sHubbleTest", func() {
 
 		hubblePodK8s1 string
 
-		hubbleSelector  = "-l k8s-app=hubble-cli"
 		hubbleNamespace = helpers.CiliumNamespace
 
 		demoPath string
@@ -43,23 +42,6 @@ var _ = Describe("K8sHubbleTest", func() {
 		app1Labels  = "id=app1,zgroup=testapp"
 		apps        = []string{helpers.App1, helpers.App2, helpers.App3}
 	)
-
-	hubbleGetPodOnNodeWithLabel := func(ns, label string) (string, error) {
-		node, err := kubectl.GetNodeNameByLabel(label)
-		if err != nil {
-			return "", fmt.Errorf("unable to find node for label %s", label)
-		}
-
-		filter := fmt.Sprintf(
-			"-o jsonpath='{.items[?(@.spec.nodeName == \"%s\")].metadata.name}'", node)
-
-		res := kubectl.ExecShort(fmt.Sprintf(
-			"%s -n %s get pods %s %s", helpers.KubectlCmd, ns, hubbleSelector, filter))
-		if !res.WasSuccessful() {
-			return "", fmt.Errorf("hubble-cli pod not found on node '%s'", node)
-		}
-		return res.Output().String(), nil
-	}
 
 	hubbleExecUntilMatch := func(ns, pod, cmd, substr string) error {
 		By("Executing %q on %s/%s", cmd, ns, pod)
@@ -124,7 +106,7 @@ var _ = Describe("K8sHubbleTest", func() {
 		})
 
 		var err error
-		hubblePodK8s1, err = hubbleGetPodOnNodeWithLabel(hubbleNamespace, helpers.K8s1)
+		hubblePodK8s1, err = kubectl.GetHubbleClientPodOnNodeWithLabel(hubbleNamespace, helpers.K8s1)
 		Expect(err).Should(BeNil(), "unable to find hubble-cli pod on %s", helpers.K8s1)
 	})
 


### PR DESCRIPTION
This enables the Hubble client and server by default for the K8sPolicy
tests. Because the Hubble pod is logging all observed flows, its output
is dumped during reporting. This allows users to inspect the network
traffic which occured during the test.