### PR TITLE
helm: Do not enable hubble-cli subchart by default

### DIFF
--- a/install/kubernetes/cilium/charts/hubble-cli/Chart.yaml
+++ b/install/kubernetes/cilium/charts/hubble-cli/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: hubble-cli
 version: 1.7.90
-appVersion: 0.5.1
+appVersion: 1.7.90
 tillerVersion: ">=2.7.2"
 description: Helm chart for running the Hubble CLI on each node
 keywords:

--- a/install/kubernetes/cilium/requirements.yaml
+++ b/install/kubernetes/cilium/requirements.yaml
@@ -5,6 +5,9 @@ dependencies:
   - name: config
     version: 1.7.90
     condition: config.enabled
+  - name: hubble-cli
+    version: 1.7.90
+    condition: hubble-cli.enabled
   - name: operator
     version: 1.7.90
     condition: operator.enabled

--- a/install/kubernetes/cilium/requirements.yaml
+++ b/install/kubernetes/cilium/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
     condition: config.enabled
   - name: hubble-cli
     version: 1.7.90
-    condition: hubble-cli.enabled
+    condition: global.hubble.cli.enabled
   - name: operator
     version: 1.7.90
     condition: operator.enabled

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -12,6 +12,10 @@ agent:
 config:
   enabled: true
 
+# Do not include the hubble-cli DaemonSet by default
+hubble-cli:
+  enabled: false
+
 # Include the cilium-operator Deployment
 operator:
   enabled: true

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -12,10 +12,6 @@ agent:
 config:
   enabled: true
 
-# Do not include the hubble-cli DaemonSet by default
-hubble-cli:
-  enabled: false
-
 # Include the cilium-operator Deployment
 operator:
   enabled: true
@@ -439,6 +435,9 @@ global:
     # See https://github.com/cilium/hubble/blob/master/Documentation/metrics.md for more comprehensive
     # documentation about Hubble's metric collection.
     metrics: []
+    # Configures the hubble-cli subchart
+    cli:
+      enabled: false
 
   # CI specific options: DO NOT USE IN PRODUCTION.
   ci:

--- a/test/k8sT/hubble.go
+++ b/test/k8sT/hubble.go
@@ -119,8 +119,8 @@ var _ = Describe("K8sHubbleTest", func() {
 		demoPath = helpers.ManifestGet(kubectl.BasePath(), "demo.yaml")
 
 		DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
-			"global.hubble.enabled": "true",
-			"hubble-cli.enabled":    "true",
+			"global.hubble.enabled":     "true",
+			"global.hubble.cli.enabled": "true",
 		})
 
 		err := kubectl.WaitforPods(hubbleNamespace, hubbleSelector, helpers.HelperTimeout)


### PR DESCRIPTION
This chart is intended for CI and debugging purposes. It should not be automatically enabled when Hubble is enabled.

Fixes: ebf9e424ba01 ("helm: Add hubble-cli subchart")

Fixes https://github.com/cilium/cilium/issues/11130

Signed-off-by: Sebastian Wicki <sebastian@isovalent.com>