### PR TITLE
Update CODEOWNERS and hide go.sum

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+go.sum linguist-generated

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,10 +1,11 @@
 # Code owners groups and a brief description of their areas:
-# @cilium-janitors      Catch-all for code not otherwise owned
+# @cilium/janitors      Catch-all for code not otherwise owned
 # @cilium/agent         Cilium Agent
 # @cilium/bpf           BPF Data Path
+# @cilium/build         Building and packaging
 # @cilium/ci            Continuous integration, testing
 # @cilium/cli           Commandline interfaces
-# @cilium/contributing  Developer documentation
+# @cilium/contributing  Developer documentation & tools
 # @cilium/docker        Docker plugin
 # @cilium/docs          Documentation, examples
 # @cilium/endpoint      Endpoint package
@@ -18,26 +19,27 @@
 # @cilium/policy        Policy behaviour
 # @cilium/proxy         L7 proxy, Envoy
 # @cilium/vendor        Vendoring, dependency management
-#
-# Specific code owners:
-# @eloycoto             Debian packaging
-# @aanm @ianvernon      Docker packaging
-# @scanf @borkmann      BPF documentation
 
 # The following filepaths should be sorted so that more specific paths occur
 # after the less specific paths, otherwise the ownership for the specific paths
 # is not properly picked up in Github.
 * @cilium/janitors
 api/ @cilium/api
+api/v1/flow/ @cilium/api @cilium/hubble
+api/v1/observer/ @cilium/api @cilium/hubble
+api/v1/peer/ @cilium/api @cilium/hubble
 bpf/ @cilium/bpf
+Makefile* @cilium/build
+bpf/Makefile* @cilium/build @cilium/bpf
+bpf/sockops/Makefile* @cilium/build @cilium/bpf
+Dockerfile* @cilium/build
 bugtool/cmd/ @cilium/cli
 cilium/ @cilium/cli
 cilium/cmd/preflight_k8s_valid_cnp.go @cilium/kubernetes
-cilium-health/cmd/ @cilium/cli
-cilium-health/launch/ @cilium/health
-contrib/packaging/deb/ @eloycoto
-contrib/packaging/docker/ @aanm @ianvernon
-contrib/vagrant @cilium/ci
+cilium-health/ @cilium/health
+cilium-health/cmd/ @cilium/health @cilium/cli
+contrib/packaging/ @cilium/build
+contrib/vagrant/ @cilium/contributing
 daemon/ @cilium/agent
 daemon/cmd/datapath.* @cilium/bpf
 daemon/cmd/endpoint.* @cilium/endpoint
@@ -52,7 +54,7 @@ daemon/cmd/proxy.go @cilium/proxy
 daemon/cmd/state.go @cilium/endpoint
 daemon/cmd/sysctl_linux.go @cilium/bpf
 Documentation/ @cilium/docs
-Documentation/bpf.rst @scanf @borkmann
+Documentation/bpf.rst @cilium/bpf
 Documentation/contributing/ @cilium/contributing
 envoy/ @cilium/proxy
 examples/ @cilium/docs
@@ -61,7 +63,7 @@ examples/minikube/ @cilium/kubernetes
 *.Jenkinsfile @cilium/ci
 hubble-relay/ @cilium/hubble
 hubble-relay.Dockerfile @cilium/hubble
-install/kubernetes/ @cilium/kubernetes
+install/kubernetes/ @cilium/kubernetes @cilium/docs
 jenkinsfiles @cilium/ci
 Jenkinsfile.nightly @cilium/ci
 operator/ @cilium/operator
@@ -107,22 +109,27 @@ pkg/monitor/format @cilium/cli
 pkg/monitor/payload @cilium/api
 pkg/mountinfo @cilium/bpf
 pkg/mtu @cilium/bpf
-pkg/option @cilium/option
+pkg/option @cilium/cli
 pkg/pidfile @cilium/agent
 pkg/policy @cilium/policy
 pkg/policy/api/ @cilium/api
 pkg/proxy/ @cilium/proxy
 pkg/proxy/accesslog @cilium/api
 pkg/serializer @cilium/agent
-pkg/service @cilium/policy
+pkg/service @cilium/loadbalancer
 pkg/sysctl @cilium/bpf
+pkg/testutils/ @cilium/ci
 pkg/tuple @cilium/bpf
 plugins/cilium-cni/ @cilium/kubernetes
 plugins/cilium-docker/ @cilium/docker
 proxylib/ @cilium/proxy
 README.rst @cilium/docs
 test/ @cilium/ci
+test/bpf/ @cilium/ci @cilium/bpf
+test/Makefile* @cilium/ci @cilium/build
 tests/ @cilium/ci
 Vagrantfile @cilium/ci
+/Vagrantfile @cilium/contributing
+go.sum @cilium/vendor
+go.mod @cilium/vendor
 vendor/ @cilium/vendor
-Makefile @cilium/janitors

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -40,6 +40,7 @@ Dockerfile* @cilium/build
 /cilium-health/cmd/ @cilium/health @cilium/cli
 /contrib/packaging/ @cilium/build
 /contrib/vagrant/ @cilium/contributing
+/contrib/coccinelle/ @cilium/bpf
 /daemon/ @cilium/agent
 /daemon/cmd/datapath.* @cilium/bpf
 /daemon/cmd/endpoint.* @cilium/endpoint

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,8 @@
 # Code owners groups and a brief description of their areas:
 # @cilium/janitors      Catch-all for code not otherwise owned
 # @cilium/agent         Cilium Agent
+# @cilium/aws           Integration with AWS
+# @cilium/azure         Integration with Azure
 # @cilium/bpf           BPF Data Path
 # @cilium/build         Building and packaging
 # @cilium/ci            Continuous integration, testing
@@ -11,6 +13,7 @@
 # @cilium/endpoint      Endpoint package
 # @cilium/health        Cilium cluster health tool
 # @cilium/hubble        Hubble integration
+# @cilium/ipam          IPAM
 # @cilium/kubernetes    K8s integration, K8s CNI plugin
 # @cilium/kvstore       Key/Value store: Consul, etcd
 # @cilium/loadbalancer  Load balancer
@@ -71,6 +74,8 @@ Jenkinsfile.nightly @cilium/ci
 /operator/ @cilium/operator
 /pkg/annotation @cilium/kubernetes
 /pkg/api/ @cilium/api
+/pkg/aws/ @cilium/aws
+/pkg/azure/ @cilium/azure
 /pkg/bpf/ @cilium/bpf
 /pkg/byteorder/ @cilium/bpf @cilium/api
 /pkg/client @cilium/api
@@ -89,6 +94,10 @@ Jenkinsfile.nightly @cilium/ci
 /pkg/health/ @cilium/health
 /pkg/hubble/ @cilium/hubble
 /pkg/identity @cilium/policy
+/pkg/ipam/ @cilium/ipam
+/pkg/ipam/allocator/aws/ @cilium/ipam @cilium/aws
+/pkg/ipam/allocator/azure/ @cilium/ipam @cilium/azure
+/pkg/ipam/allocator/operator/ @cilium/ipam @cilium/operator
 /pkg/ipcache/ @cilium/ipcache
 /pkg/k8s/ @cilium/kubernetes
 /pkg/k8s/apis/cilium.io/v2/ @cilium/api
@@ -115,6 +124,7 @@ Jenkinsfile.nightly @cilium/ci
 /pkg/pidfile @cilium/agent
 /pkg/policy @cilium/policy
 /pkg/policy/api/ @cilium/api
+/pkg/policy/groups/aws/ @cilium/policy @cilium/aws
 /pkg/proxy/ @cilium/proxy
 /pkg/proxy/accesslog @cilium/api
 /pkg/serializer @cilium/agent

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -24,112 +24,113 @@
 # after the less specific paths, otherwise the ownership for the specific paths
 # is not properly picked up in Github.
 * @cilium/janitors
-api/ @cilium/api
-api/v1/flow/ @cilium/api @cilium/hubble
-api/v1/observer/ @cilium/api @cilium/hubble
-api/v1/peer/ @cilium/api @cilium/hubble
-bpf/ @cilium/bpf
+/api/ @cilium/api
+/api/v1/flow/ @cilium/api @cilium/hubble
+/api/v1/observer/ @cilium/api @cilium/hubble
+/api/v1/peer/ @cilium/api @cilium/hubble
+/bpf/ @cilium/bpf
 Makefile* @cilium/build
-bpf/Makefile* @cilium/build @cilium/bpf
-bpf/sockops/Makefile* @cilium/build @cilium/bpf
+/bpf/Makefile* @cilium/build @cilium/bpf
+/bpf/sockops/Makefile* @cilium/build @cilium/bpf
 Dockerfile* @cilium/build
-bugtool/cmd/ @cilium/cli
-cilium/ @cilium/cli
-cilium/cmd/preflight_k8s_valid_cnp.go @cilium/kubernetes
-cilium-health/ @cilium/health
-cilium-health/cmd/ @cilium/health @cilium/cli
-contrib/packaging/ @cilium/build
-contrib/vagrant/ @cilium/contributing
-daemon/ @cilium/agent
-daemon/cmd/datapath.* @cilium/bpf
-daemon/cmd/endpoint.* @cilium/endpoint
-daemon/cmd/health.* @cilium/health
-daemon/cmd/hubble.go @cilium/hubble
-daemon/cmd/ipcache.* @cilium/ipcache
-daemon/cmd/loadbalancer.* @cilium/loadbalancer
-daemon/cmd/metrics.* @cilium/metrics
-daemon/cmd/policy.* @cilium/policy
-daemon/cmd/prefilter.go @cilium/bpf
-daemon/cmd/proxy.go @cilium/proxy
-daemon/cmd/state.go @cilium/endpoint
-daemon/cmd/sysctl_linux.go @cilium/bpf
-Documentation/ @cilium/docs
-Documentation/bpf.rst @cilium/bpf
-Documentation/contributing/ @cilium/contributing
-envoy/ @cilium/proxy
-examples/ @cilium/docs
-examples/kubernetes/ @cilium/kubernetes
-examples/minikube/ @cilium/kubernetes
+/bugtool/cmd/ @cilium/cli
+/cilium/ @cilium/cli
+/cilium/cmd/preflight_k8s_valid_cnp.go @cilium/kubernetes
+/cilium-health/ @cilium/health
+/cilium-health/cmd/ @cilium/health @cilium/cli
+/contrib/packaging/ @cilium/build
+/contrib/vagrant/ @cilium/contributing
+/daemon/ @cilium/agent
+/daemon/cmd/datapath.* @cilium/bpf
+/daemon/cmd/endpoint.* @cilium/endpoint
+/daemon/cmd/health.* @cilium/health
+/daemon/cmd/hubble.go @cilium/hubble
+/daemon/cmd/ipcache.* @cilium/ipcache
+/daemon/cmd/loadbalancer.* @cilium/loadbalancer
+/daemon/cmd/metrics.* @cilium/metrics
+/daemon/cmd/policy.* @cilium/policy
+/daemon/cmd/prefilter.go @cilium/bpf
+/daemon/cmd/proxy.go @cilium/proxy
+/daemon/cmd/state.go @cilium/endpoint
+/daemon/cmd/sysctl_linux.go @cilium/bpf
+/Documentation/ @cilium/docs
+/Documentation/bpf.rst @cilium/bpf
+/Documentation/contributing/ @cilium/contributing
+/Documentation/envoy/ @cilium/proxy
+/envoy/ @cilium/proxy
+/examples/ @cilium/docs
+/examples/kubernetes/ @cilium/kubernetes
+/examples/minikube/ @cilium/kubernetes
 *.Jenkinsfile @cilium/ci
-hubble-relay/ @cilium/hubble
-hubble-relay.Dockerfile @cilium/hubble
-install/kubernetes/ @cilium/kubernetes @cilium/docs
+/hubble-relay/ @cilium/hubble
+/hubble-relay.Dockerfile @cilium/hubble
+/install/kubernetes/ @cilium/kubernetes @cilium/docs
 jenkinsfiles @cilium/ci
 Jenkinsfile.nightly @cilium/ci
-operator/ @cilium/operator
-pkg/annotation @cilium/kubernetes
-pkg/api/ @cilium/api
-pkg/bpf/ @cilium/bpf
-pkg/byteorder/ @cilium/bpf @cilium/api
-pkg/client @cilium/api
-pkg/completion/ @cilium/proxy
-pkg/components/ @cilium/agent
-pkg/controller @cilium/agent
-pkg/counter @cilium/bpf
-pkg/datapath @cilium/bpf
-pkg/datapath/ipcache/ @cilium/ipcache
-pkg/defaults @cilium/agent
-pkg/elf @cilium/bpf
-pkg/endpoint/ @cilium/endpoint
-pkg/endpointmanager/ @cilium/endpoint
-pkg/envoy/ @cilium/proxy
-pkg/fqdn/ @cilium/agent
-pkg/health/ @cilium/health
-pkg/hubble/ @cilium/hubble
-pkg/identity @cilium/policy
-pkg/ipcache/ @cilium/ipcache
-pkg/k8s/ @cilium/kubernetes
-pkg/k8s/apis/cilium.io/v2/ @cilium/api
-pkg/k8s/client/clientset/versioned/ @cilium/api
-pkg/k8s/client/informers/ @cilium/api
-pkg/kafka/ @cilium/proxy
-pkg/kvstore/ @cilium/kvstore
-pkg/labels @cilium/policy @cilium/api
-pkg/launcher @pkg/agent
-pkg/loadbalancer @cilium/loadbalancer
-pkg/lock @pkg/agent
-pkg/logging/ @cilium/cli
-pkg/mac @cilium/bpf
-pkg/maps/ @cilium/bpf
-pkg/metrics @cilium/metrics
-pkg/monitor @cilium/monitor
-pkg/monitor/api @cilium/api
-pkg/monitor/datapath_debug.go @cilium/bpf
-pkg/monitor/format @cilium/cli
-pkg/monitor/payload @cilium/api
-pkg/mountinfo @cilium/bpf
-pkg/mtu @cilium/bpf
-pkg/option @cilium/cli
-pkg/pidfile @cilium/agent
-pkg/policy @cilium/policy
-pkg/policy/api/ @cilium/api
-pkg/proxy/ @cilium/proxy
-pkg/proxy/accesslog @cilium/api
-pkg/serializer @cilium/agent
-pkg/service @cilium/loadbalancer
-pkg/sysctl @cilium/bpf
-pkg/testutils/ @cilium/ci
-pkg/tuple @cilium/bpf
-plugins/cilium-cni/ @cilium/kubernetes
-plugins/cilium-docker/ @cilium/docker
-proxylib/ @cilium/proxy
-README.rst @cilium/docs
-test/ @cilium/ci
-test/bpf/ @cilium/ci @cilium/bpf
-test/Makefile* @cilium/ci @cilium/build
-tests/ @cilium/ci
+/operator/ @cilium/operator
+/pkg/annotation @cilium/kubernetes
+/pkg/api/ @cilium/api
+/pkg/bpf/ @cilium/bpf
+/pkg/byteorder/ @cilium/bpf @cilium/api
+/pkg/client @cilium/api
+/pkg/completion/ @cilium/proxy
+/pkg/components/ @cilium/agent
+/pkg/controller @cilium/agent
+/pkg/counter @cilium/bpf
+/pkg/datapath @cilium/bpf
+/pkg/datapath/ipcache/ @cilium/ipcache
+/pkg/defaults @cilium/agent
+/pkg/elf @cilium/bpf
+/pkg/endpoint/ @cilium/endpoint
+/pkg/endpointmanager/ @cilium/endpoint
+/pkg/envoy/ @cilium/proxy
+/pkg/fqdn/ @cilium/agent
+/pkg/health/ @cilium/health
+/pkg/hubble/ @cilium/hubble
+/pkg/identity @cilium/policy
+/pkg/ipcache/ @cilium/ipcache
+/pkg/k8s/ @cilium/kubernetes
+/pkg/k8s/apis/cilium.io/v2/ @cilium/api
+/pkg/k8s/client/clientset/versioned/ @cilium/api
+/pkg/k8s/client/informers/ @cilium/api
+/pkg/kafka/ @cilium/proxy
+/pkg/kvstore/ @cilium/kvstore
+/pkg/labels @cilium/policy @cilium/api
+/pkg/launcher @pkg/agent
+/pkg/loadbalancer @cilium/loadbalancer
+/pkg/lock @pkg/agent
+/pkg/logging/ @cilium/cli
+/pkg/mac @cilium/bpf
+/pkg/maps/ @cilium/bpf
+/pkg/metrics @cilium/metrics
+/pkg/monitor @cilium/monitor
+/pkg/monitor/api @cilium/api
+/pkg/monitor/datapath_debug.go @cilium/bpf
+/pkg/monitor/format @cilium/cli
+/pkg/monitor/payload @cilium/api
+/pkg/mountinfo @cilium/bpf
+/pkg/mtu @cilium/bpf
+/pkg/option @cilium/cli
+/pkg/pidfile @cilium/agent
+/pkg/policy @cilium/policy
+/pkg/policy/api/ @cilium/api
+/pkg/proxy/ @cilium/proxy
+/pkg/proxy/accesslog @cilium/api
+/pkg/serializer @cilium/agent
+/pkg/service @cilium/loadbalancer
+/pkg/sysctl @cilium/bpf
+/pkg/testutils/ @cilium/ci
+/pkg/tuple @cilium/bpf
+/plugins/cilium-cni/ @cilium/kubernetes
+/plugins/cilium-docker/ @cilium/docker
+/proxylib/ @cilium/proxy
+/README.rst @cilium/docs
+/test/ @cilium/ci
+/test/bpf/ @cilium/ci @cilium/bpf
+/test/Makefile* @cilium/ci @cilium/build
+/tests/ @cilium/ci
 Vagrantfile @cilium/ci
 /Vagrantfile @cilium/contributing
-go.sum @cilium/vendor
-go.mod @cilium/vendor
-vendor/ @cilium/vendor
+/go.sum @cilium/vendor
+/go.mod @cilium/vendor
+/vendor/ @cilium/vendor


### PR DESCRIPTION
The first commit reworks the code owner entries, mostly to avoid matching the catch-all janitors group unless it makes sense. In particular, it:
- introduces two new groups @cilium/ipam and @cilium/build;
- moves development tools under `@cilium/contributing`;
- removes specific code owners to prefer groups;
- adds `go.{sum,mod}` to `@cilium/vendor`.

As is, this pull request requires the creation of four new groups in the Cilium organization: @cilium/ipam, @cilium/build, @cilium/aws, and @cilium/azure.

This leaves two fairly commonly touched packages (`pkg/node` and `pkg/aws`) under `@cilium/janitors`, but I'm not sure there's a good group to assign them.

The second commit hides `go.sum` files by default in pull requests since these are generated. We will still be able to uncollapse them if needed.