### PR TITLE
make: Remove CONTAINER_ENGINE_FULL, use QUIET and CONTAINER_ENGINE

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -15,7 +15,7 @@ builder-image: Dockerfile requirements.txt
 	$(QUIET)tar c requirements.txt Dockerfile \
 	  | $(CONTAINER_ENGINE) build --tag cilium/docs-builder -
 
-DOCKER_RUN := $(CONTAINER_ENGINE_FULL) container run --rm \
+DOCKER_RUN := $(CONTAINER_ENGINE) container run --rm \
 		--workdir /src/Documentation \
 		--volume $(CURDIR)/..:/src \
 		--user "$(shell id -u):$(shell id -g)" \

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -19,9 +19,7 @@ CONFDIR?=/etc
 
 INSTALL = install
 
-# Container engine
-export CONTAINER_ENGINE?=docker
-CONTAINER_ENGINE_FULL=$(QUIET)$(CONTAINER_ENGINE)
+CONTAINER_ENGINE?=docker
 
 # Set DOCKER_IMAGE_TAG with "latest" by default
 ifeq ($(DOCKER_IMAGE_TAG),)


### PR DESCRIPTION
CONTAINER_ENGINE_FULL was defined as $(QUIET)$(CONTAINER_ENGINE), but
having that variable was confusing and inconsistent. This change removes
it and uses $(QUIET)$(CONTAINER_ENGINE) (or just CONTAINER_ENGINE it
it's not a beginning of the command).

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>