### PR TITLE
hubble-cli: Mount /var/run/cilium as a directory

### DIFF
--- a/install/kubernetes/cilium/charts/hubble-cli/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/hubble-cli/templates/daemonset.yaml
@@ -45,8 +45,8 @@ spec:
 {{- toYaml .Values.resources | trim | nindent 10 }}
 {{- end }}
           volumeMounts:
-          - mountPath: {{ .Values.global.hubble.socketPath }}
-            name: hubble-sock
+          - mountPath: {{ dir .Values.global.hubble.socketPath }}
+            name: hubble-sock-dir
             readOnly: true
       restartPolicy: Always
       terminationGracePeriodSeconds: 1
@@ -54,7 +54,7 @@ spec:
       - operator: Exists
       volumes:
       - hostPath:
-          path: {{ .Values.global.hubble.socketPath }}
-          type: Socket
-        name: hubble-sock
+          path: {{ dir .Values.global.hubble.socketPath }}
+          type: Directory
+        name: hubble-sock-dir
 {{- end }}


### PR DESCRIPTION
I've been hitting an issue with mounting /var/run/cilium/hubble.sock as
the Socket type where sometimes /var/run/cilium/hubble.sock gets created
as a directory. To reproduce this behavior on minikube:

- Deploy Cilium with the Hubble CLI enabled and wait for the hubble-cli
  to become ready. Verify that hubble.sock is a UNIX domain socket.
- Set `enable-hubble` to "false" in cilium-config configmap and restart
  Cilium.
- Now /var/run/cilium/hubble.sock is a directory. It seems like somehow
  hubble-cli creates the directory when Cilium deletes hubble.sock.

Because of this directory Cilium fails to start Hubble server the next
time `enable-hubble` gets set to `true`. With this PR /var/run/cilium
directory gets mounted as a directory instead. I manually verified this
fixes the issue.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>