### PR TITLE
Add possibility to configure native-routing-cidr in helm chart

### DIFF
--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -295,6 +295,9 @@ data:
   enable-xt-socket-fallback: {{ .Values.global.enableXTSocketFallback | quote }}
   install-iptables-rules: {{ .Values.global.installIptablesRules | quote }}
   auto-direct-node-routes: {{ .Values.global.autoDirectNodeRoutes | quote }}
+  {{- if .Values.global.nativeRoutingCIDR }}
+  native-routing-cidr: {{ .Values.global.nativeRoutingCIDR }}
+  {{- end }}
 
 {{- if .Values.global.kubeProxyReplacement }}
   kube-proxy-replacement:  {{ .Values.global.kubeProxyReplacement | quote }}

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -295,9 +295,9 @@ data:
   enable-xt-socket-fallback: {{ .Values.global.enableXTSocketFallback | quote }}
   install-iptables-rules: {{ .Values.global.installIptablesRules | quote }}
   auto-direct-node-routes: {{ .Values.global.autoDirectNodeRoutes | quote }}
-  {{- if .Values.global.nativeRoutingCIDR }}
+{{- if .Values.global.nativeRoutingCIDR }}
   native-routing-cidr: {{ .Values.global.nativeRoutingCIDR }}
-  {{- end }}
+{{- end }}
 
 {{- if .Values.global.kubeProxyReplacement }}
   kube-proxy-replacement:  {{ .Values.global.kubeProxyReplacement | quote }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -127,6 +127,10 @@ global:
   # nodes if worker nodes share a common L2 network segment.
   autoDirectNodeRoutes: false
 
+  # nativeRoutingCIDR allows to explicitly specify the CIDR for native routing. This
+  # value corresponds to the configured cluster-cidr.
+  nativeRoutingCIDR: ""
+
   # endpointRoutes enables use of per endpoint routes instead of routing vis
   # the cilium_host interface
   endpointRoutes:

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2169,6 +2169,10 @@ func (c *DaemonConfig) Validate() error {
 		return err
 	}
 
+	if err := c.checkIPv4NativeRoutingCIDR(); err != nil {
+		return nil
+	}
+
 	// Validate that the KVStore Lease TTL value lies between a particular range.
 	if c.KVstoreLeaseTTL > defaults.KVstoreLeaseMaxTTL || c.KVstoreLeaseTTL < defaults.LockLeaseTTL {
 		return fmt.Errorf("KVstoreLeaseTTL does not lie in required range(%ds, %ds)",
@@ -2753,6 +2757,15 @@ func (c *DaemonConfig) checkMapSizeLimits() error {
 	if c.FragmentsMapEntries > FragmentsMapMax {
 		return fmt.Errorf("specified max entries %d for fragment-tracking map must not exceed maximum %d",
 			c.FragmentsMapEntries, FragmentsMapMax)
+	}
+
+	return nil
+}
+
+func (c *DaemonConfig) checkIPv4NativeRoutingCIDR() error {
+	if c.IPv4NativeRoutingCIDR() == nil && c.Masquerade && c.Tunnel == TunnelDisabled && c.IPAMMode() != IPAMENI {
+		return fmt.Errorf("native routing cidr must be configured with option --%s in combination with --%s --%s=%s --%s=%s",
+			IPv4NativeRoutingCIDR, Masquerade, TunnelName, c.Tunnel, IPAM, c.IPAMMode())
 	}
 
 	return nil


### PR DESCRIPTION
With this change it is possible to configure `native-routing-cidr` option in helm chart. Additionally it makes sure, that this value is set when:

* `masquerade: true`
* ... and `tunnel: disabled`
* ... and NOT `ipam: eni`

Fixes: #11096  ("K8s Network Policy not working with configured auto-direct-node-routes")



```release-note
Add possibility to configure native-routing-cidr in helm chart.
```
Signed-off-by: Rene Zbinden <rene.zbinden@postfinance.ch>