### PR TITLE
daemon: remove deprecated conntrack-garbage-collector-interval option

### DIFF
--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -525,6 +525,8 @@ Removed options
   now removed.
 * The options ``container-runtime`` and ``container-runtime-endpoint`` were
   deprecated in Cilium 1.7 and are now removed.
+* The ``conntrack-garbage-collector-interval`` option deprecated in Cilium 1.6
+  is now removed. Please use ``conntrack-gc-interval`` instead.
 
 Removed helm options
 ~~~~~~~~~~~~~~~~~~~~

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -233,10 +233,6 @@ func init() {
 	flags.String(option.ConfigDir, "", `Configuration directory that contains a file for each option`)
 	option.BindEnv(option.ConfigDir)
 
-	flags.Uint(option.ConntrackGarbageCollectorIntervalDeprecated, 0, "Garbage collection interval for the connection tracking table (in seconds)")
-	flags.MarkDeprecated(option.ConntrackGarbageCollectorIntervalDeprecated, fmt.Sprintf("please use --%s", option.ConntrackGCInterval))
-	option.BindEnv(option.ConntrackGarbageCollectorIntervalDeprecated)
-
 	flags.Duration(option.ConntrackGCInterval, time.Duration(0), "Overwrite the connection-tracking garbage collection interval")
 	option.BindEnv(option.ConntrackGCInterval)
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -120,10 +120,6 @@ const (
 	// represents the value of that option.
 	ConfigDir = "config-dir"
 
-	// ConntrackGarbageCollectorIntervalDeprecated is the deprecated option
-	// name to set the conntrack gc interval
-	ConntrackGarbageCollectorIntervalDeprecated = "conntrack-garbage-collector-interval"
-
 	// ConntrackGCInterval is the name of the ConntrackGCInterval option
 	ConntrackGCInterval = "conntrack-gc-interval"
 
@@ -2307,6 +2303,7 @@ func (c *DaemonConfig) Populate() {
 	c.ClusterMeshConfig = viper.GetString(ClusterMeshConfigName)
 	c.CNPNodeStatusGCInterval = viper.GetDuration(CNPNodeStatusGCInterval)
 	c.CNPStatusUpdateInterval = viper.GetDuration(CNPStatusUpdateInterval)
+	c.ConntrackGCInterval = viper.GetDuration(ConntrackGCInterval)
 	c.DatapathMode = viper.GetString(DatapathMode)
 	c.Debug = viper.GetBool(DebugArg)
 	c.DebugVerbose = viper.GetStringSlice(DebugVerbose)
@@ -2545,12 +2542,6 @@ func (c *DaemonConfig) Populate() {
 
 	if m := viper.GetStringMapString(LogOpt); len(m) != 0 {
 		c.LogOpt = m
-	}
-
-	if val := viper.GetInt(ConntrackGarbageCollectorIntervalDeprecated); val != 0 {
-		c.ConntrackGCInterval = time.Duration(val) * time.Second
-	} else {
-		c.ConntrackGCInterval = viper.GetDuration(ConntrackGCInterval)
 	}
 
 	if val := viper.GetInt64(ENIParallelWorkersDeprecated); val != 0 {


### PR DESCRIPTION
The option was deprecated for Cilium 1.6 in commit df8582d16e51
("datapath: Optimize connection-tracking GC interval"), remove it for
Cilium 1.8.