### PR TITLE
CI: GKE build prunes only docker images (fix filter)

### DIFF
--- a/test/clean-local-registry-tag.sh
+++ b/test/clean-local-registry-tag.sh
@@ -21,4 +21,4 @@ docker push $1/cilium/cilium:$2
 docker push $1/cilium/cilium-dev:$2
 docker push $1/cilium/operator:$2
 
-docker system prune -f --filter "until=6h"
+docker image prune -f --all --filter "until=-6h"


### PR DESCRIPTION
We began pruning docker images older than 6 hours old. The `docker system
prune` command also prunes volumes and networks, which isn't needed.
Furthermore, the relative-time filter was missing a negative sign.

fixes 82bb57f95475c5f4e3997f62febba3ce89d7d351