### PR TITLE
docs: Add Further Readings section to kube-proxy-free getting started guide

### DIFF
--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -610,3 +610,19 @@ Limitations
       situation.
     * Kubernetes Service sessionAffinity is currently not implemented.
       This will be addressed via `GH issue 9076 <https://github.com/cilium/cilium/issues/9076>`__.
+
+Further Readings
+################
+
+The following presentations describe inner-workings of the kube-proxy replacement in BPF
+in great details:
+
+    * "Liberating Kubernetes from kube-proxy and iptables" (KubeCon North America 2019, `slides
+      <https://docs.google.com/presentation/d/1cZJ-pcwB9WG88wzhDm2jxQY4Sh8adYg0-N3qWQ8593I/edit>`__,
+      `video <https://www.youtube.com/watch?v=bIRwSIwNHC0>`__)
+    * "BPF as a revolutionary technology for the container landscape" (Fosdem 2020, `slides
+      <https://docs.google.com/presentation/d/1VOUcoIxgM_c6M_zAV1dLlRCjyYCMdR3tJv6CEdfLMh8/edit>`__,
+      `video <https://fosdem.org/2020/schedule/event/containers_bpf/>`__)
+    * "Kernel improvements for Cilium socket LB" (LSF/MM/BPF 2020, `slides
+      <https://docs.google.com/presentation/d/1w2zlpGWV7JUhHYd37El_AUZzyUNSvDfktrF5MJ5G8Bs/edit#slide=id.g746fc02b5b_2_0>`__)
+

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -37,6 +37,7 @@ Elasticsearch
 FIt
 Facebook
 Fastabend
+Fosdem
 GCE
 Gartrell
 Geneve

--- a/FURTHER_READINGS.rst
+++ b/FURTHER_READINGS.rst
@@ -17,6 +17,10 @@ Related Material
 Presentations
 -------------
 
+* Fosdem, Brussels, 2020 - BPF as a revolutionary technology for the container landscape:
+  `Slides <https://docs.google.com/presentation/d/1VOUcoIxgM_c6M_zAV1dLlRCjyYCMdR3tJv6CEdfLMh8/edit#slide=id.g7055f48ba8_0_0>`__, `Video <https://fosdem.org/2020/schedule/event/containers_bpf/>`__
+* KubeCon, North America 2019 - Liberating Kubernetes from kube-proxy and iptables:
+  `Slides <https://docs.google.com/presentation/d/1cZJ-pcwB9WG88wzhDm2jxQY4Sh8adYg0-N3qWQ8593I/edit#slide=id.g7055f48ba8_0_0>`__, `Video <https://www.youtube.com/watch?v=bIRwSIwNHC0>`__
 * KubeCon, Europe 2019 - Using eBPF to Bring Kubernetes-Aware Security to the Linux Kernel:
   `Video <https://www.youtube.com/watch?v=7PXQB-1U380>`__
 * KubeCon, Europe 2019 - Transparent Chaos Testing with Envoy , Cilium and BPF:


### PR DESCRIPTION
The added links contain useful information for readers who want to know about low-level details of the kube-proxy replacement.

Also, update `FURTHER_READINGS.md`.