### PR TITLE
ci/hubble: Fully remove Cilium installation

### DIFF
--- a/test/k8sT/hubble.go
+++ b/test/k8sT/hubble.go
@@ -144,7 +144,7 @@ var _ = Describe("K8sHubbleTest", func() {
 	})
 
 	AfterAll(func() {
-		kubectl.DeleteCiliumDS()
+		kubectl.Delete(ciliumFilename)
 		ExpectAllPodsTerminated(kubectl)
 		kubectl.CloseSSHClient()
 	})


### PR DESCRIPTION
We are generating the Cilium YAML which contains more pods than just the
Cilium DaemonSet (the `hubble-cli` DaemonSet in this case). Therefore, we
should also remove everything we generate.