### PR TITLE
ci: remove correct temporary config file

### DIFF
--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -890,7 +890,7 @@ INITSYSTEM=SYSTEMD`
 	if err != nil {
 		return err
 	}
-	defer os.Remove("cilium")
+	defer os.Remove(ciliumConfig)
 
 	confPath := filepath.Join("/home/vagrant/go/src/github.com/cilium/cilium/test", ciliumConfig)
 	res := s.Exec(fmt.Sprintf("sudo cp %s /etc/sysconfig/cilium", confPath))


### PR DESCRIPTION
It seems like 44fa06a changed name of
temporary config file, while still removing the old filename. This change fixes
it.