### PR TITLE
k8s: Initialize CRD version

### DIFF
--- a/pkg/k8s/apis/cilium.io/v2/client/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/client/register.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/versioncheck"
 
-	go_version "github.com/blang/semver"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -105,7 +104,7 @@ var (
 	//   aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 	AddToScheme = localSchemeBuilder.AddToScheme
 
-	comparableCRDSchemaVersion go_version.Version
+	comparableCRDSchemaVersion = versioncheck.MustVersion(CustomResourceDefinitionSchemaVersion)
 )
 
 // CreateCustomResourceDefinitions creates our CRD objects in the kubernetes


### PR DESCRIPTION
Initialize CRD version so that we'll detect when CRDs must be
updated. When uninitialized, the version ("0.0.0") is always lower
than the one in the cluster, so we never update CRDs.

Fixes: #11077
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
