### PR TITLE
test/bpf: Fix BPF unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 
 language: go
 
-dist: trusty
+dist: bionic
 sudo: required
 
 go:

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -2,10 +2,10 @@
 
 set -o errexit
 
-llc --version
-
 export CFLAGS="-Werror"
 export CGO_CFLAGS="-DCI_BUILD"
+export CLANG="clang-10"
+export LLC="llc-10"
 
 make unit-tests
 

--- a/.travis/prepare.sh
+++ b/.travis/prepare.sh
@@ -1,35 +1,14 @@
 #!/bin/bash
 
-CLANG_VERSION=3.8.1
+cd ../..
+mkdir cilium
+mv pchaigno/cilium cilium/cilium
+cd cilium/cilium
 
-function setup_env() {
-case `uname -m` in
-  'x86_64' )
-    CLANG_DIR="clang+llvm-$CLANG_VERSION-x86_64-linux-gnu-ubuntu-14.04"
-    ;;
-  'aarch64' )
-    CLANG_DIR="clang+llvm-$CLANG_VERSION-aarch64-linux-gnu"
-    ;;
-esac
-}
-
-function install_clang() {
-  CLANG_FILE="$CLANG_DIR.tar.xz"
-  CLANG_URL="http://releases.llvm.org/$CLANG_VERSION/$CLANG_FILE"
-
-  wget -nv $CLANG_URL
-  sudo rm -rf /usr/local/clang
-  sudo mkdir -p /usr/local
-  sudo tar -C /usr/local -xJf $CLANG_FILE
-  sudo ln -s /usr/local/$CLANG_DIR /usr/local/clang
-  rm $CLANG_FILE
-}
-
-setup_env
-install_clang
-
-NEWPATH="/usr/local/clang/bin"
-export PATH="$NEWPATH:$PATH"
+curl https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+sudo apt-add-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main"
+sudo apt-get -qq update
+sudo apt-get install -y clang-10 llvm-10
 
 # disable go modules to avoid downloading all dependencies when doing go get
 GO111MODULE=off go get golang.org/x/tools/cmd/cover

--- a/test/bpf/Makefile
+++ b/test/bpf/Makefile
@@ -4,8 +4,7 @@
 include ../../Makefile.defs
 
 FLAGS := -I../../bpf/ -I../../bpf/include -I. -D__NR_CPUS__=$(shell nproc) -O2
-FLAGS_GCC := -Wno-builtin-declaration-mismatch
-FLAGS_CLANG :=
+FLAGS_CLANG := -Wno-gnu-variable-sized-type-not-at-end
 
 BPF_CC_FLAGS := ${FLAGS} -target bpf -emit-llvm
 BPF_LLC_FLAGS := -march=bpf -mcpu=probe -filetype=obj
@@ -13,7 +12,6 @@ BPF_LLC_FLAGS := -march=bpf -mcpu=probe -filetype=obj
 LIB := $(shell find ../../bpf/ -name '*.h')
 
 CLANG ?= $(QUIET) clang
-GCC ?= $(QUIET) gcc
 LLC ?= llc
 
 BPF_TARGETS := elf-demo.o
@@ -26,7 +24,7 @@ elf-demo.o: elf-demo.c
 
 %: %.c $(LIB)
 	@$(ECHO_CC)
-	$(GCC) ${FLAGS_GCC} ${FLAGS} -I../../bpf/ $< -o $@
+	$(CLANG) ${FLAGS_CLANG} ${FLAGS} -I../../bpf/ $< -o $@
 
 clean:
 	@$(ECHO_CLEAN)


### PR DESCRIPTION
The new BPF builtin replacements are only enabled when Clang >=10 is used. So the associated unit tests currently always pass. We therefore need to:
- compile the BPF unit tests with Clang to test that code;
- update the Clang version used in Travis CI.

I tested that these changes fix the unit tests in Travis CI by introducing an error in the builtin replacements in a separate branch; the test results can be observed [here](https://travis-ci.com/github/cilium/cilium/builds/161979402).

Fixes: #11089