### PR TITLE
RenderTemplateToFile writes file to node

### DIFF
--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -29,7 +29,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/test/config"
-	"github.com/cilium/cilium/test/ginkgo-ext"
+	ginkgoext "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers/logutils"
 
 	"github.com/sirupsen/logrus"
@@ -552,7 +552,7 @@ func (s *SSHMeta) PolicyImport(path string) error {
 func (s *SSHMeta) PolicyRenderAndImport(policy string) (int, error) {
 	filename := fmt.Sprintf("policy_%s.json", MakeUID())
 	s.logger.Debugf("PolicyRenderAndImport: render policy to '%s'", filename)
-	err := RenderTemplateToFile(filename, policy, os.ModePerm)
+	err := s.RenderTemplateToFile(filename, policy, os.ModePerm)
 	if err != nil {
 		s.logger.Errorf("PolicyRenderAndImport: cannot create policy file on '%s'", filename)
 		return 0, fmt.Errorf("cannot render the policy:  %s", err)
@@ -886,11 +886,10 @@ CILIUM_OPTS=--kvstore consul --kvstore-opt consul.address=127.0.0.1:8500 --debug
 INITSYSTEM=SYSTEMD`
 
 	ciliumConfig := "cilium.conf.ginkgo"
-	err := RenderTemplateToFile(ciliumConfig, fmt.Sprintf(systemdTemplate, ciliumOpts), os.ModePerm)
+	err := s.RenderTemplateToFile(ciliumConfig, fmt.Sprintf(systemdTemplate, ciliumOpts), os.ModePerm)
 	if err != nil {
 		return err
 	}
-	defer os.Remove(ciliumConfig)
 
 	confPath := filepath.Join("/home/vagrant/go/src/github.com/cilium/cilium/test", ciliumConfig)
 	res := s.Exec(fmt.Sprintf("sudo cp %s /etc/sysconfig/cilium", confPath))

--- a/test/helpers/local_node.go
+++ b/test/helpers/local_node.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -47,6 +48,7 @@ type Executor interface {
 	ExecuteContext(ctx context.Context, cmd string, stdout io.Writer, stderr io.Writer) error
 	String() string
 	BasePath() string
+	RenderTemplateToFile(filename string, tmplt string, perm os.FileMode) error
 	setBasePath()
 
 	Logger() *logrus.Entry
@@ -250,4 +252,20 @@ func (s *LocalExecutor) ExecInBackground(ctx context.Context, cmd string, option
 
 func (s *LocalExecutor) BasePath() string {
 	return s.basePath
+}
+
+// RenderTemplateToFile renders a text/template string into a target filename
+// with specific persmisions. Returns an error if the template cannot be
+// validated or the file cannot be created.
+func (s *LocalExecutor) RenderTemplateToFile(filename string, tmplt string, perm os.FileMode) error {
+	content, err := RenderTemplate(tmplt)
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(filename, content.Bytes(), perm)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/test/helpers/policygen/models.go
+++ b/test/helpers/policygen/models.go
@@ -250,7 +250,7 @@ func (t *Target) CreateApplyManifest(spec *TestSpec, base string) error {
 		if err != nil {
 			return fmt.Errorf("cannot render template: %s", err)
 		}
-		err = helpers.RenderTemplateToFile(t.GetManifestName(spec), data.String(), os.ModePerm)
+		err = spec.Kub.RenderTemplateToFile(t.GetManifestName(spec), data.String(), os.ModePerm)
 		if err != nil {
 			return err
 		}
@@ -286,7 +286,7 @@ func (t *Target) CreateApplyManifest(spec *TestSpec, base string) error {
 			return fmt.Errorf("cannot render template: %s", err)
 		}
 
-		err = helpers.RenderTemplateToFile(t.GetManifestName(spec), data.String(), os.ModePerm)
+		err = spec.Kub.RenderTemplateToFile(t.GetManifestName(spec), data.String(), os.ModePerm)
 		if err != nil {
 			return err
 		}
@@ -473,7 +473,7 @@ spec:
     ports:
       - containerPort: 80`
 
-	err := helpers.RenderTemplateToFile(
+	err := t.Kub.RenderTemplateToFile(
 		t.GetManifestName(),
 		fmt.Sprintf(manifest, t.Prefix, t.SrcPod, t.DestPod, constants.AlpineCurlImage, constants.HttpdImage),
 		os.ModePerm)

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -83,25 +83,19 @@ func MakeUID() string {
 	return fmt.Sprintf("%08x", randGen.Uint32())
 }
 
-// RenderTemplateToFile renders a text/template string into a target filename
-// with specific persmisions. Returns eturn an error if the template cannot be
-// validated or the file cannot be created.
-func RenderTemplateToFile(filename string, tmplt string, perm os.FileMode) error {
+// RenderTemplate renders a text/template string into a buffer.
+// Returns eturn an error if the template cannot be validated.
+func RenderTemplate(tmplt string) (*bytes.Buffer, error) {
 	t, err := template.New("").Parse(tmplt)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	content := new(bytes.Buffer)
 	err = t.Execute(content, nil)
 	if err != nil {
-		return err
+		return nil, err
 	}
-
-	err = ioutil.WriteFile(filename, content.Bytes(), perm)
-	if err != nil {
-		return err
-	}
-	return nil
+	return content, nil
 }
 
 // TimeoutConfig represents the configuration for the timeout of a command.

--- a/test/runtime/Policies.go
+++ b/test/runtime/Policies.go
@@ -1679,7 +1679,7 @@ var _ = Describe("RuntimePolicyImportTests", func() {
 	It("Invalid Policies", func() {
 
 		testInvalidPolicy := func(data string) {
-			err := helpers.RenderTemplateToFile(invalidJSON, data, 0777)
+			err := vm.RenderTemplateToFile(invalidJSON, data, 0777)
 			Expect(err).Should(BeNil())
 
 			path := vm.GetFilePath(invalidJSON)
@@ -1712,7 +1712,7 @@ var _ = Describe("RuntimePolicyImportTests", func() {
 		)
 
 		BeforeEach(func() {
-			err := helpers.RenderTemplateToFile(policyJSON, policy, 0777)
+			err := vm.RenderTemplateToFile(policyJSON, policy, 0777)
 			Expect(err).Should(BeNil())
 
 			path := vm.GetFilePath(policyJSON)

--- a/test/runtime/fqdn.go
+++ b/test/runtime/fqdn.go
@@ -195,12 +195,12 @@ var _ = Describe("RuntimeFQDNPolicies", func() {
 		}
 
 		bindConfig := fmt.Sprintf(bindCiliumTestTemplate, getMapValues(worldIps)...)
-		err := helpers.RenderTemplateToFile(bindDBCilium, bindConfig, os.ModePerm)
+		err := vm.RenderTemplateToFile(bindDBCilium, bindConfig, os.ModePerm)
 		Expect(err).To(BeNil(), "bind file can't be created")
 
 		// // Installed DNSSEC domain
 		bindConfig = fmt.Sprintf(bindDNSSECTestTemplate, getMapValues(worldIps)...)
-		err = helpers.RenderTemplateToFile(bindDBDNSSSEC, bindConfig, os.ModePerm)
+		err = vm.RenderTemplateToFile(bindDBDNSSSEC, bindConfig, os.ModePerm)
 		Expect(err).To(BeNil(), "bind file can't be created")
 
 		for name, image := range ciliumOutsideImages {
@@ -212,10 +212,10 @@ var _ = Describe("RuntimeFQDNPolicies", func() {
 			outsideIps[name] = ip.String()
 		}
 		bindConfig = fmt.Sprintf(bindOutsideTestTemplate, getMapValues(outsideIps)...)
-		err = helpers.RenderTemplateToFile(bindDBOutside, bindConfig, os.ModePerm)
+		err = vm.RenderTemplateToFile(bindDBOutside, bindConfig, os.ModePerm)
 		Expect(err).To(BeNil(), "bind file can't be created")
 
-		err = helpers.RenderTemplateToFile(bindNamedConf, bind9ZoneConfig, os.ModePerm)
+		err = vm.RenderTemplateToFile(bindNamedConf, bind9ZoneConfig, os.ModePerm)
 		Expect(err).To(BeNil(), "Bind named.conf  local file can't be created")
 
 		vm.ExecWithSudo("mkdir -m777 -p /data")


### PR DESCRIPTION
RenderTemplateToFile saved the file to the host machine which was not ideal because it relied on NFS to sync the file it generated to the VM where tests were run. This patch fixes this by saving the file directly to the VM via ssh.

Signed-off-by: David Chen <yudechen@google.com>