### PR TITLE
Clean up stale ENI rules upon endpoint deletion

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -68,6 +68,7 @@ require (
 	github.com/spf13/viper v1.6.1
 	github.com/stretchr/testify v1.4.0
 	github.com/vishvananda/netlink v1.1.1-0.20200210222539-bfba8e4149db
+	github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df
 	go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738
 	go.uber.org/goleak v1.0.0
 	golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975

--- a/pkg/datapath/linux/linux_defaults/linux_defaults.go
+++ b/pkg/datapath/linux/linux_defaults/linux_defaults.go
@@ -37,6 +37,15 @@ const (
 	// IPSecProtocolID IP protocol ID for IPSec defined in RFC4303
 	RouteProtocolIPSec = 50
 
+	// RulePriorityIngress is the priority of the rule used for ingress routing
+	// of endpoints. This priority is after encryption and proxy rules, and
+	// before the local table priority.
+	RulePriorityIngress = 20
+
+	// RulePriorityEgress is the priority of the rule used for egress routing
+	// of endpoints. This priority is after the local table priority.
+	RulePriorityEgress = 110
+
 	// TunnelDeviceName the default name of the tunnel device when using vxlan
 	TunnelDeviceName = "cilium_vxlan"
 

--- a/pkg/datapath/linux/route/route_linux.go
+++ b/pkg/datapath/linux/route/route_linux.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -357,6 +358,84 @@ func lookupRule(spec Rule, family int) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+// ListRules will list IP routing rules on Linux, filtered by `filter`. When
+// `filter` is nil, this function will return all rules, "unfiltered". This
+// function is meant to replicate the behavior of `ip rule list`.
+func ListRules(family int, filter *Rule) ([]netlink.Rule, error) {
+	rules, err := netlink.RuleList(family)
+	if err != nil {
+		return nil, err
+	}
+
+	if filter == nil {
+		return rules, nil
+	}
+
+	const (
+		// RT_FILTER_PRIORITY is a flag that can be specified to signal
+		// filtering against rules with 'Priority' specified. Note: this count
+		// starts from where netlink stops, see
+		// https://github.com/vishvananda/netlink/blob/d71301a47b607450337d920f260f3dc76481298e/route_linux.go#L25
+		//
+		// TODO: Remove this function when the upstream PR has been merged:
+		// https://github.com/vishvananda/netlink/pull/538
+		RT_FILTER_PRIORITY uint64 = 1 << (12 + 1 + iota)
+
+		// RT_FILTER_MARK is a flag that can be specified to signal
+		// filtering against rules with 'Mark' specified.
+		RT_FILTER_MARK
+
+		// RT_FILTER_MASK is a flag that can be specified to signal filtering
+		// against rules with 'Mask' specified.
+		RT_FILTER_MASK
+	)
+
+	var mask uint64
+	if filter.From != nil {
+		mask |= netlink.RT_FILTER_SRC
+	}
+	if filter.To != nil {
+		mask |= netlink.RT_FILTER_DST
+	}
+	if filter.Table != 0 {
+		mask |= netlink.RT_FILTER_TABLE
+	}
+	if filter.Priority != 0 {
+		mask |= RT_FILTER_PRIORITY
+	}
+	if filter.Mark != 0 {
+		mask |= RT_FILTER_MARK
+	}
+	if filter.Mask != 0 {
+		mask |= RT_FILTER_MASK
+	}
+
+	candidates := make([]netlink.Rule, 0, len(rules))
+	for _, rule := range rules {
+		switch {
+		case mask&netlink.RT_FILTER_SRC != 0 &&
+			(rule.Src == nil || rule.Src.String() != filter.From.String()):
+			continue
+		case mask&netlink.RT_FILTER_DST != 0 &&
+			(rule.Dst == nil || rule.Dst.String() != filter.To.String()):
+			continue
+		case mask&netlink.RT_FILTER_TABLE != 0 &&
+			filter.Table != unix.RT_TABLE_UNSPEC && rule.Table != filter.Table:
+			continue
+		case mask&RT_FILTER_PRIORITY != 0 && rule.Priority != filter.Priority:
+			continue
+		case mask&RT_FILTER_MARK != 0 && rule.Mark != filter.Mark:
+			continue
+		case mask&RT_FILTER_MASK != 0 && rule.Mask != filter.Mask:
+			continue
+		}
+
+		candidates = append(candidates, rule)
+	}
+
+	return candidates, nil
 }
 
 // ReplaceRule add or replace rule in the routing table using a mark to indicate

--- a/pkg/datapath/linux/route/route_linux.go
+++ b/pkg/datapath/linux/route/route_linux.go
@@ -331,6 +331,42 @@ type Rule struct {
 	Table int
 }
 
+// String returns the string representation of a Rule (adhering to the Stringer
+// interface).
+func (r Rule) String() string {
+	var (
+		str  string
+		from string
+		to   string
+	)
+
+	str += fmt.Sprintf("%d: ", r.Priority)
+
+	if r.From != nil {
+		from = r.From.String()
+	} else {
+		from = "all"
+	}
+
+	if r.To != nil {
+		to = r.To.String()
+	} else {
+		to = "all"
+	}
+
+	if r.Table == unix.RT_TABLE_MAIN {
+		str += fmt.Sprintf("from %s to %s lookup main", from, to)
+	} else {
+		str += fmt.Sprintf("from %s to %s lookup %d", from, to, r.Table)
+	}
+
+	if r.Mark != 0 {
+		str += fmt.Sprintf(" mark 0x%x mask 0x%x", r.Mark, r.Mask)
+	}
+
+	return str
+}
+
 func lookupRule(spec Rule, family int) (bool, error) {
 	rules, err := netlink.RuleList(family)
 	if err != nil {

--- a/pkg/datapath/linux/route/route_linux_test.go
+++ b/pkg/datapath/linux/route/route_linux_test.go
@@ -23,7 +23,9 @@ import (
 
 	"github.com/cilium/cilium/pkg/testutils"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netns"
 	. "gopkg.in/check.v1"
 )
 
@@ -183,4 +185,275 @@ func (p *RouteSuitePrivileged) TestReplaceRule6(c *C) {
 	testReplaceRuleIPv6(c, 0xf00, cidr1, nil, 124)
 	testReplaceRuleIPv6(c, 0, nil, cidr1, 125)
 	testReplaceRuleIPv6(c, 0, cidr1, cidr1, 126)
+}
+
+func (p *RouteSuitePrivileged) TestListRules(c *C) {
+	testListRules4(c)
+	testListRules6(c)
+}
+
+func testListRules4(c *C) {
+	_, fakeIP, _ := net.ParseCIDR("192.0.2.40/32")
+	_, fakeIP2, _ := net.ParseCIDR("192.0.2.60/32")
+
+	runListRules(c, netlink.FAMILY_V4, fakeIP, fakeIP2)
+}
+
+func testListRules6(c *C) {
+	_, fakeIP, _ := net.ParseCIDR("fd44:7089:ff32:712b:4000::/64")
+	_, fakeIP2, _ := net.ParseCIDR("fd44:7089:ff32:712b:8000::/96")
+
+	runListRules(c, netlink.FAMILY_V6, fakeIP, fakeIP2)
+}
+
+func runListRules(c *C, family int, fakeIP, fakeIP2 *net.IPNet) {
+	currentNS, err := netns.Get()
+	c.Assert(err, IsNil)
+	defer func() {
+		c.Assert(netns.Set(currentNS), IsNil)
+		c.Log("Set back to previous network ns")
+	}()
+
+	networkNS, err := netns.New()
+	c.Assert(err, IsNil)
+	c.Log("Inside new network ns")
+	defer func() {
+		c.Assert(networkNS.Close(), IsNil)
+		c.Log("Closed new network ns")
+	}()
+
+	defaultRules, _ := ListRules(family, nil)
+
+	tests := []struct {
+		name       string
+		ruleFilter *Rule
+		preRun     func() *netlink.Rule // Creates sample rule harness
+		postRun    func(*netlink.Rule)  // Deletes sample rule harness
+		setupWant  func(*netlink.Rule) ([]netlink.Rule, bool)
+	}{
+		{
+			name:       "returns all rules",
+			ruleFilter: nil,
+			preRun:     func() *netlink.Rule { return nil },
+			postRun:    func(r *netlink.Rule) {},
+			setupWant: func(_ *netlink.Rule) ([]netlink.Rule, bool) {
+				return defaultRules, false
+			},
+		},
+		{
+			name:       "returns one rule filtered by From",
+			ruleFilter: &Rule{From: fakeIP},
+			preRun: func() *netlink.Rule {
+				r := netlink.NewRule()
+				r.Src = fakeIP
+				r.Priority = 1 // Must add priority and table otherwise it's auto-assigned
+				r.Table = 1
+				addRule(c, r)
+				return r
+			},
+			postRun: func(r *netlink.Rule) { delRule(c, r) },
+			setupWant: func(r *netlink.Rule) ([]netlink.Rule, bool) {
+				return []netlink.Rule{*r}, false
+			},
+		},
+		{
+			name:       "returns one rule filtered by To",
+			ruleFilter: &Rule{To: fakeIP},
+			preRun: func() *netlink.Rule {
+				r := netlink.NewRule()
+				r.Dst = fakeIP
+				r.Priority = 1 // Must add priority and table otherwise it's auto-assigned
+				r.Table = 1
+				addRule(c, r)
+				return r
+			},
+			postRun: func(r *netlink.Rule) { delRule(c, r) },
+			setupWant: func(r *netlink.Rule) ([]netlink.Rule, bool) {
+				return []netlink.Rule{*r}, false
+			},
+		},
+		{
+			name:       "returns two rules filtered by To",
+			ruleFilter: &Rule{To: fakeIP},
+			preRun: func() *netlink.Rule {
+				r := netlink.NewRule()
+				r.Dst = fakeIP
+				r.Priority = 1 // Must add priority and table otherwise it's auto-assigned
+				r.Table = 1
+				addRule(c, r)
+
+				rc := *r // Create almost identical copy
+				rc.Src = fakeIP2
+				addRule(c, &rc)
+
+				return r
+			},
+			postRun: func(r *netlink.Rule) {
+				delRule(c, r)
+
+				rc := *r // Delete the almost identical copy
+				rc.Src = fakeIP2
+				delRule(c, &rc)
+			},
+			setupWant: func(r *netlink.Rule) ([]netlink.Rule, bool) {
+				rs := []netlink.Rule{}
+				rs = append(rs, *r)
+
+				rc := *r // Append the almost identical copy
+				rc.Src = fakeIP2
+				rs = append(rs, rc)
+
+				return rs, false
+			},
+		},
+		{
+			name:       "returns one rule filtered by From when two rules exist",
+			ruleFilter: &Rule{From: fakeIP2},
+			preRun: func() *netlink.Rule {
+				r := netlink.NewRule()
+				r.Dst = fakeIP
+				r.Priority = 1 // Must add priority and table otherwise it's auto-assigned
+				r.Table = 1
+				addRule(c, r)
+
+				rc := *r // Create almost identical copy
+				rc.Src = fakeIP2
+				addRule(c, &rc)
+
+				return r
+			},
+			postRun: func(r *netlink.Rule) {
+				delRule(c, r)
+
+				rc := *r // Delete the almost identical copy
+				rc.Src = fakeIP2
+				delRule(c, &rc)
+			},
+			setupWant: func(r *netlink.Rule) ([]netlink.Rule, bool) {
+				rs := []netlink.Rule{}
+				// Do not append `r`
+
+				rc := *r // Append the almost identical copy
+				rc.Src = fakeIP2
+				rs = append(rs, rc)
+
+				return rs, false
+			},
+		},
+		{
+			name:       "returns rules with specific priority",
+			ruleFilter: &Rule{Priority: 5},
+			preRun: func() *netlink.Rule {
+				r := netlink.NewRule()
+				r.Src = fakeIP
+				r.Priority = 5
+				r.Table = 1
+				addRule(c, r)
+
+				for i := 2; i < 5; i++ {
+					rc := *r // Create almost identical copy
+					rc.Table = i
+					addRule(c, &rc)
+				}
+
+				return r
+			},
+			postRun: func(r *netlink.Rule) {
+				delRule(c, r)
+
+				for i := 2; i < 5; i++ {
+					rc := *r // Delete the almost identical copy
+					rc.Table = i
+					delRule(c, &rc)
+				}
+			},
+			setupWant: func(r *netlink.Rule) ([]netlink.Rule, bool) {
+				rs := []netlink.Rule{}
+				rs = append(rs, *r)
+
+				for i := 2; i < 5; i++ {
+					rc := *r // Append the almost identical copy
+					rc.Table = i
+					rs = append(rs, rc)
+				}
+
+				return rs, false
+			},
+		},
+		{
+			name:       "returns rules filtered by Table",
+			ruleFilter: &Rule{Table: 199},
+			preRun: func() *netlink.Rule {
+				r := netlink.NewRule()
+				r.Src = fakeIP
+				r.Priority = 1 // Must add priority otherwise it's auto-assigned
+				r.Table = 199
+				addRule(c, r)
+				return r
+			},
+			postRun: func(r *netlink.Rule) { delRule(c, r) },
+			setupWant: func(r *netlink.Rule) ([]netlink.Rule, bool) {
+				return []netlink.Rule{*r}, false
+			},
+		},
+		{
+			name:       "returns rules filtered by Mask",
+			ruleFilter: &Rule{Mask: 0x5},
+			preRun: func() *netlink.Rule {
+				r := netlink.NewRule()
+				r.Src = fakeIP
+				r.Priority = 1 // Must add priority and table otherwise it's auto-assigned
+				r.Table = 1
+				r.Mask = 0x5
+				addRule(c, r)
+				return r
+			},
+			postRun: func(r *netlink.Rule) { delRule(c, r) },
+			setupWant: func(r *netlink.Rule) ([]netlink.Rule, bool) {
+				return []netlink.Rule{*r}, false
+			},
+		},
+		{
+			name:       "returns rules filtered by Mark",
+			ruleFilter: &Rule{Mark: 0xbb},
+			preRun: func() *netlink.Rule {
+				r := netlink.NewRule()
+				r.Src = fakeIP
+				r.Priority = 1 // Must add priority, table, mask otherwise it's auto-assigned
+				r.Table = 1
+				r.Mask = 0xff
+				r.Mark = 0xbb
+				addRule(c, r)
+				return r
+			},
+			postRun: func(r *netlink.Rule) { delRule(c, r) },
+			setupWant: func(r *netlink.Rule) ([]netlink.Rule, bool) {
+				return []netlink.Rule{*r}, false
+			},
+		},
+	}
+	for _, tt := range tests {
+		rule := tt.preRun()
+		rules, err := ListRules(family, tt.ruleFilter)
+		tt.postRun(rule)
+
+		wantRules, wantErr := tt.setupWant(rule)
+
+		if diff := cmp.Diff(wantRules, rules); diff != "" {
+			c.Errorf("expected len: %d, got: %d\n%s\n", len(wantRules), len(rules), diff)
+		}
+		c.Assert(err != nil, Equals, wantErr)
+	}
+}
+
+func addRule(c *C, r *netlink.Rule) {
+	if err := netlink.RuleAdd(r); err != nil {
+		c.Logf("Unable to add rule: %v", err)
+	}
+}
+
+func delRule(c *C, r *netlink.Rule) {
+	if err := netlink.RuleDel(r); err != nil {
+		c.Logf("Unable to delete rule: %v", err)
+	}
 }

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/common/addressing"
 	"github.com/cilium/cilium/pkg/annotation"
+	enirouting "github.com/cilium/cilium/pkg/aws/eni/routing"
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/controller"
@@ -2073,6 +2074,21 @@ func (e *Endpoint) Delete(monitor monitorOwner, ipam ipReleaser, manager endpoin
 			if err := ipam.ReleaseIP(e.IPv6.IP()); err != nil {
 				errs = append(errs, fmt.Errorf("unable to release ipv6 address: %s", err))
 			}
+		}
+	}
+
+	if option.Config.IPAM == option.IPAMENI {
+		e.getLogger().WithFields(logrus.Fields{
+			"ep":     e.GetID(),
+			"ipAddr": e.GetIPv4Address(),
+		}).Debug("Deleting endpoint ENI rules")
+
+		// This is a best-effort attempt to cleanup. We expect there to be one
+		// ingress rule and one egress rule. If we find more than one rule in
+		// either case, then the rules will be left as-is because there was
+		// likely manual intervention.
+		if err := enirouting.Delete(e.IPv4.IP()); err != nil {
+			errs = append(errs, fmt.Errorf("unable to delete endpoint ENI rules: %s", err))
 		}
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -519,6 +519,7 @@ github.com/subosito/gotenv
 github.com/vishvananda/netlink
 github.com/vishvananda/netlink/nl
 # github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df
+## explicit
 github.com/vishvananda/netns
 # go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738
 ## explicit


### PR DESCRIPTION
See commit messages, reviewable per-commit.

Note: commits starting with "dropme!" are meant to be dropped for the final change. These changes are pending in #11073. They can be ignored for the review.

TODO:

- [x] Remove `ifindex` from function arg to `enirouting.Delete` (as it is always `-1` anyway)
- [x] Add IPv6 tests for listing rules 
- [x] Rebase on top of master when #11073 is merged and drop "dropme!" commits
- [x] Upstream PR to netlink: https://github.com/vishvananda/netlink/pull/538 :tada: 
- [x] Edit commit before merge to include issue number

Fixes: #11041

```release-note
Remove stale rules for endpoints upon deletion in ENI mode
```
