### PR TITLE
CI: Improve ability to run tests on non-CI clusters

### DIFF
--- a/test/ginkgo-ext/scopes.go
+++ b/test/ginkgo-ext/scopes.go
@@ -159,6 +159,7 @@ func BeforeAll(body func()) bool {
 		currentScope.before = append(currentScope.before, body)
 		return BeforeEach(func() {})
 	}
+
 	return true
 }
 
@@ -568,4 +569,9 @@ func SkipItIf(condition func() bool, text string, body func()) bool {
 	}
 
 	return It(text, body)
+}
+
+// Failf calls Fail with a formatted string
+func Failf(msg string, args ...interface{}) {
+	Fail(fmt.Sprintf(msg, args...))
 }

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -318,6 +318,7 @@ func (kub *Kubectl) DeleteAllNamespacesExcept(except []string) error {
 
 // PrepareCluster will prepare the cluster to run tests. It will:
 // - Delete all existing namespaces
+// - Label all nodes so the tests can use them
 func (kub *Kubectl) PrepareCluster() {
 	ginkgoext.By("Preparing cluster")
 	err := kub.DeleteAllNamespacesExcept([]string{
@@ -330,20 +331,48 @@ func (kub *Kubectl) PrepareCluster() {
 	if err != nil {
 		ginkgoext.Failf("Unable to delete non-essential namespaces: %s", err)
 	}
+
+	ginkgoext.By("Labelling nodes")
+	if err = kub.labelNodes(); err != nil {
+		ginkgoext.Failf("unable label nodes: %s", err)
+	}
 }
 
-// LabelNodes labels nodes in vagrant env. If you are running tests on different cluster you need to label your nodes by yourself
-func (kub *Kubectl) LabelNodes() {
-	kub.ExecMiddle(fmt.Sprintf("%s label --overwrite node k8s1 cilium.io/ci-node=k8s1", KubectlCmd))
-	kub.ExecMiddle(fmt.Sprintf("%s label --overwrite node k8s2 cilium.io/ci-node=k8s2", KubectlCmd))
-	kub.ExecMiddle(fmt.Sprintf("%s label --overwrite node k8s3 cilium.io/ci-node=k8s3", KubectlCmd))
+// labelNodes labels all Kubernetes nodes for use by the CI tests
+func (kub *Kubectl) labelNodes() error {
+	cmd := KubectlCmd + " get nodes -o json | jq -r '[ .items[].metadata.name ]'"
+	res := kub.ExecShort(cmd)
+	if !res.WasSuccessful() {
+		return fmt.Errorf("unable to retrieve all nodes with '%s': %s", cmd, res.OutputPrettyPrint())
+	}
+
+	var nodesList []string
+	if err := res.Unmarshal(&nodesList); err != nil {
+		return fmt.Errorf("unable to unmarshal string slice '%#v': %s", nodesList, err)
+	}
+
+	index := 1
+	for _, nodeName := range nodesList {
+		cmd := fmt.Sprintf("%s label --overwrite node %s cilium.io/ci-node=k8s%d", KubectlCmd, nodeName, index)
+		res := kub.ExecShort(cmd)
+		if !res.WasSuccessful() {
+			return fmt.Errorf("unable to label node with '%s': %s", cmd, res.OutputPrettyPrint())
+		}
+		index++
+	}
 
 	node := GetNodeWithoutCilium()
 	if node != "" {
 		// Prevent scheduling any pods on the node, as it will be used as an external client
 		// to send requests to k8s{1,2}
-		kub.ExecMiddle(fmt.Sprintf("%s taint nodes %s key=value:NoSchedule", KubectlCmd, node))
+		cmd := fmt.Sprintf("%s taint nodes %s key=value:NoSchedule", KubectlCmd, node)
+		res := kub.ExecMiddle(cmd)
+		if !res.WasSuccessful() {
+			return fmt.Errorf("unable to taint node with '%s': %s", cmd, res.OutputPrettyPrint())
+		}
 	}
+
+	return nil
 }
 
 // CepGet returns the endpoint model for the given pod name in the specified

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -288,6 +288,50 @@ func CreateKubectl(vmName string, log *logrus.Entry) (k *Kubectl) {
 	return k
 }
 
+// DeleteAllInNamespace deletes all namespaces except the ones provided in the
+// exception list
+func (kub *Kubectl) DeleteAllNamespacesExcept(except []string) error {
+	cmd := KubectlCmd + " get namespace -o json | jq -r '[ .items[].metadata.name ]'"
+	res := kub.ExecShort(cmd)
+	if !res.WasSuccessful() {
+		return fmt.Errorf("unable to retrieve all namespaces with '%s': %s", cmd, res.OutputPrettyPrint())
+	}
+
+	var namespaceList []string
+	if err := res.Unmarshal(&namespaceList); err != nil {
+		return fmt.Errorf("unable to unmarshal string slice '%#v': %s", namespaceList, err)
+	}
+
+	exceptMap := map[string]struct{}{}
+	for _, e := range except {
+		exceptMap[e] = struct{}{}
+	}
+
+	for _, namespace := range namespaceList {
+		if _, ok := exceptMap[namespace]; !ok {
+			kub.NamespaceDelete(namespace)
+		}
+	}
+
+	return nil
+}
+
+// PrepareCluster will prepare the cluster to run tests. It will:
+// - Delete all existing namespaces
+func (kub *Kubectl) PrepareCluster() {
+	ginkgoext.By("Preparing cluster")
+	err := kub.DeleteAllNamespacesExcept([]string{
+		KubeSystemNamespace,
+		GetCiliumNamespace(GetCurrentIntegration()),
+		"default",
+		"kube-node-lease",
+		"kube-public",
+	})
+	if err != nil {
+		ginkgoext.Failf("Unable to delete non-essential namespaces: %s", err)
+	}
+}
+
 // LabelNodes labels nodes in vagrant env. If you are running tests on different cluster you need to label your nodes by yourself
 func (kub *Kubectl) LabelNodes() {
 	kub.ExecMiddle(fmt.Sprintf("%s label --overwrite node k8s1 cilium.io/ci-node=k8s1", KubectlCmd))
@@ -867,11 +911,10 @@ func (kub *Kubectl) NamespaceCreate(name string) *CmdRes {
 // NamespaceDelete deletes a given Kubernetes namespace
 func (kub *Kubectl) NamespaceDelete(name string) *CmdRes {
 	ginkgoext.By("Deleting namespace %s", name)
-	res := kub.DeleteAllInNamespace(name)
-	if !res.WasSuccessful() {
-		kub.Logger().Infof("Error while deleting all objects from %s ns: %s", name, res.GetError())
+	if err := kub.DeleteAllInNamespace(name); err != nil {
+		kub.Logger().Infof("Error while deleting all objects from %s ns: %s", name, err)
 	}
-	res = kub.ExecShort(fmt.Sprintf("%s delete namespace %s", KubectlCmd, name))
+	res := kub.ExecShort(fmt.Sprintf("%s delete namespace %s", KubectlCmd, name))
 	if !res.WasSuccessful() {
 		kub.Logger().Infof("Error while deleting ns %s: %s", name, res.GetError())
 	}
@@ -881,10 +924,14 @@ func (kub *Kubectl) NamespaceDelete(name string) *CmdRes {
 }
 
 // DeleteAllInNamespace deletes all k8s objects in a namespace
-func (kub *Kubectl) DeleteAllInNamespace(name string) *CmdRes {
+func (kub *Kubectl) DeleteAllInNamespace(name string) error {
 	// we are getting all namespaced resources from k8s apiserver, and delete all objects of these types in a provided namespace
-	return kub.ExecShort(fmt.Sprintf("%s delete $(%s api-resources --namespaced=true --verbs=delete -o name | tr '\n' ',' | sed -e 's/,$//') -n %s --all",
-		KubectlCmd, KubectlCmd, name))
+	cmd := fmt.Sprintf("%s delete $(%s api-resources --namespaced=true --verbs=delete -o name | tr '\n' ',' | sed -e 's/,$//') -n %s --all", KubectlCmd, KubectlCmd, name)
+	if res := kub.ExecShort(cmd); !res.WasSuccessful() {
+		return fmt.Errorf("unable to run '%s': %s", cmd, res.OutputPrettyPrint())
+	}
+
+	return nil
 }
 
 // NamespaceLabel sets a label in a Kubernetes namespace

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -275,8 +275,6 @@ var _ = BeforeAll(func() {
 		kubectl := helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 		kubectl.PrepareCluster()
 
-		kubectl.LabelNodes()
-
 		kubectl.ApplyDefault(kubectl.GetFilePath("../examples/kubernetes/addons/prometheus/prometheus.yaml"))
 
 		go kubectl.PprofReport()

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -273,6 +273,7 @@ var _ = BeforeAll(func() {
 			}
 		}
 		kubectl := helpers.CreateKubectl(helpers.K8s1VMName(), logger)
+		kubectl.PrepareCluster()
 
 		kubectl.LabelNodes()
 


### PR DESCRIPTION
The current tests assume that certain operations are performed in scripts during cluster selection time. This makes it harder to run individual tests on a custom cluster instead of using the standard CI clusters.

This PR achieves two things:
* Deletes all non-essential namespaces (kube-system, default, cilium, ...) before the first test
* Decouples node-labeling from node naming