### PR TITLE
hubble-relay: add initial multi-node support

### DIFF
--- a/api/v1/observer/observer.pb.go
+++ b/api/v1/observer/observer.pb.go
@@ -188,12 +188,20 @@ var xxx_messageInfo_ServerStatusRequest proto.InternalMessageInfo
 
 type ServerStatusResponse struct {
 	// number of currently captured flows
+	// In a multi-node context, this is the cumulative count of all captured
+	// flows.
 	NumFlows uint64 `protobuf:"varint,1,opt,name=num_flows,json=numFlows,proto3" json:"num_flows,omitempty"`
 	// maximum capacity of the ring buffer
+	// In a multi-node context, this is the aggregation of all ring buffers
+	// capacities.
 	MaxFlows uint64 `protobuf:"varint,2,opt,name=max_flows,json=maxFlows,proto3" json:"max_flows,omitempty"`
 	// total amount of flows observed since the observer was started
+	// In a multi-node context, this is the aggregation of all flows that have
+	// been seen.
 	SeenFlows uint64 `protobuf:"varint,3,opt,name=seen_flows,json=seenFlows,proto3" json:"seen_flows,omitempty"`
 	// uptime of this observer instance in nanoseconds
+	// In a multi-node context, this field corresponds to the uptime of the
+	// longest living instance.
 	UptimeNs             uint64   `protobuf:"varint,4,opt,name=uptime_ns,json=uptimeNs,proto3" json:"uptime_ns,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`

--- a/api/v1/observer/observer.proto
+++ b/api/v1/observer/observer.proto
@@ -33,15 +33,23 @@ message ServerStatusRequest {}
 
 message ServerStatusResponse {
     // number of currently captured flows
+    // In a multi-node context, this is the cumulative count of all captured
+    // flows.
     uint64 num_flows = 1;
 
     // maximum capacity of the ring buffer
+    // In a multi-node context, this is the aggregation of all ring buffers
+    // capacities.
     uint64 max_flows = 2;
 
     // total amount of flows observed since the observer was started
+    // In a multi-node context, this is the aggregation of all flows that have
+    // been seen.
     uint64 seen_flows = 3;
 
     // uptime of this observer instance in nanoseconds
+    // In a multi-node context, this field corresponds to the uptime of the
+    // longest living instance.
     uint64 uptime_ns = 4;
 }
 

--- a/hubble-relay/cmd/serve/serve.go
+++ b/hubble-relay/cmd/serve/serve.go
@@ -27,7 +27,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var flag struct {
+type flags struct {
 	debug         bool
 	dialTimeout   time.Duration
 	listenAddress string
@@ -37,30 +37,45 @@ var flag struct {
 
 // New creates a new serve command.
 func New() *cobra.Command {
+	var f flags
 	cmd := &cobra.Command{
 		Use:   "serve",
 		Short: "Run the gRPC proxy server",
 		Long:  `Run the gRPC proxy server.`,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			return runServe()
+			return runServe(f)
 		},
 	}
-	cmd.Flags().BoolVarP(&flag.debug, "debug", "D", false, "Run in debug mode")
-	cmd.Flags().DurationVar(&flag.dialTimeout, "dial-timeout", relayoption.Default.DialTimeout, "Dial timeout when connecting to hubble peers")
-	cmd.Flags().DurationVar(&flag.retryTimeout, "retry-timeout", relayoption.Default.RetryTimeout, "Time to wait before attempting to reconnect to a hubble peer when the connection is lost")
-	cmd.Flags().StringVar(&flag.listenAddress, "listen-address", relayoption.Default.ListenAddress, "Address on which to listen")
-	cmd.Flags().StringVar(&flag.peerService, "peer-service", relayoption.Default.HubbleTarget, "Address of the server that implements the peer gRPC service")
+	cmd.Flags().BoolVarP(
+		&f.debug, "debug", "D", false, "Run in debug mode",
+	)
+	cmd.Flags().DurationVar(
+		&f.dialTimeout, "dial-timeout",
+		relayoption.Default.DialTimeout,
+		"Dial timeout when connecting to hubble peers")
+	cmd.Flags().DurationVar(
+		&f.retryTimeout, "retry-timeout",
+		relayoption.Default.RetryTimeout,
+		"Time to wait before attempting to reconnect to a hubble peer when the connection is lost")
+	cmd.Flags().StringVar(
+		&f.listenAddress, "listen-address",
+		relayoption.Default.ListenAddress,
+		"Address on which to listen")
+	cmd.Flags().StringVar(
+		&f.peerService, "peer-service",
+		relayoption.Default.HubbleTarget,
+		"Address of the server that implements the peer gRPC service")
 	return cmd
 }
 
-func runServe() error {
+func runServe(f flags) error {
 	opts := []relayoption.Option{
-		relayoption.WithDialTimeout(flag.dialTimeout),
-		relayoption.WithHubbleTarget(flag.peerService),
-		relayoption.WithListenAddress(flag.listenAddress),
-		relayoption.WithRetryTimeout(flag.retryTimeout),
+		relayoption.WithDialTimeout(f.dialTimeout),
+		relayoption.WithHubbleTarget(f.peerService),
+		relayoption.WithListenAddress(f.listenAddress),
+		relayoption.WithRetryTimeout(f.retryTimeout),
 	}
-	if flag.debug {
+	if f.debug {
 		opts = append(opts, relayoption.WithDebug())
 	}
 	srv, err := relay.NewServer(opts...)

--- a/hubble-relay/cmd/serve/serve.go
+++ b/hubble-relay/cmd/serve/serve.go
@@ -28,9 +28,10 @@ import (
 )
 
 var flag struct {
-	debug        bool
-	dialTimeout  time.Duration
-	retryTimeout time.Duration
+	debug         bool
+	dialTimeout   time.Duration
+	listenAddress string
+	retryTimeout  time.Duration
 }
 
 // New creates a new serve command.
@@ -46,12 +47,14 @@ func New() *cobra.Command {
 	cmd.Flags().BoolVarP(&flag.debug, "debug", "D", false, "Run in debug mode")
 	cmd.Flags().DurationVar(&flag.dialTimeout, "dial-timeout", relayoption.Default.DialTimeout, "Dial timeout when connecting to hubble peers")
 	cmd.Flags().DurationVar(&flag.retryTimeout, "retry-timeout", relayoption.Default.RetryTimeout, "Time to wait before attempting to reconnect to a hubble peer when the connection is lost")
+	cmd.Flags().StringVar(&flag.listenAddress, "listen-address", relayoption.Default.ListenAddress, "Address on which to listen")
 	return cmd
 }
 
 func runServe() error {
 	opts := []relayoption.Option{
 		relayoption.WithDialTimeout(flag.dialTimeout),
+		relayoption.WithListenAddress(flag.listenAddress),
 		relayoption.WithRetryTimeout(flag.retryTimeout),
 	}
 	if flag.debug {

--- a/hubble-relay/cmd/serve/serve.go
+++ b/hubble-relay/cmd/serve/serve.go
@@ -31,6 +31,7 @@ var flag struct {
 	debug         bool
 	dialTimeout   time.Duration
 	listenAddress string
+	peerService   string
 	retryTimeout  time.Duration
 }
 
@@ -48,12 +49,14 @@ func New() *cobra.Command {
 	cmd.Flags().DurationVar(&flag.dialTimeout, "dial-timeout", relayoption.Default.DialTimeout, "Dial timeout when connecting to hubble peers")
 	cmd.Flags().DurationVar(&flag.retryTimeout, "retry-timeout", relayoption.Default.RetryTimeout, "Time to wait before attempting to reconnect to a hubble peer when the connection is lost")
 	cmd.Flags().StringVar(&flag.listenAddress, "listen-address", relayoption.Default.ListenAddress, "Address on which to listen")
+	cmd.Flags().StringVar(&flag.peerService, "peer-service", relayoption.Default.HubbleTarget, "Address of the server that implements the peer gRPC service")
 	return cmd
 }
 
 func runServe() error {
 	opts := []relayoption.Option{
 		relayoption.WithDialTimeout(flag.dialTimeout),
+		relayoption.WithHubbleTarget(flag.peerService),
 		relayoption.WithListenAddress(flag.listenAddress),
 		relayoption.WithRetryTimeout(flag.retryTimeout),
 	}

--- a/hubble-relay/cmd/serve/serve.go
+++ b/hubble-relay/cmd/serve/serve.go
@@ -20,14 +20,19 @@ import (
 	"os/signal"
 
 	"github.com/cilium/cilium/pkg/hubble/relay"
+	"github.com/cilium/cilium/pkg/hubble/relay/relayoption"
 	"golang.org/x/sys/unix"
 
 	"github.com/spf13/cobra"
 )
 
+var flag struct {
+	debug bool
+}
+
 // New creates a new serve command.
 func New() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "serve",
 		Short: "Run the gRPC proxy server",
 		Long:  `Run the gRPC proxy server.`,
@@ -35,10 +40,16 @@ func New() *cobra.Command {
 			return runServe()
 		},
 	}
+	cmd.Flags().BoolVarP(&flag.debug, "debug", "D", false, "Run in debug mode")
+	return cmd
 }
 
 func runServe() error {
-	srv, err := relay.NewServer()
+	var opts []relayoption.Option
+	if flag.debug {
+		opts = append(opts, relayoption.WithDebug())
+	}
+	srv, err := relay.NewServer(opts...)
 	if err != nil {
 		return fmt.Errorf("cannot create hubble-relay server: %v", err)
 	}

--- a/pkg/hubble/relay/observer.go
+++ b/pkg/hubble/relay/observer.go
@@ -1,0 +1,190 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package relay
+
+import (
+	"context"
+	"io"
+	"time"
+
+	observerpb "github.com/cilium/cilium/api/v1/observer"
+	"github.com/sirupsen/logrus"
+
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// ensure that Server implements the observer.ObserverServer interface.
+var _ observerpb.ObserverServer = (*Server)(nil)
+
+func newObserverClient(target string, dialTimeout time.Duration) (observerpb.ObserverClient, *grpc.ClientConn, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), dialTimeout)
+	defer cancel()
+	//FIXME: remove WithInsecure once mutual TLS is implemented
+	conn, err := grpc.DialContext(ctx, target, grpc.WithInsecure(), grpc.WithBlock())
+	if err != nil {
+		return nil, nil, err
+	}
+	return observerpb.NewObserverClient(conn), conn, nil
+}
+
+// GetFlows implements observer.ObserverServer.GetFlows by proxying requests to
+// the hubble instance the proxy is connected to.
+func (s *Server) GetFlows(req *observerpb.GetFlowsRequest, stream observerpb.Observer_GetFlowsServer) error {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	g, ctx := errgroup.WithContext(ctx)
+	go func() {
+		select {
+		case <-s.stop:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	//TODO: figure out what makes a reasonnable channel size
+	peers := s.peerList()
+	flows := make(chan *observerpb.GetFlowsResponse, 10*len(peers))
+	for _, p := range peers {
+		p := p
+		g.Go(func() error {
+			//FIXME: establishing a new connection to every peer for every
+			// request is costly. Possible solutions:
+			// - selective connection: only connect to peers that have the
+			//   requested information (it still has the cost of connect/disconnect per
+			//   GetFlows request but it's at least limited in terms of scope).
+			// - Maintain a connection with all peers and reconnect when necessary.
+			cl, conn, err := newObserverClient(p.Address.String(), s.opts.DialTimeout)
+			if err != nil {
+				s.log.WithFields(logrus.Fields{
+					"error": err,
+					"peer":  p,
+				}).Error("Failed to connect to peer")
+				return nil
+			}
+			defer conn.Close()
+			c, err := cl.GetFlows(ctx, req)
+			if err != nil {
+				return err
+			}
+			for {
+				flow, err := c.Recv()
+				switch err {
+				case io.EOF, context.Canceled:
+					return nil
+				case nil:
+					select {
+					case flows <- flow:
+					case <-ctx.Done():
+						return nil
+					}
+				default:
+					if status.Code(err) != codes.Canceled {
+						s.log.WithFields(logrus.Fields{
+							"error": err,
+							"peer":  p,
+						}).Error("Failed to receive flows from peer")
+					}
+					return nil
+				}
+			}
+		})
+	}
+	go func() {
+		g.Wait()
+		close(flows)
+	}()
+	//TODO: flows are sent in the order they are received. One should make use
+	// of pkg/hubble/container/PriorityQueue to re-order flows (to the extent of
+	// what seems reasonnable)
+	for flow := range flows {
+		if err := stream.Send(flow); err != nil {
+			return err
+		}
+	}
+	return g.Wait()
+}
+
+// ServerStatus implements observer.ObserverServer.ServerStatus by aggregating
+// the ServerStatus answer of all hubble peers.
+func (s *Server) ServerStatus(ctx context.Context, req *observerpb.ServerStatusRequest) (*observerpb.ServerStatusResponse, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	g, ctx := errgroup.WithContext(ctx)
+	go func() {
+		select {
+		case <-s.stop:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	peers := s.peerList()
+	statuses := make(chan *observerpb.ServerStatusResponse, len(peers))
+	for _, p := range peers {
+		p := p
+		g.Go(func() error {
+			//FIXME: establishing a new connection to every peer for every
+			// request is costly. Possible solutions:
+			// - selective connection: only connect to peers that have the
+			//   requested information (it still has the cost of connect/disconnect per
+			//   ServerStatus request but it's at least limited in terms of scope).
+			// - Maintain a connection with all peers and reconnect when necessary.
+			cl, conn, err := newObserverClient(p.Address.String(), s.opts.DialTimeout)
+			if err != nil {
+				s.log.WithFields(logrus.Fields{
+					"error": err,
+					"peer":  p,
+				}).Error("Failed to connect to peer")
+				return nil
+			}
+			defer conn.Close()
+			status, err := cl.ServerStatus(ctx, req)
+			if err != nil {
+				s.log.WithFields(logrus.Fields{
+					"error": err,
+					"peer":  p,
+				}).Error("Failed to retrieve server status")
+				return nil
+			}
+			select {
+			case statuses <- status:
+			case <-ctx.Done():
+			}
+			return nil
+		})
+	}
+	go func() {
+		g.Wait()
+		close(statuses)
+	}()
+	resp := &observerpb.ServerStatusResponse{}
+	for status := range statuses {
+		if status == nil {
+			continue
+		}
+		resp.MaxFlows += status.MaxFlows
+		resp.NumFlows += status.NumFlows
+		resp.SeenFlows += status.SeenFlows
+		// use the oldest uptime as a reference for the uptime as cumulating
+		// values would make little sense
+		if resp.UptimeNs == 0 || resp.UptimeNs > status.UptimeNs {
+			resp.UptimeNs = status.UptimeNs
+		}
+	}
+	return resp, g.Wait()
+}

--- a/pkg/hubble/relay/peer.go
+++ b/pkg/hubble/relay/peer.go
@@ -1,0 +1,144 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package relay
+
+import (
+	"context"
+	"time"
+
+	peerpb "github.com/cilium/cilium/api/v1/peer"
+	"github.com/cilium/cilium/pkg/hubble/peer"
+
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+)
+
+func newPeerClient(target string, dialTimeout time.Duration) (peerpb.PeerClient, *grpc.ClientConn, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), dialTimeout)
+	defer cancel()
+	// the connection is assumed to be local
+	conn, err := grpc.DialContext(ctx, target, grpc.WithInsecure(), grpc.WithBlock())
+	if err != nil {
+		return nil, nil, err
+	}
+	return peerpb.NewPeerClient(conn), conn, nil
+}
+
+func (s *Server) syncPeers() {
+	ctx, cancel := context.WithCancel(context.Background())
+connect:
+	for {
+		cl, conn, err := newPeerClient(s.opts.HubbleTarget, s.opts.DialTimeout)
+		if err != nil {
+			s.log.WithFields(logrus.Fields{
+				"error":        err,
+				"dial timeout": s.opts.DialTimeout,
+			}).Warning("Failed to create peer client for peers synchronization; will try again after the timeout has expired")
+			select {
+			case <-s.stop:
+				cancel()
+				return
+			case <-time.After(s.opts.RetryTimeout):
+				continue
+			}
+		}
+		client, err := cl.Notify(ctx, &peerpb.NotifyRequest{})
+		if err != nil {
+			conn.Close()
+			s.log.WithFields(logrus.Fields{
+				"error":              err,
+				"connection timeout": s.opts.RetryTimeout,
+			}).Warning("Failed to create peer notify client for peers change notification; will try again after the timeout has expired")
+			select {
+			case <-s.stop:
+				cancel()
+				return
+			case <-time.After(s.opts.RetryTimeout):
+				continue
+			}
+		}
+		for {
+			select {
+			case <-s.stop:
+				conn.Close()
+				cancel()
+				return
+			default:
+			}
+			cn, err := client.Recv()
+			if err != nil {
+				conn.Close()
+				s.log.WithFields(logrus.Fields{
+					"error":              err,
+					"connection timeout": s.opts.RetryTimeout,
+				}).Warning("Error while receiving peer change notification; will try again after the timeout has expired")
+				select {
+				case <-s.stop:
+					cancel()
+					return
+				case <-time.After(s.opts.RetryTimeout):
+					continue connect
+				}
+			}
+			s.log.WithField("change notification", cn).Debug("Received peer change notification")
+			p := peer.FromChangeNotification(cn)
+			switch cn.GetType() {
+			case peerpb.ChangeNotificationType_PEER_ADDED:
+				s.addPeer(p)
+			case peerpb.ChangeNotificationType_PEER_DELETED:
+				s.deletePeer(p)
+			case peerpb.ChangeNotificationType_PEER_UPDATED:
+				s.updatePeer(p)
+			}
+		}
+	}
+}
+
+func (s *Server) addPeer(p *peer.Peer) {
+	if p == nil {
+		return
+	}
+	s.mu.Lock()
+	s.peers[p.Name] = *p
+	s.mu.Unlock()
+}
+
+func (s *Server) deletePeer(p *peer.Peer) {
+	if p == nil {
+		return
+	}
+	s.mu.Lock()
+	delete(s.peers, p.Name)
+	s.mu.Unlock()
+}
+
+func (s *Server) updatePeer(p *peer.Peer) {
+	if p == nil {
+		return
+	}
+	s.mu.Lock()
+	s.peers[p.Name] = *p
+	s.mu.Unlock()
+}
+
+func (s *Server) peerList() []peer.Peer {
+	s.mu.Lock()
+	p := make([]peer.Peer, 0, len(s.peers))
+	for _, v := range s.peers {
+		p = append(p, v)
+	}
+	s.mu.Unlock()
+	return p
+}

--- a/pkg/hubble/relay/relayoption/defaults.go
+++ b/pkg/hubble/relay/relayoption/defaults.go
@@ -26,6 +26,7 @@ import (
 var Default = Options{
 	HubbleTarget:  "unix://" + defaults.HubbleSockPath,
 	DialTimeout:   5 * time.Second,
+	RetryTimeout:  30 * time.Second,
 	ListenAddress: fmt.Sprintf(":%d", hubbledefaults.RelayPort),
 	Debug:         false,
 }

--- a/pkg/hubble/relay/relayoption/defaults.go
+++ b/pkg/hubble/relay/relayoption/defaults.go
@@ -27,4 +27,5 @@ var Default = Options{
 	HubbleTarget:  "unix://" + defaults.HubbleSockPath,
 	DialTimeout:   5 * time.Second,
 	ListenAddress: fmt.Sprintf(":%d", hubbledefaults.RelayPort),
+	Debug:         false,
 }

--- a/pkg/hubble/relay/relayoption/option.go
+++ b/pkg/hubble/relay/relayoption/option.go
@@ -24,6 +24,7 @@ type Options struct {
 	HubbleTarget  string
 	DialTimeout   time.Duration
 	ListenAddress string
+	Debug         bool
 }
 
 // Option customizes the configuration of the hubble-relay server.
@@ -53,6 +54,14 @@ func WithDialTimeout(t time.Duration) Option {
 func WithListenAddress(a string) Option {
 	return func(o *Options) error {
 		o.ListenAddress = a
+		return nil
+	}
+}
+
+// WithDebug enables debug mode.
+func WithDebug() Option {
+	return func(o *Options) error {
+		o.Debug = true
 		return nil
 	}
 }

--- a/pkg/hubble/relay/relayoption/option.go
+++ b/pkg/hubble/relay/relayoption/option.go
@@ -23,6 +23,7 @@ import (
 type Options struct {
 	HubbleTarget  string
 	DialTimeout   time.Duration
+	RetryTimeout  time.Duration
 	ListenAddress string
 	Debug         bool
 }
@@ -46,6 +47,15 @@ func WithHubbleTarget(t string) Option {
 func WithDialTimeout(t time.Duration) Option {
 	return func(o *Options) error {
 		o.DialTimeout = t
+		return nil
+	}
+}
+
+// WithRetryTimeout sets the duration to wait before attempting to re-connect
+// to a hubble peer when the connection is lost.
+func WithRetryTimeout(t time.Duration) Option {
+	return func(o *Options) error {
+		o.RetryTimeout = t
 		return nil
 	}
 }

--- a/pkg/hubble/relay/relayoption/option.go
+++ b/pkg/hubble/relay/relayoption/option.go
@@ -31,7 +31,8 @@ type Options struct {
 // Option customizes the configuration of the hubble-relay server.
 type Option func(o *Options) error
 
-// WithHubbleTarget sets the URL of the hubble server instance to connect to.
+// WithHubbleTarget sets the URL of the local hubble instance to connect to.
+// This target MUST implement the Peer service.
 func WithHubbleTarget(t string) Option {
 	return func(o *Options) error {
 		if !strings.HasPrefix(t, "unix://") {
@@ -43,7 +44,7 @@ func WithHubbleTarget(t string) Option {
 }
 
 // WithDialTimeout sets the dial timeout that is used when establishing a
-// connection to the hubble server instance that is being proxied.
+// connection to a hubble peer.
 func WithDialTimeout(t time.Duration) Option {
 	return func(o *Options) error {
 		o.DialTimeout = t

--- a/pkg/hubble/relay/server.go
+++ b/pkg/hubble/relay/server.go
@@ -15,32 +15,32 @@
 package relay
 
 import (
-	"context"
 	"fmt"
-	"io"
 	"net"
 
 	observerpb "github.com/cilium/cilium/api/v1/observer"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/hubble/peer"
 	"github.com/cilium/cilium/pkg/hubble/relay/relayoption"
+	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
-	"google.golang.org/grpc/status"
 )
 
 // Server is a proxy that connects to a running instance of hubble gRPC server
 // via unix domain socket.
 type Server struct {
-	client observerpb.ObserverClient
 	server *grpc.Server
 	log    logrus.FieldLogger
+	peers  map[string]peer.Peer
 	opts   relayoption.Options
+	mu     lock.Mutex
+	stop   chan struct{}
 }
 
 // NewServer creates a new hubble-relay Server.
@@ -55,12 +55,11 @@ func NewServer(options ...relayoption.Option) (*Server, error) {
 	logging.ConfigureLogLevel(opts.Debug)
 	return &Server{
 		log:   logger,
+		peers: make(map[string]peer.Peer),
+		stop:  make(chan struct{}),
 		opts:  opts,
 	}, nil
 }
-
-// ensure that GRPCServer implements the observer.ObserverServer interface.
-var _ observerpb.ObserverServer = (*Server)(nil)
 
 // Serve starts the hubble-relay server. Serve does not return unless a
 // listening fails with fatal errors. Serve will return a non-nil error if
@@ -76,57 +75,14 @@ func (s *Server) Serve() error {
 	if err != nil {
 		return fmt.Errorf("failed to listen on tcp socket %s: %v", s.opts.ListenAddress, err)
 	}
-	if err := s.connectClient(); err != nil {
-		return fmt.Errorf("failed to connect to hubble instance: %v", err)
-	}
+	go s.syncPeers()
 	return s.server.Serve(socket)
-}
-
-func (s *Server) connectClient() error {
-	ctx, cancel := context.WithTimeout(context.Background(), s.opts.DialTimeout)
-	defer cancel()
-	conn, err := grpc.DialContext(ctx, s.opts.HubbleTarget, grpc.WithInsecure(), grpc.WithBlock())
-	if err != nil {
-		return fmt.Errorf("failed to dial grpc: %v", err)
-	}
-	s.client = observerpb.NewObserverClient(conn)
-	return nil
 }
 
 // Stop terminates the hubble-relay server.
 func (s *Server) Stop() {
 	s.log.Info("Stopping server...")
+	close(s.stop)
 	s.server.Stop()
 	s.log.Info("Server stopped")
-}
-
-// GetFlows implements observer.ObserverServer.GetFlows by proxying requests to
-// the hubble instance hubble-relay is connected to.
-func (s *Server) GetFlows(req *observerpb.GetFlowsRequest, server observerpb.Observer_GetFlowsServer) error {
-	c, err := s.client.GetFlows(context.Background(), req)
-	if err != nil {
-		return err
-	}
-	for {
-		resp, err := c.Recv()
-		switch err {
-		case io.EOF, context.Canceled:
-			return nil
-		case nil:
-		default:
-			if status.Code(err) == codes.Canceled {
-				return nil
-			}
-			return err
-		}
-		if err := server.Send(resp); err != nil {
-			return err
-		}
-	}
-}
-
-// ServerStatus implements observer.ObserverServer.ServerStatus by proxying
-// requests to the hubble instance hubble-relay is connected to.
-func (s *Server) ServerStatus(ctx context.Context, req *observerpb.ServerStatusRequest) (*observerpb.ServerStatusResponse, error) {
-	return s.client.ServerStatus(ctx, req)
 }

--- a/pkg/hubble/relay/server.go
+++ b/pkg/hubble/relay/server.go
@@ -23,7 +23,10 @@ import (
 	observerpb "github.com/cilium/cilium/api/v1/observer"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
 	"github.com/cilium/cilium/pkg/hubble/relay/relayoption"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 
+	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health"
@@ -36,6 +39,7 @@ import (
 type Server struct {
 	client observerpb.ObserverClient
 	server *grpc.Server
+	log    logrus.FieldLogger
 	opts   relayoption.Options
 }
 
@@ -47,8 +51,11 @@ func NewServer(options ...relayoption.Option) (*Server, error) {
 			return nil, fmt.Errorf("failed to apply option: %v", err)
 		}
 	}
+	logger := logging.DefaultLogger.WithField(logfields.LogSubsys, "hubble-relay")
+	logging.ConfigureLogLevel(opts.Debug)
 	return &Server{
-		opts: opts,
+		log:   logger,
+		opts:  opts,
 	}, nil
 }
 
@@ -59,6 +66,7 @@ var _ observerpb.ObserverServer = (*Server)(nil)
 // listening fails with fatal errors. Serve will return a non-nil error if
 // Stop() is not called.
 func (s *Server) Serve() error {
+	s.log.WithField("options", fmt.Sprintf("%+v", s.opts)).Info("Starting server...")
 	s.server = grpc.NewServer()
 	healthSrv := health.NewServer()
 	healthSrv.SetServingStatus(v1.ObserverServiceName, healthpb.HealthCheckResponse_SERVING)
@@ -87,7 +95,9 @@ func (s *Server) connectClient() error {
 
 // Stop terminates the hubble-relay server.
 func (s *Server) Stop() {
+	s.log.Info("Stopping server...")
 	s.server.Stop()
+	s.log.Info("Server stopped")
 }
 
 // GetFlows implements observer.ObserverServer.GetFlows by proxying requests to


### PR DESCRIPTION
Please, see individual commits for details.

```
$ hubble-relay serve --debug 
level=debug msg="os.Hostname() returned" nodeName=k8s1 subsys=node
level=info msg="Starting server..." options="{HubbleTarget:unix:///var/run/cilium/hubble.sock DialTimeout:5s RetryTimeout:30s ListenAddress::4245 Debug:true}" subsys=hubble-relay
level=debug msg="Received peer change notification" change notification="name:\"k8s1\" address:\"192.168.34.11\" type:PEER_ADDED " subsys=hubble-relay
level=debug msg="Received peer change notification" change notification="name:\"k8s2\" address:\"192.168.34.12\" type:PEER_ADDED " subsys=hubble-relay
```
```
$ hubble observe --server 'localhost:4245' -f
Apr 27 14:29:45.370 [k8s1]: [f00d::a10:0:0:4bf6]:4240(cilium-health) -> [fd00::b]:51018 from-endpoint FORWARDED (TCP Flags: ACK)
Apr 27 14:29:45.370 [k8s1]: [f00d::a10:0:0:4bf6]:4240(cilium-health) -> [fd00::b]:51018 to-stack FORWARDED (TCP Flags: ACK)
Apr 27 14:29:45.370 [k8s1]: [fd00::b]:51018 -> [f00d::a10:0:0:4bf6]:4240(cilium-health) from-host FORWARDED (TCP Flags: ACK)
Apr 27 14:29:36.038 [k8s2]: [fd00::c]:38070 -> [f00d::a11:0:0:cd56]:4240(cilium-health) to-endpoint FORWARDED (TCP Flags: ACK)
Apr 27 14:29:45.489 [k8s2]: 10.17.142.26:4240(cilium-health) -> 192.168.34.11:49364 from-endpoint FORWARDED (TCP Flags: ACK)
Apr 27 14:29:45.489 [k8s2]: 10.17.142.26:4240(cilium-health) -> 192.168.34.11:49364 to-stack FORWARDED (TCP Flags: ACK)
Apr 27 14:29:45.489 [k8s2]: [f00d::a11:0:0:cd56]:4240(cilium-health) -> [fd00::b]:41642 from-endpoint FORWARDED (TCP Flags: ACK)
Apr 27 14:29:45.489 [k8s2]: [f00d::a11:0:0:cd56]:4240(cilium-health) -> [fd00::b]:41642 to-stack FORWARDED (TCP Flags: ACK)
Apr 27 14:29:45.490 [k8s2]: [fd00::b]:41642 -> [f00d::a11:0:0:cd56]:4240(cilium-health) from-host FORWARDED (TCP Flags: ACK)
Apr 27 14:29:45.490 [k8s2]: [fd00::b]:41642 -> [f00d::a11:0:0:cd56]:4240(cilium-health) to-endpoint FORWARDED (TCP Flags: ACK)
Apr 27 14:29:45.490 [k8s2]: 192.168.34.11:49364 -> 10.17.142.26:4240(cilium-health) from-host FORWARDED (TCP Flags: ACK)
Apr 27 14:29:45.370 [k8s1]: [fd00::b]:51018 -> [f00d::a10:0:0:4bf6]:4240(cilium-health) to-endpoint FORWARDED (TCP Flags: ACK)
Apr 27 14:29:46.899 [k8s1]: 192.168.33.11:6443(sun-sr-https) -> kube-system/coredns-7db7b4f79f-mxzrm:52518 from-host FORWARDED (TCP Flags: ACK, PSH)
Apr 27 14:29:46.899 [k8s1]: 192.168.33.11:443(https) -> kube-system/coredns-7db7b4f79f-mxzrm:52518 to-endpoint FORWARDED (TCP Flags: ACK, PSH)
Apr 27 14:29:46.899 [k8s1]: kube-system/coredns-7db7b4f79f-mxzrm:52518 -> default/kubernetes:443(https) from-endpoint FORWARDED (TCP Flags: ACK)
...
```

Ref https://github.com/cilium/hubble/issues/89