### PR TITLE
Split operator-only options into separate package

### DIFF
--- a/operator/ccnp_event.go
+++ b/operator/ccnp_event.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"time"
 
+	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/k8s"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -25,7 +26,6 @@ import (
 	k8sversion "github.com/cilium/cilium/pkg/k8s/version"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/metrics"
-	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/groups"
 
 	"k8s.io/api/core/v1"
@@ -67,7 +67,7 @@ func enableCCNPWatcher() error {
 			return err
 		}
 
-		ccnpStatusMgr = k8s.NewCCNPStatusEventHandler(ccnpSharedStore, ccnpStore, option.Config.CNPStatusUpdateInterval)
+		ccnpStatusMgr = k8s.NewCCNPStatusEventHandler(ccnpSharedStore, ccnpStore, operatorOption.Config.CNPStatusUpdateInterval)
 
 		go ccnpStatusMgr.WatchForCCNPStatusEvents()
 	}

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -44,11 +44,11 @@ func init() {
 	flags.Float64(operatorOption.IPAMAPIQPSLimit, defaults.IPAMAPIQPSLimit, "Queries per second limit when accessing external IPAM APIs")
 	option.BindEnv(operatorOption.IPAMAPIQPSLimit)
 
-	flags.String(option.AzureSubscriptionID, "", "Subscription ID to access Azure API")
-	option.BindEnvWithLegacyEnvFallback(option.AzureSubscriptionID, "AZURE_SUBSCRIPTION_ID")
+	flags.String(operatorOption.AzureSubscriptionID, "", "Subscription ID to access Azure API")
+	option.BindEnvWithLegacyEnvFallback(operatorOption.AzureSubscriptionID, "AZURE_SUBSCRIPTION_ID")
 
-	flags.String(option.AzureResourceGroup, "", "Resource group to use for Azure IPAM")
-	option.BindEnvWithLegacyEnvFallback(option.AzureResourceGroup, "AZURE_RESOURCE_GROUP")
+	flags.String(operatorOption.AzureResourceGroup, "", "Resource group to use for Azure IPAM")
+	option.BindEnvWithLegacyEnvFallback(operatorOption.AzureResourceGroup, "AZURE_RESOURCE_GROUP")
 
 	flags.Var(option.NewNamedMapOptions(operatorOption.AWSInstanceLimitMapping, &operatorOption.Config.AWSInstanceLimitMapping, nil),
 		operatorOption.AWSInstanceLimitMapping,

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -50,22 +50,22 @@ func init() {
 	flags.String(option.AzureResourceGroup, "", "Resource group to use for Azure IPAM")
 	option.BindEnvWithLegacyEnvFallback(option.AzureResourceGroup, "AZURE_RESOURCE_GROUP")
 
-	flags.Var(option.NewNamedMapOptions(option.AwsInstanceLimitMapping, &option.Config.AwsInstanceLimitMapping, nil),
-		option.AwsInstanceLimitMapping,
+	flags.Var(option.NewNamedMapOptions(operatorOption.AWSInstanceLimitMapping, &operatorOption.Config.AWSInstanceLimitMapping, nil),
+		operatorOption.AWSInstanceLimitMapping,
 		`Add or overwrite mappings of AWS instance limit in the form of `+
 			`{"AWS instance type": "Maximum Network Interfaces","IPv4 Addresses `+
 			`per Interface","IPv6 Addresses per Interface"}. cli example: `+
 			`--aws-instance-limit-mapping=a1.medium=2,4,4 `+
 			`--aws-instance-limit-mapping=a2.somecustomflavor=4,5,6 `+
 			`configmap example: {"a1.medium": "2,4,4", "a2.somecustomflavor": "4,5,6"}`)
-	option.BindEnv(option.AwsInstanceLimitMapping)
+	option.BindEnv(operatorOption.AWSInstanceLimitMapping)
 
-	flags.Bool(option.AwsReleaseExcessIps, false, "Enable releasing excess free IP addresses from AWS ENI.")
-	option.BindEnv(option.AwsReleaseExcessIps)
+	flags.Bool(operatorOption.AWSReleaseExcessIPs, false, "Enable releasing excess free IP addresses from AWS ENI.")
+	option.BindEnv(operatorOption.AWSReleaseExcessIPs)
 
-	flags.Var(option.NewNamedMapOptions(option.ENITags, &option.Config.ENITags, nil),
-		option.ENITags, "ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag)")
-	option.BindEnv(option.ENITags)
+	flags.Var(option.NewNamedMapOptions(operatorOption.ENITags, &operatorOption.Config.ENITags, nil),
+		operatorOption.ENITags, "ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag)")
+	option.BindEnv(operatorOption.ENITags)
 
 	flags.StringToStringVar(&operatorOption.Config.IPAMSubnetsTags, operatorOption.IPAMSubnetsTags, operatorOption.Config.IPAMSubnetsTags,
 		"Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag")
@@ -75,15 +75,15 @@ func init() {
 		"Subnets IDs (separated by commas)")
 	option.BindEnv(operatorOption.IPAMSubnetsIDs)
 
-	flags.Int64(option.ENIParallelWorkersDeprecated, defaults.ParallelAllocWorkers, "")
-	flags.MarkDeprecated(option.ENIParallelWorkersDeprecated, fmt.Sprintf("please use --%s", option.ParallelAllocWorkers))
-	option.BindEnv(option.ENIParallelWorkersDeprecated)
+	flags.Int64(operatorOption.ENIParallelWorkersDeprecated, defaults.ParallelAllocWorkers, "")
+	flags.MarkDeprecated(operatorOption.ENIParallelWorkersDeprecated, fmt.Sprintf("please use --%s", operatorOption.ParallelAllocWorkers))
+	option.BindEnv(operatorOption.ENIParallelWorkersDeprecated)
 
-	flags.Int64(option.ParallelAllocWorkers, defaults.ParallelAllocWorkers, "Maximum number of parallel IPAM workers")
-	option.BindEnv(option.ParallelAllocWorkers)
+	flags.Int64(operatorOption.ParallelAllocWorkers, defaults.ParallelAllocWorkers, "Maximum number of parallel IPAM workers")
+	option.BindEnv(operatorOption.ParallelAllocWorkers)
 
-	flags.Bool(option.UpdateEC2AdapterLimitViaAPI, false, "Use the EC2 API to update the instance type to adapter limits")
-	option.BindEnv(option.UpdateEC2AdapterLimitViaAPI)
+	flags.Bool(operatorOption.UpdateEC2AdapterLimitViaAPI, false, "Use the EC2 API to update the instance type to adapter limits")
+	option.BindEnv(operatorOption.UpdateEC2AdapterLimitViaAPI)
 
 	// Clustermesh dedicated flags
 	flags.Int(option.ClusterIDName, 0, "Unique identifier of the cluster")

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	operatorMetrics "github.com/cilium/cilium/operator/metrics"
+	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/option"
 
@@ -31,17 +32,17 @@ func init() {
 
 	flags := rootCmd.Flags()
 
-	flags.Int(option.AWSClientBurstDeprecated, defaults.IPAMAPIBurst, "")
-	flags.MarkDeprecated(option.AWSClientBurstDeprecated, fmt.Sprintf("please use --%s", option.IPAMAPIBurst))
+	flags.Int(operatorOption.AWSClientBurstDeprecated, defaults.IPAMAPIBurst, "")
+	flags.MarkDeprecated(operatorOption.AWSClientBurstDeprecated, fmt.Sprintf("please use --%s", operatorOption.IPAMAPIBurst))
 
-	flags.Int(option.IPAMAPIBurst, defaults.IPAMAPIBurst, "Upper burst limit when accessing external APIs")
-	option.BindEnv(option.IPAMAPIBurst)
+	flags.Int(operatorOption.IPAMAPIBurst, defaults.IPAMAPIBurst, "Upper burst limit when accessing external APIs")
+	option.BindEnv(operatorOption.IPAMAPIBurst)
 
-	flags.Float64(option.AWSClientQPSLimitDeprecated, defaults.IPAMAPIQPSLimit, "")
-	flags.MarkDeprecated(option.AWSClientQPSLimitDeprecated, fmt.Sprintf("please use --%s", option.IPAMAPIQPSLimit))
+	flags.Float64(operatorOption.AWSClientQPSLimitDeprecated, defaults.IPAMAPIQPSLimit, "")
+	flags.MarkDeprecated(operatorOption.AWSClientQPSLimitDeprecated, fmt.Sprintf("please use --%s", operatorOption.IPAMAPIQPSLimit))
 
-	flags.Float64(option.IPAMAPIQPSLimit, defaults.IPAMAPIQPSLimit, "Queries per second limit when accessing external IPAM APIs")
-	option.BindEnv(option.IPAMAPIQPSLimit)
+	flags.Float64(operatorOption.IPAMAPIQPSLimit, defaults.IPAMAPIQPSLimit, "Queries per second limit when accessing external IPAM APIs")
+	option.BindEnv(operatorOption.IPAMAPIQPSLimit)
 
 	flags.String(option.AzureSubscriptionID, "", "Subscription ID to access Azure API")
 	option.BindEnvWithLegacyEnvFallback(option.AzureSubscriptionID, "AZURE_SUBSCRIPTION_ID")
@@ -66,11 +67,13 @@ func init() {
 		option.ENITags, "ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag)")
 	option.BindEnv(option.ENITags)
 
-	flags.StringToStringVar(&option.Config.IPAMSubnetsTags, option.IPAMSubnetsTags, option.Config.IPAMSubnetsTags,
+	flags.StringToStringVar(&operatorOption.Config.IPAMSubnetsTags, operatorOption.IPAMSubnetsTags, operatorOption.Config.IPAMSubnetsTags,
 		"Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag")
-	option.BindEnv(option.IPAMSubnetsTags)
-	flags.StringSliceVar(&option.Config.IPAMSubnetsIDs, option.IPAMSubnetsIDs, option.Config.IPAMSubnetsIDs, "Subnets IDs (separated by commas)")
-	option.BindEnv(option.IPAMSubnetsIDs)
+	option.BindEnv(operatorOption.IPAMSubnetsTags)
+
+	flags.StringSliceVar(&operatorOption.Config.IPAMSubnetsIDs, operatorOption.IPAMSubnetsIDs, operatorOption.Config.IPAMSubnetsIDs,
+		"Subnets IDs (separated by commas)")
+	option.BindEnv(operatorOption.IPAMSubnetsIDs)
 
 	flags.Int64(option.ENIParallelWorkersDeprecated, defaults.ParallelAllocWorkers, "")
 	flags.MarkDeprecated(option.ENIParallelWorkersDeprecated, fmt.Sprintf("please use --%s", option.ParallelAllocWorkers))
@@ -97,20 +100,20 @@ func init() {
 	option.BindEnv(option.ConfigDir)
 
 	// Deprecated, remove in 1.9
-	flags.Bool(option.EnableCCNPNodeStatusGC, true, "Enable CiliumClusterwideNetworkPolicy Status garbage collection for nodes which have been removed from the cluster")
-	option.BindEnv(option.EnableCCNPNodeStatusGC)
-	flags.MarkDeprecated(option.EnableCCNPNodeStatusGC, fmt.Sprintf("Please use %s=0 to disable CCNP Status GC", option.CNPNodeStatusGCInterval))
+	flags.Bool(operatorOption.EnableCCNPNodeStatusGC, true, "Enable CiliumClusterwideNetworkPolicy Status garbage collection for nodes which have been removed from the cluster")
+	option.BindEnv(operatorOption.EnableCCNPNodeStatusGC)
+	flags.MarkDeprecated(operatorOption.EnableCCNPNodeStatusGC, fmt.Sprintf("Please use %s=0 to disable CCNP Status GC", operatorOption.CNPNodeStatusGCInterval))
 
 	// Deprecated, remove in 1.9
-	flags.Bool(option.EnableCNPNodeStatusGC, true, "Enable CiliumNetworkPolicy Status garbage collection for nodes which have been removed from the cluster")
-	option.BindEnv(option.EnableCNPNodeStatusGC)
-	flags.MarkDeprecated(option.EnableCNPNodeStatusGC, fmt.Sprintf("Please use %s=0 to disable CNP Status GC", option.CNPNodeStatusGCInterval))
+	flags.Bool(operatorOption.EnableCNPNodeStatusGC, true, "Enable CiliumNetworkPolicy Status garbage collection for nodes which have been removed from the cluster")
+	option.BindEnv(operatorOption.EnableCNPNodeStatusGC)
+	flags.MarkDeprecated(operatorOption.EnableCNPNodeStatusGC, fmt.Sprintf("Please use %s=0 to disable CNP Status GC", operatorOption.CNPNodeStatusGCInterval))
 
-	flags.Duration(option.CNPNodeStatusGCInterval, 2*time.Minute, "GC interval for nodes which have been removed from the cluster in CiliumNetworkPolicy Status")
-	option.BindEnv(option.CNPNodeStatusGCInterval)
+	flags.Duration(operatorOption.CNPNodeStatusGCInterval, 2*time.Minute, "GC interval for nodes which have been removed from the cluster in CiliumNetworkPolicy Status")
+	option.BindEnv(operatorOption.CNPNodeStatusGCInterval)
 
-	flags.Duration(option.CNPStatusUpdateInterval, 1*time.Second, "Interval between CNP status updates sent to the k8s-apiserver per-CNP")
-	option.BindEnv(option.CNPStatusUpdateInterval)
+	flags.Duration(operatorOption.CNPStatusUpdateInterval, 1*time.Second, "Interval between CNP status updates sent to the k8s-apiserver per-CNP")
+	option.BindEnv(operatorOption.CNPStatusUpdateInterval)
 
 	flags.BoolP(option.DebugArg, "D", false, "Enable debugging mode")
 	option.BindEnv(option.DebugArg)
@@ -124,27 +127,27 @@ func init() {
 	option.BindEnv(option.DisableCiliumEndpointCRDName)
 
 	// Deprecated, remove in 1.9
-	flags.Bool(option.EnableCEPGC, true, "Enable CiliumEndpoint garbage collector")
-	option.BindEnv(option.EnableCEPGC)
-	flags.MarkDeprecated(option.EnableCEPGC, fmt.Sprintf("Please use %s=0 to disable CEP GC", option.EndpointGCInterval))
+	flags.Bool(operatorOption.EnableCEPGC, true, "Enable CiliumEndpoint garbage collector")
+	option.BindEnv(operatorOption.EnableCEPGC)
+	flags.MarkDeprecated(operatorOption.EnableCEPGC, fmt.Sprintf("Please use %s=0 to disable CEP GC", operatorOption.EndpointGCInterval))
 
-	flags.Duration(option.EndpointGCInterval, 30*time.Minute, "GC interval for cilium endpoints")
-	option.BindEnv(option.EndpointGCInterval)
+	flags.Duration(operatorOption.EndpointGCInterval, 30*time.Minute, "GC interval for cilium endpoints")
+	option.BindEnv(operatorOption.EndpointGCInterval)
 
-	flags.Bool(option.EnableMetrics, false, "Enable Prometheus metrics")
-	option.BindEnv(option.EnableMetrics)
+	flags.Bool(operatorOption.EnableMetrics, false, "Enable Prometheus metrics")
+	option.BindEnv(operatorOption.EnableMetrics)
 
 	flags.String(option.IPAM, option.IPAMHostScopeLegacy, "Backend to use for IPAM")
 	option.BindEnv(option.IPAM)
 
-	flags.Duration(option.IdentityHeartbeatTimeout, 15*time.Minute, "Timeout after which identity expires on lack of heartbeat")
-	option.BindEnv(option.IdentityHeartbeatTimeout)
+	flags.Duration(operatorOption.IdentityHeartbeatTimeout, 15*time.Minute, "Timeout after which identity expires on lack of heartbeat")
+	option.BindEnv(operatorOption.IdentityHeartbeatTimeout)
 
 	flags.String(option.IdentityAllocationMode, option.IdentityAllocationModeKVstore, "Method to use for identity allocation")
 	option.BindEnv(option.IdentityAllocationMode)
 
-	flags.Duration(option.IdentityGCInterval, defaults.KVstoreLeaseTTL, "GC interval for security identities")
-	option.BindEnv(option.IdentityGCInterval)
+	flags.Duration(operatorOption.IdentityGCInterval, defaults.KVstoreLeaseTTL, "GC interval for security identities")
+	option.BindEnv(operatorOption.IdentityGCInterval)
 
 	flags.String(option.KVStore, "", "Key-value store type")
 	option.BindEnv(option.KVStore)
@@ -168,34 +171,34 @@ func init() {
 	flags.String(option.K8sKubeConfigPath, "", "Absolute path of the kubernetes kubeconfig file")
 	option.BindEnv(option.K8sKubeConfigPath)
 
-	flags.Duration(option.NodesGCInterval, 2*time.Minute, "GC interval for nodes store in the kvstore")
-	option.BindEnv(option.NodesGCInterval)
+	flags.Duration(operatorOption.NodesGCInterval, 2*time.Minute, "GC interval for nodes store in the kvstore")
+	option.BindEnv(operatorOption.NodesGCInterval)
 
-	flags.String(option.OperatorPrometheusServeAddr, ":6942", "Address to serve Prometheus metrics")
-	option.BindEnv(option.OperatorPrometheusServeAddr)
+	flags.String(operatorOption.OperatorPrometheusServeAddr, ":6942", "Address to serve Prometheus metrics")
+	option.BindEnv(operatorOption.OperatorPrometheusServeAddr)
 
-	flags.String(option.OperatorAPIServeAddr, "localhost:9234", "Address to serve API requests")
-	option.BindEnv(option.OperatorAPIServeAddr)
+	flags.String(operatorOption.OperatorAPIServeAddr, "localhost:9234", "Address to serve API requests")
+	option.BindEnv(operatorOption.OperatorAPIServeAddr)
 
-	flags.Bool(option.SyncK8sServices, true, "Synchronize Kubernetes services to kvstore")
-	option.BindEnv(option.SyncK8sServices)
+	flags.Bool(operatorOption.SyncK8sServices, true, "Synchronize Kubernetes services to kvstore")
+	option.BindEnv(operatorOption.SyncK8sServices)
 
-	flags.Bool(option.SyncK8sNodes, true, "Synchronize Kubernetes nodes to kvstore and perform CNP GC")
-	option.BindEnv(option.SyncK8sNodes)
+	flags.Bool(operatorOption.SyncK8sNodes, true, "Synchronize Kubernetes nodes to kvstore and perform CNP GC")
+	option.BindEnv(operatorOption.SyncK8sNodes)
 
-	flags.Int(option.UnmanagedPodWatcherInterval, 15, "Interval to check for unmanaged kube-dns pods (0 to disable)")
-	option.BindEnv(option.UnmanagedPodWatcherInterval)
+	flags.Int(operatorOption.UnmanagedPodWatcherInterval, 15, "Interval to check for unmanaged kube-dns pods (0 to disable)")
+	option.BindEnv(operatorOption.UnmanagedPodWatcherInterval)
 
 	flags.Bool(option.Version, false, "Print version information")
 	option.BindEnv(option.Version)
 
 	// Deprecated, remove in 1.9
 	flags.Uint16Var(&apiServerPort, "api-server-port", 9234, "Port on which the operator should serve API requests")
-	flags.MarkDeprecated("api-server-port", fmt.Sprintf("Please use %s instead", option.OperatorAPIServeAddr))
+	flags.MarkDeprecated("api-server-port", fmt.Sprintf("Please use %s instead", operatorOption.OperatorAPIServeAddr))
 
 	// Deprecated, remove in 1.9
 	flags.StringVar(&operatorMetrics.Address, "metrics-address", ":6942", "Address to serve Prometheus metrics")
-	flags.MarkDeprecated("metrics-address", fmt.Sprintf("Please use %s instead", option.OperatorPrometheusServeAddr))
+	flags.MarkDeprecated("metrics-address", fmt.Sprintf("Please use %s instead", operatorOption.OperatorPrometheusServeAddr))
 
 	flags.String(option.CMDRef, "", "Path to cmdref output directory")
 	flags.MarkHidden(option.CMDRef)

--- a/operator/identity_gc.go
+++ b/operator/identity_gc.go
@@ -17,15 +17,15 @@ package main
 import (
 	"time"
 
+	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/allocator"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/kvstore"
 	kvstoreallocator "github.com/cilium/cilium/pkg/kvstore/allocator"
-	"github.com/cilium/cilium/pkg/option"
 )
 
 func startKvstoreIdentityGC() {
-	log.Infof("Starting kvstore identity garbage collector with %s interval...", option.Config.IdentityGCInterval)
+	log.Infof("Starting kvstore identity garbage collector with %s interval...", operatorOption.Config.IdentityGCInterval)
 	backend, err := kvstoreallocator.NewKVStoreBackend(cache.IdentitiesPath, "", nil, kvstore.Client())
 	if err != nil {
 		log.WithError(err).Fatal("Unable to initialize kvstore backend for identity allocation")
@@ -42,7 +42,7 @@ func startKvstoreIdentityGC() {
 				keysToDelete = keysToDelete2
 			}
 
-			<-time.After(option.Config.IdentityGCInterval)
+			<-time.After(operatorOption.Config.IdentityGCInterval)
 		}
 	}()
 }

--- a/operator/k8s_cep_gc.go
+++ b/operator/k8s_cep_gc.go
@@ -18,10 +18,10 @@ import (
 	"context"
 	"time"
 
+	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/option"
 
 	"github.com/sirupsen/logrus"
 	core_v1 "k8s.io/api/core/v1"
@@ -53,11 +53,11 @@ func enableCiliumEndpointSyncGC() {
 	// this dummy manager is needed only to add this controller to the global list
 	controller.NewManager().UpdateController(controllerName,
 		controller.ControllerParams{
-			RunInterval: option.Config.EndpointGCInterval,
+			RunInterval: operatorOption.Config.EndpointGCInterval,
 			DoFunc: func(ctx context.Context) error {
 				var (
 					listOpts = meta_v1.ListOptions{Limit: 10}
-					loopStop = time.Now().Add(option.Config.EndpointGCInterval)
+					loopStop = time.Now().Add(operatorOption.Config.EndpointGCInterval)
 				)
 
 				pods, err := k8s.Client().CoreV1().Pods("").List(ctx, meta_v1.ListOptions{})

--- a/operator/k8s_identity.go
+++ b/operator/k8s_identity.go
@@ -18,12 +18,12 @@ import (
 	"context"
 	"time"
 
+	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/informer"
 	"github.com/cilium/cilium/pkg/k8s/types"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/option"
 
 	"github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
@@ -80,7 +80,7 @@ nextIdentity:
 		}
 
 		for _, heartbeat := range identity.Status.Nodes {
-			if time.Since(heartbeat.Time) < option.Config.IdentityHeartbeatTimeout {
+			if time.Since(heartbeat.Time) < operatorOption.Config.IdentityHeartbeatTimeout {
 				continue nextIdentity
 			}
 		}
@@ -94,11 +94,11 @@ nextIdentity:
 }
 
 func startCRDIdentityGC() {
-	log.Infof("Starting CRD identity garbage collector with %s interval...", option.Config.IdentityGCInterval)
+	log.Infof("Starting CRD identity garbage collector with %s interval...", operatorOption.Config.IdentityGCInterval)
 
 	controller.NewManager().UpdateController("crd-identity-gc",
 		controller.ControllerParams{
-			RunInterval: option.Config.IdentityGCInterval,
+			RunInterval: operatorOption.Config.IdentityGCInterval,
 			DoFunc: func(ctx context.Context) error {
 				identityGCIteration()
 				return nil

--- a/operator/k8s_node.go
+++ b/operator/k8s_node.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"time"
 
+	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/ipam"
 	"github.com/cilium/cilium/pkg/k8s"
@@ -141,11 +142,11 @@ func runNodeWatcher(nodeManager *ipam.NodeManager) error {
 
 	}()
 
-	if option.Config.EnableCNPNodeStatusGC && option.Config.CNPNodeStatusGCInterval != 0 {
+	if operatorOption.Config.EnableCNPNodeStatusGC && operatorOption.Config.CNPNodeStatusGCInterval != 0 {
 		go runCNPNodeStatusGC("cnp-node-gc", false, ciliumNodeStore)
 	}
 
-	if option.Config.EnableCCNPNodeStatusGC && option.Config.CNPNodeStatusGCInterval != 0 {
+	if operatorOption.Config.EnableCCNPNodeStatusGC && operatorOption.Config.CNPNodeStatusGCInterval != 0 {
 		go runCNPNodeStatusGC("ccnp-node-gc", true, ciliumNodeStore)
 	}
 
@@ -168,9 +169,9 @@ func runCNPNodeStatusGC(name string, clusterwide bool, ciliumNodeStore *store.Sh
 
 	controller.NewManager().UpdateController(name,
 		controller.ControllerParams{
-			RunInterval: option.Config.CNPNodeStatusGCInterval,
+			RunInterval: operatorOption.Config.CNPNodeStatusGCInterval,
 			DoFunc: func(ctx context.Context) error {
-				lastRun := time.Now().Add(-option.Config.NodesGCInterval)
+				lastRun := time.Now().Add(-operatorOption.Config.NodesGCInterval)
 				k8sCapabilities := k8sversion.Capabilities()
 				continueID := ""
 				wg := sync.WaitGroup{}

--- a/operator/k8s_pod_controller.go
+++ b/operator/k8s_pod_controller.go
@@ -19,9 +19,9 @@ import (
 	"fmt"
 	"time"
 
+	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/k8s"
-	"github.com/cilium/cilium/pkg/option"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,7 +39,7 @@ var (
 func enableUnmanagedKubeDNSController() {
 	controller.NewManager().UpdateController("restart-unmanaged-kube-dns",
 		controller.ControllerParams{
-			RunInterval: time.Duration(option.Config.UnmanagedPodWatcherInterval) * time.Second,
+			RunInterval: time.Duration(operatorOption.Config.UnmanagedPodWatcherInterval) * time.Second,
 			DoFunc: func(ctx context.Context) error {
 				for podName, lastRestart := range lastPodRestart {
 					if time.Since(lastRestart) > 2*minimalPodRestartInterval {

--- a/operator/metrics/metrics.go
+++ b/operator/metrics/metrics.go
@@ -18,7 +18,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/cilium/cilium/pkg/option"
+	operatorOption "github.com/cilium/cilium/operator/option"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -44,8 +44,8 @@ func Register() {
 }
 
 func getPrometheusServerAddr() string {
-	if option.Config.OperatorPrometheusServeAddr == "" {
+	if operatorOption.Config.OperatorPrometheusServeAddr == "" {
 		return Address
 	}
-	return option.Config.OperatorPrometheusServeAddr
+	return operatorOption.Config.OperatorPrometheusServeAddr
 }

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -1,0 +1,217 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package option
+
+import (
+	"time"
+
+	"github.com/spf13/viper"
+)
+
+const (
+	// CNPNodeStatusGCInterval is the GC interval for nodes which have been
+	// removed from the cluster in CiliumNetworkPolicy and
+	// CiliumClusterwideNetworkPolicy Status.
+	CNPNodeStatusGCInterval = "cnp-node-status-gc-interval"
+
+	// CNPStatusUpdateInterval is the interval between status updates
+	// being sent to the K8s apiserver for a given CNP.
+	CNPStatusUpdateInterval = "cnp-status-update-interval"
+
+	// EnableCEPGC enables CiliumEndpoint garbage collector
+	// Deprecated: use EndpointGCInterval and remove in 1.9
+	EnableCEPGC = "cilium-endpoint-gc"
+
+	// EnableCCNPNodeStatusGC enables CiliumClusterwideNetworkPolicy Status
+	// garbage collection for nodes which have been removed from the cluster
+	// Deprecated: use CNPNodeStatusGCInterval and remove in 1.9
+	EnableCCNPNodeStatusGC = "ccnp-node-status-gc"
+
+	// EnableCNPNodeStatusGC enables CiliumNetworkPolicy Status garbage
+	// collection for nodes which have been removed from the cluster
+	// Deprecated: use CNPNodeStatusGCInterval and remove in 1.9
+	EnableCNPNodeStatusGC = "cnp-node-status-gc"
+
+	// EnableMetrics enables prometheus metrics.
+	EnableMetrics = "enable-metrics"
+
+	// EndpointGCInterval is the interval between attempts of the CEP GC
+	// controller.
+	// Note that only one node per cluster should run this, and most iterations
+	// will simply return.
+	EndpointGCInterval = "cilium-endpoint-gc-interval"
+
+	// IdentityGCInterval is the interval in which allocator identities are
+	// attempted to be expired from the kvstore
+	IdentityGCInterval = "identity-gc-interval"
+
+	// IdentityHeartbeatTimeout is the timeout used to GC identities from k8s
+	IdentityHeartbeatTimeout = "identity-heartbeat-timeout"
+
+	// NodesGCInterval is the duration for which the nodes are GC in the KVStore.
+	NodesGCInterval = "nodes-gc-interval"
+
+	// OperatorAPIServeAddr IP:Port on which to serve api requests in
+	// operator (pass ":Port" to bind on all interfaces, "" is off)
+	OperatorAPIServeAddr = "operator-api-serve-addr"
+
+	// OperatorPrometheusServeAddr IP:Port on which to serve prometheus
+	// metrics (pass ":Port" to bind on all interfaces, "" is off).
+	OperatorPrometheusServeAddr = "operator-prometheus-serve-addr"
+
+	// SyncK8sServices synchronizes k8s services into the kvstore
+	SyncK8sServices = "synchronize-k8s-services"
+
+	// SyncK8sNodes synchronizes k8s nodes into the kvstore
+	SyncK8sNodes = "synchronize-k8s-nodes"
+
+	// UnmanagedPodWatcherInterval is the interval to check for unmanaged kube-dns pods (0 to disable)
+	UnmanagedPodWatcherInterval = "unmanaged-pod-watcher-interval"
+
+	// IPAM options
+
+	// AWSClientBurstDeprecated is the deprecated version of IPAMAPIBurst and will be rewmoved in v1.9
+	AWSClientBurstDeprecated = "aws-client-burst"
+
+	// AWSClientQPSLimitDeprecated is the deprecated version of IPAMAPIQPSLimit and will be removed in v1.9
+	AWSClientQPSLimitDeprecated = "aws-client-qps"
+
+	// IPAMAPIBurst is the burst value allowed when accessing external IPAM APIs
+	IPAMAPIBurst = "limit-ipam-api-burst"
+
+	// IPAMAPIQPSLimit is the queries per second limit when accessing external IPAM APIs
+	IPAMAPIQPSLimit = "limit-ipam-api-qps"
+
+	// IPAMSubnetsIDs are optional subnets IDs used to filter subnets and interfaces listing
+	IPAMSubnetsIDs = "subnet-ids-filter"
+
+	// IAPMSubnetsTags are optional tags used to filter subnets, and interfaces within those subnets
+	IPAMSubnetsTags = "subnet-tags-filter"
+)
+
+// OperatorConfig is the configuration used by the operator.
+type OperatorConfig struct {
+	// CNPNodeStatusGCInterval is the GC interval for nodes which have been
+	// removed from the cluster in CiliumNetworkPolicy and
+	// CiliumClusterwideNetworkPolicy Status.
+	CNPNodeStatusGCInterval time.Duration
+
+	// CNPStatusUpdateInterval is the interval between status updates
+	// being sent to the K8s apiserver for a given CNP.
+	CNPStatusUpdateInterval time.Duration
+
+	// EnableCEPGC enables CiliumEndpoint garbage collector
+	// Deprecated: use EndpointGCInterval and remove in 1.9
+	EnableCEPGC bool
+
+	// EnableCNPNodeStatusGC enables CiliumNetworkPolicy Status garbage collection
+	// for nodes which have been removed from the cluster
+	// Deprecated: use CNPNodeStatusGCInterval and remove in 1.9
+	EnableCNPNodeStatusGC bool
+
+	// EnableMetrics enables prometheus metrics.
+	EnableMetrics bool
+
+	// EnableCCNPNodeStatusGC enables CiliumClusterwideNetworkPolicy Status
+	// garbage collection for nodes which have been removed from the cluster
+	// Deprecated: use CNPNodeStatusGCInterval and remove in 1.9
+	EnableCCNPNodeStatusGC bool
+
+	// EndpointGCInterval is the interval between attempts of the CEP GC
+	// controller.
+	// Note that only one node per cluster should run this, and most iterations
+	// will simply return.
+	EndpointGCInterval time.Duration
+
+	// IdentityGCInterval is the interval in which allocator identities are
+	// attempted to be expired from the kvstore
+	IdentityGCInterval time.Duration
+
+	// IdentityHeartbeatTimeout is the timeout used to GC identities from k8s
+	IdentityHeartbeatTimeout time.Duration
+
+	// NodesGCInterval is the duration for which the nodes are GC in the KVStore.
+	NodesGCInterval time.Duration
+
+	OperatorAPIServeAddr        string
+	OperatorPrometheusServeAddr string
+
+	// SyncK8sServices synchronizes k8s services into the kvstore
+	SyncK8sServices bool
+
+	// SyncK8sNodes synchronizes k8s nodes into the kvstore
+	SyncK8sNodes bool
+
+	// UnmanagedPodWatcherInterval is the interval to check for unmanaged kube-dns pods (0 to disable)
+	UnmanagedPodWatcherInterval int
+
+	// IPAM options
+
+	// IPAMAPIBurst is the burst value allowed when accessing external IPAM APIs
+	IPAMAPIBurst int
+
+	// IPAMAPIQPSLimit is the queries per second limit when accessing external IPAM APIs
+	IPAMAPIQPSLimit float64
+
+	// IPAMSubnetsIDs are optional subnets IDs used to filter subnets and interfaces listing
+	IPAMSubnetsIDs []string
+
+	// IPAMSubnetsTags are optional tags used to filter subnets, and interfaces within those subnets
+	IPAMSubnetsTags map[string]string
+}
+
+func (c *OperatorConfig) Populate() {
+	c.CNPNodeStatusGCInterval = viper.GetDuration(CNPNodeStatusGCInterval)
+	c.CNPStatusUpdateInterval = viper.GetDuration(CNPStatusUpdateInterval)
+	c.EnableCEPGC = viper.GetBool(EnableCEPGC)
+	c.EnableCNPNodeStatusGC = viper.GetBool(EnableCNPNodeStatusGC)
+	c.EnableCCNPNodeStatusGC = viper.GetBool(EnableCCNPNodeStatusGC)
+	c.EnableMetrics = viper.GetBool(EnableMetrics)
+	c.EndpointGCInterval = viper.GetDuration(EndpointGCInterval)
+	c.IdentityGCInterval = viper.GetDuration(IdentityGCInterval)
+	c.IdentityHeartbeatTimeout = viper.GetDuration(IdentityHeartbeatTimeout)
+	c.NodesGCInterval = viper.GetDuration(NodesGCInterval)
+	c.OperatorAPIServeAddr = viper.GetString(OperatorAPIServeAddr)
+	c.OperatorPrometheusServeAddr = viper.GetString(OperatorPrometheusServeAddr)
+	c.SyncK8sServices = viper.GetBool(SyncK8sServices)
+	c.SyncK8sNodes = viper.GetBool(SyncK8sNodes)
+	c.UnmanagedPodWatcherInterval = viper.GetInt(UnmanagedPodWatcherInterval)
+
+	if val := viper.GetInt(AWSClientBurstDeprecated); val != 0 {
+		c.IPAMAPIBurst = val
+	} else {
+		c.IPAMAPIBurst = viper.GetInt(IPAMAPIBurst)
+	}
+
+	if val := viper.GetFloat64(AWSClientQPSLimitDeprecated); val != 0 {
+		c.IPAMAPIQPSLimit = val
+	} else {
+		c.IPAMAPIQPSLimit = viper.GetFloat64(IPAMAPIQPSLimit)
+	}
+
+	if m := viper.GetStringSlice(IPAMSubnetsIDs); len(m) != 0 {
+		c.IPAMSubnetsIDs = m
+	}
+
+	if m := viper.GetStringMapString(IPAMSubnetsTags); len(m) != 0 {
+		c.IPAMSubnetsTags = m
+	}
+}
+
+// Config represents the operator configuration.
+var Config = &OperatorConfig{
+	IPAMSubnetsIDs:  make([]string, 0),
+	IPAMSubnetsTags: make(map[string]string),
+}

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -126,6 +126,14 @@ const (
 	// UpdateEC2AdapterLimitViaAPI configures the operator to use the EC2
 	// API to fill out the instnacetype to adapter limit mapping.
 	UpdateEC2AdapterLimitViaAPI = "update-ec2-apdater-limit-via-api"
+
+	// Azure options
+
+	// AzureSubscriptionID is the subscription ID to use when accessing the Azure API
+	AzureSubscriptionID = "azure-subscription-id"
+
+	// AzureResourceGroup is the resource group of the nodes used for the cluster
+	AzureResourceGroup = "azure-resource-group"
 )
 
 // OperatorConfig is the configuration used by the operator.
@@ -218,6 +226,14 @@ type OperatorConfig struct {
 
 	// UpdateEC2AdapterLimitViaAPI configures the operator to use the EC2 API to fill out the instnacetype to adapter limit mapping
 	UpdateEC2AdapterLimitViaAPI bool
+
+	// Azure options
+
+	// AzureSubscriptionID is the subscription ID to use when accessing the Azure API
+	AzureSubscriptionID string
+
+	// AzureResourceGroup is the resource group of the nodes used for the cluster
+	AzureResourceGroup string
 }
 
 func (c *OperatorConfig) Populate() {
@@ -241,6 +257,11 @@ func (c *OperatorConfig) Populate() {
 
 	c.AWSReleaseExcessIPs = viper.GetBool(AWSReleaseExcessIPs)
 	c.UpdateEC2AdapterLimitViaAPI = viper.GetBool(UpdateEC2AdapterLimitViaAPI)
+
+	// Azure options
+
+	c.AzureSubscriptionID = viper.GetString(AzureSubscriptionID)
+	c.AzureResourceGroup = viper.GetString(AzureResourceGroup)
 
 	// Deprecated options
 

--- a/pkg/aws/eni/limits_test.go
+++ b/pkg/aws/eni/limits_test.go
@@ -17,13 +17,13 @@
 package eni
 
 import (
-	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/operator/option"
 
 	"gopkg.in/check.v1"
 )
 
 func (e *ENISuite) TestGetLimits(c *check.C) {
-	option.Config.AwsInstanceLimitMapping = map[string]string{"a2.custom2": "4,5,6"}
+	option.Config.AWSInstanceLimitMapping = map[string]string{"a2.custom2": "4,5,6"}
 
 	_, ok := getLimits("unknown")
 	c.Assert(ok, check.Equals, false)
@@ -33,7 +33,7 @@ func (e *ENISuite) TestGetLimits(c *check.C) {
 	c.Assert(l.Adapters, check.Not(check.Equals), 0)
 	c.Assert(l.IPv4, check.Not(check.Equals), 0)
 
-	UpdateLimitsFromUserDefinedMappings(option.Config.AwsInstanceLimitMapping)
+	UpdateLimitsFromUserDefinedMappings(option.Config.AWSInstanceLimitMapping)
 	l, ok = getLimits("a2.custom2")
 	c.Assert(ok, check.Equals, true)
 	c.Assert(l.Adapters, check.Equals, 4)

--- a/pkg/ipam/allocator/aws/aws.go
+++ b/pkg/ipam/allocator/aws/aws.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	operatorMetrics "github.com/cilium/cilium/operator/metrics"
+	operatorOption "github.com/cilium/cilium/operator/option"
 	apiMetrics "github.com/cilium/cilium/pkg/api/metrics"
 	ec2shim "github.com/cilium/cilium/pkg/aws/ec2"
 	"github.com/cilium/cilium/pkg/aws/eni"
@@ -82,7 +83,7 @@ func (*AllocatorAWS) Start(getterUpdater ipam.CiliumNodeGetterUpdater) (*ipam.No
 
 	cfg.Region = instance.Region
 
-	if option.Config.EnableMetrics {
+	if operatorOption.Config.EnableMetrics {
 		aMetrics = apiMetrics.NewPrometheusMetrics("ipam", operatorMetrics.Namespace, operatorMetrics.Registry)
 		iMetrics = ipamMetrics.NewPrometheusMetrics(operatorMetrics.Namespace, operatorMetrics.Registry)
 	} else {
@@ -90,8 +91,8 @@ func (*AllocatorAWS) Start(getterUpdater ipam.CiliumNodeGetterUpdater) (*ipam.No
 		iMetrics = &ipamMetrics.NoOpMetrics{}
 	}
 
-	subnetsFilters := ec2shim.NewSubnetsFilters(option.Config.IPAMSubnetsTags, option.Config.IPAMSubnetsIDs)
-	ec2Client := ec2shim.NewClient(ec2.New(cfg), aMetrics, option.Config.IPAMAPIQPSLimit, option.Config.IPAMAPIBurst, subnetsFilters)
+	subnetsFilters := ec2shim.NewSubnetsFilters(operatorOption.Config.IPAMSubnetsTags, operatorOption.Config.IPAMSubnetsIDs)
+	ec2Client := ec2shim.NewClient(ec2.New(cfg), aMetrics, operatorOption.Config.IPAMAPIQPSLimit, operatorOption.Config.IPAMAPIBurst, subnetsFilters)
 	log.Info("Connected to EC2 service API")
 	instances := eni.NewInstancesManager(ec2Client, option.Config.ENITags)
 	nodeManager, err := ipam.NewNodeManager(instances, getterUpdater, iMetrics,

--- a/pkg/ipam/allocator/azure/azure.go
+++ b/pkg/ipam/allocator/azure/azure.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	operatorMetrics "github.com/cilium/cilium/operator/metrics"
+	operatorOption "github.com/cilium/cilium/operator/option"
 	apiMetrics "github.com/cilium/cilium/pkg/api/metrics"
 	azureAPI "github.com/cilium/cilium/pkg/azure/api"
 	azureIPAM "github.com/cilium/cilium/pkg/azure/ipam"
@@ -70,7 +71,7 @@ func (*AllocatorAzure) Start(getterUpdater ipam.CiliumNodeGetterUpdater) (*ipam.
 		log.WithField("resourceGroupName", resourceGroupName).Debug("Detected resource group name via Azure IMS")
 	}
 
-	if option.Config.EnableMetrics {
+	if operatorOption.Config.EnableMetrics {
 		azMetrics = apiMetrics.NewPrometheusMetrics(operatorMetrics.Namespace, "azure", operatorMetrics.Registry)
 		iMetrics = ipamMetrics.NewPrometheusMetrics(operatorMetrics.Namespace, operatorMetrics.Registry)
 	} else {

--- a/pkg/ipam/allocator/azure/azure.go
+++ b/pkg/ipam/allocator/azure/azure.go
@@ -27,7 +27,6 @@ import (
 	ipamMetrics "github.com/cilium/cilium/pkg/ipam/metrics"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/option"
 	"github.com/pkg/errors"
 )
 
@@ -49,7 +48,7 @@ func (*AllocatorAzure) Start(getterUpdater ipam.CiliumNodeGetterUpdater) (*ipam.
 
 	log.Info("Starting Azure IP allocator...")
 
-	subscriptionID := option.Config.AzureSubscriptionID
+	subscriptionID := operatorOption.Config.AzureSubscriptionID
 	if subscriptionID == "" {
 		log.Debug("SubscriptionID was not specified via CLI, retrieving it via Azure IMS")
 		subID, err := azureAPI.GetSubscriptionID(context.TODO())
@@ -60,7 +59,7 @@ func (*AllocatorAzure) Start(getterUpdater ipam.CiliumNodeGetterUpdater) (*ipam.
 		log.WithField("subscriptionID", subscriptionID).Debug("Detected subscriptionID via Azure IMS")
 	}
 
-	resourceGroupName := option.Config.AzureResourceGroup
+	resourceGroupName := operatorOption.Config.AzureResourceGroup
 	if resourceGroupName == "" {
 		log.Debug("ResourceGroupName was not specified via CLI, retrieving it via Azure IMS")
 		rgName, err := azureAPI.GetResourceGroupName(context.TODO())

--- a/pkg/ipam/allocator/azure/azure.go
+++ b/pkg/ipam/allocator/azure/azure.go
@@ -79,12 +79,12 @@ func (*AllocatorAzure) Start(getterUpdater ipam.CiliumNodeGetterUpdater) (*ipam.
 		iMetrics = &ipamMetrics.NoOpMetrics{}
 	}
 
-	azureClient, err := azureAPI.NewClient(subscriptionID, resourceGroupName, azMetrics, option.Config.IPAMAPIQPSLimit, option.Config.IPAMAPIBurst)
+	azureClient, err := azureAPI.NewClient(subscriptionID, resourceGroupName, azMetrics, operatorOption.Config.IPAMAPIQPSLimit, operatorOption.Config.IPAMAPIBurst)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create Azure client: %w", err)
 	}
 	instances := azureIPAM.NewInstancesManager(azureClient)
-	nodeManager, err := ipam.NewNodeManager(instances, getterUpdater, iMetrics, option.Config.ParallelAllocWorkers, false)
+	nodeManager, err := ipam.NewNodeManager(instances, getterUpdater, iMetrics, operatorOption.Config.ParallelAllocWorkers, false)
 	if err != nil {
 		return nil, fmt.Errorf("unable to initialize Azure node manager: %w", err)
 	}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -100,15 +100,6 @@ const (
 	// in L7 HTTPs policy enforcement.
 	CertsDirectory = "certificates-directory"
 
-	// CNPNodeStatusGCInterval is the GC interval for nodes which have been
-	// removed from the cluster in CiliumNetworkPolicy and
-	// CiliumClusterwideNetworkPolicy Status.
-	CNPNodeStatusGCInterval = "cnp-node-status-gc-interval"
-
-	// CNPStatusUpdateInterval is the interval between status updates
-	// being sent to the K8s apiserver for a given CNP.
-	CNPStatusUpdateInterval = "cnp-status-update-interval"
-
 	// CGroupRoot is the path to Cgroup2 filesystem
 	CGroupRoot = "cgroup-root"
 
@@ -138,25 +129,8 @@ const (
 	// DisableEnvoyVersionCheck do not perform Envoy binary version check on startup
 	DisableEnvoyVersionCheck = "disable-envoy-version-check"
 
-	// EnableCEPGC enables CiliumEndpoint garbage collector
-	// Deprecated: use EndpointGCInterval and remove in 1.9
-	EnableCEPGC = "cilium-endpoint-gc"
-
-	// EnableCCNPNodeStatusGC enables CiliumClusterwideNetworkPolicy Status
-	// garbage collection for nodes which have been removed from the cluster
-	// Deprecated: use CNPNodeStatusGCInterval and remove in 1.9
-	EnableCCNPNodeStatusGC = "ccnp-node-status-gc"
-
-	// EnableCNPNodeStatusGC enables CiliumNetworkPolicy Status garbage collection
-	// for nodes which have been removed from the cluster
-	// Deprecated: use CNPNodeStatusGCInterval and remove in 1.9
-	EnableCNPNodeStatusGC = "cnp-node-status-gc"
-
 	// EnablePolicy enables policy enforcement in the agent.
 	EnablePolicy = "enable-policy"
-
-	// EnableMetrics enables prometheus metrics.
-	EnableMetrics = "enable-metrics"
 
 	// EnableExternalIPs enables implementation of k8s services with externalIPs in datapath
 	EnableExternalIPs = "enable-external-ips"
@@ -167,12 +141,6 @@ const (
 
 	// ParallelAllocWorkers specifies the number of parallel workers to be used for IPAM allocation
 	ParallelAllocWorkers = "parallel-alloc-workers"
-
-	// EndpointGCInterval is the interval between attempts of the CEP GC
-	// controller.
-	// Note that only one node per cluster should run this, and most iterations
-	// will simply return.
-	EndpointGCInterval = "cilium-endpoint-gc-interval"
 
 	// K8sEnableEndpointSlice enables the k8s EndpointSlice feature into Cilium
 	K8sEnableEndpointSlice = "enable-k8s-endpoint-slice"
@@ -196,13 +164,6 @@ const (
 	// which allows to use reserved label for fixed identities
 	FixedIdentityMapping = "fixed-identity-mapping"
 
-	// IdentityGCInterval is the interval in which allocator identities are
-	// attempted to be expired from the kvstore
-	IdentityGCInterval = "identity-gc-interval"
-
-	// IdentityHeartbeatTimeout is the timeout used to GC identities from k8s
-	IdentityHeartbeatTimeout = "identity-heartbeat-timeout"
-
 	// IPv4ClusterCIDRMaskSize is the mask size for the cluster wide CIDR
 	IPv4ClusterCIDRMaskSize = "ipv4-cluster-cidr-mask-size"
 
@@ -223,9 +184,6 @@ const (
 
 	// ModePreFilterGeneric for loading progs with xdpgeneric
 	ModePreFilterGeneric = XDPModeGeneric
-
-	// NodesGCInterval is the duration for which the nodes are GC in the KVStore.
-	NodesGCInterval = "nodes-gc-interval"
 
 	// IPv6ClusterAllocCIDRName is the name of the IPv6ClusterAllocCIDR option
 	IPv6ClusterAllocCIDRName = "ipv6-cluster-alloc-cidr"
@@ -376,12 +334,6 @@ const (
 	// PrometheusServeAddr IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
 	PrometheusServeAddr = "prometheus-serve-addr"
 
-	// OperatorPrometheusServeAddr IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
-	OperatorPrometheusServeAddr = "operator-prometheus-serve-addr"
-
-	// OperatorAPIServeAddr IP:Port on which to serve api requests in operator (pass ":Port" to bind on all interfaces, "" is off)
-	OperatorAPIServeAddr = "operator-api-serve-addr"
-
 	// PrometheusServeAddrDeprecated IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
 	PrometheusServeAddrDeprecated = "prometheus-serve-addr-deprecated"
 
@@ -416,15 +368,6 @@ const (
 	// ToFQDNsEnableDNSCompression allows the DNS proxy to compress responses to
 	// endpoints that are larger than 512 Bytes or the EDNS0 option, if present.
 	ToFQDNsEnableDNSCompression = "tofqdns-enable-dns-compression"
-
-	// UnmanagedPodWatcherInterval is the interval to check for unmanaged kube-dns pods (0 to disable)
-	UnmanagedPodWatcherInterval = "unmanaged-pod-watcher-interval"
-
-	// SyncK8sServices synchronizes k8s services into the kvstore
-	SyncK8sServices = "synchronize-k8s-services"
-
-	// SyncK8sNodes synchronizes k8s nodes into the kvstore
-	SyncK8sNodes = "synchronize-k8s-nodes"
 
 	// MTUName is the name of the MTU option
 	MTUName = "mtu"
@@ -703,24 +646,6 @@ const (
 
 	// IPAMENI is the value to select the AWS ENI IPAM plugin for option.IPAM
 	IPAMENI = "eni"
-
-	// IPAMAPIQPSLimit is the queries per second limit when accessing external IPAM APIs
-	IPAMAPIQPSLimit = "limit-ipam-api-qps"
-
-	// AWSClientQPSLimitDeprecated is the deprecated version of IPAMAPIQPSLimit and will be removed in v1.9
-	AWSClientQPSLimitDeprecated = "aws-client-qps"
-
-	// IPAMAPIBurst is the burst value allowed when accessing external IPAM APIs
-	IPAMAPIBurst = "limit-ipam-api-burst"
-
-	// IPAMSubnetsIDs are optional subnets IDs used to filter subnets and interfaces listing
-	IPAMSubnetsIDs = "subnet-ids-filter"
-
-	// IAPMSubnetsTags are optional tags used to filter subnets, and interfaces within those subnets
-	IPAMSubnetsTags = "subnet-tags-filter"
-
-	// AWSClientBurstDeprecated is the deprecated version of IPAMAPIBurst and will be rewmoved in v1.9
-	AWSClientBurstDeprecated = "aws-client-burst"
 
 	// IPAMAzure is the value to select the Azure IPAM plugin for
 	// option.IPAM
@@ -1531,21 +1456,19 @@ type DaemonConfig struct {
 
 	// Masquerade specifies whether or not to masquerade packets from endpoints
 	// leaving the host.
-	Masquerade                  bool
-	InstallIptRules             bool
-	MonitorAggregation          string
-	PreAllocateMaps             bool
-	IPv6NodeAddr                string
-	IPv4NodeAddr                string
-	SidecarIstioProxyImage      string
-	SocketPath                  string
-	TracePayloadlen             int
-	Version                     string
-	PProf                       bool
-	PrometheusServeAddr         string
-	OperatorPrometheusServeAddr string
-	OperatorAPIServeAddr        string
-	ToFQDNsMinTTL               int
+	Masquerade             bool
+	InstallIptRules        bool
+	MonitorAggregation     string
+	PreAllocateMaps        bool
+	IPv6NodeAddr           string
+	IPv4NodeAddr           string
+	SidecarIstioProxyImage string
+	SocketPath             string
+	TracePayloadlen        int
+	Version                string
+	PProf                  bool
+	PrometheusServeAddr    string
+	ToFQDNsMinTTL          int
 
 	// ToFQDNsProxyPort is the user-configured global, shared, DNS listen port used
 	// by the DNS Proxy. Both UDP and TCP are handled on the same port. When it
@@ -1798,69 +1721,6 @@ type DaemonConfig struct {
 
 	// Operator-specific options
 
-	// EnableCEPGC enables CiliumEndpoint garbage collector
-	// Deprecated: use EndpointGCInterval and remove in 1.9
-	EnableCEPGC bool
-
-	// EnableCNPNodeStatusGC enables CiliumNetworkPolicy Status garbage collection
-	// for nodes which have been removed from the cluster
-	// Deprecated: use CNPNodeStatusGCInterval and remove in 1.9
-	EnableCNPNodeStatusGC bool
-
-	// EnableCCNPNodeStatusGC enables CiliumClusterwideNetworkPolicy Status
-	// garbage collection for nodes which have been removed from the cluster
-	// Deprecated: use CNPNodeStatusGCInterval and remove in 1.9
-	EnableCCNPNodeStatusGC bool
-
-	// EnableMetrics enables prometheus metrics.
-	EnableMetrics bool
-
-	// SyncK8sServices synchronizes k8s services into the kvstore
-	SyncK8sServices bool
-
-	// SyncK8sNodes synchronizes k8s nodes into the kvstore
-	SyncK8sNodes bool
-
-	// CNPNodeStatusGCInterval is the GC interval for nodes which have been
-	// removed from the cluster in CiliumNetworkPolicy and
-	// CiliumClusterwideNetworkPolicy Status.
-	CNPNodeStatusGCInterval time.Duration
-
-	// CNPStatusUpdateInterval is the interval between status updates
-	// being sent to the K8s apiserver for a given CNP.
-	CNPStatusUpdateInterval time.Duration
-
-	// EndpointGCInterval is the interval between attempts of the CEP GC
-	// controller.
-	// Note that only one node per cluster should run this, and most iterations
-	// will simply return.
-	EndpointGCInterval time.Duration
-
-	// IdentityGCInterval is the interval in which allocator identities are
-	// attempted to be expired from the kvstore
-	IdentityGCInterval time.Duration
-
-	// IdentityHeartbeatTimeout is the timeout used to GC identities from k8s
-	IdentityHeartbeatTimeout time.Duration
-
-	// NodesGCInterval is the duration for which the nodes are GC in the KVStore.
-	NodesGCInterval time.Duration
-
-	// UnmanagedPodWatcherInterval is the interval to check for unmanaged kube-dns pods (0 to disable)
-	UnmanagedPodWatcherInterval int
-
-	// IPAMAPIQPSLimit is the queries per second limit when accessing external IPAM APIs
-	IPAMAPIQPSLimit float64
-
-	// IPAMAPIBurst is the burst value allowed when accessing external IPAM APIs
-	IPAMAPIBurst int
-
-	// IPAMSubnetsIDs are optional subnets IDs used to filter subnets and interfaces listing
-	IPAMSubnetsIDs []string
-
-	// IPAMSubnetsTags are optional tags used to filter subnets, and interfaces within those subnets
-	IPAMSubnetsTags map[string]string
-
 	// AWS options
 
 	// ENITags are the tags that will be added to every ENI created by the AWS ENI IPAM
@@ -1961,8 +1821,6 @@ var (
 		EnableL7Proxy:                defaults.EnableL7Proxy,
 		EndpointStatus:               make(map[string]struct{}),
 		ENITags:                      make(map[string]string),
-		IPAMSubnetsIDs:               make([]string, 0),
-		IPAMSubnetsTags:              make(map[string]string),
 		ToFQDNsMaxIPsPerHost:         defaults.ToFQDNsMaxIPsPerHost,
 		KVstorePeriodicSync:          defaults.KVstorePeriodicSync,
 		KVstoreConnectivityTimeout:   defaults.KVstoreConnectivityTimeout,
@@ -2301,9 +2159,6 @@ func (c *DaemonConfig) Populate() {
 	c.ClusterID = viper.GetInt(ClusterIDName)
 	c.ClusterName = viper.GetString(ClusterName)
 	c.ClusterMeshConfig = viper.GetString(ClusterMeshConfigName)
-	c.CNPNodeStatusGCInterval = viper.GetDuration(CNPNodeStatusGCInterval)
-	c.CNPStatusUpdateInterval = viper.GetDuration(CNPStatusUpdateInterval)
-	c.ConntrackGCInterval = viper.GetDuration(ConntrackGCInterval)
 	c.DatapathMode = viper.GetString(DatapathMode)
 	c.Debug = viper.GetBool(DebugArg)
 	c.DebugVerbose = viper.GetStringSlice(DebugVerbose)
@@ -2337,13 +2192,8 @@ func (c *DaemonConfig) Populate() {
 	c.NodePortAcceleration = viper.GetString(NodePortAcceleration)
 	c.EnableAutoProtectNodePortRange = viper.GetBool(EnableAutoProtectNodePortRange)
 	c.KubeProxyReplacement = viper.GetString(KubeProxyReplacement)
-	c.EnableCEPGC = viper.GetBool(EnableCEPGC)
-	c.EnableCNPNodeStatusGC = viper.GetBool(EnableCNPNodeStatusGC)
-	c.EnableCCNPNodeStatusGC = viper.GetBool(EnableCCNPNodeStatusGC)
-	c.EnableMetrics = viper.GetBool(EnableMetrics)
 	c.EncryptInterface = viper.GetString(EncryptInterface)
 	c.EncryptNode = viper.GetBool(EncryptNode)
-	c.EndpointGCInterval = viper.GetDuration(EndpointGCInterval)
 	c.EnvoyLogPath = viper.GetString(EnvoyLog)
 	c.ForceLocalPolicyEvalAtSource = viper.GetBool(ForceLocalPolicyEvalAtSource)
 	c.HostDevice = getHostDevice()
@@ -2353,7 +2203,6 @@ func (c *DaemonConfig) Populate() {
 	c.HTTPRetryCount = viper.GetInt(HTTPRetryCount)
 	c.HTTPRetryTimeout = viper.GetInt(HTTPRetryTimeout)
 	c.IdentityChangeGracePeriod = viper.GetDuration(IdentityChangeGracePeriod)
-	c.IdentityGCInterval = viper.GetDuration(IdentityGCInterval)
 	c.IPAM = viper.GetString(IPAM)
 	c.IPv4Range = viper.GetString(IPv4Range)
 	c.IPv4NodeAddr = viper.GetString(IPv4NodeAddr)
@@ -2390,7 +2239,6 @@ func (c *DaemonConfig) Populate() {
 	c.Logstash = viper.GetBool(Logstash)
 	c.LoopbackIPv4 = viper.GetString(LoopbackIPv4)
 	c.Masquerade = viper.GetBool(Masquerade)
-	c.IdentityHeartbeatTimeout = viper.GetDuration(IdentityHeartbeatTimeout)
 	c.InstallIptRules = viper.GetBool(InstallIptRules)
 	c.IPSecKeyFile = viper.GetString(IPSecKeyFileName)
 	c.ModePreFilter = viper.GetString(PrefilterMode)
@@ -2399,15 +2247,12 @@ func (c *DaemonConfig) Populate() {
 	c.MonitorQueueSize = viper.GetInt(MonitorQueueSizeName)
 	c.MTU = viper.GetInt(MTUName)
 	c.NAT46Range = viper.GetString(NAT46Range)
-	c.NodesGCInterval = viper.GetDuration(NodesGCInterval)
 	c.FlannelMasterDevice = viper.GetString(FlannelMasterDevice)
 	c.FlannelUninstallOnExit = viper.GetBool(FlannelUninstallOnExit)
 	c.PProf = viper.GetBool(PProf)
 	c.PreAllocateMaps = viper.GetBool(PreAllocateMapsName)
 	c.PrependIptablesChains = viper.GetBool(PrependIptablesChainsName)
 	c.PrometheusServeAddr = getPrometheusServerAddr()
-	c.OperatorPrometheusServeAddr = viper.GetString(OperatorPrometheusServeAddr)
-	c.OperatorAPIServeAddr = viper.GetString(OperatorAPIServeAddr)
 	c.ProxyConnectTimeout = viper.GetInt(ProxyConnectTimeout)
 	c.BlacklistConflictingRoutes = viper.GetBool(BlacklistConflictingRoutes)
 	c.ReadCNIConfiguration = viper.GetString(ReadCNIConfiguration)
@@ -2417,11 +2262,8 @@ func (c *DaemonConfig) Populate() {
 	c.UseSingleClusterRoute = viper.GetBool(SingleClusterRouteName)
 	c.SocketPath = viper.GetString(SocketPath)
 	c.SockopsEnable = viper.GetBool(SockopsEnableName)
-	c.SyncK8sServices = viper.GetBool(SyncK8sServices)
-	c.SyncK8sNodes = viper.GetBool(SyncK8sNodes)
 	c.TracePayloadlen = viper.GetInt(TracePayloadlen)
 	c.Tunnel = viper.GetString(TunnelName)
-	c.UnmanagedPodWatcherInterval = viper.GetInt(UnmanagedPodWatcherInterval)
 	c.UpdateEC2AdapterLimitViaAPI = viper.GetBool(UpdateEC2AdapterLimitViaAPI)
 	c.Version = viper.GetString(Version)
 	c.WriteCNIConfigurationWhenReady = viper.GetString(WriteCNIConfigurationWhenReady)
@@ -2532,14 +2374,6 @@ func (c *DaemonConfig) Populate() {
 		c.ENITags = m
 	}
 
-	if m := viper.GetStringMapString(IPAMSubnetsTags); len(m) != 0 {
-		c.IPAMSubnetsTags = m
-	}
-
-	if m := viper.GetStringSlice(IPAMSubnetsIDs); len(m) != 0 {
-		c.IPAMSubnetsIDs = m
-	}
-
 	if m := viper.GetStringMapString(LogOpt); len(m) != 0 {
 		c.LogOpt = m
 	}
@@ -2548,18 +2382,6 @@ func (c *DaemonConfig) Populate() {
 		c.ParallelAllocWorkers = val
 	} else {
 		c.ParallelAllocWorkers = viper.GetInt64(ParallelAllocWorkers)
-	}
-
-	if val := viper.GetFloat64(AWSClientQPSLimitDeprecated); val != 0 {
-		c.IPAMAPIQPSLimit = val
-	} else {
-		c.IPAMAPIQPSLimit = viper.GetFloat64(IPAMAPIQPSLimit)
-	}
-
-	if val := viper.GetInt(AWSClientBurstDeprecated); val != 0 {
-		c.IPAMAPIBurst = val
-	} else {
-		c.IPAMAPIBurst = viper.GetInt(IPAMAPIBurst)
 	}
 
 	for _, option := range viper.GetStringSlice(EndpointStatus) {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -701,12 +701,6 @@ const (
 	// EnableRemoteNodeIdentity enables use of the remote-node identity
 	EnableRemoteNodeIdentity = "enable-remote-node-identity"
 
-	// AzureSubscriptionID is the subscription ID to use when accessing the Azure API
-	AzureSubscriptionID = "azure-subscription-id"
-
-	// AzureResourceGroup is the resource group of the nodes used for the cluster
-	AzureResourceGroup = "azure-resource-group"
-
 	// PolicyAuditModeArg argument enables policy audit mode.
 	PolicyAuditModeArg = "policy-audit-mode"
 
@@ -1698,12 +1692,6 @@ type DaemonConfig struct {
 
 	// Azure options
 
-	// AzureSubscriptionID is the subscription ID to use when accessing the Azure API
-	AzureSubscriptionID string
-
-	// AzureResourceGroup is the resource group of the nodes used for the cluster
-	AzureResourceGroup string
-
 	// PolicyAuditMode enables non-drop mode for installed policies. In
 	// audit mode packets affected by policies will not be dropped.
 	// Policy related decisions can be checked via the poicy verdict messages.
@@ -2104,8 +2092,6 @@ func (c *DaemonConfig) Populate() {
 	c.AllowLocalhost = viper.GetString(AllowLocalhost)
 	c.AnnotateK8sNode = viper.GetBool(AnnotateK8sNode)
 	c.AutoCreateCiliumNodeResource = viper.GetBool(AutoCreateCiliumNodeResource)
-	c.AzureSubscriptionID = viper.GetString(AzureSubscriptionID)
-	c.AzureResourceGroup = viper.GetString(AzureResourceGroup)
 	c.BPFCompilationDebug = viper.GetBool(BPFCompileDebugName)
 	c.BPFRoot = viper.GetString(BPFRoot)
 	c.CertDirectory = viper.GetString(CertsDirectory)


### PR DESCRIPTION
Split out all options which are specific to cilium-operator into the
separate github.com/cilium/cilium/operator/option package.
    
In the long term, the goal is to separate options which are common to
all Cilium binaries from options applicable to only a specific binary
(or a subset of them). This should also help to reduce unnecessary
dependencies and binary size.