### PR TITLE
pkg/k8s: remove unused consts and variables

### DIFF
--- a/pkg/k8s/apis/cilium.io/v2/client/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/client/register.go
@@ -31,7 +31,6 @@ import (
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
@@ -80,30 +79,7 @@ var SchemeGroupVersion = schema.GroupVersion{
 	Version: CustomResourceDefinitionVersion,
 }
 
-// Resource takes an unqualified resource and returns a Group qualified GroupResource
-func Resource(resource string) schema.GroupResource {
-	return SchemeGroupVersion.WithResource(resource).GroupResource()
-}
-
 var (
-	// SchemeBuilder is needed by DeepCopy generator.
-	SchemeBuilder runtime.SchemeBuilder
-	// localSchemeBuilder and AddToScheme will stay in k8s.io/kubernetes.
-	localSchemeBuilder = &SchemeBuilder
-
-	// AddToScheme adds all types of this clientset into the given scheme.
-	// This allows composition of clientsets, like in:
-	//
-	//   import (
-	//     "k8s.io/client-go/kubernetes"
-	//     clientsetscheme "k8s.io/client-go/kuberentes/scheme"
-	//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-	//   )
-	//
-	//   kclientset, _ := kubernetes.NewForConfig(c)
-	//   aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
-	AddToScheme = localSchemeBuilder.AddToScheme
-
 	comparableCRDSchemaVersion = versioncheck.MustVersion(CustomResourceDefinitionSchemaVersion)
 )
 

--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -28,16 +28,6 @@ const (
 
 	// CustomResourceDefinitionVersion is the current version of the resource
 	CustomResourceDefinitionVersion = "v2"
-
-	// CustomResourceDefinitionSchemaVersion is semver-conformant version of CRD schema
-	// Used to determine if CRD needs to be updated in cluster
-	CustomResourceDefinitionSchemaVersion = "1.17"
-
-	// CustomResourceDefinitionSchemaVersionKey is key to label which holds the CRD schema version
-	CustomResourceDefinitionSchemaVersionKey = "io.cilium.k8s.crd.schema.version"
-
-	// CNPKindDefinition is the kind name for Cilium Network Policy
-	CNPKindDefinition = "CiliumNetworkPolicy"
 )
 
 // SchemeGroupVersion is group version used to register these objects

--- a/pkg/policy/groups/helpers.go
+++ b/pkg/policy/groups/helpers.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/k8s"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	cilium_client_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2/client"
 	"github.com/cilium/cilium/pkg/policy/api"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -52,7 +53,7 @@ func createDerivativeCNP(ctx context.Context, cnp *cilium_v2.CiliumNetworkPolicy
 			Namespace: cnp.ObjectMeta.Namespace,
 			OwnerReferences: []v1.OwnerReference{{
 				APIVersion:         cilium_v2.SchemeGroupVersion.String(),
-				Kind:               cilium_v2.CNPKindDefinition,
+				Kind:               cilium_client_v2.CNPKindDefinition,
 				Name:               cnp.ObjectMeta.Name,
 				UID:                cnp.ObjectMeta.UID,
 				BlockOwnerDeletion: &blockOwnerDeletionPtr,


### PR DESCRIPTION
Some consts and variables are no longer being by the refactoring of
f0049da61f4f, for this reason we can remove them.

Fixes: f0049da61f4f ("pkg/k8s: fix all structural issues with CNP validation")
Signed-off-by: André Martins <andre@cilium.io>