### PR TITLE
make: fix govet target after renaming hubble-proxy to hubble-relay

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -375,7 +375,7 @@ govet:
     ./cilium-health/... \
     ./common/... \
     ./daemon/... \
-    ./hubble-proxy/... \
+    ./hubble-relay/... \
     ./operator/... \
     ./pkg/... \
     ./plugins/... \


### PR DESCRIPTION
hubble-proxy was renamed to hubble-relay in #11122, adjust its name in
the `govet` list as well.