### PR TITLE
test: Allow kubectl label node to overwrite

### DIFF
--- a/test/eks/select-cluster.sh
+++ b/test/eks/select-cluster.sh
@@ -37,7 +37,7 @@ echo "labeling nodes"
 index=1
 for node in $(kubectl get nodes --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}');
 do
-    kubectl label node $node cilium.io/ci-node=k8s$index
+    kubectl label node $node cilium.io/ci-node=k8s$index --overwrite
     index=$((index+1))
 done
 

--- a/test/gke/select-cluster.sh
+++ b/test/gke/select-cluster.sh
@@ -41,7 +41,7 @@ echo "labeling nodes"
 index=1
 for node in $(kubectl get nodes --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}');
 do
-    kubectl label node $node cilium.io/ci-node=k8s$index
+    kubectl label node $node cilium.io/ci-node=k8s$index --overwrite
     index=$((index+1))
 done
 


### PR DESCRIPTION
Sometimes cluster selection for GKE fails like so:

13:31:10  labeling nodes
13:31:11  error: 'cilium.io/ci-node' already has a value (k8s1), and --overwrite is false

Add the '--overwrite' option to allow re-labeling of a node.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
