### PR TITLE
test: Only call Fail() once for all error logs

### DIFF
--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -450,6 +450,7 @@ func CanRunK8sVersion(ciliumVersion, k8sVersionStr string) (bool, error) {
 // given log messages contains an entry from the blacklist (map key) AND
 // does not contain ignore messages (map value).
 func failIfContainsBadLogMsg(logs string, blacklist map[string][]string) {
+	nFailures := 0
 	for _, msg := range strings.Split(logs, "\n") {
 		for fail, ignoreMessages := range blacklist {
 			if strings.Contains(msg, fail) {
@@ -462,10 +463,13 @@ func failIfContainsBadLogMsg(logs string, blacklist map[string][]string) {
 				}
 				if !ok {
 					fmt.Fprintf(CheckLogs, "⚠️  Found a %q in logs\n", fail)
-					Fail(fmt.Sprintf("Found a %q in Cilium Logs", fail))
+					nFailures++
 				}
 			}
 		}
+	}
+	if nFailures > 0 {
+		Fail(fmt.Sprintf("Found %d Cilium logs matching list of errors that must be investigated", nFailures))
 	}
 }
 


### PR DESCRIPTION
We've recently expanded the fail cases for when different logs are seen
in the cilium-agent logs. However at the same time we also introduced
a behaviour where for every single instance of the failure in the logs,
we will call Fail(). In local CI runs with `--holdEnvironment` this can
lead to a loop where the test is suspended for debugging, the developer
performs ^Z and `fg`, then the same failure prints again, potentially
many times over before the test can finally proceed / clean up.

Tidy it up by detecting any failure of this sort once, then failing out.

Note that the actual failure logs should already be visible earlier in
the test output so this should not hide the failures from the developer.