### PR TITLE
test: Fix skipping of NodePort tests

### DIFF
--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -918,7 +918,10 @@ var _ = Describe("K8sServicesTest", func() {
 			})
 
 		SkipContextIf(
-			helpers.DoesNotRunOnNetNextOr419Kernel,
+			func() bool {
+				return helpers.DoesNotRunOnNetNextOr419Kernel() ||
+					helpers.RunsWithKubeProxy()
+			},
 			"Tests NodePort BPF", func() {
 				// TODO(brb) Add with L7 policy test cases after GH#8971 has been fixed
 

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -983,7 +983,7 @@ var _ = Describe("K8sServicesTest", func() {
 						testHostPort()
 					})
 
-					It("Tests GH#10983", func() {
+					SkipItIf(helpers.DoesNotExistNodeWithoutCilium, "Tests GH#10983", func() {
 						var data v1.Service
 						_, k8s2IP := kubectl.GetNodeInfo(helpers.K8s2)
 


### PR DESCRIPTION
These issues were found while running tests locally with option combinations that are not tested in our CI pipelines.

The first commit skips BPF-based NodePort tests when running with kube-proxy enabled (found while running `NETNEXT=1 K8S_VERSION=1.11 ginkgo --focus="K8s*"`).
The second commit skips one test that uses the third-node, the node without Cilium, when that node isn't available (found while running `KUBEPROXY=0 NETNEXT=1 K8S_VERSION=1.11 ginkgo --focus="K8s*"`).

Test results with `KUBEPROXY=1` and the net-next kernel can be observed at #11118.

/cc @brb 