### PR TITLE
Use Go stdlib context package instead of golang.org/x/net/context

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -15,6 +15,7 @@
 package client
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -32,7 +33,6 @@ import (
 
 	runtime_client "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
-	"golang.org/x/net/context"
 )
 
 type Client struct {

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -17,6 +17,7 @@
 package client
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -24,7 +25,6 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 
-	"golang.org/x/net/context"
 	. "gopkg.in/check.v1"
 )
 

--- a/pkg/envoy/grpc.go
+++ b/pkg/envoy/grpc.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/cilium/proxy/go/cilium/api"
 	envoy_api_v2 "github.com/cilium/proxy/go/envoy/api/v2"
-	net_context "golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
 )
@@ -86,7 +85,7 @@ func (s *xdsGRPCServer) StreamListeners(stream envoy_api_v2.ListenerDiscoverySer
 	return (*xds.Server)(s).HandleRequestStream(stream.Context(), stream, ListenerTypeURL)
 }
 
-func (s *xdsGRPCServer) FetchListeners(ctx net_context.Context, req *envoy_api_v2.DiscoveryRequest) (*envoy_api_v2.DiscoveryResponse, error) {
+func (s *xdsGRPCServer) FetchListeners(ctx context.Context, req *envoy_api_v2.DiscoveryRequest) (*envoy_api_v2.DiscoveryResponse, error) {
 	// The Fetch methods are only called via the REST API, which is not
 	// implemented in Cilium. Only the Stream methods are called over gRPC.
 	return nil, ErrNotImplemented
@@ -96,7 +95,7 @@ func (s *xdsGRPCServer) StreamNetworkPolicies(stream cilium.NetworkPolicyDiscove
 	return (*xds.Server)(s).HandleRequestStream(stream.Context(), stream, NetworkPolicyTypeURL)
 }
 
-func (s *xdsGRPCServer) FetchNetworkPolicies(ctx net_context.Context, req *envoy_api_v2.DiscoveryRequest) (*envoy_api_v2.DiscoveryResponse, error) {
+func (s *xdsGRPCServer) FetchNetworkPolicies(ctx context.Context, req *envoy_api_v2.DiscoveryRequest) (*envoy_api_v2.DiscoveryResponse, error) {
 	// The Fetch methods are only called via the REST API, which is not
 	// implemented in Cilium. Only the Stream methods are called over gRPC.
 	return nil, ErrNotImplemented
@@ -106,7 +105,7 @@ func (s *xdsGRPCServer) StreamNetworkPolicyHosts(stream cilium.NetworkPolicyHost
 	return (*xds.Server)(s).HandleRequestStream(stream.Context(), stream, NetworkPolicyHostsTypeURL)
 }
 
-func (s *xdsGRPCServer) FetchNetworkPolicyHosts(ctx net_context.Context, req *envoy_api_v2.DiscoveryRequest) (*envoy_api_v2.DiscoveryResponse, error) {
+func (s *xdsGRPCServer) FetchNetworkPolicyHosts(ctx context.Context, req *envoy_api_v2.DiscoveryRequest) (*envoy_api_v2.DiscoveryResponse, error) {
 	// The Fetch methods are only called via the REST API, which is not
 	// implemented in Cilium. Only the Stream methods are called over gRPC.
 	return nil, ErrNotImplemented


### PR DESCRIPTION
The context package was added in Go 1.7 [1]. The implementation in
x/net/context is merely a type alias now on newer Go versions, so use
context directly.

[1] https://golang.org/doc/go1.7#context