### PR TITLE
k8s/informer: panic Cilium if k8s watcher panic

### DIFF
--- a/pkg/k8s/informer/informer.go
+++ b/pkg/k8s/informer/informer.go
@@ -16,11 +16,35 @@ package informer
 
 import (
 	"fmt"
+	"net/http"
 	"time"
 
-	"k8s.io/apimachinery/pkg/runtime"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+
+	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
+	utilRuntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
 )
+
+var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "k8s")
+
+func init() {
+	utilRuntime.PanicHandlers = append(
+		utilRuntime.PanicHandlers,
+		func(r interface{}) {
+			// from k8s library
+			if r == http.ErrAbortHandler {
+				// honor the http.ErrAbortHandler sentinel panic value:
+				//   ErrAbortHandler is a sentinel panic value to abort a handler.
+				//   While any panic from ServeHTTP aborts the response to the client,
+				//   panicking with ErrAbortHandler also suppresses logging of a stack trace to the server's error log.
+				return
+			}
+			log.Fatal("Panic in Kubernetes runtime handler")
+		},
+	)
+}
 
 type ConvertFunc func(obj interface{}) interface{}
 
@@ -29,7 +53,7 @@ type ConvertFunc func(obj interface{}) interface{}
 // the local cache.
 func NewInformer(
 	lw cache.ListerWatcher,
-	objType runtime.Object,
+	objType k8sRuntime.Object,
 	resyncPeriod time.Duration,
 	h cache.ResourceEventHandler,
 	convertFunc ConvertFunc,
@@ -44,7 +68,7 @@ func NewInformer(
 // caller can also set a cache.Store.
 func NewInformerWithStore(
 	lw cache.ListerWatcher,
-	objType runtime.Object,
+	objType k8sRuntime.Object,
 	resyncPeriod time.Duration,
 	h cache.ResourceEventHandler,
 	convertFunc ConvertFunc,


### PR DESCRIPTION
Since k8s watchers are running as a go routine, if that go routine
panics, will mean that Cilium will continue to run without that go
routine. This can cause watchers to stop working without the user
noticing.

This also means that a panic happening in any resource event handler
functions (AddFunc, UpdateFunc, DelFunc) would also be unnoticed.

Fixes: 637d73943c4b ("Remove function queues for Endpoint[s|Slice]")
Signed-off-by: André Martins <andre@cilium.io>