### PR TITLE
Add ability to detect iptables mode in cilium daemon image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ LABEL cilium-sha=${CILIUM_SHA}
 # versions to be built while allowing the new versions to make changes
 # that are not backwards compatible.
 #
-FROM quay.io/cilium/cilium-builder:2020-04-16 as builder
+FROM quay.io/cilium/cilium-builder:2020-04-29 as builder
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"
@@ -41,7 +41,7 @@ RUN make LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 V=$V LIBNETWORK_PLUGIN=$LIBNETWORK_PLU
 # built while allowing the new versions to make changes that are not
 # backwards compatible.
 #
-FROM quay.io/cilium/cilium-runtime:2020-04-22
+FROM quay.io/cilium/cilium-runtime:2020-04-29
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -2,7 +2,7 @@
 # Cilium build-time dependencies.
 # Image created from this file is used to build Cilium.
 #
-FROM docker.io/library/ubuntu:18.04
+FROM docker.io/library/ubuntu:20.04
 
 LABEL maintainer="maintainer@cilium.io"
 

--- a/contrib/packaging/docker/Dockerfile.runtime
+++ b/contrib/packaging/docker/Dockerfile.runtime
@@ -1,7 +1,7 @@
 #
 # Cilium runtime base image
 #
-FROM docker.io/library/ubuntu:18.04 as runtime-base
+FROM docker.io/library/ubuntu:20.04 as runtime-base
 RUN apt-get update && \
 apt-get upgrade -y && \
 #
@@ -10,8 +10,6 @@ apt-get upgrade -y && \
 apt-get install -y --no-install-recommends \
 # Additional iproute2 runtime dependencies
     libelf1 libmnl0 \
-# Additional BPF build runtime dependencies
-    libgcc-5-dev \
 # Bash completion for Cilium
     bash-completion \
 # Additional misc runtime dependencies
@@ -19,6 +17,30 @@ apt-get install -y --no-install-recommends \
 apt-get purge --auto-remove && \
 apt-get clean && \
 rm -rf /var/lib/apt/lists/*
+# Add support for auto-detection of iptables mode
+COPY iptables-wrapper /usr/sbin/iptables-wrapper
+RUN update-alternatives \
+    --install /usr/sbin/iptables \
+        iptables \
+        /usr/sbin/iptables-wrapper \
+        100 \
+    --slave /usr/sbin/iptables-restore \
+        iptables-restore \
+        /usr/sbin/iptables-wrapper \
+    --slave /usr/sbin/iptables-save \
+        iptables-save \
+        /usr/sbin/iptables-wrapper
+RUN update-alternatives \
+    --install /usr/sbin/ip6tables \
+        ip6tables \
+        /usr/sbin/iptables-wrapper \
+        100 \
+    --slave /usr/sbin/ip6tables-restore \
+        ip6tables-restore \
+        /usr/sbin/iptables-wrapper \
+    --slave /usr/sbin/ip6tables-save \
+        ip6tables-save \
+        /usr/sbin/iptables-wrapper
 
 #
 # Build Cilium runtime dependencies.
@@ -31,6 +53,7 @@ RUN \
 # Build dependencies
 #
 apt-get update && \
+DEBIAN_FRONTEND="noninteractive" \
 apt-get install -y --no-install-recommends \
 # Base runtime-build dependencies
   make curl ca-certificates xz-utils binutils \

--- a/contrib/packaging/docker/iptables-wrapper
+++ b/contrib/packaging/docker/iptables-wrapper
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# Detect whether the base system is using iptables-legacy or
+# iptables-nft. This assumes that some non-containerized process (eg
+# kubelet) has already created some iptables rules.
+
+# Bugs in iptables-nft 1.8.3 may cause it to get stuck in a loop in
+# some circumstances, so we have to run the nft check in a timeout. To
+# avoid hitting that timeout, we only bother to even check nft if
+# legacy iptables was empty / mostly empty.
+
+num_legacy_lines=$( (iptables-legacy-save || true; ip6tables-legacy-save || true) 2>/dev/null | grep '^-' | wc -l)
+if [ "${num_legacy_lines}" -ge 10 ]; then
+    mode=legacy
+else
+    num_nft_lines=$( (timeout 5 sh -c "iptables-nft-save; ip6tables-nft-save" || true) 2>/dev/null | grep '^-' | wc -l)
+    if [ "${num_legacy_lines}" -ge "${num_nft_lines}" ]; then
+	mode=legacy
+    else
+	mode=nft
+    fi
+fi
+
+update-alternatives --set iptables "/usr/sbin/iptables-${mode}" > /dev/null
+update-alternatives --set ip6tables "/usr/sbin/ip6tables-${mode}" > /dev/null
+
+# Now re-exec the original command with the newly-selected alternative
+exec "$0" "$@"
+


### PR DESCRIPTION
This feature is required by any OS that enables nft based iptables
i.e. Debian >=10, CentOS 8.1 that have iptables >=1.8.

This solution is based on kube-proxy fix to the same issue:
https://github.com/kubernetes/kubernetes/pull/82966

Bumped cilium-runtime base image to Ubuntu 20.04 that has iptables 1.8.4
Removed libgcc-5-dev which is not available in 20.04.
Added iptables-wrapper that handles iptables mode detection.

Signed-off-by: Maciej Skrocki <maciejskrocki@google.com>

```release-note
Add ability to detect iptables mode (nft/legacy) in cilium daemon image
```
