### PR TITLE
Fixes cilium-agent helm chart so the daemonset can be configured with…

### DIFF
--- a/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
@@ -38,7 +38,7 @@ spec:
 {{ toYaml .Values.global.affinity | indent 8 }}
 {{- end }}
       containers:
-{{- if .Values.global.sleepAfterInit }}
+{{- if .Values.agent.sleepAfterInit }}
       - command: [ "/bin/bash", "-c", "--" ]
         args: [ "while true; do sleep 30; done;" ]
         livenessProbe:

--- a/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
@@ -38,7 +38,7 @@ spec:
 {{ toYaml .Values.global.affinity | indent 8 }}
 {{- end }}
       containers:
-{{- if .Values.agent.sleepAfterInit }}
+{{- if .Values.sleepAfterInit }}
       - command: [ "/bin/bash", "-c", "--" ]
         args: [ "while true; do sleep 30; done;" ]
         livenessProbe:


### PR DESCRIPTION
Fixes cilium-agent helm chart so the daemonset can be configured with correct sleepAfterInit key

Fixes: #11201

Signed-off-by: Sean Winn <sean@isovalent.com>

```release-note
Setting the agent.sleepAfterInit helm chart value to True will correctly configure the agent to sleep after Init
```
