### PR TITLE
test: Only restart KubeDNS if required

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -235,6 +235,9 @@ const (
 
 	// HelmTemplate is the location of the Helm templates to install Cilium
 	HelmTemplate = "../install/kubernetes/cilium"
+
+	// ServiceSuffix is the Kubernetes service suffix
+	ServiceSuffix = "svc.cluster.local"
 )
 
 var (

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1774,6 +1774,44 @@ func (kub *Kubectl) ValidateKubernetesDNS() error {
 	return nil
 }
 
+// RestartUnmanagedPodsInNamespace restarts all pods in a namespace which are:
+// * not host networking
+// * not managed by Cilium already
+func (kub *Kubectl) RestartUnmanagedPodsInNamespace(namespace string, excludePodPrefix ...string) {
+	podList := &v1.PodList{}
+	cmd := KubectlCmd + " -n " + namespace + " get pods -o json"
+	res := kub.ExecShort(cmd)
+	if !res.WasSuccessful() {
+		ginkgoext.Failf("Unable to retrieve all pods to restart unmanaged pods with '%s': %s", cmd, res.OutputPrettyPrint())
+	}
+	if err := res.Unmarshal(podList); err != nil {
+		ginkgoext.Failf("Unable to unmarshal podlist: %s", err)
+	}
+
+iteratePods:
+	for _, pod := range podList.Items {
+		if pod.Spec.HostNetwork {
+			continue
+		}
+
+		for _, prefix := range excludePodPrefix {
+			if strings.HasPrefix(pod.Name, prefix) {
+				continue iteratePods
+			}
+		}
+
+		ep, err := kub.GetCiliumEndpoint(namespace, pod.Name)
+		if err != nil || ep.Identity == nil || ep.Identity.ID == 0 {
+			ginkgoext.By("Restarting unmanaged pod %s/%s", namespace, pod.Name)
+			cmd = KubectlCmd + " -n " + namespace + " delete pod " + pod.Name
+			res = kub.ExecShort(cmd)
+			if !res.WasSuccessful() {
+				ginkgoext.Failf("Unable to restart unmanaged pod with '%s': %s", cmd, res.OutputPrettyPrint())
+			}
+		}
+	}
+}
+
 // RedeployKubernetesDnsIfNecessary validates if the Kubernetes DNS is
 // functional and re-deploys it if it is not and then waits for it to deploy
 // successfully and become operational. See ValidateKubernetesDNS() for the

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -107,8 +107,8 @@ type TimeoutConfig struct {
 // Validate ensuires that the parameters for the TimeoutConfig are reasonable
 // for running in tests.
 func (c *TimeoutConfig) Validate() error {
-	if c.Timeout < 10*time.Second {
-		return fmt.Errorf("Timeout too short (must be at least 10 seconds): %v", c.Timeout)
+	if c.Timeout < 5*time.Second {
+		return fmt.Errorf("Timeout too short (must be at least 5 seconds): %v", c.Timeout)
 	}
 	if c.Ticker == 0 {
 		c.Ticker = 5 * time.Second

--- a/test/k8sT/assertionHelpers.go
+++ b/test/k8sT/assertionHelpers.go
@@ -128,10 +128,7 @@ func DeployCiliumOptionsAndDNS(vm *helpers.Kubectl, ciliumFilename string, optio
 
 	switch helpers.GetCurrentIntegration() {
 	case helpers.CIIntegrationGKE:
-		By("Restarting all kube-system pods")
-		if res := vm.DeleteResource("pod", fmt.Sprintf("-n %s --all", helpers.KubeSystemNamespace)); !res.WasSuccessful() {
-			log.Warningf("Unable to delete kube-system pods: %s", res.OutputPrettyPrint())
-		}
+		vm.RestartUnmanagedPodsInNamespace(helpers.KubeSystemNamespace)
 	}
 
 	switch helpers.GetCurrentIntegration() {


### PR DESCRIPTION
Instead of always restarting the kube-dns deployment, split the validation of the installation into a separate function so we can validate the deployment and only restart kube-dns if we have to.

While doing so, replace the validation with a more efficient version that invokes as few kubectl execs within loops as possible and parallelize operations were possible.

Given that Cilium is typically re-deployed before this logic is executed, the slowest path is typically the service plumbing. Allow for some aggressive timeout for the Kubernetes DNS service to be plumbed to avoid restarting it in the common case.

Example output:
```
STEP: Checking if kube-dns service is plumbed correctly
STEP: Checking if pods have identity
STEP: Checking if DNS can resolve
STEP: Checking service kube-system/kube-dns plumbing in cilium pod cilium-b9dcp: ClusterIP 10.71.240.10 not found in service list of cilium pod cilium-b9dcp
STEP: Checking service kube-system/kube-dns plumbing in cilium pod cilium-fm9qm: ClusterIP 10.71.240.10 not found in service list of cilium pod cilium-fm9qm
STEP: Checking service kube-system/kube-dns plumbing in cilium pod cilium-mxjvw: ClusterIP 10.71.240.10 not found in service list of cilium pod cilium-mxjvw
STEP: Checking service kube-system/kube-dns plumbing in cilium pod cilium-fm9qm: ClusterIP 10.71.240.10 not found in service list of cilium pod cilium-fm9qm
STEP: Checking service kube-system/kube-dns plumbing in cilium pod cilium-mxjvw: ClusterIP 10.71.240.10 not found in service list of cilium pod cilium-mxjvw
STEP: Checking service kube-system/kube-dns plumbing in cilium pod cilium-b9dcp: ClusterIP 10.71.240.10 not found in service list of cilium pod cilium-b9dcp
STEP: Checking service kube-system/kube-dns plumbing in cilium pod cilium-fm9qm: ClusterIP 10.71.240.10 not found in service list of cilium pod cilium-fm9qm
STEP: Checking service kube-system/kube-dns plumbing in cilium pod cilium-b9dcp: ClusterIP 10.71.240.10 not found in service list of cilium pod cilium-b9dcp
STEP: Checking service kube-system/kube-dns plumbing in cilium pod cilium-mxjvw: ClusterIP 10.71.240.10 not found in service list of cilium pod cilium-mxjvw
STEP: Checking service kube-system/kube-dns plumbing in cilium pod cilium-b9dcp: ClusterIP 10.71.240.10 not found in service list of cilium pod cilium-b9dcp
STEP: Checking service kube-system/kube-dns plumbing in cilium pod cilium-mxjvw: ClusterIP 10.71.240.10 not found in service list of cilium pod cilium-mxjvw
STEP: Checking service kube-system/kube-dns plumbing in cilium pod cilium-fm9qm: ClusterIP 10.71.240.10 not found in service list of cilium pod cilium-fm9qm
STEP: Checking service kube-system/kube-dns plumbing in cilium pod cilium-b9dcp: ClusterIP 10.71.240.10 not found in service list of cilium pod cilium-b9dcp
STEP: Checking service kube-system/kube-dns plumbing in cilium pod cilium-fm9qm: ClusterIP 10.71.240.10 not found in service list of cilium pod cilium-fm9qm
STEP: Checking service kube-system/kube-dns plumbing in cilium pod cilium-mxjvw: ClusterIP 10.71.240.10 not found in service list of cilium pod cilium-mxjvw
STEP: Kubernetes DNS is not ready: ClusterIP 10.71.240.10 not found in service list of cilium pod cilium-mxjvw
STEP: Restarting Kubernetes DSN (-l k8s-app=kube-dns)
STEP: Checking service kube-system/kube-dns plumbing in cilium pod cilium-mxjvw: unable to find service backend 10.68.1.228:53 in datapath of cilium pod cilium-mxjvw
STEP: Checking service kube-system/kube-dns plumbing in cilium pod cilium-b9dcp: unable to find service backend 10.68.1.228:53 in cilium pod cilium-b9dcp
STEP: Checking service kube-system/kube-dns plumbing in cilium pod cilium-fm9qm: unable to find service backend 10.68.1.228:53 in cilium pod cilium-fm9qm
STEP: Waiting for Kubernetes DNS to become operational
STEP: Checking if deployment is ready
STEP: Checking if kube-dns service is plumbed correctly
STEP: Checking if pods have identity
STEP: Checking if DNS can resolve
```

## Before

```
19:44:29 STEP: Number of ready Cilium pods: 2
19:44:29 STEP: Installing DNS Deployment
19:44:29 STEP: Restarting all kube-system pods
19:45:15 STEP: Performing Cilium preflight check
19:45:15 STEP: Performing Cilium status preflight check
19:45:16 STEP: Performing Cilium controllers preflight check
19:45:18 STEP: Performing Cilium health check
19:45:23 STEP: Performing Cilium service preflight check
19:45:23 STEP: Performing K8s service preflight check
19:45:23 STEP: Waiting for cilium-operator to be ready
19:45:23 STEP: Waiting for kube-dns to be ready
19:45:23 STEP: Running kube-dns preflight check
19:45:26 STEP: Performing K8s service preflight check
19:45:26 STEP: Making sure all endpoints are in ready state
19:45:28 STEP: Launching cilium monitor on "cilium-m9mlj"  Before: 1min
```

~1min

## After

```
20:22:11 STEP: Number of ready Cilium pods: 2
20:22:11 STEP: Validating if Kubernetes DNS is deployed
20:22:11 STEP: Checking if deployment is ready
20:22:11 STEP: Checking if kube-dns service is plumbed correctly
20:22:11 STEP: Checking if pods have identity
20:22:11 STEP: Checking if DNS can resolve
20:22:13 STEP: Kubernetes DNS is up and operational
20:22:13 STEP: Performing Cilium preflight check
20:22:13 STEP: Performing Cilium status preflight check
20:22:14 STEP: Performing Cilium controllers preflight check
20:22:15 STEP: Performing Cilium health check
20:22:21 STEP: Performing Cilium service preflight check
20:22:21 STEP: Performing K8s service preflight check
20:22:21 STEP: Waiting for cilium-operator to be ready
20:22:22 STEP: Making sure all endpoints are in ready state
20:22:24 STEP: Launching cilium monitor on "cilium-swqh6"
```

~10s

Fixes: #10980