### PR TITLE
docs: Document how to run tests on backport PRs

### DIFF
--- a/Documentation/contributing/release/backports.rst
+++ b/Documentation/contributing/release/backports.rst
@@ -189,6 +189,14 @@ Via GitHub web interface
    the ``start-backport`` script above (``GITHUB_TOKEN`` needs to be set for
    this to work).
 
+Running the CI against the pull request
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To validate a cross-section of various tests against the PRs, backport PRs
+should be validated in the CI by running all CI targets. This can be triggered
+by adding a comment to the PR with exactly the text ``never-tell-me-the-odds``.
+The comment must not contain any other characters.
+
 After the backports are merged
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/Documentation/contributing/testing/ci.rst
+++ b/Documentation/contributing/testing/ci.rst
@@ -204,6 +204,10 @@ illustrating which subset of tests the job runs.
 |                                                                                                                | test-gke          |                    |
 +----------------------------------------------------------------------------------------------------------------+-------------------+--------------------+
 
+For Backport PRs, the phrase ``never-tell-me-the-odds`` should be used to
+trigger all of the above jobs which are marked as required to validate changes
+to existing releases.
+
 There are some feature flags based on Pull Requests labels, the list of labels
 are the following:
 


### PR DESCRIPTION
I feel like there was another alternative to this phrase to trigger all jobs on backport PRs, but as much trouble as I have to remember this phrase, I don't remember what the other phrase is. (It's `never-tell-me-the-odds`)

Anyway, document it.

/cc @jrfastab @jrajahalme  