### PR TITLE
test: Overwrite existing taint when labeling nodes with NoSchedule

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -380,7 +380,7 @@ func (kub *Kubectl) labelNodes() error {
 	if node != "" {
 		// Prevent scheduling any pods on the node, as it will be used as an external client
 		// to send requests to k8s{1,2}
-		cmd := fmt.Sprintf("%s taint nodes %s key=value:NoSchedule", KubectlCmd, node)
+		cmd := fmt.Sprintf("%s taint --overwrite nodes %s key=value:NoSchedule", KubectlCmd, node)
 		res := kub.ExecMiddle(cmd)
 		if !res.WasSuccessful() {
 			return fmt.Errorf("unable to taint node with '%s': %s", cmd, res.OutputPrettyPrint())


### PR DESCRIPTION
Martynas reported that the following error occurs:
```
      unable label nodes: unable to taint node with 'kubectl taint nodes k8s3 key=value:NoSchedule': Exitcode: 1
      Stdout:
      Stderr:
         error: node k8s3 already has key taint(s) with same effect(s) and --overwrite is false
```

.. when the option `--cilium.provision=false` is used

Fixes: 014fd8e41ae ("test: Decouple node labeling from node names")