### PR TITLE
ci: Prune only docker images built for current build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@
 # cilium-envoy from github.com/cilium/proxy
 #
 FROM quay.io/cilium/cilium-envoy:a3385205ad620550b35d3b0b651e40898386e6e3 as cilium-envoy
+ARG CILIUM_SHA=""
+LABEL cilium-sha=${CILIUM_SHA}
 
 #
 # Cilium incremental build. Should be fast given builder-deps is up-to-date!
@@ -14,6 +16,8 @@ FROM quay.io/cilium/cilium-envoy:a3385205ad620550b35d3b0b651e40898386e6e3 as cil
 # that are not backwards compatible.
 #
 FROM quay.io/cilium/cilium-builder:2020-04-16 as builder
+ARG CILIUM_SHA=""
+LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"
 WORKDIR /go/src/github.com/cilium/cilium
 COPY . ./
@@ -38,6 +42,8 @@ RUN make LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 V=$V LIBNETWORK_PLUGIN=$LIBNETWORK_PLU
 # backwards compatible.
 #
 FROM quay.io/cilium/cilium-runtime:2020-04-22
+ARG CILIUM_SHA=""
+LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"
 COPY --from=builder /tmp/install /
 COPY --from=cilium-envoy / /

--- a/Makefile
+++ b/Makefile
@@ -227,6 +227,7 @@ docker-image-no-clean: GIT_VERSION
 		--build-arg LOCKDEBUG=${LOCKDEBUG} \
 		--build-arg V=${V} \
 		--build-arg LIBNETWORK_PLUGIN=${LIBNETWORK_PLUGIN} \
+		--build-arg CILIUM_SHA=$(firstword $(GIT_VERSION)) \
 		-t "cilium/cilium:$(DOCKER_IMAGE_TAG)" .
 	$(QUIET)$(CONTAINER_ENGINE) tag cilium/cilium:$(DOCKER_IMAGE_TAG) cilium/cilium:$(DOCKER_IMAGE_TAG)-${GOARCH}
 	$(QUIET)echo "Push like this when ready:"
@@ -251,8 +252,11 @@ docker-cilium-dev-manifest:
 	$(QUIET) contrib/scripts/push_manifest.sh cilium-dev $(DOCKER_IMAGE_TAG)
 
 docker-operator-image: GIT_VERSION
-	$(QUIET)$(CONTAINER_ENGINE) build --build-arg LOCKDEBUG=${LOCKDEBUG} -f cilium-operator.Dockerfile -t "cilium/operator:$(DOCKER_IMAGE_TAG)" .
-	$(QUIET)$(CONTAINER_ENGINE) tag cilium/operator:$(DOCKER_IMAGE_TAG) cilium/operator:$(DOCKER_IMAGE_TAG)-${GOARCH}
+	$(QUIET)$(CONTAINER_ENGINE) build \
+		--build-arg LOCKDEBUG=${LOCKDEBUG} \
+		--build-arg CILIUM_SHA=$(firstword $(GIT_VERSION)) \
+		-f cilium-operator.Dockerfile \
+		-t "cilium/operator:$(DOCKER_IMAGE_TAG)" .
 	$(QUIET)echo "Push like this when ready:"
 	$(QUIET)echo "docker push cilium/operator:$(DOCKER_IMAGE_TAG)-${GOARCH}"
 
@@ -261,7 +265,11 @@ docker-operator-manifest:
 	$(QUIET) contrib/scripts/push_manifest.sh operator $(DOCKER_IMAGE_TAG)
 
 docker-plugin-image: GIT_VERSION
-	$(QUIET)$(CONTAINER_ENGINE) build --build-arg LOCKDEBUG=${LOCKDEUBG} -f cilium-docker-plugin.Dockerfile -t "cilium/docker-plugin:$(DOCKER_IMAGE_TAG)" .
+	$(QUIET)$(CONTAINER_ENGINE) build \
+		--build-arg LOCKDEBUG=${LOCKDEUBG} \
+		--build-arg CILIUM_SHA=$(firstword $(GIT_VERSION)) \
+		-f cilium-docker-plugin.Dockerfile \
+		-t "cilium/docker-plugin:$(DOCKER_IMAGE_TAG)" .
 	$(QUIET)$(CONTAINER_ENGINE) tag cilium/docker-plugin:$(DOCKER_IMAGE_TAG) cilium/docker-plugin:$(DOCKER_IMAGE_TAG)-${GOARCH}
 	$(QUIET)echo "Push like this when ready:"
 	$(QUIET)echo "docker push cilium/docker-plugin:$(DOCKER_IMAGE_TAG)-${GOARCH}"

--- a/cilium-docker-plugin.Dockerfile
+++ b/cilium-docker-plugin.Dockerfile
@@ -1,4 +1,6 @@
 FROM docker.io/library/golang:1.14.2 as builder
+ARG CILIUM_SHA=""
+LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"
 ADD . /go/src/github.com/cilium/cilium
 WORKDIR /go/src/github.com/cilium/cilium/plugins/cilium-docker
@@ -6,6 +8,8 @@ ARG LOCKDEBUG
 RUN make LOCKDEBUG=$LOCKDEBUG
 
 FROM scratch
+ARG CILIUM_SHA=""
+LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"
 COPY --from=builder /go/src/github.com/cilium/cilium/plugins/cilium-docker/cilium-docker /usr/bin/cilium-docker
 WORKDIR /

--- a/cilium-operator.Dockerfile
+++ b/cilium-operator.Dockerfile
@@ -1,4 +1,6 @@
 FROM docker.io/library/golang:1.14.2 as builder
+ARG CILIUM_SHA=""
+LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"
 ADD . /go/src/github.com/cilium/cilium
 WORKDIR /go/src/github.com/cilium/cilium/operator
@@ -6,9 +8,13 @@ ARG LOCKDEBUG
 RUN make LOCKDEBUG=$LOCKDEBUG EXTRA_GO_BUILD_FLAGS="-tags operator_aws,operator_azure"
 
 FROM docker.io/library/alpine:3.9.3 as certs
+ARG CILIUM_SHA=""
+LABEL cilium-sha=${CILIUM_SHA}
 RUN apk --update add ca-certificates
 
 FROM scratch
+ARG CILIUM_SHA=""
+LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"
 COPY --from=builder /go/src/github.com/cilium/cilium/operator/cilium-operator /usr/bin/cilium-operator
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt

--- a/test/clean-local-registry-tag.sh
+++ b/test/clean-local-registry-tag.sh
@@ -21,4 +21,3 @@ docker push $1/cilium/cilium:$2
 docker push $1/cilium/cilium-dev:$2
 docker push $1/cilium/operator:$2
 
-docker image prune -f --all --filter "until=-6h"

--- a/test/make-images-push-to-local-registry.sh
+++ b/test/make-images-push-to-local-registry.sh
@@ -12,3 +12,6 @@ docker tag cilium/operator:$2 $1/cilium/operator:$2
 docker push $1/cilium/cilium:$2
 docker push $1/cilium/cilium-dev:$2
 docker push $1/cilium/operator:$2
+
+cilium_git_version="$(cat GIT_VERSION)"
+docker image prune -f --all --filter "label=cilium-sha=${cilium_git_version%% *}"


### PR DESCRIPTION
This PR should fix GKE builds failures happening on docker build stage (we are concurrently building and image and pruning images aggresively, this change makes the build clean up after itself).