### PR TITLE
ci: Add Hubble helpers

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -3492,6 +3492,20 @@ func (kub *Kubectl) HelmTemplate(chartDir, namespace, filename string, options m
 		fmt.Sprintf("--namespace=%s %s > %s", namespace, optionsString, filename))
 }
 
+// HubbleObserve runs `hubble observe --output=json <args>` on 'ns/pod' and
+// waits for its completion.
+func (kub *Kubectl) HubbleObserve(ns, pod string, args string) *CmdRes {
+	ctx, cancel := context.WithTimeout(context.Background(), ShortCommandTimeout)
+	defer cancel()
+	return kub.ExecPodCmdContext(ctx, ns, pod, fmt.Sprintf("hubble observe --output=json %s", args))
+}
+
+// HubbleObserveFollow runs `hubble observe --follow --output=json <args>` on
+// 'ns/pod' in the background. The process is stopped when ctx is cancelled.
+func (kub *Kubectl) HubbleObserveFollow(ctx context.Context, ns, pod string, args string) *CmdRes {
+	return kub.ExecPodCmdBackground(ctx, ns, pod, fmt.Sprintf("hubble observe --follow --output=json %s", args))
+}
+
 func serviceKey(s v1.Service) string {
 	return s.Namespace + "/" + s.Name
 }

--- a/test/k8sT/hubble.go
+++ b/test/k8sT/hubble.go
@@ -44,23 +44,6 @@ var _ = Describe("K8sHubbleTest", func() {
 		apps        = []string{helpers.App1, helpers.App2, helpers.App3}
 	)
 
-	hubbleGetPodOnNodeWithLabel := func(ns, label string) (string, error) {
-		node, err := kubectl.GetNodeNameByLabel(label)
-		if err != nil {
-			return "", fmt.Errorf("unable to find node for label %s", label)
-		}
-
-		filter := fmt.Sprintf(
-			"-o jsonpath='{.items[?(@.spec.nodeName == \"%s\")].metadata.name}'", node)
-
-		res := kubectl.ExecShort(fmt.Sprintf(
-			"%s -n %s get pods %s %s", helpers.KubectlCmd, ns, hubbleSelector, filter))
-		if !res.WasSuccessful() {
-			return "", fmt.Errorf("hubble-cli pod not found on node '%s'", node)
-		}
-		return res.Output().String(), nil
-	}
-
 	hubbleExecUntilMatch := func(ns, pod, cmd, substr string) error {
 		By("Executing %q on %s/%s", cmd, ns, pod)
 		body := func() bool {
@@ -125,7 +108,7 @@ var _ = Describe("K8sHubbleTest", func() {
 		err := kubectl.WaitforPods(hubbleNamespace, hubbleSelector, helpers.HelperTimeout)
 		Expect(err).Should(BeNil(), "hubble-cli pods did not become ready")
 
-		hubblePodK8s1, err = hubbleGetPodOnNodeWithLabel(hubbleNamespace, helpers.K8s1)
+		hubblePodK8s1, err = kubectl.GetHubbleClientPodOnNodeWithLabel(hubbleNamespace, helpers.K8s1)
 		Expect(err).Should(BeNil(), "unable to find hubble-cli pod on %s", helpers.K8s1)
 	})
 


### PR DESCRIPTION
This PR adds various helpers to make it easier to invoke Hubble from Ginkgo:

`helpers.Kubectl`:
- `GetHubbleClientPodOnNode()` obtains the name of the hubble-cli pod running on a particular node by its name (mirrors GetCiliumPodOnNode`).
- `GetHubbleClientPodOnNodeWithLabel()` obtains the name of the hubble-cli running on a node by label (mirrors GetCiliumPodOnNodeWithLabel`).
- `HubbleObserve()` runs `hubble observe --json` on the specified pod and waits for its completion.
- `HubbleObserveFollow()` runs `hubble observe --json --follow` on the specified pod in the background (e.g. to combine with `WaitUntilMatchFilterLine()` below).

`helpers.CmdRes`:
- `FilterLines()` applies a JSONPath filter to each line of the output and returns its result (similar to the existing `Filter` method, but supports newline-delimited JSON).
- `WaitUntilMatchFilterLine()` applies a JSONPath filter to each line of the output and waits until a line matches a custom string.
- `WaitUntilMatchFilterLineTimeout()` same as above, but with a custom timeout.

~In addition, a `ExpectHubbleClientReady()` helper is added and invoked as part of the Cilium deployment, which deployes hubble-cli pods if the `global.hubble.cli.enabled` Helm option is set.~

The existing Hubble skeleton is adapted to use these new helpers.