### PR TITLE
Add an option to cilium-agent for disabling 'HealthCheckNodePort'

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -63,6 +63,7 @@ cilium-agent [flags]
       --enable-endpoint-health-checking               Enable connectivity health checking between virtual endpoints (default true)
       --enable-endpoint-routes                        Use per endpoint routes instead of routing via cilium_host
       --enable-external-ips                           Enable k8s service externalIPs feature (requires enabling enable-node-port) (default true)
+      --enable-health-check-nodeport                  Enables a healthcheck nodePort server for NodePort services with 'healthCheckNodePort' being set (default true)
       --enable-health-checking                        Enable connectivity health checking (default true)
       --enable-host-firewall                          Enable host network policies (beta)
       --enable-host-port                              Enable k8s hostPort mapping feature (requires enabling enable-node-port) (default true)

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -836,12 +836,14 @@ This section therefore elaborates on the various ``global.kubeProxyReplacement``
   ``probe`` which checks the underlying kernel for available BPF features and automatically
   disables components responsible for the BPF kube-proxy replacement when kernel support
   is missing, the ``partial`` option requires the user to manually specify which components
-  for the BPF kube-proxy replacement should be used. Similarly to ``strict`` mode, the
-  Cilium agent will bail out on start-up with an error message if the underlying kernel
-  requirements are not met. For fine-grained configuration, ``global.hostServices.enabled``,
-  ``global.nodePort.enabled``, ``global.externalIPs.enabled`` and ``global.hostPort.enabled``
-  can be set to ``true``. By default all four options are set to ``false``. A few example
-  configurations for the ``partial`` option are provided below.
+  for the BPF kube-proxy replacement should be used. When ``global.kubeProxyReplacement``
+  is set to ``partial`` make sure to also set ``global.enableHealthCheckNodeport`` to
+  ``false``, so that the Cilium agent does not start the NodePort health check server.
+  Similarly to ``strict`` mode, the Cilium agent will bail out on start-up with an error
+  message if the underlying kernel requirements are not met. For fine-grained configuration,
+  ``global.hostServices.enabled``, ``global.nodePort.enabled``, ``global.externalIPs.enabled``
+  and ``global.hostPort.enabled`` can be set to ``true``. By default all four options are set
+  to ``false``. A few example configurations for the ``partial`` option are provided below.
 
   The following helm setup below would be equivalent to ``global.kubeProxyReplacement=strict``
   in a kube-proxy-free environment:

--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -549,6 +549,9 @@ New ConfigMap Options
     On upgrades of existing installations, this option is disabled by default,
     i.e. it is set to 0.0. Users wanting to use this feature need to enable it
     explicitly in their `ConfigMap`, see section :ref:`upgrade_configmap`.
+  
+  * ``enable-health-check-nodeport`` has been added to allow to configure
+    NodePort server health check when kube-proxy is disabled. 
 
 Deprecated options
 ~~~~~~~~~~~~~~~~~~

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -282,6 +282,9 @@ func init() {
 	flags.Bool(option.EnableHealthChecking, defaults.EnableHealthChecking, "Enable connectivity health checking")
 	option.BindEnv(option.EnableHealthChecking)
 
+	flags.Bool(option.EnableHealthCheckNodePort, defaults.EnableHealthCheckNodePort, "Enables a healthcheck nodePort server for NodePort services with 'healthCheckNodePort' being set")
+	option.BindEnv(option.EnableHealthCheckNodePort)
+
 	flags.StringSlice(option.EndpointStatus, []string{},
 		"Enable additional CiliumEndpoint status features ("+strings.Join(option.EndpointStatusValues(), ",")+")")
 	option.BindEnv(option.EndpointStatus)

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -423,7 +423,7 @@ data:
 
 {{- if .Values.global.kubeProxyReplacement }}
   kube-proxy-replacement:  {{ .Values.global.kubeProxyReplacement | quote }}
-{{- end}}
+{{- end }}
 {{- if .Values.global.hostServices }}
 {{- if .Values.global.hostServices.enabled }}
   enable-host-reachable-services: {{ .Values.global.hostServices.enabled | quote }}
@@ -454,6 +454,9 @@ data:
 {{- end }}
 {{- if .Values.global.nodePort.mode }}
   node-port-mode: {{ .Values.global.nodePort.mode | quote }}
+{{- end }}
+{{- if .Values.global.nodePort.enableHealthCheck }}
+  enable-health-check-nodeport: {{ .Values.global.nodePort.enableHealthCheck | quote}}
 {{- end }}
 {{- if .Values.global.nodePort.acceleration }}
   node-port-acceleration: {{ .Values.global.nodePort.acceleration | quote }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -356,6 +356,9 @@ global:
     # ports is detected
     autoProtectPortRange: true
 
+    # enableHealthCheck enables healthcheck nodePort server for NodePort services
+    enableHealthCheck: true
+
   # hostPort is the configuration for container hostPort mapping
   hostPort:
     # enabled enables the hostPort functionality

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -137,6 +137,7 @@ data:
   install-iptables-rules: "true"
   auto-direct-node-routes: "false"
   kube-proxy-replacement:  "probe"
+  enable-health-check-nodeport: "true"
   node-port-bind-protection: "true"
   enable-auto-protect-node-port-range: "true"
   enable-session-affinity: "true"

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -130,6 +130,7 @@ data:
   install-iptables-rules: "true"
   auto-direct-node-routes: "false"
   kube-proxy-replacement:  "probe"
+  enable-health-check-nodeport: "true"
   node-port-bind-protection: "true"
   enable-auto-protect-node-port-range: "true"
   enable-session-affinity: "true"

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -198,6 +198,10 @@ const (
 	// EnableEndpointHealthChecking
 	EnableEndpointHealthChecking = true
 
+	// EnableHealthCheckNodePort is the default value for
+	// EnableHealthCheckNodePort
+	EnableHealthCheckNodePort = true
+
 	// AlignCheckerName is the BPF object name for the alignchecker.
 	AlignCheckerName = "bpf_alignchecker.o"
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -618,6 +618,9 @@ const (
 	// EnableEndpointHealthChecking is the name of the EnableEndpointHealthChecking option
 	EnableEndpointHealthChecking = "enable-endpoint-health-checking"
 
+	// EnableHealthCheckNodePort is the name of the EnableHealthCheckNodePort option
+	EnableHealthCheckNodePort = "enable-health-check-nodeport"
+
 	// PolicyQueueSize is the size of the queues utilized by the policy
 	// repository.
 	PolicyQueueSize = "policy-queue-size"
@@ -1586,6 +1589,10 @@ type DaemonConfig struct {
 	// health endpoints
 	EnableEndpointHealthChecking bool
 
+	// EnableHealthCheckNodePort enables health checking of NodePort by
+	// cilium
+	EnableHealthCheckNodePort bool
+
 	// KVstoreKeepAliveInterval is the interval in which the lease is being
 	// renewed. This must be set to a value lesser than the LeaseTTL ideally
 	// by a factor of 3.
@@ -1866,6 +1873,7 @@ var (
 		EnableHostIPRestore:          defaults.EnableHostIPRestore,
 		EnableHealthChecking:         defaults.EnableHealthChecking,
 		EnableEndpointHealthChecking: defaults.EnableEndpointHealthChecking,
+		EnableHealthCheckNodePort:    defaults.EnableHealthCheckNodePort,
 		EnableIPv4:                   defaults.EnableIPv4,
 		EnableIPv6:                   defaults.EnableIPv6,
 		EnableL7Proxy:                defaults.EnableL7Proxy,
@@ -2240,6 +2248,7 @@ func (c *DaemonConfig) Populate() {
 	c.EnableEndpointRoutes = viper.GetBool(EnableEndpointRoutes)
 	c.EnableHealthChecking = viper.GetBool(EnableHealthChecking)
 	c.EnableEndpointHealthChecking = viper.GetBool(EnableEndpointHealthChecking)
+	c.EnableHealthCheckNodePort = viper.GetBool(EnableHealthCheckNodePort)
 	c.EnableLocalNodeRoute = viper.GetBool(EnableLocalNodeRoute)
 	c.EnablePolicy = strings.ToLower(viper.GetString(EnablePolicy))
 	c.EnableExternalIPs = viper.GetBool(EnableExternalIPs)

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -128,13 +128,18 @@ type Service struct {
 
 // NewService creates a new instance of the service handler.
 func NewService(monitorNotify monitorNotify) *Service {
+
+	var localHealthServer healthServer
+	if option.Config.EnableHealthCheckNodePort {
+		localHealthServer = healthserver.New()
+	}
 	return &Service{
 		svcByHash:       map[string]*svcInfo{},
 		svcByID:         map[lb.ID]*svcInfo{},
 		backendRefCount: counter.StringCounter{},
 		backendByHash:   map[string]*lb.Backend{},
 		monitorNotify:   monitorNotify,
-		healthServer:    healthserver.New(),
+		healthServer:    localHealthServer,
 		lbmap:           &lbmap.LBBPFMap{},
 	}
 }
@@ -265,8 +270,10 @@ func (s *Service) UpsertService(
 	// only contain local backends (i.e. it has externalTrafficPolicy=Local)
 	if onlyLocalBackends {
 		localBackendCount := len(backendsCopy)
-		s.healthServer.UpsertService(lb.ID(svc.frontend.ID), svc.svcNamespace, svc.svcName,
-			localBackendCount, svc.svcHealthCheckNodePort)
+		if option.Config.EnableHealthCheckNodePort {
+			s.healthServer.UpsertService(lb.ID(svc.frontend.ID), svc.svcNamespace, svc.svcName,
+				localBackendCount, svc.svcHealthCheckNodePort)
+		}
 	} else if svc.svcHealthCheckNodePort == 0 {
 		// Remove the health check server in case this service used to have
 		// externalTrafficPolicy=Local with HealthCheckNodePort in the previous
@@ -759,7 +766,9 @@ func (s *Service) deleteServiceLocked(svc *svcInfo) error {
 		return fmt.Errorf("Unable to release service ID %d: %s", svc.frontend.ID, err)
 	}
 
-	s.healthServer.DeleteService(lb.ID(svc.frontend.ID))
+	if option.Config.EnableHealthCheckNodePort {
+		s.healthServer.DeleteService(lb.ID(svc.frontend.ID))
+	}
 
 	deleteMetric.Inc()
 	s.notifyMonitorServiceDelete(svc.frontend.ID)


### PR DESCRIPTION
This PR adds in an option to the cilium-agent for disabling
'HealthCheckNodePort' based on the KubeProxyReplacement configuration.

Related: #11168
Signed-off-by: Swaminathan Vasudevan <svasudevan@suse.com>