### PR TITLE
pkg/k8s: add missing support for multi-stack

### DIFF
--- a/pkg/k8s/factory_functions.go
+++ b/pkg/k8s/factory_functions.go
@@ -16,6 +16,7 @@ package k8s
 
 import (
 	"reflect"
+	"sort"
 
 	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/comparator"
@@ -23,6 +24,7 @@ import (
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/types"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/strings"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/discovery/v1beta1"
@@ -210,10 +212,13 @@ func EqualV1PodContainers(c1, c2 types.PodContainer) bool {
 
 func EqualV1Pod(pod1, pod2 *types.Pod) bool {
 	// We only care about the HostIP, the PodIP and the labels of the pods.
-	if pod1.StatusPodIP != pod2.StatusPodIP ||
-		pod1.StatusHostIP != pod2.StatusHostIP ||
+	if pod1.StatusHostIP != pod2.StatusHostIP ||
 		pod1.SpecServiceAccountName != pod2.SpecServiceAccountName ||
 		pod1.SpecHostNetwork != pod2.SpecHostNetwork {
+		return false
+	}
+
+	if !strings.EqualStrings(pod1.StatusPodIPs, pod2.StatusPodIPs) {
 		return false
 	}
 
@@ -543,6 +548,30 @@ func ConvertToCNP(obj interface{}) interface{} {
 	}
 }
 
+func getPodIPs(podStats v1.PodStatus) []string {
+	// make it a set first
+	ipsMap := make(map[string]struct{}, 1+len(podStats.PodIPs))
+	if podStats.PodIP != "" {
+		ipsMap[podStats.PodIP] = struct{}{}
+	}
+	for _, podIP := range podStats.PodIPs {
+		if podIP.IP != "" {
+			ipsMap[podIP.IP] = struct{}{}
+		}
+	}
+
+	if len(ipsMap) == 0 {
+		return nil
+	}
+
+	ips := make([]string, 0, len(ipsMap))
+	for ipStr := range ipsMap {
+		ips = append(ips, ipStr)
+	}
+	sort.Strings(ips)
+	return ips
+}
+
 // ConvertToPod converts a *v1.Pod into a
 // *types.Pod or a cache.DeletedFinalStateUnknown into
 // a cache.DeletedFinalStateUnknown with a *types.Pod in its Obj.
@@ -580,7 +609,7 @@ func ConvertToPod(obj interface{}) interface{} {
 		p := &types.Pod{
 			TypeMeta:               concreteObj.TypeMeta,
 			ObjectMeta:             concreteObj.ObjectMeta,
-			StatusPodIP:            concreteObj.Status.PodIP,
+			StatusPodIPs:           getPodIPs(concreteObj.Status),
 			StatusHostIP:           concreteObj.Status.HostIP,
 			SpecServiceAccountName: concreteObj.Spec.ServiceAccountName,
 			SpecHostNetwork:        concreteObj.Spec.HostNetwork,
@@ -622,7 +651,7 @@ func ConvertToPod(obj interface{}) interface{} {
 			Obj: &types.Pod{
 				TypeMeta:               pod.TypeMeta,
 				ObjectMeta:             pod.ObjectMeta,
-				StatusPodIP:            pod.Status.PodIP,
+				StatusPodIPs:           getPodIPs(pod.Status),
 				StatusHostIP:           pod.Status.HostIP,
 				SpecServiceAccountName: pod.Spec.ServiceAccountName,
 				SpecHostNetwork:        pod.Spec.HostNetwork,

--- a/pkg/k8s/factory_functions_test.go
+++ b/pkg/k8s/factory_functions_test.go
@@ -329,14 +329,14 @@ func (s *K8sSuite) Test_EqualV1Pod(c *C) {
 						Name: "pod1",
 					},
 					StatusHostIP: "127.0.0.1",
-					StatusPodIP:  "127.0.0.2",
+					StatusPodIPs: []string{"127.0.0.2"},
 				},
 				o2: &types.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "pod1",
 					},
 					StatusHostIP: "127.0.0.1",
-					StatusPodIP:  "127.0.0.1",
+					StatusPodIPs: []string{"127.0.0.1"},
 				},
 			},
 			want: false,
@@ -349,14 +349,14 @@ func (s *K8sSuite) Test_EqualV1Pod(c *C) {
 						Name: "pod1",
 					},
 					StatusHostIP: "127.0.0.1",
-					StatusPodIP:  "127.0.0.2",
+					StatusPodIPs: []string{"127.0.0.2"},
 				},
 				o2: &types.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "pod1",
 					},
 					StatusHostIP: "127.0.0.1",
-					StatusPodIP:  "127.0.0.2",
+					StatusPodIPs: []string{"127.0.0.2"},
 				},
 			},
 			want: true,
@@ -372,14 +372,14 @@ func (s *K8sSuite) Test_EqualV1Pod(c *C) {
 						},
 					},
 					StatusHostIP: "127.0.0.1",
-					StatusPodIP:  "127.0.0.2",
+					StatusPodIPs: []string{"127.0.0.2"},
 				},
 				o2: &types.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "pod1",
 					},
 					StatusHostIP: "127.0.0.1",
-					StatusPodIP:  "127.0.0.2",
+					StatusPodIPs: []string{"127.0.0.2"},
 				},
 			},
 			want: false,
@@ -395,7 +395,7 @@ func (s *K8sSuite) Test_EqualV1Pod(c *C) {
 						},
 					},
 					StatusHostIP: "127.0.0.1",
-					StatusPodIP:  "127.0.0.2",
+					StatusPodIPs: []string{"127.0.0.2"},
 				},
 				o2: &types.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -405,7 +405,7 @@ func (s *K8sSuite) Test_EqualV1Pod(c *C) {
 						},
 					},
 					StatusHostIP: "127.0.0.1",
-					StatusPodIP:  "127.0.0.2",
+					StatusPodIPs: []string{"127.0.0.2"},
 				},
 			},
 			want: true,
@@ -421,7 +421,7 @@ func (s *K8sSuite) Test_EqualV1Pod(c *C) {
 						},
 					},
 					StatusHostIP: "127.0.0.1",
-					StatusPodIP:  "127.0.0.2",
+					StatusPodIPs: []string{"127.0.0.2"},
 				},
 				o2: &types.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -434,7 +434,7 @@ func (s *K8sSuite) Test_EqualV1Pod(c *C) {
 						},
 					},
 					StatusHostIP: "127.0.0.1",
-					StatusPodIP:  "127.0.0.2",
+					StatusPodIPs: []string{"127.0.0.2"},
 				},
 			},
 			want: false,
@@ -450,7 +450,7 @@ func (s *K8sSuite) Test_EqualV1Pod(c *C) {
 						},
 					},
 					StatusHostIP: "127.0.0.1",
-					StatusPodIP:  "127.0.0.2",
+					StatusPodIPs: []string{"127.0.0.2"},
 				},
 				o2: &types.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -463,7 +463,7 @@ func (s *K8sSuite) Test_EqualV1Pod(c *C) {
 						},
 					},
 					StatusHostIP: "127.0.0.1",
-					StatusPodIP:  "127.0.0.2",
+					StatusPodIPs: []string{"127.0.0.2"},
 				},
 			},
 			want: true,

--- a/pkg/k8s/types/types.go
+++ b/pkg/k8s/types/types.go
@@ -66,7 +66,7 @@ type PodContainer struct {
 type Pod struct {
 	metav1.TypeMeta
 	metav1.ObjectMeta
-	StatusPodIP            string
+	StatusPodIPs           []string
 	StatusHostIP           string
 	SpecServiceAccountName string
 	SpecHostNetwork        bool

--- a/pkg/k8s/types/zz_generated.deepcopy.go
+++ b/pkg/k8s/types/zz_generated.deepcopy.go
@@ -273,6 +273,11 @@ func (in *Pod) DeepCopyInto(out *Pod) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+	if in.StatusPodIPs != nil {
+		in, out := &in.StatusPodIPs, &out.StatusPodIPs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.SpecContainers != nil {
 		in, out := &in.SpecContainers, &out.SpecContainers
 		*out = make([]PodContainer, len(*in))

--- a/pkg/strings/slices.go
+++ b/pkg/strings/slices.go
@@ -1,0 +1,35 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package strings
+
+// EqualStrings returns true if both slices are equal.
+func EqualStrings(a, b []string) bool {
+	// If one is nil, the other must also be nil.
+	if (a == nil) != (b == nil) {
+		return false
+	}
+
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/strings/slices_test.go
+++ b/pkg/strings/slices_test.go
@@ -1,0 +1,81 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package strings
+
+import (
+	"testing"
+)
+
+func TestEqualStrings(t *testing.T) {
+	type args struct {
+		a []string
+		b []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "test-1",
+			args: args{
+				a: nil,
+				b: nil,
+			},
+			want: true,
+		},
+		{
+			name: "test-2",
+			args: args{
+				a: []string{""},
+				b: nil,
+			},
+			want: false,
+		},
+		{
+			name: "test-3",
+			args: args{
+				a: nil,
+				b: []string{"foo"},
+			},
+			want: false,
+		},
+		{
+			name: "test-4",
+			args: args{
+				a: []string{"foo"},
+				b: []string{"foo"},
+			},
+			want: true,
+		},
+		{
+			name: "test-5",
+			args: args{
+				a: []string{"bar", "foo"},
+				b: []string{"foo", "bar"},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := EqualStrings(tt.args.a, tt.args.b); got != tt.want {
+				t.Errorf("EqualStrings() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
As multi-stack also means that pods can contain 2 or more IP addresses
we should also populate the local podIPs also with the ones provided by
kubernetes.

Fixes: 47a87f838709 ("pkg/k8s: add support for multi-stack")
Signed-off-by: André Martins <andre@cilium.io>