### PR TITLE
hubble: Change uint64 -> uint32 in getters interfaces

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -654,7 +654,7 @@ func (d *Daemon) GetNodeSuffix() string {
 // to populate source and destination labels of flows.
 //
 //  - IdentityGetter: https://github.com/cilium/hubble/blob/04ab72591faca62a305ce0715108876167182e04/pkg/parser/getters/getters.go#L40
-func (d *Daemon) GetIdentity(securityIdentity uint64) (*models.Identity, error) {
+func (d *Daemon) GetIdentity(securityIdentity uint32) (*models.Identity, error) {
 	ident := d.identityAllocator.LookupIdentityByID(context.Background(), identity.NumericIdentity(securityIdentity))
 	if ident == nil {
 		return nil, fmt.Errorf("identity %d not found", securityIdentity)
@@ -678,7 +678,7 @@ func (d *Daemon) GetEndpointInfo(ip net.IP) (endpoint hubbleV1.EndpointInfo, ok 
 // FQDN cache of an endpoint specified by sourceEpID.
 //
 //  - DNSGetter: https://github.com/cilium/hubble/blob/04ab72591faca62a305ce0715108876167182e04/pkg/parser/getters/getters.go#L27
-func (d *Daemon) GetNamesOf(sourceEpID uint64, ip net.IP) []string {
+func (d *Daemon) GetNamesOf(sourceEpID uint32, ip net.IP) []string {
 	ep := d.endpointManager.LookupCiliumID(uint16(sourceEpID))
 	if ep == nil {
 		return nil

--- a/pkg/hubble/parser/getters/getters.go
+++ b/pkg/hubble/parser/getters/getters.go
@@ -27,7 +27,7 @@ import (
 type DNSGetter interface {
 	// GetNamesOf fetches FQDNs of a given IP from the perspective of
 	// the endpoint with ID sourceEpID
-	GetNamesOf(sourceEpID uint64, ip net.IP) (names []string)
+	GetNamesOf(sourceEpID uint32, ip net.IP) (names []string)
 }
 
 // EndpointGetter ...
@@ -39,7 +39,7 @@ type EndpointGetter interface {
 // IdentityGetter ...
 type IdentityGetter interface {
 	// GetIdentity fetches a full identity object given a numeric security id.
-	GetIdentity(id uint64) (*models.Identity, error)
+	GetIdentity(id uint32) (*models.Identity, error)
 }
 
 // IPGetter fetches per-IP metadata

--- a/pkg/hubble/parser/seven/parser.go
+++ b/pkg/hubble/parser/seven/parser.go
@@ -114,8 +114,8 @@ func (p *Parser) Decode(payload *pb.Payload, decoded *pb.Flow) error {
 	var sourceNames, destinationNames []string
 	var sourceNamespace, sourcePod, destinationNamespace, destinationPod string
 	if p.dnsGetter != nil {
-		sourceNames = p.dnsGetter.GetNamesOf(destinationEndpoint.ID, sourceIP)
-		destinationNames = p.dnsGetter.GetNamesOf(sourceEndpoint.ID, destinationIP)
+		sourceNames = p.dnsGetter.GetNamesOf(uint32(destinationEndpoint.ID), sourceIP)
+		destinationNames = p.dnsGetter.GetNamesOf(uint32(sourceEndpoint.ID), destinationIP)
 	}
 	if p.ipGetter != nil {
 		if id, ok := p.ipGetter.GetIPIdentity(sourceIP); ok {

--- a/pkg/hubble/parser/seven/parser_test.go
+++ b/pkg/hubble/parser/seven/parser_test.go
@@ -103,12 +103,12 @@ func TestDecodeL7HTTPRecord(t *testing.T) {
 	data := encodeL7Record(t, lr)
 
 	dnsGetter := &testutils.FakeFQDNCache{
-		OnGetNamesOf: func(epID uint64, ip net.IP) (names []string) {
+		OnGetNamesOf: func(epID uint32, ip net.IP) (names []string) {
 			ipStr := ip.String()
 			switch {
-			case epID == fakeSourceEndpoint.ID && ipStr == fakeDestinationEndpoint.IPv4:
+			case epID == uint32(fakeSourceEndpoint.ID) && ipStr == fakeDestinationEndpoint.IPv4:
 				return []string{"endpoint-1234"}
-			case epID == fakeDestinationEndpoint.ID && ipStr == fakeSourceEndpoint.IPv4:
+			case epID == uint32(fakeDestinationEndpoint.ID) && ipStr == fakeSourceEndpoint.IPv4:
 				return []string{"endpoint-4321"}
 			}
 			return nil

--- a/pkg/hubble/parser/threefour/parser.go
+++ b/pkg/hubble/parser/threefour/parser.go
@@ -184,7 +184,7 @@ func (p *Parser) Decode(payload *pb.Payload, decoded *pb.Flow) error {
 
 func (p *Parser) resolveNames(epID uint32, ip net.IP) (names []string) {
 	if p.dnsGetter != nil {
-		return p.dnsGetter.GetNamesOf(uint64(epID), ip)
+		return p.dnsGetter.GetNamesOf(epID, ip)
 	}
 
 	return nil
@@ -260,7 +260,7 @@ func (p *Parser) resolveEndpoint(ip net.IP, securityIdentity uint32) *pb.Endpoin
 	}
 	var labels []string
 	if p.identityGetter != nil {
-		if id, err := p.identityGetter.GetIdentity(uint64(securityIdentity)); err != nil {
+		if id, err := p.identityGetter.GetIdentity(securityIdentity); err != nil {
 			logger.GetLogger().
 				WithError(err).WithField("identity", securityIdentity).
 				Warn("failed to resolve identity")

--- a/pkg/hubble/parser/threefour/parser_test.go
+++ b/pkg/hubble/parser/threefour/parser_test.go
@@ -65,7 +65,7 @@ func TestL34Decode(t *testing.T) {
 		},
 	}
 	dnsGetter := &testutils.FakeFQDNCache{
-		OnGetNamesOf: func(epID uint64, ip net.IP) (names []string) {
+		OnGetNamesOf: func(epID uint32, ip net.IP) (names []string) {
 			if epID == 1234 {
 				switch {
 				case ip.Equal(net.ParseIP("192.168.33.11")):
@@ -166,7 +166,7 @@ func TestL34Decode(t *testing.T) {
 		},
 	}
 	dnsGetter = &testutils.FakeFQDNCache{
-		OnGetNamesOf: func(epID uint64, ip net.IP) (names []string) {
+		OnGetNamesOf: func(epID uint32, ip net.IP) (names []string) {
 			if epID == 1234 {
 				switch {
 				case ip.Equal(net.ParseIP("f00d::a10:0:0:9195")):
@@ -269,10 +269,10 @@ func TestDecodeTraceNotify(t *testing.T) {
 	require.NoError(t, err)
 	buf.Write(buffer.Bytes())
 	require.NoError(t, err)
-	identityGetter := &testutils.FakeIdentityGetter{OnGetIdentity: func(securityIdentity uint64) (*models.Identity, error) {
-		if securityIdentity == (uint64)(tn.SrcLabel) {
+	identityGetter := &testutils.FakeIdentityGetter{OnGetIdentity: func(securityIdentity uint32) (*models.Identity, error) {
+		if securityIdentity == tn.SrcLabel {
 			return &models.Identity{Labels: []string{"src=label"}}, nil
-		} else if securityIdentity == (uint64)(tn.DstLabel) {
+		} else if securityIdentity == tn.DstLabel {
 			return &models.Identity{Labels: []string{"dst=label"}}, nil
 		}
 		return nil, fmt.Errorf("identity not found for %d", securityIdentity)
@@ -313,10 +313,10 @@ func TestDecodeDropNotify(t *testing.T) {
 	buf.Write(buffer.Bytes())
 	require.NoError(t, err)
 	identityGetter := &testutils.FakeIdentityGetter{
-		OnGetIdentity: func(securityIdentity uint64) (*models.Identity, error) {
-			if securityIdentity == (uint64)(dn.SrcLabel) {
+		OnGetIdentity: func(securityIdentity uint32) (*models.Identity, error) {
+			if securityIdentity == dn.SrcLabel {
 				return &models.Identity{Labels: []string{"src=label"}}, nil
-			} else if securityIdentity == (uint64)(dn.DstLabel) {
+			} else if securityIdentity == dn.DstLabel {
 				return &models.Identity{Labels: []string{"dst=label"}}, nil
 			}
 			return nil, fmt.Errorf("identity not found for %d", securityIdentity)
@@ -336,8 +336,8 @@ func TestDecodeDropNotify(t *testing.T) {
 func TestDecodePolicyVerdictNotify(t *testing.T) {
 	var remoteLabel uint32 = 123
 	identityGetter := &testutils.FakeIdentityGetter{
-		OnGetIdentity: func(securityIdentity uint64) (*models.Identity, error) {
-			if securityIdentity == uint64(remoteLabel) {
+		OnGetIdentity: func(securityIdentity uint32) (*models.Identity, error) {
+			if securityIdentity == remoteLabel {
 				return &models.Identity{Labels: []string{"dst=label"}}, nil
 			}
 			return nil, fmt.Errorf("identity not found for %d", securityIdentity)
@@ -422,7 +422,7 @@ func TestDecodeLocalIdentity(t *testing.T) {
 	data, err := testutils.CreateL3L4Payload(tn)
 	require.NoError(t, err)
 	identityGetter := &testutils.FakeIdentityGetter{
-		OnGetIdentity: func(securityIdentity uint64) (*models.Identity, error) {
+		OnGetIdentity: func(securityIdentity uint32) (*models.Identity, error) {
 			return &models.Identity{Labels: []string{"some=label", "cidr:1.2.3.4/12", "cidr:1.2.3.4/11"}}, nil
 		},
 	}

--- a/pkg/hubble/testutils/fake.go
+++ b/pkg/hubble/testutils/fake.go
@@ -17,8 +17,8 @@ import (
 // FakeFQDNCache is used for unit tests that needs FQDNCache and/or DNSGetter.
 type FakeFQDNCache struct {
 	OnInitializeFrom func(entries []*models.DNSLookup)
-	OnAddDNSLookup   func(epID uint64, lookupTime time.Time, domainName string, ips []net.IP, ttl uint32)
-	OnGetNamesOf     func(epID uint64, ip net.IP) []string
+	OnAddDNSLookup   func(epID uint32, lookupTime time.Time, domainName string, ips []net.IP, ttl uint32)
+	OnGetNamesOf     func(epID uint32, ip net.IP) []string
 }
 
 // InitializeFrom implements FQDNCache.InitializeFrom.
@@ -31,25 +31,25 @@ func (f *FakeFQDNCache) InitializeFrom(entries []*models.DNSLookup) {
 }
 
 // AddDNSLookup implements FQDNCache.AddDNSLookup.
-func (f *FakeFQDNCache) AddDNSLookup(epID uint64, lookupTime time.Time, domainName string, ips []net.IP, ttl uint32) {
+func (f *FakeFQDNCache) AddDNSLookup(epID uint32, lookupTime time.Time, domainName string, ips []net.IP, ttl uint32) {
 	if f.OnAddDNSLookup != nil {
 		f.OnAddDNSLookup(epID, lookupTime, domainName, ips, ttl)
 		return
 	}
-	panic("AddDNSLookup(uint64, time.Time, string, []net.IP, uint32) should not have been called since it was not defined")
+	panic("AddDNSLookup(uint32, time.Time, string, []net.IP, uint32) should not have been called since it was not defined")
 }
 
 // GetNamesOf implements FQDNCache.GetNameOf.
-func (f *FakeFQDNCache) GetNamesOf(epID uint64, ip net.IP) []string {
+func (f *FakeFQDNCache) GetNamesOf(epID uint32, ip net.IP) []string {
 	if f.OnGetNamesOf != nil {
 		return f.OnGetNamesOf(epID, ip)
 	}
-	panic("GetNamesOf(uint64, net.IP) should not have been called since it was not defined")
+	panic("GetNamesOf(uint32, net.IP) should not have been called since it was not defined")
 }
 
 // NoopDNSGetter always returns an empty response.
 var NoopDNSGetter = FakeFQDNCache{
-	OnGetNamesOf: func(sourceEpID uint64, ip net.IP) (fqdns []string) {
+	OnGetNamesOf: func(sourceEpID uint32, ip net.IP) (fqdns []string) {
 		return nil
 	},
 }
@@ -116,11 +116,11 @@ var NoopServiceGetter = FakeServiceGetter{
 
 // FakeIdentityGetter is used for unit tests that need IdentityGetter.
 type FakeIdentityGetter struct {
-	OnGetIdentity func(securityIdentity uint64) (*models.Identity, error)
+	OnGetIdentity func(securityIdentity uint32) (*models.Identity, error)
 }
 
 // GetIdentity implements IdentityGetter.GetIPIdentity.
-func (f *FakeIdentityGetter) GetIdentity(securityIdentity uint64) (*models.Identity, error) {
+func (f *FakeIdentityGetter) GetIdentity(securityIdentity uint32) (*models.Identity, error) {
 	if f.OnGetIdentity != nil {
 		return f.OnGetIdentity(securityIdentity)
 	}
@@ -129,7 +129,7 @@ func (f *FakeIdentityGetter) GetIdentity(securityIdentity uint64) (*models.Ident
 
 // NoopIdentityGetter always returns an empty response.
 var NoopIdentityGetter = FakeIdentityGetter{
-	OnGetIdentity: func(securityIdentity uint64) (*models.Identity, error) {
+	OnGetIdentity: func(securityIdentity uint32) (*models.Identity, error) {
 		return &models.Identity{}, nil
 	},
 }


### PR DESCRIPTION
<!-- Description of change -->
As identity and endpoint ID are considered to be `uint32` after #11161 has been merge, this PR changes their type in `getters` interfaces accordingly and adjusts them to be `uint32` as well. Includes related changes in parsers, daemon as well as tests.

Fixes: #11241

Signed-off-by: Matej Gera <matejgera@gmail.com>

```release-note
hubble: Change uint64 -> uint32 in getters interfaces
```
