### PR TITLE
helm: Add a chart for hubble-relay

### DIFF
--- a/install/kubernetes/cilium/charts/hubble-relay/Chart.yaml
+++ b/install/kubernetes/cilium/charts/hubble-relay/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+name: hubble-relay
+version: 1.7.90
+appVersion: 1.7.90
+tillerVersion: ">=2.7.2"
+description: Helm chart for running Hubble Relay
+sources:
+  - https://github.com/cilium/cilium
+engine: gotpl

--- a/install/kubernetes/cilium/charts/hubble-relay/templates/NOTES.txt
+++ b/install/kubernetes/cilium/charts/hubble-relay/templates/NOTES.txt
@@ -1,0 +1,5 @@
+You have successfully installed Cilium {{ .Chart.Name }}
+
+Your release version is {{ .Chart.Version }}
+
+For any further help, visit https://docs.cilium.io/en/v{{ substr 0 3 .Chart.Version }}/gettinghelp

--- a/install/kubernetes/cilium/charts/hubble-relay/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/hubble-relay/templates/deployment.yaml
@@ -1,0 +1,75 @@
+{{- if .Values.global.hubble.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Chart.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    k8s-app: {{ .Chart.Name }}
+spec:
+  replicas: {{ .Values.numReplicas }}
+  selector:
+    matchLabels:
+      k8s-app: {{ .Chart.Name }}
+  template:
+    metadata:
+      labels:
+        k8s-app: {{ .Chart.Name }}
+    spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+                - key: "k8s-app"
+                  operator: In
+                  values:
+                    - cilium
+            topologyKey: "kubernetes.io/hostname"
+      containers:
+        - name: hubble-relay
+{{- if contains "/" .Values.image }}
+          image: "{{ .Values.image }}"
+{{- else }}
+          image: "{{ .Values.global.registry }}/{{ .Values.image }}:{{ .Values.global.tag }}"
+{{- end }}
+          imagePullPolicy: {{ .Values.global.pullPolicy }}
+          command:
+            - "hubble-relay"
+          args:
+            - "serve"
+            - "--peer-service=unix://{{ .Values.global.hubble.socketPath }}"
+            - "--listen-address={{ .Values.listenHost }}:{{ .Values.listenPort }}"
+{{- if .Values.dialTimeout }}
+            - "--dial-timeout={{ .Values.dialTimeout }}"
+{{- end }}
+{{- if .Values.retryTimeout }}
+            - "--retry-timeout={{ .Values.retryTimeout }}"
+{{- end }}
+          ports:
+            - name: grpc
+              containerPort: {{ .Values.listenPort }}
+          readinessProbe:
+            tcpSocket:
+              port: grpc
+          livenessProbe:
+            tcpSocket:
+              port: grpc
+{{- if .Values.resources }}
+          resources:
+{{- toYaml .Values.resources | trim | nindent 10 }}
+{{- end }}
+          volumeMounts:
+          - mountPath: {{ dir .Values.global.hubble.socketPath }}
+            name: hubble-sock-dir
+            readOnly: true
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 0
+      tolerations:
+      - operator: Exists
+      volumes:
+      - hostPath:
+          path: {{ dir .Values.global.hubble.socketPath }}
+          type: Directory
+        name: hubble-sock-dir
+{{- end }}

--- a/install/kubernetes/cilium/charts/hubble-relay/templates/service.yaml
+++ b/install/kubernetes/cilium/charts/hubble-relay/templates/service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.global.hubble.enabled }}
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ .Chart.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    k8s-app: {{ .Chart.Name }}
+spec:
+  type: ClusterIP
+  selector:
+    k8s-app: {{ .Chart.Name }}
+  ports:
+  - protocol: TCP
+    port: {{ .Values.servicePort }}
+    targetPort: {{ .Values.listenPort }}
+{{- end }}

--- a/install/kubernetes/cilium/charts/hubble-relay/values.yaml
+++ b/install/kubernetes/cilium/charts/hubble-relay/values.yaml
@@ -1,0 +1,16 @@
+image: hubble-relay
+
+# Specifies the resources for the hubble-relay pods
+resources: {}
+# Number of replicas run for the hubble-relay deployment.
+numReplicas: 1
+# Host to listen to. Specify an empty string to bind to all the interfaces.
+listenHost: ""
+# Port to listen to.
+listenPort: "4245"
+# Dial timeout to connect to the local hubble instance to receive peer information (e.g. "30s").
+dialTimeout: ~
+# Backoff duration to retry connecting to the local hubble instance in case of failure (e.g. "30s").
+retryTimeout: ~
+# Port to use for the k8s service backed by hubble-relay pods.
+servicePort: 80

--- a/install/kubernetes/cilium/requirements.yaml
+++ b/install/kubernetes/cilium/requirements.yaml
@@ -8,6 +8,9 @@ dependencies:
   - name: hubble-cli
     version: 1.7.90
     condition: global.hubble.cli.enabled
+  - name: hubble-relay
+    version: 1.7.90
+    condition: global.hubble.relay.enabled
   - name: hubble-ui
     version: 1.7.90
     condition: global.hubble.ui.enabled

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -467,6 +467,9 @@ global:
     # Configures the hubble-cli subchart
     cli:
       enabled: false
+    # Configures the hubble-relay subchart
+    relay:
+      enabled: false
 
   # CI specific options: DO NOT USE IN PRODUCTION.
   ci:


### PR DESCRIPTION
This PR adds a new helm chart for Hubble Relay deployment/service. A few
things to note:

- Each Hubble Relay pod must be scheduled on a node with Cilium running.
  Hubble Relay connects to the hubble unix domain socket to retrive peer
  information.
- For now the readiness/liveness probes simply checks if the gRPC port
  is open since Hubble Relay doesn't have the status command yet.

Closes: #11226
Ref: #11192 #10648

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>