### PR TITLE
k8s: Provide fallback for EndpointSlices detection if discovery API is not available

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -67,6 +67,7 @@ cilium-agent [flags]
       --enable-ipv4                                   Enable IPv4 support (default true)
       --enable-ipv4-fragment-tracking                 Enable IPv4 fragments tracking for L4-based lookups (default true)
       --enable-ipv6                                   Enable IPv6 support (default true)
+      --enable-k8s-api-discovery                      Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-k8s-endpoint-slice                     Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
       --enable-k8s-event-handover                     Enable k8s event handover to kvstore for improved scalability
       --enable-l7-proxy                               Enable L7 proxy for L7 policy enforcement (default true)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -27,6 +27,7 @@ cilium-operator [flags]
       --config string                           Configuration file (default "$HOME/ciliumd.yaml")
       --config-dir string                       Configuration directory that contains a file for each option
   -D, --debug                                   Enable debugging mode
+      --enable-k8s-api-discovery                Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-k8s-endpoint-slice               Enables k8s EndpointSlice feature into Cilium-Operator if the k8s cluster supports it (default true)
       --enable-metrics                          Enable Prometheus metrics
       --eni-tags map                            ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag) (default map[])

--- a/cilium/cmd/preflight_identity_crd_migrate.go
+++ b/cilium/cmd/preflight_identity_crd_migrate.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/idpool"
 	"github.com/cilium/cilium/pkg/k8s"
+	k8sconfig "github.com/cilium/cilium/pkg/k8s/config"
 	"github.com/cilium/cilium/pkg/k8s/identitybackend"
 	"github.com/cilium/cilium/pkg/kvstore"
 	kvstoreallocator "github.com/cilium/cilium/pkg/kvstore/allocator"
@@ -194,7 +195,7 @@ func initK8s(ctx context.Context) (crdBackend allocator.Backend, crdAllocator *a
 
 	k8s.Configure(k8sAPIServer, k8sKubeConfigPath, float32(k8sClientQPSLimit), k8sClientBurst)
 
-	if err := k8s.Init(); err != nil {
+	if err := k8s.Init(k8sconfig.NewDefaultConfiguration()); err != nil {
 		log.WithError(err).Fatal("Unable to connect to Kubernetes apiserver")
 	}
 

--- a/cilium/cmd/preflight_k8s_valid_cnp.go
+++ b/cilium/cmd/preflight_k8s_valid_cnp.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s"
 	v2_client "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2/client"
 	"github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/scheme"
+	k8sconfig "github.com/cilium/cilium/pkg/k8s/config"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/option"
 
@@ -65,7 +66,7 @@ func validateCNPs() error {
 
 	k8s.Configure(k8sAPIServer, k8sKubeConfigPath, float32(k8sClientQPSLimit), k8sClientBurst)
 
-	if err := k8s.Init(); err != nil {
+	if err := k8s.Init(k8sconfig.NewDefaultConfiguration()); err != nil {
 		log.WithError(err).Fatal("Unable to connect to Kubernetes apiserver")
 	}
 

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -403,7 +403,7 @@ func NewDaemon(ctx context.Context, dp datapath.Datapath) (*Daemon, *endpointRes
 
 	if k8s.IsEnabled() {
 		bootstrapStats.k8sInit.Start()
-		if err := k8s.Init(); err != nil {
+		if err := k8s.Init(option.Config); err != nil {
 			log.WithError(err).Fatal("Unable to initialize Kubernetes subsystem")
 		}
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -333,6 +333,9 @@ func init() {
 	flags.Bool(option.K8sEnableEndpointSlice, defaults.K8sEnableEndpointSlice, "Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it")
 	option.BindEnv(option.K8sEnableEndpointSlice)
 
+	flags.Bool(option.K8sEnableAPIDiscovery, defaults.K8sEnableAPIDiscovery, "Enable discovery of Kubernetes API groups and resources with the discovery API")
+	option.BindEnv(option.K8sEnableAPIDiscovery)
+
 	flags.Bool(option.EnableL7Proxy, defaults.EnableL7Proxy, "Enable L7 proxy for L7 policy enforcement")
 	option.BindEnv(option.EnableL7Proxy)
 

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -165,6 +165,9 @@ func init() {
 	flags.Bool(option.K8sEnableEndpointSlice, defaults.K8sEnableEndpointSlice, "Enables k8s EndpointSlice feature into Cilium-Operator if the k8s cluster supports it")
 	option.BindEnv(option.K8sEnableEndpointSlice)
 
+	flags.Bool(option.K8sEnableAPIDiscovery, defaults.K8sEnableAPIDiscovery, "Enable discovery of Kubernetes API groups and resources with the discovery API")
+	option.BindEnv(option.K8sEnableAPIDiscovery)
+
 	flags.String(option.K8sNamespaceName, "", "Name of the Kubernetes namespace in which Cilium Operator is deployed in")
 	option.BindEnv(option.K8sNamespaceName)
 

--- a/operator/main.go
+++ b/operator/main.go
@@ -137,13 +137,13 @@ func runOperator(cmd *cobra.Command) {
 		float32(option.Config.K8sClientQPSLimit),
 		option.Config.K8sClientBurst,
 	)
-	if err := k8s.Init(); err != nil {
+	if err := k8s.Init(option.Config); err != nil {
 		log.WithError(err).Fatal("Unable to connect to Kubernetes apiserver")
 	}
 	close(k8sInitDone)
 
 	ciliumK8sClient = k8s.CiliumClient()
-	k8sversion.Update(k8s.Client())
+	k8sversion.Update(k8s.Client(), option.Config)
 	if !k8sversion.Capabilities().MinimalVersionMet {
 		log.Fatalf("Minimal kubernetes version not met: %s < %s",
 			k8sversion.Version(), k8sversion.MinimalVersionConstraint)

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -370,4 +370,8 @@ const (
 	// FragmentsMapEntries is the default number of entries allowed in an
 	// the map used to track datagram fragments.
 	FragmentsMapEntries = 8192
+
+	// K8sEnableAPIDiscovery defines whether Kuberntes API groups and
+	// resources should be probed using the discovery API
+	K8sEnableAPIDiscovery = false
 )

--- a/pkg/k8s/cnp_test.go
+++ b/pkg/k8s/cnp_test.go
@@ -33,6 +33,7 @@ import (
 	clientset "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned"
 	"github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/fake"
 	informer "github.com/cilium/cilium/pkg/k8s/client/informers/externalversions"
+	k8sconfig "github.com/cilium/cilium/pkg/k8s/config"
 	"github.com/cilium/cilium/pkg/k8s/types"
 	k8sversion "github.com/cilium/cilium/pkg/k8s/version"
 	"github.com/cilium/cilium/pkg/logging"
@@ -431,7 +432,7 @@ func benchmarkCNPNodeStatusController(integrationTest bool, nNodes int, nParalle
 
 	restConfig, err := CreateConfig()
 	c.Assert(err, IsNil)
-	err = Init()
+	err = Init(k8sconfig.NewDefaultConfiguration())
 	c.Assert(err, IsNil)
 
 	// One client per node

--- a/pkg/k8s/config/config.go
+++ b/pkg/k8s/config/config.go
@@ -1,0 +1,40 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"github.com/cilium/cilium/pkg/defaults"
+)
+
+// Configuration is the configuration interface for the k8s package
+type Configuration interface {
+	K8sAPIDiscoveryEnabled() bool
+}
+
+// DefaultConfiguration is an implementation of Configuration with default
+// values
+type DefaultConfiguration struct{}
+
+// NewDefaultConfiguration returns an implementation of Configuration with
+// default values
+func NewDefaultConfiguration() Configuration {
+	return &DefaultConfiguration{}
+}
+
+// K8sAPIDiscoveryEnabled returns true if API discovery of API groups and
+// resources is enabled
+func (d *DefaultConfiguration) K8sAPIDiscoveryEnabled() bool {
+	return defaults.K8sEnableAPIDiscovery
+}

--- a/pkg/k8s/init.go
+++ b/pkg/k8s/init.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/backoff"
 	"github.com/cilium/cilium/pkg/controller"
 	cilium_v2_client "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2/client"
+	k8sconfig "github.com/cilium/cilium/pkg/k8s/config"
 	"github.com/cilium/cilium/pkg/k8s/types"
 	k8sversion "github.com/cilium/cilium/pkg/k8s/version"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -114,7 +115,7 @@ func useNodeCIDR(n *nodeTypes.Node) {
 
 // Init initializes the Kubernetes package. It is required to call Configure()
 // beforehand.
-func Init() error {
+func Init(conf k8sconfig.Configuration) error {
 	k8sRestClient, closeAllDefaultClientConns, err := createDefaultClient()
 	if err != nil {
 		return fmt.Errorf("unable to create k8s client: %s", err)
@@ -152,7 +153,7 @@ func Init() error {
 		)
 	}
 
-	if err := k8sversion.Update(Client()); err != nil {
+	if err := k8sversion.Update(Client(), conf); err != nil {
 		return err
 	}
 

--- a/pkg/k8s/types/types.go
+++ b/pkg/k8s/types/types.go
@@ -121,3 +121,7 @@ type CiliumEndpoint struct {
 	Encryption *v2.EncryptionSpec
 	NamedPorts models.NamedPorts
 }
+
+type Configuration interface {
+	K8sAPIDiscoveryEnabled() bool
+}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -776,6 +776,9 @@ const (
 	// FragmentsMapEntriesName configures max entries for BPF fragments
 	// tracking map.
 	FragmentsMapEntriesName = "bpf-fragments-map-max"
+
+	// K8sEnableAPIDiscovery
+	K8sEnableAPIDiscovery = "enable-k8s-api-discovery"
 )
 
 // HelpFlagSections to format the Cilium Agent help template.
@@ -835,6 +838,7 @@ var HelpFlagSections = []FlagsSection{
 			K8sHeartbeatTimeout,
 			EnableExternalIPs,
 			K8sEnableEndpointSlice,
+			K8sEnableAPIDiscovery,
 			EnableHostPort,
 			AutoCreateCiliumNodeResource,
 			DisableCNPStatusUpdates,
@@ -1776,6 +1780,8 @@ type DaemonConfig struct {
 	// sizeofPolicyElement is the size of an element (key + value) in the
 	// policy map.
 	sizeofPolicyElement int
+
+	k8sEnableAPIDiscovery bool
 }
 
 var (
@@ -1813,6 +1819,7 @@ var (
 		AllowICMPFragNeeded:          defaults.AllowICMPFragNeeded,
 		EnableWellKnownIdentities:    defaults.EnableEndpointRoutes,
 		K8sEnableK8sEndpointSlice:    defaults.K8sEnableEndpointSlice,
+		k8sEnableAPIDiscovery:        defaults.K8sEnableAPIDiscovery,
 	}
 )
 
@@ -1935,6 +1942,12 @@ func (c *DaemonConfig) LocalClusterName() string {
 // deployed in
 func (c *DaemonConfig) CiliumNamespaceName() string {
 	return c.K8sNamespace
+}
+
+// K8sAPIDiscoveryEnabled returns true if API discovery of API groups and
+// resources is enabled
+func (c *DaemonConfig) K8sAPIDiscoveryEnabled() bool {
+	return c.k8sEnableAPIDiscovery
 }
 
 func (c *DaemonConfig) validateIPv6ClusterAllocCIDR() error {
@@ -2190,6 +2203,7 @@ func (c *DaemonConfig) Populate() {
 	c.K8sClientBurst = viper.GetInt(K8sClientBurst)
 	c.K8sClientQPSLimit = viper.GetFloat64(K8sClientQPSLimit)
 	c.K8sEnableK8sEndpointSlice = viper.GetBool(K8sEnableEndpointSlice)
+	c.k8sEnableAPIDiscovery = viper.GetBool(K8sEnableAPIDiscovery)
 	c.K8sKubeConfigPath = viper.GetString(K8sKubeConfigPath)
 	c.K8sRequireIPv4PodCIDR = viper.GetBool(K8sRequireIPv4PodCIDRName)
 	c.K8sRequireIPv6PodCIDR = viper.GetBool(K8sRequireIPv6PodCIDRName)


### PR DESCRIPTION
Discovery of API groups requires the API services of the apiserver to be healthy. Such API services can depend on the readiness of regular pods which require Cilium to function correctly. By treating failure to discover API groups as fatal, a critial loop can be entered in which Cilium cannot start because the API groups can't be discovered and the API groups will only become discoverable once Cilium is up.

Warn about the lack of discovery ability and fall back to probing the API directly.