### PR TITLE
CI: use GitHub action to check Go module vendoring

### DIFF
--- a/.github/workflows/go-mod.yaml
+++ b/.github/workflows/go-mod.yaml
@@ -1,0 +1,20 @@
+name: Go module vendoring
+
+on: pull_request
+
+jobs:
+  go-mod:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.14.2
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Check module vendoring
+      run: |
+        go mod tidy
+        go mod vendor
+        git diff --exit-code
+

--- a/Makefile
+++ b/Makefile
@@ -499,12 +499,16 @@ postcheck: build
 minikube:
 	$(QUIET) contrib/scripts/minikube.sh
 
-update-golang: update-golang-dockerfiles update-travis-go-version update-test-go-version
+update-golang: update-golang-dockerfiles update-gh-actions-go-version update-travis-go-version update-test-go-version
 
 update-golang-dockerfiles:
 	$(QUIET) sed -i 's/GO_VERSION .*/GO_VERSION $(GO_VERSION)/g' Dockerfile.builder
 	$(QUIET) for fl in $(shell find . -path ./vendor -prune -o -name "*Dockerfile*" -print) ; do sed -i 's/golang:.* /golang:$(GO_VERSION) as /g' $$fl ; done
 	@echo "Updated go version in Dockerfiles to $(GO_VERSION)"
+
+update-gh-actions-go-version:
+	$(QUIET) for fl in $(shell find .github/workflows -name "*.yaml" -print) ; do sed -i 's/go-version: .*/go-version: $(GO_VERSION)/g' $$fl ; done
+	@echo "Updated go version in GitHub Actions to $(GO_VERSION)"
 
 update-travis-go-version:
 	$(QUIET) sed -e 's/TRAVIS_GO_VERSION/$(GO_VERSION)/g' .travis.yml.tmpl > .travis.yml


### PR DESCRIPTION
Run `go mod tidy` and `go mod vendor` on all PRs to check tidiness of
the Go module vendoring.

Like the docs workflow, we cannot just run this against PRs touching
`go.mod`, `go.sum` and/or `vendor/`, because this would prevent us from
marking this workflow as required to merge. The workflow won't execute
on PRs that don't modify the above files or directory and therefore,
those PRs will never become status:success.

Suggested-by: Paul Chaignon <paul@cilium.io>
Signed-off-by: Tobias Klauser <tklauser@distanz.ch>