### PR TITLE
v1.6 backports 2020-04-30

### DIFF
--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -1533,6 +1533,12 @@ func runDaemon() {
 		errs <- server.Serve()
 	}()
 
+	if k8s.IsEnabled() {
+		bootstrapStats.k8sInit.Start()
+		k8s.Client().MarkNodeReady(node.GetName())
+		bootstrapStats.k8sInit.End(true)
+	}
+
 	bootstrapStats.overall.End(true)
 	bootstrapStats.updateMetrics()
 

--- a/daemon/daemon_main.go
+++ b/daemon/daemon_main.go
@@ -999,6 +999,12 @@ func initEnv(cmd *cobra.Command) {
 		}
 	}
 
+	// This check is here instead of in DaemonConfig.Populate (invoked at the
+	// start of this function as option.Config.Populate) to avoid an import loop.
+	if option.Config.IdentityAllocationMode == option.IdentityAllocationModeCRD && !k8s.IsEnabled() {
+		log.Fatal("CRD Identity allocation mode requires k8s to be configured.")
+	}
+
 	if option.Config.PProf {
 		pprof.Enable()
 	}

--- a/daemon/sysctl_linux_test.go
+++ b/daemon/sysctl_linux_test.go
@@ -31,7 +31,7 @@ type DaemonPrivilegedSuite struct{}
 
 var _ = Suite(&DaemonPrivilegedSuite{})
 
-func (s *DaemonPrivilegedSuite) TestInitSysctlParams(c *C) {
-	err := initSysctlParams()
+func (s *DaemonPrivilegedSuite) TestEnableIPForwarding(c *C) {
+	err := enableIPForwarding()
 	c.Assert(err, IsNil)
 }

--- a/operator/main.go
+++ b/operator/main.go
@@ -342,7 +342,12 @@ func runOperator(cmd *cobra.Command) {
 		startKvstoreWatchdog()
 	}
 
-	if identityAllocationMode == option.IdentityAllocationModeCRD {
+	switch option.Config.IdentityAllocationMode {
+	case option.IdentityAllocationModeCRD:
+		if !k8s.IsEnabled() {
+			log.Fatal("CRD Identity allocation mode requires k8s to be configured.")
+		}
+
 		startManagingK8sIdentities()
 
 		if identityGCInterval != time.Duration(0) {

--- a/pkg/k8s/annotate.go
+++ b/pkg/k8s/annotate.go
@@ -104,9 +104,8 @@ func (k8sCli K8sClient) AnnotateNode(nodeName string, v4CIDR, v6CIDR *cidr.CIDR,
 				err := updateNodeAnnotation(k8sCli, nodeName, v4CIDR, v6CIDR, v4HealthIP, v6HealthIP, v4CiliumHostIP, v6CiliumHostIP)
 				if err != nil {
 					scopedLog.WithFields(logrus.Fields{}).WithError(err).Warn("Unable to patch node resource with annotation")
-					return err
 				}
-				return SetNodeNetworkUnavailableFalse(k8sCli, nodeName)
+				return err
 			},
 		})
 

--- a/pkg/k8s/config.go
+++ b/pkg/k8s/config.go
@@ -80,5 +80,6 @@ func IsEnabled() bool {
 	return config.APIServer != "" ||
 		config.KubeconfigPath != "" ||
 		(os.Getenv("KUBERNETES_SERVICE_HOST") != "" &&
-			os.Getenv("KUBERNETES_SERVICE_PORT") != "")
+			os.Getenv("KUBERNETES_SERVICE_PORT") != "") ||
+		os.Getenv("K8S_NODE_NAME") != ""
 }

--- a/pkg/k8s/identitybackend/identity.go
+++ b/pkg/k8s/identitybackend/identity.go
@@ -217,10 +217,9 @@ func (c *crdBackend) RunGC(staleKeysPrevRound map[string]uint64) (map[string]uin
 // reliablyMissing is true.
 // Note: the lock field is not supported with the k8s CRD allocator.
 func (c *crdBackend) UpdateKey(ctx context.Context, id idpool.ID, key allocator.AllocatorKey, reliablyMissing bool) error {
-	var err error
-
-	if err := c.AcquireReference(ctx, id, key, nil); err == nil {
-		log.WithError(err).WithFields(logrus.Fields{
+	err := c.AcquireReference(ctx, id, key, nil)
+	if err == nil {
+		log.WithFields(logrus.Fields{
 			logfields.Identity: id,
 			logfields.Labels:   key,
 		}).Debug("Acquired reference for identity")
@@ -229,7 +228,7 @@ func (c *crdBackend) UpdateKey(ctx context.Context, id idpool.ID, key allocator.
 
 	// The CRD (aka the master key) is missing. Try to recover by recreating it
 	// if reliablyMissing is set.
-	log.WithFields(logrus.Fields{
+	log.WithError(err).WithFields(logrus.Fields{
 		logfields.Identity: id,
 		logfields.Labels:   key,
 	}).Warning("Unable update CRD identity information with a reference for this node")


### PR DESCRIPTION
* #10729 -- Fix incorrect name in sysctl_linux_test.go (@christarazi)
 * #10767 -- k8s: Defer marking node as ready to just API is served (@tgraf)
   * Manual: needed to import context package
 * #10785 -- pkg/allocator: do not fail to allocate identity in CRD mode (@aanm)
 * #10923 -- k8s/identitybackend: log error if AcquireReference fails (@aanm)
 * #10936 -- endpoint: Avoid transient drops during policy map update (@jrajahalme)
 * #11021 -- pkg/k8s: detect k8s mode if env variable K8S_NODE_NAME is set (@aanm)
 * #11015 -- daemon: Fatal on startup when Identity CRD is enabled without k8s (@raybejjani)

**PRs not included in this backport PR**:

 * #10741 -- cilium: set encrypt node route mtu in encryption table (@jrfastab)
   * Note: seems to depend on non-backport-labelled PRs
 * #10727 -- pkg/k8s: fix all structural issues with CNP validation (@aanm)
   * Note: skipping due to non-trivial conflicts
 * #10926 -- bpf: Preserve source identity for hairpin via stack (@tgraf)
   * Note: skipping due to trouble with previous backport (PR #11239)
 * #11008 -- bpf: remap MARK_MAGIC_SNAT_DONE marker to avoid conflicts (@borkmann)
   * Note: skipping due to dependence on #10926
 * #10928 -- datapath/iptables: Masquerade hairpin traffic that traversed the stack (@tgraf)
   * Note: skipping due to trouble with previous backport (ADD LINK)
 * #11040 -- CRD: fix allocation logic of identities with the same set of labels (@aanm)
   * Note: skipping due to non-trivial conflicts
 * #10984 -- datapath: Fix wrong rev-NAT xlation due to stale conntrack entry (@brb)
   * Note: skipping due to non-trivial conflicts

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 10729 10767 10785 10923 10936 11021 11015; do contrib/backporting/set-labels.py $pr done 1.6; done
```