### PR TITLE
azure: support multiple pods subnets

### DIFF
--- a/pkg/azure/api/mock/mock.go
+++ b/pkg/azure/api/mock/mock.go
@@ -136,7 +136,7 @@ func (a *API) rateLimit() {
 	}
 }
 
-func (a *API) GetInstances(ctx context.Context) (*ipamTypes.InstanceMap, error) {
+func (a *API) GetInstances(ctx context.Context, subnets ipamTypes.SubnetMap) (*ipamTypes.InstanceMap, error) {
 	a.rateLimit()
 	a.delaySim.Delay(GetInstances)
 

--- a/pkg/azure/api/mock/mock_test.go
+++ b/pkg/azure/api/mock/mock_test.go
@@ -42,7 +42,7 @@ func (e *MockSuite) TestMock(c *check.C) {
 	api := NewAPI([]*ipamTypes.Subnet{subnet}, []*ipamTypes.VirtualNetwork{{ID: "v-1"}})
 	c.Assert(api, check.Not(check.IsNil))
 
-	instances, err := api.GetInstances(context.Background())
+	instances, err := api.GetInstances(context.Background(), ipamTypes.SubnetMap{})
 	c.Assert(err, check.IsNil)
 	c.Assert(instances.NumInstances(), check.Equals, 0)
 
@@ -59,7 +59,7 @@ func (e *MockSuite) TestMock(c *check.C) {
 		Resource: &types.AzureInterface{ID: ifaceID, Name: "eth0"},
 	})
 	api.UpdateInstances(instances)
-	instances, err = api.GetInstances(context.Background())
+	instances, err = api.GetInstances(context.Background(), ipamTypes.SubnetMap{})
 	c.Assert(err, check.IsNil)
 	c.Assert(instances.NumInstances(), check.Equals, 1)
 	instances.ForeachInterface("", func(instanceID, interfaceID string, iface ipamTypes.InterfaceRevision) error {
@@ -70,7 +70,7 @@ func (e *MockSuite) TestMock(c *check.C) {
 
 	err = api.AssignPrivateIpAddresses(context.Background(), "vm1", "vmss1", "s-1", "eth0", 2)
 	c.Assert(err, check.IsNil)
-	instances, err = api.GetInstances(context.Background())
+	instances, err = api.GetInstances(context.Background(), ipamTypes.SubnetMap{})
 	c.Assert(err, check.IsNil)
 	c.Assert(instances.NumInstances(), check.Equals, 1)
 	instances.ForeachInterface("", func(instanceID, interfaceID string, revision ipamTypes.InterfaceRevision) error {
@@ -91,7 +91,7 @@ func (e *MockSuite) TestSetMockError(c *check.C) {
 	mockError := errors.New("error")
 
 	api.SetMockError(GetInstances, mockError)
-	_, err := api.GetInstances(context.Background())
+	_, err := api.GetInstances(context.Background(), ipamTypes.SubnetMap{})
 	c.Assert(err, check.Equals, mockError)
 
 	api.SetMockError(GetVpcsAndSubnets, mockError)
@@ -109,6 +109,6 @@ func (e *MockSuite) TestSetLimiter(c *check.C) {
 	c.Assert(api, check.Not(check.IsNil))
 
 	api.SetLimiter(10.0, 2)
-	_, err := api.GetInstances(context.Background())
+	_, err := api.GetInstances(context.Background(), ipamTypes.SubnetMap{})
 	c.Assert(err, check.IsNil)
 }

--- a/pkg/azure/ipam/instances.go
+++ b/pkg/azure/ipam/instances.go
@@ -28,7 +28,7 @@ import (
 
 // AzureAPI is the API surface used of the Azure API
 type AzureAPI interface {
-	GetInstances(ctx context.Context) (*ipamTypes.InstanceMap, error)
+	GetInstances(ctx context.Context, subnets ipamTypes.SubnetMap) (*ipamTypes.InstanceMap, error)
 	GetVpcsAndSubnets(ctx context.Context) (ipamTypes.VirtualNetworkMap, ipamTypes.SubnetMap, error)
 	AssignPrivateIpAddresses(ctx context.Context, instanceID, vmssName, subnetID, interfaceName string, addresses int) error
 }
@@ -88,7 +88,7 @@ func (m *InstancesManager) Resync(ctx context.Context) time.Time {
 		return time.Time{}
 	}
 
-	instances, err := m.api.GetInstances(ctx)
+	instances, err := m.api.GetInstances(ctx, subnets)
 	if err != nil {
 		log.WithError(err).Warning("Unable to synchronize Azure instances list")
 		return time.Time{}

--- a/pkg/azure/types/types.go
+++ b/pkg/azure/types/types.go
@@ -110,6 +110,11 @@ type AzureInterface struct {
 	// SecurityGroup is the security group associated with the interface
 	SecurityGroup string `json:"security-group,omitempty"`
 
+	// GatewayIP is the interface subnet's default route
+	//
+	// +optional
+	GatewayIP string
+
 	// vmssName is the name of the virtual machine scale set. This field is
 	// set by extractIDs()
 	vmssName string

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -503,7 +503,7 @@ func (a *crdAllocator) buildAllocationResult(ip net.IP, ipInfo *ipamTypes.Alloca
 		for _, iface := range a.store.ownNode.Status.Azure.Interfaces {
 			if iface.ID == ipInfo.Resource {
 				result.Master = iface.MAC
-
+				result.GatewayIP = iface.GatewayIP
 				return
 			}
 		}

--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -488,18 +488,12 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 		res.Routes = append(res.Routes, routes...)
 	}
 
-	switch conf.IpamMode {
-	case option.IPAMENI:
-		err = eniAdd(ipConfig, ipam.IPV4, conf)
+	if conf.IpamMode == option.IPAMENI || conf.IpamMode == option.IPAMAzure {
+		err = interfaceAdd(ipConfig, ipam.IPV4, conf)
 		if err != nil {
-			err = fmt.Errorf("unable to setup ENI datapath: %s", err)
+			err = fmt.Errorf("unable to setup interface datapath: %s", err)
 			return
 		}
-
-	case option.IPAMAzure:
-		// No specific action is required. The standard veth based
-		// approach is selected for now. The agent will set up the
-		// routes as necessary.
 	}
 
 	var macAddrStr string

--- a/plugins/cilium-cni/interface.go
+++ b/plugins/cilium-cni/interface.go
@@ -26,7 +26,7 @@ import (
 	"github.com/containernetworking/cni/pkg/types/current"
 )
 
-func eniAdd(ipConfig *current.IPConfig, ipam *models.IPAMAddressResponse, conf models.DaemonConfigurationStatus) error {
+func interfaceAdd(ipConfig *current.IPConfig, ipam *models.IPAMAddressResponse, conf models.DaemonConfigurationStatus) error {
 	allCIDRs := make([]*net.IPNet, 0, len(ipam.Cidrs))
 	for _, cidrString := range ipam.Cidrs {
 		_, cidr, err := net.ParseCIDR(cidrString)


### PR DESCRIPTION
Support pods attached to secondary interfaces, and spread over several
subnets: inject explicit routes and rules to forward pods traffic to
their subnet gateway band back, set MTU, etc. the same way Cilium does
for AWS/ENI.

We mostly need to propagate subnets gw details (collecting addressPrefix
from instances manager so we can infer the subnets gateways addresses)
down to API / CRD, which can then be leveraged by the CNI plugin as we
do with ENIs.

While at it, also support k8s clusters and vpc/subnets running on
different resource groups.

Signed-off-by: Benjamin Pineau <benjamin.pineau@datadoghq.com>

```release-note
Azure: support multiple pods subnets, and networks in different resource groups
```