### PR TITLE
Improve Helm post-setup NOTES

### DIFF
--- a/install/kubernetes/cilium/charts/hubble-ui/templates/NOTES.txt
+++ b/install/kubernetes/cilium/charts/hubble-ui/templates/NOTES.txt
@@ -1,0 +1,5 @@
+You have successfully installed Cilium {{ .Chart.Name }}.
+
+Your Cilium chart release version is {{ .Chart.Version }}.
+
+For any further help, visit https://docs.cilium.io/en/v{{ substr 0 3 .Chart.Version }}/gettinghelp

--- a/install/kubernetes/cilium/templates/NOTES.txt
+++ b/install/kubernetes/cilium/templates/NOTES.txt
@@ -1,4 +1,17 @@
-You have successfully installed {{ title .Chart.Name }}.
+{{- if (and (.Values.preflight.enabled) (not (.Values.agent.enabled)) (not (.Values.config.enabled)) (not (.Values.operator.enabled))) }}
+    You have successfully ran the prefight check.
+    Now make sure to check the number of READY pods is the same as the number of running cilium pods.
+    Then make sure the cilium preflight deployment is also marked READY 1/1.
+    If you have an issues please refer to the CNP Validation section in the upgrade guide.
+{{- else if (not (.Values.config.enabled))}}
+    You have preserved the configMap and successfully installed {{ title .Chart.Name}}.
+{{- else if (and (.Values.global.hubble.enabled) (.Values.global.hubble.ui.enabled)) }}
+    You have successfully installed Cilium with hubble-ui.
+{{- else if (and (.Values.global.hubble.enabled) (.Values.global.hubble.cli.enabled) (.Values.global.hubble.ui.enabled)) }}
+    You have successfully installed Cilium with hubble-ui and hubble-cli.
+{{- else }}
+    You have successfully installed {{ title .Chart.Name }}.
+{{- end }}
 
 Your release version is {{ .Chart.Version }}.
 


### PR DESCRIPTION
This PR fixes the NOTES.txt file to reflight the correct
action at the upper level, when preflight alone is installed

Fixes: #11245
Signed-off-by: Swaminathan Vasudevan <svasudevan@suse.com>
