### PR TITLE
operator: Fix operator flags

### DIFF
--- a/operator/main.go
+++ b/operator/main.go
@@ -72,6 +72,7 @@ var (
 func initEnv() {
 	// Prepopulate option.Config with options from CLI.
 	option.Config.Populate()
+	operatorOption.Config.Populate()
 
 	// add hooks after setting up metrics in the option.Confog
 	logging.DefaultLogger.Hooks.Add(metrics.NewLoggingHook(components.CiliumOperatortName))


### PR DESCRIPTION
The operator-specific flags were not populated

Fixes: 588f8352a ("operator: split operator-only options into separate package")
