### PR TITLE
doc: Fix the kubectl create option in upgrade.rst

### DIFF
--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -43,7 +43,7 @@ file.
         --set config.enabled=false \\
         --set operator.enabled=false \\
         > cilium-preflight.yaml
-      kubectl create cilium-preflight.yaml
+      kubectl create -f cilium-preflight.yaml
 
   .. group-tab:: Helm
 
@@ -68,7 +68,7 @@ file.
         --set global.k8sServiceHost=API_SERVER_IP \\
         --set global.k8sServicePort=API_SERVER_PORT \\
         > cilium-preflight.yaml
-      kubectl create cilium-preflight.yaml
+      kubectl create -f cilium-preflight.yaml
 
   .. group-tab:: Helm (kubeproxy-free)
 
@@ -1247,7 +1247,7 @@ The cilium preflight manifest requires etcd support and can be built with:
       --set global.etcd.enabled=true \
       --set global.etcd.ssl=true \
       > cilium-preflight.yaml
-    kubectl create cilium-preflight.yaml
+    kubectl create -f cilium-preflight.yaml
 
 
 Example migration


### PR DESCRIPTION
This PR fixes the kubectl create option that was missing at
some places in the update.rst file.

Signed-off-by: Swaminathan Vasudevan <svasudevan@suse.com>
