### PR TITLE
helm: Update hubble-ui chart

### DIFF
--- a/install/kubernetes/cilium/charts/hubble-ui/templates/clusterrole.yaml
+++ b/install/kubernetes/cilium/charts/hubble-ui/templates/clusterrole.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.hubble.ui.enabled }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -41,4 +40,3 @@ rules:
       - get
       - list
       - watch
-{{- end }}

--- a/install/kubernetes/cilium/charts/hubble-ui/templates/clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/charts/hubble-ui/templates/clusterrolebinding.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.hubble.ui.enabled }}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -11,4 +10,3 @@ subjects:
   - kind: ServiceAccount
     namespace: {{ .Release.Namespace }}
     name: hubble-ui 
-{{- end }}

--- a/install/kubernetes/cilium/charts/hubble-ui/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/hubble-ui/templates/deployment.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.hubble.ui.enabled }}
 kind: Deployment
 apiVersion: apps/v1
 metadata:
@@ -35,4 +34,3 @@ spec:
               name: http
           resources:
             {{- toYaml .Values.resources | trim | nindent 12 }}
-{{- end }}

--- a/install/kubernetes/cilium/charts/hubble-ui/templates/ingress.yaml
+++ b/install/kubernetes/cilium/charts/hubble-ui/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.global.hubble.ui.enabled .Values.ingress.enabled -}}
+{{- if .Values.ingress.enabled -}}
 {{- $ingressPath := .Values.ingress.path -}}
 apiVersion: extensions/v1beta1
 kind: Ingress

--- a/install/kubernetes/cilium/charts/hubble-ui/templates/serviceaccount.yaml
+++ b/install/kubernetes/cilium/charts/hubble-ui/templates/serviceaccount.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.hubble.ui.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/install/kubernetes/cilium/charts/hubble-ui/templates/svc.yaml
+++ b/install/kubernetes/cilium/charts/hubble-ui/templates/svc.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.hubble.ui.enabled }}
 kind: Service
 apiVersion: v1
 metadata:
@@ -12,4 +11,3 @@ spec:
       port: 12000
       targetPort: 12000
   type: ClusterIP
-{{- end }}

--- a/install/kubernetes/cilium/charts/hubble-ui/values.yaml
+++ b/install/kubernetes/cilium/charts/hubble-ui/values.yaml
@@ -2,10 +2,12 @@
 image:
   # repository of the docker image
   repository: quay.io/cilium/hubble-ui
-  # tag is the container image tag to use
-  tag: latest
+  # tag is the container image tag to use.
+  # Ref: https://github.com/cilium/hubble-ui/releases
+  # Ref: https://quay.io/repository/cilium/hubble-ui?tab=tags
+  tag: v0.5.0
   # pullPolicy is the container image pull policy
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
 clusterDomain: cluster.local
 replicas: 1
 # Resource requests and limits for the 'hubble-ui' container of the 'hubble-ui' deployment, such as


### PR DESCRIPTION
- Use v0.5.0 tag by default instead of latest.
- Rely on requirements.yaml to enable the chart instead of guarding
  individual templates.

Ref: https://github.com/cilium/hubble-ui/releases

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>