### PR TITLE
bpf: Ensure build_all target always builds all bpf datapath permutations

### DIFF
--- a/bpf/.gitignore
+++ b/bpf/.gitignore
@@ -1,3 +1,4 @@
 cilium-map-migrate
 *.i
 *.s
+.rebuild_all

--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -3,7 +3,7 @@
 
 include ../Makefile.defs
 
-.PHONY: all subdirs check preprocess assembly install clean
+.PHONY: all build_all subdirs check force preprocess assembly install clean $(BUILD_PERMUTATIONS_DEP)
 
 SUBDIRS = sockops
 
@@ -17,7 +17,8 @@ include ./Makefile.bpf
 ifeq ("$(PKG_BUILD)","")
 all: $(BPF) $(TARGET) subdirs
 
-build_all:
+build_all: force
+	@touch $(BUILD_PERMUTATIONS_DEP)
 	@$(ECHO_CHECK)/*.c BUILD_PERMUTATIONS=1
 	$(QUIET) $(MAKE) $(SUBMAKEOPTS) all BUILD_PERMUTATIONS=1
 

--- a/bpf/Makefile.bpf
+++ b/bpf/Makefile.bpf
@@ -10,7 +10,10 @@ CLANG_FLAGS += -Wall -Wextra -Werror
 CLANG_FLAGS += -Wno-address-of-packed-member -Wno-unknown-warning-option -Wno-gnu-variable-sized-type-not-at-end
 LLC_FLAGS   := -march=bpf -mcpu=probe -mattr=dwarfris
 
-LIB := $(shell find $(ROOT_DIR)/bpf -name '*.h')
+# BUILD_PERMUTATIONS_DEP is a dummy file dependency that ensures all targets
+# are rebuilt when the 'build_all' target is run.
+BUILD_PERMUTATIONS_DEP := .rebuild_all
+LIB := $(shell find $(ROOT_DIR)/bpf -name '*.h') $(BUILD_PERMUTATIONS_DEP)
 BPF_C := $(patsubst %.o,%.c,$(BPF))
 BPF_ASM := $(patsubst %.o,%.s,$(BPF))
 
@@ -21,6 +24,11 @@ HOSTCC ?= gcc
 # Define all at the top here so that Makefiles which include this one will hit
 # the 'all' target first (which we expect to be overridden by the includer).
 all:
+
+$(BUILD_PERMUTATIONS_DEP):
+	@touch $(BUILD_PERMUTATIONS_DEP)
+
+force:
 
 %.ll: %.c $(LIB)
 	@$(ECHO_CC)


### PR DESCRIPTION
I noticed when running `make` that the `BUILD_PERMUTATIONS=1` build was
not being run. This commit attempts to ensure that it is always run when
running `make -C bpf build_all`. Whether or not we want to always run
this on every make is a separate question, but it seems misleading to me
to allow the regular `make -C bpf` to populate a cache that prevents the
`ALL_PERMUTATIONS` build of the datapath from actually building all
permutations.