### PR TITLE
Optimize scalability of CiliumIdentity operation

### DIFF
--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -19,7 +19,7 @@ cilium-operator [flags]
       --aws-release-excess-ips                  Enable releasing excess free IP addresses from AWS ENI.
       --azure-resource-group string             Resource group to use for Azure IPAM
       --azure-subscription-id string            Subscription ID to access Azure API
-      --cilium-endpoint-gc-interval duration    GC interval for cilium endpoints (default 30m0s)
+      --cilium-endpoint-gc-interval duration    GC interval for cilium endpoints (default 10m0s)
       --cluster-id int                          Unique identifier of the cluster
       --cluster-name string                     Name of the cluster (default "default")
       --cnp-node-status-gc-interval duration    GC interval for nodes which have been removed from the cluster in CiliumNetworkPolicy Status (default 2m0s)
@@ -33,7 +33,7 @@ cilium-operator [flags]
   -h, --help                                    help for cilium-operator
       --identity-allocation-mode string         Method to use for identity allocation (default "kvstore")
       --identity-gc-interval duration           GC interval for security identities (default 15m0s)
-      --identity-heartbeat-timeout duration     Timeout after which identity expires on lack of heartbeat (default 15m0s)
+      --identity-heartbeat-timeout duration     Timeout after which identity expires on lack of heartbeat (default 31m0s)
       --ipam string                             Backend to use for IPAM (default "hostscope-legacy")
       --k8s-api-server string                   Kubernetes API server URL
       --k8s-client-burst int                    Burst value allowed for the K8s client

--- a/install/kubernetes/cilium/charts/agent/templates/clusterrole.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/clusterrole.yaml
@@ -77,6 +77,5 @@ rules:
   - ciliumnodes
   - ciliumnodes/status
   - ciliumidentities
-  - ciliumidentities/status
   verbs:
   - '*'

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -45,6 +45,15 @@ data:
   #   the kvstore by commenting out the identity-allocation-mode below, or
   #   setting it to "kvstore".
   identity-allocation-mode: {{ .Values.global.identityAllocationMode }}
+{{- if .Values.global.identityHeartbeatTimeout }}
+  identity-heartbeat-timeout: "{{ .Values.global.identityHeartbeatTimeout }}"
+{{- end }}
+{{- if .Values.global.identityGCInterval }}
+  identity-gc-interval: "{{ .Values.global.identityGCInterval }}"
+{{- end }}
+{{- if .Values.global.endpointGCInterval }}
+  cilium-endpoint-gc-interval: "{{ .Values.global.endpointGCInterval }}"
+{{- end }}
 
   # identity-change-grace-period is the grace period that needs to pass
   # before an endpoint that has changed its identity will start using

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -242,7 +242,6 @@ rules:
   - ciliumnodes
   - ciliumnodes/status
   - ciliumidentities
-  - ciliumidentities/status
   verbs:
   - '*'
 ---

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -131,7 +131,7 @@ func init() {
 	option.BindEnv(operatorOption.EnableCEPGC)
 	flags.MarkDeprecated(operatorOption.EnableCEPGC, fmt.Sprintf("Please use %s=0 to disable CEP GC", operatorOption.EndpointGCInterval))
 
-	flags.Duration(operatorOption.EndpointGCInterval, 30*time.Minute, "GC interval for cilium endpoints")
+	flags.Duration(operatorOption.EndpointGCInterval, 10*time.Minute, "GC interval for cilium endpoints")
 	option.BindEnv(operatorOption.EndpointGCInterval)
 
 	flags.Bool(operatorOption.EnableMetrics, false, "Enable Prometheus metrics")
@@ -140,7 +140,8 @@ func init() {
 	flags.String(option.IPAM, option.IPAMHostScopeLegacy, "Backend to use for IPAM")
 	option.BindEnv(option.IPAM)
 
-	flags.Duration(operatorOption.IdentityHeartbeatTimeout, 15*time.Minute, "Timeout after which identity expires on lack of heartbeat")
+	// 31 minutes is the default to be slightly larger than 3x EndpointGCInterval
+	flags.Duration(operatorOption.IdentityHeartbeatTimeout, 31*time.Minute, "Timeout after which identity expires on lack of heartbeat")
 	option.BindEnv(operatorOption.IdentityHeartbeatTimeout)
 
 	flags.String(option.IdentityAllocationMode, option.IdentityAllocationModeKVstore, "Method to use for identity allocation")

--- a/operator/identity/heartbeat.go
+++ b/operator/identity/heartbeat.go
@@ -1,0 +1,102 @@
+// Copyright 2019-2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package identity
+
+import (
+	"time"
+
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+var (
+	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "identity-heartbeat")
+)
+
+// IdentityHeartbeatStore keeps track of the heartbeat of identities
+type IdentityHeartbeatStore struct {
+	mutex        lock.RWMutex
+	lastLifesign map[string]time.Time
+	firstRun     time.Time
+	timeout      time.Duration
+}
+
+// NewIdentityHeartbeatStore returns a new identity heartbeat store
+func NewIdentityHeartbeatStore(timeout time.Duration) *IdentityHeartbeatStore {
+	i := &IdentityHeartbeatStore{
+		timeout:      timeout,
+		lastLifesign: map[string]time.Time{},
+		firstRun:     time.Now(),
+	}
+	return i
+}
+
+// MarkAlive marks an identity as alive
+func (i *IdentityHeartbeatStore) MarkAlive(identity string, t time.Time) {
+	log.WithField("identity", identity).Debug("Marking identity alive")
+	i.mutex.Lock()
+	i.lastLifesign[identity] = t
+	i.mutex.Unlock()
+}
+
+// IsAlive returns true if the identity is still alive
+func (i *IdentityHeartbeatStore) IsAlive(identity string) bool {
+	i.mutex.RLock()
+	defer i.mutex.RUnlock()
+
+	lifesign, ok := i.lastLifesign[identity]
+	if ok {
+		// A lifesign has been recorded, check if the lifesign is older
+		// than the stale period
+		if time.Since(lifesign) < i.timeout {
+			return true
+		}
+	} else {
+		// No lifesign has ever been recorded. If the operator has not
+		// been up for longer than the stale period, then the identity
+		// is still considered alive
+		log.Debugf("No lifesign exists %s > %s", time.Since(i.firstRun), i.timeout)
+		if time.Since(i.firstRun) < i.timeout {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Delete deletes an identity from the store
+func (i *IdentityHeartbeatStore) Delete(identity string) {
+	log.WithField("identity", identity).Debug("Deleting identity in heartbeat lifesign table")
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
+	delete(i.lastLifesign, identity)
+}
+
+// GC removes all lifesign entries which have exceeded the heartbeat by a large
+// amount. This happens when the CiliumIdentity is deleted before the
+// CiliumEndpoint that refers to it. In that case, the lifesign entry will
+// continue to exist. Remove it once has not been updated for a long time.
+func (i *IdentityHeartbeatStore) GC() {
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
+
+	for identity, lifesign := range i.lastLifesign {
+		if time.Since(lifesign) > 10*i.timeout {
+			log.WithField("identity", identity).Debug("Removing unused heartbeat entry")
+			delete(i.lastLifesign, identity)
+		}
+	}
+}

--- a/operator/identity/heartbeat_test.go
+++ b/operator/identity/heartbeat_test.go
@@ -1,0 +1,74 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package identity
+
+import (
+	"testing"
+	"time"
+
+	"gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	check.TestingT(t)
+}
+
+type OperatorTestSuite struct{}
+
+var _ = check.Suite(&OperatorTestSuite{})
+
+func (s *OperatorTestSuite) TestIdentityHeartbeatStore(c *check.C) {
+	store := NewIdentityHeartbeatStore(time.Second)
+
+	// mark lifesign to now, identity must be alive, run GC, identity
+	// should still exist
+	store.MarkAlive("foo", time.Now())
+	c.Assert(store.IsAlive("foo"), check.Equals, true)
+	store.GC()
+	c.Assert(store.IsAlive("foo"), check.Equals, true)
+
+	// mark lifesign in the past, identity should not be alive anymore
+	store.MarkAlive("foo", time.Now().Add(-time.Minute))
+	c.Assert(store.IsAlive("foo"), check.Equals, false)
+
+	// mark lifesign way in the past, run GC, validate that identity is no
+	// longer tracked
+	store.MarkAlive("foo", time.Now().Add(-24*time.Hour))
+	c.Assert(store.IsAlive("foo"), check.Equals, false)
+	store.GC()
+	store.mutex.RLock()
+	_, ok := store.lastLifesign["foo"]
+	c.Assert(ok, check.Equals, false)
+	store.mutex.RUnlock()
+
+	// mark lifesign to now and validate deletion
+	store.MarkAlive("foo", time.Now())
+	store.mutex.RLock()
+	_, ok = store.lastLifesign["foo"]
+	store.mutex.RUnlock()
+	c.Assert(ok, check.Equals, true)
+	store.Delete("foo")
+	store.mutex.RLock()
+	_, ok = store.lastLifesign["foo"]
+	store.mutex.RUnlock()
+	c.Assert(ok, check.Equals, false)
+
+	// identtity foo now doesn't exist, simulate start time of operator way
+	// in the past to check if an old, stale identity will be deleeted
+	store.firstRun = time.Now().Add(-24 * time.Hour)
+	c.Assert(store.IsAlive("foo"), check.Equals, false)
+}

--- a/operator/k8s_cep_gc.go
+++ b/operator/k8s_cep_gc.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"strconv"
 	"time"
 
 	operatorOption "github.com/cilium/cilium/operator/option"
@@ -70,6 +71,7 @@ func enableCiliumEndpointSyncGC() {
 					podsCache[pod.Namespace+"/"+pod.Name] = &pod
 				}
 
+				timeNow := time.Now()
 			perCEPFetch:
 				for time.Now().Before(loopStop) { // Guard against no-break bugs
 					time.Sleep(time.Second) // Throttle lookups in case of a busy loop
@@ -96,6 +98,10 @@ func enableCiliumEndpointSyncGC() {
 
 					// For each CEP we fetched, check if we know about it
 					for _, cep := range ceps.Items {
+						if cep.Status.Identity != nil {
+							identityHeartbeat.MarkAlive(strconv.FormatInt(cep.Status.Identity.ID, 10), timeNow)
+						}
+
 						cepFullName := cep.Namespace + "/" + cep.Name
 						_, exists := podsCache[cepFullName]
 						if !exists {

--- a/pkg/k8s/apis/cilium.io/v2/types.go
+++ b/pkg/k8s/apis/cilium.io/v2/types.go
@@ -516,10 +516,13 @@ type CiliumIdentity struct {
 	// SecurityLabels is the source-of-truth set of labels for this identity.
 	SecurityLabels map[string]string `json:"security-labels"`
 
+	// Status is deprecated and no longer used, it will be removed in Cilium 1.9
 	Status IdentityStatus `json:"status"`
 }
 
 // IdentityStatus is the status of an identity
+//
+// This structure is deprecated, do not use.
 type IdentityStatus struct {
 	Nodes map[string]metav1.Time `json:"nodes,omitempty"`
 }

--- a/test/k8sT/Identity.go
+++ b/test/k8sT/Identity.go
@@ -1,0 +1,89 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8sTest
+
+import (
+	"time"
+
+	. "github.com/cilium/cilium/test/ginkgo-ext"
+	"github.com/cilium/cilium/test/helpers"
+
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("K8sIdentity", func() {
+	var kubectl *helpers.Kubectl
+	var ciliumFilename string
+
+	BeforeAll(func() {
+		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
+		ciliumFilename = helpers.TimestampFilename("cilium.yaml")
+	})
+
+	BeforeEach(func() {
+		kubectl.NodeCleanMetadata()
+	})
+
+	AfterEach(func() {
+		kubectl.DeleteCiliumDS()
+		ExpectAllPodsTerminated(kubectl)
+	})
+
+	AfterFailed(func() {
+		kubectl.CiliumReport(helpers.CiliumNamespace,
+			"cilium endpoint list")
+	})
+
+	AfterAll(func() {
+		DeployCiliumAndDNS(kubectl, ciliumFilename)
+		kubectl.CloseSSHClient()
+	})
+
+	JustAfterEach(func() {
+		blacklist := helpers.GetBadLogMessages()
+		kubectl.ValidateListOfErrorsInLogs(CurrentGinkgoTestDescription().Duration, blacklist)
+	})
+
+	deployCilium := func(options map[string]string) {
+		DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, options)
+
+		_, err := kubectl.CiliumNodesWait()
+		ExpectWithOffset(1, err).Should(BeNil(), "Failure while waiting for k8s nodes to be annotated by Cilium")
+
+		By("Making sure all endpoints are in ready state")
+		err = kubectl.CiliumEndpointWaitReady()
+		ExpectWithOffset(1, err).To(BeNil(), "Failure while waiting for all cilium endpoints to reach ready state")
+	}
+
+	Context("Identity expiration", func() {
+		It("Expiration of CiliumIdentity", func() {
+			deployCilium(map[string]string{
+				"global.endpointGCInterval":       "2s",
+				"global.identityGCInterval":       "2s",
+				"global.identityHeartbeatTimeout": "2s",
+			})
+
+			By("Creating unused CiliumIdentity")
+			dummyIdentity := helpers.ManifestGet(kubectl.BasePath(), "dummy_identity.yaml")
+			kubectl.ApplyDefault(dummyIdentity).ExpectSuccess("Cannot import dummy identity")
+
+			By("Waiting for CiliumIdentity to be garbage collected")
+			err := helpers.RepeatUntilTrue(func() bool {
+				return !kubectl.ExecShort(helpers.KubectlCmd + " get ciliumidentity 99999").WasSuccessful()
+			}, &helpers.TimeoutConfig{Timeout: 2 * time.Minute})
+			Expect(err).Should(BeNil(), "CiliumIdentity did not get garbage collected before timeout")
+		})
+	})
+})

--- a/test/k8sT/manifests/dummy_identity.yaml
+++ b/test/k8sT/manifests/dummy_identity.yaml
@@ -1,0 +1,14 @@
+apiVersion: cilium.io/v2
+kind: CiliumIdentity
+metadata:
+  labels:
+    io.cilium.k8s.policy.cluster: default
+    io.cilium.k8s.policy.serviceaccount: default
+    io.kubernetes.pod.namespace: default
+    foo: bar
+  name: "99999"
+security-labels:
+  k8s:io.cilium.k8s.policy.cluster: default
+  k8s:io.cilium.k8s.policy.serviceaccount: default
+  k8s:io.kubernetes.pod.namespace: default
+  k8s:foo: bar


### PR DESCRIPTION
This PR changes the garbage collection mechanism of identities to use the CiliumEndpoint information instead of requiring all nodes to maintain status information about who is using a particular identity.

This improves scalability of identity management in CRD mode massively.

Depends on: #11270 