### PR TITLE
endpoint: Fix incorrect warning for stat(2)

### DIFF
--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -73,7 +73,7 @@ func ReadEPsFromDirNames(ctx context.Context, owner regeneration.Owner, basePath
 			for i := 0; i < 2 && fileExists != nil; i++ {
 				time.Sleep(100 * time.Millisecond)
 				_, err := os.Stat(cHeaderFile)
-				if fileExists != err {
+				if (fileExists == nil) != (err == nil) {
 					scopedLog.WithError(err).Warn("BUG: stat() has unstable behavior")
 				}
 				fileExists = err


### PR DESCRIPTION
Since André previously noticed a transient bug on endpoint restoration, we log a warning message if we find `stat(2)` has an unstable behavior. The tests are failed if that warning is found in the logs.

The check for `stat(2)`'s unstable behavior is however incorrect and leads us to warn whenever a endpoint header file is not found. This commit fixes it.

Fixes #11028.
Fixes #11198.
