### PR TITLE
k8s/watchers: do not consider pods with empty podIPs

### DIFF
--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -498,6 +498,9 @@ func (k *K8sWatcher) deletePodHostData(pod *types.Pod) (bool, error) {
 }
 
 func validIPs(ipStrs []string) error {
+	if len(ipStrs) == 0 {
+		return fmt.Errorf("empty PodIPs")
+	}
 	for _, ipStr := range ipStrs {
 		podIP := net.ParseIP(ipStr)
 		if podIP == nil {


### PR DESCRIPTION
Fixes: 308b946d1e94 ("pkg/k8s: add missing support for multi-stack")
Signed-off-by: André Martins <andre@cilium.io>