### PR TITLE
test/gke: Disable K8sServicesTest Checks service across nodes with L7 policy Tests NodePort with L7 Policy

### DIFF
--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -976,6 +976,7 @@ var _ = Describe("K8sServicesTest", func() {
 		SkipContextIf(
 			func() bool {
 				return helpers.IsIntegration(helpers.CIIntegrationEKS) ||
+					helpers.IsIntegration(helpers.CIIntegrationGKE) || // Re-enable when GH-11235 is fixed
 					helpers.RunsWithoutKubeProxy()
 			},
 			"with L7 policy", func() {


### PR DESCRIPTION
The test is known to be broken. Disabling until #11235 is fixed
