### PR TITLE
Makefile: Move bpf 'build_all' to ci-precheck target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -439,6 +439,9 @@ microk8s: check-microk8s
 	@echo "Or, redeploy the Cilium pods:"
 	@echo "    microk8s.kubectl -n kube-system delete pod -l k8s-app=cilium"
 
+ci-precheck: precheck
+	$(QUIET) $(MAKE) $(SUBMAKEOPTS) -C bpf build_all
+
 precheck: ineffassign logging-subsys-field
 ifeq ($(SKIP_K8S_CODE_GEN_CHECK),"false")
 	@$(ECHO_CHECK) contrib/scripts/check-k8s-code-gen.sh
@@ -452,7 +455,6 @@ endif
 	$(QUIET) contrib/scripts/check-missing-tags-in-tests.sh
 	@$(ECHO_CHECK) contrib/scripts/check-assert-deep-equals.sh
 	$(QUIET) contrib/scripts/check-assert-deep-equals.sh
-	$(QUIET) $(MAKE) $(SUBMAKEOPTS) -C bpf build_all
 
 pprof-help:
 	@echo "Available pprof targets:"

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -22,4 +22,4 @@ services:
   precheck:
     extends:
       service: base_image
-    command: "bash -c 'cd /go/src/github.com/cilium/cilium/; make precheck || exit 1'"
+    command: "bash -c 'cd /go/src/github.com/cilium/cilium/; make ci-precheck || exit 1'"


### PR DESCRIPTION
This extra step takes quite a bit of time (~45s locally for me). To streamline `make` for most development use cases, move it out from the main precheck into a ci-precheck that will always be run by the CI before PRs are merged. Developers can still run the target manually if they're actively developing in the BPF area.

CC: @errordeveloper 
CC: @aanm 