### PR TITLE
vagrant: Forward port 9081 for documentation server

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -157,7 +157,8 @@ Vagrant.configure(2) do |config|
     master_vm_name = "#{$vm_base_name}1#{$build_id_name}#{$vm_kernel}"
     config.vm.define master_vm_name, primary: true do |cm|
         node_ip = "#{$master_ip}"
-		cm.vm.network "forwarded_port", guest: 6443, host: 7443, auto_correct: true
+        cm.vm.network "forwarded_port", guest: 6443, host: 7443, auto_correct: true
+        cm.vm.network "forwarded_port", guest: 9081, host: 9081, auto_correct: true
         cm.vm.network "private_network", ip: "#{$master_ip}",
             virtualbox__intnet: "cilium-test-#{$build_id}",
             :libvirt__guest_ipv6 => "yes",


### PR DESCRIPTION
With this change you can run `make render-docs` from inside the Vagrant
VM and access http://localhost:9081/ from a browser. The `render-docs`
target is failing with this exception in my environment (Mac):
```
Exception occurred:
  File "/usr/local/lib/python3.7/site-packages/sphinx/application.py", line 365, in build
    os.unlink(envfile)
PermissionError: [Errno 13] Permission denied: '/src/Documentation/_build/doctrees/environment.pickle'
```

Also replace the tab with spaces in the line above.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>