### PR TITLE
doc: Upgrade dependency verisons to remove warnings

### DIFF
--- a/Documentation/Dockerfile
+++ b/Documentation/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/python:3.7.5-alpine3.10
+FROM docker.io/library/python:3.7.7-alpine3.11
 
 LABEL maintainer="maintainer@cilium.io"
 

--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -22,9 +22,9 @@ sphinxcontrib-openapi==0.3.2
 sphinxcontrib-websupport==1.1.0
 typing==3.6.6
 urllib3==1.24.2
-sphinx-tabs==1.1.7
+sphinx-tabs==1.1.13
 recommonmark==0.4.0
-sphinxcontrib-spelling==4.2.0
+sphinxcontrib-spelling==4.2.1
 sphinx-version-warning==1.1.2
 semver==2.9.0
 yamllint==1.22.0


### PR DESCRIPTION
Upgrade dependncies to remove warnings from `make render-docs`.

- `docker.io/library/python:3.7.5-alpine3.10`

      WARNING: You are using pip version 19.3.1; however, version 20.1 is available.

- `sphinx-tabs`/`sphinxcontrib-spelling`

      RemovedInSphinx20Warning: app.info() is now deprecated. Use sphinx.util.logging instead.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>