### PR TITLE
helm: Add service account annotations for all charts

### DIFF
--- a/install/kubernetes/cilium/charts/agent/templates/serviceaccount.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/serviceaccount.yaml
@@ -3,3 +3,7 @@ kind: ServiceAccount
 metadata:
   name: cilium
   namespace: {{ .Release.Namespace }}
+  {{- if .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml .Values.serviceAccount.annotations | indent 4 }}
+  {{- end }}

--- a/install/kubernetes/cilium/charts/agent/values.yaml
+++ b/install/kubernetes/cilium/charts/agent/values.yaml
@@ -4,6 +4,10 @@ image: cilium
 # update process.
 maxUnavailable: 2
 
+# Specifies annotation for service accounts
+serviceAccount:
+  annotations: {}
+
 # Enables monitor sidecar container for specified event types
 monitor:
   enabled: false

--- a/install/kubernetes/cilium/charts/hubble-ui/templates/serviceaccount.yaml
+++ b/install/kubernetes/cilium/charts/hubble-ui/templates/serviceaccount.yaml
@@ -3,5 +3,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: hubble-ui 
+  name: hubble-ui
+  {{- if .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml .Values.serviceAccount.annotations | indent 4 }}
+  {{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/charts/hubble-ui/values.yaml
+++ b/install/kubernetes/cilium/charts/hubble-ui/values.yaml
@@ -18,7 +18,10 @@ replicas: 1
 #         cpu: 100m
 #         memory: 64Mi
 resources: {}
-  
+
+serviceAccount:
+  annotations: {}
+
 ingress:
   enabled: false
   annotations: {}

--- a/install/kubernetes/cilium/charts/managed-etcd/templates/etcd-operator-serviceaccount.yaml
+++ b/install/kubernetes/cilium/charts/managed-etcd/templates/etcd-operator-serviceaccount.yaml
@@ -3,3 +3,7 @@ kind: ServiceAccount
 metadata:
   name: cilium-etcd-sa
   namespace: {{ .Release.Namespace }}
+  {{- if .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml .Values.serviceAccount.annotations | indent 4 }}
+  {{- end }}

--- a/install/kubernetes/cilium/charts/managed-etcd/values.yaml
+++ b/install/kubernetes/cilium/charts/managed-etcd/values.yaml
@@ -1,2 +1,5 @@
 image: cilium-etcd-operator
 tag: v2.0.7
+
+serviceAccount:
+  annotations: {}

--- a/install/kubernetes/cilium/charts/operator/templates/serviceaccount.yaml
+++ b/install/kubernetes/cilium/charts/operator/templates/serviceaccount.yaml
@@ -3,3 +3,7 @@ kind: ServiceAccount
 metadata:
   name: cilium-operator
   namespace: {{ .Release.Namespace }}
+  {{- if .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml .Values.serviceAccount.annotations | indent 4 }}
+  {{- end }}

--- a/install/kubernetes/cilium/charts/operator/values.yaml
+++ b/install/kubernetes/cilium/charts/operator/values.yaml
@@ -2,5 +2,9 @@ image: operator
 # Deprecated: please use synchronizeK8sNodes in install/kubernetes/cilium/values.yaml
 synchronizeK8sNodes: true
 
+# Service account annotations
+serviceAccount:
+  annotations: {}
+
 # Specifies the resources for the operator container
 resources: {}


### PR DESCRIPTION
<!-- Description of change -->
In order to use AWS EKS IAM roles for service account, we must annotate
service account with IAM role. More details can be found here
https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-technical-overview.html

Fixes: #11303

```release-note
Support service account annotations for helm charts
```
