### PR TITLE
CI: Run coccicheck BPF target with GitHub Actions

### DIFF
--- a/.github/workflows/coccicheck.yaml
+++ b/.github/workflows/coccicheck.yaml
@@ -1,0 +1,12 @@
+name: BPF checks
+
+on:
+  - pull_request
+
+jobs:
+    coccicheck:
+        name: coccicheck
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: docker://cilium/coccicheck:latest

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -1016,7 +1016,7 @@ lb4_xlate(struct __ctx_buff *ctx, __be32 *new_daddr, __be32 *new_saddr,
 #ifdef ENABLE_SESSION_AFFINITY
 static __always_inline __u32
 __lb4_affinity_backend_id(const struct lb4_service *svc, bool netns_cookie,
-			  union lb4_affinity_client_id *id)
+			  const union lb4_affinity_client_id *id)
 {
 	__u32 now = bpf_ktime_get_sec();
 	struct lb_affinity_match match = {
@@ -1057,7 +1057,8 @@ lb4_affinity_backend_id_by_addr(const struct lb4_service *svc,
 
 static __always_inline void
 __lb4_update_affinity(const struct lb4_service *svc, bool netns_cookie,
-		      union lb4_affinity_client_id *id, __u32 backend_id)
+		      const union lb4_affinity_client_id *id,
+		      __u32 backend_id)
 {
 	__u32 now = bpf_ktime_get_sec();
 	struct lb4_affinity_key key = {
@@ -1082,7 +1083,7 @@ lb4_update_affinity_by_addr(const struct lb4_service *svc,
 
 static __always_inline void
 __lb4_delete_affinity(const struct lb4_service *svc, bool netns_cookie,
-		      union lb4_affinity_client_id *id)
+		      const union lb4_affinity_client_id *id)
 {
 	struct lb4_affinity_key key = {
 		.rev_nat_id	= svc->rev_nat_index,

--- a/contrib/coccinelle/Dockerfile
+++ b/contrib/coccinelle/Dockerfile
@@ -1,0 +1,19 @@
+FROM docker.io/library/alpine:3.11
+
+LABEL maintainer="maintainer@cilium.io"
+
+ENV COCCINELLE_VERSION 1.0.8
+
+RUN apk add -t .build_apks curl autoconf automake gcc libc-dev ocaml ocaml-dev ocaml-ocamldoc ocaml-findlib && \
+    apk add make python bash && \
+    curl -sS -L https://github.com/coccinelle/coccinelle/archive/$COCCINELLE_VERSION.tar.gz -o coccinelle.tar.gz && \
+    tar xvzf coccinelle.tar.gz && rm coccinelle.tar.gz && \
+    cd coccinelle-$COCCINELLE_VERSION && \
+    ./autogen && \
+    ./configure --disable-ocaml --disable-pcre-syntax && \
+    make && make install-spatch install-python && \
+    cd .. && rm -r coccinelle-$COCCINELLE_VERSION && \
+    strip `which spatch` && \
+    apk del .build_apks
+
+ENTRYPOINT ["./contrib/coccinelle/check-cocci.sh"]

--- a/contrib/coccinelle/check-cocci.sh
+++ b/contrib/coccinelle/check-cocci.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+make -C bpf coccicheck | tee /tmp/stdout
+exit $(grep -c "^* file " /tmp/stdout)


### PR DESCRIPTION
Runs `coccicheck` as a GitHub Action on all pull request synchronize and open events, with Coccinelle packaged as a Docker image based on Alpine.