### PR TITLE
CI: fix bash complaining about "unexpected tokens" (parenthesis)

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -3187,14 +3187,14 @@ func (kub *Kubectl) DumpCiliumCommandOutput(ctx context.Context, namespace strin
 			}
 
 			archiveName := filepath.Join(logsPath, fmt.Sprintf("bugtool-%s", pod))
-			res = kub.ExecContext(ctx, fmt.Sprintf("mkdir -p %s", archiveName))
+			res = kub.ExecContext(ctx, fmt.Sprintf("mkdir -p %q", archiveName))
 			if !res.WasSuccessful() {
 				logger.WithField("cmd", res.GetCmd()).Errorf(
 					"cannot create bugtool archive folder: %s", res.CombineOutput())
 				continue
 			}
 
-			cmd := fmt.Sprintf("tar -xf /tmp/%s -C %s --strip-components=1", line, archiveName)
+			cmd := fmt.Sprintf("tar -xf /tmp/%s -C %q --strip-components=1", line, archiveName)
 			res = kub.ExecContext(ctx, cmd, ExecOptions{SkipLog: true})
 			if !res.WasSuccessful() {
 				logger.WithField("cmd", cmd).Errorf(

--- a/test/helpers/wrappers.go
+++ b/test/helpers/wrappers.go
@@ -59,8 +59,8 @@ func Wrk(endpoint string) string {
 
 // CurlFail returns the string representing the curl command with `-s` and
 // `--fail` options enabled to curl the specified endpoint.  It takes a
-// variadic optinalValues argument. This is passed on to fmt.Sprintf() and uses
-// into the curl message
+// variadic optionalValues argument. This is passed on to fmt.Sprintf() and
+// used into the curl message.
 func CurlFail(endpoint string, optionalValues ...interface{}) string {
 	statsInfo := `time-> DNS: '%{time_namelookup}(%{remote_ip})', Connect: '%{time_connect}',` +
 		`Transfer '%{time_starttransfer}', total '%{time_total}'`
@@ -69,7 +69,7 @@ func CurlFail(endpoint string, optionalValues ...interface{}) string {
 		endpoint = fmt.Sprintf(endpoint, optionalValues...)
 	}
 	return fmt.Sprintf(
-		`curl --path-as-is -s -D /dev/stderr --fail --connect-timeout %[1]d --max-time %[2]d %[3]s -w "%[4]s"`,
+		`curl --path-as-is -s -D /dev/stderr --fail --connect-timeout %d --max-time %d %s -w "%s"`,
 		CurlConnectTimeout, CurlMaxTimeout, endpoint, statsInfo)
 }
 

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -383,7 +383,7 @@ var _ = Describe("K8sServicesTest", func() {
 		testCurlFailFromPodInHostNetNS := func(url string, count int, fromPod string) {
 			By("Making %d curl requests from %s to %q", count, fromPod, url)
 			for i := 1; i <= count; i++ {
-				res, err := kubectl.ExecInHostNetNS(context.TODO(), fromPod, helpers.CurlFail(url, "--max-time 3"))
+				res, err := kubectl.ExecInHostNetNS(context.TODO(), fromPod, helpers.CurlFail(url))
 				ExpectWithOffset(1, err).To(BeNil(), "Cannot run curl in host netns")
 				ExpectWithOffset(1, res).ShouldNot(helpers.CMDSuccess(),
 					"%s host unexpectedly connected to service %q, it should fail", fromPod, url)

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -927,8 +927,14 @@ var _ = Describe("K8sServicesTest", func() {
 			httpURL = getHTTPLink(k8s1IP, data.Spec.Ports[0].NodePort)
 			tftpURL = getTFTPLink(k8s1IP, data.Spec.Ports[1].NodePort)
 			// Local requests should be load-balanced
-			testCurlFromPodInHostNetNS(httpURL, count, k8s1NodeName)
-			testCurlFromPodInHostNetNS(tftpURL, count, k8s1NodeName)
+			if helpers.RunsWithKubeProxy() {
+				// FIXME: The Nodeport BPF implementation for
+				// externalTrafficPolicy=Local is not compliant
+				// here, and the following checks fail. Let's
+				// disable them for now. See #11746.
+				testCurlFromPodInHostNetNS(httpURL, count, k8s1NodeName)
+				testCurlFromPodInHostNetNS(tftpURL, count, k8s1NodeName)
+			}
 			// Requests from another node are not
 			testCurlFailFromPodInHostNetNS(httpURL, count, k8s2NodeName)
 			testCurlFailFromPodInHostNetNS(tftpURL, count, k8s2NodeName)


### PR DESCRIPTION
In #11094, @pchaigno reported that a few K8sServices tests contain parenthesis in their names, and that this creates confusion for the bash command used to create the bugtool archive directory if one of those tests fails on the CI.

Let's fix this by enquoting the directory name in the relevant bash commands, to avoid the parenthesis to be interpreted. This was tested in draft PR #11230, where test `Tests NodePort (kube-proxy)` is forced to fail and where we can grep the CI logs for the `unexpected token` bash error.

While grepping for that message, it appeared that the logs had other occurrences of this `unexpected token` error. They are not related to the above issues, but instead come from a wrong usage of the optional arguments for `helpers.CurlFail()` at one location in K8sServices tests. Fix this one by removing the spurious (unnecessary) argument. The aforementioned PR also has this fix, and shows that it solves the complaint from bash.

Fixes: #11094
