### PR TITLE
make: avoid building plugins/cni twice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,14 @@
 
 include Makefile.defs
 
-SUBDIRS_CILIUM_CONTAINER := proxylib envoy plugins/cilium-cni bpf cilium daemon cilium-health bugtool
+SUBDIRS_CILIUM_CONTAINER := proxylib envoy bpf cilium daemon cilium-health bugtool
+SUBDIRS := $(SUBDIRS_CILIUM_CONTAINER) operator plugins tools hubble-relay
+
+SUBDIRS_CILIUM_CONTAINER += plugins/cilium-cni
 ifdef LIBNETWORK_PLUGIN
 SUBDIRS_CILIUM_CONTAINER += plugins/cilium-docker
 endif
-SUBDIRS := $(SUBDIRS_CILIUM_CONTAINER) operator plugins tools hubble-relay
+
 GOFILES_EVAL := $(subst _$(ROOT_DIR)/,,$(shell $(GO_LIST) -e ./...))
 GOFILES ?= $(GOFILES_EVAL)
 TESTPKGS_EVAL := $(subst github.com/cilium/cilium/,,$(shell $(GO_LIST) -e ./... | grep -v '/api/v1\|/vendor\|/contrib' | grep -v -P 'test(?!/helpers/logutils)'))


### PR DESCRIPTION
Currently invoking make in the top-level directory will cause
`plugins/cilium-cni` being built twice:

```
  $ make V=0
    GO    proxylib/libcilium.so
    SKIP  envoy/
  cilium-envoy has been moved to github.com/cilium/proxy
    GO    plugins/cilium-cni/cilium-cni
    GO    cilium/cilium
    GO    daemon/cilium-agent
    GO    cilium-health/cilium-health
    GO    cilium-health/responder/cilium-health-responder
    GO    bugtool/cilium-bugtool
    GO    operator/cilium-operator
    GO    plugins/cilium-docker/cilium-docker
    GO    plugins/cilium-cni/cilium-cni
    GO    tools/alignchecker/cilium-align-checker
    GO    tools/maptool/maptool
    GO    hubble-relay/hubble-relay
```

Since `plugins` is already in `$(SUBDIRS)` and `plugins/Makefile` makes sure
to build all its subdirectories (i.e. `cilium-cni` and `cilium-docker`),
extend `$(SUBDIRS_CILIUM_CONTAINER)` with the appropriate plugins after
`$(SUBDIRS)` was defined based on in.