### PR TITLE
v1.7 backports 2020-05-04

### DIFF
--- a/Documentation/gettingstarted/istio.rst
+++ b/Documentation/gettingstarted/istio.rst
@@ -29,21 +29,20 @@ Step 2: Install cilium-istioctl
 
    Make sure that Cilium is running in your cluster before proceeding.
 
-Download the cilium enhanced istioctl version 1.5.1:
-<https://github.com/cilium/istio/releases/tag/1.5.1>`_:
+Download the `cilium enhanced istioctl version 1.5.2 <https://github.com/cilium/istio/releases/tag/1.5.2>`_:
 
 .. tabs::
   .. group-tab:: Linux
 
     .. parsed-literal::
 
-     curl -L https://github.com/cilium/istio/releases/download/1.5.1/cilium-istioctl-1.5.1-linux.tar.gz | tar xz
+     curl -L https://github.com/cilium/istio/releases/download/1.5.2/cilium-istioctl-1.5.2-linux.tar.gz | tar xz
 
   .. group-tab:: OSX
 
     .. parsed-literal::
 
-     curl -L https://github.com/cilium/istio/releases/download/1.5.1/cilium-istioctl-1.5.1-osx.tar.gz | tar xz
+     curl -L https://github.com/cilium/istio/releases/download/1.5.2/cilium-istioctl-1.5.2-osx.tar.gz | tar xz
 
 .. note::
 

--- a/test/k8sT/istio.go
+++ b/test/k8sT/istio.go
@@ -25,7 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-// This tests the Istio 1.5.1 integration, following the configuration
+// This tests the Istio integration, following the configuration
 // instructions specified in the Istio Getting Started Guide in
 // Documentation/gettingstarted/istio.rst.
 var _ = Describe("K8sIstioTest", func() {
@@ -35,7 +35,7 @@ var _ = Describe("K8sIstioTest", func() {
 		// installed.
 		istioSystemNamespace = "istio-system"
 
-		istioVersion = "1.5.1"
+		istioVersion = "1.5.2"
 
 		ciliumIstioctlURL = "https://github.com/cilium/istio/releases/download/" + istioVersion + "/cilium-istioctl-" + istioVersion + "-linux.tar.gz"
 		// istioServiceNames is the set of Istio services needed for the tests
@@ -60,7 +60,7 @@ var _ = Describe("K8sIstioTest", func() {
 		k8sVersion := helpers.GetCurrentK8SEnv()
 		switch k8sVersion {
 		case "1.7", "1.8", "1.9", "1.10", "1.11", "1.12", "1.13":
-			Skip(fmt.Sprintf("Istio 1.5.1 doesn't support K8S %s", k8sVersion))
+			Skip(fmt.Sprintf("Istio %s doesn't support K8S %s", istioVersion, k8sVersion))
 		}
 
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)


### PR DESCRIPTION
 * #11280 -- Istio: Update to release 1.5.2 (@jrajahalme)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 11280; do contrib/backporting/set-labels.py $pr done 1.7; done
```
