### PR TITLE
Misc ip-masq-agent improvements

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -108,7 +108,6 @@ cilium-agent [flags]
       --install-iptables-rules                        Install base iptables rules for cilium to mainly interact with kube-proxy (and masquerading) (default true)
       --ip-allocation-timeout duration                Time after which an incomplete CIDR allocation is considered failed (default 2m0s)
       --ip-masq-agent-config-path string              ip-masq-agent configuration file path (default "/etc/config/ip-masq-agent")
-      --ip-masq-agent-sync-period duration            ip-masq-agent configuration file synchronization period (default 1m0s)
       --ipam string                                   Backend to use for IPAM (default "hostscope-legacy")
       --ipsec-key-file string                         Path to IPSec key file
       --ipv4-node string                              IPv4 address of node (default "auto")

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -547,9 +547,6 @@ func init() {
 	flags.String(option.IPMasqAgentConfigPath, "/etc/config/ip-masq-agent", "ip-masq-agent configuration file path")
 	option.BindEnv(option.IPMasqAgentConfigPath)
 
-	flags.Duration(option.IPMasqAgentSyncPeriod, 60*time.Second, "ip-masq-agent configuration file synchronization period")
-	option.BindEnv(option.IPMasqAgentSyncPeriod)
-
 	flags.Bool(option.InstallIptRules, true, "Install base iptables rules for cilium to mainly interact with kube-proxy (and masquerading)")
 	option.BindEnv(option.InstallIptRules)
 
@@ -1295,8 +1292,11 @@ func runDaemon() {
 	}
 
 	if option.Config.EnableIPMasqAgent {
-		ipmasq.Start(option.Config.IPMasqAgentConfigPath,
-			option.Config.IPMasqAgentSyncPeriod)
+		ipmasqAgent, err := ipmasq.NewIPMasqAgent(option.Config.IPMasqAgentConfigPath)
+		if err != nil {
+			log.WithError(err).Fatal("Failed to create ip-masq-agent")
+		}
+		ipmasqAgent.Start()
 	}
 
 	if !option.Config.DryMode {

--- a/pkg/ipmasq/ipmasq_test.go
+++ b/pkg/ipmasq/ipmasq_test.go
@@ -113,6 +113,19 @@ func (i *IPMasqTestSuite) TestUpdate(c *check.C) {
 	_, ok = i.ipMasqMap.cidrs["2.2.0.0/16"]
 	c.Assert(ok, check.Equals, true)
 
+	// Write new config in JSON
+	_, err = i.configFile.Seek(0, 0)
+	c.Assert(err, check.IsNil)
+	_, err = i.configFile.WriteString(`{"nonMasqueradeCIDRs": ["8.8.0.0/16", "1.1.2.3/16"]}`)
+	c.Assert(err, check.IsNil)
+	time.Sleep(300 * time.Millisecond)
+
+	c.Assert(len(i.ipMasqMap.cidrs), check.Equals, 2)
+	_, ok = i.ipMasqMap.cidrs["8.8.0.0/16"]
+	c.Assert(ok, check.Equals, true)
+	_, ok = i.ipMasqMap.cidrs["1.1.0.0/16"]
+	c.Assert(ok, check.Equals, true)
+
 	// Delete file, should remove the CIDRs
 	err = os.Remove(i.configFile.Name())
 	c.Assert(err, check.IsNil)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -276,9 +276,6 @@ const (
 	// IPMasqAgentConfigPath is the configuration file path
 	IPMasqAgentConfigPath = "ip-masq-agent-config-path"
 
-	// IPMasqAgentSyncPeriod is the configuration file synchronization period
-	IPMasqAgentSyncPeriod = "ip-masq-agent-sync-period"
-
 	// InstallIptRules sets whether Cilium should install any iptables in general
 	InstallIptRules = "install-iptables-rules"
 
@@ -1454,7 +1451,6 @@ type DaemonConfig struct {
 	EnableBPFMasquerade    bool
 	EnableIPMasqAgent      bool
 	IPMasqAgentConfigPath  string
-	IPMasqAgentSyncPeriod  time.Duration
 	InstallIptRules        bool
 	MonitorAggregation     string
 	PreAllocateMaps        bool
@@ -2231,7 +2227,6 @@ func (c *DaemonConfig) Populate() {
 	c.EnableBPFMasquerade = viper.GetBool(EnableBPFMasquerade)
 	c.EnableIPMasqAgent = viper.GetBool(EnableIPMasqAgent)
 	c.IPMasqAgentConfigPath = viper.GetString(IPMasqAgentConfigPath)
-	c.IPMasqAgentSyncPeriod = viper.GetDuration(IPMasqAgentSyncPeriod)
 	c.InstallIptRules = viper.GetBool(InstallIptRules)
 	c.IPSecKeyFile = viper.GetString(IPSecKeyFileName)
 	c.ModePreFilter = viper.GetString(PrefilterMode)


### PR DESCRIPTION
This PR adds some improvements to the BPF ip-masq-agent:

- Allows to configure ip-masq-agent in JSON.
- Fixes the race condition in the unit tests.
- Use fsnotify instead of polling the config file.

Reviewable per commit.

Fix #11289.