### PR TITLE
Drop dependency on pkg/option in cilium-cni and cilium-docker

### DIFF
--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/datapath/connector"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
+	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
@@ -200,7 +201,7 @@ func CleanupEndpoint() {
 	// deletion of associated interfaces immediately (e.g. when a process in the
 	// namespace marked for deletion has not yet been terminated).
 	switch option.Config.DatapathMode {
-	case option.DatapathModeVeth:
+	case datapathOption.DatapathModeVeth:
 		for _, iface := range []string{legacyVethName, vethName} {
 			scopedLog := log.WithField(logfields.Veth, iface)
 			if link, err := netlink.LinkByName(iface); err == nil {
@@ -212,7 +213,7 @@ func CleanupEndpoint() {
 				scopedLog.WithError(err).Debug("Didn't find existing device")
 			}
 		}
-	case option.DatapathModeIpvlan:
+	case datapathOption.DatapathModeIpvlan:
 		if err := netns.RemoveIfFromNetNSWithNameIfBothExist(netNSName, epIfaceName); err != nil {
 			log.WithError(err).WithField(logfields.Ipvlan, epIfaceName).
 				Info("Couldn't delete cilium-health ipvlan slave device")
@@ -280,7 +281,7 @@ func LaunchAsEndpoint(baseCtx context.Context,
 	}
 
 	switch option.Config.DatapathMode {
-	case option.DatapathModeVeth:
+	case datapathOption.DatapathModeVeth:
 		_, epLink, err := connector.SetupVethWithNames(vethName, epIfaceName, mtuConfig.GetDeviceMTU(), info)
 		if err != nil {
 			return nil, fmt.Errorf("Error while creating veth: %s", err)
@@ -290,7 +291,7 @@ func LaunchAsEndpoint(baseCtx context.Context,
 			return nil, fmt.Errorf("failed to move device %q to health namespace: %s", epIfaceName, err)
 		}
 
-	case option.DatapathModeIpvlan:
+	case datapathOption.DatapathModeIpvlan:
 		mapFD, err := connector.CreateAndSetupIpvlanSlave("",
 			epIfaceName, netNS, mtuConfig.GetDeviceMTU(),
 			option.Config.Ipvlan.MasterDeviceIndex,

--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -33,6 +33,7 @@ import (
 	healthDefaults "github.com/cilium/cilium/pkg/health/defaults"
 	"github.com/cilium/cilium/pkg/health/probe"
 	"github.com/cilium/cilium/pkg/identity/cache"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/launcher"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -343,7 +344,7 @@ func LaunchAsEndpoint(baseCtx context.Context,
 		return nil, fmt.Errorf("Error while configuring routes: %s", err)
 	}
 
-	if option.Config.IPAM == option.IPAMENI {
+	if option.Config.IPAM == ipamOption.IPAMENI {
 		if err := routingConfig.Configure(healthIP,
 			mtuConfig.GetDeviceMTU(),
 			option.Config.Masquerade); err != nil {

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -47,6 +47,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	identitymodel "github.com/cilium/cilium/pkg/identity/model"
 	"github.com/cilium/cilium/pkg/ipam"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/k8s/watchers"
@@ -411,7 +412,7 @@ func NewDaemon(ctx context.Context, dp datapath.Datapath) (*Daemon, *endpointRes
 			log.WithError(err).Fatal("Unable to register CRDs")
 		}
 
-		if option.Config.IPAM == option.IPAMOperator {
+		if option.Config.IPAM == ipamOption.IPAMOperator {
 			// Create the CiliumNode custom resource. This call will block until
 			// the custom resource has been created
 			d.nodeDiscovery.UpdateCiliumNodeResource()
@@ -491,7 +492,7 @@ func NewDaemon(ctx context.Context, dp datapath.Datapath) (*Daemon, *endpointRes
 
 	// Trigger refresh and update custom resource in the apiserver with all restored endpoints.
 	// Trigger after nodeDiscovery.StartDiscovery to avoid custom resource update conflict.
-	if option.Config.IPAM == option.IPAMCRD || option.Config.IPAM == option.IPAMENI || option.Config.IPAM == option.IPAMAzure {
+	if option.Config.IPAM == ipamOption.IPAMCRD || option.Config.IPAM == ipamOption.IPAMENI || option.Config.IPAM == ipamOption.IPAMAzure {
 		if option.Config.EnableIPv6 {
 			d.ipam.IPv6Allocator.RestoreFinished()
 		}

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -45,6 +45,7 @@ import (
 	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/flowdebug"
 	"github.com/cilium/cilium/pkg/identity"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/ipmasq"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/k8s/watchers"
@@ -401,7 +402,7 @@ func init() {
 	flags.String(option.IdentityAllocationMode, option.IdentityAllocationModeKVstore, "Method to use for identity allocation")
 	option.BindEnv(option.IdentityAllocationMode)
 
-	flags.String(option.IPAM, option.IPAMHostScopeLegacy, "Backend to use for IPAM")
+	flags.String(option.IPAM, ipamOption.IPAMHostScopeLegacy, "Backend to use for IPAM")
 	option.BindEnv(option.IPAM)
 
 	flags.Int(option.IPv4ClusterCIDRMaskSize, 8, "Mask size for the cluster wide CIDR")

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/components"
 	"github.com/cilium/cilium/pkg/controller"
+	"github.com/cilium/cilium/pkg/datapath/connector"
 	"github.com/cilium/cilium/pkg/datapath/iptables"
 	linuxdatapath "github.com/cilium/cilium/pkg/datapath/linux"
 	"github.com/cilium/cilium/pkg/datapath/linux/probes"
@@ -1078,9 +1079,9 @@ func initEnv(cmd *cobra.Command) {
 				Fatal("Cannot find device interface")
 		}
 		option.Config.Ipvlan.MasterDeviceIndex = link.Attrs().Index
-		option.Config.Ipvlan.OperationMode = option.OperationModeL3
+		option.Config.Ipvlan.OperationMode = connector.OperationModeL3
 		if option.Config.InstallIptRules {
-			option.Config.Ipvlan.OperationMode = option.OperationModeL3S
+			option.Config.Ipvlan.OperationMode = connector.OperationModeL3S
 		}
 	default:
 		log.WithField(logfields.DatapathMode, option.Config.DatapathMode).Fatal("Invalid datapath mode")

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/probes"
 	"github.com/cilium/cilium/pkg/datapath/loader"
 	"github.com/cilium/cilium/pkg/datapath/maps"
+	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/flowdebug"
@@ -1025,7 +1026,7 @@ func initEnv(cmd *cobra.Command) {
 	option.Config.NAT46Prefix = r
 
 	switch option.Config.DatapathMode {
-	case option.DatapathModeVeth:
+	case datapathOption.DatapathModeVeth:
 		if name := viper.GetString(option.IpvlanMasterDevice); name != "undefined" {
 			log.WithField(logfields.IpvlanMasterDevice, name).
 				Fatal("ipvlan master device cannot be set in the 'veth' datapath mode")
@@ -1043,7 +1044,7 @@ func initEnv(cmd *cobra.Command) {
 				option.Config.EnableIPv6 = false
 			}
 		}
-	case option.DatapathModeIpvlan:
+	case datapathOption.DatapathModeIpvlan:
 		if option.Config.Tunnel != "" && option.Config.Tunnel != option.TunnelDisabled {
 			log.WithField(logfields.Tunnel, option.Config.Tunnel).
 				Fatal("tunnel cannot be set in the 'ipvlan' datapath mode")
@@ -1111,8 +1112,8 @@ func initEnv(cmd *cobra.Command) {
 		if !option.Config.EnableNodePort {
 			log.Fatalf("BPF masquerade requires NodePort (--%s=\"true\")", option.EnableNodePort)
 		}
-		if option.Config.DatapathMode == option.DatapathModeIpvlan {
-			log.Fatalf("BPF masquerade works only in veth mode (--%s=\"veth\"", option.DatapathMode)
+		if option.Config.DatapathMode == datapathOption.DatapathModeIpvlan {
+			log.Fatalf("BPF masquerade works only in veth mode (--%s=\"%s\"", option.DatapathMode, datapathOption.DatapathModeVeth)
 		}
 		if option.Config.EgressMasqueradeInterfaces != "" {
 			log.Fatalf("BPF masquerade does not allow to specify devices via --%s. Use --%s instead.", option.EgressMasqueradeInterfaces, option.Device)

--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -28,6 +28,7 @@ import (
 	linuxrouting "github.com/cilium/cilium/pkg/datapath/linux/routing"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/ipam"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/node"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
@@ -225,7 +226,7 @@ func (d *Daemon) allocateHealthIPs() error {
 			// In ENI mode, we require the gateway, CIDRs, and the ENI MAC addr
 			// in order to set up rules and routes on the local node to direct
 			// endpoint traffic out of the ENIs.
-			if option.Config.IPAM == option.IPAMENI {
+			if option.Config.IPAM == ipamOption.IPAMENI {
 				if err := d.parseHealthEndpointInfo(result); err != nil {
 					log.WithError(err).Warn("Unable to allocate health information for ENI")
 				}

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -21,6 +21,7 @@ import (
 	operatorMetrics "github.com/cilium/cilium/operator/metrics"
 	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/defaults"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/option"
 
 	"github.com/spf13/cobra"
@@ -137,7 +138,7 @@ func init() {
 	flags.Bool(operatorOption.EnableMetrics, false, "Enable Prometheus metrics")
 	option.BindEnv(operatorOption.EnableMetrics)
 
-	flags.String(option.IPAM, option.IPAMHostScopeLegacy, "Backend to use for IPAM")
+	flags.String(option.IPAM, ipamOption.IPAMHostScopeLegacy, "Backend to use for IPAM")
 	option.BindEnv(option.IPAM)
 
 	flags.Duration(operatorOption.IdentityHeartbeatTimeout, 2*defaults.KVstoreLeaseTTL, "Timeout after which identity expires on lack of heartbeat")
@@ -148,13 +149,13 @@ func init() {
 
 	flags.String(operatorOption.IPAMOperatorV4CIDR, "",
 		fmt.Sprintf("IPv4 CIDR Range for Pods in cluster. Requires '%s=%s' and '%s=%s'",
-			option.IPAM, option.IPAMOperator,
+			option.IPAM, ipamOption.IPAMOperator,
 			option.EnableIPv4Name, "true"))
 	option.BindEnv(operatorOption.IPAMOperatorV4CIDR)
 
 	flags.Int(operatorOption.NodeCIDRMaskSizeIPv4, 24,
 		fmt.Sprintf("Mask size for each IPv4 podCIDR per node. Requires '%s=%s' and '%s=%s'",
-			option.IPAM, option.IPAMOperator,
+			option.IPAM, ipamOption.IPAMOperator,
 			option.EnableIPv4Name, "true"))
 	option.BindEnv(operatorOption.NodeCIDRMaskSizeIPv4)
 
@@ -163,13 +164,13 @@ func init() {
 
 	flags.String(operatorOption.IPAMOperatorV6CIDR, "",
 		fmt.Sprintf("IPv6 CIDR Range for Pods in cluster. Requires '%s=%s' and '%s=%s'",
-			option.IPAM, option.IPAMOperator,
+			option.IPAM, ipamOption.IPAMOperator,
 			option.EnableIPv6Name, "true"))
 	option.BindEnv(operatorOption.IPAMOperatorV6CIDR)
 
 	flags.Int(operatorOption.NodeCIDRMaskSizeIPv6, 112,
 		fmt.Sprintf("Mask size for each IPv6 podCIDR per node. Requires '%s=%s' and '%s=%s'",
-			option.IPAM, option.IPAMOperator,
+			option.IPAM, ipamOption.IPAMOperator,
 			option.EnableIPv6Name, "true"))
 	option.BindEnv(operatorOption.NodeCIDRMaskSizeIPv6)
 

--- a/operator/k8s_node.go
+++ b/operator/k8s_node.go
@@ -24,6 +24,7 @@ import (
 	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/ipam/allocator"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/k8s"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	v2 "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2"
@@ -103,7 +104,7 @@ func runNodeWatcher(nodeManager *allocator.NodeEventHandler) error {
 		// present in the k8sNodeStore.
 
 		switch option.Config.IPAM {
-		case option.IPAMENI, option.IPAMAzure:
+		case ipamOption.IPAMENI, ipamOption.IPAMAzure:
 			nodes, err := ciliumK8sClient.CiliumV2().CiliumNodes().List(context.TODO(), meta_v1.ListOptions{})
 			if err != nil {
 				log.WithError(err).Warning("Unable to list CiliumNodes. Won't clean up stale CiliumNodes")

--- a/operator/main.go
+++ b/operator/main.go
@@ -25,6 +25,7 @@ import (
 	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/components"
 	"github.com/cilium/cilium/pkg/ipam/allocator"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/k8s"
 	clientset "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned"
 	k8sversion "github.com/cilium/cilium/pkg/k8s/version"
@@ -164,7 +165,7 @@ func runOperator(cmd *cobra.Command) {
 		err         error
 	)
 	switch ipamMode := option.Config.IPAM; ipamMode {
-	case option.IPAMAzure, option.IPAMENI, option.IPAMOperator:
+	case ipamOption.IPAMAzure, ipamOption.IPAMENI, ipamOption.IPAMOperator:
 		alloc, providerBuiltin := allocatorProviders[ipamMode]
 		if !providerBuiltin {
 			log.Fatalf("%s allocator is not supported by this version of cilium-operator", ipamMode)
@@ -183,7 +184,7 @@ func runOperator(cmd *cobra.Command) {
 		nodeManager = &nm
 
 		switch ipamMode {
-		case option.IPAMOperator:
+		case ipamOption.IPAMOperator:
 			// We will use CiliumNodes as the source of truth for the podCIDRs.
 			// Once the CiliumNodes are synchronized with the operator we will
 			// be able to watch for K8s Node events which they will be used

--- a/operator/provider_aws.go
+++ b/operator/provider_aws.go
@@ -19,10 +19,10 @@ package main
 import (
 	// These dependencies should be included only when this file is included in the build.
 	allocatorAWS "github.com/cilium/cilium/pkg/ipam/allocator/aws" // AWS allocator.
-	"github.com/cilium/cilium/pkg/option"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	_ "github.com/cilium/cilium/pkg/policy/groups/aws" // Register AWS policy group provider.
 )
 
 func init() {
-	allocatorProviders[option.IPAMENI] = &allocatorAWS.AllocatorAWS{}
+	allocatorProviders[ipamOption.IPAMENI] = &allocatorAWS.AllocatorAWS{}
 }

--- a/operator/provider_azure.go
+++ b/operator/provider_azure.go
@@ -19,9 +19,9 @@ package main
 import (
 	// These dependencies should be included only when this file is included in the build.
 	allocatorAzure "github.com/cilium/cilium/pkg/ipam/allocator/azure" // Azure allocator task.
-	"github.com/cilium/cilium/pkg/option"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 )
 
 func init() {
-	allocatorProviders[option.IPAMAzure] = &allocatorAzure.AllocatorAzure{}
+	allocatorProviders[ipamOption.IPAMAzure] = &allocatorAzure.AllocatorAzure{}
 }

--- a/operator/provider_operator.go
+++ b/operator/provider_operator.go
@@ -19,9 +19,9 @@ package main
 import (
 	// These dependencies should be included only when this file is included in the build.
 	allocatorOperator "github.com/cilium/cilium/pkg/ipam/allocator/operator" // Operator allocator.
-	"github.com/cilium/cilium/pkg/option"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 )
 
 func init() {
-	allocatorProviders[option.IPAMOperator] = &allocatorOperator.AllocatorOperator{}
+	allocatorProviders[ipamOption.IPAMOperator] = &allocatorOperator.AllocatorOperator{}
 }

--- a/pkg/datapath/connector/ipvlan.go
+++ b/pkg/datapath/connector/ipvlan.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/datapath/link"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/option"
 	"github.com/containernetworking/plugins/pkg/ns"
 
 	"github.com/vishvananda/netlink"
@@ -245,9 +244,9 @@ func createIpvlanSlave(lxcIfName string, mtu, masterDev int, mode string, ep *mo
 	}
 
 	switch mode {
-	case option.OperationModeL3:
+	case OperationModeL3:
 		ipvlanMode = netlink.IPVLAN_MODE_L3
-	case option.OperationModeL3S:
+	case OperationModeL3S:
 		ipvlanMode = netlink.IPVLAN_MODE_L3S
 	default:
 		return nil, nil, fmt.Errorf("invalid or unsupported ipvlan operation mode: %s", mode)

--- a/pkg/datapath/connector/option.go
+++ b/pkg/datapath/connector/option.go
@@ -1,0 +1,24 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connector
+
+// Available option for DaemonConfig.Ipvlan.OperationMode
+const (
+	// OperationModeL3S will respect iptables rules e.g. set up for masquerading
+	OperationModeL3S = "L3S"
+
+	// OperationModeL3 will bypass iptables rules on the host
+	OperationModeL3 = "L3"
+)

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/command/exec"
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/defaults"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/modules"
 	"github.com/cilium/cilium/pkg/node"
@@ -689,7 +690,7 @@ func (m *IptablesManager) remoteSnatDstAddrExclusion() string {
 
 func getDeliveryInterface(ifName string) string {
 	deliveryInterface := ifName
-	if option.Config.IPAM == option.IPAMENI || option.Config.EnableEndpointRoutes {
+	if option.Config.IPAM == ipamOption.IPAMENI || option.Config.EnableEndpointRoutes {
 		deliveryInterface = "lxc+"
 	}
 	return deliveryInterface

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/datapath/iptables"
+	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
@@ -149,7 +150,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 	cDefinesMap["CT_REPORT_INTERVAL"] = fmt.Sprintf("%d", int64(option.Config.MonitorAggregationInterval.Seconds()))
 	cDefinesMap["CT_REPORT_FLAGS"] = fmt.Sprintf("%#04x", int64(option.Config.MonitorAggregationFlags))
 
-	if option.Config.DatapathMode == option.DatapathModeIpvlan {
+	if option.Config.DatapathMode == datapathOption.DatapathModeIpvlan {
 		cDefinesMap["ENABLE_SECCTX_FROM_IPCACHE"] = "1"
 		cDefinesMap["ENABLE_EXTRA_HOST_DEV"] = "1"
 	}

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1148,7 +1148,7 @@ func (n *linuxNodeHandler) NodeValidateImplementation(nodeToValidate nodeTypes.N
 // NodeDeviceNameWithDefaultRoute returns the node's device name which
 // handles the default route in the current namespace
 func NodeDeviceNameWithDefaultRoute() (string, error) {
-	link, err := route.NodeDeviceWithDefaultRoute()
+	link, err := route.NodeDeviceWithDefaultRoute(option.Config.EnableIPv4, option.Config.EnableIPv6)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/datapath/linux/route/route_darwin.go
+++ b/pkg/datapath/linux/route/route_darwin.go
@@ -39,6 +39,6 @@ func Delete(route Route) error {
 
 // NodeDeviceWithDefaultRoute is not supported on Darwin and will return
 // an error at runtime.
-func NodeDeviceWithDefaultRoute() (netlink.Link, error) {
+func NodeDeviceWithDefaultRoute(enableIPv4, enableIPv6 bool) (netlink.Link, error) {
 	return nil, errUnsupportedOp
 }

--- a/pkg/datapath/linux/route/route_linux.go
+++ b/pkg/datapath/linux/route/route_linux.go
@@ -21,8 +21,6 @@ import (
 	"net"
 	"time"
 
-	"github.com/cilium/cilium/pkg/option"
-
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 )
@@ -553,16 +551,16 @@ func lookupDefaultRoute(family int) (netlink.Route, error) {
 
 // NodeDeviceWithDefaultRoute returns the node's device which handles the
 // default route in the current namespace
-func NodeDeviceWithDefaultRoute() (netlink.Link, error) {
+func NodeDeviceWithDefaultRoute(enableIPv4, enableIPv6 bool) (netlink.Link, error) {
 	linkIndex := 0
-	if option.Config.EnableIPv4 {
+	if enableIPv4 {
 		route, err := lookupDefaultRoute(netlink.FAMILY_V4)
 		if err != nil {
 			return nil, err
 		}
 		linkIndex = route.LinkIndex
 	}
-	if option.Config.EnableIPv6 {
+	if enableIPv6 {
 		route, err := lookupDefaultRoute(netlink.FAMILY_V6)
 		if err != nil {
 			return nil, err

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/datapath/alignchecker"
+	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
 	"github.com/cilium/cilium/pkg/datapath/prefilter"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -218,7 +219,7 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 			}
 		}
 
-		if option.Config.DatapathMode == option.DatapathModeIpvlan {
+		if option.Config.DatapathMode == datapathOption.DatapathModeIpvlan {
 			mode = "ipvlan"
 		} else {
 			mode = "direct"

--- a/pkg/datapath/option/option.go
+++ b/pkg/datapath/option/option.go
@@ -1,0 +1,25 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package option
+
+// Available options for datapath mode.
+const (
+	// DatapathModeVeth specifies veth datapath mode (i.e. containers are
+	// attached to a network via veth pairs).
+	DatapathModeVeth = "veth"
+
+	// DatapathModeIpvlan specifies ipvlan datapath mode.
+	DatapathModeIpvlan = "ipvlan"
+)

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	ciliumio "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/core/v1"
 	"github.com/cilium/cilium/pkg/labels"
@@ -2172,7 +2173,7 @@ func (e *Endpoint) Delete(monitor monitorOwner, ipam ipReleaser, manager endpoin
 		}
 	}
 
-	if option.Config.IPAM == option.IPAMENI || option.Config.IPAM == option.IPAMAzure {
+	if option.Config.IPAM == ipamOption.IPAMENI || option.Config.IPAM == ipamOption.IPAMAzure {
 		e.getLogger().WithFields(logrus.Fields{
 			"ep":     e.GetID(),
 			"ipAddr": e.GetIPv4Address(),

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -27,6 +27,7 @@ import (
 	eniTypes "github.com/cilium/cilium/pkg/aws/eni/types"
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/ip"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	"github.com/cilium/cilium/pkg/k8s"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -246,7 +247,7 @@ func (n *nodeStore) hasMinimumIPsInPool() (minimumReached bool, required, numAva
 			minimumReached = true
 		}
 
-		if n.conf.IPAMMode() == option.IPAMENI {
+		if n.conf.IPAMMode() == ipamOption.IPAMENI {
 			if vpcCIDR := deriveVpcCIDR(n.ownNode); vpcCIDR != nil {
 				if nativeCIDR := n.conf.IPv4NativeRoutingCIDR(); nativeCIDR != nil {
 					logFields := logrus.Fields{
@@ -481,7 +482,7 @@ func (a *crdAllocator) buildAllocationResult(ip net.IP, ipInfo *ipamTypes.Alloca
 
 	// In ENI mode, the Resource points to the ENI so we can derive the
 	// master interface and all CIDRs of the VPC
-	case option.IPAMENI:
+	case ipamOption.IPAMENI:
 		for _, eni := range a.store.ownNode.Status.ENI.ENIs {
 			if eni.ID == ipInfo.Resource {
 				result.Master = eni.MAC
@@ -504,7 +505,7 @@ func (a *crdAllocator) buildAllocationResult(ip net.IP, ipInfo *ipamTypes.Alloca
 
 	// In Azure mode, the Resource points to the azure interface so we can
 	// derive the master interface
-	case option.IPAMAzure:
+	case ipamOption.IPAMAzure:
 		for _, iface := range a.store.ownNode.Status.Azure.Interfaces {
 			if iface.ID == ipInfo.Resource {
 				result.Master = iface.MAC

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -19,9 +19,9 @@ import (
 
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/datapath"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/option"
 
 	"github.com/sirupsen/logrus"
 )
@@ -108,7 +108,7 @@ func NewIPAM(nodeAddressing datapath.NodeAddressing, c Configuration, owner Owne
 	}
 
 	switch c.IPAMMode() {
-	case option.IPAMHostScopeLegacy, option.IPAMKubernetes, option.IPAMOperator:
+	case ipamOption.IPAMHostScopeLegacy, ipamOption.IPAMKubernetes, ipamOption.IPAMOperator:
 		log.WithFields(logrus.Fields{
 			logfields.V4Prefix: nodeAddressing.IPv4().AllocationCIDR(),
 			logfields.V6Prefix: nodeAddressing.IPv6().AllocationCIDR(),
@@ -121,7 +121,7 @@ func NewIPAM(nodeAddressing datapath.NodeAddressing, c Configuration, owner Owne
 		if c.IPv4Enabled() {
 			ipam.IPv4Allocator = newHostScopeAllocator(nodeAddressing.IPv4().AllocationCIDR().IPNet)
 		}
-	case option.IPAMCRD, option.IPAMENI, option.IPAMAzure:
+	case ipamOption.IPAMCRD, ipamOption.IPAMENI, ipamOption.IPAMAzure:
 		log.Info("Initializing CRD-based IPAM")
 		if c.IPv6Enabled() {
 			ipam.IPv6Allocator = newCRDAllocator(IPv6, c, owner, k8sEventReg)

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/datapath/fake"
-	"github.com/cilium/cilium/pkg/option"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 
 	. "gopkg.in/check.v1"
 )
@@ -53,7 +53,7 @@ type testConfiguration struct{}
 func (t *testConfiguration) IPv4Enabled() bool                        { return true }
 func (t *testConfiguration) IPv6Enabled() bool                        { return true }
 func (t *testConfiguration) HealthCheckingEnabled() bool              { return true }
-func (t *testConfiguration) IPAMMode() string                         { return option.IPAMHostScopeLegacy }
+func (t *testConfiguration) IPAMMode() string                         { return ipamOption.IPAMHostScopeLegacy }
 func (t *testConfiguration) BlacklistConflictingRoutesEnabled() bool  { return false }
 func (t *testConfiguration) SetIPv4NativeRoutingCIDR(cidr *cidr.CIDR) {}
 func (t *testConfiguration) IPv4NativeRoutingCIDR() *cidr.CIDR        { return nil }

--- a/pkg/ipam/option/option.go
+++ b/pkg/ipam/option/option.go
@@ -1,0 +1,40 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package option
+
+const (
+	// IPAMHostScopeLegacy is the value to select the legacy hostscope IPAM mode
+	// This option will disappear in Cilium v1.9
+	IPAMHostScopeLegacy = "hostscope-legacy"
+
+	// IPAMKubernetes is the value to select the Kubernetes PodCIDR based
+	// hostscope IPAM mode
+	IPAMKubernetes = "kubernetes"
+
+	// IPAMCRD is the value to select the CRD-backed IPAM plugin for
+	// option.IPAM
+	IPAMCRD = "crd"
+
+	// IPAMENI is the value to select the AWS ENI IPAM plugin for option.IPAM
+	IPAMENI = "eni"
+
+	// IPAMAzure is the value to select the Azure IPAM plugin for
+	// option.IPAM
+	IPAMAzure = "azure"
+
+	// IPAMOperator is the value to select the Operator IPAM mode for
+	// option.IPAM
+	IPAMOperator = "cluster-pool"
+)

--- a/pkg/k8s/init.go
+++ b/pkg/k8s/init.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/backoff"
 	"github.com/cilium/cilium/pkg/controller"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	cilium_v2_client "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2/client"
 	k8sconfig "github.com/cilium/cilium/pkg/k8s/config"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/core/v1"
@@ -67,7 +68,7 @@ func retrieveNodeInformation(nodeName string) (*nodeTypes.Node, error) {
 	requireIPv6CIDR := option.Config.K8sRequireIPv6PodCIDR
 	var n *nodeTypes.Node
 
-	if option.Config.IPAM == option.IPAMOperator {
+	if option.Config.IPAM == ipamOption.IPAMOperator {
 		ciliumNode, err := CiliumClient().CiliumV2().CiliumNodes().Get(context.TODO(), nodeName, v1.GetOptions{})
 		if err != nil {
 			// If no CIDR is required, retrieving the node information is

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/defaults"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/k8s"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	k8sTypes "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/core/v1"
@@ -64,7 +65,7 @@ type NodeDiscovery struct {
 }
 
 func enableLocalNodeRoute() bool {
-	return option.Config.EnableLocalNodeRoute && !option.Config.IsFlannelMasterDeviceSet() && option.Config.IPAM != option.IPAMENI
+	return option.Config.EnableLocalNodeRoute && !option.Config.IsFlannelMasterDeviceSet() && option.Config.IPAM != ipamOption.IPAMENI
 }
 
 func getInt(i int) *int {
@@ -282,7 +283,7 @@ func (n *NodeDiscovery) UpdateCiliumNodeResource() {
 	}
 
 	switch option.Config.IPAM {
-	case option.IPAMOperator:
+	case ipamOption.IPAMOperator:
 		// We want to keep the podCIDRs untouched in this IPAM mode because
 		// the operator will verify if it can assign such podCIDRs.
 		// If the user was running in non-IPAM Operator mode and then switched
@@ -315,7 +316,7 @@ func (n *NodeDiscovery) UpdateCiliumNodeResource() {
 	}
 
 	switch option.Config.IPAM {
-	case option.IPAMENI:
+	case ipamOption.IPAMENI:
 		// set ENI field in the node only when the ENI ipam is specified
 		nodeResource.Spec.ENI = eniTypes.ENISpec{}
 		instanceID, instanceType, availabilityZone, vpcID, err := metadata.GetInstanceMetadata()
@@ -362,7 +363,7 @@ func (n *NodeDiscovery) UpdateCiliumNodeResource() {
 		nodeResource.Spec.ENI.InstanceType = instanceType
 		nodeResource.Spec.ENI.AvailabilityZone = availabilityZone
 
-	case option.IPAMAzure:
+	case ipamOption.IPAMAzure:
 		if providerID == "" {
 			log.WithError(err).Fatal("Spec.ProviderID in k8s node resource must be set for Azure IPAM")
 		}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1012,16 +1012,6 @@ var (
 	MonitorAggregationFlagsDefault = []string{"syn", "fin", "rst"}
 )
 
-// Available option for DaemonConfig.DatapathMode
-const (
-	// DatapathModeVeth specifies veth datapath mode (i.e. containers are
-	// attached to a network via veth pairs)
-	DatapathModeVeth = "veth"
-
-	// DatapathModeIpvlan specifies ipvlan datapath mode
-	DatapathModeIpvlan = "ipvlan"
-)
-
 // Available option for DaemonConfig.Tunnel
 const (
 	// TunnelVXLAN specifies VXLAN encapsulation

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/ip"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -635,29 +636,6 @@ const (
 
 	// IPAM is the IPAM method to use
 	IPAM = "ipam"
-
-	// IPAMHostScopeLegacy is the value to select the legacy hostscope IPAM mode
-	// This option will disappear in Cilium v1.9
-	IPAMHostScopeLegacy = "hostscope-legacy"
-
-	// IPAMKubernetes is the value to select the Kubernetes PodCIDR based
-	// hostscope IPAM mode
-	IPAMKubernetes = "kubernetes"
-
-	// IPAMCRD is the value to select the CRD-backed IPAM plugin for
-	// option.IPAM
-	IPAMCRD = "crd"
-
-	// IPAMENI is the value to select the AWS ENI IPAM plugin for option.IPAM
-	IPAMENI = "eni"
-
-	// IPAMAzure is the value to select the Azure IPAM plugin for
-	// option.IPAM
-	IPAMAzure = "azure"
-
-	// IPAMOperator is the value to select the Operator IPAM mode for
-	// option.IPAM
-	IPAMOperator = "cluster-pool"
 
 	// XDPModeNative for loading progs with XDPModeLinkDriver
 	XDPModeNative = "native"
@@ -1996,7 +1974,7 @@ func (c *DaemonConfig) Validate() error {
 		return fmt.Errorf("MTU '%d' cannot be negative", c.MTU)
 	}
 
-	if c.IPAM == IPAMENI && c.EnableIPv6 {
+	if c.IPAM == ipamOption.IPAMENI && c.EnableIPv6 {
 		return fmt.Errorf("IPv6 cannot be enabled in ENI IPAM mode")
 	}
 
@@ -2431,7 +2409,7 @@ func (c *DaemonConfig) Populate() {
 	}
 
 	switch c.IPAM {
-	case IPAMKubernetes:
+	case ipamOption.IPAMKubernetes:
 		if c.EnableIPv4 {
 			c.K8sRequireIPv4PodCIDR = true
 		}
@@ -2576,7 +2554,7 @@ func (c *DaemonConfig) checkMapSizeLimits() error {
 }
 
 func (c *DaemonConfig) checkIPv4NativeRoutingCIDR() error {
-	if c.IPv4NativeRoutingCIDR() == nil && c.Masquerade && c.Tunnel == TunnelDisabled && c.IPAMMode() != IPAMENI {
+	if c.IPv4NativeRoutingCIDR() == nil && c.Masquerade && c.Tunnel == TunnelDisabled && c.IPAMMode() != ipamOption.IPAMENI {
 		return fmt.Errorf("native routing cidr must be configured with option --%s in combination with --%s --%s=%s --%s=%s",
 			IPv4NativeRoutingCIDR, Masquerade, TunnelName, c.Tunnel, IPAM, c.IPAMMode())
 	}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1024,15 +1024,6 @@ const (
 	TunnelDisabled = "disabled"
 )
 
-// Available option for DaemonConfig.Ipvlan.OperationMode
-const (
-	// OperationModeL3S will respect iptables rules e.g. set up for masquerading
-	OperationModeL3S = "L3S"
-
-	// OperationModeL3 will bypass iptables rules on the host
-	OperationModeL3 = "L3"
-)
-
 // Envoy option names
 const (
 	// HTTP403Message specifies the response body for 403 responses, defaults to "Access denied"

--- a/pkg/option/config_test.go
+++ b/pkg/option/config_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/defaults"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/google/go-cmp/cmp"
 	flag "github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -236,8 +237,8 @@ func (s *OptionSuite) TestEnabledFunctions(c *C) {
 	c.Assert(d.BlacklistConflictingRoutesEnabled(), Equals, true)
 	d = &DaemonConfig{}
 	c.Assert(d.IPAMMode(), Equals, "")
-	d = &DaemonConfig{IPAM: IPAMENI}
-	c.Assert(d.IPAMMode(), Equals, IPAMENI)
+	d = &DaemonConfig{IPAM: ipamOption.IPAMENI}
+	c.Assert(d.IPAMMode(), Equals, ipamOption.IPAMENI)
 }
 
 func (s *OptionSuite) TestLocalAddressExclusion(c *C) {
@@ -479,7 +480,7 @@ func TestCheckIPv4NativeRoutingCIDR(t *testing.T) {
 			d: &DaemonConfig{
 				Masquerade:            true,
 				Tunnel:                TunnelDisabled,
-				IPAM:                  IPAMAzure,
+				IPAM:                  ipamOption.IPAMAzure,
 				ipv4NativeRoutingCIDR: cidr.MustParseCIDR("10.127.64.0/18"),
 			},
 			wantErr: false,
@@ -489,7 +490,7 @@ func TestCheckIPv4NativeRoutingCIDR(t *testing.T) {
 			d: &DaemonConfig{
 				Masquerade: false,
 				Tunnel:     TunnelDisabled,
-				IPAM:       IPAMAzure,
+				IPAM:       ipamOption.IPAMAzure,
 			},
 			wantErr: false,
 		},
@@ -498,7 +499,7 @@ func TestCheckIPv4NativeRoutingCIDR(t *testing.T) {
 			d: &DaemonConfig{
 				Masquerade: true,
 				Tunnel:     TunnelVXLAN,
-				IPAM:       IPAMAzure,
+				IPAM:       ipamOption.IPAMAzure,
 			},
 			wantErr: false,
 		},
@@ -507,7 +508,7 @@ func TestCheckIPv4NativeRoutingCIDR(t *testing.T) {
 			d: &DaemonConfig{
 				Masquerade: true,
 				Tunnel:     TunnelDisabled,
-				IPAM:       IPAMENI,
+				IPAM:       ipamOption.IPAMENI,
 			},
 			wantErr: false,
 		},
@@ -516,7 +517,7 @@ func TestCheckIPv4NativeRoutingCIDR(t *testing.T) {
 			d: &DaemonConfig{
 				Masquerade: true,
 				Tunnel:     TunnelDisabled,
-				IPAM:       IPAMAzure,
+				IPAM:       ipamOption.IPAMAzure,
 			},
 			wantErr: true,
 		},

--- a/pkg/option/runtime_options.go
+++ b/pkg/option/runtime_options.go
@@ -16,6 +16,8 @@ package option
 
 import (
 	"errors"
+
+	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
 )
 
 const (
@@ -114,7 +116,7 @@ var (
 				if !Config.EnableIPv6 {
 					return ErrNAT46ReqIPv6
 				}
-				if Config.DatapathMode == DatapathModeIpvlan {
+				if Config.DatapathMode == datapathOption.DatapathModeIpvlan {
 					return ErrNAT46ReqVeth
 				}
 			}

--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -290,11 +290,6 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 	}
 	logger.Debugf("Processing CNI ADD request %#v", args)
 
-	n, err = types.LoadNetConf(args.StdinData)
-	if err != nil {
-		err = fmt.Errorf("unable to parse CNI configuration \"%s\": %s", args.StdinData, err)
-		return
-	}
 	logger.Debugf("CNI NetConf: %#v", n)
 	if n.PrevResult != nil {
 		logger.Debugf("CNI Previous result: %#v", n.PrevResult)

--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
 	"github.com/cilium/cilium/pkg/defaults"
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -485,7 +486,8 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 		res.Routes = append(res.Routes, routes...)
 	}
 
-	if conf.IpamMode == option.IPAMENI || conf.IpamMode == option.IPAMAzure {
+	switch conf.IpamMode {
+	case ipamOption.IPAMENI, ipamOption.IPAMAzure:
 		err = interfaceAdd(ipConfig, ipam.IPV4, conf)
 		if err != nil {
 			err = fmt.Errorf("unable to setup interface datapath: %s", err)

--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/cilium/pkg/client"
 	"github.com/cilium/cilium/pkg/datapath/connector"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
+	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
 	"github.com/cilium/cilium/pkg/defaults"
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
@@ -34,7 +35,6 @@ import (
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/netns"
-	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/sysctl"
 	"github.com/cilium/cilium/pkg/uuid"
 	"github.com/cilium/cilium/pkg/version"
@@ -377,7 +377,7 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 	}
 
 	switch conf.DatapathMode {
-	case option.DatapathModeVeth:
+	case datapathOption.DatapathModeVeth:
 		var (
 			veth      *netlink.Veth
 			peer      *netlink.Link
@@ -406,7 +406,7 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 			err = fmt.Errorf("unable to set up veth on container side: %s", err)
 			return
 		}
-	case option.DatapathModeIpvlan:
+	case datapathOption.DatapathModeIpvlan:
 		ipvlanConf := *conf.IpvlanConfiguration
 		index := int(ipvlanConf.MasterDeviceIndex)
 

--- a/plugins/cilium-docker/driver/driver.go
+++ b/plugins/cilium-docker/driver/driver.go
@@ -29,12 +29,12 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/connector"
 	"github.com/cilium/cilium/pkg/datapath/link"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
+	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
 	endpointIDPkg "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/option"
 
 	apiTypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/events"
@@ -399,11 +399,11 @@ func (driver *driver) createEndpoint(w http.ResponseWriter, r *http.Request) {
 	}
 
 	switch driver.conf.DatapathMode {
-	case option.DatapathModeVeth:
+	case datapathOption.DatapathModeVeth:
 		var veth *netlink.Veth
 		veth, _, _, err = connector.SetupVeth(create.EndpointID, int(driver.conf.DeviceMTU), endpoint)
 		defer removeLinkOnErr(veth)
-	case option.DatapathModeIpvlan:
+	case datapathOption.DatapathModeIpvlan:
 		var ipvlan *netlink.IPVlan
 		ipvlan, _, _, err = connector.CreateIpvlanSlave(
 			create.EndpointID, int(driver.conf.DeviceMTU),
@@ -452,9 +452,9 @@ func (driver *driver) deleteEndpoint(w http.ResponseWriter, r *http.Request) {
 	log.WithField(logfields.Request, logfields.Repr(&del)).Debug("Delete endpoint request")
 
 	switch driver.conf.DatapathMode {
-	case option.DatapathModeVeth:
+	case datapathOption.DatapathModeVeth:
 		ifName = connector.Endpoint2IfName(del.EndpointID)
-	case option.DatapathModeIpvlan:
+	case datapathOption.DatapathModeIpvlan:
 		ifName = connector.Endpoint2TempIfName(del.EndpointID)
 	}
 


### PR DESCRIPTION
Move datapath mode, IPAM and ipvlan operation mode options out of `pkg/option` into their own special-purpose option packages (`pkg/datapath/option` and `pkg/ipam/option`, respectively). This allows to avoid dependencies on `pkg/option` and its transitive dependencies in several places. Namely, with a small internal API change in the last commit (2e6a52bfde474820fa3e0523c10f6a3110eca77c `datapath/linux: drop dependency on pkg/option` this reduces the binary size of `cilium-cni` and `cilium-docker` by ~1 MiB each (cf. #10056).

Please see individual commit messages for more details.

~Note: this should probably wait for #11083 being merged~ (was merged)