### PR TITLE
Validate when Cilium is in ENI mode that IPv4 is enabled

### DIFF
--- a/pkg/aws/eni/routing/routing.go
+++ b/pkg/aws/eni/routing/routing.go
@@ -42,6 +42,12 @@ var (
 // mtu: The ENI device MTU.
 // masq: Whether masquerading is enabled.
 func (info *RoutingInfo) Configure(ip net.IP, mtu int, masq bool) error {
+	if ip.To4() == nil {
+		log.WithFields(logrus.Fields{
+			"endpointIP": ip,
+		}).Warning("Unable to configure rules and routes because IP is not an IPv4 address")
+		return errors.New("IP not compatible")
+	}
 	ifindex, err := retrieveIfIndexFromMAC(info.MasterIfMAC, mtu)
 	if err != nil {
 		return fmt.Errorf("unable to find ifindex for interface MAC: %s", err)
@@ -119,6 +125,12 @@ func (info *RoutingInfo) Configure(ip net.IP, mtu int, masq bool) error {
 // with this ID, and because this table ID equals the ENI ifindex, it's stable
 // to rely on and therefore can be reused.
 func Delete(ip net.IP) error {
+	if ip.To4() == nil {
+		log.WithFields(logrus.Fields{
+			"endpointIP": ip,
+		}).Warning("Unable to delete rules because IP is not an IPv4 address")
+		return errors.New("IP not compatible")
+	}
 	ipWithMask := net.IPNet{
 		IP:   ip,
 		Mask: net.CIDRMask(32, 32),

--- a/pkg/aws/eni/routing/routing_test.go
+++ b/pkg/aws/eni/routing/routing_test.go
@@ -51,6 +51,23 @@ func (e *ENIRoutingSuite) TestConfigure(c *C) {
 	runFuncInNetNS(c, func() { runConfigureThenDelete(c, ri, ip, 1500, true) }, masterMAC)
 }
 
+func (e *ENIRoutingSuite) TestConfigureRoutewithIncompatibleIP(c *C) {
+	_, ri := getFakes(c)
+	ipv6 := net.ParseIP("fd00::2").To16()
+	c.Assert(ipv6, NotNil)
+	err := ri.Configure(ipv6, 1500, true)
+	c.Assert(err, NotNil)
+	c.Assert(err, ErrorMatches, "IP not compatible")
+}
+
+func (e *ENIRoutingSuite) TestDeleteRoutewithIncompatibleIP(c *C) {
+	ipv6 := net.ParseIP("fd00::2").To16()
+	c.Assert(ipv6, NotNil)
+	err := Delete(ipv6)
+	c.Assert(err, NotNil)
+	c.Assert(err, ErrorMatches, "IP not compatible")
+}
+
 func (e *ENIRoutingSuite) TestDelete(c *C) {
 	fakeIP, fakeRoutingInfo := getFakes(c)
 	masterMAC := fakeRoutingInfo.MasterIfMAC


### PR DESCRIPTION
The patch checks the Cilium ENI mode and IPv4 when ENI functions
are called.

Fixes: #11272
Signed-off-by: Swaminathan Vasudevan <svasudevan@suse.com>
