### PR TITLE
hubble: Use a single string to configure the server address

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -99,7 +99,7 @@ cilium-agent [flags]
       --http-retry-timeout uint                       Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
       --hubble-event-queue-size int                   Buffer size of the channel to receive monitor events.
       --hubble-flow-buffer-size int                   Maximum number of flows in Hubble's buffer. The actual buffer size gets rounded up to the next power of 2, e.g. 4095 => 4096 (default 4095)
-      --hubble-listen-addresses strings               List of additional addresses for Hubble server to listen to
+      --hubble-listen-address string                  An additional address for Hubble server to listen to, e.g. ":4244"
       --hubble-metrics strings                        List of Hubble metrics to enable.
       --hubble-metrics-server string                  Address to serve Hubble metrics on.
       --hubble-socket-path string                     Set hubble's socket path to listen for connections (default "/var/run/cilium/hubble.sock")

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -752,8 +752,8 @@ func init() {
 	flags.String(option.HubbleSocketPath, defaults.HubbleSockPath, "Set hubble's socket path to listen for connections")
 	option.BindEnv(option.HubbleSocketPath)
 
-	flags.StringSlice(option.HubbleListenAddresses, []string{}, "List of additional addresses for Hubble server to listen to")
-	option.BindEnv(option.HubbleListenAddresses)
+	flags.String(option.HubbleListenAddress, "", `An additional address for Hubble server to listen to, e.g. ":4244"`)
+	option.BindEnv(option.HubbleListenAddress)
 
 	flags.Int(option.HubbleFlowBufferSize, 4095, "Maximum number of flows in Hubble's buffer. The actual buffer size gets rounded up to the next power of 2, e.g. 4095 => 4096")
 	option.BindEnv(option.HubbleFlowBufferSize)

--- a/daemon/cmd/hubble.go
+++ b/daemon/cmd/hubble.go
@@ -84,13 +84,6 @@ func (d *Daemon) launchHubble() {
 		logger.Info("Hubble server is disabled")
 		return
 	}
-	addresses := option.Config.HubbleListenAddresses
-	for _, address := range addresses {
-		// TODO: remove warning once mutual TLS has been implemented
-		if !strings.HasPrefix(address, "unix://") {
-			logger.WithField("address", address).Warn("Hubble server will be exposing its API insecurely on this address")
-		}
-	}
 
 	payloadParser, err := parser.New(d, d, d, ipcache.IPIdentityCache, d)
 	if err != nil {
@@ -131,9 +124,14 @@ func (d *Daemon) launchHubble() {
 	}()
 
 	// configure another hubble instance that serve fewer gRPC services
-	if len(addresses) > 0 {
+	address := option.Config.HubbleListenAddress
+	if address != "" {
+		// TODO: remove warning once mutual TLS has been implemented
+		if !strings.HasPrefix(address, "unix://") {
+			logger.WithField("address", address).Warn("Hubble server will be exposing its API insecurely on this address")
+		}
 		srv, err := server.NewServer(logger,
-			serveroption.WithListeners(addresses),
+			serveroption.WithListeners([]string{address}),
 			serveroption.WithHealthService(),
 			serveroption.WithObserverService(d.hubbleObserver),
 		)
@@ -141,7 +139,7 @@ func (d *Daemon) launchHubble() {
 			logger.WithError(err).Error("Failed to initialize Hubble server")
 			return
 		}
-		logger.WithField("addresses", addresses).Info("Starting Hubble server")
+		logger.WithField("address", address).Info("Starting Hubble server")
 		if err := srv.Serve(); err != nil {
 			logger.WithError(err).Error("Failed to start Hubble server")
 			return

--- a/daemon/cmd/hubble.go
+++ b/daemon/cmd/hubble.go
@@ -16,7 +16,6 @@ package cmd
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -127,11 +126,9 @@ func (d *Daemon) launchHubble() {
 	address := option.Config.HubbleListenAddress
 	if address != "" {
 		// TODO: remove warning once mutual TLS has been implemented
-		if !strings.HasPrefix(address, "unix://") {
-			logger.WithField("address", address).Warn("Hubble server will be exposing its API insecurely on this address")
-		}
+		logger.WithField("address", address).Warn("Hubble server will be exposing its API insecurely on this address")
 		srv, err := server.NewServer(logger,
-			serveroption.WithListeners([]string{address}),
+			serveroption.WithTCPListener(address),
 			serveroption.WithHealthService(),
 			serveroption.WithObserverService(d.hubbleObserver),
 		)

--- a/install/kubernetes/cilium/charts/agent/templates/svc.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/svc.yaml
@@ -17,25 +17,6 @@ spec:
   selector:
     k8s-app: cilium
 {{- end }}
-{{- if .Values.global.hubble.ui.enabled }}
----
-kind: Service
-apiVersion: v1
-metadata:
-  name: hubble-grpc
-  namespace: {{ .Release.Namespace }}
-  labels:
-    k8s-app: hubble 
-spec:
-  type: ClusterIP
-  clusterIP: None
-  selector:
-    k8s-app: cilium
-  ports:
-  - targetPort: 50051
-    protocol: TCP
-    port: 50051
-{{- end }}
 {{- if and .Values.global.hubble.metrics.enabled (.Values.global.hubble.metrics.serviceMonitor.enabled) }}
 ---
 kind: Service

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -435,12 +435,8 @@ data:
     {{.}}
   {{- end }}
 {{- end }}
-  # A space separated list of additional addresses for Hubble server to listen to (e.g. ":50051 :50052").
-{{- if and .Values.global.hubble.ui.enabled (not (has "0.0.0.0:50051" .Values.global.hubble.listenAddresses)) }}
-  hubble-listen-addresses: {{ append .Values.global.hubble.listenAddresses "0.0.0.0:50051" | join " " | quote }}
-{{- else }}
-  hubble-listen-addresses: {{ .Values.global.hubble.listenAddresses | join " " | quote }}
-{{- end }}
+  # An additional address for Hubble server to listen to (e.g. ":4244").
+  hubble-listen-address: {{ .Values.global.hubble.listenAddress | quote }}
 {{- end }}
 
   # A space separated list of iptables chains to disable when installing feeder rules.

--- a/install/kubernetes/cilium/charts/hubble-ui/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/hubble-ui/templates/deployment.yaml
@@ -26,9 +26,9 @@ spec:
             - name: HUBBLE
               value: "true"
             - name: HUBBLE_SERVICE
-              value: "hubble-grpc.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+              value: "hubble-relay.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
             - name: HUBBLE_PORT
-              value: "50051"
+              value: "80"
           ports:
             - containerPort: 12000
               name: http

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -432,16 +432,13 @@ global:
       enabled: false 
     # Default unix domain socket path to listen to when Hubble is enabled. Default to "/var/run/cilium/hubble.sock".
     socketPath: /var/run/cilium/hubble.sock
-    # List of additional addresses to listen to, for example:
+    # An additional address to listen to, for example:
     #
-    #   listenAddresses:
-    #   - ":50051"
-    #   - ":50052"
+    #   listenAddress: ":4244"
     #
-    # You can specify the list of metrics from the helm CLI:
-    #
-    #   --set global.hubble.listenAddresses={:50051,:50052}
-    listenAddresses: []
+    # Set this field ":4244" if you are enabling hubble-relay, as it assumes that Hubble is listening
+    # on port 4244.
+    listenAddress: ""
     # Buffer size of the channel Hubble uses to receive monitor events. If this value is not set,
     # the queue size is set to the default monitor queue size.
     eventQueueSize: ~

--- a/pkg/hubble/server/server.go
+++ b/pkg/hubble/server/server.go
@@ -70,7 +70,6 @@ func (s *Server) Serve() error {
 	s.initGRPCServer()
 	for name, listener := range s.opts.Listeners {
 		go func(name string, listener net.Listener) {
-			s.log.WithField("listener", name).Info("Starting gRPC server on listener")
 			if err := s.srv.Serve(listener); err != nil {
 				s.log.WithError(err).Error("failed to close grpc server")
 			}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -725,8 +725,8 @@ const (
 	// HubbleSocketPath specifies the UNIX domain socket for Hubble server to listen to.
 	HubbleSocketPath = "hubble-socket-path"
 
-	// HubbleListenAddresses specifies addresses for Hubble server to listen to.
-	HubbleListenAddresses = "hubble-listen-addresses"
+	// HubbleListenAddress specifies address for Hubble server to listen to.
+	HubbleListenAddress = "hubble-listen-address"
 
 	// HubbleFlowBufferSize specifies the maximum number of flows in Hubble's buffer.
 	HubbleFlowBufferSize = "hubble-flow-buffer-size"
@@ -968,7 +968,7 @@ var HelpFlagSections = []FlagsSection{
 		Flags: []string{
 			EnableHubble,
 			HubbleSocketPath,
-			HubbleListenAddresses,
+			HubbleListenAddress,
 			HubbleFlowBufferSize,
 			HubbleEventQueueSize,
 			HubbleMetricsServer,
@@ -1733,8 +1733,8 @@ type DaemonConfig struct {
 	// HubbleSocketPath specifies the UNIX domain socket for Hubble server to listen to.
 	HubbleSocketPath string
 
-	// HubbleListenAddresses specifies addresses for Hubble to listen to.
-	HubbleListenAddresses []string
+	// HubbleListenAddress specifies address for Hubble to listen to.
+	HubbleListenAddress string
 
 	// HubbleFlowBufferSize specifies the maximum number of flows in Hubble's buffer.
 	HubbleFlowBufferSize int
@@ -2422,7 +2422,7 @@ func (c *DaemonConfig) Populate() {
 	// Hubble options.
 	c.EnableHubble = viper.GetBool(EnableHubble)
 	c.HubbleSocketPath = viper.GetString(HubbleSocketPath)
-	c.HubbleListenAddresses = viper.GetStringSlice(HubbleListenAddresses)
+	c.HubbleListenAddress = viper.GetString(HubbleListenAddress)
 	c.HubbleFlowBufferSize = viper.GetInt(HubbleFlowBufferSize)
 	c.HubbleEventQueueSize = viper.GetInt(HubbleEventQueueSize)
 	if c.HubbleEventQueueSize == 0 {


### PR DESCRIPTION
- Rename the option to `--hubble-listen-address` to make it clear that
  Hubble listens to at most one additional address.
- Remove an info message that doesn't provide any addtional info:
    ```
      level=info msg="Starting local Hubble server" address="unix:///var/run/cilium/hubble.sock" subsys=hubble
      level=info msg="Starting Hubble server" address=":4244" subsys=hubble
    - level=info msg="Starting gRPC server on listener" listener="unix:///var/run/cilium/hubble.sock" subsys=hubble
    - level=info msg="Starting gRPC server on listener" listener=":4244" subsys=hubble
    ```
- Use port 4244 in the documentation since this is the port that Hubble
  relay expects.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>