### PR TITLE
Fix fromCIDR policy on kernels 4.10 or older and extend test coverage

### DIFF
--- a/bpf/bpf_netdev.c
+++ b/bpf/bpf_netdev.c
@@ -34,6 +34,7 @@
 #include "lib/nat.h"
 #include "lib/lb.h"
 #include "lib/nodeport.h"
+#include "lib/eps.h"
 
 #if defined(FROM_HOST) && (defined(ENABLE_IPV4) || defined(ENABLE_IPV6))
 static __always_inline int rewrite_dmac_to_host(struct __ctx_buff *ctx,
@@ -94,7 +95,7 @@ resolve_srcid_ipv6(struct __ctx_buff *ctx, struct ipv6hdr *ip6,
 	/* Packets from the proxy will already have a real identity. */
 	if (identity_is_reserved(srcid_from_ipcache)) {
 		src = (union v6addr *) &ip6->saddr;
-		info = ipcache_lookup6(&IPCACHE_MAP, src, V6_CACHE_KEY_LEN);
+		info = lookup_ip6_remote_endpoint(src);
 		if (info != NULL && info->sec_label)
 			srcid_from_ipcache = info->sec_label;
 		cilium_dbg(ctx, info ? DBG_IP_ID_MAP_SUCCEED6 : DBG_IP_ID_MAP_FAILED6,
@@ -270,7 +271,7 @@ resolve_srcid_ipv4(struct __ctx_buff *ctx, const struct iphdr *ip4,
 
 	/* Packets from the proxy will already have a real identity. */
 	if (identity_is_reserved(srcid_from_ipcache)) {
-		info = ipcache_lookup4(&IPCACHE_MAP, ip4->saddr, V4_CACHE_KEY_LEN);
+		info = lookup_ip4_remote_endpoint(ip4->saddr);
 		if (info != NULL) {
 			__u32 sec_label = info->sec_label;
 			if (sec_label) {

--- a/bpf/lxc_config.h
+++ b/bpf/lxc_config.h
@@ -41,16 +41,3 @@ DEFINE_U32(POLICY_VERDICT_LOG_FILTER, 0xffff);
 #define CONNTRACK
 #define CONNTRACK_ACCOUNTING
 
-/* It appears that we can support around the below number of prefixes in an
- * unrolled loop for LPM CIDR handling in older kernels along with the rest of
- * the logic in the datapath, hence the defines below. This number was arrived
- * to by adjusting the number of prefixes and running:
- *
- *    $ make -C bpf && sudo test/bpf/verifier-test.sh
- *
- *  If you're from a future where all supported kernels include LPM map type,
- *  consider deprecating the hash-based CIDR lookup and removing the below.
- */
-#define IPCACHE4_PREFIXES 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, \
-4, 3, 2, 1
-#define IPCACHE6_PREFIXES 4, 3, 2, 1

--- a/bpf/node_config.h
+++ b/bpf/node_config.h
@@ -126,3 +126,17 @@ DEFINE_IPV6(HOST_IP, 0xbe, 0xef, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0xa, 0x
 DEFINE_IPV6(IPV6_NODEPORT, 0xbe, 0xef, 0, 0, 0, 0, 0, 0x1, 0, 0, 0, 0x1, 0x01, 0x65, 0x82, 0xbc);
 #endif
 #endif
+
+/* It appears that we can support around the below number of prefixes in an
+ * unrolled loop for LPM CIDR handling in older kernels along with the rest of
+ * the logic in the datapath, hence the defines below. This number was arrived
+ * to by adjusting the number of prefixes and running:
+ *
+ *    $ make -C bpf && sudo test/bpf/verifier-test.sh
+ *
+ *  If you're from a future where all supported kernels include LPM map type,
+ *  consider deprecating the hash-based CIDR lookup and removing the below.
+ */
+#define IPCACHE4_PREFIXES 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, \
+4, 3, 2, 1
+#define IPCACHE6_PREFIXES 4, 3, 2, 1

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2019 Authors of Cilium
+// Copyright 2017-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -98,16 +98,22 @@ const (
 	// HostDockerNetwork is the name of the host network driver.
 	HostDockerNetwork = "host"
 
+	// WorldDockerNetwork is the name of the docker network that is *not*
+	// managed by Cilium, intended to be treated as "world" for identity
+	// purposes (for policy tests).
+	WorldDockerNetwork = "world"
+
 	// Names of commonly used containers in tests.
-	Httpd1 = "httpd1"
-	Httpd2 = "httpd2"
-	Httpd3 = "httpd3"
-	App1   = "app1"
-	App2   = "app2"
-	App3   = "app3"
-	Client = "client"
-	Server = "server"
-	Host   = "host"
+	Httpd1      = "httpd1"
+	Httpd2      = "httpd2"
+	Httpd3      = "httpd3"
+	App1        = "app1"
+	App2        = "app2"
+	App3        = "app3"
+	Client      = "client"
+	Server      = "server"
+	Host        = "host"
+	WorldHttpd1 = "WorldHttpd1"
 	// Container lifecycle actions.
 	Create = "create"
 	Delete = "delete"


### PR DESCRIPTION
Builds on the draft PR originally opened by @joestringer #10580

That PR body:

This series extends the runtime CI tests to validate that fromCIDR policy works correctly using a local docker network, similar to how existing FQDN tests do.

Review patch-by-patch, there is some large refactoring of the CIDR tests in policy but it's mostly kept to one non-functional patch.
On top of that, see the final commit I added. The tests were failing in CI (and for me locally) because for kernel versions without LPM maps, ipcache_lookup4 is unable to lookup CIDRs based on a prefix other than a /32. Changing from ipcache_lookup4 to lookup_ip4_remote_endpoint fixes this because the latter function uses unrolled hash map lookups to simulate a LPM map lookups for kernels that don't support LPM maps. See bpf/lib/eps.h for further details on that.

It may be desirable to replace usage of ipcache_lookup[46] everywhere with lookup_ip[46]_remote_endpoint but that is beyond the scope of this PR.