### PR TITLE
hubble-relay: persist connections to hubble peers

### DIFF
--- a/pkg/hubble/relay/server.go
+++ b/pkg/hubble/relay/server.go
@@ -32,12 +32,18 @@ import (
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 
+type hubblePeer struct {
+	peer.Peer
+	conn    *grpc.ClientConn
+	connErr error
+}
+
 // Server is a proxy that connects to a running instance of hubble gRPC server
 // via unix domain socket.
 type Server struct {
 	server *grpc.Server
 	log    logrus.FieldLogger
-	peers  map[string]peer.Peer
+	peers  map[string]*hubblePeer
 	opts   relayoption.Options
 	mu     lock.Mutex
 	stop   chan struct{}
@@ -55,7 +61,7 @@ func NewServer(options ...relayoption.Option) (*Server, error) {
 	logging.ConfigureLogLevel(opts.Debug)
 	return &Server{
 		log:   logger,
-		peers: make(map[string]peer.Peer),
+		peers: make(map[string]*hubblePeer),
 		stop:  make(chan struct{}),
 		opts:  opts,
 	}, nil


### PR DESCRIPTION
    This commits updates hubble-relay so that instead of opening/closing a
    connection to every hubble peer for every gRPC request, connections are
    instead persisted.

    I see two main approaches to this:

    1. The optimistic approach (the one this commit implements):
       A new connection is established when a peer is added or updated. When
       the connection cannot be established, a new attempt is made at the
       next client request, without blocking the client request itself.
    2. The pessimistic approach:
       A new connection is established when a peer is added or updated. For
       each peer, a goroutine ensures that the connection is healthy by
       issuing a periodic heartbeat and attempts to (re)connect if need be.

    With the optimistic approach, a client request might end up with
    incomplete data. However, there isn't much overhead with this approach.
    The pessimistic approach limits the problem of incomplete data (without
    suppressing it). On the other hand, it generates heartbeat traffic,
    which will be non-negligible on a 5000 nodes cluster. It also forces to
    use goroutines to track the connection status with every peer. It would
    also induce more code complexity (one has to take down the corresponding
    connection monitoring goroutine when a node is deleted for instance).
    Given the above, I chose option 1.

Fixes #11229.

Note: I hope someone comes up with option 3 that would be best of both worlds :)