### PR TITLE
test: Support singleton manifests

### DIFF
--- a/test/k8sT/manifests.go
+++ b/test/k8sT/manifests.go
@@ -22,9 +22,11 @@ var (
 	deploymentManager = helpers.NewDeploymentManager()
 
 	DemoDaemonSet = helpers.Manifest{
-		Filename:     "demo_ds.yaml",
-		NumDaemonSet: 2,
-		NumPods:      1,
+		Filename:        "demo_ds.yaml",
+		DaemonSetNames:  []string{"testds", "testclient"},
+		DeploymentNames: []string{"test-k8s2"},
+		NumPods:         1,
+		Singleton:       true,
 	}
 
 	NetperfPods = helpers.Manifest{


### PR DESCRIPTION
Some manifests contain hostports or other definitions which are only
available once on a particular node. Combined with a node selector,
these can create scheduling conflicts and result in deployments
remaining in pending state.

Support marking such manifests as singleton and delete any conflicting
leftover deployment in any other namespace.

Fixes: #11311