### PR TITLE
Re-enable failing test for CI-testing

### DIFF
--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -1022,7 +1022,6 @@ var _ = Describe("K8sServicesTest", func() {
 		SkipContextIf(
 			func() bool {
 				return helpers.IsIntegration(helpers.CIIntegrationEKS) ||
-					helpers.IsIntegration(helpers.CIIntegrationGKE) || // Re-enable when GH-11235 is fixed
 					helpers.RunsWithoutKubeProxy()
 			},
 			"with L7 policy", func() {

--- a/test/k8sT/manifests/demo_ds.yaml
+++ b/test/k8sT/manifests/demo_ds.yaml
@@ -19,9 +19,13 @@ spec:
         ports:
         - containerPort: 80
         readinessProbe:
-          httpGet:
-            path: /
-            port: 80
+          exec:
+            command:
+            - curl
+            - -sS
+            - -o
+            - /dev/null
+            - http://localhost:80/
       - name: udp
         image: docker.io/cilium/echoserver-udp:v2020.01.30
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Revert "test/gke: Disable K8sServicesTest Checks service across nodes with L7 policy Tests NodePort with L7 Policy"

This reverts commit 9f325461c403c00c35151e01e04f7f102368e2c8.
