### PR TITLE
envoy: Reduce logging verbosity.

### DIFF
--- a/pkg/envoy/envoy.go
+++ b/pkg/envoy/envoy.go
@@ -173,7 +173,7 @@ func StartEnvoy(stateDir, logPath string, baseID uint64) *Envoy {
 	nodeId := "host~127.0.0.1~no-id~localdomain"
 
 	// Create static configuration
-	createBootstrap(bootstrapPath, nodeId, ingressClusterName, "version1",
+	createBootstrap(bootstrapPath, nodeId, ingressClusterName,
 		xdsPath, egressClusterName, ingressClusterName, adminPath)
 
 	log.Debugf("Envoy: Starting: %v", *e)

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -617,11 +617,11 @@ func getHTTPRule(certManager policy.CertificateManager, h *api.PortRuleHTTP, ns 
 	return &cilium.HttpNetworkPolicyRule{Headers: headers, HeaderMatches: headerMatches}, len(headerMatches) == 0
 }
 
-func createBootstrap(filePath string, name, cluster, version string, xdsSock, egressClusterName, ingressClusterName string, adminPath string) {
+func createBootstrap(filePath string, nodeId, cluster string, xdsSock, egressClusterName, ingressClusterName string, adminPath string) {
 	connectTimeout := int64(option.Config.ProxyConnectTimeout) // in seconds
 
 	bs := &envoy_config_bootstrap_v2.Bootstrap{
-		Node: &envoy_api_v2_core.Node{Id: name, Cluster: cluster, Metadata: nil, Locality: nil, BuildVersion: version},
+		Node: &envoy_api_v2_core.Node{Id: nodeId, Cluster: cluster},
 		StaticResources: &envoy_config_bootstrap_v2.Bootstrap_StaticResources{
 			Clusters: []*envoy_api_v2.Cluster{
 				{

--- a/pkg/envoy/xds/server.go
+++ b/pkg/envoy/xds/server.go
@@ -126,7 +126,7 @@ func NewServer(resourceTypes map[string]*ResourceTypeConfiguration,
 func getXDSRequestFields(req *envoy_api_v2.DiscoveryRequest) logrus.Fields {
 	return logrus.Fields{
 		logfields.XDSAckedVersion: req.GetVersionInfo(),
-		logfields.XDSClientNode:   req.GetNode(),
+		logfields.XDSClientNode:   req.GetNode().GetId(),
 		logfields.XDSTypeURL:      req.GetTypeUrl(),
 		logfields.XDSNonce:        req.GetResponseNonce(),
 	}


### PR DESCRIPTION
Reduce logging verbosity by not printing the whole 'Node' in the log messages.

Do not initialize deprecated build version field in the 'Node' in
bootstrap.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
