### PR TITLE
CI: fix kubectl.CiliumPolicyAction() by casting "cilium policy wait" duration to integer

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2298,8 +2298,8 @@ func (kub *Kubectl) CiliumPolicyAction(namespace, filepath string, action Resour
 				ctx, cancel := context.WithTimeout(context.Background(), ShortCommandTimeout)
 				defer cancel()
 				desiredRevision := revisions[ciliumPod] + 1
-				res := kub.CiliumExecContext(ctx, ciliumPod, fmt.Sprintf("cilium policy wait %d --max-wait-time %f", desiredRevision, ShortCommandTimeout.Seconds()))
-				if !(res.GetExitCode() != 0) {
+				res := kub.CiliumExecContext(ctx, ciliumPod, fmt.Sprintf("cilium policy wait %d --max-wait-time %d", desiredRevision, int(ShortCommandTimeout.Seconds())))
+				if res.GetExitCode() != 0 {
 					kub.Logger().Infof("Failed to wait for policy revision %d on pod %s", desiredRevision, ciliumPod)
 					return false
 				}


### PR DESCRIPTION
In the e2e framework, helper `kubectl.CiliumPolicyAction()` runs a call to the CLI command:

    cilium policy wait <desiredRevision> <duration>

For the `duration`, `ShortCommandTimeout.Seconds()` is used. But this resolves to the string representation of a float (`"10.000000"`) that fails to be interpreted by the CLI parser!

Let's cast the float to an integer instead, to make sure that `kubectl.CiliumPolicyAction()` correctly waits until the desired policy has been deployed. We also need to reverse the condition on the check for the `cilium policy wait` success: The wait failed if the return code is non-zero.

This should (hopefully) fix the flake reported in #11325.