### PR TITLE
Add timeout to docker prune after building images

### DIFF
--- a/test/make-images-push-to-local-registry.sh
+++ b/test/make-images-push-to-local-registry.sh
@@ -14,4 +14,9 @@ docker push $1/cilium/cilium-dev:$2
 docker push $1/cilium/operator:$2
 
 cilium_git_version="$(cat GIT_VERSION)"
-docker image prune -f --all --filter "label=cilium-sha=${cilium_git_version%% *}"
+
+counter=0
+until [ $counter -eq 10 ] || docker image prune -f --all --filter "label=cilium-sha=${cilium_git_version%% *}"; do
+	((counter++))
+	sleep 6
+done


### PR DESCRIPTION
If other build is pruning while current builds starts the prune, prune
will fail and cause the build to fail. This change adds 10 retries in 6
seconds intervals which should be enough to prune correctly