### PR TITLE
CODEOWNERS: ignore auto-generated documentation

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -58,6 +58,7 @@ Dockerfile* @cilium/build
 /daemon/cmd/state.go @cilium/endpoint
 /daemon/cmd/sysctl_linux.go @cilium/bpf
 /Documentation/ @cilium/docs
+/Documentation/cmdref @cilium/nonexistantteam
 /Documentation/bpf.rst @cilium/bpf
 /Documentation/contributing/ @cilium/contributing
 /Documentation/envoy/ @cilium/proxy


### PR DESCRIPTION
Signed-off-by: André Martins <andre@cilium.io>