### PR TITLE
[Helm] Add blacklistConflictingRoutes parameter to config chart

### DIFF
--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -151,6 +151,9 @@ data:
   # Only effective when monitor aggregation is set to "medium" or higher.
   monitor-aggregation-flags: {{ .Values.global.bpf.monitorFlags }}
 
+  # Configure blacklisting of local routes not owned by Cilium.
+  blacklist-conflicting-routes: "{{ .Values.global.blacklistConflictingRoutes }}"
+
 {{- if or .Values.global.bpf.ctTcpMax .Values.global.bpf.ctAnyMax }}
   # bpf-ct-global-*-max specifies the maximum number of connections
   # supported across all endpoints, split by protocol: tcp or other. One pair

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -146,6 +146,10 @@ global:
     enabled: false
     port: 6942
 
+  # blacklistConflictingRoutes instructs the cilium-agent whether to blacklist
+  # IP allocations conflicting with local non-cilium routes.
+  blacklistConflictingRoutes: true
+
   # enableXTSocketFallback enables the fallback compatibility solution
   # when the xt_socket kernel module is missing and it is needed for
   # the datapath L7 redirection to work properly.  See documentation

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -79,6 +79,9 @@ data:
   #
   # Only effective when monitor aggregation is set to "medium" or higher.
   monitor-aggregation-flags: all
+
+  # Configure blacklisting of local routes not owned by Cilium.
+  blacklist-conflicting-routes: "true"
   # bpf-policy-map-max specified the maximum number of entries in endpoint
   # policy map (per endpoint)
   bpf-policy-map-max: "16384"

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -72,6 +72,9 @@ data:
   #
   # Only effective when monitor aggregation is set to "medium" or higher.
   monitor-aggregation-flags: all
+
+  # Configure blacklisting of local routes not owned by Cilium.
+  blacklist-conflicting-routes: "true"
   # bpf-policy-map-max specified the maximum number of entries in endpoint
   # policy map (per endpoint)
   bpf-policy-map-max: "16384"


### PR DESCRIPTION
Add blacklist-conflicting-routes to cilium configmap.

Signed-off-by: David Donchez <donch@dailymotion.com>