### PR TITLE
bpf: only update nodeport neigh entry if stale or non-existant

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -451,9 +451,9 @@ static __always_inline int nodeport_lb6(struct __ctx_buff *ctx,
 	struct lb6_key key = {};
 	struct ct_state ct_state_new = {};
 	struct ct_state ct_state = {};
+	union macaddr smac, *mac;
 	bool backend_local;
 	__u32 monitor = 0;
-	union macaddr smac;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
@@ -557,9 +557,12 @@ redo_local:
 		return DROP_INVALID;
 	if (eth_load_saddr(ctx, smac.addr, 0) < 0)
 		return DROP_INVALID;
-	ret = map_update_elem(&NODEPORT_NEIGH6, &ip6->saddr, &smac, 0);
-	if (ret < 0) {
-		return ret;
+
+	mac = map_lookup_elem(&NODEPORT_NEIGH6, &ip6->saddr);
+	if (!mac || eth_addrcmp(mac, &smac)) {
+		ret = map_update_elem(&NODEPORT_NEIGH6, &ip6->saddr, &smac, 0);
+		if (ret < 0)
+			return ret;
 	}
 
 	if (!backend_local) {
@@ -1062,9 +1065,9 @@ static __always_inline int nodeport_lb4(struct __ctx_buff *ctx,
 	struct lb4_key key = {};
 	struct ct_state ct_state_new = {};
 	struct ct_state ct_state = {};
+	union macaddr smac, *mac;
 	bool backend_local;
 	__u32 monitor = 0;
-	union macaddr smac;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
@@ -1168,9 +1171,12 @@ redo_local:
 		return DROP_INVALID;
 	if (eth_load_saddr(ctx, smac.addr, 0) < 0)
 		return DROP_INVALID;
-	ret = map_update_elem(&NODEPORT_NEIGH4, &ip4->saddr, &smac, 0);
-	if (ret < 0) {
-		return ret;
+
+	mac = map_lookup_elem(&NODEPORT_NEIGH4, &ip4->saddr);
+	if (!mac || eth_addrcmp(mac, &smac)) {
+		ret = map_update_elem(&NODEPORT_NEIGH4, &ip4->saddr, &smac, 0);
+		if (ret < 0)
+			return ret;
 	}
 
 	if (!backend_local) {


### PR DESCRIPTION
This neigh map update is basically in the hot-path of our service handling,
so calling map update every single time is trashing performance badly in
that we might hit the same bucket spinlock in htab_lru_map_update_elem()
on different CPUs. Only really add it to the map if it's non-present or
if the smac changes for a given IP address. In my NodePort testing this
gave a +2Mpps performance improvement under stress.

Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>