### PR TITLE
hubble-relay: Add gops agent

### DIFF
--- a/hubble-relay.Dockerfile
+++ b/hubble-relay.Dockerfile
@@ -12,7 +12,7 @@ RUN go get -d github.com/google/gops && \
     git checkout -b v0.3.6 v0.3.6 && \
     git --no-pager remote -v && \
     git --no-pager log -1 && \
-    go install && \
+    CGO_ENABLED=0 go install && \
     strip /go/bin/gops
 
 FROM scratch

--- a/hubble-relay/cmd/serve/serve.go
+++ b/hubble-relay/cmd/serve/serve.go
@@ -22,13 +22,15 @@ import (
 
 	"github.com/cilium/cilium/pkg/hubble/relay"
 	"github.com/cilium/cilium/pkg/hubble/relay/relayoption"
-	"golang.org/x/sys/unix"
 
+	"github.com/google/gops/agent"
 	"github.com/spf13/cobra"
+	"golang.org/x/sys/unix"
 )
 
 type flags struct {
 	debug         bool
+	gops          bool
 	dialTimeout   time.Duration
 	listenAddress string
 	peerService   string
@@ -48,6 +50,9 @@ func New() *cobra.Command {
 	}
 	cmd.Flags().BoolVarP(
 		&f.debug, "debug", "D", false, "Run in debug mode",
+	)
+	cmd.Flags().BoolVar(
+		&f.gops, "gops", true, "Run gops agent",
 	)
 	cmd.Flags().DurationVar(
 		&f.dialTimeout, "dial-timeout",
@@ -77,6 +82,11 @@ func runServe(f flags) error {
 	}
 	if f.debug {
 		opts = append(opts, relayoption.WithDebug())
+	}
+	if f.gops {
+		if err := agent.Listen(agent.Options{}); err != nil {
+			return fmt.Errorf("failed to start gops agent: %v", err)
+		}
 	}
 	srv, err := relay.NewServer(opts...)
 	if err != nil {


### PR DESCRIPTION
It is enabled by default so that cilium-sysdump will be able to dump stack traces. The Dockerfile is updated to statically link the gops binary so it is runnable in the `scratch` image.

Manually verified with cilium/cilium-sysdump#86 on minikube.