### PR TITLE
operator: remove pod list of an entire cluster

### DIFF
--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -19,7 +19,7 @@ cilium-operator [flags]
       --aws-release-excess-ips                  Enable releasing excess free IP addresses from AWS ENI.
       --azure-resource-group string             Resource group to use for Azure IPAM
       --azure-subscription-id string            Subscription ID to access Azure API
-      --cilium-endpoint-gc-interval duration    GC interval for cilium endpoints (default 10m0s)
+      --cilium-endpoint-gc-interval duration    GC interval for cilium endpoints (default 5m0s)
       --cluster-id int                          Unique identifier of the cluster
       --cluster-name string                     Name of the cluster (default "default")
       --cnp-node-status-gc-interval duration    GC interval for nodes which have been removed from the cluster in CiliumNetworkPolicy Status (default 2m0s)
@@ -34,7 +34,7 @@ cilium-operator [flags]
   -h, --help                                    help for cilium-operator
       --identity-allocation-mode string         Method to use for identity allocation (default "kvstore")
       --identity-gc-interval duration           GC interval for security identities (default 15m0s)
-      --identity-heartbeat-timeout duration     Timeout after which identity expires on lack of heartbeat (default 31m0s)
+      --identity-heartbeat-timeout duration     Timeout after which identity expires on lack of heartbeat (default 30m0s)
       --ipam string                             Backend to use for IPAM (default "hostscope-legacy")
       --k8s-api-server string                   Kubernetes API server URL
       --k8s-client-burst int                    Burst value allowed for the K8s client

--- a/operator/flags.go
+++ b/operator/flags.go
@@ -131,7 +131,7 @@ func init() {
 	option.BindEnv(operatorOption.EnableCEPGC)
 	flags.MarkDeprecated(operatorOption.EnableCEPGC, fmt.Sprintf("Please use %s=0 to disable CEP GC", operatorOption.EndpointGCInterval))
 
-	flags.Duration(operatorOption.EndpointGCInterval, 10*time.Minute, "GC interval for cilium endpoints")
+	flags.Duration(operatorOption.EndpointGCInterval, operatorOption.EndpointGCIntervalDefault, "GC interval for cilium endpoints")
 	option.BindEnv(operatorOption.EndpointGCInterval)
 
 	flags.Bool(operatorOption.EnableMetrics, false, "Enable Prometheus metrics")
@@ -140,8 +140,7 @@ func init() {
 	flags.String(option.IPAM, option.IPAMHostScopeLegacy, "Backend to use for IPAM")
 	option.BindEnv(option.IPAM)
 
-	// 31 minutes is the default to be slightly larger than 3x EndpointGCInterval
-	flags.Duration(operatorOption.IdentityHeartbeatTimeout, 31*time.Minute, "Timeout after which identity expires on lack of heartbeat")
+	flags.Duration(operatorOption.IdentityHeartbeatTimeout, 2*defaults.KVstoreLeaseTTL, "Timeout after which identity expires on lack of heartbeat")
 	option.BindEnv(operatorOption.IdentityHeartbeatTimeout)
 
 	flags.String(option.IdentityAllocationMode, option.IdentityAllocationModeKVstore, "Method to use for identity allocation")

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -21,6 +21,11 @@ import (
 )
 
 const (
+	// EndpointGCIntervalDefault is the default time for the CEP GC
+	EndpointGCIntervalDefault = 5 * time.Minute
+)
+
+const (
 	// CNPNodeStatusGCInterval is the GC interval for nodes which have been
 	// removed from the cluster in CiliumNetworkPolicy and
 	// CiliumClusterwideNetworkPolicy Status.

--- a/operator/watchers/cilium_endpoint.go
+++ b/operator/watchers/cilium_endpoint.go
@@ -1,0 +1,139 @@
+// Copyright 2016-2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package watchers
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	cilium_cli "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/informer"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+)
+
+const identityIndex = "identity"
+
+var (
+	errNoCE  = errors.New("object is not a *cilium_api_v2.CiliumEndpoint")
+	indexers = cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+		identityIndex:        identityIndexFunc,
+	}
+
+	// CiliumEndpointStore contains all CiliumEndpoint present in k8s.
+	// Warning: The CiliumEndpoints stored in the cache are not intended to be
+	// used for Update operations in k8s as some of its fields were are not
+	// populated.
+	CiliumEndpointStore cache.Indexer
+
+	// CiliumEndpointsSynced is closed once the CiliumEndpointStore is synced
+	// with k8s.
+	CiliumEndpointsSynced = make(chan struct{})
+)
+
+// identityIndexFunc index identities by ID.
+func identityIndexFunc(obj interface{}) ([]string, error) {
+	switch t := obj.(type) {
+	case *cilium_api_v2.CiliumEndpoint:
+		if t.Status.Identity != nil {
+			id := strconv.FormatInt(t.Status.Identity.ID, 10)
+			return []string{id}, nil
+		}
+		return []string{"0"}, nil
+	}
+	return nil, fmt.Errorf("%w - found %T", errNoCE, obj)
+}
+
+// CiliumEndpointsInit starts a CiliumEndpointWatcher
+func CiliumEndpointsInit(ciliumNPClient cilium_cli.CiliumV2Interface) {
+	CiliumEndpointStore = cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, indexers)
+
+	ciliumEndpointInformer := informer.NewInformerWithStore(
+		cache.NewListWatchFromClient(ciliumNPClient.RESTClient(),
+			"ciliumendpoints", v1.NamespaceAll, fields.Everything()),
+		&cilium_api_v2.CiliumEndpoint{},
+		0,
+		cache.ResourceEventHandlerFuncs{},
+		convertToCiliumEndpoint,
+		CiliumEndpointStore,
+	)
+	go ciliumEndpointInformer.Run(wait.NeverStop)
+
+	cache.WaitForCacheSync(wait.NeverStop, ciliumEndpointInformer.HasSynced)
+	close(CiliumEndpointsSynced)
+}
+
+// convertToCiliumEndpoint converts a CiliumEndpoint to a minimal CiliumEndpoint
+// containing only a minimal set of entities used to identity a CiliumEndpoint
+// Warning: The CiliumEndpoints created by the converter are not intended to be
+// used for Update operations in k8s.
+func convertToCiliumEndpoint(obj interface{}) interface{} {
+	switch concreteObj := obj.(type) {
+	case *cilium_api_v2.CiliumEndpoint:
+		p := &cilium_api_v2.CiliumEndpoint{
+			TypeMeta: concreteObj.TypeMeta,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      concreteObj.Name,
+				Namespace: concreteObj.Namespace,
+			},
+			Status: cilium_api_v2.EndpointStatus{
+				Identity: concreteObj.Status.Identity,
+			},
+		}
+		*concreteObj = cilium_api_v2.CiliumEndpoint{}
+		return p
+	case cache.DeletedFinalStateUnknown:
+		ciliumEndpoint, ok := concreteObj.Obj.(*cilium_api_v2.CiliumEndpoint)
+		if !ok {
+			return obj
+		}
+		dfsu := cache.DeletedFinalStateUnknown{
+			Key: concreteObj.Key,
+			Obj: &cilium_api_v2.CiliumEndpoint{
+				TypeMeta: ciliumEndpoint.TypeMeta,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      ciliumEndpoint.Name,
+					Namespace: ciliumEndpoint.Namespace,
+				},
+				Status: cilium_api_v2.EndpointStatus{
+					Identity: ciliumEndpoint.Status.Identity,
+				},
+			},
+		}
+		// Small GC optimization
+		*ciliumEndpoint = cilium_api_v2.CiliumEndpoint{}
+		return dfsu
+	default:
+		return obj
+	}
+}
+
+// HasCEWithIdentity returns true or false if the Cilium Endpoint store has
+// the given identity.
+func HasCEWithIdentity(identity string) bool {
+	if CiliumEndpointStore == nil {
+		return false
+	}
+	ces, _ := CiliumEndpointStore.IndexKeys(identityIndex, identity)
+
+	return len(ces) != 0
+}

--- a/operator/watchers/pod.go
+++ b/operator/watchers/pod.go
@@ -1,0 +1,91 @@
+// Copyright 2016-2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package watchers
+
+import (
+	"github.com/cilium/cilium/pkg/k8s/informer"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/core/v1"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+var (
+	// PodStore has a minimal copy of all pods running in the cluster.
+	// Warning: The pods stored in the cache are not intended to be used for Update
+	// operations in k8s as some of its fields were are not populated.
+	PodStore cache.Store
+
+	// PodStoreSynced is closed once the PodStore is synced with k8s.
+	PodStoreSynced = make(chan struct{})
+)
+
+func PodsInit(k8sClient kubernetes.Interface) {
+	var podInformer cache.Controller
+	PodStore, podInformer = informer.NewInformer(
+		cache.NewListWatchFromClient(k8sClient.CoreV1().RESTClient(),
+			"pods", v1.NamespaceAll, fields.Everything()),
+		&slim_corev1.Pod{},
+		0,
+		cache.ResourceEventHandlerFuncs{},
+		convertToPod,
+	)
+	go podInformer.Run(wait.NeverStop)
+
+	cache.WaitForCacheSync(wait.NeverStop, podInformer.HasSynced)
+	close(PodStoreSynced)
+}
+
+// convertToPod stores a minimal version of the pod as it is only intended
+// for it to check if a pod is running in the cluster or not. The stored pod
+// should not be used to update an existing pod in the kubernetes cluster.
+func convertToPod(obj interface{}) interface{} {
+	switch concreteObj := obj.(type) {
+	case *slim_corev1.Pod:
+		p := &slim_corev1.Pod{
+			TypeMeta: concreteObj.TypeMeta,
+			ObjectMeta: slim_metav1.ObjectMeta{
+				Name:      concreteObj.Name,
+				Namespace: concreteObj.Namespace,
+			},
+		}
+		*concreteObj = slim_corev1.Pod{}
+		return p
+	case cache.DeletedFinalStateUnknown:
+		pod, ok := concreteObj.Obj.(*slim_corev1.Pod)
+		if !ok {
+			return obj
+		}
+		dfsu := cache.DeletedFinalStateUnknown{
+			Key: concreteObj.Key,
+			Obj: &slim_corev1.Pod{
+				TypeMeta: pod.TypeMeta,
+				ObjectMeta: slim_metav1.ObjectMeta{
+					Name:      pod.Name,
+					Namespace: pod.Namespace,
+				},
+			},
+		}
+		// Small GC optimization
+		*pod = slim_corev1.Pod{}
+		return dfsu
+	default:
+		return obj
+	}
+}


### PR DESCRIPTION
Doing a pod list every 30 minutes can be brutal for kube-apiserver, specially if it is not running with a limit of the number of pods that should be returned. Having a watcher that receives notifications for the pods running as well as the CEPs, is enough to provide a GC for Cilium Identities and CEPs.
    
Since we have a k8s watcher and the CEPs have an owner set to themselves the CEP GC interval was decreased to 5 minutes.
    
Also, given that we don't depend on the CEP GC to perform Cilium IdentityGC we can set the identity heartbeat timeout to 2* the KVStore Lease TTL.

Signed-off-by: André Martins <andre@cilium.io>

Fixes https://github.com/cilium/cilium/issues/11472