### PR TITLE
test: Enable embedded Hubble globally

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -106,6 +106,10 @@ var (
 		// missing LRU support. On 4.19 and net-next we enable it with
 		// kubeProxyReplacement=strict.
 		"global.sessionAffinity.enabled": "false",
+
+		// Enable embedded Hubble, both on unix socket and TCP port 4244.
+		"global.hubble.enabled":       "true",
+		"global.hubble.listenAddress": ":4244",
 	}
 
 	flannelHelmOverrides = map[string]string{
@@ -184,7 +188,7 @@ func init() {
 			defaultHelmOptions["global.tag"] = version
 			// This always works because SplitContainerURL would not return
 			// isFullyQualified == true otherwise
-			parts := strings.SplitN(image, "/", 1)
+			parts := strings.SplitN(image, "/", 2)
 			defaultHelmOptions["global.registry"] = registry + "/" + parts[0]
 		}
 	}

--- a/test/k8sT/hubble.go
+++ b/test/k8sT/hubble.go
@@ -119,7 +119,6 @@ var _ = Describe("K8sHubbleTest", func() {
 		demoPath = helpers.ManifestGet(kubectl.BasePath(), "demo.yaml")
 
 		DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
-			"global.hubble.enabled":     "true",
 			"global.hubble.cli.enabled": "true",
 		})
 


### PR DESCRIPTION
test: Enable embedded Hubble globally

- Enable embedded Hubble in the end-to-end testing by default.
- Set `global.registry` properly by splitting the image into 2 parts.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>