### PR TITLE
k8s/identitybackend: exclude k8s namespace labels from CRD metadata

### DIFF
--- a/pkg/k8s/identitybackend/identity_test.go
+++ b/pkg/k8s/identitybackend/identity_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/cilium/cilium/pkg/checker"
 
 	. "gopkg.in/check.v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 // Hook up gocheck into the "go test" runner.
@@ -34,30 +36,55 @@ type K8sIdentityBackendSuite struct{}
 var _ = Suite(&K8sIdentityBackendSuite{})
 
 func (s *K8sIdentityBackendSuite) TestSanitizeK8sLabels(c *C) {
+	path := field.NewPath("test", "labels")
 	testCases := []struct {
-		input    map[string]string
-		selected map[string]string
-		skipped  map[string]string
+		input            map[string]string
+		selected         map[string]string
+		skipped          map[string]string
+		validationErrors field.ErrorList
 	}{
 		{
-			input:    map[string]string{},
-			selected: map[string]string{},
-			skipped:  map[string]string{},
+			input:            map[string]string{},
+			selected:         map[string]string{},
+			skipped:          map[string]string{},
+			validationErrors: field.ErrorList{},
 		},
 		{
-			input:    map[string]string{"k8s:foo": "bar"},
-			selected: map[string]string{"foo": "bar"},
-			skipped:  map[string]string{},
+			input:            map[string]string{"k8s:foo": "bar"},
+			selected:         map[string]string{"foo": "bar"},
+			skipped:          map[string]string{},
+			validationErrors: field.ErrorList{},
 		},
 		{
-			input:    map[string]string{"k8s:foo": "bar", "k8s:abc": "def"},
-			selected: map[string]string{"foo": "bar", "abc": "def"},
-			skipped:  map[string]string{},
+			input:            map[string]string{"k8s:foo": "bar", "k8s:abc": "def"},
+			selected:         map[string]string{"foo": "bar", "abc": "def"},
+			skipped:          map[string]string{},
+			validationErrors: field.ErrorList{},
 		},
 		{
-			input:    map[string]string{"k8s:foo": "bar", "k8s:abc": "def", "container:something": "else"},
-			selected: map[string]string{"foo": "bar", "abc": "def"},
-			skipped:  map[string]string{"container:something": "else"},
+			input:            map[string]string{"k8s:foo": "bar", "k8s:abc": "def", "container:something": "else"},
+			selected:         map[string]string{"foo": "bar", "abc": "def"},
+			skipped:          map[string]string{"container:something": "else"},
+			validationErrors: field.ErrorList{},
+		},
+		{
+			input:    map[string]string{"k8s:some.really.really.really.really.really.really.really.long.label.name": "someval"},
+			selected: map[string]string{"some.really.really.really.really.really.really.really.long.label.name": "someval"},
+			skipped:  map[string]string{},
+			validationErrors: field.ErrorList{
+				&field.Error{
+					Type:     "FieldValueInvalid",
+					Field:    "test.labels",
+					BadValue: "some.really.really.really.really.really.really.really.long.label.name",
+					Detail:   "name part must be no more than 63 characters",
+				},
+			},
+		},
+		{
+			input:            map[string]string{"k8s:io.cilium.k8s.namespace.labels.some.really.really.long.namespace.label.name": "someval"},
+			selected:         map[string]string{},
+			skipped:          map[string]string{"k8s:io.cilium.k8s.namespace.labels.some.really.really.long.namespace.label.name": "someval"},
+			validationErrors: field.ErrorList{},
 		},
 	}
 
@@ -65,5 +92,6 @@ func (s *K8sIdentityBackendSuite) TestSanitizeK8sLabels(c *C) {
 		selected, skipped := sanitizeK8sLabels(test.input)
 		c.Assert(selected, checker.DeepEquals, test.selected)
 		c.Assert(skipped, checker.DeepEquals, test.skipped)
+		c.Assert(validation.ValidateLabels(selected, path), checker.DeepEquals, test.validationErrors)
 	}
 }


### PR DESCRIPTION
The names of synthetic labels created for k8s namespace labels are
variable in length and may be longer than the maximum 63
characters, which results in validation errors at resource
creation time.

Skip those labels along with non-k8s labels.

Signed-off-by: Romain Lenglet <rlenglet@google.com>