### PR TITLE
doc: Add SKIP_LINT option to render-docs target

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -18,6 +18,7 @@ builder-image: Dockerfile requirements.txt
 DOCKER_RUN := $(CONTAINER_ENGINE) container run --rm \
 		--workdir /src/Documentation \
 		--volume $(CURDIR)/..:/src \
+		--env SKIP_LINT=$(SKIP_LINT) \
 		--user "$(shell id -u):$(shell id -g)" \
 			cilium/docs-builder
 

--- a/Documentation/check-build.sh
+++ b/Documentation/check-build.sh
@@ -52,8 +52,11 @@ hint_about_wordlist_update() {
         "Documentation/update-spelling_wordlist.sh" "${new_words}"
 }
 
-echo "Validating documentation (syntax, spelling)..."
-if build_with_spellchecker ; then
+if [ -n "${SKIP_LINT-}" ]; then
+  echo "Skipping syntax and spelling validations..."
+else
+  echo "Validating documentation (syntax, spelling)..."
+  if build_with_spellchecker ; then
     status_ok=0
     if filter_warnings > /dev/null ;  then
         printf "\nPlease fix the following documentation warnings:\n"
@@ -70,6 +73,7 @@ if build_with_spellchecker ; then
     if [ "${status_ok}" -ne 0 ] ; then
         exit 1
     fi
+  fi
 fi
 
 # TODO: Fix broken links and re-enable this

--- a/Documentation/contributing/testing/documentation.rst
+++ b/Documentation/contributing/testing/documentation.rst
@@ -7,36 +7,16 @@
 Documentation
 =============
 
-Building
-~~~~~~~~
-
-The documentation has several dependencies which can be installed using pip:
-
-::
-
-    $ pip install -r Documentation/requirements.txt
-
-.. note:
-
-   If you are using the vagrant development environment, these requirements are
-   usually already installed.
-
 Whenever making changes to Cilium documentation you should check that you did not introduce any new warnings or errors, and also check that your changes look as you intended.  To do this you can build the docs:
-
-::
-
-    $ make -C Documentation html
-
-After this you can browse the updated docs as HTML starting at
-``Documentation\_build\html\index.html``.
-
-Alternatively you can use a Docker container to build the pages:
 
 ::
 
     $ make render-docs
 
-This builds the docs in a container and builds and starts a web server with
-your document changes.
+This generates documentation files and starts a web server using a Docker container. You can
+view the updated documentation by opening either ``Documentation/_build/html/index.html`` or
+http://localhost:9081 in a browser.
 
-Now the documentation page should be browsable on http://localhost:9080.
+.. note:: ``make render-docs`` is relatively slow since it performs syntax and spelling checks.
+          You can run ``make render-docs SKIP_LINT=1`` to render the documentation without performing
+          these checks while you iterate on updating the documentation.


### PR DESCRIPTION
Add an option to skip the syntax and spelling checks for the inpatient.
Thse checks are still enabled by default, but can be turned off while
you iterate on making documentation changes.

```
make render-docs SKIP_LINT=1  1.98s user 1.59s system 53% cpu 6.639 total
make render-docs  1.96s user 1.55s system 4% cpu 1:24.54 total
```

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>