### PR TITLE
vagrant: Fix build in dev. VM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -65,7 +65,7 @@ set -o pipefail
 
 export PATH=/home/vagrant/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games
 #{$makeclean}
-~/go/src/github.com/cilium/cilium/pkg/common/build.sh
+~/go/src/github.com/cilium/cilium/contrib/vagrant/build.sh
 rm -fr ~/go/bin/cilium*
 SCRIPT
 

--- a/contrib/vagrant/build.sh
+++ b/contrib/vagrant/build.sh
@@ -3,7 +3,7 @@
 set -e
 
 pushd `dirname $0` > /dev/null
-P="`pwd`/.."
+P="`pwd`/../.."
 popd > /dev/null
 
 cd "$P"


### PR DESCRIPTION
The build script run inside the dev. VM was inadvertently broken when moved from `common/` to `pkg/common/`. This pull request fixes that and moves that script to `contrib/vagrant/`; since only the dev. VM uses that script it makes more sense to have it with other dev. scripts.

Fixes: #11331 
/cc @Rolinh @soumynathan 