### PR TITLE
test: various cleanups found by staticcheck

### DIFF
--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -588,7 +588,7 @@ func (s *SSHMeta) ReportFailed(commands ...string) {
 	ginkgoext.GinkgoPrint(res.GetDebugMessage())
 
 	for _, cmd := range commands {
-		res = s.ExecWithSudo(fmt.Sprintf("%s", cmd), ExecOptions{SkipLog: true})
+		res = s.ExecWithSudo(cmd, ExecOptions{SkipLog: true})
 		ginkgoext.GinkgoPrint(res.GetDebugMessage())
 	}
 

--- a/test/helpers/cmd.go
+++ b/test/helpers/cmd.go
@@ -268,7 +268,6 @@ func (res *CmdRes) ExpectEqual(expected string, optionalDescription ...interface
 // Reset resets res's stdout buffer to be empty.
 func (res *CmdRes) Reset() {
 	res.stdout.Reset()
-	return
 }
 
 // SingleOut returns res's stdout as a string without any newline characters
@@ -281,8 +280,7 @@ func (res *CmdRes) SingleOut() string {
 // Unmarshal unmarshalls res's stdout into data. It assumes that the stdout of
 // res is in JSON format. Returns an error if the unmarshalling fails.
 func (res *CmdRes) Unmarshal(data interface{}) error {
-	err := json.Unmarshal(res.stdout.Bytes(), data)
-	return err
+	return json.Unmarshal(res.stdout.Bytes(), data)
 }
 
 // GetDebugMessage returns executed command and its output

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1968,7 +1968,6 @@ func (kub *Kubectl) CiliumEndpointWaitReady() error {
 				return
 			}
 			valid = true
-			return
 		}
 		wg.Add(len(ciliumPods))
 		for _, pod := range ciliumPods {

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -3391,15 +3391,6 @@ func (kub *Kubectl) DeleteETCDOperator() {
 	}
 }
 
-// reportMap saves the output of the given commands to the specified filename.
-// Function needs a directory path where the files are going to be written
-// commands are run on all pods matching selector in given namespace
-func (kub *Kubectl) reportMap(path string, reportCmds map[string]string, ns, selector string) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	kub.reportMapContext(ctx, path, reportCmds, ns, selector)
-}
-
 // reportMapContext saves the output of the given commands to the specified filename.
 // Function needs a directory path where the files are going to be written
 // commands are run on all pods matching selector

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -3022,16 +3022,13 @@ func (kub *Kubectl) ciliumStatusPreFlightCheck() error {
 	if err != nil {
 		return fmt.Errorf("cannot retrieve cilium pods: %s", err)
 	}
+	reNoQuorum := regexp.MustCompile(`^.*KVStore:.*has-quorum=false.*$`)
 	for _, pod := range ciliumPods {
 		status := kub.CiliumExecContext(context.TODO(), pod, "cilium status --all-health --all-nodes")
 		if !status.WasSuccessful() {
 			return fmt.Errorf("cilium-agent '%s' is unhealthy: %s", pod, status.OutputPrettyPrint())
 		}
-		noQuorum, err := regexp.Match(`^.*KVStore:.*has-quorum=false.*$`, status.Output().Bytes())
-		if err != nil {
-			return fmt.Errorf("Failed to check for kvstore quorum: %s", err.Error())
-		}
-		if noQuorum {
+		if reNoQuorum.Match(status.Output().Bytes()) {
 			return fmt.Errorf("KVStore doesn't have quorum: %s", status.OutputPrettyPrint())
 		}
 	}

--- a/test/helpers/local_node.go
+++ b/test/helpers/local_node.go
@@ -78,7 +78,6 @@ func (s *LocalExecutor) String() string {
 
 // CloseSSHClient is a no-op
 func (s *LocalExecutor) CloseSSHClient() {
-	return
 }
 
 func (s *LocalExecutor) setBasePath() {

--- a/test/helpers/node.go
+++ b/test/helpers/node.go
@@ -126,7 +126,6 @@ func (s *SSHMeta) setBasePath() {
 	}
 
 	s.basePath = filepath.Join(home, "go", CiliumPath)
-	return
 }
 
 // ExecuteContext executes the given `cmd` and writes the cmd's stdout and

--- a/test/helpers/policygen/models.go
+++ b/test/helpers/policygen/models.go
@@ -403,7 +403,7 @@ func (t *TestSpec) Destroy(delay time.Duration, base string) error {
 	manifestToDestroy := []string{
 		t.GetManifestsPath(base),
 		fmt.Sprintf("%s/%s", base, t.NetworkPolicyName()),
-		fmt.Sprintf("%s", t.Destination.GetManifestPath(t, base)),
+		t.Destination.GetManifestPath(t, base),
 	}
 
 	done := time.After(delay)

--- a/test/k8sT/KafkaPolicies.go
+++ b/test/k8sT/KafkaPolicies.go
@@ -29,7 +29,7 @@ var _ = Describe("K8sKafkaPolicyTest", func() {
 
 	var (
 		kubectl          *helpers.Kubectl
-		backgroundCancel context.CancelFunc = func() { return }
+		backgroundCancel context.CancelFunc = func() {}
 		backgroundError  error
 
 		// these two are set in BeforeAll

--- a/test/k8sT/Nightly.go
+++ b/test/k8sT/Nightly.go
@@ -367,7 +367,7 @@ var _ = Describe("NightlyExamples", func() {
 		var (
 			kubectl *helpers.Kubectl
 
-			cleanupCallback = func() { return }
+			cleanupCallback = func() {}
 		)
 
 		BeforeAll(func() {

--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -62,7 +62,7 @@ var _ = Describe("K8sPolicyTest", func() {
 		knpAllowEgress       string
 		cnpMatchExpression   string
 		app1Service                             = "app1-service"
-		backgroundCancel     context.CancelFunc = func() { return }
+		backgroundCancel     context.CancelFunc = func() {}
 		backgroundError      error
 		apps                 = []string{helpers.App1, helpers.App2, helpers.App3}
 		daemonCfg            map[string]string

--- a/test/k8sT/PoliciesNightly.go
+++ b/test/k8sT/PoliciesNightly.go
@@ -63,7 +63,7 @@ var _ = Describe("NightlyPolicies", func() {
 			testSpecs := policygen.GeneratedTestSpec()
 			for _, test := range testSpecs {
 				func(testSpec policygen.TestSpec) {
-					It(fmt.Sprintf("%s", testSpec), func() {
+					It(testSpec.String(), func() {
 						testSpec.RunTest(kubectl)
 					})
 				}(test)

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -458,9 +458,9 @@ var _ = Describe("K8sServicesTest", func() {
 				blockCount = 1
 			)
 			ciliumPodK8s1, err := kubectl.GetCiliumPodOnNode(helpers.CiliumNamespace, helpers.K8s1)
-			Expect(err).Should(BeNil(), fmt.Sprintf("Cannot get cilium pod on k8s1"))
+			Expect(err).Should(BeNil(), "Cannot get cilium pod on k8s1")
 			ciliumPodK8s2, err := kubectl.GetCiliumPodOnNode(helpers.CiliumNamespace, helpers.K8s2)
-			Expect(err).Should(BeNil(), fmt.Sprintf("Cannot get cilium pod on k8s2"))
+			Expect(err).Should(BeNil(), "Cannot get cilium pod on k8s2")
 
 			_, dstPodIPK8s1 := kubectl.GetPodOnNodeWithOffset(helpers.K8s1, testDS, 1)
 			_, dstPodIPK8s2 := kubectl.GetPodOnNodeWithOffset(helpers.K8s2, testDS, 1)

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -36,7 +36,7 @@ var _ = Describe("K8sServicesTest", func() {
 
 		ciliumFilename         string
 		serviceName                               = "app1-service"
-		backgroundCancel       context.CancelFunc = func() { return }
+		backgroundCancel       context.CancelFunc = func() {}
 		backgroundError        error
 		enableBackgroundReport = true
 		ciliumPodK8s1          string

--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -53,7 +53,7 @@ var _ = Describe("K8sUpdates", func() {
 	var (
 		kubectl *helpers.Kubectl
 
-		cleanupCallback = func() { return }
+		cleanupCallback = func() {}
 	)
 
 	BeforeAll(func() {

--- a/test/k8sT/demos.go
+++ b/test/k8sT/demos.go
@@ -41,7 +41,7 @@ var _ = Describe("K8sDemosTest", func() {
 		kubectl        *helpers.Kubectl
 		ciliumFilename string
 
-		backgroundCancel context.CancelFunc = func() { return }
+		backgroundCancel context.CancelFunc = func() {}
 		backgroundError  error
 
 		deathStarYAMLLink = getStarWarsResourceLink("01-deathstar.yaml")

--- a/test/k8sT/fqdn.go
+++ b/test/k8sT/fqdn.go
@@ -28,7 +28,7 @@ import (
 var _ = Describe("K8sFQDNTest", func() {
 	var (
 		kubectl          *helpers.Kubectl
-		backgroundCancel context.CancelFunc = func() { return }
+		backgroundCancel context.CancelFunc = func() {}
 		backgroundError  error
 
 		demoManifest   = ""

--- a/test/runtime/monitor.go
+++ b/test/runtime/monitor.go
@@ -327,10 +327,8 @@ var _ = Describe("RuntimeMonitorTest", func() {
 					switch fields[i] {
 					case "FROM":
 						fromID = fields[i+1]
-						break
 					case "id":
 						toID = fields[i+1]
-						break
 					}
 				}
 				if fromID == "" || toID == "" {

--- a/test/runtime/verifier.go
+++ b/test/runtime/verifier.go
@@ -55,7 +55,7 @@ var _ = Describe("RuntimeVerifier", func() {
 		GinkgoPrint("===================== TEST FAILED =====================")
 		commands := []string{"clang --version", "uname -a"}
 		for _, cmd := range commands {
-			res := vm.ExecWithSudo(fmt.Sprintf("%s", cmd))
+			res := vm.ExecWithSudo(cmd)
 			GinkgoPrint(res.GetDebugMessage())
 		}
 		GinkgoPrint("===================== EXITING REPORT GENERATION =====================\n")

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -279,7 +279,6 @@ var _ = BeforeAll(func() {
 
 		go kubectl.PprofReport()
 	}
-	return
 })
 
 var _ = AfterSuite(func() {
@@ -297,7 +296,6 @@ var _ = AfterSuite(func() {
 		helpers.DestroyVM(helpers.K8s1VMName())
 		helpers.DestroyVM(helpers.K8s2VMName())
 	}
-	return
 })
 
 func getOrSetEnvVar(key, value string) {


### PR DESCRIPTION
Fix a few issues in `test/` found by `staticcheck`:

- remove unnecessary use of `fmt.Sprintf`
- remove redundant `return`/`break` statements
- remove unused `func (*Kubectl).reportMap` 
- move regexp compilation out of loop in `ciliumStatusPreFlightCheck`
