### PR TITLE
test: reenable runtime memcache tests for testing

### DIFF
--- a/test/runtime/memcache.go
+++ b/test/runtime/memcache.go
@@ -23,7 +23,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = XDescribe("RuntimeMemcache", func() {
+var _ = Describe("RuntimeMemcache", func() {
 
 	var (
 		vm         *helpers.SSHMeta


### PR DESCRIPTION
This reverts commit d23034c2fd9f ("Mark runtime memcache tests as
pending") in order to debug flakes.