### PR TITLE
coccinelle: Fix Docker image name printed on errors

### DIFF
--- a/.github/workflows/coccicheck.yaml
+++ b/.github/workflows/coccicheck.yaml
@@ -9,6 +9,6 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
-            - uses: docker://cilium/coccicheck:latest
+            - uses: docker://cilium/coccicheck:1.0
               with:
                 entrypoint: ./contrib/coccinelle/check-cocci.sh

--- a/contrib/coccinelle/aligned.cocci
+++ b/contrib/coccinelle/aligned.cocci
@@ -59,7 +59,7 @@ cnt += 1
 
 if cnt > 0:
   print """Use the following command to fix the above issues:
-docker run --rm --user 1000 --workdir /workspace -v `pwd`:/workspace \\
-    -it coccicheck spatch --sp-file contrib/coccinelle/aligned.cocci \\
+docker run --rm --user 1000 --workdir /workspace -v `pwd`:/workspace                  \\
+    -it docker.io/cilium/coccicheck spatch --sp-file contrib/coccinelle/aligned.cocci \\
     --include-headers --very-quiet --in-place bpf/\n
 """

--- a/contrib/coccinelle/const.cocci
+++ b/contrib/coccinelle/const.cocci
@@ -65,7 +65,7 @@ cnt += 1
 
 if cnt > 0:
   print """Use the following command to fix the above issues:
-docker run --rm --user 1000 --workdir /workspace -v `pwd`:/workspace \\
-    -it coccicheck spatch --sp-file contrib/coccinelle/const.cocci   \\
+docker run --rm --user 1000 --workdir /workspace -v `pwd`:/workspace                \\
+    -it docker.io/cilium/coccicheck spatch --sp-file contrib/coccinelle/const.cocci \\
     --include-headers --very-quiet --in-place bpf/\n
 """


### PR DESCRIPTION
When Coccinelle scripts find code that needs to be changed, they print an error message that includes the command to fix the code. That command relies on a Docker image to avoid having to install Coccinelle. The name of the Docker image was however incorrect. This commit fixes it.

Fixes: 4bff090 ("coccinelle: Use Docker image to patch issues")