### PR TITLE
CODEOWNERS: Add CI team as code-owner of vagrant_box_defaults.rb

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -146,4 +146,5 @@ Vagrantfile @cilium/ci
 /Vagrantfile @cilium/contributing
 /go.sum @cilium/vendor
 /go.mod @cilium/vendor
+/vagrant_box_defaults.rb @cilium/ci
 /vendor/ @cilium/vendor


### PR DESCRIPTION
When this file is updated to include new box versions, this must be
done on a branch named `pr/update-packer-ci-build` ([docs](https://docs.cilium.io/en/latest/contributing/testing/ci/?highlight=packer#packer-ci-build)).
Otherwise the new images will not get cached, causing CI runs to slow down.

Adding the CI team as a CODEOWNER should ensure that a CI team member
has a chance to manually verify this before the PR gets merged.
Currently only an approval from the janitors team is required, who
may not know about the branch name requirement, as they rotate weekly.
