### PR TITLE
Small fixes for BPF dynamic map size flag

### DIFF
--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -448,7 +448,7 @@ New ConfigMap Options
     manually using the ``ctTcpMax``, ``ctAnyMax``, ``natMax`` options will take
     precedence over the dynamically determined value.
 
-    On upgrades of existing installations, this option is disable by default,
+    On upgrades of existing installations, this option is disabled by default,
     i.e. it is set to 0.0. Users wanting to use this feature need to enable it
     explicitly in their `ConfigMap`, see section :ref:`upgrade_configmap`.
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -797,6 +797,7 @@ var HelpFlagSections = []FlagsSection{
 			CTMapEntriesTimeoutSVCAnyName,
 			NATMapEntriesGlobalName,
 			PolicyMapEntriesName,
+			MapEntriesGlobalDynamicSizeRatioName,
 			PreAllocateMapsName,
 			BPFCompileDebugName,
 			FragmentsMapEntriesName,


### PR DESCRIPTION
Follow up for #10780 with small fixes:

- Address a doc typo found by @joestringer during review of #10780
- Add the flag to the "BPF flags" section in `cilum-agent --help` output
