### PR TITLE
make: fix govet target after moving 'common' to 'pkg'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -432,7 +432,6 @@ govet:
     ./bugtool/... \
     ./cilium/... \
     ./cilium-health/... \
-    ./common/... \
     ./daemon/... \
     ./hubble-relay/... \
     ./operator/... \


### PR DESCRIPTION
'common' can be dropped from the govet list as it was moved to
pkg/common in commit e374eac9a077 ("Move all 'common' code to 'pkg'")

This fixes the following warning during `make govet`:

    go: warning: "./common/..." matched no packages