### PR TITLE
CODEOWNERS: add cilium/agent to owners for pkg/option

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -122,7 +122,7 @@ Jenkinsfile.nightly @cilium/ci
 /pkg/monitor/payload @cilium/api
 /pkg/mountinfo @cilium/bpf
 /pkg/mtu @cilium/bpf
-/pkg/option @cilium/cli
+/pkg/option @cilium/agent @cilium/cli
 /pkg/pidfile @cilium/agent
 /pkg/policy @cilium/policy
 /pkg/policy/api/ @cilium/api


### PR DESCRIPTION
Most of the options affect the agent somehow.
