### PR TITLE
daemon: expose HTTP endpoint on localhost for health checks

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -15,6 +15,7 @@ cilium-agent [flags]
 ### Options
 
 ```
+      --agent-health-port int                         TCP port for agent health status API (default 9876)
       --agent-labels strings                          Additional labels to identify this agent
       --allow-icmp-frag-needed                        Allow ICMP Fragmentation Needed type packets for purposes like TCP Path MTU. (default true)
       --allow-localhost string                        Policy when to allow local stack to reach local endpoints { auto | always | policy } (default "auto")

--- a/Documentation/install/system_requirements.rst
+++ b/Documentation/install/system_requirements.rst
@@ -289,6 +289,19 @@ ICMP 8/0                 egress          ``worker-sg`` (self) health checks
           Routing mode, you can condense all rules into ingress/egress ANY
           port/protocol to/from self.
 
+The following ports should also be available on each node:
+
+======================== ==========================================
+Port Range / Protocol    Description
+======================== ==========================================
+4240/tcp                 cluster health checks (``cilium-health``)
+4244/tcp                 hubble server
+4245/tcp                 hubble relay
+6942/tcp                 operator Prometheus metrics
+9090/tcp                 cilium-agent Prometheus metrics
+9876/tcp                 cilium-agent health status API
+======================== ==========================================
+
 Privileges
 ==========
 

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -396,6 +396,7 @@ llvm
 loadbalancer
 loadbalancers
 loadbalancing
+localhost
 lockless
 logfile
 logout
@@ -404,9 +405,9 @@ loopback
 luke
 lwt
 macOS
+masq
 matchLabels
 matchPattern
-masq
 mc
 mediabot
 memcache

--- a/daemon/cmd/agenthealth.go
+++ b/daemon/cmd/agenthealth.go
@@ -1,0 +1,89 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"syscall"
+
+	"github.com/cilium/cilium/api/v1/models"
+
+	"golang.org/x/sys/unix"
+)
+
+func setsockoptReuseAddrAndPort(network, address string, c syscall.RawConn) error {
+	var soerr error
+	if err := c.Control(func(su uintptr) {
+		s := int(su)
+		// Allow reuse of recently-used addresses. This socket option is
+		// set by default on listeners in Go's net package, see
+		// net setDefaultListenerSockopts
+		soerr = unix.SetsockoptInt(s, unix.SOL_SOCKET, unix.SO_REUSEADDR, 1)
+		if soerr != nil {
+			return
+		}
+		// Allow reuse of recently-used ports. This gives the agent a
+		// better change to re-bind upon restarts.
+		soerr = unix.SetsockoptInt(s, unix.SOL_SOCKET, unix.SO_REUSEPORT, 1)
+	}); err != nil {
+		return err
+	}
+	return soerr
+}
+
+// startAgentHealthHTTPService registers a handler function for the /healthz
+// status HTTP endpoint exposed on addr. This endpoint reports the agent health
+// status and is equivalent to what the `cilium status --brief` CLI tool reports.
+func (d *Daemon) startAgentHealthHTTPService(addr string) {
+	lc := net.ListenConfig{Control: setsockoptReuseAddrAndPort}
+	ln, err := lc.Listen(context.Background(), "tcp", addr)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/healthz", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		isUnhealthy := func(sr *models.StatusResponse) bool {
+			if sr.Cilium != nil {
+				state := sr.Cilium.State
+				return state != models.StatusStateOk && state != models.StatusStateDisabled
+			}
+			return false
+		}
+
+		statusCode := http.StatusOK
+		sr := d.getStatus(true)
+		if isUnhealthy(&sr) {
+			statusCode = http.StatusInternalServerError
+		}
+		w.WriteHeader(statusCode)
+	}))
+	srv := &http.Server{
+		Addr:    addr,
+		Handler: mux,
+	}
+
+	go func() {
+		err := srv.Serve(ln)
+		if err == http.ErrServerClosed {
+			log.Info("healthz status API server shutdown")
+		} else if err != nil {
+			log.WithError(err).Fatal("Unable to start status healthz status API server")
+		}
+	}()
+	log.Infof("Started healthz status API server on address %s", addr)
+}

--- a/daemon/cmd/agenthealth.go
+++ b/daemon/cmd/agenthealth.go
@@ -52,7 +52,7 @@ func (d *Daemon) startAgentHealthHTTPService(addr string) {
 	lc := net.ListenConfig{Control: setsockoptReuseAddrAndPort}
 	ln, err := lc.Listen(context.Background(), "tcp", addr)
 	if err != nil {
-		log.Fatal(err)
+		log.WithError(err).Fatalf("Unable to listen on %s for healthz status API server", addr)
 	}
 
 	mux := http.NewServeMux()
@@ -82,7 +82,7 @@ func (d *Daemon) startAgentHealthHTTPService(addr string) {
 		if err == http.ErrServerClosed {
 			log.Info("healthz status API server shutdown")
 		} else if err != nil {
-			log.WithError(err).Fatal("Unable to start status healthz status API server")
+			log.WithError(err).Fatal("Unable to start healthz status API server")
 		}
 	}()
 	log.Infof("Started healthz status API server on address %s", addr)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -190,6 +190,9 @@ func init() {
 	})
 
 	// Env bindings
+	flags.Int(option.AgentHealthPort, defaults.AgentHealthPort, "TCP port for agent health status API")
+	option.BindEnv(option.AgentHealthPort)
+
 	flags.StringSlice(option.AgentLabels, []string{}, "Additional labels to identify this agent")
 	option.BindEnv(option.AgentLabels)
 
@@ -1332,6 +1335,8 @@ func runDaemon() {
 	d.startStatusCollector()
 
 	metricsErrs := initMetrics()
+
+	d.startAgentHealthHTTPService(fmt.Sprintf("localhost:%d", option.Config.AgentHealthPort))
 
 	bootstrapStats.initAPI.Start()
 	srv := server.NewServer(d.instantiateAPI())

--- a/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
@@ -55,11 +55,11 @@ spec:
         command:
         - cilium-agent
         livenessProbe:
-          exec:
-            command:
-            - cilium
-            - status
-            - --brief
+          httpGet:
+            host: '127.0.0.1'
+            path: /healthz
+            port: {{ .Values.global.agent.healthPort }}
+            scheme: HTTP
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -69,11 +69,11 @@ spec:
           successThreshold: 1
           timeoutSeconds: 5
         readinessProbe:
-          exec:
-            command:
-            - cilium
-            - status
-            - --brief
+          httpGet:
+            host: '127.0.0.1'
+            path: /healthz
+            port: {{ .Values.global.agent.healthPort }}
+            scheme: HTTP
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 30

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -69,6 +69,12 @@ data:
   debug-verbose: "{{ .Values.global.debug.verbose }}"
 {{- end }}
 
+{{- if .Values.global.agent.healthPort }}
+  # Set the TCP port for the agent health status API. This is not the port used
+  # for cilium-health.
+  agent-health-port: "{{ .Values.global.agent.healthPort }}"
+{{- end }}
+
 {{- if .Values.global.prometheus.enabled }}
   # If you want metrics enabled in all of your Cilium agents, set the port for
   # which the Cilium agents will have their metrics exposed.

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -94,6 +94,10 @@ global:
   # verbose allows additional levels of debug/trace messaging
   # verbose: flow
 
+  agent:
+    # TCP port for the agent health API. This is not the port for cilium-health.
+    healthPort: 9876
+
   # prometheus enables
   prometheus:
     enabled: false

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -364,11 +364,11 @@ spec:
         command:
         - cilium-agent
         livenessProbe:
-          exec:
-            command:
-            - cilium
-            - status
-            - --brief
+          httpGet:
+            host: '127.0.0.1'
+            path: /healthz
+            port: 9876
+            scheme: HTTP
           failureThreshold: 10
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
@@ -378,11 +378,11 @@ spec:
           successThreshold: 1
           timeoutSeconds: 5
         readinessProbe:
-          exec:
-            command:
-            - cilium
-            - status
-            - --brief
+          httpGet:
+            host: '127.0.0.1'
+            path: /healthz
+            port: 9876
+            scheme: HTTP
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 30

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -42,6 +42,9 @@ data:
 
   # If you want to run cilium in debug mode change this value to true
   debug: "false"
+  # Set the TCP port for the agent health status API. This is not the port used
+  # for cilium-health.
+  agent-health-port: "9876"
 
   # Enable IPv4 addressing. If enabled, all endpoints are allocated an IPv4
   # address.

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -19,6 +19,9 @@ import (
 )
 
 const (
+	// AgentHealthPort is the default value for option.AgentHealthPort
+	AgentHealthPort = 9876
+
 	// IPv6ClusterAllocCIDR is the default value for option.IPv6ClusterAllocCIDR
 	IPv6ClusterAllocCIDR = IPv6ClusterAllocCIDRBase + "/64"
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -57,6 +57,9 @@ type FlagsSection struct {
 }
 
 const (
+	// AgentHealthPort is the TCP port for the agent health status API.
+	AgentHealthPort = "agent-health-port"
+
 	// AgentLabels are additional labels to identify this agent
 	AgentLabels = "agent-labels"
 
@@ -1253,6 +1256,9 @@ type DaemonConfig struct {
 	// Monitor contains the configuration for the node monitor.
 	Monitor *models.MonitorStatus
 
+	// AgentHealthPort is the TCP port for the agent health status API.
+	AgentHealthPort int
+
 	// AgentLabels contains additional labels to identify this agent in monitor events.
 	AgentLabels []string
 
@@ -2140,6 +2146,7 @@ func (c *DaemonConfig) parseExcludedLocalAddresses(s []string) error {
 func (c *DaemonConfig) Populate() {
 	var err error
 
+	c.AgentHealthPort = viper.GetInt(AgentHealthPort)
 	c.AgentLabels = viper.GetStringSlice(AgentLabels)
 	c.AllowICMPFragNeeded = viper.GetBool(AllowICMPFragNeeded)
 	c.AllowLocalhost = viper.GetString(AllowLocalhost)


### PR DESCRIPTION
This is be used to replace k8s liveness/readiness probes currently
invoking `cilium status --brief`.
    
HTTP 200 corresponds to `cilium status --brief` printing `OK` and
exiting with status 0.
    
HTTP 500 corresponds to `cilium status --brief` printing an error and
exiting with status 1.

```release-note
Switch k8s liveness/readiness probes to use HTTP /healthz endpoint instead of "cilium status --brief" command.
```