### PR TITLE
ipmasq: Add default nonMasq CIDRs if config is empty

### DIFF
--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -295,7 +295,6 @@ data:
 {{- end }}
 {{- if and .Values.global.ipMasqAgent .Values.global.ipMasqAgent.enabled }}
   enable-ip-masq-agent: "true"
-  ip-masq-agent-sync-period: {{ .Values.global.ipMasqAgent.syncPeriod | quote }}
 {{- end }}
 
 {{- if .Values.global.encryption.enabled }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -129,7 +129,6 @@ global:
   # ipMasqAgent enables and controls BPF ip-masq-agent
   ipMasqAgent:
     enabled: false
-    syncPeriod: 60s
 
   # autoDirectNodeRoutes enables installation of PodCIDR routes between worker
   # nodes if worker nodes share a common L2 network segment.


### PR DESCRIPTION
To align better with the vanilla ip-masq-agent, add CIDRs from private IPv4 addr space if ip-masq-agent config is empty or missing.

Also, add a support for `masqLinkLocal` which controls whether masq'ing to the link local cidr should be enabled.

Depends on https://github.com/cilium/cilium/pull/11387 to be merged first.