### PR TITLE
BPF: fix missing "break" in nat46 switch, and minor cleanup

### DIFF
--- a/bpf/bpf_alignchecker.c
+++ b/bpf/bpf_alignchecker.c
@@ -37,7 +37,7 @@
 
 // This function is a placeholder for C struct definitions shared with Go, and
 // it's never being executed.
-int main() {
+int main(void) {
     int iter = 0;
 
     DECLARE(struct, ipv4_ct_tuple, iter);

--- a/bpf/bpf_netdev.c
+++ b/bpf/bpf_netdev.c
@@ -703,7 +703,6 @@ static __always_inline int do_netdev(struct __ctx_buff *ctx, __u16 proto,
  */
 int __always_inline handle_netdev(struct __ctx_buff *ctx, bool from_host)
 {
-	int ret = ret;
 	__u16 proto;
 
 	if (!validate_ethertype(ctx, &proto)) {

--- a/bpf/cilium-map-migrate.c
+++ b/bpf/cilium-map-migrate.c
@@ -278,7 +278,7 @@ static int bpf_derive_elf_map_from_fdinfo(int fd, struct bpf_elf_map *map)
 			map->size_value = val;
 		else if (sscanf(buff, "max_entries:\t%u", &val) == 1)
 			map->max_elem = val;
-		else if (sscanf(buff, "map_flags:\t%i", &val) == 1)
+		else if (sscanf(buff, "map_flags:\t%x", &val) == 1)
 			map->flags = val;
 	}
 
@@ -300,7 +300,7 @@ typedef int (*bpf_handle_state_t)(struct bpf_elf_ctx *ctx,
 
 char fs_base[PATH_MAX + 1];
 
-void fs_base_init()
+void fs_base_init(void)
 {
 	const char *mnt_env = getenv(BPF_ENV_MNT);
 
@@ -451,7 +451,7 @@ static int bpf_fetch_maps_end(struct bpf_elf_ctx *ctx, bpf_handle_state_t cb,
 	const char *name;
 
 	if (sym_num == 0 || sym_num > 64) {
-		fprintf(stderr, "%u maps not supported in current map section!\n",
+		fprintf(stderr, "%d maps not supported in current map section!\n",
 			sym_num);
 		return -EINVAL;
 	}

--- a/bpf/lib/ipv6.h
+++ b/bpf/lib/ipv6.h
@@ -130,7 +130,6 @@ static __always_inline void ipv6_addr_clear_suffix(union v6addr *addr,
 	addr->p3 &= GET_PREFIX(prefix);
 	prefix -= 32;
 	addr->p4 &= GET_PREFIX(prefix);
-	prefix -= 32;
 }
 
 static __always_inline int ipv6_match_prefix_64(const union v6addr *addr,

--- a/bpf/lib/nat46.h
+++ b/bpf/lib/nat46.h
@@ -165,6 +165,7 @@ static __always_inline int icmp6_to_icmp4(struct __ctx_buff *ctx, int nh_off)
 		default:
 			return DROP_UNKNOWN_ICMP6_CODE;
 		}
+		break;
 	case ICMPV6_PKT_TOOBIG:
 		icmp4.type = ICMP_DEST_UNREACH;
 		icmp4.code = ICMP_FRAG_NEEDED;
@@ -191,6 +192,7 @@ static __always_inline int icmp6_to_icmp4(struct __ctx_buff *ctx, int nh_off)
 		default:
 			return DROP_UNKNOWN_ICMP6_CODE;
 		}
+		break;
 	default:
 		return DROP_UNKNOWN_ICMP6_TYPE;
 	}

--- a/bpf/sockops/bpf_sockops.c
+++ b/bpf/sockops/bpf_sockops.c
@@ -23,6 +23,7 @@
 
 #include "bpf_sockops.h"
 
+#ifdef ENABLE_IPV4
 static __always_inline void sk_extract4_key(const struct bpf_sock_ops *ops,
 					    struct sock_key *key)
 {
@@ -115,6 +116,7 @@ static inline void bpf_sock_ops_ipv4(struct bpf_sock_ops *skops)
 
 	sock_hash_update(skops, &SOCK_OPS_MAP, &key, BPF_NOEXIST);
 }
+#endif /* ENABLE_IPV4 */
 
 #ifdef ENABLE_IPV6
 static inline void bpf_sock_ops_ipv6(struct bpf_sock_ops *skops)


### PR DESCRIPTION
While the work on checkers/static analysers for BPF code is still in progress, here are a few fixes for issues already reported by some of the tools I've been trying.

The first commit adds missing `break` keywords in a switch statement in NAT46. The bug is present since version 0.8.0, but it only concerns ICMPv6 handling and probably has a low impact. In doubt, I'm marking **this commit for backport on 1.7**.

The second patch is trivial fixes at various places in the BPF code. This second commit **does not need to be backported**.