### PR TITLE
test: Report CNI_INTEGRATION when running ginkgo

### DIFF
--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -86,6 +86,9 @@ func TestTest(t *testing.T) {
 		helpers.UserDefinedScope = config.CiliumTestConfig.TestScope
 		fmt.Printf("User specified the scope:  %q\n", config.CiliumTestConfig.TestScope)
 	}
+	if integration := helpers.GetCurrentIntegration(); integration != "" {
+		fmt.Printf("Using CNI_INTEGRATION=%q\n", integration)
+	}
 
 	configLogsOutput()
 	ShowCommands()


### PR DESCRIPTION
This can help to debug when you think you've got a CNI_INTEGRATION
enabled but it turns out you don't.