### PR TITLE
.travis: fix failure to install clang-10 on Arm64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ addons:
   apt:
     packages:
       - kernel-package
+      - gnupg
 
 before_install: ./.travis/prepare.sh
 

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -4,8 +4,6 @@ set -o errexit
 
 export CFLAGS="-Werror"
 export CGO_CFLAGS="-DCI_BUILD"
-export CLANG="clang-10"
-export LLC="llc-10"
 
 make unit-tests
 

--- a/.travis/prepare.sh
+++ b/.travis/prepare.sh
@@ -1,14 +1,49 @@
 #!/bin/bash
 
-cd ../..
-mkdir cilium
-mv pchaigno/cilium cilium/cilium
-cd cilium/cilium
+CLANG_VERSION=10.0.0
 
-curl https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-sudo apt-add-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main"
-sudo apt-get -qq update
-sudo apt-get install -y clang-10 llvm-10
+function setup_env() {
+case `uname -m` in
+  'x86_64' )
+    CLANG_DIR="clang+llvm-$CLANG_VERSION-x86_64-linux-gnu-ubuntu-18.04"
+    ;;
+  'aarch64' )
+    CLANG_DIR="clang+llvm-$CLANG_VERSION-aarch64-linux-gnu"
+    ;;
+esac
+}
+
+function install_clang() {
+  CLANG_FILE="$CLANG_DIR.tar.xz"
+  CLANG_FILE_SIG="$CLANG_FILE.sig"
+
+  CLANG_URL="https://github.com/llvm/llvm-project/releases/download/llvmorg-$CLANG_VERSION/$CLANG_FILE"
+  wget -nv $CLANG_URL
+  CLANG_URL="https://github.com/llvm/llvm-project/releases/download/llvmorg-$CLANG_VERSION/$CLANG_FILE_SIG"
+  wget -nv $CLANG_URL
+
+  wget -nv https://releases.llvm.org/$CLANG_VERSION/hans-gpg-key.asc
+  gpg --import hans-gpg-key.asc
+
+  if gpg --verify $CLANG_FILE_SIG $CLANG_FILE
+  then
+    echo $CLANG_FILE verified successfully
+  else
+    echo ERROR: Failed to verify $CLANG_FILE
+    exit 1
+  fi
+
+  sudo rm -rf /usr/local/clang
+  sudo mkdir -p /usr/local
+  sudo tar -C /usr/local -xJf $CLANG_FILE
+  sudo ln -s /usr/local/$CLANG_DIR /usr/local/clang
+  rm $CLANG_FILE $CLANG_FILE_SIG hans-gpg-key.asc
+}
+
+setup_env
+install_clang
+
+export PATH="/usr/local/clang/bin:$PATH"
 
 # disable go modules to avoid downloading all dependencies when doing go get
 GO111MODULE=off go get golang.org/x/tools/cmd/cover


### PR DESCRIPTION
source.list repository does not have a release clang-10,
Install clang-10 pre-built binaries from github release

Signed-off-by: Jianlin Lv <Jianlin.Lv@arm.com>

issue as:
https://travis-ci.com/github/cilium/cilium/jobs/329541260#L390
