### PR TITLE
bpf: Set DIRECT_ROUTING_DEV* in routed mode

### DIFF
--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -566,7 +566,7 @@ if [ "$MODE" = "direct" ] || [ "$MODE" = "ipvlan" ] || [ "$MODE" = "routed" ] ||
 
 		NP_COPTS=""
 
-		if [ "$MODE" = "direct" ] && [ "$NODE_PORT" = "true" ] ; then
+		if [ "$NODE_PORT" = "true" ] ; then
 			# First device from the list is used for direct routing between nodes
 			DIRECT_ROUTING_DEV=$(echo "${NATIVE_DEVS}" | cut -d\; -f1)
 			DIRECT_ROUTING_DEV_IDX=$(cat /sys/class/net/${DIRECT_ROUTING_DEV}/ifindex)


### PR DESCRIPTION
This commits drop the check for the mode if the NodePort BPF is enabled, which allows `DIRECT_ROUTING_DEV*` to be set in the `"routed"` mode (`--enable-endpoint-routes=true`). 

Previously, due to the check the NodePort BPF was broken with `--enable-endpoint-routes=true`, and the direct routing mode `"direct"` can be used together with `"routed"` (both modes are sharing the same variable).

/cc @pchaigno 

Fix: c5bcce4112 ("datapath: Use direct routing iface for fwding NodePort requests")