### PR TITLE
datapath/test: Do not SNAT for WORLD_ID and enable BPF masquerading by default in CI

### DIFF
--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -604,9 +604,7 @@ for iface in $(ip -o -a l | awk '{print $2}' | cut -d: -f1 | cut -d@ -f1 | grep 
 	done
 	$found && continue
 	for where in ingress egress; do
-		# bpf_netdev.o was renamed in Cilium v1.8. The following code can be
-		# removed once v1.8 is the oldest supported version.
-		if tc filter show dev "$iface" "$where" | grep -q "bpf_netdev.o"; then
+		if tc filter show dev "$iface" "$where" | grep -q "bpf_netdev[^\.]*.o"; then
 			echo "Removing bpf_netdev.o from $where of $iface"
 			tc filter del dev "$iface" "$where" || true
 		fi

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -34,20 +34,13 @@ import (
 var _ = Describe("K8sDatapathConfig", func() {
 
 	var (
-		kubectl      *helpers.Kubectl
-		monitorLog   = "monitor-aggregation.log"
-		privateIface string
-		defaultIface string
-		err          error
+		kubectl    *helpers.Kubectl
+		monitorLog = "monitor-aggregation.log"
 	)
 
 	BeforeAll(func() {
 		kubectl = helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 		deploymentManager.SetKubectl(kubectl)
-		privateIface, err = kubectl.GetPrivateIface()
-		Expect(err).Should(BeNil(), "Cannot determine private iface")
-		defaultIface, err = kubectl.GetDefaultIface()
-		Expect(err).Should(BeNil(), "Cannot determine default iface")
 	})
 
 	BeforeEach(func() {
@@ -272,9 +265,8 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 		SkipItIf(helpers.DoesNotRunOnNetNextOr419Kernel, "Check BPF masquerading", func() {
 			deploymentManager.DeployCilium(map[string]string{
-				"global.bpfMasquerade":   "true",
-				"global.nodePort.device": fmt.Sprintf(`'{%s,%s}'`, privateIface, defaultIface),
-				"global.tunnel":          "vxlan",
+				"global.tunnel":        "vxlan",
+				"global.bpfMasquerade": "true",
 			}, DeployCiliumOptionsAndDNS)
 
 			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
@@ -329,10 +321,9 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 		SkipItIf(helpers.DoesNotRunOnNetNextOr419Kernel, "Check BPF masquerading", func() {
 			deploymentManager.DeployCilium(map[string]string{
-				"global.bpfMasquerade":        "true",
-				"global.nodePort.device":      fmt.Sprintf(`'{%s,%s}'`, privateIface, defaultIface),
 				"global.tunnel":               "disabled",
 				"global.autoDirectNodeRoutes": "true",
+				"global.bpfMasquerade":        "true",
 			}, DeployCiliumOptionsAndDNS)
 
 			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
@@ -454,12 +445,9 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 		It("DirectRouting", func() {
 			deploymentManager.DeployCilium(map[string]string{
-				"global.nodePort.device":        fmt.Sprintf(`'{%s,%s}'`, privateIface, defaultIface),
-				"global.bpfMasquerade":          "true",
-				"global.ipMasqAgent.enabled":    "true",
-				"global.ipMasqAgent.syncPeriod": "1s",
-				"global.tunnel":                 "disabled",
-				"global.autoDirectNodeRoutes":   "true",
+				"global.ipMasqAgent.enabled":  "true",
+				"global.tunnel":               "disabled",
+				"global.autoDirectNodeRoutes": "true",
 			}, DeployCiliumOptionsAndDNS)
 
 			testIPMasqAgent()
@@ -467,11 +455,8 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 		It("VXLAN", func() {
 			deploymentManager.DeployCilium(map[string]string{
-				"global.nodePort.device":        fmt.Sprintf(`'{%s,%s}'`, privateIface, defaultIface),
-				"global.bpfMasquerade":          "true",
-				"global.ipMasqAgent.enabled":    "true",
-				"global.ipMasqAgent.syncPeriod": "1s",
-				"global.tunnel":                 "vxlan",
+				"global.ipMasqAgent.enabled": "true",
+				"global.tunnel":              "vxlan",
 			}, DeployCiliumOptionsAndDNS)
 
 			testIPMasqAgent()

--- a/test/k8sT/DatapathConfiguration.go
+++ b/test/k8sT/DatapathConfiguration.go
@@ -261,16 +261,12 @@ var _ = Describe("K8sDatapathConfig", func() {
 				"global.autoDirectNodeRoutes": "true",
 			}, DeployCiliumOptionsAndDNS)
 			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
-		})
 
-		SkipItIf(helpers.DoesNotRunOnNetNextOr419Kernel, "Check BPF masquerading", func() {
-			deploymentManager.DeployCilium(map[string]string{
-				"global.tunnel":        "vxlan",
-				"global.bpfMasquerade": "true",
-			}, DeployCiliumOptionsAndDNS)
-
-			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
-			Expect(testPodHTTPToOutside(kubectl, "http://google.com", false, false)).Should(BeTrue(), "Connectivity test to http://google.com failed")
+			if helpers.RunsOnNetNextOr419Kernel() {
+				By("Test BPF masquerade")
+				Expect(testPodHTTPToOutside(kubectl, "http://google.com", false, false)).
+					Should(BeTrue(), "Connectivity test to http://google.com failed")
+			}
 		})
 	})
 
@@ -317,17 +313,11 @@ var _ = Describe("K8sDatapathConfig", func() {
 			}, DeployCiliumOptionsAndDNS)
 
 			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
-		})
-
-		SkipItIf(helpers.DoesNotRunOnNetNextOr419Kernel, "Check BPF masquerading", func() {
-			deploymentManager.DeployCilium(map[string]string{
-				"global.tunnel":               "disabled",
-				"global.autoDirectNodeRoutes": "true",
-				"global.bpfMasquerade":        "true",
-			}, DeployCiliumOptionsAndDNS)
-
-			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
-			Expect(testPodHTTPToOutside(kubectl, "http://google.com", false, false)).Should(BeTrue(), "Connectivity test to http://google.com failed")
+			if helpers.RunsOnNetNextOr419Kernel() {
+				By("Test BPF masquerade")
+				Expect(testPodHTTPToOutside(kubectl, "http://google.com", false, false)).
+					Should(BeTrue(), "Connectivity test to http://google.com failed")
+			}
 		})
 
 		It("Check direct connectivity with per endpoint routes", func() {

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -1262,18 +1262,6 @@ var _ = Describe("K8sServicesTest", func() {
 					testNodePort(true, false, false) // no need to test from outside, as testDSR did it
 				})
 
-				SkipItIf(helpers.DoesNotExistNodeWithoutCilium, "Tests with direct routing, DSR and BPF MASQ", func() {
-					DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
-						"global.nodePort.mode":        "dsr",
-						"global.tunnel":               "disabled",
-						"global.autoDirectNodeRoutes": "true",
-						"global.bpfMasquerade":        "true",
-					})
-
-					testDSR(64001)
-					testNodePort(true, false, false) // no need to test from outside, as testDSR did it
-				})
-
 				SkipItIf(helpers.DoesNotExistNodeWithoutCilium, "Tests with XDP, direct routing and SNAT", func() {
 					DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
 						"global.nodePort.acceleration": "testing-only",

--- a/test/k8sT/external_ips.go
+++ b/test/k8sT/external_ips.go
@@ -243,6 +243,7 @@ var _ = Describe("K8sKubeProxyFreeMatrix tests", func() {
 					"global.autoDirectNodeRoutes": "true",
 					"global.nodePort.device":      external_ips.PublicInterfaceName,
 					"global.nodePort.enabled":     "true",
+					"global.bpfMasquerade":        "false",
 				})
 			})
 			DescribeTable("From pod running on node-1 to services being backed by a pod running on node-1",
@@ -287,6 +288,7 @@ var _ = Describe("K8sKubeProxyFreeMatrix tests", func() {
 					"global.tunnel":           "vxlan",
 					"global.nodePort.device":  external_ips.PublicInterfaceName,
 					"global.nodePort.enabled": "true",
+					"global.bpfMasquerade":    "false",
 				})
 			})
 			DescribeTable("From pod running on node-1 to services being backed by a pod running on node-1",


### PR DESCRIPTION
See commit msgs.

Depends on #11572 (let's merge this PR, and then close #11572).

Partially_fix #11442