### PR TITLE
k8s/identitybackend: use self validation function

### DIFF
--- a/pkg/k8s/identitybackend/identity_test.go
+++ b/pkg/k8s/identitybackend/identity_test.go
@@ -20,9 +20,9 @@ import (
 	"testing"
 
 	"github.com/cilium/cilium/pkg/checker"
+	"github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1/validation"
 
 	. "gopkg.in/check.v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 


### PR DESCRIPTION
Fixes: bf160f620e65 ("k8s/identitybackend: exclude k8s namespace labels from CRD metadata")
Signed-off-by: André Martins <andre@cilium.io>