### PR TITLE
v1.6 backports 2020-05-08

### DIFF
--- a/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
+++ b/install/kubernetes/cilium/charts/agent/templates/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
-{{- if .Values.global.sleepAfterInit }}
+{{- if .Values.sleepAfterInit }}
       - command: [ "/bin/bash", "-c", "--" ]
         args: [ "while true; do sleep 30; done;" ]
         livenessProbe:


### PR DESCRIPTION
* #11203 -- Fixes cilium-agent helm chart so the daemonset can be configured with… (@seanmwinn)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 11203; do contrib/backporting/set-labels.py $pr done 1.6; done
```