### PR TITLE
Doc: Update the unit test section for privileged tests

### DIFF
--- a/Documentation/contributing/testing/unit.rst
+++ b/Documentation/contributing/testing/unit.rst
@@ -63,6 +63,29 @@ run the unit tests and tear down the prerequisites:
 
     $ make unit-tests TESTPKGS=github.com/cilium/cilium/pkg/kvstore
 
+Some packages have privileged tests. They are not run by default when you run
+the unit tests for the respective package. The privileged test files have an
+entry at the top of the test file as shown.
+
+::
+
+    +build privileged_tests
+
+There are two ways that you can run the 'privileged' tests.
+
+1. To run all the 'privileged' tests for cilium follow the instructions below.
+
+::
+
+    $ sudo -E make tests-privileged
+
+2. To run a specific package 'privileged' test, follow the instructions below.
+   Here for example we are trying to run the tests for 'routing' package.
+
+::
+
+    $ TESTPKGS="pkg/aws/eni/routing" sudo -E make tests-privileged
+
 Running individual tests
 ^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
This PR adds instructions to the cilium documentation on how to
run the 'privileged' unit tests.

Fixes: #11431
Signed-off-by: Swaminathan Vasudevan <svasudevan@suse.com>
