### PR TITLE
.github: Run GitHub Actions on master

### DIFF
--- a/.github/workflows/coccicheck.yaml
+++ b/.github/workflows/coccicheck.yaml
@@ -1,7 +1,10 @@
 name: BPF checks
 
 on:
-  - pull_request
+  pull_request: {}
+  push:
+    branches:
+      - master
 
 jobs:
     coccicheck:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,7 +1,10 @@
 name: Documentation Updates
 
 on:
-  - pull_request
+  pull_request: {}
+  push:
+    branches:
+      - master
 
 jobs:
     build-html:

--- a/.github/workflows/go-mod.yaml
+++ b/.github/workflows/go-mod.yaml
@@ -1,6 +1,10 @@
 name: Go module vendoring
 
-on: pull_request
+on:
+  pull_request: {}
+  push:
+    branches:
+      - master
 
 jobs:
   go-mod:


### PR DESCRIPTION
Running our GitHub Actions on every push to master should help us notice and find the origin of regressions if we ever let some fall between the cracks.