### PR TITLE
Docker: Speed up dev image builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,10 @@ COPY . ./
 ARG LOCKDEBUG
 ARG V
 ARG LIBNETWORK_PLUGIN
+
+ARG GIT_CHECKOUT
+RUN test -z $GIT_CHECKOUT || git checkout
+
 #
 # Please do not add any dependency updates before the 'make install' here,
 # as that will mess with caching for incremental builds!
@@ -47,9 +51,9 @@ LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"
 COPY --from=builder /tmp/install /
 COPY --from=cilium-envoy / /
-COPY plugins/cilium-cni/cni-install.sh /cni-install.sh
-COPY plugins/cilium-cni/cni-uninstall.sh /cni-uninstall.sh
-COPY contrib/packaging/docker/init-container.sh /init-container.sh
+COPY --from=builder /go/src/github.com/cilium/cilium/plugins/cilium-cni/cni-install.sh /cni-install.sh
+COPY --from=builder /go/src/github.com/cilium/cilium/plugins/cilium-cni/cni-uninstall.sh /cni-uninstall.sh
+COPY --from=builder /go/src/github.com/cilium/cilium/contrib/packaging/docker/init-container.sh /init-container.sh
 WORKDIR /home/cilium
 RUN groupadd -f cilium \
     && echo ". /etc/profile.d/bash_completion.sh" >> /etc/bash.bashrc

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -21,6 +21,11 @@ INSTALL = install
 
 CONTAINER_ENGINE?=docker
 
+# Set DOCKER_DEV_ACCOUNT with "cilium" by default
+ifeq ($(DOCKER_DEV_ACCOUNT),)
+    DOCKER_DEV_ACCOUNT="cilium"
+endif
+
 # Set DOCKER_IMAGE_TAG with "latest" by default
 ifeq ($(DOCKER_IMAGE_TAG),)
     DOCKER_IMAGE_TAG="latest"


### PR DESCRIPTION
Pass the build context as a shallow git clone. This reduces the build
context from >500MB to ~25MB and shaves more than a minute from the
total build time, with the downside that only changes committed to git
will be compiled. To mitigate against omissions the output of 'git
status' is shown and the build is aborted if working tree is not
clean. This can be bypassed by defining IGNORE_GIT_STATUS to a
non-empty value (e.g., IGNORE_GIT_STATUS=1).

Use DOCKER_BUILDKIT cache feature to make dev image builds incremental
using a build cache. This should result in a build time of about 45
seconds for the consecutive builds after the first one (which takes
about 2.5 minutes). Caching can be disabled by defining the
environment variable DOCKER_DEV_NOCACHE to a non-empty value (e.g.,
DOCKER_DEV_NOCACHE=1). In this case the DOCKER_BUILDKIT is not used at
all.

The build cache is cleared with "make clean".

Add support for environment variable DOCKER_DEV_ACCOUNT that defaults
to "cilium". This makes it easier for devs to push experimental images
to personal docker hub repos.
