### PR TITLE
make: allow make docker-image with symbol table and debug info

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"
 WORKDIR /go/src/github.com/cilium/cilium
 COPY . ./
+ARG NOSTRIP
 ARG LOCKDEBUG
 ARG V
 ARG LIBNETWORK_PLUGIN
@@ -32,7 +33,7 @@ RUN test -z $GIT_CHECKOUT || git checkout
 # Please do not add any dependency updates before the 'make install' here,
 # as that will mess with caching for incremental builds!
 #
-RUN make LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 V=$V LIBNETWORK_PLUGIN=$LIBNETWORK_PLUGIN \
+RUN make NOSTRIP=$NOSTRIP LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 V=$V LIBNETWORK_PLUGIN=$LIBNETWORK_PLUGIN \
     SKIP_DOCS=true DESTDIR=/tmp/install clean-container build-container install-container
 
 #

--- a/Makefile
+++ b/Makefile
@@ -266,6 +266,7 @@ docker-image: clean docker-image-no-clean docker-operator-image docker-plugin-im
 
 docker-image-no-clean: GIT_VERSION
 	$(QUIET)$(CONTAINER_ENGINE) build \
+		--build-arg NOSTRIP=${NOSTRIP} \
 		--build-arg LOCKDEBUG=${LOCKDEBUG} \
 		--build-arg V=${V} \
 		--build-arg LIBNETWORK_PLUGIN=${LIBNETWORK_PLUGIN} \
@@ -302,6 +303,7 @@ endif
 dev-docker-image: check-status clean-build $(DEV_DOCKERFILE) GIT_VERSION
 	git clone --no-checkout --no-local --depth 1 . $(DEV_BUILD_DIR)
 	$(QUIET)$(DOCKER_BUILDKIT) $(CONTAINER_ENGINE) build -f $(DEV_DOCKERFILE) \
+		--build-arg NOSTRIP=${NOSTRIP} \
 		--build-arg LOCKDEBUG=${LOCKDEBUG} \
 		--build-arg V=${V} \
 		--build-arg CILIUM_SHA=$(firstword $(GIT_VERSION)) \
@@ -318,6 +320,7 @@ docker-cilium-dev-manifest:
 
 docker-operator-image: GIT_VERSION
 	$(QUIET)$(CONTAINER_ENGINE) build \
+		--build-arg NOSTRIP=${NOSTRIP} \
 		--build-arg LOCKDEBUG=${LOCKDEBUG} \
 		--build-arg CILIUM_SHA=$(firstword $(GIT_VERSION)) \
 		-f cilium-operator.Dockerfile \
@@ -331,6 +334,7 @@ docker-operator-manifest:
 
 docker-plugin-image: GIT_VERSION
 	$(QUIET)$(CONTAINER_ENGINE) build \
+		--build-arg NOSTRIP=${NOSTRIP} \
 		--build-arg LOCKDEBUG=${LOCKDEUBG} \
 		--build-arg CILIUM_SHA=$(firstword $(GIT_VERSION)) \
 		-f cilium-docker-plugin.Dockerfile \
@@ -360,7 +364,10 @@ docker-cilium-builder-manifest:
 	$(QUIET) contrib/scripts/push_manifest.sh cilium-builder $(UTC_DATE)
 
 docker-hubble-relay-image:
-	$(QUIET)$(CONTAINER_ENGINE) build -f hubble-relay.Dockerfile -t "cilium/hubble-relay:$(DOCKER_IMAGE_TAG)" .
+	$(QUIET)$(CONTAINER_ENGINE) build \
+		--build-arg NOSTRIP=${NOSTRIP} \
+		-f hubble-relay.Dockerfile \
+		-t "cilium/hubble-relay:$(DOCKER_IMAGE_TAG)" .
 	$(QUIET)$(CONTAINER_ENGINE) tag cilium/hubble-relay:$(DOCKER_IMAGE_TAG) cilium/hubble-relay:$(DOCKER_IMAGE_TAG)-${GOARCH}
 	$(QUIET)echo "Push like this when ready:"
 	$(QUIET)echo "${CONTAINER_ENGINE} push cilium/hubble-relay:$(DOCKER_IMAGE_TAG)-${GOARCH}"

--- a/cilium-docker-plugin.Dockerfile
+++ b/cilium-docker-plugin.Dockerfile
@@ -5,7 +5,8 @@ LABEL maintainer="maintainer@cilium.io"
 ADD . /go/src/github.com/cilium/cilium
 WORKDIR /go/src/github.com/cilium/cilium/plugins/cilium-docker
 ARG LOCKDEBUG
-RUN make LOCKDEBUG=$LOCKDEBUG
+ARG NOSTRIP
+RUN make NOSTRIP=$NOSTRIP LOCKDEBUG=$LOCKDEBUG
 
 FROM scratch
 ARG CILIUM_SHA=""

--- a/cilium-operator.Dockerfile
+++ b/cilium-operator.Dockerfile
@@ -4,8 +4,9 @@ LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"
 ADD . /go/src/github.com/cilium/cilium
 WORKDIR /go/src/github.com/cilium/cilium/operator
+ARG NOSTRIP
 ARG LOCKDEBUG
-RUN make LOCKDEBUG=$LOCKDEBUG EXTRA_GO_BUILD_FLAGS="-tags operator_aws,operator_azure"
+RUN make NOSTRIP=$NOSTRIP LOCKDEBUG=$LOCKDEBUG EXTRA_GO_BUILD_FLAGS="-tags operator_aws,operator_azure"
 
 FROM docker.io/library/alpine:3.9.3 as certs
 ARG CILIUM_SHA=""

--- a/hubble-relay.Dockerfile
+++ b/hubble-relay.Dockerfile
@@ -1,7 +1,8 @@
 FROM docker.io/library/golang:1.14.2 as builder
 ADD . /go/src/github.com/cilium/cilium
 WORKDIR /go/src/github.com/cilium/cilium/hubble-relay
-RUN make
+ARG NOSTRIP
+RUN make NOSTRIP=$NOSTRIP
 
 FROM docker.io/library/alpine:3.11 as certs
 RUN apk --update add ca-certificates


### PR DESCRIPTION
Since commit 508fee9d557c ("make: strip symbol tables from all binaries
by default"), debug info and symbol tables are stripped to reduce binary
sizes. `NOSTRIP` can be used to enable debug info and symbol tables for
making binaries, but it doesn't affect `make docker-image`.

This patch allows NOSTRIP to be used to build docker images containing
binaries with debug info and symbol tables. For example:
`make NOSTRIP=1 docker-image`

Signed-off-by: Jaff Cheng <jaff.cheng.sh@gmail.com>