### PR TITLE
cilium: rename aws/eni/routing to pkg/datapath/linux/routing

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -26,13 +26,13 @@ import (
 	hubbleProto "github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/api/v1/models"
 	health "github.com/cilium/cilium/cilium-health/launch"
-	enirouting "github.com/cilium/cilium/pkg/aws/eni/routing"
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/clustermesh"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/counter"
 	"github.com/cilium/cilium/pkg/crypto/certificatemanager"
 	"github.com/cilium/cilium/pkg/datapath"
+	linuxrouting "github.com/cilium/cilium/pkg/datapath/linux/routing"
 	"github.com/cilium/cilium/pkg/datapath/loader"
 	"github.com/cilium/cilium/pkg/debug"
 	"github.com/cilium/cilium/pkg/defaults"
@@ -144,8 +144,8 @@ type Daemon struct {
 	k8sWatcher *watchers.K8sWatcher
 
 	// healthEndpointRouting is the information required to set up the health
-	// endpoint's routing in ENI mode
-	healthEndpointRouting *enirouting.RoutingInfo
+	// endpoint's routing in ENI or Azure IPAM mode
+	healthEndpointRouting *linuxrouting.RoutingInfo
 
 	hubbleObserver *observer.LocalObserverServer
 }

--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -23,9 +23,9 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	ipamapi "github.com/cilium/cilium/api/v1/server/restapi/ipam"
 	"github.com/cilium/cilium/pkg/api"
-	enirouting "github.com/cilium/cilium/pkg/aws/eni/routing"
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/datapath"
+	linuxrouting "github.com/cilium/cilium/pkg/datapath/linux/routing"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/ipam"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -367,7 +367,7 @@ func (d *Daemon) bootstrapIPAM() {
 
 func (d *Daemon) parseHealthEndpointInfo(result *ipam.AllocationResult) error {
 	var err error
-	d.healthEndpointRouting, err = enirouting.NewRoutingInfo(result.GatewayIP,
+	d.healthEndpointRouting, err = linuxrouting.NewRoutingInfo(result.GatewayIP,
 		result.CIDRs,
 		result.Master)
 	return err

--- a/pkg/datapath/linux/routing/info.go
+++ b/pkg/datapath/linux/routing/info.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package enirouting
+package linuxrouting
 
 import (
 	"errors"
@@ -23,9 +23,9 @@ import (
 )
 
 // RoutingInfo represents information that's required to enable
-// connectivity via the local rule and route tables while in ENI mode. The
-// information in this struct is used to create rules and routes which direct
-// traffic out of the ENI devices (egress).
+// connectivity via the local rule and route tables while in ENI or Azure IPAM mode.
+// The information in this struct is used to create rules and routes which direct
+// traffic out of the interface (egress).
 //
 // This struct is mostly derived from the `ipam.AllocationResult` as the
 // information comes from IPAM.
@@ -33,12 +33,12 @@ type RoutingInfo struct {
 	// IPv4Gateway is the gateway where outbound/egress traffic is directed.
 	IPv4Gateway net.IP
 
-	// IPv4CIDRs is a list of CIDRs which the ENI device has access to. In most
+	// IPv4CIDRs is a list of CIDRs which the interface has access to. In most
 	// cases, it'll at least contain the CIDR of the IPv4Gateway IP address.
 	IPv4CIDRs []net.IPNet
 
 	// MasterIfMAC is the MAC address of the master interface that egress
-	// traffic is directed to. This is the MAC of the ENI itself which
+	// traffic is directed to. This is the MAC of the interface itself which
 	// corresponds to the IPv4Gateway IP addr.
 	MasterIfMAC mac.MAC
 }

--- a/pkg/datapath/linux/routing/info_test.go
+++ b/pkg/datapath/linux/routing/info_test.go
@@ -14,7 +14,7 @@
 
 // +build !privileged_tests
 
-package enirouting
+package linuxrouting
 
 import (
 	"net"
@@ -30,11 +30,11 @@ func Test(t *testing.T) {
 	check.TestingT(t)
 }
 
-type ENIRoutingSuite struct{}
+type LinuxRoutingSuite struct{}
 
-var _ = check.Suite(&ENIRoutingSuite{})
+var _ = check.Suite(&LinuxRoutingSuite{})
 
-func (e *ENIRoutingSuite) TestParse(c *check.C) {
+func (e *LinuxRoutingSuite) TestParse(c *check.C) {
 	_, fakeCIDR, err := net.ParseCIDR("192.168.0.0/16")
 	c.Assert(err, check.IsNil)
 

--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package enirouting
+package linuxrouting
 
 import (
 	"errors"
@@ -30,16 +30,17 @@ import (
 )
 
 var (
-	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "eni-routing")
+	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "linux-routing")
 )
 
-// Configure sets up the rules and routes needed when running in ENI mode.
-// These rules and routes direct egress traffic out of the ENI device and
+// Configure sets up the rules and routes needed when running in ENI or
+// Azure IPAM mode.
+// These rules and routes direct egress traffic out of the interface and
 // ingress traffic back to the endpoint (`ip`).
 //
-// ip: The endpoint IP address to direct traffic out / from ENI device.
-// info: The ENI device routing info used to create rules and routes.
-// mtu: The ENI device MTU.
+// ip: The endpoint IP address to direct traffic out / from interface.
+// info: The interface routing info used to create rules and routes.
+// mtu: The interface MTU.
 // masq: Whether masquerading is enabled.
 func (info *RoutingInfo) Configure(ip net.IP, mtu int, masq bool) error {
 	if ip.To4() == nil {
@@ -58,7 +59,7 @@ func (info *RoutingInfo) Configure(ip net.IP, mtu int, masq bool) error {
 		Mask: net.CIDRMask(32, 32),
 	}
 
-	// Route all traffic to the ENI address via the main routing table
+	// Route all traffic to the interface address via the main routing table
 	if err := route.ReplaceRule(route.Rule{
 		Priority: linux_defaults.RulePriorityIngress,
 		To:       &ipWithMask,

--- a/pkg/datapath/linux/routing/routing_test.go
+++ b/pkg/datapath/linux/routing/routing_test.go
@@ -14,7 +14,7 @@
 
 // +build privileged_tests
 
-package enirouting
+package linuxrouting
 
 import (
 	"net"
@@ -33,11 +33,11 @@ func Test(t *testing.T) {
 	TestingT(t)
 }
 
-type ENIRoutingSuite struct{}
+type LinuxRoutingSuite struct{}
 
-var _ = Suite(&ENIRoutingSuite{})
+var _ = Suite(&LinuxRoutingSuite{})
 
-func (e *ENIRoutingSuite) TestConfigure(c *C) {
+func (e *LinuxRoutingSuite) TestConfigure(c *C) {
 	currentNS, err := netns.Get()
 	c.Assert(err, IsNil)
 	defer func() {
@@ -51,7 +51,7 @@ func (e *ENIRoutingSuite) TestConfigure(c *C) {
 	runFuncInNetNS(c, func() { runConfigureThenDelete(c, ri, ip, 1500, true) }, masterMAC)
 }
 
-func (e *ENIRoutingSuite) TestConfigureRoutewithIncompatibleIP(c *C) {
+func (e *LinuxRoutingSuite) TestConfigureRoutewithIncompatibleIP(c *C) {
 	_, ri := getFakes(c)
 	ipv6 := net.ParseIP("fd00::2").To16()
 	c.Assert(ipv6, NotNil)
@@ -60,7 +60,7 @@ func (e *ENIRoutingSuite) TestConfigureRoutewithIncompatibleIP(c *C) {
 	c.Assert(err, ErrorMatches, "IP not compatible")
 }
 
-func (e *ENIRoutingSuite) TestDeleteRoutewithIncompatibleIP(c *C) {
+func (e *LinuxRoutingSuite) TestDeleteRoutewithIncompatibleIP(c *C) {
 	ipv6 := net.ParseIP("fd00::2").To16()
 	c.Assert(ipv6, NotNil)
 	err := Delete(ipv6)
@@ -68,7 +68,7 @@ func (e *ENIRoutingSuite) TestDeleteRoutewithIncompatibleIP(c *C) {
 	c.Assert(err, ErrorMatches, "IP not compatible")
 }
 
-func (e *ENIRoutingSuite) TestDelete(c *C) {
+func (e *LinuxRoutingSuite) TestDelete(c *C) {
 	fakeIP, fakeRoutingInfo := getFakes(c)
 	masterMAC := fakeRoutingInfo.MasterIfMAC
 
@@ -104,7 +104,7 @@ func (e *ENIRoutingSuite) TestDelete(c *C) {
 
 				runConfigure(c, fakeRoutingInfo, ip, 1500, false)
 
-				// Find ENI ingress rules so that we can create a
+				// Find interface ingress rules so that we can create a
 				// near-duplicate.
 				rules, err := route.ListRules(netlink.FAMILY_V4, &route.Rule{
 					Priority: linux_defaults.RulePriorityIngress,
@@ -114,8 +114,8 @@ func (e *ENIRoutingSuite) TestDelete(c *C) {
 
 				// Insert almost duplicate rule; the reason for this is to
 				// trigger an error while trying to delete the ingress rule. We
-				// are setting the Src because ENI ingress rules don't have one
-				// (only Dst), thus we set Src to create a near-duplicate.
+				// are setting the Src because ingress rules don't have
+				// one (only Dst), thus we set Src to create a near-duplicate.
 				r := rules[0]
 				r.Src = &net.IPNet{IP: fakeIP, Mask: net.CIDRMask(32, 32)}
 				c.Assert(netlink.RuleAdd(&r), IsNil)
@@ -211,7 +211,7 @@ func listRulesAndRoutes(c *C, family int) ([]netlink.Rule, []netlink.Route) {
 func createDummyDevice(c *C, macAddr mac.MAC) func() {
 	dummy := &netlink.Dummy{
 		LinkAttrs: netlink.LinkAttrs{
-			Name:         "enirouting-test",
+			Name:         "linuxrouting-test",
 			HardwareAddr: net.HardwareAddr(macAddr),
 		},
 	}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -30,11 +30,11 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/addressing"
 	"github.com/cilium/cilium/pkg/annotation"
-	enirouting "github.com/cilium/cilium/pkg/aws/eni/routing"
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/datapath/link"
+	linuxrouting "github.com/cilium/cilium/pkg/datapath/linux/routing"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/eventqueue"
 	"github.com/cilium/cilium/pkg/fqdn"
@@ -2172,18 +2172,18 @@ func (e *Endpoint) Delete(monitor monitorOwner, ipam ipReleaser, manager endpoin
 		}
 	}
 
-	if option.Config.IPAM == option.IPAMENI {
+	if option.Config.IPAM == option.IPAMENI || option.Config.IPAM == option.IPAMAzure {
 		e.getLogger().WithFields(logrus.Fields{
 			"ep":     e.GetID(),
 			"ipAddr": e.GetIPv4Address(),
-		}).Debug("Deleting endpoint ENI rules")
+		}).Debug("Deleting endpoint routing rules")
 
 		// This is a best-effort attempt to cleanup. We expect there to be one
 		// ingress rule and one egress rule. If we find more than one rule in
 		// either case, then the rules will be left as-is because there was
 		// likely manual intervention.
-		if err := enirouting.Delete(e.IPv4.IP()); err != nil {
-			errs = append(errs, fmt.Errorf("unable to delete endpoint ENI rules: %s", err))
+		if err := linuxrouting.Delete(e.IPv4.IP()); err != nil {
+			errs = append(errs, fmt.Errorf("unable to delete endpoint routing rules: %s", err))
 		}
 	}
 

--- a/plugins/cilium-cni/interface.go
+++ b/plugins/cilium-cni/interface.go
@@ -19,7 +19,7 @@ import (
 	"net"
 
 	"github.com/cilium/cilium/api/v1/models"
-	enirouting "github.com/cilium/cilium/pkg/aws/eni/routing"
+	linuxrouting "github.com/cilium/cilium/pkg/datapath/linux/routing"
 	"github.com/cilium/cilium/pkg/ip"
 
 	"github.com/containernetworking/cni/pkg/types/current"
@@ -41,7 +41,7 @@ func interfaceAdd(ipConfig *current.IPConfig, ipam *models.IPAMAddressResponse, 
 		cidrs = append(cidrs, *cidr)
 	}
 
-	routingInfo, err := enirouting.NewRoutingInfo(ipam.Gateway, ipam.Cidrs, ipam.MasterMac)
+	routingInfo, err := linuxrouting.NewRoutingInfo(ipam.Gateway, ipam.Cidrs, ipam.MasterMac)
 	if err != nil {
 		return fmt.Errorf("unable to parse routing info: %v", err)
 	}


### PR DESCRIPTION
Per discussion in #11268 : the routing rules we use here are in
no way specific to AWS ENI; they are for also used to setup
Azure IPAM routes.

While at it, also garbage collect routes on endpoint deletion
when running Azure IPAM mode.

Signed-off-by: Benjamin Pineau <benjamin.pineau@datadoghq.com>

```release-note
Also garbage collect Azure IPAM routes on endpoint removal
```
