### PR TITLE
v1.7 backports 2020-05-11

### DIFF
--- a/pkg/k8s/factory_functions_test.go
+++ b/pkg/k8s/factory_functions_test.go
@@ -328,14 +328,14 @@ func (s *K8sSuite) Test_EqualV1Pod(c *C) {
 						Name: "pod1",
 					},
 					StatusHostIP: "127.0.0.1",
-					StatusPodIP:  "127.0.0.2",
+					StatusPodIPs: []string{"127.0.0.2"},
 				},
 				o2: &types.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "pod1",
 					},
 					StatusHostIP: "127.0.0.1",
-					StatusPodIP:  "127.0.0.1",
+					StatusPodIPs: []string{"127.0.0.1"},
 				},
 			},
 			want: false,
@@ -348,14 +348,14 @@ func (s *K8sSuite) Test_EqualV1Pod(c *C) {
 						Name: "pod1",
 					},
 					StatusHostIP: "127.0.0.1",
-					StatusPodIP:  "127.0.0.2",
+					StatusPodIPs: []string{"127.0.0.2"},
 				},
 				o2: &types.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "pod1",
 					},
 					StatusHostIP: "127.0.0.1",
-					StatusPodIP:  "127.0.0.2",
+					StatusPodIPs: []string{"127.0.0.2"},
 				},
 			},
 			want: true,
@@ -371,14 +371,14 @@ func (s *K8sSuite) Test_EqualV1Pod(c *C) {
 						},
 					},
 					StatusHostIP: "127.0.0.1",
-					StatusPodIP:  "127.0.0.2",
+					StatusPodIPs: []string{"127.0.0.2"},
 				},
 				o2: &types.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "pod1",
 					},
 					StatusHostIP: "127.0.0.1",
-					StatusPodIP:  "127.0.0.2",
+					StatusPodIPs: []string{"127.0.0.2"},
 				},
 			},
 			want: false,
@@ -394,7 +394,7 @@ func (s *K8sSuite) Test_EqualV1Pod(c *C) {
 						},
 					},
 					StatusHostIP: "127.0.0.1",
-					StatusPodIP:  "127.0.0.2",
+					StatusPodIPs: []string{"127.0.0.2"},
 				},
 				o2: &types.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -404,7 +404,7 @@ func (s *K8sSuite) Test_EqualV1Pod(c *C) {
 						},
 					},
 					StatusHostIP: "127.0.0.1",
-					StatusPodIP:  "127.0.0.2",
+					StatusPodIPs: []string{"127.0.0.2"},
 				},
 			},
 			want: true,
@@ -420,7 +420,7 @@ func (s *K8sSuite) Test_EqualV1Pod(c *C) {
 						},
 					},
 					StatusHostIP: "127.0.0.1",
-					StatusPodIP:  "127.0.0.2",
+					StatusPodIPs: []string{"127.0.0.2"},
 				},
 				o2: &types.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -433,7 +433,7 @@ func (s *K8sSuite) Test_EqualV1Pod(c *C) {
 						},
 					},
 					StatusHostIP: "127.0.0.1",
-					StatusPodIP:  "127.0.0.2",
+					StatusPodIPs: []string{"127.0.0.2"},
 				},
 			},
 			want: false,
@@ -449,7 +449,7 @@ func (s *K8sSuite) Test_EqualV1Pod(c *C) {
 						},
 					},
 					StatusHostIP: "127.0.0.1",
-					StatusPodIP:  "127.0.0.2",
+					StatusPodIPs: []string{"127.0.0.2"},
 				},
 				o2: &types.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -462,7 +462,7 @@ func (s *K8sSuite) Test_EqualV1Pod(c *C) {
 						},
 					},
 					StatusHostIP: "127.0.0.1",
-					StatusPodIP:  "127.0.0.2",
+					StatusPodIPs: []string{"127.0.0.2"},
 				},
 			},
 			want: true,

--- a/pkg/k8s/types/types.go
+++ b/pkg/k8s/types/types.go
@@ -58,7 +58,7 @@ type PodContainer struct {
 type Pod struct {
 	metav1.TypeMeta
 	metav1.ObjectMeta
-	StatusPodIP            string
+	StatusPodIPs           []string
 	StatusHostIP           string
 	SpecServiceAccountName string
 	SpecHostNetwork        bool

--- a/pkg/k8s/types/zz_generated.deepcopy.go
+++ b/pkg/k8s/types/zz_generated.deepcopy.go
@@ -257,6 +257,11 @@ func (in *Pod) DeepCopyInto(out *Pod) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+	if in.StatusPodIPs != nil {
+		in, out := &in.StatusPodIPs, &out.StatusPodIPs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.SpecContainers != nil {
 		in, out := &in.SpecContainers, &out.SpecContainers
 		*out = make([]PodContainer, len(*in))

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -384,6 +384,9 @@ func (k *K8sWatcher) deletePodHostIP(pod *types.Pod) (bool, error) {
 }
 
 func validIPs(ipStrs []string) error {
+	if len(ipStrs) == 0 {
+		return fmt.Errorf("empty PodIPs")
+	}
 	for _, ipStr := range ipStrs {
 		podIP := net.ParseIP(ipStr)
 		if podIP == nil {

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2019 Authors of Cilium
+// Copyright 2016-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,8 +16,10 @@ package watchers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
+	"strings"
 	"sync"
 
 	"github.com/cilium/cilium/pkg/annotation"
@@ -41,7 +43,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -164,7 +166,7 @@ func (k *K8sWatcher) addK8sPodV1(pod *types.Pod) error {
 	logger := log.WithFields(logrus.Fields{
 		logfields.K8sPodName:   pod.ObjectMeta.Name,
 		logfields.K8sNamespace: pod.ObjectMeta.Namespace,
-		"podIP":                pod.StatusPodIP,
+		"podIPs":               pod.StatusPodIPs,
 		"hostIP":               pod.StatusHostIP,
 	})
 
@@ -277,7 +279,7 @@ func (k *K8sWatcher) deleteK8sPodV1(pod *types.Pod) error {
 	logger := log.WithFields(logrus.Fields{
 		logfields.K8sPodName:   pod.ObjectMeta.Name,
 		logfields.K8sNamespace: pod.ObjectMeta.Namespace,
-		"podIP":                pod.StatusPodIP,
+		"podIPs":               pod.StatusPodIPs,
 		"hostIP":               pod.StatusHostIP,
 	})
 
@@ -303,9 +305,9 @@ func (k *K8sWatcher) updatePodHostIP(pod *types.Pod) (bool, error) {
 		return true, fmt.Errorf("no/invalid HostIP: %s", pod.StatusHostIP)
 	}
 
-	podIP := net.ParseIP(pod.StatusPodIP)
-	if podIP == nil {
-		return true, fmt.Errorf("no/invalid PodIP: %s", pod.StatusPodIP)
+	err := validIPs(pod.StatusPodIPs)
+	if err != nil {
+		return true, err
 	}
 
 	hostKey := node.GetIPsecKeyIdentity()
@@ -315,18 +317,28 @@ func (k *K8sWatcher) updatePodHostIP(pod *types.Pod) (bool, error) {
 		PodName:   pod.Name,
 	}
 
-	// Initial mapping of podIP <-> hostIP <-> identity. The mapping is
-	// later updated once the allocator has determined the real identity.
-	// If the endpoint remains unmanaged, the identity remains untouched.
-	selfOwned := ipcache.IPIdentityCache.Upsert(pod.StatusPodIP, hostIP, hostKey, k8sMeta, ipcache.Identity{
-		ID:     identity.ReservedIdentityUnmanaged,
-		Source: source.Kubernetes,
-	})
-	if !selfOwned {
-		return true, fmt.Errorf("ipcache entry owned by kvstore or agent")
+	var (
+		errs    []string
+		skipped bool
+	)
+	for _, podIP := range pod.StatusPodIPs {
+		// Initial mapping of podIP <-> hostIP <-> identity. The mapping is
+		// later updated once the allocator has determined the real identity.
+		// If the endpoint remains unmanaged, the identity remains untouched.
+		selfOwned := ipcache.IPIdentityCache.Upsert(podIP, hostIP, hostKey, k8sMeta, ipcache.Identity{
+			ID:     identity.ReservedIdentityUnmanaged,
+			Source: source.Kubernetes,
+		})
+		if !selfOwned {
+			skipped = true
+			errs = append(errs, fmt.Sprintf("ipcache entry for podIP %s owned by kvstore or agent", podIP))
+		}
+	}
+	if len(errs) != 0 {
+		return skipped, errors.New(strings.Join(errs, ", "))
 	}
 
-	return false, nil
+	return skipped, nil
 }
 
 func (k *K8sWatcher) deletePodHostIP(pod *types.Pod) (bool, error) {
@@ -334,26 +346,52 @@ func (k *K8sWatcher) deletePodHostIP(pod *types.Pod) (bool, error) {
 		return true, fmt.Errorf("pod is using host networking")
 	}
 
-	podIP := net.ParseIP(pod.StatusPodIP)
-	if podIP == nil {
-		return true, fmt.Errorf("no/invalid PodIP: %s", pod.StatusPodIP)
+	err := validIPs(pod.StatusPodIPs)
+	if err != nil {
+		return true, err
 	}
 
-	// a small race condition exists here as deletion could occur in
-	// parallel based on another event but it doesn't matter as the
-	// identity is going away
-	id, exists := ipcache.IPIdentityCache.LookupByIP(pod.StatusPodIP)
-	if !exists {
-		return true, fmt.Errorf("identity for IP does not exist in case")
+	var (
+		errs    []string
+		skipped bool
+	)
+
+	for _, podIP := range pod.StatusPodIPs {
+		// a small race condition exists here as deletion could occur in
+		// parallel based on another event but it doesn't matter as the
+		// identity is going away
+		id, exists := ipcache.IPIdentityCache.LookupByIP(podIP)
+		if !exists {
+			skipped = true
+			errs = append(errs, fmt.Sprintf("identity for IP %s does not exist in case", podIP))
+			continue
+		}
+
+		if id.Source != source.Kubernetes {
+			skipped = true
+			errs = append(errs, fmt.Sprintf("ipcache entry for IP %s not owned by kubernetes source", podIP))
+			continue
+		}
+
+		ipcache.IPIdentityCache.Delete(podIP, source.Kubernetes)
 	}
 
-	if id.Source != source.Kubernetes {
-		return true, fmt.Errorf("ipcache entry not owned by kubernetes source")
+	if len(errs) != 0 {
+		return skipped, errors.New(strings.Join(errs, ", "))
 	}
 
-	ipcache.IPIdentityCache.Delete(pod.StatusPodIP, source.Kubernetes)
+	return skipped, nil
+}
 
-	return false, nil
+func validIPs(ipStrs []string) error {
+	for _, ipStr := range ipStrs {
+		podIP := net.ParseIP(ipStr)
+		if podIP == nil {
+			return fmt.Errorf("no/invalid PodIP: %s", ipStr)
+		}
+	}
+
+	return nil
 }
 
 // GetCachedPod returns a pod from the local store. Depending if the Cilium
@@ -379,7 +417,7 @@ func (k *K8sWatcher) GetCachedPod(namespace, name string) (*types.Pod, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(schema.GroupResource{
+		return nil, k8sErrors.NewNotFound(schema.GroupResource{
 			Group:    "core",
 			Resource: "pod",
 		}, name)

--- a/pkg/strings/slices.go
+++ b/pkg/strings/slices.go
@@ -1,0 +1,35 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package strings
+
+// EqualStrings returns true if both slices are equal.
+func EqualStrings(a, b []string) bool {
+	// If one is nil, the other must also be nil.
+	if (a == nil) != (b == nil) {
+		return false
+	}
+
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/strings/slices_test.go
+++ b/pkg/strings/slices_test.go
@@ -1,0 +1,81 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package strings
+
+import (
+	"testing"
+)
+
+func TestEqualStrings(t *testing.T) {
+	type args struct {
+		a []string
+		b []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "test-1",
+			args: args{
+				a: nil,
+				b: nil,
+			},
+			want: true,
+		},
+		{
+			name: "test-2",
+			args: args{
+				a: []string{""},
+				b: nil,
+			},
+			want: false,
+		},
+		{
+			name: "test-3",
+			args: args{
+				a: nil,
+				b: []string{"foo"},
+			},
+			want: false,
+		},
+		{
+			name: "test-4",
+			args: args{
+				a: []string{"foo"},
+				b: []string{"foo"},
+			},
+			want: true,
+		},
+		{
+			name: "test-5",
+			args: args{
+				a: []string{"bar", "foo"},
+				b: []string{"foo", "bar"},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := EqualStrings(tt.args.a, tt.args.b); got != tt.want {
+				t.Errorf("EqualStrings() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
 * #11240 -- pkg/k8s: add missing support for multi-stack (@aanm)
 * #11282 -- k8s/watchers: do not consider pods with empty podIPs (@aanm)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 11240 11282; do contrib/backporting/set-labels.py $pr done 1.7; done
```