### PR TITLE
Also cast to specific structure if obj is type of cache.DeletedFinalStateUnknown

### DIFF
--- a/operator/ccnp_event.go
+++ b/operator/ccnp_event.go
@@ -115,17 +115,7 @@ func enableCCNPWatcher() error {
 				metrics.EventTSK8s.SetToCurrentTime()
 				cnp := k8s.ObjToSlimCNP(obj)
 				if cnp == nil {
-					deletedObj, ok := obj.(cache.DeletedFinalStateUnknown)
-					if !ok {
-						return
-					}
-					// Delete was not observed by the watcher but is
-					// removed from kube-apiserver. This is the last
-					// known state and the object no longer exists.
-					cnp = k8s.ObjToSlimCNP(deletedObj.Obj)
-					if cnp == nil {
-						return
-					}
+					return
 				}
 				// The derivative policy will be deleted by the parent but need
 				// to delete the cnp from the pooling.

--- a/operator/cnp_event.go
+++ b/operator/cnp_event.go
@@ -123,17 +123,7 @@ func enableCNPWatcher() error {
 				metrics.EventTSK8s.SetToCurrentTime()
 				cnp := k8s.ObjToSlimCNP(obj)
 				if cnp == nil {
-					deletedObj, ok := obj.(cache.DeletedFinalStateUnknown)
-					if !ok {
-						return
-					}
-					// Delete was not observed by the watcher but is
-					// removed from kube-apiserver. This is the last
-					// known state and the object no longer exists.
-					cnp = k8s.ObjToSlimCNP(deletedObj.Obj)
-					if cnp == nil {
-						return
-					}
+					return
 				}
 				// The derivative policy will be deleted by the parent but need
 				// to delete the cnp from the pooling.

--- a/operator/k8s_node.go
+++ b/operator/k8s_node.go
@@ -83,17 +83,7 @@ func runNodeWatcher(nodeManager *ipam.NodeManager) error {
 			DeleteFunc: func(obj interface{}) {
 				n := k8s.ObjToV1Node(obj)
 				if n == nil {
-					deletedObj, ok := obj.(cache.DeletedFinalStateUnknown)
-					if !ok {
-						return
-					}
-					// Delete was not observed by the watcher but is
-					// removed from kube-apiserver. This is the last
-					// known state and the object no longer exists.
-					n = k8s.ObjToV1Node(deletedObj.Obj)
-					if n == nil {
-						return
-					}
+					return
 				}
 				deletedNode := k8s.ParseNode(n, source.Kubernetes)
 				ciliumNodeStore.DeleteLocalKey(context.TODO(), deletedNode)

--- a/operator/k8s_service_sync.go
+++ b/operator/k8s_service_sync.go
@@ -145,17 +145,7 @@ func startSynchronizingServices() {
 				metrics.EventTSK8s.SetToCurrentTime()
 				k8sSvc := k8s.ObjToV1Services(obj)
 				if k8sSvc == nil {
-					deletedObj, ok := obj.(cache.DeletedFinalStateUnknown)
-					if !ok {
-						return
-					}
-					// Delete was not observed by the watcher but is
-					// removed from kube-apiserver. This is the last
-					// known state and the object no longer exists.
-					k8sSvc = k8s.ObjToV1Services(deletedObj.Obj)
-					if k8sSvc == nil {
-						return
-					}
+					return
 				}
 				log.Debugf("Received service deletion %+v", k8sSvc)
 				k8sSvcCache.DeleteService(k8sSvc, swgSvcs)

--- a/operator/k8s_service_sync.go
+++ b/operator/k8s_service_sync.go
@@ -223,17 +223,7 @@ func endpointsInit(k8sClient kubernetes.Interface, swgEps *lock.StoppableWaitGro
 				metrics.EventTSK8s.SetToCurrentTime()
 				k8sEP := k8s.ObjToV1Endpoints(obj)
 				if k8sEP == nil {
-					deletedObj, ok := obj.(cache.DeletedFinalStateUnknown)
-					if !ok {
-						return
-					}
-					// Delete was not observed by the watcher but is
-					// removed from kube-apiserver. This is the last
-					// known state and the object no longer exists.
-					k8sEP = k8s.ObjToV1Endpoints(deletedObj.Obj)
-					if k8sEP == nil {
-						return
-					}
+					return
 				}
 				k8sSvcCache.DeleteEndpoints(k8sEP, swgEps)
 			},

--- a/operator/k8s_service_sync.go
+++ b/operator/k8s_service_sync.go
@@ -271,17 +271,7 @@ func endpointSlicesInit(k8sClient kubernetes.Interface, swgEps *lock.StoppableWa
 				metrics.EventTSK8s.SetToCurrentTime()
 				k8sEP := k8s.ObjToV1EndpointSlice(obj)
 				if k8sEP == nil {
-					deletedObj, ok := obj.(cache.DeletedFinalStateUnknown)
-					if !ok {
-						return
-					}
-					// Delete was not observed by the watcher but is
-					// removed from kube-apiserver. This is the last
-					// known state and the object no longer exists.
-					k8sEP = k8s.ObjToV1EndpointSlice(deletedObj.Obj)
-					if k8sEP == nil {
-						return
-					}
+					return
 				}
 				k8sSvcCache.DeleteEndpointSlices(k8sEP, swgEps)
 			},

--- a/pkg/k8s/watchers/cilium_clusterwide_network_policy.go
+++ b/pkg/k8s/watchers/cilium_clusterwide_network_policy.go
@@ -97,17 +97,7 @@ func (k *K8sWatcher) ciliumClusterwideNetworkPoliciesInit(ciliumNPClient *k8s.K8
 				defer func() { k.K8sEventReceived(metricCCNP, metricDelete, valid, equal) }()
 				cnp := k8s.ObjToSlimCNP(obj)
 				if cnp == nil {
-					deletedObj, ok := obj.(cache.DeletedFinalStateUnknown)
-					if !ok {
-						return
-					}
-					// Delete was not observed by the watcher but is
-					// removed from kube-apiserver. This is the last
-					// known state and the object no longer exists.
-					cnp = k8s.ObjToSlimCNP(deletedObj.Obj)
-					if cnp == nil {
-						return
-					}
+					return
 				}
 				valid = true
 				err := k.deleteCiliumNetworkPolicyV2(cnp)

--- a/pkg/k8s/watchers/cilium_endpoint.go
+++ b/pkg/k8s/watchers/cilium_endpoint.go
@@ -77,17 +77,7 @@ func (k *K8sWatcher) ciliumEndpointsInit(ciliumNPClient *k8s.K8sCiliumClient, as
 					defer func() { k.K8sEventReceived(metricCiliumEndpoint, metricDelete, valid, equal) }()
 					ciliumEndpoint := k8s.ObjToCiliumEndpoint(obj)
 					if ciliumEndpoint == nil {
-						deletedObj, ok := obj.(cache.DeletedFinalStateUnknown)
-						if !ok {
-							return
-						}
-						// Delete was not observed by the watcher but is
-						// removed from kube-apiserver. This is the last
-						// known state and the object no longer exists.
-						ciliumEndpoint = k8s.ObjToCiliumEndpoint(deletedObj.Obj)
-						if ciliumEndpoint == nil {
-							return
-						}
+						return
 					}
 					valid = true
 					k.endpointDeleted(ciliumEndpoint)

--- a/pkg/k8s/watchers/cilium_network_policy.go
+++ b/pkg/k8s/watchers/cilium_network_policy.go
@@ -163,17 +163,7 @@ func (k *K8sWatcher) ciliumNetworkPoliciesInit(ciliumNPClient *k8s.K8sCiliumClie
 				defer func() { k.K8sEventReceived(metricCNP, metricDelete, valid, equal) }()
 				cnp := k8s.ObjToSlimCNP(obj)
 				if cnp == nil {
-					deletedObj, ok := obj.(cache.DeletedFinalStateUnknown)
-					if !ok {
-						return
-					}
-					// Delete was not observed by the watcher but is
-					// removed from kube-apiserver. This is the last
-					// known state and the object no longer exists.
-					cnp = k8s.ObjToSlimCNP(deletedObj.Obj)
-					if cnp == nil {
-						return
-					}
+					return
 				}
 				valid = true
 				err := k.deleteCiliumNetworkPolicyV2(cnp)

--- a/pkg/k8s/watchers/endpoint.go
+++ b/pkg/k8s/watchers/endpoint.go
@@ -68,17 +68,7 @@ func (k *K8sWatcher) endpointsInit(k8sClient kubernetes.Interface, swgEps *lock.
 				defer func() { k.K8sEventReceived(metricEndpoint, metricDelete, valid, equal) }()
 				k8sEP := k8s.ObjToV1Endpoints(obj)
 				if k8sEP == nil {
-					deletedObj, ok := obj.(cache.DeletedFinalStateUnknown)
-					if !ok {
-						return
-					}
-					// Delete was not observed by the watcher but is
-					// removed from kube-apiserver. This is the last
-					// known state and the object no longer exists.
-					k8sEP = k8s.ObjToV1Endpoints(deletedObj.Obj)
-					if k8sEP == nil {
-						return
-					}
+					return
 				}
 				valid = true
 				err := k.deleteK8sEndpointV1(k8sEP, swgEps)

--- a/pkg/k8s/watchers/endpoint_slice.go
+++ b/pkg/k8s/watchers/endpoint_slice.go
@@ -76,17 +76,7 @@ func (k *K8sWatcher) endpointSlicesInit(k8sClient kubernetes.Interface, swgEps *
 				defer func() { k.K8sEventReceived(metricEndpointSlice, metricDelete, valid, equal) }()
 				k8sEP := k8s.ObjToV1EndpointSlice(obj)
 				if k8sEP == nil {
-					deletedObj, ok := obj.(cache.DeletedFinalStateUnknown)
-					if !ok {
-						return
-					}
-					// Delete was not observed by the watcher but is
-					// removed from kube-apiserver. This is the last
-					// known state and the object no longer exists.
-					k8sEP = k8s.ObjToV1EndpointSlice(deletedObj.Obj)
-					if k8sEP == nil {
-						return
-					}
+					return
 				}
 				valid = true
 				k.K8sSvcCache.DeleteEndpointSlices(k8sEP, swgEps)

--- a/pkg/k8s/watchers/network_policy.go
+++ b/pkg/k8s/watchers/network_policy.go
@@ -69,17 +69,7 @@ func (k *K8sWatcher) networkPoliciesInit(k8sClient kubernetes.Interface, swgKNPs
 				defer func() { k.K8sEventReceived(metricKNP, metricDelete, valid, equal) }()
 				k8sNP := k8s.ObjToV1NetworkPolicy(obj)
 				if k8sNP == nil {
-					deletedObj, ok := obj.(cache.DeletedFinalStateUnknown)
-					if !ok {
-						return
-					}
-					// Delete was not observed by the watcher but is
-					// removed from kube-apiserver. This is the last
-					// known state and the object no longer exists.
-					k8sNP = k8s.ObjToV1NetworkPolicy(deletedObj.Obj)
-					if k8sNP == nil {
-						return
-					}
+					return
 				}
 
 				valid = true

--- a/pkg/k8s/watchers/service.go
+++ b/pkg/k8s/watchers/service.go
@@ -65,17 +65,7 @@ func (k *K8sWatcher) servicesInit(k8sClient kubernetes.Interface, swgSvcs *lock.
 				defer func() { k.K8sEventReceived(metricService, metricDelete, valid, equal) }()
 				k8sSvc := k8s.ObjToV1Services(obj)
 				if k8sSvc == nil {
-					deletedObj, ok := obj.(cache.DeletedFinalStateUnknown)
-					if !ok {
-						return
-					}
-					// Delete was not observed by the watcher but is
-					// removed from kube-apiserver. This is the last
-					// known state and the object no longer exists.
-					k8sSvc = k8s.ObjToV1Services(deletedObj.Obj)
-					if k8sSvc == nil {
-						return
-					}
+					return
 				}
 
 				valid = true


### PR DESCRIPTION
Fixes https://github.com/cilium/cilium/issues/11438

```release-note
Gracefully handle lost events from k8s without printing warnings
```