### PR TITLE
k8s: Do not send DeleteService event upon DeleteEndpoints

### DIFF
--- a/pkg/k8s/service_cache.go
+++ b/pkg/k8s/service_cache.go
@@ -230,20 +230,16 @@ func (s *ServiceCache) deleteEndpoints(svcID ServiceID, swg *lock.StoppableWaitG
 
 	svc, serviceOK := s.services[svcID]
 	delete(s.endpoints, svcID)
-	endpoints, serviceReady := s.correlateEndpoints(svcID)
+	endpoints, _ := s.correlateEndpoints(svcID)
 
 	if serviceOK {
 		swg.Add()
 		event := ServiceEvent{
-			Action:    DeleteService,
+			Action:    UpdateService,
 			ID:        svcID,
 			Service:   svc,
 			Endpoints: endpoints,
 			SWG:       swg,
-		}
-
-		if serviceReady {
-			event.Action = UpdateService
 		}
 
 		s.Events <- event

--- a/pkg/k8s/service_cache_test.go
+++ b/pkg/k8s/service_cache_test.go
@@ -255,12 +255,12 @@ func testServiceCache(c *check.C,
 		return true
 	}, 2*time.Second), check.IsNil)
 
-	// Deleting the endpoints will result in a service delete event
+	// Deleting the endpoints will result in a service update event
 	deleteEndpointsCB(&svcCache, swgEps)
 	c.Assert(testutils.WaitUntil(func() bool {
 		event := <-svcCache.Events
 		defer event.SWG.Done()
-		c.Assert(event.Action, check.Equals, DeleteService)
+		c.Assert(event.Action, check.Equals, UpdateService)
 		c.Assert(event.ID, check.Equals, svcID)
 		return true
 	}, 2*time.Second), check.IsNil)


### PR DESCRIPTION
Previously, `DeleteEndpoints()` invocation might have sent `DeleteService`
event (handled by `pkg/k8s/watcher`), if a service didn't have any endpoint
left. This led to a double removal of the service in `pkg/service`, as
kube-apiserver sends a dedicated Service object removal update, which
is handled by `DeleteService()` which sends `DeleteService` event.

This triggered `"service not found"` warning msg.

To fix this, send `UpdateService` event instead of `DeleteService` from
`deleteEndpoints()`, which would trigger only update in svc backends.
The removal of a service is handled by a separate event anyways.

Fix #11399