### PR TITLE
Properly tear down gops agent on shutdown

### DIFF
--- a/daemon/cmd/cleanup.go
+++ b/daemon/cmd/cleanup.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/pidfile"
+	gops "github.com/google/gops/agent"
 
 	"golang.org/x/sys/unix"
 )
@@ -91,6 +92,7 @@ func (d *daemonCleanup) registerSigHandler() <-chan struct{} {
 
 // Clean cleans up everything created by this package.
 func (d *daemonCleanup) Clean() {
+	gops.Close()
 	close(d.cleanUPSig)
 	d.cleanUPWg.Wait()
 }

--- a/hubble-relay/cmd/serve/serve.go
+++ b/hubble-relay/cmd/serve/serve.go
@@ -97,6 +97,9 @@ func runServe(f flags) error {
 		signal.Notify(sigs, unix.SIGINT, unix.SIGTERM)
 		<-sigs
 		srv.Stop()
+		if f.gops {
+			agent.Close()
+		}
 	}()
 	return srv.Serve()
 }

--- a/operator/main.go
+++ b/operator/main.go
@@ -88,6 +88,7 @@ func main() {
 
 	go func() {
 		<-signals
+		gops.Close()
 		close(shutdownSignal)
 	}()
 

--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -85,6 +85,8 @@ func main() {
 		cmdDel,
 		cniVersion.PluginSupports("0.1.0", "0.2.0", "0.3.0", "0.3.1"),
 		"Cilium CNI plugin "+version.Version)
+
+	gops.Close()
 }
 
 func ipv6IsEnabled(ipam *models.IPAMResponse) bool {

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -47,7 +47,7 @@ var (
 
 func init() {
 	// Open socket for using gops to get stacktraces in case the tests deadlock.
-	if err := gops.Listen(gops.Options{}); err != nil {
+	if err := gops.Listen(gops.Options{ShutdownCleanup: true}); err != nil {
 		errorString := fmt.Sprintf("unable to start gops: %s", err)
 		fmt.Println(errorString)
 		os.Exit(-1)


### PR DESCRIPTION
In all executables including the gops agent, make sure the gops agent is
properly teared down on exit and all the temporary files in
`$HOME/.config` created by it are cleaned up on shutdown by calling
`gops/agent.Close()` at the appropriate place.

For #11455