### PR TITLE
bpf: Check native-routing-cidr in BPF masquerade

### DIFF
--- a/bpf/lib/ipv4.h
+++ b/bpf/lib/ipv4.h
@@ -71,6 +71,12 @@ static __always_inline bool ipv4_is_fragment(const struct iphdr *ip4)
 	return ip4->frag_off & bpf_htons(0x3FFF);
 }
 
+static __always_inline bool ipv4_is_in_subnet(__be32 addr,
+					      __be32 subnet, int prefixlen)
+{
+	return (addr & bpf_htonl(~((1<<(32-prefixlen))-1))) == subnet;
+}
+
 #ifdef ENABLE_IPV4_FRAGMENTS
 static __always_inline bool ipv4_is_not_first_fragment(const struct iphdr *ip4)
 {

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -283,6 +283,12 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 
 		if option.Config.EnableBPFMasquerade {
 			cDefinesMap["ENABLE_MASQUERADE"] = "1"
+			if cidr := option.Config.IPv4NativeRoutingCIDR(); cidr != nil {
+				cDefinesMap["IPV4_NATIVE_ROUTING_CIDR"] =
+					fmt.Sprintf("%#x", byteorder.HostSliceToNetwork(cidr.IP, reflect.Uint32).(uint32))
+				ones, _ := cidr.Mask.Size()
+				cDefinesMap["IPV4_NATIVE_ROUTING_CIDR_LEN"] = fmt.Sprintf("%d", ones)
+			}
 		}
 
 		if option.Config.EnableIPMasqAgent {


### PR DESCRIPTION
This commit extends the BPF masquerade by adding a check for whether a dst IPv4 addr is in `native-routing-cidr`.

The check fixes a problem when a node hasn't received an ipcache update for a pod running on a remote node, and thus a packet sent from a local pod to that pod is SNAT'd (this happens because the dst is considered as `WORLD_ID` until the update has been received).

Fix #11464.