### PR TITLE
CI/RuntimePolicies: Replace cilium monitor with hubble observe

### DIFF
--- a/test/helpers/cilium.go
+++ b/test/helpers/cilium.go
@@ -903,6 +903,10 @@ INITSYSTEM=SYSTEMD`
 	return nil
 }
 
+func (s *SSHMeta) SetUpCiliumWithHubble() error {
+	return s.SetUpCiliumWithOptions("--enable-hubble --tofqdns-enable-poller=true")
+}
+
 func (s *SSHMeta) SetUpCiliumWithSockops() error {
 	return s.SetUpCiliumWithOptions("--sockops-enable --tofqdns-enable-poller=true")
 }

--- a/test/helpers/cmd.go
+++ b/test/helpers/cmd.go
@@ -128,6 +128,18 @@ func (res *CmdRes) ExpectMatchesRegexp(regexp string, optionalDescription ...int
 		gomega.MatchRegexp(regexp), optionalDescription...)
 }
 
+// ExpectContainsFilterLine applies the provided JSONPath filter to each line
+// of stdout of the executed command and asserts that the expected string
+// matches at least one of the lines.
+// It accepts an optional parameter that can be used to annotate failure
+// messages.
+func (res *CmdRes) ExpectContainsFilterLine(filter, expected string, optionalDescription ...interface{}) bool {
+	lines, err := res.FilterLines(filter)
+	gomega.ExpectWithOffset(1, err).To(gomega.BeNil(), optionalDescription...)
+	return gomega.ExpectWithOffset(1, expected).Should(
+		gomega.BeElementOf(lines), optionalDescription...)
+}
+
 // ExpectDoesNotContain asserts that a string is not contained in the stdout of
 // the executed command. It accepts an optional parameter that can be used to
 // annotate failure messages.
@@ -142,6 +154,18 @@ func (res *CmdRes) ExpectDoesNotContain(data string, optionalDescription ...inte
 func (res *CmdRes) ExpectDoesNotMatchRegexp(regexp string, optionalDescription ...interface{}) bool {
 	return gomega.ExpectWithOffset(1, res.Output().String()).ToNot(
 		gomega.MatchRegexp(regexp), optionalDescription...)
+}
+
+// ExpectDoesNotContainFilterLine applies the provided JSONPath filter to each
+// line of stdout of the executed command and asserts that the expected string
+// does not matches any of the lines.
+// It accepts an optional parameter that can be used to annotate failure
+// messages.
+func (res *CmdRes) ExpectDoesNotContainFilterLine(filter, expected string, optionalDescription ...interface{}) bool {
+	lines, err := res.FilterLines(filter)
+	gomega.ExpectWithOffset(1, err).To(gomega.BeNil(), optionalDescription...)
+	return gomega.ExpectWithOffset(1, expected).ToNot(
+		gomega.BeElementOf(lines), optionalDescription...)
 }
 
 // CountLines return the number of lines in the stdout of res.

--- a/test/helpers/hubble.go
+++ b/test/helpers/hubble.go
@@ -1,0 +1,54 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helpers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+const (
+	// older versions of the Hubble CLI use a different default path
+	hubbleSock = "unix:///var/run/cilium/hubble.sock"
+)
+
+// HubbleObserve runs `hubble observe --output=json <args>`. JSON output is
+// enabled such that CmdRes.FilterLines may be used to grep for specific events
+// in the output.
+func (s *SSHMeta) HubbleObserve(args ...string) *CmdRes {
+	argsCoalesced := ""
+	if len(args) > 0 {
+		argsCoalesced = strings.Join(args, " ")
+	}
+	hubbleCmd := fmt.Sprintf("hubble observe --server=%q --output=json %s",
+		hubbleSock, argsCoalesced)
+	return s.Exec(hubbleCmd)
+}
+
+// HubbleObserveFollow runs `hubble observe --follow --output=json <args>`. The
+// command is running in the background and will be terminated only once ctx
+// is cancelled. JSON output is enabled such that
+// CmdRes.WaitUntilMatchFilterLine may be used to wait for specific events in
+// the output.
+func (s *SSHMeta) HubbleObserveFollow(ctx context.Context, args ...string) *CmdRes {
+	argsCoalesced := ""
+	if len(args) > 0 {
+		argsCoalesced = strings.Join(args, " ")
+	}
+	hubbleCmd := fmt.Sprintf("hubble observe --server=%q --follow --output=json %s",
+		hubbleSock, argsCoalesced)
+	return s.ExecInBackground(ctx, hubbleCmd)
+}


### PR DESCRIPTION
This replaces all occurrences of `cilium monitor` with `hubble observe` in the `RuntimePolicies` test suite. The motivation for this change is to increase coverage for Hubble without adding additional tests suites.

I tried to stay as faithful as possible to the original intent of the `cilium monitor` invocations, there are however some very minor differences:

- We are using labels (e.g. `[reserved:host]`, `[container:somelabel]`) instead of the numerical identities. This hopefully makes the expected output a bit more human readable and ensures that Hubble annotates the labels correctly.
- The the code grepping for policy verdict events in Hubble doesn't have access to traffic direction field, as it is not available in JSON output of the Hubble v0.5 CLI. Once we update the Runtime VM to use a newer CLI version, this will be fixed, but I don't want to block this PR for this. For now I made sure that the traffic direction is inferred via source/destination/reply combination.

Fixes: #11394
Fixes: #11363 

Reviewable per commit.