### PR TITLE
helm: set hubble-ui securityContext

### DIFF
--- a/install/kubernetes/cilium/charts/hubble-ui/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/hubble-ui/templates/deployment.yaml
@@ -13,6 +13,10 @@ spec:
       labels:
         k8s-app: hubble-ui
     spec:
+      {{- if .Values.securityContext.enabled }}
+      securityContext:
+        runAsUser: 1001
+      {{- end }}
       serviceAccountName: hubble-ui
       containers:
         - name: hubble-ui

--- a/install/kubernetes/cilium/charts/hubble-ui/values.yaml
+++ b/install/kubernetes/cilium/charts/hubble-ui/values.yaml
@@ -21,6 +21,10 @@ replicas: 1
 #         memory: 64Mi
 resources: {}
 
+securityContext:
+  # Incompatible with image version <= v0.5.0
+  enabled: false
+
 serviceAccount:
   annotations: {}
 


### PR DESCRIPTION
The image hubble-ui no longer needs run as root user

**Special notes for your reviewer**:
Do not merge it until new hubble-ui image is released, see corresponding pull request: [cilium/hubble-ui#31](https://github.com/cilium/hubble-ui/pull/31). Tested on k8s (`v1.18`) with enforced  [restricted PSP](https://kubernetes.io/docs/concepts/policy/pod-security-policy/#example-policies).

**UPDATE**:
Set it as optional to not to break `hubble-ui` <= `0.5.0` deployments.

Signed-off-by: Alex Szakaly <alex.szakaly@gmail.com>

Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [X] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.
- [X] Thanks for contributing!

<!-- Description of change -->

Fixes:
N/A
