### PR TITLE
helm: add bpf-policy-map-max option

### DIFF
--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -163,6 +163,10 @@ data:
   # table.
   bpf-nat-global-max: "{{ .Values.global.bpf.natMax }}"
 
+  # bpf-policy-map-max specified the maximum number of entries in endpoint
+  # policy map (per endpoint)
+  bpf-policy-map-max: "{{ .Values.global.bpf.policyMapMax }}"
+
   # Specifies the ratio (0.0-1.0) of total system memory to use for dynamic
   # sizing of the TCP CT, non-TCP CT, NAT and policy BPF maps.
   bpf-map-dynamic-size-ratio: "{{ .Values.global.bpf.mapDynamicSizeRatio }}"

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -235,6 +235,9 @@ global:
     # natMax is the maximum number of entries for the NAT table
     natMax: 524288
 
+    # policyMapMax is the maximum number of entries in endpoint policy map (per endpoint)
+    policyMapMax: 16384
+
     # mapDynamicSizeRatio is the ratio (0.0-1.0) of total system memory to use
     # for dynamic sizing of CT, NAT and policy BPF maps. If set to 0.0, dynamic
     # sizing of BPF maps is disabled. The default value of 0.03 (3%) leads to

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -88,6 +88,10 @@ data:
   # table.
   bpf-nat-global-max: "524288"
 
+  # bpf-policy-map-max specified the maximum number of entries in endpoint
+  # policy map (per endpoint)
+  bpf-policy-map-max: "16384"
+
   # Specifies the ratio (0.0-1.0) of total system memory to use for dynamic
   # sizing of the TCP CT, non-TCP CT, NAT and policy BPF maps.
   bpf-map-dynamic-size-ratio: "0.03"


### PR DESCRIPTION
The source of the default value origin is: v1.7/cmdref/cilium-agent

I faced an issue today which solution and problem statement is described here https://github.com/cilium/cilium/issues/9117

This PR adds an option to let users override the default value `16384`.

**Special notes for your reviewer**:
Please backport to `v1.7` release

Signed-off-by: Alex Szakaly <alex.szakaly@gmail.com>

Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [X] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.
- [X] Thanks for contributing!

<!-- Description of change -->

Fixes:
N/A
