### PR TITLE
bpf: fix circular dependency warning

### DIFF
--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -194,7 +194,7 @@ else
 all: $(TARGET)
 endif
 
-$(TARGET): $(TARGET).c
+$(TARGET): %: %.c
 	@$(ECHO_CC)
 	@# Due to gcc bug, -lelf needs to be at the end.
 	$(QUIET) ${HOST_CC} -Wall -O2 -Wno-format-truncation -I include/ $@.c -lelf -o $@


### PR DESCRIPTION
Commit 8d5654fbfd31 ("bpf: probe and emit kernel hz to node_config")
added a second binary - cilium-probe-kernel-hz - to the definition of
$(TARGET) in bpf/Makefile. This breaks the following rule:

    $(TARGET): $(TARGET).c

which now gets expanded as:

    cilium-map-migrate cilium-probe-kernel-hz: cilium-map-migrate cilium-probe-kernel-hz.c

leading to the warning

    make[1]: Circular cilium-map-migrate <- cilium-map-migrate dependency dropped.

Fix this by rewriting the $(TARGET) rule as a static pattern rule.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>