### PR TITLE
test: Override env variables after parsing command line

### DIFF
--- a/Documentation/contributing/testing/e2e.rst
+++ b/Documentation/contributing/testing/e2e.rst
@@ -442,8 +442,7 @@ This mode expects:
 - A test focus with ``--focus``. ``--focus="K8s*"`` selects all kubernetes tests.
 
 - Cilium images as full URLs specified with the ``--cilium.image`` and
-  ``--cilium.operator-image`` options, with matching ``CILIUM_IMAGE`` and
-  ``CILIUM_OPERATOR_IMAGE`` environment variables.
+  ``--cilium.operator-image`` options.
 
 - A working kubeconfig with the ``--cilium.kubeconfig`` option
 
@@ -461,7 +460,7 @@ An example invocation is
 
 ::
 
-  CNI_INTEGRATION=eks K8S_VERSION=1.13 CILIUM_IMAGE="quay.io/cilium/cilium:latest" CILIUM_OPERATOR_IMAGE="quay.io/cilium/operator:latest" ginkgo --focus="K8s*" -noColor -- -cilium.provision=false -cilium.kubeconfig=`echo ~/.kube/config` -cilium.image="quay.io/cilium/cilium:latest" -cilium.operator-image="quay.io/cilium/operator:latest" -cilium.passCLIEnvironment=true
+  CNI_INTEGRATION=eks K8S_VERSION=1.13 ginkgo --focus="K8s*" -noColor -- -cilium.provision=false -cilium.kubeconfig=`echo ~/.kube/config` -cilium.image="quay.io/cilium/cilium:latest" -cilium.operator-image="quay.io/cilium/operator:latest" -cilium.passCLIEnvironment=true
 
 GKE (experimental)
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -483,7 +482,7 @@ cluster.
 
 ::
 
-  CNI_INTEGRATION=gke K8S_VERSION=1.13 CILIUM_IMAGE="quay.io/cilium/cilium:latest" CILIUM_OPERATOR_IMAGE="quay.io/cilium/operator:latest" ginkgo -v --focus="K8sDemo*" -noColor -- -cilium.provision=false -cilium.kubeconfig=`echo ~/.kube/config` -cilium.image="quay.io/cilium/cilium:latest" -cilium.operator-image="quay.io/cilium/operator:latest" -cilium.passCLIEnvironment=true
+  CNI_INTEGRATION=gke K8S_VERSION=1.13 ginkgo -v --focus="K8sDemo*" -noColor -- -cilium.provision=false -cilium.kubeconfig=`echo ~/.kube/config` -cilium.image="quay.io/cilium/cilium:latest" -cilium.operator-image="quay.io/cilium/operator:latest" -cilium.passCLIEnvironment=true
 
 .. note:: The kubernetes version defaults to 1.13 but can be configured with
           versions between 1.13 and 1.15. Check with ``kubectl version`` 
@@ -501,7 +500,7 @@ cluster.
 
 ::
 
-  CNI_INTEGRATION=eks K8S_VERSION=1.14 CILIUM_IMAGE="quay.io/cilium/cilium:latest" CILIUM_OPERATOR_IMAGE="quay.io/cilium/operator:latest" ginkgo -v --focus="K8sDemo*" -noColor -- -cilium.provision=false -cilium.kubeconfig=`echo ~/.kube/config` -cilium.image="quay.io/cilium/cilium:latest" -cilium.operator-image="quay.io/cilium/operator:latest" -cilium.passCLIEnvironment=true
+  CNI_INTEGRATION=eks K8S_VERSION=1.14 ginkgo -v --focus="K8sDemo*" -noColor -- -cilium.provision=false -cilium.kubeconfig=`echo ~/.kube/config` -cilium.image="quay.io/cilium/cilium:latest" -cilium.operator-image="quay.io/cilium/operator:latest" -cilium.passCLIEnvironment=true
 
 Be sure to pass ``--cilium.passCLIEnvironment=true`` to allow kubectl to invoke ``aws-iam-authenticator``
 

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -179,7 +179,23 @@ func NativeRoutingEnabled() bool {
 	return tunnelDisabled || gkeEnabled
 }
 
-func init() {
+func Init() {
+	if config.CiliumTestConfig.CiliumImage != "" {
+		os.Setenv("CILIUM_IMAGE", config.CiliumTestConfig.CiliumImage)
+	}
+
+	if config.CiliumTestConfig.CiliumOperatorImage != "" {
+		os.Setenv("CILIUM_OPERATOR_IMAGE", config.CiliumTestConfig.CiliumOperatorImage)
+	}
+
+	if config.CiliumTestConfig.Registry != "" {
+		os.Setenv("CILIUM_REGISTRY", config.CiliumTestConfig.Registry)
+	}
+
+	if config.CiliumTestConfig.ProvisionK8s == false {
+		os.Setenv("SKIP_K8S_PROVISION", "true")
+	}
+
 	// Set defaults to match passed-in fully-qualified image
 	// If these are further set via CLI, they will be overwritten below
 	if v := os.Getenv("CILIUM_IMAGE"); v != "" {

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -153,6 +153,8 @@ func reportCreateVMFailure(vm string, err error) {
 }
 
 var _ = BeforeAll(func() {
+	helpers.Init()
+	By("Starting tests: command line parameters: %+v environment variables: %v", config.CiliumTestConfig, os.Environ())
 	go func() {
 		defer GinkgoRecover()
 		time.Sleep(config.CiliumTestConfig.Timeout)
@@ -221,22 +223,6 @@ var _ = BeforeAll(func() {
 		// When finish, start to build cilium in background
 		// Start k8s2
 		// Wait until compilation finished, and pull cilium image on k8s2
-
-		if config.CiliumTestConfig.CiliumImage != "" {
-			os.Setenv("CILIUM_IMAGE", config.CiliumTestConfig.CiliumImage)
-		}
-
-		if config.CiliumTestConfig.CiliumOperatorImage != "" {
-			os.Setenv("CILIUM_OPERATOR_IMAGE", config.CiliumTestConfig.CiliumOperatorImage)
-		}
-
-		if config.CiliumTestConfig.Registry != "" {
-			os.Setenv("CILIUM_REGISTRY", config.CiliumTestConfig.Registry)
-		}
-
-		if config.CiliumTestConfig.ProvisionK8s == false {
-			os.Setenv("SKIP_K8S_PROVISION", "true")
-		}
 
 		// Name for K8s VMs depends on K8s version that is running.
 


### PR DESCRIPTION
This removes the requirement to specify the agent and operator images as
both environment variables and command line options. You can still use
the environment variables to specify the images, but now the command line
options take precedence over the environment variables.

- Move the logic to override environment variables in helpers.Init().
- Call helpers.Init() in BeforeAll to give scopes.go time to parse
  command-line options in its init() function.
- Log command line options and environment variables at the beginning
  of the test.
- Update documentation.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>