### PR TITLE
build(github): Enable helm-check action for master branch

### DIFF
--- a/.github/workflows/helm-check.yaml
+++ b/.github/workflows/helm-check.yaml
@@ -1,9 +1,10 @@
 name: Helm Lint and Test Charts
 
 on:
-  pull_request:
-    paths:
-      - 'install/kubernetes/**'
+  pull_request: {}
+  push:
+    branches:
+      - master
 
 jobs:
   quick-install:


### PR DESCRIPTION
Related to
https://github.com/cilium/cilium/pull/11439#issuecomment-626715892

```release-note
Enable helm-check github action for master branch
```
