### PR TITLE
v1.7 backports 2020-05-12

### DIFF
--- a/install/kubernetes/cilium/templates/NOTES.txt
+++ b/install/kubernetes/cilium/templates/NOTES.txt
@@ -1,4 +1,13 @@
-You have successfully installed {{ title .Chart.Name }}.
+{{- if (and (.Values.preflight.enabled) (not (.Values.agent.enabled)) (not (.Values.config.enabled)) (not (.Values.operator.enabled))) }}
+    You have successfully ran the prefight check.
+    Now make sure to check the number of READY pods is the same as the number of running cilium pods.
+    Then make sure the cilium preflight deployment is also marked READY 1/1.
+    If you have an issues please refer to the CNP Validation section in the upgrade guide.
+{{- else if (not (.Values.config.enabled))}}
+    You have preserved the configMap and successfully installed {{ title .Chart.Name}}.
+{{- else }}
+    You have successfully installed {{ title .Chart.Name }}.
+{{- end }}
 
 Your release version is {{ .Chart.Version }}.
 

--- a/pkg/k8s/service_cache.go
+++ b/pkg/k8s/service_cache.go
@@ -225,20 +225,16 @@ func (s *ServiceCache) deleteEndpoints(svcID ServiceID, swg *lock.StoppableWaitG
 
 	svc, serviceOK := s.services[svcID]
 	delete(s.endpoints, svcID)
-	endpoints, serviceReady := s.correlateEndpoints(svcID)
+	endpoints, _ := s.correlateEndpoints(svcID)
 
 	if serviceOK {
 		swg.Add()
 		event := ServiceEvent{
-			Action:    DeleteService,
+			Action:    UpdateService,
 			ID:        svcID,
 			Service:   svc,
 			Endpoints: endpoints,
 			SWG:       swg,
-		}
-
-		if serviceReady {
-			event.Action = UpdateService
 		}
 
 		s.Events <- event

--- a/pkg/k8s/service_cache_test.go
+++ b/pkg/k8s/service_cache_test.go
@@ -261,12 +261,12 @@ func testServiceCache(c *check.C,
 		return true
 	}, 2*time.Second), check.IsNil)
 
-	// Deleting the endpoints will result in a service delete event
+	// Deleting the endpoints will result in a service update event
 	deleteEndpointsCB(&svcCache, swgEps)
 	c.Assert(testutils.WaitUntil(func() bool {
 		event := <-svcCache.Events
 		defer event.SWG.Done()
-		c.Assert(event.Action, check.Equals, DeleteService)
+		c.Assert(event.Action, check.Equals, UpdateService)
 		c.Assert(event.ID, check.Equals, svcID)
 		return true
 	}, 2*time.Second), check.IsNil)


### PR DESCRIPTION
* #11269 -- Improve Helm post-setup NOTES (@soumynathan)
    * Removed creation of `NOTES.txt` in the `hubble-ui` folder - see https://github.com/cilium/cilium/pull/11269#issuecomment-627187243
    * Omitted Hubble-related info in `install/kubernetes/cilium/templates/NOTES.txt`
* #11467 -- k8s: Do not send DeleteService event upon DeleteEndpoints (@brb)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 11269 11467; do contrib/backporting/set-labels.py $pr done 1.7; done
```