### PR TITLE
pkg/endpoint: return NamedPorts model consistently

### DIFF
--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -305,8 +305,17 @@ func (e *Endpoint) GetHealthModel() *models.EndpointHealth {
 // Must be called with e.Mutex locked.
 func (e *Endpoint) getNamedPortsModel() (np models.NamedPorts) {
 	k8sPorts := e.k8sPorts
+	// keep named ports ordered to avoid the unnecessary updates to
+	// kube-apiserver
+	names := make([]string, 0, len(k8sPorts))
+	for name := range k8sPorts {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
 	np = make(models.NamedPorts, 0, len(k8sPorts))
-	for name, value := range k8sPorts {
+	for _, name := range names {
+		value := k8sPorts[name]
 		np = append(np, &models.Port{
 			Name:     name,
 			Port:     value.Port,


### PR DESCRIPTION
We need to return the NamedPorts consistently across calls of
getNamedPortsModel function. This avoids unnecessary CEP updates to
kube-apiserver.

Fixes: 3a72ffc4f180 ("api: Add named ports")
Signed-off-by: André Martins <andre@cilium.io>