### PR TITLE
loader: Remove unused arguments in DeleteDatapath

### DIFF
--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -132,7 +132,7 @@ func graftDatapath(ctx context.Context, mapPath, objPath, progSec string) error 
 
 // DeleteDatapath filter from the given ifName
 func (l *Loader) DeleteDatapath(ctx context.Context, ifName, direction string) error {
-	args := []string{"filter", "delete", "dev", ifName, direction, "pref", "1", "handle", "1", "bpf"}
+	args := []string{"filter", "delete", "dev", ifName, direction}
 	cmd := exec.CommandContext(ctx, "tc", args...).WithFilters(libbpfFixupMsg)
 	_, err := cmd.CombinedOutput(log, true)
 	if err != nil {


### PR DESCRIPTION
I'm not sure these parameters are taken into account by `tc` when removing filters, but [`init.sh` doesn't specify them](https://github.com/cilium/cilium/blob/d613dea5d52494da703e72ef0011e2849f7f19ce/bpf/init.sh#L325). So let's remove them on Golang as well, for consistency and in case we later end up using them at load time.