### PR TITLE
docs: update list of advanced kernel requirements: fragment tracking

### DIFF
--- a/Documentation/install/system_requirements.rst
+++ b/Documentation/install/system_requirements.rst
@@ -160,6 +160,7 @@ a later kernel version as detailed below:
 ======================= ===============================
 Cilium Feature          Minimum Kernel Version
 ======================= ===============================
+IPv4 fragment tracking  >= 4.10
 :ref:`cidr_limitations` >= 4.11
 :ref:`host-services`    >= 4.19.57, >= 5.1.16,  >= 5.2
 :ref:`kubeproxy-free`   >= 4.19.57, >= 5.1.16,  >= 5.2


### PR DESCRIPTION
Documentation has a list of _“Advanced Features and Required Kernel Version”_. Let's add requirements for fragment tracking to the list: It depends on the availability of LRU maps, which come with [kernel commit 29ba732acbee](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=29ba732acbeece1e34c68483d1ec1f3720fa1bb3)  ("bpf: Add BPF_MAP_TYPE_LRU_HASH").

Fixes: #11295