### PR TITLE
git: ignore cilium yamls created by tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 *.o
 *.a
 *.so
+*.so.*
 
 # LLVM IR files
 *.ll
@@ -11,7 +12,6 @@
 _obj
 _test
 _build/
-hack/
 
 # Architecture specific extensions/prefixes
 *.cgo1.go
@@ -28,7 +28,7 @@ _testmain.go
 
 *.swn
 *.swp
-.vagrant/
+.vagrant
 vagrant.kubeconfig
 coverage.out
 coverage-all.out
@@ -47,29 +47,27 @@ outgoing
 *cscope.in.out
 *cscope.po.out
 *tags
+.gdb_history
 
 man/
 
-# Test files
-test/tmp.yaml
-test/*_service_manifest.json
-test/*_manifest.yaml
-test/*_policy.json
-test/*.xml
 tests/cilium-files
 test/test_results
-test/*.json
 test/.vagrant
+test/tmp.yaml
+test/*_manifest.yaml
+test/*.xml
+test/*.json
+test/*.log
+test/bpf/_results
+test/cilium-[0-9a-f]*.yaml
 
 # Emacs backup files
 *~
 
-# Automatically generated when needed
-.dockerignore
-
-# Temporary files that allow build containers/VMs work without git
-
-test/bpf/_results
-
 # generated from make targets
 *.ok
+*.build_all
+
+# In GIT but ignored for docker
+hack/

--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,6 @@
 # Folders
 _obj
 _test
-tests/cilium-files
-test/test_results
 _build/
 
 # Architecture specific extensions/prefixes
@@ -53,12 +51,13 @@ outgoing
 
 man/
 
-test/tmp.yaml
-test/*_service_manifest.json
-test/*_manifest.yaml
-test/*_policy.json
-test/*.xml
+tests/cilium-files
+test/test_results
 test/.vagrant
+test/tmp.yaml
+test/*_manifest.yaml
+test/*.xml
+test/*.json
 test/*.log
 test/bpf/_results
 test/cilium-[0-9a-f]*.yaml
@@ -66,9 +65,10 @@ test/cilium-[0-9a-f]*.yaml
 # Emacs backup files
 *~
 
-# Temporary files that allow build containers/VMs work without git
-GIT_VERSION
-
 # generated from make targets
 *.ok
 *.build_all
+
+# Temporary files that allow build containers/VMs work without git
+# Not to be ignored by docker.
+GIT_VERSION

--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ test/*.xml
 test/.vagrant
 test/*.log
 test/bpf/_results
+test/cilium-[0-9a-f]*.yaml
 
 # Emacs backup files
 *~


### PR DESCRIPTION
Add 'test/cilium-<xxxx>.yaml' files to .gitignore.

Sync .gitignore and .dockerignore. We used to create .dockerignore from .gitignore on demand. These files have diverged since we included .dockerignore in the git repo. Sync them and move all the material differences to the end with an appropriate comment.
