### PR TITLE
build: Optionally use git for all docker builds with BUILDKIT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ test/*.json
 test/*.log
 test/bpf/_results
 test/cilium-[0-9a-f]*.yaml
+test/*tmp
 
 # Emacs backup files
 *~

--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,4 @@ test/*tmp
 # Temporary files that allow build containers/VMs work without git
 # Not to be ignored by docker.
 GIT_VERSION
+BPF_SRCFILES

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# (first line comment needed for DOCKER_BUILDKIT use)
 #
 # cilium-envoy from github.com/cilium/proxy
 #
@@ -25,10 +26,6 @@ ARG NOSTRIP
 ARG LOCKDEBUG
 ARG V
 ARG LIBNETWORK_PLUGIN
-
-ARG GIT_CHECKOUT
-RUN test -z $GIT_CHECKOUT || git checkout
-
 #
 # Please do not add any dependency updates before the 'make install' here,
 # as that will mess with caching for incremental builds!

--- a/Makefile
+++ b/Makefile
@@ -327,8 +327,8 @@ ifneq ($(shell git status --porcelain),)
 	test $(IGNORE_GIT_STATUS)
 endif
 
-dev-docker-image: check-status clean-build $(DEV_DOCKERFILE) GIT_VERSION
-	git clone --no-checkout --no-local --depth 1 . $(DEV_BUILD_DIR)
+dev-docker-image: check-status $(DEV_DOCKERFILE) GIT_VERSION
+	git clone --no-checkout --no-local --depth 1 . $(DEV_BUILD_DIR) || cd $(DEV_BUILD_DIR) && git fetch --depth=1 --no-tags
 	$(QUIET)$(DOCKER_BUILDKIT) $(CONTAINER_ENGINE) build -f $(DEV_DOCKERFILE) \
 		--build-arg NOSTRIP=${NOSTRIP} \
 		--build-arg LOCKDEBUG=${LOCKDEBUG} \

--- a/Makefile
+++ b/Makefile
@@ -250,7 +250,6 @@ clean-container:
 clean: clean-container clean-build
 	-$(QUIET) $(MAKE) $(SUBMAKEOPTS) -C ./contrib/packaging/deb clean
 	-$(QUIET) $(MAKE) $(SUBMAKEOPTS) -C ./contrib/packaging/rpm clean
-	-$(QUIET) rm -f GIT_VERSION
 	-$(QUIET) docker builder prune --filter type=exec.cachemount -f
 
 clean-build:
@@ -270,8 +269,12 @@ install-container: install-bpf
 	for i in $(SUBDIRS_CILIUM_CONTAINER); do $(MAKE) $(SUBMAKEOPTS) -C $$i install; done
 
 # Workaround for not having git in the build environment
-GIT_VERSION: .git
-	echo "$(GIT_VERSION)" >GIT_VERSION
+# Touch the file only if needed
+GIT_VERSION: force
+	@if [ "$(GIT_VERSION)" != "`cat 2>/dev/null GIT_VERSION`" ] ; then echo "$(GIT_VERSION)" >GIT_VERSION; fi
+
+BPF_SRCFILES: force
+	@if [ "$(BPF_SRCFILES)" != "`cat 2>/dev/null BPF_SRCFILES`" ] ; then echo "$(BPF_SRCFILES)" >BPF_SRCFILES; fi
 
 docker-cilium-image-for-developers:
 	# DOCKER_BUILDKIT allows for faster build as well as the ability to use

--- a/Makefile
+++ b/Makefile
@@ -255,6 +255,10 @@ clean: clean-container clean-build
 clean-build:
 	-$(QUIET) rm -rf _build
 
+veryclean:
+	-$(QUIET) $(CONTAINER_ENGINE) image prune -af
+	-$(QUIET) $(CONTAINER_ENGINE) builder prune -af
+
 install-bpf:
 	$(QUIET)$(INSTALL) -m 0750 -d $(DESTDIR)$(LOCALSTATEDIR)/lib/cilium
 	-rm -rf $(DESTDIR)$(LOCALSTATEDIR)/lib/cilium/bpf/*

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ GOFILES_EVAL := $(subst _$(ROOT_DIR)/,,$(shell $(GO_LIST) -e ./...))
 GOFILES ?= $(GOFILES_EVAL)
 TESTPKGS_EVAL := $(subst github.com/cilium/cilium/,,$(shell echo $(GOFILES) | \
 	sed 's/ /\n/g' | \
-	grep -v '/api/v1\|/vendor\|/contrib' | \
+	grep -v '/api/v1\|/vendor\|/contrib\|/_build' | \
 	grep -v -P 'test(?!/helpers/logutils)'))
 TESTPKGS ?= $(TESTPKGS_EVAL)
 GOLANGVERSION := $(shell $(GO) version 2>/dev/null | grep -Eo '(go[0-9].[0-9])')

--- a/Makefile.buildkit
+++ b/Makefile.buildkit
@@ -1,0 +1,79 @@
+# Copyright 2020 Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+
+ifdef DOCKER_BUILDKIT
+
+# Export with value expected by docker
+export DOCKER_BUILDKIT=1
+
+# Clean the build directory and cache
+clean-build:
+	-$(QUIET) rm -rf $(BUILD_DIR)
+	-$(QUIET) docker builder prune --filter type=exec.cachemount -f
+
+veryclean: clean-build
+
+# Overrides for the main Dockerfile
+DOCKER_BUILD_DIR := $(BUILD_DIR)/context
+CILIUM_DOCKERFILE := $(BUILD_DIR)/cilium.Dockerfile
+OPERATOR_DOCKERFILE := $(BUILD_DIR)/cilium-operator.Dockerfile
+DOCKER_PLUGIN_DOCKERFILE := $(BUILD_DIR)/cilium-docker-plugin.Dockerfile
+HUBBLE_RELAY_DOCKERFILE := $(BUILD_DIR)/hubble-relay.Dockerfile
+
+BUILDKIT_DOCKERFILE_FILTER := | sed -e "1s|^\#.*|\# syntax = docker/dockerfile:experimental|" -e "s|^RUN\(.*\)make|RUN --mount=type=cache,target=/root/.cache/go-build\1make|"
+
+# _build/.git is a shallow bare clone of the main repo
+$(BUILD_DIR)/.git:
+	-mkdir -p $(dir $@)
+	git clone --bare --no-local --depth 1 . $@
+
+#
+# Create _build context:
+# $(DOCKER_BUILD_DIR)/.git will be a file (rather than directory) that contains git specific
+# symbolic link to _build/.git (--separate-git-dir)
+#
+$(DOCKER_BUILD_DIR): $(BUILD_DIR)/.git
+	git init --separate-git-dir=$(BUILD_DIR)/.git $@
+
+#
+# Update the docker build context by:
+# 1. shallow fetch from the main repo to _build/.git
+# 2. check out FETCH_HEAD into _build/context. Hard reset seems to be a best way of doing this.
+# 3. remove the .git file from _build/context/.git so that make running in docker knows this is
+#    no a git repo (as _build/.git is NOT part of the docker context)
+#
+# Dependencies:
+# - check that git status is clean
+# - make sure docker build context exists
+# - update GIT_VERSION in the build context if needed
+# - update BPF_SRCFILES in the build context if needed
+#
+build-context-update: check-status $(DOCKER_BUILD_DIR) $(DOCKER_BUILD_DIR)/GIT_VERSION $(DOCKER_BUILD_DIR)/BPF_SRCFILES
+	@echo "gitdir: ../.git" > $(DOCKER_BUILD_DIR)/.git
+	cd $(BUILD_DIR) && git fetch --depth=1 --no-tags
+	cd $(DOCKER_BUILD_DIR) && git reset --hard FETCH_HEAD && git clean -fd
+	@rm $(DOCKER_BUILD_DIR)/.git
+
+#
+# Docker build context does not contain the actual git repo, so we need to pass
+# GIT_VERSION and/or BPF_SRCFILES to the build context separately.
+#
+$(DOCKER_BUILD_DIR)/GIT_VERSION: GIT_VERSION $(DOCKER_BUILD_DIR)
+	cp $< $@
+$(DOCKER_BUILD_DIR)/BPF_SRCFILES: BPF_SRCFILES $(DOCKER_BUILD_DIR)
+	cp $< $@
+
+# Bare 'Dockerfile' needs a special rule
+$(CILIUM_DOCKERFILE): Dockerfile force
+	@-mkdir -p $(dir $@)
+	@cat $< $(BUILDKIT_DOCKERFILE_FILTER) > $@
+
+# Generic rule for '*.Dockerfile'
+$(BUILD_DIR)/%.Dockerfile: %.Dockerfile force
+	@-mkdir -p $(dir $@)
+	@cat $< $(BUILDKIT_DOCKERFILE_FILTER) > $@
+
+check-status:
+	@if [ -n "`git status --porcelain`" ] ; then git status && echo "These changes will not be included in build, aborting. Define IGNORE_GIT_STATUS to build anyway." && test $(IGNORE_GIT_STATUS); fi
+
+endif

--- a/Makefile.buildkit
+++ b/Makefile.buildkit
@@ -26,6 +26,7 @@ BUILDKIT_DOCKERFILE_FILTER := | sed -e "1s|^\#.*|\# syntax = docker/dockerfile:e
 $(BUILD_DIR)/.git:
 	-mkdir -p $(dir $@)
 	git clone --bare --no-local --depth 1 . $@
+	@cd $(dir $@) && git remote set-url origin "$(shell realpath --relative-to $(dir $@) $(ROOT_DIR))"
 
 #
 # Create _build context:

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -72,9 +72,14 @@ endif
 CILIUM_ENVOY_SHA=$(shell grep -o "FROM.*cilium/cilium-envoy:[0-9a-fA-F]*" $(ROOT_DIR)/Dockerfile | cut -d : -f 2)
 GO_BUILD_LDFLAGS += -X "github.com/cilium/cilium/pkg/envoy.RequiredEnvoyVersionSHA=$(CILIUM_ENVOY_SHA)"
 
-BPF_FILES_EVAL := $(shell git ls-files $(ROOT_DIR)/bpf/ | grep -v .gitignore | tr "\n" ' ')
-BPF_FILES ?= $(BPF_FILES_EVAL)
-BPF_SRCFILES := $(subst ../,,$(BPF_FILES))
+# Use git only if in a Git repo, otherwise depend on file BPF_SRCFILES existing
+ifneq ($(wildcard $(dir $(lastword $(MAKEFILE_LIST)))/.git),)
+	BPF_FILES_EVAL = $(shell git ls-files $(ROOT_DIR)/bpf/ | grep -v .gitignore | tr "\n" ' ')
+	BPF_FILES ?= $(BPF_FILES_EVAL)
+	BPF_SRCFILES := $(subst ../,,$(BPF_FILES))
+else
+	BPF_SRCFILES = $(shell cat $(ROOT_DIR)/BPF_SRCFILES)
+endif
 
 CILIUM_DATAPATH_SHA=$(shell cat $(BPF_FILES) | sha1sum | awk '{print $$1}')
 GO_BUILD_LDFLAGS += -X "github.com/cilium/cilium/pkg/datapath/loader.DatapathSHA=$(CILIUM_DATAPATH_SHA)"

--- a/cilium-docker-plugin.Dockerfile
+++ b/cilium-docker-plugin.Dockerfile
@@ -1,3 +1,5 @@
+# (first line comment needed for DOCKER_BUILDKIT use)
+#
 FROM docker.io/library/golang:1.14.3 as builder
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}

--- a/cilium-operator.Dockerfile
+++ b/cilium-operator.Dockerfile
@@ -1,3 +1,5 @@
+# (first line comment needed for DOCKER_BUILDKIT use)
+#
 FROM docker.io/library/golang:1.14.3 as builder
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}

--- a/contrib/scripts/check-assert-deep-equals.sh
+++ b/contrib/scripts/check-assert-deep-equals.sh
@@ -8,7 +8,7 @@
 set -eu
 
 if grep -IPRns 'c.Assert\(.*, (check\.)?DeepEquals, .*\)' \
-        --exclude-dir=vendor \
+        --exclude-dir={.git,_build,vendor} \
         --include=*.go; then
     echo "Found tests which use DeepEquals checker imported from check.v1."
     echo "Cilium implements its own DeepEquals checker which can be imported from:"

--- a/contrib/scripts/check-fmt.sh
+++ b/contrib/scripts/check-fmt.sh
@@ -5,6 +5,7 @@ set -o pipefail
 
 diff="$(find . ! \( -path './contrib' -prune \) \
         ! \( -path './vendor' -prune \) \
+        ! \( -path './_build' -prune \) \
         ! \( -path './.git' -prune \) \
         ! \( -path '*.validate.go' -prune \) \
         -type f -name '*.go' | xargs gofmt -d -l -s )"

--- a/contrib/scripts/check-k8s-code-gen.sh
+++ b/contrib/scripts/check-k8s-code-gen.sh
@@ -4,9 +4,9 @@ set -e
 set -o pipefail
 
 # Delete all zz_generated.deepcopy.go files
-find . -not -path "./vendor/*" -iname "*zz_generated.deepcopy.go" -exec rm  {} \;
+find . -not -path "./vendor/*" -not -path "./_build/*" -iname "*zz_generated.deepcopy.go" -exec rm  {} \;
 # Delete all zz_generated.deepequal.go files
-find . -not -path "./vendor/*" -iname "*zz_generated.deepequal.go" -exec rm  {} \;
+find . -not -path "./vendor/*" -not -path "./_build/*" -iname "*zz_generated.deepequal.go" -exec rm  {} \;
 
 # Generate all files
 make generate-k8s-api

--- a/contrib/scripts/check-log-newlines.sh
+++ b/contrib/scripts/check-log-newlines.sh
@@ -2,11 +2,8 @@
 
 set -e
 
-if grep --include \*.go -r 'log\.' . | grep -v vendor \
-  | grep -v envoy \
-  | grep -v contrib \
-  | grep -v logging.go \
-  | grep -v pkg/k8s/slim/k8s/apis/util/intstr/intsrt.go \
+if grep -r 'log\.' --include=\*.go --exclude-dir={.git,_build,vendor,envoy,contrib} . \
+  | grep -v -e logging.go -e pkg/k8s/slim/k8s/apis/util/intstr/intsrt.go \
   | grep -F "\n"; then
   echo "found newline(s) in log call(s), please remove ending \n"
   exit 1

--- a/contrib/scripts/check-logging-subsys-field.sh
+++ b/contrib/scripts/check-logging-subsys-field.sh
@@ -11,15 +11,14 @@
 # - pkg/debugdetection
 # - test/
 # - vendor/
+# - _build/
 # are excluded, because instances of DefaultLogger in those modules have their
 # specific usage which doesn't break the Prometheus logging hook.
 
 set -eu
 
 if grep -IPRns '(?!.*LogSubsys)log[ ]*= logging\.DefaultLogger.*' \
-        --exclude-dir=test \
-        --exclude-dir=pkg/debugdetection \
-        --exclude-dir=vendor \
+        --exclude-dir={.git,_build,vendor,test,pkg/debugdetection} \
         --include=*.go .; then
     echo "Logging entry instances have to contain the LogSubsys field. Example of"
     echo "properly configured entry instance:"

--- a/contrib/scripts/check-missing-tags-in-tests.sh
+++ b/contrib/scripts/check-missing-tags-in-tests.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
-set -e
-
-if grep -L --include \*_test.go '// +build' . -r | grep -v vendor | grep -v test/ ; then
-  echo "Test file(s) does not contain a tag privileged_tests or !privileged_tests tags"
+files_missing_build_tag="`grep -L -r '// +build' . --include \*_test.go \
+    --exclude-dir={.git,_build,vendor,test}`"
+if [ -n "$files_missing_build_tag" ]; then
+  echo "Test file(s) does not contain a tag privileged_tests or !privileged_tests tags:"
+  echo $files_missing_build_tag
   exit 1
 fi

--- a/contrib/scripts/lock-check.sh
+++ b/contrib/scripts/lock-check.sh
@@ -16,7 +16,7 @@
 
 # Used to cause failure when pkg/lock is not used
 for l in sync.Mutex sync.RWMutex; do
-  if grep -r --exclude-dir={vendor,externalversions,lock,contrib} -i --include \*.go "$l" .; then
+  if grep -r --exclude-dir={.git,_build,vendor,externalversions,lock,contrib} -i --include \*.go "$l" .; then
     echo "Found $l usage. Please use pkg/lock instead to improve deadlock detection";
     exit 1
   fi

--- a/contrib/scripts/rand-check.sh
+++ b/contrib/scripts/rand-check.sh
@@ -8,6 +8,8 @@
 for l in rand\.NewSource; do
   m=$(find . -name "*.go" \
 	  -not -name "*_test.go" \
+	  -not -path "./.git/*" \
+	  -not -path "./_build/*" \
 	  -not -path "./contrib/*" \
 	  -not -path "./pkg/rand/*" \
 	  -not -path "./vendor/*" \

--- a/hubble-relay.Dockerfile
+++ b/hubble-relay.Dockerfile
@@ -1,3 +1,5 @@
+# (first line comment needed for DOCKER_BUILDKIT use)
+#
 FROM docker.io/library/golang:1.14.3 as builder
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}


### PR DESCRIPTION
Make building with DOCKER_BUILDKIT and using a shallow git clone as
the build context opt-in: the developer must define DOCKER_BUILDKIT to
use these. When DOCKER_BUILDKIT is defined, the following takes place:

1. A separate docker build directory for all docker image targets is
used. This makes sure the build context only contains the files in git
and none of the other files that may exist in the working
directory. '_build' in the repo is used as the root of the build
directory by default (can be overridden by defining BUILD_DIR). A
shallow bare git clone of the main repo is created in '_build/.git',
which is checked out into '_build/context'.

The build context is subsequently synced with git fetch to avoid
overwriting all files. This makes docker build context sync much
faster and allows docker to use cached build stages.

2. The .git directory is left out of the build context, so that any
changes in there will not affect docker build stage caching. During
the build context sync a file '_build/context/.git' points to
'_build_.git', but that is removed before the context is handed to
docker.

3. BUILD_DIR can be passed in to specify an alternate build root
(replacing the default '_build'). This is beneficial in keeping the
main repo directory cleaner, and also to avoid slow file I/O in a
shared file system (e.g, between the host and a CI VM).

A new make target `veryclean` that guts docker caches has been added.
This may help resolve the issue where Docker fails to actually load an image
(e.g., cilium-builder) which leads to weird issues like `/bin/sh` not found.

Testing this on a MacBook Pro yielded the following results:

- Clean and build cilium, cilium-docker-plugin, cilium-operator, and hubble-relay

Before these changes:
$ time make docker-image
8m17.558s

After:
$ time make docker-image
5m35.515s

$ DOCKER_BUILDKIT=1 time make docker-image
2m49.41s

Fixes: #11443
