### PR TITLE
build: Add bpf to PATH for privileged tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ tests-privileged:
 	$(QUIET) $(MAKE) $(SUBMAKEOPTS) -C bpf cilium-map-migrate
 	$(MAKE) init-coverage
 	for pkg in $(patsubst %,github.com/cilium/cilium/%,$(PRIV_TEST_PKGS)); do \
-		$(GO_TEST) $(TEST_LDFLAGS) $$pkg $(GOTEST_PRIV_OPTS) $(GOTEST_COVER_OPTS) \
+		PATH=$(PATH):$(ROOT_DIR)/bpf $(GO_TEST) $(TEST_LDFLAGS) $$pkg $(GOTEST_PRIV_OPTS) $(GOTEST_COVER_OPTS) \
 		|| exit 1; \
 		tail -n +2 coverage.out >> coverage-all-tmp.out; \
 	done


### PR DESCRIPTION
Privileged unit tests need 'cilium-map-migrate' which is built for them,
but the tests can't find it as it is not in the PATH. Add 'bpf' to the
PATH to fix this.

Fix #10838
Fix #11512