### PR TITLE
test: Aid flake debugging

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1186,7 +1186,14 @@ func (kub *Kubectl) NamespaceLabel(namespace string, label string) *CmdRes {
 // the aforementioned desired state within timeout seconds. Returns false and
 // an error if the command failed or the timeout was exceeded.
 func (kub *Kubectl) WaitforPods(namespace string, filter string, timeout time.Duration) error {
-	return kub.waitForNPods(checkReady, namespace, filter, 0, timeout)
+	ginkgoext.By("WaitforPods(namespace=%q, filter=%q)", namespace, filter)
+	err := kub.waitForNPods(checkReady, namespace, filter, 0, timeout)
+	ginkgoext.By("WaitforPods(namespace=%q, filter=%q) => %v", namespace, filter, err)
+	if err != nil {
+		desc := kub.ExecShort(fmt.Sprintf("%s describe pods -n %s %s", KubectlCmd, namespace, filter))
+		ginkgoext.By(desc.GetDebugMessage())
+	}
+	return err
 }
 
 // checkPodStatusFunc returns true if the pod is in the desired state, or false
@@ -1224,7 +1231,14 @@ func checkReady(pod v1.Pod) bool {
 // When minRequired is 0, the function will derive required pod count from number
 // of pods in the cluster for every iteration.
 func (kub *Kubectl) WaitforNPodsRunning(namespace string, filter string, minRequired int, timeout time.Duration) error {
-	return kub.waitForNPods(checkRunning, namespace, filter, minRequired, timeout)
+	ginkgoext.By("WaitforNPodsRunning(namespace=%q, filter=%q)", namespace, filter)
+	err := kub.waitForNPods(checkRunning, namespace, filter, minRequired, timeout)
+	ginkgoext.By("WaitforNPods(namespace=%q, filter=%q) => %v", namespace, filter, err)
+	if err != nil {
+		desc := kub.ExecShort(fmt.Sprintf("%s describe pods -n %s %s", KubectlCmd, namespace, filter))
+		ginkgoext.By(desc.GetDebugMessage())
+	}
+	return err
 }
 
 // WaitforNPods waits up until timeout seconds have elapsed for at least
@@ -1236,7 +1250,14 @@ func (kub *Kubectl) WaitforNPodsRunning(namespace string, filter string, minRequ
 // When minRequired is 0, the function will derive required pod count from number
 // of pods in the cluster for every iteration.
 func (kub *Kubectl) WaitforNPods(namespace string, filter string, minRequired int, timeout time.Duration) error {
-	return kub.waitForNPods(checkReady, namespace, filter, minRequired, timeout)
+	ginkgoext.By("WaitforNPods(namespace=%q, filter=%q)", namespace, filter)
+	err := kub.waitForNPods(checkReady, namespace, filter, minRequired, timeout)
+	ginkgoext.By("WaitforNPods(namespace=%q, filter=%q) => %v", namespace, filter, err)
+	if err != nil {
+		desc := kub.ExecShort(fmt.Sprintf("%s describe pods -n %s %s", KubectlCmd, namespace, filter))
+		ginkgoext.By(desc.GetDebugMessage())
+	}
+	return err
 }
 
 func (kub *Kubectl) waitForNPods(checkStatus checkPodStatusFunc, namespace string, filter string, minRequired int, timeout time.Duration) error {

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1805,8 +1805,8 @@ func (kub *Kubectl) GetDefaultIface() (string, error) {
 func (kub *Kubectl) DeleteCiliumDS() error {
 	// Do not assert on success in AfterEach intentionally to avoid
 	// incomplete teardown.
-
-	_ = kub.DeleteResource("ds", fmt.Sprintf("-n %s cilium", GetCiliumNamespace(GetCurrentIntegration())))
+	ginkgoext.By("DeleteCiliumDS(namespace=%q)", CiliumNamespace)
+	_ = kub.DeleteResource("ds", fmt.Sprintf("-n %s cilium", CiliumNamespace))
 	return kub.waitToDelete("Cilium", CiliumAgentLabel)
 }
 


### PR DESCRIPTION
Just a few simple changes that add some useful output for debugging our flakes when pod waiters fail and Cilium daemonset deletion races (#11497).