### PR TITLE
v1.7 backports 2020-05-13

### DIFF
--- a/daemon/cleanup.go
+++ b/daemon/cleanup.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/pidfile"
+	gops "github.com/google/gops/agent"
 )
 
 var cleaner = &daemonCleanup{
@@ -90,6 +91,7 @@ func (d *daemonCleanup) registerSigHandler() <-chan struct{} {
 
 // Clean cleans up everything created by this package.
 func (d *daemonCleanup) Clean() {
+	gops.Close()
 	close(d.cleanUPSig)
 	d.cleanUPWg.Wait()
 }

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -132,6 +132,10 @@ data:
   bpf-ct-global-tcp-max: "{{ .Values.global.bpf.ctTcpMax }}"
   bpf-ct-global-any-max: "{{ .Values.global.bpf.ctAnyMax }}"
 
+  # bpf-policy-map-max specified the maximum number of entries in endpoint
+  # policy map (per endpoint)
+  bpf-policy-map-max: "{{ .Values.global.bpf.policyMapMax }}"
+
   # Pre-allocation of map entries allows per-packet latency to be reduced, at
   # the expense of up-front memory allocation for the entries in the maps. The
   # default value below will minimize memory usage in the default installation;

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -206,7 +206,10 @@ global:
     # tracking table
     ctAnyMax: 262144
 
-    # montiorAggregation is the level of aggregation for datapath trace events
+    # policyMapMax is the maximum number of entries in endpoint policy map (per endpoint)
+    policyMapMax: 16384
+
+    # monitorAggregation is the level of aggregation for datapath trace events
     monitorAggregation: medium
 
     # monitorInterval is the typical time between monitor notifications for

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -1,4 +1,18 @@
 ---
+# Source: cilium/charts/agent/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cilium
+  namespace: kube-system
+---
+# Source: cilium/charts/operator/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+---
 # Source: cilium/charts/config/templates/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -129,25 +143,12 @@ data:
   enable-host-reachable-services: "false"
   enable-external-ips: "false"
   enable-node-port: "false"
+  node-port-bind-protection: "true"
   enable-auto-protect-node-port-range: "true"
   # Chaining mode is set to portmap, enable health checking
   enable-endpoint-health-checking: "true"
   enable-well-known-identities: "false"
   enable-remote-node-identity: "true"
----
-# Source: cilium/charts/agent/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: cilium
-  namespace: kube-system
----
-# Source: cilium/charts/operator/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: cilium-operator
-  namespace: kube-system
 ---
 # Source: cilium/charts/agent/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -61,6 +61,10 @@ data:
   bpf-ct-global-tcp-max: "524288"
   bpf-ct-global-any-max: "262144"
 
+  # bpf-policy-map-max specified the maximum number of entries in endpoint
+  # policy map (per endpoint)
+  bpf-policy-map-max: "16384"
+
   # Pre-allocation of map entries allows per-packet latency to be reduced, at
   # the expense of up-front memory allocation for the entries in the maps. The
   # default value below will minimize memory usage in the default installation;

--- a/operator/main.go
+++ b/operator/main.go
@@ -86,6 +86,7 @@ func main() {
 
 	go func() {
 		<-signals
+		gops.Close()
 		close(shutdownSignal)
 	}()
 

--- a/plugins/cilium-cni/cilium-cni.go
+++ b/plugins/cilium-cni/cilium-cni.go
@@ -87,6 +87,8 @@ func main() {
 		cmdDel,
 		cniVersion.PluginSupports("0.1.0", "0.2.0", "0.3.0", "0.3.1"),
 		"Cilium CNI plugin "+version.Version)
+
+	gops.Close()
 }
 
 func ipv6IsEnabled(ipam *models.IPAMResponse) bool {

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -48,7 +48,7 @@ var (
 func init() {
 
 	// Open socket for using gops to get stacktraces in case the tests deadlock.
-	if err := gops.Listen(gops.Options{}); err != nil {
+	if err := gops.Listen(gops.Options{ShutdownCleanup: true}); err != nil {
 		errorString := fmt.Sprintf("unable to start gops: %s", err)
 		fmt.Println(errorString)
 		os.Exit(-1)


### PR DESCRIPTION
* #11478 -- helm: add bpf-policy-map-max option (@alex1989hu)
   * Minor rebase necessary.
 * #11471 -- Properly tear down gops agent on shutdown (@tklauser)
   * Dropped hubble changes that don't exist in v1.7.
 * Added extra commit to regenerate quick-install YAML from tree as recent
   backports didn't do so.

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 11478 11471; do contrib/backporting/set-labels.py $pr done 1.7; done
```