### PR TITLE
nat: Do not inc error metric from CT GC if related NAT entry not found

### DIFF
--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -294,7 +294,7 @@ func newMap(mapName string, m mapType) *Map {
 }
 
 func purgeCtEntry6(m *Map, key CtKey, natMap NatMap) error {
-	err := m.Delete(key)
+	err := m.DeleteButIgnoreMetricErrorCountInc(key, true)
 	if err == nil && natMap != nil {
 		natMap.DeleteMapping(key.GetTupleKey())
 	}
@@ -374,7 +374,7 @@ func doGC6(m *Map, filter *GCFilter) gcStats {
 }
 
 func purgeCtEntry4(m *Map, key CtKey, natMap NatMap) error {
-	err := m.Delete(key)
+	err := m.DeleteButIgnoreMetricErrorCountInc(key, true)
 	if err == nil && natMap != nil {
 		natMap.DeleteMapping(key.GetTupleKey())
 	}

--- a/pkg/maps/nat/nat.go
+++ b/pkg/maps/nat/nat.go
@@ -211,8 +211,8 @@ func deleteMapping4(m *Map, ctKey *tuple.TupleKey4Global) error {
 		rkey.DestPort = val.Port
 		rkey.Flags = tuple.TUPLE_F_IN
 
-		m.Delete(&key)
-		m.Delete(&rkey)
+		m.DeleteButIgnoreMetricErrorCountInc(&key, true)
+		m.DeleteButIgnoreMetricErrorCountInc(&rkey, true)
 	}
 	return nil
 }
@@ -235,8 +235,8 @@ func deleteMapping6(m *Map, ctKey *tuple.TupleKey6Global) error {
 		rkey.DestPort = val.Port
 		rkey.Flags = tuple.TUPLE_F_IN
 
-		m.Delete(&key)
-		m.Delete(&rkey)
+		m.DeleteButIgnoreMetricErrorCountInc(&key, true)
+		m.DeleteButIgnoreMetricErrorCountInc(&rkey, true)
 	}
 	return nil
 }
@@ -249,7 +249,7 @@ func deleteSwappedMapping4(m *Map, ctKey *tuple.TupleKey4Global) error {
 	key.SourcePort = key.DestPort
 	key.DestPort = port
 	key.Flags = tuple.TUPLE_F_OUT
-	m.Delete(&key)
+	m.DeleteButIgnoreMetricErrorCountInc(&key, true)
 
 	return nil
 }
@@ -262,7 +262,7 @@ func deleteSwappedMapping6(m *Map, ctKey *tuple.TupleKey6Global) error {
 	key.SourcePort = key.DestPort
 	key.DestPort = port
 	key.Flags = tuple.TUPLE_F_OUT
-	m.Delete(&key)
+	m.DeleteButIgnoreMetricErrorCountInc(&key, true)
 
 	return nil
 }


### PR DESCRIPTION
This PR adds in an additional param to bpf.Map Delete() so that the
error metric count increment can be controlled if the entry not found.

Fixes: #11485
Signed-off-by: Swaminathan Vasudevan <svasudevan@suse.com>

