### PR TITLE
doc: Change machine-type to n1-standard-4 for GKE guide

### DIFF
--- a/Documentation/gettingstarted/k8s-install-gke.rst
+++ b/Documentation/gettingstarted/k8s-install-gke.rst
@@ -39,7 +39,13 @@ using the `Google Cloud SDK <https://cloud.google.com/sdk/>`_.
 .. code:: bash
 
     export CLUSTER_NAME=cluster1
-    gcloud container clusters create $CLUSTER_NAME --image-type COS --num-nodes 2
+    gcloud container clusters create $CLUSTER_NAME --image-type COS --num-nodes 2 --machine-type n1-standard-4
+
+Retrieve the credentials to access the cluster:
+
+.. code:: bash
+
+    gcloud container clusters get-credentials tgraf-test
 
 When done, you should be able to access your cluster like this:
 


### PR DESCRIPTION
Due to defaulting to a CPU request of 0.1 core for all pods, the number
of pods on the single core machine type is limited and insufficient to
ru the connectivity-check deployment at times.

Switch to a 4 core machine type to achieve a reliable
connectivity-check result.
