### PR TITLE
istio: Update to 1.5.4

### DIFF
--- a/Documentation/gettingstarted/istio.rst
+++ b/Documentation/gettingstarted/istio.rst
@@ -29,20 +29,20 @@ Step 2: Install cilium-istioctl
 
    Make sure that Cilium is running in your cluster before proceeding.
 
-Download the `cilium enhanced istioctl version 1.5.2 <https://github.com/cilium/istio/releases/tag/1.5.2>`_:
+Download the `cilium enhanced istioctl version 1.5.4 <https://github.com/cilium/istio/releases/tag/1.5.4>`_:
 
 .. tabs::
   .. group-tab:: Linux
 
     .. parsed-literal::
 
-     curl -L https://github.com/cilium/istio/releases/download/1.5.2/cilium-istioctl-1.5.2-linux.tar.gz | tar xz
+     curl -L https://github.com/cilium/istio/releases/download/1.5.4/cilium-istioctl-1.5.4-linux.tar.gz | tar xz
 
   .. group-tab:: OSX
 
     .. parsed-literal::
 
-     curl -L https://github.com/cilium/istio/releases/download/1.5.2/cilium-istioctl-1.5.2-osx.tar.gz | tar xz
+     curl -L https://github.com/cilium/istio/releases/download/1.5.4/cilium-istioctl-1.5.4-osx.tar.gz | tar xz
 
 .. note::
 

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -197,7 +197,7 @@ data:
 
   # Regular expression matching compatible Istio sidecar istio-proxy
   # container image names
-  sidecar-istio-proxy-image: "cilium/istio_proxy"
+  sidecar-istio-proxy-image: "{{ .Values.global.proxy.sidecarImageRegex }}"
 
   # Encapsulation mode for communication between nodes
   # Possible values:

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -498,3 +498,8 @@ global:
       clusterPoolIPv4MaskSize: 24
       clusterPoolIPv6PodCIDR: "fd00::/104"
       clusterPoolIPv6MaskSize: 120
+
+  proxy:
+    # Regular expression matching compatible Istio sidecar istio-proxy
+    # container image names
+    sidecarImageRegex: "cilium/istio_proxy"

--- a/test/k8sT/istio.go
+++ b/test/k8sT/istio.go
@@ -35,9 +35,23 @@ var _ = Describe("K8sIstioTest", func() {
 		// installed.
 		istioSystemNamespace = "istio-system"
 
-		istioVersion = "1.5.2"
+		istioVersion = "1.5.4"
 
-		ciliumIstioctlURL = "https://github.com/cilium/istio/releases/download/" + istioVersion + "/cilium-istioctl-" + istioVersion + "-linux.tar.gz"
+		// Modifiers for pre-release testing, normally empty
+		prerelease     = "" // "-beta.1"
+		istioctlParams = ""
+		// Keeping these here in comments serve multiple purposes:
+		// - remind how to test with prerelease images in future
+		// - cause CI infra to prepull these images so that they do not
+		//   need to be pulled on demand during the test
+		// " --set values.pilot.image=docker.io/cilium/istio_pilot:1.5.4" +
+		// " --set values.global.proxy.image=docker.io/cilium/istio_proxy:1.5.4" +
+		// " --set values.global.proxy_init.image=docker.io/cilium/istio_proxy:1.5.4"
+		ciliumOptions = map[string]string{
+			// "global.proxy.sidecarImageRegex": "jrajahalme/istio_proxy",
+		}
+
+		ciliumIstioctlURL = "https://github.com/cilium/istio/releases/download/" + istioVersion + prerelease + "/cilium-istioctl-" + istioVersion + "-linux.tar.gz"
 		// istioServiceNames is the set of Istio services needed for the tests
 		istioServiceNames = []string{
 			"istio-ingressgateway",
@@ -72,14 +86,14 @@ var _ = Describe("K8sIstioTest", func() {
 		res.ExpectSuccess("unable to execute cilium-istioctl")
 
 		ciliumFilename = helpers.TimestampFilename("cilium.yaml")
-		DeployCiliumAndDNS(kubectl, ciliumFilename)
+		DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, ciliumOptions)
 
 		By("Labeling default namespace for sidecar injection")
 		res = kubectl.NamespaceLabel(helpers.DefaultNamespace, "istio-injection=enabled")
 		res.ExpectSuccess("unable to label namespace %q", helpers.DefaultNamespace)
 
 		By("Deplying Istio")
-		res = kubectl.Exec("./cilium-istioctl manifest apply -y")
+		res = kubectl.Exec("./cilium-istioctl manifest apply -y" + istioctlParams)
 		res.ExpectSuccess("unable to deploy Istio")
 	})
 
@@ -177,10 +191,10 @@ var _ = Describe("K8sIstioTest", func() {
 		})
 
 		// shouldConnect checks that srcPod can connect to dstURI.
-		shouldConnect := func(srcPod, dstURI string) bool {
+		shouldConnect := func(srcPod, srcContainer, dstURI string) bool {
 			By("Checking that %q can connect to %q", srcPod, dstURI)
-			res := kubectl.ExecPodCmd(
-				helpers.DefaultNamespace, srcPod, fmt.Sprintf("%s %s", wgetCommand, dstURI))
+			res := kubectl.ExecPodContainerCmd(
+				helpers.DefaultNamespace, srcPod, srcContainer, fmt.Sprintf("%s %s", wgetCommand, dstURI))
 			if !res.WasSuccessful() {
 				GinkgoPrint("Unable to connect from %q to %q: %s", srcPod, dstURI, res.OutputPrettyPrint())
 				return false
@@ -189,10 +203,10 @@ var _ = Describe("K8sIstioTest", func() {
 		}
 
 		// shouldNotConnect checks that srcPod cannot connect to dstURI.
-		shouldNotConnect := func(srcPod, dstURI string) bool {
+		shouldNotConnect := func(srcPod, srcContainer, dstURI string) bool {
 			By("Checking that %q cannot connect to %q", srcPod, dstURI)
-			res := kubectl.ExecPodCmd(
-				helpers.DefaultNamespace, srcPod, fmt.Sprintf("%s %s", wgetCommand, dstURI))
+			res := kubectl.ExecPodContainerCmd(
+				helpers.DefaultNamespace, srcPod, srcContainer, fmt.Sprintf("%s %s", wgetCommand, dstURI))
 			if res.WasSuccessful() {
 				GinkgoPrint("Was able to connect from %q to %q, but expected no connection: %s", srcPod, dstURI, res.OutputPrettyPrint())
 				return false
@@ -305,13 +319,13 @@ var _ = Describe("K8sIstioTest", func() {
 			err = helpers.WithTimeout(func() bool {
 				allGood := true
 
-				allGood = shouldConnect(reviewsPodV1.String(), formatAPI(ratings, apiPort, health)) && allGood
-				allGood = shouldNotConnect(reviewsPodV1.String(), formatAPI(ratings, apiPort, ratingsPath)) && allGood
+				allGood = shouldConnect(reviewsPodV1.String(), "reviews", formatAPI(ratings, apiPort, health)) && allGood
+				allGood = shouldNotConnect(reviewsPodV1.String(), "reviews", formatAPI(ratings, apiPort, ratingsPath)) && allGood
 
-				allGood = shouldConnect(productpagePodV1.String(), formatAPI(details, apiPort, health)) && allGood
+				allGood = shouldConnect(productpagePodV1.String(), "productpage", formatAPI(details, apiPort, health)) && allGood
 
-				allGood = shouldNotConnect(productpagePodV1.String(), formatAPI(ratings, apiPort, health)) && allGood
-				allGood = shouldNotConnect(productpagePodV1.String(), formatAPI(ratings, apiPort, ratingsPath)) && allGood
+				allGood = shouldNotConnect(productpagePodV1.String(), "productpage", formatAPI(ratings, apiPort, health)) && allGood
+				allGood = shouldNotConnect(productpagePodV1.String(), "productpage", formatAPI(ratings, apiPort, ratingsPath)) && allGood
 
 				return allGood
 			}, "Istio sidecar proxies are not configured", &helpers.TimeoutConfig{Timeout: helpers.HelperTimeout})


### PR DESCRIPTION
Update to Istio release 1.5.4 fixes:
- CVE-2020-10739: By sending a specially crafted packet, an attacker could trigger a Null Pointer Exception resulting in a Denial of Service. This could be sent to the ingress gateway or a sidecar. This is conditional on Istio being configured with Istio telemetry V2 enabled.

```release-note
Istio integration has been updated to Istio release 1.5.4
```
