### PR TITLE
bpf: don't answer ARP requests for endpoint IP

### DIFF
--- a/bpf/lib/arp.h
+++ b/bpf/lib/arp.h
@@ -30,55 +30,63 @@ static __always_inline int arp_check(struct ethhdr *eth,
 }
 
 static __always_inline int
-arp_prepare_response(struct __ctx_buff *ctx, struct ethhdr *eth,
-		     const struct arp_eth *arp_eth, __be32 ip,
-		     union macaddr *mac)
+arp_prepare_response(struct __ctx_buff *ctx, union macaddr *smac, __be32 sip,
+		     union macaddr *dmac, __be32 tip)
 {
-	union macaddr smac = *(union macaddr *) &eth->h_source;
-	__be32 sip = arp_eth->ar_sip;
 	__be16 arpop = bpf_htons(ARPOP_REPLY);
 
-	if (eth_store_saddr(ctx, mac->addr, 0) < 0 ||
-	    eth_store_daddr(ctx, smac.addr, 0) < 0 ||
+	if (eth_store_saddr(ctx, smac->addr, 0) < 0 ||
+	    eth_store_daddr(ctx, dmac->addr, 0) < 0 ||
 	    ctx_store_bytes(ctx, 20, &arpop, sizeof(arpop), 0) < 0 ||
-	    ctx_store_bytes(ctx, 22, mac, 6, 0) < 0 ||
-	    ctx_store_bytes(ctx, 28, &ip, 4, 0) < 0 ||
-	    ctx_store_bytes(ctx, 32, &smac, sizeof(smac), 0) < 0 ||
-	    ctx_store_bytes(ctx, 38, &sip, sizeof(sip), 0) < 0)
+	    /* sizeof(macadrr)=8 because of padding, use ETH_ALEN instead */
+	    ctx_store_bytes(ctx, 22, smac, ETH_ALEN, 0) < 0 ||
+	    ctx_store_bytes(ctx, 28, &sip, sizeof(sip), 0) < 0 ||
+	    ctx_store_bytes(ctx, 32, dmac, ETH_ALEN, 0) < 0 ||
+	    ctx_store_bytes(ctx, 38, &tip, sizeof(tip), 0) < 0)
 		return DROP_WRITE_ERROR;
 
 	return 0;
 }
 
-static __always_inline int arp_respond(struct __ctx_buff *ctx, union macaddr *mac,
-				       int direction)
+static __always_inline bool
+arp_validate(const struct __ctx_buff *ctx, union macaddr *mac,
+	     union macaddr *smac, __be32 *sip, __be32 *tip)
 {
 	void *data_end = (void *) (long) ctx->data_end;
 	void *data = (void *) (long) ctx->data;
 	struct arphdr *arp = data + ETH_HLEN;
 	struct ethhdr *eth = data;
 	struct arp_eth *arp_eth;
-	int ret;
 
 	if (data + ETH_HLEN + sizeof(*arp) + sizeof(*arp_eth) > data_end)
-		return CTX_ACT_OK;
+		return false;
+
+	if (!arp_check(eth, arp, mac))
+		return false;
 
 	arp_eth = data + ETH_HLEN + sizeof(*arp);
-	if (arp_check(eth, arp, mac)) {
-		__be32 target_ip = arp_eth->ar_tip;
-		ret = arp_prepare_response(ctx, eth, arp_eth, target_ip, mac);
-		if (unlikely(ret != 0))
-			goto error;
+	*smac = *(union macaddr *) &eth->h_source;
+	*sip = arp_eth->ar_sip;
+	*tip = arp_eth->ar_tip;
 
-		cilium_dbg_capture(ctx, DBG_CAPTURE_DELIVERY,
-				   ctx_get_ifindex(ctx));
-		return ctx_redirect(ctx, ctx_get_ifindex(ctx), direction);
-	}
+	return true;
+}
 
-	/* Pass any unknown ARP requests to the Linux stack */
-	return CTX_ACT_OK;
+static __always_inline int
+arp_respond(struct __ctx_buff *ctx, union macaddr *smac, __be32 sip,
+	    union macaddr *dmac, __be32 tip, int direction)
+{
+	int ret = arp_prepare_response(ctx, smac, sip, dmac, tip);
+	if (unlikely(ret != 0))
+		goto error;
+
+	cilium_dbg_capture(ctx, DBG_CAPTURE_DELIVERY,
+			   ctx_get_ifindex(ctx));
+	return ctx_redirect(ctx, ctx_get_ifindex(ctx), direction);
+
 error:
 	return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP, METRIC_EGRESS);
 }
+
 
 #endif /* __LIB_ARP__ */


### PR DESCRIPTION
Previously, bpf_lxc was answering to all ARP requests. This causes
an issue in an scenario where a duplicate address check is being
conducted inside the container by sending an ARP request for the
endpoint IP for which no answer is expected. This fixes it by answering
to ARP requests for all IPs except the endpoint IP.

Fixes: #10574

Signed-off-by: Jaime Caamaño Ruiz <jcaamano@suse.com>