### PR TITLE
doc: Add make render-docs-live-preview target

### DIFF
--- a/Documentation/.gitignore
+++ b/Documentation/.gitignore
@@ -1,2 +1,5 @@
 _build
 _api
+_preview
+Pipfile
+Pipfile.lock

--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -9,7 +9,7 @@ include ../Makefile.quiet
 default: html
 
 clean:
-	-$(QUIET)rm -rf _build
+	-$(QUIET)rm -rf _build _preview Pipfile Pipfile.lock
 
 builder-image: Dockerfile requirements.txt
 	$(QUIET)tar c requirements.txt Dockerfile \
@@ -61,3 +61,13 @@ run-server: stop-server
 
 stop-server:
 	-$(QUIET)$(CONTAINER_ENGINE) container rm --force --volumes docs-cilium
+
+pipenv:
+	@which pipenv > /dev/null || (echo "Please install pipenv: https://pipenv.pypa.io/en/latest/#install-pipenv-today"; exit 1)
+
+pipenv-install: pipenv
+	pipenv --rm || true
+	pipenv install --three -r requirements.txt
+
+live-preview: pipenv
+	pipenv run sphinx-autobuild -B $(SPHINX_OPTS) -i *.swp -Q . _preview

--- a/Documentation/contributing/testing/documentation.rst
+++ b/Documentation/contributing/testing/documentation.rst
@@ -7,7 +7,18 @@
 Documentation
 =============
 
-Whenever making changes to Cilium documentation you should check that you did not introduce any new warnings or errors, and also check that your changes look as you intended.  To do this you can build the docs:
+First, start a local document server that automatically refreshes when you save files for
+real-time preview. After installing `pipenv <https://pipenv.pypa.io/en/latest/#install-pipenv-today>`_,
+run:
+
+::
+
+    $ make render-docs-live-preview
+
+and preview the documentation at http://localhost:8000/ as you make changes. After making changes to
+Cilium documentation you should check that you did not introduce any new warnings or errors, and also
+check that your changes look as you intended one last time before opening a pull request. To do this
+you can build the docs:
 
 ::
 
@@ -16,7 +27,3 @@ Whenever making changes to Cilium documentation you should check that you did no
 This generates documentation files and starts a web server using a Docker container. You can
 view the updated documentation by opening either ``Documentation/_build/html/index.html`` or
 http://localhost:9081 in a browser.
-
-.. note:: ``make render-docs`` is relatively slow since it performs syntax and spelling checks.
-          You can run ``make render-docs SKIP_LINT=1`` to render the documentation without performing
-          these checks while you iterate on updating the documentation.

--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -11,7 +11,7 @@ MarkupSafe==1.1.1
 pyenchant==2.0.0
 Pygments==2.4.2
 pytz==2018.7
-PyYAML==4.2b1
+PyYAML==5.3.1
 requests==2.20.0
 six==1.11.0
 snowballstemmer==1.2.1

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -1,3 +1,4 @@
+Admin
 Alemayhu
 Ansible
 Apiserver
@@ -7,6 +8,7 @@ Backporting
 Balancer
 Bertin
 Blanco
+Blog
 Bookinfo
 Borkmann
 Brenden
@@ -22,6 +24,8 @@ Chewbacca
 Chun
 Cloudflare
 Clusterwide
+Committer
+Committers
 DDoS
 DMA'ed
 DNS
@@ -99,6 +103,7 @@ O'Reilly
 Orchestrators
 Pepelnjak
 Pfaff
+Plugins
 Podcasts
 Polytechnique
 Portmap
@@ -138,6 +143,7 @@ Terraform
 Tierney
 Toolchain
 Tracepoints
+Tu
 Twilio
 Userspace
 VM
@@ -157,6 +163,8 @@ Yan
 Yunsong
 Zannoni
 Zhou
+Zookeeper
+admin
 allocator
 allocators
 amd
@@ -165,6 +173,8 @@ api
 apiKeys
 apiVersion
 apiserver
+app
+apps
 arithmetics
 artii
 asm
@@ -186,6 +196,7 @@ bcc
 behaviour
 benefitting
 bgpd
+blog
 bnxt
 bookinfo
 boolean
@@ -213,6 +224,8 @@ clustermesh
 cni
 cnp
 codebase
+committer
+committers
 conf
 config
 conntrack
@@ -248,6 +261,7 @@ dereference
 deserialization
 dev
 devel
+diff
 disassembly
 discoverable
 distro
@@ -255,6 +269,7 @@ distros
 dns
 dockerhub
 dports
+droid
 dryRun
 dst
 dwarfris
@@ -269,6 +284,7 @@ endpointmanager
 etcd
 ethernet
 ethtool
+extendable
 extensibility
 externalIPs
 fallback
@@ -278,6 +294,8 @@ filenames
 filesystem
 filesystems
 firewalling
+followup
+foobar
 foundational
 fqdn
 fromCIDR
@@ -300,6 +318,7 @@ gluecon
 gobpf
 gocheck
 golang
+grep
 hairpinned
 hardcode
 hardcoded
@@ -322,13 +341,16 @@ hypervisors
 iam
 ie
 incrementing
+indices
 ingressing
 init
+inline
 inlined
 inlines
 inlining
 inodes
 integrations
+internet
 io
 ip
 ipam
@@ -448,6 +470,7 @@ nftables
 nginx
 nodeX
 observability
+offline
 onData
 onwards
 opcodes
@@ -455,6 +478,7 @@ openSUSE
 openapi
 openssl
 orchestrator
+org
 pahole
 parserfactory
 parsers
@@ -462,7 +486,10 @@ pc
 pcap
 perf
 pipelining
+playbook
 pluggable
+plugin
+plugins
 pmdabcc
 png
 podcasts
@@ -490,6 +517,7 @@ recv
 recvmsg
 refactoring
 regenerations
+regex
 regexes
 relocations
 reparsing
@@ -554,6 +582,7 @@ sysctl
 sysctls
 systemd
 systemtap
+tarball
 tc
 tcp
 tcpdump
@@ -581,6 +610,7 @@ ubuntu
 udp
 uint
 uninline
+uninstall
 unix
 unmanaged
 untriaged
@@ -624,6 +654,7 @@ www
 xdp
 xfrm
 xml
+xor
 xoring
 xwing
 yaml

--- a/Makefile
+++ b/Makefile
@@ -596,6 +596,9 @@ update-authors:
 render-docs:
 	$(MAKE) -C Documentation html run-server
 
+render-docs-live-preview:
+	$(MAKE) -C Documentation pipenv-install live-preview
+
 manpages:
 	-rm -r man
 	mkdir -p man


### PR DESCRIPTION
2 commits:

- Update spelling_wordlist.txt to include some words that are missing in the OS X English dictionary.
- Add `make render-docs-live-preview` for live preview!