### PR TITLE
envoy: Take xds mutator lock for map access

### DIFF
--- a/pkg/envoy/xds/ack.go
+++ b/pkg/envoy/xds/ack.go
@@ -147,6 +147,9 @@ func (m *AckingResourceMutatorWrapper) addVersionCompletion(typeURL string, vers
 
 // DeleteNode frees resources held for the named nodes
 func (m *AckingResourceMutatorWrapper) DeleteNode(nodeID string) {
+	m.locker.Lock()
+	defer m.locker.Unlock()
+
 	delete(m.ackedVersions, nodeID)
 }
 


### PR DESCRIPTION
'ackedVersions' was accessed in DeleteNode() without taking the mutex
which can lead to mutating the map while readers are accessing it.

Fixes: #11535
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
