### PR TITLE
pkg/identity: Watch and update labels for the host

### DIFF
--- a/pkg/identity/cache/cache_test.go
+++ b/pkg/identity/cache/cache_test.go
@@ -115,7 +115,11 @@ func (s *IdentityCacheTestSuite) TestLookupReservedIdentityByLabels(c *C) {
 					"id.foo":                   labels.ParseLabel("id.foo"),
 				},
 			},
-			want: nil,
+			want: identity.NewIdentity(identity.ReservedIdentityHost, labels.Labels{
+				labels.LabelSourceReserved: labels.ParseLabel("reserved:host"),
+				"id.foo":                   labels.ParseLabel("id.foo"),
+			},
+			),
 		},
 		{
 			name: "well-known-kvstore",

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -233,15 +233,26 @@ func LookupReservedIdentityByLabels(lbls labels.Labels) *Identity {
 			// If a fixed identity was not found then we return nil to avoid
 			// falling to a reserved identity.
 			return nil
-		// If it doesn't contain a fixed-identity then make sure the set of
-		// labels only contains a single label and that label is of the reserved
-		// type. This is to prevent users from adding cilium-reserved labels
-		// into the workloads.
+
 		case lbl.Source == labels.LabelSourceReserved:
+			// If it contains the reserved, local host identity, return it with
+			// the new list of labels. This is to ensure the local node retains
+			// this identity regardless of label changes.
+			id := GetReservedID(lbl.Key)
+			if id == ReservedIdentityHost {
+				identity := NewIdentity(ReservedIdentityHost, lbls)
+				// Pre-calculate the SHA256 hash.
+				identity.GetLabelsSHA256()
+				return identity
+			}
+
+			// If it doesn't contain a fixed-identity then make sure the set of
+			// labels only contains a single label and that label is of the
+			// reserved type. This is to prevent users from adding
+			// cilium-reserved labels into the workloads.
 			if len(lbls) != 1 {
 				return nil
 			}
-			id := GetReservedID(lbl.Key)
 			if id != IdentityUnknown && !IsUserReservedIdentity(id) {
 				return LookupReservedIdentity(id)
 			}

--- a/pkg/identity/identitymanager/manager.go
+++ b/pkg/identity/identitymanager/manager.go
@@ -113,7 +113,9 @@ func (idm *IdentityManager) RemoveOldAddNew(old, new *identity.Identity) {
 	if old == nil && new == nil {
 		return
 	}
-	if old != nil && new != nil && old.ID == new.ID {
+	// The host endpoint will always retain its reserved ID, but its labels may
+	// change so we need to update its identity.
+	if old != nil && new != nil && old.ID == new.ID && new.ID != identity.ReservedIdentityHost {
 		return
 	}
 

--- a/pkg/identity/identitymanager/manager_test.go
+++ b/pkg/identity/identitymanager/manager_test.go
@@ -86,6 +86,25 @@ func (s *IdentityManagerTestSuite) TestIdentityManagerLifecycle(c *C) {
 	c.Assert(idm.identities[barIdentity.ID].refCount, Equals, uint(2))
 }
 
+func (s *IdentityManagerTestSuite) TestHostIdentityLifecycle(c *C) {
+	idm := NewIdentityManager()
+	c.Assert(idm.identities, Not(IsNil))
+
+	hostIdentity := identity.NewIdentity(identity.ReservedIdentityHost, labels.LabelHost)
+	_, exists := idm.identities[hostIdentity.ID]
+	c.Assert(exists, Equals, false)
+
+	idm.Add(hostIdentity)
+	c.Assert(idm.identities[hostIdentity.ID].refCount, Equals, uint(1))
+
+	newHostLabels := labels.NewLabelsFromModel([]string{"id=foo"})
+	newHostLabels.MergeLabels(labels.LabelHost)
+	newHostIdentity := identity.NewIdentity(identity.ReservedIdentityHost, newHostLabels)
+	idm.RemoveOldAddNew(hostIdentity, newHostIdentity)
+	c.Assert(idm.identities[hostIdentity.ID].refCount, Equals, uint(1))
+	c.Assert(idm.identities[hostIdentity.ID].identity, checker.DeepEquals, newHostIdentity)
+}
+
 type identityManagerObserver struct {
 	added   []identity.NumericIdentity
 	removed []identity.NumericIdentity

--- a/pkg/k8s/watchers/node.go
+++ b/pkg/k8s/watchers/node.go
@@ -1,0 +1,79 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package watchers
+
+import (
+	"github.com/cilium/cilium/pkg/comparator"
+	"github.com/cilium/cilium/pkg/k8s"
+	"github.com/cilium/cilium/pkg/k8s/informer"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/core/v1"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+func (k *K8sWatcher) nodesInit(k8sClient kubernetes.Interface) {
+	_, nodeController := informer.NewInformer(
+		cache.NewListWatchFromClient(k8sClient.CoreV1().RESTClient(),
+			"nodes", v1.NamespaceAll, fields.ParseSelectorOrDie("metadata.name="+nodeTypes.GetName())),
+		&slim_corev1.Node{},
+		0,
+		cache.ResourceEventHandlerFuncs{
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				var valid, equal bool
+				if oldNode := k8s.ObjToV1Node(oldObj); oldNode != nil {
+					valid = true
+					if newNode := k8s.ObjToV1Node(newObj); newNode != nil {
+						oldNodeLabels := oldNode.GetLabels()
+						newNodeLabels := newNode.GetLabels()
+						if comparator.MapStringEquals(oldNodeLabels, newNodeLabels) {
+							equal = true
+						} else {
+							err := k.updateK8sNodeV1(oldNode, newNode)
+							k.K8sEventProcessed(metricNode, metricUpdate, err == nil)
+						}
+					}
+				}
+				k.K8sEventReceived(metricNode, metricUpdate, valid, equal)
+			},
+		},
+		nil,
+	)
+
+	k.blockWaitGroupToSyncResources(wait.NeverStop, nil, nodeController, k8sAPIGroupNodeV1Core)
+	go nodeController.Run(wait.NeverStop)
+	k.k8sAPIGroups.addAPI(k8sAPIGroupNodeV1Core)
+}
+
+func (k *K8sWatcher) updateK8sNodeV1(oldK8sNode, newK8sNode *slim_corev1.Node) error {
+	oldNodeLabels := oldK8sNode.GetLabels()
+	newNodeLabels := newK8sNode.GetLabels()
+
+	nodeEP := k.endpointManager.GetHostEndpoint()
+	if nodeEP == nil {
+		log.Error("Host endpoint not found")
+		return nil
+	}
+
+	err := updateEndpointLabels(nodeEP, oldNodeLabels, newNodeLabels)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -70,6 +70,7 @@ const (
 	metricCiliumNode     = "CiliumNode"
 	metricCiliumEndpoint = "CiliumEndpoint"
 	metricPod            = "Pod"
+	metricNode           = "Node"
 	metricService        = "Service"
 	metricCreate         = "create"
 	metricDelete         = "delete"
@@ -105,6 +106,7 @@ var (
 
 type endpointManager interface {
 	GetEndpoints() []*endpoint.Endpoint
+	GetHostEndpoint() *endpoint.Endpoint
 	LookupPodName(string) *endpoint.Endpoint
 	WaitForEndpointsAtPolicyRev(ctx context.Context, rev uint64) error
 }
@@ -463,6 +465,9 @@ func (k *K8sWatcher) EnableK8sWatcher(queueSize uint) error {
 	// kubernetes pods
 	asyncControllers.Add(1)
 	go k.podsInit(k8s.WatcherCli(), asyncControllers)
+
+	// kubernetes nodes
+	k.nodesInit(k8s.WatcherCli())
 
 	// kubernetes namespaces
 	asyncControllers.Add(1)


### PR DESCRIPTION
This commit adds a k8s watcher for label updates on the host. It allows node network policies to select the nodes based on labels. For now, the same label filters are used for the nodes as for the labels.

Whatever the labels it receives, because we know there can be only one host endpoint per node, the host endpoint will always retain its security ID of 1. We therefore don't need to reload the host endpoint's datapaths on label updates.