### PR TITLE
golangci: Enable varcheck linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -73,20 +73,20 @@ linters:
     - ineffassign
     - misspell
     - staticcheck
+    - varcheck
 
 # To enable later if makes sense
-#    - goimports
 #    - deadcode
 #    - errcheck
+#    - gocyclo
+#    - goimports
 #    - golint
+#    - gosec
 #    - gosimple
-#    - structcheck
-#    - typecheck
-#    - unused
-#    - varcheck
+#    - lll
 #    - maligned
 #    - misspell
 #    - prealloc
-#    - gocyclo
-#    - lll
-#    - gosec
+#    - structcheck
+#    - typecheck
+#    - unused

--- a/cilium-health/cmd/root.go
+++ b/cilium-health/cmd/root.go
@@ -33,7 +33,6 @@ import (
 const targetName = "cilium-health"
 
 var (
-	cfgFile   string
 	client    *clientPkg.Client
 	cmdRefDir string
 	log       = logging.DefaultLogger.WithField(logfields.LogSubsys, targetName)

--- a/cilium/cmd/cleanup.go
+++ b/cilium/cmd/cleanup.go
@@ -48,14 +48,12 @@ var (
 	cleanAll bool
 	cleanBPF bool
 	force    bool
-	runPath  string
 )
 
 const (
-	allFlagName     = "all-state"
-	bpfFlagName     = "bpf-state"
-	forceFlagName   = "force"
-	runPathFlagName = "run-path"
+	allFlagName   = "all-state"
+	bpfFlagName   = "bpf-state"
+	forceFlagName = "force"
 
 	cleanCiliumEnvVar = "CLEAN_CILIUM_STATE"
 	cleanBpfEnvVar    = "CLEAN_CILIUM_BPF_STATE"

--- a/cilium/cmd/debuginfo.go
+++ b/cilium/cmd/debuginfo.go
@@ -78,7 +78,6 @@ var debuginfoCmd = &cobra.Command{
 
 var (
 	outputToFile   bool
-	html           string
 	filePerCommand bool
 	outputOpts     []string
 	outputDir      string

--- a/pkg/aws/eni/log.go
+++ b/pkg/aws/eni/log.go
@@ -24,6 +24,5 @@ var (
 )
 
 const (
-	fieldName  = "name"
 	fieldEniID = "eniID"
 )

--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	eniTypes "github.com/cilium/cilium/pkg/aws/eni/types"
 	"github.com/cilium/cilium/pkg/ipam"
@@ -33,10 +32,6 @@ import (
 )
 
 const (
-	// warningInterval is the interval for warnings which should be done
-	// once and then repeated if the warning persists.
-	warningInterval = time.Hour
-
 	// maxAttachRetries is the maximum number of attachment retries
 	maxAttachRetries = 5
 

--- a/pkg/fqdn/util_test.go
+++ b/pkg/fqdn/util_test.go
@@ -27,18 +27,6 @@ import (
 )
 
 var (
-	// cilium.io dns target, no rule name => no rule labels
-	rule1 = makeRule("", "cilium.io")
-
-	// cilium.io dns target, no rule name => no rule labels
-	rule2 = makeRule("", "cilium.io")
-
-	// cilium.io, github.com dns targets
-	rule3 = makeRule("rule3", "cilium.io", "github.com")
-
-	// github.com dns target
-	rule4 = makeRule("rule4", "github.com")
-
 	ipLookups = map[string]*DNSIPRecords{
 		dns.Fqdn("cilium.io"): {
 			TTL: 60,

--- a/pkg/ipam/node_manager_test.go
+++ b/pkg/ipam/node_manager_test.go
@@ -36,7 +36,6 @@ import (
 var (
 	k8sapi     = &k8sMock{}
 	metricsapi = metricsmock.NewMockMetrics()
-	eniTags    = map[string]string{}
 )
 
 const testPoolID = ipamTypes.PoolID("global")

--- a/pkg/kvstore/allocator/logfields.go
+++ b/pkg/kvstore/allocator/logfields.go
@@ -20,5 +20,4 @@ const (
 	fieldPrefix  = "prefix"
 	fieldValue   = "value"
 	fieldLeaseID = "leaseID"
-	fieldRefCnt  = "refcnt"
 )

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -262,9 +262,7 @@ var (
 	}
 
 	// Misc other bpf key fields for convenience / readability.
-	l7RedirectNone_ = uint16(0)
-	l7RedirectProxy = uint16(1)
-	dirIngress      = trafficdirection.Ingress.Uint8()
+	dirIngress = trafficdirection.Ingress.Uint8()
 	// Desired map keys for L3, L3-dependent L4, L4
 	mapKeyAllowFoo__ = Key{identityFoo, 0, 0, dirIngress}
 	mapKeyAllowBar__ = Key{identityBar, 0, 0, dirIngress}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -41,7 +41,6 @@ var (
 // field names used while logging
 const (
 	fieldMarker          = "marker"
-	fieldSocket          = "socket"
 	fieldFd              = "fd"
 	fieldProxyRedirectID = "id"
 

--- a/proxylib/proxylib_memcached_test.go
+++ b/proxylib/proxylib_memcached_test.go
@@ -30,7 +30,6 @@ import (
 )
 
 var setHelloText = []byte("set key 0 0 5\r\nhello\r\n")
-var setHelloTextNoreply = []byte("set key 0 0 5 noreply\r\nhello\r\n")
 
 var getKeysText = []byte("get key1 key2 key3\r\n")
 var gatKeysText = []byte("gat 5 key1 key2 key3\r\n")

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -46,10 +46,9 @@ import (
 
 const (
 	// KubectlCmd Kubernetes controller command
-	KubectlCmd      = "kubectl"
-	manifestsPath   = "k8sT/manifests/"
-	descriptorsPath = "../examples/kubernetes"
-	kubeDNSLabel    = "k8s-app=kube-dns"
+	KubectlCmd    = "kubectl"
+	manifestsPath = "k8sT/manifests/"
+	kubeDNSLabel  = "k8s-app=kube-dns"
 
 	// DNSHelperTimeout is a predefined timeout value for K8s DNS commands. It
 	// must be larger than 5 minutes because kubedns has a hardcoded resync

--- a/test/runtime/fqdn.go
+++ b/test/runtime/fqdn.go
@@ -133,11 +133,10 @@ var _ = Describe("RuntimeFQDNPolicies", func() {
 		OutsideHttpd2     = "OutsideHttpd2"
 		OutsideHttpd3     = "OutsideHttpd3"
 
-		bindDBCilium     = "db.cilium.test"
-		bindDBOutside    = "db.outside.test"
-		bindDBDNSSSEC    = "db.dnssec.test"
-		bindNamedConf    = "named.conf.local"
-		bindNamedOptions = "named.conf.options"
+		bindDBCilium  = "db.cilium.test"
+		bindDBOutside = "db.outside.test"
+		bindDBDNSSSEC = "db.dnssec.test"
+		bindNamedConf = "named.conf.local"
 
 		world1Domain = "world1.cilium.test"
 		world1Target = "http://world1.cilium.test"


### PR DESCRIPTION
This change enables the varcheck linter in golangci, which checks for
unused global variables.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>