### PR TITLE
Shorten dummy device name in linuxrouting tests

### DIFF
--- a/pkg/datapath/linux/routing/routing_test.go
+++ b/pkg/datapath/linux/routing/routing_test.go
@@ -211,7 +211,9 @@ func listRulesAndRoutes(c *C, family int) ([]netlink.Rule, []netlink.Route) {
 func createDummyDevice(c *C, macAddr mac.MAC) func() {
 	dummy := &netlink.Dummy{
 		LinkAttrs: netlink.LinkAttrs{
-			Name:         "linuxrouting-test",
+			// NOTE: This name must be less than 16 chars, source:
+			// https://elixir.bootlin.com/linux/v5.6/source/include/uapi/linux/if.h#L33
+			Name:         "linuxrout-test",
 			HardwareAddr: net.HardwareAddr(macAddr),
 		},
 	}


### PR DESCRIPTION
Due to the refactor from #11452, the device name was renamed from
"enirouting-test" to "linuxrouting-test" which is 17 characters long,
exceeding the max device name size (`IFNAMSIZ`) of 16. [1]

This commit renames the device name to be under 16 characters.

Fixes #11547
Fixes #11452

[1]:
https://elixir.bootlin.com/linux/v5.6/source/include/uapi/linux/if.h#L33

**Note to backporters**: this PR depends on https://github.com/cilium/cilium/pull/11452 being backported