### PR TITLE
datapath: Get rid of NO_REDIRECT

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -151,10 +151,9 @@ handle_ipv6(struct __ctx_buff *ctx, __u32 secctx, bool from_host)
 			if (ret < 0)
 				return ret;
 		}
-#if defined(ENCAP_IFINDEX) || defined(NO_REDIRECT)
-		/* See IPv4 case for NO_REDIRECT comments */
+#ifdef ENCAP_IFINDEX
 		return CTX_ACT_OK;
-#endif /* ENCAP_IFINDEX || NO_REDIRECT */
+#endif
 		/* Verifier workaround: modified ctx access. */
 		if (!revalidate_data(ctx, &data, &data_end, &ip6))
 			return DROP_INVALID;
@@ -353,14 +352,9 @@ handle_ipv4(struct __ctx_buff *ctx, __u32 secctx, bool from_host)
 			if (ret < 0)
 				return ret;
 		}
-#if defined(ENCAP_IFINDEX) || defined(NO_REDIRECT)
-		/* We cannot redirect a packet to a local endpoint in the direct
-		 * routing mode, as the redirect bypasses nf_conntrack table.
-		 * This makes a second reply from the endpoint to be MASQUERADEd
-		 * or to be DROPed by k8s's "--ctstate INVALID -j DROP"
-		 * depending via which interface it was inputed. */
+#ifdef ENCAP_IFINDEX
 		return CTX_ACT_OK;
-#endif /* ENCAP_IFINDEX || NO_REDIRECT */
+#endif
 		/* Verifier workaround: modified ctx access. */
 		if (!revalidate_data(ctx, &data, &data_end, &ip4))
 			return DROP_INVALID;

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -102,24 +102,6 @@ func getFeedRule(name, args string) []string {
 	return append(argsList, ruleTail...)
 }
 
-// KernelHasNetfilter probes whether iptables related modules are present in
-// the kernel and returns true if indeed the case, else false.
-func KernelHasNetfilter() bool {
-	modulesManager := &modules.ModulesManager{}
-	if err := modulesManager.Init(); err != nil {
-		return true
-	}
-	if found, _ := modulesManager.FindModules(
-		"ip_tables", "iptable_mangle", "iptable_raw", "iptable_filter"); found {
-		return true
-	}
-	if found, _ := modulesManager.FindModules(
-		"ip6_tables", "ip6table_mangle", "ip6table_raw", "ip6table_filter"); found {
-		return true
-	}
-	return false
-}
-
 func (c *customChain) add(waitArgs []string) error {
 	var err error
 	if option.Config.EnableIPv4 {

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/datapath"
-	"github.com/cilium/cilium/pkg/datapath/iptables"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
@@ -197,10 +196,6 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 
 	if option.Config.EnableIPSec {
 		cDefinesMap["ENABLE_IPSEC"] = "1"
-	}
-
-	if option.Config.InstallIptRules || iptables.KernelHasNetfilter() {
-		cDefinesMap["NO_REDIRECT"] = "1"
 	}
 
 	if option.Config.EncryptNode {


### PR DESCRIPTION
This commit removes NO_REDIRECT which is no longer needed, as a reply from an endpoint bypasses the troublesome iptables rule via the CILIUM_CALL_IPV{4,6}_NODEPORT_REVNAT tailcall from bpf_lxc, which does skb_redirect.

TODO:

- [ ] Test with kube-proxy and direct routing when --device is specified.

Fix #11217.