### PR TITLE
fix(kvstore): Correct the error messages in kvstore get CLI

### DIFF
--- a/cilium/cmd/kvstore_get.go
+++ b/cilium/cmd/kvstore_get.go
@@ -58,8 +58,11 @@ var kvstoreGetCmd = &cobra.Command{
 			}
 		} else {
 			val, err := kvstore.Client().Get(ctx, key)
-			if err != nil || val == nil {
-				Fatalf("Unable to retrieve key: %s", err)
+			if err != nil {
+				Fatalf("Unable to retrieve key %s: %s", key, err)
+			}
+			if val == nil {
+				Fatalf("key %s is not found", key)
 			}
 			if command.OutputJSON() {
 				if err := command.PrintOutput(string(val)); err != nil {

--- a/contrib/scripts/cilium-up.sh
+++ b/contrib/scripts/cilium-up.sh
@@ -24,7 +24,7 @@ docker run -d \
    --name "cilium-consul" \
    -p 8501:8500 \
    -e 'CONSUL_LOCAL_CONFIG={"skip_leave_on_interrupt": true, "disable_update_check": true}' \
-   consul:0.8.3 \
+   consul:1.1.0 \
    agent -client=0.0.0.0 -server -bootstrap-expect 1
 
 $dir/plugins/cilium-docker/cilium-docker&

--- a/contrib/systemd/cilium-consul.service
+++ b/contrib/systemd/cilium-consul.service
@@ -7,12 +7,12 @@ Requires=docker.service
 Type=oneshot
 RemainAfterExit=yes
 TimeoutStartSec=0
-ExecStartPre=/usr/bin/docker pull consul:0.8.3
+ExecStartPre=/usr/bin/docker pull consul:1.1.0
 ExecStartPre=-/usr/bin/docker rm -f cilium-consul
 ExecStartPre=/usr/bin/docker create \
  --name 'cilium-consul'  -p 8500:8500 \
  -e CONSUL_LOCAL_CONFIG='{"skip_leave_on_interrupt": true, "disable_update_check": true}' \
- consul:0.8.3 agent -client=0.0.0.0 -server -bootstrap-expect 1 \
+ consul:1.1.0 agent -client=0.0.0.0 -server -bootstrap-expect 1 \
 
 ExecStart= /usr/bin/docker start cilium-consul
 ExecStop=-/usr/bin/docker rm -f cilium-consul

--- a/examples/getting-started/Vagrantfile
+++ b/examples/getting-started/Vagrantfile
@@ -55,7 +55,7 @@ Vagrant.configure(2) do |config|
 
     # install docker runtime
     config.vm.provision :docker, images: [
-	"consul:0.8.3",
+	"consul:1.1.0",
 	"cilium/cilium:#{cilium_tag}"
     ]
 

--- a/examples/getting-started/docker-compose.yml
+++ b/examples/getting-started/docker-compose.yml
@@ -40,5 +40,5 @@ services:
       - "8500:8500"
     environment:
       - "CONSUL_LOCAL_CONFIG={\"skip_leave_on_interrupt\": true, \"disable_update_check\": true}"
-    image: docker.io/library/consul:0.8.3
+    image: docker.io/library/consul:1.1.0
     command: agent -client=0.0.0.0 -server -bootstrap-expect 1

--- a/examples/mesos/allfiles/docker-compose.yml
+++ b/examples/mesos/allfiles/docker-compose.yml
@@ -25,5 +25,5 @@ services:
       - "8500:8500"
     environment:
       - "CONSUL_LOCAL_CONFIG={\"skip_leave_on_interrupt\": true}"
-    image: docker.io/consul:0.8.3
+    image: docker.io/consul:1.1.0
     command: agent -client=0.0.0.0 -server -bootstrap-expect 1

--- a/pkg/kvstore/consul.go
+++ b/pkg/kvstore/consul.go
@@ -200,7 +200,6 @@ func newConsulClient(ctx context.Context, config *consulAPI.Config, opts *ExtraO
 	}
 
 	boff := backoff.Exponential{Min: time.Duration(100) * time.Millisecond}
-	log.Info("Waiting for consul to elect a leader")
 
 	for i := 0; i < maxRetries; i++ {
 		var leader string
@@ -214,6 +213,7 @@ func newConsulClient(ctx context.Context, config *consulAPI.Config, opts *ExtraO
 				err = errors.New("timeout while waiting for leader to be elected")
 			}
 		}
+		log.Info("Waiting for consul to elect a leader")
 		boff.Wait(ctx)
 	}
 
@@ -284,7 +284,7 @@ func (c *consulClient) LockPath(ctx context.Context, path string) (KVLocker, err
 		switch {
 		case err != nil:
 			return nil, err
-		case ch == nil && err == nil:
+		case ch == nil:
 			Trace("Acquiring lock timed out, retrying", nil, logrus.Fields{fieldKey: path, logfields.Attempt: retries})
 		default:
 			return &ConsulLocker{Lock: lockKey}, err


### PR DESCRIPTION
The info log message `waiting for consul to elect a leader` is
misleading. I move it inside retry with backoff loop.

Separate two scenarios: error getting the key and key is nil.
While checking for this issue, I found out consul version is
quite old and not the same version in packer-ci-build (e.g. 1.1.0)
https://github.com/cilium/packer-ci-build/blob/master/provision/pull-images.sh#L9

Closes #11567

Signed-off-by: Tam Mach <sayboras@yahoo.com>

```release-note
Correct message for kvstore get (consul)
```
