### PR TITLE
fix(lint): Correct the cidrs for linux routing in cni

### DIFF
--- a/pkg/datapath/linux/routing/info.go
+++ b/pkg/datapath/linux/routing/info.go
@@ -56,7 +56,7 @@ func parse(gateway string, cidrs []string, macAddr string) (*RoutingInfo, error)
 		return nil, fmt.Errorf("invalid ip: %s", gateway)
 	}
 
-	if cidrs == nil || len(cidrs) == 0 {
+	if len(cidrs) == 0 {
 		return nil, errors.New("empty cidrs")
 	}
 

--- a/plugins/cilium-cni/interface.go
+++ b/plugins/cilium-cni/interface.go
@@ -36,12 +36,12 @@ func interfaceAdd(ipConfig *current.IPConfig, ipam *models.IPAMAddressResponse, 
 	}
 	// Coalesce CIDRs into minimum set needed for route rules
 	ipv4CIDRs, _ := ip.CoalesceCIDRs(allCIDRs)
-	cidrs := make([]net.IPNet, 0, len(ipv4CIDRs))
+	cidrs := make([]string, 0, len(ipv4CIDRs))
 	for _, cidr := range ipv4CIDRs {
-		cidrs = append(cidrs, *cidr)
+		cidrs = append(cidrs, cidr.String())
 	}
 
-	routingInfo, err := linuxrouting.NewRoutingInfo(ipam.Gateway, ipam.Cidrs, ipam.MasterMac)
+	routingInfo, err := linuxrouting.NewRoutingInfo(ipam.Gateway, cidrs, ipam.MasterMac)
 	if err != nil {
 		return fmt.Errorf("unable to parse routing info: %v", err)
 	}


### PR DESCRIPTION
Related to
https://github.com/cilium/cilium/pull/11528#discussion_r425315197

Closes #11562

Signed-off-by: Tam Mach <sayboras@yahoo.com>

```release-note
Correct cidr input in linuxRouting.NewRoutingInfo
```
