### PR TITLE
azure: support standalone (non VMSS) instances

### DIFF
--- a/pkg/azure/api/mock/mock.go
+++ b/pkg/azure/api/mock/mock.go
@@ -36,7 +36,7 @@ const (
 	AllOperations Operation = iota
 	GetInstances
 	GetVpcsAndSubnets
-	AssignPrivateIpAddresses
+	AssignPrivateIpAddressesVMSS
 	MaxOperation
 )
 
@@ -177,14 +177,18 @@ func (a *API) GetVpcsAndSubnets(ctx context.Context) (ipamTypes.VirtualNetworkMa
 	return vnets, subnets, nil
 }
 
-func (a *API) AssignPrivateIpAddresses(ctx context.Context, vmName, vmssName, subnetID, interfaceName string, addresses int) error {
+func (a *API) AssignPrivateIpAddressesVM(ctx context.Context, subnetID, interfaceName string, addresses int) error {
+	return nil
+}
+
+func (a *API) AssignPrivateIpAddressesVMSS(ctx context.Context, vmName, vmssName, subnetID, interfaceName string, addresses int) error {
 	a.rateLimit()
-	a.delaySim.Delay(AssignPrivateIpAddresses)
+	a.delaySim.Delay(AssignPrivateIpAddressesVMSS)
 
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
 
-	if err, ok := a.errors[AssignPrivateIpAddresses]; ok {
+	if err, ok := a.errors[AssignPrivateIpAddressesVMSS]; ok {
 		return err
 	}
 

--- a/pkg/azure/api/mock/mock_test.go
+++ b/pkg/azure/api/mock/mock_test.go
@@ -68,7 +68,7 @@ func (e *MockSuite) TestMock(c *check.C) {
 		return nil
 	})
 
-	err = api.AssignPrivateIpAddresses(context.Background(), "vm1", "vmss1", "s-1", "eth0", 2)
+	err = api.AssignPrivateIpAddressesVMSS(context.Background(), "vm1", "vmss1", "s-1", "eth0", 2)
 	c.Assert(err, check.IsNil)
 	instances, err = api.GetInstances(context.Background(), ipamTypes.SubnetMap{})
 	c.Assert(err, check.IsNil)
@@ -82,6 +82,20 @@ func (e *MockSuite) TestMock(c *check.C) {
 		c.Assert(len(iface.Addresses), check.Equals, 2)
 		return nil
 	})
+
+	vmIfaceID := "/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Network/networkInterfaces/vm22-if"
+	vmInstances := ipamTypes.NewInstanceMap()
+	vmInstances.Update("vm2", ipamTypes.InterfaceRevision{
+		Resource: &types.AzureInterface{ID: vmIfaceID, Name: "eth0"},
+	})
+	c.Assert(err, check.IsNil)
+	c.Assert(vmInstances.NumInstances(), check.Equals, 1)
+	vmInstances.ForeachInterface("", func(instanceID, interfaceID string, iface ipamTypes.InterfaceRevision) error {
+		c.Assert(instanceID, check.Equals, "vm2")
+		c.Assert(interfaceID, check.Equals, vmIfaceID)
+		return nil
+	})
+
 }
 
 func (e *MockSuite) TestSetMockError(c *check.C) {
@@ -98,8 +112,8 @@ func (e *MockSuite) TestSetMockError(c *check.C) {
 	_, _, err = api.GetVpcsAndSubnets(context.Background())
 	c.Assert(err, check.Equals, mockError)
 
-	api.SetMockError(AssignPrivateIpAddresses, mockError)
-	err = api.AssignPrivateIpAddresses(context.Background(), "vmss1", "i-1", "s-1", "eth0", 0)
+	api.SetMockError(AssignPrivateIpAddressesVMSS, mockError)
+	err = api.AssignPrivateIpAddressesVMSS(context.Background(), "vmss1", "i-1", "s-1", "eth0", 0)
 	c.Assert(err, check.Equals, mockError)
 }
 

--- a/pkg/azure/ipam/instances.go
+++ b/pkg/azure/ipam/instances.go
@@ -30,7 +30,8 @@ import (
 type AzureAPI interface {
 	GetInstances(ctx context.Context, subnets ipamTypes.SubnetMap) (*ipamTypes.InstanceMap, error)
 	GetVpcsAndSubnets(ctx context.Context) (ipamTypes.VirtualNetworkMap, ipamTypes.SubnetMap, error)
-	AssignPrivateIpAddresses(ctx context.Context, instanceID, vmssName, subnetID, interfaceName string, addresses int) error
+	AssignPrivateIpAddressesVM(ctx context.Context, subnetID, interfaceName string, addresses int) error
+	AssignPrivateIpAddressesVMSS(ctx context.Context, instanceID, vmssName, subnetID, interfaceName string, addresses int) error
 }
 
 // InstancesManager maintains the list of instances. It must be kept up to date

--- a/pkg/azure/ipam/node.go
+++ b/pkg/azure/ipam/node.go
@@ -82,7 +82,7 @@ func (n *Node) PrepareIPAllocation(scopedLog *logrus.Entry) (a *ipam.AllocationA
 				scopedLog.WithFields(logrus.Fields{
 					"ifaceName":    iface.Name,
 					"requiredName": requiredIfaceName,
-				}).Debug("Not considering interface for allocation sice it does not match the required name")
+				}).Debug("Not considering interface for allocation since it does not match the required name")
 				return nil
 			}
 		}
@@ -138,7 +138,11 @@ func (n *Node) AllocateIPs(ctx context.Context, a *ipam.AllocationAction) error 
 		return fmt.Errorf("invalid interface object")
 	}
 
-	return n.manager.api.AssignPrivateIpAddresses(ctx, iface.VMID(), iface.VMScaleSetName(), string(a.PoolID), iface.Name, a.AvailableForAllocation)
+	if iface.VMScaleSetName() == "" {
+		return n.manager.api.AssignPrivateIpAddressesVM(ctx, string(a.PoolID), iface.Name, a.AvailableForAllocation)
+	} else {
+		return n.manager.api.AssignPrivateIpAddressesVMSS(ctx, iface.VMID(), iface.VMScaleSetName(), string(a.PoolID), iface.Name, a.AvailableForAllocation)
+	}
 }
 
 // CreateInterface is called to create a new interface. This operation is

--- a/pkg/azure/types/types.go
+++ b/pkg/azure/types/types.go
@@ -133,6 +133,7 @@ func (a *AzureInterface) InterfaceID() string {
 
 func (a *AzureInterface) extractIDs() {
 	switch {
+	// Interface from a VMSS instance:
 	// //subscriptions/xxx/resourceGroups/yyy/providers/Microsoft.Compute/virtualMachineScaleSets/ssss/virtualMachines/vvv/networkInterfaces/iii
 	case strings.Contains(a.ID, "virtualMachineScaleSets"):
 		segs := strings.Split(a.ID, "/")
@@ -144,6 +145,13 @@ func (a *AzureInterface) extractIDs() {
 		}
 		if len(segs) >= 11 {
 			a.vmID = segs[10]
+		}
+	// Interface from a standalone instance:
+	// //subscriptions/xxx/resourceGroups/yyy/providers/Microsoft.Network/networkInterfaces/iii
+	case strings.Contains(a.ID, "/Microsoft.Network/"):
+		segs := strings.Split(a.ID, "/")
+		if len(segs) >= 5 {
+			a.resourceGroup = segs[4]
 		}
 	}
 }

--- a/pkg/azure/types/types_test.go
+++ b/pkg/azure/types/types_test.go
@@ -73,11 +73,15 @@ func (e *TypesSuite) TestForeachAddresses(c *check.C) {
 }
 
 func (e *TypesSuite) TestExtractIDs(c *check.C) {
-	intf := AzureInterface{
+	vmssIntf := AzureInterface{
 		ID: "/subscriptions/xxx/resourceGroups/MC_aks-test_aks-test_westeurope/providers/Microsoft.Compute/virtualMachineScaleSets/aks-nodepool1-10706209-vmss/virtualMachines/3/networkInterfaces/aks-nodepool1-10706209-vmss",
 	}
+	vmIntf := AzureInterface{
+		ID: "/subscriptions/xxx/resourceGroups/az-test-rg/providers/Microsoft.Network/networkInterfaces/pods-interface",
+	}
 
-	c.Assert(intf.ResourceGroup(), check.Equals, "MC_aks-test_aks-test_westeurope")
-	c.Assert(intf.VMID(), check.Equals, "3")
-	c.Assert(intf.VMScaleSetName(), check.Equals, "aks-nodepool1-10706209-vmss")
+	c.Assert(vmssIntf.ResourceGroup(), check.Equals, "MC_aks-test_aks-test_westeurope")
+	c.Assert(vmssIntf.VMID(), check.Equals, "3")
+	c.Assert(vmssIntf.VMScaleSetName(), check.Equals, "aks-nodepool1-10706209-vmss")
+	c.Assert(vmIntf.ResourceGroup(), check.Equals, "az-test-rg")
 }


### PR DESCRIPTION
Support instances that are not part of a Virtual Machine Scale Set.

Cilium only assumption with regard to machines running in VMSS was
limited to interfaces discovery. Also listing standard (non-VMSS)
network interfaces from the same Azure ResourceGroup is all we need
for those to work with Cilium.

```release-note
Azure: support non VMSS instances
```