### PR TITLE
datapath: Fix removal of bpf_netdev

### DIFF
--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -604,9 +604,7 @@ for iface in $(ip -o -a l | awk '{print $2}' | cut -d: -f1 | cut -d@ -f1 | grep 
 	done
 	$found && continue
 	for where in ingress egress; do
-		# bpf_netdev.o was renamed in Cilium v1.8. The following code can be
-		# removed once v1.8 is the oldest supported version.
-		if tc filter show dev "$iface" "$where" | grep -q "bpf_netdev.o"; then
+		if tc filter show dev "$iface" "$where" | grep -q "bpf_netdev[^\.]*.o"; then
 			echo "Removing bpf_netdev.o from $where of $iface"
 			tc filter del dev "$iface" "$where" || true
 		fi


### PR DESCRIPTION
The name of a bpf_netdev object file which is attached to a native device has changed its name - from `bpf_netdev.o` to `bpf_netdev_${NATIVE_DEV_IFACE}.o`. E.g.:

```
$ sudo tc filter show dev enp0s8 ingress
filter protocol all pref 1 bpf chain 0
filter protocol all pref 1 bpf chain 0 handle 0x1 bpf_netdev_enp0s8.o:[from-netdev] direct-action not_in_hw id 982 tag feca2ca7f6f80c7e jited
```

The change of the name broke the removal of bpf_netdev from previously used native devs.

@pchaigno Do we plan to change the name format of the obj file? Asking, as if not, then the comment https://github.com/cilium/cilium/blob/pr/brb/fix-removal-bpf-netdev/bpf/init.sh#L607 might not be accurate.

Fixes: a695f532d06 ("Endpoint for host")