### PR TITLE
feat(operator): Reuse existing port on Cilium Operator health api

### DIFF
--- a/operator/main.go
+++ b/operator/main.go
@@ -256,7 +256,6 @@ func runOperator(cmd *cobra.Command) {
 								shortCutK8sCache: &sc,
 								k8sCache:         &k8sSvcCache,
 							}
-							break
 						case errors.IsNotFound(err):
 							scopedLog.Error("Service not found in k8s")
 						default:
@@ -327,5 +326,4 @@ func runOperator(cmd *cobra.Command) {
 	<-shutdownSignal
 	// graceful exit
 	log.Info("Received termination signal. Shutting down")
-	return
 }


### PR DESCRIPTION
Enable custom TPC listener with SO_REUSEADDR and SOL_SOCKET

Closes #11573

Signed-off-by: Tam Mach <sayboras@yahoo.com>

```release-note
Reuse existing port on Cilium Operator health api
```
