### PR TITLE
helm: Ensure hubble is enabled when hubble-{relay,ui} is deployed

### DIFF
--- a/install/kubernetes/cilium/charts/hubble-relay/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/hubble-relay/templates/deployment.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.hubble.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -72,4 +71,3 @@ spec:
           path: {{ dir .Values.global.hubble.socketPath }}
           type: Directory
         name: hubble-sock-dir
-{{- end }}

--- a/install/kubernetes/cilium/charts/hubble-relay/templates/service.yaml
+++ b/install/kubernetes/cilium/charts/hubble-relay/templates/service.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.hubble.enabled }}
 kind: Service
 apiVersion: v1
 metadata:
@@ -14,4 +13,3 @@ spec:
   - protocol: TCP
     port: {{ .Values.servicePort }}
     targetPort: {{ .Values.listenPort }}
-{{- end }}

--- a/install/kubernetes/cilium/charts/hubble-relay/templates/validation.yaml
+++ b/install/kubernetes/cilium/charts/hubble-relay/templates/validation.yaml
@@ -1,0 +1,5 @@
+{{- if .Values.global.hubble.relay.enabled }}
+  {{- if not .Values.global.hubble.enabled }}
+    {{ fail "hubble-relay requires global.hubble.enabled=true" }}
+  {{- end }}
+{{- end }}

--- a/install/kubernetes/cilium/charts/hubble-ui/templates/validation.yaml
+++ b/install/kubernetes/cilium/charts/hubble-ui/templates/validation.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.global.hubble.ui.enabled }}
+  {{- if not .Values.global.hubble.enabled }}
+    {{ fail "hubble-ui requires global.hubble.enabled=true" }}
+  {{- end }}
+  {{- if not .Values.global.hubble.relay.enabled }}
+    {{ fail "hubble-ui requires global.hubble.relay.enabled=true" }}
+  {{- end }}
+{{- end }}


### PR DESCRIPTION
Neither charts will work if `global.hubble.enabled=false`. Helm will omit the empty `validation.yaml` in case all checks pass. The pattern of using a separate file for checks is inspired by the [stable/jenkins](https://github.com/helm/charts/blob/3c1b9aae280f61fc294f901c60ecf943e11e965a/stable/jenkins/templates/deprecation.yaml) chart.

Fixes: #11518