### PR TITLE
pkg/allocator: Do not log `identity does not exist` if the attempt is not at max

### DIFF
--- a/pkg/k8s/identitybackend/identity.go
+++ b/pkg/k8s/identitybackend/identity.go
@@ -134,7 +134,7 @@ func (c *crdBackend) AcquireReference(ctx context.Context, id idpool.ID, key all
 		return err
 	}
 	if !exists {
-		return fmt.Errorf("identity does not exist")
+		return allocator.ErrIdentityNonExistent
 	}
 
 	capabilities := k8sversion.Capabilities()


### PR DESCRIPTION
Hi,

Previously, a `Key allocation attempt failed` warning was logged for `identity does not exist` errors even if maxAllocAttempts wasn't reached. This also increased the cilium_errors_warnings_total metric.

This patch logs a `Key allocation attempt failed` warning for non existent identities only if maxAllocAttempts is reached.

The error type is added to `pkg/allocator/allocator.go` in order to prevent a cyclic import with `pkg/k8s/identitybackend/identity.go`. Maybe you see a better location or solution for this?

`github.com/pkg/errors` is used for error wrapping instead of `errors` because this patch will be backported to v1.6 that uses Go 1.12.

This patch will also be backported to v1.6.

Fixes: #11487

```release-note
'identity does not exist' warning messages are not logged if the allocation attempt is not at max
```
