### PR TITLE
identity: Recognize host and health identities as fixed

### DIFF
--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -118,7 +118,9 @@ func (id *Identity) IsReserved() bool {
 // IsFixed returns whether the identity represents a fixed identity
 // (true), or not (false).
 func (id *Identity) IsFixed() bool {
-	return LookupReservedIdentity(id.ID) != nil && IsUserReservedIdentity(id.ID)
+	return LookupReservedIdentity(id.ID) != nil &&
+		(id.ID == ReservedIdentityHost || id.ID == ReservedIdentityHealth ||
+			IsUserReservedIdentity(id.ID))
 }
 
 // IsWellKnown returns whether the identity represents a well known identity


### PR DESCRIPTION
The health and host identities should be recognized as fixed because endpoints with these identities will never receive new ones. So there's no point waiting on the kvstore for these endpoints.

Fixes: #11559