### PR TITLE
Add schema validation for CiliumIdentity CRD

### DIFF
--- a/pkg/k8s/apis/cilium.io/v2/client/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/client/register.go
@@ -494,7 +494,8 @@ func createIdentityCRD(clientset apiextensionsclient.Interface) error {
 			Subresources: &apiextensionsv1beta1.CustomResourceSubresources{
 				Status: &apiextensionsv1beta1.CustomResourceSubresourceStatus{},
 			},
-			Scope: apiextensionsv1beta1.ClusterScoped,
+			Scope:      apiextensionsv1beta1.ClusterScoped,
+			Validation: &ciliumIdentityCRV,
 		},
 	}
 
@@ -627,6 +628,13 @@ var (
 	// creating them, it is better to be permissive and have some data, if buggy,
 	// than to have no data in k8s.
 	cepCRV = apiextensionsv1beta1.CustomResourceValidation{
+		OpenAPIV3Schema: &apiextensionsv1beta1.JSONSchemaProps{},
+	}
+
+	// ciliumIdentityCRV is a minimal validation for CiliumIdentity objects.
+	// It is empty because CiliumIdentity objects do not have a Spec, thus we
+	// are validating that we have an empty Spec.
+	ciliumIdentityCRV = apiextensionsv1beta1.CustomResourceValidation{
 		OpenAPIV3Schema: &apiextensionsv1beta1.JSONSchemaProps{},
 	}
 


### PR DESCRIPTION
Note: this PR does **not** need to be merged for the 1.8 release.

For CRDs created under apiextensions.k8s.io/v1, they will [require schema
validation](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#specifying-a-structural-schema). In preparation for Kubernetes 1.19 which defaults to
apiextensions.k8s.io/v1 CRDs, we will need to provide schema validation
for all CRDs. CiliumIdentity is the last CRD missing schema validation.
This commit implements the schema validation. Note that the validation
validates an empty Spec, and that's because CiliumIdentity does not have
a Spec, only a Status field.

Updates https://github.com/cilium/cilium/issues/11142
Related https://github.com/cilium/cilium/pull/11607