### PR TITLE
[v1.7] install: Remove IPAM setting

### DIFF
--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -175,7 +175,7 @@ data:
 {{- end }}
 
 {{- if .Values.global.gke.enabled }}
-  ipam: "kubernetes"
+  k8s-require-ipv4-pod-cidr: "true"
   tunnel: "disabled"
   enable-endpoint-routes: "true"
   blacklist-conflicting-routes: "false"


### PR DESCRIPTION
This line was mistakenly backported as part of 5053fe488815 ("gke:
Enable native-routing mode on GKE by default"), but this option does not
exist in the v1.7 tree. Remove it.

This change was already integrated as part of the v1.7.4 release charts, this commit brings the tree in line with what was released. 