### PR TITLE
loader: Move direct routing config. to node_config.h

### DIFF
--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -564,21 +564,6 @@ if [ "$MODE" = "direct" ] || [ "$MODE" = "ipvlan" ] || [ "$MODE" = "routed" ] ||
 			done
 		fi
 
-		NP_COPTS=""
-
-		if [ "$NODE_PORT" = "true" ] ; then
-			# First device from the list is used for direct routing between nodes
-			DIRECT_ROUTING_DEV=$(echo "${NATIVE_DEVS}" | cut -d\; -f1)
-			DIRECT_ROUTING_DEV_IDX=$(cat /sys/class/net/${DIRECT_ROUTING_DEV}/ifindex)
-			NP_COPTS="${NP_COPTS} -DDIRECT_ROUTING_DEV_IFINDEX=${DIRECT_ROUTING_DEV_IDX}"
-			if [ "$IP4_HOST" != "<nil>" ]; then
-				NP_COPTS="${NP_COPTS} -DIPV4_DIRECT_ROUTING=${v4_addrs[$DIRECT_ROUTING_DEV]}"
-			fi
-			if [ "$IP6_HOST" != "<nil>" ]; then
-				NP_COPTS="${NP_COPTS} -DIPV6_DIRECT_ROUTING_VAL={.addr={${v6_addrs[$DIRECT_ROUTING_DEV]}}}"
-			fi
-		fi
-
 		echo "$NATIVE_DEVS" > $RUNDIR/device.state
 	fi
 else
@@ -696,7 +681,7 @@ if [ "$XDP_DEV" != "<nil>" ]; then
 	fi
 	if [ "$NODE_PORT" = "true" ]; then
 		NATIVE_DEV_IDX=$(cat /sys/class/net/${XDP_DEV}/ifindex)
-		COPTS="${COPTS} ${NP_COPTS} -DNATIVE_DEV_IFINDEX=${NATIVE_DEV_IDX}"
+		COPTS="${COPTS} -DNATIVE_DEV_IFINDEX=${NATIVE_DEV_IDX}"
 		# Currently it assumes that XDP_DEV is listed among NATIVE_DEVS
 		if [ "$IP4_HOST" != "<nil>" ]; then
 			COPTS="${COPTS} -DIPV4_NODEPORT=${v4_addrs[$XDP_DEV]}"

--- a/bpf/node_config.h
+++ b/bpf/node_config.h
@@ -127,6 +127,16 @@ DEFINE_IPV6(HOST_IP, 0xbe, 0xef, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0xa, 0x
 #endif
 #endif
 
+#ifdef ENABLE_NODEPORT
+# define DIRECT_ROUTING_DEV_IFINDEX 0
+# ifdef ENABLE_IPV4
+#  define IPV4_DIRECT_ROUTING 0
+# endif
+# ifdef ENABLE_IPV6
+#  define IPV6_DIRECT_ROUTING { .addr = { 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 } }
+# endif
+#endif
+
 /* It appears that we can support around the below number of prefixes in an
  * unrolled loop for LPM CIDR handling in older kernels along with the rest of
  * the logic in the datapath, hence the defines below. This number was arrived

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -156,26 +156,12 @@ func patchHostNetdevDatapath(ep datapath.Endpoint, objPath, dstPath, ifName stri
 	}
 
 	if option.Config.EnableNodePort {
-		// First device from the list is used for direct routing between nodes
-		directRoutingIface := option.Config.Devices[0]
-		directRoutingIfIndex, err := link.GetIfIndex(directRoutingIface)
-		if err != nil {
-			return err
-		}
-		opts["DIRECT_ROUTING_DEV_IFINDEX"] = directRoutingIfIndex
 		opts["NATIVE_DEV_IFINDEX"] = ifIndex
 		if option.Config.EnableIPv4 {
-			ipv4 := nodePortIPv4Addrs[directRoutingIface]
-			opts["IPV4_DIRECT_ROUTING"] = byteorder.HostSliceToNetwork(ipv4, reflect.Uint32).(uint32)
-			ipv4 = nodePortIPv4Addrs[ifName]
+			ipv4 := nodePortIPv4Addrs[ifName]
 			opts["IPV4_NODEPORT"] = byteorder.HostSliceToNetwork(ipv4, reflect.Uint32).(uint32)
 		}
 		if option.Config.EnableIPv6 {
-			directRoutingIPv6 := nodePortIPv6Addrs[directRoutingIface]
-			opts["IPV6_DIRECT_ROUTING_1"] = sliceToBe32(directRoutingIPv6[0:4])
-			opts["IPV6_DIRECT_ROUTING_2"] = sliceToBe32(directRoutingIPv6[4:8])
-			opts["IPV6_DIRECT_ROUTING_3"] = sliceToBe32(directRoutingIPv6[8:12])
-			opts["IPV6_DIRECT_ROUTING_4"] = sliceToBe32(directRoutingIPv6[12:16])
 			nodePortIPv6 := nodePortIPv6Addrs[ifName]
 			opts["IPV6_NODEPORT_1"] = sliceToBe32(nodePortIPv6[0:4])
 			opts["IPV6_NODEPORT_2"] = sliceToBe32(nodePortIPv6[4:8])

--- a/pkg/datapath/loader/template.go
+++ b/pkg/datapath/loader/template.go
@@ -221,10 +221,6 @@ func elfVariableSubstitutions(ep datapath.Endpoint) map[string]uint32 {
 	// These values are defined in nodeport.h regardless even for bpf_lxc (so
 	// regardless of whether it's the host endpoint).
 	if option.Config.EnableNodePort && option.Config.EnableIPv6 {
-		result["IPV6_DIRECT_ROUTING_1"] = 0
-		result["IPV6_DIRECT_ROUTING_2"] = 0
-		result["IPV6_DIRECT_ROUTING_3"] = 0
-		result["IPV6_DIRECT_ROUTING_4"] = 0
 		result["IPV6_NODEPORT_1"] = 0
 		result["IPV6_NODEPORT_2"] = 0
 		result["IPV6_NODEPORT_3"] = 0
@@ -233,10 +229,8 @@ func elfVariableSubstitutions(ep datapath.Endpoint) map[string]uint32 {
 
 	if ep.IsHost() {
 		if option.Config.EnableNodePort {
-			result["DIRECT_ROUTING_DEV_IFINDEX"] = 0
 			result["NATIVE_DEV_IFINDEX"] = 0
 			if option.Config.EnableIPv4 {
-				result["IPV4_DIRECT_ROUTING"] = 0
 				result["IPV4_NODEPORT"] = 0
 			}
 		}


### PR DESCRIPTION
`DIRECT_ROUTING_DEV_IFINDEX`, `IPV4_DIRECT_ROUTING`, and `IPV6_DIRECT_ROUTING`
are common across all devices, so there's no need to use static data or `BPF_V6()` for them.