### PR TITLE
bpf: use per-cpu scratch space from xdp context to store meta data

### DIFF
--- a/bpf/include/bpf/api.h
+++ b/bpf/include/bpf/api.h
@@ -16,23 +16,6 @@
 #include "verifier.h"
 #include "tailcall.h"
 #include "errno.h"
-
-#define PIN_NONE		0
-#define PIN_OBJECT_NS		1
-#define PIN_GLOBAL_NS		2
-
-struct bpf_elf_map {
-	__u32 type;
-	__u32 size_key;
-	__u32 size_value;
-	__u32 max_elem;
-	__u32 flags;
-	__u32 id;
-	__u32 pinning;
-#ifdef SOCKMAP
-	__u32 inner_id;
-	__u32 inner_idx;
-#endif
-};
+#include "loader.h"
 
 #endif /* __BPF_API__ */

--- a/bpf/include/bpf/compiler.h
+++ b/bpf/include/bpf/compiler.h
@@ -44,6 +44,10 @@
 # define unlikely(X)		__builtin_expect(!!(X), 0)
 #endif
 
+#ifndef always_succeeds		/* Mainly for documentation purpose. */
+# define always_succeeds(X)	likely(X)
+#endif
+
 #undef __always_inline		/* stddef.h defines its own */
 #define __always_inline		inline __attribute__((always_inline))
 

--- a/bpf/include/bpf/loader.h
+++ b/bpf/include/bpf/loader.h
@@ -1,0 +1,27 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Copyright (C) 2016-2020 Authors of Cilium */
+
+#ifndef __BPF_LOADER__
+#define __BPF_LOADER__
+
+#include <linux/types.h>
+
+#define PIN_NONE		0
+#define PIN_OBJECT_NS		1
+#define PIN_GLOBAL_NS		2
+
+struct bpf_elf_map {
+	__u32 type;
+	__u32 size_key;
+	__u32 size_value;
+	__u32 max_elem;
+	__u32 flags;
+	__u32 id;
+	__u32 pinning;
+#ifdef SOCKMAP
+	__u32 inner_id;
+	__u32 inner_idx;
+#endif
+};
+
+#endif /* __BPF_LOADER__ */


### PR DESCRIPTION
Moving to per-CPU scratch space instead avoids cache-misses and allows
to keep the meta buffer always hot in cache. Only really adjust the
pkt meta data space if we push up the stack to signal tc layer that we
handled the service xlation. This improves the performance on my local
testing by roughly +1.2Mpps. We don't perform an expensive clearing of
the scratch space upon entering XDP as usage here is all self-contained
and across tail calls we only read out what we populated beforehand.

Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>
