### PR TITLE
test: disable MetalLB service test until there's a drop-in replacement

### DIFF
--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -531,6 +531,11 @@ func DoesNotExistNodeWithoutCilium() bool {
 	return !ExistNodeWithoutCilium()
 }
 
+// DoesNotSupportMetalLB tells whether our CI can run MetalLB
+func DoesNotSupportMetalLB() bool {
+	return true
+}
+
 // GetNodeWithoutCilium returns a name of a node which does not run cilium.
 func GetNodeWithoutCilium() string {
 	return os.Getenv("NO_CILIUM_ON_NODE")

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -1181,7 +1181,7 @@ var _ = Describe("K8sServicesTest", func() {
 						doRequestsFromThirdHostWithLocalPort(svc2URL, 1, false, 64002)
 					})
 
-					SkipContextIf(helpers.DoesNotExistNodeWithoutCilium, "Tests with MetalLB", func() {
+					SkipContextIf(helpers.DoesNotSupportMetalLB, "Tests with MetalLB, GH#10763", func() {
 						var (
 							metalLB string
 						)


### PR DESCRIPTION
MetalLB performs ARP announcements which confuses the vbox test env setup
since it infers IP addresses of its NAT device by sniffing ARP requests.
We need a open-coded dummy LB which triggers creation of LoadBalancer
service. Until then, disable it since it's causing too many CI flakes due
to this issue.

Related: #10763
Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>