### PR TITLE
helm: added global.cni.readCniConf parameter

### DIFF
--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -411,6 +411,8 @@ data:
 {{- if .Values.global.cni.configMap }}
   read-cni-conf: {{ .Values.global.cni.confFileMountPath }}/{{ .Values.global.cni.configMapKey }}
   write-cni-conf-when-ready: {{ .Values.global.cni.hostConfDirMountPath }}/05-cilium.conflist
+{{- else if .Values.global.cni.readCniConf }}
+  read-cni-conf: {{ .Values.global.cni.readCniConf }}
 {{- end }}
 {{- if .Values.global.kubeConfigPath }}
   k8s-kubeconfig-path: {{ .Values.global.kubeConfigPath | quote }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -174,6 +174,11 @@ global:
     # binPath si the path to the CNI binary directory on the host
     binPath: /opt/cni/bin
 
+    # readCniConf allows you to specifiy the path to a CNI config to read from on agent start
+    # This can be useful it you want to manage your CNI configuration outside of a Kubernetes
+    # This parameter is mutually exclusive with the following configMap parameter
+    # readCniConf: /host/etc/cni/net.d/05-cilium.conf
+
     # configMap when defined, will mount the provided value as ConfigMap  and
     # interpret the cniConf variable as CNI configuration file and write it
     # when the agent starts up


### PR DESCRIPTION
`global.cni.readCniConf` allows you to specifiy the path to a CNI config to read from on agent start

This can be useful it you want to manage your CNI configuration outside of a Kubernetes.
This new parameter is mutually exclusive with the `global.cni.configMap` one