### PR TITLE
loader: Attach bpf_host to cilium_net from Golang

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -5,13 +5,9 @@
 #include <bpf/api.h>
 
 #include <node_config.h>
-#ifdef POD_ENDPOINT
-# include <netdev_config.h>
-#else
-# include <ep_config.h>
-# define EVENT_SOURCE HOST_EP_ID
-#endif
+#include <ep_config.h>
 
+#define EVENT_SOURCE HOST_EP_ID
 
 /* These are configuartion options which have a default value in their
  * respective header files and must thus be defined beforehand:

--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -654,11 +654,9 @@ else
 	bpf_clear_cgroups $CGROUP_ROOT recvmsg6
 fi
 
-COPTS="-DPOD_ENDPOINT=1 -DSECLABEL=${ID_WORLD}"
-CALLS_MAP="cilium_calls_netdev_ns_${ID_HOST}"
-bpf_load $HOST_DEV2 "$COPTS" "ingress" bpf_host.c bpf_host.o to-host $CALLS_MAP
 if [ "$IPSEC" == "true" ]; then
 	if [ "$ENCRYPT_DEV" != "<nil>" ]; then
+		CALLS_MAP="cilium_calls_netdev_ns_${ID_HOST}"
 		bpf_load $ENCRYPT_DEV "" "ingress" bpf_network.c bpf_network.o from-network $CALLS_MAP
 	fi
 fi

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/link"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
 	"github.com/cilium/cilium/pkg/datapath/loader/metrics"
+	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/elf"
 	"github.com/cilium/cilium/pkg/logging"
@@ -155,7 +156,7 @@ func patchHostNetdevDatapath(ep datapath.Endpoint, objPath, dstPath, ifName stri
 		return err
 	}
 
-	if option.Config.EnableNodePort {
+	if option.Config.EnableNodePort && nodePortIPv4Addrs != nil && nodePortIPv6Addrs != nil {
 		opts["NATIVE_DEV_IFINDEX"] = ifIndex
 		if option.Config.EnableIPv4 {
 			ipv4 := nodePortIPv4Addrs[ifName]
@@ -201,6 +202,22 @@ func (l *Loader) reloadHostDatapath(ctx context.Context, ep datapath.Endpoint, o
 	directions[0], directions[1] = dirIngress, dirEgress
 	objPaths[0], objPaths[1] = objPath, objPath
 	interfaceNames[0], interfaceNames[1] = ep.InterfaceName(), ep.InterfaceName()
+
+	if datapathHasMultipleMasterDevices() {
+		if _, err := netlink.LinkByName(defaults.SecondHostDevice); err != nil {
+			log.WithError(err).WithField("device", defaults.SecondHostDevice).Error("Link does not exist")
+			return err
+		} else {
+			interfaceNames = append(interfaceNames, defaults.SecondHostDevice)
+			symbols = append(symbols, symbolToHostEp)
+			directions = append(directions, dirIngress)
+			secondDevObjPath := path.Join(ep.StateDir(), hostEndpointPrefix+"_"+defaults.SecondHostDevice+".o")
+			if err := patchHostNetdevDatapath(ep, objPath, secondDevObjPath, defaults.SecondHostDevice, nil, nil); err != nil {
+				return err
+			}
+			objPaths = append(objPaths, secondDevObjPath)
+		}
+	}
 
 	nodePortIPv4Addrs := node.GetNodePortIPv4AddrsWithDevices()
 	nodePortIPv6Addrs := node.GetNodePortIPv6AddrsWithDevices()
@@ -250,6 +267,13 @@ func (l *Loader) reloadHostDatapath(ctx context.Context, ep datapath.Endpoint, o
 	}
 
 	return nil
+}
+
+func datapathHasMultipleMasterDevices() bool {
+	// In Flannel's case or when using ipvlan, HOST_DEV2 is equal to HOST_DEV1
+	// in init.sh and we have a single master device.
+	return option.Config.DatapathMode != datapathOption.DatapathModeIpvlan &&
+		!option.Config.IsFlannelMasterDeviceSet()
 }
 
 func (l *Loader) reloadDatapath(ctx context.Context, ep datapath.Endpoint, dirs *directoryInfo) error {

--- a/pkg/defaults/node.go
+++ b/pkg/defaults/node.go
@@ -33,6 +33,8 @@ const (
 	// HostDevice is the name of the device that connects the cilium IP
 	// space with the host's networking model
 	HostDevice = "cilium_host"
+	// SecondHostDevice is the name of the second interface of the host veth pair.
+	SecondHostDevice = "cilium_net"
 )
 
 var (


### PR DESCRIPTION
Attach `bpf_host` to the second host device (i.e., `cilium_net`) from Golang, as part of the host endpoint's datapath loading, instead of doing it from `init.sh`.

Doing so has the following benefits:
- We compile one less time because we only need to patch the object file
  on the Go side.
- It simplifies the weird dance around includes in `bpf_host.c`.
- It moves more code out of `init.sh`.