### PR TITLE
Fix pre-flight deployment

### DIFF
--- a/.github/workflows/helm-check.yaml
+++ b/.github/workflows/helm-check.yaml
@@ -7,6 +7,20 @@ on:
       - master
 
 jobs:
+  preflight-clusterrole:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check pre-flight clusterrole
+        run: |
+          cd install/kubernetes/cilium/charts
+          echo "Checking for differences between preflight and agent clusterrole"
+          diff \
+             -I '^[ ]\{2\}name: cilium.*' \
+             -I '^Keep file in synced with.*' \
+             agent/templates/clusterrole.yaml \
+             preflight/templates/clusterrole.yaml
+
   quick-install:
     runs-on: ubuntu-latest
     steps:

--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -38,6 +38,7 @@ file.
     .. parsed-literal::
 
       helm template |CHART_RELEASE| \\
+        --namespace=kube-system \\
         --set preflight.enabled=true \\
         --set agent.enabled=false \\
         --set config.enabled=false \\
@@ -61,6 +62,7 @@ file.
     .. parsed-literal::
 
       helm template |CHART_RELEASE| \\
+        --namespace=kube-system \\
         --set preflight.enabled=true \\
         --set agent.enabled=false \\
         --set config.enabled=false \\

--- a/install/kubernetes/cilium/charts/preflight/templates/clusterrole.yaml
+++ b/install/kubernetes/cilium/charts/preflight/templates/clusterrole.yaml
@@ -1,10 +1,10 @@
 {{- /*
-Keep file in synced with ../../preflight/templates/clusterrole.yaml
+Keep file in synced with ../../agent/templates/clusterrole.yaml
 */ -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: cilium
+  name: cilium-pre-flight
 rules:
 - apiGroups:
   - networking.k8s.io

--- a/install/kubernetes/cilium/charts/preflight/templates/clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/charts/preflight/templates/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cilium-pre-flight
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium-pre-flight
+subjects:
+- kind: ServiceAccount
+  name: cilium
+  namespace: {{ .Release.Namespace }}

--- a/install/kubernetes/cilium/charts/preflight/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/preflight/templates/deployment.yaml
@@ -52,6 +52,7 @@ spec:
               - /tmp/ready-validate-cnp
             initialDelaySeconds: 5
             periodSeconds: 5
+{{- if or ( ( not ( empty ( .Values.global.k8sServiceHost))) ( ( not ( empty ( .Values.global.k8sServicePort ))))) }}
           env:
 {{- if .Values.global.k8sServiceHost }}
           - name: KUBERNETES_SERVICE_HOST
@@ -60,6 +61,7 @@ spec:
 {{- if .Values.global.k8sServicePort }}
           - name: KUBERNETES_SERVICE_PORT
             value: {{ .Values.global.k8sServicePort | quote }}
+{{- end }}
 {{- end }}
 {{- end }}
       hostNetwork: true

--- a/install/kubernetes/cilium/charts/preflight/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/preflight/templates/deployment.yaml
@@ -52,7 +52,7 @@ spec:
               - /tmp/ready-validate-cnp
             initialDelaySeconds: 5
             periodSeconds: 5
-{{- if or ( ( not ( empty ( .Values.global.k8sServiceHost))) ( ( not ( empty ( .Values.global.k8sServicePort ))))) }}
+{{- if not ( and ( empty ( .Values.global.k8sServiceHost ))  ( empty ( .Values.global.k8sServicePort ))) }}
           env:
 {{- if .Values.global.k8sServiceHost }}
           - name: KUBERNETES_SERVICE_HOST


### PR DESCRIPTION
Read per commit basis.

Fixes issues like:

* EndpointSlices resource fetch errors on older k8s versions:
   ```
   time="2020-05-19T08:03:31Z" level=info msg="Setting up Kubernetes client"
   time="2020-05-19T08:03:31Z" level=info msg="Establishing connection to apiserver" host="https://172.20.0.1:443" subsys=k8s
   time="2020-05-19T08:03:31Z" level=info msg="Connected to apiserver" subsys=k8s
   time="2020-05-19T08:03:31Z" level=fatal msg="Unable to connect to Kubernetes apiserver" error="unable to validate EndpointSlices support: endpointslices.discovery.k8s.io \"kubernetes\" is forbidden: User \"system:serviceaccount:kube-system:cilium\" cannot get resource \"endpointslices\" in API group \"discovery.k8s.io\" in the namespace \"default\""
   ```
* CCNP errors in v1.7:
   ```
   msg="ciliumclusterwidenetworkpolicies.cilium.io is forbidden: User \"system:serviceaccount:kube-system:cilium\" cannot list resource \"ciliumclusterwidenetworkpolicies\" in API group \"cilium.io\" at the cluster scope"
   ```
   ```
   time="2020-05-19T09:39:20Z" level=info msg="Unable to retrieve EndpointSlices for default/kubernetes. Disabling EndpointSlices" error="the server could not find the requested resource (get endpointslices.discovery.k8s.io kubernetes)" subsys=k8s
   time="2020-05-19T09:39:20Z" level=error msg="the server could not find the requested resource (get ciliumclusterwidenetworkpolicies.cilium.io)"
   ```


```release-note
Fix pre-flight deployment for users upgrading from < 1.7
```