### PR TITLE
install: Fix erroneous comment

### DIFF
--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -406,7 +406,6 @@ data:
   k8s-kubeconfig-path: {{ .Values.global.kubeConfigPath | quote }}
 {{- end }}
 {{- if and ( .Values.global.endpointHealthChecking.enabled ) (or (eq .Values.global.cni.chainingMode "portmap") (eq .Values.global.cni.chainingMode "none")) }}
-  # Chaining mode is set to portmap, enable health checking
   enable-endpoint-health-checking: "true"
 {{- else}}
   # Disable health checking, when chaining mode is not set to portmap or none

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -166,7 +166,6 @@ data:
   enable-session-affinity: "true"
   k8s-require-ipv4-pod-cidr: "true"
   k8s-require-ipv6-pod-cidr: "false"
-  # Chaining mode is set to portmap, enable health checking
   enable-endpoint-health-checking: "true"
   enable-health-checking: "true"
   enable-well-known-identities: "false"


### PR DESCRIPTION
This comment implies that portmap is enabled, but the check immediately
above also covers the case where there is no chaining mode. Remove the
invalid comment.