### PR TITLE
test: Fix running CI on microk8s

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -137,6 +137,7 @@ var (
 	}
 
 	microk8sHelmOverrides = map[string]string{
+		"global.ipv6.enabled":   "false",
 		"global.cni.confPath":   "/var/snap/microk8s/current/args/cni-network",
 		"global.cni.binPath":    "/var/snap/microk8s/current/opt/cni/bin",
 		"global.cni.customConf": "true",

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -455,6 +455,7 @@ func (kub *Kubectl) PrepareCluster() {
 		"default",
 		"kube-node-lease",
 		"kube-public",
+		"container-registry",
 	})
 	if err != nil {
 		ginkgoext.Failf("Unable to delete non-essential namespaces: %s", err)


### PR DESCRIPTION
Commit 31f3b5e5b984 ("test: Delete all non-essential namespaces before
initial test") broke CI_INTEGRATION=microk8s by clobbering the namespace
used for deploying the container image. Fix it by adding this namespace
to the list of sacred namespaces that the CI won't touch.

Commit ced4ad0bcaa8 ("ipam: Add "kubernetes" IPAM mode") autoenabled
--k8s-require-ipv6-pod-cidr if --enable-ipv6 is enabled, which causes a
Cilium to get stuck waiting for the IPv6 pod CIDR to be populated in the
node. Fix it by disabling ipv6 for microk8s CI.