### PR TITLE
test: Add K8sServicesTest with L4-only policy

### DIFF
--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -1036,6 +1036,27 @@ var _ = Describe("K8sServicesTest", func() {
 			testExternalTrafficPolicyLocal()
 		})
 
+		SkipContextIf(helpers.RunsWithoutKubeProxy, "with L4 policy", func() {
+			var (
+				demoPolicy string
+			)
+
+			BeforeAll(func() {
+				demoPolicy = helpers.ManifestGet(kubectl.BasePath(), "l4-policy-demo.yaml")
+			})
+
+			AfterAll(func() {
+				// Explicitly ignore result of deletion of resources to avoid incomplete
+				// teardown if any step fails.
+				_ = kubectl.Delete(demoPolicy)
+			})
+
+			It("Tests NodePort with L4 Policy", func() {
+				applyPolicy(demoPolicy)
+				testNodePort(false, false, false)
+			})
+		})
+
 		SkipContextIf(
 			func() bool {
 				return true // GH-11578

--- a/test/k8sT/manifests/l4-policy-demo.yaml
+++ b/test/k8sT/manifests/l4-policy-demo.yaml
@@ -1,0 +1,17 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+description: "L4 policy for allowing all traffic in demo DS"
+metadata:
+  name: "l4-policy-demo"
+spec:
+  endpointSelector:
+    matchLabels:
+      zgroup: testDS
+  ingress:
+  - toPorts:
+    - ports:
+      - port: "80"
+        protocol: TCP
+    - ports:
+      - port: "69"
+        protocol: UDP


### PR DESCRIPTION
Test flakes with L7 policy seem to be independent of the proxy
redirection (e.g., tftp is not redirected, and still flakes). Add a
new test with an L4-only policy to see if it also flakes.

In local testing there are failures roughly on ~1/100 tests, when
running a test in a loop:

$ for i in {1..100}; do if kubectl exec -n kube-system log-gatherer-w4kbp \
 -- curl --path-as-is -s -D /dev/stderr --fail --connect-timeout 5 \
 --max-time 8 http://127.0.0.1:30870 2>/dev/null >/dev/null; \
 then printf +; else printf $?; fi ; done && printf "\n"
+++++++++++++++++++++++++28+++++++++++++++++++++++++28++++++++++++++++++++++++++++++++++++++++++++++++

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
