### PR TITLE
test(k8s): Correct prometheus template

### DIFF
--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -177,7 +177,7 @@ var _ = BeforeAll(func() {
 	case helpers.CIIntegrationFlannel:
 		switch helpers.GetCurrentK8SEnv() {
 		case "1.8":
-			log.Infof("Cilium in %q mode is not supported in Kubernets 1.8 due CNI < 0.6.0", helpers.CIIntegrationFlannel)
+			log.Infof("Cilium in %q mode is not supported in Kubernetes 1.8 due CNI < 0.6.0", helpers.CIIntegrationFlannel)
 			os.Exit(0)
 			return
 		}
@@ -264,7 +264,7 @@ var _ = BeforeAll(func() {
 		kubectl := helpers.CreateKubectl(helpers.K8s1VMName(), logger)
 		kubectl.PrepareCluster()
 
-		kubectl.ApplyDefault(kubectl.GetFilePath("../examples/kubernetes/addons/prometheus/prometheus.yaml"))
+		kubectl.ApplyDefault(kubectl.GetFilePath("../examples/kubernetes/addons/prometheus/monitoring-example.yaml"))
 
 		go kubectl.PprofReport()
 	}


### PR DESCRIPTION
The original template prometheus.yaml was changed as part of
https://github.com/cilium/cilium/pull/6706.

Update path to point to monitoring-example.yaml instead.

Closes #11522

Signed-off-by: Tam Mach <sayboras@yahoo.com>

```release-note
Correct prometheus template in integration test
```
