### PR TITLE
hubble-relay: enable gRPC reflection

### DIFF
--- a/pkg/hubble/relay/server.go
+++ b/pkg/hubble/relay/server.go
@@ -30,6 +30,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/reflection"
 )
 
 type hubblePeer struct {
@@ -82,6 +83,7 @@ func (s *Server) Serve() error {
 		return fmt.Errorf("failed to listen on tcp socket %s: %v", s.opts.ListenAddress, err)
 	}
 	go s.syncPeers()
+	reflection.Register(s.server)
 	return s.server.Serve(socket)
 }
 


### PR DESCRIPTION
This feature is useful for discovering the gRPC API without referring to
the .proto files.

Example:

    $ grpcurl -plaintext localhost:4245 list
    grpc.health.v1.Health
    grpc.reflection.v1alpha.ServerReflection
    observer.Observer

    $ grpcurl -plaintext localhost:4245 describe observer.Observer
    observer.Observer is a service:
    service Observer {
      rpc GetFlows ( .observer.GetFlowsRequest ) returns ( stream .observer.GetFlowsResponse );
      rpc ServerStatus ( .observer.ServerStatusRequest ) returns ( .observer.ServerStatusResponse );
    }

    $ grpcurl -plaintext localhost:4245 describe observer.GetFlowsRequest
    observer.GetFlowsRequest is a message:
    message GetFlowsRequest {
      uint64 number = 1;
      bool follow = 3;
      repeated .flow.FlowFilter blacklist = 5;
      repeated .flow.FlowFilter whitelist = 6;
      .google.protobuf.Timestamp since = 7;
      .google.protobuf.Timestamp until = 8;
    }