### PR TITLE
contrib/vagrant: enable hubble listener on :4244 (TCP) by default

### DIFF
--- a/contrib/vagrant/start.sh
+++ b/contrib/vagrant/start.sh
@@ -304,7 +304,7 @@ function write_cilium_cfg() {
     ipv6_addr="${3}"
     filename="${4}"
 
-    cilium_options=" --debug --pprof --enable-hubble --enable-k8s-event-handover --k8s-require-ipv4-pod-cidr --auto-direct-node-routes"
+    cilium_options=" --debug --pprof --enable-hubble --hubble-listen-address :4244 --enable-k8s-event-handover --k8s-require-ipv4-pod-cidr --auto-direct-node-routes"
     cilium_operator_options=" --debug"
 
     if [[ "${IPV4}" -eq "1" ]]; then


### PR DESCRIPTION
Hubble-relay needs to connect to hubble peers for multi-node support.
Enabling hubble server on :4244 makes working on hubble-relay easier as
one does not need to perform an extra step to reconfigure every VM on a
locally deployed vagrant k8s cluster to start playing with hubble-relay.