### PR TITLE
test/k8s: Migrate L7 visibility tests to hubble

### DIFF
--- a/test/k8sT/Policies.go
+++ b/test/k8sT/Policies.go
@@ -1104,6 +1104,7 @@ var _ = Describe("K8sPolicyTest", func() {
 			// avoid incomplete teardown if any step fails.
 			_ = kubectl.Delete(demoYAML)
 			ExpectAllPodsTerminated(kubectl)
+			kubectl.DeleteHubbleClientPods(helpers.CiliumNamespace)
 		})
 
 		AfterEach(func() {


### PR DESCRIPTION
Remove usage of monitor in the L7 visibility tests and
replace them with hubble using jsonpath filter to validate
concrete items.

Fixes #11396

Signed-off-by: Glib Smaga <code@gsmaga.com>