### PR TITLE
Re-enable Services test with l7 policy

### DIFF
--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -1059,10 +1059,9 @@ var _ = Describe("K8sServicesTest", func() {
 
 		SkipContextIf(
 			func() bool {
-				return true // GH-11578
-				//return helpers.IsIntegration(helpers.CIIntegrationEKS) ||
-				//helpers.IsIntegration(helpers.CIIntegrationGKE) || // Re-enable when GH-11235 is fixed
-				//helpers.RunsWithoutKubeProxy()
+				return helpers.IsIntegration(helpers.CIIntegrationEKS) ||
+					helpers.IsIntegration(helpers.CIIntegrationGKE) || // Re-enable when GH-11235 is fixed
+					helpers.RunsWithoutKubeProxy()
 			},
 			"with L7 policy", func() {
 				var (


### PR DESCRIPTION
Try with L7 after some of the testing improvements introduced since this test was disabled.

Fixes: #11578