### PR TITLE
Add CI flag -cilium.multinode[=true]

### DIFF
--- a/test/config/config.go
+++ b/test/config/config.go
@@ -40,6 +40,9 @@ type CiliumTestConfigType struct {
 	Kubeconfig          string
 	Registry            string
 	Benchmarks          bool
+	// Multinode enables the running of tests that involve more than one
+	// node. If false, some tests will silently skip multinode checks.
+	Multinode bool
 }
 
 // CiliumTestConfig holds the global configuration of commandline flags
@@ -77,4 +80,6 @@ func (c *CiliumTestConfigType) ParseFlags() {
 	flag.StringVar(&c.Registry, "cilium.registry", "", "docker registry hostname for Cilium image")
 	flag.BoolVar(&c.Benchmarks, "cilium.benchmarks", false,
 		"Specifies benchmark tests should be run which may increase test time")
+	flag.BoolVar(&c.Multinode, "cilium.multinode", true,
+		"Enable tests across multiple nodes. If disabled, such tests may silently pass")
 }

--- a/test/helpers/manifest.go
+++ b/test/helpers/manifest.go
@@ -198,8 +198,8 @@ func (m *DeploymentManager) DeployRandomNamespaceShared(manifest Manifest) strin
 	return m.DeployRandomNamespace(manifest)
 }
 
-// Deploy deploys a manifest into a random namespace using the deployment
-// manager and stores the deployment in the manager
+// DeployRandomNamespace deploys a manifest into a random namespace using the
+// deployment manager and stores the deployment in the manager
 func (m *DeploymentManager) DeployRandomNamespace(manifest Manifest) string {
 	namespace := GenerateNamespaceForTest("")
 

--- a/test/helpers/manifest.go
+++ b/test/helpers/manifest.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cilium/cilium/test/config"
 	ginkgoext "github.com/cilium/cilium/test/ginkgo-ext"
 )
 
@@ -37,6 +38,12 @@ type Manifest struct {
 	// Filename is the file (not path) of the manifest. This must point to
 	// a file that contains any number of Deployments, DaemonSets, ...
 	Filename string
+
+	// Alternate is an alternative file (not path) of the manifest that
+	// takes the place of 'Filename' for single-node testing. It is
+	// otherwise equivalent and must point to a file containing resources
+	// to deploy.
+	Alternate string
 
 	// DaemonSetNames is the list of all daemonset names in the manifest
 	DaemonSetNames []string
@@ -61,9 +68,13 @@ type Manifest struct {
 	Singleton bool
 }
 
-// GetFilename resolves the filename for the manifest.
+// GetFilename resolves the filename for the manifest depending on whether the
+// alternate filename is used (ie, single node testing YAMLs)
 func (m Manifest) GetFilename() string {
-	return m.Filename
+	if config.CiliumTestConfig.Multinode {
+		return m.Filename
+	}
+	return m.Alternate
 }
 
 // Deploy deploys the manifest. It will call ginkgoext.Fail() if any aspect of

--- a/test/k8sT/manifests.go
+++ b/test/k8sT/manifests.go
@@ -23,6 +23,7 @@ var (
 
 	DemoDaemonSet = helpers.Manifest{
 		Filename:        "demo_ds.yaml",
+		Alternate:       "demo_ds_local.yaml",
 		DaemonSetNames:  []string{"testds", "testclient"},
 		DeploymentNames: []string{"test-k8s2"},
 		NumPods:         1,

--- a/test/k8sT/manifests/demo_ds_local.yaml
+++ b/test/k8sT/manifests/demo_ds_local.yaml
@@ -1,0 +1,233 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: testds
+spec:
+  selector:
+    matchLabels:
+      zgroup: testDS
+  template:
+    metadata:
+      labels:
+        zgroup: testDS
+    spec:
+      containers:
+      - name: web
+        image: docker.io/cilium/echoserver:1.10.1
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 80
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
+      - name: udp
+        image: docker.io/cilium/echoserver-udp:v2020.01.30
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 69
+          protocol: UDP
+      terminationGracePeriodSeconds: 0
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: testclient
+spec:
+  selector:
+    matchLabels:
+      zgroup: testDSClient
+  template:
+    metadata:
+      labels:
+        zgroup: testDSClient
+    spec:
+      terminationGracePeriodSeconds: 0
+      containers:
+      - name: web
+        image: docker.io/cilium/demo-client:latest
+        imagePullPolicy: IfNotPresent
+        command: [ "sleep" ]
+        args:
+          - "1000h"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-k8s2
+spec:
+  selector:
+    matchLabels:
+      zgroup: test-k8s2
+  template:
+    metadata:
+      labels:
+        zgroup: test-k8s2
+    spec:
+      containers:
+      - name: web
+        image: docker.io/cilium/echoserver:1.10.1
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 80
+          hostPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
+      - name: udp
+        image: docker.io/cilium/echoserver-udp:v2020.01.30
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 69
+          hostPort: 6969
+          protocol: UDP
+      terminationGracePeriodSeconds: 0
+      nodeSelector:
+        "cilium.io/ci-node": k8s1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: testds-service
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: 80
+    protocol: TCP
+  - name: tftp
+    port: 69
+    targetPort: 69
+    protocol: UDP
+  selector:
+    zgroup: testDS
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-nodeport
+spec:
+  type: NodePort
+  ports:
+  - port: 10080
+    targetPort: 80
+    protocol: TCP
+    name: http
+  - port: 10069
+    targetPort: 69
+    protocol: UDP
+    name: tftp
+  selector:
+    zgroup: testDS
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-affinity
+spec:
+  type: NodePort
+  ports:
+  - port: 10080
+    targetPort: 80
+    protocol: TCP
+    name: http
+  - port: 10069
+    targetPort: 69
+    protocol: UDP
+    name: tftp
+  sessionAffinity: ClientIP
+  selector:
+    zgroup: testDS
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-nodeport-local
+spec:
+  type: NodePort
+  externalTrafficPolicy: Local
+  ports:
+  - port: 10080
+    targetPort: 80
+    protocol: TCP
+    name: http
+  - port: 10069
+    targetPort: 69
+    protocol: UDP
+    name: tftp
+  selector:
+    zgroup: testDS
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-nodeport-local-k8s2
+spec:
+  type: NodePort
+  externalTrafficPolicy: Local
+  ports:
+  - port: 10080
+    targetPort: 80
+    protocol: TCP
+    name: http
+  - port: 10069
+    targetPort: 69
+    protocol: UDP
+    name: tftp
+  selector:
+    zgroup: test-k8s2
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-nodeport-k8s2
+spec:
+  type: NodePort
+  ports:
+  - port: 10080
+    targetPort: 80
+    protocol: TCP
+    name: http
+  - port: 10069
+    targetPort: 69
+    protocol: UDP
+    name: tftp
+  selector:
+    zgroup: test-k8s2
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-lb
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+    name: http
+  selector:
+    zgroup: testDS
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-lb-local-k8s2
+spec:
+  type: LoadBalancer
+  externalTrafficPolicy: Local
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+    name: http
+  selector:
+    zgroup: test-k8s2

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -88,6 +88,15 @@ func TestTest(t *testing.T) {
 	}
 	if integration := helpers.GetCurrentIntegration(); integration != "" {
 		fmt.Printf("Using CNI_INTEGRATION=%q\n", integration)
+
+		switch integration {
+		case helpers.CIIntegrationMicrok8s:
+			fallthrough
+		case helpers.CIIntegrationMinikube:
+			fmt.Printf("Disabling multinode testing")
+			config.CiliumTestConfig.Multinode = false
+		default:
+		}
 	}
 
 	configLogsOutput()


### PR DESCRIPTION
I've previously had some success running the `K8sDatapathConfig` tests on a local microk8s (single-node) cluster by hacking some variables in the tests. Recent refactoring as part of the manifest deploymentmanager has broken this workflow, so I figured it's about time to formalize this to support this use case properly.

This PR adds a new ginkgo flag, `-cilium.multinode` which defaults to true (the current behaviour); if set to false, or if running with `CNI_INTEGRATION={microk8s,minikube}` , it allows running tests that assume multinode connectivity within a single node by avoiding nodeselectors that require a second node. This can be useful for some basic debugging of the tests in a single-node environment before moving to a more complicated environment. Note that the node must still have the k8s1 ci node label.