### PR TITLE
Fix issue where Cilium-agent fails to start on nodes without a default gateway

### DIFF
--- a/pkg/mtu/detect_linux.go
+++ b/pkg/mtu/detect_linux.go
@@ -59,6 +59,10 @@ func autoDetect() (int, error) {
 		}
 	}
 
+	if routes[0].Gw == nil {
+		return 0, fmt.Errorf("unable to find default gateway from the routes: %s", routes)
+	}
+
 	link, err := netlink.LinkByIndex(routes[0].LinkIndex)
 	if err != nil {
 		return 0, fmt.Errorf("unable to find interface of default route: %s", err)


### PR DESCRIPTION
This PR fixes the problem by checking for the default gateway
in the existing routes and if gateway is absent the 'autoDetect'
fails.
When autoDetect fails we set the default 'Ethernetmtu' and will
also raise a warning message.

Fixes: #11588
Signed-off-by: Swaminathan Vasudevan <svasudevan@suse.com>

