### PR TITLE
Support DNS matchPattern="*" to match "."

### DIFF
--- a/pkg/fqdn/matchpattern/matchpattern.go
+++ b/pkg/fqdn/matchpattern/matchpattern.go
@@ -57,7 +57,7 @@ func ToRegexp(pattern string) string {
 
 	// handle the * match-all case. This will filter down to the end.
 	if pattern == "*" {
-		pattern = "(" + allowedDNSCharsREGroup + "+.)+"
+		return "(^(" + allowedDNSCharsREGroup + "+[.])+$)|(^[.]$)"
 	}
 
 	// base case. * becomes .*, but only for DNS valid characters

--- a/pkg/fqdn/matchpattern/matchpattern_test.go
+++ b/pkg/fqdn/matchpattern/matchpattern_test.go
@@ -42,7 +42,8 @@ func (ts *MatchPatternTestSuite) TestMatchPatternREConversion(c *C) {
 	for source, target := range map[string]string{
 		"cilium.io.":   "^cilium[.]io[.]$",
 		"*.cilium.io.": "^" + allowedDNSCharsREGroup + "*[.]cilium[.]io[.]$",
-		"*":            "^(" + allowedDNSCharsREGroup + "+[.])+$",
+		"*":            "(^(" + allowedDNSCharsREGroup + "+[.])+$)|(^[.]$)",
+		".":            "^[.]$",
 	} {
 		reStr := ToRegexp(source)
 		_, err := regexp.Compile(reStr)
@@ -79,8 +80,13 @@ func (ts *MatchPatternTestSuite) TestMatchPatternMatching(c *C) {
 		},
 		{
 			pattern: "*",
-			accept:  []string{"io.", "cilium.io.", "svc.cluster.local.", "service.namesace.svc.cluster.local.", "_foobar._tcp.cilium.io."}, // the last is for SRV RFC-2782 and DNS-SD RFC6763
-			reject:  []string{"", ".", ".io.", ".cilium.io.", ".svc.cluster.local.", "cilium.io"},                                          // note no final . on this last one
+			accept:  []string{".", "io.", "cilium.io.", "svc.cluster.local.", "service.namesace.svc.cluster.local.", "_foobar._tcp.cilium.io."}, // the last is for SRV RFC-2782 and DNS-SD RFC6763
+			reject:  []string{"", ".io.", ".cilium.io.", ".svc.cluster.local.", "cilium.io"},                                                    // note no final . on this last one
+		},
+		{
+			pattern: ".",
+			accept:  []string{"."},
+			reject:  []string{"", ".io.", ".cilium.io"},
 		},
 
 		// These are more explicit tests for SRV RFC-2782 and DNS-SD RFC6763


### PR DESCRIPTION
DNS servers may request a list of root nameservers by forming an NS
request for `.`. We have received reports that when applying a
visibility policy with the DNS matchPattern `*`, DNS requests of this
kind were being dropped in the proxy.

Fix this by extending the visibility match `*` to explicitly match on
either `[validdnscharacters].`, or `.`. If the matchPattern is more
complicated than simply `*`, do not match on `.`.