### PR TITLE
k8s: Fix CCNP for host policies

### DIFF
--- a/examples/policies/l3/host/host-policy.yaml
+++ b/examples/policies/l3/host/host-policy.yaml
@@ -1,0 +1,29 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumClusterwideNetworkPolicy
+description: "Allow ports for kube-dns, kube-api, Cilium, and SSH, as well as queries to Google's DNS on UDP/53 only"
+metadata:
+  name: "allow-google-dns-on-udp-53-only"
+spec:
+  nodeSelector:
+    matchLabels:
+      {}
+  ingress:
+  - toPorts:
+    - ports:
+      - port: "6443"
+        protocol: TCP
+      - port: "22"
+        protocol: TCP
+  egress:
+  - toPorts:
+    - ports:
+      - port: "4240"
+        protocol: TCP
+      - port: "8080"
+        protocol: TCP
+  - toCIDR:
+    - "8.8.0.0/16"
+    toPorts:
+    - ports:
+      - port: "53"
+        protocol: UDP

--- a/pkg/k8s/apis/cilium.io/v2/types.go
+++ b/pkg/k8s/apis/cilium.io/v2/types.go
@@ -260,7 +260,6 @@ func (r *CiliumNetworkPolicy) Parse() (api.Rules, error) {
 	if r.Spec != nil {
 		if err := r.Spec.Sanitize(); err != nil {
 			return nil, fmt.Errorf("Invalid CiliumNetworkPolicy spec: %s", err)
-
 		}
 		cr := k8sCiliumUtils.ParseToCiliumRule(namespace, name, uid, r.Spec)
 		retRules = append(retRules, cr)


### PR DESCRIPTION
This commit fixes the CNP/CCNP parsing to accept `NodeSelectors`, used to define host policies. `NodeSelectors` are only accepted in CCNP resources. Because host policies are never limited to a namespace, it would be misleading to accept `NodeSelectors` in CNP resources.

This commit also adds a new CCNP example of host policies in the same directory as the existing JSON example.

Fixes: #11507