### PR TITLE
Adding connectivity test to troubleshooting doc

### DIFF
--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -354,6 +354,7 @@ inlining
 inodes
 integrations
 internet
+intra
 io
 ip
 ipam

--- a/Documentation/troubleshooting.rst
+++ b/Documentation/troubleshooting.rst
@@ -148,7 +148,33 @@ Cilium connectivity tests
 The Cilium connectivity test_ deploys a series of services, deployments, and 
 CiliumNetworkPolicy which will use various connectivity paths to connect to 
 each other. Connectivity paths include with and without service load-balancing 
-and various network policy combinations. The pod name indicates the connectivity
+and various network policy combinations. 
+
+.. Note::
+
+          The connectivity tests this will only work in a namespace with no
+          other pods or network policies applied. If there is a Cilium
+          Clusterwide Network Policy enabled, that may also break this
+          connectivity check.
+          
+To run the connectivity tests create an isolated test namespace called
+``cilium-test`` to deploy the tests with. 
+
+.. code:: bash
+
+    $ kubectl create ns cilium-test
+    $ kubectl apply --namespace=cilium-test -f \ |SCM_WEB|\/examples/kubernetes/connectivity-check/connectivity-check.yaml
+
+The tests cover various functionality of the system. Below we call out each test
+type. If tests pass, it suggests functionality of the referenced subsystem.
+
++---------------------------+----------------------------+-------------------------------+-----------------------------+----------------------------------------+
+| Pod-to-pod (intra-host)   | Pod-to-pod (inter-host)    | Pod-to-service (intra-host)   | Pod-to-service (inter-host) | Pod-to-external resource               | 
++===========================+============================+===============================+=============================+========================================+
+| BPF routing is functional | Dataplane, routing, network| BPF service map lookup        | VXLAN overlay port if used  | Egress, CiliumNetworkPolicy, masquerade|
++---------------------------+----------------------------+-------------------------------+-----------------------------+----------------------------------------+
+
+The pod name indicates the connectivity
 variant and the readiness and liveness gate indicates success or failure of the
 test:
 

--- a/Documentation/troubleshooting.rst
+++ b/Documentation/troubleshooting.rst
@@ -152,7 +152,7 @@ and various network policy combinations. The pod name indicates the connectivity
 variant and the readiness and liveness gate indicates success or failure of the
 test:
 
-.. _test: https://raw.githubusercontent.com/cilium/cilium/1.7.4/examples/kubernetes/connectivity-check/connectivity-check.yaml
+.. _test: \ |SCM_WEB|\/examples/kubernetes/connectivity-check/connectivity-check.yaml
 
 .. code:: bash
 

--- a/Documentation/troubleshooting.rst
+++ b/Documentation/troubleshooting.rst
@@ -168,11 +168,11 @@ To run the connectivity tests create an isolated test namespace called
 The tests cover various functionality of the system. Below we call out each test
 type. If tests pass, it suggests functionality of the referenced subsystem.
 
-+---------------------------+----------------------------+-------------------------------+-----------------------------+----------------------------------------+
-| Pod-to-pod (intra-host)   | Pod-to-pod (inter-host)    | Pod-to-service (intra-host)   | Pod-to-service (inter-host) | Pod-to-external resource               | 
-+===========================+============================+===============================+=============================+========================================+
-| BPF routing is functional | Dataplane, routing, network| BPF service map lookup        | VXLAN overlay port if used  | Egress, CiliumNetworkPolicy, masquerade|
-+---------------------------+----------------------------+-------------------------------+-----------------------------+----------------------------------------+
++---------------------------+-----------------------------+-------------------------------+-----------------------------+----------------------------------------+
+| Pod-to-pod (intra-host)   | Pod-to-pod (inter-host)     | Pod-to-service (intra-host)   | Pod-to-service (inter-host) | Pod-to-external resource               | 
++===========================+=============================+===============================+=============================+========================================+
+| BPF routing is functional | Data plane, routing, network| BPF service map lookup        | VXLAN overlay port if used  | Egress, CiliumNetworkPolicy, masquerade|
++---------------------------+-----------------------------+-------------------------------+-----------------------------+----------------------------------------+
 
 The pod name indicates the connectivity
 variant and the readiness and liveness gate indicates success or failure of the


### PR DESCRIPTION
Previously the troubleshooting documentation lacked a reference to the connectivity tests specified in the getting started guide.

Added the connectivity guide reference as well as some minor style updates

Fixes: #11581

Signed-off-by: Jed Salazar <jed@isovalent.com>

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
Add connectivity test to troubleshooting
```
