### PR TITLE
ci: Check whether pod is being terminated before deleting it

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -1814,7 +1814,7 @@ func (kub *Kubectl) RestartUnmanagedPodsInNamespace(namespace string, excludePod
 
 iteratePods:
 	for _, pod := range podList.Items {
-		if pod.Spec.HostNetwork {
+		if pod.Spec.HostNetwork || pod.DeletionTimestamp != nil {
 			continue
 		}
 


### PR DESCRIPTION
Some pods might be already being terminated in GKE clusters, which
caused test suite to fail. This change adds a check to make sure we
don't try to delete terminating pods.