### PR TITLE
Makefile: Pass lockdebug tag to tests

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -120,6 +120,7 @@ endif
 
 ifneq ($(LOCKDEBUG),)
     GO_BUILD_FLAGS += -tags lockdebug
+    GO_TEST_FLAGS += -tags lockdebug
 endif
 
 GO_BUILD_FLAGS += -ldflags '$(GO_BUILD_LDFLAGS) $(EXTRA_GO_BUILD_LDFLAGS)' $(EXTRA_GO_BUILD_FLAGS)


### PR DESCRIPTION
Previously, the lockdebug tag was only on the building of the binary.
This commit adds the ability to pass the tag to `go test` to debug
deadlocks in tests.

Example usage:

```
$ make RACE=1 LOCKDEBUG=1 unit-tests
```