### PR TITLE
proxy: Keep DNS port allocated

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -227,8 +227,10 @@ func allocatePort(port, min, max uint16) (uint16, error) {
 
 // Called with proxyPortsMutex held!
 func (pp *ProxyPort) reservePort() {
-	allocatedPorts[pp.proxyPort] = struct{}{}
-	pp.configured = true
+	if !pp.configured {
+		allocatedPorts[pp.proxyPort] = struct{}{}
+		pp.configured = true
+	}
 }
 
 // Called with proxyPortsMutex held!

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -261,14 +261,14 @@ func (p *Proxy) ackProxyPort(pp *ProxyPort) error {
 
 		// Remove old rules, if any and for different port
 		if pp.rulesPort != 0 && pp.rulesPort != pp.proxyPort {
-			scopedLog.Debugf("Removing old proxy port rules for %s:%d", pp.name, pp.rulesPort)
+			scopedLog.Infof("Removing old proxy port rules for %s:%d", pp.name, pp.rulesPort)
 			p.datapathUpdater.RemoveProxyRules(pp.rulesPort, pp.ingress, pp.name)
 			pp.rulesPort = 0
 		}
 		// Add new rules, if needed
 		if pp.rulesPort != pp.proxyPort {
 			// This should always succeed if we have managed to start-up properly
-			scopedLog.Debugf("Adding new proxy port rules for %s:%d", pp.name, pp.proxyPort)
+			scopedLog.Infof("Adding new proxy port rules for %s:%d", pp.name, pp.proxyPort)
 			err := p.datapathUpdater.InstallProxyRules(pp.proxyPort, pp.ingress, pp.name)
 			if err != nil {
 				return fmt.Errorf("Can't install proxy rules for %s: %s", pp.name, err)

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -62,6 +62,11 @@ type DatapathUpdater interface {
 type ProxyPort struct {
 	// Listener name (immutable)
 	name string
+	// isStatic is true when the listener on the proxy port is incapable
+	// of stopping and/or being reconfigured with a new proxy port once it has been
+	// first started. Set 'true' by SetProxyPort(), which is only called for
+	// static listeners (currently only DNS proxy).
+	isStatic bool
 	// parser type this port applies to (immutable)
 	parserType policy.L7ParserType
 	// 'true' for ingress, 'false' for egress (immutable)
@@ -293,6 +298,9 @@ func (p *Proxy) releaseProxyPort(name string) error {
 
 	pp.nRedirects--
 	if pp.nRedirects == 0 {
+		if pp.isStatic {
+			return fmt.Errorf("Can't release proxy port: proxy %s on %d has a static listener", name, pp.proxyPort)
+		}
 		delete(allocatedPorts, pp.proxyPort)
 		// Force new port allocation the next time this ProxyPort is used.
 		pp.configured = false
@@ -348,7 +356,8 @@ func GetProxyPort(l7Type policy.L7ParserType, ingress bool) (uint16, string, err
 
 // SetProxyPort() marks the proxy 'name' as successfully created with proxy port 'port' and creates
 // or updates the datapath rules accordingly.
-// May only be called once per proxy.
+// This should only be called for proxies that have a static listener that is already listening on
+// 'port'. May only be called once per proxy.
 func (p *Proxy) SetProxyPort(name string, port uint16) error {
 	proxyPortsMutex.Lock()
 	defer proxyPortsMutex.Unlock()
@@ -360,8 +369,9 @@ func (p *Proxy) SetProxyPort(name string, port uint16) error {
 		return fmt.Errorf("Can't set proxy port to %d: proxy %s is already configured on %d", port, name, pp.proxyPort)
 	}
 	pp.proxyPort = port
-	pp.configured = true
-	return p.ackProxyPort(pp)
+	pp.isStatic = true        // prevents release of the proxy port
+	pp.reservePort()          // marks 'port' as reserved, 'pp' as configured
+	return p.ackProxyPort(pp) // creates datapath rules, increases the reference count
 }
 
 // ReinstallRules is called by daemon reconfiguration to re-install proxy ports rules that


### PR DESCRIPTION
Proxy port for DNS becomes unallocated if the proxy port reference count reaches zero. While this should never happen for a DNS proxy port, as it starts with a reference count of 1, it would be better make sure the DNS proxy port is never reallocated as the DNS proxy can't change its listening port.

Fixes: #11637