### PR TITLE
proxy: Keep DNS port allocated

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -267,14 +267,14 @@ func (p *Proxy) ackProxyPort(pp *ProxyPort) error {
 
 		// Remove old rules, if any and for different port
 		if pp.rulesPort != 0 && pp.rulesPort != pp.proxyPort {
-			scopedLog.Debugf("Removing old proxy port rules for %s:%d", pp.name, pp.rulesPort)
+			scopedLog.Infof("Removing old proxy port rules for %s:%d", pp.name, pp.rulesPort)
 			p.datapathUpdater.RemoveProxyRules(pp.rulesPort, pp.ingress, pp.name)
 			pp.rulesPort = 0
 		}
 		// Add new rules, if needed
 		if pp.rulesPort != pp.proxyPort {
 			// This should always succeed if we have managed to start-up properly
-			scopedLog.Debugf("Adding new proxy port rules for %s:%d", pp.name, pp.proxyPort)
+			scopedLog.Infof("Adding new proxy port rules for %s:%d", pp.name, pp.proxyPort)
 			err := p.datapathUpdater.InstallProxyRules(pp.proxyPort, pp.ingress, pp.name)
 			if err != nil {
 				return fmt.Errorf("Can't install proxy rules for %s: %s", pp.name, err)

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -233,8 +233,10 @@ func allocatePort(port, min, max uint16) (uint16, error) {
 
 // Called with proxyPortsMutex held!
 func (pp *ProxyPort) reservePort() {
-	allocatedPorts[pp.proxyPort] = struct{}{}
-	pp.configured = true
+	if !pp.configured {
+		allocatedPorts[pp.proxyPort] = struct{}{}
+		pp.configured = true
+	}
 }
 
 // Called with proxyPortsMutex held!


### PR DESCRIPTION
Proxy port for DNS becomes unallocated if the proxy port reference count reaches zero. While this should never happen for a DNS proxy port, as it starts with a reference count of 1, it would be better make sure the DNS proxy port is never reallocated as the DNS proxy can't change its listening port.

Fixes: #11637

```upstream-prs
$ for pr in 11661; do contrib/backporting/set-labels.py $pr done 1.6; done
```