### PR TITLE
test/K8sServices: redeploy Cilium before fragment tracking tests

### DIFF
--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -1105,10 +1105,6 @@ var _ = Describe("K8sServicesTest", func() {
 
 				AfterAll(func() {
 					enableBackgroundReport = true
-					kubectl.DeleteCiliumDS()
-					ExpectAllPodsTerminated(kubectl)
-					// Deploy Cilium as the next test expects it to be up and running
-					DeployCiliumAndDNS(kubectl, ciliumFilename)
 				})
 
 				Context("Tests with vxlan", func() {
@@ -1333,6 +1329,7 @@ var _ = Describe("K8sServicesTest", func() {
 
 		// Net-next and not old versions, because of LRU requirement.
 		SkipItIf(helpers.DoesNotRunOnNetNextOr419Kernel, "Supports IPv4 fragments", func() {
+			DeployCiliumAndDNS(kubectl, ciliumFilename)
 			testIPv4FragmentSupport()
 		})
 	})


### PR DESCRIPTION
In #11602, Cilium redeployment was removed from most of the `AfterAll()` steps in the tests. It could not be removed in one case in the Services tests, because running IPv4 fragment tracking tests with the options used to deploy Cilium in the previous test make them fail.

Deploy Cilium with a clean configuration before running the fragment tracking tests, and remove redeployment from that `AfterAll()` block at last.