### PR TITLE
proxy: release redir.mutex on early exit, update a comment on mutex use

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -543,7 +543,8 @@ func (p *Proxy) RemoveRedirect(id string, wg *completion.WaitGroup) (error, reve
 }
 
 // removeRedirect removes an existing redirect. p.mutex must be held
-// p.mutex must NOT be held when the returned finalize and revert functions are called!
+// p.mutex must NOT be held when the returned revert function is called!
+// proxyPortsMutex must NOT be held when the returned finalize function is called!
 func (p *Proxy) removeRedirect(id string, wg *completion.WaitGroup) (err error, finalizeFunc revert.FinalizeFunc, revertFunc revert.RevertFunc) {
 	log.WithField(fieldProxyRedirectID, id).
 		Debug("Removing proxy redirect")

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -412,6 +412,7 @@ func (p *Proxy) CreateOrUpdateRedirect(l4 policy.ProxyPolicy, id string, localEn
 			var implUpdateRevertFunc revert.RevertFunc
 			implUpdateRevertFunc, err = redir.implementation.UpdateRules(wg)
 			if err != nil {
+				redir.mutex.Unlock()
 				err = fmt.Errorf("unable to update existing redirect: %s", err)
 				return 0, err, nil, nil
 			}


### PR DESCRIPTION
Clean up some mutex-related elements in the proxy package.

- Release lock on early exit from `CreateOrUpdateRedirect()`. A failure from `redir.implementation.UpdateRules()`, which (as I see it) could trigger a deadlock, seems unlikely. But it's probably better to fix it before one implementation of that function gets more susceptible to return an error and trigger an exit here without releasing the mutex.

- Update a comment on mutex usage for the functions returned by `removeRedirect()`.