### PR TITLE
azure: fix excess/off-by-one addresses allocation

### DIFF
--- a/pkg/azure/api/api.go
+++ b/pkg/azure/api/api.go
@@ -332,7 +332,7 @@ func (c *Client) AssignPrivateIpAddresses(ctx context.Context, instanceID, vmssN
 	}
 
 	ipConfigurations := make([]compute.VirtualMachineScaleSetIPConfiguration, 0, addresses)
-	for i := 0; i <= addresses; i++ {
+	for i := 0; i < addresses; i++ {
 		ipConfigurations = append(ipConfigurations,
 			compute.VirtualMachineScaleSetIPConfiguration{
 				Name: to.StringPtr(generateIpConfigName()),


### PR DESCRIPTION
Azure's `AssignPrivateIpAddresses` allocated one more address
than asked for.

Submitting that separately from #11571 due to code freeze (might
postpone the non-VMSS allocations PR). Let me know if you prefer
otherwise.