### PR TITLE
fix(helm): Correct lint error in preflight template

### DIFF
--- a/.github/workflows/helm-check.yaml
+++ b/.github/workflows/helm-check.yaml
@@ -37,18 +37,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
-      - name: Run chart-testing (lint)
-        id: lint
-        uses: helm/chart-testing-action@v1.0.0-rc.2
-        with:
-          command: lint
-          config: install/kubernetes/chart-testing.yaml
+      - name: Run helm lint
+        run: |
+          cd install/kubernetes/cilium
+          helm lint --with-subcharts --values values.yaml
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.0.0-rc.1
         with:
           install_local_path_provisioner: true
-        if: steps.lint.outputs.changed == 'true'
 
       # This test is just to make sure the helm chart can be installed. It will not replace existing integration tests
       - name: Run chart-testing (install)

--- a/install/kubernetes/cilium/charts/preflight/values.yaml
+++ b/install/kubernetes/cilium/charts/preflight/values.yaml
@@ -1,1 +1,13 @@
 image: cilium
+
+# Include the PreFlight DaemonSet
+enabled: false
+
+# Path to write the --tofqdns-pre-cache file to. When empty no file is
+# generated.
+tofqdnsPreCache: ""
+
+# By default we should always validate the installed CNPs before upgrading
+# Cilium. This will make sure the user will have the policies deployed in the
+# cluster with the right schema.
+validateCNPs: true


### PR DESCRIPTION
Currently, chart-testing lint is used for checking the template, and it
is running for main chart only (e.g. cilium). However, chart-testing is
working well for individual chart with custom values placing in ci root
directory of chart under test. Hence, if we want to keep chart testing,
we need to keep copy of cilium/values.yaml in ci/ dir of each and every
sub-charts, otherwise all related global* params cannot be resolved.
This is a little bit tedious and repetitive.

Considered that sub-chart  is unlikely installed separately, we can
just run `helm lint --with-subcharts --values values.yaml` to check for
all charts.

Closes #11670

Signed-off-by: Tam Mach <sayboras@yahoo.com>


```release-note
helm: correct lint error in preflight template
```
