### PR TITLE
test: Increase timeout for privileged unit tests

### DIFF
--- a/test/runtime/privileged_tests.go
+++ b/test/runtime/privileged_tests.go
@@ -15,13 +15,21 @@
 package RuntimeTest
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
+	"time"
 
 	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
 
 	. "github.com/onsi/gomega"
+)
+
+const (
+	// The privileged unit tests can take more than 4 minutes, the default
+	// timeout for helper commands.
+	privilegedUnitTestTimeout = 8 * time.Minute
 )
 
 var _ = Describe("RuntimePrivilegedUnitTests", func() {
@@ -43,7 +51,9 @@ var _ = Describe("RuntimePrivilegedUnitTests", func() {
 
 	It("Run Tests", func() {
 		path, _ := filepath.Split(vm.BasePath())
-		res := vm.ExecWithSudo(fmt.Sprintf("make -C %s tests-privileged", path))
+		ctx, cancel := context.WithTimeout(context.Background(), privilegedUnitTestTimeout)
+		defer cancel()
+		res := vm.ExecContext(ctx, fmt.Sprintf("sudo make -C %s tests-privileged", path))
 		res.ExpectSuccess("Failed to run privileged unit tests")
 	})
 })


### PR DESCRIPTION
The default timeout is 4 minutes, but the privileged unit tests sometimes take longer.

As a follow up, we'll need to print a proper error message when we fail because we reached the timeout.