### PR TITLE
datapath: Enable session affinity for older kernels

### DIFF
--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -569,7 +569,7 @@ static __always_inline __u32
 lb6_affinity_backend_id_by_netns(const struct lb6_service *svc __maybe_unused,
 				 union lb6_affinity_client_id *id __maybe_unused)
 {
-#if defined(ENABLE_SESSION_AFFINITY) && defined(BPF_HAVE_NETNS_COOKIE)
+#if defined(ENABLE_SESSION_AFFINITY)
 	return __lb6_affinity_backend_id(svc, true, id);
 #else
 	return 0;
@@ -581,7 +581,7 @@ lb6_update_affinity_by_netns(const struct lb6_service *svc __maybe_unused,
 			     union lb6_affinity_client_id *id __maybe_unused,
 			     __u32 backend_id __maybe_unused)
 {
-#if defined(ENABLE_SESSION_AFFINITY) && defined(BPF_HAVE_NETNS_COOKIE)
+#if defined(ENABLE_SESSION_AFFINITY)
 	__lb6_update_affinity(svc, true, id, backend_id);
 #endif
 }
@@ -590,7 +590,7 @@ static __always_inline void
 lb6_delete_affinity_by_netns(const struct lb6_service *svc __maybe_unused,
 			     union lb6_affinity_client_id *id __maybe_unused)
 {
-#if defined(ENABLE_SESSION_AFFINITY) && defined(BPF_HAVE_NETNS_COOKIE)
+#if defined(ENABLE_SESSION_AFFINITY)
 	__lb6_delete_affinity(svc, true, id);
 #endif
 }
@@ -1106,7 +1106,7 @@ static __always_inline __u32
 lb4_affinity_backend_id_by_netns(const struct lb4_service *svc __maybe_unused,
 				 union lb4_affinity_client_id *id __maybe_unused)
 {
-#if defined(ENABLE_SESSION_AFFINITY) && defined(BPF_HAVE_NETNS_COOKIE)
+#if defined(ENABLE_SESSION_AFFINITY)
 	return __lb4_affinity_backend_id(svc, true, id);
 #else
 	return 0;
@@ -1118,7 +1118,7 @@ lb4_update_affinity_by_netns(const struct lb4_service *svc __maybe_unused,
 			     union lb4_affinity_client_id *id __maybe_unused,
 			     __u32 backend_id __maybe_unused)
 {
-#if defined(ENABLE_SESSION_AFFINITY) && defined(BPF_HAVE_NETNS_COOKIE)
+#if defined(ENABLE_SESSION_AFFINITY)
 	__lb4_update_affinity(svc, true, id, backend_id);
 #endif
 }
@@ -1127,7 +1127,7 @@ static __always_inline void
 lb4_delete_affinity_by_netns(const struct lb4_service *svc __maybe_unused,
 			     union lb4_affinity_client_id *id __maybe_unused)
 {
-#if defined(ENABLE_SESSION_AFFINITY) && defined(BPF_HAVE_NETNS_COOKIE)
+#if defined(ENABLE_SESSION_AFFINITY)
 	__lb4_delete_affinity(svc, true, id);
 #endif
 }

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1867,8 +1867,9 @@ func initKubeProxyReplacementOptions() {
 			_, found2 = h["bpf_get_netns_cookie"]
 		}
 		if !(found1 && found2) {
-			log.Warnf("sessionAffinity for host reachable services needs kernel 5.7.0 or newer. " +
-				"Disabling sessionAffinity for cases when a service is accessed from a cluster.")
+			log.Warn("Session affinity for host reachable services needs kernel 5.7.0 or newer " +
+				"to work properly when accessed from inside cluster: the same service endpoint " +
+				"will be selected from all network namespaces on the host.")
 		}
 	}
 }


### PR DESCRIPTION
Instead of disabling sessionAffinity for E-W traffic (via bpf_sock) when running on < 5.7 kernel, enable it with a non-ideal functionality: the same service (annotated with "sessionAffinity") endpoint will be selected from all network namespaces on the host, because the same netns cookie (="0") will be returned for all namespaces.

The documentation update will follow soon with the session affinity docs.