### PR TITLE
pkg/metrics: add BPF memory usage

### DIFF
--- a/Documentation/configuration/metrics.rst
+++ b/Documentation/configuration/metrics.rst
@@ -110,7 +110,14 @@ Name                                       Labels                               
 ========================================== ================================================== ========================================================
 ``bpf_syscall_duration_seconds``           ``operation``, ``outcome``                         Duration of BPF system call performed
 ``bpf_map_ops_total``                      ``mapName``, ``operation``, ``outcome``            Number of BPF map operations performed
+``bpf_maps_virtual_memory_max_bytes``                                                         Max memory used by BPF maps installed in the system
+``bpf_progs_virtual_memory_max_bytes``                                                        Max memory used by BPF programs installed in the system
 ========================================== ================================================== ========================================================
+
+Both ``bpf_maps_virtual_memory_max_bytes`` and ``bpf_progs_virtual_memory_max_bytes``
+are currently reporting the system-wide memory usage of BPF that is directly
+and not directly managed by Cilium. This might change in the future and only
+report the BPF memory usage directly managed by Cilium.
 
 Drops/Forwards (L3/L4)
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/Documentation/install/upgrade.rst
+++ b/Documentation/install/upgrade.rst
@@ -479,6 +479,21 @@ Deprecated options
 * ``--tofqdns-enable-poller-events``: This option has been deprecated and will
   be removed in Cilium 1.9
 
+New Metrics
+~~~~~~~~~~~
+
+The following metrics have been added:
+
+* ``bpf_maps_virtual_memory_max_bytes``: Max memory used by BPF maps installed
+  in the system
+* ``bpf_progs_virtual_memory_max_bytes``: Max memory used by BPF programs
+  installed in the system
+
+Both ``bpf_maps_virtual_memory_max_bytes`` and ``bpf_progs_virtual_memory_max_bytes``
+are currently reporting the system-wide memory usage of BPF that is directly
+and not directly managed by Cilium. This might change in the future and only
+report the BPF memory usage directly managed by Cilium.
+
 Renamed Metrics
 ~~~~~~~~~~~~~~~
 

--- a/pkg/metrics/bpf.go
+++ b/pkg/metrics/bpf.go
@@ -1,0 +1,100 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
+)
+
+type bpfCollector struct {
+	bpfMapsMemory *prometheus.Desc
+	bpfProgMemory *prometheus.Desc
+}
+
+func newbpfCollector() *bpfCollector {
+	return &bpfCollector{
+		bpfMapsMemory: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, "", "bpf_maps_virtual_memory_max_bytes"),
+			"BPF maps kernel max memory usage size in bytes.",
+			nil, nil,
+		),
+		bpfProgMemory: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, "", "bpf_progs_virtual_memory_max_bytes"),
+			"BPF programs kernel max memory usage size in bytes.",
+			nil, nil,
+		),
+	}
+}
+
+func (s *bpfCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- s.bpfMapsMemory
+	ch <- s.bpfProgMemory
+}
+
+type memoryEntry struct {
+	BytesMemlock uint64 `json:"bytes_memlock"`
+}
+
+func getMemoryUsage(typ string) (uint64, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "bpftool", "-j", typ, "show")
+	out, err := cmd.Output()
+	if err != nil {
+		return 0, fmt.Errorf("unable to get bpftool output: %w", err)
+	}
+
+	var memoryEntries []memoryEntry
+	err = json.Unmarshal(out, &memoryEntries)
+	if err != nil {
+		return 0, fmt.Errorf("unable to unmarshal bpftool output: %w", err)
+	}
+	var totalMem uint64
+	for _, entry := range memoryEntries {
+		totalMem += entry.BytesMemlock
+	}
+	return totalMem, nil
+}
+
+func (s *bpfCollector) Collect(ch chan<- prometheus.Metric) {
+	mapMem, err := getMemoryUsage("map")
+	if err != nil {
+		log.WithError(err).Error("Error while getting BPF maps memory usage")
+	} else {
+		ch <- prometheus.MustNewConstMetric(
+			s.bpfMapsMemory,
+			prometheus.GaugeValue,
+			float64(mapMem),
+		)
+	}
+
+	progMem, err := getMemoryUsage("prog")
+	if err != nil {
+		log.WithError(err).Error("Error while getting BPF progs memory usage")
+	} else {
+		ch <- prometheus.MustNewConstMetric(
+			s.bpfProgMemory,
+			prometheus.GaugeValue,
+			float64(progMem),
+		)
+	}
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1077,6 +1077,7 @@ func init() {
 	// TODO: Figure out how to put this into a Namespace
 	// MustRegister(prometheus.NewGoCollector())
 	MustRegister(newStatusCollector())
+	MustRegister(newbpfCollector())
 }
 
 // MustRegister adds the collector to the registry, exposing this metric to


### PR DESCRIPTION
This commit introduces a new metric that will return the memory usage if
available by bpftool. It sums all `bytes_memlock` for the BPF maps and
programs installed in the system.

Signed-off-by: André Martins <andre@cilium.io>

Fixes: https://github.com/cilium/cilium/issues/11502

```release-note
Expose BPF kernel memory usage as a prometheus metric
```
