### PR TITLE
Fix various data races in pkg/aws/eni and pkg/ipam

### DIFF
--- a/pkg/aws/eni/instances.go
+++ b/pkg/aws/eni/instances.go
@@ -200,3 +200,11 @@ func (m *InstancesManager) UpdateENI(instanceID string, eni *eniTypes.ENI) {
 	m.instances.Update(instanceID, eniRevision)
 	m.mutex.Unlock()
 }
+
+// ForeachInstance will iterate over each instance inside `instances`, and call
+// `fn`. This function is read-locked for the entire execution.
+func (m *InstancesManager) ForeachInstance(instanceID string, fn ipamTypes.InterfaceIterator) {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+	m.instances.ForeachInterface(instanceID, fn)
+}

--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -66,6 +66,8 @@ type Node struct {
 
 // UpdatedNode is called when an update to the CiliumNode is received.
 func (n *Node) UpdatedNode(obj *v2.CiliumNode) {
+	n.mutex.Lock()
+	defer n.mutex.Unlock()
 	n.k8sObj = obj
 }
 
@@ -96,7 +98,10 @@ func (n *Node) PopulateStatusFields(k8sObj *v2.CiliumNode) {
 
 // getLimits returns the interface and IP limits of this node
 func (n *Node) getLimits() (ipamTypes.Limits, bool) {
-	return getLimits(n.k8sObj.Spec.ENI.InstanceType)
+	n.mutex.RLock()
+	instType := n.k8sObj.Spec.ENI.InstanceType
+	n.mutex.RUnlock()
+	return getLimits(instType)
 }
 
 // PrepareIPRelease prepares the release of ENI IPs.

--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -273,7 +273,7 @@ func (n *Node) errorInstanceNotRunning(err error) (notRunning bool) {
 	// deletion event to not have been sent out yet. The next ENI resync
 	// will cause the instance to be marked as inactive.
 	if strings.Contains(err.Error(), "is not 'running'") {
-		n.node.SetRunningLocked(false)
+		n.node.SetRunning(false)
 		log.Info("Marking node as not running")
 	}
 	return

--- a/pkg/aws/eni/node_manager_test.go
+++ b/pkg/aws/eni/node_manager_test.go
@@ -64,6 +64,14 @@ var (
 	metricsapi = metricsmock.NewMockMetrics()
 )
 
+func (e *ENISuite) SetUpTest(c *check.C) {
+	metricsapi = metricsmock.NewMockMetrics()
+}
+
+func (e *ENISuite) TearDownTest(c *check.C) {
+	metricsapi = nil
+}
+
 func (e *ENISuite) TestGetNodeNames(c *check.C) {
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups)
 	instances := NewInstancesManager(ec2api, nil)

--- a/pkg/aws/eni/node_manager_test.go
+++ b/pkg/aws/eni/node_manager_test.go
@@ -495,7 +495,9 @@ func (e *ENISuite) TestNodeManagerReleaseAddress(c *check.C) {
 	eniNode, castOK := node.Ops().(*Node)
 	c.Assert(castOK, check.Equals, true)
 	obj := node.ResourceCopy()
+	eniNode.mutex.RLock()
 	obj.Status.ENI.ENIs = eniNode.enis
+	eniNode.mutex.RUnlock()
 	node.UpdatedResource(obj)
 	syncTime := instances.Resync(context.TODO())
 	mngr.Resync(context.TODO(), syncTime)

--- a/pkg/ipam/node.go
+++ b/pkg/ipam/node.go
@@ -130,10 +130,10 @@ func (n *Node) IsRunning() bool {
 	return n.instanceRunning
 }
 
-// SetRunningLocked sets the running state of the node. This function assumes
-// that the node is locked. It is intended to be used by implementations of
-// NodeOperations which are called with the node in locked state.
-func (n *Node) SetRunningLocked(running bool) {
+func (n *Node) SetRunning(running bool) {
+	n.mutex.Lock()
+	defer n.mutex.Unlock()
+
 	n.loggerLocked().Infof("Set running %t", running)
 	n.instanceRunning = running
 	if !n.instanceRunning {


### PR DESCRIPTION
This PR also contains a potential fix for the flakiness seen in
https://github.com/cilium/cilium/issues/11560. The commit for the fix adds a
setup and cleanup method for a metrics mock implementation used in the
ENISuite.

See commit msgs.

Related https://github.com/cilium/cilium/issues/11560
Related https://github.com/cilium/cilium/issues/10677