### PR TITLE
test/k8sHubble: Clean up hubble-cli and hubble-relay pods

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -74,6 +74,12 @@ const (
 	// CiliumOperatorLabel is the label used in the Cilium Operator deployment
 	CiliumOperatorLabel = "io.cilium/app=operator"
 
+	// HubbleClientLabel is the label used for Hubble client pods
+	HubbleClientLabel = "k8s-app=hubble-cli"
+
+	// HubbleRelayLabel is the label used for the Hubble Relay deployment
+	HubbleRelayLabel = "k8s-app=hubble-relay"
+
 	// PolicyEnforcement represents the PolicyEnforcement configuration option
 	// for the Cilium agent.
 	PolicyEnforcement = "PolicyEnforcement"

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2247,6 +2247,18 @@ func (kub *Kubectl) DeleteCiliumDS() error {
 	return kub.waitToDelete("Cilium", CiliumAgentLabel)
 }
 
+func (kub *Kubectl) DeleteHubbleClientPods(ns string) error {
+	ginkgoext.By("DeleteHubbleClientPods(namespace=%q)", ns)
+	_ = kub.DeleteResource("ds", fmt.Sprintf("-n %s hubble-cli", ns))
+	return kub.waitToDelete("HubbleClient", HubbleClientLabel)
+}
+
+func (kub *Kubectl) DeleteHubbleRelay(ns string) error {
+	ginkgoext.By("DeleteHubbleRelay(namespace=%q)", ns)
+	_ = kub.DeleteResource("deployment", fmt.Sprintf("-n %s hubble-relay", ns))
+	return kub.waitToDelete("HubbleRelay", HubbleRelayLabel)
+}
+
 // ciliumUninstallHelm uninstalls Cilium with the Helm options provided.
 func (kub *Kubectl) ciliumUninstallHelm(filename string, options map[string]string) error {
 	if err := kub.generateCiliumYaml(options, filename); err != nil {
@@ -3317,7 +3329,7 @@ func (kub *Kubectl) GetHubbleClientPodOnNode(namespace string, node string) (str
 		"-o jsonpath='{.items[?(@.spec.nodeName == \"%s\")].metadata.name}'", node)
 
 	res := kub.ExecShort(fmt.Sprintf(
-		"%s -n %s get pods -l k8s-app=hubble-cli %s", KubectlCmd, namespace, filter))
+		"%s -n %s get pods -l %s %s", KubectlCmd, namespace, HubbleClientLabel, filter))
 	if !res.WasSuccessful() {
 		return "", fmt.Errorf("Hubble pod not found on node '%s': %s", node, res.OutputPrettyPrint())
 	}

--- a/test/k8sT/hubble.go
+++ b/test/k8sT/hubble.go
@@ -152,6 +152,8 @@ var _ = Describe("K8sHubbleTest", func() {
 		AfterAll(func() {
 			kubectl.Delete(demoPath)
 			kubectl.NamespaceDelete(namespaceForTest)
+			kubectl.DeleteHubbleClientPods(hubbleNamespace)
+			kubectl.DeleteHubbleRelay(hubbleNamespace)
 		})
 
 		It("Test L3/L4 Flow", func() {


### PR DESCRIPTION
Commit 5aee7040 removed the cleanup of Cilium via the Helm generated
yaml manifests, assuming the cleanup would only remove cilium agent
which will be replaced by a subsequent test.

However, tests which are using `global.hubble.cli.enabled` or
`global.hubble.relay.enabled` in their helm options will deploy
addional Hubble pods alongside cilium-agent. These additional pods have
to be cleaned up, as they are not likely going to be replaced in
subsequent tests.

This commit introduces helpers to do the removal of hubble-cli and
hubble-relay pods and invokes them in `AfterAll` in the Hubble tests.

Fixes: 5aee7040b077 ("test: Don't delete and redeploy Cilium at end of each test context")
