### PR TITLE
agent/datapath: Do not explicitly expose NodePort via cilium_host

### DIFF
--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -21,7 +21,7 @@ For installing ``kubeadm`` and for more provisioning options please refer to
 
    Cilium's kube-proxy replacement depends on the :ref:`host-services` feature,
    therefore a v4.19.57, v5.1.16, v5.2.0 or more recent Linux kernel is required.
-   We recommend a v5.3 or even more recent Linux kernel such as v5.8 as Cilium
+   We recommend a v5.3 or even more recent Linux kernel such as v5.7 as Cilium
    can perform additional optimizations in its kube-proxy replacement implementation.
 
    Note that v5.0.y kernels do not have the fix required to run the kube-proxy
@@ -196,11 +196,9 @@ port ``31940``:
     [...]
     4    10.104.239.135:80      ClusterIP      1 => 10.217.0.107:80       
                                                2 => 10.217.0.149:80       
-    5    10.217.0.181:31940     NodePort       1 => 10.217.0.107:80       
+    5    0.0.0.0:31940          NodePort       1 => 10.217.0.107:80       
                                                2 => 10.217.0.149:80       
-    6    0.0.0.0:31940          NodePort       1 => 10.217.0.107:80       
-                                               2 => 10.217.0.149:80       
-    7    192.168.178.29:31940   NodePort       1 => 10.217.0.107:80       
+    6    192.168.178.29:31940   NodePort       1 => 10.217.0.107:80       
                                                2 => 10.217.0.149:80       
 
 At the same time we can inspect through ``iptables`` in the host namespace
@@ -365,8 +363,9 @@ which has the default route on the host. To change the device, set its name in
 the ``global.nodePort.device`` helm option.
 
 In addition, thanks to the :ref:`host-services` feature, the NodePort service can
-be accessed by default from a host or a pod within a cluster via it's public,
-cilium_host device or loopback address, e.g. ``127.0.0.1:NODE_PORT``.
+be accessed by default from a host or a pod within a cluster via its public, any
+local (except for ``docker*`` prefixed names) or loopback address, e.g.
+``127.0.0.1:NODE_PORT``.
 
 If ``kube-apiserver`` was configured to use a non-default NodePort port range,
 then the same range must be passed to Cilium via the ``global.nodePort.range``

--- a/pkg/datapath/linux/node_addressing.go
+++ b/pkg/datapath/linux/node_addressing.go
@@ -89,7 +89,7 @@ func (a *addressFamilyIPv4) LocalAddresses() ([]net.IP, error) {
 // loadbalancer should implement HostPort and NodePort services.
 func (a *addressFamilyIPv4) LoadBalancerNodeAddresses() []net.IP {
 	addrs := node.GetNodePortIPv4Addrs()
-	addrs = append(addrs, net.IPv4(0, 0, 0, 0), node.GetInternalIPv4())
+	addrs = append(addrs, net.IPv4(0, 0, 0, 0))
 	return addrs
 }
 
@@ -115,7 +115,7 @@ func (a *addressFamilyIPv6) LocalAddresses() ([]net.IP, error) {
 // loadbalancer should implement HostPort and NodePort services.
 func (a *addressFamilyIPv6) LoadBalancerNodeAddresses() []net.IP {
 	addrs := node.GetNodePortIPv6Addrs()
-	addrs = append(addrs, net.IPv6zero, node.GetIPv6Router())
+	addrs = append(addrs, net.IPv6zero)
 	return addrs
 }
 

--- a/pkg/k8s/service.go
+++ b/pkg/k8s/service.go
@@ -128,16 +128,12 @@ func ParseService(svc *slim_corev1.Service, nodeAddressing datapath.NodeAddressi
 		if _, ok := svcInfo.Ports[portName]; !ok {
 			svcInfo.Ports[portName] = p
 		}
+		// TODO(brb) Get rid of this hack by moving the creation of surrogate
+		// frontends to pkg/service.
+		//
 		// This is a hack;-( In the case of NodePort service, we need to create
-		// three surrogate frontends per IP protocol - one with a zero IP addr used
-		// by the host-lb, one with a public iface IP addr and one with cilium_host
-		// IP addr.
-		// For each frontend we will need to store a service ID used for a reverse
-		// NAT translation and for deleting a service.
-		// Unfortunately, doing this in daemon/{loadbalancer,k8s_watcher}.go
-		// would introduce more complexity in already too complex LB codebase,
-		// so for now (until we have refactored the LB code) keep NodePort
-		// frontends in Service.NodePorts.
+		// surrogate frontends per IP protocol - one with a zero IP addr and
+		// one per each public iface IP addr.
 		if svc.Spec.Type == slim_corev1.ServiceTypeNodePort || svc.Spec.Type == slim_corev1.ServiceTypeLoadBalancer {
 			if option.Config.EnableNodePort && nodeAddressing != nil {
 				if _, ok := svcInfo.NodePorts[portName]; !ok {

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -3113,26 +3113,6 @@ func (kub *Kubectl) ExecInHostNetNSByLabel(ctx context.Context, label, cmd strin
 	return res.GetStdOut(), nil
 }
 
-// GetCiliumHostIPv4 retrieves cilium_host IPv4 addr of the given node.
-func (kub *Kubectl) GetCiliumHostIPv4(ctx context.Context, node string) (string, error) {
-	pod, err := kub.GetCiliumPodOnNode(GetCiliumNamespace(GetCurrentIntegration()), node)
-	if err != nil {
-		return "", fmt.Errorf("unable to retrieve cilium pod: %s", err)
-	}
-
-	cmd := "ip -4 -o a show dev cilium_host | grep -o -e 'inet [0-9.]*' | cut -d' ' -f2"
-	res := kub.ExecPodCmd(GetCiliumNamespace(GetCurrentIntegration()), pod, cmd)
-	if !res.WasSuccessful() {
-		return "", fmt.Errorf("unable to retrieve cilium_host ipv4 addr: %s", res.GetError())
-	}
-	addr := res.SingleOut()
-	if addr == "" {
-		return "", fmt.Errorf("unable to retrieve cilium_host ipv4 addr")
-	}
-
-	return addr, nil
-}
-
 // DumpCiliumCommandOutput runs a variety of commands (CiliumKubCLICommands) and writes the results to
 // TestResultsPath
 func (kub *Kubectl) DumpCiliumCommandOutput(ctx context.Context, namespace string) {


### PR DESCRIPTION
As we are planning to get rid of cilium_host and accessing a NodePort
svc via its IP addr doesn't make sense (because the IP addr is not
static), do not expose "ipv{4,6}(cilium_host):NodePort" in the BPF LB
maps.

Unfortunately, the service is still reachable via the cilium_host IP
addr because of the wildcard lookup in bpf_sock. However, remove this
svc access from the docs to avoid any surprises after cilium_host has
been removed.

```release-note
Accessing a NodePort service via cilium_host IP addr is no longer recommended.
```