### PR TITLE
test: Add externalIPs tests to K8sServicesTest and disable K8sKubeProxyFreeMatrix

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2082,6 +2082,13 @@ func (kub *Kubectl) DeployPatch(original, patchFileName string) error {
 	return nil
 }
 
+// Patch patches the given object with the given patch (string).
+func (kub *Kubectl) Patch(namespace, objType, objName, patch string) *CmdRes {
+	ginkgoext.By("Patching %s %s in namespace %s", objType, objName, namespace)
+	return kub.ExecShort(fmt.Sprintf("%s -n %s patch %s %s --patch %q",
+		KubectlCmd, namespace, objType, objName, patch))
+}
+
 func addIfNotOverwritten(options map[string]string, field, value string) map[string]string {
 	if _, ok := options[field]; !ok {
 		options[field] = value

--- a/test/k8sT/Services.go
+++ b/test/k8sT/Services.go
@@ -380,7 +380,7 @@ var _ = Describe("K8sServicesTest", func() {
 				"Request from %s to service %s failed", fromPod, url)
 		}
 
-		failRequests := func(url string, count int, fromPod string) {
+		testCurlFailFromPodInHostNetNS := func(url string, count int, fromPod string) {
 			By("Making %d curl requests from %s to %q", count, fromPod, url)
 			for i := 1; i <= count; i++ {
 				res, err := kubectl.ExecInHostNetNS(context.TODO(), fromPod, helpers.CurlFail(url, "--max-time 3"))
@@ -771,10 +771,10 @@ var _ = Describe("K8sServicesTest", func() {
 			testCurlFromPods(testDSClient, httpURL)
 			testCurlFromPods(testDSClient, tftpURL)
 			// But not from the host netns (to prevent MITM)
-			failRequests(httpURL, 1, k8s1NodeName)
-			failRequests(httpURL, 1, k8s1NodeName)
-			failRequests(httpURL, 1, k8s2NodeName)
-			failRequests(httpURL, 1, k8s2NodeName)
+			testCurlFailFromPodInHostNetNS(httpURL, 1, k8s1NodeName)
+			testCurlFailFromPodInHostNetNS(httpURL, 1, k8s1NodeName)
+			testCurlFailFromPodInHostNetNS(httpURL, 1, k8s2NodeName)
+			testCurlFailFromPodInHostNetNS(httpURL, 1, k8s2NodeName)
 			// However, it should work via the k8s1 IP addr
 			httpURL = getHTTPLink(k8s1IP, data.Spec.Ports[0].Port)
 			tftpURL = getTFTPLink(k8s1IP, data.Spec.Ports[1].Port)
@@ -970,10 +970,10 @@ var _ = Describe("K8sServicesTest", func() {
 
 			httpURL = getHTTPLink(k8s1IP, data.Spec.Ports[0].NodePort)
 			tftpURL = getTFTPLink(k8s1IP, data.Spec.Ports[1].NodePort)
-			failRequests(httpURL, count, k8s1NodeName)
-			failRequests(httpURL, count, k8s2NodeName)
-			failRequests(tftpURL, count, k8s1NodeName)
-			failRequests(tftpURL, count, k8s2NodeName)
+			testCurlFailFromPodInHostNetNS(httpURL, count, k8s1NodeName)
+			testCurlFailFromPodInHostNetNS(httpURL, count, k8s2NodeName)
+			testCurlFailFromPodInHostNetNS(tftpURL, count, k8s1NodeName)
+			testCurlFailFromPodInHostNetNS(tftpURL, count, k8s2NodeName)
 		}
 
 		testHostPort := func() {

--- a/test/k8sT/external_ips.go
+++ b/test/k8sT/external_ips.go
@@ -34,7 +34,12 @@ const (
 	namespaceTest = "external-ips-test"
 )
 
-var _ = Describe("K8sKubeProxyFreeMatrix tests", func() {
+func skipSuite(name string, t func()) bool {
+	return false
+}
+
+// Replace "skipSuite" with "Describe" to enable the suite.
+var _ = skipSuite("K8sKubeProxyFreeMatrix tests", func() {
 	var (
 		kubectl             *helpers.Kubectl
 		ciliumFilename      string

--- a/test/k8sT/manifests/demo_ds.yaml
+++ b/test/k8sT/manifests/demo_ds.yaml
@@ -231,3 +231,23 @@ spec:
     name: http
   selector:
     zgroup: test-k8s2
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-external-ips
+spec:
+  type: NodePort
+  ports:
+  - port: 20080
+    targetPort: 80
+    protocol: TCP
+    name: http
+  - port: 20069
+    targetPort: 69
+    protocol: UDP
+    name: tftp
+  externalIPs:
+  - 192.0.2.233
+  selector:
+    zgroup: testDS


### PR DESCRIPTION
See commit msgs.

`test-net-next` should run ~20min faster.

Fix #11442.