### PR TITLE
Add "--iptables-lock-timeout" to configure iptables --wait parameter

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -113,6 +113,7 @@ cilium-agent [flags]
       --ip-masq-agent-config-path string              ip-masq-agent configuration file path (default "/etc/config/ip-masq-agent")
       --ipam string                                   Backend to use for IPAM (default "hostscope-legacy")
       --ipsec-key-file string                         Path to IPSec key file
+      --iptables-lock-timeout duration                Time to pass to each iptables invocation to wait for xtables lock acquisition (default 5s)
       --ipv4-node string                              IPv4 address of node (default "auto")
       --ipv4-pod-subnets strings                      List of IPv4 pod subnets to preconfigure for encryption
       --ipv4-range string                             Per-node IPv4 endpoint prefix, e.g. 10.16.0.0/16 (default "auto")

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -563,6 +563,9 @@ func init() {
 	flags.Bool(option.InstallIptRules, true, "Install base iptables rules for cilium to mainly interact with kube-proxy (and masquerading)")
 	option.BindEnv(option.InstallIptRules)
 
+	flags.Duration(option.IPTablesLockTimeout, 5*time.Second, "Time to pass to each iptables invocation to wait for xtables lock acquisition")
+	option.BindEnv(option.IPTablesLockTimeout)
+
 	flags.Int(option.MaxCtrlIntervalName, 0, "Maximum interval (in seconds) between controller runs. Zero is no limit.")
 	flags.MarkHidden(option.MaxCtrlIntervalName)
 	option.BindEnv(option.MaxCtrlIntervalName)

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -327,6 +327,9 @@ data:
 {{- end }}
   enable-xt-socket-fallback: {{ .Values.global.enableXTSocketFallback | quote }}
   install-iptables-rules: {{ .Values.global.installIptablesRules | quote }}
+{{- if .Values.global.iptablesLockTimeout }}
+  iptables-lock-timeout: {{ .Values.global.iptablesLockTimeout | quote }}
+{{- end }}
   auto-direct-node-routes: {{ .Values.global.autoDirectNodeRoutes | quote }}
 {{- if .Values.global.nativeRoutingCIDR }}
   native-routing-cidr: {{ .Values.global.nativeRoutingCIDR }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -123,6 +123,9 @@ global:
   # disabled.
   installIptablesRules: true
 
+  # iptablesLockTimeout defines the iptables "--wait" option when invoked from Cilium.
+  # iptablesLockTimeout: "5s"
+
   # masquerade enables masquerading of traffic leaving the node for
   # destinations outside of the cluster.
   masquerade: true

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/command/exec"
@@ -61,8 +62,7 @@ var (
 )
 
 const (
-	waitString       = "-w"
-	waitSecondsValue = "5"
+	waitString = "-w"
 )
 
 type customChain struct {
@@ -417,7 +417,7 @@ func (m *IptablesManager) Init() {
 	if err == nil {
 		switch {
 		case isWaitSecondsMinVersion(v):
-			m.waitArgs = []string{waitString, waitSecondsValue}
+			m.waitArgs = []string{waitString, fmt.Sprintf("%d", option.Config.IPTablesLockTimeout/time.Second)}
 		case isWaitMinVersion(v):
 			m.waitArgs = []string{waitString}
 		}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -289,6 +289,8 @@ const (
 	// InstallIptRules sets whether Cilium should install any iptables in general
 	InstallIptRules = "install-iptables-rules"
 
+	IPTablesLockTimeout = "iptables-lock-timeout"
+
 	// IPv6NodeAddr is the IPv6 address of node
 	IPv6NodeAddr = "ipv6-node"
 
@@ -986,6 +988,7 @@ var HelpFlagSections = []FlagsSection{
 			PrependIptablesChainsName,
 			InstallIptRules,
 			DisableIptablesFeederRules,
+			IPTablesLockTimeout,
 		},
 	},
 	{
@@ -1358,6 +1361,10 @@ type DaemonConfig struct {
 	// PrependIptablesChains is the name of the option to enable prepending
 	// iptables chains instead of appending
 	PrependIptablesChains bool
+
+	// IPTablesLockTimeout defines the "-w" iptables option when the
+	// iptables CLI is directly invoked from the Cilium agent.
+	IPTablesLockTimeout time.Duration
 
 	// K8sNamespace is the name of the namespace in which Cilium is
 	// deployed in when running in Kubernetes mode
@@ -2216,6 +2223,7 @@ func (c *DaemonConfig) Populate() {
 	c.EnableIPMasqAgent = viper.GetBool(EnableIPMasqAgent)
 	c.IPMasqAgentConfigPath = viper.GetString(IPMasqAgentConfigPath)
 	c.InstallIptRules = viper.GetBool(InstallIptRules)
+	c.IPTablesLockTimeout = viper.GetDuration(IPTablesLockTimeout)
 	c.IPSecKeyFile = viper.GetString(IPSecKeyFileName)
 	c.ModePreFilter = viper.GetString(PrefilterMode)
 	c.MonitorAggregation = viper.GetString(MonitorAggregationName)


### PR DESCRIPTION
Add a new daemon CLI argument, "--iptables-lock-timeout" to specify the
iptables "--wait" argument when invoking the iptables CLI binary
directly from cilium-agent.

Fixes: #11608

Nominating for v1.6 / v1.7 backport since it's a trivial change to pipe through, and it helps to stabilize clusters for users on older versions of Cilium.