### PR TITLE
test(helm): Correct invalid input in kind-action

### DIFF
--- a/.github/workflows/helm-check.yaml
+++ b/.github/workflows/helm-check.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Create kind cluster
         uses: helm/kind-action@v1.0.0-rc.1
         with:
-          install_local_path_provisioner: true
+          version: v0.8.1
 
       # This test is just to make sure the helm chart can be installed. It will not replace existing integration tests
       - name: Run chart-testing (install)


### PR DESCRIPTION
There is warning message in github action as per below.
##[warning]Unexpected input 'install_local_path_provisioner'

This option was removed as part of https://github.com/helm/kind-action/pull/16.
Underlying kind 0.7.0+ is shipped with better local storage. I take this change
to upgrade kind version to latest as well

Signed-off-by: Tam Mach <sayboras@yahoo.com>