### PR TITLE
Ensure endpoint validation occurs before initial regeneration

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -308,9 +308,6 @@ type Endpoint struct {
 	aliveCtx        context.Context
 	aliveCancel     context.CancelFunc
 	regenFailedChan chan struct{}
-	// exposed is a channel that is closed when the endpoint is exposed in the
-	// endpoint manager.
-	exposed chan struct{}
 
 	allocator cache.IdentityAllocator
 
@@ -440,7 +437,6 @@ func createEndpoint(owner regeneration.Owner, proxy EndpointProxy, allocator cac
 		controllers:     controller.NewManager(),
 		regenFailedChan: make(chan struct{}, 1),
 		allocator:       allocator,
-		exposed:         make(chan struct{}),
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -780,7 +776,6 @@ func parseEndpoint(ctx context.Context, owner regeneration.Owner, strEp string) 
 	ep.realizedPolicy = ep.desiredPolicy
 	ep.controllers = controller.NewManager()
 	ep.regenFailedChan = make(chan struct{}, 1)
-	ep.exposed = make(chan struct{})
 
 	ctx, cancel := context.WithCancel(ctx)
 	ep.aliveCancel = cancel
@@ -2312,19 +2307,4 @@ func (e *Endpoint) setDefaultPolicyConfig() {
 	alwaysEnforce := policy.GetPolicyEnabled() == option.AlwaysEnforce
 	e.desiredPolicy.IngressPolicyEnabled = alwaysEnforce
 	e.desiredPolicy.EgressPolicyEnabled = alwaysEnforce
-}
-
-// WaitUntilExposed will return once the endpoint is exposed in the endpoint
-// manager. It returns an error in case the given context expires of if the
-// endpoint is deleted in the meanwhile, i.e., the endpoint's aliveCtx is
-// canceled.
-func (e *Endpoint) WaitUntilExposed(ctx context.Context) error {
-	select {
-	case <-e.exposed:
-		return nil
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-e.aliveCtx.Done():
-		return e.aliveCtx.Err()
-	}
 }

--- a/pkg/endpoint/manager.go
+++ b/pkg/endpoint/manager.go
@@ -46,7 +46,6 @@ func (e *Endpoint) Expose(mgr endpointManager) error {
 		e.unlock()
 		return err
 	}
-	defer close(e.exposed)
 
 	e.ID = newID
 	e.UpdateLogger(map[string]interface{}{

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -115,10 +115,10 @@ func (k *K8sWatcher) podsInit(k8sClient kubernetes.Interface, asyncControllers *
 			close(k.podStoreSet)
 		})
 
-		k.blockWaitGroupToSyncResources(isConnected, nil, podController, k8sAPIGroupPodV1Core)
+		k.blockWaitGroupToSyncResources(isConnected, nil, podController, K8sAPIGroupPodV1Core)
 		once.Do(func() {
 			asyncControllers.Done()
-			k.k8sAPIGroups.addAPI(k8sAPIGroupPodV1Core)
+			k.k8sAPIGroups.addAPI(K8sAPIGroupPodV1Core)
 		})
 		go podController.Run(isConnected)
 		return isConnected
@@ -144,10 +144,10 @@ func (k *K8sWatcher) podsInit(k8sClient kubernetes.Interface, asyncControllers *
 		isConnected := make(chan struct{})
 		// once isConnected is closed, it will stop waiting on caches to be
 		// synchronized.
-		k.blockWaitGroupToSyncResources(isConnected, nil, podController, k8sAPIGroupPodV1Core)
+		k.blockWaitGroupToSyncResources(isConnected, nil, podController, K8sAPIGroupPodV1Core)
 		once.Do(func() {
 			asyncControllers.Done()
-			k.k8sAPIGroups.addAPI(k8sAPIGroupPodV1Core)
+			k.k8sAPIGroups.addAPI(K8sAPIGroupPodV1Core)
 		})
 		go podController.Run(isConnected)
 
@@ -587,7 +587,7 @@ func validIPs(podStatus slim_corev1.PodStatus) ([]string, error) {
 //  - false: returns any pod in the cluster received by the pod watcher.
 func (k *K8sWatcher) GetCachedPod(namespace, name string) (*slim_corev1.Pod, error) {
 	<-k.controllersStarted
-	k.WaitForCacheSync(k8sAPIGroupPodV1Core)
+	k.WaitForCacheSync(K8sAPIGroupPodV1Core)
 	<-k.podStoreSet
 	k.podStoreMU.RLock()
 	defer k.podStoreMU.RUnlock()

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -52,7 +52,7 @@ const (
 	k8sAPIGroupNamespaceV1Core                  = "core/v1::Namespace"
 	K8sAPIGroupServiceV1Core                    = "core/v1::Service"
 	K8sAPIGroupEndpointV1Core                   = "core/v1::Endpoint"
-	k8sAPIGroupPodV1Core                        = "core/v1::Pods"
+	K8sAPIGroupPodV1Core                        = "core/v1::Pods"
 	k8sAPIGroupNetworkingV1Core                 = "networking.k8s.io/v1::NetworkPolicy"
 	k8sAPIGroupCiliumNetworkPolicyV2            = "cilium/v2::CiliumNetworkPolicy"
 	k8sAPIGroupCiliumClusterwideNetworkPolicyV2 = "cilium/v2::CiliumClusterwideNetworkPolicy"
@@ -387,7 +387,7 @@ func (k *K8sWatcher) InitK8sSubsystem() <-chan struct{} {
 			k8sAPIGroupNamespaceV1Core,
 			// Pods can contain labels which are essential for endpoints
 			// being restored to have the right identity.
-			k8sAPIGroupPodV1Core,
+			K8sAPIGroupPodV1Core,
 		)
 		// CiliumEndpoint is used to synchronize the ipcache, wait for
 		// it unless it is disabled


### PR DESCRIPTION
Due to a performance optimization, validateEndpoint() was changed to use
the pod store instad of contacting the apiserver directly. This required
to make the validation async to wait until the pod cache is available.

This change however caused the endpoint to be exposed and regenerated
before the endpoint was fully validated. This in turn caused the
validation to occur while the regeneration was being performed. When the
validation then failed, the endpoint was deleted while the endpoint was
being regenerated, causing the endpoint to fail with a "JoinEP" message
in the logs.

This commit requires the endpoint to be validated before exposure and
initial regeneration.

This problem only exists in master. No need to backport.

Fixes: #11645
Fixes: #11076
Fixes: #10856
Fixes: #10667
Fixes: #10278
Fixes: 9975bba1637 ("pkg/endpoint: fetch pod and namespace labels from local stores")