### PR TITLE
Set Cilium node name in init in k8s mode

### DIFF
--- a/cilium/cmd/preflight_identity_crd_migrate.go
+++ b/cilium/cmd/preflight_identity_crd_migrate.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/cilium/pkg/idpool"
 	"github.com/cilium/cilium/pkg/k8s"
 	k8sconfig "github.com/cilium/cilium/pkg/k8s/config"
+	k8sConst "github.com/cilium/cilium/pkg/k8s/constants"
 	"github.com/cilium/cilium/pkg/k8s/identitybackend"
 	"github.com/cilium/cilium/pkg/kvstore"
 	kvstoreallocator "github.com/cilium/cilium/pkg/kvstore/allocator"
@@ -200,7 +201,7 @@ func initK8s(ctx context.Context) (crdBackend allocator.Backend, crdAllocator *a
 		log.WithError(err).Fatal("Unable to connect to Kubernetes apiserver")
 	}
 
-	if err := k8s.GetNodeSpec(os.Getenv(k8s.EnvNodeNameSpec)); err != nil {
+	if err := k8s.GetNodeSpec(os.Getenv(k8sConst.EnvNodeNameSpec)); err != nil {
 		log.WithError(err).Fatal("Unable to connect to get node spec from apiserver")
 	}
 

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -47,6 +47,7 @@ import (
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s"
+	k8sConst "github.com/cilium/cilium/pkg/k8s/constants"
 	"github.com/cilium/cilium/pkg/k8s/watchers"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
@@ -414,7 +415,7 @@ func NewDaemon(ctx context.Context, dp datapath.Datapath) (*Daemon, *endpointRes
 			d.nodeDiscovery.UpdateCiliumNodeResource()
 		}
 
-		if err := k8s.GetNodeSpec(os.Getenv(k8s.EnvNodeNameSpec)); err != nil {
+		if err := k8s.GetNodeSpec(os.Getenv(k8sConst.EnvNodeNameSpec)); err != nil {
 			log.WithError(err).Fatal("Unable to connect to get node spec from apiserver")
 		}
 

--- a/pkg/k8s/constants/const.go
+++ b/pkg/k8s/constants/const.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,17 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package k8s
-
-import (
-	"time"
-)
+package constants
 
 const (
-	// BackOffLoopTimeout is the default duration when trying to reach the
-	// kube-apiserver.
-	BackOffLoopTimeout = 2 * time.Minute
-
 	// EnvNodeNameSpec is the environment label used by Kubernetes to
 	// specify the node's name.
 	EnvNodeNameSpec = "K8S_NODE_NAME"

--- a/pkg/k8s/init.go
+++ b/pkg/k8s/init.go
@@ -25,6 +25,7 @@ import (
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	cilium_v2_client "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2/client"
 	k8sconfig "github.com/cilium/cilium/pkg/k8s/config"
+	k8sConst "github.com/cilium/cilium/pkg/k8s/constants"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/core/v1"
 	k8sversion "github.com/cilium/cilium/pkg/k8s/version"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -190,7 +191,7 @@ func Init(conf k8sconfig.Configuration) error {
 func GetNodeSpec(nodeName string) error {
 	if nodeName == "" {
 		if option.Config.K8sRequireIPv4PodCIDR || option.Config.K8sRequireIPv6PodCIDR {
-			return fmt.Errorf("node name must be specified via environment variable '%s' to retrieve Kubernetes PodCIDR range", EnvNodeNameSpec)
+			return fmt.Errorf("node name must be specified via environment variable '%s' to retrieve Kubernetes PodCIDR range", k8sConst.EnvNodeNameSpec)
 		}
 		return nil
 	}

--- a/pkg/node/types/nodename.go
+++ b/pkg/node/types/nodename.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 Authors of Cilium
+// Copyright 2016-2020 Authors of Cilium
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package types
 import (
 	"os"
 
+	k8sConsts "github.com/cilium/cilium/pkg/k8s/constants"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
@@ -42,6 +43,11 @@ func GetName() string {
 }
 
 func init() {
+	// Give priority to the environment variable available in the Cilium agent
+	if name := os.Getenv(k8sConsts.EnvNodeNameSpec); name != "" {
+		nodeName = name
+		return
+	}
 	if h, err := os.Hostname(); err != nil {
 		log.WithError(err).Warn("Unable to retrieve local hostname")
 	} else {


### PR DESCRIPTION
pkg/node: give priority to nodeName from K8S_NODE_NAME env variable

If Cilium is running in k8s mode, K8S_NODE_NAME is available so we
can set the node name directly upon node initialization. This prevents
Cilium from setting the node name with a different name at a later
stage as the os.Hostname() can be return a different value than
K8S_NODE_NAME.

Fixes: dbfc2c3cb15e ("k8s: remove waiting for node spec on k8s client init")

```release-note
Fix Cilium blocking its initialization for nodes where the hostname was different that the Kubernetes node name.
```