### PR TITLE
helpers: Remove hubble-relay service in cleanup

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2256,6 +2256,7 @@ func (kub *Kubectl) DeleteHubbleClientPods(ns string) error {
 func (kub *Kubectl) DeleteHubbleRelay(ns string) error {
 	ginkgoext.By("DeleteHubbleRelay(namespace=%q)", ns)
 	_ = kub.DeleteResource("deployment", fmt.Sprintf("-n %s hubble-relay", ns))
+	_ = kub.DeleteResource("service", fmt.Sprintf("-n %s hubble-relay", ns))
 	return kub.waitToDelete("HubbleRelay", HubbleRelayLabel)
 }
 

--- a/test/k8sT/hubble.go
+++ b/test/k8sT/hubble.go
@@ -121,6 +121,8 @@ var _ = Describe("K8sHubbleTest", func() {
 	})
 
 	AfterAll(func() {
+		kubectl.DeleteHubbleClientPods(hubbleNamespace)
+		kubectl.DeleteHubbleRelay(hubbleNamespace)
 		kubectl.CloseSSHClient()
 	})
 
@@ -152,8 +154,6 @@ var _ = Describe("K8sHubbleTest", func() {
 		AfterAll(func() {
 			kubectl.Delete(demoPath)
 			kubectl.NamespaceDelete(namespaceForTest)
-			kubectl.DeleteHubbleClientPods(hubbleNamespace)
-			kubectl.DeleteHubbleRelay(hubbleNamespace)
 		})
 
 		It("Test L3/L4 Flow", func() {


### PR DESCRIPTION
This is a follow-up to #11687. Commit 5aee704 removed the cleanup
of Cilium via the Helm generated yaml manifests. This requires us
to manually remove all objects created by DeployCiliumOptionsAndDNS
which are not going to be replaced by a subsequent test suite.

This commits makes sure to also remove the hubble-relay service when
hubble-relay is cleaned up. In addition, the clean-up calls in K8sHubble
are moved to the correct AfterAll section.

This also fixes an issue on GKE where the hubble-relay service has not
been removed for 6 days. See #11720.

Fixes: 6e3cdc8fe181 ("test/k8sHubble: Clean up hubble-cli and hubble-relay pods")

Signed-off-by: Sebastian Wicki <sebastian@isovalent.com>
