### PR TITLE
doc: Fix require-ipv4-pod-cidr value for ENI and Azure mode

### DIFF
--- a/Documentation/concepts/ipam/gke.rst
+++ b/Documentation/concepts/ipam/gke.rst
@@ -37,8 +37,8 @@ Configuration
 *************
 
 The GKE IPAM mode can be enabled by setting the Helm option
-``global.gke.enabled=true`` or by setting the ConfigMap option
-``ipam: kubernetes``.
+``config.ipam=kubernetes`` or by setting the ConfigMap option ``ipam:
+kubernetes``.
 
 ***************
 Troubleshooting

--- a/Documentation/gettingstarted/ipam-cluster-pool.rst
+++ b/Documentation/gettingstarted/ipam-cluster-pool.rst
@@ -21,7 +21,7 @@ Enable Cluster-pool IPAM mode
 =============================
 
 #. Setup Cilium for Kubernetes using helm with the options:
-   ``--set global.ipam.mode=cluster-pool``.
+   ``--set config.ipam=cluster-pool``.
 #. Depending if you are using IPv4 and / or IPv6, you might want to adjust
    the ``podCIDR`` allocated for your cluster's pods with the options:
 

--- a/Documentation/gettingstarted/k8s-install-azure.rst
+++ b/Documentation/gettingstarted/k8s-install-azure.rst
@@ -89,6 +89,7 @@ Deploy Cilium release via Helm:
      --set global.azure.clientID=$AZURE_CLIENT_ID \\
      --set global.azure.clientSecret=$AZURE_CLIENT_SECRET \\
      --set global.tunnel=disabled \\
+     --set config.ipam=azure \\
      --set global.masquerade=false \\
      --set global.nodeinit.enabled=true
 

--- a/Documentation/gettingstarted/k8s-install-eks.rst
+++ b/Documentation/gettingstarted/k8s-install-eks.rst
@@ -89,6 +89,7 @@ Deploy Cilium release via Helm:
    helm install cilium |CHART_RELEASE| \\
      --namespace kube-system \\
      --set global.eni=true \\
+     --set config.ipam=eni \\
      --set global.egressMasqueradeInterfaces=eth0 \\
      --set global.tunnel=disabled \\
      --set global.nodeinit.enabled=true

--- a/Documentation/gettingstarted/k8s-install-gke.rst
+++ b/Documentation/gettingstarted/k8s-install-gke.rst
@@ -84,6 +84,7 @@ below. This will ensure all pods are managed by Cilium.
       --set nodeinit.removeCbrBridge=true \\
       --set global.cni.binPath=/home/kubernetes/bin \\
       --set global.gke.enabled=true \\
+      --set config.ipam=kubernetes \\
       --set global.native-routing-cidr=$NATIVE_CIDR
 
 The NodeInit DaemonSet is required to prepare the GKE nodes as nodes are added

--- a/install/kubernetes/cilium/charts/config/templates/configmap.yaml
+++ b/install/kubernetes/cilium/charts/config/templates/configmap.yaml
@@ -216,6 +216,7 @@ data:
 {{- end }}
 
 {{- if .Values.global.gke.enabled }}
+
   ipam: "kubernetes"
   tunnel: "disabled"
   enable-endpoint-routes: "true"
@@ -224,14 +225,12 @@ data:
 {{- end }}
 
 {{- if .Values.global.eni }}
-  ipam: "eni"
   enable-endpoint-routes: "true"
   auto-create-cilium-node-resource: "true"
   blacklist-conflicting-routes: "false"
 {{- end }}
 
 {{- if .Values.global.azure.enabled }}
-  ipam: "azure"
   enable-endpoint-routes: "true"
   auto-create-cilium-node-resource: "true"
   blacklist-conflicting-routes: "false"
@@ -391,11 +390,11 @@ data:
 {{- if and .Values.global.k8s .Values.global.k8s.requireIPv4PodCIDR }}
   k8s-require-ipv4-pod-cidr: {{ .Values.global.k8s.requireIPv4PodCIDR | quote }}
 {{- else }}
-{{- if eq .Values.global.ipam.mode "cluster-pool" }}
+{{- if eq .Values.ipam "cluster-pool" }}
   k8s-require-ipv4-pod-cidr: {{ .Values.global.ipv4.enabled | quote}}
 {{- end }}
 {{- end }}
-{{- if eq .Values.global.ipam.mode "cluster-pool" }}
+{{- if eq .Values.ipam "cluster-pool" }}
   k8s-require-ipv6-pod-cidr: {{ .Values.global.ipv6.enabled | quote}}
 {{- end }}
 {{- if and .Values.global.endpointRoutes .Values.global.endpointRoutes.enabled }}
@@ -466,9 +465,8 @@ data:
 
   # A space separated list of iptables chains to disable when installing feeder rules.
   disable-iptables-feeder-rules: {{ .Values.global.disableIptablesFeederRules | join " " | quote }}
-{{ if and .Values.global.ipam (not (or .Values.global.gke.enabled ( or .Values.global.eni .Values.global.azure.enabled ))) }}
-  ipam: {{ .Values.global.ipam.mode | quote }}
-{{- if eq .Values.global.ipam.mode "cluster-pool" }}
+  ipam: {{ default "cluster-pool" .Values.ipam | quote }}
+{{- if eq .Values.ipam "cluster-pool" }}
 {{- if .Values.global.ipv4.enabled }}
   cluster-pool-ipv4-cidr: {{ .Values.global.ipam.operator.clusterPoolIPv4PodCIDR | quote }}
   cluster-pool-ipv4-mask-size: {{ .Values.global.ipam.operator.clusterPoolIPv4MaskSize | quote  }}
@@ -476,7 +474,6 @@ data:
 {{- if .Values.global.ipv6.enabled }}
   cluster-pool-ipv6-cidr: {{ .Values.global.ipam.operator.clusterPoolIPv6PodCIDR | quote }}
   cluster-pool-ipv6-mask-size: {{ .Values.global.ipam.operator.clusterPoolIPv6MaskSize | quote }}
-{{- end }}
 {{- end }}
 {{- end }}
 

--- a/install/kubernetes/cilium/charts/config/values.yaml
+++ b/install/kubernetes/cilium/charts/config/values.yaml
@@ -1,0 +1,9 @@
+# ipam is the IPAM mode to use.
+#
+# Possible values:
+# - cluster-pool
+# - kubernetes
+# - eni
+# - azure
+# - crd
+ipam: "cluster-pool"

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -495,7 +495,6 @@ global:
     kubeCacheMutationDetector: false
 
   ipam:
-    mode: "cluster-pool"
     operator:
       clusterPoolIPv4PodCIDR: "10.0.0.0/8"
       clusterPoolIPv4MaskSize: 24

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -180,7 +180,6 @@ data:
 
   # A space separated list of iptables chains to disable when installing feeder rules.
   disable-iptables-feeder-rules: ""
-
   ipam: "cluster-pool"
   cluster-pool-ipv4-cidr: "10.0.0.0/8"
   cluster-pool-ipv4-mask-size: "24"


### PR DESCRIPTION
The helm chart was incorrectly setting require-ipv4-pod-cidr for ENI
and Azure IPAM modes.

The commit moves the ipam value into the config chart and adjusts all
guides to set it to the correct value instead of setting it indirectly
via a meta value.

Fixes: 934053ced7b ("install/kubernetes: enable Cilium-based podCIDR allocation by default")