### PR TITLE
Make used version of some docker images consistent

### DIFF
--- a/examples/kubernetes-es/es-sw-app.yaml
+++ b/examples/kubernetes-es/es-sw-app.yaml
@@ -38,7 +38,7 @@ spec:
       serviceAccount: elasticsearch
       initContainers:
       - name: init-sysctl
-        image: docker.io/library/busybox
+        image: docker.io/library/busybox:1.31.1
         imagePullPolicy: IfNotPresent
         command: ["sysctl", "-w", "vm.max_map_count=262144"]
         securityContext:

--- a/examples/kubernetes-istio/cilium-kube-inject.awk
+++ b/examples/kubernetes-istio/cilium-kube-inject.awk
@@ -5,7 +5,7 @@
 /initContainers:/ {
 	indent = $0 ; sub(/[^ ].*/, "", indent)
 	print indent "- name: sleep"
-	print indent "  image: busybox:1.28.4"
+	print indent "  image: busybox:1.31.1"
 	print indent "  imagePullPolicy: IfNotPresent"
 	print indent "  command: ['sh', '-c', 'max=120; i=0; until nslookup kube-dns.kube-system.svc.cluster.local; do i=$((i + 1)); if [ $i -eq $max ]; then echo timed-out; exit 1; else sleep 1; fi done ']"
 }

--- a/test/helpers/constants/images.go
+++ b/test/helpers/constants/images.go
@@ -37,7 +37,7 @@ const (
 	BusyboxImage = "docker.io/library/busybox:1.28.0"
 
 	// AlpineCurlImage is the image used for invoking curl with a small base image.
-	AlpineCurlImage = "docker.io/byrnedo/alpine-curl:0.1.7"
+	AlpineCurlImage = "docker.io/byrnedo/alpine-curl:0.1.8"
 
 	// MemcachedImage is the image used to test memcached in the runtime tests.
 	MemcacheDImage = "docker.io/library/memcached:1.5.11"

--- a/test/helpers/constants/images.go
+++ b/test/helpers/constants/images.go
@@ -34,7 +34,7 @@ const (
 	ZookeeperImage = "docker.io/digitalwonderland/zookeeper:latest"
 
 	// BuxyboxImage is a space efficient-image used for basic testing.
-	BusyboxImage = "docker.io/library/busybox:1.28.0"
+	BusyboxImage = "docker.io/library/busybox:1.31.1"
 
 	// AlpineCurlImage is the image used for invoking curl with a small base image.
 	AlpineCurlImage = "docker.io/byrnedo/alpine-curl:0.1.8"


### PR DESCRIPTION
This will allow to reduce the list of pre-pulled image in the dev VM a bit (see cilium/packer-ci-build#219). Please see individual commits for details.

