### PR TITLE
test: use pkg/lock instead of stdlib sync

### DIFF
--- a/test/ginkgo-ext/scopes.go
+++ b/test/ginkgo-ext/scopes.go
@@ -25,9 +25,10 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/cilium/cilium/pkg/lock"
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/config"
@@ -37,7 +38,7 @@ type scope struct {
 	parent        *scope
 	children      []*scope
 	counter       int32
-	mutex         *sync.Mutex
+	mutex         *lock.Mutex
 	before        []func()
 	after         []func()
 	afterEach     []func()
@@ -55,7 +56,7 @@ var (
 	currentScope = &scope{
 		text:    "EntireTestsuite",
 		counter: -1,
-		mutex:   &sync.Mutex{},
+		mutex:   &lock.Mutex{},
 	}
 
 	rootScope = currentScope
@@ -467,7 +468,7 @@ func wrapContextFunc(fn func(string, func()) bool, focused bool) func(string, fu
 			text:    currentScope.text + " " + text,
 			parent:  currentScope,
 			focused: focused,
-			mutex:   &sync.Mutex{},
+			mutex:   &lock.Mutex{},
 			counter: -1,
 		}
 		currentScope.children = append(currentScope.children, newScope)


### PR DESCRIPTION
Currently the contrib/scripts/lock-check.sh script fails in the CI
runtime tests with:

```
20:33:58      runtime: contrib/scripts/lock-check.sh
20:33:58      runtime: ./test/ginkgo-ext/scopes.go:	mutex         *sync.Mutex
20:33:58      runtime: ./test/ginkgo-ext/scopes.go:		mutex:   &sync.Mutex{},
20:33:58      runtime: ./test/ginkgo-ext/scopes.go:			mutex:   &sync.Mutex{},
20:33:58      runtime: Found sync.Mutex usage. Please use pkg/lock instead to improve deadlock detection
20:33:58      runtime: Makefile:508: recipe for target 'postcheck' failed
20:33:58      runtime: make: *** [postcheck] Error
```

Fixes: 9d97e52914de ("test: Mend gingko-ext")