### PR TITLE
Create healthz HTTP endpoint for kube-proxy replacement

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -15,202 +15,203 @@ cilium-agent [flags]
 ### Options
 
 ```
-      --agent-health-port int                         TCP port for agent health status API (default 9876)
-      --agent-labels strings                          Additional labels to identify this agent
-      --allow-icmp-frag-needed                        Allow ICMP Fragmentation Needed type packets for purposes like TCP Path MTU. (default true)
-      --allow-localhost string                        Policy when to allow local stack to reach local endpoints { auto | always | policy } (default "auto")
-      --annotate-k8s-node                             Annotate Kubernetes node (default true)
-      --api-rate-limit map                            API rate limiting configuration (example: --rate-limit endpoint-create=rate-limit:10/m,rate-burst:2) (default map[])
-      --auto-create-cilium-node-resource              Automatically create CiliumNode resource for own node on startup (default true)
-      --auto-direct-node-routes                       Enable automatic L2 routing between nodes
-      --bpf-compile-debug                             Enable debugging of the BPF compilation process
-      --bpf-ct-global-any-max int                     Maximum number of entries in non-TCP CT table (default 262144)
-      --bpf-ct-global-tcp-max int                     Maximum number of entries in TCP CT table (default 524288)
-      --bpf-ct-timeout-regular-any duration           Timeout for entries in non-TCP CT table (default 1m0s)
-      --bpf-ct-timeout-regular-tcp duration           Timeout for established entries in TCP CT table (default 6h0m0s)
-      --bpf-ct-timeout-regular-tcp-fin duration       Teardown timeout for entries in TCP CT table (default 10s)
-      --bpf-ct-timeout-regular-tcp-syn duration       Establishment timeout for entries in TCP CT table (default 1m0s)
-      --bpf-ct-timeout-service-any duration           Timeout for service entries in non-TCP CT table (default 1m0s)
-      --bpf-ct-timeout-service-tcp duration           Timeout for established service entries in TCP CT table (default 6h0m0s)
-      --bpf-fragments-map-max int                     Maximum number of entries in fragments tracking map (default 8192)
-      --bpf-lb-maglev-hash-seed string                Maglev cluster-wide hash seed (base64 encoded) (default "JLfvgnHc2kaSUFaI")
-      --bpf-lb-maglev-table-size uint                 Maglev per service backend table size (parameter M) (default 16381)
-      --bpf-lb-map-max int                            Maximum number of entries in Cilium BPF lbmap (default 65536)
-      --bpf-map-dynamic-size-ratio float              Ratio (0.0-1.0) of total system memory to use for dynamic sizing of CT, NAT and policy BPF maps. Set to 0.0 to disable dynamic BPF map sizing (default: 0.0)
-      --bpf-nat-global-max int                        Maximum number of entries for the global BPF NAT table (default 524288)
-      --bpf-neigh-global-max int                      Maximum number of entries for the global BPF neighbor table (default 524288)
-      --bpf-policy-map-max int                        Maximum number of entries in endpoint policy map (per endpoint) (default 16384)
-      --bpf-root string                               Path to BPF filesystem
-      --bpf-sock-rev-map-max int                      Maximum number of entries for the SockRevNAT BPF map (default 262144)
-      --certificates-directory string                 Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
-      --cgroup-root string                            Path to Cgroup2 filesystem
-      --cluster-id int                                Unique identifier of the cluster
-      --cluster-name string                           Name of the cluster (default "default")
-      --clustermesh-config string                     Path to the ClusterMesh configuration directory
-      --config string                                 Configuration file (default "$HOME/ciliumd.yaml")
-      --config-dir string                             Configuration directory that contains a file for each option
-      --conntrack-gc-interval duration                Overwrite the connection-tracking garbage collection interval
-      --crd-wait-timeout duration                     Cilium will exit if CRDs are not available within this duration upon startup (default 5m0s)
-      --datapath-mode string                          Datapath mode name (default "veth")
-  -D, --debug                                         Enable debugging mode
-      --debug-verbose strings                         List of enabled verbose debug groups
-      --devices strings                               List of devices facing cluster/external network (used for BPF NodePort, BPF masquerading and host firewall)
-      --direct-routing-device string                  Device name used to connect nodes in direct routing mode (required only by BPF NodePort; if empty, automatically set to a device with k8s InternalIP/ExternalIP or with a default route)
-      --disable-cnp-status-updates                    Do not send CNP NodeStatus updates to the Kubernetes api-server (recommended to run with "cnp-node-status-gc-interval=0" in cilium-operator)
-      --disable-conntrack                             Disable connection tracking
-      --disable-endpoint-crd                          Disable use of CiliumEndpoint CRD
-      --disable-iptables-feeder-rules strings         Chains to ignore when installing feeder rules.
-      --egress-masquerade-interfaces string           Limit egress masquerading to interface selector
-      --enable-auto-protect-node-port-range           Append NodePort range to net.ipv4.ip_local_reserved_ports if it overlaps with ephemeral port range (net.ipv4.ip_local_port_range) (default true)
-      --enable-bandwidth-manager                      Enable BPF bandwidth manager
-      --enable-bpf-clock-probe                        Enable BPF clock source probing for more efficient tick retrieval
-      --enable-bpf-masquerade                         Masquerade packets from endpoints leaving the host with BPF instead of iptables
-      --enable-bpf-tproxy                             Enable BPF-based proxy redirection, if support available
-      --enable-endpoint-health-checking               Enable connectivity health checking between virtual endpoints (default true)
-      --enable-endpoint-routes                        Use per endpoint routes instead of routing via cilium_host
-      --enable-external-ips                           Enable k8s service externalIPs feature (requires enabling enable-node-port) (default true)
-      --enable-health-check-nodeport                  Enables a healthcheck nodePort server for NodePort services with 'healthCheckNodePort' being set (default true)
-      --enable-health-checking                        Enable connectivity health checking (default true)
-      --enable-host-firewall                          Enable host network policies (beta)
-      --enable-host-legacy-routing                    Enable the legacy host forwarding model which does not bypass upper stack in host namespace
-      --enable-host-port                              Enable k8s hostPort mapping feature (requires enabling enable-node-port) (default true)
-      --enable-host-reachable-services                Enable reachability of services for host applications (beta)
-      --enable-hubble                                 Enable hubble server
-      --enable-identity-mark                          Enable setting identity mark for local traffic (default true)
-      --enable-ip-masq-agent                          Enable BPF ip-masq-agent
-      --enable-ipsec                                  Enable IPSec support
-      --enable-ipv4                                   Enable IPv4 support (default true)
-      --enable-ipv4-fragment-tracking                 Enable IPv4 fragments tracking for L4-based lookups (default true)
-      --enable-ipv6                                   Enable IPv6 support (default true)
-      --enable-ipv6-ndp                               Enable IPv6 NDP support
-      --enable-k8s-api-discovery                      Enable discovery of Kubernetes API groups and resources with the discovery API
-      --enable-k8s-endpoint-slice                     Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
-      --enable-k8s-event-handover                     Enable k8s event handover to kvstore for improved scalability
-      --enable-l7-proxy                               Enable L7 proxy for L7 policy enforcement (default true)
-      --enable-local-node-route                       Enable installation of the route which points the allocation prefix of the local node (default true)
-      --enable-monitor                                Enable the monitor unix domain socket server (default true)
-      --enable-node-port                              Enable NodePort type services by Cilium (beta)
-      --enable-policy string                          Enable policy enforcement (default "default")
-      --enable-remote-node-identity                   Enable use of remote node identity
-      --enable-session-affinity                       Enable support for service session affinity
-      --enable-svc-source-range-check                 Enable check of service source ranges (currently, only for LoadBalancer) (default true)
-      --enable-tracing                                Enable tracing while determining policy (debugging)
-      --enable-well-known-identities                  Enable well-known identities for known Kubernetes components (default true)
-      --enable-xt-socket-fallback                     Enable fallback for missing xt_socket module (default true)
-      --encrypt-interface string                      Transparent encryption interface
-      --encrypt-node                                  Enables encrypting traffic from non-Cilium pods and host networking
-      --endpoint-interface-name-prefix string         Prefix of interface name shared by all endpoints (default "lxc+")
-      --endpoint-queue-size int                       size of EventQueue per-endpoint (default 25)
-      --endpoint-status strings                       Enable additional CiliumEndpoint status features (controllers,health,log,policy,state)
-      --envoy-log string                              Path to a separate Envoy log file, if any
-      --exclude-local-address strings                 Exclude CIDR from being recognized as local address
-      --fixed-identity-mapping map                    Key-value for the fixed identity mapping which allows to use reserved label for fixed identities (default map[])
-      --flannel-master-device string                  Installs a BPF program to allow for policy enforcement in the given network interface. Allows to run Cilium on top of other CNI plugins that provide networking, e.g. flannel, where for flannel, this value should be set with 'cni0'. [EXPERIMENTAL]
-      --flannel-uninstall-on-exit                     When used along the flannel-master-device flag, it cleans up all BPF programs installed when Cilium agent is terminated.
-      --force-local-policy-eval-at-source             Force policy evaluation of all local communication at the source endpoint (default true)
-  -h, --help                                          help for cilium-agent
-      --host-reachable-services-protos strings        Only enable reachability of services for host applications for specific protocols (default [tcp,udp])
-      --http-idle-timeout uint                        Time after which a non-gRPC HTTP stream is considered failed unless traffic in the stream has been processed (in seconds); defaults to 0 (unlimited)
-      --http-max-grpc-timeout uint                    Time after which a forwarded gRPC request is considered failed unless completed (in seconds). A "grpc-timeout" header may override this with a shorter value; defaults to 0 (unlimited)
-      --http-request-timeout uint                     Time after which a forwarded HTTP request is considered failed unless completed (in seconds); Use 0 for unlimited (default 3600)
-      --http-retry-count uint                         Number of retries performed after a forwarded request attempt fails (default 3)
-      --http-retry-timeout uint                       Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
-      --hubble-disable-tls                            Allow Hubble server to run on the given listen address without TLS.
-      --hubble-event-queue-size int                   Buffer size of the channel to receive monitor events.
-      --hubble-flow-buffer-size int                   Maximum number of flows in Hubble's buffer. The actual buffer size gets rounded up to the next power of 2, e.g. 4095 => 4096 (default 4095)
-      --hubble-listen-address string                  An additional address for Hubble server to listen to, e.g. ":4244"
-      --hubble-metrics strings                        List of Hubble metrics to enable.
-      --hubble-metrics-server string                  Address to serve Hubble metrics on.
-      --hubble-socket-path string                     Set hubble's socket path to listen for connections (default "/var/run/cilium/hubble.sock")
-      --hubble-tls-cert-file string                   Path to the public key file for the Hubble server. The file must contain PEM encoded data.
-      --hubble-tls-client-ca-files strings            Paths to one or more public key files of client CA certificates to use for TLS with mutual authentication (mTLS). The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
-      --hubble-tls-key-file string                    Path to the private key file for the Hubble server. The file must contain PEM encoded data.
-      --identity-allocation-mode string               Method to use for identity allocation (default "kvstore")
-      --identity-change-grace-period duration         Time to wait before using new identity on endpoint identity change (default 5s)
-      --install-iptables-rules                        Install base iptables rules for cilium to mainly interact with kube-proxy (and masquerading) (default true)
-      --ip-allocation-timeout duration                Time after which an incomplete CIDR allocation is considered failed (default 2m0s)
-      --ip-masq-agent-config-path string              ip-masq-agent configuration file path (default "/etc/config/ip-masq-agent")
-      --ipam string                                   Backend to use for IPAM (default "cluster-pool")
-      --ipsec-key-file string                         Path to IPSec key file
-      --iptables-lock-timeout duration                Time to pass to each iptables invocation to wait for xtables lock acquisition (default 5s)
-      --iptables-random-fully                         Set iptables flag random-fully on masquerading rules
-      --ipv4-node string                              IPv4 address of node (default "auto")
-      --ipv4-pod-subnets strings                      List of IPv4 pod subnets to preconfigure for encryption
-      --ipv4-range string                             Per-node IPv4 endpoint prefix, e.g. 10.16.0.0/16 (default "auto")
-      --ipv4-service-loopback-address string          IPv4 address for service loopback SNAT (default "169.254.42.1")
-      --ipv4-service-range string                     Kubernetes IPv4 services CIDR if not inside cluster prefix (default "auto")
-      --ipv6-cluster-alloc-cidr string                IPv6 /64 CIDR used to allocate per node endpoint /96 CIDR (default "f00d::/64")
-      --ipv6-mcast-device string                      Device that joins a Solicited-Node multicast group for IPv6
-      --ipv6-node string                              IPv6 address of node (default "auto")
-      --ipv6-pod-subnets strings                      List of IPv6 pod subnets to preconfigure for encryption
-      --ipv6-range string                             Per-node IPv6 endpoint prefix, e.g. fd02:1:1::/96 (default "auto")
-      --ipv6-service-range string                     Kubernetes IPv6 services CIDR if not inside cluster prefix (default "auto")
-      --ipvlan-master-device string                   Device facing external network acting as ipvlan master (default "undefined")
-      --join-cluster                                  Join a Cilium cluster via kvstore registration
-      --k8s-api-server string                         Kubernetes API server URL
-      --k8s-heartbeat-timeout duration                Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string                    Absolute path of the kubernetes kubeconfig file
-      --k8s-namespace string                          Name of the Kubernetes namespace in which Cilium is deployed in
-      --k8s-require-ipv4-pod-cidr                     Require IPv4 PodCIDR to be specified in node resource
-      --k8s-require-ipv6-pod-cidr                     Require IPv6 PodCIDR to be specified in node resource
-      --k8s-service-proxy-name string                 Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
-      --k8s-watcher-endpoint-selector string          K8s endpoint watcher will watch for these k8s endpoints (default "metadata.name!=kube-scheduler,metadata.name!=kube-controller-manager,metadata.name!=etcd-operator,metadata.name!=gcp-controller-manager")
-      --k8s-watcher-queue-size uint                   Queue size used to serialize each k8s event type (default 1024)
-      --keep-config                                   When restoring state, keeps containers' configuration in place
-      --kube-proxy-replacement string                 auto-enable available features for kube-proxy replacement ("probe"), or enable only selected features (will panic if any selected feature cannot be enabled) ("partial") or enable all features (will panic if any feature cannot be enabled) ("strict"), or completely disable it (ignores any selected feature) ("disabled") (default "partial")
-      --kvstore string                                Key-value store type
-      --kvstore-connectivity-timeout duration         Time after which an incomplete kvstore operation  is considered failed (default 2m0s)
-      --kvstore-opt map                               Key-value store options (default map[])
-      --kvstore-periodic-sync duration                Periodic KVstore synchronization interval (default 5m0s)
-      --label-prefix-file string                      Valid label prefixes file path
-      --labels strings                                List of label prefixes used to determine identity of an endpoint
-      --lib-dir string                                Directory path to store runtime build environment (default "/var/lib/cilium")
-      --log-driver strings                            Logging endpoints to use for example syslog
-      --log-opt map                                   Log driver options for cilium (default map[])
-      --log-system-load                               Enable periodic logging of system load
-      --masquerade                                    Masquerade packets from endpoints leaving the host (default true)
-      --metrics strings                               Metrics that should be enabled or disabled from the default metric list. (+metric_foo to enable metric_foo , -metric_bar to disable metric_bar)
-      --monitor-aggregation string                    Level of monitor aggregation for traces from the datapath (default "None")
-      --monitor-aggregation-flags strings             TCP flags that trigger monitor reports when monitor aggregation is enabled (default [syn,fin,rst])
-      --monitor-aggregation-interval duration         Monitor report interval when monitor aggregation is enabled (default 5s)
-      --monitor-queue-size int                        Size of the event queue when reading monitor events
-      --mtu int                                       Overwrite auto-detected MTU of underlying network
-      --nat46-range string                            IPv6 prefix to map IPv4 addresses to (default "0:0:0:0:0:FFFF::/96")
-      --native-routing-cidr string                    Allows to explicitly specify the CIDR for native routing. This value corresponds to the configured cluster-cidr.
-      --node-port-acceleration string                 BPF NodePort acceleration via XDP ("native", "disabled") (default "disabled")
-      --node-port-algorithm string                    BPF load balancing algorithm ("random", "maglev") (default "random")
-      --node-port-bind-protection                     Reject application bind(2) requests to service ports in the NodePort range (default true)
-      --node-port-mode string                         BPF NodePort mode ("snat", "dsr", "hybrid") (default "snat")
-      --node-port-range strings                       Set the min/max NodePort port range (default [30000,32767])
-      --policy-audit-mode                             Enable policy audit (non-drop) mode
-      --policy-queue-size int                         size of queues for policy-related events (default 100)
-      --pprof                                         Enable serving the pprof debugging API
-      --preallocate-bpf-maps                          Enable BPF map pre-allocation (default true)
-      --prefilter-device string                       Device facing external network for XDP prefiltering (default "undefined")
-      --prefilter-mode string                         Prefilter mode via XDP ("native", "generic") (default "native")
-      --prepend-iptables-chains                       Prepend custom iptables chains instead of appending (default true)
-      --prometheus-serve-addr string                  IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
-      --proxy-connect-timeout uint                    Time after which a TCP connect attempt is considered failed unless completed (in seconds) (default 1)
-      --proxy-prometheus-port int                     Port to serve Envoy metrics on. Default 0 (disabled).
-      --read-cni-conf string                          Read to the CNI configuration at specified path to extract per node configuration
-      --restore                                       Restores state, if possible, from previous daemon (default true)
-      --sidecar-istio-proxy-image string              Regular expression matching compatible Istio sidecar istio-proxy container image names (default "cilium/istio_proxy")
-      --single-cluster-route                          Use a single cluster route instead of per node routes
-      --skip-crd-creation                             Skip Kubernetes Custom Resource Definitions creations
-      --socket-path string                            Sets daemon's socket path to listen for connections (default "/var/run/cilium/cilium.sock")
-      --sockops-enable                                Enable sockops when kernel supported
-      --state-dir string                              Directory path to store runtime state (default "/var/run/cilium")
-      --tofqdns-dns-reject-response-code string       DNS response code for rejecting DNS requests, available options are '[nameError refused]' (default "refused")
-      --tofqdns-enable-dns-compression                Allow the DNS proxy to compress responses to endpoints that are larger than 512 Bytes or the EDNS0 option, if present (default true)
-      --tofqdns-endpoint-max-ip-per-hostname int      Maximum number of IPs to maintain per FQDN name for each endpoint (default 50)
-      --tofqdns-max-deferred-connection-deletes int   Maximum number of IPs to retain for expired DNS lookups with still-active connections (default 10000)
-      --tofqdns-min-ttl int                           The minimum time, in seconds, to use DNS data for toFQDNs policies. (default 3600 )
-      --tofqdns-pre-cache string                      DNS cache data at this path is preloaded on agent startup
-      --tofqdns-proxy-port int                        Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port.
-      --tofqdns-proxy-response-max-delay duration     The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information. (default 100ms)
-      --trace-payloadlen int                          Length of payload to capture when tracing (default 128)
-  -t, --tunnel string                                 Tunnel mode {vxlan, geneve, disabled} (default "vxlan" for the "veth" datapath mode)
-      --version                                       Print version information
-      --write-cni-conf-when-ready string              Write the CNI configuration as specified via --read-cni-conf to path when agent is ready
+      --agent-health-port int                                TCP port for agent health status API (default 9876)
+      --agent-labels strings                                 Additional labels to identify this agent
+      --allow-icmp-frag-needed                               Allow ICMP Fragmentation Needed type packets for purposes like TCP Path MTU. (default true)
+      --allow-localhost string                               Policy when to allow local stack to reach local endpoints { auto | always | policy } (default "auto")
+      --annotate-k8s-node                                    Annotate Kubernetes node (default true)
+      --api-rate-limit map                                   API rate limiting configuration (example: --rate-limit endpoint-create=rate-limit:10/m,rate-burst:2) (default map[])
+      --auto-create-cilium-node-resource                     Automatically create CiliumNode resource for own node on startup (default true)
+      --auto-direct-node-routes                              Enable automatic L2 routing between nodes
+      --bpf-compile-debug                                    Enable debugging of the BPF compilation process
+      --bpf-ct-global-any-max int                            Maximum number of entries in non-TCP CT table (default 262144)
+      --bpf-ct-global-tcp-max int                            Maximum number of entries in TCP CT table (default 524288)
+      --bpf-ct-timeout-regular-any duration                  Timeout for entries in non-TCP CT table (default 1m0s)
+      --bpf-ct-timeout-regular-tcp duration                  Timeout for established entries in TCP CT table (default 6h0m0s)
+      --bpf-ct-timeout-regular-tcp-fin duration              Teardown timeout for entries in TCP CT table (default 10s)
+      --bpf-ct-timeout-regular-tcp-syn duration              Establishment timeout for entries in TCP CT table (default 1m0s)
+      --bpf-ct-timeout-service-any duration                  Timeout for service entries in non-TCP CT table (default 1m0s)
+      --bpf-ct-timeout-service-tcp duration                  Timeout for established service entries in TCP CT table (default 6h0m0s)
+      --bpf-fragments-map-max int                            Maximum number of entries in fragments tracking map (default 8192)
+      --bpf-lb-maglev-hash-seed string                       Maglev cluster-wide hash seed (base64 encoded) (default "JLfvgnHc2kaSUFaI")
+      --bpf-lb-maglev-table-size uint                        Maglev per service backend table size (parameter M) (default 16381)
+      --bpf-lb-map-max int                                   Maximum number of entries in Cilium BPF lbmap (default 65536)
+      --bpf-map-dynamic-size-ratio float                     Ratio (0.0-1.0) of total system memory to use for dynamic sizing of CT, NAT and policy BPF maps. Set to 0.0 to disable dynamic BPF map sizing (default: 0.0)
+      --bpf-nat-global-max int                               Maximum number of entries for the global BPF NAT table (default 524288)
+      --bpf-neigh-global-max int                             Maximum number of entries for the global BPF neighbor table (default 524288)
+      --bpf-policy-map-max int                               Maximum number of entries in endpoint policy map (per endpoint) (default 16384)
+      --bpf-root string                                      Path to BPF filesystem
+      --bpf-sock-rev-map-max int                             Maximum number of entries for the SockRevNAT BPF map (default 262144)
+      --certificates-directory string                        Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
+      --cgroup-root string                                   Path to Cgroup2 filesystem
+      --cluster-id int                                       Unique identifier of the cluster
+      --cluster-name string                                  Name of the cluster (default "default")
+      --clustermesh-config string                            Path to the ClusterMesh configuration directory
+      --config string                                        Configuration file (default "$HOME/ciliumd.yaml")
+      --config-dir string                                    Configuration directory that contains a file for each option
+      --conntrack-gc-interval duration                       Overwrite the connection-tracking garbage collection interval
+      --crd-wait-timeout duration                            Cilium will exit if CRDs are not available within this duration upon startup (default 5m0s)
+      --datapath-mode string                                 Datapath mode name (default "veth")
+  -D, --debug                                                Enable debugging mode
+      --debug-verbose strings                                List of enabled verbose debug groups
+      --devices strings                                      List of devices facing cluster/external network (used for BPF NodePort, BPF masquerading and host firewall)
+      --direct-routing-device string                         Device name used to connect nodes in direct routing mode (required only by BPF NodePort; if empty, automatically set to a device with k8s InternalIP/ExternalIP or with a default route)
+      --disable-cnp-status-updates                           Do not send CNP NodeStatus updates to the Kubernetes api-server (recommended to run with "cnp-node-status-gc-interval=0" in cilium-operator)
+      --disable-conntrack                                    Disable connection tracking
+      --disable-endpoint-crd                                 Disable use of CiliumEndpoint CRD
+      --disable-iptables-feeder-rules strings                Chains to ignore when installing feeder rules.
+      --egress-masquerade-interfaces string                  Limit egress masquerading to interface selector
+      --enable-auto-protect-node-port-range                  Append NodePort range to net.ipv4.ip_local_reserved_ports if it overlaps with ephemeral port range (net.ipv4.ip_local_port_range) (default true)
+      --enable-bandwidth-manager                             Enable BPF bandwidth manager
+      --enable-bpf-clock-probe                               Enable BPF clock source probing for more efficient tick retrieval
+      --enable-bpf-masquerade                                Masquerade packets from endpoints leaving the host with BPF instead of iptables
+      --enable-bpf-tproxy                                    Enable BPF-based proxy redirection, if support available
+      --enable-endpoint-health-checking                      Enable connectivity health checking between virtual endpoints (default true)
+      --enable-endpoint-routes                               Use per endpoint routes instead of routing via cilium_host
+      --enable-external-ips                                  Enable k8s service externalIPs feature (requires enabling enable-node-port) (default true)
+      --enable-health-check-nodeport                         Enables a healthcheck nodePort server for NodePort services with 'healthCheckNodePort' being set (default true)
+      --enable-health-checking                               Enable connectivity health checking (default true)
+      --enable-host-firewall                                 Enable host network policies (beta)
+      --enable-host-legacy-routing                           Enable the legacy host forwarding model which does not bypass upper stack in host namespace
+      --enable-host-port                                     Enable k8s hostPort mapping feature (requires enabling enable-node-port) (default true)
+      --enable-host-reachable-services                       Enable reachability of services for host applications (beta)
+      --enable-hubble                                        Enable hubble server
+      --enable-identity-mark                                 Enable setting identity mark for local traffic (default true)
+      --enable-ip-masq-agent                                 Enable BPF ip-masq-agent
+      --enable-ipsec                                         Enable IPSec support
+      --enable-ipv4                                          Enable IPv4 support (default true)
+      --enable-ipv4-fragment-tracking                        Enable IPv4 fragments tracking for L4-based lookups (default true)
+      --enable-ipv6                                          Enable IPv6 support (default true)
+      --enable-ipv6-ndp                                      Enable IPv6 NDP support
+      --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
+      --enable-k8s-endpoint-slice                            Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
+      --enable-k8s-event-handover                            Enable k8s event handover to kvstore for improved scalability
+      --enable-l7-proxy                                      Enable L7 proxy for L7 policy enforcement (default true)
+      --enable-local-node-route                              Enable installation of the route which points the allocation prefix of the local node (default true)
+      --enable-monitor                                       Enable the monitor unix domain socket server (default true)
+      --enable-node-port                                     Enable NodePort type services by Cilium (beta)
+      --enable-policy string                                 Enable policy enforcement (default "default")
+      --enable-remote-node-identity                          Enable use of remote node identity
+      --enable-session-affinity                              Enable support for service session affinity
+      --enable-svc-source-range-check                        Enable check of service source ranges (currently, only for LoadBalancer) (default true)
+      --enable-tracing                                       Enable tracing while determining policy (debugging)
+      --enable-well-known-identities                         Enable well-known identities for known Kubernetes components (default true)
+      --enable-xt-socket-fallback                            Enable fallback for missing xt_socket module (default true)
+      --encrypt-interface string                             Transparent encryption interface
+      --encrypt-node                                         Enables encrypting traffic from non-Cilium pods and host networking
+      --endpoint-interface-name-prefix string                Prefix of interface name shared by all endpoints (default "lxc+")
+      --endpoint-queue-size int                              size of EventQueue per-endpoint (default 25)
+      --endpoint-status strings                              Enable additional CiliumEndpoint status features (controllers,health,log,policy,state)
+      --envoy-log string                                     Path to a separate Envoy log file, if any
+      --exclude-local-address strings                        Exclude CIDR from being recognized as local address
+      --fixed-identity-mapping map                           Key-value for the fixed identity mapping which allows to use reserved label for fixed identities (default map[])
+      --flannel-master-device string                         Installs a BPF program to allow for policy enforcement in the given network interface. Allows to run Cilium on top of other CNI plugins that provide networking, e.g. flannel, where for flannel, this value should be set with 'cni0'. [EXPERIMENTAL]
+      --flannel-uninstall-on-exit                            When used along the flannel-master-device flag, it cleans up all BPF programs installed when Cilium agent is terminated.
+      --force-local-policy-eval-at-source                    Force policy evaluation of all local communication at the source endpoint (default true)
+  -h, --help                                                 help for cilium-agent
+      --host-reachable-services-protos strings               Only enable reachability of services for host applications for specific protocols (default [tcp,udp])
+      --http-idle-timeout uint                               Time after which a non-gRPC HTTP stream is considered failed unless traffic in the stream has been processed (in seconds); defaults to 0 (unlimited)
+      --http-max-grpc-timeout uint                           Time after which a forwarded gRPC request is considered failed unless completed (in seconds). A "grpc-timeout" header may override this with a shorter value; defaults to 0 (unlimited)
+      --http-request-timeout uint                            Time after which a forwarded HTTP request is considered failed unless completed (in seconds); Use 0 for unlimited (default 3600)
+      --http-retry-count uint                                Number of retries performed after a forwarded request attempt fails (default 3)
+      --http-retry-timeout uint                              Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
+      --hubble-disable-tls                                   Allow Hubble server to run on the given listen address without TLS.
+      --hubble-event-queue-size int                          Buffer size of the channel to receive monitor events.
+      --hubble-flow-buffer-size int                          Maximum number of flows in Hubble's buffer. The actual buffer size gets rounded up to the next power of 2, e.g. 4095 => 4096 (default 4095)
+      --hubble-listen-address string                         An additional address for Hubble server to listen to, e.g. ":4244"
+      --hubble-metrics strings                               List of Hubble metrics to enable.
+      --hubble-metrics-server string                         Address to serve Hubble metrics on.
+      --hubble-socket-path string                            Set hubble's socket path to listen for connections (default "/var/run/cilium/hubble.sock")
+      --hubble-tls-cert-file string                          Path to the public key file for the Hubble server. The file must contain PEM encoded data.
+      --hubble-tls-client-ca-files strings                   Paths to one or more public key files of client CA certificates to use for TLS with mutual authentication (mTLS). The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
+      --hubble-tls-key-file string                           Path to the private key file for the Hubble server. The file must contain PEM encoded data.
+      --identity-allocation-mode string                      Method to use for identity allocation (default "kvstore")
+      --identity-change-grace-period duration                Time to wait before using new identity on endpoint identity change (default 5s)
+      --install-iptables-rules                               Install base iptables rules for cilium to mainly interact with kube-proxy (and masquerading) (default true)
+      --ip-allocation-timeout duration                       Time after which an incomplete CIDR allocation is considered failed (default 2m0s)
+      --ip-masq-agent-config-path string                     ip-masq-agent configuration file path (default "/etc/config/ip-masq-agent")
+      --ipam string                                          Backend to use for IPAM (default "cluster-pool")
+      --ipsec-key-file string                                Path to IPSec key file
+      --iptables-lock-timeout duration                       Time to pass to each iptables invocation to wait for xtables lock acquisition (default 5s)
+      --iptables-random-fully                                Set iptables flag random-fully on masquerading rules
+      --ipv4-node string                                     IPv4 address of node (default "auto")
+      --ipv4-pod-subnets strings                             List of IPv4 pod subnets to preconfigure for encryption
+      --ipv4-range string                                    Per-node IPv4 endpoint prefix, e.g. 10.16.0.0/16 (default "auto")
+      --ipv4-service-loopback-address string                 IPv4 address for service loopback SNAT (default "169.254.42.1")
+      --ipv4-service-range string                            Kubernetes IPv4 services CIDR if not inside cluster prefix (default "auto")
+      --ipv6-cluster-alloc-cidr string                       IPv6 /64 CIDR used to allocate per node endpoint /96 CIDR (default "f00d::/64")
+      --ipv6-mcast-device string                             Device that joins a Solicited-Node multicast group for IPv6
+      --ipv6-node string                                     IPv6 address of node (default "auto")
+      --ipv6-pod-subnets strings                             List of IPv6 pod subnets to preconfigure for encryption
+      --ipv6-range string                                    Per-node IPv6 endpoint prefix, e.g. fd02:1:1::/96 (default "auto")
+      --ipv6-service-range string                            Kubernetes IPv6 services CIDR if not inside cluster prefix (default "auto")
+      --ipvlan-master-device string                          Device facing external network acting as ipvlan master (default "undefined")
+      --join-cluster                                         Join a Cilium cluster via kvstore registration
+      --k8s-api-server string                                Kubernetes API server URL
+      --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
+      --k8s-namespace string                                 Name of the Kubernetes namespace in which Cilium is deployed in
+      --k8s-require-ipv4-pod-cidr                            Require IPv4 PodCIDR to be specified in node resource
+      --k8s-require-ipv6-pod-cidr                            Require IPv6 PodCIDR to be specified in node resource
+      --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --k8s-watcher-endpoint-selector string                 K8s endpoint watcher will watch for these k8s endpoints (default "metadata.name!=kube-scheduler,metadata.name!=kube-controller-manager,metadata.name!=etcd-operator,metadata.name!=gcp-controller-manager")
+      --k8s-watcher-queue-size uint                          Queue size used to serialize each k8s event type (default 1024)
+      --keep-config                                          When restoring state, keeps containers' configuration in place
+      --kube-proxy-replacement string                        auto-enable available features for kube-proxy replacement ("probe"), or enable only selected features (will panic if any selected feature cannot be enabled) ("partial") or enable all features (will panic if any feature cannot be enabled) ("strict"), or completely disable it (ignores any selected feature) ("disabled") (default "partial")
+      --kube-proxy-replacement-healthz-bind-address string   The IP address with port for kube-proxy replacement health check server to serve on (set to '0.0.0.0:10256' for all IPv4 interfaces and '[::]:10256' for all IPv6 interfaces). Set empty to disable.
+      --kvstore string                                       Key-value store type
+      --kvstore-connectivity-timeout duration                Time after which an incomplete kvstore operation  is considered failed (default 2m0s)
+      --kvstore-opt map                                      Key-value store options (default map[])
+      --kvstore-periodic-sync duration                       Periodic KVstore synchronization interval (default 5m0s)
+      --label-prefix-file string                             Valid label prefixes file path
+      --labels strings                                       List of label prefixes used to determine identity of an endpoint
+      --lib-dir string                                       Directory path to store runtime build environment (default "/var/lib/cilium")
+      --log-driver strings                                   Logging endpoints to use for example syslog
+      --log-opt map                                          Log driver options for cilium (default map[])
+      --log-system-load                                      Enable periodic logging of system load
+      --masquerade                                           Masquerade packets from endpoints leaving the host (default true)
+      --metrics strings                                      Metrics that should be enabled or disabled from the default metric list. (+metric_foo to enable metric_foo , -metric_bar to disable metric_bar)
+      --monitor-aggregation string                           Level of monitor aggregation for traces from the datapath (default "None")
+      --monitor-aggregation-flags strings                    TCP flags that trigger monitor reports when monitor aggregation is enabled (default [syn,fin,rst])
+      --monitor-aggregation-interval duration                Monitor report interval when monitor aggregation is enabled (default 5s)
+      --monitor-queue-size int                               Size of the event queue when reading monitor events
+      --mtu int                                              Overwrite auto-detected MTU of underlying network
+      --nat46-range string                                   IPv6 prefix to map IPv4 addresses to (default "0:0:0:0:0:FFFF::/96")
+      --native-routing-cidr string                           Allows to explicitly specify the CIDR for native routing. This value corresponds to the configured cluster-cidr.
+      --node-port-acceleration string                        BPF NodePort acceleration via XDP ("native", "disabled") (default "disabled")
+      --node-port-algorithm string                           BPF load balancing algorithm ("random", "maglev") (default "random")
+      --node-port-bind-protection                            Reject application bind(2) requests to service ports in the NodePort range (default true)
+      --node-port-mode string                                BPF NodePort mode ("snat", "dsr", "hybrid") (default "snat")
+      --node-port-range strings                              Set the min/max NodePort port range (default [30000,32767])
+      --policy-audit-mode                                    Enable policy audit (non-drop) mode
+      --policy-queue-size int                                size of queues for policy-related events (default 100)
+      --pprof                                                Enable serving the pprof debugging API
+      --preallocate-bpf-maps                                 Enable BPF map pre-allocation (default true)
+      --prefilter-device string                              Device facing external network for XDP prefiltering (default "undefined")
+      --prefilter-mode string                                Prefilter mode via XDP ("native", "generic") (default "native")
+      --prepend-iptables-chains                              Prepend custom iptables chains instead of appending (default true)
+      --prometheus-serve-addr string                         IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
+      --proxy-connect-timeout uint                           Time after which a TCP connect attempt is considered failed unless completed (in seconds) (default 1)
+      --proxy-prometheus-port int                            Port to serve Envoy metrics on. Default 0 (disabled).
+      --read-cni-conf string                                 Read to the CNI configuration at specified path to extract per node configuration
+      --restore                                              Restores state, if possible, from previous daemon (default true)
+      --sidecar-istio-proxy-image string                     Regular expression matching compatible Istio sidecar istio-proxy container image names (default "cilium/istio_proxy")
+      --single-cluster-route                                 Use a single cluster route instead of per node routes
+      --skip-crd-creation                                    Skip Kubernetes Custom Resource Definitions creations
+      --socket-path string                                   Sets daemon's socket path to listen for connections (default "/var/run/cilium/cilium.sock")
+      --sockops-enable                                       Enable sockops when kernel supported
+      --state-dir string                                     Directory path to store runtime state (default "/var/run/cilium")
+      --tofqdns-dns-reject-response-code string              DNS response code for rejecting DNS requests, available options are '[nameError refused]' (default "refused")
+      --tofqdns-enable-dns-compression                       Allow the DNS proxy to compress responses to endpoints that are larger than 512 Bytes or the EDNS0 option, if present (default true)
+      --tofqdns-endpoint-max-ip-per-hostname int             Maximum number of IPs to maintain per FQDN name for each endpoint (default 50)
+      --tofqdns-max-deferred-connection-deletes int          Maximum number of IPs to retain for expired DNS lookups with still-active connections (default 10000)
+      --tofqdns-min-ttl int                                  The minimum time, in seconds, to use DNS data for toFQDNs policies. (default 3600 )
+      --tofqdns-pre-cache string                             DNS cache data at this path is preloaded on agent startup
+      --tofqdns-proxy-port int                               Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port.
+      --tofqdns-proxy-response-max-delay duration            The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information. (default 100ms)
+      --trace-payloadlen int                                 Length of payload to capture when tracing (default 128)
+  -t, --tunnel string                                        Tunnel mode {vxlan, geneve, disabled} (default "vxlan" for the "veth" datapath mode)
+      --version                                              Print version information
+      --write-cni-conf-when-ready string                     Write the CNI configuration as specified via --read-cni-conf to path when agent is ready
 ```
 

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -1098,6 +1098,16 @@ a fixed cookie value as a trade-off. This makes all applications on the host to
 select the same service endpoint for a given service with session affinity configured.
 To disable the feature, set ``config.sessionAffinity=false``.
 
+kube-proxy replacement health check server
+******************************************
+To enable health check server for the kube-proxy replacement, the
+``kubeProxyReplacementHealthzBindAddr`` option has to be set (disabled by
+default). The option accepts the IP address with port for the health check server
+to serve on.
+E.g. to enable for IPv4 interfaces set ``kubeProxyReplacementHealthzBindAddr='0.0.0.0:10256'``,
+for IPv6 - ``kubeProxyReplacementHealthzBindAddr='[::]:10256'``. The health check server is
+accessible via the HTTP ``/healthz`` endpoint.
+
 LoadBalancer Source Ranges Checks
 *********************************
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -524,6 +524,9 @@ func init() {
 		option.KubeProxyReplacementStrict, option.KubeProxyReplacementDisabled))
 	option.BindEnv(option.KubeProxyReplacement)
 
+	flags.String(option.KubeProxyReplacementHealthzBindAddr, defaults.KubeProxyReplacementHealthzBindAddr, "The IP address with port for kube-proxy replacement health check server to serve on (set to '0.0.0.0:10256' for all IPv4 interfaces and '[::]:10256' for all IPv6 interfaces). Set empty to disable.")
+	option.BindEnv(option.KubeProxyReplacementHealthzBindAddr)
+
 	flags.Bool(option.EnableHostPort, true, fmt.Sprintf("Enable k8s hostPort mapping feature (requires enabling %s)", option.EnableNodePort))
 	option.BindEnv(option.EnableHostPort)
 
@@ -1435,6 +1438,11 @@ func runDaemon() {
 	metricsErrs := initMetrics()
 
 	d.startAgentHealthHTTPService()
+	if option.Config.KubeProxyReplacementHealthzBindAddr != "" {
+		if option.Config.KubeProxyReplacement != option.KubeProxyReplacementDisabled {
+			d.startKubeProxyHealthzHTTPService(fmt.Sprintf("%s", option.Config.KubeProxyReplacementHealthzBindAddr))
+		}
+	}
 
 	bootstrapStats.initAPI.Start()
 	srv := server.NewServer(d.instantiateAPI())

--- a/daemon/cmd/kube_proxy_healthz.go
+++ b/daemon/cmd/kube_proxy_healthz.go
@@ -1,0 +1,102 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/cilium/cilium/api/v1/models"
+
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+)
+
+// DaemonInterface to help with testing.
+type DaemonInterface interface {
+	getStatus(bool) models.StatusResponse
+}
+
+// ServiceInterface to help with testing.
+type ServiceInterface interface {
+	GetLastUpdatedTs() time.Time
+	GetCurrentTs() time.Time
+}
+
+type kubeproxyHealthzHandler struct {
+	d   DaemonInterface
+	svc ServiceInterface
+}
+
+// startKubeProxyHealthzHTTPService registers a handler function for the kube-proxy /healthz
+// status HTTP endpoint exposed on addr.
+// This endpoint reports the agent health status with the timestamp.
+func (d *Daemon) startKubeProxyHealthzHTTPService(addr string) {
+	lc := net.ListenConfig{Control: setsockoptReuseAddrAndPort}
+	ln, err := lc.Listen(context.Background(), "tcp", addr)
+	addrField := logrus.Fields{"address": addr}
+	if errors.Is(err, unix.EADDRNOTAVAIL) {
+		log.WithFields(addrField).Info("KubeProxy healthz server not available")
+	} else if err != nil {
+		log.WithFields(addrField).WithError(err).Fatal("hint: kube-proxy should not be running nor listening on the same healthz-bind-address.")
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/healthz", kubeproxyHealthzHandler{d: d, svc: d.svc})
+
+	srv := &http.Server{
+		Addr:    addr,
+		Handler: mux,
+	}
+
+	go func() {
+		err := srv.Serve(ln)
+		if errors.Is(err, http.ErrServerClosed) {
+			log.WithFields(addrField).Info("kube-proxy healthz status API server shutdown")
+		} else if err != nil {
+			log.WithFields(addrField).WithError(err).Fatal("Unable to start kube-proxy healthz server")
+		}
+	}()
+	log.WithFields(addrField).Info("Started kube-proxy healthz server")
+}
+
+func (h kubeproxyHealthzHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	isUnhealthy := func(sr *models.StatusResponse) bool {
+		if sr.Cilium != nil {
+			state := sr.Cilium.State
+			return state != models.StatusStateOk && state != models.StatusStateDisabled
+		}
+		return false
+	}
+
+	statusCode := http.StatusOK
+	currentTs := h.svc.GetCurrentTs()
+	var lastUpdateTs = currentTs
+	// We piggy back here on Cilium daemon health. If Cilium is healthy, we can
+	// reasonably assume that the node networking is ready.
+	sr := h.d.getStatus(true)
+	if isUnhealthy(&sr) {
+		statusCode = http.StatusServiceUnavailable
+		lastUpdateTs = h.svc.GetLastUpdatedTs()
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(statusCode)
+	fmt.Fprintf(w, `{"lastUpdated": %q,"currentTime": %q}`, lastUpdateTs, currentTs)
+}

--- a/daemon/cmd/kube_proxy_healthz_test.go
+++ b/daemon/cmd/kube_proxy_healthz_test.go
@@ -1,0 +1,110 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !privileged_tests
+
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	"github.com/cilium/cilium/api/v1/models"
+
+	. "gopkg.in/check.v1"
+)
+
+// 'check' testing suite scaffolding.
+type KubeProxyHealthzTestSuite struct{}
+
+var _ = Suite(&KubeProxyHealthzTestSuite{})
+
+// Injected fake service.
+type FakeService struct {
+	injectedCurrentTs     time.Time
+	injectedLastUpdatedTs time.Time
+}
+
+func (s *FakeService) GetCurrentTs() time.Time {
+	return s.injectedCurrentTs
+}
+
+func (s *FakeService) GetLastUpdatedTs() time.Time {
+	return s.injectedLastUpdatedTs
+}
+
+// Injected fake daemon.
+type FakeDaemon struct {
+	injectedStatusResponse models.StatusResponse
+}
+
+func (d *FakeDaemon) getStatus(blah bool) models.StatusResponse {
+	return d.injectedStatusResponse
+}
+
+type healthzPayload struct {
+	LastUpdated string
+	CurrentTime string
+}
+
+func (s *KubeProxyHealthzTestSuite) TestKubeProxyHealth(c *C) {
+	s.healthTestHelper(c, models.StatusStateOk, http.StatusOK, true)
+	s.healthTestHelper(c, models.StatusStateWarning,
+		http.StatusServiceUnavailable, false)
+	s.healthTestHelper(c, models.StatusStateFailure,
+		http.StatusServiceUnavailable, false)
+}
+
+func (s *KubeProxyHealthzTestSuite) healthTestHelper(c *C, ciliumStatus string,
+	expectedHttpStatus int, testcasepositive bool) {
+	var lastUpdateTs, currentTs, expectedTs time.Time
+	lastUpdateTs = time.Unix(100, 0) // Fake 100 seconds after Unix.
+	currentTs = time.Unix(200, 0)    // Fake 200 seconds after Unix.
+	expectedTs = lastUpdateTs
+	if testcasepositive {
+		expectedTs = currentTs
+	}
+	// Create handler with injected behavior.
+	h := kubeproxyHealthzHandler{
+		d: &FakeDaemon{injectedStatusResponse: models.StatusResponse{
+			Cilium: &models.Status{State: ciliumStatus}}},
+		svc: &FakeService{
+			injectedCurrentTs:     currentTs,
+			injectedLastUpdatedTs: lastUpdateTs}}
+
+	// Create a new request.
+	req, err := http.NewRequest("GET", "/healthz", nil)
+	c.Assert(err, IsNil)
+	w := httptest.NewRecorder()
+
+	// Serve.
+	h.ServeHTTP(w, req)
+
+	// Main return code meets expectations.
+	c.Assert(w.Code, Equals, expectedHttpStatus,
+		Commentf("expected status code %v, got %v", expectedHttpStatus, w.Code))
+
+	// Timestamps meet expectations.
+	var payload healthzPayload
+	c.Assert(json.Unmarshal(w.Body.Bytes(), &payload), IsNil)
+	layout := "2006-01-02 15:04:05 -0700 MST"
+	lastUpdateTs, err = time.Parse(layout, payload.LastUpdated)
+	c.Assert(err, IsNil)
+
+	_, err = time.Parse(layout, payload.CurrentTime)
+	c.Assert(err, IsNil)
+	c.Assert(lastUpdateTs.Equal(expectedTs), Equals, true)
+}

--- a/daemon/cmd/sockopt.go
+++ b/daemon/cmd/sockopt.go
@@ -1,0 +1,44 @@
+// Copyright 2020 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// setsockoptReuseAddrAndPort sets the SO_REUSEADDR and SO_REUSEPORT socket options on c's
+// underlying socket in order to improve the chance to re-bind to the same address and port
+// upon agent restart.
+func setsockoptReuseAddrAndPort(network, address string, c syscall.RawConn) error {
+	var soerr error
+	if err := c.Control(func(su uintptr) {
+		s := int(su)
+		// Allow reuse of recently-used addresses. This socket option is
+		// set by default on listeners in Go's net package, see
+		// net setDefaultListenerSockopts
+		soerr = unix.SetsockoptInt(s, unix.SOL_SOCKET, unix.SO_REUSEADDR, 1)
+		if soerr != nil {
+			return
+		}
+		// Allow reuse of recently-used ports. This gives the agent a
+		// better chance to re-bind upon restarts.
+		soerr = unix.SetsockoptInt(s, unix.SOL_SOCKET, unix.SO_REUSEPORT, 1)
+	}); err != nil {
+		return err
+	}
+	return soerr
+}

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -437,6 +437,9 @@ data:
 
 {{- if hasKey .Values "kubeProxyReplacement" }}
   kube-proxy-replacement:  {{ .Values.kubeProxyReplacement | quote }}
+{{- if ne .Values.kubeProxyReplacement "disabled" }}
+  kube-proxy-replacement-healthz-bind-address: {{ default "" .Values.kubeProxyReplacementHealthzBindAddr | quote}}
+{{- end }}
 {{- end }}
 {{- if hasKey .Values "hostServices" }}
 {{- if .Values.hostServices.enabled }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -735,6 +735,12 @@ keepDeprecatedProbes: false
 # kubeProxyReplacement enables kube-proxy replacement in Cilium BPF datapath
 kubeProxyReplacement: "probe"
 
+# kubeProxyReplacement healthz server bind address
+# To enable set the value to '0.0.0.0:10256' for all ipv4
+# addresses and this '[::]:10256' for all ipv6 addresses.
+# By default it is disabled.
+kubeProxyReplacementHealthzBindAddr: ""
+
 kvstore:
   # Managed enables/disables the Cilium etcd-operator
   managed: false

--- a/install/kubernetes/experimental-install.yaml
+++ b/install/kubernetes/experimental-install.yaml
@@ -132,6 +132,7 @@ data:
   auto-direct-node-routes: "false"
   enable-bandwidth-manager: "true"
   kube-proxy-replacement:  "probe"
+  kube-proxy-replacement-healthz-bind-address: ""
   enable-health-check-nodeport: "true"
   node-port-bind-protection: "true"
   enable-auto-protect-node-port-range: "true"

--- a/install/kubernetes/quick-install.yaml
+++ b/install/kubernetes/quick-install.yaml
@@ -118,6 +118,7 @@ data:
   auto-direct-node-routes: "false"
   enable-bandwidth-manager: "false"
   kube-proxy-replacement:  "probe"
+  kube-proxy-replacement-healthz-bind-address: ""
   enable-health-check-nodeport: "true"
   node-port-bind-protection: "true"
   enable-auto-protect-node-port-range: "true"

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -389,4 +389,7 @@ const (
 	// for the support of Leases in Kubernetes when there is an error in discovering
 	// API groups using Discovery API.
 	K8sEnableLeasesFallbackDiscovery = false
+
+	// KubeProxyReplacementHealthzBindAddr is the default kubeproxyReplacement healthz server bind addr
+	KubeProxyReplacementHealthzBindAddr = ""
 )

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1240,6 +1240,9 @@ const (
 	// KubeProxyReplacementDisabled specified to completely disable kube-proxy
 	// replacement
 	KubeProxyReplacementDisabled = "disabled"
+
+	// KubeProxyReplacement healthz server bind address
+	KubeProxyReplacementHealthzBindAddr = "kube-proxy-replacement-healthz-bind-address"
 )
 
 // GetTunnelModes returns the list of all tunnel modes
@@ -1824,6 +1827,9 @@ type DaemonConfig struct {
 
 	// EnableBandwidthManager enables EDT-based pacing
 	EnableBandwidthManager bool
+
+	// KubeProxyReplacementHealthzBindAddr is the KubeProxyReplacement healthz server bind addr
+	KubeProxyReplacementHealthzBindAddr string
 
 	// EnableExternalIPs enables implementation of k8s services with externalIPs in datapath
 	EnableExternalIPs bool
@@ -2706,6 +2712,8 @@ func (c *DaemonConfig) Populate() {
 			c.K8sRequireIPv6PodCIDR = true
 		}
 	}
+
+	c.KubeProxyReplacementHealthzBindAddr = viper.GetString(KubeProxyReplacementHealthzBindAddr)
 
 	// Hubble options.
 	c.EnableHubble = viper.GetBool(EnableHubble)


### PR DESCRIPTION
This PR adds in code that creates a healthz HTTP endpoint for
kube-proxy replacement. It also provides option to configure
the listener address and port through cilium-agent and helm charts.

Fixes: #10621
Signed-off-by: Swaminathan Vasudevan <svasudevan@suse.com>
