### PR TITLE
docker: update cilium-{runtime,builder} images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ LABEL cilium-sha=${CILIUM_SHA}
 # versions to be built while allowing the new versions to make changes
 # that are not backwards compatible.
 #
-FROM quay.io/cilium/cilium-builder:2020-05-20 as builder
+FROM quay.io/cilium/cilium-builder:2020-05-29 as builder
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"
@@ -43,7 +43,7 @@ RUN make NOSTRIP=$NOSTRIP LOCKDEBUG=$LOCKDEBUG PKG_BUILD=1 V=$V LIBNETWORK_PLUGI
 # built while allowing the new versions to make changes that are not
 # backwards compatible.
 #
-FROM quay.io/cilium/cilium-runtime:2020-05-20
+FROM quay.io/cilium/cilium-runtime:2020-05-29
 ARG CILIUM_SHA=""
 LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,7 +1,7 @@
 #
 # Cilium build-time base image (image created from this file is used to build Cilium)
 #
-FROM quay.io/cilium/cilium-runtime:2020-05-20
+FROM quay.io/cilium/cilium-runtime:2020-05-29
 LABEL maintainer="maintainer@cilium.io"
 ARG ARCH=amd64
 WORKDIR /go/src/github.com/cilium/cilium

--- a/cilium-dev.Dockerfile
+++ b/cilium-dev.Dockerfile
@@ -3,7 +3,7 @@
 # development environmennt
 FROM quay.io/cilium/cilium-envoy:63de0bd958d05d82e2396125dcf6286d92464c56 as cilium-envoy
 
-FROM quay.io/cilium/cilium-runtime:2020-05-18
+FROM quay.io/cilium/cilium-runtime:2020-05-29
 LABEL maintainer="maintainer@cilium.io"
 RUN apt-get update && apt-get install make -y
 WORKDIR /go/src/github.com/cilium/cilium

--- a/contrib/packaging/docker/Dockerfile.runtime
+++ b/contrib/packaging/docker/Dockerfile.runtime
@@ -50,9 +50,9 @@ RUN apt-get update && \
     curl -sS -L https://github.com/containernetworking/plugins/releases/download/v0.7.5/cni-plugins-${ARCH}-v0.7.5.tgz -o cni.tar.gz && \
     tar -xvf cni.tar.gz ./loopback && \
     strip -s ./loopback
-COPY --from=quay.io/cilium/cilium-llvm:2020-05-05 /bin/clang /bin/llc /bin/
-COPY --from=quay.io/cilium/cilium-bpftool:2020-05-20 /bin/bpftool /bin/
-COPY --from=quay.io/cilium/cilium-iproute2:2020-05-20 /bin/tc /bin/ip /bin/
+COPY --from=docker.io/cilium/cilium-llvm:629310350b8cf33a1e426e167e1caadb6848f6c5 /bin/clang /bin/llc /bin/
+COPY --from=docker.io/cilium/cilium-bpftool:f0bbd0cb389ce92b33ff29f0489c17c8e33f9da7 /bin/bpftool /bin/
+COPY --from=docker.io/cilium/cilium-iproute2:044e7a6a43d5a42a8ce696535b3dbf773f82dbec /bin/tc /bin/ip /bin/ss /bin/
 COPY --from=gops /go/bin/gops /bin/
 
 #
@@ -61,6 +61,6 @@ COPY --from=gops /go/bin/gops /bin/
 FROM runtime-base
 LABEL maintainer="maintainer@cilium.io"
 WORKDIR /bin
-COPY --from=tools /bin/tc /bin/ip /bin/bpftool /bin/clang /bin/llc /bin/gops ./
+COPY --from=tools /bin/tc /bin/ip /bin/ss /bin/bpftool /bin/clang /bin/llc /bin/gops ./
 WORKDIR /cni
 COPY --from=tools /tmp/loopback ./

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     command: "etcd -name etcd0 -advertise-client-urls http://0.0.0.0:4002 -listen-client-urls http://0.0.0.0:4002 -initial-cluster-token etcd-cluster-1 -initial-cluster-state new"
     privileged: true
   base_image:
-    image: "quay.io/cilium/cilium-builder:2020-05-18"
+    image: "quay.io/cilium/cilium-builder:2020-05-29"
     volumes:
       - "./../:/go/src/github.com/cilium/cilium/"
     privileged: true


### PR DESCRIPTION
Pull in updated LLVM into cilium-{runtime,builder} images. On top of the
base 10.0.0, they include the cherry-picked commits from John's work:

  - https://github.com/llvm/llvm-project/commit/29bc5dd19407c4d7cad1c059dea26ee216ddc7ca
  - https://github.com/llvm/llvm-project/commit/13f6c81c5d9a7a34a684363bcaad8eb7c65356fd

Given we build https://github.com/cilium/image-tools via GH actions, move
all the tools from there to the docker.io auto-built repos.

Also adds ss tool to the runtime image.

Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>
