### PR TITLE
bpf: undo sessionAffinity for older kernels due to verifier breakage

### DIFF
--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -569,7 +569,7 @@ static __always_inline __u32
 lb6_affinity_backend_id_by_netns(const struct lb6_service *svc __maybe_unused,
 				 union lb6_affinity_client_id *id __maybe_unused)
 {
-#if defined(ENABLE_SESSION_AFFINITY)
+#if defined(ENABLE_SESSION_AFFINITY) && defined(BPF_HAVE_NETNS_COOKIE)
 	return __lb6_affinity_backend_id(svc, true, id);
 #else
 	return 0;
@@ -581,7 +581,7 @@ lb6_update_affinity_by_netns(const struct lb6_service *svc __maybe_unused,
 			     union lb6_affinity_client_id *id __maybe_unused,
 			     __u32 backend_id __maybe_unused)
 {
-#if defined(ENABLE_SESSION_AFFINITY)
+#if defined(ENABLE_SESSION_AFFINITY) && defined(BPF_HAVE_NETNS_COOKIE)
 	__lb6_update_affinity(svc, true, id, backend_id);
 #endif
 }
@@ -590,7 +590,7 @@ static __always_inline void
 lb6_delete_affinity_by_netns(const struct lb6_service *svc __maybe_unused,
 			     union lb6_affinity_client_id *id __maybe_unused)
 {
-#if defined(ENABLE_SESSION_AFFINITY)
+#if defined(ENABLE_SESSION_AFFINITY) && defined(BPF_HAVE_NETNS_COOKIE)
 	__lb6_delete_affinity(svc, true, id);
 #endif
 }
@@ -1106,7 +1106,7 @@ static __always_inline __u32
 lb4_affinity_backend_id_by_netns(const struct lb4_service *svc __maybe_unused,
 				 union lb4_affinity_client_id *id __maybe_unused)
 {
-#if defined(ENABLE_SESSION_AFFINITY)
+#if defined(ENABLE_SESSION_AFFINITY) && defined(BPF_HAVE_NETNS_COOKIE)
 	return __lb4_affinity_backend_id(svc, true, id);
 #else
 	return 0;
@@ -1118,7 +1118,7 @@ lb4_update_affinity_by_netns(const struct lb4_service *svc __maybe_unused,
 			     union lb4_affinity_client_id *id __maybe_unused,
 			     __u32 backend_id __maybe_unused)
 {
-#if defined(ENABLE_SESSION_AFFINITY)
+#if defined(ENABLE_SESSION_AFFINITY) && defined(BPF_HAVE_NETNS_COOKIE)
 	__lb4_update_affinity(svc, true, id, backend_id);
 #endif
 }
@@ -1127,7 +1127,7 @@ static __always_inline void
 lb4_delete_affinity_by_netns(const struct lb4_service *svc __maybe_unused,
 			     union lb4_affinity_client_id *id __maybe_unused)
 {
-#if defined(ENABLE_SESSION_AFFINITY)
+#if defined(ENABLE_SESSION_AFFINITY) && defined(BPF_HAVE_NETNS_COOKIE)
 	__lb4_delete_affinity(svc, true, id);
 #endif
 }

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1870,9 +1870,8 @@ func initKubeProxyReplacementOptions() {
 			_, found2 = h["bpf_get_netns_cookie"]
 		}
 		if !(found1 && found2) {
-			log.Warn("Session affinity for host reachable services needs kernel 5.7.0 or newer " +
-				"to work properly when accessed from inside cluster: the same service endpoint " +
-				"will be selected from all network namespaces on the host.")
+			log.Warnf("sessionAffinity for host reachable services needs kernel 5.7.0 or newer. " +
+				"Disabling sessionAffinity for cases when a service is accessed from a cluster.")
 		}
 	}
 }


### PR DESCRIPTION
This reverts commit 4fa26a4105eb ("datapath: Enable sessionAffinity
for older kernels"). On 4.19 it causes the following verifier error:

  msg="+ tc exec bpf pin /sys/fs/bpf/tc/globals/cilium_cgroups_connect6 obj bpf_sock.o type sockaddr attach_type connect6 sec connect6" subsys=datapath-loader
  subsys=datapath-loader
  msg="Prog section 'connect6' rejected: Invalid argument (22)!" subsys=datapath-loader
  msg=" - Type:         18" subsys=datapath-loader
  msg=" - Attach Type:  11" subsys=datapath-loader
  msg=" - Instructions: 740 (0 over limit)" subsys=datapath-loader
  msg=" - License:      GPL" subsys=datapath-loader
  subsys=datapath-loader
  msg="Verifier analysis:" subsys=datapath-loader
  subsys=datapath-loader
  msg="back-edge from insn 624 to 570" subsys=datapath-loader
  subsys=datapath-loader
  msg="Error fetching program/map!" subsys=datapath-loader

PR #11678's CI run on 4.19 was broken as well, so it seems it was
merged accidentally. We need a different workaround for this kernel,
one that the verifier can deal with.

Fixes: #11731
Reported-by: Paul Chaignon <paul@cilium.io>
Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>