### PR TITLE
etcd: Increase status check timeout to 10 seconds

### DIFF
--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -81,7 +81,7 @@ var (
 
 	// statusCheckTimeout is the timeout when performing status checks with
 	// all etcd endpoints
-	statusCheckTimeout = 5 * time.Second
+	statusCheckTimeout = 10 * time.Second
 
 	// initialConnectionTimeout  is the timeout for the initial connection to
 	// the etcd server
@@ -211,6 +211,13 @@ func (e *etcdModule) newClient(ctx context.Context, opts *ExtraOptions) (Backend
 func init() {
 	// register etcd module for use
 	registerBackend(EtcdBackendName, etcdInstance)
+
+	if duration := os.Getenv("CILIUM_ETCD_STATUS_CHECK_INTERVAL"); duration != "" {
+		timeout, err := time.ParseDuration(duration)
+		if err == nil {
+			statusCheckTimeout = timeout
+		}
+	}
 }
 
 // Hint tries to improve the error message displayed to te user.


### PR DESCRIPTION
If the node is under heavy CPU load, the status check may take longer
than 5 seconds. Increase it to 10 seconds and also make it configurable
with an environment variable.
