### PR TITLE
proxy: Do not decrement proxy port reference count when reverting.

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -15,7 +15,6 @@
 package proxy
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -398,12 +397,15 @@ func (p *Proxy) ReinstallRules() {
 // The proxy listening port is returned, but proxy configuration on that port
 // may still be ongoing asynchronously. Caller should wait for successful completion
 // on 'wg' before assuming the returned proxy port is listening.
+// Caller must call exactly one of the returned functions:
+// - finalizeFunc to make the changes stick, or
+// - revertFunc to cancel the changes.
 func (p *Proxy) CreateOrUpdateRedirect(l4 policy.ProxyPolicy, id string, localEndpoint logger.EndpointUpdater,
 	wg *completion.WaitGroup) (proxyPort uint16, err error, finalizeFunc revert.FinalizeFunc, revertFunc revert.RevertFunc) {
 
 	p.mutex.Lock()
 	defer func() {
-		p.UpdateRedirectMetrics()
+		p.updateRedirectMetrics()
 		p.mutex.Unlock()
 		if err == nil && proxyPort == 0 {
 			panic("Trying to configure zero proxy port")
@@ -503,16 +505,17 @@ func (p *Proxy) CreateOrUpdateRedirect(l4 policy.ProxyPolicy, id string, localEn
 			pp.reservePort()
 
 			revertStack.Push(func() error {
-				completionCtx, cancel := context.WithCancel(context.Background())
-				proxyWaitGroup := completion.NewWaitGroup(completionCtx)
-				err, finalize, _ := p.RemoveRedirect(id, proxyWaitGroup)
-				// Don't wait for an ACK. This is best-effort. Just clean up the completions.
-				cancel()
-				proxyWaitGroup.Wait() // Ignore the returned error.
-				if err == nil && finalize != nil {
-					finalize()
+				// Proxy port refcount has not been incremented yet, so it must not be decremented
+				// when reverting. Undo what we have done above.
+				p.mutex.Lock()
+				delete(p.redirects, id)
+				p.updateRedirectMetrics()
+				p.mutex.Unlock()
+				implFinalizeFunc, _ := redir.implementation.Close(wg)
+				if implFinalizeFunc != nil {
+					implFinalizeFunc()
 				}
-				return err
+				return nil
 			})
 
 			// Set the proxy port only after an ACK is received.
@@ -544,11 +547,11 @@ func (p *Proxy) CreateOrUpdateRedirect(l4 policy.ProxyPolicy, id string, localEn
 	return 0, err, nil, nil
 }
 
-// RemoveRedirect removes an existing redirect.
+// RemoveRedirect removes an existing redirect that has been successfully created earlier.
 func (p *Proxy) RemoveRedirect(id string, wg *completion.WaitGroup) (error, revert.FinalizeFunc, revert.RevertFunc) {
 	p.mutex.Lock()
 	defer func() {
-		p.UpdateRedirectMetrics()
+		p.updateRedirectMetrics()
 		p.mutex.Unlock()
 	}()
 	return p.removeRedirect(id, wg)
@@ -644,9 +647,9 @@ func (p *Proxy) GetStatusModel() *models.ProxyStatus {
 	return result
 }
 
-// UpdateRedirectMetrics updates the redirect metrics per application protocol
+// updateRedirectMetrics updates the redirect metrics per application protocol
 // in Prometheus. Lock needs to be held to call this function.
-func (p *Proxy) UpdateRedirectMetrics() {
+func (p *Proxy) updateRedirectMetrics() {
 	result := map[string]int{}
 	for _, redirect := range p.redirects {
 		result[string(redirect.listener.parserType)]++


### PR DESCRIPTION
Proxy port reference count is incremented only when an ACK has been received from
all proxies in a specific policy update. If any of the proxies fail to ACK in time,
the revert function is called. Proxy port reference counts must not be decremented
at this time, as they have not been incremented yet.

Fixes: #6921
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
