### PR TITLE
Cilium has added support for "named ports". Updating docs to reflect this

### DIFF
--- a/Documentation/kubernetes/policy.rst
+++ b/Documentation/kubernetes/policy.rst
@@ -49,8 +49,6 @@ Known missing features for Kubernetes Network Policy:
 +------------------------------+----------------------------------------------+
 | Feature                      | Tracking Issue                               |
 +==============================+==============================================+
-| Use of named ports           | https://github.com/cilium/cilium/issues/2942 |
-+------------------------------+----------------------------------------------+
 | Ingress CIDR-based L4 policy | https://github.com/cilium/cilium/issues/4129 |
 +------------------------------+----------------------------------------------+
 


### PR DESCRIPTION
The `known missing features of k8s netpolicy` table references `Use of named ports` however this feature has been added (Issue 2942) so removing the table

Signed-off-by: Jed Salazar jed@isovalent.com

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number