### PR TITLE
datapath: Fix panic on direct routing config

### DIFF
--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -266,7 +266,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		cDefinesMap["NODEPORT_PORT_MAX_NAT"] = "65535"
 	}
 
-	if len(option.Config.Devices) > 0 {
+	if len(option.Config.Devices) > 0 && option.Config.EnableNodePort {
 		// First device from the list is used for direct routing between nodes
 		directRoutingIface := option.Config.Devices[0]
 		directRoutingIfIndex, err := link.GetIfIndex(directRoutingIface)


### PR DESCRIPTION
If a device is given through options but NodePort is not enabled, Cilium panics when trying to set the direct routing configuration for the datapath. This panic happens because we use `node.GetNodePortIPv{4,6}AddrsWithDevices()` to retrieve the IP addresses, but since NodePort is disabled, the IP addresses weren't collected and that function returns an empty map.

Fixes: #11594