### PR TITLE
Implement values for hubble-relay to properly control sub chart values

### DIFF
--- a/install/kubernetes/cilium/charts/hubble-relay/templates/deployment.yaml
+++ b/install/kubernetes/cilium/charts/hubble-relay/templates/deployment.yaml
@@ -27,10 +27,10 @@ spec:
             topologyKey: "kubernetes.io/hostname"
       containers:
         - name: hubble-relay
-{{- if contains "/" .Values.image }}
-          image: "{{ .Values.image }}"
+{{- if contains "/" .Values.image.repository }}
+          image: "{{ .Values.image.repository }}"
 {{- else }}
-          image: "{{ .Values.global.registry }}/{{ .Values.image }}:{{ .Values.global.tag }}"
+          image: "{{ .Values.global.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
 {{- end }}
           imagePullPolicy: {{ .Values.global.pullPolicy }}
           command:

--- a/install/kubernetes/cilium/charts/hubble-relay/values.yaml
+++ b/install/kubernetes/cilium/charts/hubble-relay/values.yaml
@@ -1,16 +1,29 @@
-image: hubble-relay
+# Configuration for the Hubble CLI
+image:
+  # repository of the docker image
+  repository: hubble-relay
+  # tag is the container image tag to use
+  tag: latest
+  # pullPolicy is the container image pull policy
+  pullPolicy: Always
 
 # Specifies the resources for the hubble-relay pods
 resources: {}
+
 # Number of replicas run for the hubble-relay deployment.
 numReplicas: 1
+
 # Host to listen to. Specify an empty string to bind to all the interfaces.
 listenHost: ""
+
 # Port to listen to.
 listenPort: "4245"
+
 # Dial timeout to connect to the local hubble instance to receive peer information (e.g. "30s").
 dialTimeout: ~
+
 # Backoff duration to retry connecting to the local hubble instance in case of failure (e.g. "30s").
 retryTimeout: ~
+
 # Port to use for the k8s service backed by hubble-relay pods.
 servicePort: 80

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -27,6 +27,42 @@ preflight:
   # cluster with the right schema.
   validateCNPs: true
 
+# Configure sub-chart values for hubble-relay
+hubble-relay:
+  # # Hubble-relay is enabled using global.hubble.relay.enabled
+  # # TODO: Develop a plan to migrate global.hubble.relay.enabled and other
+  # # global values
+  #
+  # # Configuration for the Hubble CLI
+  # image:
+  #   # repository of the docker image
+  #   name: hubble-relay
+  #   # tag is the container image tag to use
+  #   tag: latest
+  #   # pullPolicy is the container image pull policy
+  #   pullPolicy: Always
+  #
+  # # Specifies the resources for the hubble-relay pods
+  # resources: {}
+  #
+  # # Number of replicas run for the hubble-relay deployment.
+  numReplicas: 1
+  #
+  # # Host to listen to. Specify an empty string to bind to all the interfaces.
+  # listenHost: ""
+  #
+  # # Port to listen to.
+  # listenPort: "4245"
+  #
+  # # Dial timeout to connect to the local hubble instance to receive peer information (e.g. "30s").
+  # dialTimeout: ~
+  #
+  # # Backoff duration to retry connecting to the local hubble instance in case of failure (e.g. "30s").
+  # retryTimeout: ~
+  #
+  # # Port to use for the k8s service backed by hubble-relay pods.
+  # servicePort: 80
+
 # global groups all configuration options that have effect on all sub-charts
 global:
   # registry is the address of the registry and orgnization for all container images

--- a/test/k8sT/hubble.go
+++ b/test/k8sT/hubble.go
@@ -114,7 +114,6 @@ var _ = Describe("K8sHubbleTest", func() {
 		DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
 			"global.hubble.metricsServer":   fmt.Sprintf(":%s", prometheusPort),
 			"global.hubble.metrics.enabled": `"{dns:query;ignoreAAAA,drop,tcp,flow,port-distribution,icmp,http}"`,
-			"global.hubble.cli.enabled":     "true",
 			"global.hubble.relay.enabled":   "true",
 		})
 


### PR DESCRIPTION
Implements hubble-relay values to properly control sub chart values using the parent chart's values file.
Documents values in the parent chart for overriding.

Fixes: #11755

Signed-off-by: Sean Winn <sean@isovalent.com>

