### PR TITLE
policy: Fix enforcement status for host endpoint

### DIFF
--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -703,6 +703,10 @@ func (p *Repository) computePolicyEnforcementAndRules(securityIdentity *identity
 		// enabled for the endpoint.
 		return true, true, matchingRules
 	case option.DefaultEnforcement:
+		if lbls.Has(labels.IDNameHost) && !option.Config.EnableHostFirewall {
+			return false, false, nil
+		}
+
 		ingress, egress, matchingRules = p.getMatchingRules(securityIdentity)
 		// If the endpoint has the reserved:init label, i.e. if it has not yet
 		// received any labels, always enforce policy (default deny).


### PR DESCRIPTION
Before this commit, host policy enforcement was reported as "enabled" as soon as policies were loaded for the host, even if the host firewall was disabled:

    ENDPOINT   POLICY (ingress)   POLICY (egress)   IDENTITY   LABELS (source:key[=value])                       IPv6                 IPv4          STATUS
               ENFORCEMENT        ENFORCEMENT
    318        Enabled            Enabled           1          reserved:host                                                                        ready
    3423       Disabled           Disabled          4          reserved:health                                   f00d::a0f:0:0:7ba4   10.16.0.148   ready

With this commit, enforcement will remain as "disabled" as long as the host firewall is disabled:

    ENDPOINT   POLICY (ingress)   POLICY (egress)   IDENTITY   LABELS (source:key[=value])                       IPv6                 IPv4          STATUS
               ENFORCEMENT        ENFORCEMENT
    318        Disabled           Disabled          1          reserved:host                                                                        ready
    3423       Disabled           Disabled          4          reserved:health                                   f00d::a0f:0:0:7ba4   10.16.0.148   ready

Fixes: #11507