### PR TITLE
docs: add missing dependency to use docs live-preview

### DIFF
--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -28,3 +28,4 @@ sphinxcontrib-spelling==4.2.1
 sphinx-version-warning==1.1.2
 semver==2.9.0
 yamllint==1.22.0
+sphinx-autobuild==0.7.1


### PR DESCRIPTION
Fixes: 38abe893dfa4 ("doc: Add make render-docs-live-preview target")
Signed-off-by: André Martins <andre@cilium.io>
