### PR TITLE
test: Add simple retries for flaky Helm operations

### DIFF
--- a/test/k8sT/Updates.go
+++ b/test/k8sT/Updates.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	. "github.com/cilium/cilium/test/ginkgo-ext"
 	"github.com/cilium/cilium/test/helpers"
@@ -177,21 +178,23 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldHelmChartVers
 			opts["agent.image"] = imageName
 			opts["preflight.image"] = imageName // preflight must match the target agent image
 		}
-		cmd, err := kubectl.RunHelm(
-			"install",
-			helmPath,
-			"cilium",
-			chartVersion,
-			helpers.CiliumNamespace,
-			opts,
-		)
-		ExpectWithOffset(1, err).To(BeNil(), "Cilium clean state %q was not able to be deployed", chartVersion)
-		ExpectWithOffset(1, cmd).To(helpers.CMDSuccess(), "Cilium clean state %q was not able to be deployed", chartVersion)
+
+		EventuallyWithOffset(1, func() (*helpers.CmdRes, error) {
+			return kubectl.RunHelm(
+				"install",
+				helmPath,
+				"cilium",
+				chartVersion,
+				helpers.CiliumNamespace,
+				opts,
+			)
+		}, time.Second*30, time.Second*1).Should(helpers.CMDSuccess(), fmt.Sprintf("Cilium clean state %q was not able to be deployed", chartVersion))
+
 		err = kubectl.WaitForCiliumReadiness()
 		ExpectWithOffset(1, err).To(BeNil(), "Cilium %q did not become ready in time", chartVersion)
 		err = kubectl.WaitForCiliumInitContainerToFinish()
 		ExpectWithOffset(1, err).To(BeNil(), "Cilium %q was not able to be clean up environment", chartVersion)
-		cmd = kubectl.ExecMiddle("helm delete cilium --namespace=" + helpers.CiliumNamespace)
+		cmd := kubectl.ExecMiddle("helm delete cilium --namespace=" + helpers.CiliumNamespace)
 		ExpectWithOffset(1, cmd).To(helpers.CMDSuccess(), "Cilium %q was not able to be deleted", chartVersion)
 		ExpectAllPodsTerminated(kubectl)
 	}
@@ -227,8 +230,9 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldHelmChartVers
 		By("Waiting for pods to be terminated..")
 		ExpectAllPodsTerminated(kubectl)
 
-		cmd := kubectl.HelmAddCiliumRepo()
-		ExpectWithOffset(1, cmd).To(helpers.CMDSuccess(), "Unable to install helm repository")
+		EventuallyWithOffset(1, func() *helpers.CmdRes {
+			return kubectl.HelmAddCiliumRepo()
+		}, time.Second*30, time.Second*1).Should(helpers.CMDSuccess(), "Unable to install helm repository")
 
 		By("Cleaning Cilium state")
 		cleanupCiliumState("cilium/cilium", oldHelmChartVersion, "cilium", oldImageVersion, "docker.io/cilium")
@@ -244,15 +248,19 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldHelmChartVers
 		if helpers.RunsWithoutKubeProxy() {
 			opts["global.nodePort.device"] = privateIface
 		}
-		cmd, err = kubectl.RunHelm(
-			"install",
-			"cilium/cilium",
-			"cilium",
-			oldHelmChartVersion,
-			helpers.CiliumNamespace,
-			opts)
-		ExpectWithOffset(1, err).To(BeNil(), "Cilium %q was not able to be deployed", oldHelmChartVersion)
-		ExpectWithOffset(1, cmd).To(helpers.CMDSuccess(), "Cilium %q was not able to be deployed", oldHelmChartVersion)
+
+		// Eventually allows multiple return values, and performs the assertion
+		// on the first return value, and expects that all other return values
+		// are zero values (nil, etc.).
+		EventuallyWithOffset(1, func() (*helpers.CmdRes, error) {
+			return kubectl.RunHelm(
+				"install",
+				"cilium/cilium",
+				"cilium",
+				oldHelmChartVersion,
+				helpers.CiliumNamespace,
+				opts)
+		}, time.Second*30, time.Second*1).Should(helpers.CMDSuccess(), fmt.Sprintf("Cilium %q was not able to be deployed", oldHelmChartVersion))
 
 		// Cilium is only ready if kvstore is ready, the kvstore is ready if
 		// kube-dns is running.
@@ -399,20 +407,22 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldHelmChartVers
 		if helpers.RunsWithoutKubeProxy() {
 			opts["global.nodePort.device"] = privateIface
 		}
-		cmd, err = kubectl.RunHelm(
-			"install",
-			filepath.Join(kubectl.BasePath(), helpers.HelmTemplate),
-			"cilium-preflight",
-			newHelmChartVersion,
-			helpers.CiliumNamespace,
-			opts)
-		ExpectWithOffset(1, err).To(BeNil(), "Unable to deploy preflight manifest")
-		ExpectWithOffset(1, cmd).To(helpers.CMDSuccess(), "Unable to deploy preflight manifest")
+
+		EventuallyWithOffset(1, func() (*helpers.CmdRes, error) {
+			return kubectl.RunHelm(
+				"install",
+				filepath.Join(kubectl.BasePath(), helpers.HelmTemplate),
+				"cilium-preflight",
+				newHelmChartVersion,
+				helpers.CiliumNamespace,
+				opts)
+		}, time.Second*30, time.Second*1).Should(helpers.CMDSuccess(), "Unable to deploy preflight manifest")
+
 		ExpectCiliumPreFlightInstallReady(kubectl)
 
 		// Once they are installed we can remove it
 		By("Removing Cilium pre-flight check DaemonSet")
-		cmd = kubectl.ExecMiddle("helm delete cilium-preflight --namespace=" + helpers.CiliumNamespace)
+		cmd := kubectl.ExecMiddle("helm delete cilium-preflight --namespace=" + helpers.CiliumNamespace)
 		ExpectWithOffset(1, cmd).To(helpers.CMDSuccess(), "Unable to delete preflight")
 
 		err = kubectl.WaitForCiliumReadiness()
@@ -429,15 +439,16 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldHelmChartVers
 		if oldHelmChartVersion == "1.6-dev" {
 			opts["agent.keepDeprecatedLabels"] = "true"
 		}
-		cmd, err = kubectl.RunHelm(
-			"upgrade",
-			filepath.Join(kubectl.BasePath(), helpers.HelmTemplate),
-			"cilium",
-			newHelmChartVersion,
-			helpers.CiliumNamespace,
-			opts)
-		ExpectWithOffset(1, err).To(BeNil(), "Cilium %q was not able to be deployed", newHelmChartVersion)
-		ExpectWithOffset(1, cmd).To(helpers.CMDSuccess(), "Cilium %q was not able to be deployed", newHelmChartVersion)
+
+		EventuallyWithOffset(1, func() (*helpers.CmdRes, error) {
+			return kubectl.RunHelm(
+				"upgrade",
+				filepath.Join(kubectl.BasePath(), helpers.HelmTemplate),
+				"cilium",
+				newHelmChartVersion,
+				helpers.CiliumNamespace,
+				opts)
+		}, time.Second*30, time.Second*1).Should(helpers.CMDSuccess(), fmt.Sprintf("Cilium %q was not able to be deployed", newHelmChartVersion))
 
 		By("Validating pods have the right image version upgraded")
 		err = helpers.WithTimeout(


### PR DESCRIPTION
This PR adds retry logic to Helm operations. It is a low-risk, cheap attempt to help reduce flakes in the case of network errors such as timeouts.

See commit msgs.