### PR TITLE
Fix issue where traffic from a pod could be dropped despite allow policy when DNS L7 rules are used

### DIFF
--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -40,6 +40,12 @@ type Identity struct {
 
 	// Source is the source of the identity in the cache
 	Source source.Source
+
+	// shadowed determines if another entry overlaps with this one.
+	// Shadowed identities are not propagated to listeners by default.
+	// Most commonly set for Identity with Source = source.Generated when
+	// a pod IP (other source) has the same IP.
+	shadowed bool
 }
 
 // IPKeyPair is the (IP, key) pair used of the identity
@@ -263,7 +269,7 @@ func (ipc *IPCache) Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *K8s
 				scopedLog.Debug("Ignoring CIDR to identity mapping as it is shadowed by an endpoint IP")
 				// Skip calling back the listeners, since the endpoint IP has
 				// precedence over the new CIDR.
-				callbackListeners = false
+				newIdentity.shadowed = true
 			}
 		}
 	} else if endpointIP := net.ParseIP(ip); endpointIP != nil { // Endpoint IP.
@@ -277,6 +283,8 @@ func (ipc *IPCache) Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *K8s
 				oldHostIP, _ = ipc.getHostIPCache(cidrStr)
 				if cidrIdentity.ID != newIdentity.ID || !oldHostIP.Equal(hostIP) {
 					scopedLog.Debug("New endpoint IP started shadowing existing CIDR to identity mapping")
+					cidrIdentity.shadowed = true
+					ipc.ipToIdentityCache[cidrStr] = cidrIdentity
 					oldIdentity = &cidrIdentity.ID
 				} else {
 					// The endpoint IP and the CIDR are associated with the
@@ -347,7 +355,7 @@ func (ipc *IPCache) Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *K8s
 		}
 	}
 
-	if callbackListeners {
+	if callbackListeners && !newIdentity.shadowed {
 		for _, listener := range ipc.listeners {
 			listener.OnIPIdentityCacheChange(Upsert, *cidr, oldHostIP, hostIP, oldIdentity, newIdentity.ID, hostKey, k8sMeta)
 		}
@@ -360,6 +368,9 @@ func (ipc *IPCache) Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *K8s
 // the listener's "OnIPIdentityCacheChange" method for each entry in the cache.
 func (ipc *IPCache) DumpToListenerLocked(listener IPIdentityMappingListener) {
 	for ip, identity := range ipc.ipToIdentityCache {
+		if identity.shadowed {
+			continue
+		}
 		hostIP, encryptKey := ipc.getHostIPCache(ip)
 		k8sMeta := ipc.GetK8sMetadata(ip)
 		_, cidr, err := net.ParseCIDR(ip)
@@ -420,6 +431,8 @@ func (ipc *IPCache) deleteLocked(ip string, source source.Source) (namedPortsCha
 			if cidrIdentity.ID != cachedIdentity.ID || !oldHostIP.Equal(newHostIP) {
 				scopedLog.Debug("Removal of endpoint IP revives shadowed CIDR to identity mapping")
 				cacheModification = Upsert
+				cidrIdentity.shadowed = false
+				ipc.ipToIdentityCache[cidrStr] = cidrIdentity
 				oldIdentity = &cachedIdentity.ID
 				newIdentity = cidrIdentity
 			} else {


### PR DESCRIPTION
From the commit message:

    Cilium defines a precedence ordering between sources for mappings from
    IP to Identity, defined in pkg/source/source.go. These are used to
    determine which Identity should be used for an IP when multiple sources
    provide conflicting reports of the Identity to be associated with an IP.
    
    This ordering was handled in the case of source.Generated CIDR/FQDN
    -sourced identities by inserting potentially two overlapping entries
    into the ipcache.IPIdentityCache when an endpoint's IP is the same as a
    CIDR mapping:
    
    * An endpoint Identity would be inserted with the key 'w.x.y.z', and
    * A CIDR Identity would be inserted with the key 'w.x.y.z/32'. (IPv6: /128)
    
    During Upsert() and Delete(), when overlapping entries existed in the
    map, this overlap would be resolved by directly checking whether another
    entry exists with/without the `/32` suffix (IPv6: /128) and either
    hiding the update from listeners (when a shadowed mapping is upserted),
    or converting the delete to an update (when a shadowing entry is
    deleted, revealing the underlying shadowed entry).
    
    During DumpToListenerLocked() however, this shadowing would not be
    resolved and instead both entries would be dumped to the caller in an
    arbitrary order. This is particularly notable on Linux 4.11 to 4.15
    where LPM support is available but deletion is not supported. In these
    cases, Cilium periodically dumps the ipcache to a listener using this
    function, and populates the BPF ipcache map using this dump. Any time this
    dump occurs (default 5 minutes), it would be possible for the ipcache
    mapping to be modified to map the IP to either of the cached identities.
    Depending on the Go runtime in use by the version of Cilium, this may or
    may not consistently provide particular dump ordering.
    
    Resolve this issue by keeping track of shadowed entries with an
    explicit boolean field in the value of the map, and avoiding dumping
    such entries in the DumpToListenerLocked() function.

This issue would require a pod on the node with the affected pod to make a request for a DNS name that maps to an IP which represents a remote pod, for that request to be processed via L7 DNS policy, and for the remote pod to subsequently make requests to the affected pod in direct routing mode on Linux 4.11-4.15.

This was only observed on v1.7.x, however I've marked it for backport to v1.6.x as well in an abundance of caution. Cilium v1.6 and v1.7 use different Go versions (v1.12 vs v1.13) so it's likely that the map iteration behaviour is different between these versions. Go doesn't make any guarantees about map iteration ordering, so this PR addresses this by explicitly resolving the overlap between identities for the same IP.

Shout outs also to @tklauser @jrajahalme for their help tracking this down.

Fixes: #11517 